### PR TITLE
chore(jangar): promote image 8f12c1ec

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 7c7461aa
-  digest: sha256:efa975302418171aca3a1b6f9ec8daa73f167d276050a6da12e77e0a5d573f05
+  tag: 8f12c1ec
+  digest: sha256:057fa1616727a662b2b0a5f4fda6bbdc8d97592d39b0dccd5b97c410039e9cea
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 7c7461aa
-    digest: sha256:96774a938992c3fd8e38ebfe64a209884aa230489a17ef675c6c046b4f32be83
+    tag: 8f12c1ec
+    digest: sha256:bb352801e455d5c59186d9ec5aab857d2edf3abe04d5b3aad0eb223710402c5e
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 7c7461aa
-    digest: sha256:efa975302418171aca3a1b6f9ec8daa73f167d276050a6da12e77e0a5d573f05
+    tag: 8f12c1ec
+    digest: sha256:057fa1616727a662b2b0a5f4fda6bbdc8d97592d39b0dccd5b97c410039e9cea
 argocdHooks:
   enabled: true
   image:
@@ -84,8 +84,6 @@ controller:
     perAgent: 10
   queue:
     perRepo: 200
-  # Agents namespace policy override to keep AgentRun history shorter in high-churn env.
-  # This intentionally overrides chart default with 7 days.
   agentRunRetentionSeconds: 604800
   jobTtlSeconds: 86400
   jobTtlSecondsAfterFinished: 86400

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-08T09:51:36Z"
+    deploy.knative.dev/rollout: "2026-03-08T20:47:22Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-08T09:51:36Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-08T20:47:22Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -61,5 +61,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "7c7461aa"
-    digest: sha256:efa975302418171aca3a1b6f9ec8daa73f167d276050a6da12e77e0a5d573f05
+    newTag: "8f12c1ec"
+    digest: sha256:057fa1616727a662b2b0a5f4fda6bbdc8d97592d39b0dccd5b97c410039e9cea


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `8f12c1ec22f47236b12f8613233567ceb6ec7d74`
- Image tag: `8f12c1ec`
- Image digest: `sha256:057fa1616727a662b2b0a5f4fda6bbdc8d97592d39b0dccd5b97c410039e9cea`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`