### PR TITLE
chore(jangar): promote image 307b5e99

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 59d968cb
-  digest: sha256:fc1031b2a71068b79ca4c1e74413bf3148aea812c8edfd03b0917cc156b67e51
+  tag: 307b5e99
+  digest: sha256:49deaadaecaa49157838f37e4e833067e46e782f6fe3c97f7b863e3084fc16de
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 59d968cb
-    digest: sha256:257fdbce2c388e0aed880d4e6c4db8eba97fcafa97f235c9949d20ec2f7dfbda
+    tag: 307b5e99
+    digest: sha256:6986369ac7cc10c1fe1d6f618c0d31cf9b229ecf7244214f41a591a82c067d3c
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 59d968cb
-    digest: sha256:fc1031b2a71068b79ca4c1e74413bf3148aea812c8edfd03b0917cc156b67e51
+    tag: 307b5e99
+    digest: sha256:49deaadaecaa49157838f37e4e833067e46e782f6fe3c97f7b863e3084fc16de
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-19T09:36:27Z"
+    deploy.knative.dev/rollout: "2026-03-20T03:42:02Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-19T09:36:27Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-20T03:42:02Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -62,5 +62,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "59d968cb"
-    digest: sha256:fc1031b2a71068b79ca4c1e74413bf3148aea812c8edfd03b0917cc156b67e51
+    newTag: "307b5e99"
+    digest: sha256:49deaadaecaa49157838f37e4e833067e46e782f6fe3c97f7b863e3084fc16de


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `307b5e991ded723ab51fbf699bf30a69534e3745`
- Image tag: `307b5e99`
- Image digest: `sha256:49deaadaecaa49157838f37e4e833067e46e782f6fe3c97f7b863e3084fc16de`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`