### PR TITLE
fix(jangar): require execution trust admission

### DIFF
--- a/docs/agents/runbooks.md
+++ b/docs/agents/runbooks.md
@@ -128,6 +128,7 @@ Confirm the workflow adapter is healthy and no Argo Workflows are required:
 curl -fsS http://localhost:8080/api/agents/control-plane/status?namespace=agents | jq '.runtime_adapters'
 curl -fsS http://localhost:8080/api/agents/control-plane/status?namespace=agents | jq '.workflows'
 curl -fsS http://localhost:8080/api/agents/control-plane/status?namespace=agents | jq '.agentrun_ingestion'
+curl -fsS http://localhost:8080/api/agents/control-plane/status?namespace=agents | jq '.execution_trust'
 kubectl api-resources --api-group=argoproj.io --no-headers || true
 kubectl -n agents get workflows.argoproj.io 2>/dev/null || true
 ```
@@ -139,6 +140,8 @@ Expected outcomes:
   `backoff_limit_exceeded_jobs`, and `top_failure_reasons`.
 - `agentrun_ingestion` reports the latest AgentRun watch/resync timestamps and stays `healthy` with
   `untouched_run_count: 0` during normal operation.
+- `execution_trust` is always present and stays `healthy`; if a swarm freeze TTL has expired without
+  reconciliation, it reports `freeze expiry unreconciled` and `/ready` should return `503`.
 - The Argo Workflows resource check returns empty output (no CRD or no workflows).
 
 ## Native workflow e2e proof

--- a/services/jangar/README.md
+++ b/services/jangar/README.md
@@ -317,9 +317,9 @@ Control-plane status now includes an additive `agentrun_ingestion` block in
 - `untouched_run_count`
 - `oldest_untouched_age_seconds`
 
-Execution-trust gating can be enabled in `/api/agents/control-plane/status` via:
+Execution trust is now a mandatory part of `/api/agents/control-plane/status` and `/ready`.
+Tracked swarm selection and response fan-out remain configurable via:
 
-- `JANGAR_CONTROL_PLANE_EXECUTION_TRUST` (optional; default: `false`)
 - `JANGAR_CONTROL_PLANE_EXECUTION_TRUST_SWARMS` (optional comma list; default: `jangar-control-plane,torghut-quant`)
 - `JANGAR_CONTROL_PLANE_EXECUTION_TRUST_SUMMARY_LIMIT` (optional; default: `20`)
 
@@ -333,13 +333,15 @@ Rollout safety now also uses gate thresholds for watch stability and empirical j
   - `status` is now a hard block when `/api/agents/control-plane/status` reports `empirical_services.jobs.status === degraded`.
   - Forecast and LEAN degradation remain observable but do not block rollout.
 
-When enabled and trust is not healthy, the status payload includes:
+The status payload always includes:
 
 - `execution_trust`
 - `swarms`
 - `stages`
 
 `execution_trust.status` will be one of `healthy`, `degraded`, `blocked`, or `unknown`.
+If a swarm remains `Frozen` after `freeze.until` has passed, execution trust now reports
+`freeze expiry unreconciled` and keeps `/ready` non-200 until the authority state is reconciled.
 `/ready` returns `503` when execution trust is `degraded`, `blocked`, or `unknown`
 and includes the same `execution_trust` block in its response.
 

--- a/services/jangar/src/components/__tests__/agents-control-plane-status.test.tsx
+++ b/services/jangar/src/components/__tests__/agents-control-plane-status.test.tsx
@@ -125,6 +125,15 @@ const baseStatus: ControlPlaneStatus = {
     deployments: [],
     message: 'healthy',
   },
+  execution_trust: {
+    status: 'healthy',
+    reason: 'execution trust is healthy.',
+    last_evaluated_at: '2026-01-20T00:00:00Z',
+    blocking_windows: [],
+    evidence_summary: [],
+  },
+  swarms: [],
+  stages: [],
   empirical_services: {
     forecast: {
       status: 'healthy',

--- a/services/jangar/src/data/agents-control-plane.ts
+++ b/services/jangar/src/data/agents-control-plane.ts
@@ -363,9 +363,9 @@ export type ControlPlaneStatus = {
   agentrun_ingestion: AgentRunIngestionStatus
   rollout_health: ControlPlaneRolloutHealth
   empirical_services: EmpiricalServicesStatus
-  execution_trust?: ExecutionTrustStatus
-  swarms?: ExecutionTrustSwarm[]
-  stages?: ExecutionTrustStage[]
+  execution_trust: ExecutionTrustStatus
+  swarms: ExecutionTrustSwarm[]
+  stages: ExecutionTrustStage[]
   namespaces: NamespaceStatus[]
 }
 

--- a/services/jangar/src/routes/ready.test.ts
+++ b/services/jangar/src/routes/ready.test.ts
@@ -37,7 +37,17 @@ describe('getReadyHandler', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     controlPlaneStatusMocks.buildExecutionTrust.mockReset()
-    delete process.env.JANGAR_CONTROL_PLANE_EXECUTION_TRUST
+    controlPlaneStatusMocks.buildExecutionTrust.mockResolvedValue({
+      executionTrust: {
+        status: 'healthy',
+        reason: 'execution trust is healthy.',
+        last_evaluated_at: '2026-03-08T21:00:00Z',
+        blocking_windows: [],
+        evidence_summary: [],
+      },
+      swarms: [],
+      stages: [],
+    })
 
     agentsControllerMocks.getAgentsControllerHealth.mockReturnValue({
       enabled: true,
@@ -165,8 +175,7 @@ describe('getReadyHandler', () => {
     expect(body.status).toBe('degraded')
   })
 
-  it('returns 200 when execution trust is healthy and enabled', async () => {
-    process.env.JANGAR_CONTROL_PLANE_EXECUTION_TRUST = 'true'
+  it('returns 200 when execution trust is healthy', async () => {
     controlPlaneStatusMocks.buildExecutionTrust.mockResolvedValue({
       executionTrust: {
         status: 'healthy',
@@ -192,7 +201,6 @@ describe('getReadyHandler', () => {
   })
 
   it('returns 503 when execution trust is blocked', async () => {
-    process.env.JANGAR_CONTROL_PLANE_EXECUTION_TRUST = 'true'
     controlPlaneStatusMocks.buildExecutionTrust.mockResolvedValue({
       executionTrust: {
         status: 'blocked',
@@ -226,7 +234,6 @@ describe('getReadyHandler', () => {
   })
 
   it('returns 503 when any watched namespace reports blocked execution trust', async () => {
-    process.env.JANGAR_CONTROL_PLANE_EXECUTION_TRUST = 'true'
     agentsControllerMocks.getAgentsControllerHealth.mockReturnValue({
       enabled: true,
       started: true,
@@ -300,17 +307,19 @@ describe('getReadyHandler', () => {
     ])
   })
 
-  it('skips execution trust check when the feature flag is disabled', async () => {
-    process.env.JANGAR_CONTROL_PLANE_EXECUTION_TRUST = '0'
-
+  it('returns 503 when execution trust evaluation fails', async () => {
+    controlPlaneStatusMocks.buildExecutionTrust.mockRejectedValue(new Error('trust fetch failed'))
     const { getReadyHandler } = await import('./ready')
 
     const response = await getReadyHandler()
 
-    expect(response.status).toBe(200)
+    expect(response.status).toBe(503)
     const body = await response.json()
-    expect(body.status).toBe('ok')
-    expect(body.execution_trust).toBeUndefined()
-    expect(controlPlaneStatusMocks.buildExecutionTrust).not.toHaveBeenCalled()
+    expect(body.status).toBe('degraded')
+    expect(body.execution_trust).toMatchObject({
+      status: 'unknown',
+    })
+    expect(body.execution_trust.reason).toContain('execution trust check failed for namespace agents')
+    expect(controlPlaneStatusMocks.buildExecutionTrust).toHaveBeenCalledTimes(1)
   })
 })

--- a/services/jangar/src/routes/ready.tsx
+++ b/services/jangar/src/routes/ready.tsx
@@ -6,7 +6,6 @@ import { getLeaderElectionStatus } from '~/server/leader-election'
 import { getOrchestrationControllerHealth } from '~/server/orchestration-controller'
 import { getSupportingControllerHealth } from '~/server/supporting-primitives-controller'
 import { buildExecutionTrust } from '~/server/control-plane-status'
-import { parseBooleanEnv } from '~/server/agents-controller/env-config'
 
 const isControllerHealthReady = (health: ReturnType<typeof getAgentsControllerHealth>) =>
   !health.enabled || health.crdsReady !== false
@@ -20,8 +19,6 @@ const isAgentRunIngestionReady = (health: ReturnType<typeof getAgentsControllerH
 
 const isStandbyLeaderElectionReady = (leaderElection: ReturnType<typeof getLeaderElectionStatus>) =>
   leaderElection.lastAttemptAt !== null && leaderElection.lastError === null
-
-const resolveExecutionTrustEnabled = () => parseBooleanEnv(process.env.JANGAR_CONTROL_PLANE_EXECUTION_TRUST, false)
 
 const uniqueStrings = (values: string[]) => [...new Set(values.filter((value) => value.length > 0))]
 
@@ -78,7 +75,6 @@ const mergeExecutionTrustStatuses = (input: {
 }
 
 const executionTrustStatus = async (namespaces: string[]) => {
-  if (!resolveExecutionTrustEnabled()) return null
   const now = new Date()
   const resolvedNamespaces = uniqueStrings(namespaces.length > 0 ? namespaces : ['agents'])
   const trusts = await Promise.all(
@@ -136,7 +132,7 @@ export const getReadyHandler = async () => {
   const agentsControllerReady = activeControllerReplica
     ? isAgentRunIngestionReady(agentsController)
     : leaderElectionReady
-  const executionTrustReady = !trust || trust.status === 'healthy'
+  const executionTrustReady = trust.status === 'healthy'
   const ready = controllersOk && agentsControllerReady && executionTrustReady
 
   const body = JSON.stringify({
@@ -146,7 +142,7 @@ export const getReadyHandler = async () => {
     agentsController,
     orchestrationController,
     supportingController,
-    ...(trust ? { execution_trust: trust } : {}),
+    execution_trust: trust,
   })
 
   const headers: Record<string, string> = {

--- a/services/jangar/src/server/__tests__/control-plane-status.test.ts
+++ b/services/jangar/src/server/__tests__/control-plane-status.test.ts
@@ -410,9 +410,32 @@ describe('control-plane status', () => {
     },
   ]
 
+  const healthyExecutionTrust: ExecutionTrustStatus = {
+    status: 'healthy',
+    reason: 'execution trust is healthy.',
+    last_evaluated_at: '2026-01-20T00:20:00Z',
+    blocking_windows: [],
+    evidence_summary: [],
+  }
+
+  const healthyExecutionTrustSnapshot = {
+    executionTrust: healthyExecutionTrust,
+    swarms: [] as ExecutionTrustSwarm[],
+    stages: [] as ExecutionTrustStage[],
+  }
+
+  const buildStatus = (
+    options: Parameters<typeof buildControlPlaneStatus>[0],
+    deps: Parameters<typeof buildControlPlaneStatus>[1] = {},
+  ) =>
+    buildControlPlaneStatus(options, {
+      resolveExecutionTrust: async () => healthyExecutionTrustSnapshot,
+      ...deps,
+    })
+
   it('returns healthy summary when components are healthy', async () => {
     setRolloutDeploymentList([healthyRolloutDeployment, healthyAgentsControllersRolloutDeployment])
-    const status = await buildControlPlaneStatus(
+    const status = await buildStatus(
       {
         namespace: 'agents',
         grpc: {
@@ -526,7 +549,7 @@ describe('control-plane status', () => {
       ],
     }
 
-    const status = await buildControlPlaneStatus(
+    const status = await buildStatus(
       {
         namespace: 'agents',
         grpc: {
@@ -639,7 +662,7 @@ describe('control-plane status', () => {
   it('keeps delay scope global when only control runtime degrades', async () => {
     setRolloutDeploymentList([healthyRolloutDeployment, healthyAgentsControllersRolloutDeployment])
 
-    const status = await buildControlPlaneStatus(
+    const status = await buildStatus(
       {
         namespace: 'agents',
         grpc: {
@@ -691,7 +714,7 @@ describe('control-plane status', () => {
   it('blocks rollout quorum when empirical jobs are degraded', async () => {
     setRolloutDeploymentList([healthyRolloutDeployment, healthyAgentsControllersRolloutDeployment])
 
-    const status = await buildControlPlaneStatus(
+    const status = await buildStatus(
       {
         namespace: 'agents',
         grpc: {
@@ -759,7 +782,7 @@ describe('control-plane status', () => {
     process.env.JANGAR_CONTROL_PLANE_WATCH_RELIABILITY_BLOCK_RESTARTS = '2'
     setRolloutDeploymentList([healthyRolloutDeployment, healthyAgentsControllersRolloutDeployment])
 
-    const status = await buildControlPlaneStatus(
+    const status = await buildStatus(
       {
         namespace: 'agents',
         grpc: {
@@ -850,7 +873,7 @@ describe('control-plane status', () => {
     process.env.JANGAR_CONTROL_PLANE_WATCH_RELIABILITY_BLOCK_RESTARTS = '10'
     setRolloutDeploymentList([healthyRolloutDeployment, healthyAgentsControllersRolloutDeployment])
 
-    const status = await buildControlPlaneStatus(
+    const status = await buildStatus(
       {
         namespace: 'agents',
         grpc: {
@@ -941,7 +964,7 @@ describe('control-plane status', () => {
     process.env.JANGAR_WORKFLOWS_DEGRADED_BACKOFF_THRESHOLD = '3'
     setRolloutDeploymentList([healthyRolloutDeployment, healthyAgentsControllersRolloutDeployment])
 
-    const status = await buildControlPlaneStatus(
+    const status = await buildStatus(
       {
         namespace: 'agents',
         grpc: {
@@ -1016,7 +1039,7 @@ describe('control-plane status', () => {
       }),
     })
 
-    const status = await buildControlPlaneStatus(
+    const status = await buildStatus(
       {
         namespace: 'agents',
         grpc: {
@@ -1084,7 +1107,7 @@ describe('control-plane status', () => {
       throw new Error('simulated kube client creation failure')
     })
     await expect(
-      buildControlPlaneStatus(
+      buildStatus(
         {
           namespace: 'agents',
           grpc: {
@@ -1113,7 +1136,7 @@ describe('control-plane status', () => {
   it('marks namespace degraded when migration consistency reports drift', async () => {
     setRolloutDeploymentList([healthyRolloutDeployment])
 
-    const status = await buildControlPlaneStatus(
+    const status = await buildStatus(
       {
         namespace: 'agents',
         grpc: {
@@ -1172,7 +1195,7 @@ describe('control-plane status', () => {
       agentRunIngestion: [],
     }
 
-    const status = await buildControlPlaneStatus(
+    const status = await buildStatus(
       {
         namespace: 'agents',
         grpc: {
@@ -1250,7 +1273,7 @@ describe('control-plane status', () => {
       },
     })
 
-    const status = await buildControlPlaneStatus(
+    const status = await buildStatus(
       {
         namespace: 'agents',
         grpc: {
@@ -1343,7 +1366,7 @@ describe('control-plane status', () => {
       },
     })
 
-    const status = await buildControlPlaneStatus(
+    const status = await buildStatus(
       {
         namespace: 'agents',
         grpc: {
@@ -1386,7 +1409,7 @@ describe('control-plane status', () => {
       (row) => row.component !== 'agents-controller' && row.component !== 'workflow-runtime',
     )
 
-    const status = await buildControlPlaneStatus(
+    const status = await buildStatus(
       {
         namespace: 'agents',
         grpc: {
@@ -1477,6 +1500,81 @@ describe('control-plane status', () => {
     expect(snapshot.stages.some((stage) => stage.phase === 'Frozen')).toBe(true)
   })
 
+  it('buildExecutionTrust blocks when freeze expiry is unreconciled', async () => {
+    kubeClientMocks.createKubernetesClient.mockReturnValue({
+      list: vi.fn(async () => ({
+        items: [
+          buildExecutionTrustSwarmResource({
+            phase: 'Frozen',
+            freezeReason: 'StageStaleness',
+            freezeUntil: '2026-01-20T00:05:00Z',
+            requirementsPending: 0,
+            requirementsLastSeen: '2026-01-20T00:19:00Z',
+            stageStates: {
+              discover: {
+                phase: 'Running',
+                healthy: true,
+                cadence: '1m',
+                lastRunTime: '2026-01-20T00:19:00Z',
+                consecutiveFailures: 0,
+              },
+              plan: {
+                phase: 'Running',
+                healthy: true,
+                cadence: '1m',
+                lastRunTime: '2026-01-20T00:19:00Z',
+                consecutiveFailures: 0,
+              },
+              implement: {
+                phase: 'Running',
+                healthy: true,
+                cadence: '1m',
+                lastRunTime: '2026-01-20T00:19:00Z',
+                consecutiveFailures: 0,
+              },
+              verify: {
+                phase: 'Running',
+                healthy: true,
+                cadence: '1m',
+                lastRunTime: '2026-01-20T00:19:00Z',
+                consecutiveFailures: 0,
+              },
+            },
+          }),
+        ],
+      })),
+    })
+
+    const snapshot = await buildExecutionTrust({
+      namespace: 'agents',
+      now: new Date('2026-01-20T00:20:00Z'),
+      swarms: ['jangar-control-plane'],
+      summaryLimit: 20,
+    })
+
+    expect(snapshot.executionTrust.status).toBe('blocked')
+    expect(snapshot.executionTrust.blocking_windows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'swarms',
+          name: 'jangar-control-plane',
+          reason: 'freeze expiry unreconciled (StageStaleness)',
+          class: 'blocked',
+        }),
+      ]),
+    )
+    expect(snapshot.swarms[0]).toMatchObject({
+      name: 'jangar-control-plane',
+      phase: 'Recovering',
+      ready: false,
+    })
+    expect(snapshot.stages[0]).toMatchObject({
+      stage: 'discover',
+      phase: 'Running',
+      last_failure_reason: 'discover waiting for freeze reconciliation',
+    })
+  })
+
   it('buildExecutionTrust marks degraded trust when requirements and stages are unhealthy', async () => {
     kubeClientMocks.createKubernetesClient.mockReturnValue({
       list: vi.fn(async () => ({
@@ -1556,10 +1654,10 @@ describe('control-plane status', () => {
     expect(snapshot.swarms[0]?.observed_generation).toBe(4)
   })
 
-  it('omits execution trust fields from status when flag is disabled', async () => {
+  it('always includes execution trust fields in status', async () => {
     setRolloutDeploymentList([healthyRolloutDeployment, healthyAgentsControllersRolloutDeployment])
 
-    const status = await buildControlPlaneStatus(
+    const status = await buildStatus(
       {
         namespace: 'agents',
         grpc: {
@@ -1607,9 +1705,9 @@ describe('control-plane status', () => {
       },
     )
 
-    expect(status.execution_trust).toBeUndefined()
-    expect(status.swarms).toBeUndefined()
-    expect(status.stages).toBeUndefined()
+    expect(status.execution_trust).toEqual(healthyExecutionTrust)
+    expect(status.swarms).toEqual([])
+    expect(status.stages).toEqual([])
     expect(status.dependency_quorum).toMatchObject({
       decision: 'allow',
       reasons: [],
@@ -1617,11 +1715,10 @@ describe('control-plane status', () => {
     })
   })
 
-  it('adds execution trust to quorum and blocks on enabled blocked trust', async () => {
-    process.env.JANGAR_CONTROL_PLANE_EXECUTION_TRUST = 'true'
+  it('adds execution trust to quorum segments and blocks on blocked trust', async () => {
     setRolloutDeploymentList([healthyRolloutDeployment, healthyAgentsControllersRolloutDeployment])
 
-    const status = await buildControlPlaneStatus(
+    const status = await buildStatus(
       {
         namespace: 'agents',
         grpc: {
@@ -1682,6 +1779,17 @@ describe('control-plane status', () => {
       reasons: ['execution_trust_blocked'],
       message: 'Control-plane dependency quorum is blocked.',
     })
+    expect(status.dependency_quorum.segments).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          segment: 'freshness_authority',
+          status: 'blocked',
+          scope: 'global',
+          confidence: 'low',
+          reasons: ['execution_trust_blocked'],
+        }),
+      ]),
+    )
     expect(status.namespaces[0]?.degraded_components ?? []).toContain('execution_trust')
   })
 })

--- a/services/jangar/src/server/control-plane-status.ts
+++ b/services/jangar/src/server/control-plane-status.ts
@@ -20,7 +20,7 @@ import {
 import { asRecord, asString, readNested } from '~/server/primitives-http'
 import { parseNamespaceScopeEnv } from '~/server/namespace-scope'
 import { createKubernetesClient, type KubernetesClient, RESOURCE_MAP } from '~/server/primitives-kube'
-import { parseBooleanEnv, parseEnvStringList, parseOptionalNumber } from '~/server/agents-controller/env-config'
+import { parseEnvStringList, parseOptionalNumber } from '~/server/agents-controller/env-config'
 import type {
   DatabaseMigrationConsistency,
   DependencyQuorumConfidence,
@@ -47,7 +47,6 @@ const DEFAULT_WATCH_RELIABILITY_BLOCK_ERRORS = 6
 const DEFAULT_WATCH_RELIABILITY_BLOCK_RESTARTS = 3
 const DEFAULT_ROLLOUT_DEPLOYMENTS = ['agents', 'agents-controllers']
 const DEFAULT_EXECUTION_TRUST_SWARMS = ['jangar-control-plane', 'torghut-quant']
-const DEFAULT_EXECUTION_TRUST_ENABLED = false
 const DEFAULT_EXECUTION_TRUST_SUMMARY_LIMIT = 20
 const MAX_TOP_FAILURE_REASONS = 5
 const MAX_WORKFLOW_COLLECTION_ERROR_SAMPLE = 3
@@ -209,9 +208,9 @@ export type ControlPlaneStatus = {
   agentrun_ingestion: AgentRunIngestionStatus
   workflows: WorkflowsReliabilityStatus
   dependency_quorum: DependencyQuorumStatus
-  execution_trust?: ExecutionTrustStatus
-  swarms?: ExecutionTrustSwarm[]
-  stages?: ExecutionTrustStage[]
+  execution_trust: ExecutionTrustStatus
+  swarms: ExecutionTrustSwarm[]
+  stages: ExecutionTrustStage[]
   rollout_health: ControlPlaneRolloutHealth
   empirical_services: EmpiricalServicesStatus
   namespaces: NamespaceStatus[]
@@ -359,9 +358,6 @@ const parseDurationToMs = (value: string | null) => {
   return amount * 24 * 60 * 60 * 1000
 }
 
-const resolveExecutionTrustEnabled = () =>
-  parseBooleanEnv(process.env.JANGAR_CONTROL_PLANE_EXECUTION_TRUST, DEFAULT_EXECUTION_TRUST_ENABLED)
-
 const resolveExecutionTrustSwarms = () => {
   const configured = parseEnvStringList('JANGAR_CONTROL_PLANE_EXECUTION_TRUST_SWARMS')
   if (configured.length > 0) return uniqueStrings(configured)
@@ -419,7 +415,7 @@ const buildExecutionTrustStage = (input: {
   stage: (typeof SWARM_STAGE_NAMES)[number]
   stageState: Record<string, unknown>
   nowMs: number
-  freezeActive: boolean
+  freezeState: 'active' | 'expired_unreconciled' | 'inactive'
 }) => {
   const configuredEveryRaw = asString(input.stageState['cadence'])
   const configuredEveryMs = parseDurationToMs(configuredEveryRaw)
@@ -444,21 +440,25 @@ const buildExecutionTrustStage = (input: {
         ? 'unknown'
         : 'high'
 
-  const phase = asString(input.stageState['phase']) ?? 'Unknown'
-  const frozen = phase.toLowerCase() === 'frozen'
-  const reason = input.freezeActive
-    ? `${input.stage} blocked by swarm freeze`
-    : frozen
-      ? `${input.stage} stage is frozen`
-      : stale
-        ? `${input.stage} stage is stale`
-        : latestFailureCount > 0
-          ? `${input.stage} consecutive failures`
-          : asString(input.stageState['phase']) === null
-            ? `${input.stage} phase missing`
-            : null
+  const rawPhase = asString(input.stageState['phase']) ?? 'Unknown'
+  const frozen = rawPhase.toLowerCase() === 'frozen'
+  const phase = input.freezeState === 'expired_unreconciled' && frozen ? 'Recovering' : rawPhase
+  const reason =
+    input.freezeState === 'active'
+      ? `${input.stage} blocked by swarm freeze`
+      : input.freezeState === 'expired_unreconciled'
+        ? `${input.stage} waiting for freeze reconciliation`
+        : frozen
+          ? `${input.stage} stage is frozen`
+          : stale
+            ? `${input.stage} stage is stale`
+            : latestFailureCount > 0
+              ? `${input.stage} consecutive failures`
+              : asString(input.stageState['phase']) === null
+                ? `${input.stage} phase missing`
+                : null
   const classReason =
-    frozen || input.freezeActive || stale
+    frozen || input.freezeState !== 'inactive' || stale
       ? 'blocked'
       : latestFailureCount > 0 || healthy === false
         ? 'degraded'
@@ -577,8 +577,15 @@ export const buildExecutionTrust = async ({
     const freezeUntil = asString(freezeRaw.until)
     const freezeUntilMs = parseDateMs(freezeUntil)
     const freezeActive = freezeUntilMs !== null && freezeUntilMs > nowMs
+    const freezeExpiredUnreconciled =
+      phase.toLowerCase() === 'frozen' && freezeUntilMs !== null && freezeUntilMs <= nowMs
     const freezeReason = asString(freezeRaw.reason) ?? null
-    const ready = phase.toLowerCase() !== 'frozen' && !freezeActive && phase.toLowerCase() !== 'disabled'
+    const projectedPhase = freezeExpiredUnreconciled ? 'Recovering' : phase
+    const ready =
+      projectedPhase.toLowerCase() !== 'frozen' &&
+      projectedPhase.toLowerCase() !== 'recovering' &&
+      !freezeActive &&
+      phase.toLowerCase() !== 'disabled'
     const observedGeneration = Number.isFinite(Number(status.observedGeneration ?? metadata.generation ?? null))
       ? Math.max(0, Number(status.observedGeneration ?? metadata.generation ?? 0))
       : null
@@ -626,6 +633,14 @@ export const buildExecutionTrust = async ({
         reason: freezeReason ? `swarm freeze active (${freezeReason})` : 'swarm freeze active',
         class: 'blocked',
       })
+    } else if (phase.toLowerCase() === 'frozen' && freezeUntilMs !== null && freezeUntilMs <= nowMs) {
+      snapshot.blockingWindows.push({
+        type: 'swarms',
+        scope: namespace,
+        name: swarmName,
+        reason: freezeReason ? `freeze expiry unreconciled (${freezeReason})` : 'freeze expiry unreconciled',
+        class: 'blocked',
+      })
     }
 
     for (const stage of SWARM_STAGE_NAMES) {
@@ -663,7 +678,7 @@ export const buildExecutionTrust = async ({
         stage,
         stageState: stageStateRaw,
         nowMs,
-        freezeActive,
+        freezeState: freezeActive ? 'active' : freezeExpiredUnreconciled ? 'expired_unreconciled' : 'inactive',
       })
       snapshot.stages.push(builtStage.stageData)
       if (builtStage.blockingClass) {
@@ -681,7 +696,7 @@ export const buildExecutionTrust = async ({
     snapshot.swarms.push({
       name: swarmName,
       namespace,
-      phase,
+      phase: projectedPhase,
       ready,
       updated_at: toIso(
         parseDateMs(asString(status.lastTransitionTime) ?? asString(status.updatedAt) ?? asString(status.observedAt)) ??
@@ -1826,6 +1841,10 @@ const buildDependencyQuorum = (input: {
     appendSegmentReason('control_runtime', reason, 'single_capability', 'medium')
   }
 
+  const addExecutionTrustReason = (reason: string, status: 'blocked' | 'degraded') => {
+    appendSegmentReason('freshness_authority', reason, 'global', status === 'blocked' ? 'low' : 'medium')
+  }
+
   const summarizeSegment = (
     segment: DependencyQuorumSegmentName,
     status: DependencyQuorumSegmentStatus,
@@ -1883,10 +1902,13 @@ const buildDependencyQuorum = (input: {
 
   if (input.executionTrust?.status === 'blocked') {
     blockReasons.push('execution_trust_blocked')
+    addExecutionTrustReason('execution_trust_blocked', 'blocked')
   } else if (input.executionTrust?.status === 'unknown') {
     blockReasons.push('execution_trust_unknown')
+    addExecutionTrustReason('execution_trust_unknown', 'blocked')
   } else if (input.executionTrust?.status === 'degraded') {
     delayReasons.push('execution_trust_degraded')
+    addExecutionTrustReason('execution_trust_degraded', 'degraded')
   }
 
   if (input.workflows.backoff_limit_exceeded_jobs >= input.degradedBackoffThreshold) {
@@ -2108,28 +2130,25 @@ export const buildControlPlaneStatus = async (
   )
   const watchReliabilityBlockErrorsThreshold = resolveWatchReliabilityBlockErrorsThreshold()
   const watchReliabilityBlockRestartsThreshold = resolveWatchReliabilityBlockRestartsThreshold()
-  const executionTrustEnabled = resolveExecutionTrustEnabled()
-  const executionTrust = executionTrustEnabled
-    ? await (deps.resolveExecutionTrust ?? buildExecutionTrust)({
-        namespace: options.namespace,
-        now,
-        swarms: resolveExecutionTrustSwarms(),
-        kube: createKubernetesClient(),
-        summaryLimit: resolveExecutionTrustSummaryLimit(),
-      }).catch(
-        (error: unknown): ExecutionTrustSnapshot => ({
-          executionTrust: {
-            status: 'unknown',
-            reason: `execution trust evaluation failed: ${normalizeMessage(error)}`,
-            last_evaluated_at: now.toISOString(),
-            blocking_windows: [],
-            evidence_summary: [],
-          },
-          swarms: [],
-          stages: [],
-        }),
-      )
-    : undefined
+  const executionTrust = await (deps.resolveExecutionTrust ?? buildExecutionTrust)({
+    namespace: options.namespace,
+    now,
+    swarms: resolveExecutionTrustSwarms(),
+    kube: createKubernetesClient(),
+    summaryLimit: resolveExecutionTrustSummaryLimit(),
+  }).catch(
+    (error: unknown): ExecutionTrustSnapshot => ({
+      executionTrust: {
+        status: 'unknown',
+        reason: `execution trust evaluation failed: ${normalizeMessage(error)}`,
+        last_evaluated_at: now.toISOString(),
+        blocking_windows: [],
+        evidence_summary: [],
+      },
+      swarms: [],
+      stages: [],
+    }),
+  )
 
   const workflows = await (deps.getWorkflowsReliabilityStatus ?? resolveWorkflowsReliabilityStatus)({
     now,
@@ -2185,9 +2204,7 @@ export const buildControlPlaneStatus = async (
     ...(empiricalServices.forecast.status === 'degraded' ? ['empirical:forecast'] : []),
     ...(empiricalServices.lean.status === 'degraded' ? ['empirical:lean'] : []),
     ...(empiricalServices.jobs.status === 'degraded' ? ['empirical:jobs'] : []),
-    ...(executionTrust?.executionTrust && executionTrust.executionTrust.status !== 'healthy'
-      ? ['execution_trust']
-      : []),
+    ...(executionTrust.executionTrust.status !== 'healthy' ? ['execution_trust'] : []),
   ]
 
   return {
@@ -2207,7 +2224,7 @@ export const buildControlPlaneStatus = async (
     },
     controllers: effectiveControllers,
     runtime_adapters: effectiveRuntimeAdapters,
-    ...(executionTrust ? { execution_trust: executionTrust.executionTrust } : {}),
+    execution_trust: executionTrust.executionTrust,
     database,
     grpc: grpcStatus,
     watch_reliability: {
@@ -2221,8 +2238,8 @@ export const buildControlPlaneStatus = async (
     },
     agentrun_ingestion: agentRunIngestion,
     rollout_health: rolloutHealth,
-    ...(executionTrust ? { swarms: executionTrust.swarms } : {}),
-    ...(executionTrust ? { stages: executionTrust.stages } : {}),
+    swarms: executionTrust.swarms,
+    stages: executionTrust.stages,
     workflows,
     dependency_quorum: dependencyQuorum,
     empirical_services: empiricalServices,


### PR DESCRIPTION
## Summary

- Make `execution_trust`, `swarms`, and `stages` mandatory in Jangar control-plane status and always enforce execution trust in `/ready`.
- Block execution trust when a swarm remains `Frozen` after `freeze.until` expires, surfacing `freeze expiry unreconciled` instead of reporting green readiness.
- Project execution-trust failures into the `freshness_authority` dependency segment so quorum reasons and segment detail stay aligned.
- Update Jangar docs/runbooks and affected status fixtures/tests for the new admission contract.

## Related Issues

None. No matching GitHub issue exists for `swarm-jangar-control-plane`; the runtime requirement came from the swarm mission objective.

## Design Provenance

- Governing design: `docs/agents/designs/53-jangar-dependency-provenance-ledger-and-consumer-acknowledged-admission-2026-03-19.md`.
- Supporting design: `docs/agents/designs/51-jangar-control-plane-execution-cells-and-collaboration-failover-2026-03-19.md`.
- Requirement signal: engineer mission objective in `argocd/applications/agents/swarm-agentrun-templates.yaml` for `codex/swarm-jangar-control-plane` (`grab the system design document, implement high-quality engineering changes, update impacted documentation, and deliver a production-ready PR`); no extra cross-swarm payload was provided.
- Acceptance slice implemented here: align `/ready` and `/api/agents/control-plane/status` on execution-trust admission and ensure non-healthy execution trust degrades a concrete dependency segment.

## Risks and Rollback

- Risk: namespaces with an expired-but-still-frozen swarm will now fail `/ready` until the authority state is reconciled; this is the intended safety change.
- Rollback: revert `fb05c24a4` to restore the previous optional execution-trust path and remove the unreconciled-freeze readiness block. No schema or data rollback is required.
- Collaboration note: `GET /api/v1/version` on `http://transactor.huly.svc.cluster.local` succeeds, but required worker-authenticated `account-info`, `list-channel-messages`, and `verify-chat-access` all time out during `GET /api/v1/account/...`, so Huly artifact updates are blocked by infrastructure rather than credentials.

## Testing

- `bun install --ignore-scripts`
- `bunx oxfmt --check services/jangar/README.md docs/agents/runbooks.md`
- `bun run --cwd services/jangar lint`
- `bun run --cwd services/jangar lint:oxlint`
- `bun run --cwd services/jangar test -- src/server/__tests__/control-plane-status.test.ts src/routes/ready.test.ts src/components/__tests__/agents-control-plane-status.test.tsx`
- `bun run --cwd services/jangar tsc` (fails in this workspace because sibling-package resolution errors remain in `services/bumba` and `@proompteng/temporal-bun-sdk`; the changed Jangar paths are covered by the targeted lint/tests above and `jangar-ci` is green)

## Screenshots (if applicable)

N/A

## Breaking Changes

- `/api/agents/control-plane/status` now always includes `execution_trust`, `swarms`, and `stages`.
- `/ready` now returns `503` when execution trust is `degraded`, `blocked`, or `unknown` even without the legacy opt-in flag.
- A swarm that stays `Frozen` after `freeze.until` has expired now reports `freeze expiry unreconciled` and keeps readiness degraded until reconciled.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
