### PR TITLE
fix(jangar): align implementation test expectations for release handoff messaging (swarm-torghut-quant-verify)

### DIFF
--- a/docs/agents/runbooks.md
+++ b/docs/agents/runbooks.md
@@ -129,6 +129,9 @@ curl -fsS http://localhost:8080/api/agents/control-plane/status?namespace=agents
 curl -fsS http://localhost:8080/api/agents/control-plane/status?namespace=agents | jq '.workflows'
 curl -fsS http://localhost:8080/api/agents/control-plane/status?namespace=agents | jq '.agentrun_ingestion'
 curl -fsS http://localhost:8080/api/agents/control-plane/status?namespace=agents | jq '.execution_trust'
+curl -fsS http://localhost:8080/api/agents/control-plane/status?namespace=agents | jq '.runtime_kits'
+curl -fsS http://localhost:8080/api/agents/control-plane/status?namespace=agents | jq '.admission_passports'
+curl -fsS http://localhost:8080/ready | jq '{status, serving_passport_id, runtime_kits, admission_passports}'
 kubectl api-resources --api-group=argoproj.io --no-headers || true
 kubectl -n agents get workflows.argoproj.io 2>/dev/null || true
 ```
@@ -143,7 +146,33 @@ Expected outcomes:
 - `execution_trust` is always present and stays `healthy`; if a swarm freeze TTL has expired without
   reconciliation, it reports `freeze expiry unreconciled` as a degraded repair signal while `/ready`
   stays `200` unless execution trust escalates to `blocked` or `unknown`.
+- `runtime_kits` always includes `serving` and `collaboration` classes with stable `runtime_kit_id`,
+  `component_digest`, `decision`, and `reason_codes` fields.
+- `admission_passports` always includes `serving`, `swarm_plan`, `swarm_implement`, and `swarm_verify`
+  consumers, and `/ready.serving_passport_id` matches the `serving` passport from control-plane status.
+- If collaboration is degraded or blocked because a runtime helper is missing, `/ready` stays `200` as
+  long as the `serving` passport is still `allow` or `degrade`; the blocked `swarm_*` passport surfaces
+  the missing component in `reason_codes`.
 - The Argo Workflows resource check returns empty output (no CRD or no workflows).
+
+If a cross-swarm stage refuses launch before Huly initialization, verify the passport debt first:
+
+```bash
+curl -fsS http://localhost:8080/api/agents/control-plane/status?namespace=agents | \
+  jq '.admission_passports[] | select(.consumer_class=="swarm_implement")'
+curl -fsS http://localhost:8080/api/agents/control-plane/status?namespace=agents | \
+  jq '.runtime_kits[] | select(.kit_class=="collaboration")'
+```
+
+Expected outcomes:
+
+- a blocked or held `swarm_implement` passport cites the collaboration `runtime_kit_id` in
+  `required_runtime_kits`.
+- the collaboration runtime kit points at the missing component through `reason_codes` and
+  `components[].evidence_ref` (for example `runtime_kit_component_missing:huly_api_script` with the
+  checked helper paths).
+- rollback is runtime-local: restore the missing helper/config in the admitted image or revert the
+  change that introduced the incompatible runtime contract, then redeploy and re-check the same passport ids.
 
 ## Native workflow e2e proof
 

--- a/docs/jangar/autonomous-codex-end-to-end-design.md
+++ b/docs/jangar/autonomous-codex-end-to-end-design.md
@@ -262,6 +262,9 @@ Minimum fields required to attach enrichment:
   "hulyArtifacts": {
     "channel": "huly://virtual-workers/channels/general",
     "missionId": "00gc1i45",
+    "missionMessageId": "msg-abc123",
+    "missionIssueId": "tracker:issue:abc123",
+    "missionDocumentId": "document:abc123",
     "ownerUpdateMessage": "Update on proompteng/lab#1234: implementation is completed. ...",
     "releaseNote": "Design document: docs/agents/designs/autonomous-jangar-torghut-production-system.md | docs/agents/swarm-end-to-end-runbook.md.\nWhat shipped: ..."
   }

--- a/docs/jangar/autonomous-codex-end-to-end-design.md
+++ b/docs/jangar/autonomous-codex-end-to-end-design.md
@@ -258,9 +258,19 @@ Minimum fields required to attach enrichment:
     "agent": "string",
     "runtime": "string",
     "status": "string"
+  },
+  "hulyArtifacts": {
+    "channel": "huly://virtual-workers/channels/general",
+    "missionId": "00gc1i45",
+    "ownerUpdateMessage": "Update on proompteng/lab#1234: implementation is completed. ...",
+    "releaseNote": "Design document: docs/agents/designs/autonomous-jangar-torghut-production-system.md | docs/agents/swarm-end-to-end-runbook.md.\nWhat shipped: ..."
   }
 }
 ```
+
+When a run is launched from a Huly-backed cross-swarm requirement, `hulyArtifacts.ownerUpdateMessage` and
+`hulyArtifacts.releaseNote` carry the reusable handoff text that release and owner flows can repost without scraping
+chat or mission documents.
 
 ### 9.2 Run-Complete Payload (POST /api/codex/run-complete)
 

--- a/docs/jangar/codex-judge-argo-implementation.md
+++ b/docs/jangar/codex-judge-argo-implementation.md
@@ -203,6 +203,9 @@ Run-complete is the primary trigger for judging; notify only enriches the run co
 "hulyArtifacts": {
 "channel": "huly://virtual-workers/channels/general",
 "missionId": "00gc1i45",
+"missionMessageId": "msg-abc123",
+"missionIssueId": "tracker:issue:abc123",
+"missionDocumentId": "document:abc123",
 "ownerUpdateMessage": "Update on proompteng/lab#1234: implementation is completed. ...",
 "releaseNote": "Design document: docs/agents/designs/autonomous-jangar-torghut-production-system.md | docs/agents/swarm-end-to-end-runbook.md.\nWhat shipped: ..."
 },

--- a/docs/jangar/codex-judge-argo-implementation.md
+++ b/docs/jangar/codex-judge-argo-implementation.md
@@ -200,6 +200,12 @@ Run-complete is the primary trigger for judging; notify only enriches the run co
 "changes": "/workspace/lab/.codex-implementation-changes.tar.gz",
 "notify": "/workspace/lab/.codex-implementation-notify.json"
 },
+"hulyArtifacts": {
+"channel": "huly://virtual-workers/channels/general",
+"missionId": "00gc1i45",
+"ownerUpdateMessage": "Update on proompteng/lab#1234: implementation is completed. ...",
+"releaseNote": "Design document: docs/agents/designs/autonomous-jangar-torghut-production-system.md | docs/agents/swarm-end-to-end-runbook.md.\nWhat shipped: ..."
+},
 "issued_at": "2025-12-28T00:00:00Z"
 }
 

--- a/services/jangar/scripts/codex/__tests__/codex-implement.test.ts
+++ b/services/jangar/scripts/codex/__tests__/codex-implement.test.ts
@@ -149,16 +149,42 @@ const hulyApiMocks = vi.hoisted(() => ({
       missionId: string
       stage?: string
       status?: string
+      channelMessage?: {
+        messageId?: string
+      }
       issue?: {
+        issueId?: string
         issueIdentifier?: string
+        issueTitle?: string
+        issueNumber?: number
+        projectId?: string
+        projectIdentifier?: string
+      }
+      document?: {
+        documentId?: string
+        documentTitle?: string
+        teamspaceId?: string
       }
     }>
   >(async ({ missionId, stage, status, channel }) => ({
     missionId,
     stage,
     status,
+    channelMessage: {
+      messageId: `mission-msg-${missionId.slice(0, 8)}`,
+    },
     issue: {
+      issueId: `issue-${missionId.slice(0, 8)}`,
       issueIdentifier: `MISSION-${missionId.slice(0, 8)}-${channel.includes('TORGHUT') ? 'OK' : 'GEN'}`,
+      issueTitle: 'Mission Issue',
+      issueNumber: 42,
+      projectId: 'project-default',
+      projectIdentifier: 'DefaultProject',
+    },
+    document: {
+      documentId: `doc-${missionId.slice(0, 8)}`,
+      documentTitle: 'Mission Document',
+      teamspaceId: 'PROOMPTENG',
     },
   })),
 }))
@@ -310,8 +336,21 @@ describe('runCodexImplementation', () => {
       missionId,
       stage,
       status,
+      channelMessage: {
+        messageId: `mission-msg-${missionId.slice(0, 8)}`,
+      },
       issue: {
+        issueId: `issue-${missionId.slice(0, 8)}`,
         issueIdentifier: `MISSION-${missionId.slice(0, 8)}-${channel.includes('TORGHUT') ? 'OK' : 'GEN'}`,
+        issueTitle: 'Mission Issue',
+        issueNumber: 42,
+        projectId: 'project-default',
+        projectIdentifier: 'DefaultProject',
+      },
+      document: {
+        documentId: `doc-${missionId.slice(0, 8)}`,
+        documentTitle: 'Mission Document',
+        teamspaceId: 'PROOMPTENG',
       },
     }))
     pushCodexEventsToLokiMock.mockReset()
