### PR TITLE
fix(torghut): harden broker readiness and warm-lane proofs

### DIFF
--- a/services/jangar/src/server/__tests__/control-plane-watch-reliability.test.ts
+++ b/services/jangar/src/server/__tests__/control-plane-watch-reliability.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import {
   clearWatchReliabilityState,
@@ -8,73 +8,60 @@ import {
   recordWatchReliabilityRestart,
 } from '~/server/control-plane-watch-reliability'
 
-const withEnv = <T>(updates: Record<string, string | undefined>, fn: () => T): T => {
-  const backup = { ...process.env }
-  Object.entries(updates).forEach(([key, value]) => {
-    if (value == null) {
-      delete process.env[key]
-    } else {
-      process.env[key] = value
-    }
-  })
-  try {
-    return fn()
-  } finally {
-    process.env = backup
-  }
-}
-
 describe('control-plane watch reliability', () => {
-  beforeEach(() => {
-    clearWatchReliabilityState()
-    vi.useFakeTimers()
-    vi.setSystemTime(new Date('2026-01-20T00:00:00Z'))
-  })
-
   afterEach(() => {
-    vi.useRealTimers()
+    clearWatchReliabilityState()
+    vi.unstubAllEnvs()
   })
 
-  it('returns degraded state when errors occur in the configured window', () => {
-    recordWatchReliabilityEvent({ resource: 'AgentRun', namespace: 'agents' })
-    recordWatchReliabilityEvent({ resource: 'AgentRun', namespace: 'agents' })
-    recordWatchReliabilityError({ resource: 'Agent', namespace: 'agents' })
-
-    const summary = getWatchReliabilitySummary()
-    expect(summary.status).toBe('degraded')
-    expect(summary.total_events).toBe(2)
-    expect(summary.total_errors).toBe(1)
-    expect(summary.total_restarts).toBe(0)
-    expect(summary.streams).toHaveLength(2)
-    expect(summary.streams[0]).toMatchObject({ resource: 'Agent', namespace: 'agents', errors: 1, events: 0 })
-    expect(summary.streams[1]).toMatchObject({ resource: 'AgentRun', namespace: 'agents', events: 2, errors: 0 })
-  })
-
-  it('returns unknown when no stream activity exists in the window', () => {
-    const summary = getWatchReliabilitySummary()
-    expect(summary.status).toBe('unknown')
-    expect(summary.total_events).toBe(0)
-    expect(summary.total_errors).toBe(0)
-    expect(summary.total_restarts).toBe(0)
-    expect(summary.streams).toHaveLength(0)
-  })
-
-  it('expires observations outside the configured window', () => {
-    withEnv({ JANGAR_CONTROL_PLANE_WATCH_HEALTH_WINDOW_MINUTES: '5' }, () => {
-      recordWatchReliabilityError({ resource: 'Agent', namespace: 'agents' })
-      vi.advanceTimersByTime(6 * 60 * 1000)
-      const summary = getWatchReliabilitySummary()
-      expect(summary.status).toBe('unknown')
-      expect(summary.total_errors).toBe(0)
-      expect(summary.streams).toHaveLength(0)
+  it('keeps a single restart observable without degrading status', () => {
+    recordWatchReliabilityEvent({
+      resource: 'toolruns.tools.proompteng.ai',
+      namespace: 'agents',
     })
+    recordWatchReliabilityRestart({
+      resource: 'toolruns.tools.proompteng.ai',
+      namespace: 'agents',
+    })
+
+    const summary = getWatchReliabilitySummary()
+
+    expect(summary.status).toBe('healthy')
+    expect(summary.observed_streams).toBe(1)
+    expect(summary.total_restarts).toBe(1)
+    expect(summary.total_errors).toBe(0)
   })
 
-  it('includes restarts in status and degraded detection', () => {
-    recordWatchReliabilityRestart({ resource: 'Workflow', namespace: 'agents' })
+  it('degrades once restarts cross the configured threshold', () => {
+    vi.stubEnv('JANGAR_CONTROL_PLANE_WATCH_HEALTH_RESTART_DEGRADE_THRESHOLD', '2')
+    recordWatchReliabilityRestart({
+      resource: 'toolruns.tools.proompteng.ai',
+      namespace: 'agents',
+    })
+    recordWatchReliabilityRestart({
+      resource: 'toolruns.tools.proompteng.ai',
+      namespace: 'agents',
+    })
+
     const summary = getWatchReliabilitySummary()
+
     expect(summary.status).toBe('degraded')
-    expect(summary.total_restarts).toBe(1)
-    expect(summary.streams[0]).toMatchObject({ resource: 'Workflow', namespace: 'agents', restarts: 1 })
+    expect(summary.total_restarts).toBe(2)
+  })
+
+  it('degrades immediately when watch errors are observed', () => {
+    recordWatchReliabilityEvent({
+      resource: 'toolruns.tools.proompteng.ai',
+      namespace: 'agents',
+    })
+    recordWatchReliabilityError({
+      resource: 'toolruns.tools.proompteng.ai',
+      namespace: 'agents',
+    })
+
+    const summary = getWatchReliabilitySummary()
+
+    expect(summary.status).toBe('degraded')
+    expect(summary.total_errors).toBe(1)
   })
 })

--- a/services/jangar/src/server/control-plane-watch-reliability.ts
+++ b/services/jangar/src/server/control-plane-watch-reliability.ts
@@ -30,6 +30,7 @@ type WatchStreamState = {
 
 const DEFAULT_WINDOW_MINUTES = 15
 const DEFAULT_STREAM_LIMIT = 20
+const DEFAULT_RESTART_DEGRADE_THRESHOLD = 2
 const MAX_RECORDED_STREAMS = 200
 const TOP_STREAM_LIMIT = 10
 const MINUTE_MS = 60_000
@@ -51,6 +52,13 @@ const resolveStreamLimit = () => {
   const parsed = Number(raw)
   if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_STREAM_LIMIT
   return Math.min(Math.max(Math.floor(parsed), 1), MAX_RECORDED_STREAMS)
+}
+
+const resolveRestartDegradeThreshold = () => {
+  const raw = process.env.JANGAR_CONTROL_PLANE_WATCH_HEALTH_RESTART_DEGRADE_THRESHOLD?.trim()
+  const parsed = Number(raw)
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_RESTART_DEGRADE_THRESHOLD
+  return Math.max(1, Math.floor(parsed))
 }
 
 const windowStartMs = (now: number, windowMinutes: number) => now - windowMinutes * MINUTE_MS
@@ -161,8 +169,14 @@ export const getWatchReliabilitySummary = (): ControlPlaneWatchReliabilitySummar
     return b.events - a.events
   })
   const topStreams = observedStreams.slice(0, Math.min(streamLimit, TOP_STREAM_LIMIT))
+  const restartDegradeThreshold = resolveRestartDegradeThreshold()
 
-  const status = totalErrors > 0 || totalRestarts > 0 ? 'degraded' : observedStreams.length > 0 ? 'healthy' : 'unknown'
+  const status =
+    totalErrors > 0 || totalRestarts >= restartDegradeThreshold
+      ? 'degraded'
+      : observedStreams.length > 0
+        ? 'healthy'
+        : 'unknown'
 
   return {
     status,

--- a/services/torghut/app/alpaca_client.py
+++ b/services/torghut/app/alpaca_client.py
@@ -62,19 +62,21 @@ class TorghutAlpacaClient:
         base_url: Optional[str] = None,
         trading_client: Optional[TradingClient] = None,
         data_client: Optional[StockHistoricalDataClient] = None,
+        paper: Optional[bool] = None,
     ) -> None:
         key = api_key or settings.apca_api_key_id
         secret = secret_key or settings.apca_api_secret_key
         base = _normalize_alpaca_base_url(base_url or settings.apca_api_base_url)
         data_base = _normalize_alpaca_base_url(settings.apca_data_api_base_url)
 
-        is_live = settings.trading_mode == "live"
+        use_paper = paper if paper is not None else settings.trading_mode != "live"
+        self.endpoint_class = "paper" if use_paper else "live"
 
         # Default to paper trading; override URL if provided.
         raw_trading_client = trading_client or TradingClient(
             api_key=key,
             secret_key=secret,
-            paper=not is_live,
+            paper=use_paper,
             url_override=base,
         )
         self._trading = raw_trading_client
@@ -85,7 +87,7 @@ class TorghutAlpacaClient:
             api_key=key,
             secret_key=secret,
             url_override=data_base,
-            sandbox=not is_live,
+            sandbox=use_paper,
         )
 
     # ------------------- Trading helpers -------------------

--- a/services/torghut/app/config.py
+++ b/services/torghut/app/config.py
@@ -1508,6 +1508,37 @@ class Settings(BaseSettings):
             "on /readyz requests before a hard refresh is forced."
         ),
     )
+    trading_alpaca_healthcheck_timeout_seconds: float = Field(
+        default=2.0,
+        alias="TRADING_ALPACA_HEALTHCHECK_TIMEOUT_SECONDS",
+        description=(
+            "Timeout in seconds for a single Alpaca account probe used by readiness "
+            "checks."
+        ),
+    )
+    trading_alpaca_healthcheck_retries: int = Field(
+        default=2,
+        alias="TRADING_ALPACA_HEALTHCHECK_RETRIES",
+        description=(
+            "Number of Alpaca account-probe attempts before readiness marks the "
+            "broker unavailable."
+        ),
+    )
+    trading_alpaca_healthcheck_backoff_seconds: float = Field(
+        default=0.25,
+        alias="TRADING_ALPACA_HEALTHCHECK_BACKOFF_SECONDS",
+        description=(
+            "Base backoff in seconds between Alpaca readiness retries."
+        ),
+    )
+    trading_alpaca_healthcheck_last_good_ttl_seconds: int = Field(
+        default=90,
+        alias="TRADING_ALPACA_HEALTHCHECK_LAST_GOOD_TTL_SECONDS",
+        description=(
+            "How long readiness may trust the last successful Alpaca probe when the "
+            "broker is only slow or transiently unreachable."
+        ),
+    )
     trading_db_schema_graph_branch_tolerance: int = Field(
         default=1,
         alias="TRADING_DB_SCHEMA_GRAPH_BRANCH_TOLERANCE",

--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import os
+import time
 from collections.abc import Mapping, Sequence
 from concurrent.futures import ThreadPoolExecutor, TimeoutError
 from contextlib import asynccontextmanager
@@ -94,6 +95,8 @@ LEAN_LANE_MANAGER = LeanLaneManager()
 WHITEPAPER_WORKFLOW = WhitepaperWorkflowService()
 _TRADING_DEPENDENCY_HEALTH_CACHE_LOCK = Lock()
 _TRADING_DEPENDENCY_HEALTH_CACHE: dict[str, dict[str, object]] = {}
+_ALPACA_HEALTH_CACHE_LOCK = Lock()
+_ALPACA_HEALTH_STATE: dict[str, object] = {}
 
 
 def _extract_bearer_token(authorization_header: str | None) -> str | None:
@@ -2743,19 +2746,221 @@ def _empirical_jobs_status() -> dict[str, object]:
         }
 
 
+def _alpaca_endpoint_class(*, paper: bool | None = None) -> str:
+    use_paper = settings.trading_mode != "live" if paper is None else paper
+    return "paper" if use_paper else "live"
+
+
+def _alpaca_failure_status(detail: str) -> str:
+    message = detail.strip().lower()
+    if "keys missing" in message:
+        return "credentials_missing"
+    if any(
+        token in message
+        for token in (
+            "unauthorized",
+            "forbidden",
+            "invalid api",
+            "authentication",
+            "not authorized",
+            "insufficient scope",
+            "access key",
+            "secret key",
+            "credentials",
+        )
+    ):
+        return "credentials_invalid"
+    if any(
+        token in message
+        for token in (
+            "timeout",
+            "timed out",
+            "deadline exceeded",
+            "read timed out",
+        )
+    ):
+        return "broker_slow"
+    if any(
+        token in message
+        for token in (
+            "connection refused",
+            "connection reset",
+            "name or service not known",
+            "temporary failure in name resolution",
+            "nodename nor servname",
+            "network is unreachable",
+            "no route to host",
+            "failed to establish a new connection",
+            "max retries exceeded",
+            "dns",
+        )
+    ):
+        return "network_unreachable"
+    return "broker_error"
+
+
+def _alpaca_probe_account(
+    client: TorghutAlpacaClient,
+    *,
+    timeout_seconds: float,
+) -> dict[str, object]:
+    executor = ThreadPoolExecutor(max_workers=1)
+    future = None
+    try:
+        future = executor.submit(client.get_account)
+        account = future.result(timeout=timeout_seconds)
+    except TimeoutError:
+        if future is not None:
+            future.cancel()
+        return {
+            "ok": False,
+            "status": "broker_slow",
+            "detail": f"alpaca account probe timed out after {timeout_seconds:.2f}s",
+        }
+    except Exception as exc:  # pragma: no cover - depends on network
+        detail = str(exc).strip() or type(exc).__name__
+        return {
+            "ok": False,
+            "status": _alpaca_failure_status(detail),
+            "detail": detail,
+        }
+    finally:
+        executor.shutdown(wait=False, cancel_futures=True)
+    return {
+        "ok": True,
+        "status": "broker_ok",
+        "detail": "ok",
+        "account": account,
+    }
+
+
+def _remember_alpaca_success(
+    *,
+    account: Mapping[str, Any],
+    endpoint_class: str,
+) -> None:
+    with _ALPACA_HEALTH_CACHE_LOCK:
+        _ALPACA_HEALTH_STATE.clear()
+        _ALPACA_HEALTH_STATE.update(
+            {
+                "last_ok_at": datetime.now(timezone.utc),
+                "account_label": str(
+                    account.get("account_number")
+                    or settings.trading_account_label
+                    or ""
+                ).strip()
+                or None,
+                "account_status": str(account.get("status") or "").strip() or None,
+                "endpoint_class": endpoint_class,
+            }
+        )
+
+
+def _alpaca_cached_last_good(
+    *,
+    failure_status: str,
+    failure_detail: str,
+    endpoint_class: str,
+) -> dict[str, object] | None:
+    if failure_status not in {"broker_slow", "network_unreachable"}:
+        return None
+    ttl_seconds = max(0, settings.trading_alpaca_healthcheck_last_good_ttl_seconds)
+    if ttl_seconds <= 0:
+        return None
+    with _ALPACA_HEALTH_CACHE_LOCK:
+        last_ok_at = cast(datetime | None, _ALPACA_HEALTH_STATE.get("last_ok_at"))
+        account_label = cast(str | None, _ALPACA_HEALTH_STATE.get("account_label"))
+        account_status = cast(str | None, _ALPACA_HEALTH_STATE.get("account_status"))
+        cached_endpoint_class = cast(
+            str | None,
+            _ALPACA_HEALTH_STATE.get("endpoint_class"),
+        )
+    if last_ok_at is None:
+        return None
+    age_seconds = max(
+        0.0,
+        round((datetime.now(timezone.utc) - last_ok_at).total_seconds(), 3),
+    )
+    if age_seconds > ttl_seconds:
+        return None
+    return {
+        "ok": True,
+        "detail": (
+            f"{failure_detail}; using cached last known good Alpaca probe from "
+            f"{last_ok_at.isoformat()}"
+        ),
+        "broker_status": failure_status,
+        "endpoint_class": cached_endpoint_class or endpoint_class,
+        "cache_used": True,
+        "last_ok_at": last_ok_at.isoformat(),
+        "cache_age_seconds": age_seconds,
+        "account_label": account_label,
+        "account_status": account_status,
+    }
+
+
 def _check_alpaca() -> dict[str, object]:
     if not settings.apca_api_key_id or not settings.apca_api_secret_key:
-        return {"ok": False, "detail": "alpaca keys missing"}
+        return {
+            "ok": False,
+            "detail": "alpaca keys missing",
+            "broker_status": "credentials_missing",
+            "endpoint_class": _alpaca_endpoint_class(),
+            "cache_used": False,
+        }
     client = TorghutAlpacaClient()
-    try:
-        with ThreadPoolExecutor(max_workers=1) as executor:
-            future = executor.submit(client.get_account)
-            future.result(timeout=2)
-    except TimeoutError:
-        return {"ok": False, "detail": "alpaca timeout"}
-    except Exception as exc:  # pragma: no cover - depends on network
-        return {"ok": False, "detail": f"alpaca error: {exc}"}
-    return {"ok": True, "detail": "ok"}
+    timeout_seconds = max(0.1, settings.trading_alpaca_healthcheck_timeout_seconds)
+    retries = max(1, settings.trading_alpaca_healthcheck_retries)
+    backoff_seconds = max(0.0, settings.trading_alpaca_healthcheck_backoff_seconds)
+    endpoint_class = str(
+        getattr(client, "endpoint_class", _alpaca_endpoint_class())
+    ).strip() or _alpaca_endpoint_class()
+
+    last_failure: dict[str, object] | None = None
+    for attempt in range(retries):
+        probe = _alpaca_probe_account(client, timeout_seconds=timeout_seconds)
+        if bool(probe.get("ok")):
+            account = cast(Mapping[str, Any], probe.get("account") or {})
+            _remember_alpaca_success(
+                account=account,
+                endpoint_class=endpoint_class,
+            )
+            return {
+                "ok": True,
+                "detail": "ok",
+                "broker_status": "broker_ok",
+                "endpoint_class": endpoint_class,
+                "cache_used": False,
+                "account_label": str(
+                    account.get("account_number")
+                    or settings.trading_account_label
+                    or ""
+                ).strip()
+                or None,
+                "account_status": str(account.get("status") or "").strip() or None,
+            }
+        last_failure = probe
+        if probe.get("status") == "credentials_invalid":
+            break
+        if attempt < retries - 1 and backoff_seconds > 0:
+            time.sleep(backoff_seconds * float(attempt + 1))
+
+    failure_status = str(last_failure.get("status") if last_failure else "broker_error")
+    failure_detail = str(last_failure.get("detail") if last_failure else "alpaca probe failed")
+    cached = _alpaca_cached_last_good(
+        failure_status=failure_status,
+        failure_detail=failure_detail,
+        endpoint_class=endpoint_class,
+    )
+    if cached is not None:
+        return cached
+    return {
+        "ok": False,
+        "detail": failure_detail,
+        "broker_status": failure_status,
+        "endpoint_class": endpoint_class,
+        "cache_used": False,
+    }
 
 
 def _tca_row_payload(row: ExecutionTCAMetric | None) -> dict[str, object] | None:

--- a/services/torghut/scripts/start_historical_simulation.py
+++ b/services/torghut/scripts/start_historical_simulation.py
@@ -3259,7 +3259,36 @@ def _remove_appledouble_sidecars(directory: Path) -> None:
         candidate.unlink(missing_ok=True)
 
 
+def _supersede_stale_simulation_progress_rows(config: PostgresRuntimeConfig) -> None:
+    def _supersede() -> None:
+        with psycopg.connect(config.torghut_runtime_dsn, autocommit=True) as conn:
+            with conn.cursor() as cursor:
+                cursor.execute(
+                    """
+                    UPDATE simulation_run_progress
+                    SET status = 'superseded',
+                        terminal_state = COALESCE(terminal_state, 'superseded'),
+                        last_error_code = COALESCE(last_error_code, 'superseded_by_runtime_reset'),
+                        last_error_message = COALESCE(
+                            last_error_message,
+                            'historical simulation runtime reset superseded stale non-terminal progress rows'
+                        ),
+                        payload_json = COALESCE(payload_json, '{}'::jsonb) ||
+                          '{"superseded_reason":"runtime_reset"}'::jsonb,
+                        updated_at = NOW()
+                    WHERE terminal_state IS NULL
+                    """
+                )
+
+    _run_with_transient_postgres_retry(
+        label='supersede_stale_simulation_progress_rows',
+        operation=_supersede,
+    )
+
+
 def _reset_postgres_runtime_state(config: PostgresRuntimeConfig) -> None:
+    _supersede_stale_simulation_progress_rows(config)
+
     def _reset() -> None:
         with psycopg.connect(config.torghut_runtime_dsn, autocommit=True) as conn:
             with conn.cursor() as cursor:

--- a/services/torghut/scripts/verify_alpaca_broker.py
+++ b/services/torghut/scripts/verify_alpaca_broker.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+"""Execute a production-real Alpaca broker proof for Torghut."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping, cast
+
+from app.alpaca_client import TorghutAlpacaClient
+from app.config import settings
+from app.db import SessionLocal
+from app.snapshots import snapshot_account_and_positions, sync_order_to_db
+from app.trading.firewall import OrderFirewall
+
+TERMINAL_ORDER_STATUSES = frozenset(
+    {
+        'filled',
+        'canceled',
+        'cancelled',
+        'expired',
+        'done_for_day',
+        'rejected',
+        'stopped',
+        'suspended',
+    }
+)
+
+
+@dataclass(frozen=True)
+class BrokerCredentials:
+    label: str
+    mode: str
+    api_key: str
+    secret_key: str
+    base_url: str | None
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _resolve_broker_credentials(mode: str, account_label: str | None) -> BrokerCredentials:
+    normalized_mode = mode.strip().lower()
+    normalized_label = (account_label or '').strip()
+    for lane in settings.trading_accounts:
+        lane_mode = str(getattr(lane, 'mode', '') or '').strip().lower()
+        lane_label = str(getattr(lane, 'label', '') or '').strip()
+        if normalized_label and lane_label != normalized_label:
+            continue
+        if lane_mode != normalized_mode:
+            continue
+        api_key = str(getattr(lane, 'api_key', '') or '').strip()
+        secret_key = str(getattr(lane, 'secret_key', '') or '').strip()
+        if not api_key or not secret_key:
+            continue
+        base_url = str(getattr(lane, 'base_url', '') or '').strip() or None
+        return BrokerCredentials(
+            label=lane_label or normalized_mode,
+            mode=normalized_mode,
+            api_key=api_key,
+            secret_key=secret_key,
+            base_url=base_url,
+        )
+
+    if normalized_mode == 'paper':
+        env_key = os.getenv('APCA_PAPER_API_KEY_ID', '').strip()
+        env_secret = os.getenv('APCA_PAPER_API_SECRET_KEY', '').strip()
+        if env_key and env_secret:
+            return BrokerCredentials(
+                label=normalized_label or os.getenv('TRADING_PAPER_ACCOUNT_LABEL', '').strip() or 'paper',
+                mode='paper',
+                api_key=env_key,
+                secret_key=env_secret,
+                base_url=os.getenv('APCA_PAPER_API_BASE_URL', '').strip() or 'https://paper-api.alpaca.markets',
+            )
+
+    if normalized_mode == settings.trading_mode:
+        api_key = (settings.apca_api_key_id or '').strip()
+        secret_key = (settings.apca_api_secret_key or '').strip()
+        if api_key and secret_key:
+            return BrokerCredentials(
+                label=normalized_label or settings.trading_account_label,
+                mode=normalized_mode,
+                api_key=api_key,
+                secret_key=secret_key,
+                base_url=(settings.apca_api_base_url or '').strip() or None,
+            )
+
+    raise SystemExit(f'broker_credentials_unavailable:mode={normalized_mode}')
+
+
+def _load_reference_price(client: TorghutAlpacaClient, symbol: str) -> float:
+    bars = client.get_bars(symbols=[symbol], timeframe='1Min', lookback_bars=1)
+    symbol_bars = bars.get(symbol) or []
+    if not symbol_bars:
+        return 1.0
+    latest = cast(Mapping[str, Any], symbol_bars[-1])
+    for key in ('close', 'c'):
+        raw = latest.get(key)
+        if raw is None:
+            continue
+        try:
+            price = float(raw)
+        except (TypeError, ValueError):
+            continue
+        if price > 0:
+            return price
+    return 1.0
+
+
+def _write_output(path: Path, payload: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(dict(payload), indent=2, sort_keys=True), encoding='utf-8')
+
+
+def _proof_payload(
+    *,
+    credentials: BrokerCredentials,
+    client: TorghutAlpacaClient,
+    symbol: str,
+    qty: float,
+    limit_price: float,
+    lifecycle: list[dict[str, Any]],
+    account: Mapping[str, Any],
+    order_id: str | None,
+    client_order_id: str,
+    verdict: str,
+    snapshot_id: str | None,
+    persisted_execution_id: str | None,
+    persist_db: bool,
+) -> dict[str, Any]:
+    return {
+        'proof_timestamp': _utc_now(),
+        'broker_mode': credentials.mode,
+        'endpoint_class': client.endpoint_class,
+        'account_label': credentials.label,
+        'account_number': account.get('account_number'),
+        'account_status': account.get('status'),
+        'symbol': symbol,
+        'qty': qty,
+        'limit_price': limit_price,
+        'order_id': order_id,
+        'client_order_id': client_order_id,
+        'persist_db': persist_db,
+        'position_snapshot_id': snapshot_id,
+        'execution_id': persisted_execution_id,
+        'lifecycle': lifecycle,
+        'final_status': lifecycle[-1]['status'] if lifecycle else None,
+        'verdict': verdict,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--mode', choices=('paper', 'live'), default='paper')
+    parser.add_argument('--account-label', default=None)
+    parser.add_argument('--symbol', default='AAPL')
+    parser.add_argument('--qty', type=float, default=1.0)
+    parser.add_argument('--limit-price', type=float, default=None)
+    parser.add_argument('--limit-discount', type=float, default=0.5)
+    parser.add_argument('--poll-seconds', type=float, default=1.0)
+    parser.add_argument('--max-wait-seconds', type=float, default=20.0)
+    parser.add_argument('--persist-db', action='store_true', default=False)
+    parser.add_argument('--output', default=None)
+    args = parser.parse_args()
+
+    credentials = _resolve_broker_credentials(args.mode, args.account_label)
+    client = TorghutAlpacaClient(
+        api_key=credentials.api_key,
+        secret_key=credentials.secret_key,
+        base_url=credentials.base_url,
+        paper=credentials.mode == 'paper',
+    )
+    firewall = OrderFirewall(client)
+    lifecycle: list[dict[str, Any]] = []
+    persisted_execution_id: str | None = None
+    snapshot_id: str | None = None
+
+    account = cast(Mapping[str, Any], firewall.get_account() or {})
+    lifecycle.append(
+        {
+            'phase': 'account_lookup',
+            'status': 'ok',
+            'at': _utc_now(),
+            'account_status': account.get('status'),
+            'account_number': account.get('account_number'),
+        }
+    )
+    asset = firewall.get_asset(args.symbol)
+    if asset is None:
+        raise SystemExit(f'asset_unavailable:{args.symbol}')
+    lifecycle.append(
+        {
+            'phase': 'asset_lookup',
+            'status': 'ok',
+            'at': _utc_now(),
+            'asset_status': asset.get('status'),
+            'tradable': asset.get('tradable'),
+        }
+    )
+
+    reference_price = args.limit_price or _load_reference_price(client, args.symbol)
+    limit_price = round(max(1.0, reference_price * max(0.05, args.limit_discount)), 2)
+    client_order_id = f'torghut-broker-proof-{int(time.time())}'
+    if args.persist_db:
+        with SessionLocal() as session:
+            snapshot = snapshot_account_and_positions(
+                session,
+                client,
+                credentials.label,
+            )
+            snapshot_id = str(snapshot.id)
+
+    submitted = firewall.submit_order(
+        symbol=args.symbol,
+        side='buy',
+        qty=args.qty,
+        order_type='limit',
+        time_in_force='day',
+        limit_price=limit_price,
+        extra_params={'client_order_id': client_order_id},
+    )
+    order_id = str(submitted.get('id') or '').strip() or None
+    lifecycle.append(
+        {
+            'phase': 'submit',
+            'status': str(submitted.get('status') or 'submitted'),
+            'at': _utc_now(),
+            'order_id': order_id,
+        }
+    )
+    if order_id is None:
+        raise SystemExit('order_submit_missing_id')
+
+    observed = firewall.get_order(order_id)
+    lifecycle.append(
+        {
+            'phase': 'readback',
+            'status': str(observed.get('status') or 'unknown'),
+            'at': _utc_now(),
+        }
+    )
+
+    final_order = observed
+    final_status = str(observed.get('status') or '').strip().lower()
+    if final_status not in TERMINAL_ORDER_STATUSES:
+        firewall.cancel_order(order_id)
+        lifecycle.append(
+            {
+                'phase': 'cancel_requested',
+                'status': 'requested',
+                'at': _utc_now(),
+            }
+        )
+        deadline = time.monotonic() + max(1.0, args.max_wait_seconds)
+        poll_seconds = max(0.1, args.poll_seconds)
+        while time.monotonic() < deadline:
+            final_order = firewall.get_order(order_id)
+            final_status = str(final_order.get('status') or '').strip().lower()
+            lifecycle.append(
+                {
+                    'phase': 'poll',
+                    'status': final_status or 'unknown',
+                    'at': _utc_now(),
+                }
+            )
+            if final_status in TERMINAL_ORDER_STATUSES:
+                break
+            time.sleep(poll_seconds)
+
+    if args.persist_db:
+        with SessionLocal() as session:
+            execution = sync_order_to_db(
+                session,
+                dict(final_order),
+                alpaca_account_label=credentials.label,
+                execution_expected_adapter='alpaca',
+                execution_actual_adapter='alpaca',
+            )
+            persisted_execution_id = str(execution.id)
+
+    verdict = (
+        'success'
+        if str(final_order.get('status') or '').strip().lower() in TERMINAL_ORDER_STATUSES
+        else 'failed'
+    )
+    payload = _proof_payload(
+        credentials=credentials,
+        client=client,
+        symbol=args.symbol,
+        qty=args.qty,
+        limit_price=limit_price,
+        lifecycle=lifecycle,
+        account=account,
+        order_id=order_id,
+        client_order_id=client_order_id,
+        verdict=verdict,
+        snapshot_id=snapshot_id,
+        persisted_execution_id=persisted_execution_id,
+        persist_db=args.persist_db,
+    )
+    if args.output:
+        _write_output(Path(args.output), payload)
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    if verdict != 'success':
+        raise SystemExit('broker_proof_failed')
+
+
+if __name__ == '__main__':
+    main()

--- a/services/torghut/tests/test_alpaca_client.py
+++ b/services/torghut/tests/test_alpaca_client.py
@@ -208,6 +208,33 @@ class TestAlpacaClient(TestCase):
         finally:
             config.settings.trading_mode = original
 
+    def test_explicit_paper_override_beats_live_runtime_mode(self) -> None:
+        from app import config
+
+        original = config.settings.trading_mode
+        config.settings.trading_mode = "live"
+
+        try:
+            with (
+                patch("app.alpaca_client.TradingClient") as mock_trading_client,
+                patch("app.alpaca_client.StockHistoricalDataClient") as mock_data_client,
+            ):
+                client = TorghutAlpacaClient(
+                    api_key="k",
+                    secret_key="s",
+                    base_url="https://paper-api.alpaca.markets",
+                    paper=True,
+                )
+
+                trading_kwargs = mock_trading_client.call_args.kwargs
+                data_kwargs = mock_data_client.call_args.kwargs
+
+                self.assertTrue(trading_kwargs.get("paper"))
+                self.assertTrue(data_kwargs.get("sandbox"))
+                self.assertEqual(client.endpoint_class, "paper")
+        finally:
+            config.settings.trading_mode = original
+
     def test_alpaca_base_url_strips_v2_suffix(self) -> None:
         with patch("app.alpaca_client.TradingClient") as mock_trading_client:
             TorghutAlpacaClient(

--- a/services/torghut/tests/test_start_historical_simulation.py
+++ b/services/torghut/tests/test_start_historical_simulation.py
@@ -704,8 +704,9 @@ class TestStartHistoricalSimulation(TestCase):
             start_historical_simulation._reset_postgres_runtime_state(config)
 
         rendered = [(str(statement), params) for statement, params in statements]
+        self.assertIn('UPDATE simulation_run_progress', rendered[0][0])
         self.assertEqual(
-            rendered,
+            rendered[1:],
             [
                 ('SELECT to_regclass(%s)', ('trade_cursor',)),
                 ('Composed([SQL(\'TRUNCATE TABLE \'), Identifier(\'trade_cursor\'), SQL(\' RESTART IDENTITY CASCADE\')])', None),

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from typing import Any
 from unittest import TestCase
 from unittest.mock import patch
 
@@ -16,8 +17,10 @@ from sqlalchemy.orm import Session, sessionmaker
 
 from app.db import get_session
 from app.main import (
+    _ALPACA_HEALTH_STATE,
     _TRADING_DEPENDENCY_HEALTH_CACHE,
     _assert_dspy_cutover_migration_guard,
+    _check_alpaca,
     _readiness_dependency_cache_key,
     app,
 )
@@ -66,6 +69,7 @@ def _truthful_empirical_payload(
 class TestTradingApi(TestCase):
     def setUp(self) -> None:
         _TRADING_DEPENDENCY_HEALTH_CACHE.clear()
+        _ALPACA_HEALTH_STATE.clear()
         engine = create_engine(
             "sqlite+pysqlite:///:memory:",
             future=True,
@@ -176,6 +180,7 @@ class TestTradingApi(TestCase):
 
     def tearDown(self) -> None:
         _TRADING_DEPENDENCY_HEALTH_CACHE.clear()
+        _ALPACA_HEALTH_STATE.clear()
         app.dependency_overrides.clear()
 
     def test_trading_decisions_endpoint(self) -> None:
@@ -920,6 +925,59 @@ class TestTradingApi(TestCase):
         finally:
             settings.trading_enabled = original
             settings.trading_universe_source = original_source
+
+    @patch(
+        "app.main._alpaca_probe_account",
+        side_effect=[
+            {
+                "ok": True,
+                "status": "broker_ok",
+                "detail": "ok",
+                "account": {
+                    "account_number": "PA3SX7FYNUTF",
+                    "status": "ACTIVE",
+                },
+            },
+            {
+                "ok": False,
+                "status": "broker_slow",
+                "detail": "alpaca account probe timed out after 2.00s",
+            },
+        ],
+    )
+    @patch("app.main.TorghutAlpacaClient")
+    def test_check_alpaca_uses_cached_last_known_good_for_slow_probe(
+        self,
+        mock_client: Any,
+        _mock_probe: object,
+    ) -> None:
+        original_key = settings.apca_api_key_id
+        original_secret = settings.apca_api_secret_key
+        original_ttl = settings.trading_alpaca_healthcheck_last_good_ttl_seconds
+        original_retries = settings.trading_alpaca_healthcheck_retries
+        try:
+            settings.apca_api_key_id = "demo-key"
+            settings.apca_api_secret_key = "demo-secret"
+            settings.trading_alpaca_healthcheck_last_good_ttl_seconds = 120
+            settings.trading_alpaca_healthcheck_retries = 1
+            mock_client.return_value.endpoint_class = "live"
+
+            first = _check_alpaca()
+            second = _check_alpaca()
+        finally:
+            settings.apca_api_key_id = original_key
+            settings.apca_api_secret_key = original_secret
+            settings.trading_alpaca_healthcheck_last_good_ttl_seconds = original_ttl
+            settings.trading_alpaca_healthcheck_retries = original_retries
+
+        self.assertTrue(first["ok"])
+        self.assertEqual(first["broker_status"], "broker_ok")
+        self.assertFalse(first["cache_used"])
+        self.assertTrue(second["ok"])
+        self.assertTrue(second["cache_used"])
+        self.assertEqual(second["broker_status"], "broker_slow")
+        self.assertEqual(second["endpoint_class"], "live")
+        self.assertEqual(second["account_label"], "PA3SX7FYNUTF")
 
     @patch(
         "app.main._evaluate_database_contract",


### PR DESCRIPTION
## Summary

- Harden Torghut Alpaca readiness with retry/backoff, broker failure classification, and last-known-good shielding for transient slow or unreachable probes.
- Reset stale non-terminal simulation progress rows before warm-lane reruns so shared lanes do not inherit ghost active-run state from abandoned simulations.
- Add a production-real Alpaca broker proof script plus regression coverage for the warm-lane reset, explicit paper-mode Alpaca client construction, and Jangar watch reliability restart tolerance.

## Related Issues

None

## Testing

- `uv run --frozen pytest services/torghut/tests/test_start_historical_simulation.py services/torghut/tests/test_trading_api.py services/torghut/tests/test_alpaca_client.py -q`
- `cd services/torghut && uv run --frozen ruff check app tests scripts migrations`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/jangar && bunx vitest run --config vitest.config.ts src/server/__tests__/control-plane-watch-reliability.test.ts src/server/__tests__/control-plane-status.test.ts`
- `cd services/jangar && bunx oxfmt --check src/server/control-plane-watch-reliability.ts src/server/__tests__/control-plane-watch-reliability.test.ts src/server/__tests__/control-plane-status.test.ts`
- `cd services/jangar && bun run tsc`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
