### PR TITLE
chore(symphony): promote image 87e7d55f

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-16T04:08:18Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-16T04:25:09Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -24,5 +24,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "f852a3e2"
-    digest: sha256:f77cc459830e0183fd150d501e75408894ceed8bed68c7355f5280e7e131eba3
+    newTag: "87e7d55f"
+    digest: sha256:f75965090d92baf3b5a83e961ef5a0d0823e0c332d9a80abecd03aa307f93364

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-16T04:08:18Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-16T04:25:09Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -26,5 +26,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "f852a3e2"
-    digest: sha256:f77cc459830e0183fd150d501e75408894ceed8bed68c7355f5280e7e131eba3
+    newTag: "87e7d55f"
+    digest: sha256:f75965090d92baf3b5a83e961ef5a0d0823e0c332d9a80abecd03aa307f93364

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,4 +6,4 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-16T04:08:18Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-16T04:25:09Z"

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -18,5 +18,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "f852a3e2"
-    digest: sha256:f77cc459830e0183fd150d501e75408894ceed8bed68c7355f5280e7e131eba3
+    newTag: "87e7d55f"
+    digest: sha256:f75965090d92baf3b5a83e961ef5a0d0823e0c332d9a80abecd03aa307f93364


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `87e7d55f801b65f7eba921a6b3058dadad720b09`
- Image tag: `87e7d55f`
- Image digest: `sha256:f75965090d92baf3b5a83e961ef5a0d0823e0c332d9a80abecd03aa307f93364`