### PR TITLE
fix(symphony): send posthog events to capture service

### DIFF
--- a/argocd/applications/symphony-base/deployment.yaml
+++ b/argocd/applications/symphony-base/deployment.yaml
@@ -66,7 +66,7 @@ spec:
             - name: POSTHOG_ENABLED
               value: "true"
             - name: POSTHOG_HOST
-              value: http://posthog-events.posthog.svc.cluster.local:8000
+              value: http://posthog-capture.posthog.svc.cluster.local:3000
             - name: POSTHOG_API_KEY
               valueFrom:
                 secretKeyRef:

--- a/services/symphony/src/config.test.ts
+++ b/services/symphony/src/config.test.ts
@@ -112,7 +112,7 @@ describe('config normalization', () => {
       {
         LINEAR_API_KEY: 'token',
         POSTHOG_ENABLED: 'true',
-        POSTHOG_HOST: 'http://posthog-events.posthog.svc.cluster.local:8000',
+        POSTHOG_HOST: 'http://posthog-capture.posthog.svc.cluster.local:3000',
         POSTHOG_API_KEY: 'phc_demo',
         POSTHOG_PROJECT_ID: '1',
         POSTHOG_DISTINCT_ID: 'symphony:test',
@@ -124,7 +124,7 @@ describe('config normalization', () => {
 
     expect(config.posthog).toEqual({
       enabled: true,
-      host: 'http://posthog-events.posthog.svc.cluster.local:8000',
+      host: 'http://posthog-capture.posthog.svc.cluster.local:3000',
       apiKey: 'phc_demo',
       projectId: '1',
       distinctId: 'symphony:test',

--- a/services/symphony/src/config.ts
+++ b/services/symphony/src/config.ts
@@ -21,7 +21,7 @@ const DEFAULT_LINEAR_ENDPOINT = 'https://api.linear.app/graphql'
 const DEFAULT_ACTIVE_STATES = ['Todo', 'In Progress']
 const DEFAULT_TERMINAL_STATES = ['Closed', 'Cancelled', 'Canceled', 'Duplicate', 'Done']
 const DEFAULT_BLOCKED_LABELS = ['manual-only', 'secret-rotation', 'cluster-recovery', 'cross-repo', 'db-migration']
-const DEFAULT_POSTHOG_HOST = 'http://posthog-events.posthog.svc.cluster.local:8000'
+const DEFAULT_POSTHOG_HOST = 'http://posthog-capture.posthog.svc.cluster.local:3000'
 
 const RawSectionSchema = Schema.Struct({
   tracker: Schema.optionalWith(

--- a/services/symphony/src/orchestrator.ts
+++ b/services/symphony/src/orchestrator.ts
@@ -2214,7 +2214,7 @@ export const makeOrchestratorLayer = (logger: Logger) =>
                   },
                   posthog: {
                     enabled: false,
-                    host: 'http://posthog-events.posthog.svc.cluster.local:8000',
+                    host: 'http://posthog-capture.posthog.svc.cluster.local:3000',
                     apiKey: null,
                     projectId: null,
                     distinctId: 'symphony:symphony',

--- a/services/symphony/src/test-fixtures.ts
+++ b/services/symphony/src/test-fixtures.ts
@@ -72,7 +72,7 @@ export const makeTestConfig = (overrides: SymphonyConfigOverrides = {}): Symphon
   },
   posthog: {
     enabled: overrides.posthog?.enabled ?? false,
-    host: overrides.posthog?.host ?? 'http://posthog-events.posthog.svc.cluster.local:8000',
+    host: overrides.posthog?.host ?? 'http://posthog-capture.posthog.svc.cluster.local:3000',
     apiKey: overrides.posthog?.apiKey ?? null,
     projectId: overrides.posthog?.projectId ?? null,
     distinctId: overrides.posthog?.distinctId ?? 'symphony:symphony',
@@ -235,7 +235,7 @@ export const makeTestSnapshot = (): RuntimeSnapshot => ({
   },
   telemetry: {
     enabled: true,
-    host: 'http://posthog-events.posthog.svc.cluster.local:8000',
+    host: 'http://posthog-capture.posthog.svc.cluster.local:3000',
     projectId: '1',
     distinctId: 'symphony:symphony',
     lastError: null,


### PR DESCRIPTION
## Summary

- point Symphony's default PostHog host at the new `posthog-capture` service in the `posthog` namespace
- update Symphony config tests and fixtures to match the capture-service ingest path
- keep the existing LLM analytics event model unchanged while cutting all base-derived Symphony deployments over

## Related Issues

None

## Testing

- kubectl kustomize argocd/applications/symphony
- bun run --cwd services/symphony tsc
- bun run --cwd services/symphony test
- bun run --cwd services/symphony lint

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
