### PR TITLE
fix(symphony): correct torghut codex auth secret naming

### DIFF
--- a/argocd/applications/symphony-torghut/codex-auth-sealedsecret.yaml
+++ b/argocd/applications/symphony-torghut/codex-auth-sealedsecret.yaml
@@ -2,7 +2,7 @@
 apiVersion: bitnami.com/v1alpha1
 kind: SealedSecret
 metadata:
-  name: codex-auth-torghut
+  name: codex-auth
   namespace: torghut
 spec:
   encryptedData:


### PR DESCRIPTION
## Summary

- fix the Torghut Symphony overlay so the generated SealedSecret name matches the deployment's expected `codex-auth-torghut`
- keep the overlay nameSuffix behavior consistent with the GitHub token and Linear API key sealed secrets
- unblock Torghut fleet rollout on the promoted Symphony image

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build argocd/applications/symphony-torghut | rg -n "kind: SealedSecret|kind: Secret|name: codex-auth-torghut|secretName: codex-auth-torghut" -n -C 1`
- `scripts/kubeconform.sh argocd/applications/symphony-torghut`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
