### PR TITLE
fix(symphony): unblock task pickup after hung polls

### DIFF
--- a/services/symphony/src/delivery-service.ts
+++ b/services/symphony/src/delivery-service.ts
@@ -16,12 +16,15 @@ import type {
   IssueRecord,
   SymphonyConfig,
 } from './types'
+import { readPositiveNumber } from './utils'
 import type { Logger } from './logger'
 
 const SERVICE_ACCOUNT_DIRECTORY = '/var/run/secrets/kubernetes.io/serviceaccount'
 const TOKEN_PATH = `${SERVICE_ACCOUNT_DIRECTORY}/token`
 const CA_PATH = `${SERVICE_ACCOUNT_DIRECTORY}/ca.crt`
 const ROLLBACK_BRANCH_PREFIX = 'codex/symphony-rollback-'
+const DEFAULT_GITHUB_REQUEST_TIMEOUT_MS = 15_000
+const DEFAULT_KUBERNETES_REQUEST_TIMEOUT_MS = 10_000
 
 type GitHubRepository = {
   owner: string
@@ -124,6 +127,7 @@ const requestKubernetes = (
   requestPath: string,
   token: string,
   ca: string,
+  timeoutMs: number,
 ): Effect.Effect<KubernetesResponse, OrchestratorError, never> =>
   Effect.tryPromise({
     try: () =>
@@ -159,7 +163,17 @@ const requestKubernetes = (
           },
         )
 
-        request.on('error', reject)
+        const timeout = setTimeout(() => {
+          request.destroy(new Error(`kubernetes request timed out after ${timeoutMs}ms`))
+        }, timeoutMs)
+
+        request.on('error', (error) => {
+          clearTimeout(timeout)
+          reject(error)
+        })
+        request.on('close', () => {
+          clearTimeout(timeout)
+        })
         request.end()
       }),
     catch: (error) => new OrchestratorError('runtime_unavailable', 'kubernetes request failed', error),
