### PR TITLE
fix(headlamp): stabilize oidc websocket access

### DIFF
--- a/argocd/applications/headlamp/headlamp-auth-bridge-configmap.yaml
+++ b/argocd/applications/headlamp/headlamp-auth-bridge-configmap.yaml
@@ -117,50 +117,381 @@ data:
       </body>
     </html>
   server.py: |
+    import base64
+    import hashlib
+    import http.client
+    import os
+    import socket
+    import ssl
+    import struct
+    import threading
+    from http.cookies import SimpleCookie
     from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
     from pathlib import Path
-    from urllib.parse import urlparse
+    from urllib.parse import parse_qs, urlparse
 
     AUTH_HTML = Path('/app/auth.html').read_bytes()
+    HEADLAMP_UPSTREAM_HOST = os.environ.get('HEADLAMP_UPSTREAM_HOST', 'headlamp')
+    HEADLAMP_UPSTREAM_PORT = int(os.environ.get('HEADLAMP_UPSTREAM_PORT', '80'))
+    HEADLAMP_WATCH_CLUSTER_NAME = os.environ.get('HEADLAMP_WATCH_CLUSTER_NAME', 'main')
+    HEADLAMP_PROXY_TIMEOUT_SECONDS = float(os.environ.get('HEADLAMP_PROXY_TIMEOUT_SECONDS', '30'))
+    HEADLAMP_WATCH_TIMEOUT_SECONDS = float(os.environ.get('HEADLAMP_WATCH_TIMEOUT_SECONDS', '3600'))
+    APISERVER_HOST = os.environ.get('KUBERNETES_SERVICE_HOST', 'kubernetes.default.svc')
+    APISERVER_PORT = int(os.environ.get('KUBERNETES_SERVICE_PORT', '443'))
+    APISERVER_CA_FILE = os.environ.get(
+      'KUBERNETES_SERVICE_CA_FILE',
+      '/var/run/secrets/kubernetes.io/serviceaccount/ca.crt',
+    )
+    HOP_BY_HOP_HEADERS = {
+      'connection',
+      'keep-alive',
+      'proxy-authenticate',
+      'proxy-authorization',
+      'te',
+      'trailer',
+      'transfer-encoding',
+      'upgrade',
+    }
+    WEBSOCKET_MAGIC = '258EAFA5-E914-47DA-95CA-C5AB0DC85B11'
+
+
+    def build_body(status, text):
+      return text.encode('utf-8')
+
+
+    def send_bytes(handler, status, body, content_type='text/plain; charset=utf-8', include_body=True):
+      handler.send_response(status)
+      handler.send_header('Content-Type', content_type)
+      handler.send_header('Cache-Control', 'no-store')
+      handler.send_header('Content-Length', str(len(body)))
+      handler.end_headers()
+      if include_body and body:
+        handler.wfile.write(body)
+
+
+    def parse_cluster_path(path):
+      parts = path.lstrip('/').split('/', 2)
+      if len(parts) < 2 or parts[0] != 'clusters':
+        return None, None
+
+      cluster = parts[1]
+      api_path = '/' + parts[2] if len(parts) == 3 else '/'
+      return cluster, api_path
+
+
+    def sanitize_cluster_name(cluster):
+      allowed = [char for char in cluster if char.isalnum() or char in '-_']
+      return ''.join(allowed)[:50]
+
+
+    def get_token_from_cookie(headers, cluster):
+      cookie_header = headers.get('Cookie')
+      if not cookie_header:
+        return None
+
+      jar = SimpleCookie()
+      try:
+        jar.load(cookie_header)
+      except Exception:
+        return None
+
+      prefix = f'headlamp-auth-{sanitize_cluster_name(cluster)}.'
+      chunks = []
+      for name, morsel in jar.items():
+        if not name.startswith(prefix):
+          continue
+
+        suffix = name[len(prefix):]
+        if suffix.isdigit():
+          chunks.append((int(suffix), morsel.value))
+
+      if not chunks:
+        return None
+
+      chunks.sort()
+      return ''.join(value for _, value in chunks)
+
+
+    def is_websocket_upgrade(headers):
+      connection = headers.get('Connection', '')
+      upgrade = headers.get('Upgrade', '')
+      return 'upgrade' in connection.lower() and upgrade.lower() == 'websocket'
+
+
+    def is_watch_request(parsed):
+      watch_values = parse_qs(parsed.query, keep_blank_values=True).get('watch', [])
+      return any(value.lower() in {'1', 'true'} for value in watch_values)
+
+
+    def choose_websocket_protocol(header_value):
+      if not header_value:
+        return None
+
+      protocols = [item.strip() for item in header_value.split(',') if item.strip()]
+      for protocol in protocols:
+        if protocol == 'base64.binary.k8s.io':
+          return protocol
+
+      for protocol in protocols:
+        if not protocol.startswith('base64url.headlamp.authorization.k8s.io.'):
+          return protocol
+
+      return None
+
+
+    def websocket_accept(key):
+      digest = hashlib.sha1((key + WEBSOCKET_MAGIC).encode('utf-8')).digest()
+      return base64.b64encode(digest).decode('utf-8')
+
+
+    def send_websocket_frame(connection, opcode, payload=b''):
+      frame = bytearray()
+      frame.append(0x80 | (opcode & 0x0F))
+
+      payload_length = len(payload)
+      if payload_length < 126:
+        frame.append(payload_length)
+      elif payload_length < 65536:
+        frame.append(126)
+        frame.extend(struct.pack('!H', payload_length))
+      else:
+        frame.append(127)
+        frame.extend(struct.pack('!Q', payload_length))
+
+      connection.sendall(frame + payload)
+
+
+    def read_request_body(handler):
+      length = int(handler.headers.get('Content-Length', '0') or '0')
+      if length <= 0:
+        return None
+      return handler.rfile.read(length)
+
+
+    def upstream_headers(handler):
+      headers = {}
+      for name, value in handler.headers.items():
+        if name.lower() in HOP_BY_HOP_HEADERS:
+          continue
+        headers[name] = value
+      return headers
+
+
+    def proxy_http_request(handler, include_body):
+      connection = http.client.HTTPConnection(
+        HEADLAMP_UPSTREAM_HOST,
+        HEADLAMP_UPSTREAM_PORT,
+        timeout=HEADLAMP_PROXY_TIMEOUT_SECONDS,
+      )
+
+      body = read_request_body(handler)
+      headers = upstream_headers(handler)
+      headers['Host'] = f'{HEADLAMP_UPSTREAM_HOST}:{HEADLAMP_UPSTREAM_PORT}'
+
+      connection.request(handler.command, handler.path, body=body, headers=headers)
+      response = connection.getresponse()
+
+      response_body = b''
+      if include_body and handler.command != 'HEAD':
+        response_body = response.read()
+
+      handler.send_response(response.status, response.reason)
+      for name, value in response.getheaders():
+        lower_name = name.lower()
+        if lower_name in HOP_BY_HOP_HEADERS or lower_name == 'content-length':
+          continue
+        handler.send_header(name, value)
+      handler.send_header('Content-Length', str(len(response_body)))
+      handler.end_headers()
+      if include_body and response_body:
+        handler.wfile.write(response_body)
+
+      connection.close()
+
+
+    def copy_bytes(source, destination):
+      try:
+        while True:
+          chunk = source.recv(65536)
+          if not chunk:
+            break
+          destination.sendall(chunk)
+      except OSError:
+        pass
+      finally:
+        try:
+          destination.shutdown(socket.SHUT_WR)
+        except OSError:
+          pass
+
+
+    def tunnel_websocket_request(handler):
+      body = read_request_body(handler)
+      upstream = socket.create_connection(
+        (HEADLAMP_UPSTREAM_HOST, HEADLAMP_UPSTREAM_PORT),
+        timeout=HEADLAMP_PROXY_TIMEOUT_SECONDS,
+      )
+
+      request_lines = [f'{handler.command} {handler.path} {handler.request_version}']
+      for name, value in handler.headers.items():
+        if name.lower() == 'host':
+          value = f'{HEADLAMP_UPSTREAM_HOST}:{HEADLAMP_UPSTREAM_PORT}'
+        request_lines.append(f'{name}: {value}')
+
+      upstream.sendall(('\r\n'.join(request_lines) + '\r\n\r\n').encode('utf-8'))
+      if body:
+        upstream.sendall(body)
+
+      handler.close_connection = True
+
+      client_to_upstream = threading.Thread(
+        target=copy_bytes,
+        args=(handler.connection, upstream),
+        daemon=True,
+      )
+      upstream_to_client = threading.Thread(
+        target=copy_bytes,
+        args=(upstream, handler.connection),
+        daemon=True,
+      )
+      client_to_upstream.start()
+      upstream_to_client.start()
+      client_to_upstream.join()
+      upstream_to_client.join()
+      upstream.close()
+
+
+    def bridge_watch_websocket(handler, parsed, cluster, api_path):
+      token = get_token_from_cookie(handler.headers, cluster)
+      if not token:
+        send_bytes(handler, 401, build_body(401, 'missing auth cookie'))
+        return
+
+      ssl_context = ssl.create_default_context(cafile=APISERVER_CA_FILE)
+      connection = http.client.HTTPSConnection(
+        APISERVER_HOST,
+        APISERVER_PORT,
+        timeout=HEADLAMP_WATCH_TIMEOUT_SECONDS,
+        context=ssl_context,
+      )
+      watch_path = api_path
+      if parsed.query:
+        watch_path = f'{watch_path}?{parsed.query}'
+
+      connection.request(
+        'GET',
+        watch_path,
+        headers={
+          'Authorization': f'Bearer {token}',
+          'Accept': 'application/json',
+        },
+      )
+      response = connection.getresponse()
+
+      if response.status != 200:
+        error_body = response.read() or build_body(response.status, response.reason)
+        send_bytes(
+          handler,
+          response.status,
+          error_body,
+          response.getheader('Content-Type', 'text/plain; charset=utf-8'),
+        )
+        connection.close()
+        return
+
+      key = handler.headers.get('Sec-WebSocket-Key')
+      if not key:
+        send_bytes(handler, 400, build_body(400, 'missing websocket key'))
+        connection.close()
+        return
+
+      handler.send_response(101, 'Switching Protocols')
+      handler.send_header('Upgrade', 'websocket')
+      handler.send_header('Connection', 'Upgrade')
+      handler.send_header('Sec-WebSocket-Accept', websocket_accept(key))
+
+      protocol = choose_websocket_protocol(handler.headers.get('Sec-WebSocket-Protocol'))
+      if protocol:
+        handler.send_header('Sec-WebSocket-Protocol', protocol)
+
+      handler.end_headers()
+      handler.close_connection = True
+
+      try:
+        while True:
+          line = response.readline()
+          if not line:
+            break
+
+          payload = line.strip()
+          if not payload:
+            continue
+
+          send_websocket_frame(handler.connection, 0x1, payload)
+      except (BrokenPipeError, ConnectionResetError, OSError, ssl.SSLError):
+        return
+      finally:
+        try:
+          send_websocket_frame(handler.connection, 0x8)
+        except OSError:
+          pass
+        connection.close()
 
 
     class Handler(BaseHTTPRequestHandler):
