### PR TITLE
fix(torghut): skip whitepapers bootstrap hook

### DIFF
--- a/argocd/applications/torghut/whitepapers-bucket-bootstrap-job.yaml
+++ b/argocd/applications/torghut/whitepapers-bucket-bootstrap-job.yaml
@@ -4,8 +4,7 @@ metadata:
   name: torghut-whitepapers-bootstrap
   namespace: torghut
   annotations:
-    argocd.argoproj.io/hook: PostSync
-    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookSucceeded
+    argocd.argoproj.io/hook: Skip
 spec:
   backoffLimit: 2
   ttlSecondsAfterFinished: 300


### PR DESCRIPTION
## Summary

- mark the whitepapers bucket bootstrap job as `argocd.argoproj.io/hook: Skip`
- stop the unrelated whitepapers bootstrap hook from blocking Torghut production syncs and Knative revision rollouts
- keep the change GitOps-only so the live trading service can reconcile cleanly without manual cluster drift

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/torghut >/dev/null`
- `kubectl get application -n argocd torghut -o jsonpath={.status.operationState.message}` showed the live sync blocked on `batch/Job/torghut-whitepapers-bootstrap` before this change

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
