### PR TITLE
chore(jangar): promote image 479c2840

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 96e32fe7
-  digest: sha256:a19754d244a35e1b52e54ffe317263598d980f8fc151b2360070f9ce722b5943
+  tag: 479c2840
+  digest: sha256:ecd299feaffe127f0f7b4fd4d00d7f978dab8f51ee96f7ab5999f71852c8a703
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 96e32fe7
-    digest: sha256:038dd608bcc43f74df69c70c66115f009e3be0b8e984e9203ecff7c788db0aef
+    tag: 479c2840
+    digest: sha256:a3d7fcb1d204d6fbdc67dee4a759a9c14301351d746aae5464726ad822c03e6d
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 96e32fe7
-    digest: sha256:a19754d244a35e1b52e54ffe317263598d980f8fc151b2360070f9ce722b5943
+    tag: 479c2840
+    digest: sha256:ecd299feaffe127f0f7b4fd4d00d7f978dab8f51ee96f7ab5999f71852c8a703
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-13T08:49:25Z"
+    deploy.knative.dev/rollout: "2026-03-13T09:33:54Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-13T08:49:25Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-13T09:33:54Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -62,5 +62,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "96e32fe7"
-    digest: sha256:a19754d244a35e1b52e54ffe317263598d980f8fc151b2360070f9ce722b5943
+    newTag: "479c2840"
+    digest: sha256:ecd299feaffe127f0f7b4fd4d00d7f978dab8f51ee96f7ab5999f71852c8a703


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `479c28403b93046e7989bd8335da0adaedb89488`
- Image tag: `479c2840`
- Image digest: `sha256:ecd299feaffe127f0f7b4fd4d00d7f978dab8f51ee96f7ab5999f71852c8a703`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`