### PR TITLE
chore(jangar): promote image 71749d29

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: ed4dcf14
-  digest: sha256:52a4a3b1df44e34af38c3e6408f7e0553fac2b32989fd57ef8ea8484fc29ee69
+  tag: 71749d29
+  digest: sha256:8347590a2af61850cac92cb8e37273c2796f888d5b5224eff6ccea9ae22e8d7c
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: ed4dcf14
-    digest: sha256:19e4ab5313dda59110f0917319e8b8f0625aa7c8a09c2f796eb0a1932e3ec8c6
+    tag: 71749d29
+    digest: sha256:91c6a929a87e50b4c71cc5fa18ced3785689c4aedee4dd4b1f64e6b72d724659
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: ed4dcf14
-    digest: sha256:52a4a3b1df44e34af38c3e6408f7e0553fac2b32989fd57ef8ea8484fc29ee69
+    tag: 71749d29
+    digest: sha256:8347590a2af61850cac92cb8e37273c2796f888d5b5224eff6ccea9ae22e8d7c
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-13T16:24:53Z"
+    deploy.knative.dev/rollout: "2026-03-13T17:42:40Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-13T16:24:53Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-13T17:42:40Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -62,5 +62,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "ed4dcf14"
-    digest: sha256:52a4a3b1df44e34af38c3e6408f7e0553fac2b32989fd57ef8ea8484fc29ee69
+    newTag: "71749d29"
+    digest: sha256:8347590a2af61850cac92cb8e37273c2796f888d5b5224eff6ccea9ae22e8d7c


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `71749d29c649b09db3b9e34c09b4db97ff3ac13b`
- Image tag: `71749d29`
- Image digest: `sha256:8347590a2af61850cac92cb8e37273c2796f888d5b5224eff6ccea9ae22e8d7c`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`