### PR TITLE
fix(torghut): layer simulation argocd automation control

### DIFF
--- a/services/torghut/scripts/start_historical_simulation.py
+++ b/services/torghut/scripts/start_historical_simulation.py
@@ -138,6 +138,7 @@ DEFAULT_RUN_MONITOR_CURSOR_GRACE_SECONDS = 120
 DEFAULT_ARGOCD_APPSET_NAME = 'product'
 DEFAULT_ARGOCD_NAMESPACE = 'argocd'
 DEFAULT_ARGOCD_APP_NAME = 'torghut'
+DEFAULT_ARGOCD_ROOT_APP_NAME = 'root'
 DEFAULT_ARGOCD_RUN_MODE = 'manual'
 DEFAULT_ROLLOUTS_NAMESPACE = 'torghut'
 DEFAULT_ROLLOUTS_RUNTIME_TEMPLATE = 'torghut-simulation-runtime-ready'
@@ -331,6 +332,7 @@ class ArgocdAutomationConfig:
     applicationset_name: str
     applicationset_namespace: str
     app_name: str
+    root_app_name: str
     desired_mode_during_run: str
     restore_mode_after_run: str
     verify_timeout_seconds: int
@@ -1069,6 +1071,7 @@ def _build_argocd_automation_config(manifest: Mapping[str, Any]) -> ArgocdAutoma
         applicationset_name=_as_text(argocd.get('applicationset_name')) or DEFAULT_ARGOCD_APPSET_NAME,
         applicationset_namespace=_as_text(argocd.get('applicationset_namespace')) or DEFAULT_ARGOCD_NAMESPACE,
         app_name=_as_text(argocd.get('app_name')) or DEFAULT_ARGOCD_APP_NAME,
+        root_app_name=_as_text(argocd.get('root_app_name')) or DEFAULT_ARGOCD_ROOT_APP_NAME,
         desired_mode_during_run=desired_mode,
         restore_mode_after_run=restore_mode,
         verify_timeout_seconds=verify_timeout_seconds,
@@ -1418,17 +1421,30 @@ def _set_argocd_automation_mode(
     }
 
 
