### PR TITLE
fix(symphony): mount jangar codex auth secret

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -28,4 +28,4 @@ spec:
             name: symphony-workflow-jangar
         - name: codex-auth
           secret:
-            secretName: codex-auth-symphony-jangar
+            secretName: codex-auth-symphony-jangar-jangar


### PR DESCRIPTION
## Summary

- point `symphony-jangar` at the SealedSecrets-generated Codex auth Secret name
- align the deployment volume mount with the live controller output in `jangar`
- unblock Jangar Symphony pods from restarting onto the rotated ChatGPT auth payload

## Related Issues

None

## Testing

- `scripts/kubeconform.sh argocd/applications/symphony-jangar`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/symphony-jangar | rg -n 'secretName:|name: codex-auth-symphony-jangar' -C 2`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
