### PR TITLE
docs(jangar): add execution-cell architecture contracts

### DIFF
--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -18,8 +18,8 @@ clear entrypoints, clear “source of truth”, and a complete catalog of relate
 - Fast Jangar/Torghut live analysis workflow: `designs/jangar-torghut-live-analysis-playbook.md`
 - Autonomous Jangar/Torghut production system design: `designs/autonomous-jangar-torghut-production-system.md`
 - Current Jangar/Torghut architecture contracts:
-  - `designs/49-jangar-control-plane-authority-ledger-and-expiry-watchdog-2026-03-19.md`
-  - `designs/50-torghut-hypothesis-capital-governor-and-data-quorum-2026-03-19.md`
+  - `designs/51-jangar-control-plane-execution-cells-and-collaboration-failover-2026-03-19.md`
+  - `../torghut/design-system/v6/50-torghut-submission-parity-council-and-options-bootstrap-escrow-2026-03-19.md`
 - Security baseline: `threat-model.md`
 - RBAC requirements: `rbac-matrix.md`
 - Production bar (non-negotiables): `production-readiness-design.md`
@@ -163,6 +163,7 @@ For env and gRPC source-of-truth changes in this branch:
 - [designs/jangar-control-plane-provider-capacity-arbitration-and-template-run-truth-2026-03-14.md](designs/jangar-control-plane-provider-capacity-arbitration-and-template-run-truth-2026-03-14.md)
 - [designs/49-jangar-control-plane-authority-ledger-and-expiry-watchdog-2026-03-19.md](designs/49-jangar-control-plane-authority-ledger-and-expiry-watchdog-2026-03-19.md)
 - [designs/50-torghut-hypothesis-capital-governor-and-data-quorum-2026-03-19.md](designs/50-torghut-hypothesis-capital-governor-and-data-quorum-2026-03-19.md)
+- [designs/51-jangar-control-plane-execution-cells-and-collaboration-failover-2026-03-19.md](designs/51-jangar-control-plane-execution-cells-and-collaboration-failover-2026-03-19.md)
 - [designs/controller-finalizer-conventions.md](designs/controller-finalizer-conventions.md)
 - [designs/controller-kubectl-version-compat.md](designs/controller-kubectl-version-compat.md)
 - [designs/controller-namespace-scope-parse-validate.md](designs/controller-namespace-scope-parse-validate.md)

