### PR TITLE
docs(torghut): add remaining options implementation design docs

### DIFF
--- a/docs/torghut/design-system/v6/35-alpaca-options-production-hardening-and-opra-promotion-2026-03-08.md
+++ b/docs/torghut/design-system/v6/35-alpaca-options-production-hardening-and-opra-promotion-2026-03-08.md
@@ -1,0 +1,420 @@
+# 35. Alpaca Options Production Hardening and OPRA Promotion (2026-03-08)
+
+## Status
+
+- Date: `2026-03-08`
+- Maturity: `implementation-ready design`
+- Scope: `argocd/applications/torghut-options/**`, `argocd/applications/torghut/**`,
+  `services/torghut/app/options_lane/**`,
+  `services/dorvud/technical-analysis-flink/**`, Torghut Postgres/ClickHouse/Kafka,
+  and the live `torghut` / `argocd` clusters
+- Depends on:
+  `33-alpaca-options-market-data-and-technical-analysis-lane-2026-03-08.md` and
+  `34-alpaca-options-lane-implementation-contract-set-2026-03-08.md`
+- Primary objective: harden the already-deployed options lane, prove regular-session
+  behavior, and promote it from `indicative` soak to `opra` without turning the
+  live lane into an opaque cutover gamble
+- Non-goals: options order execution, strategy enablement, or permanent duplicate
+  production feeds
+
+## Executive Summary
+
+Torghut now has a live options ingest and technical-analysis lane, but that is not
+the same thing as a production-complete lane. The current deployment is healthy on
+`2026-03-08`, yet it still runs on `indicative`, was validated during a closed
+session, initializes ClickHouse schema inside Flink startup, and does not extend the
+existing ClickHouse guardrail surface to the new options tables.
+
+The next implementation wave is therefore operational hardening, not new trading
+behavior.
+
+This document fixes that boundary:
+
+- no options strategy or capital allocation work is allowed to bypass the hardening
+  wave;
+- feed promotion happens in three stages: `indicative` soak, `opra` shadow, then
+  `opra` primary;
+- ClickHouse schema bootstrap moves out of the main Flink startup path;
+- options-specific session validation, guardrails, and provider-cap evidence become
+  first-class operating contracts.
+
+The design deliberately treats the current deployed lane as a valuable baseline, but
+not as the final production shape.
+
+## Context
+
+Documents 33 and 34 correctly solved the first-order design problem: create a
+separate options lane rather than trying to retrofit the equity lane. That decision
+was right, and the lane now exists. The remaining gap is subtler and more dangerous:
+operators can see pods, topics, and checkpoints, but they still do not have a
+disciplined promotion contract for live market-open proof, provider-cap learning, or
+`opra` cutover.
+
+Options data is especially hostile to wishful rollout thinking:
+
+- a closed session can look healthy even when no real-time rows are flowing;
+- `indicative` is a useful bootstrap feed but not the terminal production answer;
+- provider symbol limits and subscription churn can look stable until the first busy
+  open;
+- schema initialization inside Flink startup hides infra problems inside the hot
+  runtime path.
+
+That makes this hardening wave the last mandatory step before any options strategy or
+execution design should be treated as credible.
+
+## Verified Current State
+
+### The options lane is live and healthy, but only on a closed-session baseline
+
+Live cluster inspection on `2026-03-08` shows:
+
+- Argo application `torghut-options` is `Synced` and `Healthy`;
+- `Deployment/torghut-options-catalog`,
+  `Deployment/torghut-options-enricher`, and
+  `Deployment/torghut-ws-options` are all available;
+- `FlinkDeployment/torghut-options-ta` reports
+  `lifecycleState=STABLE`, `jobManagerDeploymentStatus=READY`, and
+  `jobStatus.state=RUNNING`;
+- Postgres contains the active options catalog and subscription state;
+- ClickHouse tables exist, but row counts remained `0` during Sunday-evening
+  verification, which is session-consistent rather than proof of a market-open path.
+
+This means the lane is deployed and restart-safe enough to inspect, but it does not
+yet have a documented regular-session promotion record.
+
+### The live lane still runs on `indicative`
+
+The current production manifests are still `indicative`-backed:
+
+- [`argocd/applications/torghut-options/ws/configmap.yaml`](argocd/applications/torghut-options/ws/configmap.yaml)
+  sets `ALPACA_FEED="indicative"`;
+- [`argocd/applications/torghut-options/enricher/configmap.yaml`](argocd/applications/torghut-options/enricher/configmap.yaml)
+  sets `ALPACA_OPTIONS_FEED="indicative"`;
+- [`argocd/applications/torghut-options/ta/configmap.yaml`](argocd/applications/torghut-options/ta/configmap.yaml)
+  sets `OPTIONS_TA_FEED="indicative"`.
+
+Document 33 explicitly selected `opra` as the production target. That target has not
+been realized yet.
+
+### Existing ClickHouse guardrails still only understand the equity TA tables
+
+[`argocd/applications/torghut/clickhouse/clickhouse-guardrails-exporter-configmap.yaml`](argocd/applications/torghut/clickhouse/clickhouse-guardrails-exporter-configmap.yaml)
+still defaults `CLICKHOUSE_REPLICATED_TABLES` to `ta_signals,ta_microbars`, and its
+freshness state is hard-coded around those two table families.
+
+That means the current replicated-table guardrail surface cannot tell operators
+whether:
+
+- `options_contract_bars_1s` is fresh,
+- `options_contract_features` is fresh, or
+- `options_surface_features` is fresh.
+
+### ClickHouse schema creation still happens inside the Flink startup path
+
+[`services/dorvud/technical-analysis-flink/src/main/kotlin/ai/proompteng/dorvud/ta/flink/OptionsTechnicalAnalysisJob.kt`](services/dorvud/technical-analysis-flink/src/main/kotlin/ai/proompteng/dorvud/ta/flink/OptionsTechnicalAnalysisJob.kt)
+calls `ensureOptionsClickhouseSchema(config)` before wiring the three ClickHouse
+sinks.
+
+That startup contract already produced one transient
+`MEMORY_LIMIT_EXCEEDED` recovery during rollout. The retry path recovered, but the
+design is still wrong: schema bootstrap is infra prep, not hot-path stream
+responsibility.
+
+### Provider-cap configuration is live, but the source-of-truth is split
+
+[`services/torghut/app/options_lane/settings.py`](services/torghut/app/options_lane/settings.py)
+defaults `OPTIONS_PROVIDER_CAP_BOOTSTRAP` to `500`, while the deployed options
+manifests currently set `OPTIONS_PROVIDER_CAP_BOOTSTRAP="200"` in:
+
+- [`argocd/applications/torghut-options/catalog/configmap.yaml`](argocd/applications/torghut-options/catalog/configmap.yaml)
+- [`argocd/applications/torghut-options/ws/configmap.yaml`](argocd/applications/torghut-options/ws/configmap.yaml)
+- [`argocd/applications/torghut-options/enricher/configmap.yaml`](argocd/applications/torghut-options/enricher/configmap.yaml)
+
+That mismatch is survivable, but it is the wrong shape for a production promotion
+process because operators do not yet have a durable provider-cap observation ledger.
+
+### There is no dedicated market-open validation workflow today
+
+Repository search over `services/torghut/scripts`,
+`argocd/applications/torghut-options`, and `argocd/applications/torghut` shows no
+options-specific market-open validation or `opra` shadow workflow. The current lane
+can be observed manually, but it cannot yet produce a repeatable proof artifact for
+first-trade, first-quote, first-snapshot, first-derived-row, or provider-cap
+acceptance.
+
+## Design Decision
+
+### Decision 1: hardening precedes all options strategy and execution work
+
+No options strategy, execution, or capital-allocation implementation may be treated
+as production-ready until this hardening wave is complete. A lane that only proved
+closed-session health on `indicative` does not yet deserve live trading behavior.
+
+### Decision 2: promote in three stages, not a single `indicative -> opra` cut
+
+Promotion proceeds in three explicit stages:
+
+1. `indicative` primary soak
+2. `opra` shadow lane
+3. `opra` primary lane
+
+The shadow stage is mandatory because it lets Torghut observe provider-cap pressure,
+first-open behavior, and derived-table freshness without risking the only running
+options lane.
+
+### Decision 3: schema bootstrap is an infra step, not a stream startup step
+
+The Flink job must assume tables already exist. Schema creation moves to an explicit
+bootstrap unit controlled by GitOps rollout order, not by job startup retries.
+
+### Decision 4: options freshness and provider-cap evidence must be session-aware
+
+Weekend and holiday closed sessions are not incidents. The system must distinguish:
+
+- no rows because the market is closed;
+- no rows because the lane is unhealthy;
+- degraded breadth because provider-cap pressure reduced the hot set;
+- blocked breadth because the lane is receiving hard provider rejections.
+
+### Decision 5: guardrails must cover both primary and shadow lanes during promotion
+
+The temporary `opra` shadow lane is a first-class production dependency during
+promotion. It therefore gets the same freshness, checkpoint, and rollout evidence
+surface as the primary lane.
+
+## Selected Architecture
+
+### Components
+
+The hardening wave introduces four explicit operating components:
+
+| Component | Type | Responsibility |
+| --- | --- | --- |
+| `torghut-options-ta-schema-bootstrap` | `Job` or Argo CD PreSync hook | Create/verify options ClickHouse tables and Karapace subjects before Flink starts |
+| `torghut-options-open-validation` | script plus on-demand `Job` | Capture market-open proof artifacts for quotes, trades, snapshots, derived rows, and provider-cap pressure |
+| `torghut-options-opra-shadow` | temporary GitOps application | Run the same options topology on `opra` with isolated topics, tables, and credentials during promotion |
+| `torghut-clickhouse-guardrails-exporter` extension | config plus exporter update | Add options table freshness, shadow-table freshness, and session-aware labels to the existing guardrail surface |
+
+### Promotion topology
+
+#### Stage A: `indicative` primary soak
+
+The currently deployed lane remains the primary options lane while hardening changes
+land. Its purpose is to keep:
+
+- contract discovery,
+- subscription rotation,
+- snapshot enrichment,
+- Flink checkpointing, and
+- operator dashboards
+
+stable while the hardening layer is added around it.
+
+#### Stage B: `opra` shadow
+
+Create a temporary `argocd/applications/torghut-options-shadow` application in the
+same `torghut` namespace. It reuses the codebase, but not the topics, tables, or
+Kafka principal.
+
+The shadow lane uses:
+
+- `ALPACA_FEED=opra`,
+- `ALPACA_OPTIONS_FEED=opra`,
+- `OPTIONS_TA_FEED=opra`,
+- shadow Kafka topic names under `torghut.options.shadow.*`,
+- shadow ClickHouse tables under `options_shadow_*`,
+- a dedicated Kafka principal such as `KafkaUser/torghut-options-shadow`.
+
+This gives Torghut side-by-side feed evidence without corrupting the primary lane's
+truth.
+
+#### Stage C: `opra` primary
+
+After shadow gates pass, the primary `torghut-options` application is flipped to
+`opra` and the shadow lane remains alive only long enough to compare one more regular
+session. After that confirmation session, the shadow lane is removed.
+
+### Schema bootstrap contract
+
+`torghut-options-ta-schema-bootstrap` owns:
+
+- `CREATE TABLE IF NOT EXISTS` for the three primary options tables;
+- `CREATE TABLE IF NOT EXISTS` for the three shadow tables during Stage B;
+- any required Karapace schema registration or schema subject existence checks;
+- idempotent success/failure reporting.
+
+The Flink job loses responsibility for schema creation. It may still verify table
+reachability, but it must not create schema objects on startup.
+
+### Market-open validation contract
+
+`torghut-options-open-validation` runs at operator request or via an automated
+workflow for every regular session used as a promotion gate. It records:
+
+- first successfully authenticated websocket session time;
+- first quote event time;
+- first trade event time;
+- first snapshot publish time;
+- first `torghut.options.ta.contract-bars.1s.v1` event time;
+- first ClickHouse row times for `options_contract_bars_1s`,
+  `options_contract_features`, and `options_surface_features`;
+- maximum hot-set breadth accepted without `405`;
+- any `406`, `410`, `412`, `413`, or `429` status bursts.
+
+The validator produces both machine-readable JSON and a small operator summary.
+
+## Interfaces and Data Contracts
+
+### Shadow lane Kafka contracts
+
+The `opra` shadow stage adds the following temporary contracts:
+
+- `torghut.options.shadow.contracts.v1`
+- `torghut.options.shadow.trades.v1`
+- `torghut.options.shadow.quotes.v1`
+- `torghut.options.shadow.snapshots.v1`
+- `torghut.options.shadow.status.v1`
+- `torghut.options.shadow.ta.contract-bars.1s.v1`
+- `torghut.options.shadow.ta.contract-features.v1`
+- `torghut.options.shadow.ta.surface-features.v1`
+- `torghut.options.shadow.ta.status.v1`
+
+These topics are temporary rollout artifacts, not long-term public product
+interfaces. They are deleted after Stage C cleanup.
+
+### Shadow lane ClickHouse tables
+
+During Stage B, the shadow lane writes to:
+
+- `options_shadow_contract_bars_1s`
+- `options_shadow_contract_features`
+- `options_shadow_surface_features`
+
+Primary and shadow data must never share the same derived tables.
+
+### Rollout evidence tables
+
+Postgres becomes the authority for promotion evidence via two new tables:
+
+#### `public.torghut_options_rollout_sessions`
+
+| Column | Type | Notes |
+| --- | --- | --- |
+| `session_date` | `date` | US market session date |
+| `lane` | `text` | `primary` or `shadow` |
+| `feed` | `text` | `indicative` or `opra` |
+| `phase` | `text` | `soak`, `shadow`, `promotion`, `post-cutover` |
+| `status` | `text` | `running`, `passed`, `failed`, `aborted` |
+| `started_at` | `timestamptz` | validator start |
+| `finished_at` | `timestamptz` | validator finish |
+| `first_quote_ts` | `timestamptz` | first quote event observed |
+| `first_trade_ts` | `timestamptz` | first trade event observed |
+| `first_snapshot_ts` | `timestamptz` | first snapshot publish observed |
+| `first_contract_bar_ts` | `timestamptz` | first TA contract bar |
+| `first_clickhouse_bar_ts` | `timestamptz` | first ClickHouse contract bar |
+| `first_clickhouse_feature_ts` | `timestamptz` | first ClickHouse contract feature |
+| `first_clickhouse_surface_ts` | `timestamptz` | first ClickHouse surface feature |
+| `summary_json` | `jsonb` | compact validator report |
+
+#### `public.torghut_options_provider_cap_observations`
+
+| Column | Type | Notes |
+| --- | --- | --- |
+| `observed_at` | `timestamptz` | observation time |
+| `lane` | `text` | `primary` or `shadow` |
+| `feed` | `text` | `indicative` or `opra` |
+| `requested_hot_contracts` | `int` | target hot set size |
+| `accepted_hot_contracts` | `int` | confirmed live breadth |
+| `rejected_hot_contracts` | `int` | contracts rejected or dropped |
+| `error_code` | `text` | provider code such as `405` |
+| `detail` | `text` | operator-readable detail |
+| `generation` | `int` | provider-cap generation at the time |
+
+### Guardrail contract
+
+The ClickHouse guardrails exporter must accept a configurable table set rather than
+assuming only equity tables. In the hardening wave it must cover:
+
+- `ta_signals`
+- `ta_microbars`
+- `options_contract_bars_1s`
+- `options_contract_features`
+- `options_surface_features`
+- `options_shadow_contract_bars_1s`
+- `options_shadow_contract_features`
+- `options_shadow_surface_features`
+
+and export a `session_state` label so closed-session gaps do not page operators as if
+they were live-session incidents.
+
+## Failure Modes and Ops
+
+### Provider-cap collapse during `opra` shadow
+
+If the shadow lane produces repeated `405` or `413` responses, the promotion gate
+fails immediately. The response is to reduce hot breadth, persist the observation,
+and rerun the next regular session, not to cut over anyway.
+
+### Schema bootstrap failure
+
+If schema bootstrap fails, Flink does not start. That is intentional. Infra failure is
+easier to reason about before stream startup than after a partially initialized job
+begins retrying.
+
+### Weekend and holiday false positives
+
+Validation and freshness alerts must use session state from the same calendar policy
+as the enricher and catalog. Closed-session `0` rows are not actionable unless an
+operator explicitly asked for a replay or a scheduled validation run.
+
+### Shadow and primary divergence
+
+If `opra` shadow and `indicative` primary diverge materially in first-open latency,
+hot-set breadth, or derived freshness, the promotion stops until the cause is
+explained. The lane must not silently treat shadow data as "just different."
+
+## Rollout Phases
+
+### Phase 1: hardening primitives
+
+- add schema bootstrap job
+- remove runtime schema creation from the Flink job
+- extend ClickHouse guardrails to options tables
+- add rollout evidence tables and market-open validator
+
+### Phase 2: `opra` shadow
+
+- deploy `torghut-options-opra-shadow`
+- run at least two regular sessions with market-open validation
+- record provider-cap observations on every session
+
+### Phase 3: `opra` primary cutover
+
+- flip the primary lane to `opra`
+- keep shadow alive for one further regular session
+- compare primary and shadow evidence before cleanup
+
+### Phase 4: cleanup and steady-state
+
+- retire shadow topics, tables, and credentials
+- freeze provider-cap defaults from observed evidence
+- treat `opra` as the only production feed
+
+## Acceptance Criteria
+
+This document is complete only when all of the following are true:
+
+- `torghut-options` runs on `opra` in production.
+- No options ClickHouse schema creation happens inside Flink startup.
+- The ClickHouse guardrail surface reports freshness for both equity and options
+  derived tables.
+- At least two consecutive `opra` shadow regular sessions pass with:
+  - first quote within `2m` of open,
+  - first trade within `2m` of open,
+  - first snapshot within `3m` of open,
+  - first ClickHouse contract bar within `5m` of open,
+  - no sustained `blocked` state over `60s`,
+  - no unresolved `405`, `406`, `410`, `412`, or `413` bursts.
+- One further regular session passes after primary cutover.
+- Provider-cap defaults in code and manifests are reconciled to an observed, durable
+  source of truth.

