### PR TITLE
fix(torghut): unblock tsmom replay batches

### DIFF
--- a/services/torghut/app/trading/feature_quality.py
+++ b/services/torghut/app/trading/feature_quality.py
@@ -21,6 +21,14 @@ REASON_SCHEMA_MISMATCH = "schema_mismatch"
 REASON_REQUIRED_NULL_RATE = "required_feature_null_rate_exceeds_threshold"
 REASON_STALENESS = "feature_staleness_exceeds_budget"
 REASON_DUPLICATE_RATIO = "duplicate_ratio_exceeds_threshold"
+BLOCKING_REASONS = frozenset(
+    {
+        REASON_NON_MONOTONIC,
+        REASON_SCHEMA_MISMATCH,
+        REASON_STALENESS,
+        REASON_DUPLICATE_RATIO,
+    }
+)
 
 
 @dataclass(frozen=True)
@@ -57,6 +65,14 @@ class FeatureQualityReport:
             "schema_mismatch_total": self.schema_mismatch_total,
             "reasons": list(self.reasons),
         }
+
+    @property
+    def blocking_reasons(self) -> list[str]:
+        return [reason for reason in self.reasons if reason in BLOCKING_REASONS]
+
+    @property
+    def warning_only_reasons(self) -> list[str]:
+        return [reason for reason in self.reasons if reason not in BLOCKING_REASONS]
 
 
 class FeatureQualityError(RuntimeError):

--- a/services/torghut/app/trading/scheduler/pipeline.py
+++ b/services/torghut/app/trading/scheduler/pipeline.py
@@ -241,16 +241,34 @@ class TradingPipeline:
                 self.state.metrics.record_feature_quality_rejection(
                     quality_report.reasons
                 )
-                self.state.metrics.record_feature_quality_cursor_commit_blocked(
-                    quality_report.reasons
-                )
                 failure_payload = self._feature_quality_failure_payload(
                     batch=batch,
                     quality_signals=quality_signals,
                     quality_report=quality_report,
                 )
