### PR TITLE
chore(symphony): promote image d262f847

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-19T07:20:26Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-19T07:51:47Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -25,5 +25,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "a3554c45"
-    digest: sha256:5b220f72e59e216ca07ff8d2b0802799e52c92939d0c1df159cc34bae894cd13
+    newTag: "d262f847"
+    digest: sha256:4c371b72aac8f98088807feddfc3b833b0e1924c581c5bf826b7fe57923ba558

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-19T07:20:26Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-19T07:51:47Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -27,5 +27,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "a3554c45"
-    digest: sha256:5b220f72e59e216ca07ff8d2b0802799e52c92939d0c1df159cc34bae894cd13
+    newTag: "d262f847"
+    digest: sha256:4c371b72aac8f98088807feddfc3b833b0e1924c581c5bf826b7fe57923ba558

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-19T07:20:26Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-19T07:51:47Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -20,5 +20,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "a3554c45"
-    digest: sha256:5b220f72e59e216ca07ff8d2b0802799e52c92939d0c1df159cc34bae894cd13
+    newTag: "d262f847"
+    digest: sha256:4c371b72aac8f98088807feddfc3b833b0e1924c581c5bf826b7fe57923ba558


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `d262f8471b7f915bb1f6cc7065230b0f5fb05079`
- Image tag: `d262f847`
- Image digest: `sha256:4c371b72aac8f98088807feddfc3b833b0e1924c581c5bf826b7fe57923ba558`