### PR TITLE
fix(argocd): ignore remaining argo rollouts crd drift

### DIFF
--- a/argocd/applicationsets/platform.yaml
+++ b/argocd/applicationsets/platform.yaml
@@ -249,26 +249,31 @@ spec:
                     name: analysisruns.argoproj.io
                     jqPathExpressions:
                       - .spec.conversion
+                      - .spec.preserveUnknownFields
                   - kind: CustomResourceDefinition
                     group: apiextensions.k8s.io
                     name: analysistemplates.argoproj.io
                     jqPathExpressions:
                       - .spec.conversion
+                      - .spec.preserveUnknownFields
                   - kind: CustomResourceDefinition
                     group: apiextensions.k8s.io
                     name: clusteranalysistemplates.argoproj.io
                     jqPathExpressions:
                       - .spec.conversion
+                      - .spec.preserveUnknownFields
                   - kind: CustomResourceDefinition
                     group: apiextensions.k8s.io
                     name: experiments.argoproj.io
                     jqPathExpressions:
                       - .spec.conversion
+                      - .spec.preserveUnknownFields
                   - kind: CustomResourceDefinition
                     group: apiextensions.k8s.io
                     name: rollouts.argoproj.io
                     jqPathExpressions:
                       - .spec.conversion
+                      - .spec.preserveUnknownFields
                 automation: manual
                 enabled: "true"
               - name: argo-workflows


### PR DESCRIPTION
## Summary

- extend the `argo-rollouts` CRD ignore rules to also ignore `spec.preserveUnknownFields`
- cover the remaining API-defaulted CRD field that kept `argo-rollouts` marked `OutOfSync` after the first fix
- leave the existing manual sync behavior unchanged

## Related Issues

None

## Testing

- `git diff --check`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/argo-rollouts | yq e 'select(.kind == "CustomResourceDefinition" and .metadata.name == "analysisruns.argoproj.io")' - > /tmp/desired-analysisruns.yaml && kubectl get crd analysisruns.argoproj.io -o yaml > /tmp/live-analysisruns.yaml && diff -u <(yq e '.spec' /tmp/desired-analysisruns.yaml) <(yq e '.spec' /tmp/live-analysisruns.yaml) | sed -n '1,40p'`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
