### PR TITLE
fix(torghut-options): restore rollout inputs

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -45,7 +45,7 @@ spec:
             - name: DB_DSN
               valueFrom:
                 secretKeyRef:
-                  name: torghut-options-db-app
+                  name: torghut-db-app
                   key: uri
             - name: ALPACA_OPTIONS_KEY_ID
               valueFrom:

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -45,7 +45,7 @@ spec:
             - name: DB_DSN
               valueFrom:
                 secretKeyRef:
-                  name: torghut-options-db-app
+                  name: torghut-db-app
                   key: uri
             - name: ALPACA_OPTIONS_KEY_ID
               valueFrom:

--- a/argocd/applications/torghut-options/ta/flinkdeployment.yaml
+++ b/argocd/applications/torghut-options/ta/flinkdeployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: torghut-options-ta
 spec:
-  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:3d7f435b1eb4df8d9e4cb5c4f0c1a7bda412d51672d0eb0eb8285b83fe31cbb1
+  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:20fe1818a7c5239d58d4e3888804163025b9b3b2ee1a1674fd7db77007f682af
   imagePullPolicy: IfNotPresent
   restartNonce: 1
   flinkVersion: v2_0
@@ -86,9 +86,9 @@ spec:
                   name: flink-checkpoints
                   key: AWS_SECRET_ACCESS_KEY
             - name: TORGHUT_TA_VERSION
-              value: a999da7b
+              value: v0.564.0-252-ga99718513
             - name: TORGHUT_TA_COMMIT
-              value: a999da7be6e8027b8a797b1df9ebde49a0ee6c36
+              value: a997185135c2786e100dd5f240286072cbaa1ed0
           ports:
             - containerPort: 9249
               name: metrics

--- a/docs/torghut/rollouts/2026-03-19-torghut-quant-verify-report.md
+++ b/docs/torghut/rollouts/2026-03-19-torghut-quant-verify-report.md
@@ -5,15 +5,26 @@
 - Mission branch: `codex/swarm-torghut-quant-verify`
 - Repository: `proompteng/lab`
 - Objective: bring open Torghut PRs to production-ready state, merge only with green checks, and confirm healthy in-cluster rollout
+- Release engineer: `Julian Hart` for Torghut Traders
 
 ## PR Queue
 
 - Enumerated open PRs on `proompteng/lab` at 2026-03-19 18:00 UTC.
-- Result: only PR `#4625` (`docs: add bilig deployment contract docs`) was open, and it is unrelated to Torghut.
-- No open `torghut` or `torghut-quant` PRs were available to unblock or merge in this run.
+- Torghut-related PRs still open in this verify loop:
+  - `#4628` `docs(torghut): record verify rollout blockers` on `codex/swarm-torghut-quant-verify`
+  - `#4631` `docs(torghut): add segment authority and promotion certificate contracts` on `codex/swarm-torghut-quant-plan`
+- Non-Torghut PR `#4625` remained unrelated and was not selected.
+- `#4631` was inspected first because it was the only conflicting Torghut PR, but GitHub refused a server-side `gh pr update-branch --rebase` refresh with `Cannot update PR branch due to conflicts`.
+- `#4628` became the selected release vehicle because it is the active verify branch and can carry the repo-owned production follow-up fixes.
 
 ## Torghut PRs Reviewed
 
+- `#4628` `docs(torghut): record verify rollout blockers`
+  - Active verify branch for this run.
+  - Expanded in this run to carry the options-lane GitOps fixes identified during rollout inspection.
+- `#4631` `docs(torghut): add segment authority and promotion certificate contracts`
+  - Open, conflict-blocked on `codex/swarm-torghut-quant-plan`.
+  - No checks failing, but not mergeable because GitHub reports branch conflicts and rejected a server-side rebase.
 - `#4591` `chore(torghut): promote image 54971ed8`
   - Merged 2026-03-19 05:51 UTC.
   - All visible checks completed successfully or skipped by policy.
