### PR TITLE
chore(jangar): promote image a771302c

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 47f740c2
-  digest: sha256:d476e76ef7aac97e76114731d03920aa429a30e7920d7d323491973ffe871176
+  tag: a771302c
+  digest: sha256:788d646cde13e0e27967886c80f35d5c4f24a323b75987414c80356c1853be2e
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 47f740c2
-    digest: sha256:3d390e3fa2971ed67efb66eabd0ce6a767fca4380ccf1f4871dc6a2c22f89e7a
+    tag: a771302c
+    digest: sha256:09b90e35dee7ef4cf5cd087bf878494366a6c78055471665e64ef8d8240fb9e4
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 47f740c2
-    digest: sha256:d476e76ef7aac97e76114731d03920aa429a30e7920d7d323491973ffe871176
+    tag: a771302c
+    digest: sha256:788d646cde13e0e27967886c80f35d5c4f24a323b75987414c80356c1853be2e
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-08T08:13:23Z"
+    deploy.knative.dev/rollout: "2026-03-08T08:31:27Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-08T08:13:23Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-08T08:31:27Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -61,5 +61,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "47f740c2"
-    digest: sha256:d476e76ef7aac97e76114731d03920aa429a30e7920d7d323491973ffe871176
+    newTag: "a771302c"
+    digest: sha256:788d646cde13e0e27967886c80f35d5c4f24a323b75987414c80356c1853be2e


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `a771302ce158325b6d69d0f83cc4aa12d6c81d54`
- Image tag: `a771302c`
- Image digest: `sha256:788d646cde13e0e27967886c80f35d5c4f24a323b75987414c80356c1853be2e`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`