### PR TITLE
fix(jangar): render rate limits only once per session

### DIFF
--- a/services/jangar/src/server/__tests__/chat-completion-encoder.test.ts
+++ b/services/jangar/src/server/__tests__/chat-completion-encoder.test.ts
@@ -169,6 +169,53 @@ describe('chat completion encoder', () => {
     expect(content).toContain('> Credits: has credits · balance 12.34')
   })
 
+  it('suppresses later rate limit updates in the same session even when values change', () => {
+    const session = createSession()
+
+    const firstFrames = session.onDelta({
+      type: 'rate_limits',
+      rateLimits: {
+        planType: 'pro',
+        primary: { usedPercent: 42, windowDurationMins: 90, resetsAt: 1_735_000_000 },
+      },
+    })
+
+    const secondFrames = session.onDelta({
+      type: 'rate_limits',
+      rateLimits: {
+        planType: 'pro',
+        primary: { usedPercent: 57, windowDurationMins: 90, resetsAt: 1_735_000_900 },
+        secondary: { usedPercent: 18, windowDurationMins: 60, resetsAt: 1_735_001_200 },
+      },
+    })
+
+    expect(collectContent(firstFrames)).toContain('> **Rate limits**')
+    expect(secondFrames).toHaveLength(0)
+  })
+
+  it('renders rate limits again for a new session', () => {
+    const firstSession = createSession()
+    const secondSession = createSession()
+
+    firstSession.onDelta({
+      type: 'rate_limits',
+      rateLimits: {
+        planType: 'pro',
+        primary: { usedPercent: 42, windowDurationMins: 90, resetsAt: 1_735_000_000 },
+      },
+    })
+
+    const secondFrames = secondSession.onDelta({
+      type: 'rate_limits',
+      rateLimits: {
+        planType: 'pro',
+        primary: { usedPercent: 57, windowDurationMins: 90, resetsAt: 1_735_000_900 },
+      },
+    })
+
+    expect(collectContent(secondFrames)).toContain('> **Rate limits**')
+  })
+
   it('emits usage and stop chunks on finalize when successful', () => {
     const session = createSession({ includeUsage: true })
 

--- a/services/jangar/src/server/chat-completion-encoder.ts
+++ b/services/jangar/src/server/chat-completion-encoder.ts
@@ -341,7 +341,7 @@ const createSession = (args: {
   let nextAnonymousToolId = 0
   let hasEmittedAnyChunk = false
   let lastPlanMarkdown: string | null = null
-  let lastRateLimitsMarkdown: string | null = null
+  let hasRenderedRateLimits = false
   let sawAnyMessageDelta = false
 
   const attachMeta = (chunk: Record<string, unknown>) => {
@@ -477,8 +477,8 @@ const createSession = (args: {
     if (type === 'rate_limits') {
       closeCommandFence(frames)
       const markdown = toRateLimitMarkdown(record?.rateLimits)
-      if (!markdown || markdown === lastRateLimitsMarkdown) return frames
-      lastRateLimitsMarkdown = markdown
+      if (!markdown || hasRenderedRateLimits) return frames
+      hasRenderedRateLimits = true
       emitContentDelta(frames, `\n\n${markdown}\n\n`)
       return frames
     }


### PR DESCRIPTION
## Summary

- render the first rate-limit update for a chat session and suppress later updates, even if the usage values change
- keep rate-limit rendering session-scoped so a fresh session still shows the initial rate-limit block
- add regression coverage for repeated updates in one session and re-rendering in a new session

## Related Issues

None

## Testing

- `bunx vitest run --config vitest.config.ts src/server/__tests__/chat-completion-encoder.test.ts` (from `services/jangar`) -> failed in this worktree with `ERR_MODULE_NOT_FOUND: Cannot find package 'vitest'`; dependencies are not installed locally here

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked. No documentation or release-note update is needed for this internal encoder behavior fix.
