### PR TITLE
docs(agents): add jangar execution-trust and torghut profitability architecture docs

### DIFF
--- a/docs/agents/designs/43-jangar-control-plane-execution-trust-safety-net-and-safe-rollout-2026-03-15.md
+++ b/docs/agents/designs/43-jangar-control-plane-execution-trust-safety-net-and-safe-rollout-2026-03-15.md
@@ -1,0 +1,174 @@
+# 43. Jangar Execution Trust Safety Net and Safe Rollout Behavior (2026-03-15)
+
+Status: Proposed (2026-03-15)
+
+## Objective
+
+Close the remaining control-plane truth gap by making stage freshness and freeze state explicit in the primary execution surface, then enforce rollout safety with deterministic, data-backed gates before canary progression or merge handoff.
+
+## Assessment Summary
+
+Collected at `2026-03-15T09:50:52Z`:
+
+- `swarm/jangar-control-plane`: `phase=Frozen`, `ready=False`, `freeze.reason=StageStaleness`, `freeze.until=2026-03-11T16:36:12.630Z`.
+- `swarm/torghut-quant`: `phase=Frozen`, `ready=False`, `freeze.reason=StageStaleness`, `freeze.until=2026-03-11T16:36:17.456Z`.
+- `requirements.pending` for Jangar: `5`.
+- `status?namespace=agents` returns `swarms=null`, `stages=null` while reporting `workflows.data_confidence=high`.
+- `GET /ready` returns `{ "status": "ok", ... "agentsController.enabled": false }`, `orchestration` and `supporting` also false.
+- Recent non-normal cluster events include repeated `FailedMount` for missing `codex-spark-swarm-*` and `jangar/torghut-swarm-*` template configmaps plus `BackoffLimitExceeded` for `jangar-swarm-verify-template-step-1-attempt-1`.
+- No CNPG or PostgreSQL direct reads were possible from `agents-sa` (`pods/exec` and `cnpg status` are forbidden), so DB checks are limited to service-level contract signals.
+
+## Sources Reviewed
+
+- `services/jangar/src/server/control-plane-status.ts`
+- `services/jangar/src/routes/ready.tsx`
+- `services/jangar/src/server/__tests__/control-plane-status.test.ts`
+- `services/jangar/src/server/control-plane-watch-reliability.ts`
+- Existing design stack in `docs/agents/designs/42-...` and `docs/agents/designs/jangar-control-plane-failure-mode-reduction-and-rollout-safety-2026-03-15.md`
+
+## Problem
+
+Current control-plane behavior can report healthy local controller + rollout state even when the monitored swarms are already frozen and stale:
+
+1. Source-of-truth for autonomy execution lives in swarm status (`StageStaleness`, per-stage `last*At`, requirement queues), but that truth is not surfaced in the `/api/agents/control-plane/status` envelope.
+2. `/ready` is still a local-process gate and does not model execution trust for autonomous stages.
+3. Stage failure modes are conflated into recent workflow counters; empty windows can hide staleness-driven freezes.
+4. Readiness and rollout gates do not consume persistent evidence classes; they may admit changes while autonomy is degraded.
+
+## Alternatives
+
+### Option A — Status doc + runbook only
+
+- Scope: keep runtime surfaces unchanged.
+- Pros: no control-plane code risk.
+- Cons: same false-green behavior persists; no deterministic hardening.
+
+### Option B — Add stage fields only
+
+- Scope: add read-only `swarms` + `stages` to status, but keep readiness and rollout gates unchanged.
+- Pros: faster deployment, better visibility.
+- Cons: visibility-only approach; false-green behavior can remain at admission/rollout stage.
+
+### Option C — Execution-trust envelope + rollout preconditions + rollback contract (recommended)
+
+- Scope: add authoritative status for execution trust and freeze class + gate readiness/rollout by those fields.
+- Pros: preserves autonomous safety under staleness/failure pressure and makes failure recovery measurable.
+- Cons: introduces new gate paths and higher implementation/test burden, but high leverage and explicit blast-radius reduction.
+
+## Decision
+
+Adopt **Option C** as the next control-plane architecture step.
+
+## Chosen Design
+
+### 1) Extend control-plane status with execution trust
+
+Add additive fields to `ControlPlaneStatus`:
+
+- `execution_trust`
+  - `status`: `healthy | degraded | blocked | unknown`
+  - `reason`
+  - `last_evaluated_at`
+  - `blocking_windows`: list of `swarms`, `stages`, `dependencies`
+  - `evidence_summary`: pointer hash list with bounded TTL
+- `swarms[]` entries per monitored swarm (`name`, `namespace`, `phase`, `ready`, `updated_at`, `observed_generation`, `freeze`, `pending_requirements`, `requirements_pending_class`, `last_discover_at`, `last_plan_at`, `last_implement_at`, `last_verify_at`)
+- `stages[]` entries (`swarm`, `stage`, `phase`, `last_run_at`, `next_expected_at`, `configured_every_ms`, `age_ms`, `stale_after_ms`, `stale`, `recent_failed_jobs`, `recent_backoff_limit_exceeded_jobs`, `last_failure_reason`, `data_confidence`)
+
+Rules:
+
+- Swarm status is authoritative on phase/ready/freeze; workflow counters enrich but cannot override it.
+- If any tracked swarm is `Frozen` or stale beyond policy, `execution_trust` is `blocked` or `degraded` depending on age and severity class.
+- `data_confidence` for status must downgrade from `high` to `low` if a required `swarms` / `stages` snapshot is missing.
+
+### 2) Make `/ready` an execution-trust gate
+
+- `getReadyHandler` should derive final readiness from:
+  - readiness of local leaders/controllers (existing),
+  - plus `execution_trust.status === healthy`.
+- Return HTTP `503` with an explicit trust block when execution trust is not healthy.
+- Keep `orchestration` and `supporting` controller checks as existing signals, but add explicit reasons: `"execution_trust.blocked:<reason>"`.
+
+### 3) Rollout safety preconditions
+
+Before any canary/rollout transition, enforce:
+
+- `execution_trust.status === healthy`.
+- `dependency_quorum.decision === allow`.
+- `empirical_services.jobs.status !== blocked` unless explicit incident policy authorizes.
+- `watch_reliability.status !== degraded` for a sustained window, unless already degraded due to known upstream incident and `resume_override` is present.
+
+If any predicate fails:
+
+- block rollouts,
+- emit `execution_trust.blocking_windows` entry with class,
+- preserve existing rollout configuration (no partial weight advance),
+- require explicit evidence before resume.
+
+### 4) Failure-class taxonomy and staged recovery
+
+- `Transient`: configmap miss + short probe flake; allow one automatic remap/retry cycle with exponential holdoff.
+- `Systemic`: repeated stage staleness + consecutive backoff failures; trigger freeze and require operator + evidence to clear.
+- `Critical`: repeated dependency failures while in freeze; hold at `blocked`, route to incident path.
+
+### 5) Required rollout recovery contract
+
+Every freeze clear must include:
+
+- freeze class + threshold cross event,
+- stage-specific stage age reduction evidence,
+- source evidence bundle (`swarms`, `events`, `jobs`, `controller status snapshot`) in artifact store,
+- confirmatory control-plane status snapshot with `execution_trust.status === healthy`.
+
+## Validation Gates
+
+### Engineering gates
+
+- Control-plane status unit tests include:
+  - mapping from `Swarm` `StageStaleness` to `execution_trust.blocked`,
+  - readiness fails on execution-trust block,
+  - rollout precondition composition with one blocked dependency.
+- Integration tests proving `workflows.data_confidence` degrades when `swarms`/`stages` data is stale or missing.
+- Static schema docs + example snapshots for `status`, `ready`, and rollout contracts.
+
+### Deployer gates
+
+- Staging validation run must pass:
+  - one controlled stale-stage event with freeze,
+  - recovery path requiring status trust return before canary resume.
+- Any `BackoffLimitExceeded` or probe timeout must not auto-clear freeze.
+- `control-plane status` and `/ready` must be green only after trust and rollback preconditions return healthy.
+
+## Rollout and Rollback Expectations
+
+For engineer:
+
+1. Merge implementation behind a feature gate (`JANGAR_CONTROL_PLANE_EXECUTION_TRUST=true`) first.
+2. Validate in `agents-ci` style path with synthetic stale swarm object.
+3. Expand to production rollout only when one full recovery cycle finishes without manual rollback.
+
+For deployer:
+
+1. Observe frozen-stage detection and no rollout weight movement during block.
+2. Confirm evidence bundle produced and stored.
+3. Open a manual incident note on first `Critical` class freeze.
+
+Rollback:
+
+- disable execution-trust gate by removing stage tracking from readiness/rollout path only if:
+  - trust computation service is unhealthy for >15m with no alternate deployment,
+  - incident ticket is opened and approved by owner,
+  - explicit temporary override token is set and time-boxed.
+
+## Risks and Mitigations
+
+- **Over-tight gating extends MTTR on benign flakiness**: gate windows and class decay with explicit override.
+- **Controller read amplification**: cache swarm snapshots per minute and cap event lookback windows.
+- **Insufficient signal-to-noise in stale classification**: include confidence metadata and age thresholds to avoid repeated freeze loops.
+- **Cross-surface drift**: add schema regression snapshot tests across control-plane status, ready, and docs contract references.
+
+## Exit Criteria
+
+- `/api/agents/control-plane/status` always includes authoritative `swarms` and `stages` under normal permissions.
+- `/ready` can only return 200 when `execution_trust.status === healthy`.
+- No rollout progression during unresolved `StageStaleness`.
+- Freeze clearance event must include explicit evidence bundle and timestamp.

