### PR TITLE
fix(torghut): restore production strategy runtime in proofs

### DIFF
--- a/services/torghut/scripts/historical_simulation_verification.py
+++ b/services/torghut/scripts/historical_simulation_verification.py
@@ -408,6 +408,59 @@ def _kubectl_json(namespace: str, args: Sequence[str]) -> dict[str, Any]:
     return {str(key): value for key, value in cast(Mapping[str, Any], payload).items()}
 
 
+def _cluster_service_http_urls(raw_url: str) -> list[str]:
+    parsed = urlsplit(raw_url)
+    host = parsed.hostname
+    if host is None or '.svc' not in host:
+        return [raw_url]
+
+    host_parts = host.split('.')
+    if len(host_parts) < 2:
+        return [raw_url]
+
+    service_name = host_parts[0]
+    namespace = host_parts[1]
+    resolved_urls = [raw_url]
+    seen_urls = {raw_url}
+
+    def _append_host(candidate_host: str | None) -> None:
+        if candidate_host is None:
+            return
+        candidate_host = candidate_host.strip()
+        if not candidate_host or candidate_host.lower() == 'none':
+            return
+        netloc = f'{candidate_host}:{parsed.port}' if parsed.port is not None else candidate_host
+        candidate_url = parsed._replace(netloc=netloc).geturl()
+        if candidate_url in seen_urls:
+            return
+        seen_urls.add(candidate_url)
+        resolved_urls.append(candidate_url)
+
+    try:
+        service_payload = _kubectl_json(namespace, ['get', 'service', service_name, '-o', 'json'])
+    except Exception:
+        service_payload = {}
+    _append_host(_as_text(_as_mapping(_as_mapping(service_payload).get('spec')).get('clusterIP')))
+
+    try:
+        endpoint_payload = _kubectl_json(namespace, ['get', 'endpoints', service_name, '-o', 'json'])
+    except Exception:
+        endpoint_payload = {}
+    subsets = endpoint_payload.get('subsets')
+    if isinstance(subsets, Sequence):
+        for subset in subsets:
+            if not isinstance(subset, Mapping):
+                continue
+            addresses = subset.get('addresses')
+            if not isinstance(addresses, Sequence):
+                continue
+            for address in addresses:
+                if not isinstance(address, Mapping):
+                    continue
+                _append_host(_as_text(address.get('ip')))
+    return resolved_urls
+
+
 def _is_transient_postgres_error(error: Exception) -> bool:
     message = str(error).lower()
     return any(pattern in message for pattern in TRANSIENT_POSTGRES_ERROR_PATTERNS)
