### PR TITLE
fix(torghut): align simulation inventory and runtime gates

### DIFF
--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -15,6 +15,8 @@ spec:
     - name: forecastService
     - name: windowStart
     - name: windowEnd
+    - name: signalTable
+    - name: priceTable
     - name: runtimeVerifyTimeoutSeconds
     - name: runtimeVerifyPollSeconds
   metrics:
@@ -48,6 +50,8 @@ spec:
                         --forecast-service "{{args.forecastService}}"
                         --window-start "{{args.windowStart}}"
                         --window-end "{{args.windowEnd}}"
+                        --signal-table "{{args.signalTable}}"
+                        --price-table "{{args.priceTable}}"
                         --runtime-timeout-seconds "{{args.runtimeVerifyTimeoutSeconds}}"
                         --runtime-poll-seconds "{{args.runtimeVerifyPollSeconds}}"
                         --json

--- a/services/torghut/app/trading/execution_adapters.py
+++ b/services/torghut/app/trading/execution_adapters.py
@@ -148,6 +148,7 @@ class SimulationExecutionAdapter:
         self._orders_by_id: dict[str, dict[str, Any]] = {}
         self._order_id_by_client_id: dict[str, str] = {}
         self._positions_by_symbol: dict[str, Decimal] = {}
+        self._seeded_from_snapshot = False
         self._producer: Any | None = None
         self._producer_init_error: str | None = None
         self._kafka_security_kwargs: dict[str, str] = {}
@@ -161,6 +162,35 @@ class SimulationExecutionAdapter:
             self._kafka_security_kwargs['sasl_plain_password'] = sasl_password
         if bootstrap_servers and bootstrap_servers.strip():
             self._producer = self._build_producer(bootstrap_servers.strip())
+
+    def seed_positions_snapshot(self, positions: list[dict[str, Any]] | None) -> None:
+        """Seed the adapter once from the broker snapshot used by decisioning."""
+
+        if self._seeded_from_snapshot:
+            return
+        seeded_positions: dict[str, Decimal] = {}
+        for raw_position in positions or []:
+            symbol = str(raw_position.get('symbol') or '').strip().upper()
+            if not symbol:
+                continue
+            raw_qty = raw_position.get('qty') or raw_position.get('quantity')
+            if raw_qty is None:
+                continue
+            try:
+                qty = Decimal(str(raw_qty))
+            except Exception:
+                continue
+            if qty == 0:
+                continue
+            side = str(raw_position.get('side') or '').strip().lower()
+            signed_qty = -abs(qty) if side == 'short' else qty
+            net_qty = seeded_positions.get(symbol, Decimal('0')) + signed_qty
+            if net_qty == 0:
+                seeded_positions.pop(symbol, None)
+                continue
+            seeded_positions[symbol] = net_qty
+        self._positions_by_symbol = seeded_positions
+        self._seeded_from_snapshot = True
 
     def submit_order(
         self,

--- a/services/torghut/app/trading/scheduler/pipeline.py
+++ b/services/torghut/app/trading/scheduler/pipeline.py
@@ -311,7 +311,8 @@ class TradingPipeline:
             "cash": str(account_snapshot.cash),
             "buying_power": str(account_snapshot.buying_power),
         }
-        positions = _clone_positions(account_snapshot.positions)
+        snapshot_positions = _clone_positions(account_snapshot.positions)
+        positions = self._resolve_execution_context_positions(snapshot_positions)
 
         universe_resolution = self.universe_resolver.get_resolution()
         self.state.universe_source_status = universe_resolution.status
@@ -364,6 +365,50 @@ class TradingPipeline:
             return None
 
         return account_snapshot, account, positions, allowed_symbols
