### PR TITLE
fix(torghut): trust terminal success in activity proof

### DIFF
--- a/services/torghut/scripts/historical_simulation_verification.py
+++ b/services/torghut/scripts/historical_simulation_verification.py
@@ -1018,23 +1018,34 @@ def _classify_activity_snapshot(
 ) -> str:
     cursor_at = _parse_optional_rfc3339_timestamp(_as_text(snapshot.get('cursor_at')))
     cursor_at_raw = snapshot.get('cursor_at')
+    signal_rows = _safe_int(snapshot.get('signal_rows'))
+    trade_decisions = _safe_int(snapshot.get('trade_decisions'))
+    executions = _safe_int(snapshot.get('executions'))
+    execution_tca_metrics = _safe_int(snapshot.get('execution_tca_metrics'))
+    execution_order_events = _safe_int(snapshot.get('execution_order_events'))
+    cursor_terminal_reached = cursor_at is not None and cursor_at >= effective_terminal_signal_ts
+    has_terminal_success_snapshot = (
+        signal_rows > 0
+        and cursor_terminal_reached
+        and trade_decisions > 0
+        and executions > 0
+        and execution_tca_metrics > 0
+        and execution_order_events > 0
+    )
+    if has_terminal_success_snapshot:
+        return 'success'
     if not runtime_ready:
         return 'infra_not_active'
-    if _safe_int(snapshot.get('signal_rows')) <= 0:
+    if signal_rows <= 0:
         return 'signals_absent'
     if cursor_at_raw is None or cursor_at is None:
         return 'cursor_not_advancing'
     if cursor_at < effective_terminal_signal_ts:
         return 'cursor_stalled_before_terminal_signal'
-    if _safe_int(snapshot.get('trade_decisions')) <= 0:
+    if trade_decisions <= 0:
         return 'decisions_absent'
