### PR TITLE
fix(torghut): fail closed on runtime strategy gaps

### DIFF
--- a/services/torghut/app/trading/decisions.py
+++ b/services/torghut/app/trading/decisions.py
@@ -106,23 +106,7 @@ class DecisionEngine:
                 equity=equity,
                 positions=positions,
             )
-            if decisions:
-                return decisions
-            runtime_telemetry = self._last_runtime_telemetry
-            legacy_decisions = self._evaluate_legacy(
-                signal,
-                filtered,
-                equity=equity,
-                positions=positions,
-            )
-            self._last_runtime_telemetry = DecisionRuntimeTelemetry(
-                mode=settings.trading_strategy_runtime_mode,
-                runtime_enabled=True,
-                fallback_to_legacy=True,
-                errors=runtime_telemetry.errors,
-                observation=runtime_telemetry.observation,
-            )
-            return legacy_decisions
+            return decisions
 
         return self._evaluate_legacy(
             signal,

--- a/services/torghut/tests/test_decisions.py
+++ b/services/torghut/tests/test_decisions.py
@@ -406,7 +406,55 @@ class TestDecisionEngine(TestCase):
         )
         self.assertEqual(source_runtime[0].get("compiler_source"), "legacy_runtime")
 
-    def test_scheduler_runtime_falls_back_to_legacy_when_plugin_missing(self) -> None:
+    def test_scheduler_runtime_does_not_fallback_to_legacy_when_runtime_returns_no_intents(
+        self,
+    ) -> None:
+        engine = DecisionEngine(price_fetcher=None)
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="tsmom-only",
+            description=(
+                "version=1.0.0\n[catalog_metadata]\n"
+                '{"strategy_type":"intraday_tsmom_v1","version":"1.0.0","compiler_source":"spec_v2"}'
+            ),
+            enabled=True,
+            base_timeframe="1Min",
+            universe_type="intraday_tsmom_v1",
+            universe_symbols=None,
+            max_position_pct_equity=None,
+            max_notional_per_trade=Decimal("500"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            symbol="AAPL",
+            payload={
+                "ema12": Decimal("100.0"),
+                "ema26": Decimal("101.0"),
+                "macd": {"macd": Decimal("0.01"), "signal": Decimal("0.05")},
+                "rsi14": Decimal("72"),
+                "price": 100,
+            },
+            timeframe="1Min",
+        )
+        with (
+            patch.object(settings, "trading_strategy_runtime_mode", "scheduler_v3"),
+            patch.object(settings, "trading_strategy_scheduler_enabled", True),
+        ):
+            decisions = engine.evaluate(signal, [strategy])
+            telemetry = engine.consume_runtime_telemetry()
+
+        self.assertEqual(decisions, [])
+        self.assertTrue(telemetry.runtime_enabled)
+        self.assertFalse(telemetry.fallback_to_legacy)
+        self.assertEqual(telemetry.errors, ())
+        self.assertIsNotNone(telemetry.observation)
+        if telemetry.observation is not None:
+            self.assertEqual(
+                telemetry.observation.strategy_intents_total.get(str(strategy.id), 0),
+                0,
+            )
+
+    def test_scheduler_runtime_fails_closed_when_plugin_missing(self) -> None:
         engine = DecisionEngine(price_fetcher=None)
         strategy = Strategy(
             id=uuid.uuid4(),
@@ -436,8 +484,8 @@ class TestDecisionEngine(TestCase):
             decisions = engine.evaluate(signal, [strategy])
             telemetry = engine.consume_runtime_telemetry()
 
-        self.assertEqual(len(decisions), 1)
-        self.assertTrue(telemetry.fallback_to_legacy)
+        self.assertEqual(decisions, [])
+        self.assertFalse(telemetry.fallback_to_legacy)
         self.assertEqual(len(telemetry.errors), 1)
         self.assertEqual(telemetry.errors[0].reason, "plugin_not_found")
         self.assertIsNotNone(telemetry.observation)
@@ -446,9 +494,6 @@ class TestDecisionEngine(TestCase):
                 telemetry.observation.strategy_errors_total.get(str(strategy.id)),
                 1,
             )
-        runtime_meta = decisions[0].params.get("strategy_runtime")
-        assert isinstance(runtime_meta, dict)
-        self.assertEqual(runtime_meta.get("plugin_id"), "legacy_builtin")
 
     def test_scheduler_runtime_attaches_forecast_contract_and_telemetry(self) -> None:
         strategy = Strategy(


### PR DESCRIPTION
## Summary

- remove the scheduler runtime fallback that silently routed empty runtime evaluations into legacy MACD/RSI logic
- fail closed when the configured runtime strategy has no intents or no plugin so live behavior reflects the active strategy catalog
- add regression coverage for empty-intent and missing-plugin scheduler runtime cases

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen pytest tests/test_decisions.py tests/test_strategy_runtime.py`

## Screenshots (if applicable)

N/A

## Breaking Changes

Scheduler runtime no longer falls back to legacy decisioning when the active strategy runtime produces no intents or cannot resolve a plugin. Operators must treat zero-intent runtime behavior as a real strategy/runtime issue rather than expecting legacy coverage.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
