### PR TITLE
feat(kafka): add broker-only node pool

### DIFF
--- a/argocd/applications/kafka/strimzi-kafka-cluster.yaml
+++ b/argocd/applications/kafka/strimzi-kafka-cluster.yaml
@@ -65,6 +65,27 @@ spec:
     class: rook-ceph-block
 ---
 apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaNodePool
+metadata:
+  name: pool-b
+  namespace: kafka
+  labels:
+    strimzi.io/cluster: kafka
+spec:
+  replicas: 3
+  roles:
+    - broker
+  resources:
+    requests:
+      cpu: '2000m'
+      memory: 4Gi
+  storage:
+    type: persistent-claim
+    size: 30Gi
+    deleteClaim: false
+    class: rook-ceph-block
+---
+apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaUser
 metadata:
   name: user1


### PR DESCRIPTION
## Summary

- add a second Strimzi KafkaNodePool named `pool-b` with three broker-only replicas
- preserve the existing three-node controller quorum on `pool-a` instead of mutating controller membership in place
- keep the new brokers on the current `rook-ceph-block` storage class and existing Kafka resource sizing for a low-risk GitOps rollout

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/kafka > /tmp/kafka-rendered.yaml`
- `kubectl create --dry-run=server -f /tmp/kafka-pool-b.yaml`
- `bun run lint:argocd`

## Breaking Changes

None. Existing data remains on `pool-a` until a later partition rebalance and broker drain.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
