### PR TITLE
fix(torghut): prevent lean shadow parity crashes

### DIFF
--- a/services/torghut/app/models/entities.py
+++ b/services/torghut/app/models/entities.py
@@ -1850,7 +1850,7 @@ class LeanExecutionShadowEvent(Base, CreatedAtMixin):
     simulated_slippage_bps: Mapped[Optional[Decimal]] = mapped_column(Numeric(20, 8), nullable=True)
     parity_delta_bps: Mapped[Optional[Decimal]] = mapped_column(Numeric(20, 8), nullable=True)
     parity_status: Mapped[str] = mapped_column(
-        String(length=32),
+        String(length=64),
         nullable=False,
         default="unknown",
         server_default=text("'unknown'"),
@@ -1908,7 +1908,7 @@ class LeanStrategyShadowEvaluation(Base, CreatedAtMixin):
     intent_json: Mapped[Any] = mapped_column(JSONType, nullable=False)
     shadow_json: Mapped[Optional[Any]] = mapped_column(JSONType, nullable=True)
     parity_status: Mapped[str] = mapped_column(
-        String(length=32),
+        String(length=64),
         nullable=False,
         default="unknown",
         server_default=text("'unknown'"),

--- a/services/torghut/app/trading/lean_lanes.py
+++ b/services/torghut/app/trading/lean_lanes.py
@@ -67,7 +67,11 @@ class LeanLaneManager:
             row.config_json = coerce_json_payload(dict(config))
             row.reproducibility_hash = str(payload.get('reproducibility_hash') or '') or row.reproducibility_hash
         session.add(row)
-        session.commit()
+        try:
+            session.commit()
+        except Exception:
+            session.rollback()
+            raise
         session.refresh(row)
         return row
 
@@ -99,7 +103,11 @@ class LeanLaneManager:
         ):
             row.completed_at = datetime.now(timezone.utc)
         session.add(row)
-        session.commit()
+        try:
+            session.commit()
+        except Exception:
+            session.rollback()
+            raise
         session.refresh(row)
         return row
 
@@ -141,7 +149,11 @@ class LeanLaneManager:
             row.governance_json = coerce_json_payload(dict(cast(Mapping[str, Any], shadow_result.get('governance') or {})))
             row.disable_switch_active = settings.trading_lean_lane_disable_switch
         session.add(row)
-        session.commit()
+        try:
+            session.commit()
+        except Exception:
+            session.rollback()
+            raise
         session.refresh(row)
         return row
 

--- a/services/torghut/app/trading/scheduler/pipeline.py
+++ b/services/torghut/app/trading/scheduler/pipeline.py
@@ -881,6 +881,14 @@ class TradingPipeline:
                 return None
             return decision
         except Exception as exc:
+            try:
+                session.rollback()
+            except Exception:
+                logger.exception(
+                    "Decision handler rollback failed strategy_id=%s symbol=%s",
+                    decision.strategy_id,
+                    decision.symbol,
+                )
             logger.exception(
                 "Decision handling failed strategy_id=%s symbol=%s error=%s",
                 decision.strategy_id,
@@ -1922,6 +1930,14 @@ class TradingPipeline:
                 shadow_result=shadow_map,
             )
         except Exception as exc:
+            try:
+                session.rollback()
+            except Exception:
+                logger.exception(
+                    "LEAN strategy shadow rollback failed strategy_id=%s symbol=%s",
+                    decision.strategy_id,
+                    decision.symbol,
+                )
             logger.warning(
                 "LEAN strategy shadow evaluation failed strategy_id=%s symbol=%s error=%s",
                 decision.strategy_id,

--- a/services/torghut/migrations/versions/0025_widen_lean_shadow_parity_status.py
+++ b/services/torghut/migrations/versions/0025_widen_lean_shadow_parity_status.py
@@ -1,0 +1,53 @@
+"""Widen LEAN shadow parity status columns.
+
+Revision ID: 0025_widen_lean_shadow_parity_status
+Revises: 0024_simulation_runtime_context
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0025_widen_lean_shadow_parity_status"
+down_revision = "0024_simulation_runtime_context"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "lean_execution_shadow_events",
+        "parity_status",
+        existing_type=sa.String(length=32),
+        type_=sa.String(length=64),
+        existing_nullable=False,
+        existing_server_default=sa.text("'unknown'"),
+    )
+    op.alter_column(
+        "lean_strategy_shadow_evaluations",
+        "parity_status",
+        existing_type=sa.String(length=32),
+        type_=sa.String(length=64),
+        existing_nullable=False,
+        existing_server_default=sa.text("'unknown'"),
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "lean_strategy_shadow_evaluations",
+        "parity_status",
+        existing_type=sa.String(length=64),
+        type_=sa.String(length=32),
+        existing_nullable=False,
+        existing_server_default=sa.text("'unknown'"),
+    )
+    op.alter_column(
+        "lean_execution_shadow_events",
+        "parity_status",
+        existing_type=sa.String(length=64),
+        type_=sa.String(length=32),
+        existing_nullable=False,
+        existing_server_default=sa.text("'unknown'"),
+    )

--- a/services/torghut/tests/test_lean_lanes.py
+++ b/services/torghut/tests/test_lean_lanes.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 from unittest import TestCase
+from unittest.mock import patch
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-from app.models import Base
+from app.lean_runner import _SCAFFOLD_BLOCKED_STATUS
+from app.models import Base, LeanExecutionShadowEvent, LeanStrategyShadowEvaluation
 from app.trading.lean_lanes import LeanLaneManager
 
 
@@ -56,8 +58,6 @@ class TestLeanLanes(TestCase):
             self.assertIsNotNone(refreshed.completed_at)
 
     def test_parity_summary_aggregates_shadow_events(self) -> None:
-        from app.models import LeanExecutionShadowEvent
-
         with self.SessionLocal() as session:
             session.add(
                 LeanExecutionShadowEvent(
@@ -87,3 +87,34 @@ class TestLeanLanes(TestCase):
         self.assertEqual(summary['drift_events'], 1)
         self.assertAlmostEqual(summary['drift_ratio'], 0.5)
         self.assertEqual(summary['failure_classes'].get('execution_quality_drift'), 1)
+
+    def test_shadow_parity_status_columns_allow_scaffold_blocked_status(self) -> None:
+        required_length = len(_SCAFFOLD_BLOCKED_STATUS)
+        self.assertGreaterEqual(
+            LeanExecutionShadowEvent.__table__.c.parity_status.type.length,
+            required_length,
+        )
+        self.assertGreaterEqual(
+            LeanStrategyShadowEvaluation.__table__.c.parity_status.type.length,
+            required_length,
+        )
+
+    def test_record_strategy_shadow_rolls_back_on_commit_error(self) -> None:
+        manager = LeanLaneManager()
+
+        with self.SessionLocal() as session:
+            with patch.object(session, 'commit', side_effect=RuntimeError('boom')):
+                with patch.object(session, 'rollback') as rollback_mock:
+                    with self.assertRaisesRegex(RuntimeError, 'boom'):
+                        manager.record_strategy_shadow(
+                            session,
+                            strategy_id='strategy-1',
+                            symbol='AAPL',
+                            intent={'action': 'buy', 'qty': '1'},
+                            shadow_result={
+                                'run_id': 'run-1',
+                                'parity_status': _SCAFFOLD_BLOCKED_STATUS,
+                                'governance': {},
+                            },
+                        )
+                rollback_mock.assert_called_once()

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -5,14 +5,16 @@ from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from pathlib import Path
 import tempfile
+from types import SimpleNamespace
 from unittest import TestCase
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 from typing import Any
 
 from sqlalchemy import create_engine, select
 from sqlalchemy.orm import Session, sessionmaker
 
 from app.models import Base, Execution, LLMDecisionReview, Strategy, TradeDecision
+from app import config
 from app.trading.decisions import DecisionEngine
 from app.trading.execution_adapters import SimulationExecutionAdapter
 from app.trading.execution import OrderExecutor
@@ -4201,6 +4203,47 @@ class TestTradingPipeline(TestCase):
             config.settings.llm_adjustment_approved = original[
                 "llm_adjustment_approved"
             ]
+
+    def test_maybe_record_lean_strategy_shadow_rolls_back_session_on_failure(self) -> None:
+        pipeline = object.__new__(TradingPipeline)
+        metrics = Mock()
+        pipeline.state = SimpleNamespace(metrics=metrics)
+        pipeline.lean_lane_manager = Mock()
+        pipeline.lean_lane_manager.record_strategy_shadow.side_effect = RuntimeError('boom')
+
+        session = Mock()
+        execution_client = Mock()
+        execution_client.evaluate_strategy_shadow.return_value = {
+            'run_id': 'run-1',
+            'parity_status': 'blocked_missing_empirical_authority',
+        }
+        decision = SimpleNamespace(
+            strategy_id='strategy-1',
+            symbol='AAPL',
+            action='buy',
+            qty=Decimal('1'),
+            order_type='market',
+            time_in_force='day',
+        )
+
+        original_enabled = config.settings.trading_lean_strategy_shadow_enabled
+        original_disable_switch = config.settings.trading_lean_lane_disable_switch
+        try:
+            config.settings.trading_lean_strategy_shadow_enabled = True
+            config.settings.trading_lean_lane_disable_switch = False
+            TradingPipeline._maybe_record_lean_strategy_shadow(
+                pipeline,
+                session=session,
+                decision=decision,
+                execution_client=execution_client,
+                selected_adapter_name='lean',
+            )
+        finally:
+            config.settings.trading_lean_strategy_shadow_enabled = original_enabled
+            config.settings.trading_lean_lane_disable_switch = original_disable_switch
+
+        session.rollback.assert_called_once()
+        metrics.record_lean_strategy_shadow.assert_any_call('error')
 
     def test_runtime_uncertainty_gate_records_uncertainty_sub_gate_action(self) -> None:
         pipeline = TradingPipeline(


### PR DESCRIPTION
## Summary

- widen LEAN shadow `parity_status` columns to allow the live scaffold status without Postgres truncation failures
- rollback SQLAlchemy sessions when LEAN shadow persistence or decision handling raises, preventing `PendingRollbackError` cascades through the trading lane
- add regressions for the parity-status width contract and shadow-write rollback handling

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_lean_lanes.py tests/test_trading_pipeline.py -k 'shadow or maybe_record_lean_strategy_shadow_rolls_back_session_on_failure'`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

Requires the Alembic migration in `services/torghut/migrations/versions/0025_widen_lean_shadow_parity_status.py` to be applied before the live service fully stops hitting the shadow parity-status truncation bug.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
