### PR TITLE
feat(torghut): add options simulation proof lane runtime

### DIFF
--- a/services/torghut/README.md
+++ b/services/torghut/README.md
@@ -264,6 +264,16 @@ Set `torghut_env_overrides.TRADING_FEATURE_MAX_STALENESS_MS` only when you want 
 When `window.profile=us_equities_regular`, the script enforces full U.S. regular session bounds
 (`09:30-16:00 America/New_York`, `390` minutes minimum) and fails if coverage is too short.
 
+The manifest can now select `lane: options` with
+`schema_version: torghut.options-simulation-manifest.v1`. That lane uses isolated
+`torghut.sim.options.*` replay topics plus
+`sim_options_contract_bars_1s` / `sim_options_contract_features` /
+`sim_options_surface_features` in the simulation ClickHouse database. Example proof-run
+manifests live at:
+
+- `config/simulation/options-smoke-open-30m-2026-03-06.yaml`
+- `config/simulation/options-full-day-2026-03-06.yaml`
+
 If `argocd.manage_automation=true` in the dataset manifest, `--mode run` automatically sets Torghut
 ApplicationSet automation to `manual` during the simulation and restores the prior mode at the end.
 
@@ -280,7 +290,8 @@ uv run python scripts/start_historical_simulation.py \
   --dataset-manifest config/simulation/example-dataset.yaml
 ```
 
-Artifacts are written under `artifacts/torghut/simulations/<run_token>/`:
+Artifacts are written under `artifacts/torghut/simulations/<run_token>/` for equity runs
+and `artifacts/torghut/simulations/options/<run_token>/` for options runs by default:
 
 - `state.json` (pre-simulation cluster config snapshot)
 - `source-dump.ndjson` (bounded source-topic dump)

--- a/services/torghut/config/simulation/options-full-day-2026-03-06.yaml
+++ b/services/torghut/config/simulation/options-full-day-2026-03-06.yaml
@@ -1,0 +1,143 @@
+schema_version: torghut.options-simulation-manifest.v1
+lane: options
+dataset_id: torghut-options-full-day-20260306
+dataset_snapshot_ref: torghut-options-full-day-20260306
+feed: indicative
+underlyings:
+  - AAPL
+  - MSFT
+  - NVDA
+catalog_snapshot_ref: artifacts/torghut/options/catalog/2026-03-06-full-day/catalog-snapshot.json
+
+contract_policy:
+  dte_min: 5
+  dte_max: 60
+  option_types:
+    - call
+    - put
+  moneyness_bands:
+    - atm
+    - one_step_otm
+    - one_step_itm
+  minimum_open_interest: 100
+
+raw_source_policy:
+  prefer_kafka: true
+  require_underlying_context: true
+  snapshots_required: true
+  allow_provider_backfill: true
+
+cost_model:
+  contract_multiplier: 100
+  spread_cross_fraction: '0.50'
+  fee_per_contract: '0.65'
+  slippage_bps: '12'
+
+proof_gates:
+  minimum_contracts: 50
+  minimum_fills: 20
+  minimum_underlyings: 3
+  require_profitability_artifacts: true
+
+window:
+  trading_day: '2026-03-06'
+  timezone: America/New_York
+  start: '2026-03-06T14:30:00Z'
+  end: '2026-03-06T21:00:00Z'
+  profile: us_equities_regular
+  min_coverage_minutes: 390
+  strict_coverage_ratio: 0.95
+
+kafka:
+  bootstrap_servers: kafka-kafka-bootstrap.kafka.svc.cluster.local:9092
+  runtime_bootstrap_servers: kafka-kafka-bootstrap.kafka.svc.cluster.local:9092
+  security_protocol: SASL_PLAINTEXT
+  sasl_mechanism: SCRAM-SHA-512
+  sasl_username: kafka-codex-credentials
+  sasl_password_env: TORGHUT_SIM_KAFKA_PASSWORD
+  runtime_security_protocol: SASL_PLAINTEXT
+  runtime_sasl_mechanism: SCRAM-SHA-512
+  runtime_sasl_username: kafka-codex-credentials
+  runtime_sasl_password_env: TORGHUT_SIM_KAFKA_PASSWORD
+  default_partitions: 6
+  replication_factor: 1
+
+clickhouse:
+  http_url: http://torghut-clickhouse.torghut.svc.cluster.local:8123
+  username: torghut
+  password_env: TORGHUT_CLICKHOUSE_PASSWORD
+  password_secret_name: torghut-clickhouse-auth
+  password_secret_key: torghut_password
+  secret_namespace: torghut
+  simulation_database: torghut_sim_options_2026_03_06_full_day
+
+postgres:
+  admin_dsn: postgresql://torghut_app@torghut-db-rw.torghut.svc.cluster.local:5432/postgres
+  admin_dsn_password_env: TORGHUT_POSTGRES_PASSWORD
+  simulation_dsn: postgresql://torghut_app@torghut-db-rw.torghut.svc.cluster.local:5432/torghut_sim_options_2026_03_06_full_day
+  runtime_simulation_dsn: postgresql://torghut_app@torghut-db-rw.torghut.svc.cluster.local:5432/torghut_sim_options_2026_03_06_full_day
+  migrations_command: /opt/venv/bin/alembic upgrade heads
+
+runtime:
+  target_mode: dedicated_service
+  namespace: torghut
+  ta_configmap: torghut-options-ta-sim-config
+  ta_deployment: torghut-options-ta-sim
+  torghut_service: torghut-sim
+  torghut_forecast_service: torghut-forecast-sim
+
+ta_config:
+  topic_key_by_role:
+    contracts: TOPIC_OPTIONS_CONTRACTS
+    trades: TOPIC_OPTIONS_TRADES
+    quotes: TOPIC_OPTIONS_QUOTES
+    snapshots: TOPIC_OPTIONS_SNAPSHOTS
+    status: TOPIC_OPTIONS_STATUS
+    ta_contract_bars: TOPIC_OPTIONS_TA_CONTRACT_BARS
+    ta_contract_features: TOPIC_OPTIONS_TA_CONTRACT_FEATURES
+    ta_surface_features: TOPIC_OPTIONS_TA_SURFACE_FEATURES
+    ta_status: TOPIC_OPTIONS_TA_STATUS
+  clickhouse_url_key: OPTIONS_TA_CLICKHOUSE_URL
+  group_id_key: OPTIONS_TA_GROUP_ID
+  auto_offset_reset_key: OPTIONS_TA_AUTO_OFFSET_RESET
+
+rollouts:
+  enabled: true
+  namespace: torghut
+  runtime_template: torghut-simulation-runtime-ready
+  activity_template: torghut-simulation-activity
+  teardown_template: torghut-simulation-teardown-clean
+  artifact_template: torghut-simulation-artifact-bundle
+
+replay:
+  pace_mode: max_throughput
+  acceleration: 1
+  max_sleep_seconds: 0
+  auto_offset_reset: earliest
+  flush_every_records: 50000
+  flush_timeout_seconds: 60
+  final_flush_timeout_seconds: 180
+  status_update_every_records: 25000
+  status_update_every_seconds: 30
+
+monitor:
+  timeout_seconds: 3600
+  poll_seconds: 20
+  min_trade_decisions: 1
+  min_executions: 1
+  min_execution_tca_metrics: 1
+  min_execution_order_events: 1
+  cursor_grace_seconds: 120
+
+argocd:
+  manage_automation: true
+  applicationset_name: product
+  applicationset_namespace: argocd
+  app_name: torghut
+  desired_mode_during_run: manual
+  restore_mode_after_run: previous
+  verify_timeout_seconds: 600
+
+reporting:
+  commission_bps: '0'
+  per_trade_fee: '0.65'

--- a/services/torghut/config/simulation/options-smoke-open-30m-2026-03-06.yaml
+++ b/services/torghut/config/simulation/options-smoke-open-30m-2026-03-06.yaml
@@ -1,0 +1,140 @@
+schema_version: torghut.options-simulation-manifest.v1
+lane: options
+dataset_id: torghut-options-smoke-open-30m-20260306
+dataset_snapshot_ref: torghut-options-smoke-open-30m-20260306
+feed: indicative
+underlyings:
+  - AAPL
+  - MSFT
+catalog_snapshot_ref: artifacts/torghut/options/catalog/2026-03-06-open/catalog-snapshot.json
+
+contract_policy:
+  dte_min: 5
+  dte_max: 45
+  option_types:
+    - call
+    - put
+  moneyness_bands:
+    - atm
+    - one_step_otm
+  minimum_open_interest: 50
+
+raw_source_policy:
+  prefer_kafka: true
+  require_underlying_context: true
+  snapshots_required: true
+  allow_provider_backfill: true
+
+cost_model:
+  contract_multiplier: 100
+  spread_cross_fraction: '0.50'
+  fee_per_contract: '0.65'
+  slippage_bps: '12'
+
+proof_gates:
+  minimum_contracts: 20
+  minimum_fills: 5
+  minimum_underlyings: 2
+  require_profitability_artifacts: true
+
+window:
+  trading_day: '2026-03-06'
+  timezone: America/New_York
+  start: '2026-03-06T14:30:00Z'
+  end: '2026-03-06T15:00:00Z'
+  min_coverage_minutes: 30
+  strict_coverage_ratio: 0.95
+
+kafka:
+  bootstrap_servers: kafka-kafka-bootstrap.kafka.svc.cluster.local:9092
+  runtime_bootstrap_servers: kafka-kafka-bootstrap.kafka.svc.cluster.local:9092
+  security_protocol: SASL_PLAINTEXT
+  sasl_mechanism: SCRAM-SHA-512
+  sasl_username: kafka-codex-credentials
+  sasl_password_env: TORGHUT_SIM_KAFKA_PASSWORD
+  runtime_security_protocol: SASL_PLAINTEXT
+  runtime_sasl_mechanism: SCRAM-SHA-512
+  runtime_sasl_username: kafka-codex-credentials
+  runtime_sasl_password_env: TORGHUT_SIM_KAFKA_PASSWORD
+  default_partitions: 6
+  replication_factor: 1
+
+clickhouse:
+  http_url: http://torghut-clickhouse.torghut.svc.cluster.local:8123
+  username: torghut
+  password_env: TORGHUT_CLICKHOUSE_PASSWORD
+  password_secret_name: torghut-clickhouse-auth
+  password_secret_key: torghut_password
+  secret_namespace: torghut
+  simulation_database: torghut_sim_options_2026_03_06_open_30m
+
+postgres:
+  admin_dsn: postgresql://torghut_app@torghut-db-rw.torghut.svc.cluster.local:5432/postgres
+  admin_dsn_password_env: TORGHUT_POSTGRES_PASSWORD
+  simulation_dsn: postgresql://torghut_app@torghut-db-rw.torghut.svc.cluster.local:5432/torghut_sim_options_2026_03_06_open_30m
+  runtime_simulation_dsn: postgresql://torghut_app@torghut-db-rw.torghut.svc.cluster.local:5432/torghut_sim_options_2026_03_06_open_30m
+  migrations_command: /opt/venv/bin/alembic upgrade heads
+
+runtime:
+  target_mode: dedicated_service
+  namespace: torghut
+  ta_configmap: torghut-options-ta-sim-config
+  ta_deployment: torghut-options-ta-sim
+  torghut_service: torghut-sim
+  torghut_forecast_service: torghut-forecast-sim
+
+ta_config:
+  topic_key_by_role:
+    contracts: TOPIC_OPTIONS_CONTRACTS
+    trades: TOPIC_OPTIONS_TRADES
+    quotes: TOPIC_OPTIONS_QUOTES
+    snapshots: TOPIC_OPTIONS_SNAPSHOTS
+    status: TOPIC_OPTIONS_STATUS
+    ta_contract_bars: TOPIC_OPTIONS_TA_CONTRACT_BARS
+    ta_contract_features: TOPIC_OPTIONS_TA_CONTRACT_FEATURES
+    ta_surface_features: TOPIC_OPTIONS_TA_SURFACE_FEATURES
+    ta_status: TOPIC_OPTIONS_TA_STATUS
+  clickhouse_url_key: OPTIONS_TA_CLICKHOUSE_URL
+  group_id_key: OPTIONS_TA_GROUP_ID
+  auto_offset_reset_key: OPTIONS_TA_AUTO_OFFSET_RESET
+
+rollouts:
+  enabled: true
+  namespace: torghut
+  runtime_template: torghut-simulation-runtime-ready
+  activity_template: torghut-simulation-activity
+  teardown_template: torghut-simulation-teardown-clean
+  artifact_template: torghut-simulation-artifact-bundle
+
+replay:
+  pace_mode: max_throughput
+  acceleration: 1
+  max_sleep_seconds: 0
+  auto_offset_reset: earliest
+  flush_every_records: 50000
+  flush_timeout_seconds: 60
+  final_flush_timeout_seconds: 180
+  status_update_every_records: 25000
+  status_update_every_seconds: 30
+
+monitor:
+  timeout_seconds: 1800
+  poll_seconds: 20
+  min_trade_decisions: 1
+  min_executions: 1
+  min_execution_tca_metrics: 1
+  min_execution_order_events: 1
+  cursor_grace_seconds: 120
+
+argocd:
+  manage_automation: true
+  applicationset_name: product
+  applicationset_namespace: argocd
+  app_name: torghut
+  desired_mode_during_run: manual
+  restore_mode_after_run: previous
+  verify_timeout_seconds: 600
+
+reporting:
+  commission_bps: '0'
+  per_trade_fee: '0.65'

--- a/services/torghut/scripts/analyze_historical_simulation.py
+++ b/services/torghut/scripts/analyze_historical_simulation.py
@@ -204,15 +204,15 @@ def _extract_run_scope_decisions(
 def _build_last_price_map(
     *,
     clickhouse_config: ClickHouseRuntimeConfig | None,
-    clickhouse_db: str,
+    price_table: str,
     tca_rows: list[dict[str, Any]],
     execution_rows: list[dict[str, Any]],
 ) -> dict[str, Decimal]:
     prices: dict[str, Decimal] = {}
-    if clickhouse_config is not None and clickhouse_config.http_url:
+    if clickhouse_config is not None and clickhouse_config.http_url and price_table:
         query = (
             f'SELECT symbol, toString(argMax(close, event_ts)) '
-            f'FROM {clickhouse_db}.ta_microbars '
+            f'FROM {price_table} '
             f'GROUP BY symbol FORMAT TabSeparated'
         )
         try:
@@ -436,6 +436,7 @@ def _render_markdown(report: Mapping[str, Any]) -> str:
             '',
             f"- Schema: `{_as_text(report.get('schema_version'))}`",
             f"- Run ID: `{_as_text(_as_mapping(report.get('run_metadata')).get('run_id'))}`",
+            f"- Lane: `{_as_text(_as_mapping(report.get('run_metadata')).get('lane')) or 'equity'}`",
             f"- Verdict: `{verdict or 'unknown'}`",
             '',
             '## Coverage',
@@ -771,7 +772,7 @@ def _build_report(args: argparse.Namespace) -> dict[str, Any]:
 
     last_prices = _build_last_price_map(
         clickhouse_config=clickhouse_config,
-        clickhouse_db=resources.clickhouse_db,
+        price_table=resources.clickhouse_price_table,
         tca_rows=tca_rows,
         execution_rows=executions,
     )
@@ -1049,10 +1050,13 @@ def _build_report(args: argparse.Namespace) -> dict[str, Any]:
         'run_id': args.run_id,
         'run_token': run_token,
         'dataset_id': resources.dataset_id,
+        'lane': resources.lane,
         'generated_at': datetime.now(timezone.utc).isoformat(),
         'manifest_path': str(manifest_path),
         'simulation_db': postgres_config.simulation_db,
         'clickhouse_db': resources.clickhouse_db,
+        'clickhouse_price_table': resources.clickhouse_price_table,
+        'clickhouse_signal_table': resources.clickhouse_signal_table,
     }
 
     report = {

--- a/services/torghut/scripts/historical_simulation_verification.py
+++ b/services/torghut/scripts/historical_simulation_verification.py
@@ -13,17 +13,12 @@ from urllib.parse import quote_plus, urlsplit
 from zoneinfo import ZoneInfo
 
 import psycopg
+from scripts.simulation_lane_contracts import (
+    EQUITY_SIMULATION_LANE,
+    simulation_lane_contract,
+)
 
-PRODUCTION_TOPIC_BY_ROLE = {
-    'trades': 'torghut.trades.v1',
-    'quotes': 'torghut.quotes.v1',
-    'bars': 'torghut.bars.1m.v1',
-    'status': 'torghut.status.v1',
-    'ta_microbars': 'torghut.ta.bars.1s.v1',
-    'ta_signals': 'torghut.ta.signals.v1',
-    'ta_status': 'torghut.ta.status.v1',
-    'order_updates': 'torghut.trade-updates.v1',
-}
+PRODUCTION_TOPIC_BY_ROLE = dict(EQUITY_SIMULATION_LANE.source_topic_by_role)
 
 TORGHUT_ENV_KEYS = [
     'DB_DSN',
@@ -151,6 +146,11 @@ def _resource_asdict(resource: Any) -> dict[str, Any]:
         payload = asdict(resource)
         return {str(key): value for key, value in cast(dict[str, Any], payload).items()}
     return dict(vars(resource))
+
+
+def _resource_lane_contract(resource: Any):
+    lane = _as_text(_resource_attr(resource, 'lane')) or 'equity'
+    return simulation_lane_contract(lane)
 
 
 def _parse_rfc3339_timestamp(value: str | None, *, label: str) -> datetime:
@@ -586,6 +586,7 @@ def _classify_activity_snapshot(
 
 def _runtime_verify(*, resources: Any, manifest: Mapping[str, Any]) -> dict[str, Any]:
     window_start, window_end = _resolve_window_bounds(manifest)
+    lane_contract = _resource_lane_contract(resources)
     namespace = _as_text(_resource_attr(resources, 'namespace')) or 'torghut'
     torghut_service = _as_text(_resource_attr(resources, 'torghut_service'))
     ta_deployment = _as_text(_resource_attr(resources, 'ta_deployment'))
@@ -631,12 +632,13 @@ def _runtime_verify(*, resources: Any, manifest: Mapping[str, Any]) -> dict[str,
     ta_data = _as_mapping(ta_config.get('data'))
     run_token = _as_text(_resource_attr(resources, 'run_token')) or ''
     ta_runtime_config = {
-        'trades_topic': _as_text(ta_data.get('TA_TRADES_TOPIC')) == _as_text(expected_topics.get('trades')),
-        'quotes_topic': _as_text(ta_data.get('TA_QUOTES_TOPIC')) == _as_text(expected_topics.get('quotes')),
-        'bars_topic': _as_text(ta_data.get('TA_BARS1M_TOPIC')) == _as_text(expected_topics.get('bars')),
-        'signals_topic': _as_text(ta_data.get('TA_SIGNALS_TOPIC')) == _as_text(expected_topics.get('ta_signals')),
-        'clickhouse_database': bool(run_token) and run_token in (_as_text(ta_data.get('TA_CLICKHOUSE_URL')) or ''),
+        f'{role}_topic': _as_text(ta_data.get(key)) == _as_text(expected_topics.get(role))
+        for role, key in lane_contract.ta_topic_key_by_role.items()
+        if role in expected_topics
     }
+    ta_runtime_config['clickhouse_database'] = bool(run_token) and run_token in (
+        _as_text(ta_data.get(lane_contract.ta_clickhouse_url_key)) or ''
+    )
     ta_runtime_config_complete = all(ta_runtime_config.values())
     revision_health: dict[str, Any] | None = None
     if latest_ready_revision:
@@ -776,8 +778,13 @@ def _verify_isolation_guards(
     postgres_config: Any,
     ta_data: Mapping[str, Any],
 ) -> dict[str, Any]:
+    lane_contract = _resource_lane_contract(resources)
     source_topic_by_role = cast(dict[str, str], _resource_attr(resources, 'source_topic_by_role'))
     simulation_topic_by_role = cast(dict[str, str], _resource_attr(resources, 'simulation_topic_by_role'))
+    clickhouse_table_by_role = cast(
+        dict[str, str],
+        _resource_attr(resources, 'clickhouse_table_by_role', default={}),
+    )
     clickhouse_signal_table = _as_text(_resource_attr(resources, 'clickhouse_signal_table'))
     clickhouse_price_table = _as_text(_resource_attr(resources, 'clickhouse_price_table'))
     ta_group_id = _as_text(_resource_attr(resources, 'ta_group_id'))
@@ -785,16 +792,25 @@ def _verify_isolation_guards(
     simulation_dsn = _as_text(_resource_attr(postgres_config, 'simulation_dsn'))
     simulation_topics_disjoint = all(
         simulation_topic_by_role.get(role) != source_topic_by_role.get(role)
-        for role in ('trades', 'quotes', 'bars', 'status')
+        for role in lane_contract.replay_roles
     )
-    signal_table_isolated = bool(clickhouse_signal_table and '.ta_signals' in clickhouse_signal_table)
-    price_table_isolated = bool(clickhouse_price_table and '.ta_microbars' in clickhouse_price_table)
+    signal_basename = lane_contract.clickhouse_simulation_table_by_role[lane_contract.signal_table_role]
+    price_basename = lane_contract.clickhouse_simulation_table_by_role[lane_contract.price_table_role]
+    signal_table_isolated = bool(clickhouse_signal_table and clickhouse_signal_table.endswith(f'.{signal_basename}'))
+    price_table_isolated = bool(clickhouse_price_table and clickhouse_price_table.endswith(f'.{price_basename}'))
+    auxiliary_tables_isolated = all(
+        table.endswith(f'.{lane_contract.clickhouse_simulation_table_by_role[role]}')
+        for role, table in clickhouse_table_by_role.items()
+        if role not in {lane_contract.signal_table_role, lane_contract.price_table_role}
+    )
     postgres_database_isolated = bool(simulation_db and simulation_db != 'torghut')
     report = {
+        'lane': lane_contract.lane,
         'simulation_topics_isolated_from_sources': simulation_topics_disjoint,
-        'ta_group_isolated': ta_group_id != _as_text(ta_data.get('TA_GROUP_ID')),
+        'ta_group_isolated': ta_group_id != _as_text(ta_data.get(lane_contract.ta_group_id_key)),
         'signal_table_isolated': signal_table_isolated,
         'price_table_isolated': price_table_isolated,
+        'auxiliary_tables_isolated': auxiliary_tables_isolated,
         'postgres_database_isolated': postgres_database_isolated,
         'simulation_dsn': simulation_dsn,
     }
@@ -810,6 +826,7 @@ def _teardown_clean(
     postgres_config: Any,
 ) -> dict[str, Any]:
     resource_payload = _resource_asdict(resources)
+    lane_contract = _resource_lane_contract(resources)
     namespace = _as_text(resource_payload.get('namespace')) or 'torghut'
     torghut_service = _as_text(resource_payload.get('torghut_service'))
     ta_configmap = _as_text(resource_payload.get('ta_configmap'))
@@ -843,8 +860,8 @@ def _teardown_clean(
         'signal_table': _as_text(_as_mapping(env_by_name.get('TRADING_SIGNAL_TABLE')).get('value')) == clickhouse_signal_table,
         'price_table': _as_text(_as_mapping(env_by_name.get('TRADING_PRICE_TABLE')).get('value')) == clickhouse_price_table,
         'order_feed_group_id': _as_text(_as_mapping(env_by_name.get('TRADING_ORDER_FEED_GROUP_ID')).get('value')) == order_feed_group_id,
-        'ta_group_id': _as_text(ta_data.get('TA_GROUP_ID')) == ta_group_id,
-        'ta_clickhouse_database': bool(run_token) and run_token in (_as_text(ta_data.get('TA_CLICKHOUSE_URL')) or ''),
+        'ta_group_id': _as_text(ta_data.get(lane_contract.ta_group_id_key)) == ta_group_id,
+        'ta_clickhouse_database': bool(run_token) and run_token in (_as_text(ta_data.get(lane_contract.ta_clickhouse_url_key)) or ''),
     }
     restored = not any(simulation_markers_present.values())
     return {

--- a/services/torghut/scripts/simulation_lane_contracts.py
+++ b/services/torghut/scripts/simulation_lane_contracts.py
@@ -1,0 +1,235 @@
+"""Shared lane contracts for Torghut historical simulation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+
+@dataclass(frozen=True)
+class SimulationLaneContract:
+    lane: str
+    schema_version: str | None
+    source_topic_by_role: dict[str, str]
+    simulation_topic_by_role: dict[str, str]
+    replay_roles: tuple[str, ...]
+    clickhouse_source_table_by_role: dict[str, str]
+    clickhouse_simulation_table_by_role: dict[str, str]
+    signal_table_role: str
+    price_table_role: str
+    ta_topic_key_by_role: dict[str, str]
+    ta_clickhouse_url_key: str
+    ta_group_id_key: str
+    ta_auto_offset_reset_key: str
+    required_manifest_fields: tuple[str, ...] = ()
+
+
+EQUITY_SIMULATION_LANE = SimulationLaneContract(
+    lane="equity",
+    schema_version=None,
+    source_topic_by_role={
+        "trades": "torghut.trades.v1",
+        "quotes": "torghut.quotes.v1",
+        "bars": "torghut.bars.1m.v1",
+        "status": "torghut.status.v1",
+        "ta_microbars": "torghut.ta.bars.1s.v1",
+        "ta_signals": "torghut.ta.signals.v1",
+        "ta_status": "torghut.ta.status.v1",
+        "order_updates": "torghut.trade-updates.v1",
+    },
+    simulation_topic_by_role={
+        "trades": "torghut.sim.trades.v1",
+        "quotes": "torghut.sim.quotes.v1",
+        "bars": "torghut.sim.bars.1m.v1",
+        "status": "torghut.sim.status.v1",
+        "ta_microbars": "torghut.sim.ta.bars.1s.v1",
+        "ta_signals": "torghut.sim.ta.signals.v1",
+        "ta_status": "torghut.sim.ta.status.v1",
+        "order_updates": "torghut.sim.trade-updates.v1",
+    },
+    replay_roles=("trades", "quotes", "bars", "status"),
+    clickhouse_source_table_by_role={
+        "price": "ta_microbars",
+        "signal": "ta_signals",
+    },
+    clickhouse_simulation_table_by_role={
+        "price": "ta_microbars",
+        "signal": "ta_signals",
+    },
+    signal_table_role="signal",
+    price_table_role="price",
+    ta_topic_key_by_role={
+        "trades": "TA_TRADES_TOPIC",
+        "quotes": "TA_QUOTES_TOPIC",
+        "bars": "TA_BARS1M_TOPIC",
+        "ta_microbars": "TA_MICROBARS_TOPIC",
+        "ta_signals": "TA_SIGNALS_TOPIC",
+    },
+    ta_clickhouse_url_key="TA_CLICKHOUSE_URL",
+    ta_group_id_key="TA_GROUP_ID",
+    ta_auto_offset_reset_key="TA_AUTO_OFFSET_RESET",
+)
+
+OPTIONS_SIMULATION_LANE = SimulationLaneContract(
+    lane="options",
+    schema_version="torghut.options-simulation-manifest.v1",
+    source_topic_by_role={
+        "contracts": "torghut.options.contracts.v1",
+        "trades": "torghut.options.trades.v1",
+        "quotes": "torghut.options.quotes.v1",
+        "snapshots": "torghut.options.snapshots.v1",
+        "status": "torghut.options.status.v1",
+        "ta_contract_bars": "torghut.options.ta.contract-bars.1s.v1",
+        "ta_contract_features": "torghut.options.ta.contract-features.v1",
+        "ta_surface_features": "torghut.options.ta.surface-features.v1",
+        "ta_status": "torghut.options.ta.status.v1",
+        "order_updates": "torghut.options.trade-updates.v1",
+    },
+    simulation_topic_by_role={
+        "contracts": "torghut.sim.options.contracts.v1",
+        "trades": "torghut.sim.options.trades.v1",
+        "quotes": "torghut.sim.options.quotes.v1",
+        "snapshots": "torghut.sim.options.snapshots.v1",
+        "status": "torghut.sim.options.status.v1",
+        "ta_contract_bars": "torghut.sim.options.ta.contract-bars.1s.v1",
+        "ta_contract_features": "torghut.sim.options.ta.contract-features.v1",
+        "ta_surface_features": "torghut.sim.options.ta.surface-features.v1",
+        "ta_status": "torghut.sim.options.ta.status.v1",
+        "order_updates": "torghut.sim.options.trade-updates.v1",
+    },
+    replay_roles=("contracts", "trades", "quotes", "snapshots", "status"),
+    clickhouse_source_table_by_role={
+        "price": "options_contract_bars_1s",
+        "signal": "options_contract_features",
+        "surface": "options_surface_features",
+    },
+    clickhouse_simulation_table_by_role={
+        "price": "sim_options_contract_bars_1s",
+        "signal": "sim_options_contract_features",
+        "surface": "sim_options_surface_features",
+    },
+    signal_table_role="signal",
+    price_table_role="price",
+    ta_topic_key_by_role={
+        "contracts": "TOPIC_OPTIONS_CONTRACTS",
+        "trades": "TOPIC_OPTIONS_TRADES",
+        "quotes": "TOPIC_OPTIONS_QUOTES",
+        "snapshots": "TOPIC_OPTIONS_SNAPSHOTS",
+        "status": "TOPIC_OPTIONS_STATUS",
+        "ta_contract_bars": "TOPIC_OPTIONS_TA_CONTRACT_BARS",
+        "ta_contract_features": "TOPIC_OPTIONS_TA_CONTRACT_FEATURES",
+        "ta_surface_features": "TOPIC_OPTIONS_TA_SURFACE_FEATURES",
+        "ta_status": "TOPIC_OPTIONS_TA_STATUS",
+    },
+    ta_clickhouse_url_key="OPTIONS_TA_CLICKHOUSE_URL",
+    ta_group_id_key="OPTIONS_TA_GROUP_ID",
+    ta_auto_offset_reset_key="OPTIONS_TA_AUTO_OFFSET_RESET",
+    required_manifest_fields=(
+        "feed",
+        "underlyings",
+        "contract_policy",
+        "catalog_snapshot_ref",
+        "raw_source_policy",
+        "cost_model",
+        "proof_gates",
+    ),
+)
+
+SIMULATION_LANE_BY_NAME = {
+    EQUITY_SIMULATION_LANE.lane: EQUITY_SIMULATION_LANE,
+    OPTIONS_SIMULATION_LANE.lane: OPTIONS_SIMULATION_LANE,
+}
+
+
+def simulation_lane_contract(value: str | None) -> SimulationLaneContract:
+    lane = (value or "equity").strip().lower() or "equity"
+    try:
+        return SIMULATION_LANE_BY_NAME[lane]
+    except KeyError as exc:
+        supported = ",".join(sorted(SIMULATION_LANE_BY_NAME))
+        raise RuntimeError(
+            f"unsupported_simulation_lane:{lane} supported={supported}"
+        ) from exc
+
+
+def simulation_lane_contract_for_manifest(
+    manifest: Mapping[str, Any],
+) -> SimulationLaneContract:
+    contract = simulation_lane_contract(_manifest_text(manifest.get("lane")))
+    schema_version = _manifest_text(manifest.get("schema_version"))
+    if (
+        contract.schema_version is not None
+        and schema_version != contract.schema_version
+    ):
+        raise RuntimeError(
+            "simulation_manifest_schema_version_invalid "
+            f"lane={contract.lane} expected={contract.schema_version} observed={schema_version or 'missing'}"
+        )
+    if contract.lane == "options":
+        _validate_options_manifest(manifest, contract=contract)
+    return contract
+
+
+def simulation_clickhouse_table_names(
+    *,
+    lane: str,
+    database: str,
+) -> dict[str, str]:
+    contract = simulation_lane_contract(lane)
+    return {
+        role: f"{database}.{table}"
+        for role, table in contract.clickhouse_simulation_table_by_role.items()
+    }
+
+
+def _validate_options_manifest(
+    manifest: Mapping[str, Any],
+    *,
+    contract: SimulationLaneContract,
+) -> None:
+    feed = _manifest_text(manifest.get("feed"))
+    if feed not in {"indicative", "opra"}:
+        raise RuntimeError(
+            f"options_simulation_feed_invalid observed={feed or 'missing'} expected=indicative|opra"
+        )
+
+    missing: list[str] = []
+    for key in contract.required_manifest_fields:
+        if not _manifest_value_present(manifest.get(key)):
+            missing.append(key)
+    if missing:
+        raise RuntimeError(
+            f"options_simulation_manifest_missing_fields:{','.join(missing)}"
+        )
+
+
+def _manifest_text(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    return text
+
+
+def _manifest_value_present(value: Any) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return bool(value.strip())
+    if isinstance(value, Mapping):
+        return len(value) > 0
+    if isinstance(value, list):
+        return len(value) > 0
+    return True
+
+
+__all__ = [
+    "EQUITY_SIMULATION_LANE",
+    "OPTIONS_SIMULATION_LANE",
+    "SIMULATION_LANE_BY_NAME",
+    "SimulationLaneContract",
+    "simulation_clickhouse_table_names",
+    "simulation_lane_contract",
+    "simulation_lane_contract_for_manifest",
+]

--- a/services/torghut/scripts/start_historical_simulation.py
+++ b/services/torghut/scripts/start_historical_simulation.py
@@ -41,6 +41,12 @@ from app.trading.completion import (
 )
 from app.trading.evaluation import build_fill_price_error_budget_report_v1
 from scripts import historical_simulation_verification as simulation_verification
+from scripts.simulation_lane_contracts import (
+    EQUITY_SIMULATION_LANE,
+    simulation_clickhouse_table_names,
+    simulation_lane_contract,
+    simulation_lane_contract_for_manifest,
+)
 
 APPLY_CONFIRMATION_PHRASE = 'START_HISTORICAL_SIMULATION'
 DEFAULT_NAMESPACE = 'torghut'
@@ -53,35 +59,9 @@ DEFAULT_SIM_TORGHUT_SERVICE = 'torghut-sim'
 DEFAULT_SIM_FORECAST_SERVICE = 'torghut-forecast-sim'
 DEFAULT_OUTPUT_ROOT = Path('artifacts/torghut/simulations')
 
-PRODUCTION_TOPIC_BY_ROLE = {
-    'trades': 'torghut.trades.v1',
-    'quotes': 'torghut.quotes.v1',
-    'bars': 'torghut.bars.1m.v1',
-    'status': 'torghut.status.v1',
-    'ta_microbars': 'torghut.ta.bars.1s.v1',
-    'ta_signals': 'torghut.ta.signals.v1',
-    'ta_status': 'torghut.ta.status.v1',
-    'order_updates': 'torghut.trade-updates.v1',
-}
-
-SIMULATION_TOPIC_BY_ROLE = {
-    'trades': 'torghut.sim.trades.v1',
-    'quotes': 'torghut.sim.quotes.v1',
-    'bars': 'torghut.sim.bars.1m.v1',
-    'status': 'torghut.sim.status.v1',
-    'ta_microbars': 'torghut.sim.ta.bars.1s.v1',
-    'ta_signals': 'torghut.sim.ta.signals.v1',
-    'ta_status': 'torghut.sim.ta.status.v1',
-    'order_updates': 'torghut.sim.trade-updates.v1',
-}
-
-TA_TOPIC_KEY_BY_ROLE = {
-    'trades': 'TA_TRADES_TOPIC',
-    'quotes': 'TA_QUOTES_TOPIC',
-    'bars': 'TA_BARS1M_TOPIC',
-    'ta_microbars': 'TA_MICROBARS_TOPIC',
-    'ta_signals': 'TA_SIGNALS_TOPIC',
-}
+PRODUCTION_TOPIC_BY_ROLE = dict(EQUITY_SIMULATION_LANE.source_topic_by_role)
+SIMULATION_TOPIC_BY_ROLE = dict(EQUITY_SIMULATION_LANE.simulation_topic_by_role)
+TA_TOPIC_KEY_BY_ROLE = dict(EQUITY_SIMULATION_LANE.ta_topic_key_by_role)
 
 TORGHUT_ENV_KEYS = [
     'DB_DSN',
@@ -162,7 +142,6 @@ DEFAULT_ROLLOUTS_VERIFY_TIMEOUT_SECONDS = 1800
 DEFAULT_ROLLOUTS_VERIFY_POLL_SECONDS = 5
 SIMULATION_RUNTIME_LOCK_NAME = 'torghut-historical-simulation-lock'
 SIMULATION_CLICKHOUSE_SCHEMA_SOURCE_DATABASE = 'torghut'
-SIMULATION_CLICKHOUSE_RUNTIME_TABLES = ('ta_microbars', 'ta_signals')
 SIMULATION_CLICKHOUSE_TABLE_VISIBILITY_ATTEMPTS = 10
 SIMULATION_CLICKHOUSE_TABLE_VISIBILITY_SLEEP_SECONDS = 0.2
 TRANSIENT_POSTGRES_ERROR_PATTERNS = (
@@ -335,6 +314,7 @@ class SimulationResources:
     run_id: str
     run_token: str
     dataset_id: str
+    lane: str
     target_mode: str
     namespace: str
     ta_configmap: str
@@ -348,6 +328,7 @@ class SimulationResources:
     ta_group_id: str
     order_feed_group_id: str
     clickhouse_db: str
+    clickhouse_table_by_role: dict[str, str]
     clickhouse_signal_table: str
     clickhouse_price_table: str
 
@@ -1031,7 +1012,36 @@ def _merge_topics(
     return merged
 
 
+def _ta_topic_key_by_role(*, lane: str, manifest: Mapping[str, Any]) -> dict[str, str]:
+    lane_contract = simulation_lane_contract(lane)
+    ta_config = _as_mapping(manifest.get('ta_config'))
+    overrides = _as_mapping(ta_config.get('topic_key_by_role'))
+    return _merge_topics(lane_contract.ta_topic_key_by_role, overrides)
+
+
+def _ta_clickhouse_url_key(*, lane: str, manifest: Mapping[str, Any]) -> str:
+    lane_contract = simulation_lane_contract(lane)
+    ta_config = _as_mapping(manifest.get('ta_config'))
+    return _as_text(ta_config.get('clickhouse_url_key')) or lane_contract.ta_clickhouse_url_key
+
+
+def _ta_group_id_key(*, lane: str, manifest: Mapping[str, Any]) -> str:
+    lane_contract = simulation_lane_contract(lane)
+    ta_config = _as_mapping(manifest.get('ta_config'))
+    return _as_text(ta_config.get('group_id_key')) or lane_contract.ta_group_id_key
+
+
+def _ta_auto_offset_reset_key(*, lane: str, manifest: Mapping[str, Any]) -> str:
+    lane_contract = simulation_lane_contract(lane)
+    ta_config = _as_mapping(manifest.get('ta_config'))
+    return (
+        _as_text(ta_config.get('auto_offset_reset_key'))
+        or lane_contract.ta_auto_offset_reset_key
+    )
+
+
 def _build_resources(run_id: str, manifest: Mapping[str, Any]) -> SimulationResources:
+    lane_contract = simulation_lane_contract_for_manifest(manifest)
     run_token = _normalize_run_token(run_id)
     dataset_id = _as_text(manifest.get('dataset_id'))
     if not dataset_id:
@@ -1042,15 +1052,20 @@ def _build_resources(run_id: str, manifest: Mapping[str, Any]) -> SimulationReso
     if target_mode not in {'dedicated_service', 'in_place'}:
         raise RuntimeError('runtime.target_mode must be one of: dedicated_service,in_place')
     output_root_raw = _as_text(runtime.get('output_root'))
-    output_root = Path(output_root_raw) if output_root_raw else DEFAULT_OUTPUT_ROOT
+    if output_root_raw:
+        output_root = Path(output_root_raw)
+    elif lane_contract.lane != 'equity':
+        output_root = DEFAULT_OUTPUT_ROOT / lane_contract.lane
+    else:
+        output_root = DEFAULT_OUTPUT_ROOT
 
     source_topics = _merge_topics(
-        PRODUCTION_TOPIC_BY_ROLE,
+        lane_contract.source_topic_by_role,
         _as_mapping(manifest.get('source_topics')),
     )
     simulation_topic_overrides = _as_mapping(manifest.get('simulation_topics'))
     simulation_topics = _merge_topics(
-        SIMULATION_TOPIC_BY_ROLE,
+        lane_contract.simulation_topic_by_role,
         simulation_topic_overrides,
     )
     for role, topic in list(simulation_topics.items()):
@@ -1059,10 +1074,8 @@ def _build_resources(run_id: str, manifest: Mapping[str, Any]) -> SimulationReso
         simulation_topics[role] = f'{topic}.{run_token}'
 
     replay_topic_by_source_topic = {
-        source_topics['trades']: simulation_topics['trades'],
-        source_topics['quotes']: simulation_topics['quotes'],
-        source_topics['bars']: simulation_topics['bars'],
-        source_topics['status']: simulation_topics['status'],
+        source_topics[role]: simulation_topics[role]
+        for role in lane_contract.replay_roles
     }
 
     clickhouse_cfg = _as_mapping(manifest.get('clickhouse'))
@@ -1070,8 +1083,12 @@ def _build_resources(run_id: str, manifest: Mapping[str, Any]) -> SimulationReso
         _as_text(clickhouse_cfg.get('simulation_database'))
         or f'torghut_sim_{run_token}'
     )
-    clickhouse_signal_table = f'{clickhouse_db}.ta_signals'
-    clickhouse_price_table = f'{clickhouse_db}.ta_microbars'
+    clickhouse_table_by_role = simulation_clickhouse_table_names(
+        lane=lane_contract.lane,
+        database=clickhouse_db,
+    )
+    clickhouse_signal_table = clickhouse_table_by_role[lane_contract.signal_table_role]
+    clickhouse_price_table = clickhouse_table_by_role[lane_contract.price_table_role]
 
     default_ta_configmap = DEFAULT_SIM_TA_CONFIGMAP if target_mode == 'dedicated_service' else DEFAULT_TA_CONFIGMAP
     default_ta_deployment = DEFAULT_SIM_TA_DEPLOYMENT if target_mode == 'dedicated_service' else DEFAULT_TA_DEPLOYMENT
@@ -1081,11 +1098,18 @@ def _build_resources(run_id: str, manifest: Mapping[str, Any]) -> SimulationReso
     default_forecast_service = (
         DEFAULT_SIM_FORECAST_SERVICE if target_mode == 'dedicated_service' else 'torghut-forecast'
     )
+    ta_group_prefix = 'torghut-options-ta-sim' if lane_contract.lane == 'options' else 'torghut-ta-sim'
+    order_feed_group_prefix = (
+        'torghut-options-order-feed-sim'
+        if lane_contract.lane == 'options'
+        else 'torghut-order-feed-sim'
+    )
 
     return SimulationResources(
         run_id=run_id,
         run_token=run_token,
         dataset_id=dataset_id,
+        lane=lane_contract.lane,
         target_mode=target_mode,
         namespace=_as_text(runtime.get('namespace')) or DEFAULT_NAMESPACE,
         ta_configmap=_as_text(runtime.get('ta_configmap')) or default_ta_configmap,
@@ -1098,9 +1122,10 @@ def _build_resources(run_id: str, manifest: Mapping[str, Any]) -> SimulationReso
         source_topic_by_role=source_topics,
         simulation_topic_by_role=simulation_topics,
         replay_topic_by_source_topic=replay_topic_by_source_topic,
-        ta_group_id=f'torghut-ta-sim-{run_token}',
-        order_feed_group_id=f'torghut-order-feed-sim-{run_token}',
+        ta_group_id=f'{ta_group_prefix}-{run_token}',
+        order_feed_group_id=f'{order_feed_group_prefix}-{run_token}',
         clickhouse_db=clickhouse_db,
+        clickhouse_table_by_role=clickhouse_table_by_role,
         clickhouse_signal_table=clickhouse_signal_table,
         clickhouse_price_table=clickhouse_price_table,
     )
@@ -2084,6 +2109,7 @@ def _build_plan_report(
         'status': 'ok',
         'run_id': resources.run_id,
         'dataset_id': resources.dataset_id,
+        'lane': resources.lane,
         'resources': {
             'namespace': resources.namespace,
             'ta_configmap': resources.ta_configmap,
@@ -2095,6 +2121,7 @@ def _build_plan_report(
             'ta_group_id': resources.ta_group_id,
             'order_feed_group_id': resources.order_feed_group_id,
             'clickhouse_database': resources.clickhouse_db,
+            'clickhouse_tables': resources.clickhouse_table_by_role,
             'clickhouse_signal_table': resources.clickhouse_signal_table,
             'clickhouse_price_table': resources.clickhouse_price_table,
             'postgres_database': postgres_config.simulation_db,
@@ -2279,10 +2306,13 @@ def _ensure_clickhouse_runtime_tables(
     *,
     config: ClickHouseRuntimeConfig,
     database: str,
+    lane: str = 'equity',
 ) -> None:
+    lane_contract = simulation_lane_contract(lane)
     endpoint_configs = _clickhouse_query_configs(config)
-    for table in SIMULATION_CLICKHOUSE_RUNTIME_TABLES:
-        source_table = f'{SIMULATION_CLICKHOUSE_SCHEMA_SOURCE_DATABASE}.{table}'
+    for role, table in lane_contract.clickhouse_simulation_table_by_role.items():
+        source_basename = lane_contract.clickhouse_source_table_by_role[role]
+        source_table = f'{SIMULATION_CLICKHOUSE_SCHEMA_SOURCE_DATABASE}.{source_basename}'
         source_ddl = _show_create_clickhouse_table(config=endpoint_configs[0], table=source_table)
         create_query = _rewrite_clickhouse_table_ddl_for_simulation(
             source_ddl=source_ddl,
@@ -2606,19 +2636,20 @@ def _configure_ta_for_simulation(
     clickhouse_config: ClickHouseRuntimeConfig,
     clickhouse_database: str,
     auto_offset_reset: str,
+    manifest: Mapping[str, Any],
 ) -> None:
     updates: dict[str, str] = {
-        'TA_GROUP_ID': resources.ta_group_id,
-        'TA_AUTO_OFFSET_RESET': auto_offset_reset,
+        _ta_group_id_key(lane=resources.lane, manifest=manifest): resources.ta_group_id,
+        _ta_auto_offset_reset_key(lane=resources.lane, manifest=manifest): auto_offset_reset,
     }
 
-    for role, key in TA_TOPIC_KEY_BY_ROLE.items():
+    for role, key in _ta_topic_key_by_role(lane=resources.lane, manifest=manifest).items():
         topic = resources.simulation_topic_by_role.get(role)
         if not topic:
             continue
         updates[key] = topic
 
-    updates['TA_CLICKHOUSE_URL'] = _clickhouse_jdbc_url_for_database(
+    updates[_ta_clickhouse_url_key(lane=resources.lane, manifest=manifest)] = _clickhouse_jdbc_url_for_database(
         clickhouse_config.http_url,
         clickhouse_database,
     )
@@ -3542,7 +3573,11 @@ def _apply(
         clickhouse_database_precreated = _clickhouse_database_precreated(manifest)
         if not clickhouse_database_precreated:
             _ensure_clickhouse_database(config=clickhouse_config, database=resources.clickhouse_db)
-        _ensure_clickhouse_runtime_tables(config=clickhouse_config, database=resources.clickhouse_db)
+        _ensure_clickhouse_runtime_tables(
+            config=clickhouse_config,
+            database=resources.clickhouse_db,
+            lane=resources.lane,
+        )
         postgres_database_precreated = _postgres_database_precreated(manifest)
         if not postgres_database_precreated:
             _ensure_postgres_database(postgres_config)
@@ -3568,6 +3603,7 @@ def _apply(
             clickhouse_config=clickhouse_config,
             clickhouse_database=resources.clickhouse_db,
             auto_offset_reset=auto_offset_reset,
+            manifest=manifest,
         )
         ta_restart_nonce = _restart_ta_deployment(resources, desired_state='running')
 

--- a/services/torghut/tests/test_analyze_historical_simulation.py
+++ b/services/torghut/tests/test_analyze_historical_simulation.py
@@ -2,14 +2,46 @@ from __future__ import annotations
 
 from decimal import Decimal
 from unittest import TestCase
+from unittest.mock import patch
 
 from scripts.analyze_historical_simulation import (
+    _build_last_price_map,
     _extract_run_scope_decisions,
     _fifo_trade_pnl,
 )
+from scripts.start_historical_simulation import ClickHouseRuntimeConfig
 
 
 class TestAnalyzeHistoricalSimulation(TestCase):
+    def test_build_last_price_map_uses_lane_specific_price_table(self) -> None:
+        captured_queries: list[str] = []
+
+        def _fake_clickhouse_query(*, config, query):  # type: ignore[no-untyped-def]
+            _ = config
+            captured_queries.append(query)
+            return 200, 'AAPL250321C00200000\t1.55\n'
+
+        with patch(
+            'scripts.analyze_historical_simulation._http_clickhouse_query',
+            side_effect=_fake_clickhouse_query,
+        ):
+            prices = _build_last_price_map(
+                clickhouse_config=ClickHouseRuntimeConfig(
+                    http_url='http://clickhouse:8123',
+                    username=None,
+                    password=None,
+                ),
+                price_table='torghut_sim_options.sim_options_contract_bars_1s',
+                tca_rows=[],
+                execution_rows=[],
+            )
+
+        self.assertEqual(prices['AAPL250321C00200000'], Decimal('1.55'))
+        self.assertIn(
+            'FROM torghut_sim_options.sim_options_contract_bars_1s',
+            captured_queries[0],
+        )
+
     def test_extract_run_scope_decisions_prefers_matching_simulation_context(self) -> None:
         decisions = [
             {

--- a/services/torghut/tests/test_start_historical_simulation.py
+++ b/services/torghut/tests/test_start_historical_simulation.py
@@ -95,6 +95,76 @@ class TestStartHistoricalSimulation(TestCase):
             'torghut.sim.trades.v1.sim_2026_02_27_01',
         )
 
+    def test_build_resources_derives_options_lane_isolation_names(self) -> None:
+        resources = _build_resources(
+            'options-sim-2026-03-06-open',
+            {
+                'schema_version': 'torghut.options-simulation-manifest.v1',
+                'lane': 'options',
+                'dataset_id': 'torghut-options-smoke-open-30m-20260306',
+                'feed': 'indicative',
+                'underlyings': ['AAPL', 'MSFT'],
+                'contract_policy': {
+                    'dte_min': 5,
+                    'dte_max': 45,
+                    'option_types': ['call', 'put'],
+                },
+                'catalog_snapshot_ref': 'artifacts/options/catalog-snapshot.json',
+                'raw_source_policy': {
+                    'prefer_kafka': True,
+                },
+                'cost_model': {
+                    'contract_multiplier': 100,
+                },
+                'proof_gates': {
+                    'minimum_contracts': 10,
+                },
+            },
+        )
+        self.assertEqual(resources.lane, 'options')
+        self.assertEqual(resources.ta_group_id, 'torghut-options-ta-sim-options_sim_2026_03_06_open')
+        self.assertEqual(
+            resources.order_feed_group_id,
+            'torghut-options-order-feed-sim-options_sim_2026_03_06_open',
+        )
+        self.assertEqual(
+            resources.simulation_topic_by_role['contracts'],
+            'torghut.sim.options.contracts.v1.options_sim_2026_03_06_open',
+        )
+        self.assertEqual(
+            resources.replay_topic_by_source_topic['torghut.options.contracts.v1'],
+            'torghut.sim.options.contracts.v1.options_sim_2026_03_06_open',
+        )
+        self.assertEqual(
+            resources.clickhouse_signal_table,
+            'torghut_sim_options_sim_2026_03_06_open.sim_options_contract_features',
+        )
+        self.assertEqual(
+            resources.clickhouse_price_table,
+            'torghut_sim_options_sim_2026_03_06_open.sim_options_contract_bars_1s',
+        )
+        self.assertEqual(
+            resources.clickhouse_table_by_role['surface'],
+            'torghut_sim_options_sim_2026_03_06_open.sim_options_surface_features',
+        )
+        self.assertTrue(str(resources.output_root).endswith('artifacts/torghut/simulations/options'))
+
+    def test_build_resources_rejects_options_manifest_missing_required_fields(self) -> None:
+        with self.assertRaisesRegex(
+            RuntimeError,
+            'options_simulation_manifest_missing_fields:contract_policy,catalog_snapshot_ref,raw_source_policy,cost_model,proof_gates',
+        ):
+            _build_resources(
+                'options-sim-1',
+                {
+                    'schema_version': 'torghut.options-simulation-manifest.v1',
+                    'lane': 'options',
+                    'dataset_id': 'dataset-a',
+                    'feed': 'indicative',
+                    'underlyings': ['AAPL'],
+                },
+            )
+
     def test_build_postgres_runtime_config_uses_template(self) -> None:
         config = _build_postgres_runtime_config(
             {
@@ -1814,6 +1884,38 @@ class TestStartHistoricalSimulation(TestCase):
                 ta_data={'TA_GROUP_ID': 'torghut-ta-main'},
             )
 
+    def test_verify_isolation_guards_accepts_options_auxiliary_tables(self) -> None:
+        resources = _build_resources(
+            'options-sim-1',
+            {
+                'schema_version': 'torghut.options-simulation-manifest.v1',
+                'lane': 'options',
+                'dataset_id': 'dataset-a',
+                'feed': 'indicative',
+                'underlyings': ['AAPL'],
+                'contract_policy': {'dte_min': 5, 'dte_max': 45},
+                'catalog_snapshot_ref': 'artifacts/options/catalog.json',
+                'raw_source_policy': {'prefer_kafka': True},
+                'cost_model': {'contract_multiplier': 100},
+                'proof_gates': {'minimum_contracts': 5},
+            },
+        )
+        postgres_config = PostgresRuntimeConfig(
+            admin_dsn='postgresql://torghut:secret@localhost:5432/postgres',
+            simulation_dsn='postgresql://torghut:secret@localhost:5432/torghut_sim_options_sim_1',
+            simulation_db='torghut_sim_options_sim_1',
+            migrations_command='uv run --frozen alembic upgrade heads',
+        )
+
+        report = _verify_isolation_guards(
+            resources=resources,
+            postgres_config=postgres_config,
+            ta_data={'OPTIONS_TA_GROUP_ID': 'torghut-options-ta-main'},
+        )
+
+        self.assertEqual(report['lane'], 'options')
+        self.assertTrue(report['auxiliary_tables_isolated'])
+
     def test_replay_dump_ignores_stale_marker_when_dump_changes(self) -> None:
         resources = _build_resources(
             'sim-1',
@@ -2871,6 +2973,7 @@ class TestStartHistoricalSimulation(TestCase):
                 'TA_TRADES_TOPIC': 'torghut.sim.trades.v1.sim_2026_03_06_open_hour',
                 'TA_QUOTES_TOPIC': 'torghut.sim.quotes.v1.sim_2026_03_06_open_hour',
                 'TA_BARS1M_TOPIC': 'torghut.sim.bars.1m.v1.sim_2026_03_06_open_hour',
+                'TA_MICROBARS_TOPIC': 'torghut.sim.ta.bars.1s.v1.sim_2026_03_06_open_hour',
                 'TA_SIGNALS_TOPIC': 'torghut.sim.ta.signals.v1.sim_2026_03_06_open_hour',
                 'TA_CLICKHOUSE_URL': 'jdbc:clickhouse://clickhouse/torghut_sim_2026_03_06_open_hour',
             }
@@ -2913,6 +3016,128 @@ class TestStartHistoricalSimulation(TestCase):
         self.assertEqual(report['runtime_state'], 'ready')
         self.assertEqual(report['environment_state'], 'complete')
         self.assertEqual(report['torghut_service']['name'], 'torghut-sim')
+        self.assertTrue(all(report['ta_runtime_config'].values()))
+
+    def test_runtime_verify_accepts_options_lane_topics_and_tables(self) -> None:
+        manifest = {
+            'schema_version': 'torghut.options-simulation-manifest.v1',
+            'lane': 'options',
+            'feed': 'indicative',
+            'underlyings': ['AAPL'],
+            'contract_policy': {'dte_min': 5, 'dte_max': 45},
+            'catalog_snapshot_ref': 'artifacts/options/catalog.json',
+            'raw_source_policy': {'prefer_kafka': True},
+            'cost_model': {'contract_multiplier': 100},
+            'proof_gates': {'minimum_contracts': 5},
+            'window': {
+                'start': '2026-03-06T14:30:00Z',
+                'end': '2026-03-06T15:00:00Z',
+            },
+        }
+        resources = _build_resources(
+            'options-sim-2026-03-06-open',
+            {
+                **manifest,
+                'dataset_id': 'dataset-a',
+                'runtime': {
+                    'target_mode': 'dedicated_service',
+                    'namespace': 'torghut',
+                    'ta_configmap': 'torghut-options-ta-sim-config',
+                    'ta_deployment': 'torghut-options-ta-sim',
+                    'torghut_service': 'torghut-sim',
+                    'torghut_forecast_service': 'torghut-forecast-sim',
+                },
+            },
+        )
+        kservice_payload = {
+            'spec': {
+                'template': {
+                    'spec': {
+                        'containers': [
+                            {
+                                'name': 'user-container',
+                                'env': [
+                                    {'name': 'TRADING_ENABLED', 'value': 'true'},
+                                    {'name': 'TRADING_SIMULATION_ENABLED', 'value': 'true'},
+                                    {'name': 'TRADING_SIGNAL_TABLE', 'value': resources.clickhouse_signal_table},
+                                    {'name': 'TRADING_PRICE_TABLE', 'value': resources.clickhouse_price_table},
+                                    {'name': 'TRADING_ORDER_FEED_ENABLED', 'value': 'true'},
+                                    {
+                                        'name': 'TRADING_ORDER_FEED_TOPIC',
+                                        'value': resources.simulation_topic_by_role['order_updates'],
+                                    },
+                                    {
+                                        'name': 'TRADING_SIMULATION_ORDER_UPDATES_TOPIC',
+                                        'value': resources.simulation_topic_by_role['order_updates'],
+                                    },
+                                    {'name': 'TRADING_SIMULATION_RUN_ID', 'value': resources.run_id},
+                                    {'name': 'TRADING_SIGNAL_ALLOWED_SOURCES', 'value': 'ws,ta'},
+                                ],
+                            }
+                        ]
+                    }
+                }
+            },
+            'status': {
+                'latestReadyRevisionName': 'torghut-sim-00001',
+                'conditions': [
+                    {
+                        'type': 'Ready',
+                        'status': 'True',
+                    }
+                ],
+            },
+        }
+        ta_configmap_payload = {
+            'data': {
+                'TOPIC_OPTIONS_CONTRACTS': resources.simulation_topic_by_role['contracts'],
+                'TOPIC_OPTIONS_TRADES': resources.simulation_topic_by_role['trades'],
+                'TOPIC_OPTIONS_QUOTES': resources.simulation_topic_by_role['quotes'],
+                'TOPIC_OPTIONS_SNAPSHOTS': resources.simulation_topic_by_role['snapshots'],
+                'TOPIC_OPTIONS_STATUS': resources.simulation_topic_by_role['status'],
+                'TOPIC_OPTIONS_TA_CONTRACT_BARS': resources.simulation_topic_by_role['ta_contract_bars'],
+                'TOPIC_OPTIONS_TA_CONTRACT_FEATURES': resources.simulation_topic_by_role['ta_contract_features'],
+                'TOPIC_OPTIONS_TA_SURFACE_FEATURES': resources.simulation_topic_by_role['ta_surface_features'],
+                'TOPIC_OPTIONS_TA_STATUS': resources.simulation_topic_by_role['ta_status'],
+                'OPTIONS_TA_CLICKHOUSE_URL': 'jdbc:clickhouse://clickhouse/torghut_sim_options_sim_2026_03_06_open',
+            }
+        }
+
+        with (
+            patch(
+                'scripts.historical_simulation_verification._kubectl_json',
+                side_effect=[kservice_payload, ta_configmap_payload],
+            ),
+            patch(
+                'scripts.historical_simulation_verification._deployment_replica_health',
+                side_effect=[
+                    {
+                        'name': 'torghut-sim-00001-deployment',
+                        'ready_replicas': 1,
+                        'available_replicas': 1,
+                        'replicas': 1,
+                    },
+                    {
+                        'name': 'torghut-forecast-sim',
+                        'ready_replicas': 1,
+                        'available_replicas': 1,
+                        'replicas': 1,
+                    },
+                ],
+            ),
+            patch(
+                'scripts.historical_simulation_verification._flink_runtime_health',
+                return_value={
+                    'name': 'torghut-options-ta-sim',
+                    'desired_state': 'running',
+                    'lifecycle_state': 'RUNNING',
+                    'job_manager_status': 'DEPLOYED',
+                },
+            ),
+        ):
+            report = _runtime_verify(resources=resources, manifest=manifest)
+
+        self.assertEqual(report['runtime_state'], 'ready')
         self.assertTrue(all(report['ta_runtime_config'].values()))
 
     def test_runtime_verify_rejects_trading_disabled_sim_revision(self) -> None:
@@ -2974,6 +3199,7 @@ class TestStartHistoricalSimulation(TestCase):
                 'TA_TRADES_TOPIC': 'torghut.sim.trades.v1.sim_2026_03_06_open_hour',
                 'TA_QUOTES_TOPIC': 'torghut.sim.quotes.v1.sim_2026_03_06_open_hour',
                 'TA_BARS1M_TOPIC': 'torghut.sim.bars.1m.v1.sim_2026_03_06_open_hour',
+                'TA_MICROBARS_TOPIC': 'torghut.sim.ta.bars.1s.v1.sim_2026_03_06_open_hour',
                 'TA_SIGNALS_TOPIC': 'torghut.sim.ta.signals.v1.sim_2026_03_06_open_hour',
                 'TA_CLICKHOUSE_URL': 'jdbc:clickhouse://clickhouse/torghut_sim_2026_03_06_open_hour',
             }
@@ -3076,6 +3302,7 @@ class TestStartHistoricalSimulation(TestCase):
                 'TA_TRADES_TOPIC': 'torghut.sim.trades.v1.sim_2026_03_06_open_hour_r18',
                 'TA_QUOTES_TOPIC': 'torghut.sim.quotes.v1.sim_2026_03_06_open_hour_r18',
                 'TA_BARS1M_TOPIC': 'torghut.sim.bars.1m.v1.sim_2026_03_06_open_hour_r18',
+                'TA_MICROBARS_TOPIC': 'torghut.sim.ta.bars.1s.v1.sim_2026_03_06_open_hour_r18',
                 'TA_SIGNALS_TOPIC': 'torghut.sim.ta.signals.v1.sim_2026_03_06_open_hour_r18',
                 'TA_CLICKHOUSE_URL': 'jdbc:clickhouse://clickhouse/torghut_sim_2026_03_06_open_hour_r18',
             }
@@ -3178,6 +3405,7 @@ class TestStartHistoricalSimulation(TestCase):
                 'TA_TRADES_TOPIC': 'torghut.sim.trades.v1.sim_2026_03_06_open_hour',
                 'TA_QUOTES_TOPIC': 'torghut.sim.quotes.v1.sim_2026_03_06_open_hour',
                 'TA_BARS1M_TOPIC': 'torghut.sim.bars.1m.v1.sim_2026_03_06_open_hour',
+                'TA_MICROBARS_TOPIC': 'torghut.sim.ta.bars.1s.v1.sim_2026_03_06_open_hour',
                 'TA_SIGNALS_TOPIC': 'torghut.sim.ta.signals.v1.sim_2026_03_06_open_hour',
                 'TA_CLICKHOUSE_URL': 'jdbc:clickhouse://clickhouse/torghut_sim_2026_03_06_open_hour',
             }


### PR DESCRIPTION
## Summary

- Added shared historical-simulation lane contracts so Torghut can derive options-specific replay topics, TA config keys, and isolated ClickHouse tables from the manifest lane.
- Made simulation planning, runtime configuration, verification, teardown checks, and profitability analysis lane-aware for `lane: options` runs.
- Added options smoke/full-day proof manifests, README guidance, and regression tests covering options resource isolation, manifest validation, verifier behavior, and analyzer price-table selection.

## Related Issues

None. Tracking doc: https://github.com/proompteng/lab/blob/main/docs/torghut/design-system/v6/36-options-simulation-replay-and-profitability-proof-lane-2026-03-08.md

## Testing

- `cd services/torghut && /tmp/torghut-venv/bin/uv lock --check`
- `cd services/torghut && /tmp/torghut-venv/bin/uv sync --python 3.12 --frozen --extra dev`
- `cd services/torghut && /tmp/torghut-venv/bin/uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && /tmp/torghut-venv/bin/uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && /tmp/torghut-venv/bin/uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && /tmp/torghut-venv/bin/uv run --frozen python -m compileall app`
- `cd services/torghut && /tmp/torghut-venv/bin/uv run --frozen ruff check app tests scripts migrations`
- `cd services/torghut && /tmp/torghut-venv/bin/uv run --frozen python scripts/check_migration_graph.py`
- `cd services/torghut && /tmp/torghut-venv/bin/uv run --frozen python -m unittest discover -s tests -p 'test_*.py'`

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
