### PR TITLE
docs(architecture): add control-plane reliability and torghut profitability design contracts

### DIFF
--- a/docs/agents/designs/42-jangar-control-plane-failure-mode-reduction-and-safe-rollout-contract-2026-03-15.md
+++ b/docs/agents/designs/42-jangar-control-plane-failure-mode-reduction-and-safe-rollout-contract-2026-03-15.md
@@ -1,0 +1,191 @@
+# 42. Jangar Control-Plane Failure-Mode Reduction and Safe Rollout Contract (2026-03-15)
+
+## Objective
+
+Increase control-plane reliability through explicit failure-domain reduction, deterministic recovery behavior, and rollout safety defaults that prevent stale or partial mission progress from propagating changes to production.
+
+This design is for the `jangar-control-plane` swarm lane and defines what is required for autonomy to continue while reducing the blast radius of:
+
+- stale stage schedules,
+- inconsistent run status, and
+- rollout progress during unresolved dependency health regressions.
+
+## Current Assessment Snapshot
+
+Observations captured at `2026-03-15`:
+
+- `jangar-control-plane` and `torghut-quant` are both `phase=Frozen` in `swarm` status.
+- The active freeze reason on `jangar-control-plane` is `StageStaleness`.
+- Stage cadence is `1h`, but evidence shows repeated last-run times and age windows from March 8, while freeze window started March 11, indicating stale progression.
+- Deployment health is healthy at rollout level, but with `requirements.pending=5` and `stageStates.*.phase=Frozen`.
+- Event history includes `BackoffLimitExceeded` for `torghut-swarm-verify-template-step-1-attempt-1`, showing stage-level failure recovery did occur but lacks a general safe recovery policy for all stage classes.
+- `/api/agents/control-plane/status?namespace=agents` reports database migration health `healthy` with all migrations applied, plus watch stream health `status=healthy`.
+- `/api/agents/control-plane/status` exposes a high failure potential in watch ingestion (`agentrun_ingestion.message="agents controller not started"` with null last event).
+
+## Problem Definition
+
+1. **Failure modes are detected but not codified into staged recovery lanes.**
+   The system can freeze safely, but currently has to rely on operator intervention to re-arm when multiple stage timers drift.
+2. **Safety gate conditions are broad, not failure-class aware.**
+3. **Rollout behavior assumes green controller state, not green dependency state.**
+   If critical dependency freshness degrades during rollout, the runbook lacks a hard guardrail that blocks canary progression preemptively.
+4. **Evidence continuity between stage-level failures and cluster-level rollout is weak.**
+   The control surface can read failures, but decision traceability between freeze cause and rollout effect is manual.
+
+## Source Architecture Review (High-Risk Modules + Coverage Notes)
+
+- `services/jangar/src/server/control-plane-status.ts` is the primary status spine, but it is only a read surface.
+- `services/jangar/src/server/supporting-primitives-controller.ts` and
+  `services/jangar/src/server/orchestration-controller.ts` control mission phase transitions and workflow scheduling.
+- `services/jangar/src/server/control-plane-watch-reliability.ts` already tracks watch restarts but has no explicit contract for automatic stage recovery thresholds.
+- `services/jangar/src/server/torghut-trading.ts` and `services/jangar/src/server/torghut-quant-runtime.ts` feed dependency and runtime signals used by `jangar-control-plane`.
+- Test coverage is present for caching, controller APIs, and route responses, but there is no direct regression test proving:
+  - freeze-to-recovery state transitions for mixed stage failures,
+  - rollback precondition checks before canary step transitions, or
+  - end-to-end dependency degradation blocking rollout steps.
+
+These are the sources that need explicit design guardrails before production autonomy can be expanded safely.
+
+## Architecture Alternatives
+
+### Option A — Keep current freeze behavior, improve operator runbooks
+
+- **Scope**: documentation only; no control-loop changes.
+- **Pros**: fast to execute; predictable.
+- **Cons**: no reduction in MTTR for repeated stage failures; still dependent on manual triage under sustained staleness.
+
+### Option B — Introduce static guard constants only
+
+- **Scope**: add one-time constants for max stale age and strict freeze thresholds.
+- **Pros**: easy to reason about and quick to roll out.
+- **Cons**: brittle under market/session drift and does not distinguish recoverable from non-recoverable failure classes.
+
+### Option C — Implement a failure-class-aware reliability gate and release guardrail stack (recommended)
+
+- **Scope**: model stage and rollout behavior as a failure-domain graph:
+  - Stage failure class + age bucket determines automatic response.
+  - Dependency degradation and watch health are explicit rollout gates.
+  - Rollout is blocked by unresolved dependency classes even if deployment health looks green.
+- **Pros**: highest control and lowest blast radius; supports autonomous recovery while staying fail-closed.
+- **Cons**: requires coordinated changes to control-plane policy evaluation and controller tests.
+
+## Decision
+
+Adopt **Option C**. The design keeps the platform safe while still enabling measurable autonomy.
+
+## Target Design
+
+### 1) Failure-class model
+
+Define three classes for stage failures:
+
+- **Transient**: single-stage pod errors, short-lived watch restarts, one-off artifact fetch misses.
+- **Systemic**: repeated run failures, repeated empty event windows, unresolved dependency quorum.
+- **Critical**: security or policy violation, repeated freeze breaches above threshold, or controller initialization failure.
+
+Each class maps to a deterministic response:
+
+- Transient: automatic re-run with exponential delay and capped retries.
+- Systemic: class-specific holdoff, auto-unfreeze once recovery evidence exists, and explicit stage re-open.
+- Critical: lock freeze and publish incident/repair action with minimal privilege.
+
+### 2) Stage recovery playbook
+
+For each stage (`discover`, `plan`, `implement`, `verify`):
+
+1. collect `last_success_at`, `last_error_at`, and `last_run_age`.
+2. apply failure-class policy from above.
+3. only escalate to freeze when:
+   - age > configured fail-fast threshold, and
+   - one of:
+     - repeated same-class failures beyond max attempts,
+     - unresolved dependency dependency quorum fail,
+     - stale state persistence.
+4. require evidence from control-plane status before unfreeze:
+   - stage staleness reduced below configured upper bound,
+   - dependency check class downgraded,
+   - readiness report is available for at least one full cycle.
+
+### 3) Safe rollout preconditions
+
+Add rollout precondition predicates before any canary step executes:
+
+- `dependency_quorum.decision` must be `allow`.
+- `empirical_services.jobs.status` must not be in `degraded` (or be explicitly whitelisted with a written override).
+- `agentrun_ingestion.status` not unknown; if unknown, block rollout and log required-fix.
+- `watch_reliability.total_errors` must be within threshold for the window.
+
+If any predicate fails, hold canary progression at current weight and execute rollback-preventive hold action.
+
+### 4) Recovery evidence contract
+
+Every unfreeze and every rollout resume must emit evidence bundle fields:
+
+- `freeze.reason`, `freeze.threshold`, `freeze.durationMs`
+- stage age recovery points
+- dependency predicate verdicts
+- rollback condition checks
+- validation artifacts (tests and status snapshots)
+
+These fields are written once and reused for mission artifact generation.
+
+## Validation Gates
+
+### Engineering gates
+
+- New tests covering stage class transitions for all 4 stages.
+- Regression tests for rollout precondition failures blocking canary advancement.
+- Integration test for unfreeze path that shows stage recovery after dependency recovery.
+- Unit tests ensuring dependency classes map deterministically to actions.
+
+### Deployer gates
+
+- Argo rollout blocked when dependency predicates fail.
+- Canaries must pass one cycle at each step before auto-advancement.
+- `service` endpoints in control-plane status must show healthy database and watch streams before merge gates open.
+- Auto-rollback must restore previous weights when rollout preconditions fail mid-flight.
+
+### Operations gates
+
+- `stageStaleness.ageMs` never exceeds `3x` stage cadence after mitigation.
+- No more than one freeze-trigger class per 24h without incident closure annotation.
+- `requirements.pending` trend declines to zero in first successful recovery cycle.
+
+## Rollout and Rollback Expectations
+
+### For Engineer (implementation stage)
+
+- First merge should include:
+  - schema for failure-class records,
+  - policy evaluator updates in status/watch stack,
+  - controller-level recovery tests.
+- Stage rollout should be feature-flagged.
+- Ship with one controlled staging mission before any production branch freeze changes.
+
+### For Deployer (production stage)
+
+- Enable rollout preconditions and holdoff first in staging namespace.
+- Observe one complete cycle:
+  - one stage staleness event,
+  - auto-recovery path,
+  - rollback holdback and re-open,
+  - healthy re-freeze clearance.
+- Expand rollout to production only after zero regression signal in 2 consecutive cycles.
+
+## Risks and Failure Modes
+
+- **Over-constraining gates** can lengthen mission duration. Mitigation: staged thresholds and explicit override with expiry.
+- **Incorrect classification of transient vs systemic failures** can cause unnecessary freezes. Mitigation: class counters with decay.
+- **Dependency gate false positives** could block legitimate recoveries. Mitigation: allowlist + evidence expiry for known intermittent signals.
+- **Incomplete historical linkage** if evidence bundles are not serialized consistently. Mitigation: mandatory evidence schema plus mandatory artifact references.
+
+## Exit Criteria
+
+- Both control-plane and deployer can show successful stage recovery with at least one documented stale-run instance per stage class.
+- Rollout does not progress when dependency gates fail.
+- Post-recovery mission logs include recovery reason + class + explicit recovery timestamp and evidence references.
+
+## References
+
+- `docs/agents/designs/28-` and `docs/agents/designs/29-` design line are the current production readyness context.
+- This document extends and supersedes previous control-plane stage-readiness assumptions around static freeze handling.

