### PR TITLE
fix(torghut): use dns-safe analysisrun names

### DIFF
--- a/services/torghut/scripts/start_historical_simulation.py
+++ b/services/torghut/scripts/start_historical_simulation.py
@@ -392,6 +392,14 @@ def _normalize_run_token(run_id: str) -> str:
     return token
 
 
+def _normalize_kubernetes_name_token(value: str) -> str:
+    token = re.sub(r'[^a-z0-9]+', '-', value.strip().lower()).strip('-')
+    token = re.sub(r'-+', '-', token)
+    if not token:
+        raise SystemExit('kubernetes name token must contain at least one alphanumeric character')
+    return token
+
+
 def _as_mapping(value: Any) -> dict[str, Any]:
     if not isinstance(value, Mapping):
         return {}
@@ -3422,12 +3430,13 @@ def _restore_argocd_after_run(
 
 
 def _analysis_run_name(*, phase: str, run_token: str) -> str:
-    base = f'torghut-sim-{phase}-{run_token}'
+    kubernetes_run_token = _normalize_kubernetes_name_token(run_token)
+    base = f'torghut-sim-{phase}-{kubernetes_run_token}'
     if len(base) <= 63:
         return base
     prefix = f'torghut-sim-{phase}-'
     remaining = 63 - len(prefix)
-    return prefix + run_token[:remaining].rstrip('-')
+    return prefix + kubernetes_run_token[:remaining].rstrip('-')
 
 
 def _analysis_run_args(

--- a/services/torghut/tests/test_start_historical_simulation.py
+++ b/services/torghut/tests/test_start_historical_simulation.py
@@ -14,6 +14,7 @@ from scripts.start_historical_simulation import (
     KafkaRuntimeConfig,
     PostgresRuntimeConfig,
     RolloutsAnalysisConfig,
+    _analysis_run_name,
     _build_clickhouse_runtime_config,
     _build_argocd_automation_config,
     _build_kafka_runtime_config,
@@ -54,6 +55,15 @@ from scripts.start_historical_simulation import (
 class TestStartHistoricalSimulation(TestCase):
     def test_normalize_run_token(self) -> None:
         self.assertEqual(_normalize_run_token('Sim-2026/02/27#Run-01'), 'sim_2026_02_27_run_01')
+
+    def test_analysis_run_name_uses_dns1123_safe_token(self) -> None:
+        self.assertEqual(
+            _analysis_run_name(
+                phase='runtime-ready',
+                run_token='sim_2026_03_06_open_hour',
+            ),
+            'torghut-sim-runtime-ready-sim-2026-03-06-open-hour',
+        )
 
     def test_build_resources_derives_isolation_names(self) -> None:
         resources = _build_resources(
@@ -1478,7 +1488,7 @@ class TestStartHistoricalSimulation(TestCase):
                         'metrics': [{'name': 'runtime-ready'}],
                     }
                 }
-            if args[:3] == ['get', 'analysisrun', 'torghut-sim-runtime-ready-sim_2026_03_06_open_hour']:
+            if args[:3] == ['get', 'analysisrun', 'torghut-sim-runtime-ready-sim-2026-03-06-open-hour']:
                 return {'status': {'phase': 'Successful'}}
             raise AssertionError(f'unexpected kubectl args: {args}')
 
@@ -1505,7 +1515,7 @@ class TestStartHistoricalSimulation(TestCase):
         self.assertIsInstance(payload, dict)
         assert isinstance(payload, dict)
         self.assertEqual(payload['kind'], 'AnalysisRun')
-        self.assertEqual(payload['metadata']['name'], 'torghut-sim-runtime-ready-sim_2026_03_06_open_hour')
+        self.assertEqual(payload['metadata']['name'], 'torghut-sim-runtime-ready-sim-2026-03-06-open-hour')
 
     def test_discover_automation_pointer_finds_nested_element(self) -> None:
         payload = {


### PR DESCRIPTION
## Summary

- Normalize `AnalysisRun` names with a DNS-1123-safe token before writing `metadata.name`.
- Preserve the existing underscore-based run token for simulation database, table, and consumer-group identifiers.
- Add regression coverage for direct AnalysisRun name generation and the rollouts analysis execution path.

## Related Issues

None

## Testing

- `pytest services/torghut/tests/test_start_historical_simulation.py -k "analysis_run_name_uses_dns1123_safe_token or run_rollouts_analysis"`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