@@ -51,11 +62,11 @@
 - Git-tracked live manifest `argocd/applications/torghut/knative-service.yaml` pins:
   - `registry.ide-newton.ts.net/lab/torghut@sha256:884bec35f7d24ef34c51240e697aa996bc134385be9f6936aa170880fe2d601e`
 - The running live pod `torghut-00153-deployment-6cf7d8d5f-726xr` is actually serving:
-  - `registry.ide-newton.ts.net/lab/torghut@sha256:a599ab5e52448e2d2e47a3b31a9d8695c1e6cca10271001e77e3f52726a6188d`
+  - `registry.ide-newton.ts.net/lab/torghut@sha256:884bec35f7d24ef34c51240e697aa996bc134385be9f6936aa170880fe2d601e`
 - The same live pod reports:
   - `serving.knative.dev/creator=admin`
-  - a recent `OOMKilled` last state
-  - repeated startup, readiness, and liveness probe failures in `kubectl describe pod`
+  - `TRADING_AUTONOMY_ALLOW_LIVE_PROMOTION=true` in the running pod while the Git-tracked manifest still sets `false`
+  - recent readiness and liveness failures in namespace events, including `LatestReadyFailed` and probe timeouts around revision `torghut-00153`
 - The simulation pod `torghut-sim-00262-deployment-b48785c4b-fqpsl` still matches the Git-tracked digest `884bec...`.
 
 ### Unhealthy torghut workloads
@@ -63,39 +74,54 @@
 - `torghut-options-catalog-676574bcc9-wkqp5`
   - `CrashLoopBackOff`
   - startup log ends with `password authentication failed for user "torghut_app"`
+  - live pod still points at secret `torghut-options-db-app`, but the current CNPG-managed `torghut-db-app` secret in namespace `torghut` has a different password value
 - `torghut-options-enricher-64b577944c-tp7fp`
   - `CrashLoopBackOff`
   - startup log ends with `password authentication failed for user "torghut_app"`
+  - live pod still points at secret `torghut-options-db-app`, which no longer matches the canonical CNPG app secret
 - `torghut-options-ta-7987889f4f-zxl5g`
   - `ImagePullBackOff`
   - `kubectl describe pod` shows repeated image pull failures for `registry.ide-newton.ts.net/lab/torghut-ta@sha256:3d7f435b1eb4df8d9e4cb5c4f0c1a7bda412d51672d0eb0eb8285b83fe31cbb1`
+  - the current repo fix on this branch updates `argocd/applications/torghut-options/ta/flinkdeployment.yaml` to the known-good digest already running for `torghut-ta`
+- `torghut-ws-options-68ffc7448b-qcnv4`
+  - running but not ready
+  - namespace events show repeated `503` readiness failures and liveness restarts, consistent with upstream options-lane dependency degradation
 - `torghut-dspy-cluster-runner`
   - job failed with `RuntimeError: jangar_agentrun_not_succeeded:dataset-build:failed`
 
+## Changes Landed On This Branch
+
+- `argocd/applications/torghut-options/catalog/deployment.yaml`
+  - repoints `DB_DSN` from stale sealed secret `torghut-options-db-app` to CNPG-managed `torghut-db-app`
+- `argocd/applications/torghut-options/enricher/deployment.yaml`
+  - repoints `DB_DSN` from stale sealed secret `torghut-options-db-app` to CNPG-managed `torghut-db-app`
+- `argocd/applications/torghut-options/ta/flinkdeployment.yaml`
+  - replaces missing TA image digest `3d7f435...` with the current live core TA digest `20fe1818...`
+  - aligns the embedded TA version and commit metadata with the promoted image that already runs in `torghut-ta`
+
 ## Merge Outcome
 
-- No merge was performed in this run.
-- Reason:
-  - there were no open Torghut PRs to merge
-  - current production verification is blocked by live service drift, unhealthy options-lane workloads, and Huly collaboration timeouts
+- `#4631` was not merged in this run because it remains conflict-blocked on a separate swarm branch.
+- `#4628` remains the active merge candidate for this branch after the options-lane GitOps fixes and artifact updates in this run.
 
 ## Risk
 
 - The core live and simulation services currently answer health checks, so the main trading path is not fully down.
 - The torghut namespace is not healthy enough to call production rollout complete because:
