### PR TITLE
fix(kafka): cut over pool-a to controllers only

### DIFF
--- a/argocd/applications/kafka/strimzi-kafka-cluster.yaml
+++ b/argocd/applications/kafka/strimzi-kafka-cluster.yaml
@@ -1,9 +1,10 @@
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: Kafka
 metadata:
   name: kafka
   namespace: kafka
   annotations:
+    argocd.argoproj.io/sync-options: Replace=true
     strimzi.io/node-pools: enabled
     strimzi.io/kraft: enabled
 spec:
@@ -42,7 +43,7 @@ spec:
     topicOperator: {}
     userOperator: {}
 ---
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaNodePool
 metadata:
   name: pool-a
@@ -53,7 +54,26 @@ spec:
   replicas: 3
   roles:
     - controller
-    - broker
+  template:
+    pod:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  strimzi.io/cluster: kafka
+                  strimzi.io/name: kafka-kafka
+                  strimzi.io/pool-name: pool-a
+              topologyKey: kubernetes.io/hostname
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: DoNotSchedule
+          labelSelector:
+            matchLabels:
+              strimzi.io/cluster: kafka
+              strimzi.io/name: kafka-kafka
+              strimzi.io/pool-name: pool-a
   resources:
     requests:
       cpu: '2000m'
@@ -64,7 +84,7 @@ spec:
     deleteClaim: false
     class: rook-ceph-block
 ---
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaNodePool
 metadata:
   name: pool-b
@@ -105,7 +125,7 @@ spec:
     deleteClaim: false
     class: rook-ceph-block
 ---
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaUser
 metadata:
   name: user1
@@ -116,7 +136,7 @@ spec:
   authentication:
     type: scram-sha-512
 ---
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaUser
 metadata:
   name: karapace
@@ -127,7 +147,7 @@ spec:
   authentication:
     type: scram-sha-512
 ---
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaUser
 metadata:
   name: facteur
@@ -148,7 +168,7 @@ spec:
           reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
           reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "facteur"
 ---
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaUser
 metadata:
   name: kafka-codex-credentials
@@ -169,7 +189,7 @@ spec:
           reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
           reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "argo-workflows,jangar"
 ---
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaUser
 metadata:
   name: froussard
@@ -190,7 +210,7 @@ spec:
           reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
           reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "froussard"
 ---
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaUser
 metadata:
   name: flink


### PR DESCRIPTION
## Summary

- cut `pool-a` over from `controller+broker` to controller-only after draining all topic replicas to `pool-b`
- add controller-pool anti-affinity and topology spread rules so the KRaft quorum stays one-per-node
- force Argo to replace the Kafka CR so deleted timeout keys are removed from live spec, and move the Kafka manifests to Strimzi `v1`

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/kafka >/tmp/kafka-rendered.yaml`
- `kubectl apply --dry-run=server -f argocd/applications/kafka/strimzi-kafka-cluster.yaml`
- `bun run lint:argocd`
- Manual live pre-cutover validation: `kafka-reassign-partitions.sh --verify` reported `0` partitions on brokers `0/1/2` and `0` under-replicated partitions before removing the broker role from `pool-a`

## Breaking Changes

- `pool-a` no longer serves broker replicas after this change; new broker capacity must be added to broker-only node pools, not the controller pool.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
