### PR TITLE
docs(kafka): record completed topology cutover

### DIFF
--- a/docs/incidents/2026-03-09-kafka-kraft-recovery-stall-and-strimzi-hardening.md
+++ b/docs/incidents/2026-03-09-kafka-kraft-recovery-stall-and-strimzi-hardening.md
@@ -129,17 +129,32 @@ Primary causes:
    - `controller.quorum.election.timeout.ms: 60000`
    - `controller.quorum.fetch.timeout.ms: 180000`
 
-## Current Verified State (At End of This Session)
+## Resolution And Current Verified State
 
-- Kafka app remained `Synced` but `Degraded`.
-- Brokers were still `0/1 Ready` and continued replaying logs.
-- Broker readiness still returned `HTTP 503` with `brokerState is 1`.
-- KafkaUsers remained `NotReady`.
-- The current boot was materially more stable than the earlier failure mode:
-  - metadata loader catch-up completed successfully,
-  - immediate duplicate-registration loops were cleared,
-  - and brokers were steadily advancing through log recovery.
-- However, recovery throughput was still too slow to declare incident resolved during this session.
+The incident was resolved in follow-up work on **2026-03-11 local / 2026-03-12 UTC** when the controller/broker split
+was completed and the live cluster converged onto the new broker set.
+
+Final verified state after the cutover:
+
+- Argo CD app `kafka`: `Synced`, `Healthy`
+- `Kafka` CR condition: `Ready=True`
+- `pool-a`: controller-only on node IDs `0,1,2`
+- `pool-b`: broker-only on node IDs `3,4,5`
+- old broker IDs `0,1,2` were unregistered from the Kafka cluster
+- active brokers `3,4,5` were all `unfenced`
+- under-replicated partitions: `0`
+- all `KafkaUser` resources: `Ready`
+
+Operational steps that closed the incident:
+
+1. The GitOps topology changes were merged so `pool-a` became controller-only and `pool-b` remained broker-only.
+2. The `pool-b` broker pods were restarted so they came up cleanly on the merged topology and clean generated config.
+3. Strimzi completed broker unregistration for old broker IDs `0,1,2`.
+4. The entity operator was restarted to clear stale bootstrap/admin-client state so `KafkaUser` reconciliation recovered.
+
+The incident is therefore closed as a resolved topology and recovery-convergence failure, with remaining follow-up
+focused on physical worker-node capacity and storage-latency risk reduction rather than unfinished Kafka logical
+topology work.
 
 ## Preventive Actions
 
@@ -153,6 +168,8 @@ Primary causes:
    - controller event latency,
    - and KRaft heartbeat/request timeout frequency.
 6. Treat direct broker ConfigMap edits as emergency-only and backport any valid long-term fix to supported Strimzi fields immediately.
+7. After major topology changes, explicitly validate broker registrations, fencing state, under-replicated partitions,
+   and `KafkaUser` reconciliation; GitOps health alone is not sufficient proof of convergence.
 
 ## Lessons Learned
 

--- a/docs/kafka-kraft-controller-broker-separation-design-2026-03-11.md
+++ b/docs/kafka-kraft-controller-broker-separation-design-2026-03-11.md
@@ -2,36 +2,36 @@
 
 ## Status
 
-- Version: `v1`
+- Version: `v2`
 - Last updated: **2026-03-11**
 - Source of truth (GitOps): `argocd/applications/kafka/**`
 - Current production baseline: Kafka `4.1.1`, Strimzi `0.50.0`
 
 ## Purpose
 
-Define the production target architecture and rollout plan to finish separating KRaft controller and broker duties in the
-shared Kafka cluster after the March 9, 2026 recovery incident and the March 11, 2026 broker-pool scale-out.
+Define the production target architecture, the executed rollout, and the remaining physical-infrastructure follow-up for
+separating KRaft controller and broker duties in the shared Kafka cluster after the March 9, 2026 recovery incident.
 
-This document is the design and rollout reference for the remaining work after PR `#4307` introduced `KafkaNodePool/pool-b`.
+This document is the design and completion record for the in-place controller/broker split delivered across PRs `#4307`,
+`#4330`, and `#4331`, plus the live operational cutover that converged the cluster afterward.
 
 ## Executive Summary
 
