### PR TITLE
fix(torghut): bootstrap options lane hot-set during discovery

### DIFF
--- a/services/torghut/app/options_lane/catalog_service.py
+++ b/services/torghut/app/options_lane/catalog_service.py
@@ -7,18 +7,18 @@ from contextlib import asynccontextmanager
 import logging
 import threading
 from datetime import datetime, timedelta
-from typing import Any
+from typing import Any, cast
 
 from fastapi import FastAPI, HTTPException
 
 from .alpaca import AlpacaApiError, AlpacaOptionsClient, normalize_contract_record
 from .kafka import OptionsKafkaProducer, SequenceGenerator, build_envelope
 from .options_status import build_status_payload
-from .repository import OptionsRepository, top_ranked_contract_rows
+from .repository import OptionsRepository, merge_top_ranked_contract_rows, top_ranked_contract_rows
 from .session import session_state, utc_now
 from .settings import get_options_lane_settings
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("uvicorn.error")
 
 settings = get_options_lane_settings()
 
@@ -40,6 +40,10 @@ class _CatalogState:
             self.last_error_detail = None
             self.ready = True
 
+    def set_ready(self) -> None:
+        with self._lock:
+            self.ready = True
+
     def set_error(self, code: str, detail: str) -> None:
         with self._lock:
             self.last_error_code = code
@@ -58,7 +62,7 @@ class _CatalogState:
 _state = _CatalogState()
 _seq = SequenceGenerator()
 _repository = OptionsRepository(settings.sqlalchemy_dsn)
-_repository.ensure_rate_bucket_defaults({"contracts": (0.25, 2), "snapshots_hot": (1.0, 10), "snapshots_cold": (0.25, 5), "bars_backfill": (0.25, 2)})
+_repository.ensure_rate_bucket_defaults({"contracts": (1.0, 4), "snapshots_hot": (1.0, 10), "snapshots_cold": (0.25, 5), "bars_backfill": (0.25, 2)})
 _producer = OptionsKafkaProducer(
     bootstrap_servers=settings.kafka_bootstrap,
     security_protocol=settings.kafka_security_protocol,
@@ -158,9 +162,11 @@ def _run_discovery_cycle() -> None:
     page_count = 0
     contract_count = 0
     changed_count = 0
+    max_open_interest = 0
+    provisional_ranked_rows: list[dict[str, Any]] = []
 
     while True:
-        while not _repository.acquire_rate_bucket("contracts", 0.25, 2):
+        while not _repository.acquire_rate_bucket("contracts", 1.0, 4):
             if _state.stop_event.wait(1.0):
                 return
         contracts, page_token = _client.list_contracts(
@@ -177,6 +183,10 @@ def _run_discovery_cycle() -> None:
             if str(contract.get("symbol") or "").strip()
         ]
         contract_count += len(normalized_contracts)
+        max_open_interest = max(
+            max_open_interest,
+            max((cast(int, contract.get("open_interest") or 0) for contract in normalized_contracts), default=0),
+        )
         changed_rows = _repository.sync_contract_catalog_page(
             normalized_contracts,
             observed_at=observed_at,
@@ -184,6 +194,27 @@ def _run_discovery_cycle() -> None:
         changed_count += len(changed_rows)
         for row in changed_rows:
             _publish_contract_row(row, observed_at=observed_at)
+        provisional_ranked_rows = merge_top_ranked_contract_rows(
+            provisional_ranked_rows,
+            normalized_contracts,
+            observed_at=observed_at,
+            hot_cap=settings.options_subscription_hot_cap,
+            warm_cap=settings.options_subscription_warm_cap,
+            max_open_interest=max(max_open_interest, 1),
+            provider_cap_bootstrap=settings.options_provider_cap_bootstrap,
+            underlying_priority=settings.underlying_priority_set,
+        )
+        if provisional_ranked_rows:
+            _repository.write_subscription_state(ranked_rows=provisional_ranked_rows, observed_at=observed_at)
+            if not _state.snapshot()["ready"] and any(row["tier"] == "hot" for row in provisional_ranked_rows):
+                _state.set_ready()
+                logger.info(
+                    "options catalog provisional hot-set ready pages=%s contracts=%s hot=%s warm=%s",
+                    page_count,
+                    contract_count,
+                    sum(1 for row in provisional_ranked_rows if row["tier"] == "hot"),
+                    sum(1 for row in provisional_ranked_rows if row["tier"] == "warm"),
+                )
         if page_count == 1 or page_count % 10 == 0 or not page_token:
             logger.info(
                 "options catalog discovery progress pages=%s contracts=%s changed=%s has_next=%s",

--- a/services/torghut/app/options_lane/repository.py
+++ b/services/torghut/app/options_lane/repository.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from contextlib import contextmanager
 from datetime import date, datetime, timedelta, timezone
 import heapq
+from itertools import chain
 import json
 from typing import Any, Iterator, cast
 
@@ -181,6 +183,7 @@ class OptionsRepository:
                     {"symbols": list(seen_symbols) or [""]},
                 ).mappings()
             }
+            upsert_rows: list[dict[str, Any]] = []
 
             for contract in contracts:
                 contract_symbol = cast(str, contract["contract_symbol"])
@@ -210,78 +213,81 @@ class OptionsRepository:
                         "provider_updated_ts",
                     )
                 )
