### PR TITLE
feat(nuc): add bilig hosts to public proxy

### DIFF
--- a/devices/nuc/nginx-proxy-manager/data/nginx/proxy_host/2.conf
+++ b/devices/nuc/nginx-proxy-manager/data/nginx/proxy_host/2.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------
-# account.huly.proompteng.ai, app.proompteng.ai, argocd.proompteng.ai, auth.proompteng.ai, cms.proompteng.ai, code.proompteng.ai, coder.proompteng.ai, collaborator.huly.proompteng.ai, convex.proompteng.ai, docs.proompteng.ai, forum.proompteng.ai, huly.proompteng.ai, posthog.proompteng.ai, proompteng.ai, rekoni.huly.proompteng.ai, stats.huly.proompteng.ai, transactor.huly.proompteng.ai, workflows.proompteng.ai
+# account.huly.proompteng.ai, api.bilig.proompteng.ai, app.proompteng.ai, argocd.proompteng.ai, auth.proompteng.ai, bilig.proompteng.ai, cms.proompteng.ai, code.proompteng.ai, coder.proompteng.ai, collaborator.huly.proompteng.ai, convex.proompteng.ai, docs.proompteng.ai, forum.proompteng.ai, huly.proompteng.ai, posthog.proompteng.ai, proompteng.ai, rekoni.huly.proompteng.ai, stats.huly.proompteng.ai, transactor.huly.proompteng.ai, workflows.proompteng.ai
 # ------------------------------------------------------------
 
 
@@ -20,7 +20,7 @@ listen 443 ssl;
 listen [::]:443 ssl;
 
 
-  server_name account.huly.proompteng.ai app.proompteng.ai argocd.proompteng.ai auth.proompteng.ai cms.proompteng.ai code.proompteng.ai coder.proompteng.ai collaborator.huly.proompteng.ai convex.proompteng.ai docs.proompteng.ai forum.proompteng.ai huly.proompteng.ai posthog.proompteng.ai proompteng.ai rekoni.huly.proompteng.ai stats.huly.proompteng.ai transactor.huly.proompteng.ai workflows.proompteng.ai;
+  server_name account.huly.proompteng.ai api.bilig.proompteng.ai app.proompteng.ai argocd.proompteng.ai auth.proompteng.ai bilig.proompteng.ai cms.proompteng.ai code.proompteng.ai coder.proompteng.ai collaborator.huly.proompteng.ai convex.proompteng.ai docs.proompteng.ai forum.proompteng.ai huly.proompteng.ai posthog.proompteng.ai proompteng.ai rekoni.huly.proompteng.ai stats.huly.proompteng.ai transactor.huly.proompteng.ai workflows.proompteng.ai;
 
   http2 on;
 
@@ -80,4 +80,3 @@ proxy_http_version 1.1;
   # Custom
   include /data/nginx/custom/server_proxy[.]conf;
 }
-


### PR DESCRIPTION
## Summary
- add bilig public hosts to the shared Nginx Proxy Manager public proxy host snapshot
- keep the repo snapshot aligned with the intended bilig public edge routing

## Notes
- Kubernetes bilig is already healthy; the remaining public failure is at the external NUC edge layer
- this PR updates the tracked NPM snapshot, but the live NUC still needs the corresponding apply/reload step