### PR TITLE
chore(symphony): promote image 99e2c03a

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-19T04:17:25Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-19T06:19:56Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -25,5 +25,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "df213efa"
-    digest: sha256:b0738c06604f53316d89e5b88f34a6dd0f7d1d3e795e4261790b01ab3b007484
+    newTag: "99e2c03a"
+    digest: sha256:1d6cdf5384cbaf221de59914ced46031ed289877945c80c03a17295baea5c60f

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-19T04:17:25Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-19T06:19:56Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -26,5 +26,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "df213efa"
-    digest: sha256:b0738c06604f53316d89e5b88f34a6dd0f7d1d3e795e4261790b01ab3b007484
+    newTag: "99e2c03a"
+    digest: sha256:1d6cdf5384cbaf221de59914ced46031ed289877945c80c03a17295baea5c60f

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-19T04:17:25Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-19T06:19:56Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -19,5 +19,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "df213efa"
-    digest: sha256:b0738c06604f53316d89e5b88f34a6dd0f7d1d3e795e4261790b01ab3b007484
+    newTag: "99e2c03a"
+    digest: sha256:1d6cdf5384cbaf221de59914ced46031ed289877945c80c03a17295baea5c60f


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `99e2c03ac0ee67adb3bc8d5629a95b9a22f8e2b5`
- Image tag: `99e2c03a`
- Image digest: `sha256:1d6cdf5384cbaf221de59914ced46031ed289877945c80c03a17295baea5c60f`