### PR TITLE
docs(whitepapers): add implementation decision artifacts for wp-f040e0028838c432f4ac4ae5

### DIFF
--- a/docs/whitepapers/wp-f040e0028838c432f4ac4ae5/design.md
+++ b/docs/whitepapers/wp-f040e0028838c432f4ac4ae5/design.md
@@ -1,0 +1,50 @@
+# Whitepaper Implementation Design — wp-f040e0028838c432f4ac4ae5
+
+## Run Context
+- Whitepaper URL: https://arxiv.org/pdf/1706.03762.pdf
+- Primary Source URI: s3://torghut-whitepapers/raw/checksum/bd/bdfaa68d8984f0dc02beaca527b76f207d99b666d31d1da728ee0728182df697/source.pdf
+- Issue: https://github.com/proompteng/lab/issues/4338
+- Issue Title: [smoke] whitepaper end-to-end validation 20260312
+- Mode: implementation
+
+## Source Synthesis (Evidence-Backed)
+The whitepaper introduces a full sequence transduction architecture based on **only attention mechanisms**. It removes recurrence and convolutions entirely from the core path in encoder/decoder stacks and uses multi-head attention with residual+norm+feed-forward sublayers to process token sequences.
+
+Key evidence-based observations:
+- `introduction.tex` and `ms.tex` establish the core objective: replace RNN/CNN with self-attention for parallelizable sequence modeling and better long-range dependency handling.
+- `model_architecture.tex` defines the exact encoder/decoder topology, embedding sharing, positional encoding choice, and sub-layer arrangement (`multi-head attention -> residual -> layer norm -> feed-forward`).
+- `why_self_attention.tex` provides explicit complexity and path-length analysis comparing self-attention, recurrent, and convolutional approaches.
+- `training.tex` provides exact training setup and hyperparameters (optimizer, warmup schedule, beam/search settings, dropout/regularization, batch construction).
+- `results.tex` provides translation and parsing baselines, including ablations and model-size experiments.
+
+## Problem Statement
+Determine whether this whitepaper can be implemented as a production feature in the current `proompteng/lab` repository state, and if so define a deterministic implementation path. If not, provide a rejection with explicit blockers, evidence, and minimal unblockers.
+
+## Assessment Summary
+The paper is **implementable in principle** from an algorithmic perspective and is foundational to current NLP practice, but this repository today is not currently structured for direct end-to-end transformer training, inference, and benchmarking at the implementation level requested. Evidence from repo scan shows AI-facing layers are orchestrational/services oriented and do not provide a contiguous ML training stack (e.g., no deep-learning framework + dataset pipeline + distributed training harness with deterministic checkpoints for this model family).
+
+## Implementation Constraints in This Repository
+- No direct transformer stack exists in immediate service paths (`packages/backend`, `services/torghut`, and app layers reviewed for this run) that directly maps to sequence-to-sequence model training and evaluation.
+- Dependencies in relevant runtime paths do not currently include the core ML libraries required by the whitepaper’s experimental workflow (`torch/transformers` style stack), while the repository’s service code appears oriented toward API orchestration and infra.
+- No in-repo deterministic benchmark harness is available for WMT-style tokenized MT evaluation (BPE, BLEU pipeline, and training checkpoints) in the paths reviewed.
+
+## Deterministic Blocker for This Run
+- **Stage**: Implementation execution in production-relevant scope.
+- **Reason**: Missing preconditions for faithful replication (deep learning training pipeline, stable checkpoints, tokenization/metric toolchain, evaluation corpus handling, and compute policy).
+- **Evidence**: Paper requires exact architecture and optimization recipe (`model_architecture.tex`, `training.tex`) plus multi-scale benchmarking (`results.tex`), while repository implementation surface in this run is not presently aligned to deliver those artifacts.
+- **Smallest unblocker**: Introduce a dedicated ML service/submodule with explicit dependency and experiment controls, or integrate with existing existing ML platform via a contract-first interface and a reproducible experiment registry.
+
+## Recommended Next Step (if unblocked)
+1. Add an implementation module in a dedicated workspace (e.g., `services/transformer/`) with explicit version-pinned deep-learning dependencies and deterministic experiment config.
+2. Implement the exact encoder/decoder blocks with residual/normalization schedule and attention masking semantics.
+3. Add reproducibility controls: random seeds, fixed tokenizer vocabulary, dataset manifests, and checkpoint/versioned outputs.
+4. Add end-to-end validation suite for architecture parity (shape checks, mask behavior, attention output reproducibility on fixed seeds).
+5. Add benchmark job definitions for WMT-like BLEU evaluation and parsing/auxiliary tasks.
+
+## Assumptions and Unknowns
+- We assume the user request is for repository-native productionization, not a literature summary only.
+- Exact numeric translation tables are treated as references for target quality; exact re-evaluation in this repo would require corpus, tokenizer, and infrastructure that are not part of current scope.
+- No changes were made to application behavior because the repo lacks the required execution substrate for this model class in the inspected area.
+
+## Decision (for this run)
+**Rejected for direct production implementation in current branch context; proceed with design-first stage and preconditions before code implementation.**

