### PR TITLE
feat(torghut): harden empirical promotion authority

### DIFF
--- a/services/torghut/app/trading/empirical_jobs.py
+++ b/services/torghut/app/trading/empirical_jobs.py
@@ -35,6 +35,79 @@ EMPIRICAL_JOB_TYPES: tuple[str, ...] = (
     "janus_event_car",
     "janus_hgrm_reward",
 )
+AUTHORITATIVE_EMPIRICAL_PROVENANCE: frozenset[str] = frozenset(
+    {
+        ArtifactProvenance.HISTORICAL_MARKET_REPLAY.value,
+        ArtifactProvenance.PAPER_RUNTIME_OBSERVED.value,
+        ArtifactProvenance.LIVE_RUNTIME_OBSERVED.value,
+    }
+)
+
+
+def _as_dict(value: object) -> dict[str, Any]:
+    return dict(cast(Mapping[str, Any], value)) if isinstance(value, Mapping) else {}
+
+
+def _as_text(value: object) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _as_string_list(value: object) -> list[str]:
+    if not isinstance(value, (list, tuple)):
+        return []
+    return [text for item in cast(list[object] | tuple[object, ...], value) if (text := _as_text(item))]
+
+
+def _lineage_is_complete(
+    *,
+    job_run_id: str,
+    dataset_snapshot_ref: str,
+    runtime_version_refs: Sequence[str],
+    model_refs: Sequence[str],
+) -> bool:
+    return (
+        bool(_as_text(job_run_id))
+        and bool(_as_text(dataset_snapshot_ref))
+        and bool(_as_string_list(runtime_version_refs))
+        and bool(_as_string_list(model_refs))
+    )
+
+
+def empirical_artifact_truthfulness_reasons(payload: Mapping[str, object]) -> list[str]:
+    reasons: list[str] = []
+    authority = _as_dict(payload.get("artifact_authority"))
+    if not authority:
+        reasons.append("artifact_authority_missing")
+    else:
+        if _as_text(authority.get("provenance")) not in AUTHORITATIVE_EMPIRICAL_PROVENANCE:
+            reasons.append("artifact_authority_provenance_invalid")
+        if _as_text(authority.get("maturity")) != EvidenceMaturity.EMPIRICALLY_VALIDATED.value:
+            reasons.append("artifact_authority_maturity_invalid")
+        if not bool(authority.get("authoritative", False)):
+            reasons.append("artifact_authority_not_authoritative")
+        if bool(authority.get("placeholder", False)):
+            reasons.append("artifact_authority_placeholder")
+
+    if not bool(payload.get("promotion_authority_eligible", False)):
+        reasons.append("promotion_authority_ineligible")
+
+    lineage = _as_dict(payload.get("lineage"))
+    if not _as_text(lineage.get("dataset_snapshot_ref")):
+        reasons.append("lineage_dataset_snapshot_ref_missing")
+    if not _as_text(lineage.get("job_run_id")):
+        reasons.append("lineage_job_run_id_missing")
+    if not _as_string_list(lineage.get("runtime_version_refs")):
+        reasons.append("lineage_runtime_version_refs_missing")
+    if not _as_string_list(lineage.get("model_refs")):
+        reasons.append("lineage_model_refs_missing")
+    return reasons
+
+
+def artifact_is_truthful(payload: Mapping[str, object]) -> bool:
+    return not empirical_artifact_truthfulness_reasons(payload)
 
 
 def _payload_hash(payload: Mapping[str, object]) -> str:
@@ -118,7 +191,13 @@ def build_empirical_benchmark_parity_report(
         str(item.get("status") or "").strip() == "pass"
         for item in normalized_scorecards.values()
     ) and not any(name not in normalized_scorecards for name in BENCHMARK_PARITY_REQUIRED_SCORECARDS)
