### PR TITLE
fix(khoshut): fail fast when inngest is unavailable

### DIFF
--- a/argocd/applications/khoshut/deployment.yaml
+++ b/argocd/applications/khoshut/deployment.yaml
@@ -25,6 +25,24 @@ spec:
           ports:
             - name: http
               containerPort: 3000
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            periodSeconds: 2
+            failureThreshold: 30
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            periodSeconds: 5
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            periodSeconds: 10
+            failureThreshold: 3
           envFrom:
             - configMapRef:
                 name: khoshut-config

--- a/services/khoshut/src/config.test.ts
+++ b/services/khoshut/src/config.test.ts
@@ -8,6 +8,9 @@ const ENV_KEYS = [
   'INNGEST_BASE_URL',
   'INNGEST_EVENT_KEY',
   'INNGEST_SIGNING_KEY',
+  'INNGEST_STARTUP_TIMEOUT_MS',
+  'INNGEST_STARTUP_CHECK_INTERVAL_MS',
+  'INNGEST_STARTUP_REQUEST_TIMEOUT_MS',
 ] as const
 const ORIGINAL_ENV = Object.fromEntries(ENV_KEYS.map((key) => [key, process.env[key]])) as Record<
   string,
@@ -46,10 +49,21 @@ describe('loadConfig', () => {
     expect(cfg.host).toBe('0.0.0.0')
     expect(cfg.port).toBe(3000)
     expect(cfg.appId).toBe('khoshut')
+    expect(cfg.startupTimeoutMs).toBe(30000)
+    expect(cfg.startupCheckIntervalMs).toBe(1000)
+    expect(cfg.startupRequestTimeoutMs).toBe(5000)
   })
 
   it('rejects an invalid port', () => {
     process.env.PORT = '70000'
     expect(() => loadConfig()).toThrow('Invalid PORT value: 70000')
+  })
+
+  it('rejects an invalid inngest startup timeout', () => {
+    process.env.INNGEST_EVENT_KEY = '0123456789abcdef0123456789abcdef'
+    process.env.INNGEST_SIGNING_KEY = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
+    process.env.INNGEST_STARTUP_TIMEOUT_MS = '0'
+
+    expect(() => loadConfig()).toThrow('Invalid INNGEST_STARTUP_TIMEOUT_MS value: 0')
   })
 })

--- a/services/khoshut/src/config.ts
+++ b/services/khoshut/src/config.ts
@@ -5,12 +5,18 @@ export type KhoshutConfig = {
   baseUrl: string
   eventKey: string
   signingKey: string
+  startupTimeoutMs: number
+  startupCheckIntervalMs: number
+  startupRequestTimeoutMs: number
 }
 
 const DEFAULT_HOST = '0.0.0.0'
 const DEFAULT_PORT = 3000
 const DEFAULT_APP_ID = 'khoshut'
 const DEFAULT_BASE_URL = 'http://inngest.inngest.svc.cluster.local:8288'
+const DEFAULT_STARTUP_TIMEOUT_MS = 30_000
+const DEFAULT_STARTUP_CHECK_INTERVAL_MS = 1_000
+const DEFAULT_STARTUP_REQUEST_TIMEOUT_MS = 5_000
 
 const HEX_VALUE = /^[a-f0-9]+$/i
 
@@ -19,6 +25,19 @@ const parsePort = (input: string | undefined): number => {
   const parsed = Number.parseInt(input, 10)
   if (!Number.isFinite(parsed) || parsed <= 0 || parsed > 65535) {
     throw new Error(`Invalid PORT value: ${input}`)
+  }
+  return parsed
+}
+
+const parsePositiveInteger = (
+  input: string | undefined,
+  defaultValue: number,
+  envName: 'INNGEST_STARTUP_TIMEOUT_MS' | 'INNGEST_STARTUP_CHECK_INTERVAL_MS' | 'INNGEST_STARTUP_REQUEST_TIMEOUT_MS',
+): number => {
+  if (!input) return defaultValue
+  const parsed = Number.parseInt(input, 10)
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`Invalid ${envName} value: ${input}`)
   }
   return parsed
 }
