### PR TITLE
chore(jangar): promote image 547ceb69

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: "97432e76"
-  digest: sha256:f072dbcbde6fada7b45c9db7e9a18b74f4153f0e24425f96722086dce286feb7
+  tag: 547ceb69
+  digest: sha256:8373201f320799cfdafd8f994c6911b937431ef2e540f63805bc03722a6af58a
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: "97432e76"
-    digest: sha256:2c1c8800d607aee06a1f91f65d121b90105d83fd48ddc04f4683d0c618eba74a
+    tag: 547ceb69
+    digest: sha256:5bf004d5c112e0ebb30da35ea000c37ac6cb638bc90d5378aab51836ebb70530
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: "97432e76"
-    digest: sha256:f072dbcbde6fada7b45c9db7e9a18b74f4153f0e24425f96722086dce286feb7
+    tag: 547ceb69
+    digest: sha256:8373201f320799cfdafd8f994c6911b937431ef2e540f63805bc03722a6af58a
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-13T21:16:23Z"
+    deploy.knative.dev/rollout: "2026-03-13T21:18:19Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-13T21:16:23Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-13T21:18:19Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -62,5 +62,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "97432e76"
-    digest: sha256:f072dbcbde6fada7b45c9db7e9a18b74f4153f0e24425f96722086dce286feb7
+    newTag: "547ceb69"
+    digest: sha256:8373201f320799cfdafd8f994c6911b937431ef2e540f63805bc03722a6af58a


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `547ceb69a6752304446f433873531b9056c2102b`
- Image tag: `547ceb69`
- Image digest: `sha256:8373201f320799cfdafd8f994c6911b937431ef2e540f63805bc03722a6af58a`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`