### PR TITLE
feat(tailscale): route kubernetes split dns via connector

### DIFF
--- a/argocd/applications/tailscale/README.md
+++ b/argocd/applications/tailscale/README.md
@@ -31,3 +31,7 @@ export TAILSCALE_SEALED_CONTROLLER_NAMESPACE=sealed-secrets
 ```
 
 After committing the refreshed `secrets.yaml`, Argo CD will reconcile the new credentials automatically.
+
+The same Argo application also carries the operator-managed `Connector` used for
+cluster subnet routing. Keep the Connector manifest in this directory aligned
+with the live pod and service CIDRs when cluster networking changes.

--- a/argocd/applications/tailscale/base/connector-subnet-router.yaml
+++ b/argocd/applications/tailscale/base/connector-subnet-router.yaml
@@ -1,0 +1,14 @@
+apiVersion: tailscale.com/v1alpha1
+kind: Connector
+metadata:
+  name: kubernetes-subnet-router
+  namespace: tailscale
+spec:
+  hostname: k8s-subnet-router
+  replicas: 1
+  tags:
+    - tag:k8s-subnet-router
+  subnetRouter:
+    advertiseRoutes:
+      - 10.244.0.0/16
+      - 10.96.0.0/12

--- a/argocd/applications/tailscale/kustomization.yaml
+++ b/argocd/applications/tailscale/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - https://raw.githubusercontent.com/tailscale/tailscale/refs/tags/v1.94.2/cmd/k8s-operator/deploy/manifests/operator.yaml
   - base/secrets.yaml
   - base/coredns-custom.yaml
+  - base/connector-subnet-router.yaml
 
 images:
   - name: tailscale/k8s-operator

--- a/devices/nuc/pihole/README.md
+++ b/devices/nuc/pihole/README.md
@@ -20,6 +20,7 @@ Files:
   - web UI ports/theme
   - Tailscale-safe DNS listener mode (`listeningMode = 'ALL'` with firewall restriction)
 - `99-kubernetes-split-dns.conf` installs the Pi-hole dnsmasq forwarding rule for `cluster.local`.
+- Pi-hole v6 requires `misc.etc_dnsmasq_d = true` in `pihole.toml` or it will ignore files in `/etc/dnsmasq.d/`.
 - `apply.sh` installs both `pihole.toml` and `99-kubernetes-split-dns.conf`, enables `tailscale --accept-routes`, opens DNS on `tailscale0`, and restarts Pi-hole.
 
 Not stored in Git:

--- a/devices/nuc/pihole/apply.sh
+++ b/devices/nuc/pihole/apply.sh
@@ -12,6 +12,8 @@ config_src="${script_dir}/99-kubernetes-split-dns.conf"
 config_dest="/etc/dnsmasq.d/99-kubernetes-split-dns.conf"
 tailscale_interface="${TAILSCALE_INTERFACE:-tailscale0}"
 lan_cidr="${LAN_CIDR:-192.168.1.0/24}"
+coredns_ip="${COREDNS_IP:-10.96.0.10}"
+kubernetes_probe="${KUBERNETES_PROBE_NAME:-kubernetes.default.svc.cluster.local}"
 
 if [[ ! -f "${toml_src}" ]]; then
   echo "missing config source: ${toml_src}" >&2
@@ -26,8 +28,13 @@ fi
 install -D -o pihole -g pihole -m 0644 "${toml_src}" "${toml_dest}"
 install -D -m 0644 "${config_src}" "${config_dest}"
 
-# Pi-hole can only forward cluster.local if this host accepts the kube-node subnet routes.
+# Pi-hole can only forward cluster.local if this host accepts the advertised cluster routes.
 tailscale set --accept-routes=true
+
+if ! tailscale debug prefs | grep -Eq '"RouteAll":[[:space:]]*true'; then
+  echo "tailscale routes are not enabled after tailscale set --accept-routes=true" >&2
+  exit 1
+fi
 
 if command -v ufw >/dev/null 2>&1; then
   ufw allow in on "${tailscale_interface}" to any port 53 proto tcp
@@ -37,6 +44,21 @@ if command -v ufw >/dev/null 2>&1; then
 fi
 
 systemctl restart pihole-FTL
+
+if ! timeout 5 bash -lc "until ip route get ${coredns_ip} >/dev/null 2>&1; do sleep 1; done"; then
+  echo "no route to CoreDNS service IP ${coredns_ip} after enabling tailscale routes" >&2
+  exit 1
+fi
+
+if ! dig +time=2 +tries=1 @"${coredns_ip}" "${kubernetes_probe}" >/dev/null; then
+  echo "CoreDNS at ${coredns_ip} is not reachable from this host" >&2
+  exit 1
+fi
+
+if ! dig +time=2 +tries=1 @127.0.0.1 "${kubernetes_probe}" >/dev/null; then
+  echo "Pi-hole did not resolve ${kubernetes_probe} via CoreDNS forwarding" >&2
+  exit 1
+fi
 
 echo "Pi-hole Tailscale DNS configuration applied."
 echo "Verification:"

--- a/devices/nuc/pihole/pihole.toml
+++ b/devices/nuc/pihole/pihole.toml
@@ -85,6 +85,9 @@ set = false
 device = ''
 utc = false
 
+[misc]
+etc_dnsmasq_d = true
+
 [webserver]
 port = '8080o,8443os,[::]:8080o,[::]:84'
 headers = [

--- a/tofu/tailscale/README.md
+++ b/tofu/tailscale/README.md
@@ -28,7 +28,19 @@ DNS settings are managed centrally through `tailscale_dns_configuration.tailnet`
 - split DNS from `dns_split_nameservers`
 - `override_local_dns` to control whether the global resolvers replace local DNS for non-tailnet queries
 
-The current default global resolver remains `192.168.1.130`. If Pi-hole should be reachable over Tailscale instead of only on the LAN, change that to the Pi-hole node's Tailscale IP after Pi-hole is configured to answer on `tailscale0` and the firewall allows DNS over the tailnet.
+The production default is split-only Kubernetes DNS:
+
+- `override_local_dns = false`
+- no global nameservers are pushed to the tailnet
+- `dns_split_nameservers = { "cluster.local" = ["100.88.12.116"] }`
+
+This keeps Pi-hole off the critical path for non-Kubernetes DNS while still routing `cluster.local` through the `nuc` device over Tailscale.
+
+Only apply this DNS posture after:
+
+- the in-cluster Tailscale `Connector` is advertising `10.244.0.0/16` and `10.96.0.0/12`
+- `nuc` can reach `10.96.0.10`
+- Pi-hole on `nuc` resolves `cluster.local` locally
 
 Example split DNS for Kubernetes through Pi-hole on the `nuc` device:
 
@@ -38,6 +50,8 @@ dns_split_nameservers = {
 }
 ```
 