@@ -44,6 +63,21 @@ export const loadConfig = (): KhoshutConfig => ({
   baseUrl: process.env.INNGEST_BASE_URL ?? DEFAULT_BASE_URL,
   eventKey: readHex('INNGEST_EVENT_KEY'),
   signingKey: readHex('INNGEST_SIGNING_KEY'),
+  startupTimeoutMs: parsePositiveInteger(
+    process.env.INNGEST_STARTUP_TIMEOUT_MS,
+    DEFAULT_STARTUP_TIMEOUT_MS,
+    'INNGEST_STARTUP_TIMEOUT_MS',
+  ),
+  startupCheckIntervalMs: parsePositiveInteger(
+    process.env.INNGEST_STARTUP_CHECK_INTERVAL_MS,
+    DEFAULT_STARTUP_CHECK_INTERVAL_MS,
+    'INNGEST_STARTUP_CHECK_INTERVAL_MS',
+  ),
+  startupRequestTimeoutMs: parsePositiveInteger(
+    process.env.INNGEST_STARTUP_REQUEST_TIMEOUT_MS,
+    DEFAULT_STARTUP_REQUEST_TIMEOUT_MS,
+    'INNGEST_STARTUP_REQUEST_TIMEOUT_MS',
+  ),
 })
 
 let cachedConfig: KhoshutConfig | null = null

--- a/services/khoshut/src/index.ts
+++ b/services/khoshut/src/index.ts
@@ -1,14 +1,7 @@
 import { serve } from 'inngest/bun'
 import { getConfig } from './config'
 import { functions, inngest } from './inngest'
-
-const config = getConfig()
-
-process.env.INNGEST_SIGNING_KEY = config.signingKey
-process.env.INNGEST_EVENT_KEY = config.eventKey
-process.env.INNGEST_BASE_URL = config.baseUrl
-
-const inngestHandler = serve({ client: inngest, functions })
+import { waitForInngestHealthy } from './startup'
 
 type TriggerPayload = {
   message?: string
@@ -31,45 +24,66 @@ const parseTriggerPayload = async (request: Request): Promise<TriggerPayload> =>
   }
 }
 
