### PR TITLE
fix(torghut): address PR 4365 review feedback

### DIFF
--- a/services/torghut/app/trading/execution_adapters.py
+++ b/services/torghut/app/trading/execution_adapters.py
@@ -148,6 +148,7 @@ class SimulationExecutionAdapter:
         self._orders_by_id: dict[str, dict[str, Any]] = {}
         self._order_id_by_client_id: dict[str, str] = {}
         self._positions_by_symbol: dict[str, Decimal] = {}
+        self._position_market_value_by_symbol: dict[str, Decimal] = {}
         self._seeded_from_snapshot = False
         self._producer: Any | None = None
         self._producer_init_error: str | None = None
@@ -169,6 +170,7 @@ class SimulationExecutionAdapter:
         if self._seeded_from_snapshot:
             return
         seeded_positions: dict[str, Decimal] = {}
+        seeded_market_values: dict[str, Decimal] = {}
         for raw_position in positions or []:
             symbol = str(raw_position.get('symbol') or '').strip().upper()
             if not symbol:
@@ -187,9 +189,14 @@ class SimulationExecutionAdapter:
             net_qty = seeded_positions.get(symbol, Decimal('0')) + signed_qty
             if net_qty == 0:
                 seeded_positions.pop(symbol, None)
+                seeded_market_values.pop(symbol, None)
                 continue
             seeded_positions[symbol] = net_qty
+            signed_market_value = _signed_position_market_value(raw_position, side=side)
+            if signed_market_value is not None:
+                seeded_market_values[symbol] = seeded_market_values.get(symbol, Decimal('0')) + signed_market_value
         self._positions_by_symbol = seeded_positions
+        self._position_market_value_by_symbol = seeded_market_values
         self._seeded_from_snapshot = True
 
     def submit_order(
@@ -322,14 +329,16 @@ class SimulationExecutionAdapter:
             if net_qty == 0:
                 continue
             side = 'long' if net_qty > 0 else 'short'
-            positions.append(
-                {
-                    'symbol': symbol,
-                    'qty': _decimal_to_order_text(abs(net_qty)),
-                    'side': side,
-                    'alpaca_account_label': self._account_label,
-                }
-            )
+            position = {
+                'symbol': symbol,
+                'qty': _decimal_to_order_text(abs(net_qty)),
+                'side': side,
+                'alpaca_account_label': self._account_label,
+            }
+            market_value = self._position_market_value_by_symbol.get(symbol)
+            if market_value is not None:
+                position['market_value'] = _signed_decimal_to_text(market_value)
+            positions.append(position)
         return positions
 
     def _apply_fill_to_positions(self, order: Mapping[str, Any]) -> None:
@@ -345,11 +354,27 @@ class SimulationExecutionAdapter:
             return
         side = str(order.get('side') or '').strip().lower()
         delta = qty if side == 'buy' else -qty
-        updated = self._positions_by_symbol.get(symbol, Decimal('0')) + delta
+        current_qty = self._positions_by_symbol.get(symbol, Decimal('0'))
+        updated = current_qty + delta
         if updated == 0:
             self._positions_by_symbol.pop(symbol, None)
+            self._position_market_value_by_symbol.pop(symbol, None)
             return
         self._positions_by_symbol[symbol] = updated
+
+        fill_price = _optional_decimal(order.get('filled_avg_price'))
+        if fill_price is None:
+            return
+        market_value_delta = delta * fill_price
+        current_market_value = self._position_market_value_by_symbol.get(symbol)
+        if current_market_value is not None:
+            self._position_market_value_by_symbol[symbol] = current_market_value + market_value_delta
+            return
+        if current_qty == 0:
+            self._position_market_value_by_symbol[symbol] = market_value_delta
+            return
+        if current_qty > 0 > updated or current_qty < 0 < updated:
+            self._position_market_value_by_symbol[symbol] = updated * fill_price
 
     def _build_producer(self, bootstrap_servers: str) -> Any | None:
         try:
@@ -1084,6 +1109,36 @@ def _decimal_to_order_text(value: Decimal) -> str:
     if not rendered:
         return '0'
     return rendered
+
+
+def _signed_decimal_to_text(value: Decimal) -> str:
+    rendered = format(value, 'f')
+    if '.' in rendered:
+        rendered = rendered.rstrip('0').rstrip('.')
+    if rendered in {'', '-0'}:
+        return '0'
+    return rendered
+
+
+def _optional_decimal(value: Any) -> Decimal | None:
+    if value is None:
+        return None
+    try:
+        return Decimal(str(value))
+    except Exception:
+        return None
+
+
+def _signed_position_market_value(position: Mapping[str, Any], *, side: str) -> Decimal | None:
+    market_value = _optional_decimal(position.get('market_value'))
+    if market_value is None:
+        return None
+    normalized_side = side.strip().lower()
+    if normalized_side == 'short':
+        return -abs(market_value)
+    if normalized_side == 'long':
+        return abs(market_value)
+    return market_value
 
 
 def _resolve_simulation_context_payload(

--- a/services/torghut/scripts/historical_simulation_verification.py
+++ b/services/torghut/scripts/historical_simulation_verification.py
@@ -66,6 +66,7 @@ DEFAULT_RUN_MONITOR_MIN_EXECUTIONS = 1
 DEFAULT_RUN_MONITOR_MIN_TCA = 1
 DEFAULT_RUN_MONITOR_MIN_ORDER_EVENTS = 0
 DEFAULT_RUN_MONITOR_CURSOR_GRACE_SECONDS = 120
+DEFAULT_HTTP_PROBE_TIMEOUT_SECONDS = 5
 TRANSIENT_POSTGRES_ERROR_PATTERNS = (
     'connection refused',
     'connection reset by peer',
@@ -820,12 +821,17 @@ def _expected_schema_subjects(
     return sorted(set(subjects))
 
 
-def _http_json_get(base_url: str, path: str) -> tuple[int, str]:
+def _http_json_get(
+    base_url: str,
+    path: str,
+    *,
+    timeout_seconds: int = DEFAULT_HTTP_PROBE_TIMEOUT_SECONDS,
+) -> tuple[int, str]:
     parsed = urlsplit(base_url)
     if not parsed.scheme or not parsed.hostname:
         raise RuntimeError(f'invalid_http_url:{base_url}')
     connection_class = HTTPSConnection if parsed.scheme == 'https' else HTTPConnection
-    connection = connection_class(parsed.hostname, parsed.port)
+    connection = connection_class(parsed.hostname, parsed.port, timeout=timeout_seconds)
     target_path = parsed.path or '/'
     if path and path != '/':
         target_path = f'{target_path.rstrip("/")}/{path.lstrip("/")}'

--- a/services/torghut/tests/test_execution_adapters.py
+++ b/services/torghut/tests/test_execution_adapters.py
@@ -184,6 +184,7 @@ class TestExecutionAdapters(TestCase):
             qty=1.5,
             order_type='market',
             time_in_force='day',
+            limit_price=10.0,
             extra_params={'client_order_id': 'decision-long'},
         )
         positions = adapter.list_positions()
@@ -194,6 +195,7 @@ class TestExecutionAdapters(TestCase):
                     'symbol': 'AAPL',
                     'qty': '1.5',
                     'side': 'long',
+                    'market_value': '15',
                     'alpaca_account_label': 'paper',
                 }
             ],
@@ -204,6 +206,7 @@ class TestExecutionAdapters(TestCase):
             qty=2.0,
             order_type='market',
             time_in_force='day',
+            limit_price=10.0,
             extra_params={'client_order_id': 'decision-short'},
         )
         positions = adapter.list_positions()
