### PR TITLE
feat(infra): add more private k8s service domains

### DIFF
--- a/argocd/applications/argo-workflows/ingressroute-private.yaml
+++ b/argocd/applications/argo-workflows/ingressroute-private.yaml
@@ -1,0 +1,16 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: argo-workflows-private
+  namespace: argo-workflows
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - kind: Rule
+      match: Host(`workflows.k8s.proompteng.ai`)
+      services:
+        - name: argo-workflows-server
+          port: 2746
+  tls:
+    secretName: wildcard-k8s-proompteng-ai-tls

--- a/argocd/applications/argo-workflows/kustomization.yaml
+++ b/argocd/applications/argo-workflows/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - codex-docker-policy.yaml
   - codex-implementation-semaphore.yaml
   - ingressroute.yaml
+  - ingressroute-private.yaml
   - rook-ceph-objectstore-user.yaml
   - rook-ceph-rgw-argo-workflows.yaml
   - rgw-bucket-job.yaml

--- a/argocd/applications/feature-flags/ingressroute-feature-flags-k8s-private.yaml
+++ b/argocd/applications/feature-flags/ingressroute-feature-flags-k8s-private.yaml
@@ -1,0 +1,16 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: feature-flags-private
+  namespace: feature-flags
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - kind: Rule
+      match: Host(`feature-flags.k8s.proompteng.ai`)
+      services:
+        - name: feature-flags
+          port: 8013
+  tls:
+    secretName: wildcard-k8s-proompteng-ai-tls

--- a/argocd/applications/feature-flags/kustomization.yaml
+++ b/argocd/applications/feature-flags/kustomization.yaml
@@ -4,6 +4,7 @@ namespace: feature-flags
 
 resources:
   - tailscale-service.yaml
+  - ingressroute-feature-flags-k8s-private.yaml
 
 helmCharts:
   - name: flipt-v2

--- a/argocd/applications/headlamp/ingressroute-headlamp-k8s-private.yaml
+++ b/argocd/applications/headlamp/ingressroute-headlamp-k8s-private.yaml
@@ -1,0 +1,16 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: headlamp-private
+  namespace: headlamp
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - kind: Rule
+      match: Host(`headlamp.k8s.proompteng.ai`)
+      services:
+        - name: headlamp
+          port: 80
+  tls:
+    secretName: wildcard-k8s-proompteng-ai-tls

--- a/argocd/applications/headlamp/kustomization.yaml
+++ b/argocd/applications/headlamp/kustomization.yaml
@@ -4,6 +4,7 @@ namespace: headlamp
 resources:
   - headlamp-oidc-rbac.yaml
   - headlamp-oidc-sealedsecret.yaml
+  - ingressroute-headlamp-k8s-private.yaml
 helmCharts:
   - name: headlamp
     repo: https://kubernetes-sigs.github.io/headlamp

--- a/argocd/applications/jangar/ingressroute-jangar-k8s-private.yaml
+++ b/argocd/applications/jangar/ingressroute-jangar-k8s-private.yaml
@@ -1,0 +1,16 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: jangar-private
+  namespace: jangar
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - kind: Rule
+      match: Host(`jangar.k8s.proompteng.ai`)
+      services:
+        - name: jangar
+          port: 80
+  tls:
+    secretName: wildcard-k8s-proompteng-ai-tls

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -17,6 +17,7 @@ resources:
   - codex-github-events-kafkasource.yaml
   - app-tailscale-service.yaml
   - tailscale-service.yaml
+  - ingressroute-jangar-k8s-private.yaml
   - postgres-cluster.yaml
   - postgres-scheduled-backup.yaml
   - openwebui-redis.yaml

--- a/argocd/applications/kafka/ingressroute-kafka-ui-k8s-private.yaml
+++ b/argocd/applications/kafka/ingressroute-kafka-ui-k8s-private.yaml
@@ -1,0 +1,16 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: kafka-ui-private
+  namespace: kafka
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - kind: Rule
+      match: Host(`kafka-ui.k8s.proompteng.ai`)
+      services:
+        - name: kafka-ui
+          port: 80
+  tls:
+    secretName: wildcard-k8s-proompteng-ai-tls

