### PR TITLE
fix(symphony): prevent ghost running workers

### DIFF
--- a/services/symphony/src/orchestrator-lifecycle.test.ts
+++ b/services/symphony/src/orchestrator-lifecycle.test.ts
@@ -145,4 +145,94 @@ describe('orchestrator lifecycle', () => {
       await runtime.dispose()
     }
   })
+
+  test('does not lose fast worker exits that happen during dispatch startup', async () => {
+    const config = makeTestConfig({
+      pollingIntervalMs: 60_000,
+      health: { preDispatch: [], postDeploy: [] },
+    })
+
+    const runtime = ManagedRuntime.make(
+      makeOrchestratorLayer(createLogger({ test: 'orchestrator-fast-exit' })).pipe(
+        Layer.provide(
+          Layer.succeed(WorkflowService, {
+            current: Effect.succeed({
+              definition: { config: {}, promptTemplate: 'Work on {{issue.identifier}}' },
+              config,
+            }),
+            config: Effect.succeed(config),
+            reload: Effect.succeed({
+              definition: { config: {}, promptTemplate: 'Work on {{issue.identifier}}' },
+              config,
+            }),
+            changes: Stream.empty,
+          }),
+        ),
+        Layer.provide(
+          Layer.succeed(TrackerService, {
+            fetchCandidateIssues: Effect.succeed([candidateIssue]),
+            fetchIssuesByStates: () => Effect.succeed([]),
+            fetchIssueStatesByIds: () => Effect.succeed([candidateIssue]),
+            executeLinearGraphql: () => Effect.succeed({}),
+            handoffIssue: () => Effect.void,
+          }),
+        ),
+        Layer.provide(
+          Layer.succeed(WorkspaceService, {
+            createForIssue: () => Effect.die('not used'),
+            runBeforeRun: () => Effect.void,
+            runAfterRun: () => Effect.void,
+            removeWorkspace: () => Effect.void,
+          }),
+        ),
+        Layer.provide(
+          Layer.succeed(IssueRunnerService, {
+            runAttempt: (_issue, _attempt, callbacks) =>
+              callbacks
+                .onWorkspacePath('/workspace/symphony/ABC-1')
+                .pipe(Effect.zipRight(Effect.succeed('/workspace/symphony/ABC-1'))),
+          }),
+        ),
+        Layer.provide(
+          Layer.succeed(LeaderElectionService, {
+            start: Effect.void,
+            stop: Effect.void,
+            status: Effect.succeed(leaderSnapshot),
+            changes: Stream.empty,
+          }),
+        ),
+        Layer.provide(
+          Layer.succeed(StateStoreService, {
+            load: Effect.succeed(emptyPersistedSchedulerState()),
+            save: () => Effect.void,
+            stateFilePath: Effect.succeed('/tmp/symphony-state.json'),
+          }),
+        ),
+        Layer.provide(Layer.succeed(TargetHealthService, { evaluatePreDispatch: Effect.succeed(targetHealthSummary) })),
+      ),
+    )
+
+    try {
+      await runtime.runPromise(
+        Effect.scoped(
+          Effect.gen(function* () {
+            const orchestrator = yield* OrchestratorService
+            yield* orchestrator.start
+            yield* orchestrator.triggerRefresh
+            yield* Effect.sleep(50)
+
+            const snapshot = yield* orchestrator.getSnapshot
+            expect(snapshot.counts.running).toBe(0)
+            expect(snapshot.counts.retrying).toBe(1)
+            expect(snapshot.retrying[0]?.issueIdentifier).toBe('ABC-1')
+            expect(snapshot.recentEvents.some((event) => event.event === 'retry_scheduled')).toBe(true)
+
+            yield* orchestrator.stop
+          }),
+        ),
+      )
+    } finally {
+      await runtime.dispose()
+    }
+  })
 })

--- a/services/symphony/src/orchestrator.ts
+++ b/services/symphony/src/orchestrator.ts
@@ -64,7 +64,7 @@ type RunningRuntimeEntry = {
   session: LiveSession
   lastError: string | null
   recentEvents: RecentEvent[]
-  workerFiber: Fiber.RuntimeFiber<void, never>
+  workerFiber: Fiber.RuntimeFiber<void, never> | null
   stopReason: WorkerStopReason
   terminalCleanupRequested: boolean
 }
@@ -421,6 +421,9 @@ const applyTokenUsage = (state: OrchestratorState, running: RunningRuntimeEntry,
   state.codexTotals.totalTokens += deltaTotal
 }
 
