### PR TITLE
docs(architecture): add rollout epoch and profit reservation contracts

### DIFF
--- a/docs/agents/designs/52-jangar-rollout-epoch-witness-and-segment-circuit-breakers-2026-03-19.md
+++ b/docs/agents/designs/52-jangar-rollout-epoch-witness-and-segment-circuit-breakers-2026-03-19.md
@@ -1,0 +1,354 @@
+# 52. Jangar Rollout Epoch Witness and Segment Circuit Breakers (2026-03-19)
+
+Status: Ready for merge (discover architecture lane)
+Date: `2026-03-19`
+Owner: Gideon Park (Torghut Traders Architecture)
+Related mission: `codex/swarm-torghut-quant-discover`
+Swarm impacts:
+
+- `jangar-control-plane`
+- `torghut-quant`
+
+Extends:
+
+- `49-jangar-control-plane-authority-ledger-and-expiry-watchdog-2026-03-19.md`
+- `50-torghut-hypothesis-capital-governor-and-data-quorum-2026-03-19.md`
+
+## Executive summary
+
+The March 19 live state shows that Jangar has improved raw control-plane health, but rollout truth is still too
+optimistic and too producer-centric:
+
+- `GET /api/agents/control-plane/status?namespace=agents` reports `dependency_quorum.decision = allow`,
+  `rollout_health.status = healthy`, and `database.status = healthy`;
+- the same payload also shows `watch_reliability.total_restarts = 5` in the last 15 minutes and
+  `leader_election.lease_namespace = default`;
+- Torghut reports `critical_toggle_parity.status = diverged` because
+  `TRADING_AUTONOMY_ALLOW_LIVE_PROMOTION` is effectively `true` while the shadow-first contract expects `false`;
+- required Huly worker verification timed out while calling
+  `GET /api/v1/account/c9b87368-e7a2-483f-885f-ff179e258950` on
+  `http://transactor.huly.svc.cluster.local`, which means a collaboration dependency can fail before the stage can
+  publish its artifacts.
+
+The architecture change in this document is to move from "Jangar says the control plane looks healthy" to a
+**Rollout Epoch Witness** that only becomes authoritative after consumers acknowledge the expected revision and config
+contract. Failures are then handled by **segment circuit breakers** so collaboration, watch churn, or one consumer's
+config drift cannot silently advance rollout or freeze unrelated runtime segments.
+
+## Mission inputs and success criteria
+
+Observed mission inputs:
+
+- repository: `proompteng/lab`
+- base: `main`
+- head: `codex/swarm-torghut-quant-discover`
+- swarmName: `torghut-quant`
+- swarmStage: `discover`
+- ownerChannel: `swarm://owner/trading`
+
+Success for this architecture artifact is:
+
+1. current cluster, source, database, and collaboration failure evidence captured with concrete read-only proof;
+2. alternatives considered and one chosen with explicit tradeoffs;
+3. engineer and deployer stages receive a single rollout-truth contract rather than multiple partially trusted
+   endpoints;
+4. rollout and rollback behavior become testable in terms of revision acknowledgement, segment health, and expiry.
+
+## Assessment snapshot
+
+### Cluster health, rollout, and collaboration evidence
+
+Read-only evidence captured on `2026-03-19`:
+
+- `curl -fsS 'http://jangar.jangar.svc.cluster.local/api/agents/control-plane/status?namespace=agents' | jq '{generated_at,leader_election,watch_reliability,rollout_health,dependency_quorum,database}'`
+  - `rollout_health.status = "healthy"`
+  - `dependency_quorum.decision = "allow"`
+  - `database.status = "healthy"`
+  - `watch_reliability.total_restarts = 5` across five watched streams in the last `15` minutes
+  - `leader_election.lease_namespace = "default"`
+- `curl -fsS http://torghut.torghut.svc.cluster.local/trading/status | jq '{shadow_first,live_submission_gate,control_plane_contract}'`
+  - `shadow_first.capital_stage = "shadow"`
+  - `live_submission_gate.allowed = true`
+  - `live_submission_gate.capital_stage = "0.10x canary"`
+  - `control_plane_contract.critical_toggle_parity.status = "diverged"`
+- `python3 skills/huly-api/scripts/huly-api.py --operation account-info ...`
+  - timed out while calling `GET /api/v1/account/c9b87368-e7a2-483f-885f-ff179e258950`
+- `python3 skills/huly-api/scripts/huly-api.py --operation list-channel-messages ...`
+  - timed out on the same account lookup path before any channel read could happen
+- `python3 skills/huly-api/scripts/huly-api.py --operation account-info --base-url https://huly.proompteng.ai ...`
+  - returned Cloudflare `403 / Error 1010`, so the public host is not a reliable worker fallback
+
+Interpretation:
+
+- Jangar can currently declare healthy rollout segments without proving that consumers applied the expected config or
+  toggle state.
+- Collaboration is operationally mandatory but architecturally invisible; today it fails as an opaque precondition,
+  not as a tracked dependency segment.
+- Watch restarts are observable, but they do not create an epoch boundary that forces re-acknowledgement from
+  dependent runtimes.
+
+### Source architecture and high-risk modules
+
+Relevant implementation surfaces on the current branch:
+
+- `services/jangar/src/server/control-plane-status.ts`
+  - `DEFAULT_EXECUTION_TRUST_ENABLED = false`
+  - rollout, watch, leader-election, and database health are reported, but consumer acknowledgement is not a required
+    predicate for `dependency_quorum = allow`
+- `services/jangar/scripts/codex/codex-implement.ts`
+  - cross-swarm Huly initialization calls `listChannelMessages(...)` and `verifyChatAccess(...)` before continuing
+  - failures are rethrown, so collaboration transport problems can fail the stage before owner updates or mission
+    artifact repair
+- `services/torghut/app/main.py`
+  - `_build_shadow_first_toggle_parity()` exposes config drift
+  - `_build_live_submission_gate_payload(...)` can still set `capital_stage = "0.10x canary"` when allowed and the
+    active capital stage is only `shadow`
+- `services/jangar/src/server/torghut-quant-runtime.ts`
+  - quant control-plane state is still stored in `globalThis` and refreshed by per-process `setInterval(...)` loops
+  - that is workable for one replica, but it is not yet an acknowledged multi-writer contract
+- existing docs already define an authority ledger and capital governor, but neither document introduces
+  a required **consumer-side acknowledgement** that the live runtime accepted the exact rollout epoch Jangar intended.
+
+Current missing tests:
+
+- no regression proving `dependency_quorum = allow` is impossible when a dependent consumer reports config-hash drift;
+- no regression proving watch restarts force a new rollout epoch rather than remaining informational noise;
+- no regression proving Huly collaboration timeouts become a segment-local hold instead of aborting the whole mission
+  path;
+- no regression proving the Jangar quant runtime behaves idempotently once more than one web process emits control-plane
+  metrics;
+- no deployer drill proving one unhealthy consumer blocks only its own promotion lane rather than the entire control
+  plane.
+
+### Database and data continuity evidence
+
+The Jangar database itself is healthy:
+
+- `database.connected = true`
+- `database.migration_consistency.applied_count = 24`
+- `database.migration_consistency.unapplied_count = 0`
+
+The problem is not storage health. The problem is missing **cross-system truth continuity**:
+
+- Jangar can persist a healthy control-plane view;
+- Torghut can simultaneously report config drift and contradictory capital semantics;
+- the system has no durable row that says "epoch X was published, consumer Y acknowledged config hash Z, and segment
+  Q was still degraded at T".
+
+## Problem statement
+
+The current control-plane topology still has four dangerous blind spots:
+
+1. rollout truth is based on producer health and inferred consumer behavior, not explicit consumer acknowledgement;
+2. collaboration/auth transport failures are hard blockers in practice but are not modeled as first-class segment
+   failures;
+3. watch churn has no durable epoch boundary, so healthy-looking summaries can outlive the evidence that justified
+   them;
+4. deployer stages cannot answer "which revision, config hash, and dependency segments were actually acknowledged by
+   Torghut when Jangar allowed promotion?"
+
+That means safer rollout behavior still depends on reading several endpoints and making human inferences. The next
+architecture step must make acknowledgement and expiry explicit.
+
+## Alternatives considered
+
+### Option A: keep the current authority-ledger and tune thresholds
+
+Pros:
+
+- smallest implementation delta
+- reuses the March 19 ledger work
+
+Cons:
+
+- still no consumer acknowledgement contract
+- still no clean way to represent Huly transport failure as a segment-local hold
+- watch restarts remain a warning, not a rollout epoch boundary
+
+### Option B: add Torghut acknowledgement only
+
+Pros:
+
+- directly addresses config drift between Jangar and Torghut
+- limited scope
+
+Cons:
+
+- does not solve collaboration failures
+- does not generalize to other dependent runtimes or future consumers
+- still lacks a common circuit-breaker contract for rollout, evidence, and external services
+
+### Option C: Rollout Epoch Witness plus Segment Circuit Breakers
+
+Pros:
+
+- makes rollout truth depend on both producer health and consumer acknowledgement
+- allows collaboration, watch, or evidence failures to degrade the right segment without silently advancing rollout
+- produces durable evidence for rollout, rollback, and incident replay
+
+Cons:
+
+- broader schema and controller changes
+- requires explicit expiry semantics and acknowledgement plumbing in dependent runtimes
+
+## Decision
+
+Adopt **Option C**.
+
+The March 19 evidence shows that the current architecture is close to healthy but still lacks the one property needed
+for safer rollout: a single durable record that ties `published intent` to `consumer acknowledgement` and
+`segment health`. Threshold tuning alone does not close that gap.
+
+## Proposed architecture
+
+### 1. Rollout Epoch Witness
+
+Introduce a durable `control_plane_rollout_epochs` record keyed by `{service, revision, rollout_epoch_id}` with:
+
+- `published_revision`
+- `expected_config_hash`
+- `expected_toggle_hash`
+- `authority_decision_id`
+- `required_segments`
+- `published_at`
+- `expires_at`
+- `rollback_epoch_id`
+- `evidence_bundle_ref`
+
+Jangar becomes the publisher of the epoch. A rollout is not authoritative until the intended consumers acknowledge it.
+
+### 2. Consumer acknowledgement rows
+
+Introduce `control_plane_epoch_acknowledgements` keyed by `{rollout_epoch_id, consumer}` with:
+
+- `consumer` (`torghut`, `agents-controllers`, `jangar-worker`, future runtimes)
+- `observed_revision`
+- `effective_config_hash`
+- `effective_toggle_hash`
+- `ack_state` (`aligned`, `drifted`, `expired`, `missing`)
+- `observed_at`
+- `expires_at`
+- `segment_snapshot`
+
+This closes the current truth gap where Torghut can expose `critical_toggle_parity = diverged` while Jangar still says
+dependency quorum is healthy.
+
+### 3. Segment circuit breakers
+
+Model rollout health as explicit segments rather than one summary:
+
+- `control_runtime`
+- `consumer_config_parity`
+- `watch_stream`
+- `database_migration`
+- `evidence_authority`
+- `simulation_capacity`
+- `external_collaboration`
+
+Each segment has `status in {healthy, hold, block, unknown}` plus reason codes and expiry. The important behavior
+change is that a failure in `external_collaboration` or one consumer's `consumer_config_parity` can block the affected
+lane without falsely rewriting unrelated segment truth.
+
+### 4. Safe rollout semantics
+
+Rollout progression becomes:
+
+1. publish rollout epoch;
+2. wait for required acknowledgements;
+3. allow `shadow -> canary` only when `control_runtime`, `consumer_config_parity`, `database_migration`, and
+   `evidence_authority` are healthy;
+4. keep `external_collaboration` mandatory for mission-closeout artifacts, but do not let it erase or overwrite an
+   already acknowledged runtime epoch;
+5. expire the epoch automatically if acknowledgements are stale or watch-stream churn crosses the epoch threshold.
+
+This is safer than the current model because watch restarts and config drift now force re-acknowledgement instead of
+remaining passive warnings.
+
+### 5. Collaboration outbox and replay
+
+When Huly verification or mission upsert fails:
+
+- write a `collaboration_outbox` row with the intended issue, document, and channel payloads;
+- mark `external_collaboration = hold`;
+- preserve the rollout epoch and all runtime acknowledgements;
+- replay the outbox when the collaborator path is healthy again.
+
+The mission still fails its collaboration acceptance gate, but the system no longer loses the runtime truth that
+existed at the time of failure.
+
+### 6. Evidence bundle shape
+
+Each epoch references an immutable bundle containing:
+
+- Jangar control-plane status snapshot
+- dependent consumer status snapshot
+- config and toggle hashes
+- collaboration probe result
+- warning event digest
+- rollout intent and rollback target
+
+Engineer and deployer then share the same proof artifact when diagnosing a blocked or expired epoch.
+
+## Validation gates
+
+Engineer gates:
+
+- add control-plane tests proving a `drifted` or `missing` acknowledgement blocks rollout even when rollout health is
+  otherwise healthy;
+- add tests proving watch restart churn opens a new epoch and expires the old one;
+- add `codex-implement.ts` tests proving Huly timeout writes collaboration outbox state and segment status instead of
+  only throwing;
+- add Torghut/Jangar contract tests proving the reported config hash and toggle hash match the acknowledged epoch.
+
+Deployer gates:
+
+- one drill where Torghut reports config drift must keep rollout in `hold` and prevent canary;
+- one drill where Huly times out must preserve the runtime epoch while failing the artifact-closeout gate;
+- one drill where watch-stream churn exceeds policy must expire the old epoch and require fresh acknowledgement;
+- no merge to live rollout unless the active epoch has unexpired acknowledgements for every required consumer.
+
+## Rollout plan
+
+1. Add additive tables for rollout epochs, acknowledgements, and collaboration outbox.
+2. Emit config/toggle hashes from Torghut and other consumers into status responses.
+3. Teach Jangar to publish epochs and read acknowledgements in advisory mode.
+4. Switch rollout admission to epoch-backed mode in canary.
+5. Move Huly failure handling from fatal precondition to tracked `external_collaboration` segment plus replay outbox.
+
+## Rollback plan
+
+If epoch-backed admission proves too strict:
+
+- keep writing epochs and acknowledgements;
+- revert deployment admission to advisory mode;
+- preserve collaboration outbox and evidence bundles for replay;
+- never delete the epoch rows from an incident window.
+
+## Risks and tradeoffs
+
+- more persistence means more retention and schema management;
+- config-hash canonicalization must stay stable across services;
+- collaboration outbox replay adds operational moving parts.
+
+Mitigations:
+
+- derive hashes from a versioned manifest serializer;
+- version the evidence bundle schema;
+- bound outbox retries and publish explicit expiry reasons.
+
+## Engineer and deployer handoff contract
+
+Engineer must deliver:
+
+1. rollout epoch and acknowledgement schemas;
+2. consumer-side config and toggle hash publication;
+3. segment circuit-breaker evaluation logic;
+4. Huly collaboration outbox and replay handling;
+5. regression coverage for drift, timeout, expiry, and watch churn.
+
+Deployer must validate:
+
+1. rollout never advances without a fresh acknowledged epoch;
+2. config drift blocks only the affected consumer lane;
+3. Huly transport failure blocks artifact completion without erasing runtime truth;
+4. rollback reuses the same epoch/evidence model instead of ad hoc log reconstruction.

