### PR TITLE
fix(huly): finalize account repair reconciliation

### DIFF
--- a/argocd/applications/huly/cockroach/cockroach-account-migration-repair-job.yaml
+++ b/argocd/applications/huly/cockroach/cockroach-account-migration-repair-job.yaml
@@ -79,8 +79,7 @@ spec:
 
               echo "repairing account_db_v2_social_id_pk_change for CockroachDB"
               sql --execute="ALTER TABLE defaultdb.global_account.otp DROP CONSTRAINT IF EXISTS otp_social_id_fk;"
-              sql --execute="ALTER TABLE defaultdb.global_account.social_id DROP CONSTRAINT IF EXISTS social_id_pk;"
-              sql --execute="ALTER TABLE defaultdb.global_account.social_id ADD CONSTRAINT social_id_pk PRIMARY KEY (_id);"
+              sql --execute="ALTER TABLE defaultdb.global_account.social_id ALTER PRIMARY KEY USING COLUMNS (_id);"
               sql --execute="
                 UPDATE defaultdb.global_account._account_applied_migrations
                 SET applied_at = now(), last_processed_at = now()

--- a/argocd/applications/huly/config/healthcheck-scripts-configmap.yaml
+++ b/argocd/applications/huly/config/healthcheck-scripts-configmap.yaml
@@ -27,22 +27,43 @@ data:
     })()
   transactor-ready.js: |
     ;(async () => {
-      const workspaceId = '00000000-0000-0000-0000-000000000000'
+      const handshakeBody = JSON.stringify({
+        method: 'workerHandshake',
+        params: { region: 'DEFAULT', version: '0.7.375', operation: 'all', wsId: 'healthcheck' },
+      })
 
-      const response = await fetch(`http://127.0.0.1:3333/api/v1/account/${workspaceId}`, {
+      const versionResponse = await fetch('http://127.0.0.1:3333/api/v1/version', {
+        signal: AbortSignal.timeout(3000),
+      }).catch((error) => {
+        console.error(`transactor version probe failed: ${error.name}: ${error.message}`)
+        process.exit(1)
+      })
+
+      const versionPayload = await versionResponse.text()
+      if (versionResponse.status >= 500) {
+        console.error(`transactor version probe returned ${versionResponse.status}: ${versionPayload}`)
+        process.exit(1)
+      }
+
+      const accountResponse = await fetch('http://account/', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: handshakeBody,
         signal: AbortSignal.timeout(3000),
       }).catch((error) => {
         console.error(`transactor account probe failed: ${error.name}: ${error.message}`)
         process.exit(1)
       })
 
-      const payload = await response.text()
-      if (response.status >= 500) {
-        console.error(`transactor account probe returned ${response.status}: ${payload}`)
+      const accountPayload = await accountResponse.text()
+      if (accountResponse.status >= 500) {
+        console.error(`transactor account probe returned ${accountResponse.status}: ${accountPayload}`)
         process.exit(1)
       }
 
-      console.log(`transactor account probe returned ${response.status}`)
+      console.log(
+        `transactor probes returned version=${versionResponse.status} account=${accountResponse.status}`,
+      )
     })()
   workspace-ready.js: |
     ;(async () => {


### PR DESCRIPTION
## Summary

- switch the Cockroach repair job to `ALTER PRIMARY KEY USING COLUMNS (_id)` so the recovery hook uses a DDL sequence Cockroach actually accepts
- make the transactor readiness probe validate local transactor health plus account handshake reachability instead of failing on the broken placeholder workspace lookup
- reconcile the GitOps manifests with the live Huly recovery so Argo can converge cleanly again

## Related Issues

None

## Testing

- `kubectl kustomize argocd/applications/huly`
- `kubectl get pods -n huly`
- `argocd app get huly -o json | jq '{sync: .status.sync.status, health: .status.health.status, operation: .status.operationState.phase, message: .status.operationState.message, revision: .status.sync.revision}'`
- `kubectl -n huly logs deployment/account --tail=80`
- `kubectl -n huly logs deployment/transactor --tail=80`
- Manual live validation: executed the repair SQL against Cockroach, verified the stuck migration was marked applied, restarted `account` / `transactor` / `workspace`, and confirmed the new pods became ready
- Manual live validation: exercised the account handshake path and verified the transactor/account/browser flows no longer fail with the prior migration loop and probe errors

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
