### PR TITLE
chore(jangar): promote image 6898ae82

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 54971ed8
-  digest: sha256:cba7eb8dd67dd3fc35be8432b13d851a02fbace07ce6dfdfbee6e857240baf52
+  tag: 6898ae82
+  digest: sha256:c0a6cd795f1b5e46d2fd47b398e0475aff0058ba1c05ec09b9da28f714dfdca3
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 54971ed8
-    digest: sha256:aa8a50b9d6217e470ee421378f821d79a91ded3b58d05dcb4a7d87f665916fad
+    tag: 6898ae82
+    digest: sha256:3c94d9c9ecd3650d1c6af9cc8c15dcce3e11fc1149eac8bc90306d55de73fd07
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 54971ed8
-    digest: sha256:cba7eb8dd67dd3fc35be8432b13d851a02fbace07ce6dfdfbee6e857240baf52
+    tag: 6898ae82
+    digest: sha256:c0a6cd795f1b5e46d2fd47b398e0475aff0058ba1c05ec09b9da28f714dfdca3
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-19T05:52:06Z"
+    deploy.knative.dev/rollout: "2026-03-19T06:19:46Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-19T05:52:06Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-19T06:19:46Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -62,5 +62,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "54971ed8"
-    digest: sha256:cba7eb8dd67dd3fc35be8432b13d851a02fbace07ce6dfdfbee6e857240baf52
+    newTag: "6898ae82"
+    digest: sha256:c0a6cd795f1b5e46d2fd47b398e0475aff0058ba1c05ec09b9da28f714dfdca3


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `6898ae8204e9e605eddc818530b3cca67aec71bf`
- Image tag: `6898ae82`
- Image digest: `sha256:c0a6cd795f1b5e46d2fd47b398e0475aff0058ba1c05ec09b9da28f714dfdca3`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`