### PR TITLE
fix(torghut): remove duplicate simulation metadata assertion

### DIFF
--- a/services/torghut/scripts/start_historical_simulation.py
+++ b/services/torghut/scripts/start_historical_simulation.py
@@ -3684,28 +3684,6 @@ def _assert_required_simulation_metadata_tables(config: PostgresRuntimeConfig) -
         label='assert_required_simulation_metadata_tables',
         operation=_validate,
     )
-    _assert_required_simulation_metadata_tables(config)
-
-
-def _assert_required_simulation_metadata_tables(config: PostgresRuntimeConfig) -> None:
-    def _validate() -> None:
-        with psycopg.connect(config.admin_simulation_dsn, autocommit=True) as conn:
-            with conn.cursor() as cursor:
-                missing_tables: list[str] = []
-                for table in SIMULATION_POSTGRES_REQUIRED_METADATA_TABLES:
-                    cursor.execute('SELECT to_regclass(%s)', (f'public.{table}',))
-                    row = cursor.fetchone()
-                    if row is None or row[0] is None:
-                        missing_tables.append(table)
-                if missing_tables:
-                    raise RuntimeError(
-                        'required_simulation_metadata_tables_missing:' + ','.join(sorted(missing_tables))
-                    )
-
-    _run_with_transient_postgres_retry(
-        label='assert_required_simulation_metadata_tables',
-        operation=_validate,
-    )
 
 
 def _remove_appledouble_sidecars(directory: Path) -> None:


### PR DESCRIPTION
## Summary

- Fix an accidental duplicate definition and recursive call in `start_historical_simulation.py`.
- Remove an invalid repeated helper definition that caused Pyright `reportRedeclaration` failures.
- Keep startup metadata-table validation behavior unchanged while making the function singular and idempotent.

## Related Issues

- None

## Testing

- `cd /workspace/lab/services/torghut && /tmp/uvenv/bin/uv sync --frozen --extra dev`
- `/tmp/uvenv/bin/uv run --frozen pyright --project pyrightconfig.json`
- `/tmp/uvenv/bin/uv run --frozen pyright --project pyrightconfig.alpha.json`
- `/tmp/uvenv/bin/uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
