### PR TITLE
fix(jangar): normalize embedded reasoning deltas

### DIFF
--- a/packages/codex/src/app-server-client.events.test.ts
+++ b/packages/codex/src/app-server-client.events.test.ts
@@ -377,6 +377,43 @@ describe('CodexAppServerClient v2 notifications', () => {
     await drainStream(stream as unknown as AsyncGenerator<unknown, unknown, void>)
   })
 
+  it('strips embedded reasoning details from command output deltas', async () => {
+    const { child, client } = setupClient()
+    await respondToInitialize(child)
+    await client.ensureReady()
+
+    const runPromise = client.runTurnStream('hello')
+    await respondToThreadStart(child, 'thread-1')
+    await respondToTurnStart(child, 'turn-1')
+    const { stream } = await runPromise
+
+    writeLine(child, {
+      method: 'item/commandExecution/outputDelta',
+      params: {
+        threadId: 'thread-1',
+        turnId: 'turn-1',
+        itemId: 'cmd-1',
+        delta: 'Installing\n<details type="reasoning" done="true"><summary>Thought</summary>\nWaiting</details>\nDone',
+      },
+    })
+
+    const output = await stream.next()
+    expect(output.value).toEqual({
+      type: 'tool',
+      toolKind: 'command',
+      id: 'cmd-1',
+      status: 'delta',
+      title: 'command output',
+      detail: 'Installing\n\nDone',
+    })
+
+    writeLine(child, {
+      method: 'turn/completed',
+      params: { threadId: 'thread-1', turn: { id: 'turn-1', status: 'completed', items: [], error: null } },
+    })
+    await drainStream(stream as unknown as AsyncGenerator<unknown, unknown, void>)
+  })
+
   it('emits mcp tool deltas from item lifecycle', async () => {
     const { child, client } = setupClient()
     await respondToInitialize(child)
@@ -617,6 +654,84 @@ describe('CodexAppServerClient v2 notifications', () => {
 
     const deltas = await drainStream(stream as unknown as AsyncGenerator<unknown, unknown, void>)
     expect(deltas).toEqual([{ type: 'message', delta: 'Cool' }])
+  })
+
+  it('splits embedded reasoning details out of agent message deltas', async () => {
+    const { child, client } = setupClient()
+    await respondToInitialize(child)
+    await client.ensureReady()
+
+    const runPromise = client.runTurnStream('hello')
+    await respondToThreadStart(child, 'thread-1')
+    await respondToTurnStart(child, 'turn-1')
+    const { stream } = await runPromise
+
+    writeLine(child, {
+      method: 'item/agentMessage/delta',
+      params: {
+        threadId: 'thread-1',
+        turnId: 'turn-1',
+        itemId: 'item-1',
+        delta:
+          'Working\n<details type="reasoning" done="true"><summary>Thought</summary>\nInvestigating</details>\nDone',
+      },
+    })
+
+    writeLine(child, {
+      method: 'turn/completed',
+      params: { threadId: 'thread-1', turn: { id: 'turn-1', status: 'completed', items: [], error: null } },
+    })
+
+    const deltas = await drainStream(stream as unknown as AsyncGenerator<unknown, unknown, void>)
+    expect(deltas).toEqual([
+      { type: 'message', delta: 'Working\n' },
+      { type: 'reasoning', delta: '\nInvestigating' },
+      { type: 'message', delta: '\nDone' },
+    ])
+  })
+
+  it('splits reasoning details that span multiple agent message deltas', async () => {
+    const { child, client } = setupClient()
+    await respondToInitialize(child)
+    await client.ensureReady()
+
+    const runPromise = client.runTurnStream('hello')
+    await respondToThreadStart(child, 'thread-1')
+    await respondToTurnStart(child, 'turn-1')
+    const { stream } = await runPromise
+
+    writeLine(child, {
+      method: 'item/agentMessage/delta',
+      params: {
+        threadId: 'thread-1',
+        turnId: 'turn-1',
+        itemId: 'item-1',
+        delta: 'Working\n<details type="reasoning" done="true"><summary>Thought</summary>\nInvest',
+      },
+    })
+
+    writeLine(child, {
+      method: 'item/agentMessage/delta',
+      params: {
+        threadId: 'thread-1',
+        turnId: 'turn-1',
+        itemId: 'item-1',
+        delta: 'igating</details>\nDone',
+      },
+    })
+
+    writeLine(child, {
+      method: 'turn/completed',
+      params: { threadId: 'thread-1', turn: { id: 'turn-1', status: 'completed', items: [], error: null } },
+    })
+
+    const deltas = await drainStream(stream as unknown as AsyncGenerator<unknown, unknown, void>)
+    expect(deltas).toEqual([
+      { type: 'message', delta: 'Working\n' },
+      { type: 'reasoning', delta: '\nInvest' },
+      { type: 'reasoning', delta: 'igating' },
+      { type: 'message', delta: '\nDone' },
+    ])
   })
 
   it('emits reasoning deltas from item/reasoning/textDelta', async () => {

--- a/packages/codex/src/app-server-client.ts
+++ b/packages/codex/src/app-server-client.ts
@@ -72,6 +72,14 @@ type TurnStream = {
   iterator: AsyncGenerator<StreamDelta, Turn | null, void>
   lastReasoningDelta: string | null
   lastMessageDelta: string | null
+  embeddedReasoningState: EmbeddedReasoningState
+  commandReasoningStates: Map<string, EmbeddedReasoningState>
+}
+
+type EmbeddedReasoningState = {
+  carry: string
+  insideDetails: boolean
+  insideSummary: boolean
 }
 
 type LegacySandboxMode = 'dangerFullAccess' | 'workspaceWrite' | 'readOnly'
@@ -219,8 +227,99 @@ const createTurnStream = (): TurnStream => {
     iterator,
     lastReasoningDelta: null,
     lastMessageDelta: null,
+    embeddedReasoningState: { carry: '', insideDetails: false, insideSummary: false },
+    commandReasoningStates: new Map(),
   }
   return stream
+}
+
+const createEmbeddedReasoningState = (): EmbeddedReasoningState => ({
+  carry: '',
+  insideDetails: false,
+  insideSummary: false,
+})
+
+const splitEmbeddedReasoningDelta = (
+  input: string,
+  state: EmbeddedReasoningState,
+): Array<{ type: 'message' | 'reasoning'; delta: string }> => {
+  if (!input) return []
+
+  const openDetailsPattern = /^<details\b[^>]*\btype\s*=\s*["']reasoning["'][^>]*>/i
+  const openSummaryPattern = /^<summary\b[^>]*>/i
+  const closeSummaryPattern = /^<\/summary\s*>/i
+  const closeDetailsPattern = /^<\/details\s*>/i
+
+  const text = state.carry ? `${state.carry}${input}` : input
+  state.carry = ''
+
+  const deltas: Array<{ type: 'message' | 'reasoning'; delta: string }> = []
+  const append = (type: 'message' | 'reasoning', delta: string) => {
+    if (!delta) return
+    const previous = deltas.at(-1)
+    if (previous?.type === type) {
+      previous.delta += delta
+      return
+    }
+    deltas.push({ type, delta })
+  }
+
+  let index = 0
+  while (index < text.length) {
+    const tagStart = text.indexOf('<', index)
+    const currentType: 'message' | 'reasoning' = state.insideDetails ? 'reasoning' : 'message'
+
+    if (tagStart === -1) {
+      if (!state.insideSummary) {
+        append(currentType, text.slice(index))
+      }
+      return deltas
+    }
+
+    if (!state.insideSummary) {
+      append(currentType, text.slice(index, tagStart))
+    }
+
+    const tagEnd = text.indexOf('>', tagStart)
+    if (tagEnd === -1) {
+      state.carry = text.slice(tagStart)
+      return deltas
+    }
+
+    const tag = text.slice(tagStart, tagEnd + 1)
+
+    if (!state.insideDetails && openDetailsPattern.test(tag)) {
+      state.insideDetails = true
+      index = tagEnd + 1
+      continue
+    }
+
+    if (state.insideDetails && openSummaryPattern.test(tag)) {
+      state.insideSummary = true
+      index = tagEnd + 1
+      continue
+    }
+
+    if (state.insideSummary && closeSummaryPattern.test(tag)) {
+      state.insideSummary = false
+      index = tagEnd + 1
+      continue
+    }
+
+    if (state.insideDetails && closeDetailsPattern.test(tag)) {
+      state.insideDetails = false
+      state.insideSummary = false
+      index = tagEnd + 1
+      continue
+    }
+
+    if (!state.insideSummary) {
+      append(currentType, tag)
+    }
+    index = tagEnd + 1
+  }
+
+  return deltas
 }
 
 export class CodexAppServerClient {
@@ -633,14 +732,76 @@ export class CodexAppServerClient {
             return
           }
 
-          stream.push({ type: 'message', delta })
+          const pieces = splitEmbeddedReasoningDelta(delta, stream.embeddedReasoningState)
+          for (const piece of pieces) {
+            if (piece.type === 'message') {
+              if (stream.lastMessageDelta === piece.delta) {
+                this.log('info', 'skipping duplicate split agent message delta', {
+                  method,
+                  deltaBytes: piece.delta.length,
+                })
+                continue
+              }
+              stream.lastMessageDelta = piece.delta
+              stream.push(piece)
+              continue
+            }
+
+            if (stream.lastReasoningDelta === piece.delta) {
+              this.log('info', 'skipping duplicate split reasoning delta', {
+                method,
+                deltaBytes: piece.delta.length,
+              })
+              continue
+            }
+            stream.lastReasoningDelta = piece.delta
+            stream.push(piece)
+          }
         },
         { trackItem },
       )
     }
 
     const pushTool = (targetParams: unknown, payload: ToolPayload, { trackItem }: { trackItem?: boolean } = {}) => {
-      routeToStream(targetParams, (stream) => stream.push({ type: 'tool', ...payload }), { trackItem })
+      routeToStream(
+        targetParams,
+        (stream) => {
+          if (payload.toolKind === 'command') {
+            const itemId = this.findItemId(targetParams) ?? payload.id
+            let state = stream.commandReasoningStates.get(itemId)
+            if (!state) {
+              state = createEmbeddedReasoningState()
+              stream.commandReasoningStates.set(itemId, state)
+            }
+
+            const sanitizeCommandText = (value: string | undefined, parserState: EmbeddedReasoningState) => {
+              if (typeof value !== 'string') return value
+              return splitEmbeddedReasoningDelta(value, parserState)
+                .filter((piece) => piece.type === 'message')
+                .map((piece) => piece.delta)
+                .join('')
+            }
+
+            if (typeof payload.detail === 'string') {
+              payload = { ...payload, detail: sanitizeCommandText(payload.detail, state) }
+            }
+
+            const aggregatedOutput = payload.data?.aggregatedOutput
+            if (typeof aggregatedOutput === 'string') {
+              payload = {
+                ...payload,
+                data: {
+                  ...payload.data,
+                  aggregatedOutput: sanitizeCommandText(aggregatedOutput, createEmbeddedReasoningState()),
+                },
+              }
+            }
+          }
+
+          stream.push({ type: 'tool', ...payload })
+        },
+        { trackItem },
+      )
     }
 
     const pushUsage = (usage: unknown) => {

--- a/services/jangar/src/server/__tests__/chat-completion-encoder.test.ts
+++ b/services/jangar/src/server/__tests__/chat-completion-encoder.test.ts
@@ -45,6 +45,13 @@ const getDeltaContent = (frame: Record<string, unknown>) => {
   return typeof content === 'string' ? content : undefined
 }
 
+const getDeltaReasoningContent = (frame: Record<string, unknown>) => {
+  const delta = getDeltaRecord(frame)
+  if (!delta) return undefined
+  const content = delta.reasoning_content
+  return typeof content === 'string' ? content : undefined
+}
+
 const getDeltaRole = (frame: Record<string, unknown>) => {
   const delta = getDeltaRecord(frame)
   if (!delta) return undefined
@@ -62,6 +69,12 @@ const getFinishReason = (frame: Record<string, unknown>) => {
 const collectContent = (frames: Record<string, unknown>[]) =>
   frames
     .map((frame) => getDeltaContent(frame))
+    .filter((value): value is string => Boolean(value))
+    .join('')
+
+const collectReasoningContent = (frames: Record<string, unknown>[]) =>
+  frames
+    .map((frame) => getDeltaReasoningContent(frame))
     .filter((value): value is string => Boolean(value))
     .join('')
 
@@ -93,6 +106,54 @@ describe('chat completion encoder', () => {
 
     expect(getDeltaRole(reasoningFrames[0] ?? {})).toBe('assistant')
     expect(getDeltaRole(messageFrames[0] ?? {})).toBeUndefined()
+  })
+
+  it('strips reasoning details markup from reasoning deltas', () => {
+    const session = createSession()
+
+    const frames = session.onDelta({
+      type: 'reasoning',
+      delta:
+        '<details type="reasoning" done="true" duration="1"><summary>Thought for 1 second</summary>\n> Investigating\n</details>',
+    })
+
+    expect(collectReasoningContent(frames)).toBe('\n> Investigating\n')
+    expect(collectContent(frames)).toBe('')
+  })
+
+  it('closes command fences before emitting reasoning deltas', () => {
+    const toolRenderer: ToolRenderer = {
+      onToolEvent: () => [{ type: 'openCommandFence' }, { type: 'emitContent', content: 'kubectl get pods\n' }],
+    }
+
+    const session = createSession({ toolRenderer })
+
+    const toolFrames = session.onDelta({ type: 'tool', id: 'tool-1', toolKind: 'command' })
+    const reasoningFrames = session.onDelta({
+      type: 'reasoning',
+      delta: '<details type="reasoning" done="true"><summary>Thought</summary>checking</details>',
+    })
+
+    expect(collectContent(toolFrames)).toContain('```ts\nkubectl get pods\n')
+    expect(collectContent(reasoningFrames)).toContain('\n```\n\n')
+    expect(collectReasoningContent(reasoningFrames)).toBe('checking')
+  })
+
+  it('strips reasoning details markup split across reasoning deltas', () => {
+    const session = createSession()
+
+    const firstFrames = session.onDelta({
+      type: 'reasoning',
+      delta: '<details type="reasoning" done="true"><summary>Thought for 1 second</summary>check',
+    })
+    const secondFrames = session.onDelta({
+      type: 'reasoning',
+      delta: 'ing</details>',
+    })
+
+    expect(collectReasoningContent(firstFrames)).toBe('check')
+    expect(collectReasoningContent(secondFrames)).toBe('ing')
+    expect(collectContent([...firstFrames, ...secondFrames])).toBe('')
   })
 
   it('attaches thread metadata to emitted chunks', () => {

--- a/services/jangar/src/server/__tests__/chat-completions.test.ts
+++ b/services/jangar/src/server/__tests__/chat-completions.test.ts
@@ -2524,6 +2524,66 @@ describe('chat completions handler', () => {
     expect(reasoningChunks.some((c) => c.choices?.[0]?.delta?.content)).toBe(false)
   })
 
+  it('closes command fences and strips reasoning details markup before emitting reasoning', async () => {
+    const mockClient = {
+      runTurnStream: async () => ({
+        turnId: 'turn-1',
+        threadId: 'thread-1',
+        stream: (async function* () {
+          yield {
+            type: 'tool',
+            toolKind: 'command',
+            id: 'tool-1',
+            status: 'started',
+            title: 'kubectl get pods -n agents',
+          }
+          yield {
+            type: 'reasoning',
+            delta:
+              '<details type="reasoning" done="true" duration="1"><summary>Thought for 1 second</summary>\n> Verifying cronjobs\n</details>',
+          }
+          yield { type: 'usage', usage: { input_tokens: 1, output_tokens: 2 } }
+        })(),
+      }),
+      stop: vi.fn(),
+      ensureReady: vi.fn(),
+    }
+    setCodexClientFactory(() => mockClient as unknown as CodexAppServerClient)
+
+    const request = new Request('http://localhost', {
+      method: 'POST',
+      body: JSON.stringify({
+        model: 'gpt-5.4',
+        messages: [{ role: 'user', content: 'hi' }],
+        stream: true,
+        stream_options: { include_usage: true },
+      }),
+    })
+
+    const response = await chatCompletionsHandler(request)
+    const text = await response.text()
+    const chunks = text
+      .trim()
+      .split('\n\n')
+      .map((part) => part.replace(/^data: /, ''))
+      .filter((part) => part !== '[DONE]')
+      .map((part) => JSON.parse(part))
+
+    const contentText = chunks
+      .map((c) => c.choices?.[0]?.delta?.content as string | undefined)
+      .filter(Boolean)
+      .join('')
+    const reasoningText = chunks
+      .map((c) => c.choices?.[0]?.delta?.reasoning_content as string | undefined)
+      .filter(Boolean)
+      .join('')
+
+    expect(contentText).toContain('```ts\nkubectl get pods -n agents')
+    expect(contentText).toContain('\n```\n\n')
+    expect(contentText).not.toContain('<details')
+    expect(reasoningText).toBe('\n> Verifying cronjobs\n')
+  })
+
   it('converts four asterisks in reasoning to a newline', async () => {
     const mockClient = {
       runTurnStream: async () => ({

--- a/services/jangar/src/server/chat-completion-encoder.ts
+++ b/services/jangar/src/server/chat-completion-encoder.ts
@@ -244,6 +244,87 @@ const normalizeDeltaText = (delta: unknown): string => {
 
 const sanitizeReasoningText = (text: string) => text.replace(/\*{4,}/g, '\n')
 
+type ReasoningDetailsState = {
+  carry: string
+  insideDetails: boolean
+  insideSummary: boolean
+}
+
+const createReasoningDetailsState = (): ReasoningDetailsState => ({
+  carry: '',
+  insideDetails: false,
+  insideSummary: false,
+})
+
+const stripReasoningDetailsMarkup = (input: string, state: ReasoningDetailsState): string => {
+  if (!input) return input
+
+  const openDetailsPattern = /^<details\b[^>]*\btype\s*=\s*["']reasoning["'][^>]*>/i
+  const openSummaryPattern = /^<summary\b[^>]*>/i
+  const closeSummaryPattern = /^<\/summary\s*>/i
+  const closeDetailsPattern = /^<\/details\s*>/i
+
+  const text = state.carry ? `${state.carry}${input}` : input
+  state.carry = ''
+
+  let output = ''
+  let index = 0
+
+  while (index < text.length) {
+    const tagStart = text.indexOf('<', index)
+    if (tagStart === -1) {
+      if (!state.insideSummary) {
+        output += text.slice(index)
+      }
+      return output
+    }
+
+    if (!state.insideSummary) {
+      output += text.slice(index, tagStart)
+    }
+
+    const tagEnd = text.indexOf('>', tagStart)
+    if (tagEnd === -1) {
+      state.carry = text.slice(tagStart)
+      return output
+    }
+
+    const tag = text.slice(tagStart, tagEnd + 1)
+
+    if (openDetailsPattern.test(tag)) {
+      state.insideDetails = true
+      index = tagEnd + 1
+      continue
+    }
+
+    if (state.insideDetails && openSummaryPattern.test(tag)) {
+      state.insideSummary = true
+      index = tagEnd + 1
+      continue
+    }
+
+    if (state.insideSummary && closeSummaryPattern.test(tag)) {
+      state.insideSummary = false
+      index = tagEnd + 1
+      continue
+    }
+
+    if (state.insideDetails && closeDetailsPattern.test(tag)) {
+      state.insideDetails = false
+      state.insideSummary = false
+      index = tagEnd + 1
+      continue
+    }
+
+    if (!state.insideSummary) {
+      output += tag
+    }
+    index = tagEnd + 1
+  }
+
+  return output
+}
+
 export const normalizeStreamError = (error: unknown) => {
   const normalized: Record<string, unknown> = { type: 'upstream', code: 'upstream_error' }
 
@@ -344,6 +425,7 @@ const createSession = (args: {
   let lastRateLimitsMarkdown: string | null = null
   let sawAnyMessageDelta = false
   let assistantContent = ''
+  const reasoningDetailsState = createReasoningDetailsState()
 
   const attachMeta = (chunk: Record<string, unknown>) => {
     const threadId = meta.threadId
@@ -514,7 +596,10 @@ const createSession = (args: {
     }
 
     if (type === 'reasoning') {
-      reasoningBuffer += sanitizeReasoningText(normalizeDeltaText(record?.delta))
+      closeCommandFence(frames)
+      reasoningBuffer += sanitizeReasoningText(
+        stripReasoningDetailsMarkup(normalizeDeltaText(record?.delta), reasoningDetailsState),
+      )
       // Emit reasoning immediately to avoid long silent periods that can trip upstream timeouts.
       flushReasoning(frames)
       return frames


### PR DESCRIPTION
## Summary

- normalize embedded `<details type="reasoning">…</details>` blocks in the shared Codex app-server client before downstream renderers see them
- split malformed agent message deltas into proper `message` and `reasoning` stream events, and scrub command output/tool payloads of embedded reasoning wrappers
- keep the Jangar encoder defensive by closing command fences before reasoning output and add regression coverage in both `packages/codex` and `services/jangar`

## Related Issues

None

## Testing

- `bunx vitest run --config vitest.config.ts src/app-server-client.events.test.ts` (from `packages/codex`)
- `bunx vitest run --config vitest.config.ts src/server/__tests__/chat-completion-encoder.test.ts` (from `services/jangar`)
- `bunx vitest run --config vitest.config.ts src/server/__tests__/chat-completions.test.ts -t "closes command fences and strips reasoning details markup before emitting reasoning|removes reasoning details from command output"` (from `services/jangar`)

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
