### PR TITLE
chore(symphony): promote image a3554c45

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-19T07:05:38Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-19T07:20:26Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -25,5 +25,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "932cb557"
-    digest: sha256:be6593a37b2cb8f3162ea98a890dbd640c261a86b18299e771e86f774ed35387
+    newTag: "a3554c45"
+    digest: sha256:5b220f72e59e216ca07ff8d2b0802799e52c92939d0c1df159cc34bae894cd13

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-19T07:05:38Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-19T07:20:26Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -27,5 +27,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "932cb557"
-    digest: sha256:be6593a37b2cb8f3162ea98a890dbd640c261a86b18299e771e86f774ed35387
+    newTag: "a3554c45"
+    digest: sha256:5b220f72e59e216ca07ff8d2b0802799e52c92939d0c1df159cc34bae894cd13

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-19T07:05:38Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-19T07:20:26Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -20,5 +20,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "932cb557"
-    digest: sha256:be6593a37b2cb8f3162ea98a890dbd640c261a86b18299e771e86f774ed35387
+    newTag: "a3554c45"
+    digest: sha256:5b220f72e59e216ca07ff8d2b0802799e52c92939d0c1df159cc34bae894cd13


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `a3554c450ee8b22fb35398f834fd8400e8372914`
- Image tag: `a3554c45`
- Image digest: `sha256:5b220f72e59e216ca07ff8d2b0802799e52c92939d0c1df159cc34bae894cd13`