### PR TITLE
fix(argocd): disable agents postsync smoke hook

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -22,6 +22,8 @@ argocdHooks:
   image:
     repository: alpine/k8s
     tag: 1.30.11
+  postSync:
+    enabled: false
   smoke:
     agentRun:
       apiVersion: agents.proompteng.ai/v1alpha1


### PR DESCRIPTION
## Summary

- disable the `agents-smoke-run` PostSync hook for the `agents` Argo CD app
- stop GitOps sync from failing when Codex runtime auth or usage is exhausted
- keep the lightweight `agents-smoke-cleanup` PreSync hook in place

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents`
- `bun run lint:argocd`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
