### PR TITLE
docs(architecture): add runtime admission and hypothesis passports

### DIFF
--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -18,6 +18,8 @@ clear entrypoints, clear “source of truth”, and a complete catalog of relate
 - Fast Jangar/Torghut live analysis workflow: `designs/jangar-torghut-live-analysis-playbook.md`
 - Autonomous Jangar/Torghut production system design: `designs/autonomous-jangar-torghut-production-system.md`
 - Current Jangar/Torghut architecture contracts:
+  - `designs/61-jangar-runtime-kits-and-admission-passports-contract-2026-03-20.md`
+  - `../torghut/design-system/v6/60-torghut-hypothesis-passports-and-capability-quote-auction-contract-2026-03-20.md`
   - `designs/60-jangar-recovery-ledger-and-consumer-attestation-contract-2026-03-20.md`
   - `../torghut/design-system/v6/59-torghut-lane-balance-sheet-and-dataset-seat-auction-contract-2026-03-20.md`
   - `designs/59-jangar-authority-session-bus-and-rollout-lease-contract-2026-03-20.md`

--- a/docs/agents/designs/61-jangar-runtime-kit-ledger-and-execution-class-admission-contract-2026-03-20.md
+++ b/docs/agents/designs/61-jangar-runtime-kit-ledger-and-execution-class-admission-contract-2026-03-20.md
@@ -1,0 +1,451 @@
+# 61. Jangar Runtime Kit Ledger and Execution-Class Admission Contract (2026-03-20)
+
+Status: Approved for implementation (`plan`)
+Date: `2026-03-20`
+Owner: Victor Chen (Jangar Engineering)
+Mission: `codex/swarm-jangar-control-plane-plan`
+Swarm impacts:
+
+- `jangar-control-plane`
+- `torghut-quant`
+
+Companion doc:
+
+- `docs/torghut/design-system/v6/60-torghut-hypothesis-passports-and-profit-guardrail-admission-contract-2026-03-20.md`
+
+Extends:
+
+- `60-jangar-recovery-ledger-and-consumer-attestation-contract-2026-03-20.md`
+- `59-jangar-authority-session-bus-and-rollout-lease-contract-2026-03-20.md`
+- `58-jangar-authority-journals-bounded-recovery-cells-and-replay-contract-2026-03-20.md`
+
+## Executive summary
+
+The decision is to make runtime completeness a first-class control-plane object by introducing a durable **Runtime Kit
+Ledger** and **Execution-Class Admissions**. Jangar will stop treating missing worker assets, stale freeze debt, and
+consumer-specific dependency freshness as one broad degraded answer. Instead it will compile which runtime kit each
+execution class needs, prove whether that kit is present, and bind rollout and consumer admission to that proof.
+
+The reason is visible in the live system on `2026-03-20`:
+
+- `GET http://jangar.jangar.svc.cluster.local/ready`
+  - returns HTTP `200`
+  - reports `execution_trust.status="degraded"`
+  - keeps `jangar-control-plane` and `torghut-quant` degraded because freeze expiry from `2026-03-11` remains
+    unreconciled
+- `GET http://jangar.jangar.svc.cluster.local/api/agents/control-plane/status?namespace=agents&window=15m`
+  - returns HTTP `200` at `2026-03-20T22:38:00.727Z`
+  - reports `rollout_health.status="healthy"` for `agents` and `agents-controllers`
+  - reports `database.status="healthy"` with `24/24` migrations applied
+  - still reports `execution_trust.status="degraded"` because stale freeze reconciliation and queued requirements are
+    mixed into one reducer
+- `kubectl get swarm -n agents jangar-control-plane torghut-quant -o yaml`
+  - shows both swarms still carrying `StageStaleness` freeze windows that expired on `2026-03-11`
+  - shows `jangar-control-plane.requirements.pending=5`
+- `kubectl logs -n agents pod/jangar-control-plane-torghut-quant-req-00gbjlqs-1-rpx2-c45gnd8d --tail=200`
+  - fails on `python3: can't open file '/app/skills/huly-api/scripts/huly-api.py'`
+  - proves a live implementation-handoff failure caused by missing runtime assets, not by generic rollout health
+
+The tradeoff is more additive persistence and a stricter rollout contract. I am keeping that trade because the system's
+next expensive failure mode is not another broad `503`. It is a healthy-enough control plane that still cannot execute
+the work its consumers asked it to do.
+
+## Mission inputs and success criteria
+
+Observed mission inputs:
+
+- repository: `proompteng/lab`
+- base: `main`
+- head: `codex/swarm-jangar-control-plane-plan`
+- swarmName: `jangar-control-plane`
+- swarmStage: `plan`
+- objective: assess cluster, source, and database state and merge architecture artifacts that improve Jangar
+  resilience, rollout safety, and Torghut profitability
+
+This artifact succeeds when:
+
+1. every Jangar consumer can cite one `runtime_kit_id` and one `execution_admission_id` instead of relying on image
+   health or route-time reduction;
+2. missing runtime assets such as the Huly skill path block only the affected execution classes rather than flattening
+   all readiness into one answer;
+3. `/ready`, `/api/agents/control-plane/status`, requirement runs, and deploy verification all expose which runtime
+   class they are trusting;
+4. rollout and rollback decisions prove both deployment digest parity and runtime-kit completeness before promotion.
+
+## Assessment snapshot
+
+### Cluster health, rollout, and event evidence
+
+The live cluster says Jangar serving is healthier than Jangar execution.
+
+- `kubectl get pods -n jangar -o wide`
+  - shows `jangar-c9bc8497-mkzl9` `2/2 Running`
+  - shows `jangar-worker-5864548487-cmrvv` `1/1 Running`
+  - shows `jangar-db-1` `1/1 Running`
+- `kubectl get pods -n agents -o wide`
+  - shows fresh `agents` and `agents-controllers` pods healthy after the latest rollout
+  - still shows repeated `Error` pods for `jangar-control-plane-torghut-quant-req-*`
+- `kubectl get events -n agents --sort-by=.lastTimestamp | tail -n 40`
+  - shows current schedule jobs succeeding and new plan/implement attempts running
+  - still shows recent `BackoffLimitExceeded` on requirement and verify jobs
+
+Interpretation:
+
+- rollout health has materially improved;
+- stale freeze debt is still present;
+- execution failures now include runtime incompleteness that the current control-plane contract cannot isolate.
+
+### Source architecture and high-risk modules
+
+The source tree still keeps runtime completeness implicit.
+
+- `services/jangar/src/server/control-plane-status.ts`
+  - compiles rollout health, execution trust, watch reliability, database health, empirical services, swarms, and
+    stages in one request-time reducer;
+  - does not publish a durable object for runtime completeness or execution-class-specific admission.
+- `services/jangar/src/routes/ready.tsx`
+  - merges execution trust across namespaces and treats `blocked` and `unknown` as hard fail;
+  - has no concept of execution classes such as `serving`, `huly-bridge`, `plan`, `implement`, or `deploy`.
+- `services/jangar/src/server/supporting-primitives-controller.ts`
+  - still carries process-local `swarmUnfreezeTimers`;
+  - remains the source of stale-freeze repair behavior, but not of a durable runtime admission story.
+- `services/jangar/scripts/codex/lib/huly-api-client.ts`
+  - resolves `skills/huly-api/scripts/huly-api.py` from a relative repo path;
+  - has no runtime-kit assertion proving the worker image or checkout actually contains that file.
+- `packages/scripts/src/jangar/verify-deployment.ts`
+  - validates Argo app health and deployment digests;
+  - does not verify runtime-kit completeness or execution admission parity for deploy-time consumers.
+
+The highest-risk missing tests are architectural:
+
+- no regression test proves a packaged AgentRun runtime contains the Huly skill path before Jangar advertises
+  cross-swarm collaboration readiness;
+- no parity test proves `/ready`, status, and deploy verification cite the same runtime admission;
+- no replay test proves stale freeze debt and runtime-kit debt can coexist without globally blocking serving.
+
+### Database, schema, freshness, and consistency evidence
+
+The database surface is healthy, but freshness is uneven in exactly the way the runtime contract needs to expose.
+
+- direct SQL via `jangar-db-rw.jangar.svc.cluster.local`
+  - connects successfully as the app user at `2026-03-20T22:40:18.235Z`
+  - shows `kysely_migration.applied_count=24`
+- `agents_control_plane.resources_current`
+  - `145` rows total, `71` active rows
+  - `latest_seen_at=2026-03-20T22:40:17.058Z`
+- `agents_control_plane.component_heartbeats`
+  - `4` rows
+  - `latest_observed_at=2026-03-20T22:40:05.896Z`
+- `torghut_control_plane.quant_metrics_latest`
+  - `504` rows
+  - `latest_as_of=2026-03-20T22:40:11.868Z`
+- `torghut_market_context_snapshots`
+  - only `25` rows
+  - `latest_as_of=2026-03-16T19:36:22.853Z`
+- `torghut_control_plane.simulation_runs`
+  - `58` rows with `40` in `failed` status
+  - `latest_updated_at=2026-03-19T10:08:32.162Z`
+
+Operational limits also matter:
+
+- `kubectl auth can-i create pods/exec -n jangar`
+  - returns `no`
+- `kubectl auth can-i create pods/portforward -n jangar`
+  - returns `no`
+- `jangar-db-ro.jangar.svc.cluster.local:5432`
+  - refused the connection from this runtime
+
+Interpretation:
+
+- Jangar already has durable state and fresh control-plane facts;
+- it does not yet model which execution classes need which runtime assets and freshness inputs;
+- that gap is now more operationally important than basic database connectivity.
+
+## Problem statement
+
+Jangar still has five resilience-critical gaps:
+
+1. rollout health and execution completeness are currently conflated even though they fail differently;
+2. runtime assets such as skills, helper scripts, and tool paths remain implicit in the image or checkout instead of
+   being part of the control-plane contract;
+3. request-time reducers still globalize stale freeze debt and consumer-specific missing dependencies into one broad
+   degraded answer;
+4. deploy verification can prove digest parity but cannot prove that the deployed runtime can perform the required
+   work;
+5. Torghut profitability still depends on Jangar exposing capability truth precisely enough to separate fresh quant
+   telemetry from stale market-context and simulation evidence.
+
+That was tolerable when outages were mostly binary. It is not acceptable for the next six months, where the system
+must serve safely while isolating execution failures before they become rollout failures.
+
+## Alternatives considered
+
+### Option A: continue the recovery-ledger and consumer-attestation line without runtime kits
+
+Summary:
+
+- keep recovery cases and consumer attestations as the main additive objects;
+- repair stale freeze behavior and make current consumers more selective.
+
+Pros:
+
+- smallest delta from the current March 20 plan stack;
+- keeps the mental model closer to the existing readiness contract.
+
+Cons:
+
+- still leaves missing runtime assets implicit;
+- still cannot explain why a requirement job fails while serving and rollout health remain acceptable;
+- keeps deploy verification blind to execution completeness.
+
+Decision: rejected.
+
+### Option B: split images and stage runtimes without new admission objects
+
+Summary:
+
+- isolate `plan`, `implement`, `verify`, and requirement handoff into separate images or workspaces;
+- let each stage own its own runtime bundle operationally.
+
+Pros:
+
+- narrows blast radius from missing files;
+- operationally simple to explain at first glance.
+
+Cons:
+
+- creates image and rollout sprawl;
+- does not provide one durable object that routes, deploy tools, and downstream consumers can share;
+- pushes correctness into packaging conventions instead of explicit control-plane truth.
+
+Decision: rejected.
+
+### Option C: runtime kit ledger plus execution-class admissions
+
+Summary:
+
+- Jangar compiles a runtime-kit ledger from image digests, mounted assets, skill refs, and required tool paths;
+- each execution class binds to one runtime kit plus one authority session and one recovery view;
+- routes, deploy verification, and downstream consumers read admissions instead of guessing from broad health.
+
+Pros:
+
+- directly addresses the live Huly-skill-path failure mode;
+- gives rollout safety a stronger bar than digest parity alone;
+- preserves future option value because new consumers can bind to classes without redefining the whole readiness model.
+
+Cons:
+
+- adds new additive tables and compiler logic;
+- requires runtime probes and shadow mode before enforcement;
+- raises the parity-testing bar for serving, deploy, and consumer surfaces.
+
+Decision: selected.
+
+## Decision
+
+Adopt **Option C**.
+
+Jangar will compile runtime kits and execution-class admissions, then bind readiness, requirement handoff, and deploy
+verification to those durable objects instead of treating runtime completeness as an implied property of rollout health.
+
+## Architecture
+
+### 1. Runtime kit ledger
+
+Add additive control-plane tables:
+
+- `control_plane_runtime_kits`
+  - `runtime_kit_id`
+  - `kit_class` (`serving`, `worker`, `huly-bridge`, `deploy-verifier`, `torghut-consumer`)
+  - `image_digest`
+  - `repo_revision`
+  - `workspace_layout_digest`
+  - `required_paths_json`
+  - `required_skills_json`
+  - `required_binaries_json`
+  - `required_env_bindings_json`
+  - `probed_at`
+  - `expires_at`
+  - `status` (`allow`, `degrade`, `block`)
+  - `reason_codes_json`
+  - `evidence_refs_json`
+- `control_plane_runtime_kit_observations`
+  - `runtime_kit_id`
+  - `subject_kind`
+  - `subject_ref`
+  - `path_or_capability`
+  - `observed_state`
+  - `reason_code`
+  - `observed_at`
+
+Rules:
+
+- runtime completeness is never inferred solely from image digest;
+- a missing required path such as `skills/huly-api/scripts/huly-api.py` becomes a first-class observation;
+- observations expire quickly enough to catch bad rollouts without turning old transient failures into permanent truth.
+
+### 2. Execution classes
+
+Add additive tables:
+
+- `control_plane_execution_classes`
+  - `execution_class_id`
+  - `consumer_id`
+  - `class_name`
+  - `required_runtime_kit_class`
+  - `required_consumer_class`
+  - `required_recovery_effect`
+  - `required_freshness_inputs_json`
+  - `serving_policy` (`allow`, `degrade`, `block`)
+  - `promotion_policy` (`allow`, `degrade`, `block`)
+- `control_plane_execution_admissions`
+  - `execution_admission_id`
+  - `execution_class_id`
+  - `authority_session_id`
+  - `consumer_attestation_id`
+  - `runtime_kit_id`
+  - `decision` (`allow`, `degrade`, `block`)
+  - `bounded_failure_scope`
+  - `reason_codes_json`
+  - `digest`
+  - `issued_at`
+  - `expires_at`
+
+Initial classes:
+
+- `jangar-serving`
+- `jangar-huly-bridge`
+- `jangar-plan-stage`
+- `jangar-implement-stage`
+- `jangar-verify-stage`
+- `jangar-deploy-verifier`
+- `torghut-runtime-consumer`
+- `torghut-promotion-consumer`
+
+Rules:
+
+- serving and handoff are distinct classes;
+- a missing Huly bridge asset blocks `jangar-huly-bridge` and dependent requirement runs, not `jangar-serving`;
+- stale freeze debt may still degrade or block promotion classes without taking serving down.
+
+### 3. Admission compiler
+
+The compiler joins four surfaces:
+
+1. authority sessions and recovery cases from the existing March 20 architecture line;
+2. runtime-kit observations from image, workspace, and mounted-asset probes;
+3. freshness inputs for required data dependencies such as quant evidence, market context, and simulation state;
+4. consumer bindings for `/ready`, codex implementation runs, deploy verification, and Torghut.
+
+Compiler outputs must:
+
+- cite the exact `runtime_kit_id` used for the decision;
+- preserve the open recovery-case ids that affected the class;
+- emit bounded `reason_codes_json` so the user sees whether the issue is runtime, freshness, recovery debt, or rollout.
+
+### 4. Read-model and consumer changes
+
+`/ready` and `/api/agents/control-plane/status` remain, but they become projections over admissions.
+
+- `/ready`
+  - returns the latest `jangar-serving` admission
+  - includes `execution_admission_id`, `runtime_kit_id`, and `consumer_attestation_id`
+- `/api/agents/control-plane/status`
+  - keeps the rich controller, rollout, database, watch, swarm, and empirical sections
+  - adds runtime kits, execution-class admissions, and bounded failure scope
+- codex requirement and plan runs
+  - record which execution admission they consumed
+  - fail closed only when their bound class is `block`
+
+### 5. Rollout safety and deployment verification
+
+`packages/scripts/src/jangar/verify-deployment.ts` must stop proving only digest parity.
+
+New deploy contract:
+
+- a rollout is promotable only when deployment digest and required runtime-kit digest both match;
+- `jangar-deploy-verifier` admission must be `allow`;
+- rollout evidence stores `execution_admission_id`, `runtime_kit_id`, and `authority_session_id`;
+- missing stage-specific runtime assets force a deploy hold even when pods are `Ready`.
+
+### 6. Validation and acceptance gates
+
+Engineer acceptance gates:
+
+- unit tests for:
+  - runtime-kit compilation with a missing skill path;
+  - execution-class admission that blocks `jangar-huly-bridge` while keeping `jangar-serving` degraded or allowed;
+  - parity between `/ready`, status, and execution admissions
+- replay test seeded with:
+  - March 11, 2026 stale freeze debt
+  - March 20, 2026 healthy rollouts
+  - the observed missing Huly skill path failure
+- deploy-verifier test proving digest parity alone is insufficient when the runtime kit is incomplete
+
+Deployer acceptance gates:
+
+- rollout records show one `execution_admission_id` per deploy attempt;
+- a canary may proceed when `jangar-serving` is `allow` or bounded `degrade`, but promotion remains blocked if the
+  required non-serving class is blocked;
+- rollback triggers include runtime-kit regression, not only pod-unready or Argo health failure.
+
+## Rollout plan
+
+Phase 0. Add tables and runtime probes in shadow mode.
+
+- write runtime kits and observations without changing consumer behavior
+- surface the missing Huly skill path as a first-class observation
+
+Phase 1. Project runtime kits and admissions through status.
+
+- keep `/ready` and deploy verification on existing logic
+- compare runtime-kit decisions against live incidents and logs
+
+Phase 2. Move codex requirement and plan runs to execution-class admission.
+
+- requirement handoff binds to `jangar-huly-bridge`
+- stage runs bind to `jangar-plan-stage`, `jangar-implement-stage`, and `jangar-verify-stage`
+
+Phase 3. Move `/ready` and deploy verification.
+
+- `/ready` reads `jangar-serving`
+- deploy verification reads `jangar-deploy-verifier`
+
+Phase 4. Retire implicit runtime assumptions.
+
+- image digest remains necessary but no longer sufficient
+- runtime-kit and execution-admission evidence becomes mandatory for promotion and handoff
+
+## Rollback
+
+If the runtime-kit compiler or admission policy is wrong:
+
+1. stop enforcing execution-class admissions in `/ready`, deploy verification, and codex runs;
+2. fall back to current request-time readiness and digest checks;
+3. preserve runtime-kit and admission rows for forensics and replay;
+4. repair the compiler in shadow mode before re-enabling enforcement.
+
+## Risks and open questions
+
+- Runtime probes that are too permissive will recreate today's implicit failure mode with prettier nouns.
+- Runtime probes that are too strict can turn harmless packaging differences into rollout churn.
+- The control plane must decide whether runtime-kit truth comes from image introspection, workspace introspection, or
+  both. I prefer both so rollouts catch checkout-layout drift as well as image drift.
+
+## Handoff to engineer and deployer
+
+Engineer handoff:
+
+- implement runtime-kit and execution-admission tables and compiler
+- expose admissions in `/ready` and `/api/agents/control-plane/status`
+- add regression coverage for the missing Huly skill path and parity coverage for serving versus handoff classes
+
+Deployer handoff:
+
+- require execution-admission and runtime-kit ids in deployment verification evidence
+- allow serving cutover only when `jangar-serving` is valid
+- keep requirement handoff, promotion, and deploy classes fail-closed until their runtime kits are complete
+
+The acceptance bar is not "the pods are healthy." The acceptance bar is being able to prove that the runtime bound to a
+consumer actually contains the assets that consumer depends on.