--- a/docs/agents/designs/51-jangar-control-plane-execution-cells-and-collaboration-failover-2026-03-19.md
+++ b/docs/agents/designs/51-jangar-control-plane-execution-cells-and-collaboration-failover-2026-03-19.md
@@ -1,0 +1,392 @@
+# 51. Jangar Control-Plane Execution Cells and Collaboration Failover (2026-03-19)
+
+Status: Approved for implementation (`plan`)
+Date: `2026-03-19`
+Owner: Victor Chen (Jangar Engineering)
+Mission: `codex/swarm-jangar-control-plane-plan`
+Swarm: `jangar-control-plane`
+
+Supersedes or extends:
+
+- `49-jangar-control-plane-authority-ledger-and-expiry-watchdog-2026-03-19.md`
+- `49-jangar-control-plane-execution-truth-spine-and-torghut-profit-circuit-2026-03-19.md`
+- `50-torghut-hypothesis-capital-governor-and-data-quorum-2026-03-19.md`
+
+Companion document:
+
+- `docs/torghut/design-system/v6/50-torghut-submission-parity-council-and-options-bootstrap-escrow-2026-03-19.md`
+
+## Executive summary
+
+The March 19 design pack correctly identified authority-ledger drift and profitability-governance contradictions, but
+the live runtime still exposes one more systemic problem: Jangar treats mixed failures as whole-swarm failures.
+
+Read-only evidence captured on `2026-03-19` shows:
+
+- `jangar-control-plane` and `torghut-quant` both remain `Frozen` even though `status.freeze.until` expired on
+  `2026-03-11`;
+- `http://jangar.jangar.svc.cluster.local/ready` still returns `status=ok` while
+  `/api/agents/control-plane/status` reports `has_execution_trust=false` and `dependency_quorum=allow`;
+- `services/jangar/src/server/control-plane-status.ts` still treats `phase == "Frozen"` as not ready even when
+  `freeze.until` is already in the past, while `services/jangar/src/server/supporting-primitives-controller.ts`
+  still drives unfreeze off local timers and stale run/status synthesis;
+- Huly collaboration is a hard dependency in practice, but the worker-scoped account probe and `find-all` query both
+  time out against `http://transactor.huly.svc.cluster.local`;
+- Torghut remains in a mixed state where core trading is up, but market-context freshness is down, quant materialized
+  metrics are empty, and options-lane pods fail on DB auth and image availability before steady-state.
+
+The selected architecture replaces "whole swarm frozen or healthy" with durable **Execution Cells**. Each cell owns a
+bounded failure domain, a durable lease, an evidence bundle, and a rollout policy. Schedules are preserved when a cell
+is unhealthy; only dispatch is suspended. Collaboration outages become a first-class cell with replayable outbox
+semantics instead of silently blocking unrelated control-plane work. Safe rollout then depends on the cell graph, not
+on a stale swarm phase or a green deployment probe.
+
+## Live assessment snapshot
+
+### Cluster health, rollout, and events
+
+Evidence captured during this plan run:
+
+- `kubectl -n agents get swarm jangar-control-plane torghut-quant -o jsonpath=...`
+  - `jangar-control-plane|Frozen|StageStaleness|2026-03-11T16:36:12.630Z|5|2026-03-11T15:48:11.742Z`
+  - `torghut-quant|Frozen|StageStaleness|2026-03-11T16:36:17.456Z|0|2026-03-11T15:48:13.974Z`
+- `curl -fsS http://jangar.jangar.svc.cluster.local/ready`
+  - returned `{"status":"ok",...}`
+- `curl -fsS http://jangar.jangar.svc.cluster.local/api/agents/control-plane/status`
+  - `database.status = "healthy"`
+  - `watch_reliability.status = "healthy"`
+  - `rollout_health.status = "healthy"`
+  - `dependency_quorum.decision = "allow"`
+  - `execution_trust` field absent because the feature flag is still effectively optional
+- `kubectl -n torghut get events --sort-by=.lastTimestamp | tail -n 40`
+  - repeated liveness/readiness failures for `torghut-00153-deployment`
+  - `torghut-options-catalog` and `torghut-options-enricher` restarting
+  - `torghut-options-ta` in `ImagePullBackOff`
+  - `torghut-ws-options` restarting on failed probes
+- `kubectl -n agents logs pod/torghut-market-context-news-batch-5ggp2-job-bn6qg --tail=120`
+  - batch runner hit a `subprocess.TimeoutExpired` on `/usr/local/bin/codex-implement` and then crashed trying to
+    write bytes to stdout as text
+
+Interpretation:
+
+- Jangar still has stale-freeze authority drift.
+- Torghut still has live mixed-state failures that should not collapse into one global freeze.
+- The market-context batch path can fail before persisting a clean control-plane explanation.
+
+### Source architecture and high-risk modules
+
+Highest-risk code seams:
+
+- `services/jangar/src/server/control-plane-status.ts`
+  - calculates `ready` as `phase.toLowerCase() !== 'frozen' && !freezeActive`, which means a stale frozen phase can
+    continue to poison trust even after `freeze.until` has expired;
+  - `DEFAULT_EXECUTION_TRUST_ENABLED = false`, so the authoritative truth surface is still optional;
+  - dependency quorum already models segments, but those segments are not yet durable execution cells with ownership,
+    expiry, or rollout policy.
+- `services/jangar/src/server/supporting-primitives-controller.ts`
+  - stale-stage detection is derived from recent runs and status timestamps;
+  - unfreeze still depends on `swarmUnfreezeTimers`, which is process-local;
+  - schedule intent and stage topology are not preserved separately from active dispatch.
+- `services/jangar/src/routes/ready.tsx`
+  - readiness only blocks on execution trust when the feature flag is enabled.
+- `services/torghut/app/main.py`
+  - `/readyz` and `/trading/status` expose richer capital semantics than the live scheduler actually enforces.
+- `services/torghut/app/trading/scheduler/pipeline.py`
+  - `_live_submission_gate()` only checks runtime flags and autonomy booleans, not the richer data/evidence quorum used
+    in the API surface.
+- `services/torghut/app/trading/completion.py`
+  - `continuity_ok` and `dependency_allow` are flattened across rows, which makes it harder to distinguish which
+    continuity dimension failed and whether the failure should demote one lane or all lanes.
+- `services/torghut/app/options_lane/catalog_service.py` and `services/torghut/app/options_lane/enricher_service.py`
+  - both instantiate `OptionsRepository(...)` and call `ensure_rate_bucket_defaults(...)` at module import time, so a
+    DB auth issue crashes the service before readiness can publish explicit bootstrap state.
+
+### Database and data assessment
+
+Database access from this service account is read-only but RBAC-limited:
+
+- `kubectl cnpg psql -n jangar jangar-db -- ...`
+  - failed with `pods "jangar-db-1" is forbidden ... cannot create resource "pods/exec"`
+- `kubectl cnpg psql -n torghut torghut-db -- ...`
+  - failed with `pods "torghut-db-1" is forbidden ... cannot create resource "pods/exec"`
+
+Service-level read-only evidence still shows the necessary data-state:
+
+- `curl -fsS http://torghut.torghut.svc.cluster.local/db-check`
+  - `ok = true`
+  - `expected_heads = ["0024_simulation_runtime_context"]`
+  - `schema_graph_branch_count = 1`
+  - lineage warnings remain for forked parents at revisions `0010` and `0015`
+- `curl -fsS http://torghut.torghut.svc.cluster.local/trading/status`
+  - `live_submission_gate.allowed = true`
+  - `capital_stage = "0.10x canary"`
+  - `promotion_eligible_total = 0`
+  - `hypotheses_total = 3`
+  - `capital_stage_totals.shadow = 3`
+- `curl -fsS http://jangar.jangar.svc.cluster.local/api/torghut/market-context/health?symbol=NVDA`
+  - `overallState = "down"`
+  - `bundleFreshnessSeconds = 275280`
+  - ClickHouse ingestion reports `clickhouse_query_failed`
+  - fundamentals and news are stale; technicals and regime are `error`
+- `curl -fsS http://jangar.jangar.svc.cluster.local/api/torghut/trading/control-plane/quant/health?...`
+  - `status = "degraded"`
+  - `latestMetricsCount = 0`
+  - `stages = []`
+- `curl -fsS http://jangar.jangar.svc.cluster.local/api/torghut/trading/control-plane/quant/alerts?...`
+  - open critical alerts for `metrics_pipeline_lag_seconds` across `1m`, `5m`, `15m`, `1h`, `1d`, `5d`, and `20d`
+
+Interpretation:
+
+- schema-current is not enough to authorize rollout or capital;
+- freshness, ingestion, collaboration, and bootstrap need separate execution ownership;
+- a database-access gap in the control-plane identity should surface as evidence, not as silent trust loss.
+
+### Collaboration assessment
+
+Required Huly checks were attempted with the dedicated architect token and expected actor id. The result was a platform
+timeout, not a credential mismatch:
+
+- `GET /api/v1/version` on `transactor.huly.svc.cluster.local` returns immediately;
+- `GET /api/v1/account/c9b87368-e7a2-483f-885f-ff179e258950` times out;
+- `POST /api/v1/find-all/c9b87368-e7a2-483f-885f-ff179e258950` also times out.
+
+This must become a modeled collaboration cell with replayable local buffering. It cannot remain an implicit fatal
+dependency for every stage.
+
+## Problem statement
+
+The current system still over-couples unrelated failures:
+
+1. stale swarm phase, stage cadence, and freeze expiry can disagree for days;
+2. unfreeze is partially driven by process-local timers instead of durable authority;
+3. schedule definitions disappear or become operationally invisible when a swarm is frozen;
+4. collaboration failures have no scoped degrade path and no replay contract;
+5. Torghut profitability decisions are still allowed to diverge across `/readyz`, `/trading/status`, and the live
+   scheduler.
+
+That topology creates the wrong operational behavior: mixed-state failures turn into ambiguous global freezes, while
+truly dangerous contradictions still slip through apparently healthy readiness surfaces.
+
+## Alternatives considered
+
+### Option A: keep the authority ledger and only patch stale-freeze handling
+
+Pros:
+
+- smallest implementation delta
+- reuses the March 19 ledger work
+
+Cons:
+
+- does not preserve schedules as durable intent
+- does not isolate collaboration failures
+- still leaves Torghut submission parity as a downstream problem
+
+Decision: rejected.
+
+### Option B: introduce a global hard gate across collaboration, data, and rollout
+
+Pros:
+
+- simple to reason about
+- maximum safety in the short term
+
+Cons:
+
+- too coarse for mixed-state production systems
+- Huly timeouts or options bootstrap failures would block unrelated Jangar plan/discover work
+- explicit failure-mode reduction is lost because everything fails the same way
+
+Decision: rejected.
+
+### Option C: execution cells with schedule preservation, collaboration failover, and submission parity
+
+Pros:
+
+- failure domains become explicit and durable
+- rollout can be blocked narrowly by the cells affected by a change
+- collaboration outages get an auditable degraded mode instead of becoming invisible fatal blockers
+- Torghut profitability can consume the same execution-cell graph without forcing one global ready bit
+
+Cons:
+
+- requires additive schema, controller, and status-surface work
+- demands disciplined dependency ownership metadata
+
+Decision: selected.
+
+## Decision
+
+Adopt **Option C**.
+
+The next control-plane layer is not another status summary. It is a durable execution-cell graph that preserves stage
+intent, isolates failure domains, and turns collaboration plus profitability contradictions into explicit evidence.
+
+## Proposed architecture
+
+### 1. Durable execution cells
+
+Add additive persistence owned by Jangar:
+
+- `control_plane_execution_cells`
+  - one row per `{swarm, cell_name, lane_scope}`
+  - fields: `cell_type`, `owner_component`, `state`, `policy_mode`, `lease_expires_at`, `depends_on`, `reason_codes`
+- `control_plane_execution_cell_events`
+  - immutable append-only event log for state transitions
+- `control_plane_execution_cell_evidence`
+  - references to Kubernetes objects, HTTP snapshots, alert snapshots, and external dependency errors
+
+Required first-wave cells:
+
+- `stage-discover`
+- `stage-plan`
+- `stage-implement`
+- `stage-verify`
+- `controller-orchestration`
+- `controller-supporting-primitives`
+- `collaboration-huly`
+- `source-auth-codex`
+- `torghut-market-context`
+- `torghut-quant-materialization`
+- `torghut-options-bootstrap`
+
+Each cell declares:
+
+- `blocking_policy`: `hard`, `soft`, or `detached`
+- `affected_surfaces`: status, readiness, rollout, submission, collaboration
+- `degrade_scope`: `cell`, `lane`, `swarm`, or `global`
+
+### 2. Preserve schedule intent even while dispatch is suspended
+
+Freezing or holding a swarm must never erase or hide schedule intent.
+
+New rules:
+
+- schedule manifests remain the durable source of stage intent;
+- unhealthy cells suspend dispatch, not configuration;
+- the UI and `/api/agents/control-plane/status` always surface preserved schedules plus the cell that is currently
+  blocking dispatch;
+- expired freeze state becomes a derived execution-cell transition, never a long-lived raw swarm phase.
+
+Implementation expectation:
+
+- move from `phase == Frozen` as operational truth to `cell_state in {hold, blocked, recovering}`;
+- persist the desired next stage dispatch in the execution-cell graph so engineer and deployer can replay it after
+  recovery.
+
+### 3. Replace process-local unfreeze with durable reconciliation leases
+
+`swarmUnfreezeTimers` can remain an optimization, but it must stop being the authority.
+
+Required behavior:
+
+- the authoritative unfreeze decision is derived from cell leases stored in the database;
+- controller restarts must be able to reconstruct pending unfreeze work from persisted rows;
+- `/ready` fails closed when a required cell is expired or stale, regardless of whether the in-process timer fired.
+
+### 4. Collaboration failover and replayable outbox
+
+Add `control_plane_collaboration_outbox` with:
+
+- `channel_kind`
+- `message_class`
+- `payload_ref`
+- `attempted_at`
+- `delivery_state`
+- `error_class`
+- `replay_after`
+
+Behavior:
+
+- if Huly account lookup or `find-all` times out, the `collaboration-huly` cell becomes `degraded`;
+- stage work that requires human-facing audit artifacts writes to the outbox and references the outbox item in the
+  execution-cell evidence bundle;
+- rollout and deploy stages remain blocked if their required collaboration policy is `hard`;
+- discover and plan stages may proceed in `detached` mode only when GitHub PR/merge evidence and local handoff
+  artifacts are present.
+
+That gives us bounded failure scope without losing auditability.
+
+### 5. Rollout predicates consume the cell graph
+
+Rollout and `/ready` must stop reasoning from a loose mix of rollout health, stale swarm phase, and optional trust.
+
+Required contract:
+
+- `/ready`
+  - returns non-200 when any `hard` required cell is `blocked`, `expired`, or `unreconciled`
+- `/api/agents/control-plane/status`
+  - always includes execution cells, their owners, expiry, evidence refs, and degrade scope
+- rollout controller
+  - writes a WAL row that includes the cell snapshot used for each canary decision
+  - blocks only on cells mapped to the changed subsystem
+
+Example mapping:
+
+- Jangar controller changes depend on `stage-*`, `controller-*`, `source-auth-codex`, `collaboration-huly`
+- Torghut options changes depend on `torghut-options-bootstrap`, `torghut-market-context`, `torghut-quant-materialization`
+- Torghut quant-only changes need not block on options bootstrap when the changed hypotheses do not declare
+  `options-data`
+
+### 6. Torghut submission parity plugs into the same cell graph
+
+The Torghut submission council defined in the companion v6 document must consume execution cells as first-class
+dependency inputs. That gives one shared truth for:
+
+- `live_submission_gate`
+- Jangar quant status
+- rollout approval for profitability-affecting changes
+
+Execution cells therefore become the common contract between reliability and profitability.
+
+## Validation gates
+
+Engineer gates:
+
+- add regression tests in `services/jangar/src/server/__tests__/control-plane-status.test.ts`
+  - expired `freeze.until` plus stale `phase == Frozen` becomes `recovering` or `blocked_expired`, not silently ready
+- add regression tests in `services/jangar/src/routes/ready.test.ts`
+  - `/ready` must fail when a required hard cell is expired or collaboration is hard-blocked
+- add controller tests in `services/jangar/src/server/__tests__/supporting-primitives-controller.test.ts`
+  - frozen swarms preserve schedules and dispatch intent
+  - controller restarts reconstruct unfreeze work from durable rows
+- add parity tests across Torghut status and scheduler inputs
+  - same evidence bundle must produce the same gate decision in API and runtime
+
+Deployer gates:
+
+- induce one stage-staleness drill and prove preserved schedules remain visible while dispatch is blocked;
+- induce one Huly timeout drill and prove the outbox captures the message plus replay state;
+- no rollout progression when any required `hard` cell is not healthy or recovering within policy;
+- store and archive the cell snapshot used for every canary step.
+
+## Rollout plan
+
+1. Add execution-cell, evidence, and outbox tables without changing readiness behavior.
+2. Mirror current truth into cells and surface them in `/api/agents/control-plane/status`.
+3. Preserve schedules during freeze/hold and add durable unfreeze reconstruction.
+4. Switch `/ready` and rollout predicates from legacy phase logic to cell logic in canary.
+5. Make Torghut submission parity consume the same cell graph.
+
+## Rollback plan
+
+If cell-based gating creates false positives:
+
+- keep writing execution-cell and outbox rows;
+- revert readiness and rollout predicates to advisory mode;
+- preserve all evidence bundles, cell events, and outbox entries for replay and incident review.
+
+Do not delete cell state during rollback. The incident record is part of the control-plane contract.
+
+## Risks and tradeoffs
+
+- More schema and cell metadata increases complexity.
+- Incorrect `blocking_policy` defaults could either over-block or under-block rollout.
+- Detached collaboration mode could be abused if evidence requirements are weak.
+
+Mitigations:
+
+- ship with a small fixed cell taxonomy first;
+- require explicit owner and degrade scope for every cell;
+- gate detached collaboration mode on durable GitHub/PR evidence and local handoff artifacts;
+- keep an operator-visible mapping from changed subsystem to required cells.

