### PR TITLE
fix(oirat): deploy image and repair docker build

### DIFF
--- a/argocd/applications/oirat/deployment.yaml
+++ b/argocd/applications/oirat/deployment.yaml
@@ -16,7 +16,7 @@ spec:
         app.kubernetes.io/name: oirat
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-02-18T20:05:27.167Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-11T09:00:54.276Z"
     spec:
       containers:
         - name: oirat

--- a/argocd/applications/oirat/kustomization.yaml
+++ b/argocd/applications/oirat/kustomization.yaml
@@ -10,4 +10,4 @@ resources:
   - alloy-deployment.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/oirat
-    newTag: "7406de93-fix2"
+    newTag: "c3afe9a21"

--- a/services/oirat/Dockerfile
+++ b/services/oirat/Dockerfile
@@ -30,8 +30,6 @@ FROM oven/bun:${BUN_VERSION} AS runner
 WORKDIR /app
 ENV NODE_ENV=production
 COPY --from=deps-prod /app/node_modules ./node_modules
-COPY --from=deps-prod /app/services/oirat/node_modules ./services/oirat/node_modules
-COPY --from=deps-prod /app/packages/discord/node_modules ./packages/discord/node_modules
 COPY --from=build /app/services/oirat ./services/oirat
 COPY --from=build /app/packages/discord/package.json ./packages/discord/package.json
 COPY --from=build /app/packages/discord/dist ./packages/discord/dist


### PR DESCRIPTION
## Summary

- fix the `oirat` Docker image build by removing per-package `node_modules` copies that do not exist in the pruned Bun install stage
- deploy and push `registry.ide-newton.ts.net/lab/oirat:c3afe9a21` with the existing typed deploy script
- update the GitOps manifests for `oirat` to the deployed image tag and refresh the rollout annotation

## Related Issues

None

## Testing

- `bun run oirat:deploy`
- `kubectl -n oirat rollout status deployment/oirat --timeout=180s`
- `kubectl -n oirat get deploy,pod -o wide`
- `kubectl -n argocd get application oirat -o jsonpath='{.status.sync.status}{" "}{.status.health.status}{" "}{.status.sync.revision}{"\n"}'`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
