### PR TITLE
feat(nuc): dedicate bilig public proxy host

### DIFF
--- a/devices/nuc/nginx-proxy-manager/data/nginx/proxy_host/2.conf
+++ b/devices/nuc/nginx-proxy-manager/data/nginx/proxy_host/2.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------
-# account.huly.proompteng.ai, api.bilig.proompteng.ai, app.proompteng.ai, argocd.proompteng.ai, auth.proompteng.ai, bilig.proompteng.ai, cms.proompteng.ai, code.proompteng.ai, coder.proompteng.ai, collaborator.huly.proompteng.ai, convex.proompteng.ai, docs.proompteng.ai, forum.proompteng.ai, huly.proompteng.ai, posthog.proompteng.ai, proompteng.ai, rekoni.huly.proompteng.ai, stats.huly.proompteng.ai, transactor.huly.proompteng.ai, workflows.proompteng.ai
+# account.huly.proompteng.ai, app.proompteng.ai, argocd.proompteng.ai, auth.proompteng.ai, cms.proompteng.ai, code.proompteng.ai, coder.proompteng.ai, collaborator.huly.proompteng.ai, convex.proompteng.ai, docs.proompteng.ai, forum.proompteng.ai, huly.proompteng.ai, posthog.proompteng.ai, proompteng.ai, rekoni.huly.proompteng.ai, stats.huly.proompteng.ai, transactor.huly.proompteng.ai, workflows.proompteng.ai
 # ------------------------------------------------------------
 
 
@@ -20,7 +20,7 @@ listen 443 ssl;
 listen [::]:443 ssl;
 
 
-  server_name account.huly.proompteng.ai api.bilig.proompteng.ai app.proompteng.ai argocd.proompteng.ai auth.proompteng.ai bilig.proompteng.ai cms.proompteng.ai code.proompteng.ai coder.proompteng.ai collaborator.huly.proompteng.ai convex.proompteng.ai docs.proompteng.ai forum.proompteng.ai huly.proompteng.ai posthog.proompteng.ai proompteng.ai rekoni.huly.proompteng.ai stats.huly.proompteng.ai transactor.huly.proompteng.ai workflows.proompteng.ai;
+  server_name account.huly.proompteng.ai app.proompteng.ai argocd.proompteng.ai auth.proompteng.ai cms.proompteng.ai code.proompteng.ai coder.proompteng.ai collaborator.huly.proompteng.ai convex.proompteng.ai docs.proompteng.ai forum.proompteng.ai huly.proompteng.ai posthog.proompteng.ai proompteng.ai rekoni.huly.proompteng.ai stats.huly.proompteng.ai transactor.huly.proompteng.ai workflows.proompteng.ai;
 
   http2 on;
 

--- a/devices/nuc/nginx-proxy-manager/data/nginx/proxy_host/99-bilig.conf
+++ b/devices/nuc/nginx-proxy-manager/data/nginx/proxy_host/99-bilig.conf
@@ -1,0 +1,40 @@
+# ------------------------------------------------------------
+# bilig.proompteng.ai, api.bilig.proompteng.ai
+# ------------------------------------------------------------
+
+server {
+  set $forward_scheme https;
+  set $server         "192.168.1.100";
+  set $port           443;
+
+  listen 80;
+  listen [::]:80;
+  listen 443 ssl;
+  listen [::]:443 ssl;
+
+  server_name bilig.proompteng.ai api.bilig.proompteng.ai;
+
+  http2 on;
+
+  include conf.d/include/letsencrypt-acme-challenge.conf;
+  include conf.d/include/ssl-cache.conf;
+  include conf.d/include/ssl-ciphers.conf;
+  ssl_certificate /etc/letsencrypt/live/bilig-npm/fullchain.pem;
+  ssl_certificate_key /etc/letsencrypt/live/bilig-npm/privkey.pem;
+
+  proxy_set_header Upgrade $http_upgrade;
+  proxy_set_header Connection $http_connection;
+  proxy_http_version 1.1;
+
+  access_log /data/logs/proxy-host-2_access.log proxy;
+  error_log /data/logs/proxy-host-2_error.log warn;
+
+  location / {
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $http_connection;
+    proxy_http_version 1.1;
+    include conf.d/include/proxy.conf;
+  }
+
+  include /data/nginx/custom/server_proxy[.]conf;
+}


### PR DESCRIPTION
## Summary
- restore the shared public proxy host to its existing domains
- add a dedicated bilig proxy host config that uses the bilig wildcard certificate
- keep the tracked NUC Nginx Proxy Manager snapshot aligned with the live production fix

## Why
The shared public proxy certificate does not include bilig hostnames. A dedicated bilig server block is required for valid TLS on  and .