### PR TITLE
fix(torghut): normalize options contracts base url

### DIFF
--- a/services/torghut/app/options_lane/alpaca.py
+++ b/services/torghut/app/options_lane/alpaca.py
@@ -27,6 +27,13 @@ def _as_json_list(value: object) -> list[object]:
     return []
 
 
+def _normalize_contracts_base_url(base_url: str) -> str:
+    normalized = base_url.rstrip("/")
+    if normalized.endswith("/v2"):
+        return normalized[: -len("/v2")]
+    return normalized
+
+
 def _normalize_iso_datetime(value: object) -> datetime | None:
     if not isinstance(value, str) or not value.strip():
         return None
@@ -94,7 +101,7 @@ class AlpacaOptionsClient:
     ) -> None:
         self._key_id = key_id
         self._secret_key = secret_key
-        self._contracts_base_url = contracts_base_url.rstrip("/")
+        self._contracts_base_url = _normalize_contracts_base_url(contracts_base_url)
         self._data_base_url = data_base_url.rstrip("/")
         self._feed = feed
 

--- a/services/torghut/tests/test_options_lane.py
+++ b/services/torghut/tests/test_options_lane.py
@@ -92,6 +92,33 @@ class TestOptionsLaneNormalization(TestCase):
         self.assertIn("feed=indicative", requests[1])
         self.assertIn("AA260313C00030000", snapshots)
 
+    def test_alpaca_client_normalizes_contracts_base_url_with_v2_suffix(self) -> None:
+        requests: list[str] = []
+
+        def fake_urlopen(request: object, timeout: int = 30) -> _FakeResponse:
+            full_url = getattr(request, "full_url")
+            requests.append(str(full_url))
+            return _FakeResponse({"option_contracts": [{"symbol": "AA260313C00030000"}]})
+
+        client = AlpacaOptionsClient(
+            key_id="key-id",
+            secret_key="secret-key",
+            contracts_base_url="https://paper-api.alpaca.markets/v2",
+            data_base_url="https://data.alpaca.markets",
+            feed="indicative",
+        )
+
+        with patch("app.options_lane.alpaca.urlopen", side_effect=fake_urlopen):
+            contracts, _ = client.list_contracts(
+                status="active",
+                limit=1,
+                expiration_date_gte=date(2026, 3, 8),
+                expiration_date_lte=date(2026, 3, 15),
+            )
+
+        self.assertEqual(contracts[0]["symbol"], "AA260313C00030000")
+        self.assertEqual(requests[0], "https://paper-api.alpaca.markets/v2/options/contracts?status=active&limit=1&expiration_date_gte=2026-03-08&expiration_date_lte=2026-03-15")
+
     def test_normalize_contract_record_maps_required_fields(self) -> None:
         observed_at = datetime(2026, 3, 8, 18, 0, tzinfo=timezone.utc)
         payload = normalize_contract_record(


### PR DESCRIPTION
## Summary

- normalize the Alpaca options contracts base URL so secrets that already include `/v2` still resolve the contracts endpoint correctly
- add a regression test covering the live secret shape (`APCA_API_BASE_URL=https://paper-api.alpaca.markets/v2`)
- keep the data-plane host split unchanged so snapshots and bars continue using the market-data hostname

## Related Issues

None

## Testing

- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen ruff check app/options_lane tests/test_options_lane.py`
- `uv run --frozen pytest tests/test_options_lane.py`
- `git diff --check`
- live secret verification in cluster: `APCA_API_BASE_URL=https://paper-api.alpaca.markets/v2`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked. No separate docs changes were required for this provider compatibility fix.