-Kubernetes subnet routes approved for tagged kube nodes come from `kubernetes_routes`. Keep this aligned with the actual pod and service CIDRs used by the cluster. As of 2026-03-11, the live cluster was observed with `--cluster-cidr=10.244.0.0/16`, `--service-cluster-ip-range=10.96.0.0/12`, and `kube-dns` at `10.96.0.10`, so the defaults include `10.244.0.0/16` and `10.96.0.0/12`.
+If the `nuc` Tailscale IP changes, update `dns_split_nameservers` before applying this stack.
+
+Kubernetes subnet routes approved for Tailscale subnet routers come from `kubernetes_routes`. Keep this aligned with the actual pod and service CIDRs used by the cluster. As of 2026-03-11, the live cluster was observed with `--cluster-cidr=10.244.0.0/16`, `--service-cluster-ip-range=10.96.0.0/12`, and `kube-dns` at `10.96.0.10`, so the defaults include `10.244.0.0/16` and `10.96.0.0/12`.
 
 > ℹ️ HTTPS certificates remain a manual tailnet toggle today. Enable MagicDNS and HTTPS in the Tailscale admin console under **DNS → HTTPS certificates** before relying on `tailscale serve` or automated cert provisioning.

--- a/tofu/tailscale/main.tf
+++ b/tofu/tailscale/main.tf
@@ -59,15 +59,15 @@ resource "tailscale_dns_configuration" "tailnet" {
 data "tailscale_devices" "all" {}
 
 locals {
-  kube_devices = {
+  subnet_router_devices = {
     for device in data.tailscale_devices.all.devices :
     device.hostname => device.id
-    if length(device.hostname) > 0 && contains(coalesce(device.tags, []), "tag:kube-node")
+    if length(device.hostname) > 0 && contains(coalesce(device.tags, []), "tag:k8s-subnet-router")
   }
 }
 
-resource "tailscale_device_subnet_routes" "kube_nodes" {
-  for_each = local.kube_devices
+resource "tailscale_device_subnet_routes" "subnet_routers" {
+  for_each = local.subnet_router_devices
 
   device_id = each.value
   routes    = var.kubernetes_routes

--- a/tofu/tailscale/templates/policy.hujson.tmpl
+++ b/tofu/tailscale/templates/policy.hujson.tmpl
@@ -9,6 +9,7 @@
   "tagOwners": {
     "tag:k8s-operator": ["autogroup:admin"],
     "tag:k8s": ["tag:k8s-operator"],
+    "tag:k8s-subnet-router": ["tag:k8s-operator"],
     "tag:kube-node": ["tag:k8s-operator"]
   },
 
@@ -46,12 +47,12 @@
     }
   ],
 
-  // Auto-approve subnet routes for tagged Kubernetes nodes so no manual
-  // intervention is required when k3s nodes rejoin or scale out.
+  // Auto-approve subnet routes for the dedicated Kubernetes subnet router
+  // devices managed through the Tailscale Kubernetes operator.
   "autoApprovers": {
     "routes": {
-      "10.244.0.0/16": ["tag:kube-node"],
-      "10.96.0.0/12": ["tag:kube-node"]
+      "10.244.0.0/16": ["tag:k8s-subnet-router"],
+      "10.96.0.0/12": ["tag:k8s-subnet-router"]
     }
   }
 }

--- a/tofu/tailscale/variables.tf
+++ b/tofu/tailscale/variables.tf
@@ -7,21 +7,21 @@ variable "tailnet" {
 variable "dns_nameservers" {
   description = "Global nameservers used by tailnet devices when overriding local DNS settings."
   type        = list(string)
-  default = [
-    "192.168.1.130"
-  ]
+  default     = []
 }
 
 variable "override_local_dns" {
   description = "Whether to force tailnet devices to use the configured global nameservers for non-tailnet queries."
   type        = bool
-  default     = true
+  default     = false
 }
 
 variable "dns_split_nameservers" {
   description = "Per-domain split DNS nameservers. Keys are domains and values are the nameserver IPs for that domain."
   type        = map(list(string))
-  default     = {}
+  default = {
+    "cluster.local" = ["100.88.12.116"]
+  }
 }
 
 variable "kubernetes_routes" {


### PR DESCRIPTION
## Summary

- add an operator-managed Tailscale Connector that advertises the live Kubernetes pod and service CIDRs from inside the cluster
- move route approval to a dedicated `tag:k8s-subnet-router` identity and retarget the Tailscale OpenTofu stack to manage connector routes
- make Pi-hole v6 on `nuc` load `/etc/dnsmasq.d`, verify accepted Tailscale routes, and forward `cluster.local` to CoreDNS without taking over non-cluster tailnet DNS

## Related Issues

None

## Testing

- `tofu -chdir=tofu/tailscale validate`
- `kubectl kustomize argocd/applications/tailscale >/tmp/tailscale-kustomize.yaml && grep -n 'kubernetes-subnet-router\|tag:k8s-subnet-router\|10.244.0.0/16\|10.96.0.0/12' /tmp/tailscale-kustomize.yaml`
- `kubectl apply --dry-run=server -f argocd/applications/tailscale/base/connector-subnet-router.yaml`
- `bash -n devices/nuc/pihole/apply.sh`
- `python3 - <<'PY' ... tomllib.load('devices/nuc/pihole/pihole.toml') ... PY`
- live tailnet apply: `tofu -chdir=tofu/tailscale apply -auto-approve`
- live connector apply: `kubectl apply -f argocd/applications/tailscale/base/connector-subnet-router.yaml`
- live `nuc` apply: `sudo ~/pihole/apply.sh`
- verification on `nuc`: `dig +short @127.0.0.1 kubernetes.default.svc.cluster.local` -> `10.96.0.1`
- verification on `nuc`: `dig +short @100.88.12.116 kubernetes.default.svc.cluster.local` -> `10.96.0.1`
- verification from this tailnet client: `dig +short kubernetes.default.svc.cluster.local` -> `10.96.0.1`
- verification from this tailnet client: `dig +short google.com` -> public Google A record with non-cluster DNS still working

## Screenshots (if applicable)

N/A

## Breaking Changes

Tailnet DNS changes from global Pi-hole DNS override to split-only `cluster.local` resolution via Pi-hole on `nuc`. Non-cluster DNS stays on the client's normal resolver path.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
