### PR TITLE
perf(torghut): warm simulation lanes and persist progress truth

### DIFF
--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -38,11 +38,28 @@ spec:
               value: json
             - name: LOG_ACCESS_LOG
               value: "true"
-            - name: DB_DSN
+            - name: TORGHUT_SIM_DB_HOST
               valueFrom:
                 secretKeyRef:
                   name: torghut-db-app
-                  key: uri
+                  key: host
+            - name: TORGHUT_SIM_DB_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: torghut-db-app
+                  key: port
+            - name: TORGHUT_SIM_DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: torghut-db-app
+                  key: username
+            - name: TORGHUT_SIM_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: torghut-db-app
+                  key: password
+            - name: DB_DSN
+              value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default
             - name: APCA_API_KEY_ID
               valueFrom:
                 secretKeyRef:
@@ -79,7 +96,7 @@ spec:
             - name: CLICKHOUSE_TIMEOUT_SECONDS
               value: "10"
             - name: TRADING_ENABLED
-              value: "false"
+              value: "true"
             - name: TRADING_KILL_SWITCH_ENABLED
               value: "false"
             - name: TRADING_FEATURE_FLAGS_ENABLED
@@ -100,6 +117,8 @@ spec:
               value: "true"
             - name: TRADING_MODE
               value: paper
+            - name: TRADING_SIGNAL_ALLOWED_SOURCES
+              value: ta
             - name: TRADING_AUTONOMY_ALLOW_LIVE_PROMOTION
               value: "false"
             - name: TRADING_ACCOUNT_LABEL
@@ -111,6 +130,10 @@ spec:
               value: "true"
             - name: TRADING_FRACTIONAL_EQUITIES_ENABLED
               value: "true"
+            - name: TRADING_SIMULATION_ENABLED
+              value: "true"
+            - name: TRADING_SIMULATION_CLOCK_MODE
+              value: cursor
             - name: TRADING_SIGNAL_SOURCE
               value: clickhouse
             - name: TRADING_SIGNAL_TABLE
@@ -154,12 +177,46 @@ spec:
             - name: TRADING_FORECAST_ROUTER_PROVIDER_URL
               value: http://torghut-forecast-sim.torghut.svc.cluster.local:8089
             - name: TRADING_POLL_MS
-              value: "5000"
+              value: "1000"
             - name: TRADING_RECONCILE_MS
-              value: "15000"
+              value: "5000"
+            - name: TRADING_SIMULATION_FETCH_WINDOW_SECONDS
+              value: "60"
             - name: TRADING_ORDER_FEED_ENABLED
-              value: "false"
+              value: "true"
+            - name: TRADING_ORDER_FEED_BOOTSTRAP_SERVERS
+              value: kafka-kafka-bootstrap.kafka:9092
+            - name: TRADING_ORDER_FEED_SECURITY_PROTOCOL
+              value: SASL_PLAINTEXT
+            - name: TRADING_ORDER_FEED_SASL_MECHANISM
+              value: SCRAM-SHA-512
+            - name: TRADING_ORDER_FEED_SASL_USERNAME
+              value: torghut-ws
+            - name: TRADING_ORDER_FEED_SASL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: torghut-ws
+                  key: password
+            - name: TRADING_ORDER_FEED_TOPIC
+              value: torghut.sim.trade-updates.v1
+            - name: TRADING_ORDER_FEED_GROUP_ID
+              value: torghut-order-feed-sim-default
             - name: TRADING_ORDER_FEED_TOPIC_V2
+            - name: TRADING_SIMULATION_ORDER_UPDATES_TOPIC
+              value: torghut.sim.trade-updates.v1
+            - name: TRADING_SIMULATION_ORDER_UPDATES_BOOTSTRAP_SERVERS
+              value: kafka-kafka-bootstrap.kafka:9092
+            - name: TRADING_SIMULATION_ORDER_UPDATES_SECURITY_PROTOCOL
+              value: SASL_PLAINTEXT
+            - name: TRADING_SIMULATION_ORDER_UPDATES_SASL_MECHANISM
+              value: SCRAM-SHA-512
+            - name: TRADING_SIMULATION_ORDER_UPDATES_SASL_USERNAME
+              value: torghut-ws
+            - name: TRADING_SIMULATION_ORDER_UPDATES_SASL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: torghut-ws
+                  key: password
             - name: TRADING_EXECUTION_ADAPTER
               value: simulation
             - name: TRADING_EXECUTION_FALLBACK_ADAPTER

--- a/services/jangar/src/server/__tests__/torghut-simulation-control-plane.test.ts
+++ b/services/jangar/src/server/__tests__/torghut-simulation-control-plane.test.ts
@@ -45,7 +45,7 @@ describe('torghut simulation control plane', () => {
       },
     )
 
