### PR TITLE
chore(jangar): promote image ed4dcf14

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: "13128e38"
-  digest: sha256:ccad5688be9390fb0fb98b3df0206f7cea2c05ebcb7aa2022bdcc9988be61269
+  tag: ed4dcf14
+  digest: sha256:52a4a3b1df44e34af38c3e6408f7e0553fac2b32989fd57ef8ea8484fc29ee69
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: "13128e38"
-    digest: sha256:465a83322e0c9a66e4920e88f7daf27a30f865f966df144b29508955d6612eb3
+    tag: ed4dcf14
+    digest: sha256:19e4ab5313dda59110f0917319e8b8f0625aa7c8a09c2f796eb0a1932e3ec8c6
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: "13128e38"
-    digest: sha256:ccad5688be9390fb0fb98b3df0206f7cea2c05ebcb7aa2022bdcc9988be61269
+    tag: ed4dcf14
+    digest: sha256:52a4a3b1df44e34af38c3e6408f7e0553fac2b32989fd57ef8ea8484fc29ee69
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-13T11:53:27Z"
+    deploy.knative.dev/rollout: "2026-03-13T16:24:53Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-13T11:53:27Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-13T16:24:53Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -62,5 +62,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "13128e38"
-    digest: sha256:ccad5688be9390fb0fb98b3df0206f7cea2c05ebcb7aa2022bdcc9988be61269
+    newTag: "ed4dcf14"
+    digest: sha256:52a4a3b1df44e34af38c3e6408f7e0553fac2b32989fd57ef8ea8484fc29ee69


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `ed4dcf14b73a631dc2fa39aa7bf247aed3cf2fcf`
- Image tag: `ed4dcf14`
- Image digest: `sha256:52a4a3b1df44e34af38c3e6408f7e0553fac2b32989fd57ef8ea8484fc29ee69`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`