-                logger.error(
-                    "Feature quality gate failed component=%s account_label=%s rows=%s reasons=%s "
+                if quality_report.blocking_reasons:
+                    self.state.metrics.record_feature_quality_cursor_commit_blocked(
+                        quality_report.blocking_reasons
+                    )
+                    logger.error(
+                        "Feature quality gate failed component=%s account_label=%s rows=%s reasons=%s "
+                        "cursor_at=%s cursor_symbol=%s cursor_seq=%s staleness_ms_p95=%s duplicate_ratio=%s "
+                        "sample=%s",
+                        failure_payload["component"],
+                        failure_payload["account_label"],
+                        quality_report.rows_total,
+                        quality_report.reasons,
+                        failure_payload["cursor_at"],
+                        failure_payload["cursor_symbol"],
+                        failure_payload["cursor_seq"],
+                        quality_report.staleness_ms_p95,
+                        quality_report.duplicate_ratio,
+                        failure_payload["sample_rows"],
+                    )
+                    return False
+
+                logger.warning(
+                    "Feature quality degradation observed component=%s account_label=%s rows=%s reasons=%s "
                     "cursor_at=%s cursor_symbol=%s cursor_seq=%s staleness_ms_p95=%s duplicate_ratio=%s "
                     "sample=%s",
                     failure_payload["component"],
@@ -264,7 +282,6 @@ class TradingPipeline:
                     quality_report.duplicate_ratio,
                     failure_payload["sample_rows"],
                 )
-                return False
 
         self.state.metrics.no_signal_reason_streak = {}
         self.state.metrics.no_signal_streak = 0

--- a/services/torghut/scripts/start_historical_simulation.py
+++ b/services/torghut/scripts/start_historical_simulation.py
@@ -274,12 +274,23 @@ KAFKA_HOST_SUFFIX_FALLBACKS = (
 _ORIGINAL_GETADDRINFO = socket.getaddrinfo
 
 
-def _kafka_host_candidates(host: str) -> list[str]:
+def _cluster_service_host_candidates(host: str) -> list[str]:
     host = host.strip()
     if not host:
         return []
 
     candidates = [host]
+    host_parts = host.split('.')
+    if len(host_parts) == 2:
+        candidates.append(f'{host}.svc')
+        candidates.append(f'{host}.svc.cluster.local')
+    if host.endswith('.svc') and not host.endswith('.svc.cluster.local'):
+        candidates.append(f'{host}.cluster.local')
+    return candidates
+
+
+def _kafka_host_candidates(host: str) -> list[str]:
+    candidates = _cluster_service_host_candidates(host)
     if '.' not in host:
         for suffix in KAFKA_HOST_SUFFIX_FALLBACKS:
             candidates.append(f'{host}{suffix}')
@@ -2368,15 +2379,23 @@ def _http_request(
         target_path = f'{target_path.rstrip("/")}/{path.lstrip("/")}'
     request_headers = dict(headers or {})
     connection_class = HTTPSConnection if scheme == 'https' else HTTPConnection
-    connection = connection_class(parsed.hostname, parsed.port)
-    try:
-        payload = body.encode('utf-8') if body is not None else None
-        connection.request(method.upper(), target_path, body=payload, headers=request_headers)
-        response = connection.getresponse()
-        response_body = response.read().decode('utf-8', errors='replace')
-        return response.status, response_body
-    finally:
-        connection.close()
+    payload = body.encode('utf-8') if body is not None else None
+    last_error: OSError | None = None
+    for hostname in _cluster_service_host_candidates(parsed.hostname):
+        connection = connection_class(hostname, parsed.port)
+        try:
+            connection.request(method.upper(), target_path, body=payload, headers=request_headers)
+            response = connection.getresponse()
+            response_body = response.read().decode('utf-8', errors='replace')
+            return response.status, response_body
+        except OSError as exc:
+            last_error = exc
+            continue
+        finally:
+            connection.close()
+    if last_error is not None:
+        raise last_error
+    raise RuntimeError('http_request_failed_without_attempts')
 
 
 def _clickhouse_query_configs(config: ClickHouseRuntimeConfig) -> list[ClickHouseRuntimeConfig]:

--- a/services/torghut/tests/test_feature_quality.py
+++ b/services/torghut/tests/test_feature_quality.py
@@ -109,6 +109,11 @@ class TestFeatureQuality(TestCase):
         self.assertFalse(report.accepted)
         self.assertGreater(report.null_rate_by_field['macd'], 0)
         self.assertIn('required_feature_null_rate_exceeds_threshold', report.reasons)
+        self.assertEqual(report.blocking_reasons, [])
+        self.assertEqual(
+            report.warning_only_reasons,
+            ['required_feature_null_rate_exceeds_threshold'],
+        )
 
     def test_batch_fails_on_non_monotonic_progression(self) -> None:
         ts = datetime(2026, 1, 1, tzinfo=timezone.utc)

--- a/services/torghut/tests/test_start_historical_simulation.py
+++ b/services/torghut/tests/test_start_historical_simulation.py
@@ -68,6 +68,29 @@ from scripts.start_historical_simulation import (
 
 
 class TestStartHistoricalSimulation(TestCase):
+    def test_cluster_service_host_candidates_expand_cluster_local_for_partially_qualified_service(self) -> None:
+        self.assertEqual(
+            start_historical_simulation._cluster_service_host_candidates('karapace.kafka.svc'),
+            ['karapace.kafka.svc', 'karapace.kafka.svc.cluster.local'],
+        )
+
+    def test_cluster_service_host_candidates_expand_service_namespace_short_form(self) -> None:
+        self.assertEqual(
+            start_historical_simulation._cluster_service_host_candidates('karapace.kafka'),
+            ['karapace.kafka', 'karapace.kafka.svc', 'karapace.kafka.svc.cluster.local'],
+        )
+
+    def test_kafka_host_candidates_expand_cluster_local_for_partially_qualified_service(self) -> None:
+        self.assertEqual(
+            start_historical_simulation._kafka_host_candidates(
+                'kafka-pool-b-5.kafka-kafka-brokers.kafka.svc'
+            ),
+            [
+                'kafka-pool-b-5.kafka-kafka-brokers.kafka.svc',
+                'kafka-pool-b-5.kafka-kafka-brokers.kafka.svc.cluster.local',
+            ],
+        )
+
     def test_normalize_run_token(self) -> None:
         self.assertEqual(_normalize_run_token('Sim-2026/02/27#Run-01'), 'sim_2026_02_27_run_01')
 

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -828,6 +828,125 @@ class TestTradingPipeline(TestCase):
                 "trading_kill_switch_enabled"
             ]
 
+    def test_pipeline_continues_when_feature_quality_has_warning_only_null_rate(self) -> None:
+        from app import config
+
+        original = {
+            "trading_enabled": config.settings.trading_enabled,
+            "trading_mode": config.settings.trading_mode,
+            "trading_live_enabled": config.settings.trading_live_enabled,
+            "trading_universe_source": config.settings.trading_universe_source,
+            "trading_static_symbols_raw": config.settings.trading_static_symbols_raw,
+            "trading_feature_quality_enabled": config.settings.trading_feature_quality_enabled,
+            "trading_feature_max_staleness_ms": config.settings.trading_feature_max_staleness_ms,
+            "trading_kill_switch_enabled": config.settings.trading_kill_switch_enabled,
+        }
+        config.settings.trading_enabled = True
+        config.settings.trading_mode = "paper"
+        config.settings.trading_live_enabled = False
+        config.settings.trading_universe_source = "static"
+        config.settings.trading_static_symbols_raw = "AAPL,MSFT"
+        config.settings.trading_feature_quality_enabled = True
+        config.settings.trading_feature_max_staleness_ms = 1_000
+        config.settings.trading_kill_switch_enabled = False
+
+        try:
+            with self.session_local() as session:
+                strategy = Strategy(
+                    name="demo",
+                    description="quality-gate warning-only regression",
+                    enabled=True,
+                    base_timeframe="1Min",
+                    universe_type="static",
+                    universe_symbols=["AAPL", "MSFT"],
+                    max_notional_per_trade=Decimal("1000"),
+                )
+                session.add(strategy)
+                session.commit()
+
+            valid_signal = SignalEnvelope(
+                event_ts=datetime(2026, 1, 1, tzinfo=timezone.utc),
+                ingest_ts=datetime(2026, 1, 1, 0, 0, 0, 500000, tzinfo=timezone.utc),
+                symbol="AAPL",
+                timeframe="1Min",
+                seq=1,
+                payload={
+                    "feature_schema_version": "3.0.0",
+                    "macd": {"macd": 1.2, "signal": 0.5},
+                    "rsi14": 25,
+                    "price": 100,
+                },
+            )
+            incomplete_signal = SignalEnvelope(
+                event_ts=datetime(2026, 1, 1, tzinfo=timezone.utc),
+                ingest_ts=datetime(2026, 1, 1, 0, 0, 0, 500000, tzinfo=timezone.utc),
+                symbol="MSFT",
+                timeframe="1Min",
+                seq=2,
+                payload={
+                    "feature_schema_version": "3.0.0",
+                    "macd": {"macd": None, "signal": None},
+                    "rsi14": None,
+                    "price": 100,
+                },
+            )
+
+            alpaca_client = FakeAlpacaClient()
+            execution_adapter = FakeAlpacaClient()
+            ingestor = FakeIngestor([valid_signal, incomplete_signal])
+            state = TradingState()
+            pipeline = TradingPipeline(
+                alpaca_client=alpaca_client,
+                order_firewall=OrderFirewall(alpaca_client),
+                ingestor=ingestor,
+                decision_engine=DecisionEngine(),
+                risk_engine=RiskEngine(),
+                executor=OrderExecutor(),
+                execution_adapter=execution_adapter,
+                reconciler=Reconciler(),
+                universe_resolver=UniverseResolver(),
+                state=state,
+                account_label="paper",
+                session_factory=self.session_local,
+            )
+
+            pipeline.run_once()
+
+            self.assertEqual(ingestor.committed_batches, 1)
+            self.assertEqual(state.metrics.feature_quality_rejections_total, 1)
+            self.assertEqual(
+                state.metrics.feature_quality_reject_reason_total.get(
+                    "required_feature_null_rate_exceeds_threshold"
+                ),
+                1,
+            )
+            self.assertIsNone(
+                state.metrics.feature_quality_cursor_commit_blocked_total.get(
+                    "required_feature_null_rate_exceeds_threshold"
+                )
+            )
+            self.assertEqual(len(alpaca_client.submitted), 1)
+            self.assertEqual(alpaca_client.submitted[0]["symbol"], "AAPL")
+        finally:
+            config.settings.trading_enabled = original["trading_enabled"]
+            config.settings.trading_mode = original["trading_mode"]
+            config.settings.trading_live_enabled = original["trading_live_enabled"]
+            config.settings.trading_universe_source = original[
+                "trading_universe_source"
+            ]
+            config.settings.trading_static_symbols_raw = original[
+                "trading_static_symbols_raw"
+            ]
+            config.settings.trading_feature_quality_enabled = original[
+                "trading_feature_quality_enabled"
+            ]
+            config.settings.trading_feature_max_staleness_ms = original[
+                "trading_feature_max_staleness_ms"
+            ]
+            config.settings.trading_kill_switch_enabled = original[
+                "trading_kill_switch_enabled"
+            ]
+
     def test_stale_planned_decision_is_force_rejected(self) -> None:
         from app import config
 


### PR DESCRIPTION
## Summary

- unblock Torghut batch progression when feature-quality degradation is limited to required-field null-rate breaches
- continue replay and live processing on warning-only feature-quality degradations while still fail-closing on ordering, schema, staleness, and duplicate faults
- add regression coverage for warning-only batch progression and cluster-local host expansion in the historical simulation launcher

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_feature_quality.py tests/test_trading_pipeline.py tests/test_start_historical_simulation.py -k 'feature_quality or quality_gate or cluster_service_host_candidates or kafka_host_candidates or runtime_verify'`
- `cd services/torghut && uv run --frozen ruff check app/trading/feature_quality.py app/trading/scheduler/pipeline.py scripts/start_historical_simulation.py tests/test_feature_quality.py tests/test_trading_pipeline.py tests/test_start_historical_simulation.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