+const interruptWorkerFiber = (fiber: Fiber.RuntimeFiber<void, never> | null) =>
+  fiber ? Fiber.interruptFork(fiber) : Effect.void
+
 export interface OrchestratorServiceDefinition {
   readonly start: Effect.Effect<void, WorkflowError | ConfigError | TrackerError | WorkspaceError | OrchestratorError>
   readonly stop: Effect.Effect<void, never>
@@ -747,20 +750,6 @@ export const makeOrchestratorLayer = (logger: Logger) =>
 
       const dispatchIssue = (issue: Issue, attempt: number | null) =>
         Effect.gen(function* () {
-          const workerEffect = issueRunner
-            .runAttempt(issue, attempt, {
-              onEvent: (event) =>
-                Queue.offer(queue, { _tag: 'CodexEventReceived', issueId: issue.id, event }).pipe(Effect.asVoid),
-              onWorkspacePath: (workspacePath) =>
-                Queue.offer(queue, { _tag: 'WorkspaceReady', issueId: issue.id, workspacePath }).pipe(Effect.asVoid),
-            })
-            .pipe(
-              Effect.exit,
-              Effect.flatMap((exit) => Queue.offer(queue, { _tag: 'WorkerExited', issueId: issue.id, exit })),
-              Effect.asVoid,
-            )
-
-          const workerFiber = yield* Effect.forkIn(workerEffect, serviceScope)
           const startedAtMs = Date.now()
           const startedAt = new Date(startedAtMs).toISOString()
 
@@ -782,7 +771,7 @@ export const makeOrchestratorLayer = (logger: Logger) =>
               session: EMPTY_SESSION(),
               lastError: null,
               recentEvents: [],
-              workerFiber,
+              workerFiber: null,
               stopReason: 'running',
               terminalCleanupRequested: false,
             }
@@ -813,6 +802,28 @@ export const makeOrchestratorLayer = (logger: Logger) =>
           if (existingRetry?.fiber) {
             yield* Fiber.interruptFork(existingRetry.fiber)
           }
+
+          const workerEffect = issueRunner
+            .runAttempt(issue, attempt, {
+              onEvent: (event) =>
+                Queue.offer(queue, { _tag: 'CodexEventReceived', issueId: issue.id, event }).pipe(Effect.asVoid),
+              onWorkspacePath: (workspacePath) =>
+                Queue.offer(queue, { _tag: 'WorkspaceReady', issueId: issue.id, workspacePath }).pipe(Effect.asVoid),
+            })
+            .pipe(
+              Effect.exit,
+              Effect.flatMap((exit) => Queue.offer(queue, { _tag: 'WorkerExited', issueId: issue.id, exit })),
+              Effect.asVoid,
+            )
+
+          const workerFiber = yield* Effect.forkIn(workerEffect, serviceScope)
+          yield* SynchronizedRef.modifyEffect(stateRef, (state) => {
+            const running = state.running.get(issue.id)
+            if (running) {
+              running.workerFiber = workerFiber
+            }
+            return Effect.succeed([undefined, state] as const)
+          })
           yield* persistStateBestEffort
         })
 
@@ -846,7 +857,7 @@ export const makeOrchestratorLayer = (logger: Logger) =>
                 }
                 return Effect.succeed([undefined, state] as const)
               })
-              yield* Fiber.interruptFork(running.workerFiber)
+              yield* interruptWorkerFiber(running.workerFiber)
               continue
             }
 
@@ -861,7 +872,7 @@ export const makeOrchestratorLayer = (logger: Logger) =>
                 }
                 return Effect.succeed([undefined, state] as const)
               })
-              yield* Fiber.interruptFork(running.workerFiber)
+              yield* interruptWorkerFiber(running.workerFiber)
               continue
             }
 
@@ -874,7 +885,7 @@ export const makeOrchestratorLayer = (logger: Logger) =>
                 }
                 return Effect.succeed([undefined, state] as const)
               })
-              yield* Fiber.interruptFork(running.workerFiber)
+              yield* interruptWorkerFiber(running.workerFiber)
               continue
             }
 
@@ -910,7 +921,7 @@ export const makeOrchestratorLayer = (logger: Logger) =>
                     }
                     return Effect.succeed([undefined, state] as const)
                   })
-                  yield* Fiber.interruptFork(running.workerFiber)
+                  yield* interruptWorkerFiber(running.workerFiber)
                 }
               }
             })
@@ -969,7 +980,7 @@ export const makeOrchestratorLayer = (logger: Logger) =>
           })
 
           for (const running of interrupted.running) {
-            yield* Fiber.interruptFork(running.workerFiber)
+            yield* interruptWorkerFiber(running.workerFiber)
           }
           for (const retry of interrupted.retries) {
             if (retry.fiber) {
@@ -1553,7 +1564,7 @@ export const makeOrchestratorLayer = (logger: Logger) =>
             }
           }
           for (const running of state.running.values()) {
-            yield* Fiber.interruptFork(running.workerFiber)
+            yield* interruptWorkerFiber(running.workerFiber)
           }
 
           yield* leaderElection.stop


### PR DESCRIPTION
## Summary

- register the running entry before the Symphony worker fiber can emit `WorkerExited`
- assign the worker fiber handle after the running record exists so fast exits cannot leave ghost running sessions
- add a regression test that covers an immediate successful worker exit during dispatch startup

## Related Issues

- None

## Testing

- `bun run --cwd services/symphony test`
- `bun run --cwd services/symphony lint:oxlint:type`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
