### PR TITLE
chore(jangar): promote image 96e32fe7

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: e3eaf1f2
-  digest: sha256:e5c3ebc8adf63d79f4f34762800ae8bbe41a44e9fa887bccc27c514379ceb0b5
+  tag: 96e32fe7
+  digest: sha256:a19754d244a35e1b52e54ffe317263598d980f8fc151b2360070f9ce722b5943
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: e3eaf1f2
-    digest: sha256:b38df8eaefa7dad47cdaf342dfc9ec1122546796b4d73c731be9b91ee566a9ca
+    tag: 96e32fe7
+    digest: sha256:038dd608bcc43f74df69c70c66115f009e3be0b8e984e9203ecff7c788db0aef
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: e3eaf1f2
-    digest: sha256:e5c3ebc8adf63d79f4f34762800ae8bbe41a44e9fa887bccc27c514379ceb0b5
+    tag: 96e32fe7
+    digest: sha256:a19754d244a35e1b52e54ffe317263598d980f8fc151b2360070f9ce722b5943
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-13T07:56:35Z"
+    deploy.knative.dev/rollout: "2026-03-13T08:49:25Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-13T07:56:35Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-13T08:49:25Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -62,5 +62,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "e3eaf1f2"
-    digest: sha256:e5c3ebc8adf63d79f4f34762800ae8bbe41a44e9fa887bccc27c514379ceb0b5
+    newTag: "96e32fe7"
+    digest: sha256:a19754d244a35e1b52e54ffe317263598d980f8fc151b2360070f9ce722b5943


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `96e32fe7792fea70141b2b4184668e29f9176ef7`
- Image tag: `96e32fe7`
- Image digest: `sha256:a19754d244a35e1b52e54ffe317263598d980f8fc151b2360070f9ce722b5943`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`