### PR TITLE
fix(temporal-bun-sdk): format scaffold template

### DIFF
--- a/packages/temporal-bun-sdk/src/bin/temporal-bun.ts
+++ b/packages/temporal-bun-sdk/src/bin/temporal-bun.ts
@@ -487,7 +487,7 @@ peer = true
     {
       path: 'src/activities/index.ts',
       contents: [
-        'export async function helloActivity(name = \'Temporal\') {',
+        "export async function helloActivity(name = 'Temporal') {",
         '  return `Hello from activity, ${name}!`',
         '}',
         '',


### PR DESCRIPTION
## Summary

- fix the oxfmt failure in the Temporal Bun SDK scaffold template
- normalize the generated activities template string so CI formatting passes
- keep the change scoped to the single file that broke the previous merge

## Related Issues

None

## Testing

- `bunx oxfmt --check packages/temporal-bun-sdk/src packages/temporal-bun-sdk/tests`
- `bun run --filter @proompteng/temporal-bun-sdk build`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