--- a/docs/agents/designs/61-jangar-runtime-kits-and-admission-passports-contract-2026-03-20.md
+++ b/docs/agents/designs/61-jangar-runtime-kits-and-admission-passports-contract-2026-03-20.md
@@ -1,0 +1,414 @@
+# 61. Jangar Runtime Kits and Admission Passports Contract (2026-03-20)
+
+Status: Approved for implementation (`plan`)
+Date: `2026-03-20`
+Owner: Victor Chen (Jangar Engineering)
+Mission: `codex/swarm-jangar-control-plane-plan`
+Swarm impacts:
+
+- `jangar-control-plane`
+- `torghut-quant`
+
+Companion doc:
+
+- `docs/torghut/design-system/v6/60-torghut-hypothesis-passports-and-capability-quote-auction-contract-2026-03-20.md`
+
+Extends:
+
+- `60-jangar-recovery-ledger-and-consumer-attestation-contract-2026-03-20.md`
+- `59-jangar-authority-session-bus-and-rollout-lease-contract-2026-03-20.md`
+- `58-jangar-authority-journals-bounded-recovery-cells-and-replay-contract-2026-03-20.md`
+- `57-jangar-authority-capsules-and-readiness-class-separation-2026-03-20.md`
+
+## Executive summary
+
+The decision is to add durable **Runtime Kits** and consumer-scoped **Admission Passports** on top of the current
+authority-session stack. Jangar already models stale freeze debt and rollout truth well enough to describe the system,
+but it still does not model whether a given runtime can actually execute the work it was admitted to do.
+
+The reason is visible in the live system on `2026-03-20`:
+
+- `kubectl get swarms.swarm.proompteng.ai -n agents -o wide`
+  - still shows `jangar-control-plane` `Frozen` `Ready=False`
+  - still shows `torghut-quant` `Frozen` `Ready=False`
+- `kubectl get swarm jangar-control-plane -n agents -o yaml`
+  - still shows `status.freeze.until="2026-03-11T16:36:12.630Z"`
+  - still shows `status.updatedAt="2026-03-11T15:48:11.742Z"`
+  - still shows `requirements.pending=5`
+- `GET http://jangar.jangar.svc.cluster.local/ready`
+  - returns HTTP `200`
+  - reports `execution_trust.status="degraded"`
+  - still lists both stale freeze reconciliation debt and pending requirements
+- `GET http://jangar.jangar.svc.cluster.local/api/agents/control-plane/status?namespace=agents&window=15m`
+  - reports `database.status="healthy"`
+  - reports `rollout_health.status="healthy"`
+  - reports `watch_reliability.status="healthy"`
+  - still reports `dependency_quorum.decision="block"`
+  - still reports `execution_trust.blocking_windows` for unreconciled freeze debt
+- `kubectl logs -n agents job/jangar-control-plane-torghut-quant-req-00gbjlqs-1-rpx2-c4597240`
+  - fails with `python3: can't open file '/app/skills/huly-api/scripts/huly-api.py': [Errno 2] No such file or directory`
+- `services/jangar/scripts/codex/lib/huly-api-client.ts`
+  - resolves the Huly helper from a runtime filesystem path
+- `services/jangar/scripts/codex/codex-implement.ts`
+  - treats Huly initialization as a blocking mission prerequisite for cross-swarm handoff
+
+The tradeoff is more persistence, one more compiler loop, and stricter admission semantics. I am keeping that trade
+because the costlier failure mode for the next six months is not stale status anymore. It is healthy-enough pods and
+healthy-enough rollout reporting that still launch work against incomplete runtimes.
+
+## Mission inputs and success criteria
+
+Observed mission inputs:
+
+- repository: `proompteng/lab`
+- base: `main`
+- head: `codex/swarm-jangar-control-plane-plan`
+- swarmName: `jangar-control-plane`
+- swarmStage: `plan`
+- objective: assess cluster/source/database state and merge architecture artifacts that improve Jangar resilience and
+  Torghut profitability
+
+This artifact succeeds when:
+
+1. Jangar publishes one runtime-admissibility contract that includes both authority truth and execution-surface truth.
+2. a missing runtime dependency such as `/app/skills/huly-api/scripts/huly-api.py` is represented as first-class
+   control-plane debt instead of only a job crash.
+3. `/ready`, `/api/agents/control-plane/status`, deploy verification, and stage launchers cite the same
+   `admission_passport_id` and `runtime_kit_digest` set.
+4. stale freeze debt blocks only the consumers that still require it, while unrelated serving classes can remain
+   healthy.
+5. engineer and deployer stages have explicit validation, rollout, and rollback gates that can be executed without
+   inferring missing runtime state from pod logs.
+
+## Assessment snapshot
+
+### Cluster health, rollout, and event evidence
+
+The live cluster says Jangar is now serving, but it is not yet proving that every admitted workload is executable.
+
+- serving path:
+  - Jangar `/ready` is back to HTTP `200`.
+  - Jangar control-plane status reports rollout health and database health as `healthy`.
+- authority debt:
+  - both swarms remain frozen on March 11 expiry timestamps.
+  - Jangar continues to expose stale-freeze and pending-requirement debt through execution trust.
+- execution debt:
+  - fresh requirement-driven jobs are still failing with `BackoffLimitExceeded`.
+  - sampled job logs show a missing Huly helper file inside the runtime image or workspace.
+
+Interpretation:
+
+- the current March 20 architecture stack solved a large part of the authority-shaping problem;
+- it did not yet solve runtime executability as a first-class control-plane subject;
+- rollout can therefore look healthy while stage execution is still non-admissible.
+
+### Source architecture and high-risk modules
+
+The code paths match the live contradiction.
+
+- `services/jangar/scripts/codex/lib/huly-api-client.ts`
+  - resolves the Huly helper from `../../../../../skills/huly-api/scripts/huly-api.py`;
+  - that path is correct in the repository checkout but still becomes a runtime correctness dependency;
+  - the control plane has no durable record of whether the required helper actually exists in the admitted runtime.
+- `services/jangar/scripts/codex/codex-implement.ts`
+  - resolves the active Huly channel and performs `listChannelMessages(...)` plus `verifyChatAccess(...)` before the
+    rest of the mission flow;
+  - a missing helper therefore becomes a pre-execution hard stop rather than a typed control-plane condition.
+- `services/jangar/src/routes/ready.tsx`
+  - merges namespace execution trust dynamically;
+  - it still answers only readiness, not whether specific execution classes are admissible.
+- `services/jangar/src/server/control-plane-status.ts`
+  - already computes rollout health, database health, watch reliability, dependency quorum, and execution-trust
+    windows;
+  - it does not yet model runtime kits, runtime component availability, or consumer-scoped admission objects.
+
+Current missing tests are architectural:
+
+- no regression proves that a missing mission runtime artifact becomes a typed degraded or blocked admission class
+  before job launch;
+- no regression proves `/ready`, status, and deploy verification share one passport digest;
+- no regression proves serving remains healthy while collaboration-specific or planner-specific execution classes are
+  blocked;
+- no regression proves a repaired runtime kit clears the same passport without manual freeze surgery.
+
+### Database, schema, freshness, and consistency evidence
+
+The database is healthy enough to hold additive runtime-admission state.
+
+- Jangar status reports:
+  - `database.connected=true`
+  - `database.latency_ms=3`
+  - `migration_consistency.applied_count=24`
+  - latest registered and applied migration `20260312_torghut_simulation_control_plane_v2`
+- direct SQL remains intentionally constrained:
+  - `kubectl cnpg psql -n jangar jangar-db -- ...`
+  - fails with `pods/exec is forbidden`
+
+Interpretation:
+
+- this is not a migration-drift problem;
+- it is an additive-persistence problem on top of a healthy control-plane database;
+- the correct move is to persist runtime-admission truth, not to widen live database access.
+
+## Problem statement
+
+Jangar still has five resilience-critical gaps:
+
+1. authority truth and runtime executability are still separate concerns, even though launch safety depends on both;
+2. a job can fail because a required helper, binary, secret mount, or workspace path is missing without that debt
+   becoming a first-class control-plane object;
+3. `/ready` can be healthy while stage launchers still admit workloads into broken runtimes, or vice versa;
+4. stale freeze debt and missing runtime artifacts are both currently flattened into generic degraded or blocked
+   reducers;
+5. deploy verification cannot yet prove that the rollout it is blessing also contains the runtime kit digests required
+   by plan, implement, verify, and Torghut consumers.
+
+That is not acceptable for the next six months of autonomous execution. The control plane needs to know not only
+whether a decision is authoritative, but whether the runtime that will execute that decision is actually complete.
+
+## Alternatives considered
+
+### Option A: patch the missing path and add more smoke tests
+
+Summary:
+
+- fix the Huly helper path in the runtime;
+- add a targeted smoke job and leave the broader architecture unchanged.
+
+Pros:
+
+- fastest local fix;
+- minimal schema change;
+- directly addresses the observed March 20 error.
+
+Cons:
+
+- still treats runtime completeness as a bug class, not a first-class contract;
+- the next missing file, secret mount, or binary will fail the same way;
+- does not align readiness, deploy verification, and stage launchers.
+
+Decision: rejected.
+
+### Option B: extend authority sessions with more runtime reason codes
+
+Summary:
+
+- keep the current authority-session and recovery-ledger shape;
+- add runtime artifact failures as more reason codes on the same compiled objects.
+
+Pros:
+
+- smaller delta than a new runtime layer;
+- reuses existing session and attestation work.
+
+Cons:
+
+- still leaves no durable representation of the runtime surface itself;
+- forces launch-critical execution details into a broad status reducer;
+- keeps consumer-specific admissibility too implicit.
+
+Decision: rejected.
+
+### Option C: runtime kits plus consumer-scoped admission passports
+
+Summary:
+
+- Jangar compiles durable runtime-kit records for each execution class;
+- a passport compiler joins runtime kits, authority sessions, and recovery cases into consumer-scoped admission
+  passports;
+- every launcher, route, and deploy verifier binds to those passports instead of only broad reducers.
+
+Pros:
+
+- makes runtime completeness a first-class control-plane subject;
+- reduces blast radius because missing collaboration assets do not have to block serving or unrelated execution
+  classes;
+- gives deployers one digest set to verify before promotion;
+- increases future option value for new stage types, workers, and downstream consumers.
+
+Cons:
+
+- adds new tables and compiler work;
+- requires shadow-mode rollout because current routes and launchers dual-read during migration;
+- raises the bar for tests around digest parity and launch refusal semantics.
+
+Decision: selected.
+
+## Decision
+
+Adopt **Option C**.
+
+Jangar will compile runtime kits and consumer-scoped admission passports. Authority remains necessary, but authority is
+not enough. A consumer is admissible only when the required authority session, recovery state, and runtime kit set are
+all current and explicit.
+
+## Architecture
+
+### 1. Runtime-kit catalog
+
+Add additive Jangar persistence:
+
+- `control_plane_runtime_kits`
+  - `runtime_kit_id`
+  - `kit_class` (`serving`, `collaboration`, `plan_worker`, `implement_worker`, `verify_worker`, `torghut_quant`)
+  - `subject_ref`
+  - `image_ref`
+  - `workspace_contract_version`
+  - `component_digest`
+  - `decision` (`healthy`, `degraded`, `blocked`, `unknown`)
+  - `observed_at`
+  - `fresh_until`
+  - `producer_revision`
+- `control_plane_runtime_kit_components`
+  - `runtime_kit_id`
+  - `component_kind` (`python_helper`, `binary`, `workspace_path`, `secret_mount`, `config_file`, `service_url`)
+  - `component_ref`
+  - `required`
+  - `present`
+  - `digest`
+  - `reason_code`
+  - `evidence_ref`
+- `control_plane_runtime_kit_events`
+  - append-only rows for `observed`, `missing`, `repaired`, `expired`, and `superseded`
+
+Rules:
+
+- a runtime kit is the smallest unit that may be admitted for an execution class;
+- missing required components are not only log lines; they are typed kit debt;
+- kit freshness must be explicit because image, workspace, and secret state can drift independently.
+
+### 2. Admission-passport compiler
+
+Add additive Jangar persistence:
+
+- `control_plane_admission_passports`
+  - `admission_passport_id`
+  - `consumer_class` (`serving`, `deploy_verify`, `swarm_plan`, `swarm_implement`, `swarm_verify`, `torghut_probe`,
+    `torghut_live`)
+  - `authority_session_id`
+  - `recovery_case_set_digest`
+  - `runtime_kit_set_digest`
+  - `decision` (`allow`, `degrade`, `hold`, `block`)
+  - `reason_codes_json`
+  - `required_subjects_json`
+  - `required_runtime_kits_json`
+  - `issued_at`
+  - `fresh_until`
+  - `producer_revision`
+- `control_plane_admission_passport_subjects`
+  - `admission_passport_id`
+  - `subject_kind`
+  - `subject_ref`
+  - `required`
+  - `decision`
+  - `evidence_ref`
+
+Rules:
+
+- `/ready` must cite the current `serving` passport, not only merged execution trust;
+- plan, implement, and verify launchers must cite their stage-specific passport before creating work;
+- deploy verification must refuse promotion when the rollout image digest and required runtime-kit digest set do not
+  match the admitted passport;
+- Torghut typed consumers must cite a passport that includes both authority and runtime subjects.
+
+### 3. Producer model
+
+Runtime kits should be compiled from least-privilege producers, not a new monolith.
+
+- image producer:
+  - reports which baked helpers, binaries, and default workspace assets exist in the deployed image;
+- workspace producer:
+  - reports required repo paths, staged scripts, and writable mount layout for active stage workers;
+- dependency producer:
+  - reports required service URLs, secrets, and external helper availability;
+- compiler:
+  - joins those facts with authority-session and recovery-ledger state to issue passports.
+
+This keeps runtime completeness auditable without broadening one service account into a cluster-wide super-reader.
+
+### 4. Immediate implementation scope
+
+Engineer stage should land the smallest credible slice:
+
+1. migrations for runtime-kit and admission-passport tables;
+2. a runtime-kit compiler for Huly helper presence, Python binary, workspace path contract, and required launcher
+   config;
+3. status payload additions:
+   - `runtime_kits`
+   - `admission_passports`
+   - `serving_passport_id`
+4. launcher behavior:
+   - cross-swarm Huly steps fail as `passport=blocked` with missing-component evidence instead of opaque retries;
+5. regression tests across:
+   - `services/jangar/scripts/codex/lib/huly-api-client.ts`
+   - `services/jangar/scripts/codex/codex-implement.ts`
+   - `services/jangar/src/routes/ready.tsx`
+   - `services/jangar/src/server/control-plane-status.ts`
+
+### 5. Failure-mode reduction
+
+This design removes four current failure classes:
+
+- missing runtime helper becomes a typed `runtime_kit_component_missing` debt instead of only a pod log;
+- serving readiness no longer has to block because a collaboration-only kit is missing;
+- deploy verification gains a deterministic check for runtime completeness instead of inferring it from post-rollout
+  job outcomes;
+- stale freeze and runtime-kit debt can be tracked independently, which reduces accidental global blockage.
+
+## Validation and rollout contract
+
+### Engineer acceptance gates
+
+The engineer stage is complete only when all of these are true:
+
+1. a failing fixture with missing `/app/skills/huly-api/scripts/huly-api.py` produces a blocked `collaboration`
+   runtime kit and a blocked `swarm_plan` or requirement passport;
+2. `/ready` includes the serving passport id and remains HTTP `200` when only non-serving kits are degraded;
+3. status includes the same passport digest set cited by deploy verification;
+4. targeted regression coverage proves missing runtime assets are surfaced before or at launch admission, not only
+   after job retries.
+
+### Deployer acceptance gates
+
+The deployer stage is complete only when all of these are true:
+
+1. shadow mode compares legacy readiness and status decisions with passport decisions for at least one full rollout
+   window;
+2. rollout verification confirms the promoted image digest matches the admitted runtime-kit set for `serving`,
+   `swarm_plan`, and `swarm_implement`;
+3. fresh requirement jobs either run successfully or fail once with a typed passport refusal, not repeated opaque
+   backoff;
+4. Huly collaboration checks succeed under the admitted collaboration kit on the promoted revision.
+
+## Rollout plan
+
+1. Land migrations and compiler in shadow mode.
+2. Publish runtime kits and passports into status without changing launch behavior.
+3. Teach `/ready` and deploy verification to cite passports while keeping the legacy reducer visible for parity.
+4. Flip launchers to require stage passports.
+5. Remove legacy admission paths only after parity is proven and stale-freeze plus runtime-kit debt are independently
+   visible in production.
+
+## Rollback plan
+
+Rollback is required if any of these occur after the cutover:
+
+- serving readiness flips from HTTP `200` to `503` only because a non-serving passport regressed;
+- passport compiler emits `unknown` for the current serving image digest;
+- launchers begin refusing valid work because runtime-kit freshness or digest comparison is unstable;
+- deploy verification cannot prove parity between rollout digest and serving or stage passports.
+
+Rollback path:
+
+- keep the new tables;
+- disable passport enforcement and revert routes and launchers to legacy reducers;
+- preserve runtime-kit observation so evidence is not lost while enforcement is rolled back.
+
+## Risks and open questions
+
+- runtime kits must not become an excuse to centralize too much image or build logic inside Jangar;
+- freshness windows must be tuned carefully or runtime-kit expiry will create noisy false negatives;
+- some runtime subjects will remain external and probabilistic; those should degrade narrowly, not force portfolio-wide
+  blockage;
+- the compiler should not trust a repo path alone when the live workload executes from a different image or mount
+  layout.

