### PR TITLE
fix(torghut): stabilize simulation bootstrap and replay freshness

### DIFF
--- a/services/torghut/app/config.py
+++ b/services/torghut/app/config.py
@@ -372,6 +372,14 @@ class Settings(BaseSettings):
             "signal continuity alert."
         ),
     )
+    trading_signal_bootstrap_grace_seconds: int = Field(
+        default=180,
+        alias="TRADING_SIGNAL_BOOTSTRAP_GRACE_SECONDS",
+        description=(
+            "Grace period after scheduler start or simulation run reset before "
+            "no-signal continuity reasons become actionable."
+        ),
+    )
     trading_signal_staleness_alert_critical_reasons_raw: Optional[str] = Field(
         default="cursor_ahead_of_stream,no_signals_in_window,universe_source_unavailable",
         alias="TRADING_SIGNAL_STALENESS_ALERT_CRITICAL_REASONS",

--- a/services/torghut/app/trading/features.py
+++ b/services/torghut/app/trading/features.py
@@ -11,6 +11,7 @@ from typing import Any, Iterable, Optional, cast
 
 from .models import SignalEnvelope
 from .regime_hmm import resolve_hmm_context, resolve_regime_route_label
+from .simulation import simulation_context_enabled
 
 FEATURE_SCHEMA_VERSION_V3 = '3.0.0'
 FEATURE_VECTOR_V3_REQUIRED_FIELDS = ('price', 'macd', 'macd_signal', 'rsi14')
@@ -332,8 +333,16 @@ def _optional_int(value: Any) -> int | None:
 
 
 def _staleness_ms(event_ts: datetime, ingest_ts: datetime | None) -> int:
-    # Use event/ingest timestamps only so replayed inputs remain deterministic.
-    reference = ingest_ts.astimezone(timezone.utc) if ingest_ts is not None else event_ts.astimezone(timezone.utc)
+    # Historical replay writes ingest_ts at replay wall-clock time, so simulation
+    # freshness must remain anchored to the historical event timestamp.
+    if simulation_context_enabled():
+        reference = event_ts.astimezone(timezone.utc)
+    else:
+        reference = (
+            ingest_ts.astimezone(timezone.utc)
+            if ingest_ts is not None
+            else event_ts.astimezone(timezone.utc)
+        )
     delta = reference - event_ts.astimezone(timezone.utc)
     return max(0, int(delta.total_seconds() * 1000))
 

--- a/services/torghut/app/trading/scheduler/governance.py
+++ b/services/torghut/app/trading/scheduler/governance.py
@@ -37,6 +37,7 @@ from .safety import (
     _latch_signal_continuity_alert_state,
     _merge_emergency_stop_reasons,
     _record_signal_continuity_recovery_cycle,
+    _signal_bootstrap_grace_active,
     _split_emergency_stop_reasons,
 )
 from .state import TradingState
@@ -438,6 +439,16 @@ class TradingSchedulerGovernanceMixin:
         for reason in sorted(critical_reasons):
             streak = self.state.metrics.no_signal_reason_streak.get(reason, 0)
             if streak >= critical_staleness_limit:
+                if reason == "no_signals_in_window" and _signal_bootstrap_grace_active(
+                    self.state,
+                    grace_seconds=settings.trading_signal_bootstrap_grace_seconds,
+                ):
+                    logger.info(
+                        "Suppressing emergency-stop staleness streak during bootstrap grace reason=%s streak=%s",
+                        reason,
+                        streak,
+                    )
+                    continue
                 if (
                     not market_session_open
                 ) and reason in market_closed_expected_reasons:

--- a/services/torghut/app/trading/scheduler/pipeline.py
+++ b/services/torghut/app/trading/scheduler/pipeline.py
@@ -96,7 +96,12 @@ from .pipeline_helpers import (
     _select_strictest_runtime_uncertainty_gate,
     _uncertainty_gate_staleness_reason,
 )
-from .safety import _is_market_session_open, _latch_signal_continuity_alert_state, _record_signal_continuity_recovery_cycle
+from .safety import (
+    _is_market_session_open,
+    _latch_signal_continuity_alert_state,
+    _record_signal_continuity_recovery_cycle,
+    _signal_bootstrap_grace_active,
+)
 from .state import (
     RuntimeUncertaintyGate,
     RuntimeUncertaintyGateAction,
@@ -225,6 +230,9 @@ class TradingPipeline:
             self.record_no_signal_batch(batch)
             self.ingestor.commit_cursor(session, batch)
             return False
+
+        if self.state.signal_bootstrap_completed_at is None:
+            self.state.signal_bootstrap_completed_at = datetime.now(timezone.utc)
 
         if settings.trading_feature_quality_enabled:
             quality_thresholds = FeatureQualityThresholds(
@@ -768,6 +776,11 @@ class TradingPipeline:
     ) -> bool:
         if reason == "cursor_ahead_of_stream":
             return True
+        if reason == "no_signals_in_window" and _signal_bootstrap_grace_active(
+            self.state,
+            grace_seconds=settings.trading_signal_bootstrap_grace_seconds,
+        ):
+            return False
         if market_session_open:
             return True
         expected_market_closed_reasons = (

--- a/services/torghut/app/trading/scheduler/runtime.py
+++ b/services/torghut/app/trading/scheduler/runtime.py
@@ -322,6 +322,8 @@ class TradingScheduler(TradingSchedulerGovernanceMixin):
         )
         self._stop_event.clear()
         self.state.startup_started_at = datetime.now(timezone.utc)
+        self.state.signal_bootstrap_started_at = self.state.startup_started_at
+        self.state.signal_bootstrap_completed_at = None
         self.state.running = False
         self._task = asyncio.create_task(self._run_loop())
 
@@ -341,6 +343,8 @@ class TradingScheduler(TradingSchedulerGovernanceMixin):
             pass
         self._task = None
         self.state.startup_started_at = None
+        self.state.signal_bootstrap_started_at = None
+        self.state.signal_bootstrap_completed_at = None
         self.state.running = False
         active_pipelines = self._pipelines or (
             [self._pipeline] if self._pipeline is not None else []
@@ -430,6 +434,8 @@ class TradingScheduler(TradingSchedulerGovernanceMixin):
         self.state.signal_continuity_alert_started_at = None
         self.state.signal_continuity_alert_last_seen_at = None
         self.state.signal_continuity_recovery_streak = 0
+        self.state.signal_bootstrap_started_at = datetime.now(timezone.utc)
+        self.state.signal_bootstrap_completed_at = None
         self.state.autonomy_no_signal_streak = 0
         self.state.last_evidence_continuity_report = None
         self.state.autonomy_failure_streak = 0

--- a/services/torghut/app/trading/scheduler/safety.py
+++ b/services/torghut/app/trading/scheduler/safety.py
@@ -108,6 +108,23 @@ def _record_signal_continuity_recovery_cycle(
     )
 
 
+def _signal_bootstrap_grace_active(
+    state: Any,
+    *,
+    grace_seconds: int,
+    now: datetime | None = None,
+) -> bool:
+    if max(0, int(grace_seconds)) <= 0:
+        return False
+    if getattr(state, "signal_bootstrap_completed_at", None) is not None:
+        return False
+    started_at = getattr(state, "signal_bootstrap_started_at", None)
+    if not isinstance(started_at, datetime):
+        return False
+    reference = now or datetime.now(timezone.utc)
+    return (reference - started_at).total_seconds() < max(0, int(grace_seconds))
+
+
 __all__ = [
     "_coerce_recovery_reason_sequence",
     "_is_market_session_open",
@@ -115,5 +132,6 @@ __all__ = [
     "_latch_signal_continuity_alert_state",
     "_merge_emergency_stop_reasons",
     "_record_signal_continuity_recovery_cycle",
+    "_signal_bootstrap_grace_active",
     "_split_emergency_stop_reasons",
 ]

--- a/services/torghut/app/trading/scheduler/state.py
+++ b/services/torghut/app/trading/scheduler/state.py
@@ -994,6 +994,8 @@ class TradingState:
     signal_continuity_alert_started_at: Optional[datetime] = None
     signal_continuity_alert_last_seen_at: Optional[datetime] = None
     signal_continuity_recovery_streak: int = 0
+    signal_bootstrap_started_at: Optional[datetime] = None
+    signal_bootstrap_completed_at: Optional[datetime] = None
     last_market_context_symbol: Optional[str] = None
     last_market_context_checked_at: Optional[datetime] = None
     last_market_context_as_of: Optional[datetime] = None

--- a/services/torghut/scripts/start_historical_simulation.py
+++ b/services/torghut/scripts/start_historical_simulation.py
@@ -1146,6 +1146,28 @@ def _replace_alembic_upgrade_target(command: str, target: str) -> str | None:
     return ' '.join(shlex.quote(item) for item in tokens)
 
 
+def _resolve_command_args(command: str) -> list[str]:
+    try:
+        tokens = shlex.split(command)
+    except Exception as exc:
+        raise RuntimeError(f'command_parse_failed:{command}') from exc
+    if not tokens:
+        raise RuntimeError('command_parse_failed:empty')
+    binary = tokens[0]
+    if os.path.isabs(binary) and not Path(binary).exists():
+        fallback_binary = shutil.which(Path(binary).name)
+        if fallback_binary:
+            _log_script_event(
+                'command_binary_resolved',
+                original_binary=binary,
+                resolved_binary=fallback_binary,
+            )
+            tokens[0] = fallback_binary
+        else:
+            raise RuntimeError(f'command_binary_not_found:{binary}')
+    return tokens
+
+
 def _run_alembic_upgrade(
     *,
     command: str,
@@ -1156,7 +1178,7 @@ def _run_alembic_upgrade(
     _run_with_transient_postgres_retry(
         label=label,
         operation=lambda: _run_command(
-            shlex.split(command),
+            _resolve_command_args(command),
             cwd=cwd,
             env=env,
         ),
@@ -1540,6 +1562,8 @@ def _run_command(
             env=dict(env) if env is not None else None,
             input=input_text,
         )
+    except FileNotFoundError as exc:
+        raise RuntimeError(f'command_missing: {" ".join(args)}: {exc.filename}') from exc
     except subprocess.CalledProcessError as exc:
         stdout = (exc.stdout or '').strip()
         stderr = (exc.stderr or '').strip()
@@ -3600,19 +3624,14 @@ def _run_migrations(config: PostgresRuntimeConfig) -> None:
     env['DB_DSN'] = config.admin_simulation_dsn
     _remove_appledouble_sidecars(repo_root / 'migrations' / 'versions')
 
-    def _run(command: str) -> None:
-        _run_command(
-            shlex.split(command),
-            cwd=repo_root,
-            env=env,
-        )
-
     migration_error: Exception | None = None
 
     try:
-        _run_with_transient_postgres_retry(
+        _run_alembic_upgrade(
+            command=config.migrations_command,
+            env=env,
+            cwd=repo_root,
             label='run_migrations',
-            operation=lambda: _run(config.migrations_command),
         )
         _assert_required_simulation_metadata_tables(config)
         return
@@ -3637,9 +3656,11 @@ def _run_migrations(config: PostgresRuntimeConfig) -> None:
             f'run_migrations_fallback_target_parse_failed: command={config.migrations_command} target={fallback_revision}'
         ) from migration_error
 
-    _run_with_transient_postgres_retry(
+    _run_alembic_upgrade(
+        command=fallback_command,
+        env=env,
+        cwd=repo_root,
         label='run_migrations_fallback_pre_vector',
-        operation=lambda: _run(fallback_command),
     )
     _assert_required_simulation_metadata_tables(config)
 
@@ -7014,20 +7035,25 @@ def _run_full_lifecycle(
     )
     completion_trace_path = _artifact_path(resources, 'completion-trace.json')
     _save_json(completion_trace_path, completion_trace)
+    gate_row_ids: dict[str, Any] = {}
+    completion_trace_db_refs = _as_mapping(completion_trace.get('db_row_refs'))
     runtime_session_factory, runtime_engine = _runtime_sessionmaker(postgres_config)
     try:
-        with runtime_session_factory() as session:
-            gate_row_ids = persist_completion_trace(
-                session=session,
-                trace_payload=completion_trace,
-                default_artifact_ref=str(completion_trace_path),
-            )
-            session.commit()
+        try:
+            with runtime_session_factory() as session:
+                gate_row_ids = persist_completion_trace(
+                    session=session,
+                    trace_payload=completion_trace,
+                    default_artifact_ref=str(completion_trace_path),
+                )
+                session.commit()
+        except Exception as exc:
+            completion_trace_db_refs['completion_gate_persist_error'] = str(exc)
+            errors.append(f'completion_trace_persist:{exc}')
     finally:
         runtime_engine.dispose()
-    updated_db_refs = _as_mapping(completion_trace.get('db_row_refs'))
-    updated_db_refs['completion_gate_row_ids'] = gate_row_ids
-    completion_trace['db_row_refs'] = updated_db_refs
+    completion_trace_db_refs['completion_gate_row_ids'] = gate_row_ids
+    completion_trace['db_row_refs'] = completion_trace_db_refs
     _save_json(completion_trace_path, completion_trace)
     if errors:
         error_payload = {

--- a/services/torghut/tests/test_feature_quality.py
+++ b/services/torghut/tests/test_feature_quality.py
@@ -5,6 +5,7 @@ import app.trading.features as feature_values
 from unittest import TestCase
 from unittest.mock import patch
 
+from app import config
 from app.trading.feature_quality import FeatureQualityThresholds, evaluate_feature_batch_quality
 from app.trading.models import SignalEnvelope
 
@@ -71,6 +72,31 @@ class TestFeatureQuality(TestCase):
         self.assertGreater(report.staleness_ms_p95, 2_000)
         self.assertIn('duplicate_ratio_exceeds_threshold', report.reasons)
         self.assertIn('feature_staleness_exceeds_budget', report.reasons)
+
+    def test_batch_uses_event_time_for_staleness_in_simulation_mode(self) -> None:
+        original = config.settings.trading_simulation_enabled
+        config.settings.trading_simulation_enabled = True
+        try:
+            ts = datetime(2026, 3, 13, 13, 30, tzinfo=timezone.utc)
+            signals = [
+                _signal(ts=ts, seq=1, ingest_lag_ms=138_744_236),
+                _signal(ts=ts + timedelta(minutes=1), seq=2, ingest_lag_ms=138_744_236),
+            ]
+
+            report = evaluate_feature_batch_quality(
+                signals,
+                thresholds=FeatureQualityThresholds(
+                    max_required_null_rate=0.01,
+                    max_duplicate_ratio=0.10,
+                    max_staleness_ms=1_000,
+                ),
+            )
+
+            self.assertTrue(report.accepted)
+            self.assertEqual(report.staleness_ms_p95, 0)
+            self.assertNotIn('feature_staleness_exceeds_budget', report.reasons)
+        finally:
+            config.settings.trading_simulation_enabled = original
 
     def test_batch_fails_closed_on_malformed_staleness_ms(self) -> None:
         signals = [

--- a/services/torghut/tests/test_start_historical_simulation.py
+++ b/services/torghut/tests/test_start_historical_simulation.py
@@ -705,11 +705,13 @@ class TestStartHistoricalSimulation(TestCase):
             migrations_command='/opt/venv/bin/alembic upgrade heads',
         )
         captured_envs: list[str] = []
+        captured_args: list[list[str]] = []
 
         def _fake_run_command(args, *, cwd=None, env=None, input_text=None) -> None:
-            _ = (args, cwd, input_text)
+            _ = (cwd, input_text)
             if env is None:
                 raise AssertionError('expected DB_DSN env to be provided')
+            captured_args.append(list(args))
             captured_envs.append(str(env['DB_DSN']))
             return None
 
@@ -723,6 +725,7 @@ class TestStartHistoricalSimulation(TestCase):
                 'scripts.start_historical_simulation._run_with_transient_postgres_retry',
                 side_effect=_fake_retry,
             ),
+            patch('scripts.start_historical_simulation.shutil.which', return_value='/usr/bin/alembic'),
             patch(
                 'scripts.start_historical_simulation._assert_required_simulation_metadata_tables',
                 return_value=None,
@@ -730,6 +733,10 @@ class TestStartHistoricalSimulation(TestCase):
         ):
             _run_migrations(config)
 
+        self.assertEqual(
+            captured_args,
+            [['/usr/bin/alembic', 'upgrade', 'heads']],
+        )
         self.assertEqual(
             captured_envs,
             ['postgresql://postgres:admin-secret@localhost:5432/torghut_sim_sim_1'],
@@ -4505,6 +4512,110 @@ class TestStartHistoricalSimulation(TestCase):
         ):
             mock_session_local.return_value.__enter__.return_value = SimpleNamespace(commit=lambda: None)
             with self.assertRaisesRegex(RuntimeError, 'simulation_run_failed:activity:decisions_absent'):
+                _run_full_lifecycle(
+                    resources=resources,
+                    manifest=manifest,
+                    manifest_path=Path('/tmp/manifest.json'),
+                    kafka_config=kafka_config,
+                    clickhouse_config=clickhouse_config,
+                    postgres_config=postgres_config,
+                    argocd_config=argocd_config,
+                    rollouts_config=rollouts_config,
+                    force_dump=False,
+                    force_replay=False,
+                    skip_teardown=True,
+                    report_only=False,
+                )
+
+    def test_run_full_lifecycle_reports_completion_trace_persist_failure_without_masking_root_cause(self) -> None:
+        resources = _build_resources(
+            'sim-persist-failure',
+            {
+                'dataset_id': 'dataset-a',
+            },
+        )
+        manifest = {
+            'dataset_id': 'dataset-a',
+            'window': {
+                'start': '2026-02-27T14:30:00Z',
+                'end': '2026-02-27T21:00:00Z',
+            },
+        }
+        kafka_config = KafkaRuntimeConfig(
+            bootstrap_servers='kafka:9092',
+            security_protocol=None,
+            sasl_mechanism=None,
+            sasl_username=None,
+            sasl_password=None,
+        )
+        clickhouse_config = ClickHouseRuntimeConfig(
+            http_url='http://clickhouse:8123',
+            username='torghut',
+            password=None,
+        )
+        postgres_config = PostgresRuntimeConfig(
+            admin_dsn='postgresql://torghut:secret@localhost:5432/postgres',
+            simulation_dsn='postgresql://torghut:secret@localhost:5432/torghut_sim_persist_failure',
+            simulation_db='torghut_sim_persist_failure',
+            migrations_command='true',
+        )
+        argocd_config = ArgocdAutomationConfig(
+            manage_automation=False,
+            applicationset_name='product',
+            applicationset_namespace='argocd',
+            app_name='torghut',
+            root_app_name='root',
+            desired_mode_during_run='manual',
+            restore_mode_after_run='previous',
+            verify_timeout_seconds=600,
+        )
+        rollouts_config = RolloutsAnalysisConfig(
+            enabled=False,
+            namespace='agents',
+            runtime_template='torghut-runtime-ready-v1',
+            activity_template='torghut-sim-activity-v1',
+            teardown_template='torghut-teardown-v1',
+            artifact_template='torghut-artifact-v1',
+            verify_timeout_seconds=900,
+            verify_poll_seconds=5,
+        )
+
+        class _FakeSession:
+            def __enter__(self) -> SimpleNamespace:
+                return SimpleNamespace(commit=lambda: None)
+
+            def __exit__(self, exc_type, exc, tb) -> bool:
+                _ = (exc_type, exc, tb)
+                return False
+
+        fake_engine = SimpleNamespace(dispose=lambda: None)
+
+        with (
+            patch('scripts.start_historical_simulation._update_run_state', return_value=None),
+            patch('scripts.start_historical_simulation._save_json', return_value=None),
+            patch('scripts.start_historical_simulation._prepare_argocd_for_run', return_value={'managed': False}),
+            patch('scripts.start_historical_simulation._restore_argocd_after_run', return_value={'managed': False}),
+            patch(
+                'scripts.start_historical_simulation._apply',
+                side_effect=RuntimeError('command_binary_not_found:/opt/venv/bin/alembic'),
+            ),
+            patch('scripts.start_historical_simulation._upsert_simulation_progress_row', return_value=None),
+            patch(
+                'scripts.start_historical_simulation._runtime_sessionmaker',
+                return_value=(lambda: _FakeSession(), fake_engine),
+            ),
+            patch(
+                'scripts.start_historical_simulation.persist_completion_trace',
+                side_effect=RuntimeError('relation "vnext_completion_gate_results" does not exist'),
+            ),
+        ):
+            with self.assertRaisesRegex(
+                RuntimeError,
+                (
+                    'simulation_run_failed:command_binary_not_found:/opt/venv/bin/alembic; '
+                    'completion_trace_persist:relation "vnext_completion_gate_results" does not exist'
+                ),
+            ):
                 _run_full_lifecycle(
                     resources=resources,
                     manifest=manifest,

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -762,6 +762,166 @@ class TestTradingPipeline(TestCase):
                 "trading_feature_max_staleness_ms"
             ]
 
+    def test_pipeline_accepts_replayed_batch_in_simulation_mode(self) -> None:
+        from app import config
+
+        original = {
+            "trading_enabled": config.settings.trading_enabled,
+            "trading_mode": config.settings.trading_mode,
+            "trading_live_enabled": config.settings.trading_live_enabled,
+            "trading_autonomy_allow_live_promotion": config.settings.trading_autonomy_allow_live_promotion,
+            "trading_universe_source": config.settings.trading_universe_source,
+            "trading_static_symbols_raw": config.settings.trading_static_symbols_raw,
+            "trading_feature_quality_enabled": config.settings.trading_feature_quality_enabled,
+            "trading_feature_max_staleness_ms": config.settings.trading_feature_max_staleness_ms,
+            "trading_kill_switch_enabled": config.settings.trading_kill_switch_enabled,
+        }
+        config.settings.trading_enabled = True
+        config.settings.trading_mode = "paper"
+        config.settings.trading_live_enabled = False
+        config.settings.trading_universe_source = "static"
+        config.settings.trading_static_symbols_raw = "AAPL"
+        config.settings.trading_feature_quality_enabled = True
+        config.settings.trading_feature_max_staleness_ms = 1_000
+        config.settings.trading_kill_switch_enabled = False
+
+        try:
+            with self.session_local() as session:
+                strategy = Strategy(
+                    name="demo",
+                    description="simulation replay staleness regression",
+                    enabled=True,
+                    base_timeframe="1Min",
+                    universe_type="static",
+                    universe_symbols=["AAPL"],
+                    max_notional_per_trade=Decimal("1000"),
+                )
+                session.add(strategy)
+                session.commit()
+
+            replayed_signal = SignalEnvelope(
+                event_ts=datetime(2026, 3, 13, 13, 30, tzinfo=timezone.utc),
+                ingest_ts=datetime(2026, 3, 15, 4, 2, 24, 236000, tzinfo=timezone.utc),
+                symbol="AAPL",
+                timeframe="1Min",
+                seq=1,
+                payload={
+                    "feature_schema_version": "3.0.0",
+                    "macd": {"macd": 1.2, "signal": 0.5},
+                    "rsi14": 25,
+                    "price": 100,
+                },
+            )
+
+            alpaca_client = FakeAlpacaClient()
+            execution_adapter = FakeAlpacaClient()
+            ingestor = FakeIngestor([replayed_signal])
+            state = TradingState()
+            pipeline = TradingPipeline(
+                alpaca_client=alpaca_client,
+                order_firewall=OrderFirewall(alpaca_client),
+                ingestor=ingestor,
+                decision_engine=DecisionEngine(),
+                risk_engine=RiskEngine(),
+                executor=OrderExecutor(),
+                execution_adapter=execution_adapter,
+                reconciler=Reconciler(),
+                universe_resolver=UniverseResolver(),
+                state=state,
+                account_label="paper",
+                session_factory=self.session_local,
+            )
+            pipeline._is_market_session_open = lambda _now=None: True  # type: ignore[method-assign]
+
+            with patch(
+                "app.trading.features.simulation_context_enabled",
+                return_value=True,
+            ):
+                pipeline.run_once()
+
+            self.assertEqual(ingestor.committed_batches, 1)
+            self.assertEqual(state.metrics.feature_quality_rejections_total, 0)
+            self.assertEqual(state.metrics.feature_staleness_ms_p95, 0)
+            self.assertEqual(len(alpaca_client.submitted), 1)
+            self.assertEqual(alpaca_client.submitted[0]["symbol"], "AAPL")
+        finally:
+            config.settings.trading_enabled = original["trading_enabled"]
+            config.settings.trading_mode = original["trading_mode"]
+            config.settings.trading_live_enabled = original["trading_live_enabled"]
+            config.settings.trading_autonomy_allow_live_promotion = original[
+                "trading_autonomy_allow_live_promotion"
+            ]
+            config.settings.trading_universe_source = original[
+                "trading_universe_source"
+            ]
+            config.settings.trading_static_symbols_raw = original[
+                "trading_static_symbols_raw"
+            ]
+            config.settings.trading_feature_quality_enabled = original[
+                "trading_feature_quality_enabled"
+            ]
+            config.settings.trading_feature_max_staleness_ms = original[
+                "trading_feature_max_staleness_ms"
+            ]
+            config.settings.trading_kill_switch_enabled = original[
+                "trading_kill_switch_enabled"
+            ]
+
+    def test_pipeline_suppresses_no_signal_alert_during_bootstrap_grace(self) -> None:
+        from app import config
+
+        original = {
+            "trading_signal_no_signal_streak_alert_threshold": config.settings.trading_signal_no_signal_streak_alert_threshold,
+            "trading_signal_bootstrap_grace_seconds": config.settings.trading_signal_bootstrap_grace_seconds,
+        }
+        config.settings.trading_signal_no_signal_streak_alert_threshold = 1
+        config.settings.trading_signal_bootstrap_grace_seconds = 180
+
+        try:
+            state = TradingState()
+            state.signal_bootstrap_started_at = datetime.now(timezone.utc)
+            state.signal_bootstrap_completed_at = None
+            pipeline = TradingPipeline(
+                alpaca_client=FakeAlpacaClient(),
+                order_firewall=OrderFirewall(FakeAlpacaClient()),
+                ingestor=FakeIngestor([]),
+                decision_engine=DecisionEngine(),
+                risk_engine=RiskEngine(),
+                executor=OrderExecutor(),
+                execution_adapter=FakeAlpacaClient(),
+                reconciler=Reconciler(),
+                universe_resolver=UniverseResolver(),
+                state=state,
+                account_label="paper",
+                session_factory=self.session_local,
+            )
+            pipeline._is_market_session_open = lambda _now=None: True  # type: ignore[method-assign]
+
+            pipeline.record_no_signal_batch(
+                SignalBatch(
+                    signals=[],
+                    cursor_at=datetime(2026, 3, 13, 13, 30, tzinfo=timezone.utc),
+                    cursor_seq=1,
+                    cursor_symbol="AAPL",
+                    no_signal_reason="no_signals_in_window",
+                )
+            )
+
+            self.assertFalse(state.last_signal_continuity_actionable)
+            self.assertFalse(state.signal_continuity_alert_active)
+            self.assertEqual(state.metrics.signal_continuity_actionable, 0)
+            self.assertEqual(
+                state.metrics.signal_expected_staleness_total.get("no_signals_in_window"),
+                1,
+            )
+        finally:
+            config.settings.trading_signal_no_signal_streak_alert_threshold = original[
+                "trading_signal_no_signal_streak_alert_threshold"
+            ]
+            config.settings.trading_signal_bootstrap_grace_seconds = original[
+                "trading_signal_bootstrap_grace_seconds"
+            ]
+
     def test_pipeline_quality_gate_uses_allowed_symbol_subset(self) -> None:
         from app import config
 

--- a/services/torghut/tests/test_trading_scheduler_safety.py
+++ b/services/torghut/tests/test_trading_scheduler_safety.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import os
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 import json
 import tempfile
 from pathlib import Path
@@ -59,6 +59,9 @@ class TestTradingSchedulerSafety(TestCase):
             "trading_signal_market_closed_expected_reasons_raw": (
                 config.settings.trading_signal_market_closed_expected_reasons_raw
             ),
+            "trading_signal_bootstrap_grace_seconds": (
+                config.settings.trading_signal_bootstrap_grace_seconds
+            ),
         }
 
     def tearDown(self) -> None:
@@ -96,6 +99,9 @@ class TestTradingSchedulerSafety(TestCase):
         config.settings.trading_signal_market_closed_expected_reasons_raw = (
             self._snapshot["trading_signal_market_closed_expected_reasons_raw"]
         )
+        config.settings.trading_signal_bootstrap_grace_seconds = self._snapshot[
+            "trading_signal_bootstrap_grace_seconds"
+        ]
 
     def test_simulation_run_context_reset_clears_run_scoped_safety_state(self) -> None:
         config.settings.trading_simulation_enabled = True
@@ -148,6 +154,8 @@ class TestTradingSchedulerSafety(TestCase):
         self.assertIsNone(scheduler.state.signal_continuity_alert_started_at)
         self.assertIsNone(scheduler.state.signal_continuity_alert_last_seen_at)
         self.assertEqual(scheduler.state.signal_continuity_recovery_streak, 0)
+        self.assertIsNotNone(scheduler.state.signal_bootstrap_started_at)
+        self.assertIsNone(scheduler.state.signal_bootstrap_completed_at)
         self.assertEqual(scheduler.state.autonomy_no_signal_streak, 0)
         self.assertIsNone(scheduler.state.last_evidence_continuity_report)
         self.assertEqual(scheduler.state.autonomy_failure_streak, 0)
@@ -227,6 +235,63 @@ class TestTradingSchedulerSafety(TestCase):
 
             self.assertFalse(scheduler.state.emergency_stop_active)
             self.assertEqual(scheduler.state.rollback_incidents_total, 0)
+
+    def test_critical_no_signal_streak_is_suppressed_during_bootstrap_grace(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config.settings.trading_autonomy_artifact_dir = tmpdir
+            config.settings.trading_emergency_stop_enabled = True
+            config.settings.trading_rollback_signal_staleness_alert_streak_limit = 2
+            config.settings.trading_signal_staleness_alert_critical_reasons_raw = (
+                "no_signals_in_window"
+            )
+            config.settings.trading_signal_market_closed_expected_reasons_raw = (
+                "cursor_tail_stable,empty_batch_advanced"
+            )
+            config.settings.trading_signal_bootstrap_grace_seconds = 180
+            scheduler = TradingScheduler()
+            scheduler._pipeline = _PipelineStub()  # type: ignore[assignment]
+            scheduler._is_market_session_open = lambda _now=None: True  # type: ignore[method-assign]
+            scheduler.state.signal_bootstrap_started_at = datetime.now(timezone.utc)
+            scheduler.state.signal_bootstrap_completed_at = None
+            scheduler.state.metrics.no_signal_reason_streak = {
+                "no_signals_in_window": 3
+            }
+
+            scheduler._evaluate_safety_controls()
+
+            self.assertFalse(scheduler.state.emergency_stop_active)
+            self.assertEqual(scheduler.state.rollback_incidents_total, 0)
+
+    def test_critical_no_signal_streak_triggers_after_bootstrap_grace_expires(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config.settings.trading_autonomy_artifact_dir = tmpdir
+            config.settings.trading_emergency_stop_enabled = True
+            config.settings.trading_rollback_signal_staleness_alert_streak_limit = 2
+            config.settings.trading_signal_staleness_alert_critical_reasons_raw = (
+                "no_signals_in_window"
+            )
+            config.settings.trading_signal_market_closed_expected_reasons_raw = (
+                "cursor_tail_stable,empty_batch_advanced"
+            )
+            config.settings.trading_signal_bootstrap_grace_seconds = 180
+            scheduler = TradingScheduler()
+            scheduler._pipeline = _PipelineStub()  # type: ignore[assignment]
+            scheduler._is_market_session_open = lambda _now=None: True  # type: ignore[method-assign]
+            scheduler.state.signal_bootstrap_started_at = datetime.now(
+                timezone.utc
+            ) - timedelta(seconds=181)
+            scheduler.state.signal_bootstrap_completed_at = None
+            scheduler.state.metrics.no_signal_reason_streak = {
+                "no_signals_in_window": 3
+            }
+
+            scheduler._evaluate_safety_controls()
+
+            self.assertTrue(scheduler.state.emergency_stop_active)
+            self.assertIn(
+                "signal_staleness_streak_exceeded:no_signals_in_window:3",
+                scheduler.state.emergency_stop_reason or "",
+            )
 
     def test_freshness_emergency_stop_auto_clears_after_recovery_hysteresis(
         self,


### PR DESCRIPTION
## Summary

- add a simulation bootstrap grace window so March 13 full-day proofs do not emergency-stop before the first replayed signals arrive
- treat replayed feature freshness off event time in simulation mode so historical signals are judged by trading-time semantics instead of wall-clock ingest delay
- harden historical simulation command resolution/persistence error handling and add regression coverage around the scheduler and simulation launcher paths

## Related Issues

None

## Testing

- `cd /Users/gregkonush/.codex/worktrees/torghut-march13-proof-fix/services/torghut && uv run --frozen python -m unittest tests.test_feature_quality tests.test_trading_scheduler_safety tests.test_trading_pipeline tests.test_start_historical_simulation`
- `cd /Users/gregkonush/.codex/worktrees/torghut-march13-proof-fix/services/torghut && uv run --frozen ruff check app/config.py app/trading/features.py app/trading/scheduler/safety.py app/trading/scheduler/runtime.py app/trading/scheduler/pipeline.py app/trading/scheduler/governance.py app/trading/scheduler/state.py tests/test_feature_quality.py tests/test_trading_scheduler_safety.py tests/test_trading_pipeline.py tests/test_start_historical_simulation.py`
- `cd /Users/gregkonush/.codex/worktrees/torghut-march13-proof-fix/services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd /Users/gregkonush/.codex/worktrees/torghut-march13-proof-fix/services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd /Users/gregkonush/.codex/worktrees/torghut-march13-proof-fix/services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
