### PR TITLE
chore(jangar): promote image 355bc3db

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 69dc2593
-  digest: sha256:9cf4862e781b7867e6d4e26a6ebf6392c1f498fd400ffff4f7f97dc0649822d7
+  tag: 355bc3db
+  digest: sha256:dcb4e355e5b7af10c8a9542a577789c6e4a9e2895d0a51f4f733b007107b8f2f
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 69dc2593
-    digest: sha256:bfa75dc2858c51835d3ef6ed1352ede8c57c0743619cc2c50db3eede5e0ec73b
+    tag: 355bc3db
+    digest: sha256:0249e2af75f7690f70fe8c4c6d2ead6fcc9805ff6adec9f017d167d81dcd3a8c
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 69dc2593
-    digest: sha256:9cf4862e781b7867e6d4e26a6ebf6392c1f498fd400ffff4f7f97dc0649822d7
+    tag: 355bc3db
+    digest: sha256:dcb4e355e5b7af10c8a9542a577789c6e4a9e2895d0a51f4f733b007107b8f2f
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-15T22:46:59Z"
+    deploy.knative.dev/rollout: "2026-03-16T10:51:09Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-15T22:46:59Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-16T10:51:09Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -62,5 +62,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "69dc2593"
-    digest: sha256:9cf4862e781b7867e6d4e26a6ebf6392c1f498fd400ffff4f7f97dc0649822d7
+    newTag: "355bc3db"
+    digest: sha256:dcb4e355e5b7af10c8a9542a577789c6e4a9e2895d0a51f4f733b007107b8f2f


### PR DESCRIPTION
## Summary

- Promote Jangar GitOps manifests to image tag `355bc3db` for the code merged in #4501.
- Update the Jangar API, worker, and agents control-plane image references and rollout annotations.
- Leave readiness behavior unchanged because execution-trust gating is not enabled in the current manifests.

## Related Issues

None

## Testing

- GitHub Actions on this PR: `Semantic Pull Request`, `Semantic Commits`, `argo-lint`, `kubeconform`, `jangar-ci (lint-and-typecheck / run)`.
- Manual release verification in the verify lane: confirmed pre-promotion live pod image/tag drift, then monitored `jangar-build-push` and `jangar-release` through PR creation for tag `355bc3db`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
