### PR TITLE
chore(jangar): promote image 38424be2

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 7072c7a7
-  digest: sha256:06798551abe09688a89caa8455c93b7e8477e660faec5410bb523f8892ea0590
+  tag: 38424be2
+  digest: sha256:fed6598eead7426e057e6e2869e6e22736ca4ed348889513af4a0b88f4b6a30c
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 7072c7a7
-    digest: sha256:228116d45fadddb3aa38c9f459af18f8375402c7ef3eadbd4ae44beca4b42504
+    tag: 38424be2
+    digest: sha256:13d8dab61f3dccfbc0520973f6c4b17112b3a00f39bafb74ded97f77a3caec5e
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 7072c7a7
-    digest: sha256:06798551abe09688a89caa8455c93b7e8477e660faec5410bb523f8892ea0590
+    tag: 38424be2
+    digest: sha256:fed6598eead7426e057e6e2869e6e22736ca4ed348889513af4a0b88f4b6a30c
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-07T22:07:45Z"
+    deploy.knative.dev/rollout: "2026-03-08T04:21:28Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-07T22:07:45Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-08T04:21:28Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -61,5 +61,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "7072c7a7"
-    digest: sha256:06798551abe09688a89caa8455c93b7e8477e660faec5410bb523f8892ea0590
+    newTag: "38424be2"
+    digest: sha256:fed6598eead7426e057e6e2869e6e22736ca4ed348889513af4a0b88f4b6a30c


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `38424be2020ee8fc6bbe8d7187640b648369546f`
- Image tag: `38424be2`
- Image digest: `sha256:fed6598eead7426e057e6e2869e6e22736ca4ed348889513af4a0b88f4b6a30c`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`