### PR TITLE
fix(torghut): initialize simulation runtime readiness

### DIFF
--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -15,6 +15,8 @@ spec:
     - name: forecastService
     - name: windowStart
     - name: windowEnd
+    - name: runtimeVerifyTimeoutSeconds
+    - name: runtimeVerifyPollSeconds
   metrics:
     - name: runtime-ready
       provider:
@@ -46,4 +48,6 @@ spec:
                         --forecast-service "{{args.forecastService}}"
                         --window-start "{{args.windowStart}}"
                         --window-end "{{args.windowEnd}}"
+                        --runtime-timeout-seconds "{{args.runtimeVerifyTimeoutSeconds}}"
+                        --runtime-poll-seconds "{{args.runtimeVerifyPollSeconds}}"
                         --json

--- a/services/torghut/scripts/run_simulation_analysis.py
+++ b/services/torghut/scripts/run_simulation_analysis.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import time
 from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
@@ -77,6 +78,8 @@ def _parser() -> argparse.ArgumentParser:
     runtime.add_argument('--forecast-service', required=True)
     runtime.add_argument('--window-start', required=True)
     runtime.add_argument('--window-end', required=True)
+    runtime.add_argument('--runtime-timeout-seconds', type=int, default=180)
+    runtime.add_argument('--runtime-poll-seconds', type=int, default=5)
 
     activity = subparsers.add_parser('activity')
     activity.add_argument('--json', action='store_true', help=argparse.SUPPRESS)
@@ -200,6 +203,25 @@ def _clickhouse_config(args: argparse.Namespace) -> _ClickHouseConfig:
     )
 
 
+def _wait_for_runtime_ready(
+    *,
+    resources: _Resources,
+    manifest: Mapping[str, Any],
+    timeout_seconds: int,
+    poll_seconds: int,
+) -> dict[str, Any]:
+    if timeout_seconds <= 0:
+        raise SystemExit('runtime-timeout-seconds must be > 0')
+    if poll_seconds <= 0:
+        raise SystemExit('runtime-poll-seconds must be > 0')
+    deadline = time.monotonic() + timeout_seconds
+    latest_report = _runtime_verify(resources=resources, manifest=manifest)
+    while latest_report.get('runtime_state') != 'ready' and time.monotonic() < deadline:
+        time.sleep(poll_seconds)
+        latest_report = _runtime_verify(resources=resources, manifest=manifest)
+    return latest_report
+
+
 def main() -> None:
     args = _parser().parse_args()
     if args.command == 'artifact-bundle':
@@ -213,7 +235,12 @@ def main() -> None:
     manifest = _manifest_from_args(args)
 
     if args.command == 'runtime-ready':
-        report = _runtime_verify(resources=resources, manifest=manifest)
+        report = _wait_for_runtime_ready(
+            resources=resources,
+            manifest=manifest,
+            timeout_seconds=args.runtime_timeout_seconds,
+            poll_seconds=args.runtime_poll_seconds,
+        )
         _emit(report, json_only=bool(args.json))
         if report.get('runtime_state') != 'ready':
             raise SystemExit(1)

--- a/services/torghut/scripts/start_historical_simulation.py
+++ b/services/torghut/scripts/start_historical_simulation.py
@@ -146,6 +146,9 @@ DEFAULT_ROLLOUTS_ACTIVITY_TEMPLATE = 'torghut-simulation-activity'
 DEFAULT_ROLLOUTS_TEARDOWN_TEMPLATE = 'torghut-simulation-teardown-clean'
 DEFAULT_ROLLOUTS_ARTIFACT_TEMPLATE = 'torghut-simulation-artifact-bundle'
 DEFAULT_ROLLOUTS_VERIFY_TIMEOUT_SECONDS = 1800
+DEFAULT_ROLLOUTS_VERIFY_POLL_SECONDS = 5
+SIMULATION_CLICKHOUSE_SCHEMA_SOURCE_DATABASE = 'torghut'
+SIMULATION_CLICKHOUSE_RUNTIME_TABLES = ('ta_microbars', 'ta_signals')
 TRANSIENT_POSTGRES_ERROR_PATTERNS = (
     'connection refused',
     'connection reset by peer',
@@ -347,6 +350,7 @@ class RolloutsAnalysisConfig:
     teardown_template: str
     artifact_template: str
     verify_timeout_seconds: int
+    verify_poll_seconds: int
 
 
 def _parse_args() -> argparse.Namespace:
@@ -1100,6 +1104,12 @@ def _build_rollouts_analysis_config(manifest: Mapping[str, Any]) -> RolloutsAnal
     )
     if verify_timeout_seconds <= 0:
         raise RuntimeError('rollouts.verify_timeout_seconds must be > 0')
