### PR TITLE
chore(jangar): promote image f3c0483c

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: f67ada1a
-  digest: sha256:96cb491b9ea4b2597078a53b8f05773d18366aea77a2f18d786d6bbd44e56aa6
+  tag: f3c0483c
+  digest: sha256:2f16373e0c4797911b1d609a8fb6cd7c0654b5d1f201c1e47c33a0587d050f48
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: f67ada1a
-    digest: sha256:7e5d7dc8a27e8df757430ee441bd3fb289582e8150fb9c0d2f85441e6a9aea75
+    tag: f3c0483c
+    digest: sha256:cb58ae0455d60b655acf9441753846b53212b45287171232ae214d68ef62ea98
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: f67ada1a
-    digest: sha256:96cb491b9ea4b2597078a53b8f05773d18366aea77a2f18d786d6bbd44e56aa6
+    tag: f3c0483c
+    digest: sha256:2f16373e0c4797911b1d609a8fb6cd7c0654b5d1f201c1e47c33a0587d050f48
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-11T08:57:51Z"
+    deploy.knative.dev/rollout: "2026-03-11T09:35:51Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-11T08:57:51Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-11T09:35:51Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -60,5 +60,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "f67ada1a"
-    digest: sha256:96cb491b9ea4b2597078a53b8f05773d18366aea77a2f18d786d6bbd44e56aa6
+    newTag: "f3c0483c"
+    digest: sha256:2f16373e0c4797911b1d609a8fb6cd7c0654b5d1f201c1e47c33a0587d050f48


### PR DESCRIPTION
## Summary

- promote the Jangar application image to `f3c0483c` with the built digest from the merged quorum-fix commit
- promote the shared agents chart Jangar and Jangar control-plane image pins to the matching release digests
- bump the Jangar rollout/restart annotations so Argo applies the new image deterministically

## Related Issues

None

## Testing

- `cd /Users/gregkonush/.codex/worktrees/89f5/lab && mise exec helm@3 -- kustomize build --enable-helm argocd/applications/jangar >/dev/null`
- `cd /Users/gregkonush/.codex/worktrees/89f5/lab && mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/dev/null`
- `cd /Users/gregkonush/.codex/worktrees/89f5/lab && crane digest registry.ide-newton.ts.net/lab/jangar:f3c0483c`
- `cd /Users/gregkonush/.codex/worktrees/89f5/lab && crane digest registry.ide-newton.ts.net/lab/jangar-control-plane:f3c0483c`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