-
-                session.execute(
-                    text(
-                        """
-                        INSERT INTO torghut_options_contract_catalog (
-                          contract_symbol,
-                          contract_id,
-                          root_symbol,
-                          underlying_symbol,
-                          expiration_date,
-                          strike_price,
-                          option_type,
-                          style,
-                          contract_size,
-                          status,
-                          tradable,
-                          open_interest,
-                          open_interest_date,
-                          close_price,
-                          close_price_date,
-                          provider_updated_ts,
-                          first_seen_ts,
-                          last_seen_ts,
-                          metadata
-                        ) VALUES (
-                          :contract_symbol,
-                          :contract_id,
-                          :root_symbol,
-                          :underlying_symbol,
-                          :expiration_date,
-                          :strike_price,
-                          :option_type,
-                          :style,
-                          :contract_size,
-                          :status,
-                          :tradable,
-                          :open_interest,
-                          :open_interest_date,
-                          :close_price,
-                          :close_price_date,
-                          :provider_updated_ts,
-                          :first_seen_ts,
-                          :last_seen_ts,
-                          CAST(:metadata AS JSONB)
-                        )
-                        ON CONFLICT (contract_symbol) DO UPDATE
-                        SET contract_id = EXCLUDED.contract_id,
-                            root_symbol = EXCLUDED.root_symbol,
-                            underlying_symbol = EXCLUDED.underlying_symbol,
-                            expiration_date = EXCLUDED.expiration_date,
-                            strike_price = EXCLUDED.strike_price,
-                            option_type = EXCLUDED.option_type,
-                            style = EXCLUDED.style,
-                            contract_size = EXCLUDED.contract_size,
-                            status = EXCLUDED.status,
-                            tradable = EXCLUDED.tradable,
-                            open_interest = EXCLUDED.open_interest,
-                            open_interest_date = EXCLUDED.open_interest_date,
-                            close_price = EXCLUDED.close_price,
-                            close_price_date = EXCLUDED.close_price_date,
-                            provider_updated_ts = EXCLUDED.provider_updated_ts,
-                            last_seen_ts = EXCLUDED.last_seen_ts,
-                            metadata = EXCLUDED.metadata
-                        """
-                    ),
+                upsert_rows.append(
                     {
                         **payload,
                         "metadata": _coerce_json(payload["metadata"]),
-                    },
+                    }
                 )
                 if changed:
                     published_rows.append(payload)
+
+            session.execute(
+                text(
+                    """
+                    INSERT INTO torghut_options_contract_catalog (
+                      contract_symbol,
+                      contract_id,
+                      root_symbol,
+                      underlying_symbol,
+                      expiration_date,
+                      strike_price,
+                      option_type,
+                      style,
+                      contract_size,
+                      status,
+                      tradable,
+                      open_interest,
+                      open_interest_date,
+                      close_price,
+                      close_price_date,
+                      provider_updated_ts,
+                      first_seen_ts,
+                      last_seen_ts,
+                      metadata
+                    ) VALUES (
+                      :contract_symbol,
+                      :contract_id,
+                      :root_symbol,
+                      :underlying_symbol,
+                      :expiration_date,
+                      :strike_price,
+                      :option_type,
+                      :style,
+                      :contract_size,
+                      :status,
+                      :tradable,
+                      :open_interest,
+                      :open_interest_date,
+                      :close_price,
+                      :close_price_date,
+                      :provider_updated_ts,
+                      :first_seen_ts,
+                      :last_seen_ts,
+                      CAST(:metadata AS JSONB)
+                    )
+                    ON CONFLICT (contract_symbol) DO UPDATE
+                    SET contract_id = EXCLUDED.contract_id,
+                        root_symbol = EXCLUDED.root_symbol,
+                        underlying_symbol = EXCLUDED.underlying_symbol,
+                        expiration_date = EXCLUDED.expiration_date,
+                        strike_price = EXCLUDED.strike_price,
+                        option_type = EXCLUDED.option_type,
+                        style = EXCLUDED.style,
+                        contract_size = EXCLUDED.contract_size,
+                        status = EXCLUDED.status,
+                        tradable = EXCLUDED.tradable,
+                        open_interest = EXCLUDED.open_interest,
+                        open_interest_date = EXCLUDED.open_interest_date,
+                        close_price = EXCLUDED.close_price,
+                        close_price_date = EXCLUDED.close_price_date,
+                        provider_updated_ts = EXCLUDED.provider_updated_ts,
+                        last_seen_ts = EXCLUDED.last_seen_ts,
+                        metadata = EXCLUDED.metadata
+                    """
+                ),
+                upsert_rows,
+            )
 
         return published_rows
 
