### PR TITLE
fix(torghut): harden ta sink recovery semantics

### DIFF
--- a/argocd/applications/torghut/ta-sim/flinkdeployment.yaml
+++ b/argocd/applications/torghut/ta-sim/flinkdeployment.yaml
@@ -113,7 +113,7 @@ spec:
                 name: torghut-ta-sim-config
           env:
             - name: TA_KAFKA_DELIVERY_GUARANTEE
-              value: EXACTLY_ONCE
+              value: AT_LEAST_ONCE
             - name: TA_KAFKA_USERNAME
               value: torghut-ws
             - name: TA_KAFKA_PASSWORD

--- a/argocd/applications/torghut/ta/flinkdeployment.yaml
+++ b/argocd/applications/torghut/ta/flinkdeployment.yaml
@@ -113,7 +113,7 @@ spec:
                 name: torghut-ta-config
           env:
             - name: TA_KAFKA_DELIVERY_GUARANTEE
-              value: EXACTLY_ONCE
+              value: AT_LEAST_ONCE
             - name: TA_KAFKA_USERNAME
               value: torghut-ws
             - name: TA_KAFKA_PASSWORD

--- a/docs/incidents/2026-03-09-torghut-ta-kafka-restore-stall-and-trading-emergency-stop.md
+++ b/docs/incidents/2026-03-09-torghut-ta-kafka-restore-stall-and-trading-emergency-stop.md
@@ -1,0 +1,114 @@
+# Incident Report: Torghut TA Kafka Restore Stall and Trading Emergency Stop
+
+- **Date**: 2026-03-09 (UTC)
+- **Severity**: High
+- **Services affected**: `torghut-ta` (Flink TA lane), `torghut` trading/autonomy runtime
+
+## Impact
+
+- Fresh TA outputs stopped advancing even though `torghut-ws` continued ingesting quotes and trades into Kafka.
+- Torghut trading entered and held `rollback.emergency_stop_active=true`, so no new decisions or executions were submitted.
+- Live mode remained enabled, but order submission was correctly blocked by stale-signal guardrails.
+
+## User-visible Symptoms
+
+- `GET /trading/status` showed:
+  - `signal_continuity.last_state=actionable_source_fault`
+  - `signal_continuity.last_reason=cursor_tail_stable`
+  - `rollback.emergency_stop_active=true`
+  - `rollback.emergency_stop_reason=signal_lag_exceeded:<seconds>`
+- `trade_decisions` and `executions` had no new rows in the incident window.
+- ClickHouse `torghut.ta_signals` and `torghut.ta_microbars` stopped advancing after `2026-03-06 21:59:08 UTC`.
+
+## Timeline (UTC)
+
+| Time | Event |
+| --- | --- |
+| 2026-03-09 07:07:41 | `torghut-ta` Flink job reached terminal `FAILED` state after exhausting restart attempts. |
+| 2026-03-09 07:07:41 | Job logs recorded `Timeout expired after 60000ms while awaiting InitProducerId` during Kafka exactly-once sink restore. |
+| 2026-03-09 13:30:03 | Torghut trading latched emergency stop on `signal_lag_exceeded`. |
+| 2026-03-09 15:28 | Live diagnosis confirmed `torghut-ws` was still producing Kafka traffic while TA outputs in ClickHouse remained stale. |
+| 2026-03-09 15:30 | Emergency reconcile initiated on `FlinkDeployment/torghut-ta` by bumping `spec.restartNonce`. |
+| 2026-03-09 15:32:56 | Flink resubmitted `torghut-technical-analysis-flink` job `ab7064f6dd3a858abc138b5f8927c5cd`. |
+| 2026-03-09 15:33 | Job reached `RUNNING`; four taskmanagers came up and TA processing resumed. |
+| 2026-03-09 15:34:20 | Torghut cleared emergency stop automatically after fresh-signal recovery cycles completed. |
+| 2026-03-09 15:35:23 | Fresh `ta_signals` rows observed again in ClickHouse. |
+
+## Root Cause
+
+Primary root cause was a transactional Kafka sink restore failure in the TA Flink job:
+
+1. `torghut-ta` used `TA_KAFKA_DELIVERY_GUARANTEE=EXACTLY_ONCE`, which enabled transactional Kafka sinks for the
+   derived TA topics.
+2. During restore from externalized state, Kafka producer initialization stalled with
+   `Timeout expired after 60000ms while awaiting InitProducerId`.
+3. After the fixed-delay restart budget was exhausted, the Flink job remained failed and TA output topics/ClickHouse
+   sinks stopped advancing.
+4. Torghut trading correctly treated the stale TA lane as a safety fault and blocked submissions via emergency stop.
+
+## Contributing Factors
+
+1. The derived TA output path was already effectively at-least-once end-to-end because ClickHouse sinks are
+   non-transactional and rely on replacing/dedup-friendly storage semantics.
+2. The operational cost of transactional restore failure was high: one failed TA job disabled live trading even though
+   ingest remained healthy.
+3. Emergency live patches to `FlinkDeployment/torghut-ta` were subject to Argo reconciliation, so they were useful for
+   recovery but not durable by themselves.
+
+## Recovery Actions Taken (Live)
+
+1. Confirmed the failure boundary:
+   - `torghut-ws` logs showed active Kafka produce traffic.
+   - `torghut.ta_signals` and `torghut.ta_microbars` in ClickHouse were stale.
+   - Torghut `/trading/status` showed emergency stop on `signal_lag_exceeded`.
+2. Reconciled `FlinkDeployment/torghut-ta` to restart the TA jobmanager and resubmit the Flink application.
+3. Verified:
+   - Flink job `RUNNING`
+   - all four TA taskmanagers healthy
+   - fresh TA rows in ClickHouse
+   - Torghut emergency stop cleared automatically after recovery cycles
+
+## Durable Fixes Implemented (Repo)
+
+1. Switched the TA derived Kafka sinks from `EXACTLY_ONCE` to `AT_LEAST_ONCE` in:
+   - `argocd/applications/torghut/ta/flinkdeployment.yaml`
+   - `argocd/applications/torghut/ta-sim/flinkdeployment.yaml`
+2. Changed the TA runtime default delivery guarantee to `AT_LEAST_ONCE` in:
+   - `services/dorvud/technical-analysis-flink/src/main/kotlin/ai/proompteng/dorvud/ta/flink/FlinkTaConfig.kt`
+3. Updated operator-facing TA docs to reflect that the production TA lane now prioritizes availability and dedup-tolerant
+   recovery over transactional Kafka output semantics.
+
+## Why This Fix Is Correct
+
+- TA output topics are derived streams, not the system of record.
+- ClickHouse storage for TA outputs already uses `ReplicatedReplacingMergeTree` keyed by `(symbol, event_ts, seq)`,
+  which is designed to tolerate duplicate writes.
+- Torghut trading consumes the recovered read path through ClickHouse/status guardrails, so availability of fresh signals
+  is more important than transactional publication on the derived Kafka topics.
+- Removing Kafka transactions from TA sinks eliminates the `InitProducerId` restore dependency that caused this outage.
+
+## Validation Evidence
+
+- Live after recovery:
+  - `GET /trading/health` returned `status=ok`
+  - `GET /trading/status` returned `signal_continuity.last_state=signals_present`
+  - `rollback.emergency_stop_active=false`
+- Flink REST:
+  - job `ab7064f6dd3a858abc138b5f8927c5cd` reached `RUNNING`
+  - `40/40` tasks running
+- ClickHouse:
+  - fresh `torghut.ta_signals` rows observed after recovery
+- Argo:
+  - application `torghut` returned `Synced / Healthy / Succeeded`
+
+## Residual Notes
+
+- No immediate new `trade_decisions` or `executions` were observed in the first few minutes after recovery. At incident
+  close this was consistent with strategy conditions rather than an active platform fault.
+
+## Follow-up Actions
+
+1. Add alerting on TA job state transitions to `FAILED` before stale-signal guardrails accumulate for hours.
+2. Add an operator-visible metric or status field exposing the active TA Kafka delivery profile (`AT_LEAST_ONCE` vs
+   transactional) so runtime semantics are obvious during incident triage.
+3. Consider a controller-safe GitOps workflow for TA restart actuation so emergency reconciles do not race Argo.

