### PR TITLE
fix(torghut): remove legacy strategy defaults

### DIFF
--- a/argocd/applications/torghut/strategy-configmap.yaml
+++ b/argocd/applications/torghut/strategy-configmap.yaml
@@ -10,13 +10,6 @@ metadata:
 data:
   strategies.yaml: |
     strategies:
-      - name: macd-rsi-default
-        description: MACD/RSI demo strategy
-        enabled: false
-        base_timeframe: "1Sec"
-        universe_type: static
-        max_notional_per_trade: 500
-        max_position_pct_equity: 0.05
       - name: intraday-tsmom-profit-v2
         description: Intraday momentum strategy tuned for higher selectivity, version=1.1.0
         enabled: true

--- a/services/torghut/config/simulation/smoke-open-30m-2026-03-06.yaml
+++ b/services/torghut/config/simulation/smoke-open-30m-2026-03-06.yaml
@@ -1,10 +1,10 @@
 dataset_id: torghut-smoke-open-30m-20260306
 dataset_snapshot_ref: torghut-smoke-open-30m-20260306
-candidate_id: legacy_macd_rsi@prod
-baseline_candidate_id: legacy_macd_rsi@baseline
-strategy_spec_ref: strategy-specs/legacy_macd_rsi@1.0.0.json
+candidate_id: intraday_tsmom_v1@prod
+baseline_candidate_id: intraday_tsmom_v1@baseline
+strategy_spec_ref: strategy-specs/intraday_tsmom_v1@1.1.0.json
 model_refs:
-  - rules/legacy_macd_rsi
+  - rules/intraday_tsmom_v1
 runtime_version_refs:
   - services/torghut@simulation
   - services/torghut-forecast@simulation

--- a/services/torghut/config/simulation/smoke-open-hour-2026-03-06.yaml
+++ b/services/torghut/config/simulation/smoke-open-hour-2026-03-06.yaml
@@ -1,10 +1,10 @@
 dataset_id: torghut-smoke-open-hour-20260306
 dataset_snapshot_ref: torghut-smoke-open-hour-20260306
-candidate_id: legacy_macd_rsi@prod
-baseline_candidate_id: legacy_macd_rsi@baseline
-strategy_spec_ref: strategy-specs/legacy_macd_rsi@1.0.0.json
+candidate_id: intraday_tsmom_v1@prod
+baseline_candidate_id: intraday_tsmom_v1@baseline
+strategy_spec_ref: strategy-specs/intraday_tsmom_v1@1.1.0.json
 model_refs:
-  - rules/legacy_macd_rsi
+  - rules/intraday_tsmom_v1
 runtime_version_refs:
   - services/torghut@simulation
   - services/torghut-forecast@simulation


### PR DESCRIPTION
## Summary

- remove the disabled `macd-rsi-default` entry from the Torghut strategy catalog ConfigMap
- repoint the stock 30-minute and 1-hour historical smoke manifests to `intraday_tsmom_v1`
- keep default simulation entrypoints aligned with the deployed TSMOM runtime instead of the retired legacy strategy

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_strategy_catalog.py`
- `cd services/torghut && uv run --frozen python - <<'PY'
from pathlib import Path
import yaml
paths = [
    Path('/Users/gregkonush/.codex/worktrees/4b2e/lab/argocd/applications/torghut/strategy-configmap.yaml'),
    Path('/Users/gregkonush/.codex/worktrees/4b2e/lab/services/torghut/config/simulation/smoke-open-30m-2026-03-06.yaml'),
    Path('/Users/gregkonush/.codex/worktrees/4b2e/lab/services/torghut/config/simulation/smoke-open-hour-2026-03-06.yaml'),
]
for path in paths:
    with path.open('r', encoding='utf-8') as handle:
        yaml.safe_load(handle)
    print(f'OK {path}')
PY`

## Breaking Changes

The bundled 30-minute and 1-hour smoke manifests no longer run the legacy MACD/RSI strategy; they now exercise `intraday_tsmom_v1` by default.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
