### PR TITLE
chore(torghut-options): promote ta image b38f3744

### DIFF
--- a/argocd/applications/torghut-options/ta/flinkdeployment.yaml
+++ b/argocd/applications/torghut-options/ta/flinkdeployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: torghut-options-ta
 spec:
-  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:c8597da2a5331836476e576d91b4d3b753dbf76be618a8124fcfea2e692936e9
+  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:badaaa187c64f30aee7e6eae629be19dd5d80ee0e76ea550597e4c32a8662222
   imagePullPolicy: IfNotPresent
   restartNonce: 1
   flinkVersion: v2_0
@@ -86,9 +86,9 @@ spec:
                   name: flink-checkpoints
                   key: AWS_SECRET_ACCESS_KEY
             - name: TORGHUT_TA_VERSION
-              value: cacd5a12
+              value: b38f3744
             - name: TORGHUT_TA_COMMIT
-              value: cacd5a12375e5ba63dfa03644b823c15ade1482e
+              value: b38f374488f20481d11bd4184bda6198b5706fdb
           ports:
             - containerPort: 9249
               name: metrics


### PR DESCRIPTION
## Summary

- Promote `torghut-options-ta` to `registry.ide-newton.ts.net/lab/torghut-ta@sha256:badaaa187c64f30aee7e6eae629be19dd5d80ee0e76ea550597e4c32a8662222`.
- Update `TORGHUT_TA_VERSION` to `b38f3744` and `TORGHUT_TA_COMMIT` to `b38f374488f20481d11bd4184bda6198b5706fdb`.
- Keep the rollout scope limited to `argocd/applications/torghut-options/ta/flinkdeployment.yaml` so Argo can replace the failed options TA image with the serializer fix.

## Related Issues

None

## Testing

- `bun run lint:argocd`
- `git diff --check origin/main...HEAD`
- `gh pr checks 4272 -R proompteng/lab`
- Reviewed `git diff origin/main...HEAD -- argocd/applications/torghut-options/ta/flinkdeployment.yaml`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
