### PR TITLE
docs(torghut): align rollout guides with execution cells

### DIFF
--- a/docs/agents/designs/51-jangar-control-plane-execution-cells-and-collaboration-failover-2026-03-19.md
+++ b/docs/agents/designs/51-jangar-control-plane-execution-cells-and-collaboration-failover-2026-03-19.md
@@ -19,21 +19,20 @@ Companion document:
 ## Executive summary
 
 The March 19 design pack correctly identified authority-ledger drift and profitability-governance contradictions, but
-the live runtime still exposes one more systemic problem: Jangar treats mixed failures as whole-swarm failures.
+the live runtime still exposes one more systemic problem: Jangar still has no authoritative distinction between
+service-level readiness, collaboration health, and canary-capable control-plane authority.
 
 Read-only evidence captured on `2026-03-19` shows:
 
-- `jangar-control-plane` and `torghut-quant` both remain `Frozen` even though `status.freeze.until` expired on
-  `2026-03-11`;
 - `http://jangar.jangar.svc.cluster.local/ready` still returns `status=ok` while
-  `/api/agents/control-plane/status` reports `has_execution_trust=false` and `dependency_quorum=allow`;
-- `services/jangar/src/server/control-plane-status.ts` still treats `phase == "Frozen"` as not ready even when
-  `freeze.until` is already in the past, while `services/jangar/src/server/supporting-primitives-controller.ts`
-  still drives unfreeze off local timers and stale run/status synthesis;
+  `agentsController.enabled=false` and `supportingController.enabled=false`;
+- `http://jangar.jangar.svc.cluster.local/api/agents/control-plane/status?namespace=agents` reports
+  `watch_reliability.status="healthy"` and `dependency_quorum.decision="allow"`, but the richer `execution_trust`
+  surface is still absent because it remains optional;
 - Huly collaboration is a hard dependency in practice, but the worker-scoped account probe and `find-all` query both
-  time out against `http://transactor.huly.svc.cluster.local`;
-- Torghut remains in a mixed state where core trading is up, but market-context freshness is down, quant materialized
-  metrics are empty, and options-lane pods fail on DB auth and image availability before steady-state.
+  time out against `http://transactor.huly.svc.cluster.local` even though `GET /api/v1/version` succeeds;
+- Torghut remains in a mixed state where core trading is up, but quant latest-store evidence is empty, the options lane
+  is materially red, and ClickHouse freshness guardrails are falling back under load.
 
 The selected architecture replaces "whole swarm frozen or healthy" with durable **Execution Cells**. Each cell owns a
 bounded failure domain, a durable lease, an evidence bundle, and a rollout policy. Schedules are preserved when a cell
@@ -47,31 +46,36 @@ on a stale swarm phase or a green deployment probe.
 
 Evidence captured during this plan run:
 
-- `kubectl -n agents get swarm jangar-control-plane torghut-quant -o jsonpath=...`
-  - `jangar-control-plane|Frozen|StageStaleness|2026-03-11T16:36:12.630Z|5|2026-03-11T15:48:11.742Z`
-  - `torghut-quant|Frozen|StageStaleness|2026-03-11T16:36:17.456Z|0|2026-03-11T15:48:13.974Z`
 - `curl -fsS http://jangar.jangar.svc.cluster.local/ready`
   - returned `{"status":"ok",...}`
-- `curl -fsS http://jangar.jangar.svc.cluster.local/api/agents/control-plane/status`
-  - `database.status = "healthy"`
+  - `leaderElection.isLeader=true`
+  - `agentsController.enabled=false`
+  - `supportingController.enabled=false`
+- `curl -fsS "http://jangar.jangar.svc.cluster.local/api/agents/control-plane/status?namespace=agents"`
   - `watch_reliability.status = "healthy"`
-  - `rollout_health.status = "healthy"`
   - `dependency_quorum.decision = "allow"`
   - `execution_trust` field absent because the feature flag is still effectively optional
