### PR TITLE
chore(openclaw): grant cluster-admin to openclaw-vm service account

### DIFF
--- a/argocd/applications/openclaw/openclaw-vm-rbac.yaml
+++ b/argocd/applications/openclaw/openclaw-vm-rbac.yaml
@@ -65,3 +65,16 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: openclaw-vm-agentruns
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: openclaw-vm-cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: openclaw-vm
+    namespace: openclaw
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin


### PR DESCRIPTION
## Summary
- grant cluster-admin access to `ServiceAccount/openclaw-vm` via `ClusterRoleBinding/openclaw-vm-cluster-admin`
- keep existing openclaw RBAC objects; add explicit break from least-privilege by design per operator request

## Why
- operator requested full cluster-wide permissions for OpenClaw VM service account to unblock cluster and codebase operations

## Security impact
- this grants full administrative access to the cluster from the OpenClaw VM identity
- treat VM compromise as cluster compromise
- recommended mitigations: audit logs, key rotation, and periodic permission review

## Rollout
- merged and ArgoCD sync triggered for `argocd/Application/openclaw`
