### PR TITLE
fix(kafka): enforce broker spread in pool-b

### DIFF
--- a/argocd/applications/kafka/strimzi-kafka-cluster.yaml
+++ b/argocd/applications/kafka/strimzi-kafka-cluster.yaml
@@ -75,6 +75,26 @@ spec:
   replicas: 3
   roles:
     - broker
+  template:
+    pod:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  strimzi.io/cluster: kafka
+                  strimzi.io/name: kafka-kafka
+                  strimzi.io/pool-name: pool-b
+              topologyKey: kubernetes.io/hostname
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: DoNotSchedule
+          labelSelector:
+            matchLabels:
+              strimzi.io/cluster: kafka
+              strimzi.io/name: kafka-kafka
+              strimzi.io/pool-name: pool-b
   resources:
     requests:
       cpu: '2000m'


### PR DESCRIPTION
## Summary

- add strict `pool-b` broker placement rules to prevent same-pool Kafka brokers from landing on one hostname
- use pod anti-affinity and hostname topology spread constraints on the broker-only node pool
- keep the change scoped to `pool-b` so the existing controller quorum is unaffected

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/kafka > /tmp/kafka-placement-rendered.yaml`
- `kubectl apply --server-side --dry-run=server -f /tmp/kafka-pool-b-placement.yaml`
- `bun run lint:argocd`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
