### PR TITLE
chore(jangar): promote image 69dc2593

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 8d38a2ef
-  digest: sha256:01644ae7e385d68c70c5636bbaa34207cf07baa3e1d420d584185c5971820688
+  tag: 69dc2593
+  digest: sha256:9cf4862e781b7867e6d4e26a6ebf6392c1f498fd400ffff4f7f97dc0649822d7
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 8d38a2ef
-    digest: sha256:2dfa9711906eb6da6b46e6497b94630315ade739a7ff846b34936ae4215f3352
+    tag: 69dc2593
+    digest: sha256:bfa75dc2858c51835d3ef6ed1352ede8c57c0743619cc2c50db3eede5e0ec73b
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 8d38a2ef
-    digest: sha256:01644ae7e385d68c70c5636bbaa34207cf07baa3e1d420d584185c5971820688
+    tag: 69dc2593
+    digest: sha256:9cf4862e781b7867e6d4e26a6ebf6392c1f498fd400ffff4f7f97dc0649822d7
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-15T01:52:56Z"
+    deploy.knative.dev/rollout: "2026-03-15T22:46:59Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-15T01:52:56Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-15T22:46:59Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -62,5 +62,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "8d38a2ef"
-    digest: sha256:01644ae7e385d68c70c5636bbaa34207cf07baa3e1d420d584185c5971820688
+    newTag: "69dc2593"
+    digest: sha256:9cf4862e781b7867e6d4e26a6ebf6392c1f498fd400ffff4f7f97dc0649822d7


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `69dc2593a7239d471f165be56b1d2f2d5a1df834`
- Image tag: `69dc2593`
- Image digest: `sha256:9cf4862e781b7867e6d4e26a6ebf6392c1f498fd400ffff4f7f97dc0649822d7`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`