-def _read_argocd_application_sync_policy(
+def _argocd_application_mode_from_sync_policy(
+    sync_policy: Mapping[str, Any] | None,
+) -> str:
+    if sync_policy is None:
+        return 'manual'
+    automated = _as_mapping(sync_policy.get('automated'))
+    if not automated:
+        return 'manual'
+    enabled = automated.get('enabled')
+    return 'auto' if bool(enabled) else 'manual'
+
+
+def _read_named_argocd_application_sync_policy(
     *,
-    config: ArgocdAutomationConfig,
+    namespace: str,
+    app_name: str,
 ) -> dict[str, Any]:
     payload = _kubectl_json_global(
         [
             '-n',
-            config.applicationset_namespace,
+            namespace,
             'get',
             'application',
-            config.app_name,
+            app_name,
             '-o',
             'json',
         ]
@@ -1436,12 +1452,21 @@ def _read_argocd_application_sync_policy(
     spec = _as_mapping(payload.get('spec'))
     sync_policy_raw = spec.get('syncPolicy')
     sync_policy = _clone_json_mapping(_as_mapping(sync_policy_raw) if isinstance(sync_policy_raw, Mapping) else None)
-    automated = _as_mapping(sync_policy.get('automated')) if sync_policy is not None else {}
-    automated_enabled = bool(automated.get('enabled')) if automated else False
+    automation_mode = _argocd_application_mode_from_sync_policy(sync_policy)
     return {
         'sync_policy': sync_policy,
-        'automated_enabled': automated_enabled,
+        'automation_mode': automation_mode,
     }
+
+
+def _read_argocd_application_sync_policy(
+    *,
+    config: ArgocdAutomationConfig,
+) -> dict[str, Any]:
+    return _read_named_argocd_application_sync_policy(
+        namespace=config.applicationset_namespace,
+        app_name=config.app_name,
+    )
 
 
 def _manual_argocd_application_sync_policy(
@@ -1460,10 +1485,15 @@ def _manual_argocd_application_sync_policy(
 def _set_argocd_application_sync_policy(
     *,
     config: ArgocdAutomationConfig,
+    app_name: str | None = None,
     desired_sync_policy: Mapping[str, Any] | None,
 ) -> dict[str, Any]:
     desired_policy = _clone_json_mapping(desired_sync_policy)
-    state = _read_argocd_application_sync_policy(config=config)
+    target_app_name = app_name or config.app_name
+    state = _read_named_argocd_application_sync_policy(
+        namespace=config.applicationset_namespace,
+        app_name=target_app_name,
+    )
     current_policy = _clone_json_mapping(cast(Mapping[str, Any] | None, state.get('sync_policy')))
     changed = current_policy != desired_policy
     if changed:
@@ -1471,21 +1501,24 @@ def _set_argocd_application_sync_policy(
             _kubectl_patch_json(
                 config.applicationset_namespace,
                 'application',
-                config.app_name,
+                target_app_name,
                 [{'op': 'remove', 'path': '/spec/syncPolicy'}],
             )
         else:
             _kubectl_patch(
                 config.applicationset_namespace,
                 'application',
-                config.app_name,
+                target_app_name,
                 {'spec': {'syncPolicy': desired_policy}},
             )
 
     deadline = datetime.now(timezone.utc) + timedelta(seconds=config.verify_timeout_seconds)
     verified_policy = current_policy
     while True:
-        verified_state = _read_argocd_application_sync_policy(config=config)
+        verified_state = _read_named_argocd_application_sync_policy(
+            namespace=config.applicationset_namespace,
+            app_name=target_app_name,
+        )
         verified_policy = _clone_json_mapping(cast(Mapping[str, Any] | None, verified_state.get('sync_policy')))
         if verified_policy == desired_policy:
             break
@@ -1501,6 +1534,41 @@ def _set_argocd_application_sync_policy(
         'previous_sync_policy': current_policy,
         'current_sync_policy': verified_policy,
         'changed': changed,
+    }
+
+
+def _wait_for_argocd_application_mode(
+    *,
+    config: ArgocdAutomationConfig,
+    app_name: str,
+    desired_mode: str,
+) -> dict[str, Any]:
+    normalized_desired = _normalized_automation_mode(desired_mode)
+    state = _read_named_argocd_application_sync_policy(
+        namespace=config.applicationset_namespace,
+        app_name=app_name,
+    )
+    current_mode = _normalized_automation_mode(_as_text(state.get('automation_mode')))
+    deadline = datetime.now(timezone.utc) + timedelta(seconds=config.verify_timeout_seconds)
+    verified_mode = current_mode
+    while True:
+        verified_state = _read_named_argocd_application_sync_policy(
+            namespace=config.applicationset_namespace,
+            app_name=app_name,
+        )
+        verified_mode = _normalized_automation_mode(_as_text(verified_state.get('automation_mode')))
+        if verified_mode == normalized_desired:
+            break
+        if datetime.now(timezone.utc) >= deadline:
+            raise RuntimeError(
+                'argocd_application_mode_verify_timeout '
+                f'app={app_name} desired={normalized_desired} observed={verified_mode}'
+            )
+        time.sleep(2)
+
+    return {
+        'app_name': app_name,
+        'current_mode': verified_mode,
     }
 
 
@@ -3378,21 +3446,37 @@ def _prepare_argocd_for_run(
         }
     automation_state = _read_argocd_automation_mode(config=config)
     current_mode = _normalized_automation_mode(_as_text(automation_state.get('mode')))
-    application_report = _set_argocd_application_sync_policy(
+    root_sync_state = _read_named_argocd_application_sync_policy(
+        namespace=config.applicationset_namespace,
+        app_name=config.root_app_name,
+    )
+    root_application_report = _set_argocd_application_sync_policy(
         config=config,
+        app_name=config.root_app_name,
         desired_sync_policy=_manual_argocd_application_sync_policy(
-            cast(Mapping[str, Any] | None, _read_argocd_application_sync_policy(config=config).get('sync_policy'))
+            cast(Mapping[str, Any] | None, root_sync_state.get('sync_policy'))
         ),
+    )
+    applicationset_report = _set_argocd_automation_mode(
+        config=config,
+        desired_mode=config.desired_mode_during_run,
+    )
+    application_mode_report = _wait_for_argocd_application_mode(
+        config=config,
+        app_name=config.app_name,
+        desired_mode=config.desired_mode_during_run,
     )
     return {
         'managed': True,
-        'changed': application_report['changed'],
+        'changed': root_application_report['changed'] or applicationset_report['changed'],
         'pointer': automation_state.get('pointer'),
         'previous_mode': current_mode,
         'desired_mode': config.desired_mode_during_run,
-        'current_mode': current_mode,
-        'applicationset_managed': False,
-        'application': application_report,
+        'current_mode': application_mode_report['current_mode'],
+        'applicationset_managed': True,
+        'applicationset': applicationset_report,
+        'root_application': root_application_report,
+        'application': application_mode_report,
     }
 
 
@@ -3408,18 +3492,36 @@ def _restore_argocd_after_run(
             'changed': False,
             'restored_mode': None,
         }
-    application_report = _set_argocd_application_sync_policy(
+    restored_mode = previous_mode
+    if config.restore_mode_after_run != 'previous':
+        restored_mode = config.restore_mode_after_run
+    if restored_mode is None:
+        restored_mode = 'auto'
+
+    applicationset_report = _set_argocd_automation_mode(
         config=config,
+        desired_mode=restored_mode,
+    )
+    root_application_report = _set_argocd_application_sync_policy(
+        config=config,
+        app_name=config.root_app_name,
         desired_sync_policy=previous_sync_policy,
+    )
+    application_mode_report = _wait_for_argocd_application_mode(
+        config=config,
+        app_name=config.app_name,
+        desired_mode=restored_mode,
     )
     return {
         'managed': True,
-        'changed': application_report['changed'],
-        'restored_mode': previous_mode,
+        'changed': root_application_report['changed'] or applicationset_report['changed'],
+        'restored_mode': restored_mode,
         'previous_mode': previous_mode,
-        'current_mode': previous_mode,
-        'applicationset_managed': False,
-        'application': application_report,
+        'current_mode': application_mode_report['current_mode'],
+        'applicationset_managed': True,
+        'applicationset': applicationset_report,
+        'root_application': root_application_report,
+        'application': application_mode_report,
     }
 
 
@@ -3705,7 +3807,7 @@ def _run_full_lifecycle(
     previous_automation_mode: str | None = None
     argocd_prepare_succeeded = False
     argocd_restore_required = False
-    previous_application_sync_policy: dict[str, Any] | None = None
+    previous_root_application_sync_policy: dict[str, Any] | None = None
 
     try:
         if report_only:
@@ -3727,21 +3829,25 @@ def _run_full_lifecycle(
                 previous_automation_mode = _normalized_automation_mode(
                     _as_text(current_state.get('mode'))
                 )
-                current_app_state = _read_argocd_application_sync_policy(config=argocd_config)
-                previous_application_sync_policy = _clone_json_mapping(
-                    cast(Mapping[str, Any] | None, current_app_state.get('sync_policy'))
+                current_root_app_state = _read_named_argocd_application_sync_policy(
+                    namespace=argocd_config.applicationset_namespace,
+                    app_name=argocd_config.root_app_name,
                 )
+                previous_root_application_sync_policy = _clone_json_mapping(
+                    cast(Mapping[str, Any] | None, current_root_app_state.get('sync_policy'))
+                )
+                current_app_state = _read_argocd_application_sync_policy(config=argocd_config)
                 argocd_restore_required = (
                     previous_automation_mode != _normalized_automation_mode(argocd_config.desired_mode_during_run)
                 )
-                if current_app_state.get('automated_enabled'):
+                if _normalized_automation_mode(_as_text(current_app_state.get('automation_mode'))) != 'manual':
                     argocd_restore_required = True
             argocd_prepare_report = _prepare_argocd_for_run(config=argocd_config)
             if previous_automation_mode is None:
                 previous_automation_mode = _as_text(argocd_prepare_report.get('previous_mode'))
-            if previous_application_sync_policy is None:
-                application_report = _as_mapping(argocd_prepare_report.get('application'))
-                previous_application_sync_policy = _clone_json_mapping(
+            if previous_root_application_sync_policy is None:
+                application_report = _as_mapping(argocd_prepare_report.get('root_application'))
+                previous_root_application_sync_policy = _clone_json_mapping(
                     cast(Mapping[str, Any] | None, application_report.get('previous_sync_policy'))
                 )
             argocd_prepare_succeeded = True
@@ -3961,7 +4067,7 @@ def _run_full_lifecycle(
                 argocd_restore_report = _restore_argocd_after_run(
                     config=argocd_config,
                     previous_mode=previous_automation_mode,
-                    previous_sync_policy=previous_application_sync_policy,
+                    previous_sync_policy=previous_root_application_sync_policy,
                 )
                 _update_run_state(resources=resources, phase='argocd_restore', status='ok')
             except Exception as exc:

--- a/services/torghut/tests/test_start_historical_simulation.py
+++ b/services/torghut/tests/test_start_historical_simulation.py
@@ -8,6 +8,7 @@ from tempfile import TemporaryDirectory
 from unittest import TestCase
 from unittest.mock import patch
 
+from scripts import start_historical_simulation
 from scripts.start_historical_simulation import (
     ArgocdAutomationConfig,
     ClickHouseRuntimeConfig,
@@ -389,6 +390,7 @@ class TestStartHistoricalSimulation(TestCase):
                 applicationset_name='product',
                 applicationset_namespace='argocd',
                 app_name='torghut',
+                root_app_name='root',
                 desired_mode_during_run='manual',
                 restore_mode_after_run='previous',
                 verify_timeout_seconds=600,
@@ -1454,6 +1456,7 @@ class TestStartHistoricalSimulation(TestCase):
             applicationset_name='product',
             applicationset_namespace='argocd',
             app_name='torghut',
+            root_app_name='root',
             desired_mode_during_run='manual',
             restore_mode_after_run='previous',
             verify_timeout_seconds=600,
@@ -1748,6 +1751,7 @@ class TestStartHistoricalSimulation(TestCase):
                     applicationset_name='product',
                     applicationset_namespace='argocd',
                     app_name='torghut',
+                    root_app_name='root',
                     desired_mode_during_run='manual',
                     restore_mode_after_run='previous',
                     verify_timeout_seconds=30,
@@ -1796,6 +1800,7 @@ class TestStartHistoricalSimulation(TestCase):
                     applicationset_name='product',
                     applicationset_namespace='argocd',
                     app_name='torghut',
+                    root_app_name='root',
                     desired_mode_during_run='manual',
                     restore_mode_after_run='previous',
                     verify_timeout_seconds=30,
@@ -1809,12 +1814,27 @@ class TestStartHistoricalSimulation(TestCase):
             {'enabled': False, 'prune': False, 'selfHeal': False},
         )
 
-    def test_prepare_argocd_for_run_patches_application_only(self) -> None:
+    def test_argocd_application_mode_from_sync_policy_treats_missing_automation_as_manual(self) -> None:
+        self.assertEqual(
+            start_historical_simulation._argocd_application_mode_from_sync_policy(
+                {'syncOptions': ['CreateNamespace=true']}
+            ),
+            'manual',
+        )
+        self.assertEqual(
+            start_historical_simulation._argocd_application_mode_from_sync_policy(
+                {'automated': {'enabled': True}}
+            ),
+            'auto',
+        )
+
+    def test_prepare_argocd_for_run_pauses_root_and_applicationset(self) -> None:
         config = ArgocdAutomationConfig(
             manage_automation=True,
             applicationset_name='product',
             applicationset_namespace='argocd',
             app_name='torghut',
+            root_app_name='root',
             desired_mode_during_run='manual',
             restore_mode_after_run='previous',
             verify_timeout_seconds=30,
@@ -1825,15 +1845,15 @@ class TestStartHistoricalSimulation(TestCase):
                 return_value={'pointer': '/spec/generators/0/list/elements/0/automation', 'mode': 'auto'},
             ) as automation_read_mock,
             patch(
-                'scripts.start_historical_simulation._read_argocd_application_sync_policy',
+                'scripts.start_historical_simulation._read_named_argocd_application_sync_policy',
                 return_value={
                     'sync_policy': {
                         'automated': {'enabled': True, 'prune': True, 'selfHeal': True},
                         'syncOptions': ['CreateNamespace=true'],
                     },
-                    'automated_enabled': True,
+                    'automation_mode': 'auto',
                 },
-            ),
+            ) as application_read_mock,
             patch(
                 'scripts.start_historical_simulation._set_argocd_application_sync_policy',
                 return_value={
@@ -1845,23 +1865,48 @@ class TestStartHistoricalSimulation(TestCase):
                     },
                     'changed': True,
                 },
-            ) as application_mock,
+            ) as root_application_mock,
+            patch(
+                'scripts.start_historical_simulation._set_argocd_automation_mode',
+                return_value={
+                    'pointer': '/spec/generators/0/list/elements/0/automation',
+                    'previous_mode': 'auto',
+                    'desired_mode': 'manual',
+                    'current_mode': 'manual',
+                    'changed': True,
+                },
+            ) as applicationset_mock,
+            patch(
+                'scripts.start_historical_simulation._wait_for_argocd_application_mode',
+                return_value={
+                    'app_name': 'torghut',
+                    'current_mode': 'manual',
+                },
+            ) as application_mode_mock,
         ):
             report = _prepare_argocd_for_run(config=config)
         automation_read_mock.assert_called_once()
-        application_mock.assert_called_once()
+        application_read_mock.assert_called_once_with(
+            namespace='argocd',
+            app_name='root',
+        )
+        root_application_mock.assert_called_once()
+        applicationset_mock.assert_called_once()
+        application_mode_mock.assert_called_once()
         self.assertTrue(report['changed'])
         self.assertIn('application', report)
-        self.assertFalse(report['applicationset_managed'])
+        self.assertIn('root_application', report)
+        self.assertTrue(report['applicationset_managed'])
         self.assertEqual(report['previous_mode'], 'auto')
-        self.assertEqual(report['current_mode'], 'auto')
+        self.assertEqual(report['current_mode'], 'manual')
 
-    def test_restore_argocd_after_run_restores_application_only(self) -> None:
+    def test_restore_argocd_after_run_restores_root_and_applicationset(self) -> None:
         config = ArgocdAutomationConfig(
             manage_automation=True,
             applicationset_name='product',
             applicationset_namespace='argocd',
             app_name='torghut',
+            root_app_name='root',
             desired_mode_during_run='manual',
             restore_mode_after_run='previous',
             verify_timeout_seconds=30,
@@ -1870,23 +1915,44 @@ class TestStartHistoricalSimulation(TestCase):
             'automated': {'enabled': True, 'prune': True, 'selfHeal': True},
             'syncOptions': ['CreateNamespace=true'],
         }
-        with patch(
-            'scripts.start_historical_simulation._set_argocd_application_sync_policy',
-            return_value={
-                'previous_sync_policy': {
-                    'automated': {'enabled': False, 'prune': False, 'selfHeal': False},
+        with (
+            patch(
+                'scripts.start_historical_simulation._set_argocd_automation_mode',
+                return_value={
+                    'pointer': '/spec/generators/0/list/elements/0/automation',
+                    'previous_mode': 'manual',
+                    'desired_mode': 'auto',
+                    'current_mode': 'auto',
+                    'changed': True,
                 },
-                'current_sync_policy': previous_sync_policy,
-                'changed': True,
-            },
-        ) as application_mock:
+            ) as applicationset_mock,
+            patch(
+                'scripts.start_historical_simulation._set_argocd_application_sync_policy',
+                return_value={
+                    'previous_sync_policy': {
+                        'automated': {'enabled': False, 'prune': False, 'selfHeal': False},
+                    },
+                    'current_sync_policy': previous_sync_policy,
+                    'changed': True,
+                },
+            ) as application_mock,
+            patch(
+                'scripts.start_historical_simulation._wait_for_argocd_application_mode',
+                return_value={
+                    'app_name': 'torghut',
+                    'current_mode': 'auto',
+                },
+            ) as application_mode_mock,
+        ):
             report = _restore_argocd_after_run(
                 config=config,
                 previous_mode='auto',
                 previous_sync_policy=previous_sync_policy,
             )
+        applicationset_mock.assert_called_once()
         application_mock.assert_called_once()
+        application_mode_mock.assert_called_once()
         self.assertTrue(report['changed'])
         self.assertEqual(report['restored_mode'], 'auto')
-        self.assertFalse(report['applicationset_managed'])
+        self.assertTrue(report['applicationset_managed'])
         self.assertEqual(report['current_mode'], 'auto')


### PR DESCRIPTION
## Summary

- pause the `root` Argo CD application before flipping the `product` ApplicationSet Torghut lane to manual for historical simulation runs
- verify child application mode from normalized manual/auto semantics instead of exact `syncPolicy` equality, which cannot hold under ApplicationSet-managed manual mode
- restore the layered Argo control plane on teardown and add regression coverage for the new root-plus-ApplicationSet flow

## Related Issues

None

## Testing

- `uv run --frozen ruff check services/torghut/scripts/start_historical_simulation.py services/torghut/tests/test_start_historical_simulation.py`
- `pytest services/torghut/tests/test_start_historical_simulation.py -q`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
