### PR TITLE
fix(torghut): normalize warm-lane storage targets

### DIFF
--- a/services/jangar/src/server/__tests__/torghut-simulation-control-plane.test.ts
+++ b/services/jangar/src/server/__tests__/torghut-simulation-control-plane.test.ts
@@ -117,6 +117,43 @@ describe('torghut simulation control plane', () => {
     })
   })
 
+  it('rewrites stale run-scoped databases when warm lanes are enabled', () => {
+    const manifest = __private.normalizeSimulationManifest(
+      {
+        dataset_id: 'dataset-a',
+        window: {
+          start: '2026-03-06T14:30:00Z',
+          end: '2026-03-06T14:45:00Z',
+        },
+        runtime: {
+          target_mode: 'dedicated_service',
+          use_warm_lane: true,
+        },
+        clickhouse: {
+          simulation_database: 'torghut_sim_old_run',
+        },
+        postgres: {
+          simulation_dsn: 'postgresql://torghut_app@torghut-db-rw.torghut.svc.cluster.local:5432/torghut_sim_old_run',
+          runtime_simulation_dsn:
+            'postgresql://torghut_app@torghut-db-rw.torghut.svc.cluster.local:5432/torghut_sim_old_run',
+        },
+      },
+      {
+        runId: 'sim-warm-proof',
+        profile: 'compact',
+      },
+    )
+
+    expect(manifest.clickhouse).toMatchObject({
+      simulation_database: 'torghut_sim_default',
+    })
+    expect(manifest.postgres).toMatchObject({
+      simulation_dsn: 'postgresql://torghut_app@torghut-db-rw.torghut.svc.cluster.local:5432/torghut_sim_default',
+      runtime_simulation_dsn:
+        'postgresql://torghut_app@torghut-db-rw.torghut.svc.cluster.local:5432/torghut_sim_default',
+    })
+  })
+
   it('resolves a writable workflow output root for relative artifact paths', () => {
     expect(__private.resolveWorkflowOutputRoot('artifacts/torghut/simulations')).toBe(
       '/tmp/torghut-simulations/artifacts/torghut/simulations',

--- a/services/jangar/src/server/torghut-simulation-control-plane.ts
+++ b/services/jangar/src/server/torghut-simulation-control-plane.ts
@@ -519,6 +519,12 @@ const defaultSimulationDatabaseName = (runIdSeed: string, useWarmLane: boolean) 
 const defaultSimulationPostgresDsn = (database: string) =>
   `postgresql://${DEFAULT_SIMULATION_POSTGRES_RUNTIME_USER}@${DEFAULT_SIMULATION_POSTGRES_HOST}/${database}`
 
+const replaceDatabaseInDsn = (dsn: string, database: string) => {
+  const parsed = new URL(dsn)
+  parsed.pathname = `/${database}`
+  return parsed.toString()
+}
+
 const parseTimestamp = (value: unknown) => {
   const text = asString(value)
   if (!text) return null
@@ -584,7 +590,9 @@ const normalizeSimulationManifest = (
   if (!asString(clickhouse.http_url)) clickhouse.http_url = DEFAULT_SIMULATION_CLICKHOUSE_HTTP_URL
   if (!asString(clickhouse.username)) clickhouse.username = DEFAULT_SIMULATION_CLICKHOUSE_USERNAME
   if (!asString(clickhouse.password_env)) clickhouse.password_env = DEFAULT_SIMULATION_CLICKHOUSE_PASSWORD_ENV
-  if (!asString(clickhouse.simulation_database)) clickhouse.simulation_database = simulationDatabase
+  if (useWarmLane || !asString(clickhouse.simulation_database)) {
+    clickhouse.simulation_database = simulationDatabase
+  }
   manifest.clickhouse = clickhouse
 
   const postgres = asRecord(manifest.postgres)
@@ -594,9 +602,13 @@ const normalizeSimulationManifest = (
   }
   if (!asString(postgres.simulation_dsn)) {
     postgres.simulation_dsn = defaultSimulationPostgresDsn(simulationDatabase)
+  } else if (useWarmLane) {
+    postgres.simulation_dsn = replaceDatabaseInDsn(String(postgres.simulation_dsn), simulationDatabase)
   }
   if (!asString(postgres.runtime_simulation_dsn)) {
     postgres.runtime_simulation_dsn = defaultSimulationPostgresDsn(simulationDatabase)
+  } else if (useWarmLane) {
+    postgres.runtime_simulation_dsn = replaceDatabaseInDsn(String(postgres.runtime_simulation_dsn), simulationDatabase)
   }
   if (!asString(postgres.migrations_command)) {
     postgres.migrations_command = DEFAULT_SIMULATION_POSTGRES_MIGRATIONS_COMMAND

--- a/services/torghut/scripts/start_historical_simulation.py
+++ b/services/torghut/scripts/start_historical_simulation.py
@@ -1319,8 +1319,12 @@ def _build_resources(run_id: str, manifest: Mapping[str, Any]) -> SimulationReso
 
     clickhouse_cfg = _as_mapping(manifest.get('clickhouse'))
     clickhouse_db = (
-        _as_text(clickhouse_cfg.get('simulation_database'))
-        or (DEFAULT_WARM_LANE_SIMULATION_DATABASE if warm_lane else f'torghut_sim_{run_token}')
+        DEFAULT_WARM_LANE_SIMULATION_DATABASE
+        if warm_lane
+        else (
+            _as_text(clickhouse_cfg.get('simulation_database'))
+            or f'torghut_sim_{run_token}'
+        )
     )
     clickhouse_table_by_role = simulation_clickhouse_table_names(
         lane=lane_contract.lane,
@@ -1379,6 +1383,39 @@ def _build_resources(run_id: str, manifest: Mapping[str, Any]) -> SimulationReso
         clickhouse_price_table=clickhouse_price_table,
         warm_lane_enabled=warm_lane,
     )
+
+
+def _canonicalize_warm_lane_manifest(
+    manifest: Mapping[str, Any],
+    *,
+    resources: SimulationResources,
+) -> dict[str, Any]:
+    if not resources.warm_lane_enabled:
+        return _as_mapping(manifest)
+
+    normalized = cast(dict[str, Any], json.loads(json.dumps(dict(manifest))))
+    clickhouse = _as_mapping(normalized.get('clickhouse'))
+    clickhouse['simulation_database'] = resources.clickhouse_db
+    normalized['clickhouse'] = clickhouse
+
+    postgres = _as_mapping(normalized.get('postgres'))
+    simulation_db = _default_simulation_postgres_db(resources)
+    simulation_dsn = _as_text(postgres.get('simulation_dsn'))
+    if simulation_dsn:
+        postgres['simulation_dsn'] = _replace_database_in_dsn(
+            simulation_dsn,
+            database=simulation_db,
+            label='manifest.postgres.simulation_dsn',
+        )
+    runtime_simulation_dsn = _as_text(postgres.get('runtime_simulation_dsn'))
+    if runtime_simulation_dsn:
+        postgres['runtime_simulation_dsn'] = _replace_database_in_dsn(
+            runtime_simulation_dsn,
+            database=simulation_db,
+            label='manifest.postgres.runtime_simulation_dsn',
+        )
+    normalized['postgres'] = postgres
+    return normalized
 
 
 def _build_argocd_automation_config(manifest: Mapping[str, Any]) -> ArgocdAutomationConfig:
@@ -6532,6 +6569,7 @@ def main() -> None:
         strict_coverage_ratio=window.get('strict_coverage_ratio'),
     )
     resources = _build_resources(args.run_id, manifest)
+    manifest = _canonicalize_warm_lane_manifest(manifest, resources=resources)
     _log_script_event(
         'resources_built',
         run_token=resources.run_token,

--- a/services/torghut/tests/test_start_historical_simulation.py
+++ b/services/torghut/tests/test_start_historical_simulation.py
@@ -316,6 +316,63 @@ class TestStartHistoricalSimulation(TestCase):
             'torghut.sim.trades.v1',
         )
 
+    def test_build_resources_ignores_run_scoped_clickhouse_database_when_warm_lane_enabled(self) -> None:
+        resources = _build_resources(
+            'sim-2026-03-14-warm',
+            {
+                'dataset_id': 'torghut-trades-2025q4',
+                'runtime': {
+                    'use_warm_lane': True,
+                },
+                'clickhouse': {
+                    'simulation_database': 'torghut_sim_stale_run',
+                },
+            },
+        )
+
+        self.assertTrue(resources.warm_lane_enabled)
+        self.assertEqual(resources.clickhouse_db, 'torghut_sim_default')
+        self.assertEqual(resources.clickhouse_signal_table, 'torghut_sim_default.ta_signals')
+
+    def test_canonicalize_warm_lane_manifest_rewrites_explicit_storage_targets(self) -> None:
+        resources = _build_resources(
+            'sim-2026-03-14-warm',
+            {
+                'dataset_id': 'torghut-trades-2025q4',
+                'runtime': {
+                    'use_warm_lane': True,
+                },
+            },
+        )
+        manifest = {
+            'dataset_id': 'torghut-trades-2025q4',
+            'runtime': {
+                'use_warm_lane': True,
+            },
+            'clickhouse': {
+                'simulation_database': 'torghut_sim_stale_run',
+            },
+            'postgres': {
+                'simulation_dsn': 'postgresql://torghut:secret@localhost:5432/torghut_sim_stale_run',
+                'runtime_simulation_dsn': 'postgresql://torghut_app:secret@localhost:5432/torghut_sim_stale_run',
+            },
+        }
+
+        normalized = start_historical_simulation._canonicalize_warm_lane_manifest(
+            manifest,
+            resources=resources,
+        )
+
+        self.assertEqual(normalized['clickhouse']['simulation_database'], 'torghut_sim_default')
+        self.assertEqual(
+            normalized['postgres']['simulation_dsn'],
+            'postgresql://torghut:secret@localhost:5432/torghut_sim_default',
+        )
+        self.assertEqual(
+            normalized['postgres']['runtime_simulation_dsn'],
+            'postgresql://torghut_app:secret@localhost:5432/torghut_sim_default',
+        )
+
     def test_build_resources_derives_options_lane_isolation_names(self) -> None:
         resources = _build_resources(
             'options-sim-2026-03-06-open',


### PR DESCRIPTION
## Summary

- force warm-lane simulation submissions onto the shared warm-lane ClickHouse and Postgres databases even when the source manifest still carries stale run-scoped storage settings
- enforce the same warm-lane storage normalization in the Python historical-simulation launcher so direct CLI/workflow runs cannot bypass the invariant
- add regressions in Jangar and Torghut proving stale run-scoped storage settings are rewritten before execution

## Related Issues

None

## Testing

- `uv run --frozen pytest services/torghut/tests/test_start_historical_simulation.py -q`
- `uv run --frozen pyright --project services/torghut/pyrightconfig.json`
- `uv run --frozen pyright --project services/torghut/pyrightconfig.alpha.json`
- `uv run --frozen pyright --project services/torghut/pyrightconfig.scripts.json`
- `uv run --frozen ruff check services/torghut/scripts/start_historical_simulation.py services/torghut/tests/test_start_historical_simulation.py`
- `bunx vitest run --config vitest.config.ts src/server/__tests__/torghut-simulation-control-plane.test.ts`
- `bun run --filter @proompteng/jangar tsc`
- `bunx oxfmt --check services/jangar/src/server/torghut-simulation-control-plane.ts services/jangar/src/server/__tests__/torghut-simulation-control-plane.test.ts`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
