### PR TITLE
chore(jangar): promote image 84130d42

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 7082cffd
-  digest: sha256:40f88f9118153a9e684f1b351df6af6c0b038b630beeab5ec7937325583743e2
+  tag: 84130d42
+  digest: sha256:a5dff066021f59615fdf85a90841cbc1aad07ee39e0a9e33c5595997366359ac
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 7082cffd
-    digest: sha256:b103cb435f4a13de533e62e02a94f92748edaa5af51ef4f7bf175122d7e08f15
+    tag: 84130d42
+    digest: sha256:6bc573c7a7f33eaf21a17baa5f9b10ef44ef0499b141f8475dba63ff35b95b5a
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 7082cffd
-    digest: sha256:40f88f9118153a9e684f1b351df6af6c0b038b630beeab5ec7937325583743e2
+    tag: 84130d42
+    digest: sha256:a5dff066021f59615fdf85a90841cbc1aad07ee39e0a9e33c5595997366359ac
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-14T16:46:16Z"
+    deploy.knative.dev/rollout: "2026-03-14T17:35:13Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-14T16:46:16Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-14T17:35:13Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -62,5 +62,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "7082cffd"
-    digest: sha256:40f88f9118153a9e684f1b351df6af6c0b038b630beeab5ec7937325583743e2
+    newTag: "84130d42"
+    digest: sha256:a5dff066021f59615fdf85a90841cbc1aad07ee39e0a9e33c5595997366359ac


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `84130d4238d06a1064a5aca2a5d2e3ba1cc9a144`
- Image tag: `84130d42`
- Image digest: `sha256:a5dff066021f59615fdf85a90841cbc1aad07ee39e0a9e33c5595997366359ac`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`