### PR TITLE
fix(torghut): ship simulation compression tools

### DIFF
--- a/services/torghut/Dockerfile
+++ b/services/torghut/Dockerfile
@@ -45,6 +45,8 @@ RUN apt-get update \
       ca-certificates \
       curl \
       libpq5 \
+      pigz \
+      zstd \
  && PLATFORM="${TARGETPLATFORM:-linux/$(dpkg --print-architecture 2>/dev/null || uname -m)}" \
  && case "${PLATFORM}" in \
       linux/amd64|linux/amd64/*|amd64|x86_64) KUBECTL_ARCH="amd64" ;; \

--- a/services/torghut/tests/test_runtime_container_tools.py
+++ b/services/torghut/tests/test_runtime_container_tools.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_runtime_image_installs_simulation_compression_tools() -> None:
+    dockerfile = Path(__file__).resolve().parent.parent / 'Dockerfile'
+    contents = dockerfile.read_text(encoding='utf-8')
+
+    assert 'pigz' in contents
+    assert 'zstd' in contents


### PR DESCRIPTION
## Summary

- install `pigz` and `zstd` into the Torghut runtime image so historical simulation can execute the advertised compressed replay paths in cluster
- keep the fast replay artifact path honest instead of depending on compression binaries that only exist on a developer workstation
- add a regression test that fails if those runtime compression tools disappear from the Torghut Dockerfile

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_runtime_container_tools.py -q`
- `cd services/torghut && uv run --frozen ruff check tests/test_runtime_container_tools.py`
- cluster proof failure reproduction from Jangar: `simulation_run_failed:[Errno 2] No such file or directory: 'zstd'`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
