### PR TITLE
feat(symphony): harden delivery runtime resilience

### DIFF
--- a/services/symphony/README.md
+++ b/services/symphony/README.md
@@ -1,6 +1,8 @@
 # Symphony
 
-Symphony is a Bun/TypeScript service that polls Linear, creates per-issue workspaces, and runs Codex app-server sessions against those workspaces using a repository-owned `WORKFLOW.md`.
+Symphony is a Bun/TypeScript delivery runtime for the `Symphony` Linear project. It polls Linear, creates
+per-issue workspaces, runs Codex app-server sessions against those workspaces using a repository-owned
+`WORKFLOW.md`, and tracks the full GitHub Actions plus GitOps delivery transaction for each issue.
 
 ## Run
 
@@ -30,15 +32,31 @@ bun run --cwd services/symphony lint:oxlint
 bun run --cwd services/symphony lint:oxlint:type
 ```
 
-## Current scope
+## Runtime scope
 
 - Strict `WORKFLOW.md` loading with typed config/defaults and last-known-good reload behavior
-- Linear polling and issue normalization
-- Per-issue workspace creation, hook execution, and terminal cleanup
-- Durable scheduler metadata under `${workspace.root}/_symphony/` for retry/session recovery across restarts
+- Linear polling, issue normalization, dispatch rules, retry scheduling, and durable scheduler state under `${workspace.root}/_symphony/`
+- Per-issue workspace creation, hook execution, terminal cleanup, and recovery from restarts or leadership changes
 - Lease-based leader election for single-cluster scheduler ownership
-- Codex app-server session runner with dynamic `linear_graphql` tool support
-- Expanded HTTP dashboard and JSON status API with policy, leader, capacity, recent events, and issue drilldowns
+- Codex app-server execution with first-class runtime tools for `linear_graphql` and GitHub delivery operations
+- Delivery transaction tracking for code PRs, required checks, merges to `main`, build workflow runs, promotion PRs, Argo rollout state, post-deploy verification, and rollback PRs
+- HTTP dashboard and JSON APIs for runtime state, issue drilldowns, delivery state, capacity, leader status, recent events, and recent errors
+
+## Delivery guarantees
+
+- Symphony does not mutate the cluster directly. Delivery stays on GitHub Actions plus GitOps.
+- Terminal delivery states clear stale runtime payloads so completed or rolled-back issues no longer appear as actively running.
+- Successful terminal delivery states clear obsolete `delivery.lastError` values instead of preserving transient refresh failures.
+- Pre-dispatch target health is tolerant of short-lived transient failures and candidate fetch uses bounded retry with backoff/jitter before dispatch pauses.
+
+## Observability surface
+
+- `GET /livez`: liveness probe
+- `GET /readyz`: readiness probe
+- `GET /`: HTML dashboard
+- `GET /api/v1/state`: full runtime snapshot
+- `POST /api/v1/refresh`: force a poll/reconcile cycle
+- `GET /api/v1/:issueIdentifier`: per-issue details including tracked state, runtime session info, retry info, run history, and delivery transaction state
 
 ## Operational docs
 

--- a/services/symphony/src/delivery-service.test.ts
+++ b/services/symphony/src/delivery-service.test.ts
@@ -1,6 +1,16 @@
 import { describe, expect, test } from 'bun:test'
 
-import { createEmptyDeliveryTransaction, deriveDeliveryStage } from './delivery-service'
+import {
+  createEmptyDeliveryTransaction,
+  deriveDeliveryStage,
+  makeDeliveryServiceLayer,
+  DeliveryService,
+} from './delivery-service'
+import { createLogger } from './logger'
+import { makeTestConfig } from './test-fixtures'
+import { WorkflowService } from './workflow'
+import { Effect, Layer, ManagedRuntime } from 'effect'
+import * as Stream from 'effect/Stream'
 
 describe('delivery transaction stages', () => {
   test('starts in coding when no delivery artifacts exist', () => {
@@ -165,5 +175,197 @@ describe('delivery transaction stages', () => {
       promotionPr: null,
       rollbackPr: null,
     })
+  })
+
+  test('clears stale delivery errors after terminal success', async () => {
+    const originalFetch = globalThis.fetch
+    const originalGhToken = process.env.GH_TOKEN
+    process.env.GH_TOKEN = 'test-token'
+
+    const config = makeTestConfig()
+    const issue = {
+      issueIdentifier: 'ABC-1',
+      issueId: 'issue-1',
+      status: 'tracked' as const,
+      workspacePath: null,
+      attempts: { restartCount: 0, currentRetryAttempt: 0 },
+      running: null,
+      retry: null,
+      logs: { codex_session_logs: [] },
+      recentEvents: [],
+      lastError: null,
+      tracked: { lastKnownState: 'In Progress' },
+      runHistory: [],
+      delivery: {
+        stage: 'promotion_merged' as const,
+        updatedAt: '2026-03-16T03:00:00.000Z',
+        codePr: {
+          number: 101,
+          url: 'https://github.com/proompteng/lab/pull/101',
+          branch: 'codex/proompt-338',
+          state: 'merged' as const,
+          title: 'feat(symphony): harden delivery runtime',
+          createdAt: null,
+          updatedAt: null,
+          mergedAt: '2026-03-16T02:55:00.000Z',
+          mergedCommitSha: 'abcdef0123456789abcdef0123456789abcdef01',
+        },
+        requiredChecks: {
+          state: 'success' as const,
+          headSha: 'abcdef0123456789abcdef0123456789abcdef01',
+          requiredCount: 2,
+          passingCount: 2,
+          failingCount: 0,
+          pendingCount: 0,
+          url: null,
+        },
+        mergedCommitSha: 'abcdef0123456789abcdef0123456789abcdef01',
+        build: null,
+        releaseContract: null,
+        promotionPr: {
+          number: 102,
+          url: 'https://github.com/proompteng/lab/pull/102',
+          branch: 'codex/symphony-release-abcdef01',
+          state: 'merged' as const,
+          title: 'chore(symphony): promote image abcdef01',
+          createdAt: null,
+          updatedAt: null,
+          mergedAt: '2026-03-16T03:00:00.000Z',
+          mergedCommitSha: 'fedcba9876543210fedcba9876543210fedcba98',
+        },
+        argo: null,
+        postDeploy: null,
+        rollbackPr: null,
+        lastError: 'transient github refresh failed',
+      },
+      updatedAt: '2026-03-16T03:00:00.000Z',
+    }
+
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = input instanceof Request ? input.url : String(input)
+      if (url.includes('/commits/abcdef0123456789abcdef0123456789abcdef01/check-runs')) {
+        return new Response(JSON.stringify({ check_runs: [] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      }
+      if (url.includes('/pulls/101')) {
+        return new Response(
+          JSON.stringify({
+            number: 101,
+            html_url: 'https://github.com/proompteng/lab/pull/101',
+            state: 'closed',
+            title: 'feat(symphony): harden delivery runtime',
+            body: '',
+            draft: false,
+            created_at: null,
+            updated_at: null,
+            merged_at: '2026-03-16T02:55:00.000Z',
+            merge_commit_sha: 'abcdef0123456789abcdef0123456789abcdef01',
+            head: {
+              ref: 'codex/proompt-338',
+              sha: 'abcdef0123456789abcdef0123456789abcdef01',
+            },
+            base: { ref: 'main' },
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        )
+      }
+      if (url.includes('/commits/abcdef0123456789abcdef0123456789abcdef01/status')) {
+        return new Response(JSON.stringify({ state: 'success', statuses: [] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      }
+      if (url.includes('/actions/runs?head_sha=abcdef0123456789abcdef0123456789abcdef01')) {
+        return new Response(JSON.stringify({ workflow_runs: [] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      }
+      if (url.includes('/actions/runs?head_sha=fedcba9876543210fedcba9876543210fedcba98')) {
+        return new Response(
+          JSON.stringify({
+            workflow_runs: [
+              {
+                id: 601,
+                html_url: 'https://github.com/proompteng/lab/actions/runs/601',
+                name: 'symphony-post-deploy-verify',
+                status: 'completed',
+                conclusion: 'success',
+                event: 'push',
+                head_sha: 'fedcba9876543210fedcba9876543210fedcba98',
+                head_branch: 'main',
+                created_at: null,
+                updated_at: null,
+              },
+            ],
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        )
+      }
+      if (url.includes('/pulls/102')) {
+        return new Response(
+          JSON.stringify({
+            number: 102,
+            html_url: 'https://github.com/proompteng/lab/pull/102',
+            state: 'closed',
+            title: 'chore(symphony): promote image abcdef01',
+            body: 'Source commit: `abcdef0123456789abcdef0123456789abcdef01`',
+            draft: false,
+            created_at: null,
+            updated_at: null,
+            merged_at: '2026-03-16T03:00:00.000Z',
+            merge_commit_sha: 'fedcba9876543210fedcba9876543210fedcba98',
+            head: {
+              ref: 'codex/symphony-release-abcdef01',
+              sha: 'fedcba9876543210fedcba9876543210fedcba98',
+            },
+            base: { ref: 'main' },
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        )
+      }
+      if (url.includes('/pulls?state=all')) {
+        return new Response(JSON.stringify([]), { status: 200, headers: { 'content-type': 'application/json' } })
+      }
+      if (url.includes('/pulls?state=open')) {
+        return new Response(JSON.stringify([]), { status: 200, headers: { 'content-type': 'application/json' } })
+      }
+      throw new Error(`unexpected fetch: ${url}`)
+    }) as typeof fetch
+
+    const runtime = ManagedRuntime.make(
+      makeDeliveryServiceLayer(createLogger({ test: 'delivery-refresh' })).pipe(
+        Layer.provide(
+          Layer.succeed(WorkflowService, {
+            current: Effect.succeed({ definition: { config: {}, promptTemplate: '' }, config }),
+            config: Effect.succeed(config),
+            reload: Effect.succeed({ definition: { config: {}, promptTemplate: '' }, config }),
+            changes: Stream.empty,
+          }),
+        ),
+      ),
+    )
+
+    try {
+      const refreshed = await runtime.runPromise(
+        Effect.gen(function* () {
+          const delivery = yield* DeliveryService
+          return yield* delivery.refreshIssueDelivery(issue, config)
+        }),
+      )
+
+      expect(refreshed.stage).toBe('completed')
+      expect(refreshed.lastError).toBeNull()
+    } finally {
+      globalThis.fetch = originalFetch
+      if (originalGhToken === undefined) {
+        delete process.env.GH_TOKEN
+      } else {
+        process.env.GH_TOKEN = originalGhToken
+      }
+      await runtime.dispose()
+    }
   })
 })

--- a/services/symphony/src/delivery-service.ts
+++ b/services/symphony/src/delivery-service.ts
@@ -256,7 +256,8 @@ const parseReleaseContractFromPullRequest = (
   }
 }
 
-const deriveLastError = (observation: DeliveryObservation): string | null => {
+const deriveLastError = (stage: DeliveryStage, observation: DeliveryObservation): string | null => {
+  if (stage === 'completed' || stage === 'rolled_back') return null
   if (observation.rollbackPr?.state === 'open') return observation.lastError ?? 'rollback pull request is open'
   if (observation.rollbackPr?.state === 'merged') return null
   if (observation.postDeploy?.state === 'failure') return 'post-deploy verification failed'
@@ -728,9 +729,10 @@ export const makeDeliveryServiceLayer = (logger: Logger) =>
             rollbackPr,
             lastError: baseDelivery.lastError,
           }
+          const stage = deriveDeliveryStage(observation)
 
           return {
-            stage: deriveDeliveryStage(observation),
+            stage,
             updatedAt: new Date().toISOString(),
             codePr,
             requiredChecks,
@@ -741,7 +743,7 @@ export const makeDeliveryServiceLayer = (logger: Logger) =>
             argo,
             postDeploy,
             rollbackPr,
-            lastError: deriveLastError(observation),
+            lastError: deriveLastError(stage, observation),
           } satisfies DeliveryTransaction
         }).pipe(
           Effect.catchAll((error) => {

--- a/services/symphony/src/issue-runner.test.ts
+++ b/services/symphony/src/issue-runner.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, test } from 'bun:test'
+
+import { Effect, Layer, ManagedRuntime } from 'effect'
+import * as Stream from 'effect/Stream'
+
+import { CodexSessionService, type CodexSessionOptions } from './codex-app-session'
+import { DeliveryService, createEmptyDeliveryTransaction } from './delivery-service'
+import { makeIssueRunnerLayer, IssueRunnerService } from './issue-runner'
+import { createLogger } from './logger'
+import { PostHogTelemetryService } from './posthog'
+import { makeTestConfig } from './test-fixtures'
+import type { Issue } from './types'
+import { TrackerService } from './linear-client'
+import { WorkflowService } from './workflow'
+import { WorkspaceService } from './workspace-manager'
+
+const issue: Issue = {
+  id: 'issue-1',
+  identifier: 'ABC-1',
+  title: 'Test issue',
+  description: null,
+  priority: 1,
+  state: 'Todo',
+  branchName: null,
+  url: null,
+  labels: [],
+  blockedBy: [],
+  createdAt: '2026-03-16T03:00:00.000Z',
+  updatedAt: '2026-03-16T03:00:00.000Z',
+}
+
+describe('issue runner runtime tools', () => {
+  test('advertises github delivery actions and routes tool calls through DeliveryService', async () => {
+    const config = makeTestConfig({ agent: { maxTurns: 1 } })
+    const seenTools: string[][] = []
+    const seenGithubCalls: Array<{ repo: string; headSha: string }> = []
+
+    const runtime = ManagedRuntime.make(
+      makeIssueRunnerLayer(createLogger({ test: 'issue-runner-tools' })).pipe(
+        Layer.provide(
+          Layer.succeed(WorkflowService, {
+            current: Effect.succeed({
+              definition: { config: {}, promptTemplate: 'Work on {{issue.identifier}}' },
+              config,
+            }),
+            config: Effect.succeed(config),
+            reload: Effect.succeed({
+              definition: { config: {}, promptTemplate: 'Work on {{issue.identifier}}' },
+              config,
+            }),
+            changes: Stream.empty,
+          }),
+        ),
+        Layer.provide(
+          Layer.succeed(TrackerService, {
+            fetchCandidateIssues: Effect.succeed([]),
+            fetchIssuesByStates: () => Effect.succeed([]),
+            fetchIssueStatesByIds: () => Effect.succeed([issue]),
+            executeLinearGraphql: () => Effect.succeed({ data: { ok: true } }),
+            handoffIssue: () => Effect.void,
+          }),
+        ),
+        Layer.provide(
+          Layer.succeed(DeliveryService, {
+            createPullRequest: () => Effect.die('not used'),
+            getPullRequest: () => Effect.die('not used'),
+            mergePullRequest: () => Effect.die('not used'),
+            inspectRequiredChecks: (repo, headSha) =>
+              Effect.sync(() => {
+                seenGithubCalls.push({ repo, headSha })
+                return {
+                  state: 'success',
+                  headSha,
+                  requiredCount: 2,
+                  passingCount: 2,
+                  failingCount: 0,
+                  pendingCount: 0,
+                  url: 'https://github.com/proompteng/lab/pull/1/checks',
+                }
+              }),
+            getWorkflowRun: () => Effect.die('not used'),
+            refreshIssueDelivery: (record) => Effect.succeed(record.delivery ?? createEmptyDeliveryTransaction()),
+          }),
+        ),
+        Layer.provide(
+          Layer.succeed(WorkspaceService, {
+            createForIssue: (identifier: string) =>
+              Effect.succeed({
+                path: `/tmp/${identifier}`,
+                workspaceKey: identifier,
+                createdNow: false,
+              }),
+            runBeforeRun: () => Effect.void,
+            runAfterRun: () => Effect.void,
+            removeWorkspace: () => Effect.void,
+          }),
+        ),
+        Layer.provide(
+          Layer.succeed(CodexSessionService, {
+            createSession: (options: CodexSessionOptions) =>
+              Effect.sync(() => {
+                seenTools.push(options.dynamicTools.map((tool) => tool.name))
+                return {
+                  runTurn: () =>
+                    options
+                      .onToolCall('github_delivery', {
+                        action: 'inspect_required_checks',
+                        headSha: 'abcdef0123456789abcdef0123456789abcdef01',
+                      })
+                      .pipe(
+                        Effect.flatMap((response) =>
+                          Effect.sync(() => {
+                            const firstItem = response.contentItems[0]
+                            const payload = JSON.parse(
+                              firstItem && 'text' in firstItem && typeof firstItem.text === 'string'
+                                ? firstItem.text
+                                : '{}',
+                            ) as { state?: string }
+                            expect(response.success).toBe(true)
+                            expect(payload.state).toBe('success')
+                            return {
+                              status: 'completed' as const,
+                              threadId: 'thread-1',
+                              turnId: 'turn-1',
+                            }
+                          }),
+                        ),
+                      ),
+                }
+              }),
+          }),
+        ),
+        Layer.provide(
+          Layer.succeed(PostHogTelemetryService, {
+            captureTrace: () => Effect.void,
+            captureSpan: () => Effect.void,
+            captureGeneration: () => Effect.void,
+            summary: Effect.succeed({
+              enabled: false,
+              host: null,
+              projectId: null,
+              distinctId: 'symphony:test',
+              lastError: null,
+            }),
+          }),
+        ),
+      ),
+    )
+
+    const previousGhToken = process.env.GH_TOKEN
+    process.env.GH_TOKEN = 'test-token'
+
+    try {
+      await runtime.runPromise(
+        Effect.gen(function* () {
+          const runner = yield* IssueRunnerService
+          const workspacePath = yield* runner.runAttempt(
+            issue,
+            null,
+            {
+              onEvent: () => Effect.void,
+              onWorkspacePath: () => Effect.void,
+            },
+            {
+              sessionId: 'session-1',
+              traceId: 'trace-1',
+              rootSpanId: 'root-1',
+            },
+          )
+
+          expect(workspacePath).toBe('/tmp/ABC-1')
+          expect(seenTools[0]).toContain('linear_graphql')
+          expect(seenTools[0]).toContain('github_delivery')
+          expect(seenGithubCalls).toEqual([
+            {
+              repo: 'proompteng/lab',
+              headSha: 'abcdef0123456789abcdef0123456789abcdef01',
+            },
+          ])
+        }),
+      )
+    } finally {
+      if (previousGhToken === undefined) {
+        delete process.env.GH_TOKEN
+      } else {
+        process.env.GH_TOKEN = previousGhToken
+      }
+      await runtime.dispose()
+    }
+  })
+})

--- a/services/symphony/src/issue-runner.ts
+++ b/services/symphony/src/issue-runner.ts
@@ -3,6 +3,7 @@ import { Context, Effect, Layer } from 'effect'
 
 import { CodexProtocolError, ConfigError, toLogError, TrackerError, WorkspaceError, WorkflowError } from './errors'
 import { CodexSessionService, type CodexEvent } from './codex-app-session'
+import { DeliveryService } from './delivery-service'
 import { finishSymphonySpan, startSymphonySpan, withSymphonyEffectSpan } from './instrumentation'
 import { TrackerService } from './linear-client'
 import type { Logger } from './logger'
@@ -29,6 +30,38 @@ const LINEAR_GRAPHQL_TOOL: DynamicToolSpec = {
   },
 }
 
+const GITHUB_DELIVERY_TOOL: DynamicToolSpec = {
+  name: 'github_delivery',
+  description: 'Execute first-class GitHub delivery operations using Symphony runtime credentials.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      action: {
+        type: 'string',
+        enum: [
+          'create_pull_request',
+          'get_pull_request',
+          'merge_pull_request',
+          'inspect_required_checks',
+          'get_workflow_run',
+        ],
+      },
+      repo: { type: 'string' },
+      title: { type: 'string' },
+      head: { type: 'string' },
+      base: { type: 'string' },
+      body: { type: 'string' },
+      draft: { type: 'boolean' },
+      number: { type: 'number' },
+      method: { type: 'string', enum: ['merge', 'squash', 'rebase'] },
+      headSha: { type: 'string' },
+      runId: { type: 'number' },
+    },
+    required: ['action'],
+    additionalProperties: true,
+  },
+}
+
 const buildContinuationPrompt = (issue: Issue, turnNumber: number, maxTurns: number): string =>
   [
     `Continue working on issue ${issue.identifier}: ${issue.title}.`,
@@ -36,6 +69,8 @@ const buildContinuationPrompt = (issue: Issue, turnNumber: number, maxTurns: num
     'Do not restate the original task. Continue from thread history, re-check the repository state, and make the next highest-value progress.',
     'If the issue is already complete or blocked, leave a concise handoff in the tracker/tooling available to you and stop.',
   ].join('\n')
+
+const hasGithubDeliveryAccess = (): boolean => Boolean(process.env.GH_TOKEN?.trim() || process.env.GITHUB_TOKEN?.trim())
 
 export type IssueRunnerCallbacks = {
   onEvent: (event: CodexEvent) => Effect.Effect<void, never>
@@ -68,6 +103,7 @@ export const makeIssueRunnerLayer = (logger: Logger) =>
     Effect.gen(function* () {
       const workflow = yield* WorkflowService
       const tracker = yield* TrackerService
+      const delivery = yield* DeliveryService
       const workspace = yield* WorkspaceService
       const codexSessions = yield* CodexSessionService
       const posthog = yield* PostHogTelemetryService
@@ -75,14 +111,14 @@ export const makeIssueRunnerLayer = (logger: Logger) =>
 
       const handleToolCall = (toolName: string, args: unknown): Effect.Effect<DynamicToolCallResponse, never> =>
         Effect.gen(function* () {
-          if (toolName !== 'linear_graphql') {
+          if (toolName !== 'linear_graphql' && toolName !== 'github_delivery') {
             return {
               success: false,
               contentItems: [{ type: 'inputText', text: JSON.stringify({ error: 'unsupported_tool_call' }) }],
             } satisfies DynamicToolCallResponse
           }
 
-          if (typeof args === 'string') {
+          if (toolName === 'linear_graphql' && typeof args === 'string') {
             const response = yield* tracker.executeLinearGraphql(args).pipe(
               Effect.catchAll((error) =>
                 Effect.succeed({
@@ -98,18 +134,117 @@ export const makeIssueRunnerLayer = (logger: Logger) =>
           }
 
           const raw = args && typeof args === 'object' ? (args as Record<string, unknown>) : {}
-          const query = typeof raw.query === 'string' ? raw.query : ''
-          const variables =
-            raw.variables && typeof raw.variables === 'object' ? (raw.variables as Record<string, unknown>) : {}
+          if (toolName === 'linear_graphql') {
+            const query = typeof raw.query === 'string' ? raw.query : ''
+            const variables =
+              raw.variables && typeof raw.variables === 'object' ? (raw.variables as Record<string, unknown>) : {}
 
-          if (query.trim().length === 0) {
+            if (query.trim().length === 0) {
+              return {
+                success: false,
+                contentItems: [{ type: 'inputText', text: JSON.stringify({ error: 'invalid_query' }) }],
+              } satisfies DynamicToolCallResponse
+            }
+
+            const response = yield* tracker.executeLinearGraphql(query, variables).pipe(
+              Effect.catchAll((error) =>
+                Effect.succeed({
+                  error: error.message,
+                  code: error.code,
+                }),
+              ),
+            )
             return {
-              success: false,
-              contentItems: [{ type: 'inputText', text: JSON.stringify({ error: 'invalid_query' }) }],
+              success: !('error' in response),
+              contentItems: [{ type: 'inputText', text: JSON.stringify(response) }],
             } satisfies DynamicToolCallResponse
           }
 
-          const response = yield* tracker.executeLinearGraphql(query, variables).pipe(
+          if (!hasGithubDeliveryAccess()) {
+            return {
+              success: false,
+              contentItems: [{ type: 'inputText', text: JSON.stringify({ error: 'github_delivery_unavailable' }) }],
+            } satisfies DynamicToolCallResponse
+          }
+
+          const workflowResult = yield* Effect.either(workflow.current)
+          if (workflowResult._tag === 'Left') {
+            return {
+              success: false,
+              contentItems: [
+                {
+                  type: 'inputText',
+                  text: JSON.stringify({
+                    error: workflowResult.left.message,
+                    code: workflowResult.left.code,
+                  }),
+                },
+              ],
+            } satisfies DynamicToolCallResponse
+          }
+
+          const { config } = workflowResult.right
+          const repo = typeof raw.repo === 'string' && raw.repo.trim().length > 0 ? raw.repo.trim() : config.target.repo
+          const action = typeof raw.action === 'string' ? raw.action : ''
+
+          const response = yield* Effect.gen(function* () {
+            switch (action) {
+              case 'create_pull_request': {
+                const title = typeof raw.title === 'string' ? raw.title : ''
+                const head = typeof raw.head === 'string' ? raw.head : ''
+                const base = typeof raw.base === 'string' ? raw.base : ''
+                const body = typeof raw.body === 'string' ? raw.body : ''
+                if (!title || !head || !base) {
+                  return {
+                    error: 'invalid_input',
+                    detail: 'create_pull_request requires title, head, and base',
+                  }
+                }
+                return yield* delivery.createPullRequest({
+                  repo,
+                  title,
+                  head,
+                  base,
+                  body,
+                  draft: raw.draft === true,
+                })
+              }
+              case 'get_pull_request': {
+                if (typeof raw.number !== 'number') {
+                  return { error: 'invalid_input', detail: 'get_pull_request requires number' }
+                }
+                return yield* delivery.getPullRequest(repo, raw.number)
+              }
+              case 'merge_pull_request': {
+                if (typeof raw.number !== 'number') {
+                  return { error: 'invalid_input', detail: 'merge_pull_request requires number' }
+                }
+                return yield* delivery.mergePullRequest({
+                  repo,
+                  number: raw.number,
+                  method:
+                    raw.method === 'merge' || raw.method === 'rebase' || raw.method === 'squash'
+                      ? raw.method
+                      : 'squash',
+                })
+              }
+              case 'inspect_required_checks': {
+                const headSha = typeof raw.headSha === 'string' ? raw.headSha : ''
+                if (!headSha) {
+                  return { error: 'invalid_input', detail: 'inspect_required_checks requires headSha' }
+                }
+                return yield* delivery.inspectRequiredChecks(repo, headSha)
+              }
+              case 'get_workflow_run': {
+                if (typeof raw.runId !== 'number') {
+                  return { error: 'invalid_input', detail: 'get_workflow_run requires runId' }
+                }
+                return yield* delivery.getWorkflowRun(repo, raw.runId)
+              }
+              default:
+                return { error: 'unsupported_action', detail: action || null }
+            }
+          }).pipe(
             Effect.catchAll((error) =>
               Effect.succeed({
                 error: error.message,
@@ -117,6 +252,7 @@ export const makeIssueRunnerLayer = (logger: Logger) =>
               }),
             ),
           )
+
           return {
             success: !('error' in response),
             contentItems: [{ type: 'inputText', text: JSON.stringify(response) }],
@@ -199,8 +335,10 @@ export const makeIssueRunnerLayer = (logger: Logger) =>
                 yield* callbacks.onWorkspacePath(workspaceInfo.path)
                 let lastIssue = issue
 
-                const dynamicTools =
-                  config.tracker.kind === 'linear' && config.tracker.apiKey ? [LINEAR_GRAPHQL_TOOL] : []
+                const dynamicTools = [
+                  ...(config.tracker.kind === 'linear' && config.tracker.apiKey ? [LINEAR_GRAPHQL_TOOL] : []),
+                  ...(hasGithubDeliveryAccess() ? [GITHUB_DELIVERY_TOOL] : []),
+                ]
 
                 const initialPrompt =
                   definition.promptTemplate.trim().length > 0

--- a/services/symphony/src/orchestrator-lifecycle.test.ts
+++ b/services/symphony/src/orchestrator-lifecycle.test.ts
@@ -4,6 +4,7 @@ import { Effect, Layer, ManagedRuntime } from 'effect'
 import * as Stream from 'effect/Stream'
 
 import { DeliveryService } from './delivery-service'
+import { TrackerError } from './errors'
 import { IssueRunnerService } from './issue-runner'
 import { createLogger } from './logger'
 import { LeaderElectionService } from './leader-election'
@@ -584,6 +585,7 @@ describe('orchestrator lifecycle', () => {
                   createdAt: '2026-03-16T03:00:10.000Z',
                   updatedAt: '2026-03-16T03:00:20.000Z',
                 },
+                lastError: null,
               }),
           }),
         ),
@@ -600,14 +602,27 @@ describe('orchestrator lifecycle', () => {
             const persistedIssue: IssueRecord = {
               issueIdentifier: candidateIssue.identifier,
               issueId: candidateIssue.id,
-              status: 'tracked',
+              status: 'running',
               workspacePath: '/workspace/symphony/ABC-1',
               attempts: { restartCount: 1, currentRetryAttempt: 0 },
-              running: null,
+              running: {
+                sessionId: 'thread-1-turn-2',
+                turnCount: 2,
+                state: 'In Progress',
+                startedAt: '2026-03-16T03:00:00.000Z',
+                lastEvent: 'turn_completed',
+                lastMessage: 'stale worker detail',
+                lastEventAt: '2026-03-16T03:00:05.000Z',
+                tokens: {
+                  inputTokens: 10,
+                  outputTokens: 5,
+                  totalTokens: 15,
+                },
+              },
               retry: null,
               logs: { codex_session_logs: [] },
               recentEvents: [],
-              lastError: null,
+              lastError: 'stale delivery error',
               tracked: { lastKnownState: 'In Progress' },
               runHistory: [],
               delivery: {
@@ -622,7 +637,7 @@ describe('orchestrator lifecycle', () => {
                 argo: null,
                 postDeploy: null,
                 rollbackPr: null,
-                lastError: null,
+                lastError: 'transient github refresh failed',
               },
               updatedAt: '2026-03-16T03:00:00.000Z',
             }
@@ -652,9 +667,115 @@ describe('orchestrator lifecycle', () => {
             const issue = yield* orchestrator.getIssueDetails(candidateIssue.identifier)
             expect(issue?.delivery?.stage).toBe('completed')
             expect(issue?.delivery?.postDeploy?.id).toBe(601)
+            expect(issue?.status).toBe('tracked')
+            expect(issue?.running).toBeNull()
+            expect(issue?.lastError).toBeNull()
+            expect(issue?.delivery?.lastError).toBeNull()
 
             const snapshot = yield* orchestrator.getSnapshot
             expect(snapshot.issues[0]?.delivery?.stage).toBe('completed')
+            expect(snapshot.issues[0]?.status).toBe('tracked')
+            expect(snapshot.counts.running).toBe(0)
+
+            yield* orchestrator.stop
+          }),
+        ),
+      )
+    } finally {
+      await runtime.dispose()
+    }
+  })
+
+  test('retries transient candidate fetch failures before pausing dispatch', async () => {
+    const config = makeTestConfig({
+      pollingIntervalMs: 60_000,
+      health: { preDispatch: [], postDeploy: [] },
+    })
+
+    let fetchCandidateIssuesCalls = 0
+
+    const runtime = ManagedRuntime.make(
+      makeOrchestratorLayer(createLogger({ test: 'orchestrator-candidate-fetch-retry' })).pipe(
+        Layer.provide(
+          Layer.succeed(WorkflowService, {
+            current: Effect.succeed({
+              definition: { config: {}, promptTemplate: 'Work on {{issue.identifier}}' },
+              config,
+            }),
+            config: Effect.succeed(config),
+            reload: Effect.succeed({
+              definition: { config: {}, promptTemplate: 'Work on {{issue.identifier}}' },
+              config,
+            }),
+            changes: Stream.empty,
+          }),
+        ),
+        Layer.provide(
+          Layer.succeed(TrackerService, {
+            fetchCandidateIssues: Effect.try({
+              try: () => {
+                fetchCandidateIssuesCalls += 1
+                if (fetchCandidateIssuesCalls < 3) {
+                  throw new Error('Linear API request failed')
+                }
+                return [candidateIssue]
+              },
+              catch: (error) => new TrackerError('linear_api_request', 'Linear API request failed', error),
+            }),
+            fetchIssuesByStates: () => Effect.succeed([]),
+            fetchIssueStatesByIds: () => Effect.succeed([candidateIssue]),
+            executeLinearGraphql: () => Effect.succeed({}),
+            handoffIssue: () => Effect.void,
+          }),
+        ),
+        Layer.provide(
+          Layer.succeed(WorkspaceService, {
+            createForIssue: () => Effect.die('not used'),
+            runBeforeRun: () => Effect.void,
+            runAfterRun: () => Effect.void,
+            removeWorkspace: () => Effect.void,
+          }),
+        ),
+        Layer.provide(
+          Layer.succeed(IssueRunnerService, {
+            runAttempt: (_issue, _attempt, callbacks, _telemetryContext) =>
+              callbacks.onWorkspacePath('/workspace/symphony/ABC-1').pipe(Effect.zipRight(Effect.never)),
+          }),
+        ),
+        Layer.provide(posthogLayer),
+        Layer.provide(deliveryLayer),
+        Layer.provide(
+          Layer.succeed(LeaderElectionService, {
+            start: Effect.void,
+            stop: Effect.void,
+            status: Effect.succeed(leaderSnapshot),
+            changes: Stream.empty,
+          }),
+        ),
+        Layer.provide(
+          Layer.succeed(StateStoreService, {
+            load: Effect.succeed(emptyPersistedSchedulerState()),
+            save: () => Effect.void,
+            stateFilePath: Effect.succeed('/tmp/symphony-state.json'),
+          }),
+        ),
+        Layer.provide(Layer.succeed(TargetHealthService, { evaluatePreDispatch: Effect.succeed(targetHealthSummary) })),
+      ),
+    )
+
+    try {
+      await runtime.runPromise(
+        Effect.scoped(
+          Effect.gen(function* () {
+            const orchestrator = yield* OrchestratorService
+            yield* orchestrator.start
+            yield* orchestrator.triggerRefresh
+            yield* Effect.sleep(1_100)
+
+            const snapshot = yield* orchestrator.getSnapshot
+            expect(fetchCandidateIssuesCalls).toBe(3)
+            expect(snapshot.counts.running).toBe(1)
+            expect(snapshot.running[0]?.issueIdentifier).toBe('ABC-1')
 
             yield* orchestrator.stop
           }),

--- a/services/symphony/src/orchestrator.ts
+++ b/services/symphony/src/orchestrator.ts
@@ -16,9 +16,9 @@ import { evaluateDispatchIssue, sortIssuesForDispatch } from './dispatch-rules'
 import { createEmptyDeliveryTransaction, DeliveryService } from './delivery-service'
 import {
   OrchestratorError,
+  TrackerError,
   toLogError,
   type ConfigError,
-  type TrackerError,
   type WorkspaceError,
   type WorkflowError,
 } from './errors'
@@ -131,6 +131,10 @@ const MAX_RECENT_ERRORS = 50
 const MAX_RUN_HISTORY = 25
 const DEFAULT_ORCHESTRATOR_COMMAND_TIMEOUT_MS = 30_000
 const DEFAULT_POLL_TICK_TIMEOUT_MS = 45_000
+const DEFAULT_CANDIDATE_FETCH_RETRY_ATTEMPTS = 2
+const DEFAULT_CANDIDATE_FETCH_RETRY_INITIAL_DELAY_MS = 250
+const DEFAULT_CANDIDATE_FETCH_RETRY_MAX_DELAY_MS = 2_000
+const TERMINAL_DELIVERY_STAGES = new Set(['completed', 'rolled_back', 'failed'])
 
 const buildTelemetrySessionId = (projectSlug: string | null, issueId: string) =>
   `symphony:${projectSlug ?? 'unknown'}:${issueId}`
@@ -199,6 +203,16 @@ const pushBounded = <T>(items: T[], item: T, limit: number) => {
   items.push(item)
   if (items.length > limit) {
     items.splice(0, items.length - limit)
+  }
+}
+
+const hasGithubDeliveryAccess = (): boolean => Boolean(process.env.GH_TOKEN?.trim() || process.env.GITHUB_TOKEN?.trim())
+
+const clearStaleRuntimeFromRecord = (record: IssueRecord) => {
+  record.status = record.retry ? 'retrying' : 'tracked'
+  record.running = null
+  if (!record.retry && TERMINAL_DELIVERY_STAGES.has(record.delivery?.stage ?? '')) {
+    record.lastError = record.delivery?.lastError ?? null
   }
 }
 
@@ -327,7 +341,10 @@ const buildPolicySummary = (config: SymphonyConfig): PolicySummary => ({
   approvalPolicy: config.codex.approvalPolicy,
   threadSandbox: config.codex.threadSandbox,
   turnSandboxPolicy: config.codex.turnSandboxPolicy,
-  allowedTools: config.tracker.kind === 'linear' && config.tracker.apiKey ? ['linear_graphql'] : [],
+  allowedTools: [
+    ...(config.tracker.kind === 'linear' && config.tracker.apiKey ? ['linear_graphql'] : []),
+    ...(hasGithubDeliveryAccess() ? ['github_delivery'] : []),
+  ],
   workspaceRoot: config.workspaceRoot,
   pollIntervalMs: config.pollingIntervalMs,
   maxConcurrentAgents: config.agent.maxConcurrentAgents,
@@ -416,7 +433,7 @@ const hydrateStateFromPersisted = (persisted: PersistedSchedulerState, config: S
   state.recentErrors = [...persisted.recentErrors]
 
   for (const record of persisted.issues) {
-    state.issueRecords.set(record.issueId, {
+    const hydratedRecord: IssueRecord = {
       ...record,
       recentEvents: [...record.recentEvents],
       runHistory: [...record.runHistory],
@@ -435,7 +452,11 @@ const hydrateStateFromPersisted = (persisted: PersistedSchedulerState, config: S
             rollbackPr: record.delivery.rollbackPr ? { ...record.delivery.rollbackPr } : null,
           }
         : null,
-    })
+    }
+    if (hydratedRecord.status === 'running') {
+      clearStaleRuntimeFromRecord(hydratedRecord)
+    }
+    state.issueRecords.set(record.issueId, hydratedRecord)
   }
 
   for (const retry of persisted.retrying) {
@@ -940,7 +961,8 @@ export const makeOrchestratorLayer = (logger: Logger) =>
                   issue_identifier: running.identifier,
                   call_id: event.toolCall.callId,
                   retry_attempt: running.retryAttempt ?? 0,
-                  span_kind: 'linear_graphql_tool_call',
+                  span_kind: 'dynamic_tool_call',
+                  tool_name: event.toolCall.name,
                 },
               }),
             )
@@ -1265,11 +1287,7 @@ export const makeOrchestratorLayer = (logger: Logger) =>
                   trackedState !== null &&
                   (config.tracker.activeStates.includes(trackedState) || trackedState === config.tracker.handoffState)
                 const deliveryStage = record.delivery?.stage ?? 'coding'
-                return (
-                  activeOrHandoff ||
-                  !['completed', 'rolled_back', 'failed'].includes(deliveryStage) ||
-                  record.status !== 'tracked'
-                )
+                return activeOrHandoff || !TERMINAL_DELIVERY_STAGES.has(deliveryStage) || record.status !== 'tracked'
               }),
             ),
           )
@@ -1280,12 +1298,69 @@ export const makeOrchestratorLayer = (logger: Logger) =>
               const current = state.issueRecords.get(record.issueId)
               if (current) {
                 current.delivery = refreshed
+                if (
+                  TERMINAL_DELIVERY_STAGES.has(refreshed.stage) &&
+                  !state.running.has(record.issueId) &&
+                  !state.retryAttempts.has(record.issueId)
+                ) {
+                  clearStaleRuntimeFromRecord(current)
+                }
+                if (refreshed.stage === 'completed') {
+                  current.lastError = null
+                }
                 current.updatedAt = new Date().toISOString()
               }
               return Effect.succeed([undefined, state] as const)
             })
           }
         })
+
+      const fetchCandidateIssuesWithRetry = (
+        context: 'dispatch' | 'candidate_fetch_handoff' | 'retry_dispatch',
+      ): Effect.Effect<Issue[], ConfigError | WorkflowError | TrackerError, never> => {
+        const attempts = readPositiveNumber(
+          process.env.SYMPHONY_CANDIDATE_FETCH_RETRY_ATTEMPTS,
+          DEFAULT_CANDIDATE_FETCH_RETRY_ATTEMPTS,
+        )
+        const initialDelayMs = readPositiveNumber(
+          process.env.SYMPHONY_CANDIDATE_FETCH_RETRY_INITIAL_DELAY_MS,
+          DEFAULT_CANDIDATE_FETCH_RETRY_INITIAL_DELAY_MS,
+        )
+        const maxDelayMs = readPositiveNumber(
+          process.env.SYMPHONY_CANDIDATE_FETCH_RETRY_MAX_DELAY_MS,
+          DEFAULT_CANDIDATE_FETCH_RETRY_MAX_DELAY_MS,
+        )
+        const retrySchedule = Schedule.whileInput<unknown>(
+          (error) => error instanceof TrackerError && error.code === 'linear_api_request',
+        )(
+          Schedule.map(
+            Schedule.intersect(Schedule.recurs(Math.max(0, attempts)))(
+              Schedule.jitteredWith({ min: 0.8, max: 1.2 })(
+                Schedule.delayed(Schedule.exponential(Duration.millis(initialDelayMs), 2), (delay) =>
+                  Duration.min(delay, Duration.millis(maxDelayMs)),
+                ),
+              ),
+            ),
+            ([delay]) => delay,
+          ),
+        )
+
+        return tracker.fetchCandidateIssues.pipe(
+          Effect.tap(() => Effect.sync(() => recordCandidateFetch('success'))),
+          Effect.retry(
+            retrySchedule.pipe(
+              Schedule.tapInput((error) =>
+                Effect.sync(() => {
+                  orchestratorLogger.log('warn', 'candidate_fetch_retrying', {
+                    context,
+                    ...toLogError(error),
+                  })
+                }),
+              ),
+            ),
+          ),
+        )
+      }
 
       const reconcileStalledRuns = (config: SymphonyConfig) =>
         config.codex.stallTimeoutMs <= 0
@@ -1492,8 +1567,7 @@ export const makeOrchestratorLayer = (logger: Logger) =>
             const issuesToHandoff = yield* withSymphonyEffectSpan(
               'symphony.poll_tick.candidate_fetch_handoff',
               {},
-              tracker.fetchCandidateIssues.pipe(
-                Effect.tap(() => Effect.sync(() => recordCandidateFetch('success'))),
+              fetchCandidateIssuesWithRetry('candidate_fetch_handoff').pipe(
                 Effect.catchAll((error) =>
                   Effect.sync(() => {
                     recordCandidateFetch('error')
@@ -1535,8 +1609,7 @@ export const makeOrchestratorLayer = (logger: Logger) =>
           const issues = yield* withSymphonyEffectSpan(
             'symphony.poll_tick.candidate_fetch',
             {},
-            tracker.fetchCandidateIssues.pipe(
-              Effect.tap(() => Effect.sync(() => recordCandidateFetch('success'))),
+            fetchCandidateIssuesWithRetry('dispatch').pipe(
               Effect.catchAll((error) =>
                 Effect.sync(() => {
                   recordCandidateFetch('error')
@@ -1678,10 +1751,7 @@ export const makeOrchestratorLayer = (logger: Logger) =>
             })
             if (!retryEntry) return
 
-            const candidatesResult = yield* tracker.fetchCandidateIssues.pipe(
-              Effect.tap(() => Effect.sync(() => recordCandidateFetch('success'))),
-              Effect.either,
-            )
+            const candidatesResult = yield* fetchCandidateIssuesWithRetry('retry_dispatch').pipe(Effect.either)
 
             if (candidatesResult._tag === 'Left') {
               const error = candidatesResult.left

--- a/services/symphony/src/target-health.test.ts
+++ b/services/symphony/src/target-health.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+
+import { Effect, Layer, ManagedRuntime } from 'effect'
+import * as Stream from 'effect/Stream'
+
+import { createLogger } from './logger'
+import { makeTargetHealthLayer, TargetHealthService } from './target-health'
+import { makeTestConfig } from './test-fixtures'
+import { WorkflowService } from './workflow'
+
+const originalFetch = globalThis.fetch
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+  delete process.env.GH_TOKEN
+  delete process.env.SYMPHONY_TRANSIENT_HEALTH_GRACE_MS
+})
+
+describe('target health resilience', () => {
+  test('treats short-lived HTTP health failures as transient after a recent healthy check', async () => {
+    const config = makeTestConfig({
+      health: {
+        preDispatch: [
+          {
+            name: 'symphony-livez',
+            type: 'http',
+            namespace: null,
+            application: null,
+            url: 'https://symphony.example.test/livez',
+            expectedStatus: 200,
+            expectedSync: null,
+            expectedHealth: null,
+            resourceKind: null,
+            resourceName: null,
+            path: null,
+          },
+        ],
+      },
+    })
+
+    let livezRequests = 0
+    process.env.GH_TOKEN = 'test-token'
+    process.env.SYMPHONY_TRANSIENT_HEALTH_GRACE_MS = '60000'
+
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = input instanceof Request ? input.url : String(input)
+      if (url.includes('/pulls?state=open')) {
+        return new Response(JSON.stringify([]), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      }
+      if (url === 'https://symphony.example.test/livez') {
+        livezRequests += 1
+        if (livezRequests === 1) {
+          return new Response('', { status: 200 })
+        }
+        throw new Error('temporary connection reset')
+      }
+      throw new Error(`unexpected fetch: ${url}`)
+    }) as typeof fetch
+
+    const runtime = ManagedRuntime.make(
+      makeTargetHealthLayer(createLogger({ test: 'target-health' })).pipe(
+        Layer.provide(
+          Layer.succeed(WorkflowService, {
+            current: Effect.succeed({
+              definition: { config: {}, promptTemplate: '' },
+              config,
+            }),
+            config: Effect.succeed(config),
+            reload: Effect.succeed({
+              definition: { config: {}, promptTemplate: '' },
+              config,
+            }),
+            changes: Stream.empty,
+          }),
+        ),
+      ),
+    )
+
+    try {
+      await runtime.runPromise(
+        Effect.gen(function* () {
+          const targetHealth = yield* TargetHealthService
+          const healthy = yield* targetHealth.evaluatePreDispatch
+          expect(healthy.readyForDispatch).toBe(true)
+          expect(healthy.lastError).toBeNull()
+
+          const transient = yield* targetHealth.evaluatePreDispatch
+          expect(transient.readyForDispatch).toBe(true)
+          expect(transient.lastError).toBeNull()
+          expect(transient.checks[0]?.ok).toBe(false)
+          expect(transient.checks[0]?.message).toContain('transient observation:')
+        }),
+      )
+    } finally {
+      await runtime.dispose()
+    }
+  })
+})

--- a/services/symphony/src/target-health.ts
+++ b/services/symphony/src/target-health.ts
@@ -2,7 +2,7 @@ import { readFile } from 'node:fs/promises'
 import { request as httpsRequest } from 'node:https'
 import process from 'node:process'
 
-import { Context, Effect, Layer } from 'effect'
+import { Context, Effect, Layer, Ref } from 'effect'
 
 import { OrchestratorError, toLogError } from './errors'
 import type { HealthCheckConfig, TargetHealthCheckResult, TargetHealthSummary } from './types'
@@ -16,10 +16,27 @@ const CA_PATH = `${SERVICE_ACCOUNT_DIRECTORY}/ca.crt`
 const DEFAULT_GITHUB_REQUEST_TIMEOUT_MS = 15_000
 const DEFAULT_HTTP_CHECK_TIMEOUT_MS = 5_000
 const DEFAULT_KUBERNETES_REQUEST_TIMEOUT_MS = 10_000
+const DEFAULT_TRANSIENT_HEALTH_GRACE_MS = 120_000
 
 type KubernetesResponse = {
   status: number
   body: string
+}
+
+type TargetHealthMemory = {
+  lastReadyAtMs: number | null
+}
+
+const isTransientArgoObservation = (observed: string | null): boolean =>
+  observed === 'Synced/Progressing' || observed === 'OutOfSync/Healthy' || observed === 'OutOfSync/Progressing'
+
+const isTransientTargetCheckFailure = (check: TargetHealthCheckResult): boolean => {
+  if (check.ok) return false
+  if (check.type === 'http') return true
+  if (check.type === 'argocd_application') {
+    return isTransientArgoObservation(check.observed)
+  }
+  return false
 }
 
 const requestKubernetes = (
@@ -462,6 +479,7 @@ export const makeTargetHealthLayer = (logger: Logger) =>
     TargetHealthService,
     Effect.gen(function* () {
       const workflow = yield* WorkflowService
+      const memoryRef = yield* Ref.make<TargetHealthMemory>({ lastReadyAtMs: null })
       const targetLogger = logger.child({ component: 'target-health' })
       const githubRequestTimeoutMs = readPositiveNumber(
         process.env.SYMPHONY_GITHUB_REQUEST_TIMEOUT_MS,
@@ -474,6 +492,10 @@ export const makeTargetHealthLayer = (logger: Logger) =>
       const kubernetesRequestTimeoutMs = readPositiveNumber(
         process.env.SYMPHONY_KUBERNETES_REQUEST_TIMEOUT_MS,
         DEFAULT_KUBERNETES_REQUEST_TIMEOUT_MS,
+      )
+      const transientGraceMs = readPositiveNumber(
+        process.env.SYMPHONY_TRANSIENT_HEALTH_GRACE_MS,
+        DEFAULT_TRANSIENT_HEALTH_GRACE_MS,
       )
 
       return {
@@ -513,15 +535,45 @@ export const makeTargetHealthLayer = (logger: Logger) =>
               )
 
               const openPromotionPr = promotionPrCount > 0
-              const lastError = promotionPrCount < 0 ? 'failed to evaluate open promotion pull requests' : null
-
-              return {
+              const hardError = promotionPrCount < 0 ? 'failed to evaluate open promotion pull requests' : null
+              const summary = {
                 checkedAt,
-                readyForDispatch: checks.every((check) => check.ok) && !openPromotionPr && lastError === null,
+                readyForDispatch: checks.every((check) => check.ok) && !openPromotionPr && hardError === null,
                 openPromotionPr,
                 promotionPrCount: Math.max(0, promotionPrCount),
                 checks,
-                lastError,
+                lastError: hardError,
+              } satisfies TargetHealthSummary
+
+              if (summary.readyForDispatch) {
+                yield* Ref.set(memoryRef, { lastReadyAtMs: Date.parse(checkedAt) })
+                return summary
+              }
+
+              const memory = yield* Ref.get(memoryRef)
+              const allFailuresTransient =
+                !summary.openPromotionPr &&
+                summary.lastError === null &&
+                summary.checks.some((check) => !check.ok) &&
+                summary.checks.every((check) => check.ok || isTransientTargetCheckFailure(check))
+              const withinGraceWindow =
+                memory.lastReadyAtMs !== null && Date.now() - memory.lastReadyAtMs <= transientGraceMs
+
+              if (!allFailuresTransient || !withinGraceWindow) {
+                return summary
+              }
+
+              return {
+                ...summary,
+                readyForDispatch: true,
+                checks: summary.checks.map((check) =>
+                  check.ok
+                    ? check
+                    : {
+                        ...check,
+                        message: `transient observation: ${check.message}`,
+                      },
+                ),
               } satisfies TargetHealthSummary
             }),
           ),


### PR DESCRIPTION
## Summary

- clear stale running issue detail and record-level errors when delivery reaches a terminal non-running state
- add a first-class `github_delivery` runtime tool backed by Symphony's delivery service instead of ad hoc shell-only control
- retry transient Linear candidate fetch failures, tolerate short-lived health flaps, and refresh the README plus focused regression coverage

## Related Issues

Resolves PROOMPT-338

## Testing

- `bun run --cwd packages/codex build`
- `bun run --cwd packages/otel build`
- `bun run --cwd services/symphony tsc`
- `bun run --cwd services/symphony lint`
- `bun run --cwd services/symphony lint:oxlint`
- `bun run --cwd services/symphony lint:oxlint:type`
- `bun test services/symphony/src/{orchestrator-lifecycle.test.ts,issue-runner.test.ts,http-server.test.ts,delivery-service.test.ts,target-health.test.ts,dispatch-rules.test.ts}`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