-- `kubectl -n torghut get events --sort-by=.lastTimestamp | tail -n 40`
-  - repeated liveness/readiness failures for `torghut-00153-deployment`
-  - `torghut-options-catalog` and `torghut-options-enricher` restarting
-  - `torghut-options-ta` in `ImagePullBackOff`
-  - `torghut-ws-options` restarting on failed probes
-- `kubectl -n agents logs pod/torghut-market-context-news-batch-5ggp2-job-bn6qg --tail=120`
-  - batch runner hit a `subprocess.TimeoutExpired` on `/usr/local/bin/codex-implement` and then crashed trying to
-    write bytes to stdout as text
+- `kubectl -n torghut get events --sort-by=.lastTimestamp | tail -n 35`
+  - repeated startup/readiness/liveness failures for `torghut-00153-deployment`
+  - `torghut-options-catalog` and `torghut-options-enricher` remain in restart backoff
+  - `torghut-options-ta` is still in `ImagePullBackOff`
+  - `torghut-ws-options` remains probe-unhealthy
+- `kubectl -n torghut get pod torghut-options-catalog-676574bcc9-wkqp5 -o json`
+  - `restartCount=871`
+  - `state.waiting.reason="CrashLoopBackOff"`
+- `kubectl -n torghut get pod torghut-options-ta-7987889f4f-zxl5g -o json`
+  - configured image digest is missing and the pod is stuck in `ImagePullBackOff`
+- `python3 skills/huly-api/scripts/huly-api.py --operation account-info ...`
+  - timed out on `GET /api/v1/account/c9b87368-e7a2-483f-885f-ff179e258950`
+- `python3 skills/huly-api/scripts/huly-api.py --operation list-channel-messages ...`
+  - timed out on `POST /api/v1/find-all/c9b87368-e7a2-483f-885f-ff179e258950`
 
 Interpretation:
 
-- Jangar still has stale-freeze authority drift.
+- Jangar can look service-ready while still lacking controller proof and collaboration proof for safe rollout.
 - Torghut still has live mixed-state failures that should not collapse into one global freeze.
-- The market-context batch path can fail before persisting a clean control-plane explanation.
+- Huly is not unreachable, but authenticated control-plane reads are hanging long enough to behave like an authority
+  fault for mission delivery.
 
 ### Source architecture and high-risk modules
 
@@ -132,14 +136,25 @@ Service-level read-only evidence still shows the necessary data-state:
   - `status = "degraded"`
   - `latestMetricsCount = 0`
   - `stages = []`
+- `curl -fsS http://torghut.torghut.svc.cluster.local/metrics`
+  - `torghut_trading_execution_clean_ratio 0.0`
+  - `torghut_trading_alpha_readiness_promotion_eligible_total 0`
+- `curl -fsS http://torghut-ws.torghut.svc.cluster.local:9090/metrics`
+  - `torghut_ws_desired_symbols_fetch_degraded 0`
+- `curl -fsS http://torghut-clickhouse-guardrails-exporter.torghut.svc.cluster.local:9108/metrics`
+  - one replica reports `nan` freshness timestamps
+  - `freshness_fallback_total` is elevated for both `ta_signals` and `ta_microbars`
 - `curl -fsS http://jangar.jangar.svc.cluster.local/api/torghut/trading/control-plane/quant/alerts?...`
   - open critical alerts for `metrics_pipeline_lag_seconds` across `1m`, `5m`, `15m`, `1h`, `1d`, `5d`, and `20d`
+- `kubectl -n torghut get pod torghut-db-1 -o json`
+  - Postgres is ready, but `restartCount=38`
 
 Interpretation:
 
 - schema-current is not enough to authorize rollout or capital;
 - freshness, ingestion, collaboration, and bootstrap need separate execution ownership;
-- a database-access gap in the control-plane identity should surface as evidence, not as silent trust loss.
+- a database-access gap in the control-plane identity should surface as evidence, not as silent trust loss;
+- healthy desired-symbol fetch and ready database pods are supporting signals, not substitutes for latest-store proof.
 
 ### Collaboration assessment
 
@@ -307,7 +322,7 @@ Behavior:
 
 That gives us bounded failure scope without losing auditability.
 