-    promotion_authority_eligible = scorecards_pass and not missing_families and bool(dataset_snapshot_ref.strip())
+    lineage_ready = _lineage_is_complete(
+        job_run_id=job_run_id,
+        dataset_snapshot_ref=dataset_snapshot_ref,
+        runtime_version_refs=runtime_version_refs,
+        model_refs=model_refs,
+    )
+    promotion_authority_eligible = scorecards_pass and not missing_families and lineage_ready
     report: dict[str, object] = {
         "schema_version": BENCHMARK_PARITY_SCHEMA_VERSION,
         "candidate_id": candidate_id,
@@ -159,6 +238,8 @@ def build_empirical_benchmark_parity_report(
             notes=(
                 "Missing required benchmark families."
                 if missing_families
+                else "Empirical benchmark parity is missing runtime or model lineage refs."
+                if not lineage_ready
                 else "Empirical benchmark parity assembled from observed benchmark runs."
             ),
         ),
@@ -188,11 +269,13 @@ def build_empirical_foundation_router_parity_report(
     required_adapters = set(FOUNDATION_ROUTER_PARITY_REQUIRED_ADAPTERS)
     normalized_adapters = [str(item).strip() for item in adapters if str(item).strip()]
     missing_adapters = sorted(item for item in required_adapters if item not in normalized_adapters)
-    promotion_authority_eligible = (
-        overall_status == "pass"
-        and not missing_adapters
-        and bool(dataset_snapshot_ref.strip())
+    lineage_ready = _lineage_is_complete(
+        job_run_id=job_run_id,
+        dataset_snapshot_ref=dataset_snapshot_ref,
+        runtime_version_refs=runtime_version_refs,
+        model_refs=model_refs,
     )
+    promotion_authority_eligible = overall_status == "pass" and not missing_adapters and lineage_ready
     report: dict[str, object] = {
         "schema_version": FOUNDATION_ROUTER_PARITY_SCHEMA_VERSION,
         "candidate_id": candidate_id,
@@ -228,6 +311,8 @@ def build_empirical_foundation_router_parity_report(
             notes=(
                 "Missing required router adapters."
                 if missing_adapters
+                else "Empirical foundation router parity is missing runtime or model lineage refs."
+                if not lineage_ready
                 else "Empirical foundation router parity assembled from replayed adapter outputs."
             ),
         ),
@@ -244,18 +329,34 @@ def promote_janus_payload_to_empirical(
     runtime_version_refs: Sequence[str] = (),
     model_refs: Sequence[str] = (),
     promotion_authority_eligible: bool,
+    require_summary_field: bool = True,
 ) -> dict[str, object]:
     upgraded = dict(payload)
+    lineage_ready = _lineage_is_complete(
+        job_run_id=job_run_id,
+        dataset_snapshot_ref=dataset_snapshot_ref,
+        runtime_version_refs=runtime_version_refs,
+        model_refs=model_refs,
+    )
+    resolved_promotion_authority_eligible = (
+        promotion_authority_eligible
+        and (not require_summary_field or bool(_as_dict(payload.get("summary"))))
+        and lineage_ready
+    )
     upgraded["lineage"] = _lineage_payload(
         job_run_id=job_run_id,
         dataset_snapshot_ref=dataset_snapshot_ref,
         runtime_version_refs=runtime_version_refs,
         model_refs=model_refs,
     )
-    upgraded["promotion_authority_eligible"] = promotion_authority_eligible
+    upgraded["promotion_authority_eligible"] = resolved_promotion_authority_eligible
     upgraded["artifact_authority"] = _empirical_contract(
-        promotion_authority_eligible=promotion_authority_eligible,
-        notes="Janus artifact assembled from replayed signal and decision windows.",
+        promotion_authority_eligible=resolved_promotion_authority_eligible,
+        notes=(
+            "Janus artifact is missing required truthfulness inputs or runtime/model lineage refs."
+            if not resolved_promotion_authority_eligible
+            else "Janus artifact assembled from replayed signal and decision windows."
+        ),
     )
     return upgraded
 
@@ -332,6 +433,8 @@ def build_empirical_jobs_status(
                 "authority": "blocked",
                 "promotion_authority_eligible": False,
                 "stale": True,
+                "truthful": False,
+                "blocked_reasons": ["job_missing"],
             }
             fresh_and_eligible = False
             continue
@@ -341,20 +444,51 @@ def build_empirical_jobs_status(
             if created_at_raw.tzinfo is not None
             else created_at_raw.replace(tzinfo=timezone.utc)
         )
+        payload = _as_dict(row.payload_json)
+        truthful_reasons = empirical_artifact_truthfulness_reasons(payload)
+        truthful = not truthful_reasons
         stale = created_at < cutoff or row.status not in {"completed", "success"}
+        blocked_reasons = sorted(
+            {
+                *truthful_reasons,
+                *(["job_stale"] if created_at < cutoff else []),
+                *(["job_status_incomplete"] if row.status not in {"completed", "success"} else []),
+                *(["row_authority_not_empirical"] if row.authority != "empirical" else []),
+                *(
+                    ["row_promotion_authority_ineligible"]
+                    if not row.promotion_authority_eligible
+                    else []
+                ),
+                *(
+                    ["row_dataset_snapshot_ref_missing"]
+                    if not _as_text(row.dataset_snapshot_ref)
+                    else []
+                ),
+            }
+        )
         jobs[job_type] = {
             "status": row.status,
-            "authority": row.authority,
-            "promotion_authority_eligible": bool(row.promotion_authority_eligible),
+            "authority": row.authority if truthful and row.authority == "empirical" else "blocked",
+            "persisted_authority": row.authority,
+            "promotion_authority_eligible": bool(row.promotion_authority_eligible) and truthful,
+            "persisted_promotion_authority_eligible": bool(row.promotion_authority_eligible),
             "dataset_snapshot_ref": row.dataset_snapshot_ref,
             "job_run_id": row.job_run_id,
             "created_at": created_at.isoformat(),
             "artifact_refs": list(cast(list[object], row.artifact_refs or [])),
             "stale": stale,
+            "truthful": truthful,
+            "blocked_reasons": blocked_reasons,
         }
-        if stale or not row.promotion_authority_eligible or row.authority != "empirical":
+        if (
+            stale
+            or not truthful
+            or not row.promotion_authority_eligible
+            or row.authority != "empirical"
+        ):
             fresh_and_eligible = False
     return {
+        "ready": fresh_and_eligible,
         "status": "healthy" if fresh_and_eligible else "degraded",
         "authority": "empirical" if fresh_and_eligible else "blocked",
         "stale_after_seconds": stale_after_seconds,
@@ -364,9 +498,11 @@ def build_empirical_jobs_status(
 
 __all__ = [
     "EMPIRICAL_JOB_TYPES",
+    "artifact_is_truthful",
     "build_empirical_benchmark_parity_report",
     "build_empirical_foundation_router_parity_report",
     "build_empirical_jobs_status",
+    "empirical_artifact_truthfulness_reasons",
     "promote_janus_payload_to_empirical",
     "upsert_empirical_job_run",
 ]

--- a/services/torghut/scripts/run_empirical_promotion_jobs.py
+++ b/services/torghut/scripts/run_empirical_promotion_jobs.py
@@ -22,6 +22,7 @@ from app.trading.completion import (
     persist_completion_trace,
 )
 from app.trading.empirical_jobs import (
+    artifact_is_truthful,
     build_empirical_benchmark_parity_report,
     build_empirical_foundation_router_parity_report,
     promote_janus_payload_to_empirical,
@@ -72,19 +73,6 @@ def _as_text(value: Any) -> str | None:
     if not text:
         return None
     return text
-
-
-def _artifact_is_truthful(payload: Mapping[str, Any]) -> bool:
-    authority = _as_dict(payload.get("artifact_authority"))
-    if not authority:
-        return False
-    return (
-        not bool(authority.get("placeholder", False))
-        and bool(authority.get("authoritative", False))
-        and str(authority.get("provenance") or "").strip()
-        not in {"synthetic_generated", "structural_placeholder"}
-        and bool(payload.get("promotion_authority_eligible", False))
-    )
 
 
 def _job_run_id(run_id: str, job_type: str, explicit: str | None = None) -> str:
@@ -173,12 +161,25 @@ def _build_janus_summary(
     reward_summary = _as_dict(hgrm_reward_payload.get("summary"))
     event_count = int(event_summary.get("event_count") or len(_as_list(event_car_payload.get("events"))) or 0)
     reward_count = int(reward_summary.get("reward_count") or len(_as_list(hgrm_reward_payload.get("rewards"))) or 0)
-    mapped_count = int(reward_summary.get("event_mapped_count") or reward_count or 0)
-    evidence_complete = event_count > 0 and reward_count > 0 and mapped_count >= reward_count
+    mapped_count = int(reward_summary.get("event_mapped_count") or 0)
+    event_truthful = artifact_is_truthful(event_car_payload)
+    reward_truthful = artifact_is_truthful(hgrm_reward_payload)
+    reasons: list[str] = []
+    if event_count <= 0:
+        reasons.append("janus_event_count_missing")
+    if reward_count <= 0:
+        reasons.append("janus_reward_count_missing")
+    if reward_count > 0 and mapped_count < reward_count:
+        reasons.append("janus_reward_event_mapping_incomplete")
+    if not event_truthful:
+        reasons.append("janus_event_car_not_truthful")
+    if not reward_truthful:
+        reasons.append("janus_hgrm_reward_not_truthful")
+    evidence_complete = not reasons
     summary: dict[str, object] = {
         "schema_version": "janus-q-evidence-v1",
         "status": "pass" if evidence_complete else "degrade",
-        "reasons": [] if evidence_complete else ["janus_empirical_inputs_incomplete"],
+        "reasons": reasons,
         "promotion_authority_eligible": evidence_complete,
         "event_car": {
             "schema_version": str(event_car_payload.get("schema_version") or "").strip() or "janus-event-car-v1",
@@ -191,6 +192,7 @@ def _build_janus_summary(
             "schema_version": str(hgrm_reward_payload.get("schema_version") or "").strip()
             or "janus-hgrm-reward-v1",
             "reward_count": reward_count,
+            "event_mapped_count": mapped_count,
             "direction_gate_pass_ratio": reward_summary.get("direction_gate_pass_ratio", "0"),
             "manifest_hash": hgrm_reward_payload.get("manifest_hash"),
             "artifact_ref": hgrm_reward_artifact_ref,
@@ -204,6 +206,7 @@ def _build_janus_summary(
         runtime_version_refs=runtime_version_refs,
         model_refs=model_refs,
         promotion_authority_eligible=evidence_complete,
+        require_summary_field=False,
     )
 
 
@@ -367,15 +370,26 @@ def main() -> int:
 
         janus_manifest = _as_dict(manifest.get("janus_q"))
         if janus_manifest:
-            janus_job_run_id = _job_run_id(
+            janus_base_job_run_id = _as_text(janus_manifest.get("job_run_id"))
+            event_job_run_id = _job_run_id(
                 run_id,
                 "janus_event_car",
-                str(janus_manifest.get("job_run_id") or ""),
+                f"{janus_base_job_run_id}:janus_event_car" if janus_base_job_run_id else None,
+            )
+            reward_job_run_id = _job_run_id(
+                run_id,
+                "janus_hgrm_reward",
+                f"{janus_base_job_run_id}:janus_hgrm_reward" if janus_base_job_run_id else None,
+            )
+            summary_job_run_id = _job_run_id(
+                run_id,
+                "janus_q",
+                f"{janus_base_job_run_id}:janus_q" if janus_base_job_run_id else None,
             )
             event_payload = promote_janus_payload_to_empirical(
                 payload=_as_dict(janus_manifest.get("event_car")),
                 dataset_snapshot_ref=dataset_snapshot_ref,
-                job_run_id=janus_job_run_id,
+                job_run_id=event_job_run_id,
                 runtime_version_refs=runtime_version_refs,
                 model_refs=model_refs,
                 promotion_authority_eligible=bool(
@@ -385,7 +399,7 @@ def main() -> int:
             reward_payload = promote_janus_payload_to_empirical(
                 payload=_as_dict(janus_manifest.get("hgrm_reward")),
                 dataset_snapshot_ref=dataset_snapshot_ref,
-                job_run_id=janus_job_run_id,
+                job_run_id=reward_job_run_id,
                 runtime_version_refs=runtime_version_refs,
                 model_refs=model_refs,
                 promotion_authority_eligible=bool(
@@ -414,7 +428,7 @@ def main() -> int:
                 event_car_artifact_ref=event_ref,
                 hgrm_reward_artifact_ref=reward_ref,
                 dataset_snapshot_ref=dataset_snapshot_ref,
-                job_run_id=janus_job_run_id,
+                job_run_id=summary_job_run_id,
                 runtime_version_refs=runtime_version_refs,
                 model_refs=model_refs,
             )
@@ -436,7 +450,7 @@ def main() -> int:
                     candidate_id=candidate_id,
                     job_name=job_name,
                     job_type=job_type,
-                    job_run_id=f"{janus_job_run_id}:{job_type}",
+                    job_run_id=event_job_run_id if job_type == "janus_event_car" else reward_job_run_id,
                     status="completed"
                     if bool(payload.get("promotion_authority_eligible"))
                     else "degraded",
@@ -455,15 +469,15 @@ def main() -> int:
             artifacts_summary["janus_hgrm_reward"] = reward_ref
             artifacts_summary["janus_q"] = summary_ref
             jobs_summary["janus_event_car"] = {
-                "job_run_id": f"{janus_job_run_id}:janus_event_car",
+                "job_run_id": event_job_run_id,
                 "eligible": bool(event_payload.get("promotion_authority_eligible")),
             }
             jobs_summary["janus_hgrm_reward"] = {
-                "job_run_id": f"{janus_job_run_id}:janus_hgrm_reward",
+                "job_run_id": reward_job_run_id,
                 "eligible": bool(reward_payload.get("promotion_authority_eligible")),
             }
             jobs_summary["janus_q"] = {
-                "job_run_id": janus_job_run_id,
+                "job_run_id": summary_job_run_id,
                 "eligible": bool(summary_payload.get("promotion_authority_eligible")),
             }
 
@@ -486,7 +500,7 @@ def main() -> int:
             )
         )
         truthfulness_satisfied = all(
-            _artifact_is_truthful(payload)
+            artifact_is_truthful(payload)
             for payload in (
                 benchmark_payload if benchmark_manifest else {},
                 foundation_payload if foundation_manifest else {},
@@ -536,19 +550,19 @@ def main() -> int:
                     "blocked_reason": blocked_reasons.get(DOC29_TRUTHFULNESS_GATE),
                     "artifact_ref": str(output_dir / "empirical-job-summary.json"),
                     "acceptance_snapshot": {
-                        "benchmark_parity_truthful": _artifact_is_truthful(benchmark_payload)
+                        "benchmark_parity_truthful": artifact_is_truthful(benchmark_payload)
                         if benchmark_manifest
                         else False,
-                        "foundation_router_truthful": _artifact_is_truthful(foundation_payload)
+                        "foundation_router_truthful": artifact_is_truthful(foundation_payload)
                         if foundation_manifest
                         else False,
-                        "janus_event_car_truthful": _artifact_is_truthful(event_payload)
+                        "janus_event_car_truthful": artifact_is_truthful(event_payload)
                         if janus_manifest
                         else False,
-                        "janus_hgrm_reward_truthful": _artifact_is_truthful(reward_payload)
+                        "janus_hgrm_reward_truthful": artifact_is_truthful(reward_payload)
                         if janus_manifest
                         else False,
-                        "janus_summary_truthful": _artifact_is_truthful(summary_payload)
+                        "janus_summary_truthful": artifact_is_truthful(summary_payload)
                         if janus_manifest
                         else False,
                     },

--- a/services/torghut/tests/test_completion_trace.py
+++ b/services/torghut/tests/test_completion_trace.py
@@ -22,6 +22,28 @@ from app.trading.completion import (
 )
 
 
+def _truthful_empirical_payload(
+    *,
+    job_run_id: str,
+    dataset_snapshot_ref: str = 'snapshot-1',
+) -> dict[str, object]:
+    return {
+        'promotion_authority_eligible': True,
+        'artifact_authority': {
+            'provenance': 'historical_market_replay',
+            'maturity': 'empirically_validated',
+            'authoritative': True,
+            'placeholder': False,
+        },
+        'lineage': {
+            'dataset_snapshot_ref': dataset_snapshot_ref,
+            'job_run_id': job_run_id,
+            'runtime_version_refs': ['services/torghut@sha256:abc'],
+            'model_refs': ['models/candidate@sha256:def'],
+        },
+    }
+
+
 class TestCompletionTrace(TestCase):
     def setUp(self) -> None:
         engine = create_engine(
@@ -94,10 +116,6 @@ class TestCompletionTrace(TestCase):
         self.assertEqual(gate['latest_run'], 'sim-2026-03-06-full-day')
 
     def test_doc29_completion_status_derives_empirical_jobs_gate(self) -> None:
-        benchmark_payload = {
-            'artifact_authority': {'authoritative': True},
-            'lineage': {'missing_families': []},
-        }
         with self.session_local() as session:
             for job_type in (
                 'benchmark_parity',
@@ -117,7 +135,9 @@ class TestCompletionTrace(TestCase):
                         promotion_authority_eligible=True,
                         dataset_snapshot_ref='snapshot-1',
                         artifact_refs=[f's3://artifacts/{job_type}.json'],
-                        payload_json=benchmark_payload,
+                        payload_json=_truthful_empirical_payload(
+                            job_run_id=f'job-{job_type}',
+                        ),
                     )
                 )
             session.commit()
@@ -174,10 +194,6 @@ class TestCompletionTrace(TestCase):
                 'janus_event_car',
                 'janus_hgrm_reward',
             ):
-                payload = {
-                    'artifact_authority': {'authoritative': True},
-                    'lineage': {'missing_families': []},
-                }
                 session.add(
                     VNextEmpiricalJobRun(
                         run_id='run-1',
@@ -190,7 +206,9 @@ class TestCompletionTrace(TestCase):
                         promotion_authority_eligible=True,
                         dataset_snapshot_ref='snapshot-1',
                         artifact_refs=[f's3://artifacts/{job_type}.json'],
-                        payload_json=payload,
+                        payload_json=_truthful_empirical_payload(
+                            job_run_id=f'job-{job_type}',
+                        ),
                     )
                 )
             session.commit()
@@ -263,10 +281,9 @@ class TestCompletionTrace(TestCase):
                         promotion_authority_eligible=True,
                         dataset_snapshot_ref='snapshot-1',
                         artifact_refs=[f's3://artifacts/{job_type}.json'],
-                        payload_json={
-                            'artifact_authority': {'authoritative': True},
-                            'lineage': {'missing_families': []},
-                        },
+                        payload_json=_truthful_empirical_payload(
+                            job_run_id=f'job-{job_type}',
+                        ),
                     )
                 )
             session.commit()
@@ -342,10 +359,9 @@ class TestCompletionTrace(TestCase):
                         promotion_authority_eligible=True,
                         dataset_snapshot_ref='snapshot-1',
                         artifact_refs=[f's3://artifacts/{job_type}.json'],
-                        payload_json={
-                            'artifact_authority': {'authoritative': True},
-                            'lineage': {'missing_families': []},
-                        },
+                        payload_json=_truthful_empirical_payload(
+                            job_run_id=f'job-{job_type}',
+                        ),
                     )
                 )
 
@@ -501,10 +517,9 @@ class TestCompletionTrace(TestCase):
                         promotion_authority_eligible=True,
                         dataset_snapshot_ref='snapshot-1',
                         artifact_refs=[f's3://artifacts/{job_type}.json'],
-                        payload_json={
-                            'artifact_authority': {'authoritative': True},
-                            'lineage': {'missing_families': []},
-                        },
+                        payload_json=_truthful_empirical_payload(
+                            job_run_id=f'job-{job_type}',
+                        ),
                     )
                 )
             session.commit()
@@ -570,10 +585,9 @@ class TestCompletionTrace(TestCase):
                         promotion_authority_eligible=True,
                         dataset_snapshot_ref='snapshot-1',
                         artifact_refs=[f's3://artifacts/{job_type}.json'],
-                        payload_json={
-                            'artifact_authority': {'authoritative': True},
-                            'lineage': {'missing_families': []},
-                        },
+                        payload_json=_truthful_empirical_payload(
+                            job_run_id=f'job-{job_type}',
+                        ),
                     )
                 )
 
@@ -675,10 +689,9 @@ class TestCompletionTrace(TestCase):
                         promotion_authority_eligible=True,
                         dataset_snapshot_ref='snapshot-1',
                         artifact_refs=[f's3://artifacts/{job_type}.json'],
-                        payload_json={
-                            'artifact_authority': {'authoritative': True},
-                            'lineage': {'missing_families': []},
-                        },
+                        payload_json=_truthful_empirical_payload(
+                            job_run_id=f'job-{job_type}',
+                        ),
                     )
                 )
             session.add(

--- a/services/torghut/tests/test_empirical_jobs.py
+++ b/services/torghut/tests/test_empirical_jobs.py
@@ -8,9 +8,12 @@ from sqlalchemy.pool import StaticPool
 
 from app.models import Base
 from app.trading.empirical_jobs import (
+    artifact_is_truthful,
     build_empirical_benchmark_parity_report,
     build_empirical_foundation_router_parity_report,
     build_empirical_jobs_status,
+    empirical_artifact_truthfulness_reasons,
+    promote_janus_payload_to_empirical,
     upsert_empirical_job_run,
 )
 
@@ -81,11 +84,77 @@ class TestEmpiricalJobs(TestCase):
                 },
             },
             degradation_summary={"confidence_calibration_error": {"degradation": 0.0}},
+            runtime_version_refs=["services/torghut@sha256:abc"],
+            model_refs=["models/candidate@sha256:def"],
         )
 
         self.assertTrue(report["promotion_authority_eligible"])
         self.assertTrue(report["artifact_authority"]["authoritative"])
         self.assertEqual(report["contract"]["generation_mode"], "empirical_benchmark_parity_v1")
+
+    def test_empirical_benchmark_report_requires_runtime_and_model_lineage(self) -> None:
+        report = build_empirical_benchmark_parity_report(
+            candidate_id="cand-1",
+            baseline_candidate_id="base-1",
+            dataset_snapshot_ref="s3://datasets/snapshot.json",
+            job_run_id="job-1",
+            benchmark_runs=[
+                {
+                    "schema_version": "benchmark-parity-run-v1",
+                    "dataset_ref": "benchmarks/obs-1",
+                    "window_ref": "20260306T000000Z",
+                    "family": family,
+                    "metrics": {},
+                    "slice_metrics": {},
+                    "policy_violations": {"deterministic_gate_compatible": True},
+                    "run_hash": f"hash-{family}",
+                }
+                for family in ("ai-trader", "fev-bench", "gift-eval")
+            ],
+            scorecards={
+                "decision_quality": {
+                    "status": "pass",
+                    "advisory_output_rate": 1.0,
+                    "advisory_output_rate_baseline": 1.0,
+                    "policy_violation_rate": 0.0,
+                    "policy_violation_rate_baseline": 0.0,
+                    "deterministic_gate_compatible": True,
+                    "decision_count": 5,
+                },
+                "reasoning_quality": {
+                    "status": "pass",
+                    "policy_violation_rate": 0.0,
+                    "policy_violation_rate_baseline": 0.0,
+                    "advisory_output_rate": 1.0,
+                    "advisory_output_rate_baseline": 1.0,
+                    "deterministic_gate_compatible": True,
+                },
+                "forecast_quality": {
+                    "status": "pass",
+                    "confidence_calibration_error": 0.01,
+                    "confidence_calibration_error_baseline": 0.01,
+                    "risk_veto_alignment": 0.99,
+                    "risk_veto_alignment_baseline": 0.99,
+                    "policy_violation_rate": 0.0,
+                    "policy_violation_rate_baseline": 0.0,
+                    "advisory_output_rate": 1.0,
+                    "advisory_output_rate_baseline": 1.0,
+                    "deterministic_gate_compatible": True,
+                },
+            },
+            degradation_summary={"confidence_calibration_error": {"degradation": 0.0}},
+        )
+
+        self.assertFalse(report["promotion_authority_eligible"])
+        self.assertFalse(report["artifact_authority"]["authoritative"])
+        self.assertIn(
+            "lineage_runtime_version_refs_missing",
+            empirical_artifact_truthfulness_reasons(report),
+        )
+        self.assertIn(
+            "lineage_model_refs_missing",
+            empirical_artifact_truthfulness_reasons(report),
+        )
 
     def test_empirical_jobs_status_tracks_freshness_per_job_type(self) -> None:
         foundation = build_empirical_foundation_router_parity_report(
@@ -99,6 +168,8 @@ class TestEmpiricalJobs(TestCase):
             drift_metrics={"max": 0.01},
             dataset_snapshot_ref="s3://datasets/snapshot.json",
             job_run_id="job-foundation-1",
+            runtime_version_refs=["services/torghut@sha256:abc"],
+            model_refs=["models/candidate@sha256:def"],
         )
         with self.session_local() as session:
             upsert_empirical_job_run(
@@ -120,5 +191,84 @@ class TestEmpiricalJobs(TestCase):
             status = build_empirical_jobs_status(session=session, stale_after_seconds=86400)
 
         self.assertEqual(status["status"], "degraded")
+        self.assertFalse(status["ready"])
         self.assertEqual(status["jobs"]["foundation_router_parity"]["authority"], "empirical")
         self.assertEqual(status["jobs"]["benchmark_parity"]["status"], "missing")
+
+    def test_promoted_janus_payload_requires_summary_and_lineage_refs(self) -> None:
+        payload = promote_janus_payload_to_empirical(
+            payload={
+                "schema_version": "janus-event-car-v1",
+                "summary": {"event_count": 3},
+            },
+            dataset_snapshot_ref="s3://datasets/snapshot.json",
+            job_run_id="job-janus-1",
+            runtime_version_refs=[],
+            model_refs=["models/candidate@sha256:def"],
+            promotion_authority_eligible=True,
+        )
+
+        self.assertFalse(payload["promotion_authority_eligible"])
+        self.assertFalse(payload["artifact_authority"]["authoritative"])
+        self.assertFalse(artifact_is_truthful(payload))
+
+    def test_empirical_jobs_status_blocks_non_truthful_payload_rows(self) -> None:
+        benchmark_payload = {
+            "schema_version": "benchmark-parity-report-v1",
+            "promotion_authority_eligible": True,
+            "artifact_authority": {
+                "provenance": "historical_market_replay",
+                "maturity": "empirically_validated",
+                "authoritative": True,
+                "placeholder": False,
+            },
+            "lineage": {
+                "dataset_snapshot_ref": "s3://datasets/snapshot.json",
+                "job_run_id": "job-benchmark-1",
+                "runtime_version_refs": ["services/torghut@sha256:abc"],
+                "model_refs": ["models/candidate@sha256:def"],
+            },
+        }
+        with self.session_local() as session:
+            for job_type in (
+                "benchmark_parity",
+                "foundation_router_parity",
+                "janus_event_car",
+                "janus_hgrm_reward",
+            ):
+                payload = dict(benchmark_payload)
+                if job_type == "janus_hgrm_reward":
+                    payload = {
+                        **payload,
+                        "promotion_authority_eligible": False,
+                        "artifact_authority": {
+                            **benchmark_payload["artifact_authority"],
+                            "authoritative": False,
+                        },
+                    }
+                upsert_empirical_job_run(
+                    session=session,
+                    run_id="run-1",
+                    candidate_id="cand-1",
+                    job_name=job_type,
+                    job_type=job_type,
+                    job_run_id=f"job-{job_type}",
+                    status="completed",
+                    authority="empirical",
+                    promotion_authority_eligible=True,
+                    dataset_snapshot_ref="s3://datasets/snapshot.json",
+                    artifact_refs=[f"s3://artifacts/{job_type}.json"],
+                    payload=payload,
+                )
+            session.commit()
+
+            status = build_empirical_jobs_status(session=session, stale_after_seconds=86400)
+
+        self.assertEqual(status["authority"], "blocked")
+        self.assertFalse(status["ready"])
+        self.assertFalse(status["jobs"]["janus_hgrm_reward"]["truthful"])
+        self.assertEqual(status["jobs"]["janus_hgrm_reward"]["authority"], "blocked")
+        self.assertIn(
+            "artifact_authority_not_authoritative",
+            status["jobs"]["janus_hgrm_reward"]["blocked_reasons"],
+        )

--- a/services/torghut/tests/test_run_empirical_promotion_jobs.py
+++ b/services/torghut/tests/test_run_empirical_promotion_jobs.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from unittest import TestCase
+
+from app.trading.empirical_jobs import promote_janus_payload_to_empirical
+from scripts.run_empirical_promotion_jobs import _build_janus_summary
+
+
+class TestRunEmpiricalPromotionJobs(TestCase):
+    def test_build_janus_summary_requires_truthful_child_artifacts(self) -> None:
+        event_payload = promote_janus_payload_to_empirical(
+            payload={
+                'schema_version': 'janus-event-car-v1',
+                'summary': {'event_count': 3},
+                'manifest_hash': 'event-hash',
+            },
+            dataset_snapshot_ref='snapshot-1',
+            job_run_id='job-event',
+            runtime_version_refs=['services/torghut@sha256:abc'],
+            model_refs=['models/candidate@sha256:def'],
+            promotion_authority_eligible=True,
+        )
+        reward_payload = promote_janus_payload_to_empirical(
+            payload={
+                'schema_version': 'janus-hgrm-reward-v1',
+                'summary': {
+                    'reward_count': 3,
+                    'event_mapped_count': 3,
+                    'direction_gate_pass_ratio': '1',
+                },
+                'manifest_hash': 'reward-hash',
+            },
+            dataset_snapshot_ref='snapshot-1',
+            job_run_id='job-reward',
+            runtime_version_refs=['services/torghut@sha256:abc'],
+            model_refs=['models/candidate@sha256:def'],
+            promotion_authority_eligible=True,
+        )
+
+        summary = _build_janus_summary(
+            event_car_payload=event_payload,
+            hgrm_reward_payload=reward_payload,
+            event_car_artifact_ref='s3://artifacts/event.json',
+            hgrm_reward_artifact_ref='s3://artifacts/reward.json',
+            dataset_snapshot_ref='snapshot-1',
+            job_run_id='job-summary',
+            runtime_version_refs=['services/torghut@sha256:abc'],
+            model_refs=['models/candidate@sha256:def'],
+        )
+
+        self.assertTrue(summary['promotion_authority_eligible'])
+        self.assertTrue(summary['artifact_authority']['authoritative'])
+        self.assertEqual(summary['reasons'], [])
+        self.assertEqual(summary['hgrm_reward']['event_mapped_count'], 3)
+
+    def test_build_janus_summary_blocks_non_truthful_child_artifacts(self) -> None:
+        event_payload = promote_janus_payload_to_empirical(
+            payload={
+                'schema_version': 'janus-event-car-v1',
+                'summary': {'event_count': 3},
+                'manifest_hash': 'event-hash',
+            },
+            dataset_snapshot_ref='snapshot-1',
+            job_run_id='job-event',
+            runtime_version_refs=[],
+            model_refs=['models/candidate@sha256:def'],
+            promotion_authority_eligible=True,
+        )
+        reward_payload = promote_janus_payload_to_empirical(
+            payload={
+                'schema_version': 'janus-hgrm-reward-v1',
+                'summary': {
+                    'reward_count': 3,
+                    'event_mapped_count': 3,
+                    'direction_gate_pass_ratio': '1',
+                },
+                'manifest_hash': 'reward-hash',
+            },
+            dataset_snapshot_ref='snapshot-1',
+            job_run_id='job-reward',
+            runtime_version_refs=['services/torghut@sha256:abc'],
+            model_refs=['models/candidate@sha256:def'],
+            promotion_authority_eligible=True,
+        )
+
+        summary = _build_janus_summary(
+            event_car_payload=event_payload,
+            hgrm_reward_payload=reward_payload,
+            event_car_artifact_ref='s3://artifacts/event.json',
+            hgrm_reward_artifact_ref='s3://artifacts/reward.json',
+            dataset_snapshot_ref='snapshot-1',
+            job_run_id='job-summary',
+            runtime_version_refs=['services/torghut@sha256:abc'],
+            model_refs=['models/candidate@sha256:def'],
+        )
+
+        self.assertFalse(summary['promotion_authority_eligible'])
+        self.assertFalse(summary['artifact_authority']['authoritative'])
+        self.assertIn('janus_event_car_not_truthful', summary['reasons'])

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -41,6 +41,28 @@ from app.models import (
 )
 
 
+def _truthful_empirical_payload(
+    *,
+    job_run_id: str,
+    dataset_snapshot_ref: str,
+) -> dict[str, object]:
+    return {
+        "promotion_authority_eligible": True,
+        "artifact_authority": {
+            "provenance": "historical_market_replay",
+            "maturity": "empirically_validated",
+            "authoritative": True,
+            "placeholder": False,
+        },
+        "lineage": {
+            "dataset_snapshot_ref": dataset_snapshot_ref,
+            "job_run_id": job_run_id,
+            "runtime_version_refs": ["services/torghut@sha256:abc"],
+            "model_refs": ["models/candidate@sha256:def"],
+        },
+    }
+
+
 class TestTradingApi(TestCase):
     def setUp(self) -> None:
         _TRADING_DEPENDENCY_HEALTH_CACHE.clear()
@@ -1900,7 +1922,10 @@ class TestTradingApi(TestCase):
                     promotion_authority_eligible=True,
                     dataset_snapshot_ref="s3://datasets/run-empirical-1.json",
                     artifact_refs=["s3://artifacts/benchmark.json"],
-                    payload_json={"artifact_authority": {"authoritative": True}},
+                    payload_json=_truthful_empirical_payload(
+                        job_run_id="job-benchmark-1",
+                        dataset_snapshot_ref="s3://datasets/run-empirical-1.json",
+                    ),
                 )
             )
             session.commit()


### PR DESCRIPTION
## Summary

- harden Torghut empirical artifact truthfulness so benchmark, foundation-router, and Janus authority now requires empirically validated lineage, allowed provenance, and non-placeholder evidence.
- make the empirical promotion script fail closed for Janus summary authority and persist distinct per-family Janus job run ids.
- add focused doc38 regression coverage and update completion/API fixtures to use truthful empirical payloads.

## Related Issues

None (tracked via [torghut-v6-doc38-empirical-promotion](https://github.com/proompteng/lab/blob/main/docs/torghut/design-system/v6/38-authoritative-empirical-promotion-evidence-contract-2026-03-09.md))

## Testing

- `cd services/torghut && PATH="/root/.local/bin:$PATH" /root/.local/bin/uv sync --frozen --extra dev`
- `cd services/torghut && PATH="/root/.local/bin:$PATH" /root/.local/bin/uv run --frozen ruff check app/trading/empirical_jobs.py scripts/run_empirical_promotion_jobs.py tests/test_empirical_jobs.py tests/test_completion_trace.py tests/test_trading_api.py tests/test_run_empirical_promotion_jobs.py`
- `cd services/torghut && PATH="/root/.local/bin:$PATH" /root/.local/bin/uv run --frozen python -m unittest tests.test_empirical_jobs tests.test_completion_trace tests.test_trading_api tests.test_run_empirical_promotion_jobs tests.test_janus_q_scaffold`
- `cd services/torghut && PATH="/root/.local/bin:$PATH" /root/.local/bin/uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && PATH="/root/.local/bin:$PATH" /root/.local/bin/uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && PATH="/root/.local/bin:$PATH" /root/.local/bin/uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
