### PR TITLE
fix(torghut): align warm-lane runtime verification topics

### DIFF
--- a/services/torghut/scripts/run_simulation_analysis.py
+++ b/services/torghut/scripts/run_simulation_analysis.py
@@ -170,7 +170,7 @@ def _resources_from_args(args: argparse.Namespace) -> _Resources:
         clickhouse_price_table=price_table,
         clickhouse_db=clickhouse_db,
         simulation_topic_by_role={
-            'order_updates': default_order_updates_topic if warm_lane_enabled else f'{default_order_updates_topic}.{run_token}',
+            'order_updates': f'{default_order_updates_topic}.{run_token}',
         },
         order_feed_group_id='torghut-order-feed-sim-default' if warm_lane_enabled else f'torghut-order-feed-sim-{run_token}',
         ta_group_id='torghut-ta-sim-default' if warm_lane_enabled else f'torghut-ta-sim-{run_token}',

--- a/services/torghut/tests/test_run_simulation_analysis.py
+++ b/services/torghut/tests/test_run_simulation_analysis.py
@@ -29,6 +29,27 @@ class TestRunSimulationAnalysis(TestCase):
         )
         self.assertEqual(resources.clickhouse_db, 'torghut_sim_2026_03_06_open_30m')
 
+    def test_runtime_ready_warm_lane_resources_keep_run_scoped_order_updates_topic(self) -> None:
+        class _Args:
+            run_id = 'sim-platform-proof-compact-20260313-r23'
+            dataset_id = 'torghut-tsmom-compact-20260311'
+            namespace = 'torghut'
+            ta_configmap = 'torghut-ta-sim-config'
+            ta_deployment = 'torghut-ta-sim'
+            torghut_service = 'torghut-sim'
+            forecast_service = 'torghut-forecast-sim'
+            signal_table = 'torghut_sim_default.ta_signals'
+            price_table = 'torghut_sim_default.ta_microbars'
+
+        resources = _resources_from_args(_Args())
+        self.assertTrue(resources.warm_lane_enabled)
+        self.assertEqual(resources.order_feed_group_id, 'torghut-order-feed-sim-default')
+        self.assertEqual(resources.ta_group_id, 'torghut-ta-sim-default')
+        self.assertEqual(
+            resources.simulation_topic_by_role['order_updates'],
+            'torghut.sim.trade-updates.v1.sim_platform_proof_compact_20260313_r23',
+        )
+
     def test_runtime_ready_resources_derive_clickhouse_db_from_price_table_when_signal_table_missing(self) -> None:
         class _Args:
             run_id = 'sim-2026-03-06-open-30m-r3'


### PR DESCRIPTION
## Summary

- align warm-lane runtime verification with the deployed per-run simulated trade-updates topic
- unblock `runtime-ready` AnalysisRuns that were falsely hanging before replay on warm-lane compact proofs
- add a regression test covering warm-lane `run_simulation_analysis.py` topic derivation

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_run_simulation_analysis.py -q`
- `cd services/torghut && uv run --frozen ruff check scripts/run_simulation_analysis.py tests/test_run_simulation_analysis.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen python scripts/run_simulation_analysis.py runtime-ready --run-id sim-platform-proof-compact-20260313-r23 --dataset-id torghut-tsmom-compact-20260311 --namespace torghut --torghut-service torghut-sim --ta-deployment torghut-ta-sim --forecast-service torghut-forecast-sim --window-start 2026-03-11T13:25:00+00:00 --window-end 2026-03-11T13:35:00+00:00 --signal-table torghut_sim_default.ta_signals --price-table torghut_sim_default.ta_microbars --runtime-timeout-seconds 5 --runtime-poll-seconds 1 --json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
