### PR TITLE
chore(symphony): promote image 32f2a121

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-16T04:37:22Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-16T05:01:33Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -25,5 +25,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "6ac7bbd4"
-    digest: sha256:e7e076b70ff95c2904a4d8bd7fa344e98eb5afeac6a110576348677c596ebc41
+    newTag: "32f2a121"
+    digest: sha256:0a4d1c63cfe2fa00b14f7b408575f902895ecc3f0c9728b626826832fc87b8cd

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-16T04:37:22Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-16T05:01:33Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -26,5 +26,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "6ac7bbd4"
-    digest: sha256:e7e076b70ff95c2904a4d8bd7fa344e98eb5afeac6a110576348677c596ebc41
+    newTag: "32f2a121"
+    digest: sha256:0a4d1c63cfe2fa00b14f7b408575f902895ecc3f0c9728b626826832fc87b8cd

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-16T04:37:22Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-16T05:01:33Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -19,5 +19,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "6ac7bbd4"
-    digest: sha256:e7e076b70ff95c2904a4d8bd7fa344e98eb5afeac6a110576348677c596ebc41
+    newTag: "32f2a121"
+    digest: sha256:0a4d1c63cfe2fa00b14f7b408575f902895ecc3f0c9728b626826832fc87b8cd


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `32f2a121484d04836c3e2269a266c9a346376ccc`
- Image tag: `32f2a121`
- Image digest: `sha256:0a4d1c63cfe2fa00b14f7b408575f902895ecc3f0c9728b626826832fc87b8cd`