### PR TITLE
chore(jangar): promote image a1567c95

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: ac135544
-  digest: sha256:174799e161e1539de01021c2ed210e179474d5d69d3bb43ef21c2a6ffcd4eb28
+  tag: a1567c95
+  digest: sha256:3267b10f8b20fdc808cf6b1fd96a658b959d5e871733c0bf2b6b9a8e794bc874
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: ac135544
-    digest: sha256:bc484d1e44d3d8fe3b6df6f662a51847701815244ac343116cd9acc79da75e41
+    tag: a1567c95
+    digest: sha256:613fb68cb5051a7d8123c999a8f9b9deb9f59620c1279efc2d5974cf77590d3f
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: ac135544
-    digest: sha256:174799e161e1539de01021c2ed210e179474d5d69d3bb43ef21c2a6ffcd4eb28
+    tag: a1567c95
+    digest: sha256:3267b10f8b20fdc808cf6b1fd96a658b959d5e871733c0bf2b6b9a8e794bc874
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-08T23:10:49Z"
+    deploy.knative.dev/rollout: "2026-03-09T04:20:25Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-08T23:10:49Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-09T04:20:25Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -61,5 +61,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "ac135544"
-    digest: sha256:174799e161e1539de01021c2ed210e179474d5d69d3bb43ef21c2a6ffcd4eb28
+    newTag: "a1567c95"
+    digest: sha256:3267b10f8b20fdc808cf6b1fd96a658b959d5e871733c0bf2b6b9a8e794bc874


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `a1567c955e2b3f5bc99696ed983f8e4a6c3f83b5`
- Image tag: `a1567c95`
- Image digest: `sha256:3267b10f8b20fdc808cf6b1fd96a658b959d5e871733c0bf2b6b9a8e794bc874`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`