### PR TITLE
chore(torghut-options): promote ws image 2b9824ae

### DIFF
--- a/argocd/applications/torghut-options/ws/deployment.yaml
+++ b/argocd/applications/torghut-options/ws/deployment.yaml
@@ -27,7 +27,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-ws-options
-          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:7a29c76d66903727fac3e0c469cbb09df3b2370e90edad30eaf9f2cbfa80d64b
+          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:db62663f3dae59c54ab99a78f63f35d830b3e5e6051d05477fa91f461f95f66a
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:
@@ -51,9 +51,9 @@ spec:
                   name: torghut-options
                   key: password
             - name: TORGHUT_WS_VERSION
-              value: bootstrap
+              value: main-2b9824ae
             - name: TORGHUT_WS_COMMIT
-              value: "0000000000000000000000000000000000000000"
+              value: 2b9824ae0abd2fae9480e3b73ab8c73b4d5392d5
             - name: JAVA_TOOL_OPTIONS
               value: -XX:+UseContainerSupport -XX:InitialRAMPercentage=40.0 -XX:MaxRAMPercentage=70.0 -XX:+ExitOnOutOfMemoryError
           ports:


### PR DESCRIPTION
## Summary

- Promote the Torghut options websocket image `2b9824ae` into GitOps manifests.
- Update `argocd/applications/torghut-options/ws/deployment.yaml` to the released digest `sha256:db62663f3dae59c54ab99a78f63f35d830b3e5e6051d05477fa91f461f95f66a`.
- Confirm the corrected websocket release workflow now downloads the build contract artifact and creates the promotion PR successfully.

## Related Issues

None

## Testing

- `gh pr diff 4245 --name-only`
- `gh pr checks 4245`
- `gh run view 22836443366 --json conclusion,url`
- `gh run view 22836525337 --json conclusion,jobs,url`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
