### PR TITLE
chore(jangar): promote image aa3430d2

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 84130d42
-  digest: sha256:a5dff066021f59615fdf85a90841cbc1aad07ee39e0a9e33c5595997366359ac
+  tag: aa3430d2
+  digest: sha256:e568a6b7956fcd52c974def5d96748a0a76def1eb43c795118f683125afbeaba
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 84130d42
-    digest: sha256:6bc573c7a7f33eaf21a17baa5f9b10ef44ef0499b141f8475dba63ff35b95b5a
+    tag: aa3430d2
+    digest: sha256:6dc079505a49ece9d6e1e5a2071ac6ede281c789b0941777dadd2d42f7be7d37
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 84130d42
-    digest: sha256:a5dff066021f59615fdf85a90841cbc1aad07ee39e0a9e33c5595997366359ac
+    tag: aa3430d2
+    digest: sha256:e568a6b7956fcd52c974def5d96748a0a76def1eb43c795118f683125afbeaba
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-14T17:35:13Z"
+    deploy.knative.dev/rollout: "2026-03-14T18:36:04Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-14T17:35:13Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-14T18:36:04Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -62,5 +62,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "84130d42"
-    digest: sha256:a5dff066021f59615fdf85a90841cbc1aad07ee39e0a9e33c5595997366359ac
+    newTag: "aa3430d2"
+    digest: sha256:e568a6b7956fcd52c974def5d96748a0a76def1eb43c795118f683125afbeaba


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `aa3430d2602e1b80d34db64f8a7c23af82580a5d`
- Image tag: `aa3430d2`
- Image digest: `sha256:e568a6b7956fcd52c974def5d96748a0a76def1eb43c795118f683125afbeaba`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`