### PR TITLE
fix(temporal-bun-sdk): fix onboarding and scaffold

### DIFF
--- a/apps/docs/content/docs/temporal-bun-sdk.mdx
+++ b/apps/docs/content/docs/temporal-bun-sdk.mdx
@@ -3,15 +3,14 @@ title: Temporal Bun SDK
 description: Run Temporal workers and clients on Bun with replay tooling, Docker helpers, and Temporal Cloud/TLS support.
 ---
 
-`@proompteng/temporal-bun-sdk` lets you run Temporal workers and clients on Bun
-without a native bridge. Out of the box, it includes:
+`@proompteng/temporal-bun-sdk` lets you run Temporal workers and clients on Bun.
+Out of the box, it includes:
 
 - Effect Schema-backed environment parsing with TLS, API key, and insecure-mode support.
 - Client and worker factories with built-in retries, payload codecs, and observability.
 - Effect Layer entry points for workers, clients, and CLI programs.
 - A `temporal-bun` CLI that scaffolds projects, validates config (`doctor`), builds Docker images, and replays histories.
 - A `temporal-bun-worker` binary that boots a worker with the SDK's default workflows/activities.
-- Pure TypeScript/Effect runtime; legacy Zig bridge assets remain archived under `packages/temporal-bun-sdk/bruke`.
 
 ## Start here
 
@@ -47,17 +46,17 @@ Generate a standalone Bun worker project:
 bunx @proompteng/temporal-bun-sdk init my-worker
 cd my-worker
 bun install
-bun run dev
 ```
 
 Run the scaffold command outside this monorepo. The generated project is meant
 to install the published npm package, not `workspace:*` dependencies.
 
-If `bun install` fails and the generated `package.json` pins
-`@proompteng/temporal-bun-sdk` to `^0.5.0`, repair it with:
+Then start Temporal locally, add a `.env`, and run the worker:
 
 ```bash
-bun add @proompteng/temporal-bun-sdk@0.7.0
+temporal server start-dev --headless
+printf "TEMPORAL_ADDRESS=127.0.0.1:7233\nTEMPORAL_NAMESPACE=default\nTEMPORAL_TASK_QUEUE=demo-worker\n" > .env
+bun run dev
 ```
 
 ### Add the SDK to an existing Bun project
@@ -251,7 +250,7 @@ chain, validates the retry presets, spins up observability services, emits a
 log, increments a counter, and flushes the selected exporter:
 
 ```bash
-bunx @proompteng/temporal-bun-sdk doctor --log-format=json --metrics=file:/tmp/metrics.json
+bunx @proompteng/temporal-bun-sdk doctor --log-format=json --metrics=file:./metrics.json
 ```
 
 The command prints a success summary (including active interceptors and the

--- a/packages/temporal-bun-sdk/README.md
+++ b/packages/temporal-bun-sdk/README.md
@@ -1,34 +1,28 @@
 # `@proompteng/temporal-bun-sdk`
 
-Run Temporal workers and clients on Bun with replay tooling, Docker helpers, and Temporal Cloud/TLS support. The SDK is implemented entirely in TypeScript, speaks gRPC over HTTP/2 using [Connect](https://connectrpc.com/), and executes workflows with the [Effect](https://effect.website/) runtime so you can avoid a native bridge.
+Run Temporal workers and clients on Bun.
 
 Full docs: <https://docs.proompteng.ai/docs/temporal-bun-sdk>
 
-## Fastest start
+## Quickstart
 
-Use this path if you want a working Bun worker as quickly as possible.
+Use this path if you want a working Bun worker in a new standalone project. Run it outside another Bun workspace or monorepo.
 
-1. Scaffold a new project in a clean directory:
+1. Create a new worker project:
 
    ```bash
-   cd /tmp
    bunx @proompteng/temporal-bun-sdk init hello-worker
    cd hello-worker
+   bun install
    ```
 
-2. Repair the generated SDK version for the current npm release:
-
-   ```bash
-   bun add @proompteng/temporal-bun-sdk@0.7.0
-   ```
-
-3. Start Temporal locally:
+2. Start Temporal locally:
 
    ```bash
    temporal server start-dev --headless
    ```
 
-4. Create a `.env` file:
+3. Create a `.env` file:
 
    ```env
    TEMPORAL_ADDRESS=127.0.0.1:7233
