### PR TITLE
chore(torghut): promote image 3a541443

### DIFF
--- a/argocd/applications/torghut-forecast/deployment.yaml
+++ b/argocd/applications/torghut-forecast/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: forecast
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:573b324af51596e86ad602e22b7dbbd1ba2cd9a7f3b7d09127015b9805a551b8
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:1aeed3822bfa23b910476f726cd79551cac53960516e2e9cbc493fd716ce2bde
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn

--- a/argocd/applications/torghut-forecast/sim/deployment.yaml
+++ b/argocd/applications/torghut-forecast/sim/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: forecast
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:573b324af51596e86ad602e22b7dbbd1ba2cd9a7f3b7d09127015b9805a551b8
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:1aeed3822bfa23b910476f726cd79551cac53960516e2e9cbc493fd716ce2bde
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn

--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:573b324af51596e86ad602e22b7dbbd1ba2cd9a7f3b7d09127015b9805a551b8
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:1aeed3822bfa23b910476f726cd79551cac53960516e2e9cbc493fd716ce2bde
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -63,9 +63,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.564.0-190-gfa0785c7
+              value: v0.564.0-192-g3a541443
             - name: TORGHUT_OPTIONS_COMMIT
-              value: fa0785c7f4d14c5d0cbd93faba2d4a83eadf841f
+              value: 3a5414432ec5e5f877495e0ae894c5b80eb71391
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:573b324af51596e86ad602e22b7dbbd1ba2cd9a7f3b7d09127015b9805a551b8
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:1aeed3822bfa23b910476f726cd79551cac53960516e2e9cbc493fd716ce2bde
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -63,9 +63,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.564.0-190-gfa0785c7
+              value: v0.564.0-192-g3a541443
             - name: TORGHUT_OPTIONS_COMMIT
-              value: fa0785c7f4d14c5d0cbd93faba2d4a83eadf841f
+              value: 3a5414432ec5e5f877495e0ae894c5b80eb71391
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -40,7 +40,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:573b324af51596e86ad602e22b7dbbd1ba2cd9a7f3b7d09127015b9805a551b8
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:1aeed3822bfa23b910476f726cd79551cac53960516e2e9cbc493fd716ce2bde
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -21,7 +21,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:573b324af51596e86ad602e22b7dbbd1ba2cd9a7f3b7d09127015b9805a551b8
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:1aeed3822bfa23b910476f726cd79551cac53960516e2e9cbc493fd716ce2bde
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -32,7 +32,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:573b324af51596e86ad602e22b7dbbd1ba2cd9a7f3b7d09127015b9805a551b8
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:1aeed3822bfa23b910476f726cd79551cac53960516e2e9cbc493fd716ce2bde
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -30,7 +30,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:573b324af51596e86ad602e22b7dbbd1ba2cd9a7f3b7d09127015b9805a551b8
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:1aeed3822bfa23b910476f726cd79551cac53960516e2e9cbc493fd716ce2bde
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:573b324af51596e86ad602e22b7dbbd1ba2cd9a7f3b7d09127015b9805a551b8
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:1aeed3822bfa23b910476f726cd79551cac53960516e2e9cbc493fd716ce2bde
           command:
             - /opt/venv/bin/alembic
           args:

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -13,7 +13,7 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:573b324af51596e86ad602e22b7dbbd1ba2cd9a7f3b7d09127015b9805a551b8
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:1aeed3822bfa23b910476f726cd79551cac53960516e2e9cbc493fd716ce2bde
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -21,7 +21,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:573b324af51596e86ad602e22b7dbbd1ba2cd9a7f3b7d09127015b9805a551b8
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:1aeed3822bfa23b910476f726cd79551cac53960516e2e9cbc493fd716ce2bde
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -39,7 +39,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:573b324af51596e86ad602e22b7dbbd1ba2cd9a7f3b7d09127015b9805a551b8
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:1aeed3822bfa23b910476f726cd79551cac53960516e2e9cbc493fd716ce2bde
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-03-16T01:43:59Z"
+        client.knative.dev/updateTimestamp: "2026-03-16T02:33:01Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:573b324af51596e86ad602e22b7dbbd1ba2cd9a7f3b7d09127015b9805a551b8
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:1aeed3822bfa23b910476f726cd79551cac53960516e2e9cbc493fd716ce2bde
           ports:
             - name: http1
               containerPort: 8181
@@ -519,9 +519,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.564.0-190-gfa0785c7
+              value: v0.564.0-192-g3a541443
             - name: TORGHUT_COMMIT
-              value: fa0785c7f4d14c5d0cbd93faba2d4a83eadf841f
+              value: 3a5414432ec5e5f877495e0ae894c5b80eb71391
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-03-16T01:43:59Z"
+        client.knative.dev/updateTimestamp: "2026-03-16T02:33:01Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -26,7 +26,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:573b324af51596e86ad602e22b7dbbd1ba2cd9a7f3b7d09127015b9805a551b8
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:1aeed3822bfa23b910476f726cd79551cac53960516e2e9cbc493fd716ce2bde
           ports:
             - name: http1
               containerPort: 8181
@@ -462,9 +462,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.564.0-190-gfa0785c7
+              value: v0.564.0-192-g3a541443
             - name: TORGHUT_COMMIT
-              value: fa0785c7f4d14c5d0cbd93faba2d4a83eadf841f
+              value: 3a5414432ec5e5f877495e0ae894c5b80eb71391
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/lean-runner-deployment.yaml
+++ b/argocd/applications/torghut/lean-runner-deployment.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: lean-runner
           # Keep in lockstep with `argocd/applications/torghut/knative-service.yaml`.
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:573b324af51596e86ad602e22b7dbbd1ba2cd9a7f3b7d09127015b9805a551b8
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:1aeed3822bfa23b910476f726cd79551cac53960516e2e9cbc493fd716ce2bde
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `3a5414432ec5e5f877495e0ae894c5b80eb71391`
- Image tag: `3a541443`
- Image digest: `sha256:1aeed3822bfa23b910476f726cd79551cac53960516e2e9cbc493fd716ce2bde`