### PR TITLE
feat(infra): add private k8s proompteng ai ingress

### DIFF
--- a/argocd/applications/argocd/base/ingressroute-private.yaml
+++ b/argocd/applications/argocd/base/ingressroute-private.yaml
@@ -1,0 +1,30 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: argocd-server-private
+  namespace: argocd
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - kind: Rule
+      match: Host(`argocd.k8s.proompteng.ai`)
+      priority: 10
+      services:
+        - name: argocd-server
+          port: 80
+    - kind: Rule
+      match: Host(`argocd.k8s.proompteng.ai`) && PathPrefix(`/api/dex`)
+      priority: 100
+      services:
+        - name: argocd-dex-server
+          port: 5556
+    - kind: Rule
+      match: Host(`argocd.k8s.proompteng.ai`) && Header(`Content-Type`, `application/grpc`)
+      priority: 11
+      services:
+        - name: argocd-server
+          port: 80
+          scheme: h2c
+  tls:
+    secretName: wildcard-k8s-proompteng-ai-tls

--- a/argocd/applications/argocd/kustomization.yaml
+++ b/argocd/applications/argocd/kustomization.yaml
@@ -11,6 +11,7 @@ configMapGenerator:
 resources:
   - https://raw.githubusercontent.com/argoproj/argo-cd/v3.3.0/manifests/ha/install.yaml
   - base/ingressroute.yaml
+  - base/ingressroute-private.yaml
   - https://raw.githubusercontent.com/argoproj-labs/argocd-image-updater/v1.1.0/config/install.yaml
   - base/secrets.yaml
   - base/argo-workflows-sso-sealedsecret.yaml

--- a/argocd/applications/observability/ingressroute-grafana-k8s-private.yaml
+++ b/argocd/applications/observability/ingressroute-grafana-k8s-private.yaml
@@ -1,0 +1,16 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: observability-grafana-private
+  namespace: observability
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - kind: Rule
+      match: Host(`grafana.k8s.proompteng.ai`)
+      services:
+        - name: observability-grafana
+          port: 80
+  tls:
+    secretName: wildcard-k8s-proompteng-ai-tls

--- a/argocd/applications/observability/kustomization.yaml
+++ b/argocd/applications/observability/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 resources:
   - rook-ceph-rgw-loki.yaml
   - tailscale-ingresses.yaml
+  - ingressroute-grafana-k8s-private.yaml
   - graf-mimir-rules.yaml
   - graf-graf-dashboard-configmap.yaml
   - graf-bumba-dashboard-configmap.yaml

--- a/argocd/applications/traefik/k8s-proompteng-ai-certificate.yaml
+++ b/argocd/applications/traefik/k8s-proompteng-ai-certificate.yaml
@@ -1,0 +1,20 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: wildcard-k8s-proompteng-ai-tls
+  namespace: traefik
+spec:
+  secretName: wildcard-k8s-proompteng-ai-tls
+  secretTemplate:
+    annotations:
+      reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "argocd,observability"
+      reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+      reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "argocd,observability"
+  dnsNames:
+    - k8s.proompteng.ai
+    - '*.k8s.proompteng.ai'
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer
+    group: cert-manager.io

--- a/argocd/applications/traefik/kustomization.yaml
+++ b/argocd/applications/traefik/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: traefik
 
 resources:
+  - k8s-proompteng-ai-certificate.yaml
 helmCharts:
   - name: traefik
     repo: https://traefik.github.io/charts

--- a/devices/nuc/pihole/README.md
+++ b/devices/nuc/pihole/README.md
@@ -6,7 +6,9 @@ Desired state:
 
 - Pi-hole on `nuc` remains the DNS server for the LAN.
 - Tailscale clients use the NUC Tailscale IP (`100.88.12.116` as observed on 2026-03-11) for `cluster.local` split DNS.
+- Tailscale clients also use the same NUC Tailscale IP for `k8s.proompteng.ai` split DNS.
 - Pi-hole forwards `cluster.local` to the in-cluster CoreDNS service at `10.96.0.10`.
+- Pi-hole serves curated `*.k8s.proompteng.ai` CNAMEs that target `traefik.traefik.svc.cluster.local` for private HTTPS ingress.
 - `nuc` accepts Tailscale subnet routes so it can reach the cluster pod/service CIDRs.
 - UFW allows DNS (`53/tcp` and `53/udp`) on `tailscale0`.
 - Pi-hole non-secret settings are sourced from this repo, not edited ad hoc on the host.