--- a/argocd/applications/kafka/kustomization.yaml
+++ b/argocd/applications/kafka/kustomization.yaml
@@ -32,6 +32,7 @@ resources:
   - https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/0.50.0/install/cluster-operator/060-Deployment-strimzi-cluster-operator.yaml
   - strimzi-operator-watched-crb.yaml
   - load-balancer.yaml
+  - ingressroute-kafka-ui-k8s-private.yaml
   - strimzi-kafka-cluster.yaml
   - kafka-codex-username-secret.yaml
   - karapace.yaml

--- a/argocd/applications/rook-ceph/ingressroute-ceph-k8s-private.yaml
+++ b/argocd/applications/rook-ceph/ingressroute-ceph-k8s-private.yaml
@@ -1,0 +1,16 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: ceph-dashboard-private
+  namespace: rook-ceph
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - kind: Rule
+      match: Host(`ceph.k8s.proompteng.ai`)
+      services:
+        - name: rook-ceph-mgr-dashboard
+          port: 7000
+  tls:
+    secretName: wildcard-k8s-proompteng-ai-tls

--- a/argocd/applications/rook-ceph/kustomization.yaml
+++ b/argocd/applications/rook-ceph/kustomization.yaml
@@ -5,6 +5,7 @@ namespace: rook-ceph
 resources:
   - storageclasses.yaml
   - tailscale-service-dashboard.yaml
+  - ingressroute-ceph-k8s-private.yaml
 
 helmCharts:
   - name: rook-ceph

--- a/argocd/applications/torghut/ingressroute-flink-k8s-private.yaml
+++ b/argocd/applications/torghut/ingressroute-flink-k8s-private.yaml
@@ -1,0 +1,16 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: torghut-flink-private
+  namespace: torghut
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - kind: Rule
+      match: Host(`flink.k8s.proompteng.ai`)
+      services:
+        - name: torghut-ta-rest
+          port: 8081
+  tls:
+    secretName: wildcard-k8s-proompteng-ai-tls

--- a/argocd/applications/torghut/kustomization.yaml
+++ b/argocd/applications/torghut/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
   - knative-service.yaml
   - knative-service-sim.yaml
   - tailscale-service.yaml
+  - ingressroute-flink-k8s-private.yaml
   - sealed-secrets.yaml
   - rook-ceph-rgw-argo-workflows-sealedsecret.yaml
   - serviceaccount.yaml

--- a/argocd/applications/traefik/k8s-proompteng-ai-certificate.yaml
+++ b/argocd/applications/traefik/k8s-proompteng-ai-certificate.yaml
@@ -8,9 +8,9 @@ spec:
   secretTemplate:
     annotations:
       reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
-      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "argocd,observability"
+      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "argocd,argo-workflows,feature-flags,headlamp,jangar,kafka,observability,rook-ceph,torghut"
       reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
-      reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "argocd,observability"
+      reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "argocd,argo-workflows,feature-flags,headlamp,jangar,kafka,observability,rook-ceph,torghut"
   dnsNames:
     - k8s.proompteng.ai
     - '*.k8s.proompteng.ai'

--- a/devices/nuc/pihole/README.md
+++ b/devices/nuc/pihole/README.md
@@ -54,6 +54,13 @@ dig +short @127.0.0.1 kubernetes.default.svc.cluster.local
 dig +short @100.88.12.116 kubernetes.default.svc.cluster.local
 dig +short @127.0.0.1 grafana.k8s.proompteng.ai
 dig +short @127.0.0.1 argocd.k8s.proompteng.ai