+      protocol_version = 'HTTP/1.1'
+
       def _handle(self, include_body):
-        path = urlparse(self.path).path
+        parsed = urlparse(self.path)
+        path = parsed.path
 
         if path == '/healthz':
           body = b'ok'
-          self.send_response(200)
-          self.send_header('Content-Type', 'text/plain; charset=utf-8')
-          self.send_header('Cache-Control', 'no-store')
-          self.send_header('Content-Length', str(len(body)))
-          self.end_headers()
-          if include_body:
-            self.wfile.write(body)
+          send_bytes(self, 200, body, include_body=include_body)
           return
 
         if path.startswith('/auth'):
-          self.send_response(200)
-          self.send_header('Content-Type', 'text/html; charset=utf-8')
-          self.send_header('Cache-Control', 'no-store')
-          self.send_header('Content-Length', str(len(AUTH_HTML)))
-          self.end_headers()
-          if include_body:
-            self.wfile.write(AUTH_HTML)
+          send_bytes(self, 200, AUTH_HTML, 'text/html; charset=utf-8', include_body)
+          return
+
+        if path.startswith('/clusters/'):
+          cluster, api_path = parse_cluster_path(path)
+          if cluster is None or api_path is None:
+            send_bytes(self, 400, build_body(400, 'invalid cluster path'), include_body=include_body)
+            return
+
+          if is_websocket_upgrade(self.headers):
+            if cluster == HEADLAMP_WATCH_CLUSTER_NAME and is_watch_request(parsed):
+              bridge_watch_websocket(self, parsed, cluster, api_path)
+            else:
+              tunnel_websocket_request(self)
+            return
+
+          proxy_http_request(self, include_body)
           return
 
         body = b'not found'