--- a/docs/torghut/design-system/v6/50-torghut-submission-parity-council-and-options-bootstrap-escrow-2026-03-19.md
+++ b/docs/torghut/design-system/v6/50-torghut-submission-parity-council-and-options-bootstrap-escrow-2026-03-19.md
@@ -1,0 +1,362 @@
+# 50. Torghut Submission Parity Council and Options Bootstrap Escrow (2026-03-19)
+
+Status: Approved for implementation (`plan`)
+Date: `2026-03-19`
+Owner: Victor Chen (Jangar Engineering)
+Mission: `codex/swarm-jangar-control-plane-plan`
+Swarm impact: `torghut-quant`
+
+Companion documents:
+
+- `docs/agents/designs/51-jangar-control-plane-execution-cells-and-collaboration-failover-2026-03-19.md`
+- `docs/agents/designs/50-torghut-hypothesis-capital-governor-and-data-quorum-2026-03-19.md`
+- `49-torghut-quant-source-of-truth-and-profit-circuit-handoff-2026-03-19.md`
+
+## Executive summary
+
+The runtime on `2026-03-19` still allows contradictory profitability states:
+
+- `GET /trading/status` reports `live_submission_gate.allowed = true` and `capital_stage = "0.10x canary"`;
+- the same payload reports `hypotheses_total = 3`, `state_totals.shadow = 3`, and `promotion_eligible_total = 0`;
+- Jangar quant health reports `latestMetricsCount = 0` and no active materialization stages;
+- Jangar market-context health reports `overallState = "down"` with stale bundle freshness;
+- options-lane services fail before readiness because DB rate-bucket defaults are written during module import and the
+  current credential for `torghut_app` is rejected;
+- `torghut-options-ta` cannot even pull its image digest.
+
+The selected architecture introduces a **Submission Parity Council** that becomes the only place allowed to emit live
+capital truth. It also introduces **Profit Cells** so hypotheses degrade locally instead of globally, and an
+**Options Bootstrap Escrow** so options-lane failures surface as explicit readiness state instead of import-time
+crashes.
+
+## Live assessment snapshot
+
+### Cluster and runtime evidence
+
+Read-only evidence collected on `2026-03-19`:
+
+- `curl -fsS http://torghut.torghut.svc.cluster.local/readyz`
+  - database contract reports `schema_current = true`
+  - expected head is `0024_simulation_runtime_context`
+  - lineage warnings remain for migration forks at `0010` and `0015`
+  - `live_submission_gate.ok = true`
+  - `capital_stage = "0.10x canary"`
+- `curl -fsS http://torghut.torghut.svc.cluster.local/trading/status`
+  - `promotion_eligible_total = 0`
+  - `capital_stage_totals.shadow = 3`
+  - `live_submission_gate.allowed = true`
+- `curl -fsS http://jangar.jangar.svc.cluster.local/api/torghut/trading/control-plane/quant/health?...`
+  - `status = "degraded"`
+  - `latestMetricsCount = 0`
+  - `stages = []`
+- `curl -fsS http://jangar.jangar.svc.cluster.local/api/torghut/trading/control-plane/quant/alerts?...`
+  - critical open alerts for `metrics_pipeline_lag_seconds` across `1m`, `5m`, `15m`, `1h`, `1d`, `5d`, and `20d`
+  - open warning alert for negative `sharpe_annualized`
+- `curl -fsS http://jangar.jangar.svc.cluster.local/api/torghut/market-context/health?symbol=NVDA`
+  - `overallState = "down"`
+  - `bundleFreshnessSeconds = 275280`
+  - ClickHouse ingestion shows `clickhouse_query_failed`
+  - fundamentals and news are stale; technicals and regime are `error`
+- `kubectl -n torghut logs pod/torghut-options-catalog-...`
+  - `password authentication failed for user "torghut_app"`
+- `kubectl -n torghut logs pod/torghut-options-enricher-...`
+  - same DB auth failure
+- `kubectl -n torghut get pod torghut-options-ta-... -o jsonpath=...`
+  - image pull fails with digest `not found`
+
+Interpretation:
+
+- Torghut has healthy schema state but unhealthy profitability evidence state.
+- Current capital truth is too permissive because it is synthesized in multiple places.
+- Options-lane bootstrap failures are currently polluting profitability readiness through crashes instead of explicit
+  cell state.
+
+### Source architecture and test gaps
+
+Relevant source seams:
+
+- `services/torghut/app/main.py`
+  - `_build_live_submission_gate_payload(...)` already composes dependency quorum, empirical readiness, and DSPy
+    readiness, but it still does not own every data-freshness and options-bootstrap input needed for capital truth.
+- `services/torghut/app/trading/scheduler/pipeline.py`
+  - `_live_submission_gate()` remains a separate implementation that only inspects runtime settings and autonomy flags;
+    it does not consume the richer inputs used by `/readyz` and `/trading/status`.
+- `services/torghut/app/trading/hypotheses.py`
+  - hypothesis summaries already carry dependency and continuity signals, but they are not promoted into one durable
+    capital-decision record with expiry and evidence refs.
+- `services/torghut/app/trading/completion.py`
+  - completion aggregation still flattens `continuity_ok` and `dependency_allow` across windows, which is too lossy for
+    lane-local guardrails.
+- `services/torghut/app/options_lane/catalog_service.py` and `services/torghut/app/options_lane/enricher_service.py`
+  - repository construction plus `ensure_rate_bucket_defaults(...)` at import time converts DB auth drift into boot
+    failure before readiness or status can explain the lane state.
+
+Current test gaps:
+
+- no parity test that proves `/readyz`, `/trading/status`, and the live scheduler return the same gate decision for the
+  same hypothesis summary and evidence inputs;
+- no regression that proves `promotion_eligible_total = 0` and `latestMetricsCount = 0` cannot yield live-capital
+  authorization;
+- no options-lane startup regression proving DB auth/image failures are published as explicit bootstrap state instead of
+  crashing the process at import time;
+- no completion-trace regression that preserves distinct continuity dimensions when only one lane is degraded.
+
+## Problem statement
+
+Torghut still has four control contradictions:
+
+1. capital truth is synthesized in multiple places;
+2. schema health is treated too generously relative to evidence freshness;
+3. options-lane bootstrap failures are not isolated as a dedicated readiness dimension;
+4. hypothesis profitability and continuity are not yet evaluated as lane-local profit cells with explicit expiry.
+
+If we do not change this, rollouts will keep oscillating between over-blocking and silent over-permissiveness.
+
+## Alternatives considered
+
+### Option A: retune the existing thresholds and keep separate gate implementations
+
+Pros:
+
+- smallest code change
+- preserves current APIs
+
+Cons:
+
+- the scheduler/status contradiction remains possible
+- options lane still fails before publishing readiness
+- no single audit artifact exists for capital promotion
+
+Decision: rejected.
+
+### Option B: fail closed globally whenever any Torghut surface is degraded
+
+Pros:
+
+- simple safety posture
+- easy to reason about operationally
+
+Cons:
+
+- too coarse for mixed-state profitability systems
+- options bootstrap or collaboration incidents would freeze unrelated equity hypotheses
+- contradicts the goal of explicit failure-mode reduction
+
+Decision: rejected.
+
+### Option C: submission parity council with profit cells and options bootstrap escrow
+
+Pros:
+
+- one gate implementation for status, readiness, and runtime
+- lane-local degradation and promotion rules
+- explicit bootstrap failure semantics for the options lane
+- measurable hypothesis contracts tied to evidence bundles
+
+Cons:
+
+- requires new persistence and a small runtime refactor
+- demands disciplined ownership of data-quorum inputs
+
+Decision: selected.
+
+## Decision
+
+Adopt **Option C**.
+
+Capital truth must become a durable, evidence-backed decision rather than an emergent property of multiple status
+surfaces.
+
+## Proposed architecture
+
+### 1. Submission Parity Council
+
+Create one pure-function module, for example `app/trading/submission_council.py`, that is imported by:
+
+- `/readyz`
+- `/trading/status`
+- `TradingPipeline._live_submission_gate()`
+- any future promotion or deployer validation scripts
+
+Inputs:
+
+- hypothesis summary
+- quant latest-store health
+- quant alert snapshot
+- market-context health bundle
+- empirical-job status
+- DSPy runtime status
+- execution-cell inputs from Jangar
+- options bootstrap status
+
+Outputs:
+
+- `allowed`
+- `capital_state`
+- `reason_codes`
+- `expires_at`
+- `required_cells`
+- `evidence_bundle_ref`
+
+No other path may synthesize a more permissive capital state.
+
+### 2. Profit cells keyed by hypothesis, lane, and account
+
+Persist `profit_cells` with one row per:
+
+- `hypothesis_id`
+- `strategy_family`
+- `account`
+- `lane_id`
+
+Each profit cell records:
+
+- `data_quorum_state`
+- `performance_window_state`
+- `continuity_state`
+- `capital_state`
+- `expires_at`
+- `reason_codes`
+- `evidence_bundle_ref`
+
+Required first-wave cells:
+
+- `H-CONT-01` continuation cell
+- `H-MICRO-01` microstructure cell
+- `H-REV-01` reversal cell
+- `options-bootstrap` cell for options-only hypotheses
+
+### 3. Measurable hypothesis policies and guardrails
+
+The council must evaluate measurable windows before authorizing anything above `observe`.
+
+Required baseline policy for all cells:
+
+- `promotion_eligible_total > 0`
+- `latestMetricsCount > 0`
+- no open critical `metrics_pipeline_lag_seconds` alert for the evaluation window
+- `market_context.overallState != "down"`
+- no required execution cell in `blocked` state
+
+Cell-specific default thresholds:
+
+- `H-CONT-01`
+  - signal continuity healthy
+  - market-context bundle freshness `< 900s`
+  - average post-cost expectancy `> 2bps` across the last 3 market sessions
+  - average absolute slippage `< 8bps`
+- `H-MICRO-01`
+  - route coverage `>= 95%`
+  - empirical decision alignment ratio `>= 0.70`
+  - no continuity alert in the last 2 evaluation windows
+- `H-REV-01`
+  - market-context bundle freshness `< 600s`
+  - no open negative Sharpe alert on the active evaluation horizon
+  - reject ratio `<= 3%`
+
+Promotion states:
+
+- `observe`
+- `0.10x canary`
+- `0.25x canary`
+- `0.50x live`
+- `1.00x live`
+- `quarantine`
+
+If a required freshness or bootstrap condition fails, the cell falls back to `observe` or `quarantine` even when
+schema state remains healthy.
+
+### 4. Options bootstrap escrow
+
+Options services must stop touching the database at import time.
+
+Required changes:
+
+- move `ensure_rate_bucket_defaults(...)` out of module import and into a startup/bootstrap phase;
+- publish `options_bootstrap_status` with explicit states:
+  - `pending`
+  - `db_auth_failed`
+  - `image_unavailable`
+  - `schema_missing`
+  - `ready`
+- wire `options_bootstrap_status` into the submission council as a separate required input for options-only profit
+  cells.
+
+This isolates options failures to options cells while making the failure auditable and testable.
+
+### 5. Evidence bundles and expiry
+
+Every council decision must reference one immutable evidence bundle containing:
+
+- the hypothesis summary snapshot
+- the quant-health payload
+- the alert snapshot
+- the market-context bundle summary
+- the options bootstrap payload
+- the Jangar execution-cell refs used for the decision
+
+Decisions expire on window boundaries. If no fresh evidence renews the bundle, capital falls back one stage rather than
+staying implicitly authorized.
+
+### 6. Completion-trace continuity dimensions
+
+Completion and profitability traces must keep at least these distinct dimensions:
+
+- `dependency_quorum_ok`
+- `signal_continuity_ok`
+- `evidence_continuity_ok`
+- `market_context_quorum_ok`
+- `options_bootstrap_ok`
+
+`continuity_ok` becomes a derived summary only. That keeps demotion logic lane-local and debuggable.
+
+## Validation gates
+
+Engineer gates:
+
+- add parity tests for the submission council used by:
+  - `services/torghut/app/main.py`
+  - `services/torghut/app/trading/scheduler/pipeline.py`
+- add regression proving `promotion_eligible_total = 0` plus `latestMetricsCount = 0` blocks any state above
+  `observe`
+- add options-lane startup tests proving DB auth and image failures surface as bootstrap state instead of import-time
+  crashes
+- add completion-trace tests that preserve distinct continuity subfields
+
+Deployer gates:
+
+- no canary or live promotion while any required critical quant lag alert remains open;
+- no canary or live promotion while `market_context.overallState = "down"`;
+- options capital remains `observe` whenever `options_bootstrap_status != ready`;
+- one forced rollback from `0.10x canary` to `observe` or `quarantine` must persist the evidence bundle and council
+  decision that triggered the rollback.
+
+## Rollout plan
+
+1. Add the submission council in mirror mode and emit advisory decisions into status.
+2. Add profit-cell persistence and options bootstrap status without changing capital authorization.
+3. Switch `/readyz` and `/trading/status` to council-backed responses.
+4. Switch `TradingPipeline` to consume the council result.
+5. Enable canary rollout only after parity tests and a forced demotion drill pass.
+
+## Rollback plan
+
+If council-driven capital gating is too noisy:
+
+- keep writing council decisions and profit-cell rows;
+- revert runtime authorization to advisory mode;
+- preserve all evidence bundles for replay and threshold tuning.
+
+Do not delete profit-cell rows during rollback. They are the audit record for capital decisions.
+
+## Risks and tradeoffs
+
+- Profit cells add persistence and policy surface area.
+- Poorly tuned thresholds could block too much capital.
+- Options bootstrap escrow creates another explicit subsystem to operate.
+
+Mitigations:
+
+- ship in advisory mirror mode first;
+- start with the three current hypothesis ids and options bootstrap only;
+- keep thresholds in versioned policy files and require evidence-bundle references for any override.

