### PR TITLE
fix(torghut): bound warm-lane simulation cursor to replay window

### DIFF
--- a/services/torghut/app/trading/ingest.py
+++ b/services/torghut/app/trading/ingest.py
@@ -19,6 +19,7 @@ from ..models import TradeCursor
 from .clickhouse import normalize_symbol, to_datetime64
 from .models import SignalEnvelope
 from .simulation import resolve_simulation_context, signal_ingest_runtime, simulation_context_enabled
+from .simulation_window import normalize_simulation_cursor, simulation_window_bounds
 from .time_source import trading_now
 
 logger = logging.getLogger(__name__)
@@ -195,18 +196,31 @@ class ClickHouseSignalIngestor:
         fast_forwarded: bool,
     ) -> "SignalBatch":
         query_window_start = cursor_at
-        if latest_signal_at is None:
+        _window_start, simulation_window_end = simulation_window_bounds()
+        effective_latest_signal_at = latest_signal_at
+        if (
+            simulation_window_end is not None
+            and effective_latest_signal_at is not None
+            and effective_latest_signal_at > simulation_window_end
+        ):
+            effective_latest_signal_at = simulation_window_end
+
+        if effective_latest_signal_at is None:
             query_window_end = query_window_start + _simulation_fetch_window()
+            if simulation_window_end is not None:
+                query_window_end = min(query_window_end, simulation_window_end)
         else:
-            effective_end = latest_signal_at or poll_started_at
+            effective_end = effective_latest_signal_at
             query_window_end = min(
                 max(query_window_start, effective_end),
                 query_window_start + _simulation_fetch_window(),
             )
+            if simulation_window_end is not None:
+                query_window_end = min(query_window_end, simulation_window_end)
         if query_window_end <= query_window_start:
             lag = (
-                max(0.0, (poll_started_at - latest_signal_at).total_seconds())
-                if latest_signal_at is not None
+                max(0.0, (poll_started_at - effective_latest_signal_at).total_seconds())
+                if effective_latest_signal_at is not None
                 else None
             )
             return SignalBatch(
@@ -217,7 +231,7 @@ class ClickHouseSignalIngestor:
                 query_start=query_window_start,
                 query_end=query_window_end,
                 signal_lag_seconds=lag,
-                no_signal_reason="cursor_tail_stable" if latest_signal_at is not None else "no_signals_in_window",
+                no_signal_reason="cursor_tail_stable" if effective_latest_signal_at is not None else "no_signals_in_window",
             )
 
         time_column = _safe_identifier(self._resolve_time_column(), kind='column')
@@ -262,8 +276,20 @@ class ClickHouseSignalIngestor:
                 no_signal_reason=None,
             )
 
