### PR TITLE
fix(torghut): unblock historical simulation dump

### DIFF
--- a/services/torghut/scripts/start_historical_simulation.py
+++ b/services/torghut/scripts/start_historical_simulation.py
@@ -2886,6 +2886,11 @@ def _dump_topics(
                             min_source_timestamp_ms = source_timestamp_ms
                         if max_source_timestamp_ms is None or source_timestamp_ms > max_source_timestamp_ms:
                             max_source_timestamp_ms = source_timestamp_ms
+                        # kafka-python position() may lag the exclusive stop offset until a later poll.
+                        # Mark the partition complete as soon as we write the final in-window record.
+                        if int(record.offset) + 1 >= stop_offset:
+                            done.add(tp)
+                            break
                     if consumer.position(tp) >= stop_offset:
                         done.add(tp)
 

--- a/services/torghut/tests/test_start_historical_simulation.py
+++ b/services/torghut/tests/test_start_historical_simulation.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from dataclasses import replace
 from datetime import datetime, timezone
 from types import SimpleNamespace
 from pathlib import Path
@@ -1021,6 +1022,119 @@ class TestStartHistoricalSimulation(TestCase):
                     dump_path=dump_path,
                     force=False,
                 )
+
+    def test_dump_topics_completes_when_last_record_reaches_stop_offset(self) -> None:
+        resources = _build_resources(
+            'sim-1',
+            {
+                'dataset_id': 'dataset-a',
+            },
+        )
+        resources = replace(
+            resources,
+            replay_topic_by_source_topic={'torghut.trades.v1': 'torghut.sim.trades.v1'},
+        )
+        kafka_config = KafkaRuntimeConfig(
+            bootstrap_servers='kafka:9092',
+            security_protocol=None,
+            sasl_mechanism=None,
+            sasl_username=None,
+            sasl_password=None,
+        )
+
+        class _OffsetMeta:
+            def __init__(self, offset: int) -> None:
+                self.offset = offset
+
+        class _Record:
+            def __init__(self, topic: str, partition: int, offset: int, timestamp: int) -> None:
+                self.topic = topic
+                self.partition = partition
+                self.offset = offset
+                self.timestamp = timestamp
+                self.key = None
+                self.value = None
+                self.headers: list[tuple[str, bytes]] = []
+
+        class _FakeConsumer:
+            def __init__(self) -> None:
+                self._tp = ('torghut.trades.v1', 0)
+                self._position = 0
+                self._poll_calls = 0
+                self._offset_lookup_calls = 0
+
+            def partitions_for_topic(self, topic: str) -> set[int]:
+                self._topic = topic
+                return {0}
+
+            def assign(self, topic_partitions: list[tuple[str, int]]) -> None:
+                self._topic_partitions = topic_partitions
+
+            def beginning_offsets(self, topic_partitions: list[tuple[str, int]]) -> dict[tuple[str, int], int]:
+                return {tp: 0 for tp in topic_partitions}
+
+            def end_offsets(self, topic_partitions: list[tuple[str, int]]) -> dict[tuple[str, int], int]:
+                return {tp: 3 for tp in topic_partitions}
+
+            def offsets_for_times(
+                self,
+                request: dict[tuple[str, int], int],
+            ) -> dict[tuple[str, int], _OffsetMeta]:
+                self._offset_lookup_calls += 1
+                offset = 0 if self._offset_lookup_calls == 1 else 3
+                return {tp: _OffsetMeta(offset) for tp in request}
+
+            def seek(self, tp: tuple[str, int], offset: int) -> None:
+                self._position = offset
+
+            def poll(self, timeout_ms: int = 0, max_records: int = 0) -> dict[tuple[str, int], list[_Record]]:
+                _ = (timeout_ms, max_records)
+                self._poll_calls += 1
+                if self._poll_calls == 1:
+                    return {
+                        self._tp: [
+                            _Record(self._tp[0], self._tp[1], 0, 1735693200000),
+                            _Record(self._tp[0], self._tp[1], 1, 1735693200100),
+                            _Record(self._tp[0], self._tp[1], 2, 1735693200200),
+                        ]
+                    }
+                if self._poll_calls > 5:
+                    raise AssertionError('dump loop did not terminate after final in-window record')
+                return {}
+
+            def position(self, tp: tuple[str, int]) -> int:
+                _ = tp
+                # Simulate the live failure: consumer position stays on the last written offset.
+                return 2
+
+            def close(self) -> None:
+                return None
+
+        with TemporaryDirectory() as tmp_dir:
+            dump_path = Path(tmp_dir) / 'source-dump.ndjson'
+            fake_consumer = _FakeConsumer()
+
+            with (
+                patch.dict(
+                    'sys.modules',
+                    {'kafka': SimpleNamespace(TopicPartition=lambda topic, partition: (topic, partition))},
+                ),
+                patch(
+                    'scripts.start_historical_simulation._consumer_for_dump',
+                    return_value=fake_consumer,
+                ),
+            ):
+                report = _dump_topics(
+                    resources=resources,
+                    kafka_config=kafka_config,
+                    manifest={'window': {'start': '2025-01-01T00:00:00Z', 'end': '2025-01-01T00:00:01Z'}},
+                    dump_path=dump_path,
+                    force=True,
+                )
+
+            self.assertEqual(report['records'], 3)
+            self.assertEqual(report['records_by_topic'], {'torghut.trades.v1': 3})
+            self.assertFalse(report['reused_existing_dump'])
 
     def test_verify_isolation_guards_rejects_simulation_topic_overlap(self) -> None:
         resources = _build_resources(


### PR DESCRIPTION
## Summary

- mark Kafka dump partitions complete when the final in-window record reaches the exclusive stop offset instead of waiting for a later poll
- add a regression test covering the live stop-offset stall where the consumer position never advances past the last dumped record
- unblock the dedicated historical simulation workflow so it can leave `dataset_prepare` and reach runtime apply on real replay windows

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen ruff check scripts/start_historical_simulation.py tests/test_start_historical_simulation.py`
- `cd services/torghut && uv run --frozen pytest tests/test_start_historical_simulation.py -q`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
