### PR TITLE
fix(simulation): harden torghut replay determinism

### DIFF
--- a/services/jangar/src/server/__tests__/torghut-simulation-control-plane-submit.test.ts
+++ b/services/jangar/src/server/__tests__/torghut-simulation-control-plane-submit.test.ts
@@ -87,6 +87,11 @@ const buildFakeDb = (currentState: FakeState) => {
       return mode === 'rows' ? rows : rows[0]
     }
 
+    if (table === 'torghut_control_plane.simulation_lane_leases') {
+      const rows = [...currentState.lanes.values()].filter(filterValue)
+      return mode === 'rows' ? rows : rows[0]
+    }
+
     return mode === 'rows' ? [] : undefined
   }
 
@@ -188,9 +193,10 @@ const buildFakeDb = (currentState: FakeState) => {
             'insert or update on table "simulation_lane_leases" violates foreign key constraint "simulation_lane_leases_run_id_fkey"',
           )
         }
-        const lane = currentState.lanes.get('sim-fast-1')
+        const laneId = String(filters.find(([column]) => column === 'lane_id')?.[1] ?? 'sim-fast-1')
+        const lane = currentState.lanes.get(laneId)
         if (!lane || lane.status !== 'available') return { numUpdatedRows: 0 }
-        currentState.lanes.set('sim-fast-1', {
+        currentState.lanes.set(laneId, {
           ...lane,
           ...values,
         })
@@ -210,8 +216,9 @@ const buildFakeDb = (currentState: FakeState) => {
         }
         if (table === 'torghut_control_plane.simulation_lane_leases') {
           const runId = String(filters.find(([column]) => column === 'run_id')?.[1] ?? '')
+          const laneIdFilter = String(filters.find(([column]) => column === 'lane_id')?.[1] ?? '')
           for (const [laneId, lane] of currentState.lanes.entries()) {
-            if (lane.run_id === runId) {
+            if ((runId && lane.run_id === runId) || (laneIdFilter && laneId === laneIdFilter)) {
               currentState.lanes.set(laneId, {
                 ...lane,
                 ...values,
@@ -339,5 +346,38 @@ describe('submitTorghutSimulationRun', () => {
         }),
       }),
     )
+  })
+
+  it('reclaims lanes reserved by terminal runs before reserving a new one', async () => {
+    state.runs.set('sim-finished', {
+      run_id: 'sim-finished',
+      status: 'succeeded',
+    })
+    state.lanes.set('sim-fast-1', {
+      lane_id: 'sim-fast-1',
+      lane_class: 'interactive',
+      status: 'reserved',
+      run_id: 'sim-finished',
+      lease_expires_at: new Date(Date.now() + 5 * 60 * 1000).toISOString(),
+    })
+
+    const result = await submitTorghutSimulationRun({
+      runId: 'sim-reclaim-proof',
+      profile: 'compact',
+      cachePolicy: 'prefer_cache',
+      manifest: {
+        dataset_id: 'dataset-a',
+        candidate_id: 'intraday_tsmom_v1@prod',
+        strategy_spec_ref: 'strategy-specs/intraday_tsmom_v1@1.1.0.json',
+        window: {
+          start: '2026-03-06T14:30:00Z',
+          end: '2026-03-06T14:45:00Z',
+        },
+      },
+    })
+
+    expect(result.run.runId).toBe('sim-reclaim-proof')
+    expect(state.lanes.get('sim-fast-1')?.run_id).toBe('sim-reclaim-proof')
+    expect((state.lanes.get('sim-fast-1')?.metadata as Record<string, unknown>)?.releaseReason).toBeUndefined()
   })
 })

--- a/services/jangar/src/server/__tests__/torghut-simulation-control-plane.test.ts
+++ b/services/jangar/src/server/__tests__/torghut-simulation-control-plane.test.ts
@@ -50,6 +50,7 @@ describe('torghut simulation control plane', () => {
       replayProfile: 'compact',
       dumpFormat: 'jsonl.zst',
     })
+    expect(manifest.ta_restore).toMatchObject({ mode: 'stateless' })
     expect(manifest.cachePolicy).toBe('require_cache')
   })
 

