### PR TITLE
fix(ci): use Temporal FQDN for SDK ARC workflow

### DIFF
--- a/.github/workflows/temporal-bun-sdk.yml
+++ b/.github/workflows/temporal-bun-sdk.yml
@@ -45,7 +45,7 @@ jobs:
       TEMPORAL_TEST_SERVER: '1'
       TEMPORAL_TEST_TIMEOUT: '5000'
       TEMPORAL_INTEGRATION_TESTS: '1'
-      TEMPORAL_ADDRESS: temporal-grpc:7233
+      TEMPORAL_ADDRESS: temporal-grpc.ide-newton.ts.net:7233
       TEMPORAL_NAMESPACE: default
       TEMPORAL_ENFORCE_REMOTE_ADDRESS: '1'
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/temporal-bun-sdk/docs/temporal-ci-cluster-requirement.md
+++ b/packages/temporal-bun-sdk/docs/temporal-ci-cluster-requirement.md
@@ -17,7 +17,8 @@ They must **not** be switched to a local `start-dev` Temporal server in CI.
 
 ## Required CI behavior
 
-- Keep CI pointed at the ArgoCD Temporal endpoint (`TEMPORAL_ADDRESS=temporal-grpc:7233` in current workflow).
+- Keep CI pointed at the ArgoCD Temporal endpoint (`TEMPORAL_ADDRESS=temporal-grpc.ide-newton.ts.net:7233`
+  in the current workflow). ARC runners do not reliably resolve the short `temporal-grpc` MagicDNS alias.
 - Keep `TEMPORAL_TEST_SERVER=1` in CI for SDK test jobs.
 - Keep `TEMPORAL_ENFORCE_REMOTE_ADDRESS=1` in CI so localhost targets fail fast.
 - If readiness is slow, improve readiness retries/diagnostics, but do not redirect CI to local Temporal.


### PR DESCRIPTION
## Summary

- switch the Temporal Bun SDK CI workflow from `temporal-grpc:7233` to `temporal-grpc.ide-newton.ts.net:7233`
- document that ARC runners do not reliably resolve the short `temporal-grpc` MagicDNS alias
- preserve the existing remote Temporal-cluster gate while using the resolvable Tailscale FQDN

## Related Issues

None

## Testing

- `gh run view 23041759292 -R proompteng/lab --log-failed`
- `kubectl exec -n arc arc-arm64-d99gv-runner-mj49p -c runner -- bash -lc 'timeout 5 bash -lc "</dev/tcp/temporal-grpc/7233" >/dev/null 2>&1 && echo short-tcp-ok || echo short-tcp-fail; timeout 5 bash -lc "</dev/tcp/temporal-grpc.ide-newton.ts.net/7233" >/dev/null 2>&1 && echo fqdn-tcp-ok || echo fqdn-tcp-fail'`
- `kubectl exec -n arc arc-arm64-d99gv-runner-mj49p -c runner -- bash -lc 'python3 - <<"PY"
import socket
for host in ["temporal-grpc", "temporal-grpc.ide-newton.ts.net"]:
    try:
        infos = socket.getaddrinfo(host, 7233, type=socket.SOCK_STREAM)
        print(host, "dns-ok", sorted({info[4][0] for info in infos}))
    except Exception as exc:
        print(host, "dns-error", repr(exc))
PY'`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
