### PR TITLE
fix(jangar): resync untouched agent runs and add control-plane logs

### DIFF
--- a/docs/agents/runbooks.md
+++ b/docs/agents/runbooks.md
@@ -127,6 +127,7 @@ Confirm the workflow adapter is healthy and no Argo Workflows are required:
 ```bash
 curl -fsS http://localhost:8080/api/agents/control-plane/status?namespace=agents | jq '.runtime_adapters'
 curl -fsS http://localhost:8080/api/agents/control-plane/status?namespace=agents | jq '.workflows'
+curl -fsS http://localhost:8080/api/agents/control-plane/status?namespace=agents | jq '.agentrun_ingestion'
 kubectl api-resources --api-group=argoproj.io --no-headers || true
 kubectl -n agents get workflows.argoproj.io 2>/dev/null || true
 ```
@@ -136,6 +137,8 @@ Expected outcomes:
 - `runtime_adapters` contains `workflow` with `status: healthy` and a native runtime message.
 - `workflows` includes a bounded rollup with `active_job_runs`, `recent_failed_jobs`,
   `backoff_limit_exceeded_jobs`, and `top_failure_reasons`.
+- `agentrun_ingestion` reports the latest AgentRun watch/resync timestamps and stays `healthy` with
+  `untouched_run_count: 0` during normal operation.
 - The Argo Workflows resource check returns empty output (no CRD or no workflows).
 
 ## Native workflow e2e proof

--- a/services/jangar/README.md
+++ b/services/jangar/README.md
@@ -226,6 +226,24 @@ Control-plane cache freshness (API read path):
 - `JANGAR_CONTROL_PLANE_CACHE_ALLOW_STALE` (optional; default: `true`)
   - Set to `false`/`0` to force live Kubernetes reads when cache rows exceed the freshness window.
 
+Agents controller AgentRun ingestion:
+
+- `JANGAR_AGENTS_CONTROLLER_RESYNC_INTERVAL_SECONDS` (optional; default: `60`)
+  - Periodic relist interval used to adopt new or drifted `AgentRun` resources even if a live watch event is missed.
+- `JANGAR_AGENTS_CONTROLLER_UNTOUCHED_WARN_AFTER_SECONDS` (optional; default: `120`)
+  - Age threshold for marking `agentrun_ingestion` degraded when untouched runs are accumulating.
+- `JANGAR_AGENTS_CONTROLLER_DEBUG_LOGS` (optional; default: `false`)
+  - Enables queue/watch/adoption debug logs in the agents controller; default logging remains decision-focused.
+
+Control-plane status now includes an additive `agentrun_ingestion` block in
+`/api/agents/control-plane/status?namespace=<ns>` with:
+
+- `status` / `message`
+- `last_watch_event_at`
+- `last_resync_at`
+- `untouched_run_count`
+- `oldest_untouched_age_seconds`
+
 ## Control-plane cache freshness behavior
 
 When cache reads are enabled for `/api/agents/control-plane/resource` and `/api/agents/control-plane/resources`, responses may include a `cache` object:

--- a/services/jangar/src/components/__tests__/agents-control-plane-status.test.tsx
+++ b/services/jangar/src/components/__tests__/agents-control-plane-status.test.tsx
@@ -88,6 +88,15 @@ const baseStatus: ControlPlaneStatus = {
     total_restarts: 0,
     streams: [],
   },
