### PR TITLE
chore(jangar): promote image 54971ed8

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 4dbea35b
-  digest: sha256:ac765c2290b0f8d4276e2dc6eda68ccc681914fcbd72edb02a6b93cb0eabd52a
+  tag: 54971ed8
+  digest: sha256:cba7eb8dd67dd3fc35be8432b13d851a02fbace07ce6dfdfbee6e857240baf52
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 4dbea35b
-    digest: sha256:a746b682ce5a378975d6ce796c5089aa20a755b4078bc35260354197414fd9dc
+    tag: 54971ed8
+    digest: sha256:aa8a50b9d6217e470ee421378f821d79a91ded3b58d05dcb4a7d87f665916fad
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 4dbea35b
-    digest: sha256:ac765c2290b0f8d4276e2dc6eda68ccc681914fcbd72edb02a6b93cb0eabd52a
+    tag: 54971ed8
+    digest: sha256:cba7eb8dd67dd3fc35be8432b13d851a02fbace07ce6dfdfbee6e857240baf52
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-16T23:53:41Z"
+    deploy.knative.dev/rollout: "2026-03-19T05:52:06Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-16T23:53:41Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-19T05:52:06Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -62,5 +62,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "4dbea35b"
-    digest: sha256:ac765c2290b0f8d4276e2dc6eda68ccc681914fcbd72edb02a6b93cb0eabd52a
+    newTag: "54971ed8"
+    digest: sha256:cba7eb8dd67dd3fc35be8432b13d851a02fbace07ce6dfdfbee6e857240baf52


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `54971ed88c9d0b8b60d6271aff064615f3f2f903`
- Image tag: `54971ed8`
- Image digest: `sha256:cba7eb8dd67dd3fc35be8432b13d851a02fbace07ce6dfdfbee6e857240baf52`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`