### PR TITLE
fix(torghut): use application sync policy for simulations

### DIFF
--- a/services/torghut/scripts/start_historical_simulation.py
+++ b/services/torghut/scripts/start_historical_simulation.py
@@ -3370,10 +3370,8 @@ def _prepare_argocd_for_run(
             'current_mode': None,
             'previous_mode': None,
         }
-    automation_report = _set_argocd_automation_mode(
-        config=config,
-        desired_mode=config.desired_mode_during_run,
-    )
+    automation_state = _read_argocd_automation_mode(config=config)
+    current_mode = _normalized_automation_mode(_as_text(automation_state.get('mode')))
     application_report = _set_argocd_application_sync_policy(
         config=config,
         desired_sync_policy=_manual_argocd_application_sync_policy(
@@ -3382,8 +3380,12 @@ def _prepare_argocd_for_run(
     )
     return {
         'managed': True,
-        'changed': automation_report['changed'] or application_report['changed'],
-        **automation_report,
+        'changed': application_report['changed'],
+        'pointer': automation_state.get('pointer'),
+        'previous_mode': current_mode,
+        'desired_mode': config.desired_mode_during_run,
+        'current_mode': current_mode,
+        'applicationset_managed': False,
         'application': application_report,
     }
 
@@ -3400,24 +3402,18 @@ def _restore_argocd_after_run(
             'changed': False,
             'restored_mode': None,
         }
-    restore_mode = config.restore_mode_after_run
-    if restore_mode == 'previous':
-        target_mode = previous_mode or 'auto'
-    else:
-        target_mode = restore_mode
-    report = _set_argocd_automation_mode(
-        config=config,
-        desired_mode=target_mode,
-    )
     application_report = _set_argocd_application_sync_policy(
         config=config,
         desired_sync_policy=previous_sync_policy,
     )
     return {
         'managed': True,
-        'restored_mode': target_mode,
+        'changed': application_report['changed'],
+        'restored_mode': previous_mode,
+        'previous_mode': previous_mode,
+        'current_mode': previous_mode,
+        'applicationset_managed': False,
         'application': application_report,
-        **report,
     }
 
 

--- a/services/torghut/tests/test_start_historical_simulation.py
+++ b/services/torghut/tests/test_start_historical_simulation.py
@@ -38,6 +38,7 @@ from scripts.start_historical_simulation import (
     _producer_for_replay,
     _redact_dsn_credentials,
     _restore_ta_configuration,
+    _restore_argocd_after_run,
     _replay_dump,
     _run_rollouts_analysis,
     _set_argocd_application_sync_policy,
@@ -1637,7 +1638,7 @@ class TestStartHistoricalSimulation(TestCase):
             {'enabled': False, 'prune': False, 'selfHeal': False},
         )
 
-    def test_prepare_argocd_for_run_patches_application_and_applicationset(self) -> None:
+    def test_prepare_argocd_for_run_patches_application_only(self) -> None:
         config = ArgocdAutomationConfig(
             manage_automation=True,
             applicationset_name='product',
@@ -1649,9 +1650,9 @@ class TestStartHistoricalSimulation(TestCase):
         )
         with (
             patch(
-                'scripts.start_historical_simulation._set_argocd_automation_mode',
-                return_value={'previous_mode': 'auto', 'current_mode': 'manual', 'changed': True},
-            ) as automation_mock,
+                'scripts.start_historical_simulation._read_argocd_automation_mode',
+                return_value={'pointer': '/spec/generators/0/list/elements/0/automation', 'mode': 'auto'},
+            ) as automation_read_mock,
             patch(
                 'scripts.start_historical_simulation._read_argocd_application_sync_policy',
                 return_value={
@@ -1676,7 +1677,45 @@ class TestStartHistoricalSimulation(TestCase):
             ) as application_mock,
         ):
             report = _prepare_argocd_for_run(config=config)
-        automation_mock.assert_called_once()
+        automation_read_mock.assert_called_once()
         application_mock.assert_called_once()
         self.assertTrue(report['changed'])
         self.assertIn('application', report)
+        self.assertFalse(report['applicationset_managed'])
+        self.assertEqual(report['previous_mode'], 'auto')
+        self.assertEqual(report['current_mode'], 'auto')
+
+    def test_restore_argocd_after_run_restores_application_only(self) -> None:
+        config = ArgocdAutomationConfig(
+            manage_automation=True,
+            applicationset_name='product',
+            applicationset_namespace='argocd',
+            app_name='torghut',
+            desired_mode_during_run='manual',
+            restore_mode_after_run='previous',
+            verify_timeout_seconds=30,
+        )
+        previous_sync_policy = {
+            'automated': {'enabled': True, 'prune': True, 'selfHeal': True},
+            'syncOptions': ['CreateNamespace=true'],
+        }
+        with patch(
+            'scripts.start_historical_simulation._set_argocd_application_sync_policy',
+            return_value={
+                'previous_sync_policy': {
+                    'automated': {'enabled': False, 'prune': False, 'selfHeal': False},
+                },
+                'current_sync_policy': previous_sync_policy,
+                'changed': True,
+            },
+        ) as application_mock:
+            report = _restore_argocd_after_run(
+                config=config,
+                previous_mode='auto',
+                previous_sync_policy=previous_sync_policy,
+            )
+        application_mock.assert_called_once()
+        self.assertTrue(report['changed'])
+        self.assertEqual(report['restored_mode'], 'auto')
+        self.assertFalse(report['applicationset_managed'])
+        self.assertEqual(report['current_mode'], 'auto')


### PR DESCRIPTION
## Summary

- stop the historical simulation workflow from blocking on mutating the Git-managed `product` ApplicationSet automation flag
- use the concrete `Application/torghut` sync policy as the run control-plane mutation while still recording ApplicationSet mode for observability
- add regression coverage for prepare/restore behavior so simulation runs only patch the Argo Application object

## Related Issues

None

## Testing

- `uv run --frozen ruff check services/torghut/scripts/start_historical_simulation.py services/torghut/tests/test_start_historical_simulation.py`
- `pytest services/torghut/tests/test_start_historical_simulation.py -q`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- manual cluster verification of the prior stuck run showed `ApplicationSet/product` automation was being reverted by GitOps while `Application/torghut` remained the real control point

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
