### PR TITLE
fix(temporal-bun-sdk): use arc tailscale short host

### DIFF
--- a/packages/temporal-bun-sdk/docs/temporal-ci-cluster-requirement.md
+++ b/packages/temporal-bun-sdk/docs/temporal-ci-cluster-requirement.md
@@ -17,9 +17,10 @@ They must **not** be switched to a local `start-dev` Temporal server in CI.
 
 ## Required CI behavior
 
-- Keep CI pointed at the ArgoCD Temporal endpoint (`TEMPORAL_ADDRESS=temporal-grpc:7233`
-  in the current workflow). ARC runners must preserve the `ide-newton.ts.net` search suffix so the
-  short `temporal-grpc` MagicDNS alias resolves on every job runner.
+- Keep CI pointed at the ArgoCD Temporal endpoint via the short Tailscale hostname
+  (`TEMPORAL_ADDRESS=temporal-grpc:7233` in the current workflow).
+- ARC runners must preserve the tailnet search suffix so `temporal-grpc` resolves to the shared
+  cluster endpoint on every job runner without hardcoding the full `*.ts.net` hostname in workflows.
 - Keep `TEMPORAL_TEST_SERVER=1` in CI for SDK test jobs.
 - Keep `TEMPORAL_ENFORCE_REMOTE_ADDRESS=1` in CI so localhost targets fail fast.
 - If readiness is slow, improve readiness retries/diagnostics, but do not redirect CI to local Temporal.
@@ -30,6 +31,6 @@ When touching Temporal CI or test harness code:
 
 1. Do not replace the cluster target with `127.0.0.1`/local dev server in CI.
 2. Validate failures first as cluster readiness/connectivity before changing execution mode.
-3. Prefer stronger readiness waiting and transient CLI retries over topology changes.
-4. Keep the workflow "Enforce ArgoCD Temporal target" check in place.
-5. Keep the workflow short-host resolution check in place so ARC regressions fail fast.
+3. Prefer stronger readiness waiting, transient CLI retries, and DNS diagnostics over topology changes
+   or swapping back to a fully-qualified fallback.
+4. Keep the workflow checks that enforce a remote endpoint and verify `temporal-grpc` resolves on ARC.


### PR DESCRIPTION
## Summary

- switch Temporal Bun SDK CI back to `temporal-grpc:7233` now that ARC runners resolve the short Tailscale hostname
- add an explicit workflow guard that fails fast if `temporal-grpc` stops resolving on ARC
- update the SDK CI cluster requirement doc to describe the short-host contract instead of the temporary FQDN workaround

## Related Issues

None

## Testing

- `kubectl exec -n arc arc-arm64-2nrjz-runner-7r4fn -c runner -- cat /etc/resolv.conf`
- `kubectl exec -n arc arc-arm64-2nrjz-runner-7r4fn -c runner -- getent hosts temporal-grpc`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
