### PR TITLE
perf(rook-ceph): benchmark and tune cephfs rwx

### DIFF
--- a/argocd/applications/rook-ceph/cluster-values.yaml
+++ b/argocd/applications/rook-ceph/cluster-values.yaml
@@ -53,6 +53,9 @@ cephClusterSpec:
   mgr:
     count: 2
     allowMultiplePerNode: false
+    modules:
+      - name: stats
+        enabled: true
 
   dashboard:
     enabled: true
@@ -106,7 +109,9 @@ cephClusterSpec:
 # Disable chart-managed default block/filesystem classes to avoid duplicates.
 # Canonical classes are managed in storageclasses.yaml as:
 # - rook-ceph-block (RWO)
-# - rook-cephfs (RWX)
+# - rook-cephfs (RWX, kernel-capable nodes only)
+# - rook-cephfs-fuse (RWX on Talos-compatible nodes)
+# - CephFilesystem details such as MDS resources
 cephBlockPools: []
 cephFileSystems: []
 

--- a/argocd/applications/rook-ceph/storageclasses.yaml
+++ b/argocd/applications/rook-ceph/storageclasses.yaml
@@ -47,8 +47,16 @@ spec:
       replicated:
         size: 2
   metadataServer:
+    # Keep a single active MDS until RWX benchmarks show metadata saturation.
     activeCount: 1
     activeStandby: true
+    resources:
+      requests:
+        cpu: "2"
+        memory: 8Gi
+      limits:
+        cpu: "4"
+        memory: 16Gi
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
@@ -58,6 +66,8 @@ provisioner: rook-ceph.cephfs.csi.ceph.com
 allowVolumeExpansion: true
 reclaimPolicy: Delete
 volumeBindingMode: Immediate
+mountOptions:
+  - noatime
 parameters:
   clusterID: rook-ceph
   fsName: cephfs
@@ -76,6 +86,8 @@ provisioner: rook-ceph.cephfs.csi.ceph.com
 allowVolumeExpansion: true
 reclaimPolicy: Delete
 volumeBindingMode: Immediate
+mountOptions:
+  - noatime
 parameters:
   clusterID: rook-ceph
   fsName: cephfs

--- a/docs/runbooks/cephfs-fuse-on-talos.md
+++ b/docs/runbooks/cephfs-fuse-on-talos.md
@@ -6,6 +6,7 @@ This runbook documents:
 
 - How we configure Rook-Ceph / Ceph-CSI for CephFS FUSE on Talos.
 - How to migrate an existing CephFS PVC to the FUSE storage class.
+- How to treat `rook-cephfs-fuse` as the compatibility RWX class when benchmarking.
 
 ## Why FUSE
 
@@ -25,12 +26,22 @@ Note: this is quoted as a string so Helm renders `CSI_FORCE_CEPHFS_KERNEL_CLIENT
 - File: `argocd/applications/rook-ceph/storageclasses.yaml`
 - Name: `rook-cephfs-fuse`
 - Key parameter: `parameters.mounter: fuse`
+- Conservative default mount option: `mountOptions: [noatime]`
+
+3. The live CephFS keeps a single active MDS and now sets explicit MDS resources:
+
+- File: `argocd/applications/rook-ceph/storageclasses.yaml`
+- Key path: `spec.metadataServer`
+- Default resources: requests `2 CPU / 8Gi`, limits `4 CPU / 16Gi`
 
 ## Using CephFS FUSE In Apps
 
 Set PVCs to use:
 
 - `storageClassName: rook-cephfs-fuse`
+
+Use this class only when the workload genuinely needs shared POSIX semantics and the node image does not provide a working kernel CephFS client.
+If a kernel-capable worker pool exists, benchmark `rook-cephfs` against `rook-cephfs-fuse` before standardizing on FUSE for a performance-sensitive workload.
 
 Example:
 
@@ -87,3 +98,8 @@ kubectl -n rook-ceph get pods
 ```
 
 2. Confirm a pod mounting the PVC starts successfully (no CephFS mount errors) and that the app becomes `Healthy` in Argo CD.
+
+## Performance Investigation
+
+The RWX-only performance workflow lives in `docs/runbooks/rook-ceph-rwx-performance.md`.
+Use that runbook before changing `activeCount`, changing hardware topology, or treating a FUSE result as representative of all CephFS RWX performance.

--- a/docs/runbooks/rook-ceph-on-talos.md
+++ b/docs/runbooks/rook-ceph-on-talos.md
@@ -67,6 +67,10 @@ Rook operator and cluster chart versions:
 
 1. `argocd/applications/rook-ceph/kustomization.yaml`
 
