### PR TITLE
fix(symphony): align linear handoff mutations with live schema

### DIFF
--- a/services/symphony/src/linear-client.test.ts
+++ b/services/symphony/src/linear-client.test.ts
@@ -193,10 +193,14 @@ describe('linear tracker client', () => {
 
       expect(requests).toHaveLength(3)
       expect(requests[0]?.query).toContain('SymphonyIssueTeamStates')
+      expect(requests[0]?.query).toContain('$issueId: String!')
       expect(requests[0]?.variables.issueId).toBe('issue-1')
       expect(requests[1]?.query).toContain('commentCreate')
+      expect(requests[1]?.query).toContain('$issueId: String!')
       expect(requests[1]?.variables.body).toContain('promotion PR is already open')
       expect(requests[2]?.query).toContain('issueUpdate')
+      expect(requests[2]?.query).toContain('$issueId: String!')
+      expect(requests[2]?.query).toContain('$stateId: String!')
       expect(requests[2]?.variables.stateId).toBe('state-backlog')
     } finally {
       await runtime.dispose()

--- a/services/symphony/src/linear-client.ts
+++ b/services/symphony/src/linear-client.ts
@@ -399,7 +399,7 @@ export const makeTrackerLayer = (logger: Logger) =>
             config.tracker.endpoint,
             config.tracker.apiKey ?? '',
             `
-              query SymphonyIssueTeamStates($issueId: ID!) {
+              query SymphonyIssueTeamStates($issueId: String!) {
                 issue(id: $issueId) {
                   team {
                     states {
@@ -481,7 +481,7 @@ export const makeTrackerLayer = (logger: Logger) =>
               config.tracker.endpoint,
               config.tracker.apiKey,
               `
-                mutation SymphonyCommentOnIssue($issueId: ID!, $body: String!) {
+                mutation SymphonyCommentOnIssue($issueId: String!, $body: String!) {
                   commentCreate(input: { issueId: $issueId, body: $body }) {
                     success
                   }
@@ -504,7 +504,7 @@ export const makeTrackerLayer = (logger: Logger) =>
               config.tracker.endpoint,
               config.tracker.apiKey,
               `
-                mutation SymphonyMoveIssueToHandoff($issueId: ID!, $stateId: ID!) {
+                mutation SymphonyMoveIssueToHandoff($issueId: String!, $stateId: String!) {
                   issueUpdate(id: $issueId, input: { stateId: $stateId }) {
                     success
                   }


### PR DESCRIPTION
## Summary

- align Symphony Linear handoff GraphQL variable types with the live Linear schema
- switch issue handoff comment and state-move mutations from `ID!` to `String!`
- add regression assertions so future changes keep the query signatures compatible with Linear

## Related Issues

None

## Testing

- `bun test services/symphony/src/linear-client.test.ts -t 'handoffIssue comments and moves the issue to the configured handoff state'`
- `bun run --cwd services/symphony test`
- `bunx oxfmt --check services/symphony/src/linear-client.ts services/symphony/src/linear-client.test.ts`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
