### PR TITLE
chore(jangar): promote image e3eaf1f2

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: f86f0d46
-  digest: sha256:5c48c4dc7d037ae19f6910fd0d3bdc868a5d7b2d4ceb17b9241790e1f8b41ef9
+  tag: e3eaf1f2
+  digest: sha256:e5c3ebc8adf63d79f4f34762800ae8bbe41a44e9fa887bccc27c514379ceb0b5
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: f86f0d46
-    digest: sha256:55e59b96617a600bbbe97f1cd1ac2a32d0def40a7bcb414df3a1edec5f0e6717
+    tag: e3eaf1f2
+    digest: sha256:b38df8eaefa7dad47cdaf342dfc9ec1122546796b4d73c731be9b91ee566a9ca
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: f86f0d46
-    digest: sha256:5c48c4dc7d037ae19f6910fd0d3bdc868a5d7b2d4ceb17b9241790e1f8b41ef9
+    tag: e3eaf1f2
+    digest: sha256:e5c3ebc8adf63d79f4f34762800ae8bbe41a44e9fa887bccc27c514379ceb0b5
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-12T08:12:10Z"
+    deploy.knative.dev/rollout: "2026-03-13T07:56:35Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-12T08:12:10Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-13T07:56:35Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -62,5 +62,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "f86f0d46"
-    digest: sha256:5c48c4dc7d037ae19f6910fd0d3bdc868a5d7b2d4ceb17b9241790e1f8b41ef9
+    newTag: "e3eaf1f2"
+    digest: sha256:e5c3ebc8adf63d79f4f34762800ae8bbe41a44e9fa887bccc27c514379ceb0b5


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `e3eaf1f2f23353013a51c7f110e1617370a13c9b`
- Image tag: `e3eaf1f2`
- Image digest: `sha256:e5c3ebc8adf63d79f4f34762800ae8bbe41a44e9fa887bccc27c514379ceb0b5`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`