### PR TITLE
chore(torghut-options): promote ws image 37aace1e

### DIFF
--- a/argocd/applications/torghut-options/ws/deployment.yaml
+++ b/argocd/applications/torghut-options/ws/deployment.yaml
@@ -29,7 +29,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-ws-options
-          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:db62663f3dae59c54ab99a78f63f35d830b3e5e6051d05477fa91f461f95f66a
+          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:5c4f73cbfbdaa56fadf225d2b146da35baf7ddecac05bff99abd929635f975dc
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:
@@ -53,9 +53,9 @@ spec:
                   name: torghut-options
                   key: password
             - name: TORGHUT_WS_VERSION
-              value: main-2b9824ae
+              value: main-37aace1e
             - name: TORGHUT_WS_COMMIT
-              value: 2b9824ae0abd2fae9480e3b73ab8c73b4d5392d5
+              value: 37aace1e6d1d37220a55080cd137ef189a4907ed
             - name: JAVA_TOOL_OPTIONS
               value: -XX:+UseContainerSupport -XX:InitialRAMPercentage=40.0 -XX:MaxRAMPercentage=70.0 -XX:+ExitOnOutOfMemoryError
           ports:


### PR DESCRIPTION
## Summary
Promote the Torghut options websocket image into GitOps manifests.

- Source commit: `37aace1e6d1d37220a55080cd137ef189a4907ed`
- Image tag: `37aace1e`
- Image digest: `sha256:5c4f73cbfbdaa56fadf225d2b146da35baf7ddecac05bff99abd929635f975dc`