### PR TITLE
fix(jangar): allow standby controllers to pass readiness

### DIFF
--- a/services/jangar/src/routes/ready.test.ts
+++ b/services/jangar/src/routes/ready.test.ts
@@ -106,7 +106,7 @@ describe('getReadyHandler', () => {
     expect(body.status).toBe('degraded')
   })
 
-  it('returns 503 when leader election is required but this instance is not leader', async () => {
+  it('returns 200 when leader election is required but this instance is a healthy standby', async () => {
     leaderElectionMocks.getLeaderElectionStatus.mockReturnValue({
       enabled: true,
       required: true,
@@ -118,6 +118,29 @@ describe('getReadyHandler', () => {
       lastAttemptAt: '2026-03-08T21:00:00Z',
       lastSuccessAt: '2026-03-08T21:00:00Z',
       lastError: null,
+    })
+
+    const { getReadyHandler } = await import('./ready')
+
+    const response = await getReadyHandler()
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.status).toBe('ok')
+  })
+
+  it('returns 503 when leader election is required but standby has not observed a healthy lease attempt', async () => {
+    leaderElectionMocks.getLeaderElectionStatus.mockReturnValue({
+      enabled: true,
+      required: true,
+      isLeader: false,
+      leaseName: 'jangar-controller-leader',
+      leaseNamespace: 'agents',
+      identity: 'agents-controllers-2',
+      lastTransitionAt: null,
+      lastAttemptAt: null,
+      lastSuccessAt: null,
+      lastError: 'lease watch failed',
     })
 
     const { getReadyHandler } = await import('./ready')

--- a/services/jangar/src/routes/ready.tsx
+++ b/services/jangar/src/routes/ready.tsx
@@ -15,6 +15,9 @@ const isAgentRunIngestionReady = (health: ReturnType<typeof getAgentsControllerH
   return namespaces.every((namespace) => assessAgentRunIngestion(namespace, health).status !== 'degraded')
 }
 
+const isStandbyLeaderElectionReady = (leaderElection: ReturnType<typeof getLeaderElectionStatus>) =>
+  leaderElection.lastAttemptAt !== null && leaderElection.lastError === null
+
 export const Route = createFileRoute('/ready')({
   server: {
     handlers: {
@@ -33,8 +36,12 @@ export const getReadyHandler = async () => {
     isControllerHealthReady(agentsController) &&
     isControllerHealthReady(orchestrationController) &&
     isControllerHealthReady(supportingController)
-  const agentsControllerReady =
-    (!leaderElection.required || leaderElection.isLeader) && isAgentRunIngestionReady(agentsController)
+  const leaderRequired = leaderElection.required
+  const activeControllerReplica = !leaderRequired || leaderElection.isLeader
+  const leaderElectionReady = activeControllerReplica || isStandbyLeaderElectionReady(leaderElection)
+  const agentsControllerReady = activeControllerReplica
+    ? isAgentRunIngestionReady(agentsController)
+    : leaderElectionReady
   const ready = controllersOk && agentsControllerReady
 
   const body = JSON.stringify({


### PR DESCRIPTION
## Summary

- allow healthy standby `agents-controllers` replicas to pass `/ready` after a successful lease attempt
- keep AgentRun ingestion as a readiness gate only on the active leader replica
- add regression coverage for healthy and unhealthy standby leader-election states

## Related Issues

None

## Testing

- `cd services/jangar && bunx vitest run --config vitest.config.ts src/routes/ready.test.ts`
- `bunx oxfmt --check services/jangar/src/routes/ready.tsx services/jangar/src/routes/ready.test.ts`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
