### PR TITLE
chore(torghut): promote image e5b4df67

### DIFF
--- a/argocd/applications/torghut-forecast/deployment.yaml
+++ b/argocd/applications/torghut-forecast/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: forecast
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:9abdf79e26a7adaf9284e09d869d611183d0ab75d34d41e53ea8e07c28bdcc1d
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8e88ae4a3f5570baff930b206b5b79b1ac90c2e7511702c2c700301db40c7294
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn

--- a/argocd/applications/torghut-forecast/sim/deployment.yaml
+++ b/argocd/applications/torghut-forecast/sim/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: forecast
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:9abdf79e26a7adaf9284e09d869d611183d0ab75d34d41e53ea8e07c28bdcc1d
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8e88ae4a3f5570baff930b206b5b79b1ac90c2e7511702c2c700301db40c7294
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -40,7 +40,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:9abdf79e26a7adaf9284e09d869d611183d0ab75d34d41e53ea8e07c28bdcc1d
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:8e88ae4a3f5570baff930b206b5b79b1ac90c2e7511702c2c700301db40c7294
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -21,7 +21,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:9abdf79e26a7adaf9284e09d869d611183d0ab75d34d41e53ea8e07c28bdcc1d
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:8e88ae4a3f5570baff930b206b5b79b1ac90c2e7511702c2c700301db40c7294
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -28,7 +28,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:9abdf79e26a7adaf9284e09d869d611183d0ab75d34d41e53ea8e07c28bdcc1d
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:8e88ae4a3f5570baff930b206b5b79b1ac90c2e7511702c2c700301db40c7294
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -30,7 +30,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:9abdf79e26a7adaf9284e09d869d611183d0ab75d34d41e53ea8e07c28bdcc1d
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:8e88ae4a3f5570baff930b206b5b79b1ac90c2e7511702c2c700301db40c7294
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:9abdf79e26a7adaf9284e09d869d611183d0ab75d34d41e53ea8e07c28bdcc1d
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8e88ae4a3f5570baff930b206b5b79b1ac90c2e7511702c2c700301db40c7294
           command:
             - alembic
           args:

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -13,7 +13,7 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:9abdf79e26a7adaf9284e09d869d611183d0ab75d34d41e53ea8e07c28bdcc1d
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8e88ae4a3f5570baff930b206b5b79b1ac90c2e7511702c2c700301db40c7294
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -21,7 +21,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:9abdf79e26a7adaf9284e09d869d611183d0ab75d34d41e53ea8e07c28bdcc1d
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:8e88ae4a3f5570baff930b206b5b79b1ac90c2e7511702c2c700301db40c7294
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -39,7 +39,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:9abdf79e26a7adaf9284e09d869d611183d0ab75d34d41e53ea8e07c28bdcc1d
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:8e88ae4a3f5570baff930b206b5b79b1ac90c2e7511702c2c700301db40c7294
       imagePullPolicy: Always
       env:
         - name: TORGHUT_SIM_KAFKA_PASSWORD

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-03-07T08:28:21Z"
+        client.knative.dev/updateTimestamp: "2026-03-07T08:34:35Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:9abdf79e26a7adaf9284e09d869d611183d0ab75d34d41e53ea8e07c28bdcc1d
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8e88ae4a3f5570baff930b206b5b79b1ac90c2e7511702c2c700301db40c7294
           ports:
             - name: http1
               containerPort: 8181
@@ -458,9 +458,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.562.0-393-g5d2138f0
+              value: v0.562.0-395-ge5b4df67
             - name: TORGHUT_COMMIT
-              value: 5d2138f0a12309d9db48f02148c6f01b93874dfd
+              value: e5b4df67cc97009af3e8303e0f03326aee03c186
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-03-07T08:28:21Z"
+        client.knative.dev/updateTimestamp: "2026-03-07T08:34:35Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -26,7 +26,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:9abdf79e26a7adaf9284e09d869d611183d0ab75d34d41e53ea8e07c28bdcc1d
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8e88ae4a3f5570baff930b206b5b79b1ac90c2e7511702c2c700301db40c7294
           ports:
             - name: http1
               containerPort: 8181
@@ -456,9 +456,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.562.0-393-g5d2138f0
+              value: v0.562.0-395-ge5b4df67
             - name: TORGHUT_COMMIT
-              value: 5d2138f0a12309d9db48f02148c6f01b93874dfd
+              value: e5b4df67cc97009af3e8303e0f03326aee03c186
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/lean-runner-deployment.yaml
+++ b/argocd/applications/torghut/lean-runner-deployment.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: lean-runner
           # Keep in lockstep with `argocd/applications/torghut/knative-service.yaml`.
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:9abdf79e26a7adaf9284e09d869d611183d0ab75d34d41e53ea8e07c28bdcc1d
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8e88ae4a3f5570baff930b206b5b79b1ac90c2e7511702c2c700301db40c7294
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `e5b4df67cc97009af3e8303e0f03326aee03c186`
- Image tag: `e5b4df67`
- Image digest: `sha256:8e88ae4a3f5570baff930b206b5b79b1ac90c2e7511702c2c700301db40c7294`