### PR TITLE
fix(torghut): cut live autonomy from trading critical path

### DIFF
--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -101,6 +101,8 @@ spec:
               value: "true"
             - name: TRADING_MODE
               value: live
+            - name: TRADING_AUTONOMY_ENABLED
+              value: "false"
             - name: TRADING_AUTONOMY_ALLOW_LIVE_PROMOTION
               value: "false"
             - name: TRADING_ACCOUNT_LABEL


### PR DESCRIPTION
## Summary

- disable Torghut live autonomy so LLM/autonomy failures cannot trip the production trading rollback path
- keep the live trading scheduler running in `TRADING_MODE=live` while removing the autonomy loop from the production critical path
- leave the separate WS overnight backfill fix to the already-merged `main` change in #4317

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/torghut >/dev/null`
- Live verification before this change showed the normal trading loop healthy while autonomy remained enabled: `GET /trading/health`, `GET /trading/status`, and production pod/env inspection via `kubectl exec`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
