### PR TITLE
fix(torghut): resolve completion matrix paths

### DIFF
--- a/services/torghut/app/trading/completion.py
+++ b/services/torghut/app/trading/completion.py
@@ -15,17 +15,22 @@ from sqlalchemy.orm import Session
 from ..models import VNextCompletionGateResult, VNextEmpiricalJobRun
 from .empirical_jobs import EMPIRICAL_JOB_TYPES, build_empirical_jobs_status
 
-DOC29_COMPLETION_MATRIX_RUNTIME_PATH = (
-    Path(__file__).resolve().parents[2] / 'config' / 'completion' / 'doc29-completion-matrix.yaml'
-)
-DOC29_COMPLETION_MATRIX_DOC_PATH = (
-    Path(__file__).resolve().parents[4]
-    / 'docs'
-    / 'torghut'
-    / 'design-system'
-    / 'v6'
-    / '29-completion-matrix-2026-03-07.yaml'
-)
+
+def _runtime_matrix_path() -> Path:
+    return Path(__file__).resolve().parents[2] / 'config' / 'completion' / 'doc29-completion-matrix.yaml'
+
+
+def _doc_matrix_path() -> Path:
+    current = Path(__file__).resolve()
+    for parent in current.parents:
+        candidate = parent / 'docs' / 'torghut' / 'design-system' / 'v6' / '29-completion-matrix-2026-03-07.yaml'
+        if candidate.exists():
+            return candidate
+    return _runtime_matrix_path()
+
+
+DOC29_COMPLETION_MATRIX_RUNTIME_PATH = _runtime_matrix_path()
+DOC29_COMPLETION_MATRIX_DOC_PATH = _doc_matrix_path()
 
 DOC29_COMPLETION_ENDPOINT = '/trading/completion/doc29'
 


### PR DESCRIPTION
## Summary

- make doc 29 completion matrix path resolution robust in both local repo checkouts and the `/app` container layout
- stop Torghut startup from crashing when the docs tree is not present in the runtime image
- preserve the existing runtime/doc matrix parity behavior in local development and CI

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_completion_trace.py tests/test_trading_api.py -q`
- `cd services/torghut && uv run --frozen ruff check app/trading/completion.py tests/test_completion_trace.py tests/test_trading_api.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
