### PR TITLE
fix(jangar): retry transient temporal sync errors

### DIFF
--- a/packages/scripts/src/jangar/__tests__/sync-temporal-routing.test.ts
+++ b/packages/scripts/src/jangar/__tests__/sync-temporal-routing.test.ts
@@ -1,6 +1,14 @@
-import { describe, expect, it } from 'bun:test'
+import { afterEach, describe, expect, it } from 'bun:test'
 
 import { __private } from '../sync-temporal-routing'
+
+const originalSpawn = Bun.spawn
+const originalSleep = Bun.sleep
+
+afterEach(() => {
+  Bun.spawn = originalSpawn
+  Bun.sleep = originalSleep
+})
 
 describe('sync-temporal-routing', () => {
   it('parses boolean and value args', () => {
@@ -61,5 +69,77 @@ describe('sync-temporal-routing', () => {
   it('strips deployment prefix from poller build ID', () => {
     expect(__private.stripDeploymentPrefix('jangar-deployment:jangar@dev', 'jangar-deployment')).toBe('jangar@dev')
     expect(__private.stripDeploymentPrefix('UNVERSIONED', 'jangar-deployment')).toBeUndefined()
+  })
+
+  it('classifies transient temporal connectivity failures', () => {
+    expect(__private.isTransientTemporalConnectivityError('failed reaching server: context deadline exceeded')).toBe(
+      true,
+    )
+    expect(__private.isTransientTemporalConnectivityError('rpc error: code = unavailable')).toBe(true)
+    expect(__private.isTransientTemporalConnectivityError('unknown namespace')).toBe(false)
+  })
+
+  it('retries transient temporal failures before succeeding', async () => {
+    const sleepCalls: number[] = []
+    Bun.sleep = (async (ms: number) => {
+      sleepCalls.push(ms)
+    }) as typeof Bun.sleep
+
+    let spawnCount = 0
+    Bun.spawn = ((..._args: Parameters<typeof Bun.spawn>) => {
+      spawnCount += 1
+      if (spawnCount === 1) {
+        return {
+          stdout: new Blob(['']).stream(),
+          stderr: new Blob(['failed reaching server: context deadline exceeded']).stream(),
+          exited: Promise.resolve(1),
+        } as unknown as ReturnType<typeof Bun.spawn>
+      }
+
+      return {
+        stdout: new Blob(['{"count":0}']).stream(),
+        stderr: new Blob(['']).stream(),
+        exited: Promise.resolve(0),
+      } as unknown as ReturnType<typeof Bun.spawn>
+    }) as typeof Bun.spawn
+
+    const result = await __private.runTemporal({ address: 'temporal.example:7233', namespace: 'default' }, [
+      'workflow',
+      'count',
+      '--query',
+      'TaskQueue="jangar"',
+      '-o',
+      'json',
+    ])
+
+    expect(spawnCount).toBe(2)
+    expect(sleepCalls).toEqual([__private.getTemporalRetryDelayMs(1)])
+    expect(result.stdout).toBe('{"count":0}')
+  })
+
+  it('does not retry non-transient temporal failures', async () => {
+    let spawnCount = 0
+    Bun.spawn = ((..._args: Parameters<typeof Bun.spawn>) => {
+      spawnCount += 1
+      return {
+        stdout: new Blob(['']).stream(),
+        stderr: new Blob(['namespace not found']).stream(),
+        exited: Promise.resolve(1),
+      } as unknown as ReturnType<typeof Bun.spawn>
+    }) as typeof Bun.spawn
+
+    await expect(
+      __private.runTemporal({ address: 'temporal.example:7233', namespace: 'default' }, [
+        'worker',
+        'deployment',
+        'describe',
+        '--name',
+        'jangar-deployment',
+        '-o',
+        'json',
+      ]),
+    ).rejects.toThrow(/namespace not found/)
+
+    expect(spawnCount).toBe(1)
   })
 })

--- a/packages/scripts/src/jangar/sync-temporal-routing.ts
+++ b/packages/scripts/src/jangar/sync-temporal-routing.ts
@@ -65,6 +65,35 @@ const defaultTaskQueue = 'jangar'
 const defaultReason = 'post-deploy temporal routing sync'
 const defaultBatchRetryDelayMs = 5_000
 const defaultBatchRetryAttempts = 5
+const defaultTemporalRetryDelayMs = 2_000
+const defaultTemporalRetryAttempts = 5
+const defaultTemporalRetryMaxDelayMs = 10_000
+
+const transientTemporalErrorPatterns = [
+  /context deadline exceeded/,
+  /deadline exceeded/,
+  /\bunavailable\b/,
+  /connection refused/,
+  /connection reset by peer/,
+  /connection reset/,
+  /broken pipe/,
+  /transport is closing/,
+  /server temporarily unavailable/,
+  /i\/o timeout/,
+  /\beof\b/,
+]
+
+const normalizeTemporalErrorMessage = (message: string): string => message.trim().toLowerCase().replace(/\s+/g, ' ')
+
+const isTransientTemporalConnectivityError = (message: string): boolean => {
+  const normalized = normalizeTemporalErrorMessage(message)
+  return transientTemporalErrorPatterns.some((pattern) => pattern.test(normalized))
+}
+
+const getTemporalRetryDelayMs = (attempt: number): number => {
+  const backoff = defaultTemporalRetryDelayMs * 2 ** Math.max(attempt - 1, 0)
+  return Math.min(backoff, defaultTemporalRetryMaxDelayMs)
+}
 
 const parseArgs = (argv: string[]): CliOptions => {
   const options: CliOptions = {}
@@ -158,22 +187,51 @@ const runTemporal = async (
   args: string[],
   allowFailure = false,
 ): Promise<CommandResult> => {
-  const subprocess = Bun.spawn(['temporal', '--address', options.address, '--namespace', options.namespace, ...args], {
-    stdout: 'pipe',
-    stderr: 'pipe',
-  })
+  let lastError: Error | undefined
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    subprocess.stdout ? new Response(subprocess.stdout).text() : Promise.resolve(''),
-    subprocess.stderr ? new Response(subprocess.stderr).text() : Promise.resolve(''),
-    subprocess.exited,
-  ])
+  for (let attempt = 1; attempt <= defaultTemporalRetryAttempts; attempt += 1) {
+    const subprocess = Bun.spawn(
+      ['temporal', '--address', options.address, '--namespace', options.namespace, ...args],
+      {
+        stdout: 'pipe',
+        stderr: 'pipe',
+      },
+    )
 
-  if (exitCode !== 0 && !allowFailure) {
-    throw new Error(`Command failed (${exitCode}): temporal ${args.join(' ')}\n${stderr || stdout}`.trim())
+    const [stdout, stderr, exitCode] = await Promise.all([
+      subprocess.stdout ? new Response(subprocess.stdout).text() : Promise.resolve(''),
+      subprocess.stderr ? new Response(subprocess.stderr).text() : Promise.resolve(''),
+      subprocess.exited,
+    ])
+
+    if (exitCode === 0) {
+      return { stdout, stderr, exitCode }
+    }
+
+    const failureMessage = `Command failed (${exitCode}): temporal ${args.join(' ')}\n${stderr || stdout}`.trim()
+    lastError = new Error(failureMessage)
+
+    if (allowFailure || attempt === defaultTemporalRetryAttempts) {
+      break
+    }
+
+    const transientErrorSource = stderr || stdout || failureMessage
+    if (!isTransientTemporalConnectivityError(transientErrorSource)) {
+      break
+    }
+
+    const delayMs = getTemporalRetryDelayMs(attempt)
+    console.log(
+      `Temporal CLI transient failure (attempt ${attempt}/${defaultTemporalRetryAttempts}); retrying in ${delayMs}ms`,
+    )
+    await Bun.sleep(delayMs)
   }
 
-  return { stdout, stderr, exitCode }
+  if (lastError) {
+    throw lastError
+  }
+
+  throw new Error(`Command failed: temporal ${args.join(' ')}`)
 }
 
 const parseJson = <T>(json: string, label: string): T => {
@@ -415,6 +473,9 @@ if (import.meta.main) {
 
 export const __private = {
   parseArgs,
+  getTemporalRetryDelayMs,
+  isTransientTemporalConnectivityError,
+  runTemporal,
   stripDeploymentPrefix,
   extractVersionedPollerBuildIds,
   selectTargetBuildId,


### PR DESCRIPTION
## Summary

- add bounded retry with exponential backoff around Temporal CLI calls in `sync-temporal-routing.ts`
- retry only clearly transient transport failures such as `context deadline exceeded`, `unavailable`, and connection resets
- add regression tests covering transient classification, retry-on-success, and fail-fast on non-transient errors

## Related Issues

None

## Testing

- `bun test packages/scripts/src/jangar/__tests__/sync-temporal-routing.test.ts`
- `bunx oxfmt --check packages/scripts/src/jangar/sync-temporal-routing.ts packages/scripts/src/jangar/__tests__/sync-temporal-routing.test.ts`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
