### PR TITLE
chore(torghut): promote image 8c553304

### DIFF
--- a/argocd/applications/torghut-forecast/deployment.yaml
+++ b/argocd/applications/torghut-forecast/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: forecast
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:88a8776d962c8db12f590ed01d5b3fe4ad68f003ede204c6ebaddbc43050bd15
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:10fb7822aaf00929e2446fac344f37638405705b37626459ed53558e774d8043
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn

--- a/argocd/applications/torghut-forecast/sim/deployment.yaml
+++ b/argocd/applications/torghut-forecast/sim/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: forecast
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:88a8776d962c8db12f590ed01d5b3fe4ad68f003ede204c6ebaddbc43050bd15
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:10fb7822aaf00929e2446fac344f37638405705b37626459ed53558e774d8043
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -40,7 +40,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:88a8776d962c8db12f590ed01d5b3fe4ad68f003ede204c6ebaddbc43050bd15
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:10fb7822aaf00929e2446fac344f37638405705b37626459ed53558e774d8043
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -21,7 +21,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:88a8776d962c8db12f590ed01d5b3fe4ad68f003ede204c6ebaddbc43050bd15
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:10fb7822aaf00929e2446fac344f37638405705b37626459ed53558e774d8043
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -30,7 +30,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:88a8776d962c8db12f590ed01d5b3fe4ad68f003ede204c6ebaddbc43050bd15
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:10fb7822aaf00929e2446fac344f37638405705b37626459ed53558e774d8043
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -30,7 +30,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:88a8776d962c8db12f590ed01d5b3fe4ad68f003ede204c6ebaddbc43050bd15
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:10fb7822aaf00929e2446fac344f37638405705b37626459ed53558e774d8043
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:88a8776d962c8db12f590ed01d5b3fe4ad68f003ede204c6ebaddbc43050bd15
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:10fb7822aaf00929e2446fac344f37638405705b37626459ed53558e774d8043
           command:
             - alembic
           args:

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -13,7 +13,7 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:88a8776d962c8db12f590ed01d5b3fe4ad68f003ede204c6ebaddbc43050bd15
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:10fb7822aaf00929e2446fac344f37638405705b37626459ed53558e774d8043
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -21,7 +21,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:88a8776d962c8db12f590ed01d5b3fe4ad68f003ede204c6ebaddbc43050bd15
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:10fb7822aaf00929e2446fac344f37638405705b37626459ed53558e774d8043
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -39,7 +39,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:88a8776d962c8db12f590ed01d5b3fe4ad68f003ede204c6ebaddbc43050bd15
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:10fb7822aaf00929e2446fac344f37638405705b37626459ed53558e774d8043
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-03-07T22:39:31Z"
+        client.knative.dev/updateTimestamp: "2026-03-08T00:49:57Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:88a8776d962c8db12f590ed01d5b3fe4ad68f003ede204c6ebaddbc43050bd15
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:10fb7822aaf00929e2446fac344f37638405705b37626459ed53558e774d8043
           ports:
             - name: http1
               containerPort: 8181
@@ -458,9 +458,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.562.0-422-g6f952bcd
+              value: v0.562.0-425-g8c553304
             - name: TORGHUT_COMMIT
-              value: 6f952bcdf5341d922a90156985cff61463f1e319
+              value: 8c553304ba7fb2964c1886630f14e0e6fd3c6462
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-03-07T22:39:31Z"
+        client.knative.dev/updateTimestamp: "2026-03-08T00:49:57Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -26,7 +26,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:88a8776d962c8db12f590ed01d5b3fe4ad68f003ede204c6ebaddbc43050bd15
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:10fb7822aaf00929e2446fac344f37638405705b37626459ed53558e774d8043
           ports:
             - name: http1
               containerPort: 8181
@@ -456,9 +456,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.562.0-422-g6f952bcd
+              value: v0.562.0-425-g8c553304
             - name: TORGHUT_COMMIT
-              value: 6f952bcdf5341d922a90156985cff61463f1e319
+              value: 8c553304ba7fb2964c1886630f14e0e6fd3c6462
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/lean-runner-deployment.yaml
+++ b/argocd/applications/torghut/lean-runner-deployment.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: lean-runner
           # Keep in lockstep with `argocd/applications/torghut/knative-service.yaml`.
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:88a8776d962c8db12f590ed01d5b3fe4ad68f003ede204c6ebaddbc43050bd15
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:10fb7822aaf00929e2446fac344f37638405705b37626459ed53558e774d8043
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `8c553304ba7fb2964c1886630f14e0e6fd3c6462`
- Image tag: `8c553304`
- Image digest: `sha256:10fb7822aaf00929e2446fac344f37638405705b37626459ed53558e774d8043`
- Migration change detected under `services/torghut/migrations/**`
- Added `do-not-automerge`; manual DB migration approval required before merge