--- a/docs/torghut/design-system/current-source-of-truth-and-priority-guide-2026-03-09.md
+++ b/docs/torghut/design-system/current-source-of-truth-and-priority-guide-2026-03-09.md
@@ -34,6 +34,8 @@ If the question is "what should I trust right now?", start here:
    - `docs/torghut/design-system/v1/historical-dataset-simulation.md`
    - `docs/torghut/design-system/v1/trading-day-simulation-automation.md`
 3. current autonomy/promotion contract source of truth:
+   - `docs/agents/designs/61-jangar-runtime-kits-and-admission-passports-contract-2026-03-20.md`
+   - `docs/torghut/design-system/v6/60-torghut-hypothesis-passports-and-capability-quote-auction-contract-2026-03-20.md`
    - `docs/torghut/design-system/v6/06-production-rollout-operations-and-governance.md`
    - `docs/torghut/design-system/v6/08-profitability-research-validation-execution-governance-system.md`
    - `docs/torghut/design-system/v6/27-live-hypothesis-ledger-and-capital-allocation-contract-2026-03-06.md`
@@ -83,76 +85,82 @@ If the question is "what should I trust right now?", start here:
 
 The current highest-priority work is:
 
-1. retire stale freeze and rollout debt into a durable recovery ledger with consumer-scoped attestations in
+1. make Jangar runtime completeness and consumer-scoped stage admission explicit through runtime kits and admission
+   passports in
+   `docs/agents/designs/61-jangar-runtime-kits-and-admission-passports-contract-2026-03-20.md`;
+2. turn Torghut lane gating into hypothesis passports and a capability quote auction in
+   `docs/torghut/design-system/v6/60-torghut-hypothesis-passports-and-capability-quote-auction-contract-2026-03-20.md`;
+3. retire stale freeze and rollout debt into a durable recovery ledger with consumer-scoped attestations in
    `docs/agents/designs/60-jangar-recovery-ledger-and-consumer-attestation-contract-2026-03-20.md`;