+RWX performance workflow:
+
+1. `docs/runbooks/rook-ceph-rwx-performance.md`
+
 ## Install / rollout steps
 
 1. Ensure you have verified the disk inventory on each node (example):
@@ -91,7 +95,10 @@ argocd app sync rook-ceph
 kubectl -n rook-ceph get pods
 kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph -s
 kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph osd tree
+kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph mgr module ls
 ```
+
+The cluster enables the Ceph mgr `stats` module declaratively so `ceph fs perf stats` is available during RWX investigations.
 
 ## Recovery: Talos node host jump (same disks, new hostname/IP)
 

--- a/docs/runbooks/rook-ceph-rwx-performance.md
+++ b/docs/runbooks/rook-ceph-rwx-performance.md
@@ -1,0 +1,131 @@
+# Rook-Ceph RWX Performance
+
+This runbook covers only RWX-capable `StorageClass` objects in the live `galactic` cluster:
+
+1. `rook-cephfs`
+1. `rook-cephfs-fuse`
+
+Non-RWX classes such as `rook-ceph-block` and non-POSIX paths such as `rook-ceph-bucket` are intentionally out of scope here.
+
+## Decision Matrix
+
+Use `rook-cephfs-fuse` when:
+
+1. The workload requires shared POSIX semantics.
+1. The workload must run on Talos nodes that do not ship the in-kernel CephFS client.
+1. Compatibility matters more than peak throughput.
+
+Use `rook-cephfs` when:
+
+1. The workload requires shared POSIX semantics.
+1. You have a worker pool with a working kernel CephFS client.
+1. The workload is performance-sensitive enough that FUSE overhead matters.
+
+Do not choose between the two classes based on anecdote. Run the same benchmark suite against both classes when a kernel-capable worker pool exists.
+
+## Current Cluster Defaults
+
+Current GitOps defaults are tuned for safe first-pass RWX investigations:
+
+1. The Ceph mgr `stats` module is enabled so `ceph fs perf stats` is available.
+1. The live `CephFilesystem` keeps `activeCount: 1` and `activeStandby: true`.
+1. The MDS pods have explicit resources: requests `2 CPU / 8Gi`, limits `4 CPU / 16Gi`.
+1. Both RWX classes set `mountOptions: [noatime]`.
+
+These defaults do not remove the known topology ceiling:
+
+1. OSDs are HDD-only on 2 storage hosts.
+1. No fast metadata tier is configured yet.
+1. `readAffinity` is still disabled.
+
+## Benchmark Assets
+
+Portable benchmark manifests live under:
+
+1. `kubernetes/rook-ceph-rwx-benchmarks`
+
+They are intentionally not part of normal Argo CD sync. Apply them only during an investigation window.
+
+Bootstrap the benchmark namespace and PVCs:
+
+```bash
+kubectl apply -k kubernetes/rook-ceph-rwx-benchmarks
+```
+
+Run the FUSE benchmark job:
+
+```bash
+kubectl apply -f kubernetes/rook-ceph-rwx-benchmarks/job-rook-cephfs-fuse.yaml
+kubectl -n rook-ceph-benchmarks logs -f job/rook-cephfs-fuse-benchmark
+```
+
+Run the kernel benchmark job only after labeling a kernel-capable worker pool:
+
+```bash
+kubectl label node <node-name> storage.proompteng.ai/cephfs-kernel-client=true
+kubectl apply -f kubernetes/rook-ceph-rwx-benchmarks/job-rook-cephfs-kernel.yaml
+kubectl -n rook-ceph-benchmarks logs -f job/rook-cephfs-kernel-benchmark
+```
+
+The benchmark suite includes:
+
+1. `fio` large sequential write then read
+1. `fio` small-block mixed random read/write
+1. metadata create/stat/delete pressure
+
+The metadata phase is a portable shell/Python harness. If you already maintain a curated `mdtest` image, prefer running that tool in the same namespace and on the same PVC for higher-fidelity metadata numbers.
+
+## Evidence Capture
+
+Capture this evidence for every benchmark window:
+
+```bash
+kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph -s
+kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph osd perf
+kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph mds stat
+kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph fs perf stats
+kubectl -n rook-ceph top pod | rg 'mds|osd|mgr'
+kubectl -n rook-ceph-benchmarks get pods -o wide
+kubectl -n rook-ceph-benchmarks logs job/rook-cephfs-fuse-benchmark
+```
+
+If you are comparing kernel vs FUSE, collect the same evidence set for both runs and keep the dataset size, concurrency, and node placement unchanged.
+
+## Decision Gates
+
+If `rook-cephfs` materially outperforms `rook-cephfs-fuse`:
+
+1. Keep FUSE as the compatibility class.
+1. Migrate only the performance-sensitive RWX workloads to a kernel-capable worker pool.
+
+If both RWX classes are slow and `ceph osd perf` stays high:
+
+1. Prioritize fast metadata media on both storage hosts.
+1. Move BlueStore metadata off HDD before increasing CephFS complexity.
+
+If metadata-heavy phases are slow but sequential throughput is acceptable:
+
+1. Keep `activeCount: 1` unless MDS saturation is proven.
+1. Prioritize MDS CPU/memory, metadata media, and application file-layout changes.
+
+If MDS CPU or cache pressure saturates before OSD latency:
+
+1. Increase MDS resources further.
+1. Consider multiple active MDS ranks only after you have stable benchmark baselines and a fast metadata tier.
+
+## Cleanup
+
+Delete benchmark jobs after each run:
+
+```bash
+kubectl -n rook-ceph-benchmarks delete job rook-cephfs-fuse-benchmark --ignore-not-found
+kubectl -n rook-ceph-benchmarks delete job rook-cephfs-kernel-benchmark --ignore-not-found
+```
+
+Delete and recreate benchmark PVCs if you need a clean filesystem state:
+
+```bash
+kubectl -n rook-ceph-benchmarks delete pvc rook-cephfs-fuse-bench --ignore-not-found
+kubectl -n rook-ceph-benchmarks delete pvc rook-cephfs-kernel-bench --ignore-not-found
+kubectl apply -k kubernetes/rook-ceph-rwx-benchmarks
+```

--- a/kubernetes/rook-ceph-rwx-benchmarks/README.md
+++ b/kubernetes/rook-ceph-rwx-benchmarks/README.md
@@ -1,0 +1,26 @@
+# Rook-Ceph RWX Benchmarks
+
+This directory contains apply-on-demand manifests for benchmarking the live RWX-capable storage classes:
+
+1. `rook-cephfs-fuse`
+1. `rook-cephfs`
+
+Bootstrap shared resources:
+
+```bash
+kubectl apply -k kubernetes/rook-ceph-rwx-benchmarks
+```
+
+Run the FUSE job:
+
+```bash
+kubectl apply -f kubernetes/rook-ceph-rwx-benchmarks/job-rook-cephfs-fuse.yaml
+```
+
+Run the kernel job only on nodes labeled `storage.proompteng.ai/cephfs-kernel-client=true`:
+
+```bash
+kubectl apply -f kubernetes/rook-ceph-rwx-benchmarks/job-rook-cephfs-kernel.yaml
+```
+
+The full workflow, evidence capture commands, and decision gates are documented in `docs/runbooks/rook-ceph-rwx-performance.md`.

--- a/kubernetes/rook-ceph-rwx-benchmarks/configmap.yaml
+++ b/kubernetes/rook-ceph-rwx-benchmarks/configmap.yaml
@@ -1,0 +1,118 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: rook-ceph-rwx-benchmark-scripts
+  namespace: rook-ceph-benchmarks
+data:
+  run-benchmark-suite.sh: |
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    mount_dir="${1:?mount dir required}"
+    result_dir="${2:?result dir required}"
+    class_name="${3:?storage class required}"
+
+    mkdir -p "${mount_dir}" "${result_dir}"
+
+    echo "storageClass=${class_name}" | tee "${result_dir}/suite.info"
+    date -u +"startedAt=%Y-%m-%dT%H:%M:%SZ" | tee -a "${result_dir}/suite.info"
+
+    fio \
+      --name=seq-write-read \
+      --directory="${mount_dir}" \
+      --rw=write \
+      --bs=1m \
+      --size=1g \
+      --numjobs=1 \
+      --iodepth=8 \
+      --direct=1 \
+      --runtime=0 \
+      --group_reporting=1 \
+      --output-format=json \
+      --output="${result_dir}/fio-sequential-write.json"
+
+    fio \
+      --name=seq-read \
+      --directory="${mount_dir}" \
+      --rw=read \
+      --bs=1m \
+      --size=1g \
+      --numjobs=1 \
+      --iodepth=8 \
+      --direct=1 \
+      --runtime=0 \
+      --group_reporting=1 \
+      --output-format=json \
+      --output="${result_dir}/fio-sequential-read.json"
+
+    fio \
+      --name=randrw-mixed \
+      --directory="${mount_dir}" \
+      --rw=randrw \
+      --rwmixread=70 \
+      --bs=4k \
+      --size=512m \
+      --numjobs=2 \
+      --iodepth=16 \
+      --direct=1 \
+      --runtime=60 \
+      --time_based=1 \
+      --group_reporting=1 \
+      --output-format=json \
+      --output="${result_dir}/fio-randrw.json"
+
+    python3 /scripts/run-metadata-benchmark.py "${mount_dir}/metadata" "${result_dir}/metadata.json"
+
+    date -u +"finishedAt=%Y-%m-%dT%H:%M:%SZ" | tee -a "${result_dir}/suite.info"
+    ls -lah "${result_dir}"
+    for result in \
+      "${result_dir}/fio-sequential-write.json" \
+      "${result_dir}/fio-sequential-read.json" \
+      "${result_dir}/fio-randrw.json" \
+      "${result_dir}/metadata.json"; do
+      echo "==== ${result##*/} ===="
+      cat "${result}"
+    done
+  run-metadata-benchmark.py: |
+    import json
+    import os
+    import shutil
+    import sys
+    import time
+    from pathlib import Path
+
+    root = Path(sys.argv[1])
+    output = Path(sys.argv[2])
+    file_count = 1000
+    root.mkdir(parents=True, exist_ok=True)
+
+    def elapsed(fn):
+      started = time.perf_counter()
+      fn()
+      return time.perf_counter() - started
+
+    def create_files():
+      payload = b"x" * 4096
+      for index in range(file_count):
+        (root / f"file-{index:05d}.dat").write_bytes(payload)
+
+    def stat_files():
+      for index in range(file_count):
+        os.stat(root / f"file-{index:05d}.dat")
+
+    def delete_files():
+      for index in range(file_count):
+        (root / f"file-{index:05d}.dat").unlink()
+
+    results = {
+      "fileCount": file_count,
+      "createSeconds": elapsed(create_files),
+      "statSeconds": elapsed(stat_files),
+      "deleteSeconds": elapsed(delete_files),
+    }
+    results["createOpsPerSecond"] = file_count / results["createSeconds"]
+    results["statOpsPerSecond"] = file_count / results["statSeconds"]
+    results["deleteOpsPerSecond"] = file_count / results["deleteSeconds"]
+
+    output.write_text(json.dumps(results, indent=2) + "\n", encoding="ascii")
+    shutil.rmtree(root, ignore_errors=True)

--- a/kubernetes/rook-ceph-rwx-benchmarks/job-rook-cephfs-fuse.yaml
+++ b/kubernetes/rook-ceph-rwx-benchmarks/job-rook-cephfs-fuse.yaml
@@ -1,0 +1,39 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rook-cephfs-fuse-benchmark
+  namespace: rook-ceph-benchmarks
+spec:
+  backoffLimit: 0
+  ttlSecondsAfterFinished: 3600
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: benchmark
+          image: debian:bookworm-slim
+          command:
+            - /bin/bash
+            - -lc
+            - |
+              set -euo pipefail
+              apt-get update
+              apt-get install -y --no-install-recommends fio python3 ca-certificates
+              /scripts/run-benchmark-suite.sh /mnt/cephfs /results rook-cephfs-fuse
+          volumeMounts:
+            - name: benchmark-volume
+              mountPath: /mnt/cephfs
+            - name: benchmark-results
+              mountPath: /results
+            - name: benchmark-scripts
+              mountPath: /scripts
+      volumes:
+        - name: benchmark-volume
+          persistentVolumeClaim:
+            claimName: rook-cephfs-fuse-bench
+        - name: benchmark-results
+          emptyDir: {}
+        - name: benchmark-scripts
+          configMap:
+            name: rook-ceph-rwx-benchmark-scripts
+            defaultMode: 0755

--- a/kubernetes/rook-ceph-rwx-benchmarks/job-rook-cephfs-kernel.yaml
+++ b/kubernetes/rook-ceph-rwx-benchmarks/job-rook-cephfs-kernel.yaml
@@ -1,0 +1,41 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rook-cephfs-kernel-benchmark
+  namespace: rook-ceph-benchmarks
+spec:
+  backoffLimit: 0
+  ttlSecondsAfterFinished: 3600
+  template:
+    spec:
+      restartPolicy: Never
+      nodeSelector:
+        storage.proompteng.ai/cephfs-kernel-client: "true"
+      containers:
+        - name: benchmark
+          image: debian:bookworm-slim
+          command:
+            - /bin/bash
+            - -lc
+            - |
+              set -euo pipefail
+              apt-get update
+              apt-get install -y --no-install-recommends fio python3 ca-certificates
+              /scripts/run-benchmark-suite.sh /mnt/cephfs /results rook-cephfs
+          volumeMounts:
+            - name: benchmark-volume
+              mountPath: /mnt/cephfs
+            - name: benchmark-results
+              mountPath: /results
+            - name: benchmark-scripts
+              mountPath: /scripts
+      volumes:
+        - name: benchmark-volume
+          persistentVolumeClaim:
+            claimName: rook-cephfs-kernel-bench
+        - name: benchmark-results
+          emptyDir: {}
+        - name: benchmark-scripts
+          configMap:
+            name: rook-ceph-rwx-benchmark-scripts
+            defaultMode: 0755

--- a/kubernetes/rook-ceph-rwx-benchmarks/kustomization.yaml
+++ b/kubernetes/rook-ceph-rwx-benchmarks/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+  - configmap.yaml
+  - pvc-rook-cephfs-fuse.yaml
+  - pvc-rook-cephfs-kernel.yaml

--- a/kubernetes/rook-ceph-rwx-benchmarks/namespace.yaml
+++ b/kubernetes/rook-ceph-rwx-benchmarks/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: rook-ceph-benchmarks

--- a/kubernetes/rook-ceph-rwx-benchmarks/pvc-rook-cephfs-fuse.yaml
+++ b/kubernetes/rook-ceph-rwx-benchmarks/pvc-rook-cephfs-fuse.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: rook-cephfs-fuse-bench
+  namespace: rook-ceph-benchmarks
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 20Gi
+  storageClassName: rook-cephfs-fuse

--- a/kubernetes/rook-ceph-rwx-benchmarks/pvc-rook-cephfs-kernel.yaml
+++ b/kubernetes/rook-ceph-rwx-benchmarks/pvc-rook-cephfs-kernel.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: rook-cephfs-kernel-bench
+  namespace: rook-ceph-benchmarks
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 20Gi
+  storageClassName: rook-cephfs


### PR DESCRIPTION
## Summary

- add declarative CephFS RWX tuning for the live `rook-cephfs` and `rook-cephfs-fuse` classes by enabling the mgr `stats` module, setting explicit MDS resources, and adding `noatime`
- add an RWX-only Ceph runbook and apply-on-demand benchmark manifests for CephFS FUSE and CephFS kernel benchmarking
- execute a live before/after `rook-cephfs-fuse` benchmark on the cluster and document the resulting improvement in metadata and mixed small-block IO, with sequential throughput still limited by the HDD-backed OSD tier

## Related Issues

None

## Testing

- `python3 - <<'PY'
import yaml
for path in [
  'argocd/applications/rook-ceph/cluster-values.yaml',
  'argocd/applications/rook-ceph/storageclasses.yaml',
  'kubernetes/rook-ceph-rwx-benchmarks/configmap.yaml',
]:
    with open(path) as f:
        list(yaml.safe_load_all(f))
    print(path)
