### PR TITLE
refactor(symphony): harden runtime with effect-ts

### DIFF
--- a/.github/workflows/agents-ci.yml
+++ b/.github/workflows/agents-ci.yml
@@ -459,10 +459,10 @@ jobs:
 
           # Use docker.io for Bun base image in CI builds to avoid mirror image metadata drift.
           # Local image rebuilds are best-effort in CI; fall back to the public image on timeout.
-          # ARC arm64 runners occasionally need materially longer than 12 minutes for the
-          # control-plane bundle graph; keep CI-specific build work lean and give the remaining
-          # build a realistic timeout instead of failing healthy progress mid-build.
-          BUILD_TIMEOUT_MINUTES=18
+          # ARC arm64 runners can spend well over 18 minutes in the pruned control-plane docker
+          # build while still making forward progress, so give the local image build enough headroom
+          # to complete instead of terminating a healthy build.
+          BUILD_TIMEOUT_MINUTES=30
           KIND_LOAD_TIMEOUT_MINUTES=20
 
           if run_with_progress "Docker build" "${BUILD_TIMEOUT_MINUTES}" env DOCKER_BUILDKIT=1 docker build \

--- a/argocd/applications/symphony/deployment.yaml
+++ b/argocd/applications/symphony/deployment.yaml
@@ -22,7 +22,7 @@ spec:
         app.kubernetes.io/name: symphony
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-13T09:03:45.727Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-13T20:52:07.078Z"
     spec:
       containers:
         - name: symphony

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -15,5 +15,5 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "ca7550d11-livefix1"
-    digest: sha256:4beccb2068b9465dd11ac75b7847d665f060f3e668e4ab5ae180f35b587532e3
+    newTag: "a109b9321-effect-20260313135159"
+    digest: sha256:0f2e32cd4fde838d09aacbccd83b12609e4040e9ad8bd71c69c4c069f0aeb7b8

