### PR TITLE
fix(symphony): restore release image builds

### DIFF
--- a/services/symphony/Dockerfile
+++ b/services/symphony/Dockerfile
@@ -9,6 +9,7 @@ ENV HUSKY=0
 
 COPY package.json bun.lock tsconfig.base.json ./
 COPY packages/codex/package.json ./packages/codex/package.json
+COPY packages/otel/package.json ./packages/otel/package.json
 COPY services/symphony/package.json ./services/symphony/package.json
 
 RUN --mount=type=cache,target=/root/.cache/bun \
@@ -16,10 +17,12 @@ RUN --mount=type=cache,target=/root/.cache/bun \
 
 FROM deps AS build
 COPY packages/codex ./packages/codex
+COPY packages/otel ./packages/otel
 COPY services/symphony ./services/symphony
 
-RUN bun --cwd packages/codex run build
-RUN bun --cwd services/symphony run tsc
+RUN bun run --cwd packages/codex build
+RUN bun run --cwd packages/otel build
+RUN bun run --cwd services/symphony tsc
 
 FROM oven/bun:${BUN_VERSION} AS runner
 ARG NODE_VERSION
@@ -57,12 +60,14 @@ RUN npm install -g "@openai/codex@${CODEX_VERSION}"
 
 COPY package.json bun.lock tsconfig.base.json ./
 COPY packages/codex/package.json ./packages/codex/package.json
+COPY packages/otel/package.json ./packages/otel/package.json
 COPY services/symphony/package.json ./services/symphony/package.json
 
 RUN --mount=type=cache,target=/root/.cache/bun \
   bun install --omit=dev --ignore-scripts --filter @proompteng/symphony
 
 COPY --from=build /app/packages/codex ./packages/codex
+COPY --from=build /app/packages/otel ./packages/otel
 COPY --from=build /app/services/symphony ./services/symphony
 
 WORKDIR /app/services/symphony

--- a/services/symphony/tsconfig.json
+++ b/services/symphony/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "noEmit": true,
     "strict": true,
-    "types": ["bun-types", "node"]
+    "types": ["bun", "node"]
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary

- copy the `packages/otel` workspace into the Symphony Docker dependency and runtime stages
- build `@proompteng/codex`, `@proompteng/otel`, and Symphony with the correct `bun run --cwd ...` commands during image builds
- align Symphony's TypeScript config with its declared Bun type package so filtered container installs typecheck reproducibly

## Related Issues

None

## Testing

- `bun run --cwd services/symphony tsc`
- `bun run --cwd services/symphony test`
- `docker buildx build --load -f services/symphony/Dockerfile -t symphony:observability-fix .`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
