### PR TITLE
fix(symphony): persist codex auth on workspace

### DIFF
--- a/argocd/applications/symphony-base/deployment.yaml
+++ b/argocd/applications/symphony-base/deployment.yaml
@@ -26,12 +26,24 @@ spec:
         - name: symphony
           image: registry.ide-newton.ts.net/lab/symphony
           imagePullPolicy: Always
-          command: ['bun', 'src/index.ts', '/etc/symphony/WORKFLOW.md']
+          command:
+            - sh
+            - -lc
+            - |
+              export HOME="${HOME:-/workspace/.codex-home}"
+              mkdir -p "$HOME/.codex"
+              if [ ! -f "$HOME/.codex/auth.json" ]; then
+                cp /var/run/codex-auth/auth.json "$HOME/.codex/auth.json"
+                chmod 600 "$HOME/.codex/auth.json"
+              fi
+              exec bun src/index.ts /etc/symphony/WORKFLOW.md
           ports:
             - name: http
               containerPort: 8080
               protocol: TCP
           env:
+            - name: HOME
+              value: /workspace/.codex-home
             - name: NODE_ENV
               value: production
             - name: LINEAR_API_KEY
@@ -86,7 +98,7 @@ spec:
               subPath: WORKFLOW.md
               readOnly: true
             - name: codex-auth
-              mountPath: /root/.codex/auth.json
+              mountPath: /var/run/codex-auth/auth.json
               subPath: auth.json
               readOnly: true
       volumes:


### PR DESCRIPTION
## Summary

- seed Codex auth from the Secret into a writable per-instance home on the Symphony workspace PVC
- stop mounting `auth.json` directly as a read-only file inside the container home
- make future refresh-token rotation persist across long-running Symphony worker sessions

## Related Issues

None

## Testing

- `scripts/kubeconform.sh argocd/applications/symphony argocd/applications/symphony-jangar argocd/applications/symphony-torghut`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/symphony-jangar | rg -n 'command:|/var/run/codex-auth|/workspace/.codex-home|mountPath: /var/run/codex-auth/auth.json' -C 2`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
