### PR TITLE
fix(openclaw): restore gitops-safe vm rbac

### DIFF
--- a/argocd/applications/openclaw/README.md
+++ b/argocd/applications/openclaw/README.md
@@ -27,8 +27,10 @@ Cloud-init should ensure:
 
 - ServiceAccount: `openclaw-vm` (namespace `openclaw`)
 - RBAC scope:
-  - can `create/delete/get/list/patch/update/watch` Argo CD `applications` in namespace `argocd`
-  - can `create/delete/get/list/watch` `agents.proompteng.ai/AgentRun` in namespace `agents`
+  - can `create/delete/get/list/patch/update/watch` Argo CD `applications`
+  - can `create/delete/get/list/watch` `agents.proompteng.ai/AgentRun`
+- Implementation note:
+  - these permissions are bound with `ClusterRole`/`ClusterRoleBinding` because the OpenClaw app applies `namespace: openclaw`, which would rewrite namespaced RBAC objects into the wrong namespace during GitOps sync
 
 ## Re-seal command (example)
 

--- a/argocd/applications/openclaw/openclaw-vm-rbac.yaml
+++ b/argocd/applications/openclaw/openclaw-vm-rbac.yaml
@@ -4,49 +4,45 @@ metadata:
   name: openclaw-vm
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
   name: openclaw-vm-argocd-applications
-  namespace: argocd
 rules:
   - apiGroups: ["argoproj.io"]
     resources: ["applications"]
     verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
   name: openclaw-vm-argocd-applications
-  namespace: argocd
 subjects:
   - kind: ServiceAccount
     name: openclaw-vm
     namespace: openclaw
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
+  kind: ClusterRole
   name: openclaw-vm-argocd-applications
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
   name: openclaw-vm-agentruns
-  namespace: agents
 rules:
   - apiGroups: ["agents.proompteng.ai"]
     resources: ["agentruns"]
     verbs: ["create", "delete", "get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
   name: openclaw-vm-agentruns
-  namespace: agents
 subjects:
   - kind: ServiceAccount
     name: openclaw-vm
     namespace: openclaw
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
+  kind: ClusterRole
   name: openclaw-vm-agentruns


### PR DESCRIPTION
## Summary

- replace the broken namespace-scoped OpenClaw VM RBAC with cluster-scoped bindings that survive the app namespace transform
- restore effective access for `openclaw-vm` to Argo CD `applications` and `agents.proompteng.ai` `agentruns` via GitOps
- document in the OpenClaw README why this app must use `ClusterRole` and `ClusterRoleBinding` for these permissions

## Related Issues

None

## Testing

- Confirmed `Application/openclaw` had already synced merged PR `#4183` but created the new RBAC resources in namespace `openclaw` instead of `argocd`/`agents`.
- Confirmed from inside `vm/openclaw` that `kubectl auth can-i` for Argo CD applications and AgentRuns still returned `no`, matching the bad in-cluster RBAC placement.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
