### PR TITLE
fix(temporal-bun-sdk): isolate sticky integration task queues

### DIFF
--- a/packages/temporal-bun-sdk/tests/integration/activity-lifecycle.integration.test.ts
+++ b/packages/temporal-bun-sdk/tests/integration/activity-lifecycle.integration.test.ts
@@ -19,11 +19,12 @@ const shouldRunIntegration = process.env.TEMPORAL_INTEGRATION_TESTS === '1'
 const describeIntegration = shouldRunIntegration ? describe : describe.skip
 const scenarioTimeoutMs = 60_000
 const hookTimeoutMs = 60_000
+const defaultTaskQueue = `temporal-bun-integration-lifecycle-${crypto.randomUUID()}`
 
 const CLI_CONFIG = {
   address: process.env.TEMPORAL_ADDRESS ?? '127.0.0.1:7233',
   namespace: process.env.TEMPORAL_NAMESPACE ?? 'default',
-  taskQueue: process.env.TEMPORAL_TASK_QUEUE ?? 'temporal-bun-integration',
+  taskQueue: process.env.TEMPORAL_TASK_QUEUE ?? defaultTaskQueue,
 }
 
 describeIntegration('Activity lifecycle integration', () => {

--- a/packages/temporal-bun-sdk/tests/integration/client-resilience.integration.test.ts
+++ b/packages/temporal-bun-sdk/tests/integration/client-resilience.integration.test.ts
@@ -19,11 +19,12 @@ import { integrationActivities, integrationWorkflows } from './workflows'
 const shouldRunIntegration = process.env.TEMPORAL_INTEGRATION_TESTS === '1'
 const describeIntegration = shouldRunIntegration ? describe : describe.skip
 const hookTimeoutMs = 60_000
+const defaultTaskQueue = `temporal-bun-integration-resilience-${crypto.randomUUID()}`
 
 const CLI_CONFIG = {
   address: process.env.TEMPORAL_ADDRESS ?? '127.0.0.1:7233',
   namespace: process.env.TEMPORAL_NAMESPACE ?? 'default',
-  taskQueue: process.env.TEMPORAL_TASK_QUEUE ?? 'temporal-bun-integration',
+  taskQueue: process.env.TEMPORAL_TASK_QUEUE ?? defaultTaskQueue,
 }
 
 describeIntegration('Temporal client resilience', () => {

--- a/packages/temporal-bun-sdk/tests/integration/test-env.ts
+++ b/packages/temporal-bun-sdk/tests/integration/test-env.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from 'node:crypto'
+
 import { Effect, Exit } from 'effect'
 
 import { loadTemporalConfig } from '../../src/config'
@@ -30,7 +32,7 @@ export interface IntegrationTestEnv {
 export const CLI_CONFIG = {
   address: process.env.TEMPORAL_ADDRESS ?? '127.0.0.1:7233',
   namespace: process.env.TEMPORAL_NAMESPACE ?? 'default',
-  taskQueue: process.env.TEMPORAL_TASK_QUEUE ?? 'temporal-bun-integration',
+  taskQueue: process.env.TEMPORAL_TASK_QUEUE ?? `temporal-bun-integration-${randomUUID()}`,
 }
 
 const isLoopbackTemporalAddress = (address: string): boolean => {


### PR DESCRIPTION
## Summary

- isolate sticky-enabled Temporal Bun SDK integration suites onto per-process task queues by default
- prevent workflow tasks from being stranded on another test file's sticky queue when Bun runs integration files in parallel
- unblock the release workflow on ARC runners by keeping the heartbeat-timeout lifecycle test on the worker that owns its sticky cache

## Related Issues

None

## Testing

- `bun install --frozen-lockfile`
- `TEMPORAL_TEST_SERVER=1 TEMPORAL_INTEGRATION_TESTS=1 TEMPORAL_ADDRESS=temporal-grpc.ide-newton.ts.net:7233 TEMPORAL_NAMESPACE=default bun run test -- tests/integration/activity-lifecycle.integration.test.ts` (in `packages/temporal-bun-sdk`)
- `TEMPORAL_TEST_SERVER=1 TEMPORAL_INTEGRATION_TESTS=1 TEMPORAL_ADDRESS=temporal-grpc.ide-newton.ts.net:7233 TEMPORAL_NAMESPACE=default bun run test -- tests/integration/workflow-updates.test.ts` (in `packages/temporal-bun-sdk`)

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
