### PR TITLE
fix(posthog): add capture ingress service

### DIFF
--- a/argocd/applications/kafka/strimzi-kafka-cluster.yaml
+++ b/argocd/applications/kafka/strimzi-kafka-cluster.yaml
@@ -21,6 +21,10 @@ spec:
         port: 9093
         type: internal
         tls: false
+      - name: posthog-ingest
+        port: 9094
+        type: internal
+        tls: true
     config:
       offsets.topic.replication.factor: 3
       transaction.state.log.replication.factor: 3

--- a/argocd/applications/posthog/deployment-posthog-capture.yaml
+++ b/argocd/applications/posthog/deployment-posthog-capture.yaml
@@ -1,0 +1,69 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: posthog-capture
+  labels:
+    "app.kubernetes.io/name": "posthog"
+    "app.kubernetes.io/instance": "posthog"
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  selector:
+    matchLabels:
+      app: posthog
+      release: "posthog"
+      role: capture
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: posthog
+        release: "posthog"
+        role: capture
+    spec:
+      nodeSelector:
+        kubernetes.io/arch: amd64
+      serviceAccountName: posthog
+      containers:
+        - name: posthog-capture
+          image: "ghcr.io/posthog/posthog/capture:master@sha256:1f15311fde70602f567d1b9ef85b71467ee3d3e031cdb671ada9befbd2a929a6"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 3000
+              protocol: TCP
+          env:
+            - name: ADDRESS
+              value: "0.0.0.0:3000"
+            - name: KAFKA_HOSTS
+              value: "kafka-kafka-bootstrap.kafka.svc.cluster.local:9094"
+            - name: KAFKA_TLS
+              value: "true"
+            - name: KAFKA_TOPIC
+              value: "events_plugin_ingestion"
+            - name: REDIS_URL
+              value: "redis://posthog-redis.posthog.svc.cluster.local:6379/"
+            - name: CAPTURE_MODE
+              value: "events"
+            - name: RUST_LOG
+              value: "info,rdkafka=warn"
+          readinessProbe:
+            httpGet:
+              path: /_readiness
+              port: 3000
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+            successThreshold: 1
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /_liveness
+              port: 3000
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 3
+            successThreshold: 1
+            failureThreshold: 6
+          resources: {}

--- a/argocd/applications/posthog/ingressroute-posthog.yaml
+++ b/argocd/applications/posthog/ingressroute-posthog.yaml
@@ -12,6 +12,12 @@ spec:
     - websecure
   routes:
     - kind: Rule
+      priority: 100
+      match: Host(`posthog.proompteng.ai`) && (PathPrefix(`/batch`) || PathPrefix(`/e`) || PathPrefix(`/i/v0`) || PathPrefix(`/capture`))
+      services:
+        - name: posthog-capture
+          port: 3000
+    - kind: Rule
       match: Host(`posthog.proompteng.ai`)
       services:
         - name: posthog-web

--- a/argocd/applications/posthog/kustomization.yaml
+++ b/argocd/applications/posthog/kustomization.yaml
@@ -11,10 +11,12 @@ resources:
   - pooler-posthog-db.yaml
   - serviceaccount-posthog.yaml
   - secret-posthog.yaml
+  - service-posthog-capture.yaml
   - service-posthog-events.yaml
   - service-posthog-web.yaml
   - service-ingestion-cdp-api.yaml
   - ingressroute-posthog.yaml
+  - deployment-posthog-capture.yaml
   - deployment-posthog-events.yaml
   - deployment-posthog-plugins.yaml
   - deployment-posthog-web.yaml

--- a/argocd/applications/posthog/service-posthog-capture.yaml
+++ b/argocd/applications/posthog/service-posthog-capture.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: posthog-capture
+  labels:
+    "app.kubernetes.io/name": "posthog"
+    "app.kubernetes.io/instance": "posthog"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 3000
+      targetPort: 3000
+      protocol: TCP
+      name: capture
+  selector:
+    app: posthog
+    role: capture


### PR DESCRIPTION
## Summary

- add a dedicated internal Kafka listener for PostHog ingest traffic
- add a new `posthog-capture` deployment and service in the `posthog` namespace
- route ingest paths on `posthog.proompteng.ai` to `posthog-capture` while leaving UI traffic on `posthog-web`

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/kafka`
- `kubectl kustomize argocd/applications/posthog`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
