### PR TITLE
fix(simulation): restore runtime-ready clickhouse parity

### DIFF
--- a/services/torghut/scripts/historical_simulation_verification.py
+++ b/services/torghut/scripts/historical_simulation_verification.py
@@ -857,6 +857,17 @@ def _clickhouse_database_from_jdbc_url(raw_url: str | None) -> str | None:
     return database or None
 
 
+def _clickhouse_database_from_table_name(table_name: str | None) -> str | None:
+    text = (table_name or '').strip()
+    if not text:
+        return None
+    database, separator, _table = text.partition('.')
+    if not separator:
+        return None
+    database = database.strip()
+    return database or None
+
+
 def _classify_activity_snapshot(
     *,
     runtime_ready: bool,
@@ -1005,7 +1016,11 @@ def _runtime_verify(*, resources: Any, manifest: Mapping[str, Any]) -> dict[str,
     trading_config_complete = all(trading_config.values())
     ta_config = _kubectl_json(namespace, ['get', 'configmap', ta_configmap, '-o', 'json'])
     ta_data = _as_mapping(ta_config.get('data'))
-    expected_clickhouse_database = _as_text(_resource_attr(resources, 'clickhouse_db'))
+    expected_clickhouse_database = (
+        _as_text(_resource_attr(resources, 'clickhouse_db'))
+        or _clickhouse_database_from_table_name(_as_text(_resource_attr(resources, 'clickhouse_signal_table')))
+        or _clickhouse_database_from_table_name(_as_text(_resource_attr(resources, 'clickhouse_price_table')))
+    )
     ta_runtime_config = {
         f'{role}_topic': _as_text(ta_data.get(key)) == _as_text(expected_topics.get(role))
         for role, key in lane_contract.ta_topic_key_by_role.items()

--- a/services/torghut/scripts/run_simulation_analysis.py
+++ b/services/torghut/scripts/run_simulation_analysis.py
@@ -31,6 +31,7 @@ class _Resources:
     torghut_forecast_service: str
     clickhouse_signal_table: str
     clickhouse_price_table: str
+    clickhouse_db: str
     simulation_topic_by_role: dict[str, str]
     order_feed_group_id: str
     ta_group_id: str
@@ -61,6 +62,14 @@ def _normalize_run_token(run_id: str) -> str:
     if not token:
         raise SystemExit('run-id must contain at least one alphanumeric character')
     return token
+
+
+def _clickhouse_database_from_table_name(table_name: str) -> str:
+    table_name = table_name.strip()
+    if not table_name:
+        return ''
+    database, separator, _table = table_name.partition('.')
+    return database.strip() if separator else ''
 
 
 def _parser() -> argparse.ArgumentParser:
@@ -141,6 +150,9 @@ def _emit(payload: Mapping[str, Any], *, json_only: bool) -> None:
 
 def _resources_from_args(args: argparse.Namespace) -> _Resources:
     run_token = _normalize_run_token(args.run_id)
+    signal_table = getattr(args, 'signal_table', '')
+    price_table = getattr(args, 'price_table', '')
+    clickhouse_db = _clickhouse_database_from_table_name(signal_table) or _clickhouse_database_from_table_name(price_table)
     return _Resources(
         run_id=args.run_id,
         run_token=run_token,
@@ -151,8 +163,9 @@ def _resources_from_args(args: argparse.Namespace) -> _Resources:
         ta_deployment=args.ta_deployment,
         torghut_service=args.torghut_service,
         torghut_forecast_service=args.forecast_service,
-        clickhouse_signal_table=getattr(args, 'signal_table', ''),
-        clickhouse_price_table=getattr(args, 'price_table', ''),
+        clickhouse_signal_table=signal_table,
+        clickhouse_price_table=price_table,
+        clickhouse_db=clickhouse_db,
         simulation_topic_by_role={
             'order_updates': f'torghut.sim.trade-updates.v1.{run_token}',
         },

--- a/services/torghut/tests/test_run_simulation_analysis.py
+++ b/services/torghut/tests/test_run_simulation_analysis.py
@@ -27,6 +27,22 @@ class TestRunSimulationAnalysis(TestCase):
             resources.simulation_topic_by_role['order_updates'],
             'torghut.sim.trade-updates.v1.sim_2026_03_06_open_30m_r3',
         )
+        self.assertEqual(resources.clickhouse_db, 'torghut_sim_2026_03_06_open_30m')
+
+    def test_runtime_ready_resources_derive_clickhouse_db_from_price_table_when_signal_table_missing(self) -> None:
+        class _Args:
+            run_id = 'sim-2026-03-06-open-30m-r3'
+            dataset_id = 'torghut-smoke-open-30m-20260306'
+            namespace = 'torghut'
+            ta_configmap = 'torghut-ta-sim-config'
+            ta_deployment = 'torghut-ta-sim'
+            torghut_service = 'torghut-sim'
+            forecast_service = 'torghut-forecast-sim'
+            signal_table = ''
+            price_table = 'torghut_sim_2026_03_06_open_30m.ta_microbars'
+
+        resources = _resources_from_args(_Args())
+        self.assertEqual(resources.clickhouse_db, 'torghut_sim_2026_03_06_open_30m')
 
     def test_runtime_ready_exits_zero_with_json_payload(self) -> None:
         stdout = io.StringIO()

--- a/services/torghut/tests/test_start_historical_simulation.py
+++ b/services/torghut/tests/test_start_historical_simulation.py
@@ -4087,6 +4087,114 @@ class TestStartHistoricalSimulation(TestCase):
         self.assertEqual(report['ta_runtime_config']['expected_clickhouse_database'], resources.clickhouse_db)
         self.assertEqual(report['ta_runtime_config']['current_clickhouse_database'], wrong_database)
 
+    def test_runtime_verify_derives_expected_clickhouse_database_from_signal_table_when_resource_field_missing(self) -> None:
+        manifest = {
+            'window': {
+                'start': '2026-03-06T14:30:00Z',
+                'end': '2026-03-06T15:30:00Z',
+            }
+        }
+        resources = _build_resources(
+            'sim-2026-03-06-open-hour',
+            {
+                'dataset_id': 'dataset-a',
+                'runtime': {
+                    'target_mode': 'dedicated_service',
+                    'namespace': 'torghut',
+                    'ta_configmap': 'torghut-ta-sim-config',
+                    'ta_deployment': 'torghut-ta-sim',
+                    'torghut_service': 'torghut-sim',
+                    'torghut_forecast_service': 'torghut-forecast-sim',
+                },
+            },
+        )
+        resources_without_db = SimpleNamespace(
+            **{
+                key: value
+                for key, value in vars(resources).items()
+                if key != 'clickhouse_db'
+            }
+        )
+        kservice_payload = {
+            'spec': {
+                'template': {
+                    'spec': {
+                        'containers': [
+                            {
+                                'name': 'user-container',
+                                'env': [
+                                    {'name': 'TRADING_ENABLED', 'value': 'true'},
+                                    {'name': 'TRADING_SIMULATION_ENABLED', 'value': 'true'},
+                                    {'name': 'TRADING_STRATEGY_RUNTIME_MODE', 'value': 'scheduler_v3'},
+                                    {'name': 'TRADING_STRATEGY_SCHEDULER_ENABLED', 'value': 'true'},
+                                    {'name': 'TRADING_SIGNAL_TABLE', 'value': resources.clickhouse_signal_table},
+                                    {'name': 'TRADING_PRICE_TABLE', 'value': resources.clickhouse_price_table},
+                                    {'name': 'TRADING_ORDER_FEED_ENABLED', 'value': 'true'},
+                                    {'name': 'TRADING_ORDER_FEED_TOPIC', 'value': resources.simulation_topic_by_role['order_updates']},
+                                    {'name': 'TRADING_SIMULATION_ORDER_UPDATES_TOPIC', 'value': resources.simulation_topic_by_role['order_updates']},
+                                    {'name': 'TRADING_SIMULATION_RUN_ID', 'value': resources.run_id},
+                                    {'name': 'TRADING_SIGNAL_ALLOWED_SOURCES', 'value': 'ws,ta'},
+                                ],
+                            }
+                        ]
+                    }
+                }
+            },
+            'status': {
+                'latestReadyRevisionName': 'torghut-sim-00001',
+                'conditions': [{'type': 'Ready', 'status': 'True'}],
+            },
+        }
+        ta_configmap_payload = {
+            'data': {
+                'TA_TRADES_TOPIC': resources.simulation_topic_by_role['trades'],
+                'TA_QUOTES_TOPIC': resources.simulation_topic_by_role['quotes'],
+                'TA_BARS1M_TOPIC': resources.simulation_topic_by_role['bars'],
+                'TA_MICROBARS_TOPIC': resources.simulation_topic_by_role['ta_microbars'],
+                'TA_SIGNALS_TOPIC': resources.simulation_topic_by_role['ta_signals'],
+                'TA_CLICKHOUSE_URL': f'jdbc:clickhouse://clickhouse/{resources.clickhouse_db}?run={resources.run_token}',
+            }
+        }
+
+        with (
+            patch(
+                'scripts.historical_simulation_verification._kubectl_json',
+                side_effect=[kservice_payload, ta_configmap_payload],
+            ),
+            patch(
+                'scripts.historical_simulation_verification._deployment_replica_health',
+                side_effect=[
+                    {
+                        'name': 'torghut-sim-00001-deployment',
+                        'ready_replicas': 1,
+                        'available_replicas': 1,
+                        'replicas': 1,
+                    },
+                    {
+                        'name': 'torghut-forecast-sim',
+                        'ready_replicas': 1,
+                        'available_replicas': 1,
+                        'replicas': 1,
+                    },
+                ],
+            ),
+            patch(
+                'scripts.historical_simulation_verification._flink_runtime_health',
+                return_value={
+                    'name': 'torghut-ta-sim',
+                    'desired_state': 'running',
+                    'lifecycle_state': 'RUNNING',
+                    'job_manager_status': 'DEPLOYED',
+                },
+            ),
+        ):
+            report = _runtime_verify(resources=resources_without_db, manifest=manifest)
+
+        self.assertEqual(report['runtime_state'], 'ready')
+        self.assertTrue(report['ta_runtime_config']['clickhouse_database'])
+        self.assertEqual(report['ta_runtime_config']['expected_clickhouse_database'], resources.clickhouse_db)
+        self.assertEqual(report['ta_runtime_config']['current_clickhouse_database'], resources.clickhouse_db)
+
     def test_runtime_verify_accepts_options_lane_topics_and_tables(self) -> None:
         manifest = {
             'schema_version': 'torghut.options-simulation-manifest.v1',


### PR DESCRIPTION
## Summary

- derive the runtime-ready ClickHouse database from run-scoped signal and price tables when the wrapper does not supply an explicit database field
- propagate the derived database through `run_simulation_analysis.py` so runtime-ready and teardown checks match the shared verifier contract
- add regressions covering wrapper database derivation and verifier fallback from run-scoped table names

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen ruff check scripts/run_simulation_analysis.py scripts/historical_simulation_verification.py tests/test_run_simulation_analysis.py tests/test_start_historical_simulation.py`
- `cd services/torghut && uv run --frozen pytest tests/test_run_simulation_analysis.py tests/test_start_historical_simulation.py -q`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen python scripts/run_simulation_analysis.py runtime-ready --run-id sim-platform-proof-compact-20260313-r16 --dataset-id torghut-proof-compact-open-20260311 --namespace torghut --torghut-service torghut-sim --ta-deployment torghut-ta-sim --forecast-service torghut-forecast-sim --window-start 2026-03-11T13:25:00+00:00 --window-end 2026-03-11T13:35:00+00:00 --signal-table torghut_sim_sim_platform_proof_compact_20260313_r16.ta_signals --price-table torghut_sim_sim_platform_proof_compact_20260313_r16.ta_microbars --runtime-timeout-seconds 1 --runtime-poll-seconds 1 --json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