--- a/docs/whitepapers/wp-f040e0028838c432f4ac4ae5/synthesis.json
+++ b/docs/whitepapers/wp-f040e0028838c432f4ac4ae5/synthesis.json
@@ -1,0 +1,65 @@
+{
+  "executive_summary": "The whitepaper proposes a full transformer architecture that replaces recurrent/convolutional sequence modeling with multi-head self-attention. It is feasible in principle but the current repository does not currently provide a contiguous, low-level ML stack to reproduce the paper end-to-end with deterministic training and evaluation, so this run is a blockable implementation decision rather than a ready-to-ship code change.",
+  "problem_statement": "Assess whether the paper 'Attention Is All You Need' can be implemented as a production-ready feature in proompteng/lab under current repository constraints, and produce an auditable, evidence-backed decision with concrete assumptions, risks, and blockers.",
+  "methodology_summary": "Read the full whitepaper source end-to-end from the provided arXiv sources (LaTeX and ar5iv text context), extracted concrete architectural, optimization, and evaluation claims by section, then audited the repository layout and existing service/tooling boundaries for deterministic reproducibility compatibility before drafting implementation viability and PR-ready design artifacts.",
+  "key_findings": [
+    "The architecture is explicitly attention-only: encoder/decoder stacks, multi-head attention, residual + layer-norm + FFN blocks, and positional encodings without recurrent/convolutional operators in the core path (model_architecture.tex).",
+    "The paper defines concrete hyperparameters and training recipe (e.g., d_model=512/1024 for base/big, h=8, d_k=d_v=64 for base, Adam config, warmup schedule, dropout, label smoothing) that are non-trivial for exact reproduction but are fully specified (training.tex).",
+    "The claimed computational rationale is quantitatively contrasted against RNN/CNN alternatives (sequential path length, parallelizability, per-layer complexity, and memory/compute scaling) (why_self_attention.tex).",
+    "Reported quality and efficiency are tied to explicit WMT14 BLEU workflows and ablations (including head count, model depth/size, positional encoding variants, and dropout impact) (results.tex).",
+    "Repository-level capability gap: inspected service/package layout does not include a native deterministic pipeline for training/serving an end-to-end NMT transformer with required preprocessing and evaluation, so the implementation cannot be completed as-is without additional service/module foundations."
+  ],
+  "novelty_claims": [
+    "Self-attention-only encoder/decoder architecture replacing recurrence and convolution in sequence transduction.",
+    "Use of residual-attention-FFN block ordering with scaled dot-product attention and multi-head parallelization, enabling efficient long-range dependency modeling.",
+    "Sinusoidal positional encodings replacing learned position parameters to support extrapolation while maintaining strong results.",
+    "Evidence-backed scaling argument showing better per-layer parallelism and shorter dependency path length versus recurrent stacks."
+  ],
+  "risk_assessment": [
+    {
+      "risk": "Reproducibility gap",
+      "impact": "High",
+      "evidence": "Paper relies on tightly specified training schedule, dataset preprocessing, and decoding parameters; repo lacks equivalent full ML experiment harness in reviewed scope.",
+      "mitigation": "Introduce a dedicated ML experiment module/service with explicit config/versioned artifact registry before implementation.",
+      "likelihood": "high"
+    },
+    {
+      "risk": "Scope mismatch",
+      "impact": "High",
+      "evidence": "Primary dependency footprint in the touched repository appears to be orchestration/API services rather than end-to-end model-training frameworks for transformer workloads.",
+      "mitigation": "Create bounded ownership boundary (new service with deep-learning dependencies) and interface contract to existing platform.",
+      "likelihood": "high"
+    },
+    {
+      "risk": "Deterministic validation risk",
+      "impact": "Medium",
+      "evidence": "WMT BLEU/beam setup and corpus workflow are part of the paper but not reproducible without corpus download/verification tooling and metric pipeline in-tree.",
+      "mitigation": "Add pinned dataset manifests, tokenizer/version metadata, and offline metric harness before green status claims.",
+      "likelihood": "medium"
+    }
+  ],
+  "citations": [
+    {
+      "source": "introduction.tex + ms.tex",
+      "claim": "Problem framing and shift from recurrence to self-attention-only transduction"
+    },
+    {
+      "source": "model_architecture.tex",
+      "claim": "Encoder-decoder stacks with 6 layers, multi-head attention sublayers, residual/LayerNorm/FFN blocks, positional encodings, token embedding sharing"
+    },
+    {
+      "source": "why_self_attention.tex",
+      "claim": "Complexity and path-length comparison between self-attention and recurrent models"
+    },
+    {
+      "source": "training.tex",
+      "claim": "Optimizer, learning-rate schedule, batching, dropout, label smoothing, and run-time/hardware details"
+    },
+    {
+      "source": "results.tex",
+      "claim": "BLEU and ablation evidence for translation tasks and scaling behavior"
+    }
+  ],
+  "implementation_plan_md": "1. Build a dedicated transformer module in a new service boundary with pinned ML dependencies and deterministic experiment config (seed, vocab, dataset manifest, and hardware profile).\n2. Implement architecture primitives exactly as paper: input/output embedding pipeline, sinusoidal position encoding, scaled dot-product attention, multi-head split/concat logic, masked self-attention + encoder-decoder attention.\n3. Reproduce training recipe from paper section-by-section (Adam settings, warmup schedule, dropout, label smoothing, beam search).\n4. Add dataset and metric harness (BPE preprocessing, validation/test BLEU scripts, parsing task hooks) with golden fixtures and checksums.\n5. Add CI-safe validation gates per repo norms: schema checks, lint/type checks for touched files, and a targeted regression test for attention mask behavior and tensor shape invariants.",
+  "confidence": 0.67
+}