--- a/docs/agents/designs/43-torghut-profitability-evidence-and-guardrail-architecture-2026-03-15.md
+++ b/docs/agents/designs/43-torghut-profitability-evidence-and-guardrail-architecture-2026-03-15.md
@@ -1,0 +1,167 @@
+# 43. Torghut Profitability Evidence-Led Architecture and Guardrails (2026-03-15)
+
+Status: Proposed (2026-03-15)
+
+## Objective
+
+Shift Torghut from implicit strategy iteration to an explicit profitability architecture with measurable hypotheses, statistical gates, and rollback-safe execution budgets that can run under frozen/autonomous cycles.
+
+## Assessment Summary
+
+Key observations:
+
+- Torghut control-plane is also frozen (`reason=StageStaleness`) while its swarm contract still reports execution status.
+- Torghut pods are running, but `torghut-ta` / simulation services show active workload and `torghut-00134-deployment` has transient readiness/liveness warnings (`HTTP 8012` timeout).
+- Completion workflow already includes explicit gates and required artifact fields (`DOC29_PAPER_GATE`, `DOC29_LIVE_CANARY_GATE`, `DOC29_LIVE_SCALE_GATE`) in `services/torghut/app/trading/completion.py`, indicating the execution path is ready for stricter gate contracts.
+- No direct CNPG data queries were possible from `agents-sa` namespace due `pods/exec` and `cnpg` RBAC constraints, so database quality proof uses service-level completion traces and migration/contract signals.
+
+## Sources Reviewed
+
+- `services/torghut/app/trading/completion.py`
+- `services/torghut/app/trading/empirical_jobs.py`
+- `services/torghut/app/trading/completion.py` (status matrix loading and `build_completion_trace`)
+- `services/torghut/app/trading` test surface
+- Existing design context in `docs/torghut/design-system/v6` and `docs/agents/designs/42-jangar-control-plane-failure-mode-reduction-and-safe-rollout-contract-2026-03-15.md`
+
+## Problem
+
+Current autonomy profitability decisions are often promoted through manual inference rather than a strict hypothesis ledger:
+
+1. Strategy changes are not consistently tied to a single experiment hypothesis with measurable effect size and confidence.
+2. Execution risk controls are present but not standardized as part of a staged profitability architecture.
+3. Completion records exist but are not yet enforced as a first-class architectural control for what can be promoted in production.
+4. In the presence of frozen staging phases, partial optimizations can still consume operational budget without sufficient profitability signal.
+
+## Alternatives
+
+### Option A — Keep current completion gate set as-is
+
+- Scope: only documentation and minor threshold updates.
+- Pros: minimal change risk.
+- Cons: limited proof strength and no experiment-level decision traceability.
+
+### Option B — Introduce hard numeric thresholds only
+
+- Scope: set stricter alpha thresholds for existing gates.
+- Pros: fast implementation.
+- Cons: brittle and ignores regime dependence (open/closed markets, volatility shock, symbol clusters).
+
+### Option C — Hypothesis-orchestrator architecture (recommended)
+
+- Scope: introduce explicit hypothesis manifests + portfolio guardrails + evidence budget enforcement before execution and merge.
+- Pros: maximizes defensibility of profit changes and minimizes silent regressions with measurable rollback triggers.
+- Cons: introduces governance and schema migration overhead.
+
+## Decision
+
+Adopt **Option C** as the next Torghut profitability architecture.
+
+## Architecture
+
+### 1) Hypothesis manifest layer
+
+Define a first-class hypothesis model for every candidate profitability change:
+
+- `HypothesisID`
+- `market_regime`: `open`, `pre_market`, `volatile`, `cross_asset`
+- `hypothesis`: concise hypothesis sentence with causal mechanism
+- `expected_effect`: directional metric target (ex: `Sharpe`, `return`, `hit_rate`, `vol_normalized_pnl`)
+- `expected_effect_threshold`
+- `sample_plan`: `symbol_set`, `lookback_days`, `holdout_days`, `walkforward_chunks`
+- `risk_budget`: max daily drawdown increment, max reject-rate increment, max turnover increase
+- `confidence_plan`: confidence intervals or Bayesian posterior thresholds
+- `guardrails`: `latency_p99`, `slippage_p95`, queue delay, order rejection entropy
+- `evidence_artifacts`: completion IDs, db query IDs, status snapshots
+- `degrade_paths`: automatic demotion actions if guardrails violate.
+
+### 2) Hypothesis contract as completion input
+
+Before promotion, completion status must include:
+
+- all required gates from `completion` manifest,
+- explicit `hypothesis_id` and `evidence_trace_id`,
+- two-stage statistical gate: simulation smoke + live canary,
+- minimum sample/coverage proof for symbol coverage,
+- explicit `portfolio_impact` summary (not just single-symbol).
+
+### 3) Regime-aware decision engine
+
+- Evaluate hypotheses in separate windows:
+  - `bull_open`, `flat_open`, `volatile_open`, `off_hours`.
+- Use separate risk budgets by regime so low-volatility gains are not incorrectly generalized.
+- Require cross-regime deltas to pass a minimum stability check before promotion, not just best regime score.
+
+### 4) Profitability guardrail contract
+
+Promotion is blocked when any threshold breaches:
+
+- `rolling_drawdown_delta_1d > 2x` baseline,
+- `reject_ratio_delta > 1.5x` baseline,
+- `slippage_p95` delta > configured limit,
+- `signal_lag` breaches for two consecutive windows,
+- confidence below minimum for intended regime coverage.
+
+Blocking event must emit:
+
+- `hypothesis_id`
+- `failing_metrics`
+- `required_remediation` + responsible owner.
+
+## Data/DB and Schema Quality Contract
+
+For every profitable hypothesis proposal, the following sources are required:
+
+- completion traces persisted by `build_completion_trace`,
+- status snapshots from torghut trading status and Jangar control-plane status,
+- empirical job rows for simulation/live canary and completion artifacts,
+- strategy outcome rows used to compute realized risk-adjusted uplift.
+
+Because DB read privileges from current assess context are insufficient, the contract requires immutable evidence artifact references in PRs and deployer evidence bundle instead of ad-hoc CLI DB inspection.
+
+## Execution and rollout model
+
+### Engineer stage
+
+1. Create hypothesis manifest with target market regime and guardrails.
+2. Run simulation and produce signed completion trace bundle.
+3. Demonstrate evidence by artifact IDs in PR body (including completion gate IDs and db query IDs).
+4. Merge only if hypothesis passes `live_canary_observed` and all required evidence fields are populated.
+
+### Deployer stage
+
+1. Rollout starts in low-risk canary namespace with one regime at a time.
+2. Maintain automatic rollback if any guardrail breach triggers for two consecutive windows.
+3. Freeze Torghut lane if two consecutive hypotheses fail guardrails in same trading day.
+
+## Validation Gates
+
+- Stage gates before promotion:
+  - statistically significant uplift over baseline on predefined interval,
+  - guardrail thresholds within budget,
+  - trace completeness: all required db/status artifacts recorded.
+- Deployment gates:
+  - live canary p95 latency and reject-ratio within expected band,
+  - no safety stop resets unbound.
+- Post-deploy gates:
+  - 24h/72h review window with evidence snapshot and rollback decision.
+
+## Rollback Strategy
+
+- On guardrail breach, auto-demote hypothesis to `stopped` state and retain candidate binary.
+- If a candidate has already merged:
+  - auto-prepare revert patch from completion trace,
+  - run emergency stop path if reject ratio remains elevated after two measurement windows,
+  - re-open only with new hypothesis ID and revised risk budget.
+
+## Risks and Tradeoffs
+
+- **Lower throughput due gate strictness**: mitigate with parallel candidate batching and off-peak scheduling.
+- **False negatives from strict confidence rules**: include minimum viable evidence exceptions with owner approval.
+- **Cross-regime overfitting**: require regime stability and holdout checks before merge.
+- **Data availability uncertainty**: mandate evidence references from immutable completion traces when direct DB reads are unavailable.
+
+## Exit Criteria
+
+- Every candidate hypothesis has a documented manifest and completion evidence chain.
+- No promotion when `DOC29_LIVE_CANARY_GATE` is blocked or confidence thresholds are unmet.
+- Every guardrail breach creates explicit rollback evidence and does not auto-delete candidate artifacts.


### PR DESCRIPTION
## Summary

- add Jangar March 15 execution-trust architecture design doc for execution truth, stale-stage recovery, and safe rollout preconditions
- add Torghut March 15 profitability architecture design doc for hypothesis-driven promotion, regime-aware guardrails, and rollback contracts
- capture discover-lane architectural decisions with explicit implementation, validation, and rollout/rollback guidance

## Related Issues

None.

## Testing

- `bunx oxfmt --check docs/agents/designs/43-jangar-control-plane-execution-trust-safety-net-and-safe-rollout-2026-03-15.md docs/agents/designs/43-torghut-profitability-evidence-and-guardrail-architecture-2026-03-15.md /workspace/.agentrun/swarm/jangar-control-plane-discover.md`

## Breaking Changes

None.