-The cluster no longer needs more controllers. It needs the existing three controllers to stop doing broker work.
+The cluster did not need more controllers. It needed the existing three controllers to stop doing broker work.
 
-The correct production end state is:
+The production topology is now:
 
 - `pool-a`: `3` controller-only nodes, preserving the existing controller quorum IDs `0,1,2`
 - `pool-b`: `3` broker-only nodes, carrying all partition replicas on broker IDs `3,4,5`
 - no broker partitions assigned to controller nodes
-- no planned application downtime during migration
+- no planned application downtime was required to complete the split
 
-The safe path is phased:
+The durable GitOps changes are merged, the old broker IDs `0,1,2` have been unregistered, and the live cluster has
+converged onto broker IDs `3,4,5`. The remaining work is outside the Kafka logical topology itself:
 
-1. Keep the existing `3`-controller quorum on `pool-a`
-2. Add worker-node capacity and enforce broker placement
-3. Reassign all partitions from brokers `0,1,2` to brokers `3,4,5`
-4. Verify steady-state health and restart behavior
-5. Remove the `broker` role from `pool-a`
+1. add more Kubernetes worker capacity for cleaner broker spread and stronger failure isolation
+2. keep monitoring storage latency on the Ceph-backed broker pool
+3. formalize the operational restart and recovery runbook for this new topology
 
 ## Background
 
@@ -45,17 +45,27 @@ On **2026-03-11**, the first durable topology step was completed by GitOps:
 - Argo CD applied the change at commit `18d023d5f13b70382e35c890e1d4a0dacfa867db`
 - new brokers `3,4,5` became `Ready`
 
-That change reduced future migration risk, but it did **not** finish the topology split. `pool-a` still carries both
-`controller` and `broker` roles, so the original controller quorum remains exposed to broker data placement and recovery
-load.
+On **2026-03-11**, the target topology was completed by GitOps in follow-up PRs:
+
+- PR `#4330` added broker anti-affinity and topology spread protections to `pool-b`
+- PR `#4331` removed the `broker` role from `pool-a`, making it controller-only in GitOps
+
+After the GitOps merge, the live cluster still needed runtime convergence:
+
+- brokers `4` and `5` remained fenced on the first incarnation after the role cutover
+- old broker IDs `0,1,2` were still present until Strimzi finished unregistering them
+- `KafkaUser` resources stayed stale `NotReady` until the entity operator was restarted
+
+Those runtime issues were resolved during the live cutover by restarting the `pool-b` brokers so they came up cleanly
+against the merged topology and then restarting the entity operator to clear stale admin-client bootstrap state.
 
 ## Current Verified State
 
-As of **2026-03-11 UTC**, the live cluster is:
+As of **2026-03-12 UTC**, the live cluster is:
 
 - Argo CD application `kafka`: `Synced`, `Healthy`
 - `KafkaNodePool/pool-a`:
-  - roles: `controller`, `broker`
+  - roles: `controller`
   - replicas: `3`
   - node IDs: `0,1,2`
   - storage: `rook-ceph-block`, `30Gi`, `deleteClaim: false`
@@ -66,22 +76,29 @@ As of **2026-03-11 UTC**, the live cluster is:
   - storage: `rook-ceph-block`, `30Gi`, `deleteClaim: false`
 - Kubernetes nodes:
   - only `3` nodes total exist in the cluster right now
-  - two Kafka brokers are currently colocated on `talos-192-168-1-203`
+  - broker spread is still constrained by the small node count, so physical failure-domain isolation remains weaker
+    than the logical Kafka topology
 - Kafka config baseline:
   - replication defaults `3`
   - `min.insync.replicas: 2`
   - no Cruise Control configured in the current `Kafka` CR
+- Operational verification:
+  - `Kafka` CR condition: `Ready=True`
+  - active broker registrations: only `3,4,5`
+  - broker endpoint state: `3,4,5` all `unfenced`
+  - under-replicated partitions: `0`
+  - `KafkaUser` resources: all `Ready`
 
 ## Problem Statement
 
-The current state is healthier than the incident state, but it is not yet production-correct for KRaft isolation.
+The Kafka topology split is complete and operationally healthy, but the broader platform is not yet at the ideal
+production footprint.
 
 Remaining issues:
 