--- a/docs/whitepapers/wp-f040e0028838c432f4ac4ae5/verdict.json
+++ b/docs/whitepapers/wp-f040e0028838c432f4ac4ae5/verdict.json
@@ -1,0 +1,56 @@
+{
+  "verdict": "BLOCKED",
+  "score": 0.28,
+  "confidence": 0.89,
+  "decision_policy": "Do not claim production readiness unless end-to-end deterministic experiment surface (data loading, tokenization, training, checkpointing, and BLEU/benchmarking) exists and is validated in-repo; block implementation when any required surface is absent.",
+  "rationale": {
+    "stage": "Production implementation in repository context",
+    "reason": "The repository segment covered in this run does not yet provide a contiguous ML stack for faithful transformer training and evaluation as specified by the whitepaper, so direct implementation would be non-deterministic and unverifiable against paper claims.",
+    "evidence": [
+      "The paper requires explicit and tightly coupled training/inference protocol (optimizer/batching/LR/decoding) and evaluation assets (WMT14-style preprocessing + BLEU workflows) documented in training/results sections.",
+      "The repo structure and dependency map reviewed for this task emphasize service orchestration and app/backend infrastructure without an in-place distributed deep-learning training module or benchmark harness aligned to WMT pipelines.",
+      "No evidence was found of an existing deterministic checkpoint/evaluation pipeline mapped to encoder-decoder translation workloads in the paths examined for this task."
+    ],
+    "smallest_unblocker": "Create a scoped ML execution service/module boundary (new workspace) with pinned ML dependencies and reproducible experiment plumbing before coding this paper’s architecture directly."
+  },
+  "rejection_reasons": [
+    {
+      "type": "scope_gap",
+      "text": "Missing native training/evaluation substrate required by the paper’s implementation details.",
+      "severity": "high"
+    },
+    {
+      "type": "determinism_gap",
+      "text": "No deterministic corpus/tokenizer/metric pipeline currently wired for the paper’s benchmark claims.",
+      "severity": "high"
+    },
+    {
+      "type": "governance_gap",
+      "text": "No explicit performance/quality gates that map to BLEU/ablation results required for production sign-off",
+      "severity": "medium"
+    }
+  ],
+  "recommendations": [
+    "Stand up a bounded transformer experiment module with deterministic dataset/version manifest and benchmark harness.",
+    "Add reproducible experiment metadata (seed, warmup/optimizer config, checkpoint lineage) before claiming reproduction parity.",
+    "If scope is reduced, implement only architecture parity tests (shape/mask/attention logic) while deferring full WMT reproduction to a dedicated ML platform path.",
+    "Re-run this whitepaper run after ML substrate exists and produce a new blocked/viable decision with fresh reproducibility evidence."
+  ],
+  "requires_followup": [
+    {
+      "next_step": "Create repository module/service scaffold for transformer training + evaluation",
+      "owner": "platform/ML engineering",
+      "status": "required"
+    },
+    {
+      "next_step": "Define reproducible dataset artifacts and WMT-compatible preprocessing pipeline",
+      "owner": "data platform",
+      "status": "required"
+    },
+    {
+      "next_step": "Integrate CI gates for new ML artifacts and deterministic validation tests",
+      "owner": "repo engineering",
+      "status": "required"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add whitepaper artifacts for run `wp-f040e0028838c432f4ac4ae5` under `docs/whitepapers/`, including `design.md`, `synthesis.json`, and `verdict.json`.
- Record a deterministic, evidence-backed implementation decision for arXiv 1706.03762 in implementation mode.
- Set clear block decision, risk assessment, and follow-up actions for repo-aligned execution readiness.

## Related Issues
- Closes: https://github.com/proompteng/lab/issues/4338

## Testing
- N/A (documentation/artifact generation only; no runtime behavior changed).

## Breaking Changes
- None.

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Documentation section added and scoped to run artifacts.
- [x] Design, synthesis, and verdict outputs are present at `docs/whitepapers/wp-f040e0028838c432f4ac4ae5/`.