-2. replace route-time lane gating with lane balance sheets and dataset-seat auctions in
+4. replace route-time lane gating with lane balance sheets and dataset-seat auctions in
    `docs/torghut/design-system/v6/59-torghut-lane-balance-sheet-and-dataset-seat-auction-contract-2026-03-20.md`;
-3. replace request-time control-plane truth with authority sessions and rollout leases in
+5. replace request-time control-plane truth with authority sessions and rollout leases in
    `docs/agents/designs/59-jangar-authority-session-bus-and-rollout-lease-contract-2026-03-20.md`;
-4. turn Jangar authority capsules into journaled, replayable cell-scoped truth in
+6. turn Jangar authority capsules into journaled, replayable cell-scoped truth in
    `docs/agents/designs/58-jangar-authority-journals-bounded-recovery-cells-and-replay-contract-2026-03-20.md`;
-5. repair cutover from broad status reduction to durable authority capsules and freeze-expiry workflows in
+7. repair cutover from broad status reduction to durable authority capsules and freeze-expiry workflows in
    `docs/agents/designs/58-jangar-authority-capsule-cutover-and-freeze-expiry-repair-contract-2026-03-20.md`;
-6. compile small Jangar authority capsules and reconcile stale swarm-freeze truth through
+8. compile small Jangar authority capsules and reconcile stale swarm-freeze truth through
    `docs/agents/designs/57-jangar-authority-capsules-freeze-reconciliation-and-consumer-slo-contract-2026-03-20.md`;
-7. replace route-local promotion truth with compiled admission receipts and rollout shadow in
+9. replace route-local promotion truth with compiled admission receipts and rollout shadow in
    `docs/agents/designs/54-jangar-admission-receipts-rollout-shadow-and-anti-entropy-reconciliation-2026-03-20.md`;
-8. collapse swarm freeze, stage failure, rollout health, and downstream freshness into one admission artifact through
+10. collapse swarm freeze, stage failure, rollout health, and downstream freshness into one admission artifact through
    `docs/agents/designs/55-jangar-rollout-fact-receipts-and-swarm-freeze-parity-2026-03-20.md`;
-9. bind every Jangar consumer to typed capability receipts and digest parity in
+11. bind every Jangar consumer to typed capability receipts and digest parity in
    `docs/agents/designs/56-jangar-capability-receipts-and-consumer-binding-contract-2026-03-20.md`;
-10. separate serving readiness from promotion authority through durable capsules and readiness classes in
+12. separate serving readiness from promotion authority through durable capsules and readiness classes in
     `docs/agents/designs/57-jangar-authority-capsules-and-readiness-class-separation-2026-03-20.md`;
-11. allocate Torghut capital through authority-session-bound profit cohorts and bounded freshness insurance in
+13. allocate Torghut capital through authority-session-bound profit cohorts and bounded freshness insurance in
     `docs/torghut/design-system/v6/58-torghut-profit-cohort-auction-and-freshness-insurance-contract-2026-03-20.md`;
-12. turn Torghut profit clocks into reserve records with forecast-calibration escrow and probe-class capital in
+14. turn Torghut profit clocks into reserve records with forecast-calibration escrow and probe-class capital in
     `docs/torghut/design-system/v6/57-torghut-profit-reserves-forecast-calibration-escrow-and-probe-auction-2026-03-20.md`;
-13. cut Torghut over from generic status-route gating to typed profit clocks and regime auctions in
+15. cut Torghut over from generic status-route gating to typed profit clocks and regime auctions in
     `docs/torghut/design-system/v6/57-torghut-profit-clock-cutover-and-regime-auction-contract-2026-03-20.md`;
-14. replace ephemeral live-capital answers with capital leases and profit-trial firebreaks in
+16. replace ephemeral live-capital answers with capital leases and profit-trial firebreaks in
     `docs/torghut/design-system/v6/53-torghut-capital-leases-and-profit-trial-firebreaks-2026-03-20.md`;
-15. allocate and revoke live capital through sleeve-scoped lease receipts and falsification events in
+17. allocate and revoke live capital through sleeve-scoped lease receipts and falsification events in
     `docs/torghut/design-system/v6/54-torghut-capital-lease-receipts-and-profit-falsification-ledger-2026-03-20.md`;
-16. settle Torghut hypothesis capital through lane capability leases and typed Jangar endpoint contracts in
+18. settle Torghut hypothesis capital through lane capability leases and typed Jangar endpoint contracts in
     `docs/torghut/design-system/v6/55-torghut-hypothesis-settlement-exchange-and-lane-capability-leases-2026-03-20.md`;
