### PR TITLE
fix(jangar): stop false watch-reliability quorum delays

### DIFF
--- a/services/jangar/src/server/__tests__/control-plane-watch-reliability.test.ts
+++ b/services/jangar/src/server/__tests__/control-plane-watch-reliability.test.ts
@@ -49,6 +49,28 @@ describe('control-plane watch reliability', () => {
     expect(summary.total_restarts).toBe(2)
   })
 
+  it('keeps independent single-stream restarts observable without degrading status', () => {
+    vi.stubEnv('JANGAR_CONTROL_PLANE_WATCH_HEALTH_RESTART_DEGRADE_THRESHOLD', '2')
+    recordWatchReliabilityRestart({
+      resource: 'toolruns.tools.proompteng.ai',
+      namespace: 'agents',
+    })
+    recordWatchReliabilityRestart({
+      resource: 'agentruns.agents.proompteng.ai',
+      namespace: 'agents',
+    })
+    recordWatchReliabilityRestart({
+      resource: 'orchestrations.orchestration.proompteng.ai',
+      namespace: 'agents',
+    })
+
+    const summary = getWatchReliabilitySummary()
+
+    expect(summary.status).toBe('healthy')
+    expect(summary.total_restarts).toBe(3)
+    expect(summary.observed_streams).toBe(3)
+  })
+
   it('degrades immediately when watch errors are observed', () => {
     recordWatchReliabilityEvent({
       resource: 'toolruns.tools.proompteng.ai',

--- a/services/jangar/src/server/control-plane-watch-reliability.ts
+++ b/services/jangar/src/server/control-plane-watch-reliability.ts
@@ -170,9 +170,10 @@ export const getWatchReliabilitySummary = (): ControlPlaneWatchReliabilitySummar
   })
   const topStreams = observedStreams.slice(0, Math.min(streamLimit, TOP_STREAM_LIMIT))
   const restartDegradeThreshold = resolveRestartDegradeThreshold()
+  const maxStreamRestarts = observedStreams.reduce((currentMax, stream) => Math.max(currentMax, stream.restarts), 0)
 
   const status =
-    totalErrors > 0 || totalRestarts >= restartDegradeThreshold
+    totalErrors > 0 || maxStreamRestarts >= restartDegradeThreshold
       ? 'degraded'
       : observedStreams.length > 0
         ? 'healthy'


### PR DESCRIPTION
## Summary

- stop Jangar control-plane watch reliability from delaying dependency quorum on one-off restarts across different streams
- keep restart counts observable while degrading only on repeated per-stream instability or actual watch errors
- add a regression test covering multiple independent single-stream restarts

## Related Issues

None

## Testing

- `cd services/jangar && bunx vitest run --config vitest.config.ts src/server/__tests__/control-plane-watch-reliability.test.ts src/server/__tests__/control-plane-status.test.ts`
- `bun run --filter @proompteng/jangar tsc`
- `bun run --filter @proompteng/jangar build`
- `bunx oxfmt --check services/jangar/src/server/control-plane-watch-reliability.ts services/jangar/src/server/__tests__/control-plane-watch-reliability.test.ts`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
