### PR TITLE
fix(torghut-ws): page startup bars backfill

### DIFF
--- a/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/ForwarderApp.kt
+++ b/services/dorvud/websockets/src/main/kotlin/ai/proompteng/dorvud/ws/ForwarderApp.kt
@@ -34,6 +34,7 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withTimeout
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.decodeFromString
@@ -67,6 +68,8 @@ import kotlin.system.exitProcess
 
 private val logger = KotlinLogging.logger {}
 private val marketSessionZoneId: ZoneId = ZoneId.of("America/New_York")
+private const val ALPACA_BARS_BACKFILL_LOOKBACK_HOURS = 12L
+private const val ALPACA_BARS_BACKFILL_LIMIT = 10_000
 
 internal fun alpacaMarketDataStreamUrl(config: ForwarderConfig): String =
   when (config.alpacaMarketType) {
@@ -86,12 +89,62 @@ internal fun alpacaBarsBackfillUrl(config: ForwarderConfig): String =
 
 internal fun alpacaBarsBackfillNeedsFeed(config: ForwarderConfig): Boolean = config.alpacaMarketType != AlpacaMarketType.CRYPTO
 
+internal fun alpacaBarsBackfillFeed(config: ForwarderConfig): String? =
+  when {
+    !alpacaBarsBackfillNeedsFeed(config) -> null
+    config.alpacaFeed.equals("overnight", ignoreCase = true) -> "boats"
+    else -> config.alpacaFeed
+  }
+
+internal data class AlpacaBarsBackfillWindow(
+  val start: Instant,
+  val end: Instant,
+)
+
+internal fun alpacaBarsBackfillWindow(now: Instant): AlpacaBarsBackfillWindow =
+  AlpacaBarsBackfillWindow(
+    start = now.minus(Duration.ofHours(ALPACA_BARS_BACKFILL_LOOKBACK_HOURS)),
+    end = now,
+  )
+
+internal data class AlpacaBarsBackfillQuery(
+  val symbols: String,
+  val timeframe: String,
+  val start: String,
+  val end: String,
+  val limit: String,
+  val sort: String,
+  val feed: String?,
+  val pageToken: String?,
+)
+
+internal fun alpacaBarsBackfillQuery(
+  config: ForwarderConfig,
+  symbols: List<String>,
+  now: Instant,
+  pageToken: String? = null,
+): AlpacaBarsBackfillQuery {
+  val window = alpacaBarsBackfillWindow(now)
+  return AlpacaBarsBackfillQuery(
+    symbols = symbols.joinToString(","),
+    timeframe = "1Min",
+    start = window.start.toString(),
+    end = window.end.toString(),
+    limit = ALPACA_BARS_BACKFILL_LIMIT.toString(),
+    sort = "asc",
+    feed = alpacaBarsBackfillFeed(config),
+    pageToken = pageToken,
+  )
+}
+
 internal fun alpacaMarketDataChannels(config: ForwarderConfig): List<String> = config.alpacaMarketDataChannels
 
 @Serializable
 internal data class AlpacaBarsResponse(
   val bars: JsonElement? = null,
   val symbol: String? = null,
+  @SerialName("next_page_token")
+  val nextPageToken: String? = null,
 )
 
 internal fun decodeAlpacaBarsResponse(
@@ -832,34 +885,46 @@ class ForwarderApp(
   private suspend fun fetchBackfillBarsChunk(symbols: List<String>): List<AlpacaBar> {
     if (symbols.isEmpty()) return emptyList()
     val url = alpacaBarsBackfillUrl(config)
+    val requestNow = Instant.ofEpochMilli(nowMs())
+    val bars = mutableListOf<AlpacaBar>()
+    var pageToken: String? = null
 
-    val response =
-      decodeAlpacaBarsResponse(
-        httpClient
-          .get(url) {
-            parameter("symbols", symbols.joinToString(","))
-            parameter("timeframe", "1Min")
-            parameter("limit", "100")
-            if (alpacaBarsBackfillNeedsFeed(config)) {
-              parameter("feed", config.alpacaFeed)
+    do {
+      val query = alpacaBarsBackfillQuery(config, symbols, requestNow, pageToken)
+      val response =
+        decodeAlpacaBarsResponse(
+          httpClient
+            .get(url) {
+              parameter("symbols", query.symbols)
+              parameter("timeframe", query.timeframe)
+              parameter("start", query.start)
+              parameter("end", query.end)
+              parameter("limit", query.limit)
+              parameter("sort", query.sort)
+              query.feed?.let { parameter("feed", it) }
+              query.pageToken?.let { parameter("page_token", it) }
+              header("APCA-API-KEY-ID", config.alpacaKeyId)
+              header("APCA-API-SECRET-KEY", config.alpacaSecretKey)
+            }.body(),
+          json,
+        )
+
+      val pageBars =
+        when (val barsElement = response.bars) {
+          null -> emptyList()
+          is JsonArray -> decodeBarsArray(barsElement, response.symbol)
+          is JsonObject ->
+            barsElement.entries.flatMap { (symbol, entry) ->
+              val arr = entry as? JsonArray ?: return@flatMap emptyList()
+              decodeBarsArray(arr, symbol)
             }
-            header("APCA-API-KEY-ID", config.alpacaKeyId)
-            header("APCA-API-SECRET-KEY", config.alpacaSecretKey)
-          }.body(),
-        json,
-      )
-
-    val barsElement = response.bars ?: return emptyList()
-
-    return when (barsElement) {
-      is JsonArray -> decodeBarsArray(barsElement, response.symbol)
-      is JsonObject ->
-        barsElement.entries.flatMap { (symbol, entry) ->
-          val arr = entry as? JsonArray ?: return@flatMap emptyList()
-          decodeBarsArray(arr, symbol)
+          else -> emptyList()
         }
-      else -> emptyList()
-    }
+      bars += pageBars
+      pageToken = response.nextPageToken
+    } while (pageToken != null)
+
+    return bars
   }
 
   private fun decodeBarsArray(

--- a/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/ForwarderEndpointsTest.kt
+++ b/services/dorvud/websockets/src/test/kotlin/ai/proompteng/dorvud/ws/ForwarderEndpointsTest.kt
@@ -4,6 +4,7 @@ import ai.proompteng.dorvud.platform.KafkaAuth
 import ai.proompteng.dorvud.platform.KafkaProducerSettings
 import ai.proompteng.dorvud.platform.KafkaTls
 import kotlinx.serialization.json.jsonObject
+import java.time.Instant
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -106,5 +107,30 @@ class ForwarderEndpointsTest {
       )
     val bars = assertNotNull(parsed.bars)
     assertTrue(bars.jsonObject.isEmpty())
+    assertEquals(null, parsed.nextPageToken)
+  }
+
+  @Test
+  fun `equity backfill query uses bounded window pagination and historical feed normalization`() {
+    val cfg = baseConfig(AlpacaMarketType.EQUITY).copy(alpacaFeed = "overnight")
+    val query = alpacaBarsBackfillQuery(cfg, listOf("AAPL", "MSFT"), Instant.parse("2026-03-11T09:30:00Z"), "page-1")
+
+    assertEquals("AAPL,MSFT", query.symbols)
+    assertEquals("1Min", query.timeframe)
+    assertEquals("2026-03-10T21:30:00Z", query.start)
+    assertEquals("2026-03-11T09:30:00Z", query.end)
+    assertEquals("10000", query.limit)
+    assertEquals("asc", query.sort)
+    assertEquals("boats", query.feed)
+    assertEquals("page-1", query.pageToken)
+  }
+
+  @Test
+  fun `crypto backfill query omits feed parameter`() {
+    val cfg = baseConfig(AlpacaMarketType.CRYPTO)
+    val query = alpacaBarsBackfillQuery(cfg, listOf("BTC/USD"), Instant.parse("2026-03-11T09:30:00Z"))
+
+    assertEquals(null, query.feed)
+    assertEquals(null, query.pageToken)
   }
 }


### PR DESCRIPTION
## Summary

- add explicit backfill request windows for Alpaca bars so startup recovery fetches recent data instead of relying on day-to-date defaults
- paginate historical bars backfill requests and raise the page size so multi-symbol startup recovery does not starve later symbols
- normalize historical equity backfill from `overnight` to `boats` and cover the request contract in websocket endpoint tests

## Related Issues

None

## Testing

- `cd /Users/gregkonush/.codex/worktrees/89f5/lab/services/dorvud && ./gradlew :websockets:test --tests 'ai.proompteng.dorvud.ws.ForwarderEndpointsTest'`
- `cd /Users/gregkonush/.codex/worktrees/89f5/lab/services/dorvud && ./gradlew :websockets:ktlintCheck`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
