### PR TITLE
chore(symphony): promote image 76cd6189

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-19T03:57:38Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-19T04:04:52Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -25,5 +25,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "db20184c"
-    digest: sha256:e6205f20561623d9b22de4390a37ea9d523612191f26ef7444d2eca8dbefd25c
+    newTag: "76cd6189"
+    digest: sha256:481b5d3ea5724ee80a55be28c41026203a3156a650fad5b5861c3fbb0fae139e

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-19T03:57:38Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-19T04:04:52Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -26,5 +26,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "db20184c"
-    digest: sha256:e6205f20561623d9b22de4390a37ea9d523612191f26ef7444d2eca8dbefd25c
+    newTag: "76cd6189"
+    digest: sha256:481b5d3ea5724ee80a55be28c41026203a3156a650fad5b5861c3fbb0fae139e

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-19T03:57:38Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-19T04:04:52Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -19,5 +19,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "db20184c"
-    digest: sha256:e6205f20561623d9b22de4390a37ea9d523612191f26ef7444d2eca8dbefd25c
+    newTag: "76cd6189"
+    digest: sha256:481b5d3ea5724ee80a55be28c41026203a3156a650fad5b5861c3fbb0fae139e


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `76cd6189ca4cd4f2a56e0e81918aa0fbfebf46e4`
- Image tag: `76cd6189`
- Image digest: `sha256:481b5d3ea5724ee80a55be28c41026203a3156a650fad5b5861c3fbb0fae139e`