-1. Controller nodes still carry broker partitions.
-2. Broker placement is not failure-domain clean because `6` Kafka pods are spread across only `3` Kubernetes nodes.
-3. A future restart on `pool-a` can still combine controller-path work with broker recovery work.
-4. There is no in-repo automated partition rebalance control plane yet.
+1. Broker placement is not failure-domain clean because `6` Kafka pods are still spread across only `3` Kubernetes nodes.
+2. Broker storage remains on `rook-ceph-block`, so Ceph latency is still a residual recovery and throughput risk.
+3. There is no in-repo automated rebalance control plane such as Cruise Control.
 
 ## Constraints And Invariants
 
@@ -159,12 +176,15 @@ flowchart TB
 - **Decision:** Move broker data off node IDs `0,1,2` and convert `pool-a` to controller-only.
 - **Rationale:** This is the supported in-place topology transition for the current Strimzi setup.
 - **Consequence:** All topic data ends up on broker IDs `3,4,5`.
+- **Status:** Completed.
 
 ### ADR-03: Add worker capacity before the heavy rebalance
 
 - **Decision:** Add at least `3` Kubernetes worker nodes before large-scale partition reassignment.
 - **Rationale:** The current cluster has only `3` nodes, so broker spread is not clean yet.
-- **Consequence:** The rebalance should not be considered production-complete until broker placement is one-per-node.
+- **Consequence:** The Kafka topology can still be correct, but the infrastructure is not yet at the desired
+  production-quality failure-domain posture.
+- **Status:** Still open.
 
 ### ADR-04: Use controlled manual partition reassignment for this migration
 
@@ -180,14 +200,46 @@ flowchart TB
   downtime.
 - **Consequence:** Storage latency remains a residual risk to monitor after the split.
 
-## Required Follow-up Changes
+## Executed Rollout
+
+### Phase 0: Broker-only capacity added
+
+- `pool-b` was created as a `3`-replica broker-only `KafkaNodePool`
+- broker IDs `3,4,5` were introduced as the target data plane
+- Argo reconciled the pool successfully
+
+### Phase 1: Broker placement protections added in GitOps
+
+- `pool-b` received anti-affinity and topology spread constraints
+- this improved placement intent, although the cluster still lacks enough worker nodes for ideal spread
+
+### Phase 2: Partition movement and broker drain completed
+
+- topic replicas were moved onto brokers `3,4,5`
+- by the time the controller-only cutover stabilized, there were no remaining partitions assigned to broker IDs `0,1,2`
+- under-replicated partitions returned to `0`
+
+### Phase 3: Controller-only conversion merged in GitOps
+
+- `pool-a` roles were changed from `controller, broker` to `controller`
+- the change merged via PR `#4331`
+- this made the intended topology durable in GitOps
+
+### Phase 4: Live runtime convergence completed
+
+- broker-only pods `kafka-pool-b-3/4/5` were restarted so they came up cleanly against the merged topology
+- Strimzi unregistered old broker IDs `0,1,2`
+- the entity operator was restarted to clear stale `KafkaUser` admin-client bootstrap failures
+- the cluster converged to a healthy steady state without planned application downtime
+
+## Remaining Infrastructure Follow-up
 
 ### 1. Add worker-node capacity
 
 Minimum requirement:
 
 - add `3` worker nodes
-- ensure broker pool pods can spread one-per-node
+- ensure the broker pool can spread one broker per worker node
 
 Recommended node policy:
 
@@ -195,164 +247,17 @@ Recommended node policy:
 - optionally taint them if Kafka brokers should be isolated from general workloads
 - keep controller pods on the existing controller quorum nodes unless a separate controller migration is designed later
 
-Recommended GitOps placement policy for `pool-b`:
+### 2. Tighten explicit placement policy once worker nodes exist
 
-- use `KafkaNodePool.spec.template.pod.affinity.nodeAffinity` to require broker-labeled nodes
-- use `KafkaNodePool.spec.template.pod.affinity.podAntiAffinity` to keep brokers apart
-- use `KafkaNodePool.spec.template.pod.topologySpreadConstraints` to enforce one broker per node where possible
+- require `pool-b` onto broker-labeled workers through node affinity
+- keep anti-affinity and topology spread active
+- optionally add explicit controller affinity for `pool-a` if the control-plane nodes must be pinned in GitOps
 
