### PR TITLE
fix(huly): repair account startup and readiness

### DIFF
--- a/argocd/applications/huly/account/account-deployment.yaml
+++ b/argocd/applications/huly/account/account-deployment.yaml
@@ -14,6 +14,10 @@ spec:
       labels:
         app: account
     spec:
+      volumes:
+        - configMap:
+            name: huly-healthcheck-scripts
+          name: healthcheck-scripts
       containers:
         - env:
             - name: ACCOUNTS_URL
@@ -46,11 +50,6 @@ spec:
               value: "postgres://selfhost:$(COCKROACH_PASSWORD)@cockroach-public:26257/defaultdb"
             - name: DB_URL
               value: "$(COCKROACH_DB_URL)?sslmode=require"
-            - name: MONGO_URL
-              valueFrom:
-                configMapKeyRef:
-                  name: huly-config
-                  key: MONGO_URL
             - name: SERVER_SECRET
               valueFrom:
                 secretKeyRef:
@@ -70,4 +69,24 @@ spec:
           resources:
             limits:
               memory: "512M"
+          startupProbe:
+            exec:
+              command:
+                - node
+                - /opt/huly-healthchecks/account-ready.js
+            failureThreshold: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+          readinessProbe:
+            exec:
+              command:
+                - node
+                - /opt/huly-healthchecks/account-ready.js
+            failureThreshold: 3
+            periodSeconds: 10
+            timeoutSeconds: 5
+          volumeMounts:
+            - mountPath: /opt/huly-healthchecks
+              name: healthcheck-scripts
+              readOnly: true
       restartPolicy: Always

--- a/argocd/applications/huly/cockroach/cockroach-account-migration-repair-job.yaml
+++ b/argocd/applications/huly/cockroach/cockroach-account-migration-repair-job.yaml
@@ -1,0 +1,85 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+    argocd.argoproj.io/sync-wave: "1"
+  labels:
+    app.kubernetes.io/name: huly
+  name: huly-account-migration-repair
+spec:
+  backoffLimit: 6
+  ttlSecondsAfterFinished: 3600
+  template:
+    spec:
+      containers:
+        - command:
+            - /bin/sh
+            - -ec
+            - |
+              sql() {
+                cockroach sql --certs-dir=/cockroach/cockroach-certs --host=cockroach-public "$@"
+              }
+
+              wait_for_cluster() {
+                for i in $(seq 1 120); do
+                  if sql --execute="SELECT 1"; then
+                    return 0
+                  fi
+                  sleep 5
+                done
+                echo "cockroach cluster is not ready"
+                return 1
+              }
+
+              pending_count() {
+                sql --format=csv --execute="
+                  SELECT count(*)
+                  FROM defaultdb.global_account._account_applied_migrations
+                  WHERE identifier = 'account_db_v2_social_id_pk_change' AND applied_at IS NULL;
+                " | tail -n +2 | tr -d '[:space:]'
+              }
+
+              wait_for_cluster
+
+              sql --execute="
+                ALTER TABLE defaultdb.global_account.social_id
+                ADD COLUMN IF NOT EXISTS _id INT8 NOT NULL DEFAULT unique_rowid();
+              "
+
+              if [ "$(pending_count)" = "1" ]; then
+                echo "repairing account_db_v2_social_id_pk_change for CockroachDB"
+                sql --execute="ALTER TABLE defaultdb.global_account.otp DROP CONSTRAINT IF EXISTS otp_social_id_fk;"
+                sql --execute="ALTER TABLE defaultdb.global_account.social_id DROP CONSTRAINT IF EXISTS social_id_pk;"
+                sql --execute="ALTER TABLE defaultdb.global_account.social_id ADD CONSTRAINT social_id_pk PRIMARY KEY (_id);"
+                sql --execute="
+                  UPDATE defaultdb.global_account._account_applied_migrations
+                  SET applied_at = now(), last_processed_at = now()
+                  WHERE identifier = 'account_db_v2_social_id_pk_change' AND applied_at IS NULL;
+                "
+              else
+                echo "account_db_v2_social_id_pk_change already repaired or not present"
+              fi
+          image: cockroachdb/cockroach:v25.4.2
+          name: repair
+          volumeMounts:
+            - mountPath: /cockroach/cockroach-certs/
+              name: client-certs
+      restartPolicy: OnFailure
+      volumes:
+        - name: client-certs
+          projected:
+            sources:
+              - secret:
+                  items:
+                    - key: ca.crt
+                      path: ca.crt
+                  name: cockroach-node
+              - secret:
+                  items:
+                    - key: tls.crt
+                      path: client.root.crt
+                    - key: tls.key
+                      path: client.root.key
+                  name: cockroach-root

