### PR TITLE
fix(deploy): roll bumba and froussard

### DIFF
--- a/apps/froussard/Dockerfile
+++ b/apps/froussard/Dockerfile
@@ -22,6 +22,7 @@ COPY services ./services
 RUN bun install --filter @proompteng/discord --filter froussard --frozen-lockfile --ignore-scripts
 
 FROM deps AS build
+RUN bun run --filter @proompteng/otel build
 RUN bun run --filter @proompteng/discord build
 RUN bun run --filter froussard build
 
@@ -32,6 +33,7 @@ FROM oven/bun:${BUN_VERSION}-slim AS runtime
 ENV NODE_ENV=production
 WORKDIR /workspace
 COPY --from=prod-deps /workspace /workspace
+COPY --from=build /workspace/packages/otel/dist /workspace/packages/otel/dist
 COPY --from=build /workspace/apps/froussard/dist /workspace/apps/froussard/dist
 WORKDIR /workspace/apps/froussard
 EXPOSE 8080

--- a/argocd/applications/bumba/deployment.yaml
+++ b/argocd/applications/bumba/deployment.yaml
@@ -22,7 +22,7 @@ spec:
         app.kubernetes.io/name: bumba
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-02-09T03:09:48.289Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-11T07:59:47.653Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/bumba/kustomization.yaml
+++ b/argocd/applications/bumba/kustomization.yaml
@@ -6,5 +6,5 @@ resources:
   - deployment.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/bumba
-    newTag: sha-38424be
+    newTag: "d8da45c10"
     newName: registry.ide-newton.ts.net/lab/bumba

--- a/argocd/applications/froussard/knative-service.yaml
+++ b/argocd/applications/froussard/knative-service.yaml
@@ -20,7 +20,7 @@ spec:
       enableServiceLinks: false
       containers:
         - name: app
-          image: registry.ide-newton.ts.net/lab/froussard@sha256:95976cec5c63c5f77e4493b08048444aabcd904bc79e0b53f2b28fa5d5df6c65
+          image: registry.ide-newton.ts.net/lab/froussard@sha256:7bd24fb4c498eee5acd28ae7d0bf0fe2a40da23df918060149e0497d4ddd2c6d
           imagePullPolicy: Always
           ports:
             - containerPort: 8080
@@ -67,9 +67,9 @@ spec:
             - name: OTEL_SERVICE_NAMESPACE
               value: froussard
             - name: FROUSSARD_VERSION
-              value: v0.551.0-76-gc0ce50c3
+              value: v0.563.0-69-gd8da45c10
             - name: FROUSSARD_COMMIT
-              value: c0ce50c33f3f0d6197d33a76e1f78c434a03e618
+              value: d8da45c10d5e1d02b0862b229bfcc61a49258a37
             - name: LGTM_TEMPO_TRACES_ENDPOINT
               value: http://observability-tempo-gateway.observability.svc.cluster.local:4317
             - name: LGTM_MIMIR_METRICS_ENDPOINT


### PR DESCRIPTION
## Summary

- Deploy Bumba image `d8da45c10` and update its rollout annotation in Argo CD manifests.
- Fix the Froussard runtime image to include built `@proompteng/otel` artifacts required at startup.
- Deploy Froussard image `registry.ide-newton.ts.net/lab/froussard@sha256:7bd24fb4c498eee5acd28ae7d0bf0fe2a40da23df918060149e0497d4ddd2c6d` and refresh its build metadata.

## Related Issues

None

## Testing

- `bun run packages/scripts/src/bumba/deploy-service.ts`
- `kubectl rollout status deployment/bumba -n jangar`
- `kubectl get deployment bumba -n jangar -o jsonpath='{.spec.template.spec.containers[0].image}{"\n"}{.status.updatedReplicas}{"/"}{.status.replicas}{" updated\n"}{.status.availableReplicas}{" available\n"}'
- `bun run packages/scripts/src/froussard/deploy-service.ts`
- `kubectl wait --for=condition=Ready ksvc/froussard -n froussard --timeout=180s`
- `kubectl get ksvc froussard -n froussard -o jsonpath='{.status.latestCreatedRevisionName}{"\n"}{.status.latestReadyRevisionName}{"\n"}{.status.url}{"\n"}'
- `kubectl logs -n froussard pod/$(kubectl get pods -n froussard -l serving.knative.dev/revision=froussard-00005 -o jsonpath='{.items[0].metadata.name}') -c app --tail=50`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
