### PR TITLE
chore(jangar): promote image f86f0d46

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 43b444ca
-  digest: sha256:e0bfba2facae15d4d6819afad89dfac0a633b8f88d98c76344ab544a56d80213
+  tag: f86f0d46
+  digest: sha256:5c48c4dc7d037ae19f6910fd0d3bdc868a5d7b2d4ceb17b9241790e1f8b41ef9
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 43b444ca
-    digest: sha256:47c821759e8653efa74c867b6b257d89863449025d05fa52fd6a069efad87cb7
+    tag: f86f0d46
+    digest: sha256:55e59b96617a600bbbe97f1cd1ac2a32d0def40a7bcb414df3a1edec5f0e6717
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 43b444ca
-    digest: sha256:e0bfba2facae15d4d6819afad89dfac0a633b8f88d98c76344ab544a56d80213
+    tag: f86f0d46
+    digest: sha256:5c48c4dc7d037ae19f6910fd0d3bdc868a5d7b2d4ceb17b9241790e1f8b41ef9
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-12T07:35:00Z"
+    deploy.knative.dev/rollout: "2026-03-12T08:12:10Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-12T07:35:00Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-12T08:12:10Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -61,5 +61,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "d8090f575"
-    digest: sha256:81cd83ae913f45173b4ac3bbae1f9c7bce92bf7bdd9866a56264318236b92268
+    newTag: "f86f0d46"
+    digest: sha256:5c48c4dc7d037ae19f6910fd0d3bdc868a5d7b2d4ceb17b9241790e1f8b41ef9


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `f86f0d463a64f74b512ceea35a155d628eed90f7`
- Image tag: `f86f0d46`
- Image digest: `sha256:5c48c4dc7d037ae19f6910fd0d3bdc868a5d7b2d4ceb17b9241790e1f8b41ef9`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`