### PR TITLE
docs(torghut): refresh design-system source-of-truth guidance

### DIFF
--- a/docs/torghut/design-system/README.md
+++ b/docs/torghut/design-system/README.md
@@ -30,6 +30,14 @@ The v1 documents are written to stay consistent with:
 - AI is **advisory** and is never allowed to bypass deterministic risk policies.
 - All “go-live” paths require explicit enablement flags and auditable change control.
 
+## Current navigation and source-of-truth guide
+
+If you are trying to decide which docs are current contract truth versus historical milestone records, start with:
+
+- `docs/torghut/design-system/current-source-of-truth-and-priority-guide-2026-03-09.md`
+
+That guide is the canonical reading order for the current corpus.
+
 ## Recommended entrypoint (single merged doc)
 
 - `docs/torghut/design-system/v1/torghut-autonomous-trading-system.md`
@@ -40,7 +48,10 @@ The v1 documents are written to stay consistent with:
 - `docs/torghut/design-system/implementation-status-matrix-2026-02-21.md`
 - `docs/torghut/design-system/implementation-audit.md`
 
-## Corpus implementation status (2026-03-01 evidence sync)
+## Corpus implementation status (historical 2026-03-01 snapshot)
+
+These counts are a dated snapshot, not a current live status board. They remain useful as a corpus-history checkpoint,
+but newer v6 docs and the current source-of-truth guide supersede them for present decisions.
 
 - root: total=2 (Implemented=0, Partial=0, Planned=2)
 - v1: total=60 (Implemented=11, Partial=44, Planned=5)
@@ -68,7 +79,9 @@ The v1 documents are written to stay consistent with:
   - Entry point: `docs/torghut/design-system/v5/index.md`
 
 - `v6/` - beyond-TSMOM intraday autonomy pack translating fresh multi-agent, regime-routing, contamination-safe
-  evaluation, benchmark parity, and profitability operating-system research into production implementation docs (2026-03-01).
+  evaluation, benchmark parity, and profitability operating-system research into production implementation docs.
+  This pack now contains both active contract docs and dated closeout/proof records; use the current source-of-truth
+  guide before treating a `Completed` or `Closeout` note as current truth.
   - Entry point: `docs/torghut/design-system/v6/index.md`
 
 - `v1/` - first cohesive design-system pass aligned to production reality as of **2026-02-08**.