+
+    def _resolve_execution_context_positions(
+        self,
+        snapshot_positions: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        seed_snapshot = getattr(self.execution_adapter, "seed_positions_snapshot", None)
+        if not callable(seed_snapshot):
+            return _clone_positions(snapshot_positions)
+        try:
+            seed_snapshot(_clone_positions(snapshot_positions))
+        except Exception as exc:
+            logger.warning(
+                "Failed to seed simulation execution positions account=%s error=%s",
+                self.account_label,
+                exc,
+            )
+            return _clone_positions(snapshot_positions)
+
+        list_positions = getattr(self.execution_adapter, "list_positions", None)
+        if not callable(list_positions):
+            return _clone_positions(snapshot_positions)
+        try:
+            seeded_positions = list_positions()
+        except Exception as exc:
+            logger.warning(
+                "Failed to read simulation execution positions account=%s error=%s",
+                self.account_label,
+                exc,
+            )
+            return _clone_positions(snapshot_positions)
+        if not isinstance(seeded_positions, list):
+            return _clone_positions(snapshot_positions)
+
+        normalized_positions: list[dict[str, Any]] = []
+        for raw_position in cast(list[Any], seeded_positions):
+            if not isinstance(raw_position, Mapping):
+                continue
+            normalized_positions.append(
+                {
+                    str(key): value
+                    for key, value in cast(Mapping[object, Any], raw_position).items()
+                }
+            )
+        return normalized_positions
 
     def _process_batch_signals(
         self,

--- a/services/torghut/scripts/start_historical_simulation.py
+++ b/services/torghut/scripts/start_historical_simulation.py
@@ -4742,7 +4742,24 @@ def _run_full_lifecycle(
                 bool(rollouts_report['enabled'])
                 and _as_mapping(cast(Mapping[str, Any], rollouts_report['runtime_analysis_run'])).get('phase') != 'Successful'
             ):
-                errors.append('environment_incomplete')
+                runtime_failure = {
+                    'reason': 'environment_incomplete',
+                    'runtime_state': runtime_verify_report.get('runtime_state'),
+                    'analysis_run': rollouts_report['runtime_analysis_run'],
+                }
+                _update_run_state(
+                    resources=resources,
+                    phase='replay',
+                    status='skipped',
+                    details=runtime_failure,
+                )
+                _update_run_state(
+                    resources=resources,
+                    phase='activity_verify',
+                    status='skipped',
+                    details=runtime_failure,
+                )
+                raise RuntimeError('environment_incomplete')
 
             _update_run_state(resources=resources, phase='replay', status='running')
             replay_report = _replay_dump(

--- a/services/torghut/tests/test_execution_adapters.py
+++ b/services/torghut/tests/test_execution_adapters.py
@@ -199,6 +199,57 @@ class TestExecutionAdapters(TestCase):
             ],
         )
 
+    def test_simulation_adapter_seeds_initial_positions_once(self) -> None:
+        adapter = SimulationExecutionAdapter(
+            bootstrap_servers=None,
+            security_protocol=None,
+            sasl_mechanism=None,
+            sasl_username=None,
+            sasl_password=None,
+            topic='torghut.sim.trade-updates.v1',
+            account_label='paper',
+            simulation_run_id='sim-2026-02-27-01',
+            dataset_id='dataset-1',
+        )
+        adapter.seed_positions_snapshot(
+            [
+                {'symbol': 'AAPL', 'qty': '2.5', 'side': 'long'},
+                {'symbol': 'MSFT', 'qty': '1', 'side': 'short'},
+            ]
+        )
+        adapter.seed_positions_snapshot(
+            [
+                {'symbol': 'AAPL', 'qty': '9', 'side': 'long'},
+            ]
+        )
+
+        adapter.submit_order(
+            symbol='AAPL',
+            side='sell',
+            qty=0.5,
+            order_type='market',
+            time_in_force='day',
+            extra_params={'client_order_id': 'decision-seeded-sell'},
+        )
+
+        self.assertEqual(
+            adapter.list_positions(),
+            [
+                {
+                    'symbol': 'AAPL',
+                    'qty': '2',
+                    'side': 'long',
+                    'alpaca_account_label': 'paper',
+                },
+                {
+                    'symbol': 'MSFT',
+                    'qty': '1',
+                    'side': 'short',
+                    'alpaca_account_label': 'paper',
+                },
+            ],
+        )
+
     def test_simulation_adapter_preserves_integer_magnitude_in_positions(self) -> None:
         adapter = SimulationExecutionAdapter(
             bootstrap_servers=None,

--- a/services/torghut/tests/test_start_historical_simulation.py
+++ b/services/torghut/tests/test_start_historical_simulation.py
@@ -9,6 +9,8 @@ from tempfile import TemporaryDirectory
 from unittest import TestCase
 from unittest.mock import patch
 
+import yaml
+
 from scripts import historical_simulation_verification, start_historical_simulation
 from scripts.start_historical_simulation import (
     ArgocdAutomationConfig,
@@ -3062,6 +3064,104 @@ class TestStartHistoricalSimulation(TestCase):
             ['apply', 'runtime_verify', 'replay', 'monitor', 'report'],
         )
 
+    def test_run_full_lifecycle_aborts_before_replay_when_runtime_not_ready(self) -> None:
+        resources = _build_resources(
+            'sim-runtime-gate-fail',
+            {
+                'dataset_id': 'dataset-a',
+            },
+        )
+        manifest = {
+            'dataset_id': 'dataset-a',
+            'window': {
+                'start': '2026-02-27T14:30:00Z',
+                'end': '2026-02-27T21:00:00Z',
+            },
+        }
+        kafka_config = KafkaRuntimeConfig(
+            bootstrap_servers='kafka:9092',
+            security_protocol=None,
+            sasl_mechanism=None,
+            sasl_username=None,
+            sasl_password=None,
+        )
+        clickhouse_config = ClickHouseRuntimeConfig(
+            http_url='http://clickhouse:8123',
+            username='torghut',
+            password=None,
+        )
+        postgres_config = PostgresRuntimeConfig(
+            admin_dsn='postgresql://torghut:secret@localhost:5432/postgres',
+            simulation_dsn='postgresql://torghut:secret@localhost:5432/torghut_sim_runtime_gate',
+            simulation_db='torghut_sim_runtime_gate',
+            migrations_command='true',
+        )
+        argocd_config = ArgocdAutomationConfig(
+            manage_automation=False,
+            applicationset_name='product',
+            applicationset_namespace='argocd',
+            app_name='torghut',
+            root_app_name='root',
+            desired_mode_during_run='manual',
+            restore_mode_after_run='previous',
+            verify_timeout_seconds=600,
+        )
+        rollouts_config = RolloutsAnalysisConfig(
+            enabled=True,
+            namespace='torghut',
+            runtime_template='torghut-simulation-runtime-ready',
+            activity_template='torghut-simulation-activity',
+            teardown_template='torghut-simulation-teardown-clean',
+            artifact_template='torghut-simulation-artifact-bundle',
+            verify_timeout_seconds=60,
+            verify_poll_seconds=5,
+        )
+
+        with (
+            patch('scripts.start_historical_simulation._ensure_supported_binary', return_value=None),
+            patch('scripts.start_historical_simulation._update_run_state', return_value=None),
+            patch('scripts.start_historical_simulation._save_json', return_value=None),
+            patch('scripts.start_historical_simulation.persist_completion_trace', return_value={}),
+            patch('scripts.start_historical_simulation.SessionLocal') as mock_session_local,
+            patch('scripts.start_historical_simulation._prepare_argocd_for_run', return_value={'managed': False}),
+            patch('scripts.start_historical_simulation._restore_argocd_after_run', return_value={'managed': False}),
+            patch('scripts.start_historical_simulation._apply', return_value={'status': 'ok'}),
+            patch(
+                'scripts.start_historical_simulation._run_rollouts_analysis',
+                return_value={'phase': 'Failed'},
+            ),
+            patch(
+                'scripts.start_historical_simulation._runtime_verify',
+                return_value={'runtime_state': 'not_ready'},
+            ),
+            patch('scripts.start_historical_simulation._replay_dump') as replay_dump,
+            patch(
+                'scripts.start_historical_simulation._report_simulation',
+                return_value={'status': 'ok'},
+            ),
+        ):
+            mock_session_local.return_value.__enter__.return_value = SimpleNamespace(commit=lambda: None)
+            with self.assertRaisesRegex(
+                RuntimeError,
+                'simulation_run_failed:environment_incomplete',
+            ):
+                _run_full_lifecycle(
+                    resources=resources,
+                    manifest=manifest,
+                    manifest_path=Path('/tmp/manifest.json'),
+                    kafka_config=kafka_config,
+                    clickhouse_config=clickhouse_config,
+                    postgres_config=postgres_config,
+                    argocd_config=argocd_config,
+                    rollouts_config=rollouts_config,
+                    force_dump=False,
+                    force_replay=False,
+                    skip_teardown=True,
+                    report_only=False,
+                )
+
+        replay_dump.assert_not_called()
+
     def test_run_full_lifecycle_waits_for_runtime_verify_without_rollouts(self) -> None:
         resources = _build_resources(
             'sim-1',
@@ -4206,6 +4306,23 @@ class TestStartHistoricalSimulation(TestCase):
         self.assertEqual(payload['spec']['args'][9]['value'], 'torghut_sim_sim_2026_03_06_open_hour.ta_microbars')
         self.assertEqual(payload['spec']['args'][-2]['value'], '60')
         self.assertEqual(payload['spec']['args'][-1]['value'], '5')
+
+    def test_runtime_ready_template_declares_signal_and_price_tables(self) -> None:
+        template_path = (
+            Path(__file__).resolve().parents[3]
+            / 'argocd'
+            / 'applications'
+            / 'torghut'
+            / 'analysis-template-runtime-ready.yaml'
+        )
+        template = yaml.safe_load(template_path.read_text(encoding='utf-8'))
+        spec = template['spec']
+        arg_names = [entry['name'] for entry in spec['args']]
+        self.assertIn('signalTable', arg_names)
+        self.assertIn('priceTable', arg_names)
+        args_text = spec['metrics'][0]['provider']['job']['spec']['template']['spec']['containers'][0]['args'][0]
+        self.assertIn('--signal-table "{{args.signalTable}}"', args_text)
+        self.assertIn('--price-table "{{args.priceTable}}"', args_text)
 
     def test_discover_automation_pointer_finds_nested_element(self) -> None:
         payload = {

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -14,6 +14,7 @@ from sqlalchemy.orm import Session, sessionmaker
 
 from app.models import Base, Execution, LLMDecisionReview, Strategy, TradeDecision
 from app.trading.decisions import DecisionEngine
+from app.trading.execution_adapters import SimulationExecutionAdapter
 from app.trading.execution import OrderExecutor
 from app.trading.firewall import OrderFirewall
 from app.trading.llm.review_engine import LLMReviewOutcome
@@ -6415,6 +6416,213 @@ class TestTradingPipeline(TestCase):
             config.settings.trading_enabled = original["trading_enabled"]
             config.settings.trading_mode = original["trading_mode"]
             config.settings.trading_live_enabled = original["trading_live_enabled"]
+            config.settings.trading_universe_source = original[
+                "trading_universe_source"
+            ]
+            config.settings.trading_static_symbols_raw = original[
+                "trading_static_symbols_raw"
+            ]
+            config.settings.llm_enabled = original["llm_enabled"]
+            config.settings.llm_fail_mode = original["llm_fail_mode"]
+            config.settings.llm_fail_mode_enforcement = original[
+                "llm_fail_mode_enforcement"
+            ]
+            config.settings.llm_fail_open_live_approved = original[
+                "llm_fail_open_live_approved"
+            ]
+            config.settings.llm_shadow_mode = original["llm_shadow_mode"]
+            config.settings.llm_min_confidence = original["llm_min_confidence"]
+            config.settings.llm_allowed_models_raw = original["llm_allowed_models_raw"]
+            config.settings.llm_evaluation_report = original["llm_evaluation_report"]
+            config.settings.llm_effective_challenge_id = original[
+                "llm_effective_challenge_id"
+            ]
+            config.settings.llm_shadow_completed_at = original[
+                "llm_shadow_completed_at"
+            ]
+            config.settings.llm_model_version_lock = original["llm_model_version_lock"]
+            config.settings.llm_adjustment_approved = original[
+                "llm_adjustment_approved"
+            ]
+            config.settings.llm_dspy_runtime_mode = original["llm_dspy_runtime_mode"]
+            config.settings.llm_dspy_artifact_hash = original["llm_dspy_artifact_hash"]
+            config.settings.llm_dspy_program_name = original["llm_dspy_program_name"]
+            config.settings.llm_dspy_signature_version = original[
+                "llm_dspy_signature_version"
+            ]
+            config.settings.llm_rollout_stage = original["llm_rollout_stage"]
+            config.settings.llm_dspy_live_runtime_block_fail_mode = original[
+                "llm_dspy_live_runtime_block_fail_mode"
+            ]
+            config.settings.llm_dspy_live_runtime_block_qty_multiplier = original[
+                "llm_dspy_live_runtime_block_qty_multiplier"
+            ]
+            config.settings.jangar_base_url = original["jangar_base_url"]
+
+    def test_pipeline_llm_dspy_runtime_reduced_sell_uses_seeded_simulation_inventory(
+        self,
+    ) -> None:
+        from app import config
+
+        original = {
+            "trading_enabled": config.settings.trading_enabled,
+            "trading_mode": config.settings.trading_mode,
+            "trading_live_enabled": config.settings.trading_live_enabled,
+            "trading_execution_adapter": config.settings.trading_execution_adapter,
+            "trading_allow_shorts": config.settings.trading_allow_shorts,
+            "trading_fractional_equities_enabled": config.settings.trading_fractional_equities_enabled,
+            "trading_universe_source": config.settings.trading_universe_source,
+            "trading_static_symbols_raw": config.settings.trading_static_symbols_raw,
+            "llm_enabled": config.settings.llm_enabled,
+            "llm_fail_mode": config.settings.llm_fail_mode,
+            "llm_fail_mode_enforcement": config.settings.llm_fail_mode_enforcement,
+            "llm_fail_open_live_approved": config.settings.llm_fail_open_live_approved,
+            "llm_shadow_mode": config.settings.llm_shadow_mode,
+            "llm_min_confidence": config.settings.llm_min_confidence,
+            "llm_allowed_models_raw": config.settings.llm_allowed_models_raw,
+            "llm_evaluation_report": config.settings.llm_evaluation_report,
+            "llm_effective_challenge_id": config.settings.llm_effective_challenge_id,
+            "llm_shadow_completed_at": config.settings.llm_shadow_completed_at,
+            "llm_model_version_lock": config.settings.llm_model_version_lock,
+            "llm_adjustment_approved": config.settings.llm_adjustment_approved,
+            "llm_dspy_runtime_mode": config.settings.llm_dspy_runtime_mode,
+            "llm_dspy_artifact_hash": config.settings.llm_dspy_artifact_hash,
+            "llm_dspy_program_name": config.settings.llm_dspy_program_name,
+            "llm_dspy_signature_version": config.settings.llm_dspy_signature_version,
+            "llm_rollout_stage": config.settings.llm_rollout_stage,
+            "llm_dspy_live_runtime_block_fail_mode": config.settings.llm_dspy_live_runtime_block_fail_mode,
+            "llm_dspy_live_runtime_block_qty_multiplier": config.settings.llm_dspy_live_runtime_block_qty_multiplier,
+            "jangar_base_url": config.settings.jangar_base_url,
+        }
+        config.settings.trading_enabled = True
+        config.settings.trading_mode = "live"
+        config.settings.trading_live_enabled = True
+        config.settings.trading_execution_adapter = "simulation"
+        config.settings.trading_allow_shorts = True
+        config.settings.trading_fractional_equities_enabled = True
+        config.settings.trading_universe_source = "static"
+        config.settings.trading_static_symbols_raw = "AAPL"
+        config.settings.llm_enabled = True
+        config.settings.llm_fail_mode = "pass_through"
+        config.settings.llm_fail_mode_enforcement = "configured"
+        config.settings.llm_fail_open_live_approved = True
+        config.settings.llm_shadow_mode = False
+        config.settings.llm_min_confidence = 0.0
+        config.settings.llm_dspy_runtime_mode = "active"
+        config.settings.jangar_base_url = "http://jangar.test"
+        config.settings.llm_dspy_artifact_hash = (
+            DSPyReviewRuntime.bootstrap_artifact_hash()
+        )
+        config.settings.llm_rollout_stage = "stage3"
+        config.settings.llm_dspy_live_runtime_block_fail_mode = (
+            "pass_through_reduced_size"
+        )
+        config.settings.llm_dspy_live_runtime_block_qty_multiplier = 0.5
+        _set_llm_guardrails(config)
+
+        try:
+            with self.session_local() as session:
+                strategy = Strategy(
+                    name="demo-sell",
+                    description="demo sell",
+                    enabled=True,
+                    base_timeframe="1Min",
+                    universe_type="static",
+                    universe_symbols=["AAPL"],
+                    max_notional_per_trade=Decimal("100"),
+                )
+                session.add(strategy)
+                session.commit()
+
+            signal = SignalEnvelope(
+                event_ts=datetime.now(timezone.utc),
+                symbol="AAPL",
+                payload={
+                    "macd": {"macd": 0.1, "signal": 0.4},
+                    "rsi14": 75,
+                    "price": 100,
+                },
+                timeframe="1Min",
+            )
+
+            alpaca_client = PositionedAlpacaClient(
+                [{"symbol": "AAPL", "qty": "2", "side": "long"}]
+            )
+            execution_adapter = SimulationExecutionAdapter(
+                bootstrap_servers=None,
+                security_protocol=None,
+                sasl_mechanism=None,
+                sasl_username=None,
+                sasl_password=None,
+                topic="torghut.sim.trade-updates.v1",
+                account_label="live",
+                simulation_run_id="sim-test",
+                dataset_id="dataset-a",
+            )
+            pipeline = TradingPipeline(
+                alpaca_client=alpaca_client,
+                order_firewall=OrderFirewall(alpaca_client),
+                ingestor=FakeIngestor([signal]),
+                decision_engine=DecisionEngine(),
+                risk_engine=RiskEngine(),
+                executor=OrderExecutor(),
+                execution_adapter=execution_adapter,
+                reconciler=Reconciler(),
+                universe_resolver=UniverseResolver(),
+                state=TradingState(),
+                account_label="live",
+                session_factory=self.session_local,
+                llm_review_engine=CountingLLMReviewEngine(),
+            )
+
+            pipeline.run_once()
+
+            with self.session_local() as session:
+                reviews = session.execute(select(LLMDecisionReview)).scalars().all()
+                decisions = session.execute(select(TradeDecision)).scalars().all()
+                executions = session.execute(select(Execution)).scalars().all()
+
+                self.assertEqual(len(reviews), 1)
+                self.assertEqual(reviews[0].verdict, "error")
+                self.assertEqual(
+                    reviews[0].rationale,
+                    "llm_dspy_live_runtime_gate_blocked",
+                )
+                self.assertEqual(
+                    reviews[0].response_json.get("fallback"), "pass_through"
+                )
+                self.assertEqual(decisions[0].status, "submitted")
+                self.assertEqual(len(executions), 1)
+                self.assertLess(executions[0].submitted_qty, Decimal("1"))
+                remaining_qty = Decimal(
+                    str(execution_adapter.list_positions()[0]["qty"])
+                )
+                self.assertEqual(
+                    remaining_qty,
+                    Decimal("2") - executions[0].submitted_qty,
+                )
+                self.assertEqual(
+                    execution_adapter.list_positions(),
+                    [
+                        {
+                            "symbol": "AAPL",
+                            "qty": str(remaining_qty.normalize()),
+                            "side": "long",
+                            "alpaca_account_label": "live",
+                        }
+                    ],
+                )
+        finally:
+            config.settings.trading_enabled = original["trading_enabled"]
+            config.settings.trading_mode = original["trading_mode"]
+            config.settings.trading_live_enabled = original["trading_live_enabled"]
+            config.settings.trading_execution_adapter = original[
+                "trading_execution_adapter"
+            ]
+            config.settings.trading_allow_shorts = original["trading_allow_shorts"]
+            config.settings.trading_fractional_equities_enabled = original[
+                "trading_fractional_equities_enabled"
+            ]
             config.settings.trading_universe_source = original[
                 "trading_universe_source"
             ]


### PR DESCRIPTION
## Summary

- seed the simulation execution adapter once from the broker snapshot and use adapter-backed positions for simulation run context
- keep reduced-size LLM runtime fallback sells aligned with submit-time inventory so fractional long-reducing sells execute in replay instead of failing locally
- fix the runtime-ready AnalysisTemplate contract to pass `signalTable` and `priceTable`
- make historical simulation abort before replay when the runtime gate is not ready
- add regression coverage for simulation seeding, reduced-size sell replay, runtime template contract, and lifecycle abort behavior

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_execution_adapters.py tests/test_trading_pipeline.py tests/test_start_historical_simulation.py tests/test_run_simulation_analysis.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
