### PR TITLE
chore(symphony): promote image df213efa

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-19T04:04:52Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-19T04:17:25Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -25,5 +25,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "76cd6189"
-    digest: sha256:481b5d3ea5724ee80a55be28c41026203a3156a650fad5b5861c3fbb0fae139e
+    newTag: "df213efa"
+    digest: sha256:b0738c06604f53316d89e5b88f34a6dd0f7d1d3e795e4261790b01ab3b007484

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-19T04:04:52Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-19T04:17:25Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -26,5 +26,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "76cd6189"
-    digest: sha256:481b5d3ea5724ee80a55be28c41026203a3156a650fad5b5861c3fbb0fae139e
+    newTag: "df213efa"
+    digest: sha256:b0738c06604f53316d89e5b88f34a6dd0f7d1d3e795e4261790b01ab3b007484

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-19T04:04:52Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-19T04:17:25Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -19,5 +19,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "76cd6189"
-    digest: sha256:481b5d3ea5724ee80a55be28c41026203a3156a650fad5b5861c3fbb0fae139e
+    newTag: "df213efa"
+    digest: sha256:b0738c06604f53316d89e5b88f34a6dd0f7d1d3e795e4261790b01ab3b007484


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `df213efa8d8fa9e65bde52226baa896ac97628d7`
- Image tag: `df213efa`
- Image digest: `sha256:b0738c06604f53316d89e5b88f34a6dd0f7d1d3e795e4261790b01ab3b007484`