--- a/docs/torghut/design-system/current-source-of-truth-and-priority-guide-2026-03-09.md
+++ b/docs/torghut/design-system/current-source-of-truth-and-priority-guide-2026-03-09.md
@@ -1,0 +1,107 @@
+# Torghut Design-System Current Source-of-Truth and Priority Guide (2026-03-09)
+
+## Status
+
+- Date: `2026-03-09`
+- Purpose: distinguish live source-of-truth docs from historical milestone records and identify the current highest-priority work
+- Scope: `docs/torghut/design-system/**`, `docs/torghut/**`, `argocd/applications/torghut/**`, `services/torghut/**`, `services/jangar/**`
+
+## Why this document exists
+
+The Torghut design corpus has accumulated several generations of:
+
+- production topology docs,
+- design contracts,
+- implementation closeouts,
+- incident/root-cause writeups,
+- current-state snapshots.
+
+That is useful history, but it creates a real operator problem: dated closeout records can be mistaken for the current
+source of truth.
+
+This guide is the current reading order and authority map.
+
+## Use this first
+
+If the question is "what should I trust right now?", start here:
+
+1. deployed/runtime source of truth:
+   - `argocd/applications/torghut/**`
+   - `services/torghut/README.md`
+   - `services/torghut/app/config.py`
+2. production-topology source of truth:
+   - `docs/torghut/design-system/v1/torghut-autonomous-trading-system.md`
+   - `docs/torghut/design-system/v1/historical-dataset-simulation.md`
+   - `docs/torghut/design-system/v1/trading-day-simulation-automation.md`
+3. current autonomy/promotion contract source of truth:
+   - `docs/torghut/design-system/v6/06-production-rollout-operations-and-governance.md`
+   - `docs/torghut/design-system/v6/08-profitability-research-validation-execution-governance-system.md`
+   - `docs/torghut/design-system/v6/27-live-hypothesis-ledger-and-capital-allocation-contract-2026-03-06.md`
+   - `docs/torghut/design-system/v6/28-hypothesis-led-alpha-readiness-and-profit-circuit-2026-03-06.md`
+   - `docs/torghut/design-system/v6/32-authoritative-alpha-readiness-and-empirical-promotion-closeout-2026-03-08.md`
+4. options-lane current design source of truth:
+   - `docs/torghut/design-system/v6/33-alpaca-options-market-data-and-technical-analysis-lane-2026-03-08.md`
+   - `docs/torghut/design-system/v6/34-alpaca-options-lane-implementation-contract-set-2026-03-08.md`
+
+## Current priority, not historical priority
+
+The current highest-priority work is:
+
+1. authoritative empirical evidence generation for benchmark parity, foundation-router parity, and Janus-Q;
+2. recurring prove-and-promote automation that exercises the empirical ledger repeatedly;
+3. HMM posterior maturity only after the empirical-authority gap is closed enough to matter operationally.
+
+This means the current next work is not:
+
+- "add a promotion lane";
+- "add manifest validation";
+- "add empirical-job persistence";
+- "add rollout phase manifests";
+- "enable one-off historical simulation."
+
+Those slices are already materially in the source tree.
+
+## Read these as historical records, not live contract truth
+
+These docs are still valuable, but mainly as dated rationale, proof, or closeout records:
+
+- `docs/torghut/design-system/implementation-status-matrix-2026-02-21.md`
+- `docs/torghut/design-system/implementation-audit.md`
+- `docs/torghut/design-system/v6/13-production-gap-closure-master-plan-2026-03-03.md`
+- `docs/torghut/design-system/v6/15-live-execution-quality-and-profitability-recovery-plan-2026-03-04.md`
+- `docs/torghut/design-system/v6/16-dspy-llm-live-gate-root-cause-and-rollout-2026-03-04.md`
+- `docs/torghut/design-system/v6/16-emergency-stop-reason-normalization-and-recovery-consistency-2026-03-04.md`
+- `docs/torghut/design-system/v6/17-emergency-stop-reason-normalization-and-recovery-stability-2026-03-04.md`
+- `docs/torghut/design-system/v6/18-trading-readiness-and-rollout-stability-2026-03-04.md`
+- `docs/torghut/design-system/v6/29-code-investigated-vnext-architecture-reset-2026-03-06.md`
+- `docs/torghut/design-system/v6/30-live-state-disposition-and-implementation-rollout-gates-2026-03-06.md`
+- `docs/torghut/design-system/v6/31-proven-autonomous-quant-llm-torghut-trading-system-2026-03-07.md`
+
+They should inform decisions, but they should not be treated as the single current operator checklist without checking
+the current contract docs above.
+
+## Current design docs that remain active
+
+These are still active contract docs rather than historical snapshots:
+
+- `docs/torghut/design-system/v1/historical-dataset-simulation.md`
+- `docs/torghut/design-system/v1/trading-day-simulation-automation.md`
+- `docs/torghut/design-system/v6/01-beyond-tsmom-system-architecture-and-latency-model.md`
+- `docs/torghut/design-system/v6/04-alpha-discovery-and-autonomous-improvement-pipeline.md`
+- `docs/torghut/design-system/v6/05-evaluation-benchmark-and-contamination-control-standard.md`
+- `docs/torghut/design-system/v6/06-production-rollout-operations-and-governance.md`
+- `docs/torghut/design-system/v6/08-profitability-research-validation-execution-governance-system.md`
+- `docs/torghut/design-system/v6/09-external-benchmark-parity-suite-ai-trader-fev-gift.md`
+- `docs/torghut/design-system/v6/32-authoritative-alpha-readiness-and-empirical-promotion-closeout-2026-03-08.md`
+- `docs/torghut/design-system/v6/33-alpaca-options-market-data-and-technical-analysis-lane-2026-03-08.md`
+- `docs/torghut/design-system/v6/34-alpaca-options-lane-implementation-contract-set-2026-03-08.md`
+
+## How to interpret ambiguous docs
+
+When a document mixes design, proof, and closeout material:
+
+1. trust the exact date in the header;
+2. check whether it is describing a baseline snapshot, a landed implementation update, or a current recommendation;
+3. prefer current source files and current contract docs when there is any conflict;
+4. treat milestone language like "completed" or "closeout" as scoped to that dated workstream, not as proof that no
+   important work remains.

--- a/docs/torghut/design-system/implementation-audit.md
+++ b/docs/torghut/design-system/implementation-audit.md
@@ -2,10 +2,16 @@
 
 - Scope: `docs/torghut/design-system/**` (all markdown design documents)
 - Source of record: `implementation-status-matrix-2026-02-21.md`
+- Audit posture (`2026-03-09`): this file is a historical audit snapshot, not the authoritative status surface for the
+  post-`2026-03-03` v6 closeout or the post-`2026-03-09` simulation/promotion documentation refresh. For current
+  status, prefer `docs/torghut/design-system/v6/index.md`,
+  `docs/torghut/design-system/v6/32-authoritative-alpha-readiness-and-empirical-promotion-closeout-2026-03-08.md`,
+  and `docs/torghut/design-system/v1/trading-day-simulation-automation.md`.
 
 ## Iteration audit trail
 
-- Last synchronized checkpoint: `implementation-audit.md` (`2026-03-01`).
+- Last synchronized checkpoint: historical full-audit snapshot on `2026-03-01`; targeted stale-doc refresh on
+  `2026-03-09`.
 - Prior iterations retained for continuity: removed from this branch.
 - Scope coverage in the last iteration: all status-bearing docs under `docs/torghut/design-system/**` plus index/audit evidence checks.
 

--- a/docs/torghut/design-system/implementation-status-matrix-2026-02-21.md
+++ b/docs/torghut/design-system/implementation-status-matrix-2026-02-21.md
@@ -1,5 +1,12 @@
 # Torghut Design Document Implementation Status Matrix (2026-02-21 strict snapshot + 2026-02-26 addendum)
 
+## Historical note (2026-03-09)
+
+This matrix is a dated strict-audit snapshot, not the current source-of-truth status board for the design corpus.
+
+Use `current-source-of-truth-and-priority-guide-2026-03-09.md` for current reading order, and use newer v6 document
+headers plus current source code for present implementation truth.
+
 ## Scope
 
 - audited every markdown design document under `docs/torghut/design-system/**`.

