### PR TITLE
chore(jangar): promote image 3f0647cc

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 355bc3db
-  digest: sha256:dcb4e355e5b7af10c8a9542a577789c6e4a9e2895d0a51f4f733b007107b8f2f
+  tag: 3f0647cc
+  digest: sha256:fd1d1d0a9c489dbbd3daa214ba83bd2ab1ad04e0acdb3935402190f61ee3a4a1
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 355bc3db
-    digest: sha256:0249e2af75f7690f70fe8c4c6d2ead6fcc9805ff6adec9f017d167d81dcd3a8c
+    tag: 3f0647cc
+    digest: sha256:0214a50d1daa9e8a60016e895fd58bb6198130a1c3f1b896bac666541c89e0f9
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 355bc3db
-    digest: sha256:dcb4e355e5b7af10c8a9542a577789c6e4a9e2895d0a51f4f733b007107b8f2f
+    tag: 3f0647cc
+    digest: sha256:fd1d1d0a9c489dbbd3daa214ba83bd2ab1ad04e0acdb3935402190f61ee3a4a1
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-16T10:51:09Z"
+    deploy.knative.dev/rollout: "2026-03-16T12:26:52Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-16T10:51:09Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-16T12:26:52Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -62,5 +62,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "355bc3db"
-    digest: sha256:dcb4e355e5b7af10c8a9542a577789c6e4a9e2895d0a51f4f733b007107b8f2f
+    newTag: "3f0647cc"
+    digest: sha256:fd1d1d0a9c489dbbd3daa214ba83bd2ab1ad04e0acdb3935402190f61ee3a4a1


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `3f0647cc2432b6b8e202f164411d84b7db4d77e1`
- Image tag: `3f0647cc`
- Image digest: `sha256:fd1d1d0a9c489dbbd3daa214ba83bd2ab1ad04e0acdb3935402190f61ee3a4a1`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`