--- a/docs/torghut/architecture.md
+++ b/docs/torghut/architecture.md
@@ -42,7 +42,7 @@ flowchart LR
   - `ta`: shared indicator utilities and schemas for downstream consumers (distinct from the Flink TA job; Flink still produces derived topics).
   - Single replica per Alpaca account to satisfy the single-connection constraint.
 - Kafka: Strimzi-managed, SASL/TLS; topics lz4, RF=3, partitions=1 per symbol.
-- Flink: 1.20.x via Operator 1.13.x; KafkaSource/Sink with exactly-once; checkpoints every 10 s to MinIO/S3.
+- Flink: 1.20.x via Operator 1.13.x; KafkaSource with at-least-once derived-topic sinks in the current profile; checkpoints every 10 s to MinIO/S3.
 - torghut main service: does **not** consume TA topics; TA is used via ClickHouse-backed APIs and external consumers.
 
 ### Version matrix

--- a/docs/torghut/design-system/v1/component-flink-ta-job.md
+++ b/docs/torghut/design-system/v1/component-flink-ta-job.md
@@ -59,7 +59,7 @@ flowchart LR
 | `TA_AUTO_OFFSET_RESET`        | Replay behavior      | `earliest`                                                      |
 | `TA_CHECKPOINT_DIR`           | Checkpoints          | `s3a://flink-checkpoints/torghut/technical-analysis`            |
 | `TA_SAVEPOINT_DIR`            | Savepoints           | `s3a://flink-checkpoints/torghut/technical-analysis/savepoints` |
