### PR TITLE
docs(torghut): add authoritative readiness design iteration

### DIFF
--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -155,6 +155,7 @@ For env and gRPC source-of-truth changes in this branch:
 - [designs/controller-failed-reconcile-events.md](designs/controller-failed-reconcile-events.md)
 - [designs/jangar-control-plane-operability-reliability-assessment.md](designs/jangar-control-plane-operability-reliability-assessment.md)
 - [designs/jangar-control-plane-capability-admission-failure-budgets-and-rollout-rings-2026-03-06.md](designs/jangar-control-plane-capability-admission-failure-budgets-and-rollout-rings-2026-03-06.md)
+- [designs/jangar-authoritative-controller-heartbeat-and-dependency-quorum-2026-03-08.md](designs/jangar-authoritative-controller-heartbeat-and-dependency-quorum-2026-03-08.md)
 - [designs/jangar-control-plane-admission-quorum-and-rollout-circuit-breaker-2026-03-06.md](designs/jangar-control-plane-admission-quorum-and-rollout-circuit-breaker-2026-03-06.md)
 - [designs/controller-finalizer-conventions.md](designs/controller-finalizer-conventions.md)
 - [designs/controller-kubectl-version-compat.md](designs/controller-kubectl-version-compat.md)

--- a/docs/agents/designs/jangar-authoritative-controller-heartbeat-and-dependency-quorum-2026-03-08.md
+++ b/docs/agents/designs/jangar-authoritative-controller-heartbeat-and-dependency-quorum-2026-03-08.md
@@ -1,0 +1,235 @@
+# Jangar Authoritative Controller Heartbeat and Dependency Quorum (2026-03-08)
+
+Status: Proposed (2026-03-08)
+
+## Summary
+
+Current `/api/agents/control-plane/status` responses derive controller health from the process that serves the HTTP
+request. In a split topology, that is not authoritative.
+
+Live evidence on `2026-03-08` shows:
+
+- the `agents` web service serves control-plane status from pods where controller workloads are disabled;
+- the actual controller workloads run in the separate `agents-controllers` deployment;
+- Torghut reads dependency quorum from the status route and therefore receives false `agents_controller_unavailable`
+  and `workflow_runtime_unavailable` block reasons even while the real controller deployment is healthy.
+
+This design introduces a topology-agnostic heartbeat-backed status contract so any Jangar status-serving pod can return
+authoritative controller/runtime truth.
+
+## Objectives
+
+- Make controller and runtime-adapter status truthful across split web/controller deployments.
+- Keep `/api/agents/control-plane/status` backward-compatible while improving authority semantics.
+- Allow remote consumers such as Torghut to treat dependency quorum as promotion-grade input.
+- Avoid requiring consumers to know which deployment currently hosts the authoritative controller workload.
+
+## Problem Statement
+
+The current control-plane status route conflates:
+
+- "this HTTP pod is not running controllers", and
+- "the cluster has no healthy controllers for this namespace".
+
+That behavior was acceptable in a single-binary or single-deployment topology, but it is wrong in the current split
+deployment layout:
+
+- `agents` deployment: status-serving web surface, controllers disabled
+- `agents-controllers` deployment: actual controller workloads enabled
+
+Because dependency quorum is derived from local controller/runtime state, remote consumers can block on a false
+negative even when the cluster is operational.
+
+## Evidence
+
+### Live cluster evidence
+
+- `kubectl get deploy -n agents agents agents-controllers -o wide`
+- `kubectl get deploy jangar -n jangar -o yaml | rg -n 'JANGAR_.*CONTROLLER_ENABLED' -C 2`
+- `kubectl get deploy agents-controllers -n agents -o yaml | rg -n 'JANGAR_.*CONTROLLER_ENABLED' -C 2`
+- `curl -fsS 'http://jangar.jangar.svc.cluster.local/api/agents/control-plane/status?namespace=agents' | jq`
+- `curl -fsS 'http://agents.agents.svc.cluster.local/api/agents/control-plane/status?namespace=agents' | jq`
+
+Observed on `2026-03-08`:
+
+- `jangar` and `agents` web services report controllers as `disabled`;
+- `agents-controllers` deployment has controller env vars enabled;
+- Torghut consumes dependency quorum from a Jangar status URL and therefore treats the dependency as blocked.
+
+### Source evidence
+
+- `services/jangar/src/server/control-plane-status.ts`
+- `services/jangar/src/server/agents-controller/index.ts`
+- `services/jangar/src/server/orchestration-controller.ts`
+- `services/jangar/src/server/supporting-primitives-controller.ts`
+- `services/torghut/app/trading/hypotheses.py`
+
+## Chosen Design
+
+### 1. Introduce authoritative heartbeat rows for controller/runtime ownership
+
+Add a shared heartbeat store written by the workloads that actually own controller/runtime authority.
+
+Minimum heartbeat dimensions:
+
+- `namespace`
+- `component`
+  - `agents-controller`
+  - `supporting-controller`
+  - `orchestration-controller`
+  - `workflow-runtime`
+  - optional future runtime adapters
+- `workload_role`
+  - `web`
+  - `controllers`
+  - other future roles if needed
+- `pod_name`
+- `deployment_name`
+- `enabled`
+- `status`
+  - `healthy`
+  - `degraded`
+  - `disabled`
+  - `unknown`
+- `message`
+- `leadership_state`
+  - `leader`
+  - `follower`
+  - `not-applicable`
+- `observed_at`
+- `expires_at`
+
+Only workloads that actually own the component may write authoritative heartbeats for that component.
+
+Examples:
+
+- `agents-controllers` may write `agents-controller`, `supporting-controller`, `orchestration-controller`, and
+  `workflow-runtime`.
+- `agents` web pods may publish `workload_role=web`, but they do not publish authoritative controller heartbeats when
+  controllers are disabled locally.
+
+### 2. Compute status from the freshest authoritative heartbeat, not local process flags
+
+Update `control-plane-status.ts` so component status resolution becomes:
+
+1. read the freshest non-expired authoritative heartbeat for the requested namespace/component;
+2. if present, use that heartbeat as the status source;
+3. if missing, return `status=unknown` with explicit authority-loss metadata;
+4. never treat "controller disabled in this web pod" as equivalent to "controller unavailable in cluster" unless the
+   web pod is also the authoritative workload for that component.
+
+This preserves fail-closed behavior while removing the current false-disabled outcome.
+
+### 3. Add authority metadata to the status payload
+
+Extend the status payload with an additive `authority` envelope:
+
+- `authority.mode`: `heartbeat | local | unknown`
+- `authority.namespace`
+- `authority.source_deployment`
+- `authority.source_pod`
+- `authority.observed_at`
+- `authority.fresh`
+- `authority.message`
+
+This makes topology truth visible to operators and downstream consumers.
+
+### 4. Derive dependency quorum from authoritative rows
+
+`buildDependencyQuorum()` should consume the resolved authoritative component states rather than directly reading local
+controller/runtime health objects from the serving pod.
+
+Behavior change:
+
+- authoritative `healthy` keeps current semantics;
+- authoritative `degraded` keeps current `delay` / `block` classification;
+- missing authority becomes `unknown` with explicit reason such as `agents_controller_status_unknown`;
+- false local `disabled` no longer causes `agents_controller_unavailable`.
+
+### 5. Preserve route compatibility for remote consumers
+
+Keep the existing status route shape and query semantics:
+
+- `/api/agents/control-plane/status?namespace=agents`
+
+This allows Torghut and other consumers to keep their current integration shape while gaining truthful results after
+the new contract lands.
+
+## Storage Choice
+
+Preferred implementation: persist heartbeats in the Jangar database.
+
+Rationale:
+
+- any status-serving pod can read the same shared state;
+- existing control-plane status already depends on database-backed context;
+- DB rows support freshness windows and historical debugging better than in-memory state;
+- no new service discovery hop is required for consumers.
+
+Alternative acceptable implementation:
+
+- shared ConfigMap or lease-backed heartbeat with bounded freshness metadata.
+
+Not selected as the primary design:
+
+- direct proxying from web pods to controller pods/services.
+
+That would couple the route to deployment topology and service discovery more tightly than necessary.
+
+## Alternatives Considered
+
+- Alternative A: point Torghut directly at the controller deployment.
+  - Pros: fast to wire if a dedicated service exists.
+  - Cons: hard-codes topology and still leaves status-serving web surfaces untruthful for other consumers.
+- Alternative B: keep local status semantics and document the limitation.
+  - Pros: zero implementation work.
+  - Cons: not acceptable for promotion-grade readiness decisions.
+- Alternative C: proxy status requests from web pods to controller pods.
+  - Pros: closer to authoritative truth than local flags.
+  - Cons: adds another availability dependency and keeps topology as part of the API contract.
+- Alternative D: chosen approach, heartbeat-backed authoritative state.
+  - Pros: topology-agnostic, cacheable, debuggable, and safe for remote consumers.
+  - Cons: requires shared-state schema and heartbeat writers.
+
+## Proposed Implementation Slices
+
+1. Add shared heartbeat storage and types.
+2. Teach authoritative workloads to write heartbeats on start, leadership changes, and periodic refresh.
+3. Refactor `control-plane-status.ts` to resolve component state from heartbeats.
+4. Add `authority` metadata to the status payload and UI/consumer types.
+5. Update Torghut and other consumers to treat `unknown` authority as non-promotable.
+6. Add regression tests for split-deployment topology where web pods are disabled locally but controllers are healthy
+   elsewhere.
+
+## Validation Plan
+
+- Unit tests:
+  - heartbeat freshness/expiry resolution
+  - authoritative-vs-local precedence
+  - dependency quorum classification from heartbeat state
+- Integration tests:
+  - split topology with web deployment `controllers disabled` and separate controller deployment `controllers enabled`
+  - route still returns healthy dependency quorum when authoritative heartbeat is fresh
+  - route returns `unknown`, not false `disabled`, when heartbeat authority is missing
+- Manual cluster checks:
+  - compare `/api/agents/control-plane/status?namespace=agents` against `kubectl get deploy agents-controllers -n agents`
+  - verify Torghut stops blocking on false `agents_controller_unavailable`
+
+## Risks
+
+- Heartbeat expiry thresholds that are too aggressive can convert transient delays into `unknown`.
+- If multiple authoritative writers exist accidentally, precedence rules must remain deterministic.
+- Database outages will degrade status authority; the route should fail closed to `unknown`, not invent healthy state.
+
+## Recommended Rollout
+
+1. Land heartbeat-backed status resolution in Jangar.
+2. Verify both `jangar` and `agents` web surfaces return the same authoritative result for `namespace=agents`.
+3. Update Torghut to continue using the status route only after the authoritative contract is live.
+4. Treat any missing or stale authority as a promotion block until freshness recovers.
+
+## Handoff
+
+- Jangar owners: implement heartbeat storage, writers, and status-route resolution.
+- Torghut owners: keep dependency quorum fail-closed and validate that promotion decisions now reflect the actual
+  `agents` controller topology.

