### PR TITLE
chore(jangar): promote image f4c73d73

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 38424be2
-  digest: sha256:fed6598eead7426e057e6e2869e6e22736ca4ed348889513af4a0b88f4b6a30c
+  tag: f4c73d73
+  digest: sha256:fedceef4235e51110688ddc3b6697d102506dd426703c4d47debfd21c116abf3
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 38424be2
-    digest: sha256:13d8dab61f3dccfbc0520973f6c4b17112b3a00f39bafb74ded97f77a3caec5e
+    tag: f4c73d73
+    digest: sha256:9229949853b0d49de50115e50c9fc17655f586f09eee54d01ad7f74766525ad5
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 38424be2
-    digest: sha256:fed6598eead7426e057e6e2869e6e22736ca4ed348889513af4a0b88f4b6a30c
+    tag: f4c73d73
+    digest: sha256:fedceef4235e51110688ddc3b6697d102506dd426703c4d47debfd21c116abf3
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-08T04:21:28Z"
+    deploy.knative.dev/rollout: "2026-03-08T05:09:27Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-08T04:21:28Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-08T05:09:27Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -61,5 +61,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "38424be2"
-    digest: sha256:fed6598eead7426e057e6e2869e6e22736ca4ed348889513af4a0b88f4b6a30c
+    newTag: "f4c73d73"
+    digest: sha256:fedceef4235e51110688ddc3b6697d102506dd426703c4d47debfd21c116abf3


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `f4c73d735434528880c9d8ebec503e2b1aa0b0b0`
- Image tag: `f4c73d73`
- Image digest: `sha256:fedceef4235e51110688ddc3b6697d102506dd426703c4d47debfd21c116abf3`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`