--- a/docs/torghut/design-system/README.md
+++ b/docs/torghut/design-system/README.md
@@ -37,6 +37,8 @@ If you are trying to decide which docs are current contract truth versus histori
 - `docs/torghut/design-system/current-source-of-truth-and-priority-guide-2026-03-09.md`
 - `docs/agents/designs/49-jangar-control-plane-authority-ledger-and-expiry-watchdog-2026-03-19.md`
 - `docs/agents/designs/50-torghut-hypothesis-capital-governor-and-data-quorum-2026-03-19.md`
+- `docs/agents/designs/52-jangar-rollout-epoch-witness-and-segment-circuit-breakers-2026-03-19.md`
+- `docs/torghut/design-system/v6/51-torghut-profit-reservations-schema-witness-and-simulation-slot-ledger-2026-03-19.md`
 
 That guide is the canonical reading order for the current corpus.
 

--- a/docs/torghut/design-system/current-source-of-truth-and-priority-guide-2026-03-09.md
+++ b/docs/torghut/design-system/current-source-of-truth-and-priority-guide-2026-03-09.md
@@ -48,6 +48,8 @@ If the question is "what should I trust right now?", start here:
    - `docs/torghut/design-system/v6/44-torghut-quant-plan-design-document-and-handoff-contract-2026-03-15.md`
    - `docs/agents/designs/49-jangar-control-plane-authority-ledger-and-expiry-watchdog-2026-03-19.md`
    - `docs/agents/designs/50-torghut-hypothesis-capital-governor-and-data-quorum-2026-03-19.md`
