### PR TITLE
fix(headlamp): tunnel auth bridge websockets upstream

### DIFF
--- a/argocd/applications/headlamp/headlamp-auth-bridge-configmap.yaml
+++ b/argocd/applications/headlamp/headlamp-auth-bridge-configmap.yaml
@@ -117,31 +117,18 @@ data:
       </body>
     </html>
   server.py: |
-    import base64
-    import hashlib
     import http.client
     import os
     import socket
-    import ssl
-    import struct
     import threading
-    from http.cookies import SimpleCookie
     from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
     from pathlib import Path
-    from urllib.parse import parse_qs, urlparse
+    from urllib.parse import urlparse
 
     AUTH_HTML = Path('/app/auth.html').read_bytes()
     HEADLAMP_UPSTREAM_HOST = os.environ.get('HEADLAMP_UPSTREAM_HOST', 'headlamp')
     HEADLAMP_UPSTREAM_PORT = int(os.environ.get('HEADLAMP_UPSTREAM_PORT', '80'))
-    HEADLAMP_WATCH_CLUSTER_NAME = os.environ.get('HEADLAMP_WATCH_CLUSTER_NAME', 'main')
     HEADLAMP_PROXY_TIMEOUT_SECONDS = float(os.environ.get('HEADLAMP_PROXY_TIMEOUT_SECONDS', '30'))
-    HEADLAMP_WATCH_TIMEOUT_SECONDS = float(os.environ.get('HEADLAMP_WATCH_TIMEOUT_SECONDS', '3600'))
-    APISERVER_HOST = os.environ.get('KUBERNETES_SERVICE_HOST', 'kubernetes.default.svc')
-    APISERVER_PORT = int(os.environ.get('KUBERNETES_SERVICE_PORT', '443'))
-    APISERVER_CA_FILE = os.environ.get(
-      'KUBERNETES_SERVICE_CA_FILE',
-      '/var/run/secrets/kubernetes.io/serviceaccount/ca.crt',
-    )
     HOP_BY_HOP_HEADERS = {
       'connection',
       'keep-alive',
@@ -152,7 +139,6 @@ data:
       'transfer-encoding',
       'upgrade',
     }
-    WEBSOCKET_MAGIC = '258EAFA5-E914-47DA-95CA-C5AB0DC85B11'
 
 
     def build_body(status, text):
@@ -169,96 +155,10 @@ data:
         handler.wfile.write(body)
 
 
-    def parse_cluster_path(path):
-      parts = path.lstrip('/').split('/', 2)
-      if len(parts) < 2 or parts[0] != 'clusters':
-        return None, None
-
-      cluster = parts[1]
-      api_path = '/' + parts[2] if len(parts) == 3 else '/'
-      return cluster, api_path
-
-
-    def sanitize_cluster_name(cluster):
-      allowed = [char for char in cluster if char.isalnum() or char in '-_']
-      return ''.join(allowed)[:50]
-
-
-    def get_token_from_cookie(headers, cluster):
-      cookie_header = headers.get('Cookie')
-      if not cookie_header:
-        return None
-
-      jar = SimpleCookie()
-      try:
-        jar.load(cookie_header)
-      except Exception:
-        return None
-
-      prefix = f'headlamp-auth-{sanitize_cluster_name(cluster)}.'
-      chunks = []
-      for name, morsel in jar.items():
-        if not name.startswith(prefix):
-          continue
-
-        suffix = name[len(prefix):]
-        if suffix.isdigit():
-          chunks.append((int(suffix), morsel.value))
-
-      if not chunks:
-        return None
-
-      chunks.sort()
-      return ''.join(value for _, value in chunks)
-
-
     def is_websocket_upgrade(headers):
       connection = headers.get('Connection', '')
       upgrade = headers.get('Upgrade', '')
       return 'upgrade' in connection.lower() and upgrade.lower() == 'websocket'
-
-
-    def is_watch_request(parsed):
-      watch_values = parse_qs(parsed.query, keep_blank_values=True).get('watch', [])
-      return any(value.lower() in {'1', 'true'} for value in watch_values)
-
-
-    def choose_websocket_protocol(header_value):
-      if not header_value:
-        return None
-
-      protocols = [item.strip() for item in header_value.split(',') if item.strip()]
-      for protocol in protocols:
-        if protocol == 'base64.binary.k8s.io':
-          return protocol
-
-      for protocol in protocols:
-        if not protocol.startswith('base64url.headlamp.authorization.k8s.io.'):
-          return protocol
-
-      return None
-
-
-    def websocket_accept(key):
-      digest = hashlib.sha1((key + WEBSOCKET_MAGIC).encode('utf-8')).digest()
-      return base64.b64encode(digest).decode('utf-8')
-
-
-    def send_websocket_frame(connection, opcode, payload=b''):
-      frame = bytearray()
-      frame.append(0x80 | (opcode & 0x0F))
-
-      payload_length = len(payload)
-      if payload_length < 126:
-        frame.append(payload_length)
-      elif payload_length < 65536:
-        frame.append(126)
-        frame.extend(struct.pack('!H', payload_length))
-      else:
-        frame.append(127)
-        frame.extend(struct.pack('!Q', payload_length))
-
-      connection.sendall(frame + payload)
 
 
     def read_request_body(handler):
