### PR TITLE
fix(symphony): send traces to the Tempo distributor

### DIFF
--- a/argocd/applications/symphony-base/deployment.yaml
+++ b/argocd/applications/symphony-base/deployment.yaml
@@ -80,7 +80,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
-              value: http://observability-tempo-gateway.observability.svc.cluster.local:4318/v1/traces
+              value: http://observability-tempo-distributor.observability.svc.cluster.local:4318/v1/traces
             - name: OTEL_EXPORTER_OTLP_METRICS_ENDPOINT
               value: http://observability-mimir-nginx.observability.svc.cluster.local/otlp/v1/metrics
             - name: OTEL_EXPORTER_OTLP_TRACES_TIMEOUT

--- a/services/symphony/src/instrumentation.test.ts
+++ b/services/symphony/src/instrumentation.test.ts
@@ -97,6 +97,12 @@ afterEach(() => {
 })
 
 describe('instrumentation bindings', () => {
+  test('uses the Tempo distributor OTLP HTTP endpoint by default', () => {
+    expect(__private.getDefaultTracesEndpointForTests()).toBe(
+      'http://observability-tempo-distributor.observability.svc.cluster.local:4318/v1/traces',
+    )
+  })
+
   test('rebinds counters, gauges, and spans to the active global providers', () => {
     const meter = new FakeMeter()
     const tracer = new FakeTracer()

--- a/services/symphony/src/instrumentation.ts
+++ b/services/symphony/src/instrumentation.ts
@@ -53,7 +53,7 @@ type TelemetryState = {
   sdk?: NodeSDK
 }
 
-const DEFAULT_TRACES_ENDPOINT = 'http://observability-tempo-gateway.observability.svc.cluster.local:4318/v1/traces'
+const DEFAULT_TRACES_ENDPOINT = 'http://observability-tempo-distributor.observability.svc.cluster.local:4318/v1/traces'
 const DEFAULT_METRICS_ENDPOINT = 'http://observability-mimir-nginx.observability.svc.cluster.local/otlp/v1/metrics'
 
 const globalState = globalThis as typeof globalThis & {
@@ -389,6 +389,9 @@ export const updateRuntimeGauges = (params: {
 }
 
 export const __private = {
+  getDefaultTracesEndpointForTests() {
+    return DEFAULT_TRACES_ENDPOINT
+  },
   resetTelemetryStateForTests() {
     delete globalState.__symphonyTelemetry
   },


### PR DESCRIPTION
## Summary

- fix Symphony OTLP trace export to use Tempo distributor `:4318` instead of the non-listening gateway endpoint
- align the GitOps deployment env with the corrected in-cluster trace endpoint
- add a regression test locking the default trace endpoint to the Tempo distributor

## Related Issues

None

## Testing

- `bun test services/symphony/src/instrumentation.test.ts`
- `bun run --cwd services/symphony tsc`
- `bun run --cwd services/symphony test`
- `scripts/kubeconform.sh argocd/applications/symphony-base`
- Manual verification before fix: `kubectl logs -n jangar deploy/symphony --since=15m | rg "observability-tempo-gateway.*4318|trace export failed"`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
