### PR TITLE
chore(jangar): promote image 311747f9

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 547ceb69
-  digest: sha256:8373201f320799cfdafd8f994c6911b937431ef2e540f63805bc03722a6af58a
+  tag: 311747f9
+  digest: sha256:6306a53e3b56e432dd0f961851f17ec328e3a7a64069b264a765f850a6cf65fc
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 547ceb69
-    digest: sha256:5bf004d5c112e0ebb30da35ea000c37ac6cb638bc90d5378aab51836ebb70530
+    tag: 311747f9
+    digest: sha256:70ba1283225018d159600b84d88dceb7a1ccb1aa2ff36032f8627d0cb2ecc471
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 547ceb69
-    digest: sha256:8373201f320799cfdafd8f994c6911b937431ef2e540f63805bc03722a6af58a
+    tag: 311747f9
+    digest: sha256:6306a53e3b56e432dd0f961851f17ec328e3a7a64069b264a765f850a6cf65fc
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-13T21:18:19Z"
+    deploy.knative.dev/rollout: "2026-03-14T08:56:35Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-13T21:18:19Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-14T08:56:35Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -62,5 +62,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "547ceb69"
-    digest: sha256:8373201f320799cfdafd8f994c6911b937431ef2e540f63805bc03722a6af58a
+    newTag: "311747f9"
+    digest: sha256:6306a53e3b56e432dd0f961851f17ec328e3a7a64069b264a765f850a6cf65fc


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `311747f94f04e82ef75ef68a9c1da03f9423fabe`
- Image tag: `311747f9`
- Image digest: `sha256:6306a53e3b56e432dd0f961851f17ec328e3a7a64069b264a765f850a6cf65fc`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`