### PR TITLE
feat(openclaw): expand vm rbac for agentruns

### DIFF
--- a/argocd/applications/openclaw/README.md
+++ b/argocd/applications/openclaw/README.md
@@ -26,9 +26,9 @@ Cloud-init should ensure:
 ## VM access model
 
 - ServiceAccount: `openclaw-vm` (namespace `openclaw`)
-- RBAC scope: **Argo CD application only**
-  - can `get/list/watch` Argo CD `applications`
-  - can `patch/update` only `argocd/Application/openclaw`
+- RBAC scope:
+  - can `create/delete/get/list/patch/update/watch` Argo CD `applications` in namespace `argocd`
+  - can `create/delete/get/list/watch` `agents.proompteng.ai/AgentRun` in namespace `agents`
 
 ## Re-seal command (example)
 

--- a/argocd/applications/openclaw/openclaw-vm-rbac.yaml
+++ b/argocd/applications/openclaw/openclaw-vm-rbac.yaml
@@ -4,27 +4,49 @@ metadata:
   name: openclaw-vm
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
-  name: openclaw-vm-argocd-app
+  name: openclaw-vm-argocd-applications
+  namespace: argocd
 rules:
   - apiGroups: ["argoproj.io"]
     resources: ["applications"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["argoproj.io"]
-    resources: ["applications"]
-    resourceNames: ["openclaw"]
-    verbs: ["patch", "update"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
-  name: openclaw-vm-argocd-app
+  name: openclaw-vm-argocd-applications
+  namespace: argocd
 subjects:
   - kind: ServiceAccount
     name: openclaw-vm
     namespace: openclaw
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: openclaw-vm-argocd-app
+  kind: Role
+  name: openclaw-vm-argocd-applications
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: openclaw-vm-agentruns
+  namespace: agents
+rules:
+  - apiGroups: ["agents.proompteng.ai"]
+    resources: ["agentruns"]
+    verbs: ["create", "delete", "get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: openclaw-vm-agentruns
+  namespace: agents
+subjects:
+  - kind: ServiceAccount
+    name: openclaw-vm
+    namespace: openclaw
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: openclaw-vm-agentruns


### PR DESCRIPTION
## Summary

- expand `openclaw-vm` permissions to manage Argo CD `applications` in namespace `argocd`
- add namespace-scoped access for `agents.proompteng.ai` `agentruns` in namespace `agents`
- update the OpenClaw README to document the new RBAC scope

## Related Issues

None

## Testing

N/A - manifest and documentation changes only; not applied or validated in-cluster from this branch.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
