### PR TITLE
chore(symphony): promote image 15c2313b

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-19T06:19:56Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-19T06:53:43Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -25,5 +25,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "99e2c03a"
-    digest: sha256:1d6cdf5384cbaf221de59914ced46031ed289877945c80c03a17295baea5c60f
+    newTag: "15c2313b"
+    digest: sha256:c38377049790eb2e28e651f1140c466b686fb1c50eaeb66d9e77720cfccd33ad

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-19T06:19:56Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-19T06:53:43Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -26,5 +26,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "99e2c03a"
-    digest: sha256:1d6cdf5384cbaf221de59914ced46031ed289877945c80c03a17295baea5c60f
+    newTag: "15c2313b"
+    digest: sha256:c38377049790eb2e28e651f1140c466b686fb1c50eaeb66d9e77720cfccd33ad

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-19T06:19:56Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-19T06:53:43Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -19,5 +19,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "99e2c03a"
-    digest: sha256:1d6cdf5384cbaf221de59914ced46031ed289877945c80c03a17295baea5c60f
+    newTag: "15c2313b"
+    digest: sha256:c38377049790eb2e28e651f1140c466b686fb1c50eaeb66d9e77720cfccd33ad


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `15c2313bf5aeb635e22cf293f6740011ae9462f5`
- Image tag: `15c2313b`
- Image digest: `sha256:c38377049790eb2e28e651f1140c466b686fb1c50eaeb66d9e77720cfccd33ad`