### PR TITLE
chore(jangar): promote image 39890e50

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: d8da45c1
-  digest: sha256:4c1444d6a2cd632451dc0a082a9bb09dd82a56137cf88ccf9467788e57b3a70e
+  tag: "39890e50"
+  digest: sha256:4a09f277c7c4d90caeccc65de3bb8d9703f4b83ab57d0329537928c10f905d64
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: d8da45c1
-    digest: sha256:b5f7c4808ceb7960a1f63fdcc4cba6ca21773d5c50674c54ee3fd299b28bc304
+    tag: "39890e50"
+    digest: sha256:9e13bccd04e8aaec3003b9ba796651a4750d733402d669cdbc61f772d61e9555
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: d8da45c1
-    digest: sha256:4c1444d6a2cd632451dc0a082a9bb09dd82a56137cf88ccf9467788e57b3a70e
+    tag: "39890e50"
+    digest: sha256:4a09f277c7c4d90caeccc65de3bb8d9703f4b83ab57d0329537928c10f905d64
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-11T08:00:55Z"
+    deploy.knative.dev/rollout: "2026-03-11T08:25:28Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-11T08:00:55Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-11T08:25:28Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -60,5 +60,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "d8da45c1"
-    digest: sha256:4c1444d6a2cd632451dc0a082a9bb09dd82a56137cf88ccf9467788e57b3a70e
+    newTag: "39890e50"
+    digest: sha256:4a09f277c7c4d90caeccc65de3bb8d9703f4b83ab57d0329537928c10f905d64


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `39890e50b3f72b601b434c0fbb9fb0b8f8e3cfb9`
- Image tag: `39890e50`
- Image digest: `sha256:4a09f277c7c4d90caeccc65de3bb8d9703f4b83ab57d0329537928c10f905d64`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`