--- a/docs/torghut/design-system/v6/32-authoritative-alpha-readiness-and-empirical-promotion-closeout-2026-03-08.md
+++ b/docs/torghut/design-system/v6/32-authoritative-alpha-readiness-and-empirical-promotion-closeout-2026-03-08.md
@@ -1,0 +1,237 @@
+# 32. Authoritative Alpha Readiness and Empirical Promotion Closeout (2026-03-08)
+
+## Status
+
+- Date: `2026-03-08`
+- Maturity: `next-iteration design + live-state recommendation`
+- Scope: `services/torghut/**`, `services/jangar/**`, `argocd/applications/torghut/**`, `docs/agents/designs/**`,
+  live Torghut/agents clusters, and Torghut Postgres promotion evidence tables
+- Primary objective: define the highest-priority next build slice after the March 7 proving lane closeout
+- Current live state: simulation/runtime is healthy, but autonomous readiness and empirical promotion are still not
+  authoritative enough for robust capital governance
+
+## Executive Summary
+
+The next highest-priority build is not "enable simulation". That slice is already materially working.
+
+Live state on `2026-03-08` shows:
+
+- `torghut` and `torghut-sim` are both `Ready=True`.
+- recent full-session simulation evidence is consistent with a healthy simulation/runtime lane.
+- `torghut /trading/health` still reports `alpha_readiness.dependency_quorum.decision=block`.
+- the current block reasons are `agents_controller_unavailable` and `workflow_runtime_unavailable`.
+- recent `torghut-empirical-promotion-*` workflows are not yet deterministic: some succeeded, while others failed on
+  workflow result/RBAC or manifest contract issues.
+
+The next build slice therefore needs to close the gap between:
+
+1. a runtime that can trade and simulate, and
+2. a promotion/admission system that can tell the truth about whether that runtime is actually promotable.
+
+The correct recommendation is:
+
+- make dependency truth authoritative,
+- make empirical promotion deterministic,
+- make the promotion ledger repeatedly exercised and operator-readable,
+- only then resume broader autonomy or strategy/model expansion.
+
+## Assessment Basis
+
+### Live cluster evidence
+
+- `kubectl get ksvc -n torghut torghut torghut-sim -o wide`
+- `curl -fsS http://torghut.torghut.svc.cluster.local/trading/health | jq`
+- `kubectl get workflow -n torghut | rg 'empirical|sim|NAME'`
+- `kubectl logs -n torghut pod/torghut-empirical-promotion-d6jsk --all-containers --tail=120`
+- `kubectl get deploy -n agents agents agents-controllers agents-alloy -o wide`
+- `curl -fsS 'http://jangar.jangar.svc.cluster.local/api/agents/control-plane/status?namespace=agents' | jq`
+
+### Source evidence
+
+- `services/torghut/app/trading/hypotheses.py`
+- `services/torghut/app/config.py`
+- `services/jangar/src/server/control-plane-status.ts`
+- `services/torghut/scripts/run_empirical_promotion_jobs.py`
+- `argocd/applications/torghut/knative-service.yaml`
+- `docs/agents/designs/jangar-authoritative-controller-heartbeat-and-dependency-quorum-2026-03-08.md`
+
+### Database evidence
+
+- `kubectl exec -n torghut torghut-db-1 -- psql -U postgres -d torghut -Atc "<counts query>"`
+- `kubectl exec -n torghut torghut-db-1 -- psql -U postgres -d torghut -P pager=off -c "<latest rows query>"`
+
+## Verified Current State
+
+### 1. Simulation/runtime is healthy enough to stop treating "enable sim" as the top blocker
+
+The current cluster does not look like a system blocked on simulation enablement:
+
+- `torghut` is serving and ready.
+- `torghut-sim` is serving and ready.
+- `torghut-ta-sim`, `torghut-forecast-sim`, and related sim-side pods are up.
+- recent full-session replay evidence has already proven that the mirrored environment can run end to end.
+
+That means the user's statement that a full-day simulation completed successfully on `2026-03-08` is directionally
+consistent with the current runtime surface.
+
+### 2. Autonomous readiness still blocks on non-authoritative dependency truth
+
+`services/torghut/app/trading/hypotheses.py` loads Jangar dependency quorum from
+`TRADING_JANGAR_CONTROL_PLANE_STATUS_URL`.
+
+Current Torghut config still points that at:
+
+- `http://jangar.jangar.svc.cluster.local/api/agents/control-plane/status?namespace=agents`
+
+The live problem is that this status surface is not authoritative for the actual `agents` control plane.
+
+Observed on `2026-03-08`:
+
+- the `agents-controllers` deployment in namespace `agents` is healthy and running the controller workload;
+- the status payload served from the current Jangar URL reports `agents-controller`, `supporting-controller`, and
+  `orchestration-controller` as `disabled`;
+- `torghut /trading/health` therefore blocks capital readiness on reasons that reflect the wrong serving topology, not
+  the actual controller state.
+
+This is more serious than a cosmetic health bug. It means the system can produce a truthful-looking readiness verdict
+from a non-authoritative source.
+
+### 3. Empirical promotion is present, but not yet deterministic enough to serve as promotion authority
+
+Recent workflow evidence shows mixed results:
+
+- some `torghut-empirical-promotion-*` workflows succeeded;
+- others failed with `workflowtaskresults.argoproj.io is forbidden`;
+- others failed because `run_empirical_promotion_jobs.py` rejected the manifest with
+  `RuntimeError: manifest must be a mapping`.
+
+This means the empirical-promotion lane is real, but it is still too brittle to be treated as a dependable promotion
+gate.
+
+### 4. The durable evidence plane exists, but the vNext promotion ledger is still thin
+
+Observed live row counts from Torghut Postgres on `2026-03-08`:
+
+- `research_runs`: `1576`
+- `research_candidates`: `322`
+- `research_promotions`: `325`
+- `vnext_promotion_decisions`: `1`
+- `vnext_empirical_job_runs`: `8`
+- `llm_dspy_workflow_artifacts`: `1`
+- `lean_canary_incidents`: `0`
+
+Recent rows reinforce the same shape:
+
+- `research_candidates` are mostly `challenger / evaluated / paper`;
+- recent `research_promotions` are denying promotion rather than advancing it;
+- the single `vnext_promotion_decisions` row is also `deny`;
+- the single DSPy workflow artifact recommends `hold`.
+
+This is not a data-empty system. It is a system whose newer promotion authority is still too sparsely exercised to be
+trusted as a mature operating loop.
+
+## Chosen Recommendation
+
+The next recommendation iteration is:
+
+1. make alpha-readiness authoritative,
+2. make empirical promotion deterministic,
+3. make promotion authority repeated and inspectable,
+4. keep broader autonomy/model expansion behind those gates.
+
+This is the shortest credible path from "simulation/proof works" to "autonomous promotion can be trusted".
+
+## What Needs To Be Built
+
+### Slice 1. Authoritative dependency quorum
+
+Implement the agents/Jangar-side design in
+`docs/agents/designs/jangar-authoritative-controller-heartbeat-and-dependency-quorum-2026-03-08.md`.
+
+Desired outcome:
+
+- any status-serving pod can return the same truthful controller/runtime state;
+- Torghut dependency quorum is based on authoritative controller heartbeats, not local env toggles on a web-serving
+  deployment;
+- if authority is missing or stale, status degrades to `unknown`, not a false `disabled`.
+
+Torghut rollout change once that slice lands:
+
+- point `TRADING_JANGAR_CONTROL_PLANE_STATUS_URL` at the service intended to represent the `agents` dependency, while
+  relying on the new heartbeat-backed status contract rather than local in-process controller state.
+
+### Slice 2. Deterministic empirical promotion workflow
+
+Empirical promotion needs to fail earlier and more clearly.
+
+Required changes:
+
+- validate promotion manifests before workflow submission;
+- remove the current class of "workflow launches, then dies on malformed manifest" failures;
+- resolve workflow result plumbing so repeated empirical jobs do not fail on result-patching/RBAC path issues;
+- treat partially written or non-authoritative empirical artifacts as ineligible, never ambiguous.
+
+### Slice 3. Promotion ledger maturity
+
+The vNext ledger needs to be exercised enough that operators can trust it.
+
+Required changes:
+
+- write successful empirical runs into `vnext_empirical_job_runs` consistently;
+- materialize promotion-denial reasons into durable decision rows;
+- attach enough operator-friendly metadata that a candidate can be traced without reconstructing the entire artifact
+  bundle by hand;
+- keep old artifact tables as evidence inputs, but make decision authority clearly legible in the new ledger.
+
+### Slice 4. Resume criteria for broader autonomy
+
+Do not re-enable broader autonomous promotion, additional swarms, or new alpha branches until:
+
+- dependency quorum reads from an authoritative source;
+- empirical-promotion success is routine rather than occasional;
+- the vNext decision tables show repeated successful writes over multiple sessions;
+- operators can explain any deny/block outcome from status plus DB rows, without log archaeology.
+
+## Alternatives Considered
+
+- Alternative A: prioritize more strategies/models first.
+  - Pros: increases research breadth.
+  - Cons: amplifies failure modes on top of an untrustworthy promotion plane.
+- Alternative B: focus only on simulation throughput.
+  - Pros: simpler and already productive.
+  - Cons: leaves the autonomous capital/readiness story unresolved.
+- Alternative C: resume swarms now that the `agents` queue is clear.
+  - Pros: restores automation quickly.
+  - Cons: reintroduces load before readiness and promotion truth are fixed.
+- Alternative D: chosen approach, fix truth/evidence authority first.
+  - Pros: directly addresses the current live failure boundary and preserves simulation gains.
+  - Cons: less flashy than strategy expansion and requires cross-service work.
+
+## Risks
+
+- The system may appear slower to "improve" because more work goes into evidence authority than strategy count.
+- Tightening promotion contracts may temporarily increase denial rates before the evidence lane stabilizes.
+- If the authoritative status slice is implemented incorrectly, it can create a different class of false green or false
+  block; topology metadata and freshness semantics must therefore remain explicit.
+
+## Exit Gates
+
+This recommendation iteration is complete only when all of the following are true:
+
+1. `/trading/health` reports dependency quorum from an authoritative source and no longer blocks on false
+   `agents_controller_unavailable` / `workflow_runtime_unavailable` signals caused by split deployment topology.
+2. A sequence of empirical-promotion workflows completes without manifest or workflow-result contract failures.
+3. `vnext_empirical_job_runs` and `vnext_promotion_decisions` contain repeated recent rows from successful production
+   exercises, not only singleton or deny-only state.
+4. Operators can determine candidate state, evidence freshness, and promotion outcome directly from status plus durable
+   DB rows.
+
+## Recommendation To Engineers
+
+If only one implementation wave can be funded next, it should be:
+
+1. authoritative dependency quorum,
+2. empirical promotion reliability,
+3. durable promotion ledger surfacing.
+
+That is the highest-leverage path from a working simulation lane to a robust autonomous trading system.

