### PR TITLE
fix(torghut): promote simulation image consumers

### DIFF
--- a/packages/scripts/src/torghut/__tests__/update-manifests.test.ts
+++ b/packages/scripts/src/torghut/__tests__/update-manifests.test.ts
@@ -9,7 +9,14 @@ import { __private } from '../update-manifests'
 const createFixture = () => {
   const dir = mkdtempSync(join(tmpdir(), 'torghut-manifests-test-'))
   const serviceManifestPath = join(dir, 'knative-service.yaml')
+  const simulationServiceManifestPath = join(dir, 'knative-service-sim.yaml')
   const migrationManifestPath = join(dir, 'db-migrations-job.yaml')
+  const leanRunnerManifestPath = join(dir, 'lean-runner-deployment.yaml')
+  const historicalWorkflowManifestPath = join(dir, 'historical-simulation-workflowtemplate.yaml')
+  const empiricalWorkflowManifestPath = join(dir, 'empirical-promotion-workflowtemplate.yaml')
+  const empiricalBackfillManifestPath = join(dir, 'empirical-jobs-backfill-job.yaml')
+  const forecastManifestPath = join(dir, 'forecast-deployment.yaml')
+  const forecastSimulationManifestPath = join(dir, 'forecast-sim-deployment.yaml')
   writeFileSync(
     serviceManifestPath,
     `apiVersion: serving.knative.dev/v1
@@ -17,6 +24,30 @@ kind: Service
 metadata:
   annotations:
     serving.knative.dev/creator: system:serviceaccount:argocd:argocd-application-controller
+    serving.knative.dev/lastModifier: admin
+spec:
+  template:
+    metadata:
+      annotations:
+        client.knative.dev/updateTimestamp: "2025-01-01T00:00:00Z"
+    spec:
+      containers:
+        - name: user-container
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:1111111111111111111111111111111111111111111111111111111111111111
+          env:
+            - name: TORGHUT_VERSION
+              value: old-version
+            - name: TORGHUT_COMMIT
+              value: old-commit
+`,
+    'utf8',
+  )
+  writeFileSync(
+    simulationServiceManifestPath,
+    `apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  annotations:
     serving.knative.dev/lastModifier: admin
 spec:
   template:
@@ -48,7 +79,40 @@ spec:
 `,
     'utf8',
   )
-  return { dir, serviceManifestPath, migrationManifestPath }
+  for (const path of [
+    leanRunnerManifestPath,
+    historicalWorkflowManifestPath,
+    empiricalWorkflowManifestPath,
+    empiricalBackfillManifestPath,
+    forecastManifestPath,
+    forecastSimulationManifestPath,
+  ]) {
+    writeFileSync(
+      path,
+      `apiVersion: v1
+kind: ConfigMap
+spec:
+  template:
+    spec:
+      containers:
+        - name: torghut
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:1111111111111111111111111111111111111111111111111111111111111111
+`,
+      'utf8',
+    )
+  }
+  return {
+    dir,
+    serviceManifestPath,
+    simulationServiceManifestPath,
+    migrationManifestPath,
+    leanRunnerManifestPath,
+    historicalWorkflowManifestPath,
+    empiricalWorkflowManifestPath,
+    empiricalBackfillManifestPath,
+    forecastManifestPath,
+    forecastSimulationManifestPath,
+  }
 }
 
 describe('update-manifests', () => {
@@ -61,11 +125,25 @@ describe('update-manifests', () => {
       commit: '1234567890abcdef1234567890abcdef12345678',
       rolloutTimestamp: '2026-02-21T04:00:00Z',
       manifestPath: relative(repoRoot, fixture.serviceManifestPath),
+      simulationManifestPath: relative(repoRoot, fixture.simulationServiceManifestPath),
       migrationManifestPath: relative(repoRoot, fixture.migrationManifestPath),
+      leanRunnerManifestPath: relative(repoRoot, fixture.leanRunnerManifestPath),
+      historicalSimulationWorkflowManifestPath: relative(repoRoot, fixture.historicalWorkflowManifestPath),
+      empiricalPromotionWorkflowManifestPath: relative(repoRoot, fixture.empiricalWorkflowManifestPath),
+      empiricalBackfillManifestPath: relative(repoRoot, fixture.empiricalBackfillManifestPath),
+      forecastManifestPath: relative(repoRoot, fixture.forecastManifestPath),
+      forecastSimulationManifestPath: relative(repoRoot, fixture.forecastSimulationManifestPath),
     })
 
     const serviceManifest = readFileSync(fixture.serviceManifestPath, 'utf8')
+    const simulationServiceManifest = readFileSync(fixture.simulationServiceManifestPath, 'utf8')
     const migrationManifest = readFileSync(fixture.migrationManifestPath, 'utf8')
+    const leanRunnerManifest = readFileSync(fixture.leanRunnerManifestPath, 'utf8')
+    const historicalWorkflowManifest = readFileSync(fixture.historicalWorkflowManifestPath, 'utf8')
+    const empiricalWorkflowManifest = readFileSync(fixture.empiricalWorkflowManifestPath, 'utf8')
+    const empiricalBackfillManifest = readFileSync(fixture.empiricalBackfillManifestPath, 'utf8')
+    const forecastManifest = readFileSync(fixture.forecastManifestPath, 'utf8')
+    const forecastSimulationManifest = readFileSync(fixture.forecastSimulationManifestPath, 'utf8')
     expect(serviceManifest).toContain('client.knative.dev/updateTimestamp: "2026-02-21T04:00:00Z"')
     expect(serviceManifest).toContain(
       'image: registry.ide-newton.ts.net/lab/torghut@sha256:430763ebeeda8734e1da3ae8c6b665bcc1b380fb815317fffc98371cccea219e',
@@ -76,14 +154,29 @@ describe('update-manifests', () => {
     expect(serviceManifest).not.toContain('serving.knative.dev/lastModifier:')
     expect(serviceManifest).toContain('value: v0.600.0')
     expect(serviceManifest).toContain('value: 1234567890abcdef1234567890abcdef12345678')
+    expect(simulationServiceManifest).toContain('client.knative.dev/updateTimestamp: "2026-02-21T04:00:00Z"')
+    expect(simulationServiceManifest).toContain('value: v0.600.0')
+    expect(simulationServiceManifest).toContain('value: 1234567890abcdef1234567890abcdef12345678')
     expect(migrationManifest).toContain(
       'image: registry.ide-newton.ts.net/lab/torghut@sha256:430763ebeeda8734e1da3ae8c6b665bcc1b380fb815317fffc98371cccea219e',
     )
+    for (const manifest of [
+      leanRunnerManifest,
+      historicalWorkflowManifest,
+      empiricalWorkflowManifest,
+      empiricalBackfillManifest,
+      forecastManifest,
+      forecastSimulationManifest,
+    ]) {
+      expect(manifest).toContain(
+        'image: registry.ide-newton.ts.net/lab/torghut@sha256:430763ebeeda8734e1da3ae8c6b665bcc1b380fb815317fffc98371cccea219e',
+      )
+    }
     expect(result.changed).toBe(true)
     expect(result.imageRef).toBe(
       'registry.ide-newton.ts.net/lab/torghut@sha256:430763ebeeda8734e1da3ae8c6b665bcc1b380fb815317fffc98371cccea219e',
     )
-    expect(result.changedPaths.length).toBe(2)
+    expect(result.changedPaths.length).toBe(9)
 
     rmSync(fixture.dir, { recursive: true, force: true })
   })
@@ -97,7 +190,14 @@ describe('update-manifests', () => {
       commit: 'abcdefabcdefabcdefabcdefabcdefabcdefabcd',
       rolloutTimestamp: '2026-02-21T05:00:00Z',
       manifestPath: relative(repoRoot, fixture.serviceManifestPath),
+      simulationManifestPath: relative(repoRoot, fixture.simulationServiceManifestPath),
       migrationManifestPath: relative(repoRoot, fixture.migrationManifestPath),
+      leanRunnerManifestPath: relative(repoRoot, fixture.leanRunnerManifestPath),
+      historicalSimulationWorkflowManifestPath: relative(repoRoot, fixture.historicalWorkflowManifestPath),
+      empiricalPromotionWorkflowManifestPath: relative(repoRoot, fixture.empiricalWorkflowManifestPath),
+      empiricalBackfillManifestPath: relative(repoRoot, fixture.empiricalBackfillManifestPath),
+      forecastManifestPath: relative(repoRoot, fixture.forecastManifestPath),
+      forecastSimulationManifestPath: relative(repoRoot, fixture.forecastSimulationManifestPath),
     }
 
     __private.updateTorghutManifests(options)

--- a/packages/scripts/src/torghut/update-manifests.ts
+++ b/packages/scripts/src/torghut/update-manifests.ts
@@ -11,7 +11,16 @@ import { execGit } from '../shared/git'
 const defaultRegistry = 'registry.ide-newton.ts.net'
 const defaultRepository = 'lab/torghut'
 const defaultManifestPath = 'argocd/applications/torghut/knative-service.yaml'
+const defaultSimulationManifestPath = 'argocd/applications/torghut/knative-service-sim.yaml'
 const defaultMigrationManifestPath = 'argocd/applications/torghut/db-migrations-job.yaml'
+const defaultLeanRunnerManifestPath = 'argocd/applications/torghut/lean-runner-deployment.yaml'
+const defaultHistoricalSimulationWorkflowManifestPath =
+  'argocd/applications/torghut/historical-simulation-workflowtemplate.yaml'
+const defaultEmpiricalPromotionWorkflowManifestPath =
+  'argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml'
+const defaultEmpiricalBackfillManifestPath = 'argocd/applications/torghut/empirical-jobs-backfill-job.yaml'
+const defaultForecastManifestPath = 'argocd/applications/torghut-forecast/deployment.yaml'
+const defaultForecastSimulationManifestPath = 'argocd/applications/torghut-forecast/sim/deployment.yaml'
 
 const digestPattern = /^sha256:[0-9a-f]{64}$/i
 
@@ -22,7 +31,14 @@ type UpdateManifestsOptions = {
   commit: string
   rolloutTimestamp: string
   manifestPath?: string
+  simulationManifestPath?: string
   migrationManifestPath?: string
+  leanRunnerManifestPath?: string
+  historicalSimulationWorkflowManifestPath?: string
+  empiricalPromotionWorkflowManifestPath?: string
+  empiricalBackfillManifestPath?: string
+  forecastManifestPath?: string
+  forecastSimulationManifestPath?: string
 }
 
 type CliOptions = {
@@ -34,7 +50,14 @@ type CliOptions = {
   commit?: string
   rolloutTimestamp?: string
   manifestPath?: string
+  simulationManifestPath?: string
   migrationManifestPath?: string
+  leanRunnerManifestPath?: string
+  historicalSimulationWorkflowManifestPath?: string
+  empiricalPromotionWorkflowManifestPath?: string
+  empiricalBackfillManifestPath?: string
+  forecastManifestPath?: string
+  forecastSimulationManifestPath?: string
 }
 
 const resolvePath = (path: string) => resolve(repoRoot, path)
@@ -120,10 +143,74 @@ const updateTorghutMigrationManifest = (options: UpdateManifestsOptions) => {
   }
 }
 
+const updateImageOnlyManifest = (options: UpdateManifestsOptions, manifestPathValue: string, label: string) => {
+  const manifestPath = resolvePath(manifestPathValue)
+  const source = readFileSync(manifestPath, 'utf8')
+  const imageRef = `${options.imageName}@${options.digest}`
+
+  const updated = replaceSingle(source, /(\n\s*image:\s*)([^\n]+)/, `$1${imageRef}`, label)
+
+  if (updated !== source) {
+    writeFileSync(manifestPath, updated, 'utf8')
+  }
+
+  return {
+    manifestPath,
+    imageRef,
+    changed: updated !== source,
+  }
+}
+
 const updateTorghutManifests = (options: UpdateManifestsOptions) => {
   const service = updateTorghutManifest(options)
+  const simulationService = updateTorghutManifest({
+    ...options,
+    manifestPath: options.simulationManifestPath ?? defaultSimulationManifestPath,
+  })
   const migration = updateTorghutMigrationManifest(options)
-  const changedPaths = [service, migration].filter((entry) => entry.changed).map((entry) => entry.manifestPath)
+  const leanRunner = updateImageOnlyManifest(
+    options,
+    options.leanRunnerManifestPath ?? defaultLeanRunnerManifestPath,
+    'torghut-lean-runner image reference',
+  )
+  const historicalSimulationWorkflow = updateImageOnlyManifest(
+    options,
+    options.historicalSimulationWorkflowManifestPath ?? defaultHistoricalSimulationWorkflowManifestPath,
+    'torghut-historical-simulation image reference',
+  )
+  const empiricalPromotionWorkflow = updateImageOnlyManifest(
+    options,
+    options.empiricalPromotionWorkflowManifestPath ?? defaultEmpiricalPromotionWorkflowManifestPath,
+    'torghut-empirical-promotion image reference',
+  )
+  const empiricalBackfill = updateImageOnlyManifest(
+    options,
+    options.empiricalBackfillManifestPath ?? defaultEmpiricalBackfillManifestPath,
+    'torghut-empirical-jobs-backfill image reference',
+  )
+  const forecast = updateImageOnlyManifest(
+    options,
+    options.forecastManifestPath ?? defaultForecastManifestPath,
+    'torghut-forecast image reference',
+  )
+  const forecastSimulation = updateImageOnlyManifest(
+    options,
+    options.forecastSimulationManifestPath ?? defaultForecastSimulationManifestPath,
+    'torghut-forecast-sim image reference',
+  )
+  const changedPaths = [
+    service,
+    simulationService,
+    migration,
+    leanRunner,
+    historicalSimulationWorkflow,
+    empiricalPromotionWorkflow,
+    empiricalBackfill,
+    forecast,
+    forecastSimulation,
+  ]
+    .filter((entry) => entry.changed)
+    .map((entry) => entry.manifestPath)
   return {
     imageRef: service.imageRef,
     changed: changedPaths.length > 0,
@@ -148,7 +235,14 @@ Options:
   --commit <sha40>
   --rollout-timestamp <ISO8601>
   --manifest-path <path>
-  --migration-manifest-path <path>`)
+  --simulation-manifest-path <path>
+  --migration-manifest-path <path>
+  --lean-runner-manifest-path <path>
+  --historical-simulation-workflow-manifest-path <path>
+  --empirical-promotion-workflow-manifest-path <path>
+  --empirical-backfill-manifest-path <path>
+  --forecast-manifest-path <path>
+  --forecast-simulation-manifest-path <path>`)
       process.exit(0)
     }
 
@@ -190,8 +284,29 @@ Options:
       case '--manifest-path':
         options.manifestPath = value
         break
+      case '--simulation-manifest-path':
+        options.simulationManifestPath = value
+        break
       case '--migration-manifest-path':
         options.migrationManifestPath = value
+        break
+      case '--lean-runner-manifest-path':
+        options.leanRunnerManifestPath = value
+        break
+      case '--historical-simulation-workflow-manifest-path':
+        options.historicalSimulationWorkflowManifestPath = value
+        break
+      case '--empirical-promotion-workflow-manifest-path':
+        options.empiricalPromotionWorkflowManifestPath = value
+        break
+      case '--empirical-backfill-manifest-path':
+        options.empiricalBackfillManifestPath = value
+        break
+      case '--forecast-manifest-path':
+        options.forecastManifestPath = value
+        break
+      case '--forecast-simulation-manifest-path':
+        options.forecastSimulationManifestPath = value
         break
       default:
         throw new Error(`Unknown option: ${flag}`)
@@ -226,7 +341,18 @@ export const main = (cliOptions?: CliOptions) => {
     commit,
     rolloutTimestamp,
     manifestPath: parsed.manifestPath ?? process.env.TORGHUT_MANIFEST_PATH,
+    simulationManifestPath: parsed.simulationManifestPath ?? process.env.TORGHUT_SIMULATION_MANIFEST_PATH,
     migrationManifestPath: parsed.migrationManifestPath ?? process.env.TORGHUT_MIGRATION_MANIFEST_PATH,
+    leanRunnerManifestPath: parsed.leanRunnerManifestPath ?? process.env.TORGHUT_LEAN_RUNNER_MANIFEST_PATH,
+    historicalSimulationWorkflowManifestPath:
+      parsed.historicalSimulationWorkflowManifestPath ?? process.env.TORGHUT_HISTORICAL_SIMULATION_WORKFLOW_PATH,
+    empiricalPromotionWorkflowManifestPath:
+      parsed.empiricalPromotionWorkflowManifestPath ?? process.env.TORGHUT_EMPIRICAL_PROMOTION_WORKFLOW_PATH,
+    empiricalBackfillManifestPath:
+      parsed.empiricalBackfillManifestPath ?? process.env.TORGHUT_EMPIRICAL_BACKFILL_MANIFEST_PATH,
+    forecastManifestPath: parsed.forecastManifestPath ?? process.env.TORGHUT_FORECAST_MANIFEST_PATH,
+    forecastSimulationManifestPath:
+      parsed.forecastSimulationManifestPath ?? process.env.TORGHUT_FORECAST_SIMULATION_MANIFEST_PATH,
   })
 
   if (result.changed) {
@@ -250,5 +376,6 @@ export const __private = {
   replaceSingle,
   updateTorghutManifest,
   updateTorghutMigrationManifest,
+  updateImageOnlyManifest,
   updateTorghutManifests,
 }


### PR DESCRIPTION
## Summary

- extend the Torghut release manifest updater to promote all Torghut image consumers, including `torghut-sim`, the simulation and empirical workflows, lean-runner, and Torghut forecast deployments
- keep the existing live service and DB migration promotion path intact while removing the sim-lane rollout gap for code-only changes
- expand the release updater tests to cover the full promoted manifest set

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/update-manifests.test.ts`
- `bunx oxfmt --check packages/scripts/src/torghut/update-manifests.ts packages/scripts/src/torghut/__tests__/update-manifests.test.ts`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