-        if latest_signal_at is not None and query_window_end >= latest_signal_at:
-            lag = max(0.0, (poll_started_at - latest_signal_at).total_seconds())
+        if effective_latest_signal_at is None:
+            return SignalBatch(
+                signals=[],
+                cursor_at=query_window_start,
+                cursor_seq=cursor_seq if fast_forwarded else None,
+                cursor_symbol=cursor_symbol if fast_forwarded else None,
+                query_start=query_window_start,
+                query_end=query_window_end,
+                signal_lag_seconds=None,
+                no_signal_reason="no_signals_in_window",
+            )
+
+        if query_window_end >= effective_latest_signal_at:
+            lag = max(0.0, (poll_started_at - effective_latest_signal_at).total_seconds())
             return SignalBatch(
                 signals=[],
                 cursor_at=query_window_end,
@@ -636,21 +662,31 @@ class ClickHouseSignalIngestor:
             order_clause = f'{safe_time_column} DESC, symbol DESC, seq DESC'
         elif time_column == 'ts':
             order_clause = f'{safe_time_column} DESC, symbol DESC'
-        queries.append(
-            ' '.join(
-                [
-                    'SELECT',
-                    f'{safe_time_column} AS latest_signal_ts',
-                    'FROM',
-                    self.table,
-                    'ORDER BY',
-                    order_clause,
-                    'LIMIT',
-                    '1',
-                    'FORMAT JSONEachRow',
-                ]
-            )
+        query_parts = [
+            'SELECT',
+            f'{safe_time_column} AS latest_signal_ts',
+            'FROM',
+            self.table,
+        ]
+        if self.simulation_mode:
+            window_start, window_end = simulation_window_bounds()
+            where_parts: list[str] = []
+            if window_start is not None:
+                where_parts.append(f'{safe_time_column} >= {to_datetime64(window_start)}')
+            if window_end is not None:
+                where_parts.append(f'{safe_time_column} <= {to_datetime64(window_end)}')
+            if where_parts:
+                query_parts.extend(['WHERE', ' AND '.join(where_parts)])
+        query_parts.extend(
+            [
+                'ORDER BY',
+                order_clause,
+                'LIMIT',
+                '1',
+                'FORMAT JSONEachRow',
+            ]
         )
+        queries.append(' '.join(query_parts))
         return queries
 
     def commit_cursor(self, session: Session, batch: "SignalBatch") -> None:
@@ -976,6 +1012,10 @@ class ClickHouseSignalIngestor:
                 cursor_at = cursor_at.replace(tzinfo=timezone.utc)
             if self.simulation_mode and cursor_at <= SIMULATION_CURSOR_BASELINE:
                 return trading_now(account_label=self.account_label), None, None
+            if self.simulation_mode:
+                normalized_cursor = normalize_simulation_cursor(cursor_at)
+                if normalized_cursor is not None and normalized_cursor != cursor_at:
+                    return normalized_cursor, None, None
             return cursor_at, cursor_row.cursor_seq, cursor_row.cursor_symbol
 
         if self.simulation_mode:

--- a/services/torghut/app/trading/simulation_window.py
+++ b/services/torghut/app/trading/simulation_window.py
@@ -1,0 +1,45 @@
+"""Shared helpers for simulation-window bounded runtime behavior."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from ..config import settings
+
+
+def _parse_datetime(raw: str | None) -> datetime | None:
+    value = (raw or '').strip()
+    if not value:
+        return None
+    normalized = f'{value[:-1]}+00:00' if value.endswith('Z') else value
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def simulation_window_bounds() -> tuple[datetime | None, datetime | None]:
+    if not settings.trading_simulation_enabled:
+        return None, None
+    start = _parse_datetime(settings.trading_simulation_window_start)
+    end = _parse_datetime(settings.trading_simulation_window_end)
+    if start is not None and end is not None and end < start:
+        end = start
+    return start, end
+
+
+def normalize_simulation_cursor(cursor_at: datetime | None) -> datetime | None:
+    if cursor_at is None:
+        return None
+    start, end = simulation_window_bounds()
+    if start is not None and cursor_at < start:
+        return start
+    if end is not None and cursor_at > end:
+        return start or end
+    return cursor_at
+
+
+__all__ = ['normalize_simulation_cursor', 'simulation_window_bounds']

--- a/services/torghut/app/trading/time_source.py
+++ b/services/torghut/app/trading/time_source.py
@@ -12,22 +12,9 @@ from sqlalchemy import select
 from ..config import settings
 from ..db import SessionLocal
 from ..models import TradeCursor
+from .simulation_window import normalize_simulation_cursor, simulation_window_bounds
 
 _SIMULATION_CURSOR_BASELINE = datetime(1970, 1, 1, tzinfo=timezone.utc)
-
-
-def _parse_datetime(raw: str | None) -> datetime | None:
-    value = (raw or "").strip()
-    if not value:
-        return None
-    normalized = f"{value[:-1]}+00:00" if value.endswith("Z") else value
-    try:
-        parsed = datetime.fromisoformat(normalized)
-    except ValueError:
-        return None
-    if parsed.tzinfo is None:
-        parsed = parsed.replace(tzinfo=timezone.utc)
-    return parsed.astimezone(timezone.utc)
 
 
 @dataclass(frozen=True)
@@ -88,10 +75,11 @@ class TradingTimeSource:
     def _resolve_simulation_snapshot(
         self, *, account_label: str | None = None
     ) -> TradingTimeSnapshot:
-        start = _parse_datetime(settings.trading_simulation_window_start)
+        start, _end = simulation_window_bounds()
         account = self._effective_account_label(account_label=account_label)
-        cursor_at = self._load_clickhouse_cursor(account_label=account)
-        if cursor_at is not None:
+        raw_cursor_at = self._load_clickhouse_cursor(account_label=account)
+        cursor_at = normalize_simulation_cursor(raw_cursor_at)
+        if raw_cursor_at is not None and cursor_at is not None and cursor_at == raw_cursor_at:
             return TradingTimeSnapshot(
                 mode="simulation_cursor",
                 now=cursor_at,
@@ -104,6 +92,13 @@ class TradingTimeSource:
                 now=start,
                 source="window_start",
                 cursor_at=None,
+            )
+        if cursor_at is not None:
+            return TradingTimeSnapshot(
+                mode="simulation_cursor",
+                now=cursor_at,
+                source="trade_cursor.normalized",
+                cursor_at=cursor_at,
             )
         now = datetime.now(timezone.utc)
         return TradingTimeSnapshot(

--- a/services/torghut/tests/test_signal_ingest.py
+++ b/services/torghut/tests/test_signal_ingest.py
@@ -315,6 +315,42 @@ class TestSignalIngest(TestCase):
         self.assertIsNone(cursor_seq)
         self.assertIsNone(cursor_symbol)
 
+    def test_simulation_mode_cursor_outside_window_resets_to_window_start(self) -> None:
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        Base.metadata.create_all(engine)
+        session_local = sessionmaker(bind=engine, expire_on_commit=False, future=True)
+
+        snapshot = {
+            "enabled": settings.trading_simulation_enabled,
+            "window_start": settings.trading_simulation_window_start,
+            "window_end": settings.trading_simulation_window_end,
+        }
+        try:
+            settings.trading_simulation_enabled = True
+            settings.trading_simulation_window_start = "2026-03-06T14:30:00Z"
+            settings.trading_simulation_window_end = "2026-03-06T14:45:00Z"
+            ingestor = ClickHouseSignalIngestor(schema='envelope', url='http://example')
+            with session_local() as session:
+                session.add(
+                    TradeCursor(
+                        source="clickhouse",
+                        account_label=ingestor.account_label,
+                        cursor_at=datetime(2026, 3, 6, 20, 22, tzinfo=timezone.utc),
+                        cursor_seq=11,
+                        cursor_symbol="NVDA",
+                    )
+                )
+                session.commit()
+                cursor_at, cursor_seq, cursor_symbol = ingestor._get_cursor(session)
+        finally:
+            settings.trading_simulation_enabled = snapshot["enabled"]
+            settings.trading_simulation_window_start = snapshot["window_start"]
+            settings.trading_simulation_window_end = snapshot["window_end"]
+
+        self.assertEqual(cursor_at, datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc))
+        self.assertIsNone(cursor_seq)
+        self.assertIsNone(cursor_symbol)
+
     def test_simulation_mode_fetch_uses_simulated_now_for_cursor_tail_lag(self) -> None:
         engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
         Base.metadata.create_all(engine)
@@ -472,6 +508,44 @@ class TestSignalIngest(TestCase):
         replay_query = ingestor.queries[-1]
         self.assertIn("WHERE event_ts >=", replay_query)
         self.assertIn("AND event_ts <=", replay_query)
+
+    def test_simulation_mode_empty_poll_without_in_window_signals_holds_cursor(self) -> None:
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        Base.metadata.create_all(engine)
+        session_local = sessionmaker(bind=engine, expire_on_commit=False, future=True)
+
+        snapshot = {
+            "enabled": settings.trading_simulation_enabled,
+            "window_start": settings.trading_simulation_window_start,
+            "window_end": settings.trading_simulation_window_end,
+        }
+        try:
+            settings.trading_simulation_enabled = True
+            settings.trading_simulation_window_start = "2026-03-06T14:30:00Z"
+            settings.trading_simulation_window_end = "2026-03-06T14:45:00Z"
+            ingestor = SimulationWindowNoLatestIngestor(
+                schema="envelope",
+                url="http://example",
+                rows=[],
+                fast_forward_stale_cursor=False,
+            )
+            with session_local() as session, patch(
+                "app.trading.ingest.trading_now",
+                return_value=datetime(2026, 3, 6, 14, 30, 0, tzinfo=timezone.utc),
+            ):
+                batch = ingestor.fetch_signals(session)
+        finally:
+            settings.trading_simulation_enabled = snapshot["enabled"]
+            settings.trading_simulation_window_start = snapshot["window_start"]
+            settings.trading_simulation_window_end = snapshot["window_end"]
+
+        self.assertEqual(batch.signals, [])
+        self.assertEqual(batch.no_signal_reason, "no_signals_in_window")
+        self.assertEqual(batch.cursor_at, datetime(2026, 3, 6, 14, 30, 0, tzinfo=timezone.utc))
+        self.assertEqual(batch.query_end, datetime(2026, 3, 6, 14, 30, 10, tzinfo=timezone.utc))
+        latest_query = next(query for query in ingestor.queries if "latest_signal_ts" in query)
+        self.assertIn("WHERE event_ts >=", latest_query)
+        self.assertIn("AND event_ts <=", latest_query)
 
     def test_build_query_flat_schema(self) -> None:
         ingestor = ClickHouseSignalIngestor(schema="flat", table="torghut.ta_signals", fast_forward_stale_cursor=False)

--- a/services/torghut/tests/test_simulation_parity_guard.py
+++ b/services/torghut/tests/test_simulation_parity_guard.py
@@ -13,6 +13,7 @@ class SimulationParityGuardTest(unittest.TestCase):
             'market_session.py',
             'simulation.py',
             'simulation_progress.py',
+            'simulation_window.py',
             'time_source.py',
             'universe.py',
         }

--- a/services/torghut/tests/test_time_source.py
+++ b/services/torghut/tests/test_time_source.py
@@ -14,6 +14,7 @@ class TestTradingTimeSource(TestCase):
             "trading_simulation_enabled": config.settings.trading_simulation_enabled,
             "trading_simulation_clock_mode": config.settings.trading_simulation_clock_mode,
             "trading_simulation_window_start": config.settings.trading_simulation_window_start,
+            "trading_simulation_window_end": config.settings.trading_simulation_window_end,
             "trading_simulation_clock_cache_seconds": config.settings.trading_simulation_clock_cache_seconds,
         }
 
@@ -21,6 +22,7 @@ class TestTradingTimeSource(TestCase):
         config.settings.trading_simulation_enabled = self._snapshot["trading_simulation_enabled"]
         config.settings.trading_simulation_clock_mode = self._snapshot["trading_simulation_clock_mode"]
         config.settings.trading_simulation_window_start = self._snapshot["trading_simulation_window_start"]
+        config.settings.trading_simulation_window_end = self._snapshot["trading_simulation_window_end"]
         config.settings.trading_simulation_clock_cache_seconds = self._snapshot["trading_simulation_clock_cache_seconds"]
 
     def test_snapshot_uses_cursor_time_when_available(self) -> None:
@@ -43,6 +45,20 @@ class TestTradingTimeSource(TestCase):
         source = TradingTimeSource()
 
         with patch.object(source, "_load_clickhouse_cursor", return_value=None):
+            snapshot = source.snapshot(account_label="TORGHUT_SIM")
+
+        self.assertEqual(snapshot.now, datetime(2026, 3, 6, 18, 0, tzinfo=timezone.utc))
+        self.assertEqual(snapshot.source, "window_start")
+
+    def test_snapshot_ignores_cursor_outside_simulation_window(self) -> None:
+        config.settings.trading_simulation_enabled = True
+        config.settings.trading_simulation_clock_mode = "cursor"
+        config.settings.trading_simulation_window_start = "2026-03-06T18:00:00Z"
+        config.settings.trading_simulation_window_end = "2026-03-06T18:15:00Z"
+        source = TradingTimeSource()
+        stale_cursor = datetime(2026, 3, 6, 19, 5, tzinfo=timezone.utc)
+
+        with patch.object(source, "_load_clickhouse_cursor", return_value=stale_cursor):
             snapshot = source.snapshot(account_label="TORGHUT_SIM")
 
         self.assertEqual(snapshot.now, datetime(2026, 3, 6, 18, 0, tzinfo=timezone.utc))


### PR DESCRIPTION
## Summary

- bound simulation ingest to the configured replay window so warm-lane cursors cannot drift past the requested run
- ignore persisted shared trade cursors that fall outside the active simulation window and fall back to the run window start instead
- scope simulation latest-signal probes to the replay window and add regressions for stale cursor normalization, bounded empty polling, and time-source fallback

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen ruff check app tests scripts migrations`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen pytest tests/test_signal_ingest.py tests/test_time_source.py tests/test_simulation_parity_guard.py -q`
- `cd services/torghut && uv run --frozen pytest tests/test_signal_ingest.py tests/test_time_source.py tests/test_simulation_parity_guard.py tests/test_run_simulation_analysis.py tests/test_start_historical_simulation.py -q`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
