### PR TITLE
chore(jangar): promote image c9cdd937

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: acfbabcd
-  digest: sha256:b94fbf115b8c6a60ef890cec0a5e8922f36d0dda13d9ca4b00a5b69c4bc2d8ae
+  tag: c9cdd937
+  digest: sha256:901bac317f1f7c5cc9d2fe8319efe990232a889e0c2f0291e2a1edb0c858db12
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: acfbabcd
-    digest: sha256:70341c8c657b2d93c068a6dee79c631d1bb50711e6209a0f002ff241845ebcbb
+    tag: c9cdd937
+    digest: sha256:9238342924aff26900194d895caf6e55a143d1708372af20ec4dd863deef1ebd
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: acfbabcd
-    digest: sha256:b94fbf115b8c6a60ef890cec0a5e8922f36d0dda13d9ca4b00a5b69c4bc2d8ae
+    tag: c9cdd937
+    digest: sha256:901bac317f1f7c5cc9d2fe8319efe990232a889e0c2f0291e2a1edb0c858db12
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-08T06:36:51Z"
+    deploy.knative.dev/rollout: "2026-03-08T07:32:58Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-08T06:36:51Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-08T07:32:58Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -61,5 +61,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "acfbabcd"
-    digest: sha256:b94fbf115b8c6a60ef890cec0a5e8922f36d0dda13d9ca4b00a5b69c4bc2d8ae
+    newTag: "c9cdd937"
+    digest: sha256:901bac317f1f7c5cc9d2fe8319efe990232a889e0c2f0291e2a1edb0c858db12


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `c9cdd937c7e2686c97b9e74e927aea30cc3b09e6`
- Image tag: `c9cdd937`
- Image digest: `sha256:901bac317f1f7c5cc9d2fe8319efe990232a889e0c2f0291e2a1edb0c858db12`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`