### PR TITLE
chore(symphony): promote image f852a3e2

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-16T03:47:22Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-16T04:08:18Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -24,5 +24,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "2c94196b"
-    digest: sha256:c5c4525301e550a249499f2abcdfdb4c97ec0952a405d2150867b5e56cc7d573
+    newTag: "f852a3e2"
+    digest: sha256:f77cc459830e0183fd150d501e75408894ceed8bed68c7355f5280e7e131eba3

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-16T03:47:22Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-16T04:08:18Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -26,5 +26,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "2c94196b"
-    digest: sha256:c5c4525301e550a249499f2abcdfdb4c97ec0952a405d2150867b5e56cc7d573
+    newTag: "f852a3e2"
+    digest: sha256:f77cc459830e0183fd150d501e75408894ceed8bed68c7355f5280e7e131eba3

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,4 +6,4 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-16T03:47:22Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-16T04:08:18Z"

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -18,5 +18,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "2c94196b"
-    digest: sha256:c5c4525301e550a249499f2abcdfdb4c97ec0952a405d2150867b5e56cc7d573
+    newTag: "f852a3e2"
+    digest: sha256:f77cc459830e0183fd150d501e75408894ceed8bed68c7355f5280e7e131eba3


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `f852a3e22edb8d8f4564cf75ecc9d39e2b648340`
- Image tag: `f852a3e2`
- Image digest: `sha256:f77cc459830e0183fd150d501e75408894ceed8bed68c7355f5280e7e131eba3`