### PR TITLE
feat: roll bilig to live images

### DIFF
--- a/argocd/applications/bilig/frontend-deployment.yaml
+++ b/argocd/applications/bilig/frontend-deployment.yaml
@@ -18,6 +18,18 @@ spec:
           image: registry.ide-newton.ts.net/lab/bilig-web
           ports:
             - containerPort: 3000
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 3000
+            initialDelaySeconds: 3
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 3000
+            initialDelaySeconds: 10
+            periodSeconds: 10
           env:
             - name: NODE_ENV
               value: "production"

--- a/argocd/applications/bilig/kustomization.yaml
+++ b/argocd/applications/bilig/kustomization.yaml
@@ -17,7 +17,7 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/bilig-web
     newName: registry.ide-newton.ts.net/lab/bilig-web
-    newTag: "fd6553c"
+    newTag: "b94da25"
   - name: registry.ide-newton.ts.net/lab/bilig-sync
     newName: registry.ide-newton.ts.net/lab/bilig-sync
-    newTag: "fd6553c"
+    newTag: "b94da25"

--- a/argocd/applications/bilig/sync-deployment.yaml
+++ b/argocd/applications/bilig/sync-deployment.yaml
@@ -19,6 +19,18 @@ spec:
           ports:
             - name: http
               containerPort: 4321
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 3
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
           env:
             - name: NODE_ENV
               value: "production"


### PR DESCRIPTION
## Summary
- roll the bilig Argo app from the dead fd6553c tag to the published b94da25 images
- add readiness and liveness probes for the bilig web and sync deployments
- keep the standalone bilig product app aligned with the live registry state

## Testing
- kubectl kustomize /Users/gregkonush/github.com/lab/argocd/applications/bilig
- verified registry digests for bilig-web:b94da25 and bilig-sync:b94da25
