### PR TITLE
fix(torghut): resolve simulation schema paths in container

### DIFF
--- a/services/torghut/scripts/start_historical_simulation.py
+++ b/services/torghut/scripts/start_historical_simulation.py
@@ -3126,7 +3126,6 @@ def _simulation_schema_registry_subject_specs(
         Mapping[str, str],
         lane_contract.schema_registry_schema_file_by_role,
     )
-    repo_root = Path(__file__).resolve().parents[3]
     specs: list[dict[str, str]] = []
     for role in simulation_schema_registry_subject_roles(lane_contract):
         topic = resources.simulation_topic_by_role.get(role)
@@ -3137,10 +3136,19 @@ def _simulation_schema_registry_subject_specs(
             {
                 'role': role,
                 'subject': f'{topic}-value',
-                'schema_path': str((repo_root / schema_relative).resolve()),
+                'schema_path': str(_resolve_schema_registry_schema_path(schema_relative)),
             }
         )
     return specs
+
+
+def _resolve_schema_registry_schema_path(schema_relative: str) -> Path:
+    script_path = Path(__file__).resolve()
+    for candidate_root in (script_path.parent, *script_path.parents):
+        candidate_path = (candidate_root / schema_relative).resolve()
+        if candidate_path.exists():
+            return candidate_path
+    return (script_path.parents[min(3, len(script_path.parents) - 1)] / schema_relative).resolve()
 
 
 def _load_schema_registry_schema_literal(schema_path: str) -> str:

--- a/services/torghut/tests/test_start_historical_simulation.py
+++ b/services/torghut/tests/test_start_historical_simulation.py
@@ -54,6 +54,7 @@ from scripts.start_historical_simulation import (
     _replay_dump,
     _run_full_lifecycle,
     _run_rollouts_analysis,
+    _simulation_schema_registry_subject_specs,
     _simulation_evidence_lineage,
     _set_argocd_application_sync_policy,
     _set_argocd_automation_mode,
@@ -167,6 +168,28 @@ class TestStartHistoricalSimulation(TestCase):
                     'underlyings': ['AAPL'],
                 },
             )
+
+    def test_simulation_schema_registry_subject_specs_resolves_container_layout(self) -> None:
+        resources = _build_resources(
+            'sim-2026-03-11-open-1h',
+            {
+                'dataset_id': 'torghut-tsmom-open-hour-20260311',
+            },
+        )
+        with TemporaryDirectory() as tmpdir:
+            app_root = Path(tmpdir) / 'app'
+            script_path = app_root / 'scripts' / 'start_historical_simulation.py'
+            schema_path = app_root / 'docs' / 'torghut' / 'schemas' / 'ta-signals.avsc'
+            script_path.parent.mkdir(parents=True)
+            script_path.write_text('# test', encoding='utf-8')
+            schema_path.parent.mkdir(parents=True)
+            schema_path.write_text('{"type":"record","name":"Signal","fields":[]}', encoding='utf-8')
+
+            with patch.object(start_historical_simulation, '__file__', str(script_path)):
+                specs = _simulation_schema_registry_subject_specs(resources=resources)
+
+        ta_signal_spec = next(spec for spec in specs if spec['role'] == 'ta_signals')
+        self.assertEqual(ta_signal_spec['schema_path'], str(schema_path.resolve()))
 
     def test_build_postgres_runtime_config_uses_template(self) -> None:
         config = _build_postgres_runtime_config(


### PR DESCRIPTION
## Summary

- resolve historical simulation schema registry file lookup without assuming a repo checkout depth that does not exist in the container image
- support both local repo execution and in-cluster `/app` workflow execution when building schema subject specs
- add regression coverage for the exact `/app/scripts/start_historical_simulation.py` Argo workflow layout

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_start_historical_simulation.py -k 'schema_registry_subject_specs_resolves_container_layout or runtime_verify or analysis_template'`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
