### PR TITLE
fix(torghut): wait for full replay window in proof monitor

### DIFF
--- a/services/torghut/scripts/historical_simulation_verification.py
+++ b/services/torghut/scripts/historical_simulation_verification.py
@@ -882,6 +882,11 @@ def _simulation_progress_snapshot(
         or _as_text(replay.get('last_price_ts'))
         or _as_text(ta.get('last_price_ts'))
     )
+    last_source_ts = (
+        _as_text(replay.get('last_source_ts'))
+        or _as_text(torghut.get('last_source_ts'))
+        or _as_text(ta.get('last_source_ts'))
+    )
     return {
         'progress_source': 'simulation_run_progress',
         'components': components,
@@ -894,6 +899,7 @@ def _simulation_progress_snapshot(
         'price_rows': 1 if last_price_ts is not None else 0,
         'last_signal_ts': last_signal_ts,
         'last_price_ts': last_price_ts,
+        'last_source_ts': last_source_ts,
         'records_dumped': _safe_int(replay.get('records_dumped')),
         'records_replayed': _safe_int(replay.get('records_replayed')),
         'strategy_type': _as_text(torghut.get('strategy_type')) or _as_text(replay.get('strategy_type')),
@@ -906,12 +912,17 @@ def _effective_terminal_signal_ts(
     *,
     window_end: datetime,
     last_signal_ts: datetime | None,
+    last_price_ts: datetime | None,
+    last_source_ts: datetime | None,
 ) -> datetime:
-    if last_signal_ts is None:
+    coverage_candidates = [
+        timestamp
+        for timestamp in (last_source_ts, last_price_ts, last_signal_ts)
+        if timestamp is not None
+    ]
+    if not coverage_candidates:
         return window_end
-    if last_signal_ts < window_end:
-        return last_signal_ts
-    return window_end
+    return min(max(coverage_candidates), window_end)
 
 
 def _clickhouse_database_from_jdbc_url(raw_url: str | None) -> str | None:
@@ -978,10 +989,13 @@ def _activity_state(
     runtime_ready = bool(runtime_verify.get('runtime_state') == 'ready')
     last_signal_ts = _parse_optional_rfc3339_timestamp(_as_text(snapshot.get('last_signal_ts')))
     last_price_ts = _parse_optional_rfc3339_timestamp(_as_text(snapshot.get('last_price_ts')))
+    last_source_ts = _parse_optional_rfc3339_timestamp(_as_text(snapshot.get('last_source_ts')))
     cursor_at = _parse_optional_rfc3339_timestamp(_as_text(snapshot.get('cursor_at')))
     effective_terminal_signal_ts = _effective_terminal_signal_ts(
         window_end=end,
         last_signal_ts=last_signal_ts,
+        last_price_ts=last_price_ts,
+        last_source_ts=last_source_ts,
     )
     trade_decisions = _safe_int(snapshot.get('trade_decisions'))
     executions = _safe_int(snapshot.get('executions'))
@@ -1009,15 +1023,18 @@ def _activity_state(
     cursor_gap_seconds: float | None = None
     if cursor_at is not None:
         cursor_gap_seconds = max((effective_terminal_signal_ts - cursor_at).total_seconds(), 0.0)
-    terminal_reason = 'window_end_reached'
-    if last_signal_ts is not None and last_signal_ts < end:
-        terminal_reason = 'terminal_signal_reached'
+    terminal_reason = (
+        'terminal_signal_reached'
+        if effective_terminal_signal_ts < end
+        else 'window_end_reached'
+    )
     return {
         'window_start': start.isoformat(),
         'window_end': end.isoformat(),
         'effective_terminal_signal_ts': effective_terminal_signal_ts.isoformat(),
         'last_signal_ts': last_signal_ts.isoformat() if last_signal_ts is not None else None,
         'last_price_ts': last_price_ts.isoformat() if last_price_ts is not None else None,
+        'last_source_ts': last_source_ts.isoformat() if last_source_ts is not None else None,
         'cursor_at': cursor_at.isoformat() if cursor_at is not None else None,
         'cursor_gap_seconds': cursor_gap_seconds,
         'thresholds_met': thresholds_met,
@@ -1027,7 +1044,7 @@ def _activity_state(
         'completion_reason': terminal_reason if terminal_reached else 'waiting_for_terminal_signal',
         'dataset_alignment': (
             'window_declared_beyond_dataset'
-            if last_signal_ts is not None and last_signal_ts < end
+            if effective_terminal_signal_ts < end
             else 'window_aligned_with_dataset'
         ),
     }

--- a/services/torghut/tests/test_start_historical_simulation.py
+++ b/services/torghut/tests/test_start_historical_simulation.py
@@ -4580,6 +4580,7 @@ class TestStartHistoricalSimulation(TestCase):
                     'execution_tca_metrics': 12,
                     'execution_order_events': 12,
                     'cursor_at': '2026-03-11T13:34:58Z',
+                    'last_source_ts': '2026-03-11T13:34:58Z',
                 },
             ),
             patch(
@@ -4588,7 +4589,7 @@ class TestStartHistoricalSimulation(TestCase):
                     'signal_rows': 120,
                     'price_rows': 120,
                     'last_signal_ts': '2026-03-11T13:34:58Z',
-                    'last_price_ts': '2026-03-11T13:34:59Z',
+                    'last_price_ts': '2026-03-11T13:34:58Z',
                 },
             ),
             patch('scripts.historical_simulation_verification.time.sleep', return_value=None),
@@ -4605,6 +4606,88 @@ class TestStartHistoricalSimulation(TestCase):
         self.assertEqual(report['activity_classification'], 'success')
         self.assertEqual(report['effective_terminal_signal_ts'], '2026-03-11T13:34:58+00:00')
         self.assertEqual(report['dataset_alignment'], 'window_declared_beyond_dataset')
+
+    def test_monitor_run_completion_waits_for_source_window_when_signal_generation_lags(self) -> None:
+        postgres_config = PostgresRuntimeConfig(
+            admin_dsn='postgresql://torghut:secret@localhost:5432/postgres',
+            simulation_dsn='postgresql://torghut:secret@localhost:5432/torghut_sim_sim_1',
+            simulation_db='torghut_sim_sim_1',
+            migrations_command='true',
+        )
+        manifest = {
+            'window': {
+                'start': '2026-03-13T13:30:00Z',
+                'end': '2026-03-13T20:00:00Z',
+            },
+            'monitor': {
+                'timeout_seconds': 30,
+                'poll_seconds': 1,
+                'cursor_grace_seconds': 0,
+                'min_trade_decisions': 1,
+                'min_executions': 1,
+                'min_execution_tca_metrics': 1,
+                'min_execution_order_events': 1,
+            },
+        }
+        resources = _build_resources('sim-1', {'dataset_id': 'dataset-a'})
+        clickhouse_config = ClickHouseRuntimeConfig(
+            http_url='http://clickhouse:8123',
+            username='torghut',
+            password=None,
+        )
+        with (
+            patch(
+                'scripts.historical_simulation_verification._monitor_snapshot',
+                side_effect=[
+                    {
+                        'trade_decisions': 0,
+                        'executions': 0,
+                        'execution_tca_metrics': 0,
+                        'execution_order_events': 0,
+                        'cursor_at': '2026-03-13T17:26:00Z',
+                        'last_source_ts': '2026-03-13T19:59:59Z',
+                    },
+                    {
+                        'trade_decisions': 17,
+                        'executions': 3,
+                        'execution_tca_metrics': 3,
+                        'execution_order_events': 3,
+                        'cursor_at': '2026-03-13T20:00:00Z',
+                        'last_source_ts': '2026-03-13T19:59:59Z',
+                    },
+                ],
+            ),
+            patch(
+                'scripts.historical_simulation_verification._signal_snapshot',
+                side_effect=[
+                    {
+                        'signal_rows': 120,
+                        'price_rows': 120,
+                        'last_signal_ts': '2026-03-13T17:26:00Z',
+                        'last_price_ts': '2026-03-13T20:00:00Z',
+                    },
+                    {
+                        'signal_rows': 120,
+                        'price_rows': 120,
+                        'last_signal_ts': '2026-03-13T20:00:00Z',
+                        'last_price_ts': '2026-03-13T20:00:00Z',
+                    },
+                ],
+            ),
+            patch('scripts.historical_simulation_verification.time.sleep', return_value=None),
+        ):
+            report = _monitor_run_completion(
+                resources=resources,
+                manifest=manifest,
+                postgres_config=postgres_config,
+                clickhouse_config=clickhouse_config,
+                runtime_verify={'runtime_state': 'ready'},
+            )
+
+        self.assertEqual(report['status'], 'ok')
+        self.assertEqual(report['activity_classification'], 'success')
+        self.assertEqual(report['effective_terminal_signal_ts'], '2026-03-13T20:00:00+00:00')
+        self.assertEqual(report['dataset_alignment'], 'window_aligned_with_dataset')
 
     def test_run_full_lifecycle_fails_when_activity_verify_is_degraded(self) -> None:
         resources = _build_resources(


### PR DESCRIPTION
## Summary

- fix the historical simulation proof monitor so terminal readiness follows authoritative source and price coverage instead of transient TA-generation progress
- surface `last_source_ts` in simulation progress snapshots and use it when computing proof completion and dataset alignment
- add a regression test for the March 13 full-day lag pattern and update the existing early-terminal coverage test

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen python -m unittest tests.test_start_historical_simulation.TestStartHistoricalSimulation.test_monitor_run_completion_succeeds_when_terminal_signal_precedes_window_end tests.test_start_historical_simulation.TestStartHistoricalSimulation.test_monitor_run_completion_waits_for_source_window_when_signal_generation_lags`
- `uv run --frozen python -m unittest tests.test_signal_ingest`
- `uv run --frozen python -m unittest tests.test_start_historical_simulation`
- `uv run --frozen ruff check /Users/gregkonush/.codex/worktrees/torghut-march13-proof-fix/services/torghut/scripts/historical_simulation_verification.py /Users/gregkonush/.codex/worktrees/torghut-march13-proof-fix/services/torghut/tests/test_start_historical_simulation.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