+    verify_poll_seconds = _safe_int(
+        rollouts.get('verify_poll_seconds'),
+        default=DEFAULT_ROLLOUTS_VERIFY_POLL_SECONDS,
+    )
+    if verify_poll_seconds <= 0:
+        raise RuntimeError('rollouts.verify_poll_seconds must be > 0')
     return RolloutsAnalysisConfig(
         enabled=enabled,
         namespace=_as_text(rollouts.get('namespace')) or DEFAULT_ROLLOUTS_NAMESPACE,
@@ -1108,6 +1118,7 @@ def _build_rollouts_analysis_config(manifest: Mapping[str, Any]) -> RolloutsAnal
         teardown_template=_as_text(rollouts.get('teardown_template')) or DEFAULT_ROLLOUTS_TEARDOWN_TEMPLATE,
         artifact_template=_as_text(rollouts.get('artifact_template')) or DEFAULT_ROLLOUTS_ARTIFACT_TEMPLATE,
         verify_timeout_seconds=verify_timeout_seconds,
+        verify_poll_seconds=verify_poll_seconds,
     )
 
 
@@ -2021,6 +2032,69 @@ def _ensure_clickhouse_database(
     status, body = _http_clickhouse_query(config=config, query=create_query)
     if status < 200 or status >= 300:
         raise RuntimeError(f'clickhouse_create_database_failed:{status}:{body[:200]}')
+
+
+def _show_create_clickhouse_table(
+    *,
+    config: ClickHouseRuntimeConfig,
+    table: str,
+) -> str:
+    status, body = _http_clickhouse_query(config=config, query=f'SHOW CREATE TABLE {table}')
+    if status < 200 or status >= 300:
+        raise RuntimeError(f'clickhouse_show_create_failed:{table}:{status}:{body[:200]}')
+    ddl = body.strip()
+    if '\\n' in ddl:
+        ddl = ddl.replace('\\n', '\n')
+    if "\\'" in ddl:
+        ddl = ddl.replace("\\'", "'")
+    return ddl.strip()
+
+
+def _rewrite_clickhouse_table_ddl_for_simulation(
+    *,
+    source_ddl: str,
+    source_table: str,
+    database: str,
+    table: str,
+) -> str:
+    ddl = source_ddl.strip().rstrip(';')
+    ddl = ddl.replace(
+        f'CREATE TABLE {source_table}',
+        f'CREATE TABLE IF NOT EXISTS {database}.{table}',
+        1,
+    )
+    engine_pattern = re.compile(
+        r"ReplicatedReplacingMergeTree\('([^']+)',\s*'\{replica\}'",
+        re.MULTILINE,
+    )
+    replicated_path = f"/clickhouse/tables/{{cluster}}/{{shard}}/{database}/{table}"
+    if not engine_pattern.search(ddl):
+        raise RuntimeError(f'clickhouse_schema_missing_replicated_engine:{source_table}')
+    ddl = engine_pattern.sub(
+        f"ReplicatedReplacingMergeTree('{replicated_path}', '{{replica}}'",
+        ddl,
+        count=1,
+    )
+    return ddl
+
+
+def _ensure_clickhouse_runtime_tables(
+    *,
+    config: ClickHouseRuntimeConfig,
+    database: str,
+) -> None:
+    for table in SIMULATION_CLICKHOUSE_RUNTIME_TABLES:
+        source_table = f'{SIMULATION_CLICKHOUSE_SCHEMA_SOURCE_DATABASE}.{table}'
+        source_ddl = _show_create_clickhouse_table(config=config, table=source_table)
+        create_query = _rewrite_clickhouse_table_ddl_for_simulation(
+            source_ddl=source_ddl,
+            source_table=source_table,
+            database=database,
+            table=table,
+        )
+        status, body = _http_clickhouse_query(config=config, query=create_query)
+        if status < 200 or status >= 300:
+            raise RuntimeError(f'clickhouse_create_table_failed:{database}.{table}:{status}:{body[:200]}')
 
 
 def _ensure_postgres_database(config: PostgresRuntimeConfig) -> None:
@@ -3124,6 +3198,7 @@ def _apply(
         manifest=manifest,
     )
     _ensure_clickhouse_database(config=clickhouse_config, database=resources.clickhouse_db)
+    _ensure_clickhouse_runtime_tables(config=clickhouse_config, database=resources.clickhouse_db)
     _ensure_postgres_database(postgres_config)
     postgres_permissions_report = _ensure_postgres_runtime_permissions(postgres_config)
     _run_migrations(postgres_config)
@@ -3550,6 +3625,7 @@ def _analysis_run_args(
     manifest: Mapping[str, Any],
     postgres_config: PostgresRuntimeConfig,
     clickhouse_config: ClickHouseRuntimeConfig,
+    rollouts_config: RolloutsAnalysisConfig,
 ) -> dict[str, str]:
     window_start, window_end = _resolve_window_bounds(manifest)
     args: dict[str, str] = {
@@ -3568,6 +3644,8 @@ def _analysis_run_args(
         'postgresDatabase': postgres_config.simulation_db,
         'clickhouseHttpUrl': clickhouse_config.http_url,
         'clickhouseUsername': clickhouse_config.username or '',
+        'runtimeVerifyTimeoutSeconds': str(rollouts_config.verify_timeout_seconds),
+        'runtimeVerifyPollSeconds': str(rollouts_config.verify_poll_seconds),
     }
     monitor = _as_mapping(manifest.get('monitor'))
     if phase == 'activity':
@@ -3719,6 +3797,7 @@ def _run_rollouts_analysis(
             manifest=manifest,
             postgres_config=postgres_config,
             clickhouse_config=clickhouse_config,
+            rollouts_config=rollouts_config,
         ),
     )
     _kubectl_apply(rollouts_config.namespace, payload)

--- a/services/torghut/tests/test_run_simulation_analysis.py
+++ b/services/torghut/tests/test_run_simulation_analysis.py
@@ -48,6 +48,54 @@ class TestRunSimulationAnalysis(TestCase):
         payload = json.loads(stdout.getvalue())
         self.assertEqual(payload['runtime_state'], 'ready')
 
+    def test_runtime_ready_waits_until_runtime_is_ready(self) -> None:
+        stdout = io.StringIO()
+        with (
+            patch(
+                'sys.argv',
+                [
+                    'run_simulation_analysis.py',
+                    'runtime-ready',
+                    '--run-id',
+                    'sim-1',
+                    '--dataset-id',
+                    'dataset-a',
+                    '--namespace',
+                    'torghut',
+                    '--torghut-service',
+                    'torghut-sim',
+                    '--ta-deployment',
+                    'torghut-ta-sim',
+                    '--forecast-service',
+                    'torghut-forecast-sim',
+                    '--window-start',
+                    '2026-03-06T14:30:00Z',
+                    '--window-end',
+                    '2026-03-06T15:30:00Z',
+                    '--runtime-timeout-seconds',
+                    '30',
+                    '--runtime-poll-seconds',
+                    '1',
+                    '--json',
+                ],
+            ),
+            patch(
+                'scripts.run_simulation_analysis._runtime_verify',
+                side_effect=[
+                    {'runtime_state': 'not_ready', 'environment_state': 'complete'},
+                    {'runtime_state': 'ready', 'environment_state': 'complete'},
+                ],
+            ) as verify_mock,
+            patch('scripts.run_simulation_analysis.time.sleep', return_value=None) as sleep_mock,
+            redirect_stdout(stdout),
+        ):
+            main()
+
+        self.assertEqual(verify_mock.call_count, 2)
+        sleep_mock.assert_called_once_with(1)
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(payload['runtime_state'], 'ready')
+
     def test_activity_exits_nonzero_when_report_is_degraded(self) -> None:
         stdout = io.StringIO()
         with (

--- a/services/torghut/tests/test_start_historical_simulation.py
+++ b/services/torghut/tests/test_start_historical_simulation.py
@@ -472,6 +472,54 @@ class TestStartHistoricalSimulation(TestCase):
         self.assertEqual(headers.get('X-ClickHouse-User'), 'torghut')
         self.assertEqual(headers.get('X-ClickHouse-Key'), 'secret')
 
+    def test_ensure_clickhouse_runtime_tables_clones_simulation_schema(self) -> None:
+        queries: list[str] = []
+        source_microbars = (
+            "CREATE TABLE torghut.ta_microbars\\n"
+            "(\\n`symbol` LowCardinality(String)\\n)\\n"
+            "ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{cluster}/{shard}/ta_microbars', '{replica}', ingest_ts)"
+        )
+        source_signals = (
+            "CREATE TABLE torghut.ta_signals\\n"
+            "(\\n`symbol` LowCardinality(String)\\n)\\n"
+            "ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{cluster}/{shard}/ta_signals', '{replica}', ingest_ts)"
+        )
+
+        def _fake_clickhouse_query(*, config: ClickHouseRuntimeConfig, query: str) -> tuple[int, str]:
+            _ = config
+            queries.append(query)
+            if query == 'SHOW CREATE TABLE torghut.ta_microbars':
+                return 200, source_microbars
+            if query == 'SHOW CREATE TABLE torghut.ta_signals':
+                return 200, source_signals
+            return 200, ''
+
+        with patch(
+            'scripts.start_historical_simulation._http_clickhouse_query',
+            side_effect=_fake_clickhouse_query,
+        ):
+            start_historical_simulation._ensure_clickhouse_runtime_tables(
+                config=ClickHouseRuntimeConfig(
+                    http_url='http://clickhouse:8123',
+                    username='torghut',
+                    password='secret',
+                ),
+                database='torghut_sim_sim_1',
+            )
+
+        self.assertEqual(queries[0], 'SHOW CREATE TABLE torghut.ta_microbars')
+        self.assertIn('CREATE TABLE IF NOT EXISTS torghut_sim_sim_1.ta_microbars', queries[1])
+        self.assertIn(
+            "/clickhouse/tables/{cluster}/{shard}/torghut_sim_sim_1/ta_microbars",
+            queries[1],
+        )
+        self.assertEqual(queries[2], 'SHOW CREATE TABLE torghut.ta_signals')
+        self.assertIn('CREATE TABLE IF NOT EXISTS torghut_sim_sim_1.ta_signals', queries[3])
+        self.assertIn(
+            "/clickhouse/tables/{cluster}/{shard}/torghut_sim_sim_1/ta_signals",
+            queries[3],
+        )
+
     def test_ensure_topics_caps_partitions_to_available_brokers(self) -> None:
         resources = _build_resources(
             'sim-1',
@@ -1479,6 +1527,7 @@ class TestStartHistoricalSimulation(TestCase):
             teardown_template='torghut-teardown-v1',
             artifact_template='torghut-artifact-v1',
             verify_timeout_seconds=900,
+            verify_poll_seconds=5,
         )
 
         with (
@@ -1605,6 +1654,7 @@ class TestStartHistoricalSimulation(TestCase):
         self.assertEqual(config.runtime_template, 'torghut-simulation-runtime-ready')
         self.assertEqual(config.activity_template, 'torghut-simulation-activity')
         self.assertEqual(config.teardown_template, 'torghut-simulation-teardown-clean')
+        self.assertEqual(config.verify_poll_seconds, 5)
 
     def test_run_rollouts_analysis_materializes_analysisrun_from_template(self) -> None:
         resources = _build_resources('sim-2026-03-06-open-hour', {'dataset_id': 'dataset-a'})
@@ -1642,6 +1692,7 @@ class TestStartHistoricalSimulation(TestCase):
             teardown_template='torghut-simulation-teardown-clean',
             artifact_template='torghut-simulation-artifact-bundle',
             verify_timeout_seconds=60,
+            verify_poll_seconds=5,
         )
         captured_apply: dict[str, object] = {}
 
@@ -1659,6 +1710,8 @@ class TestStartHistoricalSimulation(TestCase):
                             {'name': 'forecastService'},
                             {'name': 'windowStart'},
                             {'name': 'windowEnd'},
+                            {'name': 'runtimeVerifyTimeoutSeconds'},
+                            {'name': 'runtimeVerifyPollSeconds'},
                         ],
                         'metrics': [{'name': 'runtime-ready'}],
                     }
