### PR TITLE
fix(simulation): codify workflow postgres admin injection

### DIFF
--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -62,6 +62,11 @@ spec:
             secretKeyRef:
               name: torghut-db-app
               key: password
+        - name: TORGHUT_POSTGRES_ADMIN_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: torghut-db-superuser
+              key: password
       command:
         - /bin/bash
         - -lc
@@ -117,6 +122,42 @@ spec:
           runtime.setdefault("torghut_forecast_service", "torghut-forecast-sim")
           runtime["output_root"] = output_root
           payload["runtime"] = runtime
+
+          def _with_password_if_missing(dsn: str | None, password: str | None) -> str | None:
+            if not dsn or not password:
+              return dsn
+            from urllib.parse import quote_plus, urlsplit
+            parsed = urlsplit(dsn)
+            if parsed.password is not None or parsed.username is None or parsed.hostname is None:
+              return dsn
+            host = parsed.hostname
+            if parsed.port is not None:
+              host = f"{host}:{parsed.port}"
+            return parsed._replace(netloc=f"{quote_plus(parsed.username)}:{quote_plus(password)}@{host}").geturl()
+
+          postgres = payload.get("postgres")
+          if not isinstance(postgres, dict):
+            postgres = {}
+          admin_password_env = postgres.get("admin_dsn_password_env")
+          admin_password = os.environ.get(admin_password_env) if isinstance(admin_password_env, str) else None
+          simulation_password_env = postgres.get("simulation_dsn_password_env")
+          if not isinstance(simulation_password_env, str) or not simulation_password_env:
+            simulation_password_env = "TORGHUT_POSTGRES_PASSWORD"
+          simulation_password = os.environ.get(simulation_password_env)
+          runtime_simulation_password_env = postgres.get("runtime_simulation_dsn_password_env")
+          if not isinstance(runtime_simulation_password_env, str) or not runtime_simulation_password_env:
+            runtime_simulation_password_env = simulation_password_env
+          runtime_simulation_password = os.environ.get(runtime_simulation_password_env)
+          admin_dsn = postgres.get("admin_dsn")
+          if isinstance(admin_dsn, str):
+            postgres["admin_dsn"] = _with_password_if_missing(admin_dsn, admin_password)
+          simulation_dsn = postgres.get("simulation_dsn")
+          if isinstance(simulation_dsn, str):
+            postgres["simulation_dsn"] = _with_password_if_missing(simulation_dsn, simulation_password)
+          runtime_simulation_dsn = postgres.get("runtime_simulation_dsn")
+          if isinstance(runtime_simulation_dsn, str):
+            postgres["runtime_simulation_dsn"] = _with_password_if_missing(runtime_simulation_dsn, runtime_simulation_password)
+          payload["postgres"] = postgres
 
           rollouts = payload.get("rollouts")
           if not isinstance(rollouts, dict):

--- a/packages/scripts/src/torghut/__tests__/update-manifests.test.ts
+++ b/packages/scripts/src/torghut/__tests__/update-manifests.test.ts
@@ -152,6 +152,20 @@ spec:
 }
 
 describe('update-manifests', () => {
+  it('keeps workflow template postgres password injection logic in repo', () => {
+    const historicalWorkflowManifest = readFileSync(
+      join(repoRoot, 'argocd/applications/torghut/historical-simulation-workflowtemplate.yaml'),
+      'utf8',
+    )
+
+    expect(historicalWorkflowManifest).toContain('- name: TORGHUT_POSTGRES_ADMIN_PASSWORD')
+    expect(historicalWorkflowManifest).toContain('name: torghut-db-superuser')
+    expect(historicalWorkflowManifest).toContain('def _with_password_if_missing')
+    expect(historicalWorkflowManifest).toContain('admin_dsn_password_env')
+    expect(historicalWorkflowManifest).toContain('simulation_dsn_password_env')
+    expect(historicalWorkflowManifest).toContain('runtime_simulation_dsn_password_env')
+  })
+
   it('updates service and migration image digest, rollout timestamp, and metadata env values', () => {
     const fixture = createFixture()
     const result = __private.updateTorghutManifests({


### PR DESCRIPTION
## Summary

- codify the historical simulation workflow's Postgres admin password wiring in Git so Argo cannot revert the live cluster hotfix
- inject missing passwords into admin, simulation, and runtime simulation DSNs inside the workflow template before `start_historical_simulation.py` runs
- add a regression test that fails if the workflow template loses the admin-password DSN injection logic again

## Related Issues

None

## Testing

- `cd packages/scripts && bun test src/torghut/__tests__/update-manifests.test.ts`
- `python - <<'PY' ... yaml.safe_load(...) ... PY` against `argocd/applications/torghut/historical-simulation-workflowtemplate.yaml`
- `bunx oxfmt --check packages/scripts/src/torghut/__tests__/update-manifests.test.ts`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