+  agentrun_ingestion: {
+    namespace: 'agents',
+    status: 'healthy',
+    message: 'AgentRun ingestion healthy',
+    last_watch_event_at: '2026-01-20T00:00:00Z',
+    last_resync_at: '2026-01-20T00:00:00Z',
+    untouched_run_count: 0,
+    oldest_untouched_age_seconds: null,
+  },
   rollout_health: {
     status: 'healthy',
     observed_deployments: 0,

--- a/services/jangar/src/components/agents-control-plane-status.tsx
+++ b/services/jangar/src/components/agents-control-plane-status.tsx
@@ -166,6 +166,29 @@ export const ControlPlaneStatusPanel = ({
 
         <div className="space-y-2">
           <div className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+            AgentRun ingestion
+          </div>
+          <div className="rounded-none border p-2 border-border/60 bg-muted/30 space-y-1">
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <span className="font-medium text-foreground">{status.agentrun_ingestion.namespace}</span>
+              <StatusBadge label={status.agentrun_ingestion.status} />
+            </div>
+            <div className="text-muted-foreground">{status.agentrun_ingestion.message || 'OK'}</div>
+            <div className="text-muted-foreground">
+              Last watch event: {formatTimestamp(status.agentrun_ingestion.last_watch_event_at || null)} · Last resync:{' '}
+              {formatTimestamp(status.agentrun_ingestion.last_resync_at || null)}
+            </div>
+            <div className="text-muted-foreground">
+              Untouched runs: {renderSummaryValue(status.agentrun_ingestion.untouched_run_count)} · Oldest age:{' '}
+              {status.agentrun_ingestion.oldest_untouched_age_seconds == null
+                ? '—'
+                : `${status.agentrun_ingestion.oldest_untouched_age_seconds}s`}
+            </div>
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <div className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
             Workflow reliability
           </div>
           <div className="rounded-none border p-3 border-border/60 bg-muted/30 space-y-1">

--- a/services/jangar/src/data/agents-control-plane.ts
+++ b/services/jangar/src/data/agents-control-plane.ts
@@ -206,6 +206,16 @@ export type ControlPlaneWatchReliability = {
   streams: ControlPlaneWatchReliabilityStream[]
 }
 
+export type AgentRunIngestionStatus = {
+  namespace: string
+  status: 'healthy' | 'degraded' | 'unknown'
+  message: string
+  last_watch_event_at: string
+  last_resync_at: string
+  untouched_run_count: number
+  oldest_untouched_age_seconds: number | null
+}
+
 export type GrpcStatus = {
   enabled: boolean
   address: string
@@ -262,6 +272,7 @@ export type ControlPlaneStatus = {
   database: DatabaseStatus
   grpc: GrpcStatus
   watch_reliability: ControlPlaneWatchReliability
+  agentrun_ingestion: AgentRunIngestionStatus
   rollout_health: ControlPlaneRolloutHealth
   empirical_services: EmpiricalServicesStatus
   namespaces: NamespaceStatus[]

--- a/services/jangar/src/server/__tests__/agents-controller.test.ts
+++ b/services/jangar/src/server/__tests__/agents-controller.test.ts
@@ -455,6 +455,61 @@ describe('agents controller startup', () => {
       }
     }
   })
+
+  it('dedupes repeated ingestion stall logs and emits recovery once', async () => {
+    stopAgentsController()
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {})
+    const state = { namespaces: new Map() }
+    const staleRun = buildAgentRun({
+      metadata: {
+        name: 'run-stale',
+        namespace: 'agents',
+        generation: 1,
+        creationTimestamp: '2026-01-20T00:00:00Z',
+        finalizers: [],
+      },
+      status: {},
+    })
+    const healthyList = { items: [] }
+    const staleList = { items: [staleRun] }
+    const kube = buildKube({
+      list: vi.fn(async (resource: string) => {
+        if (resource === RESOURCE_MAP.AgentRun) {
+          return staleList
+        }
+        return { items: [] }
+      }),
+      get: vi.fn(async () => null),
+    })
+
+    try {
+      await __test.resyncAgentRunsForNamespace(kube as never, 'agents', state as never, defaultConcurrency, 'manual')
+      await __test.resyncAgentRunsForNamespace(kube as never, 'agents', state as never, defaultConcurrency, 'manual')
+
+      let stallMessages = warnSpy.mock.calls
+        .map((call) => String(call[0]))
+        .filter((line) => line.includes('agentrun_ingestion_stalled'))
+      expect(stallMessages).toHaveLength(1)
+
+      ;(kube.list as ReturnType<typeof vi.fn>).mockImplementation(async (resource: string) => {
+        if (resource === RESOURCE_MAP.AgentRun) {
+          return healthyList
+        }
+        return { items: [] }
+      })
+
+      await __test.resyncAgentRunsForNamespace(kube as never, 'agents', state as never, defaultConcurrency, 'manual')
+
+      const recoveryMessages = infoSpy.mock.calls
+        .map((call) => String(call[0]))
+        .filter((line) => line.includes('agentrun_ingestion_recovered'))
+      expect(recoveryMessages).toHaveLength(1)
+    } finally {
+      warnSpy.mockRestore()
+      infoSpy.mockRestore()
+    }
+  })
 })
 
 describe('AgentRun artifacts limits', () => {

--- a/services/jangar/src/server/__tests__/agents-controller.test.ts
+++ b/services/jangar/src/server/__tests__/agents-controller.test.ts
@@ -6,6 +6,9 @@ import { describe, expect, it, vi } from 'vitest'
 const metricsMocks = vi.hoisted(() => ({
   recordReconcileDurationMs: vi.fn(),
   recordAgentRunOutcome: vi.fn(),
+  recordAgentRunResyncAdoptions: vi.fn(),
+  recordAgentRunUntouchedBacklog: vi.fn(),
+  recordAgentRunUntouchedOldestAgeSeconds: vi.fn(),
   recordAgentConcurrency: vi.fn(),
   recordAgentQueueDepth: vi.fn(),
   recordAgentRateLimitRejection: vi.fn(),
@@ -242,6 +245,215 @@ describe('agents controller startup', () => {
     stopAgentsController()
 
     expect(stopWatch).toHaveBeenCalledTimes(1)
+  })
+
+  it('adopts untouched AgentRuns during controller resync', async () => {
+    stopAgentsController()
+    const state = { namespaces: new Map() }
+    const kube = buildKube({
+      list: vi.fn(async (resource: string) => {
+        if (resource === RESOURCE_MAP.AgentRun) {
+          return {
+            items: [
+              buildAgentRun({
+                metadata: {
+                  name: 'run-resync',
+                  namespace: 'agents',
+                  generation: 1,
+                  creationTimestamp: '2026-01-20T00:00:00Z',
+                  finalizers: [],
+                },
+                status: {},
+              }),
+            ],
+          }
+        }
+        return { items: [] }
+      }),
+      get: vi.fn(async (resource: string) => {
+        if (resource === RESOURCE_MAP.Agent) {
+          return {
+            metadata: { name: 'agent-1' },
+            spec: { providerRef: { name: 'provider-1' }, defaults: { systemPrompt: 'default-agent-prompt' } },
+          }
+        }
+        if (resource === RESOURCE_MAP.AgentProvider) {
+          return { metadata: { name: 'provider-1' }, spec: { binary: '/usr/local/bin/agent-runner' } }
+        }
+        if (resource === RESOURCE_MAP.ImplementationSpec) {
+          return { metadata: { name: 'impl-1' }, spec: { text: 'demo' } }
+        }
+        return null
+      }),
+    })
+
+    await __test.resyncAgentRunsForNamespace(kube as never, 'agents', state as never, defaultConcurrency, 'manual')
+
+    expect(kube.patch).toHaveBeenCalledWith(RESOURCE_MAP.AgentRun, 'run-resync', 'agents', {
+      metadata: { finalizers: [finalizer] },
+    })
+    expect(getLastStatus(kube as never).phase).toBe('Running')
+    expect(__test.getRuntimeMutableState().agentRunIngestionState.get('agents')?.untouchedRunCount).toBe(1)
+  })
+
+  it('adopts missed AgentRuns on watch restart resync', async () => {
+    stopAgentsController()
+    const state = { namespaces: new Map() }
+    const kube = buildKube({
+      list: vi.fn(async (resource: string) => {
+        if (resource === RESOURCE_MAP.AgentRun) {
+          return {
+            items: [
+              buildAgentRun({
+                metadata: {
+                  name: 'run-watch-restart',
+                  namespace: 'agents',
+                  generation: 2,
+                  creationTimestamp: '2026-01-20T00:00:00Z',
+                  finalizers: [],
+                },
+                status: {
+                  observedGeneration: 1,
+                },
+              }),
+            ],
+          }
+        }
+        return { items: [] }
+      }),
+      get: vi.fn(async (resource: string) => {
+        if (resource === RESOURCE_MAP.Agent) {
+          return {
+            metadata: { name: 'agent-1' },
+            spec: { providerRef: { name: 'provider-1' }, defaults: { systemPrompt: 'default-agent-prompt' } },
+          }
+        }
+        if (resource === RESOURCE_MAP.AgentProvider) {
+          return { metadata: { name: 'provider-1' }, spec: { binary: '/usr/local/bin/agent-runner' } }
+        }
+        if (resource === RESOURCE_MAP.ImplementationSpec) {
+          return { metadata: { name: 'impl-1' }, spec: { text: 'demo' } }
+        }
+        return null
+      }),
+    })
+
+    await __test.resyncAgentRunsForNamespace(
+      kube as never,
+      'agents',
+      state as never,
+      defaultConcurrency,
+      'watch_restart',
+    )
+
+    expect(kube.patch).toHaveBeenCalledWith(RESOURCE_MAP.AgentRun, 'run-watch-restart', 'agents', {
+      metadata: { finalizers: [finalizer] },
+    })
+    expect(getLastStatus(kube as never).phase).toBe('Running')
+  })
+
+  it('emits structured reconcile logs for successful first-touch submission', async () => {
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {})
+    const kube = buildKube({
+      get: vi.fn(async (resource: string) => {
+        if (resource === RESOURCE_MAP.Agent) {
+          return {
+            metadata: { name: 'agent-1' },
+            spec: { providerRef: { name: 'provider-1' }, defaults: { systemPrompt: 'default-agent-prompt' } },
+          }
+        }
+        if (resource === RESOURCE_MAP.AgentProvider) {
+          return { metadata: { name: 'provider-1' }, spec: { binary: '/usr/local/bin/agent-runner' } }
+        }
+        if (resource === RESOURCE_MAP.ImplementationSpec) {
+          return { metadata: { name: 'impl-1' }, spec: { text: 'demo' } }
+        }
+        return null
+      }),
+    })
+
+    let messages: string[] = []
+    try {
+      await __test.reconcileAgentRun(
+        kube as never,
+        buildAgentRun(),
+        'agents',
+        [],
+        [],
+        defaultConcurrency,
+        buildInFlight(),
+        0,
+      )
+      messages = infoSpy.mock.calls.map((call) => String(call[0]))
+    } finally {
+      infoSpy.mockRestore()
+    }
+
+    expect(messages.some((message) => message.includes('reconcile_started'))).toBe(true)
+    expect(messages.some((message) => message.includes('reconcile_submitted'))).toBe(true)
+  })
+
+  it('gates debug adoption logs behind the debug env flag', async () => {
+    stopAgentsController()
+    const previousDebug = process.env.JANGAR_AGENTS_CONTROLLER_DEBUG_LOGS
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {})
+    const state = { namespaces: new Map() }
+    const kube = buildKube({
+      list: vi.fn(async (resource: string) => {
+        if (resource === RESOURCE_MAP.AgentRun) {
+          return {
+            items: [
+              buildAgentRun({
+                metadata: {
+                  name: 'run-debug',
+                  namespace: 'agents',
+                  generation: 1,
+                  creationTimestamp: '2026-01-20T00:00:00Z',
+                  finalizers: [],
+                },
+                status: {},
+              }),
+            ],
+          }
+        }
+        return { items: [] }
+      }),
+      get: vi.fn(async (resource: string) => {
+        if (resource === RESOURCE_MAP.Agent) {
+          return {
+            metadata: { name: 'agent-1' },
+            spec: { providerRef: { name: 'provider-1' }, defaults: { systemPrompt: 'default-agent-prompt' } },
+          }
+        }
+        if (resource === RESOURCE_MAP.AgentProvider) {
+          return { metadata: { name: 'provider-1' }, spec: { binary: '/usr/local/bin/agent-runner' } }
+        }
+        if (resource === RESOURCE_MAP.ImplementationSpec) {
+          return { metadata: { name: 'impl-1' }, spec: { text: 'demo' } }
+        }
+        return null
+      }),
+    })
+
+    try {
+      delete process.env.JANGAR_AGENTS_CONTROLLER_DEBUG_LOGS
+      await __test.resyncAgentRunsForNamespace(kube as never, 'agents', state as never, defaultConcurrency, 'manual')
+      let messages = infoSpy.mock.calls.map((call) => String(call[0]))
+      expect(messages.some((message) => message.includes('agentrun_resync_adopted'))).toBe(false)
+
+      infoSpy.mockClear()
+      process.env.JANGAR_AGENTS_CONTROLLER_DEBUG_LOGS = 'true'
+      await __test.resyncAgentRunsForNamespace(kube as never, 'agents', state as never, defaultConcurrency, 'manual')
+      messages = infoSpy.mock.calls.map((call) => String(call[0]))
+      expect(messages.some((message) => message.includes('agentrun_resync_adopted'))).toBe(true)
+    } finally {
+      infoSpy.mockRestore()
+      if (previousDebug === undefined) {
+        delete process.env.JANGAR_AGENTS_CONTROLLER_DEBUG_LOGS
+      } else {
+        process.env.JANGAR_AGENTS_CONTROLLER_DEBUG_LOGS = previousDebug
+      }
+    }
   })
 })
 

--- a/services/jangar/src/server/__tests__/control-plane-status.test.ts
+++ b/services/jangar/src/server/__tests__/control-plane-status.test.ts
@@ -51,6 +51,15 @@ const healthyController = {
   crdsReady: true,
   missingCrds: [],
   lastCheckedAt: '2026-01-20T00:00:00Z',
+  agentRunIngestion: [
+    {
+      namespace: 'agents',
+      lastWatchEventAt: '2026-01-20T00:00:00Z',
+      lastResyncAt: '2026-01-20T00:00:00Z',
+      untouchedRunCount: 0,
+      oldestUntouchedAgeSeconds: null,
+    },
+  ],
 }
 
 const buildWorkflowsReliabilityStatus = (
@@ -253,6 +262,15 @@ describe('control-plane status', () => {
     expect(status.namespaces[0]?.degraded_components ?? []).toHaveLength(0)
     expect(status.watch_reliability).toEqual(watchReliabilityHealthy)
     expect(status.watch_reliability.streams).toHaveLength(2)
+    expect(status.agentrun_ingestion).toEqual({
+      namespace: 'agents',
+      status: 'healthy',
+      message: 'AgentRun ingestion healthy',
+      last_watch_event_at: '2026-01-20T00:00:00Z',
+      last_resync_at: '2026-01-20T00:00:00Z',
+      untouched_run_count: 0,
+      oldest_untouched_age_seconds: null,
+    })
     expect(status.rollout_health.status).toBe('healthy')
     expect(status.rollout_health.observed_deployments).toBe(1)
     expect(status.rollout_health.degraded_deployments).toBe(0)
@@ -271,6 +289,15 @@ describe('control-plane status', () => {
       crdsReady: false,
       missingCrds: ['agents.agents.proompteng.ai'],
       lastCheckedAt: '2026-01-20T00:00:00Z',
+      agentRunIngestion: [
+        {
+          namespace: 'agents',
+          lastWatchEventAt: '2026-01-20T00:00:00Z',
+          lastResyncAt: '2026-01-20T00:00:00Z',
+          untouchedRunCount: 3,
+          oldestUntouchedAgeSeconds: 180,
+        },
+      ],
     }
 
     const status = await buildControlPlaneStatus(
@@ -338,11 +365,15 @@ describe('control-plane status', () => {
     expect(degraded).toContain('runtime:temporal')
     expect(degraded).toContain('database')
     expect(degraded).toContain('watch_reliability')
+    expect(degraded).toContain('agentrun_ingestion')
     expect(degraded).toContain('empirical:forecast')
     expect(degraded).toContain('empirical:jobs')
     expect(degraded).not.toContain('grpc')
     expect(status.watch_reliability.status).toBe('degraded')
     expect(status.watch_reliability.total_errors).toBe(2)
+    expect(status.agentrun_ingestion.status).toBe('degraded')
+    expect(status.agentrun_ingestion.untouched_run_count).toBe(3)
+    expect(status.agentrun_ingestion.oldest_untouched_age_seconds).toBe(180)
     expect(status.dependency_quorum.reasons).toContain('forecast_service_unhealthy')
     expect(status.empirical_services.jobs.status).toBe('degraded')
   })

--- a/services/jangar/src/server/__tests__/kube-watch.test.ts
+++ b/services/jangar/src/server/__tests__/kube-watch.test.ts
@@ -142,4 +142,22 @@ describe('kube-watch', () => {
     vi.advanceTimersByTime(2000)
     expect(spawnMocks).toHaveBeenCalledTimes(2)
   })
+
+  it('invokes onRestart with the restart reason when the process exits non-zero', () => {
+    const watchProcess = createMockWatchProcess()
+    spawnMocks.mockReturnValue(watchProcess)
+
+    const onRestart = vi.fn()
+    watchHandle = startResourceWatch({
+      resource: 'agentruns',
+      namespace: 'agents',
+      onEvent: vi.fn(),
+      onRestart,
+      restartDelayMs: 2000,
+    })
+
+    watchProcess.emit('close', 1)
+
+    expect(onRestart).toHaveBeenCalledWith('nonzero_exit')
+  })
 })

--- a/services/jangar/src/server/agents-controller/agent-run-reconciler.ts
+++ b/services/jangar/src/server/agents-controller/agent-run-reconciler.ts
@@ -32,6 +32,7 @@ import { cancelRuntime, parseRuntimeRef, type RuntimeRef } from './runtime-resou
 import { resolveSystemPrompt } from './system-prompt'
 import { collectBlockedSecrets, resolveAuthSecretConfig, resolveVcsContext } from './vcs-context'
 import { validateParameters } from './workflow'
+import { logAgentsControllerInfo, logAgentsControllerWarn, toLogError } from './operational-logging'
 
 type KubeClient = ReturnType<typeof createKubernetesClient>
 
@@ -173,6 +174,7 @@ export const createAgentRunReconciler = (deps: AgentRunReconcilerDependencies) =
     inFlight: InFlightCounts,
     globalInFlight: number,
   ) => {
+    const reconcileStartedAt = Date.now()
     const metadata = asRecord(agentRun.metadata) ?? {}
     const name = asString(metadata.name) ?? ''
     const spec = asRecord(agentRun.spec) ?? {}
@@ -254,6 +256,65 @@ export const createAgentRunReconciler = (deps: AgentRunReconcilerDependencies) =
     const workload = asRecord(readNested(spec, ['workload'])) ?? {}
     let workloadImage: string | null = null
     const repository = resolveRunRepository(agentRun)
+    const logContext = {
+      namespace,
+      runName: name,
+      generation: observedGeneration,
+      runtimeType: runtimeType ?? 'unknown',
+      repository: repository || '',
+    }
+    const logBlocked = (reason: string, message: string) => {
+      logAgentsControllerInfo('reconcile_blocked', {
+        ...logContext,
+        decision: 'blocked',
+        reason,
+        message,
+        durationMs: Date.now() - reconcileStartedAt,
+      })
+    }
+    const logInvalidSpec = (reason: string, message: string) => {
+      logAgentsControllerInfo('reconcile_invalid_spec', {
+        ...logContext,
+        decision: 'invalid_spec',
+        reason,
+        message,
+        durationMs: Date.now() - reconcileStartedAt,
+      })
+    }
+    const logSubmitted = (runtimeRef: RuntimeRef | null) => {
+      logAgentsControllerInfo('reconcile_submitted', {
+        ...logContext,
+        decision: 'submitted',
+        runtimeRefType: runtimeRef?.type ?? 'unknown',
+        runtimeRefName: runtimeRef?.name ?? '',
+        durationMs: Date.now() - reconcileStartedAt,
+      })
+    }
+    const logSubmitFailed = (reason: string, message: string) => {
+      logAgentsControllerWarn('reconcile_submit_failed', {
+        ...logContext,
+        decision: 'submit_failed',
+        reason,
+        message,
+        durationMs: Date.now() - reconcileStartedAt,
+      })
+    }
+    const logTerminalOutcome = (outcome: 'Succeeded' | 'Failed', reason: string, message: string) => {
+      logAgentsControllerInfo('reconcile_terminal', {
+        ...logContext,
+        decision: 'terminal',
+        outcome,
+        reason,
+        message,
+        durationMs: Date.now() - reconcileStartedAt,
+      })
+    }
+
+    logAgentsControllerInfo('reconcile_started', {
+      ...logContext,
+      decision: 'start',
+      phase,
+    })
 
     if (deleting) {
       if (hasFinalizer) {
@@ -267,7 +328,10 @@ export const createAgentRunReconciler = (deps: AgentRunReconcilerDependencies) =
               getTemporalClient: getTemporalClient as () => Promise<TemporalCancelClient>,
             })
           } catch (error) {
-            console.warn('[jangar] runtime cleanup failed', error)
+            logAgentsControllerWarn('runtime_cleanup_failed', {
+              ...logContext,
+              ...toLogError(error),
+            })
           }
         }
         try {
@@ -404,12 +468,14 @@ export const createAgentRunReconciler = (deps: AgentRunReconcilerDependencies) =
     }
 
     if (shouldSubmit && agentName && (inFlight.perAgent.get(agentName) ?? 0) >= concurrency.perAgent) {
+      const message = `Agent ${agentName} reached concurrency limit`
       const updated = upsertCondition(conditions, {
         type: 'Blocked',
         status: 'True',
         reason: 'ConcurrencyLimit',
-        message: `Agent ${agentName} reached concurrency limit`,
+        message,
       })
+      logBlocked('ConcurrencyLimit', message)
       await setStatus(kube, agentRun, { observedGeneration, conditions: updated, phase: 'Pending' })
       return
     }
@@ -418,35 +484,41 @@ export const createAgentRunReconciler = (deps: AgentRunReconcilerDependencies) =
     if (shouldSubmit && repoLimit !== null) {
       const repoKey = normalizeRepositoryKey(repository)
       if ((inFlight.perRepository.get(repoKey) ?? 0) >= repoLimit) {
+        const message = `Repository ${repository} reached concurrency limit`
         const updated = upsertCondition(conditions, {
           type: 'Blocked',
           status: 'True',
           reason: 'ConcurrencyLimit',
-          message: `Repository ${repository} reached concurrency limit`,
+          message,
         })
+        logBlocked('ConcurrencyLimit', message)
         await setStatus(kube, agentRun, { observedGeneration, conditions: updated, phase: 'Pending' })
         return
       }
     }
 
     if (shouldSubmit && inFlight.total >= concurrency.perNamespace) {
+      const message = `Namespace ${namespace} reached concurrency limit`
       const updated = upsertCondition(conditions, {
         type: 'Blocked',
         status: 'True',
         reason: 'ConcurrencyLimit',
-        message: `Namespace ${namespace} reached concurrency limit`,
+        message,
       })
+      logBlocked('ConcurrencyLimit', message)
       await setStatus(kube, agentRun, { observedGeneration, conditions: updated, phase: 'Pending' })
       return
     }
 
     if (shouldSubmit && globalInFlight >= concurrency.cluster) {
+      const message = 'Cluster concurrency limit reached'
       const updated = upsertCondition(conditions, {
         type: 'Blocked',
         status: 'True',
         reason: 'ConcurrencyLimit',
-        message: 'Cluster concurrency limit reached',
+        message,
       })
+      logBlocked('ConcurrencyLimit', message)
       await setStatus(kube, agentRun, { observedGeneration, conditions: updated, phase: 'Pending' })
       return
     }
@@ -470,34 +542,40 @@ export const createAgentRunReconciler = (deps: AgentRunReconcilerDependencies) =
       }
 
       if (queueLimits.perNamespace > 0 && queueCounts.queuedNamespace >= queueLimits.perNamespace) {
+        const message = `Namespace ${namespace} reached queue limit`
         const updated = upsertCondition(conditions, {
           type: 'Blocked',
           status: 'True',
           reason: 'QueueLimit',
-          message: `Namespace ${namespace} reached queue limit`,
+          message,
         })
+        logBlocked('QueueLimit', message)
         await setStatus(kube, agentRun, { observedGeneration, conditions: updated, phase: 'Pending' })
         return
       }
 
       if (queueLimits.cluster > 0 && queueCounts.queuedCluster >= queueLimits.cluster) {
+        const message = 'Cluster queue limit reached'
         const updated = upsertCondition(conditions, {
           type: 'Blocked',
           status: 'True',
           reason: 'QueueLimit',
-          message: 'Cluster queue limit reached',
+          message,
         })
+        logBlocked('QueueLimit', message)
         await setStatus(kube, agentRun, { observedGeneration, conditions: updated, phase: 'Pending' })
         return
       }
 
       if (normalizedRepo && queueLimits.perRepo > 0 && queueCounts.queuedRepo >= queueLimits.perRepo) {
+        const message = `Repository ${repository} reached queue limit`
         const updated = upsertCondition(conditions, {
           type: 'Blocked',
           status: 'True',
           reason: 'QueueLimit',
-          message: `Repository ${repository} reached queue limit`,
+          message,
         })
+        logBlocked('QueueLimit', message)
         await setStatus(kube, agentRun, { observedGeneration, conditions: updated, phase: 'Pending' })
         return
       }
@@ -522,6 +600,7 @@ export const createAgentRunReconciler = (deps: AgentRunReconcilerDependencies) =
           reason: 'RateLimit',
           message: `${rateDecision.message} (retry after ${rateDecision.retryAfterSeconds}s)`,
         })
