### PR TITLE
chore(symphony): promote image db20184c

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-19T03:51:05Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-19T03:57:38Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -25,5 +25,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "af739c46"
-    digest: sha256:a77714e8c5cc71f75ea8833b5b15e358c579bc3e0d858ae94cc0567707c8ad55
+    newTag: "db20184c"
+    digest: sha256:e6205f20561623d9b22de4390a37ea9d523612191f26ef7444d2eca8dbefd25c

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-19T03:51:05Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-19T03:57:38Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -26,5 +26,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "af739c46"
-    digest: sha256:a77714e8c5cc71f75ea8833b5b15e358c579bc3e0d858ae94cc0567707c8ad55
+    newTag: "db20184c"
+    digest: sha256:e6205f20561623d9b22de4390a37ea9d523612191f26ef7444d2eca8dbefd25c

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-19T03:51:05Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-19T03:57:38Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -19,5 +19,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "af739c46"
-    digest: sha256:a77714e8c5cc71f75ea8833b5b15e358c579bc3e0d858ae94cc0567707c8ad55
+    newTag: "db20184c"
+    digest: sha256:e6205f20561623d9b22de4390a37ea9d523612191f26ef7444d2eca8dbefd25c


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `db20184ce03355a24a29a552c2ffe358a6fa15f5`
- Image tag: `db20184c`
- Image digest: `sha256:e6205f20561623d9b22de4390a37ea9d523612191f26ef7444d2eca8dbefd25c`