### PR TITLE
fix(torghut): replay after sim runtime is ready

### DIFF
--- a/services/torghut/scripts/start_historical_simulation.py
+++ b/services/torghut/scripts/start_historical_simulation.py
@@ -1008,10 +1008,15 @@ def _build_resources(run_id: str, manifest: Mapping[str, Any]) -> SimulationReso
         PRODUCTION_TOPIC_BY_ROLE,
         _as_mapping(manifest.get('source_topics')),
     )
+    simulation_topic_overrides = _as_mapping(manifest.get('simulation_topics'))
     simulation_topics = _merge_topics(
         SIMULATION_TOPIC_BY_ROLE,
-        _as_mapping(manifest.get('simulation_topics')),
+        simulation_topic_overrides,
     )
+    for role, topic in list(simulation_topics.items()):
+        if role in simulation_topic_overrides:
+            continue
+        simulation_topics[role] = f'{topic}.{run_token}'
 
     replay_topic_by_source_topic = {
         source_topics['trades']: simulation_topics['trades'],
@@ -3219,14 +3224,6 @@ def _apply(
         manifest=manifest,
         dump_report=dump_report,
     )
-    replay_report = _replay_dump(
-        resources=resources,
-        kafka_config=kafka_config,
-        manifest=manifest,
-        dump_path=dump_path,
-        force=force_replay,
-    )
-
     replay_cfg = _as_mapping(manifest.get('replay'))
     auto_offset_reset = (_as_text(replay_cfg.get('auto_offset_reset')) or 'earliest').lower()
     _configure_ta_for_simulation(
@@ -3254,7 +3251,6 @@ def _apply(
         'state_path': str(state_path),
         'dump': dump_report,
         'dump_coverage': dump_coverage,
-        'replay': replay_report,
         'topics': topics_report,
         'ta_restart_nonce': ta_restart_nonce,
         'resources': asdict(resources)
@@ -3274,7 +3270,6 @@ def _apply(
         'window_policy': window_policy,
     }
     _save_json(run_manifest_path, report)
-    _save_json(_artifact_path(resources, 'replay-report.json'), replay_report)
     return report
 
 
@@ -3882,6 +3877,7 @@ def _run_full_lifecycle(
     argocd_prepare_report: dict[str, Any] | None = None
     argocd_restore_report: dict[str, Any] | None = None
     apply_report: dict[str, Any] | None = None
+    replay_report: dict[str, Any] | None = None
     runtime_verify_report: dict[str, Any] | None = None
     monitor_report: dict[str, Any] | None = None
     analytics_report: dict[str, Any] | None = None
@@ -3992,6 +3988,22 @@ def _run_full_lifecycle(
             ):
                 errors.append('environment_incomplete')
 
+            _update_run_state(resources=resources, phase='replay', status='running')
+            replay_report = _replay_dump(
+                resources=resources,
+                kafka_config=kafka_config,
+                manifest=manifest,
+                dump_path=_state_paths(resources)[2],
+                force=force_replay,
+            )
+            _save_json(_artifact_path(resources, 'replay-report.json'), replay_report)
+            _update_run_state(
+                resources=resources,
+                phase='replay',
+                status='ok',
+                details=replay_report,
+            )
+
             _update_run_state(resources=resources, phase='activity_verify', status='running')
             if bool(rollouts_report['enabled']):
                 activity_analysis_run = _run_rollouts_analysis(
@@ -4063,6 +4075,12 @@ def _run_full_lifecycle(
             _update_run_state(
                 resources=resources,
                 phase='runtime_verify',
+                status='skipped',
+                details={'report_only': True},
+            )
+            _update_run_state(
+                resources=resources,
+                phase='replay',
                 status='skipped',
                 details={'report_only': True},
             )
@@ -4181,6 +4199,7 @@ def _run_full_lifecycle(
         'argocd_prepare': argocd_prepare_report,
         'argocd_restore': argocd_restore_report,
         'apply': apply_report,
+        'replay': replay_report,
         'runtime_verify': runtime_verify_report,
         'monitor': monitor_report,
         'report': analytics_report,
@@ -4191,6 +4210,7 @@ def _run_full_lifecycle(
     run_manifest_path = _state_paths(resources)[1]
     if apply_report is not None:
         updated_apply_report = dict(apply_report)
+        updated_apply_report['replay'] = replay_report
         updated_apply_report['rollouts'] = rollouts_report
         _save_json(run_manifest_path, updated_apply_report)
     _save_json(run_manifest_path.with_name('run-full-lifecycle-manifest.json'), report)

--- a/services/torghut/tests/test_start_historical_simulation.py
+++ b/services/torghut/tests/test_start_historical_simulation.py
@@ -80,10 +80,13 @@ class TestStartHistoricalSimulation(TestCase):
         self.assertEqual(resources.ta_group_id, 'torghut-ta-sim-sim_2026_02_27_01')
         self.assertEqual(resources.order_feed_group_id, 'torghut-order-feed-sim-sim_2026_02_27_01')
         self.assertEqual(resources.clickhouse_signal_table, 'torghut_sim_sim_2026_02_27_01.ta_signals')
-        self.assertEqual(resources.simulation_topic_by_role['order_updates'], 'torghut.sim.trade-updates.v1')
+        self.assertEqual(
+            resources.simulation_topic_by_role['order_updates'],
+            'torghut.sim.trade-updates.v1.sim_2026_02_27_01',
+        )
         self.assertEqual(
             resources.replay_topic_by_source_topic['torghut.trades.v1'],
-            'torghut.sim.trades.v1',
+            'torghut.sim.trades.v1.sim_2026_02_27_01',
         )
 
     def test_build_postgres_runtime_config_uses_template(self) -> None:
@@ -1650,6 +1653,7 @@ class TestStartHistoricalSimulation(TestCase):
             patch('scripts.start_historical_simulation._save_json', return_value=None),
             patch('scripts.start_historical_simulation._apply', return_value={'status': 'ok'}),
             patch('scripts.start_historical_simulation._runtime_verify', return_value={'runtime_state': 'ready'}),
+            patch('scripts.start_historical_simulation._replay_dump', return_value={'status': 'ok'}),
             patch(
                 'scripts.start_historical_simulation._monitor_run_completion',
                 return_value={
@@ -1675,6 +1679,120 @@ class TestStartHistoricalSimulation(TestCase):
                     skip_teardown=True,
                     report_only=False,
                 )
+
+    def test_run_full_lifecycle_replays_after_runtime_verify(self) -> None:
+        resources = _build_resources(
+            'sim-1',
+            {
+                'dataset_id': 'dataset-a',
+            },
+        )
+        manifest = {
+            'dataset_id': 'dataset-a',
+            'window': {
+                'start': '2026-02-27T14:30:00Z',
+                'end': '2026-02-27T21:00:00Z',
+            },
+        }
+        kafka_config = KafkaRuntimeConfig(
+            bootstrap_servers='kafka:9092',
+            security_protocol=None,
+            sasl_mechanism=None,
+            sasl_username=None,
+            sasl_password=None,
+        )
+        clickhouse_config = ClickHouseRuntimeConfig(
+            http_url='http://clickhouse:8123',
+            username='torghut',
+            password=None,
+        )
+        postgres_config = PostgresRuntimeConfig(
+            admin_dsn='postgresql://torghut:secret@localhost:5432/postgres',
+            simulation_dsn='postgresql://torghut:secret@localhost:5432/torghut_sim_sim_1',
+            simulation_db='torghut_sim_sim_1',
+            migrations_command='true',
+        )
+        argocd_config = ArgocdAutomationConfig(
+            manage_automation=False,
+            applicationset_name='product',
+            applicationset_namespace='argocd',
+            app_name='torghut',
+            root_app_name='root',
+            desired_mode_during_run='manual',
+            restore_mode_after_run='previous',
+            verify_timeout_seconds=600,
+        )
+        rollouts_config = RolloutsAnalysisConfig(
+            enabled=False,
+            namespace='agents',
+            runtime_template='torghut-runtime-ready-v1',
+            activity_template='torghut-sim-activity-v1',
+            teardown_template='torghut-teardown-v1',
+            artifact_template='torghut-artifact-v1',
+            verify_timeout_seconds=900,
+            verify_poll_seconds=5,
+        )
+        call_order: list[str] = []
+
+        with (
+            patch('scripts.start_historical_simulation._ensure_supported_binary', return_value=None),
+            patch('scripts.start_historical_simulation._update_run_state', return_value=None),
+            patch('scripts.start_historical_simulation._save_json', return_value=None),
+            patch('scripts.start_historical_simulation._prepare_argocd_for_run', return_value={'managed': False}),
+            patch('scripts.start_historical_simulation._restore_argocd_after_run', return_value={'managed': False}),
+            patch(
+                'scripts.start_historical_simulation._apply',
+                side_effect=lambda **_: call_order.append('apply') or {'status': 'ok'},
+            ),
+            patch(
+                'scripts.start_historical_simulation._runtime_verify',
+                side_effect=lambda **_: call_order.append('runtime_verify') or {'runtime_state': 'ready'},
+            ),
+            patch(
+                'scripts.start_historical_simulation._replay_dump',
+                side_effect=lambda **_: call_order.append('replay') or {'status': 'ok'},
+            ),
+            patch(
+                'scripts.start_historical_simulation._monitor_run_completion',
+                side_effect=lambda **_: call_order.append('monitor')
+                or {
+                    'status': 'ok',
+                    'activity_classification': 'success',
+                    'final_snapshot': {
+                        'signal_rows': 5,
+                        'price_rows': 5,
+                        'trade_decisions': 3,
+                        'cursor_at': '2026-02-27T21:00:00Z',
+                        'executions': 2,
+                        'execution_tca_metrics': 2,
+                        'execution_order_events': 2,
+                    },
+                },
+            ),
+            patch(
+                'scripts.start_historical_simulation._report_simulation',
+                side_effect=lambda **_: call_order.append('report') or {'status': 'ok'},
+            ),
+        ):
+            _run_full_lifecycle(
+                resources=resources,
+                manifest=manifest,
+                manifest_path=Path('/tmp/manifest.json'),
+                kafka_config=kafka_config,
+                clickhouse_config=clickhouse_config,
+                postgres_config=postgres_config,
+                argocd_config=argocd_config,
+                rollouts_config=rollouts_config,
+                force_dump=False,
+                force_replay=False,
+                skip_teardown=True,
+                report_only=False,
+            )
+
+        self.assertEqual(
+            call_order,
+            ['apply', 'runtime_verify', 'replay', 'monitor', 'report'],
+        )
 
     def test_runtime_verify_accepts_dedicated_sim_runtime_with_ready_replicas(self) -> None:
         manifest = {


### PR DESCRIPTION
## Summary

- configure `torghut-ta-sim` and `torghut-sim` before replay so runtime verification happens against a live sim environment instead of after replay is already over
- make default simulation topics run-scoped to avoid stale-message bleed between historical simulation runs
- add regression coverage for the new topic naming and for replay ordering after runtime verification

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen ruff check scripts/start_historical_simulation.py tests/test_start_historical_simulation.py`
- `cd services/torghut && uv run --frozen pytest tests/test_start_historical_simulation.py -q`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

- historical simulation default topics are now run-scoped for dedicated simulation runs; operator manifests that explicitly override `simulation_topics` are unchanged

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
