### PR TITLE
fix(torghut): wire simulation trace db session

### DIFF
--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -42,6 +42,11 @@ spec:
       image: registry.ide-newton.ts.net/lab/torghut@sha256:74d4f4b227a3d54926f24afc3d3762d8f7d868ddd214b5ed922b2200857e8a1d
       imagePullPolicy: Always
       env:
+        - name: DB_DSN
+          valueFrom:
+            secretKeyRef:
+              name: torghut-db-app
+              key: uri
         - name: TORGHUT_SIM_KAFKA_PASSWORD
           valueFrom:
             secretKeyRef:

--- a/services/torghut/config/simulation/smoke-open-30m-2026-03-06.yaml
+++ b/services/torghut/config/simulation/smoke-open-30m-2026-03-06.yaml
@@ -1,0 +1,90 @@
+dataset_id: torghut-smoke-open-30m-20260306
+dataset_snapshot_ref: torghut-smoke-open-30m-20260306
+
+window:
+  trading_day: '2026-03-06'
+  timezone: America/New_York
+  start: '2026-03-06T14:30:00Z'
+  end: '2026-03-06T15:00:00Z'
+  min_coverage_minutes: 30
+  strict_coverage_ratio: 0.95
+
+kafka:
+  bootstrap_servers: kafka-kafka-bootstrap.kafka.svc.cluster.local:9092
+  runtime_bootstrap_servers: kafka-kafka-bootstrap.kafka.svc.cluster.local:9092
+  security_protocol: SASL_PLAINTEXT
+  sasl_mechanism: SCRAM-SHA-512
+  sasl_username: kafka-codex-credentials
+  sasl_password_env: TORGHUT_SIM_KAFKA_PASSWORD
+  runtime_security_protocol: SASL_PLAINTEXT
+  runtime_sasl_mechanism: SCRAM-SHA-512
+  runtime_sasl_username: kafka-codex-credentials
+  runtime_sasl_password_env: TORGHUT_SIM_KAFKA_PASSWORD
+  default_partitions: 8
+  replication_factor: 1
+
+clickhouse:
+  http_url: http://torghut-clickhouse.torghut.svc.cluster.local:8123
+  username: torghut
+  password_env: TORGHUT_CLICKHOUSE_PASSWORD
+  password_secret_name: torghut-clickhouse-auth
+  password_secret_key: torghut_password
+  secret_namespace: torghut
+  simulation_database: torghut_sim_2026_03_06_open_30m
+
+postgres:
+  admin_dsn: postgresql://torghut_app@torghut-db-rw.torghut.svc.cluster.local:5432/postgres
+  admin_dsn_password_env: TORGHUT_POSTGRES_PASSWORD
+  simulation_dsn: postgresql://torghut_app@torghut-db-rw.torghut.svc.cluster.local:5432/torghut_sim_sim_2026_03_06_open_30m
+  runtime_simulation_dsn: postgresql://torghut_app@torghut-db-rw.torghut.svc.cluster.local:5432/torghut_sim_sim_2026_03_06_open_30m
+  migrations_command: /opt/venv/bin/alembic upgrade heads
+
+runtime:
+  target_mode: dedicated_service
+  namespace: torghut
+  ta_configmap: torghut-ta-sim-config
+  ta_deployment: torghut-ta-sim
+  torghut_service: torghut-sim
+  torghut_forecast_service: torghut-forecast-sim
+  output_root: artifacts/torghut/simulations
+
+rollouts:
+  enabled: true
+  namespace: torghut
+  runtime_template: torghut-simulation-runtime-ready
+  activity_template: torghut-simulation-activity
+  teardown_template: torghut-simulation-teardown-clean
+  artifact_template: torghut-simulation-artifact-bundle
+
+replay:
+  pace_mode: max_throughput
+  acceleration: 1
+  max_sleep_seconds: 0
+  auto_offset_reset: earliest
+  flush_every_records: 50000
+  flush_timeout_seconds: 60
+  final_flush_timeout_seconds: 180
+  status_update_every_records: 25000
+  status_update_every_seconds: 30
+
+monitor:
+  timeout_seconds: 1800
+  poll_seconds: 20
+  min_trade_decisions: 1
+  min_executions: 1
+  min_execution_tca_metrics: 1
+  min_execution_order_events: 1
+  cursor_grace_seconds: 120
+
+argocd:
+  manage_automation: true
+  applicationset_name: product
+  applicationset_namespace: argocd
+  app_name: torghut
+  desired_mode_during_run: manual
+  restore_mode_after_run: previous
+  verify_timeout_seconds: 600
+
+reporting:
+  commission_bps: '0'
+  per_trade_fee: '0'


### PR DESCRIPTION
## Summary

- provide `DB_DSN` to the historical simulation workflow so completion-trace persistence can use the live Torghut app database instead of falling back to an invalid localhost DSN
- add the tracked 30-minute open-window canary manifest for March 6, 2026 so the first proving run is reproducible from Git
- keep the dedicated-service simulation contract and rollout wiring otherwise unchanged

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/torghut >/tmp/torghut-kustomize.yaml`
- `rg -n "name: DB_DSN|name: torghut-historical-simulation" /tmp/torghut-kustomize.yaml`
- `rg -n "dataset_id: torghut-smoke-open-30m-20260306|start: '2026-03-06T14:30:00Z'|end: '2026-03-06T15:00:00Z'" services/torghut/config/simulation/smoke-open-30m-2026-03-06.yaml`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