--- a/docs/torghut/design-system/v6/index.md
+++ b/docs/torghut/design-system/v6/index.md
@@ -24,6 +24,9 @@
   baseline from the March 7 implementation closeout, while keeping live promotion as an operator-controlled decision.
 - `31-proven-autonomous-quant-llm-torghut-trading-system-2026-03-07.md` now anchors the target-state design in the
   actual proof results and the full-session replay profitability nuance.
+- `32-authoritative-alpha-readiness-and-empirical-promotion-closeout-2026-03-08.md` now records the next
+  recommendation iteration: keep simulation gains, but prioritize authoritative dependency truth, deterministic
+  empirical promotion, and a repeatedly exercised promotion ledger before resuming broader autonomy expansion.
 
 ## Purpose
 
@@ -76,6 +79,7 @@ This pack is positioned as the next architecture layer above:
 29. `29-code-investigated-vnext-architecture-reset-2026-03-06.md`
 30. `30-live-state-disposition-and-implementation-rollout-gates-2026-03-06.md`
 31. `31-proven-autonomous-quant-llm-torghut-trading-system-2026-03-07.md`
+32. `32-authoritative-alpha-readiness-and-empirical-promotion-closeout-2026-03-08.md`
 
 ## Recommended Build Order
 
@@ -110,6 +114,7 @@ This pack is positioned as the next architecture layer above:
 29. `29-code-investigated-vnext-architecture-reset-2026-03-06.md`
 30. `30-live-state-disposition-and-implementation-rollout-gates-2026-03-06.md`
 31. `31-proven-autonomous-quant-llm-torghut-trading-system-2026-03-07.md`
+32. `32-authoritative-alpha-readiness-and-empirical-promotion-closeout-2026-03-08.md`
 
 ## Why This Sequence
 


### PR DESCRIPTION
## Summary

- Add a Torghut v6 design doc for the next recommendation iteration after the March 7 proving-lane closeout.
- Add an agents/Jangar design doc for an authoritative heartbeat-backed control-plane status contract so Torghut can trust dependency quorum in split web/controller topologies.
- Update the Torghut v6 index and agents docs index so both new design docs are discoverable in the repo.

## Related Issues

None

## Testing

- `git diff --check`
- Manual review of the new design docs against the live March 8, 2026 cluster findings, source paths, and Torghut Postgres evidence queried during the investigation.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
