### PR TITLE
feat(design): add torghut-quant resilience and profitability architecture contracts

### DIFF
--- a/docs/torghut/design-system/current-source-of-truth-and-priority-guide-2026-03-09.md
+++ b/docs/torghut/design-system/current-source-of-truth-and-priority-guide-2026-03-09.md
@@ -52,14 +52,15 @@ If the question is "what should I trust right now?", start here:
 The current highest-priority work is:
 
 1. replace query-derived control-plane freshness with the producer-authored ledger defined in
-   `docs/torghut/design-system/v6/39-freshness-ledger-and-hypothesis-proof-mesh-2026-03-14.md`
-   and complete rollout segmentation in `docs/torghut/design-system/v6/40-control-plane-resilience-and-safer-rollout-for-torghut-quant-2026-03-15.md`;
+   `docs/torghut/design-system/v6/39-freshness-ledger-and-hypothesis-proof-mesh-2026-03-14.md`;
 2. land hypothesis-scoped proof bundles so alpha readiness is based on persisted evidence rather than aggregate zeroed
    counters;
-3. complete profitability lanes and guardrails from
-   `docs/torghut/design-system/v6/41-torghut-quant-profitability-and-guardrail-architecture-2026-03-15.md`;
-4. keep the March 9 empirical-authority contract active by wiring recurring prove-and-promote automation into those
-   proof bundles.
+3. keep the March 9 empirical-authority contract active by wiring recurring prove-and-promote automation into those
+   proof bundles;
+4. isolate control-plane failure domains with rollout-safe gates in
+   `docs/torghut/design-system/v6/40-control-plane-resilience-and-safer-rollout-for-torghut-quant-2026-03-15.md`;
+5. implement hypothesis-specific profitability guardrails in
+   `docs/torghut/design-system/v6/41-torghut-quant-profitability-and-guardrail-architecture-2026-03-15.md`.
 
 This means the current next work is not:
 

