### PR TITLE
fix(kafka): shorten posthog listener name

### DIFF
--- a/argocd/applications/kafka/strimzi-kafka-cluster.yaml
+++ b/argocd/applications/kafka/strimzi-kafka-cluster.yaml
@@ -21,7 +21,7 @@ spec:
         port: 9093
         type: internal
         tls: false
-      - name: posthog-ingest
+      - name: phingest
         port: 9094
         type: internal
         tls: true


### PR DESCRIPTION
## Summary

- rename the PostHog Kafka listener from `posthog-ingest` to `phingest`
- keep the existing 9094 TLS listener configuration unchanged
- make the GitOps manifest match the live Strimzi hotfix used to complete the rollout

## Related Issues

None

## Testing

- mise exec helm@3 -- kustomize build --enable-helm argocd/applications/kafka

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
