### PR TITLE
chore(torghut): promote image a32df9bf

### DIFF
--- a/argocd/applications/torghut-forecast/deployment.yaml
+++ b/argocd/applications/torghut-forecast/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: forecast
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:a9c60e5ed5ddd06253e3126d363d4f6c82c1ef4fc5ea809e21c012ee39d438a5
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8f71bd1b8fb426d909887c32ad9f3793dbc41446e8ad2e99ff865af52b32217c
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn

--- a/argocd/applications/torghut-forecast/sim/deployment.yaml
+++ b/argocd/applications/torghut-forecast/sim/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: forecast
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:a9c60e5ed5ddd06253e3126d363d4f6c82c1ef4fc5ea809e21c012ee39d438a5
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8f71bd1b8fb426d909887c32ad9f3793dbc41446e8ad2e99ff865af52b32217c
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn

--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:a9c60e5ed5ddd06253e3126d363d4f6c82c1ef4fc5ea809e21c012ee39d438a5
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8f71bd1b8fb426d909887c32ad9f3793dbc41446e8ad2e99ff865af52b32217c
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -63,9 +63,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.564.0-230-g3f0647cc
+              value: v0.564.0-233-ga32df9bf
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 3f0647cc2432b6b8e202f164411d84b7db4d77e1
+              value: a32df9bfcc36c2110487a11a4f2815ef228785ab
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:a9c60e5ed5ddd06253e3126d363d4f6c82c1ef4fc5ea809e21c012ee39d438a5
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8f71bd1b8fb426d909887c32ad9f3793dbc41446e8ad2e99ff865af52b32217c
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -63,9 +63,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.564.0-230-g3f0647cc
+              value: v0.564.0-233-ga32df9bf
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 3f0647cc2432b6b8e202f164411d84b7db4d77e1
+              value: a32df9bfcc36c2110487a11a4f2815ef228785ab
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -40,7 +40,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:a9c60e5ed5ddd06253e3126d363d4f6c82c1ef4fc5ea809e21c012ee39d438a5
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:8f71bd1b8fb426d909887c32ad9f3793dbc41446e8ad2e99ff865af52b32217c
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -21,7 +21,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:a9c60e5ed5ddd06253e3126d363d4f6c82c1ef4fc5ea809e21c012ee39d438a5
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:8f71bd1b8fb426d909887c32ad9f3793dbc41446e8ad2e99ff865af52b32217c
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -32,7 +32,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:a9c60e5ed5ddd06253e3126d363d4f6c82c1ef4fc5ea809e21c012ee39d438a5
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:8f71bd1b8fb426d909887c32ad9f3793dbc41446e8ad2e99ff865af52b32217c
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -30,7 +30,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:a9c60e5ed5ddd06253e3126d363d4f6c82c1ef4fc5ea809e21c012ee39d438a5
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:8f71bd1b8fb426d909887c32ad9f3793dbc41446e8ad2e99ff865af52b32217c
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:a9c60e5ed5ddd06253e3126d363d4f6c82c1ef4fc5ea809e21c012ee39d438a5
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8f71bd1b8fb426d909887c32ad9f3793dbc41446e8ad2e99ff865af52b32217c
           command:
             - /opt/venv/bin/alembic
           args:

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -13,7 +13,7 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:a9c60e5ed5ddd06253e3126d363d4f6c82c1ef4fc5ea809e21c012ee39d438a5
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8f71bd1b8fb426d909887c32ad9f3793dbc41446e8ad2e99ff865af52b32217c
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -21,7 +21,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:a9c60e5ed5ddd06253e3126d363d4f6c82c1ef4fc5ea809e21c012ee39d438a5
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:8f71bd1b8fb426d909887c32ad9f3793dbc41446e8ad2e99ff865af52b32217c
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -39,7 +39,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:a9c60e5ed5ddd06253e3126d363d4f6c82c1ef4fc5ea809e21c012ee39d438a5
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:8f71bd1b8fb426d909887c32ad9f3793dbc41446e8ad2e99ff865af52b32217c
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-03-16T12:21:01Z"
+        client.knative.dev/updateTimestamp: "2026-03-16T14:16:45Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:a9c60e5ed5ddd06253e3126d363d4f6c82c1ef4fc5ea809e21c012ee39d438a5
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8f71bd1b8fb426d909887c32ad9f3793dbc41446e8ad2e99ff865af52b32217c
           ports:
             - name: http1
               containerPort: 8181
@@ -519,9 +519,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.564.0-230-g3f0647cc
+              value: v0.564.0-233-ga32df9bf
             - name: TORGHUT_COMMIT
-              value: 3f0647cc2432b6b8e202f164411d84b7db4d77e1
+              value: a32df9bfcc36c2110487a11a4f2815ef228785ab
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-03-16T12:21:01Z"
+        client.knative.dev/updateTimestamp: "2026-03-16T14:16:45Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -26,7 +26,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:a9c60e5ed5ddd06253e3126d363d4f6c82c1ef4fc5ea809e21c012ee39d438a5
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8f71bd1b8fb426d909887c32ad9f3793dbc41446e8ad2e99ff865af52b32217c
           ports:
             - name: http1
               containerPort: 8181
@@ -462,9 +462,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.564.0-230-g3f0647cc
+              value: v0.564.0-233-ga32df9bf
             - name: TORGHUT_COMMIT
-              value: 3f0647cc2432b6b8e202f164411d84b7db4d77e1
+              value: a32df9bfcc36c2110487a11a4f2815ef228785ab
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/lean-runner-deployment.yaml
+++ b/argocd/applications/torghut/lean-runner-deployment.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: lean-runner
           # Keep in lockstep with `argocd/applications/torghut/knative-service.yaml`.
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:a9c60e5ed5ddd06253e3126d363d4f6c82c1ef4fc5ea809e21c012ee39d438a5
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8f71bd1b8fb426d909887c32ad9f3793dbc41446e8ad2e99ff865af52b32217c
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `a32df9bfcc36c2110487a11a4f2815ef228785ab`
- Image tag: `a32df9bf`
- Image digest: `sha256:8f71bd1b8fb426d909887c32ad9f3793dbc41446e8ad2e99ff865af52b32217c`