-  - the live service does not match the Git-tracked digest
+  - the live `torghut` revision still shows manual/admin drift in env state even though the image digest now matches Git
   - options-lane services are unavailable
+  - `torghut-options` is configured as `automation: manual` in `argocd/applicationsets/product.yaml`, so a merged Git fix still requires GitOps reconciliation before live pods change
   - the release persona cannot complete required Huly audit updates from this runtime
 
 ## Rollback Path
 
 - If the latest Torghut live-path changes need to be rolled back, revert PRs `#4615`, `#4603`, and `#4591` in reverse order through normal PR flow and let Argo CD reconcile.
-- If the live service drift is unintended, restore the Git-tracked Knative service image through Git instead of another manual admin update.
-- For the options lane, restore valid `torghut_app` database credentials and publish the missing `torghut-ta` image digest before re-running verification.
+- If the live service drift is unintended, restore the Git-tracked Knative service env through Git instead of another manual admin update.
+- If the options-lane fix regresses, revert the `#4628` follow-up commit to point catalog/enricher back to `torghut-options-db-app` and restore the previous options TA digest.
 
 ## Next Action
 
-- Restore Huly transactor responsiveness for dedicated-account API calls.
-- Reconcile the live `torghut` Knative service back to Git-tracked state or land the missing manifest update through PR.
-- Repair the options-lane database credentials and `torghut-ta` image availability.
-- Re-run the verify loop once the namespace is fully healthy.
+- Merge `#4628` once CI stays green.
+- Ask the owning operator to reconcile the manual `torghut-options` Argo app to apply the merged secret-reference and TA-image fixes.
+- Restore Huly transactor responsiveness for dedicated-account API calls so the required issue/chat/doc artifacts can be written by the Julian Hart account.
+- Re-run the verify loop after GitOps reconciliation and confirm catalog/enricher/TA/ws-options readiness plus the live `torghut` env drift state.


### PR DESCRIPTION
## Summary

- point `torghut-options` catalog and enricher at the canonical CNPG-managed `torghut-db-app` secret instead of the stale `torghut-options-db-app` secret
- repin `torghut-options` TA to the known-good `torghut-ta` digest already running for the core TA lane
- refresh the March 19 verify report with the real PR queue, the `#4631` conflict blocker, rollout evidence, risk, rollback notes, and next action

## Related Issues

None

## Testing

- `git diff --check`
- `scripts/argo-lint.sh argocd/applications/torghut-options`
- `export PATH="$(go env GOPATH)/bin:$PATH" && scripts/kubeconform.sh argocd/applications/torghut-options`
- `kubectl get pods -n torghut -o wide`
- `kubectl logs -n torghut torghut-options-catalog-676574bcc9-wkqp5 --tail=120`
- `kubectl logs -n torghut torghut-options-enricher-64b577944c-tp7fp --tail=120`
- `kubectl describe pod -n torghut torghut-options-ta-7987889f4f-zxl5g`
- `kubectl get secret -n torghut torghut-options-db-app -o yaml`
- `kubectl get secret -n torghut torghut-db-app -o yaml`
- `kubectl get events -n torghut --sort-by=.lastTimestamp | tail -n 60`
- `curl --max-time 8 http://torghut-00153-private.torghut.svc.cluster.local/healthz`
- `curl --max-time 8 http://torghut-sim-00262-private.torghut.svc.cluster.local/healthz`
- `curl --max-time 8 http://torghut-forecast.torghut.svc.cluster.local:8089/healthz`
- `curl --max-time 8 http://torghut-lean-runner.torghut.svc.cluster.local:8088/healthz`
- `gh pr update-branch 4631 -R proompteng/lab --rebase` (fails with `Cannot update PR branch due to conflicts`)
- `python3 skills/huly-api/scripts/huly-api.py --operation account-info ...` (timed out against `http://transactor.huly.svc.cluster.local`)
- `python3 skills/huly-api/scripts/huly-api.py --operation list-channel-messages ...` (timed out against `http://transactor.huly.svc.cluster.local`)

## Breaking Changes

- `torghut-options` catalog and enricher now consume `torghut-db-app`; the legacy `torghut-options-db-app` secret is no longer on the intended runtime path.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