@@ -50,6 +52,8 @@ grep -E '^(\\[dns\\]|interface|listeningMode|upstreams|\\[dhcp\\]|active|start|e
 dig +short @127.0.0.1 google.com
 dig +short @127.0.0.1 kubernetes.default.svc.cluster.local
 dig +short @100.88.12.116 kubernetes.default.svc.cluster.local
+dig +short @127.0.0.1 grafana.k8s.proompteng.ai
+dig +short @127.0.0.1 argocd.k8s.proompteng.ai
 ```
 
 ## Verify from another tailnet client
@@ -59,6 +63,8 @@ After the Tailscale split DNS rule is applied from [tofu/tailscale/main.tf](/Use
 ```bash
 dig +short kubernetes.default.svc.cluster.local
 dig +short @100.88.12.116 kubernetes.default.svc.cluster.local
+dig +short grafana.k8s.proompteng.ai
+dig +short argocd.k8s.proompteng.ai
 ```
 
 If these fail:

--- a/devices/nuc/pihole/apply.sh
+++ b/devices/nuc/pihole/apply.sh
@@ -14,6 +14,10 @@ tailscale_interface="${TAILSCALE_INTERFACE:-tailscale0}"
 lan_cidr="${LAN_CIDR:-192.168.1.0/24}"
 coredns_ip="${COREDNS_IP:-10.96.0.10}"
 kubernetes_probe="${KUBERNETES_PROBE_NAME:-kubernetes.default.svc.cluster.local}"
+private_https_probes=(
+  "${PRIVATE_HTTPS_PROBE_GRAFANA:-grafana.k8s.proompteng.ai}"
+  "${PRIVATE_HTTPS_PROBE_ARGOCD:-argocd.k8s.proompteng.ai}"
+)
 
 if [[ ! -f "${toml_src}" ]]; then
   echo "missing config source: ${toml_src}" >&2
@@ -60,6 +64,13 @@ if ! dig +time=2 +tries=1 @127.0.0.1 "${kubernetes_probe}" >/dev/null; then
   exit 1
 fi
 
+for private_https_probe in "${private_https_probes[@]}"; do
+  if ! dig +time=2 +tries=1 @127.0.0.1 "${private_https_probe}" >/dev/null; then
+    echo "Pi-hole did not resolve ${private_https_probe} toward the private ingress path" >&2
+    exit 1
+  fi
+done
+
 echo "Pi-hole Tailscale DNS configuration applied."
 echo "Verification:"
 echo "  tailscale status --json | jq '.Self.TailscaleIPs[0], .Self.HostName'"
@@ -67,3 +78,5 @@ echo "  grep -E '^(\\[dns\\]|interface|listeningMode|upstreams|\\[dhcp\\]|active
 echo "  dig +short @127.0.0.1 google.com"
 echo "  dig +short @127.0.0.1 kubernetes.default.svc.cluster.local"
 echo "  dig +short @$(tailscale ip -4 | head -n1) kubernetes.default.svc.cluster.local"
+echo "  dig +short @127.0.0.1 grafana.k8s.proompteng.ai"
+echo "  dig +short @127.0.0.1 argocd.k8s.proompteng.ai"

--- a/devices/nuc/pihole/pihole.toml
+++ b/devices/nuc/pihole/pihole.toml
@@ -41,6 +41,8 @@ cnameRecords = [
   'registry.lan,kube.lan',
   'npm.lan,kube.lan',
   'argocd.lan,kube.lan',
+  'grafana.k8s.proompteng.ai,traefik.traefik.svc.cluster.local',
+  'argocd.k8s.proompteng.ai,traefik.traefik.svc.cluster.local',
 ]
 localise = true
 

--- a/tofu/tailscale/README.md
+++ b/tofu/tailscale/README.md
@@ -32,9 +32,9 @@ The production default is split-only Kubernetes DNS:
 
 - `override_local_dns = false`
 - no global nameservers are pushed to the tailnet
-- `dns_split_nameservers = { "cluster.local" = ["100.88.12.116"] }`
+- `dns_split_nameservers = { "cluster.local" = ["100.88.12.116"], "k8s.proompteng.ai" = ["100.88.12.116"] }`
 
-This keeps Pi-hole off the critical path for non-Kubernetes DNS while still routing `cluster.local` through the `nuc` device over Tailscale.
+This keeps Pi-hole off the critical path for non-Kubernetes DNS while still routing raw Kubernetes names and curated private service hostnames through the `nuc` device over Tailscale.
 
 Only apply this DNS posture after:
 
@@ -46,9 +46,12 @@ Example split DNS for Kubernetes through Pi-hole on the `nuc` device:
 
 ```hcl
 dns_split_nameservers = {
-  "cluster.local" = ["100.88.12.116"]
+  "cluster.local"     = ["100.88.12.116"]
+  "k8s.proompteng.ai" = ["100.88.12.116"]
 }
 ```
+
+Use `cluster.local` for raw Kubernetes service discovery and `k8s.proompteng.ai` for curated private HTTPS hostnames that Pi-hole resolves toward the in-cluster Traefik service.
 
 If the `nuc` Tailscale IP changes, update `dns_split_nameservers` before applying this stack.
 

--- a/tofu/tailscale/variables.tf
+++ b/tofu/tailscale/variables.tf
@@ -20,7 +20,8 @@ variable "dns_split_nameservers" {
   description = "Per-domain split DNS nameservers. Keys are domains and values are the nameserver IPs for that domain."
   type        = map(list(string))
   default = {
-    "cluster.local" = ["100.88.12.116"]
+    "cluster.local"     = ["100.88.12.116"]
+    "k8s.proompteng.ai" = ["100.88.12.116"]
   }
 }
 


### PR DESCRIPTION
## Summary

- add a private `k8s.proompteng.ai` split-DNS zone in Tailscale, backed by Pi-hole on `nuc`
- issue a Let’s Encrypt wildcard cert for `k8s.proompteng.ai` and reflect it into `argocd` and `observability`
- expose `argocd.k8s.proompteng.ai` and `grafana.k8s.proompteng.ai` through Traefik with explicit TLS secrets
- update the reproducible Pi-hole bundle so those private hostnames resolve to the in-cluster Traefik service
- document and persist the private ingress/TLS rollout so repo state matches the live deployment

## Related Issues

None

## Testing

- `tofu -chdir=tofu/tailscale validate`
- `bash -n devices/nuc/pihole/apply.sh`
- `python3 - <<'PY'` to parse `devices/nuc/pihole/pihole.toml` with `tomllib`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/traefik | kubectl apply --dry-run=server -f -`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/observability | kubectl apply --dry-run=server -f -`
- `kubectl apply --dry-run=server -f argocd/applications/argocd/base/ingressroute-private.yaml`
- `kubectl apply --dry-run=server -f argocd/applications/observability/ingressroute-grafana-k8s-private.yaml`
- `kubectl apply -f argocd/applications/traefik/k8s-proompteng-ai-certificate.yaml`
- `kubectl wait --for=condition=Ready -n traefik certificate/wildcard-k8s-proompteng-ai-tls --timeout=10m`
- `kubectl apply -f argocd/applications/argocd/base/ingressroute-private.yaml`
- `kubectl apply -f argocd/applications/observability/ingressroute-grafana-k8s-private.yaml`
- `ssh kalmyk@192.168.1.130 'chmod +x ~/pihole/apply.sh && sudo ~/pihole/apply.sh'`
- `ssh kalmyk@192.168.1.130 'tailscale debug prefs | jq "{CorpDNS,RouteAll}"'`
- `ssh kalmyk@192.168.1.130 'dig +short @127.0.0.1 kubernetes.default.svc.cluster.local'`
- `ssh kalmyk@192.168.1.130 'dig +short @127.0.0.1 grafana.k8s.proompteng.ai'`
- `ssh kalmyk@192.168.1.130 'dig +short @127.0.0.1 argocd.k8s.proompteng.ai'`
- `TF_VAR_tailscale_api_key="$TS_API_KEY" tofu -chdir=tofu/tailscale plan -out=tfplan`
- `TF_VAR_tailscale_api_key="$TS_API_KEY" tofu -chdir=tofu/tailscale apply -auto-approve tfplan`
- `dig +short grafana.k8s.proompteng.ai`
- `dig +short argocd.k8s.proompteng.ai`
- `dig +short kubernetes.default.svc.cluster.local`
- `echo | openssl s_client -connect grafana.k8s.proompteng.ai:443 -servername grafana.k8s.proompteng.ai 2>/dev/null | openssl x509 -noout -subject -issuer -ext subjectAltName`
- `echo | openssl s_client -connect argocd.k8s.proompteng.ai:443 -servername argocd.k8s.proompteng.ai 2>/dev/null | openssl x509 -noout -subject -issuer -ext subjectAltName`
- `curl -ksS https://grafana.k8s.proompteng.ai/login | head -n 5`
- `curl -ksS https://argocd.k8s.proompteng.ai/ | head -n 5`
- `sudo dscacheutil -flushcache && sudo killall -HUP mDNSResponder` on this Mac to clear a stale public cache entry for `argocd.k8s.proompteng.ai`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
