### PR TITLE
chore(torghut-options): promote ws image b4201cf7

### DIFF
--- a/argocd/applications/torghut-options/ws/deployment.yaml
+++ b/argocd/applications/torghut-options/ws/deployment.yaml
@@ -29,7 +29,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-ws-options
-          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:123c7b9ce0378977ddd45c8dd9f61b56156e795b330aa3814d1f4d0db64c3502
+          image: registry.ide-newton.ts.net/lab/torghut-ws@sha256:ca389a40d9d6a7521e8c732b87860b2a41ab821083eedb858b6df7657bfd057d
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:
@@ -53,9 +53,9 @@ spec:
                   name: torghut-options
                   key: password
             - name: TORGHUT_WS_VERSION
-              value: main-ca2312e1
+              value: main-b4201cf7
             - name: TORGHUT_WS_COMMIT
-              value: ca2312e1a9ae8ebdd409b7ed8fa55fdd9647b8a1
+              value: b4201cf75a74276b702affa737a17625736c5ad0
             - name: JAVA_TOOL_OPTIONS
               value: -XX:+UseContainerSupport -XX:InitialRAMPercentage=40.0 -XX:MaxRAMPercentage=70.0 -XX:+ExitOnOutOfMemoryError
           ports:


### PR DESCRIPTION
## Summary
Promote the Torghut options websocket image into GitOps manifests.

- Source commit: `b4201cf75a74276b702affa737a17625736c5ad0`
- Image tag: `b4201cf7`
- Image digest: `sha256:ca389a40d9d6a7521e8c732b87860b2a41ab821083eedb858b6df7657bfd057d`