### PR TITLE
fix(headlamp): remove unsupported session ttl arg

### DIFF
--- a/argocd/applications/headlamp/kustomization.yaml
+++ b/argocd/applications/headlamp/kustomization.yaml
@@ -10,6 +10,30 @@ resources:
   - ingressroute-headlamp-auth-bridge-k8s-private.yaml
   - ingressroute-headlamp-k8s-private.yaml
 patches:
+  - target:
+      kind: Deployment
+      name: headlamp
+      namespace: headlamp
+    patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: headlamp
+        namespace: headlamp
+      spec:
+        template:
+          spec:
+            containers:
+              - name: headlamp
+                args:
+                  - -in-cluster
+                  - -in-cluster-context-name=main
+                  - -plugins-dir=/headlamp/plugins
+                  - -oidc-client-id=$(OIDC_CLIENT_ID)
+                  - -oidc-client-secret=$(OIDC_CLIENT_SECRET)
+                  - -oidc-idp-issuer-url=$(OIDC_ISSUER_URL)
+                  - -oidc-scopes=$(OIDC_SCOPES)
+                  - -oidc-use-access-token=$(OIDC_USE_ACCESS_TOKEN)
   - path: patch-headlamp-tailscale-ingress-auth-bridge.yaml
 helmCharts:
   - name: headlamp


### PR DESCRIPTION
## Summary

- patch the Headlamp 0.40.1 Helm render to remove the unsupported `-session-ttl` arg from the Deployment
- keep the Headlamp image and chart on 0.40.1 while restoring compatibility with the current server binary
- unblock the in-cluster rollout introduced by #4426 without changing OIDC or ingress behavior

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/headlamp > /tmp/headlamp-render-fixed.yaml && ! rg -n "session-ttl" /tmp/headlamp-render-fixed.yaml && rg -n "ghcr.io/headlamp-k8s/headlamp|args:" /tmp/headlamp-render-fixed.yaml | sed -n "1,40p"`
- `bun run lint:argocd`
- `kubectl logs -n headlamp headlamp-c4d578889-jwg8q --previous` (captured `flag provided but not defined: -session-ttl` from the failed rollout on commit `d6cf8a679814a538da13dc6934fa77b6575727fa`)

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
