### PR TITLE
chore(symphony): promote image 0cdccec6

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-19T09:50:35Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-19T22:04:28Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -25,5 +25,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "a736dfa8"
-    digest: sha256:d98f54027e130dac7c847efa6a74be0f7a9f5e27c0f8c5ef951fd48acf1b31a1
+    newTag: "0cdccec6"
+    digest: sha256:c47b221a7186e8577f7d3c48e3e389a08f57534968eb5abf41e2b773f61d365e

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-19T09:50:35Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-19T22:04:28Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -27,5 +27,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "a736dfa8"
-    digest: sha256:d98f54027e130dac7c847efa6a74be0f7a9f5e27c0f8c5ef951fd48acf1b31a1
+    newTag: "0cdccec6"
+    digest: sha256:c47b221a7186e8577f7d3c48e3e389a08f57534968eb5abf41e2b773f61d365e

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-19T09:50:35Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-19T22:04:28Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -20,5 +20,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "a736dfa8"
-    digest: sha256:d98f54027e130dac7c847efa6a74be0f7a9f5e27c0f8c5ef951fd48acf1b31a1
+    newTag: "0cdccec6"
+    digest: sha256:c47b221a7186e8577f7d3c48e3e389a08f57534968eb5abf41e2b773f61d365e


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `0cdccec6f1e9e96cc2f1c6c6ba6ed34ffd36afac`
- Image tag: `0cdccec6`
- Image digest: `sha256:c47b221a7186e8577f7d3c48e3e389a08f57534968eb5abf41e2b773f61d365e`