### PR TITLE
docs(agents): add March 19 control-plane architecture contracts

### DIFF
--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -17,6 +17,9 @@ clear entrypoints, clear “source of truth”, and a complete catalog of relate
 - How to install/upgrade/debug (ops): `runbooks.md`
 - Fast Jangar/Torghut live analysis workflow: `designs/jangar-torghut-live-analysis-playbook.md`
 - Autonomous Jangar/Torghut production system design: `designs/autonomous-jangar-torghut-production-system.md`
+- Current Jangar/Torghut architecture contracts:
+  - `designs/49-jangar-control-plane-authority-ledger-and-expiry-watchdog-2026-03-19.md`
+  - `designs/50-torghut-hypothesis-capital-governor-and-data-quorum-2026-03-19.md`
 - Security baseline: `threat-model.md`
 - RBAC requirements: `rbac-matrix.md`
 - Production bar (non-negotiables): `production-readiness-design.md`
@@ -158,6 +161,8 @@ For env and gRPC source-of-truth changes in this branch:
 - [designs/jangar-authoritative-controller-heartbeat-and-dependency-quorum-2026-03-08.md](designs/jangar-authoritative-controller-heartbeat-and-dependency-quorum-2026-03-08.md)
 - [designs/jangar-control-plane-admission-quorum-and-rollout-circuit-breaker-2026-03-06.md](designs/jangar-control-plane-admission-quorum-and-rollout-circuit-breaker-2026-03-06.md)
 - [designs/jangar-control-plane-provider-capacity-arbitration-and-template-run-truth-2026-03-14.md](designs/jangar-control-plane-provider-capacity-arbitration-and-template-run-truth-2026-03-14.md)
+- [designs/49-jangar-control-plane-authority-ledger-and-expiry-watchdog-2026-03-19.md](designs/49-jangar-control-plane-authority-ledger-and-expiry-watchdog-2026-03-19.md)
+- [designs/50-torghut-hypothesis-capital-governor-and-data-quorum-2026-03-19.md](designs/50-torghut-hypothesis-capital-governor-and-data-quorum-2026-03-19.md)
 - [designs/controller-finalizer-conventions.md](designs/controller-finalizer-conventions.md)
 - [designs/controller-kubectl-version-compat.md](designs/controller-kubectl-version-compat.md)
 - [designs/controller-namespace-scope-parse-validate.md](designs/controller-namespace-scope-parse-validate.md)

