### PR TITLE
fix(jangar): ignore follower controller quorum noise

### DIFF
--- a/services/jangar/src/server/__tests__/control-plane-status.test.ts
+++ b/services/jangar/src/server/__tests__/control-plane-status.test.ts
@@ -972,6 +972,70 @@ describe('control-plane status', () => {
     })
   })
 
+  it('keeps supporting and orchestration controller degradation observable without delaying dependency quorum', async () => {
+    setRolloutDeploymentList([healthyRolloutDeployment, availableButDegradedAgentsControllersRolloutDeployment])
+
+    const nonLeaderController = {
+      enabled: true,
+      started: false,
+      namespaces: ['agents'],
+      crdsReady: null,
+      missingCrds: [],
+      lastCheckedAt: '2026-01-20T00:00:00Z',
+      agentRunIngestion: [],
+    }
+
+    const status = await buildControlPlaneStatus(
+      {
+        namespace: 'agents',
+        grpc: {
+          enabled: true,
+          address: '127.0.0.1:50051',
+          status: 'healthy',
+          message: '',
+        },
+      },
+      {
+        now: () => new Date('2026-01-20T00:00:00Z'),
+        getHeartbeat: createHeartbeatResolver(
+          buildHeartbeatRows({
+            'supporting-controller': {
+              status: 'degraded',
+              message: 'supporting controller not started',
+              leadership_state: 'follower',
+            },
+            'orchestration-controller': {
+              status: 'degraded',
+              message: 'orchestration controller not started',
+              leadership_state: 'follower',
+            },
+          }),
+        ),
+        getAgentsControllerHealth: () => healthyController,
+        getSupportingControllerHealth: () => nonLeaderController,
+        getOrchestrationControllerHealth: () => nonLeaderController,
+        resolveTemporalAdapter: async () => buildTemporalAdapter(),
+        checkDatabase: async () => buildDatabaseStatus(),
+        getWatchReliabilitySummary: () => watchReliabilityHealthy,
+        getWorkflowsReliabilityStatus: async () => buildWorkflowsReliabilityStatus(),
+      },
+    )
+
+    expect(status.controllers.find((controller) => controller.name === 'supporting-controller')?.status).toBe(
+      'degraded',
+    )
+    expect(status.controllers.find((controller) => controller.name === 'orchestration-controller')?.status).toBe(
+      'degraded',
+    )
+    expect(status.namespaces[0]?.degraded_components).toContain('supporting-controller')
+    expect(status.namespaces[0]?.degraded_components).toContain('orchestration-controller')
+    expect(status.dependency_quorum).toEqual({
+      decision: 'allow',
+      reasons: [],
+      message: 'Control-plane admission dependencies are healthy.',
+    })
+  })
+
   it('fails closed to unknown authority when a controller heartbeat is missing', async () => {
     setRolloutDeploymentList([healthyRolloutDeployment])
 

--- a/services/jangar/src/server/control-plane-status.ts
+++ b/services/jangar/src/server/control-plane-status.ts
@@ -1278,16 +1278,16 @@ const buildDependencyQuorum = (input: {
   for (const controller of input.controllers) {
     if (controller.status === 'healthy') continue
 
+    // Supporting and orchestration controllers are observable control-plane signals,
+    // but live trading readiness only requires agents-controller + workflow runtime.
+    if (controller.name !== 'agents-controller') continue
+
     if (controller.status === 'unknown') {
       blockReasons.push(asDependencyReason(controller.name, 'status_unknown'))
       continue
     }
 
-    if (controller.name === 'agents-controller') {
-      blockReasons.push('agents_controller_unavailable')
-      continue
-    }
-    delayReasons.push(`${controller.name.replace(/-/g, '_')}_degraded`)
+    blockReasons.push('agents_controller_unavailable')
   }
 
   const workflowAdapter = input.runtimeAdapters.find((adapter) => adapter.name === 'workflow')
@@ -1319,12 +1319,9 @@ const buildDependencyQuorum = (input: {
     delayReasons.push('watch_reliability_degraded')
   }
 
-  if (hasMaterialRolloutDegradation(input.rolloutHealth)) {
-    delayReasons.push('rollout_health_degraded')
-  }
-
-  // Forecast/LEAN/empirical jobs remain observable via empirical_services and degraded_components,
-  // but they are not hard admission dependencies for live trading control-plane readiness.
+  // Rollout churn plus supporting/orchestration/forecast/LEAN/empirical job state stay observable via
+  // rollout_health, degraded_components, and empirical_services, but they are not hard live-trading
+  // admission dependencies.
 
   const reasons = uniqueStrings(blockReasons.length > 0 ? blockReasons : delayReasons)
   const decision: DependencyQuorumStatus['decision'] =


### PR DESCRIPTION
## Summary

- narrow Jangar dependency quorum so follower-only supporting/orchestration controller status does not delay live trading readiness
- stop treating rollout churn as a capital-delay signal when the required agents controller and workflow runtime are already available
- add a regression test covering degraded follower controllers plus mid-update rollout health

## Related Issues

None

## Testing

- `cd /Users/gregkonush/.codex/worktrees/89f5/lab/services/jangar && bunx vitest run --config vitest.config.ts src/server/__tests__/control-plane-status.test.ts`
- `cd /Users/gregkonush/.codex/worktrees/89f5/lab && bunx oxfmt --check services/jangar/src/server/control-plane-status.ts services/jangar/src/server/__tests__/control-plane-status.test.ts`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
