### PR TITLE
fix(headlamp): deploy patched websocket image

### DIFF
--- a/argocd/applications/headlamp/values.yaml
+++ b/argocd/applications/headlamp/values.yaml
@@ -5,7 +5,7 @@ deploymentAnnotations:
 image:
   registry: registry.ide-newton.ts.net
   repository: lab/headlamp@sha256
-  tag: b98127a560afe1d19a6022fd0179b4f0655550be0848ced41541c07245819188
+  tag: 6a9bc2112e8de09a9ded297a7d321f202aaf5184b3761ec7ac35d9d3b39d0634
 persistentVolumeClaim:
   enabled: false
 podSecurityContext:

--- a/services/headlamp/Dockerfile
+++ b/services/headlamp/Dockerfile
@@ -34,14 +34,15 @@ ENV GOPATH=/go \
 
 COPY --from=source /src/backend/go.* /headlamp/backend/
 COPY scripts /tools
-COPY patches /patches
+COPY patches /tools/patches
 
 RUN --mount=type=cache,target=/go/pkg/mod \
     cd ./backend && go mod download
 
 COPY --from=source /src/backend /headlamp/backend
 
-RUN sh /tools/apply-upstream-patches.sh /headlamp
+RUN sh /tools/apply-upstream-patches.sh /headlamp \
+    && grep -q 'handleHTTPWatchStream' /headlamp/backend/cmd/multiplexer.go
 
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \


### PR DESCRIPTION
## Summary

- fix the Headlamp image build so backend multiplexer patches are copied to the path the build script actually reads
- fail the Docker build if the HTTP watch-stream multiplexer patch is missing from `backend/cmd/multiplexer.go`
- update Headlamp GitOps values to deploy the corrected image digest `sha256:6a9bc2112e8de09a9ded297a7d321f202aaf5184b3761ec7ac35d9d3b39d0634`

## Related Issues

None

## Testing

- `sh services/headlamp/scripts/fetch-upstream.sh services/headlamp/.upstream`
- `sh services/headlamp/scripts/test-upstream.sh`
- `docker buildx build --platform linux/arm64 --load -t headlamp:test services/headlamp`
- `docker buildx build --platform linux/arm64 --push -t registry.ide-newton.ts.net/lab/headlamp:ws-http-20260314-2 services/headlamp`
- `docker buildx imagetools inspect registry.ide-newton.ts.net/lab/headlamp:ws-http-20260314-2`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/headlamp >/dev/null`
- `bun run lint:argocd`
- Manual: instrumented a real Headlamp browser session and confirmed the previous image still returned `/wsMultiplexer` `dialing WebSocket: websocket: bad handshake` status errors, which this PR fixes at the image-build layer

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
