### PR TITLE
fix(torghut): finalize options lane rollout

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -14,6 +14,8 @@ spec:
     metadata:
       labels:
         app: torghut-options-catalog
+      annotations:
+        kubectl.kubernetes.io/restartedAt: "2026-03-09T03:45:00Z"
     spec:
       serviceAccountName: torghut-runtime
       containers:

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -14,6 +14,8 @@ spec:
     metadata:
       labels:
         app: torghut-options-enricher
+      annotations:
+        kubectl.kubernetes.io/restartedAt: "2026-03-09T03:45:00Z"
     spec:
       serviceAccountName: torghut-runtime
       containers:

--- a/argocd/applications/torghut-options/ws/deployment.yaml
+++ b/argocd/applications/torghut-options/ws/deployment.yaml
@@ -16,6 +16,8 @@ spec:
     metadata:
       labels:
         app: torghut-ws-options
+      annotations:
+        kubectl.kubernetes.io/restartedAt: "2026-03-09T03:45:00Z"
     spec:
       serviceAccountName: torghut-runtime
       securityContext:

--- a/services/torghut/app/options_lane/settings.py
+++ b/services/torghut/app/options_lane/settings.py
@@ -188,6 +188,19 @@ class OptionsLaneSettings(BaseSettings):
             return [item.upper() for item in _split_csv(value)]
         return []
 
+    @field_validator("sqlalchemy_dsn", mode="before")
+    @classmethod
+    def _normalize_sqlalchemy_dsn(cls, value: Any) -> Any:
+        if not isinstance(value, str):
+            return value
+        if value.startswith("postgresql+psycopg://"):
+            return value
+        if value.startswith("postgres://"):
+            return value.replace("postgres://", "postgresql+psycopg://", 1)
+        if value.startswith("postgresql://"):
+            return value.replace("postgresql://", "postgresql+psycopg://", 1)
+        return value
+
     @property
     def holiday_set(self) -> set[str]:
         return {item for item in self.options_market_holidays if item}

--- a/services/torghut/tests/test_options_lane.py
+++ b/services/torghut/tests/test_options_lane.py
@@ -53,6 +53,7 @@ class TestOptionsLaneSettings(TestCase):
     def test_settings_accept_blank_csv_lists(self) -> None:
         settings = OptionsLaneSettings()
 
+        self.assertEqual(settings.sqlalchemy_dsn, "postgresql+psycopg://torghut:torghut@localhost:5432/torghut")
         self.assertEqual(settings.options_market_holidays, [])
         self.assertEqual(settings.options_underlying_priority_symbols, [])
 


### PR DESCRIPTION
## Summary

- normalize the options lane SQLAlchemy DSN onto the installed `psycopg` driver so catalog and enricher boot against the live Postgres secret
- add a regression assertion covering DSN normalization alongside the existing blank list settings case
- force fresh rollouts for the options catalog, enricher, and websocket deployments so config-backed env changes are applied on the next Argo sync

## Related Issues

None

## Testing

- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen ruff check app/options_lane tests/test_options_lane.py`
- `uv run --frozen pytest tests/test_options_lane.py`
- `bun run lint:argocd`
- `git diff --check`
- direct Alpaca options websocket auth smoke test with live cluster credentials (`indicative` authenticated; `opra` returned `409 insufficient subscription`)

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked. No separate docs changes were required for this rollout fix.