+   - `docs/agents/designs/52-jangar-rollout-epoch-witness-and-segment-circuit-breakers-2026-03-19.md`
+   - `docs/torghut/design-system/v6/51-torghut-profit-reservations-schema-witness-and-simulation-slot-ledger-2026-03-19.md`
 
 4. options-lane current design source of truth:
    - `docs/torghut/design-system/v6/33-alpaca-options-market-data-and-technical-analysis-lane-2026-03-08.md`
@@ -59,16 +61,21 @@ The current highest-priority work is:
 
 1. replace optional/stale control-plane truth with the authority-ledger and expiry-watchdog contract in
    `docs/agents/designs/49-jangar-control-plane-authority-ledger-and-expiry-watchdog-2026-03-19.md`;
-2. force capital-stage decisions through the hypothesis capital governor and data-quorum contract in
+2. make rollout truth depend on rollout-epoch acknowledgement and segment circuit breakers in
+   `docs/agents/designs/52-jangar-rollout-epoch-witness-and-segment-circuit-breakers-2026-03-19.md`;
+3. force capital-stage decisions through the hypothesis capital governor and data-quorum contract in
    `docs/agents/designs/50-torghut-hypothesis-capital-governor-and-data-quorum-2026-03-19.md`;
-3. keep producer-authored freshness and proof bundles active by continuing the ledger direction defined in
+4. make non-shadow capital depend on expiring profit reservations, schema fitness, and simulation slot ownership in
+   `docs/torghut/design-system/v6/51-torghut-profit-reservations-schema-witness-and-simulation-slot-ledger-2026-03-19.md`;
+5. keep producer-authored freshness and proof bundles active by continuing the ledger direction defined in
    `docs/torghut/design-system/v6/39-freshness-ledger-and-hypothesis-proof-mesh-2026-03-14.md`;