--- a/docs/torghut/design-system/v6/40-control-plane-resilience-and-safe-rollout-contract-2026-03-15.md
+++ b/docs/torghut/design-system/v6/40-control-plane-resilience-and-safe-rollout-contract-2026-03-15.md
@@ -1,0 +1,231 @@
+# 40. Control-Plane Resilience and Safe Rollout Contract for Torghut Quant (2026-03-15)
+
+## Status
+
+- Date: `2026-03-15`
+- Maturity: `architecture decision + implementation contract`
+- Owner: `torghut-quant swarm architecture stage`
+- Scope: Jangar control-plane freshness quorum, dependency watch reliability, Knative rollout guardrails, and deployment-level rollback policy for the Torghut quant stack
+- Depends on:
+  - `docs/torghut/design-system/v6/39-freshness-ledger-and-hypothesis-proof-mesh-2026-03-14.md`
+  - `docs/torghut/design-system/v6/24-knative-probe-port-normalization-and-rollout-stability-2026-03-04.md`
+  - `docs/torghut/design-system/v6/25-knative-startup-probe-port-fix-2026-03-04.md`
+  - `docs/torghut/design-system/v6/26-database-migration-lineage-and-readiness-contract-2026-03-05.md`
+
+## Why this doc exists
+
+The March 15 cluster read is still showing a pattern where control-plane availability appears healthy while operational truth is not. The failure domains are now better mapped and need explicit architectural isolation before any further optimization work is safe.
+
+- `kubectl -n torghut get events ...` includes repeated probe and startup churn on the torghut Knative service.
+- `kubectl -n jangar get events ...` includes recurring `ErrorNoBackup` on `cluster/jangar-db-restore`.
+- `kubectl -n torghut get pods` shows one torghut pod cycling readiness under pressure.
+- `/api/torghut/trading/control-plane/quant/health` still reports dependency delay and low freshness confidence while dependency components may be recoverable individually.
+
+The control-plane is currently too coupled:
+
+- a single stream warning (`watch_reliability_degraded`) influences capital decisions;
+- fresh data errors can trigger broad dependency delays;
+- and readiness output does not separate evidence freshness from rollout noise.
+
+That coupling produces false negatives for profitable strategies and false positives for stability.
+
+## Problem statement
+
+The control-plane must absorb noisy runtime signals without turning them into irreversible platform-wide lockout. Three coupled failure modes currently dominate:
+
+1. Probe flapping creates temporary dependency delays because there is no durable, component-scoped truth source.
+2. Watch reliability is treated as a cross-cutting blocker, even when component-level continuity would support safe continuation.
+3. Rollout and dependency checks are evaluated in lockstep, so rollout noise (for example, temporary Knative readiness oscillation) can mask otherwise healthy data pipelines.
+
+## Evidence snapshot (March 15, 2026)
+
+- Cluster surface: repeated probe readiness issues in torghut and error-no-backup markers on jangar restore jobs indicate unstable startup and recovery conditions.
+- Source surface: `services/jangar/src/server/control-plane-status.ts` still includes `watch_reliability_degraded` as a direct quorum delay reason.
+- Source surface: `services/jangar/src/server/torghut-quant-status.ts` and `services/jangar/src/server/torghut-quant-metrics.ts` still aggregate freshness as direct control-plane gating signals.
+- Database surface: no explicit control-plane watcher durability ledger exists in the currently active `services/torghut/migrations/versions` lineage for producer-authored watch and rollout health rows.
+
+## Alternatives considered
+
+### Option A. Expand current probe tolerances
+
+Adjust probe thresholds, timeouts, and backoff windows to reduce noise.
+
+- Pros: quick and low-touch.
+- Cons: noise suppression is reactive, not structural; does not define a durable recovery contract; does not isolate failure modes across watch, rollout, and freshness paths.
+
+### Option B. Remove watch-reliability from gating entirely
+
+Ignore `watch_reliability_degraded` from capital decision logic and rely solely on raw endpoint and freshness numbers.
+
+- Pros: prevents one noisy stream from blocking all hypotheses.
+- Cons: can hide real ingestion blind spots and shifts failure risk to silent drift.
+
+### Option C. Chosen. Introduce a control-plane resilience spine with segment-local failure semantics
+
+Split control-plane truth into three independently surfaced planes:
+
+- rollout safety plane (`provision_readiness`, `startup_stability`);
+- dependency-data truth plane (`component_observations`, `component_rollups`);
+- authority plane (the schema and readiness reason bundle consumed by Torghut).
+
+This keeps fail-closed behavior but reduces blast radius from single-surface failure.
+
+## Decision
+
+Implement `control-plane resilience spine v2` with:
+
+- bounded, producer-authored freshness observation records,
+- per-surface quorum thresholds,
+- explicit degradation modes (`degraded`, `blocked`, `unknown`) with hard TTLs,
+- and staged rollout gating where rollout noise cannot directly force capital lockouts unless evidence plane confirms it.
+
+## Architecture
+
+### 1) Control-plane observation contract
+
+Define durable observations for Jangar control-plane components:
+
+- `control_plane_component_observations` rows:
+  - `component` in:
+    - `knative_startup`,
+    - `watch_ingest`,
+    - `ta_signal_freshness`,
+    - `market_context_bundle`,
+    - `empirical_job_scheduler`.
+  - `scope_key` for workload/component identifier,
+  - `observation_ts`,
+  - `status` (`healthy`, `degraded`, `blocked`, `unknown`),
+  - `freshness_seconds`,
+  - `ttl_seconds`,
+  - `quality_score`,
+  - `reason_code` and `reason_chain`,
+  - `evidence_ref` list.
+
+- `control_plane_component_rollups` rows:
+  - same keying and a fixed set of `status_by_surface`,
+  - `effective_at`,
+  - `degradation_budget_remaining`,
+  - `quorum_decision`,
+  - `last_good_until`.
+
+Producer responsibility:
+
+- write all high-value observations directly from producers (watchers, schedulers, ta pipelines),
+- attach explicit evidence references for every status transition.
+
+Consumer responsibility:
+
+- read rollups for live gating,
+- surface legacy compatibility fields for staged cutover,
+- degrade only the relevant plane when a single observation is stale.
+
+### 2) Dependency quorum rewrite
+
+Replace direct `watch_reliability_degraded` hard dependency behavior with:
+
+- `surface_health = blocked` only when both:
+  - watch replay freshness exceeds `watch_staleness_budget_seconds`, and
+  - no valid `last_good_until` exists.
+- else mark `surface_health = degraded` and continue with explicit warning reasons.
+
+### 3) Rollout safety gates
+
+Add staged rollout guardrail:
+
+- `rollout_gate_level=preview`:
+  - no capital gating,
+  - require 2 consecutive successful readiness reports.
+- `rollout_gate_level=shadow`:
+  - compute shadow dependency decision,
+  - no hard block,
+  - export mismatch telemetry.
+- `rollout_gate_level=enforced`:
+  - enable hard block only for components whose quorum and freshness budgets expired.
+
+### 4) Failure-mode reduction and self-healing
+
+Each failing surface gets one explicit recovery strategy:
+
+- `watch_ingest`: bounded stale-window fallback and per-stream grace period,
+- `knative_startup`: container-specific restart suppression during expected cold start windows plus readiness probe budget,
+- `empirical_job_scheduler`: automatic recovery task with idempotent re-run marker,
+- `market_context_bundle`: source-of-true bundle missing triggers `market_context_bundle_stale` rather than global delay.
+
+## Implementation contract
+
+### Engineering stage
+
+1. Add observation and rollup table definitions in Jangar source-of-truth persistence path with strict schema migration.
+2. Emit producer observations for at least:
+   - watch stream partitions,
+   - ta freshness snapshot completion,
+   - market-context bundle materialization,
+   - empirical job completion.
+3. Split dependency quorum logic into per-surface thresholds.
+4. Add explicit comparison output in control-plane status response:
+   - legacy decision,
+   - spine decision,
+   - mismatch reason set.
+5. Add rollout gate feature flags:
+   - `control_plane_rollout.preview.enabled`,
+   - `control_plane_rollout.shadow.enabled`,
+   - `control_plane_rollout.enforced.enabled`.
+
+### Validation gates (engineering)
+
+- Jangar readiness remains safe under stale watch stream without whole-system lockout.
+- `watch_reliability_degraded` no longer hard-blocks all hypotheses unless its surface decision and freshness budget require it.
+- No repeated emergency dependency blocks during stable one-market-session operation.
+- Hot-path query fallback to broad scans is gone; control-plane path relies on rollup read and bounded lookbacks.
+
+### Deployer stage
+
+1. Deploy dual-write mode for 1 full regular session.
+2. Move to shadow mode and compare legacy vs rollup decision divergence.
+3. Enable enforced gate only when no critical mismatch persists for at least one session.
+
+## Rollout plan
+
+1. **Wave 1 (safe dual-write):** keep existing semantics but begin recording control-plane observations and rollups.
+2. **Wave 2 (shadow read):** add comparison telemetry and maintain existing control decision as source of truth.
+3. **Wave 3 (enforced gates):** enable surface-scoped gate semantics with stricter safety toggles and rollback plan active.
+4. **Wave 4 (steady-state cleanup):** remove deprecated global reason paths, keep compatibility aliases for one release train.
+
+## Rollback plan
+
+- Disable the spine read path and return to legacy `watch_reliability_degraded` path.
+- Preserve observation tables for forensics, do not delete rows.
+- If control-plane false negatives rise above threshold, disable `control_plane_rollout.enforced.enabled` within 15 minutes and revert to shadow mode.
+
+Hard rollback triggers:
+
+- enforced gate differs from legacy on two consecutive sessions with no source correction,
+- startup flaps increase by more than 2x while table writes remain healthy,
+- control-plane schema check fails or migration lineage mismatch appears.
+
+## Risks
+
+- More moving parts means more schema maintenance.
+- Incorrect TTLs could amplify unknown states if not tuned.
+- Without strict evidence references, false confidence can persist in dashboards.
+- Too-strongly partitioned gates can over-fragment operator interpretation.
+
+## Expected outcomes
+
+- Immediate resilience improvement from failure isolation.
+- Lower false negatives from control-plane noise.
+- Safer, staged rollout with explicit rollback path and measured activation criteria.
+
+## Engineer handoff acceptance
+
+1. Observation producers and rollup consumers are implemented with migration lineage tracked.
+2. Control-plane status includes legacy-vs-spine decision comparison.
+3. Rollout gate toggles exist and can be switched by deployers without schema changes.
+4. One full session completed in dual-write + shadow mode with no unresolved safety mismatch.
+
+## Deployer handoff acceptance
+
+1. Rollout gates are controlled through config and documented in GitOps.
+2. A minimum of one production session runs in shadow mode and one in enforced mode.
+3. Emergency rollback command path and monitoring runbook exist before enforced mode enablement.
+4. No unresolved hard mismatches between legacy and spine decisions by the end of enforced rollout.