--- a/docs/torghut/design-system/v6/36-options-simulation-replay-and-profitability-proof-lane-2026-03-08.md
+++ b/docs/torghut/design-system/v6/36-options-simulation-replay-and-profitability-proof-lane-2026-03-08.md
@@ -1,0 +1,383 @@
+# 36. Options Simulation, Replay, and Profitability Proof Lane (2026-03-08)
+
+## Status
+
+- Date: `2026-03-08`
+- Maturity: `implementation-ready design`
+- Scope: `services/torghut/scripts/**`, `services/torghut/app/trading/**`,
+  `services/torghut/app/options_lane/**`, `argocd/applications/torghut/**`,
+  simulation Postgres/ClickHouse/Kafka assets, and artifact generation for options
+  evidence
+- Depends on:
+  `33-alpaca-options-market-data-and-technical-analysis-lane-2026-03-08.md`,
+  `34-alpaca-options-lane-implementation-contract-set-2026-03-08.md`, and
+  `35-alpaca-options-production-hardening-and-opra-promotion-2026-03-08.md`
+- Primary objective: extend Torghut's historical simulation and proof workflow from
+  equity-only runtime assumptions to a deterministic options replay lane that can
+  generate profitability evidence before live options trading is allowed
+- Non-goals: live options order routing, assignment automation, or full
+  multi-broker abstraction
+
+## Executive Summary
+
+Torghut already has strong simulation machinery, but it is still equity-shaped. The
+historical simulation entrypoints, verification logic, and report generators are all
+hard-coded around equity topics and the equity ClickHouse tables
+`ta_microbars` / `ta_signals`. At the same time, the new options lane already has the
+beginnings of replay support in source: Alpaca historical option bars exist in the
+client, and the options control plane already reserves a `bars_backfill` rate bucket.
+
+That mismatch creates a dangerous gap. Torghut can ingest options data in production,
+yet it still cannot prove an options strategy against a deterministic replay lane
+using the same discipline it now expects for equities.
+
+This document closes that gap:
+
+- options replay becomes an extension of the existing historical simulation system,
+  not a side notebook workflow;
+- replay datasets are assembled from raw options topics plus provider backfill
+  artifacts, not from current-state tables alone;
+- simulation topics, tables, manifests, and reports become asset-lane aware;
+- profitability proof requires contract-aware transaction-cost and lifecycle evidence,
+  not only gross PnL.
+
+## Context
+
+The market-data lane is necessary but not sufficient. Production options trading
+without a replay and proof lane would create the exact anti-pattern Torghut already
+learned to avoid in the equity system: runtime confidence without empirical
+promotion evidence.
+
+Options make this even more important because replay correctness is harder:
+
+- contracts expire and disappear;
+- liquidity is sparse and spread-driven;
+- raw quotes often matter more than prints;
+- open interest, Greeks, and IV matter to strategy logic and cost modeling;
+- the replay universe must preserve both contract-level and underlying-level truth.
+
+That means the options replay lane must be contract-aware from ingest to artifact,
+not just "another table copy."
+
+## Verified Current State
+
+### Historical simulation entrypoints are equity-only
+
+[`services/torghut/scripts/start_historical_simulation.py`](services/torghut/scripts/start_historical_simulation.py)
+defines only equity production and simulation topic families:
+
+- `torghut.trades.v1`
+- `torghut.quotes.v1`
+- `torghut.bars.1m.v1`
+- `torghut.ta.bars.1s.v1`
+- `torghut.ta.signals.v1`
+- `torghut.trade-updates.v1`
+
+and their `torghut.sim.*` equivalents.
+
+The same file fixes simulation ClickHouse runtime tables to
+`('ta_microbars', 'ta_signals')`, and later wires:
+
+- `TRADING_SIGNAL_TABLE=<db>.ta_signals`
+- `TRADING_PRICE_TABLE=<db>.ta_microbars`
+
+That is a direct proof that the current replay path cannot host options-derived
+signals without design work.
+
+### Verification and report tooling are still bound to equity tables and topics
+
+[`services/torghut/scripts/historical_simulation_verification.py`](services/torghut/scripts/historical_simulation_verification.py)
+checks only the equity topic family and only accepts ClickHouse isolation when:
+
+- the signal table ends in `.ta_signals`
+- the price table ends in `.ta_microbars`
+
+[`services/torghut/scripts/analyze_historical_simulation.py`](services/torghut/scripts/analyze_historical_simulation.py)
+queries `FROM {clickhouse_db}.ta_microbars` for price reconstruction and does not
+look at any options-derived table family.
+
+### The options lane has partial backfill plumbing, but not an end-to-end replay path
+
+[`services/torghut/app/options_lane/alpaca.py`](services/torghut/app/options_lane/alpaca.py)
+already defines `get_option_bars(...)`.
+
+[`services/torghut/app/options_lane/catalog_service.py`](services/torghut/app/options_lane/catalog_service.py)
+and
+[`services/torghut/app/options_lane/enricher_service.py`](services/torghut/app/options_lane/enricher_service.py)
+both initialize a `bars_backfill` rate bucket.
+
+But repository search shows no current caller for `get_option_bars(...)`, so Torghut
+does not yet have a working historical options backfill or replay reconstruction
+path.
+
+### Dataset selection and proof workflows still assume an equity universe
+
+[`services/torghut/app/trading/llm/dspy_compile/dataset.py`](services/torghut/app/trading/llm/dspy_compile/dataset.py)
+recognizes `torghut:equity:enabled`, but there is no options universe selector or
+contract-set selector.
+
+That means the current dataset compiler cannot express:
+
+- an underlying universe for options,
+- a contract filter policy,
+- an expiry or DTE band,
+- a call/put mix, or
+- a hot-set snapshot for replay reproducibility.
+
+## Design Decision
+
+### Decision 1: no live options capital before replay proof exists
+
+Options strategy or execution work may not be promoted ahead of a replay lane that
+can reproduce inputs, outputs, and profitability evidence. The replay lane is a gate,
+not a nice-to-have.
+
+### Decision 2: extend the existing historical simulation framework instead of forking it
+
+Torghut already has:
+
+- simulation namespace wiring,
+- rollout analysis support,
+- verification gates,
+- artifact bundles, and
+- post-run reporting.
+
+The correct move is to make that framework asset-lane aware, not to create a second,
+options-only proof workflow that drifts immediately.
+
+### Decision 3: the canonical replay input is raw market data plus versioned backfill artifacts
+
+Replays must be reconstructable from:
+
+- raw options topic dumps when the window is inside Kafka retention,
+- Alpaca historical bars and snapshot artifacts when the window falls outside Kafka
+  retention,
+- the contract catalog snapshot that was valid for the window,
+- the underlying equity price context used by the features.
+
+Derived ClickHouse tables are a useful verification source, but not the only source
+of truth for replay construction.
+
+### Decision 4: profitability proof is contract-aware, not equity-PnL-with-different-symbols
+
+Any options proof must account for:
+
+- contract multiplier,
+- quoted spread and fill side,
+- open/close direction,
+- DTE bucket,
+- expiry outcomes,
+- stale or missing Greeks/snapshots,
+- underlying concentration.
+
+Gross return without these controls is not an acceptable promotion metric.
+
+## Selected Architecture
+
+### Replay components
+
+The replay lane introduces five implementation units:
+
+| Component | Type | Responsibility |
+| --- | --- | --- |
+| `torghut-options-dataset-builder` | script / batch job | Build a reproducible dataset bundle for one options simulation window |
+| `torghut-options-ta-replay` | replay workflow extension | Rehydrate raw options topics into `torghut.sim.options.*` topics |
+| `torghut-options-ta-sim` | Flink simulation job | Materialize options simulation derived topics and ClickHouse tables |
+| `torghut-options-simulation-verifier` | script extension | Verify topic coverage, table isolation, contract coverage, and replay fidelity |
+| `torghut-options-simulation-report` | report generator extension | Produce profitability, liquidity, spread, and lifecycle artifacts |
+
+### Dataset bundle layout
+
+Each options replay window produces an artifact root:
+
+`artifacts/torghut/simulations/options/<run-id>/`
+
+Required bundle contents:
+
+- `manifest.json`
+- `contract_catalog.jsonl`
+- `raw/contracts.jsonl`
+- `raw/trades.jsonl`
+- `raw/quotes.jsonl`
+- `raw/snapshots.jsonl`
+- `raw/status.jsonl`
+- `backfill/option-bars.jsonl`
+- `backfill/underlying-bars.jsonl`
+- `validation/coverage.json`
+- `reports/profitability.json`
+- `reports/liquidity.json`
+- `reports/pnl-by-underlying.csv`
+- `reports/pnl-by-expiry.csv`
+- `reports/pnl-by-dte-band.csv`
+
+### Replay flow
+
+1. Load a versioned simulation manifest.
+2. Resolve the underlying universe and contract-selection policy for the requested
+   window.
+3. Pull raw topic data from Kafka when retention permits.
+4. Fill older gaps with Alpaca historical option bars and snapshot artifacts.
+5. Materialize a frozen contract catalog snapshot for the window.
+6. Rehydrate the dataset into `torghut.sim.options.*` topics.
+7. Run `torghut-options-ta-sim` to produce derived options simulation tables.
+8. Execute verification and profitability analysis against the isolated simulation
+   assets.
+
+### Asset-lane generalization of the existing simulation system
+
+The current historical simulation framework remains the control shell, but it gains a
+top-level lane selector:
+
+- `lane=equity`
+- `lane=options`
+
+The lane determines:
+
+- topic families,
+- ClickHouse table families,
+- manifest validation rules,
+- replay source requirements,
+- report sections and cost model hooks.
+
+This lets Torghut preserve one simulation operating model while still having
+asset-aware contracts.
+
+## Interfaces and Data Contracts
+
+### Options simulation topic family
+
+The replay lane introduces the isolated topic namespace:
+
+- `torghut.sim.options.contracts.v1`
+- `torghut.sim.options.trades.v1`
+- `torghut.sim.options.quotes.v1`
+- `torghut.sim.options.snapshots.v1`
+- `torghut.sim.options.status.v1`
+- `torghut.sim.options.ta.contract-bars.1s.v1`
+- `torghut.sim.options.ta.contract-features.v1`
+- `torghut.sim.options.ta.surface-features.v1`
+- `torghut.sim.options.ta.status.v1`
+- `torghut.sim.options.trade-updates.v1`
+
+These are the simulation analogues of the live options topics from document 34.
+
+### Options simulation ClickHouse tables
+
+Simulation ClickHouse tables are isolated from live production tables:
+
+- `sim_options_contract_bars_1s`
+- `sim_options_contract_features`
+- `sim_options_surface_features`
+
+`TRADING_SIGNAL_TABLE` and `TRADING_PRICE_TABLE` for options simulation must point to
+these tables, not to live options tables and not to equity simulation tables.
+
+### Options simulation manifest
+
+Each replay run is defined by `torghut.options-simulation-manifest.v1`.
+
+Required fields:
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `schema_version` | `string` | fixed to `torghut.options-simulation-manifest.v1` |
+| `lane` | `string` | must equal `options` |
+| `feed` | `string` | `indicative` or `opra` |
+| `window.start` | `timestamp` | inclusive UTC start |
+| `window.end` | `timestamp` | exclusive UTC end |
+| `underlyings` | `array<string>` | underlying symbol set or selector |
+| `contract_policy` | `object` | DTE, expiry, call/put, strike-distance, and liquidity filters |
+| `catalog_snapshot_ref` | `string` | immutable contract snapshot artifact |
+| `raw_source_policy` | `object` | Kafka-retention vs provider-backfill rules |
+| `cost_model` | `object` | spread crossing, fee, multiplier, and fill assumptions |
+| `proof_gates` | `object` | coverage, minimum fills, minimum contracts, and artifact thresholds |
+
+### Profitability report contract
+
+`reports/profitability.json` must include:
+
+- gross PnL
+- net PnL
+- spread cost
+- slippage cost
+- fee cost
+- fill-rate
+- quote-staleness rate
+- contract-count
+- underlying-count
+- expiry-distribution
+- DTE-band distribution
+- max drawdown
+- win rate
+- Sharpe-like risk summary
+
+Each metric must be reported both overall and by:
+
+- underlying
+- expiry date
+- option type
+- DTE band
+
+## Failure Modes and Ops
+
+### Survivorship bias
+
+Replay must use the window-valid contract catalog snapshot, not the currently active
+catalog. Otherwise expired contracts disappear and the proof becomes optimistic.
+
+### Backfill incompleteness outside Kafka retention
+
+If a replay window depends on provider backfill and the required bars or snapshots are
+missing, the run fails. It does not silently degrade to a partial proof.
+
+### Underlying-price mismatch
+
+Options replay requires the underlying price context used by feature generation. A run
+that replays options contracts without matching underlying bars is invalid.
+
+### Cost-model optimism
+
+If the replay report cannot prove spread, fill, and multiplier assumptions, the proof
+is not promotion-grade even if gross PnL is positive.
+
+## Rollout Phases
+
+### Phase 1: lane-aware simulation framework
+
+- generalize the historical simulation manifest and topic/table routing by lane
+- add options topic and table families
+- isolate options simulation resources from live resources
+
+### Phase 2: dataset and backfill builder
+
+- implement the options dataset builder
+- wire Alpaca historical option bars into replay artifact generation
+- freeze contract catalog snapshots per run
+
+### Phase 3: verifier and report extension
+
+- extend verification to options topics/tables
+- extend reporting to options profitability and liquidity metrics
+- add artifact completeness gates
+
+### Phase 4: proof runs
+
+- run smoke replay windows
+- run at least one full regular session replay
+- compare replay coverage and derived-table fidelity against live-lane truth
+
+## Acceptance Criteria
+
+This document is complete only when all of the following are true:
+
+- `start_historical_simulation.py` can run with `lane=options`.
+- Replay assets are isolated under `torghut.sim.options.*` topics and
+  `sim_options_*` tables.
+- The verifier refuses to pass when contract catalog, raw topic coverage, or
+  underlying context is incomplete.
+- A smoke run and a full-session run both complete with reproducible manifests and
+  artifact bundles.
+- Profitability reports include spread, slippage, multiplier, DTE-band, and
+  underlying-level attribution.
+- No options strategy is allowed to request live capital without attaching one of
+  these proof artifacts.

