### PR TITLE
chore(torghut): promote image 17d6df59

### DIFF
--- a/argocd/applications/torghut-forecast/deployment.yaml
+++ b/argocd/applications/torghut-forecast/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: forecast
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:b68073384a7243bd0ef9e148ae5534857eccaed1a415c7e4468e6895cca5a627
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:08005b8d90504f4034106dd7f9c674a37664c786e48931f15a6b62f22e5e69dd
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn

--- a/argocd/applications/torghut-forecast/sim/deployment.yaml
+++ b/argocd/applications/torghut-forecast/sim/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: forecast
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:b68073384a7243bd0ef9e148ae5534857eccaed1a415c7e4468e6895cca5a627
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:08005b8d90504f4034106dd7f9c674a37664c786e48931f15a6b62f22e5e69dd
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn

--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:b68073384a7243bd0ef9e148ae5534857eccaed1a415c7e4468e6895cca5a627
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:08005b8d90504f4034106dd7f9c674a37664c786e48931f15a6b62f22e5e69dd
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -63,9 +63,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.564.0-106-g401b338c
+              value: v0.564.0-108-g17d6df59
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 401b338c1c3ca55b6bbaebbcfc207c354d2479c9
+              value: 17d6df5963e928a266c52a3865fcb2fbfe0b1d60
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:b68073384a7243bd0ef9e148ae5534857eccaed1a415c7e4468e6895cca5a627
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:08005b8d90504f4034106dd7f9c674a37664c786e48931f15a6b62f22e5e69dd
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -63,9 +63,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.564.0-106-g401b338c
+              value: v0.564.0-108-g17d6df59
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 401b338c1c3ca55b6bbaebbcfc207c354d2479c9
+              value: 17d6df5963e928a266c52a3865fcb2fbfe0b1d60
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -40,7 +40,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:b68073384a7243bd0ef9e148ae5534857eccaed1a415c7e4468e6895cca5a627
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:08005b8d90504f4034106dd7f9c674a37664c786e48931f15a6b62f22e5e69dd
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -21,7 +21,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:b68073384a7243bd0ef9e148ae5534857eccaed1a415c7e4468e6895cca5a627
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:08005b8d90504f4034106dd7f9c674a37664c786e48931f15a6b62f22e5e69dd
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -32,7 +32,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:b68073384a7243bd0ef9e148ae5534857eccaed1a415c7e4468e6895cca5a627
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:08005b8d90504f4034106dd7f9c674a37664c786e48931f15a6b62f22e5e69dd
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -30,7 +30,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:b68073384a7243bd0ef9e148ae5534857eccaed1a415c7e4468e6895cca5a627
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:08005b8d90504f4034106dd7f9c674a37664c786e48931f15a6b62f22e5e69dd
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:b68073384a7243bd0ef9e148ae5534857eccaed1a415c7e4468e6895cca5a627
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:08005b8d90504f4034106dd7f9c674a37664c786e48931f15a6b62f22e5e69dd
           command:
             - alembic
           args:

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -13,7 +13,7 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:b68073384a7243bd0ef9e148ae5534857eccaed1a415c7e4468e6895cca5a627
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:08005b8d90504f4034106dd7f9c674a37664c786e48931f15a6b62f22e5e69dd
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -21,7 +21,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:b68073384a7243bd0ef9e148ae5534857eccaed1a415c7e4468e6895cca5a627
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:08005b8d90504f4034106dd7f9c674a37664c786e48931f15a6b62f22e5e69dd
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -39,7 +39,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:b68073384a7243bd0ef9e148ae5534857eccaed1a415c7e4468e6895cca5a627
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:08005b8d90504f4034106dd7f9c674a37664c786e48931f15a6b62f22e5e69dd
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-03-13T18:51:00Z"
+        client.knative.dev/updateTimestamp: "2026-03-13T19:31:26Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:b68073384a7243bd0ef9e148ae5534857eccaed1a415c7e4468e6895cca5a627
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:08005b8d90504f4034106dd7f9c674a37664c786e48931f15a6b62f22e5e69dd
           ports:
             - name: http1
               containerPort: 8181
@@ -519,9 +519,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.564.0-106-g401b338c
+              value: v0.564.0-108-g17d6df59
             - name: TORGHUT_COMMIT
-              value: 401b338c1c3ca55b6bbaebbcfc207c354d2479c9
+              value: 17d6df5963e928a266c52a3865fcb2fbfe0b1d60
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-03-13T18:51:00Z"
+        client.knative.dev/updateTimestamp: "2026-03-13T19:31:26Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -26,7 +26,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:b68073384a7243bd0ef9e148ae5534857eccaed1a415c7e4468e6895cca5a627
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:08005b8d90504f4034106dd7f9c674a37664c786e48931f15a6b62f22e5e69dd
           ports:
             - name: http1
               containerPort: 8181
@@ -462,9 +462,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.564.0-106-g401b338c
+              value: v0.564.0-108-g17d6df59
             - name: TORGHUT_COMMIT
-              value: 401b338c1c3ca55b6bbaebbcfc207c354d2479c9
+              value: 17d6df5963e928a266c52a3865fcb2fbfe0b1d60
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/lean-runner-deployment.yaml
+++ b/argocd/applications/torghut/lean-runner-deployment.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: lean-runner
           # Keep in lockstep with `argocd/applications/torghut/knative-service.yaml`.
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:b68073384a7243bd0ef9e148ae5534857eccaed1a415c7e4468e6895cca5a627
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:08005b8d90504f4034106dd7f9c674a37664c786e48931f15a6b62f22e5e69dd
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `17d6df5963e928a266c52a3865fcb2fbfe0b1d60`
- Image tag: `17d6df59`
- Image digest: `sha256:08005b8d90504f4034106dd7f9c674a37664c786e48931f15a6b62f22e5e69dd`