### PR TITLE
fix(arc): add tailscale search suffix to runner pods

### DIFF
--- a/argocd/applications/arc/README.md
+++ b/argocd/applications/arc/README.md
@@ -7,6 +7,7 @@ These runners are not pinned to any specific node by default.
 - Keep the custom template (init container + privileged `docker:dind` sidecar with `DOCKER_HOST=unix:///var/run/docker.sock`) when reapplying so Docker builds continue to work under Kubernetes mode.
 - Runner workspace storage uses dynamic PVCs (20Gi) and must target an existing RWO StorageClass (currently `local-path`).
 - Tailscale connectivity now comes from the node-level installation managed by OpenTofu (`tofu/harvester/main.tf`) and Ansible (`ansible/playbooks/install_tailscale.yml`); no sidecar or additional secret is required in the runner pods.
+- ARC runner and listener pods append the tailnet search suffix `ide-newton.ts.net` via `dnsConfig.searches`, so bare tailnet hosts such as `temporal-grpc` resolve from GitHub Actions jobs without hardcoding the full `*.ts.net` name.
 - Generate the `github-token` SealedSecret with `scripts/generate-arc-github-token-secret.sh`. The script reads the token from 1Password via `${ARC_GITHUB_TOKEN_OP_PATH}` (defaults to `op://infra/github personal token/token`) and writes the sealed manifest to `argocd/applications/arc/github-token.yaml`.
 
 [Taint a node](../../kubernetes/README.md#tainting-a-node) (optional)

--- a/argocd/applications/arc/application.yaml
+++ b/argocd/applications/arc/application.yaml
@@ -37,12 +37,18 @@ spec:
                   storage: 20Gi
           listenerTemplate:
             spec:
+              dnsConfig:
+                searches:
+                  - ide-newton.ts.net
               containers:
                 - name: listener
           template:
             spec:
               nodeSelector:
                 kubernetes.io/arch: arm64
+              dnsConfig:
+                searches:
+                  - ide-newton.ts.net
               securityContext:
                 runAsNonRoot: false
                 # ARC runners need a writable tool cache under /home/runner/_work/_tool.


### PR DESCRIPTION
## Summary

- add the tailnet search suffix to ARC listener and runner pods so short Tailscale names resolve inside GitHub Actions jobs
- keep the fix in GitOps by updating the ARC Argo application instead of hardcoding `*.ts.net` hostnames in workflows
- document the ARC DNS behavior in the runner README

## Related Issues

None

## Testing

- `kubectl exec -n arc arc-arm64-d99gv-runner-69s7l -c runner -- cat /etc/resolv.conf`
- `kubectl exec -n arc arc-arm64-d99gv-runner-69s7l -c runner -- getent hosts temporal-grpc`
- `kubectl exec -n arc arc-arm64-d99gv-runner-69s7l -c runner -- getent hosts temporal-grpc.ide-newton.ts.net`
- `kubectl get autoscalingrunnersets.actions.github.com -n arc -o yaml`
- `bun run lint:argocd`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
