### PR TITLE
chore(torghut-options): promote ta image 43640bd2

### DIFF
--- a/argocd/applications/torghut-options/ta/flinkdeployment.yaml
+++ b/argocd/applications/torghut-options/ta/flinkdeployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: torghut-options-ta
 spec:
-  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:587e43e94fc5876a7277717855a14244e460847deb47a7b2c22c190b09014b97
+  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:0f458d3218b0804370dd7fdd0edb727c9136356d0e45840931aa9bdaa6b23186
   imagePullPolicy: IfNotPresent
   restartNonce: 1
   flinkVersion: v2_0
@@ -86,9 +86,9 @@ spec:
                   name: flink-checkpoints
                   key: AWS_SECRET_ACCESS_KEY
             - name: TORGHUT_TA_VERSION
-              value: 2b9824ae
+              value: 43640bd2
             - name: TORGHUT_TA_COMMIT
-              value: 2b9824ae0abd2fae9480e3b73ab8c73b4d5392d5
+              value: 43640bd2d03840f52b32054206dd340af807985b
           ports:
             - containerPort: 9249
               name: metrics


### PR DESCRIPTION
## Summary
Promote the Torghut options TA image into GitOps manifests.

- Source commit: `43640bd2d03840f52b32054206dd340af807985b`
- Image tag: `43640bd2`
- Image digest: `sha256:0f458d3218b0804370dd7fdd0edb727c9136356d0e45840931aa9bdaa6b23186`