### PR TITLE
fix(argo-workflows): use private SSO callback

### DIFF
--- a/argocd/applications/argo-workflows/ingressroute.yaml
+++ b/argocd/applications/argo-workflows/ingressroute.yaml
@@ -11,6 +11,8 @@ spec:
   routes:
     - match: Host(`workflows.proompteng.ai`)
       kind: Rule
+      middlewares:
+        - name: workflows-canonical-host
       services:
         - name: argo-workflows-server
           port: 2746

--- a/argocd/applications/argo-workflows/kustomization.yaml
+++ b/argocd/applications/argo-workflows/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - codex-docker-policy.yaml
   - codex-implementation-semaphore.yaml
   - ingressroute.yaml
+  - middleware-workflows-canonical-host.yaml
   - ingressroute-private.yaml
   - rook-ceph-objectstore-user.yaml
   - rook-ceph-rgw-argo-workflows.yaml
@@ -58,7 +59,7 @@ helmCharts:
           clientSecret:
             name: argo-workflows-sso
             key: client-secret
-          redirectUrl: https://workflows.proompteng.ai/oauth2/callback
+          redirectUrl: https://workflows.k8s.proompteng.ai/oauth2/callback
           scopes:
             - openid
             - profile

--- a/argocd/applications/argo-workflows/middleware-workflows-canonical-host.yaml
+++ b/argocd/applications/argo-workflows/middleware-workflows-canonical-host.yaml
@@ -1,0 +1,10 @@
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: workflows-canonical-host
+  namespace: argo-workflows
+spec:
+  redirectRegex:
+    regex: ^https?://workflows\\.proompteng\\.ai(.*)
+    replacement: https://workflows.k8s.proompteng.ai$1
+    permanent: true

--- a/argocd/applications/argocd/overlays/argocd-cm.yaml
+++ b/argocd/applications/argocd/overlays/argocd-cm.yaml
@@ -79,6 +79,7 @@ data:
         name: Argo Workflows
         redirectURIs:
           - https://workflows.proompteng.ai/oauth2/callback
+          - https://workflows.k8s.proompteng.ai/oauth2/callback
         secretEnv: ARGO_WORKFLOWS_SSO_CLIENT_SECRET
     staticPasswords:
       - email: admin@proompteng.ai


### PR DESCRIPTION
## Summary

- switch Argo Workflows SSO to use `workflows.k8s.proompteng.ai` as the callback host
- allow the private callback URI in the Argo CD Dex static client while retaining the legacy public URI
- add a Traefik middleware on the legacy public Workflows host to steer traffic toward the private canonical host

## Related Issues

None

## Testing

- `git diff --check`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/argo-workflows >/tmp/argo-workflows-rendered.yaml && kubectl apply --dry-run=server -f /tmp/argo-workflows-rendered.yaml`
- `kubectl apply --dry-run=server -f argocd/applications/argo-workflows/middleware-workflows-canonical-host.yaml -f argocd/applications/argo-workflows/ingressroute.yaml -f argocd/applications/argo-workflows/ingressroute-private.yaml`
- Live incident fix: applied the rendered Argo Workflows configmap, applied the middleware/ingress updates, patched `argocd-cm`, and restarted `argo-workflows-server` and `argocd-dex-server`
- `kubectl get cm -n argo-workflows argo-workflows-workflow-controller-configmap -o jsonpath='{.data.config}' | rg 'redirectUrl'`
- `kubectl get cm -n argocd argocd-cm -o jsonpath='{.data.dex\.config}' | rg 'workflows\.(k8s\.)?proompteng\.ai/oauth2/callback'`
- `python3 - <<'PY'` against `https://workflows.k8s.proompteng.ai/oauth2/redirect?redirect=%2F` confirmed `redirect_uri=https%3A%2F%2Fworkflows.k8s.proompteng.ai%2Foauth2%2Fcallback` in the `302 Location` header
- Playwright verification: loaded `https://workflows.k8s.proompteng.ai/login?redirect=%2F` and confirmed the private-host login screen flows into Dex instead of bouncing to the old public callback

## Breaking Changes

- `workflows.k8s.proompteng.ai` is now the canonical SSO callback host for Argo Workflows. Existing public-host bookmarks may still load, but interactive auth is now anchored on the private hostname.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
