### PR TITLE
fix(jangar): submit torghut workflows to argo-workflows

### DIFF
--- a/services/jangar/src/server/__tests__/torghut-simulation-control-plane-submit.test.ts
+++ b/services/jangar/src/server/__tests__/torghut-simulation-control-plane-submit.test.ts
@@ -308,10 +308,18 @@ describe('submitTorghutSimulationRun', () => {
 
     expect(result.idempotent).toBe(false)
     expect(result.run.runId).toBe('sim-fk-proof')
+    expect(result.run.namespace).toBe('argo-workflows')
     expect(state.operationLog.indexOf('insert-run')).toBeLessThan(state.operationLog.indexOf('reserve-lane'))
     expect(state.lanes.get('sim-fast-1')?.run_id).toBe('sim-fk-proof')
     expect(state.runs.get('sim-fk-proof')?.lane_id).toBe('sim-fast-1')
+    expect(state.runs.get('sim-fk-proof')?.namespace).toBe('argo-workflows')
     expect(state.runs.get('sim-fk-proof')?.workflow_name).toBe('workflow-demo')
+    expect((state.runs.get('sim-fk-proof')?.metadata as Record<string, unknown>)?.workflowNamespace).toBe(
+      'argo-workflows',
+    )
     expect(kubeMocks.apply).toHaveBeenCalledOnce()
+    expect((kubeMocks.apply.mock.calls[0]?.[0] as Record<string, unknown>)?.metadata).toMatchObject({
+      namespace: 'argo-workflows',
+    })
   })
 })

--- a/services/jangar/src/server/torghut-simulation-control-plane.ts
+++ b/services/jangar/src/server/torghut-simulation-control-plane.ts
@@ -105,7 +105,8 @@ export type TorghutSimulationPreset = {
   manifest: JsonRecord
 }
 
-const DEFAULT_NAMESPACE = 'torghut'
+const DEFAULT_TORGHUT_NAMESPACE = 'torghut'
+const DEFAULT_WORKFLOW_NAMESPACE = 'argo-workflows'
 const DEFAULT_OUTPUT_ROOT = 'artifacts/torghut/simulations'
 const DEFAULT_PRIORITY = 'interactive'
 const DEFAULT_PROFILE = 'smoke'
@@ -231,7 +232,12 @@ const resolveSimulationServiceName = (manifest: JsonRecord) => {
 
 const resolveSimulationNamespace = (manifest: JsonRecord) => {
   const runtime = asRecord(manifest.runtime)
-  return asString(runtime.namespace) ?? DEFAULT_NAMESPACE
+  return asString(runtime.namespace) ?? DEFAULT_TORGHUT_NAMESPACE
+}
+
+const resolveSimulationWorkflowNamespace = (manifest: JsonRecord) => {
+  const runtime = asRecord(manifest.runtime)
+  return asString(runtime.workflow_namespace) ?? DEFAULT_WORKFLOW_NAMESPACE
 }
 
 const buildSimulationCacheKey = (manifest: JsonRecord, profile: string) =>
@@ -711,6 +717,7 @@ const ensureDb = async () => {
 const buildWorkflowManifest = (params: {
   runId: string
   manifest: JsonRecord
+  workflowNamespace: string
   forceReplay: boolean
   forceDump: boolean
   allowMissingState: boolean
@@ -720,7 +727,7 @@ const buildWorkflowManifest = (params: {
   kind: 'Workflow',
   metadata: {
     generateName: 'torghut-historical-simulation-',
-    namespace: DEFAULT_NAMESPACE,
+    namespace: params.workflowNamespace,
     labels: {
       'jangar.proompteng.ai/control-plane': 'torghut-simulation',
       'jangar.proompteng.ai/run-id': params.runId,
@@ -924,7 +931,7 @@ export const submitTorghutSimulationRun = async (request: TorghutSimulationRunRe
       idempotency_key: idempotencyKey,
       workflow_name: null,
       workflow_uid: null,
-      namespace: DEFAULT_NAMESPACE,
+      namespace: resolveSimulationWorkflowNamespace(manifest),
       status: 'submitting',
       workflow_phase: null,
       lane,
@@ -946,6 +953,7 @@ export const submitTorghutSimulationRun = async (request: TorghutSimulationRunRe
         ...request.metadata,
         torghutService: resolveSimulationServiceName(manifest),
         torghutNamespace: resolveSimulationNamespace(manifest),
+        workflowNamespace: resolveSimulationWorkflowNamespace(manifest),
       },
       progress: {
         phase: 'submitting',
@@ -981,6 +989,7 @@ export const submitTorghutSimulationRun = async (request: TorghutSimulationRunRe
         },
         torghutService: resolveSimulationServiceName(manifest),
         torghutNamespace: resolveSimulationNamespace(manifest),
+        workflowNamespace: resolveSimulationWorkflowNamespace(manifest),
       },
       progress: {
         phase: 'lane_reserved',
@@ -993,6 +1002,7 @@ export const submitTorghutSimulationRun = async (request: TorghutSimulationRunRe
   const workflowManifest = buildWorkflowManifest({
     runId,
     manifest,
+    workflowNamespace: resolveSimulationWorkflowNamespace(manifest),
     forceReplay: request.forceReplay ?? false,
     forceDump: request.forceDump ?? false,
     allowMissingState: request.allowMissingState ?? false,
@@ -1027,6 +1037,7 @@ export const submitTorghutSimulationRun = async (request: TorghutSimulationRunRe
         },
         torghutService: resolveSimulationServiceName(manifest),
         torghutNamespace: resolveSimulationNamespace(manifest),
+        workflowNamespace: resolveSimulationWorkflowNamespace(manifest),
         workflowResource: created,
       },
       progress: {


### PR DESCRIPTION
## Summary

- fix Jangar Torghut simulation workflow submission to create the Argo `Workflow` in `argo-workflows`, which is where the live `torghut-historical-simulation` `WorkflowTemplate` actually exists
- preserve the separate Torghut runtime namespace contract in metadata so the control plane still points progress collection at the live `torghut` service namespace
- extend the submission regression test to prove the stored run namespace and submitted workflow manifest both target `argo-workflows`

## Related Issues

None

## Testing

- `cd services/jangar && bunx vitest run --config vitest.config.ts src/server/__tests__/torghut-simulation-control-plane-submit.test.ts src/server/__tests__/torghut-simulation-control-plane.test.ts src/routes/api/torghut/simulation/simulation-routes.test.ts`
- `cd services/jangar && bun run tsc`
- `cd services/jangar && bun run build`
- Live cluster repro before fix: `POST /api/torghut/simulation/runs` accepted, but the created workflow failed immediately with `workflowtemplates.argoproj.io "torghut-historical-simulation" not found` because the workflow was submitted to namespace `torghut`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