-| `TA_KAFKA_DELIVERY_GUARANTEE` | Kafka sink semantics | `EXACTLY_ONCE`                                                  |
+| `TA_KAFKA_DELIVERY_GUARANTEE` | Kafka sink semantics | `AT_LEAST_ONCE`                                                 |
 | `TA_MAX_OUT_OF_ORDER_MS`      | Watermark tolerance  | `2000`                                                          |
 | `TA_CLICKHOUSE_URL`           | JDBC URL             | `jdbc:clickhouse://...:8123/torghut`                            |
 | `TA_CLICKHOUSE_BATCH_SIZE`    | Sink batching        | `500`                                                           |
@@ -72,6 +72,7 @@ flowchart LR
 - `execution.checkpointing.mode=EXACTLY_ONCE`
 - `execution.checkpointing.externalized-checkpoint-retention=RETAIN_ON_CANCELLATION`
 - `job.upgradeMode=last-state` (checkpoint-aware upgrades/restarts by default)
+- `TA_KAFKA_DELIVERY_GUARANTEE=AT_LEAST_ONCE` for derived TA topic availability
 
 ### Canonical replay/backfill workflow
 
@@ -84,16 +85,17 @@ non-destructive modes) is documented canonically in:
 
 The job supports Kafka delivery guarantees (see `FlinkTaConfig.kt`):
 
-- `TA_KAFKA_DELIVERY_GUARANTEE=EXACTLY_ONCE` (recommended)
-- `TA_KAFKA_TRANSACTION_TIMEOUT_MS` must exceed checkpoint interval and broker settings.
+- `TA_KAFKA_DELIVERY_GUARANTEE=AT_LEAST_ONCE` (current production default)
+- `TA_KAFKA_DELIVERY_GUARANTEE=EXACTLY_ONCE` remains available as an opt-in profile when transactional restore risk is acceptable.
+- `TA_KAFKA_TRANSACTION_TIMEOUT_MS` must exceed checkpoint interval and broker settings when the transactional profile is enabled.
 
 As deployed (2026-02-23):
 
