### PR TITLE
fix(torghut): repair teardown-clean analysis cli

### DIFF
--- a/services/torghut/scripts/run_simulation_analysis.py
+++ b/services/torghut/scripts/run_simulation_analysis.py
@@ -175,12 +175,14 @@ def _resources_from_args(args: argparse.Namespace) -> _Resources:
 
 
 def _manifest_from_args(args: argparse.Namespace) -> dict[str, Any]:
-    manifest = {
-        'window': {
-            'start': args.window_start,
-            'end': args.window_end,
+    manifest: dict[str, Any] = {}
+    window_start = getattr(args, 'window_start', '')
+    window_end = getattr(args, 'window_end', '')
+    if window_start and window_end:
+        manifest['window'] = {
+            'start': window_start,
+            'end': window_end,
         }
-    }
     if hasattr(args, 'monitor_timeout_seconds'):
         manifest['monitor'] = {
             'timeout_seconds': args.monitor_timeout_seconds,

--- a/services/torghut/tests/test_run_simulation_analysis.py
+++ b/services/torghut/tests/test_run_simulation_analysis.py
@@ -223,3 +223,48 @@ class TestRunSimulationAnalysis(TestCase):
         self.assertEqual(ctx.exception.code, 1)
         payload = json.loads(stdout.getvalue())
         self.assertEqual(payload['activity_classification'], 'executions_absent')
+
+    def test_teardown_clean_does_not_require_window_arguments(self) -> None:
+        stdout = io.StringIO()
+        with (
+            patch(
+                'sys.argv',
+                [
+                    'run_simulation_analysis.py',
+                    'teardown-clean',
+                    '--run-id',
+                    'sim-1',
+                    '--dataset-id',
+                    'dataset-a',
+                    '--namespace',
+                    'torghut',
+                    '--ta-configmap',
+                    'torghut-ta-sim-config',
+                    '--ta-deployment',
+                    'torghut-ta-sim',
+                    '--torghut-service',
+                    'torghut-sim',
+                    '--forecast-service',
+                    'torghut-forecast-sim',
+                    '--signal-table',
+                    'torghut_sim_sim_1.ta_signals',
+                    '--price-table',
+                    'torghut_sim_sim_1.ta_microbars',
+                    '--postgres-base-dsn',
+                    'postgresql://torghut:secret@localhost:5432/postgres',
+                    '--postgres-database',
+                    'torghut_sim_sim_1',
+                    '--json',
+                ],
+            ),
+            patch(
+                'scripts.run_simulation_analysis._teardown_clean',
+                return_value={'status': 'ok', 'activity_classification': 'success', 'restored': True},
+            ),
+            redirect_stdout(stdout),
+        ):
+            main()
+
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(payload['status'], 'ok')
+        self.assertTrue(payload['restored'])


### PR DESCRIPTION
## Summary

- repair the `run_simulation_analysis.py teardown-clean` subcommand so it no longer requires `window_start/window_end` arguments
- keep manifest construction command-aware so teardown verification can run after restore without crashing before cleanup checks execute
- add a regression test that exercises `teardown-clean` end to end through the CLI entrypoint without activity-window arguments

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_run_simulation_analysis.py tests/test_start_historical_simulation.py -q`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen ruff check scripts/run_simulation_analysis.py tests/test_run_simulation_analysis.py`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
