### PR TITLE
chore(symphony): promote image 6ac7bbd4

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-16T04:25:09Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-16T04:37:22Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -24,5 +24,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "87e7d55f"
-    digest: sha256:f75965090d92baf3b5a83e961ef5a0d0823e0c332d9a80abecd03aa307f93364
+    newTag: "6ac7bbd4"
+    digest: sha256:e7e076b70ff95c2904a4d8bd7fa344e98eb5afeac6a110576348677c596ebc41

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-16T04:25:09Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-16T04:37:22Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -26,5 +26,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "87e7d55f"
-    digest: sha256:f75965090d92baf3b5a83e961ef5a0d0823e0c332d9a80abecd03aa307f93364
+    newTag: "6ac7bbd4"
+    digest: sha256:e7e076b70ff95c2904a4d8bd7fa344e98eb5afeac6a110576348677c596ebc41

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,4 +6,4 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-16T04:25:09Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-16T04:37:22Z"

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -18,5 +18,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "87e7d55f"
-    digest: sha256:f75965090d92baf3b5a83e961ef5a0d0823e0c332d9a80abecd03aa307f93364
+    newTag: "6ac7bbd4"
+    digest: sha256:e7e076b70ff95c2904a4d8bd7fa344e98eb5afeac6a110576348677c596ebc41


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `6ac7bbd43b9c8073d403ff51350f4bed88a06e67`
- Image tag: `6ac7bbd4`
- Image digest: `sha256:e7e076b70ff95c2904a4d8bd7fa344e98eb5afeac6a110576348677c596ebc41`