### PR TITLE
chore(torghut): promote image f14e43a7

### DIFF
--- a/argocd/applications/torghut-forecast/deployment.yaml
+++ b/argocd/applications/torghut-forecast/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: forecast
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:0f50f32d3aca84ee529c5904d43f6627ac07b4592f4c3f78788f7f075b041e9e
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:129ad8f8ab120f83d2dd94649c34b6a79862c11e587204015a784358472b7237
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn

--- a/argocd/applications/torghut-forecast/sim/deployment.yaml
+++ b/argocd/applications/torghut-forecast/sim/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: forecast
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:0f50f32d3aca84ee529c5904d43f6627ac07b4592f4c3f78788f7f075b041e9e
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:129ad8f8ab120f83d2dd94649c34b6a79862c11e587204015a784358472b7237
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn

--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:0f50f32d3aca84ee529c5904d43f6627ac07b4592f4c3f78788f7f075b041e9e
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:129ad8f8ab120f83d2dd94649c34b6a79862c11e587204015a784358472b7237
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -63,9 +63,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.564.0-156-g8d38a2ef
+              value: v0.564.0-163-gf14e43a7
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 8d38a2efeb3157bab86c383ff8098f5bcc1cc1a7
+              value: f14e43a7b2004d3febd317a6ef47aea08fea7a44
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:0f50f32d3aca84ee529c5904d43f6627ac07b4592f4c3f78788f7f075b041e9e
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:129ad8f8ab120f83d2dd94649c34b6a79862c11e587204015a784358472b7237
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -63,9 +63,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.564.0-156-g8d38a2ef
+              value: v0.564.0-163-gf14e43a7
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 8d38a2efeb3157bab86c383ff8098f5bcc1cc1a7
+              value: f14e43a7b2004d3febd317a6ef47aea08fea7a44
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -40,7 +40,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:0f50f32d3aca84ee529c5904d43f6627ac07b4592f4c3f78788f7f075b041e9e
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:129ad8f8ab120f83d2dd94649c34b6a79862c11e587204015a784358472b7237
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -21,7 +21,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:0f50f32d3aca84ee529c5904d43f6627ac07b4592f4c3f78788f7f075b041e9e
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:129ad8f8ab120f83d2dd94649c34b6a79862c11e587204015a784358472b7237
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -32,7 +32,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:0f50f32d3aca84ee529c5904d43f6627ac07b4592f4c3f78788f7f075b041e9e
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:129ad8f8ab120f83d2dd94649c34b6a79862c11e587204015a784358472b7237
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -30,7 +30,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:0f50f32d3aca84ee529c5904d43f6627ac07b4592f4c3f78788f7f075b041e9e
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:129ad8f8ab120f83d2dd94649c34b6a79862c11e587204015a784358472b7237
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:0f50f32d3aca84ee529c5904d43f6627ac07b4592f4c3f78788f7f075b041e9e
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:129ad8f8ab120f83d2dd94649c34b6a79862c11e587204015a784358472b7237
           command:
             - alembic
           args:

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -13,7 +13,7 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:0f50f32d3aca84ee529c5904d43f6627ac07b4592f4c3f78788f7f075b041e9e
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:129ad8f8ab120f83d2dd94649c34b6a79862c11e587204015a784358472b7237
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -21,7 +21,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:0f50f32d3aca84ee529c5904d43f6627ac07b4592f4c3f78788f7f075b041e9e
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:129ad8f8ab120f83d2dd94649c34b6a79862c11e587204015a784358472b7237
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -39,7 +39,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:0f50f32d3aca84ee529c5904d43f6627ac07b4592f4c3f78788f7f075b041e9e
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:129ad8f8ab120f83d2dd94649c34b6a79862c11e587204015a784358472b7237
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-03-15T01:46:04Z"
+        client.knative.dev/updateTimestamp: "2026-03-15T02:39:41Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:0f50f32d3aca84ee529c5904d43f6627ac07b4592f4c3f78788f7f075b041e9e
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:129ad8f8ab120f83d2dd94649c34b6a79862c11e587204015a784358472b7237
           ports:
             - name: http1
               containerPort: 8181
@@ -519,9 +519,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.564.0-156-g8d38a2ef
+              value: v0.564.0-163-gf14e43a7
             - name: TORGHUT_COMMIT
-              value: 8d38a2efeb3157bab86c383ff8098f5bcc1cc1a7
+              value: f14e43a7b2004d3febd317a6ef47aea08fea7a44
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-03-15T01:46:04Z"
+        client.knative.dev/updateTimestamp: "2026-03-15T02:39:41Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -26,7 +26,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:0f50f32d3aca84ee529c5904d43f6627ac07b4592f4c3f78788f7f075b041e9e
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:129ad8f8ab120f83d2dd94649c34b6a79862c11e587204015a784358472b7237
           ports:
             - name: http1
               containerPort: 8181
@@ -462,9 +462,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.564.0-156-g8d38a2ef
+              value: v0.564.0-163-gf14e43a7
             - name: TORGHUT_COMMIT
-              value: 8d38a2efeb3157bab86c383ff8098f5bcc1cc1a7
+              value: f14e43a7b2004d3febd317a6ef47aea08fea7a44
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/lean-runner-deployment.yaml
+++ b/argocd/applications/torghut/lean-runner-deployment.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: lean-runner
           # Keep in lockstep with `argocd/applications/torghut/knative-service.yaml`.
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:0f50f32d3aca84ee529c5904d43f6627ac07b4592f4c3f78788f7f075b041e9e
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:129ad8f8ab120f83d2dd94649c34b6a79862c11e587204015a784358472b7237
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `f14e43a7b2004d3febd317a6ef47aea08fea7a44`
- Image tag: `f14e43a7`
- Image digest: `sha256:129ad8f8ab120f83d2dd94649c34b6a79862c11e587204015a784358472b7237`