### PR TITLE
fix(torghut): resolve warm-lane runtime dsn

### DIFF
--- a/services/torghut/scripts/start_historical_simulation.py
+++ b/services/torghut/scripts/start_historical_simulation.py
@@ -19,7 +19,7 @@ import socket
 import time
 import uuid
 from contextlib import contextmanager
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, replace
 from datetime import date, datetime, timedelta, timezone
 from decimal import Decimal
 from pathlib import Path
@@ -2049,6 +2049,129 @@ def _kservice_container_with_env(
     updated = dict(container)
     updated['env'] = list(env_entries)
     return updated
+
+
+def _read_secret_key_ref(
+    *,
+    namespace: str,
+    name: str,
+    key: str,
+) -> str:
+    secret = _kubectl_json(namespace, ['get', 'secret', name, '-o', 'json'])
+    data = _as_mapping(secret.get('data'))
+    encoded = _as_text(data.get(key))
+    if encoded is None:
+        raise RuntimeError(f'secret_key_missing:{namespace}:{name}:{key}')
+    try:
+        decoded = _b64_to_bytes(encoded)
+        if decoded is None:
+            raise RuntimeError('empty_secret_value')
+        return decoded.decode('utf-8')
+    except Exception as exc:  # pragma: no cover - defensive decode guard
+        raise RuntimeError(f'secret_key_decode_failed:{namespace}:{name}:{key}') from exc
+
+
+def _read_configmap_key_ref(
+    *,
+    namespace: str,
+    name: str,
+    key: str,
+) -> str:
+    configmap = _kubectl_json(namespace, ['get', 'configmap', name, '-o', 'json'])
+    data = _as_mapping(configmap.get('data'))
+    value = _as_text(data.get(key))
+    if value is None:
+        raise RuntimeError(f'configmap_key_missing:{namespace}:{name}:{key}')
+    return value
+
+
+def _expand_env_value_refs(value: str, resolved: Mapping[str, str]) -> str:
+    def _sub(match: re.Match[str]) -> str:
+        key = match.group(1)
+        return resolved.get(key, match.group(0))
+
+    return re.sub(r'\$\(([A-Za-z_][A-Za-z0-9_]*)\)', _sub, value)
+
+
+def _resolve_kservice_env_values(
+    *,
+    namespace: str,
+    env_entries: Sequence[Mapping[str, Any]],
+) -> dict[str, str]:
+    resolved: dict[str, str] = {}
+    deferred: dict[str, str] = {}
+    for entry in env_entries:
+        name = _as_text(entry.get('name'))
+        if not name:
+            continue
+        raw_value = entry.get('value')
+        if raw_value is not None:
+            deferred[name] = str(raw_value)
+            continue
+        value_from = _as_mapping(entry.get('valueFrom'))
+        secret_key_ref = _as_mapping(value_from.get('secretKeyRef'))
+        if secret_key_ref:
+            secret_name = _as_text(secret_key_ref.get('name'))
+            secret_key = _as_text(secret_key_ref.get('key'))
+            if not secret_name or not secret_key:
+                raise RuntimeError(f'kservice_env_secret_key_ref_invalid:{name}')
+            resolved[name] = _read_secret_key_ref(
+                namespace=namespace,
+                name=secret_name,
+                key=secret_key,
+            )
+            continue
+        configmap_key_ref = _as_mapping(value_from.get('configMapKeyRef'))
+        if configmap_key_ref:
+            configmap_name = _as_text(configmap_key_ref.get('name'))
+            configmap_key = _as_text(configmap_key_ref.get('key'))
+            if not configmap_name or not configmap_key:
+                raise RuntimeError(f'kservice_env_configmap_key_ref_invalid:{name}')
+            resolved[name] = _read_configmap_key_ref(
+                namespace=namespace,
+                name=configmap_name,
+                key=configmap_key,
+            )
+    if deferred:
+        for _ in range(len(deferred) + len(resolved) + 1):
+            changed = False
+            for key, value in deferred.items():
+                expanded = _expand_env_value_refs(value, resolved)
+                if key not in resolved or resolved[key] != expanded:
+                    resolved[key] = expanded
+                    changed = True
+            if not changed:
+                break
+    return resolved
+
+
+def _resolve_warm_lane_runtime_postgres_config(
+    *,
+    resources: SimulationResources,
+    postgres_config: PostgresRuntimeConfig,
+) -> PostgresRuntimeConfig:
+    if postgres_config.runtime_simulation_dsn:
+        return postgres_config
+    service = _kubectl_json(
+        resources.namespace,
+        ['get', 'kservice', resources.torghut_service, '-o', 'json'],
+    )
+    _, env_entries = _kservice_env(service)
+    resolved_env = _resolve_kservice_env_values(
+        namespace=resources.namespace,
+        env_entries=env_entries,
+    )
+    current_runtime_dsn = _as_text(resolved_env.get('DB_DSN'))
+    if not current_runtime_dsn:
+        raise RuntimeError(
+            f'warm_lane_runtime_dsn_unavailable:{resources.namespace}:{resources.torghut_service}'
+        )
+    runtime_dsn = _replace_database_in_dsn(
+        current_runtime_dsn,
+        database=postgres_config.simulation_db,
+        label=f'{resources.torghut_service}.env.DB_DSN',
+    )
+    return replace(postgres_config, runtime_simulation_dsn=runtime_dsn)
 
 
 def _merge_env_entries(
@@ -6209,10 +6332,16 @@ def main() -> None:
         manifest,
         simulation_db=_default_simulation_postgres_db(resources),
     )
+    if resources.warm_lane_enabled:
+        postgres_config = _resolve_warm_lane_runtime_postgres_config(
+            resources=resources,
+            postgres_config=postgres_config,
+        )
     _log_script_event(
         'postgres_config_ready',
         admin_dsn=_redact_dsn_credentials(postgres_config.admin_dsn),
         simulation_dsn=_redact_dsn_credentials(postgres_config.simulation_dsn),
+        runtime_simulation_dsn=_redact_dsn_credentials(postgres_config.torghut_runtime_dsn),
         simulation_db=postgres_config.simulation_db,
         migration_command=postgres_config.migrations_command,
     )

--- a/services/torghut/tests/test_start_historical_simulation.py
+++ b/services/torghut/tests/test_start_historical_simulation.py
@@ -56,6 +56,7 @@ from scripts.start_historical_simulation import (
     _restore_argocd_after_run,
     _restore_torghut_env,
     _replay_dump,
+    _resolve_warm_lane_runtime_postgres_config,
     _run_full_lifecycle,
     _run_rollouts_analysis,
     _load_schema_registry_schema_literal,
@@ -1284,6 +1285,188 @@ class TestStartHistoricalSimulation(TestCase):
         configure_service.assert_not_called()
         self.assertTrue(report['warm_lane_enabled'])
         self.assertEqual(report['seeded_cursor_at'], '2026-02-27T14:30:00+00:00')
+
+    def test_resolve_warm_lane_runtime_postgres_config_uses_current_kservice_dsn(self) -> None:
+        resources = _build_resources(
+            'sim-1',
+            {
+                'dataset_id': 'dataset-a',
+                'runtime': {'use_warm_lane': True},
+            },
+        )
+        postgres_config = PostgresRuntimeConfig(
+            admin_dsn='postgresql://postgres:admin-secret@db.example:5432/postgres',
+            simulation_dsn='postgresql://postgres:admin-secret@db.example:5432/torghut_sim_default',
+            simulation_db='torghut_sim_default',
+            migrations_command='true',
+        )
+
+        def _kubectl_json_side_effect(namespace: str, args: list[str]) -> dict[str, Any]:
+            self.assertEqual(namespace, 'torghut')
+            if args[:3] == ['get', 'kservice', 'torghut-sim']:
+                return {
+                    'spec': {
+                        'template': {
+                            'spec': {
+                                'containers': [
+                                    {
+                                        'env': [
+                                            {
+                                                'name': 'TORGHUT_SIM_DB_HOST',
+                                                'valueFrom': {
+                                                    'secretKeyRef': {
+                                                        'name': 'torghut-db-app',
+                                                        'key': 'host',
+                                                    }
+                                                },
+                                            },
+                                            {
+                                                'name': 'TORGHUT_SIM_DB_PORT',
+                                                'valueFrom': {
+                                                    'secretKeyRef': {
+                                                        'name': 'torghut-db-app',
+                                                        'key': 'port',
+                                                    }
+                                                },
+                                            },
+                                            {
+                                                'name': 'TORGHUT_SIM_DB_USER',
+                                                'valueFrom': {
+                                                    'secretKeyRef': {
+                                                        'name': 'torghut-db-app',
+                                                        'key': 'username',
+                                                    }
+                                                },
+                                            },
+                                            {
+                                                'name': 'TORGHUT_SIM_DB_PASSWORD',
+                                                'valueFrom': {
+                                                    'secretKeyRef': {
+                                                        'name': 'torghut-db-app',
+                                                        'key': 'password',
+                                                    }
+                                                },
+                                            },
+                                            {
+                                                'name': 'DB_DSN',
+                                                'value': 'postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default',
+                                            },
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                }
+            if args[:3] == ['get', 'secret', 'torghut-db-app']:
+                encoded = {
+                    'host': 'ZGIuZXhhbXBsZQ==',
+                    'port': 'NTQzMg==',
+                    'username': 'dG9yZ2h1dF9hcHA=',
+                    'password': 'YXBwLXNlY3JldA==',
+                }
+                return {'data': encoded}
+            raise AssertionError(f'unexpected kubectl args: {args}')
+
+        with patch('scripts.start_historical_simulation._kubectl_json', side_effect=_kubectl_json_side_effect):
+            resolved = _resolve_warm_lane_runtime_postgres_config(
+                resources=resources,
+                postgres_config=postgres_config,
+            )
+
+        self.assertEqual(
+            resolved.torghut_runtime_dsn,
+            'postgresql://torghut_app:app-secret@db.example:5432/torghut_sim_default',
+        )
+
+    def test_apply_uses_resolved_warm_lane_runtime_dsn_for_permissions_and_migrations(self) -> None:
+        resources = _build_resources(
+            'sim-1',
+            {
+                'dataset_id': 'dataset-a',
+                'runtime': {'use_warm_lane': True},
+            },
+        )
+        kafka_config = KafkaRuntimeConfig(
+            bootstrap_servers='kafka:9092',
+            security_protocol=None,
+            sasl_mechanism=None,
+            sasl_username=None,
+            sasl_password=None,
+        )
+        clickhouse_config = ClickHouseRuntimeConfig(
+            http_url='http://clickhouse:8123',
+            username='torghut',
+            password='secret',
+        )
+        postgres_config = PostgresRuntimeConfig(
+            admin_dsn='postgresql://postgres:secret@localhost:5432/postgres',
+            simulation_dsn='postgresql://postgres:secret@localhost:5432/torghut_sim_default',
+            simulation_db='torghut_sim_default',
+            migrations_command='true',
+        )
+        runtime_config = replace(
+            postgres_config,
+            runtime_simulation_dsn='postgresql://torghut_app:secret@localhost:5432/torghut_sim_default',
+        )
+        manifest = {
+            'dataset_id': 'dataset-a',
+            'runtime': {'use_warm_lane': True},
+            'clickhouse': {'database_precreated': True},
+            'postgres': {'database_precreated': True},
+            'window': {
+                'start': '2026-02-27T14:30:00Z',
+                'end': '2026-02-27T15:30:00Z',
+            },
+        }
+
+        with TemporaryDirectory() as tmpdir:
+            resources = replace(resources, output_root=Path(tmpdir))
+            with (
+                patch('scripts.start_historical_simulation._ensure_supported_binary', return_value=None),
+                patch('scripts.start_historical_simulation._ensure_lz4_codec_available', return_value=None),
+                patch(
+                    'scripts.start_historical_simulation._acquire_simulation_runtime_lock',
+                    return_value={'status': 'acquired', 'run_id': resources.run_id},
+                ),
+                patch(
+                    'scripts.start_historical_simulation._capture_cluster_state',
+                    return_value={'ta_data': {'TA_GROUP_ID': 'torghut-ta-sim-default'}},
+                ),
+                patch('scripts.start_historical_simulation._ensure_topics', return_value={'status': 'ok'}),
+                patch('scripts.start_historical_simulation._ensure_clickhouse_runtime_tables', return_value=None),
+                patch(
+                    'scripts.start_historical_simulation._ensure_postgres_runtime_permissions',
+                    return_value={'grants_applied': True},
+                ) as ensure_permissions,
+                patch('scripts.start_historical_simulation._run_migrations', return_value=None) as run_migrations,
+                patch('scripts.start_historical_simulation._reset_postgres_runtime_state', return_value=None) as reset_runtime_state,
+                patch(
+                    'scripts.start_historical_simulation._seed_simulation_trade_cursor',
+                    return_value=datetime(2026, 2, 27, 14, 30, tzinfo=timezone.utc),
+                ),
+                patch(
+                    'scripts.start_historical_simulation._dump_topics',
+                    return_value={'records': 1, 'sha256': 'abc'},
+                ),
+                patch(
+                    'scripts.start_historical_simulation._validate_dump_coverage',
+                    return_value={'coverage_ratio': 1.0},
+                ),
+            ):
+                start_historical_simulation._apply(
+                    resources=resources,
+                    manifest=manifest,
+                    kafka_config=kafka_config,
+                    clickhouse_config=clickhouse_config,
+                    postgres_config=runtime_config,
+                    force_dump=False,
+                    force_replay=False,
+                )
+
+        ensure_permissions.assert_called_once_with(runtime_config)
+        run_migrations.assert_called_once_with(runtime_config)
+        reset_runtime_state.assert_called_once_with(runtime_config)
 
     def test_apply_uses_stateless_ta_restart_when_manifest_requests_it(self) -> None:
         resources = _build_resources('sim-1', {'dataset_id': 'dataset-a'})


### PR DESCRIPTION
## Summary

- resolve warm-lane runtime Postgres DSNs from the live `torghut-sim` service environment instead of defaulting to the admin user
- use the resolved runtime DSN when granting permissions and running migrations so warm-lane replays target the actual service role
- add regression coverage for KService env resolution and warm-lane runtime DSN usage in the simulation launcher

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_start_historical_simulation.py -k 'warm_lane_runtime_dsn or warm_lane_runtime or seed_simulation_trade_cursor' -q`
- `cd services/torghut && uv run --frozen ruff check scripts/start_historical_simulation.py tests/test_start_historical_simulation.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