--- a/bun.lock
+++ b/bun.lock
@@ -498,7 +498,7 @@
     },
     "packages/temporal-bun-sdk": {
       "name": "@proompteng/temporal-bun-sdk",
-      "version": "0.6.1",
+      "version": "0.7.0",
       "bin": {
         "temporal-bun": "./dist/src/bin/temporal-bun.js",
         "temporal-bun-skill": "./dist/src/bin/temporal-bun-skill.js",
@@ -782,7 +782,9 @@
       "name": "@proompteng/symphony",
       "version": "0.1.0",
       "dependencies": {
+        "@effect/schema": "^0.75.5",
         "@proompteng/codex": "workspace:*",
+        "effect": "^3.19.18",
         "handlebars": "^4.7.8",
         "yaml": "^2.8.2",
       },

--- a/services/symphony/package.json
+++ b/services/symphony/package.json
@@ -13,7 +13,9 @@
     "tsc": "bunx tsc --noEmit"
   },
   "dependencies": {
+    "@effect/schema": "^0.75.5",
     "@proompteng/codex": "workspace:*",
+    "effect": "^3.19.18",
     "handlebars": "^4.7.8",
     "yaml": "^2.8.2"
   },

--- a/services/symphony/src/codex-app-session.test.ts
+++ b/services/symphony/src/codex-app-session.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from 'bun:test'
+
+import { CodexProtocolError } from './errors'
+import { decodeProtocolMessage } from './codex-app-session'
+
+describe('codex protocol decoding', () => {
+  test('decodes JSON-RPC protocol lines', () => {
+    const decoded = decodeProtocolMessage('{"id":1,"method":"initialize","params":{}}')
+    expect(decoded).toEqual({ id: 1, method: 'initialize', params: {} })
+  })
+
+  test('rejects non-object JSON payloads', () => {
+    expect(() => decodeProtocolMessage('"text"')).toThrow(CodexProtocolError)
+  })
+})

--- a/services/symphony/src/codex-app-session.ts
+++ b/services/symphony/src/codex-app-session.ts
@@ -1,4 +1,14 @@
-import { type ChildProcessWithoutNullStreams, spawn } from 'node:child_process'
+import { spawn } from 'node:child_process'
+import type { ChildProcessWithoutNullStreams } from 'node:child_process'
+
+import * as Schema from '@effect/schema/Schema'
+import { Context, Effect, Layer, Runtime } from 'effect'
+import * as Deferred from 'effect/Deferred'
+import * as Fiber from 'effect/Fiber'
+import * as Ref from 'effect/Ref'
+import * as Scope from 'effect/Scope'
+import * as Stream from 'effect/Stream'
+import * as SynchronizedRef from 'effect/SynchronizedRef'
 
 import type {
   AskForApproval,
@@ -13,23 +23,19 @@ import type {
   TurnStartResponse,
 } from '@proompteng/codex'
 
-import { SymphonyError, toError } from './errors'
+import { CodexProtocolError, toLogError } from './errors'
 import type { Logger } from './logger'
 import type { TokenUsageTotals } from './types'
 
 type PendingRequest = {
   method: string
-  resolve: (value: unknown) => void
-  reject: (reason: unknown) => void
-  timer: Timer
+  deferred: Deferred.Deferred<unknown, CodexProtocolError>
 }
 
 type ActiveTurn = {
   threadId: string
   turnId: string
-  resolve: (value: TurnOutcome) => void
-  reject: (reason: unknown) => void
-  timer: Timer
+  deferred: Deferred.Deferred<TurnOutcome, CodexProtocolError>
 }
 
 export type CodexEvent = {
@@ -50,7 +56,7 @@ export type TurnOutcome = {
   turnId: string
 }
 
-type CodexAppSessionOptions = {
+export type CodexSessionOptions = {
   command: string
   cwd: string
   approvalPolicy: AskForApproval | null
@@ -61,9 +67,36 @@ type CodexAppSessionOptions = {
   title: string
   dynamicTools: DynamicToolSpec[]
   logger: Logger
-  onEvent: (event: CodexEvent) => void
-  onToolCall: (tool: string, args: unknown) => Promise<DynamicToolCallResponse>
+  onEvent: (event: CodexEvent) => Effect.Effect<void, never>
+  onToolCall: (tool: string, args: unknown) => Effect.Effect<DynamicToolCallResponse, never>
 }
+
+export type CodexSessionHandle = {
+  readonly runTurn: (prompt: string) => Effect.Effect<TurnOutcome, CodexProtocolError>
+}
+
+export interface CodexSessionServiceDefinition {
+  readonly createSession: (
+    options: CodexSessionOptions,
+  ) => Effect.Effect<CodexSessionHandle, CodexProtocolError, Scope.Scope>
+}
+
+export class CodexSessionService extends Context.Tag('symphony/CodexSessionService')<
+  CodexSessionService,
+  CodexSessionServiceDefinition
+>() {}
+
+const JsonRpcResponseSchema = Schema.Struct({
+  id: Schema.Number,
+  result: Schema.optional(Schema.Unknown),
+  error: Schema.optional(Schema.Unknown),
+})
+
+const JsonRpcMethodSchema = Schema.Struct({
+  method: Schema.String,
+  params: Schema.optional(Schema.Unknown),
+  id: Schema.optional(Schema.Number),
+})
 
 const toSandboxPolicy = (sandbox: SandboxMode | null, override: SandboxPolicy | null): SandboxPolicy => {
   if (override) return override
@@ -139,408 +172,474 @@ const extractTurnId = (value: unknown): string | null => {
   return null
 }
 
-export class CodexAppSession {
-  private readonly options: CodexAppSessionOptions
-  private readonly child: ChildProcessWithoutNullStreams
-  private readonly pending = new Map<number, PendingRequest>()
-  private readonly logger: Logger
-  private buffer = ''
-  private nextRequestId = 1
-  private ready = false
-  private threadId: string | null = null
-  private activeTurn: ActiveTurn | null = null
-  private exitError: Error | null = null
-  private stopped = false
-
-  constructor(options: CodexAppSessionOptions) {
-    this.options = options
-    this.logger = options.logger.child({ component: 'codex-app-session', workspace_path: options.cwd })
-    this.child = spawn('bash', ['-lc', options.command], {
-      cwd: options.cwd,
-      env: process.env,
-      stdio: ['pipe', 'pipe', 'pipe'],
-    })
-
-    this.child.stdout.on('data', (chunk: Buffer) => {
-      this.buffer += chunk.toString('utf8')
-      const lines = this.buffer.split('\n')
-      this.buffer = lines.pop() ?? ''
-      for (const line of lines) {
-        this.handleStdoutLine(line)
-      }
-    })
-    this.child.stderr.on('data', (chunk: Buffer) => {
-      const text = chunk.toString('utf8').trim()
-      if (text.length > 0) {
-        this.logger.log('info', 'codex_stderr', { message: text })
-      }
-    })
-    this.child.on('exit', (code, signal) => {
-      const error = new SymphonyError(
-        'port_exit',
-        `codex app-server exited code=${code ?? 'unknown'} signal=${signal ?? 'unknown'}`,
-      )
-      this.exitError = error
-      for (const [id, pending] of this.pending) {
-        clearTimeout(pending.timer)
-        pending.reject(error)
-        this.pending.delete(id)
-      }
-      if (this.activeTurn) {
-        clearTimeout(this.activeTurn.timer)
-        this.activeTurn.reject(error)
-        this.activeTurn = null
-      }
-    })
-  }
-
-  async initialize(): Promise<void> {
-    if (this.ready) return
-    await this.request('initialize', { clientInfo: { name: 'symphony', version: '0.1.0' }, capabilities: {} })
-    this.write({ method: 'initialized', params: {} })
-    this.ready = true
-    this.options.onEvent({
-      event: 'session_started',
-      timestamp: new Date().toISOString(),
-      codexAppServerPid: String(this.child.pid ?? ''),
-      message: 'codex app-server initialized',
-    })
-  }
-
-  async runTurn(prompt: string): Promise<TurnOutcome> {
-    await this.initialize()
-    const threadId = this.threadId ?? (await this.startThread())
-    const turnId = await this.startTurn(threadId, prompt)
-    return new Promise<TurnOutcome>((resolve, reject) => {
-      const timer = setTimeout(() => {
-        this.activeTurn = null
-        reject(new SymphonyError('turn_timeout', `turn ${turnId} exceeded ${this.options.turnTimeoutMs}ms`))
-      }, this.options.turnTimeoutMs)
-
-      this.activeTurn = {
-        threadId,
-        turnId,
-        resolve,
-        reject,
-        timer,
-      }
-    })
-  }
-
-  stop(): void {
-    if (this.stopped) return
-    this.stopped = true
-    if (!this.child.killed) {
-      this.child.kill('SIGKILL')
-    }
-  }
-
-  private async startThread(): Promise<string> {
-    const params: ThreadStartParams = {
-      model: null,
-      modelProvider: null,
-      cwd: this.options.cwd,
-      approvalPolicy: this.options.approvalPolicy,
-      sandbox: this.options.threadSandbox,
-      config: { mcp_servers: {}, web_search: 'live' },
-      serviceName: 'symphony',
-      baseInstructions: null,
-      developerInstructions: null,
-      personality: null,
-      ephemeral: false,
-      dynamicTools: this.options.dynamicTools,
-      experimentalRawEvents: false,
-      persistExtendedHistory: false,
-    }
-    const response = (await this.request('thread/start', params)) as ThreadStartResponse
-    this.threadId = response.thread.id
-    return response.thread.id
-  }
-
-  private async startTurn(threadId: string, prompt: string): Promise<string> {
-    const params: TurnStartParams = {
-      threadId,
-      input: [{ type: 'text', text: prompt, text_elements: [] }],
-      cwd: this.options.cwd,
-      approvalPolicy: this.options.approvalPolicy,
-      sandboxPolicy: toSandboxPolicy(this.options.threadSandbox, this.options.turnSandboxPolicy),
-      model: null,
-      serviceTier: null,
-      effort: null,
-      summary: null,
-      personality: null,
-      outputSchema: null,
-      collaborationMode: null,
-    }
-    const response = (await this.request('turn/start', params)) as TurnStartResponse
-    const turnId = response.turn.id
-    const sessionId = `${threadId}-${turnId}`
-    this.options.onEvent({
-      event: 'turn_started',
-      timestamp: new Date().toISOString(),
-      codexAppServerPid: String(this.child.pid ?? ''),
-      threadId,
-      turnId,
-      sessionId,
-      message: this.options.title,
-    })
-    return turnId
-  }
-
-  private handleStdoutLine(rawLine: string): void {
-    const trimmed = rawLine.trim()
-    if (trimmed.length === 0) return
-
-    let message: Record<string, unknown>
-    try {
-      message = JSON.parse(trimmed) as Record<string, unknown>
-    } catch (error) {
-      this.options.onEvent({
-        event: 'malformed',
-        timestamp: new Date().toISOString(),
-        codexAppServerPid: String(this.child.pid ?? ''),
-        message: trimmed.slice(0, 400),
-      })
-      this.logger.log('warn', 'codex_stdout_malformed', { error: toError(error).message, line: trimmed.slice(0, 400) })
-      return
-    }
-
-    if (typeof message.id === 'number' && ('result' in message || 'error' in message)) {
-      const pending = this.pending.get(message.id)
-      if (!pending) return
-      clearTimeout(pending.timer)
-      this.pending.delete(message.id)
-      if ('error' in message && message.error !== undefined) {
-        pending.reject(new SymphonyError('response_error', `${pending.method} failed`, message.error))
-      } else {
-        pending.resolve(message.result)
-      }
-      return
-    }
-
-    if (typeof message.id === 'number' && typeof message.method === 'string') {
-      void this.handleServerRequest(message.id, message.method, message.params)
-      return
-    }
-
-    if (typeof message.method === 'string') {
-      this.handleNotification(message.method, message.params)
-    }
-  }
-
-  private async handleServerRequest(id: number, method: string, params: unknown): Promise<void> {
-    if (method === 'item/commandExecution/requestApproval') {
-      this.write({ id, result: { decision: 'acceptForSession' } })
-      this.emitEvent('approval_auto_approved', params, 'auto-approved command execution')
-      return
-    }
-    if (method === 'item/fileChange/requestApproval') {
-      this.write({ id, result: { decision: 'acceptForSession' } })
-      this.emitEvent('approval_auto_approved', params, 'auto-approved file change')
-      return
-    }
-    if (method === 'applyPatchApproval' || method === 'execCommandApproval') {
-      this.write({ id, result: { decision: 'approved_for_session' } })
-      this.emitEvent('approval_auto_approved', params, 'auto-approved legacy approval request')
-      return
-    }
-    if (method === 'mcpServer/elicitation/request') {
-      this.write({ id, result: { action: 'decline', content: null } })
-      this.emitEvent('notification', params, 'declined mcp elicitation request')
-      return
-    }
-    if (method === 'item/tool/requestUserInput') {
-      this.write({ id, error: { code: -32000, message: 'turn_input_required' } })
-      const error = new SymphonyError('turn_input_required', 'agent requested user input')
-      this.emitEvent('turn_input_required', params, 'agent requested user input')
-      if (this.activeTurn) {
-        clearTimeout(this.activeTurn.timer)
-        this.activeTurn.reject(error)
-        this.activeTurn = null
-      }
-      return
-    }
-    if (method === 'item/tool/call') {
-      const raw = params as { tool?: unknown; arguments?: unknown } | null
-      const toolName = typeof raw?.tool === 'string' ? raw.tool : ''
-      try {
-        const result = await this.options.onToolCall(toolName, raw?.arguments)
-        this.write({ id, result })
-        if (!result.success) {
-          this.emitEvent('unsupported_tool_call', params, `tool ${toolName} returned failure`)
-        }
-      } catch (error) {
-        const payload: DynamicToolCallResponse = {
-          success: false,
-          contentItems: [{ type: 'inputText', text: JSON.stringify({ error: toError(error).message }) }],
-        }
-        this.write({ id, result: payload })
-        this.emitEvent('unsupported_tool_call', params, `tool ${toolName} failed`)
-      }
-      return
-    }
-
-    this.write({ id, result: { acknowledged: true } })
-    this.emitEvent('notification', params, `acknowledged ${method}`)
-  }
-
-  private handleNotification(method: string, params: unknown): void {
-    if (method === 'turn/completed') {
-      const threadId = extractThreadId(params) ?? this.activeTurn?.threadId ?? this.threadId
-      const turnId = extractTurnId(params) ?? this.activeTurn?.turnId
-      const status = (params as { turn?: { status?: unknown } } | null | undefined)?.turn?.status
-      const sessionId = threadId && turnId ? `${threadId}-${turnId}` : null
-      if (this.activeTurn && turnId === this.activeTurn.turnId) {
-        clearTimeout(this.activeTurn.timer)
-        const resolver = this.activeTurn
-        this.activeTurn = null
-        if (status === 'completed') {
-          resolver.resolve({ status: 'completed', threadId: resolver.threadId, turnId: resolver.turnId })
-          this.options.onEvent({
-            event: 'turn_completed',
-            timestamp: new Date().toISOString(),
-            codexAppServerPid: String(this.child.pid ?? ''),
-            sessionId,
-            threadId: resolver.threadId,
-            turnId: resolver.turnId,
-            message: this.options.title,
-          })
-          return
-        }
-        if (status === 'interrupted') {
-          resolver.reject(new SymphonyError('turn_cancelled', `turn ${resolver.turnId} was interrupted`))
-          this.options.onEvent({
-            event: 'turn_cancelled',
-            timestamp: new Date().toISOString(),
-            codexAppServerPid: String(this.child.pid ?? ''),
-            sessionId,
-            threadId: resolver.threadId,
-            turnId: resolver.turnId,
-            message: this.options.title,
-          })
-          return
-        }
-        resolver.reject(new SymphonyError('turn_failed', `turn ${resolver.turnId} failed`, params))
-        this.options.onEvent({
-          event: 'turn_failed',
-          timestamp: new Date().toISOString(),
-          codexAppServerPid: String(this.child.pid ?? ''),
-          sessionId,
-          threadId: resolver.threadId,
-          turnId: resolver.turnId,
-          message: this.options.title,
+const writeMessage = (
+  child: ChildProcessWithoutNullStreams,
+  payload: Record<string, unknown>,
+): Effect.Effect<void, CodexProtocolError, never> =>
+  Effect.tryPromise({
+    try: () =>
+      new Promise<void>((resolve, reject) => {
+        child.stdin.write(`${JSON.stringify(payload)}\n`, 'utf8', (error) => {
+          if (error) {
+            reject(error)
+            return
+          }
+          resolve()
         })
-      }
-      return
-    }
+      }),
+    catch: (error) => new CodexProtocolError('response_error', 'failed to write to codex app-server stdin', error),
+  })
 
-    if (method === 'item/agentMessage/delta') {
-      const delta =
-        typeof (params as { delta?: unknown } | null | undefined)?.delta === 'string'
-          ? (params as { delta: string }).delta
-          : null
-      if (delta) {
-        this.emitEvent('notification', params, delta)
-      }
-      return
-    }
+const decodeResponse = Schema.decodeUnknownEither(JsonRpcResponseSchema)
+const decodeMethod = Schema.decodeUnknownEither(JsonRpcMethodSchema)
 
-    if (method === 'thread/tokenUsage/updated') {
-      const usage = extractTokenUsage(
-        (params as { tokenUsage?: unknown; usage?: unknown } | null | undefined)?.tokenUsage ??
-          (params as { usage?: unknown } | null | undefined)?.usage,
-      )
-      if (usage) {
-        this.options.onEvent({
-          event: 'notification',
-          timestamp: new Date().toISOString(),
-          codexAppServerPid: String(this.child.pid ?? ''),
-          threadId: extractThreadId(params) ?? this.threadId,
-          turnId: extractTurnId(params),
-          usage,
-        })
-      }
-      return
-    }
-
-    if (method === 'account/rateLimits/updated') {
-      const rateLimits = ((params as { rateLimits?: unknown } | null | undefined)?.rateLimits ??
-        null) as RateLimitSnapshot | null
-      this.options.onEvent({
-        event: 'notification',
-        timestamp: new Date().toISOString(),
-        codexAppServerPid: String(this.child.pid ?? ''),
-        threadId: extractThreadId(params) ?? this.threadId,
-        turnId: extractTurnId(params),
-        rateLimits,
-      })
-      return
-    }
-
-    if (method === 'error') {
-      if (this.activeTurn) {
-        clearTimeout(this.activeTurn.timer)
-        const resolver = this.activeTurn
-        this.activeTurn = null
-        resolver.reject(new SymphonyError('turn_failed', 'codex app-server reported a stream error', params))
-      }
-      this.emitEvent('turn_ended_with_error', params, JSON.stringify(params))
-      return
-    }
-
-    this.emitEvent('other_message', params, method)
+export const decodeProtocolMessage = (rawLine: string): Record<string, unknown> | null => {
+  const trimmed = rawLine.trim()
+  if (trimmed.length === 0) return null
+  const parsed = JSON.parse(trimmed) as unknown
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    throw new CodexProtocolError('response_error', 'codex protocol line was not an object', parsed)
   }
-
-  private emitEvent(event: string, params: unknown, message: string | null): void {
-    const threadId = extractThreadId(params) ?? this.threadId
-    const turnId = extractTurnId(params)
-    const sessionId = threadId && turnId ? `${threadId}-${turnId}` : null
-    this.options.onEvent({
-      event,
-      timestamp: new Date().toISOString(),
-      codexAppServerPid: String(this.child.pid ?? ''),
-      sessionId,
-      threadId,
-      turnId,
-      message,
-    })
-  }
-
-  private async request(method: string, params: unknown): Promise<unknown> {
-    if (this.exitError) throw this.exitError
-    const id = this.nextRequestId
-    this.nextRequestId += 1
-
-    return new Promise((resolve, reject) => {
-      const timer = setTimeout(() => {
-        this.pending.delete(id)
-        reject(
-          new SymphonyError('response_timeout', `${method} did not complete within ${this.options.readTimeoutMs}ms`),
-        )
-      }, this.options.readTimeoutMs)
-
-      this.pending.set(id, {
-        method,
-        resolve,
-        reject,
-        timer,
-      })
-
-      try {
-        this.write({ id, method, params })
-      } catch (error) {
-        clearTimeout(timer)
-        this.pending.delete(id)
-        reject(error)
-      }
-    })
-  }
-
-  private write(payload: unknown): void {
-    const serialized = `${JSON.stringify(payload)}\n`
-    const ok = this.child.stdin.write(serialized)
-    if (!ok) {
-      this.logger.log('warn', 'codex_stdin_backpressure', {})
-    }
-  }
+  return parsed as Record<string, unknown>
 }
+
+export const makeCodexSessionLayer = (logger: Logger) =>
+  Layer.succeed(CodexSessionService, {
+    createSession: (options) =>
+      Effect.gen(function* () {
+        yield* Scope.Scope
+        const runtime = yield* Effect.runtime<never>()
+        const sessionLogger = options.logger.child({
+          component: 'codex-app-session',
+          workspace_path: options.cwd,
+        })
+        const pending = new Map<number, PendingRequest>()
+        const nextRequestId = yield* Ref.make(1)
+        const threadIdRef = yield* Ref.make<string | null>(null)
+        const activeTurnRef = yield* SynchronizedRef.make<ActiveTurn | null>(null)
+        const readyRef = yield* Ref.make(false)
+
+        const failAllPending = (error: CodexProtocolError) =>
+          Effect.gen(function* () {
+            for (const [id, entry] of pending) {
+              pending.delete(id)
+              yield* Deferred.fail(entry.deferred, error)
+            }
+            const activeTurn = yield* SynchronizedRef.get(activeTurnRef)
+            if (activeTurn) {
+              yield* Deferred.fail(activeTurn.deferred, error)
+              yield* SynchronizedRef.set(activeTurnRef, null)
+            }
+          })
+
+        const child = yield* Effect.acquireRelease(
+          Effect.sync(() =>
+            spawn('bash', ['-lc', options.command], {
+              cwd: options.cwd,
+              env: process.env,
+              stdio: ['pipe', 'pipe', 'pipe'],
+            }),
+          ),
+          (resource) =>
+            Effect.sync(() => {
+              if (!resource.killed) {
+                resource.kill('SIGKILL')
+              }
+            }),
+        )
+
+        yield* Effect.sync(() => {
+          child.once('exit', (code, signal) => {
+            const error = new CodexProtocolError(
+              'port_exit',
+              `codex app-server exited code=${code ?? 'unknown'} signal=${signal ?? 'unknown'}`,
+            )
+            Runtime.runFork(runtime)(failAllPending(error))
+          })
+        })
+
+        const handleServerRequest = (id: number, method: string, params: unknown) =>
+          Effect.gen(function* () {
+            if (method === 'item/commandExecution/requestApproval') {
+              yield* writeMessage(child, { id, result: { decision: 'acceptForSession' } })
+              yield* options.onEvent({
+                event: 'approval_auto_approved',
+                timestamp: new Date().toISOString(),
+                codexAppServerPid: String(child.pid ?? ''),
+                message: 'auto-approved command execution',
+              })
+              return
+            }
+
+            if (method === 'item/fileChange/requestApproval') {
+              yield* writeMessage(child, { id, result: { decision: 'acceptForSession' } })
+              yield* options.onEvent({
+                event: 'approval_auto_approved',
+                timestamp: new Date().toISOString(),
+                codexAppServerPid: String(child.pid ?? ''),
+                message: 'auto-approved file change',
+              })
+              return
+            }
+
+            if (method === 'applyPatchApproval' || method === 'execCommandApproval') {
+              yield* writeMessage(child, { id, result: { decision: 'approved_for_session' } })
+              yield* options.onEvent({
+                event: 'approval_auto_approved',
+                timestamp: new Date().toISOString(),
+                codexAppServerPid: String(child.pid ?? ''),
+                message: 'auto-approved legacy approval request',
+              })
+              return
+            }
+
+            if (method === 'mcpServer/elicitation/request') {
+              yield* writeMessage(child, { id, result: { action: 'decline', content: null } })
+              yield* options.onEvent({
+                event: 'notification',
+                timestamp: new Date().toISOString(),
+                codexAppServerPid: String(child.pid ?? ''),
+                message: 'declined mcp elicitation request',
+              })
+              return
+            }
+
+            if (method === 'item/tool/requestUserInput') {
+              yield* writeMessage(child, { id, error: { code: -32000, message: 'turn_input_required' } })
+              const activeTurn = yield* SynchronizedRef.get(activeTurnRef)
+              if (activeTurn) {
+                yield* Deferred.fail(
+                  activeTurn.deferred,
+                  new CodexProtocolError('turn_input_required', 'agent requested user input'),
+                )
+                yield* SynchronizedRef.set(activeTurnRef, null)
+              }
+              yield* options.onEvent({
+                event: 'turn_input_required',
+                timestamp: new Date().toISOString(),
+                codexAppServerPid: String(child.pid ?? ''),
+                message: 'agent requested user input',
+              })
+              return
+            }
+
+            if (method === 'item/tool/call') {
+              const raw = params && typeof params === 'object' ? (params as Record<string, unknown>) : {}
+              const toolCallId =
+                typeof raw.callId === 'string' ? raw.callId : typeof raw.id === 'string' ? raw.id : null
+              const toolName = typeof raw.name === 'string' ? raw.name : 'unknown'
+              const args = 'input' in raw ? raw.input : raw.arguments
+              const result = yield* options.onToolCall(toolName, args)
+              yield* writeMessage(child, { id, result: { ...result, callId: toolCallId } })
+              return
+            }
+
+            yield* writeMessage(child, {
+              id,
+              result: {
+                success: false,
+                error: 'unsupported_tool_call',
+              },
+            })
+          }).pipe(
+            Effect.catchAll((error) =>
+              Effect.sync(() => {
+                sessionLogger.log('warn', 'codex_request_handling_failed', {
+                  method,
+                  ...toLogError(error),
+                })
+              }),
+            ),
+          )
+
+        const emitTurnOutcome = (
+          status: TurnOutcome['status'],
+          turnId: string,
+          threadId: string,
+          message?: string | null,
+        ) =>
+          Effect.gen(function* () {
+            const activeTurn = yield* SynchronizedRef.get(activeTurnRef)
+            if (!activeTurn || activeTurn.turnId !== turnId) return
+
+            yield* Deferred.succeed(activeTurn.deferred, { status, turnId, threadId })
+            yield* SynchronizedRef.set(activeTurnRef, null)
+            yield* options.onEvent({
+              event: `turn_${status}`,
+              timestamp: new Date().toISOString(),
+              codexAppServerPid: String(child.pid ?? ''),
+              sessionId: `${threadId}-${turnId}`,
+              threadId,
+              turnId,
+              message: message ?? null,
+            })
+          })
+
+        const handleNotification = (method: string, params: unknown) =>
+          Effect.gen(function* () {
+            const timestamp = new Date().toISOString()
+            const usage = extractTokenUsage(params)
+            const rateLimits =
+              params && typeof params === 'object' && 'rateLimits' in params
+                ? ((params as { rateLimits?: RateLimitSnapshot | null }).rateLimits ?? null)
+                : null
+
+            if (method === 'turn/completed') {
+              const activeTurn = yield* SynchronizedRef.get(activeTurnRef)
+              if (activeTurn) {
+                yield* emitTurnOutcome('completed', activeTurn.turnId, activeTurn.threadId)
+              }
+              return
+            }
+
+            if (method === 'turn/failed') {
+              const activeTurn = yield* SynchronizedRef.get(activeTurnRef)
+              if (activeTurn) {
+                yield* emitTurnOutcome('failed', activeTurn.turnId, activeTurn.threadId)
+              }
+              return
+            }
+
+            if (method === 'turn/cancelled') {
+              const activeTurn = yield* SynchronizedRef.get(activeTurnRef)
+              if (activeTurn) {
+                yield* emitTurnOutcome('cancelled', activeTurn.turnId, activeTurn.threadId)
+              }
+              return
+            }
+
+            yield* options.onEvent({
+              event: method.replaceAll('/', '_'),
+              timestamp,
+              codexAppServerPid: String(child.pid ?? ''),
+              threadId: extractThreadId(params),
+              turnId: extractTurnId(params),
+              sessionId:
+                extractThreadId(params) && extractTurnId(params)
+                  ? `${extractThreadId(params)}-${extractTurnId(params)}`
+                  : null,
+              message:
+                params && typeof params === 'object' && 'message' in params && typeof params.message === 'string'
+                  ? params.message
+                  : null,
+              usage,
+              rateLimits,
+            })
+          })
+
+        const handleProtocolLine = (line: string) =>
+          Effect.gen(function* () {
+            let message: Record<string, unknown> | null = null
+            try {
+              message = decodeProtocolMessage(line)
+            } catch (error) {
+              yield* options.onEvent({
+                event: 'malformed',
+                timestamp: new Date().toISOString(),
+                codexAppServerPid: String(child.pid ?? ''),
+                message: line.trim().slice(0, 400),
+              })
+              yield* Effect.sync(() => {
+                sessionLogger.log('warn', 'codex_stdout_malformed', {
+                  line: line.trim().slice(0, 400),
+                  ...toLogError(error),
+                })
+              })
+              return
+            }
+
+            if (!message) return
+
+            const responseDecoded = decodeResponse(message)
+            if (responseDecoded._tag === 'Right' && ('result' in message || 'error' in message)) {
+              const response = responseDecoded.right
+              const request = pending.get(response.id)
+              if (!request) return
+              pending.delete(response.id)
+
+              if (response.error !== undefined) {
+                yield* Deferred.fail(
+                  request.deferred,
+                  new CodexProtocolError('response_error', `${request.method} failed`, response.error),
+                )
+              } else {
+                yield* Deferred.succeed(request.deferred, response.result)
+              }
+              return
+            }
+
+            const methodDecoded = decodeMethod(message)
+            if (methodDecoded._tag === 'Right') {
+              const request = methodDecoded.right
+              if (typeof request.id === 'number') {
+                yield* handleServerRequest(request.id, request.method, request.params)
+                return
+              }
+              yield* handleNotification(request.method, request.params)
+            }
+          }).pipe(
+            Effect.catchAll((error) =>
+              Effect.sync(() => {
+                sessionLogger.log('warn', 'codex_protocol_error', toLogError(error))
+              }),
+            ),
+          )
+
+        const stdoutFiber = yield* Stream.fromAsyncIterable(
+          child.stdout,
+          (error) => new CodexProtocolError('port_exit', 'codex stdout stream failed', error),
+        ).pipe(Stream.decodeText(), Stream.splitLines, Stream.runForEach(handleProtocolLine), Effect.forkScoped)
+
+        const stderrFiber = yield* Stream.fromAsyncIterable(
+          child.stderr,
+          (error) => new CodexProtocolError('port_exit', 'codex stderr stream failed', error),
+        ).pipe(
+          Stream.decodeText(),
+          Stream.splitLines,
+          Stream.runForEach((line) =>
+            Effect.sync(() => {
+              if (line.trim().length === 0) return
+              sessionLogger.log('info', 'codex_stderr', { message: line.trim() })
+            }),
+          ),
+          Effect.forkScoped,
+        )
+
+        yield* Effect.addFinalizer(() =>
+          Fiber.interruptFork(stdoutFiber).pipe(Effect.zipRight(Fiber.interruptFork(stderrFiber))),
+        )
+
+        const request = (method: string, params: unknown) =>
+          Effect.gen(function* () {
+            const id = yield* Ref.modify(nextRequestId, (current) => [current, current + 1] as const)
+            const deferred = yield* Deferred.make<unknown, CodexProtocolError>()
+            pending.set(id, { method, deferred })
+            yield* writeMessage(child, { id, method, params })
+            return yield* Deferred.await(deferred).pipe(
+              Effect.timeoutFail({
+                duration: options.readTimeoutMs,
+                onTimeout: () =>
+                  new CodexProtocolError('response_timeout', `${method} timed out after ${options.readTimeoutMs}ms`),
+              }),
+              Effect.ensuring(Effect.sync(() => pending.delete(id))),
+            )
+          })
+
+        const initialize = Ref.get(readyRef).pipe(
+          Effect.flatMap((ready) =>
+            ready
+              ? Effect.void
+              : request('initialize', {
+                  clientInfo: { name: 'symphony', version: '0.1.0' },
+                  capabilities: {},
+                }).pipe(
+                  Effect.zipRight(writeMessage(child, { method: 'initialized', params: {} })),
+                  Effect.zipRight(Ref.set(readyRef, true)),
+                  Effect.zipRight(
+                    options.onEvent({
+                      event: 'session_started',
+                      timestamp: new Date().toISOString(),
+                      codexAppServerPid: String(child.pid ?? ''),
+                      message: 'codex app-server initialized',
+                    }),
+                  ),
+                ),
+          ),
+        )
+
+        const startThread = Effect.gen(function* () {
+          const existing = yield* Ref.get(threadIdRef)
+          if (existing) return existing
+
+          const params: ThreadStartParams = {
+            model: null,
+            modelProvider: null,
+            cwd: options.cwd,
+            approvalPolicy: options.approvalPolicy,
+            sandbox: options.threadSandbox,
+            config: { mcp_servers: {}, web_search: 'live' },
+            serviceName: 'symphony',
+            baseInstructions: null,
+            developerInstructions: null,
+            personality: null,
+            ephemeral: false,
+            dynamicTools: options.dynamicTools,
+            experimentalRawEvents: false,
+            persistExtendedHistory: false,
+          }
+
+          const response = (yield* request('thread/start', params)) as ThreadStartResponse
+          yield* Ref.set(threadIdRef, response.thread.id)
+          return response.thread.id
+        })
+
+        const startTurn = (threadId: string, prompt: string) =>
+          Effect.gen(function* () {
+            const params: TurnStartParams = {
+              threadId,
+              input: [{ type: 'text', text: prompt, text_elements: [] }],
+              cwd: options.cwd,
+              approvalPolicy: options.approvalPolicy,
+              sandboxPolicy: toSandboxPolicy(options.threadSandbox, options.turnSandboxPolicy),
+              model: null,
+              serviceTier: null,
+              effort: null,
+              summary: null,
+              personality: null,
+              outputSchema: null,
+              collaborationMode: null,
+            }
+
+            const response = (yield* request('turn/start', params)) as TurnStartResponse
+            const turnId = response.turn.id
+            const deferred = yield* Deferred.make<TurnOutcome, CodexProtocolError>()
+            yield* SynchronizedRef.set(activeTurnRef, { threadId, turnId, deferred })
+            yield* options.onEvent({
+              event: 'turn_started',
+              timestamp: new Date().toISOString(),
+              codexAppServerPid: String(child.pid ?? ''),
+              threadId,
+              turnId,
+              sessionId: `${threadId}-${turnId}`,
+              message: options.title,
+            })
+            return {
+              turnId,
+              deferred,
+            }
+          })
+
+        const handle: CodexSessionHandle = {
+          runTurn: (prompt) =>
+            Effect.gen(function* () {
+              yield* initialize
+              const threadId = yield* startThread
+              const { turnId, deferred } = yield* startTurn(threadId, prompt)
+              return yield* Deferred.await(deferred).pipe(
+                Effect.timeoutFail({
+                  duration: options.turnTimeoutMs,
+                  onTimeout: () =>
+                    new CodexProtocolError('turn_timeout', `turn ${turnId} exceeded ${options.turnTimeoutMs}ms`),
+                }),
+                Effect.catchAll((error) =>
+                  error.code === 'turn_input_required'
+                    ? Effect.fail(error)
+                    : Effect.fail(
+                        error.code === 'turn_timeout'
+                          ? error
+                          : new CodexProtocolError('turn_failed', error.message, error.causeValue),
+                      ),
+                ),
+              )
+            }),
+        }
+
+        return handle
+      }).pipe(
+        Effect.tapError((error) =>
+          Effect.sync(() => {
+            logger.log('warn', 'codex_session_create_failed', toLogError(error))
+          }),
+        ),
+      ),
+  })

--- a/services/symphony/src/config.ts
+++ b/services/symphony/src/config.ts
@@ -1,25 +1,107 @@
 import path from 'node:path'
 
-import type { AskForApproval, SandboxMode, SandboxPolicy } from '@proompteng/codex'
+import type * as ParseResult from '@effect/schema/ParseResult'
+import * as Schema from '@effect/schema/Schema'
+import * as TreeFormatter from '@effect/schema/TreeFormatter'
+import { Effect } from 'effect'
 
-import { SymphonyError } from './errors'
+import { ConfigError } from './errors'
 import type { SymphonyConfig } from './types'
 import {
   DEFAULT_WORKSPACE_ROOT,
   expandPathValue,
   hasPathSeparator,
+  normalizeState,
   normalizeStringList,
   readNumber,
   readPositiveNumber,
-  normalizeState,
 } from './utils'
 
 const DEFAULT_LINEAR_ENDPOINT = 'https://api.linear.app/graphql'
 const DEFAULT_ACTIVE_STATES = ['Todo', 'In Progress']
 const DEFAULT_TERMINAL_STATES = ['Closed', 'Cancelled', 'Canceled', 'Duplicate', 'Done']
 
-const readMap = (value: unknown): Record<string, unknown> =>
-  value && typeof value === 'object' && !Array.isArray(value) ? (value as Record<string, unknown>) : {}
+const RawSectionSchema = Schema.Struct({
+  tracker: Schema.optionalWith(
+    Schema.Struct({
+      kind: Schema.optionalWith(Schema.Unknown, { nullable: true }),
+      endpoint: Schema.optionalWith(Schema.Unknown, { nullable: true }),
+      api_key: Schema.optionalWith(Schema.Unknown, { nullable: true }),
+      project_slug: Schema.optionalWith(Schema.Unknown, { nullable: true }),
+      active_states: Schema.optionalWith(Schema.Unknown, { nullable: true }),
+      terminal_states: Schema.optionalWith(Schema.Unknown, { nullable: true }),
+    }),
+    { nullable: true },
+  ),
+  polling: Schema.optionalWith(
+    Schema.Struct({
+      interval_ms: Schema.optionalWith(Schema.Unknown, { nullable: true }),
+    }),
+    { nullable: true },
+  ),
+  workspace: Schema.optionalWith(
+    Schema.Struct({
+      root: Schema.optionalWith(Schema.Unknown, { nullable: true }),
+    }),
+    { nullable: true },
+  ),
+  hooks: Schema.optionalWith(
+    Schema.Struct({
+      after_create: Schema.optionalWith(Schema.Unknown, { nullable: true }),
+      before_run: Schema.optionalWith(Schema.Unknown, { nullable: true }),
+      after_run: Schema.optionalWith(Schema.Unknown, { nullable: true }),
+      before_remove: Schema.optionalWith(Schema.Unknown, { nullable: true }),
+      timeout_ms: Schema.optionalWith(Schema.Unknown, { nullable: true }),
+    }),
+    { nullable: true },
+  ),
+  worker: Schema.optionalWith(
+    Schema.Struct({
+      ssh_hosts: Schema.optionalWith(Schema.Unknown, { nullable: true }),
+      max_concurrent_agents_per_host: Schema.optionalWith(Schema.Unknown, { nullable: true }),
+    }),
+    { nullable: true },
+  ),
+  agent: Schema.optionalWith(
+    Schema.Struct({
+      max_concurrent_agents: Schema.optionalWith(Schema.Unknown, { nullable: true }),
+      max_concurrent_agents_by_state: Schema.optionalWith(Schema.Unknown, { nullable: true }),
+      max_retry_backoff_ms: Schema.optionalWith(Schema.Unknown, { nullable: true }),
+      max_turns: Schema.optionalWith(Schema.Unknown, { nullable: true }),
+    }),
+    { nullable: true },
+  ),
+  codex: Schema.optionalWith(
+    Schema.Struct({
+      command: Schema.optionalWith(Schema.Unknown, { nullable: true }),
+      approval_policy: Schema.optionalWith(Schema.Unknown, { nullable: true }),
+      thread_sandbox: Schema.optionalWith(Schema.Unknown, { nullable: true }),
+      turn_sandbox_policy: Schema.optionalWith(Schema.Unknown, { nullable: true }),
+      turn_timeout_ms: Schema.optionalWith(Schema.Unknown, { nullable: true }),
+      read_timeout_ms: Schema.optionalWith(Schema.Unknown, { nullable: true }),
+      stall_timeout_ms: Schema.optionalWith(Schema.Unknown, { nullable: true }),
+    }),
+    { nullable: true },
+  ),
+  server: Schema.optionalWith(
+    Schema.Struct({
+      host: Schema.optionalWith(Schema.Unknown, { nullable: true }),
+      port: Schema.optionalWith(Schema.Unknown, { nullable: true }),
+    }),
+    { nullable: true },
+  ),
+})
+
+type RawConfigSections = typeof RawSectionSchema.Type
+
+const decodeRawSections = Schema.decodeUnknown(RawSectionSchema)
+
+const formatSchemaError = (error: ParseResult.ParseError): string => TreeFormatter.formatErrorSync(error)
+
+const mapSchemaError = <A>(
+  effect: Effect.Effect<A, ParseResult.ParseError, never>,
+): Effect.Effect<A, ConfigError, never> =>
+  effect.pipe(Effect.mapError((error) => new ConfigError('workflow_parse_error', formatSchemaError(error), error)))
 
 const resolveMaybeEnvToken = (
   value: unknown,
@@ -36,39 +118,44 @@ const normalizeWorkspaceRoot = (value: unknown, env: NodeJS.ProcessEnv): string 
   if (typeof value !== 'string' || value.trim().length === 0) {
     return DEFAULT_WORKSPACE_ROOT
   }
+
   const expanded = expandPathValue(value.trim(), env)
   if (expanded.length === 0) return DEFAULT_WORKSPACE_ROOT
   if (expanded.startsWith('http://') || expanded.startsWith('https://')) return expanded
+
   if (hasPathSeparator(expanded) || expanded.startsWith('~') || expanded.startsWith('$') || path.isAbsolute(expanded)) {
     return path.resolve(expanded)
   }
+
   return expanded
 }
 
 const normalizeConcurrencyMap = (value: unknown): Record<string, number> => {
-  const raw = readMap(value)
-  const entries = Object.entries(raw)
-    .map(([key, rawValue]) => {
-      const parsed = readPositiveNumber(rawValue, Number.NaN)
-      return [normalizeState(key), parsed] as const
-    })
-    .filter(([, parsed]) => Number.isFinite(parsed) && parsed > 0)
-  return Object.fromEntries(entries)
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {}
+
+  return Object.fromEntries(
+    Object.entries(value)
+      .map(([key, rawValue]) => {
+        const parsed = readPositiveNumber(rawValue, Number.NaN)
+        return [normalizeState(key), parsed] as const
+      })
+      .filter(([, parsed]) => Number.isFinite(parsed) && parsed > 0),
+  )
 }
 
-export const toSymphonyConfig = (
+const normalizeConfig = (
   workflowPath: string,
-  rawConfig: Record<string, unknown>,
-  env: NodeJS.ProcessEnv = process.env,
+  rawConfig: RawConfigSections,
+  env: NodeJS.ProcessEnv,
 ): SymphonyConfig => {
-  const tracker = readMap(rawConfig.tracker)
-  const polling = readMap(rawConfig.polling)
-  const workspace = readMap(rawConfig.workspace)
-  const hooks = readMap(rawConfig.hooks)
-  const worker = readMap(rawConfig.worker)
-  const agent = readMap(rawConfig.agent)
-  const codex = readMap(rawConfig.codex)
-  const server = readMap(rawConfig.server)
+  const tracker = rawConfig.tracker ?? {}
+  const polling = rawConfig.polling ?? {}
+  const workspace = rawConfig.workspace ?? {}
+  const hooks = rawConfig.hooks ?? {}
+  const worker = rawConfig.worker ?? {}
+  const agent = rawConfig.agent ?? {}
+  const codex = rawConfig.codex ?? {}
+  const server = rawConfig.server ?? {}
 
   return {
     workflowPath: path.resolve(workflowPath),
@@ -115,9 +202,12 @@ export const toSymphonyConfig = (
         typeof codex.command === 'string' && codex.command.trim().length > 0
           ? codex.command.trim()
           : 'codex app-server',
-      approvalPolicy: (codex.approval_policy ?? null) as AskForApproval | null,
-      threadSandbox: (codex.thread_sandbox ?? null) as SandboxMode | null,
-      turnSandboxPolicy: (codex.turn_sandbox_policy ?? null) as SandboxPolicy | null,
+      approvalPolicy: typeof codex.approval_policy === 'string' ? (codex.approval_policy as never) : null,
+      threadSandbox: typeof codex.thread_sandbox === 'string' ? (codex.thread_sandbox as never) : null,
+      turnSandboxPolicy:
+        codex.turn_sandbox_policy && typeof codex.turn_sandbox_policy === 'object'
+          ? (codex.turn_sandbox_policy as never)
+          : null,
       turnTimeoutMs: readPositiveNumber(codex.turn_timeout_ms, 3_600_000),
       readTimeoutMs: readPositiveNumber(codex.read_timeout_ms, 5_000),
       stallTimeoutMs: readNumber(codex.stall_timeout_ms, 300_000),
@@ -129,20 +219,45 @@ export const toSymphonyConfig = (
   }
 }
 
+export const toSymphonyConfigEffect = (
+  workflowPath: string,
+  rawConfig: Record<string, unknown>,
+  env: NodeJS.ProcessEnv = process.env,
+): Effect.Effect<SymphonyConfig, ConfigError, never> =>
+  mapSchemaError(decodeRawSections(rawConfig)).pipe(
+    Effect.map((decoded) => normalizeConfig(workflowPath, decoded, env)),
+  )
+
+export const toSymphonyConfig = (
+  workflowPath: string,
+  rawConfig: Record<string, unknown>,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<SymphonyConfig> => Effect.runPromise(toSymphonyConfigEffect(workflowPath, rawConfig, env))
+
+export const validateDispatchConfigEffect = (config: SymphonyConfig): Effect.Effect<void, ConfigError, never> =>
+  Effect.gen(function* () {
+    if (!config.tracker.kind) {
+      return yield* Effect.fail(new ConfigError('unsupported_tracker_kind', 'tracker.kind is required'))
+    }
+    if (config.tracker.kind !== 'linear') {
+      return yield* Effect.fail(
+        new ConfigError('unsupported_tracker_kind', `tracker.kind ${config.tracker.kind} is not supported`),
+      )
+    }
+    if (!config.tracker.apiKey) {
+      return yield* Effect.fail(new ConfigError('missing_tracker_api_key', 'tracker.api_key is required'))
+    }
+    if (!config.tracker.projectSlug) {
+      return yield* Effect.fail(new ConfigError('missing_tracker_project_slug', 'tracker.project_slug is required'))
+    }
+    if (!config.codex.command || config.codex.command.trim().length === 0) {
+      return yield* Effect.fail(new ConfigError('invalid_codex_command', 'codex.command must be set'))
+    }
+  })
+
 export const validateDispatchConfig = (config: SymphonyConfig): void => {
-  if (!config.tracker.kind) {
-    throw new SymphonyError('unsupported_tracker_kind', 'tracker.kind is required')
-  }
-  if (config.tracker.kind !== 'linear') {
-    throw new SymphonyError('unsupported_tracker_kind', `tracker.kind ${config.tracker.kind} is not supported`)
-  }
-  if (!config.tracker.apiKey) {
-    throw new SymphonyError('missing_tracker_api_key', 'tracker.api_key is required')
-  }
-  if (!config.tracker.projectSlug) {
-    throw new SymphonyError('missing_tracker_project_slug', 'tracker.project_slug is required')
-  }
-  if (!config.codex.command || config.codex.command.trim().length === 0) {
-    throw new SymphonyError('invalid_codex_command', 'codex.command must be set')
+  const result = Effect.runSync(Effect.either(validateDispatchConfigEffect(config)))
+  if (result._tag === 'Left') {
+    throw result.left
   }
 }

--- a/services/symphony/src/errors.ts
+++ b/services/symphony/src/errors.ts
@@ -1,12 +1,112 @@
-export class SymphonyError extends Error {
-  readonly code: string
+export type SymphonyErrorTag =
+  | 'WorkflowError'
+  | 'ConfigError'
+  | 'TrackerError'
+  | 'WorkspaceError'
+  | 'CodexProtocolError'
+  | 'OrchestratorError'
+
+export type SymphonyErrorCode =
+  | 'candidate_fetch_failed'
+  | 'codex_not_found'
+  | 'dispatch_validation_failed'
+  | 'invalid_codex_command'
+  | 'invalid_issue_identifier'
+  | 'invalid_workspace_cwd'
+  | 'linear_api_request'
+  | 'linear_api_status'
+  | 'linear_graphql_errors'
+  | 'linear_graphql_invalid_input'
+  | 'linear_missing_end_cursor'
+  | 'linear_unknown_payload'
+  | 'missing_tracker_api_key'
+  | 'missing_tracker_project_slug'
+  | 'missing_workflow_file'
+  | 'orchestrator_not_started'
+  | 'port_exit'
+  | 'response_error'
+  | 'response_timeout'
+  | 'runtime_unavailable'
+  | 'startup_failed'
+  | 'template_parse_error'
+  | 'template_render_error'
+  | 'turn_cancelled'
+  | 'turn_failed'
+  | 'turn_input_required'
+  | 'turn_timeout'
+  | 'unsupported_tracker_kind'
+  | 'workflow_front_matter_not_a_map'
+  | 'workflow_parse_error'
+  | 'workspace_create_failed'
+  | 'workspace_hook_error'
+  | 'workspace_hook_timeout'
+  | 'workspace_path_not_directory'
+  | 'worker_aborted'
+
+export abstract class SymphonyError extends Error {
+  abstract readonly _tag: SymphonyErrorTag
+  readonly code: SymphonyErrorCode
   readonly causeValue: unknown
 
-  constructor(code: string, message: string, causeValue?: unknown) {
+  protected constructor(code: SymphonyErrorCode, message: string, causeValue?: unknown) {
     super(message)
     this.name = 'SymphonyError'
     this.code = code
     this.causeValue = causeValue
+  }
+}
+
+export class WorkflowError extends SymphonyError {
+  readonly _tag = 'WorkflowError' as const
+
+  constructor(code: SymphonyErrorCode, message: string, causeValue?: unknown) {
+    super(code, message, causeValue)
+    this.name = 'WorkflowError'
+  }
+}
+
+export class ConfigError extends SymphonyError {
+  readonly _tag = 'ConfigError' as const
+
+  constructor(code: SymphonyErrorCode, message: string, causeValue?: unknown) {
+    super(code, message, causeValue)
+    this.name = 'ConfigError'
+  }
+}
+
+export class TrackerError extends SymphonyError {
+  readonly _tag = 'TrackerError' as const
+
+  constructor(code: SymphonyErrorCode, message: string, causeValue?: unknown) {
+    super(code, message, causeValue)
+    this.name = 'TrackerError'
+  }
+}
+
+export class WorkspaceError extends SymphonyError {
+  readonly _tag = 'WorkspaceError' as const
+
+  constructor(code: SymphonyErrorCode, message: string, causeValue?: unknown) {
+    super(code, message, causeValue)
+    this.name = 'WorkspaceError'
+  }
+}
+
+export class CodexProtocolError extends SymphonyError {
+  readonly _tag = 'CodexProtocolError' as const
+
+  constructor(code: SymphonyErrorCode, message: string, causeValue?: unknown) {
+    super(code, message, causeValue)
+    this.name = 'CodexProtocolError'
+  }
+}
+
+export class OrchestratorError extends SymphonyError {
+  readonly _tag = 'OrchestratorError' as const
+
+  constructor(code: SymphonyErrorCode, message: string, causeValue?: unknown) {
+    super(code, message, causeValue)
+    this.name = 'OrchestratorError'
   }
 }
 
@@ -15,4 +115,18 @@ export const isSymphonyError = (value: unknown): value is SymphonyError => value
 export const toError = (error: unknown): Error => {
   if (error instanceof Error) return error
   return new Error(typeof error === 'string' ? error : JSON.stringify(error))
+}
+
+export const toLogError = (error: unknown): Record<string, unknown> => {
+  if (error instanceof SymphonyError) {
+    return {
+      error: error.message,
+      error_code: error.code,
+      error_tag: error._tag,
+    }
+  }
+
+  return {
+    error: toError(error).message,
+  }
 }

--- a/services/symphony/src/http-server.test.ts
+++ b/services/symphony/src/http-server.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from 'bun:test'
+
+import { parseIssueIdentifierPath } from './http-server'
+
+describe('http request parsing', () => {
+  test('parses issue identifier paths', () => {
+    expect(parseIssueIdentifierPath('/api/v1/ABC-123')).toEqual({ issueIdentifier: 'ABC-123' })
+  })
+
+  test('rejects empty issue identifier paths', () => {
+    expect(parseIssueIdentifierPath('/api/v1/')).toBeNull()
+  })
+})

--- a/services/symphony/src/http-server.ts
+++ b/services/symphony/src/http-server.ts
@@ -1,109 +1,48 @@
+import { Effect } from 'effect'
+import type { ManagedRuntime } from 'effect/ManagedRuntime'
+
+import { OrchestratorService } from './orchestrator'
 import type { Logger } from './logger'
-import { SymphonyOrchestrator } from './orchestrator'
+import type { RuntimeSnapshot } from './types'
 
-export class SymphonyHttpServer {
-  private readonly orchestrator: SymphonyOrchestrator
-  private readonly logger: Logger
-  private server: ReturnType<typeof Bun.serve> | null = null
+type IssueIdentifierParams = {
+  issueIdentifier: string
+}
 
-  constructor(orchestrator: SymphonyOrchestrator, logger: Logger) {
-    this.orchestrator = orchestrator
-    this.logger = logger.child({ component: 'http-server' })
-  }
+export const parseIssueIdentifierPath = (pathname: string): IssueIdentifierParams | null => {
+  if (!pathname.startsWith('/api/v1/')) return null
+  const issueIdentifier = decodeURIComponent(pathname.replace('/api/v1/', ''))
+  return issueIdentifier.length > 0 ? { issueIdentifier } : null
+}
 
-  start(port: number, host: string): number {
-    this.server = Bun.serve({
-      hostname: host,
-      port,
-      fetch: async (request) => {
-        const url = new URL(request.url)
-        if (request.method === 'GET' && (url.pathname === '/livez' || url.pathname === '/readyz')) {
-          return Response.json({ ok: true })
-        }
-        if (request.method === 'GET' && url.pathname === '/') {
-          return new Response(this.renderDashboard(), {
-            headers: { 'content-type': 'text/html; charset=utf-8' },
-          })
-        }
-        if (request.method === 'GET' && url.pathname === '/api/v1/state') {
-          return Response.json(this.orchestrator.getSnapshot())
-        }
-        if (request.method === 'POST' && url.pathname === '/api/v1/refresh') {
-          await this.orchestrator.triggerRefresh()
-          return Response.json(
-            {
-              queued: true,
-              coalesced: false,
-              requestedAt: new Date().toISOString(),
-              operations: ['poll', 'reconcile'],
-            },
-            { status: 202 },
-          )
-        }
-        if (request.method === 'GET' && url.pathname.startsWith('/api/v1/')) {
-          const issueIdentifier = decodeURIComponent(url.pathname.replace('/api/v1/', ''))
-          if (issueIdentifier.length === 0) {
-            return Response.json(
-              { error: { code: 'invalid_issue_identifier', message: 'missing issue identifier' } },
-              { status: 400 },
-            )
-          }
-          const details = this.orchestrator.getIssueDetails(issueIdentifier)
-          if (!details) {
-            return Response.json(
-              { error: { code: 'issue_not_found', message: `issue ${issueIdentifier} is not in memory` } },
-              { status: 404 },
-            )
-          }
-          return Response.json(details)
-        }
-        if (url.pathname === '/' || url.pathname.startsWith('/api/v1/')) {
-          return Response.json(
-            { error: { code: 'method_not_allowed', message: 'method not allowed' } },
-            { status: 405 },
-          )
-        }
-        return Response.json({ error: { code: 'not_found', message: 'not found' } }, { status: 404 })
-      },
-    })
-    this.logger.log('info', 'http_server_started', { host, port: this.server.port })
-    return this.server.port ?? port
-  }
+const renderDashboard = (snapshot: RuntimeSnapshot) => {
+  const runningRows = snapshot.running
+    .map(
+      (row) => `
+        <tr>
+          <td>${row.issueIdentifier}</td>
+          <td>${row.state}</td>
+          <td>${row.turnCount}</td>
+          <td>${row.lastEvent ?? ''}</td>
+          <td>${row.lastMessage ?? ''}</td>
+          <td>${row.tokens.totalTokens}</td>
+        </tr>`,
+    )
+    .join('')
 
-  stop(): void {
-    void this.server?.stop(true)
-    this.server = null
-  }
+  const retryRows = snapshot.retrying
+    .map(
+      (row) => `
+        <tr>
+          <td>${row.issueIdentifier}</td>
+          <td>${row.attempt}</td>
+          <td>${row.dueAt}</td>
+          <td>${row.error ?? ''}</td>
+        </tr>`,
+    )
+    .join('')
 
-  private renderDashboard(): string {
-    const snapshot = this.orchestrator.getSnapshot()
-    const runningRows = snapshot.running
-      .map(
-        (row) => `
-          <tr>
-            <td>${row.issueIdentifier}</td>
-            <td>${row.state}</td>
-            <td>${row.turnCount}</td>
-            <td>${row.lastEvent ?? ''}</td>
-            <td>${row.lastMessage ?? ''}</td>
-            <td>${row.tokens.totalTokens}</td>
-          </tr>`,
-      )
-      .join('')
-
-    const retryRows = snapshot.retrying
-      .map(
-        (row) => `
-          <tr>
-            <td>${row.issueIdentifier}</td>
-            <td>${row.attempt}</td>
-            <td>${row.dueAt}</td>
-            <td>${row.error ?? ''}</td>
-          </tr>`,
-      )
-      .join('')
-
-    return `<!doctype html>
+  return `<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />
@@ -137,5 +76,100 @@ export class SymphonyHttpServer {
     </table>
   </body>
 </html>`
+}
+
+const handleRequestEffect = (request: Request) =>
+  Effect.gen(function* () {
+    const orchestrator = yield* OrchestratorService
+    const url = new URL(request.url)
+
+    if (request.method === 'GET' && (url.pathname === '/livez' || url.pathname === '/readyz')) {
+      return Response.json({ ok: true })
+    }
+
+    if (request.method === 'GET' && url.pathname === '/') {
+      const snapshot = yield* orchestrator.getSnapshot
+      return new Response(renderDashboard(snapshot as never), {
+        headers: { 'content-type': 'text/html; charset=utf-8' },
+      })
+    }
+
+    if (request.method === 'GET' && url.pathname === '/api/v1/state') {
+      return Response.json(yield* orchestrator.getSnapshot)
+    }
+
+    if (request.method === 'POST' && url.pathname === '/api/v1/refresh') {
+      yield* orchestrator.triggerRefresh
+      return Response.json(
+        {
+          queued: true,
+          coalesced: false,
+          requestedAt: new Date().toISOString(),
+          operations: ['poll', 'reconcile'],
+        },
+        { status: 202 },
+      )
+    }
+
+    if (request.method === 'GET' && url.pathname.startsWith('/api/v1/')) {
+      const params = parseIssueIdentifierPath(url.pathname)
+      if (!params) {
+        return Response.json(
+          { error: { code: 'invalid_issue_identifier', message: 'missing issue identifier' } },
+          { status: 400 },
+        )
+      }
+
+      const details = yield* orchestrator.getIssueDetails(params.issueIdentifier)
+      if (!details) {
+        return Response.json(
+          { error: { code: 'issue_not_found', message: `issue ${params.issueIdentifier} is not in memory` } },
+          { status: 404 },
+        )
+      }
+      return Response.json(details)
+    }
+
+    if (url.pathname === '/' || url.pathname.startsWith('/api/v1/')) {
+      return Response.json({ error: { code: 'method_not_allowed', message: 'method not allowed' } }, { status: 405 })
+    }
+
+    return Response.json({ error: { code: 'not_found', message: 'not found' } }, { status: 404 })
+  })
+
+export class SymphonyHttpServer<R, E> {
+  private readonly runtime: ManagedRuntime<R, E>
+  private readonly logger: Logger
+  private server: ReturnType<typeof Bun.serve> | null = null
+
+  constructor(runtime: ManagedRuntime<R, E>, logger: Logger) {
+    this.runtime = runtime
+    this.logger = logger.child({ component: 'http-server' })
+  }
+
+  start(port: number, host: string): number {
+    this.server = Bun.serve({
+      hostname: host,
+      port,
+      fetch: (request): Promise<Response> =>
+        (this.runtime.runPromise(handleRequestEffect(request) as never) as Promise<Response>).catch((error: unknown) =>
+          Response.json(
+            {
+              error: {
+                code: 'internal_error',
+                message: error instanceof Error ? error.message : String(error),
+              },
+            },
+            { status: 500 },
+          ),
+        ),
+    })
+    this.logger.log('info', 'http_server_started', { host, port: this.server.port })
+    return this.server.port ?? port
+  }
+
+  stop(): void {
+    void this.server?.stop(true)
+    this.server = null
   }
 }

--- a/services/symphony/src/index.ts
+++ b/services/symphony/src/index.ts
@@ -1,8 +1,10 @@
-import { access } from 'node:fs/promises'
 import process from 'node:process'
 
+import { Deferred, Effect } from 'effect'
+
+import { OrchestratorService } from './orchestrator'
 import { createLogger } from './logger'
-import { SymphonyOrchestrator } from './orchestrator'
+import { makeSymphonyRuntime } from './runtime'
 import { SymphonyHttpServer } from './http-server'
 import { toError } from './errors'
 
@@ -40,29 +42,54 @@ const parseArgs = (argv: string[]) => {
 const main = async () => {
   const logger = createLogger({ service: 'symphony' })
   const { workflowPath, host: cliHost, port: cliPort } = parseArgs(process.argv.slice(2))
-  await access(workflowPath)
+  const runtime = makeSymphonyRuntime(workflowPath, logger)
 
-  const orchestrator = new SymphonyOrchestrator(workflowPath, logger)
-  await orchestrator.start()
+  try {
+    await runtime.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const orchestrator = yield* OrchestratorService
+          yield* orchestrator.start
 
-  let httpServer: SymphonyHttpServer | null = null
-  const workflowServer = (await orchestrator.getCurrentConfig()).server
-  const hostToUse = cliHost ?? workflowServer.host
-  const workflowPort = workflowServer.port
-  const portToUse = cliPort ?? workflowPort
-  if (portToUse !== null && Number.isFinite(portToUse)) {
-    httpServer = new SymphonyHttpServer(orchestrator, logger)
-    httpServer.start(portToUse, hostToUse)
+          const workflowServer = yield* orchestrator.getCurrentConfig.pipe(Effect.map((config) => config.server))
+          const hostToUse = cliHost ?? workflowServer.host
+          const portToUse = cliPort ?? workflowServer.port
+
+          let httpServer: SymphonyHttpServer<never, never> | null = null
+          yield* Effect.addFinalizer(() =>
+            Effect.sync(() => {
+              httpServer?.stop()
+            }),
+          )
+
+          if (portToUse !== null && Number.isFinite(portToUse)) {
+            httpServer = new SymphonyHttpServer(runtime as never, logger)
+            httpServer.start(portToUse, hostToUse)
+          }
+
+          const shutdownSignal = yield* Deferred.make<void, never>()
+          const onSignal = () => {
+            void runtime.runPromise(Deferred.succeed(shutdownSignal, undefined))
+          }
+
+          process.on('SIGINT', onSignal)
+          process.on('SIGTERM', onSignal)
+
+          yield* Effect.addFinalizer(() =>
+            Effect.sync(() => {
+              process.off('SIGINT', onSignal)
+              process.off('SIGTERM', onSignal)
+            }),
+          )
+
+          yield* Deferred.await(shutdownSignal)
+          yield* orchestrator.stop
+        }),
+      ),
+    )
+  } finally {
+    await runtime.dispose()
   }
-
-  const shutdown = async () => {
-    httpServer?.stop()
-    await orchestrator.stop()
-    process.exit(0)
-  }
-
-  process.on('SIGINT', () => void shutdown())
-  process.on('SIGTERM', () => void shutdown())
 }
 
 main().catch((error) => {

--- a/services/symphony/src/issue-runner.ts
+++ b/services/symphony/src/issue-runner.ts
@@ -1,13 +1,15 @@
 import type { DynamicToolCallResponse, DynamicToolSpec } from '@proompteng/codex'
+import { Context, Effect, Layer } from 'effect'
 
-import { SymphonyError, toError } from './errors'
-import type { Logger } from './logger'
-import { renderPromptTemplate } from './template'
-import type { Issue, SymphonyConfig, WorkflowDefinition } from './types'
-import type { IssueTrackerClient } from './linear-client'
+import { CodexProtocolError, ConfigError, toLogError, TrackerError, WorkspaceError, WorkflowError } from './errors'
+import { CodexSessionService, type CodexEvent } from './codex-app-session'
+import { TrackerService } from './linear-client'
+import type { Issue } from './types'
 import { normalizeState } from './utils'
-import { CodexAppSession, type CodexEvent } from './codex-app-session'
-import { WorkspaceManager } from './workspace-manager'
+import { WorkflowService } from './workflow'
+import { WorkspaceService } from './workspace-manager'
+import { renderPromptTemplate } from './template'
+import type { Logger } from './logger'
 
 const FALLBACK_PROMPT = 'You are working on an issue from Linear.'
 
@@ -33,61 +35,36 @@ const buildContinuationPrompt = (issue: Issue, turnNumber: number, maxTurns: num
     'If the issue is already complete or blocked, leave a concise handoff in the tracker/tooling available to you and stop.',
   ].join('\n')
 
-export class IssueRunner {
-  private readonly configProvider: () => Promise<SymphonyConfig>
-  private readonly workflowProvider: () => Promise<{ definition: WorkflowDefinition; config: SymphonyConfig }>
-  private readonly tracker: IssueTrackerClient
-  private readonly workspaceManager: WorkspaceManager
-  private readonly logger: Logger
+export type IssueRunnerCallbacks = {
+  onEvent: (event: CodexEvent) => Effect.Effect<void, never>
+  onWorkspacePath: (workspacePath: string) => Effect.Effect<void, never>
+}
 
-  constructor(options: {
-    configProvider: () => Promise<SymphonyConfig>
-    workflowProvider: () => Promise<{ definition: WorkflowDefinition; config: SymphonyConfig }>
-    tracker: IssueTrackerClient
-    workspaceManager: WorkspaceManager
-    logger: Logger
-  }) {
-    this.configProvider = options.configProvider
-    this.workflowProvider = options.workflowProvider
-    this.tracker = options.tracker
-    this.workspaceManager = options.workspaceManager
-    this.logger = options.logger.child({ component: 'issue-runner' })
-  }
-
-  async runAttempt(
+export interface IssueRunnerServiceDefinition {
+  readonly runAttempt: (
     issue: Issue,
     attempt: number | null,
-    onEvent: (event: CodexEvent) => void,
-    signal: AbortSignal,
-  ): Promise<string> {
-    const { definition, config } = await this.workflowProvider()
-    const workspace = await this.workspaceManager.createForIssue(issue.identifier)
-    let session: CodexAppSession | null = null
-    let lastIssue = issue
+    callbacks: IssueRunnerCallbacks,
+  ) => Effect.Effect<string, WorkflowError | ConfigError | TrackerError | WorkspaceError | CodexProtocolError>
+}
 
-    try {
-      await this.workspaceManager.runBeforeRun(workspace.path)
+export class IssueRunnerService extends Context.Tag('symphony/IssueRunnerService')<
+  IssueRunnerService,
+  IssueRunnerServiceDefinition
+>() {}
 
-      const initialPrompt =
-        definition.promptTemplate.trim().length > 0
-          ? renderPromptTemplate(definition.promptTemplate, { issue, attempt })
-          : FALLBACK_PROMPT
+export const makeIssueRunnerLayer = (logger: Logger) =>
+  Layer.effect(
+    IssueRunnerService,
+    Effect.gen(function* () {
+      const workflow = yield* WorkflowService
+      const tracker = yield* TrackerService
+      const workspace = yield* WorkspaceService
+      const codexSessions = yield* CodexSessionService
+      const issueRunnerLogger = logger.child({ component: 'issue-runner' })
 
-      const dynamicTools = config.tracker.kind === 'linear' && config.tracker.apiKey ? [LINEAR_GRAPHQL_TOOL] : []
-
-      session = new CodexAppSession({
-        command: config.codex.command,
-        cwd: workspace.path,
-        approvalPolicy: config.codex.approvalPolicy,
-        threadSandbox: config.codex.threadSandbox,
-        turnSandboxPolicy: config.codex.turnSandboxPolicy,
-        readTimeoutMs: config.codex.readTimeoutMs,
-        turnTimeoutMs: config.codex.turnTimeoutMs,
-        title: `${issue.identifier}: ${issue.title}`,
-        dynamicTools,
-        logger: this.logger.child({ issue_id: issue.id, issue_identifier: issue.identifier }),
-        onEvent,
-        onToolCall: async (toolName, args) => {
+      const handleToolCall = (toolName: string, args: unknown): Effect.Effect<DynamicToolCallResponse, never> =>
+        Effect.gen(function* () {
           if (toolName !== 'linear_graphql') {
             return {
               success: false,
@@ -96,9 +73,16 @@ export class IssueRunner {
           }
 
           if (typeof args === 'string') {
-            const response = await this.tracker.executeLinearGraphql(args)
+            const response = yield* tracker.executeLinearGraphql(args).pipe(
+              Effect.catchAll((error) =>
+                Effect.succeed({
+                  error: error.message,
+                  code: error.code,
+                }),
+              ),
+            )
             return {
-              success: true,
+              success: !('error' in response),
               contentItems: [{ type: 'inputText', text: JSON.stringify(response) }],
             } satisfies DynamicToolCallResponse
           }
@@ -107,61 +91,108 @@ export class IssueRunner {
           const query = typeof raw.query === 'string' ? raw.query : ''
           const variables =
             raw.variables && typeof raw.variables === 'object' ? (raw.variables as Record<string, unknown>) : {}
+
           if (query.trim().length === 0) {
             return {
               success: false,
               contentItems: [{ type: 'inputText', text: JSON.stringify({ error: 'invalid_query' }) }],
             } satisfies DynamicToolCallResponse
           }
-          const response = await this.tracker.executeLinearGraphql(query, variables)
+
+          const response = yield* tracker.executeLinearGraphql(query, variables).pipe(
+            Effect.catchAll((error) =>
+              Effect.succeed({
+                error: error.message,
+                code: error.code,
+              }),
+            ),
+          )
           return {
-            success: true,
+            success: !('error' in response),
             contentItems: [{ type: 'inputText', text: JSON.stringify(response) }],
           } satisfies DynamicToolCallResponse
-        },
-      })
-
-      for (let turnNumber = 1; turnNumber <= config.agent.maxTurns; turnNumber += 1) {
-        if (signal.aborted) {
-          throw new SymphonyError('worker_aborted', 'worker was aborted')
-        }
-
-        const prompt =
-          turnNumber === 1 ? initialPrompt : buildContinuationPrompt(lastIssue, turnNumber, config.agent.maxTurns)
-        const outcome = await session.runTurn(prompt)
-        if (outcome.status !== 'completed') {
-          throw new SymphonyError('turn_failed', `turn ${outcome.turnId} ended with status ${outcome.status}`)
-        }
-
-        const refreshed = await this.tracker.fetchIssueStatesByIds([lastIssue.id])
-        if (refreshed.length === 0) {
-          break
-        }
-        lastIssue = refreshed[0]
-        const normalizedState = normalizeState(lastIssue.state)
-        const activeStates = new Set(config.tracker.activeStates.map((state) => normalizeState(state)))
-        if (!activeStates.has(normalizedState)) {
-          break
-        }
-      }
-
-      return workspace.path
-    } catch (error) {
-      if (signal.aborted) {
-        throw new SymphonyError('worker_aborted', 'worker was aborted', error)
-      }
-      throw error
-    } finally {
-      session?.stop()
-      try {
-        await this.workspaceManager.runAfterRun(workspace.path)
-      } catch (error) {
-        this.logger.log('warn', 'workspace_after_run_failed', {
-          issue_id: issue.id,
-          issue_identifier: issue.identifier,
-          error: toError(error).message,
         })
-      }
-    }
-  }
-}
+
+      return {
+        runAttempt: (issue, attempt, callbacks) =>
+          Effect.scoped(
+            Effect.gen(function* () {
+              const { definition, config } = yield* workflow.current
+              const runLogger = issueRunnerLogger.child({ issue_id: issue.id, issue_identifier: issue.identifier })
+              const workspaceInfo = yield* workspace.createForIssue(issue.identifier)
+              yield* callbacks.onWorkspacePath(workspaceInfo.path)
+              let lastIssue = issue
+
+              const dynamicTools =
+                config.tracker.kind === 'linear' && config.tracker.apiKey ? [LINEAR_GRAPHQL_TOOL] : []
+
+              const initialPrompt =
+                definition.promptTemplate.trim().length > 0
+                  ? renderPromptTemplate(definition.promptTemplate, { issue, attempt })
+                  : FALLBACK_PROMPT
+
+              const session = yield* codexSessions.createSession({
+                command: config.codex.command,
+                cwd: workspaceInfo.path,
+                approvalPolicy: config.codex.approvalPolicy,
+                threadSandbox: config.codex.threadSandbox,
+                turnSandboxPolicy: config.codex.turnSandboxPolicy,
+                readTimeoutMs: config.codex.readTimeoutMs,
+                turnTimeoutMs: config.codex.turnTimeoutMs,
+                title: `${issue.identifier}: ${issue.title}`,
+                dynamicTools,
+                logger: runLogger,
+                onEvent: callbacks.onEvent,
+                onToolCall: handleToolCall,
+              })
+
+              yield* workspace.runBeforeRun(workspaceInfo.path)
+
+              const program = Effect.gen(function* () {
+                for (let turnNumber = 1; turnNumber <= config.agent.maxTurns; turnNumber += 1) {
+                  const prompt =
+                    turnNumber === 1
+                      ? initialPrompt
+                      : buildContinuationPrompt(lastIssue, turnNumber, config.agent.maxTurns)
+                  const outcome = yield* session.runTurn(prompt)
+                  if (outcome.status !== 'completed') {
+                    return yield* Effect.fail(
+                      new CodexProtocolError(
+                        'turn_failed',
+                        `turn ${outcome.turnId} ended with status ${outcome.status}`,
+                      ),
+                    )
+                  }
+
+                  const refreshed = yield* tracker.fetchIssueStatesByIds([lastIssue.id])
+                  if (refreshed.length === 0) {
+                    break
+                  }
+                  lastIssue = refreshed[0]
+
+                  const latestConfig = yield* workflow.config
+                  const activeStates = new Set(latestConfig.tracker.activeStates.map((state) => normalizeState(state)))
+                  if (!activeStates.has(normalizeState(lastIssue.state))) {
+                    break
+                  }
+                }
+
+                return workspaceInfo.path
+              })
+
+              return yield* program.pipe(
+                Effect.ensuring(
+                  workspace.runAfterRun(workspaceInfo.path).pipe(
+                    Effect.catchAll((error) =>
+                      Effect.sync(() => {
+                        runLogger.log('warn', 'workspace_after_run_failed', toLogError(error))
+                      }),
+                    ),
+                  ),
+                ),
+              )
+            }),
+          ),
+      } satisfies IssueRunnerServiceDefinition
+    }),
+  )

--- a/services/symphony/src/linear-client.test.ts
+++ b/services/symphony/src/linear-client.test.ts
@@ -1,7 +1,12 @@
 import { afterEach, describe, expect, test } from 'bun:test'
 
-import { createLinearTrackerClient } from './linear-client'
+import { Effect, Layer, ManagedRuntime } from 'effect'
+import * as Stream from 'effect/Stream'
+
+import { createLogger } from './logger'
+import { makeTrackerLayer, TrackerService } from './linear-client'
 import type { SymphonyConfig } from './types'
+import { WorkflowService } from './workflow'
 
 const baseConfig: SymphonyConfig = {
   workflowPath: '/tmp/WORKFLOW.md',
@@ -53,6 +58,20 @@ afterEach(() => {
   globalThis.fetch = originalFetch
 })
 
+const makeRuntime = () =>
+  ManagedRuntime.make(
+    makeTrackerLayer(createLogger({ test: 'linear' })).pipe(
+      Layer.provide(
+        Layer.succeed(WorkflowService, {
+          current: Effect.succeed({ definition: { config: {}, promptTemplate: '' }, config: baseConfig }),
+          config: Effect.succeed(baseConfig),
+          reload: Effect.succeed({ definition: { config: {}, promptTemplate: '' }, config: baseConfig }),
+          changes: Stream.empty,
+        }),
+      ),
+    ),
+  )
+
 describe('linear tracker client', () => {
   test('fetchIssuesByStates skips API calls for empty inputs', async () => {
     let called = false
@@ -61,11 +80,20 @@ describe('linear tracker client', () => {
       throw new Error('should not be called')
     }) as unknown as typeof fetch
 
-    const client = await createLinearTrackerClient(async () => baseConfig)
-    const issues = await client.fetchIssuesByStates([])
+    const runtime = makeRuntime()
+    try {
+      const issues = await runtime.runPromise(
+        Effect.gen(function* () {
+          const tracker = yield* TrackerService
+          return yield* tracker.fetchIssuesByStates([])
+        }),
+      )
 
-    expect(issues).toEqual([])
-    expect(called).toBe(false)
+      expect(issues).toEqual([])
+      expect(called).toBe(false)
+    } finally {
+      await runtime.dispose()
+    }
   })
 
   test('fetchCandidateIssues normalizes labels and blockers', async () => {
@@ -113,15 +141,24 @@ describe('linear tracker client', () => {
       )
     }) as unknown as typeof fetch
 
-    const client = await createLinearTrackerClient(async () => baseConfig)
-    const issues = await client.fetchCandidateIssues()
+    const runtime = makeRuntime()
+    try {
+      const issues = await runtime.runPromise(
+        Effect.gen(function* () {
+          const tracker = yield* TrackerService
+          return yield* tracker.fetchCandidateIssues
+        }),
+      )
 
-    expect(requests).toHaveLength(1)
-    expect(requests[0]?.query).toContain('slugId')
-    expect(requests[0]?.query).not.toContain('inverseRelations(filter:')
-    expect(requests[0]?.variables.projectSlug).toBe('symphony')
-    expect(issues).toHaveLength(1)
-    expect(issues[0]?.labels).toEqual(['bug', 'high'])
-    expect(issues[0]?.blockedBy).toEqual([{ id: 'issue-0', identifier: 'ABC-122', state: 'In Progress' }])
+      expect(requests).toHaveLength(1)
+      expect(requests[0]?.query).toContain('slugId')
+      expect(requests[0]?.query).not.toContain('inverseRelations(filter:')
+      expect(requests[0]?.variables.projectSlug).toBe('symphony')
+      expect(issues).toHaveLength(1)
+      expect(issues[0]?.labels).toEqual(['bug', 'high'])
+      expect(issues[0]?.blockedBy).toEqual([{ id: 'issue-0', identifier: 'ABC-122', state: 'In Progress' }])
+    } finally {
+      await runtime.dispose()
+    }
   })
 })

--- a/services/symphony/src/linear-client.ts
+++ b/services/symphony/src/linear-client.ts
@@ -1,23 +1,115 @@
-import { SymphonyError } from './errors'
-import type { Issue, SymphonyConfig } from './types'
+import type * as ParseResult from '@effect/schema/ParseResult'
+import * as Schema from '@effect/schema/Schema'
+import * as TreeFormatter from '@effect/schema/TreeFormatter'
+import { Context, Effect, Layer } from 'effect'
+
+import { ConfigError, TrackerError, WorkflowError, toLogError } from './errors'
+import type { Issue } from './types'
 import { normalizeState, parseIsoTimestamp } from './utils'
+import { WorkflowService } from './workflow'
+import type { Logger } from './logger'
 
 const PAGE_SIZE = 50
 const REQUEST_TIMEOUT_MS = 30_000
-
-type GraphqlResponse = {
-  data?: Record<string, unknown>
-  errors?: unknown
-}
-
-type IssueTrackerClient = {
-  fetchCandidateIssues: () => Promise<Issue[]>
-  fetchIssuesByStates: (states: string[]) => Promise<Issue[]>
-  fetchIssueStatesByIds: (issueIds: string[]) => Promise<Issue[]>
-  executeLinearGraphql: (query: string, variables?: Record<string, unknown>) => Promise<Record<string, unknown>>
-}
-
 const singleOperationPattern = /\b(query|mutation|subscription)\b/g
+
+const NullableStringSchema = Schema.optionalWith(Schema.String, { nullable: true })
+
+const IssueNodeSchema = Schema.Struct({
+  id: NullableStringSchema,
+  identifier: NullableStringSchema,
+  title: NullableStringSchema,
+  description: NullableStringSchema,
+  priority: Schema.optionalWith(Schema.Union(Schema.Number, Schema.String), { nullable: true }),
+  branchName: NullableStringSchema,
+  url: NullableStringSchema,
+  createdAt: NullableStringSchema,
+  updatedAt: NullableStringSchema,
+  state: Schema.optionalWith(
+    Schema.Struct({
+      name: NullableStringSchema,
+    }),
+    { nullable: true },
+  ),
+  labels: Schema.optionalWith(
+    Schema.Struct({
+      nodes: Schema.optionalWith(
+        Schema.Array(
+          Schema.Struct({
+            name: NullableStringSchema,
+          }),
+        ),
+        { nullable: true },
+      ),
+    }),
+    { nullable: true },
+  ),
+  inverseRelations: Schema.optionalWith(
+    Schema.Struct({
+      nodes: Schema.optionalWith(
+        Schema.Array(
+          Schema.Struct({
+            type: NullableStringSchema,
+            issue: Schema.optionalWith(
+              Schema.Struct({
+                id: NullableStringSchema,
+                identifier: NullableStringSchema,
+                state: Schema.optionalWith(
+                  Schema.Struct({
+                    name: NullableStringSchema,
+                  }),
+                  { nullable: true },
+                ),
+              }),
+              { nullable: true },
+            ),
+            sourceIssue: Schema.optionalWith(
+              Schema.Struct({
+                id: NullableStringSchema,
+                identifier: NullableStringSchema,
+                state: Schema.optionalWith(
+                  Schema.Struct({
+                    name: NullableStringSchema,
+                  }),
+                  { nullable: true },
+                ),
+              }),
+              { nullable: true },
+            ),
+          }),
+        ),
+        { nullable: true },
+      ),
+    }),
+    { nullable: true },
+  ),
+})
+
+const IssuesPageSchema = Schema.Struct({
+  issues: Schema.Struct({
+    nodes: Schema.optionalWith(Schema.Array(IssueNodeSchema), { nullable: true }),
+    pageInfo: Schema.optionalWith(
+      Schema.Struct({
+        hasNextPage: Schema.optionalWith(Schema.Boolean, { nullable: true }),
+        endCursor: NullableStringSchema,
+      }),
+      { nullable: true },
+    ),
+  }),
+})
+
+const GraphqlEnvelopeSchema = Schema.Struct({
+  data: Schema.optionalWith(Schema.Unknown, { nullable: true }),
+  errors: Schema.optionalWith(Schema.Unknown, { nullable: true }),
+})
+
+type IssueNode = typeof IssueNodeSchema.Type
+type IssuesPage = typeof IssuesPageSchema.Type
+
+const decodeIssuesPage = Schema.decodeUnknown(IssuesPageSchema)
+const decodeGraphqlEnvelope = Schema.decodeUnknown(GraphqlEnvelopeSchema)
+
+const formatSchemaError = (error: ParseResult.ParseError): string => TreeFormatter.formatErrorSync(error)
 
 const readText = (value: unknown): string | null => (typeof value === 'string' ? value : null)
 
@@ -28,124 +120,126 @@ const normalizePriority = (value: unknown): number | null =>
       ? Number.parseInt(value, 10)
       : null
 
-const normalizeLabels = (value: unknown): string[] => {
-  const nodes = Array.isArray((value as { nodes?: unknown } | null | undefined)?.nodes)
-    ? ((value as { nodes: Array<Record<string, unknown>> }).nodes ?? [])
-    : []
-  return nodes
-    .map((entry) => (typeof entry.name === 'string' ? entry.name.trim().toLowerCase() : ''))
-    .filter((entry) => entry.length > 0)
-}
+const normalizeLabels = (node: IssueNode): string[] =>
+  (node.labels?.nodes ?? []).map((entry) => entry.name?.trim().toLowerCase() ?? '').filter((entry) => entry.length > 0)
 
-const normalizeBlockedBy = (value: unknown) => {
-  const nodes = Array.isArray((value as { nodes?: unknown } | null | undefined)?.nodes)
-    ? ((value as { nodes: Array<Record<string, unknown>> }).nodes ?? [])
-    : []
-  return nodes
-    .filter((entry) => normalizeState(typeof entry.type === 'string' ? entry.type : null) === 'blocks')
+const normalizeBlockedBy = (node: IssueNode) =>
+  (node.inverseRelations?.nodes ?? [])
+    .filter((entry) => normalizeState(entry.type) === 'blocks')
     .map((entry) => {
-      const blocker = (entry.issue ?? entry.sourceIssue ?? null) as Record<string, unknown> | null
-      const blockerState = (blocker?.state ?? null) as Record<string, unknown> | null
+      const blocker = entry.issue ?? entry.sourceIssue ?? null
       return {
-        id: typeof blocker?.id === 'string' ? blocker.id : null,
-        identifier: typeof blocker?.identifier === 'string' ? blocker.identifier : null,
-        state: typeof blockerState?.name === 'string' ? blockerState.name : null,
+        id: blocker?.id ?? null,
+        identifier: blocker?.identifier ?? null,
+        state: blocker?.state?.name ?? null,
       }
     })
-}
 
-const normalizeIssue = (node: Record<string, unknown>): Issue => {
-  const statePayload = (node.state ?? null) as Record<string, unknown> | null
-  return {
-    id: readText(node.id) ?? '',
-    identifier: readText(node.identifier) ?? '',
-    title: readText(node.title) ?? '',
-    description: readText(node.description),
-    priority: normalizePriority(node.priority),
-    state: readText(statePayload?.name) ?? '',
-    branchName: readText(node.branchName),
-    url: readText(node.url),
-    labels: normalizeLabels(node.labels),
-    blockedBy: normalizeBlockedBy(node.inverseRelations),
-    createdAt: parseIsoTimestamp(node.createdAt),
-    updatedAt: parseIsoTimestamp(node.updatedAt),
-  }
-}
+const normalizeIssue = (node: IssueNode): Issue => ({
+  id: node.id ?? '',
+  identifier: node.identifier ?? '',
+  title: node.title ?? '',
+  description: readText(node.description),
+  priority: normalizePriority(node.priority),
+  state: node.state?.name ?? '',
+  branchName: readText(node.branchName),
+  url: readText(node.url),
+  labels: normalizeLabels(node),
+  blockedBy: normalizeBlockedBy(node),
+  createdAt: parseIsoTimestamp(node.createdAt),
+  updatedAt: parseIsoTimestamp(node.updatedAt),
+})
 
-const validateOperationCount = (query: string): void => {
+const mapSchemaError = (error: ParseResult.ParseError) =>
+  new TrackerError('linear_unknown_payload', formatSchemaError(error), error)
+
+const validateOperationCount = (query: string): Effect.Effect<void, TrackerError, never> => {
   const matches = query.match(singleOperationPattern) ?? []
-  if (matches.length > 1) {
-    throw new SymphonyError(
-      'linear_graphql_invalid_input',
-      'linear_graphql accepts exactly one GraphQL operation per call',
-    )
-  }
+  return matches.length > 1
+    ? Effect.fail(
+        new TrackerError(
+          'linear_graphql_invalid_input',
+          'linear_graphql accepts exactly one GraphQL operation per call',
+        ),
+      )
+    : Effect.void
 }
 
-const requestGraphql = async (
-  config: SymphonyConfig,
+const requestGraphql = (
+  endpoint: string,
+  apiKey: string,
   query: string,
-  variables: Record<string, unknown> = {},
-): Promise<Record<string, unknown>> => {
-  const controller = new AbortController()
-  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS)
+  variables: Record<string, unknown>,
+): Effect.Effect<unknown, TrackerError, never> =>
+  Effect.gen(function* () {
+    const controller = new AbortController()
 
-  try {
-    const response = await fetch(config.tracker.endpoint, {
-      method: 'POST',
-      headers: {
-        'content-type': 'application/json',
-        authorization: config.tracker.apiKey ?? '',
-      },
-      body: JSON.stringify({ query, variables }),
-      signal: controller.signal,
+    const response = yield* Effect.tryPromise({
+      try: () =>
+        fetch(endpoint, {
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+            authorization: apiKey,
+          },
+          body: JSON.stringify({ query, variables }),
+          signal: controller.signal,
+        }),
+      catch: (error) => new TrackerError('linear_api_request', 'Linear API request failed', error),
+    }).pipe(
+      Effect.timeoutFail({
+        duration: REQUEST_TIMEOUT_MS,
+        onTimeout: () => {
+          controller.abort()
+          return new TrackerError('linear_api_request', `Linear API request timed out after ${REQUEST_TIMEOUT_MS}ms`)
+        },
+      }),
+    )
+
+    const bodyText = yield* Effect.tryPromise({
+      try: () => response.text(),
+      catch: (error) => new TrackerError('linear_api_request', 'failed to read Linear API response', error),
     })
 
     if (!response.ok) {
-      const body = await response.text()
-      throw new SymphonyError('linear_api_status', `Linear API returned ${response.status}`, body)
-    }
-
-    const payload = (await response.json()) as GraphqlResponse
-    if (payload.errors) {
-      throw new SymphonyError('linear_graphql_errors', 'Linear GraphQL request returned errors', payload.errors)
-    }
-    if (!payload.data || typeof payload.data !== 'object') {
-      throw new SymphonyError(
-        'linear_unknown_payload',
-        'Linear GraphQL response did not include a data object',
-        payload,
+      return yield* Effect.fail(
+        new TrackerError('linear_api_status', `Linear API returned ${response.status}`, bodyText),
       )
     }
 
-    return payload.data
-  } catch (error) {
-    if (error instanceof SymphonyError) throw error
-    if (error instanceof DOMException && error.name === 'AbortError') {
-      throw new SymphonyError('linear_api_request', `Linear API request timed out after ${REQUEST_TIMEOUT_MS}ms`)
+    const rawJson = yield* Effect.try({
+      try: () => (bodyText.length === 0 ? {} : JSON.parse(bodyText)),
+      catch: (error) => new TrackerError('linear_unknown_payload', 'Linear API returned invalid JSON', error),
+    })
+
+    const envelope = yield* decodeGraphqlEnvelope(rawJson).pipe(Effect.mapError(mapSchemaError))
+    if (envelope.errors) {
+      return yield* Effect.fail(
+        new TrackerError('linear_graphql_errors', 'Linear GraphQL request returned errors', envelope.errors),
+      )
     }
-    throw new SymphonyError('linear_api_request', 'Linear API request failed', error)
-  } finally {
-    clearTimeout(timeout)
-  }
+    if (envelope.data === null || envelope.data === undefined) {
+      return yield* Effect.fail(
+        new TrackerError('linear_unknown_payload', 'Linear GraphQL response did not include a data object', rawJson),
+      )
+    }
+
+    return envelope.data
+  })
+
+export interface IssueTrackerClient {
+  readonly fetchCandidateIssues: Effect.Effect<Issue[], WorkflowError | ConfigError | TrackerError>
+  readonly fetchIssuesByStates: (states: string[]) => Effect.Effect<Issue[], WorkflowError | ConfigError | TrackerError>
+  readonly fetchIssueStatesByIds: (
+    issueIds: string[],
+  ) => Effect.Effect<Issue[], WorkflowError | ConfigError | TrackerError>
+  readonly executeLinearGraphql: (
+    query: string,
+    variables?: Record<string, unknown>,
+  ) => Effect.Effect<Record<string, unknown>, WorkflowError | ConfigError | TrackerError>
 }
 
-const collectIssuePage = (
-  payload: Record<string, unknown>,
-): { nodes: Record<string, unknown>[]; hasNextPage: boolean; endCursor: string | null } => {
-  const issues = (payload.issues ?? null) as Record<string, unknown> | null
-  const nodes = Array.isArray(issues?.nodes) ? (issues?.nodes as Record<string, unknown>[]) : []
-  const pageInfo = (issues?.pageInfo ?? null) as Record<string, unknown> | null
-  const hasNextPage = Boolean(pageInfo?.hasNextPage)
-  const endCursor = typeof pageInfo?.endCursor === 'string' ? pageInfo.endCursor : null
-  if (hasNextPage && !endCursor) {
-    throw new SymphonyError(
-      'linear_missing_end_cursor',
-      'Linear pagination reported hasNextPage=true without endCursor',
-    )
-  }
-  return { nodes, hasNextPage, endCursor }
-}
+export class TrackerService extends Context.Tag('symphony/TrackerService')<TrackerService, IssueTrackerClient>() {}
 
 const issueSelection = `
   id
@@ -167,96 +261,135 @@ const issueSelection = `
         identifier
         state { name }
       }
+      sourceIssue {
+        id
+        identifier
+        state { name }
+      }
     }
   }
 `
 
-export const createLinearTrackerClient = async (
-  configProvider: () => Promise<SymphonyConfig>,
-): Promise<IssueTrackerClient> => {
-  const fetchIssuesByFilter = async (stateNames: string[], options?: { issueIds?: string[] }): Promise<Issue[]> => {
-    if (stateNames.length === 0) return []
-    const config = await configProvider()
+export const makeTrackerLayer = (logger: Logger) =>
+  Layer.effect(
+    TrackerService,
+    Effect.gen(function* () {
+      const workflow = yield* WorkflowService
+      const trackerLogger = logger.child({ component: 'linear-tracker' })
 
-    const query = `
-      query SymphonyIssues($projectSlug: String!, $stateNames: [String!], $after: String, $issueIds: [ID!]) {
-        issues(
-          first: ${PAGE_SIZE},
-          after: $after,
-          filter: {
-            project: { slugId: { eq: $projectSlug } }
-            state: { name: { in: $stateNames } }
-            id: { in: $issueIds }
-          }
-        ) {
-          nodes {
-            ${issueSelection}
-          }
-          pageInfo {
-            hasNextPage
-            endCursor
-          }
-        }
-      }
-    `
+      const fetchIssuesByFilter = (stateNames: string[], options?: { issueIds?: string[] }) =>
+        Effect.gen(function* () {
+          if (stateNames.length === 0) return [] as Issue[]
 
-    const issues: Issue[] = []
-    let cursor: string | null = null
-    let hasNextPage = true
+          const config = yield* workflow.config
+          const query = `
+            query SymphonyIssues($projectSlug: String!, $stateNames: [String!], $after: String, $issueIds: [ID!]) {
+              issues(
+                first: ${PAGE_SIZE},
+                after: $after,
+                filter: {
+                  project: { slugId: { eq: $projectSlug } }
+                  state: { name: { in: $stateNames } }
+                  id: { in: $issueIds }
+                }
+              ) {
+                nodes {
+                  ${issueSelection}
+                }
+                pageInfo {
+                  hasNextPage
+                  endCursor
+                }
+              }
+            }
+          `
 
-    while (hasNextPage) {
-      const data = await requestGraphql(config, query, {
-        projectSlug: config.tracker.projectSlug,
-        stateNames,
-        after: cursor,
-        issueIds: options?.issueIds && options.issueIds.length > 0 ? options.issueIds : null,
-      })
-      const page = collectIssuePage(data)
-      for (const node of page.nodes) {
-        const normalized = normalizeIssue(node)
-        if (normalized.id && normalized.identifier && normalized.title && normalized.state) {
-          issues.push(normalized)
-        }
-      }
-      hasNextPage = page.hasNextPage
-      cursor = page.endCursor
-      if (hasNextPage && !cursor) {
-        throw new SymphonyError(
-          'linear_missing_end_cursor',
-          'Linear pagination could not continue without an endCursor',
+          const issues: Issue[] = []
+          let cursor: string | null = null
+          let hasNextPage = true
+
+          while (hasNextPage) {
+            const rawData: unknown = yield* requestGraphql(
+              config.tracker.endpoint,
+              config.tracker.apiKey ?? '',
+              query,
+              {
+                projectSlug: config.tracker.projectSlug,
+                stateNames,
+                after: cursor,
+                issueIds: options?.issueIds && options.issueIds.length > 0 ? options.issueIds : null,
+              },
+            )
+
+            const page: IssuesPage = yield* decodeIssuesPage(rawData).pipe(Effect.mapError(mapSchemaError))
+            for (const node of page.issues.nodes ?? []) {
+              const normalized = normalizeIssue(node)
+              if (normalized.id && normalized.identifier && normalized.title && normalized.state) {
+                issues.push(normalized)
+              }
+            }
+
+            hasNextPage = Boolean(page.issues.pageInfo?.hasNextPage)
+            cursor = page.issues.pageInfo?.endCursor ?? null
+            if (hasNextPage && !cursor) {
+              return yield* Effect.fail(
+                new TrackerError(
+                  'linear_missing_end_cursor',
+                  'Linear pagination reported hasNextPage=true without endCursor',
+                ),
+              )
+            }
+          }
+
+          return issues
+        }).pipe(
+          Effect.tapError((error) =>
+            Effect.sync(() => {
+              trackerLogger.log('warn', 'linear_request_failed', {
+                states: stateNames,
+                issue_ids: options?.issueIds ?? null,
+                ...toLogError(error),
+              })
+            }),
+          ),
         )
+
+      const service: IssueTrackerClient = {
+        fetchCandidateIssues: workflow.config.pipe(
+          Effect.flatMap((config) => fetchIssuesByFilter(config.tracker.activeStates)),
+        ),
+        fetchIssuesByStates: (states) => {
+          if (states.length === 0) return Effect.succeed([])
+          return fetchIssuesByFilter(states)
+        },
+        fetchIssueStatesByIds: (issueIds) =>
+          Effect.gen(function* () {
+            if (issueIds.length === 0) return [] as Issue[]
+            const config = yield* workflow.config
+            const normalizedStates = Array.from(
+              new Set([...config.tracker.activeStates, ...config.tracker.terminalStates]),
+            )
+            const issues = yield* fetchIssuesByFilter(normalizedStates, { issueIds })
+            const byId = new Map(issues.map((issue) => [issue.id, issue]))
+            return issueIds.map((issueId) => byId.get(issueId)).filter((issue): issue is Issue => Boolean(issue))
+          }),
+        executeLinearGraphql: (query, variables = {}) =>
+          Effect.gen(function* () {
+            const config = yield* workflow.config
+            if (config.tracker.kind !== 'linear' || !config.tracker.apiKey) {
+              return yield* Effect.fail(new TrackerError('missing_tracker_api_key', 'Linear auth is not configured'))
+            }
+            yield* validateOperationCount(query)
+            const data = yield* requestGraphql(config.tracker.endpoint, config.tracker.apiKey, query, variables)
+            if (!data || typeof data !== 'object' || Array.isArray(data)) {
+              return yield* Effect.fail(
+                new TrackerError('linear_unknown_payload', 'Linear GraphQL response was not an object', data),
+              )
+            }
+            return data as Record<string, unknown>
+          }),
       }
-    }
 
-    return issues
-  }
-
-  return {
-    fetchCandidateIssues: async () => {
-      const config = await configProvider()
-      return fetchIssuesByFilter(config.tracker.activeStates)
-    },
-    fetchIssuesByStates: async (states: string[]) => {
-      if (states.length === 0) return []
-      return fetchIssuesByFilter(states)
-    },
-    fetchIssueStatesByIds: async (issueIds: string[]) => {
-      if (issueIds.length === 0) return []
-      const config = await configProvider()
-      const normalizedStates = Array.from(new Set([...config.tracker.activeStates, ...config.tracker.terminalStates]))
-      const issues = await fetchIssuesByFilter(normalizedStates, { issueIds })
-      const byId = new Map(issues.map((issue) => [issue.id, issue]))
-      return issueIds.map((issueId) => byId.get(issueId)).filter((issue): issue is Issue => Boolean(issue))
-    },
-    executeLinearGraphql: async (query: string, variables: Record<string, unknown> = {}) => {
-      const config = await configProvider()
-      if (config.tracker.kind !== 'linear' || !config.tracker.apiKey) {
-        throw new SymphonyError('missing_tracker_api_key', 'Linear auth is not configured')
-      }
-      validateOperationCount(query)
-      return requestGraphql(config, query, variables)
-    },
-  }
-}
-
-export type { IssueTrackerClient }
+      return service
+    }),
+  )

--- a/services/symphony/src/orchestrator.ts
+++ b/services/symphony/src/orchestrator.ts
@@ -1,28 +1,87 @@
-import { setTimeout as delay } from 'node:timers/promises'
+import { Context, Effect, Layer } from 'effect'
+import * as Duration from 'effect/Duration'
+import * as Exit from 'effect/Exit'
+import * as Fiber from 'effect/Fiber'
+import * as Queue from 'effect/Queue'
+import * as Ref from 'effect/Ref'
+import * as Schedule from 'effect/Schedule'
+import * as SynchronizedRef from 'effect/SynchronizedRef'
 
-import { toError } from './errors'
-import { sortIssuesForDispatch, shouldDispatchIssue } from './dispatch-rules'
-import { createLinearTrackerClient, type IssueTrackerClient } from './linear-client'
-import type { Logger } from './logger'
+import { validateDispatchConfigEffect } from './config'
+import type { CodexEvent } from './codex-app-session'
+import { shouldDispatchIssue, sortIssuesForDispatch } from './dispatch-rules'
+import {
+  OrchestratorError,
+  toLogError,
+  type ConfigError,
+  type TrackerError,
+  type WorkspaceError,
+  type WorkflowError,
+} from './errors'
+import { IssueRunnerService } from './issue-runner'
+import { TrackerService } from './linear-client'
 import type {
   CodexTotals,
   Issue,
+  IssueDetails,
   LiveSession,
   RecentEvent,
-  RetryEntry,
-  RunningEntry,
   RuntimeSnapshot,
   SymphonyConfig,
   TokenUsageTotals,
 } from './types'
 import { normalizeState } from './utils'
-import { validateDispatchConfig } from './config'
-import { WorkspaceManager } from './workspace-manager'
-import { IssueRunner } from './issue-runner'
-import { WorkflowStore } from './workflow'
-import type { CodexEvent } from './codex-app-session'
+import { WorkflowService } from './workflow'
+import { WorkspaceService } from './workspace-manager'
+import type { Logger } from './logger'
 
-type WorkerExitReason = 'normal' | 'failed' | 'stalled' | 'terminal' | 'inactive'
+type WorkerStopReason = 'running' | 'failed' | 'stalled' | 'terminal' | 'inactive'
+
+type RunningRuntimeEntry = {
+  issue: Issue
+  issueId: string
+  identifier: string
+  retryAttempt: number | null
+  workspacePath: string
+  startedAt: string
+  startedAtMs: number
+  session: LiveSession
+  lastError: string | null
+  recentEvents: RecentEvent[]
+  workerFiber: Fiber.RuntimeFiber<void, never>
+  stopReason: WorkerStopReason
+  terminalCleanupRequested: boolean
+}
+
+type RetryRuntimeEntry = {
+  issueId: string
+  identifier: string
+  attempt: number
+  dueAtMs: number
+  error: string | null
+  fiber: Fiber.RuntimeFiber<void, never>
+}
+
+type OrchestratorState = {
+  pollIntervalMs: number
+  maxConcurrentAgents: number
+  running: Map<string, RunningRuntimeEntry>
+  claimed: Set<string>
+  retryAttempts: Map<string, RetryRuntimeEntry>
+  completed: Set<string>
+  codexTotals: CodexTotals
+  codexRateLimits: RuntimeSnapshot['rateLimits']
+}
+
+type OrchestratorCommand =
+  | { _tag: 'PollTick' }
+  | { _tag: 'StallSweep' }
+  | { _tag: 'RetryDue'; issueId: string }
+  | { _tag: 'WorkspaceReady'; issueId: string; workspacePath: string }
+  | { _tag: 'CodexEventReceived'; issueId: string; event: CodexEvent }
+  | { _tag: 'WorkerExited'; issueId: string; exit: Exit.Exit<string, unknown> }
+
+const MAX_RECENT_EVENTS = 50
 
 const EMPTY_SESSION = (): LiveSession => ({
   sessionId: null,
@@ -48,534 +107,727 @@ const EMPTY_TOTALS = (): CodexTotals => ({
   endedRuntimeSeconds: 0,
 })
 
-const MAX_RECENT_EVENTS = 50
+const EMPTY_STATE = (): OrchestratorState => ({
+  pollIntervalMs: 30_000,
+  maxConcurrentAgents: 10,
+  running: new Map(),
+  claimed: new Set(),
+  retryAttempts: new Map(),
+  completed: new Set(),
+  codexTotals: EMPTY_TOTALS(),
+  codexRateLimits: null,
+})
 
-export class SymphonyOrchestrator {
-  private readonly workflowStore: WorkflowStore
-  private readonly logger: Logger
-  private readonly workspaceManager: WorkspaceManager
-  private readonly tracker: Promise<IssueTrackerClient>
-  private readonly issueRunner: Promise<IssueRunner>
+const computeRetryDelayMs = (
+  attempt: number,
+  maxRetryBackoffMs: number,
+  delayType: 'continuation' | 'failure',
+): number =>
+  delayType === 'continuation' ? 1_000 : Math.min(10_000 * 2 ** Math.max(0, attempt - 1), maxRetryBackoffMs)
 
-  private pollTimer: Timer | null = null
-  private tickInFlight = false
-  private refreshRequested = false
-  private started = false
-
-  private readonly state = {
-    running: new Map<string, RunningEntry>(),
-    claimed: new Set<string>(),
-    retryAttempts: new Map<string, RetryEntry>(),
-    completed: new Set<string>(),
-    codexTotals: EMPTY_TOTALS(),
-    codexRateLimits: null as RuntimeSnapshot['rateLimits'],
-  }
-
-  constructor(workflowPath: string, logger: Logger) {
-    this.logger = logger.child({ component: 'orchestrator' })
-    this.workflowStore = new WorkflowStore(workflowPath, this.logger)
-    this.workspaceManager = new WorkspaceManager(
-      async () => (await this.workflowStore.getCurrent()).config,
-      this.logger,
-    )
-    this.tracker = createLinearTrackerClient(async () => (await this.workflowStore.getCurrent()).config)
-    this.issueRunner = this.tracker.then(
-      (tracker) =>
-        new IssueRunner({
-          configProvider: async () => (await this.workflowStore.getCurrent()).config,
-          workflowProvider: async () => this.workflowStore.getCurrent(),
-          tracker,
-          workspaceManager: this.workspaceManager,
-          logger: this.logger,
-        }),
-    )
-  }
-
-  async start(): Promise<void> {
-    await this.workflowStore.initialize()
-    this.workflowStore.startWatching()
-    const { config } = await this.workflowStore.getCurrent()
-    validateDispatchConfig(config)
-
-    const tracker = await this.tracker
-    try {
-      const terminalIssues = await tracker.fetchIssuesByStates(config.tracker.terminalStates)
-      await Promise.all(terminalIssues.map((issue) => this.workspaceManager.removeWorkspace(issue.identifier)))
-    } catch (error) {
-      this.logger.log('warn', 'startup_terminal_cleanup_failed', { error: toError(error).message })
-    }
-
-    this.started = true
-    this.scheduleTick(0)
-  }
-
-  async stop(): Promise<void> {
-    this.started = false
-    if (this.pollTimer) {
-      clearTimeout(this.pollTimer)
-    }
-    this.pollTimer = null
-    this.workflowStore.close()
-    for (const retryEntry of this.state.retryAttempts.values()) {
-      clearTimeout(retryEntry.timerHandle)
-    }
-    this.state.retryAttempts.clear()
-    for (const running of this.state.running.values()) {
-      running.abortController.abort()
-    }
-    await delay(10)
-  }
-
-  async triggerRefresh(): Promise<void> {
-    this.refreshRequested = true
-    this.scheduleTick(0)
-  }
-
-  getSnapshot(): RuntimeSnapshot {
-    const generatedAt = new Date().toISOString()
-    const nowMs = Date.now()
-    const running = Array.from(this.state.running.values())
-    const retrying = Array.from(this.state.retryAttempts.values())
-    const activeRuntimeSeconds = running.reduce(
-      (total, entry) => total + Math.max(0, nowMs - entry.startedAtMs) / 1_000,
-      0,
-    )
-
+const buildIssueDetails = (state: OrchestratorState, issueIdentifier: string): IssueDetails | null => {
+  const running = Array.from(state.running.values()).find((entry) => entry.identifier === issueIdentifier)
+  if (running) {
     return {
-      generatedAt,
-      counts: {
-        running: running.length,
-        retrying: retrying.length,
+      issueIdentifier: running.identifier,
+      issueId: running.issueId,
+      status: 'running',
+      workspace: { path: running.workspacePath || null },
+      attempts: {
+        restartCount: running.retryAttempt ?? 0,
+        currentRetryAttempt: running.retryAttempt ?? 0,
       },
-      running: running.map((entry) => ({
-        issueId: entry.issueId,
-        issueIdentifier: entry.identifier,
-        state: entry.issue.state,
-        sessionId: entry.session.sessionId,
-        turnCount: entry.session.turnCount,
-        lastEvent: entry.session.lastCodexEvent,
-        lastMessage: entry.session.lastCodexMessage,
-        startedAt: entry.startedAt,
-        lastEventAt: entry.session.lastCodexTimestamp,
+      running: {
+        sessionId: running.session.sessionId,
+        turnCount: running.session.turnCount,
+        state: running.issue.state,
+        startedAt: running.startedAt,
+        lastEvent: running.session.lastCodexEvent,
+        lastMessage: running.session.lastCodexMessage,
+        lastEventAt: running.session.lastCodexTimestamp,
         tokens: {
-          inputTokens: entry.session.codexInputTokens,
-          outputTokens: entry.session.codexOutputTokens,
-          totalTokens: entry.session.codexTotalTokens,
+          inputTokens: running.session.codexInputTokens,
+          outputTokens: running.session.codexOutputTokens,
+          totalTokens: running.session.codexTotalTokens,
         },
-      })),
-      retrying: retrying.map((entry) => ({
-        issueId: entry.issueId,
-        issueIdentifier: entry.identifier,
-        attempt: entry.attempt,
-        dueAt: new Date(entry.dueAtMs).toISOString(),
-        error: entry.error,
-      })),
-      codexTotals: {
-        inputTokens: this.state.codexTotals.inputTokens,
-        outputTokens: this.state.codexTotals.outputTokens,
-        totalTokens: this.state.codexTotals.totalTokens,
-        secondsRunning: this.state.codexTotals.endedRuntimeSeconds + activeRuntimeSeconds,
       },
-      rateLimits: this.state.codexRateLimits,
+      retry: null,
+      logs: { codex_session_logs: [] },
+      recentEvents: running.recentEvents,
+      lastError: running.lastError,
+      tracked: {},
     }
   }
 
-  async getCurrentConfig(): Promise<SymphonyConfig> {
-    return (await this.workflowStore.getCurrent()).config
-  }
-
-  getIssueDetails(issueIdentifier: string) {
-    const running = Array.from(this.state.running.values()).find((entry) => entry.identifier === issueIdentifier)
-    if (running) {
-      return {
-        issueIdentifier: running.identifier,
-        issueId: running.issueId,
-        status: 'running',
-        workspace: { path: running.workspacePath },
-        attempts: {
-          restartCount: running.retryAttempt ?? 0,
-          currentRetryAttempt: running.retryAttempt ?? 0,
-        },
-        running: {
-          sessionId: running.session.sessionId,
-          turnCount: running.session.turnCount,
-          state: running.issue.state,
-          startedAt: running.startedAt,
-          lastEvent: running.session.lastCodexEvent,
-          lastMessage: running.session.lastCodexMessage,
-          lastEventAt: running.session.lastCodexTimestamp,
-          tokens: {
-            inputTokens: running.session.codexInputTokens,
-            outputTokens: running.session.codexOutputTokens,
-            totalTokens: running.session.codexTotalTokens,
-          },
-        },
-        retry: null,
-        logs: { codex_session_logs: [] },
-        recentEvents: running.recentEvents,
-        lastError: running.lastError,
-        tracked: {},
-      }
-    }
-
-    const retry = Array.from(this.state.retryAttempts.values()).find((entry) => entry.identifier === issueIdentifier)
-    if (retry) {
-      return {
-        issueIdentifier: retry.identifier,
-        issueId: retry.issueId,
-        status: 'retrying',
-        workspace: { path: null },
-        attempts: {
-          restartCount: retry.attempt,
-          currentRetryAttempt: retry.attempt,
-        },
-        running: null,
-        retry: {
-          attempt: retry.attempt,
-          dueAt: new Date(retry.dueAtMs).toISOString(),
-          error: retry.error,
-        },
-        logs: { codex_session_logs: [] },
-        recentEvents: [],
-        lastError: retry.error,
-        tracked: {},
-      }
-    }
-
-    return null
-  }
-
-  private scheduleTick(delayMs: number): void {
-    if (!this.started) return
-    if (this.pollTimer) {
-      clearTimeout(this.pollTimer)
-    }
-    this.pollTimer = setTimeout(
-      () => {
-        void this.tick()
+  const retry = Array.from(state.retryAttempts.values()).find((entry) => entry.identifier === issueIdentifier)
+  if (retry) {
+    return {
+      issueIdentifier: retry.identifier,
+      issueId: retry.issueId,
+      status: 'retrying',
+      workspace: { path: null },
+      attempts: {
+        restartCount: retry.attempt,
+        currentRetryAttempt: retry.attempt,
       },
-      Math.max(0, delayMs),
-    )
-  }
-
-  private async tick(): Promise<void> {
-    if (this.tickInFlight) {
-      this.refreshRequested = true
-      return
-    }
-
-    this.tickInFlight = true
-    try {
-      const { config } = await this.workflowStore.getCurrent()
-      await this.reconcileRunningIssues(config)
-
-      try {
-        validateDispatchConfig(config)
-      } catch (error) {
-        this.logger.log('error', 'dispatch_validation_failed', { error: toError(error).message })
-        this.scheduleTick(config.pollingIntervalMs)
-        return
-      }
-
-      const tracker = await this.tracker
-      let issues: Issue[]
-      try {
-        issues = await tracker.fetchCandidateIssues()
-      } catch (error) {
-        this.logger.log('error', 'candidate_fetch_failed', { error: toError(error).message })
-        this.scheduleTick(config.pollingIntervalMs)
-        return
-      }
-
-      const sorted = sortIssuesForDispatch(issues)
-
-      for (const issue of sorted) {
-        if (!this.shouldDispatch(issue, config)) continue
-        this.dispatchIssue(issue, null)
-      }
-
-      this.scheduleTick(this.refreshRequested ? 0 : config.pollingIntervalMs)
-      this.refreshRequested = false
-    } finally {
-      this.tickInFlight = false
-    }
-  }
-
-  private async reconcileRunningIssues(config: SymphonyConfig): Promise<void> {
-    if (config.codex.stallTimeoutMs > 0) {
-      const nowMs = Date.now()
-      for (const running of this.state.running.values()) {
-        const lastEventMs = running.session.lastCodexTimestamp
-          ? Date.parse(running.session.lastCodexTimestamp)
-          : running.startedAtMs
-        if (nowMs - lastEventMs > config.codex.stallTimeoutMs) {
-          running.stopReason = 'stalled'
-          running.abortController.abort()
-        }
-      }
-    }
-
-    if (this.state.running.size === 0) return
-
-    try {
-      const tracker = await this.tracker
-      const refreshed = await tracker.fetchIssueStatesByIds(Array.from(this.state.running.keys()))
-      const refreshedById = new Map(refreshed.map((issue) => [issue.id, issue]))
-      const activeStates = new Set(config.tracker.activeStates.map((state) => normalizeState(state)))
-      const terminalStates = new Set(config.tracker.terminalStates.map((state) => normalizeState(state)))
-
-      for (const [issueId, running] of this.state.running.entries()) {
-        const latest = refreshedById.get(issueId)
-        if (!latest) {
-          running.stopReason = 'inactive'
-          running.abortController.abort()
-          continue
-        }
-        const state = normalizeState(latest.state)
-        if (terminalStates.has(state)) {
-          running.issue = latest
-          running.stopReason = 'terminal'
-          running.terminalCleanupRequested = true
-          running.abortController.abort()
-          continue
-        }
-        if (!activeStates.has(state)) {
-          running.issue = latest
-          running.stopReason = 'inactive'
-          running.abortController.abort()
-          continue
-        }
-        running.issue = latest
-      }
-    } catch (error) {
-      this.logger.log('warn', 'running_state_refresh_failed', { error: toError(error).message })
-    }
-  }
-
-  private dispatchIssue(issue: Issue, attempt: number | null): void {
-    if (this.state.running.has(issue.id) || this.state.claimed.has(issue.id)) return
-    void this.spawnWorker(issue, attempt)
-  }
-
-  private async spawnWorker(issue: Issue, attempt: number | null): Promise<void> {
-    const issueRunner = await this.issueRunner
-    const startedAtMs = Date.now()
-    const startedAt = new Date(startedAtMs).toISOString()
-    const abortController = new AbortController()
-
-    this.state.claimed.add(issue.id)
-    const workerPromise = issueRunner
-      .runAttempt(
-        issue,
-        attempt,
-        (event) => {
-          this.handleCodexEvent(issue.id, event)
-        },
-        abortController.signal,
-      )
-      .then(async (workspacePath) => {
-        await this.handleWorkerExit(issue.id, 'normal', null, workspacePath)
-      })
-      .catch(async (error) => {
-        const running = this.state.running.get(issue.id)
-        const workspacePath = running?.workspacePath ?? ''
-        const reason = running?.stopReason && running.stopReason !== 'running' ? running.stopReason : 'failed'
-        await this.handleWorkerExit(issue.id, reason, error, workspacePath)
-      })
-
-    this.state.running.set(issue.id, {
-      issue,
-      issueId: issue.id,
-      identifier: issue.identifier,
-      retryAttempt: attempt,
-      workspacePath: '',
-      startedAt,
-      startedAtMs,
-      session: EMPTY_SESSION(),
-      lastError: null,
+      running: null,
+      retry: {
+        attempt: retry.attempt,
+        dueAt: new Date(retry.dueAtMs).toISOString(),
+        error: retry.error,
+      },
+      logs: { codex_session_logs: [] },
       recentEvents: [],
-      workerHandle: workerPromise,
-      abortController,
-      stopReason: 'running',
-      terminalCleanupRequested: false,
-    })
+      lastError: retry.error,
+      tracked: {},
+    }
   }
 
-  private async handleWorkerExit(
-    issueId: string,
-    reason: WorkerExitReason,
-    error: unknown,
-    workspacePath: string,
-  ): Promise<void> {
-    const running = this.state.running.get(issueId)
-    if (!running) return
+  return null
+}
 
-    if (workspacePath) {
-      running.workspacePath = workspacePath
-    }
+export interface OrchestratorServiceDefinition {
+  readonly start: Effect.Effect<void, WorkflowError | ConfigError | TrackerError | WorkspaceError | OrchestratorError>
+  readonly stop: Effect.Effect<void, never>
+  readonly triggerRefresh: Effect.Effect<void, never>
+  readonly getSnapshot: Effect.Effect<RuntimeSnapshot, never>
+  readonly getIssueDetails: (issueIdentifier: string) => Effect.Effect<IssueDetails | null, never>
+  readonly getCurrentConfig: Effect.Effect<SymphonyConfig, WorkflowError | ConfigError | OrchestratorError>
+}
 
-    this.state.running.delete(issueId)
-    const runtimeSeconds = Math.max(0, Date.now() - running.startedAtMs) / 1_000
-    this.state.codexTotals.endedRuntimeSeconds += runtimeSeconds
+export class OrchestratorService extends Context.Tag('symphony/OrchestratorService')<
+  OrchestratorService,
+  OrchestratorServiceDefinition
+>() {}
 
-    const errorMessage = error ? toError(error).message : null
+export const makeOrchestratorLayer = (logger: Logger) =>
+  Layer.scoped(
+    OrchestratorService,
+    Effect.gen(function* () {
+      const workflow = yield* WorkflowService
+      const tracker = yield* TrackerService
+      const workspace = yield* WorkspaceService
+      const issueRunner = yield* IssueRunnerService
+      const orchestratorLogger = logger.child({ component: 'orchestrator' })
 
-    if (reason === 'terminal') {
-      this.state.claimed.delete(issueId)
-      if (running.terminalCleanupRequested) {
-        await this.workspaceManager.removeWorkspace(running.identifier)
-      }
-      return
-    }
+      const stateRef = yield* SynchronizedRef.make<OrchestratorState>(EMPTY_STATE())
+      const queue = yield* Queue.unbounded<OrchestratorCommand>()
+      const startedRef = yield* Ref.make(false)
+      const pollQueuedRef = yield* Ref.make(false)
+      const stallQueuedRef = yield* Ref.make(false)
+      const processorFiberRef = yield* Ref.make<Fiber.RuntimeFiber<void, never> | null>(null)
+      const pollFiberRef = yield* Ref.make<Fiber.RuntimeFiber<void, never> | null>(null)
+      const stallFiberRef = yield* Ref.make<Fiber.RuntimeFiber<void, never> | null>(null)
 
-    if (reason === 'inactive') {
-      this.state.claimed.delete(issueId)
-      return
-    }
-
-    if (reason === 'normal') {
-      this.state.completed.add(issueId)
-      this.scheduleRetry(issueId, 1, running.identifier, 'continuation', null)
-      return
-    }
-
-    const nextAttempt = (running.retryAttempt ?? 0) + 1
-    this.scheduleRetry(issueId, nextAttempt, running.identifier, 'failure', errorMessage)
-  }
-
-  private scheduleRetry(
-    issueId: string,
-    attempt: number,
-    identifier: string,
-    delayType: 'continuation' | 'failure',
-    error: string | null,
-  ): void {
-    const existing = this.state.retryAttempts.get(issueId)
-    if (existing) {
-      clearTimeout(existing.timerHandle)
-      this.state.retryAttempts.delete(issueId)
-    }
-
-    this.state.claimed.add(issueId)
-    const maxRetryBackoffMs = (() => {
-      const current = this.workflowStore.getCurrent()
-      return current.then(({ config }) => config.agent.maxRetryBackoffMs)
-    })()
-
-    void maxRetryBackoffMs.then((capMs) => {
-      const delayMs = delayType === 'continuation' ? 1_000 : Math.min(10_000 * 2 ** Math.max(0, attempt - 1), capMs)
-      const dueAtMs = Date.now() + delayMs
-      const timerHandle = setTimeout(() => {
-        void this.onRetryTimer(issueId)
-      }, delayMs)
-
-      this.state.retryAttempts.set(issueId, {
-        issueId,
-        identifier,
-        attempt,
-        dueAtMs,
-        timerHandle,
-        error,
-      })
-    })
-  }
-
-  private async onRetryTimer(issueId: string): Promise<void> {
-    const retryEntry = this.state.retryAttempts.get(issueId)
-    if (!retryEntry) return
-    this.state.retryAttempts.delete(issueId)
-
-    const tracker = await this.tracker
-    let candidates: Issue[]
-    try {
-      candidates = await tracker.fetchCandidateIssues()
-    } catch (error) {
-      this.logger.log('warn', 'retry_poll_failed', {
-        issue_id: issueId,
-        issue_identifier: retryEntry.identifier,
-        error: toError(error).message,
-      })
-      this.scheduleRetry(issueId, retryEntry.attempt + 1, retryEntry.identifier, 'failure', 'retry poll failed')
-      return
-    }
-
-    const issue = candidates.find((candidate) => candidate.id === issueId)
-    if (!issue) {
-      this.state.claimed.delete(issueId)
-      return
-    }
-
-    const { config } = await this.workflowStore.getCurrent()
-    if (!this.shouldDispatch(issue, config)) {
-      this.scheduleRetry(
-        issueId,
-        retryEntry.attempt + 1,
-        issue.identifier,
-        'failure',
-        'no available orchestrator slots',
+      const enqueuePoll = Ref.getAndSet(pollQueuedRef, true).pipe(
+        Effect.flatMap((alreadyQueued) => (alreadyQueued ? Effect.void : Queue.offer(queue, { _tag: 'PollTick' }))),
       )
-      return
-    }
 
-    this.state.claimed.delete(issueId)
-    this.dispatchIssue(issue, retryEntry.attempt)
-  }
+      const enqueueStallSweep = Ref.getAndSet(stallQueuedRef, true).pipe(
+        Effect.flatMap((alreadyQueued) => (alreadyQueued ? Effect.void : Queue.offer(queue, { _tag: 'StallSweep' }))),
+      )
 
-  private shouldDispatch(issue: Issue, config: SymphonyConfig): boolean {
-    return shouldDispatchIssue(issue, {
-      config,
-      runningIssues: Array.from(this.state.running.values()).map((entry) => entry.issue),
-      claimedIssueIds: this.state.claimed,
-    })
-  }
+      const applyTokenUsage = (
+        state: OrchestratorState,
+        running: RunningRuntimeEntry,
+        usage: TokenUsageTotals,
+      ): void => {
+        const deltaInput = Math.max(0, usage.inputTokens - running.session.lastReportedInputTokens)
+        const deltaOutput = Math.max(0, usage.outputTokens - running.session.lastReportedOutputTokens)
+        const deltaTotal = Math.max(0, usage.totalTokens - running.session.lastReportedTotalTokens)
 
-  private handleCodexEvent(issueId: string, event: CodexEvent): void {
-    const running = this.state.running.get(issueId)
-    if (!running) return
+        running.session.codexInputTokens = usage.inputTokens
+        running.session.codexOutputTokens = usage.outputTokens
+        running.session.codexTotalTokens = usage.totalTokens
+        running.session.lastReportedInputTokens = usage.inputTokens
+        running.session.lastReportedOutputTokens = usage.outputTokens
+        running.session.lastReportedTotalTokens = usage.totalTokens
 
-    running.session.codexAppServerPid = event.codexAppServerPid
-    running.session.sessionId = event.sessionId ?? running.session.sessionId
-    running.session.threadId = event.threadId ?? running.session.threadId
-    running.session.turnId = event.turnId ?? running.session.turnId
-    running.session.lastCodexEvent = event.event
-    running.session.lastCodexTimestamp = event.timestamp
-    running.session.lastCodexMessage = event.message ?? running.session.lastCodexMessage
-    if (event.event === 'turn_started') {
-      running.session.turnCount += 1
-    }
-    if (event.message && event.message.trim().length > 0) {
-      const recentEvent: RecentEvent = {
-        at: event.timestamp,
-        event: event.event,
-        message: event.message,
+        state.codexTotals.inputTokens += deltaInput
+        state.codexTotals.outputTokens += deltaOutput
+        state.codexTotals.totalTokens += deltaTotal
       }
-      running.recentEvents.push(recentEvent)
-      if (running.recentEvents.length > MAX_RECENT_EVENTS) {
-        running.recentEvents.splice(0, running.recentEvents.length - MAX_RECENT_EVENTS)
+
+      const scheduleRetry = (
+        issueId: string,
+        identifier: string,
+        attempt: number,
+        delayType: 'continuation' | 'failure',
+        error: string | null,
+      ) =>
+        Effect.gen(function* () {
+          const config = yield* workflow.config
+          const delayMs = computeRetryDelayMs(attempt, config.agent.maxRetryBackoffMs, delayType)
+          const dueAtMs = Date.now() + delayMs
+
+          const existing = yield* SynchronizedRef.modifyEffect(stateRef, (state) =>
+            Effect.succeed([state.retryAttempts.get(issueId) ?? null, state] as const),
+          )
+          if (existing) {
+            yield* Fiber.interruptFork(existing.fiber)
+          }
+
+          const fiber = yield* Effect.sleep(Duration.millis(delayMs)).pipe(
+            Effect.zipRight(Queue.offer(queue, { _tag: 'RetryDue', issueId })),
+            Effect.asVoid,
+            Effect.forkScoped,
+          )
+
+          yield* SynchronizedRef.modifyEffect(stateRef, (state) => {
+            state.claimed.add(issueId)
+            state.retryAttempts.set(issueId, {
+              issueId,
+              identifier,
+              attempt,
+              dueAtMs,
+              error,
+              fiber,
+            })
+            return Effect.succeed([undefined, state] as const)
+          })
+        })
+
+      const handleCodexEvent = (issueId: string, event: CodexEvent) =>
+        SynchronizedRef.modifyEffect(stateRef, (state) => {
+          const running = state.running.get(issueId)
+          if (!running) {
+            return Effect.succeed([undefined, state] as const)
+          }
+
+          running.session.codexAppServerPid = event.codexAppServerPid
+          running.session.sessionId = event.sessionId ?? running.session.sessionId
+          running.session.threadId = event.threadId ?? running.session.threadId
+          running.session.turnId = event.turnId ?? running.session.turnId
+          running.session.lastCodexEvent = event.event
+          running.session.lastCodexTimestamp = event.timestamp
+          running.session.lastCodexMessage = event.message ?? running.session.lastCodexMessage
+          if (event.event === 'turn_started') {
+            running.session.turnCount += 1
+          }
+          if (event.message && event.message.trim().length > 0) {
+            running.recentEvents.push({
+              at: event.timestamp,
+              event: event.event,
+              message: event.message,
+            })
+            if (running.recentEvents.length > MAX_RECENT_EVENTS) {
+              running.recentEvents.splice(0, running.recentEvents.length - MAX_RECENT_EVENTS)
+            }
+          }
+          if (event.rateLimits) {
+            state.codexRateLimits = event.rateLimits
+          }
+          if (event.usage) {
+            applyTokenUsage(state, running, event.usage)
+          }
+          return Effect.succeed([undefined, state] as const)
+        })
+
+      const dispatchIssue = (issue: Issue, attempt: number | null) =>
+        Effect.gen(function* () {
+          const workerEffect = issueRunner
+            .runAttempt(issue, attempt, {
+              onEvent: (event) =>
+                Queue.offer(queue, { _tag: 'CodexEventReceived', issueId: issue.id, event }).pipe(Effect.asVoid),
+              onWorkspacePath: (workspacePath) =>
+                Queue.offer(queue, { _tag: 'WorkspaceReady', issueId: issue.id, workspacePath }).pipe(Effect.asVoid),
+            })
+            .pipe(
+              Effect.exit,
+              Effect.flatMap((exit) => Queue.offer(queue, { _tag: 'WorkerExited', issueId: issue.id, exit })),
+              Effect.asVoid,
+            )
+
+          const workerFiber = yield* Effect.forkScoped(workerEffect)
+          const startedAtMs = Date.now()
+          const startedAt = new Date(startedAtMs).toISOString()
+
+          yield* SynchronizedRef.modifyEffect(stateRef, (state) => {
+            state.claimed.add(issue.id)
+            const existingRetry = state.retryAttempts.get(issue.id)
+            if (existingRetry) {
+              state.retryAttempts.delete(issue.id)
+            }
+            state.running.set(issue.id, {
+              issue,
+              issueId: issue.id,
+              identifier: issue.identifier,
+              retryAttempt: attempt,
+              workspacePath: '',
+              startedAt,
+              startedAtMs,
+              session: EMPTY_SESSION(),
+              lastError: null,
+              recentEvents: [],
+              workerFiber,
+              stopReason: 'running',
+              terminalCleanupRequested: false,
+            })
+            return Effect.succeed([existingRetry ?? null, state] as const)
+          }).pipe(
+            Effect.flatMap((existingRetry) => (existingRetry ? Fiber.interruptFork(existingRetry.fiber) : Effect.void)),
+          )
+        })
+
+      const reconcileRunningIssues = (config: SymphonyConfig) =>
+        Effect.gen(function* () {
+          const runningEntries = yield* SynchronizedRef.modifyEffect(stateRef, (state) =>
+            Effect.succeed([Array.from(state.running.values()), state] as const),
+          )
+          if (runningEntries.length === 0) return
+
+          const refreshed = yield* tracker.fetchIssueStatesByIds(runningEntries.map((entry) => entry.issueId)).pipe(
+            Effect.catchAll((error) =>
+              Effect.sync(() => {
+                orchestratorLogger.log('warn', 'running_state_refresh_failed', toLogError(error))
+              }).pipe(Effect.zipRight(Effect.succeed<Issue[]>([]))),
+            ),
+          )
+          if (refreshed.length === 0) return
+
+          const refreshedById = new Map(refreshed.map((issue) => [issue.id, issue]))
+          const activeStates = new Set(config.tracker.activeStates.map((state) => normalizeState(state)))
+          const terminalStates = new Set(config.tracker.terminalStates.map((state) => normalizeState(state)))
+
+          for (const running of runningEntries) {
+            const latest = refreshedById.get(running.issueId)
+            if (!latest) {
+              yield* SynchronizedRef.modifyEffect(stateRef, (state) => {
+                const current = state.running.get(running.issueId)
+                if (current) {
+                  current.stopReason = 'inactive'
+                }
+                return Effect.succeed([undefined, state] as const)
+              })
+              yield* Fiber.interruptFork(running.workerFiber)
+              continue
+            }
+
+            const nextState = normalizeState(latest.state)
+            if (terminalStates.has(nextState)) {
+              yield* SynchronizedRef.modifyEffect(stateRef, (state) => {
+                const current = state.running.get(running.issueId)
+                if (current) {
+                  current.issue = latest
+                  current.stopReason = 'terminal'
+                  current.terminalCleanupRequested = true
+                }
+                return Effect.succeed([undefined, state] as const)
+              })
+              yield* Fiber.interruptFork(running.workerFiber)
+              continue
+            }
+
+            if (!activeStates.has(nextState)) {
+              yield* SynchronizedRef.modifyEffect(stateRef, (state) => {
+                const current = state.running.get(running.issueId)
+                if (current) {
+                  current.issue = latest
+                  current.stopReason = 'inactive'
+                }
+                return Effect.succeed([undefined, state] as const)
+              })
+              yield* Fiber.interruptFork(running.workerFiber)
+              continue
+            }
+
+            yield* SynchronizedRef.modifyEffect(stateRef, (state) => {
+              const current = state.running.get(running.issueId)
+              if (current) {
+                current.issue = latest
+              }
+              return Effect.succeed([undefined, state] as const)
+            })
+          }
+        })
+
+      const reconcileStalledRuns = (config: SymphonyConfig) =>
+        config.codex.stallTimeoutMs <= 0
+          ? Effect.void
+          : Effect.gen(function* () {
+              const nowMs = Date.now()
+              const runningEntries = yield* SynchronizedRef.modifyEffect(stateRef, (state) =>
+                Effect.succeed([Array.from(state.running.values()), state] as const),
+              )
+              for (const running of runningEntries) {
+                const lastEventMs = running.session.lastCodexTimestamp
+                  ? Date.parse(running.session.lastCodexTimestamp)
+                  : running.startedAtMs
+                if (nowMs - lastEventMs > config.codex.stallTimeoutMs) {
+                  yield* SynchronizedRef.modifyEffect(stateRef, (state) => {
+                    const current = state.running.get(running.issueId)
+                    if (current) {
+                      current.stopReason = 'stalled'
+                    }
+                    return Effect.succeed([undefined, state] as const)
+                  })
+                  yield* Fiber.interruptFork(running.workerFiber)
+                }
+              }
+            })
+
+      const processPollTick = Effect.gen(function* () {
+        yield* Ref.set(pollQueuedRef, false)
+        const { config } = yield* workflow.current
+        yield* SynchronizedRef.modifyEffect(stateRef, (state) => {
+          state.pollIntervalMs = config.pollingIntervalMs
+          state.maxConcurrentAgents = config.agent.maxConcurrentAgents
+          return Effect.succeed([undefined, state] as const)
+        })
+
+        yield* reconcileRunningIssues(config)
+        yield* validateDispatchConfigEffect(config).pipe(
+          Effect.catchAll((error) =>
+            Effect.sync(() => {
+              orchestratorLogger.log('error', 'dispatch_validation_failed', toLogError(error))
+            }),
+          ),
+        )
+
+        const validation = yield* Effect.either(validateDispatchConfigEffect(config))
+        if (validation._tag === 'Left') return
+
+        const issues = yield* tracker.fetchCandidateIssues.pipe(
+          Effect.catchAll((error) =>
+            Effect.sync(() => {
+              orchestratorLogger.log('error', 'candidate_fetch_failed', toLogError(error))
+            }).pipe(Effect.zipRight(Effect.succeed<Issue[]>([]))),
+          ),
+        )
+
+        if (issues.length === 0) return
+
+        const state = yield* SynchronizedRef.get(stateRef)
+        for (const issue of sortIssuesForDispatch(issues)) {
+          if (
+            shouldDispatchIssue(issue, {
+              config,
+              runningIssues: Array.from(state.running.values()).map((entry) => entry.issue),
+              claimedIssueIds: state.claimed,
+            })
+          ) {
+            yield* dispatchIssue(issue, null)
+          }
+        }
+      })
+
+      const processRetryDue = (issueId: string) =>
+        Effect.gen(function* () {
+          const retryEntry = yield* SynchronizedRef.modifyEffect(stateRef, (state) => {
+            const current = state.retryAttempts.get(issueId) ?? null
+            if (current) {
+              state.retryAttempts.delete(issueId)
+            }
+            return Effect.succeed([current, state] as const)
+          })
+          if (!retryEntry) return
+
+          const candidates = yield* tracker.fetchCandidateIssues.pipe(
+            Effect.catchAll((error) =>
+              Effect.sync(() => {
+                orchestratorLogger.log('warn', 'retry_poll_failed', {
+                  issue_id: issueId,
+                  issue_identifier: retryEntry.identifier,
+                  ...toLogError(error),
+                })
+              }).pipe(Effect.zipRight(Effect.succeed<Issue[]>([]))),
+            ),
+          )
+
+          if (candidates.length === 0) {
+            yield* scheduleRetry(issueId, retryEntry.identifier, retryEntry.attempt + 1, 'failure', 'retry poll failed')
+            return
+          }
+
+          const issue = candidates.find((candidate) => candidate.id === issueId)
+          if (!issue) {
+            yield* SynchronizedRef.modifyEffect(stateRef, (state) => {
+              state.claimed.delete(issueId)
+              return Effect.succeed([undefined, state] as const)
+            })
+            return
+          }
+
+          const config = yield* workflow.config
+          const state = yield* SynchronizedRef.get(stateRef)
+          if (
+            !shouldDispatchIssue(issue, {
+              config,
+              runningIssues: Array.from(state.running.values()).map((entry) => entry.issue),
+              claimedIssueIds: state.claimed,
+            })
+          ) {
+            yield* scheduleRetry(
+              issueId,
+              issue.identifier,
+              retryEntry.attempt + 1,
+              'failure',
+              'no available orchestrator slots',
+            )
+            return
+          }
+
+          yield* SynchronizedRef.modifyEffect(stateRef, (runtimeState) => {
+            runtimeState.claimed.delete(issueId)
+            return Effect.succeed([undefined, runtimeState] as const)
+          })
+          yield* dispatchIssue(issue, retryEntry.attempt)
+        })
+
+      const processWorkerExit = (issueId: string, exit: Exit.Exit<string, unknown>) =>
+        Effect.gen(function* () {
+          const running = yield* SynchronizedRef.modifyEffect(stateRef, (state) => {
+            const current = state.running.get(issueId) ?? null
+            if (current) {
+              state.running.delete(issueId)
+              const runtimeSeconds = Math.max(0, Date.now() - current.startedAtMs) / 1_000
+              state.codexTotals.endedRuntimeSeconds += runtimeSeconds
+            }
+            return Effect.succeed([current, state] as const)
+          })
+          if (!running) return
+
+          const errorMessage = Exit.isFailure(exit) ? toUnknownMessage(exit.cause) : null
+          const reason = Exit.isSuccess(exit)
+            ? 'normal'
+            : running.stopReason !== 'running'
+              ? running.stopReason
+              : 'failed'
+
+          if (reason === 'terminal') {
+            yield* SynchronizedRef.modifyEffect(stateRef, (state) => {
+              state.claimed.delete(issueId)
+              return Effect.succeed([undefined, state] as const)
+            })
+            if (running.terminalCleanupRequested) {
+              yield* workspace.removeWorkspace(running.identifier).pipe(
+                Effect.catchAll((error) =>
+                  Effect.sync(() => {
+                    orchestratorLogger.log('warn', 'terminal_workspace_cleanup_failed', {
+                      issue_id: issueId,
+                      issue_identifier: running.identifier,
+                      ...toLogError(error),
+                    })
+                  }),
+                ),
+              )
+            }
+            return
+          }
+
+          if (reason === 'inactive') {
+            yield* SynchronizedRef.modifyEffect(stateRef, (state) => {
+              state.claimed.delete(issueId)
+              return Effect.succeed([undefined, state] as const)
+            })
+            return
+          }
+
+          if (reason === 'normal') {
+            yield* SynchronizedRef.modifyEffect(stateRef, (state) => {
+              state.completed.add(issueId)
+              return Effect.succeed([undefined, state] as const)
+            })
+            yield* scheduleRetry(issueId, running.identifier, 1, 'continuation', null)
+            return
+          }
+
+          yield* scheduleRetry(issueId, running.identifier, (running.retryAttempt ?? 0) + 1, 'failure', errorMessage)
+        })
+
+      const handleCommand = (command: OrchestratorCommand) =>
+        Effect.matchEffect(
+          (() => {
+            switch (command._tag) {
+              case 'PollTick':
+                return processPollTick
+              case 'StallSweep':
+                return Ref.set(stallQueuedRef, false).pipe(
+                  Effect.zipRight(workflow.config.pipe(Effect.flatMap((config) => reconcileStalledRuns(config)))),
+                )
+              case 'RetryDue':
+                return processRetryDue(command.issueId)
+              case 'WorkspaceReady':
+                return SynchronizedRef.modifyEffect(stateRef, (state) => {
+                  const running = state.running.get(command.issueId)
+                  if (running) {
+                    running.workspacePath = command.workspacePath
+                  }
+                  return Effect.succeed([undefined, state] as const)
+                })
+              case 'CodexEventReceived':
+                return handleCodexEvent(command.issueId, command.event)
+              case 'WorkerExited':
+                return processWorkerExit(command.issueId, command.exit)
+            }
+          })(),
+          {
+            onFailure: (error) =>
+              Effect.sync(() => {
+                orchestratorLogger.log('warn', 'orchestrator_command_failed', {
+                  command: command._tag,
+                  ...toLogError(error),
+                })
+              }),
+            onSuccess: () => Effect.void,
+          },
+        )
+
+      const startProcessor = Effect.forever(Queue.take(queue).pipe(Effect.flatMap(handleCommand))).pipe(
+        Effect.forkScoped,
+      )
+
+      const startSchedulers = Effect.gen(function* () {
+        const pollSchedule = Schedule.addDelayEffect(Schedule.forever, () =>
+          workflow.config.pipe(
+            Effect.map((config) => Duration.millis(config.pollingIntervalMs)),
+            Effect.catchAll(() => Effect.succeed(Duration.millis(30_000))),
+          ),
+        )
+        const stallSchedule = Schedule.addDelayEffect(Schedule.forever, () =>
+          workflow.config.pipe(
+            Effect.map((config) =>
+              Duration.millis(
+                config.codex.stallTimeoutMs > 0
+                  ? Math.max(1_000, Math.min(config.pollingIntervalMs, Math.floor(config.codex.stallTimeoutMs / 2)))
+                  : Math.max(5_000, config.pollingIntervalMs),
+              ),
+            ),
+            Effect.catchAll(() => Effect.succeed(Duration.millis(30_000))),
+          ),
+        )
+
+        const pollFiber = yield* Effect.repeat(enqueuePoll, pollSchedule).pipe(Effect.asVoid, Effect.forkScoped)
+        const stallFiber = yield* Effect.repeat(enqueueStallSweep, stallSchedule).pipe(Effect.asVoid, Effect.forkScoped)
+        yield* Ref.set(pollFiberRef, pollFiber)
+        yield* Ref.set(stallFiberRef, stallFiber)
+      })
+
+      const startupCleanup = workflow.config.pipe(
+        Effect.flatMap((config) =>
+          tracker.fetchIssuesByStates(config.tracker.terminalStates).pipe(
+            Effect.flatMap((issues) => Effect.forEach(issues, (issue) => workspace.removeWorkspace(issue.identifier))),
+            Effect.catchAll((error) =>
+              Effect.sync(() => {
+                orchestratorLogger.log('warn', 'startup_terminal_cleanup_failed', toLogError(error))
+              }),
+            ),
+          ),
+        ),
+      )
+
+      const service: OrchestratorServiceDefinition = {
+        start: Effect.scoped(
+          Ref.get(startedRef).pipe(
+            Effect.flatMap((started) =>
+              started
+                ? Effect.void
+                : Effect.gen(function* () {
+                    const config = yield* workflow.config
+                    yield* validateDispatchConfigEffect(config)
+                    yield* startupCleanup
+                    const processorFiber = yield* startProcessor
+                    yield* Ref.set(processorFiberRef, processorFiber)
+                    yield* startSchedulers
+                    yield* Ref.set(startedRef, true)
+                  }),
+            ),
+          ),
+        ),
+        stop: Effect.gen(function* () {
+          yield* Ref.set(startedRef, false)
+
+          const processorFiber = yield* Ref.get(processorFiberRef)
+          if (processorFiber) {
+            yield* Fiber.interruptFork(processorFiber)
+          }
+
+          const pollFiber = yield* Ref.get(pollFiberRef)
+          if (pollFiber) {
+            yield* Fiber.interruptFork(pollFiber)
+          }
+
+          const stallFiber = yield* Ref.get(stallFiberRef)
+          if (stallFiber) {
+            yield* Fiber.interruptFork(stallFiber)
+          }
+
+          const state = yield* SynchronizedRef.get(stateRef)
+          for (const retry of state.retryAttempts.values()) {
+            yield* Fiber.interruptFork(retry.fiber)
+          }
+          for (const running of state.running.values()) {
+            yield* Fiber.interruptFork(running.workerFiber)
+          }
+        }),
+        triggerRefresh: enqueuePoll,
+        getSnapshot: SynchronizedRef.get(stateRef).pipe(
+          Effect.map((state) => {
+            const generatedAt = new Date().toISOString()
+            const nowMs = Date.now()
+            const running = Array.from(state.running.values())
+            const retrying = Array.from(state.retryAttempts.values())
+            const activeRuntimeSeconds = running.reduce(
+              (total, entry) => total + Math.max(0, nowMs - entry.startedAtMs) / 1_000,
+              0,
+            )
+
+            return {
+              generatedAt,
+              counts: {
+                running: running.length,
+                retrying: retrying.length,
+              },
+              running: running.map((entry) => ({
+                issueId: entry.issueId,
+                issueIdentifier: entry.identifier,
+                state: entry.issue.state,
+                sessionId: entry.session.sessionId,
+                turnCount: entry.session.turnCount,
+                lastEvent: entry.session.lastCodexEvent,
+                lastMessage: entry.session.lastCodexMessage,
+                startedAt: entry.startedAt,
+                lastEventAt: entry.session.lastCodexTimestamp,
+                tokens: {
+                  inputTokens: entry.session.codexInputTokens,
+                  outputTokens: entry.session.codexOutputTokens,
+                  totalTokens: entry.session.codexTotalTokens,
+                },
+              })),
+              retrying: retrying.map((entry) => ({
+                issueId: entry.issueId,
+                issueIdentifier: entry.identifier,
+                attempt: entry.attempt,
+                dueAt: new Date(entry.dueAtMs).toISOString(),
+                error: entry.error,
+              })),
+              codexTotals: {
+                inputTokens: state.codexTotals.inputTokens,
+                outputTokens: state.codexTotals.outputTokens,
+                totalTokens: state.codexTotals.totalTokens,
+                secondsRunning: state.codexTotals.endedRuntimeSeconds + activeRuntimeSeconds,
+              },
+              rateLimits: state.codexRateLimits,
+            } satisfies RuntimeSnapshot
+          }),
+        ),
+        getIssueDetails: (issueIdentifier) =>
+          SynchronizedRef.get(stateRef).pipe(Effect.map((state) => buildIssueDetails(state, issueIdentifier))),
+        getCurrentConfig: workflow.config.pipe(
+          Effect.mapError((error) => new OrchestratorError('runtime_unavailable', error.message, error)),
+        ),
       }
-    }
-    if (event.rateLimits) {
-      this.state.codexRateLimits = event.rateLimits
-    }
-    if (event.usage) {
-      this.applyTokenUsage(running, event.usage)
-    }
+
+      return service
+    }),
+  )
+
+const toUnknownMessage = (cause: unknown): string => {
+  if (cause instanceof Error) return cause.message
+  if (cause && typeof cause === 'object' && 'failure' in cause) {
+    const failure = (cause as { failure?: unknown }).failure
+    if (failure instanceof Error) return failure.message
+    if (typeof failure === 'string') return failure
   }
-
-  private applyTokenUsage(running: RunningEntry, usage: TokenUsageTotals): void {
-    const deltaInput = Math.max(0, usage.inputTokens - running.session.lastReportedInputTokens)
-    const deltaOutput = Math.max(0, usage.outputTokens - running.session.lastReportedOutputTokens)
-    const deltaTotal = Math.max(0, usage.totalTokens - running.session.lastReportedTotalTokens)
-
-    running.session.codexInputTokens = usage.inputTokens
-    running.session.codexOutputTokens = usage.outputTokens
-    running.session.codexTotalTokens = usage.totalTokens
-    running.session.lastReportedInputTokens = usage.inputTokens
-    running.session.lastReportedOutputTokens = usage.outputTokens
-    running.session.lastReportedTotalTokens = usage.totalTokens
-
-    this.state.codexTotals.inputTokens += deltaInput
-    this.state.codexTotals.outputTokens += deltaOutput
-    this.state.codexTotals.totalTokens += deltaTotal
-  }
+  return typeof cause === 'string' ? cause : JSON.stringify(cause)
 }

--- a/services/symphony/src/runtime.ts
+++ b/services/symphony/src/runtime.ts
@@ -1,0 +1,31 @@
+import { Layer, ManagedRuntime } from 'effect'
+
+import { makeCodexSessionLayer } from './codex-app-session'
+import { makeIssueRunnerLayer } from './issue-runner'
+import { makeTrackerLayer } from './linear-client'
+import { makeOrchestratorLayer } from './orchestrator'
+import { makeWorkflowLayer } from './workflow'
+import { makeShellLayer, makeWorkspaceLayer } from './workspace-manager'
+import type { Logger } from './logger'
+
+export const makeSymphonyLayer = (workflowPath: string, logger: Logger) => {
+  const workflowLayer = makeWorkflowLayer(workflowPath, logger)
+  const shellLayer = makeShellLayer(logger)
+  const trackerLayer = makeTrackerLayer(logger).pipe(Layer.provide(workflowLayer))
+  const workspaceLayer = makeWorkspaceLayer(logger).pipe(Layer.provide(shellLayer), Layer.provide(workflowLayer))
+  const codexSessionLayer = makeCodexSessionLayer(logger)
+  const issueRunnerLayer = makeIssueRunnerLayer(logger)
+    .pipe(Layer.provide(codexSessionLayer))
+    .pipe(Layer.provide(workspaceLayer))
+    .pipe(Layer.provide(trackerLayer))
+    .pipe(Layer.provide(workflowLayer))
+
+  return makeOrchestratorLayer(logger)
+    .pipe(Layer.provide(issueRunnerLayer))
+    .pipe(Layer.provide(workspaceLayer))
+    .pipe(Layer.provide(trackerLayer))
+    .pipe(Layer.provide(workflowLayer))
+}
+
+export const makeSymphonyRuntime = (workflowPath: string, logger: Logger) =>
+  ManagedRuntime.make(makeSymphonyLayer(workflowPath, logger))

--- a/services/symphony/src/template.ts
+++ b/services/symphony/src/template.ts
@@ -1,6 +1,6 @@
 import Handlebars from 'handlebars'
 
-import { SymphonyError } from './errors'
+import { WorkflowError } from './errors'
 import type { Issue } from './types'
 
 export type PromptTemplateInput = {
@@ -20,7 +20,7 @@ const createTemplateEngine = () => {
 
   engine.registerHelper('helperMissing', function helperMissing(this: unknown, ...args: unknown[]) {
     const helperName = typeof args.at(-1) === 'object' ? (args.at(-1) as { name?: string }).name : 'unknown'
-    throw new SymphonyError('template_render_error', `unknown helper ${helperName ?? 'unknown'}`)
+    throw new WorkflowError('template_render_error', `unknown helper ${helperName ?? 'unknown'}`)
   })
 
   engine.registerHelper('json', (value: unknown) => JSON.stringify(value))
@@ -45,12 +45,12 @@ export const renderPromptTemplate = (template: string, input: PromptTemplateInpu
   try {
     compiled = engine.compile(template, { strict: true, noEscape: true })
   } catch (error) {
-    throw new SymphonyError('template_parse_error', 'failed to parse workflow prompt template', error)
+    throw new WorkflowError('template_parse_error', 'failed to parse workflow prompt template', error)
   }
 
   try {
     return compiled(input).trim()
   } catch (error) {
-    throw new SymphonyError('template_render_error', 'failed to render workflow prompt template', error)
+    throw new WorkflowError('template_render_error', 'failed to render workflow prompt template', error)
   }
 }

--- a/services/symphony/src/types.ts
+++ b/services/symphony/src/types.ts
@@ -82,6 +82,12 @@ export type SymphonyConfig = {
   server: ServerConfig
 }
 
+export type LoadedWorkflow = {
+  definition: WorkflowDefinition
+  config: SymphonyConfig
+  mtimeMs: number
+}
+
 export type WorkspaceInfo = {
   path: string
   workspaceKey: string
@@ -117,32 +123,6 @@ export type RecentEvent = {
   message: string | null
 }
 
-export type RetryEntry = {
-  issueId: string
-  identifier: string
-  attempt: number
-  dueAtMs: number
-  timerHandle: Timer
-  error: string | null
-}
-
-export type RunningEntry = {
-  issue: Issue
-  issueId: string
-  identifier: string
-  retryAttempt: number | null
-  workspacePath: string
-  startedAt: string
-  startedAtMs: number
-  session: LiveSession
-  lastError: string | null
-  recentEvents: RecentEvent[]
-  workerHandle: Promise<void>
-  abortController: AbortController
-  stopReason: 'running' | 'stalled' | 'terminal' | 'inactive'
-  terminalCleanupRequested: boolean
-}
-
 export type CodexTotals = TokenUsageTotals & {
   endedRuntimeSeconds: number
 }
@@ -176,4 +156,38 @@ export type RuntimeSnapshot = {
     secondsRunning: number
   }
   rateLimits: RateLimitSnapshot | null
+}
+
+export type IssueDetails = {
+  issueIdentifier: string
+  issueId: string
+  status: 'running' | 'retrying'
+  workspace: {
+    path: string | null
+  }
+  attempts: {
+    restartCount: number
+    currentRetryAttempt: number
+  }
+  running: {
+    sessionId: string | null
+    turnCount: number
+    state: string
+    startedAt: string
+    lastEvent: string | null
+    lastMessage: string | null
+    lastEventAt: string | null
+    tokens: TokenUsageTotals
+  } | null
+  retry: {
+    attempt: number
+    dueAt: string
+    error: string | null
+  } | null
+  logs: {
+    codex_session_logs: unknown[]
+  }
+  recentEvents: RecentEvent[]
+  lastError: string | null
+  tracked: Record<string, unknown>
 }

--- a/services/symphony/src/workflow.test.ts
+++ b/services/symphony/src/workflow.test.ts
@@ -3,8 +3,10 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 
+import { Effect, ManagedRuntime } from 'effect'
+
 import { createLogger } from './logger'
-import { loadWorkflowFile, WorkflowStore } from './workflow'
+import { loadWorkflowFile, makeWorkflowLayer, WorkflowService } from './workflow'
 
 describe('workflow loader', () => {
   let tempDir = ''
@@ -39,7 +41,7 @@ describe('workflow loader', () => {
     expect(workflow.promptTemplate).toBe('Work on {{issue.identifier}}.')
   })
 
-  test('WorkflowStore keeps the last known good workflow on invalid reload', async () => {
+  test('WorkflowService keeps the last known good workflow on invalid reload', async () => {
     const workflowPath = path.join(tempDir, 'WORKFLOW.md')
     writeFileSync(
       workflowPath,
@@ -47,15 +49,31 @@ describe('workflow loader', () => {
       'utf8',
     )
 
-    const store = new WorkflowStore(workflowPath, createLogger({ test: 'workflow' }))
-    await store.initialize()
+    const runtime = ManagedRuntime.make(makeWorkflowLayer(workflowPath, createLogger({ test: 'workflow' })))
+    try {
+      const initial = await runtime.runPromise(
+        Effect.gen(function* () {
+          const service = yield* WorkflowService
+          return yield* service.current
+        }),
+      )
+      expect(initial.definition.promptTemplate).toBe('Initial prompt')
 
-    await Bun.sleep(20)
-    writeFileSync(workflowPath, ['---', '- invalid', '---', 'Broken'].join('\n'), 'utf8')
+      await Bun.sleep(20)
+      writeFileSync(workflowPath, ['---', '- invalid', '---', 'Broken'].join('\n'), 'utf8')
+      await Bun.sleep(20)
 
-    const current = await store.getCurrent()
-    expect(current.definition.promptTemplate).toBe('Initial prompt')
-    expect(current.config.tracker.projectSlug).toBe('symphony')
-    store.close()
+      const current = await runtime.runPromise(
+        Effect.gen(function* () {
+          const service = yield* WorkflowService
+          return yield* service.current
+        }),
+      )
+
+      expect(current.definition.promptTemplate).toBe('Initial prompt')
+      expect(current.config.tracker.projectSlug).toBe('symphony')
+    } finally {
+      await runtime.dispose()
+    }
   })
 })

--- a/services/symphony/src/workflow.ts
+++ b/services/symphony/src/workflow.ts
@@ -1,31 +1,52 @@
-import { readFile, watch, type FSWatcher } from 'node:fs'
+import { readFile, watch } from 'node:fs'
 import { stat } from 'node:fs/promises'
+import type { FSWatcher } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 
+import type * as ParseResult from '@effect/schema/ParseResult'
+import * as Schema from '@effect/schema/Schema'
+import * as TreeFormatter from '@effect/schema/TreeFormatter'
+import { Context, Effect, Layer, Runtime } from 'effect'
+import * as SubscriptionRef from 'effect/SubscriptionRef'
+import * as Stream from 'effect/Stream'
 import YAML from 'yaml'
 
-import { SymphonyError } from './errors'
+import { toSymphonyConfigEffect } from './config'
+import { ConfigError, WorkflowError, toLogError } from './errors'
+import type { LoadedWorkflow, SymphonyConfig, WorkflowDefinition } from './types'
 import type { Logger } from './logger'
-import { toSymphonyConfig } from './config'
-import type { SymphonyConfig, WorkflowDefinition } from './types'
 
-const readFileText = async (filePath: string): Promise<string> =>
-  new Promise((resolvePromise, rejectPromise) => {
+const WorkflowFrontMatterSchema = Schema.Record({
+  key: Schema.String,
+  value: Schema.Unknown,
+})
+
+const decodeWorkflowFrontMatter = Schema.decodeUnknown(WorkflowFrontMatterSchema)
+
+const formatSchemaError = (error: ParseResult.ParseError): string => TreeFormatter.formatErrorSync(error)
+
+const readFileText = (filePath: string): Effect.Effect<string, WorkflowError, never> =>
+  Effect.async((resume) => {
     readFile(filePath, 'utf8', (error, data) => {
       if (error) {
-        rejectPromise(error)
+        resume(
+          Effect.fail(new WorkflowError('missing_workflow_file', `failed to read workflow file ${filePath}`, error)),
+        )
         return
       }
-      resolvePromise(data)
+      resume(Effect.succeed(data))
     })
   })
 
-const readFrontMatter = (content: string): WorkflowDefinition => {
+const parseFrontMatter = (
+  workflowPath: string,
+  content: string,
+): Effect.Effect<WorkflowDefinition, WorkflowError, never> => {
   if (!content.startsWith('---')) {
-    return {
+    return Effect.succeed({
       config: {},
       promptTemplate: content.trim(),
-    }
+    })
   }
 
   const lines = content.split(/\r?\n/)
@@ -36,127 +57,167 @@ const readFrontMatter = (content: string): WorkflowDefinition => {
       break
     }
   }
+
   if (closingIndex === -1) {
-    throw new SymphonyError('workflow_parse_error', 'workflow front matter is missing closing delimiter')
+    return Effect.fail(
+      new WorkflowError('workflow_parse_error', `workflow ${workflowPath} front matter is missing closing delimiter`),
+    )
   }
 
   const yamlText = lines.slice(1, closingIndex).join('\n')
-  const body = lines
+  const promptTemplate = lines
     .slice(closingIndex + 1)
     .join('\n')
     .trim()
 
-  let parsed: unknown
-  try {
-    parsed = yamlText.trim().length > 0 ? YAML.parse(yamlText) : {}
-  } catch (error) {
-    throw new SymphonyError('workflow_parse_error', 'failed to parse workflow front matter', error)
-  }
-
-  if (parsed === null || Array.isArray(parsed) || typeof parsed !== 'object') {
-    throw new SymphonyError('workflow_front_matter_not_a_map', 'workflow front matter must decode to a map')
-  }
-
-  return {
-    config: parsed as Record<string, unknown>,
-    promptTemplate: body,
-  }
+  return Effect.try({
+    try: () => (yamlText.trim().length > 0 ? YAML.parse(yamlText) : {}),
+    catch: (error) => new WorkflowError('workflow_parse_error', 'failed to parse workflow front matter', error),
+  }).pipe(
+    Effect.flatMap((parsed) =>
+      decodeWorkflowFrontMatter(parsed).pipe(
+        Effect.mapError(
+          (error) => new WorkflowError('workflow_front_matter_not_a_map', formatSchemaError(error), error),
+        ),
+      ),
+    ),
+    Effect.map((config) => ({
+      config,
+      promptTemplate,
+    })),
+  )
 }
 
-export const loadWorkflowFile = async (workflowPath: string): Promise<WorkflowDefinition> => {
-  try {
-    const content = await readFileText(workflowPath)
-    return readFrontMatter(content)
-  } catch (error) {
-    if (error instanceof SymphonyError) throw error
-    throw new SymphonyError('missing_workflow_file', `failed to read workflow file ${workflowPath}`, error)
-  }
-}
-
-export class WorkflowStore {
-  private readonly workflowPath: string
-  private readonly logger: Logger
-  private watcher: FSWatcher | null = null
-  private lastKnownGood: { definition: WorkflowDefinition; config: SymphonyConfig } | null = null
-  private lastLoadedMtimeMs = 0
-
-  constructor(workflowPath: string, logger: Logger) {
-    this.workflowPath = resolve(workflowPath)
-    this.logger = logger.child({ component: 'workflow-store', workflow_path: this.workflowPath })
-  }
-
-  async initialize(): Promise<void> {
-    const loaded = await this.reload()
-    this.lastKnownGood = loaded
-  }
-
-  async getCurrent(): Promise<{ definition: WorkflowDefinition; config: SymphonyConfig }> {
-    await this.reloadIfChanged()
-    if (!this.lastKnownGood) {
-      await this.initialize()
-    }
-    if (!this.lastKnownGood) {
-      throw new SymphonyError('missing_workflow_file', `workflow file ${this.workflowPath} is unavailable`)
-    }
-    return this.lastKnownGood
-  }
-
-  startWatching(): void {
-    if (this.watcher) return
-    const directory = dirname(this.workflowPath)
-    this.watcher = watch(directory, { persistent: false }, async (_eventType, filename) => {
-      if (filename && resolve(directory, filename.toString()) !== this.workflowPath) return
-      try {
-        await this.reload()
-      } catch (error) {
-        this.logger.log('error', 'workflow_reload_failed', {
-          error: error instanceof Error ? error.message : String(error),
-        })
-      }
+const readLoadedWorkflowEffect = (
+  workflowPath: string,
+): Effect.Effect<LoadedWorkflow, WorkflowError | ConfigError, never> =>
+  Effect.gen(function* () {
+    const resolvedPath = resolve(workflowPath)
+    const content = yield* readFileText(resolvedPath)
+    const definition = yield* parseFrontMatter(resolvedPath, content)
+    const metadata = yield* Effect.tryPromise({
+      try: () => stat(resolvedPath),
+      catch: (error) =>
+        new WorkflowError('missing_workflow_file', `failed to stat workflow file ${resolvedPath}`, error),
     })
-  }
+    const config = yield* toSymphonyConfigEffect(resolvedPath, definition.config)
 
-  close(): void {
-    this.watcher?.close()
-    this.watcher = null
-  }
+    return {
+      definition,
+      config,
+      mtimeMs: metadata.mtimeMs,
+    } satisfies LoadedWorkflow
+  })
 
-  private async reloadIfChanged(): Promise<void> {
-    let nextMtimeMs: number
-    try {
-      const metadata = await stat(this.workflowPath)
-      nextMtimeMs = metadata.mtimeMs
-    } catch (error) {
-      if (!this.lastKnownGood) {
-        throw new SymphonyError('missing_workflow_file', `failed to stat workflow file ${this.workflowPath}`, error)
-      }
-      this.logger.log('warn', 'workflow_stat_failed', { error: error instanceof Error ? error.message : String(error) })
-      return
-    }
+export const loadWorkflowFileEffect = (workflowPath: string): Effect.Effect<WorkflowDefinition, WorkflowError, never> =>
+  readFileText(resolve(workflowPath)).pipe(
+    Effect.flatMap((content) => parseFrontMatter(resolve(workflowPath), content)),
+  )
 
-    if (nextMtimeMs <= this.lastLoadedMtimeMs && this.lastKnownGood) return
-    try {
-      await this.reload()
-    } catch (error) {
-      if (!this.lastKnownGood) throw error
-      this.logger.log('error', 'workflow_reload_failed', {
-        error: error instanceof Error ? error.message : String(error),
+export const loadWorkflowFile = (workflowPath: string): Promise<WorkflowDefinition> =>
+  Effect.runPromise(loadWorkflowFileEffect(workflowPath))
+
+export interface WorkflowServiceDefinition {
+  readonly current: Effect.Effect<
+    { definition: WorkflowDefinition; config: SymphonyConfig },
+    WorkflowError | ConfigError
+  >
+  readonly config: Effect.Effect<SymphonyConfig, WorkflowError | ConfigError>
+  readonly reload: Effect.Effect<
+    { definition: WorkflowDefinition; config: SymphonyConfig },
+    WorkflowError | ConfigError
+  >
+  readonly changes: Stream.Stream<{ definition: WorkflowDefinition; config: SymphonyConfig }>
+}
+
+export class WorkflowService extends Context.Tag('symphony/WorkflowService')<
+  WorkflowService,
+  WorkflowServiceDefinition
+>() {}
+
+export const makeWorkflowLayer = (workflowPath: string, logger: Logger) =>
+  Layer.scoped(
+    WorkflowService,
+    Effect.gen(function* () {
+      const resolvedPath = resolve(workflowPath)
+      const runtime = yield* Effect.runtime<never>()
+      const workflowLogger = logger.child({ component: 'workflow-service', workflow_path: resolvedPath })
+      const initial = yield* readLoadedWorkflowEffect(resolvedPath)
+      const ref = yield* SubscriptionRef.make(initial)
+
+      const reloadAndKeepLastKnownGood = readLoadedWorkflowEffect(resolvedPath).pipe(
+        Effect.flatMap((loaded) =>
+          SubscriptionRef.set(ref, loaded).pipe(
+            Effect.tap(() =>
+              Effect.sync(() => {
+                workflowLogger.log('info', 'workflow_reloaded', {
+                  poll_interval_ms: loaded.config.pollingIntervalMs,
+                  max_concurrent_agents: loaded.config.agent.maxConcurrentAgents,
+                })
+              }),
+            ),
+            Effect.as(loaded),
+          ),
+        ),
+      )
+
+      const safeReload = reloadAndKeepLastKnownGood.pipe(
+        Effect.catchAll((error) =>
+          Effect.sync(() => {
+            workflowLogger.log('error', 'workflow_reload_failed', toLogError(error))
+          }).pipe(Effect.zipRight(SubscriptionRef.get(ref))),
+        ),
+      )
+
+      yield* Effect.acquireRelease(
+        Effect.sync(() =>
+          watch(dirname(resolvedPath), { persistent: false }, (_eventType, filename) => {
+            if (filename && resolve(dirname(resolvedPath), filename.toString()) !== resolvedPath) return
+            Runtime.runFork(runtime)(safeReload)
+          }),
+        ),
+        (resource: FSWatcher) =>
+          Effect.sync(() => {
+            resource.close()
+          }),
+      )
+
+      const current = Effect.gen(function* () {
+        const latest = yield* SubscriptionRef.get(ref)
+        const metadata = yield* Effect.tryPromise({
+          try: () => stat(resolvedPath),
+          catch: (error) =>
+            new WorkflowError('missing_workflow_file', `failed to stat workflow file ${resolvedPath}`, error),
+        }).pipe(
+          Effect.catchAll((error) =>
+            Effect.sync(() => {
+              workflowLogger.log('warn', 'workflow_stat_failed', toLogError(error))
+            }).pipe(Effect.zipRight(Effect.succeed<{ mtimeMs: number }>({ mtimeMs: latest.mtimeMs }))),
+          ),
+        )
+
+        if (metadata.mtimeMs > latest.mtimeMs) {
+          return yield* safeReload.pipe(
+            Effect.map((loaded) => ({ definition: loaded.definition, config: loaded.config })),
+          )
+        }
+
+        return {
+          definition: latest.definition,
+          config: latest.config,
+        }
       })
-    }
-  }
 
-  private async reload(): Promise<{ definition: WorkflowDefinition; config: SymphonyConfig }> {
-    const definition = await loadWorkflowFile(this.workflowPath)
-    const config = toSymphonyConfig(this.workflowPath, definition.config)
-    const metadata = await stat(this.workflowPath)
-
-    const loaded = { definition, config }
-    this.lastKnownGood = loaded
-    this.lastLoadedMtimeMs = metadata.mtimeMs
-    this.logger.log('info', 'workflow_reloaded', {
-      poll_interval_ms: config.pollingIntervalMs,
-      max_concurrent_agents: config.agent.maxConcurrentAgents,
-    })
-    return loaded
-  }
-}
+      return {
+        current,
+        config: current.pipe(Effect.map((loaded) => loaded.config)),
+        reload: safeReload.pipe(Effect.map((loaded) => ({ definition: loaded.definition, config: loaded.config }))),
+        changes: ref.changes.pipe(
+          Stream.map((loaded) => ({
+            definition: loaded.definition,
+            config: loaded.config,
+          })),
+        ),
+      } satisfies WorkflowServiceDefinition
+    }),
+  )

--- a/services/symphony/src/workspace-manager.test.ts
+++ b/services/symphony/src/workspace-manager.test.ts
@@ -3,9 +3,13 @@ import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync } from 'node:f
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 
+import { Effect, Layer, ManagedRuntime } from 'effect'
+import * as Stream from 'effect/Stream'
+
 import { createLogger } from './logger'
 import type { SymphonyConfig } from './types'
-import { WorkspaceManager } from './workspace-manager'
+import { WorkflowService } from './workflow'
+import { makeShellLayer, makeWorkspaceLayer, WorkspaceService } from './workspace-manager'
 
 const makeConfig = (workspaceRoot: string): SymphonyConfig => ({
   workflowPath: path.join(workspaceRoot, 'WORKFLOW.md'),
@@ -65,26 +69,55 @@ describe('workspace manager', () => {
   })
 
   test('creates deterministic sanitized workspaces and runs hooks with correct lifecycle', async () => {
-    const manager = new WorkspaceManager(async () => config, createLogger({ test: 'workspace' }))
+    const workflowLayer = Layer.succeed(WorkflowService, {
+      current: Effect.succeed({ definition: { config: {}, promptTemplate: '' }, config }),
+      config: Effect.succeed(config),
+      reload: Effect.succeed({ definition: { config: {}, promptTemplate: '' }, config }),
+      changes: Stream.empty,
+    })
+    const runtime = ManagedRuntime.make(
+      makeWorkspaceLayer(createLogger({ test: 'workspace' }))
+        .pipe(Layer.provide(makeShellLayer(createLogger({ test: 'workspace-shell' }))))
+        .pipe(Layer.provide(workflowLayer)),
+    )
 
-    const first = await manager.createForIssue('ABC/123')
-    expect(first.workspaceKey).toBe('ABC_123')
-    expect(first.createdNow).toBe(true)
-    expect(first.path).toBe(path.join(tempDir, 'ABC_123'))
+    try {
+      const first = await runtime.runPromise(
+        Effect.gen(function* () {
+          const manager = yield* WorkspaceService
+          return yield* manager.createForIssue('ABC/123')
+        }),
+      )
+      expect(first.workspaceKey).toBe('ABC_123')
+      expect(first.createdNow).toBe(true)
+      expect(first.path).toBe(path.join(tempDir, 'ABC_123'))
 
-    mkdirSync(path.join(first.path, 'tmp'), { recursive: true })
-    mkdirSync(path.join(first.path, '.elixir_ls'), { recursive: true })
+      mkdirSync(path.join(first.path, 'tmp'), { recursive: true })
+      mkdirSync(path.join(first.path, '.elixir_ls'), { recursive: true })
 
-    const second = await manager.createForIssue('ABC/123')
-    expect(second.createdNow).toBe(false)
-    expect(existsSync(path.join(second.path, 'tmp'))).toBe(false)
-    expect(existsSync(path.join(second.path, '.elixir_ls'))).toBe(false)
+      const second = await runtime.runPromise(
+        Effect.gen(function* () {
+          const manager = yield* WorkspaceService
+          return yield* manager.createForIssue('ABC/123')
+        }),
+      )
+      expect(second.createdNow).toBe(false)
+      expect(existsSync(path.join(second.path, 'tmp'))).toBe(false)
+      expect(existsSync(path.join(second.path, '.elixir_ls'))).toBe(false)
 
-    await manager.runBeforeRun(second.path)
-    await manager.runAfterRun(second.path)
-    await manager.removeWorkspace('ABC/123')
+      await runtime.runPromise(
+        Effect.gen(function* () {
+          const manager = yield* WorkspaceService
+          yield* manager.runBeforeRun(second.path)
+          yield* manager.runAfterRun(second.path)
+          yield* manager.removeWorkspace('ABC/123')
+        }),
+      )
 
-    const hookLog = readFileSync(path.join(tempDir, 'hooks.log'), 'utf8').trim().split('\n')
-    expect(hookLog).toEqual(['after_create', 'before_run', 'after_run', 'before_remove'])
+      const hookLog = readFileSync(path.join(tempDir, 'hooks.log'), 'utf8').trim().split('\n')
+      expect(hookLog).toEqual(['after_create', 'before_run', 'after_run', 'before_remove'])
+    } finally {
+      await runtime.dispose()
+    }
   })
 })

--- a/services/symphony/src/workspace-manager.ts
+++ b/services/symphony/src/workspace-manager.ts
@@ -1,11 +1,15 @@
+import { spawn } from 'node:child_process'
 import { mkdir, readdir, rm, stat } from 'node:fs/promises'
 import path from 'node:path'
-import { spawn } from 'node:child_process'
 
-import { SymphonyError } from './errors'
-import type { Logger } from './logger'
-import type { SymphonyConfig, WorkspaceInfo } from './types'
+import { Context, Effect, Layer } from 'effect'
+import * as Duration from 'effect/Duration'
+
+import { ConfigError, WorkspaceError, WorkflowError, toLogError } from './errors'
+import type { WorkspaceInfo } from './types'
 import { ensurePathInsideRoot, sanitizeWorkspaceKey, toAbsolutePath } from './utils'
+import { WorkflowService } from './workflow'
+import type { Logger } from './logger'
 
 const PREP_GARBAGE = ['tmp', '.elixir_ls']
 const MAX_HOOK_LOG_BYTES = 4_096
@@ -13,186 +17,314 @@ const MAX_HOOK_LOG_BYTES = 4_096
 const truncateOutput = (value: string): string =>
   value.length > MAX_HOOK_LOG_BYTES ? `${value.slice(0, MAX_HOOK_LOG_BYTES)}…` : value
 
-export class WorkspaceManager {
-  private readonly configProvider: () => Promise<SymphonyConfig>
-  private readonly logger: Logger
+export type ShellResult = {
+  stdout: string
+  stderr: string
+}
 
-  constructor(configProvider: () => Promise<SymphonyConfig>, logger: Logger) {
-    this.configProvider = configProvider
-    this.logger = logger.child({ component: 'workspace-manager' })
-  }
+export interface ShellServiceDefinition {
+  readonly run: (
+    script: string,
+    options: {
+      cwd: string
+      timeoutMs: number
+      hookName: 'after_create' | 'before_run' | 'after_run' | 'before_remove'
+    },
+  ) => Effect.Effect<ShellResult, WorkspaceError>
+}
 
-  async createForIssue(identifier: string): Promise<WorkspaceInfo> {
-    const config = await this.configProvider()
-    const workspaceKey = sanitizeWorkspaceKey(identifier)
-    const root = toAbsolutePath(config.workspaceRoot)
-    const workspacePath = toAbsolutePath(path.join(root, workspaceKey))
+export class ShellService extends Context.Tag('symphony/ShellService')<ShellService, ShellServiceDefinition>() {}
 
-    if (!ensurePathInsideRoot(root, workspacePath)) {
-      throw new SymphonyError('invalid_workspace_cwd', `workspace path ${workspacePath} escapes root ${root}`)
-    }
+export interface WorkspaceServiceDefinition {
+  readonly createForIssue: (
+    identifier: string,
+  ) => Effect.Effect<WorkspaceInfo, WorkflowError | ConfigError | WorkspaceError>
+  readonly runBeforeRun: (workspacePath: string) => Effect.Effect<void, WorkflowError | ConfigError | WorkspaceError>
+  readonly runAfterRun: (workspacePath: string) => Effect.Effect<void, WorkflowError | ConfigError | WorkspaceError>
+  readonly removeWorkspace: (identifier: string) => Effect.Effect<void, WorkflowError | ConfigError | WorkspaceError>
+}
 
-    await mkdir(root, { recursive: true })
+export class WorkspaceService extends Context.Tag('symphony/WorkspaceService')<
+  WorkspaceService,
+  WorkspaceServiceDefinition
+>() {}
 
-    let createdNow = false
-    try {
-      const metadata = await stat(workspacePath)
-      if (!metadata.isDirectory()) {
-        throw new SymphonyError('workspace_path_not_directory', `workspace path ${workspacePath} is not a directory`)
-      }
-    } catch (error) {
-      if (error instanceof SymphonyError) throw error
-      const nodeError = error as NodeJS.ErrnoException
-      if (nodeError?.code && nodeError.code !== 'ENOENT') {
-        throw new SymphonyError('workspace_create_failed', `failed to inspect workspace ${workspacePath}`, error)
-      }
-      await mkdir(workspacePath, { recursive: true })
-      createdNow = true
-    }
-
-    await this.cleanupEphemeralArtifacts(workspacePath)
-
-    if (createdNow && config.hooks.afterCreate) {
-      await this.runHook('after_create', config.hooks.afterCreate, workspacePath, config.hooks.timeoutMs, true)
-    }
-
-    return {
-      path: workspacePath,
-      workspaceKey,
-      createdNow,
-    }
-  }
-
-  async runBeforeRun(workspacePath: string): Promise<void> {
-    const config = await this.configProvider()
-    if (!config.hooks.beforeRun) return
-    await this.runHook('before_run', config.hooks.beforeRun, workspacePath, config.hooks.timeoutMs, true)
-  }
-
-  async runAfterRun(workspacePath: string): Promise<void> {
-    const config = await this.configProvider()
-    if (!config.hooks.afterRun) return
-    await this.runHook('after_run', config.hooks.afterRun, workspacePath, config.hooks.timeoutMs, false)
-  }
-
-  async removeWorkspace(identifier: string): Promise<void> {
-    const config = await this.configProvider()
-    const workspaceKey = sanitizeWorkspaceKey(identifier)
-    const root = toAbsolutePath(config.workspaceRoot)
-    const workspacePath = toAbsolutePath(path.join(root, workspaceKey))
-    if (!ensurePathInsideRoot(root, workspacePath)) {
-      throw new SymphonyError('invalid_workspace_cwd', `workspace path ${workspacePath} escapes root ${root}`)
-    }
-
-    try {
-      const metadata = await stat(workspacePath)
-      if (!metadata.isDirectory()) {
-        throw new SymphonyError('workspace_path_not_directory', `workspace path ${workspacePath} is not a directory`)
-      }
-    } catch {
-      return
-    }
-
-    if (config.hooks.beforeRemove) {
-      await this.runHook('before_remove', config.hooks.beforeRemove, workspacePath, config.hooks.timeoutMs, false)
-    }
-    await rm(workspacePath, { recursive: true, force: true })
-    this.logger.log('info', 'workspace_removed', { workspace_path: workspacePath })
-  }
-
-  private async cleanupEphemeralArtifacts(workspacePath: string): Promise<void> {
-    try {
+const cleanupEphemeralArtifacts = (workspacePath: string): Effect.Effect<void, never, never> =>
+  Effect.tryPromise({
+    try: async () => {
       const entries = await readdir(workspacePath)
       await Promise.all(
         entries
           .filter((entry) => PREP_GARBAGE.includes(entry))
           .map((entry) => rm(path.join(workspacePath, entry), { recursive: true, force: true })),
       )
-    } catch {
-      return
-    }
-  }
+    },
+    catch: () => undefined,
+  }).pipe(
+    Effect.asVoid,
+    Effect.catchAll(() => Effect.void),
+  )
 
-  private async runHook(
-    hookName: 'after_create' | 'before_run' | 'after_run' | 'before_remove',
-    script: string,
-    workspacePath: string,
-    timeoutMs: number,
-    failOnError: boolean,
-  ): Promise<void> {
-    await new Promise<void>((resolve, reject) => {
-      const child = spawn('bash', ['-lc', script], {
-        cwd: workspacePath,
-        env: process.env,
-        stdio: ['ignore', 'pipe', 'pipe'],
-      })
+export const makeShellLayer = (logger: Logger) =>
+  Layer.succeed(ShellService, {
+    run: (script, options) =>
+      Effect.scoped(
+        Effect.acquireRelease(
+          Effect.sync(() =>
+            spawn('bash', ['-lc', script], {
+              cwd: options.cwd,
+              env: process.env,
+              stdio: ['ignore', 'pipe', 'pipe'],
+            }),
+          ),
+          (child) =>
+            Effect.sync(() => {
+              if (!child.killed) {
+                child.kill('SIGKILL')
+              }
+            }),
+        ).pipe(
+          Effect.flatMap((child) =>
+            Effect.async<ShellResult, WorkspaceError>((resume) => {
+              let stdout = ''
+              let stderr = ''
 
-      let stdout = ''
-      let stderr = ''
+              child.stdout.on('data', (chunk: Buffer) => {
+                stdout += chunk.toString('utf8')
+              })
+              child.stderr.on('data', (chunk: Buffer) => {
+                stderr += chunk.toString('utf8')
+              })
 
-      const timer = setTimeout(() => {
-        child.kill('SIGKILL')
-        const error = new SymphonyError('workspace_hook_timeout', `hook ${hookName} timed out after ${timeoutMs}ms`)
-        this.logger.log(failOnError ? 'error' : 'warn', 'workspace_hook_timeout', {
-          hook: hookName,
-          workspace_path: workspacePath,
-          timeout_ms: timeoutMs,
-        })
-        if (failOnError) {
-          reject(error)
-        } else {
-          resolve()
-        }
-      }, timeoutMs)
+              child.once('error', (error) => {
+                resume(
+                  Effect.fail(
+                    new WorkspaceError('workspace_hook_error', `hook ${options.hookName} failed to start`, error),
+                  ),
+                )
+              })
 
-      child.stdout.on('data', (chunk: Buffer) => {
-        stdout += chunk.toString('utf8')
-      })
-      child.stderr.on('data', (chunk: Buffer) => {
-        stderr += chunk.toString('utf8')
-      })
+              child.once('exit', (code, signal) => {
+                if (code === 0) {
+                  resume(Effect.succeed({ stdout, stderr }))
+                  return
+                }
 
-      child.on('error', (error) => {
-        clearTimeout(timer)
-        const wrapped = new SymphonyError('workspace_hook_error', `hook ${hookName} failed to start`, error)
-        this.logger.log(failOnError ? 'error' : 'warn', 'workspace_hook_error', {
-          hook: hookName,
-          workspace_path: workspacePath,
-          error: error.message,
-        })
-        if (failOnError) {
-          reject(wrapped)
-        } else {
-          resolve()
-        }
-      })
+                resume(
+                  Effect.fail(
+                    new WorkspaceError(
+                      'workspace_hook_error',
+                      `hook ${options.hookName} failed with code ${code ?? 'unknown'} signal ${signal ?? 'unknown'}`,
+                      {
+                        stdout: truncateOutput(stdout),
+                        stderr: truncateOutput(stderr),
+                        exitCode: code,
+                        signal,
+                      },
+                    ),
+                  ),
+                )
+              })
 
-      child.on('exit', (code, signal) => {
-        clearTimeout(timer)
-        if (code === 0) {
-          this.logger.log('info', 'workspace_hook_completed', {
-            hook: hookName,
-            workspace_path: workspacePath,
-          })
-          resolve()
-          return
-        }
+              return Effect.void
+            }).pipe(
+              Effect.timeoutFail({
+                duration: Duration.millis(options.timeoutMs),
+                onTimeout: () =>
+                  new WorkspaceError(
+                    'workspace_hook_timeout',
+                    `hook ${options.hookName} timed out after ${options.timeoutMs}ms`,
+                  ),
+              }),
+            ),
+          ),
+          Effect.tapError((error) =>
+            Effect.sync(() => {
+              logger.log('warn', 'workspace_shell_failed', {
+                hook: options.hookName,
+                workspace_path: options.cwd,
+                ...toLogError(error),
+              })
+            }),
+          ),
+        ),
+      ),
+  })
 
-        const message = `hook ${hookName} failed with code ${code ?? 'unknown'} signal ${signal ?? 'unknown'}`
-        this.logger.log(failOnError ? 'error' : 'warn', 'workspace_hook_failed', {
-          hook: hookName,
-          workspace_path: workspacePath,
-          exit_code: code,
-          signal,
-          stdout: truncateOutput(stdout),
-          stderr: truncateOutput(stderr),
-        })
-        if (failOnError) {
-          reject(new SymphonyError('workspace_hook_error', message))
-        } else {
-          resolve()
-        }
-      })
-    })
-  }
-}
+export const makeWorkspaceLayer = (logger: Logger) =>
+  Layer.effect(
+    WorkspaceService,
+    Effect.gen(function* () {
+      const workflow = yield* WorkflowService
+      const shell = yield* ShellService
+      const workspaceLogger = logger.child({ component: 'workspace-service' })
+
+      const runHook = (
+        hookName: 'after_create' | 'before_run' | 'after_run' | 'before_remove',
+        script: string,
+        workspacePath: string,
+        timeoutMs: number,
+        failOnError: boolean,
+      ) =>
+        shell.run(script, { cwd: workspacePath, timeoutMs, hookName }).pipe(
+          Effect.tap(() =>
+            Effect.sync(() => {
+              workspaceLogger.log('info', 'workspace_hook_completed', {
+                hook: hookName,
+                workspace_path: workspacePath,
+              })
+            }),
+          ),
+          Effect.catchAll((error) => {
+            const logLevel = failOnError ? 'error' : 'warn'
+            const logEffect = Effect.sync(() => {
+              workspaceLogger.log(logLevel, 'workspace_hook_failed', {
+                hook: hookName,
+                workspace_path: workspacePath,
+                ...toLogError(error),
+                ...(error.causeValue && typeof error.causeValue === 'object'
+                  ? (error.causeValue as Record<string, unknown>)
+                  : {}),
+              })
+            })
+
+            return failOnError ? logEffect.pipe(Effect.zipRight(Effect.fail(error))) : logEffect.pipe(Effect.asVoid)
+          }),
+        )
+
+      const service: WorkspaceServiceDefinition = {
+        createForIssue: (identifier) =>
+          Effect.gen(function* () {
+            const config = yield* workflow.config
+            const workspaceKey = sanitizeWorkspaceKey(identifier)
+            const root = toAbsolutePath(config.workspaceRoot)
+            const workspacePath = toAbsolutePath(path.join(root, workspaceKey))
+
+            if (!ensurePathInsideRoot(root, workspacePath)) {
+              return yield* Effect.fail(
+                new WorkspaceError('invalid_workspace_cwd', `workspace path ${workspacePath} escapes root ${root}`),
+              )
+            }
+
+            yield* Effect.tryPromise({
+              try: () => mkdir(root, { recursive: true }),
+              catch: (error) =>
+                new WorkspaceError('workspace_create_failed', `failed to ensure workspace root ${root}`, error),
+            })
+
+            let createdNow = false
+
+            const metadataResult = yield* Effect.either(
+              Effect.tryPromise({
+                try: () => stat(workspacePath),
+                catch: (error) =>
+                  new WorkspaceError('workspace_create_failed', `failed to inspect workspace ${workspacePath}`, error),
+              }),
+            )
+
+            if (metadataResult._tag === 'Left') {
+              const nodeError = metadataResult.left.causeValue as NodeJS.ErrnoException | undefined
+              if (nodeError?.code && nodeError.code !== 'ENOENT') {
+                return yield* Effect.fail(metadataResult.left)
+              }
+
+              yield* Effect.tryPromise({
+                try: () => mkdir(workspacePath, { recursive: true }),
+                catch: (error) =>
+                  new WorkspaceError('workspace_create_failed', `failed to create workspace ${workspacePath}`, error),
+              })
+              createdNow = true
+            } else if (!metadataResult.right.isDirectory()) {
+              return yield* Effect.fail(
+                new WorkspaceError(
+                  'workspace_path_not_directory',
+                  `workspace path ${workspacePath} is not a directory`,
+                ),
+              )
+            }
+
+            yield* cleanupEphemeralArtifacts(workspacePath)
+
+            if (createdNow && config.hooks.afterCreate) {
+              yield* runHook('after_create', config.hooks.afterCreate, workspacePath, config.hooks.timeoutMs, true)
+            }
+
+            return {
+              path: workspacePath,
+              workspaceKey,
+              createdNow,
+            }
+          }),
+        runBeforeRun: (workspacePath) =>
+          workflow.config.pipe(
+            Effect.flatMap((config) =>
+              config.hooks.beforeRun
+                ? runHook('before_run', config.hooks.beforeRun, workspacePath, config.hooks.timeoutMs, true)
+                : Effect.void,
+            ),
+          ),
+        runAfterRun: (workspacePath) =>
+          workflow.config.pipe(
+            Effect.flatMap((config) =>
+              config.hooks.afterRun
+                ? runHook('after_run', config.hooks.afterRun, workspacePath, config.hooks.timeoutMs, false)
+                : Effect.void,
+            ),
+          ),
+        removeWorkspace: (identifier) =>
+          Effect.gen(function* () {
+            const config = yield* workflow.config
+            const workspaceKey = sanitizeWorkspaceKey(identifier)
+            const root = toAbsolutePath(config.workspaceRoot)
+            const workspacePath = toAbsolutePath(path.join(root, workspaceKey))
+
+            if (!ensurePathInsideRoot(root, workspacePath)) {
+              return yield* Effect.fail(
+                new WorkspaceError('invalid_workspace_cwd', `workspace path ${workspacePath} escapes root ${root}`),
+              )
+            }
+
+            const metadataResult = yield* Effect.either(
+              Effect.tryPromise({
+                try: () => stat(workspacePath),
+                catch: (error) =>
+                  new WorkspaceError('workspace_create_failed', `failed to inspect workspace ${workspacePath}`, error),
+              }),
+            )
+
+            if (metadataResult._tag === 'Left') {
+              const nodeError = metadataResult.left.causeValue as NodeJS.ErrnoException | undefined
+              if (nodeError?.code === 'ENOENT') {
+                return
+              }
+              return yield* Effect.fail(metadataResult.left)
+            }
+
+            if (!metadataResult.right.isDirectory()) {
+              return yield* Effect.fail(
+                new WorkspaceError(
+                  'workspace_path_not_directory',
+                  `workspace path ${workspacePath} is not a directory`,
+                ),
+              )
+            }
+
+            if (config.hooks.beforeRemove) {
+              yield* runHook('before_remove', config.hooks.beforeRemove, workspacePath, config.hooks.timeoutMs, false)
+            }
+
+            yield* Effect.tryPromise({
+              try: () => rm(workspacePath, { recursive: true, force: true }),
+              catch: (error) =>
+                new WorkspaceError('workspace_create_failed', `failed to remove workspace ${workspacePath}`, error),
+            })
+
+            yield* Effect.sync(() => {
+              workspaceLogger.log('info', 'workspace_removed', { workspace_path: workspacePath })
+            })
+          }),
+      }
+
+      return service
+    }),
+  )


### PR DESCRIPTION
## Summary

- refactor Symphony into an Effect-first runtime with tagged services, typed error ADTs, scoped resource lifecycles, and queue-backed orchestration state
- harden workflow, Linear, HTTP, and Codex protocol boundaries with schema-based decoding while preserving the existing CLI, `WORKFLOW.md`, and API contracts
- roll the Argo Symphony app forward to image `registry.ide-newton.ts.net/lab/symphony:a109b9321-effect-20260313135159@sha256:0f2e32cd4fde838d09aacbccd83b12609e4040e9ad8bd71c69c4c069f0aeb7b8`
- extend the `agents-ci` local Jangar image build timeout from 18m to 30m so the required integration gate does not kill a healthy ARC arm64 build mid-flight

## Related Issues

None

## Testing

- `bun run --cwd services/symphony tsc`
- `bun run --cwd services/symphony test`
- `bun run --cwd services/symphony lint:oxlint:type`
- `bunx oxfmt --check services/symphony packages/scripts/src/symphony argocd/applications/symphony`
- `scripts/kubeconform.sh argocd/applications/symphony`
- GitHub Actions rerun for `agents-ci/integration` after the workflow timeout change

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