-4. isolate control-plane failure domains with rollout-safe gates in
+6. isolate control-plane failure domains with rollout-safe gates in
    `docs/torghut/design-system/v6/40-control-plane-resilience-and-safer-rollout-for-torghut-quant-2026-03-15.md`;
-5. retain hypothesis-specific profitability guardrails from
+7. retain hypothesis-specific profitability guardrails from
    `docs/torghut/design-system/v6/41-torghut-quant-profitability-and-guardrail-architecture-2026-03-15.md`,
    but make them subordinate to fresh data quorum and immutable evidence bundles;
-6. execute the merged control-plane/profitability program with the March 19 authority and governor contracts layered on
+8. execute the merged control-plane/profitability program with the March 19 authority, epoch, governor, and reservation
+   contracts layered on
    top of the March 15-16 design set.
 
 This means the current next work is not:
@@ -121,6 +128,8 @@ These are still active contract docs rather than historical snapshots:
 - `docs/torghut/design-system/v6/44-torghut-quant-plan-design-document-and-handoff-contract-2026-03-15.md`
 - `docs/agents/designs/49-jangar-control-plane-authority-ledger-and-expiry-watchdog-2026-03-19.md`
 - `docs/agents/designs/50-torghut-hypothesis-capital-governor-and-data-quorum-2026-03-19.md`
+- `docs/agents/designs/52-jangar-rollout-epoch-witness-and-segment-circuit-breakers-2026-03-19.md`
+- `docs/torghut/design-system/v6/51-torghut-profit-reservations-schema-witness-and-simulation-slot-ledger-2026-03-19.md`
 - `docs/torghut/design-system/v6/33-alpaca-options-market-data-and-technical-analysis-lane-2026-03-08.md`
 - `docs/torghut/design-system/v6/34-alpaca-options-lane-implementation-contract-set-2026-03-08.md`
 

