### PR TITLE
chore(jangar): promote image 8d38a2ef

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: fe748f88
-  digest: sha256:82ca57123a34386aa70cd57be9d1e907c20318f826b7483cbb101103a9f0d163
+  tag: 8d38a2ef
+  digest: sha256:01644ae7e385d68c70c5636bbaa34207cf07baa3e1d420d584185c5971820688
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: fe748f88
-    digest: sha256:d60128da326cd4cde489411e06e559161f45c7205571b75f351f44bf753b4d0b
+    tag: 8d38a2ef
+    digest: sha256:2dfa9711906eb6da6b46e6497b94630315ade739a7ff846b34936ae4215f3352
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: fe748f88
-    digest: sha256:82ca57123a34386aa70cd57be9d1e907c20318f826b7483cbb101103a9f0d163
+    tag: 8d38a2ef
+    digest: sha256:01644ae7e385d68c70c5636bbaa34207cf07baa3e1d420d584185c5971820688
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-14T20:41:37Z"
+    deploy.knative.dev/rollout: "2026-03-15T01:52:56Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-14T20:41:37Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-15T01:52:56Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -62,5 +62,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "fe748f88"
-    digest: sha256:82ca57123a34386aa70cd57be9d1e907c20318f826b7483cbb101103a9f0d163
+    newTag: "8d38a2ef"
+    digest: sha256:01644ae7e385d68c70c5636bbaa34207cf07baa3e1d420d584185c5971820688


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `8d38a2efeb3157bab86c383ff8098f5bcc1cc1a7`
- Image tag: `8d38a2ef`
- Image digest: `sha256:01644ae7e385d68c70c5636bbaa34207cf07baa3e1d420d584185c5971820688`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`