--- a/docs/torghut/design-system/v1/historical-dataset-simulation.md
+++ b/docs/torghut/design-system/v1/historical-dataset-simulation.md
@@ -6,9 +6,26 @@
 - Last updated: **2026-02-27**
 - Source of truth (config): `argocd/applications/torghut/**`
 - Implementation status: `Partial`
-- Implementation evidence: `services/torghut/scripts/start_historical_simulation.py`, `services/torghut/scripts/analyze_historical_simulation.py`, `services/torghut/tests/test_start_historical_simulation.py`, `services/torghut/tests/test_analyze_historical_simulation.py`, `services/torghut/app/config.py`
-- Implementation gaps: no first-class cluster-wide trading-day scheduler and no dedicated zero-touch evidence publication control loop for production operators yet.
+- Implementation evidence: `services/torghut/scripts/start_historical_simulation.py`, `services/torghut/scripts/analyze_historical_simulation.py`, `argocd/applications/torghut/historical-simulation-workflowtemplate.yaml`, `docs/torghut/rollouts/historical-simulation-playbook.md`, `services/torghut/tests/test_start_historical_simulation.py`, `services/torghut/tests/test_analyze_historical_simulation.py`, `services/torghut/tests/test_completion_trace.py`, `services/torghut/app/config.py`
+- Implementation gaps: no first-class recurring trading-day planner/day-run registry and no dedicated zero-touch recurring evidence publication control loop for production operators yet.
 - Rollout and verification: keep this doc implementation-ready by wiring one-click/cron automation against pre-generated manifests and validating isolation deltas in `run_manifest.json`.
+
+## Implementation update (2026-03-09)
+
+This document was stale where it still read like the historical simulation surface was mostly prospective.
+
+The current repository already has:
+
+- the canonical `start_historical_simulation.py` starter for plan/apply/run/verify/teardown flows;
+- a GitOps-managed `torghut-historical-simulation` Argo `WorkflowTemplate`;
+- operator playbook/README execution flows for running the simulation surface without ad hoc manual patching;
+- completion-trace persistence/reporting for simulation runs.
+
+The remaining gap is recurring orchestration rather than single-run capability:
+
+- no cluster-wide trading-day scheduler;
+- no durable day-run registry for repeated session exercises;
+- no zero-touch prove-and-publish control loop for production operators.
 
 ## Purpose
 