-- `argocd/applications/torghut/ta/flinkdeployment.yaml` sets `TA_KAFKA_DELIVERY_GUARANTEE=EXACTLY_ONCE`.
+- `argocd/applications/torghut/ta/flinkdeployment.yaml` sets `TA_KAFKA_DELIVERY_GUARANTEE=AT_LEAST_ONCE`.
 - Required validation for replay/recovery posture:
-  - broker transaction settings and timeouts remain compatible,
-  - consumers that require committed visibility use `isolation.level=read_committed`,
-  - replay behavior and idempotency/dedup in ClickHouse remain intact (ClickHouse sink remains at-least-once).
+  - replay behavior and idempotency/dedup in ClickHouse remain intact (ClickHouse sink remains at-least-once),
+  - downstream consumers tolerate duplicate derived-topic records by `(symbol,event_ts,seq)`,
+  - if the transactional profile is re-enabled, broker transaction settings and consumer isolation levels are reviewed explicitly.
 
 **Important:** ClickHouse JDBC sink is not transactional in the same way Kafka is; it must be treated as at-least-once.
 Storage keys/ORDER BY must allow dedup or “last write wins” semantics.

--- a/docs/torghut/design-system/v1/operations-ta-replay-and-recovery.md
+++ b/docs/torghut/design-system/v1/operations-ta-replay-and-recovery.md
@@ -33,7 +33,7 @@ Provide oncall operational procedures for recovering TA outputs when:
 - ClickHouse: `svc/torghut-clickhouse:8123` (auth via `Secret/torghut-clickhouse-auth`)
 - Checkpoints/savepoints: MinIO/S3 path from `state.checkpoints.dir` + `state.savepoints.dir` in `argocd/applications/torghut/ta/flinkdeployment.yaml`
 - Kafka topics (current names): `TA_TRADES_TOPIC`, `TA_QUOTES_TOPIC`, `TA_BARS1M_TOPIC`, `TA_MICROBARS_TOPIC`, `TA_SIGNALS_TOPIC` in `argocd/applications/torghut/ta/configmap.yaml`
-- Delivery guarantee: `TA_KAFKA_DELIVERY_GUARANTEE` is set in `argocd/applications/torghut/ta/flinkdeployment.yaml` (currently `EXACTLY_ONCE`).
+- Delivery guarantee: `TA_KAFKA_DELIVERY_GUARANTEE` is set in `argocd/applications/torghut/ta/flinkdeployment.yaml` (currently `AT_LEAST_ONCE`).
 
 ## Quick architecture reminder
 
@@ -106,6 +106,7 @@ This is a known production failure mode.
    - Emergency-only: `kubectl -n torghut patch flinkdeployment torghut-ta --type=merge -p '{"spec":{"restartNonce":<bump>}}'`
 5. Verify:
    - ClickHouse `max(event_ts)` advances in `torghut.ta_signals`.
+   - Flink REST reports the job `RUNNING` and taskmanagers allocated before clearing trading incident status.
 
 ## Procedure B: ClickHouse replicas read-only (keeper metadata loss)
 

--- a/docs/torghut/design-system/v1/torghut-autonomous-trading-system.md
+++ b/docs/torghut/design-system/v1/torghut-autonomous-trading-system.md
@@ -158,7 +158,7 @@ As deployed config is in:
 
 Delivery semantics:
 
-- Kafka is configured with `TA_KAFKA_DELIVERY_GUARANTEE=EXACTLY_ONCE`.
+- Kafka is configured with `TA_KAFKA_DELIVERY_GUARANTEE=AT_LEAST_ONCE` in the current production profile.
 - ClickHouse writes are at-least-once; design assumes duplicates are tolerable.
 
 Known production failure: ClickHouse disk pressure causing JDBC failures and TA job failure.

--- a/docs/torghut/flink-ta.md
+++ b/docs/torghut/flink-ta.md
@@ -38,7 +38,7 @@ Use Avro or JSON with Karapace; backward-compatible evolution.
   - Trades -> hopping 1s/1s to micro-bars (O/H/L/C/V, vwap).
   - Bars (1s + upstream 1m) -> EMA12/26 -> MACD; RSI14; Bollinger20/2; VWAP (session & rolling window); realized vol (30-60s); join with quotes for spread/imbalance.
   - Dedup optional: drop duplicates by trade id and (event_ts, symbol) for quotes/bars before aggregation.