-### 5. Rollout predicates consume the cell graph
+### 5. Rollout predicates consume the cell graph and emit clearance leases
 
 Rollout and `/ready` must stop reasoning from a loose mix of rollout health, stale swarm phase, and optional trust.
 
@@ -327,6 +342,12 @@ Example mapping:
 - Torghut options changes depend on `torghut-options-bootstrap`, `torghut-market-context`, `torghut-quant-materialization`
 - Torghut quant-only changes need not block on options bootstrap when the changed hypotheses do not declare
   `options-data`
+
+The deployable view of this graph is a **clearance lease**:
+
+- a lease is valid only while every required hard cell is fresh;
+- the lease records the exact cell snapshot used for the decision;
+- Torghut and deployer tooling must treat a missing or expired lease as `observe` or `hold`, never as implicit canary.
 
 ### 6. Torghut submission parity plugs into the same cell graph
 
@@ -358,6 +379,8 @@ Deployer gates:
 - induce one stage-staleness drill and prove preserved schedules remain visible while dispatch is blocked;
 - induce one Huly timeout drill and prove the outbox captures the message plus replay state;
 - no rollout progression when any required `hard` cell is not healthy or recovering within policy;
+- no canary-capable lease when `latestMetricsCount == 0` or `torghut_trading_execution_clean_ratio < 0.75` for the
+  affected profitability lanes;
 - store and archive the cell snapshot used for every canary step.
 
 ## Rollout plan

