### PR TITLE
fix(torghut): stabilize warm replay proof

### DIFF
--- a/services/jangar/src/server/__tests__/torghut-simulation-control-plane.test.ts
+++ b/services/jangar/src/server/__tests__/torghut-simulation-control-plane.test.ts
@@ -154,6 +154,42 @@ describe('torghut simulation control plane', () => {
     })
   })
 
+  it('builds stable cache keys and manifest digests regardless of object key order', () => {
+    const manifestA = {
+      dataset_id: 'dataset-a',
+      lane: 'equity',
+      candidate_id: 'candidate-a',
+      baseline_candidate_id: 'baseline-a',
+      strategy_spec_ref: 'strategy-specs/intraday_tsmom_v1@1.1.0.json',
+      performance: {
+        dumpFormat: 'jsonl.zst',
+      },
+      window: {
+        start: '2026-03-06T14:30:00Z',
+        end: '2026-03-06T15:30:00Z',
+      },
+    }
+    const manifestB = {
+      window: {
+        end: '2026-03-06T15:30:00Z',
+        start: '2026-03-06T14:30:00Z',
+      },
+      performance: {
+        dumpFormat: 'jsonl.zst',
+      },
+      strategy_spec_ref: 'strategy-specs/intraday_tsmom_v1@1.1.0.json',
+      baseline_candidate_id: 'baseline-a',
+      candidate_id: 'candidate-a',
+      lane: 'equity',
+      dataset_id: 'dataset-a',
+    }
+
+    expect(__private.buildSimulationCacheKey(manifestA, 'compact')).toBe(
+      __private.buildSimulationCacheKey(manifestB, 'compact'),
+    )
+    expect(__private.manifestDigest(manifestA)).toBe(__private.manifestDigest(manifestB))
+  })
+
   it('resolves a writable workflow output root for relative artifact paths', () => {
     expect(__private.resolveWorkflowOutputRoot('artifacts/torghut/simulations')).toBe(
       '/tmp/torghut-simulations/artifacts/torghut/simulations',

--- a/services/jangar/src/server/torghut-simulation-control-plane.ts
+++ b/services/jangar/src/server/torghut-simulation-control-plane.ts
@@ -3,6 +3,7 @@ import { posix as pathPosix } from 'node:path'
 
 import { sql } from 'kysely'
 
+import { stableJsonStringifyForHash } from '~/server/agents-controller/template-hash'
 import { getDb } from '~/server/db'
 import { ensureMigrations } from '~/server/kysely-migrations'
 import { createKubernetesClient } from '~/server/primitives-kube'
@@ -266,7 +267,7 @@ const resolveSimulationWorkflowNamespace = (manifest: JsonRecord) => {
 const buildSimulationCacheKey = (manifest: JsonRecord, profile: string) =>
   createHash('sha256')
     .update(
-      JSON.stringify({
+      stableJsonStringifyForHash({
         lane: asString(manifest.lane) ?? 'equity',
         dataset_id: asString(manifest.dataset_id),
         window: asRecord(manifest.window),
@@ -841,7 +842,8 @@ const snapshotFromRow = (row: Record<string, unknown>): TorghutSimulationRunSnap
   updatedAt: String(row.updated_at),
 })
 
-const manifestDigest = (manifest: JsonRecord) => createHash('sha256').update(JSON.stringify(manifest)).digest('hex')
+const manifestDigest = (manifest: JsonRecord) =>
+  createHash('sha256').update(stableJsonStringifyForHash(manifest)).digest('hex')
 
 const expectedArtifactsForRun = (runId: string, outputRoot: string, dumpFormat: string) => {
   const runToken = normalizeRunToken(runId)
@@ -1648,8 +1650,10 @@ export const cancelTorghutSimulationRun = async (runId: string) => {
 
 export const __private = {
   buildRobustnessScorecard,
+  buildSimulationCacheKey,
   expectedArtifactsForRun,
   buildCampaignRunId,
+  manifestDigest,
   normalizeCampaignRequest,
   normalizeRunToken,
   normalizeSimulationManifest,

--- a/services/torghut/app/trading/scheduler/runtime.py
+++ b/services/torghut/app/trading/scheduler/runtime.py
@@ -25,6 +25,7 @@ from ..order_feed import OrderFeedIngestor
 from ..prices import ClickHousePriceFetcher
 from ..reconcile import Reconciler
 from ..risk import RiskEngine
+from ..simulation_progress import active_simulation_runtime_context
 from ..simulation import resolve_market_context_as_of
 from ..time_source import trading_time_status
 from ..universe import UniverseResolver
@@ -42,6 +43,7 @@ class TradingScheduler(TradingSchedulerGovernanceMixin):
         self._stop_event = asyncio.Event()
         self._pipeline: Optional[TradingPipeline] = None
         self._pipelines: list[TradingPipeline] = []
+        self._active_simulation_run_id: str | None = None
 
     def _emit_autonomy_domain_telemetry(
         self,
@@ -369,6 +371,7 @@ class TradingScheduler(TradingSchedulerGovernanceMixin):
         )
         try:
             while not self._stop_event.is_set():
+                self._sync_simulation_run_context()
                 await self._run_trading_iteration()
                 now = datetime.now(timezone.utc)
                 if self._interval_elapsed(last_reconcile, reconcile_interval, now=now):
@@ -391,6 +394,70 @@ class TradingScheduler(TradingSchedulerGovernanceMixin):
         finally:
             self.state.running = False
             logger.info("Trading scheduler loop exited")
+
+    def _sync_simulation_run_context(self) -> None:
+        if not settings.trading_simulation_enabled:
+            self._active_simulation_run_id = None
+            return
+
+        runtime_context = active_simulation_runtime_context()
+        active_run_id = str((runtime_context or {}).get("run_id") or "").strip() or None
+        if active_run_id == self._active_simulation_run_id:
+            return
+
+        previous_run_id = self._active_simulation_run_id
+        self._active_simulation_run_id = active_run_id
+        if active_run_id is None:
+            return
+
+        self._reset_simulation_run_state(
+            previous_run_id=previous_run_id,
+            active_run_id=active_run_id,
+        )
+
+    def _reset_simulation_run_state(
+        self,
+        *,
+        previous_run_id: str | None,
+        active_run_id: str,
+    ) -> None:
+        self.state.last_error = None
+        self.state.last_ingest_signals_total = 0
+        self.state.last_ingest_window_start = None
+        self.state.last_ingest_window_end = None
+        self.state.last_ingest_reason = None
+        self.state.last_signal_continuity_state = None
+        self.state.last_signal_continuity_reason = None
+        self.state.last_signal_continuity_actionable = None
+        self.state.signal_continuity_alert_active = False
+        self.state.signal_continuity_alert_reason = None
+        self.state.signal_continuity_alert_started_at = None
+        self.state.signal_continuity_alert_last_seen_at = None
+        self.state.signal_continuity_recovery_streak = 0
+        self.state.autonomy_no_signal_streak = 0
+        self.state.last_evidence_continuity_report = None
+        self.state.autonomy_failure_streak = 0
+        self.state.universe_fail_safe_blocked = False
+        self.state.universe_fail_safe_block_reason = None
+        self.state.emergency_stop_active = False
+        self.state.emergency_stop_reason = None
+        self.state.emergency_stop_triggered_at = None
+        self.state.emergency_stop_resolved_at = None
+        self.state.emergency_stop_recovery_streak = 0
+        self.state.rollback_incident_evidence_path = None
+        self.state.metrics.no_signal_streak = 0
+        self.state.metrics.no_signal_reason_streak = {}
+        self.state.metrics.signal_lag_seconds = None
+        self.state.metrics.signal_continuity_actionable = 0
+        self.state.metrics.record_signal_continuity_alert_state(
+            active=False,
+            recovery_streak=0,
+        )
+        logger.info(
+            "Trading scheduler reset simulation run state previous_run_id=%s active_run_id=%s",
+            previous_run_id or "none",
+            active_run_id,
+        )
 
     @staticmethod
     def _interval_elapsed(

--- a/services/torghut/scripts/start_historical_simulation.py
+++ b/services/torghut/scripts/start_historical_simulation.py
@@ -5052,6 +5052,8 @@ def _apply(
             auto_offset_reset=auto_offset_reset,
             manifest=manifest,
         )
+        ta_restart_required = warm_lane_enabled or ta_reconfigured
+        ta_restart_forced = warm_lane_enabled and not ta_reconfigured
         if ta_reconfigured:
             _configure_ta_for_simulation(
                 resources=resources,
@@ -5060,6 +5062,7 @@ def _apply(
                 auto_offset_reset=auto_offset_reset,
                 manifest=manifest,
             )
+        if ta_restart_required:
             ta_restart_nonce = _restart_ta_deployment(
                 resources,
                 desired_state='running',
@@ -5101,6 +5104,7 @@ def _apply(
         'topics': topics_report,
         'schema_registry': schema_registry_report,
         'ta_restart_nonce': ta_restart_nonce,
+        'ta_restart_forced': ta_restart_forced,
         'ta_reconfigured': ta_reconfigured,
         'torghut_reconfigured': torghut_reconfigured,
         'warm_lane_enabled': warm_lane_enabled,

--- a/services/torghut/tests/test_start_historical_simulation.py
+++ b/services/torghut/tests/test_start_historical_simulation.py
@@ -1262,7 +1262,7 @@ class TestStartHistoricalSimulation(TestCase):
         self.assertTrue(report['postgres']['database_precreated'])
         self.assertEqual(report['simulation_lock']['status'], 'acquired')
 
-    def test_apply_skips_reconfigure_when_warm_lane_baseline_is_already_ready(self) -> None:
+    def test_apply_restarts_ta_when_warm_lane_baseline_is_already_ready(self) -> None:
         resources = _build_resources(
             'sim-1',
             {
@@ -1358,10 +1358,16 @@ class TestStartHistoricalSimulation(TestCase):
                 )
 
         configure_ta.assert_not_called()
-        restart_ta.assert_not_called()
+        restart_ta.assert_called_once_with(
+            resources,
+            desired_state='running',
+            upgrade_mode='stateless',
+        )
         configure_service.assert_not_called()
         self.assertTrue(report['warm_lane_enabled'])
         self.assertFalse(report['ta_reconfigured'])
+        self.assertTrue(report['ta_restart_forced'])
+        self.assertEqual(report['ta_restart_nonce'], 7)
         self.assertFalse(report['torghut_reconfigured'])
         self.assertEqual(report['seeded_cursor_at'], '2026-02-27T14:30:00+00:00')
 

--- a/services/torghut/tests/test_trading_scheduler_safety.py
+++ b/services/torghut/tests/test_trading_scheduler_safety.py
@@ -43,6 +43,7 @@ class TestTradingSchedulerSafety(TestCase):
         self._snapshot = {
             "trading_autonomy_artifact_dir": config.settings.trading_autonomy_artifact_dir,
             "trading_emergency_stop_enabled": config.settings.trading_emergency_stop_enabled,
+            "trading_simulation_enabled": config.settings.trading_simulation_enabled,
             "trading_allow_shorts": config.settings.trading_allow_shorts,
             "trading_emergency_stop_recovery_cycles": config.settings.trading_emergency_stop_recovery_cycles,
             "trading_rollback_signal_lag_seconds_limit": config.settings.trading_rollback_signal_lag_seconds_limit,
@@ -66,6 +67,9 @@ class TestTradingSchedulerSafety(TestCase):
         ]
         config.settings.trading_emergency_stop_enabled = self._snapshot[
             "trading_emergency_stop_enabled"
+        ]
+        config.settings.trading_simulation_enabled = self._snapshot[
+            "trading_simulation_enabled"
         ]
         config.settings.trading_allow_shorts = self._snapshot["trading_allow_shorts"]
         config.settings.trading_emergency_stop_recovery_cycles = self._snapshot[
@@ -92,6 +96,75 @@ class TestTradingSchedulerSafety(TestCase):
         config.settings.trading_signal_market_closed_expected_reasons_raw = (
             self._snapshot["trading_signal_market_closed_expected_reasons_raw"]
         )
+
+    def test_simulation_run_context_reset_clears_run_scoped_safety_state(self) -> None:
+        config.settings.trading_simulation_enabled = True
+        scheduler = TradingScheduler()
+        scheduler._active_simulation_run_id = "sim-run-1"
+        scheduler.state.last_error = "stale_error"
+        scheduler.state.last_ingest_reason = "no_signals_in_window"
+        scheduler.state.last_signal_continuity_state = "actionable_source_fault"
+        scheduler.state.last_signal_continuity_reason = "no_signals_in_window"
+        scheduler.state.last_signal_continuity_actionable = True
+        scheduler.state.signal_continuity_alert_active = True
+        scheduler.state.signal_continuity_alert_reason = "no_signals_in_window"
+        scheduler.state.signal_continuity_alert_started_at = datetime.now(timezone.utc)
+        scheduler.state.signal_continuity_alert_last_seen_at = datetime.now(timezone.utc)
+        scheduler.state.signal_continuity_recovery_streak = 2
+        scheduler.state.autonomy_no_signal_streak = 4
+        scheduler.state.last_evidence_continuity_report = {"status": "stale"}
+        scheduler.state.autonomy_failure_streak = 2
+        scheduler.state.universe_fail_safe_blocked = True
+        scheduler.state.universe_fail_safe_block_reason = "stale_block"
+        scheduler.state.emergency_stop_active = True
+        scheduler.state.emergency_stop_reason = "signal_staleness_streak_exceeded:no_signals_in_window:3"
+        scheduler.state.emergency_stop_triggered_at = datetime.now(timezone.utc)
+        scheduler.state.emergency_stop_resolved_at = datetime.now(timezone.utc)
+        scheduler.state.emergency_stop_recovery_streak = 1
+        scheduler.state.rollback_incident_evidence_path = "/tmp/stale-incident.json"
+        scheduler.state.metrics.no_signal_streak = 4
+        scheduler.state.metrics.no_signal_reason_streak = {"no_signals_in_window": 4}
+        scheduler.state.metrics.signal_lag_seconds = 91
+        scheduler.state.metrics.signal_continuity_actionable = 1
+        scheduler.state.metrics.record_signal_continuity_alert_state(
+            active=True,
+            recovery_streak=2,
+        )
+
+        with patch(
+            "app.trading.scheduler.runtime.active_simulation_runtime_context",
+            return_value={"run_id": "sim-run-2"},
+        ):
+            scheduler._sync_simulation_run_context()
+
+        self.assertEqual(scheduler._active_simulation_run_id, "sim-run-2")
+        self.assertIsNone(scheduler.state.last_error)
+        self.assertIsNone(scheduler.state.last_ingest_reason)
+        self.assertIsNone(scheduler.state.last_signal_continuity_state)
+        self.assertIsNone(scheduler.state.last_signal_continuity_reason)
+        self.assertIsNone(scheduler.state.last_signal_continuity_actionable)
+        self.assertFalse(scheduler.state.signal_continuity_alert_active)
+        self.assertIsNone(scheduler.state.signal_continuity_alert_reason)
+        self.assertIsNone(scheduler.state.signal_continuity_alert_started_at)
+        self.assertIsNone(scheduler.state.signal_continuity_alert_last_seen_at)
+        self.assertEqual(scheduler.state.signal_continuity_recovery_streak, 0)
+        self.assertEqual(scheduler.state.autonomy_no_signal_streak, 0)
+        self.assertIsNone(scheduler.state.last_evidence_continuity_report)
+        self.assertEqual(scheduler.state.autonomy_failure_streak, 0)
+        self.assertFalse(scheduler.state.universe_fail_safe_blocked)
+        self.assertIsNone(scheduler.state.universe_fail_safe_block_reason)
+        self.assertFalse(scheduler.state.emergency_stop_active)
+        self.assertIsNone(scheduler.state.emergency_stop_reason)
+        self.assertIsNone(scheduler.state.emergency_stop_triggered_at)
+        self.assertIsNone(scheduler.state.emergency_stop_resolved_at)
+        self.assertEqual(scheduler.state.emergency_stop_recovery_streak, 0)
+        self.assertIsNone(scheduler.state.rollback_incident_evidence_path)
+        self.assertEqual(scheduler.state.metrics.no_signal_streak, 0)
+        self.assertEqual(scheduler.state.metrics.no_signal_reason_streak, {})
+        self.assertIsNone(scheduler.state.metrics.signal_lag_seconds)
+        self.assertEqual(scheduler.state.metrics.signal_continuity_actionable, 0)
+        self.assertEqual(scheduler.state.metrics.signal_continuity_alert_active, 0)
+        self.assertEqual(scheduler.state.metrics.signal_continuity_alert_recovery_streak, 0)
 
     def test_emergency_stop_triggers_on_signal_lag(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary

- make Jangar simulation cache keys and manifest digests stable across equivalent manifest key orderings so warm runs resolve the intended cache entry
- force a TA deployment restart for every warm-lane simulation apply, even when the baseline config already matches, so replayed windows do not reuse stale TA state
- reset Torghut run-scoped simulation safety state when the active simulation run id changes so failed warm attempts cannot poison the next replay

## Related Issues

None

## Testing

- `cd services/jangar && bunx vitest run --config vitest.config.ts src/server/__tests__/torghut-simulation-control-plane.test.ts`
- `cd services/torghut && uv run --frozen pytest tests/test_start_historical_simulation.py tests/test_trading_scheduler_safety.py -q`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen ruff check app tests scripts`
- `bun run --filter @proompteng/jangar tsc`
- `bun run --filter @proompteng/jangar build`
- `bunx oxfmt --check services/jangar/src/server/torghut-simulation-control-plane.ts services/jangar/src/server/__tests__/torghut-simulation-control-plane.test.ts`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
