### PR TITLE
fix(headlamp): use access token for oidc watches

### DIFF
--- a/argocd/applications/headlamp/values.yaml
+++ b/argocd/applications/headlamp/values.yaml
@@ -18,6 +18,8 @@ config:
 env:
   - name: OIDC_SCOPES
     value: 'openid profile email offline_access'
+  - name: OIDC_USE_ACCESS_TOKEN
+    value: 'true'
 ingress:
   enabled: true
   ingressClassName: tailscale

--- a/docs/headlamp-setup.md
+++ b/docs/headlamp-setup.md
@@ -83,6 +83,10 @@ Headlamp now derives the callback URL dynamically from the request host when `co
 is omitted, so the same deployment can complete OIDC flows on both the Tailscale hostname and the private
 `k8s.proompteng.ai` hostname.
 
+For OIDC-backed cluster watches, logs, exec, and port-forward websocket upgrades, keep
+`OIDC_USE_ACCESS_TOKEN=true` in the Headlamp deployment env. Without it, ordinary REST
+requests may work while websocket watches fail with `1006` and repeated `401` health checks.
+
 Commit and sync the Keycloak and Headlamp Argo CD apps.
 
 Recommended sync order:
@@ -170,6 +174,7 @@ Make sure the Keycloak groups mapper is configured so the `groups` claim is pres
 ## Troubleshooting
 
 - **401 Unauthorized**: kube-apiserver OIDC config missing or mismatched (issuer/client-id/CA).
+- **WebSocket watches fail (`1006`) or `/clusters/<name>/healthz` loops on 401**: make sure Headlamp is started with `OIDC_USE_ACCESS_TOKEN=true` so it can authenticate websocket upgrades for OIDC-backed clusters.
 - **403 Forbidden**: RBAC missing. Add/update `headlamp-oidc-rbac.yaml` and sync Argo CD.
 - **Redirect always goes to the Tailscale hostname**: the running Headlamp deployment still has a fixed `-oidc-callback-url`. Sync the updated Headlamp manifests so it can derive the callback from the request host.
 - **Sign-in gets stuck on `/auth?cluster=...`**: sync the `headlamp-auth-bridge` resources and the patched Tailscale Ingress. The bridge page forces the popup flow to hand control back to the main Headlamp window even if Headlamp misses the original storage-event handoff.


### PR DESCRIPTION
## Summary

- inject `OIDC_USE_ACCESS_TOKEN=true` into the Headlamp deployment values
- ensure the rendered deployment starts Headlamp with `-oidc-use-access-token=$(OIDC_USE_ACCESS_TOKEN)`
- document the websocket/watch failure mode for OIDC-backed Headlamp clusters

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/headlamp >/tmp/headlamp-render.yaml && rg -n "oidc-use-access-token|OIDC_USE_ACCESS_TOKEN" /tmp/headlamp-render.yaml`
- Manual browser reproduction on `https://headlamp.k8s.proompteng.ai/c/main/workloads`: authenticated REST calls succeeded but websocket watches only offered `base64.binary.k8s.io` and closed with `1006`
- Verified the deployed Headlamp runtime contains the upstream bearer websocket support string `base64url.bearer.authorization.k8s.io`, so the missing config gate is the likely cause

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