@@ -36,13 +30,13 @@ Use this path if you want a working Bun worker as quickly as possible.
    TEMPORAL_TASK_QUEUE=hello-bun
    ```
 
-5. Run the worker:
+4. Run the worker:
 
    ```bash
    bun run dev
    ```
 
-6. In another shell, start the example workflow:
+5. In another shell, start the example workflow:
 
    ```bash
    temporal workflow start \
@@ -53,7 +47,7 @@ Use this path if you want a working Bun worker as quickly as possible.
 
 You should see the worker pick up the workflow and complete it.
 
-## Install into an existing Bun project
+## Add To An Existing Bun Project
 
 ```bash
 bun add @proompteng/temporal-bun-sdk
@@ -62,12 +56,11 @@ bun add @proompteng/temporal-bun-sdk
 For Temporal Cloud, TLS, Docker, replay, and observability, use the full guide:
 <https://docs.proompteng.ai/docs/temporal-bun-sdk>
 
-## Why teams adopt it
+## Why Teams Adopt It
 
-- **Bun-native runtime** – run workers, activities, and clients directly on Bun.
+- **Runs directly on Bun** – workers, activities, and clients stay in one Bun-based project.
 - **Production path included** – TLS, Temporal Cloud, Docker packaging, retries, observability, and replay tooling are built in.
 - **Typed workflow surface** – workflows, queries, updates, signals, schedules, and Cloud/Operator RPCs are exposed with typed helpers.
-- **No native bridge required** – the runtime is pure TypeScript and uses generated protobuf stubs.
 - **CLI included** – `temporal-bun` scaffolds workers, validates config with `doctor`, builds Docker images, and replays histories.
 
 ## Prerequisites
@@ -479,7 +472,7 @@ bunx temporal-bun skill list
 bunx temporal-bun skill install temporal
 
 # install into a custom directory
-bunx temporal-bun skill install temporal --to /tmp/my-skills
+bunx temporal-bun skill install temporal --to ~/my-skills
 ```
 
 For direct scripting, use the exported API from `@proompteng/temporal-bun-sdk/skills`:
@@ -490,7 +483,7 @@ import { installBundledSkill, listBundledSkills } from '@proompteng/temporal-bun
 const skills = await listBundledSkills()
 await installBundledSkill({
   skillName: skills[0]?.name ?? 'temporal',
-  destinationDir: '/tmp/skills',
+  destinationDir: '/path/to/skills',
   force: true,
 })
 ```

--- a/packages/temporal-bun-sdk/src/bin/temporal-bun.ts
+++ b/packages/temporal-bun-sdk/src/bin/temporal-bun.ts
@@ -259,7 +259,7 @@ Options:
   --file <path>           Dockerfile path for docker-build (default: ./Dockerfile)
   --log-format <format>   Set TEMPORAL_LOG_FORMAT for doctor (json|pretty)
   --log-level <level>     Set TEMPORAL_LOG_LEVEL for doctor (debug|info|warn|error)
-  --metrics <spec>        Set metrics exporter spec for doctor (e.g., file:/tmp/metrics.json)
+  --metrics <spec>        Set metrics exporter spec for doctor (e.g., file:./metrics.json)
   --metrics-exporter <name>
                           Alternate way to set TEMPORAL_METRICS_EXPORTER
   --metrics-endpoint <url>
@@ -408,7 +408,7 @@ export type Template = {
   contents: string
 }
 
-const SCAFFOLD_SDK_VERSION = '^0.7.0'
+const SCAFFOLD_SDK_VERSION = '^0.7.1'
 
 export function projectTemplates(name: string): Template[] {
   return [
@@ -482,6 +482,20 @@ peer = true
         ']',
         '',
         'export default workflows',
+      ].join('\n'),
+    },
+    {
+      path: 'src/activities/index.ts',
+      contents: [
+        'export async function helloActivity(name = \'Temporal\') {',
+        '  return `Hello from activity, ${name}!`',
+        '}',
+        '',
+        'export const activities = {',
+        '  helloActivity,',
+        '}',
+        '',
+        'export default activities',
       ].join('\n'),
     },
     {


### PR DESCRIPTION
## Summary

- simplify the npm README quickstart so first-time users get one direct setup path instead of `/tmp` guidance and runtime internals
- align the docs page and scaffolded dependency version with the current package release
- add the missing generated `src/activities/index.ts` template so a new worker project boots instead of failing on import

## Related Issues

None

## Testing

- `git diff --check`
- `bun run --filter @proompteng/temporal-bun-sdk build`
- `bun run --cwd apps/docs build`
- scaffolded a fresh project from the local CLI and verified `bun run dev` reaches Temporal connection attempts instead of failing on a missing module

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