--- a/docs/torghut/design-system/v6/51-torghut-profit-reservations-schema-witness-and-simulation-slot-ledger-2026-03-19.md
+++ b/docs/torghut/design-system/v6/51-torghut-profit-reservations-schema-witness-and-simulation-slot-ledger-2026-03-19.md
@@ -1,0 +1,396 @@
+# 51. Torghut Profit Reservations, Schema Witness, and Simulation Slot Ledger (2026-03-19)
+
+Status: Ready for merge (discover architecture lane)
+Date: `2026-03-19`
+Owner: Gideon Park (Torghut Traders Architecture)
+Related mission: `codex/swarm-torghut-quant-discover`
+Companion docs:
+
+- `docs/agents/designs/52-jangar-rollout-epoch-witness-and-segment-circuit-breakers-2026-03-19.md`
+- `docs/agents/designs/50-torghut-hypothesis-capital-governor-and-data-quorum-2026-03-19.md`
+
+## Executive summary
+
+The March 19 live runtime exposes a profitability control contradiction that the current architecture does not fully
+close:
+
+- `GET /trading/status` reports `live_submission_gate.allowed = true` and upgrades `shadow` to `0.10x canary`;
+- the same payload reports `active_capital_stage = "shadow"`,
+  `alpha_readiness_promotion_eligible_total = 0`, and
+  `critical_toggle_parity.status = "diverged"`;
+- runtime logs show `lean_strategy_shadow_evaluations.parity_status` rejecting
+  `blocked_missing_empirical_authority` because the column is only `varchar(32)`, which then cascades into
+  `PendingRollbackError` and `torghut.runtime.loop_failed`;
+- options-lane services are failing before steady state because database auth and image pull are red;
+- historical simulation workflows are repeatedly failing on
+  `simulation_runtime_lock_held:<run_id>:<dataset_id>` because there is only one namespace-wide runtime lock.
+
+The architecture change in this document is to make non-shadow capital depend on an expiring **Profit Reservation**
+that is backed by a **Schema Witness** and a **Simulation Slot Ledger**. A hypothesis may only hold canary/live
+capital while its reservation remains fresh, its required subsystem segments are healthy, and its prove loop owns a
+compatible simulation slot.
+
+## Assessment snapshot
+
+### Cluster health, rollout, and runtime evidence
+
+Read-only evidence captured on `2026-03-19`:
+
+- `kubectl get pods -n torghut --no-headers | awk '$3!="Running" && $3!="Completed" {print $1, $2, $3, $4, $5}'`
+  - `torghut-options-catalog ... CrashLoopBackOff`
+  - `torghut-options-enricher ... CrashLoopBackOff`
+  - `torghut-options-ta ... ImagePullBackOff`
+  - `torghut-dspy-cluster-runner ... Error`
+- `kubectl get pods -n argo-workflows | rg 'torghut-historical-simulation'`
+  - recent workflow pods remain dominated by `Error`
+- `kubectl get events -n torghut --sort-by=.lastTimestamp | tail -n 40`
+  - `torghut-00153` had startup, readiness, and liveness failures before stabilizing
+  - options pods are still in backoff and image-pull failure loops
+- `kubectl logs -n argo-workflows torghut-historical-simulation-2blt5 -c main --tail=120`
+  - failed with `simulation_runtime_lock_held:sim-proof-884bec35-march18-refresh-20260319-080910:torghut-full-day-20260318-884bec35`
+
+Interpretation:
+
+- the core Torghut runtime is still available;
+- prove, options, and support lanes are not reliable enough to be treated as implicit prerequisites for live capital;
+- a single namespace-wide simulation lock is too coarse for repeated empirical workflows.
+
+### Source architecture and test gaps
+
+Relevant current-branch implementation surfaces:
+
+- `services/torghut/app/main.py`
+  - `_build_live_submission_gate_payload(...)` sets `allowed = true` when promotion, empirical, DSPy, and dependency
+    checks pass, then upgrades `shadow` to `0.10x canary`
+  - `_build_shadow_first_toggle_parity()` correctly exposes config drift, but that drift does not currently force a
+    stricter gate than `allowed = true`
+- `services/torghut/app/trading/hypotheses.py`
+  - `compile_hypothesis_runtime_statuses(...)` evaluates every manifest against one shared TCA summary
+  - `max_rolling_drawdown_bps` exists in the manifest, but the promotion path does not currently enforce it
+- `services/torghut/app/models/entities.py`
+  - `lean_strategy_shadow_evaluations.parity_status` is `String(length=32)`
+- `services/torghut/app/db.py` and `services/torghut/app/main.py`
+  - startup still calls `metadata.create_all()` / `Base.metadata.create_all()`
+  - that can create ORM-declared tables outside Alembic and weaken drift detection for migration-only objects
+- `services/torghut/migrations/versions/0012_lean_multilane_foundation.py`
+  - creates the same `String(length=32)` column in the database
+- `services/torghut/app/lean_runner.py`
+  - emits `blocked_missing_empirical_authority`, which is longer than the current schema
+- `services/torghut/app/options_lane/catalog_service.py` and `services/torghut/app/options_lane/enricher_service.py`
+  - construct `OptionsRepository(...)` and call `ensure_rate_bucket_defaults(...)` at module import time
+  - this makes DB auth drift a boot-time crash rather than a surfaced readiness segment
+- `services/torghut/scripts/start_historical_simulation.py`
+  - uses a single namespace-wide `ConfigMap/torghut-historical-simulation-lock`
+  - when a different run owns it, the workflow fails with `simulation_runtime_lock_held`
+
+Current missing tests:
+
+- no regression proving `critical_toggle_parity = diverged` forces capital to stay `observe` or `shadow`;
+- no regression proving TCA profitability inputs remain isolated per hypothesis or strategy family;
+- no regression proving `max_rolling_drawdown_bps` changes readiness or capital state;
+- no regression proving schema-write incompatibility blocks canary/live reservations;
+- no regression proving options bootstrap red status leaves unrelated hypotheses free to collect evidence while
+  keeping options-dependent hypotheses in `observe`;
+- no regression proving multiple empirical workflows can queue by dataset/hypothesis without clobbering one another.
+
+### Database and data quality evidence
+
+Read-only evidence captured on `2026-03-19`:
+
+- `curl -fsS http://torghut.torghut.svc.cluster.local/db-check`
+  - `schema_current = true`
+  - current head is `0024_simulation_runtime_context`
+  - lineage warnings remain because parent forks are present
+- `curl -fsS http://torghut.torghut.svc.cluster.local/trading/status | jq '{shadow_first,live_submission_gate,market_context,metrics,control_plane_contract}'`
+  - `shadow_first.capital_stage = "shadow"`
+  - `live_submission_gate.allowed = true`
+  - `market_context.alert_active = true`
+  - fundamentals and news are stale
+  - `metrics.orders_submitted_total = 0`
+  - `metrics.orders_rejected_total = 23`
+  - `metrics.domain_telemetry_event_total["torghut.runtime.loop_failed"] = 18`
+  - `metrics.lean_strategy_shadow_total = {"blocked_missing_empirical_authority":16,"error":16}`
+- `kubectl logs -n torghut torghut-00153-deployment-... -c user-container --tail=120`
+  - repeated `StringDataRightTruncation` on `lean_strategy_shadow_evaluations.parity_status`
+  - followed by `PendingRollbackError`, which contaminates later runtime work in the same session
+- `kubectl logs -n torghut torghut-options-catalog-... --tail=120`
+  - `password authentication failed for user "torghut_app"`
+- `kubectl logs -n torghut torghut-options-enricher-... --tail=120`
+  - same DB auth failure
+
+Interpretation:
+
+- `schema_current = true` is not sufficient for capital safety;
+- ORM startup DDL can mask migration drift, so the witness has to reason about write compatibility and ownership, not
+  only current Alembic heads;
+- the live runtime needs a notion of **schema fitness for the writes it will actually attempt**;
+- options readiness and simulation capacity must become explicit reservation dependencies rather than incidental pod
+  symptoms.
+
+## Problem statement
+
+The current Torghut architecture still lets several dangerous contradictions coexist:
+
+1. status and scheduler can imply live-capital readiness even when the active hypothesis state is only `shadow`;
+2. profitability inputs are still partially shared across hypotheses, which lets one lane's TCA window influence
+   unrelated promotion decisions;
+3. schema drift is treated as binary `current/not current`, which misses write-compatibility failures such as the
+   `parity_status` width mismatch;
+4. prove workflows contend on one coarse lock, turning empirical automation into a source of recurring failures;
+5. options-lane boot failures are visible only as pod crashes, not as a typed dependency segment that the capital path
+   can consume.
+
+Minor bug fixes would help, but they would not create a durable capital contract. The system needs a capital object
+that expires, carries evidence, and can be withdrawn when its dependencies degrade.
+
+## Alternatives considered
+
+### Option A: patch each failure individually
+
+Pros:
+
+- quickest path to partial improvement
+- addresses today's concrete bugs
+
+Cons:
+
+- still no authoritative capital object
+- still no shared status/scheduler/runtime contract
+- simulation prove loops would remain globally serialized in a fragile way
+
+### Option B: enforce a stricter global gate
+
+Pros:
+
+- simple to explain
+- safer than today's optimistic gate
+
+Cons:
+
+- too coarse
+- turns options or prove-lane failures into whole-portfolio freezes
+- does not isolate hypotheses by required subsystems
+
+### Option C: Profit Reservations + Schema Witness + Simulation Slot Ledger
+
+Pros:
+
+- makes capital explicit, expiring, and auditable
+- isolates failures to the hypotheses and lanes that depend on the broken subsystem
+- turns simulation contention into a schedulable resource instead of a namespace-wide collision
+
+Cons:
+
+- larger schema and contract surface
+- requires shared status/scheduler/runtime adoption
+
+## Decision
+
+Adopt **Option C**.
+
+The runtime evidence is already telling us what the architecture is missing: capital cannot be a derived side effect of
+several summaries. It needs to be a first-class reservation object that is granted, renewed, or revoked based on
+measurable evidence and subsystem health.
+
+## Proposed architecture
+
+### 1. Profit Reservation ledger
+
+Introduce `profit_reservations` keyed by `{hypothesis_id, candidate_id, account, reservation_window}` with:
+
+- `reservation_id`
+- `capital_state_requested`
+- `capital_state_granted`
+- `rollout_epoch_id`
+- `schema_witness_id`
+- `simulation_slot_id`
+- `required_segments`
+- `blocked_reasons`
+- `evidence_bundle_refs`
+- `granted_at`
+- `expires_at`
+
+Use standardized granted states:
+
+- `observe`
+- `canary_0_10x`
+- `canary_0_25x`
+- `live`
+- `scale`
+- `quarantine`
+
+Non-shadow order submission requires an unexpired reservation in one of the non-observe states.
+
+### 2. Schema Witness
+
+Introduce a `schema_witnesses` record that extends `/db-check` with write-contract compatibility:
+
+- `schema_head_signature`
+- `schema_graph_signature`
+- `lineage_warning_count`
+- `write_contract_version`
+- `write_contract_hash`
+- `compatibility_state`
+- `failing_tables`
+- `failing_columns`
+- `observed_at`
+- `expires_at`
+
+Examples of witness failures:
+
+- `lean_strategy_shadow_evaluations.parity_status` cannot hold the longest emitted status string
+- startup-created ORM tables drift from Alembic ownership or omit migration-only structures
+- required options tables or grants are missing
+- runtime writes are failing even though migration heads are current
+
+Capital reservations must treat `compatibility_state != healthy` as a blocking reason.
+
+### 3. Segment-scoped reservation dependencies
+
+Each hypothesis declares its required segments, for example:
+
+- `market_context`
+- `ta_core`
+- `options_data`
+- `lean_shadow`
+- `empirical_jobs`
+- `simulation_capacity`
+- `consumer_config_parity`
+
+This preserves blast-radius isolation:
+
+- an options-lane outage blocks only options-dependent reservations;
+- a schema witness failure in `lean_shadow` blocks hypotheses that depend on shadow parity proof;
+- a consumer config drift from the rollout epoch blocks any reservation that requires aligned capital policy.
+
+### 4. Simulation Slot Ledger
+
+Replace the single namespace-wide ConfigMap lock with `simulation_slots` keyed by:
+
+- `dataset_snapshot_ref`
+- `hypothesis_family`
+- `account`
+- `window`
+
+Each slot carries:
+
+- `slot_id`
+- `owner_run_id`
+- `slot_state` (`queued`, `leased`, `expired`, `released`)
+- `leased_at`
+- `lease_expires_at`
+- `replayable`
+- `artifact_root`
+
+Multiple prove workflows can then queue safely when they target different datasets or hypothesis families, while exact
+conflicts become explicit leased slots rather than hard failures.
+
+### 5. Shared decision function
+
+`/trading/status`, scheduler submission, and execution adapters must all consume the same reservation decision:
+
+- if `critical_toggle_parity = diverged`, reservations fall back to `observe`;
+- if `promotion_eligible_total <= 0`, reservations cannot exceed `observe`;
+- if `market_context` or other required segments are stale, reservations expire or remain blocked;
+- if the schema witness or slot lease is invalid, live-capital submission is denied even when the old gate would have
+  said `allowed = true`.
+
+This removes the current contradiction where status can expose drift while the live gate still claims readiness.
+
+### 6. Guardrails for measurable trading hypotheses
+
+Every hypothesis must define reservation guardrails in two windows:
+
+- freshness window
+  - required segments fresh
+  - schema witness healthy
+  - simulation slot either not required or currently leased
+  - no critical runtime-loop failure burst
+- performance window
+  - minimum sample count
+  - minimum post-cost expectancy
+  - maximum slippage
+  - maximum rejection ratio
+  - no repeated rollback condition
+
+Reservation renewal requires both windows to pass. Expiry or repeated failure forces `observe` or `quarantine`.
+
+### 7. Options subsystem contract
+
+Options-capable hypotheses cannot leave `observe` until:
+
+- image availability is proven for the options TA worker;
+- DB auth succeeds for catalog and enricher services;
+- rate-bucket bootstrap completed after service start, not only at import time;
+- readiness publishes an explicit `options_bootstrap` state with heartbeat freshness.
+
+This converts today's crash loops into typed reservation reasons such as:
+
+- `options_db_auth_invalid`
+- `options_image_unavailable`
+- `options_bootstrap_incomplete`
+- `options_schema_incompatible`
+
+## Validation gates
+
+Engineer gates:
+
+- add status/scheduler parity tests proving `critical_toggle_parity = diverged` cannot coexist with a non-observe
+  reservation;
+- add schema witness tests covering the `parity_status` width mismatch and other write-contract failures;
+- add options readiness tests proving DB auth drift becomes a typed segment failure rather than only a boot crash;
+- add simulation slot tests proving conflicting runs queue or lease cleanly instead of failing with a shared lock
+  collision.
+
+Deployer gates:
+
+- no hypothesis receives `canary_0_10x` or above without a fresh reservation and schema witness;
+- induce a schema-write failure and confirm reservations downgrade to `observe` or `quarantine`;
+- induce an options bootstrap failure and confirm only options-dependent hypotheses are blocked;
+- run concurrent empirical workflows and confirm slot leasing is deterministic and observable.
+
+## Rollout plan
+
+1. Add additive tables for profit reservations, schema witnesses, and simulation slots.
+2. Emit reservation and witness payloads alongside existing status responses.
+3. Switch scheduler admission to reservation-backed mode in advisory shadow.
+4. Move options bootstrap and schema-fitness checks into typed readiness segments.
+5. Replace the namespace-wide simulation lock with slot leasing and expiry.
+
+## Rollback plan
+
+If reservation-backed admission is too strict:
+
+- keep writing reservations, schema witnesses, and slot rows;
+- demote consumption back to advisory mode;
+- preserve the evidence rows for replay and tuning;
+- do not reintroduce the namespace-wide simulation lock once slot state exists.
+
+## Risks and tradeoffs
+
+- more stateful control objects increase schema and retention cost;
+- reservation expiry tuning can be noisy if freshness windows are too tight;
+- slot scheduling adds queueing behavior that must be visible to operators.
+
+Mitigations:
+
+- version the witness and reservation schemas;
+- keep expiry defaults conservative and tune from observed windows;
+- export slot, witness, and reservation metrics directly in `/trading/status`.
+
+## Engineer and deployer handoff contract
+
+Engineer must deliver:
+
+1. reservation, witness, and slot data models;
+2. one shared reservation decision function for status and scheduler;
+3. schema-fitness probes for live runtime writes;
+4. options bootstrap publication as readiness state;
+5. regression coverage for drift, schema mismatch, slot contention, and segment-local demotion.
+
+Deployer must validate:
+
+1. non-observe capital never exists without a fresh reservation;
+2. schema incompatibility downgrades capital before runtime loops fail repeatedly;
+3. options failures remain hypothesis-local;
+4. empirical workflows can run concurrently through slot leasing without recreating the current lock backlog.

