### PR TITLE
chore(torghut): promote image 41da8ce3

### DIFF
--- a/argocd/applications/torghut-forecast/deployment.yaml
+++ b/argocd/applications/torghut-forecast/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: forecast
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:74d4f4b227a3d54926f24afc3d3762d8f7d868ddd214b5ed922b2200857e8a1d
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:525f5f68ab7e69d8594b69f6c1d2dca8b00f41fc4662fa0d0ae3dcc77a0053a0
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn

--- a/argocd/applications/torghut-forecast/sim/deployment.yaml
+++ b/argocd/applications/torghut-forecast/sim/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: forecast
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:74d4f4b227a3d54926f24afc3d3762d8f7d868ddd214b5ed922b2200857e8a1d
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:525f5f68ab7e69d8594b69f6c1d2dca8b00f41fc4662fa0d0ae3dcc77a0053a0
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -40,7 +40,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:74d4f4b227a3d54926f24afc3d3762d8f7d868ddd214b5ed922b2200857e8a1d
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:525f5f68ab7e69d8594b69f6c1d2dca8b00f41fc4662fa0d0ae3dcc77a0053a0
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -21,7 +21,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:74d4f4b227a3d54926f24afc3d3762d8f7d868ddd214b5ed922b2200857e8a1d
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:525f5f68ab7e69d8594b69f6c1d2dca8b00f41fc4662fa0d0ae3dcc77a0053a0
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -30,7 +30,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:74d4f4b227a3d54926f24afc3d3762d8f7d868ddd214b5ed922b2200857e8a1d
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:525f5f68ab7e69d8594b69f6c1d2dca8b00f41fc4662fa0d0ae3dcc77a0053a0
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -30,7 +30,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:74d4f4b227a3d54926f24afc3d3762d8f7d868ddd214b5ed922b2200857e8a1d
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:525f5f68ab7e69d8594b69f6c1d2dca8b00f41fc4662fa0d0ae3dcc77a0053a0
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:74d4f4b227a3d54926f24afc3d3762d8f7d868ddd214b5ed922b2200857e8a1d
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:525f5f68ab7e69d8594b69f6c1d2dca8b00f41fc4662fa0d0ae3dcc77a0053a0
           command:
             - alembic
           args:

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -13,7 +13,7 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:74d4f4b227a3d54926f24afc3d3762d8f7d868ddd214b5ed922b2200857e8a1d
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:525f5f68ab7e69d8594b69f6c1d2dca8b00f41fc4662fa0d0ae3dcc77a0053a0
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -21,7 +21,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:74d4f4b227a3d54926f24afc3d3762d8f7d868ddd214b5ed922b2200857e8a1d
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:525f5f68ab7e69d8594b69f6c1d2dca8b00f41fc4662fa0d0ae3dcc77a0053a0
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -39,7 +39,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:74d4f4b227a3d54926f24afc3d3762d8f7d868ddd214b5ed922b2200857e8a1d
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:525f5f68ab7e69d8594b69f6c1d2dca8b00f41fc4662fa0d0ae3dcc77a0053a0
       imagePullPolicy: Always
       env:
         - name: TORGHUT_SIM_KAFKA_PASSWORD

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-03-07T21:27:55Z"
+        client.knative.dev/updateTimestamp: "2026-03-07T21:35:17Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:74d4f4b227a3d54926f24afc3d3762d8f7d868ddd214b5ed922b2200857e8a1d
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:525f5f68ab7e69d8594b69f6c1d2dca8b00f41fc4662fa0d0ae3dcc77a0053a0
           ports:
             - name: http1
               containerPort: 8181
@@ -458,9 +458,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.562.0-415-g27736f6c
+              value: v0.562.0-417-g41da8ce3
             - name: TORGHUT_COMMIT
-              value: 27736f6cfd8670dae3604ed7701a593e439dcb4a
+              value: 41da8ce3cf45183f901d0bd3da73f48c860ea109
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-03-07T21:27:55Z"
+        client.knative.dev/updateTimestamp: "2026-03-07T21:35:17Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -26,7 +26,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:74d4f4b227a3d54926f24afc3d3762d8f7d868ddd214b5ed922b2200857e8a1d
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:525f5f68ab7e69d8594b69f6c1d2dca8b00f41fc4662fa0d0ae3dcc77a0053a0
           ports:
             - name: http1
               containerPort: 8181
@@ -456,9 +456,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.562.0-415-g27736f6c
+              value: v0.562.0-417-g41da8ce3
             - name: TORGHUT_COMMIT
-              value: 27736f6cfd8670dae3604ed7701a593e439dcb4a
+              value: 41da8ce3cf45183f901d0bd3da73f48c860ea109
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/lean-runner-deployment.yaml
+++ b/argocd/applications/torghut/lean-runner-deployment.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: lean-runner
           # Keep in lockstep with `argocd/applications/torghut/knative-service.yaml`.
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:74d4f4b227a3d54926f24afc3d3762d8f7d868ddd214b5ed922b2200857e8a1d
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:525f5f68ab7e69d8594b69f6c1d2dca8b00f41fc4662fa0d0ae3dcc77a0053a0
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `41da8ce3cf45183f901d0bd3da73f48c860ea109`
- Image tag: `41da8ce3`
- Image digest: `sha256:525f5f68ab7e69d8594b69f6c1d2dca8b00f41fc4662fa0d0ae3dcc77a0053a0`