### PR TITLE
chore(jangar): promote image 43b444ca

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 01fd28d0
-  digest: sha256:cfb504523baf5d6da1d39922ef89d3dec74958aa302af6ce09471c5e10a8b593
+  tag: 43b444ca
+  digest: sha256:e0bfba2facae15d4d6819afad89dfac0a633b8f88d98c76344ab544a56d80213
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 01fd28d0
-    digest: sha256:3a1edcbe83417bd46d995d164ca0d000777208fe3da00612843b5138b5fa451c
+    tag: 43b444ca
+    digest: sha256:47c821759e8653efa74c867b6b257d89863449025d05fa52fd6a069efad87cb7
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 01fd28d0
-    digest: sha256:cfb504523baf5d6da1d39922ef89d3dec74958aa302af6ce09471c5e10a8b593
+    tag: 43b444ca
+    digest: sha256:e0bfba2facae15d4d6819afad89dfac0a633b8f88d98c76344ab544a56d80213
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-11T10:42:38Z"
+    deploy.knative.dev/rollout: "2026-03-11T15:48:38Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-11T10:42:38Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-11T15:48:38Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -60,5 +60,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "01fd28d0"
-    digest: sha256:cfb504523baf5d6da1d39922ef89d3dec74958aa302af6ce09471c5e10a8b593
+    newTag: "43b444ca"
+    digest: sha256:e0bfba2facae15d4d6819afad89dfac0a633b8f88d98c76344ab544a56d80213


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `43b444ca9ed969dec672b1a84b5f498de97e7831`
- Image tag: `43b444ca`
- Image digest: `sha256:e0bfba2facae15d4d6819afad89dfac0a633b8f88d98c76344ab544a56d80213`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`