--- a/argocd/applications/huly/config/config.yaml
+++ b/argocd/applications/huly/config/config.yaml
@@ -10,6 +10,5 @@ data:
   STATS_URL: 'https://stats.huly.proompteng.ai/'
   TRANSACTOR_URL: 'ws://transactor;wss://transactor.huly.proompteng.ai/'
   MINIO_ENDPOINT: 'rook-ceph-rgw-objectstore.rook-ceph.svc.cluster.local:80'
-  MONGO_URL: 'mongodb://mongodb:27017'
   ELASTIC_URL: 'http://elastic:9200'
   ELASTIC_INDEX_NAME: 'huly_storage_index'

--- a/argocd/applications/huly/config/healthcheck-scripts-configmap.yaml
+++ b/argocd/applications/huly/config/healthcheck-scripts-configmap.yaml
@@ -1,0 +1,68 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: huly-healthcheck-scripts
+data:
+  account-ready.js: |
+    ;(async () => {
+      const body = JSON.stringify({ method: 'workerHandshake', params: {} })
+
+      const response = await fetch('http://127.0.0.1:3000/', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body,
+        signal: AbortSignal.timeout(3000),
+      }).catch((error) => {
+        console.error(`account workerHandshake probe failed: ${error.name}: ${error.message}`)
+        process.exit(1)
+      })
+
+      const payload = await response.text()
+      if (response.status >= 500) {
+        console.error(`account workerHandshake probe returned ${response.status}: ${payload}`)
+        process.exit(1)
+      }
+
+      console.log(`account workerHandshake probe returned ${response.status}`)
+    })()
+  transactor-ready.js: |
+    ;(async () => {
+      const workspaceId = '00000000-0000-0000-0000-000000000000'
+
+      const response = await fetch(`http://127.0.0.1:3333/api/v1/account/${workspaceId}`, {
+        signal: AbortSignal.timeout(3000),
+      }).catch((error) => {
+        console.error(`transactor account probe failed: ${error.name}: ${error.message}`)
+        process.exit(1)
+      })
+
+      const payload = await response.text()
+      if (response.status >= 500) {
+        console.error(`transactor account probe returned ${response.status}: ${payload}`)
+        process.exit(1)
+      }
+
+      console.log(`transactor account probe returned ${response.status}`)
+    })()
+  workspace-ready.js: |
+    ;(async () => {
+      const body = JSON.stringify({ method: 'workerHandshake', params: {} })
+
+      const response = await fetch('http://account/', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body,
+        signal: AbortSignal.timeout(3000),
+      }).catch((error) => {
+        console.error(`workspace handshake probe failed: ${error.name}: ${error.message}`)
+        process.exit(1)
+      })
+
+      const payload = await response.text()
+      if (response.status >= 500) {
+        console.error(`workspace handshake probe returned ${response.status}: ${payload}`)
+        process.exit(1)
+      }
+
+      console.log(`workspace handshake probe returned ${response.status}`)
+    })()

--- a/argocd/applications/huly/front/front-deployment.yaml
+++ b/argocd/applications/huly/front/front-deployment.yaml
@@ -44,11 +44,6 @@ spec:
                 secretKeyRef:
                   name: huly-secret
                   key: STORAGE_CONFIG
-            - name: MONGO_URL
-              valueFrom:
-                configMapKeyRef:
-                  name: huly-config
-                  key: MONGO_URL
             - name: REKONI_URL
               valueFrom:
                 configMapKeyRef:

--- a/argocd/applications/huly/kustomization.yaml
+++ b/argocd/applications/huly/kustomization.yaml
@@ -6,12 +6,14 @@ resources:
   - account/account-deployment.yaml
   - account/account-ingress.yaml
   - account/account-service.yaml