--- a/docs/torghut/design-system/v6/index.md
+++ b/docs/torghut/design-system/v6/index.md
@@ -10,6 +10,7 @@
 - Implementation status (strict, core 01-13 docs, source-state refresh `2026-03-09`): `Implemented=7`, `Partial=5`, `Completed=1`
 - Evidence (historical closure): `13-production-gap-closure-master-plan-2026-03-03.md` (Wave 0-6 closure + DoD)
 - Evidence (current next-work priority):
+  - `50-torghut-submission-parity-council-and-options-bootstrap-escrow-2026-03-19.md`
   - `40-control-plane-resilience-and-safer-rollout-for-torghut-quant-2026-03-15.md`
   - `41-torghut-quant-profitability-and-guardrail-architecture-2026-03-15.md`
   - `39-freshness-ledger-and-hypothesis-proof-mesh-2026-03-14.md`
@@ -18,7 +19,7 @@
 - `48-torghut-quant-discover-implementation-readiness-and-handoff-contract-2026-03-16.md`
 - `49-torghut-quant-source-of-truth-and-profit-circuit-handoff-2026-03-19.md`
 - Cross-system source of truth:
-  - `docs/agents/designs/49-jangar-control-plane-execution-truth-spine-and-torghut-profit-circuit-2026-03-19.md`
+  - `docs/agents/designs/51-jangar-control-plane-execution-cells-and-collaboration-failover-2026-03-19.md`
 - Discover stage merge anchor:
   - `42-torghut-quant-control-plane-resilience-and-profitability-architecture-merge-contract-2026-03-15.md`
   - `42-torghut-quant-control-plane-and-profitability-program-2026-03-15.md`