+dig +short @127.0.0.1 ceph.k8s.proompteng.ai
+dig +short @127.0.0.1 jangar.k8s.proompteng.ai
+dig +short @127.0.0.1 workflows.k8s.proompteng.ai
+dig +short @127.0.0.1 feature-flags.k8s.proompteng.ai
+dig +short @127.0.0.1 flink.k8s.proompteng.ai
+dig +short @127.0.0.1 headlamp.k8s.proompteng.ai
+dig +short @127.0.0.1 kafka-ui.k8s.proompteng.ai
 ```
 
 ## Verify from another tailnet client
@@ -65,6 +72,13 @@ dig +short kubernetes.default.svc.cluster.local
 dig +short @100.88.12.116 kubernetes.default.svc.cluster.local
 dig +short grafana.k8s.proompteng.ai
 dig +short argocd.k8s.proompteng.ai
+dig +short ceph.k8s.proompteng.ai
+dig +short jangar.k8s.proompteng.ai
+dig +short workflows.k8s.proompteng.ai
+dig +short feature-flags.k8s.proompteng.ai
+dig +short flink.k8s.proompteng.ai
+dig +short headlamp.k8s.proompteng.ai
+dig +short kafka-ui.k8s.proompteng.ai
 ```
 
 If these fail:

--- a/devices/nuc/pihole/apply.sh
+++ b/devices/nuc/pihole/apply.sh
@@ -17,6 +17,13 @@ kubernetes_probe="${KUBERNETES_PROBE_NAME:-kubernetes.default.svc.cluster.local}
 private_https_probes=(
   "${PRIVATE_HTTPS_PROBE_GRAFANA:-grafana.k8s.proompteng.ai}"
   "${PRIVATE_HTTPS_PROBE_ARGOCD:-argocd.k8s.proompteng.ai}"
+  "${PRIVATE_HTTPS_PROBE_CEPH:-ceph.k8s.proompteng.ai}"
+  "${PRIVATE_HTTPS_PROBE_JANGAR:-jangar.k8s.proompteng.ai}"
+  "${PRIVATE_HTTPS_PROBE_WORKFLOWS:-workflows.k8s.proompteng.ai}"
+  "${PRIVATE_HTTPS_PROBE_FEATURE_FLAGS:-feature-flags.k8s.proompteng.ai}"
+  "${PRIVATE_HTTPS_PROBE_FLINK:-flink.k8s.proompteng.ai}"
+  "${PRIVATE_HTTPS_PROBE_HEADLAMP:-headlamp.k8s.proompteng.ai}"
+  "${PRIVATE_HTTPS_PROBE_KAFKA_UI:-kafka-ui.k8s.proompteng.ai}"
 )
 
 if [[ ! -f "${toml_src}" ]]; then
@@ -80,3 +87,10 @@ echo "  dig +short @127.0.0.1 kubernetes.default.svc.cluster.local"
 echo "  dig +short @$(tailscale ip -4 | head -n1) kubernetes.default.svc.cluster.local"
 echo "  dig +short @127.0.0.1 grafana.k8s.proompteng.ai"
 echo "  dig +short @127.0.0.1 argocd.k8s.proompteng.ai"
+echo "  dig +short @127.0.0.1 ceph.k8s.proompteng.ai"
+echo "  dig +short @127.0.0.1 jangar.k8s.proompteng.ai"
+echo "  dig +short @127.0.0.1 workflows.k8s.proompteng.ai"
+echo "  dig +short @127.0.0.1 feature-flags.k8s.proompteng.ai"
+echo "  dig +short @127.0.0.1 flink.k8s.proompteng.ai"
+echo "  dig +short @127.0.0.1 headlamp.k8s.proompteng.ai"
+echo "  dig +short @127.0.0.1 kafka-ui.k8s.proompteng.ai"

--- a/devices/nuc/pihole/pihole.toml
+++ b/devices/nuc/pihole/pihole.toml
@@ -43,6 +43,13 @@ cnameRecords = [
   'argocd.lan,kube.lan',
   'grafana.k8s.proompteng.ai,traefik.traefik.svc.cluster.local',
   'argocd.k8s.proompteng.ai,traefik.traefik.svc.cluster.local',
+  'ceph.k8s.proompteng.ai,traefik.traefik.svc.cluster.local',
+  'jangar.k8s.proompteng.ai,traefik.traefik.svc.cluster.local',
+  'workflows.k8s.proompteng.ai,traefik.traefik.svc.cluster.local',
+  'feature-flags.k8s.proompteng.ai,traefik.traefik.svc.cluster.local',
+  'flink.k8s.proompteng.ai,traefik.traefik.svc.cluster.local',
+  'headlamp.k8s.proompteng.ai,traefik.traefik.svc.cluster.local',
+  'kafka-ui.k8s.proompteng.ai,traefik.traefik.svc.cluster.local',
 ]
 localise = true
 