--- a/services/jangar/src/server/torghut-simulation-control-plane.ts
+++ b/services/jangar/src/server/torghut-simulation-control-plane.ts
@@ -217,6 +217,9 @@ const BATCH_LANES = ['sim-batch-1'] as const
 const CONTROL_PLANE_LEASE_OWNER = 'jangar-control-plane'
 const PROGRESS_FETCH_TIMEOUT_MS = 2_500
 
+const defaultTaRestoreMode = (profile: string) =>
+  profile.trim().toLowerCase() === 'full_day' ? 'required' : 'stateless'
+
 const resolveRunClass = (profile: string, priority: string) => {
   const normalizedProfile = profile.trim().toLowerCase()
   const normalizedPriority = priority.trim().toLowerCase()
@@ -267,6 +270,7 @@ const resolveWorkflowOutputRoot = (outputRoot: string) => {
 
 const reserveSimulationLane = async (params: { runId: string; runClass: string; cacheKey: string | null }) => {
   const db = await ensureDb()
+  await reconcileSimulationLaneLeases(db)
   const laneIds = resolveLaneIds(params.runClass)
   const now = new Date()
   const leaseExpiresAt = new Date(now.getTime() + 15 * 60 * 1000)
@@ -518,6 +522,10 @@ const normalizeSimulationManifest = (
   if (!asString(performance.dumpFormat)) performance.dumpFormat = DEFAULT_DUMP_FORMAT
   manifest.performance = performance
 
+  const taRestore = asRecord(manifest.ta_restore)
+  if (!asString(taRestore.mode)) taRestore.mode = defaultTaRestoreMode(String(performance.replayProfile))
+  manifest.ta_restore = taRestore
+
   if (overrides.cachePolicy) {
     manifest.cachePolicy = overrides.cachePolicy
   } else if (!asString(manifest.cachePolicy)) {
@@ -525,6 +533,49 @@ const normalizeSimulationManifest = (
   }
 
   return manifest
+}
+
+const reconcileSimulationLaneLeases = async (db: Awaited<ReturnType<typeof ensureDb>>) => {
+  const now = new Date()
+  const lanes = await db.selectFrom('torghut_control_plane.simulation_lane_leases').selectAll().execute()
+
+  for (const lane of lanes) {
+    const laneRow = lane as Record<string, unknown>
+    const runId = asString(laneRow.run_id)
+    const leaseExpiresAt = asString(laneRow.lease_expires_at)
+    const expired = leaseExpiresAt ? new Date(leaseExpiresAt).getTime() <= now.getTime() : false
+    let terminal = false
+
+    if (runId) {
+      const run = await db
+        .selectFrom('torghut_control_plane.simulation_runs')
+        .selectAll()
+        .where('run_id', '=', runId)
+        .executeTakeFirst()
+      terminal = Boolean(run && TERMINAL_RUN_STATUSES.has(String((run as Record<string, unknown>).status)))
+    }
+
+    if (!expired && !terminal) continue
+
+    await db
+      .updateTable('torghut_control_plane.simulation_lane_leases')
+      .set({
+        status: 'available',
+        run_id: null,
+        cache_key: null,
+        lease_owner: null,
+        lease_expires_at: null,
+        last_heartbeat_at: now,
+        updated_at: now,
+        metadata: {
+          releasedAt: now.toISOString(),
+          releasedBy: CONTROL_PLANE_LEASE_OWNER,
+          releaseReason: terminal ? 'run_terminal' : 'lease_expired',
+        },
+      })
+      .where('lane_id', '=', String(laneRow.lane_id))
+      .execute()
+  }
 }
 
 const buildRobustnessScorecard = (runs: TorghutSimulationRunSnapshot[]) => {
@@ -1109,6 +1160,7 @@ export const getTorghutSimulationRun = async (runId: string) => {
 
 export const listTorghutSimulationRuns = async (limit = 20) => {
   const db = await ensureDb()
+  await reconcileSimulationLaneLeases(db)
   const rows = await db
     .selectFrom('torghut_control_plane.simulation_runs')
     .selectAll()

--- a/services/torghut/config/simulation/full-day-2026-03-06.yaml
+++ b/services/torghut/config/simulation/full-day-2026-03-06.yaml
@@ -9,6 +9,9 @@ runtime_version_refs:
   - services/torghut@simulation
   - services/torghut-forecast@simulation
 
+ta_restore:
+  mode: required
+
 window:
   profile: us_equities_regular
   trading_day: '2026-03-06'

--- a/services/torghut/config/simulation/options-full-day-2026-03-06.yaml
+++ b/services/torghut/config/simulation/options-full-day-2026-03-06.yaml
@@ -39,6 +39,9 @@ proof_gates:
   minimum_underlyings: 3
   require_profitability_artifacts: true
 
+ta_restore:
+  mode: required
+
 window:
   trading_day: '2026-03-06'
   timezone: America/New_York

--- a/services/torghut/config/simulation/options-smoke-open-30m-2026-03-06.yaml
+++ b/services/torghut/config/simulation/options-smoke-open-30m-2026-03-06.yaml
@@ -37,6 +37,9 @@ proof_gates:
   minimum_underlyings: 2
   require_profitability_artifacts: true
 
+ta_restore:
+  mode: stateless
+
 window:
   trading_day: '2026-03-06'
   timezone: America/New_York

--- a/services/torghut/config/simulation/smoke-open-30m-2026-03-06.yaml
+++ b/services/torghut/config/simulation/smoke-open-30m-2026-03-06.yaml
@@ -9,6 +9,9 @@ runtime_version_refs:
   - services/torghut@simulation
   - services/torghut-forecast@simulation
 
+ta_restore:
+  mode: stateless
+
 window:
   trading_day: '2026-03-06'
   timezone: America/New_York

--- a/services/torghut/config/simulation/smoke-open-hour-2026-03-06.yaml
+++ b/services/torghut/config/simulation/smoke-open-hour-2026-03-06.yaml
@@ -9,6 +9,9 @@ runtime_version_refs:
   - services/torghut@simulation
   - services/torghut-forecast@simulation
 
+ta_restore:
+  mode: stateless
+
 window:
   trading_day: '2026-03-06'
   timezone: America/New_York

--- a/services/torghut/scripts/historical_simulation_verification.py
+++ b/services/torghut/scripts/historical_simulation_verification.py
@@ -829,6 +829,19 @@ def _effective_terminal_signal_ts(
     return window_end
 
 
+def _clickhouse_database_from_jdbc_url(raw_url: str | None) -> str | None:
+    text = (raw_url or '').strip()
+    if not text:
+        return None
+    if text.startswith('jdbc:'):
+        text = text[len('jdbc:') :]
+    parsed = urlsplit(text)
+    if not parsed.path:
+        return None
+    database = parsed.path.lstrip('/').split('/', 1)[0]
+    return database or None
+
+
 def _classify_activity_snapshot(
     *,
     runtime_ready: bool,
@@ -977,16 +990,22 @@ def _runtime_verify(*, resources: Any, manifest: Mapping[str, Any]) -> dict[str,
     trading_config_complete = all(trading_config.values())
     ta_config = _kubectl_json(namespace, ['get', 'configmap', ta_configmap, '-o', 'json'])
     ta_data = _as_mapping(ta_config.get('data'))
-    run_token = _as_text(_resource_attr(resources, 'run_token')) or ''
+    expected_clickhouse_database = _as_text(_resource_attr(resources, 'clickhouse_db'))
     ta_runtime_config = {
         f'{role}_topic': _as_text(ta_data.get(key)) == _as_text(expected_topics.get(role))
         for role, key in lane_contract.ta_topic_key_by_role.items()
         if role in expected_topics
     }
-    ta_runtime_config['clickhouse_database'] = bool(run_token) and run_token in (
-        _as_text(ta_data.get(lane_contract.ta_clickhouse_url_key)) or ''
+    ta_runtime_config['clickhouse_database'] = _clickhouse_database_from_jdbc_url(
+        _as_text(ta_data.get(lane_contract.ta_clickhouse_url_key))
+    ) == expected_clickhouse_database
+    ta_runtime_config['expected_clickhouse_database'] = expected_clickhouse_database
+    ta_runtime_config['current_clickhouse_database'] = _clickhouse_database_from_jdbc_url(
+        _as_text(ta_data.get(lane_contract.ta_clickhouse_url_key))
     )
-    ta_runtime_config_complete = all(ta_runtime_config.values())
+    ta_runtime_config_complete = all(
+        value for key, value in ta_runtime_config.items() if key not in {'expected_clickhouse_database', 'current_clickhouse_database'}
+    )
     schema_registry = _schema_registry_health(
         ta_data=ta_data,
         lane_contract=lane_contract,
@@ -1356,7 +1375,7 @@ def _teardown_clean(
     ta_configmap = _as_text(resource_payload.get('ta_configmap'))
     ta_deployment = _as_text(resource_payload.get('ta_deployment'))
     run_id = _as_text(resource_payload.get('run_id')) or ''
-    run_token = _as_text(resource_payload.get('run_token')) or ''
+    simulation_clickhouse_db = _as_text(resource_payload.get('clickhouse_db')) or ''
     clickhouse_signal_table = _as_text(resource_payload.get('clickhouse_signal_table')) or ''
     clickhouse_price_table = _as_text(resource_payload.get('clickhouse_price_table')) or ''
     order_feed_group_id = _as_text(resource_payload.get('order_feed_group_id')) or ''
@@ -1385,7 +1404,10 @@ def _teardown_clean(
         'price_table': _as_text(_as_mapping(env_by_name.get('TRADING_PRICE_TABLE')).get('value')) == clickhouse_price_table,
         'order_feed_group_id': _as_text(_as_mapping(env_by_name.get('TRADING_ORDER_FEED_GROUP_ID')).get('value')) == order_feed_group_id,
         'ta_group_id': _as_text(ta_data.get(lane_contract.ta_group_id_key)) == ta_group_id,
-        'ta_clickhouse_database': bool(run_token) and run_token in (_as_text(ta_data.get(lane_contract.ta_clickhouse_url_key)) or ''),
+        'ta_clickhouse_database': _clickhouse_database_from_jdbc_url(
+            _as_text(ta_data.get(lane_contract.ta_clickhouse_url_key))
+        )
+        == simulation_clickhouse_db,
     }
     restored = not any(simulation_markers_present.values())
     return {

--- a/services/torghut/scripts/start_historical_simulation.py
+++ b/services/torghut/scripts/start_historical_simulation.py
@@ -2187,7 +2187,13 @@ def _artifact_path(resources: SimulationResources, filename: str) -> Path:
 
 def _ta_restore_policy(manifest: Mapping[str, Any]) -> dict[str, Any]:
     ta_restore = _as_mapping(manifest.get('ta_restore'))
-    mode = (_as_text(ta_restore.get('mode')) or 'required').strip().lower()
+    replay_profile = _as_text(_performance_config(manifest).get('replay_profile')) or DEFAULT_SIMULATION_REPLAY_PROFILE
+    explicit_mode = (_as_text(ta_restore.get('mode')) or '').strip().lower()
+    mode = explicit_mode
+    source = 'explicit'
+    if not mode:
+        mode = 'required' if replay_profile == 'full_day' else 'stateless'
+        source = f'profile_default:{replay_profile}'
     allowed_modes = {'required', 'stateless_if_missing', 'stateless'}
     if mode not in allowed_modes:
         raise RuntimeError(
@@ -2195,6 +2201,8 @@ def _ta_restore_policy(manifest: Mapping[str, Any]) -> dict[str, Any]:
         )
     return {
         'mode': mode,
+        'source': source,
+        'replay_profile': replay_profile,
         'stateless_recovery_enabled': mode in {'stateless_if_missing', 'stateless'},
     }
 
@@ -2221,7 +2229,7 @@ def _resolve_ta_restore_configuration(
             'configured': not missing,
             'effective_upgrade_mode': 'stateless',
             'fallback_applied': False,
-            'reason': 'explicit_stateless',
+            'reason': 'profile_default_stateless' if str(policy.get('source', '')).startswith('profile_default:') else 'explicit_stateless',
         }
     if missing:
         missing_reason = f'restore_state_missing:{",".join(sorted(missing))}'

--- a/services/torghut/tests/test_start_historical_simulation.py
+++ b/services/torghut/tests/test_start_historical_simulation.py
@@ -97,6 +97,38 @@ class TestStartHistoricalSimulation(TestCase):
     def test_normalize_run_token(self) -> None:
         self.assertEqual(_normalize_run_token('Sim-2026/02/27#Run-01'), 'sim_2026_02_27_run_01')
 
+    def test_ta_restore_policy_defaults_compact_profiles_to_stateless(self) -> None:
+        policy = start_historical_simulation._ta_restore_policy(
+            {
+                'window': {
+                    'start': '2026-03-06T14:30:00Z',
+                    'end': '2026-03-06T14:45:00Z',
+                },
+                'performance': {
+                    'replayProfile': 'compact',
+                },
+            }
+        )
+
+        self.assertEqual(policy['mode'], 'stateless')
+        self.assertEqual(policy['source'], 'profile_default:compact')
+
+    def test_ta_restore_policy_defaults_full_day_profiles_to_required(self) -> None:
+        policy = start_historical_simulation._ta_restore_policy(
+            {
+                'window': {
+                    'start': '2026-03-06T14:30:00Z',
+                    'end': '2026-03-06T21:00:00Z',
+                },
+                'performance': {
+                    'replayProfile': 'full_day',
+                },
+            }
+        )
+
+        self.assertEqual(policy['mode'], 'required')
+        self.assertEqual(policy['source'], 'profile_default:full_day')
+
     def test_analysis_run_name_uses_dns1123_safe_token(self) -> None:
         self.assertEqual(
             _analysis_run_name(
@@ -794,7 +826,8 @@ class TestStartHistoricalSimulation(TestCase):
         self.assertIn('state_path', report['artifacts'])
         self.assertIn('run_manifest_path', report['artifacts'])
         self.assertIn('dump_path', report['artifacts'])
-        self.assertEqual(report['ta_restore']['mode'], 'required')
+        self.assertEqual(report['ta_restore']['mode'], 'stateless')
+        self.assertEqual(report['ta_restore']['source'], 'profile_default:hourly')
         postgres_dsn = report['resources']['postgres_simulation_dsn']
         assert isinstance(postgres_dsn, str)
         self.assertIn(':***@', postgres_dsn)
@@ -1140,6 +1173,7 @@ class TestStartHistoricalSimulation(TestCase):
         )
         manifest = {
             'dataset_id': 'dataset-a',
+            'ta_restore': {'mode': 'required'},
             'window': {
                 'start': '2026-02-27T14:30:00Z',
                 'end': '2026-02-27T15:30:00Z',
@@ -1176,6 +1210,104 @@ class TestStartHistoricalSimulation(TestCase):
                     )
 
         release_lock.assert_called_once_with(resources=resources)
+
+    def test_apply_defaults_compact_profiles_to_stateless_restore(self) -> None:
+        resources = _build_resources('sim-1', {'dataset_id': 'dataset-a'})
+        kafka_config = KafkaRuntimeConfig(
+            bootstrap_servers='kafka:9092',
+            security_protocol=None,
+            sasl_mechanism=None,
+            sasl_username=None,
+            sasl_password=None,
+        )
+        clickhouse_config = ClickHouseRuntimeConfig(
+            http_url='http://clickhouse:8123',
+            username='torghut',
+            password='secret',
+        )
+        postgres_config = PostgresRuntimeConfig(
+            admin_dsn='postgresql://torghut:secret@localhost:5432/postgres',
+            simulation_dsn='postgresql://torghut:secret@localhost:5432/torghut_sim_sim_1',
+            simulation_db='torghut_sim_sim_1',
+            migrations_command='true',
+        )
+        manifest = {
+            'dataset_id': 'dataset-a',
+            'clickhouse': {'database_precreated': True},
+            'postgres': {'database_precreated': True},
+            'window': {
+                'start': '2026-02-27T14:30:00Z',
+                'end': '2026-02-27T15:00:00Z',
+            },
+            'performance': {
+                'replayProfile': 'compact',
+            },
+        }
+
+        with TemporaryDirectory() as tmpdir:
+            resources = replace(resources, output_root=Path(tmpdir))
+            with (
+                patch('scripts.start_historical_simulation._ensure_supported_binary', return_value=None),
+                patch('scripts.start_historical_simulation._ensure_lz4_codec_available', return_value=None),
+                patch(
+                    'scripts.start_historical_simulation._acquire_simulation_runtime_lock',
+                    return_value={'status': 'acquired', 'run_id': resources.run_id},
+                ),
+                patch(
+                    'scripts.start_historical_simulation._capture_cluster_state',
+                    return_value={
+                        'ta_data': {
+                            'TA_GROUP_ID': 'prod-ta-group',
+                            'TA_CHECKPOINT_DIR': '/checkpoints',
+                            'TA_SAVEPOINT_DIR': '/savepoints',
+                        }
+                    },
+                ),
+                patch('scripts.start_historical_simulation._ensure_topics', return_value={'status': 'ok'}),
+                patch('scripts.start_historical_simulation._ensure_clickhouse_database'),
+                patch('scripts.start_historical_simulation._ensure_clickhouse_runtime_tables', return_value=None),
+                patch('scripts.start_historical_simulation._ensure_postgres_database'),
+                patch(
+                    'scripts.start_historical_simulation._ensure_postgres_runtime_permissions',
+                    return_value={'grants_applied': True},
+                ),
+                patch('scripts.start_historical_simulation._run_migrations', return_value=None),
+                patch('scripts.start_historical_simulation._reset_postgres_runtime_state', return_value=None),
+                patch(
+                    'scripts.start_historical_simulation._dump_topics',
+                    return_value={'records': 1, 'sha256': 'abc'},
+                ),
+                patch(
+                    'scripts.start_historical_simulation._validate_dump_coverage',
+                    return_value={'coverage_ratio': 1.0},
+                ),
+                patch('scripts.start_historical_simulation._configure_ta_for_simulation', return_value=None),
+                patch(
+                    'scripts.start_historical_simulation._restart_ta_deployment',
+                    return_value='nonce',
+                ) as restart_ta,
+                patch(
+                    'scripts.start_historical_simulation._configure_torghut_service_for_simulation',
+                    return_value=None,
+                ),
+            ):
+                report = start_historical_simulation._apply(
+                    resources=resources,
+                    manifest=manifest,
+                    kafka_config=kafka_config,
+                    clickhouse_config=clickhouse_config,
+                    postgres_config=postgres_config,
+                    force_dump=False,
+                    force_replay=False,
+                )
+
+        restart_ta.assert_called_once_with(
+            resources,
+            desired_state='running',
+            upgrade_mode='stateless',
+        )
+        self.assertEqual(report['ta_restore']['effective_upgrade_mode'], 'stateless')
+        self.assertEqual(report['ta_restore']['reason'], 'profile_default_stateless')
 
     def test_apply_falls_back_to_stateless_when_restore_state_config_missing(self) -> None:
         resources = _build_resources('sim-1', {'dataset_id': 'dataset-a'})
@@ -3765,7 +3897,7 @@ class TestStartHistoricalSimulation(TestCase):
                 'TA_BARS1M_TOPIC': 'torghut.sim.bars.1m.v1.sim_2026_03_06_open_hour',
                 'TA_MICROBARS_TOPIC': 'torghut.sim.ta.bars.1s.v1.sim_2026_03_06_open_hour',
                 'TA_SIGNALS_TOPIC': 'torghut.sim.ta.signals.v1.sim_2026_03_06_open_hour',
-                'TA_CLICKHOUSE_URL': 'jdbc:clickhouse://clickhouse/torghut_sim_2026_03_06_open_hour',
+                'TA_CLICKHOUSE_URL': f'jdbc:clickhouse://clickhouse/{resources.clickhouse_db}',
             }
         }
 
@@ -3807,6 +3939,108 @@ class TestStartHistoricalSimulation(TestCase):
         self.assertEqual(report['environment_state'], 'complete')
         self.assertEqual(report['torghut_service']['name'], 'torghut-sim')
         self.assertTrue(all(report['ta_runtime_config'].values()))
+
+    def test_runtime_verify_requires_exact_clickhouse_database_match(self) -> None:
+        manifest = {
+            'window': {
+                'start': '2026-03-06T14:30:00Z',
+                'end': '2026-03-06T15:30:00Z',
+            }
+        }
+        resources = _build_resources(
+            'sim-2026-03-06-open-hour',
+            {
+                'dataset_id': 'dataset-a',
+                'runtime': {
+                    'target_mode': 'dedicated_service',
+                    'namespace': 'torghut',
+                    'ta_configmap': 'torghut-ta-sim-config',
+                    'ta_deployment': 'torghut-ta-sim',
+                    'torghut_service': 'torghut-sim',
+                    'torghut_forecast_service': 'torghut-forecast-sim',
+                },
+            },
+        )
+        wrong_database = f'{resources.clickhouse_db}_stale'
+        kservice_payload = {
+            'spec': {
+                'template': {
+                    'spec': {
+                        'containers': [
+                            {
+                                'name': 'user-container',
+                                'env': [
+                                    {'name': 'TRADING_ENABLED', 'value': 'true'},
+                                    {'name': 'TRADING_SIMULATION_ENABLED', 'value': 'true'},
+                                    {'name': 'TRADING_STRATEGY_RUNTIME_MODE', 'value': 'scheduler_v3'},
+                                    {'name': 'TRADING_STRATEGY_SCHEDULER_ENABLED', 'value': 'true'},
+                                    {'name': 'TRADING_SIGNAL_TABLE', 'value': resources.clickhouse_signal_table},
+                                    {'name': 'TRADING_PRICE_TABLE', 'value': resources.clickhouse_price_table},
+                                    {'name': 'TRADING_ORDER_FEED_ENABLED', 'value': 'true'},
+                                    {'name': 'TRADING_ORDER_FEED_TOPIC', 'value': resources.simulation_topic_by_role['order_updates']},
+                                    {'name': 'TRADING_SIMULATION_ORDER_UPDATES_TOPIC', 'value': resources.simulation_topic_by_role['order_updates']},
+                                    {'name': 'TRADING_SIMULATION_RUN_ID', 'value': resources.run_id},
+                                    {'name': 'TRADING_SIGNAL_ALLOWED_SOURCES', 'value': 'ws,ta'},
+                                ],
+                            }
+                        ]
+                    }
+                }
+            },
+            'status': {
+                'latestReadyRevisionName': 'torghut-sim-00001',
+                'conditions': [{'type': 'Ready', 'status': 'True'}],
+            },
+        }
+        ta_configmap_payload = {
+            'data': {
+                'TA_TRADES_TOPIC': resources.simulation_topic_by_role['trades'],
+                'TA_QUOTES_TOPIC': resources.simulation_topic_by_role['quotes'],
+                'TA_BARS1M_TOPIC': resources.simulation_topic_by_role['bars'],
+                'TA_MICROBARS_TOPIC': resources.simulation_topic_by_role['ta_microbars'],
+                'TA_SIGNALS_TOPIC': resources.simulation_topic_by_role['ta_signals'],
+                'TA_CLICKHOUSE_URL': f'jdbc:clickhouse://clickhouse/{wrong_database}?run={resources.run_token}',
+            }
+        }
+
+        with (
+            patch(
+                'scripts.historical_simulation_verification._kubectl_json',
+                side_effect=[kservice_payload, ta_configmap_payload],
+            ),
+            patch(
+                'scripts.historical_simulation_verification._deployment_replica_health',
+                side_effect=[
+                    {
+                        'name': 'torghut-sim-00001-deployment',
+                        'ready_replicas': 1,
+                        'available_replicas': 1,
+                        'replicas': 1,
+                    },
+                    {
+                        'name': 'torghut-forecast-sim',
+                        'ready_replicas': 1,
+                        'available_replicas': 1,
+                        'replicas': 1,
+                    },
+                ],
+            ),
+            patch(
+                'scripts.historical_simulation_verification._flink_runtime_health',
+                return_value={
+                    'name': 'torghut-ta-sim',
+                    'desired_state': 'running',
+                    'lifecycle_state': 'RUNNING',
+                    'job_manager_status': 'DEPLOYED',
+                },
+            ),
+        ):
+            report = _runtime_verify(resources=resources, manifest=manifest)
+
+        self.assertEqual(report['runtime_state'], 'not_ready')
+        self.assertFalse(report['ta_runtime_config']['clickhouse_database'])
+        self.assertEqual(report['ta_runtime_config']['expected_clickhouse_database'], resources.clickhouse_db)
+        self.assertEqual(report['ta_runtime_config']['current_clickhouse_database'], wrong_database)
 
     def test_runtime_verify_accepts_options_lane_topics_and_tables(self) -> None:
         manifest = {
@@ -4002,7 +4236,7 @@ class TestStartHistoricalSimulation(TestCase):
                 'TA_BARS1M_TOPIC': 'torghut.sim.bars.1m.v1.sim_2026_03_06_open_hour',
                 'TA_MICROBARS_TOPIC': 'torghut.sim.ta.bars.1s.v1.sim_2026_03_06_open_hour',
                 'TA_SIGNALS_TOPIC': 'torghut.sim.ta.signals.v1.sim_2026_03_06_open_hour',
-                'TA_CLICKHOUSE_URL': 'jdbc:clickhouse://clickhouse/torghut_sim_2026_03_06_open_hour',
+                'TA_CLICKHOUSE_URL': f'jdbc:clickhouse://clickhouse/{resources.clickhouse_db}',
             }
         }
 


### PR DESCRIPTION
## Summary

- default compact, smoke, and hourly Torghut simulations to stateless TA restore so clean-baseline replays do not inherit Flink `last-state` contamination
- validate TA ClickHouse routing by exact database match in the shared simulation verifier and make Jangar manifest defaults/lane reservation recovery reflect the same replay contract
- make bundled TSMOM simulation manifests explicit about restore mode and add regression coverage for restore defaults, verifier DB matching, and terminal-lane reclamation

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_start_historical_simulation.py -q`
- `cd services/torghut && uv run --frozen ruff check app tests scripts migrations`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/jangar && bunx vitest run --config vitest.config.ts src/server/__tests__/torghut-simulation-control-plane.test.ts src/server/__tests__/torghut-simulation-control-plane-submit.test.ts`
- `cd services/jangar && bun run tsc`
- `cd services/jangar && bun run build`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
