### PR TITLE
fix(headlamp): bind the live oidc admin user

### DIFF
--- a/argocd/applications/headlamp/headlamp-oidc-rbac.yaml
+++ b/argocd/applications/headlamp/headlamp-oidc-rbac.yaml
@@ -12,4 +12,6 @@ roleRef:
   name: cluster-admin
 subjects:
   - kind: User
+    name: oidc:admin
+  - kind: User
     name: oidc:gregkonush

--- a/docs/headlamp-setup.md
+++ b/docs/headlamp-setup.md
@@ -153,7 +153,9 @@ Grant permissions using a ClusterRoleBinding in GitOps.
 Default binding (user-based):
 
 - `argocd/applications/headlamp/headlamp-oidc-rbac.yaml`
-- Binds `User: oidc:gregkonush` to `cluster-admin`.
+- Binds `User: oidc:admin` to `cluster-admin` for the current Keycloak admin login.
+- Keeps `User: oidc:gregkonush` as a second subject so a dedicated user can be added without losing access.
+- Match these subjects to the value emitted in the OIDC `preferred_username` claim. The kube-apiserver in `galactic` uses `--oidc-username-claim=preferred_username` and `--oidc-username-prefix=oidc:`.
 
 If you prefer group-based RBAC, change the subject to:
 

--- a/docs/keycloak-oidc.md
+++ b/docs/keycloak-oidc.md
@@ -73,6 +73,7 @@ Issuer and scopes:
 
 - Issuer: Realm → **Realm settings** → **Endpoints** → **OpenID Endpoint Configuration** (`issuer`)
 - Scopes: `openid profile email`
+- The kube-apiserver on `galactic` binds Kubernetes usernames from the OIDC `preferred_username` claim with the `oidc:` prefix, so RBAC subjects should look like `oidc:<preferred_username>`.
 
 Optional (recommended) group mapper:
 


### PR DESCRIPTION
## Summary

- add `oidc:admin` to the Headlamp OIDC `cluster-admin` ClusterRoleBinding
- keep `oidc:gregkonush` as a second subject so a dedicated user can be added without losing access
- document that Kubernetes RBAC subjects must match the Keycloak `preferred_username` claim with the `oidc:` prefix

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/headlamp | rg -n "headlamp-oidc-admin|oidc:admin|oidc:gregkonush" -n -C 2`
- `kubectl apply -f argocd/applications/headlamp/headlamp-oidc-rbac.yaml`
- `kubectl get clusterrolebinding headlamp-oidc-admin -o yaml`
- `kubectl auth can-i --as=oidc:admin get nodes`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