@@ -444,16 +497,6 @@ def _http_clickhouse_query(
     http_url = _as_text(_resource_attr(config, 'http_url'))
     if http_url is None:
         raise RuntimeError('clickhouse http_url is required')
-    parsed = urlsplit(http_url)
-    if not parsed.scheme or not parsed.hostname:
-        raise RuntimeError(f'invalid_clickhouse_http_url:{http_url}')
-
-    connection_class = HTTPSConnection if parsed.scheme == 'https' else HTTPConnection
-    connection = connection_class(parsed.hostname, parsed.port)
-    path = parsed.path or '/'
-    if parsed.query:
-        path = f'{path}?{parsed.query}'
-
     headers = {'Content-Type': 'text/plain'}
     username = _as_text(_resource_attr(config, 'username'))
     password = _as_text(_resource_attr(config, 'password'))
@@ -462,12 +505,30 @@ def _http_clickhouse_query(
     if password is not None:
         headers['X-ClickHouse-Key'] = password
 
-    try:
-        connection.request('POST', path, body=query.encode('utf-8'), headers=headers)
-        response = connection.getresponse()
-        return response.status, response.read().decode('utf-8')
-    finally:
-        connection.close()
+    last_error: OSError | None = None
+    for candidate_url in _cluster_service_http_urls(http_url):
+        parsed = urlsplit(candidate_url)
+        if not parsed.scheme or not parsed.hostname:
+            raise RuntimeError(f'invalid_clickhouse_http_url:{candidate_url}')
+        connection_class = HTTPSConnection if parsed.scheme == 'https' else HTTPConnection
+        connection: HTTPConnection | HTTPSConnection | None = None
+        try:
+            connection = connection_class(parsed.hostname, parsed.port)
+            path = parsed.path or '/'
+            if parsed.query:
+                path = f'{path}?{parsed.query}'
+            connection.request('POST', path, body=query.encode('utf-8'), headers=headers)
+            response = connection.getresponse()
+            return response.status, response.read().decode('utf-8')
+        except OSError as exc:
+            last_error = exc
+            continue
+        finally:
+            if connection is not None:
+                connection.close()
+    if last_error is not None:
+        raise last_error
+    raise RuntimeError(f'invalid_clickhouse_http_url:{http_url}')
 
 
 def _condition_status(payload: Mapping[str, Any], *, condition_type: str) -> str | None:

--- a/services/torghut/scripts/start_historical_simulation.py
+++ b/services/torghut/scripts/start_historical_simulation.py
@@ -4107,6 +4107,8 @@ def _torghut_service_env_for_simulation(
         'TRADING_MODE': 'paper',
         'TRADING_ACCOUNT_LABEL': account_label,
         'TRADING_FEATURE_FLAGS_ENABLED': 'false',
+        'TRADING_STRATEGY_RUNTIME_MODE': 'scheduler_v3',
+        'TRADING_STRATEGY_SCHEDULER_ENABLED': 'true',
         'TA_CLICKHOUSE_URL': clickhouse_config.http_url,
         'TA_CLICKHOUSE_USERNAME': clickhouse_config.username or '',
         'TA_CLICKHOUSE_PASSWORD': clickhouse_config.password or '',

--- a/services/torghut/tests/test_start_historical_simulation.py
+++ b/services/torghut/tests/test_start_historical_simulation.py
@@ -1279,6 +1279,64 @@ class TestStartHistoricalSimulation(TestCase):
         self.assertEqual(headers.get('X-ClickHouse-User'), 'torghut')
         self.assertEqual(headers.get('X-ClickHouse-Key'), 'secret')
 
+    def test_verification_http_clickhouse_query_retries_kubernetes_service_endpoints(self) -> None:
+        attempted_hosts: list[str] = []
+
+        class _FakeResponse:
+            status = 200
+
+            def read(self) -> bytes:
+                return b'1'
+
+        class _FakeConnection:
+            def __init__(self, host: str, port: int | None) -> None:
+                attempted_hosts.append(host)
+                self._host = host
+
+            def request(
+                self,
+                method: str,
+                path: str,
+                body: bytes | None = None,
+                headers: dict[str, str] | None = None,
+            ) -> None:
+                if self._host == 'torghut-clickhouse.torghut.svc.cluster.local':
+                    raise OSError('[Errno 8] nodename nor servname provided, or not known')
+
+            def getresponse(self) -> _FakeResponse:
+                return _FakeResponse()
+
+            def close(self) -> None:
+                return None
+
+        def _fake_kubectl_json(namespace: str, args: tuple[str, ...]) -> dict[str, object]:
+            self.assertEqual(namespace, 'torghut')
+            if list(args[:3]) == ['get', 'service', 'torghut-clickhouse']:
+                return {'spec': {'clusterIP': '10.104.171.228'}}
+            if list(args[:3]) == ['get', 'endpoints', 'torghut-clickhouse']:
+                return {'subsets': []}
+            self.fail(f'unexpected kubectl args: {args!r}')
+
+        with (
+            patch('scripts.historical_simulation_verification.HTTPConnection', _FakeConnection),
+            patch('scripts.historical_simulation_verification._kubectl_json', side_effect=_fake_kubectl_json),
+        ):
+            status, body = historical_simulation_verification._http_clickhouse_query(
+                config=ClickHouseRuntimeConfig(
+                    http_url='http://torghut-clickhouse.torghut.svc.cluster.local:8123',
+                    username='torghut',
+                    password='secret',
+                ),
+                query='SELECT 1',
+            )
+
+        self.assertEqual(status, 200)
+        self.assertEqual(body, '1')
+        self.assertEqual(
+            attempted_hosts,
+            ['torghut-clickhouse.torghut.svc.cluster.local', '10.104.171.228'],
+        )
+
     def test_clickhouse_query_configs_resolves_service_endpoints(self) -> None:
         config = ClickHouseRuntimeConfig(
             http_url='http://torghut-clickhouse.torghut.svc.cluster.local:8123',
@@ -3031,6 +3089,14 @@ class TestStartHistoricalSimulation(TestCase):
             'true',
         )
         self.assertEqual(
+            env_by_name['TRADING_STRATEGY_RUNTIME_MODE'].get('value'),
+            'scheduler_v3',
+        )
+        self.assertEqual(
+            env_by_name['TRADING_STRATEGY_SCHEDULER_ENABLED'].get('value'),
+            'true',
+        )
+        self.assertEqual(
             env_by_name['TA_CLICKHOUSE_URL'].get('value'),
             'http://chi-torghut-clickhouse-default-0-0.torghut.svc.cluster.local:8123',
         )
@@ -3145,6 +3211,112 @@ class TestStartHistoricalSimulation(TestCase):
         self.assertEqual(
             env_by_name['TRADING_FEATURE_QUALITY_ENABLED'].get('value'),
             'true',
+        )
+        self.assertEqual(
+            env_by_name['TRADING_STRATEGY_RUNTIME_MODE'].get('value'),
+            'scheduler_v3',
+        )
+        self.assertEqual(
+            env_by_name['TRADING_STRATEGY_SCHEDULER_ENABLED'].get('value'),
+            'true',
+        )
+
+    def test_configure_torghut_service_allows_explicit_runtime_override(self) -> None:
+        resources = _build_resources(
+            'sim-runtime-override',
+            {
+                'dataset_id': 'dataset-a',
+            },
+        )
+        postgres_config = PostgresRuntimeConfig(
+            admin_dsn='postgresql://torghut:secret@localhost:5432/postgres',
+            simulation_dsn='postgresql://torghut:secret@localhost:5432/torghut_sim_sim_runtime_override',
+            simulation_db='torghut_sim_sim_runtime_override',
+            migrations_command='true',
+        )
+        kafka_config = KafkaRuntimeConfig(
+            bootstrap_servers='kafka:9092',
+            security_protocol='SASL_PLAINTEXT',
+            sasl_mechanism='SCRAM-SHA-512',
+            sasl_username='user',
+            sasl_password='secret',
+        )
+        service_payload = {
+            'spec': {
+                'template': {
+                    'spec': {
+                        'containers': [
+                            {
+                                'name': 'user-container',
+                                'image': 'registry.example/lab/torghut@sha256:abc',
+                                'env': [],
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+        captured_patch: dict[str, object] = {}
+
+        with (
+            patch(
+                'scripts.start_historical_simulation._kubectl_json',
+                return_value=service_payload,
+            ),
+            patch(
+                'scripts.start_historical_simulation._kubectl_patch',
+                side_effect=lambda namespace, kind, name, patch: captured_patch.update(
+                    {'namespace': namespace, 'kind': kind, 'name': name, 'patch': patch}
+                ),
+            ),
+        ):
+            _configure_torghut_service_for_simulation(
+                resources=resources,
+                manifest={
+                    'window': {
+                        'start': '2026-02-27T14:30:00Z',
+                        'end': '2026-02-27T21:00:00Z',
+                    }
+                },
+                postgres_config=postgres_config,
+                clickhouse_config=ClickHouseRuntimeConfig(
+                    http_url='http://clickhouse:8123',
+                    username='torghut',
+                    password='secret',
+                ),
+                kafka_config=kafka_config,
+                torghut_env_overrides={
+                    'TRADING_STRATEGY_RUNTIME_MODE': 'plugin_v3',
+                    'TRADING_STRATEGY_SCHEDULER_ENABLED': 'false',
+                },
+            )
+
+        patch_payload = captured_patch.get('patch')
+        self.assertIsInstance(patch_payload, dict)
+        assert isinstance(patch_payload, dict)
+        containers = (
+            patch_payload.get('spec', {})
+            .get('template', {})
+            .get('spec', {})
+            .get('containers', [])
+        )
+        self.assertIsInstance(containers, list)
+        assert isinstance(containers, list)
+        env_entries = containers[0].get('env') if containers else []
+        self.assertIsInstance(env_entries, list)
+        assert isinstance(env_entries, list)
+        env_by_name = {
+            str(item.get('name')): item
+            for item in env_entries
+            if isinstance(item, dict)
+        }
+        self.assertEqual(
+            env_by_name['TRADING_STRATEGY_RUNTIME_MODE'].get('value'),
+            'plugin_v3',
+        )
+        self.assertEqual(
+            env_by_name['TRADING_STRATEGY_SCHEDULER_ENABLED'].get('value'),
+            'false',
         )
 
     def test_offset_for_time_lookup_falls_back_for_missing_or_invalid_offset(self) -> None:


### PR DESCRIPTION
## Summary

- force historical simulation service revisions to pin the production scheduler runtime on by default so proof runs do not silently fall back to legacy mode
- preserve explicit simulation override behavior for strategy runtime flags and add regression coverage around the torghut service patch payload
- harden ClickHouse verification against in-cluster DNS failures by retrying Kubernetes service and endpoint IPs during proof analysis

## Related Issues

None

## Testing

- `uv run --frozen python -m unittest tests.test_start_historical_simulation.TestStartHistoricalSimulation.test_configure_torghut_service_preserves_existing_container_fields tests.test_start_historical_simulation.TestStartHistoricalSimulation.test_configure_torghut_service_applies_manifest_overrides tests.test_start_historical_simulation.TestStartHistoricalSimulation.test_configure_torghut_service_allows_explicit_runtime_override tests.test_start_historical_simulation.TestStartHistoricalSimulation.test_http_clickhouse_query_uses_post_with_query_body tests.test_start_historical_simulation.TestStartHistoricalSimulation.test_verification_http_clickhouse_query_retries_kubernetes_service_endpoints`
- `uv run --frozen ruff check scripts/start_historical_simulation.py scripts/historical_simulation_verification.py tests/test_start_historical_simulation.py`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`

## Breaking Changes

None
