### PR TITLE
chore(torghut): promote image 89a4ff3a

### DIFF
--- a/argocd/applications/torghut-forecast/deployment.yaml
+++ b/argocd/applications/torghut-forecast/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: forecast
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:7fcc6065164aecf6f266b119b52fc207b5917436190d0aa38b77ae1c0872f63a
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:7472ac7dca6e4aeb49dc18f733655874cc560e2b3a6978bb7455f546023f2866
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn

--- a/argocd/applications/torghut-forecast/sim/deployment.yaml
+++ b/argocd/applications/torghut-forecast/sim/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: forecast
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:7fcc6065164aecf6f266b119b52fc207b5917436190d0aa38b77ae1c0872f63a
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:7472ac7dca6e4aeb49dc18f733655874cc560e2b3a6978bb7455f546023f2866
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -40,7 +40,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:7fcc6065164aecf6f266b119b52fc207b5917436190d0aa38b77ae1c0872f63a
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:7472ac7dca6e4aeb49dc18f733655874cc560e2b3a6978bb7455f546023f2866
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -21,7 +21,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:7fcc6065164aecf6f266b119b52fc207b5917436190d0aa38b77ae1c0872f63a
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:7472ac7dca6e4aeb49dc18f733655874cc560e2b3a6978bb7455f546023f2866
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -28,7 +28,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:7fcc6065164aecf6f266b119b52fc207b5917436190d0aa38b77ae1c0872f63a
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:7472ac7dca6e4aeb49dc18f733655874cc560e2b3a6978bb7455f546023f2866
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -30,7 +30,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:7fcc6065164aecf6f266b119b52fc207b5917436190d0aa38b77ae1c0872f63a
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:7472ac7dca6e4aeb49dc18f733655874cc560e2b3a6978bb7455f546023f2866
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:7fcc6065164aecf6f266b119b52fc207b5917436190d0aa38b77ae1c0872f63a
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:7472ac7dca6e4aeb49dc18f733655874cc560e2b3a6978bb7455f546023f2866
           command:
             - alembic
           args:

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -13,7 +13,7 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:7fcc6065164aecf6f266b119b52fc207b5917436190d0aa38b77ae1c0872f63a
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:7472ac7dca6e4aeb49dc18f733655874cc560e2b3a6978bb7455f546023f2866
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -21,7 +21,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:7fcc6065164aecf6f266b119b52fc207b5917436190d0aa38b77ae1c0872f63a
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:7472ac7dca6e4aeb49dc18f733655874cc560e2b3a6978bb7455f546023f2866
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -39,7 +39,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:7fcc6065164aecf6f266b119b52fc207b5917436190d0aa38b77ae1c0872f63a
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:7472ac7dca6e4aeb49dc18f733655874cc560e2b3a6978bb7455f546023f2866
       imagePullPolicy: Always
       env:
         - name: TORGHUT_SIM_KAFKA_PASSWORD

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-03-07T08:51:32Z"
+        client.knative.dev/updateTimestamp: "2026-03-07T09:24:31Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:7fcc6065164aecf6f266b119b52fc207b5917436190d0aa38b77ae1c0872f63a
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:7472ac7dca6e4aeb49dc18f733655874cc560e2b3a6978bb7455f546023f2866
           ports:
             - name: http1
               containerPort: 8181
@@ -458,9 +458,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.562.0-397-g294e49ae
+              value: v0.562.0-399-g89a4ff3a
             - name: TORGHUT_COMMIT
-              value: 294e49ae76dbb85cca89bb19acba6a97a19472a8
+              value: 89a4ff3a26416a77117b8bbe509877fe925d7425
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-03-07T08:51:32Z"
+        client.knative.dev/updateTimestamp: "2026-03-07T09:24:31Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -26,7 +26,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:7fcc6065164aecf6f266b119b52fc207b5917436190d0aa38b77ae1c0872f63a
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:7472ac7dca6e4aeb49dc18f733655874cc560e2b3a6978bb7455f546023f2866
           ports:
             - name: http1
               containerPort: 8181
@@ -456,9 +456,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.562.0-397-g294e49ae
+              value: v0.562.0-399-g89a4ff3a
             - name: TORGHUT_COMMIT
-              value: 294e49ae76dbb85cca89bb19acba6a97a19472a8
+              value: 89a4ff3a26416a77117b8bbe509877fe925d7425
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/lean-runner-deployment.yaml
+++ b/argocd/applications/torghut/lean-runner-deployment.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: lean-runner
           # Keep in lockstep with `argocd/applications/torghut/knative-service.yaml`.
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:7fcc6065164aecf6f266b119b52fc207b5917436190d0aa38b77ae1c0872f63a
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:7472ac7dca6e4aeb49dc18f733655874cc560e2b3a6978bb7455f546023f2866
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `89a4ff3a26416a77117b8bbe509877fe925d7425`
- Image tag: `89a4ff3a`
- Image digest: `sha256:7472ac7dca6e4aeb49dc18f733655874cc560e2b3a6978bb7455f546023f2866`