### PR TITLE
feat(torghut): gate historical simulation with argo rollouts

### DIFF
--- a/argocd/applications/argo-rollouts/README.md
+++ b/argocd/applications/argo-rollouts/README.md
@@ -1,0 +1,14 @@
+# Argo Rollouts
+
+This application installs the Argo Rollouts controller and CRDs for cluster-wide analysis and rollout control.
+
+Phase 1 usage in this repo:
+
+- managed as a **platform** app from `argocd/applicationsets/platform.yaml`
+- dashboard disabled
+- traffic-router integrations disabled
+- controller metrics enabled
+- analysis Jobs pinned to namespace `torghut` so Torghut simulation `AnalysisRun` templates execute with namespace-local RBAC and secrets
+
+Torghut historical simulations continue to use Argo Workflows as the orchestrator. Argo Rollouts is introduced here as the
+execution and status controller for simulation `AnalysisRun` gates.

--- a/argocd/applications/argo-rollouts/kustomization.yaml
+++ b/argocd/applications/argo-rollouts/kustomization.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+helmCharts:
+  - name: argo-rollouts
+    repo: https://argoproj.github.io/argo-helm
+    version: 2.40.6
+    releaseName: argo-rollouts
+    namespace: argo-rollouts
+    valuesInline:
+      installCRDs: true
+      keepCRDs: true
+      clusterInstall: true
+      createClusterAggregateRoles: true
+      controller:
+        replicas: 2
+        metrics:
+          enabled: true
+        extraEnv:
+          - name: ARGO_ROLLOUTS_ANALYSIS_JOB_NAMESPACE
+            value: torghut

--- a/argocd/applications/torghut/README.md
+++ b/argocd/applications/torghut/README.md
@@ -57,12 +57,57 @@ By default, the workflow now targets the dedicated simulation surfaces managed i
 `Service/torghut-forecast-sim`. Supply explicit `runtime.*` overrides in the dataset manifest only when you
 intentionally need different resource names.
 
+### Argo Rollouts gate plane
+
+Simulation gating now uses Argo Rollouts in phase 1:
+
+- sync the platform app `argo-rollouts` before using the simulation workflow
+- verify the Rollouts controller and CRDs are healthy
+- keep `torghut-historical-simulation` as the orchestrator in `argo-workflows`
+- use namespaced `AnalysisTemplate` / `AnalysisRun` resources in `torghut` for:
+  - runtime readiness
+  - activity success classification
+  - teardown cleanliness
+
+Phase 1 does not migrate `torghut-sim` or `torghut-ta-sim` to `Rollout` kinds. The dedicated simulation workloads
+remain:
+
+- Knative `Service/torghut-sim`
+- `FlinkDeployment/torghut-ta-sim`
+- `Deployment` and `Service/torghut-forecast-sim`
+
+Required namespaced AnalysisTemplates:
+
+- `torghut-simulation-runtime-ready`
+- `torghut-simulation-activity`
+- `torghut-simulation-teardown-clean`
+- `torghut-simulation-artifact-bundle`
+
+Canonical operator flow:
+
+1. Sync Argo CD app `argo-rollouts`.
+2. Verify Rollouts CRDs/controller are healthy.
+3. Sync Argo CD apps `torghut` and `torghut-forecast`.
+4. Verify the AnalysisTemplates exist in namespace `torghut`.
+5. Submit `torghut-historical-simulation`.
+6. Observe both the Argo Workflow phases and the `AnalysisRun` objects in `torghut`.
+7. Treat the `AnalysisRun` outcomes as the authoritative simulation gate results.
+
+Quick checks:
+
+```bash
+kubectl get crd analysisruns.argoproj.io analysistemplates.argoproj.io -o name
+kubectl get analysistemplate -n torghut
+kubectl get analysisrun -n torghut
+```
+
 ### Scope / target resources (as deployed)
 - Kubernetes namespace: `torghut`
 - Flink TA job: `FlinkDeployment/torghut-ta-sim` (`argocd/applications/torghut/ta-sim/flinkdeployment.yaml`)
 - TA config: `ConfigMap/torghut-ta-sim-config` (`argocd/applications/torghut/ta-sim/configmap.yaml`)
 - Trading service: Knative `Service/torghut-sim` (`argocd/applications/torghut/knative-service-sim.yaml`)
 - Forecast service: `Service/torghut-forecast-sim` (`argocd/applications/torghut-forecast/sim/service.yaml`)
+- Simulation gates: `AnalysisTemplate/*` and `AnalysisRun/*` in namespace `torghut`
 - DB migration gate: `Job/torghut-db-migrations` (`argocd/applications/torghut/db-migrations-job.yaml`, Argo `PreSync` hook)
 - Kafka namespace/tools: `kafka` (Strimzi); bootstrap `kafka-kafka-bootstrap.kafka:9092`
 - Ceph RGW bucket: `ObjectBucketClaim/flink-checkpoints` (for Flink checkpoint/savepoint storage)

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -1,0 +1,86 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AnalysisTemplate
+metadata:
+  name: torghut-simulation-activity
+  namespace: torghut
+  labels:
+    app.kubernetes.io/name: torghut
+spec:
+  args:
+    - name: runId
+    - name: datasetId
+    - name: namespace
+    - name: torghutService
+    - name: taDeployment
+    - name: forecastService
+    - name: windowStart
+    - name: windowEnd
+    - name: signalTable
+    - name: priceTable
+    - name: postgresDatabase
+    - name: clickhouseHttpUrl
+    - name: clickhouseUsername
+    - name: monitorTimeoutSeconds
+    - name: monitorPollSeconds
+    - name: minTradeDecisions
+    - name: minExecutions
+    - name: minExecutionTcaMetrics
+    - name: minExecutionOrderEvents
+    - name: cursorGraceSeconds
+  metrics:
+    - name: activity
+      provider:
+        job:
+          spec:
+            backoffLimit: 0
+            ttlSecondsAfterFinished: 300
+            template:
+              spec:
+                serviceAccountName: torghut-runtime
+                restartPolicy: Never
+                containers:
+                  - name: analysis
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:ed936c6d5d5263aa170f97d37ce866a26316ab74bd313d941ae302fb43f65277
+                    imagePullPolicy: IfNotPresent
+                    env:
+                      - name: DB_DSN
+                        valueFrom:
+                          secretKeyRef:
+                            name: torghut-db-app
+                            key: uri
+                      - name: TORGHUT_CLICKHOUSE_PASSWORD
+                        valueFrom:
+                          secretKeyRef:
+                            name: torghut-clickhouse-auth
+                            key: torghut_password
+                    command:
+                      - /bin/bash
+                      - -lc
+                    args:
+                      - >-
+                        set -euo pipefail &&
+                        cd /app &&
+                        /opt/venv/bin/python scripts/run_simulation_analysis.py activity
+                        --run-id "{{args.runId}}"
+                        --dataset-id "{{args.datasetId}}"
+                        --namespace "{{args.namespace}}"
+                        --torghut-service "{{args.torghutService}}"
+                        --ta-deployment "{{args.taDeployment}}"
+                        --forecast-service "{{args.forecastService}}"
+                        --window-start "{{args.windowStart}}"
+                        --window-end "{{args.windowEnd}}"
+                        --signal-table "{{args.signalTable}}"
+                        --price-table "{{args.priceTable}}"
+                        --postgres-base-dsn-env DB_DSN
+                        --postgres-database "{{args.postgresDatabase}}"
+                        --clickhouse-http-url "{{args.clickhouseHttpUrl}}"
+                        --clickhouse-username "{{args.clickhouseUsername}}"
+                        --clickhouse-password-env TORGHUT_CLICKHOUSE_PASSWORD
+                        --monitor-timeout-seconds "{{args.monitorTimeoutSeconds}}"
+                        --monitor-poll-seconds "{{args.monitorPollSeconds}}"
+                        --min-trade-decisions "{{args.minTradeDecisions}}"
+                        --min-executions "{{args.minExecutions}}"
+                        --min-execution-tca-metrics "{{args.minExecutionTcaMetrics}}"
+                        --min-execution-order-events "{{args.minExecutionOrderEvents}}"
+                        --cursor-grace-seconds "{{args.cursorGraceSeconds}}"
+                        --json

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -1,0 +1,35 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AnalysisTemplate
+metadata:
+  name: torghut-simulation-artifact-bundle
+  namespace: torghut
+  labels:
+    app.kubernetes.io/name: torghut
+spec:
+  args:
+    - name: runDir
+  metrics:
+    - name: artifact-bundle
+      provider:
+        job:
+          spec:
+            backoffLimit: 0
+            ttlSecondsAfterFinished: 300
+            template:
+              spec:
+                serviceAccountName: torghut-runtime
+                restartPolicy: Never
+                containers:
+                  - name: analysis
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:ed936c6d5d5263aa170f97d37ce866a26316ab74bd313d941ae302fb43f65277
+                    imagePullPolicy: IfNotPresent
+                    command:
+                      - /bin/bash
+                      - -lc
+                    args:
+                      - >-
+                        set -euo pipefail &&
+                        cd /app &&
+                        /opt/venv/bin/python scripts/run_simulation_analysis.py artifact-bundle
+                        --run-dir "{{args.runDir}}"
+                        --json

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -1,0 +1,49 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AnalysisTemplate
+metadata:
+  name: torghut-simulation-runtime-ready
+  namespace: torghut
+  labels:
+    app.kubernetes.io/name: torghut
+spec:
+  args:
+    - name: runId
+    - name: datasetId
+    - name: namespace
+    - name: torghutService
+    - name: taDeployment
+    - name: forecastService
+    - name: windowStart
+    - name: windowEnd
+  metrics:
+    - name: runtime-ready
+      provider:
+        job:
+          spec:
+            backoffLimit: 0
+            ttlSecondsAfterFinished: 300
+            template:
+              spec:
+                serviceAccountName: torghut-runtime
+                restartPolicy: Never
+                containers:
+                  - name: analysis
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:ed936c6d5d5263aa170f97d37ce866a26316ab74bd313d941ae302fb43f65277
+                    imagePullPolicy: IfNotPresent
+                    command:
+                      - /bin/bash
+                      - -lc
+                    args:
+                      - >-
+                        set -euo pipefail &&
+                        cd /app &&
+                        /opt/venv/bin/python scripts/run_simulation_analysis.py runtime-ready
+                        --run-id "{{args.runId}}"
+                        --dataset-id "{{args.datasetId}}"
+                        --namespace "{{args.namespace}}"
+                        --torghut-service "{{args.torghutService}}"
+                        --ta-deployment "{{args.taDeployment}}"
+                        --forecast-service "{{args.forecastService}}"
+                        --window-start "{{args.windowStart}}"
+                        --window-end "{{args.windowEnd}}"
+                        --json

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -1,0 +1,60 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AnalysisTemplate
+metadata:
+  name: torghut-simulation-teardown-clean
+  namespace: torghut
+  labels:
+    app.kubernetes.io/name: torghut
+spec:
+  args:
+    - name: runId
+    - name: datasetId
+    - name: namespace
+    - name: taConfigmap
+    - name: taDeployment
+    - name: torghutService
+    - name: forecastService
+    - name: signalTable
+    - name: priceTable
+    - name: postgresDatabase
+  metrics:
+    - name: teardown-clean
+      provider:
+        job:
+          spec:
+            backoffLimit: 0
+            ttlSecondsAfterFinished: 300
+            template:
+              spec:
+                serviceAccountName: torghut-runtime
+                restartPolicy: Never
+                containers:
+                  - name: analysis
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:ed936c6d5d5263aa170f97d37ce866a26316ab74bd313d941ae302fb43f65277
+                    imagePullPolicy: IfNotPresent
+                    env:
+                      - name: DB_DSN
+                        valueFrom:
+                          secretKeyRef:
+                            name: torghut-db-app
+                            key: uri
+                    command:
+                      - /bin/bash
+                      - -lc
+                    args:
+                      - >-
+                        set -euo pipefail &&
+                        cd /app &&
+                        /opt/venv/bin/python scripts/run_simulation_analysis.py teardown-clean
+                        --run-id "{{args.runId}}"
+                        --dataset-id "{{args.datasetId}}"
+                        --namespace "{{args.namespace}}"
+                        --ta-configmap "{{args.taConfigmap}}"
+                        --ta-deployment "{{args.taDeployment}}"
+                        --torghut-service "{{args.torghutService}}"
+                        --forecast-service "{{args.forecastService}}"
+                        --signal-table "{{args.signalTable}}"
+                        --price-table "{{args.priceTable}}"
+                        --postgres-base-dsn-env DB_DSN
+                        --postgres-database "{{args.postgresDatabase}}"
+                        --json

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -113,6 +113,17 @@ spec:
           runtime["output_root"] = output_root
           payload["runtime"] = runtime
 
+          rollouts = payload.get("rollouts")
+          if not isinstance(rollouts, dict):
+            rollouts = {}
+          rollouts.setdefault("enabled", True)
+          rollouts.setdefault("namespace", runtime.get("namespace", "torghut"))
+          rollouts.setdefault("runtime_template", "torghut-simulation-runtime-ready")
+          rollouts.setdefault("activity_template", "torghut-simulation-activity")
+          rollouts.setdefault("teardown_template", "torghut-simulation-teardown-clean")
+          rollouts.setdefault("artifact_template", "torghut-simulation-artifact-bundle")
+          payload["rollouts"] = rollouts
+
           with open(manifest_path, 'w', encoding='utf-8') as handle:
             yaml.safe_dump(payload, handle, default_flow_style=False, sort_keys=False)
           PY

--- a/argocd/applications/torghut/kustomization.yaml
+++ b/argocd/applications/torghut/kustomization.yaml
@@ -17,6 +17,9 @@ resources:
   - serviceaccount.yaml
   - role.yaml
   - rolebinding.yaml
+  - rollouts-analysis-role.yaml
+  - rollouts-analysis-rolebinding-codex-workflow.yaml
+  - rollouts-analysis-rolebinding-runtime.yaml
   - alloy-rbac.yaml
   - alloy-configmap.yaml
   - alloy-deployment.yaml
@@ -31,6 +34,10 @@ resources:
   - empirical-artifacts-retention-cronjob.yaml
   - empirical-promotion-workflowtemplate.yaml
   - historical-simulation-workflowtemplate.yaml
+  - analysis-template-runtime-ready.yaml
+  - analysis-template-activity.yaml
+  - analysis-template-teardown-clean.yaml
+  - analysis-template-artifact-bundle.yaml
   - clickhouse
   - ws
   - ta

