### PR TITLE
chore(jangar): promote image acfbabcd

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: f4c73d73
-  digest: sha256:fedceef4235e51110688ddc3b6697d102506dd426703c4d47debfd21c116abf3
+  tag: acfbabcd
+  digest: sha256:b94fbf115b8c6a60ef890cec0a5e8922f36d0dda13d9ca4b00a5b69c4bc2d8ae
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: f4c73d73
-    digest: sha256:9229949853b0d49de50115e50c9fc17655f586f09eee54d01ad7f74766525ad5
+    tag: acfbabcd
+    digest: sha256:70341c8c657b2d93c068a6dee79c631d1bb50711e6209a0f002ff241845ebcbb
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: f4c73d73
-    digest: sha256:fedceef4235e51110688ddc3b6697d102506dd426703c4d47debfd21c116abf3
+    tag: acfbabcd
+    digest: sha256:b94fbf115b8c6a60ef890cec0a5e8922f36d0dda13d9ca4b00a5b69c4bc2d8ae
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-08T05:09:27Z"
+    deploy.knative.dev/rollout: "2026-03-08T06:36:51Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-08T05:09:27Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-08T06:36:51Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -61,5 +61,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "f4c73d73"
-    digest: sha256:fedceef4235e51110688ddc3b6697d102506dd426703c4d47debfd21c116abf3
+    newTag: "acfbabcd"
+    digest: sha256:b94fbf115b8c6a60ef890cec0a5e8922f36d0dda13d9ca4b00a5b69c4bc2d8ae


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `acfbabcd08b884c6ba08cd63f783525f3a60e7dd`
- Image tag: `acfbabcd`
- Image digest: `sha256:b94fbf115b8c6a60ef890cec0a5e8922f36d0dda13d9ca4b00a5b69c4bc2d8ae`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`