PY`
- `kubectl kustomize kubernetes/rook-ceph-rwx-benchmarks`
- `kubectl apply --dry-run=client -f kubernetes/rook-ceph-rwx-benchmarks/job-rook-cephfs-fuse.yaml -f kubernetes/rook-ceph-rwx-benchmarks/job-rook-cephfs-kernel.yaml`
- `kubectl apply -k kubernetes/rook-ceph-rwx-benchmarks`
- live benchmark before changes on `rook-cephfs-fuse` with Ceph evidence capture (`ceph -s`, `ceph osd perf`, `ceph mds stat`)
- live benchmark after changes on `rook-cephfs-fuse` with Ceph evidence capture (`ceph -s`, `ceph osd perf`, `ceph mds stat`, `ceph fs perf stats`)
- observed benchmark summary:
  - baseline: sequential write ~9.1 MiB/s, sequential read ~37.9 MiB/s, randrw read ~128 KiB/s, randrw write ~56 KiB/s, metadata create ~623 ops/s, stat ~3806 ops/s, delete ~1265 ops/s
  - after tuning: sequential write ~6.2 MiB/s, sequential read ~29.0 MiB/s, randrw read ~177 KiB/s, randrw write ~78 KiB/s, metadata create ~839 ops/s, stat ~5050 ops/s, delete ~1788 ops/s

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
