### PR TITLE
chore(symphony): promote image 6cd9ecf

### DIFF
--- a/argocd/applications/symphony/deployment.yaml
+++ b/argocd/applications/symphony/deployment.yaml
@@ -22,7 +22,7 @@ spec:
         app.kubernetes.io/name: symphony
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-14T08:46:14.333Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-15T00:12:15.975Z"
     spec:
       serviceAccountName: symphony
       containers:

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -18,5 +18,5 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "25909fe11-linearfix-20260314014602"
-    digest: sha256:639b7ff7b4759b72a0ef37c0fded552fc1862f57b03e9dc6c581584150cb05fa
+    newTag: "sha-6cd9ecf"
+    digest: sha256:5133413281bd516b3f45074057e02779901cfec457ce59d3e3a47bc9dded0416


### PR DESCRIPTION
## Summary

- update the Symphony GitOps manifest to the image built from main commit `6cd9ecfd69ad74b4887bfd145b0aadb8e8e1ce48`
- pin Argo to immutable digest `sha256:5133413281bd516b3f45074057e02779901cfec457ce59d3e3a47bc9dded0416`
- bump the deployment restart annotation so the rollout is explicit in the manifest history

## Related Issues

None

## Testing

- `scripts/kubeconform.sh argocd/applications/symphony`
- `docker buildx imagetools inspect registry.ide-newton.ts.net/lab/symphony:sha-6cd9ecf --format '{{json .Manifest}}'`
- `gh run view 23099361873 -R proompteng/lab --job 67097213479 --log | rg -n "registry.ide-newton.ts.net/lab/symphony|digest|sha-"`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
