### PR TITLE
fix(jangar): support kubectl watch compatibility

### DIFF
--- a/services/jangar/src/server/__tests__/kube-watch.test.ts
+++ b/services/jangar/src/server/__tests__/kube-watch.test.ts
@@ -3,6 +3,7 @@ import { EventEmitter } from 'node:events'
 
 const childProcessMocks = vi.hoisted(() => ({
   spawn: vi.fn(),
+  spawnSync: vi.fn(),
 }))
 
 vi.mock('node:child_process', () => childProcessMocks)
@@ -17,7 +18,7 @@ vi.mock('~/server/metrics', () => ({
   recordKubeWatchRestart: (...args: unknown[]) => recordWatchRestartMock(...args),
 }))
 
-import { startResourceWatch } from '~/server/kube-watch'
+import { resetKubectlWatchCompatibilityCacheForTests, startResourceWatch } from '~/server/kube-watch'
 
 type MockWatchProcess = EventEmitter & {
   stdout: EventEmitter & { setEncoding: (encoding: string | undefined) => void }
@@ -40,14 +41,21 @@ const createMockWatchProcess = () => {
 
 describe('kube-watch', () => {
   const spawnMocks = childProcessMocks.spawn
+  const spawnSyncMocks = childProcessMocks.spawnSync
   let watchHandle: ReturnType<typeof startResourceWatch> | null = null
 
   beforeEach(() => {
     vi.useFakeTimers()
     spawnMocks.mockReset()
+    spawnSyncMocks.mockReset()
+    spawnSyncMocks.mockReturnValue({
+      stdout: '    --resource-version="":\n',
+      stderr: '',
+    })
     recordWatchEventMock.mockReset()
     recordWatchErrorMock.mockReset()
     recordWatchRestartMock.mockReset()
+    resetKubectlWatchCompatibilityCacheForTests()
   })
 
   afterEach(() => {
@@ -237,5 +245,30 @@ describe('kube-watch', () => {
 
     expect(spawnMocks).toHaveBeenCalledTimes(2)
     expect(spawnMocks.mock.calls[1]?.[1]).not.toContain('--resource-version=12345')
+  })
+
+  it('skips the resource version flag when kubectl get does not support it', () => {
+    const watchProcess = createMockWatchProcess()
+    spawnMocks.mockReturnValue(watchProcess)
+    spawnSyncMocks.mockReturnValue({
+      stdout: '    --watch-only=false:\n',
+      stderr: '',
+    })
+
+    watchHandle = startResourceWatch({
+      resource: 'approvalpolicies.approvals.proompteng.ai',
+      namespace: 'agents',
+      resourceVersion: '12345',
+      onEvent: vi.fn(),
+    })
+
+    expect(spawnSyncMocks).toHaveBeenCalledWith(
+      'kubectl',
+      ['get', '--help'],
+      expect.objectContaining({
+        encoding: 'utf8',
+      }),
+    )
+    expect(spawnMocks.mock.calls[0]?.[1]).not.toContain('--resource-version=12345')
   })
 })

--- a/services/jangar/src/server/kube-watch.ts
+++ b/services/jangar/src/server/kube-watch.ts
@@ -1,4 +1,4 @@
-import { spawn } from 'node:child_process'
+import { spawn, spawnSync } from 'node:child_process'
 import { recordKubeWatchError, recordKubeWatchEvent, recordKubeWatchRestart } from '~/server/metrics'
 import {
   recordWatchReliabilityError,
@@ -29,6 +29,30 @@ type WatchHandle = {
 }
 
 const DEFAULT_RESTART_DELAY_MS = 2_000
+let kubectlGetSupportsResourceVersionFlag: boolean | null = null
+
+const detectKubectlGetSupportsResourceVersionFlag = (): boolean => {
+  if (kubectlGetSupportsResourceVersionFlag !== null) {
+    return kubectlGetSupportsResourceVersionFlag
+  }
+
+  try {
+    const result = spawnSync('kubectl', ['get', '--help'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    const output = `${result.stdout ?? ''}\n${result.stderr ?? ''}`
+    kubectlGetSupportsResourceVersionFlag = output.includes('--resource-version')
+  } catch {
+    kubectlGetSupportsResourceVersionFlag = false
+  }
+
+  return kubectlGetSupportsResourceVersionFlag
+}
+
+export const resetKubectlWatchCompatibilityCacheForTests = () => {
+  kubectlGetSupportsResourceVersionFlag = null
+}
 
 const parseJsonStream = (onJson: (jsonText: string) => void) => {
   let buffer = ''
@@ -148,7 +172,7 @@ export const startResourceWatch = (options: WatchOptions): WatchHandle => {
       'json',
       '--request-timeout=0',
     ]
-    if (currentResourceVersion) {
+    if (currentResourceVersion && detectKubectlGetSupportsResourceVersionFlag()) {
       args.push(`--resource-version=${currentResourceVersion}`)
     }
     if (labelSelector) {


### PR DESCRIPTION
## Summary

- detect whether the local kubectl client supports `kubectl get --resource-version` before adding the flag to watch invocations
- skip the flag on newer clients that removed it so Jangar watch streams do not crash and poison control-plane watch reliability
- add a regression test covering the no-support fallback path

## Related Issues

None

## Testing

- `bunx vitest run --config vitest.config.ts src/server/__tests__/kube-watch.test.ts`
- `bunx oxfmt --check src/server/kube-watch.ts src/server/__tests__/kube-watch.test.ts`
- `bunx tsc --noEmit -p tsconfig.app.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
