### PR TITLE
chore(symphony): promote image d0a8cbc6

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-19T22:04:28Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-20T03:44:48Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -25,5 +25,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "0cdccec6"
-    digest: sha256:c47b221a7186e8577f7d3c48e3e389a08f57534968eb5abf41e2b773f61d365e
+    newTag: "d0a8cbc6"
+    digest: sha256:5773bb7f2b7990e45cef9ba7f849e4e85be5f65a4469ea8e03dcbc3a29c5a058

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-19T22:04:28Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-20T03:44:48Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -27,5 +27,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "0cdccec6"
-    digest: sha256:c47b221a7186e8577f7d3c48e3e389a08f57534968eb5abf41e2b773f61d365e
+    newTag: "d0a8cbc6"
+    digest: sha256:5773bb7f2b7990e45cef9ba7f849e4e85be5f65a4469ea8e03dcbc3a29c5a058

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-19T22:04:28Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-20T03:44:48Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -20,5 +20,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "0cdccec6"
-    digest: sha256:c47b221a7186e8577f7d3c48e3e389a08f57534968eb5abf41e2b773f61d365e
+    newTag: "d0a8cbc6"
+    digest: sha256:5773bb7f2b7990e45cef9ba7f849e4e85be5f65a4469ea8e03dcbc3a29c5a058


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `d0a8cbc68ad966476c2cdca2843836d502b2f655`
- Image tag: `d0a8cbc6`
- Image digest: `sha256:5773bb7f2b7990e45cef9ba7f849e4e85be5f65a4469ea8e03dcbc3a29c5a058`