### PR TITLE
fix(torghut): pass sim order topic to runtime analysis

### DIFF
--- a/services/torghut/scripts/run_simulation_analysis.py
+++ b/services/torghut/scripts/run_simulation_analysis.py
@@ -31,6 +31,7 @@ class _Resources:
     torghut_forecast_service: str
     clickhouse_signal_table: str
     clickhouse_price_table: str
+    simulation_topic_by_role: dict[str, str]
     order_feed_group_id: str
     ta_group_id: str
 
@@ -150,6 +151,9 @@ def _resources_from_args(args: argparse.Namespace) -> _Resources:
         torghut_forecast_service=args.forecast_service,
         clickhouse_signal_table=getattr(args, 'signal_table', ''),
         clickhouse_price_table=getattr(args, 'price_table', ''),
+        simulation_topic_by_role={
+            'order_updates': f'torghut.sim.trade-updates.v1.{run_token}',
+        },
         order_feed_group_id=f'torghut-order-feed-sim-{run_token}',
         ta_group_id=f'torghut-ta-sim-{run_token}',
     )

--- a/services/torghut/tests/test_run_simulation_analysis.py
+++ b/services/torghut/tests/test_run_simulation_analysis.py
@@ -6,10 +6,28 @@ from contextlib import redirect_stdout
 from unittest import TestCase
 from unittest.mock import patch
 
-from scripts.run_simulation_analysis import main
+from scripts.run_simulation_analysis import _resources_from_args, main
 
 
 class TestRunSimulationAnalysis(TestCase):
+    def test_runtime_ready_resources_include_run_scoped_order_updates_topic(self) -> None:
+        class _Args:
+            run_id = 'sim-2026-03-06-open-30m-r3'
+            dataset_id = 'torghut-smoke-open-30m-20260306'
+            namespace = 'torghut'
+            ta_configmap = 'torghut-ta-sim-config'
+            ta_deployment = 'torghut-ta-sim'
+            torghut_service = 'torghut-sim'
+            forecast_service = 'torghut-forecast-sim'
+            signal_table = 'torghut_sim_2026_03_06_open_30m.ta_signals'
+            price_table = 'torghut_sim_2026_03_06_open_30m.ta_microbars'
+
+        resources = _resources_from_args(_Args())
+        self.assertEqual(
+            resources.simulation_topic_by_role['order_updates'],
+            'torghut.sim.trade-updates.v1.sim_2026_03_06_open_30m_r3',
+        )
+
     def test_runtime_ready_exits_zero_with_json_payload(self) -> None:
         stdout = io.StringIO()
         with (


### PR DESCRIPTION
## Summary

- include the run-scoped simulation order-updates topic in the `run_simulation_analysis.py` runtime resource shape so `_runtime_verify()` can actually satisfy the trading-config checks
- fix the runtime-ready AnalysisRun hang for dedicated simulation runs that already have correct env wiring in `torghut-sim`
- add a regression test for the run-scoped order-updates topic derivation

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_run_simulation_analysis.py -q`
- `cd services/torghut && uv run --frozen ruff check scripts/run_simulation_analysis.py tests/test_run_simulation_analysis.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
