### PR TITLE
chore(torghut-options): promote ws image a999da7b

### DIFF
--- a/argocd/applications/torghut-options/ws/deployment.yaml
+++ b/argocd/applications/torghut-options/ws/deployment.yaml
@@ -29,7 +29,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-ws-options
-          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:db62663f3dae59c54ab99a78f63f35d830b3e5e6051d05477fa91f461f95f66a
+          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:6ac78ad7646c9eb18da73fd117ecf235e620741a384f3d5f2f6312c87ff464b6
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:
@@ -53,9 +53,9 @@ spec:
                   name: torghut-options
                   key: password
             - name: TORGHUT_WS_VERSION
-              value: main-2b9824ae
+              value: main-a999da7b
             - name: TORGHUT_WS_COMMIT
-              value: 2b9824ae0abd2fae9480e3b73ab8c73b4d5392d5
+              value: a999da7be6e8027b8a797b1df9ebde49a0ee6c36
             - name: JAVA_TOOL_OPTIONS
               value: -XX:+UseContainerSupport -XX:InitialRAMPercentage=40.0 -XX:MaxRAMPercentage=70.0 -XX:+ExitOnOutOfMemoryError
           ports:


### PR DESCRIPTION
## Summary
Promote the Torghut options websocket image into GitOps manifests.

- Source commit: `a999da7be6e8027b8a797b1df9ebde49a0ee6c36`
- Image tag: `a999da7b`
- Image digest: `sha256:6ac78ad7646c9eb18da73fd117ecf235e620741a384f3d5f2f6312c87ff464b6`