### PR TITLE
chore(symphony): promote image af739c46

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-16T16:00:35Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-16T16:26:37Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -25,5 +25,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "971a5d5c"
-    digest: sha256:4660c2674310952f85699431d33c7fa17218f4cec8ac175fc6f8a0207cf02783
+    newTag: "af739c46"
+    digest: sha256:a77714e8c5cc71f75ea8833b5b15e358c579bc3e0d858ae94cc0567707c8ad55

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-16T16:00:35Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-16T16:26:37Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -26,5 +26,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "971a5d5c"
-    digest: sha256:4660c2674310952f85699431d33c7fa17218f4cec8ac175fc6f8a0207cf02783
+    newTag: "af739c46"
+    digest: sha256:a77714e8c5cc71f75ea8833b5b15e358c579bc3e0d858ae94cc0567707c8ad55

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-16T16:00:35Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-16T16:26:37Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -19,5 +19,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "971a5d5c"
-    digest: sha256:4660c2674310952f85699431d33c7fa17218f4cec8ac175fc6f8a0207cf02783
+    newTag: "af739c46"
+    digest: sha256:a77714e8c5cc71f75ea8833b5b15e358c579bc3e0d858ae94cc0567707c8ad55


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `af739c463b87a619fc7ddb215fe35cc1c01e12fc`
- Image tag: `af739c46`
- Image digest: `sha256:a77714e8c5cc71f75ea8833b5b15e358c579bc3e0d858ae94cc0567707c8ad55`