### PR TITLE
fix(headlamp): recover oidc sessions after cache loss

### DIFF
--- a/.github/workflows/headlamp-ci.yml
+++ b/.github/workflows/headlamp-ci.yml
@@ -67,6 +67,20 @@ jobs:
             golang:1.24.13@sha256:d2d2bc1c84f7e60d7d2438a3836ae7d0c847f4888464e7ec9ba3a1339a1ee804 \
             sh services/headlamp/scripts/test-upstream.sh
 
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Run Upstream Frontend Auth Regression Test
+        run: |
+          TMP_DIR="$(mktemp -d)"
+          sh services/headlamp/scripts/fetch-upstream.sh "${TMP_DIR}"
+          sh services/headlamp/scripts/apply-upstream-patches.sh "${TMP_DIR}"
+          cd "${TMP_DIR}/frontend"
+          npm ci
+          npm test -- --run src/lib/k8s/api/authError.test.ts
+
       - name: Fetch pinned Headlamp upstream source
         run: sh services/headlamp/scripts/fetch-upstream.sh services/headlamp/.upstream
 

--- a/argocd/applications/headlamp/values.yaml
+++ b/argocd/applications/headlamp/values.yaml
@@ -5,7 +5,7 @@ deploymentAnnotations:
 image:
   registry: registry.ide-newton.ts.net
   repository: lab/headlamp@sha256
-  tag: ca62d0b40a54a6e823db0ba3ce2bdceee1e1110a9846119cb0b00cc53decff8e
+  tag: e0ae7eab580410ad5b189b1fde26fd9d2cdc038269c3ed85cadfbbc7e365bb55
 persistentVolumeClaim:
   enabled: false
 podSecurityContext:

--- a/services/headlamp/Dockerfile
+++ b/services/headlamp/Dockerfile
@@ -40,6 +40,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     cd ./backend && go mod download
 
 COPY --from=source /src/backend /headlamp/backend
+COPY --from=source /src/frontend /headlamp/frontend
 
 RUN sh /tools/apply-upstream-patches.sh /headlamp \
     && grep -q 'handleHTTPWatchStream' /headlamp/backend/cmd/multiplexer.go
@@ -55,6 +56,8 @@ WORKDIR /headlamp
 COPY --from=source /src/.git /headlamp/.git
 COPY --from=source /src/app/package.json /headlamp/app/package.json
 COPY --from=source /src/frontend/package*.json /headlamp/frontend/
+COPY scripts /tools
+COPY patches /tools/patches
 
 RUN cd ./frontend && npm ci --only=prod
 
@@ -62,7 +65,10 @@ FROM frontend-build AS frontend
 
 ENV REACT_APP_ENABLE_WEBSOCKET_MULTIPLEXER=true
 
+COPY --from=source /src/backend /headlamp/backend
 COPY --from=source /src/frontend /headlamp/frontend
+
+RUN sh /tools/apply-upstream-patches.sh /headlamp
 
 RUN cd ./frontend && npm run build
 