-    expect(manifest.runtime).toMatchObject({ output_root: '/tmp/torghut-sim' })
+    expect(manifest.runtime).toMatchObject({ output_root: '/tmp/torghut-sim', use_warm_lane: true })
     expect(manifest.performance).toMatchObject({
       replayProfile: 'compact',
       dumpFormat: 'jsonl.zst',

--- a/services/jangar/src/server/torghut-simulation-control-plane.ts
+++ b/services/jangar/src/server/torghut-simulation-control-plane.ts
@@ -212,8 +212,8 @@ const DEFAULT_SIMULATION_PRESETS: TorghutSimulationPreset[] = [
 ]
 
 const TERMINAL_RUN_STATUSES = new Set(['succeeded', 'failed', 'cancelled'])
-const INTERACTIVE_LANES = ['sim-fast-1', 'sim-fast-2', 'sim-fast-3'] as const
-const BATCH_LANES = ['sim-batch-1'] as const
+const INTERACTIVE_LANES = ['sim-fast-1'] as const
+const BATCH_LANES = ['sim-fast-1'] as const
 const CONTROL_PLANE_LEASE_OWNER = 'jangar-control-plane'
 const PROGRESS_FETCH_TIMEOUT_MS = 2_500
 
@@ -512,8 +512,14 @@ const normalizeSimulationManifest = (
   if (!asString(window.end)) throw new Error('manifest.window.end is required')
 
   const runtime = asRecord(manifest.runtime)
+  const targetMode = (asString(runtime.target_mode) ?? 'dedicated_service').toLowerCase()
+  runtime.target_mode = targetMode
   if (overrides.outputRoot) runtime.output_root = overrides.outputRoot
   if (!asString(runtime.output_root)) runtime.output_root = DEFAULT_OUTPUT_ROOT
+  if (runtime.use_warm_lane === undefined && runtime.useWarmLane === undefined) {
+    const lane = (asString(manifest.lane) ?? 'equity').toLowerCase()
+    runtime.use_warm_lane = targetMode === 'dedicated_service' && lane === 'equity'
+  }
   manifest.runtime = runtime
 
   const performance = asRecord(manifest.performance)

--- a/services/torghut/app/config.py
+++ b/services/torghut/app/config.py
@@ -959,6 +959,11 @@ class Settings(BaseSettings):
         alias="TRADING_SIMULATION_CLOCK_CACHE_SECONDS",
         description="Cache TTL for replay clock lookups against the simulation cursor store.",
     )
+    trading_simulation_fetch_window_seconds: int = Field(
+        default=10,
+        alias="TRADING_SIMULATION_FETCH_WINDOW_SECONDS",
+        description="Maximum simulation signal window drained per ingest fetch.",
+    )
     trading_simulation_universe_symbols_path: Optional[str] = Field(
         default=None,
         alias="TRADING_SIMULATION_UNIVERSE_SYMBOLS_PATH",

--- a/services/torghut/app/trading/ingest.py
+++ b/services/torghut/app/trading/ingest.py
@@ -27,7 +27,8 @@ FLAT_CURSOR_OVERLAP = timedelta(seconds=2)
 LATEST_SIGNAL_TS_CACHE_TTL = timedelta(seconds=30)
 LATEST_SIGNAL_TS_ERROR_LOG_COOLDOWN = timedelta(minutes=5)
 SIMULATION_CURSOR_BASELINE = datetime(1970, 1, 1, tzinfo=timezone.utc)
-SIMULATION_FETCH_WINDOW = timedelta(seconds=10)
+def _simulation_fetch_window() -> timedelta:
+    return timedelta(seconds=max(1, settings.trading_simulation_fetch_window_seconds))
 
 FLAT_SIGNAL_COLUMNS = [
     "ts",
@@ -195,12 +196,12 @@ class ClickHouseSignalIngestor:
     ) -> "SignalBatch":
         query_window_start = cursor_at
         if latest_signal_at is None:
-            query_window_end = query_window_start + SIMULATION_FETCH_WINDOW
+            query_window_end = query_window_start + _simulation_fetch_window()
         else:
             effective_end = latest_signal_at or poll_started_at
             query_window_end = min(
                 max(query_window_start, effective_end),
-                query_window_start + SIMULATION_FETCH_WINDOW,
+                query_window_start + _simulation_fetch_window(),
             )
         if query_window_end <= query_window_start:
             lag = (

--- a/services/torghut/app/trading/simulation_progress.py
+++ b/services/torghut/app/trading/simulation_progress.py
@@ -340,6 +340,10 @@ def simulation_progress_snapshot(
     ta = components.get(COMPONENT_TA, {})
     artifacts = components.get(COMPONENT_ARTIFACTS, {})
     artifacts_payload = cast(dict[str, Any], artifacts.get('payload') or {})
+    analysis_run = artifacts_payload.get('analysis_run')
+    activity_classification = artifacts_payload.get('activity_classification')
+    if activity_classification is None and isinstance(analysis_run, Mapping):
+        activity_classification = cast(dict[str, Any], analysis_run).get('activity_classification')
     strategy_type = cast(Optional[str], torghut.get('strategy_type') or replay.get('strategy_type'))
     statuses = {component: payload.get('status') for component, payload in components.items()}
     return {
@@ -363,11 +367,7 @@ def simulation_progress_snapshot(
             'strategy_type': strategy_type,
             'legacy_path_count': int(torghut.get('legacy_path_count') or 0),
             'fallback_count': int(torghut.get('fallback_count') or 0),
-            'activity_classification': (
-                cast(dict[str, Any], artifacts_payload.get('analysis_run') or {}).get('activity_classification')
-                if isinstance(artifacts_payload.get('analysis_run'), Mapping)
-                else artifacts_payload.get('activity_classification')
-            ),
+            'activity_classification': activity_classification,
             'final_artifacts_ready': bool(artifacts.get('terminal_state') == 'complete'),
         },
     }

--- a/services/torghut/scripts/analyze_historical_simulation.py
+++ b/services/torghut/scripts/analyze_historical_simulation.py
@@ -22,9 +22,9 @@ from scripts.start_historical_simulation import (
     _build_clickhouse_runtime_config,
     _build_postgres_runtime_config,
     _build_resources,
+    _default_simulation_postgres_db,
     _http_clickhouse_query,
     _load_manifest,
-    _normalize_run_token,
     _parse_rfc3339_timestamp,
     _resolve_window_bounds,
     _safe_float,
@@ -479,11 +479,9 @@ def _build_report(args: argparse.Namespace) -> dict[str, Any]:
     manifest_path = Path(args.dataset_manifest)
     manifest = _load_manifest(manifest_path)
     resources = _build_resources(args.run_id, manifest)
-    run_token = _normalize_run_token(args.run_id)
-
     postgres_config = _build_postgres_runtime_config(
         manifest,
-        simulation_db=f'torghut_sim_{run_token}',
+        simulation_db=_default_simulation_postgres_db(resources),
     )
     if args.simulation_dsn:
         postgres_config = type(postgres_config)(
@@ -1048,7 +1046,7 @@ def _build_report(args: argparse.Namespace) -> dict[str, Any]:
 
     run_metadata = {
         'run_id': args.run_id,
-        'run_token': run_token,
+        'run_token': resources.run_token,
         'dataset_id': resources.dataset_id,
         'lane': resources.lane,
         'generated_at': datetime.now(timezone.utc).isoformat(),

--- a/services/torghut/scripts/historical_simulation_verification.py
+++ b/services/torghut/scripts/historical_simulation_verification.py
@@ -992,6 +992,7 @@ def _runtime_verify(*, resources: Any, manifest: Mapping[str, Any]) -> dict[str,
         _as_mapping(_resource_attr(resources, 'simulation_topic_by_role')).get('order_updates')
     )
     expected_topics = _as_mapping(_resource_attr(resources, 'simulation_topic_by_role'))
+    warm_lane_enabled = bool(_resource_attr(resources, 'warm_lane_enabled', default=False))
     runtime_mode = _env_value('TRADING_STRATEGY_RUNTIME_MODE')
     scheduler_enabled = _env_value('TRADING_STRATEGY_SCHEDULER_ENABLED') == 'true'
     strategy_runtime_active = runtime_mode == 'plugin_v3' or (
@@ -1010,7 +1011,8 @@ def _runtime_verify(*, resources: Any, manifest: Mapping[str, Any]) -> dict[str,
         'order_feed_topic': _env_value('TRADING_ORDER_FEED_TOPIC') == expected_order_updates_topic,
         'simulation_order_updates_topic': _env_value('TRADING_SIMULATION_ORDER_UPDATES_TOPIC')
         == expected_order_updates_topic,
-        'simulation_run_id': _env_value('TRADING_SIMULATION_RUN_ID') == _as_text(_resource_attr(resources, 'run_id')),
+        'simulation_run_id': warm_lane_enabled
+        or _env_value('TRADING_SIMULATION_RUN_ID') == _as_text(_resource_attr(resources, 'run_id')),
         'signal_allowed_sources': 'ta' in _normalized_string_set(_env_value('TRADING_SIGNAL_ALLOWED_SOURCES')),
     }
     trading_config_complete = all(trading_config.values())
@@ -1369,6 +1371,7 @@ def _verify_isolation_guards(
     clickhouse_signal_table = _as_text(_resource_attr(resources, 'clickhouse_signal_table'))
     clickhouse_price_table = _as_text(_resource_attr(resources, 'clickhouse_price_table'))
     ta_group_id = _as_text(_resource_attr(resources, 'ta_group_id'))
+    warm_lane_enabled = bool(_resource_attr(resources, 'warm_lane_enabled', default=False))
     simulation_db = _as_text(_resource_attr(postgres_config, 'simulation_db'))
     simulation_dsn = _as_text(_resource_attr(postgres_config, 'simulation_dsn'))
     simulation_topics_disjoint = all(
@@ -1388,7 +1391,8 @@ def _verify_isolation_guards(
     report = {
         'lane': lane_contract.lane,
         'simulation_topics_isolated_from_sources': simulation_topics_disjoint,
-        'ta_group_isolated': ta_group_id != _as_text(ta_data.get(lane_contract.ta_group_id_key)),
+        'ta_group_isolated': warm_lane_enabled
+        or ta_group_id != _as_text(ta_data.get(lane_contract.ta_group_id_key)),
         'signal_table_isolated': signal_table_isolated,
         'price_table_isolated': price_table_isolated,
         'auxiliary_tables_isolated': auxiliary_tables_isolated,

--- a/services/torghut/scripts/run_simulation_analysis.py
+++ b/services/torghut/scripts/run_simulation_analysis.py
@@ -35,6 +35,7 @@ class _Resources:
     simulation_topic_by_role: dict[str, str]
     order_feed_group_id: str
     ta_group_id: str
+    warm_lane_enabled: bool = False
 
 
 @dataclass(frozen=True)
@@ -153,6 +154,8 @@ def _resources_from_args(args: argparse.Namespace) -> _Resources:
     signal_table = getattr(args, 'signal_table', '')
     price_table = getattr(args, 'price_table', '')
     clickhouse_db = _clickhouse_database_from_table_name(signal_table) or _clickhouse_database_from_table_name(price_table)
+    warm_lane_enabled = clickhouse_db == 'torghut_sim_default'
+    default_order_updates_topic = 'torghut.sim.trade-updates.v1'
     return _Resources(
         run_id=args.run_id,
         run_token=run_token,
@@ -167,10 +170,11 @@ def _resources_from_args(args: argparse.Namespace) -> _Resources:
         clickhouse_price_table=price_table,
         clickhouse_db=clickhouse_db,
         simulation_topic_by_role={
-            'order_updates': f'torghut.sim.trade-updates.v1.{run_token}',
+            'order_updates': default_order_updates_topic if warm_lane_enabled else f'{default_order_updates_topic}.{run_token}',
         },
-        order_feed_group_id=f'torghut-order-feed-sim-{run_token}',
-        ta_group_id=f'torghut-ta-sim-{run_token}',
+        order_feed_group_id='torghut-order-feed-sim-default' if warm_lane_enabled else f'torghut-order-feed-sim-{run_token}',
+        ta_group_id='torghut-ta-sim-default' if warm_lane_enabled else f'torghut-ta-sim-{run_token}',
+        warm_lane_enabled=warm_lane_enabled,
     )
 
 

--- a/services/torghut/scripts/start_historical_simulation.py
+++ b/services/torghut/scripts/start_historical_simulation.py
@@ -46,6 +46,7 @@ from app.trading.simulation_progress import (
     COMPONENT_ARTIFACTS,
     COMPONENT_REPLAY,
     COMPONENT_TA,
+    COMPONENT_TORGHUT,
 )
 from scripts import historical_simulation_verification as simulation_verification
 from scripts.simulation_lane_contracts import (
@@ -136,6 +137,7 @@ DEFAULT_RUN_MONITOR_MIN_EXECUTIONS = 1
 DEFAULT_RUN_MONITOR_MIN_TCA = 1
 DEFAULT_RUN_MONITOR_MIN_ORDER_EVENTS = 0
 DEFAULT_RUN_MONITOR_CURSOR_GRACE_SECONDS = 120
+DEFAULT_WARM_LANE_SIMULATION_DATABASE = 'torghut_sim_default'
 DEFAULT_SIMULATION_DUMP_FORMAT = 'jsonl.zst'
 SUPPORTED_SIMULATION_DUMP_FORMATS = {
     'ndjson': '.ndjson',
@@ -506,6 +508,7 @@ class SimulationResources:
     clickhouse_table_by_role: dict[str, str]
     clickhouse_signal_table: str
     clickhouse_price_table: str
+    warm_lane_enabled: bool = False
 
 
 @dataclass(frozen=True)
@@ -1254,6 +1257,20 @@ def _ta_auto_offset_reset_key(*, lane: str, manifest: Mapping[str, Any]) -> str:
     )
 
 
+def _warm_lane_enabled(*, manifest: Mapping[str, Any], lane: str, target_mode: str) -> bool:
+    runtime = _as_mapping(manifest.get('runtime'))
+    explicit = runtime.get('use_warm_lane')
+    if explicit is None:
+        explicit = runtime.get('useWarmLane')
+    return explicit is not None and str(explicit).strip().lower() in {'1', 'true', 'yes', 'on'}
+
+
+def _default_simulation_postgres_db(resources: SimulationResources) -> str:
+    if resources.warm_lane_enabled:
+        return DEFAULT_WARM_LANE_SIMULATION_DATABASE
+    return f'torghut_sim_{resources.run_token}'
+
+
 def _build_resources(run_id: str, manifest: Mapping[str, Any]) -> SimulationResources:
     _validate_simulation_strategy_policy(manifest)
     lane_contract = simulation_lane_contract_for_manifest(manifest)
@@ -1266,6 +1283,11 @@ def _build_resources(run_id: str, manifest: Mapping[str, Any]) -> SimulationReso
     target_mode = (_as_text(runtime.get('target_mode')) or 'dedicated_service').strip().lower()
     if target_mode not in {'dedicated_service', 'in_place'}:
         raise RuntimeError('runtime.target_mode must be one of: dedicated_service,in_place')
+    warm_lane = _warm_lane_enabled(
+        manifest=manifest,
+        lane=lane_contract.lane,
+        target_mode=target_mode,
+    )
     output_root_raw = _as_text(runtime.get('output_root'))
     if output_root_raw:
         output_root = Path(output_root_raw)
@@ -1283,10 +1305,11 @@ def _build_resources(run_id: str, manifest: Mapping[str, Any]) -> SimulationReso
         lane_contract.simulation_topic_by_role,
         simulation_topic_overrides,
     )
-    for role, topic in list(simulation_topics.items()):
-        if role in simulation_topic_overrides:
-            continue
-        simulation_topics[role] = f'{topic}.{run_token}'
+    if not warm_lane:
+        for role, topic in list(simulation_topics.items()):
+            if role in simulation_topic_overrides:
+                continue
+            simulation_topics[role] = f'{topic}.{run_token}'
 
     replay_topic_by_source_topic = {
         source_topics[role]: simulation_topics[role]
@@ -1296,7 +1319,7 @@ def _build_resources(run_id: str, manifest: Mapping[str, Any]) -> SimulationReso
     clickhouse_cfg = _as_mapping(manifest.get('clickhouse'))
     clickhouse_db = (
         _as_text(clickhouse_cfg.get('simulation_database'))
-        or f'torghut_sim_{run_token}'
+        or (DEFAULT_WARM_LANE_SIMULATION_DATABASE if warm_lane else f'torghut_sim_{run_token}')
     )
     clickhouse_table_by_role = simulation_clickhouse_table_names(
         lane=lane_contract.lane,
@@ -1319,6 +1342,16 @@ def _build_resources(run_id: str, manifest: Mapping[str, Any]) -> SimulationReso
         if lane_contract.lane == 'options'
         else 'torghut-order-feed-sim'
     )
+    ta_group_id = (
+        f'{ta_group_prefix}-default'
+        if warm_lane
+        else f'{ta_group_prefix}-{run_token}'
+    )
+    order_feed_group_id = (
+        f'{order_feed_group_prefix}-default'
+        if warm_lane
+        else f'{order_feed_group_prefix}-{run_token}'
+    )
 
     return SimulationResources(
         run_id=run_id,
@@ -1337,12 +1370,13 @@ def _build_resources(run_id: str, manifest: Mapping[str, Any]) -> SimulationReso
         source_topic_by_role=source_topics,
         simulation_topic_by_role=simulation_topics,
         replay_topic_by_source_topic=replay_topic_by_source_topic,
-        ta_group_id=f'{ta_group_prefix}-{run_token}',
-        order_feed_group_id=f'{order_feed_group_prefix}-{run_token}',
+        ta_group_id=ta_group_id,
+        order_feed_group_id=order_feed_group_id,
         clickhouse_db=clickhouse_db,
         clickhouse_table_by_role=clickhouse_table_by_role,
         clickhouse_signal_table=clickhouse_signal_table,
         clickhouse_price_table=clickhouse_price_table,
+        warm_lane_enabled=warm_lane,
     )
 
 
@@ -3122,6 +3156,51 @@ def _reset_postgres_runtime_state(config: PostgresRuntimeConfig) -> None:
     )
 
 
+def _seed_simulation_trade_cursor(
+    *,
+    config: PostgresRuntimeConfig,
+    manifest: Mapping[str, Any],
+    account_label: str = 'TORGHUT_SIM',
+) -> datetime:
+    window_start, _window_end = _resolve_window_bounds(manifest)
+
+    def _seed() -> None:
+        with psycopg.connect(config.torghut_runtime_dsn, autocommit=True) as conn:
+            with conn.cursor() as cursor:
+                cursor.execute(
+                    """
+                    INSERT INTO trade_cursor (
+                      source,
+                      account_label,
+                      cursor_at,
+                      cursor_seq,
+                      cursor_symbol
+                    ) VALUES (
+                      'clickhouse',
+                      %(account_label)s,
+                      %(cursor_at)s,
+                      NULL,
+                      NULL
+                    )
+                    ON CONFLICT (source, account_label) DO UPDATE SET
+                      cursor_at = EXCLUDED.cursor_at,
+                      cursor_seq = NULL,
+                      cursor_symbol = NULL,
+                      updated_at = NOW()
+                    """,
+                    {
+                        'account_label': account_label,
+                        'cursor_at': window_start,
+                    },
+                )
+
+    _run_with_transient_postgres_retry(
+        label='seed_simulation_trade_cursor',
+        operation=_seed,
+    )
+    return window_start
+
+
 def _runtime_sessionmaker(config: PostgresRuntimeConfig) -> tuple[Any, Any]:
     runtime_dsn = config.torghut_runtime_dsn
     if runtime_dsn.startswith('postgresql://'):
@@ -4497,6 +4576,7 @@ def _apply(
     _ensure_lz4_codec_available()
     window_policy = _validate_window_policy(manifest)
     torghut_env_overrides = _torghut_env_overrides_from_manifest(manifest)
+    warm_lane_enabled = resources.warm_lane_enabled
 
     state_path, run_manifest_path, dump_path = _state_paths(resources, manifest)
     _ensure_directory(state_path)
@@ -4552,6 +4632,10 @@ def _apply(
         postgres_permissions_report = _ensure_postgres_runtime_permissions(postgres_config)
         _run_migrations(postgres_config)
         _reset_postgres_runtime_state(postgres_config)
+        seeded_cursor_at = _seed_simulation_trade_cursor(
+            config=postgres_config,
+            manifest=manifest,
+        )
         _upsert_simulation_progress_row(
             postgres_config=postgres_config,
             resources=resources,
@@ -4588,27 +4672,30 @@ def _apply(
         )
         replay_cfg = _as_mapping(manifest.get('replay'))
         auto_offset_reset = (_as_text(replay_cfg.get('auto_offset_reset')) or 'earliest').lower()
-        _configure_ta_for_simulation(
-            resources=resources,
-            clickhouse_config=clickhouse_config,
-            clickhouse_database=resources.clickhouse_db,
-            auto_offset_reset=auto_offset_reset,
-            manifest=manifest,
-        )
-        ta_restart_nonce = _restart_ta_deployment(
-            resources,
-            desired_state='running',
-            upgrade_mode=str(ta_restore.get('effective_upgrade_mode') or 'last-state'),
-        )
+        if warm_lane_enabled:
+            ta_restart_nonce = None
+        else:
+            _configure_ta_for_simulation(
+                resources=resources,
+                clickhouse_config=clickhouse_config,
+                clickhouse_database=resources.clickhouse_db,
+                auto_offset_reset=auto_offset_reset,
+                manifest=manifest,
+            )
+            ta_restart_nonce = _restart_ta_deployment(
+                resources,
+                desired_state='running',
+                upgrade_mode=str(ta_restore.get('effective_upgrade_mode') or 'last-state'),
+            )
 
-        _configure_torghut_service_for_simulation(
-            resources=resources,
-            manifest=manifest,
-            postgres_config=postgres_config,
-            clickhouse_config=clickhouse_config,
-            kafka_config=kafka_config,
-            torghut_env_overrides=torghut_env_overrides,
-        )
+            _configure_torghut_service_for_simulation(
+                resources=resources,
+                manifest=manifest,
+                postgres_config=postgres_config,
+                clickhouse_config=clickhouse_config,
+                kafka_config=kafka_config,
+                torghut_env_overrides=torghut_env_overrides,
+            )
     except Exception:
         _release_simulation_runtime_lock(resources=resources)
         raise
@@ -4625,6 +4712,8 @@ def _apply(
         'topics': topics_report,
         'schema_registry': schema_registry_report,
         'ta_restart_nonce': ta_restart_nonce,
+        'warm_lane_enabled': warm_lane_enabled,
+        'seeded_cursor_at': seeded_cursor_at.isoformat(),
         'resources': asdict(resources)
         | {
             'output_root': str(resources.output_root),
@@ -4657,6 +4746,7 @@ def _teardown(
     allow_missing_state: bool,
 ) -> dict[str, Any]:
     _ensure_supported_binary('kubectl')
+    warm_lane_enabled = resources.warm_lane_enabled
     state_path, run_manifest_path, dump_path = _state_paths(resources, manifest)
     if not state_path.exists():
         lock_report = _release_simulation_runtime_lock(resources=resources)
@@ -4703,11 +4793,14 @@ def _teardown(
         }
 
     state = _load_json(state_path)
-    _restore_ta_configuration(resources, state)
-    _restore_torghut_env(resources, state)
-
-    original_state = _as_text(state.get('ta_job_state')) or 'running'
-    ta_restart_nonce = _restart_ta_deployment(resources, desired_state=original_state)
+    if warm_lane_enabled:
+        original_state = 'running'
+        ta_restart_nonce = None
+    else:
+        _restore_ta_configuration(resources, state)
+        _restore_torghut_env(resources, state)
+        original_state = _as_text(state.get('ta_job_state')) or 'running'
+        ta_restart_nonce = _restart_ta_deployment(resources, desired_state=original_state)
     lock_report = _release_simulation_runtime_lock(resources=resources)
     report = {
         'status': 'ok',
@@ -4719,6 +4812,8 @@ def _teardown(
         'dump_path': str(dump_path),
         'ta_restart_nonce': ta_restart_nonce,
         'restored_ta_state': original_state,
+        'warm_lane_enabled': warm_lane_enabled,
+        'skipped_restore': warm_lane_enabled,
         'simulation_lock': lock_report,
     }
     _save_json(run_manifest_path.with_name('teardown-manifest.json'), report)
@@ -5659,6 +5754,35 @@ def _run_full_lifecycle(
                 clickhouse_config=clickhouse_config,
                 runtime_verify=runtime_verify_report,
             )
+            final_snapshot = _as_mapping(monitor_report.get('final_snapshot'))
+            _upsert_simulation_progress_row(
+                postgres_config=postgres_config,
+                resources=resources,
+                component=COMPONENT_TORGHUT,
+                status='activity_verified',
+                last_signal_ts=_parse_optional_rfc3339_timestamp(
+                    _as_text(final_snapshot.get('last_signal_ts'))
+                ),
+                last_price_ts=_parse_optional_rfc3339_timestamp(
+                    _as_text(final_snapshot.get('last_price_ts'))
+                ),
+                cursor_at=_parse_optional_rfc3339_timestamp(
+                    _as_text(final_snapshot.get('cursor_at'))
+                ),
+                trade_decisions=_safe_int(final_snapshot.get('trade_decisions')),
+                executions=_safe_int(final_snapshot.get('executions')),
+                execution_tca_metrics=_safe_int(final_snapshot.get('execution_tca_metrics')),
+                execution_order_events=_safe_int(final_snapshot.get('execution_order_events')),
+                legacy_path_count=_safe_int(final_snapshot.get('legacy_path_count')),
+                fallback_count=_safe_int(final_snapshot.get('fallback_count')),
+                terminal_state='complete'
+                if _as_text(monitor_report.get('activity_classification')) == 'success'
+                else None,
+                payload={
+                    'activity_classification': monitor_report.get('activity_classification'),
+                    'effective_terminal_signal_ts': monitor_report.get('effective_terminal_signal_ts'),
+                },
+            )
             if bool(rollouts_report['enabled']):
                 try:
                     activity_analysis_run = _run_rollouts_analysis(
@@ -5791,6 +5915,21 @@ def _run_full_lifecycle(
             errors=errors,
         )
         _save_json(_artifact_path(resources, 'run-summary.json'), run_summary_report)
+        _upsert_simulation_progress_row(
+            postgres_config=postgres_config,
+            resources=resources,
+            component=COMPONENT_TORGHUT,
+            status='reported',
+            strategy_type=_as_text(strategy_proof_report.get('strategy_type')),
+            legacy_path_count=_safe_int(strategy_proof_report.get('legacy_path_count')),
+            fallback_count=_safe_int(strategy_proof_report.get('fallback_order_count')),
+            terminal_state='complete',
+            payload={
+                'strategy_type': strategy_proof_report.get('strategy_type'),
+                'legacy_path_count': strategy_proof_report.get('legacy_path_count'),
+                'fallback_order_count': strategy_proof_report.get('fallback_order_count'),
+            },
+        )
         _upsert_simulation_progress_row(
             postgres_config=postgres_config,
             resources=resources,
@@ -6064,7 +6203,7 @@ def main() -> None:
     )
     postgres_config = _build_postgres_runtime_config(
         manifest,
-        simulation_db=f'torghut_sim_{resources.run_token}',
+        simulation_db=_default_simulation_postgres_db(resources),
     )
     _log_script_event(
         'postgres_config_ready',

--- a/services/torghut/tests/test_simulation_progress.py
+++ b/services/torghut/tests/test_simulation_progress.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from app.trading.simulation_progress import (
+    COMPONENT_ARTIFACTS,
+    COMPONENT_REPLAY,
+    COMPONENT_TORGHUT,
+    simulation_progress_snapshot,
+)
+
+
+def _row(**values: object) -> SimpleNamespace:
+    defaults = {
+        'component': COMPONENT_REPLAY,
+        'dataset_id': 'dataset-a',
+        'lane': 'equity',
+        'workflow_name': None,
+        'status': 'running',
+        'updated_at': datetime.now(timezone.utc),
+        'last_source_ts': None,
+        'last_signal_ts': None,
+        'last_price_ts': None,
+        'cursor_at': None,
+        'records_dumped': 0,
+        'records_replayed': 0,
+        'trade_decisions': 0,
+        'executions': 0,
+        'execution_tca_metrics': 0,
+        'execution_order_events': 0,
+        'strategy_type': None,
+        'legacy_path_count': 0,
+        'fallback_count': 0,
+        'terminal_state': None,
+        'last_error_code': None,
+        'last_error_message': None,
+        'payload_json': {},
+    }
+    defaults.update(values)
+    return SimpleNamespace(**defaults)
+
+
+class TestSimulationProgress(TestCase):
+    def test_snapshot_prefers_top_level_activity_classification(self) -> None:
+        session = MagicMock()
+        session.execute.return_value.scalars.return_value.all.return_value = [
+            _row(
+                component=COMPONENT_REPLAY,
+                records_dumped=100,
+                records_replayed=100,
+            ),
+            _row(
+                component=COMPONENT_TORGHUT,
+                trade_decisions=5,
+                executions=4,
+                execution_tca_metrics=4,
+                execution_order_events=4,
+            ),
+            _row(
+                component=COMPONENT_ARTIFACTS,
+                terminal_state='complete',
+                payload_json={
+                    'activity_classification': 'success',
+                    'analysis_run': {'phase': 'Successful'},
+                },
+            ),
+        ]
+
+        with patch('app.trading.simulation_progress.simulation_progress_context', return_value=None):
+            snapshot = simulation_progress_snapshot(session, run_id='sim-proof')
+
+        self.assertTrue(snapshot['enabled'])
+        self.assertEqual(snapshot['summary']['activity_classification'], 'success')
+        self.assertTrue(snapshot['summary']['final_artifacts_ready'])

--- a/services/torghut/tests/test_start_historical_simulation.py
+++ b/services/torghut/tests/test_start_historical_simulation.py
@@ -291,6 +291,29 @@ class TestStartHistoricalSimulation(TestCase):
             'torghut.sim.trades.v1.sim_2026_02_27_01',
         )
 
+    def test_build_resources_uses_stable_defaults_when_warm_lane_enabled(self) -> None:
+        resources = _build_resources(
+            'sim-2026-02-27-01',
+            {
+                'dataset_id': 'torghut-trades-2025q4',
+                'runtime': {
+                    'use_warm_lane': True,
+                },
+            },
+        )
+        self.assertTrue(resources.warm_lane_enabled)
+        self.assertEqual(resources.ta_group_id, 'torghut-ta-sim-default')
+        self.assertEqual(resources.order_feed_group_id, 'torghut-order-feed-sim-default')
+        self.assertEqual(resources.clickhouse_signal_table, 'torghut_sim_default.ta_signals')
+        self.assertEqual(
+            resources.simulation_topic_by_role['order_updates'],
+            'torghut.sim.trade-updates.v1',
+        )
+        self.assertEqual(
+            resources.replay_topic_by_source_topic['torghut.trades.v1'],
+            'torghut.sim.trades.v1',
+        )
+
     def test_build_resources_derives_options_lane_isolation_names(self) -> None:
         resources = _build_resources(
             'options-sim-2026-03-06-open',
@@ -1073,6 +1096,10 @@ class TestStartHistoricalSimulation(TestCase):
                 patch('scripts.start_historical_simulation._run_migrations', return_value=None),
                 patch('scripts.start_historical_simulation._reset_postgres_runtime_state', return_value=None),
                 patch(
+                    'scripts.start_historical_simulation._seed_simulation_trade_cursor',
+                    return_value=datetime(2026, 2, 27, 14, 30, tzinfo=timezone.utc),
+                ),
+                patch(
                     'scripts.start_historical_simulation._dump_topics',
                     return_value={'records': 1, 'sha256': 'abc'},
                 ),
@@ -1102,6 +1129,96 @@ class TestStartHistoricalSimulation(TestCase):
         self.assertTrue(report['clickhouse']['database_precreated'])
         self.assertTrue(report['postgres']['database_precreated'])
         self.assertEqual(report['simulation_lock']['status'], 'acquired')
+
+    def test_apply_skips_runtime_reconfiguration_for_warm_lane(self) -> None:
+        resources = _build_resources(
+            'sim-1',
+            {
+                'dataset_id': 'dataset-a',
+                'runtime': {'use_warm_lane': True},
+            },
+        )
+        kafka_config = KafkaRuntimeConfig(
+            bootstrap_servers='kafka:9092',
+            security_protocol=None,
+            sasl_mechanism=None,
+            sasl_username=None,
+            sasl_password=None,
+        )
+        clickhouse_config = ClickHouseRuntimeConfig(
+            http_url='http://clickhouse:8123',
+            username='torghut',
+            password='secret',
+        )
+        postgres_config = PostgresRuntimeConfig(
+            admin_dsn='postgresql://torghut:secret@localhost:5432/postgres',
+            simulation_dsn='postgresql://torghut:secret@localhost:5432/torghut_sim_default',
+            simulation_db='torghut_sim_default',
+            migrations_command='true',
+        )
+        manifest = {
+            'dataset_id': 'dataset-a',
+            'runtime': {'use_warm_lane': True},
+            'clickhouse': {'database_precreated': True},
+            'postgres': {'database_precreated': True},
+            'window': {
+                'start': '2026-02-27T14:30:00Z',
+                'end': '2026-02-27T15:30:00Z',
+            },
+        }
+
+        with TemporaryDirectory() as tmpdir:
+            resources = replace(resources, output_root=Path(tmpdir))
+            with (
+                patch('scripts.start_historical_simulation._ensure_supported_binary', return_value=None),
+                patch('scripts.start_historical_simulation._ensure_lz4_codec_available', return_value=None),
+                patch(
+                    'scripts.start_historical_simulation._acquire_simulation_runtime_lock',
+                    return_value={'status': 'acquired', 'run_id': resources.run_id},
+                ),
+                patch(
+                    'scripts.start_historical_simulation._capture_cluster_state',
+                    return_value={'ta_data': {'TA_GROUP_ID': 'torghut-ta-sim-default'}},
+                ),
+                patch('scripts.start_historical_simulation._ensure_topics', return_value={'status': 'ok'}),
+                patch('scripts.start_historical_simulation._ensure_clickhouse_runtime_tables', return_value=None),
+                patch(
+                    'scripts.start_historical_simulation._ensure_postgres_runtime_permissions',
+                    return_value={'grants_applied': True},
+                ),
+                patch('scripts.start_historical_simulation._run_migrations', return_value=None),
+                patch('scripts.start_historical_simulation._reset_postgres_runtime_state', return_value=None),
+                patch(
+                    'scripts.start_historical_simulation._seed_simulation_trade_cursor',
+                    return_value=datetime(2026, 2, 27, 14, 30, tzinfo=timezone.utc),
+                ),
+                patch(
+                    'scripts.start_historical_simulation._dump_topics',
+                    return_value={'records': 1, 'sha256': 'abc'},
+                ),
+                patch(
+                    'scripts.start_historical_simulation._validate_dump_coverage',
+                    return_value={'coverage_ratio': 1.0},
+                ),
+                patch('scripts.start_historical_simulation._configure_ta_for_simulation') as configure_ta,
+                patch('scripts.start_historical_simulation._restart_ta_deployment') as restart_ta,
+                patch('scripts.start_historical_simulation._configure_torghut_service_for_simulation') as configure_service,
+            ):
+                report = start_historical_simulation._apply(
+                    resources=resources,
+                    manifest=manifest,
+                    kafka_config=kafka_config,
+                    clickhouse_config=clickhouse_config,
+                    postgres_config=postgres_config,
+                    force_dump=False,
+                    force_replay=False,
+                )
+
+        configure_ta.assert_not_called()
+        restart_ta.assert_not_called()
+        configure_service.assert_not_called()
+        self.assertTrue(report['warm_lane_enabled'])
+        self.assertEqual(report['seeded_cursor_at'], '2026-02-27T14:30:00+00:00')
 
     def test_apply_uses_stateless_ta_restart_when_manifest_requests_it(self) -> None:
         resources = _build_resources('sim-1', {'dataset_id': 'dataset-a'})
@@ -1161,6 +1278,10 @@ class TestStartHistoricalSimulation(TestCase):
                 ),
                 patch('scripts.start_historical_simulation._run_migrations', return_value=None),
                 patch('scripts.start_historical_simulation._reset_postgres_runtime_state', return_value=None),
+                patch(
+                    'scripts.start_historical_simulation._seed_simulation_trade_cursor',
+                    return_value=datetime(2026, 2, 27, 14, 30, tzinfo=timezone.utc),
+                ),
                 patch(
                     'scripts.start_historical_simulation._dump_topics',
                     return_value={'records': 1, 'sha256': 'abc'},
@@ -1320,6 +1441,10 @@ class TestStartHistoricalSimulation(TestCase):
                 patch('scripts.start_historical_simulation._run_migrations', return_value=None),
                 patch('scripts.start_historical_simulation._reset_postgres_runtime_state', return_value=None),
                 patch(
+                    'scripts.start_historical_simulation._seed_simulation_trade_cursor',
+                    return_value=datetime(2026, 2, 27, 14, 30, tzinfo=timezone.utc),
+                ),
+                patch(
                     'scripts.start_historical_simulation._dump_topics',
                     return_value={'records': 1, 'sha256': 'abc'},
                 ),
@@ -1409,6 +1534,10 @@ class TestStartHistoricalSimulation(TestCase):
                 ),
                 patch('scripts.start_historical_simulation._run_migrations', return_value=None),
                 patch('scripts.start_historical_simulation._reset_postgres_runtime_state', return_value=None),
+                patch(
+                    'scripts.start_historical_simulation._seed_simulation_trade_cursor',
+                    return_value=datetime(2026, 2, 27, 14, 30, tzinfo=timezone.utc),
+                ),
                 patch(
                     'scripts.start_historical_simulation._dump_topics',
                     return_value={'records': 1, 'sha256': 'abc'},
@@ -2968,6 +3097,47 @@ class TestStartHistoricalSimulation(TestCase):
         release_lock.assert_called_once_with(resources=resources)
         self.assertFalse(report['state_found'])
         self.assertEqual(report['simulation_lock']['status'], 'released')
+
+    def test_teardown_skips_runtime_restore_for_warm_lane(self) -> None:
+        resources = _build_resources(
+            'sim-1',
+            {
+                'dataset_id': 'dataset-a',
+                'runtime': {'use_warm_lane': True},
+            },
+        )
+        with TemporaryDirectory() as tmpdir:
+            resources = replace(resources, output_root=Path(tmpdir))
+            state_path = resources.output_root / resources.run_token / 'state.json'
+            state_path.parent.mkdir(parents=True, exist_ok=True)
+            state_path.write_text(json.dumps({'ta_job_state': 'running'}))
+
+            with (
+                patch(
+                    'scripts.start_historical_simulation._read_simulation_runtime_lock',
+                    return_value={'run_id': resources.run_id},
+                ),
+                patch(
+                    'scripts.start_historical_simulation._release_simulation_runtime_lock',
+                    return_value={'status': 'released', 'run_id': resources.run_id},
+                ) as release_lock,
+                patch('scripts.start_historical_simulation._restore_ta_configuration') as restore_ta,
+                patch('scripts.start_historical_simulation._restore_torghut_env') as restore_env,
+                patch('scripts.start_historical_simulation._restart_ta_deployment') as restart_ta,
+                patch('scripts.start_historical_simulation._ensure_supported_binary', return_value=None),
+            ):
+                report = start_historical_simulation._teardown(
+                    resources=resources,
+                    allow_missing_state=False,
+                )
+
+        restore_ta.assert_not_called()
+        restore_env.assert_not_called()
+        restart_ta.assert_not_called()
+        release_lock.assert_called_once_with(resources=resources)
+        self.assertTrue(report['warm_lane_enabled'])
+        self.assertTrue(report['skipped_restore'])
+        self.assertIsNone(report['ta_restart_nonce'])
 
     def test_build_simulation_completion_trace_marks_smoke_gate_satisfied(self) -> None:
         resources = _build_resources(


### PR DESCRIPTION
## Summary

- make warm-lane simulation runs reuse stable `torghut-sim` runtime resources instead of reconfiguring TA and Torghut on every compact replay
- persist final simulation progress truth into the runtime ledger and fix Jangar summary extraction so post-teardown run status stays authoritative
- add warm-lane defaults in the Jangar control plane plus Torghut regression coverage for resource planning, apply/teardown skips, and progress summary classification

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_start_historical_simulation.py tests/test_run_simulation_analysis.py tests/test_simulation_progress.py -q`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen ruff check app tests scripts migrations`
- `cd services/jangar && bunx vitest run --config vitest.config.ts src/server/__tests__/torghut-simulation-control-plane.test.ts src/server/__tests__/torghut-simulation-control-plane-submit.test.ts`
- `bun run --filter @proompteng/jangar tsc`
- `bun run --filter @proompteng/jangar build`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
