### PR TITLE
fix(torghut): align 1sec tsmom runtime contract

### DIFF
--- a/argocd/applications/torghut/strategy-configmap.yaml
+++ b/argocd/applications/torghut/strategy-configmap.yaml
@@ -11,12 +11,25 @@ data:
   strategies.yaml: |
     strategies:
       - name: intraday-tsmom-profit-v2
+        strategy_id: intraday_tsmom_v1@prod
+        strategy_type: intraday_tsmom_v1
+        version: 1.1.0
         description: Intraday momentum strategy tuned for higher selectivity, version=1.1.0
         enabled: true
         base_timeframe: "1Sec"
         universe_type: intraday_tsmom_v1
         max_notional_per_trade: 1000
         max_position_pct_equity: 0.08
+        params:
+          bullish_hist_min: "0.005"
+          bearish_hist_min: "0.004"
+          bearish_hist_cap: "0.03"
+          min_bull_rsi: "52"
+          max_bull_rsi: "62"
+          max_bear_rsi: "45"
+          vol_floor: "0"
+          vol_ceil: "0.00030"
+          low_vol_bonus_threshold: "0.00020"
   forecast-router-policy.json: |
     {
       "policy_version": "forecast_router_policy_v2",

--- a/services/torghut/app/trading/autonomy/runtime.py
+++ b/services/torghut/app/trading/autonomy/runtime.py
@@ -13,6 +13,7 @@ from ..features import (
     normalize_feature_vector_v3,
     validate_declared_features,
 )
+from ..intraday_tsmom_contract import evaluate_intraday_tsmom_signal, validate_intraday_tsmom_params
 from ..models import SignalEnvelope, StrategyDecision
 from ..strategy_specs import build_compiled_strategy_artifacts, strategy_type_supports_spec_v2
 
@@ -177,28 +178,7 @@ class IntradayTsmomV1Plugin:
     version = '1.1.0'
 
     def validate_params(self, params: dict[str, Any]) -> None:
-        _validate_optional_decimal_param(
-            params=params,
-            key='bullish_hist_min',
-            invalid_error='invalid_bullish_hist_min',
-        )
-        _validate_optional_decimal_param(
-            params=params,
-            key='bearish_hist_min',
-            invalid_error='invalid_bearish_hist_min',
-        )
-        _validate_optional_rsi_param(
-            params=params,
-            key='min_bull_rsi',
-            invalid_error='invalid_min_bull_rsi',
-            out_of_range_error='min_bull_rsi_out_of_range',
-        )
-        _validate_optional_rsi_param(
-            params=params,
-            key='max_bull_rsi',
-            invalid_error='invalid_max_bull_rsi',
-            out_of_range_error='max_bull_rsi_out_of_range',
-        )
+        validate_intraday_tsmom_params(params)
 
     def required_features(self) -> set[str]:
         return {'price', 'ema12', 'ema26', 'macd', 'macd_signal', 'rsi14', 'vol_realized_w60s'}
@@ -213,78 +193,38 @@ class IntradayTsmomV1Plugin:
         macd_signal = _decimal(fv.values.get('macd_signal'))
         rsi14 = _decimal(fv.values.get('rsi14'))
         vol = _decimal(fv.values.get('vol_realized_w60s'))
-
-        if ema12 is None or ema26 is None or macd is None or macd_signal is None or rsi14 is None:
+        evaluation = evaluate_intraday_tsmom_signal(
+            timeframe=fv.timeframe,
+            params=ctx.params,
+            ema12=ema12,
+            ema26=ema26,
+            macd=macd,
+            macd_signal=macd_signal,
+            rsi14=rsi14,
+            vol_realized_w60s=vol,
+        )
+        if evaluation is None:
             return None
 
-        macd_hist = macd - macd_signal
-        trend_up = ema12 > ema26 and macd > macd_signal
-        trend_down = ema12 < ema26 and macd < macd_signal
-
-        bullish_hist_min = _decimal(ctx.params.get('bullish_hist_min')) or Decimal('0.04')
-        bearish_hist_min = _decimal(ctx.params.get('bearish_hist_min')) or Decimal('0.05')
-        min_bull_rsi = _decimal(ctx.params.get('min_bull_rsi')) or Decimal('52')
-        max_bull_rsi = _decimal(ctx.params.get('max_bull_rsi')) or Decimal('62')
-        min_bear_rsi = _decimal(ctx.params.get('min_bear_rsi')) or Decimal('66')
-        bearish_hist_cap = _decimal(ctx.params.get('bearish_hist_cap')) or Decimal('0.12')
-
-        vol_floor = _decimal(ctx.params.get('vol_floor')) or Decimal('0.001')
-        vol_ceil = _decimal(ctx.params.get('vol_ceil')) or Decimal('0.012')
-
-        vol_ok = vol is None or (vol_floor <= vol <= vol_ceil)
-
-        if trend_up and vol_ok and macd_hist >= bullish_hist_min and min_bull_rsi <= rsi14 <= max_bull_rsi:
-            confidence = Decimal('0.64')
-            if macd_hist >= bullish_hist_min * Decimal('2'):
-                confidence += Decimal('0.05')
-            if vol is not None and vol <= Decimal('0.008'):
-                confidence += Decimal('0.03')
-            if rsi14 >= max_bull_rsi:
-                confidence += Decimal('0.02')
-            return StrategyIntent(
-                strategy_id=ctx.strategy_id,
-                symbol=fv.symbol,
-                direction='long',
-                confidence=min(confidence, Decimal('0.84')),
-                target_qty=_decimal(ctx.params.get('qty')) or Decimal('1'),
-                horizon='intraday',
-                rationale=['tsmom_trend_up', 'momentum_confirmed', 'volatility_within_budget'],
-                meta={
-                    'strategy_type': ctx.strategy_type,
-                    'schema': fv.feature_schema_version,
-                    'feature_hash': fv.normalization_hash,
-                    'macd_hist': str(macd_hist),
-                    'compiler_source': 'spec_v2' if ctx.strategy_spec else 'legacy_runtime',
-                },
-            )
-
-        if (
-            trend_down
-            and -macd_hist >= bearish_hist_min
-            and -macd_hist <= bearish_hist_cap
-            and rsi14 >= min_bear_rsi
-        ):
-            confidence = Decimal('0.62')
-            if rsi14 >= Decimal('72'):
-                confidence += Decimal('0.03')
-            return StrategyIntent(
-                strategy_id=ctx.strategy_id,
-                symbol=fv.symbol,
-                direction='short',
-                confidence=min(confidence, Decimal('0.80')),
-                target_qty=_decimal(ctx.params.get('qty')) or Decimal('1'),
-                horizon='intraday',
-                rationale=['tsmom_trend_down', 'momentum_reversal_exit'],
-                meta={
-                    'strategy_type': ctx.strategy_type,
-                    'schema': fv.feature_schema_version,
-                    'feature_hash': fv.normalization_hash,
-                    'macd_hist': str(macd_hist),
-                    'compiler_source': 'spec_v2' if ctx.strategy_spec else 'legacy_runtime',
-                },
-            )
-
-        return None
+        return StrategyIntent(
+            strategy_id=ctx.strategy_id,
+            symbol=fv.symbol,
+            direction=evaluation.direction,
+            confidence=min(
+                evaluation.confidence,
+                Decimal('0.84') if evaluation.direction == 'long' else Decimal('0.80'),
+            ),
+            target_qty=_decimal(ctx.params.get('qty')) or Decimal('1'),
+            horizon='intraday',
+            rationale=list(evaluation.rationale),
+            meta={
+                'strategy_type': ctx.strategy_type,
+                'schema': fv.feature_schema_version,
+                'feature_hash': fv.normalization_hash,
+                'macd_hist': str(evaluation.macd_hist),
+                'compiler_source': 'spec_v2' if ctx.strategy_spec else 'legacy_runtime',
+            },
+        )
 
 
 class StrategyRuntime:
@@ -427,34 +367,6 @@ def _decimal(value: Any) -> Decimal | None:
         return Decimal(str(value))
     except (ArithmeticError, TypeError, ValueError):
         return None
-
-
-def _validate_optional_decimal_param(
-    *,
-    params: dict[str, Any],
-    key: str,
-    invalid_error: str,
-) -> None:
-    if key not in params:
-        return
-    if _decimal(params.get(key)) is None:
-        raise ValueError(invalid_error)
-
-
-def _validate_optional_rsi_param(
-    *,
-    params: dict[str, Any],
-    key: str,
-    invalid_error: str,
-    out_of_range_error: str,
-) -> None:
-    if key not in params:
-        return
-    value = _decimal(params.get(key))
-    if value is None:
-        raise ValueError(invalid_error)
-    if value < 0 or value > 100:
-        raise ValueError(out_of_range_error)
 
 
 __all__ = [

--- a/services/torghut/app/trading/intraday_tsmom_contract.py
+++ b/services/torghut/app/trading/intraday_tsmom_contract.py
@@ -1,0 +1,347 @@
+"""Shared parameter contract for intraday_tsmom_v1 across runtimes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Any, Literal, Mapping
+
+
+@dataclass(frozen=True)
+class IntradayTsmomThresholdProfile:
+    bullish_hist_min: Decimal
+    bearish_hist_min: Decimal
+    min_bull_rsi: Decimal
+    max_bull_rsi: Decimal
+    min_bear_rsi: Decimal | None
+    max_bear_rsi: Decimal | None
+    vol_floor: Decimal | None
+    vol_ceil: Decimal | None
+    bearish_hist_cap: Decimal | None
+    low_vol_bonus_threshold: Decimal | None
+
+
+@dataclass(frozen=True)
+class IntradayTsmomEvaluation:
+    direction: Literal["long", "short"]
+    confidence: Decimal
+    rationale: tuple[str, ...]
+    macd_hist: Decimal
+    thresholds: IntradayTsmomThresholdProfile
+
+
+_ONE_SECOND_PROFILE = IntradayTsmomThresholdProfile(
+    bullish_hist_min=Decimal("0.005"),
+    bearish_hist_min=Decimal("0.004"),
+    min_bull_rsi=Decimal("52"),
+    max_bull_rsi=Decimal("62"),
+    min_bear_rsi=None,
+    max_bear_rsi=Decimal("45"),
+    vol_floor=Decimal("0"),
+    vol_ceil=Decimal("0.00030"),
+    bearish_hist_cap=Decimal("0.03"),
+    low_vol_bonus_threshold=Decimal("0.00020"),
+)
+
+_DEFAULT_PROFILE = IntradayTsmomThresholdProfile(
+    bullish_hist_min=Decimal("0.04"),
+    bearish_hist_min=Decimal("0.06"),
+    min_bull_rsi=Decimal("52"),
+    max_bull_rsi=Decimal("62"),
+    min_bear_rsi=Decimal("66"),
+    max_bear_rsi=None,
+    vol_floor=Decimal("0.001"),
+    vol_ceil=Decimal("0.012"),
+    bearish_hist_cap=None,
+    low_vol_bonus_threshold=Decimal("0.008"),
+)
+
+
+def validate_intraday_tsmom_params(params: Mapping[str, Any]) -> None:
+    for key in (
+        "bullish_hist_min",
+        "bearish_hist_min",
+        "bearish_hist_cap",
+        "vol_floor",
+        "vol_ceil",
+        "low_vol_bonus_threshold",
+    ):
+        _validate_optional_decimal_param(
+            params=params,
+            key=key,
+            invalid_error=f"invalid_{key}",
+        )
+    for key in ("min_bull_rsi", "max_bull_rsi", "min_bear_rsi", "max_bear_rsi"):
+        _validate_optional_rsi_param(
+            params=params,
+            key=key,
+            invalid_error=f"invalid_{key}",
+            out_of_range_error=f"{key}_out_of_range",
+        )
+
+
+def resolve_intraday_tsmom_thresholds(
+    *,
+    params: Mapping[str, Any],
+    timeframe: str | None,
+) -> IntradayTsmomThresholdProfile:
+    validate_intraday_tsmom_params(params)
+    profile = _profile_for_timeframe(timeframe)
+    return IntradayTsmomThresholdProfile(
+        bullish_hist_min=_decimal_param(
+            params=params,
+            key="bullish_hist_min",
+            default=profile.bullish_hist_min,
+        ),
+        bearish_hist_min=_decimal_param(
+            params=params,
+            key="bearish_hist_min",
+            default=profile.bearish_hist_min,
+        ),
+        min_bull_rsi=_decimal_param(
+            params=params,
+            key="min_bull_rsi",
+            default=profile.min_bull_rsi,
+        ),
+        max_bull_rsi=_decimal_param(
+            params=params,
+            key="max_bull_rsi",
+            default=profile.max_bull_rsi,
+        ),
+        min_bear_rsi=_optional_decimal_param(
+            params=params,
+            key="min_bear_rsi",
+            default=profile.min_bear_rsi,
+        ),
+        max_bear_rsi=_optional_decimal_param(
+            params=params,
+            key="max_bear_rsi",
+            default=profile.max_bear_rsi,
+        ),
+        vol_floor=_optional_decimal_param(
+            params=params,
+            key="vol_floor",
+            default=profile.vol_floor,
+        ),
+        vol_ceil=_optional_decimal_param(
+            params=params,
+            key="vol_ceil",
+            default=profile.vol_ceil,
+        ),
+        bearish_hist_cap=_optional_decimal_param(
+            params=params,
+            key="bearish_hist_cap",
+            default=profile.bearish_hist_cap,
+        ),
+        low_vol_bonus_threshold=_optional_decimal_param(
+            params=params,
+            key="low_vol_bonus_threshold",
+            default=profile.low_vol_bonus_threshold,
+        ),
+    )
+
+
+def evaluate_intraday_tsmom_signal(
+    *,
+    timeframe: str | None,
+    params: Mapping[str, Any],
+    ema12: Decimal | None,
+    ema26: Decimal | None,
+    macd: Decimal | None,
+    macd_signal: Decimal | None,
+    rsi14: Decimal | None,
+    vol_realized_w60s: Decimal | None,
+) -> IntradayTsmomEvaluation | None:
+    if (
+        ema12 is None
+        or ema26 is None
+        or macd is None
+        or macd_signal is None
+        or rsi14 is None
+    ):
+        return None
+
+    thresholds = resolve_intraday_tsmom_thresholds(
+        params=params,
+        timeframe=timeframe,
+    )
+    macd_hist = macd - macd_signal
+    trend_up = ema12 > ema26 and macd > macd_signal
+    trend_down = ema12 < ema26 and macd < macd_signal
+    vol_ok = _volatility_within_budget(
+        vol_realized_w60s,
+        floor=thresholds.vol_floor,
+        ceil=thresholds.vol_ceil,
+    )
+
+    if (
+        trend_up
+        and vol_ok
+        and macd_hist >= thresholds.bullish_hist_min
+        and thresholds.min_bull_rsi <= rsi14 <= thresholds.max_bull_rsi
+    ):
+        confidence = Decimal("0.64")
+        if macd_hist >= thresholds.bullish_hist_min * Decimal("2"):
+            confidence += Decimal("0.05")
+        if (
+            vol_realized_w60s is not None
+            and thresholds.low_vol_bonus_threshold is not None
+            and vol_realized_w60s <= thresholds.low_vol_bonus_threshold
+        ):
+            confidence += Decimal("0.03")
+        if rsi14 >= thresholds.max_bull_rsi:
+            confidence += Decimal("0.02")
+        return IntradayTsmomEvaluation(
+            direction="long",
+            confidence=min(confidence, Decimal("0.84")),
+            rationale=(
+                "tsmom_trend_up",
+                "momentum_confirmed",
+                "volatility_within_budget",
+            ),
+            macd_hist=macd_hist,
+            thresholds=thresholds,
+        )
+
+    bearish_hist = -macd_hist
+    if (
+        trend_down
+        and bearish_hist >= thresholds.bearish_hist_min
+        and _rsi_within_bearish_bounds(
+            rsi14,
+            min_bear_rsi=thresholds.min_bear_rsi,
+            max_bear_rsi=thresholds.max_bear_rsi,
+        )
+    ):
+        if thresholds.bearish_hist_cap is not None and bearish_hist > thresholds.bearish_hist_cap:
+            return None
+        confidence = Decimal("0.62")
+        if thresholds.max_bear_rsi is not None and rsi14 <= thresholds.max_bear_rsi:
+            confidence += Decimal("0.03")
+        elif thresholds.min_bear_rsi is not None and rsi14 >= thresholds.min_bear_rsi + Decimal("6"):
+            confidence += Decimal("0.03")
+        return IntradayTsmomEvaluation(
+            direction="short",
+            confidence=min(confidence, Decimal("0.80")),
+            rationale=("tsmom_trend_down", "momentum_reversal_exit"),
+            macd_hist=macd_hist,
+            thresholds=thresholds,
+        )
+
+    return None
+
+
+def _profile_for_timeframe(timeframe: str | None) -> IntradayTsmomThresholdProfile:
+    normalized = _normalize_timeframe(timeframe)
+    if normalized == "1sec":
+        return _ONE_SECOND_PROFILE
+    return _DEFAULT_PROFILE
+
+
+def _normalize_timeframe(value: str | None) -> str | None:
+    if value is None:
+        return None
+    normalized = value.strip().lower()
+    if normalized in {"1sec", "1s", "pt1s"}:
+        return "1sec"
+    if normalized in {"1min", "1m", "pt1m"}:
+        return "1min"
+    return normalized
+
+
+def _decimal_param(
+    *,
+    params: Mapping[str, Any],
+    key: str,
+    default: Decimal,
+) -> Decimal:
+    resolved = _optional_decimal_param(params=params, key=key, default=default)
+    return default if resolved is None else resolved
+
+
+def _optional_decimal_param(
+    *,
+    params: Mapping[str, Any],
+    key: str,
+    default: Decimal | None,
+) -> Decimal | None:
+    if key not in params:
+        return default
+    value = _decimal(params.get(key))
+    return default if value is None else value
+
+
+def _decimal(value: Any) -> Decimal | None:
+    if value is None:
+        return None
+    if isinstance(value, Decimal):
+        return value
+    try:
+        return Decimal(str(value))
+    except (ArithmeticError, TypeError, ValueError):
+        return None
+
+
+def _validate_optional_decimal_param(
+    *,
+    params: Mapping[str, Any],
+    key: str,
+    invalid_error: str,
+) -> None:
+    if key not in params:
+        return
+    if _decimal(params.get(key)) is None:
+        raise ValueError(invalid_error)
+
+
+def _validate_optional_rsi_param(
+    *,
+    params: Mapping[str, Any],
+    key: str,
+    invalid_error: str,
+    out_of_range_error: str,
+) -> None:
+    if key not in params:
+        return
+    value = _decimal(params.get(key))
+    if value is None:
+        raise ValueError(invalid_error)
+    if value < 0 or value > 100:
+        raise ValueError(out_of_range_error)
+
+
+def _volatility_within_budget(
+    volatility: Decimal | None,
+    *,
+    floor: Decimal | None,
+    ceil: Decimal | None,
+) -> bool:
+    if volatility is None:
+        return True
+    if floor is not None and volatility < floor:
+        return False
+    if ceil is not None and volatility > ceil:
+        return False
+    return True
+
+
+def _rsi_within_bearish_bounds(
+    rsi14: Decimal,
+    *,
+    min_bear_rsi: Decimal | None,
+    max_bear_rsi: Decimal | None,
+) -> bool:
+    if min_bear_rsi is not None and rsi14 < min_bear_rsi:
+        return False
+    if max_bear_rsi is not None and rsi14 > max_bear_rsi:
+        return False
+    return True
+
+
+__all__ = [
+    "IntradayTsmomEvaluation",
+    "IntradayTsmomThresholdProfile",
+    "evaluate_intraday_tsmom_signal",
+    "resolve_intraday_tsmom_thresholds",
+    "validate_intraday_tsmom_params",
+]

--- a/services/torghut/app/trading/strategy_runtime.py
+++ b/services/torghut/app/trading/strategy_runtime.py
@@ -14,6 +14,7 @@ from typing import Any, Literal, Protocol, cast
 from ..models import Strategy
 from ..strategies.catalog import extract_catalog_metadata
 from .features import FeatureVectorV3, validate_declared_features
+from .intraday_tsmom_contract import evaluate_intraday_tsmom_signal
 from .strategy_specs import build_compiled_strategy_artifacts, strategy_type_supports_spec_v2
 
 
@@ -380,79 +381,39 @@ class IntradayTsmomPlugin:
     def evaluate(
         self, context: StrategyContext, features: FeatureVectorV3
     ) -> StrategyIntent | None:
-        _ = context
         ema12 = _decimal(features.values.get("ema12"))
         ema26 = _decimal(features.values.get("ema26"))
         macd = _decimal(features.values.get("macd"))
         macd_signal = _decimal(features.values.get("macd_signal"))
         rsi14 = _decimal(features.values.get("rsi14"))
         vol = _decimal(features.values.get("vol_realized_w60s"))
-
-        if (
-            ema12 is None
-            or ema26 is None
-            or macd is None
-            or macd_signal is None
-            or rsi14 is None
-        ):
+        evaluation = evaluate_intraday_tsmom_signal(
+            timeframe=context.timeframe,
+            params=context.params,
+            ema12=ema12,
+            ema26=ema26,
+            macd=macd,
+            macd_signal=macd_signal,
+            rsi14=rsi14,
+            vol_realized_w60s=vol,
+        )
+        if evaluation is None:
             return None
 
-        macd_hist = macd - macd_signal
-        trend_up = ema12 > ema26 and macd > macd_signal
-        trend_down = ema12 < ema26 and macd < macd_signal
-        # Profit-focused filter: avoid noisy low-conviction and high-volatility windows.
-        vol_ok = vol is None or (Decimal("0.001") <= vol <= Decimal("0.012"))
-
         target_notional = _target_notional(context.params)
-
-        if (
-            trend_up
-            and vol_ok
-            and macd_hist >= Decimal("0.04")
-            and Decimal("52") <= rsi14 <= Decimal("62")
-        ):
-            confidence = Decimal("0.64")
-            if macd_hist >= Decimal("0.10"):
-                confidence += Decimal("0.05")
-            if vol is not None and vol <= Decimal("0.008"):
-                confidence += Decimal("0.03")
-            return StrategyIntent(
-                strategy_id=context.strategy_id,
-                symbol=context.symbol,
-                direction="buy",
-                confidence=min(confidence, Decimal("0.82")),
-                target_notional=target_notional,
-                horizon=context.timeframe,
-                explain=(
-                    "tsmom_trend_up",
-                    "momentum_confirmed",
-                    "volatility_within_budget",
-                ),
-                feature_snapshot_hash=features.normalization_hash,
-                required_features=self.required_features,
-            )
-
-        if (
-            trend_down
-            and rsi14 >= Decimal("66")
-            and (macd_signal - macd) >= Decimal("0.06")
-        ):
-            confidence = Decimal("0.62")
-            if rsi14 >= Decimal("72"):
-                confidence += Decimal("0.03")
-            return StrategyIntent(
-                strategy_id=context.strategy_id,
-                symbol=context.symbol,
-                direction="sell",
-                confidence=min(confidence, Decimal("0.78")),
-                target_notional=target_notional,
-                horizon=context.timeframe,
-                explain=("tsmom_trend_down", "momentum_reversal_exit"),
-                feature_snapshot_hash=features.normalization_hash,
-                required_features=self.required_features,
-            )
-
-        return None
+        direction = "buy" if evaluation.direction == "long" else "sell"
+        confidence_cap = Decimal("0.84") if evaluation.direction == "long" else Decimal("0.80")
+        return StrategyIntent(
+            strategy_id=context.strategy_id,
+            symbol=context.symbol,
+            direction=direction,
+            confidence=min(evaluation.confidence, confidence_cap),
+            target_notional=target_notional,
+            horizon=context.timeframe,
+            explain=evaluation.rationale,
+            feature_snapshot_hash=features.normalization_hash,
+            required_features=self.required_features,
+        )
 
 
 class StrategyRuntime:

--- a/services/torghut/config/autonomous-strategy-intraday-tsmom-sample.yaml
+++ b/services/torghut/config/autonomous-strategy-intraday-tsmom-sample.yaml
@@ -3,6 +3,15 @@ strategies:
     strategy_type: intraday_tsmom_v1
     version: 1.1.0
     enabled: true
-    base_timeframe: 1Min
+    base_timeframe: 1Sec
     priority: 100
-    params: {}
+    params:
+      bullish_hist_min: "0.005"
+      bearish_hist_min: "0.004"
+      bearish_hist_cap: "0.03"
+      min_bull_rsi: "52"
+      max_bull_rsi: "62"
+      max_bear_rsi: "45"
+      vol_floor: "0"
+      vol_ceil: "0.00030"
+      low_vol_bonus_threshold: "0.00020"

--- a/services/torghut/tests/test_autonomy_runtime.py
+++ b/services/torghut/tests/test_autonomy_runtime.py
@@ -137,3 +137,67 @@ class TestAutonomyRuntime(TestCase):
         )
         self.assertEqual(len(result.decisions), 1)
         self.assertEqual(result.decisions[0].action, 'sell')
+
+    def test_intraday_tsmom_v1_plugin_emits_buy_for_one_second_profile(self) -> None:
+        runtime = StrategyRuntime(default_runtime_registry())
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 13, 13, 33, 46, tzinfo=timezone.utc),
+            symbol='MSFT',
+            timeframe='1Sec',
+            payload={
+                'macd': {'macd': '0.0061800252285331625', 'signal': '-0.0207157904036421'},
+                'rsi14': '60.84685352855714',
+                'price': '395.5129',
+                'ema12': '395.51296737223805',
+                'ema26': '395.50678734700955',
+                'vol_realized_w60s': '0.00009809491242978304',
+            },
+        )
+
+        result = runtime.evaluate(
+            signal,
+            [
+                StrategyRuntimeConfig(
+                    strategy_id='tsmom-1sec',
+                    strategy_type='intraday_tsmom_v1',
+                    version='1.1.0',
+                    base_timeframe='1Sec',
+                    params={},
+                )
+            ],
+        )
+
+        self.assertEqual(len(result.decisions), 1)
+        self.assertEqual(result.decisions[0].action, 'buy')
+
+    def test_intraday_tsmom_v1_plugin_emits_sell_for_one_second_profile(self) -> None:
+        runtime = StrategyRuntime(default_runtime_registry())
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 13, 13, 36, 38, tzinfo=timezone.utc),
+            symbol='PLTR',
+            timeframe='1Sec',
+            payload={
+                'macd': {'macd': '-0.004793351722122387', 'signal': '-0.000495365185694872'},
+                'rsi14': '39.013689684962074',
+                'price': '150.9813',
+                'ema12': '150.98135382176636',
+                'ema26': '150.9861471734885',
+                'vol_realized_w60s': '0.00011776977395581281',
+            },
+        )
+
+        result = runtime.evaluate(
+            signal,
+            [
+                StrategyRuntimeConfig(
+                    strategy_id='tsmom-1sec',
+                    strategy_type='intraday_tsmom_v1',
+                    version='1.1.0',
+                    base_timeframe='1Sec',
+                    params={},
+                )
+            ],
+        )
+
+        self.assertEqual(len(result.decisions), 1)
+        self.assertEqual(result.decisions[0].action, 'sell')

--- a/services/torghut/tests/test_strategy_runtime.py
+++ b/services/torghut/tests/test_strategy_runtime.py
@@ -202,6 +202,80 @@ class TestStrategyRuntime(TestCase):
         self.assertIn("tsmom_trend_down", decision.intent.rationale)
         self.assertIn("momentum_reversal_exit", decision.intent.rationale)
 
+    def test_intraday_tsmom_plugin_emits_buy_for_one_second_profile(self) -> None:
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="intraday-tsmom-1sec",
+            description="version=1.1.0",
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="intraday_tsmom_v1",
+            universe_symbols=["MSFT"],
+            max_position_pct_equity=Decimal("0.02"),
+            max_notional_per_trade=Decimal("2500"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 13, 13, 33, 46, tzinfo=timezone.utc),
+            symbol="MSFT",
+            timeframe="1Sec",
+            seq=1,
+            payload={
+                "price": 395.5129,
+                "ema12": 395.51296737223805,
+                "ema26": 395.50678734700955,
+                "macd": 0.0061800252285331625,
+                "macd_signal": -0.0207157904036421,
+                "rsi14": 60.84685352855714,
+                "vol_realized_w60s": 0.00009809491242978304,
+            },
+        )
+        feature_contract = normalize_feature_vector_v3(signal)
+        runtime = StrategyRuntime()
+
+        decision = runtime.evaluate(strategy, feature_contract, timeframe="1Sec")
+
+        self.assertIsNotNone(decision)
+        assert decision is not None
+        self.assertEqual(decision.intent.action, "buy")
+        self.assertIn("tsmom_trend_up", decision.intent.rationale)
+
+    def test_intraday_tsmom_plugin_emits_sell_for_one_second_profile(self) -> None:
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="intraday-tsmom-1sec",
+            description="version=1.1.0",
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="intraday_tsmom_v1",
+            universe_symbols=["PLTR"],
+            max_position_pct_equity=Decimal("0.02"),
+            max_notional_per_trade=Decimal("2500"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 13, 13, 36, 38, tzinfo=timezone.utc),
+            symbol="PLTR",
+            timeframe="1Sec",
+            seq=1,
+            payload={
+                "price": 150.9813,
+                "ema12": 150.98135382176636,
+                "ema26": 150.9861471734885,
+                "macd": -0.004793351722122387,
+                "macd_signal": -0.000495365185694872,
+                "rsi14": 39.013689684962074,
+                "vol_realized_w60s": 0.00011776977395581281,
+            },
+        )
+        feature_contract = normalize_feature_vector_v3(signal)
+        runtime = StrategyRuntime()
+
+        decision = runtime.evaluate(strategy, feature_contract, timeframe="1Sec")
+
+        self.assertIsNotNone(decision)
+        assert decision is not None
+        self.assertEqual(decision.intent.action, "sell")
+        self.assertIn("tsmom_trend_down", decision.intent.rationale)
+
     def test_runtime_isolates_plugin_failures_and_continues(self) -> None:
         healthy = Strategy(
             id=uuid.uuid4(),


### PR DESCRIPTION
## Summary

- factor `intraday_tsmom_v1` signal evaluation into one shared contract consumed by both the scheduler runtime and the autonomy runtime
- add explicit 1-second production parameters to the Torghut strategy catalog and sample config so live/sim no longer fall back to mismatched hidden defaults
- add March 13-scale regression coverage for 1-second buy and sell signals in both runtime test suites

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen python -m unittest tests.test_strategy_runtime tests.test_autonomy_runtime tests.test_strategy_catalog`
- `uv run --frozen python -m unittest tests.test_strategy_runtime tests.test_autonomy_runtime`
- `uv run --frozen ruff check app/trading/strategy_runtime.py app/trading/autonomy/runtime.py app/trading/intraday_tsmom_contract.py tests/test_strategy_runtime.py tests/test_autonomy_runtime.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
