### PR TITLE
chore(jangar): promote image 7e4c8c6b

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: aa3430d2
-  digest: sha256:e568a6b7956fcd52c974def5d96748a0a76def1eb43c795118f683125afbeaba
+  tag: 7e4c8c6b
+  digest: sha256:899b6167780961540d4faf53ee7e561c9e01672929979aabefa09d6619c61aac
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: aa3430d2
-    digest: sha256:6dc079505a49ece9d6e1e5a2071ac6ede281c789b0941777dadd2d42f7be7d37
+    tag: 7e4c8c6b
+    digest: sha256:ea302485e0e9fe4530b129f11e05ee64ccfc6c1aeee4cf993323bb28b8ff6986
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: aa3430d2
-    digest: sha256:e568a6b7956fcd52c974def5d96748a0a76def1eb43c795118f683125afbeaba
+    tag: 7e4c8c6b
+    digest: sha256:899b6167780961540d4faf53ee7e561c9e01672929979aabefa09d6619c61aac
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-14T18:36:04Z"
+    deploy.knative.dev/rollout: "2026-03-14T19:44:29Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-14T18:36:04Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-14T19:44:29Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -62,5 +62,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "aa3430d2"
-    digest: sha256:e568a6b7956fcd52c974def5d96748a0a76def1eb43c795118f683125afbeaba
+    newTag: "7e4c8c6b"
+    digest: sha256:899b6167780961540d4faf53ee7e561c9e01672929979aabefa09d6619c61aac


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `7e4c8c6b6a162c73daf0d5b30b39c530d0de7387`
- Image tag: `7e4c8c6b`
- Image digest: `sha256:899b6167780961540d4faf53ee7e561c9e01672929979aabefa09d6619c61aac`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`