-    if (
-        _safe_int(snapshot.get('executions')) <= 0
-        or _safe_int(snapshot.get('execution_tca_metrics')) <= 0
-        or (
-            _safe_int(snapshot.get('executions')) > 0
-            and _safe_int(snapshot.get('execution_order_events')) <= 0
-        )
+    if executions <= 0 or execution_tca_metrics <= 0 or (
+        executions > 0 and execution_order_events <= 0
     ):
         return 'executions_absent'
     return 'success'

--- a/services/torghut/tests/test_start_historical_simulation.py
+++ b/services/torghut/tests/test_start_historical_simulation.py
@@ -4629,6 +4629,94 @@ class TestStartHistoricalSimulation(TestCase):
         self.assertEqual(report['effective_terminal_signal_ts'], '2026-03-11T13:34:58+00:00')
         self.assertEqual(report['dataset_alignment'], 'window_declared_beyond_dataset')
 
+    def test_current_activity_report_prefers_terminal_success_over_runtime_flap(self) -> None:
+        postgres_config = PostgresRuntimeConfig(
+            admin_dsn='postgresql://torghut:secret@localhost:5432/postgres',
+            simulation_dsn='postgresql://torghut:secret@localhost:5432/torghut_sim_sim_1',
+            simulation_db='torghut_sim_sim_1',
+            migrations_command='true',
+        )
+        manifest = {
+            'window': {
+                'start': '2026-03-13T13:30:00Z',
+                'end': '2026-03-13T20:00:00Z',
+            },
+            'monitor': {
+                'timeout_seconds': 14400,
+                'poll_seconds': 30,
+                'min_trade_decisions': 1,
+                'min_executions': 1,
+                'min_execution_tca_metrics': 1,
+                'min_execution_order_events': 1,
+                'cursor_grace_seconds': 120,
+            },
+        }
+        resources = _build_resources(
+            'sim-proof-terminal-success',
+            {
+                'dataset_id': 'dataset-a',
+                'runtime': {
+                    'target_mode': 'dedicated_service',
+                    'namespace': 'torghut',
+                    'ta_configmap': 'torghut-ta-sim-config',
+                    'ta_deployment': 'torghut-ta-sim',
+                    'torghut_service': 'torghut-sim',
+                    'torghut_forecast_service': 'torghut-forecast-sim',
+                },
+            },
+        )
+        clickhouse_config = ClickHouseRuntimeConfig(
+            http_url='http://clickhouse:8123',
+            username='torghut',
+            password=None,
+        )
+        with patch(
+            'scripts.historical_simulation_verification._simulation_progress_snapshot',
+            return_value={
+                'components': {
+                    'replay': {
+                        'last_source_ts': '2026-03-13T19:59:59.714000+00:00',
+                        'status': 'replayed',
+                    },
+                    'torghut': {
+                        'cursor_at': '2026-03-13T20:00:00+00:00',
+                        'execution_order_events': 59,
+                        'execution_tca_metrics': 59,
+                        'executions': 59,
+                        'last_signal_ts': '2026-03-13T20:00:00+00:00',
+                        'status': 'running',
+                        'trade_decisions': 174,
+                    },
+                },
+                'cursor_at': '2026-03-13T20:00:00+00:00',
+                'execution_order_events': 59,
+                'execution_tca_metrics': 59,
+                'executions': 59,
+                'last_price_ts': None,
+                'last_signal_ts': '2026-03-13T20:00:00+00:00',
+                'last_source_ts': '2026-03-13T19:59:59.714000+00:00',
+                'price_rows': 0,
+                'progress_source': 'simulation_run_progress',
+                'records_dumped': 0,
+                'records_replayed': 8435001,
+                'signal_rows': 1,
+                'trade_decisions': 174,
+            },
+        ):
+            report = historical_simulation_verification._current_activity_report(
+                resources=resources,
+                manifest=manifest,
+                postgres_config=postgres_config,
+                clickhouse_config=clickhouse_config,
+                runtime_verify={'runtime_state': 'not_ready'},
+            )
+
+        self.assertEqual(report['status'], 'ok')
+        self.assertEqual(report['activity_classification'], 'success')
+        self.assertTrue(report['terminal_reached'])
+        self.assertTrue(report['thresholds_met'])
+        self.assertEqual(report['cursor_at'], '2026-03-13T20:00:00+00:00')
+
     def test_monitor_run_completion_uses_direct_counts_when_progress_rows_are_stale(self) -> None:
         postgres_config = PostgresRuntimeConfig(
             admin_dsn='postgresql://torghut:secret@localhost:5432/postgres',


### PR DESCRIPTION
## Summary

- make the activity proof classifier trust a completed terminal snapshot even if live runtime readiness flaps during post-run analysis
- add a regression test for the March 13 proof case where the snapshot already has terminal cursor, decisions, executions, TCA, and order events
- keep the post-run Rollouts activity gate aligned with the real Torghut execution evidence instead of a transient live readiness sample

## Related Issues

None

## Testing

- `uv run --frozen python -m unittest tests.test_start_historical_simulation.TestStartHistoricalSimulation.test_monitor_run_completion_requires_order_events_when_executions_exist tests.test_start_historical_simulation.TestStartHistoricalSimulation.test_monitor_run_completion_succeeds_when_terminal_signal_precedes_window_end tests.test_start_historical_simulation.TestStartHistoricalSimulation.test_current_activity_report_prefers_terminal_success_over_runtime_flap tests.test_start_historical_simulation.TestStartHistoricalSimulation.test_monitor_run_completion_uses_direct_counts_when_progress_rows_are_stale`
- `uv run --frozen ruff check services/torghut/scripts/historical_simulation_verification.py services/torghut/tests/test_start_historical_simulation.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen python - <<'PY' ...` against completed run `sim-proof-9d28f0fa-march13-fresh-20260316-044516` to verify patched activity analysis returns `success` with `174` trade decisions and `59` executions even when live `runtime_state` has already fallen back to `not_ready`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
