### PR TITLE
chore(symphony): promote image 932cb557

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-19T06:53:43Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-19T07:05:38Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -25,5 +25,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "15c2313b"
-    digest: sha256:c38377049790eb2e28e651f1140c466b686fb1c50eaeb66d9e77720cfccd33ad
+    newTag: "932cb557"
+    digest: sha256:be6593a37b2cb8f3162ea98a890dbd640c261a86b18299e771e86f774ed35387

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-19T06:53:43Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-19T07:05:38Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -26,5 +26,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "15c2313b"
-    digest: sha256:c38377049790eb2e28e651f1140c466b686fb1c50eaeb66d9e77720cfccd33ad
+    newTag: "932cb557"
+    digest: sha256:be6593a37b2cb8f3162ea98a890dbd640c261a86b18299e771e86f774ed35387

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-19T06:53:43Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-19T07:05:38Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -19,5 +19,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "15c2313b"
-    digest: sha256:c38377049790eb2e28e651f1140c466b686fb1c50eaeb66d9e77720cfccd33ad
+    newTag: "932cb557"
+    digest: sha256:be6593a37b2cb8f3162ea98a890dbd640c261a86b18299e771e86f774ed35387


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `932cb5571f28134e605ef4351307f375eb994614`
- Image tag: `932cb557`
- Image digest: `sha256:be6593a37b2cb8f3162ea98a890dbd640c261a86b18299e771e86f774ed35387`