@@ -214,6 +217,7 @@ class TestExecutionAdapters(TestCase):
                     'symbol': 'AAPL',
                     'qty': '0.5',
                     'side': 'short',
+                    'market_value': '-5',
                     'alpaca_account_label': 'paper',
                 }
             ],
@@ -233,8 +237,8 @@ class TestExecutionAdapters(TestCase):
         )
         adapter.seed_positions_snapshot(
             [
-                {'symbol': 'AAPL', 'qty': '2.5', 'side': 'long'},
-                {'symbol': 'MSFT', 'qty': '1', 'side': 'short'},
+                {'symbol': 'AAPL', 'qty': '2.5', 'side': 'long', 'market_value': '250'},
+                {'symbol': 'MSFT', 'qty': '1', 'side': 'short', 'market_value': '10'},
             ]
         )
         adapter.seed_positions_snapshot(
@@ -249,6 +253,7 @@ class TestExecutionAdapters(TestCase):
             qty=0.5,
             order_type='market',
             time_in_force='day',
+            limit_price=100.0,
             extra_params={'client_order_id': 'decision-seeded-sell'},
         )
 
@@ -259,12 +264,14 @@ class TestExecutionAdapters(TestCase):
                     'symbol': 'AAPL',
                     'qty': '2',
                     'side': 'long',
+                    'market_value': '200',
                     'alpaca_account_label': 'paper',
                 },
                 {
                     'symbol': 'MSFT',
                     'qty': '1',
                     'side': 'short',
+                    'market_value': '-10',
                     'alpaca_account_label': 'paper',
                 },
             ],
@@ -288,6 +295,7 @@ class TestExecutionAdapters(TestCase):
             qty=10.0,
             order_type='market',
             time_in_force='day',