@@ -1691,6 +1744,8 @@ class TestStartHistoricalSimulation(TestCase):
         assert isinstance(payload, dict)
         self.assertEqual(payload['kind'], 'AnalysisRun')
         self.assertEqual(payload['metadata']['name'], 'torghut-sim-runtime-ready-sim-2026-03-06-open-hour')
+        self.assertEqual(payload['spec']['args'][-2]['value'], '60')
+        self.assertEqual(payload['spec']['args'][-1]['value'], '5')
 
     def test_discover_automation_pointer_finds_nested_element(self) -> None:
         payload = {


### PR DESCRIPTION
## Summary

- initialize the isolated ClickHouse simulation tables before TA/Flink starts so the dedicated simulation lane stops crashing on missing `ta_signals` / `ta_microbars` tables
- make the runtime-ready analysis job poll until the dedicated sim runtime actually becomes ready instead of failing on the first cold-start probe
- pass the runtime verify timeout/poll settings through the runtime-ready AnalysisTemplate and add focused regression coverage for both fixes

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen ruff check scripts/start_historical_simulation.py scripts/run_simulation_analysis.py ../torghut/tests/test_start_historical_simulation.py ../torghut/tests/test_run_simulation_analysis.py`
- `cd services/torghut && uv run --frozen pytest tests/test_start_historical_simulation.py tests/test_run_simulation_analysis.py -q`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