--- a/docs/torghut/design-system/v6/37-options-trading-runtime-execution-and-risk-integration-2026-03-08.md
+++ b/docs/torghut/design-system/v6/37-options-trading-runtime-execution-and-risk-integration-2026-03-08.md
@@ -1,0 +1,351 @@
+# 37. Options Trading Runtime, Execution, and Risk Integration (2026-03-08)
+
+## Status
+
+- Date: `2026-03-08`
+- Maturity: `implementation-ready design`
+- Scope: `services/torghut/app/trading/**`, `services/torghut/scripts/**`,
+  options broker integration, Torghut Postgres execution/accounting state, and the
+  operating contracts that would eventually allow options decisions to become orders
+- Depends on:
+  `33-alpaca-options-market-data-and-technical-analysis-lane-2026-03-08.md`,
+  `34-alpaca-options-lane-implementation-contract-set-2026-03-08.md`,
+  `35-alpaca-options-production-hardening-and-opra-promotion-2026-03-08.md`, and
+  `36-options-simulation-replay-and-profitability-proof-lane-2026-03-08.md`
+- Primary objective: define the safe runtime boundary for bringing options-derived
+  signals into Torghut trading, including order construction, pricing, portfolio
+  sizing, exercise/assignment handling, and promotion gates
+- Non-goals: immediate live options execution, uncovered short options, or a broad
+  "all asset classes everywhere" refactor
+
+## Executive Summary
+
+The current Torghut trading runtime is still equity-shaped. Prices are read from
+`ta_microbars`; the dataset compiler recognizes `torghut:equity:enabled`; execution
+policy normalizes to common US-equity tick sizes; risk and portfolio controls are
+framed around `equity`, `buying_power`, and `max_position_pct_equity`.
+
+That is not a criticism. It is simply the proof that documents 33 through 36 were the
+right first moves: build data truth and replay proof before pretending the existing
+runtime can safely carry options orders.
+
+This document defines the next boundary:
+
+- options trading is a lane-specific runtime integration, not a casual extension of
+  equity `ta_signals`;
+- initial execution scope is intentionally narrow: long premium and position-closing
+  flows only;
+- risk authority becomes contract-aware, multiplier-aware, and expiry-aware;
+- Alpaca option activities, exercise instructions, and DNE behavior are explicit
+  operating contracts, not afterthoughts.
+
+## Context
+
+Live options trading adds a second layer of complexity beyond market data:
+
+- order payloads differ from equities even when the broker reuses the same order API;
+- early exercise and expiration create non-trade lifecycle events;
+- buying power, premium-at-risk, and assignment risk are not captured by equity-only
+  sizing logic;
+- one contract symbol represents leverage on an underlying security rather than the
+  underlying security itself.
+
+Alpaca's current options trading docs also make the operating constraints explicit:
+
+- options orders use the Trading API order endpoint with options-specific
+  validations;
+- options positions reuse the Positions API shape;
+- exercise has an API endpoint;
+- DNE has an API endpoint in current docs;
+- assignment activity is not delivered via websocket and must be polled from REST /
+  account activities.
+
+These behaviors have to be first-class in the Torghut design, not hidden inside a
+generic execution adapter.
+
+## Verified Current State
+
+### Execution price normalization is explicitly US-equity-oriented
+
+[`services/torghut/app/trading/execution_policy.py`](services/torghut/app/trading/execution_policy.py)
+documents `_normalize_price_for_trading(...)` as aligning broker-facing prices to
+"common US-equity tick sizes" and quantizes prices to:
+
+- `0.0001` below `$1`
+- `0.01` otherwise
+
+That is not a safe universal rule for options orders.
+
+### Market-price lookup still reads the equity microbar table
+
+[`services/torghut/app/trading/prices.py`](services/torghut/app/trading/prices.py)
+queries `ta_microbars` and returns `source="ta_microbars"` in the market snapshot.
+
+There is no options-aware pricing adapter that reads
+`options_contract_bars_1s` or an options quote surface.
+
+### Dataset selection still only recognizes an equity universe contract
+
+[`services/torghut/app/trading/llm/dspy_compile/dataset.py`](services/torghut/app/trading/llm/dspy_compile/dataset.py)
+supports `torghut:equity:enabled`, but no options universe selector. That proves the
+current research and dataset tooling cannot yet train or evaluate strategy logic on an
+options contract universe.
+
+### Risk and portfolio controls are equity-centric
+
+[`services/torghut/app/trading/risk.py`](services/torghut/app/trading/risk.py)
+enforces position growth against `equity * max_pct`.
+
+Repository search across `services/torghut/app/trading/**` shows the broader runtime
+is still anchored to:
+
+- `max_position_pct_equity`
+- `buying_power`
+- `ta_signals`
+- `ta_microbars`
+
+There is no existing concept of:
+
+- contract multiplier,
+- max premium at risk,
+- defined-risk spread width,
+- expiry concentration,
+- assignment exposure.
+
+## Design Decision
+
+### Decision 1: options trading is a dedicated runtime lane
+
+The first live options trading implementation is not allowed to "just read from the
+options tables" while remaining otherwise equity-shaped. It gets explicit lane-aware
+pricing, risk, portfolio, and execution surfaces.
+
+### Decision 2: initial live scope is long premium and close-outs only
+
+The first live options execution scope is deliberately narrow:
+
+- buy-to-open single-leg long calls and puts
+- sell-to-close of held long positions
+- broker-driven exercise/DNE instruction handling for held longs
+
+The following are explicitly excluded from the first live phase:
+
+- naked short calls
+- naked short puts
+- uncovered assignment exposure
+- multi-leg spread execution
+- automatic exercise of new short positions
+
+This is the smallest scope that can still produce real trading value without forcing
+assignment and margin complexity into the first live cut.
+
+### Decision 3: promotion requires replay proof from document 36
+
+No options strategy, rule model, or LLM-controlled decision path can reach live order
+submission until it has attached replay evidence from the options proof lane.
+
+### Decision 4: lifecycle events are risk events, not bookkeeping
+
+Exercise, DNE, assignment, and expiry affect both risk and state truth. Torghut must
+poll and persist these events rather than assuming websocket order updates are
+sufficient.
+
+## Selected Architecture
+
+### Runtime components
+
+The options trading wave introduces five runtime components:
+
+| Component | Responsibility |
+| --- | --- |
+| `OptionsSignalAdapter` | Read options-derived features and convert them into trading-runtime signal objects |
+| `OptionsPriceService` | Resolve executable prices from options quotes, contract bars, and broker confirmations |
+| `OptionsRiskPolicy` | Enforce premium, concentration, DTE, liquidity, and lifecycle limits |
+| `OptionsExecutionAdapter` | Build and submit broker order payloads and reconcile order activities |
+| `OptionsLifecycleMonitor` | Poll positions and activities for exercise, DNE, assignment, and expiry transitions |
+
+These may live inside the existing `services/torghut/app/trading/**` package tree,
+but they are lane-specific interfaces, not anonymous conditionals scattered through
+the equity runtime.
+
+### Runtime flow
+
+1. `OptionsSignalAdapter` reads `options_contract_features` and
+   `options_surface_features`.
+2. It emits a lane-aware signal that carries:
+   - contract symbol
+   - underlying symbol
+   - option type
+   - strike
+   - expiry
+   - DTE
+   - mid/mark context
+   - liquidity / spread quality
+3. `OptionsRiskPolicy` decides whether the signal is tradable.
+4. `OptionsExecutionAdapter` constructs an Alpaca-compatible order request.
+5. `OptionsLifecycleMonitor` keeps the resulting position state truthful through
+   order fills, exercise instructions, DNE actions, assignments, and expiry.
+
+### Data model contract
+
+The runtime uses two distinct symbol concepts:
+
+- `underlying_symbol`: the equity symbol such as `AAPL`
+- `contract_symbol`: the option contract such as `AAPL250321C00200000`
+
+Every options trading decision must carry both. No downstream layer may attempt to
+reconstruct one from the other.
+
+### Broker integration contract
+
+Based on Alpaca's current official docs:
+
+- options orders use the standard order endpoint with options-specific validation
+  rules;
+- option positions use the Positions API;
+- exercise instructions are submitted through the exercise endpoint;
+- DNE instructions exist and must be modeled explicitly;
+- options-specific non-trade activities and assignment visibility come from account
+  activity polling rather than websocket updates.
+
+This means `OptionsExecutionAdapter` is only half the story. `OptionsLifecycleMonitor`
+is equally mandatory because broker truth extends beyond orders and fills.
+
+## Interfaces and Data Contracts
+
+### Runtime input tables
+
+The first live options trading runtime reads from:
+
+- `options_contract_features`
+- `options_surface_features`
+
+It does not read from equity `ta_signals` or `ta_microbars`.
+
+### Runtime decision contract
+
+The options decision object must carry at minimum:
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `lane` | `string` | fixed to `options` |
+| `contract_symbol` | `string` | broker order symbol |
+| `underlying_symbol` | `string` | underlying equity |
+| `action` | `string` | `buy_to_open`, `sell_to_close`, `exercise`, `dne` |
+| `qty_contracts` | `decimal` | contract count |
+| `limit_price` | `decimal` | contract premium price |
+| `option_type` | `string` | `call` or `put` |
+| `strike_price` | `decimal` | strike |
+| `expiration_date` | `date` | expiry date |
+| `dte` | `int` | days to expiry |
+| `mid_price` | `decimal` | observed mid |
+| `mark_price` | `decimal` | observed mark if present |
+| `spread_bps` | `decimal` | liquidity quality input |
+| `premium_notional` | `decimal` | `qty * price * multiplier` |
+| `rationale_json` | `jsonb` | strategy / LLM rationale payload |
+
+### Runtime risk policy contract
+
+`OptionsRiskPolicy` must enforce all of the following before order submission:
+
+- maximum premium-at-risk per contract and per underlying
+- maximum portfolio premium-at-risk
+- minimum liquidity thresholds
+- maximum spread thresholds
+- minimum DTE and maximum DTE bands
+- expiry-day restrictions
+- concentration caps by underlying and expiry bucket
+- explicit blocking of unsupported strategies
+
+### Runtime state tables
+
+The options execution wave introduces four Torghut-owned Postgres tables:
+
+- `public.torghut_options_trade_decisions`
+- `public.torghut_options_orders`
+- `public.torghut_options_positions`
+- `public.torghut_options_lifecycle_events`
+
+`torghut_options_lifecycle_events` must persist:
+
+- exercise instructions
+- DNE instructions
+- assignment activities
+- expiry events
+- broker sell-out events related to exercise risk
+
+### Promotion gate contract
+
+An options strategy can only move from paper or simulation to live when all of the
+following exist:
+
+- document 35 hardening gates have passed on `opra`
+- document 36 replay proof artifacts exist for the strategy
+- runtime risk policy is enabled in enforce mode
+- lifecycle polling and reconciliation are active
+
+## Failure Modes and Ops
+
+### Wrong tick-size normalization
+
+If options orders reuse equity price normalization blindly, Torghut may produce broker
+rejects or deterministic price drift. Options pricing must be normalized by broker
+rules for options, not by the current equity helper.
+
+### Lifecycle truth gaps
+
+If Torghut only listens for order updates and ignores activity polling, assignment,
+exercise, or expiry state can desynchronize positions and capital usage.
+
+### Hidden short-risk expansion
+
+Any future spread or short-option support must be a separate design wave. The first
+live options phase must not quietly drift from long premium into assignment-bearing
+short exposure.
+
+### Cross-lane contamination
+
+Equity and options runtime state must remain isolated enough that:
+
+- option positions do not overwrite equity positions,
+- options decisions do not pollute equity datasets,
+- equity pricing code does not price options orders.
+
+## Rollout Phases
+
+### Phase 1: lane-aware runtime primitives
+
+- add options signal, price, risk, and execution interfaces
+- add options lifecycle polling and state persistence
+- keep execution in paper/simulation only
+
+### Phase 2: paper options trading
+
+- run strategy decisions through the full runtime
+- submit paper broker orders only
+- exercise DNE and lifecycle monitoring on paper accounts
+
+### Phase 3: narrow live promotion
+
+- enable live long-premium entries and close-outs only
+- keep short options and spreads disabled
+- require operator approval for the first live sessions
+
+## Acceptance Criteria
+
+This document is complete only when all of the following are true:
+
+- Options runtime reads options-derived tables, not equity tables.
+- Options decisions carry both `contract_symbol` and `underlying_symbol`.
+- Risk enforcement covers premium-at-risk, DTE, spread quality, and concentration.
+- Lifecycle monitoring persists exercise, DNE, assignment, and expiry events.
+- Paper trading passes before live is enabled.
+- The first live phase supports only long-premium entries and close-outs.
+
+## External References
+
+- [Options Trading](https://docs.alpaca.markets/docs/options-trading)
+- [Create an Order](https://docs.alpaca.markets/v1.3/reference/orders)
+- [Exercise an Options Position](https://docs.alpaca.markets/v1.3/reference/optionexercise)
+- [Do Not Exercise an Options Position](https://docs.alpaca.markets/v1.3/reference/optiondonotexercise)
+- [Non-Trade Activities for Option Events](https://docs.alpaca.markets/docs/non-trade-activities-for-option-events)

--- a/docs/torghut/design-system/v6/index.md
+++ b/docs/torghut/design-system/v6/index.md
@@ -31,6 +31,13 @@
   separate Alpaca options ingest and TA lane, grounded in the current equity-only Torghut runtime and cluster state.
 - `34-alpaca-options-lane-implementation-contract-set-2026-03-08.md` now turns that architecture into explicit event,
   storage, identity, and SLO contracts for implementation.
+- `35-alpaca-options-production-hardening-and-opra-promotion-2026-03-08.md` now records the remaining production
+  hardening work for the deployed options lane: market-open validation, `opra` shadow promotion, ClickHouse schema
+  bootstrap, and options-specific guardrails.
+- `36-options-simulation-replay-and-profitability-proof-lane-2026-03-08.md` now defines the lane-aware simulation,
+  replay, and profitability-proof system required before any options strategy can request live capital.
+- `37-options-trading-runtime-execution-and-risk-integration-2026-03-08.md` now defines the eventual trading-runtime
+  integration contract for options signals, pricing, risk, lifecycle handling, and broker execution boundaries.
 
 ## Purpose
 
@@ -86,6 +93,9 @@ This pack is positioned as the next architecture layer above:
 32. `32-authoritative-alpha-readiness-and-empirical-promotion-closeout-2026-03-08.md`
 33. `33-alpaca-options-market-data-and-technical-analysis-lane-2026-03-08.md`
 34. `34-alpaca-options-lane-implementation-contract-set-2026-03-08.md`
+35. `35-alpaca-options-production-hardening-and-opra-promotion-2026-03-08.md`
+36. `36-options-simulation-replay-and-profitability-proof-lane-2026-03-08.md`
+37. `37-options-trading-runtime-execution-and-risk-integration-2026-03-08.md`
 
 ## Recommended Build Order
 
@@ -123,6 +133,9 @@ This pack is positioned as the next architecture layer above:
 32. `32-authoritative-alpha-readiness-and-empirical-promotion-closeout-2026-03-08.md`
 33. `33-alpaca-options-market-data-and-technical-analysis-lane-2026-03-08.md`
 34. `34-alpaca-options-lane-implementation-contract-set-2026-03-08.md`
+35. `35-alpaca-options-production-hardening-and-opra-promotion-2026-03-08.md`
+36. `36-options-simulation-replay-and-profitability-proof-lane-2026-03-08.md`
+37. `37-options-trading-runtime-execution-and-risk-integration-2026-03-08.md`
 
 ## Why This Sequence
 
@@ -146,3 +159,9 @@ This pack is positioned as the next architecture layer above:
   and time-gated live promotion.
 - The Alpaca options implementation contract set follows the architecture doc because options ingest is only safe to
   build once the concrete topic, storage, rate-limit, and identity contracts are fixed.
+- Options hardening and `opra` promotion follow the implementation contract set because the lane now exists in
+  production and must prove real-session behavior before strategy work is resumed.
+- The options replay and profitability-proof lane follows hardening because simulation truth depends on a trustworthy
+  live data contract and a session-proven production feed.
+- The options trading-runtime integration comes last because it is only safe once both the market-data lane and the
+  replay/proof lane are authoritative.


### PR DESCRIPTION
## Summary

- add v6 doc 35 covering options lane production hardening, market-open validation, and `opra` promotion
- add v6 doc 36 covering options simulation, replay, and profitability-proof contracts
- add v6 doc 37 covering options trading runtime, execution, and risk integration boundaries
- update the v6 design-system index to include the new documents and sequencing rationale

## Related Issues

None

## Testing

- `git diff --check`
- targeted unresolved-marker scan across the new docs and the v6 index
- manual source review of the new docs against the current live lane state and the referenced repo files

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
