### PR TITLE
fix(symphony): format lease timestamps for kubernetes

### DIFF
--- a/services/symphony/src/leader-election.test.ts
+++ b/services/symphony/src/leader-election.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, test } from 'bun:test'
+
+import { formatKubernetesMicroTime } from './leader-election'
+
+describe('leader election lease timestamp formatting', () => {
+  test('formats Kubernetes MicroTime values with six fractional digits', () => {
+    expect(formatKubernetesMicroTime(new Date('2026-03-15T00:16:00.123Z'))).toBe('2026-03-15T00:16:00.123000Z')
+    expect(formatKubernetesMicroTime(new Date('2026-03-15T00:16:00.000Z'))).toBe('2026-03-15T00:16:00.000000Z')
+  })
+})

--- a/services/symphony/src/leader-election.ts
+++ b/services/symphony/src/leader-election.ts
@@ -73,6 +73,17 @@ const parseIntegerEnv = (value: string | undefined, fallback: number, min: numbe
 
 const nowIso = () => new Date().toISOString()
 
+export const formatKubernetesMicroTime = (date: Date): string => {
+  const iso = date.toISOString()
+  const [secondsPart, fractionalPartWithSuffix] = iso.split('.')
+  if (!secondsPart || !fractionalPartWithSuffix) return iso
+
+  const milliseconds = fractionalPartWithSuffix.replace('Z', '')
+  return `${secondsPart}.${milliseconds.padEnd(6, '0')}Z`
+}
+
+const nowKubernetesMicroTime = () => formatKubernetesMicroTime(new Date())
+
 const safeString = (value: unknown): string => {
   if (value === null || value === undefined) return ''
   if (typeof value === 'string') return value
@@ -111,8 +122,8 @@ const buildLease = (config: LeaderElectionConfig, identity: string): KubernetesL
   spec: {
     holderIdentity: identity,
     leaseDurationSeconds: config.leaseDurationSeconds,
-    acquireTime: nowIso(),
-    renewTime: nowIso(),
+    acquireTime: nowKubernetesMicroTime(),
+    renewTime: nowKubernetesMicroTime(),
     leaseTransitions: 0,
   },
 })
@@ -134,8 +145,8 @@ const updateLease = (current: KubernetesLease, config: LeaderElectionConfig, ide
       ...current.spec,
       holderIdentity: identity,
       leaseDurationSeconds: config.leaseDurationSeconds,
-      acquireTime: current.spec?.acquireTime ?? nowIso(),
-      renewTime: nowIso(),
+      acquireTime: current.spec?.acquireTime ?? nowKubernetesMicroTime(),
+      renewTime: nowKubernetesMicroTime(),
       leaseTransitions:
         previousHolder.length === 0 || previousHolder === identity ? currentTransitions : currentTransitions + 1,
     },
@@ -153,7 +164,7 @@ const clearLeaseHolder = (current: KubernetesLease, config: LeaderElectionConfig
     ...current.spec,
     holderIdentity: '',
     leaseDurationSeconds: config.leaseDurationSeconds,
-    renewTime: nowIso(),
+    renewTime: nowKubernetesMicroTime(),
   },
 })
 


### PR DESCRIPTION
## Summary

- format Kubernetes Lease `acquireTime` and `renewTime` values as microsecond timestamps accepted by the coordination API
- keep Symphony status timestamps unchanged while fixing only the leader-election lease payload
- add a regression test covering the lease timestamp formatter used by the leader-election client

## Related Issues

None

## Testing

- `bun test services/symphony/src/leader-election.test.ts`
- `bun run --cwd services/symphony tsc`
- `bun run --cwd services/symphony test`
- `bun run --cwd services/symphony lint`
- `bun run --cwd services/symphony lint:oxlint:type`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
