### PR TITLE
chore(jangar): promote image 4dbea35b

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 3f0647cc
-  digest: sha256:fd1d1d0a9c489dbbd3daa214ba83bd2ab1ad04e0acdb3935402190f61ee3a4a1
+  tag: 4dbea35b
+  digest: sha256:ac765c2290b0f8d4276e2dc6eda68ccc681914fcbd72edb02a6b93cb0eabd52a
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 3f0647cc
-    digest: sha256:0214a50d1daa9e8a60016e895fd58bb6198130a1c3f1b896bac666541c89e0f9
+    tag: 4dbea35b
+    digest: sha256:a746b682ce5a378975d6ce796c5089aa20a755b4078bc35260354197414fd9dc
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 3f0647cc
-    digest: sha256:fd1d1d0a9c489dbbd3daa214ba83bd2ab1ad04e0acdb3935402190f61ee3a4a1
+    tag: 4dbea35b
+    digest: sha256:ac765c2290b0f8d4276e2dc6eda68ccc681914fcbd72edb02a6b93cb0eabd52a
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-16T12:26:52Z"
+    deploy.knative.dev/rollout: "2026-03-16T23:53:41Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-16T12:26:52Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-16T23:53:41Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -62,5 +62,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "3f0647cc"
-    digest: sha256:fd1d1d0a9c489dbbd3daa214ba83bd2ab1ad04e0acdb3935402190f61ee3a4a1
+    newTag: "4dbea35b"
+    digest: sha256:ac765c2290b0f8d4276e2dc6eda68ccc681914fcbd72edb02a6b93cb0eabd52a


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `4dbea35bc6a792fef6449c49cbf66477d15ef1bc`
- Image tag: `4dbea35b`
- Image digest: `sha256:ac765c2290b0f8d4276e2dc6eda68ccc681914fcbd72edb02a6b93cb0eabd52a`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`