### PR TITLE
chore(jangar): promote image f67ada1a

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: "39890e50"
-  digest: sha256:4a09f277c7c4d90caeccc65de3bb8d9703f4b83ab57d0329537928c10f905d64
+  tag: f67ada1a
+  digest: sha256:96cb491b9ea4b2597078a53b8f05773d18366aea77a2f18d786d6bbd44e56aa6
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: "39890e50"
-    digest: sha256:9e13bccd04e8aaec3003b9ba796651a4750d733402d669cdbc61f772d61e9555
+    tag: f67ada1a
+    digest: sha256:7e5d7dc8a27e8df757430ee441bd3fb289582e8150fb9c0d2f85441e6a9aea75
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: "39890e50"
-    digest: sha256:4a09f277c7c4d90caeccc65de3bb8d9703f4b83ab57d0329537928c10f905d64
+    tag: f67ada1a
+    digest: sha256:96cb491b9ea4b2597078a53b8f05773d18366aea77a2f18d786d6bbd44e56aa6
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-11T08:27:31.496Z"
+    deploy.knative.dev/rollout: "2026-03-11T08:57:51Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-11T08:27:31.496Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-11T08:57:51Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -60,5 +60,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "b0412430d"
-    digest: sha256:478917f6216cba20e1b86d8058e0b44c38638f12105bccd19002f50cbbb15e94
+    newTag: "f67ada1a"
+    digest: sha256:96cb491b9ea4b2597078a53b8f05773d18366aea77a2f18d786d6bbd44e56aa6


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `f67ada1af2906a0b93d6b302ab7e3c3e812081f4`
- Image tag: `f67ada1a`
- Image digest: `sha256:96cb491b9ea4b2597078a53b8f05773d18366aea77a2f18d786d6bbd44e56aa6`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`