### PR TITLE
fix(jangar): remove codex auto compact override

### DIFF
--- a/services/jangar/scripts/codex-config-container.toml
+++ b/services/jangar/scripts/codex-config-container.toml
@@ -2,8 +2,6 @@ model = "gpt-5.4"
 model_reasoning_summary = "detailed"
 model_reasoning_effort = "high"
 model_verbosity = "medium"
-# Keep compaction proactive for long-running OpenWebUI sessions while staying well below model context limits.
-model_auto_compact_token_limit = 24000
 approval_policy = "never"
 sandbox_mode = "danger-full-access"
 suppress_unstable_features_warning = true


### PR DESCRIPTION
## Summary

- Removes the Jangar Codex container override for `model_auto_compact_token_limit`.
- Lets the runtime fall back to Codex default compaction behavior instead of compacting around 24k tokens.
- Leaves the rest of the container Codex configuration unchanged.

## Related Issues

None

## Testing

- `sed -n '1,40p' services/jangar/scripts/codex-config-container.toml`
- `rg -n "model_auto_compact_token_limit" services/jangar -S`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked. No additional docs or release notes were required for this config-only change.
