### PR TITLE
fix(torghut): address doc29 review follow-up

### DIFF
--- a/services/torghut/app/trading/autonomy/policy_checks.py
+++ b/services/torghut/app/trading/autonomy/policy_checks.py
@@ -216,7 +216,10 @@ def evaluate_promotion_prerequisites(
         else None
     )
     for item in required_artifacts:
-        if item == "gates/benchmark-parity-report-v1.json" and existing_benchmark_path is not None:
+        if item in {
+            "gates/benchmark-parity-report-v1.json",
+            "benchmarks/benchmark-parity-report-v1.json",
+        } and existing_benchmark_path is not None:
             continue
         if not (artifact_root / item).exists():
             missing_artifacts.append(item)

--- a/services/torghut/scripts/start_historical_simulation.py
+++ b/services/torghut/scripts/start_historical_simulation.py
@@ -3885,7 +3885,7 @@ def _report_simulation(
 
 def _doc29_simulation_gate_ids(manifest: Mapping[str, Any]) -> list[str]:
     window = _as_mapping(manifest.get('window'))
-    profile = _as_text(window.get('profile'))
+    profile = (_as_text(window.get('profile')) or '').strip().lower() or None
     min_coverage_minutes = _safe_int(window.get('min_coverage_minutes'), default=0)
     if profile == US_EQUITIES_REGULAR_PROFILE or min_coverage_minutes >= US_EQUITIES_REGULAR_MINUTES:
         return [DOC29_SIMULATION_FULL_DAY_GATE]

--- a/services/torghut/tests/test_policy_checks.py
+++ b/services/torghut/tests/test_policy_checks.py
@@ -3767,6 +3767,55 @@ class TestPolicyChecks(TestCase):
             promotion.required_artifacts,
         )
 
+    def test_promotion_prerequisites_allow_legacy_required_benchmark_parity_artifact(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "research").mkdir(parents=True, exist_ok=True)
+            (root / "backtest").mkdir(parents=True, exist_ok=True)
+            (root / "gates").mkdir(parents=True, exist_ok=True)
+            (root / "paper-candidate").mkdir(parents=True, exist_ok=True)
+            (root / "research" / "candidate-spec.json").write_text(
+                "{}",
+                encoding="utf-8",
+            )
+            (root / "backtest" / "evaluation-report.json").write_text(
+                "{}",
+                encoding="utf-8",
+            )
+            (root / "gates" / "gate-evaluation.json").write_text("{}", encoding="utf-8")
+            (root / "paper-candidate" / "strategy-configmap-patch.yaml").write_text(
+                "kind: ConfigMap", encoding="utf-8"
+            )
+            _write_benchmark_parity_payload(root)
+
+            promotion = evaluate_promotion_prerequisites(
+                policy_payload={
+                    "promotion_require_benchmark_parity": True,
+                    "promotion_benchmark_parity_required_targets": ["paper"],
+                    "promotion_benchmark_required_artifacts": [
+                        "benchmarks/benchmark-parity-report-v1.json"
+                    ],
+                    "gate6_require_profitability_evidence": False,
+                    "gate6_require_janus_evidence": False,
+                    "promotion_require_janus_evidence": False,
+                    "promotion_require_profitability_stage_manifest": False,
+                },
+                gate_report_payload=_gate_report(),
+                candidate_state_payload=_candidate_state(),
+                promotion_target="paper",
+                artifact_root=root,
+            )
+
+        self.assertTrue(promotion.allowed)
+        self.assertNotIn("benchmark_parity_artifact_missing", promotion.reasons)
+        self.assertNotIn("required_artifacts_missing", promotion.reasons)
+        self.assertIn(
+            "benchmarks/benchmark-parity-report-v1.json",
+            promotion.required_artifacts,
+        )
+
     def test_promotion_prerequisites_fail_when_benchmark_parity_degradation_threshold_is_exceeded(
         self,
     ) -> None:

--- a/services/torghut/tests/test_start_historical_simulation.py
+++ b/services/torghut/tests/test_start_historical_simulation.py
@@ -26,6 +26,7 @@ from scripts.start_historical_simulation import (
     _build_rollouts_analysis_config,
     _build_simulation_completion_trace,
     _configure_torghut_service_for_simulation,
+    _doc29_simulation_gate_ids,
     _discover_automation_pointer,
     _find_vector_extension_blocking_revision,
     _dump_topics,
@@ -1721,6 +1722,17 @@ class TestStartHistoricalSimulation(TestCase):
         )
         self.assertEqual(policy['profile'], 'us_equities_regular')
         self.assertEqual(policy['min_coverage_minutes'], 390)
+
+    def test_doc29_simulation_gate_ids_normalize_mixed_case_profile(self) -> None:
+        gate_ids = _doc29_simulation_gate_ids(
+            {
+                'window': {
+                    'profile': 'US_EQUITIES_REGULAR',
+                    'min_coverage_minutes': 60,
+                }
+            }
+        )
+        self.assertEqual(gate_ids, ['simulation_full_day_coverage'])
 
     def test_validate_window_policy_rejects_profile_mismatch(self) -> None:
         with self.assertRaisesRegex(RuntimeError, 'window_profile_mismatch:us_equities_regular'):


### PR DESCRIPTION
## Summary

- allow the legacy `benchmarks/benchmark-parity-report-v1.json` required-artifact path to pass promotion checks when benchmark parity evidence exists at either supported location
- normalize `window.profile` before doc29 simulation gate selection so mixed-case manifests still record full-day coverage correctly
- add Torghut regression tests for both review-reported cases from PR #4188

## Related Issues

Related to #4188

## Testing

- `uv run --frozen pytest tests/test_policy_checks.py -k "benchmark_parity_artifact"`
- `uv run --frozen pytest tests/test_start_historical_simulation.py -k "doc29_simulation_gate_ids or validate_window_policy_us_equities_regular_profile"`
- `uv run --frozen ruff check app/trading/autonomy/policy_checks.py scripts/start_historical_simulation.py tests/test_policy_checks.py tests/test_start_historical_simulation.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
