### PR TITLE
chore(symphony): promote image 971a5d5c

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-16T05:25:41Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-16T16:00:35Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -25,5 +25,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "3553b93e"
-    digest: sha256:e31daa022fe6367a4e481c39951f2b244552c555019f1881013f1484d144edd4
+    newTag: "971a5d5c"
+    digest: sha256:4660c2674310952f85699431d33c7fa17218f4cec8ac175fc6f8a0207cf02783

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-16T05:25:41Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-16T16:00:35Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -26,5 +26,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "3553b93e"
-    digest: sha256:e31daa022fe6367a4e481c39951f2b244552c555019f1881013f1484d144edd4
+    newTag: "971a5d5c"
+    digest: sha256:4660c2674310952f85699431d33c7fa17218f4cec8ac175fc6f8a0207cf02783

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-16T05:25:41Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-16T16:00:35Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -19,5 +19,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "3553b93e"
-    digest: sha256:e31daa022fe6367a4e481c39951f2b244552c555019f1881013f1484d144edd4
+    newTag: "971a5d5c"
+    digest: sha256:4660c2674310952f85699431d33c7fa17218f4cec8ac175fc6f8a0207cf02783


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `971a5d5cc88022464c4309c98661458c2b987caf`
- Image tag: `971a5d5c`
- Image digest: `sha256:4660c2674310952f85699431d33c7fa17218f4cec8ac175fc6f8a0207cf02783`