### PR TITLE
fix(torghut): stabilize production proof lanes

### DIFF
--- a/docs/torghut/production-readiness-proof-runbook.md
+++ b/docs/torghut/production-readiness-proof-runbook.md
@@ -32,6 +32,10 @@ This runbook is the authoritative operator sequence for a production-readiness s
 
 Run one fresh March 13 full-day replay on the frozen digest.
 
+Replay contract for the proof lane:
+- historical proof manifests must use `ta_restore.mode=stateless`
+- proof reruns must hard-reset TA operator state; resuming prior checkpoint lineage is invalid for readiness signoff
+
 Required outcome:
 - non-zero decisions
 - non-zero executions

--- a/services/jangar/src/server/__tests__/torghut-simulation-control-plane-submit.test.ts
+++ b/services/jangar/src/server/__tests__/torghut-simulation-control-plane-submit.test.ts
@@ -399,9 +399,12 @@ describe('submitTorghutSimulationRun', () => {
   it('preserves the existing ready cache artifact when a run consumes a cache hit', async () => {
     const manifest = {
       dataset_id: 'dataset-a',
+      dataset_snapshot_ref: 'dataset-a@snapshot-1',
       candidate_id: 'intraday_tsmom_v1@prod',
       baseline_candidate_id: 'intraday_tsmom_v1@baseline',
       strategy_spec_ref: 'strategy-specs/intraday_tsmom_v1@1.1.0.json',
+      model_refs: ['rules/intraday_tsmom_v1'],
+      runtime_version_refs: ['services/torghut@sha256:abc'],
       window: {
         start: '2026-03-06T14:30:00Z',
         end: '2026-03-06T14:45:00Z',
@@ -414,12 +417,16 @@ describe('submitTorghutSimulationRun', () => {
     const cacheKey = createHash('sha256')
       .update(
         stableJsonStringifyForHash({
+          schema_version: 'torghut-simulation-cache-v2',
           lane: 'equity',
           dataset_id: manifest.dataset_id,
+          dataset_snapshot_ref: manifest.dataset_snapshot_ref,
           window: manifest.window,
           strategy_spec_ref: manifest.strategy_spec_ref,
           candidate_id: manifest.candidate_id,
           baseline_candidate_id: manifest.baseline_candidate_id,
+          model_refs: manifest.model_refs,
+          runtime_version_refs: manifest.runtime_version_refs,
           dump_format: manifest.performance.dumpFormat,
           profile: 'compact',
         }),
@@ -461,9 +468,12 @@ describe('submitTorghutSimulationRun', () => {
   it('records deterministic durable cache artifact paths on a cache miss', async () => {
     const manifest = {
       dataset_id: 'dataset-b',
+      dataset_snapshot_ref: 'dataset-b@snapshot-2',
       candidate_id: 'intraday_tsmom_v1@prod',
       baseline_candidate_id: 'intraday_tsmom_v1@baseline',
       strategy_spec_ref: 'strategy-specs/intraday_tsmom_v1@1.1.0.json',
+      model_refs: ['rules/intraday_tsmom_v1'],
+      runtime_version_refs: ['services/torghut@sha256:def'],
       window: {
         start: '2026-03-13T13:30:00Z',
         end: '2026-03-13T20:00:00Z',
@@ -476,12 +486,16 @@ describe('submitTorghutSimulationRun', () => {
     const cacheKey = createHash('sha256')
       .update(
         stableJsonStringifyForHash({
+          schema_version: 'torghut-simulation-cache-v2',
           lane: 'equity',
           dataset_id: manifest.dataset_id,
+          dataset_snapshot_ref: manifest.dataset_snapshot_ref,
           window: manifest.window,
           strategy_spec_ref: manifest.strategy_spec_ref,
           candidate_id: manifest.candidate_id,
           baseline_candidate_id: manifest.baseline_candidate_id,
+          model_refs: manifest.model_refs,
+          runtime_version_refs: manifest.runtime_version_refs,
           dump_format: manifest.performance.dumpFormat,
           profile: 'compact',
         }),

--- a/services/jangar/src/server/__tests__/torghut-simulation-control-plane.test.ts
+++ b/services/jangar/src/server/__tests__/torghut-simulation-control-plane.test.ts
@@ -86,6 +86,29 @@ describe('torghut simulation control plane', () => {
     })
   })
 
+  it('defaults full-day proofs to stateless TA recovery', () => {
+    const manifest = __private.normalizeSimulationManifest(
+      {
+        dataset_id: 'dataset-a',
+        window: {
+          start: '2026-03-13T13:30:00Z',
+          end: '2026-03-13T20:00:00Z',
+        },
+      },
+      {
+        runId: 'sim-demo-full-day',
+        outputRoot: '/tmp/torghut-sim',
+        cachePolicy: 'refresh',
+        profile: 'full_day',
+      },
+    )
+
+    expect(manifest.performance).toMatchObject({
+      replayProfile: 'full_day',
+    })
+    expect(manifest.ta_restore).toMatchObject({ mode: 'stateless' })
+  })
+
   it('derives isolated simulation databases when warm lanes are disabled', () => {
     const manifest = __private.normalizeSimulationManifest(
       {
@@ -157,10 +180,13 @@ describe('torghut simulation control plane', () => {
   it('builds stable cache keys and manifest digests regardless of object key order', () => {
     const manifestA = {
       dataset_id: 'dataset-a',
+      dataset_snapshot_ref: 'dataset-a@snapshot-1',
       lane: 'equity',
       candidate_id: 'candidate-a',
       baseline_candidate_id: 'baseline-a',
       strategy_spec_ref: 'strategy-specs/intraday_tsmom_v1@1.1.0.json',
+      model_refs: ['rules/intraday_tsmom_v1', 'rules/risk-v1'],
+      runtime_version_refs: ['services/torghut@sha256:abc', 'services/torghut-forecast@sha256:def'],
       performance: {
         dumpFormat: 'jsonl.zst',
       },
@@ -177,10 +203,13 @@ describe('torghut simulation control plane', () => {
       performance: {
         dumpFormat: 'jsonl.zst',
       },
+      runtime_version_refs: ['services/torghut@sha256:abc', 'services/torghut-forecast@sha256:def'],
+      model_refs: ['rules/intraday_tsmom_v1', 'rules/risk-v1'],
       strategy_spec_ref: 'strategy-specs/intraday_tsmom_v1@1.1.0.json',
       baseline_candidate_id: 'baseline-a',
       candidate_id: 'candidate-a',
       lane: 'equity',
+      dataset_snapshot_ref: 'dataset-a@snapshot-1',
       dataset_id: 'dataset-a',
     }
 

--- a/services/jangar/src/server/torghut-simulation-control-plane.ts
+++ b/services/jangar/src/server/torghut-simulation-control-plane.ts
@@ -235,9 +235,9 @@ const INTERACTIVE_LANES = ['sim-fast-1'] as const
 const BATCH_LANES = ['sim-fast-1'] as const
 const CONTROL_PLANE_LEASE_OWNER = 'jangar-control-plane'
 const PROGRESS_FETCH_TIMEOUT_MS = 2_500
+const SIMULATION_CACHE_KEY_SCHEMA_VERSION = 'torghut-simulation-cache-v2'
 
-const defaultTaRestoreMode = (profile: string) =>
-  profile.trim().toLowerCase() === 'full_day' ? 'required' : 'stateless'
+const defaultTaRestoreMode = (_profile: string) => 'stateless'
 
 const resolveRunClass = (profile: string, priority: string) => {
   const normalizedProfile = profile.trim().toLowerCase()
@@ -264,16 +264,29 @@ const resolveSimulationWorkflowNamespace = (manifest: JsonRecord) => {
   return asString(runtime.workflow_namespace) ?? DEFAULT_WORKFLOW_NAMESPACE
 }
 
+const stableStringList = (value: unknown) =>
+  [
+    ...new Set(
+      asArray(value)
+        .map((item) => asString(item)?.trim())
+        .filter((item): item is string => Boolean(item)),
+    ),
+  ].sort()
+
 const buildSimulationCacheKey = (manifest: JsonRecord, profile: string) =>
   createHash('sha256')
     .update(
       stableJsonStringifyForHash({
+        schema_version: SIMULATION_CACHE_KEY_SCHEMA_VERSION,
         lane: asString(manifest.lane) ?? 'equity',
         dataset_id: asString(manifest.dataset_id),
+        dataset_snapshot_ref: asString(manifest.dataset_snapshot_ref) ?? asString(manifest.dataset_id),
         window: asRecord(manifest.window),
         strategy_spec_ref: asString(manifest.strategy_spec_ref),
         candidate_id: asString(manifest.candidate_id),
         baseline_candidate_id: asString(manifest.baseline_candidate_id),
+        model_refs: stableStringList(manifest.model_refs),
+        runtime_version_refs: stableStringList(manifest.runtime_version_refs),
         dump_format: asString(asRecord(manifest.performance).dumpFormat) ?? DEFAULT_DUMP_FORMAT,
         profile,
       }),

--- a/services/torghut/app/trading/feature_quality.py
+++ b/services/torghut/app/trading/feature_quality.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from statistics import quantiles
 
 from .features import (
+    FEATURE_SCHEMA_VERSION_V3,
     FEATURE_VECTOR_V3_REQUIRED_FIELDS,
     map_feature_values_v3,
     signal_declares_compatible_schema,
@@ -83,14 +84,14 @@ class FeatureQualityError(RuntimeError):
 class _FeatureQualityScan:
     null_counts: dict[str, int]
     malformed_staleness_count: int = 0
-    seen_keys: set[tuple[datetime, str, int]] = dataclass_field(
-        default_factory=lambda: set[tuple[datetime, str, int]]()
+    seen_keys: set[tuple[datetime, str, str, int, str, str]] = dataclass_field(
+        default_factory=lambda: set[tuple[datetime, str, str, int, str, str]]()
     )
     duplicate_total: int = 0
     schema_mismatch_total: int = 0
     staleness_values: list[int] = dataclass_field(default_factory=lambda: list[int]())
     non_monotonic_detected: bool = False
-    previous_key: tuple[datetime, str, int] | None = None
+    previous_key: tuple[datetime, str, str, int, str, str] | None = None
 
 
 def evaluate_feature_batch_quality(
@@ -165,7 +166,7 @@ def _scan_feature_batch(signals: list[SignalEnvelope]) -> _FeatureQualityScan:
         else:
             scan.staleness_values.append(staleness)
 
-        key = (signal.event_ts, signal.symbol, signal.seq or 0)
+        key = _quality_identity_key(signal)
         if key in scan.seen_keys:
             scan.duplicate_total += 1
         else:
@@ -247,6 +248,26 @@ def _coerce_staleness_ms(value: object) -> int | None:
         except ValueError:
             return None
     return None
+
+
+def _quality_identity_key(
+    signal: SignalEnvelope,
+) -> tuple[datetime, str, str, int, str, str]:
+    payload = signal.payload or {}
+    declared_schema = payload.get('feature_schema_version')
+    schema_version = (
+        str(declared_schema).strip()
+        if declared_schema not in (None, '')
+        else FEATURE_SCHEMA_VERSION_V3
+    )
+    return (
+        signal.event_ts,
+        signal.symbol,
+        signal.timeframe or '1Min',
+        signal.seq or 0,
+        signal.source or 'unknown',
+        schema_version,
+    )
 
 
 __all__ = [

--- a/services/torghut/app/trading/ingest.py
+++ b/services/torghut/app/trading/ingest.py
@@ -19,6 +19,7 @@ from ..models import TradeCursor
 from .clickhouse import normalize_symbol, to_datetime64
 from .models import SignalEnvelope
 from .simulation import resolve_simulation_context, signal_ingest_runtime, simulation_context_enabled
+from .simulation_progress import active_simulation_runtime_context
 from .simulation_window import normalize_simulation_cursor, simulation_window_bounds
 from .time_source import trading_now
 
@@ -820,11 +821,11 @@ class ClickHouseSignalIngestor:
         if self.schema == "flat" or len(signals) < 2:
             return signals
 
-        deduped_by_key: dict[tuple[datetime, str, str | None], SignalEnvelope] = {}
+        deduped_by_key: dict[tuple[datetime, str, str | None, tuple[Any, ...], str], SignalEnvelope] = {}
         for signal in signals:
             key = _signal_identity(signal)
             current = deduped_by_key.get(key)
-            if current is None or _prefer_earlier_ingest_signal(candidate=signal, current=current):
+            if current is None or _prefer_preferred_signal(candidate=signal, current=current):
                 deduped_by_key[key] = signal
         if len(deduped_by_key) == len(signals):
             return signals
@@ -1331,11 +1332,15 @@ def _next_signal_cursor_state(
     return max_event_ts, max_seq, max_symbol
 
 
-def _signal_identity(signal: SignalEnvelope) -> tuple[datetime, str, str | None]:
+def _signal_identity(
+    signal: SignalEnvelope,
+) -> tuple[datetime, str, str | None, tuple[Any, ...], str]:
     return (
         signal.event_ts.astimezone(timezone.utc),
         signal.symbol,
         signal.timeframe,
+        _signal_provenance_key(signal),
+        _signal_payload_fingerprint(signal),
     )
 
 
@@ -1349,14 +1354,80 @@ def _signal_sort_key(signal: SignalEnvelope) -> tuple[datetime, str, str, int, s
     )
 
 
-def _prefer_earlier_ingest_signal(*, candidate: SignalEnvelope, current: SignalEnvelope) -> bool:
-    current_ingest = current.ingest_ts.astimezone(timezone.utc) if current.ingest_ts is not None else None
-    candidate_ingest = candidate.ingest_ts.astimezone(timezone.utc) if candidate.ingest_ts is not None else None
-    if current_ingest is None:
-        return candidate_ingest is not None
-    if candidate_ingest is None:
+def _prefer_preferred_signal(*, candidate: SignalEnvelope, current: SignalEnvelope) -> bool:
+    return _signal_preference_key(candidate) > _signal_preference_key(current)
+
+
+def _signal_preference_key(signal: SignalEnvelope) -> tuple[int, int, int, str, int, str]:
+    return (
+        1 if _signal_matches_active_simulation_run(signal) else 0,
+        _signal_provenance_completeness(signal),
+        len(_signal_payload_fingerprint(signal)),
+        _signal_payload_context_fingerprint(signal),
+        _coerce_seq(signal.seq) or -1,
+        signal.source or '',
+    )
+
+
+def _signal_matches_active_simulation_run(signal: SignalEnvelope) -> bool:
+    context = _signal_simulation_context(signal)
+    signal_run_id = str(context.get('simulation_run_id') or '').strip()
+    if not signal_run_id:
         return False
-    return candidate_ingest < current_ingest
+    runtime_context = active_simulation_runtime_context()
+    active_run_id = str(
+        (runtime_context or {}).get('run_id') or settings.trading_simulation_run_id or ''
+    ).strip()
+    if not active_run_id:
+        return False
+    return signal_run_id == active_run_id
+
+
+def _signal_provenance_completeness(signal: SignalEnvelope) -> int:
+    context = _signal_simulation_context(signal)
+    values: tuple[Any, ...] = (
+        context.get('dataset_event_id'),
+        context.get('source_topic'),
+        context.get('source_partition'),
+        context.get('source_offset'),
+        context.get('replay_topic'),
+        context.get('signal_seq'),
+        signal.seq,
+        signal.source,
+    )
+    return sum(1 for value in values if value not in (None, '', -1))
+
+
+def _signal_provenance_key(signal: SignalEnvelope) -> tuple[Any, ...]:
+    context = _signal_simulation_context(signal)
+    return (
+        str(context.get('dataset_event_id') or ''),
+        str(context.get('source_topic') or ''),
+        _coerce_seq(context.get('source_partition')) or -1,
+        _coerce_seq(context.get('source_offset')) or -1,
+        str(context.get('replay_topic') or ''),
+        _coerce_seq(context.get('signal_seq')) or _coerce_seq(signal.seq) or -1,
+        signal.source or '',
+    )
+
+
+def _signal_payload_fingerprint(signal: SignalEnvelope) -> str:
+    payload = dict(signal.payload)
+    payload.pop('simulation_context', None)
+    return json.dumps(payload, sort_keys=True, separators=(',', ':'), default=str)
+
+
+def _signal_payload_context_fingerprint(signal: SignalEnvelope) -> str:
+    context = dict(_signal_simulation_context(signal))
+    context.pop('simulation_run_id', None)
+    return json.dumps(context, sort_keys=True, separators=(',', ':'), default=str)
+
+
+def _signal_simulation_context(signal: SignalEnvelope) -> dict[str, Any]:
+    raw_context = signal.payload.get('simulation_context')
+    if isinstance(raw_context, Mapping):
+        return {str(key): value for key, value in cast(Mapping[object, Any], raw_context).items()}
+    return {}
 
 
 def _coerce_seq(value: Any) -> Optional[int]:

--- a/services/torghut/app/trading/ingest.py
+++ b/services/torghut/app/trading/ingest.py
@@ -236,13 +236,13 @@ class ClickHouseSignalIngestor:
             )
 
         time_column = _safe_identifier(self._resolve_time_column(), kind='column')
-        query = self._build_replay_query(
+        query = self._build_simulation_query(
             start=query_window_start,
             end=query_window_end,
-            normalized_symbol=None,
-            limit=None,
+            cursor_at=cursor_at,
+            cursor_seq=cursor_seq,
+            cursor_symbol=cursor_symbol,
             time_column=time_column,
-            ordered=False,
         )
         rows = self._query_clickhouse(query)
         signals = self._signals_from_rows(rows)
@@ -580,6 +580,73 @@ class ClickHouseSignalIngestor:
             query_parts.extend(['LIMIT', str(max(int(limit), 1))])
         query_parts.append('FORMAT JSONEachRow')
         return ' '.join(query_parts)
+
+    def _build_simulation_query(
+        self,
+        *,
+        start: datetime,
+        end: datetime,
+        cursor_at: datetime,
+        cursor_seq: Optional[int],
+        cursor_symbol: Optional[str],
+        time_column: str,
+    ) -> str:
+        cursor_expr = to_datetime64(cursor_at)
+        where_parts = [
+            f'{time_column} >= {to_datetime64(start)}',
+            f'{time_column} <= {to_datetime64(end)}',
+        ]
+        supports_seq = self._supports_seq_for_time_column(time_column)
+        if supports_seq:
+            if cursor_seq is not None or cursor_symbol is not None:
+                symbol_clause = ''
+                if cursor_symbol is not None:
+                    symbol_literal = _quote_literal(cursor_symbol)
+                    if cursor_seq is not None:
+                        symbol_clause = (
+                            f'(symbol > {symbol_literal} OR '
+                            f'(symbol = {symbol_literal} AND seq > {cursor_seq}))'
+                        )
+                    else:
+                        symbol_clause = f'symbol > {symbol_literal}'
+                else:
+                    symbol_clause = f'seq > {cursor_seq}'
+                where_parts.append(
+                    f'({time_column} > {cursor_expr} OR '
+                    f'({time_column} = {cursor_expr} AND {symbol_clause}))'
+                )
+            else:
+                where_parts.append(f'{time_column} >= {cursor_expr}')
+        elif cursor_symbol is not None:
+            symbol_literal = _quote_literal(cursor_symbol)
+            where_parts.append(
+                f'({time_column} > {cursor_expr} OR '
+                f'({time_column} = {cursor_expr} AND symbol > {symbol_literal}))'
+            )
+        else:
+            where_parts.append(f'{time_column} >= {cursor_expr}')
+
+        order_clause = f'{time_column} ASC'
+        if supports_seq:
+            order_clause = f'{time_column} ASC, symbol ASC, seq ASC'
+        elif time_column == 'ts':
+            order_clause = f'{time_column} ASC, symbol ASC'
+
+        return ' '.join(
+            [
+                'SELECT',
+                self._select_expression(time_column),
+                'FROM',
+                self.table,
+                'WHERE',
+                ' AND '.join(where_parts),
+                'ORDER BY',
+                order_clause,
+                'LIMIT',
+                str(max(int(self.batch_size), 1)),
+                'FORMAT JSONEachRow',
+            ]
+        )
 
     def _signals_from_rows(self, rows: list[dict[str, Any]]) -> list[SignalEnvelope]:
         signals: list[SignalEnvelope] = []

--- a/services/torghut/app/trading/ingest.py
+++ b/services/torghut/app/trading/ingest.py
@@ -818,7 +818,7 @@ class ClickHouseSignalIngestor:
         return self._sorted_signals(self._filter_signals(self._dedupe_signals(signals)))
 
     def _dedupe_signals(self, signals: list[SignalEnvelope]) -> list[SignalEnvelope]:
-        if self.schema == "flat" or len(signals) < 2:
+        if len(signals) < 2:
             return signals
 
         deduped_by_key: dict[tuple[datetime, str, str | None, tuple[Any, ...], str], SignalEnvelope] = {}

--- a/services/torghut/scripts/build_historical_profitability_proof.py
+++ b/services/torghut/scripts/build_historical_profitability_proof.py
@@ -1,0 +1,710 @@
+#!/usr/bin/env python3
+"""Build profitability proof artifacts from historical simulation run directories."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from decimal import Decimal
+from pathlib import Path
+from typing import Any, Mapping
+
+import yaml
+
+from app.trading.evaluation import (
+    build_profitability_evidence_v4,
+    execute_profitability_benchmark_v4,
+    validate_profitability_evidence_v4,
+)
+
+_SERVICE_ROOT = Path(__file__).resolve().parent.parent
+_PROFITABILITY_PROOF_SCHEMA_VERSION = 'torghut.historical-profitability-proof.v1'
+_DEFAULT_BASELINE_ID = 'cash-flat@baseline'
+
+
+@dataclass(frozen=True)
+class HistoricalRunSummary:
+    run_id: str
+    run_dir: Path
+    trading_day: str
+    candidate_id: str
+    baseline_candidate_id: str
+    strategy_spec_ref: str
+    model_refs: list[str]
+    runtime_version_refs: list[str]
+    net_pnl: Decimal
+    max_drawdown: Decimal
+    cost_bps: Decimal
+    trade_count: int
+    decision_count: int
+    execution_notional_total: Decimal
+    estimated_cost_total: Decimal
+    confidence_value: Decimal
+    verdict_status: str
+    signal_hash: str
+    strategy_config_hash: str
+    gate_policy_hash: str
+    simulation_report_path: Path
+    replay_report_path: Path | None
+    trade_pnl_csv_path: Path | None
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description='Build profitability proof artifacts from historical Torghut simulation outputs.',
+    )
+    parser.add_argument('--run-dir', action='append', required=True, help='Historical simulation run directory.')
+    parser.add_argument(
+        '--baseline-run-dir',
+        action='append',
+        default=[],
+        help='Optional baseline historical simulation run directory.',
+    )
+    parser.add_argument('--output-dir', required=True, help='Directory for generated proof artifacts.')
+    parser.add_argument('--hypothesis', default='', help='Explicit hypothesis text for the proof manifest.')
+    parser.add_argument('--baseline-id', default='', help='Optional baseline identifier override.')
+    parser.add_argument('--json', action='store_true')
+    return parser.parse_args()
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding='utf-8'))
+    if not isinstance(payload, Mapping):
+        raise RuntimeError(f'json_mapping_required:{path}')
+    return {str(key): value for key, value in payload.items()}
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    payload = yaml.safe_load(path.read_text(encoding='utf-8'))
+    if not isinstance(payload, Mapping):
+        raise RuntimeError(f'yaml_mapping_required:{path}')
+    return {str(key): value for key, value in payload.items()}
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return {str(key): item for key, item in value.items()} if isinstance(value, Mapping) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    return list(value) if isinstance(value, list) else []
+
+
+def _as_text(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _as_decimal(value: Any) -> Decimal:
+    try:
+        return Decimal(str(value))
+    except Exception:
+        return Decimal('0')
+
+
+def _as_int(value: Any) -> int:
+    try:
+        return int(value)
+    except Exception:
+        return 0
+
+
+def _clamp_confidence(value: Decimal) -> Decimal:
+    if value < 0:
+        return Decimal('0')
+    if value > 1:
+        return Decimal('1')
+    return value
+
+
+def _sha256_bytes(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _sha256_json(payload: Mapping[str, Any]) -> str:
+    return _sha256_bytes(
+        json.dumps(payload, indent=2, sort_keys=True, default=str).encode('utf-8')
+    )
+
+
+def _stable_hash_payload(payload: Any) -> str:
+    return _sha256_bytes(
+        json.dumps(payload, sort_keys=True, separators=(',', ':'), default=str).encode('utf-8')
+    )
+
+
+def _resolve_manifest_path(run_dir: Path, report: Mapping[str, Any]) -> Path | None:
+    run_metadata = _as_dict(report.get('run_metadata'))
+    raw = _as_text(run_metadata.get('manifest_path'))
+    if raw is None:
+        return None
+    candidate = Path(raw)
+    if candidate.is_absolute() and candidate.exists():
+        return candidate
+    for resolved in (_SERVICE_ROOT / raw, run_dir / raw, Path.cwd() / raw):
+        if resolved.exists():
+            return resolved
+    return None
+
+
+def _load_source_manifest(run_dir: Path, report: Mapping[str, Any]) -> tuple[dict[str, Any], Path | None]:
+    path = _resolve_manifest_path(run_dir, report)
+    if path is None:
+        return {}, None
+    if path.suffix.lower() in {'.yaml', '.yml'}:
+        return _load_yaml(path), path
+    return _load_json(path), path
+
+
+def _lineage_text(
+    *,
+    key: str,
+    run_manifest: Mapping[str, Any],
+    source_manifest: Mapping[str, Any],
+) -> str | None:
+    lineage = _as_dict(run_manifest.get('evidence_lineage'))
+    return _as_text(lineage.get(key)) or _as_text(source_manifest.get(key))
+
+
+def _lineage_list(
+    *,
+    key: str,
+    run_manifest: Mapping[str, Any],
+    source_manifest: Mapping[str, Any],
+) -> list[str]:
+    lineage = _as_dict(run_manifest.get('evidence_lineage'))
+    raw = lineage.get(key)
+    if isinstance(raw, list):
+        return [text for item in raw if (text := _as_text(item))]
+    source_raw = source_manifest.get(key)
+    if isinstance(source_raw, list):
+        return [text for item in source_raw if (text := _as_text(item))]
+    return []
+
+
+def _load_trade_contributions(path: Path | None) -> list[Decimal]:
+    if path is None or not path.exists():
+        return []
+    contributions: list[Decimal] = []
+    with path.open(newline='', encoding='utf-8') as handle:
+        reader = csv.DictReader(handle)
+        rows = sorted(reader, key=lambda row: str(row.get('created_at') or ''))
+        for row in rows:
+            contributions.append(_as_decimal(row.get('realized_pnl_contribution')))
+    return contributions
+
+
+def _estimate_day_drawdown(*, net_pnl: Decimal, trade_pnl_csv_path: Path | None) -> Decimal:
+    equity = Decimal('0')
+    peak = Decimal('0')
+    max_drawdown = Decimal('0')
+    realized_total = Decimal('0')
+    for contribution in _load_trade_contributions(trade_pnl_csv_path):
+        realized_total += contribution
+        equity += contribution
+        if equity > peak:
+            peak = equity
+        drawdown = peak - equity
+        if drawdown > max_drawdown:
+            max_drawdown = drawdown
+    residual = net_pnl - realized_total
+    equity += residual
+    if equity > peak:
+        peak = equity
+    drawdown = peak - equity
+    if drawdown > max_drawdown:
+        max_drawdown = drawdown
+    if max_drawdown == 0 and net_pnl < 0:
+        return abs(net_pnl)
+    return max_drawdown
+
+
+def _best_signal_hash(run_dir: Path, replay_report: Mapping[str, Any]) -> str:
+    replay_hash = _as_text(replay_report.get('dump_sha256'))
+    if replay_hash:
+        return replay_hash
+    dump_manifest_path = run_dir / 'source-dump.jsonl.zst.manifest.json'
+    if dump_manifest_path.exists():
+        dump_manifest = _load_json(dump_manifest_path)
+        chunks = _as_list(dump_manifest.get('chunks'))
+        chunk_hashes = [
+            _as_text(_as_dict(item).get('payload_sha256')) or _as_text(_as_dict(item).get('sha256')) or ''
+            for item in chunks
+        ]
+        normalized = [item for item in chunk_hashes if item]
+        if normalized:
+            return _stable_hash_payload(normalized)
+        return _sha256_bytes(dump_manifest_path.read_bytes())
+    source_dump_path = run_dir / 'source-dump.jsonl.zst'
+    if source_dump_path.exists():
+        return _sha256_bytes(source_dump_path.read_bytes())
+    raise RuntimeError(f'signal_hash_missing:{run_dir}')
+
+
+def _load_run_summary(run_dir: Path) -> HistoricalRunSummary:
+    run_manifest_path = run_dir / 'run-manifest.json'
+    simulation_report_path = run_dir / 'report' / 'simulation-report.json'
+    replay_report_path = run_dir / 'replay-report.json'
+    trade_pnl_csv_path = run_dir / 'report' / 'trade-pnl.csv'
+
+    run_manifest = _load_json(run_manifest_path)
+    report = _load_json(simulation_report_path)
+    replay_report = _load_json(replay_report_path) if replay_report_path.exists() else {}
+    source_manifest, source_manifest_path = _load_source_manifest(run_dir, report)
+
+    candidate_id = _lineage_text(
+        key='candidate_id',
+        run_manifest=run_manifest,
+        source_manifest=source_manifest,
+    )
+    if candidate_id is None:
+        raise RuntimeError(f'candidate_id_missing:{run_dir}')
+    baseline_candidate_id = _lineage_text(
+        key='baseline_candidate_id',
+        run_manifest=run_manifest,
+        source_manifest=source_manifest,
+    ) or _DEFAULT_BASELINE_ID
+    strategy_spec_ref = _lineage_text(
+        key='strategy_spec_ref',
+        run_manifest=run_manifest,
+        source_manifest=source_manifest,
+    )
+    if strategy_spec_ref is None:
+        raise RuntimeError(f'strategy_spec_ref_missing:{run_dir}')
+    model_refs = _lineage_list(
+        key='model_refs',
+        run_manifest=run_manifest,
+        source_manifest=source_manifest,
+    )
+    runtime_version_refs = _lineage_list(
+        key='runtime_version_refs',
+        run_manifest=run_manifest,
+        source_manifest=source_manifest,
+    )
+    if not model_refs or not runtime_version_refs:
+        raise RuntimeError(f'evidence_lineage_incomplete:{run_dir}')
+
+    coverage = _as_dict(report.get('coverage'))
+    trading_day = (
+        _as_text(_as_dict(source_manifest.get('window')).get('trading_day'))
+        or _as_text(coverage.get('window_start'),)
+    )
+    if trading_day is None:
+        raise RuntimeError(f'trading_day_missing:{run_dir}')
+    if 'T' in trading_day:
+        trading_day = trading_day.split('T', 1)[0]
+
+    funnel = _as_dict(report.get('funnel'))
+    pnl = _as_dict(report.get('pnl'))
+    llm = _as_dict(report.get('llm'))
+    verdict = (_as_text(_as_dict(report.get('verdict')).get('status')) or 'FAIL').upper()
+    if verdict == 'FAIL':
+        raise RuntimeError(f'simulation_report_failed:{run_dir}')
+
+    net_pnl = _as_decimal(
+        pnl.get('net_pnl_estimated')
+        or pnl.get('gross_pnl')
+        or pnl.get('realized_pnl')
+        or '0'
+    )
+    execution_notional_total = _as_decimal(pnl.get('execution_notional_total'))
+    estimated_cost_total = _as_decimal(pnl.get('estimated_cost_total'))
+    cost_bps = Decimal('0')
+    if execution_notional_total > 0:
+        cost_bps = (estimated_cost_total / execution_notional_total) * Decimal('10000')
+
+    raw_confidence = _as_text(llm.get('avg_confidence'))
+    confidence_value = (
+        _clamp_confidence(_as_decimal(raw_confidence))
+        if raw_confidence is not None
+        else Decimal('1') if net_pnl > 0 else Decimal('0')
+    )
+
+    signal_hash = _best_signal_hash(run_dir, replay_report)
+    strategy_config_hash = (
+        _sha256_bytes(source_manifest_path.read_bytes())
+        if source_manifest_path is not None
+        else _sha256_bytes(strategy_spec_ref.encode('utf-8'))
+    )
+    gate_policy_hash = _stable_hash_payload(
+        {
+            'monitor': _as_dict(source_manifest.get('monitor')),
+            'window': _as_dict(source_manifest.get('window')),
+            'report_window': coverage,
+        }
+    )
+
+    return HistoricalRunSummary(
+        run_id=_as_text(run_manifest.get('run_id')) or run_dir.name,
+        run_dir=run_dir,
+        trading_day=trading_day,
+        candidate_id=candidate_id,
+        baseline_candidate_id=baseline_candidate_id,
+        strategy_spec_ref=strategy_spec_ref,
+        model_refs=model_refs,
+        runtime_version_refs=runtime_version_refs,
+        net_pnl=net_pnl,
+        max_drawdown=_estimate_day_drawdown(net_pnl=net_pnl, trade_pnl_csv_path=trade_pnl_csv_path),
+        cost_bps=cost_bps,
+        trade_count=_as_int(funnel.get('executions')),
+        decision_count=_as_int(funnel.get('trade_decisions')),
+        execution_notional_total=execution_notional_total,
+        estimated_cost_total=estimated_cost_total,
+        confidence_value=confidence_value,
+        verdict_status=verdict,
+        signal_hash=signal_hash,
+        strategy_config_hash=strategy_config_hash,
+        gate_policy_hash=gate_policy_hash,
+        simulation_report_path=simulation_report_path,
+        replay_report_path=replay_report_path if replay_report_path.exists() else None,
+        trade_pnl_csv_path=trade_pnl_csv_path if trade_pnl_csv_path.exists() else None,
+    )
+
+
+def _require_consistent_lineage(run_summaries: list[HistoricalRunSummary], *, label: str) -> None:
+    if not run_summaries:
+        raise RuntimeError(f'{label}_run_set_empty')
+    trading_days = [item.trading_day for item in run_summaries]
+    if len(set(trading_days)) != len(trading_days):
+        raise RuntimeError(f'{label}_trading_day_duplicate')
+    candidate_ids = {item.candidate_id for item in run_summaries}
+    if len(candidate_ids) != 1:
+        raise RuntimeError(f'{label}_candidate_id_mismatch')
+    strategy_specs = {item.strategy_spec_ref for item in run_summaries}
+    if len(strategy_specs) != 1:
+        raise RuntimeError(f'{label}_strategy_spec_mismatch')
+    model_refs = {tuple(item.model_refs) for item in run_summaries}
+    if len(model_refs) != 1:
+        raise RuntimeError(f'{label}_model_refs_mismatch')
+    runtime_refs = {tuple(item.runtime_version_refs) for item in run_summaries}
+    if len(runtime_refs) != 1:
+        raise RuntimeError(f'{label}_runtime_refs_mismatch')
+
+
+def _window_max_drawdown(run_summaries: list[HistoricalRunSummary]) -> Decimal:
+    equity = Decimal('0')
+    peak = Decimal('0')
+    max_drawdown = Decimal('0')
+    for item in sorted(run_summaries, key=lambda value: value.trading_day):
+        equity += item.net_pnl
+        if equity > peak:
+            peak = equity
+        drawdown = peak - equity
+        if drawdown > max_drawdown:
+            max_drawdown = drawdown
+    return max_drawdown
+
+
+def _build_report_payload(run_summaries: list[HistoricalRunSummary]) -> dict[str, object]:
+    ordered = sorted(run_summaries, key=lambda value: value.trading_day)
+    total_net = sum((item.net_pnl for item in ordered), Decimal('0'))
+    total_notional = sum((item.execution_notional_total for item in ordered), Decimal('0'))
+    total_cost = sum((item.estimated_cost_total for item in ordered), Decimal('0'))
+    total_trades = sum(item.trade_count for item in ordered)
+    total_decisions = sum(item.decision_count for item in ordered)
+    market_cost_bps = (
+        (total_cost / total_notional) * Decimal('10000')
+        if total_notional > 0
+        else Decimal('0')
+    )
+    folds = [
+        {
+            'fold_name': item.trading_day,
+            'trade_count': item.trade_count,
+            'net_pnl': str(item.net_pnl),
+            'max_drawdown': str(item.max_drawdown),
+            'cost_bps': str(item.cost_bps),
+            'turnover_ratio': '0',
+            'regime_label': item.trading_day,
+        }
+        for item in ordered
+    ]
+    return {
+        'metrics': {
+            'net_pnl': str(total_net),
+            'max_drawdown': str(_window_max_drawdown(ordered)),
+            'cost_bps': str(market_cost_bps),
+            'trade_count': total_trades,
+            'decision_count': total_decisions,
+            'turnover_ratio': '0',
+        },
+        'robustness': {
+            'folds': folds,
+        },
+        'impact_assumptions': {
+            'decisions_with_spread': total_decisions,
+            'decisions_with_volatility': total_decisions,
+            'decisions_with_adv': total_decisions,
+            'assumptions': {
+                'recorded_inputs_count': str(total_decisions),
+                'fallback_inputs_count': '0',
+            },
+        },
+    }
+
+
+def _build_zero_baseline_payload(trading_days: list[str]) -> dict[str, object]:
+    return {
+        'metrics': {
+            'net_pnl': '0',
+            'max_drawdown': '0',
+            'cost_bps': '0',
+            'trade_count': 0,
+            'decision_count': 0,
+            'turnover_ratio': '0',
+        },
+        'robustness': {
+            'folds': [
+                {
+                    'fold_name': trading_day,
+                    'trade_count': 0,
+                    'net_pnl': '0',
+                    'max_drawdown': '0',
+                    'cost_bps': '0',
+                    'turnover_ratio': '0',
+                    'regime_label': trading_day,
+                }
+                for trading_day in trading_days
+            ],
+        },
+        'impact_assumptions': {
+            'decisions_with_spread': 0,
+            'decisions_with_volatility': 0,
+            'decisions_with_adv': 0,
+            'assumptions': {
+                'recorded_inputs_count': '0',
+                'fallback_inputs_count': '0',
+            },
+        },
+    }
+
+
+def _effect_size(candidate_report_payload: Mapping[str, Any]) -> Decimal:
+    folds = _as_list(_as_dict(candidate_report_payload.get('robustness')).get('folds'))
+    daily_values = [_as_decimal(_as_dict(item).get('net_pnl')) for item in folds]
+    if not daily_values:
+        return Decimal('0')
+    mean_value = sum(daily_values, Decimal('0')) / Decimal(len(daily_values))
+    if len(daily_values) <= 1:
+        return mean_value
+    variance = sum((value - mean_value) ** 2 for value in daily_values) / Decimal(len(daily_values))
+    std_dev = variance.sqrt()
+    if std_dev <= 0:
+        return mean_value
+    return mean_value / std_dev
+
+
+def _artifact_refs(run_summaries: list[HistoricalRunSummary]) -> list[str]:
+    refs: list[str] = []
+    for item in run_summaries:
+        refs.append(str(item.simulation_report_path))
+        if item.replay_report_path is not None:
+            refs.append(str(item.replay_report_path))
+        if item.trade_pnl_csv_path is not None:
+            refs.append(str(item.trade_pnl_csv_path))
+    return sorted(set(refs))
+
+
+def _proof_passed(
+    *,
+    candidate_report_payload: Mapping[str, Any],
+    validation_payload: Mapping[str, Any],
+    proof_payload: Mapping[str, Any],
+) -> tuple[bool, list[str]]:
+    reasons: list[str] = []
+    if not bool(validation_payload.get('passed')):
+        reasons.append('profitability_evidence_validation_failed')
+    market_net = _as_decimal(_as_dict(candidate_report_payload.get('metrics')).get('net_pnl'))
+    if market_net <= 0:
+        reasons.append('market_net_pnl_not_positive')
+    p_value = _as_decimal(_as_dict(proof_payload.get('statistics')).get('p_value'))
+    if p_value > Decimal('0.05'):
+        reasons.append('p_value_above_0_05')
+    return (not reasons, reasons)
+
+
+def build_historical_profitability_bundle(
+    *,
+    run_dirs: list[Path],
+    output_dir: Path,
+    hypothesis: str = '',
+    baseline_run_dirs: list[Path] | None = None,
+    baseline_id: str = '',
+    generated_at: datetime | None = None,
+) -> dict[str, Any]:
+    timestamp = generated_at or datetime.now(timezone.utc)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    candidate_runs = [_load_run_summary(path) for path in run_dirs]
+    _require_consistent_lineage(candidate_runs, label='candidate')
+
+    candidate_id = candidate_runs[0].candidate_id
+    inferred_baseline_id = baseline_id.strip() or candidate_runs[0].baseline_candidate_id or _DEFAULT_BASELINE_ID
+
+    candidate_report_payload = _build_report_payload(candidate_runs)
+    baseline_report_payload: dict[str, object]
+    if baseline_run_dirs:
+        baseline_runs = [_load_run_summary(path) for path in baseline_run_dirs]
+        _require_consistent_lineage(baseline_runs, label='baseline')
+        baseline_report_payload = _build_report_payload(baseline_runs)
+        inferred_baseline_id = baseline_id.strip() or baseline_runs[0].candidate_id
+    else:
+        baseline_report_payload = _build_zero_baseline_payload(
+            [item.trading_day for item in sorted(candidate_runs, key=lambda value: value.trading_day)]
+        )
+
+    candidate_report_path = output_dir / 'candidate-report.json'
+    baseline_report_path = output_dir / 'baseline-report.json'
+    candidate_report_path.write_text(json.dumps(candidate_report_payload, indent=2), encoding='utf-8')
+    baseline_report_path.write_text(json.dumps(baseline_report_payload, indent=2), encoding='utf-8')
+
+    reproducibility_hashes = {
+        'signals': _stable_hash_payload([item.signal_hash for item in candidate_runs]),
+        'strategy_config': _stable_hash_payload(
+            {
+                'candidate_id': candidate_id,
+                'strategy_spec_ref': candidate_runs[0].strategy_spec_ref,
+                'model_refs': candidate_runs[0].model_refs,
+                'runtime_version_refs': candidate_runs[0].runtime_version_refs,
+                'per_run_hashes': [item.strategy_config_hash for item in candidate_runs],
+            }
+        ),
+        'gate_policy': _stable_hash_payload([item.gate_policy_hash for item in candidate_runs]),
+        'candidate_report': _sha256_json(candidate_report_payload),
+        'baseline_report': _sha256_json(baseline_report_payload),
+    }
+
+    benchmark = execute_profitability_benchmark_v4(
+        candidate_id=candidate_id,
+        baseline_id=inferred_baseline_id,
+        candidate_report_payload=dict(candidate_report_payload),
+        baseline_report_payload=dict(baseline_report_payload),
+        executed_at=timestamp,
+    )
+    benchmark_path = output_dir / 'profitability-benchmark-v4.json'
+    benchmark_path.write_text(json.dumps(benchmark.to_payload(), indent=2), encoding='utf-8')
+
+    confidence_values = [item.confidence_value for item in candidate_runs]
+    evidence = build_profitability_evidence_v4(
+        run_id='historical-oos-profitability',
+        candidate_id=candidate_id,
+        baseline_id=inferred_baseline_id,
+        candidate_report_payload=dict(candidate_report_payload),
+        benchmark=benchmark,
+        confidence_values=confidence_values,
+        reproducibility_hashes=reproducibility_hashes,
+        artifact_refs=[* _artifact_refs(candidate_runs), str(candidate_report_path), str(baseline_report_path)],
+        generated_at=timestamp,
+    )
+    evidence_payload = evidence.to_payload()
+    evidence_path = output_dir / 'profitability-evidence-v4.json'
+    evidence_path.write_text(json.dumps(evidence_payload, indent=2), encoding='utf-8')
+
+    validation = validate_profitability_evidence_v4(evidence, checked_at=timestamp)
+    validation_payload = validation.to_payload()
+    validation_path = output_dir / 'profitability-evidence-validation.json'
+    validation_path.write_text(json.dumps(validation_payload, indent=2), encoding='utf-8')
+
+    benchmark_payload = benchmark.to_payload()
+    market_slice = _as_dict(
+        next(
+            (
+                item
+                for item in _as_list(benchmark_payload.get('slices'))
+                if _as_text(_as_dict(item).get('slice_key')) == 'market:all'
+            ),
+            {},
+        )
+    )
+    proof_payload: dict[str, Any] = {
+        'schema_version': _PROFITABILITY_PROOF_SCHEMA_VERSION,
+        'generated_at': timestamp.isoformat(),
+        'hypothesis': hypothesis.strip()
+        or f'{candidate_id} is profitable over the historical OOS replay window',
+        'sample_size': len(candidate_runs),
+        'window_days': len(candidate_runs),
+        'statistics': {
+            'effect_size': float(_effect_size(candidate_report_payload)),
+            'p_value': float(_as_decimal(_as_dict(evidence_payload.get('significance')).get('p_value_two_sided'))),
+            'ci_95_low': _as_text(_as_dict(evidence_payload.get('significance')).get('ci_95_low')) or '0',
+            'ci_95_high': _as_text(_as_dict(evidence_payload.get('significance')).get('ci_95_high')) or '0',
+        },
+        'risk_controls': {
+            'max_drawdown_delta': float(_as_decimal(_as_dict(market_slice.get('deltas')).get('max_drawdown_delta'))),
+            'market_net_pnl_delta': _as_text(_as_dict(market_slice.get('deltas')).get('net_pnl_delta')) or '0',
+            'return_over_drawdown': _as_text(
+                _as_dict(evidence_payload.get('risk_adjusted_metrics')).get('return_over_drawdown')
+            )
+            or '0',
+        },
+        'candidate_id': candidate_id,
+        'baseline_id': inferred_baseline_id,
+        'source_runs': [
+            {
+                'run_id': item.run_id,
+                'trading_day': item.trading_day,
+                'verdict_status': item.verdict_status,
+                'trade_count': item.trade_count,
+                'decision_count': item.decision_count,
+                'net_pnl': str(item.net_pnl),
+                'max_drawdown': str(item.max_drawdown),
+            }
+            for item in sorted(candidate_runs, key=lambda value: value.trading_day)
+        ],
+        'artifacts': {
+            'candidate_report': str(candidate_report_path),
+            'baseline_report': str(baseline_report_path),
+            'profitability_benchmark': str(benchmark_path),
+            'profitability_evidence': str(evidence_path),
+            'profitability_validation': str(validation_path),
+        },
+    }
+    passed, failed_reasons = _proof_passed(
+        candidate_report_payload=candidate_report_payload,
+        validation_payload=validation_payload,
+        proof_payload=proof_payload,
+    )
+    proof_payload['passed'] = passed
+    proof_payload['failed_reasons'] = failed_reasons
+    proof_path = output_dir / 'profitability-proof.json'
+    proof_path.write_text(json.dumps(proof_payload, indent=2), encoding='utf-8')
+
+    summary = {
+        'candidate_id': candidate_id,
+        'baseline_id': inferred_baseline_id,
+        'output_dir': str(output_dir),
+        'profitability_proof_path': str(proof_path),
+        'profitability_benchmark_path': str(benchmark_path),
+        'profitability_evidence_path': str(evidence_path),
+        'profitability_validation_path': str(validation_path),
+        'passed': passed,
+        'failed_reasons': failed_reasons,
+    }
+    return summary
+
+
+def main() -> int:
+    args = _parse_args()
+    summary = build_historical_profitability_bundle(
+        run_dirs=[Path(path) for path in args.run_dir],
+        baseline_run_dirs=[Path(path) for path in args.baseline_run_dir],
+        output_dir=Path(args.output_dir),
+        hypothesis=args.hypothesis,
+        baseline_id=args.baseline_id,
+    )
+    if args.json:
+        print(json.dumps(summary, indent=2))
+    else:
+        print(json.dumps(summary))
+    if not summary.get('passed'):
+        raise SystemExit(1)
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/services/torghut/scripts/generate_historical_profitability_manifests.py
+++ b/services/torghut/scripts/generate_historical_profitability_manifests.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+"""Generate deterministic full-day historical simulation manifests for an OOS proof window."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from datetime import UTC, date, datetime, timedelta
+from pathlib import Path
+from typing import Sequence
+
+import yaml
+
+
+@dataclass(frozen=True)
+class ManifestWindow:
+    trading_day: date
+    manifest_path: Path
+    dataset_id: str
+    simulation_database: str
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--start-date', required=True, help='Inclusive UTC trading-day start in YYYY-MM-DD format.')
+    parser.add_argument('--end-date', required=True, help='Inclusive UTC trading-day end in YYYY-MM-DD format.')
+    parser.add_argument(
+        '--digest',
+        required=True,
+        help='Frozen torghut digest, for example sha256:abc123... or registry...@sha256:abc123...',
+    )
+    parser.add_argument('--output-dir', required=True, help='Directory where manifests should be written.')
+    parser.add_argument('--cache-policy', default='refresh', help='Replay cache policy for each generated manifest.')
+    parser.add_argument('--candidate-id', default='intraday_tsmom_v1@prod')
+    parser.add_argument('--baseline-candidate-id', default='intraday_tsmom_v1@baseline')
+    parser.add_argument('--strategy-spec-ref', default='strategy-specs/intraday_tsmom_v1@1.1.0.json')
+    parser.add_argument('--model-ref', action='append', default=['rules/intraday_tsmom_v1'])
+    parser.add_argument('--json', action='store_true')
+    return parser.parse_args()
+
+
+def _parse_day(raw: str) -> date:
+    try:
+        return date.fromisoformat(raw)
+    except ValueError as exc:
+        raise RuntimeError(f'invalid_date:{raw}') from exc
+
+
+def _normalized_digest(raw: str) -> str:
+    text = raw.strip()
+    if not text:
+        raise RuntimeError('digest_required')
+    if '@sha256:' in text:
+        return text.split('@sha256:', 1)[1]
+    if text.startswith('sha256:'):
+        return text.split('sha256:', 1)[1]
+    return text
+
+
+def _iter_trading_days(*, start_day: date, end_day: date) -> list[date]:
+    if end_day < start_day:
+        raise RuntimeError('date_range_invalid')
+    days: list[date] = []
+    cursor = start_day
+    while cursor <= end_day:
+        if cursor.weekday() < 5:
+            days.append(cursor)
+        cursor += timedelta(days=1)
+    if not days:
+        raise RuntimeError('no_trading_days_in_range')
+    return days
+
+
+def _manifest_payload(
+    *,
+    trading_day: date,
+    digest: str,
+    digest_short: str,
+    cache_policy: str,
+    candidate_id: str,
+    baseline_candidate_id: str,
+    strategy_spec_ref: str,
+    model_refs: Sequence[str],
+) -> dict[str, object]:
+    day_compact = trading_day.strftime('%Y%m%d')
+    day_iso = trading_day.isoformat()
+    return {
+        'dataset_id': f'torghut-full-day-{day_compact}-{digest_short}',
+        'dataset_snapshot_ref': f'torghut-full-day-{day_compact}-{digest_short}',
+        'candidate_id': candidate_id,
+        'baseline_candidate_id': baseline_candidate_id,
+        'strategy_spec_ref': strategy_spec_ref,
+        'model_refs': list(model_refs),
+        'runtime_version_refs': [
+            f'services/torghut@sha256:{digest}',
+            f'services/torghut-forecast@sha256:{digest}',
+        ],
+        'cachePolicy': cache_policy,
+        'performance': {
+            'replayProfile': 'full_day',
+            'dumpFormat': 'jsonl.zst',
+        },
+        'ta_restore': {
+            'mode': 'stateless',
+        },
+        'window': {
+            'profile': 'us_equities_regular',
+            'trading_day': day_iso,
+            'timezone': 'America/New_York',
+            'start': f'{day_iso}T13:30:00Z',
+            'end': f'{day_iso}T20:00:00Z',
+            'min_coverage_minutes': 390,
+            'strict_coverage_ratio': 0.95,
+        },
+        'kafka': {
+            'bootstrap_servers': 'kafka-kafka-bootstrap.kafka.svc.cluster.local:9092',
+            'runtime_bootstrap_servers': 'kafka-kafka-bootstrap.kafka.svc.cluster.local:9092',
+            'security_protocol': 'SASL_PLAINTEXT',
+            'sasl_mechanism': 'SCRAM-SHA-512',
+            'sasl_username': 'kafka-codex-credentials',
+            'sasl_password_env': 'TORGHUT_SIM_KAFKA_PASSWORD',
+            'runtime_security_protocol': 'SASL_PLAINTEXT',
+            'runtime_sasl_mechanism': 'SCRAM-SHA-512',
+            'runtime_sasl_username': 'kafka-codex-credentials',
+            'runtime_sasl_password_env': 'TORGHUT_SIM_KAFKA_PASSWORD',
+            'default_partitions': 8,
+            'replication_factor': 1,
+        },
+        'clickhouse': {
+            'http_url': 'http://torghut-clickhouse.torghut.svc.cluster.local:8123',
+            'username': 'torghut',
+            'password_env': 'TORGHUT_CLICKHOUSE_PASSWORD',
+            'password_secret_name': 'torghut-clickhouse-auth',
+            'password_secret_key': 'torghut_password',
+            'secret_namespace': 'torghut',
+            'simulation_database': f'torghut_sim_{trading_day.strftime("%Y_%m_%d")}_full_day_{digest_short}',
+        },
+        'postgres': {
+            'admin_dsn': 'postgresql://postgres@torghut-db-rw.torghut.svc.cluster.local:5432/postgres',
+            'admin_dsn_password_env': 'TORGHUT_POSTGRES_ADMIN_PASSWORD',
+            'simulation_dsn': (
+                'postgresql://torghut_app@torghut-db-rw.torghut.svc.cluster.local:5432/'
+                f'torghut_sim_{trading_day.strftime("%Y_%m_%d")}_full_day_{digest_short}'
+            ),
+            'simulation_dsn_password_env': 'TORGHUT_POSTGRES_PASSWORD',
+            'runtime_simulation_dsn': (
+                'postgresql://torghut_app@torghut-db-rw.torghut.svc.cluster.local:5432/'
+                f'torghut_sim_{trading_day.strftime("%Y_%m_%d")}_full_day_{digest_short}'
+            ),
+            'runtime_simulation_dsn_password_env': 'TORGHUT_POSTGRES_PASSWORD',
+            'migrations_command': '/opt/venv/bin/alembic upgrade heads',
+        },
+        'runtime': {
+            'target_mode': 'dedicated_service',
+            'namespace': 'torghut',
+            'ta_configmap': 'torghut-ta-sim-config',
+            'ta_deployment': 'torghut-ta-sim',
+            'torghut_service': 'torghut-sim',
+            'torghut_forecast_service': 'torghut-forecast-sim',
+            'output_root': 'artifacts/torghut/simulations',
+        },
+        'rollouts': {
+            'enabled': True,
+            'namespace': 'torghut',
+            'runtime_template': 'torghut-simulation-runtime-ready',
+            'activity_template': 'torghut-simulation-activity',
+            'teardown_template': 'torghut-simulation-teardown-clean',
+            'artifact_template': 'torghut-simulation-artifact-bundle',
+        },
+        'replay': {
+            'pace_mode': 'max_throughput',
+            'acceleration': 1,
+            'max_sleep_seconds': 0,
+            'auto_offset_reset': 'earliest',
+            'flush_every_records': 50000,
+            'flush_timeout_seconds': 60,
+            'final_flush_timeout_seconds': 180,
+            'status_update_every_records': 25000,
+            'status_update_every_seconds': 30,
+        },
+        'monitor': {
+            'timeout_seconds': 14400,
+            'poll_seconds': 30,
+            'min_trade_decisions': 1,
+            'min_executions': 1,
+            'min_execution_tca_metrics': 1,
+            'min_execution_order_events': 1,
+            'cursor_grace_seconds': 120,
+        },
+        'argocd': {
+            'manage_automation': True,
+            'applicationset_name': 'product',
+            'applicationset_namespace': 'argocd',
+            'app_name': 'torghut',
+            'desired_mode_during_run': 'manual',
+            'restore_mode_after_run': 'previous',
+            'verify_timeout_seconds': 900,
+        },
+        'reporting': {
+            'commission_bps': '0',
+            'per_trade_fee': '0',
+        },
+    }
+
+
+def generate_profitability_manifests(
+    *,
+    start_day: date,
+    end_day: date,
+    digest: str,
+    output_dir: Path,
+    cache_policy: str,
+    candidate_id: str,
+    baseline_candidate_id: str,
+    strategy_spec_ref: str,
+    model_refs: Sequence[str],
+    generated_at: datetime | None = None,
+) -> dict[str, object]:
+    normalized_digest = _normalized_digest(digest)
+    digest_short = normalized_digest[:8]
+    output_dir.mkdir(parents=True, exist_ok=True)
+    generated_timestamp = (generated_at or datetime.now(UTC)).isoformat()
+
+    manifests: list[ManifestWindow] = []
+    for trading_day in _iter_trading_days(start_day=start_day, end_day=end_day):
+        filename = f'full-day-{trading_day.isoformat()}-{cache_policy}-{digest_short}-proof.yaml'
+        manifest_path = output_dir / filename
+        simulation_database = f'torghut_sim_{trading_day.strftime("%Y_%m_%d")}_full_day_{digest_short}'
+        payload = _manifest_payload(
+            trading_day=trading_day,
+            digest=normalized_digest,
+            digest_short=digest_short,
+            cache_policy=cache_policy,
+            candidate_id=candidate_id,
+            baseline_candidate_id=baseline_candidate_id,
+            strategy_spec_ref=strategy_spec_ref,
+            model_refs=model_refs,
+        )
+        manifest_path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding='utf-8')
+        manifests.append(
+            ManifestWindow(
+                trading_day=trading_day,
+                manifest_path=manifest_path,
+                dataset_id=str(payload['dataset_id']),
+                simulation_database=simulation_database,
+            )
+        )
+
+    index_payload = {
+        'schema_version': 'torghut.historical-profitability-manifest-index.v1',
+        'generated_at': generated_timestamp,
+        'digest': normalized_digest,
+        'cache_policy': cache_policy,
+        'manifests': [
+            {
+                'trading_day': item.trading_day.isoformat(),
+                'manifest_path': str(item.manifest_path),
+                'dataset_id': item.dataset_id,
+                'simulation_database': item.simulation_database,
+            }
+            for item in manifests
+        ],
+    }
+    (output_dir / 'manifest-index.json').write_text(json.dumps(index_payload, indent=2), encoding='utf-8')
+    return index_payload
+
+
+def main() -> int:
+    args = _parse_args()
+    summary = generate_profitability_manifests(
+        start_day=_parse_day(args.start_date),
+        end_day=_parse_day(args.end_date),
+        digest=args.digest,
+        output_dir=Path(args.output_dir),
+        cache_policy=args.cache_policy,
+        candidate_id=args.candidate_id,
+        baseline_candidate_id=args.baseline_candidate_id,
+        strategy_spec_ref=args.strategy_spec_ref,
+        model_refs=args.model_ref,
+    )
+    if args.json:
+        print(json.dumps(summary, indent=2))
+    else:
+        print(json.dumps(summary))
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/services/torghut/scripts/run_simulation_analysis.py
+++ b/services/torghut/scripts/run_simulation_analysis.py
@@ -11,7 +11,7 @@ from typing import Any
 
 from scripts.historical_simulation_verification import (
     _artifact_bundle,
-    _current_activity_report,
+    _monitor_run_completion,
     _replace_database_in_dsn,
     _runtime_verify,
     _teardown_clean,
@@ -282,7 +282,7 @@ def main() -> None:
 
     clickhouse_config = _clickhouse_config(args)
     runtime_verify = _runtime_verify(resources=resources, manifest=manifest)
-    report = _current_activity_report(
+    report = _monitor_run_completion(
         resources=resources,
         manifest=manifest,
         postgres_config=postgres_config,

--- a/services/torghut/scripts/start_historical_simulation.py
+++ b/services/torghut/scripts/start_historical_simulation.py
@@ -205,6 +205,7 @@ DEFAULT_ARGOCD_NAMESPACE = 'argocd'
 DEFAULT_ARGOCD_APP_NAME = 'torghut'
 DEFAULT_ARGOCD_ROOT_APP_NAME = 'root'
 DEFAULT_ARGOCD_RUN_MODE = 'manual'
+_ARGOCD_SKIP_RECONCILE_ANNOTATION = 'argocd.argoproj.io/skip-reconcile'
 DEFAULT_ROLLOUTS_NAMESPACE = 'torghut'
 DEFAULT_ROLLOUTS_RUNTIME_TEMPLATE = 'torghut-simulation-runtime-ready'
 DEFAULT_ROLLOUTS_ACTIVITY_TEMPLATE = 'torghut-simulation-activity'
@@ -1995,12 +1996,17 @@ def _read_named_argocd_application_sync_policy(
         ]
     )
     spec = _as_mapping(payload.get('spec'))
+    metadata = _as_mapping(payload.get('metadata'))
+    annotations = _as_mapping(metadata.get('annotations'))
     sync_policy_raw = spec.get('syncPolicy')
     sync_policy = _clone_json_mapping(_as_mapping(sync_policy_raw) if isinstance(sync_policy_raw, Mapping) else None)
     automation_mode = _argocd_application_mode_from_sync_policy(sync_policy)
+    skip_reconcile_value = _as_text(annotations.get(_ARGOCD_SKIP_RECONCILE_ANNOTATION))
     return {
         'sync_policy': sync_policy,
         'automation_mode': automation_mode,
+        'skip_reconcile_value': skip_reconcile_value,
+        'skip_reconcile_enabled': (skip_reconcile_value or '').lower() == 'true',
     }
 
 
@@ -2078,6 +2084,66 @@ def _set_argocd_application_sync_policy(
     return {
         'previous_sync_policy': current_policy,
         'current_sync_policy': verified_policy,
+        'changed': changed,
+    }
+
+
+def _normalize_argocd_skip_reconcile_value(value: str | None) -> str | None:
+    normalized = _as_text(value)
+    if normalized is None:
+        return None
+    normalized = normalized.lower()
+    if normalized not in {'true', 'false'}:
+        raise RuntimeError(f'unsupported_argocd_skip_reconcile_value:{value}')
+    return normalized
+
+
+def _set_argocd_application_skip_reconcile(
+    *,
+    config: ArgocdAutomationConfig,
+    app_name: str | None = None,
+    desired_value: str | None,
+) -> dict[str, Any]:
+    normalized_desired = _normalize_argocd_skip_reconcile_value(desired_value)
+    target_app_name = app_name or config.app_name
+    state = _read_named_argocd_application_sync_policy(
+        namespace=config.applicationset_namespace,
+        app_name=target_app_name,
+    )
+    current_value = _normalize_argocd_skip_reconcile_value(_as_text(state.get('skip_reconcile_value')))
+    changed = current_value != normalized_desired
+    if changed:
+        _kubectl_patch(
+            config.applicationset_namespace,
+            'application',
+            target_app_name,
+            {'metadata': {'annotations': {_ARGOCD_SKIP_RECONCILE_ANNOTATION: normalized_desired}}},
+        )
+
+    deadline = datetime.now(timezone.utc) + timedelta(seconds=config.verify_timeout_seconds)
+    verified_value = current_value
+    while True:
+        verified_state = _read_named_argocd_application_sync_policy(
+            namespace=config.applicationset_namespace,
+            app_name=target_app_name,
+        )
+        verified_value = _normalize_argocd_skip_reconcile_value(
+            _as_text(verified_state.get('skip_reconcile_value'))
+        )
+        if verified_value == normalized_desired:
+            break
+        if datetime.now(timezone.utc) >= deadline:
+            raise RuntimeError(
+                'argocd_application_skip_reconcile_verify_timeout '
+                f'desired={normalized_desired} observed={verified_value}'
+            )
+        time.sleep(2)
+
+    return {
+        'app_name': target_app_name,
+        'previous_value': current_value,
+        'current_value': verified_value,
+        'enabled': verified_value == 'true',
         'changed': changed,
     }
 
@@ -6094,9 +6160,20 @@ def _prepare_argocd_for_run(
         }
     automation_state = _read_argocd_automation_mode(config=config)
     current_mode = _normalized_automation_mode(_as_text(automation_state.get('mode')))
+    child_sync_state = _read_named_argocd_application_sync_policy(
+        namespace=config.applicationset_namespace,
+        app_name=config.app_name,
+    )
     root_sync_state = _read_named_argocd_application_sync_policy(
         namespace=config.applicationset_namespace,
         app_name=config.root_app_name,
+    )
+    child_application_report = _set_argocd_application_sync_policy(
+        config=config,
+        app_name=config.app_name,
+        desired_sync_policy=_manual_argocd_application_sync_policy(
+            cast(Mapping[str, Any] | None, child_sync_state.get('sync_policy'))
+        ),
     )
     root_application_report = _set_argocd_application_sync_policy(
         config=config,
@@ -6104,6 +6181,11 @@ def _prepare_argocd_for_run(
         desired_sync_policy=_manual_argocd_application_sync_policy(
             cast(Mapping[str, Any] | None, root_sync_state.get('sync_policy'))
         ),
+    )
+    application_skip_reconcile_report = _set_argocd_application_skip_reconcile(
+        config=config,
+        app_name=config.app_name,
+        desired_value='true',
     )
     applicationset_report = _set_argocd_automation_mode(
         config=config,
@@ -6116,13 +6198,20 @@ def _prepare_argocd_for_run(
     )
     return {
         'managed': True,
-        'changed': root_application_report['changed'] or applicationset_report['changed'],
+        'changed': (
+            child_application_report['changed']
+            or root_application_report['changed']
+            or application_skip_reconcile_report['changed']
+            or applicationset_report['changed']
+        ),
         'pointer': automation_state.get('pointer'),
         'previous_mode': current_mode,
         'desired_mode': config.desired_mode_during_run,
         'current_mode': application_mode_report['current_mode'],
         'applicationset_managed': True,
         'applicationset': applicationset_report,
+        'application_sync_policy': child_application_report,
+        'application_skip_reconcile': application_skip_reconcile_report,
         'root_application': root_application_report,
         'application': application_mode_report,
     }
@@ -6157,9 +6246,11 @@ def _ensure_argocd_manual_before_runtime_mutation(
         cast(Mapping[str, Any] | None, root_state.get('sync_policy'))
     )
     current_applicationset_mode = _normalized_automation_mode(_as_text(applicationset_state.get('mode')))
+    current_skip_reconcile_enabled = bool(application_state.get('skip_reconcile_enabled'))
     if (
         current_applicationset_mode == desired_mode
         and current_application_mode == desired_mode
+        and current_skip_reconcile_enabled
         and current_root_sync_policy == desired_root_sync_policy
     ):
         return {
@@ -6184,6 +6275,13 @@ def _ensure_argocd_manual_before_runtime_mutation(
                 'app_name': config.app_name,
                 'current_mode': current_application_mode,
             },
+            'application_skip_reconcile': {
+                'app_name': config.app_name,
+                'current_value': _as_text(application_state.get('skip_reconcile_value')),
+                'desired_value': 'true',
+                'enabled': current_skip_reconcile_enabled,
+                'changed': False,
+            },
         }
 
     report = _prepare_argocd_for_run(config=config)
@@ -6195,7 +6293,9 @@ def _restore_argocd_after_run(
     *,
     config: ArgocdAutomationConfig,
     previous_mode: str | None,
-    previous_sync_policy: Mapping[str, Any] | None,
+    previous_root_sync_policy: Mapping[str, Any] | None,
+    previous_child_sync_policy: Mapping[str, Any] | None,
+    previous_child_skip_reconcile_value: str | None,
 ) -> dict[str, Any]:
     if not config.manage_automation:
         return {
@@ -6209,6 +6309,16 @@ def _restore_argocd_after_run(
     if restored_mode is None:
         restored_mode = 'auto'
 
+    child_application_report = _set_argocd_application_sync_policy(
+        config=config,
+        app_name=config.app_name,
+        desired_sync_policy=previous_child_sync_policy,
+    )
+    child_skip_reconcile_report = _set_argocd_application_skip_reconcile(
+        config=config,
+        app_name=config.app_name,
+        desired_value=previous_child_skip_reconcile_value,
+    )
     applicationset_report = _set_argocd_automation_mode(
         config=config,
         desired_mode=restored_mode,
@@ -6216,7 +6326,7 @@ def _restore_argocd_after_run(
     root_application_report = _set_argocd_application_sync_policy(
         config=config,
         app_name=config.root_app_name,
-        desired_sync_policy=previous_sync_policy,
+        desired_sync_policy=previous_root_sync_policy,
     )
     application_mode_report = _wait_for_argocd_application_mode(
         config=config,
@@ -6225,12 +6335,19 @@ def _restore_argocd_after_run(
     )
     return {
         'managed': True,
-        'changed': root_application_report['changed'] or applicationset_report['changed'],
+        'changed': (
+            child_application_report['changed']
+            or child_skip_reconcile_report['changed']
+            or root_application_report['changed']
+            or applicationset_report['changed']
+        ),
         'restored_mode': restored_mode,
         'previous_mode': previous_mode,
         'current_mode': application_mode_report['current_mode'],
         'applicationset_managed': True,
         'applicationset': applicationset_report,
+        'application_sync_policy': child_application_report,
+        'application_skip_reconcile': child_skip_reconcile_report,
         'root_application': root_application_report,
         'application': application_mode_report,
     }
@@ -6955,6 +7072,8 @@ def _run_full_lifecycle(
     argocd_prepare_succeeded = False
     argocd_restore_required = False
     previous_root_application_sync_policy: dict[str, Any] | None = None
+    previous_child_application_sync_policy: dict[str, Any] | None = None
+    previous_child_skip_reconcile_value: str | None = None
     teardown_succeeded = False
 
     try:
@@ -6985,10 +7104,16 @@ def _run_full_lifecycle(
                     cast(Mapping[str, Any] | None, current_root_app_state.get('sync_policy'))
                 )
                 current_app_state = _read_argocd_application_sync_policy(config=argocd_config)
+                previous_child_application_sync_policy = _clone_json_mapping(
+                    cast(Mapping[str, Any] | None, current_app_state.get('sync_policy'))
+                )
+                previous_child_skip_reconcile_value = _as_text(current_app_state.get('skip_reconcile_value'))
                 argocd_restore_required = (
                     previous_automation_mode != _normalized_automation_mode(argocd_config.desired_mode_during_run)
                 )
                 if _normalized_automation_mode(_as_text(current_app_state.get('automation_mode'))) != 'manual':
+                    argocd_restore_required = True
+                if not bool(current_app_state.get('skip_reconcile_enabled')):
                     argocd_restore_required = True
             argocd_prepare_report = _prepare_argocd_for_run(config=argocd_config)
             if previous_automation_mode is None:
@@ -6998,6 +7123,14 @@ def _run_full_lifecycle(
                 previous_root_application_sync_policy = _clone_json_mapping(
                     cast(Mapping[str, Any] | None, application_report.get('previous_sync_policy'))
                 )
+            if previous_child_application_sync_policy is None:
+                application_report = _as_mapping(argocd_prepare_report.get('application_sync_policy'))
+                previous_child_application_sync_policy = _clone_json_mapping(
+                    cast(Mapping[str, Any] | None, application_report.get('previous_sync_policy'))
+                )
+            if previous_child_skip_reconcile_value is None:
+                skip_report = _as_mapping(argocd_prepare_report.get('application_skip_reconcile'))
+                previous_child_skip_reconcile_value = _as_text(skip_report.get('previous_value'))
             argocd_prepare_succeeded = True
             _update_run_state(
                 resources=resources,
@@ -7364,7 +7497,9 @@ def _run_full_lifecycle(
                 argocd_restore_report = _restore_argocd_after_run(
                     config=argocd_config,
                     previous_mode=previous_automation_mode,
-                    previous_sync_policy=previous_root_application_sync_policy,
+                    previous_root_sync_policy=previous_root_application_sync_policy,
+                    previous_child_sync_policy=previous_child_application_sync_policy,
+                    previous_child_skip_reconcile_value=previous_child_skip_reconcile_value,
                 )
                 _update_run_state(resources=resources, phase='argocd_restore', status='ok')
             except Exception as exc:

--- a/services/torghut/scripts/start_historical_simulation.py
+++ b/services/torghut/scripts/start_historical_simulation.py
@@ -205,7 +205,6 @@ DEFAULT_ARGOCD_NAMESPACE = 'argocd'
 DEFAULT_ARGOCD_APP_NAME = 'torghut'
 DEFAULT_ARGOCD_ROOT_APP_NAME = 'root'
 DEFAULT_ARGOCD_RUN_MODE = 'manual'
-_ARGOCD_SKIP_RECONCILE_ANNOTATION = 'argocd.argoproj.io/skip-reconcile'
 DEFAULT_ROLLOUTS_NAMESPACE = 'torghut'
 DEFAULT_ROLLOUTS_RUNTIME_TEMPLATE = 'torghut-simulation-runtime-ready'
 DEFAULT_ROLLOUTS_ACTIVITY_TEMPLATE = 'torghut-simulation-activity'
@@ -1731,12 +1730,12 @@ def _json_pointer_unescape(value: str) -> str:
     return value.replace('~1', '/').replace('~0', '~')
 
 
-def _discover_automation_pointer(
+def _discover_applicationset_entry(
     node: Any,
     *,
     app_name: str,
     path: str = '',
-) -> tuple[str, str] | None:
+) -> tuple[str, dict[str, Any]] | None:
     if isinstance(node, Mapping):
         elements = node.get('elements')
         if isinstance(elements, list):
@@ -1745,25 +1744,63 @@ def _discover_automation_pointer(
                 if not isinstance(entry, Mapping):
                     continue
                 name = _as_text(entry.get('name'))
-                automation = _as_text(entry.get('automation'))
-                if name == app_name and automation is not None:
-                    pointer = (
-                        f'{elements_path}/{idx}/{_json_pointer_escape("automation")}'
-                    )
-                    return pointer, automation
+                if name == app_name:
+                    pointer = f'{elements_path}/{idx}'
+                    return pointer, _clone_json_mapping(entry) or {}
         for key, value in node.items():
             child_path = f'{path}/{_json_pointer_escape(str(key))}'
-            found = _discover_automation_pointer(value, app_name=app_name, path=child_path)
+            found = _discover_applicationset_entry(value, app_name=app_name, path=child_path)
             if found is not None:
                 return found
         return None
     if isinstance(node, list):
         for idx, value in enumerate(node):
             child_path = f'{path}/{idx}'
-            found = _discover_automation_pointer(value, app_name=app_name, path=child_path)
+            found = _discover_applicationset_entry(value, app_name=app_name, path=child_path)
             if found is not None:
                 return found
     return None
+
+
+def _read_argocd_applicationset_entry(
+    *,
+    config: ArgocdAutomationConfig,
+) -> dict[str, Any]:
+    payload = _kubectl_json_global(
+        [
+            '-n',
+            config.applicationset_namespace,
+            'get',
+            'applicationset',
+            config.applicationset_name,
+            '-o',
+            'json',
+        ]
+    )
+    discovered = _discover_applicationset_entry(payload, app_name=config.app_name)
+    if discovered is None:
+        raise RuntimeError(
+            'argocd_applicationset_entry_not_found '
+            f'applicationset={config.applicationset_name} app={config.app_name}'
+        )
+    pointer, entry = discovered
+    automation = _as_text(entry.get('automation'))
+    if automation is None:
+        raise RuntimeError(
+            'argocd_automation_path_not_found '
+            f'applicationset={config.applicationset_name} app={config.app_name}'
+        )
+    return {
+        'pointer': pointer,
+        'entry': entry,
+        'automation_pointer': f'{pointer}/{_json_pointer_escape("automation")}',
+        'mode': _normalized_automation_mode(automation),
+        'ignore_differences': _clone_json_list(
+            cast(Sequence[Any] | None, entry.get('ignoreDifferences'))
+            if isinstance(entry.get('ignoreDifferences'), list)
+            else None
+        ),
+    }
 
 
 def _json_pointer_get(payload: Any, pointer: str) -> Any:
@@ -1798,6 +1835,12 @@ def _clone_json_mapping(value: Mapping[str, Any] | None) -> dict[str, Any] | Non
     if value is None:
         return None
     return cast(dict[str, Any], json.loads(json.dumps(dict(value))))
+
+
+def _clone_json_list(value: Sequence[Any] | None) -> list[Any] | None:
+    if value is None:
+        return None
+    return cast(list[Any], json.loads(json.dumps(list(value))))
 
 
 def _simulation_lock_payload(
@@ -1888,28 +1931,10 @@ def _read_argocd_automation_mode(
     *,
     config: ArgocdAutomationConfig,
 ) -> dict[str, Any]:
-    payload = _kubectl_json_global(
-        [
-            '-n',
-            config.applicationset_namespace,
-            'get',
-            'applicationset',
-            config.applicationset_name,
-            '-o',
-            'json',
-        ]
-    )
-    discovered = _discover_automation_pointer(payload, app_name=config.app_name)
-    if discovered is None:
-        raise RuntimeError(
-            'argocd_automation_path_not_found '
-            f'applicationset={config.applicationset_name} app={config.app_name}'
-        )
-    pointer, automation = discovered
-    mode = _normalized_automation_mode(automation)
+    entry_state = _read_argocd_applicationset_entry(config=config)
     return {
-        'pointer': pointer,
-        'mode': mode,
+        'pointer': entry_state['automation_pointer'],
+        'mode': entry_state['mode'],
     }
 
 
@@ -1919,8 +1944,8 @@ def _set_argocd_automation_mode(
     desired_mode: str,
 ) -> dict[str, Any]:
     normalized_desired = _normalized_automation_mode(desired_mode)
-    state = _read_argocd_automation_mode(config=config)
-    pointer = str(state['pointer'])
+    state = _read_argocd_applicationset_entry(config=config)
+    pointer = str(state['automation_pointer'])
     current_mode = _normalized_automation_mode(_as_text(state.get('mode')))
     changed = current_mode != normalized_desired
     if changed:
@@ -1941,8 +1966,8 @@ def _set_argocd_automation_mode(
     deadline = started + timedelta(seconds=config.verify_timeout_seconds)
     verified_mode = current_mode
     while True:
-        verified_state = _read_argocd_automation_mode(config=config)
-        pointer_observed = str(verified_state['pointer'])
+        verified_state = _read_argocd_applicationset_entry(config=config)
+        pointer_observed = str(verified_state['automation_pointer'])
         if pointer_observed != pointer:
             raise RuntimeError(
                 'argocd_automation_pointer_changed '
@@ -1997,16 +2022,17 @@ def _read_named_argocd_application_sync_policy(
     )
     spec = _as_mapping(payload.get('spec'))
     metadata = _as_mapping(payload.get('metadata'))
-    annotations = _as_mapping(metadata.get('annotations'))
     sync_policy_raw = spec.get('syncPolicy')
     sync_policy = _clone_json_mapping(_as_mapping(sync_policy_raw) if isinstance(sync_policy_raw, Mapping) else None)
+    ignore_differences_raw = spec.get('ignoreDifferences')
+    ignore_differences = _clone_json_list(
+        cast(Sequence[Any] | None, ignore_differences_raw) if isinstance(ignore_differences_raw, list) else None
+    )
     automation_mode = _argocd_application_mode_from_sync_policy(sync_policy)
-    skip_reconcile_value = _as_text(annotations.get(_ARGOCD_SKIP_RECONCILE_ANNOTATION))
     return {
         'sync_policy': sync_policy,
+        'ignore_differences': ignore_differences,
         'automation_mode': automation_mode,
-        'skip_reconcile_value': skip_reconcile_value,
-        'skip_reconcile_enabled': (skip_reconcile_value or '').lower() == 'true',
     }
 
 
@@ -2090,62 +2116,199 @@ def _set_argocd_application_sync_policy(
     }
 
 
-def _normalize_argocd_skip_reconcile_value(value: str | None) -> str | None:
-    normalized = _as_text(value)
-    if normalized is None:
-        return None
-    normalized = normalized.lower()
-    if normalized not in {'true', 'false'}:
-        raise RuntimeError(f'unsupported_argocd_skip_reconcile_value:{value}')
-    return normalized
+def _normalized_argocd_ignore_difference_rule(
+    rule: Mapping[str, Any],
+) -> dict[str, Any]:
+    normalized_rule = _clone_json_mapping(rule) or {}
+    for key in ('group', 'name', 'namespace'):
+        value = _as_text(normalized_rule.get(key))
+        if value:
+            normalized_rule[key] = value
+        else:
+            normalized_rule.pop(key, None)
+    for key in ('jsonPointers', 'jqPathExpressions', 'managedFieldsManagers'):
+        values = normalized_rule.get(key)
+        if not isinstance(values, list):
+            continue
+        normalized_rule[key] = sorted(_as_text(item) or '' for item in values if _as_text(item))
+    return normalized_rule
 
 
-def _set_argocd_application_skip_reconcile(
+def _normalized_argocd_ignore_differences(
+    ignore_differences: Sequence[Mapping[str, Any]] | None,
+) -> list[dict[str, Any]]:
+    if not ignore_differences:
+        return []
+    normalized_rules = [
+        _normalized_argocd_ignore_difference_rule(rule)
+        for rule in ignore_differences
+    ]
+    normalized_rules.sort(key=lambda item: json.dumps(item, sort_keys=True, separators=(',', ':')))
+    return normalized_rules
+
+
+def _simulation_runtime_argocd_ignore_differences(
+    *,
+    resources: SimulationResources,
+) -> list[dict[str, Any]]:
+    return [
+        {
+            'group': 'serving.knative.dev',
+            'kind': 'Service',
+            'namespace': resources.namespace,
+            'name': resources.torghut_service,
+            'jsonPointers': ['/spec/template/spec/containers/0/env'],
+        },
+        {
+            'group': '',
+            'kind': 'ConfigMap',
+            'namespace': resources.namespace,
+            'name': resources.ta_configmap,
+            'jsonPointers': ['/data'],
+        },
+        {
+            'group': 'flink.apache.org',
+            'kind': 'FlinkDeployment',
+            'namespace': resources.namespace,
+            'name': resources.ta_deployment,
+            'jsonPointers': ['/spec/job/state', '/spec/job/upgradeMode', '/spec/restartNonce'],
+        },
+    ]
+
+
+def _merge_argocd_application_ignore_differences(
+    *,
+    current_ignore_differences: Sequence[Mapping[str, Any]] | None,
+    resources: SimulationResources,
+) -> list[dict[str, Any]]:
+    merged_rules = _normalized_argocd_ignore_differences(current_ignore_differences)
+    existing_keys = {
+        json.dumps(rule, sort_keys=True, separators=(',', ':'))
+        for rule in merged_rules
+    }
+    for rule in _simulation_runtime_argocd_ignore_differences(resources=resources):
+        normalized_rule = _normalized_argocd_ignore_difference_rule(rule)
+        normalized_key = json.dumps(normalized_rule, sort_keys=True, separators=(',', ':'))
+        if normalized_key in existing_keys:
+            continue
+        merged_rules.append(normalized_rule)
+        existing_keys.add(normalized_key)
+    merged_rules.sort(key=lambda item: json.dumps(item, sort_keys=True, separators=(',', ':')))
+    return merged_rules
+
+
+def _argocd_ignore_differences_cover_runtime_mutations(
+    *,
+    current_ignore_differences: Sequence[Mapping[str, Any]] | None,
+    resources: SimulationResources,
+) -> bool:
+    return _argocd_ignore_differences_cover_required_rules(
+        current_ignore_differences=current_ignore_differences,
+        required_ignore_differences=_simulation_runtime_argocd_ignore_differences(resources=resources),
+    )
+
+
+def _argocd_ignore_differences_cover_required_rules(
+    *,
+    current_ignore_differences: Sequence[Mapping[str, Any]] | None,
+    required_ignore_differences: Sequence[Mapping[str, Any]] | None,
+) -> bool:
+    current_rules = {
+        json.dumps(rule, sort_keys=True, separators=(',', ':'))
+        for rule in _normalized_argocd_ignore_differences(current_ignore_differences)
+    }
+    required_rules = {
+        json.dumps(rule, sort_keys=True, separators=(',', ':'))
+        for rule in _normalized_argocd_ignore_differences(required_ignore_differences)
+    }
+    return required_rules.issubset(current_rules)
+
+
+def _set_argocd_application_ignore_differences(
     *,
     config: ArgocdAutomationConfig,
     app_name: str | None = None,
-    desired_value: str | None,
+    required_ignore_differences: Sequence[Mapping[str, Any]] | None = None,
+    desired_ignore_differences: Sequence[Mapping[str, Any]] | None,
 ) -> dict[str, Any]:
-    normalized_desired = _normalize_argocd_skip_reconcile_value(desired_value)
+    normalized_desired = _normalized_argocd_ignore_differences(desired_ignore_differences)
+    normalized_required = _normalized_argocd_ignore_differences(required_ignore_differences)
     target_app_name = app_name or config.app_name
-    state = _read_named_argocd_application_sync_policy(
-        namespace=config.applicationset_namespace,
-        app_name=target_app_name,
+    if target_app_name != config.app_name:
+        raise RuntimeError(f'unsupported_argocd_managed_application:{target_app_name}')
+    state = _read_argocd_applicationset_entry(config=config)
+    current_ignore_differences = _normalized_argocd_ignore_differences(
+        cast(Sequence[Mapping[str, Any]] | None, state.get('ignore_differences'))
     )
-    current_value = _normalize_argocd_skip_reconcile_value(_as_text(state.get('skip_reconcile_value')))
-    changed = current_value != normalized_desired
+    changed = current_ignore_differences != normalized_desired
     if changed:
-        _kubectl_patch(
-            config.applicationset_namespace,
-            'application',
-            target_app_name,
-            {'metadata': {'annotations': {_ARGOCD_SKIP_RECONCILE_ANNOTATION: normalized_desired}}},
-        )
+        ignore_differences_pointer = f'{state["pointer"]}/{_json_pointer_escape("ignoreDifferences")}'
+        patch_op = 'replace' if current_ignore_differences else 'add'
+        if normalized_desired:
+            _kubectl_patch_json(
+                config.applicationset_namespace,
+                'applicationset',
+                config.applicationset_name,
+                [
+                    {
+                        'op': patch_op,
+                        'path': ignore_differences_pointer,
+                        'value': normalized_desired,
+                    }
+                ],
+            )
+        else:
+            _kubectl_patch_json(
+                config.applicationset_namespace,
+                'applicationset',
+                config.applicationset_name,
+                [{'op': 'remove', 'path': ignore_differences_pointer}],
+            )
 
     deadline = datetime.now(timezone.utc) + timedelta(seconds=config.verify_timeout_seconds)
-    verified_value = current_value
+    verified_ignore_differences = current_ignore_differences
+    verified_application_ignore_differences = _normalized_argocd_ignore_differences(None)
     while True:
-        verified_state = _read_named_argocd_application_sync_policy(
+        verified_state = _read_argocd_applicationset_entry(config=config)
+        verified_ignore_differences = _normalized_argocd_ignore_differences(
+            cast(Sequence[Mapping[str, Any]] | None, verified_state.get('ignore_differences'))
+        )
+        application_state = _read_named_argocd_application_sync_policy(
             namespace=config.applicationset_namespace,
             app_name=target_app_name,
         )
-        verified_value = _normalize_argocd_skip_reconcile_value(
-            _as_text(verified_state.get('skip_reconcile_value'))
+        verified_application_ignore_differences = _normalized_argocd_ignore_differences(
+            cast(Sequence[Mapping[str, Any]] | None, application_state.get('ignore_differences'))
         )
-        if verified_value == normalized_desired:
+        if (
+            verified_ignore_differences == normalized_desired
+            and verified_application_ignore_differences == normalized_desired
+        ):
             break
         if datetime.now(timezone.utc) >= deadline:
             raise RuntimeError(
-                'argocd_application_skip_reconcile_verify_timeout '
-                f'desired={normalized_desired} observed={verified_value}'
+                'argocd_application_ignore_differences_verify_timeout '
+                f'desired={json.dumps(normalized_desired, sort_keys=True)} '
+                f'observed_applicationset={json.dumps(verified_ignore_differences, sort_keys=True)} '
+                f'observed_application={json.dumps(verified_application_ignore_differences, sort_keys=True)}'
             )
         time.sleep(2)
 
     return {
         'app_name': target_app_name,
-        'previous_value': current_value,
-        'current_value': verified_value,
-        'enabled': verified_value == 'true',
+        'applicationset_pointer': _as_text(state.get('pointer')),
+        'previous_ignore_differences': current_ignore_differences,
+        'current_ignore_differences': verified_ignore_differences,
+        'current_application_ignore_differences': verified_application_ignore_differences,
+        'required_ignore_differences': normalized_required,
+        'coverage_complete': (
+            True
+            if not normalized_required
+            else _argocd_ignore_differences_cover_required_rules(
+                current_ignore_differences=verified_application_ignore_differences,
+                required_ignore_differences=normalized_required,
+            )
+        ),
         'changed': changed,
     }
 
@@ -5960,6 +6123,7 @@ def _apply(
         ):
             argocd_runtime_guard_report = _ensure_argocd_manual_before_runtime_mutation(
                 config=argocd_config,
+                resources=resources,
             )
         ta_reconfigured = _ta_runtime_reconfigure_required(
             resources=resources,
@@ -6152,6 +6316,7 @@ def _teardown(
 def _prepare_argocd_for_run(
     *,
     config: ArgocdAutomationConfig,
+    resources: SimulationResources,
 ) -> dict[str, Any]:
     if not config.manage_automation:
         return {
@@ -6184,10 +6349,14 @@ def _prepare_argocd_for_run(
             cast(Mapping[str, Any] | None, root_sync_state.get('sync_policy'))
         ),
     )
-    application_skip_reconcile_report = _set_argocd_application_skip_reconcile(
+    application_ignore_differences_report = _set_argocd_application_ignore_differences(
         config=config,
         app_name=config.app_name,
-        desired_value='true',
+        required_ignore_differences=_simulation_runtime_argocd_ignore_differences(resources=resources),
+        desired_ignore_differences=_merge_argocd_application_ignore_differences(
+            current_ignore_differences=cast(Sequence[Mapping[str, Any]] | None, child_sync_state.get('ignore_differences')),
+            resources=resources,
+        ),
     )
     applicationset_report = _set_argocd_automation_mode(
         config=config,
@@ -6203,7 +6372,7 @@ def _prepare_argocd_for_run(
         'changed': (
             child_application_report['changed']
             or root_application_report['changed']
-            or application_skip_reconcile_report['changed']
+            or application_ignore_differences_report['changed']
             or applicationset_report['changed']
         ),
         'pointer': automation_state.get('pointer'),
@@ -6213,7 +6382,7 @@ def _prepare_argocd_for_run(
         'applicationset_managed': True,
         'applicationset': applicationset_report,
         'application_sync_policy': child_application_report,
-        'application_skip_reconcile': application_skip_reconcile_report,
+        'application_ignore_differences': application_ignore_differences_report,
         'root_application': root_application_report,
         'application': application_mode_report,
     }
@@ -6222,6 +6391,7 @@ def _prepare_argocd_for_run(
 def _ensure_argocd_manual_before_runtime_mutation(
     *,
     config: ArgocdAutomationConfig,
+    resources: SimulationResources,
 ) -> dict[str, Any]:
     if not config.manage_automation:
         return {
@@ -6248,11 +6418,15 @@ def _ensure_argocd_manual_before_runtime_mutation(
         cast(Mapping[str, Any] | None, root_state.get('sync_policy'))
     )
     current_applicationset_mode = _normalized_automation_mode(_as_text(applicationset_state.get('mode')))
-    current_skip_reconcile_enabled = bool(application_state.get('skip_reconcile_enabled'))
+    current_ignore_differences = cast(Sequence[Mapping[str, Any]] | None, application_state.get('ignore_differences'))
+    current_runtime_guard_complete = _argocd_ignore_differences_cover_runtime_mutations(
+        current_ignore_differences=current_ignore_differences,
+        resources=resources,
+    )
     if (
         current_applicationset_mode == desired_mode
         and current_application_mode == desired_mode
-        and current_skip_reconcile_enabled
+        and current_runtime_guard_complete
         and current_root_sync_policy == desired_root_sync_policy
     ):
         return {
@@ -6277,16 +6451,16 @@ def _ensure_argocd_manual_before_runtime_mutation(
                 'app_name': config.app_name,
                 'current_mode': current_application_mode,
             },
-            'application_skip_reconcile': {
+            'application_ignore_differences': {
                 'app_name': config.app_name,
-                'current_value': _as_text(application_state.get('skip_reconcile_value')),
-                'desired_value': 'true',
-                'enabled': current_skip_reconcile_enabled,
+                'current_ignore_differences': _normalized_argocd_ignore_differences(current_ignore_differences),
+                'required_ignore_differences': _simulation_runtime_argocd_ignore_differences(resources=resources),
+                'coverage_complete': current_runtime_guard_complete,
                 'changed': False,
             },
         }
 
-    report = _prepare_argocd_for_run(config=config)
+    report = _prepare_argocd_for_run(config=config, resources=resources)
     report['reason'] = 'reasserted_manual_before_runtime_mutation'
     return report
 
@@ -6297,7 +6471,7 @@ def _restore_argocd_after_run(
     previous_mode: str | None,
     previous_root_sync_policy: Mapping[str, Any] | None,
     previous_child_sync_policy: Mapping[str, Any] | None,
-    previous_child_skip_reconcile_value: str | None,
+    previous_child_ignore_differences: Sequence[Mapping[str, Any]] | None,
 ) -> dict[str, Any]:
     if not config.manage_automation:
         return {
@@ -6316,10 +6490,10 @@ def _restore_argocd_after_run(
         app_name=config.app_name,
         desired_sync_policy=previous_child_sync_policy,
     )
-    child_skip_reconcile_report = _set_argocd_application_skip_reconcile(
+    child_ignore_differences_report = _set_argocd_application_ignore_differences(
         config=config,
         app_name=config.app_name,
-        desired_value=previous_child_skip_reconcile_value,
+        desired_ignore_differences=previous_child_ignore_differences,
     )
     applicationset_report = _set_argocd_automation_mode(
         config=config,
@@ -6339,7 +6513,7 @@ def _restore_argocd_after_run(
         'managed': True,
         'changed': (
             child_application_report['changed']
-            or child_skip_reconcile_report['changed']
+            or child_ignore_differences_report['changed']
             or root_application_report['changed']
             or applicationset_report['changed']
         ),
@@ -6349,7 +6523,7 @@ def _restore_argocd_after_run(
         'applicationset_managed': True,
         'applicationset': applicationset_report,
         'application_sync_policy': child_application_report,
-        'application_skip_reconcile': child_skip_reconcile_report,
+        'application_ignore_differences': child_ignore_differences_report,
         'root_application': root_application_report,
         'application': application_mode_report,
     }
@@ -7075,7 +7249,7 @@ def _run_full_lifecycle(
     argocd_restore_required = False
     previous_root_application_sync_policy: dict[str, Any] | None = None
     previous_child_application_sync_policy: dict[str, Any] | None = None
-    previous_child_skip_reconcile_value: str | None = None
+    previous_child_ignore_differences: list[dict[str, Any]] | None = None
     teardown_succeeded = False
 
     try:
@@ -7109,15 +7283,20 @@ def _run_full_lifecycle(
                 previous_child_application_sync_policy = _clone_json_mapping(
                     cast(Mapping[str, Any] | None, current_app_state.get('sync_policy'))
                 )
-                previous_child_skip_reconcile_value = _as_text(current_app_state.get('skip_reconcile_value'))
+                previous_child_ignore_differences = _clone_json_list(
+                    cast(Sequence[Any] | None, current_app_state.get('ignore_differences'))
+                )
                 argocd_restore_required = (
                     previous_automation_mode != _normalized_automation_mode(argocd_config.desired_mode_during_run)
                 )
                 if _normalized_automation_mode(_as_text(current_app_state.get('automation_mode'))) != 'manual':
                     argocd_restore_required = True
-                if not bool(current_app_state.get('skip_reconcile_enabled')):
+                if not _argocd_ignore_differences_cover_runtime_mutations(
+                    current_ignore_differences=cast(Sequence[Mapping[str, Any]] | None, current_app_state.get('ignore_differences')),
+                    resources=resources,
+                ):
                     argocd_restore_required = True
-            argocd_prepare_report = _prepare_argocd_for_run(config=argocd_config)
+            argocd_prepare_report = _prepare_argocd_for_run(config=argocd_config, resources=resources)
             if previous_automation_mode is None:
                 previous_automation_mode = _as_text(argocd_prepare_report.get('previous_mode'))
             if previous_root_application_sync_policy is None:
@@ -7130,9 +7309,11 @@ def _run_full_lifecycle(
                 previous_child_application_sync_policy = _clone_json_mapping(
                     cast(Mapping[str, Any] | None, application_report.get('previous_sync_policy'))
                 )
-            if previous_child_skip_reconcile_value is None:
-                skip_report = _as_mapping(argocd_prepare_report.get('application_skip_reconcile'))
-                previous_child_skip_reconcile_value = _as_text(skip_report.get('previous_value'))
+            if previous_child_ignore_differences is None:
+                ignore_report = _as_mapping(argocd_prepare_report.get('application_ignore_differences'))
+                previous_child_ignore_differences = _clone_json_list(
+                    cast(Sequence[Any] | None, ignore_report.get('previous_ignore_differences'))
+                )
             argocd_prepare_succeeded = True
             _update_run_state(
                 resources=resources,
@@ -7501,7 +7682,7 @@ def _run_full_lifecycle(
                     previous_mode=previous_automation_mode,
                     previous_root_sync_policy=previous_root_application_sync_policy,
                     previous_child_sync_policy=previous_child_application_sync_policy,
-                    previous_child_skip_reconcile_value=previous_child_skip_reconcile_value,
+                    previous_child_ignore_differences=previous_child_ignore_differences,
                 )
                 _update_run_state(resources=resources, phase='argocd_restore', status='ok')
             except Exception as exc:

--- a/services/torghut/scripts/start_historical_simulation.py
+++ b/services/torghut/scripts/start_historical_simulation.py
@@ -2024,6 +2024,8 @@ def _manual_argocd_application_sync_policy(
     current_sync_policy: Mapping[str, Any] | None,
 ) -> dict[str, Any]:
     manual_policy = _clone_json_mapping(current_sync_policy) or {}
+    if _argocd_application_mode_from_sync_policy(manual_policy) == 'manual':
+        return manual_policy
     automated = _as_mapping(manual_policy.get('automated'))
     manual_automated = dict(automated)
     manual_automated['enabled'] = False

--- a/services/torghut/scripts/start_historical_simulation.py
+++ b/services/torghut/scripts/start_historical_simulation.py
@@ -5056,10 +5056,10 @@ def _dump_topics(
     dump_started_at = datetime.now(timezone.utc)
     raw_dump_path = dump_path
     staged_dump_path = _dump_sort_stage_path(dump_path)
-    sorted_dump_path = _dump_sort_output_path(dump_path)
     dump_format = _as_text(performance_cfg.get('dump_format')) or DEFAULT_SIMULATION_DUMP_FORMAT
     if _dump_format_for_path(dump_path) != 'ndjson':
         raw_dump_path = dump_path.with_suffix(dump_path.suffix + '.tmp.ndjson')
+    sorted_dump_path = _dump_sort_output_path(raw_dump_path)
     try:
         topic_partitions: list[Any] = []
         for topic in resources.replay_topic_by_source_topic.keys():

--- a/services/torghut/scripts/start_historical_simulation.py
+++ b/services/torghut/scripts/start_historical_simulation.py
@@ -73,6 +73,7 @@ DEFAULT_OUTPUT_ROOT = Path('artifacts/torghut/simulations')
 DEFAULT_SIMULATION_CACHE_BUCKET = 'argo-workflows'
 DEFAULT_SIMULATION_CACHE_ENDPOINT = 'http://rook-ceph-rgw-objectstore.rook-ceph.svc.cluster.local:80'
 DEFAULT_SIMULATION_CACHE_PREFIX = 'torghut-simulation-cache'
+SIMULATION_CACHE_KEY_SCHEMA_VERSION = 'torghut-simulation-cache-v2'
 
 PRODUCTION_TOPIC_BY_ROLE = dict(EQUITY_SIMULATION_LANE.source_topic_by_role)
 SIMULATION_TOPIC_BY_ROLE = dict(EQUITY_SIMULATION_LANE.simulation_topic_by_role)
@@ -211,6 +212,13 @@ DEFAULT_ROLLOUTS_TEARDOWN_TEMPLATE = 'torghut-simulation-teardown-clean'
 DEFAULT_ROLLOUTS_ARTIFACT_TEMPLATE = 'torghut-simulation-artifact-bundle'
 DEFAULT_ROLLOUTS_VERIFY_TIMEOUT_SECONDS = 1800
 DEFAULT_ROLLOUTS_VERIFY_POLL_SECONDS = 5
+DEFAULT_SIMULATION_CACHE_CEPH_TIMEOUT_SECONDS = 20
+SIMULATION_CACHE_UPLOAD_MIN_TIMEOUT_SECONDS = 60
+SIMULATION_CACHE_UPLOAD_TIMEOUT_MAX_SECONDS = 900
+SIMULATION_CACHE_UPLOAD_BYTES_PER_SECOND_FLOOR = 2 * 1024 * 1024
+SIMULATION_CACHE_UPLOAD_TIMEOUT_SLACK_SECONDS = 30
+SIMULATION_CACHE_UPLOAD_RETRY_ATTEMPTS = 3
+SIMULATION_CACHE_UPLOAD_RETRY_SLEEP_SECONDS = 2.0
 SIMULATION_RUNTIME_LOCK_NAME = 'torghut-historical-simulation-lock'
 SIMULATION_CLICKHOUSE_SCHEMA_SOURCE_DATABASE = 'torghut'
 SIMULATION_CLICKHOUSE_TABLE_VISIBILITY_ATTEMPTS = 10
@@ -2432,6 +2440,67 @@ def _dump_suffix(dump_format: str) -> str:
     return suffix
 
 
+def _stable_json_for_hash(payload: Mapping[str, Any]) -> str:
+    return json.dumps(dict(payload), sort_keys=True, separators=(',', ':'))
+
+
+def _stable_string_list(values: Any) -> list[str]:
+    return sorted({item for item in _as_string_list(values) if item})
+
+
+def _cache_lineage_payload(manifest: Mapping[str, Any]) -> dict[str, Any]:
+    performance_cfg = _performance_config(manifest)
+    return {
+        'schema_version': SIMULATION_CACHE_KEY_SCHEMA_VERSION,
+        'lane': _as_text(manifest.get('lane')) or 'equity',
+        'dataset_id': _as_text(manifest.get('dataset_id')),
+        'dataset_snapshot_ref': _as_text(manifest.get('dataset_snapshot_ref'))
+        or _as_text(manifest.get('dataset_id')),
+        'window': _as_mapping(manifest.get('window')),
+        'strategy_spec_ref': _as_text(manifest.get('strategy_spec_ref')),
+        'candidate_id': _as_text(manifest.get('candidate_id')),
+        'baseline_candidate_id': _as_text(manifest.get('baseline_candidate_id')),
+        'model_refs': _stable_string_list(manifest.get('model_refs')),
+        'runtime_version_refs': _stable_string_list(manifest.get('runtime_version_refs')),
+        'dump_format': _as_text(performance_cfg.get('dump_format')) or DEFAULT_SIMULATION_DUMP_FORMAT,
+        'profile': _as_text(performance_cfg.get('replay_profile')) or DEFAULT_SIMULATION_REPLAY_PROFILE,
+    }
+
+
+def _derived_simulation_cache_key(manifest: Mapping[str, Any]) -> str:
+    payload = _cache_lineage_payload(manifest)
+    return hashlib.sha256(_stable_json_for_hash(payload).encode('utf-8')).hexdigest()
+
+
+def _derived_simulation_cache_paths(cache_key: str, dump_format: str) -> dict[str, str]:
+    normalized_prefix = DEFAULT_SIMULATION_CACHE_PREFIX.strip('/')
+    object_key = '/'.join(
+        part
+        for part in (
+            normalized_prefix,
+            cache_key.strip(),
+            f'source-dump{_dump_suffix(dump_format)}',
+        )
+        if part
+    )
+    artifact_path = f's3://{DEFAULT_SIMULATION_CACHE_BUCKET}/{object_key}'
+    return {
+        'cache_artifact_path': artifact_path,
+        'cache_manifest_path': f'{artifact_path}.manifest.json',
+    }
+
+
+def _cache_artifact_lineage_matches(
+    *,
+    manifest: Mapping[str, Any],
+    artifact_manifest: Mapping[str, Any],
+) -> bool:
+    artifact_lineage = _as_mapping(artifact_manifest.get('lineage'))
+    if not artifact_lineage:
+        return False
+    return artifact_lineage == _cache_lineage_payload(manifest)
+
+
 def _state_paths(
     resources: SimulationResources,
     manifest: Mapping[str, Any] | None = None,
@@ -2448,6 +2517,77 @@ def _state_paths(
 
 def _dump_artifact_manifest_path(dump_path: Path) -> Path:
     return dump_path.with_suffix(dump_path.suffix + '.manifest.json')
+
+
+def _dump_sort_stage_path(dump_path: Path) -> Path:
+    return dump_path.with_suffix(dump_path.suffix + '.sort-stage.tsv')
+
+
+def _dump_sort_output_path(dump_path: Path) -> Path:
+    return dump_path.with_suffix(dump_path.suffix + '.sort-output.tsv')
+
+
+def _dump_sort_key(
+    *,
+    source_timestamp_ms: int,
+    source_topic: str,
+    source_partition: int,
+    source_offset: int,
+) -> str:
+    return '\t'.join(
+        (
+            f'{source_timestamp_ms:020d}',
+            source_topic,
+            f'{source_partition:010d}',
+            f'{source_offset:020d}',
+        )
+    )
+
+
+def _materialize_deterministic_dump(
+    *,
+    staged_path: Path,
+    dump_path: Path,
+) -> str:
+    _ensure_supported_binary('sort')
+    sorted_path = _dump_sort_output_path(dump_path)
+    try:
+        with sorted_path.open('w', encoding='utf-8') as sorted_handle:
+            subprocess.run(
+                [
+                    'sort',
+                    '-t',
+                    '\t',
+                    '-k1,1n',
+                    '-k2,2',
+                    '-k3,3n',
+                    '-k4,4n',
+                    str(staged_path),
+                ],
+                check=True,
+                text=True,
+                stdout=sorted_handle,
+                stderr=subprocess.PIPE,
+            )
+    except FileNotFoundError as exc:
+        raise RuntimeError(f'command_missing: sort: {exc.filename}') from exc
+    except subprocess.CalledProcessError as exc:
+        detail = (exc.stderr or '').strip() or str(exc)
+        raise RuntimeError(f'command_failed: sort: {detail}') from exc
+
+    hasher = hashlib.sha256()
+    with sorted_path.open('r', encoding='utf-8') as sorted_handle, dump_path.open('w', encoding='utf-8') as dump_handle:
+        for row in sorted_handle:
+            parts = row.split('\t', 4)
+            if len(parts) != 5:
+                raise RuntimeError('deterministic_dump_sort_row_invalid')
+            line = parts[4]
+            dump_handle.write(line)
+            stripped = line.rstrip('\n')
+            hasher.update(stripped.encode('utf-8'))
+            hasher.update(b'\n')
+
+    return hasher.hexdigest()
 
 
 def _run_state_path(resources: SimulationResources) -> Path:
@@ -2467,7 +2607,9 @@ def _ta_restore_policy(manifest: Mapping[str, Any]) -> dict[str, Any]:
     mode = explicit_mode
     source = 'explicit'
     if not mode:
-        mode = 'required' if replay_profile == 'full_day' else 'stateless'
+        # Historical replay must be deterministic on a frozen dump; do not resume prior
+        # TA operator state unless a future lineage-aware restore contract exists.
+        mode = 'stateless'
         source = f'profile_default:{replay_profile}'
     allowed_modes = {'required', 'stateless_if_missing', 'stateless'}
     if mode not in allowed_modes:
@@ -2647,7 +2789,9 @@ def _write_dump_marker_from_manifest(
     )
 
 
-def _simulation_cache_client_from_env() -> tuple[CephS3Client | None, str]:
+def _simulation_cache_client_from_env(
+    timeout_seconds: int | None = None,
+) -> tuple[CephS3Client | None, str]:
     access_key = (
         os.getenv('TORGHUT_SIM_CACHE_CEPH_ACCESS_KEY', '').strip()
         or os.getenv('AWS_ACCESS_KEY_ID', '').strip()
@@ -2665,9 +2809,17 @@ def _simulation_cache_client_from_env() -> tuple[CephS3Client | None, str]:
         or DEFAULT_SIMULATION_CACHE_ENDPOINT
     )
     region = os.getenv('TORGHUT_SIM_CACHE_CEPH_REGION', 'us-east-1').strip() or 'us-east-1'
-    timeout_seconds = max(
+    effective_timeout_seconds = max(
         1,
-        int(os.getenv('TORGHUT_SIM_CACHE_CEPH_TIMEOUT_SECONDS', '20') or '20'),
+        timeout_seconds
+        if timeout_seconds is not None
+        else int(
+            os.getenv(
+                'TORGHUT_SIM_CACHE_CEPH_TIMEOUT_SECONDS',
+                str(DEFAULT_SIMULATION_CACHE_CEPH_TIMEOUT_SECONDS),
+            )
+            or str(DEFAULT_SIMULATION_CACHE_CEPH_TIMEOUT_SECONDS)
+        ),
     )
     if not access_key or not secret_key or not endpoint:
         return None, bucket
@@ -2677,19 +2829,112 @@ def _simulation_cache_client_from_env() -> tuple[CephS3Client | None, str]:
             access_key=access_key,
             secret_key=secret_key,
             region=region,
-            timeout_seconds=timeout_seconds,
+            timeout_seconds=effective_timeout_seconds,
         ),
         bucket,
     )
 
 
+def _simulation_cache_upload_timeout_seconds(dump_path: Path) -> int:
+    configured_timeout_seconds = max(
+        1,
+        int(
+            os.getenv(
+                'TORGHUT_SIM_CACHE_CEPH_TIMEOUT_SECONDS',
+                str(DEFAULT_SIMULATION_CACHE_CEPH_TIMEOUT_SECONDS),
+            )
+            or str(DEFAULT_SIMULATION_CACHE_CEPH_TIMEOUT_SECONDS)
+        ),
+    )
+    size_bytes = max(dump_path.stat().st_size, 0)
+    size_based_timeout_seconds = SIMULATION_CACHE_UPLOAD_TIMEOUT_SLACK_SECONDS
+    if size_bytes > 0:
+        size_based_timeout_seconds += int(
+            (
+                size_bytes + SIMULATION_CACHE_UPLOAD_BYTES_PER_SECOND_FLOOR - 1
+            )
+            // SIMULATION_CACHE_UPLOAD_BYTES_PER_SECOND_FLOOR
+        )
+    return min(
+        SIMULATION_CACHE_UPLOAD_TIMEOUT_MAX_SECONDS,
+        max(
+            configured_timeout_seconds,
+            SIMULATION_CACHE_UPLOAD_MIN_TIMEOUT_SECONDS,
+            size_based_timeout_seconds,
+        ),
+    )
+
+
+def _simulation_cache_upload_attempts() -> tuple[int, float]:
+    attempts = max(
+        1,
+        _safe_int(
+            os.getenv(
+                'TORGHUT_SIM_CACHE_CEPH_UPLOAD_RETRY_ATTEMPTS',
+                str(SIMULATION_CACHE_UPLOAD_RETRY_ATTEMPTS),
+            ),
+            default=SIMULATION_CACHE_UPLOAD_RETRY_ATTEMPTS,
+        ),
+    )
+    try:
+        sleep_seconds = float(
+            os.getenv(
+                'TORGHUT_SIM_CACHE_CEPH_UPLOAD_RETRY_SLEEP_SECONDS',
+                str(SIMULATION_CACHE_UPLOAD_RETRY_SLEEP_SECONDS),
+            )
+            or str(SIMULATION_CACHE_UPLOAD_RETRY_SLEEP_SECONDS)
+        )
+    except ValueError:
+        sleep_seconds = SIMULATION_CACHE_UPLOAD_RETRY_SLEEP_SECONDS
+    return attempts, max(sleep_seconds, 0.0)
+
+
+def _is_transient_simulation_cache_upload_error(error: Exception) -> bool:
+    if isinstance(error, (TimeoutError, OSError)):
+        return True
+    message = str(error).lower()
+    if not message:
+        return False
+    transient_markers = (
+        'timed out',
+        'timeout',
+        'temporary failure',
+        'temporarily unavailable',
+        'connection reset',
+        'connection aborted',
+        'broken pipe',
+        'service unavailable',
+        'ceph_upload_http_500',
+        'ceph_upload_http_502',
+        'ceph_upload_http_503',
+        'ceph_upload_http_504',
+    )
+    return any(marker in message for marker in transient_markers)
+
+
 def _cache_metadata(manifest: Mapping[str, Any]) -> dict[str, str]:
     metadata = _as_mapping(manifest.get('metadata'))
+    performance_cfg = _performance_config(manifest)
+    cache_decision = (_as_text(metadata.get('cacheDecision')) or '').lower()
+    cache_key = _as_text(metadata.get('cacheKey')) or _derived_simulation_cache_key(manifest)
+    cache_artifact_path = _as_text(metadata.get('cacheArtifactPath')) or ''
+    cache_manifest_path = _as_text(metadata.get('cacheChunkManifestPath')) or ''
+    if cache_key and (not cache_artifact_path or not cache_manifest_path):
+        derived_paths = _derived_simulation_cache_paths(
+            cache_key,
+            _as_text(performance_cfg.get('dump_format')) or DEFAULT_SIMULATION_DUMP_FORMAT,
+        )
+        if not cache_artifact_path:
+            cache_artifact_path = derived_paths['cache_artifact_path']
+        if not cache_manifest_path:
+            cache_manifest_path = derived_paths['cache_manifest_path']
+    if not cache_decision and (_as_text(performance_cfg.get('cache_policy')) or 'prefer_cache') == 'refresh':
+        cache_decision = 'refresh'
     return {
-        'cache_key': _as_text(metadata.get('cacheKey')) or '',
-        'cache_decision': (_as_text(metadata.get('cacheDecision')) or '').lower(),
-        'cache_artifact_path': _as_text(metadata.get('cacheArtifactPath')) or '',
-        'cache_manifest_path': _as_text(metadata.get('cacheChunkManifestPath')) or '',
+        'cache_key': cache_key,
+        'cache_decision': cache_decision,
+        'cache_artifact_path': cache_artifact_path,
+        'cache_manifest_path': cache_manifest_path,
     }
 
 
@@ -2715,6 +2960,11 @@ def _restore_cached_dump_if_available(
     cache_artifact_path = cache['cache_artifact_path']
     cache_manifest_path = cache['cache_manifest_path']
     cache_policy = _as_text(_performance_config(manifest).get('cache_policy')) or 'prefer_cache'
+    cache_decision = cache['cache_decision']
+    if cache_decision and cache_decision != 'hit':
+        if cache_policy == 'require_cache':
+            raise RuntimeError(f'required_cache_not_ready:{cache_decision}')
+        return None
     if not cache_artifact_path:
         if cache_policy == 'require_cache':
             raise RuntimeError('required_cache_artifact_path_missing')
@@ -2745,6 +2995,11 @@ def _restore_cached_dump_if_available(
             artifact_manifest = json.loads(manifest_payload.decode('utf-8'))
             if not isinstance(artifact_manifest, Mapping):
                 raise RuntimeError('cache_manifest_invalid_payload')
+            if not _cache_artifact_lineage_matches(
+                manifest=manifest,
+                artifact_manifest=cast(Mapping[str, Any], artifact_manifest),
+            ):
+                raise RuntimeError('cache_manifest_lineage_mismatch')
             _dump_artifact_manifest_path(dump_path).write_text(
                 json.dumps(dict(artifact_manifest), indent=2, sort_keys=True),
                 encoding='utf-8',
@@ -2803,7 +3058,8 @@ def _upload_dump_to_cache(
     if artifact_ref is None or manifest_ref is None:
         return None
 
-    client, default_bucket = _simulation_cache_client_from_env()
+    timeout_seconds = _simulation_cache_upload_timeout_seconds(dump_path)
+    client, default_bucket = _simulation_cache_client_from_env(timeout_seconds=timeout_seconds)
     if client is None:
         return None
 
@@ -2817,26 +3073,45 @@ def _upload_dump_to_cache(
         'jsonl.gz': 'application/gzip',
         'jsonl.zst': 'application/zstd',
     }[_dump_format_for_path(dump_path)]
-    dump_result = client.put_object(
-        bucket=bucket,
-        key=key,
-        body=dump_path.read_bytes(),
-        content_type=dump_content_type,
-    )
     manifest_path = _dump_artifact_manifest_path(dump_path)
-    manifest_result = client.put_object(
-        bucket=manifest_bucket,
-        key=manifest_key,
-        body=manifest_path.read_bytes(),
-        content_type='application/json',
-    )
-    return {
-        'cache_key': cache_key,
-        'artifact_path': f's3://{bucket}/{key}',
-        'artifact_etag': dump_result.get('etag'),
-        'manifest_path': f's3://{manifest_bucket}/{manifest_key}',
-        'manifest_etag': manifest_result.get('etag'),
-    }
+    dump_body = dump_path.read_bytes()
+    manifest_body = manifest_path.read_bytes()
+    retry_attempts, retry_sleep_seconds = _simulation_cache_upload_attempts()
+    last_error: Exception | None = None
+
+    for attempt in range(1, retry_attempts + 1):
+        try:
+            dump_result = client.put_object(
+                bucket=bucket,
+                key=key,
+                body=dump_body,
+                content_type=dump_content_type,
+            )
+            manifest_result = client.put_object(
+                bucket=manifest_bucket,
+                key=manifest_key,
+                body=manifest_body,
+                content_type='application/json',
+            )
+            return {
+                'status': 'ok',
+                'cache_key': cache_key,
+                'artifact_path': f's3://{bucket}/{key}',
+                'artifact_etag': dump_result.get('etag'),
+                'manifest_path': f's3://{manifest_bucket}/{manifest_key}',
+                'manifest_etag': manifest_result.get('etag'),
+                'timeout_seconds': timeout_seconds,
+                'attempt_count': attempt,
+            }
+        except Exception as exc:
+            last_error = exc
+            if attempt >= retry_attempts or not _is_transient_simulation_cache_upload_error(exc):
+                break
+            time.sleep(retry_sleep_seconds * attempt)
+
+    if last_error is None:
+        return None
+    raise last_error
 
 
 def _utc_from_millis(value: int | None) -> datetime | None:
@@ -4774,13 +5049,14 @@ def _dump_topics(
     from kafka import TopicPartition  # type: ignore[import-not-found]
 
     consumer = _consumer_for_dump(kafka_config, resources.run_token)
-    hasher = hashlib.sha256()
     count = 0
     count_by_topic: dict[str, int] = {}
     min_source_timestamp_ms: int | None = None
     max_source_timestamp_ms: int | None = None
     dump_started_at = datetime.now(timezone.utc)
     raw_dump_path = dump_path
+    staged_dump_path = _dump_sort_stage_path(dump_path)
+    sorted_dump_path = _dump_sort_output_path(dump_path)
     dump_format = _as_text(performance_cfg.get('dump_format')) or DEFAULT_SIMULATION_DUMP_FORMAT
     if _dump_format_for_path(dump_path) != 'ndjson':
         raw_dump_path = dump_path.with_suffix(dump_path.suffix + '.tmp.ndjson')
@@ -4828,7 +5104,7 @@ def _dump_topics(
 
         _ensure_directory(raw_dump_path)
         done: set[Any] = set()
-        with raw_dump_path.open('w', encoding='utf-8') as handle:
+        with staged_dump_path.open('w', encoding='utf-8') as handle:
             idle_polls = 0
             while len(done) < len(topic_partitions):
                 if count >= expected_records:
@@ -4875,10 +5151,17 @@ def _dump_topics(
                             'headers': _headers_to_json(getattr(record, 'headers', [])),
                         }
                         line = json.dumps(line_payload, sort_keys=True)
+                        handle.write(
+                            _dump_sort_key(
+                                source_timestamp_ms=int(record.timestamp),
+                                source_topic=source_topic,
+                                source_partition=int(record.partition),
+                                source_offset=int(record.offset),
+                            )
+                        )
+                        handle.write('\t')
                         handle.write(line)
                         handle.write('\n')
-                        hasher.update(line.encode('utf-8'))
-                        hasher.update(b'\n')
                         count += 1
                         count_by_topic[source_topic] = count_by_topic.get(source_topic, 0) + 1
                         source_timestamp_ms = int(record.timestamp)
@@ -4900,6 +5183,10 @@ def _dump_topics(
                         done.update(topic_partitions)
                         break
 
+        payload_sha256 = _materialize_deterministic_dump(
+            staged_path=staged_dump_path,
+            dump_path=raw_dump_path,
+        )
         if raw_dump_path != dump_path:
             _compress_dump_file(source_path=raw_dump_path, dump_path=dump_path)
         file_sha256 = _file_sha256(dump_path)
@@ -4910,7 +5197,7 @@ def _dump_topics(
             'records': count,
             'expected_records': expected_records,
             'sha256': file_sha256,
-            'payload_sha256': hasher.hexdigest(),
+            'payload_sha256': payload_sha256,
             'records_by_topic': count_by_topic,
             'start': start.isoformat(),
             'end': end.isoformat(),
@@ -4934,7 +5221,7 @@ def _dump_topics(
                 'dump_path': str(dump_path),
                 'dump_format': dump_format,
                 'records_by_topic': count_by_topic,
-                'payload_sha256': hasher.hexdigest(),
+                'payload_sha256': payload_sha256,
                 'dump_sha256': file_sha256,
             },
         )
@@ -4951,6 +5238,7 @@ def _dump_topics(
             {
                 'dataset_id': resources.dataset_id,
                 'run_id': resources.run_id,
+                'lineage': _cache_lineage_payload(manifest),
                 'dump_format': dump_format,
                 'cache_policy': _as_text(performance_cfg.get('cache_policy')) or 'prefer_cache',
                 'replay_profile': _as_text(performance_cfg.get('replay_profile')) or DEFAULT_SIMULATION_REPLAY_PROFILE,
@@ -4960,7 +5248,7 @@ def _dump_topics(
                         'path': str(dump_path),
                         'records': count,
                         'sha256': file_sha256,
-                        'payload_sha256': hasher.hexdigest(),
+                        'payload_sha256': payload_sha256,
                         'min_source_timestamp_ms': min_source_timestamp_ms,
                         'max_source_timestamp_ms': max_source_timestamp_ms,
                     }
@@ -4968,16 +5256,31 @@ def _dump_topics(
             },
         )
         if _cache_metadata(manifest)['cache_decision'] != 'hit':
-            cache_upload_report = _upload_dump_to_cache(
-                manifest=manifest,
-                dump_path=dump_path,
-            )
+            try:
+                cache_upload_report = _upload_dump_to_cache(
+                    manifest=manifest,
+                    dump_path=dump_path,
+                )
+            except Exception as exc:
+                cache_upload_report = {
+                    'status': 'error',
+                    'cache_key': _cache_metadata(manifest).get('cache_key'),
+                    'error': str(exc),
+                }
+                _log_script_event(
+                    'Failed to upload simulation dump to durable cache',
+                    cache_key=_cache_metadata(manifest).get('cache_key') or 'unknown',
+                    cache_artifact_path=_cache_metadata(manifest).get('cache_artifact_path') or None,
+                    error=str(exc),
+                )
             if cache_upload_report is not None:
                 report['cache_upload'] = cache_upload_report
         return report
     finally:
         if raw_dump_path != dump_path:
             raw_dump_path.unlink(missing_ok=True)
+        staged_dump_path.unlink(missing_ok=True)
+        sorted_dump_path.unlink(missing_ok=True)
         consumer.close()
 
 
@@ -5433,6 +5736,7 @@ def _apply(
     kafka_config: KafkaRuntimeConfig,
     clickhouse_config: ClickHouseRuntimeConfig,
     postgres_config: PostgresRuntimeConfig,
+    argocd_config: ArgocdAutomationConfig | None = None,
     force_dump: bool,
     force_replay: bool,
 ) -> dict[str, Any]:
@@ -5450,6 +5754,7 @@ def _apply(
     ta_reconfigured = False
     torghut_reconfigured = False
     ta_restart_nonce: int | None = None
+    argocd_runtime_guard_report: dict[str, Any] | None = None
 
     state_path, run_manifest_path, dump_path = _state_paths(resources, manifest)
     _ensure_directory(state_path)
@@ -5581,6 +5886,13 @@ def _apply(
         )
         replay_cfg = _as_mapping(manifest.get('replay'))
         auto_offset_reset = (_as_text(replay_cfg.get('auto_offset_reset')) or 'earliest').lower()
+        if (
+            argocd_config is not None
+            and resources.target_mode == 'dedicated_service'
+        ):
+            argocd_runtime_guard_report = _ensure_argocd_manual_before_runtime_mutation(
+                config=argocd_config,
+            )
         ta_reconfigured = _ta_runtime_reconfigure_required(
             resources=resources,
             clickhouse_config=clickhouse_config,
@@ -5643,6 +5955,7 @@ def _apply(
         'ta_restart_forced': ta_restart_forced,
         'ta_reconfigured': ta_reconfigured,
         'torghut_reconfigured': torghut_reconfigured,
+        'argocd_runtime_guard': argocd_runtime_guard_report,
         'warm_lane_enabled': warm_lane_enabled,
         'account_label': account_label,
         'seeded_cursor_at': seeded_cursor_at.isoformat(),
@@ -5813,6 +6126,69 @@ def _prepare_argocd_for_run(
         'root_application': root_application_report,
         'application': application_mode_report,
     }
+
+
+def _ensure_argocd_manual_before_runtime_mutation(
+    *,
+    config: ArgocdAutomationConfig,
+) -> dict[str, Any]:
+    if not config.manage_automation:
+        return {
+            'managed': False,
+            'changed': False,
+            'reason': 'automation_management_disabled',
+        }
+
+    desired_mode = _normalized_automation_mode(config.desired_mode_during_run)
+    applicationset_state = _read_argocd_automation_mode(config=config)
+    application_state = _read_named_argocd_application_sync_policy(
+        namespace=config.applicationset_namespace,
+        app_name=config.app_name,
+    )
+    root_state = _read_named_argocd_application_sync_policy(
+        namespace=config.applicationset_namespace,
+        app_name=config.root_app_name,
+    )
+    desired_root_sync_policy = _manual_argocd_application_sync_policy(
+        cast(Mapping[str, Any] | None, root_state.get('sync_policy'))
+    )
+    current_application_mode = _normalized_automation_mode(_as_text(application_state.get('automation_mode')))
+    current_root_sync_policy = _clone_json_mapping(
+        cast(Mapping[str, Any] | None, root_state.get('sync_policy'))
+    )
+    current_applicationset_mode = _normalized_automation_mode(_as_text(applicationset_state.get('mode')))
+    if (
+        current_applicationset_mode == desired_mode
+        and current_application_mode == desired_mode
+        and current_root_sync_policy == desired_root_sync_policy
+    ):
+        return {
+            'managed': True,
+            'changed': False,
+            'reason': 'already_manual',
+            'desired_mode': desired_mode,
+            'current_mode': current_application_mode,
+            'applicationset_managed': True,
+            'applicationset': {
+                'pointer': applicationset_state.get('pointer'),
+                'current_mode': current_applicationset_mode,
+                'desired_mode': desired_mode,
+                'changed': False,
+            },
+            'root_application': {
+                'current_sync_policy': current_root_sync_policy,
+                'desired_sync_policy': desired_root_sync_policy,
+                'changed': False,
+            },
+            'application': {
+                'app_name': config.app_name,
+                'current_mode': current_application_mode,
+            },
+        }
+
+    report = _prepare_argocd_for_run(config=config)
+    report['reason'] = 'reasserted_manual_before_runtime_mutation'
+    return report
 
 
 def _restore_argocd_after_run(
@@ -6379,6 +6755,28 @@ def _existing_artifact_refs(resources: SimulationResources, analytics_report: Ma
     return refs
 
 
+def _completion_trace_coverage_ratio(
+    *,
+    window_policy: Mapping[str, Any],
+    dump_coverage: Mapping[str, Any],
+    analytics_report: Mapping[str, Any],
+) -> float:
+    coverage_ratio = dump_coverage.get('coverage_ratio')
+    if coverage_ratio is not None:
+        return max(_safe_float(coverage_ratio), 0.0)
+
+    observed_minutes = _safe_float(dump_coverage.get('observed_minutes'), default=0.0)
+    min_coverage_minutes = _safe_int(window_policy.get('min_coverage_minutes'), default=0)
+    if observed_minutes > 0 and min_coverage_minutes > 0:
+        return max(observed_minutes / float(min_coverage_minutes), 0.0)
+
+    report_coverage = _as_mapping(analytics_report.get('coverage'))
+    report_ratio = report_coverage.get('window_coverage_ratio_from_dump')
+    if report_ratio is not None:
+        return max(_safe_float(report_ratio), 0.0)
+    return 0.0
+
+
 def _build_simulation_completion_trace(
     *,
     resources: SimulationResources,
@@ -6407,7 +6805,11 @@ def _build_simulation_completion_trace(
     execution_order_events = _safe_int(final_snapshot.get('execution_order_events'))
     activity_classification = _as_text(monitor_payload.get('activity_classification')) or 'unknown'
     runtime_state = _as_text(runtime_payload.get('runtime_state')) or 'unknown'
-    coverage_ratio = float(dump_coverage.get('coverage_ratio') or 0.0)
+    coverage_ratio = _completion_trace_coverage_ratio(
+        window_policy=window_policy,
+        dump_coverage=dump_coverage,
+        analytics_report=analytics_payload,
+    )
     strict_ratio = float(window_policy.get('strict_coverage_ratio') or 0.0)
     fill_price_payload = _as_mapping(fill_price_error_budget_report)
     gate_results: dict[str, dict[str, Any]] = {}
@@ -6612,6 +7014,7 @@ def _run_full_lifecycle(
                 kafka_config=kafka_config,
                 clickhouse_config=clickhouse_config,
                 postgres_config=postgres_config,
+                argocd_config=argocd_config,
                 force_dump=force_dump,
                 force_replay=force_replay,
             )
@@ -7215,6 +7618,7 @@ def main() -> None:
             kafka_config=kafka_config,
             clickhouse_config=clickhouse_config,
             postgres_config=postgres_config,
+            argocd_config=argocd_config,
             force_dump=bool(args.force_dump),
             force_replay=bool(args.force_replay),
         )

--- a/services/torghut/scripts/verify_historical_simulation_parity.py
+++ b/services/torghut/scripts/verify_historical_simulation_parity.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Verify deterministic parity across historical simulation run directories."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+
+@dataclass(frozen=True)
+class ParitySnapshot:
+    run_dir: Path
+    run_id: str
+    activity_classification: str
+    trade_decisions: int
+    executions: int
+    execution_tca_metrics: int
+    execution_order_events: int
+    legacy_path_count: int
+    fallback_count: int
+    net_pnl_estimated: str
+    dump_sha256: str
+    parity_hash: str
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--run-dir', action='append', required=True, help='Historical simulation run directory.')
+    parser.add_argument('--json', action='store_true')
+    return parser.parse_args()
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding='utf-8'))
+    if not isinstance(payload, Mapping):
+        raise RuntimeError(f'json_mapping_required:{path}')
+    return {str(key): value for key, value in payload.items()}
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return {str(key): item for key, item in value.items()} if isinstance(value, Mapping) else {}
+
+
+def _as_text(value: Any) -> str:
+    return str(value).strip() if value is not None else ''
+
+
+def _as_int(value: Any) -> int:
+    try:
+        return int(value)
+    except Exception:
+        return 0
+
+
+def _stable_hash(payload: Mapping[str, Any]) -> str:
+    encoded = json.dumps(dict(payload), sort_keys=True, separators=(',', ':'), default=str).encode('utf-8')
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _load_snapshot(run_dir: Path) -> ParitySnapshot:
+    lifecycle = _load_json(run_dir / 'run-full-lifecycle-manifest.json')
+    report = _as_dict(lifecycle.get('report'))
+    replay = _as_dict(lifecycle.get('replay'))
+    monitor = _as_dict(lifecycle.get('monitor'))
+    final_snapshot = _as_dict(monitor.get('final_snapshot'))
+    funnel = _as_dict(report.get('funnel'))
+    pnl = _as_dict(report.get('pnl'))
+
+    canonical_payload = {
+        'activity_classification': _as_text(monitor.get('activity_classification')),
+        'trade_decisions': _as_int(funnel.get('trade_decisions')),
+        'executions': _as_int(funnel.get('executions')),
+        'execution_tca_metrics': _as_int(funnel.get('execution_tca_metrics')),
+        'execution_order_events': _as_int(funnel.get('execution_order_events')),
+        'legacy_path_count': _as_int(final_snapshot.get('legacy_path_count')),
+        'fallback_count': _as_int(final_snapshot.get('fallback_count')),
+        'net_pnl_estimated': _as_text(pnl.get('net_pnl_estimated')),
+        'dump_sha256': _as_text(replay.get('dump_sha256')),
+    }
+
+    return ParitySnapshot(
+        run_dir=run_dir,
+        run_id=_as_text(lifecycle.get('run_id')) or run_dir.name,
+        activity_classification=canonical_payload['activity_classification'],
+        trade_decisions=canonical_payload['trade_decisions'],
+        executions=canonical_payload['executions'],
+        execution_tca_metrics=canonical_payload['execution_tca_metrics'],
+        execution_order_events=canonical_payload['execution_order_events'],
+        legacy_path_count=canonical_payload['legacy_path_count'],
+        fallback_count=canonical_payload['fallback_count'],
+        net_pnl_estimated=canonical_payload['net_pnl_estimated'],
+        dump_sha256=canonical_payload['dump_sha256'],
+        parity_hash=_stable_hash(canonical_payload),
+    )
+
+
+def build_historical_parity_report(*, run_dirs: list[Path]) -> dict[str, Any]:
+    snapshots = [_load_snapshot(path) for path in run_dirs]
+    if len(snapshots) < 2:
+        raise RuntimeError('historical_parity_requires_at_least_two_runs')
+    baseline = snapshots[0]
+    failed_reasons: list[str] = []
+    for snapshot in snapshots:
+        if snapshot.activity_classification != 'success':
+            failed_reasons.append(f'activity_not_success:{snapshot.run_id}')
+        if snapshot.legacy_path_count != 0:
+            failed_reasons.append(f'legacy_path_count_nonzero:{snapshot.run_id}')
+        if snapshot.fallback_count != 0:
+            failed_reasons.append(f'fallback_count_nonzero:{snapshot.run_id}')
+        if snapshot.parity_hash != baseline.parity_hash:
+            failed_reasons.append(f'parity_hash_mismatch:{snapshot.run_id}')
+        if snapshot.dump_sha256 != baseline.dump_sha256:
+            failed_reasons.append(f'dump_sha256_mismatch:{snapshot.run_id}')
+    return {
+        'schema_version': 'torghut.historical-simulation-parity.v1',
+        'passed': not failed_reasons,
+        'failed_reasons': failed_reasons,
+        'baseline_run_id': baseline.run_id,
+        'baseline_parity_hash': baseline.parity_hash,
+        'baseline_dump_sha256': baseline.dump_sha256,
+        'runs': [
+            {
+                'run_id': item.run_id,
+                'run_dir': str(item.run_dir),
+                'activity_classification': item.activity_classification,
+                'trade_decisions': item.trade_decisions,
+                'executions': item.executions,
+                'execution_tca_metrics': item.execution_tca_metrics,
+                'execution_order_events': item.execution_order_events,
+                'legacy_path_count': item.legacy_path_count,
+                'fallback_count': item.fallback_count,
+                'net_pnl_estimated': item.net_pnl_estimated,
+                'dump_sha256': item.dump_sha256,
+                'parity_hash': item.parity_hash,
+            }
+            for item in snapshots
+        ],
+    }
+
+
+def main() -> int:
+    args = _parse_args()
+    report = build_historical_parity_report(run_dirs=[Path(path) for path in args.run_dir])
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        print(json.dumps(report))
+    if not report.get('passed'):
+        raise SystemExit(1)
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/services/torghut/tests/test_build_historical_profitability_proof.py
+++ b/services/torghut/tests/test_build_historical_profitability_proof.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import TestCase
+
+import yaml
+
+from scripts.build_historical_profitability_proof import (
+    build_historical_profitability_bundle,
+)
+
+
+class TestBuildHistoricalProfitabilityProof(TestCase):
+    def test_builds_profitable_bundle_from_historical_runs(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            run_a = _write_run(
+                root=root,
+                run_name='sim-a',
+                trading_day='2026-03-02',
+                net_pnl='10',
+                decision_count=8,
+                execution_count=4,
+                avg_confidence='0.9',
+                dump_hash='dump-a',
+            )
+            run_b = _write_run(
+                root=root,
+                run_name='sim-b',
+                trading_day='2026-03-03',
+                net_pnl='5',
+                decision_count=7,
+                execution_count=3,
+                avg_confidence='0.85',
+                dump_hash='dump-b',
+            )
+            output_dir = root / 'out'
+
+            summary = build_historical_profitability_bundle(
+                run_dirs=[run_a, run_b],
+                output_dir=output_dir,
+                hypothesis='intraday_tsmom_v1 is profitable over the OOS replay window',
+            )
+
+            self.assertTrue(summary['passed'])
+            proof_payload = json.loads((output_dir / 'profitability-proof.json').read_text(encoding='utf-8'))
+            self.assertTrue(proof_payload['passed'])
+            self.assertEqual(proof_payload['sample_size'], 2)
+            self.assertEqual(proof_payload['window_days'], 2)
+
+            candidate_report = json.loads((output_dir / 'candidate-report.json').read_text(encoding='utf-8'))
+            self.assertEqual(candidate_report['metrics']['net_pnl'], '15')
+            self.assertEqual(candidate_report['metrics']['trade_count'], 7)
+            self.assertEqual(len(candidate_report['robustness']['folds']), 2)
+
+            validation_payload = json.loads(
+                (output_dir / 'profitability-evidence-validation.json').read_text(encoding='utf-8')
+            )
+            self.assertTrue(validation_payload['passed'])
+
+    def test_rejects_inconsistent_candidate_lineage(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            run_a = _write_run(
+                root=root,
+                run_name='sim-a',
+                trading_day='2026-03-02',
+                net_pnl='10',
+                decision_count=8,
+                execution_count=4,
+                avg_confidence='0.9',
+                dump_hash='dump-a',
+                candidate_id='intraday_tsmom_v1@prod',
+            )
+            run_b = _write_run(
+                root=root,
+                run_name='sim-b',
+                trading_day='2026-03-03',
+                net_pnl='5',
+                decision_count=7,
+                execution_count=3,
+                avg_confidence='0.85',
+                dump_hash='dump-b',
+                candidate_id='other_candidate@prod',
+            )
+
+            with self.assertRaises(RuntimeError):
+                build_historical_profitability_bundle(
+                    run_dirs=[run_a, run_b],
+                    output_dir=root / 'out',
+                )
+
+    def test_rejects_duplicate_trading_days(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            run_a = _write_run(
+                root=root,
+                run_name='sim-a',
+                trading_day='2026-03-02',
+                net_pnl='10',
+                decision_count=8,
+                execution_count=4,
+                avg_confidence='0.9',
+                dump_hash='dump-a',
+            )
+            run_b = _write_run(
+                root=root,
+                run_name='sim-b',
+                trading_day='2026-03-02',
+                net_pnl='5',
+                decision_count=7,
+                execution_count=3,
+                avg_confidence='0.85',
+                dump_hash='dump-b',
+            )
+
+            with self.assertRaises(RuntimeError):
+                build_historical_profitability_bundle(
+                    run_dirs=[run_a, run_b],
+                    output_dir=root / 'out',
+                )
+
+
+def _write_run(
+    *,
+    root: Path,
+    run_name: str,
+    trading_day: str,
+    net_pnl: str,
+    decision_count: int,
+    execution_count: int,
+    avg_confidence: str,
+    dump_hash: str,
+    candidate_id: str = 'intraday_tsmom_v1@prod',
+) -> Path:
+    run_dir = root / run_name
+    report_dir = run_dir / 'report'
+    report_dir.mkdir(parents=True, exist_ok=True)
+
+    manifest_path = root / f'{run_name}.yaml'
+    manifest_path.write_text(
+        yaml.safe_dump(
+            {
+                'window': {
+                    'trading_day': trading_day,
+                },
+                'candidate_id': candidate_id,
+                'baseline_candidate_id': 'cash-flat@baseline',
+                'strategy_spec_ref': 'strategy-specs/intraday_tsmom_v1@1.1.0.json',
+                'model_refs': ['rules/intraday_tsmom_v1'],
+                'runtime_version_refs': ['services/torghut@sha256:test'],
+                'monitor': {
+                    'min_trade_decisions': 1,
+                    'min_executions': 1,
+                },
+            },
+            sort_keys=False,
+        ),
+        encoding='utf-8',
+    )
+
+    (run_dir / 'run-manifest.json').write_text(
+        json.dumps(
+            {
+                'run_id': run_name,
+                'evidence_lineage': {
+                    'candidate_id': candidate_id,
+                    'baseline_candidate_id': 'cash-flat@baseline',
+                    'strategy_spec_ref': 'strategy-specs/intraday_tsmom_v1@1.1.0.json',
+                    'model_refs': ['rules/intraday_tsmom_v1'],
+                    'runtime_version_refs': ['services/torghut@sha256:test'],
+                },
+            }
+        ),
+        encoding='utf-8',
+    )
+    (run_dir / 'replay-report.json').write_text(
+        json.dumps(
+            {
+                'dump_sha256': dump_hash,
+            }
+        ),
+        encoding='utf-8',
+    )
+    (report_dir / 'trade-pnl.csv').write_text(
+        'avg_fill_price,created_at,execution_id,filled_qty,realized_pnl_contribution,side,symbol,trade_decision_id\n'
+        f'100,2026-03-16T12:00:00Z,exec-1,1,0,buy,AAPL,td-1\n'
+        f'100,2026-03-16T12:01:00Z,exec-2,1,{net_pnl},sell,AAPL,td-2\n',
+        encoding='utf-8',
+    )
+    (report_dir / 'simulation-report.json').write_text(
+        json.dumps(
+            {
+                'run_metadata': {
+                    'run_id': run_name,
+                    'manifest_path': str(manifest_path),
+                },
+                'coverage': {
+                    'window_start': f'{trading_day}T13:30:00+00:00',
+                },
+                'funnel': {
+                    'trade_decisions': decision_count,
+                    'executions': execution_count,
+                },
+                'pnl': {
+                    'net_pnl_estimated': net_pnl,
+                    'estimated_cost_total': '0',
+                    'execution_notional_total': '1000',
+                },
+                'llm': {
+                    'avg_confidence': avg_confidence,
+                },
+                'verdict': {
+                    'status': 'PASS',
+                },
+            }
+        ),
+        encoding='utf-8',
+    )
+    return run_dir

--- a/services/torghut/tests/test_feature_quality.py
+++ b/services/torghut/tests/test_feature_quality.py
@@ -73,6 +73,26 @@ class TestFeatureQuality(TestCase):
         self.assertIn('duplicate_ratio_exceeds_threshold', report.reasons)
         self.assertIn('feature_staleness_exceeds_budget', report.reasons)
 
+    def test_batch_treats_distinct_sources_as_distinct_feature_rows(self) -> None:
+        ts = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        signals = [
+            _signal(ts=ts, seq=1).model_copy(update={'source': 'ta'}),
+            _signal(ts=ts, seq=1).model_copy(update={'source': 'ws'}),
+        ]
+
+        report = evaluate_feature_batch_quality(
+            signals,
+            thresholds=FeatureQualityThresholds(
+                max_required_null_rate=0.01,
+                max_duplicate_ratio=0.0,
+                max_staleness_ms=2_000,
+            ),
+        )
+
+        self.assertTrue(report.accepted)
+        self.assertEqual(report.duplicate_ratio, 0.0)
+        self.assertNotIn('duplicate_ratio_exceeds_threshold', report.reasons)
+
     def test_batch_uses_event_time_for_staleness_in_simulation_mode(self) -> None:
         original = config.settings.trading_simulation_enabled
         config.settings.trading_simulation_enabled = True

--- a/services/torghut/tests/test_generate_historical_profitability_manifests.py
+++ b/services/torghut/tests/test_generate_historical_profitability_manifests.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import json
+from datetime import date, datetime
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import TestCase
+
+import yaml
+
+from scripts.generate_historical_profitability_manifests import (
+    generate_profitability_manifests,
+)
+
+
+class TestGenerateHistoricalProfitabilityManifests(TestCase):
+    def test_generates_business_day_manifests_for_frozen_digest(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir)
+
+            summary = generate_profitability_manifests(
+                start_day=date(2026, 3, 2),
+                end_day=date(2026, 3, 8),
+                digest='sha256:a9c60e5ed5ddd06253e3126d363d4f6c82c1ef4fc5ea809e21c012ee39d438a5',
+                output_dir=output_dir,
+                cache_policy='refresh',
+                candidate_id='intraday_tsmom_v1@prod',
+                baseline_candidate_id='intraday_tsmom_v1@baseline',
+                strategy_spec_ref='strategy-specs/intraday_tsmom_v1@1.1.0.json',
+                model_refs=['rules/intraday_tsmom_v1'],
+                generated_at=datetime(2026, 3, 16, 12, 0, 0),
+            )
+
+            manifests = summary['manifests']
+            self.assertEqual(len(manifests), 5)
+            self.assertEqual(
+                [item['trading_day'] for item in manifests],
+                ['2026-03-02', '2026-03-03', '2026-03-04', '2026-03-05', '2026-03-06'],
+            )
+
+            first_manifest_path = Path(manifests[0]['manifest_path'])
+            payload = yaml.safe_load(first_manifest_path.read_text(encoding='utf-8'))
+            self.assertEqual(payload['dataset_id'], 'torghut-full-day-20260302-a9c60e5e')
+            self.assertEqual(payload['cachePolicy'], 'refresh')
+            self.assertEqual(
+                payload['runtime_version_refs'],
+                [
+                    'services/torghut@sha256:a9c60e5ed5ddd06253e3126d363d4f6c82c1ef4fc5ea809e21c012ee39d438a5',
+                    'services/torghut-forecast@sha256:a9c60e5ed5ddd06253e3126d363d4f6c82c1ef4fc5ea809e21c012ee39d438a5',
+                ],
+            )
+            self.assertEqual(payload['window']['start'], '2026-03-02T13:30:00Z')
+            self.assertEqual(payload['window']['end'], '2026-03-02T20:00:00Z')
+            self.assertEqual(
+                payload['clickhouse']['simulation_database'],
+                'torghut_sim_2026_03_02_full_day_a9c60e5e',
+            )
+
+            index_payload = json.loads((output_dir / 'manifest-index.json').read_text(encoding='utf-8'))
+            self.assertEqual(index_payload['schema_version'], 'torghut.historical-profitability-manifest-index.v1')
+            self.assertEqual(index_payload['cache_policy'], 'refresh')

--- a/services/torghut/tests/test_run_simulation_analysis.py
+++ b/services/torghut/tests/test_run_simulation_analysis.py
@@ -233,7 +233,7 @@ class TestRunSimulationAnalysis(TestCase):
                 return_value={'runtime_state': 'ready', 'environment_state': 'complete'},
             ),
             patch(
-                'scripts.run_simulation_analysis._current_activity_report',
+                'scripts.run_simulation_analysis._monitor_run_completion',
                 return_value={'status': 'degraded', 'activity_classification': 'executions_absent'},
             ),
             redirect_stdout(stdout),
@@ -244,6 +244,67 @@ class TestRunSimulationAnalysis(TestCase):
         self.assertEqual(ctx.exception.code, 1)
         payload = json.loads(stdout.getvalue())
         self.assertEqual(payload['activity_classification'], 'executions_absent')
+
+    def test_activity_uses_completion_monitor_and_exits_zero_when_successful(self) -> None:
+        stdout = io.StringIO()
+        with (
+            patch(
+                'sys.argv',
+                [
+                    'run_simulation_analysis.py',
+                    'activity',
+                    '--run-id',
+                    'sim-1',
+                    '--dataset-id',
+                    'dataset-a',
+                    '--namespace',
+                    'torghut',
+                    '--torghut-service',
+                    'torghut-sim',
+                    '--ta-deployment',
+                    'torghut-ta-sim',
+                    '--forecast-service',
+                    'torghut-forecast-sim',
+                    '--window-start',
+                    '2026-03-06T14:30:00Z',
+                    '--window-end',
+                    '2026-03-06T15:30:00Z',
+                    '--signal-table',
+                    'torghut_sim_sim_1.ta_signals',
+                    '--price-table',
+                    'torghut_sim_sim_1.ta_microbars',
+                    '--postgres-base-dsn',
+                    'postgresql://torghut:secret@localhost:5432/postgres',
+                    '--postgres-database',
+                    'torghut_sim_sim_1',
+                    '--clickhouse-http-url',
+                    'http://clickhouse:8123',
+                    '--clickhouse-username',
+                    'torghut',
+                    '--json',
+                ],
+            ),
+            patch(
+                'scripts.run_simulation_analysis._runtime_verify',
+                return_value={'runtime_state': 'ready', 'environment_state': 'complete'},
+            ),
+            patch(
+                'scripts.run_simulation_analysis._monitor_run_completion',
+                return_value={
+                    'status': 'ok',
+                    'activity_classification': 'success',
+                    'trade_decisions': 3,
+                    'executions': 2,
+                },
+            ) as monitor_mock,
+            redirect_stdout(stdout),
+        ):
+            main()
+
+        monitor_mock.assert_called_once()
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(payload['activity_classification'], 'success')
+        self.assertEqual(payload['trade_decisions'], 3)
 
     def test_teardown_clean_does_not_require_window_arguments(self) -> None:
         stdout = io.StringIO()

--- a/services/torghut/tests/test_signal_ingest.py
+++ b/services/torghut/tests/test_signal_ingest.py
@@ -386,7 +386,7 @@ class TestSignalIngest(TestCase):
         self.assertEqual(batch.query_end, latest_signal)
         self.assertEqual(batch.signal_lag_seconds, 0.0)
 
-    def test_simulation_mode_fetch_uses_bounded_replay_query_without_order_by(self) -> None:
+    def test_simulation_mode_fetch_uses_bounded_cursor_ordered_query(self) -> None:
         engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
         Base.metadata.create_all(engine)
         session_local = sessionmaker(bind=engine, expire_on_commit=False, future=True)
@@ -417,7 +417,8 @@ class TestSignalIngest(TestCase):
         replay_query = ingestor.queries[-1]
         self.assertIn("WHERE event_ts >= toDateTime64", replay_query)
         self.assertIn("AND event_ts <= toDateTime64", replay_query)
-        self.assertNotIn("ORDER BY", replay_query)
+        self.assertIn("ORDER BY event_ts ASC, symbol ASC, seq ASC", replay_query)
+        self.assertIn("LIMIT 500", replay_query)
 
     def test_simulation_mode_fetch_filters_cursor_boundary_rows_before_advancing(self) -> None:
         engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
@@ -1117,6 +1118,66 @@ class TestSignalIngest(TestCase):
             [("AMAT", 6651), ("AMD", 18723), ("AVGO", 22894)],
         )
         self.assertIsNone(batch.no_signal_reason)
+
+    def test_simulation_fetch_query_is_cursor_ordered_limited_and_bounded(self) -> None:
+        ingestor = SimulationWindowIngestor(
+            schema='envelope',
+            table='torghut.ta_signals',
+            url='http://example',
+            latest_signal_ts=datetime(2026, 3, 13, 13, 30, 20, tzinfo=timezone.utc),
+            rows=[
+                {
+                    'event_ts': '2026-03-13T13:30:10Z',
+                    'symbol': 'AVGO',
+                    'payload': {'feature_schema_version': '3.0.0'},
+                    'timeframe': '1Sec',
+                    'seq': 22894,
+                    'source': 'ta',
+                },
+            ],
+            batch_size=64,
+            fast_forward_stale_cursor=False,
+        )
+
+        batch = ingestor._fetch_simulation_signals(
+            cursor_at=datetime(2026, 3, 13, 13, 30, 10, tzinfo=timezone.utc),
+            cursor_seq=22888,
+            cursor_symbol='AAPL',
+            latest_signal_at=datetime(2026, 3, 13, 13, 30, 20, tzinfo=timezone.utc),
+            poll_started_at=datetime(2026, 3, 13, 13, 30, 11, tzinfo=timezone.utc),
+            fast_forwarded=False,
+        )
+
+        query = ingestor.queries[-1]
+        self.assertIn('ORDER BY event_ts ASC, symbol ASC, seq ASC', query)
+        self.assertIn('LIMIT 64', query)
+        self.assertIn('event_ts <=', query)
+        self.assertIn("symbol > 'AAPL' OR (symbol = 'AAPL' AND seq > 22888)", query)
+        self.assertEqual([(signal.symbol, signal.seq) for signal in batch.signals], [('AVGO', 22894)])
+
+    def test_simulation_fetch_query_keeps_equal_timestamp_without_tiebreakers(self) -> None:
+        ingestor = SimulationWindowIngestor(
+            schema='envelope',
+            table='torghut.ta_signals',
+            url='http://example',
+            latest_signal_ts=datetime(2026, 3, 13, 13, 30, 20, tzinfo=timezone.utc),
+            rows=[],
+            batch_size=32,
+            fast_forward_stale_cursor=False,
+        )
+
+        ingestor._fetch_simulation_signals(
+            cursor_at=datetime(2026, 3, 13, 13, 30, 10, tzinfo=timezone.utc),
+            cursor_seq=None,
+            cursor_symbol=None,
+            latest_signal_at=datetime(2026, 3, 13, 13, 30, 20, tzinfo=timezone.utc),
+            poll_started_at=datetime(2026, 3, 13, 13, 30, 11, tzinfo=timezone.utc),
+            fast_forwarded=False,
+        )
+
+        query = ingestor.queries[-1]
+        self.assertIn('AND event_ts >= ', query)
+        self.assertNotIn('AND (event_ts > ', query)
 
     def test_cursor_is_account_scoped(self) -> None:
         engine = create_engine("sqlite+pysqlite:///:memory:", future=True)

--- a/services/torghut/tests/test_signal_ingest.py
+++ b/services/torghut/tests/test_signal_ingest.py
@@ -1295,6 +1295,62 @@ class TestSignalIngest(TestCase):
             self.assertEqual(len(batch.signals), 2)
             self.assertEqual(batch.cursor_at, base_ts + timedelta(seconds=1))
 
+    def test_fetch_signals_between_dedupes_identical_flat_rows(self) -> None:
+        base_ts = datetime(2026, 3, 13, 16, 34, 30, tzinfo=timezone.utc)
+        rows = [
+            {
+                "ts": base_ts.isoformat(),
+                "symbol": "META",
+                "seq": 3545,
+                "source": "ta",
+                "macd": -0.0137,
+                "macd_signal": 0.0135,
+                "rsi14": 40.82,
+                "price": 625.20,
+            },
+            {
+                "ts": base_ts.isoformat(),
+                "symbol": "META",
+                "seq": 3545,
+                "source": "ta",
+                "macd": -0.0137,
+                "macd_signal": 0.0135,
+                "rsi14": 40.82,
+                "price": 625.20,
+            },
+            {
+                "ts": (base_ts + timedelta(seconds=1)).isoformat(),
+                "symbol": "META",
+                "seq": 3546,
+                "source": "ta",
+                "macd": -0.0101,
+                "macd_signal": 0.0102,
+                "rsi14": 41.10,
+                "price": 625.50,
+            },
+        ]
+
+        class FlatDuplicateIngestor(SchemaDiscoveringIngestor):
+            def _query_clickhouse(self, query: str) -> list[dict[str, object]]:
+                if query.strip().startswith("SELECT name FROM system.columns"):
+                    return super()._query_clickhouse(query)
+                return rows
+
+        ingestor = FlatDuplicateIngestor(
+            schema="flat",
+            table="torghut.ta_signals",
+            url="http://example",
+            columns={"ts", "symbol", "seq", "source", "macd", "macd_signal", "rsi14", "price"},
+        )
+        signals = ingestor.fetch_signals_between(
+            start=base_ts,
+            end=base_ts + timedelta(seconds=2),
+            symbol="META",
+        )
+
+        self.assertEqual(len(signals), 2)
+        self.assertEqual([signal.seq for signal in signals], [3545, 3546])
+
     def test_fetch_signals_between_rejects_invalid_symbol(self) -> None:
         ingestor = CapturingIngestor(schema="flat", table="torghut.ta_signals", url="http://example")
         signals = ingestor.fetch_signals_between(

--- a/services/torghut/tests/test_signal_ingest.py
+++ b/services/torghut/tests/test_signal_ingest.py
@@ -653,23 +653,43 @@ class TestSignalIngest(TestCase):
         self.assertIn("AND event_ts <= toDateTime64", envelope_ingestor.last_query)
         self.assertIn("ORDER BY event_ts ASC, seq ASC", envelope_ingestor.last_query)
 
-    def test_fetch_signals_between_dedupes_envelope_duplicates_by_earliest_ingest(self) -> None:
+    def test_fetch_signals_between_dedupes_replay_duplicates_by_stable_identity(self) -> None:
         rows = [
             {
                 "event_ts": "2026-03-06T14:50:00Z",
                 "ingest_ts": "2026-03-08T01:33:32.461000Z",
                 "symbol": "SIM-SPY",
-                "payload": {"rsi14": 30},
+                "payload": {
+                    "rsi14": 30,
+                    "simulation_context": {
+                        "dataset_event_id": "evt-1",
+                        "source_topic": "torghut.trades.v1",
+                        "source_partition": 2,
+                        "source_offset": 900,
+                        "signal_seq": 100,
+                        "simulation_run_id": "sim-old",
+                    },
+                },
                 "seq": 100,
-                "source": "ta",
+                "source": "ws",
                 "window_size": "PT1S",
             },
             {
                 "event_ts": "2026-03-06T14:50:00Z",
                 "ingest_ts": "2026-03-06T14:51:00.316000Z",
                 "symbol": "SIM-SPY",
-                "payload": {"rsi14": 30},
-                "seq": 200,
+                "payload": {
+                    "rsi14": 30,
+                    "simulation_context": {
+                        "dataset_event_id": "evt-1",
+                        "source_topic": "torghut.trades.v1",
+                        "source_partition": 2,
+                        "source_offset": 900,
+                        "signal_seq": 100,
+                        "simulation_run_id": "sim-current",
+                    },
+                },
+                "seq": 100,
                 "source": "ws",
                 "window_size": "PT1S",
             },
@@ -677,9 +697,19 @@ class TestSignalIngest(TestCase):
                 "event_ts": "2026-03-06T14:50:01Z",
                 "ingest_ts": "2026-03-06T14:51:01.316000Z",
                 "symbol": "SIM-SPY",
-                "payload": {"rsi14": 31},
+                "payload": {
+                    "rsi14": 31,
+                    "simulation_context": {
+                        "dataset_event_id": "evt-2",
+                        "source_topic": "torghut.trades.v1",
+                        "source_partition": 2,
+                        "source_offset": 901,
+                        "signal_seq": 101,
+                        "simulation_run_id": "sim-current",
+                    },
+                },
                 "seq": 101,
-                "source": "ta",
+                "source": "ws",
                 "window_size": "PT1S",
             },
         ]
@@ -688,21 +718,82 @@ class TestSignalIngest(TestCase):
             def _query_clickhouse(self, query: str) -> list[dict[str, object]]:
                 return rows
 
-        ingestor = DuplicateEnvelopeIngestor(schema="envelope", table="torghut.ta_signals", url="http://example")
+        original_enabled = settings.trading_simulation_enabled
+        original_run_id = settings.trading_simulation_run_id
+        try:
+            settings.trading_simulation_enabled = True
+            settings.trading_simulation_run_id = "sim-current"
+            ingestor = DuplicateEnvelopeIngestor(schema="envelope", table="torghut.ta_signals", url="http://example")
+            signals = ingestor.fetch_signals_between(
+                start=datetime(2026, 3, 6, 14, 50, tzinfo=timezone.utc),
+                end=datetime(2026, 3, 6, 14, 51, tzinfo=timezone.utc),
+            )
+        finally:
+            settings.trading_simulation_enabled = original_enabled
+            settings.trading_simulation_run_id = original_run_id
+
+        self.assertEqual(len(signals), 2)
+        self.assertEqual(signals[0].event_ts, datetime(2026, 3, 6, 14, 50, tzinfo=timezone.utc))
+        self.assertEqual(signals[0].seq, 100)
+        self.assertEqual(signals[0].source, "ws")
+        self.assertEqual(
+            signals[0].payload.get("simulation_context", {}).get("simulation_run_id"),
+            "sim-current",
+        )
+        self.assertEqual(signals[1].seq, 101)
+
+    def test_fetch_signals_between_preserves_distinct_envelopes_sharing_timestamp(self) -> None:
+        rows = [
+            {
+                "event_ts": "2026-03-06T14:50:00Z",
+                "ingest_ts": "2026-03-08T01:33:32.461000Z",
+                "symbol": "SIM-SPY",
+                "payload": {
+                    "rsi14": 30,
+                    "simulation_context": {
+                        "dataset_event_id": "evt-1",
+                        "source_topic": "torghut.trades.v1",
+                        "source_partition": 2,
+                        "source_offset": 900,
+                        "signal_seq": 100,
+                    },
+                },
+                "seq": 100,
+                "source": "ta",
+                "window_size": "PT1S",
+            },
+            {
+                "event_ts": "2026-03-06T14:50:00Z",
+                "ingest_ts": "2026-03-06T14:51:00.316000Z",
+                "symbol": "SIM-SPY",
+                "payload": {
+                    "rsi14": 31,
+                    "simulation_context": {
+                        "dataset_event_id": "evt-2",
+                        "source_topic": "torghut.quotes.v1",
+                        "source_partition": 5,
+                        "source_offset": 1234,
+                        "signal_seq": 200,
+                    },
+                },
+                "seq": 200,
+                "source": "ws",
+                "window_size": "PT1S",
+            },
+        ]
+
+        class DistinctEnvelopeIngestor(ClickHouseSignalIngestor):
+            def _query_clickhouse(self, query: str) -> list[dict[str, object]]:
+                return rows
+
+        ingestor = DistinctEnvelopeIngestor(schema="envelope", table="torghut.ta_signals", url="http://example")
         signals = ingestor.fetch_signals_between(
             start=datetime(2026, 3, 6, 14, 50, tzinfo=timezone.utc),
             end=datetime(2026, 3, 6, 14, 51, tzinfo=timezone.utc),
         )
 
         self.assertEqual(len(signals), 2)
-        self.assertEqual(signals[0].event_ts, datetime(2026, 3, 6, 14, 50, tzinfo=timezone.utc))
-        self.assertEqual(signals[0].seq, 200)
-        self.assertEqual(signals[0].source, "ws")
-        self.assertEqual(
-            signals[0].ingest_ts,
-            datetime(2026, 3, 6, 14, 51, 0, 316000, tzinfo=timezone.utc),
-        )
-        self.assertEqual(signals[1].seq, 101)
+        self.assertEqual([signal.seq for signal in signals], [100, 200])
 
     def test_fetch_signals_between_filters_disallowed_sources(self) -> None:
         rows = [

--- a/services/torghut/tests/test_start_historical_simulation.py
+++ b/services/torghut/tests/test_start_historical_simulation.py
@@ -35,7 +35,7 @@ from scripts.start_historical_simulation import (
     _count_lines,
     _configure_torghut_service_for_simulation,
     _doc29_simulation_gate_ids,
-    _discover_automation_pointer,
+    _discover_applicationset_entry,
     _find_vector_extension_blocking_revision,
     _dump_topics,
     _dump_sha256_for_replay,
@@ -1687,7 +1687,7 @@ class TestStartHistoricalSimulation(TestCase):
                     force_replay=False,
                 )
 
-        runtime_guard.assert_called_once_with(config=argocd_config)
+        runtime_guard.assert_called_once_with(config=argocd_config, resources=resources)
         self.assertEqual(report['argocd_runtime_guard'], {'managed': True, 'changed': True})
 
     def test_apply_restarts_ta_when_warm_lane_baseline_is_already_ready(self) -> None:
@@ -8471,7 +8471,7 @@ class TestStartHistoricalSimulation(TestCase):
         self.assertIn('--signal-table "{{args.signalTable}}"', args_text)
         self.assertIn('--price-table "{{args.priceTable}}"', args_text)
 
-    def test_discover_automation_pointer_finds_nested_element(self) -> None:
+    def test_discover_applicationset_entry_finds_nested_element(self) -> None:
         payload = {
             'spec': {
                 'generators': [
@@ -8493,12 +8493,12 @@ class TestStartHistoricalSimulation(TestCase):
                 ]
             }
         }
-        discovered = _discover_automation_pointer(payload, app_name='torghut')
+        discovered = _discover_applicationset_entry(payload, app_name='torghut')
         self.assertIsNotNone(discovered)
         assert discovered is not None
-        pointer, mode = discovered
+        pointer, entry = discovered
         self.assertIn('/spec/', pointer)
-        self.assertEqual(mode, 'manual')
+        self.assertEqual(entry['automation'], 'manual')
 
     def test_set_argocd_automation_mode_patches_and_verifies(self) -> None:
         payload_auto = {
@@ -8603,27 +8603,45 @@ class TestStartHistoricalSimulation(TestCase):
             {'enabled': False, 'prune': False, 'selfHeal': False},
         )
 
-    def test_set_argocd_application_skip_reconcile_patches_and_verifies(self) -> None:
-        payload_unset = {
-            'metadata': {
-                'annotations': {},
+    def test_set_argocd_application_ignore_differences_patches_and_verifies(self) -> None:
+        runtime_ignore_differences = [
+            {
+                'group': 'serving.knative.dev',
+                'kind': 'Service',
+                'namespace': 'torghut',
+                'name': 'torghut-sim',
+                'jsonPointers': ['/spec/template/spec/containers/0/env'],
             }
-        }
-        payload_enabled = {
-            'metadata': {
-                'annotations': {
-                    'argocd.argoproj.io/skip-reconcile': 'true',
-                }
-            }
-        }
+        ]
         with (
             patch(
-                'scripts.start_historical_simulation._kubectl_json_global',
-                side_effect=[payload_unset, payload_enabled],
+                'scripts.start_historical_simulation._read_argocd_applicationset_entry',
+                side_effect=[
+                    {
+                        'pointer': '/spec/generators/0/list/elements/0',
+                        'automation_pointer': '/spec/generators/0/list/elements/0/automation',
+                        'mode': 'manual',
+                        'ignore_differences': [],
+                    },
+                    {
+                        'pointer': '/spec/generators/0/list/elements/0',
+                        'automation_pointer': '/spec/generators/0/list/elements/0/automation',
+                        'mode': 'manual',
+                        'ignore_differences': runtime_ignore_differences,
+                    },
+                ],
             ),
-            patch('scripts.start_historical_simulation._kubectl_patch') as patch_mock,
+            patch(
+                'scripts.start_historical_simulation._read_named_argocd_application_sync_policy',
+                return_value={
+                    'sync_policy': None,
+                    'automation_mode': 'manual',
+                    'ignore_differences': runtime_ignore_differences,
+                },
+            ),
+            patch('scripts.start_historical_simulation._kubectl_patch_json') as patch_mock,
         ):
-            report = start_historical_simulation._set_argocd_application_skip_reconcile(
+            report = start_historical_simulation._set_argocd_application_ignore_differences(
                 config=ArgocdAutomationConfig(
                     manage_automation=True,
                     applicationset_name='product',
@@ -8634,12 +8652,24 @@ class TestStartHistoricalSimulation(TestCase):
                     restore_mode_after_run='previous',
                     verify_timeout_seconds=30,
                 ),
-                desired_value='true',
+                required_ignore_differences=runtime_ignore_differences,
+                desired_ignore_differences=runtime_ignore_differences,
             )
         self.assertTrue(report['changed'])
-        patch_mock.assert_called_once()
-        self.assertEqual(report['current_value'], 'true')
-        self.assertTrue(report['enabled'])
+        patch_mock.assert_called_once_with(
+            'argocd',
+            'applicationset',
+            'product',
+            [
+                {
+                    'op': 'add',
+                    'path': '/spec/generators/0/list/elements/0/ignoreDifferences',
+                    'value': runtime_ignore_differences,
+                }
+            ],
+        )
+        self.assertEqual(report['current_ignore_differences'], runtime_ignore_differences)
+        self.assertTrue(report['coverage_complete'])
 
     def test_argocd_application_mode_from_sync_policy_treats_missing_automation_as_manual(self) -> None:
         self.assertEqual(
@@ -8673,6 +8703,19 @@ class TestStartHistoricalSimulation(TestCase):
             restore_mode_after_run='previous',
             verify_timeout_seconds=30,
         )
+        resources = SimpleNamespace(
+            namespace='torghut',
+            torghut_service='torghut-sim',
+            ta_configmap='torghut-ta-sim-config',
+            ta_deployment='torghut-ta-sim',
+        )
+        baseline_ignore_differences = [
+            {
+                'group': 'serving.knative.dev',
+                'kind': 'Service',
+                'jsonPointers': ['/metadata/annotations'],
+            }
+        ]
         with (
             patch(
                 'scripts.start_historical_simulation._read_argocd_automation_mode',
@@ -8687,8 +8730,7 @@ class TestStartHistoricalSimulation(TestCase):
                             'syncOptions': ['CreateNamespace=true'],
                         },
                         'automation_mode': 'auto',
-                        'skip_reconcile_enabled': False,
-                        'skip_reconcile_value': None,
+                        'ignore_differences': baseline_ignore_differences,
                     },
                     {
                         'sync_policy': {
@@ -8696,6 +8738,7 @@ class TestStartHistoricalSimulation(TestCase):
                             'syncOptions': ['CreateNamespace=true'],
                         },
                         'automation_mode': 'auto',
+                        'ignore_differences': None,
                     },
                 ],
             ) as application_read_mock,
@@ -8723,14 +8766,15 @@ class TestStartHistoricalSimulation(TestCase):
                 ],
             ) as application_sync_mock,
             patch(
-                'scripts.start_historical_simulation._set_argocd_application_skip_reconcile',
+                'scripts.start_historical_simulation._set_argocd_application_ignore_differences',
                 return_value={
-                    'previous_value': None,
-                    'current_value': 'true',
-                    'enabled': True,
+                    'previous_ignore_differences': baseline_ignore_differences,
+                    'current_ignore_differences': baseline_ignore_differences,
+                    'required_ignore_differences': [],
+                    'coverage_complete': True,
                     'changed': True,
                 },
-            ) as skip_reconcile_mock,
+            ) as ignore_differences_mock,
             patch(
                 'scripts.start_historical_simulation._set_argocd_automation_mode',
                 return_value={
@@ -8749,7 +8793,7 @@ class TestStartHistoricalSimulation(TestCase):
                 },
             ) as application_mode_mock,
         ):
-            report = _prepare_argocd_for_run(config=config)
+            report = _prepare_argocd_for_run(config=config, resources=resources)
         automation_read_mock.assert_called_once()
         self.assertEqual(application_read_mock.call_args_list, [
             call(namespace='argocd', app_name='torghut'),
@@ -8773,10 +8817,16 @@ class TestStartHistoricalSimulation(TestCase):
                 },
             ),
         ])
-        skip_reconcile_mock.assert_called_once_with(
+        ignore_differences_mock.assert_called_once_with(
             config=config,
             app_name='torghut',
-            desired_value='true',
+            required_ignore_differences=start_historical_simulation._simulation_runtime_argocd_ignore_differences(
+                resources=resources
+            ),
+            desired_ignore_differences=start_historical_simulation._merge_argocd_application_ignore_differences(
+                current_ignore_differences=baseline_ignore_differences,
+                resources=resources,
+            ),
         )
         applicationset_mock.assert_called_once()
         application_mode_mock.assert_called_once()
@@ -8784,7 +8834,7 @@ class TestStartHistoricalSimulation(TestCase):
         self.assertIn('application', report)
         self.assertIn('root_application', report)
         self.assertIn('application_sync_policy', report)
-        self.assertIn('application_skip_reconcile', report)
+        self.assertIn('application_ignore_differences', report)
         self.assertTrue(report['applicationset_managed'])
         self.assertEqual(report['previous_mode'], 'auto')
         self.assertEqual(report['current_mode'], 'manual')
@@ -8800,6 +8850,15 @@ class TestStartHistoricalSimulation(TestCase):
             restore_mode_after_run='previous',
             verify_timeout_seconds=30,
         )
+        resources = SimpleNamespace(
+            namespace='torghut',
+            torghut_service='torghut-sim',
+            ta_configmap='torghut-ta-sim-config',
+            ta_deployment='torghut-ta-sim',
+        )
+        runtime_ignore_differences = start_historical_simulation._simulation_runtime_argocd_ignore_differences(
+            resources=resources
+        )
         with (
             patch(
                 'scripts.start_historical_simulation._read_argocd_automation_mode',
@@ -8814,8 +8873,7 @@ class TestStartHistoricalSimulation(TestCase):
                             'syncOptions': ['CreateNamespace=true'],
                         },
                         'automation_mode': 'manual',
-                        'skip_reconcile_enabled': True,
-                        'skip_reconcile_value': 'true',
+                        'ignore_differences': runtime_ignore_differences,
                     },
                     {
                         'sync_policy': {
@@ -8823,18 +8881,22 @@ class TestStartHistoricalSimulation(TestCase):
                             'syncOptions': ['CreateNamespace=true'],
                         },
                         'automation_mode': 'manual',
+                        'ignore_differences': None,
                     },
                 ],
             ),
             patch('scripts.start_historical_simulation._prepare_argocd_for_run') as prepare_mock,
         ):
-            report = start_historical_simulation._ensure_argocd_manual_before_runtime_mutation(config=config)
+            report = start_historical_simulation._ensure_argocd_manual_before_runtime_mutation(
+                config=config,
+                resources=resources,
+            )
 
         prepare_mock.assert_not_called()
         self.assertEqual(report['reason'], 'already_manual')
         self.assertFalse(report['changed'])
         self.assertEqual(report['current_mode'], 'manual')
-        self.assertTrue(report['application_skip_reconcile']['enabled'])
+        self.assertTrue(report['application_ignore_differences']['coverage_complete'])
 
     def test_ensure_argocd_manual_before_runtime_mutation_reasserts_when_child_app_drifted(self) -> None:
         config = ArgocdAutomationConfig(
@@ -8846,6 +8908,12 @@ class TestStartHistoricalSimulation(TestCase):
             desired_mode_during_run='manual',
             restore_mode_after_run='previous',
             verify_timeout_seconds=30,
+        )
+        resources = SimpleNamespace(
+            namespace='torghut',
+            torghut_service='torghut-sim',
+            ta_configmap='torghut-ta-sim-config',
+            ta_deployment='torghut-ta-sim',
         )
         with (
             patch(
@@ -8861,8 +8929,7 @@ class TestStartHistoricalSimulation(TestCase):
                             'syncOptions': ['CreateNamespace=true'],
                         },
                         'automation_mode': 'auto',
-                        'skip_reconcile_enabled': False,
-                        'skip_reconcile_value': None,
+                        'ignore_differences': [],
                     },
                     {
                         'sync_policy': {
@@ -8870,6 +8937,7 @@ class TestStartHistoricalSimulation(TestCase):
                             'syncOptions': ['CreateNamespace=true'],
                         },
                         'automation_mode': 'manual',
+                        'ignore_differences': None,
                     },
                 ],
             ),
@@ -8878,9 +8946,12 @@ class TestStartHistoricalSimulation(TestCase):
                 return_value={'managed': True, 'changed': True, 'current_mode': 'manual'},
             ) as prepare_mock,
         ):
-            report = start_historical_simulation._ensure_argocd_manual_before_runtime_mutation(config=config)
+            report = start_historical_simulation._ensure_argocd_manual_before_runtime_mutation(
+                config=config,
+                resources=resources,
+            )
 
-        prepare_mock.assert_called_once_with(config=config)
+        prepare_mock.assert_called_once_with(config=config, resources=resources)
         self.assertEqual(report['reason'], 'reasserted_manual_before_runtime_mutation')
         self.assertTrue(report['changed'])
 
@@ -8930,14 +9001,15 @@ class TestStartHistoricalSimulation(TestCase):
                 ],
             ) as application_mock,
             patch(
-                'scripts.start_historical_simulation._set_argocd_application_skip_reconcile',
+                'scripts.start_historical_simulation._set_argocd_application_ignore_differences',
                 return_value={
-                    'previous_value': 'true',
-                    'current_value': None,
-                    'enabled': False,
+                    'previous_ignore_differences': [{'group': '', 'kind': 'ConfigMap', 'jsonPointers': ['/data']}],
+                    'current_ignore_differences': [],
+                    'required_ignore_differences': [],
+                    'coverage_complete': True,
                     'changed': True,
                 },
-            ) as skip_reconcile_mock,
+            ) as ignore_differences_mock,
             patch(
                 'scripts.start_historical_simulation._wait_for_argocd_application_mode',
                 return_value={
@@ -8951,14 +9023,14 @@ class TestStartHistoricalSimulation(TestCase):
                 previous_mode='auto',
                 previous_root_sync_policy=previous_sync_policy,
                 previous_child_sync_policy=previous_sync_policy,
-                previous_child_skip_reconcile_value=None,
+                previous_child_ignore_differences=None,
             )
         applicationset_mock.assert_called_once()
         self.assertEqual(application_mock.call_count, 2)
-        skip_reconcile_mock.assert_called_once_with(
+        ignore_differences_mock.assert_called_once_with(
             config=config,
             app_name='torghut',
-            desired_value=None,
+            desired_ignore_differences=None,
         )
         application_mode_mock.assert_called_once()
         self.assertTrue(report['changed'])

--- a/services/torghut/tests/test_start_historical_simulation.py
+++ b/services/torghut/tests/test_start_historical_simulation.py
@@ -8655,6 +8655,13 @@ class TestStartHistoricalSimulation(TestCase):
             'auto',
         )
 
+    def test_manual_argocd_application_sync_policy_preserves_existing_manual_shape(self) -> None:
+        policy = {'syncOptions': ['CreateNamespace=true']}
+
+        manual_policy = start_historical_simulation._manual_argocd_application_sync_policy(policy)
+
+        self.assertEqual(manual_policy, policy)
+
     def test_prepare_argocd_for_run_pauses_root_and_applicationset(self) -> None:
         config = ArgocdAutomationConfig(
             manage_automation=True,

--- a/services/torghut/tests/test_start_historical_simulation.py
+++ b/services/torghut/tests/test_start_historical_simulation.py
@@ -162,7 +162,7 @@ class TestStartHistoricalSimulation(TestCase):
         self.assertEqual(policy['mode'], 'stateless')
         self.assertEqual(policy['source'], 'profile_default:compact')
 
-    def test_ta_restore_policy_defaults_full_day_profiles_to_required(self) -> None:
+    def test_ta_restore_policy_defaults_full_day_profiles_to_stateless(self) -> None:
         policy = start_historical_simulation._ta_restore_policy(
             {
                 'window': {
@@ -175,7 +175,7 @@ class TestStartHistoricalSimulation(TestCase):
             }
         )
 
-        self.assertEqual(policy['mode'], 'required')
+        self.assertEqual(policy['mode'], 'stateless')
         self.assertEqual(policy['source'], 'profile_default:full_day')
 
     def test_analysis_run_name_uses_dns1123_safe_token(self) -> None:
@@ -1560,6 +1560,134 @@ class TestStartHistoricalSimulation(TestCase):
         self.assertTrue(report['clickhouse']['database_precreated'])
         self.assertTrue(report['postgres']['database_precreated'])
         self.assertEqual(report['simulation_lock']['status'], 'acquired')
+
+    def test_apply_reasserts_manual_argocd_control_before_runtime_mutation(self) -> None:
+        resources = _build_resources('sim-1', {'dataset_id': 'dataset-a'})
+        kafka_config = KafkaRuntimeConfig(
+            bootstrap_servers='kafka:9092',
+            security_protocol=None,
+            sasl_mechanism=None,
+            sasl_username=None,
+            sasl_password=None,
+        )
+        clickhouse_config = ClickHouseRuntimeConfig(
+            http_url='http://clickhouse:8123',
+            username='torghut',
+            password='secret',
+        )
+        postgres_config = PostgresRuntimeConfig(
+            admin_dsn='postgresql://torghut:secret@localhost:5432/postgres',
+            simulation_dsn='postgresql://torghut:secret@localhost:5432/torghut_sim_sim_1',
+            simulation_db='torghut_sim_sim_1',
+            migrations_command='true',
+        )
+        argocd_config = ArgocdAutomationConfig(
+            manage_automation=True,
+            applicationset_name='product',
+            applicationset_namespace='argocd',
+            app_name='torghut',
+            root_app_name='root',
+            desired_mode_during_run='manual',
+            restore_mode_after_run='previous',
+            verify_timeout_seconds=30,
+        )
+        manifest = {
+            'dataset_id': 'dataset-a',
+            'window': {
+                'start': '2026-02-27T14:30:00Z',
+                'end': '2026-02-27T15:30:00Z',
+            },
+        }
+
+        with TemporaryDirectory() as tmpdir:
+            resources = replace(resources, output_root=Path(tmpdir))
+            with ExitStack() as stack:
+                stack.enter_context(patch('scripts.start_historical_simulation._ensure_supported_binary'))
+                stack.enter_context(patch('scripts.start_historical_simulation._ensure_lz4_codec_available'))
+                stack.enter_context(
+                    patch(
+                        'scripts.start_historical_simulation._acquire_simulation_runtime_lock',
+                        return_value={'status': 'acquired', 'run_id': resources.run_id},
+                    ),
+                )
+                stack.enter_context(
+                    patch(
+                        'scripts.start_historical_simulation._capture_cluster_state',
+                        return_value={
+                            'ta_data': {
+                                'TA_GROUP_ID': 'prod-ta-group',
+                                'TA_CHECKPOINT_DIR': 's3a://bucket/checkpoints',
+                                'TA_SAVEPOINT_DIR': 's3a://bucket/savepoints',
+                            }
+                        },
+                    ),
+                )
+                stack.enter_context(patch('scripts.start_historical_simulation._ensure_topics', return_value={'status': 'ok'}))
+                stack.enter_context(patch('scripts.start_historical_simulation._ensure_clickhouse_database'))
+                stack.enter_context(patch('scripts.start_historical_simulation._ensure_clickhouse_runtime_tables', return_value=None))
+                stack.enter_context(patch('scripts.start_historical_simulation._ensure_postgres_database'))
+                stack.enter_context(
+                    patch(
+                        'scripts.start_historical_simulation._ensure_postgres_runtime_permissions',
+                        return_value={'grants_applied': True},
+                    ),
+                )
+                stack.enter_context(patch('scripts.start_historical_simulation._run_migrations', return_value=None))
+                stack.enter_context(patch('scripts.start_historical_simulation._reset_postgres_runtime_state', return_value=None))
+                stack.enter_context(
+                    patch(
+                        'scripts.start_historical_simulation._seed_simulation_trade_cursor',
+                        return_value=datetime(2026, 2, 27, 14, 30, tzinfo=timezone.utc),
+                    ),
+                )
+                stack.enter_context(patch('scripts.start_historical_simulation._upsert_simulation_runtime_context', return_value=None))
+                stack.enter_context(patch('scripts.start_historical_simulation._dump_topics', return_value={'records': 1, 'sha256': 'abc'}))
+                stack.enter_context(
+                    patch(
+                        'scripts.start_historical_simulation._validate_dump_coverage',
+                        return_value={'coverage_ratio': 1.0},
+                    ),
+                )
+                runtime_guard = stack.enter_context(
+                    patch(
+                        'scripts.start_historical_simulation._ensure_argocd_manual_before_runtime_mutation',
+                        return_value={'managed': True, 'changed': True},
+                    ),
+                )
+                stack.enter_context(
+                    patch(
+                        'scripts.start_historical_simulation._ta_runtime_reconfigure_required',
+                        return_value=True,
+                    ),
+                )
+                stack.enter_context(
+                    patch(
+                        'scripts.start_historical_simulation._torghut_service_reconfigure_required',
+                        return_value=True,
+                    ),
+                )
+                stack.enter_context(patch('scripts.start_historical_simulation._configure_ta_for_simulation', return_value=None))
+                stack.enter_context(patch('scripts.start_historical_simulation._restart_ta_deployment', return_value='nonce'))
+                stack.enter_context(
+                    patch(
+                        'scripts.start_historical_simulation._configure_torghut_service_for_simulation',
+                        return_value=None,
+                    ),
+                )
+
+                report = start_historical_simulation._apply(
+                    resources=resources,
+                    manifest=manifest,
+                    kafka_config=kafka_config,
+                    clickhouse_config=clickhouse_config,
+                    postgres_config=postgres_config,
+                    argocd_config=argocd_config,
+                    force_dump=False,
+                    force_replay=False,
+                )
+
+        runtime_guard.assert_called_once_with(config=argocd_config)
+        self.assertEqual(report['argocd_runtime_guard'], {'managed': True, 'changed': True})
 
     def test_apply_restarts_ta_when_warm_lane_baseline_is_already_ready(self) -> None:
         resources = _build_resources(
@@ -3182,6 +3310,8 @@ class TestStartHistoricalSimulation(TestCase):
                 torghut_env_overrides={
                     'TRADING_FEATURE_MAX_STALENESS_MS': '43200000',
                     'TRADING_FEATURE_QUALITY_ENABLED': 'true',
+                    'TRADING_STRATEGY_RUNTIME_MODE': 'plugin_v3',
+                    'TRADING_STRATEGY_SCHEDULER_ENABLED': 'false',
                 },
             )
 
@@ -3214,11 +3344,11 @@ class TestStartHistoricalSimulation(TestCase):
         )
         self.assertEqual(
             env_by_name['TRADING_STRATEGY_RUNTIME_MODE'].get('value'),
-            'scheduler_v3',
+            'plugin_v3',
         )
         self.assertEqual(
             env_by_name['TRADING_STRATEGY_SCHEDULER_ENABLED'].get('value'),
-            'true',
+            'false',
         )
 
     def test_configure_torghut_service_allows_explicit_runtime_override(self) -> None:
@@ -3452,9 +3582,31 @@ class TestStartHistoricalSimulation(TestCase):
         dump_sha256 = start_historical_simulation.hashlib.sha256(dump_bytes).hexdigest()
         cache_artifact_path = 's3://argo-workflows/torghut-simulation-cache/cache-key/source-dump.ndjson'
         cache_manifest_path = f'{cache_artifact_path}.manifest.json'
+        manifest = {
+            'dataset_id': resources.dataset_id,
+            'dataset_snapshot_ref': 'dataset-a@snapshot-1',
+            'candidate_id': 'intraday_tsmom_v1@prod',
+            'baseline_candidate_id': 'intraday_tsmom_v1@baseline',
+            'strategy_spec_ref': 'strategy-specs/intraday_tsmom_v1@1.1.0.json',
+            'model_refs': ['rules/intraday_tsmom_v1'],
+            'runtime_version_refs': ['services/torghut@sha256:abc'],
+            'cachePolicy': 'prefer_cache',
+            'metadata': {
+                'cacheKey': 'cache-key',
+                'cacheDecision': 'hit',
+                'cacheArtifactPath': cache_artifact_path,
+                'cacheChunkManifestPath': cache_manifest_path,
+            },
+            'performance': {
+                'dumpFormat': 'ndjson',
+                'replayProfile': 'compact',
+            },
+            'window': {'start': '2026-01-01T00:00:00Z', 'end': '2026-01-01T01:00:00Z'},
+        }
         artifact_manifest = {
             'dataset_id': resources.dataset_id,
             'run_id': 'prior-run',
+            'lineage': start_historical_simulation._cache_lineage_payload(manifest),
             'dump_format': 'ndjson',
             'cache_policy': 'prefer_cache',
             'replay_profile': 'compact',
@@ -3481,21 +3633,6 @@ class TestStartHistoricalSimulation(TestCase):
 
         with TemporaryDirectory() as tmp_dir:
             dump_path = Path(tmp_dir) / 'source-dump.ndjson'
-            manifest = {
-                'cachePolicy': 'prefer_cache',
-                'metadata': {
-                    'cacheKey': 'cache-key',
-                    'cacheDecision': 'hit',
-                    'cacheArtifactPath': cache_artifact_path,
-                    'cacheChunkManifestPath': cache_manifest_path,
-                },
-                'performance': {
-                    'dumpFormat': 'ndjson',
-                    'replayProfile': 'compact',
-                },
-                'window': {'start': '2026-01-01T00:00:00Z', 'end': '2026-01-01T01:00:00Z'},
-            }
-
             with (
                 patch(
                     'scripts.start_historical_simulation._consumer_for_dump',
@@ -3521,6 +3658,550 @@ class TestStartHistoricalSimulation(TestCase):
             marker = json.loads(dump_path.with_suffix('.dump-marker.json').read_text(encoding='utf-8'))
             self.assertEqual(marker['dump_sha256'], dump_sha256)
             self.assertEqual(marker['records'], 1)
+
+    def test_dump_topics_derives_durable_cache_metadata_for_local_manifests(self) -> None:
+        resources = _build_resources(
+            'sim-1',
+            {
+                'dataset_id': 'dataset-a',
+            },
+        )
+        kafka_config = KafkaRuntimeConfig(
+            bootstrap_servers='kafka:9092',
+            security_protocol=None,
+            sasl_mechanism=None,
+            sasl_username=None,
+            sasl_password=None,
+        )
+        dump_line = json.dumps(
+            {
+                'source_topic': resources.source_topic_by_role['trades'],
+                'replay_topic': resources.simulation_topic_by_role['trades'],
+                'source_timestamp_ms': 1704067200000,
+                'key_b64': None,
+                'value_b64': None,
+                'headers': [],
+            }
+        )
+        dump_bytes = f'{dump_line}\n'.encode('utf-8')
+        dump_sha256 = start_historical_simulation.hashlib.sha256(dump_bytes).hexdigest()
+        manifest = {
+            'dataset_id': resources.dataset_id,
+            'dataset_snapshot_ref': 'dataset-a@snapshot-1',
+            'candidate_id': 'intraday_tsmom_v1@prod',
+            'baseline_candidate_id': 'intraday_tsmom_v1@baseline',
+            'strategy_spec_ref': 'strategy-specs/intraday_tsmom_v1@1.1.0.json',
+            'model_refs': ['rules/intraday_tsmom_v1'],
+            'runtime_version_refs': ['services/torghut@sha256:abc'],
+            'cachePolicy': 'prefer_cache',
+            'performance': {
+                'dumpFormat': 'ndjson',
+                'replayProfile': 'compact',
+            },
+            'window': {'start': '2026-01-01T00:00:00Z', 'end': '2026-01-01T01:00:00Z'},
+        }
+        cache_metadata = start_historical_simulation._cache_metadata(manifest)
+        cache_artifact_path = cache_metadata['cache_artifact_path']
+        cache_manifest_path = cache_metadata['cache_manifest_path']
+        self.assertTrue(cache_metadata['cache_key'])
+        self.assertTrue(cache_artifact_path.endswith('/source-dump.ndjson'))
+        self.assertEqual(cache_manifest_path, f'{cache_artifact_path}.manifest.json')
+        artifact_manifest = {
+            'dataset_id': resources.dataset_id,
+            'run_id': 'prior-run',
+            'lineage': start_historical_simulation._cache_lineage_payload(manifest),
+            'dump_format': 'ndjson',
+            'cache_policy': 'prefer_cache',
+            'replay_profile': 'compact',
+            'chunk_count': 1,
+            'chunks': [
+                {
+                    'path': cache_artifact_path,
+                    'records': 1,
+                    'sha256': dump_sha256,
+                    'payload_sha256': dump_sha256,
+                    'min_source_timestamp_ms': 1704067200000,
+                    'max_source_timestamp_ms': 1704067200000,
+                }
+            ],
+        }
+
+        class _FakeCephClient:
+            def get_object(self, *, bucket: str, key: str) -> bytes:
+                if bucket != 'argo-workflows':
+                    raise AssertionError(f'unexpected bucket: {bucket}')
+                if key.endswith('.manifest.json'):
+                    return json.dumps(artifact_manifest).encode('utf-8')
+                return dump_bytes
+
+        with TemporaryDirectory() as tmp_dir:
+            dump_path = Path(tmp_dir) / 'source-dump.ndjson'
+
+            with (
+                patch(
+                    'scripts.start_historical_simulation._consumer_for_dump',
+                    side_effect=AssertionError('expected durable cache restore; consumer should not be constructed'),
+                ),
+                patch(
+                    'scripts.start_historical_simulation._simulation_cache_client_from_env',
+                    return_value=(_FakeCephClient(), 'argo-workflows'),
+                ),
+            ):
+                report = _dump_topics(
+                    resources=resources,
+                    kafka_config=kafka_config,
+                    manifest=manifest,
+                    dump_path=dump_path,
+                    force=False,
+                )
+
+            self.assertTrue(report['restored_from_cache'])
+            self.assertEqual(report['records'], 1)
+            self.assertEqual(report['cache_artifact_path'], cache_artifact_path)
+            self.assertTrue(dump_path.exists())
+
+    def test_restore_cached_dump_rejects_lineage_mismatch(self) -> None:
+        manifest = {
+            'dataset_id': 'dataset-a',
+            'dataset_snapshot_ref': 'dataset-a@snapshot-2',
+            'candidate_id': 'intraday_tsmom_v1@prod',
+            'baseline_candidate_id': 'intraday_tsmom_v1@baseline',
+            'strategy_spec_ref': 'strategy-specs/intraday_tsmom_v1@1.1.0.json',
+            'model_refs': ['rules/intraday_tsmom_v1'],
+            'runtime_version_refs': ['services/torghut@sha256:def'],
+            'cachePolicy': 'prefer_cache',
+            'performance': {
+                'dumpFormat': 'ndjson',
+                'replayProfile': 'compact',
+            },
+            'window': {'start': '2026-01-01T00:00:00Z', 'end': '2026-01-01T01:00:00Z'},
+        }
+        cache_metadata = start_historical_simulation._cache_metadata(manifest)
+        artifact_manifest = {
+            'dataset_id': 'dataset-a',
+            'run_id': 'prior-run',
+            'lineage': {
+                'schema_version': 'torghut-simulation-cache-v1',
+                'lane': 'equity',
+                'dataset_id': 'dataset-a',
+                'dataset_snapshot_ref': 'dataset-a@snapshot-1',
+                'window': manifest['window'],
+                'strategy_spec_ref': manifest['strategy_spec_ref'],
+                'candidate_id': manifest['candidate_id'],
+                'baseline_candidate_id': manifest['baseline_candidate_id'],
+                'model_refs': manifest['model_refs'],
+                'runtime_version_refs': ['services/torghut@sha256:abc'],
+                'dump_format': 'ndjson',
+                'profile': 'compact',
+            },
+            'dump_format': 'ndjson',
+            'cache_policy': 'prefer_cache',
+            'replay_profile': 'compact',
+            'chunk_count': 1,
+            'chunks': [
+                {
+                    'path': cache_metadata['cache_artifact_path'],
+                    'records': 1,
+                    'sha256': 'abc',
+                    'payload_sha256': 'abc',
+                    'min_source_timestamp_ms': 1704067200000,
+                    'max_source_timestamp_ms': 1704067200000,
+                }
+            ],
+        }
+
+        class _FakeCephClient:
+            def get_object(self, *, bucket: str, key: str) -> bytes:
+                if key.endswith('.manifest.json'):
+                    return json.dumps(artifact_manifest).encode('utf-8')
+                return b'{}\n'
+
+        with TemporaryDirectory() as tmp_dir:
+            dump_path = Path(tmp_dir) / 'source-dump.ndjson'
+            with patch(
+                'scripts.start_historical_simulation._simulation_cache_client_from_env',
+                return_value=(_FakeCephClient(), 'argo-workflows'),
+            ):
+                report = start_historical_simulation._restore_cached_dump_if_available(
+                    manifest=manifest,
+                    dump_path=dump_path,
+                )
+
+        self.assertIsNone(report)
+        self.assertFalse(dump_path.exists())
+
+    def test_restore_cached_dump_skips_explicit_non_hit_cache_decision(self) -> None:
+        manifest = {
+            'cachePolicy': 'prefer_cache',
+            'metadata': {
+                'cacheKey': 'cache-key',
+                'cacheDecision': 'miss',
+                'cacheArtifactPath': 's3://argo-workflows/torghut-simulation-cache/cache-key/source-dump.ndjson',
+                'cacheChunkManifestPath': (
+                    's3://argo-workflows/torghut-simulation-cache/cache-key/source-dump.ndjson.manifest.json'
+                ),
+            },
+            'performance': {
+                'dumpFormat': 'ndjson',
+            },
+        }
+
+        with TemporaryDirectory() as tmp_dir:
+            dump_path = Path(tmp_dir) / 'source-dump.ndjson'
+
+            with patch(
+                'scripts.start_historical_simulation._simulation_cache_client_from_env',
+                side_effect=AssertionError('non-hit cache decisions must not attempt restore'),
+            ):
+                report = start_historical_simulation._restore_cached_dump_if_available(
+                    manifest=manifest,
+                    dump_path=dump_path,
+                )
+
+        self.assertIsNone(report)
+        self.assertFalse(dump_path.exists())
+
+    def test_simulation_cache_upload_timeout_seconds_scales_with_dump_size(self) -> None:
+        with TemporaryDirectory() as tmp_dir:
+            dump_path = Path(tmp_dir) / 'source-dump.jsonl.zst'
+            dump_path.write_bytes(b'x' * (5 * 1024 * 1024))
+
+            timeout_seconds = start_historical_simulation._simulation_cache_upload_timeout_seconds(dump_path)
+
+        self.assertGreaterEqual(timeout_seconds, 60)
+
+    def test_upload_dump_to_cache_retries_transient_timeout(self) -> None:
+        manifest = {
+            'dataset_id': 'dataset-a',
+            'dataset_snapshot_ref': 'dataset-a@snapshot-1',
+            'candidate_id': 'intraday_tsmom_v1@prod',
+            'baseline_candidate_id': 'intraday_tsmom_v1@baseline',
+            'strategy_spec_ref': 'strategy-specs/intraday_tsmom_v1@1.1.0.json',
+            'model_refs': ['rules/intraday_tsmom_v1'],
+            'runtime_version_refs': ['services/torghut@sha256:abc'],
+            'cachePolicy': 'refresh',
+            'performance': {
+                'dumpFormat': 'ndjson',
+                'replayProfile': 'compact',
+            },
+            'window': {'start': '2026-01-01T00:00:00Z', 'end': '2026-01-01T01:00:00Z'},
+        }
+        client_timeouts: list[int | None] = []
+        put_attempts: list[tuple[str, str]] = []
+
+        class _FakeCephClient:
+            def __init__(self, timeout_seconds: int | None) -> None:
+                self.timeout_seconds = timeout_seconds
+                self._attempt = 0
+
+            def put_object(
+                self,
+                *,
+                bucket: str,
+                key: str,
+                body: bytes,
+                content_type: str,
+            ) -> dict[str, Any]:
+                _ = (body, content_type)
+                put_attempts.append((bucket, key))
+                self._attempt += 1
+                if self._attempt == 1:
+                    raise TimeoutError('timed out')
+                return {'etag': f'etag-{self._attempt}'}
+
+        def _fake_cache_client(timeout_seconds: int | None = None) -> tuple[Any, str]:
+            client_timeouts.append(timeout_seconds)
+            return _FakeCephClient(timeout_seconds), 'argo-workflows'
+
+        with TemporaryDirectory() as tmp_dir:
+            dump_path = Path(tmp_dir) / 'source-dump.ndjson'
+            dump_path.write_bytes(b'{}\n')
+            dump_manifest_path = start_historical_simulation._dump_artifact_manifest_path(dump_path)
+            dump_manifest_path.write_text(
+                json.dumps(
+                    {
+                        'dataset_id': 'dataset-a',
+                        'run_id': 'sim-1',
+                        'lineage': start_historical_simulation._cache_lineage_payload(manifest),
+                        'dump_format': 'ndjson',
+                        'cache_policy': 'refresh',
+                        'replay_profile': 'compact',
+                        'chunk_count': 1,
+                        'chunks': [
+                            {
+                                'path': str(dump_path),
+                                'records': 1,
+                                'sha256': 'abc',
+                                'payload_sha256': 'abc',
+                            }
+                        ],
+                    }
+                ),
+                encoding='utf-8',
+            )
+
+            with (
+                patch(
+                    'scripts.start_historical_simulation._simulation_cache_client_from_env',
+                    side_effect=_fake_cache_client,
+                ),
+                patch(
+                    'scripts.start_historical_simulation.time.sleep',
+                    return_value=None,
+                ),
+            ):
+                report = start_historical_simulation._upload_dump_to_cache(
+                    manifest=manifest,
+                    dump_path=dump_path,
+                )
+
+        self.assertEqual(report['status'], 'ok')
+        self.assertEqual(report['attempt_count'], 2)
+        self.assertEqual(len(client_timeouts), 1)
+        self.assertGreaterEqual(client_timeouts[0] or 0, 60)
+        self.assertEqual(len(put_attempts), 3)
+
+    def test_dump_topics_records_cache_upload_error_without_failing_fresh_dump(self) -> None:
+        resources = _build_resources(
+            'sim-1',
+            {
+                'dataset_id': 'dataset-a',
+            },
+        )
+        resources = replace(
+            resources,
+            replay_topic_by_source_topic={'torghut.trades.v1': 'torghut.sim.trades.v1'},
+        )
+        kafka_config = KafkaRuntimeConfig(
+            bootstrap_servers='kafka:9092',
+            security_protocol=None,
+            sasl_mechanism=None,
+            sasl_username=None,
+            sasl_password=None,
+        )
+
+        class _OffsetMeta:
+            def __init__(self, offset: int) -> None:
+                self.offset = offset
+
+        class _Record:
+            def __init__(self, topic: str, partition: int, offset: int, timestamp: int) -> None:
+                self.topic = topic
+                self.partition = partition
+                self.offset = offset
+                self.timestamp = timestamp
+                self.key = None
+                self.value = None
+                self.headers: list[tuple[str, bytes]] = []
+
+        class _FakeConsumer:
+            def __init__(self) -> None:
+                self._tp = ('torghut.trades.v1', 0)
+                self._position = 0
+                self._poll_calls = 0
+                self._offset_lookup_calls = 0
+
+            def partitions_for_topic(self, topic: str) -> set[int]:
+                self._topic = topic
+                return {0}
+
+            def assign(self, topic_partitions: list[tuple[str, int]]) -> None:
+                self._topic_partitions = topic_partitions
+
+            def beginning_offsets(self, topic_partitions: list[tuple[str, int]]) -> dict[tuple[str, int], int]:
+                return {tp: 0 for tp in topic_partitions}
+
+            def end_offsets(self, topic_partitions: list[tuple[str, int]]) -> dict[tuple[str, int], int]:
+                return {tp: 1 for tp in topic_partitions}
+
+            def offsets_for_times(
+                self,
+                request: dict[tuple[str, int], int],
+            ) -> dict[tuple[str, int], _OffsetMeta]:
+                self._offset_lookup_calls += 1
+                offset = 0 if self._offset_lookup_calls == 1 else 1
+                return {tp: _OffsetMeta(offset) for tp in request}
+
+            def seek(self, tp: tuple[str, int], offset: int) -> None:
+                self._position = offset
+
+            def poll(self, timeout_ms: int = 0, max_records: int = 0) -> dict[tuple[str, int], list[_Record]]:
+                _ = (timeout_ms, max_records)
+                self._poll_calls += 1
+                if self._poll_calls == 1:
+                    self._position = 1
+                    return {
+                        self._tp: [_Record(self._tp[0], self._tp[1], 0, 1735693200100)],
+                    }
+                return {}
+
+            def position(self, tp: tuple[str, int]) -> int:
+                _ = tp
+                return self._position
+
+            def close(self) -> None:
+                return None
+
+        manifest = {
+            'dataset_id': 'dataset-a',
+            'dataset_snapshot_ref': 'dataset-a@snapshot-1',
+            'candidate_id': 'intraday_tsmom_v1@prod',
+            'baseline_candidate_id': 'intraday_tsmom_v1@baseline',
+            'strategy_spec_ref': 'strategy-specs/intraday_tsmom_v1@1.1.0.json',
+            'model_refs': ['rules/intraday_tsmom_v1'],
+            'runtime_version_refs': ['services/torghut@sha256:abc'],
+            'cachePolicy': 'refresh',
+            'performance': {
+                'dumpFormat': 'ndjson',
+                'replayProfile': 'compact',
+            },
+            'window': {'start': '2025-01-01T00:00:00Z', 'end': '2025-01-01T00:00:01Z'},
+        }
+
+        with TemporaryDirectory() as tmp_dir:
+            dump_path = Path(tmp_dir) / 'source-dump.ndjson'
+            with (
+                patch.dict(
+                    'sys.modules',
+                    {'kafka': SimpleNamespace(TopicPartition=lambda topic, partition: (topic, partition))},
+                ),
+                patch(
+                    'scripts.start_historical_simulation._consumer_for_dump',
+                    return_value=_FakeConsumer(),
+                ),
+                patch(
+                    'scripts.start_historical_simulation._upload_dump_to_cache',
+                    side_effect=TimeoutError('timed out'),
+                ),
+            ):
+                report = _dump_topics(
+                    resources=resources,
+                    kafka_config=kafka_config,
+                    manifest=manifest,
+                    dump_path=dump_path,
+                    force=True,
+                )
+
+        self.assertEqual(report['records'], 1)
+        self.assertEqual(report['cache_upload']['status'], 'error')
+        self.assertEqual(report['cache_upload']['error'], 'timed out')
+
+    def test_dump_topics_orders_output_deterministically_across_partitions(self) -> None:
+        resources = _build_resources(
+            'sim-1',
+            {
+                'dataset_id': 'dataset-a',
+            },
+        )
+        resources = replace(
+            resources,
+            replay_topic_by_source_topic={'torghut.trades.v1': 'torghut.sim.trades.v1'},
+        )
+        kafka_config = KafkaRuntimeConfig(
+            bootstrap_servers='kafka:9092',
+            security_protocol=None,
+            sasl_mechanism=None,
+            sasl_username=None,
+            sasl_password=None,
+        )
+
+        class _OffsetMeta:
+            def __init__(self, offset: int) -> None:
+                self.offset = offset
+
+        class _Record:
+            def __init__(self, topic: str, partition: int, offset: int, timestamp: int) -> None:
+                self.topic = topic
+                self.partition = partition
+                self.offset = offset
+                self.timestamp = timestamp
+                self.key = None
+                self.value = None
+                self.headers: list[tuple[str, bytes]] = []
+
+        class _FakeConsumer:
+            def __init__(self) -> None:
+                self._topic = 'torghut.trades.v1'
+                self._positions = {
+                    (self._topic, 0): 0,
+                    (self._topic, 1): 0,
+                }
+                self._offset_lookup_calls = 0
+                self._poll_calls = 0
+
+            def partitions_for_topic(self, topic: str) -> set[int]:
+                self._topic = topic
+                return {0, 1}
+
+            def assign(self, topic_partitions: list[tuple[str, int]]) -> None:
+                self._topic_partitions = topic_partitions
+
+            def beginning_offsets(self, topic_partitions: list[tuple[str, int]]) -> dict[tuple[str, int], int]:
+                return {tp: 0 for tp in topic_partitions}
+
+            def end_offsets(self, topic_partitions: list[tuple[str, int]]) -> dict[tuple[str, int], int]:
+                return {tp: 1 for tp in topic_partitions}
+
+            def offsets_for_times(
+                self,
+                request: dict[tuple[str, int], int],
+            ) -> dict[tuple[str, int], _OffsetMeta]:
+                self._offset_lookup_calls += 1
+                offset = 0 if self._offset_lookup_calls == 1 else 1
+                return {tp: _OffsetMeta(offset) for tp in request}
+
+            def seek(self, tp: tuple[str, int], offset: int) -> None:
+                self._positions[tp] = offset
+
+            def poll(self, timeout_ms: int = 0, max_records: int = 0) -> dict[tuple[str, int], list[_Record]]:
+                _ = (timeout_ms, max_records)
+                self._poll_calls += 1
+                if self._poll_calls == 1:
+                    self._positions[(self._topic, 1)] = 1
+                    self._positions[(self._topic, 0)] = 1
+                    return {
+                        (self._topic, 1): [_Record(self._topic, 1, 0, 1735693200200)],
+                        (self._topic, 0): [_Record(self._topic, 0, 0, 1735693200100)],
+                    }
+                return {}
+
+            def position(self, tp: tuple[str, int]) -> int:
+                return self._positions[tp]
+
+            def close(self) -> None:
+                return None
+
+        with TemporaryDirectory() as tmp_dir:
+            dump_path = Path(tmp_dir) / 'source-dump.ndjson'
+            fake_consumer = _FakeConsumer()
+
+            with (
+                patch.dict(
+                    'sys.modules',
+                    {'kafka': SimpleNamespace(TopicPartition=lambda topic, partition: (topic, partition))},
+                ),
+                patch(
+                    'scripts.start_historical_simulation._consumer_for_dump',
+                    return_value=fake_consumer,
+                ),
+            ):
+                report = _dump_topics(
+                    resources=resources,
+                    kafka_config=kafka_config,
+                    manifest={'window': {'start': '2025-01-01T00:00:00Z', 'end': '2025-01-01T00:00:01Z'}},
+                    dump_path=dump_path,
+                    force=True,
+                )
+
+            lines = [json.loads(line) for line in dump_path.read_text(encoding='utf-8').splitlines()]
+            self.assertEqual(report['records'], 2)
+            self.assertEqual(
+                [(line['source_timestamp_ms'], line['source_partition'], line['source_offset']) for line in lines],
+                [
+                    (1735693200100, 0, 0),
+                    (1735693200200, 1, 0),
+                ],
+            )
 
     def test_dump_topics_completes_when_last_record_reaches_stop_offset(self) -> None:
         resources = _build_resources(
@@ -4433,6 +5114,92 @@ class TestStartHistoricalSimulation(TestCase):
         self.assertEqual(full_day['status'], 'satisfied')
         self.assertIsNone(full_day['blocked_reason'])
 
+    def test_build_simulation_completion_trace_derives_full_day_coverage_from_observed_minutes(self) -> None:
+        resources = _build_resources(
+            'sim-2026-03-13-full-day',
+            {
+                'dataset_id': 'torghut-full-day-20260313',
+                'dataset_snapshot_ref': 'torghut-full-day-20260313',
+                'window': {
+                    'profile': 'us_equities_regular',
+                    'start': '2026-03-13T13:30:00Z',
+                    'end': '2026-03-13T20:00:00Z',
+                    'min_coverage_minutes': 390,
+                    'strict_coverage_ratio': 0.95,
+                },
+            },
+        )
+        postgres = PostgresRuntimeConfig(
+            admin_dsn='postgresql://torghut:secret@localhost/postgres',
+            simulation_dsn='postgresql://torghut:secret@localhost/torghut_sim_full_day',
+            simulation_db='torghut_sim_full_day',
+            migrations_command='alembic upgrade heads',
+        )
+        with TemporaryDirectory() as tmpdir:
+            resources = replace(resources, output_root=Path(tmpdir))
+            for filename in (
+                'run-manifest.json',
+                'run-full-lifecycle-manifest.json',
+                'runtime-verify.json',
+                'replay-report.json',
+                'signal-activity.json',
+                'decision-activity.json',
+                'execution-activity.json',
+            ):
+                (resources.output_root / resources.run_token / filename).parent.mkdir(
+                    parents=True,
+                    exist_ok=True,
+                )
+                (resources.output_root / resources.run_token / filename).write_text(
+                    '{}',
+                    encoding='utf-8',
+                )
+
+            trace = _build_simulation_completion_trace(
+                resources=resources,
+                manifest={
+                    'dataset_snapshot_ref': 'torghut-full-day-20260313',
+                    'window': {
+                        'profile': 'us_equities_regular',
+                        'start': '2026-03-13T13:30:00Z',
+                        'end': '2026-03-13T20:00:00Z',
+                        'min_coverage_minutes': 390,
+                        'strict_coverage_ratio': 0.95,
+                    },
+                },
+                postgres_config=postgres,
+                apply_report={
+                    'window_policy': {'min_coverage_minutes': 390, 'strict_coverage_ratio': 0.95},
+                    'dump_coverage': {
+                        'observed_minutes': 389.9975,
+                        'required_minutes': 370.5,
+                        'strict_ratio': 0.95,
+                    },
+                },
+                runtime_verify_report={'runtime_state': 'ready'},
+                monitor_report={
+                    'activity_classification': 'success',
+                    'final_snapshot': {
+                        'trade_decisions': 123,
+                        'executions': 16,
+                        'execution_tca_metrics': 16,
+                        'execution_order_events': 16,
+                    },
+                },
+                analytics_report={},
+                fill_price_error_budget_report={
+                    'status': 'within_budget',
+                    'schema_version': 'fill-price-error-budget-report-v1',
+                },
+                rollouts_report={},
+                errors=[],
+            )
+
+        full_day = trace['result_by_gate']['simulation_full_day_coverage']
+        self.assertEqual(full_day['status'], 'satisfied')
+        self.assertIsNone(full_day['blocked_reason'])
+        self.assertAlmostEqual(full_day['acceptance_snapshot']['coverage_ratio'], 389.9975 / 390.0)
+
     def test_validate_window_policy_us_equities_regular_profile(self) -> None:
         policy = _validate_window_policy(
             {
@@ -4492,6 +5259,30 @@ class TestStartHistoricalSimulation(TestCase):
                 },
             )
 
+    def test_validate_dump_coverage_reports_ratio_when_policy_present(self) -> None:
+        coverage = _validate_dump_coverage(
+            manifest={
+                'window': {
+                    'profile': 'us_equities_regular',
+                    'trading_day': '2026-03-13',
+                    'timezone': 'America/New_York',
+                    'start': '2026-03-13T13:30:00Z',
+                    'end': '2026-03-13T20:00:00Z',
+                    'min_coverage_minutes': 390,
+                    'strict_coverage_ratio': 0.95,
+                }
+            },
+            dump_report={
+                'records': 100,
+                'min_source_timestamp_ms': 1773408600150,
+                'max_source_timestamp_ms': 1773432000000,
+            },
+        )
+
+        self.assertTrue(coverage['applied'])
+        self.assertAlmostEqual(coverage['coverage_ratio'], 389.9975 / 390.0)
+        self.assertAlmostEqual(coverage['required_minutes'], 390 * 0.95)
+
     def test_validate_dump_coverage_reports_full_day_coverage_ratio(self) -> None:
         report = _validate_dump_coverage(
             manifest={
@@ -4501,6 +5292,8 @@ class TestStartHistoricalSimulation(TestCase):
                     'timezone': 'America/New_York',
                     'start': '2026-02-27T14:30:00Z',
                     'end': '2026-02-27T21:00:00Z',
+                    'min_coverage_minutes': 390,
+                    'strict_coverage_ratio': 0.95,
                 }
             },
             dump_report={
@@ -7772,6 +8565,96 @@ class TestStartHistoricalSimulation(TestCase):
         self.assertTrue(report['applicationset_managed'])
         self.assertEqual(report['previous_mode'], 'auto')
         self.assertEqual(report['current_mode'], 'manual')
+
+    def test_ensure_argocd_manual_before_runtime_mutation_noops_when_everything_is_manual(self) -> None:
+        config = ArgocdAutomationConfig(
+            manage_automation=True,
+            applicationset_name='product',
+            applicationset_namespace='argocd',
+            app_name='torghut',
+            root_app_name='root',
+            desired_mode_during_run='manual',
+            restore_mode_after_run='previous',
+            verify_timeout_seconds=30,
+        )
+        with (
+            patch(
+                'scripts.start_historical_simulation._read_argocd_automation_mode',
+                return_value={'pointer': '/spec/generators/0/list/elements/0/automation', 'mode': 'manual'},
+            ),
+            patch(
+                'scripts.start_historical_simulation._read_named_argocd_application_sync_policy',
+                side_effect=[
+                    {
+                        'sync_policy': {
+                            'automated': {'enabled': False, 'prune': False, 'selfHeal': False},
+                            'syncOptions': ['CreateNamespace=true'],
+                        },
+                        'automation_mode': 'manual',
+                    },
+                    {
+                        'sync_policy': {
+                            'automated': {'enabled': False, 'prune': False, 'selfHeal': False},
+                            'syncOptions': ['CreateNamespace=true'],
+                        },
+                        'automation_mode': 'manual',
+                    },
+                ],
+            ),
+            patch('scripts.start_historical_simulation._prepare_argocd_for_run') as prepare_mock,
+        ):
+            report = start_historical_simulation._ensure_argocd_manual_before_runtime_mutation(config=config)
+
+        prepare_mock.assert_not_called()
+        self.assertEqual(report['reason'], 'already_manual')
+        self.assertFalse(report['changed'])
+        self.assertEqual(report['current_mode'], 'manual')
+
+    def test_ensure_argocd_manual_before_runtime_mutation_reasserts_when_child_app_drifted(self) -> None:
+        config = ArgocdAutomationConfig(
+            manage_automation=True,
+            applicationset_name='product',
+            applicationset_namespace='argocd',
+            app_name='torghut',
+            root_app_name='root',
+            desired_mode_during_run='manual',
+            restore_mode_after_run='previous',
+            verify_timeout_seconds=30,
+        )
+        with (
+            patch(
+                'scripts.start_historical_simulation._read_argocd_automation_mode',
+                return_value={'pointer': '/spec/generators/0/list/elements/0/automation', 'mode': 'manual'},
+            ),
+            patch(
+                'scripts.start_historical_simulation._read_named_argocd_application_sync_policy',
+                side_effect=[
+                    {
+                        'sync_policy': {
+                            'automated': {'enabled': True, 'prune': True, 'selfHeal': True},
+                            'syncOptions': ['CreateNamespace=true'],
+                        },
+                        'automation_mode': 'auto',
+                    },
+                    {
+                        'sync_policy': {
+                            'automated': {'enabled': False, 'prune': False, 'selfHeal': False},
+                            'syncOptions': ['CreateNamespace=true'],
+                        },
+                        'automation_mode': 'manual',
+                    },
+                ],
+            ),
+            patch(
+                'scripts.start_historical_simulation._prepare_argocd_for_run',
+                return_value={'managed': True, 'changed': True, 'current_mode': 'manual'},
+            ) as prepare_mock,
+        ):
+            report = start_historical_simulation._ensure_argocd_manual_before_runtime_mutation(config=config)
+
+        prepare_mock.assert_called_once_with(config=config)
+        self.assertEqual(report['reason'], 'reasserted_manual_before_runtime_mutation')
+        self.assertTrue(report['changed'])
 
     def test_restore_argocd_after_run_restores_root_and_applicationset(self) -> None:
         config = ArgocdAutomationConfig(

--- a/services/torghut/tests/test_start_historical_simulation.py
+++ b/services/torghut/tests/test_start_historical_simulation.py
@@ -8603,6 +8603,44 @@ class TestStartHistoricalSimulation(TestCase):
             {'enabled': False, 'prune': False, 'selfHeal': False},
         )
 
+    def test_set_argocd_application_skip_reconcile_patches_and_verifies(self) -> None:
+        payload_unset = {
+            'metadata': {
+                'annotations': {},
+            }
+        }
+        payload_enabled = {
+            'metadata': {
+                'annotations': {
+                    'argocd.argoproj.io/skip-reconcile': 'true',
+                }
+            }
+        }
+        with (
+            patch(
+                'scripts.start_historical_simulation._kubectl_json_global',
+                side_effect=[payload_unset, payload_enabled],
+            ),
+            patch('scripts.start_historical_simulation._kubectl_patch') as patch_mock,
+        ):
+            report = start_historical_simulation._set_argocd_application_skip_reconcile(
+                config=ArgocdAutomationConfig(
+                    manage_automation=True,
+                    applicationset_name='product',
+                    applicationset_namespace='argocd',
+                    app_name='torghut',
+                    root_app_name='root',
+                    desired_mode_during_run='manual',
+                    restore_mode_after_run='previous',
+                    verify_timeout_seconds=30,
+                ),
+                desired_value='true',
+            )
+        self.assertTrue(report['changed'])
+        patch_mock.assert_called_once()
+        self.assertEqual(report['current_value'], 'true')
+        self.assertTrue(report['enabled'])
+
     def test_argocd_application_mode_from_sync_policy_treats_missing_automation_as_manual(self) -> None:
         self.assertEqual(
             start_historical_simulation._argocd_application_mode_from_sync_policy(
@@ -8635,26 +8673,57 @@ class TestStartHistoricalSimulation(TestCase):
             ) as automation_read_mock,
             patch(
                 'scripts.start_historical_simulation._read_named_argocd_application_sync_policy',
-                return_value={
-                    'sync_policy': {
-                        'automated': {'enabled': True, 'prune': True, 'selfHeal': True},
-                        'syncOptions': ['CreateNamespace=true'],
+                side_effect=[
+                    {
+                        'sync_policy': {
+                            'automated': {'enabled': True, 'prune': True, 'selfHeal': True},
+                            'syncOptions': ['CreateNamespace=true'],
+                        },
+                        'automation_mode': 'auto',
+                        'skip_reconcile_enabled': False,
+                        'skip_reconcile_value': None,
                     },
-                    'automation_mode': 'auto',
-                },
+                    {
+                        'sync_policy': {
+                            'automated': {'enabled': True, 'prune': True, 'selfHeal': True},
+                            'syncOptions': ['CreateNamespace=true'],
+                        },
+                        'automation_mode': 'auto',
+                    },
+                ],
             ) as application_read_mock,
             patch(
                 'scripts.start_historical_simulation._set_argocd_application_sync_policy',
+                side_effect=[
+                    {
+                        'previous_sync_policy': {
+                            'automated': {'enabled': True, 'prune': True, 'selfHeal': True},
+                        },
+                        'current_sync_policy': {
+                            'automated': {'enabled': False, 'prune': False, 'selfHeal': False},
+                        },
+                        'changed': True,
+                    },
+                    {
+                        'previous_sync_policy': {
+                            'automated': {'enabled': True, 'prune': True, 'selfHeal': True},
+                        },
+                        'current_sync_policy': {
+                            'automated': {'enabled': False, 'prune': False, 'selfHeal': False},
+                        },
+                        'changed': True,
+                    },
+                ],
+            ) as application_sync_mock,
+            patch(
+                'scripts.start_historical_simulation._set_argocd_application_skip_reconcile',
                 return_value={
-                    'previous_sync_policy': {
-                        'automated': {'enabled': True, 'prune': True, 'selfHeal': True},
-                    },
-                    'current_sync_policy': {
-                        'automated': {'enabled': False, 'prune': False, 'selfHeal': False},
-                    },
+                    'previous_value': None,
+                    'current_value': 'true',
+                    'enabled': True,
                     'changed': True,
                 },
-            ) as root_application_mock,
+            ) as skip_reconcile_mock,
             patch(
                 'scripts.start_historical_simulation._set_argocd_automation_mode',
                 return_value={
@@ -8675,16 +8744,40 @@ class TestStartHistoricalSimulation(TestCase):
         ):
             report = _prepare_argocd_for_run(config=config)
         automation_read_mock.assert_called_once()
-        application_read_mock.assert_called_once_with(
-            namespace='argocd',
-            app_name='root',
+        self.assertEqual(application_read_mock.call_args_list, [
+            call(namespace='argocd', app_name='torghut'),
+            call(namespace='argocd', app_name='root'),
+        ])
+        self.assertEqual(application_sync_mock.call_args_list, [
+            call(
+                config=config,
+                app_name='torghut',
+                desired_sync_policy={
+                    'automated': {'enabled': False, 'prune': False, 'selfHeal': False},
+                    'syncOptions': ['CreateNamespace=true'],
+                },
+            ),
+            call(
+                config=config,
+                app_name='root',
+                desired_sync_policy={
+                    'automated': {'enabled': False, 'prune': False, 'selfHeal': False},
+                    'syncOptions': ['CreateNamespace=true'],
+                },
+            ),
+        ])
+        skip_reconcile_mock.assert_called_once_with(
+            config=config,
+            app_name='torghut',
+            desired_value='true',
         )
-        root_application_mock.assert_called_once()
         applicationset_mock.assert_called_once()
         application_mode_mock.assert_called_once()
         self.assertTrue(report['changed'])
         self.assertIn('application', report)
         self.assertIn('root_application', report)
+        self.assertIn('application_sync_policy', report)
+        self.assertIn('application_skip_reconcile', report)
         self.assertTrue(report['applicationset_managed'])
         self.assertEqual(report['previous_mode'], 'auto')
         self.assertEqual(report['current_mode'], 'manual')
@@ -8714,6 +8807,8 @@ class TestStartHistoricalSimulation(TestCase):
                             'syncOptions': ['CreateNamespace=true'],
                         },
                         'automation_mode': 'manual',
+                        'skip_reconcile_enabled': True,
+                        'skip_reconcile_value': 'true',
                     },
                     {
                         'sync_policy': {
@@ -8732,6 +8827,7 @@ class TestStartHistoricalSimulation(TestCase):
         self.assertEqual(report['reason'], 'already_manual')
         self.assertFalse(report['changed'])
         self.assertEqual(report['current_mode'], 'manual')
+        self.assertTrue(report['application_skip_reconcile']['enabled'])
 
     def test_ensure_argocd_manual_before_runtime_mutation_reasserts_when_child_app_drifted(self) -> None:
         config = ArgocdAutomationConfig(
@@ -8758,6 +8854,8 @@ class TestStartHistoricalSimulation(TestCase):
                             'syncOptions': ['CreateNamespace=true'],
                         },
                         'automation_mode': 'auto',
+                        'skip_reconcile_enabled': False,
+                        'skip_reconcile_value': None,
                     },
                     {
                         'sync_policy': {
@@ -8807,14 +8905,32 @@ class TestStartHistoricalSimulation(TestCase):
             ) as applicationset_mock,
             patch(
                 'scripts.start_historical_simulation._set_argocd_application_sync_policy',
-                return_value={
-                    'previous_sync_policy': {
-                        'automated': {'enabled': False, 'prune': False, 'selfHeal': False},
+                side_effect=[
+                    {
+                        'previous_sync_policy': {
+                            'automated': {'enabled': False, 'prune': False, 'selfHeal': False},
+                        },
+                        'current_sync_policy': previous_sync_policy,
+                        'changed': True,
                     },
-                    'current_sync_policy': previous_sync_policy,
+                    {
+                        'previous_sync_policy': {
+                            'automated': {'enabled': False, 'prune': False, 'selfHeal': False},
+                        },
+                        'current_sync_policy': previous_sync_policy,
+                        'changed': True,
+                    },
+                ],
+            ) as application_mock,
+            patch(
+                'scripts.start_historical_simulation._set_argocd_application_skip_reconcile',
+                return_value={
+                    'previous_value': 'true',
+                    'current_value': None,
+                    'enabled': False,
                     'changed': True,
                 },
-            ) as application_mock,
+            ) as skip_reconcile_mock,
             patch(
                 'scripts.start_historical_simulation._wait_for_argocd_application_mode',
                 return_value={
@@ -8826,10 +8942,17 @@ class TestStartHistoricalSimulation(TestCase):
             report = _restore_argocd_after_run(
                 config=config,
                 previous_mode='auto',
-                previous_sync_policy=previous_sync_policy,
+                previous_root_sync_policy=previous_sync_policy,
+                previous_child_sync_policy=previous_sync_policy,
+                previous_child_skip_reconcile_value=None,
             )
         applicationset_mock.assert_called_once()
-        application_mock.assert_called_once()
+        self.assertEqual(application_mock.call_count, 2)
+        skip_reconcile_mock.assert_called_once_with(
+            config=config,
+            app_name='torghut',
+            desired_value=None,
+        )
         application_mode_mock.assert_called_once()
         self.assertTrue(report['changed'])
         self.assertEqual(report['restored_mode'], 'auto')

--- a/services/torghut/tests/test_start_historical_simulation.py
+++ b/services/torghut/tests/test_start_historical_simulation.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import gzip
 import json
 import uuid
 from contextlib import ExitStack
@@ -4202,6 +4203,128 @@ class TestStartHistoricalSimulation(TestCase):
                     (1735693200200, 1, 0),
                 ],
             )
+
+    def test_dump_topics_cleans_compressed_sort_temps(self) -> None:
+        resources = _build_resources(
+            'sim-1',
+            {
+                'dataset_id': 'dataset-a',
+            },
+        )
+        resources = replace(
+            resources,
+            replay_topic_by_source_topic={'torghut.trades.v1': 'torghut.sim.trades.v1'},
+        )
+        kafka_config = KafkaRuntimeConfig(
+            bootstrap_servers='kafka:9092',
+            security_protocol=None,
+            sasl_mechanism=None,
+            sasl_username=None,
+            sasl_password=None,
+        )
+
+        class _OffsetMeta:
+            def __init__(self, offset: int) -> None:
+                self.offset = offset
+
+        class _Record:
+            def __init__(self, topic: str, partition: int, offset: int, timestamp: int) -> None:
+                self.topic = topic
+                self.partition = partition
+                self.offset = offset
+                self.timestamp = timestamp
+                self.key = None
+                self.value = None
+                self.headers: list[tuple[str, bytes]] = []
+
+        class _FakeConsumer:
+            def __init__(self) -> None:
+                self._topic = 'torghut.trades.v1'
+                self._position = 0
+                self._offset_lookup_calls = 0
+                self._poll_calls = 0
+
+            def partitions_for_topic(self, topic: str) -> set[int]:
+                self._topic = topic
+                return {0}
+
+            def assign(self, topic_partitions: list[tuple[str, int]]) -> None:
+                self._topic_partitions = topic_partitions
+
+            def beginning_offsets(self, topic_partitions: list[tuple[str, int]]) -> dict[tuple[str, int], int]:
+                return {tp: 0 for tp in topic_partitions}
+
+            def end_offsets(self, topic_partitions: list[tuple[str, int]]) -> dict[tuple[str, int], int]:
+                return {tp: 1 for tp in topic_partitions}
+
+            def offsets_for_times(
+                self,
+                request: dict[tuple[str, int], int],
+            ) -> dict[tuple[str, int], _OffsetMeta]:
+                self._offset_lookup_calls += 1
+                offset = 0 if self._offset_lookup_calls == 1 else 1
+                return {tp: _OffsetMeta(offset) for tp in request}
+
+            def seek(self, tp: tuple[str, int], offset: int) -> None:
+                self._position = offset
+
+            def poll(self, timeout_ms: int = 0, max_records: int = 0) -> dict[tuple[str, int], list[_Record]]:
+                _ = (timeout_ms, max_records)
+                self._poll_calls += 1
+                if self._poll_calls == 1:
+                    self._position = 1
+                    return {
+                        (self._topic, 0): [_Record(self._topic, 0, 0, 1735693200100)],
+                    }
+                return {}
+
+            def position(self, tp: tuple[str, int]) -> int:
+                _ = tp
+                return self._position
+
+            def close(self) -> None:
+                return None
+
+        manifest = {
+            'performance': {
+                'dumpFormat': 'jsonl.gz',
+            },
+            'window': {'start': '2025-01-01T00:00:00Z', 'end': '2025-01-01T00:00:01Z'},
+        }
+
+        with TemporaryDirectory() as tmp_dir:
+            dump_path = Path(tmp_dir) / 'source-dump.jsonl.gz'
+            raw_dump_path = dump_path.with_suffix(dump_path.suffix + '.tmp.ndjson')
+            staged_dump_path = dump_path.with_suffix(dump_path.suffix + '.sort-stage.tsv')
+            sorted_dump_path = raw_dump_path.with_suffix(raw_dump_path.suffix + '.sort-output.tsv')
+
+            with (
+                patch.dict(
+                    'sys.modules',
+                    {'kafka': SimpleNamespace(TopicPartition=lambda topic, partition: (topic, partition))},
+                ),
+                patch(
+                    'scripts.start_historical_simulation._consumer_for_dump',
+                    return_value=_FakeConsumer(),
+                ),
+            ):
+                report = _dump_topics(
+                    resources=resources,
+                    kafka_config=kafka_config,
+                    manifest=manifest,
+                    dump_path=dump_path,
+                    force=True,
+                )
+
+            self.assertEqual(report['records'], 1)
+            self.assertTrue(dump_path.exists())
+            self.assertFalse(raw_dump_path.exists())
+            self.assertFalse(staged_dump_path.exists())
+            self.assertFalse(sorted_dump_path.exists())
+            with gzip.open(dump_path, 'rt', encoding='utf-8') as handle:
+                lines = [json.loads(line) for line in handle]
+            self.assertEqual(len(lines), 1)
+            self.assertEqual(lines[0]['source_timestamp_ms'], 1735693200100)
 
     def test_dump_topics_completes_when_last_record_reaches_stop_offset(self) -> None:
         resources = _build_resources(

--- a/services/torghut/tests/test_verify_historical_simulation_parity.py
+++ b/services/torghut/tests/test_verify_historical_simulation_parity.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import TestCase
+
+from scripts.verify_historical_simulation_parity import build_historical_parity_report
+
+
+class TestVerifyHistoricalSimulationParity(TestCase):
+    def test_passes_when_runs_match(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            run_a = _write_run(root=root, run_name='run-a', trade_decisions=10, executions=4, net_pnl='12.5')
+            run_b = _write_run(root=root, run_name='run-b', trade_decisions=10, executions=4, net_pnl='12.5')
+
+            report = build_historical_parity_report(run_dirs=[run_a, run_b])
+
+            self.assertTrue(report['passed'])
+            self.assertEqual(report['failed_reasons'], [])
+
+    def test_fails_when_metrics_drift(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            run_a = _write_run(root=root, run_name='run-a', trade_decisions=10, executions=4, net_pnl='12.5')
+            run_b = _write_run(root=root, run_name='run-b', trade_decisions=11, executions=4, net_pnl='12.5')
+
+            report = build_historical_parity_report(run_dirs=[run_a, run_b])
+
+            self.assertFalse(report['passed'])
+            self.assertIn('parity_hash_mismatch:run-b', report['failed_reasons'])
+
+
+def _write_run(
+    *,
+    root: Path,
+    run_name: str,
+    trade_decisions: int,
+    executions: int,
+    net_pnl: str,
+) -> Path:
+    run_dir = root / run_name
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / 'run-full-lifecycle-manifest.json').write_text(
+        json.dumps(
+            {
+                'run_id': run_name,
+                'replay': {
+                    'dump_sha256': 'dump-sha',
+                },
+                'monitor': {
+                    'activity_classification': 'success',
+                    'final_snapshot': {
+                        'legacy_path_count': 0,
+                        'fallback_count': 0,
+                    },
+                },
+                'report': {
+                    'funnel': {
+                        'trade_decisions': trade_decisions,
+                        'executions': executions,
+                        'execution_tca_metrics': executions,
+                        'execution_order_events': executions,
+                    },
+                    'pnl': {
+                        'net_pnl_estimated': net_pnl,
+                    },
+                },
+            }
+        ),
+        encoding='utf-8',
+    )
+    return run_dir


### PR DESCRIPTION
## Summary

- Replace the dedicated simulation proof guard with ApplicationSet-backed `ignoreDifferences` handling so Argo stops reverting runtime proof mutations mid-run.
- Preserve and restore the prior root/child sync policy and ignore-differences state around historical simulation setup and teardown.
- Switch simulation signal ingestion to cursor-bounded, ordered, batch-limited ClickHouse reads so the proof path matches production logic and avoids memory-limit failures on March 13 full-day replays.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_start_historical_simulation.py -k "argocd or applicationset_entry or reasserts_manual_argocd_control_before_runtime_mutation"`
- `uv run --frozen pytest tests/test_signal_ingest.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
