### PR TITLE
fix(torghut): match cnpg storage size to live volume

### DIFF
--- a/argocd/applications/torghut/postgres-cluster.yaml
+++ b/argocd/applications/torghut/postgres-cluster.yaml
@@ -8,7 +8,7 @@ spec:
   primaryUpdateStrategy: unsupervised
   storage:
     storageClass: rook-ceph-block
-    size: 5Gi
+    size: 50Gi
   bootstrap:
     initdb:
       database: torghut


### PR DESCRIPTION
## Summary

- update `argocd/applications/torghut/postgres-cluster.yaml` to request `50Gi` instead of `5Gi`
- align GitOps desired state with the live CNPG `Cluster/torghut-db`, which already runs at `50Gi`
- stop Argo CD from retrying an invalid storage shrink on every Torghut sync

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/torghut >/tmp/torghut-kustomize.yaml`
- `kubectl get cluster torghut-db -n torghut -o yaml` and verified `spec.storage.size: 50Gi` live

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