-const server = Bun.serve({
-  hostname: config.host,
-  port: config.port,
-  async fetch(request) {
-    const url = new URL(request.url)
+const createHealthResponse = (body: { status: 'ok'; appId: string; baseUrl: string; inngestHealthy: true }) =>
+  json(body, 200)
 
-    if (url.pathname === '/api/inngest') {
-      return inngestHandler(request)
-    }
+const main = async (): Promise<void> => {
+  const config = getConfig()
 
-    if (url.pathname === '/healthz') {
-      return json({
-        status: 'ok',
-        appId: config.appId,
-        baseUrl: config.baseUrl,
-      })
-    }
+  process.env.INNGEST_SIGNING_KEY = config.signingKey
+  process.env.INNGEST_EVENT_KEY = config.eventKey
+  process.env.INNGEST_BASE_URL = config.baseUrl
 
-    if (url.pathname === '/trigger' && request.method === 'POST') {
-      const payload = await parseTriggerPayload(request)
-      const message =
-        typeof payload.message === 'string' && payload.message.trim().length > 0 ? payload.message : 'Mend!'
-      const eventResult = await inngest.send({
-        name: 'khoshut/workflow.requested',
-        data: {
+  await waitForInngestHealthy(config)
+
+  const inngestHandler = serve({ client: inngest, functions })
+
+  const server = Bun.serve({
+    hostname: config.host,
+    port: config.port,
+    async fetch(request) {
+      const url = new URL(request.url)
+
+      if (url.pathname === '/api/inngest') {
+        return inngestHandler(request)
+      }
+
+      if (url.pathname === '/healthz' || url.pathname === '/readyz') {
+        return createHealthResponse({
+          status: 'ok',
+          appId: config.appId,
+          baseUrl: config.baseUrl,
+          inngestHealthy: true,
+        })
+      }
+
+      if (url.pathname === '/trigger' && request.method === 'POST') {
+        const payload = await parseTriggerPayload(request)
+        const message =
+          typeof payload.message === 'string' && payload.message.trim().length > 0 ? payload.message : 'Mend!'
+        const eventResult = await inngest.send({
+          name: 'khoshut/workflow.requested',
+          data: {
+            message,
+          },
+        })
+
+        return json({
+          status: 'queued',
+          event: eventResult,
           message,
-        },
-      })
+        })
+      }
 
-      return json({
-        status: 'queued',
-        event: eventResult,
-        message,
-      })
-    }
+      return json({ error: 'Not found' }, 404)
+    },
+  })
 
-    return json({ error: 'Not found' }, 404)
-  },
+  console.log(`Khoshut service listening on http://${config.host}:${server.port}`)
+  console.log(`Inngest endpoint: http://${config.host}:${server.port}/api/inngest`)
+}
+
+await main().catch((error) => {
+  console.error('[khoshut] fatal startup error', error)
+  process.exit(1)
 })
-
-console.log(`Khoshut service listening on http://${config.host}:${server.port}`)
-console.log(`Inngest endpoint: http://${config.host}:${server.port}/api/inngest`)

--- a/services/khoshut/src/startup.test.ts
+++ b/services/khoshut/src/startup.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'bun:test'
+import { checkInngestHealth, waitForInngestHealthy } from './startup'
+
+const asFetch = (fn: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>): typeof fetch =>
+  fn as typeof fetch
+
+describe('checkInngestHealth', () => {
+  it('returns success when the health endpoint responds with 200', async () => {
+    const result = await checkInngestHealth(
+      {
+        baseUrl: 'http://inngest.example.internal:8288',
+        startupRequestTimeoutMs: 1_000,
+      },
+      asFetch(async () => new Response(JSON.stringify({ status: 200, message: 'OK' }), { status: 200 })),
+    )
+
+    expect(result.ok).toBe(true)
+    expect(result.url).toBe('http://inngest.example.internal:8288/health')
+    expect(result.status).toBe(200)
+  })
+
+  it('returns failure details when the health endpoint is unavailable', async () => {
+    const result = await checkInngestHealth(
+      {
+        baseUrl: 'http://inngest.example.internal:8288',
+        startupRequestTimeoutMs: 1_000,
+      },
+      asFetch(async () => {
+        throw new Error('connect ECONNREFUSED')
+      }),
+    )
+
+    expect(result.ok).toBe(false)
+    expect(result.message).toContain('ECONNREFUSED')
+  })
+})
+
+describe('waitForInngestHealthy', () => {
+  it('retries until the health endpoint becomes available', async () => {
+    let attempts = 0
+    let nowValue = 0
+
+    await waitForInngestHealthy(
+      {
+        baseUrl: 'http://inngest.example.internal:8288',
+        startupTimeoutMs: 5_000,
+        startupCheckIntervalMs: 250,
+        startupRequestTimeoutMs: 1_000,
+      },
+      {
+        fetchImpl: asFetch(async () => {
+          attempts += 1
+          if (attempts < 3) {
+            throw new Error('connect ECONNREFUSED')
+          }
+          return new Response(JSON.stringify({ status: 200, message: 'OK' }), { status: 200 })
+        }),
+        delayImpl: async (ms) => {
+          nowValue += ms
+        },
+        now: () => nowValue,
+        logger: {
+          warn() {},
+        },
+      },
+    )
+
+    expect(attempts).toBe(3)
+  })
+
+  it('throws when Inngest never becomes healthy before the deadline', async () => {
+    let nowValue = 0
+
+    await expect(
+      waitForInngestHealthy(
+        {
+          baseUrl: 'http://inngest.example.internal:8288',
+          startupTimeoutMs: 1_000,
+          startupCheckIntervalMs: 500,
+          startupRequestTimeoutMs: 250,
+        },
+        {
+          fetchImpl: asFetch(async () => {
+            throw new Error('connect ECONNREFUSED')
+          }),
+          delayImpl: async (ms) => {
+            nowValue += ms
+          },
+          now: () => nowValue,
+          logger: {
+            warn() {},
+          },
+        },
+      ),
+    ).rejects.toThrow('Timed out waiting for Inngest health')
+  })
+})

--- a/services/khoshut/src/startup.ts
+++ b/services/khoshut/src/startup.ts
@@ -1,0 +1,106 @@
+import type { KhoshutConfig } from './config'
+
+type FetchLike = typeof fetch
+type DelayLike = (ms: number) => Promise<void>
+type NowLike = () => number
+type LoggerLike = Pick<typeof console, 'warn'>
+
+type InngestHealthStatus = {
+  ok: boolean
+  url: string
+  message: string
+  status?: number
+}
+
+const delay: DelayLike = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
+const buildInngestHealthUrl = (baseUrl: string): string => new URL('/health', baseUrl).toString()
+
+const buildTimeoutSignal = (timeoutMs: number): AbortSignal | undefined => {
+  if (typeof AbortSignal === 'undefined' || typeof AbortSignal.timeout !== 'function') {
+    return undefined
+  }
+  return AbortSignal.timeout(timeoutMs)
+}
+
+export const checkInngestHealth = async (
+  config: Pick<KhoshutConfig, 'baseUrl' | 'startupRequestTimeoutMs'>,
+  fetchImpl: FetchLike = fetch,
+): Promise<InngestHealthStatus> => {
+  const url = buildInngestHealthUrl(config.baseUrl)
+
+  try {
+    const response = await fetchImpl(url, {
+      method: 'GET',
+      headers: {
+        accept: 'application/json',
+      },
+      signal: buildTimeoutSignal(config.startupRequestTimeoutMs),
+    })
+
+    if (!response.ok) {
+      return {
+        ok: false,
+        url,
+        status: response.status,
+        message: `health endpoint returned HTTP ${response.status}`,
+      }
+    }
+
+    return {
+      ok: true,
+      url,
+      status: response.status,
+      message: 'ok',
+    }
+  } catch (error) {
+    return {
+      ok: false,
+      url,
+      message: error instanceof Error ? error.message : String(error),
+    }
+  }
+}
+
+export const waitForInngestHealthy = async (
+  config: Pick<KhoshutConfig, 'baseUrl' | 'startupTimeoutMs' | 'startupCheckIntervalMs' | 'startupRequestTimeoutMs'>,
+  options: {
+    fetchImpl?: FetchLike
+    delayImpl?: DelayLike
+    now?: NowLike
+    logger?: LoggerLike
+  } = {},
+): Promise<void> => {
+  const fetchImpl = options.fetchImpl ?? fetch
+  const delayImpl = options.delayImpl ?? delay
+  const now = options.now ?? Date.now
+  const logger = options.logger ?? console
+  const deadline = now() + config.startupTimeoutMs
+  let attempt = 0
+  let lastFailure: InngestHealthStatus | null = null
+
+  while (now() <= deadline) {
+    attempt += 1
+    const status = await checkInngestHealth(config, fetchImpl)
+    if (status.ok) {
+      return
+    }
+
+    lastFailure = status
+    const remainingMs = Math.max(0, deadline - now())
+    logger.warn(
+      `[khoshut] Inngest health check attempt ${attempt} failed for ${status.url}: ${status.message} (remaining ${remainingMs}ms)`,
+    )
+
+    if (remainingMs === 0) {
+      break
+    }
+
+    await delayImpl(Math.min(config.startupCheckIntervalMs, remainingMs))
+  }
+
+  const detail = lastFailure
+    ? `${lastFailure.url} (${lastFailure.status ?? 'no-status'}): ${lastFailure.message}`
+    : 'no attempts were executed'
+  throw new Error(`Timed out waiting for Inngest health after ${config.startupTimeoutMs}ms: ${detail}`)
+}


### PR DESCRIPTION
## Summary

- make Khoshut block startup on a successful Inngest `/health` preflight instead of serving traffic while registration is broken
- add retryable startup health checks with explicit timeout, interval, and request-timeout config plus regression tests
- add Kubernetes startup, readiness, and liveness probes on `/healthz` so the deployment reflects the real post-fix boot contract without breaking old-image rollouts

## Related Issues

None

## Testing

- `bun run --filter @proompteng/khoshut test`
- `bun run --filter @proompteng/khoshut tsc`
- `bun run --filter @proompteng/khoshut lint`
- `bunx oxlint --config .oxlintrc.json services/khoshut/src`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/khoshut`
- `kubectl get secret inngest -n inngest -o yaml` and `kubectl get secret inngest -n khoshut -o yaml` plus SHA-256 comparison to verify Khoshut is using the reflected source keys, not stale credentials
- `kubectl logs deployment/khoshut -n khoshut --tail=200` and `kubectl run ... curlimages/curl ... http://inngest.inngest.svc.cluster.local:8288/health` to confirm the current failure is not an Inngest outage

## Breaking Changes

None. The service now exits instead of staying up when Inngest is unavailable during startup.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked. No documentation or release-note update is required for this internal service reliability fix.