-### 2. Add placement policy to the Kafka GitOps manifests
+### 3. Add steady-state recovery and latency observability
 
-This design expects a follow-up PR that updates `pool-b` with:
-
-- worker-node affinity
-- anti-affinity against other Kafka brokers
-- topology spread constraints by `kubernetes.io/hostname`
-
-Optional follow-up:
-
-- add corresponding node affinity for `pool-a` if controller placement must be explicitly pinned
-
-### 3. Audit topic replication and capacity before reassignment
-
-Before moving replicas:
-
-- confirm no critical topics are still at replication factor `1`
-- confirm internal topics remain at replication factor `3`
-- confirm projected broker-disk usage fits on brokers `3,4,5`
-- confirm the cluster has no sustained under-replicated partitions
-
-Capacity gate:
-
-- do not start the migration unless the target broker pool has enough free capacity to absorb all existing broker data
-  from `pool-a` with headroom for normal growth and compaction
-
-## Rollout Plan
-
-### Phase 0: Completed baseline
-
-Already done:
-
-- `pool-b` created and reconciled
-- brokers `3,4,5` registered and are `Ready`
-- Argo app `kafka` is `Synced` and `Healthy`
-
-### Phase 1: Prepare scheduling and capacity
-
-1. Add `3` worker nodes.
-2. Label the worker nodes for Kafka brokers.
-3. Patch GitOps manifests so `pool-b` only schedules onto broker-labeled workers.
-4. Let Strimzi roll `pool-b` onto the new workers.
-5. Verify one broker per node and healthy PVC attachment.
-
-Exit criteria:
-
-- `pool-b-3`, `pool-b-4`, `pool-b-5` each run on a distinct worker node
-- `pool-a` remains healthy
-- Argo app `kafka` remains `Healthy`
-
-### Phase 2: Inventory and generate reassignment plans
-
-1. Collect current topic and partition assignments.
-2. Build reassignment JSON that targets only brokers `3,4,5`.
-3. Exclude no topics unless there is an explicit documented exception.
-4. Split reassignment into batches if total movement volume is high.
-
-Recommended batching order:
-
-1. low-value and low-throughput topics
-2. application topics
-3. internal topics such as `__consumer_offsets` and `__transaction_state`
-
-Rationale:
-
-- prove mechanics first on the lowest-risk data
-- keep rollback simpler early
-- move critical internals only after the target brokers have shown stable behavior
-
-### Phase 3: Execute reassignment with throttles
-
-Recommended execution method:
-
-- use Kafka admin tooling from a Strimzi Kafka container or another trusted admin pod
-- execute reassignment with inter-broker and replication throttles
-- verify completion after every batch before starting the next one
-
-Representative workflow:
-
-```sh
-# 1. Export current assignments for the batch.
-kafka-topics.sh --bootstrap-server kafka-kafka-bootstrap.kafka.svc:9092 --describe
-
-# 2. Generate a reassignment targeting brokers 3,4,5.
-kafka-reassign-partitions.sh \
-  --bootstrap-server kafka-kafka-bootstrap.kafka.svc:9092 \
-  --topics-to-move-json-file topics-batch.json \
-  --broker-list 3,4,5 \
-  --generate > reassignment-batch.out
-
-# 3. Execute with throttle.
-kafka-reassign-partitions.sh \
-  --bootstrap-server kafka-kafka-bootstrap.kafka.svc:9092 \
-  --reassignment-json-file reassignment-batch.json \
-  --execute
-
-# 4. Verify until complete.
-kafka-reassign-partitions.sh \
-  --bootstrap-server kafka-kafka-bootstrap.kafka.svc:9092 \
-  --reassignment-json-file reassignment-batch.json \
-  --verify
-```
-
-Operational guardrails:
-
-- only one reassignment batch at a time
-- do not start a new batch if under-replicated partitions are non-zero
-- do not remove throttles or proceed during controller instability
-- pause if broker disk, network, or Ceph latency spikes materially
-
-### Phase 4: Validate broker drain completion
-
-Before touching roles, prove that brokers `0,1,2` no longer host topic replicas.
-
-Required validation:
-
-- no topic partitions assigned to brokers `0,1,2`
-- no leaders on brokers `0,1,2`
-- no preferred leaders on brokers `0,1,2`
-- all partitions on brokers `3,4,5` have healthy ISR
-
-Acceptance gate:
-
-- maintain clean steady state for at least one business day before role removal
-
-### Phase 5: Convert `pool-a` to controller-only
-
-Once broker drain is complete:
-
-1. Update `KafkaNodePool/pool-a` roles from:
-   - `controller`
-   - `broker`
-2. To:
-   - `controller`
-3. Merge the GitOps PR and let Argo reconcile.
-4. Verify `pool-a` rolls cleanly as controller-only.
-
-Post-change expected state:
-
-- `pool-a`: controller-only
-- `pool-b`: broker-only
-- no partition data assigned to controller nodes
-
-### Phase 6: Post-cut validation and recovery drill
-
-Run production validation after the split:
-
-1. rolling restart one broker in `pool-b`
-2. rolling restart one controller in `pool-a`
-3. confirm no application-visible outage
-4. confirm Kafka users remain `Ready`
-5. confirm broker recovery time is materially lower than the March 9 incident path
+- alert on under-replicated partitions, offline partitions, and broker fencing
+- alert on controller event latency and KRaft heartbeat timeout churn
+- keep `KafkaUser` readiness and entity-operator health on the shared-cluster operational dashboard
 
 ## Observability And Validation
 
