### PR TITLE
feat(symphony): add fleet observability telemetry

### DIFF
--- a/.github/workflows/symphony-ci.yml
+++ b/.github/workflows/symphony-ci.yml
@@ -10,6 +10,11 @@ on:
       - 'argocd/applications/symphony-jangar/**'
       - 'argocd/applications/symphony-torghut/**'
       - 'argocd/applications/symphony-base/**'
+      - 'argocd/applications/jangar/alloy-configmap.yaml'
+      - 'argocd/applications/torghut/alloy-configmap.yaml'
+      - 'argocd/applications/observability/graf-mimir-rules.yaml'
+      - 'argocd/applications/observability/kustomization.yaml'
+      - 'argocd/applications/observability/symphony-fleet-dashboard-configmap.yaml'
       - 'argocd/applicationsets/product.yaml'
       - '.github/workflows/symphony-ci.yml'
       - '.github/workflows/symphony-build-push.yaml'
@@ -34,8 +39,8 @@ jobs:
     with:
       bun-version: 1.3.10
       node-version: 24.11.1
-      install-command: bun install --frozen-lockfile --ignore-scripts && bun run --cwd packages/codex build
-      lint-command: bunx oxfmt --check services/symphony packages/scripts/src/symphony argocd/applications/symphony argocd/applications/symphony-jangar argocd/applications/symphony-torghut argocd/applications/symphony-base
+      install-command: bun install --frozen-lockfile --ignore-scripts && bun run --cwd packages/otel build && bun run --cwd packages/codex build
+      lint-command: bunx oxfmt --check services/symphony packages/scripts/src/symphony argocd/applications/symphony argocd/applications/symphony-jangar argocd/applications/symphony-torghut argocd/applications/symphony-base argocd/applications/jangar/alloy-configmap.yaml argocd/applications/torghut/alloy-configmap.yaml argocd/applications/observability/graf-mimir-rules.yaml argocd/applications/observability/kustomization.yaml argocd/applications/observability/symphony-fleet-dashboard-configmap.yaml
       oxlint-command: bun run --cwd services/symphony lint:oxlint
       oxlint-type-command: bun run --cwd services/symphony lint:oxlint:type && bun run --cwd packages/scripts lint:oxlint:type
       test-command: bun run --cwd services/symphony tsc && bun run --cwd services/symphony test && bun test packages/scripts/src/symphony/release-contract.test.ts packages/scripts/src/symphony/deploy-service.test.ts

--- a/argocd/applications/jangar/alloy-configmap.yaml
+++ b/argocd/applications/jangar/alloy-configmap.yaml
@@ -166,10 +166,84 @@ data:
       forward_to = [loki.write.default.receiver]
     }
 
+    // Symphony self-hosting lane
+    discovery.kubernetes "symphony" {
+      role = "pod"
+
+      namespaces {
+        names = ["jangar"]
+      }
+
+      selectors {
+        role  = "pod"
+        label = "app.kubernetes.io/name=symphony"
+      }
+    }
+
+    loki.source.kubernetes "symphony" {
+      targets    = discovery.kubernetes.symphony.targets
+      forward_to = [loki.process.symphony.receiver]
+    }
+
+    loki.process "symphony" {
+      stage.labels {
+        values = {
+          namespace = "{{ .Labels.namespace }}",
+          pod       = "{{ .Labels.pod }}",
+          container = "{{ .Labels.container }}",
+        }
+      }
+
+      stage.static_labels {
+        values = {
+          app = "symphony",
+          job = "symphony",
+        }
+      }
+
+      forward_to = [loki.write.default.receiver]
+    }
+
+    // Symphony Jangar lane
+    discovery.kubernetes "symphony_jangar" {
+      role = "pod"
+
+      namespaces {
+        names = ["jangar"]
+      }
+
+      selectors {
+        role  = "pod"
+        label = "app.kubernetes.io/name=symphony-jangar"
+      }
+    }
+
+    loki.source.kubernetes "symphony_jangar" {
+      targets    = discovery.kubernetes.symphony_jangar.targets
+      forward_to = [loki.process.symphony_jangar.receiver]
+    }
+
+    loki.process "symphony_jangar" {
+      stage.labels {
+        values = {
+          namespace = "{{ .Labels.namespace }}",
+          pod       = "{{ .Labels.pod }}",
+          container = "{{ .Labels.container }}",
+        }
+      }
+
+      stage.static_labels {
+        values = {
+          app = "symphony-jangar",
+          job = "symphony-jangar",
+        }
+      }
+
+      forward_to = [loki.write.default.receiver]
+    }
+
     loki.write "default" {
       endpoint {
         url = "http://observability-loki-loki-distributed-gateway.observability.svc.cluster.local/loki/api/v1/push"
       }
     }
-
-    // Future: add OTLP/metrics pipelines here once Jangar publishes telemetry.

--- a/argocd/applications/observability/graf-mimir-rules.yaml
+++ b/argocd/applications/observability/graf-mimir-rules.yaml
@@ -259,6 +259,82 @@ data:
                 Guardrails freshness checks are falling back from precise to low-memory mode.
                 This usually indicates ClickHouse query pressure or tight memory headroom.
               runbook_url: docs/torghut/design-system/v1/component-clickhouse-capacity-ttl-and-disk-guardrails.md
+      - name: symphony-fleet.rules
+        rules:
+          - alert: SymphonyNoLeader
+            expr: |
+              max by (instance) (
+                symphony_leader_state{
+                  instance=~"symphony|symphony-jangar|symphony-torghut"
+                }
+              ) != 1
+            for: 5m
+            labels:
+              severity: critical
+            annotations:
+              summary: Symphony instance has no active leader
+              description: |
+                One Symphony instance has not reported an active leader for 5 minutes.
+                Dispatch and reconciliation for that lane are likely stalled.
+          - alert: SymphonyPollStalled
+            expr: |
+              time() - max by (instance) (
+                symphony_last_successful_poll_timestamp_seconds{
+                  instance=~"symphony|symphony-jangar|symphony-torghut"
+                }
+              ) > 300
+            for: 5m
+            labels:
+              severity: warning
+            annotations:
+              summary: Symphony polling is stalled
+              description: |
+                A Symphony instance has not completed a successful poll tick for more than 5 minutes.
+          - alert: SymphonyRetryBacklogStuck
+            expr: |
+              max by (instance) (
+                symphony_retry_queue_size{
+                  instance=~"symphony|symphony-jangar|symphony-torghut"
+                }
+              ) > 0
+            for: 15m
+            labels:
+              severity: warning
+            annotations:
+              summary: Symphony retry backlog is stuck
+              description: |
+                A Symphony instance has had retry work queued continuously for 15 minutes.
+          - alert: SymphonyWorkerFailuresHigh
+            expr: |
+              sum by (instance) (
+                increase(
+                  symphony_worker_outcomes_total{
+                    instance=~"symphony|symphony-jangar|symphony-torghut",
+                    outcome=~"failed|stalled"
+                  }[15m]
+                )
+              ) >= 3
+            for: 15m
+            labels:
+              severity: warning
+            annotations:
+              summary: Symphony worker failures are elevated
+              description: |
+                A Symphony instance has recorded at least 3 failed or stalled worker outcomes in the last 15 minutes.
+          - alert: SymphonyTargetHealthBlocked
+            expr: |
+              max by (instance) (
+                symphony_target_health_ready{
+                  instance=~"symphony|symphony-jangar|symphony-torghut"
+                }
+              ) == 0
+            for: 10m
+            labels:
+              severity: warning
+            annotations:
+              summary: Symphony dispatch is blocked by target health
+              description: |
+                A Symphony instance has reported target health not ready for dispatch for 10 minutes.
       - name: torghut-ws.rules
         rules:
           - alert: TorghutWSForwarderDown

--- a/argocd/applications/observability/kustomization.yaml
+++ b/argocd/applications/observability/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - graf-mimir-rules.yaml
   - graf-graf-dashboard-configmap.yaml
   - graf-bumba-dashboard-configmap.yaml
+  - symphony-fleet-dashboard-configmap.yaml
   - codex-pipeline-dashboard-configmap.yaml
   - torghut-execution-recovery-dashboard-configmap.yaml
 