--- a/docs/torghut/design-system/v6/index.md
+++ b/docs/torghut/design-system/v6/index.md
@@ -11,6 +11,7 @@
 - Evidence (historical closure): `13-production-gap-closure-master-plan-2026-03-03.md` (Wave 0-6 closure + DoD)
 - Evidence (current next-work priority):
   - `50-torghut-submission-parity-council-and-options-bootstrap-escrow-2026-03-19.md`
+  - `51-torghut-profit-reservations-schema-witness-and-simulation-slot-ledger-2026-03-19.md`
   - `40-control-plane-resilience-and-safer-rollout-for-torghut-quant-2026-03-15.md`
   - `41-torghut-quant-profitability-and-guardrail-architecture-2026-03-15.md`
   - `39-freshness-ledger-and-hypothesis-proof-mesh-2026-03-14.md`
@@ -18,8 +19,12 @@
 - `47-torghut-quant-plan-merge-contract-and-handoff-implementation-2026-03-16.md`
 - `48-torghut-quant-discover-implementation-readiness-and-handoff-contract-2026-03-16.md`
 - `49-torghut-quant-source-of-truth-and-profit-circuit-handoff-2026-03-19.md`
+- `50-torghut-submission-parity-council-and-options-bootstrap-escrow-2026-03-19.md`
+- `51-torghut-profit-reservations-schema-witness-and-simulation-slot-ledger-2026-03-19.md`
 - Cross-system source of truth:
   - `docs/agents/designs/51-jangar-control-plane-execution-cells-and-collaboration-failover-2026-03-19.md`