--- a/docs/agents/designs/49-jangar-control-plane-authority-ledger-and-expiry-watchdog-2026-03-19.md
+++ b/docs/agents/designs/49-jangar-control-plane-authority-ledger-and-expiry-watchdog-2026-03-19.md
@@ -1,0 +1,283 @@
+# 49. Jangar Control-Plane Authority Ledger and Expiry Watchdog (2026-03-19)
+
+Status: Ready for merge (discover architecture lane)
+Date: `2026-03-19`
+Owner: Victor Chen (Jangar Engineering Architecture)
+Related mission: `codex/swarm-jangar-control-plane-discover`
+Swarm: `jangar-control-plane`
+Supersedes/extends:
+
+- `44-jangar-control-plane-segmented-failure-domain-and-safe-rollout-contract-2026-03-16.md`
+- `47-jangar-control-plane-resilience-and-torghut-profitability-architecture-2026-03-16.md`
+- `48-jangar-control-plane-resilience-and-torghut-profitability-implementation-contract-2026-03-16.md`
+
+## Executive summary
+
+Jangar currently exposes a control-plane truth gap:
+
+- the swarm object is still `Frozen` on `2026-03-19` even though `status.freeze.until` expired on `2026-03-11`,
+- the service-level `/ready` and `/api/agents/control-plane/status` endpoints still report healthy rollout/database state,
+- `execution_trust` remains absent from live status because it is disabled by default,
+- operator RBAC is not broad enough to assume ad hoc cluster inspection will always fill the gap.
+
+The architecture change in this document is to make rollout safety depend on an **Authority Ledger** rather than a loose mix of deployment rollout health, stale `Swarm.status.phase`, and optional trust wiring. The ledger becomes the single control-plane source of truth for stage freshness, freeze expiry, schedule authority, and safe canary progression.
+
+## Assessment snapshot
+
+### Cluster health, rollout, and events
+
+Fresh evidence captured during this discover run:
+
+- `kubectl get swarm -n agents jangar-control-plane -o jsonpath='{.status.phase}|{.status.freeze.reason}|{.status.requirements.pending}|{.status.statusUpdatedAt}|{.status.conditions[?(@.type=="Ready")].status}'`
+  - returned `Frozen|StageStaleness|5||False`
+- `kubectl get swarm -n agents jangar-control-plane -o yaml`
+  - `status.freeze.until: 2026-03-11T16:36:12.630Z`
+  - `status.updatedAt: 2026-03-11T15:48:11.742Z`
+  - all stage last-run timestamps still anchored on `2026-03-08`
+  - result: the freeze TTL is expired, but the swarm still presents as frozen/stale
+- `curl -fsS http://jangar.jangar.svc.cluster.local/ready`
+  - returned `{"status":"ok", ...}`
+- `curl -fsS http://jangar.jangar.svc.cluster.local/api/agents/control-plane/status | jq '{database,watch_reliability,agentrun_ingestion,rollout_health,has_execution_trust:(has("execution_trust"))}'`
+  - database healthy, rollout health healthy, watch reliability healthy, `agentrun_ingestion.status = "unknown"`, `has_execution_trust = false`
+- `kubectl get events -A --field-selector type=Warning --sort-by='.lastTimestamp' | tail -n 80`
+  - still shows active warning churn in adjacent workloads, especially Torghut readiness failures and restart loops
+
+### Source architecture and test gaps
+
+Current source surfaces already contain the raw ingredients for stronger control, but they are not yet authoritative:
+
+- `services/jangar/src/server/control-plane-status.ts`
+  - live default is `DEFAULT_EXECUTION_TRUST_ENABLED = false`
+  - rollout health, watch reliability, migration consistency, and stage-derived trust exist, but the trust surface is optional
+- `services/jangar/src/server/control-plane-watch-reliability.ts`
+  - watch evidence is still maintained in a process-local map, which means restart/split-topology behavior can erase the same evidence that should keep rollout blocked
+- `services/jangar/src/routes/ready.tsx`
+  - readiness only blocks on execution trust when execution trust is enabled
+- `services/jangar/src/server/control-plane-heartbeat-publisher.ts`
+  - heartbeats already exist, but they are not yet the sole authority for stage freshness and freeze clearance
+- `services/jangar/src/server/orchestration-controller.ts`
+  - rollout metadata is emitted, but there is no immutable authority log for block/clear transitions
+- `services/jangar/src/server/supporting-primitives-controller.ts` and `services/jangar/src/server/orchestration-controller.ts`
+  - still compute freeze/policy behavior locally rather than consuming one authoritative trust contract
+
+Coverage gaps that still matter:
+
+- no regression proving an expired `freeze.until` cannot leave the swarm effectively frozen forever
+- no end-to-end test tying `Swarm.status.phase`, stage cadence freshness, and canary progression to one deterministic decision surface
+- no evidence-bundle contract proving which source overruled which when rollout remains blocked
+
+### Database / data continuity assessment
+
+Live control-plane reads show the Jangar database itself is healthy:
+
+- `/api/agents/control-plane/status`
+  - `database.connected = true`
+  - `latency_ms = 7`
+  - `migration_consistency.applied_count = 24`
+  - `migration_consistency.unapplied_count = 0`
+- direct read-only Postgres checks against `jangar-db-app`
+  - `torghut_symbols = 12`
+  - `torghut_market_context_snapshots.max(updated_at) = 2026-03-16T19:37:55.367Z`
+  - `torghut_market_context_dispatch_state.count = 0`
+  - `torghut_control_plane.simulation_runs.max(updated_at) = 2026-03-19T10:08:32.162Z`
+  - `torghut_control_plane.simulation_lane_leases.max(last_heartbeat_at) = 2026-03-19T10:08:32.191Z`
+
+The database issue is therefore not core storage health. The issue is that authority is still reconstructed from transient object status and process-local summaries even while persisted control-plane tables show mixed freshness across segments. The architecture needs a durable ledger that can distinguish fresh simulation authority from stale market-context or stage authority.
+
+## Problem framing
+
+1. A stale swarm can outlive its own freeze TTL, which means `Swarm.status.phase` is not reliable enough to govern rollout on its own.
+2. `/ready` can remain green while stage cadence is dead, because rollout health and trust health are separate concepts today.
+3. Optional `execution_trust` is too weak for production-safe rollout decisions; when disabled, the safe path disappears entirely.
+4. Operators cannot assume broad cluster RBAC during incident triage, so the swarm and status surfaces themselves must carry authoritative evidence.
+
+## Architecture alternatives
+
+### Option A: enable the existing execution-trust feature as-is
+
+Pros:
+
+- smallest code delta
+- reuses current status model
+
+Cons:
+
+- still no durable authority record for freeze-expiry and stage-lease decisions
+- still vulnerable to stale swarm status outliving its truth window
+
+### Option B: add a freeze-expiry janitor only
+
+Pros:
+
+- directly addresses the expired-freeze symptom
+- low implementation cost
+
+Cons:
+
+- does not solve rollout truth split between rollout health, stage freshness, and readiness
+- gives no auditable decision history
+
+### Option C: introduce an Authority Ledger with expiry watchdog and rollout write-ahead log
+
+Pros:
+
+- one authoritative decision surface for stage freshness, freeze expiry, and canary gating
+- durable evidence for block, hold, clear, and replay
+- works even when operator RBAC is narrow
+
+Cons:
+
+- larger implementation scope across status, controllers, and persistence
+
+## Decision
+
+Adopt **Option C**.
+
+The March 19 evidence is not just an observability nuisance. It shows the current architecture can report healthy deployments while leaving the swarm operationally frozen with no fresh stage activity. That is a control-plane truth failure, so the fix must be architectural rather than cosmetic.
+
+## Proposed architecture
+
+### 1. Authority Ledger as the source of truth
+
+Introduce a durable ledger owned by Jangar with three records:
+
+- `control_plane_authority_leases`
+  - one row per `{swarm, stage, authority_source}`
+  - fields: `observed_at`, `lease_expires_at`, `cadence_ms`, `source_kind`, `source_id`, `confidence`, `evidence_ref`
+- `control_plane_authority_decisions`
+  - one row per evaluated swarm decision
+  - fields: `decision_id`, `authority_state`, `blocking_class`, `freeze_state`, `reason_codes`, `evidence_bundle_id`
+- `control_plane_evidence_bundles`
+  - immutable references to the swarm snapshot, warning-event digest, heartbeat summary, rollout digest, and requirement queue digest used in the decision
+
+The control-plane UI/API may still project the current status from Kubernetes objects, but rollout control must read from the ledger summary, not directly from `Swarm.status.phase`.
+
+### 2. Expiry watchdog with explicit post-expiry states
+
+Replace the current binary mental model of `frozen` versus `not frozen` with explicit post-expiry states:
+
+- `freeze_active`
+- `freeze_expired_unreconciled`
+- `hold_shadow_catchup`
+- `recovering`
+- `healthy`
+
+When `freeze.until` passes, the watchdog must do one of two things within one reconciliation window:
+
+1. transition to `recovering` if fresh stage leases and evidence bundles exist
+2. transition to `freeze_expired_unreconciled` if stage leases are still stale
+
+The important rule is that a swarm cannot remain indefinitely in `Frozen` without a fresh authority decision.
+
+### 3. Stage lease quorum and synthetic catch-up
+
+Each stage (`discover`, `plan`, `implement`, `verify`) must publish a lease entry on start and completion.
+
+Rollout safety rules:
+
+- if any required stage lease is stale beyond `2x cadence`, canary progression is blocked
+- if a freeze expires while required stages are still stale, Jangar must queue a **shadow catch-up** run rather than auto-clearing to healthy
+- shadow catch-up runs must not mutate production state; they only restore authority truth and evidence continuity
+
+This keeps stale schedules from silently becoming “healthy by omission.”
+
+### 4. Rollout write-ahead log
+
+Before any canary step, write an intent record:
+
+- `desired_weight`
+- `current_weight`
+- `authority_decision_id`
+- `required_clearance_window_ms`
+- `expected_recovery_conditions`
+
+If rollout cannot continue, the controller writes a terminal hold/block record with the same `authority_decision_id`. That gives engineer and deployer stages a deterministic replay chain instead of reconstructing intent from logs.
+
+### 5. Readiness and status contract changes
+
+`/ready` and `/api/agents/control-plane/status` must both consume the ledger summary:
+
+- `/ready`
+  - non-200 when `authority_state in {blocked, freeze_expired_unreconciled, hold_shadow_catchup}`
+- `/api/agents/control-plane/status`
+  - always includes `authority_ledger`
+  - no feature flag for the authoritative view
+  - exposes `decision_age_ms`, `required_stage_leases`, `expired_freeze_count`, `evidence_bundle_refs`
+
+Deployment rollout health remains informative, but never overrides ledger truth.
+
+## Validation gates
+
+Engineer gates:
+
+- add unit coverage in `services/jangar/src/server/control-plane-status.test.ts` for:
+  - expired freeze -> `freeze_expired_unreconciled`
+  - fresh leases + expired freeze -> `recovering`
+  - stale stage lease -> canary block even when deployment rollout is healthy
+- add readiness-route coverage in `services/jangar/src/routes/__tests__/ready.test.ts`
+  - readiness must fail when authority ledger says `freeze_expired_unreconciled`
+- add controller tests around rollout WAL behavior in `services/jangar/src/server/orchestration-controller.test.ts`
+- add persistence tests for evidence bundle immutability
+
+Deployer gates:
+
+- no canary progression when `authority_state != healthy`
+- one forced schedule-staleness drill must generate:
+  - an authority decision
+  - a bundle of evidence refs
+  - a shadow catch-up run
+- one freeze-expiry drill must prove the system moves to `recovering` or `freeze_expired_unreconciled`, never silently remains frozen
+
+## Rollout plan
+
+1. Add ledger tables and write-paths behind additive schema changes.
+2. Emit ledger summaries into status responses while keeping legacy fields.
+3. Switch `/ready` to authority-ledger mode in canary.
+4. Switch rollout controller predicates from deployment-health-first to ledger-first.
+5. Remove the execution-trust feature flag once ledger-backed authority is stable.
+
+## Rollback plan
+
+If rollout of the ledger itself causes false blocks:
+
+- keep writing ledger rows
+- revert predicate consumption to advisory mode
+- preserve evidence bundles and WAL rows for replay analysis
+
+Do not delete the ledger rows during rollback. They are part of the incident record.
+
+## Risks and tradeoffs
+
+- More persistence means more schema and retention management.
+- Bad lease TTL tuning could create noisy false holds.
+- Shadow catch-up runs add execution cost.
+
+Mitigations:
+
+- use bounded TTL defaults from observed stage cadence
+- version the evidence bundle schema
+- cap shadow catch-up frequency and emit explicit anti-flap cooldowns
+
+## Engineer and deployer handoff contract
+
+Engineer must deliver:
+
+1. ledger schema and authoritative decision builder
+2. freeze-expiry watchdog with explicit post-expiry states
+3. readiness/status consumption of the ledger
+4. rollout WAL and evidence bundles
+5. regression coverage for expiry, stale leases, and canary blocking
+
+Deployer must validate:
+
+1. healthy deployments alone do not clear stale schedule authority
+2. expired freezes become explicit recovery/hold states
+3. shadow catch-up runs are non-mutating
+4. canary progression only occurs after ledger-backed healthy decisions
+
+## Success criteria
+
+- the swarm cannot remain frozen past `freeze.until` without a fresh authority decision
+- `/ready` and canary rollout agree on the same authority state
+- operators can explain a hold/block decision from a single evidence bundle without broad cluster RBAC
+- stage freshness becomes durable, replayable, and auditable

