### PR TITLE
chore(jangar): promote image 7072c7a7

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 9f306ea4
-  digest: sha256:10787a512cfadcbdd084e0c2814e0e5fc2ae5322b2289e85e5624cd93f2d45fb
+  tag: 7072c7a7
+  digest: sha256:06798551abe09688a89caa8455c93b7e8477e660faec5410bb523f8892ea0590
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 9f306ea4
-    digest: sha256:892e9edcdea8bed8c262649b65409c681da3c74af4b994bf9f4be8ba22abab3f
+    tag: 7072c7a7
+    digest: sha256:228116d45fadddb3aa38c9f459af18f8375402c7ef3eadbd4ae44beca4b42504
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 9f306ea4
-    digest: sha256:10787a512cfadcbdd084e0c2814e0e5fc2ae5322b2289e85e5624cd93f2d45fb
+    tag: 7072c7a7
+    digest: sha256:06798551abe09688a89caa8455c93b7e8477e660faec5410bb523f8892ea0590
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-06T23:10:22Z"
+    deploy.knative.dev/rollout: "2026-03-07T22:07:45Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-06T23:10:22Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-07T22:07:45Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -61,5 +61,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "9f306ea4"
-    digest: sha256:10787a512cfadcbdd084e0c2814e0e5fc2ae5322b2289e85e5624cd93f2d45fb
+    newTag: "7072c7a7"
+    digest: sha256:06798551abe09688a89caa8455c93b7e8477e660faec5410bb523f8892ea0590


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `7072c7a7396dc0aee496767dbad2d7eca657f973`
- Image tag: `7072c7a7`
- Image digest: `sha256:06798551abe09688a89caa8455c93b7e8477e660faec5410bb523f8892ea0590`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`