+  - cockroach/cockroach-account-migration-repair-job.yaml
   - cockroach/cockroach-bootstrap-job.yaml
   - cockroach/cockroach-cluster.yaml
   - collaborator/collaborator-deployment.yaml
   - collaborator/collaborator-ingress.yaml
   - collaborator/collaborator-service.yaml
   - config/config.yaml
+  - config/healthcheck-scripts-configmap.yaml
   - config/secret.yaml
   - elastic/elastic-deployment.yaml
   - elastic/elastic-persistentvolumeclaim.yaml

--- a/argocd/applications/huly/transactor/transactor-deployment.yaml
+++ b/argocd/applications/huly/transactor/transactor-deployment.yaml
@@ -14,6 +14,10 @@ spec:
       labels:
         app: transactor
     spec:
+      volumes:
+        - configMap:
+            name: huly-healthcheck-scripts
+          name: healthcheck-scripts
       containers:
         - env:
             - name: ACCOUNTS_URL
@@ -32,11 +36,6 @@ spec:
                 secretKeyRef:
                   name: huly-secret
                   key: STORAGE_CONFIG
-            - name: MONGO_URL
-              valueFrom:
-                configMapKeyRef:
-                  name: huly-config
-                  key: MONGO_URL
             - name: COCKROACH_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -62,4 +61,24 @@ spec:
           ports:
             - containerPort: 3333
               protocol: TCP
+          startupProbe:
+            exec:
+              command:
+                - node
+                - /opt/huly-healthchecks/transactor-ready.js
+            failureThreshold: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+          readinessProbe:
+            exec:
+              command:
+                - node
+                - /opt/huly-healthchecks/transactor-ready.js
+            failureThreshold: 3
+            periodSeconds: 10
+            timeoutSeconds: 5
+          volumeMounts:
+            - mountPath: /opt/huly-healthchecks
+              name: healthcheck-scripts
+              readOnly: true
       restartPolicy: Always

--- a/argocd/applications/huly/workspace/workspace-deployment.yaml
+++ b/argocd/applications/huly/workspace/workspace-deployment.yaml
@@ -14,6 +14,10 @@ spec:
       labels:
         app: workspace
     spec:
+      volumes:
+        - configMap:
+            name: huly-healthcheck-scripts
+          name: healthcheck-scripts
       containers:
         - env:
             - name: ACCOUNTS_URL
@@ -43,11 +47,6 @@ spec:
               value: "$(COCKROACH_DB_URL)?sslmode=require"
             - name: DB_URL
               value: "$(COCKROACH_DB_URL)?sslmode=require"
-            - name: MONGO_URL
-              valueFrom:
-                configMapKeyRef:
-                  name: huly-config
-                  key: MONGO_URL
             - name: SERVER_SECRET
               valueFrom:
                 secretKeyRef:
@@ -60,4 +59,24 @@ spec:
           resources:
             limits:
               memory: "512M"
+          startupProbe:
+            exec:
+              command:
+                - node
+                - /opt/huly-healthchecks/workspace-ready.js
+            failureThreshold: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+          readinessProbe:
+            exec:
+              command:
+                - node
+                - /opt/huly-healthchecks/workspace-ready.js
+            failureThreshold: 3
+            periodSeconds: 10
+            timeoutSeconds: 5
+          volumeMounts:
+            - mountPath: /opt/huly-healthchecks
+              name: healthcheck-scripts
+              readOnly: true
       restartPolicy: Always


### PR DESCRIPTION
## Summary

- add an idempotent Cockroach repair job for Huly's stuck `account_db_v2_social_id_pk_change` migration
- remove stale `MONGO_URL` wiring from the Huly Cockroach deployments so the manifests match the supported upstream topology
- add DB-backed readiness/startup probes for account, transactor, and workspace so Argo no longer reports false green when auth/handshake paths are broken

## Related Issues

None

## Testing

- `kubectl kustomize argocd/applications/huly`
- `kubectl apply --dry-run=server -n huly -f <(kubectl kustomize argocd/applications/huly)`
- live probe before fix: `kubectl -n huly exec deploy/account -- sh -lc 'node - <<"NODE" ... workerHandshake ... NODE'` returned `TimeoutError`
- live probe before fix: `kubectl -n huly exec deploy/transactor -- sh -lc 'node - <<"NODE" ... /api/v1/account/... ... NODE'` returned `500 {"message":"Failed to execute operation","error":"Cannot read properties of undefined (reading 'split')"}`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
