### PR TITLE
chore(jangar): promote image 47f740c2

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: c9cdd937
-  digest: sha256:901bac317f1f7c5cc9d2fe8319efe990232a889e0c2f0291e2a1edb0c858db12
+  tag: 47f740c2
+  digest: sha256:d476e76ef7aac97e76114731d03920aa429a30e7920d7d323491973ffe871176
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: c9cdd937
-    digest: sha256:9238342924aff26900194d895caf6e55a143d1708372af20ec4dd863deef1ebd
+    tag: 47f740c2
+    digest: sha256:3d390e3fa2971ed67efb66eabd0ce6a767fca4380ccf1f4871dc6a2c22f89e7a
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: c9cdd937
-    digest: sha256:901bac317f1f7c5cc9d2fe8319efe990232a889e0c2f0291e2a1edb0c858db12
+    tag: 47f740c2
+    digest: sha256:d476e76ef7aac97e76114731d03920aa429a30e7920d7d323491973ffe871176
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-08T07:32:58Z"
+    deploy.knative.dev/rollout: "2026-03-08T08:13:23Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-08T07:32:58Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-08T08:13:23Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -61,5 +61,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "c9cdd937"
-    digest: sha256:901bac317f1f7c5cc9d2fe8319efe990232a889e0c2f0291e2a1edb0c858db12
+    newTag: "47f740c2"
+    digest: sha256:d476e76ef7aac97e76114731d03920aa429a30e7920d7d323491973ffe871176


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `47f740c2652bd0eacb0a7c590b84de3db974d8a8`
- Image tag: `47f740c2`
- Image digest: `sha256:d476e76ef7aac97e76114731d03920aa429a30e7920d7d323491973ffe871176`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`