### PR TITLE
chore(torghut-options): promote ta image 2b9824ae

### DIFF
--- a/argocd/applications/torghut-options/ta/flinkdeployment.yaml
+++ b/argocd/applications/torghut-options/ta/flinkdeployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: torghut-options-ta
 spec:
-  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:436aecef1aae71f18fd01935ca97cb26866d149154edb4dab4222d66c4e849b3
+  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:587e43e94fc5876a7277717855a14244e460847deb47a7b2c22c190b09014b97
   imagePullPolicy: IfNotPresent
   restartNonce: 1
   flinkVersion: v2_0
@@ -86,9 +86,9 @@ spec:
                   name: flink-checkpoints
                   key: AWS_SECRET_ACCESS_KEY
             - name: TORGHUT_TA_VERSION
-              value: bootstrap
+              value: 2b9824ae
             - name: TORGHUT_TA_COMMIT
-              value: "0000000000000000000000000000000000000000"
+              value: 2b9824ae0abd2fae9480e3b73ab8c73b4d5392d5
           ports:
             - containerPort: 9249
               name: metrics


### PR DESCRIPTION
## Summary

- Promote the Torghut options TA image `2b9824ae` into GitOps manifests.
- Update `argocd/applications/torghut-options/ta/flinkdeployment.yaml` to the released digest `sha256:587e43e94fc5876a7277717855a14244e460847deb47a7b2c22c190b09014b97`.
- Confirm the TA build and release workflows now publish the release contract artifact and create the promotion PR successfully.

## Related Issues

None

## Testing

- `gh pr diff 4246 --name-only`
- `gh pr checks 4246`
- `gh run view 22836443365 --json conclusion,url`
- `gh run view 22836538483 --json conclusion,jobs,url`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
