### PR TITLE
fix(symphony): force issue branches and add python toolchain

### DIFF
--- a/argocd/applications/symphony-jangar/WORKFLOW.md
+++ b/argocd/applications/symphony-jangar/WORKFLOW.md
@@ -33,7 +33,41 @@ hooks:
     else
       git remote set-url origin https://github.com/proompteng/lab.git
     fi
-    git fetch --depth 1 origin main
+    ISSUE_IDENTIFIER="${SYMPHONY_ISSUE_IDENTIFIER:-}"
+    ISSUE_SLUG=""
+    if [ -n "${ISSUE_IDENTIFIER}" ]; then
+      ISSUE_SLUG="$(printf '%s' "${ISSUE_IDENTIFIER}" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9._-]/-/g')"
+    fi
+    CURRENT_BRANCH="$(git branch --show-current || true)"
+    ISSUE_BRANCH="${SYMPHONY_ISSUE_BRANCH_NAME:-}"
+    case "${ISSUE_BRANCH}" in
+      codex/*) ;;
+      *) ISSUE_BRANCH="" ;;
+    esac
+    if [ -n "${ISSUE_SLUG}" ]; then
+      case "${CURRENT_BRANCH}" in
+        "codex/${ISSUE_SLUG}"|"codex/${ISSUE_SLUG}-"*|"codex/${ISSUE_SLUG}/"*)
+          ISSUE_BRANCH="${CURRENT_BRANCH}"
+          ;;
+      esac
+      if [ -z "${ISSUE_BRANCH}" ]; then
+        ISSUE_BRANCH="codex/${ISSUE_SLUG}"
+      fi
+    fi
+    if [ -n "${ISSUE_BRANCH}" ]; then
+      git fetch --depth 1 origin main "${ISSUE_BRANCH}" || git fetch --depth 1 origin main
+      if [ "${CURRENT_BRANCH}" != "${ISSUE_BRANCH}" ]; then
+        if git show-ref --verify --quiet "refs/heads/${ISSUE_BRANCH}"; then
+          git checkout "${ISSUE_BRANCH}"
+        elif git ls-remote --exit-code --heads origin "${ISSUE_BRANCH}" >/dev/null 2>&1; then
+          git checkout -b "${ISSUE_BRANCH}" "origin/${ISSUE_BRANCH}"
+        else
+          git checkout -b "${ISSUE_BRANCH}" origin/main
+        fi
+      fi
+    else
+      git fetch --depth 1 origin main
+    fi
     mkdir -p .codex
   after_run: |
     set -euo pipefail

--- a/argocd/applications/symphony-torghut/WORKFLOW.md
+++ b/argocd/applications/symphony-torghut/WORKFLOW.md
@@ -33,7 +33,41 @@ hooks:
     else
       git remote set-url origin https://github.com/proompteng/lab.git
     fi
-    git fetch --depth 1 origin main
+    ISSUE_IDENTIFIER="${SYMPHONY_ISSUE_IDENTIFIER:-}"
+    ISSUE_SLUG=""
+    if [ -n "${ISSUE_IDENTIFIER}" ]; then
+      ISSUE_SLUG="$(printf '%s' "${ISSUE_IDENTIFIER}" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9._-]/-/g')"
+    fi
+    CURRENT_BRANCH="$(git branch --show-current || true)"
+    ISSUE_BRANCH="${SYMPHONY_ISSUE_BRANCH_NAME:-}"
+    case "${ISSUE_BRANCH}" in
+      codex/*) ;;
+      *) ISSUE_BRANCH="" ;;
+    esac
+    if [ -n "${ISSUE_SLUG}" ]; then
+      case "${CURRENT_BRANCH}" in
+        "codex/${ISSUE_SLUG}"|"codex/${ISSUE_SLUG}-"*|"codex/${ISSUE_SLUG}/"*)
+          ISSUE_BRANCH="${CURRENT_BRANCH}"
+          ;;
+      esac
+      if [ -z "${ISSUE_BRANCH}" ]; then
+        ISSUE_BRANCH="codex/${ISSUE_SLUG}"
+      fi
+    fi
+    if [ -n "${ISSUE_BRANCH}" ]; then
+      git fetch --depth 1 origin main "${ISSUE_BRANCH}" || git fetch --depth 1 origin main
+      if [ "${CURRENT_BRANCH}" != "${ISSUE_BRANCH}" ]; then
+        if git show-ref --verify --quiet "refs/heads/${ISSUE_BRANCH}"; then
+          git checkout "${ISSUE_BRANCH}"
+        elif git ls-remote --exit-code --heads origin "${ISSUE_BRANCH}" >/dev/null 2>&1; then
+          git checkout -b "${ISSUE_BRANCH}" "origin/${ISSUE_BRANCH}"
+        else
+          git checkout -b "${ISSUE_BRANCH}" origin/main
+        fi
+      fi
+    else
+      git fetch --depth 1 origin main
+    fi
     mkdir -p .codex
   after_run: |
     set -euo pipefail

--- a/argocd/applications/symphony/WORKFLOW.md
+++ b/argocd/applications/symphony/WORKFLOW.md
@@ -33,7 +33,41 @@ hooks:
     else
       git remote set-url origin https://github.com/proompteng/lab.git
     fi
-    git fetch --depth 1 origin main
+    ISSUE_IDENTIFIER="${SYMPHONY_ISSUE_IDENTIFIER:-}"
+    ISSUE_SLUG=""
+    if [ -n "${ISSUE_IDENTIFIER}" ]; then
+      ISSUE_SLUG="$(printf '%s' "${ISSUE_IDENTIFIER}" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9._-]/-/g')"
+    fi
+    CURRENT_BRANCH="$(git branch --show-current || true)"
+    ISSUE_BRANCH="${SYMPHONY_ISSUE_BRANCH_NAME:-}"
+    case "${ISSUE_BRANCH}" in
+      codex/*) ;;
+      *) ISSUE_BRANCH="" ;;
+    esac
+    if [ -n "${ISSUE_SLUG}" ]; then
+      case "${CURRENT_BRANCH}" in
+        "codex/${ISSUE_SLUG}"|"codex/${ISSUE_SLUG}-"*|"codex/${ISSUE_SLUG}/"*)
+          ISSUE_BRANCH="${CURRENT_BRANCH}"
+          ;;
+      esac
+      if [ -z "${ISSUE_BRANCH}" ]; then
+        ISSUE_BRANCH="codex/${ISSUE_SLUG}"
+      fi
+    fi
+    if [ -n "${ISSUE_BRANCH}" ]; then
+      git fetch --depth 1 origin main "${ISSUE_BRANCH}" || git fetch --depth 1 origin main
+      if [ "${CURRENT_BRANCH}" != "${ISSUE_BRANCH}" ]; then
+        if git show-ref --verify --quiet "refs/heads/${ISSUE_BRANCH}"; then
+          git checkout "${ISSUE_BRANCH}"
+        elif git ls-remote --exit-code --heads origin "${ISSUE_BRANCH}" >/dev/null 2>&1; then
+          git checkout -b "${ISSUE_BRANCH}" "origin/${ISSUE_BRANCH}"
+        else
+          git checkout -b "${ISSUE_BRANCH}" origin/main
+        fi
+      fi
+    else
+      git fetch --depth 1 origin main
+    fi
     mkdir -p .codex
   after_run: |
     set -euo pipefail

--- a/services/symphony/Dockerfile
+++ b/services/symphony/Dockerfile
@@ -32,7 +32,8 @@ RUN --mount=type=cache,target=/var/cache/apt \
   --mount=type=cache,target=/var/lib/apt/lists \
   set -eux; \
   apt-get update -o Acquire::Retries=3 -o Acquire::http::Timeout=20 -o Acquire::https::Timeout=20; \
-  apt-get install -y --no-install-recommends bash ca-certificates curl gh git jq xz-utils; \
+  apt-get install -y --no-install-recommends bash ca-certificates curl gh git jq python3 python3-pip python3-venv ripgrep xz-utils; \
+  python3 -m pip install --no-cache-dir --break-system-packages uv; \
   rm -rf /var/lib/apt/lists/*
 
 RUN set -eux; \

--- a/services/symphony/src/issue-runner.ts
+++ b/services/symphony/src/issue-runner.ts
@@ -146,7 +146,15 @@ export const makeIssueRunnerLayer = (logger: Logger) =>
                 onToolCall: handleToolCall,
               })
 
-              yield* workspace.runBeforeRun(workspaceInfo.path)
+              const hookContext = {
+                issueId: issue.id,
+                issueIdentifier: issue.identifier,
+                issueBranchName: issue.branchName,
+                issueTitle: issue.title,
+                issueState: issue.state,
+              }
+
+              yield* workspace.runBeforeRun(workspaceInfo.path, hookContext)
 
               const program = Effect.gen(function* () {
                 for (let turnNumber = 1; turnNumber <= config.agent.maxTurns; turnNumber += 1) {
@@ -182,13 +190,21 @@ export const makeIssueRunnerLayer = (logger: Logger) =>
 
               return yield* program.pipe(
                 Effect.ensuring(
-                  workspace.runAfterRun(workspaceInfo.path).pipe(
-                    Effect.catchAll((error) =>
-                      Effect.sync(() => {
-                        runLogger.log('warn', 'workspace_after_run_failed', toLogError(error))
-                      }),
+                  workspace
+                    .runAfterRun(workspaceInfo.path, {
+                      issueId: lastIssue.id,
+                      issueIdentifier: lastIssue.identifier,
+                      issueBranchName: lastIssue.branchName,
+                      issueTitle: lastIssue.title,
+                      issueState: lastIssue.state,
+                    })
+                    .pipe(
+                      Effect.catchAll((error) =>
+                        Effect.sync(() => {
+                          runLogger.log('warn', 'workspace_after_run_failed', toLogError(error))
+                        }),
+                      ),
                     ),
-                  ),
                 ),
               )
             }),

--- a/services/symphony/src/types.ts
+++ b/services/symphony/src/types.ts
@@ -149,6 +149,14 @@ export type WorkspaceInfo = {
   createdNow: boolean
 }
 
+export type WorkspaceHookContext = {
+  issueId?: string | null
+  issueIdentifier?: string | null
+  issueBranchName?: string | null
+  issueTitle?: string | null
+  issueState?: string | null
+}
+
 export type TokenUsageTotals = {
   inputTokens: number
   outputTokens: number

--- a/services/symphony/src/workspace-manager.test.ts
+++ b/services/symphony/src/workspace-manager.test.ts
@@ -21,9 +21,10 @@ const makeConfig = (workspaceRoot: string): SymphonyConfig =>
     },
     hooks: {
       afterCreate: 'echo after_create >> ../hooks.log',
-      beforeRun: 'echo before_run >> ../hooks.log',
-      afterRun: 'echo after_run >> ../hooks.log',
-      beforeRemove: 'echo before_remove >> ../hooks.log',
+      beforeRun:
+        'printf "before_run:%s:%s\\n" "${SYMPHONY_ISSUE_IDENTIFIER:-}" "${SYMPHONY_ISSUE_BRANCH_NAME:-}" >> ../hooks.log',
+      afterRun: 'printf "after_run:%s\\n" "${SYMPHONY_ISSUE_STATE:-}" >> ../hooks.log',
+      beforeRemove: 'printf "before_remove:%s\\n" "${SYMPHONY_ISSUE_IDENTIFIER:-}" >> ../hooks.log',
       timeoutMs: 5_000,
     },
   })
@@ -81,14 +82,25 @@ describe('workspace manager', () => {
       await runtime.runPromise(
         Effect.gen(function* () {
           const manager = yield* WorkspaceService
-          yield* manager.runBeforeRun(second.path)
-          yield* manager.runAfterRun(second.path)
+          yield* manager.runBeforeRun(second.path, {
+            issueIdentifier: 'ABC/123',
+            issueBranchName: 'codex/abc-123',
+            issueState: 'In Progress',
+          })
+          yield* manager.runAfterRun(second.path, {
+            issueState: 'In Progress',
+          })
           yield* manager.removeWorkspace('ABC/123')
         }),
       )
 
       const hookLog = readFileSync(path.join(tempDir, 'hooks.log'), 'utf8').trim().split('\n')
-      expect(hookLog).toEqual(['after_create', 'before_run', 'after_run', 'before_remove'])
+      expect(hookLog).toEqual([
+        'after_create',
+        'before_run:ABC/123:codex/abc-123',
+        'after_run:In Progress',
+        'before_remove:ABC/123',
+      ])
     } finally {
       await runtime.dispose()
     }

--- a/services/symphony/src/workspace-manager.ts
+++ b/services/symphony/src/workspace-manager.ts
@@ -6,12 +6,12 @@ import { Context, Effect, Layer } from 'effect'
 import * as Duration from 'effect/Duration'
 
 import { ConfigError, WorkspaceError, WorkflowError, toLogError } from './errors'
-import type { WorkspaceInfo } from './types'
+import type { WorkspaceHookContext, WorkspaceInfo } from './types'
 import { ensurePathInsideRoot, sanitizeWorkspaceKey, toAbsolutePath } from './utils'
 import { WorkflowService } from './workflow'
 import type { Logger } from './logger'
 
-const PREP_GARBAGE = ['tmp', '.elixir_ls']
+const PREP_GARBAGE = ['tmp', '.elixir_ls', '.bun-tmp']
 const MAX_HOOK_LOG_BYTES = 4_096
 
 const truncateOutput = (value: string): string =>
@@ -29,6 +29,7 @@ export interface ShellServiceDefinition {
       cwd: string
       timeoutMs: number
       hookName: 'after_create' | 'before_run' | 'after_run' | 'before_remove'
+      env?: Record<string, string>
     },
   ) => Effect.Effect<ShellResult, WorkspaceError>
 }
@@ -39,8 +40,14 @@ export interface WorkspaceServiceDefinition {
   readonly createForIssue: (
     identifier: string,
   ) => Effect.Effect<WorkspaceInfo, WorkflowError | ConfigError | WorkspaceError>
-  readonly runBeforeRun: (workspacePath: string) => Effect.Effect<void, WorkflowError | ConfigError | WorkspaceError>
-  readonly runAfterRun: (workspacePath: string) => Effect.Effect<void, WorkflowError | ConfigError | WorkspaceError>
+  readonly runBeforeRun: (
+    workspacePath: string,
+    context?: WorkspaceHookContext,
+  ) => Effect.Effect<void, WorkflowError | ConfigError | WorkspaceError>
+  readonly runAfterRun: (
+    workspacePath: string,
+    context?: WorkspaceHookContext,
+  ) => Effect.Effect<void, WorkflowError | ConfigError | WorkspaceError>
   readonly removeWorkspace: (identifier: string) => Effect.Effect<void, WorkflowError | ConfigError | WorkspaceError>
 }
 
@@ -73,7 +80,10 @@ export const makeShellLayer = (logger: Logger) =>
           Effect.sync(() =>
             spawn('bash', ['-lc', script], {
               cwd: options.cwd,
-              env: process.env,
+              env: {
+                ...process.env,
+                ...options.env,
+              },
               stdio: ['ignore', 'pipe', 'pipe'],
             }),
           ),
@@ -151,6 +161,18 @@ export const makeShellLayer = (logger: Logger) =>
       ),
   })
 
+const buildHookEnv = (context?: WorkspaceHookContext): Record<string, string> => {
+  const env: Record<string, string> = {}
+
+  if (context?.issueId) env.SYMPHONY_ISSUE_ID = context.issueId
+  if (context?.issueIdentifier) env.SYMPHONY_ISSUE_IDENTIFIER = context.issueIdentifier
+  if (context?.issueBranchName) env.SYMPHONY_ISSUE_BRANCH_NAME = context.issueBranchName
+  if (context?.issueTitle) env.SYMPHONY_ISSUE_TITLE = context.issueTitle
+  if (context?.issueState) env.SYMPHONY_ISSUE_STATE = context.issueState
+
+  return env
+}
+
 export const makeWorkspaceLayer = (logger: Logger) =>
   Layer.effect(
     WorkspaceService,
@@ -165,8 +187,9 @@ export const makeWorkspaceLayer = (logger: Logger) =>
         workspacePath: string,
         timeoutMs: number,
         failOnError: boolean,
+        context?: WorkspaceHookContext,
       ) =>
-        shell.run(script, { cwd: workspacePath, timeoutMs, hookName }).pipe(
+        shell.run(script, { cwd: workspacePath, timeoutMs, hookName, env: buildHookEnv(context) }).pipe(
           Effect.tap(() =>
             Effect.sync(() => {
               workspaceLogger.log('info', 'workspace_hook_completed', {
@@ -246,7 +269,9 @@ export const makeWorkspaceLayer = (logger: Logger) =>
             yield* cleanupEphemeralArtifacts(workspacePath)
 
             if (createdNow && config.hooks.afterCreate) {
-              yield* runHook('after_create', config.hooks.afterCreate, workspacePath, config.hooks.timeoutMs, true)
+              yield* runHook('after_create', config.hooks.afterCreate, workspacePath, config.hooks.timeoutMs, true, {
+                issueIdentifier: identifier,
+              })
             }
 
             return {
@@ -255,19 +280,19 @@ export const makeWorkspaceLayer = (logger: Logger) =>
               createdNow,
             }
           }),
-        runBeforeRun: (workspacePath) =>
+        runBeforeRun: (workspacePath, context) =>
           workflow.config.pipe(
             Effect.flatMap((config) =>
               config.hooks.beforeRun
-                ? runHook('before_run', config.hooks.beforeRun, workspacePath, config.hooks.timeoutMs, true)
+                ? runHook('before_run', config.hooks.beforeRun, workspacePath, config.hooks.timeoutMs, true, context)
                 : Effect.void,
             ),
           ),
-        runAfterRun: (workspacePath) =>
+        runAfterRun: (workspacePath, context) =>
           workflow.config.pipe(
             Effect.flatMap((config) =>
               config.hooks.afterRun
-                ? runHook('after_run', config.hooks.afterRun, workspacePath, config.hooks.timeoutMs, false)
+                ? runHook('after_run', config.hooks.afterRun, workspacePath, config.hooks.timeoutMs, false, context)
                 : Effect.void,
             ),
           ),
@@ -310,7 +335,9 @@ export const makeWorkspaceLayer = (logger: Logger) =>
             }
 
             if (config.hooks.beforeRemove) {
-              yield* runHook('before_remove', config.hooks.beforeRemove, workspacePath, config.hooks.timeoutMs, false)
+              yield* runHook('before_remove', config.hooks.beforeRemove, workspacePath, config.hooks.timeoutMs, false, {
+                issueIdentifier: identifier,
+              })
             }
 
             yield* Effect.tryPromise({


### PR DESCRIPTION
## Summary

- pass issue metadata into Symphony workspace hooks so hook scripts can make per-issue decisions
- force each Symphony workspace onto a stable `codex/<ticket>` delivery branch before runs instead of leaving tickets on `main`
- add `python3`, `uv`, and `ripgrep` to the Symphony runtime image so the Torghut lane can validate Python changes in-cluster

## Related Issues

Refs PROOMPT-329
Refs PROOMPT-330

## Testing

- `bun run --cwd services/symphony tsc`
- `bun run --cwd services/symphony test`
- `bun run --cwd services/symphony lint`
- `bun run --cwd services/symphony lint:oxlint:type`
- `scripts/kubeconform.sh argocd/applications/symphony argocd/applications/symphony-jangar argocd/applications/symphony-torghut`
- Verified the new branch-prep logic against live stuck workspaces: `PROOMPT-330` preserves `codex/proompt-330-launchpad` and `PROOMPT-329` resolves to `codex/proompt-329`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