@@ -71,6 +72,9 @@ Current source-state priority is narrower:
 - `49-torghut-quant-source-of-truth-and-profit-circuit-handoff-2026-03-19.md` now binds the v6 Torghut lane to the
   March 19 cross-system source-of-truth architecture, replaces mixed promotion vocabulary with
   `observe/canary/live/scale/quarantine`, and makes scheduler/status parity plus options-bootstrap gating explicit.
+- `50-torghut-submission-parity-council-and-options-bootstrap-escrow-2026-03-19.md` now turns the March 19 mixed-state
+  runtime evidence into one submission-council contract, lane-local profit cells, and an options bootstrap escrow that
+  keeps import-time DB/image failures from masquerading as general profitability truth.
 - `40-control-plane-resilience-and-safer-rollout-for-torghut-quant-2026-03-15.md` now defines segment-local
   control-plane authority and scoped rollout semantics to prevent watch noise from becoming global rollout blockers.
 - `41-torghut-quant-profitability-and-guardrail-architecture-2026-03-15.md` now defines multi-horizon profitability
@@ -159,6 +163,7 @@ This pack is positioned as the next architecture layer above:
 46. `47-torghut-quant-plan-merge-contract-and-handoff-implementation-2026-03-16.md`
 47. `48-torghut-quant-discover-implementation-readiness-and-handoff-contract-2026-03-16.md`
 48. `49-torghut-quant-source-of-truth-and-profit-circuit-handoff-2026-03-19.md`