-- Sinks: `KafkaSink` to TA topics with `delivery.guarantee=exactly-once`, idempotent/transactional; partitioner fixed (key=symbol).
+- Sinks: `KafkaSink` to TA topics with `delivery.guarantee=at-least-once` in the current production profile; transactional exactly-once remains opt-in; partitioner fixed (key=symbol).
 
 ### Window/indicator details
 
@@ -84,11 +84,11 @@ S3A properties (example):
 
 - Upgrade flow: trigger savepoint (or last-state), update image tag, redeploy; verify running and checkpointing.
 - Rollback: redeploy previous image with last-state or restore from savepoint.
-- On exactly-once sinks, prefer `--drain` or allow checkpoint to finish before shutdown to avoid in-flight txn aborts.
+- On transactional sink profiles, prefer `--drain` or allow checkpoint to finish before shutdown to avoid in-flight txn aborts.
 
 ### Sink settings (KafkaSink)
 
-- `deliveryGuarantee = EXACTLY_ONCE`
+- `deliveryGuarantee = AT_LEAST_ONCE` (current production profile)
 - `transaction.timeout.ms` > checkpoint timeout + failover (e.g., 120s)
 - `linger.ms` 20-50; `compression.type` lz4; `enable.idempotence` true
 - `acks=all`; `max.in.flight.requests.per.connection=5` (ok with idempotence)
@@ -124,7 +124,7 @@ Alert suggestions (Mimir/Alertmanager):
 
 - Replay FAKEPACA or recorded NVDA slice into Kafka; verify micro-bars and TA signals content and ordering.
 - Lag test: p99(now - event_ts) ≤500 ms.
-- Failure test: kill JM/TM, confirm restore from last checkpoint, no duplicate outputs (read_committed consumer).
+- Failure test: kill JM/TM, confirm restore from last checkpoint, and verify downstream dedup correctness on `(symbol,event_ts,seq)`.
 - Schema test: evolve additive field and confirm backward compatibility.
 - Load test: sustained message rate near expected peak; observe checkpoint duration, backpressure.
 
@@ -136,7 +136,7 @@ Alert suggestions (Mimir/Alertmanager):
 
 ## Consumer guidance (downstream)
 
-- Use `isolation.level=read_committed` when TA sink runs in exactly-once mode; can switch to read_uncommitted if at-least-once profile is enabled.
+- Use `isolation.level=read_uncommitted` or default consumer semantics for the at-least-once profile; use `read_committed` only if the transactional profile is explicitly enabled again.
 - Expect envelope fields (`event_ts`, `ingest_ts`, `seq`, `is_final`, `window`); be tolerant to additive fields.
 
 ## Mermaid (processing graph)

--- a/docs/torghut/low-latency-notes.md
+++ b/docs/torghut/low-latency-notes.md
@@ -58,8 +58,8 @@ Karapace usage: https://docs.aiven.io/docs/products/karapace/concepts/schema-reg
 
 ## Low-latency profile toggle
 
-- Default profile: exactly-once sinks, transactions on, checkpoints 10 s.
-- Low-latency profile: at-least-once sinks (disable transactions), buffer-timeout 5 ms, watermark interval 50 ms; downstream consumers must dedup.
+- Default profile: at-least-once sinks, checkpoints 10 s, downstream dedup on derived TA topics.
+- Transactional profile: exactly-once Kafka sinks, transactions on, and `read_committed` consumers when restore risk is acceptable.
 
 ## Alpaca WS constraints
 

--- a/docs/torghut/main-service-consumer.md
+++ b/docs/torghut/main-service-consumer.md
@@ -16,7 +16,7 @@ How the main torghut service should consume TA outputs and switch sources safely
 ## Client config
 
 - `enable.idempotence=true` (producer, if writing responses) - not required for consumer.
