### PR TITLE
fix(torghut): bind warm-lane service to simulation run

### DIFF
--- a/services/torghut/scripts/start_historical_simulation.py
+++ b/services/torghut/scripts/start_historical_simulation.py
@@ -4810,15 +4810,14 @@ def _apply(
             upgrade_mode=str(ta_restore.get('effective_upgrade_mode') or 'last-state'),
         )
 
-        if not warm_lane_enabled:
-            _configure_torghut_service_for_simulation(
-                resources=resources,
-                manifest=manifest,
-                postgres_config=postgres_config,
-                clickhouse_config=clickhouse_config,
-                kafka_config=kafka_config,
-                torghut_env_overrides=torghut_env_overrides,
-            )
+        _configure_torghut_service_for_simulation(
+            resources=resources,
+            manifest=manifest,
+            postgres_config=postgres_config,
+            clickhouse_config=clickhouse_config,
+            kafka_config=kafka_config,
+            torghut_env_overrides=torghut_env_overrides,
+        )
     except Exception:
         _release_simulation_runtime_lock(resources=resources)
         raise
@@ -4917,13 +4916,9 @@ def _teardown(
 
     state = _load_json(state_path)
     _restore_ta_configuration(resources, state)
-    if warm_lane_enabled:
-        original_state = _as_text(state.get('ta_job_state')) or 'running'
-        ta_restart_nonce = _restart_ta_deployment(resources, desired_state=original_state)
-    else:
-        _restore_torghut_env(resources, state)
-        original_state = _as_text(state.get('ta_job_state')) or 'running'
-        ta_restart_nonce = _restart_ta_deployment(resources, desired_state=original_state)
+    _restore_torghut_env(resources, state)
+    original_state = _as_text(state.get('ta_job_state')) or 'running'
+    ta_restart_nonce = _restart_ta_deployment(resources, desired_state=original_state)
     lock_report = _release_simulation_runtime_lock(resources=resources)
     report = {
         'status': 'ok',

--- a/services/torghut/tests/test_start_historical_simulation.py
+++ b/services/torghut/tests/test_start_historical_simulation.py
@@ -1285,7 +1285,7 @@ class TestStartHistoricalSimulation(TestCase):
 
         configure_ta.assert_called_once()
         restart_ta.assert_called_once()
-        configure_service.assert_not_called()
+        configure_service.assert_called_once()
         self.assertTrue(report['warm_lane_enabled'])
         self.assertEqual(report['seeded_cursor_at'], '2026-02-27T14:30:00+00:00')
 
@@ -3386,7 +3386,7 @@ class TestStartHistoricalSimulation(TestCase):
                 )
 
         restore_ta.assert_called_once_with(resources, {'ta_job_state': 'running'})
-        restore_env.assert_not_called()
+        restore_env.assert_called_once_with(resources, {'ta_job_state': 'running'})
         restart_ta.assert_called_once_with(resources, desired_state='running')
         release_lock.assert_called_once_with(resources=resources)
         self.assertTrue(report['warm_lane_enabled'])


### PR DESCRIPTION
## Summary

- reconfigure `torghut-sim` for each warm-lane simulation run instead of only patching TA
- restore the warm-lane `torghut-sim` environment during teardown so shared simulation services return to their baseline config
- add regression coverage for warm-lane apply and teardown so the service binding cannot silently regress again

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_start_historical_simulation.py -k 'warm_lane or restore_torghut_env' -q`
- `cd services/torghut && uv run --frozen pytest tests/test_start_historical_simulation.py tests/test_run_simulation_analysis.py -q`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
