### PR TITLE
fix(rook-ceph): restore metadata device config

### DIFF
--- a/argocd/applications/local-path/patches/local-path-config.patch.yaml
+++ b/argocd/applications/local-path/patches/local-path-config.patch.yaml
@@ -9,10 +9,7 @@ data:
       "nodePathMap":[
         {
           "node":"talos-192-168-1-85",
-          "paths":[
-            "/var/mnt/local-path-provisioner",
-            "/var/mnt/local-path-provisioner-extra"
-          ]
+          "paths":["/var/mnt/local-path-provisioner"]
         },
         {
           "node":"talos-192-168-1-194",

--- a/argocd/applications/rook-ceph/cluster-values.yaml
+++ b/argocd/applications/rook-ceph/cluster-values.yaml
@@ -81,17 +81,19 @@ cephClusterSpec:
     deviceFilter: ""
     nodes:
       - name: talos-192-168-1-85
+        config:
+          metadataDevice: /dev/disk/by-id/nvme-CT4000P3PSSD8_2402E88D0863
         devices:
           - name: /dev/disk/by-id/ata-ST24000NM000C-3WD103_ZXA12R7C
           - name: /dev/disk/by-id/ata-ST24000NM000C-3WD103_ZXA0LKW9
           - name: /dev/disk/by-id/ata-ST24000NM000C-3WD103_ZXA0HS7E
       - name: talos-192-168-1-203
+        config:
+          metadataDevice: /dev/disk/by-id/nvme-KINGSTON_SNV3S1000G_50026B76878F0B27
         devices:
           - name: /dev/disk/by-id/ata-ST24000NM000C-3WD103_ZXA0NL5D
           - name: /dev/disk/by-id/ata-ST24000NM000C-3WD103_ZXA0MZ1M
           - name: /dev/disk/by-id/ata-ST24000NM000C-3WD103_ZXA0LVM9
-    config:
-      databaseSizeMB: "2048"
 
   disruptionManagement:
     managePodBudgets: true


### PR DESCRIPTION
## Summary

- restore the `local-path` config patch to remove the extra path on `talos-192-168-1-85`
- restore per-node Rook-Ceph `metadataDevice` settings for the two OSD hosts
- drop the stale cluster-wide `databaseSizeMB` override from the PR scope

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/rook-ceph >/tmp/rook-ceph-kustomize.yaml`
- `kustomize build argocd/applications/local-path >/tmp/local-path-kustomize.yaml`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
