### PR TITLE
fix(keycloak): add headlamp audience mapper

### DIFF
--- a/argocd/applications/keycloak/headlamp-client-bootstrap-job.yaml
+++ b/argocd/applications/keycloak/headlamp-client-bootstrap-job.yaml
@@ -83,6 +83,23 @@ spec:
               }
               EOF
 
+              cat > /tmp/kubernetes-audience-mapper.json <<EOF
+              {
+                "name": "kubernetes-audience",
+                "protocol": "openid-connect",
+                "protocolMapper": "oidc-audience-mapper",
+                "consentRequired": false,
+                "config": {
+                  "included.client.audience": "${HEADLAMP_OIDC_CLIENT_ID}",
+                  "access.token.claim": "true",
+                  "id.token.claim": "false",
+                  "userinfo.token.claim": "false",
+                  "introspection.token.claim": "true",
+                  "lightweight.claim": "false"
+                }
+              }
+              EOF
+
               client_resource_id="$(
                 /opt/keycloak/bin/kcadm.sh get clients \
                   --config "$KCADM_CONFIG" \
@@ -130,6 +147,31 @@ spec:
                 --config "$KCADM_CONFIG" \
                 -r "$KEYCLOAK_REALM" \
                 -s "secret=${HEADLAMP_OIDC_CLIENT_SECRET}"
+
+              mapper_resource_id="$(
+                /opt/keycloak/bin/kcadm.sh get "clients/$client_resource_id/protocol-mappers/models" \
+                  --config "$KCADM_CONFIG" \
+                  -r "$KEYCLOAK_REALM" \
+                  --fields id,name \
+                  --format csv \
+                  --noquotes \
+                  | tr -d '\r' \
+                  | awk -F, '$2=="kubernetes-audience"{print $1; exit}'
+              )"
+
+              if [ -n "$mapper_resource_id" ]; then
+                /opt/keycloak/bin/kcadm.sh update "clients/$client_resource_id/protocol-mappers/models/$mapper_resource_id" \
+                  --config "$KCADM_CONFIG" \
+                  -r "$KEYCLOAK_REALM" \
+                  --merge \
+                  -f /tmp/kubernetes-audience-mapper.json
+              else
+                /opt/keycloak/bin/kcadm.sh create "clients/$client_resource_id/protocol-mappers/models" \
+                  --config "$KCADM_CONFIG" \
+                  -r "$KEYCLOAK_REALM" \
+                  -f /tmp/kubernetes-audience-mapper.json \
+                  >/dev/null
+              fi
 
               echo "Configured Keycloak client ${HEADLAMP_OIDC_CLIENT_ID} in realm ${KEYCLOAK_REALM}"
           securityContext:

--- a/docs/headlamp-setup.md
+++ b/docs/headlamp-setup.md
@@ -86,6 +86,9 @@ is omitted, so the same deployment can complete OIDC flows on both the Tailscale
 For OIDC-backed cluster watches, logs, exec, and port-forward websocket upgrades, keep
 `OIDC_USE_ACCESS_TOKEN=true` in the Headlamp deployment env. Without it, ordinary REST
 requests may work while websocket watches fail with `1006` and repeated `401` health checks.
+That mode also requires the Keycloak `kubernetes` client to emit the access token with audience
+`kubernetes`, which the GitOps bootstrap job now enforces via the `kubernetes-audience`
+protocol mapper.
 
 Commit and sync the Keycloak and Headlamp Argo CD apps.
 
@@ -175,6 +178,7 @@ Make sure the Keycloak groups mapper is configured so the `groups` claim is pres
 
 - **401 Unauthorized**: kube-apiserver OIDC config missing or mismatched (issuer/client-id/CA).
 - **WebSocket watches fail (`1006`) or `/clusters/<name>/healthz` loops on 401**: make sure Headlamp is started with `OIDC_USE_ACCESS_TOKEN=true` so it can authenticate websocket upgrades for OIDC-backed clusters.
+- **WebSocket watches still fail after enabling `OIDC_USE_ACCESS_TOKEN=true`**: confirm the Keycloak `kubernetes` client access token includes audience `kubernetes`. Without that mapper, Headlamp can log in but kube-apiserver rejects the bearer token on watch and health endpoints.
 - **403 Forbidden**: RBAC missing. Add/update `headlamp-oidc-rbac.yaml` and sync Argo CD.
 - **Redirect always goes to the Tailscale hostname**: the running Headlamp deployment still has a fixed `-oidc-callback-url`. Sync the updated Headlamp manifests so it can derive the callback from the request host.
 - **Sign-in gets stuck on `/auth?cluster=...`**: sync the `headlamp-auth-bridge` resources and the patched Tailscale Ingress. The bridge page forces the popup flow to hand control back to the main Headlamp window even if Headlamp misses the original storage-event handoff.

--- a/docs/keycloak-oidc.md
+++ b/docs/keycloak-oidc.md
@@ -74,6 +74,9 @@ Issuer and scopes:
 - Issuer: Realm → **Realm settings** → **Endpoints** → **OpenID Endpoint Configuration** (`issuer`)
 - Scopes: `openid profile email`
 - The kube-apiserver on `galactic` binds Kubernetes usernames from the OIDC `preferred_username` claim with the `oidc:` prefix, so RBAC subjects should look like `oidc:<preferred_username>`.
+- The GitOps bootstrap job also enforces a `kubernetes-audience` protocol mapper so access tokens
+  include audience `kubernetes`, which Headlamp needs when it uses the OIDC access token for
+  websocket watches, logs, exec, and port-forward traffic.
 
 Optional (recommended) group mapper:
 


### PR DESCRIPTION
## Summary

- add an idempotent `kubernetes-audience` protocol mapper to the Keycloak Headlamp bootstrap job
- keep the Headlamp OIDC runbooks aligned with the audience-mapper requirement for access-token-based websocket traffic
- make the Keycloak bootstrap enforce the audience claim on every Argo sync instead of relying on a live-only hotfix

## Related Issues

None

## Testing

- `kubectl kustomize argocd/applications/keycloak >/tmp/keycloak-render.yaml && rg -n "kubernetes-audience|oidc-audience-mapper|headlamp-client-bootstrap" /tmp/keycloak-render.yaml`
- manual Keycloak validation with `kcadm.sh` to confirm the live `kubernetes` client exposes the `kubernetes-audience` mapper after bootstrap logic was added
- live browser validation on `https://headlamp.k8s.proompteng.ai/c/main/workloads` to confirm the audience claim fix removed the earlier `expected audience "kubernetes"` failure and isolated the remaining websocket-auth defect to Headlamp runtime behavior

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