+        logBlocked('RateLimit', `${rateDecision.message} (retry after ${rateDecision.retryAfterSeconds}s)`)
         await setStatus(kube, agentRun, { observedGeneration, conditions: updated, phase: 'Pending' })
         return
       }
@@ -529,12 +608,14 @@ export const createAgentRunReconciler = (deps: AgentRunReconcilerDependencies) =
 
     if (shouldSubmit) {
       if (!runtimeType) {
+        const message = 'spec.runtime.type is required'
         const updated = upsertCondition(conditions, {
           type: 'InvalidSpec',
           status: 'True',
           reason: 'MissingRuntime',
-          message: 'spec.runtime.type is required',
+          message,
         })
+        logInvalidSpec('MissingRuntime', message)
         await setStatus(kube, agentRun, { observedGeneration, conditions: updated, phase: 'Failed' })
         return
       }
@@ -547,6 +628,7 @@ export const createAgentRunReconciler = (deps: AgentRunReconcilerDependencies) =
           reason: parameterCheck.reason,
           message: parameterCheck.message,
         })
+        logInvalidSpec(parameterCheck.reason, parameterCheck.message)
         await setStatus(kube, agentRun, { observedGeneration, conditions: updated, phase: 'Failed' })
         return
       }
@@ -558,6 +640,7 @@ export const createAgentRunReconciler = (deps: AgentRunReconcilerDependencies) =
           reason: labelPolicy.reason,
           message: labelPolicy.message,
         })
+        logInvalidSpec(labelPolicy.reason, labelPolicy.message)
         await setStatus(kube, agentRun, { observedGeneration, conditions: updated, phase: 'Failed' })
         return
       }
@@ -566,13 +649,15 @@ export const createAgentRunReconciler = (deps: AgentRunReconcilerDependencies) =
       if (runtimeType === 'job') {
         workloadImage = resolveJobImage(workload)
         if (!workloadImage) {
+          const message =
+            'spec.workload.image, JANGAR_AGENT_RUNNER_IMAGE, or JANGAR_AGENT_IMAGE is required for job runtime'
           const updated = upsertCondition(conditions, {
             type: 'InvalidSpec',
             status: 'True',
             reason: 'MissingWorkloadImage',
-            message:
-              'spec.workload.image, JANGAR_AGENT_RUNNER_IMAGE, or JANGAR_AGENT_IMAGE is required for job runtime',
+            message,
           })
+          logInvalidSpec('MissingWorkloadImage', message)
           await setStatus(kube, agentRun, { observedGeneration, conditions: updated, phase: 'Failed' })
           return
         }
@@ -584,6 +669,7 @@ export const createAgentRunReconciler = (deps: AgentRunReconcilerDependencies) =
             reason: imagePolicy.reason,
             message: imagePolicy.message,
           })
+          logInvalidSpec(imagePolicy.reason, imagePolicy.message)
           await setStatus(kube, agentRun, { observedGeneration, conditions: updated, phase: 'Failed' })
           return
         }
