### PR TITLE
chore(jangar): promote image 97432e76

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 71749d29
-  digest: sha256:8347590a2af61850cac92cb8e37273c2796f888d5b5224eff6ccea9ae22e8d7c
+  tag: "97432e76"
+  digest: sha256:f072dbcbde6fada7b45c9db7e9a18b74f4153f0e24425f96722086dce286feb7
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 71749d29
-    digest: sha256:91c6a929a87e50b4c71cc5fa18ced3785689c4aedee4dd4b1f64e6b72d724659
+    tag: "97432e76"
+    digest: sha256:2c1c8800d607aee06a1f91f65d121b90105d83fd48ddc04f4683d0c618eba74a
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 71749d29
-    digest: sha256:8347590a2af61850cac92cb8e37273c2796f888d5b5224eff6ccea9ae22e8d7c
+    tag: "97432e76"
+    digest: sha256:f072dbcbde6fada7b45c9db7e9a18b74f4153f0e24425f96722086dce286feb7
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-13T17:42:40Z"
+    deploy.knative.dev/rollout: "2026-03-13T21:16:23Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-13T17:42:40Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-13T21:16:23Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -62,5 +62,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "71749d29"
-    digest: sha256:8347590a2af61850cac92cb8e37273c2796f888d5b5224eff6ccea9ae22e8d7c
+    newTag: "97432e76"
+    digest: sha256:f072dbcbde6fada7b45c9db7e9a18b74f4153f0e24425f96722086dce286feb7


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `97432e76396566d523ae7edda6bbdcb8e88e03a0`
- Image tag: `97432e76`
- Image digest: `sha256:f072dbcbde6fada7b45c9db7e9a18b74f4153f0e24425f96722086dce286feb7`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`