### PR TITLE
fix(ci): keep temporal-bun publish green after npm release

### DIFF
--- a/.github/workflows/temporal-bun-sdk.yml
+++ b/.github/workflows/temporal-bun-sdk.yml
@@ -226,6 +226,8 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      issues: write
+      pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -322,8 +324,11 @@ jobs:
           branch="release-please--branches--main--components--temporal-bun-sdk"
           pr_number=$(gh pr list --head "$branch" --state merged --limit 1 --json number --jq '.[0].number')
           if [[ -n "$pr_number" ]]; then
-            gh pr edit "$pr_number" --remove-label "autorelease: pending" --add-label "autorelease: tagged"
-            echo "Updated labels on release PR #$pr_number"
+            if gh pr edit "$pr_number" --remove-label "autorelease: pending" --add-label "autorelease: tagged"; then
+              echo "Updated labels on release PR #$pr_number"
+            else
+              echo "::warning::Failed to update labels on release PR #$pr_number"
+            fi
           else
             echo "No merged release PR found for $branch; skipping label update"
           fi


### PR DESCRIPTION
## Summary

- grant the Temporal Bun SDK publish job the permissions needed to update release PR labels
- make the post-publish release PR label update emit a warning instead of failing the whole workflow
- keep successful npm publishes green even if the cosmetic label mutation cannot run

## Related Issues

None

## Testing

- `python3 - <<'PY'
import yaml
from pathlib import Path
with Path('.github/workflows/temporal-bun-sdk.yml').open() as f:
    yaml.safe_load(f)
print('yaml-ok')
PY`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