-        self.send_response(404)
-        self.send_header('Content-Type', 'text/plain; charset=utf-8')
-        self.send_header('Content-Length', str(len(body)))
-        self.end_headers()
-        if include_body:
-          self.wfile.write(body)
+        send_bytes(self, 404, body, include_body=include_body)
 
       def do_GET(self):
         self._handle(True)
 
       def do_HEAD(self):
+        self._handle(False)
+
+      def do_POST(self):
+        self._handle(True)
+
+      def do_PUT(self):
+        self._handle(True)
+
+      def do_PATCH(self):
+        self._handle(True)
+
+      def do_DELETE(self):
+        self._handle(True)
+
+      def do_OPTIONS(self):
         self._handle(False)
 
       def log_message(self, format, *args):

--- a/argocd/applications/headlamp/headlamp-auth-bridge-deployment.yaml
+++ b/argocd/applications/headlamp/headlamp-auth-bridge-deployment.yaml
@@ -30,6 +30,17 @@ spec:
           ports:
             - containerPort: 8080
               name: http
+          env:
+            - name: HEADLAMP_UPSTREAM_HOST
+              value: headlamp
+            - name: HEADLAMP_UPSTREAM_PORT
+              value: '80'
+            - name: HEADLAMP_WATCH_CLUSTER_NAME
+              value: main
+            - name: HEADLAMP_PROXY_TIMEOUT_SECONDS
+              value: '30'
+            - name: HEADLAMP_WATCH_TIMEOUT_SECONDS
+              value: '3600'
           livenessProbe:
             httpGet:
               path: /healthz