-17. replace URL-derived authority with typed capability leases and lane-local profit clocks in
+19. replace URL-derived authority with typed capability leases and lane-local profit clocks in
     `docs/torghut/design-system/v6/56-torghut-capability-leases-and-profit-clocks-2026-03-20.md`;
-18. move from coarse gate payloads to durable profit clocks and a lane-aware capital auction in
+20. move from coarse gate payloads to durable profit clocks and a lane-aware capital auction in
     `docs/torghut/design-system/v6/56-torghut-profit-clocks-and-capital-allocation-auction-2026-03-20.md`;
-19. make unknown or contradictory rollout evidence veto-capable through witness mirrors and promotion covenants in
+21. make unknown or contradictory rollout evidence veto-capable through witness mirrors and promotion covenants in
     `docs/agents/designs/54-jangar-witness-mirror-quorum-and-promotion-veto-2026-03-20.md`;
-20. make non-observe capital depend on a single cross-plane profit certificate plus lane-scoped options auth/bootstrap
+22. make non-observe capital depend on a single cross-plane profit certificate plus lane-scoped options auth/bootstrap
     isolation in
     `docs/torghut/design-system/v6/53-torghut-cross-plane-profit-certificate-veto-and-options-auth-isolation-2026-03-20.md`;
-21. replace whole-swarm failure coupling with execution cells and collaboration failover in
+23. replace whole-swarm failure coupling with execution cells and collaboration failover in
     `docs/agents/designs/51-jangar-control-plane-execution-cells-and-collaboration-failover-2026-03-19.md`;
-22. make rollout truth depend on rollout-epoch acknowledgement and segment circuit breakers in
+24. make rollout truth depend on rollout-epoch acknowledgement and segment circuit breakers in
     `docs/agents/designs/52-jangar-rollout-epoch-witness-and-segment-circuit-breakers-2026-03-19.md`;
-23. force submission parity and options bootstrap escrow through the Torghut plan contract in
+25. force submission parity and options bootstrap escrow through the Torghut plan contract in
     `docs/torghut/design-system/v6/50-torghut-submission-parity-council-and-options-bootstrap-escrow-2026-03-19.md`;
-24. force capital-stage decisions through the hypothesis capital governor, promotion-certificate, and data-quorum
+26. force capital-stage decisions through the hypothesis capital governor, promotion-certificate, and data-quorum
     contract in `docs/agents/designs/50-torghut-hypothesis-capital-governor-and-data-quorum-2026-03-19.md`;
-25. make admission truth durable with dependency provenance, consumer acknowledgement, and replayable collaboration in
+27. make admission truth durable with dependency provenance, consumer acknowledgement, and replayable collaboration in
     `docs/agents/designs/53-jangar-dependency-provenance-ledger-and-consumer-acknowledged-admission-2026-03-19.md`;
-26. extend that control plane with the segment-authority-graph and promotion-certificate fail-safe in
+28. extend that control plane with the segment-authority-graph and promotion-certificate fail-safe in
     `docs/agents/designs/52-jangar-segment-authority-graph-and-promotion-certificate-fail-safe-2026-03-19.md`;
-27. make non-shadow capital depend on expiring profit reservations, schema fitness, and simulation slot ownership in
+29. make non-shadow capital depend on expiring profit reservations, schema fitness, and simulation slot ownership in
     `docs/torghut/design-system/v6/51-torghut-profit-reservations-schema-witness-and-simulation-slot-ledger-2026-03-19.md`;
-28. wire Torghut scheduler and status through the segment-firebreak handoff in
+30. wire Torghut scheduler and status through the segment-firebreak handoff in
     `docs/torghut/design-system/v6/51-torghut-promotion-certificate-and-segment-firebreak-handoff-2026-03-19.md`;
-29. make sleeve-level capital, deallocation, and evidence decay explicit in
+31. make sleeve-level capital, deallocation, and evidence decay explicit in
     `docs/torghut/design-system/v6/52-torghut-profit-sleeves-segment-scoped-deallocation-and-evidence-decay-2026-03-19.md`;
-30. keep producer-authored freshness and proof bundles active by continuing the ledger direction defined in
+32. keep producer-authored freshness and proof bundles active by continuing the ledger direction defined in
     `docs/torghut/design-system/v6/39-freshness-ledger-and-hypothesis-proof-mesh-2026-03-14.md`;
-31. isolate control-plane failure domains with rollout-safe gates in
+33. isolate control-plane failure domains with rollout-safe gates in
     `docs/torghut/design-system/v6/40-control-plane-resilience-and-safer-rollout-for-torghut-quant-2026-03-15.md`;
-32. retain hypothesis-specific profitability guardrails from
+34. retain hypothesis-specific profitability guardrails from
     `docs/torghut/design-system/v6/41-torghut-quant-profitability-and-guardrail-architecture-2026-03-15.md`,
     but make them subordinate to fresh data quorum, immutable evidence bundles, and lease revocation;
-33. execute the merged control-plane/profitability program with the March 15-16 base, the March 19 authority stack,
+35. execute the merged control-plane/profitability program with the March 15-16 base, the March 19 authority stack,
     and the March 20 readiness-class, session, journal, cutover, reserve, witness-quorum, admission-receipt,
     fact-receipt, binding-contract, profit-certificate, capital-lease, falsification-ledger, settlement-exchange,
-    authority-capsule, profit-clock, and profit-cohort contracts layered on top.
+    authority-capsule, runtime-kit, admission-passport, hypothesis-passport, capability-quote-auction, profit-clock,
+    and profit-cohort contracts layered on top.
 
 ## Supporting discover-stage rationale
 
@@ -199,6 +207,8 @@ These are still active contract docs rather than historical snapshots:
 
 - `docs/torghut/design-system/v1/historical-dataset-simulation.md`
 - `docs/torghut/design-system/v1/trading-day-simulation-automation.md`
+- `docs/agents/designs/61-jangar-runtime-kits-and-admission-passports-contract-2026-03-20.md`
+- `docs/torghut/design-system/v6/60-torghut-hypothesis-passports-and-capability-quote-auction-contract-2026-03-20.md`
 - `docs/torghut/design-system/v6/01-beyond-tsmom-system-architecture-and-latency-model.md`
 - `docs/torghut/design-system/v6/04-alpha-discovery-and-autonomous-improvement-pipeline.md`
 - `docs/torghut/design-system/v6/05-evaluation-benchmark-and-contamination-control-standard.md`

