### PR TITLE
chore(jangar): promote image d8da45c1

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 222eafb9
-  digest: sha256:b72547d1a19cb1118039dacbd36bab9060ad419bfef29fd0d8c9d8574906a38b
+  tag: d8da45c1
+  digest: sha256:4c1444d6a2cd632451dc0a082a9bb09dd82a56137cf88ccf9467788e57b3a70e
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 222eafb9
-    digest: sha256:4d42eb0876275f19bb745101bd4ecd96ccd24e84e048b57d3876e82510d546b4
+    tag: d8da45c1
+    digest: sha256:b5f7c4808ceb7960a1f63fdcc4cba6ca21773d5c50674c54ee3fd299b28bc304
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 222eafb9
-    digest: sha256:b72547d1a19cb1118039dacbd36bab9060ad419bfef29fd0d8c9d8574906a38b
+    tag: d8da45c1
+    digest: sha256:4c1444d6a2cd632451dc0a082a9bb09dd82a56137cf88ccf9467788e57b3a70e
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-11T07:37:16.837Z"
+    deploy.knative.dev/rollout: "2026-03-11T08:00:55Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-11T07:37:16.837Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-11T08:00:55Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -61,5 +61,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "8d9ea4cb2"
-    digest: sha256:53e1a29cef6376c5a2b86fa67be45b77936ec71e66c6a8237c9c761bcfefadef
+    newTag: "d8da45c1"
+    digest: sha256:4c1444d6a2cd632451dc0a082a9bb09dd82a56137cf88ccf9467788e57b3a70e


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `d8da45c10d5e1d02b0862b229bfcc61a49258a37`
- Image tag: `d8da45c1`
- Image digest: `sha256:4c1444d6a2cd632451dc0a082a9bb09dd82a56137cf88ccf9467788e57b3a70e`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`