### PR TITLE
fix(symphony): sync self pvc manifest with live claim

### DIFF
--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
   - target-argocd-rolebinding.yaml
 patches:
   - path: deployment.patch.yaml
+  - path: pvc.patch.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony

--- a/argocd/applications/symphony/pvc.patch.yaml
+++ b/argocd/applications/symphony/pvc.patch.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: symphony-workspace
+spec:
+  storageClassName: rook-ceph-block
+  resources:
+    requests:
+      storage: 50Gi


### PR DESCRIPTION
## Summary

- add a self-app-only PVC overlay patch for `argocd/applications/symphony`
- align the rendered `symphony-workspace` claim with the live immutable PVC fields (`rook-ceph-block`, `50Gi`)
- clear the last Argo drift on the `symphony` fleet app without changing Jangar or Torghut PVC sizing

## Related Issues

None

## Testing

- `kubectl kustomize argocd/applications/symphony | sed -n '/kind: PersistentVolumeClaim/,+18p'`
- `scripts/kubeconform.sh argocd/applications/symphony`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