--- a/docs/torghut/design-system/v6/60-torghut-hypothesis-passports-and-capability-quote-auction-contract-2026-03-20.md
+++ b/docs/torghut/design-system/v6/60-torghut-hypothesis-passports-and-capability-quote-auction-contract-2026-03-20.md
@@ -1,0 +1,400 @@
+# 60. Torghut Hypothesis Passports and Capability Quote Auction Contract (2026-03-20)
+
+Status: Approved for implementation (`plan`)
+Date: `2026-03-20`
+Owner: Victor Chen (Jangar Engineering)
+Mission: `codex/swarm-jangar-control-plane-plan`
+Swarm impacts:
+
+- `torghut-quant`
+- `jangar-control-plane`
+
+Companion doc:
+
+- `docs/agents/designs/61-jangar-runtime-kits-and-admission-passports-contract-2026-03-20.md`
+
+Extends:
+
+- `59-torghut-lane-balance-sheet-and-dataset-seat-auction-contract-2026-03-20.md`
+- `58-torghut-profit-cohort-auction-and-freshness-insurance-contract-2026-03-20.md`
+- `57-torghut-profit-reserves-forecast-calibration-escrow-and-probe-auction-2026-03-20.md`
+- `56-torghut-capability-leases-and-profit-clocks-2026-03-20.md`
+
+## Executive summary
+
+The decision is to move Torghut from one coarse live-submission gate to per-lane **Hypothesis Passports** priced by a
+durable **Capability Quote Auction**. Torghut should stop flattening mixed Jangar and local evidence into one
+portfolio-wide `observe` answer and instead allocate only the capital class that the evidence can honestly support for
+each hypothesis family.
+
+The reason is visible in the live system on `2026-03-20`:
+
+- `GET http://torghut.torghut.svc.cluster.local/trading/status`
+  - reports `live_submission_gate.allowed=false`
+  - reports `capital_stage="shadow"` and `capital_state="observe"`
+  - reports blocked reasons:
+    - `alpha_readiness_not_promotion_eligible`
+    - `empirical_jobs_not_ready`
+    - `dependency_quorum_block`
+    - `quant_health_fetch_failed`
+    - `live_promotion_disabled`
+  - still resolves `quant_evidence.source_url` from
+    `http://jangar.jangar.svc.cluster.local/api/agents/control-plane/status?...`
+- `GET http://torghut.torghut.svc.cluster.local/readyz`
+  - returns `status="degraded"`
+  - repeats the same quant-evidence fetch failure and shadow capital stage
+- `GET http://jangar.jangar.svc.cluster.local/api/torghut/trading/control-plane/quant/health?account=PA3SX7FYNUTF&window=15m`
+  - returns `status="degraded"`
+  - returns `latestMetricsCount=36`
+  - returns `metricsPipelineLagSeconds=2`
+  - returns `maxStageLagSeconds=95273`
+- `kubectl get pods -n torghut -o wide`
+  - shows the main Torghut revision `2/2 Running`
+  - shows both `torghut-forecast` pods `0/1 Running`
+  - shows both `torghut-forecast-sim` pods `0/1 Running`
+
+The tradeoff is more persistence, more price-setting logic, and stricter guardrails around probe capital. I am keeping
+that trade because the expensive failure mode is no longer raw safety. It is lost option value: the system blocks the
+entire lane stack even when typed quant evidence and some non-forecast hypotheses still have usable information.
+
+## Mission inputs and success criteria
+
+Observed mission inputs:
+
+- repository: `proompteng/lab`
+- base: `main`
+- head: `codex/swarm-jangar-control-plane-plan`
+- swarmName: `jangar-control-plane`
+- swarmStage: `plan`
+- objective: improve Jangar resilience and Torghut profitability with merged architecture outputs
+
+This artifact succeeds when:
+
+1. every hypothesis lane binds to one durable passport that cites required Jangar admission passports and local
+   evidence quotes;
+2. wrong-endpoint authority becomes structurally impossible for quant-health and similar typed capabilities;
+3. degraded forecast or market-context evidence can reduce only the affected capital class instead of forcing a global
+   portfolio stop;
+4. profitability hypotheses and guardrails are measurable enough to reject the design if it does not outperform the
+   current global-block baseline in paper mode.
+
+## Assessment snapshot
+
+### Cluster and runtime evidence
+
+Current Torghut runtime truth is mixed, not absent.
+
+- the main trading service is running and answering requests;
+- quant-health authority from Jangar is degraded but non-empty;
+- forecast infrastructure is not ready;
+- the live-submission gate still collapses those mixed facts into one shadow or observe answer.
+
+Interpretation:
+
+- Torghut already fails closed, which is safe;
+- it does not yet preserve future option value when some capability classes remain usable;
+- the wrong-endpoint fallback for quant evidence proves the current gate is still too path-centric and too coarse.
+
+### Source architecture and high-risk modules
+
+The code paths explain why the portfolio still over-blocks.
+
+- `services/torghut/app/trading/submission_council.py`
+  - `resolve_quant_health_url()` still derives authority from configured URL families;
+  - `build_live_submission_gate_payload(...)` still settles one top-level gate for all lanes;
+  - the current payload chooses one active capital stage rather than a lane-scoped passport set.
+- `services/torghut/app/trading/hypotheses.py`
+  - `JangarDependencyQuorumStatus` still reduces upstream truth to `decision`, `reasons`, and `message`;
+  - runtime hypothesis summaries still compute coarse `capital_stage` buckets from shared dependency status.
+- `services/torghut/app/trading/scheduler/pipeline.py`
+  - caches and reuses one live-submission gate;
+  - the scheduler therefore remains coupled to the same coarse gate semantics exposed by status routes.
+- `services/torghut/app/main.py`
+  - `/readyz` and `/trading/status` both project the shared gate;
+  - there is still no durable per-hypothesis passport id bridging runtime and status.
+
+Current missing tests are architectural:
+
+- no regression proves per-lane passport ids are shared by scheduler, `/readyz`, and `/trading/status`;
+- no regression proves a degraded forecast cluster only clips forecast-dependent capital classes;
+- no regression proves wrong-endpoint quant authority is rejected even when the fetched payload looks superficially
+  valid;
+- no regression proves the auction cannot allocate more than the configured bounded probe capital when evidence is
+  mixed.
+
+### Database, schema, and consistency evidence
+
+Torghut persistence is ready for additive lane-scoped contracts.
+
+- existing source already persists:
+  - `strategy_hypotheses`
+  - `strategy_hypothesis_metric_windows`
+  - `strategy_capital_allocations`
+  - `strategy_promotion_decisions`
+- runtime health says the service can still read and project trading state;
+- direct CNPG SQL remains intentionally constrained from this worker, so the design should rely on additive application
+  persistence rather than wider database privileges.
+
+Interpretation:
+
+- the missing primitive is not another global gate bit;
+- it is one durable passport and pricing layer between Jangar admission truth, local evidence quality, and capital
+  allocation.
+
+## Problem statement
+
+Torghut still has five profitability-critical gaps:
+
+1. it resolves critical upstream capability truth from URL families instead of one typed upstream passport;
+2. it settles one coarse live-submission gate for many heterogeneous hypothesis families;
+3. forecast or market-context degradation still destroys too much option value because the gate does not price
+   capability quality per lane;
+4. scheduler, `/readyz`, and `/trading/status` can remain aligned only by reusing the same coarse runtime function,
+   not by citing one durable passport id;
+5. there is no measurable mechanism for testing whether bounded degraded-mode allocation improves paper profitability
+   without violating drawdown and freshness guardrails.
+
+That is safe enough to avoid a blow-up. It is not a profitable six-month control system.
+
+## Alternatives considered
+
+### Option A: keep the global gate and only remove the wrong endpoint fallback
+
+Summary:
+
+- require the typed quant-health route;
+- preserve the rest of the current live-submission gate structure.
+
+Pros:
+
+- smallest implementation delta;
+- removes one concrete correctness bug quickly.
+
+Cons:
+
+- still over-blocks the whole portfolio on mixed evidence;
+- still leaves scheduler and route parity dependent on one coarse gate function;
+- does not create measurable degraded-mode profitability experiments.
+
+Decision: rejected.
+
+### Option B: move final capital truth into Jangar
+
+Summary:
+
+- Jangar would issue final lane capital eligibility and Torghut would mostly execute it.
+
+Pros:
+
+- simple top-level authority story;
+- fewer Torghut-local policy objects.
+
+Cons:
+
+- couples infrastructure authority to trading-local economics;
+- increases blast radius from Jangar mistakes;
+- reduces future option value for Torghut experimentation and lane-specific alpha policies.
+
+Decision: rejected.
+
+### Option C: hypothesis passports plus capability quote auction
+
+Summary:
+
+- Jangar admission passports become one upstream input, not the entire answer;
+- Torghut settles per-hypothesis passports that price local and upstream capability quality;
+- a quote auction allocates bounded probe or canary capital only to passports whose guardrails permit it.
+
+Pros:
+
+- makes lane-local degradation explicit;
+- preserves strict global safety while unlocking bounded degraded-mode learning;
+- gives scheduler and status surfaces one durable passport id to share;
+- creates measurable, falsifiable profitability hypotheses.
+
+Cons:
+
+- adds persistence and pricing logic;
+- requires careful rollout because overly optimistic quote math could leak capital;
+- demands explicit experiment gates and rollback rules.
+
+Decision: selected.
+
+## Decision
+
+Adopt **Option C**.
+
+Torghut will settle lane-scoped hypothesis passports and price them through a capability quote auction. Capital can
+move only through those passports, not directly from coarse gate payloads or path-derived upstream truth.
+
+## Architecture
+
+### 1. Hypothesis-passport ledger
+
+Add additive Torghut persistence:
+
+- `hypothesis_passports`
+  - `hypothesis_passport_id`
+  - `hypothesis_id`
+  - `lane_id`
+  - `account_label`
+  - `jangar_admission_passport_id`
+  - `required_capabilities_json`
+  - `decision` (`block`, `observe`, `probe`, `canary`, `live`)
+  - `reason_codes_json`
+  - `evidence_digest`
+  - `issued_at`
+  - `fresh_until`
+  - `rollback_required`
+- `hypothesis_passport_capabilities`
+  - `hypothesis_passport_id`
+  - `capability_kind` (`quant_health`, `market_context`, `forecast_calibration`, `empirical_jobs`, `feature_coverage`,
+    `execution_trust`)
+  - `required`
+  - `quote_id`
+  - `decision`
+  - `evidence_ref`
+
+Rules:
+
+- scheduler, `/readyz`, and `/trading/status` must all cite the same passport id for the same lane and account;
+- no hypothesis may advance capital without a fresh upstream Jangar admission passport and fresh local evidence quotes;
+- wrong-endpoint upstream evidence is invalid even if the returned payload happens to parse.
+
+### 2. Capability quote book
+
+Add additive Torghut persistence:
+
+- `capability_quotes`
+  - `quote_id`
+  - `capability_kind`
+  - `subject_ref`
+  - `source_kind` (`jangar_passport`, `forecast_runtime`, `market_context`, `empirical_jobs`)
+  - `quality_score`
+  - `confidence_score`
+  - `fresh_until`
+  - `max_capital_class` (`block`, `observe`, `probe`, `canary`, `live`)
+  - `reason_codes_json`
+  - `evidence_digest`
+  - `producer_revision`
+- `capability_quote_events`
+  - immutable history for `issued`, `expired`, `repriced`, `revoked`
+
+Rules:
+
+- quotes price capability quality, not direct trading alpha;
+- a degraded but fresh quote may still support bounded `probe` capital;
+- a stale or unknown quote may not support anything above `observe`.
+
+### 3. Capability quote auction
+
+The auction is intentionally narrow.
+
+- Inputs:
+  - fresh hypothesis passports;
+  - bounded probe budget;
+  - recent realized slippage, fill rate, and drawdown;
+  - quote quality and confidence.
+- Output:
+  - per-lane `allocated_capital_class`;
+  - optional `probe_budget_bps`;
+  - `next_reprice_at`;
+  - `kill_switch_reason` when the auction rejects all candidates.
+
+Hard guardrails:
+
+- total degraded-mode probe capital stays below a fixed percentage of paper or shadow risk budget;
+- any stale or unknown upstream Jangar passport forces `observe`;
+- any drawdown or slippage breach bypasses the auction and forces `observe` or `block`;
+- options or forecast-dependent lanes may not borrow capability from unrelated lanes.
+
+### 4. Measurable profitability hypotheses
+
+This design should be rejected if these hypotheses do not hold in paper mode:
+
+1. Passport precision hypothesis:
+   - lanes whose required capabilities remain healthy should maintain or improve decision throughput relative to the
+     current global-block baseline.
+   - measure: `decision_count`, `eligible_lane_count`, and `suppressed_reason_mix`.
+2. Bounded degraded-mode learning hypothesis:
+   - allowing `probe` capital only for lanes with fresh degraded-but-usable quotes should improve evidence generation
+     without materially worsening simulated or paper drawdown.
+   - measure: `probe_capital_pnl_bps`, `max_probe_drawdown_bps`, `probe_fill_rate`, `quote_expiry_cancellations`.
+3. Authority-parity hypothesis:
+   - scheduler, `/readyz`, and `/trading/status` should agree on the active passport id and capital class for every
+     lane.
+   - measure: `passport_parity_rate`, target `>= 99.9%`.
+
+### 5. Immediate implementation scope
+
+Engineer stage should land the smallest credible slice:
+
+1. reject wrong-endpoint quant authority when the source URL is not the typed quant-health surface;
+2. persist capability quotes for:
+   - `quant_health`
+   - `forecast_calibration`
+   - `empirical_jobs`
+3. persist one hypothesis passport per lane and account;
+4. teach scheduler, `/readyz`, and `/trading/status` to cite the same passport id;
+5. add a bounded `probe` capital class in shadow mode only.
+
+### 6. Failure-mode reduction and profit upside
+
+This design removes three current profit leaks:
+
+- generic control-plane status can no longer masquerade as quant authority;
+- forecast degradation can deallocate only forecast-dependent lanes instead of the whole portfolio;
+- mixed evidence can still produce bounded, measurable learning instead of guaranteed inactivity.
+
+## Validation and rollout contract
+
+### Engineer acceptance gates
+
+The engineer stage is complete only when all of these are true:
+
+1. the wrong-endpoint quant-health fallback is rejected by passport compilation;
+2. scheduler, `/readyz`, and `/trading/status` expose the same `hypothesis_passport_id` for a test lane;
+3. a degraded-but-fresh quant quote can support `probe` but not `canary` or `live`;
+4. a stale or missing Jangar admission passport forces `observe` or `block`;
+5. regression tests cover per-lane capital isolation and auction budget caps.
+
+### Deployer acceptance gates
+
+The deployer stage is complete only when all of these are true:
+
+1. passport and quote compilation runs in shadow mode with parity telemetry before capital behavior changes;
+2. bounded `probe` capital is enabled only for paper or explicitly shadow-scoped accounts first;
+3. daily verification confirms no lane exceeded the degraded-mode probe budget and no stale passport was used for
+   capital allocation;
+4. quote or passport drift automatically reverts affected lanes to `observe`.
+
+## Rollout plan
+
+1. Land quote and passport tables plus shadow-mode compiler.
+2. Reject wrong-endpoint authority immediately.
+3. Emit passport ids in scheduler and status surfaces without changing capital behavior.
+4. Enable bounded `probe` capital for paper mode only.
+5. Promote to broader use only if the measurable hypotheses beat the current baseline and guardrails remain clean.
+
+## Rollback plan
+
+Rollback is required if any of these occur:
+
+- a lane receives `probe` or higher capital with a stale upstream passport;
+- quote-parity or passport-parity drops below the agreed floor;
+- degraded-mode probe capital exceeds the configured cap;
+- drawdown or slippage metrics worsen beyond the planned guardrail relative to the global-block baseline.
+
+Rollback path:
+
+- keep quote and passport observation tables;
+- disable auction-driven capital and fall back to the current global gate;
+- preserve all emitted quotes and passports so the failed rollout is diagnosable and replayable.
+
+## Risks and open questions
+
+- quote math must remain conservative or the system will learn the wrong lesson from degraded data;
+- too many capability kinds would turn the auction into an opaque optimizer; the first slice should stay small;
+- lane manifests must declare required capabilities explicitly or the passport layer will inherit today’s ambiguity in
+  a new form;
+- profitability must be judged on evidence generation and risk-adjusted outcomes, not only raw decision count.

