### PR TITLE
chore(argocd): upgrade headlamp and keycloak

### DIFF
--- a/argocd/applications/headlamp/kustomization.yaml
+++ b/argocd/applications/headlamp/kustomization.yaml
@@ -14,7 +14,7 @@ patches:
 helmCharts:
   - name: headlamp
     repo: https://kubernetes-sigs.github.io/headlamp
-    version: 0.40.0
+    version: 0.40.1
     releaseName: headlamp
     namespace: headlamp
     valuesFile: values.yaml

--- a/argocd/applications/keycloak/headlamp-client-bootstrap-job.yaml
+++ b/argocd/applications/keycloak/headlamp-client-bootstrap-job.yaml
@@ -23,7 +23,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: bootstrap
-          image: quay.io/keycloak/keycloak:26.4.7
+          image: quay.io/keycloak/keycloak:26.5.1
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/keycloak/keycloak.yaml
+++ b/argocd/applications/keycloak/keycloak.yaml
@@ -49,7 +49,7 @@ spec:
     spec:
       containers:
         - name: keycloak
-          image: quay.io/keycloak/keycloak:26.4.7
+          image: quay.io/keycloak/keycloak:26.5.1
           args: ["start"]
           env:
             - name: KC_BOOTSTRAP_ADMIN_USERNAME


### PR DESCRIPTION
## Summary

- bump the Headlamp Helm chart from 0.40.0 to 0.40.1 so the rendered app matches the latest upstream release
- bump the Keycloak StatefulSet image from 26.4.7 to 26.5.1
- keep the Keycloak Headlamp client bootstrap job on the same 26.5.1 image as the server deployment

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/headlamp > /tmp/headlamp-render.yaml && rg -n "chart:|app.kubernetes.io/version|image:|tag:" /tmp/headlamp-render.yaml | head -n 20`
- `kubectl kustomize argocd/applications/keycloak > /tmp/keycloak-render.yaml && rg -n "quay.io/keycloak/keycloak|image:" /tmp/keycloak-render.yaml | head -n 20`
- `curl -fsSL 'https://quay.io/api/v1/repository/keycloak/keycloak/tag/?onlyActiveTags=true&limit=100' | jq -r '.tags[] | select(.name=="26.5.1") | .name'`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