--- a/docs/runbooks/torghut-quant-control-plane.md
+++ b/docs/runbooks/torghut-quant-control-plane.md
@@ -6,9 +6,11 @@ Use this runbook for alerts tied to the Jangar quant control-plane (near-real-ti
 upstream Torghut trading signals. This covers data freshness, decision activity, execution quality proxies, and
 control-plane stream health.
 
-This runbook is aligned with the discover-stage architecture merge contract:
+This runbook is aligned with the current March 19 plan-stage architecture contracts:
 
 - `docs/torghut/design-system/v6/42-torghut-quant-control-plane-resilience-and-profitability-architecture-merge-contract-2026-03-15.md`
+- `docs/torghut/design-system/v6/50-torghut-submission-parity-council-and-options-bootstrap-escrow-2026-03-19.md`
+- `docs/agents/designs/51-jangar-control-plane-execution-cells-and-collaboration-failover-2026-03-19.md`
 
 When running under scoped service accounts, treat unavailable cluster capabilities (`kubectl exec`, `kubectl logs` with target
 containers, or DB pod exec) as a controlled evidence gap and prioritize control-plane status surface checks instead.
@@ -59,6 +61,10 @@ Alert rules are defined in `argocd/applications/observability/graf-mimir-rules.y
    - If `dependency_quorum.decision == "block"` or (`dependency_quorum.decision == "delay"` with `dependency_quorum.degradation_scope` that blocks capital progress), treat the affected control-plane segment as the active blocker and verify impact before disabling promotion.
    - If `dependency_quorum.degradation_scope` is set to `single_capability`, pause affected capital movement paths only and confirm other lanes remain evaluable before broad actions.
    - If a single hypothesis is `blocked` or `shadow`, do not disable the whole service by default; verify the specific blocker reasons and keep unaffected lanes observable.
+   - Treat `live_submission_gate.capital_stage` as configured intent, not sufficient clearance by itself. Before any canary progression, also require:
+     - `alpha_readiness_promotion_eligible_total > 0`
+     - non-empty quant latest-store evidence from Jangar
+     - healthy options bootstrap for options-dependent hypotheses
    - Per-lane blockers are now scoped via each hypothesis manifest dependency capabilities, so a degraded dependency (for example
      `jangar_dependency_delay`) should only affect hypotheses that explicitly require that capability.
    - Read segment output from `dependency_quorum.segments` to confirm impact: check each `segment`, `status`, `scope`, and `reasons` before rerouting incident response.
@@ -84,13 +90,33 @@ Alert rules are defined in `argocd/applications/observability/graf-mimir-rules.y
    - Fail criteria:
      - `TorghutSignalsStaleDuringMarketHours`, `TorghutMicrobarsStaleDuringMarketHours`, `TorghutWSDesiredSymbolsFetchFailing`,
        or `TorghutClickHouseFreshnessQueryFallbacks` is firing.
-4. Validate market-context health on active symbols (not default symbol only).
+4. Validate quant latest-store evidence before any canary progression.
+   - `curl -fsS "http://127.0.0.1:8080/api/torghut/trading/control-plane/quant/health?account=paper&window=1d" | jq '{status, latestMetricsCount, emptyLatestStoreAlarm, metricsPipelineLagSeconds, stages, maxStageLagSeconds}'`
+   - Pass criteria:
+     - `latestMetricsCount > 0`
+     - `emptyLatestStoreAlarm == false`
+     - `status == "ok"` for the target window
+   - Hard stop criteria:
+     - `latestMetricsCount == 0`
+     - `emptyLatestStoreAlarm == true`
+     - stage list empty for the target canary window
+5. Validate market-context health on active symbols (not default symbol only).
    - `SYMS=$(kubectl cnpg psql -n torghut torghut-db -- -d torghut -At -c "select distinct symbol from trade_decisions where created_at >= now() - interval '1 day' and status in ('planned','submitted','accepted','filled') order by symbol limit 8;")`
    - `for s in $SYMS; do curl -fsS "http://127.0.0.1:8080/api/torghut/market-context/health?symbol=${s}" | jq '{symbol: .symbol, healthy: .healthy, reasons: .reasons}'; done`
-5. Check Jangar SSE health for control-plane dashboards.
+6. Validate options-lane bootstrap before enabling any options-dependent hypothesis.
+   - `kubectl -n torghut get pods | rg 'torghut-options-(catalog|enricher|ta)|torghut-ws-options'`
+   - Pass criteria:
+     - no `CrashLoopBackOff` on catalog or enricher
+     - no `ImagePullBackOff` on options TA
+     - no sustained restart churn on `torghut-ws-options`
+   - Hard stop criteria:
+     - image pull failures
+     - DB auth or bootstrap crashes
+     - missing readiness explanation from the options services
+7. Check Jangar SSE health for control-plane dashboards.
    - Review Jangar logs for `torghut-quant` stream errors.
    - Verify the quant control-plane UI connection in Jangar (`/torghut/control-plane`).
-6. Verify domain telemetry correlation continuity (PostHog contract, non-critical path).
+8. Verify domain telemetry correlation continuity (PostHog contract, non-critical path).
    - `curl -fsS "http://127.0.0.1:8081/trading/status" | jq '.control_plane_contract | {last_autonomy_recommendation_trace_id, domain_telemetry_event_total, domain_telemetry_dropped_total}'`
    - `curl -fsS "http://127.0.0.1:8081/trading/executions?limit=20" | jq '[.[] | {id, trade_decision_id, execution_correlation_id, execution_idempotency_key}]'`
    - Pass criteria:
@@ -100,12 +126,14 @@ Alert rules are defined in `argocd/applications/observability/graf-mimir-rules.y
    - Fail criteria:
      - correlation IDs are absent on newly-created execution rows.
      - telemetry drops grow with reasons other than expected operational modes (for example `disabled` during planned disablement).
-7. Verify recovery gate thresholds before canary progression.
+9. Verify recovery gate thresholds before canary progression.
    - `curl -fsS "http://127.0.0.1:8081/metrics" | rg 'torghut_trading_(execution_clean_ratio|execution_reject_ratio|decision_reject_reason_total|llm_unavailable_reject_reason_total)'`
    - Acceptance thresholds for progression:
      - `torghut_trading_execution_clean_ratio >= 0.75`
      - `qty_below_min` share <= `0.03` of recent decisions
      - `llm_unavailable_*` reject share <= `0.02` of recent decisions
+     - `alpha_readiness_promotion_eligible_total > 0`
+     - quant latest-store evidence is non-empty for the target window
    - Hard rollback triggers:
      - clean ratio < `0.70` for 15 minutes
      - `qty_below_min` share > `0.05` for 30 minutes

--- a/docs/torghut/design-system/current-source-of-truth-and-priority-guide-2026-03-09.md
+++ b/docs/torghut/design-system/current-source-of-truth-and-priority-guide-2026-03-09.md
@@ -41,14 +41,15 @@ If the question is "what should I trust right now?", start here:
    - `docs/torghut/design-system/v6/32-authoritative-alpha-readiness-and-empirical-promotion-closeout-2026-03-08.md`
    - `docs/torghut/design-system/v6/38-authoritative-empirical-promotion-evidence-contract-2026-03-09.md`
    - `docs/torghut/design-system/v6/39-freshness-ledger-and-hypothesis-proof-mesh-2026-03-14.md`
-
    - `docs/torghut/design-system/v6/40-control-plane-resilience-and-safer-rollout-for-torghut-quant-2026-03-15.md`
    - `docs/torghut/design-system/v6/41-torghut-quant-profitability-and-guardrail-architecture-2026-03-15.md`
    - `docs/torghut/design-system/v6/42-torghut-quant-control-plane-and-profitability-program-2026-03-15.md`
    - `docs/torghut/design-system/v6/44-torghut-quant-plan-design-document-and-handoff-contract-2026-03-15.md`
    - `docs/agents/designs/49-jangar-control-plane-authority-ledger-and-expiry-watchdog-2026-03-19.md`
    - `docs/agents/designs/50-torghut-hypothesis-capital-governor-and-data-quorum-2026-03-19.md`
+   - `docs/agents/designs/51-jangar-control-plane-execution-cells-and-collaboration-failover-2026-03-19.md`
    - `docs/agents/designs/52-jangar-rollout-epoch-witness-and-segment-circuit-breakers-2026-03-19.md`
+   - `docs/torghut/design-system/v6/50-torghut-submission-parity-council-and-options-bootstrap-escrow-2026-03-19.md`
    - `docs/torghut/design-system/v6/51-torghut-profit-reservations-schema-witness-and-simulation-slot-ledger-2026-03-19.md`
 
 4. options-lane current design source of truth:
@@ -61,22 +62,25 @@ The current highest-priority work is:
 
 1. replace optional/stale control-plane truth with the authority-ledger and expiry-watchdog contract in
    `docs/agents/designs/49-jangar-control-plane-authority-ledger-and-expiry-watchdog-2026-03-19.md`;
-2. make rollout truth depend on rollout-epoch acknowledgement and segment circuit breakers in
+2. replace optional and mixed control-plane truth with the execution-cell and collaboration-failover contract in
+   `docs/agents/designs/51-jangar-control-plane-execution-cells-and-collaboration-failover-2026-03-19.md`;
+3. make rollout truth depend on rollout-epoch acknowledgement and segment circuit breakers in
    `docs/agents/designs/52-jangar-rollout-epoch-witness-and-segment-circuit-breakers-2026-03-19.md`;
-3. force capital-stage decisions through the hypothesis capital governor and data-quorum contract in
+4. force capital-stage decisions through the hypothesis capital governor, submission-parity council, and options
+   bootstrap escrow contracts in
    `docs/agents/designs/50-torghut-hypothesis-capital-governor-and-data-quorum-2026-03-19.md`;
-4. make non-shadow capital depend on expiring profit reservations, schema fitness, and simulation slot ownership in
+   and `docs/torghut/design-system/v6/50-torghut-submission-parity-council-and-options-bootstrap-escrow-2026-03-19.md`;
+5. make non-shadow capital depend on expiring profit reservations, schema fitness, and simulation slot ownership in
    `docs/torghut/design-system/v6/51-torghut-profit-reservations-schema-witness-and-simulation-slot-ledger-2026-03-19.md`;
-5. keep producer-authored freshness and proof bundles active by continuing the ledger direction defined in
+6. keep producer-authored freshness and proof bundles active by continuing the ledger direction defined in
    `docs/torghut/design-system/v6/39-freshness-ledger-and-hypothesis-proof-mesh-2026-03-14.md`;
-6. isolate control-plane failure domains with rollout-safe gates in
+7. isolate control-plane failure domains with rollout-safe gates in
    `docs/torghut/design-system/v6/40-control-plane-resilience-and-safer-rollout-for-torghut-quant-2026-03-15.md`;
-7. retain hypothesis-specific profitability guardrails from
+8. retain hypothesis-specific profitability guardrails from
    `docs/torghut/design-system/v6/41-torghut-quant-profitability-and-guardrail-architecture-2026-03-15.md`,
    but make them subordinate to fresh data quorum and immutable evidence bundles;
-8. execute the merged control-plane/profitability program with the March 19 authority, epoch, governor, and reservation
-   contracts layered on
-   top of the March 15-16 design set.
+9. execute the merged control-plane/profitability program with the March 19 authority, execution-cell, epoch,
+   governor, council, reservation, and bootstrap-escrow contracts layered on top of the March 15-16 design set.
 
 This means the current next work is not:
 
@@ -128,7 +132,9 @@ These are still active contract docs rather than historical snapshots:
 - `docs/torghut/design-system/v6/44-torghut-quant-plan-design-document-and-handoff-contract-2026-03-15.md`
 - `docs/agents/designs/49-jangar-control-plane-authority-ledger-and-expiry-watchdog-2026-03-19.md`
 - `docs/agents/designs/50-torghut-hypothesis-capital-governor-and-data-quorum-2026-03-19.md`
+- `docs/agents/designs/51-jangar-control-plane-execution-cells-and-collaboration-failover-2026-03-19.md`
 - `docs/agents/designs/52-jangar-rollout-epoch-witness-and-segment-circuit-breakers-2026-03-19.md`
+- `docs/torghut/design-system/v6/50-torghut-submission-parity-council-and-options-bootstrap-escrow-2026-03-19.md`
 - `docs/torghut/design-system/v6/51-torghut-profit-reservations-schema-witness-and-simulation-slot-ledger-2026-03-19.md`
 - `docs/torghut/design-system/v6/33-alpaca-options-market-data-and-technical-analysis-lane-2026-03-08.md`
 - `docs/torghut/design-system/v6/34-alpaca-options-lane-implementation-contract-set-2026-03-08.md`

--- a/docs/torghut/design-system/v6/50-torghut-submission-parity-council-and-options-bootstrap-escrow-2026-03-19.md
+++ b/docs/torghut/design-system/v6/50-torghut-submission-parity-council-and-options-bootstrap-escrow-2026-03-19.md
@@ -19,6 +19,8 @@ The runtime on `2026-03-19` still allows contradictory profitability states:
 - `GET /trading/status` reports `live_submission_gate.allowed = true` and `capital_stage = "0.10x canary"`;
 - the same payload reports `hypotheses_total = 3`, `state_totals.shadow = 3`, and `promotion_eligible_total = 0`;
 - Jangar quant health reports `latestMetricsCount = 0` and no active materialization stages;
+- Torghut metrics report `execution_clean_ratio = 0.0`;
+- desired-symbol fetch is healthy while the latest-store is still empty, proving those are different readiness surfaces;
 - Jangar market-context health reports `overallState = "down"` with stale bundle freshness;
 - options-lane services fail before readiness because DB rate-bucket defaults are written during module import and the
   current credential for `torghut_app` is rejected;
@@ -49,6 +51,14 @@ Read-only evidence collected on `2026-03-19`:
   - `status = "degraded"`
   - `latestMetricsCount = 0`
   - `stages = []`
+- `curl -fsS http://torghut.torghut.svc.cluster.local/metrics`
+  - `torghut_trading_execution_clean_ratio 0.0`
+  - `torghut_trading_alpha_readiness_promotion_eligible_total 0`
+- `curl -fsS http://torghut-ws.torghut.svc.cluster.local:9090/metrics`
+  - `torghut_ws_desired_symbols_fetch_degraded 0`
+- `curl -fsS http://torghut-clickhouse-guardrails-exporter.torghut.svc.cluster.local:9108/metrics`
+  - one replica reports `nan` freshness timestamps
+  - `freshness_fallback_total` is elevated for both `ta_signals` and `ta_microbars`
 - `curl -fsS http://jangar.jangar.svc.cluster.local/api/torghut/trading/control-plane/quant/alerts?...`
   - critical open alerts for `metrics_pipeline_lag_seconds` across `1m`, `5m`, `15m`, `1h`, `1d`, `5d`, and `20d`
   - open warning alert for negative `sharpe_annualized`
@@ -57,12 +67,13 @@ Read-only evidence collected on `2026-03-19`:
   - `bundleFreshnessSeconds = 275280`
   - ClickHouse ingestion shows `clickhouse_query_failed`
   - fundamentals and news are stale; technicals and regime are `error`
-- `kubectl -n torghut logs pod/torghut-options-catalog-...`
-  - `password authentication failed for user "torghut_app"`
-- `kubectl -n torghut logs pod/torghut-options-enricher-...`
-  - same DB auth failure
-- `kubectl -n torghut get pod torghut-options-ta-... -o jsonpath=...`
+- `kubectl -n torghut get pod torghut-options-catalog-676574bcc9-wkqp5 -o json`
+  - `restartCount=871`
+  - `CrashLoopBackOff`
+- `kubectl -n torghut get pod torghut-options-ta-7987889f4f-zxl5g -o json`
   - image pull fails with digest `not found`
+- `kubectl -n torghut get pod torghut-db-1 -o json`
+  - Postgres is ready, but `restartCount=38`
 
 Interpretation:
 
@@ -70,6 +81,7 @@ Interpretation:
 - Current capital truth is too permissive because it is synthesized in multiple places.
 - Options-lane bootstrap failures are currently polluting profitability readiness through crashes instead of explicit
   cell state.
+- Healthy symbol-forwarder status alone is not enough to authorize canary capital while latest-store evidence is empty.
 
 ### Source architecture and test gaps
 
@@ -186,7 +198,7 @@ Inputs:
 - market-context health bundle
 - empirical-job status
 - DSPy runtime status
-- execution-cell inputs from Jangar
+- execution-cell inputs and clearance lease refs from Jangar
 - options bootstrap status
 
 Outputs:
@@ -234,6 +246,7 @@ Required baseline policy for all cells:
 
 - `promotion_eligible_total > 0`
 - `latestMetricsCount > 0`
+- `torghut_trading_execution_clean_ratio >= 0.75`
 - no open critical `metrics_pipeline_lag_seconds` alert for the evaluation window
 - `market_context.overallState != "down"`
 - no required execution cell in `blocked` state
@@ -327,6 +340,8 @@ Deployer gates:
 
 - no canary or live promotion while any required critical quant lag alert remains open;
 - no canary or live promotion while `market_context.overallState = "down"`;
+- no canary or live promotion while `torghut_trading_execution_clean_ratio < 0.75`;
+- no canary or live promotion while `latestMetricsCount = 0` for the target window;
 - options capital remains `observe` whenever `options_bootstrap_status != ready`;
 - one forced rollback from `0.10x canary` to `observe` or `quarantine` must persist the evidence bundle and council
   decision that triggered the rollback.


### PR DESCRIPTION
## Summary

- align the March 19 Jangar and Torghut architecture contracts with the latest cluster and profitability evidence
- update the Torghut quant control-plane runbook with explicit canary blockers for empty latest-store evidence and unhealthy options bootstrap
- refresh the Torghut current source-of-truth guide so operators land on the execution-cell and submission-parity contracts first

## Related Issues

None

## Testing

- `bunx oxfmt --check docs/agents/designs/51-jangar-control-plane-execution-cells-and-collaboration-failover-2026-03-19.md docs/torghut/design-system/v6/50-torghut-submission-parity-council-and-options-bootstrap-escrow-2026-03-19.md docs/runbooks/torghut-quant-control-plane.md docs/torghut/design-system/current-source-of-truth-and-priority-guide-2026-03-09.md`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