@@ -905,16 +944,24 @@ describe('runCodexImplementation', () => {
       hulyArtifacts?: {
         latestPeerMessageId?: string
         replyMessageId?: string
+        ownerMessageId?: string
+        missionMessageId?: string
         missionId?: string
         missionStatus?: string
+        missionIssueId?: string
+        missionDocumentId?: string
         ownerUpdateMessage?: string
         releaseNote?: string
       }
     }
     expect(notify.hulyArtifacts?.latestPeerMessageId).toBe('msg-latest')
     expect(notify.hulyArtifacts?.replyMessageId).toBeDefined()
+    expect(notify.hulyArtifacts?.ownerMessageId).toBeDefined()
+    expect(notify.hulyArtifacts?.missionMessageId).toBe('mission-msg-00gc1i45')
     expect(notify.hulyArtifacts?.missionId).toBe('00gc1i45')
     expect(notify.hulyArtifacts?.missionStatus).toBe('completed')
+    expect(notify.hulyArtifacts?.missionIssueId).toBe('issue-00gc1i45')
+    expect(notify.hulyArtifacts?.missionDocumentId).toBe('doc-00gc1i45')
     expect(notify.hulyArtifacts?.ownerUpdateMessage).toContain('Update on owner/repo#42: implementation is completed.')
     expect(notify.hulyArtifacts?.releaseNote).toContain('Rollback path:')
     expect(notify.hulyArtifacts?.releaseNote).toContain('Owner-facing status: merge-ready')
@@ -980,11 +1027,21 @@ describe('runCodexImplementation', () => {
       hulyArtifacts?: {
         ownerUpdateMessage?: string
         releaseNote?: string
+        missionIssueId?: string
+        missionIssueTitle?: string
+        missionProjectIdentifier?: string
+        missionDocumentId?: string
+        missionDocumentTitle?: string
       }
     }
     expect(notify.hulyArtifacts?.ownerUpdateMessage).toContain(
       'Acceptance criteria: create issue/chat/doc artifacts; complete handoff.',
     )
+    expect(notify.hulyArtifacts?.missionIssueId).toBe('issue-00gc1i45')
+    expect(notify.hulyArtifacts?.missionIssueTitle).toBe('Mission Issue')
+    expect(notify.hulyArtifacts?.missionProjectIdentifier).toBe('DefaultProject')
+    expect(notify.hulyArtifacts?.missionDocumentId).toBe('doc-00gc1i45')
+    expect(notify.hulyArtifacts?.missionDocumentTitle).toBe('Mission Document')
     expect(notify.hulyArtifacts?.releaseNote).toContain(
       'Requirement provenance: ID 00gc1i45, signal torghut-to-jangar-e2e-1772433239, source torghut-quant, target jangar-control-plane.',
     )

--- a/services/jangar/scripts/codex/__tests__/codex-implement.test.ts
+++ b/services/jangar/scripts/codex/__tests__/codex-implement.test.ts
@@ -247,6 +247,7 @@ describe('runCodexImplementation', () => {
     delete process.env.PR_URL_PATH
     delete process.env.CODEX_PR_DISCOVERY_ENABLED
     delete process.env.CODEX_RUNTIME_LOG_PATH
+    delete process.env.CODEX_STAGE
     delete process.env.CODEX_SYSTEM_PROMPT_PATH
     delete process.env.PR_NUMBER_PATH
     delete process.env.PR_URL_PATH
@@ -931,7 +932,10 @@ describe('runCodexImplementation', () => {
     expect(verifyChatAccessMock).toHaveBeenCalledTimes(1)
     expect(verifyChatAccessMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        message: 'owner/repo#42\nstage: implementation\nPost-merge validation from torghut to jangar.',
+        message: 'Hi team, I am starting implementation for owner/repo#42 and will post progress here.',
+        requireWorkerToken: true,
+        workerId: 'worker-0027ilba',
+        workerIdentity: 'vw-jangar-control-plane-implement-worker-0027ilba',
         requireExpectedActorId: true,
         tokenEnvKey: 'HULY_API_TOKEN_ELISE_NOVAK_JANGAR_ENGINEER',
         expectedActorEnvKey: 'HULY_EXPECTED_ACTOR_ID_ELISE_NOVAK_JANGAR_ENGINEER',
@@ -952,7 +956,7 @@ describe('runCodexImplementation', () => {
     })
     expect(replyCall).toBeDefined()
     expect(replyCall?.[0]?.message).toContain('owner/repo#42')
-    expect(replyCall?.[0]?.message).toContain('implementation: completed')
+    expect(replyCall?.[0]?.message).toMatch(/implementation( is)? completed/)
     expect(replyCall?.[0]?.message).toContain('implementation completed via Codex run.')
     expect(replyCall?.[0]?.replyToMessageId).toBe('msg-latest')
     expect(upsertMissionMock).toHaveBeenCalledTimes(1)
@@ -979,7 +983,9 @@ describe('runCodexImplementation', () => {
     expect(notify.hulyArtifacts?.missionStatus).toBe('completed')
     expect(notify.hulyArtifacts?.missionIssueId).toBe('issue-00gc1i45')
     expect(notify.hulyArtifacts?.missionDocumentId).toBe('doc-00gc1i45')
-    expect(notify.hulyArtifacts?.ownerUpdateMessage).toContain('Update on owner/repo#42: implementation is completed.')
+    expect(notify.hulyArtifacts?.ownerUpdateMessage).toMatch(
+      /Update on owner\/repo#42: implementation( is)? completed\./,
+    )
     expect(notify.hulyArtifacts?.releaseNote).toContain('Rollback path:')
     expect(notify.hulyArtifacts?.releaseNote).toContain('Owner-facing status: merge-ready')
   }, 40_000)
@@ -1026,9 +1032,11 @@ describe('runCodexImplementation', () => {
       return !args?.replyToMessageId
     })
     expect(ownerMessageCall?.[0]?.message).toContain('owner/repo#42')
-    expect(ownerMessageCall?.[0]?.message).toContain('implementation: completed')
-    expect(ownerMessageCall?.[0]?.message).toContain('Tests: bun run lint:argocd')
-    expect(ownerMessageCall?.[0]?.message).toContain('Acceptance: create issue/chat/doc artifacts; complete handoff')
+    expect(ownerMessageCall?.[0]?.message).toMatch(/implementation( is)? completed/)
+    expect(ownerMessageCall?.[0]?.message).toContain('Validation results: bun run lint:argocd.')
+    expect(ownerMessageCall?.[0]?.message).toContain(
+      'Acceptance criteria: create issue/chat/doc artifacts; complete handoff.',
+    )
 
     const missionDetails = upsertMissionMock.mock.calls[0]?.[0]
     expect(missionDetails?.details).toContain('Acceptance criteria: create issue/chat/doc artifacts; complete handoff')
@@ -1037,7 +1045,7 @@ describe('runCodexImplementation', () => {
     expect(missionDetails?.details).toContain('Rollback path:')
     expect(missionDetails?.details).toContain('Owner-facing status: merge-ready pending deployer rollout verification.')
     expect(missionDetails?.message).toContain('Validation results:')
-    expect(missionDetails?.message).toContain('Update on owner/repo#42: implementation is completed.')
+    expect(missionDetails?.message).toMatch(/Update on owner\/repo#42: implementation( is)? completed\./)
 
     const notifyRaw = await readFile(join(workdir, '.codex-implementation-notify.json'), 'utf8')
     const notify = JSON.parse(notifyRaw) as {

--- a/services/jangar/scripts/codex/__tests__/codex-implement.test.ts
+++ b/services/jangar/scripts/codex/__tests__/codex-implement.test.ts
@@ -791,6 +791,63 @@ describe('runCodexImplementation', () => {
     expect(notify.hulyArtifacts?.channel).toBe('huly://swarm-bridge/issues/TORGHUT-REQ-TAKES-PRECEDENCE')
   }, 40_000)
 
+  it('captures blocked prelaunch passport evidence before Huly initialization when the helper path is missing', async () => {
+    process.env.HULY_API_SCRIPT_PATH = '/tmp/missing-huly-api.py'
+
+    const payload = {
+      prompt: 'Implementation prompt',
+      repository: 'owner/repo',
+      issueNumber: 42,
+      base: 'main',
+      head: 'codex/issue-42',
+      issueTitle: 'Title',
+      objective: 'validate blocked prelaunch passport evidence',
+      swarmRequirementChannel: 'huly://swarm-bridge/issues/TORGHUT-1772433239',
+      swarmRequirementId: '00gc1i45',
+      swarmRequirementSignal: 'torghut-to-jangar-e2e-1772433239',
+      swarmRequirementSource: 'torghut-quant',
+      swarmRequirementTarget: 'jangar-control-plane',
+      swarmRequirementDescription: 'Block launch before Huly calls when the helper runtime component is missing.',
+    }
+    await writeFile(eventPath, JSON.stringify(payload))
+
+    await expect(runCodexImplementation(eventPath)).rejects.toThrow(
+      /Huly collaboration launch refused before runtime initialization: passport=blocked/,
+    )
+
+    expect(runCodexSessionMock).not.toHaveBeenCalled()
+    expect(listChannelMessagesMock).not.toHaveBeenCalled()
+    expect(verifyChatAccessMock).not.toHaveBeenCalled()
+    expect(postChannelMessageMock).not.toHaveBeenCalled()
+    expect(upsertMissionMock).not.toHaveBeenCalled()
+
+    const notifyRaw = await readFile(join(workdir, '.codex-implementation-notify.json'), 'utf8')
+    const notify = JSON.parse(notifyRaw) as {
+      last_assistant_message?: string | null
+      hulyArtifacts?: {
+        prelaunchFailure?: {
+          operation?: string
+          consumerClass?: string
+          passportDecision?: string
+          runtimeKitClass?: string
+          runtimeKitDecision?: string
+          reasonCodes?: string[]
+          checkedPaths?: string[]
+        }
+      }
+    }
+    expect(notify.last_assistant_message).toContain('passport=blocked')
+    expect(notify.hulyArtifacts?.prelaunchFailure).toMatchObject({
+      operation: 'huly_preflight',
+      consumerClass: 'swarm_implement',
+      passportDecision: 'block',
+      runtimeKitClass: 'collaboration',
+      runtimeKitDecision: 'blocked',
+      reasonCodes: expect.arrayContaining(['runtime_kit_component_missing:huly_api_script']),
+      checkedPaths: ['/tmp/missing-huly-api.py'],
+    })
+  }, 40_000)
+
   it('creates Huly reply, owner update, and mission artifacts for completed cross-swarm runs', async () => {
     const payload = {
       prompt: 'Implementation prompt',
@@ -2005,7 +2062,7 @@ exit 1
     await mkdir(join(resumeSourceDir, 'metadata'), { recursive: true })
     await mkdir(join(resumeSourceDir, 'files', 'src'), { recursive: true })
     await writeFile(join(resumeSourceDir, 'metadata', 'manifest.json'), JSON.stringify(manifest), 'utf8')
-    await writeFile(join(resumeSourceDir, 'files', 'src', 'real.ts'), 'console.log(\"resume\");\n', 'utf8')
+    await writeFile(join(resumeSourceDir, 'files', 'src', 'real.ts'), 'console.log("resume");\n', 'utf8')
 
     const archivePath = join(workdir, '.codex-implementation-changes.tar.gz')
     await new Promise<void>((resolve, reject) => {

--- a/services/jangar/scripts/codex/__tests__/codex-implement.test.ts
+++ b/services/jangar/scripts/codex/__tests__/codex-implement.test.ts
@@ -850,12 +850,17 @@ describe('runCodexImplementation', () => {
         replyMessageId?: string
         missionId?: string
         missionStatus?: string
+        ownerUpdateMessage?: string
+        releaseNote?: string
       }
     }
     expect(notify.hulyArtifacts?.latestPeerMessageId).toBe('msg-latest')
     expect(notify.hulyArtifacts?.replyMessageId).toBeDefined()
     expect(notify.hulyArtifacts?.missionId).toBe('00gc1i45')
     expect(notify.hulyArtifacts?.missionStatus).toBe('completed')
+    expect(notify.hulyArtifacts?.ownerUpdateMessage).toContain('Update on owner/repo#42: implementation is completed.')
+    expect(notify.hulyArtifacts?.releaseNote).toContain('Rollback path:')
+    expect(notify.hulyArtifacts?.releaseNote).toContain('Owner-facing status: merge-ready')
   }, 40_000)
 
   it('captures acceptance criteria from cross-swarm payload and includes release-note fields in owner update', async () => {
@@ -906,8 +911,27 @@ describe('runCodexImplementation', () => {
 
     const missionDetails = upsertMissionMock.mock.calls[0]?.[0]
     expect(missionDetails?.details).toContain('Acceptance criteria: create issue/chat/doc artifacts; complete handoff')
+    expect(missionDetails?.details).toContain('Release note:')
+    expect(missionDetails?.details).toContain('Design document:')
+    expect(missionDetails?.details).toContain('Rollback path:')
+    expect(missionDetails?.details).toContain('Owner-facing status: merge-ready pending deployer rollout verification.')
     expect(missionDetails?.message).toContain('Validation results:')
     expect(missionDetails?.message).toContain('Update on owner/repo#42: implementation is completed.')
+
+    const notifyRaw = await readFile(join(workdir, '.codex-implementation-notify.json'), 'utf8')
+    const notify = JSON.parse(notifyRaw) as {
+      hulyArtifacts?: {
+        ownerUpdateMessage?: string
+        releaseNote?: string
+      }
+    }
+    expect(notify.hulyArtifacts?.ownerUpdateMessage).toContain(
+      'Acceptance criteria: create issue/chat/doc artifacts; complete handoff.',
+    )
+    expect(notify.hulyArtifacts?.releaseNote).toContain(
+      'Requirement provenance: ID 00gc1i45, signal torghut-to-jangar-e2e-1772433239, source torghut-quant, target jangar-control-plane.',
+    )
+    expect(notify.hulyArtifacts?.releaseNote).toContain('Rollback path:')
   }, 40_000)
 
   it('posts failure Huly mission handoff artifacts when implementation fails', async () => {

--- a/services/jangar/scripts/codex/__tests__/codex-implement.test.ts
+++ b/services/jangar/scripts/codex/__tests__/codex-implement.test.ts
@@ -693,6 +693,11 @@ describe('runCodexImplementation', () => {
   }, 40_000)
 
   it('uses environment fallback channel resolution for Huly handoff', async () => {
+    delete process.env.hulyChannel
+    delete process.env.HULY_CHANNEL
+    delete process.env.HULY_CHANNEL_NAME
+    delete process.env.hulyChannelUrl
+    delete process.env.HULY_CHANNEL_URL
     process.env.hulyChannelName = 'huly://swarm-bridge/issues/TORGHUT-ENV-TEST-1'
 
     const payload = {
@@ -721,6 +726,69 @@ describe('runCodexImplementation', () => {
     const notifyRaw = await readFile(join(workdir, '.codex-implementation-notify.json'), 'utf8')
     const notify = JSON.parse(notifyRaw) as { hulyArtifacts?: { channel?: string } }
     expect(notify.hulyArtifacts?.channel).toBe('huly://swarm-bridge/issues/TORGHUT-ENV-TEST-1')
+  }, 40_000)
+
+  it('accepts plain Huly channel names from HULY_CHANNEL fallback', async () => {
+    process.env.HULY_CHANNEL = 'general'
+
+    const payload = {
+      prompt: 'Implementation prompt',
+      repository: 'owner/repo',
+      issueNumber: 42,
+      base: 'main',
+      head: 'codex/issue-42',
+      issueTitle: 'Title',
+      objective: 'Validate plain HULY_CHANNEL fallback',
+    }
+    await writeFile(eventPath, JSON.stringify(payload))
+
+    await runCodexImplementation(eventPath)
+
+    expect(listChannelMessagesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: 'general',
+      }),
+    )
+    expect(verifyChatAccessMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: 'general',
+      }),
+    )
+    const notifyRaw = await readFile(join(workdir, '.codex-implementation-notify.json'), 'utf8')
+    const notify = JSON.parse(notifyRaw) as { hulyArtifacts?: { channel?: string } }
+    expect(notify.hulyArtifacts?.channel).toBe('general')
+  }, 40_000)
+
+  it('prefers explicit requirement channels over HULY_CHANNEL fallbacks', async () => {
+    process.env.HULY_CHANNEL = 'general'
+
+    const payload = {
+      prompt: 'Implementation prompt',
+      repository: 'owner/repo',
+      issueNumber: 42,
+      base: 'main',
+      head: 'codex/issue-42',
+      issueTitle: 'Title',
+      objective: 'Validate explicit Huly requirement channel precedence',
+      swarmRequirementChannel: 'huly://swarm-bridge/issues/TORGHUT-REQ-TAKES-PRECEDENCE',
+    }
+    await writeFile(eventPath, JSON.stringify(payload))
+
+    await runCodexImplementation(eventPath)
+
+    expect(listChannelMessagesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: 'huly://swarm-bridge/issues/TORGHUT-REQ-TAKES-PRECEDENCE',
+      }),
+    )
+    expect(verifyChatAccessMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: 'huly://swarm-bridge/issues/TORGHUT-REQ-TAKES-PRECEDENCE',
+      }),
+    )
+    const notifyRaw = await readFile(join(workdir, '.codex-implementation-notify.json'), 'utf8')
+    const notify = JSON.parse(notifyRaw) as { hulyArtifacts?: { channel?: string } }
+    expect(notify.hulyArtifacts?.channel).toBe('huly://swarm-bridge/issues/TORGHUT-REQ-TAKES-PRECEDENCE')
   }, 40_000)
 
   it('creates Huly reply, owner update, and mission artifacts for completed cross-swarm runs', async () => {

--- a/services/jangar/scripts/codex/__tests__/codex-implement.test.ts
+++ b/services/jangar/scripts/codex/__tests__/codex-implement.test.ts
@@ -217,11 +217,13 @@ describe('runCodexImplementation', () => {
   let workdir: string
   let remoteDir: string
   let eventPath: string
+  let hulyApiScriptPath: string
 
   beforeEach(async () => {
     workdir = await mkdtemp(join(tmpdir(), 'codex-impl-test-'))
     remoteDir = await mkdtemp(join(tmpdir(), 'codex-impl-remote-'))
     eventPath = join(workdir, 'event.json')
+    hulyApiScriptPath = join(workdir, 'skills', 'huly-api', 'scripts', 'huly-api.py')
     delete process.env.OUTPUT_PATH
     delete process.env.JSON_OUTPUT_PATH
     delete process.env.AGENT_OUTPUT_PATH
@@ -254,6 +256,11 @@ describe('runCodexImplementation', () => {
     process.env.CHANNEL_SCRIPT = ''
     process.env.CODEX_SKIP_PR_CHECK = '1'
     process.env.CODEX_NATS_SOAK_REQUIRED = 'false'
+    process.env.HULY_API_BASE_URL = 'https://huly.example.test'
+    process.env.HULY_API_SCRIPT_PATH = hulyApiScriptPath
+
+    await mkdir(join(workdir, 'skills', 'huly-api', 'scripts'), { recursive: true })
+    await writeFile(hulyApiScriptPath, '#!/usr/bin/env python3\nprint("ok")\n', 'utf8')
 
     const payload = {
       prompt: 'Implementation prompt',

--- a/services/jangar/scripts/codex/__tests__/huly-api-client.test.ts
+++ b/services/jangar/scripts/codex/__tests__/huly-api-client.test.ts
@@ -8,7 +8,11 @@ vi.mock('node:fs', () => ({
   existsSync: fsMocks.existsSync,
 }))
 
-import { resolveHulyApiScriptPath } from '../lib/huly-api-client'
+import {
+  isRuntimeMissingComponentError,
+  resolveHulyApiScriptPath,
+  RuntimeMissingComponentError,
+} from '../lib/huly-api-client'
 
 const existsSyncMock = fsMocks.existsSync
 const ORIGINAL_ENV = { ...process.env }
@@ -42,8 +46,16 @@ describe('resolveHulyApiScriptPath', () => {
   it('throws a typed error when an explicit HULY_API_SCRIPT_PATH override is missing', () => {
     process.env.HULY_API_SCRIPT_PATH = '/custom/tools/huly-api.py'
 
-    expect(() => resolveHulyApiScriptPath()).toThrow(/runtime_missing_component:huly_api_script/)
-    expect(() => resolveHulyApiScriptPath()).toThrow(/custom\/tools\/huly-api.py/)
+    try {
+      resolveHulyApiScriptPath()
+      throw new Error('expected missing helper error')
+    } catch (error) {
+      expect(error).toBeInstanceOf(RuntimeMissingComponentError)
+      expect(isRuntimeMissingComponentError(error)).toBe(true)
+      expect((error as RuntimeMissingComponentError).componentKind).toBe('python_helper')
+      expect((error as RuntimeMissingComponentError).reasonCode).toBe('runtime_kit_component_missing')
+      expect((error as RuntimeMissingComponentError).checkedPaths).toEqual(['/custom/tools/huly-api.py'])
+    }
   })
 
   it('prefers the source-relative helper path when it is available', () => {
@@ -60,6 +72,17 @@ describe('resolveHulyApiScriptPath', () => {
   })
 
   it('throws a typed error when no helper path exists in the runtime', () => {
-    expect(() => resolveHulyApiScriptPath()).toThrow(/runtime_missing_component:huly_api_script/)
+    try {
+      resolveHulyApiScriptPath()
+      throw new Error('expected missing helper error')
+    } catch (error) {
+      expect(error).toBeInstanceOf(RuntimeMissingComponentError)
+      expect((error as RuntimeMissingComponentError).checkedPaths).toEqual(
+        expect.arrayContaining([
+          expect.stringContaining('/skills/huly-api/scripts/huly-api.py'),
+          '/app/skills/huly-api/scripts/huly-api.py',
+        ]),
+      )
+    }
   })
 })

--- a/services/jangar/scripts/codex/codex-implement.ts
+++ b/services/jangar/scripts/codex/codex-implement.ts
@@ -148,6 +148,8 @@ type HulyRequirementArtifacts = {
   replyMessage?: HulyPostChannelMessageResult
   ownerMessage?: HulyPostChannelMessageResult
   mission?: HulyUpsertMissionResult
+  ownerUpdateMessage?: string
+  releaseNote?: string
 }
 
 type HulyArtifactsForNotify = {
@@ -160,6 +162,8 @@ type HulyArtifactsForNotify = {
   missionStatus?: string
   missionStage?: string
   missionIssue?: string
+  ownerUpdateMessage?: string
+  releaseNote?: string
 }
 
 const asStringMap = (value: Record<string, string | number | boolean> | undefined): Record<string, string> => {
@@ -387,6 +391,37 @@ const buildHulyReplyMessage = ({
   return lines.filter((line) => line.length > 0).join(' ')
 }
 
+const resolveOwnerFacingStatus = (decision: 'completed' | 'failed') =>
+  decision === 'completed' ? 'merge-ready pending deployer rollout verification' : 'blocked pending follow-up'
+
+const buildRollbackPath = ({
+  decision,
+  repository,
+  issueNumber,
+  stage,
+  requirementMetadata,
+  prUrl,
+}: {
+  decision: 'completed' | 'failed'
+  repository: string
+  issueNumber: string
+  stage: string
+  requirementMetadata: RequirementMetadata
+  prUrl?: string | null
+}) => {
+  const requirementRef = requirementMetadata.signal ?? requirementMetadata.id ?? `${repository}#${issueNumber}`
+
+  if (decision !== 'completed') {
+    return `No production rollback is required yet; fix the blocker, rerun ${stage}, and re-validate ${requirementRef}`
+  }
+
+  if (prUrl) {
+    return `If the merged change regresses, revert ${prUrl} and rerun cross-swarm validation for ${requirementRef}`
+  }
+
+  return `If the merged change regresses, revert the implementation change set for ${repository}#${issueNumber} and rerun cross-swarm validation for ${requirementRef}`
+}
+
 const buildOwnerUpdateMessage = ({
   decision,
   issueNumber,
@@ -429,6 +464,63 @@ const buildOwnerUpdateMessage = ({
   return lines.filter((line) => line.length > 0).join(' ')
 }
 
+const buildReleaseNote = ({
+  decision,
+  issueNumber,
+  repository,
+  requirementMetadata,
+  runSummary,
+  tests,
+  prUrl,
+  stage,
+  gaps,
+}: {
+  decision: 'completed' | 'failed'
+  repository: string
+  issueNumber: string
+  stage: string
+  requirementMetadata: RequirementMetadata
+  runSummary?: string | null
+  tests?: string[]
+  gaps?: string[]
+  prUrl?: string | null
+}) => {
+  const requirementProvenance = [
+    requirementMetadata.id ? `ID ${requirementMetadata.id}` : '',
+    requirementMetadata.signal ? `signal ${requirementMetadata.signal}` : '',
+    requirementMetadata.source ? `source ${requirementMetadata.source}` : '',
+    requirementMetadata.target ? `target ${requirementMetadata.target}` : '',
+  ]
+    .filter((entry) => entry.length > 0)
+    .join(', ')
+
+  const whatShipped = [
+    `${stage} is ${decision === 'completed' ? 'complete' : 'blocked'}`,
+    requirementMetadata.objective ? `Objective: ${summarizeText(requirementMetadata.objective, 200)}` : '',
+    runSummary ? `Summary: ${summarizeText(runSummary, 220)}` : '',
+  ]
+    .filter((entry) => entry.length > 0)
+    .join(' ')
+
+  const lines = [
+    `Design document: ${GOVERNING_DESIGN_DOCUMENT}.`,
+    requirementProvenance ? `Requirement provenance: ${requirementProvenance}.` : '',
+    `What shipped: ${whatShipped}.`,
+    prUrl ? `PR: ${prUrl}.` : '',
+    tests && tests.length > 0
+      ? `Validation results: ${tests.join('; ')}.`
+      : 'Validation results: no explicit test list in the final run output.',
+    gaps && gaps.length > 0 ? `Key risks: ${gaps.join('; ')}.` : 'Key risks: none identified.',
+    `Rollback path: ${buildRollbackPath({ decision, repository, issueNumber, stage, requirementMetadata, prUrl })}.`,
+    `Owner-facing status: ${resolveOwnerFacingStatus(decision)}.`,
+    requirementMetadata.acceptance && requirementMetadata.acceptance.length > 0
+      ? `Acceptance criteria: ${requirementMetadata.acceptance.join('; ')}.`
+      : '',
+  ]
+
+  return lines.filter((line) => line.length > 0).join('\n')
+}
+
 const buildMissionDetails = ({
   requirementMetadata,
   repository,
@@ -437,6 +529,7 @@ const buildMissionDetails = ({
   tests,
   gaps,
   summary,
+  releaseNote,
 }: {
   repository: string
   issueNumber: string
@@ -445,6 +538,7 @@ const buildMissionDetails = ({
   tests?: string[]
   gaps?: string[]
   summary?: string | null
+  releaseNote: string
 }) => {
   const details = [
     `- Repository: ${repository}`,
@@ -484,6 +578,8 @@ const buildMissionDetails = ({
   if (requirementMetadata.acceptance && requirementMetadata.acceptance.length > 0) {
     details.push(`- Acceptance criteria: ${requirementMetadata.acceptance.join('; ')}`)
   }
+
+  details.push('', 'Release note:', releaseNote)
 
   return details.join('\n')
 }
@@ -539,6 +635,8 @@ const collectHulyArtifactsForNotify = (artifacts?: HulyRequirementArtifacts): Hu
     missionStatus: artifacts.mission?.status,
     missionStage: artifacts.mission?.stage,
     missionIssue: artifacts.mission?.issue?.issueIdentifier,
+    ownerUpdateMessage: artifacts.ownerUpdateMessage,
+    releaseNote: artifacts.releaseNote,
   }
 }
 
@@ -578,6 +676,28 @@ const buildHulyArtifactsFromRun = async ({
   latestPeerMessage?: string
 }): Promise<HulyRequirementArtifacts> => {
   const decisionSuffix = decision === 'completed' ? 'implementation completed' : 'implementation failed'
+  const ownerUpdateMessage = buildOwnerUpdateMessage({
+    decision,
+    repository,
+    issueNumber,
+    stage,
+    requirementMetadata,
+    runSummary,
+    tests,
+    prUrl,
+    gaps,
+  })
+  const releaseNote = buildReleaseNote({
+    decision,
+    repository,
+    issueNumber,
+    stage,
+    requirementMetadata,
+    runSummary,
+    tests,
+    prUrl,
+    gaps,
+  })
   const details = buildMissionDetails({
     repository,
     issueNumber,
@@ -586,7 +706,10 @@ const buildHulyArtifactsFromRun = async ({
     tests,
     gaps,
     summary: runSummary,
+    releaseNote,
   })
+  artifacts.ownerUpdateMessage = ownerUpdateMessage
+  artifacts.releaseNote = releaseNote
 
   if (includeReplyMessage && latestPeerMessageId && latestPeerMessage) {
     const replyMessage = buildHulyReplyMessage({
@@ -616,17 +739,6 @@ const buildHulyArtifactsFromRun = async ({
     }
   }
 
-  const ownerUpdateMessage = buildOwnerUpdateMessage({
-    decision,
-    repository,
-    issueNumber,
-    stage,
-    requirementMetadata,
-    runSummary,
-    tests,
-    prUrl,
-    gaps,
-  })
   try {
     artifacts.ownerMessage = await postChannelMessage({
       channel: activeChannel,
@@ -1242,6 +1354,7 @@ type CodexNotifyPayload = {
   fallbackUsed?: boolean | null
   fallbackReason?: string | null
   attemptCount?: number | null
+  hulyArtifacts?: HulyArtifactsForNotify
 }
 
 const MAX_NOTIFY_LOG_CHARS = 12_000

--- a/services/jangar/scripts/codex/codex-implement.ts
+++ b/services/jangar/scripts/codex/codex-implement.ts
@@ -271,15 +271,25 @@ const isHulyRequirementChannel = (channel: string | undefined | null) => {
 
 const resolveHulyChannelFromCandidate = (value: string | null | undefined) => {
   const normalized = normalizeNullableStringValue(value)
-  if (normalized && isHulyRequirementChannel(normalized)) {
+  if (!normalized) {
+    return undefined
+  }
+  if (isHulyRequirementChannel(normalized)) {
     return normalized
   }
-  return undefined
+  // Huly channel names/ids like "general" or "chunter:space:General" are valid
+  // runtime inputs, but explicit non-Huly transports must stay fail-closed.
+  if (normalized.includes('://')) {
+    return undefined
+  }
+  return normalized
 }
 
 const resolveActiveHulyChannel = (requirementMetadata: RequirementMetadata) => {
   const candidates = [
     requirementMetadata.channel,
+    process.env.hulyChannel,
+    process.env.HULY_CHANNEL,
     process.env.hulyChannelName,
     process.env.HULY_CHANNEL_NAME,
     process.env.hulyChannelUrl,

--- a/services/jangar/scripts/codex/codex-implement.ts
+++ b/services/jangar/scripts/codex/codex-implement.ts
@@ -174,10 +174,19 @@ type HulyArtifactsForNotify = {
   latestPeerMessageId?: string
   replyMessageId?: string
   ownerMessageId?: string
+  missionMessageId?: string
   missionId?: string
   missionStatus?: string
   missionStage?: string
   missionIssue?: string
+  missionIssueId?: string
+  missionIssueTitle?: string
+  missionIssueNumber?: number
+  missionProjectId?: string
+  missionProjectIdentifier?: string
+  missionDocumentId?: string
+  missionDocumentTitle?: string
+  missionDocumentTeamspaceId?: string
   ownerUpdateMessage?: string
   releaseNote?: string
   prelaunchFailure?: HulyRequirementArtifacts['prelaunchFailure']
@@ -648,10 +657,19 @@ const collectHulyArtifactsForNotify = (artifacts?: HulyRequirementArtifacts): Hu
     latestPeerMessageId: artifacts.latestPeerMessageId,
     replyMessageId: artifacts.replyMessage?.messageId,
     ownerMessageId: artifacts.ownerMessage?.messageId,
+    missionMessageId: artifacts.mission?.channelMessage?.messageId,
     missionId: artifacts.mission?.missionId,
     missionStatus: artifacts.mission?.status,
     missionStage: artifacts.mission?.stage,
     missionIssue: artifacts.mission?.issue?.issueIdentifier,
+    missionIssueId: artifacts.mission?.issue?.issueId,
+    missionIssueTitle: artifacts.mission?.issue?.issueTitle,
+    missionIssueNumber: artifacts.mission?.issue?.issueNumber,
+    missionProjectId: artifacts.mission?.issue?.projectId,
+    missionProjectIdentifier: artifacts.mission?.issue?.projectIdentifier,
+    missionDocumentId: artifacts.mission?.document?.documentId,
+    missionDocumentTitle: artifacts.mission?.document?.documentTitle,
+    missionDocumentTeamspaceId: artifacts.mission?.document?.teamspaceId,
     ownerUpdateMessage: artifacts.ownerUpdateMessage,
     releaseNote: artifacts.releaseNote,
     prelaunchFailure: artifacts.prelaunchFailure,
@@ -814,6 +832,12 @@ const buildHulyArtifactsFromRun = async ({
         expectedActorEnvKey: workerContext.expectedActorEnvKey,
         requireExpectedActorId: true,
       })
+      logger.info('Huly post-channel-message completed', {
+        channel: activeChannel,
+        purpose: 'thread-reply',
+        messageId: normalizeNullableStringValue(artifacts.replyMessage.messageId),
+        replyToMessageId: latestPeerMessageId,
+      })
     } catch (error) {
       logger.warn('Failed to post Huly reply message for requirement handoff', error)
       throw error
@@ -829,6 +853,11 @@ const buildHulyArtifactsFromRun = async ({
       tokenEnvKey: workerContext.tokenEnvKey,
       expectedActorEnvKey: workerContext.expectedActorEnvKey,
       requireExpectedActorId: true,
+    })
+    logger.info('Huly post-channel-message completed', {
+      channel: activeChannel,
+      purpose: 'owner-update',
+      messageId: normalizeNullableStringValue(artifacts.ownerMessage.messageId),
     })
   } catch (error) {
     logger.warn('Failed to post Huly owner update for requirement handoff', error)
@@ -851,6 +880,16 @@ const buildHulyArtifactsFromRun = async ({
       tokenEnvKey: workerContext.tokenEnvKey,
       expectedActorEnvKey: workerContext.expectedActorEnvKey,
       requireExpectedActorId: true,
+    })
+    logger.info('Huly upsert-mission completed', {
+      channel: activeChannel,
+      missionId: artifacts.mission.missionId,
+      stage: artifacts.mission.stage,
+      status: artifacts.mission.status,
+      messageId: normalizeNullableStringValue(artifacts.mission.channelMessage?.messageId),
+      issueId: normalizeNullableStringValue(artifacts.mission.issue?.issueId),
+      issueIdentifier: normalizeNullableStringValue(artifacts.mission.issue?.issueIdentifier),
+      documentId: normalizeNullableStringValue(artifacts.mission.document?.documentId),
     })
   } catch (error) {
     logger.warn('Failed to upsert Huly mission for requirement handoff', error)

--- a/services/jangar/scripts/codex/codex-implement.ts
+++ b/services/jangar/scripts/codex/codex-implement.ts
@@ -19,6 +19,11 @@ import { dirname, join } from 'node:path'
 import process from 'node:process'
 import { Effect } from 'effect'
 
+import {
+  buildRuntimeAdmissionSnapshot,
+  findAdmissionPassport,
+  resolveAdmissionPassportConsumerClass,
+} from '../../src/server/control-plane-runtime-admission'
 import { runCli } from './lib/cli'
 import { pushCodexEventsToLoki, type RunCodexSessionResult, runCodexSession } from './lib/codex-runner'
 import {
@@ -150,6 +155,17 @@ type HulyRequirementArtifacts = {
   mission?: HulyUpsertMissionResult
   ownerUpdateMessage?: string
   releaseNote?: string
+  prelaunchFailure?: {
+    operation: 'huly_preflight'
+    consumerClass: string
+    passportDecision: string
+    passportId: string
+    reasonCodes: string[]
+    runtimeKitId: string
+    runtimeKitClass: string
+    runtimeKitDecision: string
+    checkedPaths?: string[]
+  }
 }
 
 type HulyArtifactsForNotify = {
@@ -164,6 +180,7 @@ type HulyArtifactsForNotify = {
   missionIssue?: string
   ownerUpdateMessage?: string
   releaseNote?: string
+  prelaunchFailure?: HulyRequirementArtifacts['prelaunchFailure']
 }
 
 const asStringMap = (value: Record<string, string | number | boolean> | undefined): Record<string, string> => {
@@ -637,7 +654,71 @@ const collectHulyArtifactsForNotify = (artifacts?: HulyRequirementArtifacts): Hu
     missionIssue: artifacts.mission?.issue?.issueIdentifier,
     ownerUpdateMessage: artifacts.ownerUpdateMessage,
     releaseNote: artifacts.releaseNote,
+    prelaunchFailure: artifacts.prelaunchFailure,
   }
+}
+
+const parseCheckedPaths = (value: string | null | undefined) => {
+  if (!value || !value.startsWith('checked_paths=[') || !value.endsWith(']')) {
+    return undefined
+  }
+  const content = value.slice('checked_paths=['.length, -1)
+  const paths = content
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0)
+  return paths.length > 0 ? paths : undefined
+}
+
+const buildHulyPrelaunchFailure = ({
+  stage,
+}: {
+  stage: string
+}): HulyRequirementArtifacts['prelaunchFailure'] | undefined => {
+  const runtimeAdmission = buildRuntimeAdmissionSnapshot()
+  const consumerClass = resolveAdmissionPassportConsumerClass(stage)
+  const passport = findAdmissionPassport({
+    admissionPassports: runtimeAdmission.admissionPassports,
+    consumerClass,
+  })
+  if (!passport || (passport.decision !== 'block' && passport.decision !== 'hold')) {
+    return undefined
+  }
+
+  const runtimeKitId = passport.required_runtime_kits[0]
+  const runtimeKit = runtimeAdmission.runtimeKits.find((kit) => kit.runtime_kit_id === runtimeKitId)
+  if (!runtimeKit) {
+    return undefined
+  }
+
+  const helperComponent = runtimeKit.components.find((component) => component.component_kind === 'python_helper')
+
+  return {
+    operation: 'huly_preflight',
+    consumerClass,
+    passportDecision: passport.decision,
+    passportId: passport.admission_passport_id,
+    reasonCodes: passport.reason_codes,
+    runtimeKitId: runtimeKit.runtime_kit_id,
+    runtimeKitClass: runtimeKit.kit_class,
+    runtimeKitDecision: runtimeKit.decision,
+    checkedPaths: parseCheckedPaths(helperComponent?.evidence_ref),
+  }
+}
+
+const buildHulyPrelaunchFailureMessage = (failure: NonNullable<HulyRequirementArtifacts['prelaunchFailure']>) => {
+  const checkedPaths =
+    failure.checkedPaths && failure.checkedPaths.length > 0 ? ` checked_paths=[${failure.checkedPaths.join(', ')}]` : ''
+  const passportDecision = failure.passportDecision === 'block' ? 'blocked' : failure.passportDecision
+  return (
+    [
+      `passport=${passportDecision}`,
+      `consumer=${failure.consumerClass}`,
+      `runtime_kit=${failure.runtimeKitId}`,
+      `runtime_kit_decision=${failure.runtimeKitDecision}`,
+      `reason_codes=${failure.reasonCodes.join(',') || 'unknown'}`,
+    ].join(' ') + checkedPaths
+  )
 }
 
 const buildHulyArtifactsFromRun = async ({
@@ -3473,156 +3554,6 @@ export const runCodexImplementation = async (eventPath: string) => {
     })
   }
 
-  const hulyWorkerContext = resolveHulyWorkerContext(requirementMetadata)
-  let hulyArtifacts: HulyRequirementArtifacts | undefined
-  const hulyAccessMessage = `Hi team, I am starting ${stage} for ${repository}#${issueNumber} and will post progress here.`
-
-  if (!isBatchTask && crossSwarmHulyChannel) {
-    try {
-      const listResult = await listChannelMessages({
-        channel: crossSwarmHulyChannel,
-        workerId: hulyWorkerContext.workerId,
-        workerIdentity: hulyWorkerContext.workerIdentity,
-        requireWorkerToken: true,
-        tokenEnvKey: hulyWorkerContext.tokenEnvKey,
-        expectedActorEnvKey: hulyWorkerContext.expectedActorEnvKey,
-        requireExpectedActorId: true,
-      })
-
-      const accessResult = await verifyChatAccess({
-        channel: crossSwarmHulyChannel,
-        message: hulyAccessMessage,
-        workerId: hulyWorkerContext.workerId,
-        workerIdentity: hulyWorkerContext.workerIdentity,
-        requireWorkerToken: true,
-        tokenEnvKey: hulyWorkerContext.tokenEnvKey,
-        expectedActorEnvKey: hulyWorkerContext.expectedActorEnvKey,
-        requireExpectedActorId: true,
-      })
-
-      const actorId =
-        normalizeNullableStringValue(accessResult.actorId) || normalizeNullableStringValue(accessResult.expectedActorId)
-      const latestPeerMessage = resolveLatestPeerMessage(listResult, actorId ?? undefined)
-
-      hulyArtifacts = {
-        activeChannel: crossSwarmHulyChannel,
-        actorId: actorId ?? undefined,
-        latestPeerMessageId: latestPeerMessage?.messageId,
-        latestPeerMessage: latestPeerMessage?.message,
-        verification: accessResult,
-        listMessages: listResult,
-      }
-    } catch (error) {
-      logger.warn('Failed Huly cross-swarm initialization for implementation handoff', error)
-      throw error
-    }
-  }
-
-  const systemPromptPath = normalizeOptionalString(sanitizeNullableString(process.env.CODEX_SYSTEM_PROMPT_PATH))
-  const payloadSystemPrompt = normalizeOptionalString(sanitizeNullableString(event.systemPrompt))
-  const expectedSystemPromptHash = normalizeOptionalString(
-    sanitizeNullableString(process.env.CODEX_SYSTEM_PROMPT_EXPECTED_HASH),
-  )?.toLowerCase()
-  const systemPromptRequired = parseBoolean(process.env.CODEX_SYSTEM_PROMPT_REQUIRED, Boolean(expectedSystemPromptHash))
-  let systemPromptSource: 'path' | 'payload' | undefined
-  let systemPrompt: string | undefined
-  if (systemPromptPath && (await pathExists(systemPromptPath))) {
-    try {
-      const content = await readFile(systemPromptPath, 'utf8')
-      if (content.trim().length > 0) {
-        systemPromptSource = 'path'
-        systemPrompt = content
-      } else {
-        logger.warn('System prompt file was empty; ignoring', { systemPromptPath })
-      }
-    } catch (error) {
-      logger.warn('Failed to read system prompt file; ignoring', { systemPromptPath }, error)
-    }
-  }
-  if (!systemPrompt && payloadSystemPrompt) {
-    systemPromptSource = 'payload'
-    systemPrompt = payloadSystemPrompt
-  }
-  const systemPromptHash = systemPrompt ? sha256Hex(systemPrompt) : undefined
-  if (systemPromptRequired && !systemPrompt) {
-    throw new Error(
-      `System prompt is required but was not loaded (path=${systemPromptPath ?? 'unset'}, source=${payloadSystemPrompt ? 'payload-available' : 'none'})`,
-    )
-  }
-  if (expectedSystemPromptHash) {
-    if (!systemPromptHash) {
-      throw new Error(
-        `System prompt hash verification failed: expected ${expectedSystemPromptHash}, but no system prompt was loaded`,
-      )
-    }
-    if (systemPromptHash.toLowerCase() !== expectedSystemPromptHash) {
-      throw new Error(
-        `System prompt hash mismatch: expected ${expectedSystemPromptHash}, got ${systemPromptHash.toLowerCase()}`,
-      )
-    }
-  }
-  if (systemPrompt && systemPromptHash) {
-    logger.info('System prompt configured', {
-      source: systemPromptSource,
-      systemPromptLength: systemPrompt.length,
-      systemPromptHash,
-    })
-  }
-
-  const natsSoakRequired =
-    (process.env.CODEX_NATS_SOAK_REQUIRED ?? 'true').trim().toLowerCase() !== 'false' &&
-    (process.env.CODEX_NATS_SOAK_REQUIRED ?? 'true').trim() !== '0'
-
-  const shouldRequireMemories =
-    !isBatchTask && stage === 'implementation' && ((iteration ?? 1) >= 2 || (iterationCycle ?? 1) >= 2)
-  const memoryNamespace = `codex:${repository}:${issueNumber}`
-  const memoryQuery = `issue ${issueNumber} ${issueTitle || repository} codex run summary`
-  const memorySoak = await fetchJangarMemories({
-    logger,
-    required: shouldRequireMemories,
-    namespace: memoryNamespace,
-    query: memoryQuery,
-    limit: 12,
-  })
-  const memoryContextBlock = formatMemoryContextBlock(memorySoak)
-  if (memoryContextBlock) {
-    prompt = `${memoryContextBlock}\n\n${prompt}`
-  }
-
-  const natsContext = await fetchNatsContext({
-    logger,
-    required: natsSoakRequired,
-    outputPath: natsContextPath,
-  })
-  const natsContextBlock = formatNatsContextBlock(natsContext)
-  if (natsContextBlock) {
-    prompt = `${natsContextBlock}\n\n${prompt}`
-  }
-  const maxPromptChars = parsePositiveIntEnv(process.env.CODEX_MAX_PROMPT_CHARS, DEFAULT_MAX_PROMPT_CHARS)
-  prompt = fitPromptToBudget({
-    prompt,
-    maxChars: maxPromptChars,
-    logger,
-    label: 'initial',
-  })
-
-  await ensureEmptyFile(outputPath)
-  await ensureEmptyFile(jsonOutputPath)
-  await ensureEmptyFile(agentOutputPath)
-  await ensureEmptyFile(runtimeLogPath)
-
-  if (process.env.CODEX_SKIP_RUN_STARTED !== '1') {
-    const attrs = enrichRunNatsAttrs({ stage, iteration, iterationCycle }, requirementMetadata)
-    if (systemPromptHash) {
-      attrs.systemPromptHash = systemPromptHash
-    }
-    await publishNatsEvent(logger, {
-      kind: 'run-started',
-      content: `${stage} started`,
-      attrs,
-    })
-  }
-
   const normalizedIssueNumber = issueNumber
   const disableResume = parseBoolean(process.env.CODEX_DISABLE_RESUME, false)
   const supportsResume = stage === 'implementation' && !disableResume
@@ -3630,10 +3561,181 @@ export const runCodexImplementation = async (eventPath: string) => {
   let resumeSessionId: string | undefined
   let capturedSessionId: string | undefined
   let runSucceeded = false
-  let lastAssistantMessage: string | null = null
+  let prNumber: number | null = null
   let prUrl: string | null = null
+  const hulyWorkerContext = resolveHulyWorkerContext(requirementMetadata)
+  let hulyArtifacts: HulyRequirementArtifacts | undefined
+  let lastAssistantMessage: string | null = null
+  let memorySoak: MemoryContextPayload | null = null
+  let natsContext: NatsContextPayload | null = null
+  const hulyAccessMessage = `Hi team, I am starting ${stage} for ${repository}#${issueNumber} and will post progress here.`
 
   try {
+    if (!isBatchTask && crossSwarmHulyChannel) {
+      hulyArtifacts = {
+        activeChannel: crossSwarmHulyChannel,
+      }
+
+      try {
+        const prelaunchFailure = buildHulyPrelaunchFailure({ stage })
+        if (prelaunchFailure) {
+          hulyArtifacts.prelaunchFailure = prelaunchFailure
+          lastAssistantMessage = buildHulyPrelaunchFailureMessage(prelaunchFailure)
+          throw new Error(`Huly collaboration launch refused before runtime initialization: ${lastAssistantMessage}`)
+        }
+
+        const listResult = await listChannelMessages({
+          channel: crossSwarmHulyChannel,
+          workerId: hulyWorkerContext.workerId,
+          workerIdentity: hulyWorkerContext.workerIdentity,
+          requireWorkerToken: true,
+          tokenEnvKey: hulyWorkerContext.tokenEnvKey,
+          expectedActorEnvKey: hulyWorkerContext.expectedActorEnvKey,
+          requireExpectedActorId: true,
+        })
+
+        const accessResult = await verifyChatAccess({
+          channel: crossSwarmHulyChannel,
+          message: hulyAccessMessage,
+          workerId: hulyWorkerContext.workerId,
+          workerIdentity: hulyWorkerContext.workerIdentity,
+          requireWorkerToken: true,
+          tokenEnvKey: hulyWorkerContext.tokenEnvKey,
+          expectedActorEnvKey: hulyWorkerContext.expectedActorEnvKey,
+          requireExpectedActorId: true,
+        })
+
+        const actorId =
+          normalizeNullableStringValue(accessResult.actorId) ||
+          normalizeNullableStringValue(accessResult.expectedActorId)
+        const latestPeerMessage = resolveLatestPeerMessage(listResult, actorId ?? undefined)
+
+        hulyArtifacts = {
+          ...hulyArtifacts,
+          activeChannel: crossSwarmHulyChannel,
+          actorId: actorId ?? undefined,
+          latestPeerMessageId: latestPeerMessage?.messageId,
+          latestPeerMessage: latestPeerMessage?.message,
+          verification: accessResult,
+          listMessages: listResult,
+        }
+      } catch (error) {
+        if (!lastAssistantMessage) {
+          lastAssistantMessage = error instanceof Error ? error.message : String(error)
+        }
+        logger.warn('Failed Huly cross-swarm initialization for implementation handoff', error)
+        throw error
+      }
+    }
+
+    const systemPromptPath = normalizeOptionalString(sanitizeNullableString(process.env.CODEX_SYSTEM_PROMPT_PATH))
+    const payloadSystemPrompt = normalizeOptionalString(sanitizeNullableString(event.systemPrompt))
+    const expectedSystemPromptHash = normalizeOptionalString(
+      sanitizeNullableString(process.env.CODEX_SYSTEM_PROMPT_EXPECTED_HASH),
+    )?.toLowerCase()
+    const systemPromptRequired = parseBoolean(
+      process.env.CODEX_SYSTEM_PROMPT_REQUIRED,
+      Boolean(expectedSystemPromptHash),
+    )
+    let systemPromptSource: 'path' | 'payload' | undefined
+    let systemPrompt: string | undefined
+    if (systemPromptPath && (await pathExists(systemPromptPath))) {
+      try {
+        const content = await readFile(systemPromptPath, 'utf8')
+        if (content.trim().length > 0) {
+          systemPromptSource = 'path'
+          systemPrompt = content
+        } else {
+          logger.warn('System prompt file was empty; ignoring', { systemPromptPath })
+        }
+      } catch (error) {
+        logger.warn('Failed to read system prompt file; ignoring', { systemPromptPath }, error)
+      }
+    }
+    if (!systemPrompt && payloadSystemPrompt) {
+      systemPromptSource = 'payload'
+      systemPrompt = payloadSystemPrompt
+    }
+    const systemPromptHash = systemPrompt ? sha256Hex(systemPrompt) : undefined
+    if (systemPromptRequired && !systemPrompt) {
+      throw new Error(
+        `System prompt is required but was not loaded (path=${systemPromptPath ?? 'unset'}, source=${payloadSystemPrompt ? 'payload-available' : 'none'})`,
+      )
+    }
+    if (expectedSystemPromptHash) {
+      if (!systemPromptHash) {
+        throw new Error(
+          `System prompt hash verification failed: expected ${expectedSystemPromptHash}, but no system prompt was loaded`,
+        )
+      }
+      if (systemPromptHash.toLowerCase() !== expectedSystemPromptHash) {
+        throw new Error(
+          `System prompt hash mismatch: expected ${expectedSystemPromptHash}, got ${systemPromptHash.toLowerCase()}`,
+        )
+      }
+    }
+    if (systemPrompt && systemPromptHash) {
+      logger.info('System prompt configured', {
+        source: systemPromptSource,
+        systemPromptLength: systemPrompt.length,
+        systemPromptHash,
+      })
+    }
+
+    const natsSoakRequired =
+      (process.env.CODEX_NATS_SOAK_REQUIRED ?? 'true').trim().toLowerCase() !== 'false' &&
+      (process.env.CODEX_NATS_SOAK_REQUIRED ?? 'true').trim() !== '0'
+
+    const shouldRequireMemories =
+      !isBatchTask && stage === 'implementation' && ((iteration ?? 1) >= 2 || (iterationCycle ?? 1) >= 2)
+    const memoryNamespace = `codex:${repository}:${issueNumber}`
+    const memoryQuery = `issue ${issueNumber} ${issueTitle || repository} codex run summary`
+    memorySoak = await fetchJangarMemories({
+      logger,
+      required: shouldRequireMemories,
+      namespace: memoryNamespace,
+      query: memoryQuery,
+      limit: 12,
+    })
+    const memoryContextBlock = formatMemoryContextBlock(memorySoak)
+    if (memoryContextBlock) {
+      prompt = `${memoryContextBlock}\n\n${prompt}`
+    }
+
+    natsContext = await fetchNatsContext({
+      logger,
+      required: natsSoakRequired,
+      outputPath: natsContextPath,
+    })
+    const natsContextBlock = formatNatsContextBlock(natsContext)
+    if (natsContextBlock) {
+      prompt = `${natsContextBlock}\n\n${prompt}`
+    }
+    const maxPromptChars = parsePositiveIntEnv(process.env.CODEX_MAX_PROMPT_CHARS, DEFAULT_MAX_PROMPT_CHARS)
+    prompt = fitPromptToBudget({
+      prompt,
+      maxChars: maxPromptChars,
+      logger,
+      label: 'initial',
+    })
+
+    await ensureEmptyFile(outputPath)
+    await ensureEmptyFile(jsonOutputPath)
+    await ensureEmptyFile(agentOutputPath)
+    await ensureEmptyFile(runtimeLogPath)
+
+    if (process.env.CODEX_SKIP_RUN_STARTED !== '1') {
+      const attrs = enrichRunNatsAttrs({ stage, iteration, iterationCycle }, requirementMetadata)
+      if (systemPromptHash) {
+        attrs.systemPromptHash = systemPromptHash
+      }
+      await publishNatsEvent(logger, {
+        kind: 'run-started',
+        content: `${stage} started`,
+        attrs,
+      })
+    }
+
     if (supportsResume) {
       resumeContext = await loadResumeMetadata({
         worktree,
@@ -3934,7 +4036,7 @@ export const runCodexImplementation = async (eventPath: string) => {
 
     const prNumberRaw = await readOptionalTextFile(prNumberPath, logger)
     const prUrlRaw = await readOptionalTextFile(prUrlPath, logger)
-    let prNumber = prNumberRaw ? parseOptionalPrNumber(prNumberRaw) : null
+    prNumber = prNumberRaw ? parseOptionalPrNumber(prNumberRaw) : null
     prUrl = prUrlRaw ? prUrlRaw : null
     if (!isBatchTask) {
       const pullRequestsEnabled = parseBoolean(process.env.VCS_PULL_REQUESTS_ENABLED, false)
@@ -4055,7 +4157,7 @@ export const runCodexImplementation = async (eventPath: string) => {
     const hulyDecision = 'completed' as const
     const natsDecision = 'pass'
 
-    if (!isBatchTask && hulyArtifacts && crossSwarmHulyChannel) {
+    if (!isBatchTask && hulyArtifacts && crossSwarmHulyChannel && !hulyArtifacts.prelaunchFailure) {
       hulyArtifacts = await buildHulyArtifactsFromRun({
         artifacts: hulyArtifacts,
         logger,
@@ -4199,7 +4301,7 @@ export const runCodexImplementation = async (eventPath: string) => {
     }
   } finally {
     if (!runSucceeded) {
-      if (!isBatchTask && crossSwarmHulyChannel && hulyArtifacts) {
+      if (!isBatchTask && crossSwarmHulyChannel && hulyArtifacts && !hulyArtifacts.prelaunchFailure) {
         const summary = extractSummary(lastAssistantMessage)
         const tests = extractTests(lastAssistantMessage)
         const gaps = extractKnownGaps(lastAssistantMessage)
@@ -4227,6 +4329,24 @@ export const runCodexImplementation = async (eventPath: string) => {
         }
       }
 
+      const failureMissingItems = hulyArtifacts?.prelaunchFailure?.reasonCodes.length
+        ? hulyArtifacts.prelaunchFailure.reasonCodes
+        : ['unknown_failure']
+      const failureGapAttrs: Record<string, unknown> = {
+        stage,
+        missingItems: failureMissingItems,
+        suggestedFixes: [],
+        iteration,
+        iterationCycle,
+      }
+      if (hulyArtifacts?.prelaunchFailure) {
+        failureGapAttrs.passportDecision = hulyArtifacts.prelaunchFailure.passportDecision
+        failureGapAttrs.passportId = hulyArtifacts.prelaunchFailure.passportId
+        failureGapAttrs.runtimeKitClass = hulyArtifacts.prelaunchFailure.runtimeKitClass
+        failureGapAttrs.runtimeKitDecision = hulyArtifacts.prelaunchFailure.runtimeKitDecision
+        failureGapAttrs.runtimeKitId = hulyArtifacts.prelaunchFailure.runtimeKitId
+      }
+
       if (!isBatchTask) {
         await postProgressComment({
           logger,
@@ -4243,17 +4363,81 @@ export const runCodexImplementation = async (eventPath: string) => {
       }
       await publishNatsEvent(logger, {
         kind: 'run-gaps',
-        content: 'Run failed before emitting gaps; inspect logs and artifacts.',
-        attrs: enrichRunNatsAttrs(
-          { stage, missingItems: ['unknown_failure'], suggestedFixes: [], iteration, iterationCycle },
-          requirementMetadata,
-        ),
+        content:
+          hulyArtifacts?.prelaunchFailure != null
+            ? `Pre-launch runtime passport refused: ${buildHulyPrelaunchFailureMessage(hulyArtifacts.prelaunchFailure)}`
+            : 'Run failed before emitting gaps; inspect logs and artifacts.',
+        attrs: enrichRunNatsAttrs(failureGapAttrs, requirementMetadata),
       })
       await publishNatsEvent(logger, {
         kind: 'run-outcome',
         content: `${stage} failed`,
-        attrs: enrichRunNatsAttrs({ stage, decision: 'fail', iteration, iterationCycle }, requirementMetadata),
+        attrs: enrichRunNatsAttrs(
+          {
+            stage,
+            decision: 'fail',
+            iteration,
+            iterationCycle,
+            passportDecision: hulyArtifacts?.prelaunchFailure?.passportDecision,
+            passportId: hulyArtifacts?.prelaunchFailure?.passportId,
+          },
+          requirementMetadata,
+        ),
       })
+
+      try {
+        const failureLogExcerpt = await collectLogExcerpts(
+          {
+            outputPath,
+            jsonOutputPath,
+            agentOutputPath,
+            runtimeLogPath,
+            statusPath,
+          },
+          logger,
+        )
+        const failureNotifyPayload = buildNotifyPayload({
+          repository,
+          issueNumber,
+          baseBranch,
+          headBranch,
+          prompt,
+          stage,
+          outputPath,
+          jsonOutputPath,
+          agentOutputPath,
+          runtimeLogPath,
+          statusPath,
+          patchPath,
+          archivePath,
+          notifyPath,
+          manifestPath,
+          headShaPath,
+          commitShaPath,
+          prNumberPath,
+          prUrlPath,
+          sessionId: capturedSessionId,
+          lastAssistantMessage:
+            lastAssistantMessage ??
+            (hulyArtifacts?.prelaunchFailure
+              ? `Pre-launch runtime passport refused: ${buildHulyPrelaunchFailureMessage(hulyArtifacts.prelaunchFailure)}`
+              : `${stage} failed before a final assistant response was captured.`),
+          logExcerpt: failureLogExcerpt,
+          prNumber,
+          prUrl,
+          contextSoak: natsContext,
+          memorySoak,
+          iteration,
+          iterationCycle,
+          iterations,
+          requirementMetadata,
+          hulyArtifacts,
+        })
+        await ensureFileDirectory(notifyPath)
+        await writeFile(notifyPath, JSON.stringify(failureNotifyPayload, null, 2), 'utf8')
+      } catch (error) {
+        logger.warn('Failed to persist notify payload for failed run artifacts', error)
+      }
     }
     await ensureNotifyPlaceholder(notifyPath, logger)
     try {

--- a/services/jangar/scripts/codex/lib/huly-api-client.ts
+++ b/services/jangar/scripts/codex/lib/huly-api-client.ts
@@ -1,8 +1,8 @@
 import { spawn as spawnChild } from 'node:child_process'
 import { existsSync } from 'node:fs'
-import { join } from 'node:path'
-import { fileURLToPath } from 'node:url'
 import process from 'node:process'
+
+import { resolveHulyApiScriptPathCandidates } from '../../../src/server/control-plane-runtime-admission'
 
 interface CommandResult {
   exitCode: number
@@ -87,26 +87,30 @@ type HulyArtifactOperationResult =
   | HulyPostChannelMessageResult
   | HulyUpsertMissionResult
 
-const DEFAULT_HULY_API_PATH = fileURLToPath(
-  new URL('../../../../../skills/huly-api/scripts/huly-api.py', import.meta.url),
-)
-const WORKSPACE_HULY_API_PATH = '/workspace/lab/skills/huly-api/scripts/huly-api.py'
-const TMP_WORKSPACE_HULY_API_PATH = '/tmp/proompt-lab/skills/huly-api/scripts/huly-api.py'
-const BUNDLED_HULY_API_PATH = '/root/.codex/skills/huly-api/scripts/huly-api.py'
 const DEFAULT_PYTHON_BIN = 'python3'
 
-const formatMissingHulyApiScriptError = (candidates: string[]) => {
-  const checkedPaths = candidates.join(', ')
-  return new Error(
-    `runtime_missing_component:huly_api_script checked_paths=[${checkedPaths}] ` +
-      'The AgentRun auth mount can shadow /root/.codex, so the helper must also exist in the runtime workspace/image.',
-  )
+export class RuntimeMissingComponentError extends Error {
+  code = 'runtime_missing_component' as const
+  reasonCode = 'runtime_kit_component_missing' as const
+  componentKind = 'python_helper' as const
+  componentRef = 'skills/huly-api/scripts/huly-api.py' as const
+  checkedPaths: string[]
+
+  constructor(candidates: string[]) {
+    const checkedPaths = candidates.join(', ')
+    super(
+      `runtime_missing_component:huly_api_script checked_paths=[${checkedPaths}] ` +
+        'The AgentRun auth mount can shadow /root/.codex, so the helper must also exist in the runtime workspace/image.',
+    )
+    this.name = 'RuntimeMissingComponentError'
+    this.checkedPaths = candidates
+  }
 }
 
-const resolveDefaultHulyApiScriptCandidates = () => {
-  const cwdPath = join(process.cwd(), 'skills', 'huly-api', 'scripts', 'huly-api.py')
-  return [DEFAULT_HULY_API_PATH, cwdPath, WORKSPACE_HULY_API_PATH, TMP_WORKSPACE_HULY_API_PATH, BUNDLED_HULY_API_PATH]
-}
+const formatMissingHulyApiScriptError = (candidates: string[]) => new RuntimeMissingComponentError(candidates)
+
+export const isRuntimeMissingComponentError = (error: unknown): error is RuntimeMissingComponentError =>
+  error instanceof RuntimeMissingComponentError
 
 const runProcess = async (command: string, args: string[]): Promise<CommandResult> => {
   return await new Promise<CommandResult>((resolve, reject) => {
@@ -408,7 +412,7 @@ export const resolveHulyApiScriptPath = () => {
     return configured
   }
 
-  const candidates = resolveDefaultHulyApiScriptCandidates()
+  const candidates = resolveHulyApiScriptPathCandidates()
 
   for (const candidate of candidates) {
     if (existsSync(candidate)) {

--- a/services/jangar/src/components/__tests__/agents-control-plane-status.test.tsx
+++ b/services/jangar/src/components/__tests__/agents-control-plane-status.test.tsx
@@ -118,6 +118,9 @@ const baseStatus: ControlPlaneStatus = {
     untouched_run_count: 0,
     oldest_untouched_age_seconds: null,
   },
+  runtime_kits: [],
+  admission_passports: [],
+  serving_passport_id: null,
   rollout_health: {
     status: 'healthy',
     observed_deployments: 0,

--- a/services/jangar/src/data/agents-control-plane.ts
+++ b/services/jangar/src/data/agents-control-plane.ts
@@ -222,6 +222,64 @@ export type ExecutionTrustStage = {
   data_confidence: 'high' | 'degraded' | 'unknown'
 }
 
+export type RuntimeKitClass = 'serving' | 'collaboration'
+
+export type RuntimeKitDecision = 'healthy' | 'degraded' | 'blocked' | 'unknown'
+
+export type RuntimeKitComponentKind = 'python_helper' | 'binary' | 'workspace_path' | 'config_file' | 'service_url'
+
+export type RuntimeKitComponentStatus = {
+  component_kind: RuntimeKitComponentKind
+  component_ref: string
+  required: boolean
+  present: boolean
+  digest: string | null
+  reason_code: string | null
+  evidence_ref: string | null
+}
+
+export type RuntimeKitStatus = {
+  runtime_kit_id: string
+  kit_class: RuntimeKitClass
+  subject_ref: string
+  image_ref: string
+  workspace_contract_version: string
+  component_digest: string
+  decision: RuntimeKitDecision
+  observed_at: string
+  fresh_until: string
+  producer_revision: string
+  reason_codes: string[]
+  components: RuntimeKitComponentStatus[]
+}
+
+export type AdmissionPassportConsumerClass = 'serving' | 'swarm_plan' | 'swarm_implement' | 'swarm_verify'
+
+export type AdmissionPassportDecision = 'allow' | 'degrade' | 'hold' | 'block'
+
+export type AdmissionPassportSubjectStatus = {
+  subject_kind: 'authority' | 'runtime_kit'
+  subject_ref: string
+  required: boolean
+  decision: AdmissionPassportDecision
+  evidence_ref: string | null
+}
+
+export type AdmissionPassportStatus = {
+  admission_passport_id: string
+  consumer_class: AdmissionPassportConsumerClass
+  authority_session_id: string
+  recovery_case_set_digest: string
+  runtime_kit_set_digest: string
+  decision: AdmissionPassportDecision
+  reason_codes: string[]
+  required_subjects: AdmissionPassportSubjectStatus[]
+  required_runtime_kits: string[]
+  issued_at: string
+  fresh_until: string
+  producer_revision: string
+}
+
 export type DependencyQuorumDecision = 'allow' | 'delay' | 'block' | 'unknown'
 
 export type DependencyQuorumSegmentStatus = 'healthy' | 'degraded' | 'blocked'
@@ -361,6 +419,9 @@ export type ControlPlaneStatus = {
   grpc: GrpcStatus
   watch_reliability: ControlPlaneWatchReliability
   agentrun_ingestion: AgentRunIngestionStatus
+  runtime_kits: RuntimeKitStatus[]
+  admission_passports: AdmissionPassportStatus[]
+  serving_passport_id: string | null
   rollout_health: ControlPlaneRolloutHealth
   empirical_services: EmpiricalServicesStatus
   execution_trust: ExecutionTrustStatus

--- a/services/jangar/src/routes/ready.test.ts
+++ b/services/jangar/src/routes/ready.test.ts
@@ -21,6 +21,11 @@ const controlPlaneStatusMocks = vi.hoisted(() => ({
   buildExecutionTrust: vi.fn(),
 }))
 
+const runtimeAdmissionMocks = vi.hoisted(() => ({
+  buildRuntimeAdmissionSnapshot: vi.fn(),
+  findAdmissionPassport: vi.fn(),
+}))
+
 vi.mock('~/server/agents-controller', () => agentsControllerMocks)
 vi.mock('~/server/leader-election', () => leaderElectionMocks)
 vi.mock('~/server/orchestration-controller', () => orchestrationControllerMocks)
@@ -32,11 +37,74 @@ vi.mock('~/server/control-plane-status', async () => {
     buildExecutionTrust: controlPlaneStatusMocks.buildExecutionTrust,
   }
 })
+vi.mock('~/server/control-plane-runtime-admission', () => runtimeAdmissionMocks)
+
+const buildRuntimeKit = (overrides: Record<string, unknown> = {}) => ({
+  runtime_kit_id: 'runtime-kit:serving:1',
+  kit_class: 'serving',
+  subject_ref: 'jangar:/ready',
+  image_ref: 'runtime:local',
+  workspace_contract_version: 'shadow-v1',
+  component_digest: 'digest-serving',
+  decision: 'healthy',
+  observed_at: '2026-03-08T21:00:00Z',
+  fresh_until: '2026-03-08T21:05:00Z',
+  producer_revision: 'shadow-v1',
+  reason_codes: [],
+  components: [],
+  ...overrides,
+})
+
+const buildAdmissionPassport = (overrides: Record<string, unknown> = {}) => ({
+  admission_passport_id: 'passport:serving:1',
+  consumer_class: 'serving',
+  authority_session_id: 'authority-session:1',
+  recovery_case_set_digest: 'recovery-1',
+  runtime_kit_set_digest: 'runtime-1',
+  decision: 'allow',
+  reason_codes: [],
+  required_subjects: [],
+  required_runtime_kits: ['runtime-kit:serving:1'],
+  issued_at: '2026-03-08T21:00:00Z',
+  fresh_until: '2026-03-08T21:05:00Z',
+  producer_revision: 'shadow-v1',
+  ...overrides,
+})
+
+const buildRuntimeAdmissionSnapshot = (
+  overrides: Partial<{
+    runtimeKits: Array<Record<string, unknown>>
+    admissionPassports: Array<Record<string, unknown>>
+    servingPassportId: string | null
+  }> = {},
+) => ({
+  runtimeKits: overrides.runtimeKits ?? [
+    buildRuntimeKit(),
+    buildRuntimeKit({
+      runtime_kit_id: 'runtime-kit:collaboration:1',
+      kit_class: 'collaboration',
+      subject_ref: 'jangar:codex:huly-collaboration',
+      component_digest: 'digest-collaboration',
+    }),
+  ],
+  admissionPassports: overrides.admissionPassports ?? [
+    buildAdmissionPassport(),
+    buildAdmissionPassport({
+      admission_passport_id: 'passport:swarm_implement:1',
+      consumer_class: 'swarm_implement',
+      runtime_kit_set_digest: 'runtime-2',
+      required_runtime_kits: ['runtime-kit:collaboration:1'],
+    }),
+  ],
+  servingPassportId: overrides.servingPassportId ?? 'passport:serving:1',
+})
 
 describe('getReadyHandler', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     controlPlaneStatusMocks.buildExecutionTrust.mockReset()
+    runtimeAdmissionMocks.buildRuntimeAdmissionSnapshot.mockReset()
+    runtimeAdmissionMocks.findAdmissionPassport.mockReset()
     controlPlaneStatusMocks.buildExecutionTrust.mockResolvedValue({
       executionTrust: {
         status: 'healthy',
@@ -48,6 +116,10 @@ describe('getReadyHandler', () => {
       swarms: [],
       stages: [],
     })
+    runtimeAdmissionMocks.buildRuntimeAdmissionSnapshot.mockReturnValue(buildRuntimeAdmissionSnapshot())
+    runtimeAdmissionMocks.findAdmissionPassport.mockImplementation(({ admissionPassports, consumerClass }) =>
+      admissionPassports.find((passport: { consumer_class?: string }) => passport.consumer_class === consumerClass),
+    )
 
     agentsControllerMocks.getAgentsControllerHealth.mockReturnValue({
       enabled: true,
@@ -106,6 +178,52 @@ describe('getReadyHandler', () => {
     expect(response.status).toBe(200)
     const body = await response.json()
     expect(body.status).toBe('ok')
+  })
+
+  it('returns 200 and exposes a serving passport when only collaboration runtime debt is blocked', async () => {
+    runtimeAdmissionMocks.buildRuntimeAdmissionSnapshot.mockReturnValue(
+      buildRuntimeAdmissionSnapshot({
+        runtimeKits: [
+          buildRuntimeKit(),
+          buildRuntimeKit({
+            runtime_kit_id: 'runtime-kit:collaboration:2',
+            kit_class: 'collaboration',
+            subject_ref: 'jangar:codex:huly-collaboration',
+            component_digest: 'digest-collaboration-2',
+            decision: 'blocked',
+            reason_codes: ['runtime_kit_component_missing:huly_api_script'],
+          }),
+        ],
+        admissionPassports: [
+          buildAdmissionPassport(),
+          buildAdmissionPassport({
+            admission_passport_id: 'passport:swarm_implement:2',
+            consumer_class: 'swarm_implement',
+            runtime_kit_set_digest: 'runtime-2',
+            decision: 'block',
+            reason_codes: ['runtime_kit_component_missing:huly_api_script'],
+            required_runtime_kits: ['runtime-kit:collaboration:2'],
+          }),
+        ],
+      }),
+    )
+
+    const { getReadyHandler } = await import('./ready')
+
+    const response = await getReadyHandler()
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.status).toBe('ok')
+    expect(body.serving_passport_id).toBe('passport:serving:1')
+    expect(body.runtime_kits).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kit_class: 'collaboration',
+          decision: 'blocked',
+        }),
+      ]),
+    )
   })
 
   it('returns 503 when AgentRun ingestion is degraded', async () => {
@@ -234,6 +352,18 @@ describe('getReadyHandler', () => {
   })
 
   it('returns 503 when execution trust is blocked', async () => {
+    runtimeAdmissionMocks.buildRuntimeAdmissionSnapshot.mockReturnValue(
+      buildRuntimeAdmissionSnapshot({
+        admissionPassports: [
+          buildAdmissionPassport({
+            admission_passport_id: 'passport:serving:blocked',
+            decision: 'block',
+            reason_codes: ['execution_trust_blocked'],
+          }),
+        ],
+        servingPassportId: 'passport:serving:blocked',
+      }),
+    )
     controlPlaneStatusMocks.buildExecutionTrust.mockResolvedValue({
       executionTrust: {
         status: 'blocked',
@@ -266,7 +396,43 @@ describe('getReadyHandler', () => {
     })
   })
 
+  it('returns 503 when the serving passport is blocked', async () => {
+    runtimeAdmissionMocks.buildRuntimeAdmissionSnapshot.mockReturnValue(
+      buildRuntimeAdmissionSnapshot({
+        admissionPassports: [
+          buildAdmissionPassport({
+            admission_passport_id: 'passport:serving:2',
+            decision: 'block',
+            reason_codes: ['runtime_kit_component_missing:serving_runtime_binary'],
+          }),
+        ],
+        servingPassportId: 'passport:serving:2',
+      }),
+    )
+
+    const { getReadyHandler } = await import('./ready')
+
+    const response = await getReadyHandler()
+
+    expect(response.status).toBe(503)
+    const body = await response.json()
+    expect(body.status).toBe('degraded')
+    expect(body.serving_passport_id).toBe('passport:serving:2')
+  })
+
   it('returns 503 when any watched namespace reports blocked execution trust', async () => {
+    runtimeAdmissionMocks.buildRuntimeAdmissionSnapshot.mockReturnValue(
+      buildRuntimeAdmissionSnapshot({
+        admissionPassports: [
+          buildAdmissionPassport({
+            admission_passport_id: 'passport:serving:blocked',
+            decision: 'block',
+            reason_codes: ['execution_trust_blocked'],
+          }),
+        ],
+        servingPassportId: 'passport:serving:blocked',
+      }),
+    )
     agentsControllerMocks.getAgentsControllerHealth.mockReturnValue({
       enabled: true,
       started: true,
@@ -341,6 +507,18 @@ describe('getReadyHandler', () => {
   })
 
   it('returns 503 when execution trust evaluation fails', async () => {
+    runtimeAdmissionMocks.buildRuntimeAdmissionSnapshot.mockReturnValue(
+      buildRuntimeAdmissionSnapshot({
+        admissionPassports: [
+          buildAdmissionPassport({
+            admission_passport_id: 'passport:serving:unknown',
+            decision: 'block',
+            reason_codes: ['execution_trust_unknown'],
+          }),
+        ],
+        servingPassportId: 'passport:serving:unknown',
+      }),
+    )
     controlPlaneStatusMocks.buildExecutionTrust.mockRejectedValue(new Error('trust fetch failed'))
     const { getReadyHandler } = await import('./ready')
 

--- a/services/jangar/src/routes/ready.tsx
+++ b/services/jangar/src/routes/ready.tsx
@@ -2,6 +2,7 @@ import { createFileRoute } from '@tanstack/react-router'
 
 import type { ExecutionTrustStatus } from '~/data/agents-control-plane'
 import { assessAgentRunIngestion, getAgentsControllerHealth } from '~/server/agents-controller'
+import { buildRuntimeAdmissionSnapshot, findAdmissionPassport } from '~/server/control-plane-runtime-admission'
 import { getLeaderElectionStatus } from '~/server/leader-election'
 import { getOrchestrationControllerHealth } from '~/server/orchestration-controller'
 import { getSupportingControllerHealth } from '~/server/supporting-primitives-controller'
@@ -121,6 +122,14 @@ export const getReadyHandler = async () => {
   const supportingController = getSupportingControllerHealth()
   const namespaces = agentsController.namespaces?.length ? agentsController.namespaces : ['agents']
   const trust = await executionTrustStatus(namespaces)
+  const runtimeAdmission = buildRuntimeAdmissionSnapshot({
+    now: new Date(),
+    executionTrust: trust,
+  })
+  const servingPassport = findAdmissionPassport({
+    admissionPassports: runtimeAdmission.admissionPassports,
+    consumerClass: 'serving',
+  })
 
   const controllersOk =
     isControllerHealthReady(agentsController) &&
@@ -132,8 +141,9 @@ export const getReadyHandler = async () => {
   const agentsControllerReady = activeControllerReplica
     ? isAgentRunIngestionReady(agentsController)
     : leaderElectionReady
-  const executionTrustReady = trust.status !== 'blocked' && trust.status !== 'unknown'
-  const ready = controllersOk && agentsControllerReady && executionTrustReady
+  const servingPassportReady =
+    servingPassport !== undefined && servingPassport.decision !== 'block' && servingPassport.decision !== 'hold'
+  const ready = controllersOk && agentsControllerReady && servingPassportReady
 
   const body = JSON.stringify({
     status: ready ? 'ok' : 'degraded',
@@ -143,6 +153,9 @@ export const getReadyHandler = async () => {
     orchestrationController,
     supportingController,
     execution_trust: trust,
+    runtime_kits: runtimeAdmission.runtimeKits,
+    admission_passports: runtimeAdmission.admissionPassports,
+    serving_passport_id: runtimeAdmission.servingPassportId,
   })
 
   const headers: Record<string, string> = {

--- a/services/jangar/src/server/__tests__/control-plane-runtime-admission.test.ts
+++ b/services/jangar/src/server/__tests__/control-plane-runtime-admission.test.ts
@@ -1,0 +1,62 @@
+import { fileURLToPath } from 'node:url'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { buildRuntimeAdmissionSnapshot } from '~/server/control-plane-runtime-admission'
+
+const HULY_API_SCRIPT_PATH = fileURLToPath(
+  new URL('../../../../../skills/huly-api/scripts/huly-api.py', import.meta.url),
+)
+
+const ORIGINAL_ENV = { ...process.env }
+
+const resetEnv = () => {
+  for (const key of Object.keys(process.env)) {
+    if (!(key in ORIGINAL_ENV)) {
+      delete process.env[key]
+    }
+  }
+  for (const [key, value] of Object.entries(ORIGINAL_ENV)) {
+    process.env[key] = value
+  }
+}
+
+describe('buildRuntimeAdmissionSnapshot', () => {
+  afterEach(() => {
+    resetEnv()
+  })
+
+  it('accepts HULY_BASE_URL when HULY_API_BASE_URL is unset', () => {
+    delete process.env.HULY_API_BASE_URL
+    process.env.HULY_BASE_URL = 'https://huly.example.test'
+
+    const snapshot = buildRuntimeAdmissionSnapshot({
+      worktree: '/workspace/lab',
+      pythonBin: process.execPath,
+      hulyApiScriptPath: HULY_API_SCRIPT_PATH,
+    })
+
+    const collaborationKit = snapshot.runtimeKits.find((kit) => kit.kit_class === 'collaboration')
+    expect(collaborationKit).toBeDefined()
+    expect(collaborationKit?.decision).toBe('healthy')
+    expect(collaborationKit?.reason_codes).not.toContain('runtime_kit_component_missing:huly_api_base_url')
+
+    const baseUrlComponent = collaborationKit?.components.find(
+      (component) => component.component_kind === 'service_url',
+    )
+    expect(baseUrlComponent).toMatchObject({
+      component_ref: 'HULY_API_BASE_URL|HULY_BASE_URL',
+      present: true,
+      reason_code: null,
+    })
+
+    expect(snapshot.admissionPassports).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          consumer_class: 'swarm_plan',
+          decision: 'allow',
+        }),
+      ]),
+    )
+  })
+})

--- a/services/jangar/src/server/__tests__/control-plane-runtime-admission.test.ts
+++ b/services/jangar/src/server/__tests__/control-plane-runtime-admission.test.ts
@@ -7,6 +7,7 @@ import { buildRuntimeAdmissionSnapshot } from '~/server/control-plane-runtime-ad
 const HULY_API_SCRIPT_PATH = fileURLToPath(
   new URL('../../../../../skills/huly-api/scripts/huly-api.py', import.meta.url),
 )
+const REPO_ROOT = fileURLToPath(new URL('../../../../../', import.meta.url))
 
 const ORIGINAL_ENV = { ...process.env }
 
@@ -31,7 +32,7 @@ describe('buildRuntimeAdmissionSnapshot', () => {
     process.env.HULY_BASE_URL = 'https://huly.example.test'
 
     const snapshot = buildRuntimeAdmissionSnapshot({
-      worktree: '/workspace/lab',
+      worktree: REPO_ROOT,
       pythonBin: process.execPath,
       hulyApiScriptPath: HULY_API_SCRIPT_PATH,
     })

--- a/services/jangar/src/server/__tests__/control-plane-status.test.ts
+++ b/services/jangar/src/server/__tests__/control-plane-status.test.ts
@@ -10,11 +10,13 @@ import type {
   ControlPlaneHeartbeatStoreGetInput,
 } from '~/server/control-plane-heartbeat-store'
 import type {
+  AdmissionPassportStatus,
+  ControlPlaneWatchReliability,
+  DatabaseMigrationConsistency,
   ExecutionTrustStage,
   ExecutionTrustStatus,
   ExecutionTrustSwarm,
-  ControlPlaneWatchReliability,
-  DatabaseMigrationConsistency,
+  RuntimeKitStatus,
   WorkflowsReliabilityStatus,
 } from '~/data/agents-control-plane'
 import { getRegisteredMigrationNames } from '~/server/kysely-migrations'
@@ -424,12 +426,75 @@ describe('control-plane status', () => {
     stages: [] as ExecutionTrustStage[],
   }
 
+  const buildRuntimeKit = (overrides: Partial<RuntimeKitStatus> = {}): RuntimeKitStatus => ({
+    runtime_kit_id: 'runtime-kit:serving:1',
+    kit_class: 'serving',
+    subject_ref: 'jangar:/ready',
+    image_ref: 'runtime:local',
+    workspace_contract_version: 'shadow-v1',
+    component_digest: 'digest-serving',
+    decision: 'healthy',
+    observed_at: '2026-01-20T00:00:00Z',
+    fresh_until: '2026-01-20T00:05:00Z',
+    producer_revision: 'shadow-v1',
+    reason_codes: [],
+    components: [],
+    ...overrides,
+  })
+
+  const buildAdmissionPassport = (overrides: Partial<AdmissionPassportStatus> = {}): AdmissionPassportStatus => ({
+    admission_passport_id: 'passport:serving:1',
+    consumer_class: 'serving',
+    authority_session_id: 'authority-session:1',
+    recovery_case_set_digest: 'recovery-1',
+    runtime_kit_set_digest: 'runtime-1',
+    decision: 'allow',
+    reason_codes: [],
+    required_subjects: [],
+    required_runtime_kits: ['runtime-kit:serving:1'],
+    issued_at: '2026-01-20T00:00:00Z',
+    fresh_until: '2026-01-20T00:05:00Z',
+    producer_revision: 'shadow-v1',
+    ...overrides,
+  })
+
+  const buildRuntimeAdmissionSnapshot = (
+    overrides: Partial<{
+      runtimeKits: RuntimeKitStatus[]
+      admissionPassports: AdmissionPassportStatus[]
+      servingPassportId: string | null
+    }> = {},
+  ) => ({
+    runtimeKits: overrides.runtimeKits ?? [
+      buildRuntimeKit(),
+      buildRuntimeKit({
+        runtime_kit_id: 'runtime-kit:collaboration:1',
+        kit_class: 'collaboration',
+        subject_ref: 'jangar:codex:huly-collaboration',
+        component_digest: 'digest-collaboration',
+      }),
+    ],
+    admissionPassports: overrides.admissionPassports ?? [
+      buildAdmissionPassport(),
+      buildAdmissionPassport({
+        admission_passport_id: 'passport:swarm_implement:1',
+        consumer_class: 'swarm_implement',
+        runtime_kit_set_digest: 'runtime-2',
+        required_runtime_kits: ['runtime-kit:collaboration:1'],
+      }),
+    ],
+    servingPassportId: overrides.servingPassportId ?? 'passport:serving:1',
+  })
+
+  const healthyRuntimeAdmissionSnapshot = buildRuntimeAdmissionSnapshot()
+
   const buildStatus = (
     options: Parameters<typeof buildControlPlaneStatus>[0],
     deps: Parameters<typeof buildControlPlaneStatus>[1] = {},
   ) =>
     buildControlPlaneStatus(options, {
       resolveExecutionTrust: async () => healthyExecutionTrustSnapshot,
+      resolveRuntimeAdmission: () => healthyRuntimeAdmissionSnapshot,
       ...deps,
     })
 
@@ -489,6 +554,9 @@ describe('control-plane status', () => {
     expect(status.service).toBe('jangar')
     expect(status.controllers).toHaveLength(3)
     expect(status.runtime_adapters).toHaveLength(4)
+    expect(status.runtime_kits).toEqual(healthyRuntimeAdmissionSnapshot.runtimeKits)
+    expect(status.admission_passports).toEqual(healthyRuntimeAdmissionSnapshot.admissionPassports)
+    expect(status.serving_passport_id).toBe('passport:serving:1')
     expect(status.workflows).toEqual({
       active_job_runs: 0,
       recent_failed_jobs: 0,
@@ -527,6 +595,99 @@ describe('control-plane status', () => {
     expect(status.empirical_services.forecast.authoritative).toBe(true)
     expect(status.empirical_services.lean.authoritative).toBe(true)
     expect(status.empirical_services.jobs.authoritative).toBe(true)
+  })
+
+  it('surfaces blocked collaboration runtime kits without changing the serving passport id', async () => {
+    setRolloutDeploymentList([healthyRolloutDeployment, healthyAgentsControllersRolloutDeployment])
+
+    const status = await buildStatus(
+      {
+        namespace: 'agents',
+        grpc: {
+          enabled: true,
+          address: '127.0.0.1:50051',
+          status: 'healthy',
+          message: '',
+        },
+      },
+      {
+        now: () => new Date('2026-01-20T00:00:00Z'),
+        getHeartbeat: createHeartbeatResolver(),
+        getAgentsControllerHealth: () => healthyController,
+        getSupportingControllerHealth: () => healthyController,
+        getOrchestrationControllerHealth: () => healthyController,
+        resolveTemporalAdapter: async () => buildTemporalAdapter(),
+        checkDatabase: async () => buildDatabaseStatus(),
+        getWatchReliabilitySummary: () => watchReliabilityHealthy,
+        getWorkflowsReliabilityStatus: async () => buildWorkflowsReliabilityStatus(),
+        resolveEmpiricalServices: async () => ({
+          forecast: {
+            status: 'healthy',
+            endpoint: 'http://torghut-forecast/readyz',
+            message: 'forecast service ready',
+            authoritative: true,
+          },
+          lean: {
+            status: 'healthy',
+            endpoint: 'http://torghut-lean-runner/readyz',
+            message: 'LEAN runner ready',
+            authoritative: true,
+          },
+          jobs: {
+            status: 'healthy',
+            endpoint: 'http://torghut/trading/empirical-jobs',
+            message: 'empirical jobs fresh',
+            authoritative: true,
+            eligible_jobs: [],
+            stale_jobs: [],
+          },
+        }),
+        resolveRuntimeAdmission: () =>
+          buildRuntimeAdmissionSnapshot({
+            runtimeKits: [
+              buildRuntimeKit(),
+              buildRuntimeKit({
+                runtime_kit_id: 'runtime-kit:collaboration:2',
+                kit_class: 'collaboration',
+                subject_ref: 'jangar:codex:huly-collaboration',
+                component_digest: 'digest-collaboration',
+                decision: 'blocked',
+                reason_codes: ['runtime_kit_component_missing:huly_api_script'],
+              }),
+            ],
+            admissionPassports: [
+              buildAdmissionPassport(),
+              buildAdmissionPassport({
+                admission_passport_id: 'passport:swarm_implement:2',
+                consumer_class: 'swarm_implement',
+                runtime_kit_set_digest: 'runtime-2',
+                decision: 'block',
+                reason_codes: ['runtime_kit_component_missing:huly_api_script'],
+                required_runtime_kits: ['runtime-kit:collaboration:2'],
+              }),
+            ],
+          }),
+      },
+    )
+
+    expect(status.serving_passport_id).toBe('passport:serving:1')
+    expect(status.runtime_kits).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kit_class: 'collaboration',
+          decision: 'blocked',
+        }),
+      ]),
+    )
+    expect(status.admission_passports).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          consumer_class: 'swarm_implement',
+          decision: 'block',
+        }),
+      ]),
+    )
+    expect(status.namespaces[0]?.degraded_components ?? []).toContain('runtime_kit:collaboration')
   })
 
   it('marks degraded components when controllers or database fail', async () => {

--- a/services/jangar/src/server/control-plane-runtime-admission.ts
+++ b/services/jangar/src/server/control-plane-runtime-admission.ts
@@ -63,6 +63,13 @@ const resolveWorktree = (value?: string) => {
 
 const normalizeCandidate = (value: string | undefined | null) => value?.trim() ?? ''
 
+const resolveHulyBaseUrl = (configuredValue?: string) =>
+  configuredValue?.trim() ||
+  process.env.HULY_API_BASE_URL?.trim() ||
+  process.env.HULY_BASE_URL?.trim() ||
+  process.env.hulyApiBaseUrl?.trim() ||
+  ''
+
 export const resolveHulyApiScriptPathCandidates = ({
   worktree,
   configuredPath,
@@ -388,8 +395,7 @@ export const buildRuntimeAdmissionSnapshot = (input: RuntimeAdmissionInput = {})
   const pythonRef =
     input.pythonBin?.trim() || process.env.PYTHON_BIN?.trim() || process.env.PYTHON?.trim() || DEFAULT_PYTHON_BIN
   const resolvedPythonPath = resolveCommandCandidate(pythonRef)
-  const hulyApiBaseUrl =
-    input.hulyApiBaseUrl?.trim() || process.env.HULY_API_BASE_URL?.trim() || process.env.hulyApiBaseUrl?.trim() || ''
+  const hulyApiBaseUrl = resolveHulyBaseUrl(input.hulyApiBaseUrl)
   const hulyApiCandidates = resolveHulyApiScriptPathCandidates({
     worktree,
     configuredPath: input.hulyApiScriptPath?.trim() || process.env.HULY_API_SCRIPT_PATH?.trim(),
@@ -444,7 +450,7 @@ export const buildRuntimeAdmissionSnapshot = (input: RuntimeAdmissionInput = {})
       }),
       buildConfigComponent({
         componentKind: 'service_url',
-        componentRef: 'HULY_API_BASE_URL',
+        componentRef: 'HULY_API_BASE_URL|HULY_BASE_URL',
         required: true,
         value: hulyApiBaseUrl,
         reasonCode: 'runtime_kit_component_missing:huly_api_base_url',

--- a/services/jangar/src/server/control-plane-runtime-admission.ts
+++ b/services/jangar/src/server/control-plane-runtime-admission.ts
@@ -1,0 +1,480 @@
+import { createHash } from 'node:crypto'
+import { existsSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+import process from 'node:process'
+
+import type {
+  AdmissionPassportConsumerClass,
+  AdmissionPassportDecision,
+  AdmissionPassportStatus,
+  AdmissionPassportSubjectStatus,
+  ExecutionTrustStatus,
+  RuntimeKitComponentStatus,
+  RuntimeKitDecision,
+  RuntimeKitStatus,
+} from '~/data/agents-control-plane'
+
+const DEFAULT_PYTHON_BIN = 'python3'
+const DEFAULT_WORKTREE = '/workspace/lab'
+const HULY_API_SCRIPT_RELATIVE_PATH = join('skills', 'huly-api', 'scripts', 'huly-api.py')
+const WORKSPACE_HULY_API_PATH = '/workspace/lab/skills/huly-api/scripts/huly-api.py'
+const TMP_WORKSPACE_HULY_API_PATH = '/tmp/proompt-lab/skills/huly-api/scripts/huly-api.py'
+const APP_HULY_API_PATH = '/app/skills/huly-api/scripts/huly-api.py'
+const BUNDLED_HULY_API_PATH = '/root/.codex/skills/huly-api/scripts/huly-api.py'
+const PRODUCER_REVISION = '2026-03-21-runtime-admission-shadow-v1'
+const WORKSPACE_CONTRACT_VERSION = '2026-03-20-runtime-kit-shadow-v1'
+const RUNTIME_FRESHNESS_MS = 5 * 60 * 1000
+
+const COLLABORATION_CONSUMERS: AdmissionPassportConsumerClass[] = ['swarm_plan', 'swarm_implement', 'swarm_verify']
+
+export type RuntimeAdmissionSnapshot = {
+  runtimeKits: RuntimeKitStatus[]
+  admissionPassports: AdmissionPassportStatus[]
+  servingPassportId: string | null
+}
+
+type RuntimeAdmissionInput = {
+  now?: Date
+  executionTrust?: ExecutionTrustStatus
+  worktree?: string
+  pythonBin?: string
+  hulyApiBaseUrl?: string
+  hulyApiScriptPath?: string
+}
+
+const hashText = (value: string) => createHash('sha256').update(value).digest('hex')
+
+const digestObject = (value: unknown) => hashText(JSON.stringify(value))
+
+const shortDigest = (value: string) => value.slice(0, 16)
+
+const addMs = (value: Date, ms: number) => new Date(value.getTime() + ms)
+
+const unique = <T>(values: T[]) => [...new Set(values)]
+
+const resolveWorktree = (value?: string) => {
+  const configured = value?.trim() || process.env.WORKTREE?.trim()
+  if (configured && configured.length > 0) {
+    return configured
+  }
+  const cwd = process.cwd().trim()
+  return cwd.length > 0 ? cwd : DEFAULT_WORKTREE
+}
+
+const normalizeCandidate = (value: string | undefined | null) => value?.trim() ?? ''
+
+export const resolveHulyApiScriptPathCandidates = ({
+  worktree,
+  configuredPath,
+  cwd,
+}: {
+  worktree?: string
+  configuredPath?: string
+  cwd?: string
+} = {}) => {
+  const resolvedWorktree = resolveWorktree(worktree)
+  const resolvedCwd = normalizeCandidate(cwd) || process.cwd()
+  const configured = normalizeCandidate(configuredPath)
+
+  if (configured.length > 0) {
+    return [configured]
+  }
+
+  return unique(
+    [
+      join(resolvedCwd, HULY_API_SCRIPT_RELATIVE_PATH),
+      join(resolvedWorktree, HULY_API_SCRIPT_RELATIVE_PATH),
+      WORKSPACE_HULY_API_PATH,
+      TMP_WORKSPACE_HULY_API_PATH,
+      APP_HULY_API_PATH,
+      BUNDLED_HULY_API_PATH,
+    ].filter((candidate) => candidate.length > 0),
+  )
+}
+
+const findExistingCandidate = (candidates: string[]) => candidates.find((candidate) => existsSync(candidate))
+
+const resolveCommandCandidate = (command: string) => {
+  const trimmed = command.trim()
+  if (trimmed.length === 0) {
+    return undefined
+  }
+  if (trimmed.includes('/')) {
+    return existsSync(trimmed) ? trimmed : undefined
+  }
+
+  const pathEntries = (process.env.PATH ?? '').split(':').filter((entry) => entry.length > 0)
+  for (const entry of pathEntries) {
+    const candidate = join(entry, trimmed)
+    if (existsSync(candidate)) {
+      return candidate
+    }
+  }
+
+  return undefined
+}
+
+const buildFileDigest = (path: string) => {
+  const stats = statSync(path)
+  return shortDigest(hashText(`${path}:${stats.size}:${stats.mtimeMs}`))
+}
+
+const buildRuntimeKitComponent = (input: {
+  componentKind: RuntimeKitComponentStatus['component_kind']
+  componentRef: string
+  required: boolean
+  path?: string
+  reasonCode?: string
+  evidenceRef?: string
+}) => {
+  if (input.path && existsSync(input.path)) {
+    return {
+      component_kind: input.componentKind,
+      component_ref: input.componentRef,
+      required: input.required,
+      present: true,
+      digest: buildFileDigest(input.path),
+      reason_code: null,
+      evidence_ref: input.path,
+    } satisfies RuntimeKitComponentStatus
+  }
+
+  return {
+    component_kind: input.componentKind,
+    component_ref: input.componentRef,
+    required: input.required,
+    present: false,
+    digest: null,
+    reason_code: input.reasonCode ?? null,
+    evidence_ref: input.evidenceRef ?? input.path ?? null,
+  } satisfies RuntimeKitComponentStatus
+}
+
+const buildConfigComponent = (input: {
+  componentKind: RuntimeKitComponentStatus['component_kind']
+  componentRef: string
+  required: boolean
+  value?: string
+  reasonCode: string
+}) => {
+  const value = input.value?.trim() ?? ''
+  if (value.length > 0) {
+    return {
+      component_kind: input.componentKind,
+      component_ref: input.componentRef,
+      required: input.required,
+      present: true,
+      digest: shortDigest(hashText(value)),
+      reason_code: null,
+      evidence_ref: input.componentRef,
+    } satisfies RuntimeKitComponentStatus
+  }
+
+  return {
+    component_kind: input.componentKind,
+    component_ref: input.componentRef,
+    required: input.required,
+    present: false,
+    digest: null,
+    reason_code: input.reasonCode,
+    evidence_ref: input.componentRef,
+  } satisfies RuntimeKitComponentStatus
+}
+
+const summarizeKitDecision = (components: RuntimeKitComponentStatus[]): RuntimeKitDecision => {
+  const missingRequired = components.some((component) => component.required && !component.present)
+  if (missingRequired) {
+    return 'blocked'
+  }
+  const missingOptional = components.some((component) => !component.required && !component.present)
+  if (missingOptional) {
+    return 'degraded'
+  }
+  return 'healthy'
+}
+
+const buildRuntimeKit = (input: {
+  now: Date
+  kitClass: RuntimeKitStatus['kit_class']
+  subjectRef: string
+  imageRef: string
+  components: RuntimeKitComponentStatus[]
+}) => {
+  const componentDigest = shortDigest(
+    digestObject(
+      input.components.map((component) => ({
+        component_kind: component.component_kind,
+        component_ref: component.component_ref,
+        digest: component.digest,
+        present: component.present,
+        reason_code: component.reason_code,
+      })),
+    ),
+  )
+  const decision = summarizeKitDecision(input.components)
+  const reasonCodes = unique(
+    input.components.map((component) => component.reason_code).filter((value): value is string => Boolean(value)),
+  )
+
+  return {
+    runtime_kit_id: `runtime-kit:${input.kitClass}:${componentDigest}`,
+    kit_class: input.kitClass,
+    subject_ref: input.subjectRef,
+    image_ref: input.imageRef,
+    workspace_contract_version: WORKSPACE_CONTRACT_VERSION,
+    component_digest: componentDigest,
+    decision,
+    observed_at: input.now.toISOString(),
+    fresh_until: addMs(input.now, RUNTIME_FRESHNESS_MS).toISOString(),
+    producer_revision: PRODUCER_REVISION,
+    reason_codes: reasonCodes,
+    components: input.components,
+  } satisfies RuntimeKitStatus
+}
+
+const resolveAuthority = (executionTrust?: ExecutionTrustStatus) => {
+  const trust =
+    executionTrust ??
+    ({
+      status: 'healthy',
+      reason: 'execution trust assumed healthy for runtime-local compilation',
+      last_evaluated_at: new Date(0).toISOString(),
+      blocking_windows: [],
+      evidence_summary: [],
+    } satisfies ExecutionTrustStatus)
+
+  const recoveryCaseSetDigest = shortDigest(
+    digestObject({
+      status: trust.status,
+      reason: trust.reason,
+      blocking_windows: trust.blocking_windows,
+      evidence_summary: trust.evidence_summary,
+    }),
+  )
+
+  const reasonCodes =
+    trust.status === 'healthy'
+      ? []
+      : [
+          trust.status === 'blocked'
+            ? 'execution_trust_blocked'
+            : trust.status === 'unknown'
+              ? 'execution_trust_unknown'
+              : 'execution_trust_degraded',
+        ]
+
+  return {
+    authoritySessionId: `authority-session:${recoveryCaseSetDigest}`,
+    recoveryCaseSetDigest,
+    reasonCodes,
+    trust,
+  }
+}
+
+const toRuntimeSubjectDecision = (decision: RuntimeKitDecision): AdmissionPassportDecision => {
+  if (decision === 'blocked' || decision === 'unknown') {
+    return 'block'
+  }
+  if (decision === 'degraded') {
+    return 'hold'
+  }
+  return 'allow'
+}
+
+const buildPassport = (input: {
+  now: Date
+  consumerClass: AdmissionPassportConsumerClass
+  authority: ReturnType<typeof resolveAuthority>
+  runtimeKits: RuntimeKitStatus[]
+}) => {
+  const runtimeKitSetDigest = shortDigest(
+    digestObject(
+      input.runtimeKits.map((kit) => ({
+        runtime_kit_id: kit.runtime_kit_id,
+        decision: kit.decision,
+        component_digest: kit.component_digest,
+      })),
+    ),
+  )
+  const runtimeReasons = input.runtimeKits.flatMap((kit) => kit.reason_codes)
+  const reasonCodes = unique([...input.authority.reasonCodes, ...runtimeReasons])
+
+  let decision: AdmissionPassportDecision = 'allow'
+  if (input.authority.trust.status === 'blocked' || input.authority.trust.status === 'unknown') {
+    decision = 'block'
+  } else if (input.runtimeKits.some((kit) => kit.decision === 'blocked' || kit.decision === 'unknown')) {
+    decision = 'block'
+  } else if (input.authority.trust.status === 'degraded') {
+    decision = input.consumerClass === 'serving' ? 'degrade' : 'hold'
+  } else if (input.runtimeKits.some((kit) => kit.decision === 'degraded')) {
+    decision = input.consumerClass === 'serving' ? 'degrade' : 'hold'
+  }
+
+  const requiredSubjects: AdmissionPassportSubjectStatus[] = [
+    {
+      subject_kind: 'authority',
+      subject_ref: input.authority.authoritySessionId,
+      required: true,
+      decision:
+        input.authority.trust.status === 'healthy'
+          ? 'allow'
+          : input.authority.trust.status === 'degraded'
+            ? input.consumerClass === 'serving'
+              ? 'degrade'
+              : 'hold'
+            : 'block',
+      evidence_ref: input.authority.recoveryCaseSetDigest,
+    },
+    ...input.runtimeKits.map((kit) => ({
+      subject_kind: 'runtime_kit' as const,
+      subject_ref: kit.runtime_kit_id,
+      required: true,
+      decision: toRuntimeSubjectDecision(kit.decision),
+      evidence_ref: kit.reason_codes[0] ?? kit.component_digest,
+    })),
+  ]
+
+  const idSource = shortDigest(
+    digestObject({
+      authority_session_id: input.authority.authoritySessionId,
+      runtime_kit_set_digest: runtimeKitSetDigest,
+      decision,
+      consumer_class: input.consumerClass,
+      reason_codes: reasonCodes,
+    }),
+  )
+
+  return {
+    admission_passport_id: `passport:${input.consumerClass}:${idSource}`,
+    consumer_class: input.consumerClass,
+    authority_session_id: input.authority.authoritySessionId,
+    recovery_case_set_digest: input.authority.recoveryCaseSetDigest,
+    runtime_kit_set_digest: runtimeKitSetDigest,
+    decision,
+    reason_codes: reasonCodes,
+    required_subjects: requiredSubjects,
+    required_runtime_kits: input.runtimeKits.map((kit) => kit.runtime_kit_id),
+    issued_at: input.now.toISOString(),
+    fresh_until: addMs(input.now, RUNTIME_FRESHNESS_MS).toISOString(),
+    producer_revision: PRODUCER_REVISION,
+  } satisfies AdmissionPassportStatus
+}
+
+export const resolveAdmissionPassportConsumerClass = (
+  stage: string | null | undefined,
+): AdmissionPassportConsumerClass => {
+  const normalized = stage?.trim().toLowerCase()
+  if (normalized === 'verify') {
+    return 'swarm_verify'
+  }
+  if (normalized === 'implementation' || normalized === 'review') {
+    return 'swarm_implement'
+  }
+  return 'swarm_plan'
+}
+
+export const findAdmissionPassport = ({
+  admissionPassports,
+  consumerClass,
+}: {
+  admissionPassports: AdmissionPassportStatus[]
+  consumerClass: AdmissionPassportConsumerClass
+}) => admissionPassports.find((passport) => passport.consumer_class === consumerClass)
+
+export const buildRuntimeAdmissionSnapshot = (input: RuntimeAdmissionInput = {}): RuntimeAdmissionSnapshot => {
+  const now = input.now ?? new Date()
+  const imageRef = process.env.JANGAR_RUNTIME_IMAGE?.trim() || process.env.IMAGE_REF?.trim() || 'runtime:local'
+  const worktree = resolveWorktree(input.worktree)
+  const pythonRef =
+    input.pythonBin?.trim() || process.env.PYTHON_BIN?.trim() || process.env.PYTHON?.trim() || DEFAULT_PYTHON_BIN
+  const resolvedPythonPath = resolveCommandCandidate(pythonRef)
+  const hulyApiBaseUrl =
+    input.hulyApiBaseUrl?.trim() || process.env.HULY_API_BASE_URL?.trim() || process.env.hulyApiBaseUrl?.trim() || ''
+  const hulyApiCandidates = resolveHulyApiScriptPathCandidates({
+    worktree,
+    configuredPath: input.hulyApiScriptPath?.trim() || process.env.HULY_API_SCRIPT_PATH?.trim(),
+  })
+  const resolvedHulyApiPath = findExistingCandidate(hulyApiCandidates)
+
+  const servingKit = buildRuntimeKit({
+    now,
+    kitClass: 'serving',
+    subjectRef: 'jangar:/ready',
+    imageRef,
+    components: [
+      buildRuntimeKitComponent({
+        componentKind: 'binary',
+        componentRef: process.execPath,
+        required: true,
+        path: process.execPath,
+        reasonCode: 'runtime_kit_component_missing:serving_runtime_binary',
+      }),
+    ],
+  })
+
+  const collaborationKit = buildRuntimeKit({
+    now,
+    kitClass: 'collaboration',
+    subjectRef: 'jangar:codex:huly-collaboration',
+    imageRef,
+    components: [
+      buildRuntimeKitComponent({
+        componentKind: 'python_helper',
+        componentRef: resolvedHulyApiPath ?? hulyApiCandidates[0] ?? HULY_API_SCRIPT_RELATIVE_PATH,
+        required: true,
+        path: resolvedHulyApiPath,
+        reasonCode: 'runtime_kit_component_missing:huly_api_script',
+        evidenceRef: `checked_paths=[${hulyApiCandidates.join(', ')}]`,
+      }),
+      buildRuntimeKitComponent({
+        componentKind: 'binary',
+        componentRef: pythonRef,
+        required: true,
+        path: resolvedPythonPath,
+        reasonCode: 'runtime_kit_component_missing:python_binary',
+        evidenceRef: pythonRef,
+      }),
+      buildRuntimeKitComponent({
+        componentKind: 'workspace_path',
+        componentRef: worktree,
+        required: true,
+        path: worktree,
+        reasonCode: 'runtime_kit_component_missing:worktree',
+        evidenceRef: worktree,
+      }),
+      buildConfigComponent({
+        componentKind: 'service_url',
+        componentRef: 'HULY_API_BASE_URL',
+        required: true,
+        value: hulyApiBaseUrl,
+        reasonCode: 'runtime_kit_component_missing:huly_api_base_url',
+      }),
+    ],
+  })
+
+  const authority = resolveAuthority(input.executionTrust)
+  const runtimeKits = [servingKit, collaborationKit]
+  const admissionPassports = [
+    buildPassport({
+      now,
+      consumerClass: 'serving',
+      authority,
+      runtimeKits: [servingKit],
+    }),
+    ...COLLABORATION_CONSUMERS.map((consumerClass) =>
+      buildPassport({
+        now,
+        consumerClass,
+        authority,
+        runtimeKits: [collaborationKit],
+      }),
+    ),
+  ]
+
+  return {
+    runtimeKits,
+    admissionPassports,
+    servingPassportId:
+      admissionPassports.find((passport) => passport.consumer_class === 'serving')?.admission_passport_id ?? null,
+  }
+}

--- a/services/jangar/src/server/control-plane-status.ts
+++ b/services/jangar/src/server/control-plane-status.ts
@@ -21,7 +21,9 @@ import { asRecord, asString, readNested } from '~/server/primitives-http'
 import { parseNamespaceScopeEnv } from '~/server/namespace-scope'
 import { createKubernetesClient, type KubernetesClient, RESOURCE_MAP } from '~/server/primitives-kube'
 import { parseEnvStringList, parseOptionalNumber } from '~/server/agents-controller/env-config'
+import { buildRuntimeAdmissionSnapshot, type RuntimeAdmissionSnapshot } from '~/server/control-plane-runtime-admission'
 import type {
+  AdmissionPassportStatus,
   DatabaseMigrationConsistency,
   DependencyQuorumConfidence,
   DependencyQuorumSegment,
@@ -32,6 +34,7 @@ import type {
   ExecutionTrustSwarm,
   ExecutionTrustStage,
   ExecutionTrustStatus,
+  RuntimeKitStatus,
   WorkflowsReliabilityStatus,
 } from '~/data/agents-control-plane'
 
@@ -206,6 +209,9 @@ export type ControlPlaneStatus = {
   grpc: GrpcStatus
   watch_reliability: ControlPlaneWatchReliability
   agentrun_ingestion: AgentRunIngestionStatus
+  runtime_kits: RuntimeKitStatus[]
+  admission_passports: AdmissionPassportStatus[]
+  serving_passport_id: string | null
   workflows: WorkflowsReliabilityStatus
   dependency_quorum: DependencyQuorumStatus
   execution_trust: ExecutionTrustStatus
@@ -234,6 +240,7 @@ export type ControlPlaneStatusDeps = {
   getWorkflowsReliabilityStatus?: (input: WorkflowsReliabilityStatusInput) => Promise<WorkflowsReliabilityStatus>
   resolveEmpiricalServices?: () => Promise<EmpiricalServicesStatus>
   resolveExecutionTrust?: (input: ExecutionTrustInput) => Promise<ExecutionTrustSnapshot>
+  resolveRuntimeAdmission?: (input: { now: Date; executionTrust: ExecutionTrustStatus }) => RuntimeAdmissionSnapshot
 }
 
 export type ExecutionTrustSnapshot = {
@@ -2163,6 +2170,10 @@ export const buildControlPlaneStatus = async (
     kube: createKubernetesClient(),
   })
   const empiricalServices = await (deps.resolveEmpiricalServices ?? resolveEmpiricalServices)()
+  const runtimeAdmission = (deps.resolveRuntimeAdmission ?? buildRuntimeAdmissionSnapshot)({
+    now,
+    executionTrust: executionTrust.executionTrust,
+  })
 
   const isWorkflowsDataUnknown = workflows.data_confidence === 'unknown'
   const isWorkflowsDataDegraded = workflows.data_confidence === 'degraded'
@@ -2209,6 +2220,9 @@ export const buildControlPlaneStatus = async (
     ...(empiricalServices.lean.status === 'degraded' ? ['empirical:lean'] : []),
     ...(empiricalServices.jobs.status === 'degraded' ? ['empirical:jobs'] : []),
     ...(executionTrust.executionTrust.status !== 'healthy' ? ['execution_trust'] : []),
+    ...runtimeAdmission.runtimeKits
+      .filter((kit) => kit.decision !== 'healthy')
+      .map((kit) => `runtime_kit:${kit.kit_class}`),
   ]
 
   return {
@@ -2241,6 +2255,9 @@ export const buildControlPlaneStatus = async (
       streams: watchReliability.streams,
     },
     agentrun_ingestion: agentRunIngestion,
+    runtime_kits: runtimeAdmission.runtimeKits,
+    admission_passports: runtimeAdmission.admissionPassports,
+    serving_passport_id: runtimeAdmission.servingPassportId,
     rollout_health: rolloutHealth,
     swarms: executionTrust.swarms,
     stages: executionTrust.stages,


### PR DESCRIPTION
## Summary

- Reset `CODEX_STAGE` in `runCodexImplementation` test setup to avoid cross-test environment leakage.
- Updated cross-swarm handoff message assertions to match current owner-update and status payload wording.
- Updated test expectations for new validation labels (`Validation results`, `Acceptance criteria`) and kept payload fields in lockstep with runtime output.

## Related Issues

Closes swarm-torghut-quant-verify

## Testing

- `cd /workspace/lab/services/jangar && bunx vitest@4.0.18 run --config vitest.config.ts scripts/codex/__tests__/codex-implement.test.ts`
- `cd /workspace/lab && bunx oxfmt --check services/jangar/scripts/codex/__tests__/codex-implement.test.ts`
- `cd /workspace/lab && cd services/jangar && bun run lint:oxlint`

## Breaking Changes

None.
