### PR TITLE
fix(coder): upgrade coder to v2.31.4

### DIFF
--- a/argocd/applications/coder/Chart.yaml
+++ b/argocd/applications/coder/Chart.yaml
@@ -1,10 +1,10 @@
 apiVersion: v2
-appVersion: 0.0.1
+appVersion: 2.31.4
 description: Coder open source developer platform
 name: coder
-version: 2.28.6
+version: 2.31.4
 type: application
 dependencies:
   - name: coder
-    version: 2.28.6
+    version: 2.31.4
     repository: https://helm.coder.com/v2

--- a/docs/coder-workspace-bootstrap.md
+++ b/docs/coder-workspace-bootstrap.md
@@ -5,7 +5,7 @@ This document explains how to maintain the single `k8s-arm64` template in Coder,
 ## Prerequisites
 
 - Logged in to the Coder deployment (`coder login ...`).
-- `coder` CLI v2.28.6 or newer on your local machine (download instructions in the [Coder CLI manual](https://coder.com/docs/cli/install)).
+- `coder` CLI v2.31.4 or newer on your local machine (download instructions in the [Coder CLI manual](https://coder.com/docs/cli/install)).
 - Repository cloned locally (this repo, default path `~/github.com/lab`).
 
 ## Template Update Loop


### PR DESCRIPTION
## Summary

- upgrade the Helm-managed coder application from 2.28.6 to 2.31.4
- align the wrapper chart metadata and dependency version with the official upstream release
- update the Coder workspace bootstrap doc to reflect the newer CLI baseline

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/coder >/tmp/coder-render.yaml`
- `gh release view -R coder/coder --json tagName,publishedAt,name`
- `mise exec helm@3 -- sh -lc 'helm repo add coder-v2 https://helm.coder.com/v2 >/dev/null 2>&1 || true; helm repo update >/dev/null 2>&1; helm show chart coder-v2/coder --version 2.31.4'`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
