### PR TITLE
chore(jangar): promote image a3554c45

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 6898ae82
-  digest: sha256:c0a6cd795f1b5e46d2fd47b398e0475aff0058ba1c05ec09b9da28f714dfdca3
+  tag: a3554c45
+  digest: sha256:34884662ff5269d4af0b20148fbecd077ceed5ee806be4082fe8959e7437bd8e
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 6898ae82
-    digest: sha256:3c94d9c9ecd3650d1c6af9cc8c15dcce3e11fc1149eac8bc90306d55de73fd07
+    tag: a3554c45
+    digest: sha256:2bc4a507ce5233b56999b5bfae8c68909eaa91e7ea11edf55a280e952fe9c007
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 6898ae82
-    digest: sha256:c0a6cd795f1b5e46d2fd47b398e0475aff0058ba1c05ec09b9da28f714dfdca3
+    tag: a3554c45
+    digest: sha256:34884662ff5269d4af0b20148fbecd077ceed5ee806be4082fe8959e7437bd8e
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-19T06:19:46Z"
+    deploy.knative.dev/rollout: "2026-03-19T07:22:21Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-19T06:19:46Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-19T07:22:21Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -62,5 +62,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "6898ae82"
-    digest: sha256:c0a6cd795f1b5e46d2fd47b398e0475aff0058ba1c05ec09b9da28f714dfdca3
+    newTag: "a3554c45"
+    digest: sha256:34884662ff5269d4af0b20148fbecd077ceed5ee806be4082fe8959e7437bd8e


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `a3554c450ee8b22fb35398f834fd8400e8372914`
- Image tag: `a3554c45`
- Image digest: `sha256:34884662ff5269d4af0b20148fbecd077ceed5ee806be4082fe8959e7437bd8e`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`