### PR TITLE
fix(huly): run account repair during sync

### DIFF
--- a/argocd/applications/huly/cockroach/cockroach-account-migration-repair-job.yaml
+++ b/argocd/applications/huly/cockroach/cockroach-account-migration-repair-job.yaml
@@ -2,9 +2,9 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   annotations:
-    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook: Sync
     argocd.argoproj.io/hook-delete-policy: HookSucceeded
-    argocd.argoproj.io/sync-wave: "1"
+    argocd.argoproj.io/sync-wave: "0"
   labels:
     app.kubernetes.io/name: huly
   name: huly-account-migration-repair
@@ -33,34 +33,59 @@ spec:
                 return 1
               }
 
-              pending_count() {
+              migration_status() {
                 sql --format=csv --execute="
-                  SELECT count(*)
+                  SELECT CASE
+                    WHEN applied_at IS NULL THEN 'pending'
+                    ELSE 'applied'
+                  END
                   FROM defaultdb.global_account._account_applied_migrations
-                  WHERE identifier = 'account_db_v2_social_id_pk_change' AND applied_at IS NULL;
-                " | tail -n +2 | tr -d '[:space:]'
+                  WHERE identifier = 'account_db_v2_social_id_pk_change'
+                  LIMIT 1;
+                " 2>/dev/null | tail -n +2 | tr -d '[:space:]'
+              }
+
+              wait_for_pending_migration() {
+                for i in $(seq 1 120); do
+                  status="$(migration_status)"
+                  case "$status" in
+                    pending|applied)
+                      echo "migration status: $status"
+                      printf '%s' "$status"
+                      return 0
+                      ;;
+                    *)
+                      sleep 5
+                      ;;
+                  esac
+                done
+
+                echo "migration row account_db_v2_social_id_pk_change did not appear in time"
+                return 1
               }
 
               wait_for_cluster
+              status="$(wait_for_pending_migration)"
+
+              if [ "$status" = "applied" ]; then
+                echo "account_db_v2_social_id_pk_change already repaired"
+                exit 0
+              fi
 
               sql --execute="
                 ALTER TABLE defaultdb.global_account.social_id
                 ADD COLUMN IF NOT EXISTS _id INT8 NOT NULL DEFAULT unique_rowid();
               "
 
-              if [ "$(pending_count)" = "1" ]; then
-                echo "repairing account_db_v2_social_id_pk_change for CockroachDB"
-                sql --execute="ALTER TABLE defaultdb.global_account.otp DROP CONSTRAINT IF EXISTS otp_social_id_fk;"
-                sql --execute="ALTER TABLE defaultdb.global_account.social_id DROP CONSTRAINT IF EXISTS social_id_pk;"
-                sql --execute="ALTER TABLE defaultdb.global_account.social_id ADD CONSTRAINT social_id_pk PRIMARY KEY (_id);"
-                sql --execute="
-                  UPDATE defaultdb.global_account._account_applied_migrations
-                  SET applied_at = now(), last_processed_at = now()
-                  WHERE identifier = 'account_db_v2_social_id_pk_change' AND applied_at IS NULL;
-                "
-              else
-                echo "account_db_v2_social_id_pk_change already repaired or not present"
-              fi
+              echo "repairing account_db_v2_social_id_pk_change for CockroachDB"
+              sql --execute="ALTER TABLE defaultdb.global_account.otp DROP CONSTRAINT IF EXISTS otp_social_id_fk;"
+              sql --execute="ALTER TABLE defaultdb.global_account.social_id DROP CONSTRAINT IF EXISTS social_id_pk;"
+              sql --execute="ALTER TABLE defaultdb.global_account.social_id ADD CONSTRAINT social_id_pk PRIMARY KEY (_id);"
+              sql --execute="
+                UPDATE defaultdb.global_account._account_applied_migrations
+                SET applied_at = now(), last_processed_at = now()
+                WHERE identifier = 'account_db_v2_social_id_pk_change' AND applied_at IS NULL;
+              "
           image: cockroachdb/cockroach:v25.4.2
           name: repair
           volumeMounts:


### PR DESCRIPTION
## Summary

- change the Huly account migration repair job from a `PostSync` hook to a `Sync` hook so Argo can run it before the app reaches healthy state
- make the repair job wait for the pending `account_db_v2_social_id_pk_change` migration row instead of assuming the schema exists immediately
- keep the repair idempotent by exiting cleanly when the migration is already marked applied

## Related Issues

None

## Testing

- `kubectl kustomize argocd/applications/huly`
- `kubectl -n argocd get application huly -o wide`
- `kubectl -n huly get pods -o wide`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
