### PR TITLE
chore(jangar): promote image ac135544

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 8f12c1ec
-  digest: sha256:057fa1616727a662b2b0a5f4fda6bbdc8d97592d39b0dccd5b97c410039e9cea
+  tag: ac135544
+  digest: sha256:174799e161e1539de01021c2ed210e179474d5d69d3bb43ef21c2a6ffcd4eb28
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 8f12c1ec
-    digest: sha256:bb352801e455d5c59186d9ec5aab857d2edf3abe04d5b3aad0eb223710402c5e
+    tag: ac135544
+    digest: sha256:bc484d1e44d3d8fe3b6df6f662a51847701815244ac343116cd9acc79da75e41
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 8f12c1ec
-    digest: sha256:057fa1616727a662b2b0a5f4fda6bbdc8d97592d39b0dccd5b97c410039e9cea
+    tag: ac135544
+    digest: sha256:174799e161e1539de01021c2ed210e179474d5d69d3bb43ef21c2a6ffcd4eb28
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-08T20:47:22Z"
+    deploy.knative.dev/rollout: "2026-03-08T23:10:49Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-08T20:47:22Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-08T23:10:49Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -61,5 +61,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "8f12c1ec"
-    digest: sha256:057fa1616727a662b2b0a5f4fda6bbdc8d97592d39b0dccd5b97c410039e9cea
+    newTag: "ac135544"
+    digest: sha256:174799e161e1539de01021c2ed210e179474d5d69d3bb43ef21c2a6ffcd4eb28


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `ac135544972263844b9086eda7491e1fda063572`
- Image tag: `ac135544`
- Image digest: `sha256:174799e161e1539de01021c2ed210e179474d5d69d3bb43ef21c2a6ffcd4eb28`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`