--- a/docs/torghut/design-system/v6/60-torghut-hypothesis-passports-and-profit-guardrail-admission-contract-2026-03-20.md
+++ b/docs/torghut/design-system/v6/60-torghut-hypothesis-passports-and-profit-guardrail-admission-contract-2026-03-20.md
@@ -1,0 +1,409 @@
+# 60. Torghut Hypothesis Passports and Profit Guardrail Admission Contract (2026-03-20)
+
+Status: Approved for implementation (`plan`)
+Date: `2026-03-20`
+Owner: Victor Chen (Jangar Engineering)
+Mission: `codex/swarm-jangar-control-plane-plan`
+Swarm impacts:
+
+- `jangar-control-plane`
+- `torghut-quant`
+
+Companion doc:
+
+- `docs/agents/designs/61-jangar-runtime-kit-ledger-and-execution-class-admission-contract-2026-03-20.md`
+
+Extends:
+
+- `59-torghut-lane-balance-sheet-and-dataset-seat-auction-contract-2026-03-20.md`
+- `58-torghut-profit-cohort-auction-and-freshness-insurance-contract-2026-03-20.md`
+- `55-torghut-hypothesis-settlement-exchange-and-lane-capability-leases-2026-03-20.md`
+
+## Executive summary
+
+The decision is to make every profitability decision depend on a durable **Hypothesis Passport** and a
+**Profit Guardrail Admission**. Torghut will stop treating fresh quant metrics, stale market-context evidence, and
+failing simulation history as one blended readiness impression. Each tradeable hypothesis will instead prove the exact
+dataset seat, execution admission, simulation proof, and guardrail state that authorized it.
+
+The reason is visible in live data on `2026-03-20`:
+
+- `torghut_control_plane.quant_metrics_latest`
+  - `504` rows
+  - `latest_as_of=2026-03-20T22:40:11.868Z`
+- `torghut_control_plane.quant_alerts`
+  - `29` rows with `1` still open
+- `torghut_control_plane.quant_pipeline_health`
+  - `9,582,819` rows total
+  - `3,195,032` failing rows overall
+  - last-hour sample still shows `ingestion` entirely `ok=false`
+- `torghut_market_context_snapshots`
+  - only `25` rows
+  - `latest_as_of=2026-03-16T19:36:22.853Z`
+- `torghut_market_context_runs`
+  - `11` nonterminal rows
+  - one row still `running` from `2026-03-11`
+- `torghut_control_plane.simulation_runs`
+  - `58` rows total with `40` in `failed` status
+  - latest updates stop at `2026-03-19T10:08:32.162Z`
+- `torghut_control_plane.simulation_lane_leases`
+  - `4` rows
+  - all lanes currently `available`, none actively bound to proof work
+
+The tradeoff is more additive state and stricter live-capital rules. I am keeping that trade because the current
+profitability failure mode is false confidence: one fresh surface can look healthy while the market-context and
+simulation evidence required to trust it are already stale.
+
+## Mission inputs and success criteria
+
+Observed mission inputs:
+
+- repository: `proompteng/lab`
+- base: `main`
+- head: `codex/swarm-jangar-control-plane-plan`
+- swarmName: `jangar-control-plane`
+- swarmStage: `plan`
+- objective: improve Jangar resilience and define Torghut profitability architecture with measurable hypotheses and
+  guardrails
+
+This artifact succeeds when:
+
+1. every tradeable Torghut hypothesis can cite one `hypothesis_passport_id`, one `dataset_seat_id`, and one
+   `execution_admission_id`;
+2. stale market context, simulation debt, and quant-ingestion failures clamp only the affected hypotheses instead of
+   flattening all profitability readiness;
+3. `/trading/status`, `/trading/profitability/runtime`, live submission gate payloads, and promotion tooling project
+   the same passport ids;
+4. canary and live capital require explicit guardrail admission that is stricter than diagnostic or probe evaluation.
+
+## Assessment snapshot
+
+### Cluster and control-plane implications
+
+The live Jangar surface can now serve while still carrying degraded execution trust. That is useful for Torghut only if
+Torghut consumes the degradation precisely instead of translating it into broad capital pessimism or optimism.
+
+- Jangar `/ready` is serving with degraded trust rather than hard blocked;
+- requirement jobs still fail on missing Huly runtime assets;
+- `jangar-control-plane` and `torghut-quant` still carry stale freeze debt from March 11, 2026.
+
+Interpretation:
+
+- Torghut needs a profitability contract that can survive bounded Jangar degradation;
+- it also needs a more explicit way to reject stale upstream evidence when the trading hypothesis depends on it.
+
+### Source architecture and high-risk modules
+
+The Torghut runtime still keeps too much profitability truth in route-time composition.
+
+- `services/torghut/app/main.py`
+  - builds `/ready`, `/trading/status`, and `/trading/profitability/runtime` from a mixture of scheduler state,
+    empirical jobs, quant evidence, and live submission gate payloads;
+  - does not project a durable hypothesis-scoped passport object.
+- `services/torghut/app/trading/scheduler/pipeline.py`
+  - composes live submission gate payloads from hypothesis summary, empirical jobs, and quant evidence;
+  - still treats those surfaces as immediate inputs rather than as one persisted profitability contract.
+- `services/torghut/app/trading/submission_council.py`
+  - resolves capital stage and blocking reasons at decision time;
+  - does not bind those decisions to one dataset seat, simulation proof, or Jangar execution admission.
+- `services/torghut/app/trading/empirical_jobs.py`
+  - correctly models freshness and truthfulness per empirical job type;
+  - still stops at job readiness and does not mint a durable hypothesis-scoped profitability object.
+- `services/torghut/app/trading/scheduler/state.py`
+  - contains rich in-memory metrics and counters;
+  - should remain a fast cache and telemetry source, not the long-term authority for profitability admission.
+
+The highest-risk test gaps are now cross-surface:
+
+- no regression test proves a hypothesis stays blocked when market context is stale even though quant metrics remain
+  fresh;
+- no test proves a stale simulation proof clamps live promotion while allowing `observe` or `probe`;
+- no endpoint parity test proves `/trading/status` and `/trading/profitability/runtime` expose the same profitability
+  object ids.
+
+### Data, schema, freshness, and consistency evidence
+
+Torghut already has the additive persistence needed for a stronger contract.
+
+- `torghut_control_plane.quant_metrics_latest`, `quant_alerts`, and `quant_pipeline_health`
+  - provide fresh but mixed quant truth
+- `torghut_market_context_snapshots`, `torghut_market_context_runs`, and `torghut_market_context_evidence`
+  - provide durable market-context lineage, but that lineage is currently stale
+- `torghut_control_plane.simulation_runs`, `simulation_run_events`, `simulation_artifacts`, `dataset_cache`, and
+  `simulation_lane_leases`
+  - provide durable simulation and dataset state, but the latest updates are stale and failure-heavy
+
+Interpretation:
+
+- Torghut does not need a new database;
+- it needs a hypothesis-level object that composes these additive tables into a deterministic profitability answer.
+
+## Problem statement
+
+Torghut still has five profitability-critical gaps:
+
+1. fresh quant metrics can mask stale market-context and simulation evidence;
+2. live submission gate logic still resolves too much profitability truth at request time;
+3. hypothesis-level evidence is not durably bundled into one replayable object;
+4. guardrails do not yet distinguish `observe`, `probe`, `canary`, and `live` with enough hypothesis-specific rigor;
+5. Jangar execution degradation is not yet consumed as an explicit profitability input with bounded blast radius.
+
+That is good enough for dashboards. It is not good enough for live capital.
+
+## Alternatives considered
+
+### Option A: keep dataset seats and lane balance sheets as the final profitability contract
+
+Summary:
+
+- continue the current March 20 direction with dataset seats and lane balance sheets only;
+- let submission and promotion logic read those objects directly.
+
+Pros:
+
+- smallest delta from the latest Torghut plan stack;
+- already grounded in existing simulation and dataset tables.
+
+Cons:
+
+- still leaves hypothesis identity and guardrail state spread across multiple payloads;
+- does not make Jangar execution admission a first-class profitability input;
+- keeps too much live-vs-probe logic in route-time council code.
+
+Decision: rejected.
+
+### Option B: centralize final profitability gating back inside Jangar
+
+Summary:
+
+- let Jangar publish the final tradeability answer for Torghut hypotheses;
+- keep Torghut mostly as an execution engine.
+
+Pros:
+
+- one operator-facing authority surface;
+- less Torghut-side compiler work.
+
+Cons:
+
+- couples platform runtime truth to trading economics too tightly;
+- reduces Torghut-local option value for new research lanes and guardrails;
+- makes a Jangar mistake more expensive than it should be.
+
+Decision: rejected.
+
+### Option C: hypothesis passports plus profit guardrail admissions
+
+Summary:
+
+- Torghut compiles one passport per hypothesis from dataset seats, simulation proofs, market-context evidence, quant
+  health, and Jangar execution admissions;
+- guardrail admission turns that passport into an explicit `observe`, `probe`, `canary`, `live`, or `quarantine`
+  decision.
+
+Pros:
+
+- makes mixed freshness actionable without globalizing it;
+- gives every promotion and rollback one replayable evidence object;
+- keeps platform authority in Jangar and trading economics in Torghut.
+
+Cons:
+
+- adds additive tables and a stricter compiler;
+- requires endpoint parity and shadow rollout before any capital effect;
+- exposes stale profitability debt more plainly than current summary payloads do.
+
+Decision: selected.
+
+## Decision
+
+Adopt **Option C**.
+
+Torghut will compile hypothesis passports and profit guardrail admissions, then bind live submission, profitability
+status, and promotion logic to those durable objects instead of inferring the same decision differently on each route.
+
+## Architecture
+
+### 1. Hypothesis passports
+
+Add additive Torghut tables:
+
+- `hypothesis_passports`
+  - `hypothesis_passport_id`
+  - `hypothesis_id`
+  - `lane_id`
+  - `dataset_seat_id`
+  - `execution_admission_id`
+  - `market_context_ref`
+  - `simulation_proof_ref`
+  - `quant_health_ref`
+  - `empirical_bundle_ref`
+  - `decision_window`
+  - `freshness_budget_seconds`
+  - `passport_class` (`observe`, `probe`, `canary`, `live`)
+  - `status` (`allow`, `degrade`, `block`, `quarantine`)
+  - `reason_codes_json`
+  - `issued_at`
+  - `expires_at`
+- `hypothesis_passport_inputs`
+  - `hypothesis_passport_id`
+  - `source_name`
+  - `source_status`
+  - `freshness_seconds`
+  - `truthfulness`
+  - `evidence_ref`
+
+Rules:
+
+- a passport is per hypothesis and per lane, not account-global;
+- fresh quant metrics alone cannot mint a live-class passport;
+- a passport expires when any required evidence surface exceeds its freshness budget.
+
+### 2. Profit guardrail admissions
+
+Add additive tables:
+
+- `profit_guardrail_admissions`
+  - `profit_guardrail_admission_id`
+  - `hypothesis_passport_id`
+  - `capital_stage`
+  - `max_notional`
+  - `max_drawdown_bps`
+  - `max_slippage_bps`
+  - `required_simulation_recency_seconds`
+  - `required_market_context_status`
+  - `required_quant_health_status`
+  - `decision` (`observe`, `probe`, `canary`, `live`, `quarantine`)
+  - `reason_codes_json`
+  - `issued_at`
+  - `expires_at`
+- `profit_guardrail_events`
+  - `profit_guardrail_admission_id`
+  - `event_type`
+  - `before_decision`
+  - `after_decision`
+  - `reason_code`
+  - `evidence_ref`
+  - `created_at`
+
+Rules:
+
+- `observe`
+  - allowed when the hypothesis can still be scored diagnostically
+- `probe`
+  - allowed only with a valid passport and bounded stale debt
+- `canary`
+  - allowed only with fresh market context, fresh simulation proof, healthy quant health, and Jangar promotion
+    admission `allow`
+- `live`
+  - requires repeated positive canary evidence and no open blocking guardrail reason
+- `quarantine`
+  - is automatic when a bound passport expires or a required surface turns invalid
+
+### 3. Source cutover expectations
+
+Implementation scope implied by this contract:
+
+- `services/torghut/app/main.py`
+  - project `hypothesis_passport_id` and `profit_guardrail_admission_id` through `/trading/status` and
+    `/trading/profitability/runtime`
+- `services/torghut/app/trading/scheduler/pipeline.py`
+  - write passports and guardrail admissions after evaluating hypothesis summary, empirical jobs, and quant health
+- `services/torghut/app/trading/submission_council.py`
+  - stop being the final authority for capital stage on its own
+  - consume the latest profit guardrail admission instead
+- `services/torghut/app/trading/empirical_jobs.py`
+  - keep compiling truthful empirical readiness
+  - also emit the references needed to mint or invalidate a hypothesis passport
+- `services/torghut/app/trading/scheduler/state.py`
+  - remain an in-memory telemetry and fast-cache layer only
+
+### 4. Guardrail semantics for the current live evidence
+
+The current `2026-03-20` evidence implies:
+
+- fresh `quant_metrics_latest` may support `observe` or bounded `probe`;
+- stale `torghut_market_context_snapshots` from `2026-03-16` block `canary` and `live`;
+- `40` failed simulation runs and idle lane leases block any passport class that requires fresh replay proof;
+- persistent `ingestion ok=false` in recent `quant_pipeline_health` must become a named guardrail reason, not a
+  detail hidden inside a large payload.
+
+### 5. Validation and acceptance gates
+
+Engineer acceptance gates:
+
+- unit tests for:
+  - passport compilation under fresh quant but stale market context;
+  - guardrail admission under stale simulation proofs;
+  - route parity between `/trading/status` and `/trading/profitability/runtime`
+- replay tests using:
+  - the stale market-context snapshot state from `2026-03-16`
+  - the simulation failure-heavy state from `2026-03-19`
+  - the fresh quant metrics state from `2026-03-20`
+- regression proving Jangar execution admission degradation can clamp only the affected hypotheses
+
+Deployer acceptance gates:
+
+- `probe` capital only on first rollout, with explicit notional caps from guardrail admissions;
+- no `canary` or `live` capital while market context or simulation proof remains stale;
+- rollback or quarantine is automatic when the latest guardrail admission drops below the currently active capital
+  stage.
+
+## Rollout plan
+
+Phase 0. Add tables and shadow writes.
+
+- keep current live submission gate behavior
+- expose passport and guardrail ids in shadow mode only
+
+Phase 1. Endpoint parity.
+
+- `/trading/status` and `/trading/profitability/runtime` both project the latest passport and guardrail ids
+- no capital effect yet
+
+Phase 2. Probe-only adoption.
+
+- live submission council may consume guardrail admissions only for `observe` and tightly capped `probe`
+- stale market context or stale simulation proof clamps probe notional to near zero
+
+Phase 3. Canary cutover.
+
+- canary requires fresh market context, recent simulation proof, healthy quant inputs, and valid Jangar promotion
+  admission
+
+Phase 4. Live promotion.
+
+- live capital requires repeated positive canary history plus a currently `allow` guardrail admission
+
+## Rollback
+
+If the passport compiler or guardrail policy is wrong:
+
+1. set all profit guardrail admissions to `observe`;
+2. stop using guardrail decisions for live or canary capital;
+3. preserve passports and guardrail events for replay and audit;
+4. repair the compiler in shadow mode before re-enabling capital effects.
+
+## Risks and open questions
+
+- Passport TTL that is too short will create avoidable probe churn.
+- Passport TTL that is too long will let stale market-context or simulation evidence linger past credibility.
+- The first implementation increment must decide whether replay jobs or live runtime writes mint the initial passports.
+  I prefer replay-first so profitability guardrails stay empirical before they become promotional.
+
+## Handoff to engineer and deployer
+
+Engineer handoff:
+
+- implement hypothesis-passport and profit-guardrail tables and compiler
+- project passport and guardrail ids through the trading status surfaces
+- add regression coverage for stale market context, stale simulation proof, and bounded probe admission
+
+Deployer handoff:
+
+- require passport and guardrail ids in rollout and promotion evidence
+- keep capital capped at `observe` or `probe` until market-context and simulation freshness are restored
+- treat `quarantine` or expired passports as automatic demotion triggers
+
+The acceptance bar is not "the runtime still has some fresh metrics." The acceptance bar is being able to prove which
+hypothesis had which evidence, which guardrail, and which capital class at the moment it was allowed to act.