@@ -361,83 +261,6 @@ data:
       upstream.close()
 
 
-    def bridge_watch_websocket(handler, parsed, cluster, api_path):
-      token = get_token_from_cookie(handler.headers, cluster)
-      if not token:
-        send_bytes(handler, 401, build_body(401, 'missing auth cookie'))
-        return
-
-      ssl_context = ssl.create_default_context(cafile=APISERVER_CA_FILE)
-      connection = http.client.HTTPSConnection(
-        APISERVER_HOST,
-        APISERVER_PORT,
-        timeout=HEADLAMP_WATCH_TIMEOUT_SECONDS,
-        context=ssl_context,
-      )
-      watch_path = api_path
-      if parsed.query:
-        watch_path = f'{watch_path}?{parsed.query}'
-
-      connection.request(
-        'GET',
-        watch_path,
-        headers={
-          'Authorization': f'Bearer {token}',
-          'Accept': 'application/json',
-        },
-      )
-      response = connection.getresponse()
-
-      if response.status != 200:
-        error_body = response.read() or build_body(response.status, response.reason)
-        send_bytes(
-          handler,
-          response.status,
-          error_body,
-          response.getheader('Content-Type', 'text/plain; charset=utf-8'),
-        )
-        connection.close()
-        return
-
-      key = handler.headers.get('Sec-WebSocket-Key')
-      if not key:
-        send_bytes(handler, 400, build_body(400, 'missing websocket key'))
-        connection.close()
-        return
-
-      handler.send_response(101, 'Switching Protocols')
-      handler.send_header('Upgrade', 'websocket')
-      handler.send_header('Connection', 'Upgrade')
-      handler.send_header('Sec-WebSocket-Accept', websocket_accept(key))
-
-      protocol = choose_websocket_protocol(handler.headers.get('Sec-WebSocket-Protocol'))
-      if protocol:
-        handler.send_header('Sec-WebSocket-Protocol', protocol)
-
-      handler.end_headers()
-      handler.close_connection = True
-
-      try:
-        while True:
-          line = response.readline()
-          if not line:
-            break
-
-          payload = line.strip()
-          if not payload:
-            continue
-
-          send_websocket_frame(handler.connection, 0x1, payload)
-      except (BrokenPipeError, ConnectionResetError, OSError, ssl.SSLError):
-        return
-      finally:
-        try:
-          send_websocket_frame(handler.connection, 0x8)
-        except OSError:
-          pass
-        connection.close()
-
-
     class Handler(BaseHTTPRequestHandler):
       protocol_version = 'HTTP/1.1'
 
@@ -455,16 +278,8 @@ data:
           return
 
         if path.startswith('/clusters/'):
-          cluster, api_path = parse_cluster_path(path)
-          if cluster is None or api_path is None:
-            send_bytes(self, 400, build_body(400, 'invalid cluster path'), include_body=include_body)
-            return
-
           if is_websocket_upgrade(self.headers):
-            if cluster == HEADLAMP_WATCH_CLUSTER_NAME and is_watch_request(parsed):
-              bridge_watch_websocket(self, parsed, cluster, api_path)
-            else:
-              tunnel_websocket_request(self)
+            tunnel_websocket_request(self)
             return
 
           proxy_http_request(self, include_body)

--- a/argocd/applications/headlamp/headlamp-auth-bridge-deployment.yaml
+++ b/argocd/applications/headlamp/headlamp-auth-bridge-deployment.yaml
@@ -35,12 +35,8 @@ spec:
               value: headlamp
             - name: HEADLAMP_UPSTREAM_PORT
               value: '80'
-            - name: HEADLAMP_WATCH_CLUSTER_NAME
-              value: main
             - name: HEADLAMP_PROXY_TIMEOUT_SECONDS
               value: '30'
-            - name: HEADLAMP_WATCH_TIMEOUT_SECONDS
-              value: '3600'
           livenessProbe:
             httpGet:
               path: /healthz


### PR DESCRIPTION
## Summary

- remove the custom kube-apiserver watch websocket bridge from the Headlamp auth bridge
- tunnel `/clusters` websocket upgrades upstream to Headlamp so its multiplexer handles auth and subprotocols correctly
- drop the now-unused watch bridge environment variables from the auth bridge deployment

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/headlamp`
- `bun run lint:argocd`
- Signed into `https://headlamp.k8s.proompteng.ai` and verified `https://headlamp.k8s.proompteng.ai/c/main/workloads` loads real data after the change
- Verified authenticated websocket opens in a live browser for `/clusters/main/api/v1/pods?watch=1`, `/clusters/main/api/v1/nodes?watch=1`, `/clusters/main/api/v1/namespaces?watch=1`, and `/clusters/main/apis/batch/v1/jobs?watch=1`
- Applied the same manifests live in-cluster and verified the `headlamp-auth-bridge` and `headlamp` deployments rolled out successfully

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
