### PR TITLE
chore(jangar): promote image 2b6a9646

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 479c2840
-  digest: sha256:ecd299feaffe127f0f7b4fd4d00d7f978dab8f51ee96f7ab5999f71852c8a703
+  tag: 2b6a9646
+  digest: sha256:e392f8420958825e589d04a8ca3520348135835c120026c16921c27a1a9c60f8
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 479c2840
-    digest: sha256:a3d7fcb1d204d6fbdc67dee4a759a9c14301351d746aae5464726ad822c03e6d
+    tag: 2b6a9646
+    digest: sha256:40aa0c906dd6ec083309b3d13f113d8fcbeec76db0a69eb1b75e8c4bc4672a74
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 479c2840
-    digest: sha256:ecd299feaffe127f0f7b4fd4d00d7f978dab8f51ee96f7ab5999f71852c8a703
+    tag: 2b6a9646
+    digest: sha256:e392f8420958825e589d04a8ca3520348135835c120026c16921c27a1a9c60f8
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-13T09:33:54Z"
+    deploy.knative.dev/rollout: "2026-03-13T10:00:08Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-13T09:33:54Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-13T10:00:08Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -62,5 +62,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "479c2840"
-    digest: sha256:ecd299feaffe127f0f7b4fd4d00d7f978dab8f51ee96f7ab5999f71852c8a703
+    newTag: "2b6a9646"
+    digest: sha256:e392f8420958825e589d04a8ca3520348135835c120026c16921c27a1a9c60f8


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `2b6a96464679708e10dddcbc8ba491c42e7c8fd7`
- Image tag: `2b6a9646`
- Image digest: `sha256:e392f8420958825e589d04a8ca3520348135835c120026c16921c27a1a9c60f8`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`