@@ -788,6 +794,30 @@ def top_ranked_contract_rows(
     return ranked
 
 
+def merge_top_ranked_contract_rows(
+    ranked_rows: Iterable[dict[str, Any]],
+    contracts: Iterable[dict[str, Any]],
+    *,
+    observed_at: datetime,
+    hot_cap: int,
+    warm_cap: int,
+    max_open_interest: int,
+    provider_cap_bootstrap: int,
+    underlying_priority: set[str],
+) -> list[dict[str, Any]]:
+    """Merge new contract rows into the current hot/warm candidate set."""
+
+    return top_ranked_contract_rows(
+        iter(chain(ranked_rows, contracts)),
+        observed_at=observed_at,
+        hot_cap=hot_cap,
+        warm_cap=warm_cap,
+        max_open_interest=max_open_interest,
+        provider_cap_bootstrap=provider_cap_bootstrap,
+        underlying_priority=underlying_priority,
+    )
+
+
 def _tier_limits(*, hot_cap: int, warm_cap: int, provider_cap_bootstrap: int) -> tuple[int, int]:
     hot_count = min(hot_cap, max(int(provider_cap_bootstrap * 0.8), 0))
     warm_count = min(warm_cap, hot_count * 5 if hot_count > 0 else warm_cap)
@@ -880,6 +910,12 @@ def _build_ranked_contract_row(
 
     return {
         "contract_symbol": row["contract_symbol"],
+        "status": row.get("status", "active"),
+        "underlying_symbol": row["underlying_symbol"],
+        "expiration_date": row["expiration_date"],
+        "strike_price": row.get("strike_price"),
+        "close_price": row.get("close_price"),
+        "open_interest": open_interest,
         "ranking_score": ranking_score,
         "ranking_inputs": {
             "liquidity_score": round(liquidity_score, 6),

--- a/services/torghut/tests/test_options_lane.py
+++ b/services/torghut/tests/test_options_lane.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 
 from app.options_lane.alpaca import AlpacaOptionsClient, normalize_contract_record, normalize_snapshot_record
 from app.options_lane.options_status import build_status_payload
-from app.options_lane.repository import ranked_contract_rows, top_ranked_contract_rows
+from app.options_lane.repository import merge_top_ranked_contract_rows, ranked_contract_rows, top_ranked_contract_rows
 from app.options_lane.settings import OptionsLaneSettings
 from app.options_lane.session import session_state
 
@@ -267,6 +267,55 @@ class TestOptionsLaneRanking(TestCase):
                     },
                 ]
             ),
+            observed_at=observed_at,
+            hot_cap=1,
+            warm_cap=1,
+            max_open_interest=100,
+            provider_cap_bootstrap=2,
+            underlying_priority={"AAPL"},
+        )
+
+        self.assertEqual([row["contract_symbol"] for row in ranked], ["AAPL260320C00100000", "AAPL260320P00100000"])
+        self.assertEqual([row["tier"] for row in ranked], ["hot", "warm"])
+
+    def test_merge_top_ranked_contract_rows_promotes_better_later_page_candidates(self) -> None:
+        observed_at = datetime(2026, 3, 8, 18, 0, tzinfo=timezone.utc)
+        first_page_ranked = top_ranked_contract_rows(
+            iter(
+                [
+                    {
+                        "contract_symbol": "AAPL260320P00100000",
+                        "status": "active",
+                        "underlying_symbol": "AAPL",
+                        "expiration_date": date(2026, 3, 20),
+                        "strike_price": 100.0,
+                        "close_price": 100.0,
+                        "open_interest": 80,
+                        "ranking_inputs": {},
+                    }
+                ]
+            ),
+            observed_at=observed_at,
+            hot_cap=1,
+            warm_cap=1,
+            max_open_interest=80,
+            provider_cap_bootstrap=2,
+            underlying_priority={"AAPL"},
+        )
+        ranked = merge_top_ranked_contract_rows(
+            first_page_ranked,
+            [
+                {
+                    "contract_symbol": "AAPL260320C00100000",
+                    "status": "active",
+                    "underlying_symbol": "AAPL",
+                    "expiration_date": date(2026, 3, 20),
+                    "strike_price": 100.0,
+                    "close_price": 100.0,
+                    "open_interest": 100,
+                    "ranking_inputs": {},
+                }
+            ],
             observed_at=observed_at,
             hot_cap=1,
             warm_cap=1,


### PR DESCRIPTION
## Summary

- Batch options catalog page upserts so discovery spends less time in per-row Postgres writes.
- Publish and persist a provisional options hot set during discovery so the catalog service becomes ready before the full universe pass completes.
- Raise the default contracts rate-bucket seed and add a regression test for cross-page hot-set promotion.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen ruff check app/options_lane tests/test_options_lane.py`
- `cd services/torghut && uv run --frozen pytest tests/test_options_lane.py`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
