### PR TITLE
chore(jangar): promote image fe748f88

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 7e4c8c6b
-  digest: sha256:899b6167780961540d4faf53ee7e561c9e01672929979aabefa09d6619c61aac
+  tag: fe748f88
+  digest: sha256:82ca57123a34386aa70cd57be9d1e907c20318f826b7483cbb101103a9f0d163
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 7e4c8c6b
-    digest: sha256:ea302485e0e9fe4530b129f11e05ee64ccfc6c1aeee4cf993323bb28b8ff6986
+    tag: fe748f88
+    digest: sha256:d60128da326cd4cde489411e06e559161f45c7205571b75f351f44bf753b4d0b
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 7e4c8c6b
-    digest: sha256:899b6167780961540d4faf53ee7e561c9e01672929979aabefa09d6619c61aac
+    tag: fe748f88
+    digest: sha256:82ca57123a34386aa70cd57be9d1e907c20318f826b7483cbb101103a9f0d163
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-14T19:44:29Z"
+    deploy.knative.dev/rollout: "2026-03-14T20:41:37Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-14T19:44:29Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-14T20:41:37Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -62,5 +62,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "7e4c8c6b"
-    digest: sha256:899b6167780961540d4faf53ee7e561c9e01672929979aabefa09d6619c61aac
+    newTag: "fe748f88"
+    digest: sha256:82ca57123a34386aa70cd57be9d1e907c20318f826b7483cbb101103a9f0d163


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `fe748f88b8d764257a5d89b34ea9e9d51fb15969`
- Image tag: `fe748f88`
- Image digest: `sha256:82ca57123a34386aa70cd57be9d1e907c20318f826b7483cbb101103a9f0d163`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`