### PR TITLE
chore(openclaw): make kustomization namespace-scoped

### DIFF
--- a/argocd/applications/openclaw/kustomization.yaml
+++ b/argocd/applications/openclaw/kustomization.yaml
@@ -1,5 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: openclaw
 resources:
   - cloud-init-secret.yaml
   - virtualmachine.yaml

--- a/argocd/applications/openclaw/openclaw-vm-rbac.yaml
+++ b/argocd/applications/openclaw/openclaw-vm-rbac.yaml
@@ -2,13 +2,11 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: openclaw-vm
-  namespace: openclaw
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
   name: openclaw-vm-argocd-app
-  namespace: argocd
 rules:
   - apiGroups: ["argoproj.io"]
     resources: ["applications"]
@@ -19,15 +17,14 @@ rules:
     verbs: ["patch", "update"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
   name: openclaw-vm-argocd-app
-  namespace: argocd
 subjects:
   - kind: ServiceAccount
     name: openclaw-vm
     namespace: openclaw
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
+  kind: ClusterRole
   name: openclaw-vm-argocd-app


### PR DESCRIPTION
## Summary
- restore `namespace: openclaw` in `argocd/applications/openclaw/kustomization.yaml`
- keep VM service account access scoped to ArgoCD applications via ClusterRole/ClusterRoleBinding
- preserve ability to patch/update only `argocd/Application/openclaw`

## Validation
- rendered with `kubectl kustomize argocd/applications/openclaw`