### PR TITLE
chore(torghut): promote image 955e7bd6

### DIFF
--- a/argocd/applications/torghut-forecast/deployment.yaml
+++ b/argocd/applications/torghut-forecast/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: forecast
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:84ea9ce44ec50f2e16dd7792c981194c052db5d775565cd3f350851778cc08f6
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:276228ffb5e1974af1bd73d51fba17bf68103c8c04a3739c5034d37c882973aa
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn

--- a/argocd/applications/torghut-forecast/sim/deployment.yaml
+++ b/argocd/applications/torghut-forecast/sim/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: forecast
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:84ea9ce44ec50f2e16dd7792c981194c052db5d775565cd3f350851778cc08f6
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:276228ffb5e1974af1bd73d51fba17bf68103c8c04a3739c5034d37c882973aa
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -40,7 +40,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:84ea9ce44ec50f2e16dd7792c981194c052db5d775565cd3f350851778cc08f6
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:276228ffb5e1974af1bd73d51fba17bf68103c8c04a3739c5034d37c882973aa
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -21,7 +21,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:84ea9ce44ec50f2e16dd7792c981194c052db5d775565cd3f350851778cc08f6
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:276228ffb5e1974af1bd73d51fba17bf68103c8c04a3739c5034d37c882973aa
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -30,7 +30,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:84ea9ce44ec50f2e16dd7792c981194c052db5d775565cd3f350851778cc08f6
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:276228ffb5e1974af1bd73d51fba17bf68103c8c04a3739c5034d37c882973aa
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -30,7 +30,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:84ea9ce44ec50f2e16dd7792c981194c052db5d775565cd3f350851778cc08f6
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:276228ffb5e1974af1bd73d51fba17bf68103c8c04a3739c5034d37c882973aa
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:84ea9ce44ec50f2e16dd7792c981194c052db5d775565cd3f350851778cc08f6
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:276228ffb5e1974af1bd73d51fba17bf68103c8c04a3739c5034d37c882973aa
           command:
             - alembic
           args:

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -13,7 +13,7 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:84ea9ce44ec50f2e16dd7792c981194c052db5d775565cd3f350851778cc08f6
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:276228ffb5e1974af1bd73d51fba17bf68103c8c04a3739c5034d37c882973aa
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -21,7 +21,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:84ea9ce44ec50f2e16dd7792c981194c052db5d775565cd3f350851778cc08f6
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:276228ffb5e1974af1bd73d51fba17bf68103c8c04a3739c5034d37c882973aa
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -39,7 +39,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:84ea9ce44ec50f2e16dd7792c981194c052db5d775565cd3f350851778cc08f6
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:276228ffb5e1974af1bd73d51fba17bf68103c8c04a3739c5034d37c882973aa
       imagePullPolicy: Always
       env:
         - name: TORGHUT_SIM_KAFKA_PASSWORD

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-03-07T09:27:57Z"
+        client.knative.dev/updateTimestamp: "2026-03-07T09:49:15Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:84ea9ce44ec50f2e16dd7792c981194c052db5d775565cd3f350851778cc08f6
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:276228ffb5e1974af1bd73d51fba17bf68103c8c04a3739c5034d37c882973aa
           ports:
             - name: http1
               containerPort: 8181
@@ -458,9 +458,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.562.0-400-g1697fd27
+              value: v0.562.0-402-g955e7bd6
             - name: TORGHUT_COMMIT
-              value: 1697fd2713f6e41119522bfa90198df026ade44c
+              value: 955e7bd633866e4b3768e937db16ff6df6ec3e09
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-03-07T09:27:57Z"
+        client.knative.dev/updateTimestamp: "2026-03-07T09:49:15Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -26,7 +26,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:84ea9ce44ec50f2e16dd7792c981194c052db5d775565cd3f350851778cc08f6
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:276228ffb5e1974af1bd73d51fba17bf68103c8c04a3739c5034d37c882973aa
           ports:
             - name: http1
               containerPort: 8181
@@ -456,9 +456,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.562.0-400-g1697fd27
+              value: v0.562.0-402-g955e7bd6
             - name: TORGHUT_COMMIT
-              value: 1697fd2713f6e41119522bfa90198df026ade44c
+              value: 955e7bd633866e4b3768e937db16ff6df6ec3e09
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/lean-runner-deployment.yaml
+++ b/argocd/applications/torghut/lean-runner-deployment.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: lean-runner
           # Keep in lockstep with `argocd/applications/torghut/knative-service.yaml`.
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:84ea9ce44ec50f2e16dd7792c981194c052db5d775565cd3f350851778cc08f6
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:276228ffb5e1974af1bd73d51fba17bf68103c8c04a3739c5034d37c882973aa
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `955e7bd633866e4b3768e937db16ff6df6ec3e09`
- Image tag: `955e7bd6`
- Image digest: `sha256:276228ffb5e1974af1bd73d51fba17bf68103c8c04a3739c5034d37c882973aa`