+  - `docs/agents/designs/49-jangar-control-plane-execution-truth-spine-and-torghut-profit-circuit-2026-03-19.md`
+  - `docs/agents/designs/52-jangar-rollout-epoch-witness-and-segment-circuit-breakers-2026-03-19.md`
 - Discover stage merge anchor:
   - `42-torghut-quant-control-plane-resilience-and-profitability-architecture-merge-contract-2026-03-15.md`
   - `42-torghut-quant-control-plane-and-profitability-program-2026-03-15.md`
@@ -75,6 +80,12 @@ Current source-state priority is narrower:
 - `50-torghut-submission-parity-council-and-options-bootstrap-escrow-2026-03-19.md` now turns the March 19 mixed-state
   runtime evidence into one submission-council contract, lane-local profit cells, and an options bootstrap escrow that
   keeps import-time DB/image failures from masquerading as general profitability truth.
+- `51-torghut-profit-reservations-schema-witness-and-simulation-slot-ledger-2026-03-19.md` now turns the March 19
+  live contradictions into a stricter capital contract: non-observe capital requires an expiring profit reservation,
+  a healthy schema witness, and owned simulation-slot capacity.
+- `docs/agents/designs/52-jangar-rollout-epoch-witness-and-segment-circuit-breakers-2026-03-19.md` now extends the
+  March 19 authority-ledger work by requiring consumer acknowledgement of rollout epochs and by turning Huly transport
+  failures into explicit segment circuit breakers rather than implicit fatal preconditions.
 - `40-control-plane-resilience-and-safer-rollout-for-torghut-quant-2026-03-15.md` now defines segment-local
   control-plane authority and scoped rollout semantics to prevent watch noise from becoming global rollout blockers.
 - `41-torghut-quant-profitability-and-guardrail-architecture-2026-03-15.md` now defines multi-horizon profitability