--- a/argocd/applications/observability/symphony-fleet-dashboard-configmap.yaml
+++ b/argocd/applications/observability/symphony-fleet-dashboard-configmap.yaml
@@ -1,0 +1,334 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: symphony-fleet-dashboard
+  namespace: observability
+data:
+  symphony-fleet-dashboard.json: |
+    {
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": "-- Grafana --",
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "type": "dashboard"
+          }
+        ]
+      },
+      "editable": true,
+      "graphTooltip": 0,
+      "id": null,
+      "iteration": 1,
+      "links": [],
+      "panels": [
+        {
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "id": 1,
+          "options": {
+            "content": "### Quick Links\n- [Symphony traces](\/explore?left=%7B%22datasource%22%3A%22tempo%22%2C%22queries%22%3A%5B%7B%22refId%22%3A%22A%22%2C%22query%22%3A%22%7Bservice.name%3D%5C%22symphony%5C%22%7D%22%7D%5D%2C%22range%22%3A%7B%22from%22%3A%22now-1h%22%2C%22to%22%3A%22now%22%7D%7D) · [logs](\/explore?left=%7B%22datasource%22%3A%22loki%22%2C%22queries%22%3A%5B%7B%22refId%22%3A%22A%22%2C%22expr%22%3A%22%7Bjob%3D%5C%22symphony%5C%22%7D%22%7D%5D%2C%22range%22%3A%7B%22from%22%3A%22now-1h%22%2C%22to%22%3A%22now%22%7D%7D)\n- [Symphony Jangar traces](\/explore?left=%7B%22datasource%22%3A%22tempo%22%2C%22queries%22%3A%5B%7B%22refId%22%3A%22A%22%2C%22query%22%3A%22%7Bservice.name%3D%5C%22symphony-jangar%5C%22%7D%22%7D%5D%2C%22range%22%3A%7B%22from%22%3A%22now-1h%22%2C%22to%22%3A%22now%22%7D%7D) · [logs](\/explore?left=%7B%22datasource%22%3A%22loki%22%2C%22queries%22%3A%5B%7B%22refId%22%3A%22A%22%2C%22expr%22%3A%22%7Bjob%3D%5C%22symphony-jangar%5C%22%7D%22%7D%5D%2C%22range%22%3A%7B%22from%22%3A%22now-1h%22%2C%22to%22%3A%22now%22%7D%7D)\n- [Symphony Torghut traces](\/explore?left=%7B%22datasource%22%3A%22tempo%22%2C%22queries%22%3A%5B%7B%22refId%22%3A%22A%22%2C%22query%22%3A%22%7Bservice.name%3D%5C%22symphony-torghut%5C%22%7D%22%7D%5D%2C%22range%22%3A%7B%22from%22%3A%22now-1h%22%2C%22to%22%3A%22now%22%7D%7D) · [logs](\/explore?left=%7B%22datasource%22%3A%22loki%22%2C%22queries%22%3A%5B%7B%22refId%22%3A%22A%22%2C%22expr%22%3A%22%7Bjob%3D%5C%22symphony-torghut%5C%22%7D%22%7D%5D%2C%22range%22%3A%7B%22from%22%3A%22now-1h%22%2C%22to%22%3A%22now%22%7D%7D)",
+            "mode": "markdown"
+          },
+          "title": "Quick Links",
+          "type": "text"
+        },
+        {
+          "datasource": "prom",
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 0,
+            "y": 7
+          },
+          "id": 2,
+          "options": {
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            }
+          },
+          "targets": [
+            {
+              "expr": "max by (instance) (symphony_leader_state{instance=~\"symphony|symphony-jangar|symphony-torghut\"})",
+              "legendFormat": "{{instance}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Leader Status",
+          "type": "stat"
+        },
+        {
+          "datasource": "prom",
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 8,
+            "y": 7
+          },
+          "id": 3,
+          "options": {
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            }
+          },
+          "targets": [
+            {
+              "expr": "max by (instance) (symphony_target_health_ready{instance=~\"symphony|symphony-jangar|symphony-torghut\"})",
+              "legendFormat": "{{instance}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Target Health Ready",
+          "type": "stat"
+        },
+        {
+          "datasource": "prom",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 16,
+            "y": 7
+          },
+          "id": 4,
+          "options": {
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            }
+          },
+          "targets": [
+            {
+              "expr": "max by (instance) (symphony_running_issues{instance=~\"symphony|symphony-jangar|symphony-torghut\"})",
+              "legendFormat": "{{instance}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Running Issues",
+          "type": "stat"
+        },
+        {
+          "datasource": "prom",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 14
+          },
+          "id": 5,
+          "options": {
+            "tooltip": {
+              "mode": "multi"
+            }
+          },
+          "targets": [
+            {
+              "expr": "max by (instance) (symphony_retry_queue_size{instance=~\"symphony|symphony-jangar|symphony-torghut\"})",
+              "legendFormat": "{{instance}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Retry Queue Size",
+          "type": "timeseries"
+        },
+        {
+          "datasource": "prom",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 14
+          },
+          "id": 6,
+          "options": {
+            "tooltip": {
+              "mode": "multi"
+            }
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum by (instance, le) (rate(symphony_poll_duration_ms_bucket{instance=~\"symphony|symphony-jangar|symphony-torghut\"}[5m])))",
+              "legendFormat": "{{instance}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Poll Duration P95",
+          "type": "timeseries"
+        },
+        {
+          "datasource": "prom",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 22
+          },
+          "id": 7,
+          "options": {
+            "tooltip": {
+              "mode": "multi"
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum by (instance, outcome) (rate(symphony_worker_outcomes_total{instance=~\"symphony|symphony-jangar|symphony-torghut\"}[15m]))",
+              "legendFormat": "{{instance}} {{outcome}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Worker Outcome Rates",
+          "type": "timeseries"
+        },
+        {
+          "datasource": "prom",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 22
+          },
+          "id": 8,
+          "options": {
+            "tooltip": {
+              "mode": "multi"
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum by (instance) (rate(symphony_codex_total_tokens_total{instance=~\"symphony|symphony-jangar|symphony-torghut\"}[5m]))",
+              "legendFormat": "{{instance}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Codex Token Throughput",
+          "type": "timeseries"
+        },
+        {
+          "datasource": "loki",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 30
+          },
+          "id": 9,
+          "options": {
+            "tooltip": {
+              "mode": "multi"
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum by (job) (count_over_time({job=~\"symphony|symphony-jangar|symphony-torghut\"} | json | level=~\"error|fatal\" [5m]))",
+              "legendFormat": "{{job}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Recent Error Log Volume",
+          "type": "timeseries"
+        }
+      ],
+      "refresh": "30s",
+      "schemaVersion": 36,
+      "style": "dark",
+      "tags": [
+        "symphony",
+        "observability"
+      ],
+      "templating": {
+        "list": []
+      },
+      "time": {
+        "from": "now-6h",
+        "to": "now"
+      },
+      "timezone": "browser",
+      "title": "Symphony Fleet Observability",
+      "uid": "symphony-fleet-observability",
+      "version": 1
+    }

--- a/argocd/applications/symphony-base/deployment.yaml
+++ b/argocd/applications/symphony-base/deployment.yaml
@@ -67,6 +67,32 @@ spec:
               value: "true"
             - name: SYMPHONY_LEADER_ELECTION_LEASE_NAME
               value: symphony-leader
+            - name: OTEL_SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['app.kubernetes.io/name']
+            - name: OTEL_SERVICE_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OTEL_SERVICE_INSTANCE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+              value: http://observability-tempo-gateway.observability.svc.cluster.local:4318/v1/traces
+            - name: OTEL_EXPORTER_OTLP_METRICS_ENDPOINT
+              value: http://observability-mimir-nginx.observability.svc.cluster.local/otlp/v1/metrics
+            - name: OTEL_EXPORTER_OTLP_TRACES_TIMEOUT
+              value: "20000"
+            - name: OTEL_EXPORTER_OTLP_METRICS_TIMEOUT
+              value: "20000"
+            - name: OTEL_METRIC_EXPORT_INTERVAL
+              value: "15000"
+            - name: OTEL_METRIC_EXPORT_TIMEOUT
+              value: "20000"
+            - name: OTEL_LOGS_EXPORTER
+              value: none
           readinessProbe:
             httpGet:
               path: /readyz

--- a/argocd/applications/torghut/alloy-configmap.yaml
+++ b/argocd/applications/torghut/alloy-configmap.yaml
@@ -31,6 +31,25 @@ data:
         regex         = "chi-torghut-clickhouse-.*"
         action        = "drop"
       }
+
+      rule {
+        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        regex         = "symphony-torghut"
+        action        = "drop"
+      }
+    }
+
+    discovery.kubernetes "symphony_torghut" {
+      role = "pod"
+
+      namespaces {
+        names = ["torghut"]
+      }
+
+      selectors {
+        role  = "pod"
+        label = "app.kubernetes.io/name=symphony-torghut"
+      }
     }
 
     discovery.kubernetes "torghut_endpoints" {
@@ -107,6 +126,30 @@ data:
       stage.static_labels {
         values = {
           job = "torghut",
+        }
+      }
+
+      forward_to = [loki.write.default.receiver]
+    }
+
+    loki.source.kubernetes "symphony_torghut" {
+      targets    = discovery.kubernetes.symphony_torghut.targets
+      forward_to = [loki.process.symphony_torghut.receiver]
+    }
+
+    loki.process "symphony_torghut" {
+      stage.labels {
+        values = {
+          namespace = "{{ .Labels.namespace }}",
+          pod       = "{{ .Labels.pod }}",
+          container = "{{ .Labels.container }}",
+        }
+      }
+
+      stage.static_labels {
+        values = {
+          app = "symphony-torghut",
+          job = "symphony-torghut",
         }
       }
 

--- a/bun.lock
+++ b/bun.lock
@@ -784,6 +784,7 @@
       "dependencies": {
         "@effect/schema": "^0.75.5",
         "@proompteng/codex": "workspace:*",
+        "@proompteng/otel": "workspace:*",
         "effect": "^3.19.18",
         "handlebars": "^4.7.8",
         "yaml": "^2.8.2",

--- a/packages/otel/src/api.ts
+++ b/packages/otel/src/api.ts
@@ -1,10 +1,14 @@
 import { DiagConsoleLogger, DiagLogLevel, diag } from './diag'
-import { type Counter, type Histogram, NoopMeterProvider } from './sdk-metrics'
-import { NoopTracerProvider, type Span, type SpanOptions, SpanStatusCode } from './sdk-trace'
+import { NoopMeterProvider } from './sdk-metrics'
+import { NoopTracerProvider, SpanStatusCode } from './sdk-trace'
+
+import type { Counter, Gauge, Histogram } from './sdk-metrics'
+import type { Span, SpanOptions } from './sdk-trace'
 
 type MeterLike = {
   createCounter: (name: string, options?: { description?: string; unit?: string }) => Counter
   createHistogram: (name: string, options?: { description?: string; unit?: string }) => Histogram
+  createGauge: (name: string, options?: { description?: string; unit?: string }) => Gauge
 }
 
 type TracerLike = {
@@ -41,4 +45,5 @@ export const trace = {
 }
 
 export { DiagConsoleLogger, DiagLogLevel, diag, SpanStatusCode }
-export type { Counter, Histogram }
+export type { Counter, Gauge, Histogram } from './sdk-metrics'
+export type { Span, SpanOptions } from './sdk-trace'

--- a/packages/otel/src/otlp-proto.ts
+++ b/packages/otel/src/otlp-proto.ts
@@ -330,6 +330,13 @@ const encodeMetric = (metric: ResourceMetrics['scopeMetrics'][number]['metrics']
   if (metric.unit) {
     writer.writeStringField(3, metric.unit)
   }
+  if (metric.gauge) {
+    const gaugeWriter = new ProtoWriter()
+    for (const dataPoint of metric.gauge.dataPoints) {
+      gaugeWriter.writeMessageField(1, encodeNumberDataPoint(dataPoint))
+    }
+    writer.writeMessageField(5, gaugeWriter.finish())
+  }
   if (metric.sum) {
     const sumWriter = new ProtoWriter()
     for (const dataPoint of metric.sum.dataPoints) {

--- a/packages/otel/src/sdk-metrics.ts
+++ b/packages/otel/src/sdk-metrics.ts
@@ -13,6 +13,10 @@ export interface Histogram {
   record(value: number, attributes?: Attributes): void
 }
 
+export interface Gauge {
+  set(value: number, attributes?: Attributes): void
+}
+
 export enum AggregationTemporality {
   UNSPECIFIED = 'AGGREGATION_TEMPORALITY_UNSPECIFIED',
   DELTA = 'AGGREGATION_TEMPORALITY_DELTA',
@@ -30,11 +34,12 @@ export class Aggregation {
 export enum InstrumentType {
   COUNTER = 'counter',
   HISTOGRAM = 'histogram',
+  GAUGE = 'gauge',
 }
 
 export type MetricDataPoint = {
   attributes: ReturnType<typeof attributesToKeyValueList>
-  startTimeUnixNano: string
+  startTimeUnixNano?: string
   timeUnixNano: string
   asDouble?: number
   count?: string
@@ -49,6 +54,9 @@ export type Metric = {
   name: string
   description?: string
   unit?: string
+  gauge?: {
+    dataPoints: MetricDataPoint[]
+  }
   sum?: {
     aggregationTemporality: AggregationTemporality
     isMonotonic: boolean
@@ -316,11 +324,59 @@ class HistogramInstrument implements Histogram {
   }
 }
 
+class GaugeInstrument implements Gauge {
+  readonly #name: string
+  readonly #description?: string
+  readonly #unit?: string
+  readonly #records = new Map<string, { attributes: Attributes; value: number }>()
+
+  constructor(name: string, description?: string, unit?: string) {
+    this.#name = name
+    this.#description = description
+    this.#unit = unit
+  }
+
+  set(value: number, attributes?: Attributes): void {
+    if (!Number.isFinite(value)) {
+      return
+    }
+    const normalized = attributes ?? {}
+    const key = stableAttributesKey(normalized)
+    this.#records.set(key, { attributes: normalized, value })
+  }
+
+  collect(timeUnixNano: string): Metric | null {
+    if (this.#records.size === 0) {
+      return null
+    }
+    const dataPoints: MetricDataPoint[] = []
+    for (const record of this.#records.values()) {
+      dataPoints.push({
+        attributes: attributesToKeyValueList(record.attributes),
+        timeUnixNano,
+        asDouble: record.value,
+      })
+    }
+    if (dataPoints.length === 0) {
+      return null
+    }
+    return {
+      name: this.#name,
+      description: this.#description,
+      unit: this.#unit,
+      gauge: {
+        dataPoints,
+      },
+    }
+  }
+}
+
 class Meter {
   readonly #name: string
   readonly #version?: string
   readonly #counters = new Map<string, CounterInstrument>()
   readonly #histograms = new Map<string, HistogramInstrument>()
+  readonly #gauges = new Map<string, GaugeInstrument>()
 
   constructor(name: string, version?: string) {
     this.#name = name
@@ -347,6 +403,16 @@ class Meter {
     return histogram
   }
 
+  createGauge(name: string, options?: { description?: string; unit?: string }): Gauge {
+    const existing = this.#gauges.get(name)
+    if (existing) {
+      return existing
+    }
+    const gauge = new GaugeInstrument(name, options?.description, options?.unit)
+    this.#gauges.set(name, gauge)
+    return gauge
+  }
+
   collect(timeUnixNano: string): Metric[] {
     const metrics: Metric[] = []
     for (const counter of this.#counters.values()) {
@@ -357,6 +423,12 @@ class Meter {
     }
     for (const histogram of this.#histograms.values()) {
       const metric = histogram.collect(timeUnixNano)
+      if (metric) {
+        metrics.push(metric)
+      }
+    }
+    for (const gauge of this.#gauges.values()) {
+      const metric = gauge.collect(timeUnixNano)
       if (metric) {
         metrics.push(metric)
       }
@@ -437,6 +509,10 @@ class NoopHistogram implements Histogram {
   record(): void {}
 }
 
+class NoopGauge implements Gauge {
+  set(): void {}
+}
+
 class NoopMeter {
   createCounter(): Counter {
     return new NoopCounter()
@@ -444,6 +520,10 @@ class NoopMeter {
 
   createHistogram(): Histogram {
     return new NoopHistogram()
+  }
+
+  createGauge(): Gauge {
+    return new NoopGauge()
   }
 }
 

--- a/packages/otel/src/sdk-trace.ts
+++ b/packages/otel/src/sdk-trace.ts
@@ -108,6 +108,12 @@ export type SpanOptions = {
   attributes?: SpanAttributes
   startTime?: number
   kind?: SpanKind
+  parentSpan?: Span | SpanContext
+}
+
+export type SpanContext = {
+  traceId: string
+  spanId: string
 }
 
 export class Span {
@@ -195,6 +201,13 @@ export class Span {
     return !this.#ended
   }
 
+  spanContext(): SpanContext {
+    return {
+      traceId: this.#traceId,
+      spanId: this.#spanId,
+    }
+  }
+
   private toSpanData(endTimeUnixNano: string): SpanData {
     return {
       traceId: this.#traceId,
@@ -262,7 +275,8 @@ export class Tracer {
   }
 
   startSpan(name: string, options: SpanOptions = {}): Span {
-    const traceId = generateTraceId()
+    const parentContext = options.parentSpan instanceof Span ? options.parentSpan.spanContext() : options.parentSpan
+    const traceId = parentContext?.traceId ?? generateTraceId()
     const spanId = generateSpanId()
     return new Span({
       name,
@@ -271,6 +285,7 @@ export class Tracer {
       startTimeUnixNano: toUnixNano(options.startTime ?? Date.now()),
       traceId,
       spanId,
+      parentSpanId: parentContext?.spanId,
       resourceAttributes: this.#resourceAttributes,
       scope: this.#scope,
       processor: this.#processor,

--- a/packages/otel/tests/metrics.test.ts
+++ b/packages/otel/tests/metrics.test.ts
@@ -41,6 +41,8 @@ test('metric reader exports counters and histograms with resource attributes', a
   counter.add(2, { env: 'test' })
   const histogram = meter.createHistogram('unit_histogram', { description: 'unit histogram', unit: 'ms' })
   histogram.record(5, { env: 'test' })
+  const gauge = meter.createGauge('unit_gauge', { description: 'unit gauge' })
+  gauge.set(7, { env: 'test' })
 
   await reader.forceFlush()
   await provider.shutdown()
@@ -51,6 +53,9 @@ test('metric reader exports counters and histograms with resource attributes', a
   const scopeMetrics = payload.scopeMetrics[0]
   expect(scopeMetrics.metrics.map((metric) => metric.name)).toContain('unit_counter')
   expect(scopeMetrics.metrics.map((metric) => metric.name)).toContain('unit_histogram')
+  expect(scopeMetrics.metrics.map((metric) => metric.name)).toContain('unit_gauge')
+  const gaugeMetric = scopeMetrics.metrics.find((metric) => metric.name === 'unit_gauge')
+  expect(gaugeMetric?.gauge?.dataPoints[0]?.asDouble).toBe(7)
 })
 
 test('metric reader skips instruments without data points', async () => {

--- a/packages/otel/tests/traces.test.ts
+++ b/packages/otel/tests/traces.test.ts
@@ -3,7 +3,26 @@ import http2 from 'node:http2'
 
 import { ExportResultCode } from '../src/core'
 import { OTLPTraceExporter } from '../src/exporter-trace-otlp-http'
-import { type SpanData, SpanKind, SpanStatusCode } from '../src/sdk-trace'
+import { Resource } from '../src/resources'
+import {
+  createSimpleSpanProcessor,
+  type SpanData,
+  type SpanExporter,
+  SpanKind,
+  SpanStatusCode,
+  TracerProvider,
+} from '../src/sdk-trace'
+
+class TestSpanExporter implements SpanExporter {
+  readonly exported: SpanData[] = []
+
+  export(spans: SpanData[], resultCallback: (result: { code: ExportResultCode; error?: Error }) => void): void {
+    this.exported.push(...spans)
+    resultCallback({ code: ExportResultCode.SUCCESS })
+  }
+
+  async shutdown(): Promise<void> {}
+}
 
 test('trace exporter emits OTLP resourceSpans payload', async () => {
   const requests: string[] = []
@@ -102,6 +121,30 @@ test('trace exporter emits protobuf payload when configured', async () => {
 
   expect(capturedContentType).toBe('application/x-protobuf')
   expect(capturedLength).toBeGreaterThan(0)
+})
+
+test('tracer preserves parent-child relationships', async () => {
+  const exporter = new TestSpanExporter()
+  const provider = new TracerProvider({
+    resource: new Resource({ 'service.name': 'otel-test' }),
+  })
+  provider.addSpanProcessor(createSimpleSpanProcessor(exporter))
+
+  const tracer = provider.getTracer('unit-test')
+  const parent = tracer.startSpan('parent-span')
+  const child = tracer.startSpan('child-span', { parentSpan: parent })
+  child.end()
+  parent.end()
+  await provider.forceFlush()
+  await provider.shutdown()
+
+  const parentSpan = exporter.exported.find((span) => span.name === 'parent-span')
+  const childSpan = exporter.exported.find((span) => span.name === 'child-span')
+
+  expect(parentSpan).toBeDefined()
+  expect(childSpan).toBeDefined()
+  expect(childSpan?.traceId).toBe(parentSpan?.traceId)
+  expect(childSpan?.parentSpanId).toBe(parentSpan?.spanId)
 })
 
 test('trace exporter sends gRPC payload', async () => {

--- a/services/symphony/package.json
+++ b/services/symphony/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@effect/schema": "^0.75.5",
     "@proompteng/codex": "workspace:*",
+    "@proompteng/otel": "workspace:*",
     "effect": "^3.19.18",
     "handlebars": "^4.7.8",
     "yaml": "^2.8.2"

--- a/services/symphony/src/codex-app-session.ts
+++ b/services/symphony/src/codex-app-session.ts
@@ -22,8 +22,10 @@ import type {
   TurnStartParams,
   TurnStartResponse,
 } from '@proompteng/codex'
+import type { Span } from '@proompteng/otel/api'
 
 import { CodexProtocolError, toLogError } from './errors'
+import { withSymphonyEffectSpan } from './instrumentation'
 import type { Logger } from './logger'
 import type { TokenUsageTotals } from './types'
 
@@ -82,6 +84,7 @@ export type CodexSessionOptions = {
   turnTimeoutMs: number
   title: string
   dynamicTools: DynamicToolSpec[]
+  parentSpan?: Span
   logger: Logger
   onEvent: (event: CodexEvent) => Effect.Effect<void, never>
   onToolCall: (tool: string, args: unknown) => Effect.Effect<DynamicToolCallResponse, never>
@@ -371,7 +374,15 @@ export const makeCodexSessionLayer = (logger: Logger) =>
                 typeof raw.callId === 'string' ? raw.callId : typeof raw.id === 'string' ? raw.id : null
               const toolName = typeof raw.name === 'string' ? raw.name : 'unknown'
               const args = 'input' in raw ? raw.input : raw.arguments
-              const result = yield* options.onToolCall(toolName, args)
+              const result = yield* withSymphonyEffectSpan(
+                'symphony.codex.tool_call',
+                {
+                  'codex.tool.name': toolName,
+                  'codex.tool.call_id': toolCallId ?? 'unknown',
+                },
+                options.onToolCall(toolName, args),
+                { parentSpan: options.parentSpan },
+              )
               yield* writeMessage(child, { id, result: { ...result, callId: toolCallId } })
               return
             }
@@ -684,22 +695,27 @@ export const makeCodexSessionLayer = (logger: Logger) =>
           Effect.flatMap((ready) =>
             ready
               ? Effect.void
-              : request('initialize', {
-                  clientInfo: { name: 'symphony', version: '0.1.0' },
-                  capabilities: {
-                    experimentalApi: options.dynamicTools.length > 0,
-                  },
-                }).pipe(
-                  Effect.zipRight(writeMessage(child, { method: 'initialized', params: {} })),
-                  Effect.zipRight(Ref.set(readyRef, true)),
-                  Effect.zipRight(
-                    options.onEvent({
-                      event: 'session_started',
-                      timestamp: new Date().toISOString(),
-                      codexAppServerPid: String(child.pid ?? ''),
-                      message: 'codex app-server initialized',
-                    }),
+              : withSymphonyEffectSpan(
+                  'symphony.codex.initialize',
+                  { 'workspace.path': options.cwd },
+                  request('initialize', {
+                    clientInfo: { name: 'symphony', version: '0.1.0' },
+                    capabilities: {
+                      experimentalApi: options.dynamicTools.length > 0,
+                    },
+                  }).pipe(
+                    Effect.zipRight(writeMessage(child, { method: 'initialized', params: {} })),
+                    Effect.zipRight(Ref.set(readyRef, true)),
+                    Effect.zipRight(
+                      options.onEvent({
+                        event: 'session_started',
+                        timestamp: new Date().toISOString(),
+                        codexAppServerPid: String(child.pid ?? ''),
+                        message: 'codex app-server initialized',
+                      }),
+                    ),
                   ),
+                  { parentSpan: options.parentSpan },
                 ),
           ),
         )
@@ -725,7 +741,12 @@ export const makeCodexSessionLayer = (logger: Logger) =>
             persistExtendedHistory: false,
           }
 
-          const response = (yield* request('thread/start', params)) as ThreadStartResponse
+          const response = (yield* withSymphonyEffectSpan(
+            'symphony.codex.thread_start',
+            { 'workspace.path': options.cwd },
+            request('thread/start', params),
+            { parentSpan: options.parentSpan },
+          )) as ThreadStartResponse
           yield* Ref.set(threadIdRef, response.thread.id)
           return response.thread.id
         })
@@ -747,7 +768,15 @@ export const makeCodexSessionLayer = (logger: Logger) =>
               collaborationMode: null,
             }
 
-            const response = (yield* request('turn/start', params)) as TurnStartResponse
+            const response = (yield* withSymphonyEffectSpan(
+              'symphony.codex.turn_start',
+              {
+                'workspace.path': options.cwd,
+                'thread.id': threadId,
+              },
+              request('turn/start', params),
+              { parentSpan: options.parentSpan },
+            )) as TurnStartResponse
             const turnId = response.turn.id
             const deferred = yield* Deferred.make<TurnOutcome, CodexProtocolError>()
             yield* SynchronizedRef.set(activeTurnRef, { threadId, turnId, deferred })

--- a/services/symphony/src/http-server.ts
+++ b/services/symphony/src/http-server.ts
@@ -1,6 +1,7 @@
 import { Effect } from 'effect'
 import type { ManagedRuntime } from 'effect/ManagedRuntime'
 
+import { finishSymphonySpan, startSymphonySpan } from './instrumentation'
 import { OrchestratorService } from './orchestrator'
 import type { Logger } from './logger'
 import type { RuntimeSnapshot } from './types'
@@ -13,6 +14,16 @@ export const parseIssueIdentifierPath = (pathname: string): IssueIdentifierParam
   if (!pathname.startsWith('/api/v1/')) return null
   const issueIdentifier = decodeURIComponent(pathname.replace('/api/v1/', ''))
   return issueIdentifier.length > 0 ? { issueIdentifier } : null
+}
+
+const resolveHttpRouteName = (request: Request, pathname: string) => {
+  if (request.method === 'GET' && pathname === '/livez') return 'symphony.http.livez'
+  if (request.method === 'GET' && pathname === '/readyz') return 'symphony.http.readyz'
+  if (request.method === 'GET' && pathname === '/') return 'symphony.http.dashboard'
+  if (request.method === 'GET' && pathname === '/api/v1/state') return 'symphony.http.state'
+  if (request.method === 'POST' && pathname === '/api/v1/refresh') return 'symphony.http.refresh'
+  if (request.method === 'GET' && pathname.startsWith('/api/v1/')) return 'symphony.http.issue_details'
+  return 'symphony.http.request'
 }
 
 const stringifyForHtml = (value: unknown): string => {
@@ -408,9 +419,26 @@ export class SymphonyHttpServer<R, E> {
     this.server = Bun.serve({
       hostname: host,
       port,
-      fetch: (request): Promise<Response> =>
-        (this.runtime.runPromise(handleRequestEffect(request) as never) as Promise<Response>).catch((error: unknown) =>
-          Response.json(
+      fetch: (request): Promise<Response> => {
+        const url = new URL(request.url)
+        const params =
+          request.method === 'GET' && url.pathname.startsWith('/api/v1/')
+            ? parseIssueIdentifierPath(url.pathname)
+            : null
+        const span = startSymphonySpan(resolveHttpRouteName(request, url.pathname), {
+          'http.method': request.method,
+          'http.route': url.pathname,
+          ...(params ? { 'issue.identifier': params.issueIdentifier } : {}),
+        })
+
+        const finishWithResponse = (response: Response) => {
+          span.setAttribute('http.status_code', response.status)
+          finishSymphonySpan(span)
+          return response
+        }
+
+        const finishWithError = (error: unknown) => {
+          const response = Response.json(
             {
               error: {
                 code: 'internal_error',
@@ -418,8 +446,17 @@ export class SymphonyHttpServer<R, E> {
               },
             },
             { status: 500 },
-          ),
-        ),
+          )
+          span.setAttribute('http.status_code', response.status)
+          finishSymphonySpan(span, error)
+          return response
+        }
+
+        return (this.runtime.runPromise(handleRequestEffect(request) as never) as Promise<Response>).then(
+          finishWithResponse,
+          finishWithError,
+        )
+      },
     })
     this.logger.log('info', 'http_server_started', { host, port: this.server.port })
     return this.server.port ?? port

--- a/services/symphony/src/index.ts
+++ b/services/symphony/src/index.ts
@@ -2,6 +2,8 @@ import process from 'node:process'
 
 import { Deferred, Effect } from 'effect'
 
+import './instrumentation'
+
 import { OrchestratorService } from './orchestrator'
 import { createLogger } from './logger'
 import { makeSymphonyRuntime } from './runtime'

--- a/services/symphony/src/instrumentation.ts
+++ b/services/symphony/src/instrumentation.ts
@@ -1,0 +1,373 @@
+import {
+  DiagConsoleLogger,
+  DiagLogLevel,
+  diag,
+  type Counter,
+  type Gauge,
+  type Histogram,
+  type Span,
+  SpanStatusCode,
+  metrics,
+  trace,
+} from '@proompteng/otel/api'
+import { getNodeAutoInstrumentations } from '@proompteng/otel/auto-instrumentations-node'
+import { OTLPMetricExporter } from '@proompteng/otel/exporter-metrics-otlp-http'
+import { OTLPTraceExporter } from '@proompteng/otel/exporter-trace-otlp-http'
+import { Resource } from '@proompteng/otel/resources'
+import { PeriodicExportingMetricReader } from '@proompteng/otel/sdk-metrics'
+import { NodeSDK } from '@proompteng/otel/sdk-node'
+import {
+  SEMRESATTRS_SERVICE_INSTANCE_ID,
+  SEMRESATTRS_SERVICE_NAME,
+  SEMRESATTRS_SERVICE_NAMESPACE,
+} from '@proompteng/otel/semantic-conventions'
+import { Effect } from 'effect'
+
+type MetricAttributes = Record<string, string | number | boolean>
+
+type SymphonyMetrics = {
+  pollTicksTotal: Counter
+  pollDurationMs: Histogram
+  reconcileDurationMs: Histogram
+  candidateFetchTotal: Counter
+  issueDispatchTotal: Counter
+  issueHandoffTotal: Counter
+  workerOutcomesTotal: Counter
+  workerDurationMs: Histogram
+  runningIssues: Gauge
+  retryQueueSize: Gauge
+  targetHealthReady: Gauge
+  leaderState: Gauge
+  lastSuccessfulPollTimestampSeconds: Gauge
+  codexInputTokensTotal: Counter
+  codexOutputTokensTotal: Counter
+  codexTotalTokensTotal: Counter
+}
+
+type TelemetryState = {
+  initialized: boolean
+  enabled: boolean
+  instance: string
+  tracer: ReturnType<typeof trace.getTracer>
+  metrics: SymphonyMetrics
+  sdk?: NodeSDK
+}
+
+const DEFAULT_TRACES_ENDPOINT = 'http://observability-tempo-gateway.observability.svc.cluster.local:4318/v1/traces'
+const DEFAULT_METRICS_ENDPOINT = 'http://observability-mimir-nginx.observability.svc.cluster.local/otlp/v1/metrics'
+
+const globalState = globalThis as typeof globalThis & {
+  __symphonyTelemetry?: TelemetryState
+}
+
+const isTruthy = (value?: string) => {
+  if (!value) return false
+  return ['1', 'true', 'yes', 'on'].includes(value.toLowerCase())
+}
+
+const isTestEnv = () => process.env.NODE_ENV === 'test' || Boolean(process.env.VITEST) || Boolean(process.env.BUN_TEST)
+
+const parseNumber = (value?: string): number | undefined => {
+  if (!value) return undefined
+  const parsed = Number.parseInt(value, 10)
+  return Number.isFinite(parsed) ? parsed : undefined
+}
+
+const formatUnknownError = (error: unknown): string => {
+  if (error instanceof Error) return error.message
+  if (typeof error === 'string') return error
+  try {
+    return JSON.stringify(error)
+  } catch {
+    return 'unknown error'
+  }
+}
+
+const resolveInstance = () =>
+  process.env.OTEL_SERVICE_NAME?.trim() || process.env.SYMPHONY_INSTANCE_NAME?.trim() || 'symphony'
+
+const recordCounter = (counter: Counter, value: number, attributes?: MetricAttributes) => {
+  if (!Number.isFinite(value) || value < 0) return
+  counter.add(value, attributes)
+}
+
+const recordHistogram = (histogram: Histogram, value: number, attributes?: MetricAttributes) => {
+  if (!Number.isFinite(value) || value < 0) return
+  histogram.record(value, attributes)
+}
+
+const setGauge = (gauge: Gauge, value: number, attributes?: MetricAttributes) => {
+  if (!Number.isFinite(value)) return
+  gauge.set(value, attributes)
+}
+
+const ensureTelemetryState = (): TelemetryState => {
+  const existing = globalState.__symphonyTelemetry
+  if (existing) return existing
+
+  diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.ERROR)
+
+  const instance = resolveInstance()
+  const meter = metrics.getMeter('symphony')
+  const tracer = trace.getTracer('symphony')
+
+  const created: TelemetryState = {
+    initialized: false,
+    enabled: true,
+    instance,
+    tracer,
+    metrics: {
+      pollTicksTotal: meter.createCounter('symphony_poll_ticks_total', {
+        description: 'Total Symphony poll ticks by result.',
+      }),
+      pollDurationMs: meter.createHistogram('symphony_poll_duration_ms', {
+        description: 'Symphony poll tick duration.',
+        unit: 'ms',
+      }),
+      reconcileDurationMs: meter.createHistogram('symphony_reconcile_duration_ms', {
+        description: 'Symphony running-issue reconciliation duration.',
+        unit: 'ms',
+      }),
+      candidateFetchTotal: meter.createCounter('symphony_candidate_fetch_total', {
+        description: 'Total candidate issue fetch attempts by result.',
+      }),
+      issueDispatchTotal: meter.createCounter('symphony_issue_dispatch_total', {
+        description: 'Total dispatched issues by state.',
+      }),
+      issueHandoffTotal: meter.createCounter('symphony_issue_handoff_total', {
+        description: 'Total issue handoffs by reason.',
+      }),
+      workerOutcomesTotal: meter.createCounter('symphony_worker_outcomes_total', {
+        description: 'Total Symphony worker outcomes.',
+      }),
+      workerDurationMs: meter.createHistogram('symphony_worker_duration_ms', {
+        description: 'Symphony worker runtime by outcome.',
+        unit: 'ms',
+      }),
+      runningIssues: meter.createGauge('symphony_running_issues', {
+        description: 'Current number of running issues.',
+      }),
+      retryQueueSize: meter.createGauge('symphony_retry_queue_size', {
+        description: 'Current number of retry-queued issues.',
+      }),
+      targetHealthReady: meter.createGauge('symphony_target_health_ready', {
+        description: 'Whether target health currently allows dispatch (1 or 0).',
+      }),
+      leaderState: meter.createGauge('symphony_leader_state', {
+        description: 'Whether this replica is currently the leader (1 or 0).',
+      }),
+      lastSuccessfulPollTimestampSeconds: meter.createGauge('symphony_last_successful_poll_timestamp_seconds', {
+        description: 'Unix timestamp of the last successful poll tick.',
+        unit: 's',
+      }),
+      codexInputTokensTotal: meter.createCounter('symphony_codex_input_tokens_total', {
+        description: 'Total Codex input tokens consumed by Symphony.',
+      }),
+      codexOutputTokensTotal: meter.createCounter('symphony_codex_output_tokens_total', {
+        description: 'Total Codex output tokens consumed by Symphony.',
+      }),
+      codexTotalTokensTotal: meter.createCounter('symphony_codex_total_tokens_total', {
+        description: 'Total Codex tokens consumed by Symphony.',
+      }),
+    },
+  }
+  globalState.__symphonyTelemetry = created
+  return created
+}
+
+const initializeSdk = () => {
+  const state = ensureTelemetryState()
+  if (state.initialized) return state
+
+  const serviceName = process.env.OTEL_SERVICE_NAME ?? state.instance
+  const serviceNamespace = process.env.OTEL_SERVICE_NAMESPACE ?? process.env.POD_NAMESPACE ?? 'default'
+  const serviceInstanceId = process.env.OTEL_SERVICE_INSTANCE_ID ?? process.env.HOSTNAME ?? process.pid.toString()
+
+  if (isTruthy(process.env.OTEL_SDK_DISABLED) || isTestEnv()) {
+    state.enabled = false
+    state.initialized = true
+    return state
+  }
+
+  const tracesEndpoint = process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT ?? DEFAULT_TRACES_ENDPOINT
+  const metricsEndpoint = process.env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT ?? DEFAULT_METRICS_ENDPOINT
+  const tracesTimeoutMs = Math.max(parseNumber(process.env.OTEL_EXPORTER_OTLP_TRACES_TIMEOUT) ?? 20_000, 1_000)
+  const metricsTimeoutMs = Math.max(parseNumber(process.env.OTEL_EXPORTER_OTLP_METRICS_TIMEOUT) ?? 20_000, 1_000)
+  const exportIntervalMillis = Math.max(parseNumber(process.env.OTEL_METRIC_EXPORT_INTERVAL) ?? 15_000, 5_000)
+  const exportTimeoutMillis = Math.max(parseNumber(process.env.OTEL_METRIC_EXPORT_TIMEOUT) ?? metricsTimeoutMs, 5_000)
+
+  const resource = Resource.default().merge(
+    new Resource({
+      [SEMRESATTRS_SERVICE_NAME]: serviceName,
+      [SEMRESATTRS_SERVICE_NAMESPACE]: serviceNamespace,
+      [SEMRESATTRS_SERVICE_INSTANCE_ID]: serviceInstanceId,
+    }),
+  )
+
+  const metricReader = new PeriodicExportingMetricReader({
+    exporter: new OTLPMetricExporter({
+      url: metricsEndpoint,
+      protocol: 'http/json',
+      timeoutMillis: metricsTimeoutMs,
+    }),
+    exportIntervalMillis,
+    exportTimeoutMillis,
+  })
+
+  const sdk = new NodeSDK({
+    resource,
+    traceExporter: new OTLPTraceExporter({
+      url: tracesEndpoint,
+      protocol: 'http/json',
+      timeoutMillis: tracesTimeoutMs,
+    }),
+    metricReader,
+    instrumentations: [
+      getNodeAutoInstrumentations({
+        '@opentelemetry/instrumentation-http': { enabled: true },
+        '@opentelemetry/instrumentation-undici': { enabled: true },
+      }),
+    ],
+  })
+
+  state.sdk = sdk
+  state.initialized = true
+
+  try {
+    Promise.resolve(sdk.start()).catch((error) => {
+      diag.error('failed to start Symphony OpenTelemetry SDK', error)
+    })
+  } catch (error) {
+    diag.error('failed to start Symphony OpenTelemetry SDK', error)
+  }
+
+  const shutdown = () => {
+    void sdk.shutdown().catch((error) => {
+      diag.error('failed to shutdown Symphony OpenTelemetry SDK', error)
+    })
+  }
+
+  process.once('SIGTERM', shutdown)
+  process.once('SIGINT', shutdown)
+
+  return state
+}
+
+const metricAttrs = (attributes: MetricAttributes = {}): MetricAttributes => ({
+  instance: ensureTelemetryState().instance,
+  ...attributes,
+})
+
+const spanAttrs = (attributes: MetricAttributes = {}): MetricAttributes => ({
+  'service.name': ensureTelemetryState().instance,
+  instance: ensureTelemetryState().instance,
+  ...attributes,
+})
+
+export const initializeSymphonyInstrumentation = () => initializeSdk()
+
+export const startSymphonySpan = (
+  name: string,
+  attributes: MetricAttributes = {},
+  options: { parentSpan?: Span } = {},
+) =>
+  ensureTelemetryState().tracer.startSpan(name, { attributes: spanAttrs(attributes), parentSpan: options.parentSpan })
+
+export const finishSymphonySpan = (span: Span, error?: unknown) => {
+  if (error) {
+    span.setStatus({
+      code: SpanStatusCode.ERROR,
+      message: formatUnknownError(error),
+    })
+    if (error instanceof Error) {
+      span.recordException(error)
+    }
+  } else {
+    span.setStatus({ code: SpanStatusCode.OK })
+  }
+  span.end()
+}
+
+export const withSymphonyEffectSpan = <A, E, R>(
+  name: string,
+  attributes: MetricAttributes,
+  effect: Effect.Effect<A, E, R>,
+  options: { parentSpan?: Span } = {},
+) =>
+  Effect.suspend(() => {
+    const span = startSymphonySpan(name, attributes, options)
+    return effect.pipe(
+      Effect.matchEffect({
+        onFailure: (error) =>
+          Effect.sync(() => {
+            finishSymphonySpan(span, error)
+          }).pipe(Effect.zipRight(Effect.fail(error))),
+        onSuccess: (result) =>
+          Effect.sync(() => {
+            finishSymphonySpan(span)
+          }).pipe(Effect.as(result)),
+      }),
+    )
+  })
+
+export const recordPollTick = (result: string, durationMs: number) => {
+  const state = ensureTelemetryState()
+  recordCounter(state.metrics.pollTicksTotal, 1, metricAttrs({ result }))
+  recordHistogram(state.metrics.pollDurationMs, durationMs, metricAttrs({ result }))
+}
+
+export const recordReconcileDuration = (durationMs: number) => {
+  const state = ensureTelemetryState()
+  recordHistogram(state.metrics.reconcileDurationMs, durationMs, metricAttrs())
+}
+
+export const recordCandidateFetch = (result: string) => {
+  const state = ensureTelemetryState()
+  recordCounter(state.metrics.candidateFetchTotal, 1, metricAttrs({ result }))
+}
+
+export const recordIssueDispatch = (stateName: string) => {
+  const state = ensureTelemetryState()
+  recordCounter(state.metrics.issueDispatchTotal, 1, metricAttrs({ state: stateName }))
+}
+
+export const recordIssueHandoff = (reason: string) => {
+  const state = ensureTelemetryState()
+  recordCounter(state.metrics.issueHandoffTotal, 1, metricAttrs({ reason }))
+}
+
+export const recordWorkerOutcome = (outcome: string, durationMs: number) => {
+  const state = ensureTelemetryState()
+  recordCounter(state.metrics.workerOutcomesTotal, 1, metricAttrs({ outcome }))
+  recordHistogram(state.metrics.workerDurationMs, durationMs, metricAttrs({ outcome }))
+}
+
+export const recordCodexTokenUsage = (inputTokens: number, outputTokens: number, totalTokens: number) => {
+  const state = ensureTelemetryState()
+  recordCounter(state.metrics.codexInputTokensTotal, inputTokens, metricAttrs())
+  recordCounter(state.metrics.codexOutputTokensTotal, outputTokens, metricAttrs())
+  recordCounter(state.metrics.codexTotalTokensTotal, totalTokens, metricAttrs())
+}
+
+export const updateRuntimeGauges = (params: {
+  runningIssues: number
+  retryQueueSize: number
+  targetHealthReady?: boolean
+  leaderState?: boolean
+  lastSuccessfulPollTimestampSeconds?: number
+}) => {
+  const state = ensureTelemetryState()
+  setGauge(state.metrics.runningIssues, params.runningIssues, metricAttrs())
+  setGauge(state.metrics.retryQueueSize, params.retryQueueSize, metricAttrs())
+  if (params.targetHealthReady !== undefined) {
+    setGauge(state.metrics.targetHealthReady, params.targetHealthReady ? 1 : 0, metricAttrs())
+  }
+  if (params.leaderState !== undefined) {
+    setGauge(state.metrics.leaderState, params.leaderState ? 1 : 0, metricAttrs())
+  }
+  if (params.lastSuccessfulPollTimestampSeconds !== undefined) {
+    setGauge(state.metrics.lastSuccessfulPollTimestampSeconds, params.lastSuccessfulPollTimestampSeconds, metricAttrs())
+  }
+}
+
+initializeSymphonyInstrumentation()

--- a/services/symphony/src/issue-runner.ts
+++ b/services/symphony/src/issue-runner.ts
@@ -3,6 +3,7 @@ import { Context, Effect, Layer } from 'effect'
 
 import { CodexProtocolError, ConfigError, toLogError, TrackerError, WorkspaceError, WorkflowError } from './errors'
 import { CodexSessionService, type CodexEvent } from './codex-app-session'
+import { finishSymphonySpan, startSymphonySpan, withSymphonyEffectSpan } from './instrumentation'
 import { TrackerService } from './linear-client'
 import type { Issue } from './types'
 import { normalizeState } from './utils'
@@ -117,96 +118,135 @@ export const makeIssueRunnerLayer = (logger: Logger) =>
         runAttempt: (issue, attempt, callbacks) =>
           Effect.scoped(
             Effect.gen(function* () {
-              const { definition, config } = yield* workflow.current
-              const runLogger = issueRunnerLogger.child({ issue_id: issue.id, issue_identifier: issue.identifier })
-              const workspaceInfo = yield* workspace.createForIssue(issue.identifier)
-              yield* callbacks.onWorkspacePath(workspaceInfo.path)
-              let lastIssue = issue
-
-              const dynamicTools =
-                config.tracker.kind === 'linear' && config.tracker.apiKey ? [LINEAR_GRAPHQL_TOOL] : []
-
-              const initialPrompt =
-                definition.promptTemplate.trim().length > 0
-                  ? renderPromptTemplate(definition.promptTemplate, { issue, attempt })
-                  : FALLBACK_PROMPT
-
-              const session = yield* codexSessions.createSession({
-                command: config.codex.command,
-                cwd: workspaceInfo.path,
-                approvalPolicy: config.codex.approvalPolicy,
-                threadSandbox: config.codex.threadSandbox,
-                turnSandboxPolicy: config.codex.turnSandboxPolicy,
-                readTimeoutMs: config.codex.readTimeoutMs,
-                turnTimeoutMs: config.codex.turnTimeoutMs,
-                title: `${issue.identifier}: ${issue.title}`,
-                dynamicTools,
-                logger: runLogger,
-                onEvent: callbacks.onEvent,
-                onToolCall: handleToolCall,
+              const runSpan = startSymphonySpan('symphony.worker_attempt', {
+                'issue.id': issue.id,
+                'issue.identifier': issue.identifier,
+                'issue.title': issue.title,
+                attempt: attempt ?? 'first-run',
               })
+              try {
+                const { definition, config } = yield* workflow.current
+                const runLogger = issueRunnerLogger.child({ issue_id: issue.id, issue_identifier: issue.identifier })
+                const workspaceInfo = yield* withSymphonyEffectSpan(
+                  'symphony.worker_attempt.workspace_create',
+                  { 'issue.identifier': issue.identifier },
+                  workspace.createForIssue(issue.identifier),
+                  { parentSpan: runSpan },
+                )
+                yield* callbacks.onWorkspacePath(workspaceInfo.path)
+                let lastIssue = issue
 
-              const hookContext = {
-                issueId: issue.id,
-                issueIdentifier: issue.identifier,
-                issueBranchName: issue.branchName,
-                issueTitle: issue.title,
-                issueState: issue.state,
-              }
+                const dynamicTools =
+                  config.tracker.kind === 'linear' && config.tracker.apiKey ? [LINEAR_GRAPHQL_TOOL] : []
 
-              yield* workspace.runBeforeRun(workspaceInfo.path, hookContext)
+                const initialPrompt =
+                  definition.promptTemplate.trim().length > 0
+                    ? renderPromptTemplate(definition.promptTemplate, { issue, attempt })
+                    : FALLBACK_PROMPT
 
-              const program = Effect.gen(function* () {
-                for (let turnNumber = 1; turnNumber <= config.agent.maxTurns; turnNumber += 1) {
-                  const prompt =
-                    turnNumber === 1
-                      ? initialPrompt
-                      : buildContinuationPrompt(lastIssue, turnNumber, config.agent.maxTurns)
-                  const outcome = yield* session.runTurn(prompt)
-                  if (outcome.status !== 'completed') {
-                    return yield* Effect.fail(
-                      new CodexProtocolError(
-                        'turn_failed',
-                        `turn ${outcome.turnId} ended with status ${outcome.status}`,
-                      ),
-                    )
-                  }
+                const session = yield* codexSessions.createSession({
+                  command: config.codex.command,
+                  cwd: workspaceInfo.path,
+                  approvalPolicy: config.codex.approvalPolicy,
+                  threadSandbox: config.codex.threadSandbox,
+                  turnSandboxPolicy: config.codex.turnSandboxPolicy,
+                  readTimeoutMs: config.codex.readTimeoutMs,
+                  turnTimeoutMs: config.codex.turnTimeoutMs,
+                  title: `${issue.identifier}: ${issue.title}`,
+                  dynamicTools,
+                  parentSpan: runSpan,
+                  logger: runLogger,
+                  onEvent: callbacks.onEvent,
+                  onToolCall: handleToolCall,
+                })
 
-                  const refreshed = yield* tracker.fetchIssueStatesByIds([lastIssue.id])
-                  if (refreshed.length === 0) {
-                    break
-                  }
-                  lastIssue = refreshed[0]
-
-                  const latestConfig = yield* workflow.config
-                  const activeStates = new Set(latestConfig.tracker.activeStates.map((state) => normalizeState(state)))
-                  if (!activeStates.has(normalizeState(lastIssue.state))) {
-                    break
-                  }
+                const hookContext = {
+                  issueId: issue.id,
+                  issueIdentifier: issue.identifier,
+                  issueBranchName: issue.branchName,
+                  issueTitle: issue.title,
+                  issueState: issue.state,
                 }
 
-                return workspaceInfo.path
-              })
+                yield* withSymphonyEffectSpan(
+                  'symphony.worker_attempt.before_run_hook',
+                  { 'issue.identifier': issue.identifier, 'workspace.path': workspaceInfo.path },
+                  workspace.runBeforeRun(workspaceInfo.path, hookContext),
+                  { parentSpan: runSpan },
+                )
 
-              return yield* program.pipe(
-                Effect.ensuring(
-                  workspace
-                    .runAfterRun(workspaceInfo.path, {
-                      issueId: lastIssue.id,
-                      issueIdentifier: lastIssue.identifier,
-                      issueBranchName: lastIssue.branchName,
-                      issueTitle: lastIssue.title,
-                      issueState: lastIssue.state,
-                    })
-                    .pipe(
-                      Effect.catchAll((error) =>
-                        Effect.sync(() => {
-                          runLogger.log('warn', 'workspace_after_run_failed', toLogError(error))
-                        }),
+                const result = yield* Effect.gen(function* () {
+                  for (let turnNumber = 1; turnNumber <= config.agent.maxTurns; turnNumber += 1) {
+                    const prompt =
+                      turnNumber === 1
+                        ? initialPrompt
+                        : buildContinuationPrompt(lastIssue, turnNumber, config.agent.maxTurns)
+                    const outcome = yield* withSymphonyEffectSpan(
+                      'symphony.worker_attempt.turn',
+                      {
+                        'issue.identifier': lastIssue.identifier,
+                        'workspace.path': workspaceInfo.path,
+                        'turn.number': turnNumber,
+                      },
+                      session.runTurn(prompt),
+                      { parentSpan: runSpan },
+                    )
+                    if (outcome.status !== 'completed') {
+                      return yield* Effect.fail(
+                        new CodexProtocolError(
+                          'turn_failed',
+                          `turn ${outcome.turnId} ended with status ${outcome.status}`,
+                        ),
+                      )
+                    }
+
+                    const refreshed = yield* withSymphonyEffectSpan(
+                      'symphony.worker_attempt.refresh_issue_state',
+                      { 'issue.identifier': lastIssue.identifier },
+                      tracker.fetchIssueStatesByIds([lastIssue.id]),
+                      { parentSpan: runSpan },
+                    )
+                    if (refreshed.length === 0) {
+                      break
+                    }
+                    lastIssue = refreshed[0]
+
+                    const latestConfig = yield* workflow.config
+                    const activeStates = new Set(
+                      latestConfig.tracker.activeStates.map((state) => normalizeState(state)),
+                    )
+                    if (!activeStates.has(normalizeState(lastIssue.state))) {
+                      break
+                    }
+                  }
+
+                  return workspaceInfo.path
+                }).pipe(
+                  Effect.ensuring(
+                    workspace
+                      .runAfterRun(workspaceInfo.path, {
+                        issueId: lastIssue.id,
+                        issueIdentifier: lastIssue.identifier,
+                        issueBranchName: lastIssue.branchName,
+                        issueTitle: lastIssue.title,
+                        issueState: lastIssue.state,
+                      })
+                      .pipe(
+                        Effect.catchAll((error) =>
+                          Effect.sync(() => {
+                            runLogger.log('warn', 'workspace_after_run_failed', toLogError(error))
+                          }),
+                        ),
                       ),
-                    ),
-                ),
-              )
+                  ),
+                )
+
+                finishSymphonySpan(runSpan)
+                return result
+              } catch (error) {
+                finishSymphonySpan(runSpan, error)
+                throw error
+              }
             }),
           ),
       } satisfies IssueRunnerServiceDefinition

--- a/services/symphony/src/orchestrator.ts
+++ b/services/symphony/src/orchestrator.ts
@@ -21,6 +21,19 @@ import {
   type WorkflowError,
 } from './errors'
 import { IssueRunnerService } from './issue-runner'
+import {
+  finishSymphonySpan,
+  recordCandidateFetch,
+  recordCodexTokenUsage,
+  recordIssueDispatch,
+  recordIssueHandoff,
+  recordPollTick,
+  recordReconcileDuration,
+  recordWorkerOutcome,
+  startSymphonySpan,
+  updateRuntimeGauges,
+  withSymphonyEffectSpan,
+} from './instrumentation'
 import { LeaderElectionService } from './leader-election'
 import { TrackerService } from './linear-client'
 import { emptyPersistedSchedulerState, StateStoreService } from './state-store'
@@ -404,6 +417,21 @@ const toPersistedState = (state: OrchestratorState): PersistedSchedulerState => 
   ),
 })
 
+const syncStateMetrics = (
+  state: OrchestratorState,
+  options: {
+    targetHealthReady?: boolean
+    leaderState?: boolean
+    lastSuccessfulPollTimestampSeconds?: number
+  } = {},
+) => {
+  updateRuntimeGauges({
+    runningIssues: state.running.size,
+    retryQueueSize: state.retryAttempts.size,
+    ...options,
+  })
+}
+
 const applyTokenUsage = (state: OrchestratorState, running: RunningRuntimeEntry, usage: TokenUsageTotals): void => {
   const deltaInput = Math.max(0, usage.inputTokens - running.session.lastReportedInputTokens)
   const deltaOutput = Math.max(0, usage.outputTokens - running.session.lastReportedOutputTokens)
@@ -419,6 +447,7 @@ const applyTokenUsage = (state: OrchestratorState, running: RunningRuntimeEntry,
   state.codexTotals.inputTokens += deltaInput
   state.codexTotals.outputTokens += deltaOutput
   state.codexTotals.totalTokens += deltaTotal
+  recordCodexTokenUsage(deltaInput, deltaOutput, deltaTotal)
 }
 
 const interruptWorkerFiber = (fiber: Fiber.RuntimeFiber<void, never> | null) =>
@@ -538,6 +567,7 @@ export const makeOrchestratorLayer = (logger: Logger) =>
         detail: string,
       ) =>
         tracker.handoffIssue(issue.id, buildHandoffMessage(issue, config, detail), config.tracker.handoffState).pipe(
+          Effect.tap(() => Effect.sync(() => recordIssueHandoff(reason))),
           Effect.tap(() =>
             SynchronizedRef.modifyEffect(stateRef, (state) => {
               addRecentEvent(state, {
@@ -643,6 +673,7 @@ export const makeOrchestratorLayer = (logger: Logger) =>
               level: error ? 'warn' : 'info',
               reason: delayType,
             })
+            syncStateMetrics(state)
             return Effect.succeed([undefined, state] as const)
           })
 
@@ -673,6 +704,7 @@ export const makeOrchestratorLayer = (logger: Logger) =>
             workspacePath: record.workspacePath,
             sessionId: null,
           })
+          syncStateMetrics(state)
           return Effect.succeed([undefined, state] as const)
         }).pipe(Effect.zipRight(persistStateBestEffort))
 
@@ -752,6 +784,7 @@ export const makeOrchestratorLayer = (logger: Logger) =>
         Effect.gen(function* () {
           const startedAtMs = Date.now()
           const startedAt = new Date(startedAtMs).toISOString()
+          recordIssueDispatch(normalizeState(issue.state))
 
           const existingRetry = yield* SynchronizedRef.modifyEffect(stateRef, (state) => {
             state.claimed.add(issue.id)
@@ -796,6 +829,7 @@ export const makeOrchestratorLayer = (logger: Logger) =>
               workspacePath: null,
               sessionId: null,
             })
+            syncStateMetrics(state)
             return Effect.succeed([retry, state] as const)
           })
 
@@ -822,84 +856,92 @@ export const makeOrchestratorLayer = (logger: Logger) =>
             if (running) {
               running.workerFiber = workerFiber
             }
+            syncStateMetrics(state)
             return Effect.succeed([undefined, state] as const)
           })
           yield* persistStateBestEffort
         })
 
       const reconcileRunningIssues = (config: SymphonyConfig) =>
-        Effect.gen(function* () {
-          const runningEntries = yield* SynchronizedRef.modifyEffect(stateRef, (state) =>
-            Effect.succeed([Array.from(state.running.values()), state] as const),
-          )
-          if (runningEntries.length === 0) return
+        (() => {
+          const startedAtMs = Date.now()
+          return withSymphonyEffectSpan(
+            'symphony.reconcile',
+            {},
+            Effect.gen(function* () {
+              const runningEntries = yield* SynchronizedRef.modifyEffect(stateRef, (state) =>
+                Effect.succeed([Array.from(state.running.values()), state] as const),
+              )
+              if (runningEntries.length === 0) return
 
-          const refreshed = yield* tracker.fetchIssueStatesByIds(runningEntries.map((entry) => entry.issueId)).pipe(
-            Effect.catchAll((error) =>
-              Effect.sync(() => {
-                orchestratorLogger.log('warn', 'running_state_refresh_failed', toLogError(error))
-              }).pipe(Effect.zipRight(Effect.succeed<Issue[]>([]))),
-            ),
-          )
-          if (refreshed.length === 0) return
+              const refreshed = yield* tracker.fetchIssueStatesByIds(runningEntries.map((entry) => entry.issueId)).pipe(
+                Effect.catchAll((error) =>
+                  Effect.sync(() => {
+                    orchestratorLogger.log('warn', 'running_state_refresh_failed', toLogError(error))
+                  }).pipe(Effect.zipRight(Effect.succeed<Issue[]>([]))),
+                ),
+              )
+              if (refreshed.length === 0) return
 
-          const refreshedById = new Map(refreshed.map((issue) => [issue.id, issue]))
-          const activeStates = new Set(config.tracker.activeStates.map((state) => normalizeState(state)))
-          const terminalStates = new Set(config.tracker.terminalStates.map((state) => normalizeState(state)))
+              const refreshedById = new Map(refreshed.map((issue) => [issue.id, issue]))
+              const activeStates = new Set(config.tracker.activeStates.map((state) => normalizeState(state)))
+              const terminalStates = new Set(config.tracker.terminalStates.map((state) => normalizeState(state)))
 
-          for (const running of runningEntries) {
-            const latest = refreshedById.get(running.issueId)
-            if (!latest) {
-              yield* SynchronizedRef.modifyEffect(stateRef, (state) => {
-                const current = state.running.get(running.issueId)
-                if (current) {
-                  current.stopReason = 'inactive'
+              for (const running of runningEntries) {
+                const latest = refreshedById.get(running.issueId)
+                if (!latest) {
+                  yield* SynchronizedRef.modifyEffect(stateRef, (state) => {
+                    const current = state.running.get(running.issueId)
+                    if (current) {
+                      current.stopReason = 'inactive'
+                    }
+                    return Effect.succeed([undefined, state] as const)
+                  })
+                  yield* interruptWorkerFiber(running.workerFiber)
+                  continue
                 }
-                return Effect.succeed([undefined, state] as const)
-              })
-              yield* interruptWorkerFiber(running.workerFiber)
-              continue
-            }
 
-            const nextState = normalizeState(latest.state)
-            if (terminalStates.has(nextState)) {
-              yield* SynchronizedRef.modifyEffect(stateRef, (state) => {
-                const current = state.running.get(running.issueId)
-                if (current) {
-                  current.issue = latest
-                  current.stopReason = 'terminal'
-                  current.terminalCleanupRequested = true
+                const nextState = normalizeState(latest.state)
+                if (terminalStates.has(nextState)) {
+                  yield* SynchronizedRef.modifyEffect(stateRef, (state) => {
+                    const current = state.running.get(running.issueId)
+                    if (current) {
+                      current.issue = latest
+                      current.stopReason = 'terminal'
+                      current.terminalCleanupRequested = true
+                    }
+                    return Effect.succeed([undefined, state] as const)
+                  })
+                  yield* interruptWorkerFiber(running.workerFiber)
+                  continue
                 }
-                return Effect.succeed([undefined, state] as const)
-              })
-              yield* interruptWorkerFiber(running.workerFiber)
-              continue
-            }
 
-            if (!activeStates.has(nextState)) {
-              yield* SynchronizedRef.modifyEffect(stateRef, (state) => {
-                const current = state.running.get(running.issueId)
-                if (current) {
-                  current.issue = latest
-                  current.stopReason = 'inactive'
+                if (!activeStates.has(nextState)) {
+                  yield* SynchronizedRef.modifyEffect(stateRef, (state) => {
+                    const current = state.running.get(running.issueId)
+                    if (current) {
+                      current.issue = latest
+                      current.stopReason = 'inactive'
+                    }
+                    return Effect.succeed([undefined, state] as const)
+                  })
+                  yield* interruptWorkerFiber(running.workerFiber)
+                  continue
                 }
-                return Effect.succeed([undefined, state] as const)
-              })
-              yield* interruptWorkerFiber(running.workerFiber)
-              continue
-            }
 
-            yield* SynchronizedRef.modifyEffect(stateRef, (state) => {
-              const current = state.running.get(running.issueId)
-              if (current) {
-                current.issue = latest
-                const record = ensureIssueRecord(state, current.issueId, current.identifier)
-                syncRecordFromRunning(record, current)
+                yield* SynchronizedRef.modifyEffect(stateRef, (state) => {
+                  const current = state.running.get(running.issueId)
+                  if (current) {
+                    current.issue = latest
+                    const record = ensureIssueRecord(state, current.issueId, current.identifier)
+                    syncRecordFromRunning(record, current)
+                  }
+                  return Effect.succeed([undefined, state] as const)
+                })
               }
-              return Effect.succeed([undefined, state] as const)
-            })
-          }
-        })
+            }),
+          ).pipe(Effect.ensuring(Effect.sync(() => recordReconcileDuration(Date.now() - startedAtMs))))
+        })()
 
       const reconcileStalledRuns = (config: SymphonyConfig) =>
         config.codex.stallTimeoutMs <= 0
@@ -936,6 +978,7 @@ export const makeOrchestratorLayer = (logger: Logger) =>
               level: leader.isLeader ? 'info' : 'warn',
               reason: leader.isLeader ? 'leader' : 'follower',
             })
+            syncStateMetrics(state, { leaderState: leader.isLeader })
             return Effect.succeed([undefined, state] as const)
           })
 
@@ -990,281 +1033,385 @@ export const makeOrchestratorLayer = (logger: Logger) =>
           yield* persistStateBestEffort
         })
 
-      const processPollTick = Effect.gen(function* () {
-        yield* Ref.set(pollQueuedRef, false)
+      const processPollTick = (() => {
+        const startedAtMs = Date.now()
+        const pollSpan = startSymphonySpan('symphony.poll_tick')
+        let finished = false
+        let pollResult = 'success'
 
-        const leader = yield* leaderElection.status
-        if (!leader.isLeader) {
-          yield* SynchronizedRef.modifyEffect(stateRef, (state) => {
-            addRecentEvent(state, {
-              at: new Date().toISOString(),
-              event: 'poll_skipped',
-              message: 'poll skipped because this replica is not leader',
-              level: 'warn',
-              reason: 'follower_not_leader',
-            })
-            return Effect.succeed([undefined, state] as const)
-          })
-          yield* persistStateBestEffort
-          return
-        }
-
-        const loaded = yield* workflow.current
-        const { config } = loaded
-        yield* SynchronizedRef.modifyEffect(stateRef, (state) => {
-          state.pollIntervalMs = config.pollingIntervalMs
-          state.maxConcurrentAgents = config.agent.maxConcurrentAgents
-          return Effect.succeed([undefined, state] as const)
-        })
-
-        yield* reconcileRunningIssues(config)
-
-        const validation = yield* Effect.either(validateDispatchConfigEffect(config))
-        if (validation._tag === 'Left') {
-          yield* Effect.sync(() => {
-            orchestratorLogger.log('error', 'dispatch_validation_failed', toLogError(validation.left))
-          })
-          yield* SynchronizedRef.modifyEffect(stateRef, (state) => {
-            addRecentError(state, {
-              at: new Date().toISOString(),
-              code: validation.left.code,
-              message: validation.left.message,
-              issueId: null,
-              issueIdentifier: null,
-              context: 'dispatch_validation',
-            })
-            addRecentEvent(state, {
-              at: new Date().toISOString(),
-              event: 'dispatch_skipped',
-              message: validation.left.message,
-              level: 'error',
-              reason: 'config_invalid',
-            })
-            return Effect.succeed([undefined, state] as const)
-          })
-          yield* persistStateBestEffort
-          return
-        }
-
-        const preDispatchHealth = yield* targetHealth.evaluatePreDispatch
-        if (!preDispatchHealth.readyForDispatch) {
-          const handoffReason = preDispatchHealth.openPromotionPr ? 'promotion_pr_open' : 'target_not_ready'
-          const blockedMessage = preDispatchHealth.openPromotionPr
-            ? 'dispatch paused because a promotion pull request is already open'
-            : preDispatchHealth.lastError
-              ? `dispatch paused: ${preDispatchHealth.lastError}`
-              : preDispatchHealth.checks
-                  .filter((check) => !check.ok)
-                  .map((check) => check.message)
-                  .join('; ') || 'dispatch paused because target health checks are failing'
-          yield* SynchronizedRef.modifyEffect(stateRef, (state) => {
-            addRecentEvent(state, {
-              at: new Date().toISOString(),
-              event: 'dispatch_paused',
-              message: blockedMessage,
-              level: 'warn',
-              reason: handoffReason,
-            })
-            return Effect.succeed([undefined, state] as const)
-          })
-          const issuesToHandoff = yield* tracker.fetchCandidateIssues.pipe(
-            Effect.catchAll((error) =>
-              Effect.sync(() => {
-                orchestratorLogger.log('error', 'candidate_fetch_failed_for_handoff', toLogError(error))
-              }).pipe(
-                Effect.zipRight(
-                  SynchronizedRef.modifyEffect(stateRef, (state) => {
-                    addRecentError(state, {
-                      at: new Date().toISOString(),
-                      code: error.code,
-                      message: error.message,
-                      issueId: null,
-                      issueIdentifier: null,
-                      context: 'candidate_fetch_handoff',
-                    })
-                    return Effect.succeed([undefined, state] as const)
-                  }),
-                ),
-                Effect.zipRight(Effect.succeed<Issue[]>([])),
-              ),
-            ),
-          )
-          yield* Effect.forEach(
-            issuesToHandoff,
-            (issue) => handoffSkippedIssue(issue, config, handoffReason, blockedMessage),
-            { concurrency: 1, discard: true },
-          )
-          yield* persistStateBestEffort
-          return
-        }
-
-        const issues = yield* tracker.fetchCandidateIssues.pipe(
-          Effect.catchAll((error) =>
-            Effect.sync(() => {
-              orchestratorLogger.log('error', 'candidate_fetch_failed', toLogError(error))
-            }).pipe(
-              Effect.zipRight(
-                SynchronizedRef.modifyEffect(stateRef, (state) => {
-                  addRecentError(state, {
-                    at: new Date().toISOString(),
-                    code: error.code,
-                    message: error.message,
-                    issueId: null,
-                    issueIdentifier: null,
-                    context: 'candidate_fetch',
-                  })
-                  return Effect.succeed([undefined, state] as const)
-                }),
-              ),
-              Effect.zipRight(Effect.succeed<Issue[]>([])),
-            ),
-          ),
-        )
-
-        if (issues.length === 0) {
-          yield* persistStateBestEffort
-          return
-        }
-
-        for (const issue of sortIssuesForDispatch(issues)) {
-          const currentState = yield* SynchronizedRef.get(stateRef)
-          const decision = evaluateDispatchIssue(issue, {
-            config,
-            runningIssues: Array.from(currentState.running.values()).map((entry) => entry.issue),
-            claimedIssueIds: currentState.claimed,
-          })
-
-          if (decision.eligible) {
-            yield* dispatchIssue(issue, null)
-            continue
+        const finishPoll = (error?: unknown) => {
+          if (!finished) {
+            finished = true
+            finishSymphonySpan(pollSpan, error)
+            recordPollTick(pollResult, Date.now() - startedAtMs)
           }
+        }
 
-          if (
-            decision.reason === 'no_slots' ||
-            decision.reason === 'manual_work_required' ||
-            decision.reason === 'blocked_issue' ||
-            decision.reason === 'non_active_state'
-          ) {
+        return Effect.gen(function* () {
+          yield* Ref.set(pollQueuedRef, false)
+
+          const leader = yield* leaderElection.status
+          if (!leader.isLeader) {
+            pollResult = 'follower_not_leader'
             yield* SynchronizedRef.modifyEffect(stateRef, (state) => {
               addRecentEvent(state, {
                 at: new Date().toISOString(),
-                event: 'dispatch_skipped',
-                message: `issue ${issue.identifier} not dispatched: ${decision.reason}`,
-                issueId: issue.id,
-                issueIdentifier: issue.identifier,
+                event: 'poll_skipped',
+                message: 'poll skipped because this replica is not leader',
                 level: 'warn',
-                reason: decision.reason,
+                reason: 'follower_not_leader',
               })
+              syncStateMetrics(state, { leaderState: leader.isLeader })
               return Effect.succeed([undefined, state] as const)
             })
-            if (decision.reason === 'manual_work_required') {
-              yield* handoffSkippedIssue(
-                issue,
-                config,
-                'manual_work_required',
-                'the issue requires manual work outside the first-wave autonomous scope',
-              )
-            }
-            if (decision.reason === 'no_slots') {
-              break
-            }
-          }
-        }
-
-        yield* persistStateBestEffort
-      })
-
-      const processRetryDue = (issueId: string) =>
-        Effect.gen(function* () {
-          const leader = yield* leaderElection.status
-          if (!leader.isLeader) {
-            yield* SynchronizedRef.modifyEffect(stateRef, (state) => {
-              const current = state.retryAttempts.get(issueId)
-              if (current) {
-                current.fiber = null
-              }
-              return Effect.succeed([undefined, state] as const)
-            })
+            yield* persistStateBestEffort
             return
           }
 
-          const retryEntry = yield* SynchronizedRef.modifyEffect(stateRef, (state) => {
-            const current = state.retryAttempts.get(issueId) ?? null
-            if (current) {
-              state.retryAttempts.delete(issueId)
-            }
-            return Effect.succeed([current, state] as const)
+          const loaded = yield* workflow.current
+          const { config } = loaded
+          yield* SynchronizedRef.modifyEffect(stateRef, (state) => {
+            state.pollIntervalMs = config.pollingIntervalMs
+            state.maxConcurrentAgents = config.agent.maxConcurrentAgents
+            syncStateMetrics(state, { leaderState: leader.isLeader })
+            return Effect.succeed([undefined, state] as const)
           })
-          if (!retryEntry) return
 
-          const candidatesResult = yield* tracker.fetchCandidateIssues.pipe(Effect.either)
+          yield* withSymphonyEffectSpan('symphony.poll_tick.reconcile', {}, reconcileRunningIssues(config), {
+            parentSpan: pollSpan,
+          })
 
-          if (candidatesResult._tag === 'Left') {
-            const error = candidatesResult.left
+          const validation = yield* Effect.either(validateDispatchConfigEffect(config))
+          if (validation._tag === 'Left') {
+            pollResult = 'config_invalid'
             yield* Effect.sync(() => {
-              orchestratorLogger.log('warn', 'retry_poll_failed', {
-                issue_id: issueId,
-                issue_identifier: retryEntry.identifier,
-                ...toLogError(error),
-              })
+              orchestratorLogger.log('error', 'dispatch_validation_failed', toLogError(validation.left))
             })
-            yield* scheduleRetry(issueId, retryEntry.identifier, retryEntry.attempt + 1, 'failure', 'retry poll failed')
+            yield* SynchronizedRef.modifyEffect(stateRef, (state) => {
+              addRecentError(state, {
+                at: new Date().toISOString(),
+                code: validation.left.code,
+                message: validation.left.message,
+                issueId: null,
+                issueIdentifier: null,
+                context: 'dispatch_validation',
+              })
+              addRecentEvent(state, {
+                at: new Date().toISOString(),
+                event: 'dispatch_skipped',
+                message: validation.left.message,
+                level: 'error',
+                reason: 'config_invalid',
+              })
+              return Effect.succeed([undefined, state] as const)
+            })
+            yield* persistStateBestEffort
             return
           }
 
-          const candidates = candidatesResult.right
-
-          const preDispatchHealth = yield* targetHealth.evaluatePreDispatch
+          const preDispatchHealth = yield* withSymphonyEffectSpan(
+            'symphony.poll_tick.target_health',
+            {},
+            targetHealth.evaluatePreDispatch,
+            { parentSpan: pollSpan },
+          )
           if (!preDispatchHealth.readyForDispatch) {
-            const reason = preDispatchHealth.openPromotionPr
-              ? 'promotion pull request already open'
-              : preDispatchHealth.lastError || 'target health checks are failing'
-            yield* scheduleRetry(issueId, retryEntry.identifier, retryEntry.attempt + 1, 'failure', reason)
-            return
-          }
-
-          const issue = candidates.find((candidate) => candidate.id === issueId)
-          if (!issue) {
-            yield* releaseClaim(issueId, retryEntry.identifier, 'issue no longer active during retry dispatch')
-            return
-          }
-
-          const config = yield* workflow.config
-          const runtimeState = yield* SynchronizedRef.get(stateRef)
-          const claimedIssueIds = new Set(runtimeState.claimed)
-          claimedIssueIds.delete(issueId)
-          const decision = evaluateDispatchIssue(issue, {
-            config,
-            runningIssues: Array.from(runtimeState.running.values()).map((entry) => entry.issue),
-            claimedIssueIds,
-          })
-
-          if (!decision.eligible) {
-            const reason =
-              decision.reason === 'no_slots'
-                ? 'no available orchestrator slots'
-                : decision.reason === 'blocked_issue'
-                  ? 'issue blocked by active dependency'
-                  : `issue not dispatchable: ${decision.reason}`
-            yield* scheduleRetry(issueId, issue.identifier, retryEntry.attempt + 1, 'failure', reason)
+            pollResult = preDispatchHealth.openPromotionPr ? 'promotion_pr_open' : 'target_not_ready'
+            const handoffReason = preDispatchHealth.openPromotionPr ? 'promotion_pr_open' : 'target_not_ready'
+            const blockedMessage = preDispatchHealth.openPromotionPr
+              ? 'dispatch paused because a promotion pull request is already open'
+              : preDispatchHealth.lastError
+                ? `dispatch paused: ${preDispatchHealth.lastError}`
+                : preDispatchHealth.checks
+                    .filter((check) => !check.ok)
+                    .map((check) => check.message)
+                    .join('; ') || 'dispatch paused because target health checks are failing'
+            yield* SynchronizedRef.modifyEffect(stateRef, (state) => {
+              addRecentEvent(state, {
+                at: new Date().toISOString(),
+                event: 'dispatch_paused',
+                message: blockedMessage,
+                level: 'warn',
+                reason: handoffReason,
+              })
+              syncStateMetrics(state, { targetHealthReady: false, leaderState: leader.isLeader })
+              return Effect.succeed([undefined, state] as const)
+            })
+            const issuesToHandoff = yield* withSymphonyEffectSpan(
+              'symphony.poll_tick.candidate_fetch_handoff',
+              {},
+              tracker.fetchCandidateIssues.pipe(
+                Effect.tap(() => Effect.sync(() => recordCandidateFetch('success'))),
+                Effect.catchAll((error) =>
+                  Effect.sync(() => {
+                    recordCandidateFetch('error')
+                    orchestratorLogger.log('error', 'candidate_fetch_failed_for_handoff', toLogError(error))
+                  }).pipe(
+                    Effect.zipRight(
+                      SynchronizedRef.modifyEffect(stateRef, (state) => {
+                        addRecentError(state, {
+                          at: new Date().toISOString(),
+                          code: error.code,
+                          message: error.message,
+                          issueId: null,
+                          issueIdentifier: null,
+                          context: 'candidate_fetch_handoff',
+                        })
+                        return Effect.succeed([undefined, state] as const)
+                      }),
+                    ),
+                    Effect.zipRight(Effect.succeed<Issue[]>([])),
+                  ),
+                ),
+              ),
+              { parentSpan: pollSpan },
+            )
+            yield* Effect.forEach(
+              issuesToHandoff,
+              (issue) => handoffSkippedIssue(issue, config, handoffReason, blockedMessage),
+              { concurrency: 1, discard: true },
+            )
+            yield* persistStateBestEffort
             return
           }
 
           yield* SynchronizedRef.modifyEffect(stateRef, (state) => {
-            state.claimed.delete(issueId)
+            syncStateMetrics(state, { targetHealthReady: true, leaderState: leader.isLeader })
             return Effect.succeed([undefined, state] as const)
           })
-          yield* dispatchIssue(issue, retryEntry.attempt)
-        })
+
+          const issues = yield* withSymphonyEffectSpan(
+            'symphony.poll_tick.candidate_fetch',
+            {},
+            tracker.fetchCandidateIssues.pipe(
+              Effect.tap(() => Effect.sync(() => recordCandidateFetch('success'))),
+              Effect.catchAll((error) =>
+                Effect.sync(() => {
+                  recordCandidateFetch('error')
+                  orchestratorLogger.log('error', 'candidate_fetch_failed', toLogError(error))
+                }).pipe(
+                  Effect.zipRight(
+                    SynchronizedRef.modifyEffect(stateRef, (state) => {
+                      addRecentError(state, {
+                        at: new Date().toISOString(),
+                        code: error.code,
+                        message: error.message,
+                        issueId: null,
+                        issueIdentifier: null,
+                        context: 'candidate_fetch',
+                      })
+                      return Effect.succeed([undefined, state] as const)
+                    }),
+                  ),
+                  Effect.zipRight(Effect.succeed<Issue[]>([])),
+                ),
+              ),
+            ),
+            { parentSpan: pollSpan },
+          )
+
+          if (issues.length === 0) {
+            yield* SynchronizedRef.modifyEffect(stateRef, (state) => {
+              syncStateMetrics(state, {
+                targetHealthReady: true,
+                leaderState: leader.isLeader,
+                lastSuccessfulPollTimestampSeconds: Math.floor(Date.now() / 1000),
+              })
+              return Effect.succeed([undefined, state] as const)
+            })
+            yield* persistStateBestEffort
+            return
+          }
+
+          for (const issue of sortIssuesForDispatch(issues)) {
+            const currentState = yield* SynchronizedRef.get(stateRef)
+            const decision = evaluateDispatchIssue(issue, {
+              config,
+              runningIssues: Array.from(currentState.running.values()).map((entry) => entry.issue),
+              claimedIssueIds: currentState.claimed,
+            })
+
+            if (decision.eligible) {
+              yield* withSymphonyEffectSpan(
+                'symphony.poll_tick.dispatch',
+                { 'issue.identifier': issue.identifier, 'issue.id': issue.id, 'issue.state': issue.state },
+                dispatchIssue(issue, null),
+                { parentSpan: pollSpan },
+              )
+              continue
+            }
+
+            if (
+              decision.reason === 'no_slots' ||
+              decision.reason === 'manual_work_required' ||
+              decision.reason === 'blocked_issue' ||
+              decision.reason === 'non_active_state'
+            ) {
+              yield* SynchronizedRef.modifyEffect(stateRef, (state) => {
+                addRecentEvent(state, {
+                  at: new Date().toISOString(),
+                  event: 'dispatch_skipped',
+                  message: `issue ${issue.identifier} not dispatched: ${decision.reason}`,
+                  issueId: issue.id,
+                  issueIdentifier: issue.identifier,
+                  level: 'warn',
+                  reason: decision.reason,
+                })
+                return Effect.succeed([undefined, state] as const)
+              })
+              if (decision.reason === 'manual_work_required') {
+                yield* handoffSkippedIssue(
+                  issue,
+                  config,
+                  'manual_work_required',
+                  'the issue requires manual work outside the first-wave autonomous scope',
+                )
+              }
+              if (decision.reason === 'no_slots') {
+                pollResult = 'no_slots'
+                break
+              }
+            }
+          }
+
+          yield* SynchronizedRef.modifyEffect(stateRef, (state) => {
+            syncStateMetrics(state, {
+              targetHealthReady: true,
+              leaderState: leader.isLeader,
+              lastSuccessfulPollTimestampSeconds: Math.floor(Date.now() / 1000),
+            })
+            return Effect.succeed([undefined, state] as const)
+          })
+          yield* persistStateBestEffort
+        }).pipe(
+          Effect.tapError((error) =>
+            Effect.sync(() => {
+              pollResult = 'failed'
+              finishPoll(error)
+            }),
+          ),
+          Effect.ensuring(
+            Effect.sync(() => {
+              finishPoll()
+            }),
+          ),
+        )
+      })()
+
+      const processRetryDue = (issueId: string) =>
+        withSymphonyEffectSpan(
+          'symphony.retry_due',
+          { 'issue.id': issueId },
+          Effect.gen(function* () {
+            const leader = yield* leaderElection.status
+            if (!leader.isLeader) {
+              yield* SynchronizedRef.modifyEffect(stateRef, (state) => {
+                const current = state.retryAttempts.get(issueId)
+                if (current) {
+                  current.fiber = null
+                }
+                syncStateMetrics(state, { leaderState: leader.isLeader })
+                return Effect.succeed([undefined, state] as const)
+              })
+              return
+            }
+
+            const retryEntry = yield* SynchronizedRef.modifyEffect(stateRef, (state) => {
+              const current = state.retryAttempts.get(issueId) ?? null
+              if (current) {
+                state.retryAttempts.delete(issueId)
+              }
+              syncStateMetrics(state, { leaderState: leader.isLeader })
+              return Effect.succeed([current, state] as const)
+            })
+            if (!retryEntry) return
+
+            const candidatesResult = yield* tracker.fetchCandidateIssues.pipe(
+              Effect.tap(() => Effect.sync(() => recordCandidateFetch('success'))),
+              Effect.either,
+            )
+
+            if (candidatesResult._tag === 'Left') {
+              const error = candidatesResult.left
+              recordCandidateFetch('error')
+              yield* Effect.sync(() => {
+                orchestratorLogger.log('warn', 'retry_poll_failed', {
+                  issue_id: issueId,
+                  issue_identifier: retryEntry.identifier,
+                  ...toLogError(error),
+                })
+              })
+              yield* scheduleRetry(
+                issueId,
+                retryEntry.identifier,
+                retryEntry.attempt + 1,
+                'failure',
+                'retry poll failed',
+              )
+              return
+            }
+
+            const candidates = candidatesResult.right
+
+            const preDispatchHealth = yield* withSymphonyEffectSpan(
+              'symphony.retry_due.target_health',
+              { 'issue.id': issueId },
+              targetHealth.evaluatePreDispatch,
+            )
+            if (!preDispatchHealth.readyForDispatch) {
+              const reason = preDispatchHealth.openPromotionPr
+                ? 'promotion pull request already open'
+                : preDispatchHealth.lastError || 'target health checks are failing'
+              yield* scheduleRetry(issueId, retryEntry.identifier, retryEntry.attempt + 1, 'failure', reason)
+              return
+            }
+
+            const issue = candidates.find((candidate) => candidate.id === issueId)
+            if (!issue) {
+              yield* releaseClaim(issueId, retryEntry.identifier, 'issue no longer active during retry dispatch')
+              return
+            }
+
+            const config = yield* workflow.config
+            const runtimeState = yield* SynchronizedRef.get(stateRef)
+            const claimedIssueIds = new Set(runtimeState.claimed)
+            claimedIssueIds.delete(issueId)
+            const decision = evaluateDispatchIssue(issue, {
+              config,
+              runningIssues: Array.from(runtimeState.running.values()).map((entry) => entry.issue),
+              claimedIssueIds,
+            })
+
+            if (!decision.eligible) {
+              const reason =
+                decision.reason === 'no_slots'
+                  ? 'no available orchestrator slots'
+                  : decision.reason === 'blocked_issue'
+                    ? 'issue blocked by active dependency'
+                    : `issue not dispatchable: ${decision.reason}`
+              yield* scheduleRetry(issueId, issue.identifier, retryEntry.attempt + 1, 'failure', reason)
+              return
+            }
+
+            yield* SynchronizedRef.modifyEffect(stateRef, (state) => {
+              state.claimed.delete(issueId)
+              syncStateMetrics(state)
+              return Effect.succeed([undefined, state] as const)
+            })
+            yield* dispatchIssue(issue, retryEntry.attempt)
+          }),
+        )
 
       const processWorkerExit = (issueId: string, exit: Exit.Exit<string, unknown>) =>
         Effect.gen(function* () {
+          const completedAtMs = Date.now()
           const running = yield* SynchronizedRef.modifyEffect(stateRef, (state) => {
             const current = state.running.get(issueId) ?? null
             if (current) {
               state.running.delete(issueId)
-              const runtimeSeconds = Math.max(0, Date.now() - current.startedAtMs) / 1_000
+              const runtimeSeconds = Math.max(0, completedAtMs - current.startedAtMs) / 1_000
               state.codexTotals.endedRuntimeSeconds += runtimeSeconds
+              syncStateMetrics(state)
             }
             return Effect.succeed([current, state] as const)
           })
@@ -1276,6 +1423,8 @@ export const makeOrchestratorLayer = (logger: Logger) =>
             : running.stopReason !== 'running'
               ? running.stopReason
               : 'failed'
+          const durationMs = Math.max(0, completedAtMs - running.startedAtMs)
+          recordWorkerOutcome(reason, durationMs)
 
           const record = yield* SynchronizedRef.modifyEffect(stateRef, (state) => {
             const existing = ensureIssueRecord(state, running.issueId, running.identifier)
@@ -1308,6 +1457,7 @@ export const makeOrchestratorLayer = (logger: Logger) =>
                 level: 'info',
                 reason: 'terminal',
               })
+              syncStateMetrics(state)
               return Effect.succeed([undefined, state] as const)
             })
             if (running.terminalCleanupRequested) {
@@ -1343,6 +1493,7 @@ export const makeOrchestratorLayer = (logger: Logger) =>
                 workspacePath: running.workspacePath || null,
                 sessionId: running.session.sessionId,
               })
+              syncStateMetrics(state)
               return Effect.succeed([undefined, state] as const)
             })
             yield* persistStateBestEffort
@@ -1507,7 +1658,9 @@ export const makeOrchestratorLayer = (logger: Logger) =>
                       }).pipe(Effect.zipRight(Effect.succeed(emptyPersistedSchedulerState()))),
                     ),
                   )
-                  yield* SynchronizedRef.set(stateRef, hydrateStateFromPersisted(persisted, loaded.config))
+                  const restoredState = hydrateStateFromPersisted(persisted, loaded.config)
+                  syncStateMetrics(restoredState, { leaderState: false })
+                  yield* SynchronizedRef.set(stateRef, restoredState)
 
                   yield* leaderElection.start
 
@@ -1527,6 +1680,10 @@ export const makeOrchestratorLayer = (logger: Logger) =>
 
                   const currentLeader = yield* leaderElection.status
                   yield* Ref.set(seenLeaderStateRef, currentLeader.isLeader)
+                  yield* SynchronizedRef.modifyEffect(stateRef, (state) => {
+                    syncStateMetrics(state, { leaderState: currentLeader.isLeader })
+                    return Effect.succeed([undefined, state] as const)
+                  })
                   yield* Queue.offer(queue, { _tag: 'LeaderChanged', leader: currentLeader })
 
                   yield* startSchedulers


### PR DESCRIPTION
## Summary

- add native Symphony OpenTelemetry metrics and traces across poll, reconcile, worker, codex, and HTTP flows
- add per-instance Loki collection for `symphony`, `symphony-jangar`, and `symphony-torghut` plus OTEL env wiring in the shared deployment base
- add a Symphony fleet Grafana dashboard and Mimir alert rules for leader loss, poll stalls, retry backlog, worker failures, and blocked target health

## Related Issues

None

## Testing

- `bun run --cwd packages/otel test`
- `bun run --cwd services/symphony tsc`
- `bun run --cwd services/symphony test`
- `bun run --cwd services/symphony lint`
- `bun run --cwd services/symphony lint:oxlint:type`
- `scripts/kubeconform.sh argocd/applications/observability argocd/applications/jangar argocd/applications/torghut argocd/applications/symphony-base`
- `bun --cwd services/symphony -e "import fs from 'node:fs'; import YAML from 'yaml'; const file='/Users/gregkonush/.codex/worktrees/88a8/lab/argocd/applications/observability/symphony-fleet-dashboard-configmap.yaml'; const doc=YAML.parse(fs.readFileSync(file,'utf8')); JSON.parse(doc.data['symphony-fleet-dashboard.json']); console.log('dashboard json ok')"`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