@@ -592,12 +678,14 @@ export const createAgentRunReconciler = (deps: AgentRunReconcilerDependencies) =
       if (runtimeType === 'custom') {
         const endpoint = asString(runtimeConfig.endpoint)
         if (!endpoint) {
+          const message = 'spec.runtime.config.endpoint is required for custom runtime'
           const updated = upsertCondition(conditions, {
             type: 'InvalidSpec',
             status: 'True',
             reason: 'MissingEndpoint',
-            message: 'spec.runtime.config.endpoint is required for custom runtime',
+            message,
           })
+          logInvalidSpec('MissingEndpoint', message)
           await setStatus(kube, agentRun, { observedGeneration, conditions: updated, phase: 'Failed' })
           return
         }
@@ -607,13 +695,15 @@ export const createAgentRunReconciler = (deps: AgentRunReconcilerDependencies) =
         const workflowType = asString(runtimeConfig.workflowType)
         const taskQueue = asString(runtimeConfig.taskQueue)
         if (!workflowType || !taskQueue) {
+          const message =
+            'spec.runtime.config.workflowType and spec.runtime.config.taskQueue are required for temporal runtime'
           const updated = upsertCondition(conditions, {
             type: 'InvalidSpec',
             status: 'True',
             reason: 'MissingTemporalConfig',
-            message:
-              'spec.runtime.config.workflowType and spec.runtime.config.taskQueue are required for temporal runtime',
+            message,
           })
+          logInvalidSpec('MissingTemporalConfig', message)
           await setStatus(kube, agentRun, { observedGeneration, conditions: updated, phase: 'Failed' })
           return
         }
@@ -626,12 +716,14 @@ export const createAgentRunReconciler = (deps: AgentRunReconcilerDependencies) =
 
       const agent = agentName ? await kube.get(RESOURCE_MAP.Agent, agentName, namespace) : null
       if (!agent) {
+        const message = `agent ${agentName} not found`
         const updated = upsertCondition(conditions, {
           type: 'InvalidSpec',
           status: 'True',
           reason: 'MissingAgent',
-          message: `agent ${agentName} not found`,
+          message,
         })
+        logInvalidSpec('MissingAgent', message)
         await setStatus(kube, agentRun, { observedGeneration, conditions: updated, phase: 'Failed' })
         return
       }
@@ -639,12 +731,14 @@ export const createAgentRunReconciler = (deps: AgentRunReconcilerDependencies) =
       const providerName = asString(readNested(agent, ['spec', 'providerRef', 'name']))
       const provider = providerName ? await kube.get(RESOURCE_MAP.AgentProvider, providerName, namespace) : null
       if (!provider) {
+        const message = `agent provider ${providerName ?? 'unknown'} not found`
         const updated = upsertCondition(conditions, {
           type: 'InvalidSpec',
           status: 'True',
           reason: 'MissingProvider',
-          message: `agent provider ${providerName ?? 'unknown'} not found`,
+          message,
         })
+        logInvalidSpec('MissingProvider', message)
         await setStatus(kube, agentRun, { observedGeneration, conditions: updated, phase: 'Failed' })
         return
       }
@@ -658,12 +752,14 @@ export const createAgentRunReconciler = (deps: AgentRunReconcilerDependencies) =
       if (allowedSecrets.length > 0) {
         const forbidden = runSecrets.filter((secret) => !allowedSecrets.includes(secret))
         if (forbidden.length > 0) {
+          const message = `spec.secrets contains disallowed entries: ${forbidden.join(', ')}`
           const updated = upsertCondition(conditions, {
             type: 'InvalidSpec',
             status: 'True',
             reason: 'SecretNotAllowed',
-            message: `spec.secrets contains disallowed entries: ${forbidden.join(', ')}`,
+            message,
           })
+          logInvalidSpec('SecretNotAllowed', message)
           await setStatus(kube, agentRun, { observedGeneration, conditions: updated, phase: 'Failed' })
           return
         }
@@ -673,12 +769,14 @@ export const createAgentRunReconciler = (deps: AgentRunReconcilerDependencies) =
         const rawServiceAccount = resolveRunnerServiceAccount(runtimeConfig)
         const effectiveServiceAccount = rawServiceAccount || 'default'
         if (!allowedServiceAccounts.includes(effectiveServiceAccount)) {
+          const message = `serviceAccount ${effectiveServiceAccount} is not allowlisted`
           const updated = upsertCondition(conditions, {
             type: 'InvalidSpec',
             status: 'True',
             reason: 'ServiceAccountNotAllowed',
-            message: `serviceAccount ${effectiveServiceAccount} is not allowlisted`,
+            message,
           })
+          logInvalidSpec('ServiceAccountNotAllowed', message)
           await setStatus(kube, agentRun, { observedGeneration, conditions: updated, phase: 'Failed' })
           return
         }
@@ -695,12 +793,14 @@ export const createAgentRunReconciler = (deps: AgentRunReconcilerDependencies) =
       }
 
       if (!implResource) {
+        const message = 'implementationSpecRef or implementation.inline is required'
         const updated = upsertCondition(conditions, {
           type: 'InvalidSpec',
           status: 'True',
           reason: 'MissingImplementation',
-          message: 'implementationSpecRef or implementation.inline is required',
+          message,
         })
+        logInvalidSpec('MissingImplementation', message)
         await setStatus(kube, agentRun, { observedGeneration, conditions: updated, phase: 'Failed' })
         return
       }
@@ -714,6 +814,7 @@ export const createAgentRunReconciler = (deps: AgentRunReconcilerDependencies) =
           reason: contractCheck.reason,
           message: contractCheck.message,
         })