--- a/docs/torghut/design-system/v6/40-decision-profitability-circuit-and-evidenced-capital-allocation-2026-03-15.md
+++ b/docs/torghut/design-system/v6/40-decision-profitability-circuit-and-evidenced-capital-allocation-2026-03-15.md
@@ -1,0 +1,191 @@
+# 40. Decision-Quality and Profitability Circuit for Torghut Trading (2026-03-15)
+
+## Objective
+
+Increase profitable decision throughput by introducing a staged, evidence-first profitability circuit that converts live/training signals into controlled capital allocation decisions.
+
+This design is for the `torghut-quant` lane and focuses on measurable hypotheses plus guardrails that prevent scale before signal quality and execution truth are proven.
+
+## Current Assessment Snapshot
+
+- `api/torghut/trading/strategies` currently exposes two strategies:
+  - `4b0051ba-ae40-43c1-9d8b-ad5a57a2b8f6` (`intraday-tsmom-profit-v2`, enabled)
+  - `a4b5ba1c-d749-4522-bdab-9b26d2fa68de` (`macd-rsi-default`, disabled)
+- `api/torghut/trading/control-plane/quant/health` for active strategy returns:
+  - `status=ok`,
+  - `latestMetricsCount=0`,
+  - `runtimeEnabled=true`,
+  - `stages=[]` (no active stage lag metrics in window).
+- `api/torghut/trading/summary?strategy_id=...&day=2026-03-15` returns:
+  - `decisions.generatedCount=0`,
+  - `executions.filledCount=0`,
+  - `submissionFunnel.submittedCount=0`,
+  - `rejections.rejectedCount` with dominant blockers (`symbol_capacity_exhausted`, `qty_below_min`),
+  - runtime profitability caveat flags indicating evidence is proxy-heavy and not profitability-certain.
+- `api/agents/control-plane/status?namespace=agents` reports empirical services with `empirical:jobs` degraded in `namespaces[0]`.
+- `series` endpoint for active strategy returns an empty series window when queried with the default account and 24h bounds.
+
+## Problem Definition
+
+The system has solid control-plane plumbing but weak trading action throughput and weak decision-quality assurance in the paper-to-live bridge.
+
+Current pain points:
+
+1. **Paper signal generation is low despite runtime health.**
+2. **Execution quality evidence is insufficiently tied to promotion decisions.**
+3. **Symbol/qty rejections dominate business activity**, suggesting the strategy is blocked before it can become profitable rather than tested in a controlled capital ladder.
+4. **Empirical job freshness is degraded**, so strategy confidence can be computed on incomplete data.
+
+## Source Architecture Review
+
+Relevant high-impact modules:
+
+- `services/jangar/src/server/torghut-trading.ts` and
+  `services/jangar/src/server/torghut-symbols.ts` shape market context and symbol constraints.
+- `services/jangar/src/server/torghut-quant-runtime.ts` and
+  `services/jangar/src/server/torghut-quant-runtime-materialization` define runtime and materialization behavior.
+- `services/jangar/src/routes/api/torghut/trading/control-plane/quant/*` provide health, summary, and time-series signals for gating promotion.
+- `services/jangar/src/server/__tests__/torghut-trading-summary.test.ts` already tracks blocked decision causes and funnel metrics, which can be extended for new profitability gates.
+
+Gap from source view:
+
+- No explicit profitability allocator circuit that transitions capacity from `shadow` to broader capital bands on measured evidence.
+- No closed-form hypothesis schema that requires both pre-trade and post-trade evidence to move a strategy across bands.
+- No single source document that binds rejection reasons to adaptive remediation actions.
+
+## Architecture Alternatives
+
+### Option A — Tune existing thresholds
+
+- **Pros**: quick and minimal risk to code.
+- **Cons**: does not solve root issue that no hypothesis has to meet staged performance truth before scaling.
+
+### Option B — Add execution-side controls only
+
+- **Pros**: can prevent bad executions and protect capital immediately.
+- **Cons**: still allows promotion of weak hypotheses at shadow levels; no evidence of profitability learning.
+
+### Option C — Introduce a hypothesis-led profitability circuit with capital-stage ladder (recommended)
+
+- **Pros**: highest signal quality and auditable path from decision signal -> evidence -> promotion.
+- **Cons**: larger implementation scope and requires tighter coupling between Torghut runtime + Jangar artifact contract.
+
+## Decision
+
+Adopt **Option C**.
+
+## Target Design
+
+### 1) Hypothesis Ledger and Capital Ladder
+
+Create a unified lifecycle:
+
+1. **Hypothesis definition**
+   - strategy_id + objective + expected effect size + risk budget.
+2. **Pilot (`shadow`)**
+   - auto-enter with bounded capital budget and strict rejection telemetry.
+3. **Canary (`paper`)**
+   - only if shadow proves directional signal quality and capacity constraints are not structural.
+4. **Scale (`live`)**
+   - only if paper-to-live divergence and post-cost metrics validate within guardrails.
+
+### 2) Measurable Hypotheses and Guardrails
+
+#### H1: Decision Lift and Throughput
+
+- Hypothesis passes to `paper` if in 24h:
+  - `decisions.plannedCount >= 300` and `decisions.generatedCount >= 300`,
+  - `plannedCount - blockedCount >= 120`,
+  - ratio(`blockedCount`, `generatedCount`) < `0.30`.
+- Fail-safe if repeated `qty_below_min` or `symbol_capacity_exhausted` exceed `2/3` of blocked reasons.
+
+#### H2: Execution and Cost Sanity
+
+- Hypothesis passes canary if over 7d rolling window:
+  - `executionCount >= 5`,
+  - `avgAbsSlippageBps <= 2x` historical baseline for the same symbol class,
+  - realizedPnL proxy must trend non-negative for 3 consecutive windows with no missing materialized metrics.
+
+#### H3: Live Proof Stability
+
+- Promotion to wider live bands requires 72h observed live window with:
+  - `max drawdown >= -1.5%` at portfolio level,
+  - `decision_count >= 100`,
+  - rolling sharpe above `0` for 2 consecutive windows,
+  - no unresolved empirical freshness degradation.
+
+### 3) Evidence-First Gate Chain
+
+Each ladder transition requires a single evidence manifest with:
+
+- strategyId + hypothesisId,
+- decision funnel snapshot,
+- rejection split and top reasons,
+- replay or time-series proof references,
+- dependency gate status,
+- capital band transition action and timestamp.
+
+### 4) De-risking the Execution Boundary
+
+- Introduce pre-allocation capacity checks that enforce symbol-level exposure and minimum order quantity before strategy-wide scaling.
+- Route repeated rejection clusters into a remediation task:
+  - `symbol_capacity_exhausted` -> symbol universe prune/refactor task,
+  - `qty_below_min` -> order sizing policy task.
+- Keep the strategy active in `shadow` until remediation and revalidation complete.
+
+## Validation Gates
+
+### Scientist / Algorithm Gate
+
+- new hypotheses only if baseline comparator exists for same strategy and window,
+- no synthetic metrics permitted for gating;
+  all required fields must be non-empty and timestamped in DB.
+
+### Engineer Gate
+
+- schema-level tests for hypothesis manifest,
+- tests proving hypothesis transitions require all gate conditions.
+- regression test proving rejection clusters trigger remediation task references.
+
+### Deployer Gate
+
+- no transition from `shadow` to `paper` without a completed manifest,
+- no transition from `paper` to live without live observation evidence and dependency clearance,
+- deployment rollback if live proof drops below guardrails within 72h.
+
+## Rollout Plan and Runtime Expectations
+
+### Recommended phased rollout
+
+1. Add hypothesis manifest + evidence writer.
+2. Enforce `paper` promotion gate checks only.
+3. Add `live` scale gates after one week stable evidence collection.
+4. Integrate rejection clustering tasks into operator runbook for recurring blockage reasons.
+
+### Rollback Expectations
+
+- If any hypothesis fails at ladder transition, revert to previous capital band immediately and keep runtime enabled only for safe minimum capacity.
+- Keep strategy enabled for observation in reduced mode if it is non-degraded but under-performing.
+- Surface the failed hypothesis and reason in explicit handoff artifacts.
+
+## Risks and Mitigations
+
+- **Over-filters can choke discovery.** Mitigation: minimum baseline thresholds are soft-started with controlled exceptions and tracked with audit reasons.
+- **Data freshness gaps can inflate false negatives.** Mitigation: include freshness checks as hard preconditions.
+- **Hypothesis churn may increase operational overhead.** Mitigation: periodic clustering and auto-summarized remediation recommendations.
+
+## Success Criteria
+
+- paper transition only when all H1/H2 conditions are met and evidence bundle is complete.
+- zero `live` transitions without completed 72h live proof.
+- measurable drop in `topBlockedReasons` dominated by capacity/qty classes after remediation tasks run.
+- sustained non-zero `decisions.generatedCount` and `executions.filledCount` for at least one strategy.
+
+## Relation to Current Roadmaps
+
+This design complements:
+
+- `docs/torghut/design-system/v6/31-proven-autonomous-quant-llm-torghut-trading-system-2026-03-07.md`
+- `docs/torghut/design-system/v6/39-freshness-ledger-and-hypothesis-proof-mesh-2026-03-14.md`
+
+and should be treated as the next-step ladder and gates update.


### PR DESCRIPTION
## Summary

- Add a production-grade Jangar control-plane reliability design documenting stage failure-class recovery and rollout precondition gating.
- Add a Torghut profitability architecture design documenting hypothesis-led capital ladders, measurable H1/H2/H3 gates, and scaling/rollback conditions.
- Add operationally actionable contracts for engineer/deployer handoff with validation, rollout, rollback, and risk clauses.

## Related Issues

None

## Testing

- `bunx oxfmt --check docs/agents/designs/42-jangar-control-plane-failure-mode-reduction-and-safe-rollout-contract-2026-03-15.md docs/torghut/design-system/v6/40-decision-profitability-circuit-and-evidenced-capital-allocation-2026-03-15.md`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
