### PR TITLE
chore(jangar): promote image 4c7ff3cf

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: a615d2ef
-  digest: sha256:f46cab8982b475aa9eb49b300b3f2072176722ad94b3a7df87dedec9142ae08f
+  tag: 4c7ff3cf
+  digest: sha256:4bb042b69f98b765ff4dc1150ffb572a73e1ad47a07646619f7bfe1ec098aa13
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: a615d2ef
-    digest: sha256:bf8a10f42887518ef27ec8a34e4df94258cffd23bd1bd8267a60364bae1d2723
+    tag: 4c7ff3cf
+    digest: sha256:9abd755e0e27ddfde253775b3c4bd5350c56f373940d8c416439ced9521a6c28
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: a615d2ef
-    digest: sha256:f46cab8982b475aa9eb49b300b3f2072176722ad94b3a7df87dedec9142ae08f
+    tag: 4c7ff3cf
+    digest: sha256:4bb042b69f98b765ff4dc1150ffb572a73e1ad47a07646619f7bfe1ec098aa13
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-03-20T04:31:18Z"
+    deploy.knative.dev/rollout: "2026-03-20T06:45:54Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-03-20T04:31:18Z"
+        kubectl.kubernetes.io/restartedAt: "2026-03-20T06:45:54Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -62,5 +62,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "a615d2ef"
-    digest: sha256:f46cab8982b475aa9eb49b300b3f2072176722ad94b3a7df87dedec9142ae08f
+    newTag: "4c7ff3cf"
+    digest: sha256:4bb042b69f98b765ff4dc1150ffb572a73e1ad47a07646619f7bfe1ec098aa13


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `4c7ff3cf0297ed388f0fe8f4f4675380fa50f272`
- Image tag: `4c7ff3cf`
- Image digest: `sha256:4bb042b69f98b765ff4dc1150ffb572a73e1ad47a07646619f7bfe1ec098aa13`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`