### PR TITLE
chore(jangar): promote image dd06facb

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 2b6a9646
-  digest: sha256:e392f8420958825e589d04a8ca3520348135835c120026c16921c27a1a9c60f8
+  tag: dd06facb
+  digest: sha256:71e27de1bbb6d37e855038377a02956b9de95f55c90a1d64eb3bc20297860ce1
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 2b6a9646
-    digest: sha256:40aa0c906dd6ec083309b3d13f113d8fcbeec76db0a69eb1b75e8c4bc4672a74
+    tag: dd06facb
+    digest: sha256:f0edc415e2e46793b6345802ae54df48316b5364b4d4a6d4d7056b153ab2d41c
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 2b6a9646
-    digest: sha256:e392f8420958825e589d04a8ca3520348135835c120026c16921c27a1a9c60f8
+    tag: dd06facb
+    digest: sha256:71e27de1bbb6d37e855038377a02956b9de95f55c90a1d64eb3bc20297860ce1
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-13T10:00:08Z"
+    deploy.knative.dev/rollout: "2026-03-13T11:14:26Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-13T10:00:08Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-13T11:14:26Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -62,5 +62,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "2b6a9646"
-    digest: sha256:e392f8420958825e589d04a8ca3520348135835c120026c16921c27a1a9c60f8
+    newTag: "dd06facb"
+    digest: sha256:71e27de1bbb6d37e855038377a02956b9de95f55c90a1d64eb3bc20297860ce1


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `dd06facbd8a8f61a650d188aebe61b4cd5772251`
- Image tag: `dd06facb`
- Image digest: `sha256:71e27de1bbb6d37e855038377a02956b9de95f55c90a1d64eb3bc20297860ce1`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`