### PR TITLE
chore(torghut): promote image 6f952bcd

### DIFF
--- a/argocd/applications/torghut-forecast/deployment.yaml
+++ b/argocd/applications/torghut-forecast/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: forecast
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:8c471dc2d2af8d60f98e2fd1c4c34fdb9e4ec97deb3b96e24982e6bb89516de3
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:88a8776d962c8db12f590ed01d5b3fe4ad68f003ede204c6ebaddbc43050bd15
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn

--- a/argocd/applications/torghut-forecast/sim/deployment.yaml
+++ b/argocd/applications/torghut-forecast/sim/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: forecast
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:8c471dc2d2af8d60f98e2fd1c4c34fdb9e4ec97deb3b96e24982e6bb89516de3
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:88a8776d962c8db12f590ed01d5b3fe4ad68f003ede204c6ebaddbc43050bd15
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -40,7 +40,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:8c471dc2d2af8d60f98e2fd1c4c34fdb9e4ec97deb3b96e24982e6bb89516de3
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:88a8776d962c8db12f590ed01d5b3fe4ad68f003ede204c6ebaddbc43050bd15
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -21,7 +21,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:8c471dc2d2af8d60f98e2fd1c4c34fdb9e4ec97deb3b96e24982e6bb89516de3
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:88a8776d962c8db12f590ed01d5b3fe4ad68f003ede204c6ebaddbc43050bd15
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -30,7 +30,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:8c471dc2d2af8d60f98e2fd1c4c34fdb9e4ec97deb3b96e24982e6bb89516de3
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:88a8776d962c8db12f590ed01d5b3fe4ad68f003ede204c6ebaddbc43050bd15
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -30,7 +30,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:8c471dc2d2af8d60f98e2fd1c4c34fdb9e4ec97deb3b96e24982e6bb89516de3
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:88a8776d962c8db12f590ed01d5b3fe4ad68f003ede204c6ebaddbc43050bd15
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:8c471dc2d2af8d60f98e2fd1c4c34fdb9e4ec97deb3b96e24982e6bb89516de3
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:88a8776d962c8db12f590ed01d5b3fe4ad68f003ede204c6ebaddbc43050bd15
           command:
             - alembic
           args:

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -13,7 +13,7 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:8c471dc2d2af8d60f98e2fd1c4c34fdb9e4ec97deb3b96e24982e6bb89516de3
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:88a8776d962c8db12f590ed01d5b3fe4ad68f003ede204c6ebaddbc43050bd15
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -21,7 +21,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:8c471dc2d2af8d60f98e2fd1c4c34fdb9e4ec97deb3b96e24982e6bb89516de3
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:88a8776d962c8db12f590ed01d5b3fe4ad68f003ede204c6ebaddbc43050bd15
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -39,7 +39,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:8c471dc2d2af8d60f98e2fd1c4c34fdb9e4ec97deb3b96e24982e6bb89516de3
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:88a8776d962c8db12f590ed01d5b3fe4ad68f003ede204c6ebaddbc43050bd15
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-03-07T21:49:23Z"
+        client.knative.dev/updateTimestamp: "2026-03-07T22:39:31Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:8c471dc2d2af8d60f98e2fd1c4c34fdb9e4ec97deb3b96e24982e6bb89516de3
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:88a8776d962c8db12f590ed01d5b3fe4ad68f003ede204c6ebaddbc43050bd15
           ports:
             - name: http1
               containerPort: 8181
@@ -458,9 +458,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.562.0-418-gbededee9
+              value: v0.562.0-422-g6f952bcd
             - name: TORGHUT_COMMIT
-              value: bededee9c9ce3efe930ec2e6917b06748d723075
+              value: 6f952bcdf5341d922a90156985cff61463f1e319
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-03-07T21:49:23Z"
+        client.knative.dev/updateTimestamp: "2026-03-07T22:39:31Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -26,7 +26,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:8c471dc2d2af8d60f98e2fd1c4c34fdb9e4ec97deb3b96e24982e6bb89516de3
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:88a8776d962c8db12f590ed01d5b3fe4ad68f003ede204c6ebaddbc43050bd15
           ports:
             - name: http1
               containerPort: 8181
@@ -456,9 +456,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.562.0-418-gbededee9
+              value: v0.562.0-422-g6f952bcd
             - name: TORGHUT_COMMIT
-              value: bededee9c9ce3efe930ec2e6917b06748d723075
+              value: 6f952bcdf5341d922a90156985cff61463f1e319
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/lean-runner-deployment.yaml
+++ b/argocd/applications/torghut/lean-runner-deployment.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: lean-runner
           # Keep in lockstep with `argocd/applications/torghut/knative-service.yaml`.
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:8c471dc2d2af8d60f98e2fd1c4c34fdb9e4ec97deb3b96e24982e6bb89516de3
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:88a8776d962c8db12f590ed01d5b3fe4ad68f003ede204c6ebaddbc43050bd15
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `6f952bcdf5341d922a90156985cff61463f1e319`
- Image tag: `6f952bcd`
- Image digest: `sha256:88a8776d962c8db12f590ed01d5b3fe4ad68f003ede204c6ebaddbc43050bd15`