--- a/services/headlamp/patches/0003-oidc-refresh-reauth.patch
+++ b/services/headlamp/patches/0003-oidc-refresh-reauth.patch
@@ -1,0 +1,705 @@
+diff --git a/backend/cmd/headlamp.go b/backend/cmd/headlamp.go
+index b428cc4dd..1483e882a 100644
+--- a/backend/cmd/headlamp.go
++++ b/backend/cmd/headlamp.go
+@@ -925,10 +925,14 @@ func createHeadlampHandler(config *HeadlampConfig) http.Handler {
+ 	return r
+ }
+ 
++type tokenRefreshResult struct {
++	reauthRequired bool
++}
++
+ func (c *HeadlampConfig) refreshAndSetToken(oidcAuthConfig *kubeconfig.OidcConfig,
+ 	cache cache.Cache[interface{}], token string,
+ 	w http.ResponseWriter, r *http.Request, cluster string, span trace.Span, ctx context.Context,
+-) {
++) tokenRefreshResult {
+ 	// The token type to use
+ 	tokenType := "id_token"
+ 	if c.oidcUseAccessToken {
+@@ -949,6 +953,16 @@ func (c *HeadlampConfig) refreshAndSetToken(oidcAuthConfig *kubeconfig.OidcConfi
+ 		idpIssuerURL,
+ 	)
+ 	if err != nil {
++		if errors.Is(err, auth.ErrRefreshTokenUnavailable) {
++			auth.ClearTokenCookie(w, r, cluster, c.BaseURL)
++			logger.Log(logger.LevelWarn, map[string]string{"cluster": cluster},
++				err, "cached refresh token unavailable; reauthentication required")
++			c.telemetryHandler.RecordEvent(span, "Cached refresh token unavailable; clearing auth cookie")
++			c.telemetryHandler.RecordErrorCount(ctx, attribute.String("error", "token_refresh_reauth_required"))
++
++			return tokenRefreshResult{reauthRequired: true}
++		}
++
+ 		logger.Log(logger.LevelError, map[string]string{"cluster": cluster},
+ 			err, "failed to refresh token")
+ 		c.telemetryHandler.RecordError(span, err, "Token refresh failed")
+@@ -966,6 +980,8 @@ func (c *HeadlampConfig) refreshAndSetToken(oidcAuthConfig *kubeconfig.OidcConfi
+ 
+ 		c.telemetryHandler.RecordEvent(span, "Token refreshed successfully")
+ 	}
++
++	return tokenRefreshResult{}
+ }
+ 
+ // setTokenFromCookie attempts to get a token from the cookie and set it as Authorization header.
+@@ -1105,7 +1121,15 @@ func (c *HeadlampConfig) OIDCTokenRefreshMiddleware(next http.Handler) http.Hand
+ 		}
+ 
+ 		// refresh and cache new token
+-		c.refreshAndSetToken(oidcAuthConfig, c.cache, token, w, r, cluster, span, ctx)
++		refreshResult := c.refreshAndSetToken(oidcAuthConfig, c.cache, token, w, r, cluster, span, ctx)
++		if refreshResult.reauthRequired {
++			http.Error(w, "Unauthorized", http.StatusUnauthorized)
++			c.telemetryHandler.RecordDuration(ctx, start,
++				attribute.String("api.route", "OIDCTokenRefreshMiddleware"),
++				attribute.String("status", "reauth_required"))
++
++			return
++		}
+ 
+ 		next.ServeHTTP(w, r)
+ 		c.telemetryHandler.RecordDuration(ctx, start,
+diff --git a/backend/cmd/headlamp_test.go b/backend/cmd/headlamp_test.go
+index c67563d74..637501f7b 100644
+--- a/backend/cmd/headlamp_test.go
++++ b/backend/cmd/headlamp_test.go
+@@ -38,6 +38,7 @@ import (
+ 
+ 	"github.com/google/uuid"
+ 	"github.com/gorilla/mux"
++	auth "github.com/kubernetes-sigs/headlamp/backend/pkg/auth"
+ 	"github.com/kubernetes-sigs/headlamp/backend/pkg/cache"
+ 	"github.com/kubernetes-sigs/headlamp/backend/pkg/config"
+ 	"github.com/kubernetes-sigs/headlamp/backend/pkg/headlampconfig"
+@@ -70,6 +71,17 @@ func makeJSONReq(method, url string, jsonObj interface{}) (*http.Request, error)
+ 	return http.NewRequestWithContext(context.Background(), method, url, bytes.NewBuffer(jsonBytes))
+ }
+ 
++func makeJWTWithExp(t *testing.T, exp time.Time) string {
++	t.Helper()
++
++	payloadBytes, err := json.Marshal(map[string]interface{}{"exp": float64(exp.Unix())})
++	if err != nil {
++		t.Fatalf("failed to marshal payload: %v", err)
++	}
++
++	return "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0." + base64.RawURLEncoding.EncodeToString(payloadBytes) + "."
++}
++
+ func getResponse(handler http.Handler, method, url string, body interface{}) (*httptest.ResponseRecorder, error) {
+ 	req, err := makeJSONReq(method, url, body)
+ 	if err != nil {
+@@ -975,6 +987,56 @@ func TestOIDCTokenRefreshMiddleware(t *testing.T) {
+ 	assert.Equal(t, http.StatusOK, rec.Code)
+ }
+ 
++func TestOIDCTokenRefreshMiddleware_MissingRefreshTokenRequiresReauth(t *testing.T) {
++	kubeConfigStore := kubeconfig.NewContextStore()
++	require.NoError(t, kubeConfigStore.AddContext(&kubeconfig.Context{
++		Name: "test-cluster",
++		OidcConf: &kubeconfig.OidcConfig{
++			ClientID:     "cid",
++			ClientSecret: "secret",
++			IdpIssuerURL: "https://issuer.example",
++		},
++	}))
++
++	config := &HeadlampConfig{
++		HeadlampCFG: &headlampconfig.HeadlampCFG{
++			KubeConfigStore: kubeConfigStore,
++		},
++		cache:              cache.New[interface{}](),
++		oidcUseAccessToken: true,
++		telemetryHandler:   &telemetry.RequestHandler{},
++	}
++
++	handlerCalled := false
++	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
++		handlerCalled = true
++		w.WriteHeader(http.StatusOK)
++	})
++
++	req := httptest.NewRequest("GET", "/clusters/test-cluster/api/v1/namespaces", nil)
++	req.AddCookie(&http.Cookie{
++		Name:  "headlamp-auth-test-cluster.0",
++		Value: makeJWTWithExp(t, time.Now().Add(auth.JWTExpirationTTL/2)),
++	})
++	rec := httptest.NewRecorder()
++
++	config.OIDCTokenRefreshMiddleware(handler).ServeHTTP(rec, req)
++
++	assert.Equal(t, http.StatusUnauthorized, rec.Code)
++	assert.False(t, handlerCalled)
++
++	var clearedCookie *http.Cookie
++	for _, cookie := range rec.Result().Cookies() {
++		if cookie.Name == "headlamp-auth-test-cluster.0" && cookie.Path == "/clusters/test-cluster" {
++			clearedCookie = cookie
++			break
++		}
++	}
++
++	require.NotNil(t, clearedCookie)
++	assert.Equal(t, -1, clearedCookie.MaxAge)
++}
++
+ func TestStartHeadlampServer(t *testing.T) {
+ 	// Create a temporary directory for plugins
+ 	tempDir, err := os.MkdirTemp("", "headlamp-test")
+diff --git a/backend/pkg/auth/auth.go b/backend/pkg/auth/auth.go
+index 0c4689a6f..dc1e83fbe 100644
+--- a/backend/pkg/auth/auth.go
++++ b/backend/pkg/auth/auth.go
+@@ -46,6 +46,8 @@ const (
+ 
+ const JWTExpirationTTL = 10 * time.Second // seconds
+ 
++var ErrRefreshTokenUnavailable = errors.New("refresh token unavailable")
++
+ // DecodeBase64JSON decodes a base64 URL-encoded JSON string into a map.
+ func DecodeBase64JSON(base64JSON string) (map[string]interface{}, error) {
+ 	payloadBytes, err := base64.RawURLEncoding.DecodeString(base64JSON)
+@@ -68,6 +70,28 @@ var clusterPathRegex = regexp.MustCompile(`^/clusters/([^/]+)/.*`)
+ // https://datatracker.ietf.org/doc/html/rfc6750#section-2.1
+ var bearerTokenRegex = regexp.MustCompile(`^[\x21-\x7E]+$`)
+ 
++func getCachedRefreshToken(ctx context.Context, tokenCache cache.Cache[interface{}], token string) (string, error) {
++	refreshToken, err := tokenCache.Get(ctx, oidcKeyPrefix+token)
++	if err != nil {
++		if errors.Is(err, cache.ErrNotFound) {
++			return "", ErrRefreshTokenUnavailable
++		}
++
++		return "", fmt.Errorf("getting refresh token: %w", err)
++	}
++
++	rToken, ok := refreshToken.(string)
++	if !ok {
++		return "", fmt.Errorf("failed to get refresh token")
++	}
++
++	if strings.TrimSpace(rToken) == "" {
++		return "", ErrRefreshTokenUnavailable
++	}
++
++	return rToken, nil
++}
++
+ // ParseClusterAndToken extracts the cluster name from the URL path and
+ // the Bearer token from the Authorization header of the HTTP request, falling
+ // back to the cluster cookie when the header is missing.
+@@ -170,18 +194,13 @@ func CacheRefreshedToken(token *oauth2.Token, tokenType string, oldToken string,
+ // GetNewToken uses the provided credentials and fetches the old refresh
+ // token from the cache to obtain a new OAuth2 token
+ // from the specified token URL endpoint.
+-func GetNewToken(clientID, clientSecret string, cache cache.Cache[interface{}],
++func GetNewToken(clientID, clientSecret string, tokenCache cache.Cache[interface{}],
+ 	tokenType string, token string, tokenURL string, ctx context.Context,
+ ) (*oauth2.Token, error) {
+ 	// get refresh token
+-	refreshToken, err := cache.Get(ctx, oidcKeyPrefix+token)
++	rToken, err := getCachedRefreshToken(ctx, tokenCache, token)
+ 	if err != nil {
+-		return nil, fmt.Errorf("getting refresh token: %v", err)
+-	}
+-
+-	rToken, ok := refreshToken.(string)
+-	if !ok {
+-		return nil, fmt.Errorf("failed to get refresh token")
++		return nil, err
+ 	}
+ 
+ 	// Create OAuth2 config with client credentials and token endpoint
+@@ -200,7 +219,7 @@ func GetNewToken(clientID, clientSecret string, cache cache.Cache[interface{}],
+ 	}
+ 
+ 	// update the refresh token in the cache
+-	if err := CacheRefreshedToken(newToken, tokenType, token, rToken, cache); err != nil {
++	if err := CacheRefreshedToken(newToken, tokenType, token, rToken, tokenCache); err != nil {
+ 		return nil, fmt.Errorf("caching refreshed token: %v", err)
+ 	}
+ 
+@@ -247,11 +266,15 @@ func ConfigureTLSContext(ctx context.Context, skipTLSVerify *bool, caCert *strin
+ // and re-populates the cache so subsequent requests can reuse it. The provided ctx
+ // controls cancellation and deadlines for all outbound requests during the refresh.
+ func RefreshAndCacheNewToken(ctx context.Context, oidcAuthConfig *kubeconfig.OidcConfig,
+-	cache cache.Cache[interface{}],
++	tokenCache cache.Cache[interface{}],
+ 	tokenType, token, issuerURL string,
+ ) (*oauth2.Token, error) {
+ 	ctx = ConfigureTLSContext(ctx, oidcAuthConfig.SkipTLSVerify, oidcAuthConfig.CACert)
+ 
++	if _, err := getCachedRefreshToken(ctx, tokenCache, token); err != nil {
++		return nil, fmt.Errorf("refreshing token: %w", err)
++	}
++
+ 	// get provider
+ 	provider, err := oidc.NewProvider(ctx, issuerURL)
+ 	if err != nil {
+@@ -261,7 +284,7 @@ func RefreshAndCacheNewToken(ctx context.Context, oidcAuthConfig *kubeconfig.Oid
+ 	newToken, err := GetNewToken(
+ 		oidcAuthConfig.ClientID,
+ 		oidcAuthConfig.ClientSecret,
+-		cache,
++		tokenCache,
+ 		tokenType,
+ 		token,
+ 		provider.Endpoint().TokenURL,
+diff --git a/backend/pkg/auth/auth_test.go b/backend/pkg/auth/auth_test.go
+index ef0940ae8..9f2fcb0ee 100644
+--- a/backend/pkg/auth/auth_test.go
++++ b/backend/pkg/auth/auth_test.go
+@@ -414,10 +414,15 @@ func (f *fakeCache) Get(_ context.Context, key string) (interface{}, error) {
+ 	}
+ 
+ 	if f.store == nil {
+-		return nil, nil
++		return nil, cache.ErrNotFound
+ 	}
+ 
+-	return f.store[key], nil
++	val, ok := f.store[key]
++	if !ok {
++		return nil, cache.ErrNotFound
++	}
++
++	return val, nil
+ }
+ 
+ func (f *fakeCache) Set(_ context.Context, key string, val interface{}) error {
+@@ -672,7 +677,12 @@ func TestGetNewToken_PreHTTPFailures(t *testing.T) {
+ 		{
+ 			"missing refresh token",
+ 			&fakeCache{store: map[string]interface{}{}},
+-			"failed to get refresh token",
++			auth.ErrRefreshTokenUnavailable.Error(),
++		},
++		{
++			"empty refresh token",
++			&fakeCache{store: map[string]interface{}{"oidc-token-OLD": ""}},
++			auth.ErrRefreshTokenUnavailable.Error(),
+ 		},
+ 	} {
+ 		t.Run(tc.name, func(t *testing.T) {
+diff --git a/backend/pkg/auth/cookies.go b/backend/pkg/auth/cookies.go
+index bab079a6d..165a0bd3f 100644
+--- a/backend/pkg/auth/cookies.go
++++ b/backend/pkg/auth/cookies.go
+@@ -19,9 +19,11 @@ package auth
+ import (
+ 	"errors"
+ 	"fmt"
++	"math"
+ 	"net/http"
+ 	"regexp"
+ 	"strings"
++	"time"
+ )
+ 
+ const (
+@@ -29,6 +31,9 @@ const (
+ 	chunkSize = 3800
+ 	// clearCookieChunkCount bounds cleanup for stale chunked cookies across auth paths.
+ 	clearCookieChunkCount = 8
++	// defaultCookieMaxAgeSeconds preserves the upstream 24-hour upper bound when a token
++	// does not expose a usable JWT expiry.
++	defaultCookieMaxAgeSeconds = 86400
+ )
+ 
+ // GetCookiePath returns the full cookie path including baseURL.
+@@ -105,6 +110,7 @@ func SetTokenCookie(w http.ResponseWriter, r *http.Request, cluster, token, base
+ 
+ 	// if token is larger than maxCookieSize, split it into multiple cookies
+ 	chunks := splitToken(token, chunkSize)
++	maxAge := getTokenCookieMaxAge(token)
+ 
+ 	for _, path := range []string{GetCookiePath(baseURL, cluster), GetWebSocketCookiePath(baseURL)} {
+ 		for i, chunk := range chunks {
+@@ -115,7 +121,7 @@ func SetTokenCookie(w http.ResponseWriter, r *http.Request, cluster, token, base
+ 				Secure:   secure,
+ 				SameSite: http.SameSiteStrictMode,
+ 				Path:     path,
+-				MaxAge:   86400, // 24 hours
++				MaxAge:   maxAge,
+ 			}
+ 
+ 			http.SetCookie(w, cookie)
+@@ -123,6 +129,35 @@ func SetTokenCookie(w http.ResponseWriter, r *http.Request, cluster, token, base
+ 	}
+ }
+ 
++func getTokenCookieMaxAge(token string) int {
++	parts := strings.SplitN(token, ".", 3)
++	if len(parts) != 3 || parts[1] == "" {
++		return defaultCookieMaxAgeSeconds
++	}
++
++	payload, err := DecodeBase64JSON(parts[1])
++	if err != nil {
++		return defaultCookieMaxAgeSeconds
++	}
++
++	expiryUnixTimeUTC, err := GetExpiryUnixTimeUTC(payload)
++	if err != nil {
++		return defaultCookieMaxAgeSeconds
++	}
++
++	remaining := time.Until(expiryUnixTimeUTC)
++	if remaining <= 0 {
++		return 0
++	}
++
++	maxAge := int(math.Ceil(remaining.Seconds()))
++	if maxAge > defaultCookieMaxAgeSeconds {
++		return defaultCookieMaxAgeSeconds
++	}
++
++	return maxAge
++}
++
+ // GetTokenFromCookie retrieves an authentication cookie for a specific cluster.
+ func GetTokenFromCookie(r *http.Request, cluster string) (string, error) {
+ 	sanitizedCluster := SanitizeClusterName(cluster)
+diff --git a/backend/pkg/auth/cookies_test.go b/backend/pkg/auth/cookies_test.go
+index d44f1b719..f89b8f539 100644
+--- a/backend/pkg/auth/cookies_test.go
++++ b/backend/pkg/auth/cookies_test.go
+@@ -18,10 +18,13 @@ package auth_test
+ 
+ import (
+ 	"crypto/tls"
++	"encoding/base64"
++	"encoding/json"
+ 	"net/http"
+ 	"net/http/httptest"
+ 	"strings"
+ 	"testing"
++	"time"
+ 
+ 	"github.com/kubernetes-sigs/headlamp/backend/pkg/auth"
+ )
+@@ -31,6 +34,17 @@ const (
+ 	localhostOrigin = "http://localhost:3000"
+ )
+ 
++func makeCookieJWT(t *testing.T, payload map[string]interface{}) string {
++	t.Helper()
++
++	payloadBytes, err := json.Marshal(payload)
++	if err != nil {
++		t.Fatalf("failed to marshal payload: %v", err)
++	}
++
++	return "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0." + base64.RawURLEncoding.EncodeToString(payloadBytes) + "."
++}
++
+ func TestSanitizeClusterName(t *testing.T) {
+ 	tests := []struct {
+ 		input    string
+@@ -198,6 +212,27 @@ func TestGetWebSocketCookiePath(t *testing.T) {
+ 	}
+ }
+ 
++func TestSetTokenCookie_UsesTokenExpiryForMaxAge(t *testing.T) {
++	req := httptest.NewRequest("GET", localhostOrigin, nil)
++	req.Host = localhost
++	w := httptest.NewRecorder()
++	token := makeCookieJWT(t, map[string]interface{}{
++		"exp": float64(time.Now().Add(2 * time.Minute).Unix()),
++	})
++
++	auth.SetTokenCookie(w, req, "test-cluster", token, "")
++
++	for _, cookie := range w.Result().Cookies() {
++		if cookie.MaxAge == -1 {
++			continue
++		}
++
++		if cookie.MaxAge <= 0 || cookie.MaxAge > 120 {
++			t.Fatalf("expected cookie max age to track token expiry, got %d", cookie.MaxAge)
++		}
++	}
++}
++
+ func TestSetAndGetAuthCookie(t *testing.T) {
+ 	req := httptest.NewRequest("GET", localhost, nil)
+ 	req.Host = localhost
+diff --git a/frontend/src/lib/k8s/api/v1/clusterRequests.ts b/frontend/src/lib/k8s/api/v1/clusterRequests.ts
+index 1c17b3c8a..ff06d878d 100644
+--- a/frontend/src/lib/k8s/api/v1/clusterRequests.ts
++++ b/frontend/src/lib/k8s/api/v1/clusterRequests.ts
+@@ -20,12 +20,11 @@ import { addBackstageAuthHeaders } from '../../../../helpers/addBackstageAuthHea
+ import { isDebugVerbose } from '../../../../helpers/debugVerbose';
+ import { getAppUrl } from '../../../../helpers/getAppUrl';
+ import { isBackstage } from '../../../../helpers/isBackstage';
+-import store from '../../../../redux/stores/store';
+ import { findKubeconfigByClusterName } from '../../../../stateless/findKubeconfigByClusterName';
+ import { getUserIdFromLocalStorage } from '../../../../stateless/getUserIdFromLocalStorage';
+-import { logout } from '../../../auth';
+ import { getCluster } from '../../../cluster';
+ import type { KubeObjectInterface } from '../../KubeObject';
++import { handleClusterAuthError } from '../authError';
+ import type { ApiError } from '../v2/ApiError';
+ import { CLUSTERS_PREFIX, DEFAULT_TIMEOUT, JSON_HEADERS } from './constants';
+ import { asQuery, combinePath } from './formatUrl';
+@@ -66,18 +65,6 @@ export interface ClusterRequestParams extends RequestParams {
+   autoLogoutOnAuthError?: boolean;
+ }
+ 
+-/**
+- * @returns Auth type of the cluster, or an empty string if the cluster is not found.
+- * It could return 'oidc' or '' for example.
+- *
+- * @param cluster - Name of the cluster.
+- */
+-export function getClusterAuthType(cluster: string): string {
+-  const state = store.getState();
+-  const authType: string = state.config?.clusters?.[cluster]?.['auth_type'] || '';
+-  return authType;
+-}
+-
+ /**
+  * Sends a request to the backend. If the useCluster parameter is true (which it is, by default), it will be
+  * treated as a request to the Kubernetes server of the currently defined (in the URL) cluster.
+@@ -189,10 +176,13 @@ export async function clusterRequest(
+ 
+   if (!response.ok) {
+     const { status, statusText } = response;
+-    if (autoLogoutOnAuthError && status === 401 && opts.headers.Authorization) {
+-      console.error('Logging out due to auth error', { status, statusText, path });
+-      logout(cluster);
+-    }
++    await handleClusterAuthError({
++      autoLogoutOnAuthError,
++      cluster,
++      hasAuthorizationHeader: Boolean(opts.headers.Authorization),
++      path,
++      status,
++    });
+ 
+     let message = statusText;
+     try {
+diff --git a/frontend/src/lib/k8s/api/v2/fetch.ts b/frontend/src/lib/k8s/api/v2/fetch.ts
+index c4a98d5cb..9b07f17c7 100644
+--- a/frontend/src/lib/k8s/api/v2/fetch.ts
++++ b/frontend/src/lib/k8s/api/v2/fetch.ts
+@@ -18,6 +18,7 @@ import { addBackstageAuthHeaders } from '../../../../helpers/addBackstageAuthHea
+ import { getAppUrl } from '../../../../helpers/getAppUrl';
+ import { findKubeconfigByClusterName } from '../../../../stateless/findKubeconfigByClusterName';
+ import { getUserIdFromLocalStorage } from '../../../../stateless/getUserIdFromLocalStorage';
++import { handleClusterAuthError } from '../authError';
+ import { ApiError } from './ApiError';
+ import { makeUrl } from './makeUrl';
+ 
+@@ -92,6 +93,13 @@ export async function clusterFetch(url: string | URL, init: RequestInit & { clus
+   } catch (e) {
+     if (e instanceof ApiError) {
+       e.cluster = init.cluster;
++      await handleClusterAuthError({
++        autoLogoutOnAuthError: true,
++        cluster: init.cluster,
++        hasAuthorizationHeader: init.headers.has('Authorization'),
++        path: String(url),
++        status: e.status,
++      });
+     }
+     throw e;
+   }
+diff --git a/frontend/src/lib/k8s/api/authError.ts b/frontend/src/lib/k8s/api/authError.ts
+new file mode 100644
+index 000000000..86aaae718
+--- /dev/null
++++ b/frontend/src/lib/k8s/api/authError.ts
+@@ -0,0 +1,71 @@
++/*
++ * Copyright 2025 The Kubernetes Authors
++ *
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at
++ *
++ * http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++ */
++
++import store from '../../../redux/stores/store';
++import { logout } from '../../auth';
++import { createRouteURL } from '../../router/createRouteURL';
++
++interface ClusterAuthErrorOptions {
++  autoLogoutOnAuthError: boolean;
++  cluster: string;
++  hasAuthorizationHeader: boolean;
++  navigate?: (path: string) => void;
++  path?: string;
++  status?: number;
++}
++
++/**
++ * @returns Auth type of the cluster, or an empty string if the cluster is not found.
++ * It could return 'oidc' or '' for example.
++ */
++export function getClusterAuthType(cluster: string): string {
++  const state = store.getState();
++  const authType: string = state.config?.clusters?.[cluster]?.['auth_type'] || '';
++  return authType;
++}
++
++export async function handleClusterAuthError({
++  autoLogoutOnAuthError,
++  cluster,
++  hasAuthorizationHeader,
++  navigate = path => window.location.assign(path),
++  path,
++  status,
++}: ClusterAuthErrorOptions): Promise<boolean> {
++  if (!autoLogoutOnAuthError || status !== 401 || !cluster) {
++    return false;
++  }
++
++  const authType = getClusterAuthType(cluster);
++  const shouldRedirectToLogin = !hasAuthorizationHeader && authType === 'oidc';
++  if (!hasAuthorizationHeader && !shouldRedirectToLogin) {
++    return false;
++  }
++
++  console.error('Logging out due to auth error', {
++    authType,
++    cluster,
++    path,
++    status,
++  });
++  await logout(cluster);
++
++  if (shouldRedirectToLogin) {
++    navigate(createRouteURL('login', { cluster }));
++  }
++
++  return true;
++}
+diff --git a/frontend/src/lib/k8s/api/authError.test.ts b/frontend/src/lib/k8s/api/authError.test.ts
+new file mode 100644
+index 000000000..58363209e
+--- /dev/null
++++ b/frontend/src/lib/k8s/api/authError.test.ts
+@@ -0,0 +1,113 @@
++/*
++ * Copyright 2025 The Kubernetes Authors
++ *
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at
++ *
++ * http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++ */
++
++import { beforeEach, describe, expect, it, vi } from 'vitest';
++import { handleClusterAuthError } from './authError';
++
++const { mockCreateRouteURL, mockGetState, mockLogout } = vi.hoisted(() => ({
++  mockCreateRouteURL: vi.fn().mockReturnValue('/c/test-cluster/login'),
++  mockGetState: vi.fn(),
++  mockLogout: vi.fn().mockResolvedValue(undefined),
++}));
++
++vi.mock('../../auth', () => ({
++  logout: mockLogout,
++}));
++
++vi.mock('../../router/createRouteURL', () => ({
++  createRouteURL: mockCreateRouteURL,
++}));
++
++vi.mock('../../../redux/stores/store', () => ({
++  default: {
++    getState: mockGetState,
++  },
++}));
++
++describe('handleClusterAuthError', () => {
++  let navigate: ReturnType<typeof vi.fn>;
++
++  beforeEach(() => {
++    navigate = vi.fn();
++    mockLogout.mockClear();
++    mockCreateRouteURL.mockClear();
++    mockGetState.mockReset();
++    mockGetState.mockReturnValue({
++      config: {
++        clusters: {
++          'test-cluster': { auth_type: 'oidc' },
++        },
++      },
++    });
++  });
++
++  it('redirects cookie-based OIDC sessions back to login on 401', async () => {
++    await expect(
++      handleClusterAuthError({
++        autoLogoutOnAuthError: true,
++        cluster: 'test-cluster',
++        hasAuthorizationHeader: false,
++        navigate,
++        path: '/api/v1/namespaces',
++        status: 401,
++      })
++    ).resolves.toBe(true);
++
++    expect(mockLogout).toHaveBeenCalledWith('test-cluster');
++    expect(mockCreateRouteURL).toHaveBeenCalledWith('login', { cluster: 'test-cluster' });
++    expect(navigate).toHaveBeenCalledWith('/c/test-cluster/login');
++  });
++
++  it('logs out header-based sessions without redirecting', async () => {
++    await expect(
++      handleClusterAuthError({
++        autoLogoutOnAuthError: true,
++        cluster: 'test-cluster',
++        hasAuthorizationHeader: true,
++        navigate,
++        path: '/api/v1/namespaces',
++        status: 401,
++      })
++    ).resolves.toBe(true);
++
++    expect(mockLogout).toHaveBeenCalledWith('test-cluster');
++    expect(navigate).not.toHaveBeenCalled();
++  });
++
++  it('ignores cookie-based 401s for non-OIDC clusters', async () => {
++    mockGetState.mockReturnValue({
++      config: {
++        clusters: {
++          'test-cluster': { auth_type: '' },
++        },
++      },
++    });
++
++    await expect(
++      handleClusterAuthError({
++        autoLogoutOnAuthError: true,
++        cluster: 'test-cluster',
++        hasAuthorizationHeader: false,
++        navigate,
++        path: '/api/v1/namespaces',
++        status: 401,
++      })
++    ).resolves.toBe(false);
++
++    expect(mockLogout).not.toHaveBeenCalled();
++    expect(navigate).not.toHaveBeenCalled();
++  });
++});

--- a/services/headlamp/scripts/test-upstream.sh
+++ b/services/headlamp/scripts/test-upstream.sh
@@ -11,5 +11,11 @@ sh "$SCRIPT_DIR/fetch-upstream.sh" "$WORK_DIR"
 sh "$SCRIPT_DIR/apply-upstream-patches.sh" "$WORK_DIR"
 
 cd "$WORK_DIR/backend"
-go test ./cmd -run 'Test(GetOrCreateConnection|EstablishClusterConnection|GetOrCreateConnection_HTTPWatchStream|Reconnect|Reconnect_WithToken)'
-go test ./pkg/auth -run 'Test(GetCookiePath|GetWebSocketCookiePath|SetAndGetAuthCookie|GetAuthCookieChunked|ClearAuthCookie)'
+go test ./cmd -run 'Test(GetOrCreateConnection|EstablishClusterConnection|GetOrCreateConnection_HTTPWatchStream|Reconnect|Reconnect_WithToken|OIDCTokenRefreshMiddleware)'
+go test ./pkg/auth -run 'Test(GetCookiePath|GetWebSocketCookiePath|SetAndGetAuthCookie|GetAuthCookieChunked|ClearAuthCookie|SetTokenCookie_UsesTokenExpiryForMaxAge|GetNewToken_PreHTTPFailures)'
+
+if command -v npm >/dev/null 2>&1; then
+  cd "$WORK_DIR/frontend"
+  npm ci
+  npm test -- --run src/lib/k8s/api/authError.test.ts
+fi


### PR DESCRIPTION
## Summary

- recover Headlamp OIDC sessions cleanly when the in-memory refresh-token cache is missing instead of logging repeated refresh errors
- align auth cookie lifetime to token expiry and return a clean 401 reauth path when refresh is no longer possible
- add frontend cookie-based OIDC 401 recovery, patch the image build so frontend patches are applied, and pin the new live image digest in GitOps

## Related Issues

None

## Testing

- `sh services/headlamp/scripts/test-upstream.sh`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/headlamp >/tmp/headlamp-render.yaml`
- `bun run lint:argocd`
- `docker buildx build --platform linux/arm64 --push --metadata-file /tmp/headlamp-build-metadata.json -t registry.ide-newton.ts.net/lab/headlamp:oidc-reauth-20260314-200534 --build-arg LAB_GIT_SHA=$(git rev-parse HEAD) services/headlamp`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
