### PR TITLE
feat: enable bilig ingress tls

### DIFF
--- a/argocd/applications/bilig/frontend-ingressroute.yaml
+++ b/argocd/applications/bilig/frontend-ingressroute.yaml
@@ -13,3 +13,4 @@ spec:
       services:
         - name: bilig-web
           port: 80
+  tls: {}

--- a/argocd/applications/bilig/sync-ingressroute.yaml
+++ b/argocd/applications/bilig/sync-ingressroute.yaml
@@ -13,3 +13,4 @@ spec:
       services:
         - name: bilig-sync
           port: 80
+  tls: {}


### PR DESCRIPTION
## Summary
- enable explicit Traefik TLS on the bilig web ingress route
- enable explicit Traefik TLS on the bilig sync ingress route
- close the remaining public-edge blocker after the in-cluster rollout succeeded

## Testing
- kubectl kustomize /Users/gregkonush/github.com/lab/argocd/applications/bilig
- verified the live bilig Application is already Synced/Healthy in-cluster