-- `isolation.level=read_committed` when TA sink uses transactions (default profile).
+- `isolation.level=read_committed` only if the TA sink is explicitly switched back to a transactional profile.
 - `auto.offset.reset=latest` for steady state; `earliest` for backfill/replay tools.
 - SASL/TLS from Strimzi KafkaUser secret; truststore mounted; set `ssl.endpoint.identification.algorithm=HTTPS`.
 

--- a/docs/torghut/system-design.md
+++ b/docs/torghut/system-design.md
@@ -95,10 +95,10 @@ flowchart LR
 
 ### Flink Checkpointing
 
-Flink checkpoints provide exactly-once semantics when configured with durable storage and connectors that support transactional semantics. Production guidance:
+Flink checkpoints preserve operator state consistently when configured with durable storage. End-to-end exactly-once still depends on transactional connectors and is not the current Torghut TA production profile. Production guidance:
 
 - Enable checkpointing and store checkpoints in durable storage (S3/MinIO). (Flink docs)
-- Use exactly-once checkpoints for TA pipelines. (Flink docs)
+- Use durable checkpoints for TA pipelines, and prefer at-least-once derived Kafka sinks when duplicate-tolerant consumers/storage already exist. (Flink docs)
 - Savepoints are the primary tool for upgrades and migrations. (Flink docs)
 
 ### Kafka Retention and Compaction

--- a/docs/torghut/test-harness.md
+++ b/docs/torghut/test-harness.md
@@ -55,5 +55,5 @@ kcat -b $KAFKA_BOOTSTRAP -t torghut.ta.signals.v1 \
 ## Acceptance checks
 
 - p99(now - event_ts) ≤ 500 ms (target)
-- No duplicate seq per symbol after restart (read_committed consumer)
+- Duplicate derived-topic records remain dedupable by `(symbol,event_ts,seq)` after restart
 - Checkpoint age < 2 × interval and sink txn failures = 0 during load

--- a/services/dorvud/technical-analysis-flink/src/main/kotlin/ai/proompteng/dorvud/ta/flink/FlinkTaConfig.kt
+++ b/services/dorvud/technical-analysis-flink/src/main/kotlin/ai/proompteng/dorvud/ta/flink/FlinkTaConfig.kt
@@ -116,7 +116,7 @@ data class FlinkTaConfig(
         s3Secure = envBool("TA_S3_SECURE", false),
         s3AccessKey = env("TA_S3_ACCESS_KEY"),
         s3SecretKey = env("TA_S3_SECRET_KEY"),
-        deliveryGuarantee = envDeliveryGuarantee("TA_KAFKA_DELIVERY_GUARANTEE", DeliveryGuarantee.EXACTLY_ONCE),
+        deliveryGuarantee = envDeliveryGuarantee("TA_KAFKA_DELIVERY_GUARANTEE", DeliveryGuarantee.AT_LEAST_ONCE),
         transactionTimeoutMs = envLong("TA_KAFKA_TRANSACTION_TIMEOUT_MS", 120_000),
         clickhouseUrl = clickhouseUrl,
         clickhouseUsername = env("TA_CLICKHOUSE_USERNAME", "torghut"),


### PR DESCRIPTION
## Summary

- Switch Torghut TA and TA-sim derived-topic Kafka sinks to `AT_LEAST_ONCE` and align the Flink TA runtime default with that production profile.
- Add a postmortem for the 2026-03-09 TA Kafka restore stall that froze TA outputs and triggered Torghut trading emergency stop.
- Update operator-facing TA docs to describe the new delivery profile, duplicate-tolerant expectations, and recovery validation steps.

## Related Issues

None

## Testing

- `mise exec java@21 -- ./gradlew :technical-analysis-flink:test --tests "ai.proompteng.dorvud.ta.flink.SerializationSchemasTest"`

## Screenshots (if applicable)

N/A

## Breaking Changes

TA derived Kafka sinks now default to and are deployed with `AT_LEAST_ONCE` delivery. Downstream consumers and operational validation should treat `(symbol, event_ts, seq)` as the dedup key for derived-topic replay/restart scenarios.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