--- a/docs/agents/designs/50-torghut-hypothesis-capital-governor-and-data-quorum-2026-03-19.md
+++ b/docs/agents/designs/50-torghut-hypothesis-capital-governor-and-data-quorum-2026-03-19.md
@@ -1,0 +1,315 @@
+# 50. Torghut Hypothesis Capital Governor and Data Quorum (2026-03-19)
+
+Status: Ready for merge (discover architecture lane)
+Date: `2026-03-19`
+Owner: Victor Chen (Jangar Engineering Architecture)
+Related mission: `codex/swarm-jangar-control-plane-discover`
+Swarm impact: `torghut-quant`
+Companion doc:
+
+- `49-jangar-control-plane-authority-ledger-and-expiry-watchdog-2026-03-19.md`
+
+## Executive summary
+
+Torghut currently exposes a profitability control contradiction:
+
+- runtime readiness reports `live_submission_gate.allowed = true` with capital stage `0.10x canary`
+- the same readiness payload reports `hypotheses_total = 3`, all in `shadow`, with `promotion_eligible_total = 0`
+- Jangar quant control-plane health reports `status = degraded`, `latestMetricsCount = 0`, and `emptyLatestStoreAlarm = true`
+- the active strategy snapshot returns an empty metric frame
+
+The architecture change in this document is to insert a **Hypothesis Capital Governor** between hypothesis readiness and any non-shadow capital stage. The governor combines fresh quant evidence, dependency segment health, and hypothesis eligibility into a single capital decision that can be audited and rolled back.
+
+## Assessment snapshot
+
+### Cluster health and rollout evidence
+
+Fresh runtime evidence captured during this discover run:
+
+- `kubectl get pods -n torghut -o wide`
+  - `torghut-options-catalog` in `CrashLoopBackOff`
+  - `torghut-options-enricher` in `CrashLoopBackOff`
+  - `torghut-options-ta` in `ImagePullBackOff`
+  - `torghut-ws-options` running but with high restart churn
+- `kubectl get events -A --field-selector type=Warning --sort-by='.lastTimestamp' | tail -n 80`
+  - recurring readiness/liveness failures and backoff restarts remain live in the Torghut surface
+
+### Runtime data and database evidence
+
+`curl -fsS http://torghut.torghut.svc.cluster.local/readyz | jq ...` showed:
+
+- `dependencies.database.schema_current = true`
+- expected/current migration head `0024_simulation_runtime_context`
+- migration lineage warnings still exist because parent forks are present in the schema graph
+- `alpha_readiness.state_totals = {"shadow": 3}`
+- `alpha_readiness.promotion_eligible_total = 0`
+- `live_submission_gate.allowed = true`
+- `live_submission_gate.capital_stage = "0.10x canary"`
+
+Direct read-only data-store checks showed:
+
+- Torghut Postgres (`torghut-db-app`)
+  - `alembic_version = 0024_simulation_runtime_context`
+  - `trade_decisions = 29700`, `max(created_at) = 2026-03-19T17:44:25.133Z`
+  - `executions = 3`, `max(created_at) = 2026-03-14T19:17:43.858Z`
+  - `torghut_options_watermarks.max(last_success_ts) = 2026-03-11T01:08:11.973Z`
+- Torghut ClickHouse (`torghut-clickhouse`)
+  - `ta_signals.engine = ReplicatedReplacingMergeTree`, `max(event_ts) = 2026-03-19 17:45:13`
+  - `ta_microbars.engine = ReplicatedReplacingMergeTree`, `max(event_ts) = 2026-03-19 17:45:13`
+
+`curl -fsS 'http://jangar.jangar.svc.cluster.local/api/torghut/trading/control-plane/quant/health?account=paper&window=15m'`
+returned:
+
+- `status = "degraded"`
+- `latestMetricsUpdatedAt = null`
+- `latestMetricsCount = 0`
+- `emptyLatestStoreAlarm = true`
+- `stages = []`
+
+`curl -fsS 'http://jangar.jangar.svc.cluster.local/api/torghut/trading/control-plane/quant/snapshot?strategy_id=4b0051ba-ae40-43c1-9d8b-ad5a57a2b8f6&account=paper&window=15m'`
+returned:
+
+- `metrics = []`
+- `alerts = []`
+
+### Source architecture and test gaps
+
+Current code already has useful building blocks:
+
+- `services/torghut/app/trading/hypotheses.py`
+  - computes per-hypothesis state, capital stage, promotion eligibility, rollback requirement
+- `services/torghut/app/main.py`
+  - builds `live_submission_gate` from hypothesis summary, empirical jobs, and dependency quorum
+- `services/jangar/src/routes/api/torghut/trading/control-plane/quant/health.ts`
+  - exposes freshness alarms and empty metric store state
+- `services/jangar/src/routes/api/torghut/trading/control-plane/quant/snapshot.ts`
+  - exposes concrete frame payloads and alerts
+
+The missing piece is not instrumentation. The missing piece is a single policy layer that says:
+
+- empty quant evidence means no capital beyond shadow
+- segment-local failures demote only the affected hypotheses
+- readiness cannot declare a live gate without a matching evidence-backed capital decision
+
+## Problem framing
+
+1. Capital stage decisions are still vulnerable to contradictions between readiness, hypothesis summary, and quant metric freshness.
+2. Segment-local failures in Torghut options/data services do not yet translate into explicit per-hypothesis capital demotion rules, even when Postgres watermarks and runtime pods are stale while ClickHouse TA ingestion is fresh.
+3. Profitability evidence exists, but it is not packaged as a governor contract with immutable acceptance and rollback criteria.
+4. Database schema health alone is being interpreted too generously; a current schema does not mean current trading evidence.
+
+## Architecture alternatives
+
+### Option A: tighten thresholds inside existing hypothesis logic only
+
+Pros:
+
+- smallest implementation delta
+- reuses current state model
+
+Cons:
+
+- still leaves multiple endpoints responsible for final capital truth
+- still weak on auditability and segment scoping
+
+### Option B: force global live gate off whenever any quant metric surface is degraded
+
+Pros:
+
+- simple safety improvement
+
+Cons:
+
+- too coarse
+- turns local options/data incidents into portfolio-wide freezes
+
+### Option C: add a Hypothesis Capital Governor with segment-aware data quorum
+
+Pros:
+
+- preserves local failure isolation
+- makes capital allocation explicitly evidence-driven
+- gives deployer-stage rollout and rollback a deterministic source of truth
+
+Cons:
+
+- requires explicit contract plumbing across Torghut and Jangar read surfaces
+
+## Decision
+
+Adopt **Option C**.
+
+The March 19 runtime picture is clear: schema health and dependency quorum are not sufficient for profitability promotion. Capital stage must be constrained by fresh quant evidence and matched hypothesis state.
+
+## Proposed architecture
+
+### 1. Hypothesis Capital Governor
+
+Introduce a governor that produces a single record per hypothesis family:
+
+- `governor_decision_id`
+- `hypothesis_id`
+- `strategy_family`
+- `segment_dependencies`
+- `data_quorum_state`
+- `capital_state`
+- `reason_codes`
+- `evidence_bundle_refs`
+- `expires_at`
+
+`capital_state` becomes the only deployable capital truth:
+
+- `shadow`
+- `observe`
+- `0.10x canary`
+- `0.25x canary`
+- `0.50x live`
+- `1.00x live`
+- `rollback_required`
+
+No other endpoint may synthesize a more permissive capital state than the governor.
+
+### 2. Data quorum before capital quorum
+
+The governor must refuse any non-shadow capital stage when one of these is true:
+
+- `latestMetricsCount == 0`
+- `emptyLatestStoreAlarm == true`
+- quant `stages` is empty for the required evaluation window
+- active strategy frame contains no metrics
+- required dependency segment is `blocked` or `hold`
+
+This is the core contract change: **schema-current is necessary, but not sufficient**.
+
+### 3. Segment-scoped dependency mapping
+
+Attach each hypothesis to explicit dependency segments, for example:
+
+- `market-context`
+- `ta-core`
+- `options-data`
+- `execution`
+- `empirical`
+- `llm-review`
+
+If `options-data` is degraded, only the hypotheses that declare `options-data` are demoted to `observe` or `shadow`. Unrelated hypotheses may stay eligible.
+
+This reduces blast radius while staying economically honest.
+
+### 4. Measurable hypothesis acceptance windows
+
+The governor must evaluate each hypothesis across at least two windows:
+
+- `freshness window`
+  - metrics present, route coverage present, update lag within policy
+- `performance window`
+  - sample count, slippage, expectancy, rejection ratio, and continuity pass
+
+Baseline policy contract:
+
+- freshness:
+  - `latestMetricsCount > 0`
+  - required frame window non-empty
+  - no missing-update alarm during active session
+- performance:
+  - `promotion_eligible_total > 0`
+  - effect size above manifest threshold
+  - no guardrail breach for two consecutive windows
+
+If freshness fails, performance is not even evaluated for promotion.
+
+### 5. Portfolio guardrails
+
+Add portfolio-level brakes above the per-hypothesis governor:
+
+- maximum simultaneous non-shadow hypotheses per regime
+- maximum capital concentration per strategy family
+- forced `observe` mode if two governor decisions expire without fresh evidence renewal
+- automatic rollback if a live hypothesis loses data quorum for two consecutive windows
+
+This keeps stale evidence from quietly inheriting live capital.
+
+### 6. Immutable evidence bundles
+
+Each governor decision must reference an immutable evidence bundle containing:
+
+- hypothesis summary snapshot
+- quant health snapshot
+- frame snapshot identifiers
+- dependency segment summary
+- live submission gate payload
+- decision timestamp and expiry
+
+Engineer and deployer stages then reason from the same bundle rather than different endpoints.
+
+## Validation gates
+
+Engineer gates:
+
+- add tests in `services/torghut/app` for:
+  - `promotion_eligible_total = 0` forces `capital_state = shadow|observe`
+  - empty metric store blocks any non-shadow capital stage
+  - degraded dependency segment demotes only affected hypotheses
+- add tests in `services/jangar/src/routes/api/torghut/trading/control-plane/quant/health.ts`
+  - freshness failures map cleanly into governor inputs
+- add status contract tests proving `live_submission_gate` cannot report a more permissive state than the governor
+
+Deployer gates:
+
+- no move to `0.10x canary` unless a fresh governor decision exists
+- one induced empty-metrics drill must demote the affected hypothesis to `shadow` or `observe`
+- one segment-local options outage drill must leave unrelated hypotheses eligible while demoting affected ones
+- rollback evidence must include the precise failing freshness or performance window
+
+## Rollout plan
+
+1. Add governor record schema and read model.
+2. Emit governor decision alongside current readiness and alpha-readiness payloads.
+3. Switch `live_submission_gate` to consume the governor decision rather than raw summary fields.
+4. Enable per-segment demotion in canary before enabling portfolio-level capital guardrails.
+
+## Rollback plan
+
+If the governor proves too strict in early rollout:
+
+- keep collecting governor decisions
+- demote consumption to advisory-only
+- preserve non-shadow decisions only when both existing and governor paths agree
+
+Rollback must never discard the evidence bundles that justified a previous demotion or hold.
+
+## Risks and tradeoffs
+
+- stricter freshness requirements can reduce trading throughput during data turbulence
+- segment mapping adds contract maintenance overhead
+- more explicit capital state means more deployer discipline
+
+Mitigations:
+
+- ship default dependency maps per strategy family
+- use expiry-based renewal so stale evidence naturally ages out
+- stage rollout with observe-only governance first
+
+## Engineer and deployer handoff contract
+
+Engineer must deliver:
+
+1. governor data model and decision builder
+2. segment dependency mapping for each live hypothesis family
+3. live gate consumption of governor outputs
+4. regression coverage for empty metrics, empty frames, and segment-local demotion
+5. evidence bundle emission and retention
+
+Deployer must validate:
+
+1. capital stage never advances when quant evidence is empty or stale
+2. segment-local outages only demote dependent hypotheses
+3. portfolio guardrails can force observe/rollback without global shutdown
+4. every live-capital decision is backed by a fresh evidence bundle
+
+## Success criteria
+
+- no hypothesis can reach non-shadow capital with empty quant evidence
+- live submission gate and hypothesis summary cannot contradict each other
+- segment-local failures reduce blast radius instead of freezing the whole portfolio
+- capital decisions become explicit, measurable, and auditable

