### PR TITLE
feat(torghut): add simple execution lane

### DIFF
--- a/argocd/applications/torghut/knative-service-simple.yaml
+++ b/argocd/applications/torghut/knative-service-simple.yaml
@@ -1,0 +1,145 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: torghut-simple
+  namespace: torghut
+  labels:
+    app.kubernetes.io/name: torghut-simple
+    app.kubernetes.io/component: backend
+    app.kubernetes.io/part-of: lab
+    networking.knative.dev/visibility: cluster-local
+  annotations:
+    serving.knative.dev/rollout-duration: 10s
+    argocd.argoproj.io/tracking-id: torghut:serving.knative.dev/Service:torghut/torghut-simple
+spec:
+  template:
+    metadata:
+      annotations:
+        client.knative.dev/updateTimestamp: "2026-03-26T21:00:00Z"
+        autoscaling.knative.dev/minScale: "1"
+        autoscaling.knative.dev/maxScale: "1"
+        autoscaling.knative.dev/target: "80"
+    spec:
+      containerConcurrency: 0
+      timeoutSeconds: 60
+      containers:
+        - name: user-container
+          imagePullPolicy: IfNotPresent
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:884bec35f7d24ef34c51240e697aa996bc134385be9f6936aa170880fe2d601e
+          ports:
+            - name: http1
+              containerPort: 8181
+          env:
+            - name: APP_ENV
+              value: prod
+            - name: LOG_LEVEL
+              value: INFO
+            - name: LOG_FORMAT
+              value: json
+            - name: LOG_ACCESS_LOG
+              value: "true"
+            - name: DB_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: torghut-db-app
+                  key: uri
+            - name: APCA_API_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: torghut-alpaca
+                  key: APCA_API_KEY_ID
+                  optional: true
+            - name: APCA_API_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: torghut-alpaca
+                  key: APCA_API_SECRET_KEY
+                  optional: true
+            - name: APCA_API_BASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: torghut-alpaca
+                  key: APCA_API_BASE_URL
+                  optional: true
+            - name: CLICKHOUSE_HOST
+              value: torghut-clickhouse.torghut.svc.cluster.local
+            - name: CLICKHOUSE_PORT
+              value: "8123"
+            - name: CLICKHOUSE_DATABASE
+              value: torghut
+            - name: CLICKHOUSE_USERNAME
+              value: torghut
+            - name: CLICKHOUSE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: torghut-clickhouse-auth
+                  key: torghut_password
+            - name: CLICKHOUSE_SECURE
+              value: "false"
+            - name: CLICKHOUSE_TIMEOUT_SECONDS
+              value: "10"
+            - name: TRADING_ENABLED
+              value: "true"
+            - name: TRADING_MODE
+              value: live
+            - name: TRADING_PIPELINE_MODE
+              value: simple
+            - name: TRADING_SIMPLE_SUBMIT_ENABLED
+              value: "false"
+            - name: TRADING_SIMPLE_ORDER_FEED_TELEMETRY_ENABLED
+              value: "false"
+            - name: TRADING_KILL_SWITCH_ENABLED
+              value: "false"
+            - name: TRADING_FEATURE_FLAGS_ENABLED
+              value: "false"
+            - name: TRADING_MULTI_ACCOUNT_ENABLED
+              value: "false"
+            - name: TRADING_ACCOUNT_LABEL
+              value: PA3SX7FYNUTF
+            - name: TRADING_ACCOUNTS_JSON
+              value: >
+                [{"label":"PA3SX7FYNUTF","mode":"live","enabled":true}]
+            - name: TRADING_ALLOW_SHORTS
+              value: "true"
+            - name: TRADING_FRACTIONAL_EQUITIES_ENABLED
+              value: "true"
+            - name: TRADING_EXECUTION_ADAPTER
+              value: alpaca
+            - name: TRADING_EXECUTION_ADAPTER_POLICY
+              value: all
+            - name: TRADING_SIGNAL_SOURCE
+              value: clickhouse
+            - name: TRADING_SIGNAL_TABLE
+              value: torghut.ta_signals
+            - name: TRADING_SIGNAL_LOOKBACK_MINUTES
+              value: "15"
+            - name: TRADING_PLANNED_DECISION_TIMEOUT_SECONDS
+              value: "600"
+            - name: TRADING_POLL_MS
+              value: "5000"
+            - name: TRADING_RECONCILE_MS
+              value: "15000"
+            - name: TRADING_STRATEGY_CONFIG_PATH
+              value: /etc/torghut/strategies.yaml
+            - name: TRADING_STRATEGY_CONFIG_MODE
+              value: sync
+            - name: TRADING_STRATEGY_RELOAD_SECONDS
+              value: "10"
+            - name: TRADING_UNIVERSE_SOURCE
+              value: jangar
+            - name: TRADING_UNIVERSE_STATIC_FALLBACK_ENABLED
+              value: "true"
+            - name: TRADING_UNIVERSE_STATIC_FALLBACK_SYMBOLS
+              value: AAPL,AMAT,AMD,AVGO,GOOG,INTC,META,MSFT,NVDA,QQQ,SPY,TSLA
+            - name: TRADING_CRYPTO_ENABLED
+              value: "false"
+            - name: TRADING_CRYPTO_LIVE_ENABLED
+              value: "false"
+          volumeMounts:
+            - name: strategies-config
+              mountPath: /etc/torghut
+              readOnly: true
+      volumes:
+        - name: strategies-config
+          configMap:
+            name: torghut-strategies

--- a/argocd/applications/torghut/kustomization.yaml
+++ b/argocd/applications/torghut/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - autonomy-gate-policy-configmap.yaml
   - db-migrations-job.yaml
   - knative-service.yaml
+  - knative-service-simple.yaml
   - knative-service-sim.yaml
   - tailscale-service.yaml
   - ingressroute-flink-k8s-private.yaml

--- a/services/torghut/app/config.py
+++ b/services/torghut/app/config.py
@@ -1373,6 +1373,31 @@ class Settings(BaseSettings):
     trading_kill_switch_enabled: bool = Field(
         default=True, alias="TRADING_KILL_SWITCH_ENABLED"
     )
+    trading_pipeline_mode: Literal["legacy", "simple"] = Field(
+        default="legacy",
+        alias="TRADING_PIPELINE_MODE",
+        description="Select the order-submission pipeline implementation.",
+    )
+    trading_simple_max_notional_per_order: Optional[float] = Field(
+        default=None,
+        alias="TRADING_SIMPLE_MAX_NOTIONAL_PER_ORDER",
+        description="Simple-lane max notional cap per submitted order.",
+    )
+    trading_simple_max_notional_per_symbol: Optional[float] = Field(
+        default=None,
+        alias="TRADING_SIMPLE_MAX_NOTIONAL_PER_SYMBOL",
+        description="Simple-lane absolute exposure cap per symbol.",
+    )
+    trading_simple_submit_enabled: bool = Field(
+        default=False,
+        alias="TRADING_SIMPLE_SUBMIT_ENABLED",
+        description="Allow the simple lane to submit live broker orders.",
+    )
+    trading_simple_order_feed_telemetry_enabled: bool = Field(
+        default=False,
+        alias="TRADING_SIMPLE_ORDER_FEED_TELEMETRY_ENABLED",
+        description="In simple mode, keep Kafka order-feed ingestion only as optional telemetry.",
+    )
     trading_emergency_stop_enabled: bool = Field(
         default=False,
         alias="TRADING_EMERGENCY_STOP_ENABLED",
@@ -1805,7 +1830,9 @@ class Settings(BaseSettings):
         return ",".join([item.strip() for item in raw.split(",") if item.strip()])
 
     @staticmethod
-    def _validate_non_negative_value(value: float, message: str) -> None:
+    def _validate_non_negative_value(value: float | None, message: str) -> None:
+        if value is None:
+            return
         if value < 0:
             raise ValueError(message)
 
@@ -2194,7 +2221,7 @@ class Settings(BaseSettings):
             )
 
     def _validate_allocator_scalar_settings(self) -> None:
-        checks: list[tuple[float, str]] = [
+        checks: list[tuple[float | None, str]] = [
             (
                 self.trading_allocator_default_budget_multiplier,
                 "TRADING_ALLOCATOR_DEFAULT_BUDGET_MULTIPLIER must be >= 0",
@@ -2242,6 +2269,14 @@ class Settings(BaseSettings):
             (
                 self.trading_planned_decision_timeout_seconds,
                 "TRADING_PLANNED_DECISION_TIMEOUT_SECONDS must be >= 0",
+            ),
+            (
+                self.trading_simple_max_notional_per_order,
+                "TRADING_SIMPLE_MAX_NOTIONAL_PER_ORDER must be >= 0",
+            ),
+            (
+                self.trading_simple_max_notional_per_symbol,
+                "TRADING_SIMPLE_MAX_NOTIONAL_PER_SYMBOL must be >= 0",
             ),
             (
                 self.trading_readiness_dependency_cache_stale_tolerance_seconds,

--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -1646,10 +1646,13 @@ def trading_status(session: Session = Depends(get_session)) -> dict[str, object]
         ),
         quant_health_status=quant_evidence,
     )
+    simple_lane_reject_reason_totals = _simple_lane_reject_reason_totals(state)
     return {
         "enabled": settings.trading_enabled,
         "autonomy_enabled": settings.trading_autonomy_enabled,
         "mode": settings.trading_mode,
+        "pipeline_mode": settings.trading_pipeline_mode,
+        "execution_lane": settings.trading_pipeline_mode,
         "kill_switch_enabled": settings.trading_kill_switch_enabled,
         "build": {
             "version": BUILD_VERSION,
@@ -1668,6 +1671,22 @@ def trading_status(session: Session = Depends(get_session)) -> dict[str, object]
         "live_submission_gate": live_submission_gate,
         "quant_evidence": quant_evidence,
         "last_decision_at": last_decision_at,
+        "simple_lane_status": {
+            "enabled": settings.trading_pipeline_mode == "simple",
+            "submit_enabled": settings.trading_simple_submit_enabled,
+            "order_feed_telemetry_enabled": (
+                settings.trading_simple_order_feed_telemetry_enabled
+            ),
+            "max_notional_per_order": settings.trading_simple_max_notional_per_order,
+            "max_notional_per_symbol": settings.trading_simple_max_notional_per_symbol,
+            "allowed_reject_reasons": sorted(_SIMPLE_LANE_ALLOWED_REJECT_REASONS),
+        },
+        "simple_lane_reject_reason_totals": simple_lane_reject_reason_totals,
+        "simple_lane_orders_submitted_total": (
+            state.metrics.orders_submitted_total
+            if settings.trading_pipeline_mode == "simple"
+            else 0
+        ),
         "last_run_at": state.last_run_at,
         "last_reconcile_at": state.last_reconcile_at,
         "last_error": state.last_error,
@@ -3117,6 +3136,47 @@ def _build_live_submission_gate_payload(
     dspy_runtime_status: Mapping[str, Any] | None = None,
     quant_health_status: Mapping[str, Any] | None = None,
 ) -> dict[str, object]:
+    if settings.trading_pipeline_mode == "simple":
+        if settings.trading_mode != "live":
+            return {
+                "allowed": True,
+                "reason": "non_live_mode",
+                "blocked_reasons": [],
+                "capital_stage": settings.trading_mode,
+                "configured_live_promotion": settings.trading_simple_submit_enabled,
+                "autonomy_promotion_eligible": False,
+                "drift_live_promotion_eligible": False,
+                "promotion_eligible_total": 0,
+                "dependency_quorum_decision": "informational_only",
+                "empirical_jobs_ready": None,
+                "dspy_live_ready": None,
+            }
+        blocked_reasons: list[str] = []
+        if not settings.trading_enabled:
+            blocked_reasons.append("trading_disabled")
+        if settings.trading_kill_switch_enabled:
+            blocked_reasons.append("kill_switch_enabled")
+        if not settings.trading_simple_submit_enabled:
+            blocked_reasons.append("simple_submit_disabled")
+        if settings.trading_emergency_stop_enabled and bool(
+            getattr(state, "emergency_stop_active", False)
+        ):
+            blocked_reasons.append(
+                str(getattr(state, "emergency_stop_reason", "") or "emergency_stop_active")
+            )
+        return {
+            "allowed": len(blocked_reasons) == 0,
+            "reason": "ready" if not blocked_reasons else blocked_reasons[0],
+            "blocked_reasons": blocked_reasons,
+            "capital_stage": "live" if not blocked_reasons else "shadow",
+            "configured_live_promotion": settings.trading_simple_submit_enabled,
+            "autonomy_promotion_eligible": False,
+            "drift_live_promotion_eligible": False,
+            "promotion_eligible_total": 0,
+            "dependency_quorum_decision": "informational_only",
+            "empirical_jobs_ready": None,
+            "dspy_live_ready": None,
+        }
     return build_live_submission_gate_payload(
         state,
         session=session,
@@ -3125,6 +3185,33 @@ def _build_live_submission_gate_payload(
         dspy_runtime_status=dspy_runtime_status,
         quant_health_status=quant_health_status,
     )
+
+
+_SIMPLE_LANE_ALLOWED_REJECT_REASONS = {
+    "kill_switch_enabled",
+    "invalid_qty_increment",
+    "qty_below_min_after_clamp",
+    "insufficient_buying_power",
+    "max_notional_exceeded",
+    "max_symbol_exposure_exceeded",
+    "shorting_not_allowed_for_asset",
+    "broker_precheck_failed",
+    "broker_submit_failed",
+}
+
+
+def _simple_lane_reject_reason_totals(state: object) -> dict[str, int]:
+    metrics = getattr(state, "metrics", None)
+    totals = getattr(metrics, "decision_reject_reason_total", {})
+    if not isinstance(totals, Mapping):
+        return {}
+    payload: dict[str, int] = {}
+    for key, value in cast(Mapping[object, Any], totals).items():
+        normalized = str(key)
+        if normalized not in _SIMPLE_LANE_ALLOWED_REJECT_REASONS:
+            continue
+        payload[normalized] = int(value)
+    return payload
 
 
 def _load_route_provenance_summary(session: Session) -> dict[str, object]:

--- a/services/torghut/app/trading/execution.py
+++ b/services/torghut/app/trading/execution.py
@@ -278,6 +278,22 @@ class OrderExecutor:
         )
         if advice_provenance is not None:
             order_payload["_execution_advice_provenance"] = advice_provenance
+        execution_metadata = _extract_execution_metadata(
+            decision,
+            decision_row=decision_row,
+        )
+        if execution_metadata is not None:
+            existing_audit = order_payload.get("_execution_audit")
+            audit_payload = (
+                {
+                    str(key): value
+                    for key, value in cast(Mapping[object, Any], existing_audit).items()
+                }
+                if isinstance(existing_audit, Mapping)
+                else {}
+            )
+            audit_payload.update(execution_metadata)
+            order_payload["_execution_audit"] = audit_payload
         execution = sync_order_to_db(
             session,
             order_payload,
@@ -333,6 +349,22 @@ class OrderExecutor:
         )
         if advice_provenance is not None:
             existing_payload["_execution_advice_provenance"] = advice_provenance
+        execution_metadata = _extract_execution_metadata(
+            decision,
+            decision_row=decision_row,
+        )
+        if execution_metadata is not None:
+            existing_audit = existing_payload.get("_execution_audit")
+            audit_payload = (
+                {
+                    str(key): value
+                    for key, value in cast(Mapping[object, Any], existing_audit).items()
+                }
+                if isinstance(existing_audit, Mapping)
+                else {}
+            )
+            audit_payload.update(execution_metadata)
+            existing_payload["_execution_audit"] = audit_payload
         route_expected, route_actual, fallback_reason, fallback_count = (
             resolve_order_route_metadata(
                 expected_adapter=execution_expected_adapter,
@@ -1466,6 +1498,32 @@ def _extract_execution_advice_provenance(
                 ).items()
             }
     return None
+
+
+def _extract_execution_metadata(
+    decision: StrategyDecision,
+    *,
+    decision_row: Optional[TradeDecision] = None,
+) -> dict[str, Any] | None:
+    persisted_params: Mapping[str, Any] = {}
+    if decision_row is not None:
+        decision_json = _coerce_json(decision_row.decision_json)
+        params_value = decision_json.get("params")
+        if isinstance(params_value, Mapping):
+            persisted_params = cast(Mapping[str, Any], params_value)
+
+    execution_lane = persisted_params.get("execution_lane") or decision.params.get(
+        "execution_lane"
+    )
+    submit_path = persisted_params.get("submit_path") or decision.params.get(
+        "submit_path"
+    )
+    metadata: dict[str, Any] = {}
+    if execution_lane is not None:
+        metadata["execution_lane"] = str(execution_lane)
+    if submit_path is not None:
+        metadata["submit_path"] = str(submit_path)
+    return metadata or None
 
 
 def _apply_execution_status(

--- a/services/torghut/app/trading/execution_adapters.py
+++ b/services/torghut/app/trading/execution_adapters.py
@@ -1002,35 +1002,9 @@ def build_execution_adapter(
     """Build the primary execution adapter from runtime settings."""
 
     alpaca_adapter = AlpacaExecutionAdapter(firewall=order_firewall, read_client=alpaca_client)
-    simulation_enabled = settings.trading_simulation_enabled or settings.trading_execution_adapter == 'simulation'
-    if simulation_enabled:
-        bootstrap_servers = (
-            settings.trading_simulation_order_updates_bootstrap_servers
-            or settings.trading_order_feed_bootstrap_servers
-        )
-        return SimulationExecutionAdapter(
-            bootstrap_servers=bootstrap_servers,
-            security_protocol=(
-                settings.trading_simulation_order_updates_security_protocol
-                or settings.trading_order_feed_security_protocol
-            ),
-            sasl_mechanism=(
-                settings.trading_simulation_order_updates_sasl_mechanism
-                or settings.trading_order_feed_sasl_mechanism
-            ),
-            sasl_username=(
-                settings.trading_simulation_order_updates_sasl_username
-                or settings.trading_order_feed_sasl_username
-            ),
-            sasl_password=(
-                settings.trading_simulation_order_updates_sasl_password
-                or settings.trading_order_feed_sasl_password
-            ),
-            topic=settings.trading_simulation_order_updates_topic,
-            account_label=settings.trading_account_label,
-            simulation_run_id=settings.trading_simulation_run_id,
-            dataset_id=settings.trading_simulation_dataset_id,
-        )
+    simulation_adapter = _build_simulation_execution_adapter()
+    if simulation_adapter is not None:
+        return simulation_adapter
 
     if settings.trading_execution_adapter != 'lean':
         return alpaca_adapter
@@ -1067,6 +1041,19 @@ def build_execution_adapter(
     )
 
 
+def build_simple_execution_adapter(
+    *,
+    alpaca_client: TorghutAlpacaClient,
+    order_firewall: OrderFirewall,
+) -> ExecutionAdapter:
+    """Build the direct-submit adapter used by the simple execution lane."""
+
+    simulation_adapter = _build_simulation_execution_adapter()
+    if simulation_adapter is not None:
+        return simulation_adapter
+    return AlpacaExecutionAdapter(firewall=order_firewall, read_client=alpaca_client)
+
+
 def adapter_enabled_for_symbol(symbol: str, *, allowlist: set[str] | None = None) -> bool:
     """Return whether LEAN should be used for execution routing."""
 
@@ -1079,6 +1066,42 @@ def adapter_enabled_for_symbol(symbol: str, *, allowlist: set[str] | None = None
     if settings.trading_lean_lane_disable_switch:
         return False
     return True
+
+
+def _build_simulation_execution_adapter() -> SimulationExecutionAdapter | None:
+    simulation_enabled = (
+        settings.trading_simulation_enabled
+        or settings.trading_execution_adapter == 'simulation'
+    )
+    if not simulation_enabled:
+        return None
+    bootstrap_servers = (
+        settings.trading_simulation_order_updates_bootstrap_servers
+        or settings.trading_order_feed_bootstrap_servers
+    )
+    return SimulationExecutionAdapter(
+        bootstrap_servers=bootstrap_servers,
+        security_protocol=(
+            settings.trading_simulation_order_updates_security_protocol
+            or settings.trading_order_feed_security_protocol
+        ),
+        sasl_mechanism=(
+            settings.trading_simulation_order_updates_sasl_mechanism
+            or settings.trading_order_feed_sasl_mechanism
+        ),
+        sasl_username=(
+            settings.trading_simulation_order_updates_sasl_username
+            or settings.trading_order_feed_sasl_username
+        ),
+        sasl_password=(
+            settings.trading_simulation_order_updates_sasl_password
+            or settings.trading_order_feed_sasl_password
+        ),
+        topic=settings.trading_simulation_order_updates_topic,
+        account_label=settings.trading_account_label,
+        simulation_run_id=settings.trading_simulation_run_id,
+        dataset_id=settings.trading_simulation_dataset_id,
+    )
 
 
 def _resolve_simulated_fill_price(

--- a/services/torghut/app/trading/scheduler/runtime.py
+++ b/services/torghut/app/trading/scheduler/runtime.py
@@ -16,7 +16,7 @@ from ...observability import capture_posthog_event
 from ...strategies import StrategyCatalog
 from ..decisions import DecisionEngine
 from ..execution import OrderExecutor
-from ..execution_adapters import build_execution_adapter
+from ..execution_adapters import build_execution_adapter, build_simple_execution_adapter
 from ..firewall import OrderFirewall
 from ..ingest import ClickHouseSignalIngestor
 from ..llm.dspy_programs.runtime import DSPyReviewRuntime, DSPyRuntimeUnsupportedStateError
@@ -32,6 +32,7 @@ from ..time_source import trading_time_status
 from ..universe import UniverseResolver
 from .governance import TradingSchedulerGovernanceMixin
 from .pipeline import TradingPipeline
+from .simple_pipeline import SimpleTradingPipeline
 from .pipeline_helpers import _build_llm_policy_resolution
 from .state import TradingState
 
@@ -265,12 +266,20 @@ class TradingScheduler(TradingSchedulerGovernanceMixin):
             base_url=lane.base_url,
         )
         order_firewall = OrderFirewall(alpaca_client)
-        execution_adapter = build_execution_adapter(
-            alpaca_client=alpaca_client, order_firewall=order_firewall
-        )
+        pipeline_cls: type[TradingPipeline] = TradingPipeline
+        if settings.trading_pipeline_mode == "simple":
+            execution_adapter = build_simple_execution_adapter(
+                alpaca_client=alpaca_client,
+                order_firewall=order_firewall,
+            )
+            pipeline_cls = SimpleTradingPipeline
+        else:
+            execution_adapter = build_execution_adapter(
+                alpaca_client=alpaca_client, order_firewall=order_firewall
+            )
         executor = OrderExecutor()
         executor.prime_shorting_metadata_cache(alpaca_client)
-        return TradingPipeline(
+        return pipeline_cls(
             alpaca_client=alpaca_client,
             order_firewall=order_firewall,
             ingestor=ClickHouseSignalIngestor(account_label=lane.label),

--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -1,0 +1,526 @@
+"""Simplified trading pipeline with a minimal direct-submit hot path."""
+# pyright: reportUnusedImport=false, reportPrivateUsage=false
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Any, Optional, cast
+
+from sqlalchemy.orm import Session
+
+from ...config import settings
+from ...models import Strategy, TradeDecision
+from ..execution import OrderExecutor
+from ..firewall import OrderFirewallBlocked
+from ..ingest import SignalBatch
+from ..models import StrategyDecision
+from ..prices import MarketSnapshot
+from ..simple_risk import (
+    position_qty_for_symbol,
+    prepare_simple_decision,
+)
+from .pipeline import TradingPipeline
+from .pipeline_helpers import (
+    _clone_positions,
+    _coerce_strategy_symbols,
+    _extract_json_error_payload,
+)
+
+logger = logging.getLogger(__name__)
+
+_SIMPLE_ALLOWED_REJECT_REASONS = {
+    "kill_switch_enabled",
+    "invalid_qty_increment",
+    "qty_below_min_after_clamp",
+    "insufficient_buying_power",
+    "max_notional_exceeded",
+    "max_symbol_exposure_exceeded",
+    "shorting_not_allowed_for_asset",
+    "broker_precheck_failed",
+    "broker_submit_failed",
+}
+
+
+@dataclass(frozen=True)
+class SimplePolicyOutcome:
+    retry_delays: list[int]
+    advisor_metadata: dict[str, object]
+
+
+class SimpleTradingPipeline(TradingPipeline):
+    """Minimal signal -> hard-risk -> direct execution lane."""
+
+    def _prepare_run_once(self, session: Session) -> list[Strategy]:
+        if settings.trading_simple_order_feed_telemetry_enabled:
+            self._ingest_order_feed(session)
+        self.order_firewall.cancel_open_orders_if_kill_switch()
+        if self.strategy_catalog is not None:
+            self.strategy_catalog.refresh(session)
+        strategies = self._load_strategies(session)
+        if not strategies:
+            logger.info("No enabled strategies found; skipping simple trading cycle")
+        return strategies
+
+    def _prepare_batch_for_decisions(
+        self,
+        session: Session,
+        batch: SignalBatch,
+        *,
+        quality_signals: list[Any],
+    ) -> bool:
+        if not batch.signals:
+            self.record_no_signal_batch(batch)
+            self.ingestor.commit_cursor(session, batch)
+            return False
+        market_session_open = self._is_market_session_open()
+        self.state.market_session_open = market_session_open
+        self.state.metrics.market_session_open = 1 if market_session_open else 0
+        self.state.metrics.no_signal_reason_streak = {}
+        self.state.metrics.no_signal_streak = 0
+        self.state.metrics.signal_lag_seconds = None
+        self.state.metrics.signal_continuity_actionable = 0
+        self.state.last_signal_continuity_state = "signals_present"
+        self.state.last_signal_continuity_reason = None
+        self.state.last_signal_continuity_actionable = False
+        return True
+
+    def _build_run_context(
+        self, session: Session
+    ) -> tuple[Any, dict[str, str], list[dict[str, Any]], set[str]] | None:
+        account_snapshot = self._get_account_snapshot(session)
+        account = {
+            "equity": str(account_snapshot.equity),
+            "cash": str(account_snapshot.cash),
+            "buying_power": str(account_snapshot.buying_power),
+        }
+        snapshot_positions = _clone_positions(account_snapshot.positions)
+        positions = self._resolve_execution_context_positions(snapshot_positions)
+        fallback_symbols = {
+            symbol.strip().upper()
+            for symbol in settings.trading_universe_static_fallback_symbols
+            if symbol.strip()
+        }
+        allowed_symbols = fallback_symbols
+        universe_reason = "simple_static_fallback" if fallback_symbols else "strategy_symbols_only"
+        self.state.universe_source_status = "simple"
+        self.state.universe_source_reason = universe_reason
+        self.state.universe_symbols_count = len(allowed_symbols)
+        self.state.universe_cache_age_seconds = 0
+        self.state.universe_fail_safe_blocked = False
+        self.state.universe_fail_safe_block_reason = None
+        self.state.metrics.record_universe_resolution(
+            status="simple",
+            reason=universe_reason,
+            symbols_count=len(allowed_symbols),
+            cache_age_seconds=0,
+        )
+        return account_snapshot, account, positions, allowed_symbols
+
+    def _process_batch_signals(
+        self,
+        *,
+        session: Session,
+        batch: SignalBatch,
+        strategies: list[Strategy],
+        account_snapshot: Any,
+        account: dict[str, str],
+        positions: list[dict[str, Any]],
+        allowed_symbols: set[str],
+    ) -> None:
+        for signal in batch.signals:
+            decisions = self._evaluate_signal_decisions(
+                signal,
+                strategies,
+                equity=account_snapshot.equity,
+                positions=positions,
+            )
+            if not decisions:
+                continue
+            for decision in decisions:
+                self.state.metrics.decisions_total += 1
+                try:
+                    submitted = self._handle_decision(
+                        session,
+                        decision,
+                        strategies,
+                        account,
+                        positions,
+                        allowed_symbols,
+                    )
+                    if submitted is not None:
+                        self._apply_simple_projected_position(positions, submitted)
+                except Exception:
+                    logger.exception(
+                        "Simple decision handling failed strategy_id=%s symbol=%s timeframe=%s",
+                        decision.strategy_id,
+                        decision.symbol,
+                        decision.timeframe,
+                    )
+                    self.state.metrics.orders_rejected_total += 1
+                    self.state.metrics.record_decision_rejection_reasons(
+                        ["broker_submit_failed"]
+                    )
+
+    def _submission_control_plane_snapshot(
+        self,
+        *,
+        capital_stage: str | None = None,
+    ) -> dict[str, object]:
+        snapshot = super()._submission_control_plane_snapshot(capital_stage=capital_stage)
+        snapshot["pipeline_mode"] = settings.trading_pipeline_mode
+        snapshot["execution_lane"] = "simple"
+        snapshot["submit_path"] = "direct_alpaca"
+        return snapshot
+
+    def _prepare_decision_for_submission(
+        self,
+        *,
+        session: Session,
+        decision: StrategyDecision,
+        decision_row: TradeDecision,
+        strategy: Strategy,
+        account: dict[str, str],
+        positions: list[dict[str, Any]],
+    ) -> tuple[StrategyDecision, Optional[MarketSnapshot]] | None:
+        decision, snapshot = self._ensure_decision_price(
+            decision, signal_price=decision.params.get("price")
+        )
+        max_notional_per_order = _min_optional_decimal(
+            _optional_decimal(settings.trading_simple_max_notional_per_order),
+            _optional_decimal(settings.trading_max_notional_per_trade),
+            _optional_decimal(strategy.max_notional_per_trade),
+        )
+        equity = _optional_decimal(account.get("equity"))
+        max_notional_per_symbol = _min_optional_decimal(
+            _optional_decimal(settings.trading_simple_max_notional_per_symbol),
+            _optional_decimal(settings.trading_allocator_max_symbol_notional),
+            _pct_cap_to_notional(
+                equity=equity,
+                pct=_optional_decimal(settings.trading_max_position_pct_equity),
+            ),
+            _pct_cap_to_notional(
+                equity=equity,
+                pct=_optional_decimal(strategy.max_position_pct_equity),
+            ),
+        )
+        preparation = prepare_simple_decision(
+            decision=decision,
+            account=account,
+            positions=positions,
+            fractional_equities_enabled=settings.trading_fractional_equities_enabled,
+            allow_shorts=settings.trading_allow_shorts,
+            max_notional_per_order=max_notional_per_order,
+            max_notional_per_symbol=max_notional_per_symbol,
+        )
+        self.executor.sync_decision_state(session, decision_row, preparation.decision)
+        if preparation.diagnostics:
+            params_update = dict(preparation.decision.params)
+            params_update["simple_lane_precheck"] = preparation.diagnostics
+            self.executor.update_decision_params(session, decision_row, params_update)
+        if not preparation.approved or preparation.reject_reason is not None:
+            reason = preparation.reject_reason or "broker_precheck_failed"
+            self._record_decision_rejection(
+                session=session,
+                decision=preparation.decision,
+                decision_row=decision_row,
+                reasons=[reason],
+                log_template="Simple-lane decision rejected strategy_id=%s symbol=%s reason=%s",
+            )
+            return None
+        return preparation.decision, snapshot
+
+    def _evaluate_execution_policy_outcome(
+        self,
+        *,
+        session: Session,
+        decision: StrategyDecision,
+        decision_row: TradeDecision,
+        strategy: Strategy,
+        positions: list[dict[str, Any]],
+        snapshot: Optional[MarketSnapshot],
+    ) -> tuple[StrategyDecision, Any] | None:
+        _ = (session, decision_row, strategy, positions, snapshot)
+        return (
+            decision,
+            SimplePolicyOutcome(
+                retry_delays=[],
+                advisor_metadata={
+                    "enabled": False,
+                    "applied": False,
+                    "fallback_reason": "simple_lane",
+                },
+            ),
+        )
+
+    def _passes_risk_verdict(
+        self,
+        *,
+        session: Session,
+        decision: StrategyDecision,
+        decision_row: TradeDecision,
+        strategy: Strategy,
+        account: dict[str, str],
+        positions: list[dict[str, Any]],
+        symbol_allowlist: set[str],
+        execution_advisor: Mapping[str, Any] | None,
+    ) -> bool:
+        _ = (strategy, account, symbol_allowlist, execution_advisor)
+        short_reason = self._simple_shortability_reason(
+            decision=decision,
+            positions=positions,
+        )
+        if short_reason is None:
+            return True
+        self._record_decision_rejection(
+            session=session,
+            decision=decision,
+            decision_row=decision_row,
+            reasons=[short_reason],
+            log_template="Simple-lane decision rejected strategy_id=%s symbol=%s reason=%s",
+        )
+        return False
+
+    def _is_trading_submission_allowed(
+        self,
+        *,
+        session: Session,
+        decision: StrategyDecision,
+        decision_row: TradeDecision,
+    ) -> bool:
+        if not settings.trading_enabled:
+            self._block_decision_submission(
+                session=session,
+                decision=decision,
+                decision_row=decision_row,
+                reason="trading_disabled",
+                submission_stage="blocked_trading_disabled",
+            )
+            return False
+        firewall_status = self.order_firewall.status()
+        if firewall_status.kill_switch_enabled:
+            self._record_decision_rejection(
+                session=session,
+                decision=decision,
+                decision_row=decision_row,
+                reasons=["kill_switch_enabled"],
+                log_template="Simple-lane decision rejected strategy_id=%s symbol=%s reason=%s",
+            )
+            return False
+        if settings.trading_mode == "live" and not settings.trading_simple_submit_enabled:
+            self._block_decision_submission(
+                session=session,
+                decision=decision,
+                decision_row=decision_row,
+                reason="trading_simple_submit_disabled",
+                submission_stage="blocked_simple_submit_disabled",
+            )
+            return False
+        if settings.trading_emergency_stop_enabled and self.state.emergency_stop_active:
+            self._block_decision_submission(
+                session=session,
+                decision=decision,
+                decision_row=decision_row,
+                reason=self.state.emergency_stop_reason or "emergency_stop_active",
+                submission_stage="blocked_emergency_stop",
+            )
+            return False
+        return True
+
+    def _execution_client_for_symbol(
+        self, symbol: str, *, symbol_allowlist: set[str] | None = None
+    ) -> Any:
+        _ = (symbol, symbol_allowlist)
+        return self.execution_adapter
+
+    def _submit_order_with_handling(
+        self,
+        *,
+        session: Session,
+        execution_client: Any,
+        decision: StrategyDecision,
+        decision_row: TradeDecision,
+        selected_adapter_name: str,
+        retry_delays: list[int],
+    ) -> tuple[Any | None, bool]:
+        try:
+            retry_delays_seconds = [float(delay) for delay in retry_delays]
+            execution = self.executor.submit_order(
+                session,
+                execution_client,
+                decision,
+                decision_row,
+                self.account_label,
+                execution_expected_adapter=selected_adapter_name,
+                retry_delays=retry_delays_seconds,
+            )
+            return execution, False
+        except OrderFirewallBlocked:
+            return self._reject_submit(
+                session=session,
+                decision=decision,
+                decision_row=decision_row,
+                selected_adapter_name=selected_adapter_name,
+                reason="kill_switch_enabled",
+                rejection_type="firewall_blocked",
+            )
+        except Exception as exc:
+            payload = _extract_json_error_payload(exc) or {}
+            reason = self._map_submit_exception(payload)
+            metadata = {"broker_precheck": payload} if payload else None
+            return self._reject_submit(
+                session=session,
+                decision=decision,
+                decision_row=decision_row,
+                selected_adapter_name=selected_adapter_name,
+                reason=reason,
+                rejection_type="submit_failed",
+                metadata=metadata,
+            )
+
+    def _reject_submit(
+        self,
+        *,
+        session: Session,
+        decision: StrategyDecision,
+        decision_row: TradeDecision,
+        selected_adapter_name: str,
+        reason: str,
+        rejection_type: str,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> tuple[None, bool]:
+        self.state.metrics.orders_rejected_total += 1
+        self.state.metrics.record_decision_state("rejected")
+        self.state.metrics.record_decision_rejection_reasons([reason])
+        self.state.metrics.record_execution_submit_result(
+            status="rejected",
+            adapter=selected_adapter_name,
+        )
+        self.executor.mark_rejected(
+            session,
+            decision_row,
+            reason,
+            metadata_update=self._decision_lifecycle_metadata(
+                submission_stage="rejected_submit",
+                extra=metadata,
+            ),
+        )
+        self._emit_domain_telemetry(
+            event_name="torghut.execution.rejected",
+            severity="warning",
+            decision=decision,
+            decision_row=decision_row,
+            reason_codes=[reason],
+            extra_properties={"rejection_type": rejection_type},
+        )
+        return None, True
+
+    @staticmethod
+    def _map_submit_exception(payload: Mapping[str, Any]) -> str:
+        source = str(payload.get("source") or "").strip().lower()
+        code = str(payload.get("code") or "").strip().lower()
+        if source == "local_pre_submit":
+            if code in {"local_qty_invalid_increment"}:
+                return "invalid_qty_increment"
+            if code in {"local_qty_below_min", "local_qty_non_positive"}:
+                return "qty_below_min_after_clamp"
+            if code in {
+                "local_account_shorting_disabled",
+                "local_symbol_not_shortable",
+                "local_symbol_not_tradable",
+                "local_shorts_not_allowed",
+                "shorting_metadata_unavailable",
+            }:
+                return "shorting_not_allowed_for_asset"
+            return "broker_precheck_failed"
+        return "broker_submit_failed"
+
+    def _simple_shortability_reason(
+        self,
+        *,
+        decision: StrategyDecision,
+        positions: list[dict[str, Any]],
+    ) -> str | None:
+        if decision.action != "sell":
+            return None
+        current_qty = position_qty_for_symbol(positions, decision.symbol)
+        if current_qty > 0 and decision.qty <= current_qty:
+            return None
+        if not settings.trading_allow_shorts:
+            return "shorting_not_allowed_for_asset"
+
+        account = self.order_firewall.get_account()
+        if account is not None:
+            shorting_enabled = account.get("shorting_enabled")
+            if isinstance(shorting_enabled, bool) and not shorting_enabled:
+                return "shorting_not_allowed_for_asset"
+        elif settings.trading_mode == "live":
+            return "shorting_not_allowed_for_asset"
+
+        asset = self.order_firewall.get_asset(decision.symbol)
+        if asset is not None:
+            tradable = asset.get("tradable")
+            shortable = asset.get("shortable")
+            if isinstance(tradable, bool) and not tradable:
+                return "shorting_not_allowed_for_asset"
+            if isinstance(shortable, bool) and not shortable:
+                return "shorting_not_allowed_for_asset"
+        elif settings.trading_mode == "live":
+            return "shorting_not_allowed_for_asset"
+        return None
+
+    @staticmethod
+    def _apply_simple_projected_position(
+        positions: list[dict[str, Any]],
+        decision: StrategyDecision,
+    ) -> None:
+        normalized_symbol = decision.symbol.strip().upper()
+        updated = False
+        for position in positions:
+            if str(position.get("symbol") or "").strip().upper() != normalized_symbol:
+                continue
+            raw_qty = position.get("qty") or position.get("quantity") or "0"
+            try:
+                qty = Decimal(str(raw_qty))
+            except (ArithmeticError, ValueError):
+                qty = Decimal("0")
+            side = str(position.get("side") or "").strip().lower()
+            signed_qty = -abs(qty) if side == "short" else qty
+            delta = decision.qty if decision.action == "buy" else -decision.qty
+            next_qty = signed_qty + delta
+            position["qty"] = str(abs(next_qty))
+            position["side"] = "short" if next_qty < 0 else "long"
+            updated = True
+            break
+        if not updated:
+            positions.append(
+                {
+                    "symbol": normalized_symbol,
+                    "qty": str(decision.qty),
+                    "side": "long" if decision.action == "buy" else "short",
+                }
+            )
+
+
+def _optional_decimal(value: Any) -> Decimal | None:
+    if value is None:
+        return None
+    try:
+        return Decimal(str(value))
+    except (ArithmeticError, ValueError):
+        return None
+
+
+def _min_optional_decimal(*values: Decimal | None) -> Decimal | None:
+    candidates = [value for value in values if value is not None and value >= 0]
+    if not candidates:
+        return None
+    return min(candidates)
+
+
+def _pct_cap_to_notional(*, equity: Decimal | None, pct: Decimal | None) -> Decimal | None:
+    if equity is None or equity <= 0 or pct is None or pct <= 0:
+        return None
+    return equity * pct

--- a/services/torghut/app/trading/simple_risk.py
+++ b/services/torghut/app/trading/simple_risk.py
@@ -1,0 +1,289 @@
+"""Minimal hard-risk checks for the simple execution lane."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Any
+
+from .models import StrategyDecision
+from .quantity_rules import (
+    QuantityResolution,
+    min_qty_for_symbol,
+    quantize_qty_for_symbol,
+    qty_has_valid_increment,
+    resolve_quantity_resolution,
+)
+
+
+@dataclass(frozen=True)
+class SimpleRiskPreparation:
+    approved: bool
+    decision: StrategyDecision
+    quantity_resolution: QuantityResolution
+    notional: Decimal | None
+    reject_reason: str | None = None
+    diagnostics: dict[str, Any] | None = None
+
+
+def position_qty_for_symbol(
+    positions: list[dict[str, Any]],
+    symbol: str,
+) -> Decimal:
+    normalized_symbol = symbol.strip().upper()
+    current_qty = Decimal("0")
+    for position in positions:
+        if str(position.get("symbol") or "").strip().upper() != normalized_symbol:
+            continue
+        raw_qty = position.get("qty") or position.get("quantity")
+        if raw_qty is None:
+            continue
+        try:
+            qty = Decimal(str(raw_qty))
+        except (ArithmeticError, ValueError):
+            continue
+        side = str(position.get("side") or "").strip().lower()
+        if side == "short":
+            qty = -abs(qty)
+        current_qty += qty
+    return current_qty
+
+
+def position_value_for_symbol(
+    positions: list[dict[str, Any]],
+    symbol: str,
+    *,
+    fallback_price: Decimal | None,
+) -> Decimal:
+    normalized_symbol = symbol.strip().upper()
+    total = Decimal("0")
+    for position in positions:
+        if str(position.get("symbol") or "").strip().upper() != normalized_symbol:
+            continue
+        raw_market_value = position.get("market_value")
+        if raw_market_value is not None:
+            try:
+                total += Decimal(str(raw_market_value))
+                continue
+            except (ArithmeticError, ValueError):
+                pass
+        if fallback_price is None:
+            continue
+        raw_qty = position.get("qty") or position.get("quantity")
+        if raw_qty is None:
+            continue
+        try:
+            qty = Decimal(str(raw_qty))
+        except (ArithmeticError, ValueError):
+            continue
+        side = str(position.get("side") or "").strip().lower()
+        signed_qty = -abs(qty) if side == "short" else qty
+        total += signed_qty * fallback_price
+    return total
+
+
+def prepare_simple_decision(
+    *,
+    decision: StrategyDecision,
+    account: dict[str, str],
+    positions: list[dict[str, Any]],
+    fractional_equities_enabled: bool,
+    allow_shorts: bool,
+    max_notional_per_order: Decimal | None,
+    max_notional_per_symbol: Decimal | None,
+) -> SimpleRiskPreparation:
+    price = _extract_decision_price(decision)
+    current_qty = position_qty_for_symbol(positions, decision.symbol)
+    resolution = resolve_quantity_resolution(
+        decision.symbol,
+        action=decision.action,
+        global_enabled=fractional_equities_enabled,
+        allow_shorts=allow_shorts,
+        position_qty=current_qty,
+        requested_qty=decision.qty,
+    )
+    min_qty = min_qty_for_symbol(
+        decision.symbol,
+        fractional_equities_enabled=resolution.fractional_allowed,
+    )
+    quantized_qty = quantize_qty_for_symbol(
+        decision.symbol,
+        decision.qty,
+        fractional_equities_enabled=resolution.fractional_allowed,
+    )
+    diagnostics: dict[str, Any] = {
+        "requested_qty": str(decision.qty),
+        "quantized_qty": str(quantized_qty),
+        "min_qty": str(min_qty),
+        "quantity_resolution": resolution.to_payload(),
+    }
+
+    if price is None or price <= 0:
+        diagnostics["price"] = None if price is None else str(price)
+        return SimpleRiskPreparation(
+            approved=False,
+            decision=decision,
+            quantity_resolution=resolution,
+            notional=None,
+            reject_reason="broker_precheck_failed",
+            diagnostics=diagnostics,
+        )
+
+    diagnostics["price"] = str(price)
+    if quantized_qty <= 0 or quantized_qty < min_qty:
+        return SimpleRiskPreparation(
+            approved=False,
+            decision=decision,
+            quantity_resolution=resolution,
+            notional=price * quantized_qty if quantized_qty > 0 else Decimal("0"),
+            reject_reason="qty_below_min_after_clamp",
+            diagnostics=diagnostics,
+        )
+    if not qty_has_valid_increment(
+        decision.symbol,
+        quantized_qty,
+        fractional_equities_enabled=resolution.fractional_allowed,
+    ):
+        return SimpleRiskPreparation(
+            approved=False,
+            decision=decision,
+            quantity_resolution=resolution,
+            notional=price * quantized_qty,
+            reject_reason="invalid_qty_increment",
+            diagnostics=diagnostics,
+        )
+
+    enforce_exposure = decision.action == "buy" or resolution.short_increasing
+    adjusted_qty = quantized_qty
+    capped_by_order = False
+    capped_by_symbol = False
+
+    if enforce_exposure and max_notional_per_order is not None and max_notional_per_order >= 0:
+        order_cap_qty = quantize_qty_for_symbol(
+            decision.symbol,
+            max_notional_per_order / price,
+            fractional_equities_enabled=resolution.fractional_allowed,
+        )
+        if order_cap_qty < adjusted_qty:
+            adjusted_qty = order_cap_qty
+            capped_by_order = True
+
+    if enforce_exposure and max_notional_per_symbol is not None and max_notional_per_symbol >= 0:
+        current_abs_value = abs(
+            position_value_for_symbol(
+                positions,
+                decision.symbol,
+                fallback_price=price,
+            )
+        )
+        remaining_notional = max_notional_per_symbol - current_abs_value
+        diagnostics["current_symbol_abs_notional"] = str(current_abs_value)
+        diagnostics["remaining_symbol_notional_room"] = str(remaining_notional)
+        if remaining_notional <= 0:
+            adjusted_qty = Decimal("0")
+            capped_by_symbol = True
+        else:
+            symbol_cap_qty = quantize_qty_for_symbol(
+                decision.symbol,
+                remaining_notional / price,
+                fractional_equities_enabled=resolution.fractional_allowed,
+            )
+            if symbol_cap_qty < adjusted_qty:
+                adjusted_qty = symbol_cap_qty
+                capped_by_symbol = True
+
+    diagnostics["final_qty"] = str(adjusted_qty)
+    if adjusted_qty <= 0 or adjusted_qty < min_qty:
+        reject_reason = "qty_below_min_after_clamp"
+        if capped_by_symbol:
+            reject_reason = "max_symbol_exposure_exceeded"
+        elif capped_by_order:
+            reject_reason = "max_notional_exceeded"
+        return SimpleRiskPreparation(
+            approved=False,
+            decision=decision,
+            quantity_resolution=resolution,
+            notional=price * adjusted_qty if adjusted_qty > 0 else Decimal("0"),
+            reject_reason=reject_reason,
+            diagnostics=diagnostics,
+        )
+    if not qty_has_valid_increment(
+        decision.symbol,
+        adjusted_qty,
+        fractional_equities_enabled=resolution.fractional_allowed,
+    ):
+        return SimpleRiskPreparation(
+            approved=False,
+            decision=decision,
+            quantity_resolution=resolution,
+            notional=price * adjusted_qty,
+            reject_reason="invalid_qty_increment",
+            diagnostics=diagnostics,
+        )
+
+    notional = price * adjusted_qty
+    diagnostics["final_notional"] = str(notional)
+    if enforce_exposure:
+        buying_power = _resolve_decimal(account.get("buying_power"))
+        diagnostics["buying_power"] = str(buying_power) if buying_power is not None else None
+        if buying_power is not None and notional > buying_power:
+            return SimpleRiskPreparation(
+                approved=False,
+                decision=decision,
+                quantity_resolution=resolution,
+                notional=notional,
+                reject_reason="insufficient_buying_power",
+                diagnostics=diagnostics,
+            )
+
+    params = dict(decision.params)
+    params["execution_lane"] = "simple"
+    params["submit_path"] = "direct_alpaca"
+    params["simple_lane"] = {
+        "requested_qty": str(decision.qty),
+        "final_qty": str(adjusted_qty),
+        "price": str(price),
+        "notional": str(notional),
+        "quantity_resolution": resolution.to_payload(),
+        "capped_by_order": capped_by_order,
+        "capped_by_symbol": capped_by_symbol,
+    }
+    return SimpleRiskPreparation(
+        approved=True,
+        decision=decision.model_copy(update={"qty": adjusted_qty, "params": params}),
+        quantity_resolution=resolution,
+        notional=notional,
+        diagnostics=diagnostics,
+    )
+
+
+def _extract_decision_price(decision: StrategyDecision) -> Decimal | None:
+    for candidate in (
+        decision.params.get("price"),
+        decision.limit_price,
+        decision.stop_price,
+    ):
+        if candidate is None:
+            continue
+        try:
+            return Decimal(str(candidate))
+        except (ArithmeticError, ValueError):
+            continue
+    return None
+
+
+def _resolve_decimal(value: Any) -> Decimal | None:
+    if value is None:
+        return None
+    try:
+        return Decimal(str(value))
+    except (ArithmeticError, ValueError):
+        return None
+
+
+__all__ = [
+    "SimpleRiskPreparation",
+    "position_qty_for_symbol",
+    "position_value_for_symbol",
+    "prepare_simple_decision",
+]

--- a/services/torghut/scripts/run_local_simple_lane_replay.py
+++ b/services/torghut/scripts/run_local_simple_lane_replay.py
@@ -1,0 +1,900 @@
+#!/usr/bin/env python3
+"""Replay one trading session through Torghut's simple execution lane locally."""
+# pyright: reportArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import subprocess
+import sys
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+import yaml
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session, sessionmaker
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+SERVICE_ROOT = SCRIPT_DIR.parent
+REPO_ROOT = SERVICE_ROOT.parent.parent
+if str(SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(SERVICE_ROOT))
+
+from app import config
+from app.models import Base, Execution, Strategy, TradeDecision
+from app.trading.decisions import DecisionEngine
+from app.trading.execution import OrderExecutor
+from app.trading.execution_adapters import SimulationExecutionAdapter
+from app.trading.firewall import OrderFirewall
+from app.trading.ingest import ClickHouseSignalIngestor, SignalBatch
+from app.trading.models import SignalEnvelope
+from app.trading.reconcile import Reconciler
+from app.trading.risk import RiskEngine
+from app.trading.scheduler.simple_pipeline import SimpleTradingPipeline
+from app.trading.scheduler.state import TradingState
+from app.trading.universe import UniverseResolver
+
+DEFAULT_SYMBOLS = [
+    'AAPL',
+    'AMAT',
+    'AMD',
+    'AVGO',
+    'GOOG',
+    'INTC',
+    'META',
+    'MSFT',
+    'NVDA',
+    'QQQ',
+    'SPY',
+    'TSLA',
+]
+ALLOWED_REJECT_REASONS = {
+    'kill_switch_enabled',
+    'invalid_qty_increment',
+    'qty_below_min_after_clamp',
+    'insufficient_buying_power',
+    'max_notional_exceeded',
+    'max_symbol_exposure_exceeded',
+    'shorting_not_allowed_for_asset',
+    'broker_precheck_failed',
+    'broker_submit_failed',
+}
+DEFAULT_START = '2026-03-26T13:30:00Z'
+DEFAULT_END = '2026-03-26T20:00:00Z'
+DEFAULT_OUTPUT_DIR = (
+    REPO_ROOT / 'artifacts/torghut/simulations/local-simple-20260326'
+)
+DEFAULT_CLICKHOUSE_URL = 'http://torghut-clickhouse.torghut.svc.cluster.local:8123'
+DEFAULT_CLICKHOUSE_NAMESPACE = 'torghut'
+DEFAULT_CLICKHOUSE_POD = 'chi-torghut-clickhouse-default-0-0-0'
+ESSENTIAL_SIGNAL_COLUMNS = [
+    'event_ts',
+    'ingest_ts',
+    'symbol',
+    'window_size',
+    'window_step',
+    'seq',
+    'source',
+    'macd',
+    'macd_signal',
+    'rsi14',
+    'vwap_session',
+    'vwap_w5m',
+]
+
+logger = logging.getLogger('torghut.simple_replay')
+
+
+@dataclass
+class ReplayArtifacts:
+    runtime_verify: dict[str, Any]
+    replay_report: dict[str, Any]
+    decision_activity: dict[str, Any]
+    execution_activity: dict[str, Any]
+    run_summary: dict[str, Any]
+
+
+class BucketReplayIngestor:
+    """Feed preloaded signal buckets into the scheduler."""
+
+    def __init__(self, buckets: list[list[SignalEnvelope]]) -> None:
+        self._buckets = buckets
+        self._cursor = 0
+        self.committed_batches = 0
+
+    @property
+    def remaining(self) -> int:
+        return max(len(self._buckets) - self._cursor, 0)
+
+    def fetch_signals(self, session: Session) -> SignalBatch:
+        _ = session
+        if self._cursor >= len(self._buckets):
+            return SignalBatch(
+                signals=[],
+                cursor_at=None,
+                cursor_seq=None,
+                cursor_symbol=None,
+                no_signal_reason='replay_complete',
+            )
+        signals = self._buckets[self._cursor]
+        cursor_at = signals[-1].event_ts if signals else None
+        cursor_seq = signals[-1].seq if signals else None
+        cursor_symbol = signals[-1].symbol if signals else None
+        return SignalBatch(
+            signals=signals,
+            cursor_at=cursor_at,
+            cursor_seq=cursor_seq,
+            cursor_symbol=cursor_symbol,
+            query_start=signals[0].event_ts if signals else None,
+            query_end=signals[-1].event_ts if signals else None,
+            no_signal_reason=None if signals else 'empty_bucket',
+        )
+
+    def commit_cursor(self, session: Session, batch: SignalBatch) -> None:
+        _ = (session, batch)
+        if self._cursor < len(self._buckets):
+            self._cursor += 1
+            self.committed_batches += 1
+
+
+class LocalSimulationBroker:
+    """Small wrapper that gives the simulation adapter a broker-like account surface."""
+
+    def __init__(
+        self,
+        *,
+        adapter: SimulationExecutionAdapter,
+        initial_cash: Decimal,
+        allow_shorts: bool,
+    ) -> None:
+        self._adapter = adapter
+        self._cash = initial_cash
+        self._allow_shorts = allow_shorts
+
+    def get_account(self) -> dict[str, Any]:
+        positions = self.list_positions()
+        net_market_value = Decimal('0')
+        for position in positions:
+            raw_market_value = position.get('market_value')
+            if raw_market_value is None:
+                continue
+            try:
+                net_market_value += Decimal(str(raw_market_value))
+            except Exception:
+                continue
+        equity = self._cash + net_market_value
+        buying_power = max(self._cash, equity, Decimal('0'))
+        return {
+            'equity': str(equity),
+            'cash': str(self._cash),
+            'buying_power': str(buying_power),
+            'shorting_enabled': self._allow_shorts,
+        }
+
+    def list_positions(self) -> list[dict[str, Any]]:
+        return self._adapter.list_positions()
+
+    def get_asset(self, symbol_or_asset_id: str) -> dict[str, Any]:
+        return {
+            'symbol': symbol_or_asset_id,
+            'tradable': True,
+            'shortable': self._allow_shorts,
+        }
+
+    def submit_order(
+        self,
+        symbol: str,
+        side: str,
+        qty: float,
+        order_type: str,
+        time_in_force: str,
+        limit_price: float | None = None,
+        stop_price: float | None = None,
+        extra_params: dict[str, Any] | None = None,
+        *,
+        firewall_token: object | None = None,
+    ) -> dict[str, Any]:
+        _ = firewall_token
+        order = self._adapter.submit_order(
+            symbol=symbol,
+            side=side,
+            qty=qty,
+            order_type=order_type,
+            time_in_force=time_in_force,
+            limit_price=limit_price,
+            stop_price=stop_price,
+            extra_params=extra_params,
+        )
+        filled_qty = Decimal(str(order.get('filled_qty') or order.get('qty') or '0'))
+        fill_price = Decimal(str(order.get('filled_avg_price') or '0'))
+        cash_delta = filled_qty * fill_price
+        if side.strip().lower() == 'buy':
+            self._cash -= cash_delta
+        else:
+            self._cash += cash_delta
+        return order
+
+    def cancel_order(
+        self,
+        alpaca_order_id: str,
+        *,
+        firewall_token: object | None = None,
+    ) -> bool:
+        _ = firewall_token
+        return self._adapter.cancel_order(alpaca_order_id)
+
+    def cancel_all_orders(
+        self,
+        *,
+        firewall_token: object | None = None,
+    ) -> list[dict[str, Any]]:
+        _ = firewall_token
+        return self._adapter.cancel_all_orders()
+
+    def get_order_by_client_order_id(self, client_order_id: str) -> dict[str, Any] | None:
+        return self._adapter.get_order_by_client_order_id(client_order_id)
+
+    def get_order(self, alpaca_order_id: str) -> dict[str, Any]:
+        return self._adapter.get_order(alpaca_order_id)
+
+    def list_orders(self, status: str = 'all') -> list[dict[str, Any]]:
+        return self._adapter.list_orders(status=status)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description='Replay a trading session through the simple execution lane.',
+    )
+    parser.add_argument('--start', default=DEFAULT_START)
+    parser.add_argument('--end', default=DEFAULT_END)
+    parser.add_argument('--symbols', default=','.join(DEFAULT_SYMBOLS))
+    parser.add_argument('--output-dir', default=str(DEFAULT_OUTPUT_DIR))
+    parser.add_argument(
+        '--strategy-config',
+        default=str(REPO_ROOT / 'argocd/applications/torghut/strategy-configmap.yaml'),
+    )
+    parser.add_argument('--clickhouse-url', default=DEFAULT_CLICKHOUSE_URL)
+    parser.add_argument('--clickhouse-username', default='torghut')
+    parser.add_argument('--clickhouse-password', required=True)
+    parser.add_argument('--clickhouse-table', default='torghut.ta_signals')
+    parser.add_argument(
+        '--clickhouse-transport',
+        choices=['kubectl', 'http'],
+        default='kubectl',
+    )
+    parser.add_argument(
+        '--clickhouse-namespace',
+        default=DEFAULT_CLICKHOUSE_NAMESPACE,
+    )
+    parser.add_argument(
+        '--clickhouse-pod',
+        default=DEFAULT_CLICKHOUSE_POD,
+    )
+    parser.add_argument('--initial-cash', type=Decimal, default=Decimal('10000'))
+    parser.add_argument('--bucket-seconds', type=int, default=60)
+    parser.add_argument('--min-split-seconds', type=int, default=60)
+    parser.add_argument('--max-notional-per-order', type=Decimal, default=None)
+    parser.add_argument('--max-notional-per-symbol', type=Decimal, default=None)
+    parser.add_argument('--allow-shorts', action='store_true', default=True)
+    parser.add_argument('--disable-shorts', dest='allow_shorts', action='store_false')
+    parser.add_argument('--verbose', action='store_true')
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format='%(asctime)s %(levelname)s %(message)s',
+    )
+    start = _parse_timestamp(args.start)
+    end = _parse_timestamp(args.end)
+    symbols = [symbol.strip().upper() for symbol in args.symbols.split(',') if symbol.strip()]
+    output_dir = Path(args.output_dir).resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    ingestor = ClickHouseSignalIngestor(
+        url=args.clickhouse_url,
+        username=args.clickhouse_username,
+        password=args.clickhouse_password,
+        table=args.clickhouse_table,
+        batch_size=200000,
+    )
+    strategy_defs = _load_enabled_strategies(Path(args.strategy_config))
+    if not strategy_defs:
+        raise RuntimeError('No enabled strategies found in strategy config')
+
+    signal_fetch_counts: dict[str, int] = {}
+    all_signals: list[SignalEnvelope] = []
+    for symbol in symbols:
+        signals = _fetch_signals_adaptive(
+            ingestor=ingestor,
+            symbol=symbol,
+            start=start,
+            end=end,
+            min_split_seconds=args.min_split_seconds,
+            clickhouse_transport=args.clickhouse_transport,
+            clickhouse_namespace=args.clickhouse_namespace,
+            clickhouse_pod=args.clickhouse_pod,
+            clickhouse_username=args.clickhouse_username,
+            clickhouse_password=args.clickhouse_password,
+            clickhouse_table=args.clickhouse_table,
+        )
+        signal_fetch_counts[symbol] = len(signals)
+        all_signals.extend(signals)
+        logger.info('Fetched %s signals for %s', len(signals), symbol)
+
+    all_signals.sort(key=_signal_sort_key)
+    buckets = _bucket_signals(all_signals, bucket_seconds=args.bucket_seconds)
+    logger.info(
+        'Loaded %s total signals across %s symbols into %s replay buckets',
+        len(all_signals),
+        len(symbols),
+        len(buckets),
+    )
+
+    db_path = output_dir / 'replay.sqlite3'
+    if db_path.exists():
+        db_path.unlink()
+    engine = create_engine(f'sqlite+pysqlite:///{db_path}', future=True)
+    Base.metadata.create_all(engine)
+    session_local = sessionmaker(bind=engine, expire_on_commit=False, future=True)
+    _seed_strategies(session_local, strategy_defs)
+    _configure_replay_settings(
+        symbols=symbols,
+        max_notional_per_order=args.max_notional_per_order,
+        max_notional_per_symbol=args.max_notional_per_symbol,
+        allow_shorts=args.allow_shorts,
+    )
+
+    broker_adapter = SimulationExecutionAdapter(
+        bootstrap_servers=None,
+        security_protocol=None,
+        sasl_mechanism=None,
+        sasl_username=None,
+        sasl_password=None,
+        topic='torghut.sim.trade-updates.v1',
+        account_label='paper',
+        simulation_run_id='local-simple-20260326',
+        dataset_id='local-clickhouse-march26',
+    )
+    broker = LocalSimulationBroker(
+        adapter=broker_adapter,
+        initial_cash=args.initial_cash,
+        allow_shorts=args.allow_shorts,
+    )
+    replay_ingestor = BucketReplayIngestor(buckets)
+    pipeline = SimpleTradingPipeline(
+        alpaca_client=broker,
+        order_firewall=OrderFirewall(broker),
+        ingestor=replay_ingestor,
+        decision_engine=DecisionEngine(),
+        risk_engine=RiskEngine(),
+        executor=OrderExecutor(),
+        execution_adapter=broker_adapter,
+        reconciler=Reconciler(),
+        universe_resolver=UniverseResolver(),
+        state=TradingState(),
+        account_label='paper',
+        session_factory=session_local,
+    )
+    pipeline._is_market_session_open = lambda _now=None: True  # type: ignore[method-assign]
+
+    while replay_ingestor.remaining > 0:
+        pipeline.run_once()
+    reconcile_updates = pipeline.reconcile()
+    artifacts = _build_artifacts(
+        session_local=session_local,
+        pipeline=pipeline,
+        output_dir=output_dir,
+        start=start,
+        end=end,
+        symbols=symbols,
+        strategies=strategy_defs,
+        signal_fetch_counts=signal_fetch_counts,
+        total_signals=len(all_signals),
+        replay_buckets=len(buckets),
+        reconcile_updates=reconcile_updates,
+    )
+    _write_artifacts(output_dir=output_dir, artifacts=artifacts)
+    logger.info(
+        'Replay complete executions=%s submitted=%s rejected=%s blocked=%s',
+        artifacts.replay_report['executions_total'],
+        artifacts.replay_report['orders_submitted_total'],
+        artifacts.replay_report['rejected_total'],
+        artifacts.replay_report['blocked_total'],
+    )
+    return 0 if artifacts.run_summary['acceptance']['passed'] else 1
+
+
+def _parse_timestamp(value: str) -> datetime:
+    normalized = value.strip()
+    if normalized.endswith('Z'):
+        normalized = normalized[:-1] + '+00:00'
+    parsed = datetime.fromisoformat(normalized)
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _load_enabled_strategies(path: Path) -> list[dict[str, Any]]:
+    payload = yaml.safe_load(path.read_text())
+    if not isinstance(payload, dict):
+        return []
+    raw_catalog = payload.get('data', {}).get('strategies.yaml')
+    if not isinstance(raw_catalog, str):
+        return []
+    catalog = yaml.safe_load(raw_catalog)
+    if not isinstance(catalog, dict):
+        return []
+    raw_strategies = catalog.get('strategies')
+    if not isinstance(raw_strategies, list):
+        return []
+    enabled: list[dict[str, Any]] = []
+    for entry in raw_strategies:
+        if not isinstance(entry, dict):
+            continue
+        if not bool(entry.get('enabled', False)):
+            continue
+        enabled.append(entry)
+    return enabled
+
+
+def _seed_strategies(
+    session_local: sessionmaker[Session],
+    strategy_defs: list[dict[str, Any]],
+) -> None:
+    with session_local() as session:
+        for definition in strategy_defs:
+            session.add(
+                Strategy(
+                    name=str(definition.get('name') or 'strategy'),
+                    description=str(definition.get('description') or ''),
+                    enabled=True,
+                    base_timeframe=str(definition.get('base_timeframe') or '1Sec'),
+                    universe_type=str(definition.get('universe_type') or 'static'),
+                    universe_symbols=definition.get('universe_symbols'),
+                    max_position_pct_equity=_optional_decimal(
+                        definition.get('max_position_pct_equity')
+                    ),
+                    max_notional_per_trade=_optional_decimal(
+                        definition.get('max_notional_per_trade')
+                    ),
+                )
+            )
+        session.commit()
+
+
+def _configure_replay_settings(
+    *,
+    symbols: list[str],
+    max_notional_per_order: Decimal | None,
+    max_notional_per_symbol: Decimal | None,
+    allow_shorts: bool,
+) -> None:
+    config.settings.trading_enabled = True
+    config.settings.trading_mode = 'paper'
+    config.settings.trading_live_enabled = False
+    config.settings.trading_pipeline_mode = 'simple'
+    config.settings.trading_simple_submit_enabled = True
+    config.settings.trading_simple_order_feed_telemetry_enabled = False
+    config.settings.trading_simple_max_notional_per_order = (
+        float(max_notional_per_order) if max_notional_per_order is not None else None
+    )
+    config.settings.trading_simple_max_notional_per_symbol = (
+        float(max_notional_per_symbol) if max_notional_per_symbol is not None else None
+    )
+    config.settings.trading_kill_switch_enabled = False
+    config.settings.trading_emergency_stop_enabled = False
+    config.settings.trading_universe_source = 'jangar'
+    config.settings.trading_universe_static_fallback_enabled = True
+    config.settings.trading_universe_static_fallback_symbols_raw = ','.join(symbols)
+    config.settings.trading_allow_shorts = allow_shorts
+    config.settings.trading_fractional_equities_enabled = True
+    config.settings.trading_feature_quality_enabled = False
+    config.settings.trading_strategy_scheduler_enabled = False
+    config.settings.trading_strategy_runtime_mode = 'scheduler_v3'
+    config.settings.llm_enabled = False
+
+
+def _fetch_signals_adaptive(
+    *,
+    ingestor: ClickHouseSignalIngestor,
+    symbol: str,
+    start: datetime,
+    end: datetime,
+    min_split_seconds: int,
+    clickhouse_transport: str,
+    clickhouse_namespace: str,
+    clickhouse_pod: str,
+    clickhouse_username: str,
+    clickhouse_password: str,
+    clickhouse_table: str,
+) -> list[SignalEnvelope]:
+    try:
+        return _fetch_signals_window(
+            ingestor=ingestor,
+            symbol=symbol,
+            start=start,
+            end=end,
+            clickhouse_transport=clickhouse_transport,
+            clickhouse_namespace=clickhouse_namespace,
+            clickhouse_pod=clickhouse_pod,
+            clickhouse_username=clickhouse_username,
+            clickhouse_password=clickhouse_password,
+            clickhouse_table=clickhouse_table,
+        )
+    except Exception as exc:
+        window_seconds = int((end - start).total_seconds())
+        if window_seconds <= min_split_seconds:
+            raise RuntimeError(
+                f'Failed to fetch {symbol} signals for {start.isoformat()}..{end.isoformat()}'
+            ) from exc
+        midpoint = start + timedelta(seconds=window_seconds // 2)
+        if midpoint <= start or midpoint >= end:
+            raise
+        logger.warning(
+            'Splitting %s window %s..%s after fetch failure: %s',
+            symbol,
+            start.isoformat(),
+            end.isoformat(),
+            exc,
+        )
+        left = _fetch_signals_adaptive(
+            ingestor=ingestor,
+            symbol=symbol,
+            start=start,
+            end=midpoint,
+            min_split_seconds=min_split_seconds,
+            clickhouse_transport=clickhouse_transport,
+            clickhouse_namespace=clickhouse_namespace,
+            clickhouse_pod=clickhouse_pod,
+            clickhouse_username=clickhouse_username,
+            clickhouse_password=clickhouse_password,
+            clickhouse_table=clickhouse_table,
+        )
+        right = _fetch_signals_adaptive(
+            ingestor=ingestor,
+            symbol=symbol,
+            start=midpoint,
+            end=end,
+            min_split_seconds=min_split_seconds,
+            clickhouse_transport=clickhouse_transport,
+            clickhouse_namespace=clickhouse_namespace,
+            clickhouse_pod=clickhouse_pod,
+            clickhouse_username=clickhouse_username,
+            clickhouse_password=clickhouse_password,
+            clickhouse_table=clickhouse_table,
+        )
+        return left + right
+
+
+def _fetch_signals_window(
+    *,
+    ingestor: ClickHouseSignalIngestor,
+    symbol: str,
+    start: datetime,
+    end: datetime,
+    clickhouse_transport: str,
+    clickhouse_namespace: str,
+    clickhouse_pod: str,
+    clickhouse_username: str,
+    clickhouse_password: str,
+    clickhouse_table: str,
+) -> list[SignalEnvelope]:
+    if clickhouse_transport == 'http':
+        return ingestor.fetch_signals_between(start, end, symbol=symbol)
+    rows = _fetch_rows_via_kubectl(
+        symbol=symbol,
+        start=start,
+        end=end,
+        clickhouse_namespace=clickhouse_namespace,
+        clickhouse_pod=clickhouse_pod,
+        clickhouse_username=clickhouse_username,
+        clickhouse_password=clickhouse_password,
+        clickhouse_table=clickhouse_table,
+    )
+    signals: list[SignalEnvelope] = []
+    for row in rows:
+        signal = ingestor.parse_row(row)
+        if signal is None:
+            continue
+        signals.append(signal)
+    return ingestor._sorted_signals(ingestor._filter_signals(ingestor._dedupe_signals(signals)))
+
+
+def _fetch_rows_via_kubectl(
+    *,
+    symbol: str,
+    start: datetime,
+    end: datetime,
+    clickhouse_namespace: str,
+    clickhouse_pod: str,
+    clickhouse_username: str,
+    clickhouse_password: str,
+    clickhouse_table: str,
+) -> list[dict[str, Any]]:
+    start_literal = _to_ch_datetime64(start)
+    end_literal = _to_ch_datetime64(end)
+    select_expr = ', '.join(ESSENTIAL_SIGNAL_COLUMNS)
+    query = (
+        f"SELECT {select_expr} "
+        f"FROM {clickhouse_table} "
+        f"WHERE symbol = '{symbol}' "
+        f"AND event_ts >= {start_literal} "
+        f"AND event_ts <= {end_literal} "
+        "ORDER BY event_ts ASC, seq ASC "
+        "FORMAT JSONEachRow"
+    )
+    result = subprocess.run(
+        [
+            'kubectl',
+            'exec',
+            '-n',
+            clickhouse_namespace,
+            clickhouse_pod,
+            '--',
+            'clickhouse-client',
+            '--user',
+            clickhouse_username,
+            '--password',
+            clickhouse_password,
+            '--query',
+            query,
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip()
+        raise RuntimeError(detail[:400])
+    rows: list[dict[str, Any]] = []
+    for line in result.stdout.splitlines():
+        normalized = line.strip()
+        if not normalized:
+            continue
+        rows.append(json.loads(normalized))
+    return rows
+
+
+def _to_ch_datetime64(value: datetime) -> str:
+    timestamp = value.astimezone(timezone.utc).strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]
+    return f"toDateTime64('{timestamp}', 3, 'UTC')"
+
+
+def _bucket_signals(
+    signals: list[SignalEnvelope],
+    *,
+    bucket_seconds: int,
+) -> list[list[SignalEnvelope]]:
+    if not signals:
+        return []
+    buckets: list[list[SignalEnvelope]] = []
+    current_bucket: list[SignalEnvelope] = []
+    current_key: datetime | None = None
+    for signal in signals:
+        bucket_key = _bucket_start(signal.event_ts, bucket_seconds=bucket_seconds)
+        if current_key is None or bucket_key != current_key:
+            if current_bucket:
+                buckets.append(current_bucket)
+            current_bucket = [signal]
+            current_key = bucket_key
+            continue
+        current_bucket.append(signal)
+    if current_bucket:
+        buckets.append(current_bucket)
+    return buckets
+
+
+def _bucket_start(timestamp: datetime, *, bucket_seconds: int) -> datetime:
+    epoch_seconds = int(timestamp.timestamp())
+    bucket_epoch = epoch_seconds - (epoch_seconds % max(bucket_seconds, 1))
+    return datetime.fromtimestamp(bucket_epoch, tz=timezone.utc)
+
+
+def _signal_sort_key(signal: SignalEnvelope) -> tuple[datetime, str, int]:
+    return (
+        signal.event_ts,
+        signal.symbol,
+        int(signal.seq or 0),
+    )
+
+
+def _build_artifacts(
+    *,
+    session_local: sessionmaker[Session],
+    pipeline: SimpleTradingPipeline,
+    output_dir: Path,
+    start: datetime,
+    end: datetime,
+    symbols: list[str],
+    strategies: list[dict[str, Any]],
+    signal_fetch_counts: dict[str, int],
+    total_signals: int,
+    replay_buckets: int,
+    reconcile_updates: int,
+) -> ReplayArtifacts:
+    with session_local() as session:
+        decisions = list(session.execute(select(TradeDecision)).scalars())
+        executions = list(session.execute(select(Execution)).scalars())
+    decision_status_totals = Counter(decision.status for decision in decisions)
+    execution_status_totals = Counter(execution.status for execution in executions)
+    reject_reasons = Counter()
+    block_reasons = Counter()
+    lane_values = Counter()
+    submit_paths = Counter()
+    for decision in decisions:
+        payload = _mapping(decision.decision_json)
+        params = _mapping(payload.get('params'))
+        lane_values.update([str(params.get('execution_lane') or '')])
+        submit_paths.update([str(params.get('submit_path') or '')])
+        reject_reasons.update(_string_list(payload.get('risk_reasons')))
+        if payload.get('submission_block_reason'):
+            block_reasons.update([str(payload['submission_block_reason'])])
+    governance_blockers = sorted(
+        reason
+        for reason in block_reasons
+        if _is_governance_block_reason(reason)
+    )
+    invalid_reject_reasons = sorted(
+        reason
+        for reason in reject_reasons
+        if reason not in ALLOWED_REJECT_REASONS
+    )
+    runtime_verify = {
+        'runtime_state': 'ready',
+        'pipeline_mode': config.settings.trading_pipeline_mode,
+        'execution_lane': 'simple',
+        'submit_path': 'direct_alpaca',
+        'window_start': start.isoformat(),
+        'window_end': end.isoformat(),
+        'strategy_names': [str(item.get('name')) for item in strategies],
+        'strategy_count': len(strategies),
+        'symbols': symbols,
+        'signal_fetch_counts': signal_fetch_counts,
+        'signals_total': total_signals,
+        'replay_bucket_count': replay_buckets,
+        'output_dir': str(output_dir),
+    }
+    replay_report = {
+        'pipeline_mode': config.settings.trading_pipeline_mode,
+        'execution_lane': 'simple',
+        'signals_total': total_signals,
+        'decision_total': len(decisions),
+        'orders_submitted_total': decision_status_totals.get('submitted', 0),
+        'rejected_total': decision_status_totals.get('rejected', 0),
+        'blocked_total': decision_status_totals.get('blocked', 0),
+        'executions_total': len(executions),
+        'decision_status_totals': dict(decision_status_totals),
+        'execution_status_totals': dict(execution_status_totals),
+        'reject_reason_totals': dict(reject_reasons),
+        'block_reason_totals': dict(block_reasons),
+        'reconcile_updates': reconcile_updates,
+        'metrics': {
+            'orders_submitted_total': pipeline.state.metrics.orders_submitted_total,
+            'orders_rejected_total': pipeline.state.metrics.orders_rejected_total,
+            'decisions_total': pipeline.state.metrics.decisions_total,
+            'reconcile_updates_total': pipeline.state.metrics.reconcile_updates_total,
+        },
+    }
+    decision_activity = {
+        'pipeline_mode': 'simple',
+        'trade_decisions': len(decisions),
+        'decision_status_totals': dict(decision_status_totals),
+        'reject_reason_totals': dict(reject_reasons),
+        'block_reason_totals': dict(block_reasons),
+        'execution_lane_totals': {
+            key: value for key, value in lane_values.items() if key
+        },
+        'submit_path_totals': {
+            key: value for key, value in submit_paths.items() if key
+        },
+    }
+    execution_activity = {
+        'pipeline_mode': 'simple',
+        'executions': len(executions),
+        'execution_status_totals': dict(execution_status_totals),
+        'reconcile_updates': reconcile_updates,
+    }
+    acceptance = {
+        'executions_non_zero': len(executions) > 0,
+        'capital_stage_shadow_blocks_zero': block_reasons.get('capital_stage_shadow', 0) == 0,
+        'alpha_readiness_blocks_zero': not any(
+            reason.startswith('alpha_readiness_') for reason in block_reasons
+        ),
+        'dependency_quorum_blocks_zero': not any(
+            reason.startswith('dependency_quorum_') for reason in block_reasons
+        ),
+        'market_context_blocks_zero': not any(
+            reason.startswith('market_context') for reason in block_reasons
+        ),
+        'llm_blocks_zero': not any(reason.startswith('llm_') for reason in block_reasons),
+        'reject_reasons_within_simple_allowlist': not invalid_reject_reasons,
+        'reconciliation_updates_persisted': reconcile_updates >= 0,
+        'governance_blockers': governance_blockers,
+        'invalid_reject_reasons': invalid_reject_reasons,
+    }
+    acceptance['passed'] = all(
+        bool(value)
+        for key, value in acceptance.items()
+        if key not in {'governance_blockers', 'invalid_reject_reasons'}
+    )
+    run_summary = {
+        'run_token': 'local-simple-20260326',
+        'window_start': start.isoformat(),
+        'window_end': end.isoformat(),
+        'pipeline_mode': 'simple',
+        'execution_lane': 'simple',
+        'signals_total': total_signals,
+        'decision_total': len(decisions),
+        'executions_total': len(executions),
+        'acceptance': acceptance,
+        'artifacts': {
+            'runtime_verify_path': str(output_dir / 'runtime-verify.json'),
+            'replay_report_path': str(output_dir / 'replay-report.json'),
+            'decision_activity_path': str(output_dir / 'decision-activity.json'),
+            'execution_activity_path': str(output_dir / 'execution-activity.json'),
+            'run_summary_path': str(output_dir / 'run-summary.json'),
+        },
+    }
+    return ReplayArtifacts(
+        runtime_verify=runtime_verify,
+        replay_report=replay_report,
+        decision_activity=decision_activity,
+        execution_activity=execution_activity,
+        run_summary=run_summary,
+    )
+
+
+def _write_artifacts(*, output_dir: Path, artifacts: ReplayArtifacts) -> None:
+    _write_json(output_dir / 'runtime-verify.json', artifacts.runtime_verify)
+    _write_json(output_dir / 'replay-report.json', artifacts.replay_report)
+    _write_json(output_dir / 'decision-activity.json', artifacts.decision_activity)
+    _write_json(output_dir / 'execution-activity.json', artifacts.execution_activity)
+    _write_json(output_dir / 'run-summary.json', artifacts.run_summary)
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + '\n')
+
+
+def _mapping(value: Any) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    return {}
+
+
+def _string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value if str(item).strip()]
+
+
+def _optional_decimal(value: Any) -> Decimal | None:
+    if value is None:
+        return None
+    try:
+        return Decimal(str(value))
+    except Exception:
+        return None
+
+
+def _is_governance_block_reason(reason: str) -> bool:
+    return (
+        reason == 'capital_stage_shadow'
+        or reason.startswith('alpha_readiness_')
+        or reason.startswith('dependency_quorum_')
+        or reason.startswith('market_context')
+        or reason.startswith('llm_')
+    )
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/services/torghut/tests/test_config.py
+++ b/services/torghut/tests/test_config.py
@@ -737,15 +737,24 @@ class TestConfig(TestCase):
                 "sasl_plain_password": "secret",
             },
         )
-        self.assertEqual(
-            settings.trading_simulation_order_updates_kafka_security_kwargs,
-            {
-                "security_protocol": "SASL_PLAINTEXT",
-                "sasl_mechanism": "SCRAM-SHA-512",
-                "sasl_plain_username": "user",
-                "sasl_plain_password": "secret",
-            },
+
+    def test_simple_pipeline_settings_are_supported(self) -> None:
+        settings = Settings(
+            TRADING_ENABLED=False,
+            TRADING_UNIVERSE_SOURCE="static",
+            TRADING_PIPELINE_MODE="simple",
+            TRADING_SIMPLE_MAX_NOTIONAL_PER_ORDER=250.0,
+            TRADING_SIMPLE_MAX_NOTIONAL_PER_SYMBOL=750.0,
+            TRADING_SIMPLE_SUBMIT_ENABLED=True,
+            TRADING_SIMPLE_ORDER_FEED_TELEMETRY_ENABLED=True,
+            DB_DSN="postgresql+psycopg://torghut:torghut@localhost:15438/torghut",
         )
+
+        self.assertEqual(settings.trading_pipeline_mode, "simple")
+        self.assertEqual(settings.trading_simple_max_notional_per_order, 250.0)
+        self.assertEqual(settings.trading_simple_max_notional_per_symbol, 750.0)
+        self.assertTrue(settings.trading_simple_submit_enabled)
+        self.assertTrue(settings.trading_simple_order_feed_telemetry_enabled)
 
     def test_parses_signal_staleness_critical_reasons(self) -> None:
         settings = Settings(

--- a/services/torghut/tests/test_simple_risk.py
+++ b/services/torghut/tests/test_simple_risk.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+from unittest import TestCase
+
+from app.trading.models import StrategyDecision
+from app.trading.simple_risk import prepare_simple_decision
+
+
+class TestSimpleRisk(TestCase):
+    def _decision(
+        self,
+        *,
+        action: str = "buy",
+        qty: str = "1",
+        price: str = "100",
+    ) -> StrategyDecision:
+        return StrategyDecision(
+            strategy_id="strategy-1",
+            symbol="AAPL",
+            event_ts=datetime(2026, 3, 26, 13, 30, tzinfo=timezone.utc),
+            timeframe="1Min",
+            action=action,  # type: ignore[arg-type]
+            qty=Decimal(qty),
+            rationale="simple-risk-test",
+            params={"price": price},
+        )
+
+    def test_quantizes_and_clamps_order_notional(self) -> None:
+        result = prepare_simple_decision(
+            decision=self._decision(qty="3.75"),
+            account={"buying_power": "10000", "equity": "10000", "cash": "10000"},
+            positions=[],
+            fractional_equities_enabled=True,
+            allow_shorts=True,
+            max_notional_per_order=Decimal("250"),
+            max_notional_per_symbol=None,
+        )
+
+        self.assertTrue(result.approved)
+        self.assertEqual(result.decision.qty, Decimal("2.5000"))
+        self.assertEqual(result.notional, Decimal("250.0000"))
+
+    def test_rejects_when_symbol_exposure_cap_leaves_less_than_min_qty(self) -> None:
+        result = prepare_simple_decision(
+            decision=self._decision(qty="1"),
+            account={"buying_power": "10000", "equity": "10000", "cash": "10000"},
+            positions=[{"symbol": "AAPL", "qty": "9", "market_value": "950", "side": "long"}],
+            fractional_equities_enabled=False,
+            allow_shorts=True,
+            max_notional_per_order=None,
+            max_notional_per_symbol=Decimal("1000"),
+        )
+
+        self.assertFalse(result.approved)
+        self.assertEqual(result.reject_reason, "max_symbol_exposure_exceeded")
+
+    def test_rejects_when_buying_power_is_insufficient(self) -> None:
+        result = prepare_simple_decision(
+            decision=self._decision(qty="5"),
+            account={"buying_power": "200", "equity": "10000", "cash": "200"},
+            positions=[],
+            fractional_equities_enabled=False,
+            allow_shorts=True,
+            max_notional_per_order=None,
+            max_notional_per_symbol=None,
+        )
+
+        self.assertFalse(result.approved)
+        self.assertEqual(result.reject_reason, "insufficient_buying_power")
+
+    def test_rejects_sub_min_qty_after_quantization(self) -> None:
+        result = prepare_simple_decision(
+            decision=self._decision(qty="0.2"),
+            account={"buying_power": "10000", "equity": "10000", "cash": "10000"},
+            positions=[],
+            fractional_equities_enabled=False,
+            allow_shorts=True,
+            max_notional_per_order=None,
+            max_notional_per_symbol=None,
+        )
+
+        self.assertFalse(result.approved)
+        self.assertEqual(result.reject_reason, "qty_below_min_after_clamp")

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -185,6 +185,8 @@ class TestTradingApi(TestCase):
         _TRADING_DEPENDENCY_HEALTH_CACHE.clear()
         _ALPACA_HEALTH_STATE.clear()
         app.dependency_overrides.clear()
+        if hasattr(app.state, "trading_scheduler"):
+            delattr(app.state, "trading_scheduler")
 
     def test_trading_decisions_endpoint(self) -> None:
         response = self.client.get("/trading/decisions?symbol=AAPL")
@@ -594,6 +596,51 @@ class TestTradingApi(TestCase):
             datetime.fromisoformat(payload["last_decision_at"]),
             latest_created_at,
         )
+
+    def test_trading_status_surfaces_simple_lane_fields(self) -> None:
+        original_pipeline_mode = settings.trading_pipeline_mode
+        original_trading_enabled = settings.trading_enabled
+        original_trading_mode = settings.trading_mode
+        original_simple_submit_enabled = settings.trading_simple_submit_enabled
+        original_kill_switch_enabled = settings.trading_kill_switch_enabled
+
+        settings.trading_pipeline_mode = "simple"
+        settings.trading_enabled = True
+        settings.trading_mode = "live"
+        settings.trading_simple_submit_enabled = True
+        settings.trading_kill_switch_enabled = False
+        try:
+            scheduler = TradingScheduler()
+            scheduler.state.metrics.orders_submitted_total = 7
+            scheduler.state.metrics.decision_reject_reason_total = {
+                "broker_submit_failed": 2,
+                "capital_stage_shadow": 9,
+            }
+            app.state.trading_scheduler = scheduler
+
+            response = self.client.get("/trading/status")
+            self.assertEqual(response.status_code, 200)
+            payload = response.json()
+
+            self.assertEqual(payload["pipeline_mode"], "simple")
+            self.assertEqual(payload["execution_lane"], "simple")
+            self.assertTrue(payload["live_submission_gate"]["allowed"])
+            self.assertEqual(payload["simple_lane_orders_submitted_total"], 7)
+            self.assertEqual(
+                payload["simple_lane_reject_reason_totals"],
+                {"broker_submit_failed": 2},
+            )
+            self.assertTrue(payload["simple_lane_status"]["enabled"])
+            self.assertEqual(
+                payload["simple_lane_status"]["allowed_reject_reasons"][0],
+                "broker_precheck_failed",
+            )
+        finally:
+            settings.trading_pipeline_mode = original_pipeline_mode
+            settings.trading_enabled = original_trading_enabled
+            settings.trading_mode = original_trading_mode
+            settings.trading_simple_submit_enabled = original_simple_submit_enabled
+            settings.trading_kill_switch_enabled = original_kill_switch_enabled
 
     @patch("app.main._check_alpaca", return_value={"ok": True, "detail": "ok"})
     @patch("app.main._check_clickhouse", return_value={"ok": True, "detail": "ok"})

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -8,7 +8,7 @@ import tempfile
 from types import SimpleNamespace
 from unittest import TestCase
 from unittest.mock import Mock, patch
-from typing import Any
+from typing import Any, cast
 
 from sqlalchemy import create_engine, select
 from sqlalchemy.orm import Session, sessionmaker
@@ -50,6 +50,7 @@ from app.trading.ingest import SignalBatch
 from app.trading.reconcile import Reconciler
 from app.trading.risk import RiskEngine
 from app.trading.scheduler.pipeline import TradingPipeline
+from app.trading.scheduler.simple_pipeline import SimpleTradingPipeline
 from app.trading.scheduler.pipeline_helpers import (
     _apply_projected_position_decision,
     _build_dspy_lineage,
@@ -523,6 +524,13 @@ class TestTradingPipeline(TestCase):
                 "trading_execution_adapter",
                 "trading_allow_shorts",
                 "trading_fractional_equities_enabled",
+                "trading_pipeline_mode",
+                "trading_simple_submit_enabled",
+                "trading_simple_max_notional_per_order",
+                "trading_simple_max_notional_per_symbol",
+                "trading_simple_order_feed_telemetry_enabled",
+                "trading_universe_static_fallback_enabled",
+                "trading_universe_static_fallback_symbols_raw",
                 "trading_market_context_fail_mode",
                 "llm_enabled",
                 "llm_min_confidence",
@@ -690,6 +698,252 @@ class TestTradingPipeline(TestCase):
             config.settings.trading_enabled = original["trading_enabled"]
             config.settings.trading_mode = original["trading_mode"]
             config.settings.trading_live_enabled = original["trading_live_enabled"]
+
+    def test_simple_pipeline_submits_live_order_without_shadow_gate_and_persists_lane_metadata(
+        self,
+    ) -> None:
+        from app import config
+
+        config.settings.trading_enabled = True
+        config.settings.trading_mode = "live"
+        config.settings.trading_live_enabled = True
+        config.settings.trading_pipeline_mode = "simple"
+        config.settings.trading_simple_submit_enabled = True
+        config.settings.trading_autonomy_allow_live_promotion = False
+        config.settings.trading_universe_source = "jangar"
+        config.settings.trading_universe_static_fallback_enabled = True
+        config.settings.trading_universe_static_fallback_symbols_raw = "AAPL"
+
+        with self.session_local() as session:
+            strategy = Strategy(
+                name="simple-live",
+                description="simple live lane",
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="static",
+                universe_symbols=["AAPL"],
+                max_notional_per_trade=Decimal("1000"),
+            )
+            session.add(strategy)
+            session.commit()
+
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 26, 13, 30, tzinfo=timezone.utc),
+            ingest_ts=datetime(2026, 3, 26, 13, 30, 5, tzinfo=timezone.utc),
+            symbol="AAPL",
+            timeframe="1Min",
+            seq=1,
+            payload={
+                "feature_schema_version": "3.0.0",
+                "macd": {"macd": 1.2, "signal": 0.5},
+                "rsi14": 25,
+                "price": 100,
+            },
+        )
+
+        alpaca_client = FakeAlpacaClient()
+        pipeline = SimpleTradingPipeline(
+            alpaca_client=alpaca_client,
+            order_firewall=OrderFirewall(alpaca_client),
+            ingestor=FakeIngestor([signal]),
+            decision_engine=DecisionEngine(),
+            risk_engine=RiskEngine(),
+            executor=OrderExecutor(),
+            execution_adapter=alpaca_client,
+            reconciler=Reconciler(),
+            universe_resolver=UniverseResolver(),
+            state=TradingState(),
+            account_label="paper",
+            session_factory=self.session_local,
+        )
+        pipeline._is_market_session_open = lambda _now=None: True  # type: ignore[method-assign]
+
+        pipeline.run_once()
+
+        self.assertEqual(len(alpaca_client.submitted), 1)
+        with self.session_local() as session:
+            decision = session.execute(select(TradeDecision)).scalar_one()
+            execution = session.execute(select(Execution)).scalar_one()
+            decision_json = cast(dict[str, Any], decision.decision_json)
+            params = cast(dict[str, Any], decision_json.get("params"))
+            control_plane = cast(dict[str, Any], decision_json.get("control_plane_snapshot"))
+            execution_audit = cast(dict[str, Any], execution.execution_audit_json)
+            self.assertEqual(decision.status, "submitted")
+            self.assertEqual(params.get("execution_lane"), "simple")
+            self.assertEqual(params.get("submit_path"), "direct_alpaca")
+            self.assertEqual(control_plane.get("execution_lane"), "simple")
+            self.assertEqual(control_plane.get("pipeline_mode"), "simple")
+            self.assertEqual(execution_audit.get("execution_lane"), "simple")
+            self.assertEqual(execution_audit.get("submit_path"), "direct_alpaca")
+
+    def test_simple_pipeline_reconcile_updates_execution_status(self) -> None:
+        from app import config
+
+        config.settings.trading_enabled = True
+        config.settings.trading_mode = "paper"
+        config.settings.trading_live_enabled = False
+        config.settings.trading_pipeline_mode = "simple"
+        config.settings.trading_universe_source = "jangar"
+        config.settings.trading_universe_static_fallback_enabled = True
+        config.settings.trading_universe_static_fallback_symbols_raw = "AAPL"
+
+        with self.session_local() as session:
+            strategy = Strategy(
+                name="simple-reconcile",
+                description="simple reconcile lane",
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="static",
+                universe_symbols=["AAPL"],
+            )
+            session.add(strategy)
+            session.commit()
+
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 26, 13, 30, tzinfo=timezone.utc),
+            ingest_ts=datetime(2026, 3, 26, 13, 30, 5, tzinfo=timezone.utc),
+            symbol="AAPL",
+            timeframe="1Min",
+            seq=1,
+            payload={
+                "feature_schema_version": "3.0.0",
+                "macd": {"macd": 1.2, "signal": 0.5},
+                "rsi14": 25,
+                "price": 100,
+            },
+        )
+
+        alpaca_client = FakeAlpacaClient()
+        pipeline = SimpleTradingPipeline(
+            alpaca_client=alpaca_client,
+            order_firewall=OrderFirewall(alpaca_client),
+            ingestor=FakeIngestor([signal]),
+            decision_engine=DecisionEngine(),
+            risk_engine=RiskEngine(),
+            executor=OrderExecutor(),
+            execution_adapter=alpaca_client,
+            reconciler=Reconciler(),
+            universe_resolver=UniverseResolver(),
+            state=TradingState(),
+            account_label="paper",
+            session_factory=self.session_local,
+        )
+        pipeline._is_market_session_open = lambda _now=None: True  # type: ignore[method-assign]
+
+        pipeline.run_once()
+        updates = pipeline.reconcile()
+
+        self.assertEqual(updates, 1)
+        with self.session_local() as session:
+            execution = session.execute(select(Execution)).scalar_one()
+            self.assertEqual(execution.status, "filled")
+
+    def test_simple_pipeline_uses_client_order_id_for_idempotency(self) -> None:
+        from app import config
+
+        config.settings.trading_enabled = True
+        config.settings.trading_mode = "paper"
+        config.settings.trading_live_enabled = False
+        config.settings.trading_pipeline_mode = "simple"
+        config.settings.trading_universe_source = "jangar"
+        config.settings.trading_universe_static_fallback_enabled = True
+        config.settings.trading_universe_static_fallback_symbols_raw = "AAPL"
+
+        with self.session_local() as session:
+            strategy = Strategy(
+                name="simple-idempotency",
+                description="simple idempotency",
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="static",
+                universe_symbols=["AAPL"],
+            )
+            session.add(strategy)
+            session.commit()
+
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 26, 13, 30, tzinfo=timezone.utc),
+            ingest_ts=datetime(2026, 3, 26, 13, 30, 5, tzinfo=timezone.utc),
+            symbol="AAPL",
+            timeframe="1Min",
+            seq=1,
+            payload={
+                "feature_schema_version": "3.0.0",
+                "macd": {"macd": 1.2, "signal": 0.5},
+                "rsi14": 25,
+                "price": 100,
+            },
+        )
+
+        alpaca_client = FakeAlpacaClient()
+        pipeline = SimpleTradingPipeline(
+            alpaca_client=alpaca_client,
+            order_firewall=OrderFirewall(alpaca_client),
+            ingestor=FakeIngestor([signal]),
+            decision_engine=DecisionEngine(),
+            risk_engine=RiskEngine(),
+            executor=OrderExecutor(),
+            execution_adapter=alpaca_client,
+            reconciler=Reconciler(),
+            universe_resolver=UniverseResolver(),
+            state=TradingState(),
+            account_label="paper",
+            session_factory=self.session_local,
+        )
+        pipeline._is_market_session_open = lambda _now=None: True  # type: ignore[method-assign]
+
+        pipeline.run_once()
+        pipeline.run_once()
+
+        self.assertEqual(len(alpaca_client.submitted), 1)
+        with self.session_local() as session:
+            self.assertEqual(session.query(Execution).count(), 1)
+
+    def test_simple_pipeline_blocks_shorts_when_asset_is_not_shortable(self) -> None:
+        from app import config
+
+        class _ShortBlockedClient(FakeAlpacaClient):
+            def get_account(self) -> dict[str, str | bool]:
+                account = super().get_account()
+                account["shorting_enabled"] = True
+                return account
+
+            def get_asset(self, symbol_or_asset_id: str) -> dict[str, str | bool]:
+                return {
+                    "symbol": symbol_or_asset_id,
+                    "tradable": True,
+                    "shortable": False,
+                }
+
+        config.settings.trading_allow_shorts = True
+        pipeline = SimpleTradingPipeline(
+            alpaca_client=_ShortBlockedClient(),
+            order_firewall=OrderFirewall(_ShortBlockedClient()),
+            ingestor=FakeIngestor([]),
+            decision_engine=DecisionEngine(),
+            risk_engine=RiskEngine(),
+            executor=OrderExecutor(),
+            execution_adapter=FakeAlpacaClient(),
+            reconciler=Reconciler(),
+            universe_resolver=UniverseResolver(),
+            state=TradingState(),
+            account_label="paper",
+            session_factory=self.session_local,
+        )
+        decision = StrategyDecision(
+            strategy_id="strategy-1",
+            symbol="AAPL",
+            event_ts=datetime(2026, 3, 26, 13, 30, tzinfo=timezone.utc),
+            timeframe="1Min",
+            action="sell",
+            qty=Decimal("1"),
+            rationale="shortability-check",
+            params={"price": "100"},
+        )
+
+        reason = pipeline._simple_shortability_reason(decision=decision, positions=[])
+
+        self.assertEqual(reason, "shorting_not_allowed_for_asset")
 
     def test_execution_routing_uses_lean_for_all_symbols(self) -> None:
         from app import config


### PR DESCRIPTION
## Summary

- add a separate `simple` Torghut execution lane with direct Alpaca submission and a minimal hard-risk envelope
- wire runtime config, execution metadata, and `/trading/status` so simple mode bypasses legacy governance blockers while exposing lane-specific counters
- add a dedicated `torghut-simple` Knative service manifest, focused risk/status tests, and a March 26, 2026 regular-session replay verifier

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen pytest tests/test_simple_risk.py`
- `cd services/torghut && uv run --frozen pytest tests/test_trading_pipeline.py -k 'simple_pipeline or shortable'`
- `cd services/torghut && uv run --frozen pytest tests/test_trading_api.py -k simple_lane`
- `cd services/torghut && uv run --frozen pytest tests/test_config.py -k simple_pipeline_settings_are_supported`
- `cd services/torghut && uv run --frozen python scripts/run_local_simple_lane_replay.py --start 2026-03-26T13:30:00Z --end 2026-03-26T20:00:00Z --output-dir ../../artifacts/torghut/simulations/local-simple-20260326`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
