### PR TITLE
fix(simulation): harden schema registry runtime probe

### DIFF
--- a/services/torghut/scripts/historical_simulation_verification.py
+++ b/services/torghut/scripts/historical_simulation_verification.py
@@ -148,6 +148,21 @@ def _safe_float(value: Any, *, default: float = 0.0) -> float:
     return default
 
 
+def _cluster_service_host_candidates(host: str) -> list[str]:
+    host = host.strip()
+    if not host:
+        return []
+
+    candidates = [host]
+    host_parts = host.split('.')
+    if len(host_parts) == 2:
+        candidates.append(f'{host}.svc')
+        candidates.append(f'{host}.svc.cluster.local')
+    if host.endswith('.svc') and not host.endswith('.svc.cluster.local'):
+        candidates.append(f'{host}.cluster.local')
+    return candidates
+
+
 def _normalized_string_set(raw: str | None) -> set[str]:
     if raw is None:
         return set()
@@ -1134,16 +1149,24 @@ def _http_json_get(
     if not parsed.scheme or not parsed.hostname:
         raise RuntimeError(f'invalid_http_url:{base_url}')
     connection_class = HTTPSConnection if parsed.scheme == 'https' else HTTPConnection
-    connection = connection_class(parsed.hostname, parsed.port, timeout=timeout_seconds)
     target_path = parsed.path or '/'
     if path and path != '/':
         target_path = f'{target_path.rstrip("/")}/{path.lstrip("/")}'
-    try:
-        connection.request('GET', target_path)
-        response = connection.getresponse()
-        return response.status, response.read().decode('utf-8', errors='replace')
-    finally:
-        connection.close()
+    last_error: OSError | None = None
+    for hostname in _cluster_service_host_candidates(parsed.hostname):
+        connection = connection_class(hostname, parsed.port, timeout=timeout_seconds)
+        try:
+            connection.request('GET', target_path)
+            response = connection.getresponse()
+            return response.status, response.read().decode('utf-8', errors='replace')
+        except OSError as exc:
+            last_error = exc
+            continue
+        finally:
+            connection.close()
+    if last_error is not None:
+        raise last_error
+    raise RuntimeError('http_request_failed_without_attempts')
 
 
 def _analysis_image_freshness(

--- a/services/torghut/tests/test_start_historical_simulation.py
+++ b/services/torghut/tests/test_start_historical_simulation.py
@@ -71,6 +71,51 @@ from scripts.start_historical_simulation import (
 
 
 class TestStartHistoricalSimulation(TestCase):
+    def test_verification_cluster_service_host_candidates_expand_service_namespace_short_form(self) -> None:
+        self.assertEqual(
+            historical_simulation_verification._cluster_service_host_candidates('karapace.kafka'),
+            ['karapace.kafka', 'karapace.kafka.svc', 'karapace.kafka.svc.cluster.local'],
+        )
+
+    def test_verification_http_json_get_retries_cluster_local_service_hostnames(self) -> None:
+        attempted_hosts: list[str] = []
+
+        class _FakeResponse:
+            status = 200
+
+            def read(self) -> bytes:
+                return b'[]'
+
+        class _FakeConnection:
+            def __init__(self, host: str, port: int | None, timeout: int | None = None) -> None:
+                attempted_hosts.append(host)
+                self._host = host
+                self._port = port
+                self._timeout = timeout
+
+            def request(self, method: str, path: str) -> None:
+                if self._host == 'karapace.kafka':
+                    raise OSError('lookup failed')
+
+            def getresponse(self) -> _FakeResponse:
+                return _FakeResponse()
+
+            def close(self) -> None:
+                return None
+
+        with patch(
+            'scripts.historical_simulation_verification.HTTPConnection',
+            _FakeConnection,
+        ):
+            status, body = historical_simulation_verification._http_json_get(
+                'http://karapace.kafka:8081',
+                '/subjects',
+            )
+
+        self.assertEqual(status, 200)
+        self.assertEqual(body, '[]')
+        self.assertEqual(attempted_hosts, ['karapace.kafka', 'karapace.kafka.svc'])
+
     def test_cluster_service_host_candidates_expand_cluster_local_for_partially_qualified_service(self) -> None:
         self.assertEqual(
             start_historical_simulation._cluster_service_host_candidates('karapace.kafka.svc'),


### PR DESCRIPTION
## Summary

- harden the simulation runtime-ready schema registry probe to retry in-cluster service host variants like `service.namespace.svc`
- add a regression test covering the HTTP fallback path used by the runtime verifier
- preserve the existing runtime-ready contract while removing the DNS failure that blocked replay from starting in cluster

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_start_historical_simulation.py -k "verification_http_json_get_retries_cluster_local_service_hostnames or verification_cluster_service_host_candidates_expand_service_namespace_short_form or runtime_verify_rejects_schema_registry_subject_failure" -q`
- `cd services/torghut && uv run --frozen ruff check scripts/historical_simulation_verification.py tests/test_start_historical_simulation.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