--- a/docs/torghut/design-system/README.md
+++ b/docs/torghut/design-system/README.md
@@ -35,6 +35,8 @@ The v1 documents are written to stay consistent with:
 If you are trying to decide which docs are current contract truth versus historical milestone records, start with:
 
 - `docs/torghut/design-system/current-source-of-truth-and-priority-guide-2026-03-09.md`
+- `docs/agents/designs/49-jangar-control-plane-authority-ledger-and-expiry-watchdog-2026-03-19.md`
+- `docs/agents/designs/50-torghut-hypothesis-capital-governor-and-data-quorum-2026-03-19.md`
 
 That guide is the canonical reading order for the current corpus.
 

--- a/docs/torghut/design-system/current-source-of-truth-and-priority-guide-2026-03-09.md
+++ b/docs/torghut/design-system/current-source-of-truth-and-priority-guide-2026-03-09.md
@@ -1,8 +1,8 @@
-# Torghut Design-System Current Source-of-Truth and Priority Guide (2026-03-09)
+# Torghut Design-System Current Source-of-Truth and Priority Guide (updated 2026-03-19)
 
 ## Status
 
-- Date: `2026-03-09`
+- Date: `2026-03-19`
 - Purpose: distinguish live source-of-truth docs from historical milestone records and identify the current highest-priority work
 - Scope: `docs/torghut/design-system/**`, `docs/torghut/**`, `argocd/applications/torghut/**`, `services/torghut/**`, `services/jangar/**`
 
