### PR TITLE
chore(symphony): promote image b3511a1

### DIFF
--- a/argocd/applications/symphony/deployment.yaml
+++ b/argocd/applications/symphony/deployment.yaml
@@ -22,7 +22,7 @@ spec:
         app.kubernetes.io/name: symphony
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-15T00:12:15.975Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-15T00:22:33.983Z"
     spec:
       serviceAccountName: symphony
       containers:

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -18,5 +18,5 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "sha-6cd9ecf"
-    digest: sha256:5133413281bd516b3f45074057e02779901cfec457ce59d3e3a47bc9dded0416
+    newTag: "sha-b3511a1"
+    digest: sha256:53218facc729108e2ca8d515d08f9c364886487c5335f2771d9fabfa2b3df590


### PR DESCRIPTION
## Summary

- promote Symphony Argo manifests to the `sha-b3511a1` image built from the leader-election lease timestamp fix
- pin the deployment to digest `sha256:53218facc729108e2ca8d515d08f9c364886487c5335f2771d9fabfa2b3df590`
- update the rollout annotation so Argo forces the new pod replacement

## Related Issues

None

## Testing

- `scripts/kubeconform.sh argocd/applications/symphony`
- `docker buildx imagetools inspect registry.ide-newton.ts.net/lab/symphony:sha-b3511a1 --format '{{json .Manifest}}'`
- `gh run view 23099531127 -R proompteng/lab --job 67097694306 --log | rg -n "registry.ide-newton.ts.net/lab/symphony|sha-b3511a1|sha256:53218facc729108e2ca8d515d08f9c364886487c5335f2771d9fabfa2b3df590"`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