--- a/argocd/applications/torghut/rollouts-analysis-role.yaml
+++ b/argocd/applications/torghut/rollouts-analysis-role.yaml
@@ -1,0 +1,24 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: torghut-rollouts-analysis
+  namespace: torghut
+rules:
+  - apiGroups: ['argoproj.io']
+    resources: ['analysisruns']
+    verbs: ['create', 'get', 'list', 'watch', 'patch', 'delete']
+  - apiGroups: ['argoproj.io']
+    resources: ['analysistemplates']
+    verbs: ['get', 'list', 'watch']
+  - apiGroups: ['']
+    resources: ['pods', 'pods/log', 'configmaps', 'services']
+    verbs: ['get', 'list', 'watch']
+  - apiGroups: ['apps']
+    resources: ['deployments']
+    verbs: ['get', 'list', 'watch']
+  - apiGroups: ['serving.knative.dev']
+    resources: ['services', 'revisions']
+    verbs: ['get', 'list', 'watch']
+  - apiGroups: ['flink.apache.org']
+    resources: ['flinkdeployments']
+    verbs: ['get', 'list', 'watch']

--- a/argocd/applications/torghut/rollouts-analysis-rolebinding-codex-workflow.yaml
+++ b/argocd/applications/torghut/rollouts-analysis-rolebinding-codex-workflow.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: torghut-rollouts-analysis-codex-workflow
+  namespace: torghut
+subjects:
+  - kind: ServiceAccount
+    name: codex-workflow
+    namespace: argo-workflows
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: torghut-rollouts-analysis

--- a/argocd/applications/torghut/rollouts-analysis-rolebinding-runtime.yaml
+++ b/argocd/applications/torghut/rollouts-analysis-rolebinding-runtime.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: torghut-rollouts-analysis-runtime
+  namespace: torghut
+subjects:
+  - kind: ServiceAccount
+    name: torghut-runtime
+    namespace: torghut
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: torghut-rollouts-analysis

--- a/argocd/applicationsets/platform.yaml
+++ b/argocd/applicationsets/platform.yaml
@@ -238,6 +238,13 @@ spec:
                   argocd.argoproj.io/sync-wave: "2"
                 automation: auto
                 enabled: "true"
+              - name: argo-rollouts
+                path: argocd/applications/argo-rollouts
+                namespace: argo-rollouts
+                annotations:
+                  argocd.argoproj.io/sync-wave: "3"
+                automation: manual
+                enabled: "true"
               - name: argo-workflows
                 path: argocd/applications/argo-workflows
                 namespace: argo-workflows

--- a/docs/torghut/rollouts/historical-simulation-playbook.md
+++ b/docs/torghut/rollouts/historical-simulation-playbook.md
@@ -27,6 +27,10 @@ Use this playbook when you need to:
 
 ## Prerequisites
 
+- Argo CD app `argo-rollouts` synced and healthy.
+- Rollouts CRDs available:
+  - `analysisruns.argoproj.io`
+  - `analysistemplates.argoproj.io`
 - `kubectl` access to the target cluster and namespace (`torghut`).
 - Access to the cluster services for Kafka, ClickHouse, and Postgres from Argo workflow runtime.
 - A dataset manifest file (YAML/JSON) with explicit `window.start` and `window.end`.
@@ -71,8 +75,17 @@ Expected dedicated resources:
 - `FlinkDeployment/torghut-ta-sim`
 - `ConfigMap/torghut-ta-sim-config`
 - `Service/torghut-forecast-sim`
+- `AnalysisTemplate/torghut-simulation-runtime-ready`
+- `AnalysisTemplate/torghut-simulation-activity`
+- `AnalysisTemplate/torghut-simulation-teardown-clean`
 
 This playbook is Argo-first and should not be executed locally.
+
+Phase 1 note:
+
+- Argo Workflows remains the simulation orchestrator.
+- Argo Rollouts is used as the gate/control plane via `AnalysisTemplate` and `AnalysisRun`.
+- `torghut-sim` and `torghut-ta-sim` are not migrated to `Rollout` resources in this phase.
 
 ## Step 2: Plan (Argo)
 
@@ -116,9 +129,23 @@ argo submit --from workflowtemplate/torghut-historical-simulation \
 
 - Argo automation switch to `manual` (if manifest enables management),
 - apply (dump/replay/configure),
-- monitor until cursor reaches run window and thresholds are met,
+- runtime verification through an `AnalysisRun`,
+- activity verification through an `AnalysisRun`,
 - post-run report generation,
-- teardown + Argo automation restore.
+- teardown + Argo automation restore,
+- teardown cleanliness verification through an `AnalysisRun`.
+
+Observe the gate plane while the workflow is running:
+
+```bash
+kubectl get analysisrun -n torghut -w
+```
+
+Expected AnalysisRuns per simulation run:
+
+- `torghut-sim-runtime-ready-<run-token>`
+- `torghut-sim-activity-<run-token>`
+- `torghut-sim-teardown-clean-<run-token>`
 
 Workflow pods run in the image environment, so ensure the manifest includes:
 
@@ -207,6 +234,8 @@ Expected values are `torghut.sim.*` topics and `TA_GROUP_ID=torghut-ta-sim-<run_
   - latest `RUN_STATE ...` lines visible in argo logs showing `subphase=replay` with non-zero records while waiting
  - `dump_coverage` present and passing
  - `window_policy` present
+ - `rollouts.runtime_analysis_run` populated after runtime gate completes
+ - `rollouts.activity_analysis_run` populated after activity gate completes
 
 ## Step 5: Collect Empirical Evidence
 
@@ -215,6 +244,10 @@ Collect all of:
 - `run-manifest.json`
 - `run-full-lifecycle-manifest.json`
 - `run-state.json`
+- `runtime-verify.json`
+- `signal-activity.json`
+- `decision-activity.json`
+- `execution-activity.json`
 - `source-dump.replay-marker.json`
 - `report/simulation-report.json`
 - `report/simulation-report.md`
@@ -223,6 +256,7 @@ Collect all of:
 - `report/llm-review-summary.csv`
 - Torghut `/trading/status` snapshot
 - TA + Torghut logs for the run window
+- `AnalysisRun` YAML/status for runtime, activity, and teardown gates
 - Postgres row counts in simulation DB:
   - `trade_decisions`
   - `executions`
@@ -252,6 +286,15 @@ kubectl exec -i -n torghut chi-torghut-clickhouse-default-0-0-0 -- \
            FROM system.parts
            WHERE active=1 AND database='<simulation_db>'
            GROUP BY table ORDER BY table FORMAT TabSeparated"
+```
+
+Gate inspection:
+
+```bash
+kubectl get analysisrun -n torghut
+kubectl get analysisrun -n torghut torghut-sim-runtime-ready-<run_token> -o yaml
+kubectl get analysisrun -n torghut torghut-sim-activity-<run_token> -o yaml
+kubectl get analysisrun -n torghut torghut-sim-teardown-clean-<run_token> -o yaml
 ```
 
 ## Step 6: Split-Mode Teardown (Only if you did not use `mode=run`)