@@ -46,6 +46,8 @@ If the question is "what should I trust right now?", start here:
    - `docs/torghut/design-system/v6/41-torghut-quant-profitability-and-guardrail-architecture-2026-03-15.md`
    - `docs/torghut/design-system/v6/42-torghut-quant-control-plane-and-profitability-program-2026-03-15.md`
    - `docs/torghut/design-system/v6/44-torghut-quant-plan-design-document-and-handoff-contract-2026-03-15.md`
+   - `docs/agents/designs/49-jangar-control-plane-authority-ledger-and-expiry-watchdog-2026-03-19.md`
+   - `docs/agents/designs/50-torghut-hypothesis-capital-governor-and-data-quorum-2026-03-19.md`
 
 4. options-lane current design source of truth:
    - `docs/torghut/design-system/v6/33-alpaca-options-market-data-and-technical-analysis-lane-2026-03-08.md`
@@ -55,18 +57,19 @@ If the question is "what should I trust right now?", start here:
 
 The current highest-priority work is:
 
-1. replace query-derived control-plane freshness with the producer-authored ledger defined in
+1. replace optional/stale control-plane truth with the authority-ledger and expiry-watchdog contract in
+   `docs/agents/designs/49-jangar-control-plane-authority-ledger-and-expiry-watchdog-2026-03-19.md`;
+2. force capital-stage decisions through the hypothesis capital governor and data-quorum contract in
+   `docs/agents/designs/50-torghut-hypothesis-capital-governor-and-data-quorum-2026-03-19.md`;
+3. keep producer-authored freshness and proof bundles active by continuing the ledger direction defined in
    `docs/torghut/design-system/v6/39-freshness-ledger-and-hypothesis-proof-mesh-2026-03-14.md`;