+49. `50-torghut-submission-parity-council-and-options-bootstrap-escrow-2026-03-19.md`
 
 ## Recommended Build Order
 
@@ -206,6 +211,7 @@ This pack is positioned as the next architecture layer above:
 42. `42-torghut-quant-control-plane-resilience-and-profitability-architecture-merge-contract-2026-03-15.md`
 43. `42-torghut-quant-control-plane-and-profitability-program-2026-03-15.md`
 44. `49-torghut-quant-source-of-truth-and-profit-circuit-handoff-2026-03-19.md`
+45. `50-torghut-submission-parity-council-and-options-bootstrap-escrow-2026-03-19.md`
 
 ## Why This Sequence
 


### PR DESCRIPTION
## Summary

- add a Jangar architecture contract for durable execution cells, preserved unfreeze intent, collaboration failover, and safer rollout predicates
- add a Torghut architecture contract for submission-parity council logic, measurable promotion hypotheses, and options bootstrap escrow
- update the Jangar and Torghut design indexes so the new contracts become the current source of truth for engineer and deployer handoff

## Related Issues

None

## Testing

- `bunx oxfmt --check docs/agents/README.md docs/agents/designs/51-jangar-control-plane-execution-cells-and-collaboration-failover-2026-03-19.md docs/torghut/design-system/v6/index.md docs/torghut/design-system/v6/50-torghut-submission-parity-council-and-options-bootstrap-escrow-2026-03-19.md`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