@@ -164,6 +175,7 @@ This pack is positioned as the next architecture layer above:
 47. `48-torghut-quant-discover-implementation-readiness-and-handoff-contract-2026-03-16.md`
 48. `49-torghut-quant-source-of-truth-and-profit-circuit-handoff-2026-03-19.md`
 49. `50-torghut-submission-parity-council-and-options-bootstrap-escrow-2026-03-19.md`
+50. `51-torghut-profit-reservations-schema-witness-and-simulation-slot-ledger-2026-03-19.md`
 
 ## Recommended Build Order
 
@@ -212,6 +224,7 @@ This pack is positioned as the next architecture layer above:
 43. `42-torghut-quant-control-plane-and-profitability-program-2026-03-15.md`
 44. `49-torghut-quant-source-of-truth-and-profit-circuit-handoff-2026-03-19.md`
 45. `50-torghut-submission-parity-council-and-options-bootstrap-escrow-2026-03-19.md`
+46. `51-torghut-profit-reservations-schema-witness-and-simulation-slot-ledger-2026-03-19.md`
 
 ## Why This Sequence
 


### PR DESCRIPTION
## Summary

- add a new Jangar architecture contract for rollout epoch witnesses, consumer acknowledgements, and segment circuit breakers
- add a new Torghut architecture contract for profit reservations, schema witnesses, and simulation-slot leasing
- update the Torghut source-of-truth guide and v6 index so engineer and deployer stages treat the new docs as active contract truth

## Related Issues

None

## Testing

- `git diff --check`
- `python3 - <<'PY' ...` to verify `/workspace/.agentrun/swarm/torghut-quant-discover.md` stays within the required line and character limits
- manual verification that the new docs are referenced from `docs/torghut/design-system/current-source-of-truth-and-priority-guide-2026-03-09.md`, `docs/torghut/design-system/README.md`, and `docs/torghut/design-system/v6/index.md`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