--- a/packages/scripts/src/torghut/__tests__/update-manifests.test.ts
+++ b/packages/scripts/src/torghut/__tests__/update-manifests.test.ts
@@ -14,6 +14,10 @@ const createFixture = () => {
   const leanRunnerManifestPath = join(dir, 'lean-runner-deployment.yaml')
   const historicalWorkflowManifestPath = join(dir, 'historical-simulation-workflowtemplate.yaml')
   const empiricalWorkflowManifestPath = join(dir, 'empirical-promotion-workflowtemplate.yaml')
+  const analysisRuntimeReadyManifestPath = join(dir, 'analysis-template-runtime-ready.yaml')
+  const analysisActivityManifestPath = join(dir, 'analysis-template-activity.yaml')
+  const analysisTeardownManifestPath = join(dir, 'analysis-template-teardown-clean.yaml')
+  const analysisArtifactManifestPath = join(dir, 'analysis-template-artifact-bundle.yaml')
   const empiricalBackfillManifestPath = join(dir, 'empirical-jobs-backfill-job.yaml')
   const forecastManifestPath = join(dir, 'forecast-deployment.yaml')
   const forecastSimulationManifestPath = join(dir, 'forecast-sim-deployment.yaml')
@@ -83,6 +87,10 @@ spec:
     leanRunnerManifestPath,
     historicalWorkflowManifestPath,
     empiricalWorkflowManifestPath,
+    analysisRuntimeReadyManifestPath,
+    analysisActivityManifestPath,
+    analysisTeardownManifestPath,
+    analysisArtifactManifestPath,
     empiricalBackfillManifestPath,
     forecastManifestPath,
     forecastSimulationManifestPath,
@@ -109,6 +117,10 @@ spec:
     leanRunnerManifestPath,
     historicalWorkflowManifestPath,
     empiricalWorkflowManifestPath,
+    analysisRuntimeReadyManifestPath,
+    analysisActivityManifestPath,
+    analysisTeardownManifestPath,
+    analysisArtifactManifestPath,
     empiricalBackfillManifestPath,
     forecastManifestPath,
     forecastSimulationManifestPath,
@@ -130,6 +142,10 @@ describe('update-manifests', () => {
       leanRunnerManifestPath: relative(repoRoot, fixture.leanRunnerManifestPath),
       historicalSimulationWorkflowManifestPath: relative(repoRoot, fixture.historicalWorkflowManifestPath),
       empiricalPromotionWorkflowManifestPath: relative(repoRoot, fixture.empiricalWorkflowManifestPath),
+      analysisRuntimeReadyManifestPath: relative(repoRoot, fixture.analysisRuntimeReadyManifestPath),
+      analysisActivityManifestPath: relative(repoRoot, fixture.analysisActivityManifestPath),
+      analysisTeardownManifestPath: relative(repoRoot, fixture.analysisTeardownManifestPath),
+      analysisArtifactManifestPath: relative(repoRoot, fixture.analysisArtifactManifestPath),
       empiricalBackfillManifestPath: relative(repoRoot, fixture.empiricalBackfillManifestPath),
       forecastManifestPath: relative(repoRoot, fixture.forecastManifestPath),
       forecastSimulationManifestPath: relative(repoRoot, fixture.forecastSimulationManifestPath),
@@ -141,6 +157,10 @@ describe('update-manifests', () => {
     const leanRunnerManifest = readFileSync(fixture.leanRunnerManifestPath, 'utf8')
     const historicalWorkflowManifest = readFileSync(fixture.historicalWorkflowManifestPath, 'utf8')
     const empiricalWorkflowManifest = readFileSync(fixture.empiricalWorkflowManifestPath, 'utf8')
+    const analysisRuntimeReadyManifest = readFileSync(fixture.analysisRuntimeReadyManifestPath, 'utf8')
+    const analysisActivityManifest = readFileSync(fixture.analysisActivityManifestPath, 'utf8')
+    const analysisTeardownManifest = readFileSync(fixture.analysisTeardownManifestPath, 'utf8')
+    const analysisArtifactManifest = readFileSync(fixture.analysisArtifactManifestPath, 'utf8')
     const empiricalBackfillManifest = readFileSync(fixture.empiricalBackfillManifestPath, 'utf8')
     const forecastManifest = readFileSync(fixture.forecastManifestPath, 'utf8')
     const forecastSimulationManifest = readFileSync(fixture.forecastSimulationManifestPath, 'utf8')
@@ -164,6 +184,10 @@ describe('update-manifests', () => {
       leanRunnerManifest,
       historicalWorkflowManifest,
       empiricalWorkflowManifest,
+      analysisRuntimeReadyManifest,
+      analysisActivityManifest,
+      analysisTeardownManifest,
+      analysisArtifactManifest,
       empiricalBackfillManifest,
       forecastManifest,
       forecastSimulationManifest,
@@ -176,7 +200,7 @@ describe('update-manifests', () => {
     expect(result.imageRef).toBe(
       'registry.ide-newton.ts.net/lab/torghut@sha256:430763ebeeda8734e1da3ae8c6b665bcc1b380fb815317fffc98371cccea219e',
     )
-    expect(result.changedPaths.length).toBe(9)
+    expect(result.changedPaths.length).toBe(13)
 
     rmSync(fixture.dir, { recursive: true, force: true })
   })
@@ -195,6 +219,10 @@ describe('update-manifests', () => {
       leanRunnerManifestPath: relative(repoRoot, fixture.leanRunnerManifestPath),
       historicalSimulationWorkflowManifestPath: relative(repoRoot, fixture.historicalWorkflowManifestPath),
       empiricalPromotionWorkflowManifestPath: relative(repoRoot, fixture.empiricalWorkflowManifestPath),
+      analysisRuntimeReadyManifestPath: relative(repoRoot, fixture.analysisRuntimeReadyManifestPath),
+      analysisActivityManifestPath: relative(repoRoot, fixture.analysisActivityManifestPath),
+      analysisTeardownManifestPath: relative(repoRoot, fixture.analysisTeardownManifestPath),
+      analysisArtifactManifestPath: relative(repoRoot, fixture.analysisArtifactManifestPath),
       empiricalBackfillManifestPath: relative(repoRoot, fixture.empiricalBackfillManifestPath),
       forecastManifestPath: relative(repoRoot, fixture.forecastManifestPath),
       forecastSimulationManifestPath: relative(repoRoot, fixture.forecastSimulationManifestPath),

--- a/packages/scripts/src/torghut/update-manifests.ts
+++ b/packages/scripts/src/torghut/update-manifests.ts
@@ -18,6 +18,10 @@ const defaultHistoricalSimulationWorkflowManifestPath =
   'argocd/applications/torghut/historical-simulation-workflowtemplate.yaml'
 const defaultEmpiricalPromotionWorkflowManifestPath =
   'argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml'
+const defaultAnalysisRuntimeReadyManifestPath = 'argocd/applications/torghut/analysis-template-runtime-ready.yaml'
+const defaultAnalysisActivityManifestPath = 'argocd/applications/torghut/analysis-template-activity.yaml'
+const defaultAnalysisTeardownManifestPath = 'argocd/applications/torghut/analysis-template-teardown-clean.yaml'
+const defaultAnalysisArtifactManifestPath = 'argocd/applications/torghut/analysis-template-artifact-bundle.yaml'
 const defaultEmpiricalBackfillManifestPath = 'argocd/applications/torghut/empirical-jobs-backfill-job.yaml'
 const defaultForecastManifestPath = 'argocd/applications/torghut-forecast/deployment.yaml'
 const defaultForecastSimulationManifestPath = 'argocd/applications/torghut-forecast/sim/deployment.yaml'
@@ -36,6 +40,10 @@ type UpdateManifestsOptions = {
   leanRunnerManifestPath?: string
   historicalSimulationWorkflowManifestPath?: string
   empiricalPromotionWorkflowManifestPath?: string
+  analysisRuntimeReadyManifestPath?: string
+  analysisActivityManifestPath?: string
+  analysisTeardownManifestPath?: string
+  analysisArtifactManifestPath?: string
   empiricalBackfillManifestPath?: string
   forecastManifestPath?: string
   forecastSimulationManifestPath?: string
@@ -55,6 +63,10 @@ type CliOptions = {
   leanRunnerManifestPath?: string
   historicalSimulationWorkflowManifestPath?: string
   empiricalPromotionWorkflowManifestPath?: string
+  analysisRuntimeReadyManifestPath?: string
+  analysisActivityManifestPath?: string
+  analysisTeardownManifestPath?: string
+  analysisArtifactManifestPath?: string
   empiricalBackfillManifestPath?: string
   forecastManifestPath?: string
   forecastSimulationManifestPath?: string
@@ -183,6 +195,26 @@ const updateTorghutManifests = (options: UpdateManifestsOptions) => {
     options.empiricalPromotionWorkflowManifestPath ?? defaultEmpiricalPromotionWorkflowManifestPath,
     'torghut-empirical-promotion image reference',
   )
+  const analysisRuntimeReady = updateImageOnlyManifest(
+    options,
+    options.analysisRuntimeReadyManifestPath ?? defaultAnalysisRuntimeReadyManifestPath,
+    'torghut-simulation-runtime-ready image reference',
+  )
+  const analysisActivity = updateImageOnlyManifest(
+    options,
+    options.analysisActivityManifestPath ?? defaultAnalysisActivityManifestPath,
+    'torghut-simulation-activity image reference',
+  )
+  const analysisTeardown = updateImageOnlyManifest(
+    options,
+    options.analysisTeardownManifestPath ?? defaultAnalysisTeardownManifestPath,
+    'torghut-simulation-teardown-clean image reference',
+  )
+  const analysisArtifact = updateImageOnlyManifest(
+    options,
+    options.analysisArtifactManifestPath ?? defaultAnalysisArtifactManifestPath,
+    'torghut-simulation-artifact-bundle image reference',
+  )
   const empiricalBackfill = updateImageOnlyManifest(
     options,
     options.empiricalBackfillManifestPath ?? defaultEmpiricalBackfillManifestPath,
@@ -205,6 +237,10 @@ const updateTorghutManifests = (options: UpdateManifestsOptions) => {
     leanRunner,
     historicalSimulationWorkflow,
     empiricalPromotionWorkflow,
+    analysisRuntimeReady,
+    analysisActivity,
+    analysisTeardown,
+    analysisArtifact,
     empiricalBackfill,
     forecast,
     forecastSimulation,
@@ -240,6 +276,10 @@ Options:
   --lean-runner-manifest-path <path>
   --historical-simulation-workflow-manifest-path <path>
   --empirical-promotion-workflow-manifest-path <path>
+  --analysis-runtime-ready-manifest-path <path>
+  --analysis-activity-manifest-path <path>
+  --analysis-teardown-manifest-path <path>
+  --analysis-artifact-manifest-path <path>
   --empirical-backfill-manifest-path <path>
   --forecast-manifest-path <path>
   --forecast-simulation-manifest-path <path>`)
@@ -299,6 +339,18 @@ Options:
       case '--empirical-promotion-workflow-manifest-path':
         options.empiricalPromotionWorkflowManifestPath = value
         break
+      case '--analysis-runtime-ready-manifest-path':
+        options.analysisRuntimeReadyManifestPath = value
+        break
+      case '--analysis-activity-manifest-path':
+        options.analysisActivityManifestPath = value
+        break
+      case '--analysis-teardown-manifest-path':
+        options.analysisTeardownManifestPath = value
+        break
+      case '--analysis-artifact-manifest-path':
+        options.analysisArtifactManifestPath = value
+        break
       case '--empirical-backfill-manifest-path':
         options.empiricalBackfillManifestPath = value
         break
@@ -348,6 +400,14 @@ export const main = (cliOptions?: CliOptions) => {
       parsed.historicalSimulationWorkflowManifestPath ?? process.env.TORGHUT_HISTORICAL_SIMULATION_WORKFLOW_PATH,
     empiricalPromotionWorkflowManifestPath:
       parsed.empiricalPromotionWorkflowManifestPath ?? process.env.TORGHUT_EMPIRICAL_PROMOTION_WORKFLOW_PATH,
+    analysisRuntimeReadyManifestPath:
+      parsed.analysisRuntimeReadyManifestPath ?? process.env.TORGHUT_ANALYSIS_RUNTIME_READY_MANIFEST_PATH,
+    analysisActivityManifestPath:
+      parsed.analysisActivityManifestPath ?? process.env.TORGHUT_ANALYSIS_ACTIVITY_MANIFEST_PATH,
+    analysisTeardownManifestPath:
+      parsed.analysisTeardownManifestPath ?? process.env.TORGHUT_ANALYSIS_TEARDOWN_MANIFEST_PATH,
+    analysisArtifactManifestPath:
+      parsed.analysisArtifactManifestPath ?? process.env.TORGHUT_ANALYSIS_ARTIFACT_MANIFEST_PATH,
     empiricalBackfillManifestPath:
       parsed.empiricalBackfillManifestPath ?? process.env.TORGHUT_EMPIRICAL_BACKFILL_MANIFEST_PATH,
     forecastManifestPath: parsed.forecastManifestPath ?? process.env.TORGHUT_FORECAST_MANIFEST_PATH,

--- a/services/torghut/config/simulation/example-dataset.yaml
+++ b/services/torghut/config/simulation/example-dataset.yaml
@@ -47,6 +47,14 @@ runtime:
   torghut_forecast_service: torghut-forecast-sim
   output_root: artifacts/torghut/simulations
 
+rollouts:
+  enabled: true
+  namespace: torghut
+  runtime_template: torghut-simulation-runtime-ready
+  activity_template: torghut-simulation-activity
+  teardown_template: torghut-simulation-teardown-clean
+  artifact_template: torghut-simulation-artifact-bundle
+
 replay:
   pace_mode: max_throughput
   acceleration: 1

--- a/services/torghut/config/simulation/full-day-2026-03-06.yaml
+++ b/services/torghut/config/simulation/full-day-2026-03-06.yaml
@@ -49,6 +49,14 @@ runtime:
   torghut_forecast_service: torghut-forecast-sim
   output_root: artifacts/torghut/simulations
 
+rollouts:
+  enabled: true
+  namespace: torghut
+  runtime_template: torghut-simulation-runtime-ready
+  activity_template: torghut-simulation-activity
+  teardown_template: torghut-simulation-teardown-clean
+  artifact_template: torghut-simulation-artifact-bundle
+
 replay:
   pace_mode: max_throughput
   acceleration: 1

--- a/services/torghut/config/simulation/smoke-open-hour-2026-03-06.yaml
+++ b/services/torghut/config/simulation/smoke-open-hour-2026-03-06.yaml
@@ -48,6 +48,14 @@ runtime:
   torghut_forecast_service: torghut-forecast-sim
   output_root: artifacts/torghut/simulations
 
+rollouts:
+  enabled: true
+  namespace: torghut
+  runtime_template: torghut-simulation-runtime-ready
+  activity_template: torghut-simulation-activity
+  teardown_template: torghut-simulation-teardown-clean
+  artifact_template: torghut-simulation-artifact-bundle
+
 replay:
   pace_mode: max_throughput
   acceleration: 1

--- a/services/torghut/scripts/historical_simulation_verification.py
+++ b/services/torghut/scripts/historical_simulation_verification.py
@@ -1,0 +1,853 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import time
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import asdict, is_dataclass
+from datetime import date, datetime, timedelta, timezone
+from http.client import HTTPConnection, HTTPSConnection
+from pathlib import Path
+from typing import Any, cast
+from urllib.parse import quote_plus, urlsplit
+from zoneinfo import ZoneInfo
+
+import psycopg
+
+PRODUCTION_TOPIC_BY_ROLE = {
+    'trades': 'torghut.trades.v1',
+    'quotes': 'torghut.quotes.v1',
+    'bars': 'torghut.bars.1m.v1',
+    'status': 'torghut.status.v1',
+    'ta_microbars': 'torghut.ta.bars.1s.v1',
+    'ta_signals': 'torghut.ta.signals.v1',
+    'ta_status': 'torghut.ta.status.v1',
+    'order_updates': 'torghut.trade-updates.v1',
+}
+
+TORGHUT_ENV_KEYS = [
+    'DB_DSN',
+    'TRADING_MODE',
+    'TRADING_FEATURE_FLAGS_ENABLED',
+    'TRADING_FEATURE_QUALITY_ENABLED',
+    'TRADING_FEATURE_MAX_REQUIRED_NULL_RATE',
+    'TRADING_FEATURE_MAX_STALENESS_MS',
+    'TRADING_FEATURE_MAX_DUPLICATE_RATIO',
+    'TRADING_STRATEGY_RUNTIME_MODE',
+    'TRADING_STRATEGY_SCHEDULER_ENABLED',
+    'TRADING_SIGNAL_TABLE',
+    'TRADING_PRICE_TABLE',
+    'TRADING_ORDER_FEED_ENABLED',
+    'TRADING_ORDER_FEED_BOOTSTRAP_SERVERS',
+    'TRADING_ORDER_FEED_SECURITY_PROTOCOL',
+    'TRADING_ORDER_FEED_SASL_MECHANISM',
+    'TRADING_ORDER_FEED_SASL_USERNAME',
+    'TRADING_ORDER_FEED_SASL_PASSWORD',
+    'TRADING_ORDER_FEED_TOPIC',
+    'TRADING_ORDER_FEED_TOPIC_V2',
+    'TRADING_ORDER_FEED_GROUP_ID',
+    'TRADING_EXECUTION_ADAPTER',
+    'TRADING_EXECUTION_FALLBACK_ADAPTER',
+    'TRADING_SIMULATION_ENABLED',
+    'TRADING_SIMULATION_RUN_ID',
+    'TRADING_SIMULATION_DATASET_ID',
+    'TRADING_SIMULATION_ORDER_UPDATES_TOPIC',
+    'TRADING_SIMULATION_ORDER_UPDATES_BOOTSTRAP_SERVERS',
+    'TRADING_SIMULATION_ORDER_UPDATES_SECURITY_PROTOCOL',
+    'TRADING_SIMULATION_ORDER_UPDATES_SASL_MECHANISM',
+    'TRADING_SIMULATION_ORDER_UPDATES_SASL_USERNAME',
+    'TRADING_SIMULATION_ORDER_UPDATES_SASL_PASSWORD',
+]
+
+US_EQUITIES_REGULAR_PROFILE = 'us_equities_regular'
+US_EQUITIES_REGULAR_TIMEZONE = 'America/New_York'
+US_EQUITIES_REGULAR_MINUTES = 390
+DEFAULT_COVERAGE_STRICT_RATIO = 0.95
+DEFAULT_RUN_MONITOR_TIMEOUT_SECONDS = 900
+DEFAULT_RUN_MONITOR_POLL_SECONDS = 15
+DEFAULT_RUN_MONITOR_MIN_DECISIONS = 1
+DEFAULT_RUN_MONITOR_MIN_EXECUTIONS = 1
+DEFAULT_RUN_MONITOR_MIN_TCA = 1
+DEFAULT_RUN_MONITOR_MIN_ORDER_EVENTS = 0
+DEFAULT_RUN_MONITOR_CURSOR_GRACE_SECONDS = 120
+TRANSIENT_POSTGRES_ERROR_PATTERNS = (
+    'connection refused',
+    'connection reset by peer',
+    'could not receive data from server',
+    'server closed the connection unexpectedly',
+    'connection to server at',
+    'terminating connection due to administrator command',
+    'timeout expired',
+)
+
+
+def _as_mapping(value: Any) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        return {}
+    return {str(key): item for key, item in cast(Mapping[str, Any], value).items()}
+
+
+def _as_text(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    return text
+
+
+def _safe_int(value: Any, *, default: int = 0) -> int:
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if isinstance(value, str):
+        stripped = value.strip()
+        if stripped:
+            try:
+                return int(stripped)
+            except ValueError:
+                return default
+    return default
+
+
+def _safe_float(value: Any, *, default: float = 0.0) -> float:
+    if isinstance(value, bool):
+        return float(value)
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        stripped = value.strip()
+        if stripped:
+            try:
+                return float(stripped)
+            except ValueError:
+                return default
+    return default
+
+
+def _resource_attr(resource: Any, key: str, *, default: Any = None) -> Any:
+    if isinstance(resource, Mapping):
+        return resource.get(key, default)
+    return getattr(resource, key, default)
+
+
+def _resource_asdict(resource: Any) -> dict[str, Any]:
+    if isinstance(resource, Mapping):
+        return {str(key): value for key, value in cast(Mapping[str, Any], resource).items()}
+    if is_dataclass(resource):
+        payload = asdict(resource)
+        return {str(key): value for key, value in cast(dict[str, Any], payload).items()}
+    return dict(vars(resource))
+
+
+def _parse_rfc3339_timestamp(value: str | None, *, label: str) -> datetime:
+    if value is None:
+        raise SystemExit(f'{label} is required in manifest')
+    cleaned = value.replace('Z', '+00:00')
+    try:
+        parsed = datetime.fromisoformat(cleaned)
+    except ValueError as exc:
+        raise SystemExit(f'invalid {label} timestamp: {value}') from exc
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _resolve_window_bounds(manifest: Mapping[str, Any]) -> tuple[datetime, datetime]:
+    window = _as_mapping(manifest.get('window'))
+    start = _parse_rfc3339_timestamp(_as_text(window.get('start')), label='window.start')
+    end = _parse_rfc3339_timestamp(_as_text(window.get('end')), label='window.end')
+    if end <= start:
+        raise RuntimeError('window.end must be after window.start')
+    return start, end
+
+
+def _window_min_coverage_minutes(window: Mapping[str, Any], *, profile: str | None) -> int | None:
+    raw_minutes = window.get('min_coverage_minutes')
+    if raw_minutes is not None:
+        minutes = _safe_int(raw_minutes, default=-1)
+        if minutes <= 0:
+            raise RuntimeError('window.min_coverage_minutes must be > 0 when provided')
+        return minutes
+    if profile == US_EQUITIES_REGULAR_PROFILE:
+        return US_EQUITIES_REGULAR_MINUTES
+    return None
+
+
+def _validate_us_equities_regular_profile(
+    *,
+    start: datetime,
+    end: datetime,
+    window: Mapping[str, Any],
+) -> None:
+    trading_day_raw = _as_text(window.get('trading_day'))
+    if trading_day_raw is None:
+        raise RuntimeError('window.trading_day is required when window.profile=us_equities_regular')
+    timezone_name = _as_text(window.get('timezone')) or US_EQUITIES_REGULAR_TIMEZONE
+    try:
+        local_tz = ZoneInfo(timezone_name)
+    except Exception as exc:
+        raise RuntimeError(f'invalid_window_timezone:{timezone_name}') from exc
+    try:
+        trading_day = date.fromisoformat(trading_day_raw)
+    except ValueError as exc:
+        raise RuntimeError(f'invalid_window_trading_day:{trading_day_raw}') from exc
+
+    expected_start_local = datetime(trading_day.year, trading_day.month, trading_day.day, 9, 30, tzinfo=local_tz)
+    expected_end_local = datetime(trading_day.year, trading_day.month, trading_day.day, 16, 0, tzinfo=local_tz)
+    expected_start_utc = expected_start_local.astimezone(timezone.utc)
+    expected_end_utc = expected_end_local.astimezone(timezone.utc)
+    if start != expected_start_utc or end != expected_end_utc:
+        raise RuntimeError(
+            'window_profile_mismatch:us_equities_regular '
+            f'expected_start={expected_start_utc.isoformat()} '
+            f'expected_end={expected_end_utc.isoformat()} '
+            f'observed_start={start.isoformat()} '
+            f'observed_end={end.isoformat()}'
+        )
+
+
+def _validate_window_policy(manifest: Mapping[str, Any]) -> dict[str, Any]:
+    start, end = _resolve_window_bounds(manifest)
+    window = _as_mapping(manifest.get('window'))
+    profile = (_as_text(window.get('profile')) or '').strip().lower() or None
+    if profile == US_EQUITIES_REGULAR_PROFILE:
+        _validate_us_equities_regular_profile(start=start, end=end, window=window)
+    elif profile is not None:
+        raise RuntimeError(f'unsupported_window_profile:{profile}')
+
+    min_coverage_minutes = _window_min_coverage_minutes(window, profile=profile)
+    observed_minutes = (end - start).total_seconds() / 60.0
+    if min_coverage_minutes is not None and observed_minutes < float(min_coverage_minutes):
+        raise RuntimeError(
+            'window_coverage_too_small '
+            f'observed_minutes={observed_minutes:.3f} '
+            f'minimum_required={min_coverage_minutes}'
+        )
+
+    strict_ratio = _safe_float(window.get('strict_coverage_ratio'), default=DEFAULT_COVERAGE_STRICT_RATIO)
+    if strict_ratio <= 0 or strict_ratio > 1:
+        raise RuntimeError('window.strict_coverage_ratio must be in (0, 1]')
+
+    return {
+        'window_start': start.isoformat(),
+        'window_end': end.isoformat(),
+        'profile': profile,
+        'min_coverage_minutes': min_coverage_minutes,
+        'observed_minutes': observed_minutes,
+        'strict_coverage_ratio': strict_ratio,
+    }
+
+
+def _validate_dump_coverage(
+    *,
+    manifest: Mapping[str, Any],
+    dump_report: Mapping[str, Any],
+) -> dict[str, Any]:
+    window = _as_mapping(manifest.get('window'))
+    profile = (_as_text(window.get('profile')) or '').strip().lower() or None
+    min_coverage_minutes = _window_min_coverage_minutes(
+        window,
+        profile=profile,
+    )
+    strict_ratio_raw = window.get('strict_coverage_ratio')
+    strict_ratio = (
+        _safe_float(strict_ratio_raw, default=DEFAULT_COVERAGE_STRICT_RATIO)
+        if strict_ratio_raw is not None
+        else DEFAULT_COVERAGE_STRICT_RATIO
+    )
+
+    records = _safe_int(dump_report.get('records'))
+    if records <= 0:
+        raise RuntimeError('dump_records_empty')
+
+    min_source_timestamp_ms = dump_report.get('min_source_timestamp_ms')
+    max_source_timestamp_ms = dump_report.get('max_source_timestamp_ms')
+    if min_source_timestamp_ms is None or max_source_timestamp_ms is None:
+        return {
+            'applied': False,
+            'reason': 'timestamp_coverage_unavailable',
+        }
+
+    min_ms = _safe_int(min_source_timestamp_ms, default=-1)
+    max_ms = _safe_int(max_source_timestamp_ms, default=-1)
+    if min_ms < 0 or max_ms < 0 or max_ms < min_ms:
+        raise RuntimeError('dump_timestamp_coverage_invalid')
+    observed_minutes = (max_ms - min_ms) / 60_000.0
+
+    if min_coverage_minutes is not None:
+        required_minutes = float(min_coverage_minutes) * strict_ratio
+        if observed_minutes < required_minutes:
+            raise RuntimeError(
+                'dump_coverage_too_short '
+                f'observed_minutes={observed_minutes:.2f} '
+                f'required_minutes={required_minutes:.2f} '
+                f'strict_ratio={strict_ratio:.4f}'
+            )
+        return {
+            'applied': True,
+            'observed_minutes': observed_minutes,
+            'required_minutes': required_minutes,
+            'min_source_timestamp_ms': min_ms,
+            'max_source_timestamp_ms': max_ms,
+            'strict_ratio': strict_ratio,
+            'profile': profile,
+        }
+    return {
+        'applied': False,
+        'observed_minutes': observed_minutes,
+        'reason': 'no_minimum_coverage_policy',
+        'min_source_timestamp_ms': min_ms,
+        'max_source_timestamp_ms': max_ms,
+    }
+
+
+def _replace_database_in_dsn(dsn: str, *, database: str, label: str) -> str:
+    parsed = urlsplit(dsn)
+    if not parsed.scheme or not parsed.netloc:
+        raise SystemExit(f'{label} must be a valid URL')
+    return parsed._replace(path='/' + quote_plus(database)).geturl()
+
+
+def _run_command(
+    args: Sequence[str],
+    *,
+    input_text: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    try:
+        return subprocess.run(
+            list(args),
+            check=True,
+            text=True,
+            capture_output=True,
+            input=input_text,
+        )
+    except subprocess.CalledProcessError as exc:
+        stdout = (exc.stdout or '').strip()
+        stderr = (exc.stderr or '').strip()
+        detail = stderr or stdout or str(exc)
+        raise RuntimeError(f'command_failed: {" ".join(args)}: {detail}') from exc
+
+
+def _kubectl_json(namespace: str, args: Sequence[str]) -> dict[str, Any]:
+    result = _run_command(['kubectl', '-n', namespace, *args])
+    payload = json.loads(result.stdout)
+    if not isinstance(payload, Mapping):
+        raise RuntimeError('kubectl did not return a mapping payload')
+    return {str(key): value for key, value in cast(Mapping[str, Any], payload).items()}
+
+
+def _is_transient_postgres_error(error: Exception) -> bool:
+    message = str(error).lower()
+    return any(pattern in message for pattern in TRANSIENT_POSTGRES_ERROR_PATTERNS)
+
+
+def _run_with_transient_postgres_retry(
+    *,
+    label: str,
+    operation: Callable[[], Any],
+    attempts: int = 8,
+    sleep_seconds: float = 0.5,
+) -> Any:
+    last_error: Exception | None = None
+    for attempt in range(1, attempts + 1):
+        try:
+            return operation()
+        except Exception as exc:
+            if not _is_transient_postgres_error(exc):
+                raise
+            last_error = exc
+            if attempt >= attempts:
+                break
+            time.sleep(sleep_seconds * attempt)
+    if last_error is None:
+        raise RuntimeError(f'{label}: transient retry failed without captured exception')
+    raise RuntimeError(f'{label}: exhausted transient retries: {last_error}') from last_error
+
+
+def _http_clickhouse_query(
+    *,
+    config: Any,
+    query: str,
+) -> tuple[int, str]:
+    http_url = _as_text(_resource_attr(config, 'http_url'))
+    if http_url is None:
+        raise RuntimeError('clickhouse http_url is required')
+    parsed = urlsplit(http_url)
+    if not parsed.scheme or not parsed.hostname:
+        raise RuntimeError(f'invalid_clickhouse_http_url:{http_url}')
+
+    connection_class = HTTPSConnection if parsed.scheme == 'https' else HTTPConnection
+    connection = connection_class(parsed.hostname, parsed.port)
+    path = parsed.path or '/'
+    if parsed.query:
+        path = f'{path}?{parsed.query}'
+
+    headers = {'Content-Type': 'text/plain'}
+    username = _as_text(_resource_attr(config, 'username'))
+    password = _as_text(_resource_attr(config, 'password'))
+    if username is not None:
+        headers['X-ClickHouse-User'] = username
+    if password is not None:
+        headers['X-ClickHouse-Key'] = password
+
+    try:
+        connection.request('POST', path, body=query.encode('utf-8'), headers=headers)
+        response = connection.getresponse()
+        return response.status, response.read().decode('utf-8')
+    finally:
+        connection.close()
+
+
+def _condition_status(payload: Mapping[str, Any], *, condition_type: str) -> str | None:
+    conditions = payload.get('conditions')
+    if not isinstance(conditions, list):
+        return None
+    for raw_item in conditions:
+        if not isinstance(raw_item, Mapping):
+            continue
+        item = cast(Mapping[str, Any], raw_item)
+        if _as_text(item.get('type')) == condition_type:
+            return _as_text(item.get('status'))
+    return None
+
+
+def _deployment_replica_health(namespace: str, name: str) -> dict[str, Any]:
+    deployment = _kubectl_json(namespace, ['get', 'deployment', name, '-o', 'json'])
+    status = _as_mapping(deployment.get('status'))
+    return {
+        'name': name,
+        'ready_replicas': int(status.get('readyReplicas') or 0),
+        'available_replicas': int(status.get('availableReplicas') or 0),
+        'replicas': int(status.get('replicas') or 0),
+    }
+
+
+def _flink_runtime_health(namespace: str, name: str) -> dict[str, Any]:
+    deployment = _kubectl_json(namespace, ['get', 'flinkdeployment', name, '-o', 'json'])
+    spec = _as_mapping(deployment.get('spec'))
+    status = _as_mapping(deployment.get('status'))
+    job_status = _as_mapping(status.get('jobStatus'))
+    lifecycle_state = _as_text(job_status.get('state')) or _as_text(status.get('jobManagerDeploymentStatus'))
+    return {
+        'name': name,
+        'desired_state': _as_text(_as_mapping(spec.get('job')).get('state')) or 'unknown',
+        'lifecycle_state': lifecycle_state or 'unknown',
+        'job_manager_status': _as_text(status.get('jobManagerDeploymentStatus')) or 'unknown',
+    }
+
+
+def _kservice_env(service: Mapping[str, Any]) -> tuple[str, list[dict[str, Any]]]:
+    spec = _as_mapping(service.get('spec'))
+    template = _as_mapping(spec.get('template'))
+    template_spec = _as_mapping(template.get('spec'))
+    containers = template_spec.get('containers')
+    if not isinstance(containers, list) or not containers:
+        raise RuntimeError('kservice container spec missing')
+    first = containers[0]
+    if not isinstance(first, Mapping):
+        raise RuntimeError('kservice container spec invalid')
+    container = _as_mapping(first)
+    container_name = _as_text(container.get('name')) or 'user-container'
+    env_raw = container.get('env')
+    env: list[dict[str, Any]] = []
+    if isinstance(env_raw, list):
+        for item in env_raw:
+            if isinstance(item, Mapping):
+                env.append(_as_mapping(item))
+    return container_name, env
+
+
+def _monitor_settings(manifest: Mapping[str, Any]) -> dict[str, int]:
+    monitor = _as_mapping(manifest.get('monitor'))
+    timeout_seconds = _safe_int(monitor.get('timeout_seconds'), default=DEFAULT_RUN_MONITOR_TIMEOUT_SECONDS)
+    poll_seconds = _safe_int(monitor.get('poll_seconds'), default=DEFAULT_RUN_MONITOR_POLL_SECONDS)
+    min_decisions = _safe_int(monitor.get('min_trade_decisions'), default=DEFAULT_RUN_MONITOR_MIN_DECISIONS)
+    min_executions = _safe_int(monitor.get('min_executions'), default=DEFAULT_RUN_MONITOR_MIN_EXECUTIONS)
+    min_tca = _safe_int(monitor.get('min_execution_tca_metrics'), default=DEFAULT_RUN_MONITOR_MIN_TCA)
+    min_order_events = _safe_int(
+        monitor.get('min_execution_order_events'),
+        default=DEFAULT_RUN_MONITOR_MIN_ORDER_EVENTS,
+    )
+    cursor_grace_seconds = _safe_int(
+        monitor.get('cursor_grace_seconds'),
+        default=DEFAULT_RUN_MONITOR_CURSOR_GRACE_SECONDS,
+    )
+    if timeout_seconds <= 0:
+        raise RuntimeError('monitor.timeout_seconds must be > 0')
+    if poll_seconds <= 0:
+        raise RuntimeError('monitor.poll_seconds must be > 0')
+    if min_decisions < 0 or min_executions < 0 or min_tca < 0 or min_order_events < 0:
+        raise RuntimeError('monitor minimum thresholds cannot be negative')
+    if cursor_grace_seconds < 0:
+        raise RuntimeError('monitor.cursor_grace_seconds cannot be negative')
+    return {
+        'timeout_seconds': timeout_seconds,
+        'poll_seconds': poll_seconds,
+        'min_trade_decisions': min_decisions,
+        'min_executions': min_executions,
+        'min_execution_tca_metrics': min_tca,
+        'min_execution_order_events': min_order_events,
+        'cursor_grace_seconds': cursor_grace_seconds,
+    }
+
+
+def _monitor_snapshot(postgres_config: Any) -> dict[str, Any]:
+    dsn = _as_text(_resource_attr(postgres_config, 'torghut_runtime_dsn')) or _as_text(_resource_attr(postgres_config, 'simulation_dsn'))
+    if dsn is None:
+        raise RuntimeError('postgres runtime dsn is required')
+
+    def _snapshot() -> dict[str, Any]:
+        with psycopg.connect(dsn) as conn:
+            with conn.cursor() as cursor:
+                cursor.execute('SELECT count(*) FROM trade_decisions')
+                decision_row = cursor.fetchone()
+                trade_decisions = _safe_int(decision_row[0] if decision_row else 0)
+                cursor.execute('SELECT count(*) FROM executions')
+                execution_row = cursor.fetchone()
+                executions = _safe_int(execution_row[0] if execution_row else 0)
+                cursor.execute('SELECT count(*) FROM execution_tca_metrics')
+                tca_row = cursor.fetchone()
+                execution_tca_metrics = _safe_int(tca_row[0] if tca_row else 0)
+                cursor.execute('SELECT count(*) FROM execution_order_events')
+                order_event_row = cursor.fetchone()
+                execution_order_events = _safe_int(order_event_row[0] if order_event_row else 0)
+                cursor.execute("SELECT max(cursor_at) FROM trade_cursor WHERE source='clickhouse'")
+                row = cursor.fetchone()
+                cursor_at_raw = row[0] if row else None
+                cursor_at = cursor_at_raw.astimezone(timezone.utc) if isinstance(cursor_at_raw, datetime) else None
+        return {
+            'trade_decisions': trade_decisions,
+            'executions': executions,
+            'execution_tca_metrics': execution_tca_metrics,
+            'execution_order_events': execution_order_events,
+            'cursor_at': cursor_at.isoformat() if cursor_at is not None else None,
+        }
+
+    return cast(
+        dict[str, Any],
+        _run_with_transient_postgres_retry(label='monitor_snapshot', operation=_snapshot),
+    )
+
+
+def _signal_snapshot(*, resources: Any, clickhouse_config: Any) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for key, table in {
+        'signal_rows': _resource_attr(resources, 'clickhouse_signal_table'),
+        'price_rows': _resource_attr(resources, 'clickhouse_price_table'),
+    }.items():
+        query = f'SELECT count() FROM {table}'
+        status, body = _http_clickhouse_query(config=clickhouse_config, query=query)
+        if status < 200 or status >= 300:
+            counts[key] = 0
+            continue
+        counts[key] = _safe_int(body.strip(), default=0)
+    return counts
+
+
+def _classify_activity_snapshot(
+    *,
+    runtime_ready: bool,
+    snapshot: Mapping[str, Any],
+) -> str:
+    cursor_at_raw = snapshot.get('cursor_at')
+    if not runtime_ready:
+        return 'infra_not_active'
+    if cursor_at_raw is None:
+        return 'cursor_not_advancing'
+    if _safe_int(snapshot.get('signal_rows')) <= 0:
+        return 'signals_absent'
+    if _safe_int(snapshot.get('trade_decisions')) <= 0:
+        return 'decisions_absent'
+    if (
+        _safe_int(snapshot.get('executions')) <= 0
+        or _safe_int(snapshot.get('execution_tca_metrics')) <= 0
+        or (
+            _safe_int(snapshot.get('executions')) > 0
+            and _safe_int(snapshot.get('execution_order_events')) <= 0
+        )
+    ):
+        return 'executions_absent'
+    return 'success'
+
+
+def _runtime_verify(*, resources: Any, manifest: Mapping[str, Any]) -> dict[str, Any]:
+    window_start, window_end = _resolve_window_bounds(manifest)
+    namespace = _as_text(_resource_attr(resources, 'namespace')) or 'torghut'
+    torghut_service = _as_text(_resource_attr(resources, 'torghut_service'))
+    ta_deployment = _as_text(_resource_attr(resources, 'ta_deployment'))
+    forecast_service = _as_text(_resource_attr(resources, 'torghut_forecast_service'))
+    if torghut_service is None or ta_deployment is None or forecast_service is None:
+        raise RuntimeError('simulation resources are incomplete')
+
+    service = _kubectl_json(namespace, ['get', 'kservice', torghut_service, '-o', 'json'])
+    service_status = _as_mapping(service.get('status'))
+    latest_ready_revision = _as_text(service_status.get('latestReadyRevisionName'))
+    ready = _condition_status(service_status, condition_type='Ready') == 'True'
+    revision_health: dict[str, Any] | None = None
+    if latest_ready_revision:
+        revision_health = _deployment_replica_health(namespace, f'{latest_ready_revision}-deployment')
+    ta_health = _flink_runtime_health(namespace, ta_deployment)
+    forecast_health = _deployment_replica_health(namespace, forecast_service)
+    return {
+        'runtime_state': 'ready'
+        if ready
+        and revision_health is not None
+        and revision_health['ready_replicas'] > 0
+        and ta_health['desired_state'] == 'running'
+        and ta_health['lifecycle_state'] in {'RUNNING', 'running', 'DEPLOYED'}
+        and forecast_health['ready_replicas'] > 0
+        else 'not_ready',
+        'target_mode': _as_text(_resource_attr(resources, 'target_mode')),
+        'window_start': window_start.astimezone(timezone.utc).isoformat(),
+        'window_end': window_end.astimezone(timezone.utc).isoformat(),
+        'torghut_service': {
+            'name': torghut_service,
+            'ready': ready,
+            'latest_ready_revision': latest_ready_revision,
+            'revision_health': revision_health,
+        },
+        'ta_runtime': ta_health,
+        'forecast_runtime': forecast_health,
+        'environment_state': 'complete' if forecast_health['ready_replicas'] > 0 else 'environment_incomplete',
+    }
+
+
+def _current_activity_report(
+    *,
+    resources: Any,
+    manifest: Mapping[str, Any],
+    postgres_config: Any,
+    clickhouse_config: Any,
+    runtime_verify: Mapping[str, Any],
+) -> dict[str, Any]:
+    start, end = _resolve_window_bounds(manifest)
+    settings = _monitor_settings(manifest)
+    snapshot = _monitor_snapshot(postgres_config)
+    snapshot.update(_signal_snapshot(resources=resources, clickhouse_config=clickhouse_config))
+    classification = _classify_activity_snapshot(
+        runtime_ready=bool(runtime_verify.get('runtime_state') == 'ready'),
+        snapshot=snapshot,
+    )
+    return {
+        'status': 'ok' if classification == 'success' else 'degraded',
+        'activity_classification': classification,
+        'window_start': start.isoformat(),
+        'window_end': end.isoformat(),
+        'monitor': settings,
+        'poll_count': 1,
+        'final_snapshot': {
+            'polled_at': datetime.now(timezone.utc).isoformat(),
+            **snapshot,
+        },
+        'polls': [],
+    }
+
+
+def _monitor_run_completion(
+    *,
+    resources: Any,
+    manifest: Mapping[str, Any],
+    postgres_config: Any,
+    clickhouse_config: Any,
+    runtime_verify: Mapping[str, Any],
+) -> dict[str, Any]:
+    start, end = _resolve_window_bounds(manifest)
+    settings = _monitor_settings(manifest)
+    deadline = datetime.now(timezone.utc) + timedelta(seconds=settings['timeout_seconds'])
+    polls: list[dict[str, Any]] = []
+    cursor_reached_at: datetime | None = None
+    runtime_ready = bool(runtime_verify.get('runtime_state') == 'ready')
+    while True:
+        snapshot = _monitor_snapshot(postgres_config)
+        snapshot.update(_signal_snapshot(resources=resources, clickhouse_config=clickhouse_config))
+        polled_at = datetime.now(timezone.utc)
+        poll_payload = {'polled_at': polled_at.isoformat(), **snapshot}
+        polls.append(poll_payload)
+        cursor_at_raw = snapshot.get('cursor_at')
+        cursor_at = _parse_rfc3339_timestamp(cast(str | None, cursor_at_raw), label='cursor_at') if isinstance(cursor_at_raw, str) else None
+        cursor_reached = cursor_at is not None and cursor_at >= end
+        thresholds_met = (
+            _safe_int(snapshot.get('trade_decisions')) >= settings['min_trade_decisions']
+            and _safe_int(snapshot.get('executions')) >= settings['min_executions']
+            and _safe_int(snapshot.get('execution_tca_metrics')) >= settings['min_execution_tca_metrics']
+            and _safe_int(snapshot.get('execution_order_events')) >= settings['min_execution_order_events']
+        )
+        executions = _safe_int(snapshot.get('executions'))
+        order_events = _safe_int(snapshot.get('execution_order_events'))
+        order_event_contract_met = executions <= 0 or order_events > 0
+        completion_ready = thresholds_met and order_event_contract_met
+
+        if cursor_reached and cursor_reached_at is None:
+            cursor_reached_at = polled_at
+        if cursor_reached and completion_ready:
+            return {
+                'status': 'ok',
+                'activity_classification': 'success',
+                'window_start': start.isoformat(),
+                'window_end': end.isoformat(),
+                'monitor': settings,
+                'poll_count': len(polls),
+                'final_snapshot': poll_payload,
+                'polls': polls[-20:],
+            }
+        if polled_at >= deadline or (
+            cursor_reached
+            and cursor_reached_at is not None
+            and int((polled_at - cursor_reached_at).total_seconds()) >= settings['cursor_grace_seconds']
+        ):
+            classification = _classify_activity_snapshot(runtime_ready=runtime_ready, snapshot=snapshot)
+            return {
+                'status': 'ok' if classification == 'success' else 'degraded',
+                'activity_classification': classification,
+                'window_start': start.isoformat(),
+                'window_end': end.isoformat(),
+                'monitor': settings,
+                'poll_count': len(polls),
+                'final_snapshot': poll_payload,
+                'polls': polls[-20:],
+            }
+        time.sleep(settings['poll_seconds'])
+
+
+def _verify_isolation_guards(
+    *,
+    resources: Any,
+    postgres_config: Any,
+    ta_data: Mapping[str, Any],
+) -> dict[str, Any]:
+    source_topic_by_role = cast(dict[str, str], _resource_attr(resources, 'source_topic_by_role'))
+    simulation_topic_by_role = cast(dict[str, str], _resource_attr(resources, 'simulation_topic_by_role'))
+    clickhouse_signal_table = _as_text(_resource_attr(resources, 'clickhouse_signal_table'))
+    clickhouse_price_table = _as_text(_resource_attr(resources, 'clickhouse_price_table'))
+    ta_group_id = _as_text(_resource_attr(resources, 'ta_group_id'))
+    simulation_db = _as_text(_resource_attr(postgres_config, 'simulation_db'))
+    simulation_dsn = _as_text(_resource_attr(postgres_config, 'simulation_dsn'))
+    simulation_topics_disjoint = all(
+        simulation_topic_by_role.get(role) != source_topic_by_role.get(role)
+        for role in ('trades', 'quotes', 'bars', 'status')
+    )
+    signal_table_isolated = bool(clickhouse_signal_table and '.ta_signals' in clickhouse_signal_table)
+    price_table_isolated = bool(clickhouse_price_table and '.ta_microbars' in clickhouse_price_table)
+    postgres_database_isolated = bool(simulation_db and simulation_db != 'torghut')
+    report = {
+        'simulation_topics_isolated_from_sources': simulation_topics_disjoint,
+        'ta_group_isolated': ta_group_id != _as_text(ta_data.get('TA_GROUP_ID')),
+        'signal_table_isolated': signal_table_isolated,
+        'price_table_isolated': price_table_isolated,
+        'postgres_database_isolated': postgres_database_isolated,
+        'simulation_dsn': simulation_dsn,
+    }
+    if not all(bool(item) for item in report.values() if isinstance(item, bool)):
+        failed = [key for key, passed in report.items() if isinstance(passed, bool) and not passed]
+        raise RuntimeError(f'isolation_guard_failed:{",".join(failed)}')
+    return report
+
+
+def _teardown_clean(
+    *,
+    resources: Any,
+    postgres_config: Any,
+) -> dict[str, Any]:
+    resource_payload = _resource_asdict(resources)
+    namespace = _as_text(resource_payload.get('namespace')) or 'torghut'
+    torghut_service = _as_text(resource_payload.get('torghut_service'))
+    ta_configmap = _as_text(resource_payload.get('ta_configmap'))
+    ta_deployment = _as_text(resource_payload.get('ta_deployment'))
+    run_id = _as_text(resource_payload.get('run_id')) or ''
+    run_token = _as_text(resource_payload.get('run_token')) or ''
+    clickhouse_signal_table = _as_text(resource_payload.get('clickhouse_signal_table')) or ''
+    clickhouse_price_table = _as_text(resource_payload.get('clickhouse_price_table')) or ''
+    order_feed_group_id = _as_text(resource_payload.get('order_feed_group_id')) or ''
+    ta_group_id = _as_text(resource_payload.get('ta_group_id')) or ''
+    runtime_dsn = _as_text(_resource_attr(postgres_config, 'torghut_runtime_dsn')) or ''
+
+    if torghut_service is None or ta_configmap is None or ta_deployment is None:
+        raise RuntimeError('simulation resources are incomplete for teardown validation')
+
+    service = _kubectl_json(namespace, ['get', 'kservice', torghut_service, '-o', 'json'])
+    _, env_entries = _kservice_env(service)
+    env_by_name = {
+        _as_text(entry.get('name')): entry
+        for entry in env_entries
+        if _as_text(entry.get('name'))
+    }
+    ta_config = _kubectl_json(namespace, ['get', 'configmap', ta_configmap, '-o', 'json'])
+    ta_data = _as_mapping(ta_config.get('data'))
+    ta_health = _flink_runtime_health(namespace, ta_deployment)
+
+    simulation_markers_present = {
+        'trading_simulation_enabled': _as_text(_as_mapping(env_by_name.get('TRADING_SIMULATION_ENABLED')).get('value')) == 'true',
+        'trading_simulation_run_id': _as_text(_as_mapping(env_by_name.get('TRADING_SIMULATION_RUN_ID')).get('value')) == run_id,
+        'db_dsn': _as_text(_as_mapping(env_by_name.get('DB_DSN')).get('value')) == runtime_dsn,
+        'signal_table': _as_text(_as_mapping(env_by_name.get('TRADING_SIGNAL_TABLE')).get('value')) == clickhouse_signal_table,
+        'price_table': _as_text(_as_mapping(env_by_name.get('TRADING_PRICE_TABLE')).get('value')) == clickhouse_price_table,
+        'order_feed_group_id': _as_text(_as_mapping(env_by_name.get('TRADING_ORDER_FEED_GROUP_ID')).get('value')) == order_feed_group_id,
+        'ta_group_id': _as_text(ta_data.get('TA_GROUP_ID')) == ta_group_id,
+        'ta_clickhouse_database': bool(run_token) and run_token in (_as_text(ta_data.get('TA_CLICKHOUSE_URL')) or ''),
+    }
+    restored = not any(simulation_markers_present.values())
+    return {
+        'status': 'ok' if restored else 'degraded',
+        'activity_classification': 'success' if restored else 'environment_incomplete',
+        'restored': restored,
+        'ta_runtime': ta_health,
+        'simulation_markers_present': simulation_markers_present,
+    }
+
+
+def _artifact_bundle(
+    *,
+    run_dir: Path,
+) -> dict[str, Any]:
+    required = [
+        'run-manifest.json',
+        'runtime-verify.json',
+        'replay-report.json',
+        'signal-activity.json',
+        'decision-activity.json',
+        'execution-activity.json',
+        'report/simulation-report.json',
+    ]
+    existing = [path for path in required if (run_dir / path).exists()]
+    missing = [path for path in required if path not in existing]
+    return {
+        'status': 'ok' if not missing else 'degraded',
+        'activity_classification': 'success' if not missing else 'environment_incomplete',
+        'run_dir': str(run_dir),
+        'existing': existing,
+        'missing': missing,
+    }
+
+
+__all__ = [
+    'DEFAULT_COVERAGE_STRICT_RATIO',
+    'DEFAULT_RUN_MONITOR_CURSOR_GRACE_SECONDS',
+    'DEFAULT_RUN_MONITOR_MIN_DECISIONS',
+    'DEFAULT_RUN_MONITOR_MIN_EXECUTIONS',
+    'DEFAULT_RUN_MONITOR_MIN_ORDER_EVENTS',
+    'DEFAULT_RUN_MONITOR_MIN_TCA',
+    'DEFAULT_RUN_MONITOR_POLL_SECONDS',
+    'DEFAULT_RUN_MONITOR_TIMEOUT_SECONDS',
+    'PRODUCTION_TOPIC_BY_ROLE',
+    'TORGHUT_ENV_KEYS',
+    '_artifact_bundle',
+    '_as_mapping',
+    '_as_text',
+    '_current_activity_report',
+    '_http_clickhouse_query',
+    '_monitor_run_completion',
+    '_monitor_snapshot',
+    '_resolve_window_bounds',
+    '_runtime_verify',
+    '_safe_float',
+    '_safe_int',
+    '_signal_snapshot',
+    '_teardown_clean',
+    '_validate_dump_coverage',
+    '_validate_window_policy',
+    '_verify_isolation_guards',
+]

--- a/services/torghut/scripts/run_simulation_analysis.py
+++ b/services/torghut/scripts/run_simulation_analysis.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from scripts.historical_simulation_verification import (
+    _artifact_bundle,
+    _monitor_run_completion,
+    _replace_database_in_dsn,
+    _runtime_verify,
+    _teardown_clean,
+)
+
+
+@dataclass(frozen=True)
+class _Resources:
+    run_id: str
+    run_token: str
+    dataset_id: str
+    target_mode: str
+    namespace: str
+    ta_configmap: str
+    ta_deployment: str
+    torghut_service: str
+    torghut_forecast_service: str
+    clickhouse_signal_table: str
+    clickhouse_price_table: str
+    order_feed_group_id: str
+    ta_group_id: str
+
+
+@dataclass(frozen=True)
+class _PostgresConfig:
+    simulation_dsn: str
+    simulation_db: str
+
+    @property
+    def torghut_runtime_dsn(self) -> str:
+        return self.simulation_dsn
+
+
+@dataclass(frozen=True)
+class _ClickHouseConfig:
+    http_url: str
+    username: str | None
+    password: str | None
+
+
+def _normalize_run_token(run_id: str) -> str:
+    import re
+
+    token = re.sub(r'[^a-zA-Z0-9]+', '_', run_id.strip().lower()).strip('_')
+    token = re.sub(r'_+', '_', token)
+    if not token:
+        raise SystemExit('run-id must contain at least one alphanumeric character')
+    return token
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description='Run Torghut simulation analysis gates.')
+    parser.add_argument('--json', action='store_true', help='Emit compact JSON')
+
+    subparsers = parser.add_subparsers(dest='command', required=True)
+
+    runtime = subparsers.add_parser('runtime-ready')
+    runtime.add_argument('--json', action='store_true', help=argparse.SUPPRESS)
+    runtime.add_argument('--run-id', required=True)
+    runtime.add_argument('--dataset-id', required=True)
+    runtime.add_argument('--namespace', required=True)
+    runtime.add_argument('--torghut-service', required=True)
+    runtime.add_argument('--ta-deployment', required=True)
+    runtime.add_argument('--forecast-service', required=True)
+    runtime.add_argument('--window-start', required=True)
+    runtime.add_argument('--window-end', required=True)
+
+    activity = subparsers.add_parser('activity')
+    activity.add_argument('--json', action='store_true', help=argparse.SUPPRESS)
+    activity.add_argument('--run-id', required=True)
+    activity.add_argument('--dataset-id', required=True)
+    activity.add_argument('--namespace', required=True)
+    activity.add_argument('--torghut-service', required=True)
+    activity.add_argument('--ta-deployment', required=True)
+    activity.add_argument('--forecast-service', required=True)
+    activity.add_argument('--window-start', required=True)
+    activity.add_argument('--window-end', required=True)
+    activity.add_argument('--signal-table', required=True)
+    activity.add_argument('--price-table', required=True)
+    activity.add_argument('--postgres-base-dsn', default='')
+    activity.add_argument('--postgres-base-dsn-env', default='DB_DSN')
+    activity.add_argument('--postgres-database', required=True)
+    activity.add_argument('--clickhouse-http-url', required=True)
+    activity.add_argument('--clickhouse-username', default='')
+    activity.add_argument('--clickhouse-password-env', default='TORGHUT_CLICKHOUSE_PASSWORD')
+    activity.add_argument('--monitor-timeout-seconds', type=int, default=900)
+    activity.add_argument('--monitor-poll-seconds', type=int, default=15)
+    activity.add_argument('--min-trade-decisions', type=int, default=1)
+    activity.add_argument('--min-executions', type=int, default=1)
+    activity.add_argument('--min-execution-tca-metrics', type=int, default=1)
+    activity.add_argument('--min-execution-order-events', type=int, default=0)
+    activity.add_argument('--cursor-grace-seconds', type=int, default=120)
+
+    teardown = subparsers.add_parser('teardown-clean')
+    teardown.add_argument('--json', action='store_true', help=argparse.SUPPRESS)
+    teardown.add_argument('--run-id', required=True)
+    teardown.add_argument('--dataset-id', required=True)
+    teardown.add_argument('--namespace', required=True)
+    teardown.add_argument('--ta-configmap', required=True)
+    teardown.add_argument('--ta-deployment', required=True)
+    teardown.add_argument('--torghut-service', required=True)
+    teardown.add_argument('--forecast-service', required=True)
+    teardown.add_argument('--signal-table', required=True)
+    teardown.add_argument('--price-table', required=True)
+    teardown.add_argument('--postgres-base-dsn', default='')
+    teardown.add_argument('--postgres-base-dsn-env', default='DB_DSN')
+    teardown.add_argument('--postgres-database', required=True)
+
+    artifact = subparsers.add_parser('artifact-bundle')
+    artifact.add_argument('--json', action='store_true', help=argparse.SUPPRESS)
+    artifact.add_argument('--run-dir', required=True)
+
+    return parser
+
+
+def _emit(payload: Mapping[str, Any], *, json_only: bool) -> None:
+    if json_only:
+        print(json.dumps(dict(payload), sort_keys=True, separators=(',', ':')))
+        return
+    print(json.dumps(dict(payload), indent=2, sort_keys=True))
+
+
+def _resources_from_args(args: argparse.Namespace) -> _Resources:
+    run_token = _normalize_run_token(args.run_id)
+    return _Resources(
+        run_id=args.run_id,
+        run_token=run_token,
+        dataset_id=args.dataset_id,
+        target_mode='dedicated_service',
+        namespace=args.namespace,
+        ta_configmap=getattr(args, 'ta_configmap', 'torghut-ta-sim-config'),
+        ta_deployment=args.ta_deployment,
+        torghut_service=args.torghut_service,
+        torghut_forecast_service=args.forecast_service,
+        clickhouse_signal_table=getattr(args, 'signal_table', ''),
+        clickhouse_price_table=getattr(args, 'price_table', ''),
+        order_feed_group_id=f'torghut-order-feed-sim-{run_token}',
+        ta_group_id=f'torghut-ta-sim-{run_token}',
+    )
+
+
+def _manifest_from_args(args: argparse.Namespace) -> dict[str, Any]:
+    manifest = {
+        'window': {
+            'start': args.window_start,
+            'end': args.window_end,
+        }
+    }
+    if hasattr(args, 'monitor_timeout_seconds'):
+        manifest['monitor'] = {
+            'timeout_seconds': args.monitor_timeout_seconds,
+            'poll_seconds': args.monitor_poll_seconds,
+            'min_trade_decisions': args.min_trade_decisions,
+            'min_executions': args.min_executions,
+            'min_execution_tca_metrics': args.min_execution_tca_metrics,
+            'min_execution_order_events': args.min_execution_order_events,
+            'cursor_grace_seconds': args.cursor_grace_seconds,
+        }
+    return manifest
+
+
+def _postgres_config(args: argparse.Namespace) -> _PostgresConfig:
+    base_dsn = args.postgres_base_dsn or ''
+    if not base_dsn:
+        import os
+
+        base_dsn = os.environ.get(args.postgres_base_dsn_env, '')
+    if not base_dsn:
+        raise SystemExit('postgres base dsn is required')
+    return _PostgresConfig(
+        simulation_dsn=_replace_database_in_dsn(
+            base_dsn,
+            database=args.postgres_database,
+            label='postgres base dsn',
+        ),
+        simulation_db=args.postgres_database,
+    )
+
+
+def _clickhouse_config(args: argparse.Namespace) -> _ClickHouseConfig:
+    import os
+
+    return _ClickHouseConfig(
+        http_url=args.clickhouse_http_url.rstrip('/'),
+        username=args.clickhouse_username or None,
+        password=os.environ.get(args.clickhouse_password_env),
+    )
+
+
+def main() -> None:
+    args = _parser().parse_args()
+    if args.command == 'artifact-bundle':
+        report = _artifact_bundle(run_dir=Path(args.run_dir))
+        _emit(report, json_only=bool(args.json))
+        if report['status'] != 'ok':
+            raise SystemExit(1)
+        return
+
+    resources = _resources_from_args(args)
+    manifest = _manifest_from_args(args)
+
+    if args.command == 'runtime-ready':
+        report = _runtime_verify(resources=resources, manifest=manifest)
+        _emit(report, json_only=bool(args.json))
+        if report.get('runtime_state') != 'ready':
+            raise SystemExit(1)
+        return
+
+    postgres_config = _postgres_config(args)
+
+    if args.command == 'teardown-clean':
+        report = _teardown_clean(resources=resources, postgres_config=postgres_config)
+        _emit(report, json_only=bool(args.json))
+        if report.get('status') != 'ok':
+            raise SystemExit(1)
+        return
+
+    clickhouse_config = _clickhouse_config(args)
+    runtime_verify = _runtime_verify(resources=resources, manifest=manifest)
+    report = _monitor_run_completion(
+        resources=resources,
+        manifest=manifest,
+        postgres_config=postgres_config,
+        clickhouse_config=clickhouse_config,
+        runtime_verify=runtime_verify,
+    )
+    _emit(report, json_only=bool(args.json))
+    if report.get('status') != 'ok':
+        raise SystemExit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/services/torghut/scripts/start_historical_simulation.py
+++ b/services/torghut/scripts/start_historical_simulation.py
@@ -28,6 +28,8 @@ import psycopg
 from psycopg import sql
 import yaml
 
+from scripts import historical_simulation_verification as simulation_verification
+
 APPLY_CONFIRMATION_PHRASE = 'START_HISTORICAL_SIMULATION'
 DEFAULT_NAMESPACE = 'torghut'
 DEFAULT_TA_CONFIGMAP = 'torghut-ta-config'
@@ -131,6 +133,12 @@ DEFAULT_ARGOCD_APPSET_NAME = 'product'
 DEFAULT_ARGOCD_NAMESPACE = 'argocd'
 DEFAULT_ARGOCD_APP_NAME = 'torghut'
 DEFAULT_ARGOCD_RUN_MODE = 'manual'
+DEFAULT_ROLLOUTS_NAMESPACE = 'torghut'
+DEFAULT_ROLLOUTS_RUNTIME_TEMPLATE = 'torghut-simulation-runtime-ready'
+DEFAULT_ROLLOUTS_ACTIVITY_TEMPLATE = 'torghut-simulation-activity'
+DEFAULT_ROLLOUTS_TEARDOWN_TEMPLATE = 'torghut-simulation-teardown-clean'
+DEFAULT_ROLLOUTS_ARTIFACT_TEMPLATE = 'torghut-simulation-artifact-bundle'
+DEFAULT_ROLLOUTS_VERIFY_TIMEOUT_SECONDS = 1800
 TRANSIENT_POSTGRES_ERROR_PATTERNS = (
     'connection refused',
     'connection reset by peer',
@@ -319,6 +327,17 @@ class ArgocdAutomationConfig:
     app_name: str
     desired_mode_during_run: str
     restore_mode_after_run: str
+    verify_timeout_seconds: int
+
+
+@dataclass(frozen=True)
+class RolloutsAnalysisConfig:
+    enabled: bool
+    namespace: str
+    runtime_template: str
+    activity_template: str
+    teardown_template: str
+    artifact_template: str
     verify_timeout_seconds: int
 
 
@@ -1050,6 +1069,31 @@ def _build_argocd_automation_config(manifest: Mapping[str, Any]) -> ArgocdAutoma
     )
 
 
+def _build_rollouts_analysis_config(manifest: Mapping[str, Any]) -> RolloutsAnalysisConfig:
+    rollouts = _as_mapping(manifest.get('rollouts'))
+    enabled = str(rollouts.get('enabled', 'false')).strip().lower() in {
+        '1',
+        'true',
+        'yes',
+        'on',
+    }
+    verify_timeout_seconds = _safe_int(
+        rollouts.get('verify_timeout_seconds'),
+        default=DEFAULT_ROLLOUTS_VERIFY_TIMEOUT_SECONDS,
+    )
+    if verify_timeout_seconds <= 0:
+        raise RuntimeError('rollouts.verify_timeout_seconds must be > 0')
+    return RolloutsAnalysisConfig(
+        enabled=enabled,
+        namespace=_as_text(rollouts.get('namespace')) or DEFAULT_ROLLOUTS_NAMESPACE,
+        runtime_template=_as_text(rollouts.get('runtime_template')) or DEFAULT_ROLLOUTS_RUNTIME_TEMPLATE,
+        activity_template=_as_text(rollouts.get('activity_template')) or DEFAULT_ROLLOUTS_ACTIVITY_TEMPLATE,
+        teardown_template=_as_text(rollouts.get('teardown_template')) or DEFAULT_ROLLOUTS_TEARDOWN_TEMPLATE,
+        artifact_template=_as_text(rollouts.get('artifact_template')) or DEFAULT_ROLLOUTS_ARTIFACT_TEMPLATE,
+        verify_timeout_seconds=verify_timeout_seconds,
+    )
+
+
 def _ensure_supported_binary(name: str) -> None:
     if shutil.which(name) is None:
         raise SystemExit(f'{name} not found in PATH')
@@ -1145,6 +1189,28 @@ def _kubectl_json_global(args: Sequence[str]) -> dict[str, Any]:
     if not isinstance(payload, Mapping):
         raise RuntimeError('kubectl did not return a mapping payload')
     return {str(key): value for key, value in cast(Mapping[str, Any], payload).items()}
+
+
+def _kubectl_apply(namespace: str, payload: Mapping[str, Any]) -> None:
+    _run_command(
+        ['kubectl', '-n', namespace, 'apply', '-f', '-'],
+        input_text=yaml.safe_dump(dict(payload), sort_keys=False),
+    )
+
+
+def _kubectl_delete_if_exists(namespace: str, kind: str, name: str) -> None:
+    _run_command(
+        [
+            'kubectl',
+            '-n',
+            namespace,
+            'delete',
+            kind,
+            name,
+            '--ignore-not-found=true',
+            '--wait=false',
+        ]
+    )
 
 
 def _kubectl_patch(namespace: str, kind: str, name: str, patch: Mapping[str, Any]) -> None:
@@ -1777,6 +1843,7 @@ def _build_plan_report(
     window = _as_mapping(manifest.get('window'))
     torghut_env_overrides = _torghut_env_overrides_from_manifest(manifest)
     window_policy = _validate_window_policy(manifest)
+    rollouts_config = _build_rollouts_analysis_config(manifest)
     return {
         'status': 'ok',
         'run_id': resources.run_id,
@@ -1817,6 +1884,7 @@ def _build_plan_report(
             'username': clickhouse_config.username,
         },
         'argocd': asdict(argocd_config),
+        'rollouts': asdict(rollouts_config),
         'artifacts': {
             'state_path': str(state_path),
             'run_manifest_path': str(run_manifest_path),
@@ -3353,6 +3421,201 @@ def _restore_argocd_after_run(
     }
 
 
+def _analysis_run_name(*, phase: str, run_token: str) -> str:
+    base = f'torghut-sim-{phase}-{run_token}'
+    if len(base) <= 63:
+        return base
+    prefix = f'torghut-sim-{phase}-'
+    remaining = 63 - len(prefix)
+    return prefix + run_token[:remaining].rstrip('-')
+
+
+def _analysis_run_args(
+    *,
+    phase: str,
+    resources: SimulationResources,
+    manifest: Mapping[str, Any],
+    postgres_config: PostgresRuntimeConfig,
+    clickhouse_config: ClickHouseRuntimeConfig,
+) -> dict[str, str]:
+    window_start, window_end = _resolve_window_bounds(manifest)
+    args: dict[str, str] = {
+        'runId': resources.run_id,
+        'datasetId': resources.dataset_id,
+        'runToken': resources.run_token,
+        'namespace': resources.namespace,
+        'torghutService': resources.torghut_service,
+        'taConfigmap': resources.ta_configmap,
+        'taDeployment': resources.ta_deployment,
+        'forecastService': resources.torghut_forecast_service,
+        'windowStart': window_start.isoformat(),
+        'windowEnd': window_end.isoformat(),
+        'signalTable': resources.clickhouse_signal_table,
+        'priceTable': resources.clickhouse_price_table,
+        'postgresDatabase': postgres_config.simulation_db,
+        'clickhouseHttpUrl': clickhouse_config.http_url,
+        'clickhouseUsername': clickhouse_config.username or '',
+    }
+    monitor = _as_mapping(manifest.get('monitor'))
+    if phase == 'activity':
+        args.update(
+            {
+                'monitorTimeoutSeconds': str(
+                    _safe_int(monitor.get('timeout_seconds'), default=DEFAULT_RUN_MONITOR_TIMEOUT_SECONDS)
+                ),
+                'monitorPollSeconds': str(
+                    _safe_int(monitor.get('poll_seconds'), default=DEFAULT_RUN_MONITOR_POLL_SECONDS)
+                ),
+                'minTradeDecisions': str(
+                    _safe_int(monitor.get('min_trade_decisions'), default=DEFAULT_RUN_MONITOR_MIN_DECISIONS)
+                ),
+                'minExecutions': str(
+                    _safe_int(monitor.get('min_executions'), default=DEFAULT_RUN_MONITOR_MIN_EXECUTIONS)
+                ),
+                'minExecutionTcaMetrics': str(
+                    _safe_int(
+                        monitor.get('min_execution_tca_metrics'),
+                        default=DEFAULT_RUN_MONITOR_MIN_TCA,
+                    )
+                ),
+                'minExecutionOrderEvents': str(
+                    _safe_int(
+                        monitor.get('min_execution_order_events'),
+                        default=DEFAULT_RUN_MONITOR_MIN_ORDER_EVENTS,
+                    )
+                ),
+                'cursorGraceSeconds': str(
+                    _safe_int(
+                        monitor.get('cursor_grace_seconds'),
+                        default=DEFAULT_RUN_MONITOR_CURSOR_GRACE_SECONDS,
+                    )
+                ),
+            }
+        )
+    return args
+
+
+def _render_analysis_run_spec(
+    *,
+    rollouts_config: RolloutsAnalysisConfig,
+    template_name: str,
+    name: str,
+    args_by_name: Mapping[str, str],
+) -> dict[str, Any]:
+    template_payload = _kubectl_json(
+        rollouts_config.namespace,
+        ['get', 'analysistemplate', template_name, '-o', 'json'],
+    )
+    template_spec = _as_mapping(template_payload.get('spec'))
+    template_args = template_spec.get('args')
+    resolved_args: list[dict[str, Any]] = []
+    if isinstance(template_args, list):
+        for raw_arg in template_args:
+            if not isinstance(raw_arg, Mapping):
+                continue
+            entry = _as_mapping(raw_arg)
+            arg_name = _as_text(entry.get('name'))
+            if arg_name is None:
+                continue
+            resolved: dict[str, Any] = {'name': arg_name}
+            if arg_name in args_by_name:
+                resolved['value'] = args_by_name[arg_name]
+            elif 'value' in entry:
+                resolved['value'] = entry.get('value')
+            elif 'valueFrom' in entry:
+                resolved['valueFrom'] = entry.get('valueFrom')
+            else:
+                raise RuntimeError(f'missing_analysis_template_arg:{template_name}:{arg_name}')
+            resolved_args.append(resolved)
+
+    metrics = template_spec.get('metrics')
+    if not isinstance(metrics, list) or not metrics:
+        raise RuntimeError(f'invalid_analysis_template_metrics:{template_name}')
+
+    analysis_run_spec: dict[str, Any] = {
+        'args': resolved_args,
+        'metrics': metrics,
+    }
+    for key in ('dryRun', 'measurementRetention'):
+        if key in template_spec:
+            analysis_run_spec[key] = template_spec[key]
+
+    return {
+        'apiVersion': 'argoproj.io/v1alpha1',
+        'kind': 'AnalysisRun',
+        'metadata': {
+            'name': name,
+            'namespace': rollouts_config.namespace,
+            'labels': {
+                'app.kubernetes.io/name': 'torghut',
+                'torghut.proompteng.ai/analysis-template': template_name,
+            },
+        },
+        'spec': analysis_run_spec,
+    }
+
+
+def _wait_for_analysis_run(
+    *,
+    namespace: str,
+    name: str,
+    timeout_seconds: int,
+) -> dict[str, Any]:
+    deadline = datetime.now(timezone.utc) + timedelta(seconds=timeout_seconds)
+    while True:
+        payload = _kubectl_json(namespace, ['get', 'analysisrun', name, '-o', 'json'])
+        status = _as_mapping(payload.get('status'))
+        phase = _as_text(status.get('phase')) or 'Pending'
+        metric_results = status.get('metricResults')
+        report = {
+            'name': name,
+            'namespace': namespace,
+            'phase': phase,
+            'message': _as_text(status.get('message')),
+            'started_at': _as_text(status.get('startedAt')),
+            'completed_at': _as_text(status.get('completedAt')),
+            'metric_results': metric_results if isinstance(metric_results, list) else [],
+        }
+        if phase in {'Successful', 'Failed', 'Error', 'Inconclusive'}:
+            report['status'] = 'ok' if phase == 'Successful' else 'degraded'
+            return report
+        if datetime.now(timezone.utc) >= deadline:
+            raise RuntimeError(f'analysisrun_timeout:{name}:{phase}')
+        time.sleep(5)
+
+
+def _run_rollouts_analysis(
+    *,
+    resources: SimulationResources,
+    manifest: Mapping[str, Any],
+    postgres_config: PostgresRuntimeConfig,
+    clickhouse_config: ClickHouseRuntimeConfig,
+    rollouts_config: RolloutsAnalysisConfig,
+    phase: str,
+    template_name: str,
+) -> dict[str, Any]:
+    analysis_name = _analysis_run_name(phase=phase, run_token=resources.run_token)
+    _kubectl_delete_if_exists(rollouts_config.namespace, 'analysisrun', analysis_name)
+    payload = _render_analysis_run_spec(
+        rollouts_config=rollouts_config,
+        template_name=template_name,
+        name=analysis_name,
+        args_by_name=_analysis_run_args(
+            phase=phase,
+            resources=resources,
+            manifest=manifest,
+            postgres_config=postgres_config,
+            clickhouse_config=clickhouse_config,
+        ),
+    )
+    _kubectl_apply(rollouts_config.namespace, payload)
+    return _wait_for_analysis_run(
+        namespace=rollouts_config.namespace,
+        name=analysis_name,
+        timeout_seconds=rollouts_config.verify_timeout_seconds,
+    )
+
+
 def _report_simulation(
     *,
     resources: SimulationResources,
@@ -3409,6 +3672,7 @@ def _run_full_lifecycle(
     clickhouse_config: ClickHouseRuntimeConfig,
     postgres_config: PostgresRuntimeConfig,
     argocd_config: ArgocdAutomationConfig,
+    rollouts_config: RolloutsAnalysisConfig,
     force_dump: bool,
     force_replay: bool,
     skip_teardown: bool,
@@ -3425,6 +3689,16 @@ def _run_full_lifecycle(
     monitor_report: dict[str, Any] | None = None
     analytics_report: dict[str, Any] | None = None
     teardown_report: dict[str, Any] | None = None
+    rollouts_report: dict[str, Any] = {
+        'enabled': bool(
+            rollouts_config.enabled
+            and resources.target_mode == 'dedicated_service'
+        ),
+        'runtime_analysis_run': None,
+        'activity_analysis_run': None,
+        'teardown_analysis_run': None,
+        'artifact_analysis_run': None,
+    }
     errors: list[str] = []
     previous_automation_mode: str | None = None
     argocd_prepare_succeeded = False
@@ -3491,10 +3765,19 @@ def _run_full_lifecycle(
             _update_run_state(resources=resources, phase='dataset_prepare', status='ok')
 
             _update_run_state(resources=resources, phase='runtime_verify', status='running')
-            runtime_verify_report = _runtime_verify(
-                resources=resources,
-                manifest=manifest,
-            )
+            if bool(rollouts_report['enabled']):
+                runtime_analysis_run = _run_rollouts_analysis(
+                    resources=resources,
+                    manifest=manifest,
+                    postgres_config=postgres_config,
+                    clickhouse_config=clickhouse_config,
+                    rollouts_config=rollouts_config,
+                    phase='runtime-ready',
+                    template_name=rollouts_config.runtime_template,
+                )
+                rollouts_report['runtime_analysis_run'] = runtime_analysis_run
+            runtime_verify_report = _runtime_verify(resources=resources, manifest=manifest)
+            runtime_verify_report['analysis_run'] = rollouts_report['runtime_analysis_run']
             _save_json(_artifact_path(resources, 'runtime-verify.json'), runtime_verify_report)
             _update_run_state(
                 resources=resources,
@@ -3502,32 +3785,58 @@ def _run_full_lifecycle(
                 status='ok' if runtime_verify_report.get('runtime_state') == 'ready' else 'error',
                 details=runtime_verify_report,
             )
-            if runtime_verify_report.get('runtime_state') != 'ready':
+            if runtime_verify_report.get('runtime_state') != 'ready' or (
+                bool(rollouts_report['enabled'])
+                and _as_mapping(cast(Mapping[str, Any], rollouts_report['runtime_analysis_run'])).get('phase') != 'Successful'
+            ):
                 errors.append('environment_incomplete')
 
             _update_run_state(resources=resources, phase='activity_verify', status='running')
-            monitor_report = _monitor_run_completion(
-                resources=resources,
-                manifest=manifest,
-                postgres_config=postgres_config,
-                clickhouse_config=clickhouse_config,
-                runtime_verify=runtime_verify_report,
-            )
+            if bool(rollouts_report['enabled']):
+                activity_analysis_run = _run_rollouts_analysis(
+                    resources=resources,
+                    manifest=manifest,
+                    postgres_config=postgres_config,
+                    clickhouse_config=clickhouse_config,
+                    rollouts_config=rollouts_config,
+                    phase='activity',
+                    template_name=rollouts_config.activity_template,
+                )
+                rollouts_report['activity_analysis_run'] = activity_analysis_run
+                monitor_report = simulation_verification._current_activity_report(
+                    resources=resources,
+                    manifest=manifest,
+                    postgres_config=postgres_config,
+                    clickhouse_config=clickhouse_config,
+                    runtime_verify=runtime_verify_report,
+                )
+            else:
+                monitor_report = _monitor_run_completion(
+                    resources=resources,
+                    manifest=manifest,
+                    postgres_config=postgres_config,
+                    clickhouse_config=clickhouse_config,
+                    runtime_verify=runtime_verify_report,
+                )
+            monitor_report['analysis_run'] = rollouts_report['activity_analysis_run']
             _save_json(_artifact_path(resources, 'signal-activity.json'), {
                 'activity_classification': monitor_report.get('activity_classification'),
                 'signal_rows': _as_mapping(monitor_report.get('final_snapshot')).get('signal_rows'),
                 'price_rows': _as_mapping(monitor_report.get('final_snapshot')).get('price_rows'),
+                'analysis_run': rollouts_report['activity_analysis_run'],
             })
             _save_json(_artifact_path(resources, 'decision-activity.json'), {
                 'activity_classification': monitor_report.get('activity_classification'),
                 'trade_decisions': _as_mapping(monitor_report.get('final_snapshot')).get('trade_decisions'),
                 'cursor_at': _as_mapping(monitor_report.get('final_snapshot')).get('cursor_at'),
+                'analysis_run': rollouts_report['activity_analysis_run'],
             })
             _save_json(_artifact_path(resources, 'execution-activity.json'), {
                 'activity_classification': monitor_report.get('activity_classification'),
                 'executions': _as_mapping(monitor_report.get('final_snapshot')).get('executions'),
                 'execution_tca_metrics': _as_mapping(monitor_report.get('final_snapshot')).get('execution_tca_metrics'),
                 'execution_order_events': _as_mapping(monitor_report.get('final_snapshot')).get('execution_order_events'),
+                'analysis_run': rollouts_report['activity_analysis_run'],
             })
             _update_run_state(
                 resources=resources,
@@ -3535,7 +3844,12 @@ def _run_full_lifecycle(
                 status='ok' if monitor_report.get('activity_classification') == 'success' else 'degraded',
                 details=monitor_report,
             )
-            if monitor_report.get('activity_classification') in {'infra_not_active', 'environment_incomplete'}:
+            activity_analysis_phase = _as_mapping(
+                cast(Mapping[str, Any], rollouts_report['activity_analysis_run'])
+            ).get('phase')
+            if monitor_report.get('activity_classification') in {'infra_not_active', 'environment_incomplete'} or (
+                bool(rollouts_report['enabled']) and activity_analysis_phase != 'Successful'
+            ):
                 errors.append(f'activity:{monitor_report.get("activity_classification")}')
         else:
             _update_run_state(
@@ -3581,7 +3895,23 @@ def _run_full_lifecycle(
                     resources=resources,
                     allow_missing_state=True,
                 )
+                if bool(rollouts_report['enabled']):
+                    teardown_analysis_run = _run_rollouts_analysis(
+                        resources=resources,
+                        manifest=manifest,
+                        postgres_config=postgres_config,
+                        clickhouse_config=clickhouse_config,
+                        rollouts_config=rollouts_config,
+                        phase='teardown-clean',
+                        template_name=rollouts_config.teardown_template,
+                    )
+                    rollouts_report['teardown_analysis_run'] = teardown_analysis_run
+                teardown_report['analysis_run'] = rollouts_report['teardown_analysis_run']
                 _update_run_state(resources=resources, phase='teardown', status='ok')
+                if bool(rollouts_report['enabled']) and _as_mapping(
+                    cast(Mapping[str, Any], rollouts_report['teardown_analysis_run'])
+                ).get('phase') != 'Successful':
+                    errors.append('teardown:environment_incomplete')
             except Exception as exc:
                 errors.append(f'teardown:{exc}')
                 _update_run_state(
@@ -3653,9 +3983,14 @@ def _run_full_lifecycle(
         'monitor': monitor_report,
         'report': analytics_report,
         'teardown': teardown_report,
+        'rollouts': rollouts_report,
         'errors': errors,
     }
     run_manifest_path = _state_paths(resources)[1]
+    if apply_report is not None:
+        updated_apply_report = dict(apply_report)
+        updated_apply_report['rollouts'] = rollouts_report
+        _save_json(run_manifest_path, updated_apply_report)
     _save_json(run_manifest_path.with_name('run-full-lifecycle-manifest.json'), report)
     if errors:
         raise RuntimeError('simulation_run_failed:' + '; '.join(errors))
@@ -3667,6 +4002,16 @@ def _render_report(payload: Mapping[str, Any], *, json_only: bool) -> None:
         print(json.dumps(dict(payload), sort_keys=True, separators=(',', ':')))
         return
     print(json.dumps(dict(payload), indent=2, sort_keys=True))
+
+
+_http_clickhouse_query = simulation_verification._http_clickhouse_query
+_monitor_run_completion = simulation_verification._monitor_run_completion
+_monitor_snapshot = simulation_verification._monitor_snapshot
+_runtime_verify = simulation_verification._runtime_verify
+_signal_snapshot = simulation_verification._signal_snapshot
+_validate_dump_coverage = simulation_verification._validate_dump_coverage
+_validate_window_policy = simulation_verification._validate_window_policy
+_verify_isolation_guards = simulation_verification._verify_isolation_guards
 
 
 def main() -> None:
@@ -3727,6 +4072,15 @@ def main() -> None:
         applicationset_name=argocd_config.applicationset_name,
         app_name=argocd_config.app_name,
         desired_mode_during_run=argocd_config.desired_mode_during_run,
+    )
+    rollouts_config = _build_rollouts_analysis_config(manifest)
+    _log_script_event(
+        'rollouts_config_ready',
+        enabled=rollouts_config.enabled,
+        namespace=rollouts_config.namespace,
+        runtime_template=rollouts_config.runtime_template,
+        activity_template=rollouts_config.activity_template,
+        teardown_template=rollouts_config.teardown_template,
     )
     postgres_config = _build_postgres_runtime_config(
         manifest,
@@ -3804,6 +4158,7 @@ def main() -> None:
             clickhouse_config=clickhouse_config,
             postgres_config=postgres_config,
             argocd_config=argocd_config,
+            rollouts_config=rollouts_config,
             force_dump=bool(args.force_dump),
             force_replay=bool(args.force_replay),
             skip_teardown=bool(args.skip_teardown),

--- a/services/torghut/tests/test_run_simulation_analysis.py
+++ b/services/torghut/tests/test_run_simulation_analysis.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import io
+import json
+from contextlib import redirect_stdout
+from unittest import TestCase
+from unittest.mock import patch
+
+from scripts.run_simulation_analysis import main
+
+
+class TestRunSimulationAnalysis(TestCase):
+    def test_runtime_ready_exits_zero_with_json_payload(self) -> None:
+        stdout = io.StringIO()
+        with (
+            patch(
+                'sys.argv',
+                [
+                    'run_simulation_analysis.py',
+                    'runtime-ready',
+                    '--run-id',
+                    'sim-1',
+                    '--dataset-id',
+                    'dataset-a',
+                    '--namespace',
+                    'torghut',
+                    '--torghut-service',
+                    'torghut-sim',
+                    '--ta-deployment',
+                    'torghut-ta-sim',
+                    '--forecast-service',
+                    'torghut-forecast-sim',
+                    '--window-start',
+                    '2026-03-06T14:30:00Z',
+                    '--window-end',
+                    '2026-03-06T15:30:00Z',
+                    '--json',
+                ],
+            ),
+            patch(
+                'scripts.run_simulation_analysis._runtime_verify',
+                return_value={'runtime_state': 'ready', 'environment_state': 'complete'},
+            ),
+            redirect_stdout(stdout),
+        ):
+            main()
+
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(payload['runtime_state'], 'ready')
+
+    def test_activity_exits_nonzero_when_report_is_degraded(self) -> None:
+        stdout = io.StringIO()
+        with (
+            patch(
+                'sys.argv',
+                [
+                    'run_simulation_analysis.py',
+                    'activity',
+                    '--run-id',
+                    'sim-1',
+                    '--dataset-id',
+                    'dataset-a',
+                    '--namespace',
+                    'torghut',
+                    '--torghut-service',
+                    'torghut-sim',
+                    '--ta-deployment',
+                    'torghut-ta-sim',
+                    '--forecast-service',
+                    'torghut-forecast-sim',
+                    '--window-start',
+                    '2026-03-06T14:30:00Z',
+                    '--window-end',
+                    '2026-03-06T15:30:00Z',
+                    '--signal-table',
+                    'torghut_sim_sim_1.ta_signals',
+                    '--price-table',
+                    'torghut_sim_sim_1.ta_microbars',
+                    '--postgres-base-dsn',
+                    'postgresql://torghut:secret@localhost:5432/postgres',
+                    '--postgres-database',
+                    'torghut_sim_sim_1',
+                    '--clickhouse-http-url',
+                    'http://clickhouse:8123',
+                    '--clickhouse-username',
+                    'torghut',
+                    '--json',
+                ],
+            ),
+            patch(
+                'scripts.run_simulation_analysis._runtime_verify',
+                return_value={'runtime_state': 'ready', 'environment_state': 'complete'},
+            ),
+            patch(
+                'scripts.run_simulation_analysis._monitor_run_completion',
+                return_value={'status': 'degraded', 'activity_classification': 'executions_absent'},
+            ),
+            redirect_stdout(stdout),
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                main()
+
+        self.assertEqual(ctx.exception.code, 1)
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(payload['activity_classification'], 'executions_absent')

--- a/services/torghut/tests/test_start_historical_simulation.py
+++ b/services/torghut/tests/test_start_historical_simulation.py
@@ -13,12 +13,14 @@ from scripts.start_historical_simulation import (
     ClickHouseRuntimeConfig,
     KafkaRuntimeConfig,
     PostgresRuntimeConfig,
+    RolloutsAnalysisConfig,
     _build_clickhouse_runtime_config,
     _build_argocd_automation_config,
     _build_kafka_runtime_config,
     _build_plan_report,
     _build_postgres_runtime_config,
     _build_resources,
+    _build_rollouts_analysis_config,
     _configure_torghut_service_for_simulation,
     _discover_automation_pointer,
     _find_vector_extension_blocking_revision,
@@ -37,6 +39,7 @@ from scripts.start_historical_simulation import (
     _redact_dsn_credentials,
     _restore_ta_configuration,
     _replay_dump,
+    _run_rollouts_analysis,
     _set_argocd_application_sync_policy,
     _set_argocd_automation_mode,
     _runtime_verify,
@@ -430,7 +433,7 @@ class TestStartHistoricalSimulation(TestCase):
             def close(self) -> None:
                 captured['closed'] = True
 
-        with patch('scripts.start_historical_simulation.HTTPConnection', _FakeConnection):
+        with patch('scripts.historical_simulation_verification.HTTPConnection', _FakeConnection):
             status, body = _http_clickhouse_query(
                 config=ClickHouseRuntimeConfig(
                     http_url='http://clickhouse:8123',
@@ -1300,7 +1303,7 @@ class TestStartHistoricalSimulation(TestCase):
         )
         with (
             patch(
-                'scripts.start_historical_simulation._monitor_snapshot',
+                'scripts.historical_simulation_verification._monitor_snapshot',
                 return_value={
                     'trade_decisions': 10,
                     'executions': 5,
@@ -1310,10 +1313,10 @@ class TestStartHistoricalSimulation(TestCase):
                 },
             ),
             patch(
-                'scripts.start_historical_simulation._signal_snapshot',
+                'scripts.historical_simulation_verification._signal_snapshot',
                 return_value={'signal_rows': 10, 'price_rows': 10},
             ),
-            patch('scripts.start_historical_simulation.time.sleep', return_value=None),
+            patch('scripts.historical_simulation_verification.time.sleep', return_value=None),
         ):
             report = _monitor_run_completion(
                 resources=resources,
@@ -1359,9 +1362,9 @@ class TestStartHistoricalSimulation(TestCase):
         }
 
         with (
-            patch('scripts.start_historical_simulation._kubectl_json', return_value=kservice_payload),
+            patch('scripts.historical_simulation_verification._kubectl_json', return_value=kservice_payload),
             patch(
-                'scripts.start_historical_simulation._deployment_replica_health',
+                'scripts.historical_simulation_verification._deployment_replica_health',
                 side_effect=[
                     {
                         'name': 'torghut-sim-00001-deployment',
@@ -1378,7 +1381,7 @@ class TestStartHistoricalSimulation(TestCase):
                 ],
             ),
             patch(
-                'scripts.start_historical_simulation._fink_runtime_health',
+                'scripts.historical_simulation_verification._flink_runtime_health',
                 return_value={
                     'name': 'torghut-ta-sim',
                     'desired_state': 'running',
@@ -1409,6 +1412,100 @@ class TestStartHistoricalSimulation(TestCase):
         )
 
         self.assertTrue(config.manage_automation)
+
+    def test_build_rollouts_analysis_config_defaults(self) -> None:
+        config = _build_rollouts_analysis_config({})
+        self.assertFalse(config.enabled)
+        self.assertEqual(config.namespace, 'torghut')
+        self.assertEqual(config.runtime_template, 'torghut-simulation-runtime-ready')
+        self.assertEqual(config.activity_template, 'torghut-simulation-activity')
+        self.assertEqual(config.teardown_template, 'torghut-simulation-teardown-clean')
+
+    def test_run_rollouts_analysis_materializes_analysisrun_from_template(self) -> None:
+        resources = _build_resources('sim-2026-03-06-open-hour', {'dataset_id': 'dataset-a'})
+        manifest = {
+            'window': {
+                'start': '2026-03-06T14:30:00Z',
+                'end': '2026-03-06T15:30:00Z',
+            },
+            'monitor': {
+                'timeout_seconds': 60,
+                'poll_seconds': 5,
+                'min_trade_decisions': 1,
+                'min_executions': 1,
+                'min_execution_tca_metrics': 1,
+                'min_execution_order_events': 1,
+                'cursor_grace_seconds': 10,
+            },
+        }
+        postgres_config = PostgresRuntimeConfig(
+            admin_dsn='postgresql://torghut:secret@localhost:5432/postgres',
+            simulation_dsn='postgresql://torghut:secret@localhost:5432/torghut_sim_sim_1',
+            simulation_db='torghut_sim_sim_1',
+            migrations_command='true',
+        )
+        clickhouse_config = ClickHouseRuntimeConfig(
+            http_url='http://clickhouse:8123',
+            username='torghut',
+            password=None,
+        )
+        rollouts_config = RolloutsAnalysisConfig(
+            enabled=True,
+            namespace='torghut',
+            runtime_template='torghut-simulation-runtime-ready',
+            activity_template='torghut-simulation-activity',
+            teardown_template='torghut-simulation-teardown-clean',
+            artifact_template='torghut-simulation-artifact-bundle',
+            verify_timeout_seconds=60,
+        )
+        captured_apply: dict[str, object] = {}
+
+        def _fake_kubectl_json(namespace: str, args: list[str]) -> dict[str, object]:
+            self.assertEqual(namespace, 'torghut')
+            if args[:3] == ['get', 'analysistemplate', 'torghut-simulation-runtime-ready']:
+                return {
+                    'spec': {
+                        'args': [
+                            {'name': 'runId'},
+                            {'name': 'datasetId'},
+                            {'name': 'namespace'},
+                            {'name': 'torghutService'},
+                            {'name': 'taDeployment'},
+                            {'name': 'forecastService'},
+                            {'name': 'windowStart'},
+                            {'name': 'windowEnd'},
+                        ],
+                        'metrics': [{'name': 'runtime-ready'}],
+                    }
+                }
+            if args[:3] == ['get', 'analysisrun', 'torghut-sim-runtime-ready-sim_2026_03_06_open_hour']:
+                return {'status': {'phase': 'Successful'}}
+            raise AssertionError(f'unexpected kubectl args: {args}')
+
+        with (
+            patch('scripts.start_historical_simulation._kubectl_delete_if_exists', return_value=None),
+            patch(
+                'scripts.start_historical_simulation._kubectl_apply',
+                side_effect=lambda namespace, payload: captured_apply.update({'namespace': namespace, 'payload': payload}),
+            ),
+            patch('scripts.start_historical_simulation._kubectl_json', side_effect=_fake_kubectl_json),
+        ):
+            report = _run_rollouts_analysis(
+                resources=resources,
+                manifest=manifest,
+                postgres_config=postgres_config,
+                clickhouse_config=clickhouse_config,
+                rollouts_config=rollouts_config,
+                phase='runtime-ready',
+                template_name='torghut-simulation-runtime-ready',
+            )
+
+        self.assertEqual(report['phase'], 'Successful')
+        payload = captured_apply['payload']
+        self.assertIsInstance(payload, dict)
+        assert isinstance(payload, dict)
+        self.assertEqual(payload['kind'], 'AnalysisRun')
+        self.assertEqual(payload['metadata']['name'], 'torghut-sim-runtime-ready-sim_2026_03_06_open_hour')
 
     def test_discover_automation_pointer_finds_nested_element(self) -> None:
         payload = {


### PR DESCRIPTION
## Summary

- add a new platform Argo CD app for `argo-rollouts` using the official Helm chart with CRDs and metrics enabled
- add Torghut-owned `AnalysisTemplate` and RBAC resources so historical simulation runs can gate runtime, activity, and teardown via Rollouts `AnalysisRun`s
- extract shared simulation verification helpers and add `run_simulation_analysis.py`, then wire `start_historical_simulation.py` to submit and wait on `AnalysisRun`s for dedicated-service runs
- update simulation manifests, rollout documentation, and Torghut image-promotion tooling so the new analysis templates and Rollouts defaults are part of the normal GitOps path

## Related Issues

None

## Testing

- `uv run --frozen ruff check services/torghut/scripts/historical_simulation_verification.py services/torghut/scripts/run_simulation_analysis.py services/torghut/scripts/start_historical_simulation.py services/torghut/tests/test_start_historical_simulation.py services/torghut/tests/test_run_simulation_analysis.py`
- `uv run --frozen pytest services/torghut/tests/test_start_historical_simulation.py services/torghut/tests/test_run_simulation_analysis.py -q`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `bun test packages/scripts/src/torghut/__tests__/update-manifests.test.ts`
- `bunx oxfmt --check packages/scripts/src/torghut/update-manifests.ts packages/scripts/src/torghut/__tests__/update-manifests.test.ts`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/argo-rollouts`
- `kustomize build argocd/applications/torghut`
- `kustomize build argocd/applications/torghut-forecast`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