--- a/docs/torghut/design-system/v6/index.md
+++ b/docs/torghut/design-system/v6/index.md
@@ -10,6 +10,7 @@
 - Implementation status (strict, core 01-13 docs, source-state refresh `2026-03-09`): `Implemented=7`, `Partial=5`, `Completed=1`
 - Evidence (historical closure): `13-production-gap-closure-master-plan-2026-03-03.md` (Wave 0-6 closure + DoD)
 - Evidence (current next-work priority):
+  - `60-torghut-hypothesis-passports-and-capability-quote-auction-contract-2026-03-20.md`
   - `59-torghut-lane-balance-sheet-and-dataset-seat-auction-contract-2026-03-20.md`
   - `58-torghut-profit-cohort-auction-and-freshness-insurance-contract-2026-03-20.md`
   - `56-torghut-capability-leases-and-profit-clocks-2026-03-20.md`
@@ -32,6 +33,8 @@
 - `51-torghut-profit-reservations-schema-witness-and-simulation-slot-ledger-2026-03-19.md`
 - `51-torghut-promotion-certificate-and-segment-firebreak-handoff-2026-03-19.md`
 - Cross-system source of truth:
+  - `docs/agents/designs/61-jangar-runtime-kits-and-admission-passports-contract-2026-03-20.md`
+  - `60-torghut-hypothesis-passports-and-capability-quote-auction-contract-2026-03-20.md`
   - `docs/agents/designs/60-jangar-recovery-ledger-and-consumer-attestation-contract-2026-03-20.md`
   - `docs/agents/designs/59-jangar-authority-session-bus-and-rollout-lease-contract-2026-03-20.md`
   - `docs/agents/designs/58-jangar-authority-capsule-cutover-and-freeze-expiry-repair-contract-2026-03-20.md`
@@ -131,6 +134,9 @@ Current source-state priority is narrower:
 - `59-torghut-lane-balance-sheet-and-dataset-seat-auction-contract-2026-03-20.md` now turns the March 20 live-state
   evidence into lane-local balance sheets, dataset seats, and explicit freshness-bond probe capital so Torghut can
   allocate scarce capital by evidence quality instead of one route-time blocked answer.
+- `60-torghut-hypothesis-passports-and-capability-quote-auction-contract-2026-03-20.md` now adds the next
+  profitability layer: Torghut must settle one passport per lane, price capability quality explicitly, and allocate
+  only bounded probe capital when degraded-but-usable evidence still exists.
 - `docs/agents/designs/56-jangar-capability-receipts-and-consumer-binding-contract-2026-03-20.md` now defines the
   next control-plane step: typed capability receipts plus explicit binding sets that force `/ready`, deploy
   verification, and Torghut consumers to share the same receipt digest and freshness contract.
@@ -142,6 +148,9 @@ Current source-state priority is narrower:
 - `docs/agents/designs/59-jangar-authority-session-bus-and-rollout-lease-contract-2026-03-20.md` now turns those
   capsules into one durable authority session and rollout-lease contract so `/ready`, status, deploy verification, and
   downstream consumers stop re-deriving control-plane truth per request.
+- `docs/agents/designs/61-jangar-runtime-kits-and-admission-passports-contract-2026-03-20.md` now closes the next
+  remaining gap above sessions and recovery ledgers by making runtime completeness a first-class control-plane subject
+  and binding consumers to passport ids that include both authority truth and executable runtime kits.
 - `docs/agents/designs/54-jangar-witness-mirror-quorum-and-promotion-veto-2026-03-20.md` now turns incomplete rollout
   evidence into a first-class veto by requiring fresh witness mirrors for rollout, stage health, and consumer
   acknowledgement before Jangar may emit promotion-friendly authority.


### PR DESCRIPTION
## Summary

- Add a new Jangar plan-stage architecture contract for runtime kits and admission passports, grounded in the live March 20 stale-freeze and missing Huly helper failure mode.
- Add a Torghut profitability companion that replaces coarse lane gating with hypothesis passports, a capability quote auction, measurable paper-mode hypotheses, and explicit capital guardrails.
- Update the active agents and Torghut design indexes so the new pair becomes part of the current reading path above the March 20 authority-session and recovery-ledger stack.

## Related Issues

None

## Testing

- `git diff --check`
- `rg -n "TODO|TBD|<\\.\\.\\.|\\[\\.\\.\\.\\]" docs/agents/designs/61-jangar-runtime-kits-and-admission-passports-contract-2026-03-20.md docs/torghut/design-system/v6/60-torghut-hypothesis-passports-and-capability-quote-auction-contract-2026-03-20.md docs/agents/README.md docs/torghut/design-system/v6/index.md docs/torghut/design-system/current-source-of-truth-and-priority-guide-2026-03-09.md`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
