### PR TITLE
chore(torghut): promote image cafd13b9

### DIFF
--- a/argocd/applications/torghut-forecast/deployment.yaml
+++ b/argocd/applications/torghut-forecast/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: forecast
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:bb70f75a67894c73d30c28b8d8b2f24e99d86b2d530200dc659810b1c2c22694
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:bbc36450dbbe555416facad675a5380bc481374a43e552b577bd4193bb7dcb48
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn

--- a/argocd/applications/torghut-forecast/sim/deployment.yaml
+++ b/argocd/applications/torghut-forecast/sim/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: forecast
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:bb70f75a67894c73d30c28b8d8b2f24e99d86b2d530200dc659810b1c2c22694
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:bbc36450dbbe555416facad675a5380bc481374a43e552b577bd4193bb7dcb48
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn

--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:bb70f75a67894c73d30c28b8d8b2f24e99d86b2d530200dc659810b1c2c22694
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:bbc36450dbbe555416facad675a5380bc481374a43e552b577bd4193bb7dcb48
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -63,9 +63,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.563.0-51-g4512c5c4
+              value: v0.564.0-25-gcafd13b9
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 4512c5c4be4bf30d36bc275da540e10ca6335d2b
+              value: cafd13b99743a46b8880bc798bd4ccb47fc56583
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:bb70f75a67894c73d30c28b8d8b2f24e99d86b2d530200dc659810b1c2c22694
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:bbc36450dbbe555416facad675a5380bc481374a43e552b577bd4193bb7dcb48
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -63,9 +63,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.563.0-51-g4512c5c4
+              value: v0.564.0-25-gcafd13b9
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 4512c5c4be4bf30d36bc275da540e10ca6335d2b
+              value: cafd13b99743a46b8880bc798bd4ccb47fc56583
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -40,7 +40,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:bb70f75a67894c73d30c28b8d8b2f24e99d86b2d530200dc659810b1c2c22694
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:bbc36450dbbe555416facad675a5380bc481374a43e552b577bd4193bb7dcb48
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -21,7 +21,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:bb70f75a67894c73d30c28b8d8b2f24e99d86b2d530200dc659810b1c2c22694
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:bbc36450dbbe555416facad675a5380bc481374a43e552b577bd4193bb7dcb48
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -30,7 +30,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:bb70f75a67894c73d30c28b8d8b2f24e99d86b2d530200dc659810b1c2c22694
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:bbc36450dbbe555416facad675a5380bc481374a43e552b577bd4193bb7dcb48
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -30,7 +30,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:bb70f75a67894c73d30c28b8d8b2f24e99d86b2d530200dc659810b1c2c22694
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:bbc36450dbbe555416facad675a5380bc481374a43e552b577bd4193bb7dcb48
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:bb70f75a67894c73d30c28b8d8b2f24e99d86b2d530200dc659810b1c2c22694
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:bbc36450dbbe555416facad675a5380bc481374a43e552b577bd4193bb7dcb48
           command:
             - alembic
           args:

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -13,7 +13,7 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:bb70f75a67894c73d30c28b8d8b2f24e99d86b2d530200dc659810b1c2c22694
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:bbc36450dbbe555416facad675a5380bc481374a43e552b577bd4193bb7dcb48
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -21,7 +21,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:bb70f75a67894c73d30c28b8d8b2f24e99d86b2d530200dc659810b1c2c22694
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:bbc36450dbbe555416facad675a5380bc481374a43e552b577bd4193bb7dcb48
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -39,7 +39,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:bb70f75a67894c73d30c28b8d8b2f24e99d86b2d530200dc659810b1c2c22694
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:bbc36450dbbe555416facad675a5380bc481374a43e552b577bd4193bb7dcb48
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-03-09T04:57:54Z"
+        client.knative.dev/updateTimestamp: "2026-03-12T04:40:11Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:bb70f75a67894c73d30c28b8d8b2f24e99d86b2d530200dc659810b1c2c22694
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:bbc36450dbbe555416facad675a5380bc481374a43e552b577bd4193bb7dcb48
           ports:
             - name: http1
               containerPort: 8181
@@ -458,9 +458,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.563.0-51-g4512c5c4
+              value: v0.564.0-25-gcafd13b9
             - name: TORGHUT_COMMIT
-              value: 4512c5c4be4bf30d36bc275da540e10ca6335d2b
+              value: cafd13b99743a46b8880bc798bd4ccb47fc56583
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-03-09T04:57:54Z"
+        client.knative.dev/updateTimestamp: "2026-03-12T04:40:11Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -26,7 +26,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:bb70f75a67894c73d30c28b8d8b2f24e99d86b2d530200dc659810b1c2c22694
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:bbc36450dbbe555416facad675a5380bc481374a43e552b577bd4193bb7dcb48
           ports:
             - name: http1
               containerPort: 8181
@@ -458,9 +458,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.563.0-51-g4512c5c4
+              value: v0.564.0-25-gcafd13b9
             - name: TORGHUT_COMMIT
-              value: 4512c5c4be4bf30d36bc275da540e10ca6335d2b
+              value: cafd13b99743a46b8880bc798bd4ccb47fc56583
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/lean-runner-deployment.yaml
+++ b/argocd/applications/torghut/lean-runner-deployment.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: lean-runner
           # Keep in lockstep with `argocd/applications/torghut/knative-service.yaml`.
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:bb70f75a67894c73d30c28b8d8b2f24e99d86b2d530200dc659810b1c2c22694
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:bbc36450dbbe555416facad675a5380bc481374a43e552b577bd4193bb7dcb48
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `cafd13b99743a46b8880bc798bd4ccb47fc56583`
- Image tag: `cafd13b9`
- Image digest: `sha256:bbc36450dbbe555416facad675a5380bc481374a43e552b577bd4193bb7dcb48`