### PR TITLE
fix(torghut): stabilize historical proof replay

### DIFF
--- a/docs/torghut/production-readiness-proof-runbook.md
+++ b/docs/torghut/production-readiness-proof-runbook.md
@@ -32,6 +32,10 @@ This runbook is the authoritative operator sequence for a production-readiness s
 
 Run one fresh March 13 full-day replay on the frozen digest.
 
+Replay contract for the proof lane:
+- historical proof manifests must use `ta_restore.mode=stateless`
+- proof reruns must hard-reset TA operator state; resuming prior checkpoint lineage is invalid for readiness signoff
+
 Required outcome:
 - non-zero decisions
 - non-zero executions

--- a/services/jangar/src/server/__tests__/torghut-simulation-control-plane-submit.test.ts
+++ b/services/jangar/src/server/__tests__/torghut-simulation-control-plane-submit.test.ts
@@ -399,9 +399,12 @@ describe('submitTorghutSimulationRun', () => {
   it('preserves the existing ready cache artifact when a run consumes a cache hit', async () => {
     const manifest = {
       dataset_id: 'dataset-a',
+      dataset_snapshot_ref: 'dataset-a@snapshot-1',
       candidate_id: 'intraday_tsmom_v1@prod',
       baseline_candidate_id: 'intraday_tsmom_v1@baseline',
       strategy_spec_ref: 'strategy-specs/intraday_tsmom_v1@1.1.0.json',
+      model_refs: ['rules/intraday_tsmom_v1'],
+      runtime_version_refs: ['services/torghut@sha256:abc'],
       window: {
         start: '2026-03-06T14:30:00Z',
         end: '2026-03-06T14:45:00Z',
@@ -414,12 +417,16 @@ describe('submitTorghutSimulationRun', () => {
     const cacheKey = createHash('sha256')
       .update(
         stableJsonStringifyForHash({
+          schema_version: 'torghut-simulation-cache-v2',
           lane: 'equity',
           dataset_id: manifest.dataset_id,
+          dataset_snapshot_ref: manifest.dataset_snapshot_ref,
           window: manifest.window,
           strategy_spec_ref: manifest.strategy_spec_ref,
           candidate_id: manifest.candidate_id,
           baseline_candidate_id: manifest.baseline_candidate_id,
+          model_refs: manifest.model_refs,
+          runtime_version_refs: manifest.runtime_version_refs,
           dump_format: manifest.performance.dumpFormat,
           profile: 'compact',
         }),
@@ -461,9 +468,12 @@ describe('submitTorghutSimulationRun', () => {
   it('records deterministic durable cache artifact paths on a cache miss', async () => {
     const manifest = {
       dataset_id: 'dataset-b',
+      dataset_snapshot_ref: 'dataset-b@snapshot-2',
       candidate_id: 'intraday_tsmom_v1@prod',
       baseline_candidate_id: 'intraday_tsmom_v1@baseline',
       strategy_spec_ref: 'strategy-specs/intraday_tsmom_v1@1.1.0.json',
+      model_refs: ['rules/intraday_tsmom_v1'],
+      runtime_version_refs: ['services/torghut@sha256:def'],
       window: {
         start: '2026-03-13T13:30:00Z',
         end: '2026-03-13T20:00:00Z',
@@ -476,12 +486,16 @@ describe('submitTorghutSimulationRun', () => {
     const cacheKey = createHash('sha256')
       .update(
         stableJsonStringifyForHash({
+          schema_version: 'torghut-simulation-cache-v2',
           lane: 'equity',
           dataset_id: manifest.dataset_id,
+          dataset_snapshot_ref: manifest.dataset_snapshot_ref,
           window: manifest.window,
           strategy_spec_ref: manifest.strategy_spec_ref,
           candidate_id: manifest.candidate_id,
           baseline_candidate_id: manifest.baseline_candidate_id,
+          model_refs: manifest.model_refs,
+          runtime_version_refs: manifest.runtime_version_refs,
           dump_format: manifest.performance.dumpFormat,
           profile: 'compact',
         }),

--- a/services/jangar/src/server/__tests__/torghut-simulation-control-plane.test.ts
+++ b/services/jangar/src/server/__tests__/torghut-simulation-control-plane.test.ts
@@ -86,6 +86,29 @@ describe('torghut simulation control plane', () => {
     })
   })
 
+  it('defaults full-day proofs to stateless TA recovery', () => {
+    const manifest = __private.normalizeSimulationManifest(
+      {
+        dataset_id: 'dataset-a',
+        window: {
+          start: '2026-03-13T13:30:00Z',
+          end: '2026-03-13T20:00:00Z',
+        },
+      },
+      {
+        runId: 'sim-demo-full-day',
+        outputRoot: '/tmp/torghut-sim',
+        cachePolicy: 'refresh',
+        profile: 'full_day',
+      },
+    )
+
+    expect(manifest.performance).toMatchObject({
+      replayProfile: 'full_day',
+    })
+    expect(manifest.ta_restore).toMatchObject({ mode: 'stateless' })
+  })
+
   it('derives isolated simulation databases when warm lanes are disabled', () => {
     const manifest = __private.normalizeSimulationManifest(
       {
@@ -157,10 +180,13 @@ describe('torghut simulation control plane', () => {
   it('builds stable cache keys and manifest digests regardless of object key order', () => {
     const manifestA = {
       dataset_id: 'dataset-a',
+      dataset_snapshot_ref: 'dataset-a@snapshot-1',
       lane: 'equity',
       candidate_id: 'candidate-a',
       baseline_candidate_id: 'baseline-a',
       strategy_spec_ref: 'strategy-specs/intraday_tsmom_v1@1.1.0.json',
+      model_refs: ['rules/intraday_tsmom_v1', 'rules/risk-v1'],
+      runtime_version_refs: ['services/torghut@sha256:abc', 'services/torghut-forecast@sha256:def'],
       performance: {
         dumpFormat: 'jsonl.zst',
       },
@@ -177,10 +203,13 @@ describe('torghut simulation control plane', () => {
       performance: {
         dumpFormat: 'jsonl.zst',
       },
+      runtime_version_refs: ['services/torghut@sha256:abc', 'services/torghut-forecast@sha256:def'],
+      model_refs: ['rules/intraday_tsmom_v1', 'rules/risk-v1'],
       strategy_spec_ref: 'strategy-specs/intraday_tsmom_v1@1.1.0.json',
       baseline_candidate_id: 'baseline-a',
       candidate_id: 'candidate-a',
       lane: 'equity',
+      dataset_snapshot_ref: 'dataset-a@snapshot-1',
       dataset_id: 'dataset-a',
     }
 

--- a/services/jangar/src/server/torghut-simulation-control-plane.ts
+++ b/services/jangar/src/server/torghut-simulation-control-plane.ts
@@ -235,9 +235,9 @@ const INTERACTIVE_LANES = ['sim-fast-1'] as const
 const BATCH_LANES = ['sim-fast-1'] as const
 const CONTROL_PLANE_LEASE_OWNER = 'jangar-control-plane'
 const PROGRESS_FETCH_TIMEOUT_MS = 2_500
+const SIMULATION_CACHE_KEY_SCHEMA_VERSION = 'torghut-simulation-cache-v2'
 
-const defaultTaRestoreMode = (profile: string) =>
-  profile.trim().toLowerCase() === 'full_day' ? 'required' : 'stateless'
+const defaultTaRestoreMode = (_profile: string) => 'stateless'
 
 const resolveRunClass = (profile: string, priority: string) => {
   const normalizedProfile = profile.trim().toLowerCase()
@@ -264,16 +264,29 @@ const resolveSimulationWorkflowNamespace = (manifest: JsonRecord) => {
   return asString(runtime.workflow_namespace) ?? DEFAULT_WORKFLOW_NAMESPACE
 }
 
+const stableStringList = (value: unknown) =>
+  [
+    ...new Set(
+      asArray(value)
+        .map((item) => asString(item)?.trim())
+        .filter((item): item is string => Boolean(item)),
+    ),
+  ].sort()
+
 const buildSimulationCacheKey = (manifest: JsonRecord, profile: string) =>
   createHash('sha256')
     .update(
       stableJsonStringifyForHash({
+        schema_version: SIMULATION_CACHE_KEY_SCHEMA_VERSION,
         lane: asString(manifest.lane) ?? 'equity',
         dataset_id: asString(manifest.dataset_id),
+        dataset_snapshot_ref: asString(manifest.dataset_snapshot_ref) ?? asString(manifest.dataset_id),
         window: asRecord(manifest.window),
         strategy_spec_ref: asString(manifest.strategy_spec_ref),
         candidate_id: asString(manifest.candidate_id),
         baseline_candidate_id: asString(manifest.baseline_candidate_id),
+        model_refs: stableStringList(manifest.model_refs),
+        runtime_version_refs: stableStringList(manifest.runtime_version_refs),
         dump_format: asString(asRecord(manifest.performance).dumpFormat) ?? DEFAULT_DUMP_FORMAT,
         profile,
       }),

--- a/services/torghut/app/trading/ingest.py
+++ b/services/torghut/app/trading/ingest.py
@@ -19,6 +19,7 @@ from ..models import TradeCursor
 from .clickhouse import normalize_symbol, to_datetime64
 from .models import SignalEnvelope
 from .simulation import resolve_simulation_context, signal_ingest_runtime, simulation_context_enabled
+from .simulation_progress import active_simulation_runtime_context
 from .simulation_window import normalize_simulation_cursor, simulation_window_bounds
 from .time_source import trading_now
 
@@ -820,11 +821,11 @@ class ClickHouseSignalIngestor:
         if self.schema == "flat" or len(signals) < 2:
             return signals
 
-        deduped_by_key: dict[tuple[datetime, str, str | None], SignalEnvelope] = {}
+        deduped_by_key: dict[tuple[datetime, str, str | None, tuple[Any, ...], str], SignalEnvelope] = {}
         for signal in signals:
             key = _signal_identity(signal)
             current = deduped_by_key.get(key)
-            if current is None or _prefer_earlier_ingest_signal(candidate=signal, current=current):
+            if current is None or _prefer_preferred_signal(candidate=signal, current=current):
                 deduped_by_key[key] = signal
         if len(deduped_by_key) == len(signals):
             return signals
@@ -1331,11 +1332,15 @@ def _next_signal_cursor_state(
     return max_event_ts, max_seq, max_symbol
 
 
-def _signal_identity(signal: SignalEnvelope) -> tuple[datetime, str, str | None]:
+def _signal_identity(
+    signal: SignalEnvelope,
+) -> tuple[datetime, str, str | None, tuple[Any, ...], str]:
     return (
         signal.event_ts.astimezone(timezone.utc),
         signal.symbol,
         signal.timeframe,
+        _signal_provenance_key(signal),
+        _signal_payload_fingerprint(signal),
     )
 
 
@@ -1349,14 +1354,80 @@ def _signal_sort_key(signal: SignalEnvelope) -> tuple[datetime, str, str, int, s
     )
 
 
-def _prefer_earlier_ingest_signal(*, candidate: SignalEnvelope, current: SignalEnvelope) -> bool:
-    current_ingest = current.ingest_ts.astimezone(timezone.utc) if current.ingest_ts is not None else None
-    candidate_ingest = candidate.ingest_ts.astimezone(timezone.utc) if candidate.ingest_ts is not None else None
-    if current_ingest is None:
-        return candidate_ingest is not None
-    if candidate_ingest is None:
+def _prefer_preferred_signal(*, candidate: SignalEnvelope, current: SignalEnvelope) -> bool:
+    return _signal_preference_key(candidate) > _signal_preference_key(current)
+
+
+def _signal_preference_key(signal: SignalEnvelope) -> tuple[int, int, int, str, int, str]:
+    return (
+        1 if _signal_matches_active_simulation_run(signal) else 0,
+        _signal_provenance_completeness(signal),
+        len(_signal_payload_fingerprint(signal)),
+        _signal_payload_context_fingerprint(signal),
+        _coerce_seq(signal.seq) or -1,
+        signal.source or '',
+    )
+
+
+def _signal_matches_active_simulation_run(signal: SignalEnvelope) -> bool:
+    context = _signal_simulation_context(signal)
+    signal_run_id = str(context.get('simulation_run_id') or '').strip()
+    if not signal_run_id:
         return False
-    return candidate_ingest < current_ingest
+    runtime_context = active_simulation_runtime_context()
+    active_run_id = str(
+        (runtime_context or {}).get('run_id') or settings.trading_simulation_run_id or ''
+    ).strip()
+    if not active_run_id:
+        return False
+    return signal_run_id == active_run_id
+
+
+def _signal_provenance_completeness(signal: SignalEnvelope) -> int:
+    context = _signal_simulation_context(signal)
+    values: tuple[Any, ...] = (
+        context.get('dataset_event_id'),
+        context.get('source_topic'),
+        context.get('source_partition'),
+        context.get('source_offset'),
+        context.get('replay_topic'),
+        context.get('signal_seq'),
+        signal.seq,
+        signal.source,
+    )
+    return sum(1 for value in values if value not in (None, '', -1))
+
+
+def _signal_provenance_key(signal: SignalEnvelope) -> tuple[Any, ...]:
+    context = _signal_simulation_context(signal)
+    return (
+        str(context.get('dataset_event_id') or ''),
+        str(context.get('source_topic') or ''),
+        _coerce_seq(context.get('source_partition')) or -1,
+        _coerce_seq(context.get('source_offset')) or -1,
+        str(context.get('replay_topic') or ''),
+        _coerce_seq(context.get('signal_seq')) or _coerce_seq(signal.seq) or -1,
+        signal.source or '',
+    )
+
+
+def _signal_payload_fingerprint(signal: SignalEnvelope) -> str:
+    payload = dict(signal.payload)
+    payload.pop('simulation_context', None)
+    return json.dumps(payload, sort_keys=True, separators=(',', ':'), default=str)
+
+
+def _signal_payload_context_fingerprint(signal: SignalEnvelope) -> str:
+    context = dict(_signal_simulation_context(signal))
+    context.pop('simulation_run_id', None)
+    return json.dumps(context, sort_keys=True, separators=(',', ':'), default=str)
+
+
+def _signal_simulation_context(signal: SignalEnvelope) -> dict[str, Any]:
+    raw_context = signal.payload.get('simulation_context')
+    if isinstance(raw_context, Mapping):
+        return {str(key): value for key, value in cast(Mapping[object, Any], raw_context).items()}
+    return {}
 
 
 def _coerce_seq(value: Any) -> Optional[int]:

--- a/services/torghut/scripts/run_simulation_analysis.py
+++ b/services/torghut/scripts/run_simulation_analysis.py
@@ -11,7 +11,7 @@ from typing import Any
 
 from scripts.historical_simulation_verification import (
     _artifact_bundle,
-    _current_activity_report,
+    _monitor_run_completion,
     _replace_database_in_dsn,
     _runtime_verify,
     _teardown_clean,
@@ -282,7 +282,7 @@ def main() -> None:
 
     clickhouse_config = _clickhouse_config(args)
     runtime_verify = _runtime_verify(resources=resources, manifest=manifest)
-    report = _current_activity_report(
+    report = _monitor_run_completion(
         resources=resources,
         manifest=manifest,
         postgres_config=postgres_config,

--- a/services/torghut/scripts/start_historical_simulation.py
+++ b/services/torghut/scripts/start_historical_simulation.py
@@ -73,6 +73,7 @@ DEFAULT_OUTPUT_ROOT = Path('artifacts/torghut/simulations')
 DEFAULT_SIMULATION_CACHE_BUCKET = 'argo-workflows'
 DEFAULT_SIMULATION_CACHE_ENDPOINT = 'http://rook-ceph-rgw-objectstore.rook-ceph.svc.cluster.local:80'
 DEFAULT_SIMULATION_CACHE_PREFIX = 'torghut-simulation-cache'
+SIMULATION_CACHE_KEY_SCHEMA_VERSION = 'torghut-simulation-cache-v2'
 
 PRODUCTION_TOPIC_BY_ROLE = dict(EQUITY_SIMULATION_LANE.source_topic_by_role)
 SIMULATION_TOPIC_BY_ROLE = dict(EQUITY_SIMULATION_LANE.simulation_topic_by_role)
@@ -211,6 +212,13 @@ DEFAULT_ROLLOUTS_TEARDOWN_TEMPLATE = 'torghut-simulation-teardown-clean'
 DEFAULT_ROLLOUTS_ARTIFACT_TEMPLATE = 'torghut-simulation-artifact-bundle'
 DEFAULT_ROLLOUTS_VERIFY_TIMEOUT_SECONDS = 1800
 DEFAULT_ROLLOUTS_VERIFY_POLL_SECONDS = 5
+DEFAULT_SIMULATION_CACHE_CEPH_TIMEOUT_SECONDS = 20
+SIMULATION_CACHE_UPLOAD_MIN_TIMEOUT_SECONDS = 60
+SIMULATION_CACHE_UPLOAD_TIMEOUT_MAX_SECONDS = 900
+SIMULATION_CACHE_UPLOAD_BYTES_PER_SECOND_FLOOR = 2 * 1024 * 1024
+SIMULATION_CACHE_UPLOAD_TIMEOUT_SLACK_SECONDS = 30
+SIMULATION_CACHE_UPLOAD_RETRY_ATTEMPTS = 3
+SIMULATION_CACHE_UPLOAD_RETRY_SLEEP_SECONDS = 2.0
 SIMULATION_RUNTIME_LOCK_NAME = 'torghut-historical-simulation-lock'
 SIMULATION_CLICKHOUSE_SCHEMA_SOURCE_DATABASE = 'torghut'
 SIMULATION_CLICKHOUSE_TABLE_VISIBILITY_ATTEMPTS = 10
@@ -2432,6 +2440,67 @@ def _dump_suffix(dump_format: str) -> str:
     return suffix
 
 
+def _stable_json_for_hash(payload: Mapping[str, Any]) -> str:
+    return json.dumps(dict(payload), sort_keys=True, separators=(',', ':'))
+
+
+def _stable_string_list(values: Any) -> list[str]:
+    return sorted({item for item in _as_string_list(values) if item})
+
+
+def _cache_lineage_payload(manifest: Mapping[str, Any]) -> dict[str, Any]:
+    performance_cfg = _performance_config(manifest)
+    return {
+        'schema_version': SIMULATION_CACHE_KEY_SCHEMA_VERSION,
+        'lane': _as_text(manifest.get('lane')) or 'equity',
+        'dataset_id': _as_text(manifest.get('dataset_id')),
+        'dataset_snapshot_ref': _as_text(manifest.get('dataset_snapshot_ref'))
+        or _as_text(manifest.get('dataset_id')),
+        'window': _as_mapping(manifest.get('window')),
+        'strategy_spec_ref': _as_text(manifest.get('strategy_spec_ref')),
+        'candidate_id': _as_text(manifest.get('candidate_id')),
+        'baseline_candidate_id': _as_text(manifest.get('baseline_candidate_id')),
+        'model_refs': _stable_string_list(manifest.get('model_refs')),
+        'runtime_version_refs': _stable_string_list(manifest.get('runtime_version_refs')),
+        'dump_format': _as_text(performance_cfg.get('dump_format')) or DEFAULT_SIMULATION_DUMP_FORMAT,
+        'profile': _as_text(performance_cfg.get('replay_profile')) or DEFAULT_SIMULATION_REPLAY_PROFILE,
+    }
+
+
+def _derived_simulation_cache_key(manifest: Mapping[str, Any]) -> str:
+    payload = _cache_lineage_payload(manifest)
+    return hashlib.sha256(_stable_json_for_hash(payload).encode('utf-8')).hexdigest()
+
+
+def _derived_simulation_cache_paths(cache_key: str, dump_format: str) -> dict[str, str]:
+    normalized_prefix = DEFAULT_SIMULATION_CACHE_PREFIX.strip('/')
+    object_key = '/'.join(
+        part
+        for part in (
+            normalized_prefix,
+            cache_key.strip(),
+            f'source-dump{_dump_suffix(dump_format)}',
+        )
+        if part
+    )
+    artifact_path = f's3://{DEFAULT_SIMULATION_CACHE_BUCKET}/{object_key}'
+    return {
+        'cache_artifact_path': artifact_path,
+        'cache_manifest_path': f'{artifact_path}.manifest.json',
+    }
+
+
+def _cache_artifact_lineage_matches(
+    *,
+    manifest: Mapping[str, Any],
+    artifact_manifest: Mapping[str, Any],
+) -> bool:
+    artifact_lineage = _as_mapping(artifact_manifest.get('lineage'))
+    if not artifact_lineage:
+        return False
+    return artifact_lineage == _cache_lineage_payload(manifest)
+
+
 def _state_paths(
     resources: SimulationResources,
     manifest: Mapping[str, Any] | None = None,
@@ -2448,6 +2517,77 @@ def _state_paths(
 
 def _dump_artifact_manifest_path(dump_path: Path) -> Path:
     return dump_path.with_suffix(dump_path.suffix + '.manifest.json')
+
+
+def _dump_sort_stage_path(dump_path: Path) -> Path:
+    return dump_path.with_suffix(dump_path.suffix + '.sort-stage.tsv')
+
+
+def _dump_sort_output_path(dump_path: Path) -> Path:
+    return dump_path.with_suffix(dump_path.suffix + '.sort-output.tsv')
+
+
+def _dump_sort_key(
+    *,
+    source_timestamp_ms: int,
+    source_topic: str,
+    source_partition: int,
+    source_offset: int,
+) -> str:
+    return '\t'.join(
+        (
+            f'{source_timestamp_ms:020d}',
+            source_topic,
+            f'{source_partition:010d}',
+            f'{source_offset:020d}',
+        )
+    )
+
+
+def _materialize_deterministic_dump(
+    *,
+    staged_path: Path,
+    dump_path: Path,
+) -> str:
+    _ensure_supported_binary('sort')
+    sorted_path = _dump_sort_output_path(dump_path)
+    try:
+        with sorted_path.open('w', encoding='utf-8') as sorted_handle:
+            subprocess.run(
+                [
+                    'sort',
+                    '-t',
+                    '\t',
+                    '-k1,1n',
+                    '-k2,2',
+                    '-k3,3n',
+                    '-k4,4n',
+                    str(staged_path),
+                ],
+                check=True,
+                text=True,
+                stdout=sorted_handle,
+                stderr=subprocess.PIPE,
+            )
+    except FileNotFoundError as exc:
+        raise RuntimeError(f'command_missing: sort: {exc.filename}') from exc
+    except subprocess.CalledProcessError as exc:
+        detail = (exc.stderr or '').strip() or str(exc)
+        raise RuntimeError(f'command_failed: sort: {detail}') from exc
+
+    hasher = hashlib.sha256()
+    with sorted_path.open('r', encoding='utf-8') as sorted_handle, dump_path.open('w', encoding='utf-8') as dump_handle:
+        for row in sorted_handle:
+            parts = row.split('\t', 4)
+            if len(parts) != 5:
+                raise RuntimeError('deterministic_dump_sort_row_invalid')
+            line = parts[4]
+            dump_handle.write(line)
+            stripped = line.rstrip('\n')
+            hasher.update(stripped.encode('utf-8'))
+            hasher.update(b'\n')
+
+    return hasher.hexdigest()
 
 
 def _run_state_path(resources: SimulationResources) -> Path:
@@ -2467,7 +2607,9 @@ def _ta_restore_policy(manifest: Mapping[str, Any]) -> dict[str, Any]:
     mode = explicit_mode
     source = 'explicit'
     if not mode:
-        mode = 'required' if replay_profile == 'full_day' else 'stateless'
+        # Historical replay must be deterministic on a frozen dump; do not resume prior
+        # TA operator state unless a future lineage-aware restore contract exists.
+        mode = 'stateless'
         source = f'profile_default:{replay_profile}'
     allowed_modes = {'required', 'stateless_if_missing', 'stateless'}
     if mode not in allowed_modes:
@@ -2647,7 +2789,9 @@ def _write_dump_marker_from_manifest(
     )
 
 
-def _simulation_cache_client_from_env() -> tuple[CephS3Client | None, str]:
+def _simulation_cache_client_from_env(
+    timeout_seconds: int | None = None,
+) -> tuple[CephS3Client | None, str]:
     access_key = (
         os.getenv('TORGHUT_SIM_CACHE_CEPH_ACCESS_KEY', '').strip()
         or os.getenv('AWS_ACCESS_KEY_ID', '').strip()
@@ -2665,9 +2809,17 @@ def _simulation_cache_client_from_env() -> tuple[CephS3Client | None, str]:
         or DEFAULT_SIMULATION_CACHE_ENDPOINT
     )
     region = os.getenv('TORGHUT_SIM_CACHE_CEPH_REGION', 'us-east-1').strip() or 'us-east-1'
-    timeout_seconds = max(
+    effective_timeout_seconds = max(
         1,
-        int(os.getenv('TORGHUT_SIM_CACHE_CEPH_TIMEOUT_SECONDS', '20') or '20'),
+        timeout_seconds
+        if timeout_seconds is not None
+        else int(
+            os.getenv(
+                'TORGHUT_SIM_CACHE_CEPH_TIMEOUT_SECONDS',
+                str(DEFAULT_SIMULATION_CACHE_CEPH_TIMEOUT_SECONDS),
+            )
+            or str(DEFAULT_SIMULATION_CACHE_CEPH_TIMEOUT_SECONDS)
+        ),
     )
     if not access_key or not secret_key or not endpoint:
         return None, bucket
@@ -2677,19 +2829,112 @@ def _simulation_cache_client_from_env() -> tuple[CephS3Client | None, str]:
             access_key=access_key,
             secret_key=secret_key,
             region=region,
-            timeout_seconds=timeout_seconds,
+            timeout_seconds=effective_timeout_seconds,
         ),
         bucket,
     )
 
 
+def _simulation_cache_upload_timeout_seconds(dump_path: Path) -> int:
+    configured_timeout_seconds = max(
+        1,
+        int(
+            os.getenv(
+                'TORGHUT_SIM_CACHE_CEPH_TIMEOUT_SECONDS',
+                str(DEFAULT_SIMULATION_CACHE_CEPH_TIMEOUT_SECONDS),
+            )
+            or str(DEFAULT_SIMULATION_CACHE_CEPH_TIMEOUT_SECONDS)
+        ),
+    )
+    size_bytes = max(dump_path.stat().st_size, 0)
+    size_based_timeout_seconds = SIMULATION_CACHE_UPLOAD_TIMEOUT_SLACK_SECONDS
+    if size_bytes > 0:
+        size_based_timeout_seconds += int(
+            (
+                size_bytes + SIMULATION_CACHE_UPLOAD_BYTES_PER_SECOND_FLOOR - 1
+            )
+            // SIMULATION_CACHE_UPLOAD_BYTES_PER_SECOND_FLOOR
+        )
+    return min(
+        SIMULATION_CACHE_UPLOAD_TIMEOUT_MAX_SECONDS,
+        max(
+            configured_timeout_seconds,
+            SIMULATION_CACHE_UPLOAD_MIN_TIMEOUT_SECONDS,
+            size_based_timeout_seconds,
+        ),
+    )
+
+
+def _simulation_cache_upload_attempts() -> tuple[int, float]:
+    attempts = max(
+        1,
+        _safe_int(
+            os.getenv(
+                'TORGHUT_SIM_CACHE_CEPH_UPLOAD_RETRY_ATTEMPTS',
+                str(SIMULATION_CACHE_UPLOAD_RETRY_ATTEMPTS),
+            ),
+            default=SIMULATION_CACHE_UPLOAD_RETRY_ATTEMPTS,
+        ),
+    )
+    try:
+        sleep_seconds = float(
+            os.getenv(
+                'TORGHUT_SIM_CACHE_CEPH_UPLOAD_RETRY_SLEEP_SECONDS',
+                str(SIMULATION_CACHE_UPLOAD_RETRY_SLEEP_SECONDS),
+            )
+            or str(SIMULATION_CACHE_UPLOAD_RETRY_SLEEP_SECONDS)
+        )
+    except ValueError:
+        sleep_seconds = SIMULATION_CACHE_UPLOAD_RETRY_SLEEP_SECONDS
+    return attempts, max(sleep_seconds, 0.0)
+
+
+def _is_transient_simulation_cache_upload_error(error: Exception) -> bool:
+    if isinstance(error, (TimeoutError, OSError)):
+        return True
+    message = str(error).lower()
+    if not message:
+        return False
+    transient_markers = (
+        'timed out',
+        'timeout',
+        'temporary failure',
+        'temporarily unavailable',
+        'connection reset',
+        'connection aborted',
+        'broken pipe',
+        'service unavailable',
+        'ceph_upload_http_500',
+        'ceph_upload_http_502',
+        'ceph_upload_http_503',
+        'ceph_upload_http_504',
+    )
+    return any(marker in message for marker in transient_markers)
+
+
 def _cache_metadata(manifest: Mapping[str, Any]) -> dict[str, str]:
     metadata = _as_mapping(manifest.get('metadata'))
+    performance_cfg = _performance_config(manifest)
+    cache_decision = (_as_text(metadata.get('cacheDecision')) or '').lower()
+    cache_key = _as_text(metadata.get('cacheKey')) or _derived_simulation_cache_key(manifest)
+    cache_artifact_path = _as_text(metadata.get('cacheArtifactPath')) or ''
+    cache_manifest_path = _as_text(metadata.get('cacheChunkManifestPath')) or ''
+    if cache_key and (not cache_artifact_path or not cache_manifest_path):
+        derived_paths = _derived_simulation_cache_paths(
+            cache_key,
+            _as_text(performance_cfg.get('dump_format')) or DEFAULT_SIMULATION_DUMP_FORMAT,
+        )
+        if not cache_artifact_path:
+            cache_artifact_path = derived_paths['cache_artifact_path']
+        if not cache_manifest_path:
+            cache_manifest_path = derived_paths['cache_manifest_path']
+    if not cache_decision and (_as_text(performance_cfg.get('cache_policy')) or 'prefer_cache') == 'refresh':
+        cache_decision = 'refresh'
     return {
-        'cache_key': _as_text(metadata.get('cacheKey')) or '',
-        'cache_decision': (_as_text(metadata.get('cacheDecision')) or '').lower(),
-        'cache_artifact_path': _as_text(metadata.get('cacheArtifactPath')) or '',
-        'cache_manifest_path': _as_text(metadata.get('cacheChunkManifestPath')) or '',
+        'cache_key': cache_key,
+        'cache_decision': cache_decision,
+        'cache_artifact_path': cache_artifact_path,
+        'cache_manifest_path': cache_manifest_path,
     }
 
 
@@ -2715,6 +2960,11 @@ def _restore_cached_dump_if_available(
     cache_artifact_path = cache['cache_artifact_path']
     cache_manifest_path = cache['cache_manifest_path']
     cache_policy = _as_text(_performance_config(manifest).get('cache_policy')) or 'prefer_cache'
+    cache_decision = cache['cache_decision']
+    if cache_decision and cache_decision != 'hit':
+        if cache_policy == 'require_cache':
+            raise RuntimeError(f'required_cache_not_ready:{cache_decision}')
+        return None
     if not cache_artifact_path:
         if cache_policy == 'require_cache':
             raise RuntimeError('required_cache_artifact_path_missing')
@@ -2745,6 +2995,11 @@ def _restore_cached_dump_if_available(
             artifact_manifest = json.loads(manifest_payload.decode('utf-8'))
             if not isinstance(artifact_manifest, Mapping):
                 raise RuntimeError('cache_manifest_invalid_payload')
+            if not _cache_artifact_lineage_matches(
+                manifest=manifest,
+                artifact_manifest=cast(Mapping[str, Any], artifact_manifest),
+            ):
+                raise RuntimeError('cache_manifest_lineage_mismatch')
             _dump_artifact_manifest_path(dump_path).write_text(
                 json.dumps(dict(artifact_manifest), indent=2, sort_keys=True),
                 encoding='utf-8',
@@ -2803,7 +3058,8 @@ def _upload_dump_to_cache(
     if artifact_ref is None or manifest_ref is None:
         return None
 
-    client, default_bucket = _simulation_cache_client_from_env()
+    timeout_seconds = _simulation_cache_upload_timeout_seconds(dump_path)
+    client, default_bucket = _simulation_cache_client_from_env(timeout_seconds=timeout_seconds)
     if client is None:
         return None
 
@@ -2817,26 +3073,45 @@ def _upload_dump_to_cache(
         'jsonl.gz': 'application/gzip',
         'jsonl.zst': 'application/zstd',
     }[_dump_format_for_path(dump_path)]
-    dump_result = client.put_object(
-        bucket=bucket,
-        key=key,
-        body=dump_path.read_bytes(),
-        content_type=dump_content_type,
-    )
     manifest_path = _dump_artifact_manifest_path(dump_path)
-    manifest_result = client.put_object(
-        bucket=manifest_bucket,
-        key=manifest_key,
-        body=manifest_path.read_bytes(),
-        content_type='application/json',
-    )
-    return {
-        'cache_key': cache_key,
-        'artifact_path': f's3://{bucket}/{key}',
-        'artifact_etag': dump_result.get('etag'),
-        'manifest_path': f's3://{manifest_bucket}/{manifest_key}',
-        'manifest_etag': manifest_result.get('etag'),
-    }
+    dump_body = dump_path.read_bytes()
+    manifest_body = manifest_path.read_bytes()
+    retry_attempts, retry_sleep_seconds = _simulation_cache_upload_attempts()
+    last_error: Exception | None = None
+
+    for attempt in range(1, retry_attempts + 1):
+        try:
+            dump_result = client.put_object(
+                bucket=bucket,
+                key=key,
+                body=dump_body,
+                content_type=dump_content_type,
+            )
+            manifest_result = client.put_object(
+                bucket=manifest_bucket,
+                key=manifest_key,
+                body=manifest_body,
+                content_type='application/json',
+            )
+            return {
+                'status': 'ok',
+                'cache_key': cache_key,
+                'artifact_path': f's3://{bucket}/{key}',
+                'artifact_etag': dump_result.get('etag'),
+                'manifest_path': f's3://{manifest_bucket}/{manifest_key}',
+                'manifest_etag': manifest_result.get('etag'),
+                'timeout_seconds': timeout_seconds,
+                'attempt_count': attempt,
+            }
+        except Exception as exc:
+            last_error = exc
+            if attempt >= retry_attempts or not _is_transient_simulation_cache_upload_error(exc):
+                break
+            time.sleep(retry_sleep_seconds * attempt)
+
+    if last_error is None:
+        return None
+    raise last_error
 
 
 def _utc_from_millis(value: int | None) -> datetime | None:
@@ -4774,13 +5049,14 @@ def _dump_topics(
     from kafka import TopicPartition  # type: ignore[import-not-found]
 
     consumer = _consumer_for_dump(kafka_config, resources.run_token)
-    hasher = hashlib.sha256()
     count = 0
     count_by_topic: dict[str, int] = {}
     min_source_timestamp_ms: int | None = None
     max_source_timestamp_ms: int | None = None
     dump_started_at = datetime.now(timezone.utc)
     raw_dump_path = dump_path
+    staged_dump_path = _dump_sort_stage_path(dump_path)
+    sorted_dump_path = _dump_sort_output_path(dump_path)
     dump_format = _as_text(performance_cfg.get('dump_format')) or DEFAULT_SIMULATION_DUMP_FORMAT
     if _dump_format_for_path(dump_path) != 'ndjson':
         raw_dump_path = dump_path.with_suffix(dump_path.suffix + '.tmp.ndjson')
@@ -4828,7 +5104,7 @@ def _dump_topics(
 
         _ensure_directory(raw_dump_path)
         done: set[Any] = set()
-        with raw_dump_path.open('w', encoding='utf-8') as handle:
+        with staged_dump_path.open('w', encoding='utf-8') as handle:
             idle_polls = 0
             while len(done) < len(topic_partitions):
                 if count >= expected_records:
@@ -4875,10 +5151,17 @@ def _dump_topics(
                             'headers': _headers_to_json(getattr(record, 'headers', [])),
                         }
                         line = json.dumps(line_payload, sort_keys=True)
+                        handle.write(
+                            _dump_sort_key(
+                                source_timestamp_ms=int(record.timestamp),
+                                source_topic=source_topic,
+                                source_partition=int(record.partition),
+                                source_offset=int(record.offset),
+                            )
+                        )
+                        handle.write('\t')
                         handle.write(line)
                         handle.write('\n')
-                        hasher.update(line.encode('utf-8'))
-                        hasher.update(b'\n')
                         count += 1
                         count_by_topic[source_topic] = count_by_topic.get(source_topic, 0) + 1
                         source_timestamp_ms = int(record.timestamp)
@@ -4900,6 +5183,10 @@ def _dump_topics(
                         done.update(topic_partitions)
                         break
 
+        payload_sha256 = _materialize_deterministic_dump(
+            staged_path=staged_dump_path,
+            dump_path=raw_dump_path,
+        )
         if raw_dump_path != dump_path:
             _compress_dump_file(source_path=raw_dump_path, dump_path=dump_path)
         file_sha256 = _file_sha256(dump_path)
@@ -4910,7 +5197,7 @@ def _dump_topics(
             'records': count,
             'expected_records': expected_records,
             'sha256': file_sha256,
-            'payload_sha256': hasher.hexdigest(),
+            'payload_sha256': payload_sha256,
             'records_by_topic': count_by_topic,
             'start': start.isoformat(),
             'end': end.isoformat(),
@@ -4934,7 +5221,7 @@ def _dump_topics(
                 'dump_path': str(dump_path),
                 'dump_format': dump_format,
                 'records_by_topic': count_by_topic,
-                'payload_sha256': hasher.hexdigest(),
+                'payload_sha256': payload_sha256,
                 'dump_sha256': file_sha256,
             },
         )
@@ -4951,6 +5238,7 @@ def _dump_topics(
             {
                 'dataset_id': resources.dataset_id,
                 'run_id': resources.run_id,
+                'lineage': _cache_lineage_payload(manifest),
                 'dump_format': dump_format,
                 'cache_policy': _as_text(performance_cfg.get('cache_policy')) or 'prefer_cache',
                 'replay_profile': _as_text(performance_cfg.get('replay_profile')) or DEFAULT_SIMULATION_REPLAY_PROFILE,
@@ -4960,7 +5248,7 @@ def _dump_topics(
                         'path': str(dump_path),
                         'records': count,
                         'sha256': file_sha256,
-                        'payload_sha256': hasher.hexdigest(),
+                        'payload_sha256': payload_sha256,
                         'min_source_timestamp_ms': min_source_timestamp_ms,
                         'max_source_timestamp_ms': max_source_timestamp_ms,
                     }
@@ -4968,16 +5256,31 @@ def _dump_topics(
             },
         )
         if _cache_metadata(manifest)['cache_decision'] != 'hit':
-            cache_upload_report = _upload_dump_to_cache(
-                manifest=manifest,
-                dump_path=dump_path,
-            )
+            try:
+                cache_upload_report = _upload_dump_to_cache(
+                    manifest=manifest,
+                    dump_path=dump_path,
+                )
+            except Exception as exc:
+                cache_upload_report = {
+                    'status': 'error',
+                    'cache_key': _cache_metadata(manifest).get('cache_key'),
+                    'error': str(exc),
+                }
+                _log_script_event(
+                    'Failed to upload simulation dump to durable cache',
+                    cache_key=_cache_metadata(manifest).get('cache_key') or 'unknown',
+                    cache_artifact_path=_cache_metadata(manifest).get('cache_artifact_path') or None,
+                    error=str(exc),
+                )
             if cache_upload_report is not None:
                 report['cache_upload'] = cache_upload_report
         return report
     finally:
         if raw_dump_path != dump_path:
             raw_dump_path.unlink(missing_ok=True)
+        staged_dump_path.unlink(missing_ok=True)
+        sorted_dump_path.unlink(missing_ok=True)
         consumer.close()
 
 
@@ -5433,6 +5736,7 @@ def _apply(
     kafka_config: KafkaRuntimeConfig,
     clickhouse_config: ClickHouseRuntimeConfig,
     postgres_config: PostgresRuntimeConfig,
+    argocd_config: ArgocdAutomationConfig | None = None,
     force_dump: bool,
     force_replay: bool,
 ) -> dict[str, Any]:
@@ -5450,6 +5754,7 @@ def _apply(
     ta_reconfigured = False
     torghut_reconfigured = False
     ta_restart_nonce: int | None = None
+    argocd_runtime_guard_report: dict[str, Any] | None = None
 
     state_path, run_manifest_path, dump_path = _state_paths(resources, manifest)
     _ensure_directory(state_path)
@@ -5581,6 +5886,13 @@ def _apply(
         )
         replay_cfg = _as_mapping(manifest.get('replay'))
         auto_offset_reset = (_as_text(replay_cfg.get('auto_offset_reset')) or 'earliest').lower()
+        if (
+            argocd_config is not None
+            and resources.target_mode == 'dedicated_service'
+        ):
+            argocd_runtime_guard_report = _ensure_argocd_manual_before_runtime_mutation(
+                config=argocd_config,
+            )
         ta_reconfigured = _ta_runtime_reconfigure_required(
             resources=resources,
             clickhouse_config=clickhouse_config,
@@ -5643,6 +5955,7 @@ def _apply(
         'ta_restart_forced': ta_restart_forced,
         'ta_reconfigured': ta_reconfigured,
         'torghut_reconfigured': torghut_reconfigured,
+        'argocd_runtime_guard': argocd_runtime_guard_report,
         'warm_lane_enabled': warm_lane_enabled,
         'account_label': account_label,
         'seeded_cursor_at': seeded_cursor_at.isoformat(),
@@ -5813,6 +6126,69 @@ def _prepare_argocd_for_run(
         'root_application': root_application_report,
         'application': application_mode_report,
     }
+
+
+def _ensure_argocd_manual_before_runtime_mutation(
+    *,
+    config: ArgocdAutomationConfig,
+) -> dict[str, Any]:
+    if not config.manage_automation:
+        return {
+            'managed': False,
+            'changed': False,
+            'reason': 'automation_management_disabled',
+        }
+
+    desired_mode = _normalized_automation_mode(config.desired_mode_during_run)
+    applicationset_state = _read_argocd_automation_mode(config=config)
+    application_state = _read_named_argocd_application_sync_policy(
+        namespace=config.applicationset_namespace,
+        app_name=config.app_name,
+    )
+    root_state = _read_named_argocd_application_sync_policy(
+        namespace=config.applicationset_namespace,
+        app_name=config.root_app_name,
+    )
+    desired_root_sync_policy = _manual_argocd_application_sync_policy(
+        cast(Mapping[str, Any] | None, root_state.get('sync_policy'))
+    )
+    current_application_mode = _normalized_automation_mode(_as_text(application_state.get('automation_mode')))
+    current_root_sync_policy = _clone_json_mapping(
+        cast(Mapping[str, Any] | None, root_state.get('sync_policy'))
+    )
+    current_applicationset_mode = _normalized_automation_mode(_as_text(applicationset_state.get('mode')))
+    if (
+        current_applicationset_mode == desired_mode
+        and current_application_mode == desired_mode
+        and current_root_sync_policy == desired_root_sync_policy
+    ):
+        return {
+            'managed': True,
+            'changed': False,
+            'reason': 'already_manual',
+            'desired_mode': desired_mode,
+            'current_mode': current_application_mode,
+            'applicationset_managed': True,
+            'applicationset': {
+                'pointer': applicationset_state.get('pointer'),
+                'current_mode': current_applicationset_mode,
+                'desired_mode': desired_mode,
+                'changed': False,
+            },
+            'root_application': {
+                'current_sync_policy': current_root_sync_policy,
+                'desired_sync_policy': desired_root_sync_policy,
+                'changed': False,
+            },
+            'application': {
+                'app_name': config.app_name,
+                'current_mode': current_application_mode,
+            },
+        }
+
+    report = _prepare_argocd_for_run(config=config)
+    report['reason'] = 'reasserted_manual_before_runtime_mutation'
+    return report
 
 
 def _restore_argocd_after_run(
@@ -6379,6 +6755,28 @@ def _existing_artifact_refs(resources: SimulationResources, analytics_report: Ma
     return refs
 
 
+def _completion_trace_coverage_ratio(
+    *,
+    window_policy: Mapping[str, Any],
+    dump_coverage: Mapping[str, Any],
+    analytics_report: Mapping[str, Any],
+) -> float:
+    coverage_ratio = dump_coverage.get('coverage_ratio')
+    if coverage_ratio is not None:
+        return max(_safe_float(coverage_ratio), 0.0)
+
+    observed_minutes = _safe_float(dump_coverage.get('observed_minutes'), default=0.0)
+    min_coverage_minutes = _safe_int(window_policy.get('min_coverage_minutes'), default=0)
+    if observed_minutes > 0 and min_coverage_minutes > 0:
+        return max(observed_minutes / float(min_coverage_minutes), 0.0)
+
+    report_coverage = _as_mapping(analytics_report.get('coverage'))
+    report_ratio = report_coverage.get('window_coverage_ratio_from_dump')
+    if report_ratio is not None:
+        return max(_safe_float(report_ratio), 0.0)
+    return 0.0
+
+
 def _build_simulation_completion_trace(
     *,
     resources: SimulationResources,
@@ -6407,7 +6805,11 @@ def _build_simulation_completion_trace(
     execution_order_events = _safe_int(final_snapshot.get('execution_order_events'))
     activity_classification = _as_text(monitor_payload.get('activity_classification')) or 'unknown'
     runtime_state = _as_text(runtime_payload.get('runtime_state')) or 'unknown'
-    coverage_ratio = float(dump_coverage.get('coverage_ratio') or 0.0)
+    coverage_ratio = _completion_trace_coverage_ratio(
+        window_policy=window_policy,
+        dump_coverage=dump_coverage,
+        analytics_report=analytics_payload,
+    )
     strict_ratio = float(window_policy.get('strict_coverage_ratio') or 0.0)
     fill_price_payload = _as_mapping(fill_price_error_budget_report)
     gate_results: dict[str, dict[str, Any]] = {}
@@ -6612,6 +7014,7 @@ def _run_full_lifecycle(
                 kafka_config=kafka_config,
                 clickhouse_config=clickhouse_config,
                 postgres_config=postgres_config,
+                argocd_config=argocd_config,
                 force_dump=force_dump,
                 force_replay=force_replay,
             )
@@ -7215,6 +7618,7 @@ def main() -> None:
             kafka_config=kafka_config,
             clickhouse_config=clickhouse_config,
             postgres_config=postgres_config,
+            argocd_config=argocd_config,
             force_dump=bool(args.force_dump),
             force_replay=bool(args.force_replay),
         )

--- a/services/torghut/tests/test_run_simulation_analysis.py
+++ b/services/torghut/tests/test_run_simulation_analysis.py
@@ -233,7 +233,7 @@ class TestRunSimulationAnalysis(TestCase):
                 return_value={'runtime_state': 'ready', 'environment_state': 'complete'},
             ),
             patch(
-                'scripts.run_simulation_analysis._current_activity_report',
+                'scripts.run_simulation_analysis._monitor_run_completion',
                 return_value={'status': 'degraded', 'activity_classification': 'executions_absent'},
             ),
             redirect_stdout(stdout),
@@ -244,6 +244,67 @@ class TestRunSimulationAnalysis(TestCase):
         self.assertEqual(ctx.exception.code, 1)
         payload = json.loads(stdout.getvalue())
         self.assertEqual(payload['activity_classification'], 'executions_absent')
+
+    def test_activity_uses_completion_monitor_and_exits_zero_when_successful(self) -> None:
+        stdout = io.StringIO()
+        with (
+            patch(
+                'sys.argv',
+                [
+                    'run_simulation_analysis.py',
+                    'activity',
+                    '--run-id',
+                    'sim-1',
+                    '--dataset-id',
+                    'dataset-a',
+                    '--namespace',
+                    'torghut',
+                    '--torghut-service',
+                    'torghut-sim',
+                    '--ta-deployment',
+                    'torghut-ta-sim',
+                    '--forecast-service',
+                    'torghut-forecast-sim',
+                    '--window-start',
+                    '2026-03-06T14:30:00Z',
+                    '--window-end',
+                    '2026-03-06T15:30:00Z',
+                    '--signal-table',
+                    'torghut_sim_sim_1.ta_signals',
+                    '--price-table',
+                    'torghut_sim_sim_1.ta_microbars',
+                    '--postgres-base-dsn',
+                    'postgresql://torghut:secret@localhost:5432/postgres',
+                    '--postgres-database',
+                    'torghut_sim_sim_1',
+                    '--clickhouse-http-url',
+                    'http://clickhouse:8123',
+                    '--clickhouse-username',
+                    'torghut',
+                    '--json',
+                ],
+            ),
+            patch(
+                'scripts.run_simulation_analysis._runtime_verify',
+                return_value={'runtime_state': 'ready', 'environment_state': 'complete'},
+            ),
+            patch(
+                'scripts.run_simulation_analysis._monitor_run_completion',
+                return_value={
+                    'status': 'ok',
+                    'activity_classification': 'success',
+                    'trade_decisions': 3,
+                    'executions': 2,
+                },
+            ) as monitor_mock,
+            redirect_stdout(stdout),
+        ):
+            main()
+
+        monitor_mock.assert_called_once()
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(payload['activity_classification'], 'success')
+        self.assertEqual(payload['trade_decisions'], 3)
 
     def test_teardown_clean_does_not_require_window_arguments(self) -> None:
         stdout = io.StringIO()

--- a/services/torghut/tests/test_signal_ingest.py
+++ b/services/torghut/tests/test_signal_ingest.py
@@ -653,23 +653,43 @@ class TestSignalIngest(TestCase):
         self.assertIn("AND event_ts <= toDateTime64", envelope_ingestor.last_query)
         self.assertIn("ORDER BY event_ts ASC, seq ASC", envelope_ingestor.last_query)
 
-    def test_fetch_signals_between_dedupes_envelope_duplicates_by_earliest_ingest(self) -> None:
+    def test_fetch_signals_between_dedupes_replay_duplicates_by_stable_identity(self) -> None:
         rows = [
             {
                 "event_ts": "2026-03-06T14:50:00Z",
                 "ingest_ts": "2026-03-08T01:33:32.461000Z",
                 "symbol": "SIM-SPY",
-                "payload": {"rsi14": 30},
+                "payload": {
+                    "rsi14": 30,
+                    "simulation_context": {
+                        "dataset_event_id": "evt-1",
+                        "source_topic": "torghut.trades.v1",
+                        "source_partition": 2,
+                        "source_offset": 900,
+                        "signal_seq": 100,
+                        "simulation_run_id": "sim-old",
+                    },
+                },
                 "seq": 100,
-                "source": "ta",
+                "source": "ws",
                 "window_size": "PT1S",
             },
             {
                 "event_ts": "2026-03-06T14:50:00Z",
                 "ingest_ts": "2026-03-06T14:51:00.316000Z",
                 "symbol": "SIM-SPY",
-                "payload": {"rsi14": 30},
-                "seq": 200,
+                "payload": {
+                    "rsi14": 30,
+                    "simulation_context": {
+                        "dataset_event_id": "evt-1",
+                        "source_topic": "torghut.trades.v1",
+                        "source_partition": 2,
+                        "source_offset": 900,
+                        "signal_seq": 100,
+                        "simulation_run_id": "sim-current",
+                    },
+                },
+                "seq": 100,
                 "source": "ws",
                 "window_size": "PT1S",
             },
@@ -677,9 +697,19 @@ class TestSignalIngest(TestCase):
                 "event_ts": "2026-03-06T14:50:01Z",
                 "ingest_ts": "2026-03-06T14:51:01.316000Z",
                 "symbol": "SIM-SPY",
-                "payload": {"rsi14": 31},
+                "payload": {
+                    "rsi14": 31,
+                    "simulation_context": {
+                        "dataset_event_id": "evt-2",
+                        "source_topic": "torghut.trades.v1",
+                        "source_partition": 2,
+                        "source_offset": 901,
+                        "signal_seq": 101,
+                        "simulation_run_id": "sim-current",
+                    },
+                },
                 "seq": 101,
-                "source": "ta",
+                "source": "ws",
                 "window_size": "PT1S",
             },
         ]
@@ -688,21 +718,82 @@ class TestSignalIngest(TestCase):
             def _query_clickhouse(self, query: str) -> list[dict[str, object]]:
                 return rows
 
-        ingestor = DuplicateEnvelopeIngestor(schema="envelope", table="torghut.ta_signals", url="http://example")
+        original_enabled = settings.trading_simulation_enabled
+        original_run_id = settings.trading_simulation_run_id
+        try:
+            settings.trading_simulation_enabled = True
+            settings.trading_simulation_run_id = "sim-current"
+            ingestor = DuplicateEnvelopeIngestor(schema="envelope", table="torghut.ta_signals", url="http://example")
+            signals = ingestor.fetch_signals_between(
+                start=datetime(2026, 3, 6, 14, 50, tzinfo=timezone.utc),
+                end=datetime(2026, 3, 6, 14, 51, tzinfo=timezone.utc),
+            )
+        finally:
+            settings.trading_simulation_enabled = original_enabled
+            settings.trading_simulation_run_id = original_run_id
+
+        self.assertEqual(len(signals), 2)
+        self.assertEqual(signals[0].event_ts, datetime(2026, 3, 6, 14, 50, tzinfo=timezone.utc))
+        self.assertEqual(signals[0].seq, 100)
+        self.assertEqual(signals[0].source, "ws")
+        self.assertEqual(
+            signals[0].payload.get("simulation_context", {}).get("simulation_run_id"),
+            "sim-current",
+        )
+        self.assertEqual(signals[1].seq, 101)
+
+    def test_fetch_signals_between_preserves_distinct_envelopes_sharing_timestamp(self) -> None:
+        rows = [
+            {
+                "event_ts": "2026-03-06T14:50:00Z",
+                "ingest_ts": "2026-03-08T01:33:32.461000Z",
+                "symbol": "SIM-SPY",
+                "payload": {
+                    "rsi14": 30,
+                    "simulation_context": {
+                        "dataset_event_id": "evt-1",
+                        "source_topic": "torghut.trades.v1",
+                        "source_partition": 2,
+                        "source_offset": 900,
+                        "signal_seq": 100,
+                    },
+                },
+                "seq": 100,
+                "source": "ta",
+                "window_size": "PT1S",
+            },
+            {
+                "event_ts": "2026-03-06T14:50:00Z",
+                "ingest_ts": "2026-03-06T14:51:00.316000Z",
+                "symbol": "SIM-SPY",
+                "payload": {
+                    "rsi14": 31,
+                    "simulation_context": {
+                        "dataset_event_id": "evt-2",
+                        "source_topic": "torghut.quotes.v1",
+                        "source_partition": 5,
+                        "source_offset": 1234,
+                        "signal_seq": 200,
+                    },
+                },
+                "seq": 200,
+                "source": "ws",
+                "window_size": "PT1S",
+            },
+        ]
+
+        class DistinctEnvelopeIngestor(ClickHouseSignalIngestor):
+            def _query_clickhouse(self, query: str) -> list[dict[str, object]]:
+                return rows
+
+        ingestor = DistinctEnvelopeIngestor(schema="envelope", table="torghut.ta_signals", url="http://example")
         signals = ingestor.fetch_signals_between(
             start=datetime(2026, 3, 6, 14, 50, tzinfo=timezone.utc),
             end=datetime(2026, 3, 6, 14, 51, tzinfo=timezone.utc),
         )
 
         self.assertEqual(len(signals), 2)
-        self.assertEqual(signals[0].event_ts, datetime(2026, 3, 6, 14, 50, tzinfo=timezone.utc))
-        self.assertEqual(signals[0].seq, 200)
-        self.assertEqual(signals[0].source, "ws")
-        self.assertEqual(
-            signals[0].ingest_ts,
-            datetime(2026, 3, 6, 14, 51, 0, 316000, tzinfo=timezone.utc),
-        )
-        self.assertEqual(signals[1].seq, 101)
+        self.assertEqual([signal.seq for signal in signals], [100, 200])
 
     def test_fetch_signals_between_filters_disallowed_sources(self) -> None:
         rows = [

--- a/services/torghut/tests/test_start_historical_simulation.py
+++ b/services/torghut/tests/test_start_historical_simulation.py
@@ -162,7 +162,7 @@ class TestStartHistoricalSimulation(TestCase):
         self.assertEqual(policy['mode'], 'stateless')
         self.assertEqual(policy['source'], 'profile_default:compact')
 
-    def test_ta_restore_policy_defaults_full_day_profiles_to_required(self) -> None:
+    def test_ta_restore_policy_defaults_full_day_profiles_to_stateless(self) -> None:
         policy = start_historical_simulation._ta_restore_policy(
             {
                 'window': {
@@ -175,7 +175,7 @@ class TestStartHistoricalSimulation(TestCase):
             }
         )
 
-        self.assertEqual(policy['mode'], 'required')
+        self.assertEqual(policy['mode'], 'stateless')
         self.assertEqual(policy['source'], 'profile_default:full_day')
 
     def test_analysis_run_name_uses_dns1123_safe_token(self) -> None:
@@ -1560,6 +1560,134 @@ class TestStartHistoricalSimulation(TestCase):
         self.assertTrue(report['clickhouse']['database_precreated'])
         self.assertTrue(report['postgres']['database_precreated'])
         self.assertEqual(report['simulation_lock']['status'], 'acquired')
+
+    def test_apply_reasserts_manual_argocd_control_before_runtime_mutation(self) -> None:
+        resources = _build_resources('sim-1', {'dataset_id': 'dataset-a'})
+        kafka_config = KafkaRuntimeConfig(
+            bootstrap_servers='kafka:9092',
+            security_protocol=None,
+            sasl_mechanism=None,
+            sasl_username=None,
+            sasl_password=None,
+        )
+        clickhouse_config = ClickHouseRuntimeConfig(
+            http_url='http://clickhouse:8123',
+            username='torghut',
+            password='secret',
+        )
+        postgres_config = PostgresRuntimeConfig(
+            admin_dsn='postgresql://torghut:secret@localhost:5432/postgres',
+            simulation_dsn='postgresql://torghut:secret@localhost:5432/torghut_sim_sim_1',
+            simulation_db='torghut_sim_sim_1',
+            migrations_command='true',
+        )
+        argocd_config = ArgocdAutomationConfig(
+            manage_automation=True,
+            applicationset_name='product',
+            applicationset_namespace='argocd',
+            app_name='torghut',
+            root_app_name='root',
+            desired_mode_during_run='manual',
+            restore_mode_after_run='previous',
+            verify_timeout_seconds=30,
+        )
+        manifest = {
+            'dataset_id': 'dataset-a',
+            'window': {
+                'start': '2026-02-27T14:30:00Z',
+                'end': '2026-02-27T15:30:00Z',
+            },
+        }
+
+        with TemporaryDirectory() as tmpdir:
+            resources = replace(resources, output_root=Path(tmpdir))
+            with ExitStack() as stack:
+                stack.enter_context(patch('scripts.start_historical_simulation._ensure_supported_binary'))
+                stack.enter_context(patch('scripts.start_historical_simulation._ensure_lz4_codec_available'))
+                stack.enter_context(
+                    patch(
+                        'scripts.start_historical_simulation._acquire_simulation_runtime_lock',
+                        return_value={'status': 'acquired', 'run_id': resources.run_id},
+                    ),
+                )
+                stack.enter_context(
+                    patch(
+                        'scripts.start_historical_simulation._capture_cluster_state',
+                        return_value={
+                            'ta_data': {
+                                'TA_GROUP_ID': 'prod-ta-group',
+                                'TA_CHECKPOINT_DIR': 's3a://bucket/checkpoints',
+                                'TA_SAVEPOINT_DIR': 's3a://bucket/savepoints',
+                            }
+                        },
+                    ),
+                )
+                stack.enter_context(patch('scripts.start_historical_simulation._ensure_topics', return_value={'status': 'ok'}))
+                stack.enter_context(patch('scripts.start_historical_simulation._ensure_clickhouse_database'))
+                stack.enter_context(patch('scripts.start_historical_simulation._ensure_clickhouse_runtime_tables', return_value=None))
+                stack.enter_context(patch('scripts.start_historical_simulation._ensure_postgres_database'))
+                stack.enter_context(
+                    patch(
+                        'scripts.start_historical_simulation._ensure_postgres_runtime_permissions',
+                        return_value={'grants_applied': True},
+                    ),
+                )
+                stack.enter_context(patch('scripts.start_historical_simulation._run_migrations', return_value=None))
+                stack.enter_context(patch('scripts.start_historical_simulation._reset_postgres_runtime_state', return_value=None))
+                stack.enter_context(
+                    patch(
+                        'scripts.start_historical_simulation._seed_simulation_trade_cursor',
+                        return_value=datetime(2026, 2, 27, 14, 30, tzinfo=timezone.utc),
+                    ),
+                )
+                stack.enter_context(patch('scripts.start_historical_simulation._upsert_simulation_runtime_context', return_value=None))
+                stack.enter_context(patch('scripts.start_historical_simulation._dump_topics', return_value={'records': 1, 'sha256': 'abc'}))
+                stack.enter_context(
+                    patch(
+                        'scripts.start_historical_simulation._validate_dump_coverage',
+                        return_value={'coverage_ratio': 1.0},
+                    ),
+                )
+                runtime_guard = stack.enter_context(
+                    patch(
+                        'scripts.start_historical_simulation._ensure_argocd_manual_before_runtime_mutation',
+                        return_value={'managed': True, 'changed': True},
+                    ),
+                )
+                stack.enter_context(
+                    patch(
+                        'scripts.start_historical_simulation._ta_runtime_reconfigure_required',
+                        return_value=True,
+                    ),
+                )
+                stack.enter_context(
+                    patch(
+                        'scripts.start_historical_simulation._torghut_service_reconfigure_required',
+                        return_value=True,
+                    ),
+                )
+                stack.enter_context(patch('scripts.start_historical_simulation._configure_ta_for_simulation', return_value=None))
+                stack.enter_context(patch('scripts.start_historical_simulation._restart_ta_deployment', return_value='nonce'))
+                stack.enter_context(
+                    patch(
+                        'scripts.start_historical_simulation._configure_torghut_service_for_simulation',
+                        return_value=None,
+                    ),
+                )
+
+                report = start_historical_simulation._apply(
+                    resources=resources,
+                    manifest=manifest,
+                    kafka_config=kafka_config,
+                    clickhouse_config=clickhouse_config,
+                    postgres_config=postgres_config,
+                    argocd_config=argocd_config,
+                    force_dump=False,
+                    force_replay=False,
+                )
+
+        runtime_guard.assert_called_once_with(config=argocd_config)
+        self.assertEqual(report['argocd_runtime_guard'], {'managed': True, 'changed': True})
 
     def test_apply_restarts_ta_when_warm_lane_baseline_is_already_ready(self) -> None:
         resources = _build_resources(
@@ -3182,6 +3310,8 @@ class TestStartHistoricalSimulation(TestCase):
                 torghut_env_overrides={
                     'TRADING_FEATURE_MAX_STALENESS_MS': '43200000',
                     'TRADING_FEATURE_QUALITY_ENABLED': 'true',
+                    'TRADING_STRATEGY_RUNTIME_MODE': 'plugin_v3',
+                    'TRADING_STRATEGY_SCHEDULER_ENABLED': 'false',
                 },
             )
 
@@ -3214,11 +3344,11 @@ class TestStartHistoricalSimulation(TestCase):
         )
         self.assertEqual(
             env_by_name['TRADING_STRATEGY_RUNTIME_MODE'].get('value'),
-            'scheduler_v3',
+            'plugin_v3',
         )
         self.assertEqual(
             env_by_name['TRADING_STRATEGY_SCHEDULER_ENABLED'].get('value'),
-            'true',
+            'false',
         )
 
     def test_configure_torghut_service_allows_explicit_runtime_override(self) -> None:
@@ -3452,9 +3582,31 @@ class TestStartHistoricalSimulation(TestCase):
         dump_sha256 = start_historical_simulation.hashlib.sha256(dump_bytes).hexdigest()
         cache_artifact_path = 's3://argo-workflows/torghut-simulation-cache/cache-key/source-dump.ndjson'
         cache_manifest_path = f'{cache_artifact_path}.manifest.json'
+        manifest = {
+            'dataset_id': resources.dataset_id,
+            'dataset_snapshot_ref': 'dataset-a@snapshot-1',
+            'candidate_id': 'intraday_tsmom_v1@prod',
+            'baseline_candidate_id': 'intraday_tsmom_v1@baseline',
+            'strategy_spec_ref': 'strategy-specs/intraday_tsmom_v1@1.1.0.json',
+            'model_refs': ['rules/intraday_tsmom_v1'],
+            'runtime_version_refs': ['services/torghut@sha256:abc'],
+            'cachePolicy': 'prefer_cache',
+            'metadata': {
+                'cacheKey': 'cache-key',
+                'cacheDecision': 'hit',
+                'cacheArtifactPath': cache_artifact_path,
+                'cacheChunkManifestPath': cache_manifest_path,
+            },
+            'performance': {
+                'dumpFormat': 'ndjson',
+                'replayProfile': 'compact',
+            },
+            'window': {'start': '2026-01-01T00:00:00Z', 'end': '2026-01-01T01:00:00Z'},
+        }
         artifact_manifest = {
             'dataset_id': resources.dataset_id,
             'run_id': 'prior-run',
+            'lineage': start_historical_simulation._cache_lineage_payload(manifest),
             'dump_format': 'ndjson',
             'cache_policy': 'prefer_cache',
             'replay_profile': 'compact',
@@ -3481,21 +3633,6 @@ class TestStartHistoricalSimulation(TestCase):
 
         with TemporaryDirectory() as tmp_dir:
             dump_path = Path(tmp_dir) / 'source-dump.ndjson'
-            manifest = {
-                'cachePolicy': 'prefer_cache',
-                'metadata': {
-                    'cacheKey': 'cache-key',
-                    'cacheDecision': 'hit',
-                    'cacheArtifactPath': cache_artifact_path,
-                    'cacheChunkManifestPath': cache_manifest_path,
-                },
-                'performance': {
-                    'dumpFormat': 'ndjson',
-                    'replayProfile': 'compact',
-                },
-                'window': {'start': '2026-01-01T00:00:00Z', 'end': '2026-01-01T01:00:00Z'},
-            }
-
             with (
                 patch(
                     'scripts.start_historical_simulation._consumer_for_dump',
@@ -3521,6 +3658,550 @@ class TestStartHistoricalSimulation(TestCase):
             marker = json.loads(dump_path.with_suffix('.dump-marker.json').read_text(encoding='utf-8'))
             self.assertEqual(marker['dump_sha256'], dump_sha256)
             self.assertEqual(marker['records'], 1)
+
+    def test_dump_topics_derives_durable_cache_metadata_for_local_manifests(self) -> None:
+        resources = _build_resources(
+            'sim-1',
+            {
+                'dataset_id': 'dataset-a',
+            },
+        )
+        kafka_config = KafkaRuntimeConfig(
+            bootstrap_servers='kafka:9092',
+            security_protocol=None,
+            sasl_mechanism=None,
+            sasl_username=None,
+            sasl_password=None,
+        )
+        dump_line = json.dumps(
+            {
+                'source_topic': resources.source_topic_by_role['trades'],
+                'replay_topic': resources.simulation_topic_by_role['trades'],
+                'source_timestamp_ms': 1704067200000,
+                'key_b64': None,
+                'value_b64': None,
+                'headers': [],
+            }
+        )
+        dump_bytes = f'{dump_line}\n'.encode('utf-8')
+        dump_sha256 = start_historical_simulation.hashlib.sha256(dump_bytes).hexdigest()
+        manifest = {
+            'dataset_id': resources.dataset_id,
+            'dataset_snapshot_ref': 'dataset-a@snapshot-1',
+            'candidate_id': 'intraday_tsmom_v1@prod',
+            'baseline_candidate_id': 'intraday_tsmom_v1@baseline',
+            'strategy_spec_ref': 'strategy-specs/intraday_tsmom_v1@1.1.0.json',
+            'model_refs': ['rules/intraday_tsmom_v1'],
+            'runtime_version_refs': ['services/torghut@sha256:abc'],
+            'cachePolicy': 'prefer_cache',
+            'performance': {
+                'dumpFormat': 'ndjson',
+                'replayProfile': 'compact',
+            },
+            'window': {'start': '2026-01-01T00:00:00Z', 'end': '2026-01-01T01:00:00Z'},
+        }
+        cache_metadata = start_historical_simulation._cache_metadata(manifest)
+        cache_artifact_path = cache_metadata['cache_artifact_path']
+        cache_manifest_path = cache_metadata['cache_manifest_path']
+        self.assertTrue(cache_metadata['cache_key'])
+        self.assertTrue(cache_artifact_path.endswith('/source-dump.ndjson'))
+        self.assertEqual(cache_manifest_path, f'{cache_artifact_path}.manifest.json')
+        artifact_manifest = {
+            'dataset_id': resources.dataset_id,
+            'run_id': 'prior-run',
+            'lineage': start_historical_simulation._cache_lineage_payload(manifest),
+            'dump_format': 'ndjson',
+            'cache_policy': 'prefer_cache',
+            'replay_profile': 'compact',
+            'chunk_count': 1,
+            'chunks': [
+                {
+                    'path': cache_artifact_path,
+                    'records': 1,
+                    'sha256': dump_sha256,
+                    'payload_sha256': dump_sha256,
+                    'min_source_timestamp_ms': 1704067200000,
+                    'max_source_timestamp_ms': 1704067200000,
+                }
+            ],
+        }
+
+        class _FakeCephClient:
+            def get_object(self, *, bucket: str, key: str) -> bytes:
+                if bucket != 'argo-workflows':
+                    raise AssertionError(f'unexpected bucket: {bucket}')
+                if key.endswith('.manifest.json'):
+                    return json.dumps(artifact_manifest).encode('utf-8')
+                return dump_bytes
+
+        with TemporaryDirectory() as tmp_dir:
+            dump_path = Path(tmp_dir) / 'source-dump.ndjson'
+
+            with (
+                patch(
+                    'scripts.start_historical_simulation._consumer_for_dump',
+                    side_effect=AssertionError('expected durable cache restore; consumer should not be constructed'),
+                ),
+                patch(
+                    'scripts.start_historical_simulation._simulation_cache_client_from_env',
+                    return_value=(_FakeCephClient(), 'argo-workflows'),
+                ),
+            ):
+                report = _dump_topics(
+                    resources=resources,
+                    kafka_config=kafka_config,
+                    manifest=manifest,
+                    dump_path=dump_path,
+                    force=False,
+                )
+
+            self.assertTrue(report['restored_from_cache'])
+            self.assertEqual(report['records'], 1)
+            self.assertEqual(report['cache_artifact_path'], cache_artifact_path)
+            self.assertTrue(dump_path.exists())
+
+    def test_restore_cached_dump_rejects_lineage_mismatch(self) -> None:
+        manifest = {
+            'dataset_id': 'dataset-a',
+            'dataset_snapshot_ref': 'dataset-a@snapshot-2',
+            'candidate_id': 'intraday_tsmom_v1@prod',
+            'baseline_candidate_id': 'intraday_tsmom_v1@baseline',
+            'strategy_spec_ref': 'strategy-specs/intraday_tsmom_v1@1.1.0.json',
+            'model_refs': ['rules/intraday_tsmom_v1'],
+            'runtime_version_refs': ['services/torghut@sha256:def'],
+            'cachePolicy': 'prefer_cache',
+            'performance': {
+                'dumpFormat': 'ndjson',
+                'replayProfile': 'compact',
+            },
+            'window': {'start': '2026-01-01T00:00:00Z', 'end': '2026-01-01T01:00:00Z'},
+        }
+        cache_metadata = start_historical_simulation._cache_metadata(manifest)
+        artifact_manifest = {
+            'dataset_id': 'dataset-a',
+            'run_id': 'prior-run',
+            'lineage': {
+                'schema_version': 'torghut-simulation-cache-v1',
+                'lane': 'equity',
+                'dataset_id': 'dataset-a',
+                'dataset_snapshot_ref': 'dataset-a@snapshot-1',
+                'window': manifest['window'],
+                'strategy_spec_ref': manifest['strategy_spec_ref'],
+                'candidate_id': manifest['candidate_id'],
+                'baseline_candidate_id': manifest['baseline_candidate_id'],
+                'model_refs': manifest['model_refs'],
+                'runtime_version_refs': ['services/torghut@sha256:abc'],
+                'dump_format': 'ndjson',
+                'profile': 'compact',
+            },
+            'dump_format': 'ndjson',
+            'cache_policy': 'prefer_cache',
+            'replay_profile': 'compact',
+            'chunk_count': 1,
+            'chunks': [
+                {
+                    'path': cache_metadata['cache_artifact_path'],
+                    'records': 1,
+                    'sha256': 'abc',
+                    'payload_sha256': 'abc',
+                    'min_source_timestamp_ms': 1704067200000,
+                    'max_source_timestamp_ms': 1704067200000,
+                }
+            ],
+        }
+
+        class _FakeCephClient:
+            def get_object(self, *, bucket: str, key: str) -> bytes:
+                if key.endswith('.manifest.json'):
+                    return json.dumps(artifact_manifest).encode('utf-8')
+                return b'{}\n'
+
+        with TemporaryDirectory() as tmp_dir:
+            dump_path = Path(tmp_dir) / 'source-dump.ndjson'
+            with patch(
+                'scripts.start_historical_simulation._simulation_cache_client_from_env',
+                return_value=(_FakeCephClient(), 'argo-workflows'),
+            ):
+                report = start_historical_simulation._restore_cached_dump_if_available(
+                    manifest=manifest,
+                    dump_path=dump_path,
+                )
+
+        self.assertIsNone(report)
+        self.assertFalse(dump_path.exists())
+
+    def test_restore_cached_dump_skips_explicit_non_hit_cache_decision(self) -> None:
+        manifest = {
+            'cachePolicy': 'prefer_cache',
+            'metadata': {
+                'cacheKey': 'cache-key',
+                'cacheDecision': 'miss',
+                'cacheArtifactPath': 's3://argo-workflows/torghut-simulation-cache/cache-key/source-dump.ndjson',
+                'cacheChunkManifestPath': (
+                    's3://argo-workflows/torghut-simulation-cache/cache-key/source-dump.ndjson.manifest.json'
+                ),
+            },
+            'performance': {
+                'dumpFormat': 'ndjson',
+            },
+        }
+
+        with TemporaryDirectory() as tmp_dir:
+            dump_path = Path(tmp_dir) / 'source-dump.ndjson'
+
+            with patch(
+                'scripts.start_historical_simulation._simulation_cache_client_from_env',
+                side_effect=AssertionError('non-hit cache decisions must not attempt restore'),
+            ):
+                report = start_historical_simulation._restore_cached_dump_if_available(
+                    manifest=manifest,
+                    dump_path=dump_path,
+                )
+
+        self.assertIsNone(report)
+        self.assertFalse(dump_path.exists())
+
+    def test_simulation_cache_upload_timeout_seconds_scales_with_dump_size(self) -> None:
+        with TemporaryDirectory() as tmp_dir:
+            dump_path = Path(tmp_dir) / 'source-dump.jsonl.zst'
+            dump_path.write_bytes(b'x' * (5 * 1024 * 1024))
+
+            timeout_seconds = start_historical_simulation._simulation_cache_upload_timeout_seconds(dump_path)
+
+        self.assertGreaterEqual(timeout_seconds, 60)
+
+    def test_upload_dump_to_cache_retries_transient_timeout(self) -> None:
+        manifest = {
+            'dataset_id': 'dataset-a',
+            'dataset_snapshot_ref': 'dataset-a@snapshot-1',
+            'candidate_id': 'intraday_tsmom_v1@prod',
+            'baseline_candidate_id': 'intraday_tsmom_v1@baseline',
+            'strategy_spec_ref': 'strategy-specs/intraday_tsmom_v1@1.1.0.json',
+            'model_refs': ['rules/intraday_tsmom_v1'],
+            'runtime_version_refs': ['services/torghut@sha256:abc'],
+            'cachePolicy': 'refresh',
+            'performance': {
+                'dumpFormat': 'ndjson',
+                'replayProfile': 'compact',
+            },
+            'window': {'start': '2026-01-01T00:00:00Z', 'end': '2026-01-01T01:00:00Z'},
+        }
+        client_timeouts: list[int | None] = []
+        put_attempts: list[tuple[str, str]] = []
+
+        class _FakeCephClient:
+            def __init__(self, timeout_seconds: int | None) -> None:
+                self.timeout_seconds = timeout_seconds
+                self._attempt = 0
+
+            def put_object(
+                self,
+                *,
+                bucket: str,
+                key: str,
+                body: bytes,
+                content_type: str,
+            ) -> dict[str, Any]:
+                _ = (body, content_type)
+                put_attempts.append((bucket, key))
+                self._attempt += 1
+                if self._attempt == 1:
+                    raise TimeoutError('timed out')
+                return {'etag': f'etag-{self._attempt}'}
+
+        def _fake_cache_client(timeout_seconds: int | None = None) -> tuple[Any, str]:
+            client_timeouts.append(timeout_seconds)
+            return _FakeCephClient(timeout_seconds), 'argo-workflows'
+
+        with TemporaryDirectory() as tmp_dir:
+            dump_path = Path(tmp_dir) / 'source-dump.ndjson'
+            dump_path.write_bytes(b'{}\n')
+            dump_manifest_path = start_historical_simulation._dump_artifact_manifest_path(dump_path)
+            dump_manifest_path.write_text(
+                json.dumps(
+                    {
+                        'dataset_id': 'dataset-a',
+                        'run_id': 'sim-1',
+                        'lineage': start_historical_simulation._cache_lineage_payload(manifest),
+                        'dump_format': 'ndjson',
+                        'cache_policy': 'refresh',
+                        'replay_profile': 'compact',
+                        'chunk_count': 1,
+                        'chunks': [
+                            {
+                                'path': str(dump_path),
+                                'records': 1,
+                                'sha256': 'abc',
+                                'payload_sha256': 'abc',
+                            }
+                        ],
+                    }
+                ),
+                encoding='utf-8',
+            )
+
+            with (
+                patch(
+                    'scripts.start_historical_simulation._simulation_cache_client_from_env',
+                    side_effect=_fake_cache_client,
+                ),
+                patch(
+                    'scripts.start_historical_simulation.time.sleep',
+                    return_value=None,
+                ),
+            ):
+                report = start_historical_simulation._upload_dump_to_cache(
+                    manifest=manifest,
+                    dump_path=dump_path,
+                )
+
+        self.assertEqual(report['status'], 'ok')
+        self.assertEqual(report['attempt_count'], 2)
+        self.assertEqual(len(client_timeouts), 1)
+        self.assertGreaterEqual(client_timeouts[0] or 0, 60)
+        self.assertEqual(len(put_attempts), 3)
+
+    def test_dump_topics_records_cache_upload_error_without_failing_fresh_dump(self) -> None:
+        resources = _build_resources(
+            'sim-1',
+            {
+                'dataset_id': 'dataset-a',
+            },
+        )
+        resources = replace(
+            resources,
+            replay_topic_by_source_topic={'torghut.trades.v1': 'torghut.sim.trades.v1'},
+        )
+        kafka_config = KafkaRuntimeConfig(
+            bootstrap_servers='kafka:9092',
+            security_protocol=None,
+            sasl_mechanism=None,
+            sasl_username=None,
+            sasl_password=None,
+        )
+
+        class _OffsetMeta:
+            def __init__(self, offset: int) -> None:
+                self.offset = offset
+
+        class _Record:
+            def __init__(self, topic: str, partition: int, offset: int, timestamp: int) -> None:
+                self.topic = topic
+                self.partition = partition
+                self.offset = offset
+                self.timestamp = timestamp
+                self.key = None
+                self.value = None
+                self.headers: list[tuple[str, bytes]] = []
+
+        class _FakeConsumer:
+            def __init__(self) -> None:
+                self._tp = ('torghut.trades.v1', 0)
+                self._position = 0
+                self._poll_calls = 0
+                self._offset_lookup_calls = 0
+
+            def partitions_for_topic(self, topic: str) -> set[int]:
+                self._topic = topic
+                return {0}
+
+            def assign(self, topic_partitions: list[tuple[str, int]]) -> None:
+                self._topic_partitions = topic_partitions
+
+            def beginning_offsets(self, topic_partitions: list[tuple[str, int]]) -> dict[tuple[str, int], int]:
+                return {tp: 0 for tp in topic_partitions}
+
+            def end_offsets(self, topic_partitions: list[tuple[str, int]]) -> dict[tuple[str, int], int]:
+                return {tp: 1 for tp in topic_partitions}
+
+            def offsets_for_times(
+                self,
+                request: dict[tuple[str, int], int],
+            ) -> dict[tuple[str, int], _OffsetMeta]:
+                self._offset_lookup_calls += 1
+                offset = 0 if self._offset_lookup_calls == 1 else 1
+                return {tp: _OffsetMeta(offset) for tp in request}
+
+            def seek(self, tp: tuple[str, int], offset: int) -> None:
+                self._position = offset
+
+            def poll(self, timeout_ms: int = 0, max_records: int = 0) -> dict[tuple[str, int], list[_Record]]:
+                _ = (timeout_ms, max_records)
+                self._poll_calls += 1
+                if self._poll_calls == 1:
+                    self._position = 1
+                    return {
+                        self._tp: [_Record(self._tp[0], self._tp[1], 0, 1735693200100)],
+                    }
+                return {}
+
+            def position(self, tp: tuple[str, int]) -> int:
+                _ = tp
+                return self._position
+
+            def close(self) -> None:
+                return None
+
+        manifest = {
+            'dataset_id': 'dataset-a',
+            'dataset_snapshot_ref': 'dataset-a@snapshot-1',
+            'candidate_id': 'intraday_tsmom_v1@prod',
+            'baseline_candidate_id': 'intraday_tsmom_v1@baseline',
+            'strategy_spec_ref': 'strategy-specs/intraday_tsmom_v1@1.1.0.json',
+            'model_refs': ['rules/intraday_tsmom_v1'],
+            'runtime_version_refs': ['services/torghut@sha256:abc'],
+            'cachePolicy': 'refresh',
+            'performance': {
+                'dumpFormat': 'ndjson',
+                'replayProfile': 'compact',
+            },
+            'window': {'start': '2025-01-01T00:00:00Z', 'end': '2025-01-01T00:00:01Z'},
+        }
+
+        with TemporaryDirectory() as tmp_dir:
+            dump_path = Path(tmp_dir) / 'source-dump.ndjson'
+            with (
+                patch.dict(
+                    'sys.modules',
+                    {'kafka': SimpleNamespace(TopicPartition=lambda topic, partition: (topic, partition))},
+                ),
+                patch(
+                    'scripts.start_historical_simulation._consumer_for_dump',
+                    return_value=_FakeConsumer(),
+                ),
+                patch(
+                    'scripts.start_historical_simulation._upload_dump_to_cache',
+                    side_effect=TimeoutError('timed out'),
+                ),
+            ):
+                report = _dump_topics(
+                    resources=resources,
+                    kafka_config=kafka_config,
+                    manifest=manifest,
+                    dump_path=dump_path,
+                    force=True,
+                )
+
+        self.assertEqual(report['records'], 1)
+        self.assertEqual(report['cache_upload']['status'], 'error')
+        self.assertEqual(report['cache_upload']['error'], 'timed out')
+
+    def test_dump_topics_orders_output_deterministically_across_partitions(self) -> None:
+        resources = _build_resources(
+            'sim-1',
+            {
+                'dataset_id': 'dataset-a',
+            },
+        )
+        resources = replace(
+            resources,
+            replay_topic_by_source_topic={'torghut.trades.v1': 'torghut.sim.trades.v1'},
+        )
+        kafka_config = KafkaRuntimeConfig(
+            bootstrap_servers='kafka:9092',
+            security_protocol=None,
+            sasl_mechanism=None,
+            sasl_username=None,
+            sasl_password=None,
+        )
+
+        class _OffsetMeta:
+            def __init__(self, offset: int) -> None:
+                self.offset = offset
+
+        class _Record:
+            def __init__(self, topic: str, partition: int, offset: int, timestamp: int) -> None:
+                self.topic = topic
+                self.partition = partition
+                self.offset = offset
+                self.timestamp = timestamp
+                self.key = None
+                self.value = None
+                self.headers: list[tuple[str, bytes]] = []
+
+        class _FakeConsumer:
+            def __init__(self) -> None:
+                self._topic = 'torghut.trades.v1'
+                self._positions = {
+                    (self._topic, 0): 0,
+                    (self._topic, 1): 0,
+                }
+                self._offset_lookup_calls = 0
+                self._poll_calls = 0
+
+            def partitions_for_topic(self, topic: str) -> set[int]:
+                self._topic = topic
+                return {0, 1}
+
+            def assign(self, topic_partitions: list[tuple[str, int]]) -> None:
+                self._topic_partitions = topic_partitions
+
+            def beginning_offsets(self, topic_partitions: list[tuple[str, int]]) -> dict[tuple[str, int], int]:
+                return {tp: 0 for tp in topic_partitions}
+
+            def end_offsets(self, topic_partitions: list[tuple[str, int]]) -> dict[tuple[str, int], int]:
+                return {tp: 1 for tp in topic_partitions}
+
+            def offsets_for_times(
+                self,
+                request: dict[tuple[str, int], int],
+            ) -> dict[tuple[str, int], _OffsetMeta]:
+                self._offset_lookup_calls += 1
+                offset = 0 if self._offset_lookup_calls == 1 else 1
+                return {tp: _OffsetMeta(offset) for tp in request}
+
+            def seek(self, tp: tuple[str, int], offset: int) -> None:
+                self._positions[tp] = offset
+
+            def poll(self, timeout_ms: int = 0, max_records: int = 0) -> dict[tuple[str, int], list[_Record]]:
+                _ = (timeout_ms, max_records)
+                self._poll_calls += 1
+                if self._poll_calls == 1:
+                    self._positions[(self._topic, 1)] = 1
+                    self._positions[(self._topic, 0)] = 1
+                    return {
+                        (self._topic, 1): [_Record(self._topic, 1, 0, 1735693200200)],
+                        (self._topic, 0): [_Record(self._topic, 0, 0, 1735693200100)],
+                    }
+                return {}
+
+            def position(self, tp: tuple[str, int]) -> int:
+                return self._positions[tp]
+
+            def close(self) -> None:
+                return None
+
+        with TemporaryDirectory() as tmp_dir:
+            dump_path = Path(tmp_dir) / 'source-dump.ndjson'
+            fake_consumer = _FakeConsumer()
+
+            with (
+                patch.dict(
+                    'sys.modules',
+                    {'kafka': SimpleNamespace(TopicPartition=lambda topic, partition: (topic, partition))},
+                ),
+                patch(
+                    'scripts.start_historical_simulation._consumer_for_dump',
+                    return_value=fake_consumer,
+                ),
+            ):
+                report = _dump_topics(
+                    resources=resources,
+                    kafka_config=kafka_config,
+                    manifest={'window': {'start': '2025-01-01T00:00:00Z', 'end': '2025-01-01T00:00:01Z'}},
+                    dump_path=dump_path,
+                    force=True,
+                )
+
+            lines = [json.loads(line) for line in dump_path.read_text(encoding='utf-8').splitlines()]
+            self.assertEqual(report['records'], 2)
+            self.assertEqual(
+                [(line['source_timestamp_ms'], line['source_partition'], line['source_offset']) for line in lines],
+                [
+                    (1735693200100, 0, 0),
+                    (1735693200200, 1, 0),
+                ],
+            )
 
     def test_dump_topics_completes_when_last_record_reaches_stop_offset(self) -> None:
         resources = _build_resources(
@@ -4433,6 +5114,92 @@ class TestStartHistoricalSimulation(TestCase):
         self.assertEqual(full_day['status'], 'satisfied')
         self.assertIsNone(full_day['blocked_reason'])
 
+    def test_build_simulation_completion_trace_derives_full_day_coverage_from_observed_minutes(self) -> None:
+        resources = _build_resources(
+            'sim-2026-03-13-full-day',
+            {
+                'dataset_id': 'torghut-full-day-20260313',
+                'dataset_snapshot_ref': 'torghut-full-day-20260313',
+                'window': {
+                    'profile': 'us_equities_regular',
+                    'start': '2026-03-13T13:30:00Z',
+                    'end': '2026-03-13T20:00:00Z',
+                    'min_coverage_minutes': 390,
+                    'strict_coverage_ratio': 0.95,
+                },
+            },
+        )
+        postgres = PostgresRuntimeConfig(
+            admin_dsn='postgresql://torghut:secret@localhost/postgres',
+            simulation_dsn='postgresql://torghut:secret@localhost/torghut_sim_full_day',
+            simulation_db='torghut_sim_full_day',
+            migrations_command='alembic upgrade heads',
+        )
+        with TemporaryDirectory() as tmpdir:
+            resources = replace(resources, output_root=Path(tmpdir))
+            for filename in (
+                'run-manifest.json',
+                'run-full-lifecycle-manifest.json',
+                'runtime-verify.json',
+                'replay-report.json',
+                'signal-activity.json',
+                'decision-activity.json',
+                'execution-activity.json',
+            ):
+                (resources.output_root / resources.run_token / filename).parent.mkdir(
+                    parents=True,
+                    exist_ok=True,
+                )
+                (resources.output_root / resources.run_token / filename).write_text(
+                    '{}',
+                    encoding='utf-8',
+                )
+
+            trace = _build_simulation_completion_trace(
+                resources=resources,
+                manifest={
+                    'dataset_snapshot_ref': 'torghut-full-day-20260313',
+                    'window': {
+                        'profile': 'us_equities_regular',
+                        'start': '2026-03-13T13:30:00Z',
+                        'end': '2026-03-13T20:00:00Z',
+                        'min_coverage_minutes': 390,
+                        'strict_coverage_ratio': 0.95,
+                    },
+                },
+                postgres_config=postgres,
+                apply_report={
+                    'window_policy': {'min_coverage_minutes': 390, 'strict_coverage_ratio': 0.95},
+                    'dump_coverage': {
+                        'observed_minutes': 389.9975,
+                        'required_minutes': 370.5,
+                        'strict_ratio': 0.95,
+                    },
+                },
+                runtime_verify_report={'runtime_state': 'ready'},
+                monitor_report={
+                    'activity_classification': 'success',
+                    'final_snapshot': {
+                        'trade_decisions': 123,
+                        'executions': 16,
+                        'execution_tca_metrics': 16,
+                        'execution_order_events': 16,
+                    },
+                },
+                analytics_report={},
+                fill_price_error_budget_report={
+                    'status': 'within_budget',
+                    'schema_version': 'fill-price-error-budget-report-v1',
+                },
+                rollouts_report={},
+                errors=[],
+            )
+
+        full_day = trace['result_by_gate']['simulation_full_day_coverage']
+        self.assertEqual(full_day['status'], 'satisfied')
+        self.assertIsNone(full_day['blocked_reason'])
+        self.assertAlmostEqual(full_day['acceptance_snapshot']['coverage_ratio'], 389.9975 / 390.0)
+
     def test_validate_window_policy_us_equities_regular_profile(self) -> None:
         policy = _validate_window_policy(
             {
@@ -4492,6 +5259,30 @@ class TestStartHistoricalSimulation(TestCase):
                 },
             )
 
+    def test_validate_dump_coverage_reports_ratio_when_policy_present(self) -> None:
+        coverage = _validate_dump_coverage(
+            manifest={
+                'window': {
+                    'profile': 'us_equities_regular',
+                    'trading_day': '2026-03-13',
+                    'timezone': 'America/New_York',
+                    'start': '2026-03-13T13:30:00Z',
+                    'end': '2026-03-13T20:00:00Z',
+                    'min_coverage_minutes': 390,
+                    'strict_coverage_ratio': 0.95,
+                }
+            },
+            dump_report={
+                'records': 100,
+                'min_source_timestamp_ms': 1773408600150,
+                'max_source_timestamp_ms': 1773432000000,
+            },
+        )
+
+        self.assertTrue(coverage['applied'])
+        self.assertAlmostEqual(coverage['coverage_ratio'], 389.9975 / 390.0)
+        self.assertAlmostEqual(coverage['required_minutes'], 390 * 0.95)
+
     def test_validate_dump_coverage_reports_full_day_coverage_ratio(self) -> None:
         report = _validate_dump_coverage(
             manifest={
@@ -4501,6 +5292,8 @@ class TestStartHistoricalSimulation(TestCase):
                     'timezone': 'America/New_York',
                     'start': '2026-02-27T14:30:00Z',
                     'end': '2026-02-27T21:00:00Z',
+                    'min_coverage_minutes': 390,
+                    'strict_coverage_ratio': 0.95,
                 }
             },
             dump_report={
@@ -7772,6 +8565,96 @@ class TestStartHistoricalSimulation(TestCase):
         self.assertTrue(report['applicationset_managed'])
         self.assertEqual(report['previous_mode'], 'auto')
         self.assertEqual(report['current_mode'], 'manual')
+
+    def test_ensure_argocd_manual_before_runtime_mutation_noops_when_everything_is_manual(self) -> None:
+        config = ArgocdAutomationConfig(
+            manage_automation=True,
+            applicationset_name='product',
+            applicationset_namespace='argocd',
+            app_name='torghut',
+            root_app_name='root',
+            desired_mode_during_run='manual',
+            restore_mode_after_run='previous',
+            verify_timeout_seconds=30,
+        )
+        with (
+            patch(
+                'scripts.start_historical_simulation._read_argocd_automation_mode',
+                return_value={'pointer': '/spec/generators/0/list/elements/0/automation', 'mode': 'manual'},
+            ),
+            patch(
+                'scripts.start_historical_simulation._read_named_argocd_application_sync_policy',
+                side_effect=[
+                    {
+                        'sync_policy': {
+                            'automated': {'enabled': False, 'prune': False, 'selfHeal': False},
+                            'syncOptions': ['CreateNamespace=true'],
+                        },
+                        'automation_mode': 'manual',
+                    },
+                    {
+                        'sync_policy': {
+                            'automated': {'enabled': False, 'prune': False, 'selfHeal': False},
+                            'syncOptions': ['CreateNamespace=true'],
+                        },
+                        'automation_mode': 'manual',
+                    },
+                ],
+            ),
+            patch('scripts.start_historical_simulation._prepare_argocd_for_run') as prepare_mock,
+        ):
+            report = start_historical_simulation._ensure_argocd_manual_before_runtime_mutation(config=config)
+
+        prepare_mock.assert_not_called()
+        self.assertEqual(report['reason'], 'already_manual')
+        self.assertFalse(report['changed'])
+        self.assertEqual(report['current_mode'], 'manual')
+
+    def test_ensure_argocd_manual_before_runtime_mutation_reasserts_when_child_app_drifted(self) -> None:
+        config = ArgocdAutomationConfig(
+            manage_automation=True,
+            applicationset_name='product',
+            applicationset_namespace='argocd',
+            app_name='torghut',
+            root_app_name='root',
+            desired_mode_during_run='manual',
+            restore_mode_after_run='previous',
+            verify_timeout_seconds=30,
+        )
+        with (
+            patch(
+                'scripts.start_historical_simulation._read_argocd_automation_mode',
+                return_value={'pointer': '/spec/generators/0/list/elements/0/automation', 'mode': 'manual'},
+            ),
+            patch(
+                'scripts.start_historical_simulation._read_named_argocd_application_sync_policy',
+                side_effect=[
+                    {
+                        'sync_policy': {
+                            'automated': {'enabled': True, 'prune': True, 'selfHeal': True},
+                            'syncOptions': ['CreateNamespace=true'],
+                        },
+                        'automation_mode': 'auto',
+                    },
+                    {
+                        'sync_policy': {
+                            'automated': {'enabled': False, 'prune': False, 'selfHeal': False},
+                            'syncOptions': ['CreateNamespace=true'],
+                        },
+                        'automation_mode': 'manual',
+                    },
+                ],
+            ),
+            patch(
+                'scripts.start_historical_simulation._prepare_argocd_for_run',
+                return_value={'managed': True, 'changed': True, 'current_mode': 'manual'},
+            ) as prepare_mock,
+        ):
+            report = start_historical_simulation._ensure_argocd_manual_before_runtime_mutation(config=config)
+
+        prepare_mock.assert_called_once_with(config=config)
+        self.assertEqual(report['reason'], 'reasserted_manual_before_runtime_mutation')
+        self.assertTrue(report['changed'])
 
     def test_restore_argocd_after_run_restores_root_and_applicationset(self) -> None:
         config = ArgocdAutomationConfig(


### PR DESCRIPTION
## Summary

- make historical simulation dump generation and cache lineage deterministic so warm proofs restore the exact March 13 source dump
- harden Torghut signal dedupe to preserve distinct envelopes and prefer the active simulation run when stale lane rows coexist
- default proof reruns to stateless TA recovery, tighten Jangar cache keys, and document the production-readiness proof contract in the runbook

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_signal_ingest.py tests/test_start_historical_simulation.py tests/test_run_simulation_analysis.py -q`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `bunx vitest run --config vitest.config.ts src/server/__tests__/torghut-simulation-control-plane-submit.test.ts src/server/__tests__/torghut-simulation-control-plane.test.ts`
- `bun run --filter @proompteng/jangar tsc`
- `bunx oxfmt --check services/jangar/src/server/torghut-simulation-control-plane.ts services/jangar/src/server/__tests__/torghut-simulation-control-plane-submit.test.ts services/jangar/src/server/__tests__/torghut-simulation-control-plane.test.ts`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