+        logInvalidSpec(contractCheck.reason, contractCheck.message)
         await setStatus(kube, agentRun, {
           observedGeneration,
           conditions: updated,
@@ -728,12 +829,14 @@ export const createAgentRunReconciler = (deps: AgentRunReconcilerDependencies) =
       const agentMemoryRef = asString(readNested(agent, ['spec', 'memoryRef', 'name']))
       if ((runMemoryRef || agentMemoryRef) && !memory) {
         const missingName = runMemoryRef || agentMemoryRef || 'unknown'
+        const message = `memory ${missingName} not found`
         const updated = upsertCondition(conditions, {
           type: 'InvalidSpec',
           status: 'True',
           reason: 'MissingMemory',
-          message: `memory ${missingName} not found`,
+          message,
         })
+        logInvalidSpec('MissingMemory', message)
         await setStatus(kube, agentRun, {
           observedGeneration,
           conditions: updated,
@@ -749,12 +852,14 @@ export const createAgentRunReconciler = (deps: AgentRunReconcilerDependencies) =
         ...(authSecret ? [authSecret.name] : []),
       ])
       if (blockedSecrets.length > 0) {
+        const message = `secrets blocked by controller policy: ${blockedSecrets.join(', ')}`
         const updated = upsertCondition(conditions, {
           type: 'InvalidSpec',
           status: 'True',
           reason: 'SecretBlocked',
-          message: `secrets blocked by controller policy: ${blockedSecrets.join(', ')}`,
+          message,
         })
+        logInvalidSpec('SecretBlocked', message)
         await setStatus(kube, agentRun, {
           observedGeneration,
           conditions: updated,
@@ -772,6 +877,7 @@ export const createAgentRunReconciler = (deps: AgentRunReconcilerDependencies) =
           reason: authSecretPolicy.reason,
           message: authSecretPolicy.message,
         })
+        logInvalidSpec(authSecretPolicy.reason, authSecretPolicy.message)
         await setStatus(kube, agentRun, {
           observedGeneration,
           conditions: updated,
@@ -782,12 +888,14 @@ export const createAgentRunReconciler = (deps: AgentRunReconcilerDependencies) =
       }
       if (memorySecretName) {
         if (allowedSecrets.length > 0 && !allowedSecrets.includes(memorySecretName)) {
+          const message = `memory secret ${memorySecretName} is not allowlisted by the Agent`
           const updated = upsertCondition(conditions, {
             type: 'InvalidSpec',
             status: 'True',
             reason: 'SecretNotAllowed',
-            message: `memory secret ${memorySecretName} is not allowlisted by the Agent`,
+            message,
           })
+          logInvalidSpec('SecretNotAllowed', message)
           await setStatus(kube, agentRun, {
             observedGeneration,
             conditions: updated,
@@ -797,12 +905,14 @@ export const createAgentRunReconciler = (deps: AgentRunReconcilerDependencies) =
           return
         }
         if (runSecrets.length > 0 && !runSecrets.includes(memorySecretName)) {
+          const message = `memory secret ${memorySecretName} is not included in spec.secrets`
           const updated = upsertCondition(conditions, {
             type: 'InvalidSpec',
             status: 'True',
             reason: 'SecretNotAllowed',
-            message: `memory secret ${memorySecretName} is not included in spec.secrets`,
+            message,
           })
+          logInvalidSpec('SecretNotAllowed', message)
           await setStatus(kube, agentRun, {
             observedGeneration,
             conditions: updated,
@@ -828,6 +938,7 @@ export const createAgentRunReconciler = (deps: AgentRunReconcilerDependencies) =
           reason: systemPromptResolution.reason,
           message: systemPromptResolution.message,
         })
+        logInvalidSpec(systemPromptResolution.reason, systemPromptResolution.message)
         await setStatus(kube, agentRun, {
           observedGeneration,
           conditions: updated,
@@ -848,12 +959,15 @@ export const createAgentRunReconciler = (deps: AgentRunReconcilerDependencies) =
         existingRuns,
       })
       if (!vcsResolution.ok) {
+        const reason = vcsResolution.reason ?? 'VcsUnavailable'
+        const message = vcsResolution.message ?? 'vcs provider unavailable'
         const updated = upsertCondition(conditions, {
           type: 'InvalidSpec',
           status: 'True',
-          reason: vcsResolution.reason ?? 'VcsUnavailable',
-          message: vcsResolution.message ?? 'vcs provider unavailable',
+          reason,
+          message,
         })
+        logInvalidSpec(reason, message)
         await setStatus(kube, agentRun, {
           observedGeneration,
           phase: 'Failed',
@@ -934,6 +1048,7 @@ export const createAgentRunReconciler = (deps: AgentRunReconcilerDependencies) =
           status: 'True',
           reason: 'Submitted',
         })
+        logSubmitted(newRuntimeRef)
         await setStatus(kube, agentRun, {
           observedGeneration,
           runtimeRef: newRuntimeRef,
@@ -948,12 +1063,14 @@ export const createAgentRunReconciler = (deps: AgentRunReconcilerDependencies) =
             : {}),
         })
       } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
         const updated = upsertCondition(baseConditions, {
           type: 'Failed',
           status: 'True',
           reason: 'SubmitFailed',
-          message: error instanceof Error ? error.message : String(error),
+          message,
         })
+        logSubmitFailed('SubmitFailed', message)
         await setStatus(kube, agentRun, {
           observedGeneration,
           phase: 'Failed',
@@ -981,11 +1098,19 @@ export const createAgentRunReconciler = (deps: AgentRunReconcilerDependencies) =
       const jobObservedAt = asString(runtimeRefRecord.jobObservedAt)
       if (!job) {
         if (jobObservedAt) {
+          const message = `job ${asString(runtimeRef.name) ?? 'unknown'} not found`
           const updated = upsertCondition(conditions, {
             type: 'Warning',
             status: 'True',
             reason: 'JobMissing',
-            message: `job ${asString(runtimeRef.name) ?? 'unknown'} not found`,
+            message,
+          })
+          logAgentsControllerWarn('reconcile_runtime_orphaned', {
+            ...logContext,
+            decision: 'runtime_orphaned',
+            reason: 'JobMissing',
+            message,
+            durationMs: Date.now() - reconcileStartedAt,
           })
           await setStatus(kube, agentRun, {
             observedGeneration,
@@ -1003,6 +1128,7 @@ export const createAgentRunReconciler = (deps: AgentRunReconcilerDependencies) =
       const failed = Number(jobStatus.failed ?? 0)
       if (succeeded > 0 || isJobComplete(job)) {
         const updated = upsertCondition(conditions, { type: 'Succeeded', status: 'True', reason: 'Completed' })
+        logTerminalOutcome('Succeeded', 'Completed', `job ${asString(runtimeRef.name) ?? 'unknown'} completed`)
         await setStatus(kube, agentRun, {
           observedGeneration,
           phase: 'Succeeded',
@@ -1026,6 +1152,7 @@ export const createAgentRunReconciler = (deps: AgentRunReconcilerDependencies) =
           reason: failureDetail.reason,
           message: failureDetail.message,
         })
+        logTerminalOutcome('Failed', failureDetail.reason, failureDetail.message)
         await setStatus(kube, agentRun, {
           observedGeneration,
           phase: 'Failed',

--- a/services/jangar/src/server/agents-controller/index.ts
+++ b/services/jangar/src/server/agents-controller/index.ts
@@ -196,6 +196,8 @@ const createDefaultAgentRunIngestionRuntimeState = (): AgentRunIngestionRuntimeS
   lastResyncAtMs: null,
   untouchedRunCount: 0,
   oldestUntouchedAgeSeconds: null,
+  lastResyncSummarySignature: null,
+  lastStallSignature: null,
 })
 
 const getAgentRunIngestionRuntimeState = (namespace: string) => {
@@ -853,24 +855,52 @@ const resyncAgentRunsForNamespace = async (
     recordAgentRunResyncAdoptions(candidateRuns.length, { namespace, reason })
   }
 
-  logAgentsControllerInfo('agentrun_resync_completed', {
-    namespace,
-    reason,
-    totalRuns: refreshedRuns.size,
-    candidateCount: candidateRuns.length,
+  const resyncSummarySignature = [
+    refreshedRuns.size,
+    candidateRuns.length,
     untouchedRunCount,
-    oldestUntouchedAgeSeconds,
-  })
+    oldestUntouchedAgeSeconds ?? 'none',
+  ].join(':')
+  const shouldLogResyncSummary =
+    reason !== 'periodic' ||
+    candidateRuns.length > 0 ||
+    ingestionState.lastResyncSummarySignature !== resyncSummarySignature
+  if (shouldLogResyncSummary) {
+    logAgentsControllerInfo('agentrun_resync_completed', {
+      namespace,
+      reason,
+      totalRuns: refreshedRuns.size,
+      candidateCount: candidateRuns.length,
+      untouchedRunCount,
+      oldestUntouchedAgeSeconds,
+    })
+    ingestionState.lastResyncSummarySignature = resyncSummarySignature
+  }
 
   const warnAfterSeconds = resolveAgentRunUntouchedWarnAfterSeconds()
-  if (untouchedRunCount > 0 && oldestUntouchedAgeSeconds !== null && oldestUntouchedAgeSeconds >= warnAfterSeconds) {
-    logAgentsControllerWarn('agentrun_ingestion_stalled', {
+  const stallSignature =
+    untouchedRunCount > 0 && oldestUntouchedAgeSeconds !== null && oldestUntouchedAgeSeconds >= warnAfterSeconds
+      ? [untouchedRunCount, oldestUntouchedAgeSeconds, warnAfterSeconds].join(':')
+      : null
+  if (stallSignature) {
+    if (ingestionState.lastStallSignature !== stallSignature) {
+      logAgentsControllerWarn('agentrun_ingestion_stalled', {
+        namespace,
+        reason,
+        untouchedRunCount,
+        oldestUntouchedAgeSeconds,
+        warnAfterSeconds,
+      })
+      ingestionState.lastStallSignature = stallSignature
+    }
+  } else if (ingestionState.lastStallSignature !== null) {
+    logAgentsControllerInfo('agentrun_ingestion_recovered', {
       namespace,
       reason,
       untouchedRunCount,
       oldestUntouchedAgeSeconds,
-      warnAfterSeconds,
     })
+    ingestionState.lastStallSignature = null
   }
 
   for (const candidate of candidateRuns) {

--- a/services/jangar/src/server/agents-controller/index.ts
+++ b/services/jangar/src/server/agents-controller/index.ts
@@ -5,7 +5,14 @@ import { Context, Effect, Layer, ManagedRuntime } from 'effect'
 import { resolveBooleanFeatureToggle } from '~/server/feature-flags'
 import { createGitHubClient } from '~/server/github-client'
 import { startResourceWatch } from '~/server/kube-watch'
-import { recordAgentConcurrency, recordAgentRunOutcome, recordReconcileDurationMs } from '~/server/metrics'
+import {
+  recordAgentConcurrency,
+  recordAgentRunOutcome,
+  recordAgentRunResyncAdoptions,
+  recordAgentRunUntouchedBacklog,
+  recordAgentRunUntouchedOldestAgeSeconds,
+  recordReconcileDurationMs,
+} from '~/server/metrics'
 import { parseNamespaceScopeEnv } from '~/server/namespace-scope'
 import { asRecord, asString, readNested } from '~/server/primitives-http'
 import { createKubernetesClient, RESOURCE_MAP } from '~/server/primitives-kube'
@@ -35,7 +42,12 @@ import {
   requestAgentsControllerStart,
   requestAgentsControllerStop,
 } from './lifecycle-machine'
-import { type AgentsControllerMutableState, type CrdCheckState, createMutableState } from './mutable-state'
+import {
+  type AgentRunIngestionRuntimeState,
+  type AgentsControllerMutableState,
+  type CrdCheckState,
+  createMutableState,
+} from './mutable-state'
 import {
   type ControllerState,
   ensureNamespaceState,
@@ -61,6 +73,13 @@ import {
 } from './vcs-context'
 import { createWorkflowReconciler } from './workflow-reconciler'
 import { validateAutonomousCodexAuthSecret } from './policy'
+import {
+  logAgentsControllerDebug,
+  logAgentsControllerError,
+  logAgentsControllerInfo,
+  logAgentsControllerWarn,
+  toLogError,
+} from './operational-logging'
 
 const DEFAULT_NAMESPACES = ['agents']
 const DEFAULT_AGENTRUN_RETENTION_SECONDS = 30 * 24 * 60 * 60
@@ -70,6 +89,8 @@ const DEFAULT_TEMPORAL_ADDRESS = `${DEFAULT_TEMPORAL_HOST}:${DEFAULT_TEMPORAL_PO
 const IMPLEMENTATION_TEXT_LIMIT = 128 * 1024
 const DEFAULT_AGENTRUN_IDEMPOTENCY_RETENTION_DAYS = 30
 const DEFAULT_AGENTS_CONTROLLER_ENABLED_FLAG_KEY = 'jangar.agents_controller.enabled'
+const DEFAULT_AGENTRUN_RESYNC_INTERVAL_SECONDS = 60
+const DEFAULT_AGENTRUN_UNTOUCHED_WARN_AFTER_SECONDS = 120
 const WHITEPAPER_RUN_ID_PREFIX = 'wp-'
 const DEFAULT_WHITEPAPER_FINALIZE_BASE_URL = 'http://torghut.torghut.svc.cluster.local'
 const DEFAULT_SERVICE_ACCOUNT_TOKEN_PATH = '/var/run/secrets/kubernetes.io/serviceaccount/token'
@@ -99,6 +120,25 @@ type ControllerHealthState = {
   started: boolean
   crdCheckState: CrdCheckState | null
   namespaces: string[] | null
+  agentRunIngestion: AgentRunIngestionHealth[]
+}
+
+export type AgentRunIngestionHealth = {
+  namespace: string
+  lastWatchEventAt: string | null
+  lastResyncAt: string | null
+  untouchedRunCount: number
+  oldestUntouchedAgeSeconds: number | null
+}
+
+export type AgentsControllerHealth = {
+  enabled: boolean
+  started: boolean
+  namespaces: string[] | null
+  crdsReady: boolean | null
+  missingCrds: string[]
+  lastCheckedAt: string | null
+  agentRunIngestion?: AgentRunIngestionHealth[]
 }
 
 const globalState = globalThis as typeof globalThis & {
@@ -107,7 +147,7 @@ const globalState = globalThis as typeof globalThis & {
 
 const controllerState = (() => {
   if (globalState.__jangarAgentsControllerState) return globalState.__jangarAgentsControllerState
-  const initial = { started: false, crdCheckState: null, namespaces: null }
+  const initial = { started: false, crdCheckState: null, namespaces: null, agentRunIngestion: [] }
   globalState.__jangarAgentsControllerState = initial
   return initial
 })()
@@ -136,6 +176,87 @@ const initializeRuntimeMutableStateForLayer = () => {
 }
 
 const nowIso = () => new Date().toISOString()
+
+const resolveAgentRunResyncIntervalSeconds = () =>
+  parseNumberEnv(
+    process.env.JANGAR_AGENTS_CONTROLLER_RESYNC_INTERVAL_SECONDS,
+    DEFAULT_AGENTRUN_RESYNC_INTERVAL_SECONDS,
+    1,
+  )
+
+const resolveAgentRunUntouchedWarnAfterSeconds = () =>
+  parseNumberEnv(
+    process.env.JANGAR_AGENTS_CONTROLLER_UNTOUCHED_WARN_AFTER_SECONDS,
+    DEFAULT_AGENTRUN_UNTOUCHED_WARN_AFTER_SECONDS,
+    1,
+  )
+
+const createDefaultAgentRunIngestionRuntimeState = (): AgentRunIngestionRuntimeState => ({
+  lastWatchEventAtMs: null,
+  lastResyncAtMs: null,
+  untouchedRunCount: 0,
+  oldestUntouchedAgeSeconds: null,
+})
+
+const getAgentRunIngestionRuntimeState = (namespace: string) => {
+  const existing = runtimeMutableState.agentRunIngestionState.get(namespace)
+  if (existing) return existing
+  const created = createDefaultAgentRunIngestionRuntimeState()
+  runtimeMutableState.agentRunIngestionState.set(namespace, created)
+  return created
+}
+
+const buildAgentRunIngestionHealth = (
+  namespace: string,
+  state: AgentRunIngestionRuntimeState,
+): AgentRunIngestionHealth => ({
+  namespace,
+  lastWatchEventAt: state.lastWatchEventAtMs ? new Date(state.lastWatchEventAtMs).toISOString() : null,
+  lastResyncAt: state.lastResyncAtMs ? new Date(state.lastResyncAtMs).toISOString() : null,
+  untouchedRunCount: state.untouchedRunCount,
+  oldestUntouchedAgeSeconds: state.oldestUntouchedAgeSeconds,
+})
+
+const syncControllerAgentRunIngestionHealth = () => {
+  controllerState.agentRunIngestion = Array.from(runtimeMutableState.agentRunIngestionState.entries())
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([namespace, state]) => buildAgentRunIngestionHealth(namespace, state))
+}
+
+const recordAgentRunWatchEventSeen = (namespace: string) => {
+  getAgentRunIngestionRuntimeState(namespace).lastWatchEventAtMs = Date.now()
+  syncControllerAgentRunIngestionHealth()
+}
+
+const getAgentRunUntouchedReasons = (agentRun: Record<string, unknown>) => {
+  const reasons: string[] = []
+  const metadata = asRecord(agentRun.metadata) ?? {}
+  const status = asRecord(agentRun.status) ?? {}
+  const generation = metadata.generation
+  const observedGeneration = status.observedGeneration
+  const phase = asString(status.phase)
+  const finalizers = Array.isArray(metadata.finalizers)
+    ? metadata.finalizers.filter((item): item is string => typeof item === 'string')
+    : []
+
+  if (!phase) reasons.push('missing_phase')
+  if (observedGeneration == null) {
+    reasons.push('missing_observed_generation')
+  } else if (generation != null && observedGeneration !== generation) {
+    reasons.push('generation_drift')
+  }
+  if (!finalizers.includes('agents.proompteng.ai/runtime-cleanup')) {
+    reasons.push('missing_finalizer')
+  }
+  return reasons
+}
+
+const getAgentRunCreationTimestampMs = (agentRun: Record<string, unknown>) => {
+  const createdAt = asString(readNested(agentRun, ['metadata', 'creationTimestamp']))
+  if (!createdAt) return null
+  const parsed = Date.parse(createdAt)
+  return Number.isNaN(parsed) ? null : parsed
+}
 
 const safeParseJsonRecord = (value: string) => {
   try {
@@ -469,13 +590,14 @@ const resolveNamespaces = async () => {
   return resolved
 }
 
-export const getAgentsControllerHealth = () => ({
+export const getAgentsControllerHealth = (): AgentsControllerHealth => ({
   enabled: shouldStart(),
   started: controllerState.started,
   namespaces: controllerState.namespaces,
   crdsReady: controllerState.crdCheckState?.ok ?? null,
   missingCrds: controllerState.crdCheckState?.missing ?? [],
   lastCheckedAt: controllerState.crdCheckState?.checkedAt ?? null,
+  agentRunIngestion: controllerState.agentRunIngestion,
 })
 
 const isAgentRunIdempotencyEnabled = () => parseBooleanEnv(process.env.JANGAR_AGENTRUN_IDEMPOTENCY_ENABLED, true)
@@ -653,14 +775,116 @@ const resetControllerRateState = () => {
 }
 
 const enqueueNamespaceTask = (namespace: string, task: () => Promise<void>) => {
+  logAgentsControllerDebug('namespace_task_enqueued', { namespace })
   const current = runtimeMutableState.namespaceQueues.get(namespace) ?? Promise.resolve()
   const next = current
     .catch(() => undefined)
-    .then(task)
+    .then(async () => {
+      const startedAt = Date.now()
+      logAgentsControllerDebug('namespace_task_started', { namespace })
+      try {
+        await task()
+      } finally {
+        logAgentsControllerDebug('namespace_task_completed', {
+          namespace,
+          durationMs: Date.now() - startedAt,
+        })
+      }
+    })
     .catch((error) => {
-      console.warn('[jangar] agents controller task failed', error)
+      logAgentsControllerWarn('namespace_task_failed', {
+        namespace,
+        ...toLogError(error),
+      })
     })
   runtimeMutableState.namespaceQueues.set(namespace, next)
+  return next
+}
+
+const resyncAgentRunsForNamespace = async (
+  kube: ReturnType<typeof createKubernetesClient>,
+  namespace: string,
+  state: ControllerState,
+  concurrency: ReturnType<typeof parseConcurrency>,
+  reason: 'periodic' | 'watch_restart' | 'manual',
+) => {
+  const nsState = ensureNamespaceState(state, namespace)
+  const runList = listItems(await kube.list(RESOURCE_MAP.AgentRun, namespace))
+  const refreshedRuns = new Map<string, Record<string, unknown>>()
+  const candidateRuns: Array<{ run: Record<string, unknown>; reasons: string[] }> = []
+  let untouchedRunCount = 0
+  let oldestUntouchedAgeSeconds: number | null = null
+  const now = Date.now()
+
+  for (const run of runList) {
+    const name = asString(readNested(run, ['metadata', 'name']))
+    if (!name) continue
+    refreshedRuns.set(name, run)
+    const reasons = getAgentRunUntouchedReasons(run)
+    const untouchedReasons = reasons.filter((entry) => entry !== 'generation_drift')
+    if (untouchedReasons.length > 0) {
+      untouchedRunCount += 1
+      const createdAtMs = getAgentRunCreationTimestampMs(run)
+      if (createdAtMs !== null) {
+        const ageSeconds = Math.max(0, Math.floor((now - createdAtMs) / 1000))
+        oldestUntouchedAgeSeconds =
+          oldestUntouchedAgeSeconds === null ? ageSeconds : Math.max(oldestUntouchedAgeSeconds, ageSeconds)
+      }
+    }
+    if (reasons.length > 0) {
+      candidateRuns.push({ run, reasons })
+    }
+  }
+
+  nsState.runs = refreshedRuns
+
+  const ingestionState = getAgentRunIngestionRuntimeState(namespace)
+  ingestionState.lastResyncAtMs = now
+  ingestionState.untouchedRunCount = untouchedRunCount
+  ingestionState.oldestUntouchedAgeSeconds = oldestUntouchedAgeSeconds
+  syncControllerAgentRunIngestionHealth()
+
+  recordAgentRunUntouchedBacklog(untouchedRunCount, { namespace, reason })
+  if (oldestUntouchedAgeSeconds !== null) {
+    recordAgentRunUntouchedOldestAgeSeconds(oldestUntouchedAgeSeconds, { namespace, reason })
+  }
+
+  if (candidateRuns.length > 0) {
+    recordAgentRunResyncAdoptions(candidateRuns.length, { namespace, reason })
+  }
+
+  logAgentsControllerInfo('agentrun_resync_completed', {
+    namespace,
+    reason,
+    totalRuns: refreshedRuns.size,
+    candidateCount: candidateRuns.length,
+    untouchedRunCount,
+    oldestUntouchedAgeSeconds,
+  })
+
+  const warnAfterSeconds = resolveAgentRunUntouchedWarnAfterSeconds()
+  if (untouchedRunCount > 0 && oldestUntouchedAgeSeconds !== null && oldestUntouchedAgeSeconds >= warnAfterSeconds) {
+    logAgentsControllerWarn('agentrun_ingestion_stalled', {
+      namespace,
+      reason,
+      untouchedRunCount,
+      oldestUntouchedAgeSeconds,
+      warnAfterSeconds,
+    })
+  }
+
+  for (const candidate of candidateRuns) {
+    const runName = asString(readNested(candidate.run, ['metadata', 'name'])) ?? 'unknown'
+    logAgentsControllerDebug('agentrun_resync_adopted', {
+      namespace,
+      runName,
+      reason,
+      adoptionReasons: candidate.reasons,
+    })
+    await enqueueNamespaceTask(namespace, () =>
+      reconcileRunWithState(kube, namespace, candidate.run, state, concurrency),
+    )
+  }
 }
 
 const {
@@ -929,6 +1153,13 @@ const startNamespaceWatches = (
   const handleAgentRunEvent = (event: { type?: string; object?: Record<string, unknown> }) => {
     const resource = asRecord(event.object)
     if (!resource) return
+    const runName = asString(readNested(resource, ['metadata', 'name'])) ?? 'unknown'
+    recordAgentRunWatchEventSeen(namespace)
+    logAgentsControllerDebug('agentrun_watch_event_seen', {
+      namespace,
+      runName,
+      eventType: event.type ?? 'UNKNOWN',
+    })
     updateStateMap(nsState.runs, event.type, resource)
     if (event.type === 'DELETED') return
     enqueueNamespaceTask(namespace, () => reconcileRunWithState(kube, namespace, resource, state, concurrency))
@@ -995,7 +1226,18 @@ const startNamespaceWatches = (
       resource: RESOURCE_MAP.AgentRun,
       namespace,
       onEvent: handleAgentRunEvent,
-      onError: (error) => console.warn('[jangar] agent run watch failed', error),
+      onError: (error) =>
+        logAgentsControllerWarn('agentrun_watch_failed', {
+          namespace,
+          ...toLogError(error),
+        }),
+      onRestart: (restartReason) => {
+        logAgentsControllerWarn('agentrun_watch_restarted', {
+          namespace,
+          reason: restartReason,
+        })
+        void resyncAgentRunsForNamespace(kube, namespace, state, concurrency, 'watch_restart')
+      },
     }),
   )
   handles.push(
@@ -1057,6 +1299,16 @@ const startNamespaceWatches = (
       onError: (error) => console.warn('[jangar] agent job watch failed', error),
     }),
   )
+
+  const resyncInterval = resolveAgentRunResyncIntervalSeconds() * 1000
+  const timer = setInterval(() => {
+    void resyncAgentRunsForNamespace(kube, namespace, state, concurrency, 'periodic')
+  }, resyncInterval)
+  handles.push({
+    stop: () => clearInterval(timer),
+  })
+
+  void resyncAgentRunsForNamespace(kube, namespace, state, concurrency, 'manual')
 }
 
 const startAgentsControllerInternal = async () => {
@@ -1090,8 +1342,10 @@ const startAgentsControllerInternal = async () => {
       resolveCrdCheckNamespace,
       nowIso,
     })
+    runtimeMutableState.crdCheckState = crdsReady
+    controllerState.crdCheckState = crdsReady
   } catch (error) {
-    console.error('[jangar] agents controller failed to validate namespace scope', error)
+    logAgentsControllerError('startup_namespace_scope_failed', toLogError(error))
     runtimeMutableState.starting = false
     markAgentsControllerStartFailed(runtimeMutableState.lifecycleActor)
     if (error instanceof Error && error.name === 'NamespaceScopeConfigError') {
@@ -1100,7 +1354,9 @@ const startAgentsControllerInternal = async () => {
     throw error
   }
   if (!crdsReady.ok) {
-    console.error('[jangar] agents controller will not start without CRDs')
+    logAgentsControllerError('startup_missing_crds', {
+      missingCrds: crdsReady.missing,
+    })
     runtimeMutableState.starting = false
     markAgentsControllerStartFailed(runtimeMutableState.lifecycleActor)
     return
@@ -1110,7 +1366,7 @@ const startAgentsControllerInternal = async () => {
     const namespaces = await resolveNamespaces()
     if (runtimeMutableState.lifecycleToken !== token) return
     controllerState.namespaces = namespaces
-    console.info('[jangar] agents controller namespace scope:', JSON.stringify(namespaces))
+    logAgentsControllerInfo('startup_namespace_scope', { namespaces })
     const kube = createKubernetesClient()
     const concurrency = parseConcurrency()
     const state: ControllerState = { namespaces: new Map() }
@@ -1128,8 +1384,10 @@ const startAgentsControllerInternal = async () => {
     runtimeMutableState.started = true
     markAgentsControllerStarted(runtimeMutableState.lifecycleActor)
     controllerState.started = true
+    syncControllerAgentRunIngestionHealth()
+    logAgentsControllerInfo('startup_complete', { namespaces })
   } catch (error) {
-    console.error('[jangar] agents controller failed to start', error)
+    logAgentsControllerError('startup_failed', toLogError(error))
     if (runtimeMutableState.lifecycleToken === token) {
       markAgentsControllerStartFailed(runtimeMutableState.lifecycleActor)
     }
@@ -1162,12 +1420,12 @@ const stopAgentsControllerInternal = () => {
   runtimeMutableState.watchHandles = []
   runtimeMutableState.controllerSnapshot = null
   runtimeMutableState.namespaceQueues.clear()
+  runtimeMutableState.agentRunIngestionState.clear()
   runtimeMutableState.started = false
   controllerState.started = false
   controllerState.namespaces = null
+  controllerState.agentRunIngestion = []
 }
-
-export type AgentsControllerHealth = ReturnType<typeof getAgentsControllerHealth>
 
 export type AgentsControllerService = {
   start: Effect.Effect<void, Error>
@@ -1229,4 +1487,7 @@ export const __test = {
   resolveVcsPrRateLimits,
   resolveJobImage,
   resolveVcsContext,
+  getAgentRunUntouchedReasons,
+  resyncAgentRunsForNamespace,
+  syncControllerAgentRunIngestionHealth,
 }

--- a/services/jangar/src/server/agents-controller/mutable-state.ts
+++ b/services/jangar/src/server/agents-controller/mutable-state.ts
@@ -16,6 +16,8 @@ export type AgentRunIngestionRuntimeState = {
   lastResyncAtMs: number | null
   untouchedRunCount: number
   oldestUntouchedAgeSeconds: number | null
+  lastResyncSummarySignature: string | null
+  lastStallSignature: string | null
 }
 
 export type AgentsControllerMutableState<TControllerState> = {

--- a/services/jangar/src/server/agents-controller/mutable-state.ts
+++ b/services/jangar/src/server/agents-controller/mutable-state.ts
@@ -11,6 +11,13 @@ export type CrdCheckState = {
 
 export type RateBucket = { count: number; resetAt: number }
 
+export type AgentRunIngestionRuntimeState = {
+  lastWatchEventAtMs: number | null
+  lastResyncAtMs: number | null
+  untouchedRunCount: number
+  oldestUntouchedAgeSeconds: number | null
+}
+
 export type AgentsControllerMutableState<TControllerState> = {
   lifecycleActor: AgentsControllerLifecycleActor
   started: boolean
@@ -30,6 +37,7 @@ export type AgentsControllerMutableState<TControllerState> = {
     perNamespace: Map<string, RateBucket>
     perRepo: Map<string, RateBucket>
   }
+  agentRunIngestionState: Map<string, AgentRunIngestionRuntimeState>
 }
 
 export const createMutableState = <TControllerState>(input: {
@@ -54,4 +62,5 @@ export const createMutableState = <TControllerState>(input: {
     perNamespace: new Map<string, RateBucket>(),
     perRepo: new Map<string, RateBucket>(),
   },
+  agentRunIngestionState: new Map<string, AgentRunIngestionRuntimeState>(),
 })

--- a/services/jangar/src/server/agents-controller/operational-logging.ts
+++ b/services/jangar/src/server/agents-controller/operational-logging.ts
@@ -1,0 +1,51 @@
+import { parseBooleanEnv } from './env-config'
+
+type LogLevel = 'info' | 'warn' | 'error'
+
+type LogPayload = Record<string, unknown>
+
+const COMPONENT = 'agents-controller'
+
+const normalizeError = (error: unknown) => (error instanceof Error ? error.message : String(error))
+
+const writeLog = (level: LogLevel, event: string, payload: LogPayload = {}) => {
+  const entry = {
+    component: COMPONENT,
+    event,
+    ...payload,
+  }
+  const message = `[jangar][${COMPONENT}] ${event}`
+  if (level === 'error') {
+    console.error(message, entry)
+    return
+  }
+  if (level === 'warn') {
+    console.warn(message, entry)
+    return
+  }
+  console.info(message, entry)
+}
+
+export const isAgentsControllerDebugLoggingEnabled = () =>
+  parseBooleanEnv(process.env.JANGAR_AGENTS_CONTROLLER_DEBUG_LOGS, false)
+
+export const logAgentsControllerInfo = (event: string, payload?: LogPayload) => {
+  writeLog('info', event, payload)
+}
+
+export const logAgentsControllerWarn = (event: string, payload?: LogPayload) => {
+  writeLog('warn', event, payload)
+}
+
+export const logAgentsControllerError = (event: string, payload?: LogPayload) => {
+  writeLog('error', event, payload)
+}
+
+export const logAgentsControllerDebug = (event: string, payload?: LogPayload) => {
+  if (!isAgentsControllerDebugLoggingEnabled()) return
+  writeLog('info', event, payload)
+}
+
+export const toLogError = (error: unknown) => ({
+  error: normalizeError(error),
+})

--- a/services/jangar/src/server/agents-controller/workflow-reconciler.ts
+++ b/services/jangar/src/server/agents-controller/workflow-reconciler.ts
@@ -26,6 +26,7 @@ import {
   type WorkflowStepStatus,
   type WorkflowStepSpec,
 } from './workflow'
+import { logAgentsControllerInfo, logAgentsControllerWarn } from './operational-logging'
 
 type KubeClient = ReturnType<typeof createKubernetesClient>
 
@@ -402,6 +403,7 @@ export const createWorkflowReconciler = (deps: WorkflowReconcilerDependencies) =
     memories: Record<string, unknown>[],
     options: { initialSubmit?: boolean } = {},
   ) => {
+    const reconcileStartedAt = Date.now()
     const metadata = asRecord(agentRun.metadata) ?? {}
     const runName = asString(metadata.name) ?? 'agentrun'
     const status = asRecord(agentRun.status) ?? {}
@@ -411,6 +413,24 @@ export const createWorkflowReconciler = (deps: WorkflowReconcilerDependencies) =
     const baseWorkload = asRecord(readNested(agentRun, ['spec', 'workload'])) ?? {}
     const workflowValidation = validateWorkflowSteps(workflowSteps, { baseWorkload })
     const conditions = deps.buildConditions(agentRun)
+    const runtimeType = asString(readNested(agentRun, ['spec', 'runtime', 'type'])) ?? 'workflow'
+    const repository = asString(readNested(agentRun, ['spec', 'parameters', 'repository'])) ?? ''
+    const logContext = {
+      namespace,
+      runName,
+      generation: observedGeneration,
+      runtimeType,
+      repository,
+    }
+    const logInvalidSpec = (reason: string, message: string) => {
+      logAgentsControllerInfo('reconcile_invalid_spec', {
+        ...logContext,
+        decision: 'invalid_spec',
+        reason,
+        message,
+        durationMs: Date.now() - reconcileStartedAt,
+      })
+    }
 
     if (!workflowValidation.ok) {
       const updated = upsertCondition(conditions, {
@@ -419,6 +439,7 @@ export const createWorkflowReconciler = (deps: WorkflowReconcilerDependencies) =
         reason: workflowValidation.reason,
         message: workflowValidation.message,
       })
+      logInvalidSpec(workflowValidation.reason, workflowValidation.message)
       await deps.setStatus(kube, agentRun, {
         observedGeneration,
         phase: 'Failed',
@@ -444,6 +465,7 @@ export const createWorkflowReconciler = (deps: WorkflowReconcilerDependencies) =
         reason: imagePolicy.reason,
         message: imagePolicy.message,
       })
+      logInvalidSpec(imagePolicy.reason, imagePolicy.message)
       await deps.setStatus(kube, agentRun, {
         observedGeneration,
         phase: 'Failed',
@@ -461,6 +483,7 @@ export const createWorkflowReconciler = (deps: WorkflowReconcilerDependencies) =
         reason: dependencies.reason,
         message: dependencies.message,
       })
+      logInvalidSpec(dependencies.reason, dependencies.message)
       await deps.setStatus(kube, agentRun, {
         observedGeneration,
         phase: 'Failed',
@@ -492,6 +515,7 @@ export const createWorkflowReconciler = (deps: WorkflowReconcilerDependencies) =
         reason: systemPromptResolution.reason,
         message: systemPromptResolution.message,
       })
+      logInvalidSpec(systemPromptResolution.reason, systemPromptResolution.message)
       await deps.setStatus(kube, agentRun, {
         observedGeneration,
         phase: 'Failed',
@@ -816,6 +840,13 @@ export const createWorkflowReconciler = (deps: WorkflowReconcilerDependencies) =
             reason: 'WorkflowJobMissing',
             message: `workflow step ${stepSpec.name} job ${jobName} not found`,
           })
+          logAgentsControllerWarn('reconcile_runtime_orphaned', {
+            ...logContext,
+            decision: 'runtime_orphaned',
+            reason: 'WorkflowJobMissing',
+            message: `workflow step ${stepSpec.name} job ${jobName} not found`,
+            durationMs: Date.now() - reconcileStartedAt,
+          })
           if (stepStatus.attempt < maxAttempts) {
             setWorkflowStepPhase(stepStatus, 'Retrying', 'Job missing; retrying')
             stepStatus.finishedAt = deps.nowIso()
@@ -1056,6 +1087,14 @@ export const createWorkflowReconciler = (deps: WorkflowReconcilerDependencies) =
         reason: workflowFailure.reason,
         message: workflowFailure.message,
       })
+      logAgentsControllerInfo('reconcile_terminal', {
+        ...logContext,
+        decision: 'terminal',
+        outcome: 'Failed',
+        reason: workflowFailure.reason,
+        message: workflowFailure.message,
+        durationMs: Date.now() - reconcileStartedAt,
+      })
       await deps.setStatus(kube, agentRun, {
         observedGeneration,
         phase: 'Failed',
@@ -1083,6 +1122,14 @@ export const createWorkflowReconciler = (deps: WorkflowReconcilerDependencies) =
         status: 'True',
         reason: 'Completed',
       })
+      logAgentsControllerInfo('reconcile_terminal', {
+        ...logContext,
+        decision: 'terminal',
+        outcome: 'Succeeded',
+        reason: 'Completed',
+        message: 'workflow completed',
+        durationMs: Date.now() - reconcileStartedAt,
+      })
       await deps.setStatus(kube, agentRun, {
         observedGeneration,
         phase: 'Succeeded',
@@ -1106,6 +1153,13 @@ export const createWorkflowReconciler = (deps: WorkflowReconcilerDependencies) =
       let updated = baseConditions
       if (options.initialSubmit) {
         updated = upsertCondition(updated, { type: 'Accepted', status: 'True', reason: 'Submitted' })
+        logAgentsControllerInfo('reconcile_submitted', {
+          ...logContext,
+          decision: 'submitted',
+          runtimeRefType: 'workflow',
+          runtimeRefName: runtimeRefUpdate?.name ?? '',
+          durationMs: Date.now() - reconcileStartedAt,
+        })
       }
       updated = upsertCondition(updated, { type: 'InProgress', status: 'True', reason: 'Running' })
       await deps.setStatus(kube, agentRun, {

--- a/services/jangar/src/server/control-plane-status.ts
+++ b/services/jangar/src/server/control-plane-status.ts
@@ -140,6 +140,16 @@ export type ControlPlaneWatchReliability = {
   streams: ControlPlaneWatchReliabilitySummary['streams']
 }
 
+export type AgentRunIngestionStatus = {
+  namespace: string
+  status: 'healthy' | 'degraded' | 'unknown'
+  message: string
+  last_watch_event_at: string
+  last_resync_at: string
+  untouched_run_count: number
+  oldest_untouched_age_seconds: number | null
+}
+
 export type ControlPlaneStatus = {
   service: string
   generated_at: string
@@ -160,6 +170,7 @@ export type ControlPlaneStatus = {
   database: DatabaseStatus
   grpc: GrpcStatus
   watch_reliability: ControlPlaneWatchReliability
+  agentrun_ingestion: AgentRunIngestionStatus
   workflows: WorkflowsReliabilityStatus
   dependency_quorum: DependencyQuorumStatus
   rollout_health: ControlPlaneRolloutHealth
@@ -186,6 +197,38 @@ export type ControlPlaneStatusDeps = {
 }
 
 const normalizeMessage = (value: unknown) => (value instanceof Error ? value.message : String(value))
+
+const buildAgentRunIngestionStatus = (
+  namespace: string,
+  health: ReturnType<typeof getAgentsControllerHealth>,
+): AgentRunIngestionStatus => {
+  const entry = (health.agentRunIngestion ?? []).find((item) => item.namespace === namespace) ?? {
+    namespace,
+    lastWatchEventAt: null,
+    lastResyncAt: null,
+    untouchedRunCount: 0,
+    oldestUntouchedAgeSeconds: null,
+  }
+  const warnAfterSeconds = parseOptionalNumber(process.env.JANGAR_AGENTS_CONTROLLER_UNTOUCHED_WARN_AFTER_SECONDS) ?? 120
+  const isDegraded =
+    entry.untouchedRunCount > 0 &&
+    entry.oldestUntouchedAgeSeconds !== null &&
+    entry.oldestUntouchedAgeSeconds >= warnAfterSeconds
+
+  return {
+    namespace,
+    status: isDegraded ? 'degraded' : health.started ? 'healthy' : 'unknown',
+    message: isDegraded
+      ? `untouched AgentRuns detected for ${entry.oldestUntouchedAgeSeconds}s`
+      : health.started
+        ? 'AgentRun ingestion healthy'
+        : 'agents controller not started',
+    last_watch_event_at: entry.lastWatchEventAt ?? '',
+    last_resync_at: entry.lastResyncAt ?? '',
+    untouched_run_count: entry.untouchedRunCount,
+    oldest_untouched_age_seconds: entry.oldestUntouchedAgeSeconds,
+  }
+}
 
 const buildMigrationConsistencyStatus = (input: {
   migrationTable: string | null
@@ -1198,6 +1241,7 @@ export const buildControlPlaneStatus = async (
   const isWorkflowsDataUnavailable = isWorkflowsDataUnknown || isWorkflowsDataDegraded
   const isWorkflowsWarning = workflows.backoff_limit_exceeded_jobs >= warningBackoffThreshold
   const isWorkflowsDegraded = workflows.backoff_limit_exceeded_jobs >= degradedBackoffThreshold
+  const agentRunIngestion = buildAgentRunIngestionStatus(options.namespace, agentsHealth)
   const dependencyQuorum = buildDependencyQuorum({
     controllers,
     runtimeAdapters,
@@ -1220,6 +1264,7 @@ export const buildControlPlaneStatus = async (
     ...(database.status === 'healthy' ? [] : ['database']),
     ...(grpcStatus.enabled && grpcStatus.status !== 'healthy' ? ['grpc'] : []),
     ...(watchReliability.status === 'degraded' ? ['watch_reliability'] : []),
+    ...(agentRunIngestion.status === 'degraded' ? ['agentrun_ingestion'] : []),
     ...(isWorkflowsDataUnavailable || isWorkflowsWarning || isWorkflowsDegraded ? ['workflows'] : []),
     ...(isWorkflowsDataUnknown || isWorkflowsDegraded ? ['runtime:workflows'] : []),
     ...(rolloutHealth.status === 'degraded' ? ['rollout_health'] : []),
@@ -1256,6 +1301,7 @@ export const buildControlPlaneStatus = async (
       total_restarts: watchReliability.total_restarts,
       streams: watchReliability.streams,
     },
+    agentrun_ingestion: agentRunIngestion,
     rollout_health: rolloutHealth,
     workflows,
     dependency_quorum: dependencyQuorum,

--- a/services/jangar/src/server/kube-watch.ts
+++ b/services/jangar/src/server/kube-watch.ts
@@ -19,6 +19,7 @@ type WatchOptions = {
   restartDelayMs?: number
   onEvent: (event: WatchEvent) => void | Promise<void>
   onError?: (error: Error) => void
+  onRestart?: (reason: string) => void | Promise<void>
   logPrefix?: string
 }
 
@@ -92,6 +93,7 @@ export const startResourceWatch = (options: WatchOptions): WatchHandle => {
     restartDelayMs = DEFAULT_RESTART_DELAY_MS,
     onEvent,
     onError,
+    onRestart,
     logPrefix = '[jangar][watch]',
   } = options
 
@@ -117,6 +119,7 @@ export const startResourceWatch = (options: WatchOptions): WatchHandle => {
       resource: normalizedResource,
       namespace: normalizedNamespace,
     })
+    void onRestart?.(reason)
   }
 
   const start = () => {

--- a/services/jangar/src/server/metrics.ts
+++ b/services/jangar/src/server/metrics.ts
@@ -29,6 +29,9 @@ type JangarMetrics = {
   agentRateLimitRejections: Counter
   agentConcurrency: Histogram
   agentRunOutcomes: Counter
+  agentRunResyncAdoptions: Counter
+  agentRunUntouchedBacklog: Histogram
+  agentRunUntouchedOldestAgeSeconds: Histogram
   reconcileDurationMs: Histogram
   torghutQuantFrames: Counter
   torghutQuantStaleFrames: Counter
@@ -146,6 +149,27 @@ export const recordAgentConcurrency = (count: number, attributes?: MetricsAttrib
 export const recordAgentRunOutcome = (outcome: string, attributes?: MetricsAttributes) => {
   if (!metricsState.enabled) return
   recordCounter(metricsState.metrics?.agentRunOutcomes, 1, { outcome, ...attributes })
+}
+
+export const recordAgentRunResyncAdoptions = (count: number, attributes?: MetricsAttributes) => {
+  if (!metricsState.enabled) return
+  if (Number.isFinite(count) && count > 0) {
+    recordCounter(metricsState.metrics?.agentRunResyncAdoptions, count, attributes)
+  }
+}
+
+export const recordAgentRunUntouchedBacklog = (count: number, attributes?: MetricsAttributes) => {
+  if (!metricsState.enabled) return
+  if (Number.isFinite(count) && count >= 0) {
+    recordHistogram(metricsState.metrics?.agentRunUntouchedBacklog, count, attributes)
+  }
+}
+
+export const recordAgentRunUntouchedOldestAgeSeconds = (ageSeconds: number, attributes?: MetricsAttributes) => {
+  if (!metricsState.enabled) return
+  if (Number.isFinite(ageSeconds) && ageSeconds >= 0) {
+    recordHistogram(metricsState.metrics?.agentRunUntouchedOldestAgeSeconds, ageSeconds, attributes)
+  }
 }
 
 export const recordReconcileDurationMs = (durationMs: number, attributes?: MetricsAttributes) => {
@@ -584,6 +608,16 @@ const createMetricsState = (): MetricsState => {
       }),
       agentRunOutcomes: meter.createCounter('jangar_agent_run_outcomes_total', {
         description: 'Count of AgentRun terminal outcomes by phase.',
+      }),
+      agentRunResyncAdoptions: meter.createCounter('jangar_agentrun_resync_adoptions_total', {
+        description: 'Count of AgentRuns adopted for reconciliation by controller resync sweeps.',
+      }),
+      agentRunUntouchedBacklog: meter.createHistogram('jangar_agentrun_untouched_backlog', {
+        description: 'Observed count of untouched AgentRuns detected by the controller.',
+      }),
+      agentRunUntouchedOldestAgeSeconds: meter.createHistogram('jangar_agentrun_untouched_oldest_age_seconds', {
+        description: 'Observed age in seconds of the oldest untouched AgentRun.',
+        unit: 's',
       }),
       reconcileDurationMs: meter.createHistogram('jangar_reconcile_duration_ms', {
         description: 'Time spent reconciling agents controller resources.',


### PR DESCRIPTION
## Summary

- add an agents-controller AgentRun relist/resync path so newly created runs are adopted even when the live watch path misses them
- add structured control-plane logging for AgentRun/watch/reconcile decisions plus ingestion metrics and restart hooks
- expose `agentrun_ingestion` in control-plane status and surface it in the Jangar status panel
- reduce repeated ingestion stall log noise by logging unchanged degraded state once and emitting a recovery event when the backlog clears
- document the new ingestion env vars and status field in the Jangar README and agents runbook

## Related Issues

None

## Testing

- `bunx vitest run --config vitest.config.ts src/server/__tests__/agents-controller.test.ts src/server/__tests__/control-plane-status.test.ts src/server/__tests__/kube-watch.test.ts src/components/__tests__/agents-control-plane-status.test.tsx`
- `bunx tsc --noEmit -p tsconfig.app.json`
- `bun run --filter @proompteng/jangar lint`
- `bun run --filter @proompteng/jangar lint:oxlint` (passes with pre-existing warnings outside this change set)

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
