### PR TITLE
feat: add bilig Argo product skeleton

### DIFF
--- a/argocd/applications/bilig/README.md
+++ b/argocd/applications/bilig/README.md
@@ -1,0 +1,25 @@
+# bilig
+
+This app is the standalone ArgoCD product shell for `bilig`.
+
+## Components
+
+- `bilig-web`: browser shell
+- `bilig-sync`: realtime sync and remote agent API
+- `bilig-db`: CNPG Postgres cluster
+- `bilig-redis`: Redis session/presence cache
+- `bilig-alloy`: namespace-local logs and metrics forwarding
+
+## Hosts
+
+- `bilig.proompteng.ai`
+- `api.bilig.proompteng.ai`
+
+## Promotion mode
+
+This app is registered as `manual` automation in the product ApplicationSet until the bilig production acceptance matrix is green.
+
+## Notes
+
+- The first tranche keeps object-storage integration optional and disabled-by-default in the app config until the durable snapshot adapter lands.
+- The app is safe to register now because manual sync prevents accidental rollout before the corresponding container images are published.

--- a/argocd/applications/bilig/alloy-configmap.yaml
+++ b/argocd/applications/bilig/alloy-configmap.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: bilig-alloy
+  namespace: bilig
+data:
+  config.river: |
+    logging {
+      level  = "info"
+      format = "logfmt"
+    }
+
+    discovery.kubernetes "bilig_endpoints" {
+      role = "endpoints"
+
+      namespaces {
+        names = ["bilig"]
+      }
+    }
+
+    discovery.relabel "bilig_metrics" {
+      targets = discovery.kubernetes.bilig_endpoints.targets
+
+      rule {
+        source_labels = ["__meta_kubernetes_endpoint_port_name"]
+        regex         = "(?i)http|metrics"
+        action        = "keep"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_service_name"]
+        target_label  = "service"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_namespace"]
+        target_label  = "namespace"
+      }
+    }
+
+    prometheus.remote_write "mimir" {
+      endpoint {
+        url = "http://observability-mimir-nginx.observability.svc.cluster.local/api/v1/push"
+      }
+    }
+
+    prometheus.scrape "bilig" {
+      job_name   = "bilig"
+      targets    = discovery.relabel.bilig_metrics.output
+      forward_to = [prometheus.remote_write.mimir.receiver]
+    }

--- a/argocd/applications/bilig/alloy-deployment.yaml
+++ b/argocd/applications/bilig/alloy-deployment.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bilig-alloy
+  namespace: bilig
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: bilig-alloy
+  template:
+    metadata:
+      labels:
+        app: bilig-alloy
+    spec:
+      serviceAccountName: bilig-alloy
+      containers:
+        - name: alloy
+          image: grafana/alloy:v1.11.2
+          args:
+            - run
+            - /etc/alloy/config.river
+          ports:
+            - name: http
+              containerPort: 12345
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 300m
+              memory: 256Mi
+          volumeMounts:
+            - name: config
+              mountPath: /etc/alloy
+      volumes:
+        - name: config
+          configMap:
+            name: bilig-alloy
+            items:
+              - key: config.river
+                path: config.river

