### PR TITLE
chore(jangar): promote image 222eafb9

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: a1567c95
-  digest: sha256:3267b10f8b20fdc808cf6b1fd96a658b959d5e871733c0bf2b6b9a8e794bc874
+  tag: 222eafb9
+  digest: sha256:b72547d1a19cb1118039dacbd36bab9060ad419bfef29fd0d8c9d8574906a38b
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: a1567c95
-    digest: sha256:613fb68cb5051a7d8123c999a8f9b9deb9f59620c1279efc2d5974cf77590d3f
+    tag: 222eafb9
+    digest: sha256:4d42eb0876275f19bb745101bd4ecd96ccd24e84e048b57d3876e82510d546b4
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: a1567c95
-    digest: sha256:3267b10f8b20fdc808cf6b1fd96a658b959d5e871733c0bf2b6b9a8e794bc874
+    tag: 222eafb9
+    digest: sha256:b72547d1a19cb1118039dacbd36bab9060ad419bfef29fd0d8c9d8574906a38b
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-09T04:20:25Z"
+    deploy.knative.dev/rollout: "2026-03-09T07:34:15Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-09T04:20:25Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-09T07:34:15Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -61,5 +61,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "a1567c95"
-    digest: sha256:3267b10f8b20fdc808cf6b1fd96a658b959d5e871733c0bf2b6b9a8e794bc874
+    newTag: "222eafb9"
+    digest: sha256:b72547d1a19cb1118039dacbd36bab9060ad419bfef29fd0d8c9d8574906a38b


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `222eafb9c03304265a7d0e76d885a27b7417096a`
- Image tag: `222eafb9`
- Image digest: `sha256:b72547d1a19cb1118039dacbd36bab9060ad419bfef29fd0d8c9d8574906a38b`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`