@@ -152,9 +169,9 @@ Required `simulation_context` payload (persist in decision JSON + execution audi
 
 ## Single-script starter requirements
 
-A single CLI script is required as the canonical start entrypoint.
+The canonical start entrypoint is the existing CLI script.
 
-Proposed command:
+Canonical command:
 
 ```bash
 uv run python services/torghut/scripts/start_historical_simulation.py --run-id <run_id> --dataset-manifest <path>

--- a/docs/torghut/design-system/v1/index.md
+++ b/docs/torghut/design-system/v1/index.md
@@ -9,6 +9,14 @@
 - Status: `Planned` (index/meta/snapshot)
 - Implementation status (strict): `Implemented=11`, `Partial=44`, `Planned=5` of 60
 
+## Historical note (2026-03-09)
+
+The counts above are a dated v1 corpus snapshot, not a current live implementation dashboard.
+
+For current reading order across the full Torghut design corpus, use:
+
+- `docs/torghut/design-system/current-source-of-truth-and-priority-guide-2026-03-09.md`
+
 ## Purpose
 
 This index centralizes the first production-facing design-system corpus (`v1`) for the Torghut stack.

--- a/docs/torghut/design-system/v1/trading-day-simulation-automation.md
+++ b/docs/torghut/design-system/v1/trading-day-simulation-automation.md
@@ -6,13 +6,30 @@
 - Date: `2026-02-28`
 - Scope: automation strategy and runbook for recurring trading-day replay simulations
 - Source of truth (runtime): `start_historical_simulation.py` and live cluster config
-- Implementation status: `Planned`
-- Implementation evidence: `services/torghut/scripts/start_historical_simulation.py`, `services/torghut/scripts/analyze_historical_simulation.py`, `docs/torghut/rollouts/historical-simulation-playbook.md`
-- Implementation gaps: no dedicated `automate_trading_day_simulation.py` orchestrator, no production CronJob/Temporal workflow for batch-day simulation windows, and no persisted day-run registry schema.
+- Implementation status: `Partial`
+- Implementation evidence: `services/torghut/scripts/start_historical_simulation.py`, `services/torghut/scripts/analyze_historical_simulation.py`, `argocd/applications/torghut/historical-simulation-workflowtemplate.yaml`, `argocd/applications/torghut/README.md`, `docs/torghut/rollouts/historical-simulation-playbook.md`
+- Implementation gaps: no dedicated `automate_trading_day_simulation.py` batch-day planner/orchestrator, no production CronJob/Temporal workflow for recurring session windows, and no persisted day-run registry schema.
 - Rollout and verification:
   - ship and version `services/torghut/scripts/automate_trading_day_simulation.py`,
   - run at least one dry-run day from a staging manifest repository,
   - enforce pre/post contamination query checks and archive day artifacts under `artifacts/torghut/simulations/<run_token>/`.
+
+## Implementation update (2026-03-09)
+
+This document was stale when it described the entire automation surface as planned-only.
+
+The current repository already includes:
+
+- `start_historical_simulation.py` support for end-to-end `run` execution with report/teardown handling;
+- a GitOps-managed `torghut-historical-simulation` Argo `WorkflowTemplate`;
+- an operator playbook and README flow for running the dedicated simulation surfaces without manual cluster patching;
+- analysis/report generation paths for full-session replay output.
+
+The remaining gap is narrower:
+
+- recurring day planning and batch scheduling are still missing;
+- empirical prove-and-promote runs still depend on manual or ad hoc workflow submission rather than a daily control loop;
+- the repo still lacks a first-class day-run registry that records repeated session exercises as an operating loop.
 
 ## Purpose
 

--- a/docs/torghut/design-system/v6/01-beyond-tsmom-system-architecture-and-latency-model.md
+++ b/docs/torghut/design-system/v6/01-beyond-tsmom-system-architecture-and-latency-model.md
@@ -13,7 +13,21 @@
   - `services/torghut/app/trading/scheduler.py`
   - `services/torghut/app/trading/portfolio.py`
   - `services/torghut/app/trading/regime.py`
-- Rollout gap: missing first-class HMM control-plane and promotion lane that enforces this architecture as the dominant live path.
+  - `services/torghut/app/trading/autonomy/lane.py`
+  - `services/torghut/app/trading/autonomy/phase_manifest_contract.py`
+- Rollout gap: the promotion lane and rollout-manifest machinery already exist, but first-class HMM posterior inference remains partial, so this architecture is not yet enforced by an authoritative posterior-driven control plane as the dominant live path.
+
+## Implementation update (2026-03-09)
+
+This document was stale where it implied the promotion lane itself was still missing.
+
+Current source already has autonomous lane artifact emission, stage lineage, promotion-decision persistence, and canonical rollout manifests for the beyond-TSMOM stack.
+
+The remaining architecture gap is narrower:
+
+- HMM posterior inference is still partial;
+- live routing is still not driven by an authoritative posterior service;
+- empirical promotion authority is still stronger in control-plane contract shape than in true model-evidence quality.
 
 ## Objective
 

--- a/docs/torghut/design-system/v6/04-alpha-discovery-and-autonomous-improvement-pipeline.md
+++ b/docs/torghut/design-system/v6/04-alpha-discovery-and-autonomous-improvement-pipeline.md
@@ -8,9 +8,18 @@
 - Scope: offline strategy and factor discovery pipeline that continuously improves live expert stack without unsafe online mutation
 - Implementation status: `Implemented`
 - Evidence:
-  - `docs/torghut/design-system/v6/04-alpha-discovery-and-autonomous-improvement-pipeline.md` (design-level contract)
+  - `services/torghut/app/trading/alpha/lane.py`
+  - `services/torghut/app/trading/autonomy/lane.py`
+  - `services/torghut/tests/test_alpha_lane.py`
+  - `services/torghut/tests/test_autonomous_lane.py`
 - Rollout gap: deterministic lane execution for candidate generation, evaluation, and promotion recommendation is implemented in
   `services/torghut/app/trading/alpha` and `services/torghut/app/trading/autonomy`; direct cluster mutation remains out-of-band.
+
+## Implementation update (2026-03-09)
+
+This doc previously cited only itself as implementation evidence.
+
+The implemented source of truth is the alpha/autonomy lane code that writes stage manifests, lineage hashes, stage trace ids, and profitability-linked recommendation bundles. The remaining deliberate non-goal is unchanged: discovery lanes recommend and persist evidence, but they do not mutate the live cluster directly.
 
 ## Objective
 

--- a/docs/torghut/design-system/v6/05-evaluation-benchmark-and-contamination-control-standard.md
+++ b/docs/torghut/design-system/v6/05-evaluation-benchmark-and-contamination-control-standard.md
@@ -11,10 +11,29 @@
   - `services/torghut/app/trading/autonomy/gates.py`
   - `services/torghut/app/trading/autonomy/policy_checks.py`
   - `services/torghut/app/trading/evaluation.py`
+  - `services/torghut/app/trading/empirical_jobs.py`
+  - `services/torghut/app/main.py`
   - `services/torghut/tests/test_profitability_evidence_v4.py`
   - `services/torghut/tests/test_trading_pipeline.py`
   - `services/torghut/tests/test_governance_policy_dry_run.py`
-- Rollout gap: repo does not yet enforce a complete contamination-safe promotion artifact registry across all strategy and LLM families.
+  - `services/torghut/tests/test_empirical_jobs.py`
+  - `services/torghut/tests/test_trading_api.py`
+- Rollout gap: fail-closed contamination and profitability-stage enforcement are already in-tree, but the repo still lacks authoritative empirical evidence across all benchmark, router, and Janus families; several parity artifacts remain deterministic scaffold outputs rather than promotion-authoritative evidence.
+
+## Implementation update (2026-03-09)
+
+This document was stale where it described the evaluation registry problem as if the control-plane enforcement surface did not exist yet.
+
+The current repository already contains:
+
+- profitability-stage manifest generation and hard-fail validation paths in the autonomous lane and policy checks;
+- empirical job persistence/status surfacing for benchmark-style evidence production;
+- operator-readable status endpoints for empirical jobs and doc29 completion gates.
+
+The remaining gap is not basic registry existence. It is evidence authority:
+
+- benchmark parity, foundation-router parity, and Janus-Q still include deterministic scaffold authority paths;
+- those artifacts therefore cannot yet serve as fully authoritative contamination-safe promotion evidence across all families.
 
 ## Objective
 

--- a/docs/torghut/design-system/v6/06-production-rollout-operations-and-governance.md
+++ b/docs/torghut/design-system/v6/06-production-rollout-operations-and-governance.md
@@ -12,10 +12,26 @@ The authoritative implementation is in:
 
 - `services/torghut/app/trading/autonomy/phase_manifest_contract.py`
 - Scope: phased rollout plan for Beyond-TSMOM architecture with explicit SLO, rollback, and governance controls
-- Implementation status: `In Progress`
+- Implementation status: `Implemented`
 - Evidence:
-  - `docs/torghut/design-system/v6/06-production-rollout-operations-and-governance.md` (rollout plan)
+  - `services/torghut/app/trading/autonomy/phase_manifest_contract.py`
+  - `services/torghut/app/trading/autonomy/lane.py`
+  - `services/torghut/app/trading/scheduler/governance.py`
+  - `services/torghut/tests/test_autonomous_lane.py`
+  - `services/torghut/tests/test_trading_scheduler_autonomy.py`
 - Rollout status: canonical phase manifest, canary gates, and rollback proof artifacts are integrated into the autonomous lane + scheduler governance pipeline.
+
+## Implementation update (2026-03-09)
+
+This document was stale where it still presented the rollout contract as merely in progress.
+
+The canonical phase manifest, runtime-governance append path, rollback-proof normalization, and scheduler-side updates are already implemented and covered by tests.
+
+The remaining live-program risk is upstream of this contract:
+
+- HMM posterior maturity is still partial;
+- empirical promotion evidence is still not authoritative enough across all families;
+- those gaps should not be confused with missing rollout-manifest machinery.
 
 ## Objective
 

--- a/docs/torghut/design-system/v6/09-external-benchmark-parity-suite-ai-trader-fev-gift.md
+++ b/docs/torghut/design-system/v6/09-external-benchmark-parity-suite-ai-trader-fev-gift.md
@@ -9,10 +9,27 @@
 - Implementation status: `Partial`
 - Evidence:
   - `services/torghut/app/trading/parity.py`
+  - `services/torghut/app/trading/empirical_jobs.py`
   - `services/torghut/app/trading/autonomy/policy_checks.py`
   - `services/torghut/tests/test_feature_parity.py`
   - `services/torghut/tests/test_policy_checks.py`
-- Rollout gap: Wave 4 benchmark parity closure is implemented (`2026-03-03`) across contract standardization, family coverage/calibration drift bounds, and fail-closed scorecard completeness checks; remaining program closure is Wave 5-6.
+  - `services/torghut/tests/test_empirical_jobs.py`
+- Rollout gap: Wave 4 benchmark parity contract closure is implemented (`2026-03-03`), but several benchmark-family artifacts are still deterministic scaffold outputs with `blocked_missing_empirical_authority`; remaining closure is replacing those placeholders with authoritative empirical evidence and exercising them recurrently.
+
+## Implementation update (2026-03-09)
+
+This document was stale where it sounded like the remaining work was generic Wave 5-6 program completion rather than a concrete authority problem.
+
+The current repository already has:
+
+- benchmark parity report contracts and fail-closed policy checks;
+- empirical benchmark report builders/persistence surfaces;
+- standardized scorecard shapes for candidate-vs-baseline evaluation.
+
+The remaining gap is narrower and more important:
+
+- `services/torghut/app/trading/parity.py` still emits deterministic scaffold authority for several parity families;
+- those reports remain useful as contract scaffolding, but they are not yet promotion-authoritative empirical evidence.
 
 ## Objective
 

--- a/docs/torghut/design-system/v6/13-production-gap-closure-master-plan-2026-03-03.md
+++ b/docs/torghut/design-system/v6/13-production-gap-closure-master-plan-2026-03-03.md
@@ -8,6 +8,12 @@
 - Scope: close all currently documented `Partial`/`Planned` gaps across the active Torghut autonomous quant stack and supporting v4/v5 dependencies.
 - Implementation status: `Completed` (Wave 0-6 + legacy disposition closure completed `2026-03-03`)
 
+## Historical note (2026-03-09)
+
+This document remains the dated March 3 closure record for the Wave 0-6 program.
+
+It is not the authoritative current next-work list. Later source-state docs, especially `29` through `32`, supersede it for current prioritization because control-plane contract closure landed faster than authoritative empirical evidence generation.
+
 ## Objective
 
 Deliver one production-grade autonomous quant operating system that is:

--- a/docs/torghut/design-system/v6/15-live-execution-quality-and-profitability-recovery-plan-2026-03-04.md
+++ b/docs/torghut/design-system/v6/15-live-execution-quality-and-profitability-recovery-plan-2026-03-04.md
@@ -8,6 +8,16 @@
 - Owners: `torghut`, `jangar`, `observability`
 - Primary objective: restore clean execution and reach sustained profitable sessions with controlled risk.
 
+## Usage note (2026-03-09)
+
+This document is a dated March 4 recovery plan tied to the rejection profile observed on March 3.
+
+Use it as historical diagnosis and recovery rationale, not as the sole current trading-priority document. For current
+promotion/evidence priority, use:
+
+- `docs/torghut/design-system/current-source-of-truth-and-priority-guide-2026-03-09.md`
+- `docs/torghut/design-system/v6/32-authoritative-alpha-readiness-and-empirical-promotion-closeout-2026-03-08.md`
+
 ## Executive Summary
 
 On **2026-03-03 (America/New_York)**, Torghut was runtime-healthy but trading-outcome unhealthy:

--- a/docs/torghut/design-system/v6/16-dspy-llm-live-gate-root-cause-and-rollout-2026-03-04.md
+++ b/docs/torghut/design-system/v6/16-dspy-llm-live-gate-root-cause-and-rollout-2026-03-04.md
@@ -1,5 +1,12 @@
 # 16. DSPy LLM Live-Gate Root Cause and Rollout Plan (2026-03-04)
 
+## Usage note (2026-03-09)
+
+This is a dated incident/root-cause and rollout document for the March 3-4 DSPy live-gate failure mode.
+
+Read it as historical implementation rationale. Do not treat it as the current overall Torghut next-work priority or
+the current autonomy/evidence source of truth.
+
 ## Incident Summary
 
 Date observed: 2026-03-03 (UTC)

--- a/docs/torghut/design-system/v6/18-trading-readiness-and-rollout-stability-2026-03-04.md
+++ b/docs/torghut/design-system/v6/18-trading-readiness-and-rollout-stability-2026-03-04.md
@@ -1,5 +1,12 @@
 # 17. Trading Readiness and Rollout Stability Through Dependency-aware `/readyz` (2026-03-04)
 
+## Usage note (2026-03-09)
+
+This document is a dated rollout-stability change record for dependency-aware readiness.
+
+The `/readyz` slice is already implemented in source; this doc should now be read as rationale and rollout history, not
+as an open implementation gap.
+
 ## Context
 
 - Rollout events observed repeated readiness/liveness instability on `torghut` pods:

--- a/docs/torghut/design-system/v6/29-code-investigated-vnext-architecture-reset-2026-03-06.md
+++ b/docs/torghut/design-system/v6/29-code-investigated-vnext-architecture-reset-2026-03-06.md
@@ -8,6 +8,18 @@
 - Primary objective: preserve Torghut's strong deterministic execution and governance core while replacing synthetic alpha and evaluation surfaces with empirical, replayable, and promotion-safe ones.
 - Implementation closeout: `doc29` completion contract satisfied in recorded evidence on `2026-03-07`
 
+## Usage note (2026-03-09)
+
+Read this document as:
+
+- the architecture-reset rationale that explained why empirical truth mattered more than more autonomy, and
+- the dated doc29 closeout record for truthful promotion gating.
+
+Do not treat it as the single current next-work checklist. For that, use:
+
+- `docs/torghut/design-system/current-source-of-truth-and-priority-guide-2026-03-09.md`
+- `docs/torghut/design-system/v6/32-authoritative-alpha-readiness-and-empirical-promotion-closeout-2026-03-08.md`
+
 ## Executive Summary
 
 Direct source inspection shows that Torghut already contains a substantial control plane:

--- a/docs/torghut/design-system/v6/30-live-state-disposition-and-implementation-rollout-gates-2026-03-06.md
+++ b/docs/torghut/design-system/v6/30-live-state-disposition-and-implementation-rollout-gates-2026-03-06.md
@@ -8,6 +8,22 @@
 - Primary objective: convert the March 6 architecture designs into a single current-state disposition that says what to keep, what to implement next, and what must stay blocked until live evidence becomes truthful.
 - Follow-up state: core runtime-truth slice landed in source on `2026-03-07`; live promotion can still remain operator-disabled
 
+## Usage note (2026-03-09)
+
+This is the March 6 live-state baseline plus the March 7 implementation update.
+
+Use it for:
+
+- the observed live baseline that motivated the proving-lane work,
+- the maintain/improve/innovate disposition logic,
+- rollout-gate rationale.
+
+Do not use it as the only current readiness truth without also checking:
+
+- `docs/torghut/design-system/v6/06-production-rollout-operations-and-governance.md`
+- `docs/torghut/design-system/v6/08-profitability-research-validation-execution-governance-system.md`
+- `docs/torghut/design-system/v6/32-authoritative-alpha-readiness-and-empirical-promotion-closeout-2026-03-08.md`
+
 ## Executive Summary
 
 The current live `torghut` system is operationally healthy but still not empirically ready to consume meaningful capital.

--- a/docs/torghut/design-system/v6/31-proven-autonomous-quant-llm-torghut-trading-system-2026-03-07.md
+++ b/docs/torghut/design-system/v6/31-proven-autonomous-quant-llm-torghut-trading-system-2026-03-07.md
@@ -8,6 +8,16 @@
 - Primary objective: define the clean end-state architecture for a truthful, empirically validated, autonomous quant trading system where LLMs increase research and control quality without becoming a source of synthetic trading authority.
 - Current proof state: the doc29 gate chain is satisfied in recorded evidence, while live promotion may still remain operator-disabled
 
+## Usage note (2026-03-09)
+
+This document is the target-state architecture plus the March 7 proof interpretation.
+
+Use it for end-state system shape and invariants. Do not read it as proof that empirical-authority work is complete.
+The current remaining next-work priority is still captured by:
+
+- `docs/torghut/design-system/current-source-of-truth-and-priority-guide-2026-03-09.md`
+- `docs/torghut/design-system/v6/32-authoritative-alpha-readiness-and-empirical-promotion-closeout-2026-03-08.md`
+
 ## Executive Summary
 
 Torghut already has the bones of a serious trading control system:

--- a/docs/torghut/design-system/v6/32-authoritative-alpha-readiness-and-empirical-promotion-closeout-2026-03-08.md
+++ b/docs/torghut/design-system/v6/32-authoritative-alpha-readiness-and-empirical-promotion-closeout-2026-03-08.md
@@ -9,6 +9,10 @@
 - Primary objective: define the highest-priority next build slice after the March 7 proving lane closeout
 - Current live state: simulation/runtime is healthy, but autonomous readiness and empirical promotion are still not
   authoritative enough for robust capital governance
+- Source-state update (`2026-03-09`): the repo now contains heartbeat-backed dependency quorum behavior, empirical
+  manifest validation, workflow-result RBAC, persisted empirical job rows, persisted `vnext_promotion_decisions`, and
+  operator status endpoints; the remaining stale recommendation is to keep funding already-landed control-plane slices
+  instead of finishing authoritative empirical evidence generation and recurring prove-and-promote automation.
 
 ## Executive Summary
 
@@ -34,6 +38,26 @@ The correct recommendation is:
 - make empirical promotion deterministic,
 - make the promotion ledger repeatedly exercised and operator-readable,
 - only then resume broader autonomy or strategy/model expansion.
+
+## Implementation update (2026-03-09)
+
+The March 8 live-cluster findings remain useful as a snapshot, but the source tree has moved ahead of this recommendation.
+
+The following slices are now materially implemented in code:
+
+- heartbeat-backed Jangar control-plane authority and fail-closed `unknown` handling for missing authoritative rows;
+- empirical manifest normalization/validation before promotion processing;
+- `workflowtaskresults` RBAC for the Torghut runtime service account;
+- persisted `vnext_empirical_job_runs` freshness rows and `/trading/empirical-jobs` status surfacing;
+- persisted `VNextPromotionDecision` rows and `/trading/completion/doc29` gate surfacing.
+
+The remaining highest-priority gap is therefore narrower and more specific than this doc originally states:
+
+1. replace deterministic scaffold evidence for benchmark parity, foundation-router parity, and Janus-Q with replay- or
+   live-window-derived empirical artifacts that can actually carry promotion authority;
+2. add recurring prove-and-promote automation so those artifacts are generated and exercised across repeated sessions
+   instead of one-off manual submissions;
+3. keep broader autonomy, new alpha branches, and model-family expansion behind those empirical-authority gates.
 
 ## Assessment Basis
 
@@ -132,44 +156,40 @@ trusted as a mature operating loop.
 
 ## Chosen Recommendation
 
-The next recommendation iteration is:
+The updated recommendation iteration is:
 
-1. make alpha-readiness authoritative,
-2. make empirical promotion deterministic,
+1. make empirical promotion authoritative,
+2. make prove-and-promote execution recurring,
 3. make promotion authority repeated and inspectable,
 4. keep broader autonomy/model expansion behind those gates.
 
-This is the shortest credible path from "simulation/proof works" to "autonomous promotion can be trusted".
+This is the shortest credible path from "simulation/proof works" to "autonomous promotion can be trusted" without
+re-funding already-landed control-plane work.
 
 ## What Needs To Be Built
 
-### Slice 1. Authoritative dependency quorum
+### Slice 1. Authoritative empirical promotion evidence
 
-Implement the agents/Jangar-side design in
-`docs/agents/designs/jangar-authoritative-controller-heartbeat-and-dependency-quorum-2026-03-08.md`.
-
-Desired outcome:
-
-- any status-serving pod can return the same truthful controller/runtime state;
-- Torghut dependency quorum is based on authoritative controller heartbeats, not local env toggles on a web-serving
-  deployment;
-- if authority is missing or stale, status degrades to `unknown`, not a false `disabled`.
-
-Torghut rollout change once that slice lands:
-
-- point `TRADING_JANGAR_CONTROL_PLANE_STATUS_URL` at the service intended to represent the `agents` dependency, while
-  relying on the new heartbeat-backed status contract rather than local in-process controller state.
-
-### Slice 2. Deterministic empirical promotion workflow
-
-Empirical promotion needs to fail earlier and more clearly.
+Empirical promotion still needs to become authoritative, not merely durable.
 
 Required changes:
 
-- validate promotion manifests before workflow submission;
-- remove the current class of "workflow launches, then dies on malformed manifest" failures;
-- resolve workflow result plumbing so repeated empirical jobs do not fail on result-patching/RBAC path issues;
+- replace deterministic scaffold outputs for benchmark parity, foundation-router parity, and Janus-Q with artifacts
+  derived from replayed or observed windows;
+- keep manifest validation and persistence fail-closed, but promote only from empirical lineage with non-placeholder
+  authority contracts;
 - treat partially written or non-authoritative empirical artifacts as ineligible, never ambiguous.
+
+### Slice 2. Recurring prove-and-promote automation
+
+The control plane is present, but the operating loop is still too manual.
+
+Required changes:
+
+- add a recurring trading-day planner/orchestrator that runs historical simulation, empirical promotion, and
+  readiness verification as one repeatable flow;
+- remove the current dependence on ad hoc Argo submissions for repeated proving sessions;
+- materialize a day-run registry so repeated exercises are inspectable without reconstructing workflow history by hand.
 
 ### Slice 3. Promotion ledger maturity
 
@@ -187,10 +207,10 @@ Required changes:
 
 Do not re-enable broader autonomous promotion, additional swarms, or new alpha branches until:
 
-- dependency quorum reads from an authoritative source;
 - empirical-promotion success is routine rather than occasional;
 - the vNext decision tables show repeated successful writes over multiple sessions;
 - operators can explain any deny/block outcome from status plus DB rows, without log archaeology.
+- promotion-authority artifacts are empirical rather than deterministic scaffold output.
 
 ## Alternatives Considered
 
@@ -230,8 +250,8 @@ This recommendation iteration is complete only when all of the following are tru
 
 If only one implementation wave can be funded next, it should be:
 
-1. authoritative dependency quorum,
-2. empirical promotion reliability,
+1. authoritative empirical promotion evidence generation,
+2. recurring prove-and-promote automation,
 3. durable promotion ledger surfacing.
 
 That is the highest-leverage path from a working simulation lane to a robust autonomous trading system.

--- a/docs/torghut/design-system/v6/index.md
+++ b/docs/torghut/design-system/v6/index.md
@@ -6,11 +6,28 @@
 - Date: `2026-03-03`
 - Maturity: `production-quality design pack`
 - Scope: intraday strategy architecture upgrade beyond static TSMOM, with regime-adaptive routing, DSPy-governed LLM reasoning, contamination-safe evaluation, and production rollout controls
-- Implementation status: `Completed` (program closure passed against all v6/13 definition-of-done criteria on `2026-03-03`)
-- Implementation status (strict): `Implemented=16`, `Partial=0`, `Planned=0` of 16
-- Evidence: `13-production-gap-closure-master-plan-2026-03-03.md` (Wave 0-6 closure + DoD)
+- Implementation status: `Mixed` (historical program closure recorded on `2026-03-03`; source-state refreshed on `2026-03-09`)
+- Implementation status (strict, core 01-13 docs, source-state refresh `2026-03-09`): `Implemented=7`, `Partial=5`, `Completed=1`
+- Evidence (historical closure): `13-production-gap-closure-master-plan-2026-03-03.md` (Wave 0-6 closure + DoD)
+- Evidence (current next-work priority): `32-authoritative-alpha-readiness-and-empirical-promotion-closeout-2026-03-08.md`
 - Evidence sync: `14-legacy-gap-disposition-map-2026-03-03.md` (signed v4/v5 disposition completeness)
 - Rollout status: v6 pack controls are represented by merged runtime/control-plane closure phases in `main` (`#3921` through `#3960`).
+
+## Current reading order
+
+For current corpus navigation across active contract docs versus historical closeout records, use:
+
+- `docs/torghut/design-system/current-source-of-truth-and-priority-guide-2026-03-09.md`
+
+## Historical closeout note (2026-03-09)
+
+The March 3 completion record remains useful as a dated closure milestone, but it should not be read as "nothing important remains."
+
+Current source-state priority is narrower:
+
+- control-plane closure is materially landed;
+- authoritative empirical evidence generation is not;
+- recurring prove-and-promote automation remains the active next operating gap.
 
 ## Recent Updates
 
@@ -25,8 +42,9 @@
 - `31-proven-autonomous-quant-llm-torghut-trading-system-2026-03-07.md` now anchors the target-state design in the
   actual proof results and the full-session replay profitability nuance.
 - `32-authoritative-alpha-readiness-and-empirical-promotion-closeout-2026-03-08.md` now records the next
-  recommendation iteration: keep simulation gains, but prioritize authoritative dependency truth, deterministic
-  empirical promotion, and a repeatedly exercised promotion ledger before resuming broader autonomy expansion.
+  recommendation iteration, updated on `2026-03-09` to reflect source reality: heartbeat-backed dependency quorum,
+  manifest validation, persistence, and status surfacing are already in-tree, so the remaining priority is
+  authoritative empirical evidence generation plus recurring prove-and-promote automation.
 - `33-alpaca-options-market-data-and-technical-analysis-lane-2026-03-08.md` now records the production design for a
   separate Alpaca options ingest and TA lane, grounded in the current equity-only Torghut runtime and cluster state.
 - `34-alpaca-options-lane-implementation-contract-set-2026-03-08.md` now turns that architecture into explicit event,


### PR DESCRIPTION
## Summary

- add a current source-of-truth and priority guide for the Torghut design-system corpus
- mark stale index and closeout docs as dated snapshots or usage-noted historical records
- refresh active v1/v6 docs so already-landed control-plane and simulation work is documented accurately while remaining gaps stay focused on empirical authority and recurring automation

## Related Issues

None

## Testing

- `git diff --check`
- Manual audit of the updated docs against current `services/torghut/**`, `services/jangar/**`, and `argocd/applications/torghut/**` source state

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
