### PR TITLE
fix(torghut): restore simulation migration access

### DIFF
--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
           imagePullPolicy: IfNotPresent
           image: registry.ide-newton.ts.net/lab/torghut@sha256:129ad8f8ab120f83d2dd94649c34b6a79862c11e587204015a784358472b7237
           command:
-            - alembic
+            - /opt/venv/bin/alembic
           args:
             - -c
             - /app/alembic.ini

--- a/services/torghut/scripts/start_historical_simulation.py
+++ b/services/torghut/scripts/start_historical_simulation.py
@@ -3462,6 +3462,7 @@ def _ensure_postgres_database(config: PostgresRuntimeConfig) -> None:
 
 def _ensure_postgres_runtime_permissions(config: PostgresRuntimeConfig) -> dict[str, Any]:
     simulation_role = _username_from_dsn(config.torghut_runtime_dsn) or _username_from_dsn(config.simulation_dsn)
+    admin_role = _username_from_dsn(config.admin_dsn)
     admin_simulation_dsn = _replace_database_in_dsn(
         config.admin_dsn,
         database=config.simulation_db,
@@ -3470,6 +3471,7 @@ def _ensure_postgres_runtime_permissions(config: PostgresRuntimeConfig) -> dict[
 
     def _ensure() -> dict[str, Any]:
         grants_applied = False
+        default_privileges_applied = False
         with psycopg.connect(config.admin_dsn, autocommit=True) as conn:
             with conn.cursor() as cursor:
                 if simulation_role:
@@ -3516,10 +3518,70 @@ def _ensure_postgres_runtime_permissions(config: PostgresRuntimeConfig) -> dict[
                             sql.Identifier(simulation_role),
                         )
                     )
+                    cursor.execute(
+                        sql.SQL('GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA public TO {}').format(
+                            sql.Identifier(simulation_role),
+                        )
+                    )
+                    if admin_role:
+                        cursor.execute(
+                            sql.SQL(
+                                'ALTER DEFAULT PRIVILEGES FOR ROLE {} IN SCHEMA public '
+                                'GRANT ALL PRIVILEGES ON TABLES TO {}'
+                            ).format(
+                                sql.Identifier(admin_role),
+                                sql.Identifier(simulation_role),
+                            )
+                        )
+                        cursor.execute(
+                            sql.SQL(
+                                'ALTER DEFAULT PRIVILEGES FOR ROLE {} IN SCHEMA public '
+                                'GRANT ALL PRIVILEGES ON SEQUENCES TO {}'
+                            ).format(
+                                sql.Identifier(admin_role),
+                                sql.Identifier(simulation_role),
+                            )
+                        )
+                        cursor.execute(
+                            sql.SQL(
+                                'ALTER DEFAULT PRIVILEGES FOR ROLE {} IN SCHEMA public '
+                                'GRANT EXECUTE ON FUNCTIONS TO {}'
+                            ).format(
+                                sql.Identifier(admin_role),
+                                sql.Identifier(simulation_role),
+                            )
+                        )
+                    else:
+                        cursor.execute(
+                            sql.SQL(
+                                'ALTER DEFAULT PRIVILEGES IN SCHEMA public '
+                                'GRANT ALL PRIVILEGES ON TABLES TO {}'
+                            ).format(
+                                sql.Identifier(simulation_role),
+                            )
+                        )
+                        cursor.execute(
+                            sql.SQL(
+                                'ALTER DEFAULT PRIVILEGES IN SCHEMA public '
+                                'GRANT ALL PRIVILEGES ON SEQUENCES TO {}'
+                            ).format(
+                                sql.Identifier(simulation_role),
+                            )
+                        )
+                        cursor.execute(
+                            sql.SQL(
+                                'ALTER DEFAULT PRIVILEGES IN SCHEMA public '
+                                'GRANT EXECUTE ON FUNCTIONS TO {}'
+                            ).format(
+                                sql.Identifier(simulation_role),
+                            )
+                        )
                     grants_applied = True
+                    default_privileges_applied = True
         return {
             'simulation_role': simulation_role,
             'grants_applied': grants_applied,
+            'default_privileges_applied': default_privileges_applied,
             'vector_extension_checked': has_vector_extension,
         }
 
@@ -5410,8 +5472,10 @@ def _apply(
         postgres_database_precreated = _postgres_database_precreated(manifest)
         if not postgres_database_precreated:
             _ensure_postgres_database(postgres_config)
-        postgres_permissions_report = _ensure_postgres_runtime_permissions(postgres_config)
+        _ensure_postgres_runtime_permissions(postgres_config)
         _run_migrations(postgres_config)
+        # Alembic runs under the admin role, so newly created objects must be re-granted to the runtime role.
+        postgres_permissions_report = _ensure_postgres_runtime_permissions(postgres_config)
         _reset_postgres_runtime_state(postgres_config)
         seeded_cursor_at = _seed_simulation_trade_cursor(
             config=postgres_config,

--- a/services/torghut/tests/test_start_historical_simulation.py
+++ b/services/torghut/tests/test_start_historical_simulation.py
@@ -735,6 +735,100 @@ class TestStartHistoricalSimulation(TestCase):
             ['postgresql://postgres:admin-secret@localhost:5432/torghut_sim_sim_1'],
         )
 
+    def test_ensure_postgres_runtime_permissions_sets_default_privileges_for_migrated_objects(self) -> None:
+        config = PostgresRuntimeConfig(
+            admin_dsn='postgresql://postgres:admin-secret@localhost:5432/postgres',
+            simulation_dsn='postgresql://torghut_app:secret@localhost:5432/torghut_sim_sim_1',
+            simulation_db='torghut_sim_sim_1',
+            migrations_command='/opt/venv/bin/alembic upgrade heads',
+        )
+        admin_statements: list[object] = []
+        simulation_statements: list[object] = []
+
+        class _FakeCursor:
+            def __init__(self, statements: list[object]) -> None:
+                self._statements = statements
+
+            def execute(self, statement: object, params: object | None = None) -> None:
+                _ = params
+                self._statements.append(statement)
+
+            def __enter__(self) -> _FakeCursor:
+                return self
+
+            def __exit__(self, exc_type, exc, tb) -> bool:
+                _ = (exc_type, exc, tb)
+                return False
+
+        class _FakeConnection:
+            def __init__(self, statements: list[object]) -> None:
+                self._statements = statements
+
+            def cursor(self) -> _FakeCursor:
+                return _FakeCursor(self._statements)
+
+            def __enter__(self) -> _FakeConnection:
+                return self
+
+            def __exit__(self, exc_type, exc, tb) -> bool:
+                _ = (exc_type, exc, tb)
+                return False
+
+        def _fake_connect(dsn: str, autocommit: bool = False) -> _FakeConnection:
+            self.assertTrue(autocommit)
+            if dsn == config.admin_dsn:
+                return _FakeConnection(admin_statements)
+            if dsn == config.admin_simulation_dsn:
+                return _FakeConnection(simulation_statements)
+            raise AssertionError(f'unexpected dsn: {dsn}')
+
+        def _fake_retry(*, label: str, operation: object, attempts: int = 8, sleep_seconds: float = 0.5) -> Any:
+            _ = (label, attempts, sleep_seconds)
+            return operation()
+
+        with (
+            patch('scripts.start_historical_simulation.psycopg.connect', side_effect=_fake_connect),
+            patch(
+                'scripts.start_historical_simulation._run_with_transient_postgres_retry',
+                side_effect=_fake_retry,
+            ),
+            patch(
+                'scripts.start_historical_simulation._postgres_extension_exists',
+                return_value=True,
+            ),
+        ):
+            report = start_historical_simulation._ensure_postgres_runtime_permissions(config)
+
+        rendered_admin = [repr(statement) for statement in admin_statements]
+        rendered_simulation = [repr(statement) for statement in simulation_statements]
+
+        self.assertEqual(report['simulation_role'], 'torghut_app')
+        self.assertTrue(report['grants_applied'])
+        self.assertTrue(report['default_privileges_applied'])
+        self.assertTrue(
+            any(
+                'GRANT ALL PRIVILEGES ON DATABASE ' in statement
+                and "Identifier('torghut_sim_sim_1')" in statement
+                and "Identifier('torghut_app')" in statement
+                for statement in rendered_admin
+            ),
+            rendered_admin,
+        )
+        self.assertTrue(
+            any('GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO ' in statement for statement in rendered_simulation),
+            rendered_simulation,
+        )
+        self.assertTrue(
+            any(
+                'ALTER DEFAULT PRIVILEGES FOR ROLE ' in statement
+                and 'GRANT ALL PRIVILEGES ON TABLES TO ' in statement
+                and "Identifier('postgres')" in statement
+                and "Identifier('torghut_app')" in statement
+                for statement in rendered_simulation
+            ),
+            rendered_simulation,
+        )
+
     def test_assert_required_simulation_metadata_tables_raises_when_missing(self) -> None:
         config = PostgresRuntimeConfig(
             admin_dsn='postgresql://postgres:admin-secret@localhost:5432/postgres',
@@ -1797,7 +1891,7 @@ class TestStartHistoricalSimulation(TestCase):
                     force_replay=False,
                 )
 
-        ensure_permissions.assert_called_once_with(runtime_config)
+        self.assertEqual(ensure_permissions.call_args_list, [call(runtime_config), call(runtime_config)])
         run_migrations.assert_called_once_with(runtime_config)
         reset_runtime_state.assert_called_once_with(runtime_config)
 


### PR DESCRIPTION
## Summary

- fix isolated Torghut simulation databases so admin-run Alembic migrations leave runtime-visible table, sequence, and function privileges behind for `torghut_app`
- re-apply runtime grants after migrations so freshly created simulation metadata tables are immediately writable during the same proof run
- fix the Torghut Argo DB migration hook to call `/opt/venv/bin/alembic`, matching the production image layout used in cluster

## Related Issues

None

## Testing

- `uv run --frozen python -m unittest tests.test_start_historical_simulation`
- `uv run --frozen ruff check scripts/start_historical_simulation.py tests/test_start_historical_simulation.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `mise exec helm@3 -- kustomize build argocd/applications/torghut >/tmp/torghut-argocd-render.yaml && wc -l /tmp/torghut-argocd-render.yaml`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
