### PR TITLE
fix(openclaw): complete vm agentrun rbac

### DIFF
--- a/argocd/applications/openclaw/README.md
+++ b/argocd/applications/openclaw/README.md
@@ -29,6 +29,9 @@ Cloud-init should ensure:
 - RBAC scope:
   - can `create/delete/get/list/patch/update/watch` Argo CD `applications`
   - can `create/delete/get/list/watch` `agents.proompteng.ai/AgentRun`
+  - can `get/list/watch` `Agent`, `ImplementationSpec`, and `VersionControlProvider` in `agents`
+  - can `get` the allowlisted AgentRun Secrets `codex-github-token` and `codex-openai-key`
+  - can `get/list/watch` Jobs, Pods, and ConfigMaps plus `get` Pod logs for AgentRun inspection
 - Implementation note:
   - these permissions are bound with `ClusterRole`/`ClusterRoleBinding` because the OpenClaw app applies `namespace: openclaw`, which would rewrite namespaced RBAC objects into the wrong namespace during GitOps sync
 

--- a/argocd/applications/openclaw/openclaw-vm-rbac.yaml
+++ b/argocd/applications/openclaw/openclaw-vm-rbac.yaml
@@ -33,6 +33,22 @@ rules:
   - apiGroups: ["agents.proompteng.ai"]
     resources: ["agentruns"]
     verbs: ["create", "delete", "get", "list", "watch"]
+  - apiGroups: ["agents.proompteng.ai"]
+    resources: ["agents", "implementationspecs", "versioncontrolproviders"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: ["codex-github-token", "codex-openai-key"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["configmaps", "pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get"]
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
## Summary

- extend the OpenClaw VM AgentRun RBAC beyond raw `agentruns` CRUD so it matches the documented AgentRun creation and monitoring flow
- add read access for `Agent`, `ImplementationSpec`, `VersionControlProvider`, Jobs, Pods, Pod logs, and ConfigMaps used during preflight and run inspection
- restrict secret reads to the allowlisted AgentRun secrets `codex-github-token` and `codex-openai-key`, and document the expanded scope in the OpenClaw README

## Related Issues

None

## Testing

- Reviewed `docs/agents/agentrun-creation-guide.md` and `docs/agents/rbac-matrix.md` to identify the missing permissions required for documented AgentRun preflight and monitoring.
- Confirmed the prior OpenClaw RBAC only covered Argo CD applications plus `agentruns`, which was insufficient for the documented workflow.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