@@ -334,6 +348,14 @@ export const makeDeliveryServiceLayer = (logger: Logger) =>
     Effect.sync(() => {
       const deliveryLogger = logger.child({ component: 'delivery-service' })
       const githubToken = process.env.GH_TOKEN?.trim() || process.env.GITHUB_TOKEN?.trim() || null
+      const githubRequestTimeoutMs = readPositiveNumber(
+        process.env.SYMPHONY_GITHUB_REQUEST_TIMEOUT_MS,
+        DEFAULT_GITHUB_REQUEST_TIMEOUT_MS,
+      )
+      const kubernetesRequestTimeoutMs = readPositiveNumber(
+        process.env.SYMPHONY_KUBERNETES_REQUEST_TIMEOUT_MS,
+        DEFAULT_KUBERNETES_REQUEST_TIMEOUT_MS,
+      )
 
       const githubRequest = <T>(
         repo: string,
@@ -349,23 +371,32 @@ export const makeDeliveryServiceLayer = (logger: Logger) =>
         const requestUrl = new URL(`https://api.github.com${path}`)
         return Effect.tryPromise({
           try: async () => {
-            const response = await fetch(requestUrl, {
-              ...init,
-              headers: {
-                authorization: `Bearer ${githubToken}`,
-                accept: 'application/vnd.github+json',
-                'user-agent': 'symphony',
-                ...init.headers,
-              },
-            })
-            if (!response.ok) {
-              throw new OrchestratorError(
-                'runtime_unavailable',
-                `github request failed for ${repo}${path}: ${response.status}`,
-                await response.text(),
-              )
+            const controller = new AbortController()
+            const timeout = setTimeout(() => {
+              controller.abort(`github request timed out after ${githubRequestTimeoutMs}ms`)
+            }, githubRequestTimeoutMs)
+            const headers = new Headers(init.headers)
+            headers.set('authorization', `Bearer ${githubToken}`)
+            headers.set('accept', 'application/vnd.github+json')
+            headers.set('user-agent', 'symphony')
+
+            try {
+              const response = await fetch(requestUrl, {
+                ...init,
+                headers,
+                signal: controller.signal,
+              })
+              if (!response.ok) {
+                throw new OrchestratorError(
+                  'runtime_unavailable',
+                  `github request failed for ${repo}${path}: ${response.status}`,
+                  await response.text(),
+                )
+              }
+              return (await response.json()) as T
+            } finally {
+              clearTimeout(timeout)
             }
-            return (await response.json()) as T
           },
           catch: (error) =>
             error instanceof OrchestratorError
@@ -523,6 +554,7 @@ export const makeDeliveryServiceLayer = (logger: Logger) =>
               `/apis/argoproj.io/v1alpha1/namespaces/${argoNamespace}/applications/${config.target.argocdApplication}`,
               token,
               ca,
+              kubernetesRequestTimeoutMs,
             ).pipe(
               Effect.flatMap((response) => {
                 if (response.status !== 200) {

--- a/services/symphony/src/orchestrator-lifecycle.test.ts
+++ b/services/symphony/src/orchestrator-lifecycle.test.ts
@@ -94,6 +94,125 @@ const deliveryLayer = Layer.succeed(DeliveryService, {
 })
 
 describe('orchestrator lifecycle', () => {
+  test('recovers from a timed out poll command and dispatches on the next refresh', async () => {
+    const previousCommandTimeout = process.env.SYMPHONY_COMMAND_TIMEOUT_MS
+    const previousPollTimeout = process.env.SYMPHONY_POLL_TICK_TIMEOUT_MS
+    process.env.SYMPHONY_COMMAND_TIMEOUT_MS = '25'
+    process.env.SYMPHONY_POLL_TICK_TIMEOUT_MS = '25'
+
+    const config = makeTestConfig({
+      pollingIntervalMs: 60_000,
+      health: { preDispatch: [], postDeploy: [] },
+    })
+
+    let fetchCandidateIssuesCalls = 0
+    let preDispatchChecks = 0
+
+    const runtime = ManagedRuntime.make(
+      makeOrchestratorLayer(createLogger({ test: 'orchestrator-poll-timeout-recovery' })).pipe(
+        Layer.provide(
+          Layer.succeed(WorkflowService, {
+            current: Effect.succeed({
+              definition: { config: {}, promptTemplate: 'Work on {{issue.identifier}}' },
+              config,
+            }),
+            config: Effect.succeed(config),
+            reload: Effect.succeed({
+              definition: { config: {}, promptTemplate: 'Work on {{issue.identifier}}' },
+              config,
+            }),
+            changes: Stream.empty,
+          }),
+        ),
+        Layer.provide(
+          Layer.succeed(TrackerService, {
+            fetchCandidateIssues: Effect.sync(() => {
+              fetchCandidateIssuesCalls += 1
+              return [candidateIssue]
+            }),
+            fetchIssuesByStates: () => Effect.succeed([]),
+            fetchIssueStatesByIds: () => Effect.succeed([candidateIssue]),
+            executeLinearGraphql: () => Effect.succeed({}),
+            handoffIssue: () => Effect.void,
+          }),
+        ),
+        Layer.provide(
+          Layer.succeed(WorkspaceService, {
+            createForIssue: () => Effect.die('not used'),
+            runBeforeRun: () => Effect.void,
+            runAfterRun: () => Effect.void,
+            removeWorkspace: () => Effect.void,
+          }),
+        ),
+        Layer.provide(
+          Layer.succeed(IssueRunnerService, {
+            runAttempt: (_issue, _attempt, callbacks, _telemetryContext) =>
+              callbacks.onWorkspacePath('/workspace/symphony/ABC-1').pipe(Effect.zipRight(Effect.never)),
+          }),
+        ),
+        Layer.provide(posthogLayer),
+        Layer.provide(deliveryLayer),
+        Layer.provide(
+          Layer.succeed(LeaderElectionService, {
+            start: Effect.void,
+            stop: Effect.void,
+            status: Effect.succeed(leaderSnapshot),
+            changes: Stream.empty,
+          }),
+        ),
+        Layer.provide(
+          Layer.succeed(StateStoreService, {
+            load: Effect.succeed(emptyPersistedSchedulerState()),
+            save: () => Effect.void,
+            stateFilePath: Effect.succeed('/tmp/symphony-state.json'),
+          }),
+        ),
+        Layer.provide(
+          Layer.succeed(TargetHealthService, {
+            evaluatePreDispatch: Effect.sync(() => {
+              preDispatchChecks += 1
+              return preDispatchChecks
+            }).pipe(Effect.flatMap((attempt) => (attempt === 1 ? Effect.never : Effect.succeed(targetHealthSummary)))),
+          }),
+        ),
+      ),
+    )
+
+    try {
+      await runtime.runPromise(
+        Effect.scoped(
+          Effect.gen(function* () {
+            const orchestrator = yield* OrchestratorService
+            yield* orchestrator.start
+            yield* Effect.sleep(75)
+            yield* orchestrator.triggerRefresh
+            yield* Effect.sleep(75)
+
+            const snapshot = yield* orchestrator.getSnapshot
+            expect(preDispatchChecks).toBeGreaterThanOrEqual(2)
+            expect(fetchCandidateIssuesCalls).toBeGreaterThan(0)
+            expect(snapshot.counts.running).toBe(1)
+            expect(snapshot.running[0]?.issueIdentifier).toBe('ABC-1')
+
+            yield* orchestrator.stop
+          }),
+        ),
+      )
+    } finally {
+      if (previousCommandTimeout === undefined) {
+        delete process.env.SYMPHONY_COMMAND_TIMEOUT_MS
+      } else {
+        process.env.SYMPHONY_COMMAND_TIMEOUT_MS = previousCommandTimeout
+      }
+      if (previousPollTimeout === undefined) {
+        delete process.env.SYMPHONY_POLL_TICK_TIMEOUT_MS
+      } else {
+        process.env.SYMPHONY_POLL_TICK_TIMEOUT_MS = previousPollTimeout
+      }
+      await runtime.dispose()
+    }
+  })
+
   test('continues processing refresh work after start returns', async () => {
     const config = makeTestConfig({
       pollingIntervalMs: 60_000,

--- a/services/symphony/src/orchestrator.ts
+++ b/services/symphony/src/orchestrator.ts
@@ -1,4 +1,5 @@
 import { Context, Effect, Layer } from 'effect'
+import * as Cause from 'effect/Cause'
 import * as Duration from 'effect/Duration'
 import * as Exit from 'effect/Exit'
 import * as Fiber from 'effect/Fiber'
@@ -61,7 +62,7 @@ import type {
   TokenUsageTotals,
   WorkflowSummary,
 } from './types'
-import { normalizeState } from './utils'
+import { normalizeState, readPositiveNumber } from './utils'
 import { WorkflowService } from './workflow'
 import { WorkspaceService } from './workspace-manager'
 import type { Logger } from './logger'
@@ -128,6 +129,8 @@ const MAX_GLOBAL_EVENTS = 100
 const MAX_ISSUE_EVENTS = 50
 const MAX_RECENT_ERRORS = 50
 const MAX_RUN_HISTORY = 25
+const DEFAULT_ORCHESTRATOR_COMMAND_TIMEOUT_MS = 30_000
+const DEFAULT_POLL_TICK_TIMEOUT_MS = 45_000
 
 const buildTelemetrySessionId = (projectSlug: string | null, issueId: string) =>
   `symphony:${projectSlug ?? 'unknown'}:${issueId}`
@@ -543,6 +546,14 @@ export const makeOrchestratorLayer = (logger: Logger) =>
       const startedRef = yield* Ref.make(false)
       const pollQueuedRef = yield* Ref.make(false)
       const stallQueuedRef = yield* Ref.make(false)
+      const orchestratorCommandTimeoutMs = readPositiveNumber(
+        process.env.SYMPHONY_COMMAND_TIMEOUT_MS,
+        DEFAULT_ORCHESTRATOR_COMMAND_TIMEOUT_MS,
+      )
+      const pollTickTimeoutMs = readPositiveNumber(
+        process.env.SYMPHONY_POLL_TICK_TIMEOUT_MS,
+        DEFAULT_POLL_TICK_TIMEOUT_MS,
+      )
       const seenLeaderStateRef = yield* Ref.make<boolean | null>(null)
       const processorFiberRef = yield* Ref.make<Fiber.RuntimeFiber<void, never> | null>(null)
       const pollFiberRef = yield* Ref.make<Fiber.RuntimeFiber<void, never> | null>(null)
@@ -1366,7 +1377,7 @@ export const makeOrchestratorLayer = (logger: Logger) =>
           yield* persistStateBestEffort
         })
 
-      const processPollTick = (() => {
+      const processPollTick = () => {
         const startedAtMs = Date.now()
         const pollSpan = startSymphonySpan('symphony.poll_tick')
         let finished = false
@@ -1637,7 +1648,7 @@ export const makeOrchestratorLayer = (logger: Logger) =>
             }),
           ),
         )
-      })()
+      }
 
       const processRetryDue = (issueId: string) =>
         withSymphonyEffectSpan(
@@ -1946,89 +1957,102 @@ export const makeOrchestratorLayer = (logger: Logger) =>
           )
         })
 
-      const handleCommand = (command: OrchestratorCommand) =>
-        Effect.matchEffect(
-          (() => {
-            switch (command._tag) {
-              case 'PollTick':
-                return processPollTick
-              case 'StallSweep':
-                return Ref.set(stallQueuedRef, false).pipe(
-                  Effect.zipRight(
-                    leaderElection.status.pipe(
-                      Effect.flatMap((leader) =>
-                        leader.isLeader
-                          ? workflow.config.pipe(Effect.flatMap((config) => reconcileStalledRuns(config)))
-                          : Effect.void,
-                      ),
-                    ),
+      const getCommandTimeoutMs = (command: OrchestratorCommand): number =>
+        command._tag === 'PollTick' ? pollTickTimeoutMs : orchestratorCommandTimeoutMs
+
+      const buildCommandEffect = (command: OrchestratorCommand) => {
+        switch (command._tag) {
+          case 'PollTick':
+            return processPollTick()
+          case 'StallSweep':
+            return Ref.set(stallQueuedRef, false).pipe(
+              Effect.zipRight(
+                leaderElection.status.pipe(
+                  Effect.flatMap((leader) =>
+                    leader.isLeader
+                      ? workflow.config.pipe(Effect.flatMap((config) => reconcileStalledRuns(config)))
+                      : Effect.void,
                   ),
-                )
-              case 'RetryDue':
-                return processRetryDue(command.issueId)
-              case 'LeaderChanged':
-                return handleLeaderChanged(command.leader)
-              case 'WorkspaceReady':
-                return SynchronizedRef.modifyEffect(stateRef, (state) => {
-                  const running = state.running.get(command.issueId)
-                  let telemetryEffect: Effect.Effect<void, never> = Effect.void
-                  if (running) {
-                    running.workspacePath = command.workspacePath
-                    const record = ensureIssueRecord(state, running.issueId, running.identifier)
-                    record.workspacePath = command.workspacePath
-                    syncRecordFromRunning(record, running)
-                    addRunHistory(record, {
-                      at: new Date().toISOString(),
-                      status: 'workspace_ready',
-                      attempt: running.retryAttempt,
-                      message: null,
-                      workspacePath: command.workspacePath,
-                      sessionId: running.session.sessionId,
-                    })
-                    addRecentEvent(state, {
-                      at: new Date().toISOString(),
-                      event: 'workspace_ready',
-                      message: command.workspacePath,
-                      issueId: running.issueId,
-                      issueIdentifier: running.identifier,
-                      level: 'info',
-                    })
-                    telemetryEffect = posthog.captureSpan({
-                      traceId: running.telemetry.traceId,
-                      sessionId: running.telemetry.sessionId,
-                      spanId: `${running.telemetry.traceId}:workspace-ready:${Date.now()}`,
-                      parentId: running.telemetry.rootSpanId,
-                      spanName: 'workspace_ready',
-                      outputState: {
-                        workspace_path: command.workspacePath,
-                      },
-                      properties: {
-                        issue_id: running.issueId,
-                        issue_identifier: running.identifier,
-                      },
-                    })
-                  }
-                  return Effect.succeed([telemetryEffect, state] as const)
-                }).pipe(
-                  Effect.flatMap((telemetryEffect) => telemetryEffect),
-                  Effect.zipRight(persistStateBestEffort),
-                )
-              case 'CodexEventReceived':
-                return handleCodexEvent(command.issueId, command.event)
-              case 'WorkerExited':
-                return processWorkerExit(command.issueId, command.exit)
-            }
-          })(),
-          {
-            onFailure: (error) =>
-              Effect.sync(() => {
-                orchestratorLogger.log('warn', 'orchestrator_command_failed', {
-                  command: command._tag,
-                  ...toLogError(error),
+                ),
+              ),
+            )
+          case 'RetryDue':
+            return processRetryDue(command.issueId)
+          case 'LeaderChanged':
+            return handleLeaderChanged(command.leader)
+          case 'WorkspaceReady':
+            return SynchronizedRef.modifyEffect(stateRef, (state) => {
+              const running = state.running.get(command.issueId)
+              let telemetryEffect: Effect.Effect<void, never> = Effect.void
+              if (running) {
+                running.workspacePath = command.workspacePath
+                const record = ensureIssueRecord(state, running.issueId, running.identifier)
+                record.workspacePath = command.workspacePath
+                syncRecordFromRunning(record, running)
+                addRunHistory(record, {
+                  at: new Date().toISOString(),
+                  status: 'workspace_ready',
+                  attempt: running.retryAttempt,
+                  message: null,
+                  workspacePath: command.workspacePath,
+                  sessionId: running.session.sessionId,
                 })
-              }),
-            onSuccess: () => Effect.void,
-          },
+                addRecentEvent(state, {
+                  at: new Date().toISOString(),
+                  event: 'workspace_ready',
+                  message: command.workspacePath,
+                  issueId: running.issueId,
+                  issueIdentifier: running.identifier,
+                  level: 'info',
+                })
+                telemetryEffect = posthog.captureSpan({
+                  traceId: running.telemetry.traceId,
+                  sessionId: running.telemetry.sessionId,
+                  spanId: `${running.telemetry.traceId}:workspace-ready:${Date.now()}`,
+                  parentId: running.telemetry.rootSpanId,
+                  spanName: 'workspace_ready',
+                  outputState: {
+                    workspace_path: command.workspacePath,
+                  },
+                  properties: {
+                    issue_id: running.issueId,
+                    issue_identifier: running.identifier,
+                  },
+                })
+              }
+              return Effect.succeed([telemetryEffect, state] as const)
+            }).pipe(
+              Effect.flatMap((telemetryEffect) => telemetryEffect),
+              Effect.zipRight(persistStateBestEffort),
+            )
+          case 'CodexEventReceived':
+            return handleCodexEvent(command.issueId, command.event)
+          case 'WorkerExited':
+            return processWorkerExit(command.issueId, command.exit)
+        }
+      }
+
+      const handleCommand = (command: OrchestratorCommand) =>
+        buildCommandEffect(command).pipe(
+          Effect.timeoutFail({
+            duration: Duration.millis(getCommandTimeoutMs(command)),
+            onTimeout: () =>
+              new OrchestratorError(
+                'runtime_unavailable',
+                `orchestrator command ${command._tag} timed out after ${getCommandTimeoutMs(command)}ms`,
+              ),
+          }),
+          Effect.catchAllCause((cause) => {
+            if (Cause.isInterruptedOnly(cause)) {
+              return Effect.void
+            }
+            return Effect.sync(() => {
+              orchestratorLogger.log('warn', 'orchestrator_command_failed', {
+                command: command._tag,
+                ...toLogError(Cause.squash(cause)),
+              })
+            })
+          }),
         )
 
       const startProcessor = Effect.forever(Queue.take(queue).pipe(Effect.flatMap(handleCommand))).pipe(

--- a/services/symphony/src/target-health.ts
+++ b/services/symphony/src/target-health.ts
@@ -6,12 +6,16 @@ import { Context, Effect, Layer } from 'effect'
 
 import { OrchestratorError, toLogError } from './errors'
 import type { HealthCheckConfig, TargetHealthCheckResult, TargetHealthSummary } from './types'
+import { readPositiveNumber } from './utils'
 import { WorkflowService } from './workflow'
 import type { Logger } from './logger'
 
 const SERVICE_ACCOUNT_DIRECTORY = '/var/run/secrets/kubernetes.io/serviceaccount'
 const TOKEN_PATH = `${SERVICE_ACCOUNT_DIRECTORY}/token`
 const CA_PATH = `${SERVICE_ACCOUNT_DIRECTORY}/ca.crt`
+const DEFAULT_GITHUB_REQUEST_TIMEOUT_MS = 15_000
+const DEFAULT_HTTP_CHECK_TIMEOUT_MS = 5_000
+const DEFAULT_KUBERNETES_REQUEST_TIMEOUT_MS = 10_000
 
 type KubernetesResponse = {
   status: number
@@ -23,6 +27,7 @@ const requestKubernetes = (
   path: string,
   token: string,
   ca: string,
+  timeoutMs: number,
 ): Effect.Effect<KubernetesResponse, OrchestratorError, never> =>
   Effect.tryPromise({
     try: () =>
@@ -58,7 +63,17 @@ const requestKubernetes = (
           },
         )
 
-        request.on('error', reject)
+        const timeout = setTimeout(() => {
+          request.destroy(new Error(`kubernetes request timed out after ${timeoutMs}ms`))
+        }, timeoutMs)
+
+        request.on('error', (error) => {
+          clearTimeout(timeout)
+          reject(error)
+        })
+        request.on('close', () => {
+          clearTimeout(timeout)
+        })
         request.end()
       }),
     catch: (error) => new OrchestratorError('target_health_check_failed', 'kubernetes request failed', error),
@@ -83,6 +98,7 @@ const evaluateArgoApplicationCheck = (
   check: HealthCheckConfig,
   token: string,
   ca: string,
+  timeoutMs: number,
 ): Effect.Effect<TargetHealthCheckResult, OrchestratorError, never> => {
   const namespace = check.namespace ?? 'argocd'
   const application = check.application ?? ''
@@ -98,6 +114,7 @@ const evaluateArgoApplicationCheck = (
     `/apis/argoproj.io/v1alpha1/namespaces/${namespace}/applications/${application}`,
     token,
     ca,
+    timeoutMs,
   ).pipe(
     Effect.flatMap((response) => {
       if (response.status !== 200) {
@@ -137,6 +154,7 @@ const evaluateKnativeServiceCheck = (
   check: HealthCheckConfig,
   token: string,
   ca: string,
+  timeoutMs: number,
 ): Effect.Effect<TargetHealthCheckResult, OrchestratorError, never> => {
   const namespace = check.namespace ?? ''
   const serviceName = check.resourceName ?? ''
@@ -151,6 +169,7 @@ const evaluateKnativeServiceCheck = (
     `/apis/serving.knative.dev/v1/namespaces/${namespace}/services/${serviceName}`,
     token,
     ca,
+    timeoutMs,
   ).pipe(
     Effect.flatMap((response) => {
       if (response.status !== 200) {
@@ -223,6 +242,7 @@ const evaluateKubernetesResourceCheck = (
   check: HealthCheckConfig,
   token: string,
   ca: string,
+  timeoutMs: number,
 ): Effect.Effect<TargetHealthCheckResult, OrchestratorError, never> =>
   Effect.try({
     try: () => deriveResourcePath(check),
@@ -231,7 +251,7 @@ const evaluateKubernetesResourceCheck = (
         ? error
         : new OrchestratorError('target_health_check_failed', 'failed to resolve kubernetes resource path', error),
   }).pipe(
-    Effect.flatMap((resourcePath) => requestKubernetes('GET', resourcePath, token, ca)),
+    Effect.flatMap((resourcePath) => requestKubernetes('GET', resourcePath, token, ca, timeoutMs)),
     Effect.flatMap((response) => {
       if (response.status !== 200) {
         return Effect.fail(
@@ -319,6 +339,7 @@ const evaluateKubernetesResourceCheck = (
 
 const evaluateHttpCheck = (
   check: HealthCheckConfig,
+  timeoutMs: number,
 ): Effect.Effect<TargetHealthCheckResult, OrchestratorError, never> => {
   const url = check.url ?? ''
   if (!url) {
@@ -327,8 +348,17 @@ const evaluateHttpCheck = (
 
   return Effect.tryPromise({
     try: async () => {
-      const response = await fetch(url)
-      return response.status
+      const controller = new AbortController()
+      const timeout = setTimeout(() => {
+        controller.abort(`http check timed out after ${timeoutMs}ms`)
+      }, timeoutMs)
+
+      try {
+        const response = await fetch(url, { signal: controller.signal })
+        return response.status
+      } finally {
+        clearTimeout(timeout)
+      }
     },
     catch: (error) => new OrchestratorError('target_health_check_failed', `failed to fetch ${url}`, error),
   }).pipe(
@@ -352,16 +382,18 @@ const evaluateCheck = (
   check: HealthCheckConfig,
   token: string,
   ca: string,
+  httpCheckTimeoutMs: number,
+  kubernetesRequestTimeoutMs: number,
 ): Effect.Effect<TargetHealthCheckResult, OrchestratorError, never> => {
   switch (check.type) {
     case 'argocd_application':
-      return evaluateArgoApplicationCheck(check, token, ca)
+      return evaluateArgoApplicationCheck(check, token, ca, kubernetesRequestTimeoutMs)
     case 'http':
-      return evaluateHttpCheck(check)
+      return evaluateHttpCheck(check, httpCheckTimeoutMs)
     case 'knative_service':
-      return evaluateKnativeServiceCheck(check, token, ca)
+      return evaluateKnativeServiceCheck(check, token, ca, kubernetesRequestTimeoutMs)
     case 'kubernetes_resource':
-      return evaluateKubernetesResourceCheck(check, token, ca)
+      return evaluateKubernetesResourceCheck(check, token, ca, kubernetesRequestTimeoutMs)
   }
 }
 
@@ -370,6 +402,7 @@ const fetchOpenPromotionPrCount = (
   defaultBranch: string,
   promotionBranchPrefix: string,
   token: string | null,
+  timeoutMs: number,
 ): Effect.Effect<number, OrchestratorError, never> => {
   if (!promotionBranchPrefix) return Effect.succeed(0)
   if (!token) {
@@ -378,25 +411,35 @@ const fetchOpenPromotionPrCount = (
 
   return Effect.tryPromise({
     try: async () => {
-      const response = await fetch(
-        `https://api.github.com/repos/${repo}/pulls?state=open&base=${encodeURIComponent(defaultBranch)}&per_page=100`,
-        {
-          headers: {
-            authorization: `Bearer ${token}`,
-            accept: 'application/vnd.github+json',
-            'user-agent': 'symphony',
+      const controller = new AbortController()
+      const timeout = setTimeout(() => {
+        controller.abort(`github request timed out after ${timeoutMs}ms`)
+      }, timeoutMs)
+
+      try {
+        const response = await fetch(
+          `https://api.github.com/repos/${repo}/pulls?state=open&base=${encodeURIComponent(defaultBranch)}&per_page=100`,
+          {
+            headers: {
+              authorization: `Bearer ${token}`,
+              accept: 'application/vnd.github+json',
+              'user-agent': 'symphony',
+            },
+            signal: controller.signal,
           },
-        },
-      )
-      if (!response.ok) {
-        throw new OrchestratorError(
-          'target_health_check_failed',
-          `github pull request list returned ${response.status}`,
-          await response.text(),
         )
+        if (!response.ok) {
+          throw new OrchestratorError(
+            'target_health_check_failed',
+            `github pull request list returned ${response.status}`,
+            await response.text(),
+          )
+        }
+        const payload = (await response.json()) as Array<{ head?: { ref?: string } }>
+        return payload.filter((pullRequest) => (pullRequest.head?.ref ?? '').startsWith(promotionBranchPrefix)).length
+      } finally {
+        clearTimeout(timeout)
       }
-      const payload = (await response.json()) as Array<{ head?: { ref?: string } }>
-      return payload.filter((pullRequest) => (pullRequest.head?.ref ?? '').startsWith(promotionBranchPrefix)).length
     },
     catch: (error) =>
       error instanceof OrchestratorError
@@ -420,6 +463,18 @@ export const makeTargetHealthLayer = (logger: Logger) =>
     Effect.gen(function* () {
       const workflow = yield* WorkflowService
       const targetLogger = logger.child({ component: 'target-health' })
+      const githubRequestTimeoutMs = readPositiveNumber(
+        process.env.SYMPHONY_GITHUB_REQUEST_TIMEOUT_MS,
+        DEFAULT_GITHUB_REQUEST_TIMEOUT_MS,
+      )
+      const httpCheckTimeoutMs = readPositiveNumber(
+        process.env.SYMPHONY_HTTP_CHECK_TIMEOUT_MS,
+        DEFAULT_HTTP_CHECK_TIMEOUT_MS,
+      )
+      const kubernetesRequestTimeoutMs = readPositiveNumber(
+        process.env.SYMPHONY_KUBERNETES_REQUEST_TIMEOUT_MS,
+        DEFAULT_KUBERNETES_REQUEST_TIMEOUT_MS,
+      )
 
       return {
         evaluatePreDispatch: workflow.current.pipe(
@@ -431,7 +486,7 @@ export const makeTargetHealthLayer = (logger: Logger) =>
               const githubToken = process.env.GH_TOKEN?.trim() || process.env.GITHUB_TOKEN?.trim() || null
 
               const checks = yield* Effect.forEach(config.health.preDispatch, (check) =>
-                evaluateCheck(check, token, ca).pipe(
+                evaluateCheck(check, token, ca, httpCheckTimeoutMs, kubernetesRequestTimeoutMs).pipe(
                   Effect.catchAll((error) =>
                     Effect.succeed({
                       name: check.name,
@@ -449,6 +504,7 @@ export const makeTargetHealthLayer = (logger: Logger) =>
                 config.target.defaultBranch,
                 config.release.promotionBranchPrefix,
                 githubToken,
+                githubRequestTimeoutMs,
               ).pipe(
                 Effect.catchAll((error) => {
                   targetLogger.log('warn', 'target_health_github_query_failed', toLogError(error))


### PR DESCRIPTION
## Summary

- add hard timeouts to Symphony GitHub, Kubernetes, and HTTP health-check requests so external I/O cannot hang indefinitely
- time-bound queued orchestrator commands and rebuild the poll effect per execution so one wedged poll cannot freeze future task pickup
- add a regression test proving Symphony recovers from a timed out poll and dispatches work on the next refresh

## Related Issues

Resolves PROOMPT-337

## Testing

- `bun install --frozen-lockfile`
- `bun run --cwd services/symphony tsc`
- `bun run --cwd services/symphony test orchestrator-lifecycle.test.ts delivery-service.test.ts`
- `bun run --cwd services/symphony test`
- `bun run --cwd services/symphony lint`
- `bun run --cwd services/symphony lint:oxlint:type`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
