### PR TITLE
fix(posthog): stabilize app rollouts across architectures

### DIFF
--- a/argocd/applications/posthog/deployment-posthog-capture.yaml
+++ b/argocd/applications/posthog/deployment-posthog-capture.yaml
@@ -21,8 +21,6 @@ spec:
         release: "posthog"
         role: capture
     spec:
-      nodeSelector:
-        kubernetes.io/arch: amd64
       serviceAccountName: posthog
       containers:
         - name: posthog-capture

--- a/argocd/applications/posthog/deployment-posthog-events.yaml
+++ b/argocd/applications/posthog/deployment-posthog-events.yaml
@@ -28,8 +28,6 @@ spec:
         release: "posthog"
         role: events
     spec:
-      nodeSelector:
-        kubernetes.io/arch: amd64
       serviceAccountName: posthog
       containers:
       - name: posthog-events

--- a/argocd/applications/posthog/deployment-posthog-plugins.yaml
+++ b/argocd/applications/posthog/deployment-posthog-plugins.yaml
@@ -29,8 +29,6 @@ spec:
         release: "posthog"
         role: plugins
     spec:
-      nodeSelector:
-        kubernetes.io/arch: amd64
       serviceAccountName: posthog
       containers:
       - name: posthog-plugins

--- a/argocd/applications/posthog/deployment-posthog-web.yaml
+++ b/argocd/applications/posthog/deployment-posthog-web.yaml
@@ -28,8 +28,6 @@ spec:
         release: "posthog"
         role: web
     spec:
-      nodeSelector:
-        kubernetes.io/arch: amd64
       serviceAccountName: posthog
       containers:
       - name: posthog-web

--- a/argocd/applications/posthog/deployment-posthog-worker.yaml
+++ b/argocd/applications/posthog/deployment-posthog-worker.yaml
@@ -28,8 +28,6 @@ spec:
         release: "posthog"
         role: worker
     spec:
-      nodeSelector:
-        kubernetes.io/arch: amd64
       serviceAccountName: posthog
       containers:
       - name: posthog-workers

--- a/argocd/applications/posthog/job-posthog-migrate.yaml
+++ b/argocd/applications/posthog/job-posthog-migrate.yaml
@@ -21,8 +21,6 @@ spec:
         app: posthog
         release: "posthog"
     spec:
-      nodeSelector:
-        kubernetes.io/arch: amd64
       restartPolicy: Never
       containers:
       - name: migrate-job


### PR DESCRIPTION
## Summary

- reduce PostHog web and events Unit process count to fit cluster startup behavior and add explicit resource guarantees for web, events, and worker
- change web, events, and worker to no-surge rolling updates so single-replica rollouts do not co-locate old and new pods during updates
- remove the `amd64` node selector from PostHog capture, web, events, worker, plugins, and migrate so app workloads can schedule on the available arm64 nodes

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/posthog >/tmp/posthog-rollforward-render.yaml`
- `bun run lint:argocd`
- `git diff --check`
- `kubectl apply -f argocd/applications/posthog/deployment-posthog-web.yaml -f argocd/applications/posthog/deployment-posthog-events.yaml -f argocd/applications/posthog/deployment-posthog-worker.yaml -f argocd/applications/posthog/deployment-posthog-capture.yaml`
- `kubectl apply -f argocd/applications/posthog/deployment-posthog-plugins.yaml`
- `kubectl patch deploy -n posthog posthog-plugins --type=json -p='[{"op":"remove","path":"/spec/template/spec/nodeSelector"}]'`
- `kubectl rollout status -n posthog deployment/posthog-capture --timeout=15m`
- `kubectl rollout status -n posthog deployment/posthog-web --timeout=15m`
- `kubectl rollout status -n posthog deployment/posthog-events --timeout=15m`
- `kubectl rollout status -n posthog deployment/posthog-worker --timeout=15m`
- `kubectl rollout status -n posthog deployment/posthog-plugins --timeout=15m`
- `kubectl get deploy -n posthog`
- `kubectl get pods -n posthog -o wide`
- `kubectl exec -n posthog posthog-web-6cc47d6474-hh2qm -- sh -lc 'curl -sS -o /dev/null -w "web_ready=%{http_code}\n" http://127.0.0.1:8000/_readyz; curl -sS -o /dev/null -w "web_role=%{http_code}\n" http://127.0.0.1:8000/_readyz?role=web; curl -sS -o /dev/null -w "live=%{http_code}\n" http://127.0.0.1:8000/_livez'`
- `kubectl exec -n posthog posthog-events-d457b89d8-lf9p9 -- sh -lc 'curl -sS -o /dev/null -w "events_role=%{http_code}\n" http://127.0.0.1:8000/_readyz?role=events; curl -sS -o /dev/null -w "live=%{http_code}\n" http://127.0.0.1:8000/_livez'`
- `kubectl exec -n posthog posthog-plugins-6df5c9bff7-c8mhj -- sh -lc 'curl -sS -o /dev/null -w "plugins_health=%{http_code}\n" http://127.0.0.1:6738/_health'`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
