### PR TITLE
chore(torghut): promote image 8fd04482

### DIFF
--- a/argocd/applications/torghut-forecast/deployment.yaml
+++ b/argocd/applications/torghut-forecast/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: forecast
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:d629044f8d6c299b8997a38c6676b8d65e0bec05018aaa007a998b2ae4431b79
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:b8728bee8fcab43be6b74920604be3f1f29e6cdcb94e42db0fe0493b59f2eab8
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn

--- a/argocd/applications/torghut-forecast/sim/deployment.yaml
+++ b/argocd/applications/torghut-forecast/sim/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: forecast
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:d629044f8d6c299b8997a38c6676b8d65e0bec05018aaa007a998b2ae4431b79
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:b8728bee8fcab43be6b74920604be3f1f29e6cdcb94e42db0fe0493b59f2eab8
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -40,7 +40,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:d629044f8d6c299b8997a38c6676b8d65e0bec05018aaa007a998b2ae4431b79
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:b8728bee8fcab43be6b74920604be3f1f29e6cdcb94e42db0fe0493b59f2eab8
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -21,7 +21,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:d629044f8d6c299b8997a38c6676b8d65e0bec05018aaa007a998b2ae4431b79
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:b8728bee8fcab43be6b74920604be3f1f29e6cdcb94e42db0fe0493b59f2eab8
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -30,7 +30,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:d629044f8d6c299b8997a38c6676b8d65e0bec05018aaa007a998b2ae4431b79
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:b8728bee8fcab43be6b74920604be3f1f29e6cdcb94e42db0fe0493b59f2eab8
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -30,7 +30,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:d629044f8d6c299b8997a38c6676b8d65e0bec05018aaa007a998b2ae4431b79
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:b8728bee8fcab43be6b74920604be3f1f29e6cdcb94e42db0fe0493b59f2eab8
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:d629044f8d6c299b8997a38c6676b8d65e0bec05018aaa007a998b2ae4431b79
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:b8728bee8fcab43be6b74920604be3f1f29e6cdcb94e42db0fe0493b59f2eab8
           command:
             - alembic
           args:

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -13,7 +13,7 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:d629044f8d6c299b8997a38c6676b8d65e0bec05018aaa007a998b2ae4431b79
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:b8728bee8fcab43be6b74920604be3f1f29e6cdcb94e42db0fe0493b59f2eab8
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -21,7 +21,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:d629044f8d6c299b8997a38c6676b8d65e0bec05018aaa007a998b2ae4431b79
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:b8728bee8fcab43be6b74920604be3f1f29e6cdcb94e42db0fe0493b59f2eab8
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -39,7 +39,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:d629044f8d6c299b8997a38c6676b8d65e0bec05018aaa007a998b2ae4431b79
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:b8728bee8fcab43be6b74920604be3f1f29e6cdcb94e42db0fe0493b59f2eab8
       imagePullPolicy: Always
       env:
         - name: TORGHUT_SIM_KAFKA_PASSWORD

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-03-07T10:10:30Z"
+        client.knative.dev/updateTimestamp: "2026-03-07T10:28:53Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:d629044f8d6c299b8997a38c6676b8d65e0bec05018aaa007a998b2ae4431b79
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:b8728bee8fcab43be6b74920604be3f1f29e6cdcb94e42db0fe0493b59f2eab8
           ports:
             - name: http1
               containerPort: 8181
@@ -458,9 +458,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.562.0-404-g4897e09d
+              value: v0.562.0-406-g8fd04482
             - name: TORGHUT_COMMIT
-              value: 4897e09d120845d33de50c882a5ce62c6724f6fe
+              value: 8fd04482e418e5e878d3ff1b8a791c0d86944ffc
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-03-07T10:10:30Z"
+        client.knative.dev/updateTimestamp: "2026-03-07T10:28:53Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -26,7 +26,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:d629044f8d6c299b8997a38c6676b8d65e0bec05018aaa007a998b2ae4431b79
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:b8728bee8fcab43be6b74920604be3f1f29e6cdcb94e42db0fe0493b59f2eab8
           ports:
             - name: http1
               containerPort: 8181
@@ -456,9 +456,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.562.0-404-g4897e09d
+              value: v0.562.0-406-g8fd04482
             - name: TORGHUT_COMMIT
-              value: 4897e09d120845d33de50c882a5ce62c6724f6fe
+              value: 8fd04482e418e5e878d3ff1b8a791c0d86944ffc
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/lean-runner-deployment.yaml
+++ b/argocd/applications/torghut/lean-runner-deployment.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: lean-runner
           # Keep in lockstep with `argocd/applications/torghut/knative-service.yaml`.
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:d629044f8d6c299b8997a38c6676b8d65e0bec05018aaa007a998b2ae4431b79
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:b8728bee8fcab43be6b74920604be3f1f29e6cdcb94e42db0fe0493b59f2eab8
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `8fd04482e418e5e878d3ff1b8a791c0d86944ffc`
- Image tag: `8fd04482`
- Image digest: `sha256:b8728bee8fcab43be6b74920604be3f1f29e6cdcb94e42db0fe0493b59f2eab8`