+            limit_price=100.0,
             extra_params={'client_order_id': 'decision-integer'},
         )
         self.assertEqual(
@@ -297,6 +305,88 @@ class TestExecutionAdapters(TestCase):
                     'symbol': 'AAPL',
                     'qty': '10',
                     'side': 'long',
+                    'market_value': '1000',
+                    'alpaca_account_label': 'paper',
+                }
+            ],
+        )
+
+    def test_simulation_adapter_does_not_emit_partial_market_value_for_untracked_seed(self) -> None:
+        adapter = SimulationExecutionAdapter(
+            bootstrap_servers=None,
+            security_protocol=None,
+            sasl_mechanism=None,
+            sasl_username=None,
+            sasl_password=None,
+            topic='torghut.sim.trade-updates.v1',
+            account_label='paper',
+            simulation_run_id='sim-2026-02-27-01',
+            dataset_id='dataset-1',
+        )
+        adapter.seed_positions_snapshot(
+            [
+                {'symbol': 'AAPL', 'qty': '2', 'side': 'long'},
+            ]
+        )
+
+        adapter.submit_order(
+            symbol='AAPL',
+            side='sell',
+            qty=0.5,
+            order_type='market',
+            time_in_force='day',
+            limit_price=100.0,
+            extra_params={'client_order_id': 'decision-seeded-reduce'},
+        )
+
+        self.assertEqual(
+            adapter.list_positions(),
+            [
+                {
+                    'symbol': 'AAPL',
+                    'qty': '1.5',
+                    'side': 'long',
+                    'alpaca_account_label': 'paper',
+                }
+            ],
+        )
+
+    def test_simulation_adapter_tracks_cross_zero_market_value_after_untracked_seed(self) -> None:
+        adapter = SimulationExecutionAdapter(
+            bootstrap_servers=None,
+            security_protocol=None,
+            sasl_mechanism=None,
+            sasl_username=None,
+            sasl_password=None,
+            topic='torghut.sim.trade-updates.v1',
+            account_label='paper',
+            simulation_run_id='sim-2026-02-27-01',
+            dataset_id='dataset-1',
+        )
+        adapter.seed_positions_snapshot(
+            [
+                {'symbol': 'AAPL', 'qty': '2', 'side': 'long'},
+            ]
+        )
+
+        adapter.submit_order(
+            symbol='AAPL',
+            side='sell',
+            qty=3.0,
+            order_type='market',
+            time_in_force='day',
+            limit_price=100.0,
+            extra_params={'client_order_id': 'decision-seeded-cross-zero'},
+        )
+
+        self.assertEqual(
+            adapter.list_positions(),
+            [
+                {
+                    'symbol': 'AAPL',
+                    'qty': '1',
+                    'side': 'short',
+                    'market_value': '-100',
                     'alpaca_account_label': 'paper',
                 }
             ],

--- a/services/torghut/tests/test_start_historical_simulation.py
+++ b/services/torghut/tests/test_start_historical_simulation.py
@@ -103,6 +103,55 @@ class TestStartHistoricalSimulation(TestCase):
             'torghut-sim-runtime-ready-sim-2026-03-06-open-hour',
         )
 
+    def test_schema_registry_http_json_get_sets_connection_timeout(self) -> None:
+        captured: dict[str, object] = {}
+
+        class _FakeResponse:
+            status = 200
+
+            def read(self) -> bytes:
+                return b'{}'
+
+        class _FakeConnection:
+            def __init__(
+                self,
+                host: str,
+                port: int | None,
+                *,
+                timeout: int | float | None = None,
+            ) -> None:
+                captured['host'] = host
+                captured['port'] = port
+                captured['timeout'] = timeout
+
+            def request(self, method: str, path: str) -> None:
+                captured['method'] = method
+                captured['path'] = path
+
+            def getresponse(self) -> _FakeResponse:
+                return _FakeResponse()
+
+            def close(self) -> None:
+                captured['closed'] = True
+
+        with patch('scripts.historical_simulation_verification.HTTPConnection', _FakeConnection):
+            status, body = historical_simulation_verification._http_json_get(
+                'http://schema-registry:8081',
+                '/subjects',
+            )
+
+        self.assertEqual(status, 200)
+        self.assertEqual(body, '{}')
+        self.assertEqual(captured.get('host'), 'schema-registry')
+        self.assertEqual(captured.get('port'), 8081)
+        self.assertEqual(
+            captured.get('timeout'),
+            historical_simulation_verification.DEFAULT_HTTP_PROBE_TIMEOUT_SECONDS,
+        )
+        self.assertEqual(captured.get('method'), 'GET')
+        self.assertEqual(captured.get('path'), '/subjects')
+        self.assertTrue(captured.get('closed'))
+
     def test_build_resources_derives_isolation_names(self) -> None:
         resources = _build_resources(
             'sim-2026-02-27-01',


### PR DESCRIPTION
## Summary

- preserve signed `market_value` in Torghut simulation positions when seeding broker inventory and applying synthetic fills so exposure-based safeguards stay accurate
- add regression coverage for seeded simulation inventory, untracked-value reductions, and cross-zero residual positions in the simulation adapter
- add an explicit timeout to schema-registry readiness HTTP probes and cover the timeout wiring with a focused test

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_execution_adapters.py tests/test_start_historical_simulation.py tests/test_trading_pipeline.py -k 'test_simulation_adapter or test_schema_registry_http_json_get_sets_connection_timeout or test_pipeline_llm_dspy_runtime_reduced_sell_uses_seeded_simulation_inventory'`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