### PR DESCRIPTION
## Summary

- add private `k8s.proompteng.ai` routes for Ceph, Jangar, Argo Workflows, Feature Flags, Flink, Headlamp, and Kafka UI
- extend the wildcard `k8s.proompteng.ai` certificate intent to the additional consumer namespaces
- update the reproducible Pi-hole bundle so the new private hostnames resolve to the in-cluster Traefik service
- keep the rollout additive by leaving the existing Tailscale-hosted entrypoints in place while introducing the new private aliases
- document the extra private DNS verification commands for the NUC bundle

## Related Issues

None

## Testing

- `bash -n devices/nuc/pihole/apply.sh`
- `python3 - <<'PY'` to parse `devices/nuc/pihole/pihole.toml` with `tomllib`
- `kubectl apply --dry-run=server -f argocd/applications/traefik/k8s-proompteng-ai-certificate.yaml -f argocd/applications/rook-ceph/ingressroute-ceph-k8s-private.yaml -f argocd/applications/jangar/ingressroute-jangar-k8s-private.yaml -f argocd/applications/argo-workflows/ingressroute-private.yaml -f argocd/applications/feature-flags/ingressroute-feature-flags-k8s-private.yaml -f argocd/applications/headlamp/ingressroute-headlamp-k8s-private.yaml -f argocd/applications/kafka/ingressroute-kafka-ui-k8s-private.yaml -f argocd/applications/torghut/ingressroute-flink-k8s-private.yaml`
- `kubectl apply -f argocd/applications/traefik/k8s-proompteng-ai-certificate.yaml -f argocd/applications/rook-ceph/ingressroute-ceph-k8s-private.yaml -f argocd/applications/jangar/ingressroute-jangar-k8s-private.yaml -f argocd/applications/argo-workflows/ingressroute-private.yaml -f argocd/applications/feature-flags/ingressroute-feature-flags-k8s-private.yaml -f argocd/applications/headlamp/ingressroute-headlamp-k8s-private.yaml -f argocd/applications/kafka/ingressroute-kafka-ui-k8s-private.yaml -f argocd/applications/torghut/ingressroute-flink-k8s-private.yaml`
- `scp devices/nuc/pihole/pihole.toml devices/nuc/pihole/99-kubernetes-split-dns.conf devices/nuc/pihole/apply.sh kalmyk@192.168.1.130:~/pihole/`
- `ssh kalmyk@192.168.1.130 'chmod +x ~/pihole/apply.sh && sudo ~/pihole/apply.sh'`
- `ssh kalmyk@192.168.1.130 'for h in ceph.k8s.proompteng.ai jangar.k8s.proompteng.ai workflows.k8s.proompteng.ai feature-flags.k8s.proompteng.ai flink.k8s.proompteng.ai headlamp.k8s.proompteng.ai kafka-ui.k8s.proompteng.ai; do echo "== $h =="; dig +short @127.0.0.1 "$h"; done'`
- `sudo dscacheutil -flushcache && sudo killall -HUP mDNSResponder`
- `python3 - <<'PY'` to verify `socket.getaddrinfo()` resolves the seven new hosts to `10.110.253.67`
- `python3 - <<'PY'` to `curl -ksS -o /dev/null -w '%{http_code}'` each of the seven new hosts and confirm `200`
- `python3 - <<'PY'` to run `openssl s_client ... | openssl x509 -noout -subject -issuer` for the seven new hosts and confirm the Let's Encrypt wildcard cert
- One-time live remediation: copied the already-issued wildcard TLS secret into the new namespaces so the routes serve immediately while the certificate source-of-truth catches up on `main`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