--- a/argocd/applications/bilig/alloy-rbac.yaml
+++ b/argocd/applications/bilig/alloy-rbac.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: bilig-alloy
+  namespace: bilig
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: bilig-alloy
+  namespace: bilig
+rules:
+  - apiGroups: [""]
+    resources: ["endpoints", "services", "pods", "pods/log"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: bilig-alloy
+  namespace: bilig
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: bilig-alloy
+subjects:
+  - kind: ServiceAccount
+    name: bilig-alloy
+    namespace: bilig

--- a/argocd/applications/bilig/frontend-deployment.yaml
+++ b/argocd/applications/bilig/frontend-deployment.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bilig-web
+  namespace: bilig
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: bilig-web
+  template:
+    metadata:
+      labels:
+        app: bilig-web
+    spec:
+      containers:
+        - name: bilig-web
+          image: registry.ide-newton.ts.net/lab/bilig-web
+          ports:
+            - containerPort: 3000
+          env:
+            - name: NODE_ENV
+              value: "production"
+            - name: PORT
+              value: "3000"
+            - name: BILIG_SYNC_URL
+              value: wss://api.bilig.proompteng.ai/v1/ws
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 750m
+              memory: 768Mi

--- a/argocd/applications/bilig/frontend-ingressroute.yaml
+++ b/argocd/applications/bilig/frontend-ingressroute.yaml
@@ -1,0 +1,15 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: bilig-web
+  namespace: bilig
+spec:
+  entryPoints:
+    - web
+    - websecure
+  routes:
+    - kind: Rule
+      match: Host(`bilig.proompteng.ai`)
+      services:
+        - name: bilig-web
+          port: 80

--- a/argocd/applications/bilig/frontend-service.yaml
+++ b/argocd/applications/bilig/frontend-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: bilig-web
+  namespace: bilig
+spec:
+  selector:
+    app: bilig-web
+  ports:
+    - port: 80
+      targetPort: 3000

--- a/argocd/applications/bilig/kustomization.yaml
+++ b/argocd/applications/bilig/kustomization.yaml
@@ -1,0 +1,23 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - frontend-deployment.yaml
+  - frontend-service.yaml
+  - frontend-ingressroute.yaml
+  - sync-deployment.yaml
+  - sync-service.yaml
+  - sync-ingressroute.yaml
+  - redis-deployment.yaml
+  - redis-service.yaml
+  - postgres-cluster.yaml
+  - object-storage-configmap.yaml
+  - alloy-configmap.yaml
+  - alloy-deployment.yaml
+  - alloy-rbac.yaml
+images:
+  - name: registry.ide-newton.ts.net/lab/bilig-web
+    newName: registry.ide-newton.ts.net/lab/bilig-web
+    newTag: "fd6553c"
+  - name: registry.ide-newton.ts.net/lab/bilig-sync
+    newName: registry.ide-newton.ts.net/lab/bilig-sync
+    newTag: "fd6553c"

--- a/argocd/applications/bilig/object-storage-configmap.yaml
+++ b/argocd/applications/bilig/object-storage-configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: bilig-object-storage
+  namespace: bilig
+data:
+  SNAPSHOT_BUCKET: bilig-snapshots
+  SNAPSHOT_ENDPOINT: ""

--- a/argocd/applications/bilig/postgres-cluster.yaml
+++ b/argocd/applications/bilig/postgres-cluster.yaml
@@ -1,0 +1,19 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: bilig-db
+  namespace: bilig
+spec:
+  instances: 1
+  primaryUpdateStrategy: unsupervised
+  storage:
+    storageClass: rook-ceph-block
+    size: 10Gi
+  bootstrap:
+    initdb:
+      database: bilig
+      owner: bilig
+      encoding: "UTF8"
+      dataChecksums: true
+  monitoring:
+    enablePodMonitor: true

--- a/argocd/applications/bilig/redis-deployment.yaml
+++ b/argocd/applications/bilig/redis-deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bilig-redis
+  namespace: bilig
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: bilig-redis
+  template:
+    metadata:
+      labels:
+        app: bilig-redis
+    spec:
+      containers:
+        - name: redis
+          image: redis:7.4.7
+          ports:
+            - containerPort: 6379
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 250m
+              memory: 256Mi

--- a/argocd/applications/bilig/redis-service.yaml
+++ b/argocd/applications/bilig/redis-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: bilig-redis
+  namespace: bilig
+spec:
+  selector:
+    app: bilig-redis
+  ports:
+    - port: 6379
+      targetPort: 6379

--- a/argocd/applications/bilig/sync-deployment.yaml
+++ b/argocd/applications/bilig/sync-deployment.yaml
@@ -1,0 +1,53 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bilig-sync
+  namespace: bilig
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: bilig-sync
+  template:
+    metadata:
+      labels:
+        app: bilig-sync
+    spec:
+      containers:
+        - name: bilig-sync
+          image: registry.ide-newton.ts.net/lab/bilig-sync
+          ports:
+            - name: http
+              containerPort: 4321
+          env:
+            - name: NODE_ENV
+              value: "production"
+            - name: PORT
+              value: "4321"
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: bilig-db-app
+                  key: uri
+                  optional: true
+            - name: REDIS_URL
+              value: redis://bilig-redis:6379
+            - name: SNAPSHOT_BUCKET
+              valueFrom:
+                configMapKeyRef:
+                  name: bilig-object-storage
+                  key: SNAPSHOT_BUCKET
+                  optional: true
+            - name: SNAPSHOT_ENDPOINT
+              valueFrom:
+                configMapKeyRef:
+                  name: bilig-object-storage
+                  key: SNAPSHOT_ENDPOINT
+                  optional: true
+          resources:
+            requests:
+              cpu: 200m
+              memory: 256Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi

--- a/argocd/applications/bilig/sync-ingressroute.yaml
+++ b/argocd/applications/bilig/sync-ingressroute.yaml
@@ -1,0 +1,15 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: bilig-sync
+  namespace: bilig
+spec:
+  entryPoints:
+    - web
+    - websecure
+  routes:
+    - kind: Rule
+      match: Host(`api.bilig.proompteng.ai`)
+      services:
+        - name: bilig-sync
+          port: 80

--- a/argocd/applications/bilig/sync-service.yaml
+++ b/argocd/applications/bilig/sync-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: bilig-sync
+  namespace: bilig
+spec:
+  selector:
+    app: bilig-sync
+  ports:
+    - name: http
+      port: 80
+      targetPort: 4321

--- a/argocd/applicationsets/product.yaml
+++ b/argocd/applicationsets/product.yaml
@@ -280,6 +280,14 @@ spec:
                   argocd.argoproj.io/sync-wave: "7"
                 automation: manual
                 enabled: "true"
+              - name: bilig
+                path: argocd/applications/bilig
+                namespace: bilig
+                renderWithLovely: false
+                annotations:
+                  argocd.argoproj.io/sync-wave: "6"
+                automation: manual
+                enabled: "true"
               - name: posthog
                 path: argocd/applications/posthog
                 namespace: posthog


### PR DESCRIPTION
## Summary
- register standalone bilig product app in the product ApplicationSet
- add frontend, sync API, postgres, redis, and observability manifests under argocd/applications/bilig
- keep automation manual until bilig production acceptance gates are green

## Notes
- this is the first GitOps skeleton for bilig and is intentionally safe-by-default
- no auto-promotion is enabled yet