### PR TITLE
chore(symphony): promote image 2c94196b

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-15T01:37:56Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-16T03:47:22Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -24,5 +24,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "0e89c49f"
-    digest: sha256:64ce115e9a4c24bb0ec7a7d16a1850857f35acb61843ff07c0adcd29029a7595
+    newTag: "2c94196b"
+    digest: sha256:c5c4525301e550a249499f2abcdfdb4c97ec0952a405d2150867b5e56cc7d573

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-15T01:37:56Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-16T03:47:22Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -26,5 +26,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "0e89c49f"
-    digest: sha256:64ce115e9a4c24bb0ec7a7d16a1850857f35acb61843ff07c0adcd29029a7595
+    newTag: "2c94196b"
+    digest: sha256:c5c4525301e550a249499f2abcdfdb4c97ec0952a405d2150867b5e56cc7d573

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,4 +6,4 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-15T01:37:56Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-16T03:47:22Z"

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -18,5 +18,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "0e89c49f"
-    digest: sha256:64ce115e9a4c24bb0ec7a7d16a1850857f35acb61843ff07c0adcd29029a7595
+    newTag: "2c94196b"
+    digest: sha256:c5c4525301e550a249499f2abcdfdb4c97ec0952a405d2150867b5e56cc7d573


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `2c94196b1334cb713dc50549294a1d784d840836`
- Image tag: `2c94196b`
- Image digest: `sha256:c5c4525301e550a249499f2abcdfdb4c97ec0952a405d2150867b5e56cc7d573`