-2. land hypothesis-scoped proof bundles so alpha readiness is based on persisted evidence rather than aggregate zeroed
-   counters;
-3. keep the March 9 empirical-authority contract active by wiring recurring prove-and-promote automation into those
-   proof bundles;
 4. isolate control-plane failure domains with rollout-safe gates in
    `docs/torghut/design-system/v6/40-control-plane-resilience-and-safer-rollout-for-torghut-quant-2026-03-15.md`;
-5. implement hypothesis-specific profitability guardrails in
-   `docs/torghut/design-system/v6/41-torghut-quant-profitability-and-guardrail-architecture-2026-03-15.md`.
-6. execute the merged control-plane/profitability program and its mixed-failure rollback strategy in
-   `docs/torghut/design-system/v6/42-torghut-quant-control-plane-and-profitability-program-2026-03-15.md`.
+5. retain hypothesis-specific profitability guardrails from
+   `docs/torghut/design-system/v6/41-torghut-quant-profitability-and-guardrail-architecture-2026-03-15.md`,
+   but make them subordinate to fresh data quorum and immutable evidence bundles;
+6. execute the merged control-plane/profitability program with the March 19 authority and governor contracts layered on
+   top of the March 15-16 design set.
 
 This means the current next work is not:
 
@@ -116,6 +119,8 @@ These are still active contract docs rather than historical snapshots:
 - `docs/torghut/design-system/v6/41-torghut-quant-profitability-and-guardrail-architecture-2026-03-15.md`
 - `docs/torghut/design-system/v6/42-torghut-quant-control-plane-and-profitability-program-2026-03-15.md`
 - `docs/torghut/design-system/v6/44-torghut-quant-plan-design-document-and-handoff-contract-2026-03-15.md`
