### PR TITLE
feat: add bilig public tls certificate

### DIFF
--- a/argocd/applications/bilig/bilig-cert-tls.yaml
+++ b/argocd/applications/bilig/bilig-cert-tls.yaml
@@ -1,0 +1,14 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: bilig-wildcard-tls
+  namespace: bilig
+spec:
+  secretName: bilig-wildcard-tls
+  dnsNames:
+    - bilig.proompteng.ai
+    - '*.bilig.proompteng.ai'
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer
+    group: cert-manager.io

--- a/argocd/applications/bilig/frontend-ingressroute.yaml
+++ b/argocd/applications/bilig/frontend-ingressroute.yaml
@@ -13,4 +13,5 @@ spec:
       services:
         - name: bilig-web
           port: 80
-  tls: {}
+  tls:
+    secretName: bilig-wildcard-tls

--- a/argocd/applications/bilig/kustomization.yaml
+++ b/argocd/applications/bilig/kustomization.yaml
@@ -1,6 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - bilig-cert-tls.yaml
   - frontend-deployment.yaml
   - frontend-service.yaml
   - frontend-ingressroute.yaml

--- a/argocd/applications/bilig/sync-ingressroute.yaml
+++ b/argocd/applications/bilig/sync-ingressroute.yaml
@@ -13,4 +13,5 @@ spec:
       services:
         - name: bilig-sync
           port: 80
-  tls: {}
+  tls:
+    secretName: bilig-wildcard-tls


### PR DESCRIPTION
## Summary
- add a cert-manager certificate for bilig.proompteng.ai and *.bilig.proompteng.ai
- point bilig web and sync ingress routes at the new bilig-wildcard-tls secret
- replace the Traefik default self-signed cert path that was causing Cloudflare 525

## Testing
- kubectl kustomize /Users/gregkonush/github.com/lab/argocd/applications/bilig
- verified the current public bilig host is failing with the Traefik default cert, so this change targets the actual root cause
