### PR TITLE
fix(jangar): remove empirical gates from dependency quorum

### DIFF
--- a/services/jangar/src/server/__tests__/control-plane-status.test.ts
+++ b/services/jangar/src/server/__tests__/control-plane-status.test.ts
@@ -483,8 +483,73 @@ describe('control-plane status', () => {
     expect(status.agentrun_ingestion.status).toBe('degraded')
     expect(status.agentrun_ingestion.untouched_run_count).toBe(3)
     expect(status.agentrun_ingestion.oldest_untouched_age_seconds).toBe(180)
-    expect(status.dependency_quorum.reasons).toContain('forecast_service_unhealthy')
     expect(status.empirical_services.jobs.status).toBe('degraded')
+  })
+
+  it('keeps empirical degradations observable without delaying dependency quorum', async () => {
+    setRolloutDeploymentList([healthyRolloutDeployment, healthyAgentsControllersRolloutDeployment])
+
+    const status = await buildControlPlaneStatus(
+      {
+        namespace: 'agents',
+        grpc: {
+          enabled: true,
+          address: '127.0.0.1:50051',
+          status: 'healthy',
+          message: '',
+        },
+      },
+      {
+        now: () => new Date('2026-01-20T00:00:00Z'),
+        getHeartbeat: createHeartbeatResolver(),
+        getAgentsControllerHealth: () => healthyController,
+        getSupportingControllerHealth: () => healthyController,
+        getOrchestrationControllerHealth: () => healthyController,
+        resolveTemporalAdapter: async () => buildTemporalAdapter(),
+        checkDatabase: async () => buildDatabaseStatus(),
+        getWatchReliabilitySummary: () => watchReliabilityHealthy,
+        getWorkflowsReliabilityStatus: async () => buildWorkflowsReliabilityStatus(),
+        resolveEmpiricalServices: async () => ({
+          forecast: {
+            status: 'degraded',
+            endpoint: 'http://torghut-forecast/readyz',
+            message: 'forecast service readiness failed',
+            authoritative: false,
+          },
+          lean: {
+            status: 'healthy',
+            endpoint: 'http://torghut-lean-runner/readyz',
+            message: 'LEAN runner ready',
+            authoritative: false,
+            authoritative_modes: [],
+          },
+          jobs: {
+            status: 'degraded',
+            endpoint: 'http://torghut/trading/empirical-jobs',
+            message: 'stale empirical jobs: benchmark_parity',
+            authoritative: false,
+            eligible_jobs: ['foundation_router_parity'],
+            stale_jobs: ['benchmark_parity'],
+          },
+        }),
+      },
+    )
+
+    expect(status.dependency_quorum).toEqual({
+      decision: 'allow',
+      reasons: [],
+      message: 'Control-plane admission dependencies are healthy.',
+    })
+    expect(status.namespaces[0]?.status).toBe('degraded')
+    expect(status.namespaces[0]?.degraded_components ?? []).toContain('empirical:forecast')
+    expect(status.namespaces[0]?.degraded_components ?? []).toContain('empirical:jobs')
+    expect(status.namespaces[0]?.degraded_components ?? []).not.toContain('empirical:lean')
+    expect(status.empirical_services.forecast.status).toBe('degraded')
+    expect(status.empirical_services.lean.authoritative).toBe(false)
+    expect(status.empirical_services.jobs).toMatchObject({
+      status: 'degraded',
+      stale_jobs: ['benchmark_parity'],
+    })
   })
 
   it('marks workflows as degraded when backoff count crosses warning threshold', async () => {

--- a/services/jangar/src/server/control-plane-status.ts
+++ b/services/jangar/src/server/control-plane-status.ts
@@ -1323,32 +1323,8 @@ const buildDependencyQuorum = (input: {
     delayReasons.push('rollout_health_degraded')
   }
 
-  if (input.empiricalServices.forecast.status === 'degraded') {
-    blockReasons.push('forecast_service_unhealthy')
-  } else if (
-    input.empiricalServices.forecast.status === 'healthy' &&
-    input.empiricalServices.forecast.authoritative === false
-  ) {
-    delayReasons.push('forecast_calibration_stale')
-  }
-
-  if (input.empiricalServices.lean.status === 'degraded') {
-    blockReasons.push('lean_runner_unhealthy')
-  } else if (
-    input.empiricalServices.lean.status === 'healthy' &&
-    input.empiricalServices.lean.authoritative === false
-  ) {
-    delayReasons.push('lean_authority_missing')
-  }
-
-  if (input.empiricalServices.jobs.status === 'degraded') {
-    delayReasons.push('empirical_jobs_stale')
-  } else if (
-    input.empiricalServices.jobs.status === 'healthy' &&
-    input.empiricalServices.jobs.authoritative === false
-  ) {
-    delayReasons.push('empirical_jobs_not_authoritative')
-  }
+  // Forecast/LEAN/empirical jobs remain observable via empirical_services and degraded_components,
+  // but they are not hard admission dependencies for live trading control-plane readiness.
 
   const reasons = uniqueStrings(blockReasons.length > 0 ? blockReasons : delayReasons)
   const decision: DependencyQuorumStatus['decision'] =


### PR DESCRIPTION
## Summary

- narrow Jangar `dependency_quorum` so it only reflects hard control-plane/runtime dependencies
- keep forecast, LEAN, and empirical job degradation visible through `empirical_services` and `degraded_components`
- add a regression test proving empirical degradations remain observable without delaying quorum

## Related Issues

None

## Testing

- `bunx vitest run --config vitest.config.ts src/server/__tests__/control-plane-status.test.ts`
- `bunx oxfmt --check services/jangar/src/server/control-plane-status.ts services/jangar/src/server/__tests__/control-plane-status.test.ts`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
