### PR TITLE
docs: add bilig deployment contract docs

### DIFF
--- a/docs/bilig-deployment-contract.md
+++ b/docs/bilig-deployment-contract.md
@@ -1,0 +1,26 @@
+# `bilig` Deployment Contract
+
+## Scope
+
+`lab` owns the deployment contract for `bilig` runtime environments.
+
+## Required deployment surfaces
+
+- `bilig-web`
+- `bilig-sync`
+- supporting stateful dependencies required by the active product milestone
+
+## Runtime assumptions imported from `bilig`
+
+- Top 100 formula milestone is the active product milestone
+- WASM binary size and frontend bundle size are release-gated
+- workbook metadata needed by formulas must be preserved across runtime boundaries
+- volatile/runtime context required by the formula engine must be injectable by the deployed runtime
+
+## Explicit non-scope
+
+- formula semantics
+- parser behavior
+- compatibility registry content
+
+Those remain owned by `bilig`.

--- a/docs/bilig-observability-contract.md
+++ b/docs/bilig-observability-contract.md
@@ -1,0 +1,27 @@
+# `bilig` Observability Contract
+
+## Required signals
+
+- release SHA
+- app version
+- WASM binary version
+- formula execution metrics:
+  - JS oracle validations
+  - WASM shadow runs
+  - WASM production runs
+- formula error rates by visible Excel error family
+- recalc latency
+- browser/runtime startup latency
+
+## Top 100-specific requirement
+
+Observability must let operators answer:
+
+- which formula families are running in WASM production mode
+- whether a promoted family is still falling back unexpectedly
+- whether a rollout regressed formula latency or error rates
+
+## Ownership split
+
+- metric semantics originate in `bilig`
+- collection, routing, dashboards, and alerts are owned by `lab`

--- a/docs/bilig-rollout-gates.md
+++ b/docs/bilig-rollout-gates.md
@@ -1,0 +1,23 @@
+# `bilig` Rollout Gates
+
+## Gate set
+
+- image build succeeds
+- application health checks pass
+- product browser acceptance remains green
+- formula acceptance remains green on the shipping SHA
+- release size budgets remain inside the declared ceiling
+- no rollout proceeds on a SHA with open formula acceptance regressions
+
+## Top 100-specific rule
+
+If a formula family is promoted to WASM production mode in `bilig`, rollout must use the same SHA for:
+
+- product app
+- sync/runtime services
+- observability labels and dashboards
+
+## Ownership
+
+- `bilig` defines product acceptance
+- `lab` enforces rollout progression and rollback policy


### PR DESCRIPTION
## Summary
- add downstream bilig deployment contract docs
- add rollout gates doc
- add observability contract doc

## Notes
- generated alongside the bilig Top 100 parity/doc tranche
- main is PR-protected, so this is the review path for the infra-side docs