### PR TITLE
chore(jangar): promote image a615d2ef

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 307b5e99
-  digest: sha256:49deaadaecaa49157838f37e4e833067e46e782f6fe3c97f7b863e3084fc16de
+  tag: a615d2ef
+  digest: sha256:f46cab8982b475aa9eb49b300b3f2072176722ad94b3a7df87dedec9142ae08f
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 307b5e99
-    digest: sha256:6986369ac7cc10c1fe1d6f618c0d31cf9b229ecf7244214f41a591a82c067d3c
+    tag: a615d2ef
+    digest: sha256:bf8a10f42887518ef27ec8a34e4df94258cffd23bd1bd8267a60364bae1d2723
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 307b5e99
-    digest: sha256:49deaadaecaa49157838f37e4e833067e46e782f6fe3c97f7b863e3084fc16de
+    tag: a615d2ef
+    digest: sha256:f46cab8982b475aa9eb49b300b3f2072176722ad94b3a7df87dedec9142ae08f
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-20T03:42:02Z"
+    deploy.knative.dev/rollout: "2026-03-20T04:31:18Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-20T03:42:02Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-20T04:31:18Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -62,5 +62,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "307b5e99"
-    digest: sha256:49deaadaecaa49157838f37e4e833067e46e782f6fe3c97f7b863e3084fc16de
+    newTag: "a615d2ef"
+    digest: sha256:f46cab8982b475aa9eb49b300b3f2072176722ad94b3a7df87dedec9142ae08f


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `a615d2ef0b1cad4dfb4ab017fc2a4fdea5ea7ba2`
- Image tag: `a615d2ef`
- Image digest: `sha256:f46cab8982b475aa9eb49b300b3f2072176722ad94b3a7df87dedec9142ae08f`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`