+- `docs/agents/designs/49-jangar-control-plane-authority-ledger-and-expiry-watchdog-2026-03-19.md`
+- `docs/agents/designs/50-torghut-hypothesis-capital-governor-and-data-quorum-2026-03-19.md`
 - `docs/torghut/design-system/v6/33-alpaca-options-market-data-and-technical-analysis-lane-2026-03-08.md`
 - `docs/torghut/design-system/v6/34-alpaca-options-lane-implementation-contract-set-2026-03-08.md`
 


### PR DESCRIPTION
## Summary

- add a March 19 Jangar architecture contract that turns stale freeze/stage truth into an authority-ledger and expiry-watchdog design
- add a March 19 Torghut architecture contract that introduces a hypothesis capital governor tied to fresh quant evidence and segment-aware data quorum
- anchor both docs in fresh cluster, source, and database evidence gathered from live read-only cluster/API/DB surfaces
- update the Agents and Torghut design indexes so engineer and deployer stages can find the new contracts without following stale March 15 references

## Related Issues

None

## Testing

- `git diff --check`
- `cd services/jangar && bunx vitest run --config vitest.config.ts src/server/__tests__/control-plane-watch-reliability.test.ts src/server/__tests__/control-plane-status.test.ts src/routes/ready.test.ts src/server/__tests__/supporting-primitives-controller.test.ts`
- `cd services/torghut && python3 -m pytest tests/test_hypotheses.py tests/test_policy_checks.py -q` (environment limitation: `/usr/bin/python3: No module named pytest`)

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