@@ -40,11 +51,11 @@ spec:
               port: http
           resources:
             requests:
-              cpu: 10m
-              memory: 24Mi
+              cpu: 25m
+              memory: 32Mi
             limits:
-              cpu: 100m
-              memory: 64Mi
+              cpu: 250m
+              memory: 128Mi
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/argocd/applications/headlamp/ingressroute-headlamp-auth-bridge-k8s-private.yaml
+++ b/argocd/applications/headlamp/ingressroute-headlamp-auth-bridge-k8s-private.yaml
@@ -9,6 +9,13 @@ spec:
   routes:
     - kind: Rule
       match: Host(`headlamp.k8s.proompteng.ai`) && PathPrefix(`/auth`)
+      priority: 20
+      services:
+        - name: headlamp-auth-bridge
+          port: 8080
+    - kind: Rule
+      match: Host(`headlamp.k8s.proompteng.ai`) && PathPrefix(`/clusters`)
+      priority: 19
       services:
         - name: headlamp-auth-bridge
           port: 8080

--- a/argocd/applications/headlamp/ingressroute-headlamp-k8s-private.yaml
+++ b/argocd/applications/headlamp/ingressroute-headlamp-k8s-private.yaml
@@ -9,6 +9,7 @@ spec:
   routes:
     - kind: Rule
       match: Host(`headlamp.k8s.proompteng.ai`)
+      priority: 1
       services:
         - name: headlamp
           port: 80

--- a/argocd/applications/headlamp/kustomization.yaml
+++ b/argocd/applications/headlamp/kustomization.yaml
@@ -33,6 +33,7 @@ patches:
                   - -oidc-client-secret=$(OIDC_CLIENT_SECRET)
                   - -oidc-idp-issuer-url=$(OIDC_ISSUER_URL)
                   - -oidc-scopes=$(OIDC_SCOPES)
+                  - -oidc-ca-file=/etc/ssl/certs/ca-certificates.crt
                   - -oidc-use-access-token=$(OIDC_USE_ACCESS_TOKEN)
   - path: patch-headlamp-tailscale-ingress-auth-bridge.yaml
 helmCharts:

--- a/argocd/applications/headlamp/patch-headlamp-tailscale-ingress-auth-bridge.yaml
+++ b/argocd/applications/headlamp/patch-headlamp-tailscale-ingress-auth-bridge.yaml
@@ -15,6 +15,13 @@ spec:
                 name: headlamp-auth-bridge
                 port:
                   number: 8080
+          - path: /clusters
+            pathType: Prefix
+            backend:
+              service:
+                name: headlamp-auth-bridge
+                port:
+                  number: 8080
           - path: /
             pathType: Prefix
             backend:

--- a/argocd/applications/headlamp/values.yaml
+++ b/argocd/applications/headlamp/values.yaml
@@ -17,7 +17,7 @@ config:
       name: headlamp-oidc
 env:
   - name: OIDC_SCOPES
-    value: 'openid profile email offline_access'
+    value: 'openid,profile,email,offline_access'
   - name: OIDC_USE_ACCESS_TOKEN
     value: 'true'
 ingress:

--- a/argocd/applications/keycloak/headlamp-client-bootstrap-job.yaml
+++ b/argocd/applications/keycloak/headlamp-client-bootstrap-job.yaml
@@ -56,6 +56,14 @@ spec:
                 sleep 5
               done
 
+              /opt/keycloak/bin/kcadm.sh update "realms/$KEYCLOAK_REALM" \
+                --config "$KCADM_CONFIG" \
+                -s "accessTokenLifespan=${KEYCLOAK_REALM_ACCESS_TOKEN_LIFESPAN_SECONDS}" \
+                -s "ssoSessionIdleTimeout=${KEYCLOAK_REALM_SSO_SESSION_IDLE_SECONDS}" \
+                -s "ssoSessionMaxLifespan=${KEYCLOAK_REALM_SSO_SESSION_MAX_SECONDS}" \
+                -s "clientSessionIdleTimeout=${KEYCLOAK_REALM_CLIENT_SESSION_IDLE_SECONDS}" \
+                -s "clientSessionMaxLifespan=${KEYCLOAK_REALM_CLIENT_SESSION_MAX_SECONDS}"
+
               cat > /tmp/headlamp-client.json <<EOF
               {
                 "clientId": "${HEADLAMP_OIDC_CLIENT_ID}",
@@ -198,6 +206,16 @@ spec:
               value: https://headlamp.k8s.proompteng.ai
             - name: HEADLAMP_PRIVATE_CALLBACK_URL
               value: https://headlamp.k8s.proompteng.ai/oidc-callback
+            - name: KEYCLOAK_REALM_ACCESS_TOKEN_LIFESPAN_SECONDS
+              value: '300'
+            - name: KEYCLOAK_REALM_SSO_SESSION_IDLE_SECONDS
+              value: '28800'
+            - name: KEYCLOAK_REALM_SSO_SESSION_MAX_SECONDS
+              value: '86400'
+            - name: KEYCLOAK_REALM_CLIENT_SESSION_IDLE_SECONDS
+              value: '28800'
+            - name: KEYCLOAK_REALM_CLIENT_SESSION_MAX_SECONDS
+              value: '86400'
             - name: KEYCLOAK_ADMIN_USERNAME
               valueFrom:
                 secretKeyRef:

--- a/docs/headlamp-setup.md
+++ b/docs/headlamp-setup.md
@@ -14,7 +14,9 @@ This runbook covers Headlamp deployment, OIDC wiring with Keycloak, control-plan
 ## Operations model
 
 - Headlamp application config is GitOps-managed from `argocd/applications/headlamp`.
-- The `/auth` popup callback is fronted by a tiny auth bridge service so successful OIDC redirects can always hand control back to the main Headlamp window.
+- The `headlamp-auth-bridge` service now fronts both `/auth` and `/clusters`.
+- `/auth` completes the popup handoff back to the main Headlamp window.
+- `/clusters` keeps ordinary cluster API requests flowing to Headlamp, but bridges watch websocket requests to plain HTTP watches against the kube-apiserver. This avoids the websocket handshake failures seen with Headlamp `0.40.1` against Kubernetes `v1.35.0`.
 - Keycloak client bootstrap for Headlamp is GitOps-managed from `argocd/applications/keycloak/headlamp-client-bootstrap-job.yaml`.
 - Kube-apiserver OIDC settings have an Ansible playbook only for `k3s` clusters: `ansible/playbooks/k3s-oidc.yml`.
 - The current `galactic` cluster is Talos-based, so the control-plane OIDC path here is Talos machine config patches, not the `k3s` Ansible playbook.
@@ -52,7 +54,7 @@ Login settings:
 OIDC values:
 
 - Issuer: `https://auth.proompteng.ai/realms/master`
-- Scopes: `openid profile email`
+- Scopes: `openid profile email offline_access`
   - For longer-lived Headlamp sessions, include `offline_access` and ensure it is assigned to the client (Default or Optional + requested).
 
 Optional (recommended) group mapper:
@@ -72,7 +74,7 @@ kubectl -n headlamp create secret generic headlamp-oidc \
   --from-literal=OIDC_CLIENT_ID=kubernetes \
   --from-literal=OIDC_CLIENT_SECRET='<client-secret>' \
   --from-literal=OIDC_ISSUER_URL='https://auth.proompteng.ai/realms/master' \
-  --from-literal=OIDC_SCOPES='openid profile email' \
+  --from-literal=OIDC_SCOPES='openid,profile,email,offline_access' \
   --dry-run=client -o yaml \
   | kubeseal --controller-name sealed-secrets \
   --controller-namespace sealed-secrets -o yaml \
@@ -105,6 +107,7 @@ Headlamp relies on refresh tokens to avoid frequent logouts. Set realm and clien
 Balanced profile (recommended for Headlamp):
 
 - Realm settings → Sessions
+  - Access Token Lifespan: 5 minutes
   - SSO Session Idle: 8 hours
   - SSO Session Max: 1 day
   - Client Session Idle: 8 hours
@@ -114,6 +117,9 @@ Balanced profile (recommended for Headlamp):
   - Offline Session Max Limited: Enabled
   - Offline Session Max: 30 days
   - Client Offline Session Max: 30 days
+
+The GitOps bootstrap job now enforces these realm session defaults for the `master` realm so Headlamp
+does not churn access tokens every 60 seconds.
 
 Also ensure the client has the `offline_access` scope assigned (Clients → <client> → Client scopes).
 Log out/in to Headlamp after changes so it receives a new refresh token.

--- a/docs/keycloak-oidc.md
+++ b/docs/keycloak-oidc.md
@@ -20,6 +20,12 @@ For Headlamp-specific wiring (OIDC secret, RBAC, control-plane OIDC args), see `
 - The `kubernetes` OIDC client used by Headlamp and the kube-apiserver is GitOps-managed by:
   - `argocd/applications/keycloak/headlamp-client-sealedsecret.yaml`
   - `argocd/applications/keycloak/headlamp-client-bootstrap-job.yaml`
+- That bootstrap job also enforces the realm session defaults Headlamp depends on:
+  - Access token lifespan `300`
+  - SSO session idle `28800`
+  - SSO session max `86400`
+  - Client session idle `28800`
+  - Client session max `86400`
 - There is no Ansible playbook in this repo for Keycloak realm or client management.
 - The only OIDC-related Ansible playbook in this repo is `ansible/playbooks/k3s-oidc.yml`, and that is for `k3s` API server flags, not for Keycloak application state.
 
@@ -72,7 +78,7 @@ Login settings (Headlamp):
 Issuer and scopes:
 
 - Issuer: Realm → **Realm settings** → **Endpoints** → **OpenID Endpoint Configuration** (`issuer`)
-- Scopes: `openid profile email`
+- Scopes: `openid profile email offline_access`
 - The kube-apiserver on `galactic` binds Kubernetes usernames from the OIDC `preferred_username` claim with the `oidc:` prefix, so RBAC subjects should look like `oidc:<preferred_username>`.
 - The GitOps bootstrap job also enforces a `kubernetes-audience` protocol mapper so access tokens
   include audience `kubernetes`, which Headlamp needs when it uses the OIDC access token for


### PR DESCRIPTION
## Summary

- route private `headlamp.k8s.proompteng.ai` `/clusters` traffic through the auth bridge and lower the default private Traefik route priority so websocket upgrades stop falling through to the raw Headlamp service
- expand the auth bridge from a callback page into a `/clusters` proxy that can tunnel normal requests and bridge watch websocket traffic, while removing the fixed OIDC callback URL so both the tailscale and k8s hosts work
- harden OIDC handling by switching Headlamp scopes to the expected comma-delimited format, passing an explicit CA bundle, and bootstrapping longer Keycloak token/session lifetimes plus the existing `kubernetes` audience mapper
- document the root cause, rollout shape, and the remaining live-validation caveat around Argo still reconciling the older `main` revision in-cluster

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/headlamp >/tmp/headlamp-render.yaml`
- `kubectl kustomize argocd/applications/keycloak >/tmp/keycloak-render.yaml`
- `bun run lint:argocd`
- Python compile and local harness validation of `argocd/applications/headlamp/headlamp-auth-bridge-configmap.yaml` against mocked Headlamp and kube-apiserver endpoints
- Browser validation with Playwright against `https://headlamp.k8s.proompteng.ai`: confirmed fresh OIDC login returns a valid `kubernetes` audience token with a 5 minute expiry, ordinary authenticated HTTP cluster requests succeed, and the remaining live websocket failure is explained by the cluster still reconciling the old bridge script from the current `main` Argo revision
- Live protocol checks with `curl` and `kubectl` to confirm the current cluster is still on the old bridge ConfigMap and that websocket upgrades are falling through to the default Headlamp route without the merged GitOps changes

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
