### PR TITLE
chore(symphony): promote image 3553b93e

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-16T05:01:33Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-16T05:25:41Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -25,5 +25,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "32f2a121"
-    digest: sha256:0a4d1c63cfe2fa00b14f7b408575f902895ecc3f0c9728b626826832fc87b8cd
+    newTag: "3553b93e"
+    digest: sha256:e31daa022fe6367a4e481c39951f2b244552c555019f1881013f1484d144edd4

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-16T05:01:33Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-16T05:25:41Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -26,5 +26,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "32f2a121"
-    digest: sha256:0a4d1c63cfe2fa00b14f7b408575f902895ecc3f0c9728b626826832fc87b8cd
+    newTag: "3553b93e"
+    digest: sha256:e31daa022fe6367a4e481c39951f2b244552c555019f1881013f1484d144edd4

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-16T05:01:33Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-16T05:25:41Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -19,5 +19,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "32f2a121"
-    digest: sha256:0a4d1c63cfe2fa00b14f7b408575f902895ecc3f0c9728b626826832fc87b8cd
+    newTag: "3553b93e"
+    digest: sha256:e31daa022fe6367a4e481c39951f2b244552c555019f1881013f1484d144edd4


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `3553b93e93269f3d00f244e37763470a29cb3ad8`
- Image tag: `3553b93e`
- Image digest: `sha256:e31daa022fe6367a4e481c39951f2b244552c555019f1881013f1484d144edd4`