### PR TITLE
chore(torghut): promote image 46dcfe58

### DIFF
--- a/argocd/applications/torghut-forecast/deployment.yaml
+++ b/argocd/applications/torghut-forecast/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: forecast
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:332b5d57b6951c5e285dd2ed92910f9736dfcba5475bb87a2a4813f2f8371452
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:5e86165040743db9df9e59fe1645f34a31ee273e0d522014dec7239d17b592fe
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn

--- a/argocd/applications/torghut-forecast/sim/deployment.yaml
+++ b/argocd/applications/torghut-forecast/sim/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: forecast
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:332b5d57b6951c5e285dd2ed92910f9736dfcba5475bb87a2a4813f2f8371452
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:5e86165040743db9df9e59fe1645f34a31ee273e0d522014dec7239d17b592fe
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn

--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:332b5d57b6951c5e285dd2ed92910f9736dfcba5475bb87a2a4813f2f8371452
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:5e86165040743db9df9e59fe1645f34a31ee273e0d522014dec7239d17b592fe
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -63,9 +63,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.564.0-209-g30a44861
+              value: v0.564.0-218-g46dcfe58
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 30a44861591365cad14d6478e1183ca777e0d5ea
+              value: 46dcfe58701da18fe77a18ef56ddea2b0b43adfd
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:332b5d57b6951c5e285dd2ed92910f9736dfcba5475bb87a2a4813f2f8371452
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:5e86165040743db9df9e59fe1645f34a31ee273e0d522014dec7239d17b592fe
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -63,9 +63,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.564.0-209-g30a44861
+              value: v0.564.0-218-g46dcfe58
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 30a44861591365cad14d6478e1183ca777e0d5ea
+              value: 46dcfe58701da18fe77a18ef56ddea2b0b43adfd
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -40,7 +40,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:332b5d57b6951c5e285dd2ed92910f9736dfcba5475bb87a2a4813f2f8371452
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:5e86165040743db9df9e59fe1645f34a31ee273e0d522014dec7239d17b592fe
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -21,7 +21,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:332b5d57b6951c5e285dd2ed92910f9736dfcba5475bb87a2a4813f2f8371452
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:5e86165040743db9df9e59fe1645f34a31ee273e0d522014dec7239d17b592fe
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -32,7 +32,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:332b5d57b6951c5e285dd2ed92910f9736dfcba5475bb87a2a4813f2f8371452
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:5e86165040743db9df9e59fe1645f34a31ee273e0d522014dec7239d17b592fe
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -30,7 +30,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:332b5d57b6951c5e285dd2ed92910f9736dfcba5475bb87a2a4813f2f8371452
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:5e86165040743db9df9e59fe1645f34a31ee273e0d522014dec7239d17b592fe
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:332b5d57b6951c5e285dd2ed92910f9736dfcba5475bb87a2a4813f2f8371452
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:5e86165040743db9df9e59fe1645f34a31ee273e0d522014dec7239d17b592fe
           command:
             - /opt/venv/bin/alembic
           args:

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -13,7 +13,7 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:332b5d57b6951c5e285dd2ed92910f9736dfcba5475bb87a2a4813f2f8371452
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:5e86165040743db9df9e59fe1645f34a31ee273e0d522014dec7239d17b592fe
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -21,7 +21,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:332b5d57b6951c5e285dd2ed92910f9736dfcba5475bb87a2a4813f2f8371452
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:5e86165040743db9df9e59fe1645f34a31ee273e0d522014dec7239d17b592fe
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -39,7 +39,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:332b5d57b6951c5e285dd2ed92910f9736dfcba5475bb87a2a4813f2f8371452
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:5e86165040743db9df9e59fe1645f34a31ee273e0d522014dec7239d17b592fe
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-03-16T05:22:08Z"
+        client.knative.dev/updateTimestamp: "2026-03-16T06:46:27Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:332b5d57b6951c5e285dd2ed92910f9736dfcba5475bb87a2a4813f2f8371452
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:5e86165040743db9df9e59fe1645f34a31ee273e0d522014dec7239d17b592fe
           ports:
             - name: http1
               containerPort: 8181
@@ -519,9 +519,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.564.0-209-g30a44861
+              value: v0.564.0-218-g46dcfe58
             - name: TORGHUT_COMMIT
-              value: 30a44861591365cad14d6478e1183ca777e0d5ea
+              value: 46dcfe58701da18fe77a18ef56ddea2b0b43adfd
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-03-16T05:22:08Z"
+        client.knative.dev/updateTimestamp: "2026-03-16T06:46:27Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -26,7 +26,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:332b5d57b6951c5e285dd2ed92910f9736dfcba5475bb87a2a4813f2f8371452
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:5e86165040743db9df9e59fe1645f34a31ee273e0d522014dec7239d17b592fe
           ports:
             - name: http1
               containerPort: 8181
@@ -462,9 +462,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.564.0-209-g30a44861
+              value: v0.564.0-218-g46dcfe58
             - name: TORGHUT_COMMIT
-              value: 30a44861591365cad14d6478e1183ca777e0d5ea
+              value: 46dcfe58701da18fe77a18ef56ddea2b0b43adfd
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/lean-runner-deployment.yaml
+++ b/argocd/applications/torghut/lean-runner-deployment.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: lean-runner
           # Keep in lockstep with `argocd/applications/torghut/knative-service.yaml`.
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:332b5d57b6951c5e285dd2ed92910f9736dfcba5475bb87a2a4813f2f8371452
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:5e86165040743db9df9e59fe1645f34a31ee273e0d522014dec7239d17b592fe
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `46dcfe58701da18fe77a18ef56ddea2b0b43adfd`
- Image tag: `46dcfe58`
- Image digest: `sha256:5e86165040743db9df9e59fe1645f34a31ee273e0d522014dec7239d17b592fe`