### PR TITLE
fix(torghut): close march 18 live rejection gates

### DIFF
--- a/argocd/applications/feature-flags/gitops/default/features.yaml
+++ b/argocd/applications/feature-flags/gitops/default/features.yaml
@@ -154,7 +154,7 @@ flags:
     name: Torghut Trading Fractional Equities Enabled
     description: Enables fractional equity quantities for long-side orders.
     type: BOOLEAN_FLAG_TYPE
-    enabled: false
+    enabled: true
   - key: torghut_trading_kill_switch_enabled
     name: Torghut Trading Kill Switch Enabled
     description: Enables kill switch checks before order submission.

--- a/services/jangar/src/server/torghut-quant-metrics-store.ts
+++ b/services/jangar/src/server/torghut-quant-metrics-store.ts
@@ -305,7 +305,7 @@ export const getQuantLatestStoreStatus = async (
   const filters: Array<unknown> = []
   if (params.strategyId) filters.push(sql`strategy_id = ${params.strategyId}::uuid`)
   if (params.account) filters.push(sql`account = ${params.account}`)
-  if (params.window) filters.push(sql`window = ${params.window}`)
+  if (params.window) filters.push(sql`${sql.ref('window')} = ${params.window}`)
   const whereSql = filters.length > 0 ? sql`where ${sql.join(filters, sql` and `)}` : sql``
 
   const result = await sql<{ updated_at: Date | string | null; count: number | string | null }>`

--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -576,11 +576,6 @@ def _evaluate_trading_health_payload(
         and cache_age_seconds
         > settings.trading_readiness_dependency_cache_ttl_seconds
     )
-    dependency_statuses = [
-        cast(dict[str, object], checks).get("ok", True)
-        for name, checks in dependencies.items()
-        if name != "readiness_cache"
-    ]
     dependencies["readiness_cache"] = {
         "checked_at": checked_at.isoformat(),
         "cache_ttl_seconds": settings.trading_readiness_dependency_cache_ttl_seconds,
@@ -589,10 +584,6 @@ def _evaluate_trading_health_payload(
         "cache_age_seconds": cache_age_seconds,
         "cache_stale": cache_stale,
     }
-
-    overall_ok = scheduler_ok and all(bool(dep) for dep in dependency_statuses)
-    status = "ok" if overall_ok else "degraded"
-    status_code = 200 if overall_ok else 503
 
     alpha_readiness: dict[str, object]
     try:
@@ -626,6 +617,58 @@ def _evaluate_trading_health_payload(
                 "message": str(exc),
             },
         }
+        hypothesis_summary = {}
+
+    llm_status = scheduler.llm_status()
+    dspy_runtime = (
+        cast(dict[str, object], llm_status.get("dspy_runtime"))
+        if isinstance(llm_status.get("dspy_runtime"), dict)
+        else {}
+    )
+    empirical_jobs = _empirical_jobs_status()
+    live_submission_gate = _build_live_submission_gate_payload(
+        scheduler.state,
+        hypothesis_summary=hypothesis_summary,
+        empirical_jobs_status=empirical_jobs,
+        dspy_runtime_status=dspy_runtime,
+    )
+    dependencies["empirical_jobs"] = {
+        "ok": bool(empirical_jobs.get("ready")),
+        "detail": str(empirical_jobs.get("status") or "unknown"),
+        "authority": empirical_jobs.get("authority"),
+    }
+    dependencies["dspy_runtime"] = {
+        "ok": bool(dspy_runtime.get("live_ready", False))
+        if str(dspy_runtime.get("mode") or "").strip().lower() == "active"
+        else True,
+        "detail": (
+            "ready"
+            if bool(dspy_runtime.get("live_ready", False))
+            else ", ".join(
+                [
+                    str(item).strip()
+                    for item in cast(list[object], dspy_runtime.get("readiness_reasons") or [])
+                    if str(item).strip()
+                ]
+            )
+            or "not_ready"
+        ),
+        "artifact_hash": dspy_runtime.get("artifact_hash"),
+    }
+    dependencies["live_submission_gate"] = {
+        "ok": bool(live_submission_gate.get("allowed", False)),
+        "detail": str(live_submission_gate.get("reason") or "unknown"),
+        "capital_stage": live_submission_gate.get("capital_stage"),
+    }
+    dependency_statuses = [
+        cast(dict[str, object], checks).get("ok", True)
+        for name, checks in dependencies.items()
+        if name != "readiness_cache"
+    ]
+
+    overall_ok = scheduler_ok and all(bool(dep) for dep in dependency_statuses)
+    status = "ok" if overall_ok else "degraded"
+    status_code = 200 if overall_ok else 503
 
     return (
         {
@@ -633,6 +676,7 @@ def _evaluate_trading_health_payload(
             "scheduler": scheduler_payload,
             "dependencies": dependencies,
             "alpha_readiness": alpha_readiness,
+            "live_submission_gate": live_submission_gate,
         },
         status_code,
     )
@@ -1561,6 +1605,16 @@ def trading_status(session: Session = Depends(get_session)) -> dict[str, object]
     shorting_metadata_status = scheduler.shorting_metadata_status()
     rejection_alert_status = scheduler.rejection_alert_status()
     active_simulation_context = active_simulation_runtime_context()
+    empirical_jobs = _empirical_jobs_status()
+    live_submission_gate = _build_live_submission_gate_payload(
+        state,
+        hypothesis_summary=hypothesis_summary,
+        empirical_jobs_status=empirical_jobs,
+        dspy_runtime_status=cast(
+            dict[str, object],
+            scheduler.llm_status().get("dspy_runtime", {}),
+        ),
+    )
     return {
         "enabled": settings.trading_enabled,
         "autonomy_enabled": settings.trading_autonomy_enabled,
@@ -1580,6 +1634,7 @@ def trading_status(session: Session = Depends(get_session)) -> dict[str, object]
             "fallback_total": dict(state.metrics.execution_advisor_fallback_total),
         },
         "running": state.running,
+        "live_submission_gate": live_submission_gate,
         "last_run_at": state.last_run_at,
         "last_reconcile_at": state.last_reconcile_at,
         "last_error": state.last_error,
@@ -1681,7 +1736,7 @@ def trading_status(session: Session = Depends(get_session)) -> dict[str, object]
         "hypotheses": hypothesis_payload,
         "forecast_service": _forecast_service_status(),
         "lean_authority": _lean_authority_status(),
-        "empirical_jobs": _empirical_jobs_status(),
+        "empirical_jobs": empirical_jobs,
         "simulation": {
             "enabled": settings.trading_simulation_enabled,
             "run_id": (active_simulation_context or {}).get("run_id") or settings.trading_simulation_run_id,
@@ -3018,6 +3073,92 @@ def _build_hypothesis_runtime_payload(
         summary,
         dependency_quorum,
     )
+
+
+def _build_live_submission_gate_payload(
+    state: object,
+    *,
+    hypothesis_summary: Mapping[str, Any] | None,
+    empirical_jobs_status: Mapping[str, Any] | None = None,
+    dspy_runtime_status: Mapping[str, Any] | None = None,
+) -> dict[str, object]:
+    summary: Mapping[str, Any] = hypothesis_summary or {}
+    dependency_quorum_payload: dict[str, Any] = (
+        dict(cast(Mapping[str, Any], summary.get("dependency_quorum")))
+        if isinstance(summary.get("dependency_quorum"), Mapping)
+        else {}
+    )
+    dependency_decision = (
+        str(dependency_quorum_payload.get("decision") or "").strip().lower() or "unknown"
+    )
+    promotion_eligible_total = _safe_int(summary.get("promotion_eligible_total"))
+    empirical_ready = (
+        bool(empirical_jobs_status.get("ready"))
+        if isinstance(empirical_jobs_status, Mapping)
+        else None
+    )
+    dspy_mode = (
+        str(dspy_runtime_status.get("mode") or "").strip().lower()
+        if isinstance(dspy_runtime_status, Mapping)
+        else ""
+    )
+    dspy_live_ready = (
+        bool(dspy_runtime_status.get("live_ready"))
+        if isinstance(dspy_runtime_status, Mapping) and dspy_mode == "active"
+        else None
+    )
+    configured_live_promotion = bool(settings.trading_autonomy_allow_live_promotion)
+    autonomy_promotion_eligible = bool(
+        getattr(state, "last_autonomy_promotion_eligible", False)
+    )
+    drift_live_promotion_eligible = bool(
+        getattr(state, "drift_live_promotion_eligible", False)
+    )
+    active_capital_stage = _resolve_active_capital_stage(summary)
+    if settings.trading_mode != "live":
+        return {
+            "allowed": True,
+            "reason": "non_live_mode",
+            "blocked_reasons": [],
+            "capital_stage": settings.trading_mode,
+            "configured_live_promotion": configured_live_promotion,
+            "autonomy_promotion_eligible": autonomy_promotion_eligible,
+            "drift_live_promotion_eligible": drift_live_promotion_eligible,
+            "promotion_eligible_total": promotion_eligible_total,
+            "dependency_quorum_decision": dependency_decision,
+            "empirical_jobs_ready": empirical_ready,
+            "dspy_live_ready": dspy_live_ready,
+        }
+
+    blocked_reasons: list[str] = []
+    if promotion_eligible_total <= 0:
+        blocked_reasons.append("alpha_readiness_not_promotion_eligible")
+    if empirical_ready is False:
+        blocked_reasons.append("empirical_jobs_not_ready")
+    if dspy_live_ready is False:
+        blocked_reasons.append("dspy_live_runtime_not_ready")
+    if dependency_decision != "allow":
+        blocked_reasons.append(f"dependency_quorum_{dependency_decision}")
+    if not configured_live_promotion and not autonomy_promotion_eligible and not drift_live_promotion_eligible:
+        blocked_reasons.append("live_promotion_disabled")
+
+    allowed = len(blocked_reasons) == 0
+    if allowed and active_capital_stage == "shadow":
+        active_capital_stage = "0.10x canary"
+
+    return {
+        "allowed": allowed,
+        "reason": "ready" if allowed else blocked_reasons[0],
+        "blocked_reasons": blocked_reasons,
+        "capital_stage": active_capital_stage,
+        "configured_live_promotion": configured_live_promotion,
+        "autonomy_promotion_eligible": autonomy_promotion_eligible,
+        "drift_live_promotion_eligible": drift_live_promotion_eligible,
+        "promotion_eligible_total": promotion_eligible_total,
+        "dependency_quorum_decision": dependency_decision,
+        "empirical_jobs_ready": empirical_ready,
+        "dspy_live_ready": dspy_live_ready,
+    }
 
 
 def _load_route_provenance_summary(session: Session) -> dict[str, object]:

--- a/services/torghut/app/trading/decisions.py
+++ b/services/torghut/app/trading/decisions.py
@@ -41,6 +41,7 @@ from .strategy_runtime import (
 )
 
 logger = logging.getLogger(__name__)
+_SHORT_ENTRY_BELOW_MIN_QTY_REASON = "short_entry_below_min_qty"
 
 
 @dataclass(frozen=True)
@@ -217,6 +218,14 @@ class DecisionEngine:
                 equity=equity,
                 positions=positions,
             )
+            if _skip_non_executable_decision_qty(qty=qty, sizing_meta=sizing_meta):
+                logger.debug(
+                    "Skipping non-executable aggregated decision symbol=%s action=%s reason=%s",
+                    intent.symbol,
+                    intent.direction,
+                    sizing_meta.get("reason"),
+                )
+                continue
             forecast_contract: dict[str, Any] | None = None
             forecast_audit: dict[str, Any] | None = None
             if self.forecast_router is not None:
@@ -372,6 +381,15 @@ class DecisionEngine:
             equity=equity,
             positions=positions,
         )
+        if _skip_non_executable_decision_qty(qty=qty, sizing_meta=sizing_meta):
+            logger.debug(
+                "Skipping non-executable legacy decision strategy_id=%s symbol=%s action=%s reason=%s",
+                strategy.id,
+                signal.symbol,
+                action,
+                sizing_meta.get("reason"),
+            )
+            return None
 
         return StrategyDecision(
             strategy_id=str(strategy.id),
@@ -745,6 +763,26 @@ def _resolve_qty(
     if notional_budget is None or notional_budget <= 0:
         return default_qty, {"method": "default_qty", "reason": "missing_budget"}
 
+    symbol_notional_cap = _resolve_symbol_notional_cap(
+        strategy_pcts=[optional_decimal(strategy.max_position_pct_equity)],
+        equity=equity,
+    )
+    current_value = _position_value_for_symbol(positions, symbol)
+    if (
+        action.strip().lower() == "buy"
+        and symbol_notional_cap is not None
+        and current_value is not None
+        and current_value >= symbol_notional_cap
+    ):
+        return Decimal("0"), {
+            "method": method,
+            "reason": "symbol_capacity_exhausted",
+            "notional_budget": str(notional_budget),
+            "price": str(price),
+            "current_value": str(current_value),
+            "symbol_notional_cap": str(symbol_notional_cap),
+        }
+
     requested_qty = notional_budget / price
     position_qty = _position_qty_for_symbol(positions, symbol)
     resolution = resolve_quantity_resolution(
@@ -764,6 +802,22 @@ def _resolve_qty(
         symbol, fractional_equities_enabled=resolution.fractional_allowed
     )
     if qty < min_qty:
+        position_qty = resolution.position_qty
+        entering_short = (
+            action.strip().lower() == "sell"
+            and not resolution.fractional_allowed
+            and (position_qty is None or position_qty <= 0)
+        )
+        if entering_short:
+            return Decimal("0"), {
+                "method": method,
+                "reason": _SHORT_ENTRY_BELOW_MIN_QTY_REASON,
+                "notional_budget": str(notional_budget),
+                "price": str(price),
+                "requested_qty": str(requested_qty),
+                "min_qty": str(min_qty),
+                "quantity_resolution": resolution.to_payload(),
+            }
         qty = min_qty
 
     return qty, {
@@ -793,6 +847,26 @@ def _resolve_qty_for_aggregated(
     if total_budget <= 0:
         return default_qty, {"method": "default_qty", "reason": "missing_budget"}
 
+    symbol_notional_cap = _resolve_symbol_notional_cap(
+        strategy_pcts=[optional_decimal(strategy.max_position_pct_equity) for strategy in strategies],
+        equity=equity,
+    )
+    current_value = _position_value_for_symbol(positions, symbol)
+    if (
+        action.strip().lower() == "buy"
+        and symbol_notional_cap is not None
+        and current_value is not None
+        and current_value >= symbol_notional_cap
+    ):
+        return Decimal("0"), {
+            "method": "aggregated_notional_budget",
+            "reason": "symbol_capacity_exhausted",
+            "notional_budget": str(total_budget),
+            "price": str(price),
+            "current_value": str(current_value),
+            "symbol_notional_cap": str(symbol_notional_cap),
+        }
+
     requested_qty = total_budget / price
     position_qty = _position_qty_for_symbol(positions, symbol)
     resolution = resolve_quantity_resolution(
@@ -812,12 +886,38 @@ def _resolve_qty_for_aggregated(
         symbol, fractional_equities_enabled=resolution.fractional_allowed
     )
     if qty < min_qty:
+        position_qty = resolution.position_qty
+        entering_short = (
+            action.strip().lower() == "sell"
+            and not resolution.fractional_allowed
+            and (position_qty is None or position_qty <= 0)
+        )
+        if entering_short:
+            return Decimal("0"), {
+                "method": "aggregated_notional_budget",
+                "reason": _SHORT_ENTRY_BELOW_MIN_QTY_REASON,
+                "notional_budget": str(total_budget),
+                "price": str(price),
+                "requested_qty": str(requested_qty),
+                "min_qty": str(min_qty),
+                "quantity_resolution": resolution.to_payload(),
+            }
         qty = min_qty
     return qty, {
         "method": "aggregated_notional_budget",
         "notional_budget": str(total_budget),
         "price": str(price),
         "quantity_resolution": resolution.to_payload(),
+    }
+
+
+def _skip_non_executable_decision_qty(
+    *, qty: Decimal, sizing_meta: Mapping[str, Any]
+) -> bool:
+    reason = str(sizing_meta.get("reason") or "").strip()
+    return qty <= 0 and reason in {
+        _SHORT_ENTRY_BELOW_MIN_QTY_REASON,
+        "symbol_capacity_exhausted",
     }
 
 
@@ -848,6 +948,55 @@ def _position_qty_for_symbol(
     if not matched:
         return Decimal("0")
     return current_qty
+
+
+def _position_value_for_symbol(
+    positions: Optional[list[dict[str, Any]]],
+    symbol: str,
+) -> Optional[Decimal]:
+    if positions is None:
+        return None
+    normalized_symbol = symbol.strip().upper()
+    current_value = Decimal("0")
+    matched = False
+    for position in positions:
+        if str(position.get("symbol") or "").strip().upper() != normalized_symbol:
+            continue
+        raw_value = (
+            position.get("market_value")
+            or position.get("current_value")
+            or position.get("notional")
+        )
+        if raw_value is None:
+            continue
+        try:
+            value = Decimal(str(raw_value))
+        except (ArithmeticError, ValueError):
+            continue
+        matched = True
+        current_value += abs(value)
+    if not matched:
+        return None
+    return current_value
+
+
+def _resolve_symbol_notional_cap(
+    *,
+    strategy_pcts: list[Optional[Decimal]],
+    equity: Optional[Decimal],
+) -> Optional[Decimal]:
+    if equity is None or equity <= 0:
+        return None
+    caps: list[Decimal] = []
+    global_pct = optional_decimal(settings.trading_max_position_pct_equity)
+    if global_pct is not None and global_pct > 0:
+        caps.append(equity * global_pct)
+    for pct in strategy_pcts:
+        if pct is not None and pct > 0:
+            caps.append(equity * pct)
+    if not caps:
+        return None
+    return min(caps)
 
 
 def _has_legacy_indicator_inputs(features: SignalFeatures) -> bool:

--- a/services/torghut/app/trading/empirical_jobs.py
+++ b/services/torghut/app/trading/empirical_jobs.py
@@ -425,9 +425,17 @@ def build_empirical_jobs_status(
             break
     jobs: dict[str, object] = {}
     fresh_and_eligible = True
+    eligible_jobs: list[str] = []
+    missing_jobs: list[str] = []
+    stale_jobs: list[str] = []
+    ineligible_jobs: list[str] = []
+    candidate_ids: set[str] = set()
+    dataset_snapshot_refs: set[str] = set()
     for job_type in EMPIRICAL_JOB_TYPES:
         row = latest_by_type.get(job_type)
         if row is None:
+            missing_jobs.append(job_type)
+            ineligible_jobs.append(job_type)
             jobs[job_type] = {
                 "status": "missing",
                 "authority": "blocked",
@@ -448,6 +456,8 @@ def build_empirical_jobs_status(
         truthful_reasons = empirical_artifact_truthfulness_reasons(payload)
         truthful = not truthful_reasons
         stale = created_at < cutoff or row.status not in {"completed", "success"}
+        dataset_snapshot_ref = _as_text(row.dataset_snapshot_ref)
+        candidate_id = _as_text(row.candidate_id)
         blocked_reasons = sorted(
             {
                 *truthful_reasons,
@@ -466,6 +476,23 @@ def build_empirical_jobs_status(
                 ),
             }
         )
+        if stale:
+            stale_jobs.append(job_type)
+        if candidate_id is not None:
+            candidate_ids.add(candidate_id)
+        if dataset_snapshot_ref is not None:
+            dataset_snapshot_refs.add(dataset_snapshot_ref)
+        job_ready = (
+            not stale
+            and truthful
+            and bool(row.promotion_authority_eligible)
+            and row.authority == "empirical"
+            and dataset_snapshot_ref is not None
+        )
+        if job_ready:
+            eligible_jobs.append(job_type)
+        else:
+            ineligible_jobs.append(job_type)
         jobs[job_type] = {
             "status": row.status,
             "authority": row.authority if truthful and row.authority == "empirical" else "blocked",
@@ -473,6 +500,7 @@ def build_empirical_jobs_status(
             "promotion_authority_eligible": bool(row.promotion_authority_eligible) and truthful,
             "persisted_promotion_authority_eligible": bool(row.promotion_authority_eligible),
             "dataset_snapshot_ref": row.dataset_snapshot_ref,
+            "candidate_id": row.candidate_id,
             "job_run_id": row.job_run_id,
             "created_at": created_at.isoformat(),
             "artifact_refs": list(cast(list[object], row.artifact_refs or [])),
@@ -487,11 +515,36 @@ def build_empirical_jobs_status(
             or row.authority != "empirical"
         ):
             fresh_and_eligible = False
+    status_blocked_reasons: list[str] = []
+    if len(candidate_ids) > 1:
+        fresh_and_eligible = False
+        status_blocked_reasons.append("candidate_id_mismatch")
+    if len(dataset_snapshot_refs) > 1:
+        fresh_and_eligible = False
+        status_blocked_reasons.append("dataset_snapshot_ref_mismatch")
+    if missing_jobs:
+        message = f"missing empirical jobs: {', '.join(sorted(missing_jobs))}"
+    elif stale_jobs:
+        message = f"stale empirical jobs: {', '.join(sorted(stale_jobs))}"
+    elif ineligible_jobs:
+        message = f"ineligible empirical jobs: {', '.join(sorted(ineligible_jobs))}"
+    elif status_blocked_reasons:
+        message = f"empirical job bundle invalid: {', '.join(status_blocked_reasons)}"
+    else:
+        message = "empirical jobs fresh"
     return {
         "ready": fresh_and_eligible,
         "status": "healthy" if fresh_and_eligible else "degraded",
         "authority": "empirical" if fresh_and_eligible else "blocked",
         "stale_after_seconds": stale_after_seconds,
+        "message": message,
+        "eligible_jobs": sorted(eligible_jobs),
+        "missing_jobs": sorted(missing_jobs),
+        "stale_jobs": sorted(stale_jobs),
+        "ineligible_jobs": sorted(set(ineligible_jobs)),
+        "candidate_ids": sorted(candidate_ids),
+        "dataset_snapshot_refs": sorted(dataset_snapshot_refs),
+        "blocked_reasons": status_blocked_reasons,
         "jobs": jobs,
     }
 

--- a/services/torghut/app/trading/scheduler/pipeline.py
+++ b/services/torghut/app/trading/scheduler/pipeline.py
@@ -96,12 +96,7 @@ from .pipeline_helpers import (
     _select_strictest_runtime_uncertainty_gate,
     _uncertainty_gate_staleness_reason,
 )
-from .safety import (
-    _is_market_session_open,
-    _latch_signal_continuity_alert_state,
-    _record_signal_continuity_recovery_cycle,
-    _signal_bootstrap_grace_active,
-)
+from .safety import _is_market_session_open, _latch_signal_continuity_alert_state, _record_signal_continuity_recovery_cycle
 from .state import (
     RuntimeUncertaintyGate,
     RuntimeUncertaintyGateAction,
@@ -230,9 +225,6 @@ class TradingPipeline:
             self.record_no_signal_batch(batch)
             self.ingestor.commit_cursor(session, batch)
             return False
-
-        if self.state.signal_bootstrap_completed_at is None:
-            self.state.signal_bootstrap_completed_at = datetime.now(timezone.utc)
 
         if settings.trading_feature_quality_enabled:
             quality_thresholds = FeatureQualityThresholds(
@@ -776,11 +768,6 @@ class TradingPipeline:
     ) -> bool:
         if reason == "cursor_ahead_of_stream":
             return True
-        if reason == "no_signals_in_window" and _signal_bootstrap_grace_active(
-            self.state,
-            grace_seconds=settings.trading_signal_bootstrap_grace_seconds,
-        ):
-            return False
         if market_session_open:
             return True
         expected_market_closed_reasons = (
@@ -934,18 +921,59 @@ class TradingPipeline:
             ),
         )
 
-    def _submission_capital_stage(self) -> str:
+    def _live_submission_gate(self) -> dict[str, object]:
         if settings.trading_mode != "live":
-            return settings.trading_mode
-        if not settings.trading_autonomy_allow_live_promotion:
-            return "shadow"
-        return "0.10x canary"
+            return {
+                "allowed": True,
+                "reason": "non_live_mode",
+                "capital_stage": settings.trading_mode,
+                "configured_live_promotion": settings.trading_autonomy_allow_live_promotion,
+                "autonomy_promotion_eligible": self.state.last_autonomy_promotion_eligible,
+                "autonomy_promotion_action": self.state.last_autonomy_promotion_action,
+                "drift_live_promotion_eligible": self.state.drift_live_promotion_eligible,
+            }
+
+        evidence_eligible = bool(self.state.last_autonomy_promotion_eligible) or bool(
+            self.state.drift_live_promotion_eligible
+        )
+        if settings.trading_autonomy_allow_live_promotion or evidence_eligible:
+            return {
+                "allowed": True,
+                "reason": (
+                    "configured_live_promotion"
+                    if settings.trading_autonomy_allow_live_promotion
+                    else "autonomy_promotion_eligible"
+                ),
+                "capital_stage": "0.10x canary",
+                "configured_live_promotion": settings.trading_autonomy_allow_live_promotion,
+                "autonomy_promotion_eligible": self.state.last_autonomy_promotion_eligible,
+                "autonomy_promotion_action": self.state.last_autonomy_promotion_action,
+                "drift_live_promotion_eligible": self.state.drift_live_promotion_eligible,
+            }
+
+        return {
+            "allowed": False,
+            "reason": "live_promotion_disabled",
+            "capital_stage": "shadow",
+            "configured_live_promotion": settings.trading_autonomy_allow_live_promotion,
+            "autonomy_promotion_eligible": self.state.last_autonomy_promotion_eligible,
+            "autonomy_promotion_action": self.state.last_autonomy_promotion_action,
+            "drift_live_promotion_eligible": self.state.drift_live_promotion_eligible,
+        }
+
+    def _submission_capital_stage(self) -> str:
+        gate = self._live_submission_gate()
+        capital_stage = gate.get("capital_stage")
+        if isinstance(capital_stage, str) and capital_stage.strip():
+            return capital_stage
+        return settings.trading_mode
 
     def _submission_control_plane_snapshot(
         self,
         *,
         capital_stage: str | None = None,
     ) -> dict[str, object]:
+        gate = self._live_submission_gate()
         return {
             "active_revision": os.getenv("K_REVISION", "").strip() or None,
             "trading_enabled": settings.trading_enabled,
@@ -955,6 +983,7 @@ class TradingPipeline:
             "trading_kill_switch_enabled": settings.trading_kill_switch_enabled,
             "trading_execution_adapter_policy": settings.trading_execution_adapter_policy,
             "capital_stage": capital_stage or self._submission_capital_stage(),
+            "live_submission_gate": gate,
         }
 
     def _decision_lifecycle_metadata(
@@ -1654,9 +1683,9 @@ class TradingPipeline:
                 decision.symbol,
             )
             return False
-        if (
-            settings.trading_mode == "live"
-            and not settings.trading_autonomy_allow_live_promotion
+        live_submission_gate = self._live_submission_gate()
+        if settings.trading_mode == "live" and not bool(
+            live_submission_gate.get("allowed", False)
         ):
             self._block_decision_submission(
                 session=session,
@@ -1665,12 +1694,14 @@ class TradingPipeline:
                 reason="capital_stage_shadow",
                 submission_stage="blocked_capital_stage_shadow",
                 capital_stage="shadow",
+                extra_metadata={"live_submission_gate": live_submission_gate},
             )
             logger.info(
-                "Decision held in shadow stage strategy_id=%s decision_id=%s symbol=%s",
+                "Decision held in shadow stage strategy_id=%s decision_id=%s symbol=%s gate_reason=%s",
                 decision.strategy_id,
                 decision_row.id,
                 decision.symbol,
+                live_submission_gate.get("reason"),
             )
             return False
         if not (
@@ -2776,6 +2807,9 @@ class TradingPipeline:
         if settings.llm_dspy_runtime_mode == "active":
             gate_allowed, dspy_live_gate_reasons = settings.llm_dspy_live_runtime_gate()
             if not gate_allowed:
+                reject_reason, runtime_subtype = self._classify_dspy_live_runtime_block(
+                    dspy_live_gate_reasons
+                )
                 return self._handle_llm_dspy_live_runtime_block(
                     session=session,
                     decision=decision,
@@ -2783,13 +2817,18 @@ class TradingPipeline:
                     account=account,
                     positions=positions,
                     reason="llm_dspy_live_runtime_gate_blocked",
-                    reject_reason="llm_runtime_fallback",
+                    reject_reason=reject_reason,
                     risk_flags=list(dspy_live_gate_reasons),
                     response_payload_extra={
                         "llm_runtime": {
-                            "reject_reason": "llm_runtime_fallback",
-                            "subtype": "dspy_live_runtime_gate",
+                            "reject_reason": reject_reason,
+                            "subtype": runtime_subtype,
                             "error": "llm_dspy_live_runtime_gate_blocked",
+                            "primary_reason": (
+                                dspy_live_gate_reasons[0]
+                                if dspy_live_gate_reasons
+                                else "llm_dspy_live_runtime_gate_blocked"
+                            ),
                         }
                     },
                     policy_resolution=_build_llm_policy_resolution(
@@ -2813,6 +2852,9 @@ class TradingPipeline:
                 )
 
             if not dspy_live_ready:
+                reject_reason, runtime_subtype = self._classify_dspy_live_runtime_block(
+                    dspy_live_readiness_reasons
+                )
                 return self._handle_llm_dspy_live_runtime_block(
                     session=session,
                     decision=decision,
@@ -2820,13 +2862,18 @@ class TradingPipeline:
                     account=account,
                     positions=positions,
                     reason="llm_dspy_live_runtime_gate_blocked",
-                    reject_reason="llm_runtime_fallback",
+                    reject_reason=reject_reason,
                     risk_flags=list(dspy_live_readiness_reasons),
                     response_payload_extra={
                         "llm_runtime": {
-                            "reject_reason": "llm_runtime_fallback",
-                            "subtype": "dspy_live_runtime_gate",
+                            "reject_reason": reject_reason,
+                            "subtype": runtime_subtype,
                             "error": "llm_dspy_live_runtime_gate_blocked",
+                            "primary_reason": (
+                                dspy_live_readiness_reasons[0]
+                                if dspy_live_readiness_reasons
+                                else "llm_dspy_live_runtime_gate_blocked"
+                            ),
                         }
                     },
                     policy_resolution=_build_llm_policy_resolution(
@@ -2975,7 +3022,7 @@ class TradingPipeline:
         policy_resolution: Optional[dict[str, Any]] = None,
     ) -> tuple[StrategyDecision, Optional[str]]:
         block_fail_mode = settings.llm_dspy_live_runtime_block_fail_mode
-        if reject_reason == "llm_runtime_fallback":
+        if reject_reason.startswith("llm_runtime_fallback"):
             self.state.metrics.llm_runtime_fallback_total += 1
         effective_fail_mode = "veto" if block_fail_mode == "veto" else "pass_through"
         passthrough_decision = decision
@@ -3001,6 +3048,38 @@ class TradingPipeline:
             response_payload_extra=response_payload_extra,
             policy_resolution=policy_resolution,
         )
+
+    @staticmethod
+    def _classify_dspy_live_runtime_block(
+        reasons: Sequence[str] | tuple[str, ...],
+    ) -> tuple[str, str]:
+        normalized = tuple(str(reason).strip() for reason in reasons if str(reason).strip())
+        if any(
+            reason.startswith("dspy_live_readiness_error:")
+            or reason == "dspy_live_runtime_not_ready"
+            for reason in normalized
+        ):
+            return ("llm_runtime_fallback_runtime_not_ready", "runtime_not_ready")
+        if any(
+            "artifact" in reason or "manifest" in reason or "executor" in reason
+            for reason in normalized
+        ):
+            return ("llm_runtime_fallback_artifact_invalid", "artifact_invalid")
+        if any(
+            reason.startswith("dspy_live_")
+            or reason.startswith("dspy_jangar_")
+            or reason.startswith("llm_model_")
+            or reason.startswith("llm_shadow_")
+            or reason.startswith("llm_evaluation_")
+            or reason.startswith("llm_effective_")
+            or reason.startswith("llm_committee_")
+            or reason.startswith("dspy_cutover_")
+            or reason == "migration_guard_failed"
+            or "migration_guard" in reason
+            for reason in normalized
+        ):
+            return ("llm_runtime_fallback_policy_blocked", "policy_blocked")
+        return ("llm_runtime_fallback_runtime_not_ready", "runtime_not_ready")
 
     def _bounded_degraded_qty(
         self,

--- a/services/torghut/app/trading/scheduler/runtime.py
+++ b/services/torghut/app/trading/scheduler/runtime.py
@@ -19,6 +19,7 @@ from ..execution import OrderExecutor
 from ..execution_adapters import build_execution_adapter
 from ..firewall import OrderFirewall
 from ..ingest import ClickHouseSignalIngestor
+from ..llm.dspy_programs.runtime import DSPyReviewRuntime, DSPyRuntimeUnsupportedStateError
 from ..llm.guardrails import evaluate_llm_guardrails
 from ..market_context import MarketContextClient
 from ..order_feed import OrderFeedIngestor
@@ -105,6 +106,30 @@ class TradingScheduler(TradingSchedulerGovernanceMixin):
             effective_fail_mode=guardrails.effective_fail_mode,
             guardrail_reasons=guardrails.reasons,
         )
+        dspy_runtime_status: dict[str, object] = {
+            "mode": settings.llm_dspy_runtime_mode,
+            "artifact_hash": settings.llm_dspy_artifact_hash,
+            "live_ready": False,
+            "readiness_reasons": [],
+            "executor": None,
+            "artifact_source": None,
+        }
+        if settings.llm_dspy_runtime_mode:
+            try:
+                dspy_runtime = DSPyReviewRuntime.from_settings()
+                live_ready, readiness_reasons = dspy_runtime.evaluate_live_readiness()
+                dspy_runtime_status["live_ready"] = live_ready
+                dspy_runtime_status["readiness_reasons"] = list(readiness_reasons)
+                if live_ready:
+                    manifest = dspy_runtime._resolve_artifact_manifest()
+                    dspy_runtime_status["executor"] = manifest.executor
+                    dspy_runtime_status["artifact_source"] = manifest.source
+            except DSPyRuntimeUnsupportedStateError as exc:
+                dspy_runtime_status["readiness_reasons"] = [str(exc)]
+            except Exception as exc:  # pragma: no cover - additive status surface only
+                dspy_runtime_status["readiness_reasons"] = [
+                    f"dspy_status_error:{type(exc).__name__}"
+                ]
         return {
             "enabled": settings.llm_enabled,
             "rollout_stage": guardrails.rollout_stage,
@@ -127,6 +152,7 @@ class TradingScheduler(TradingSchedulerGovernanceMixin):
             ],
             "dspy_live_runtime_block_fail_mode": settings.llm_dspy_live_runtime_block_fail_mode,
             "dspy_live_runtime_block_qty_multiplier": settings.llm_dspy_live_runtime_block_qty_multiplier,
+            "dspy_runtime": dspy_runtime_status,
             "circuit": circuit_snapshot,
             "guardrails": {
                 "allow_requests": guardrails.allow_requests,

--- a/services/torghut/tests/test_decisions.py
+++ b/services/torghut/tests/test_decisions.py
@@ -237,6 +237,78 @@ class TestDecisionEngine(TestCase):
             settings.trading_fractional_equities_enabled = original_fractional
             settings.trading_allow_shorts = original_allow_shorts
 
+    def test_legacy_sell_without_inventory_below_one_share_is_skipped(self) -> None:
+        original_fractional = settings.trading_fractional_equities_enabled
+        original_allow_shorts = settings.trading_allow_shorts
+        settings.trading_fractional_equities_enabled = True
+        settings.trading_allow_shorts = True
+        try:
+            engine = DecisionEngine(price_fetcher=None)
+            strategy = Strategy(
+                name="small-short-sell",
+                description=None,
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="static",
+                universe_symbols=None,
+                max_position_pct_equity=None,
+                max_notional_per_trade=Decimal("50"),
+            )
+            signal = SignalEnvelope(
+                event_ts=datetime(2026, 1, 1, tzinfo=timezone.utc),
+                symbol="AAPL",
+                payload={
+                    "macd": {"macd": Decimal("0.1"), "signal": Decimal("1.0")},
+                    "rsi14": Decimal("80"),
+                    "price": Decimal("100"),
+                },
+                timeframe="1Min",
+            )
+
+            decisions = engine.evaluate(signal, [strategy], positions=None)
+
+            self.assertEqual(decisions, [])
+        finally:
+            settings.trading_fractional_equities_enabled = original_fractional
+            settings.trading_allow_shorts = original_allow_shorts
+
+    def test_legacy_buy_at_symbol_cap_is_skipped(self) -> None:
+        original_max_pct = settings.trading_max_position_pct_equity
+        settings.trading_max_position_pct_equity = 0.08
+        try:
+            engine = DecisionEngine(price_fetcher=None)
+            strategy = Strategy(
+                name="capped-buy",
+                description=None,
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="static",
+                universe_symbols=None,
+                max_position_pct_equity=Decimal("0.08"),
+                max_notional_per_trade=Decimal("100"),
+            )
+            signal = SignalEnvelope(
+                event_ts=datetime(2026, 1, 1, tzinfo=timezone.utc),
+                symbol="AAPL",
+                payload={
+                    "macd": {"macd": Decimal("1.0"), "signal": Decimal("0.1")},
+                    "rsi14": Decimal("20"),
+                    "price": Decimal("100"),
+                },
+                timeframe="1Min",
+            )
+
+            decisions = engine.evaluate(
+                signal,
+                [strategy],
+                equity=Decimal("10000"),
+                positions=[{"symbol": "AAPL", "qty": "8", "market_value": "800"}],
+            )
+
+            self.assertEqual(decisions, [])
+        finally:
+            settings.trading_max_position_pct_equity = original_max_pct
+
     def test_legacy_sell_reducing_long_can_remain_fractional(self) -> None:
         original_fractional = settings.trading_fractional_equities_enabled
         original_allow_shorts = settings.trading_allow_shorts
@@ -405,6 +477,90 @@ class TestDecisionEngine(TestCase):
             "buy",
         )
         self.assertEqual(source_runtime[0].get("compiler_source"), "legacy_runtime")
+
+    def test_scheduler_runtime_skips_non_executable_fractional_short_entry(self) -> None:
+        engine = DecisionEngine(price_fetcher=None)
+        engine.strategy_runtime = StrategyRuntime(
+            registry=StrategyRegistry(
+                plugins={
+                    "sell_plugin": _SellPlugin(),
+                }
+            )
+        )
+        strategy = Strategy(
+            id=uuid.UUID("00000000-0000-0000-0000-000000000003"),
+            name="sell",
+            description="version=1.0.0",
+            enabled=True,
+            base_timeframe="1Min",
+            universe_type="sell_plugin",
+            universe_symbols=None,
+            max_position_pct_equity=None,
+            max_notional_per_trade=Decimal("50"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            symbol="AAPL",
+            payload={
+                "macd": {"macd": Decimal("0.1"), "signal": Decimal("1.0")},
+                "rsi14": Decimal("80"),
+                "price": 100,
+            },
+            timeframe="1Min",
+        )
+        with (
+            patch.object(settings, "trading_strategy_runtime_mode", "scheduler_v3"),
+            patch.object(settings, "trading_strategy_scheduler_enabled", True),
+            patch.object(settings, "trading_fractional_equities_enabled", True),
+            patch.object(settings, "trading_allow_shorts", True),
+        ):
+            decisions = engine.evaluate(signal, [strategy], positions=None)
+
+        self.assertEqual(decisions, [])
+
+    def test_scheduler_runtime_skips_buy_when_symbol_cap_is_exhausted(self) -> None:
+        engine = DecisionEngine(price_fetcher=None)
+        engine.strategy_runtime = StrategyRuntime(
+            registry=StrategyRegistry(
+                plugins={
+                    "buy_plugin": _BuyPlugin(),
+                }
+            )
+        )
+        strategy = Strategy(
+            id=uuid.UUID("00000000-0000-0000-0000-000000000004"),
+            name="buy",
+            description="version=1.0.0",
+            enabled=True,
+            base_timeframe="1Min",
+            universe_type="buy_plugin",
+            universe_symbols=None,
+            max_position_pct_equity=Decimal("0.08"),
+            max_notional_per_trade=Decimal("100"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            symbol="AAPL",
+            payload={
+                "macd": {"macd": Decimal("1.0"), "signal": Decimal("0.1")},
+                "rsi14": Decimal("20"),
+                "price": 100,
+            },
+            timeframe="1Min",
+        )
+        with (
+            patch.object(settings, "trading_strategy_runtime_mode", "scheduler_v3"),
+            patch.object(settings, "trading_strategy_scheduler_enabled", True),
+            patch.object(settings, "trading_max_position_pct_equity", 0.08),
+        ):
+            decisions = engine.evaluate(
+                signal,
+                [strategy],
+                equity=Decimal("10000"),
+                positions=[{"symbol": "AAPL", "qty": "8", "market_value": "800"}],
+            )
+
+        self.assertEqual(decisions, [])
 
     def test_scheduler_runtime_does_not_fallback_to_legacy_when_runtime_returns_no_intents(
         self,

--- a/services/torghut/tests/test_empirical_jobs.py
+++ b/services/torghut/tests/test_empirical_jobs.py
@@ -8,6 +8,7 @@ from sqlalchemy.pool import StaticPool
 
 from app.models import Base
 from app.trading.empirical_jobs import (
+    EMPIRICAL_JOB_TYPES,
     artifact_is_truthful,
     build_empirical_benchmark_parity_report,
     build_empirical_foundation_router_parity_report,
@@ -192,6 +193,12 @@ class TestEmpiricalJobs(TestCase):
 
         self.assertEqual(status["status"], "degraded")
         self.assertFalse(status["ready"])
+        self.assertEqual(status["message"], "missing empirical jobs: benchmark_parity, janus_event_car, janus_hgrm_reward")
+        self.assertEqual(status["eligible_jobs"], ["foundation_router_parity"])
+        self.assertEqual(
+            status["missing_jobs"],
+            ["benchmark_parity", "janus_event_car", "janus_hgrm_reward"],
+        )
         self.assertEqual(status["jobs"]["foundation_router_parity"]["authority"], "empirical")
         self.assertEqual(status["jobs"]["benchmark_parity"]["status"], "missing")
 
@@ -266,9 +273,78 @@ class TestEmpiricalJobs(TestCase):
 
         self.assertEqual(status["authority"], "blocked")
         self.assertFalse(status["ready"])
+        self.assertEqual(status["message"], "ineligible empirical jobs: janus_hgrm_reward")
+        self.assertEqual(status["eligible_jobs"], ["benchmark_parity", "foundation_router_parity", "janus_event_car"])
+        self.assertEqual(status["ineligible_jobs"], ["janus_hgrm_reward"])
         self.assertFalse(status["jobs"]["janus_hgrm_reward"]["truthful"])
         self.assertEqual(status["jobs"]["janus_hgrm_reward"]["authority"], "blocked")
         self.assertIn(
             "artifact_authority_not_authoritative",
             status["jobs"]["janus_hgrm_reward"]["blocked_reasons"],
+        )
+
+    def test_empirical_jobs_status_blocks_cross_job_lineage_mismatch(self) -> None:
+        payload = {
+            "schema_version": "benchmark-parity-report-v1",
+            "promotion_authority_eligible": True,
+            "artifact_authority": {
+                "provenance": "historical_market_replay",
+                "maturity": "empirically_validated",
+                "authoritative": True,
+                "placeholder": False,
+            },
+            "lineage": {
+                "dataset_snapshot_ref": "s3://datasets/snapshot-a.json",
+                "job_run_id": "job-benchmark-1",
+                "runtime_version_refs": ["services/torghut@sha256:abc"],
+                "model_refs": ["models/candidate@sha256:def"],
+            },
+        }
+        with self.session_local() as session:
+            for index, job_type in enumerate(EMPIRICAL_JOB_TYPES):
+                dataset_snapshot_ref = (
+                    "s3://datasets/snapshot-a.json"
+                    if index < 2
+                    else "s3://datasets/snapshot-b.json"
+                )
+                candidate_id = "cand-a" if index < 2 else "cand-b"
+                upsert_empirical_job_run(
+                    session=session,
+                    run_id="run-1",
+                    candidate_id=candidate_id,
+                    job_name=job_type,
+                    job_type=job_type,
+                    job_run_id=f"job-{job_type}",
+                    status="completed",
+                    authority="empirical",
+                    promotion_authority_eligible=True,
+                    dataset_snapshot_ref=dataset_snapshot_ref,
+                    artifact_refs=[f"s3://artifacts/{job_type}.json"],
+                    payload={
+                        **payload,
+                        "lineage": {
+                            **payload["lineage"],
+                            "dataset_snapshot_ref": dataset_snapshot_ref,
+                            "job_run_id": f"job-{job_type}",
+                        },
+                    },
+                )
+            session.commit()
+
+            status = build_empirical_jobs_status(session=session, stale_after_seconds=86400)
+
+        self.assertFalse(status["ready"])
+        self.assertEqual(status["status"], "degraded")
+        self.assertEqual(
+            status["message"],
+            "empirical job bundle invalid: candidate_id_mismatch, dataset_snapshot_ref_mismatch",
+        )
+        self.assertEqual(
+            status["blocked_reasons"],
+            ["candidate_id_mismatch", "dataset_snapshot_ref_mismatch"],
+        )
+        self.assertEqual(status["candidate_ids"], ["cand-a", "cand-b"])
+        self.assertEqual(
+            status["dataset_snapshot_refs"],
+            ["s3://datasets/snapshot-a.json", "s3://datasets/snapshot-b.json"],
         )

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -2009,6 +2009,12 @@ class TestTradingApi(TestCase):
         self.assertEqual(response.status_code, 200)
         payload = response.json()
         self.assertIn("jobs", payload)
+        self.assertEqual(payload["message"], "missing empirical jobs: foundation_router_parity, janus_event_car, janus_hgrm_reward")
+        self.assertEqual(payload["eligible_jobs"], ["benchmark_parity"])
+        self.assertEqual(
+            payload["missing_jobs"],
+            ["foundation_router_parity", "janus_event_car", "janus_hgrm_reward"],
+        )
         self.assertEqual(payload["jobs"]["benchmark_parity"]["authority"], "empirical")
         self.assertEqual(payload["jobs"]["benchmark_parity"]["job_run_id"], "job-benchmark-1")
 

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -1436,6 +1436,12 @@ class TestTradingPipeline(TestCase):
                     ),
                     False,
                 )
+                live_submission_gate = control_plane_snapshot.get("live_submission_gate")
+                assert isinstance(live_submission_gate, dict)
+                self.assertEqual(live_submission_gate.get("allowed"), False)
+                self.assertEqual(
+                    live_submission_gate.get("reason"), "live_promotion_disabled"
+                )
 
             self.assertEqual(alpaca_client.submitted, [])
             self.assertEqual(
@@ -1454,6 +1460,114 @@ class TestTradingPipeline(TestCase):
             ]
             config.settings.trading_kill_switch_enabled = original[
                 "trading_kill_switch_enabled"
+            ]
+
+    def test_live_submission_allows_autonomy_eligible_canary_without_static_flag(
+        self,
+    ) -> None:
+        from app import config
+
+        original = {
+            "trading_enabled": config.settings.trading_enabled,
+            "trading_mode": config.settings.trading_mode,
+            "trading_live_enabled": config.settings.trading_live_enabled,
+            "trading_autonomy_enabled": config.settings.trading_autonomy_enabled,
+            "trading_autonomy_allow_live_promotion": config.settings.trading_autonomy_allow_live_promotion,
+            "trading_kill_switch_enabled": config.settings.trading_kill_switch_enabled,
+            "trading_universe_source": config.settings.trading_universe_source,
+            "trading_static_symbols_raw": config.settings.trading_static_symbols_raw,
+        }
+        config.settings.trading_enabled = True
+        config.settings.trading_mode = "live"
+        config.settings.trading_live_enabled = True
+        config.settings.trading_autonomy_enabled = True
+        config.settings.trading_autonomy_allow_live_promotion = False
+        config.settings.trading_kill_switch_enabled = False
+        config.settings.trading_universe_source = "static"
+        config.settings.trading_static_symbols_raw = "AAPL"
+
+        try:
+            with self.session_local() as session:
+                strategy = Strategy(
+                    name="live-canary-eligible",
+                    description="promotion-eligible live canary",
+                    enabled=True,
+                    base_timeframe="1Min",
+                    universe_type="static",
+                    universe_symbols=["AAPL"],
+                    max_notional_per_trade=Decimal("1000"),
+                )
+                session.add(strategy)
+                session.commit()
+
+            signal = SignalEnvelope(
+                event_ts=datetime.now(timezone.utc),
+                symbol="AAPL",
+                payload={
+                    "macd": {"macd": 1.1, "signal": 0.4},
+                    "rsi14": 25,
+                    "price": 100,
+                },
+                timeframe="1Min",
+            )
+
+            alpaca_client = FakeAlpacaClient()
+            state = TradingState(
+                last_autonomy_promotion_eligible=True,
+                last_autonomy_promotion_action="promote",
+            )
+            pipeline = TradingPipeline(
+                alpaca_client=alpaca_client,
+                order_firewall=OrderFirewall(alpaca_client),
+                ingestor=FakeIngestor([signal]),
+                decision_engine=DecisionEngine(),
+                risk_engine=RiskEngine(),
+                executor=OrderExecutor(),
+                execution_adapter=alpaca_client,
+                reconciler=Reconciler(),
+                universe_resolver=UniverseResolver(),
+                state=state,
+                account_label="live",
+                session_factory=self.session_local,
+            )
+
+            pipeline.run_once()
+
+            with self.session_local() as session:
+                decision_rows = session.execute(select(TradeDecision)).scalars().all()
+                self.assertEqual(len(decision_rows), 1)
+                self.assertNotEqual(decision_rows[0].status, "blocked")
+                decision_json = decision_rows[0].decision_json
+                assert isinstance(decision_json, dict)
+                control_plane_snapshot = decision_json.get("control_plane_snapshot")
+                assert isinstance(control_plane_snapshot, dict)
+                live_submission_gate = control_plane_snapshot.get("live_submission_gate")
+                assert isinstance(live_submission_gate, dict)
+                self.assertEqual(live_submission_gate.get("allowed"), True)
+                self.assertEqual(
+                    live_submission_gate.get("reason"),
+                    "autonomy_promotion_eligible",
+                )
+
+            self.assertEqual(len(alpaca_client.submitted), 1)
+        finally:
+            config.settings.trading_enabled = original["trading_enabled"]
+            config.settings.trading_mode = original["trading_mode"]
+            config.settings.trading_live_enabled = original["trading_live_enabled"]
+            config.settings.trading_autonomy_enabled = original[
+                "trading_autonomy_enabled"
+            ]
+            config.settings.trading_autonomy_allow_live_promotion = original[
+                "trading_autonomy_allow_live_promotion"
+            ]
+            config.settings.trading_kill_switch_enabled = original[
+                "trading_kill_switch_enabled"
+            ]
+            config.settings.trading_universe_source = original[
+                "trading_universe_source"
+            ]
+            config.settings.trading_static_symbols_raw = original[
+                "trading_static_symbols_raw"
             ]
             config.settings.trading_universe_source = original[
                 "trading_universe_source"
@@ -6329,6 +6443,13 @@ class TestTradingPipeline(TestCase):
                 self.assertEqual(
                     reviews[0].rationale, "llm_dspy_live_runtime_gate_blocked"
                 )
+                llm_runtime = reviews[0].response_json.get("llm_runtime", {})
+                self.assertEqual(
+                    llm_runtime.get("reject_reason"),
+                    "llm_runtime_fallback_policy_blocked",
+                )
+                self.assertEqual(llm_runtime.get("subtype"), "policy_blocked")
+                self.assertIsInstance(llm_runtime.get("primary_reason"), str)
                 self.assertEqual(len(executions), 0)
                 self.assertEqual(engine.review_calls, 0)
         finally:
@@ -6368,6 +6489,23 @@ class TestTradingPipeline(TestCase):
             ]
             config.settings.llm_rollout_stage = original["llm_rollout_stage"]
             config.settings.jangar_base_url = original["jangar_base_url"]
+
+    def test_classify_dspy_live_runtime_block_distinguishes_artifact_and_runtime_causes(
+        self,
+    ) -> None:
+        artifact = TradingPipeline._classify_dspy_live_runtime_block(
+            ("dspy_bootstrap_artifact_forbidden",)
+        )
+        runtime = TradingPipeline._classify_dspy_live_runtime_block(
+            ("dspy_live_readiness_error:TimeoutError",)
+        )
+
+        self.assertEqual(
+            artifact, ("llm_runtime_fallback_artifact_invalid", "artifact_invalid")
+        )
+        self.assertEqual(
+            runtime, ("llm_runtime_fallback_runtime_not_ready", "runtime_not_ready")
+        )
 
     def test_pipeline_llm_dspy_live_runtime_gate_blocks_malformed_artifact_hash(
         self,


### PR DESCRIPTION
## Summary

- fix the Jangar quant-health `window` filter so March 18 control-plane checks stop failing with SQL syntax errors
- expose explicit live submission gate, DSPy runtime readiness, and empirical-job status in Torghut control-plane payloads for operator diagnosis
- allow live submission when autonomy promotion evidence is already eligible, while keeping the path fail-closed with actionable block reasons
- suppress the dominant March 18 non-executable decisions before they become downstream rejects and enable long-equity fractional execution via GitOps
- add regression coverage for the March 18 shadow-block, DSPy gate classification, empirical bundle integrity, quant-health filtering, and decision suppression paths

## Related Issues

None

## Testing

- `PYENV_SKIP_REHASH=1 uv run --frozen pytest tests/test_empirical_jobs.py tests/test_trading_api.py tests/test_trading_pipeline.py tests/test_decisions.py -k 'empirical_jobs_status or trading_empirical_jobs_endpoint_exposes_latest_job_freshness or pipeline_llm_dspy_live_runtime_gate_blocked_in_live or classify_dspy_live_runtime_block_distinguishes_artifact_and_runtime_causes or live_submission_allows_autonomy_eligible_canary_without_static_flag or live_shadow_stage_blocks_policy_approved_decision or sell_without_inventory or buy_at_symbol_cap or skips_non_executable_fractional_short_entry or skips_buy_when_symbol_cap_is_exhausted or fractional_equity_qty_when_enabled'`
- `PYENV_SKIP_REHASH=1 uv run --frozen pyright --project pyrightconfig.json`
- `PYENV_SKIP_REHASH=1 uv run --frozen pyright --project pyrightconfig.alpha.json`
- `PYENV_SKIP_REHASH=1 uv run --frozen pyright --project pyrightconfig.scripts.json`
- `bun run --filter @proompteng/jangar tsc`
- `bunx vitest run --config vitest.config.ts src/routes/api/torghut/trading/control-plane/quant/-health.test.ts src/server/__tests__/torghut-quant-metrics.test.ts`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
