### PR TITLE
chore(torghut): promote image d36b3c18

### DIFF
--- a/argocd/applications/torghut-forecast/deployment.yaml
+++ b/argocd/applications/torghut-forecast/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: forecast
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:1c8b3d57e51b299f8560b295cb53a357f443f6d2cc05e07c1d5723bcaeb4f801
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:ebe0d44efa888b388474cbb29cfb928c59a74c7f11e5cc9c2223cea7a1d0a783
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn

--- a/argocd/applications/torghut-forecast/sim/deployment.yaml
+++ b/argocd/applications/torghut-forecast/sim/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: forecast
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:1c8b3d57e51b299f8560b295cb53a357f443f6d2cc05e07c1d5723bcaeb4f801
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:ebe0d44efa888b388474cbb29cfb928c59a74c7f11e5cc9c2223cea7a1d0a783
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn

--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:1c8b3d57e51b299f8560b295cb53a357f443f6d2cc05e07c1d5723bcaeb4f801
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:ebe0d44efa888b388474cbb29cfb928c59a74c7f11e5cc9c2223cea7a1d0a783
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -63,9 +63,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.564.0-95-g58b4c069
+              value: v0.564.0-99-gd36b3c18
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 58b4c069582242102597d2edd36ee35d55d43f0f
+              value: d36b3c18a8a695ed67d8db571d12e37135188a49
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:1c8b3d57e51b299f8560b295cb53a357f443f6d2cc05e07c1d5723bcaeb4f801
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:ebe0d44efa888b388474cbb29cfb928c59a74c7f11e5cc9c2223cea7a1d0a783
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -63,9 +63,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.564.0-95-g58b4c069
+              value: v0.564.0-99-gd36b3c18
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 58b4c069582242102597d2edd36ee35d55d43f0f
+              value: d36b3c18a8a695ed67d8db571d12e37135188a49
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -40,7 +40,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:1c8b3d57e51b299f8560b295cb53a357f443f6d2cc05e07c1d5723bcaeb4f801
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:ebe0d44efa888b388474cbb29cfb928c59a74c7f11e5cc9c2223cea7a1d0a783
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -21,7 +21,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:1c8b3d57e51b299f8560b295cb53a357f443f6d2cc05e07c1d5723bcaeb4f801
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:ebe0d44efa888b388474cbb29cfb928c59a74c7f11e5cc9c2223cea7a1d0a783
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -32,7 +32,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:1c8b3d57e51b299f8560b295cb53a357f443f6d2cc05e07c1d5723bcaeb4f801
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:ebe0d44efa888b388474cbb29cfb928c59a74c7f11e5cc9c2223cea7a1d0a783
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -30,7 +30,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:1c8b3d57e51b299f8560b295cb53a357f443f6d2cc05e07c1d5723bcaeb4f801
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:ebe0d44efa888b388474cbb29cfb928c59a74c7f11e5cc9c2223cea7a1d0a783
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:1c8b3d57e51b299f8560b295cb53a357f443f6d2cc05e07c1d5723bcaeb4f801
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:ebe0d44efa888b388474cbb29cfb928c59a74c7f11e5cc9c2223cea7a1d0a783
           command:
             - alembic
           args:

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -13,7 +13,7 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:1c8b3d57e51b299f8560b295cb53a357f443f6d2cc05e07c1d5723bcaeb4f801
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:ebe0d44efa888b388474cbb29cfb928c59a74c7f11e5cc9c2223cea7a1d0a783
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -21,7 +21,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:1c8b3d57e51b299f8560b295cb53a357f443f6d2cc05e07c1d5723bcaeb4f801
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:ebe0d44efa888b388474cbb29cfb928c59a74c7f11e5cc9c2223cea7a1d0a783
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -39,7 +39,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:1c8b3d57e51b299f8560b295cb53a357f443f6d2cc05e07c1d5723bcaeb4f801
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:ebe0d44efa888b388474cbb29cfb928c59a74c7f11e5cc9c2223cea7a1d0a783
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-03-13T16:54:26Z"
+        client.knative.dev/updateTimestamp: "2026-03-13T17:16:21Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:1c8b3d57e51b299f8560b295cb53a357f443f6d2cc05e07c1d5723bcaeb4f801
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:ebe0d44efa888b388474cbb29cfb928c59a74c7f11e5cc9c2223cea7a1d0a783
           ports:
             - name: http1
               containerPort: 8181
@@ -519,9 +519,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.564.0-95-g58b4c069
+              value: v0.564.0-99-gd36b3c18
             - name: TORGHUT_COMMIT
-              value: 58b4c069582242102597d2edd36ee35d55d43f0f
+              value: d36b3c18a8a695ed67d8db571d12e37135188a49
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-03-13T16:54:26Z"
+        client.knative.dev/updateTimestamp: "2026-03-13T17:16:21Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -26,7 +26,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:1c8b3d57e51b299f8560b295cb53a357f443f6d2cc05e07c1d5723bcaeb4f801
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:ebe0d44efa888b388474cbb29cfb928c59a74c7f11e5cc9c2223cea7a1d0a783
           ports:
             - name: http1
               containerPort: 8181
@@ -462,9 +462,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.564.0-95-g58b4c069
+              value: v0.564.0-99-gd36b3c18
             - name: TORGHUT_COMMIT
-              value: 58b4c069582242102597d2edd36ee35d55d43f0f
+              value: d36b3c18a8a695ed67d8db571d12e37135188a49
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/lean-runner-deployment.yaml
+++ b/argocd/applications/torghut/lean-runner-deployment.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: lean-runner
           # Keep in lockstep with `argocd/applications/torghut/knative-service.yaml`.
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:1c8b3d57e51b299f8560b295cb53a357f443f6d2cc05e07c1d5723bcaeb4f801
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:ebe0d44efa888b388474cbb29cfb928c59a74c7f11e5cc9c2223cea7a1d0a783
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `d36b3c18a8a695ed67d8db571d12e37135188a49`
- Image tag: `d36b3c18`
- Image digest: `sha256:ebe0d44efa888b388474cbb29cfb928c59a74c7f11e5cc9c2223cea7a1d0a783`