@@ -417,7 +322,7 @@ Important note:
 
 ## Success Criteria
 
-The migration is complete only when all of the following are true:
+The topology program is considered complete for the Kafka layer when all of the following are true:
 
 1. Argo app `kafka` is `Synced` and `Healthy`.
 2. `pool-a` is controller-only.
@@ -428,21 +333,26 @@ The migration is complete only when all of the following are true:
 7. A rolling restart of one broker and one controller completes without incident.
 8. Controller-path latency is materially lower than the March 9 incident profile.
 
+Status at the time of this update:
+
+- Criteria `1` through `6` are satisfied.
+- Criteria `7` and `8` should remain part of operational follow-up and routine recovery drills.
+
 ## Residual Risks
 
 - `rook-ceph-block` latency may still be a bottleneck even after role separation.
 - A three-broker cluster still has limited data-plane fault tolerance compared with larger broker fleets.
-- Manual reassignment is operationally safe but more operator-dependent than Cruise Control.
-- If workers are not added, broker colocation continues to weaken fault isolation.
+- The completed one-time reassignment worked, but future balancing is still more operator-dependent than Cruise Control.
+- Until more worker nodes exist, broker colocation continues to weaken fault isolation.
 
 ## Follow-up Work After This Design
 
 ### Near-term follow-ups
 
-1. GitOps PR for broker-node affinity and topology spread rules
-2. infrastructure change to add `3` worker nodes
-3. runbook PR for the exact reassignment commands and throttle defaults used in production
-4. GitOps PR to convert `pool-a` to controller-only after the drain is complete
+1. infrastructure change to add `3` worker nodes
+2. GitOps PR to require `pool-b` onto broker-labeled workers once those nodes exist
+3. runbook PR for broker/controller restart drills and Kafka recovery verification under the new topology
+4. optional automation design for future partition balancing and capacity management
 
 ### Optional longer-term follow-ups
 


### PR DESCRIPTION
## Summary

- update the Kafka controller/broker separation design doc to record the completed target topology
- document the live convergence work that brought brokers 3, 4, and 5 fully online and unfenced
- close the March 9, 2026 Kafka incident report with the final resolved state and follow-up risks

## Related Issues

None

## Testing

- `git diff --check`
- `kubectl get application -n argocd kafka -o jsonpath='{.status.sync.status} {.status.health.status}{"\n"}'`
- `kubectl get kafka -n kafka kafka -o jsonpath='{range .status.conditions[*]}{.type}={.status} {.message}{"\n"}{end}'`
- `kubectl exec -n kafka kafka-pool-b-3 -- /opt/kafka/bin/kafka-cluster.sh list-endpoints --bootstrap-server localhost:9093 --include-fenced-brokers`
- `kubectl exec -n kafka kafka-pool-b-3 -- bash -lc '/opt/kafka/bin/kafka-topics.sh --bootstrap-server localhost:9093 --describe --under-replicated-partitions | wc -l'`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
