### PR TITLE
fix(torghut): tolerate missing sim rollout timestamp

### DIFF
--- a/packages/scripts/src/torghut/__tests__/update-manifests.test.ts
+++ b/packages/scripts/src/torghut/__tests__/update-manifests.test.ts
@@ -57,7 +57,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2025-01-01T00:00:00Z"
+        autoscaling.knative.dev/minScale: "1"
     spec:
       containers:
         - name: user-container

--- a/packages/scripts/src/torghut/update-manifests.ts
+++ b/packages/scripts/src/torghut/update-manifests.ts
@@ -89,18 +89,30 @@ const replaceSingle = (source: string, pattern: RegExp, replacement: string, lab
   return source.replace(pattern, replacement)
 }
 
+const upsertKnativeRolloutTimestamp = (source: string, rolloutTimestamp: string): string => {
+  const annotationPattern = /(client\.knative\.dev\/updateTimestamp:\s*)(?:"[^"]*"|'[^']*'|[^\n]+)/
+  if (annotationPattern.test(source)) {
+    return source.replace(annotationPattern, `$1"${rolloutTimestamp}"`)
+  }
+
+  const annotationsBlockPattern = /(\n\s*template:\n\s*metadata:\n\s*annotations:\n)/
+  if (!annotationsBlockPattern.test(source)) {
+    throw new Error('Unable to locate rollout timestamp annotation block in torghut manifest')
+  }
+
+  return source.replace(
+    annotationsBlockPattern,
+    `$1        client.knative.dev/updateTimestamp: "${rolloutTimestamp}"\n`,
+  )
+}
+
 const updateTorghutManifest = (options: UpdateManifestsOptions) => {
   const manifestPath = resolvePath(options.manifestPath ?? defaultManifestPath)
   const source = readFileSync(manifestPath, 'utf8')
   const imageRef = `${options.imageName}@${options.digest}`
 
   let updated = source
-  updated = replaceSingle(
-    updated,
-    /(client\.knative\.dev\/updateTimestamp:\s*)(?:"[^"]*"|'[^']*'|[^\n]+)/,
-    `$1"${options.rolloutTimestamp}"`,
-    'rollout timestamp annotation',
-  )
+  updated = upsertKnativeRolloutTimestamp(updated, options.rolloutTimestamp)
   updated = replaceSingle(
     updated,
     /(- name:\s*user-container[\s\S]*?\n\s*image:\s*)([^\n]+)/,


### PR DESCRIPTION
## Summary

- make the Torghut manifest updater insert `client.knative.dev/updateTimestamp` when a Knative service manifest does not already have it
- cover the real `knative-service-sim.yaml` shape in the updater regression test so the release pipeline cannot regress on the sim service path
- unblock the `torghut-release` workflow for the historical simulation Rollouts rollout

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/update-manifests.test.ts`
- `bunx oxfmt --check packages/scripts/src/torghut/update-manifests.ts packages/scripts/src/torghut/__tests__/update-manifests.test.ts`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
