### PR TITLE
chore(symphony): promote image 0e89c49f

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-14T22:00:00.000Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-15T01:37:56Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -24,5 +24,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "sha-b3511a1"
-    digest: sha256:53218facc729108e2ca8d515d08f9c364886487c5335f2771d9fabfa2b3df590
+    newTag: "0e89c49f"
+    digest: sha256:64ce115e9a4c24bb0ec7a7d16a1850857f35acb61843ff07c0adcd29029a7595

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-14T22:00:00.000Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-15T01:37:56Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -26,5 +26,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "sha-b3511a1"
-    digest: sha256:53218facc729108e2ca8d515d08f9c364886487c5335f2771d9fabfa2b3df590
+    newTag: "0e89c49f"
+    digest: sha256:64ce115e9a4c24bb0ec7a7d16a1850857f35acb61843ff07c0adcd29029a7595

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,4 +6,4 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-14T22:00:00.000Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-15T01:37:56Z"

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -17,5 +17,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "sha-b3511a1"
-    digest: sha256:53218facc729108e2ca8d515d08f9c364886487c5335f2771d9fabfa2b3df590
+    newTag: "0e89c49f"
+    digest: sha256:64ce115e9a4c24bb0ec7a7d16a1850857f35acb61843ff07c0adcd29029a7595


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `0e89c49f33538694ae253a769dbc5694fcbc27c3`
- Image tag: `0e89c49f`
- Image digest: `sha256:64ce115e9a4c24bb0ec7a7d16a1850857f35acb61843ff07c0adcd29029a7595`