### PR TITLE
docs(jangar): complete OpenWebUI rich UI completion design

### DIFF
--- a/docs/jangar/openwebui-rich-ui-completion-endpoint-design-2026-03-08.md
+++ b/docs/jangar/openwebui-rich-ui-completion-endpoint-design-2026-03-08.md
@@ -138,7 +138,8 @@ export type JangarEventV1 = {
   - `assistant:error`
   - `tool:${toolKind}:${toolId}`
 - `seq` is local to one assistant turn and starts at `1`.
-- `revision` increments only when reducer state changes for the logical entity.
+- `revision` increments on every accepted reducer-state mutation for the logical entity.
+- `append_text` events are not exempt: every new text chunk for the same `logicalId` must advance `revision`, even when the payload shape is unchanged.
 - `seq` and `revision` are independent; both must be validated.
 
 ### Compatibility and drop rules
@@ -151,6 +152,7 @@ export type JangarEventV1 = {
 - drop events when:
   - `seq <= lastSeq`
   - `revision <= lastRevisionByLogicalId[logicalId]`
+- A reused `revision` for a later append/update is a producer bug because the reducer treats same-or-lower revisions as stale and drops them.
 
 ## Source mapping and lane contracts
 


### PR DESCRIPTION
## Summary

- Reworked `docs/jangar/openwebui-rich-ui-completion-endpoint-design-2026-03-08.md` into a production-ready v1 design for OpenWebUI rich completion rendering.
- Added explicit contract details for `jangar_event` schema, versioning, lane reducers, compact persistence for replay, and spillover/renderRef lifecycle behavior.
- Added concrete implementation phasing with file ownership and dependency ordering, plus rollout/rollback, risk, and validation plans.
- Added explicit compatibility expectations for non-stream behavior and non-OpenWebUI clients.

## Related Issues

- Reference design artifact: https://github.com/proompteng/lab/blob/main/docs/jangar/openwebui-rich-ui-completion-endpoint-design-2026-03-08.md

## Testing

- `bunx oxfmt --check docs/jangar/openwebui-rich-ui-completion-endpoint-design-2026-03-08.md`
- `bunx oxfmt docs/jangar/openwebui-rich-ui-completion-endpoint-design-2026-03-08.md`
- `bunx oxfmt --check docs/jangar/openwebui-rich-ui-completion-endpoint-design-2026-03-08.md`
- `gh pr checks 4242 --watch --fail-fast=false -R proompteng/lab`

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
