### PR TITLE
chore(jangar): promote image 7c7461aa

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: a771302c
-  digest: sha256:788d646cde13e0e27967886c80f35d5c4f24a323b75987414c80356c1853be2e
+  tag: 7c7461aa
+  digest: sha256:efa975302418171aca3a1b6f9ec8daa73f167d276050a6da12e77e0a5d573f05
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: a771302c
-    digest: sha256:09b90e35dee7ef4cf5cd087bf878494366a6c78055471665e64ef8d8240fb9e4
+    tag: 7c7461aa
+    digest: sha256:96774a938992c3fd8e38ebfe64a209884aa230489a17ef675c6c046b4f32be83
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: a771302c
-    digest: sha256:788d646cde13e0e27967886c80f35d5c4f24a323b75987414c80356c1853be2e
+    tag: 7c7461aa
+    digest: sha256:efa975302418171aca3a1b6f9ec8daa73f167d276050a6da12e77e0a5d573f05
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-08T08:31:27Z"
+    deploy.knative.dev/rollout: "2026-03-08T09:51:36Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-08T08:31:27Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-08T09:51:36Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -61,5 +61,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "a771302c"
-    digest: sha256:788d646cde13e0e27967886c80f35d5c4f24a323b75987414c80356c1853be2e
+    newTag: "7c7461aa"
+    digest: sha256:efa975302418171aca3a1b6f9ec8daa73f167d276050a6da12e77e0a5d573f05


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `7c7461aa5ae8848b9894ccb2eb37a1553e667832`
- Image tag: `7c7461aa`
- Image digest: `sha256:efa975302418171aca3a1b6f9ec8daa73f167d276050a6da12e77e0a5d573f05`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`