### PR TITLE
chore(jangar): promote image 01fd28d0

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: f3c0483c
-  digest: sha256:2f16373e0c4797911b1d609a8fb6cd7c0654b5d1f201c1e47c33a0587d050f48
+  tag: 01fd28d0
+  digest: sha256:cfb504523baf5d6da1d39922ef89d3dec74958aa302af6ce09471c5e10a8b593
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: f3c0483c
-    digest: sha256:cb58ae0455d60b655acf9441753846b53212b45287171232ae214d68ef62ea98
+    tag: 01fd28d0
+    digest: sha256:3a1edcbe83417bd46d995d164ca0d000777208fe3da00612843b5138b5fa451c
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: f3c0483c
-    digest: sha256:2f16373e0c4797911b1d609a8fb6cd7c0654b5d1f201c1e47c33a0587d050f48
+    tag: 01fd28d0
+    digest: sha256:cfb504523baf5d6da1d39922ef89d3dec74958aa302af6ce09471c5e10a8b593
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-11T09:37:47Z"
+    deploy.knative.dev/rollout: "2026-03-11T10:42:38Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-11T09:37:47Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-11T10:42:38Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -60,5 +60,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "f3c0483c"
-    digest: sha256:2f16373e0c4797911b1d609a8fb6cd7c0654b5d1f201c1e47c33a0587d050f48
+    newTag: "01fd28d0"
+    digest: sha256:cfb504523baf5d6da1d39922ef89d3dec74958aa302af6ce09471c5e10a8b593


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `01fd28d0af8500737ca28b0241078c6e966c3b8a`
- Image tag: `01fd28d0`
- Image digest: `sha256:cfb504523baf5d6da1d39922ef89d3dec74958aa302af6ce09471c5e10a8b593`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`