### PR TITLE
fix(symphony): refresh cached codex auth

### DIFF
--- a/argocd/applications/symphony-base/deployment.yaml
+++ b/argocd/applications/symphony-base/deployment.yaml
@@ -32,7 +32,7 @@ spec:
             - |
               export HOME="${HOME:-/workspace/.codex-home}"
               mkdir -p "$HOME/.codex"
-              if [ ! -f "$HOME/.codex/auth.json" ]; then
+              if [ ! -f "$HOME/.codex/auth.json" ] || ! cmp -s /var/run/codex-auth/auth.json "$HOME/.codex/auth.json"; then
                 cp /var/run/codex-auth/auth.json "$HOME/.codex/auth.json"
                 chmod 600 "$HOME/.codex/auth.json"
               fi


### PR DESCRIPTION
## Summary

- refresh the cached PVC-backed Codex auth file whenever the mounted secret content changes
- keep the writable `HOME=/workspace/.codex-home` behavior but remove the stale copy-once trap
- make future `codex-auth` SealedSecret rotations take effect on the next pod restart without manual cleanup

## Related Issues

None

## Testing

- `scripts/kubeconform.sh argocd/applications/symphony argocd/applications/symphony-jangar argocd/applications/symphony-torghut`
- `git diff -- argocd/applications/symphony-base/deployment.yaml | sed -n '1,120p'`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