--- a/docs/torghut/design-system/v6/41-profitability-hypothesis-and-guardrail-contract-2026-03-15.md
+++ b/docs/torghut/design-system/v6/41-profitability-hypothesis-and-guardrail-contract-2026-03-15.md
@@ -1,0 +1,190 @@
+# 41. Profitability Hypothesis Mesh and Guardrail Architecture for Torghut Quant (2026-03-15)
+
+## Status
+
+- Date: `2026-03-15`
+- Maturity: `architecture decision + implementation contract`
+- Owner: `torghut-quant swarm architecture stage`
+- Scope: Torghut hypothesis lifecycle, empirical proof granularity, and profit-constrained capital ramp rules
+- Depends on:
+  - `docs/torghut/design-system/v6/39-freshness-ledger-and-hypothesis-proof-mesh-2026-03-14.md`
+  - `docs/torghut/design-system/v6/32-authoritative-alpha-readiness-and-empirical-promotion-closeout-2026-03-08.md`
+  - `docs/torghut/design-system/v6/08-profitability-research-validation-execution-governance-system.md`
+
+## Why this doc exists
+
+The current Torghut readiness contract is still aggregate-first. That design is useful for uptime, but weak for profitability governance.
+
+Current behavior ties multiple hypotheses to one set of process counters and leaves promotion with reduced interpretability. This is the same failure that causes:
+
+- `promotion_eligible_total` to look zero while real process windows are partially useful,
+- independent hypotheses to block one another due to shared counters,
+- and empirical absence to be inferred indirectly from missing live counters.
+
+This design introduces a hypothesis mesh with measurable profitability gates and explicit divergence rules.
+
+## Problem statement
+
+Three risks are currently highest:
+
+1. **Counter collapse:** counters across families merge evidence quality into one integer path.
+2. **No portfolio of hypotheses:** a single stale indicator can disable all hypotheses, including those with independent evidence.
+3. **No measurable profit guardrail by lane:** promotion decisions do not enforce post-cost profitability and run-cost discipline at each evidence window.
+
+## Evidence snapshot (March 15, 2026)
+
+- Source surface: `services/torghut/app/trading/hypotheses.py` still computes readiness from process counters (for example `feature_batch_rows_total`, `drift_detection_checks_total`) and uses shared reasons.
+- Source surface: `services/torghut/app/main.py` surfaces these counters in health payloads, but no dedicated hypothesis proof lineage is yet contract-bound to every stage.
+- Source surface: `services/jangar/src/server/torghut-quant-status.ts` does not yet expose independent per-hypothesis profitability evidence state.
+- Database surface: migration history includes governance and empirical-job artifacts, but no dedicated per-hypothesis proof window/fitness tables for production guardrails in the latest schema lineage.
+
+## Alternatives considered
+
+### Option A. Keep aggregate counters and add more threshold tuning
+
+- Pros: minimal changes.
+- Cons: does not create per-hypothesis isolation or robust profitability attribution, so low-margin hypotheses can be masked by healthy families.
+
+### Option B. Centralize everything in Jangar with a single promotion gate
+
+- Pros: single visibility point.
+- Cons: increases control-plane coupling and does not preserve Torghut-native profitability policy boundaries.
+
+### Option C. Chosen. Hypothesis mesh with profitability-first proof windows and explicit risk envelope
+
+Keep Torghut as authority for profitability while giving Jangar a durable evidence source of readiness state. This keeps execution and research boundaries intact and enables measurable cross-hypothesis behavior.
+
+## Decision
+
+Adopt a three-layer profitability architecture:
+
+1. **Hypothesis contract layer** for independent evidence windows and blockers.
+2. **Profit envelope layer** for post-cost expectancy, max drawdown, and execution quality controls.
+3. **Capital controller layer** that gates allocation per hypothesis by weighted confidence and risk state.
+
+This allows profitable hypotheses to remain active while unprofitable or under-proven ones hold or shrink.
+
+## Architecture
+
+### 1) Hypothesis proof windows
+
+Define per-hypothesis persisted windows:
+
+- `hypothesis_profit_windows`:
+  - `hypothesis_id`,
+  - `window_id`,
+  - `window_start`, `window_end`,
+  - `feature_coverage` by family and symbol set,
+  - `continuity_score`,
+  - `market_context_state`,
+  - `empirical_refs`,
+  - `signal_quality_score`,
+  - `created_at` + `source_ref`.
+- `hypothesis_profit_readiness`:
+  - `hypothesis_id`,
+  - `window_id`,
+  - `readiness_state` (`ready`, `blocked`, `degraded_last_good`, `failed`),
+  - `degrade_reason_set`,
+  - `proof_ttl_seconds`,
+  - `next_review_at`.
+
+### 2) Profitability hypotheses and measurable guardrails
+
+Each hypothesis publishes explicit measurable hypotheses with minimum acceptance values before canary:
+
+- **H1: Market-context continuity hypothesis**
+  - minimum continuity score threshold,
+  - max tolerated missing-domain ratio,
+  - stale bundle penalty curve by domain.
+- **H2: Signal-to-slippage hypothesis**
+  - post-cost expectancy must be positive across at least `N` trades in the proof window,
+  - realized slippage must remain below a configurable percentile envelope,
+  - order rejects and fallback ratio must stay below threshold.
+- **H3: Regime transfer hypothesis**
+  - no promotion from one regime profile to another without independent proof refresh,
+  - regime confusion score must improve versus last-good evidence.
+
+These hypotheses are testable and explicit enough for engineering and deployers to monitor independently.
+
+### 3) Capital envelope and allocation coupling
+
+Capital controller uses per-hypothesis budgets:
+
+- `base_alloc_pct` from governance baseline,
+- `profit_guardrail_multiplier` from recent proof quality,
+- `empirical_job_validity_ratio` multiplier,
+- `confidence_clip` when evidence freshness degrades.
+
+No single counter can disable all hypotheses anymore; each hypothesis has independent readiness plus a capped global safety floor.
+
+### 4) Proof refresh and canary policy
+
+- proof windows must refresh before any capital-up decision.
+- canary promotion for any hypothesis requires:
+  - fresh proof window,
+  - at least one positive post-cost trade cohort,
+  - no critical guardrail violations.
+- a blocked hypothesis can still feed feature ranking telemetry, but must not consume new capital.
+
+## Implementation contract
+
+### Engineering stage
+
+1. Add persistence for the two tables above in Torghut migration path.
+2. Write proof windows from runtime evidence producers and attach empirical-job family refs.
+3. Expose `proof_window_id`, `proof_score`, and `readiness_state` in `/trading/status` and `/trading/health`.
+4. Refactor readiness reasons in `services/torghut/app/trading/hypotheses.py` to reason from proof windows first, counters as telemetry.
+5. Implement hypothesis-level capital control in scheduler paths with explicit dealloc-on-block actions.
+
+### Validation gates (engineering)
+
+- Hypothesis readiness must diverge by family in at least one session window without cross-hypothesis bleed.
+- A hypothesis blocked by empirical-job absence must report that reason directly and not rely on opaque aggregate counters.
+- Post-cost profitability and slippage guardrails reject promotion even if process counters appear healthy.
+- Rollback behavior keeps persisted proof windows and surfaces stale but traceable reasons.
+
+### Deployer stage
+
+1. Deploy proof write path in dual-write mode for one full US session.
+2. Enable proof-backed readiness in shadow mode and compare reason maps with legacy view.
+3. Enable canary capital controls for one hypothesis at a time.
+
+## Rollout plan
+
+1. **Wave 1 (ledger + contracts):** dual-write proof windows and readiness rows.
+2. **Wave 2 (shadow read):** maintain legacy reasons alongside proof-based reasons.
+3. **Wave 3 (proof-first):** use proof readiness for scheduler/capital decisions.
+4. **Wave 4 (guardrail tightening):** progressively enforce post-cost profitability and drawdown thresholds.
+
+## Rollback plan
+
+- Disable proof-first mode and switch back to legacy counters if proof freshness mismatch exceeds session tolerance.
+- Pause any hypothesis that entered proof-ready without sufficient empirical refresh.
+- Retain all proof windows and readiness rows for forensic comparison.
+
+## Risks
+
+- Migration load if proof windows are produced at too granular a resolution.
+- Overfitting to short windows if window size policies are not regime-aware.
+- Hypothesis-specific deallocations can increase operational complexity if not explained in operator dashboards.
+- Guardrail strictness can over-prune in volatile sessions if envelope parameters are not adaptive.
+
+## Expected outcomes
+
+- Measurable profitability gates become first-class contract terms.
+- Multiple hypotheses can be evaluated and traded independently.
+- Promotion and capital decisions become auditable by proof lineage, not by opaque runtime counters.
+
+## Engineer handoff acceptance
+
+1. Proof window persistence and proof-based hypothesis readiness are implemented and observable.
+2. `/trading/status` and `/trading/health` provide proof lineage and readiness states with timestamped evidence refs.
+3. Capital scheduler uses hypothesis-level decisions with explicit dealloc controls.
+4. At least one session validates divergent readiness between two hypotheses under mixed evidence conditions.
+
+## Deployer handoff acceptance
+
+1. At least one session runs with proof-first scheduler for a controlled subset.
+2. Guardrails show explicit reject reasons for post-cost expectancy, drawdown, or slippage breaches.
+3. No hard capital lockout occurred from unrelated hypothesis failure states.
+4. Rollback toggles are documented and can be exercised without schema mutation.


### PR DESCRIPTION
## Summary

- Added two production-grade architecture documents that define the next Torghut quant control-plane and profitability implementation contracts:
  - `docs/torghut/design-system/v6/40-control-plane-resilience-and-safe-rollout-contract-2026-03-15.md`
  - `docs/torghut/design-system/v6/41-profitability-hypothesis-and-guardrail-contract-2026-03-15.md`
- Updated Torghut design source-of-truth maps so these contracts are now the active priority for the Jan/Mar 2026 operations plan:
  - `docs/torghut/design-system/current-source-of-truth-and-priority-guide-2026-03-09.md`
  - `docs/torghut/design-system/v6/index.md`
- Defined alternatives, explicit decisions, validation gates, rollout and rollback behavior, and engineer/deployer acceptance criteria for both reliability and profitability stages.

## Related Issues

None.

## Testing

- `git diff` review of updated design sources and docs.
- `cat`/`sed` validation of new documents for required sections: problem context, alternatives, decision, validation, rollout, rollback, risks, and handoff conditions.
- No runtime code paths were changed; only architecture and source-of-truth documentation was updated.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Documentation sections are filled and align to current-source of truth.
- [x] Architecture PR defines explicit rollout and rollback behavior for engineer and deployer handoff.
