### PR TITLE
chore(symphony): promote image a736dfa8

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-19T07:51:47Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-19T09:50:35Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -25,5 +25,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "d262f847"
-    digest: sha256:4c371b72aac8f98088807feddfc3b833b0e1924c581c5bf826b7fe57923ba558
+    newTag: "a736dfa8"
+    digest: sha256:d98f54027e130dac7c847efa6a74be0f7a9f5e27c0f8c5ef951fd48acf1b31a1

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-19T07:51:47Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-19T09:50:35Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -27,5 +27,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "d262f847"
-    digest: sha256:4c371b72aac8f98088807feddfc3b833b0e1924c581c5bf826b7fe57923ba558
+    newTag: "a736dfa8"
+    digest: sha256:d98f54027e130dac7c847efa6a74be0f7a9f5e27c0f8c5ef951fd48acf1b31a1

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-19T07:51:47Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-19T09:50:35Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -20,5 +20,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "d262f847"
-    digest: sha256:4c371b72aac8f98088807feddfc3b833b0e1924c581c5bf826b7fe57923ba558
+    newTag: "a736dfa8"
+    digest: sha256:d98f54027e130dac7c847efa6a74be0f7a9f5e27c0f8c5ef951fd48acf1b31a1


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `a736dfa89290a9bd6c07a0c3bdeff7d025d1ad86`
- Image tag: `a736dfa8`
- Image digest: `sha256:d98f54027e130dac7c847efa6a74be0f7a9f5e27c0f8c5ef951fd48acf1b31a1`