### PR TITLE
feat(torghut): harden replay and add research sleeves

### DIFF
--- a/argocd/applications/torghut/clickhouse/clickhouse-cluster.yaml
+++ b/argocd/applications/torghut/clickhouse/clickhouse-cluster.yaml
@@ -28,7 +28,7 @@ spec:
             <level>information</level>
           </logger>
 
-          <!-- Bound internal system logs so they cannot starve user-table writes on a 4Gi pod. -->
+          <!-- Bound internal system logs so they cannot starve user-table writes on an 8Gi pod. -->
           <text_log>
             <level>information</level>
             <engine>Engine = MergeTree PARTITION BY event_date ORDER BY event_time TTL event_date + INTERVAL 3 DAY</engine>
@@ -137,10 +137,10 @@ spec:
               resources:
                 requests:
                   cpu: 1
-                  memory: 2Gi
+                  memory: 4Gi
                 limits:
                   cpu: 2
-                  memory: 4Gi
+                  memory: 8Gi
     volumeClaimTemplates:
       - name: chi-data
         spec:

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -126,6 +126,16 @@ spec:
               value: "5000"
             - name: TRADING_RECONCILE_MS
               value: "15000"
+            - name: TRADING_ORDER_FEED_TOPIC_V2
+              value: torghut.trade-updates.v2
+            - name: TRADING_EXECUTION_ADAPTER
+              value: lean
+            - name: TRADING_EXECUTION_FALLBACK_ADAPTER
+              value: alpaca
+            - name: TRADING_EXECUTION_ADAPTER_POLICY
+              value: all
+            - name: TRADING_EXECUTION_PREFER_LIMIT
+              value: "true"
             - name: TRADING_EXECUTION_ADVISOR_LIVE_APPLY_ENABLED
               value: "false"
             - name: TRADING_EXECUTION_ADVISOR_ENABLED

--- a/argocd/applications/torghut/strategy-configmap.yaml
+++ b/argocd/applications/torghut/strategy-configmap.yaml
@@ -10,16 +10,17 @@ metadata:
 data:
   strategies.yaml: |
     strategies:
-      - name: intraday-tsmom-profit-v2
+      - name: intraday-tsmom-profit-v3
         strategy_id: intraday_tsmom_v1@prod
         strategy_type: intraday_tsmom_v1
         version: 1.1.0
-        description: Intraday momentum strategy tuned for higher selectivity, version=1.1.0
+        description: Intraday momentum strategy tuned for higher selectivity and bounded 3x intraday buying power, version=1.1.0
         enabled: true
         base_timeframe: "1Sec"
         universe_type: intraday_tsmom_v1
-        max_notional_per_trade: 2500
-        max_position_pct_equity: 0.08
+        universe_symbols: ["AAPL", "AMAT", "AMD", "AVGO", "GOOG", "INTC", "META", "MSFT", "MU", "NVDA", "PLTR", "SHOP"]
+        max_notional_per_trade: 94770
+        max_position_pct_equity: 3.0
         params:
           bullish_hist_min: "0.04"
           bullish_hist_cap: "0.055"
@@ -31,9 +32,162 @@ data:
           vol_floor: "0"
           vol_ceil: "0.00019"
           low_vol_bonus_threshold: "0.00020"
+          max_spread_bps: "60"
+          entry_start_minute_utc: "880"
           max_price_above_ema12_bps: "0"
           min_price_below_ema12_bps: "2"
           max_price_below_ema12_bps: "28"
+          max_gross_exposure_pct_equity: "3.0"
+          entry_cooldown_seconds: "7200"
+          exit_cooldown_seconds: "0"
+          min_hold_seconds: "0"
+          entry_end_minute_utc: "1180"
+          long_stop_loss_bps: "25"
+          long_stop_loss_spread_bps_multiplier: "0.25"
+          long_stop_loss_volatility_bps_multiplier: "4"
+          long_trailing_stop_activation_profit_bps: "25"
+          long_trailing_stop_drawdown_bps: "18"
+          long_trailing_stop_spread_bps_multiplier: "0.15"
+          long_trailing_stop_volatility_bps_multiplier: "4"
+          require_positive_price_for_signal_exit: "true"
+          min_signal_exit_profit_bps: "8"
+      - name: momentum-pullback-long-v1
+        strategy_id: momentum_pullback_long_v1@research
+        strategy_type: momentum_pullback_long_v1
+        version: 1.0.0
+        description: Research-backed momentum pullback sleeve for liquid equities, version=1.0.0
+        enabled: false
+        base_timeframe: "1Sec"
+        universe_type: momentum_pullback_long_v1
+        universe_symbols: ["AAPL", "AMAT", "AMD", "AVGO", "GOOG", "INTC", "META", "MSFT", "MU", "NVDA", "PLTR", "SHOP"]
+        max_notional_per_trade: 31590
+        max_position_pct_equity: 1.0
+        params:
+          bullish_hist_min: "0.030"
+          bullish_hist_cap: "0.060"
+          min_bull_rsi: "56"
+          max_bull_rsi: "61"
+          vol_floor: "0.00005"
+          vol_ceil: "0.00024"
+          min_price_below_ema12_bps: "3"
+          max_price_below_ema12_bps: "10"
+          max_spread_bps: "4"
+          min_imbalance_pressure: "0.02"
+          exit_macd_hist_max: "-0.004"
+          exit_rsi_max: "47"
+          entry_start_minute_utc: "930"
+          entry_end_minute_utc: "1170"
+          session_flatten_start_minute_utc: "1170"
+          entry_cooldown_seconds: "1800"
+          exit_cooldown_seconds: "180"
+          min_hold_seconds: "180"
+          max_hold_seconds: "1500"
+          max_concurrent_positions: "1"
+          require_positive_price_for_signal_exit: "true"
+      - name: breakout-continuation-long-v1
+        strategy_id: breakout_continuation_long_v1@research
+        strategy_type: breakout_continuation_long_v1
+        version: 1.0.0
+        description: Research-backed breakout continuation sleeve with spread and imbalance confirmation, version=1.0.0
+        enabled: false
+        base_timeframe: "1Sec"
+        universe_type: breakout_continuation_long_v1
+        universe_symbols: ["AAPL", "AMAT", "AMD", "AVGO", "GOOG", "INTC", "META", "MSFT", "MU", "NVDA", "PLTR", "SHOP"]
+        max_notional_per_trade: 14000
+        max_position_pct_equity: 1.0
+        params:
+          bullish_hist_min: "0.015"
+          min_bull_rsi: "60"
+          max_bull_rsi: "68"
+          vol_floor: "0.00004"
+          vol_ceil: "0.00028"
+          min_price_above_ema12_bps: "1"
+          max_price_above_ema12_bps: "8"
+          min_price_above_vwap_bps: "4"
+          max_price_above_vwap_bps: "16"
+          max_spread_bps: "4"
+          min_imbalance_pressure: "0.08"
+          exit_macd_hist_max: "-0.003"
+          entry_start_minute_utc: "900"
+          entry_end_minute_utc: "1170"
+          session_flatten_start_minute_utc: "1170"
+          entry_cooldown_seconds: "1800"
+          exit_cooldown_seconds: "120"
+          min_hold_seconds: "180"
+          max_hold_seconds: "900"
+          max_concurrent_positions: "2"
+          require_positive_price_for_signal_exit: "true"
+      - name: mean-reversion-rebound-long-v1
+        strategy_id: mean_reversion_rebound_long_v1@research
+        strategy_type: mean_reversion_rebound_long_v1
+        version: 1.0.0
+        description: Research-backed intraday rebound sleeve after controlled downside dislocation, version=1.0.0
+        enabled: false
+        base_timeframe: "1Sec"
+        universe_type: mean_reversion_rebound_long_v1
+        universe_symbols: ["AAPL", "AMAT", "AMD", "AVGO", "GOOG", "INTC", "META", "MSFT", "MU", "NVDA", "PLTR", "SHOP"]
+        max_notional_per_trade: 12000
+        max_position_pct_equity: 1.0
+        params:
+          bullish_hist_min: "0.004"
+          bullish_hist_cap: "0.030"
+          min_bull_rsi: "43"
+          max_bull_rsi: "50"
+          vol_floor: "0.00005"
+          vol_ceil: "0.00035"
+          min_price_below_vwap_bps: "15"
+          max_price_below_vwap_bps: "45"
+          min_price_below_ema12_bps: "6"
+          max_price_below_ema12_bps: "24"
+          max_spread_bps: "5"
+          min_imbalance_pressure: "0.06"
+          exit_macd_hist_max: "-0.002"
+          exit_rsi_min: "58"
+          entry_start_minute_utc: "840"
+          entry_end_minute_utc: "1080"
+          session_flatten_start_minute_utc: "1080"
+          entry_cooldown_seconds: "1200"
+          exit_cooldown_seconds: "120"
+          min_hold_seconds: "120"
+          max_hold_seconds: "420"
+          max_concurrent_positions: "1"
+          require_positive_price_for_signal_exit: "true"
+      - name: late-day-continuation-long-v1
+        strategy_id: late_day_continuation_long_v1@research
+        strategy_type: late_day_continuation_long_v1
+        version: 1.0.0
+        description: Research-backed late-day continuation sleeve for strong liquid equities into the close, version=1.0.0
+        enabled: false
+        base_timeframe: "1Sec"
+        universe_type: late_day_continuation_long_v1
+        universe_symbols: ["AAPL", "AMAT", "AMD", "AVGO", "GOOG", "INTC", "META", "MSFT", "MU", "NVDA", "PLTR", "SHOP"]
+        max_notional_per_trade: 14000
+        max_position_pct_equity: 1.0
+        params:
+          bullish_hist_min: "0.008"
+          bullish_hist_cap: "0.045"
+          min_bull_rsi: "58"
+          max_bull_rsi: "70"
+          vol_floor: "0.00005"
+          vol_ceil: "0.00030"
+          min_price_above_ema12_bps: "0"
+          max_price_above_ema12_bps: "12"
+          min_price_above_vwap_bps: "2"
+          max_price_above_vwap_bps: "16"
+          max_spread_bps: "4"
+          min_imbalance_pressure: "0.00"
+          exit_macd_hist_max: "-0.004"
+          exit_rsi_max: "55"
+          entry_start_minute_utc: "1095"
+          entry_end_minute_utc: "1155"
+          session_flatten_start_minute_utc: "1170"
+          min_entry_minutes_before_flatten: "10"
+          entry_cooldown_seconds: "14400"
+          exit_cooldown_seconds: "120"
+          min_hold_seconds: "120"
+          max_hold_seconds: "900"
+          max_concurrent_positions: "1"
+          require_positive_price_for_signal_exit: "true"
   forecast-router-policy.json: |
     {
       "policy_version": "forecast_router_policy_v2",

--- a/argocd/applications/torghut/strategy-configmap.yaml
+++ b/argocd/applications/torghut/strategy-configmap.yaml
@@ -18,18 +18,22 @@ data:
         enabled: true
         base_timeframe: "1Sec"
         universe_type: intraday_tsmom_v1
-        max_notional_per_trade: 1000
+        max_notional_per_trade: 2500
         max_position_pct_equity: 0.08
         params:
-          bullish_hist_min: "0.005"
+          bullish_hist_min: "0.04"
+          bullish_hist_cap: "0.055"
           bearish_hist_min: "0.004"
           bearish_hist_cap: "0.03"
-          min_bull_rsi: "52"
-          max_bull_rsi: "62"
+          min_bull_rsi: "56"
+          max_bull_rsi: "58"
           max_bear_rsi: "45"
           vol_floor: "0"
-          vol_ceil: "0.00030"
+          vol_ceil: "0.00019"
           low_vol_bonus_threshold: "0.00020"
+          max_price_above_ema12_bps: "0"
+          min_price_below_ema12_bps: "2"
+          max_price_below_ema12_bps: "28"
   forecast-router-policy.json: |
     {
       "policy_version": "forecast_router_policy_v2",

--- a/docs/torghut/design-system/current-source-of-truth-and-priority-guide-2026-03-09.md
+++ b/docs/torghut/design-system/current-source-of-truth-and-priority-guide-2026-03-09.md
@@ -1,8 +1,8 @@
-# Torghut Design-System Current Source-of-Truth and Priority Guide (updated 2026-03-21)
+# Torghut Design-System Current Source-of-Truth and Priority Guide (updated 2026-03-27)
 
 ## Status
 
-- Date: `2026-03-21`
+- Date: `2026-03-27`
 - Purpose: distinguish live source-of-truth docs from historical milestone records and identify the current highest-priority work
 - Scope: `docs/torghut/design-system/**`, `docs/torghut/**`, `argocd/applications/torghut/**`, `services/torghut/**`, `services/jangar/**`
 
@@ -76,6 +76,8 @@ If the question is "what should I trust right now?", start here:
    - `docs/torghut/design-system/v6/51-torghut-profit-reservations-schema-witness-and-simulation-slot-ledger-2026-03-19.md`
    - `docs/torghut/design-system/v6/51-torghut-promotion-certificate-and-segment-firebreak-handoff-2026-03-19.md`
    - `docs/torghut/design-system/v6/52-torghut-profit-sleeves-segment-scoped-deallocation-and-evidence-decay-2026-03-19.md`
+   - `docs/torghut/design-system/v6/53-torghut-kafka-retention-bootstrap-and-archive-backed-profitability-proof-2026-03-27.md`
+   - `docs/torghut/design-system/v6/54-torghut-research-backed-sleeves-and-this-week-holdout-proof-2026-03-27.md`
    - `docs/torghut/design-system/v6/53-torghut-cross-plane-profit-certificate-veto-and-options-auth-isolation-2026-03-20.md`
    - `docs/torghut/design-system/v6/53-torghut-capital-leases-and-profit-trial-firebreaks-2026-03-20.md`
    - `docs/torghut/design-system/v6/54-torghut-capital-lease-receipts-and-profit-falsification-ledger-2026-03-20.md`
@@ -94,6 +96,13 @@ If the question is "what should I trust right now?", start here:
 ## Current priority, not historical priority
 
 The current highest-priority work is:
+
+The March 27 profitability-proof contracts are also active operator work for the retained internal-history window:
+
+- convert Kafka-retained recent history into immutable replay bundles and archive-backed profitability proof in
+  `docs/torghut/design-system/v6/53-torghut-kafka-retention-bootstrap-and-archive-backed-profitability-proof-2026-03-27.md`;
+- turn the retained March 16 through March 27 internal window into a frozen selection/holdout sleeve-proof contract in
+  `docs/torghut/design-system/v6/54-torghut-research-backed-sleeves-and-this-week-holdout-proof-2026-03-27.md`.
 
 1. cut Jangar over to shadow-compiled, sealed recovery epochs and enforce backlog-seat ownership before rollout in
    `docs/agents/designs/65-jangar-recovery-epoch-cutover-and-backlog-seat-enforcement-contract-2026-03-21.md`;
@@ -277,6 +286,8 @@ These are still active contract docs rather than historical snapshots:
 - `docs/torghut/design-system/v6/51-torghut-profit-reservations-schema-witness-and-simulation-slot-ledger-2026-03-19.md`
 - `docs/torghut/design-system/v6/52-torghut-profit-sleeves-segment-scoped-deallocation-and-evidence-decay-2026-03-19.md`
 - `docs/torghut/design-system/v6/51-torghut-promotion-certificate-and-segment-firebreak-handoff-2026-03-19.md`
+- `docs/torghut/design-system/v6/53-torghut-kafka-retention-bootstrap-and-archive-backed-profitability-proof-2026-03-27.md`
+- `docs/torghut/design-system/v6/54-torghut-research-backed-sleeves-and-this-week-holdout-proof-2026-03-27.md`
 - `docs/torghut/design-system/v6/53-torghut-cross-plane-profit-certificate-veto-and-options-auth-isolation-2026-03-20.md`
 - `docs/torghut/design-system/v6/53-torghut-capital-leases-and-profit-trial-firebreaks-2026-03-20.md`
 - `docs/torghut/design-system/v6/54-torghut-capital-lease-receipts-and-profit-falsification-ledger-2026-03-20.md`

--- a/docs/torghut/design-system/v6/53-torghut-kafka-retention-bootstrap-and-archive-backed-profitability-proof-2026-03-27.md
+++ b/docs/torghut/design-system/v6/53-torghut-kafka-retention-bootstrap-and-archive-backed-profitability-proof-2026-03-27.md
@@ -1,0 +1,728 @@
+# 53. Torghut Kafka-Retention Bootstrap and Archive-Backed Profitability Proof (2026-03-27)
+
+## Status
+
+- Date: `2026-03-27`
+- Maturity: `implementation contract`
+- Scope: `services/torghut/scripts/{start_historical_simulation.py,generate_historical_profitability_manifests.py,analyze_historical_simulation.py}`, `services/torghut/app/trading/{evaluation.py,completion.py,empirical_jobs.py}`, `services/torghut/app/models/entities.py`, `argocd/applications/torghut/**`, and Torghut/Jangar promotion evidence handoff
+- Depends on:
+  - `docs/torghut/design-system/v1/component-kafka-topics-and-retention.md`
+  - `docs/torghut/design-system/v1/historical-dataset-simulation.md`
+  - `docs/torghut/design-system/v1/trading-day-simulation-automation.md`
+  - `docs/torghut/design-system/v6/05-evaluation-benchmark-and-contamination-control-standard.md`
+  - `docs/torghut/design-system/v6/08-profitability-research-validation-execution-governance-system.md`
+  - `docs/torghut/design-system/v6/38-authoritative-empirical-promotion-evidence-contract-2026-03-09.md`
+  - `docs/torghut/design-system/v6/51-torghut-promotion-certificate-and-segment-firebreak-handoff-2026-03-19.md`
+  - `docs/torghut/design-system/v6/52-torghut-profit-sleeves-segment-scoped-deallocation-and-evidence-decay-2026-03-19.md`
+- Implementation status: `Not started`
+- Primary objective: turn retained Kafka topic windows plus existing historical-simulation machinery into a durable internal profitability-proof system that can honestly certify or reject `>= $250` average net P&L per trading day on current capital
+
+## Executive summary
+
+The current Torghut profitability contradiction is not "there is no internal data."
+
+The current contradiction is:
+
+1. high-value recent data still exists in Kafka, but it expires quickly;
+2. Torghut already has a bounded historical simulation engine, but not a recurring archive-and-proof control loop;
+3. retained simulation databases and one-off runs exist, but the canonical proof registries remain almost empty; and
+4. the system therefore cannot yet distinguish "recent replay is possible" from "promotion-grade profitability has been proven."
+
+Observed live state on `2026-03-27`:
+
+- Kafka topic retention:
+  - `torghut.trades.v1`: `7d`, `delete`, `3` partitions
+  - `torghut.quotes.v1`: `7d`, `delete`, `3` partitions
+  - `torghut.bars.1m.v1`: `30d`, `delete`, `3` partitions
+  - `torghut.status.v1`: `7d`, `compact,delete`, `3` partitions
+  - `torghut.ta.bars.1s.v1`: `14d`, `delete`, `1` partition
+  - `torghut.ta.signals.v1`: `14d`, `delete`, `1` partition
+  - `torghut.ta.status.v1`: `7d`, `compact,delete`, `1` partition
+  - `torghut.trade-updates.v1`: `7d`, `delete`, `3` partitions
+- Conservative replay-grade internal surface assessment:
+  - `ta_signals`: `697,566` rows where `source='ta'` and `window_size='PT1S'`, `10` trading days, `2026-03-16` through `2026-03-27`, `12` symbols
+  - `ta_microbars`: `13` trading days retained
+  - `trade_decisions`: `11` retained trading dates
+  - `position_snapshots`: `14` retained trading dates
+  - `executions`: `2` retained trading dates
+  - options ClickHouse tables have no retained proof-grade partitions
+- ClickHouse active parts:
+  - `ta_microbars`: `13` partitions, `2026-03-11` through `2026-03-27`, `892,974` rows
+  - `ta_signals`: `10` partitions, `2026-03-16` through `2026-03-27`, `847,873` rows
+- Postgres retained day coverage:
+  - `trade_decisions`: `11` trading dates, `2026-03-12` through `2026-03-27`
+  - `position_snapshots`: `14` trading dates, `2026-03-11` through `2026-03-27`
+  - `executions`: `2` trading dates, `2026-03-14` and `2026-03-27`
+  - `execution_order_events`: `0` retained dates
+- Canonical proof/control tables:
+  - `lean_backtest_runs`: `0`
+  - `vnext_empirical_job_runs`: `16` rows
+  - `vnext_dataset_snapshots`: `0`
+  - `vnext_promotion_decisions`: `0`
+  - `simulation_run_progress`: `0`
+- Isolated simulation databases already exist: `43` `torghut_sim_*` databases in CNPG, proving prior replay activity happened, but without a canonical registry proving profitability authority.
+
+Conclusion:
+
+- The user is correct that Kafka contains important missing information.
+- Kafka retention is enough to bootstrap an internal archive now.
+- Kafka retention alone is not enough to support a truthful `>= $250/day` promotion claim.
+- The missing system is a **retention-to-archive profitability proof pipeline**.
+
+This document defines that system.
+
+## Relationship to the `>= $250/day` internal-data program
+
+This document preserves the previously defined `Torghut >= $250/Day Internal-Data Profitability Program`.
+
+It does **not** replace that plan with a Kafka-only shortcut.
+
+The preserved commitments remain:
+
+- a daily internal archive pipeline over Torghut-owned surfaces;
+- daily inventory contracts:
+  - `market_day_inventory.json`
+  - `execution_day_inventory.json`
+  - `replay_day_manifest.json`
+- fail-closed `data_sufficiency` status with `insufficient_history`;
+- research-grade and promotion-grade walk-forward proof windows;
+- required artifacts:
+  - `trial-ledger.json`
+  - `statistical-validity-report.json`
+  - `profitability-certificate.json`
+- v1 proof portfolio scope:
+  - long-only
+  - US equities
+  - intraday
+  - three sleeves
+- hard historical and paper profitability gates for the `>= $250/day` target;
+- capped live rollout only after historical and paper proof succeed.
+
+What changes in this document is narrower:
+
+- Kafka retention becomes the bounded bootstrap source that lets Torghut capture expiring recent history;
+- archive bundles remain the durable proof surface;
+- ClickHouse/Postgres day surfaces remain part of the archived evidence contract rather than being replaced.
+
+## Non-goals
+
+- claiming that the current Torghut sleeve family is already profitable enough;
+- using external market-data vendors or non-repo proof stores;
+- treating TA-derived topics as the only authoritative replay source for equities;
+- allowing live capital promotion directly from one-off local replays;
+- replacing the existing Jangar-issued promotion certificate model.
+
+## Problem statement
+
+Torghut currently lacks an authoritative answer to five profit-critical questions:
+
+1. Which recent trading days are still fully reconstructable from Kafka source topics before retention expires?
+2. Which days have enough execution and runtime evidence to count toward profitability proof rather than replay-only diagnosis?
+3. Where is the immutable internal replay bundle for each day, and how is its lineage tied to candidate, runtime, and artifact hashes?
+4. How does Torghut fail closed when historical depth is insufficient for a `>= $250/day` claim?
+5. How does Torghut move from recent-window bootstrap to durable historical OOS proof without inventing a second architecture?
+
+Until those are answered, any profitability target is vulnerable to:
+
+- retention expiry,
+- ad hoc day selection,
+- repeated tuning on the same short window,
+- missing trial accounting,
+- paper/live promotion from insufficient history.
+
+## Alternatives considered
+
+### Option A: use current ClickHouse/Postgres surfaces only
+
+Pros:
+
+- smallest implementation delta
+- no new archive workflow
+
+Cons:
+
+- current retained depth is too short
+- executions and order events are sparse
+- current ClickHouse headroom is too low for heavy ad hoc aggregates
+- does not recover expiring Kafka source history
+
+Decision: rejected.
+
+### Option B: treat Kafka retention itself as the profitability archive
+
+Pros:
+
+- recent history is real and internal
+- source fidelity is strong for replay while retention remains
+
+Cons:
+
+- retention expiry destroys proof depth
+- no immutable per-day lineage bundle
+- no deterministic artifact bundle for later audit
+- cannot support promotion-grade reproducibility
+
+Decision: rejected.
+
+### Option C: Kafka-retention bootstrap plus archive-backed proof
+
+Pros:
+
+- immediately captures recent internal history before it expires
+- reuses the existing historical simulation engine and manifest flow
+- creates durable per-day replay bundles and proof artifacts
+- supports fail-closed sufficiency gates and later promotion authority
+
+Cons:
+
+- requires a new recurring archival control loop
+- requires explicit trial-ledger and statistical-validity artifacts
+- delays strong profitability claims until enough archived depth exists
+
+Decision: selected.
+
+## Decision
+
+Adopt a two-layer internal-data system:
+
+1. **Kafka retention layer** is the bounded recent-history bootstrap source for equities.
+2. **Archive-backed replay bundles** are the durable source of truth for profitability proof, historical OOS validation, and promotion authority.
+
+For the equities lane:
+
+- authoritative full-fidelity replay input comes from source topics `trades`, `quotes`, `bars`, and `status`, matching `EQUITY_SIMULATION_LANE.replay_roles`;
+- TA topics remain derived, useful for coverage and bootstrap diagnosis, but not sufficient as the sole long-horizon proof source;
+- every retained trading day must be converted before expiry into an immutable replay bundle with deterministic lineage, daily inventory contracts, and proof artifacts.
+
+Promotion authority for `>= $250/day` is blocked unless the archive-backed proof system says otherwise.
+
+## Target profitability contract
+
+The proof target in this document is:
+
+- `profit_target_daily_net_usd = 250`
+- measured as average **net** P&L per trading day
+- on **current capital**, not on scaled capital
+- after modeled execution cost
+- validated on historical OOS test folds and then paper trading
+
+This is an aggressive target on the current account base. The architecture therefore assumes:
+
+- multiple sleeves rather than one tuned sleeve,
+- rejection and execution defects must be pushed left,
+- historical proof must be multiple-testing-aware,
+- paper proof must confirm that the historical signal survives operational reality.
+
+## Canonical data-source hierarchy
+
+### 1. Nearline replay source of truth
+
+For the equities lane, the canonical nearline replay source is:
+
+- `torghut.trades.v1`
+- `torghut.quotes.v1`
+- `torghut.bars.1m.v1`
+- `torghut.status.v1`
+
+These match the replay roles already encoded in:
+
+- `services/torghut/scripts/simulation_lane_contracts.py`
+
+Rules:
+
+- `trades` and `quotes` are the hard limit for full-fidelity equity replay and expire at `7d`.
+- `bars.1m` has `30d` retention and may support coarse diagnostics, but it is not enough to reconstruct the full equity replay lane once `trades` and `quotes` expire.
+- `ta.bars.1s` and `ta.signals` are derived and expire at `14d`; they are useful for bootstrap inspection, coverage checks, and replay verification, but not as the sole long-horizon proof surface.
+
+### 2. Durable proof source of truth
+
+The canonical durable proof source is a per-trading-day archive bundle consisting of:
+
+- bounded Kafka source dump
+- ClickHouse day-scope exports or summaries for `ta_signals` and `ta_microbars`
+- Postgres day-scope exports or summaries for `trade_decisions`, `executions`, `position_snapshots`, and `execution_order_events`
+- existing empirical-job artifacts when present
+- replay manifest
+- run manifest
+- simulation/post-run analysis report
+- inventory contracts
+- dataset snapshot row
+- empirical-job and promotion artifacts that point back to the dataset snapshot
+
+These bundles must be immutable once published.
+
+## Architecture
+
+### 1. Daily archive coordinator
+
+Add a recurring archive coordinator that runs after each trading day and before Kafka source retention expires.
+
+Primary responsibilities:
+
+1. identify the latest completed New York trading day;
+2. inspect Kafka source-topic availability and offsets for the target window;
+3. snapshot the existing day surfaces from ClickHouse, Postgres, and empirical-job rows;
+4. generate or reuse a deterministic historical simulation manifest;
+5. run a bounded full-day replay into isolated simulation surfaces;
+6. emit inventory contracts and immutable artifacts;
+7. register the day as archive-ready, partial, or insufficient;
+8. accumulate archive depth until historical proof becomes eligible.
+
+Canonical runtime building blocks to reuse:
+
+- `services/torghut/scripts/generate_historical_profitability_manifests.py`
+- `services/torghut/scripts/start_historical_simulation.py`
+- `services/torghut/scripts/analyze_historical_simulation.py`
+- `docs/torghut/rollouts/historical-simulation-playbook.md`
+
+### 2. Day inventory contracts
+
+Every archived trading day must produce three first-class JSON contracts.
+
+#### `market_day_inventory.json`
+
+Purpose: declare whether a day is replayable from market-data history.
+
+Required fields:
+
+- `schema_version`
+- `trading_day`
+- `window.start`
+- `window.end`
+- `lane`
+- `source_topics[]`
+- `source_topic_retention_ms_by_topic`
+- `source_offsets`
+- `source_records_by_topic`
+- `symbols`
+- `clickhouse_coverage`
+- `clickhouse_day_exports`
+- `replayable_market_day`
+- `missing_topics[]`
+- `missing_partitions[]`
+- `missing_symbols[]`
+- `reconstruction_source_provenance`
+- `observed_at`
+
+#### `execution_day_inventory.json`
+
+Purpose: declare whether a day has enough runtime/execution evidence to count toward profitability proof.
+
+Required fields:
+
+- `schema_version`
+- `trading_day`
+- `candidate_scope`
+- `trade_decisions_present`
+- `executions_present`
+- `execution_order_events_present`
+- `position_snapshots_present`
+- `postgres_day_exports`
+- `empirical_artifact_refs`
+- `rejections_by_reason`
+- `broker_failures_by_reason`
+- `execution_day_eligible`
+- `missing_execution_surfaces[]`
+- `observed_at`
+
+#### `replay_day_manifest.json`
+
+Purpose: bind the immutable replay bundle to the exact lineage used for proof.
+
+Required fields:
+
+- `schema_version`
+- `run_id`
+- `dataset_id`
+- `dataset_snapshot_ref`
+- `candidate_id`
+- `baseline_candidate_id`
+- `trading_day`
+- `window`
+- `source_dump_ref`
+- `source_dump_sha256`
+- `run_manifest_ref`
+- `analysis_report_ref`
+- `simulation_database`
+- `runtime_version_refs`
+- `model_refs`
+- `strategy_spec_ref`
+- `artifact_bundle_sha256`
+- `archive_status`
+
+### 3. Durable dataset registration
+
+Every archive-ready day must write one `vnext_dataset_snapshots` row.
+
+Canonical contract:
+
+- `run_id`: simulation or archive coordinator run id
+- `candidate_id`: optional during raw-day archival, required for proof-window registration
+- `dataset_id`: deterministic day bundle id
+- `source`: `historical_market_replay`
+- `dataset_version`: digest or day-bundle lineage version
+- `dataset_from` / `dataset_to`: exact UTC bounds
+- `artifact_ref`: immutable bundle root
+- `payload_json`: inventory summaries, hashes, and sufficiency metadata
+
+Important rule:
+
+- the existence of simulation databases alone does not count as durable history;
+- only days with a persisted dataset snapshot row and immutable artifact ref count toward proof depth.
+
+### 4. Data sufficiency gate
+
+Add a mandatory `data_sufficiency` section to the profitability evidence path.
+
+Minimum required fields:
+
+- `market_days_available`
+- `execution_days_available`
+- `replay_ready_market_days`
+- `proof_eligible_days`
+- `symbol_coverage`
+- `missing_days`
+- `source_provenance`
+- `retention_risk_days_remaining`
+- `status`
+- `blockers[]`
+
+Status enum:
+
+- `insufficient_history`
+- `research_only`
+- `historical_ready`
+- `paper_ready`
+
+Hard rules:
+
+- no profitability certificate above `insufficient_history` unless `>= 20` archived replayable market days exist;
+- no promotion-grade historical proof unless `>= 60` archived replayable market days exist;
+- no paper promotion claim unless `>= 20` paper/runtime execution days exist;
+- any missing lineage, missing archive refs, or mismatched dataset snapshot refs forces `insufficient_history`.
+
+### 5. Profitability proof engine
+
+Extend the current walk-forward/evaluation path into an archive-backed proof engine.
+
+Required properties:
+
+- forward-only daily folds
+- one trading-day embargo
+- deterministic fold manifests
+- full trial ledger for every searched candidate
+- deterministic artifact hashes
+- explicit after-cost P&L accounting
+
+Phased proof windows:
+
+#### Research-grade bootstrap
+
+- starts once `>= 20` archived replayable market days exist
+- purpose: eliminate broken sleeves and confirm harness truthfulness
+- output status may be at most `research_only`
+
+#### Promotion-grade historical proof
+
+- starts once `>= 60` archived replayable market days exist
+- canonical fold policy: rolling `40/10/10` trading-day train/validation/test with `1` day embargo
+- only test folds count toward promotion claims
+
+Required artifacts:
+
+- `trial-ledger.json`
+- `statistical-validity-report.json`
+- `profitability-certificate.json`
+- `walkforward-results.json`
+
+### 6. Statistical-validity contract
+
+The proof engine must stop treating repeated short-window tuning as enough.
+
+Required gates for a candidate to become `historical_proven`:
+
+- OOS average daily net P&L on test folds `>= $250`
+- OOS median daily net P&L on test folds `>= $125`
+- profitable-day ratio `>= 60%`
+- after-cost net P&L positive
+- `PBO <= 0.20`
+- `DSR > 0`
+- Reality Check p-value `< 0.05`
+- no incomplete trial ledger
+
+The trial ledger must record all searched candidates, including rejected ones, with:
+
+- `candidate_id`
+- `sleeve_id`
+- `parameter_hash`
+- `search_batch_id`
+- `dataset_snapshot_refs`
+- `selection_status`
+- `selection_reason`
+- `metrics_summary`
+
+This contract preserves the original plan rule that the current March history is bootstrap and harness-validation material only.
+
+### 7. Sleeve portfolio design
+
+To pursue the `>= $250/day` target on current capital, v1 proof scope is:
+
+- US equities
+- long-only
+- intraday only
+
+Initial proof portfolio contains three sleeve families:
+
+- `momentum_pullback_long`
+- `breakout_continuation_long`
+- `mean_reversion_rebound_long`
+
+Each sleeve must emit:
+
+- `sleeve_id`
+- `candidate_id`
+- `data_lineage_id`
+- `proof_window_id`
+
+The design intentionally excludes shorting in v1 proof because:
+
+- current live rejection history is dominated by short-related failures;
+- options retained history is not yet present in proof-grade form;
+- long-only proof removes an avoidable failure class while the archive-and-proof system is being built.
+
+### 8. Push-left rejection and execution controls
+
+Profitability proof is invalid if a large share of candidate behavior dies inside broker or runtime defects.
+
+Before any proof claim can count, the runtime must push these causes left:
+
+- no flat-to-short order creation in the v1 proof portfolio;
+- enforce qty and price increments before order submission;
+- enforce symbol eligibility before order creation;
+- enforce participation and exposure caps before order creation;
+- classify broker-submit failures into retryable vs structural;
+- record structural submission failures in day inventory and trial ledger.
+
+Execution realism requirements:
+
+- arrival-price benchmark
+- partial-fill modeling
+- modeled latency buckets
+- simulated-vs-paper divergence report
+- slippage and rejection summaries included in `profitability-certificate.json`
+
+### 9. Profitability certificate states
+
+Define a Torghut-local profitability certificate artifact that feeds, but does not replace, Jangar-issued promotion certificates.
+
+Status enum:
+
+- `insufficient_history`
+- `research_only`
+- `historical_proven`
+- `paper_proven`
+- `live_capped`
+- `live_full`
+
+Mandatory fields:
+
+- `status`
+- `candidate_id`
+- `sleeve_ids`
+- `profit_target_daily_net_usd`
+- `data_sufficiency`
+- `proof_window`
+- `trial_count`
+- `promotion_blockers`
+- `historical_metrics`
+- `paper_metrics`
+- `execution_realism_summary`
+- `dataset_snapshot_refs`
+- `artifact_refs`
+- `generated_at`
+
+Rules:
+
+- `historical_proven` requires the historical proof gate to pass.
+- `paper_proven` requires the historical proof gate and paper gate to pass on the same lineage.
+- `live_capped` and `live_full` remain subordinate to the March 19 certificate/firebreak architecture and require fresh Jangar-issued promotion certificates.
+
+### 10. Paper and live rollout gates
+
+Historical proof alone is not enough.
+
+Paper gate:
+
+- `20` consecutive trading days
+- average daily net P&L `>= $250`
+- median daily net P&L `>= $150`
+- at least `12` profitable days
+- no more than `3` consecutive losing days
+- max paper drawdown `<= $1,500`
+- rejection rate `< 2%`
+- average absolute slippage `<= 20 bps`
+- p95 absolute slippage `<= 35 bps`
+
+Live rollout:
+
+1. `live_capped` at `25%` target notional for `5` trading days
+2. `live_capped` at `50%` target notional for `10` trading days
+3. `live_full` only if live-vs-paper drift, drawdown, and slippage remain within policy
+
+Fail-closed rule:
+
+- any certificate read failure, dataset lineage mismatch, or segment-health blocker forces `observe`
+
+## Implementation boundary
+
+### Reuse and extend
+
+These surfaces remain canonical and must be extended rather than bypassed:
+
+- `services/torghut/scripts/start_historical_simulation.py`
+- `services/torghut/scripts/generate_historical_profitability_manifests.py`
+- `services/torghut/scripts/analyze_historical_simulation.py`
+- `services/torghut/app/trading/evaluation.py`
+- `services/torghut/app/trading/empirical_jobs.py`
+- `services/torghut/app/trading/completion.py`
+- `services/torghut/app/models/entities.py`
+
+### Add
+
+Add the following first-class scripts:
+
+- `services/torghut/scripts/archive_recent_kafka_trading_days.py`
+  - daily archive coordinator
+  - generates day inventory contracts
+  - writes dataset snapshot rows
+- `services/torghut/scripts/run_archive_backed_profitability_proof.py`
+  - deterministic walk-forward runner
+  - emits trial ledger, statistical validity, and profitability certificate artifacts
+- `services/torghut/scripts/summarize_profitability_archive_state.py`
+  - operator-readable archive sufficiency summary
+
+### Persistence changes
+
+Do not invent a parallel proof registry unless the existing surfaces are insufficient.
+
+Default design:
+
+- `vnext_dataset_snapshots` becomes the durable day-bundle registry
+- `vnext_empirical_job_runs` remains the authoritative empirical artifact registry
+- `vnext_promotion_decisions` stores profitability proof decisions and their artifact refs
+- new artifact families live in object storage and are referenced by the rows above
+
+The archive bundle for each day must therefore contain both:
+
+- source replay lineage from Kafka, and
+- retained Torghut day surfaces from ClickHouse/Postgres/empirical rows
+
+so that the original internal-data archive plan remains intact.
+
+If a new table is later required, it must exist only to normalize day inventory summaries or trial-ledger metadata that cannot be stored sanely in `payload_json`.
+
+## Rollout sequence
+
+### Phase 0: bootstrap from current retained history
+
+- use the existing Kafka retention window immediately
+- archive the existing ClickHouse/Postgres/empirical day surfaces for the same windows
+- archive every replayable day still recoverable from retained source topics
+- use current March history for harness verification and research-only elimination
+- do not issue profitability claims above `research_only`
+
+### Phase 1: recurring archive loop
+
+- run daily after each completed trading day
+- create immutable day bundles before source retention expires
+- keep day inventory and dataset snapshot registry current
+
+### Phase 2: archive-backed research proof
+
+- begin once `>= 20` replayable archived days exist
+- eliminate broken sleeves and rejected execution paths
+- produce research-only profitability certificates
+
+### Phase 3: promotion-grade historical proof
+
+- begin once `>= 60` replayable archived days exist
+- run the `40/10/10` embargoed walk-forward program
+- promote only candidates that pass historical gates
+
+### Phase 4: paper proof
+
+- run `20` consecutive trading days on the archived-lineage candidate
+- require the paper gate to pass
+
+### Phase 5: capped live rollout
+
+- rely on the existing certificate/firebreak architecture
+- permit only capped live states until drift remains within policy
+
+## Testing and verification contract
+
+### Unit tests
+
+- data-sufficiency calculation
+- trading-day completeness and missing-day detection
+- day inventory contract validation
+- deterministic bundle hash generation
+- fold generation with embargo
+- trial-ledger completeness
+- PBO, DSR, and Reality Check calculations
+- rejection push-left enforcement
+
+### Integration tests
+
+- archive coordinator can convert a retained Kafka day into a dataset snapshot plus artifact bundle
+- replay reproducibility from archived bundle artifacts
+- historical proof hard-fails on insufficient history
+- historical proof rejects candidates below `$250/day`
+- profitability certificate blocks on missing lineage or missing dataset snapshot refs
+- paper proof aggregation over `20` days
+- Jangar/Torghut certificate handoff preserves fail-closed behavior
+
+### Acceptance scenarios
+
+- current March-only archive depth resolves to `insufficient_history` or `research_only`, never `historical_proven`
+- a positive candidate below `$250/day` fails
+- a candidate with positive P&L but failed statistical validity fails
+- a candidate with historical proof but failed paper proof does not promote
+- live rollout halts automatically when drift, drawdown, or slippage breaches
+
+## Operator guidance
+
+Use this document when the question is:
+
+- "Can Kafka still save enough recent history to build a real proof program?"
+- "What counts as internal replayable history?"
+- "When is Torghut allowed to claim `>= $250/day`?"
+- "What must exist before Jangar can issue a non-observe promotion certificate?"
+
+Do not use this document to justify:
+
+- one-off manual replay success as promotion proof;
+- configuration-only profitability tuning on a single recent week;
+- promotion from ClickHouse/Postgres fragments without archived lineage bundles.
+
+## Assumptions and defaults
+
+- triple-digit profitability means `>= $250` average **net** P&L per trading day;
+- no new external vendor or data source is introduced;
+- internal historical proof is blocked today by retention-to-archive depth, not by a missing scoring formula;
+- the first milestone is not "claim profitability";
+- the first milestone is "build internal archival and proof machinery so profitability can be proven honestly."
+
+## References
+
+- `docs/torghut/design-system/v1/component-kafka-topics-and-retention.md`
+- `docs/torghut/design-system/v1/historical-dataset-simulation.md`
+- `docs/torghut/design-system/v1/trading-day-simulation-automation.md`
+- `docs/torghut/rollouts/historical-simulation-playbook.md`
+- `services/torghut/scripts/simulation_lane_contracts.py`
+- `services/torghut/scripts/generate_historical_profitability_manifests.py`
+- `services/torghut/scripts/start_historical_simulation.py`
+- `services/torghut/scripts/analyze_historical_simulation.py`
+- `docs/torghut/design-system/v6/38-authoritative-empirical-promotion-evidence-contract-2026-03-09.md`
+- `docs/torghut/design-system/v6/51-torghut-promotion-certificate-and-segment-firebreak-handoff-2026-03-19.md`
+- `docs/torghut/design-system/v6/52-torghut-profit-sleeves-segment-scoped-deallocation-and-evidence-decay-2026-03-19.md`

--- a/docs/torghut/design-system/v6/53-torghut-kafka-retention-bootstrap-and-archive-backed-profitability-proof-2026-03-27.md
+++ b/docs/torghut/design-system/v6/53-torghut-kafka-retention-bootstrap-and-archive-backed-profitability-proof-2026-03-27.md
@@ -104,6 +104,13 @@ What changes in this document is narrower:
 - archive bundles remain the durable proof surface;
 - ClickHouse/Postgres day surfaces remain part of the archived evidence contract rather than being replaced.
 
+This document does **not** require this week's retained-window simulations to start from Kafka.
+
+For the currently retained March 16 through March 27, 2026 window, direct ClickHouse TA replay is the primary
+research/simulation path when the needed day coverage already exists in `torghut.ta_signals` and `torghut.ta_microbars`.
+Kafka matters here as the bounded bootstrap for durable archive creation before retention expiry, not as the mandatory
+entrypoint for every short-window replay.
+
 ## Non-goals
 
 - claiming that the current Torghut sleeve family is already profitable enough;

--- a/docs/torghut/design-system/v6/54-torghut-research-backed-sleeves-and-this-week-holdout-proof-2026-03-27.md
+++ b/docs/torghut/design-system/v6/54-torghut-research-backed-sleeves-and-this-week-holdout-proof-2026-03-27.md
@@ -1,0 +1,629 @@
+# 54. Torghut Research-Backed Sleeves and This-Week Holdout Proof Contract (2026-03-27)
+
+## Status
+
+- Date: `2026-03-27`
+- Maturity: `implementation contract`
+- Scope: `services/torghut/app/trading/{strategy_runtime.py,decisions.py,intraday_tsmom_contract.py,evaluation.py}`, `services/torghut/scripts/{local_intraday_tsmom_replay.py,generate_historical_profitability_manifests.py,start_historical_simulation.py,build_historical_profitability_proof.py}`, `argocd/applications/torghut/strategy-configmap.yaml`, and archive/proof artifacts under `services/torghut/artifacts/**`
+- Depends on:
+  - `docs/torghut/design-system/v6/05-evaluation-benchmark-and-contamination-control-standard.md`
+  - `docs/torghut/design-system/v6/08-profitability-research-validation-execution-governance-system.md`
+  - `docs/torghut/design-system/v6/38-authoritative-empirical-promotion-evidence-contract-2026-03-09.md`
+  - `docs/torghut/design-system/v6/53-torghut-kafka-retention-bootstrap-and-archive-backed-profitability-proof-2026-03-27.md`
+  - `docs/torghut/design-system/v1/historical-dataset-simulation.md`
+  - `docs/torghut/design-system/v1/trading-day-simulation-automation.md`
+- Implementation status: `Not started`
+- Primary objective: define the research-backed multi-sleeve strategy family Torghut should test on the retained March 16 through March 27, 2026 internal window, and define an honest proof workflow for the March 23 through March 27, 2026 holdout week using only currently available internal data
+
+## Executive summary
+
+The current archive/proof document in doc53 answers **how Torghut must preserve and certify evidence**.
+
+It does not answer two other questions tightly enough:
+
+1. what sleeve family should Torghut actually test on the retained internal week; and
+2. how should Torghut use the exact March 23 through March 27, 2026 ClickHouse surface without contaminating the holdout or crashing ClickHouse.
+
+This document answers those questions.
+
+Observed ClickHouse state on `2026-03-27`:
+
+- retained replay-grade `ta_signals` rows where `source='ta'` and `window_size='PT1S'`:
+  - `697,566` rows
+  - first event `2026-03-16 12:01:38 UTC`
+  - last event `2026-03-27 20:57:16 UTC`
+- retained active-part totals:
+  - `torghut.ta_signals`: `847,873` rows across `10` partitions, `2026-03-16` through `2026-03-27`
+  - `torghut.ta_microbars`: `892,974` rows across `13` partitions, `2026-03-11` through `2026-03-27`
+- March 23 through March 27, 2026 week inventory:
+  - replay-grade `ta_signals` rows: `369,268`
+  - active-part `ta_signals` rows: `432,286`
+  - active-part `ta_microbars` rows: `369,268`
+  - symbol universe: `12`
+  - symbols: `AAPL`, `AMAT`, `AMD`, `AVGO`, `GOOG`, `INTC`, `META`, `MSFT`, `MU`, `NVDA`, `PLTR`, `SHOP`
+- options tables in ClickHouse currently show no retained active partitions
+
+Operational constraint:
+
+- broad week-level aggregates on `ta_microbars`, and even some week-level symbol aggregates on `ta_signals`, fail with `MEMORY_LIMIT_EXCEEDED` on the current ClickHouse pod budget;
+- therefore the proof workflow for this week must use:
+  - `system.parts` partition metadata for inventory,
+  - day-bounded or chunk-bounded direct reads for replay,
+  - immutable archived replay bundles for repeated proof runs.
+
+Decision:
+
+- keep doc53 as the authoritative `>= $250/day` archive/proof program;
+- use the currently retained March 16 through March 20, 2026 window as the **selection/calibration** slice;
+- use March 23 through March 27, 2026 as the **untouched holdout** slice;
+- treat direct ClickHouse TA replay as the **primary** simulation path for this week;
+- replace the single-sleeve mindset with a research-backed, long-only, three-sleeve portfolio:
+  - `momentum_pullback_long_v1`
+  - `breakout_continuation_long_v1`
+  - `mean_reversion_rebound_long_v1`
+
+This document does **not** claim the target has been proven.
+
+This document defines the only honest way to test the current retained window.
+
+## Relationship to doc53
+
+Doc53 remains the source of truth for:
+
+- immutable replay bundles;
+- `data_sufficiency`;
+- `trial-ledger.json`;
+- `statistical-validity-report.json`;
+- `profitability-certificate.json`;
+- the fail-closed `insufficient_history` status;
+- the `>= $250/day` historical and paper promotion program.
+
+This document is narrower.
+
+It defines:
+
+- the research-backed sleeve families Torghut should implement next;
+- the exact March 16 through March 27, 2026 window split;
+- the safe ClickHouse access pattern for this week;
+- the exact this-week proof artifacts and command flow;
+- the boundary between "holdout week profitable" and "promotion-grade profitable."
+
+If this document conflicts with doc53 on promotion authority, doc53 wins.
+
+## ClickHouse data available for the current week
+
+### Primary simulation source for this week
+
+For the retained March 16 through March 27, 2026 window, Torghut should simulate from the TA data already materialized
+into ClickHouse.
+
+That means:
+
+- primary replay source for this week:
+  - `torghut.ta_signals` for the current local replay script
+  - `torghut.ta_microbars` as an additional source for the multi-sleeve successor when needed
+- primary runner for this week:
+  - `services/torghut/scripts/local_intraday_tsmom_replay.py`
+  - and its multi-sleeve successor defined in this document
+- Kafka is **not** the required replay starting point for this week's research loop
+
+Kafka remains relevant only for:
+
+- durable archive creation before retention expires;
+- later proof reproducibility once ClickHouse retention moves on;
+- historical simulation rebuilds when ClickHouse no longer retains the needed days.
+
+### This-week inventory
+
+The current retained holdout week is `2026-03-23` through `2026-03-27`.
+
+Replay-grade `ta_signals` coverage (`source='ta'`, `window_size='PT1S'`):
+
+| Trading day | Rows | Symbols | First event (UTC) | Last event (UTC) |
+| --- | ---: | ---: | --- | --- |
+| `2026-03-23` | `72,069` | `12` | `2026-03-23 12:00:10` | `2026-03-23 20:58:53` |
+| `2026-03-24` | `68,020` | `12` | `2026-03-24 12:00:48` | `2026-03-24 20:59:26` |
+| `2026-03-25` | `74,969` | `12` | `2026-03-25 12:00:19` | `2026-03-25 20:59:48` |
+| `2026-03-26` | `82,841` | `12` | `2026-03-26 12:02:22` | `2026-03-26 20:59:56` |
+| `2026-03-27` | `71,369` | `12` | `2026-03-27 12:00:19` | `2026-03-27 20:57:16` |
+| **Total** | **`369,268`** | **`12`** | `2026-03-23 12:00:10` | `2026-03-27 20:57:16` |
+
+Active parts by table for the same week:
+
+| Trading day | `ta_signals` active-part rows | `ta_microbars` active-part rows |
+| --- | ---: | ---: |
+| `2026-03-23` | `92,656` | `72,069` |
+| `2026-03-24` | `80,862` | `68,020` |
+| `2026-03-25` | `84,392` | `74,969` |
+| `2026-03-26` | `95,566` | `82,841` |
+| `2026-03-27` | `78,810` | `71,369` |
+| **Total** | **`432,286`** | **`369,268`** |
+
+### Retained-window inventory
+
+The full currently retained replay-grade `ta_signals` window is:
+
+- `2026-03-16` through `2026-03-27`
+- `697,566` filtered replay rows
+- `10` trading days
+
+The currently retained active-part `ta_signals` partitions are:
+
+| Trading day | Rows |
+| --- | ---: |
+| `2026-03-16` | `89,039` |
+| `2026-03-17` | `73,678` |
+| `2026-03-18` | `76,304` |
+| `2026-03-19` | `86,547` |
+| `2026-03-20` | `90,019` |
+| `2026-03-23` | `92,656` |
+| `2026-03-24` | `80,862` |
+| `2026-03-25` | `84,392` |
+| `2026-03-26` | `95,566` |
+| `2026-03-27` | `78,810` |
+
+The available replay universe for the current retained window is:
+
+- `AAPL`
+- `AMAT`
+- `AMD`
+- `AVGO`
+- `GOOG`
+- `INTC`
+- `META`
+- `MSFT`
+- `MU`
+- `NVDA`
+- `PLTR`
+- `SHOP`
+
+### Operational caveat
+
+This week's data is real and usable, but the current ClickHouse pod does not have enough headroom for careless analytics.
+
+Observed on `2026-03-27`:
+
+- a grouped week query over `ta_microbars` failed with `MEMORY_LIMIT_EXCEEDED`;
+- a week-level `GROUP BY symbol` over replay-grade `ta_signals` also failed with `MEMORY_LIMIT_EXCEEDED`.
+
+Therefore the approved query pattern for this week is:
+
+1. use `system.parts` for inventory and partition-level row counts;
+2. use direct `ta_signals` reads only in day-bounded or chunk-bounded windows;
+3. avoid repeated broad week aggregates on raw ClickHouse tables;
+4. convert the week into archived replay bundles before repeated candidate-search loops.
+
+## Research synthesis
+
+### What the literature supports
+
+The relevant literature does not support "one generic intraday rule."
+
+It supports **separate sleeve families**:
+
+1. **Intraday continuation / momentum**
+   - The first part of the day can predict later-day continuation in highly liquid instruments, especially when volatility and participation are elevated.
+   - Sources:
+     - [Beat the Market: An Effective Intraday Momentum Strategy for the S&P500 ETF (SPY)](https://papers.ssrn.com/sol3/papers.cfm?abstract_id=4824172)
+     - [Intraday Patterns in the Cross-section of Stock Returns](https://arxiv.org/abs/1005.3535)
+2. **Short-horizon reversal after dislocation**
+   - Extreme intraday price moves can mean-revert, but only if the move looks like a temporary liquidity shock rather than persistent directional flow.
+   - Source:
+     - [Short-term market reaction after extreme price changes of liquid stocks](https://arxiv.org/abs/cond-mat/0406696)
+3. **Order-flow / imbalance-confirmed continuation**
+   - Per-symbol flow and imbalance can strengthen continuation, but the sign is conditional and can reverse if the flow is broad, crowded, or already exhausted.
+   - Source:
+     - [Trade Co-occurrence, Trade Flow Decomposition, and Conditional Order Imbalance in Equity Markets](https://arxiv.org/abs/2209.10334)
+4. **Execution realism is central**
+   - A sleeve only exists if its predicted edge clears expected execution cost and risk at the time of order submission.
+   - Source:
+     - [Measuring and Modeling Execution Cost and Risk](https://pages.stern.nyu.edu/rengle/executioncost.pdf)
+5. **Data-snooping controls are mandatory**
+   - Repeatedly tuning on the same small window without correction creates false edge.
+   - Sources:
+     - [A Reality Check for Data Snooping](https://www.econometricsociety.org/publications/econometrica/browse/volume/2000)
+     - [The Probability of Backtest Overfitting](https://www.davidhbailey.com/dhbpapers/backtest-prob.pdf)
+     - [The Deflated Sharpe Ratio](https://www.davidhbailey.com/dhbpapers/deflated-sharpe.pdf)
+
+### What Torghut should infer from that research
+
+This is an inference from the literature plus the retained Torghut surface.
+
+Torghut should:
+
+- stay **long-only** for this proof lane;
+- keep continuation and reversal in **separate sleeves**;
+- use imbalance only as a **confirmation input**, not as a stand-alone alpha claim;
+- enforce spread, extension, and volatility gates before sizing;
+- treat the March 23 through March 27 week as a **frozen holdout**, not as another tuning sandbox.
+
+## Decision
+
+Adopt a three-sleeve proof portfolio for the retained March window:
+
+1. `momentum_pullback_long_v1`
+2. `breakout_continuation_long_v1`
+3. `mean_reversion_rebound_long_v1`
+
+All three sleeves must:
+
+- be long-only;
+- treat sell actions as exit-only;
+- emit:
+  - `sleeve_id`
+  - `candidate_id`
+  - `data_lineage_id`
+  - `proof_window_id`
+  - `research_family`
+  - `entry_gate_id`
+- be replayable from currently available `ta_signals` plus `ta_microbars`;
+- be valid under chunked local replay and historical simulation manifests.
+
+## Sleeve definitions
+
+### 1. `momentum_pullback_long_v1`
+
+Research family:
+
+- intraday continuation with extension control
+
+Purpose:
+
+- capture continuation only when the instrument is trending up, but entry is taken on a controlled pullback instead of pure chase.
+
+Available inputs:
+
+- `ema12`
+- `ema26`
+- `macd`
+- `macd_signal`
+- `rsi14`
+- `vol_realized_w60s`
+- midpoint from `imbalance_bid_px` / `imbalance_ask_px`
+- spread from `imbalance_ask_px - imbalance_bid_px`
+
+Derived features required:
+
+- `mid_px`
+- `spread_bps`
+- `price_vs_ema12_bps`
+- `macd_hist`
+- `session_minutes_from_open`
+
+Entry contract:
+
+- eligible window:
+  - `14:00 UTC` through `19:15 UTC`
+- trend:
+  - `ema12 > ema26`
+  - `macd > macd_signal`
+- pullback band:
+  - price is not above `ema12`
+  - price is between `2` and `35` bps below `ema12`
+- confirmation:
+  - `macd_hist > 0`
+  - `rsi14` is bullish but not exhausted
+  - `vol_realized_w60s` inside configured band
+- execution gate:
+  - spread below sleeve cap
+  - no existing long re-entry in the same direction
+
+Exit contract:
+
+- flatten on trend failure, spread blowout, time stop, or end of day
+
+Implementation surfaces:
+
+- extend or replace parts of `services/torghut/app/trading/intraday_tsmom_contract.py`
+- register plugin in `services/torghut/app/trading/strategy_runtime.py`
+- keep exit-only sell enforcement in `services/torghut/app/trading/decisions.py`
+
+### 2. `breakout_continuation_long_v1`
+
+Research family:
+
+- momentum continuation with imbalance confirmation
+
+Purpose:
+
+- capture continuation only when price expansion is accompanied by favorable per-symbol bid/ask imbalance and acceptable spread.
+
+Available inputs:
+
+- all `momentum_pullback_long_v1` inputs
+- `imbalance_bid_sz`
+- `imbalance_ask_sz`
+- `microstructure_signal_v1`
+
+Derived features required:
+
+- `imbalance_pressure = (bid_sz - ask_sz) / (bid_sz + ask_sz)`
+- `spread_bps`
+- `breakout_distance_bps` versus recent local high or opening range high
+- `breakout_age_seconds`
+
+Entry contract:
+
+- eligible window:
+  - `14:00 UTC` through `19:30 UTC`
+- breakout:
+  - price exceeds local breakout reference
+  - breakout is fresh, not late and exhausted
+- confirmation:
+  - `imbalance_pressure` above configured floor
+  - spread below sleeve cap
+  - volatility inside band
+  - trend still aligned (`ema12 > ema26`)
+- do not enter if:
+  - breakout is already overextended versus `ema12`
+  - spread widens beyond cap
+  - existing long exposure already fills the symbol budget
+
+Exit contract:
+
+- flatten on failed breakout, imbalance reversal, time stop, or end of day
+
+Implementation surfaces:
+
+- new plugin module under `services/torghut/app/trading/`
+- metadata emission through `RuntimeDecision.metadata()` in `services/torghut/app/trading/strategy_runtime.py`
+- sizing and symbol-cap enforcement in `services/torghut/app/trading/decisions.py`
+
+### 3. `mean_reversion_rebound_long_v1`
+
+Research family:
+
+- shock reversal after liquidity normalization
+
+Purpose:
+
+- capture rebound only after a downside shock looks temporarily dislocated and then begins to normalize.
+
+Available inputs:
+
+- midpoint and spread
+- `rsi14`
+- `macd_hist`
+- `vol_realized_w60s`
+- `ema12`
+- `vwap_session`
+
+Derived features required:
+
+- `shock_distance_bps` versus rolling anchor
+- `rebound_reclaim_bps`
+- `spread_normalized`
+- `oversold_state`
+
+Entry contract:
+
+- eligible window:
+  - `14:00 UTC` through `18:45 UTC`
+- shock:
+  - price has sold off sharply versus recent anchor
+  - `rsi14` is oversold
+  - realized volatility is elevated
+- normalization:
+  - spread has narrowed back below sleeve cap
+  - midpoint has reclaimed above a short anchor
+  - `macd_hist` is improving, not still accelerating down
+- do not enter while:
+  - spread remains blown out
+  - price is still making new local lows
+
+Exit contract:
+
+- flatten at mean-reversion target, renewed downside acceleration, time stop, or end of day
+
+Implementation surfaces:
+
+- new plugin module under `services/torghut/app/trading/`
+- execution gate wiring in `services/torghut/app/trading/decisions.py`
+- cost-aware target/stop evaluation in the local replay harness
+
+## Portfolio and allocator contract for the retained week
+
+The week-proof portfolio must be sleeve-aware.
+
+Allocator limits:
+
+- max gross exposure: `1.0x` equity
+- max symbol exposure: `0.20x` equity
+- max sleeve exposure: `0.35x` equity
+- max concurrent positions: `5`
+- one active position per symbol
+
+Pre-trade hard fails:
+
+- no short entries
+- no flat sells
+- no re-entry while already long in the same sleeve direction
+- no entry when spread cap fails
+- no entry when symbol cap is exhausted
+
+Important limitation:
+
+- the currently retained ClickHouse surface does **not** provide a full marketwide participation model;
+- therefore true participation-rate caps versus total consolidated tape volume are **not** available from this week alone;
+- the live-capital program in doc53 must still treat marketwide participation modeling as incomplete until durable archive bundles or richer execution surfaces exist.
+
+## This-week proof workflow
+
+### Proof split
+
+Use the currently retained window as:
+
+- **selection/calibration week**: `2026-03-16` through `2026-03-20`
+- **holdout week**: `2026-03-23` through `2026-03-27`
+
+Rules:
+
+- no threshold changes after the holdout is first touched;
+- all searched candidates must be recorded in the trial ledger;
+- the holdout week is only run after the candidate set is frozen.
+
+### Required new artifacts
+
+Add a week-proof artifact directory:
+
+- `services/torghut/artifacts/proof-weeks/2026-03-23/`
+
+Required files:
+
+- `clickhouse-week-inventory.json`
+- `selection-week-trial-ledger.json`
+- `research-sleeve-config.lock.json`
+- `holdout-week-report.json`
+- `holdout-week-profitability-proof.json`
+- `holdout-week-statistical-validity.json`
+
+### Required scripts
+
+Add:
+
+1. `services/torghut/scripts/build_weekly_clickhouse_inventory.py`
+   - outputs exact week inventory from `system.parts` plus safe direct day queries
+   - never runs broad week-level raw aggregates
+2. `services/torghut/scripts/local_research_sleeve_replay.py`
+   - generalizes the current local replay from one sleeve to the three-sleeve portfolio
+   - reuses the chunked fetch pattern from `local_intraday_tsmom_replay.py`
+   - outputs per-sleeve, per-symbol, and per-day performance
+3. `services/torghut/scripts/run_this_week_holdout_proof.py`
+   - enforces the March 16 through March 20 selection window
+   - freezes chosen candidates
+   - runs the March 23 through March 27 holdout replay
+   - writes the week-specific artifacts above
+
+### Required command flow
+
+1. Build week inventory from ClickHouse.
+2. Run baseline replay on the selection week using the current production `intraday_tsmom_v1` config.
+3. Search candidate grids for the three new sleeves on the selection week only.
+4. Freeze the selected candidate set into `research-sleeve-config.lock.json`.
+5. Replay the holdout week.
+6. Only if direct ClickHouse replay becomes unusable for a required day, fall back to archived manifests or historical simulation for that day.
+7. Build proof artifacts and compare against:
+   - cash-flat baseline
+   - current production `intraday_tsmom_v1` baseline
+
+### Safe query contract
+
+The local proof scripts for this week must:
+
+- read replay data in small time chunks, not one giant week query;
+- prefer `ta_signals` for replay reads;
+- treat the existing TA ClickHouse tables as the default source for this week;
+- use `system.parts` for row inventories;
+- avoid week-level `GROUP BY symbol` and `GROUP BY trading_day` on raw `ta_microbars`;
+- archive bundles after the first valid replay to avoid hitting ClickHouse repeatedly.
+
+### Existing evidence that ClickHouse is sufficient for this week
+
+The current week already has enough retained ClickHouse TA data to drive the local replay path:
+
+- the retained holdout week exposes `369,268` replay-grade `ta_signals` rows across `5` trading days and `12` symbols;
+- the existing `local_intraday_tsmom_replay.py` script reads ClickHouse in bounded chunks rather than one raw week scan;
+- the existing `local_intraday_tsmom_replay.py` script currently reads `torghut.ta_signals` directly, not Kafka;
+- that direct ClickHouse replay path has already succeeded on `2026-03-23` through `2026-03-27`.
+
+So the operational problem for this week is **not** "Kafka must be replayed first."
+
+The operational problem is:
+
+- use the already materialized TA data correctly;
+- avoid memory-bound analytics;
+- freeze selection versus holdout;
+- then archive the resulting evidence before retention expires.
+
+## Proof semantics for this week
+
+The only honest claim this week can support is:
+
+- "This frozen candidate set was or was not profitable on the March 23 through March 27, 2026 holdout week after modeled costs."
+
+This week cannot support the stronger claim:
+
+- "`>= $250/day` has been proven for Torghut."
+
+That stronger claim remains blocked on doc53 requirements:
+
+- enough archived history;
+- selection-bias-aware evidence;
+- historical OOS gates;
+- paper gates.
+
+## Acceptance criteria
+
+This document is implemented only when all of the following are true:
+
+1. The week inventory script writes `clickhouse-week-inventory.json` with the exact retained March 23 through March 27 counts.
+2. The multi-sleeve replay script can run on the retained week without issuing broad memory-bound ClickHouse aggregates.
+3. Every decision emitted by the three sleeves includes:
+   - `sleeve_id`
+   - `candidate_id`
+   - `data_lineage_id`
+   - `proof_window_id`
+4. The holdout proof runner writes:
+   - `selection-week-trial-ledger.json`
+   - `research-sleeve-config.lock.json`
+   - `holdout-week-report.json`
+   - `holdout-week-profitability-proof.json`
+   - `holdout-week-statistical-validity.json`
+5. Holdout reporting compares the frozen multi-sleeve portfolio against:
+   - cash-flat
+   - the current `intraday_tsmom_v1` baseline
+6. The reporting layer explicitly marks the result as:
+   - `holdout_week_positive`,
+   - `holdout_week_negative`, or
+   - `holdout_week_inconclusive`,
+   and never upgrades it to `historical_proven` or `paper_proven`.
+
+## Appendix: exact queries used for the live inventory snapshot
+
+The following query classes produced the March 27 snapshot used in this document:
+
+1. `system.parts` inventory:
+
+```sql
+SELECT table, partition AS trading_day, sum(rows) AS rows
+FROM system.parts
+WHERE active
+  AND database = 'torghut'
+  AND table IN ('ta_signals', 'ta_microbars')
+  AND partition >= '2026-03-23'
+  AND partition <= '2026-03-27'
+GROUP BY table, trading_day
+ORDER BY table, trading_day
+```
+
+2. replay-grade `ta_signals` day coverage:
+
+```sql
+SELECT
+  toDate(event_ts) AS trading_day,
+  count() AS rows,
+  uniqExact(symbol) AS symbols,
+  min(event_ts) AS first_ts,
+  max(event_ts) AS last_ts
+FROM torghut.ta_signals
+WHERE source = 'ta'
+  AND window_size = 'PT1S'
+  AND event_ts >= toDateTime64('2026-03-23 00:00:00', 3, 'UTC')
+  AND event_ts < toDateTime64('2026-03-28 00:00:00', 3, 'UTC')
+GROUP BY trading_day
+ORDER BY trading_day
+```
+
+3. retained replay universe:
+
+```sql
+SELECT DISTINCT symbol
+FROM torghut.ta_signals
+WHERE source = 'ta'
+  AND window_size = 'PT1S'
+  AND event_ts >= toDateTime64('2026-03-23 00:00:00', 3, 'UTC')
+  AND event_ts < toDateTime64('2026-03-28 00:00:00', 3, 'UTC')
+ORDER BY symbol
+```
+
+Broad raw `ta_microbars` aggregates were intentionally excluded from the approved proof loop because they triggered `MEMORY_LIMIT_EXCEEDED` on the current cluster state.

--- a/docs/torghut/design-system/v6/index.md
+++ b/docs/torghut/design-system/v6/index.md
@@ -10,6 +10,8 @@
 - Implementation status (strict, core 01-13 docs, source-state refresh `2026-03-09`): `Implemented=7`, `Partial=5`, `Completed=1`
 - Evidence (historical closure): `13-production-gap-closure-master-plan-2026-03-03.md` (Wave 0-6 closure + DoD)
 - Evidence (current next-work priority):
+  - `53-torghut-kafka-retention-bootstrap-and-archive-backed-profitability-proof-2026-03-27.md`
+  - `54-torghut-research-backed-sleeves-and-this-week-holdout-proof-2026-03-27.md`
   - `64-torghut-profit-window-cutover-and-escrow-enforcement-contract-2026-03-21.md`
   - `docs/agents/designs/65-jangar-recovery-epoch-cutover-and-backlog-seat-enforcement-contract-2026-03-21.md`
   - `63-torghut-profit-windows-and-evidence-escrow-contract-2026-03-21.md`
@@ -125,6 +127,14 @@ Current source-state priority is narrower:
 - `52-torghut-profit-sleeves-segment-scoped-deallocation-and-evidence-decay-2026-03-19.md` now makes that capital
   contract hypothesis-local: each sleeve carries segment requirements, evidence expiry, overlap caps, and typed
   alert-driven deallocation.
+- `53-torghut-kafka-retention-bootstrap-and-archive-backed-profitability-proof-2026-03-27.md` now turns the March 27
+  data-availability reality into one concrete proof program: Kafka retention is the bounded bootstrap source,
+  immutable replay bundles are the durable truth surface, and `>= $250/day` remains blocked until archive-backed
+  historical and paper gates pass.
+- `54-torghut-research-backed-sleeves-and-this-week-holdout-proof-2026-03-27.md` now turns the retained March 16
+  through March 27 ClickHouse surface into one concrete strategy-and-proof contract: separate continuation,
+  breakout, and rebound sleeves, a frozen March 23 through March 27 holdout week, and a safe query discipline that
+  avoids memory-bound raw ClickHouse aggregates.
 - `53-torghut-cross-plane-profit-certificate-veto-and-options-auth-isolation-2026-03-20.md` now makes the next step
   explicit: non-observe capital depends on one certificate that consumes Jangar witness quorum, Jangar market-context
   and quant evidence, toggle parity, and typed options auth/bootstrap escrow rather than local gate optimism.
@@ -307,6 +317,8 @@ This pack is positioned as the next architecture layer above:
 50. `51-torghut-profit-reservations-schema-witness-and-simulation-slot-ledger-2026-03-19.md`
 51. `51-torghut-promotion-certificate-and-segment-firebreak-handoff-2026-03-19.md`
 52. `52-torghut-profit-sleeves-segment-scoped-deallocation-and-evidence-decay-2026-03-19.md`
+53. `53-torghut-kafka-retention-bootstrap-and-archive-backed-profitability-proof-2026-03-27.md`
+54. `54-torghut-research-backed-sleeves-and-this-week-holdout-proof-2026-03-27.md`
 53. `53-torghut-cross-plane-profit-certificate-veto-and-options-auth-isolation-2026-03-20.md`
 54. `54-torghut-capital-lease-receipts-and-profit-falsification-ledger-2026-03-20.md`
 55. `55-torghut-hypothesis-settlement-exchange-and-lane-capability-leases-2026-03-20.md`

--- a/services/torghut/app/trading/autonomy/runtime.py
+++ b/services/torghut/app/trading/autonomy/runtime.py
@@ -187,6 +187,7 @@ class IntradayTsmomV1Plugin:
         return 0
 
     def on_event(self, fv: FeatureVectorV3, ctx: StrategyContext) -> StrategyIntent | None:
+        price = _decimal(fv.values.get('price'))
         ema12 = _decimal(fv.values.get('ema12'))
         ema26 = _decimal(fv.values.get('ema26'))
         macd = _decimal(fv.values.get('macd'))
@@ -196,6 +197,7 @@ class IntradayTsmomV1Plugin:
         evaluation = evaluate_intraday_tsmom_signal(
             timeframe=fv.timeframe,
             params=ctx.params,
+            price=price,
             ema12=ema12,
             ema26=ema26,
             macd=macd,

--- a/services/torghut/app/trading/autonomy/runtime.py
+++ b/services/torghut/app/trading/autonomy/runtime.py
@@ -197,7 +197,9 @@ class IntradayTsmomV1Plugin:
         evaluation = evaluate_intraday_tsmom_signal(
             timeframe=fv.timeframe,
             params=ctx.params,
+            event_ts=fv.event_ts,
             price=price,
+            spread=_decimal(fv.values.get('spread')),
             ema12=ema12,
             ema26=ema26,
             macd=macd,

--- a/services/torghut/app/trading/decisions.py
+++ b/services/torghut/app/trading/decisions.py
@@ -42,6 +42,8 @@ from .strategy_runtime import (
 
 logger = logging.getLogger(__name__)
 _SHORT_ENTRY_BELOW_MIN_QTY_REASON = "short_entry_below_min_qty"
+_SAME_DIRECTION_REENTRY_REASON = "same_direction_reentry"
+_EXIT_ONLY_SELL_FLAT_REASON = "exit_only_sell_without_long_position"
 
 
 @dataclass(frozen=True)
@@ -178,8 +180,6 @@ class DecisionEngine:
 
         decisions: list[StrategyDecision] = []
         self._last_forecast_telemetry = []
-        if not runtime_eval.intents:
-            return decisions
 
         strategies_by_id = {str(strategy.id): strategy for strategy in strategies}
         raw_runtime_by_strategy_id = {
@@ -302,6 +302,21 @@ class DecisionEngine:
                     | {"sizing": sizing_meta},
                 )
             )
+        overlay_decision = _build_runtime_position_exit_overlay(
+            signal=signal,
+            strategies=strategies,
+            timeframe=timeframe,
+            decisions=decisions,
+            positions=positions,
+            equity=equity,
+            price=price,
+            features=features,
+            snapshot=snapshot,
+            raw_runtime_by_strategy_id=raw_runtime_by_strategy_id,
+            runtime_eval=runtime_eval,
+        )
+        if overlay_decision is not None:
+            decisions.append(overlay_decision)
         return decisions
 
     def _evaluate_legacy(
@@ -768,23 +783,61 @@ def _resolve_qty(
         equity=equity,
     )
     current_value = _position_value_for_symbol(positions, symbol)
-    if (
-        action.strip().lower() == "buy"
-        and symbol_notional_cap is not None
-        and current_value is not None
-        and current_value >= symbol_notional_cap
+    position_qty = _position_qty_for_symbol(positions, symbol)
+    normalized_action = action.strip().lower()
+    exit_only_sell = _treats_sell_as_exit_only(strategy) and normalized_action == "sell"
+    if exit_only_sell and position_qty is not None and position_qty <= 0:
+        return Decimal("0"), {
+            "method": method,
+            "reason": _EXIT_ONLY_SELL_FLAT_REASON,
+            "notional_budget": str(notional_budget),
+            "price": str(price),
+            "position_qty": str(position_qty),
+        }
+    if _blocks_same_direction_reentry(strategy) and _same_direction_reentry_exists(
+        action=normalized_action,
+        position_qty=position_qty,
     ):
+        return Decimal("0"), {
+            "method": method,
+            "reason": _SAME_DIRECTION_REENTRY_REASON,
+            "notional_budget": str(notional_budget),
+            "price": str(price),
+            "position_qty": (
+                str(position_qty) if position_qty is not None else None
+            ),
+        }
+
+    requested_qty = notional_budget / price
+    if exit_only_sell and position_qty is not None and position_qty > 0:
+        requested_qty = position_qty
+    capped_requested_qty = _cap_requested_qty_by_symbol_cap(
+        action=normalized_action,
+        requested_qty=requested_qty,
+        price=price,
+        position_qty=position_qty,
+        symbol_notional_cap=symbol_notional_cap,
+    )
+    cap_applied = capped_requested_qty is not None and capped_requested_qty < requested_qty
+    if capped_requested_qty is not None:
+        requested_qty = capped_requested_qty
+    if requested_qty <= 0:
         return Decimal("0"), {
             "method": method,
             "reason": "symbol_capacity_exhausted",
             "notional_budget": str(notional_budget),
             "price": str(price),
-            "current_value": str(current_value),
-            "symbol_notional_cap": str(symbol_notional_cap),
+            "requested_qty": str(notional_budget / price),
+            "current_value": str(current_value) if current_value is not None else None,
+            "position_qty": (
+                str(position_qty) if position_qty is not None else None
+            ),
+            "symbol_notional_cap": (
+                str(symbol_notional_cap)
+                if symbol_notional_cap is not None
+                else None
+            ),
         }
-
-    requested_qty = notional_budget / price
-    position_qty = _position_qty_for_symbol(positions, symbol)
     resolution = resolve_quantity_resolution(
         action=action,
         symbol=symbol,
@@ -802,6 +855,27 @@ def _resolve_qty(
         symbol, fractional_equities_enabled=resolution.fractional_allowed
     )
     if qty < min_qty:
+        if cap_applied:
+            return Decimal("0"), {
+                "method": method,
+                "reason": "symbol_capacity_exhausted",
+                "notional_budget": str(notional_budget),
+                "price": str(price),
+                "requested_qty": str(requested_qty),
+                "min_qty": str(min_qty),
+                "current_value": (
+                    str(current_value) if current_value is not None else None
+                ),
+                "position_qty": (
+                    str(position_qty) if position_qty is not None else None
+                ),
+                "symbol_notional_cap": (
+                    str(symbol_notional_cap)
+                    if symbol_notional_cap is not None
+                    else None
+                ),
+                "quantity_resolution": resolution.to_payload(),
+            }
         position_qty = resolution.position_qty
         entering_short = (
             action.strip().lower() == "sell"
@@ -824,6 +898,13 @@ def _resolve_qty(
         "method": method,
         "notional_budget": str(notional_budget),
         "price": str(price),
+        "requested_qty": str(requested_qty),
+        "current_value": str(current_value) if current_value is not None else None,
+        "position_qty": str(position_qty) if position_qty is not None else None,
+        "symbol_notional_cap": (
+            str(symbol_notional_cap) if symbol_notional_cap is not None else None
+        ),
+        "symbol_capacity_limited": cap_applied,
         "quantity_resolution": resolution.to_payload(),
     }
 
@@ -852,23 +933,63 @@ def _resolve_qty_for_aggregated(
         equity=equity,
     )
     current_value = _position_value_for_symbol(positions, symbol)
-    if (
-        action.strip().lower() == "buy"
-        and symbol_notional_cap is not None
-        and current_value is not None
-        and current_value >= symbol_notional_cap
+    position_qty = _position_qty_for_symbol(positions, symbol)
+    normalized_action = action.strip().lower()
+    exit_only_sell = (
+        _treats_sell_as_exit_only_any(strategies) and normalized_action == "sell"
+    )
+    if exit_only_sell and position_qty is not None and position_qty <= 0:
+        return Decimal("0"), {
+            "method": "aggregated_notional_budget",
+            "reason": _EXIT_ONLY_SELL_FLAT_REASON,
+            "notional_budget": str(total_budget),
+            "price": str(price),
+            "position_qty": str(position_qty),
+        }
+    if _blocks_same_direction_reentry_any(strategies) and _same_direction_reentry_exists(
+        action=normalized_action,
+        position_qty=position_qty,
     ):
+        return Decimal("0"), {
+            "method": "aggregated_notional_budget",
+            "reason": _SAME_DIRECTION_REENTRY_REASON,
+            "notional_budget": str(total_budget),
+            "price": str(price),
+            "position_qty": (
+                str(position_qty) if position_qty is not None else None
+            ),
+        }
+
+    requested_qty = total_budget / price
+    if exit_only_sell and position_qty is not None and position_qty > 0:
+        requested_qty = position_qty
+    capped_requested_qty = _cap_requested_qty_by_symbol_cap(
+        action=normalized_action,
+        requested_qty=requested_qty,
+        price=price,
+        position_qty=position_qty,
+        symbol_notional_cap=symbol_notional_cap,
+    )
+    cap_applied = capped_requested_qty is not None and capped_requested_qty < requested_qty
+    if capped_requested_qty is not None:
+        requested_qty = capped_requested_qty
+    if requested_qty <= 0:
         return Decimal("0"), {
             "method": "aggregated_notional_budget",
             "reason": "symbol_capacity_exhausted",
             "notional_budget": str(total_budget),
             "price": str(price),
-            "current_value": str(current_value),
-            "symbol_notional_cap": str(symbol_notional_cap),
+            "requested_qty": str(total_budget / price),
+            "current_value": str(current_value) if current_value is not None else None,
+            "position_qty": (
+                str(position_qty) if position_qty is not None else None
+            ),
+            "symbol_notional_cap": (
+                str(symbol_notional_cap)
+                if symbol_notional_cap is not None
+                else None
+            ),
         }
-
-    requested_qty = total_budget / price
-    position_qty = _position_qty_for_symbol(positions, symbol)
     resolution = resolve_quantity_resolution(
         action=action,
         symbol=symbol,
@@ -886,6 +1007,27 @@ def _resolve_qty_for_aggregated(
         symbol, fractional_equities_enabled=resolution.fractional_allowed
     )
     if qty < min_qty:
+        if cap_applied:
+            return Decimal("0"), {
+                "method": "aggregated_notional_budget",
+                "reason": "symbol_capacity_exhausted",
+                "notional_budget": str(total_budget),
+                "price": str(price),
+                "requested_qty": str(requested_qty),
+                "min_qty": str(min_qty),
+                "current_value": (
+                    str(current_value) if current_value is not None else None
+                ),
+                "position_qty": (
+                    str(position_qty) if position_qty is not None else None
+                ),
+                "symbol_notional_cap": (
+                    str(symbol_notional_cap)
+                    if symbol_notional_cap is not None
+                    else None
+                ),
+                "quantity_resolution": resolution.to_payload(),
+            }
         position_qty = resolution.position_qty
         entering_short = (
             action.strip().lower() == "sell"
@@ -907,6 +1049,13 @@ def _resolve_qty_for_aggregated(
         "method": "aggregated_notional_budget",
         "notional_budget": str(total_budget),
         "price": str(price),
+        "requested_qty": str(requested_qty),
+        "current_value": str(current_value) if current_value is not None else None,
+        "position_qty": str(position_qty) if position_qty is not None else None,
+        "symbol_notional_cap": (
+            str(symbol_notional_cap) if symbol_notional_cap is not None else None
+        ),
+        "symbol_capacity_limited": cap_applied,
         "quantity_resolution": resolution.to_payload(),
     }
 
@@ -916,9 +1065,222 @@ def _skip_non_executable_decision_qty(
 ) -> bool:
     reason = str(sizing_meta.get("reason") or "").strip()
     return qty <= 0 and reason in {
+        _EXIT_ONLY_SELL_FLAT_REASON,
         _SHORT_ENTRY_BELOW_MIN_QTY_REASON,
+        _SAME_DIRECTION_REENTRY_REASON,
         "symbol_capacity_exhausted",
     }
+
+
+def _build_runtime_position_exit_overlay(
+    *,
+    signal: SignalEnvelope,
+    strategies: list[Strategy],
+    timeframe: str,
+    decisions: list[StrategyDecision],
+    positions: Optional[list[dict[str, Any]]],
+    equity: Optional[Decimal],
+    price: Optional[Decimal],
+    features: SignalFeatures,
+    snapshot: Optional[MarketSnapshot],
+    raw_runtime_by_strategy_id: Mapping[str, dict[str, Any]],
+    runtime_eval: Any,
+) -> StrategyDecision | None:
+    if price is None or positions is None:
+        return None
+    if any(
+        decision.symbol == signal.symbol and decision.action == "sell"
+        for decision in decisions
+    ):
+        return None
+
+    eligible_strategies = [
+        strategy
+        for strategy in strategies
+        if strategy.enabled
+        and strategy.base_timeframe == timeframe
+        and _treats_sell_as_exit_only(strategy)
+    ]
+    if not eligible_strategies:
+        return None
+
+    position_qty = _position_qty_for_symbol(positions, signal.symbol)
+    if position_qty is None or position_qty <= 0:
+        return None
+
+    avg_entry_price = _position_avg_entry_price_for_symbol(positions, signal.symbol)
+    if avg_entry_price is None or avg_entry_price <= 0 or price >= avg_entry_price:
+        return None
+
+    stop_loss_bps = _resolve_min_positive_strategy_param(
+        strategies=eligible_strategies,
+        key="long_stop_loss_bps",
+    )
+    if stop_loss_bps is None or stop_loss_bps <= 0:
+        return None
+
+    drawdown_bps = ((avg_entry_price - price) / avg_entry_price) * Decimal("10000")
+    if drawdown_bps < stop_loss_bps:
+        return None
+
+    qty, sizing_meta = _resolve_qty_for_aggregated(
+        eligible_strategies,
+        symbol=signal.symbol,
+        action="sell",
+        price=price,
+        equity=equity,
+        positions=positions,
+    )
+    if _skip_non_executable_decision_qty(qty=qty, sizing_meta=sizing_meta):
+        return None
+
+    primary_strategy = eligible_strategies[0]
+    primary_runtime_metadata = dict(
+        raw_runtime_by_strategy_id.get(str(primary_strategy.id), {})
+    )
+    runtime_metadata = {
+        "mode": settings.trading_strategy_runtime_mode,
+        "aggregated": True,
+        "primary_strategy_row_id": str(primary_strategy.id),
+        "primary_declared_strategy_id": primary_runtime_metadata.get(
+            "declared_strategy_id"
+        ),
+        "source_strategy_ids": [str(strategy.id) for strategy in eligible_strategies],
+        "source_declared_strategy_ids": [
+            str(item.get("declared_strategy_id"))
+            for item in raw_runtime_by_strategy_id.values()
+            if str(item.get("declared_strategy_id") or "").strip()
+        ],
+        "compiler_sources": sorted(
+            {
+                str(item.get("compiler_source") or "").strip()
+                for item in raw_runtime_by_strategy_id.values()
+                if str(item.get("compiler_source") or "").strip()
+            }
+        ),
+        "source_strategy_runtime": [
+            dict(raw_runtime_by_strategy_id[str(strategy.id)])
+            for strategy in eligible_strategies
+            if str(strategy.id) in raw_runtime_by_strategy_id
+        ],
+        "intent_conflicts_total": runtime_eval.observation.intent_conflicts_total,
+        "strategy_errors": [
+            {
+                "strategy_id": error.strategy_id,
+                "strategy_type": error.strategy_type,
+                "plugin_id": error.plugin_id,
+                "reason": error.reason,
+            }
+            for error in runtime_eval.errors
+        ],
+        "exit_overlay": "long_stop_loss_bps",
+    }
+    decision = StrategyDecision(
+        strategy_id=str(primary_strategy.id),
+        symbol=signal.symbol,
+        event_ts=signal.event_ts,
+        timeframe=timeframe,
+        action="sell",
+        qty=qty,
+        order_type="market",
+        time_in_force="day",
+        rationale="position_stop_loss_exit",
+        params=_build_params(
+            signal=signal,
+            macd=features.macd,
+            macd_signal=features.macd_signal,
+            rsi=features.rsi,
+            price=price,
+            volatility=features.volatility,
+            snapshot=snapshot,
+            runtime_metadata=runtime_metadata,
+        )
+        | {
+            "sizing": sizing_meta,
+            "position_exit": {
+                "type": "long_stop_loss_bps",
+                "threshold_bps": stop_loss_bps,
+                "drawdown_bps": drawdown_bps,
+                "avg_entry_price": avg_entry_price,
+            },
+        },
+    )
+    return decision
+
+
+def _blocks_same_direction_reentry(strategy: Strategy) -> bool:
+    normalized = str(strategy.universe_type or "").strip().lower()
+    return normalized in {"intraday_tsmom_v1", "intraday_tsmom", "tsmom_intraday"}
+
+
+def _treats_sell_as_exit_only(strategy: Strategy) -> bool:
+    normalized = str(strategy.universe_type or "").strip().lower()
+    return normalized in {"intraday_tsmom_v1", "intraday_tsmom", "tsmom_intraday"}
+
+
+def _blocks_same_direction_reentry_any(strategies: list[Strategy]) -> bool:
+    return any(_blocks_same_direction_reentry(strategy) for strategy in strategies)
+
+
+def _treats_sell_as_exit_only_any(strategies: list[Strategy]) -> bool:
+    return any(_treats_sell_as_exit_only(strategy) for strategy in strategies)
+
+
+def _same_direction_reentry_exists(
+    *,
+    action: str,
+    position_qty: Optional[Decimal],
+) -> bool:
+    if position_qty is None:
+        return False
+    if action == "buy":
+        return position_qty > 0
+    if action == "sell":
+        return position_qty < 0
+    return False
+
+
+def _cap_requested_qty_by_symbol_cap(
+    *,
+    action: str,
+    requested_qty: Decimal,
+    price: Decimal,
+    position_qty: Optional[Decimal],
+    symbol_notional_cap: Optional[Decimal],
+) -> Decimal | None:
+    if requested_qty <= 0:
+        return Decimal("0")
+    if symbol_notional_cap is None or symbol_notional_cap <= 0:
+        return None
+    if price <= 0 or position_qty is None:
+        return None
+
+    cap_qty = symbol_notional_cap / price
+    max_requested_qty = _max_requested_qty_with_symbol_cap(
+        action=action,
+        position_qty=position_qty,
+        cap_qty=cap_qty,
+    )
+    return min(requested_qty, max_requested_qty)
+
+
+def _max_requested_qty_with_symbol_cap(
+    *,
+    action: str,
+    position_qty: Decimal,
+    cap_qty: Decimal,
+) -> Decimal:
+    if cap_qty <= 0:
+        return Decimal("0")
+    if action == "buy":
+        if position_qty < 0:
+            return abs(position_qty) + cap_qty
+        return max(Decimal("0"), cap_qty - position_qty)
+    if action == "sell":
+        if position_qty > 0:
+            return position_qty + cap_qty
+        return max(Decimal("0"), cap_qty - abs(position_qty))
+    return Decimal("0")
 
 
 def _position_qty_for_symbol(
@@ -978,6 +1340,48 @@ def _position_value_for_symbol(
     if not matched:
         return None
     return current_value
+
+
+def _position_avg_entry_price_for_symbol(
+    positions: Optional[list[dict[str, Any]]],
+    symbol: str,
+) -> Optional[Decimal]:
+    if positions is None:
+        return None
+    normalized_symbol = symbol.strip().upper()
+    for position in positions:
+        if str(position.get("symbol") or "").strip().upper() != normalized_symbol:
+            continue
+        raw_value = position.get("avg_entry_price") or position.get("average_entry_price")
+        if raw_value is None:
+            continue
+        try:
+            return Decimal(str(raw_value))
+        except (ArithmeticError, ValueError):
+            continue
+    return None
+
+
+def _resolve_min_positive_strategy_param(
+    *,
+    strategies: list[Strategy],
+    key: str,
+) -> Optional[Decimal]:
+    values: list[Decimal] = []
+    for strategy in strategies:
+        params = StrategyRuntime.definition_from_strategy(strategy).params
+        raw_value = params.get(key)
+        if raw_value is None:
+            continue
+        try:
+            resolved = Decimal(str(raw_value))
+        except (ArithmeticError, ValueError):
+            continue
+        if resolved > 0:
+            values.append(resolved)
+    if not values:
+        return None
+    return min(values)
 
 
 def _resolve_symbol_notional_cap(

--- a/services/torghut/app/trading/decisions.py
+++ b/services/torghut/app/trading/decisions.py
@@ -6,7 +6,8 @@ import logging
 import re
 from collections.abc import Mapping
 from dataclasses import dataclass, field
-from decimal import Decimal
+from datetime import datetime, timezone
+from decimal import Decimal, ROUND_HALF_UP
 from typing import Any, Iterable, Literal, Optional, cast
 
 from ..config import settings
@@ -71,6 +72,8 @@ class DecisionEngine:
             runtime_enabled=False,
             fallback_to_legacy=False,
         )
+        self._last_emitted_action_at: dict[tuple[str, str], datetime] = {}
+        self._position_peak_price_by_symbol: dict[str, Decimal] = {}
         self.forecast_router = (
             build_default_forecast_router(
                 policy_path=settings.trading_forecast_router_policy_path,
@@ -143,6 +146,7 @@ class DecisionEngine:
         timeframe = signal.timeframe
         if timeframe is None:
             return []
+        actual_positions = _actual_positions_only(positions)
         features = extract_signal_features(signal)
 
         price = features.price
@@ -151,6 +155,11 @@ class DecisionEngine:
             snapshot = self.price_fetcher.fetch_market_snapshot(signal)
             if snapshot is not None:
                 price = snapshot.price
+        position_peak_price = self._sync_position_peak_price(
+            symbol=signal.symbol,
+            positions=actual_positions,
+            price=price,
+        )
 
         normalized_payload = dict(signal.payload)
         if price is not None and "price" not in normalized_payload:
@@ -185,21 +194,41 @@ class DecisionEngine:
         raw_runtime_by_strategy_id = {
             item.intent.strategy_id: item.metadata() for item in runtime_eval.raw_intents
         }
-        for intent in runtime_eval.intents:
-            source_strategy_ids = list(intent.source_strategy_ids)
-            primary_strategy_id = source_strategy_ids[0] if source_strategy_ids else None
-            if primary_strategy_id is None:
-                logger.warning(
-                    "Skipping aggregated intent without source strategy symbol=%s horizon=%s",
-                    intent.symbol,
-                    intent.horizon,
-                )
-                continue
+        isolated_strategy_ids = {
+            str(strategy.id)
+            for strategy in strategies
+            if _strategy_uses_position_isolation(strategy)
+        }
+        non_isolated_strategy_ids = {
+            str(strategy.id) for strategy in strategies if str(strategy.id) not in isolated_strategy_ids
+        }
+        aggregated_intents, _ = self.strategy_runtime.aggregator.aggregate(
+            [
+                item.intent
+                for item in runtime_eval.raw_intents
+                if item.intent.strategy_id not in isolated_strategy_ids
+            ]
+        )
+
+        def _append_runtime_intent_decision(
+            *,
+            primary_strategy_id: str,
+            source_strategy_ids: list[str],
+            symbol: str,
+            direction: str,
+            explain: tuple[str, ...],
+            feature_snapshot_hashes: list[str],
+            positions_scope: Optional[list[dict[str, Any]]],
+            aggregated: bool,
+            position_isolation_mode: str | None = None,
+        ) -> None:
             source_strategies = [
                 strategies_by_id[strategy_id]
                 for strategy_id in source_strategy_ids
                 if strategy_id in strategies_by_id
             ]
+            if not source_strategies:
+                return
             source_runtime_metadata = [
                 dict(raw_runtime_by_strategy_id[strategy_id])
                 for strategy_id in source_strategy_ids
@@ -212,20 +241,21 @@ class DecisionEngine:
             )
             qty, sizing_meta = _resolve_qty_for_aggregated(
                 source_strategies,
-                symbol=intent.symbol,
-                action=intent.direction,
+                symbol=symbol,
+                action=direction,
                 price=price,
                 equity=equity,
-                positions=positions,
+                positions=positions_scope,
+                capacity_positions=positions,
             )
             if _skip_non_executable_decision_qty(qty=qty, sizing_meta=sizing_meta):
                 logger.debug(
-                    "Skipping non-executable aggregated decision symbol=%s action=%s reason=%s",
-                    intent.symbol,
-                    intent.direction,
+                    "Skipping non-executable runtime decision symbol=%s action=%s reason=%s",
+                    symbol,
+                    direction,
                     sizing_meta.get("reason"),
                 )
-                continue
+                return
             forecast_contract: dict[str, Any] | None = None
             forecast_audit: dict[str, Any] | None = None
             if self.forecast_router is not None:
@@ -237,17 +267,36 @@ class DecisionEngine:
                 forecast_contract = forecast_result.contract.to_payload()
                 forecast_audit = forecast_result.audit.to_payload()
                 self._last_forecast_telemetry.append(forecast_result.telemetry)
+            trade_policy = _resolve_runtime_trade_policy(source_strategies)
+            if not _passes_runtime_trade_policy(
+                last_emitted_action_at=self._last_emitted_action_at,
+                signal_ts=signal.event_ts,
+                symbol=symbol,
+                action=direction,
+                positions=positions_scope,
+                policy=trade_policy,
+            ):
+                return
+            if not _passes_signal_exit_policy(
+                strategies=source_strategies,
+                symbol=symbol,
+                action=direction,
+                price=price,
+                signal=signal,
+                positions=positions_scope,
+            ):
+                return
             decisions.append(
                 StrategyDecision(
                     strategy_id=primary_strategy_id,
-                    symbol=intent.symbol,
+                    symbol=symbol,
                     event_ts=signal.event_ts,
                     timeframe=timeframe,
-                    action=intent.direction,
+                    action=cast(Literal["buy", "sell"], direction),
                     qty=qty,
                     order_type="market",
                     time_in_force="day",
-                    rationale=",".join(intent.explain),
+                    rationale=",".join(explain),
                     params=_build_params(
                         signal=signal,
                         macd=features.macd,
@@ -258,7 +307,8 @@ class DecisionEngine:
                         snapshot=snapshot,
                         runtime_metadata={
                             "mode": settings.trading_strategy_runtime_mode,
-                            "aggregated": True,
+                            "aggregated": aggregated,
+                            "position_isolation_mode": position_isolation_mode,
                             "primary_strategy_row_id": primary_strategy_id,
                             "primary_declared_strategy_id": primary_runtime_metadata.get(
                                 "declared_strategy_id"
@@ -277,9 +327,7 @@ class DecisionEngine:
                                 }
                             ),
                             "source_strategy_runtime": source_runtime_metadata,
-                            "feature_snapshot_hashes": list(
-                                intent.feature_snapshot_hashes
-                            ),
+                            "feature_snapshot_hashes": feature_snapshot_hashes,
                             "intent_conflicts_total": runtime_eval.observation.intent_conflicts_total,
                             "strategy_errors": [
                                 {
@@ -302,22 +350,148 @@ class DecisionEngine:
                     | {"sizing": sizing_meta},
                 )
             )
+            self._last_emitted_action_at[(symbol, direction)] = signal.event_ts
+
+        for raw_decision in runtime_eval.raw_intents:
+            primary_strategy_id = raw_decision.intent.strategy_id
+            if primary_strategy_id not in isolated_strategy_ids:
+                continue
+            strategy = strategies_by_id.get(primary_strategy_id)
+            if strategy is None:
+                continue
+            _append_runtime_intent_decision(
+                primary_strategy_id=primary_strategy_id,
+                source_strategy_ids=[primary_strategy_id],
+                symbol=raw_decision.intent.symbol,
+                direction=raw_decision.intent.direction,
+                explain=raw_decision.intent.explain,
+                feature_snapshot_hashes=[raw_decision.feature_hash],
+                positions_scope=_positions_for_strategy_action(
+                    positions,
+                    strategy_id=primary_strategy_id,
+                    action=raw_decision.intent.direction,
+                ),
+                aggregated=False,
+                position_isolation_mode="per_strategy",
+            )
+
+        for intent in aggregated_intents:
+            source_strategy_ids = list(intent.source_strategy_ids)
+            primary_strategy_id = source_strategy_ids[0] if source_strategy_ids else None
+            if primary_strategy_id is None:
+                logger.warning(
+                    "Skipping aggregated intent without source strategy symbol=%s horizon=%s",
+                    intent.symbol,
+                    intent.horizon,
+                )
+                continue
+            _append_runtime_intent_decision(
+                primary_strategy_id=primary_strategy_id,
+                source_strategy_ids=source_strategy_ids,
+                symbol=intent.symbol,
+                direction=intent.direction,
+                explain=intent.explain,
+                feature_snapshot_hashes=list(intent.feature_snapshot_hashes),
+                positions_scope=(
+                    actual_positions
+                    if intent.direction == "sell"
+                    else positions
+                ),
+                aggregated=True,
+            )
+        for isolated_strategy_id in sorted(isolated_strategy_ids):
+            strategy = strategies_by_id.get(isolated_strategy_id)
+            if strategy is None:
+                continue
+            overlay_decision = _build_runtime_position_exit_overlay(
+                signal=signal,
+                strategies=[strategy],
+                timeframe=timeframe,
+                decisions=[
+                    decision
+                    for decision in decisions
+                    if decision.symbol == signal.symbol and decision.strategy_id == isolated_strategy_id
+                ],
+                positions=_positions_for_strategy_action(
+                    actual_positions,
+                    strategy_id=isolated_strategy_id,
+                    action="sell",
+                ),
+                equity=equity,
+                price=price,
+                features=features,
+                snapshot=snapshot,
+                raw_runtime_by_strategy_id=raw_runtime_by_strategy_id,
+                runtime_eval=runtime_eval,
+                position_peak_price=position_peak_price,
+                aggregated=False,
+                position_isolation_mode="per_strategy",
+            )
+            if overlay_decision is not None:
+                decisions.append(overlay_decision)
         overlay_decision = _build_runtime_position_exit_overlay(
             signal=signal,
-            strategies=strategies,
+            strategies=[
+                strategy
+                for strategy in strategies
+                if str(strategy.id) in non_isolated_strategy_ids
+            ],
             timeframe=timeframe,
-            decisions=decisions,
-            positions=positions,
+            decisions=[
+                decision
+                for decision in decisions
+                if decision.symbol == signal.symbol and decision.strategy_id in non_isolated_strategy_ids
+            ],
+            positions=actual_positions,
             equity=equity,
             price=price,
             features=features,
             snapshot=snapshot,
             raw_runtime_by_strategy_id=raw_runtime_by_strategy_id,
             runtime_eval=runtime_eval,
+            position_peak_price=position_peak_price,
         )
         if overlay_decision is not None:
             decisions.append(overlay_decision)
         return decisions
+
+    def _sync_position_peak_price(
+        self,
+        *,
+        symbol: str,
+        positions: Optional[list[dict[str, Any]]],
+        price: Optional[Decimal],
+    ) -> Decimal | None:
+        active_symbols = {
+            str(position.get("symbol") or "").strip().upper()
+            for position in (positions or [])
+            if (_position_qty_from_payload(position) or Decimal("0")) > 0
+        }
+        for tracked_symbol in list(self._position_peak_price_by_symbol):
+            if tracked_symbol not in active_symbols:
+                self._position_peak_price_by_symbol.pop(tracked_symbol, None)
+
+        normalized_symbol = symbol.strip().upper()
+        position_qty = _position_qty_for_symbol(positions, normalized_symbol)
+        if position_qty is None or position_qty <= 0:
+            self._position_peak_price_by_symbol.pop(normalized_symbol, None)
+            return None
+
+        avg_entry_price = _position_avg_entry_price_for_symbol(positions, normalized_symbol)
+        candidates = [
+            candidate
+            for candidate in (
+                self._position_peak_price_by_symbol.get(normalized_symbol),
+                avg_entry_price,
+                price,
+            )
+            if candidate is not None and candidate > 0
+        ]
+        if not candidates:
+            return None
+        peak_price = max(candidates)
+        self._position_peak_price_by_symbol[normalized_symbol] = peak_price
+        return peak_price
 
     def _evaluate_legacy(
         self,
@@ -782,7 +956,12 @@ def _resolve_qty(
         strategy_pcts=[optional_decimal(strategy.max_position_pct_equity)],
         equity=equity,
     )
+    portfolio_gross_cap = _resolve_portfolio_gross_cap(
+        strategies=[strategy],
+        equity=equity,
+    )
     current_value = _position_value_for_symbol(positions, symbol)
+    current_gross = _portfolio_gross_exposure(positions)
     position_qty = _position_qty_for_symbol(positions, symbol)
     normalized_action = action.strip().lower()
     exit_only_sell = _treats_sell_as_exit_only(strategy) and normalized_action == "sell"
@@ -821,14 +1000,37 @@ def _resolve_qty(
     cap_applied = capped_requested_qty is not None and capped_requested_qty < requested_qty
     if capped_requested_qty is not None:
         requested_qty = capped_requested_qty
+    capped_by_portfolio_qty = _cap_requested_qty_by_portfolio_gross_cap(
+        action=normalized_action,
+        requested_qty=requested_qty,
+        price=price,
+        positions=positions,
+        portfolio_gross_cap=portfolio_gross_cap,
+    )
+    portfolio_cap_applied = (
+        capped_by_portfolio_qty is not None and capped_by_portfolio_qty < requested_qty
+    )
+    if capped_by_portfolio_qty is not None:
+        requested_qty = capped_by_portfolio_qty
     if requested_qty <= 0:
+        capacity_reason = (
+            "portfolio_gross_capacity_exhausted"
+            if portfolio_cap_applied or (
+                normalized_action == "buy"
+                and portfolio_gross_cap is not None
+                and portfolio_gross_cap > 0
+                and current_gross >= portfolio_gross_cap
+            )
+            else "symbol_capacity_exhausted"
+        )
         return Decimal("0"), {
             "method": method,
-            "reason": "symbol_capacity_exhausted",
+            "reason": capacity_reason,
             "notional_budget": str(notional_budget),
             "price": str(price),
             "requested_qty": str(notional_budget / price),
             "current_value": str(current_value) if current_value is not None else None,
+            "current_gross": str(current_gross),
             "position_qty": (
                 str(position_qty) if position_qty is not None else None
             ),
@@ -836,6 +1038,9 @@ def _resolve_qty(
                 str(symbol_notional_cap)
                 if symbol_notional_cap is not None
                 else None
+            ),
+            "portfolio_gross_cap": (
+                str(portfolio_gross_cap) if portfolio_gross_cap is not None else None
             ),
         }
     resolution = resolve_quantity_resolution(
@@ -855,10 +1060,15 @@ def _resolve_qty(
         symbol, fractional_equities_enabled=resolution.fractional_allowed
     )
     if qty < min_qty:
-        if cap_applied:
+        if cap_applied or portfolio_cap_applied:
+            capacity_reason = (
+                "portfolio_gross_capacity_exhausted"
+                if portfolio_cap_applied and not cap_applied
+                else "symbol_capacity_exhausted"
+            )
             return Decimal("0"), {
                 "method": method,
-                "reason": "symbol_capacity_exhausted",
+                "reason": capacity_reason,
                 "notional_budget": str(notional_budget),
                 "price": str(price),
                 "requested_qty": str(requested_qty),
@@ -866,6 +1076,7 @@ def _resolve_qty(
                 "current_value": (
                     str(current_value) if current_value is not None else None
                 ),
+                "current_gross": str(current_gross),
                 "position_qty": (
                     str(position_qty) if position_qty is not None else None
                 ),
@@ -873,6 +1084,9 @@ def _resolve_qty(
                     str(symbol_notional_cap)
                     if symbol_notional_cap is not None
                     else None
+                ),
+                "portfolio_gross_cap": (
+                    str(portfolio_gross_cap) if portfolio_gross_cap is not None else None
                 ),
                 "quantity_resolution": resolution.to_payload(),
             }
@@ -900,11 +1114,16 @@ def _resolve_qty(
         "price": str(price),
         "requested_qty": str(requested_qty),
         "current_value": str(current_value) if current_value is not None else None,
+        "current_gross": str(current_gross),
         "position_qty": str(position_qty) if position_qty is not None else None,
         "symbol_notional_cap": (
             str(symbol_notional_cap) if symbol_notional_cap is not None else None
         ),
         "symbol_capacity_limited": cap_applied,
+        "portfolio_gross_cap": (
+            str(portfolio_gross_cap) if portfolio_gross_cap is not None else None
+        ),
+        "portfolio_gross_limited": portfolio_cap_applied,
         "quantity_resolution": resolution.to_payload(),
     }
 
@@ -917,6 +1136,7 @@ def _resolve_qty_for_aggregated(
     price: Optional[Decimal],
     equity: Optional[Decimal],
     positions: Optional[list[dict[str, Any]]],
+    capacity_positions: Optional[list[dict[str, Any]]] = None,
 ) -> tuple[Decimal, dict[str, Any]]:
     default_qty = Decimal(str(settings.trading_default_qty))
     if price is None or price <= 0:
@@ -924,6 +1144,9 @@ def _resolve_qty_for_aggregated(
     if not strategies:
         return default_qty, {"method": "default_qty", "reason": "no_strategies"}
 
+    effective_capacity_positions = (
+        capacity_positions if capacity_positions is not None else positions
+    )
     total_budget = _resolve_aggregated_notional_budget(strategies, equity=equity)
     if total_budget <= 0:
         return default_qty, {"method": "default_qty", "reason": "missing_budget"}
@@ -932,7 +1155,12 @@ def _resolve_qty_for_aggregated(
         strategy_pcts=[optional_decimal(strategy.max_position_pct_equity) for strategy in strategies],
         equity=equity,
     )
-    current_value = _position_value_for_symbol(positions, symbol)
+    portfolio_gross_cap = _resolve_portfolio_gross_cap(
+        strategies=strategies,
+        equity=equity,
+    )
+    current_value = _position_value_for_symbol(effective_capacity_positions, symbol)
+    current_gross = _portfolio_gross_exposure(effective_capacity_positions)
     position_qty = _position_qty_for_symbol(positions, symbol)
     normalized_action = action.strip().lower()
     exit_only_sell = (
@@ -973,14 +1201,37 @@ def _resolve_qty_for_aggregated(
     cap_applied = capped_requested_qty is not None and capped_requested_qty < requested_qty
     if capped_requested_qty is not None:
         requested_qty = capped_requested_qty
+    capped_by_portfolio_qty = _cap_requested_qty_by_portfolio_gross_cap(
+        action=normalized_action,
+        requested_qty=requested_qty,
+        price=price,
+        positions=effective_capacity_positions,
+        portfolio_gross_cap=portfolio_gross_cap,
+    )
+    portfolio_cap_applied = (
+        capped_by_portfolio_qty is not None and capped_by_portfolio_qty < requested_qty
+    )
+    if capped_by_portfolio_qty is not None:
+        requested_qty = capped_by_portfolio_qty
     if requested_qty <= 0:
+        capacity_reason = (
+            "portfolio_gross_capacity_exhausted"
+            if portfolio_cap_applied or (
+                normalized_action == "buy"
+                and portfolio_gross_cap is not None
+                and portfolio_gross_cap > 0
+                and current_gross >= portfolio_gross_cap
+            )
+            else "symbol_capacity_exhausted"
+        )
         return Decimal("0"), {
             "method": "aggregated_notional_budget",
-            "reason": "symbol_capacity_exhausted",
+            "reason": capacity_reason,
             "notional_budget": str(total_budget),
             "price": str(price),
             "requested_qty": str(total_budget / price),
             "current_value": str(current_value) if current_value is not None else None,
+            "current_gross": str(current_gross),
             "position_qty": (
                 str(position_qty) if position_qty is not None else None
             ),
@@ -988,6 +1239,9 @@ def _resolve_qty_for_aggregated(
                 str(symbol_notional_cap)
                 if symbol_notional_cap is not None
                 else None
+            ),
+            "portfolio_gross_cap": (
+                str(portfolio_gross_cap) if portfolio_gross_cap is not None else None
             ),
         }
     resolution = resolve_quantity_resolution(
@@ -1007,10 +1261,15 @@ def _resolve_qty_for_aggregated(
         symbol, fractional_equities_enabled=resolution.fractional_allowed
     )
     if qty < min_qty:
-        if cap_applied:
+        if cap_applied or portfolio_cap_applied:
+            capacity_reason = (
+                "portfolio_gross_capacity_exhausted"
+                if portfolio_cap_applied and not cap_applied
+                else "symbol_capacity_exhausted"
+            )
             return Decimal("0"), {
                 "method": "aggregated_notional_budget",
-                "reason": "symbol_capacity_exhausted",
+                "reason": capacity_reason,
                 "notional_budget": str(total_budget),
                 "price": str(price),
                 "requested_qty": str(requested_qty),
@@ -1018,6 +1277,7 @@ def _resolve_qty_for_aggregated(
                 "current_value": (
                     str(current_value) if current_value is not None else None
                 ),
+                "current_gross": str(current_gross),
                 "position_qty": (
                     str(position_qty) if position_qty is not None else None
                 ),
@@ -1025,6 +1285,9 @@ def _resolve_qty_for_aggregated(
                     str(symbol_notional_cap)
                     if symbol_notional_cap is not None
                     else None
+                ),
+                "portfolio_gross_cap": (
+                    str(portfolio_gross_cap) if portfolio_gross_cap is not None else None
                 ),
                 "quantity_resolution": resolution.to_payload(),
             }
@@ -1051,11 +1314,16 @@ def _resolve_qty_for_aggregated(
         "price": str(price),
         "requested_qty": str(requested_qty),
         "current_value": str(current_value) if current_value is not None else None,
+        "current_gross": str(current_gross),
         "position_qty": str(position_qty) if position_qty is not None else None,
         "symbol_notional_cap": (
             str(symbol_notional_cap) if symbol_notional_cap is not None else None
         ),
         "symbol_capacity_limited": cap_applied,
+        "portfolio_gross_cap": (
+            str(portfolio_gross_cap) if portfolio_gross_cap is not None else None
+        ),
+        "portfolio_gross_limited": portfolio_cap_applied,
         "quantity_resolution": resolution.to_payload(),
     }
 
@@ -1069,6 +1337,7 @@ def _skip_non_executable_decision_qty(
         _SHORT_ENTRY_BELOW_MIN_QTY_REASON,
         _SAME_DIRECTION_REENTRY_REASON,
         "symbol_capacity_exhausted",
+        "portfolio_gross_capacity_exhausted",
     }
 
 
@@ -1085,6 +1354,9 @@ def _build_runtime_position_exit_overlay(
     snapshot: Optional[MarketSnapshot],
     raw_runtime_by_strategy_id: Mapping[str, dict[str, Any]],
     runtime_eval: Any,
+    position_peak_price: Decimal | None,
+    aggregated: bool = True,
+    position_isolation_mode: str | None = None,
 ) -> StrategyDecision | None:
     if price is None or positions is None:
         return None
@@ -1109,18 +1381,132 @@ def _build_runtime_position_exit_overlay(
         return None
 
     avg_entry_price = _position_avg_entry_price_for_symbol(positions, signal.symbol)
-    if avg_entry_price is None or avg_entry_price <= 0 or price >= avg_entry_price:
+    if avg_entry_price is None or avg_entry_price <= 0:
         return None
 
-    stop_loss_bps = _resolve_min_positive_strategy_param(
+    spread_bps = _signal_spread_bps(signal=signal, price=price)
+    volatility_bps = _volatility_to_bps(features.volatility)
+
+    hard_stop_loss_bps = _resolve_min_positive_strategy_param(
         strategies=eligible_strategies,
         key="long_stop_loss_bps",
     )
-    if stop_loss_bps is None or stop_loss_bps <= 0:
+    hard_stop_threshold_bps = _resolve_dynamic_exit_threshold_bps(
+        strategies=eligible_strategies,
+        base_bps=hard_stop_loss_bps,
+        spread_bps=spread_bps,
+        spread_multiplier_key="long_stop_loss_spread_bps_multiplier",
+        volatility_bps=volatility_bps,
+        volatility_multiplier_key="long_stop_loss_volatility_bps_multiplier",
+    )
+    entry_drawdown_bps = Decimal("0")
+    if price < avg_entry_price:
+        entry_drawdown_bps = ((avg_entry_price - price) / avg_entry_price) * Decimal("10000")
+
+    trailing_activation_profit_bps = _resolve_min_positive_strategy_param(
+        strategies=eligible_strategies,
+        key="long_trailing_stop_activation_profit_bps",
+    )
+    trailing_drawdown_bps = _resolve_min_positive_strategy_param(
+        strategies=eligible_strategies,
+        key="long_trailing_stop_drawdown_bps",
+    )
+    trailing_stop_threshold_bps = _resolve_dynamic_exit_threshold_bps(
+        strategies=eligible_strategies,
+        base_bps=trailing_drawdown_bps,
+        spread_bps=spread_bps,
+        spread_multiplier_key="long_trailing_stop_spread_bps_multiplier",
+        volatility_bps=volatility_bps,
+        volatility_multiplier_key="long_trailing_stop_volatility_bps_multiplier",
+    )
+
+    exit_type: str | None = None
+    exit_rationale: str | None = None
+    trigger_threshold_bps: Decimal | None = None
+    trigger_drawdown_bps: Decimal | None = None
+    position_age_seconds = _position_age_seconds_for_symbol(
+        positions,
+        signal.symbol,
+        signal_ts=signal.event_ts,
+    )
+    flatten_start_minute_utc = _resolve_max_nonnegative_strategy_param(
+        strategies=eligible_strategies,
+        key="session_flatten_start_minute_utc",
+    )
+    max_hold_seconds = _resolve_max_nonnegative_strategy_param(
+        strategies=eligible_strategies,
+        key="max_hold_seconds",
+    )
+    minute_of_day_utc = Decimal(
+        str(signal.event_ts.astimezone(timezone.utc).hour * 60 + signal.event_ts.astimezone(timezone.utc).minute)
+    )
+
+    if (
+        position_peak_price is not None
+        and position_peak_price > avg_entry_price
+        and trailing_activation_profit_bps is not None
+        and trailing_stop_threshold_bps is not None
+        and trailing_stop_threshold_bps > 0
+    ):
+        peak_profit_bps = ((position_peak_price - avg_entry_price) / avg_entry_price) * Decimal("10000")
+        if peak_profit_bps >= trailing_activation_profit_bps and price < position_peak_price:
+            peak_drawdown_bps = ((position_peak_price - price) / position_peak_price) * Decimal("10000")
+            if peak_drawdown_bps >= trailing_stop_threshold_bps:
+                exit_type = "long_trailing_stop_bps"
+                exit_rationale = "position_trailing_stop_exit"
+                trigger_threshold_bps = trailing_stop_threshold_bps
+                trigger_drawdown_bps = peak_drawdown_bps
+
+    if (
+        exit_type is None
+        and hard_stop_threshold_bps is not None
+        and hard_stop_threshold_bps > 0
+        and entry_drawdown_bps >= hard_stop_threshold_bps
+    ):
+        exit_type = "long_stop_loss_bps"
+        exit_rationale = "position_stop_loss_exit"
+        trigger_threshold_bps = hard_stop_threshold_bps
+        trigger_drawdown_bps = entry_drawdown_bps
+
+    if (
+        exit_type is None
+        and max_hold_seconds is not None
+        and max_hold_seconds > 0
+        and position_age_seconds is not None
+        and position_age_seconds >= int(max_hold_seconds)
+    ):
+        exit_type = "max_hold_seconds"
+        exit_rationale = "position_time_exit"
+        trigger_threshold_bps = max_hold_seconds
+
+    if (
+        exit_type is None
+        and flatten_start_minute_utc is not None
+        and minute_of_day_utc >= flatten_start_minute_utc
+    ):
+        exit_type = "session_flatten_minute_utc"
+        exit_rationale = "session_flatten_exit"
+        trigger_threshold_bps = flatten_start_minute_utc
+
+    if exit_type is None or exit_rationale is None:
         return None
 
-    drawdown_bps = ((avg_entry_price - price) / avg_entry_price) * Decimal("10000")
-    if drawdown_bps < stop_loss_bps:
+    reference_exit_price = _reference_exit_price(
+        price=price,
+        signal=signal,
+        action="sell",
+    )
+    realized_bps = _realized_exit_bps(
+        avg_entry_price=avg_entry_price,
+        exit_price=reference_exit_price,
+    )
+    if (
+        exit_type not in {"long_stop_loss_bps", "max_hold_seconds", "session_flatten_minute_utc"}
+        and not _passes_exit_profit_policy(
+        strategies=eligible_strategies,
+        realized_bps=realized_bps,
+        )
+    ):
         return None
 
     qty, sizing_meta = _resolve_qty_for_aggregated(
@@ -1140,7 +1526,8 @@ def _build_runtime_position_exit_overlay(
     )
     runtime_metadata = {
         "mode": settings.trading_strategy_runtime_mode,
-        "aggregated": True,
+        "aggregated": aggregated,
+        "position_isolation_mode": position_isolation_mode,
         "primary_strategy_row_id": str(primary_strategy.id),
         "primary_declared_strategy_id": primary_runtime_metadata.get(
             "declared_strategy_id"
@@ -1173,7 +1560,7 @@ def _build_runtime_position_exit_overlay(
             }
             for error in runtime_eval.errors
         ],
-        "exit_overlay": "long_stop_loss_bps",
+        "exit_overlay": exit_type,
     }
     decision = StrategyDecision(
         strategy_id=str(primary_strategy.id),
@@ -1184,7 +1571,7 @@ def _build_runtime_position_exit_overlay(
         qty=qty,
         order_type="market",
         time_in_force="day",
-        rationale="position_stop_loss_exit",
+        rationale=exit_rationale,
         params=_build_params(
             signal=signal,
             macd=features.macd,
@@ -1198,10 +1585,16 @@ def _build_runtime_position_exit_overlay(
         | {
             "sizing": sizing_meta,
             "position_exit": {
-                "type": "long_stop_loss_bps",
-                "threshold_bps": stop_loss_bps,
-                "drawdown_bps": drawdown_bps,
+                "type": exit_type,
+                "threshold_bps": trigger_threshold_bps,
+                "drawdown_bps": trigger_drawdown_bps,
                 "avg_entry_price": avg_entry_price,
+                "peak_price": position_peak_price,
+                "entry_drawdown_bps": entry_drawdown_bps,
+                "reference_exit_price": reference_exit_price,
+                "realized_bps": realized_bps,
+                "spread_bps": spread_bps,
+                "volatility_bps": volatility_bps,
             },
         },
     )
@@ -1210,12 +1603,69 @@ def _build_runtime_position_exit_overlay(
 
 def _blocks_same_direction_reentry(strategy: Strategy) -> bool:
     normalized = str(strategy.universe_type or "").strip().lower()
-    return normalized in {"intraday_tsmom_v1", "intraday_tsmom", "tsmom_intraday"}
+    return normalized in {
+        "intraday_tsmom_v1",
+        "intraday_tsmom",
+        "tsmom_intraday",
+        "momentum_pullback_long_v1",
+        "breakout_continuation_long_v1",
+        "mean_reversion_rebound_long_v1",
+        "late_day_continuation_long_v1",
+    }
+
+
+def _strategy_uses_position_isolation(strategy: Strategy) -> bool:
+    params = StrategyRuntime.definition_from_strategy(strategy).params
+    return str(params.get("position_isolation_mode") or "").strip().lower() == "per_strategy"
+
+
+def _positions_for_strategy_action(
+    positions: Optional[list[dict[str, Any]]],
+    *,
+    strategy_id: str,
+    action: str,
+) -> Optional[list[dict[str, Any]]]:
+    if not positions:
+        return positions
+    tagged_positions = [
+        dict(position)
+        for position in positions
+        if str(position.get("strategy_id") or "").strip() == strategy_id
+    ]
+    if action.strip().lower() == "sell":
+        return _actual_positions_only(tagged_positions)
+    if tagged_positions:
+        return tagged_positions
+    return []
+
+
+def _is_pending_entry_position(position: Mapping[str, Any]) -> bool:
+    return bool(position.get("pending_entry"))
+
+
+def _actual_positions_only(
+    positions: Optional[list[dict[str, Any]]],
+) -> Optional[list[dict[str, Any]]]:
+    if not positions:
+        return positions
+    return [
+        dict(position)
+        for position in positions
+        if not _is_pending_entry_position(position)
+    ]
 
 
 def _treats_sell_as_exit_only(strategy: Strategy) -> bool:
     normalized = str(strategy.universe_type or "").strip().lower()
-    return normalized in {"intraday_tsmom_v1", "intraday_tsmom", "tsmom_intraday"}
+    return normalized in {
+        "intraday_tsmom_v1",
+        "intraday_tsmom",
+        "tsmom_intraday",
+        "momentum_pullback_long_v1",
+        "breakout_continuation_long_v1",
+        "mean_reversion_rebound_long_v1",
+        "late_day_continuation_long_v1",
+    }
 
 
 def _blocks_same_direction_reentry_any(strategies: list[Strategy]) -> bool:
@@ -1264,6 +1714,28 @@ def _cap_requested_qty_by_symbol_cap(
     return min(requested_qty, max_requested_qty)
 
 
+def _cap_requested_qty_by_portfolio_gross_cap(
+    *,
+    action: str,
+    requested_qty: Decimal,
+    price: Decimal,
+    positions: Optional[list[dict[str, Any]]],
+    portfolio_gross_cap: Optional[Decimal],
+) -> Decimal | None:
+    if requested_qty <= 0:
+        return Decimal("0")
+    if action != "buy":
+        return None
+    if portfolio_gross_cap is None or portfolio_gross_cap <= 0 or price <= 0:
+        return None
+    current_gross = _portfolio_gross_exposure(positions)
+    available_notional = portfolio_gross_cap - current_gross
+    if available_notional <= 0:
+        return Decimal("0")
+    cap_qty = available_notional / price
+    return min(requested_qty, cap_qty)
+
+
 def _max_requested_qty_with_symbol_cap(
     *,
     action: str,
@@ -1310,6 +1782,41 @@ def _position_qty_for_symbol(
     if not matched:
         return Decimal("0")
     return current_qty
+
+
+def _position_qty_from_payload(position: Mapping[str, Any]) -> Decimal | None:
+    raw_qty = position.get("qty") or position.get("quantity")
+    if raw_qty is None:
+        return None
+    try:
+        qty = Decimal(str(raw_qty))
+    except (ArithmeticError, ValueError):
+        return None
+    side = str(position.get("side") or "").strip().lower()
+    if side == "short":
+        qty = -abs(qty)
+    return qty
+
+
+def _portfolio_gross_exposure(
+    positions: Optional[list[dict[str, Any]]],
+) -> Decimal:
+    if not positions:
+        return Decimal("0")
+    gross = Decimal("0")
+    for position in positions:
+        raw_value = (
+            position.get("market_value")
+            or position.get("current_value")
+            or position.get("notional")
+        )
+        if raw_value is None:
+            continue
+        try:
+            gross += abs(Decimal(str(raw_value)))
+        except (ArithmeticError, ValueError):
+            continue
+    return gross
 
 
 def _position_value_for_symbol(
@@ -1384,6 +1891,144 @@ def _resolve_min_positive_strategy_param(
     return min(values)
 
 
+def _resolve_max_nonnegative_strategy_param(
+    *,
+    strategies: list[Strategy],
+    key: str,
+) -> Optional[Decimal]:
+    values: list[Decimal] = []
+    for strategy in strategies:
+        params = StrategyRuntime.definition_from_strategy(strategy).params
+        raw_value = params.get(key)
+        if raw_value is None:
+            continue
+        try:
+            resolved = Decimal(str(raw_value))
+        except (ArithmeticError, ValueError):
+            continue
+        if resolved >= 0:
+            values.append(resolved)
+    if not values:
+        return None
+    return max(values)
+
+
+def _resolve_dynamic_exit_threshold_bps(
+    *,
+    strategies: list[Strategy],
+    base_bps: Decimal | None,
+    spread_bps: Decimal | None,
+    spread_multiplier_key: str,
+    volatility_bps: Decimal | None,
+    volatility_multiplier_key: str,
+) -> Decimal | None:
+    if base_bps is None or base_bps <= 0:
+        return None
+    threshold_bps = base_bps
+    spread_multiplier = _resolve_max_nonnegative_strategy_param(
+        strategies=strategies,
+        key=spread_multiplier_key,
+    )
+    if (
+        spread_bps is not None
+        and spread_bps > 0
+        and spread_multiplier is not None
+        and spread_multiplier > 0
+    ):
+        threshold_bps += spread_bps * spread_multiplier
+    volatility_multiplier = _resolve_max_nonnegative_strategy_param(
+        strategies=strategies,
+        key=volatility_multiplier_key,
+    )
+    if (
+        volatility_bps is not None
+        and volatility_bps > 0
+        and volatility_multiplier is not None
+        and volatility_multiplier > 0
+    ):
+        threshold_bps += volatility_bps * volatility_multiplier
+    return threshold_bps
+
+
+def _volatility_to_bps(volatility: Decimal | None) -> Decimal | None:
+    if volatility is None or volatility <= 0:
+        return None
+    return volatility * Decimal("10000")
+
+
+def _signal_spread_bps(
+    *,
+    signal: SignalEnvelope,
+    price: Decimal,
+) -> Decimal | None:
+    spread = _signal_spread(signal)
+    if spread is None or spread <= 0 or price <= 0:
+        return None
+    return (spread / price) * Decimal("10000")
+
+
+def _reference_exit_price(
+    *,
+    price: Decimal,
+    signal: SignalEnvelope,
+    action: str,
+) -> Decimal:
+    if settings.trading_execution_prefer_limit:
+        return _near_touch_exit_price(
+            price,
+            _signal_spread(signal),
+            action,
+        )
+    return price
+
+
+def _realized_exit_bps(
+    *,
+    avg_entry_price: Decimal,
+    exit_price: Decimal,
+) -> Decimal:
+    return ((exit_price - avg_entry_price) / avg_entry_price) * Decimal("10000")
+
+
+def _passes_exit_profit_policy(
+    *,
+    strategies: list[Strategy],
+    realized_bps: Decimal,
+) -> bool:
+    if _resolve_bool_strategy_param(
+        strategies=strategies,
+        key="require_positive_price_for_signal_exit",
+        default=True,
+    ) and realized_bps <= 0:
+        return False
+
+    min_profit_bps = _resolve_max_nonnegative_strategy_param(
+        strategies=strategies,
+        key="min_signal_exit_profit_bps",
+    )
+    if min_profit_bps is not None and realized_bps < min_profit_bps:
+        return False
+    return True
+
+
+def _resolve_bool_strategy_param(
+    *,
+    strategies: list[Strategy],
+    key: str,
+    default: bool,
+) -> bool:
+    resolved_any = False
+    resolved = False
+    for strategy in strategies:
+        params = StrategyRuntime.definition_from_strategy(strategy).params
+        value = _bool_param(params.get(key))
+        if value is None:
+            continue
+        resolved_any = True
+        resolved = resolved or value
+    return resolved if resolved_any else default
+
+
 def _resolve_symbol_notional_cap(
     *,
     strategy_pcts: list[Optional[Decimal]],
@@ -1398,6 +2043,36 @@ def _resolve_symbol_notional_cap(
     for pct in strategy_pcts:
         if pct is not None and pct > 0:
             caps.append(equity * pct)
+    if not caps:
+        return None
+    return min(caps)
+
+
+def _resolve_portfolio_gross_cap(
+    *,
+    strategies: list[Strategy],
+    equity: Optional[Decimal],
+) -> Optional[Decimal]:
+    caps: list[Decimal] = []
+    absolute_cap = optional_decimal(settings.trading_portfolio_max_gross_exposure)
+    if absolute_cap is not None and absolute_cap > 0:
+        caps.append(absolute_cap)
+    if equity is not None and equity > 0:
+        global_pct = optional_decimal(settings.trading_portfolio_max_gross_exposure_pct_equity)
+        if global_pct is not None and global_pct > 0:
+            caps.append(equity * global_pct)
+        strategy_pct = _resolve_min_positive_strategy_param(
+            strategies=strategies,
+            key="max_gross_exposure_pct_equity",
+        )
+        if strategy_pct is not None and strategy_pct > 0:
+            caps.append(equity * strategy_pct)
+    strategy_absolute = _resolve_min_positive_strategy_param(
+        strategies=strategies,
+        key="max_gross_exposure",
+    )
+    if strategy_absolute is not None and strategy_absolute > 0:
+        caps.append(strategy_absolute)
     if not caps:
         return None
     return min(caps)
@@ -1446,6 +2121,261 @@ def _resolve_aggregated_notional_budget(
     if pct is not None and pct > 0:
         return equity * pct
     return Decimal("0")
+
+
+def _resolve_runtime_trade_policy(strategies: list[Strategy]) -> dict[str, int]:
+    entry_cooldown = 0
+    exit_cooldown = 0
+    min_hold = 0
+    max_hold_candidates: list[int] = []
+    max_concurrent_candidates: list[int] = []
+    for strategy in strategies:
+        params = StrategyRuntime.definition_from_strategy(strategy).params
+        entry_cooldown = max(
+            entry_cooldown,
+            _int_param(params.get("entry_cooldown_seconds")),
+        )
+        exit_cooldown = max(
+            exit_cooldown,
+            _int_param(params.get("exit_cooldown_seconds")),
+        )
+        min_hold = max(
+            min_hold,
+            _int_param(params.get("min_hold_seconds")),
+        )
+        max_hold_seconds = _int_param(params.get("max_hold_seconds"))
+        if max_hold_seconds > 0:
+            max_hold_candidates.append(max_hold_seconds)
+        max_concurrent_positions = _int_param(params.get("max_concurrent_positions"))
+        if max_concurrent_positions > 0:
+            max_concurrent_candidates.append(max_concurrent_positions)
+    return {
+        "entry_cooldown_seconds": entry_cooldown,
+        "exit_cooldown_seconds": exit_cooldown,
+        "min_hold_seconds": min_hold,
+        "max_hold_seconds": min(max_hold_candidates) if max_hold_candidates else 0,
+        "max_concurrent_positions": (
+            min(max_concurrent_candidates) if max_concurrent_candidates else 0
+        ),
+    }
+
+
+def _passes_runtime_trade_policy(
+    *,
+    last_emitted_action_at: dict[tuple[str, str], datetime],
+    signal_ts: datetime,
+    symbol: str,
+    action: str,
+    positions: Optional[list[dict[str, Any]]],
+    policy: Mapping[str, int],
+) -> bool:
+    normalized_action = action.strip().lower()
+    if normalized_action == "buy":
+        max_concurrent_positions = max(0, int(policy.get("max_concurrent_positions", 0)))
+        if (
+            max_concurrent_positions > 0
+            and _count_open_long_positions(positions) >= max_concurrent_positions
+        ):
+            return False
+
+    cooldown_key = (
+        "entry_cooldown_seconds"
+        if normalized_action == "buy"
+        else "exit_cooldown_seconds"
+    )
+    cooldown_seconds = max(0, int(policy.get(cooldown_key, 0)))
+    last_emitted = last_emitted_action_at.get((symbol, normalized_action))
+    if (
+        cooldown_seconds > 0
+        and last_emitted is not None
+        and (signal_ts.astimezone(timezone.utc) - last_emitted.astimezone(timezone.utc)).total_seconds()
+        < cooldown_seconds
+    ):
+        return False
+
+    if normalized_action != "sell":
+        return True
+
+    min_hold_seconds = max(0, int(policy.get("min_hold_seconds", 0)))
+    if min_hold_seconds <= 0:
+        return True
+    position_opened_at = _position_opened_at_for_symbol(positions, symbol)
+    if position_opened_at is None:
+        return True
+    age_seconds = (
+        signal_ts.astimezone(timezone.utc)
+        - position_opened_at.astimezone(timezone.utc)
+    ).total_seconds()
+    return age_seconds >= min_hold_seconds
+
+
+def _passes_signal_exit_policy(
+    *,
+    strategies: list[Strategy],
+    symbol: str,
+    action: str,
+    price: Optional[Decimal],
+    signal: SignalEnvelope,
+    positions: Optional[list[dict[str, Any]]],
+) -> bool:
+    normalized_action = action.strip().lower()
+    if (
+        normalized_action != "sell"
+        or price is None
+        or price <= 0
+        or not _treats_sell_as_exit_only_any(strategies)
+    ):
+        return True
+
+    position_qty = _position_qty_for_symbol(positions, symbol)
+    if position_qty is None or position_qty <= 0:
+        return True
+
+    avg_entry_price = _position_avg_entry_price_for_symbol(positions, symbol)
+    if avg_entry_price is None or avg_entry_price <= 0:
+        return True
+
+    reference_exit_price = _reference_exit_price(
+        price=price,
+        signal=signal,
+        action=normalized_action,
+    )
+    realized_bps = _realized_exit_bps(
+        avg_entry_price=avg_entry_price,
+        exit_price=reference_exit_price,
+    )
+    return _passes_exit_profit_policy(
+        strategies=strategies,
+        realized_bps=realized_bps,
+    )
+
+
+def _signal_spread(signal: SignalEnvelope) -> Decimal | None:
+    payload = signal.payload or {}
+    spread = optional_decimal(payload.get("spread"))
+    if spread is not None and spread > 0:
+        return spread
+
+    bid = optional_decimal(payload.get("imbalance_bid_px"))
+    ask = optional_decimal(payload.get("imbalance_ask_px"))
+    imbalance_payload = payload.get("imbalance")
+    if isinstance(imbalance_payload, Mapping):
+        imbalance_mapping = cast(Mapping[str, Any], imbalance_payload)
+        if bid is None:
+            bid = optional_decimal(imbalance_mapping.get("bid_px"))
+        if ask is None:
+            ask = optional_decimal(imbalance_mapping.get("ask_px"))
+        if spread is None:
+            spread = optional_decimal(imbalance_mapping.get("spread"))
+    if spread is not None and spread > 0:
+        return spread
+    if bid is None or ask is None or ask <= bid:
+        return None
+    return ask - bid
+
+
+def _near_touch_exit_price(
+    price: Decimal,
+    spread: Decimal | None,
+    action: str,
+) -> Decimal:
+    if spread is None or spread <= 0:
+        return _normalize_exit_price(price)
+    half_spread = spread / Decimal("2")
+    if action == "buy":
+        return _normalize_exit_price(price + half_spread)
+    return _normalize_exit_price(price - half_spread)
+
+
+def _normalize_exit_price(price: Decimal) -> Decimal:
+    tick_size = Decimal("0.0001") if price.copy_abs() < Decimal("1") else Decimal("0.01")
+    return price.quantize(tick_size, rounding=ROUND_HALF_UP)
+
+
+def _position_opened_at_for_symbol(
+    positions: Optional[list[dict[str, Any]]],
+    symbol: str,
+) -> datetime | None:
+    if not positions:
+        return None
+    for position in positions:
+        if str(position.get("symbol") or "").strip().upper() != symbol.strip().upper():
+            continue
+        raw = position.get("opened_at")
+        if raw is None:
+            return None
+        try:
+            parsed = datetime.fromisoformat(str(raw).replace("Z", "+00:00"))
+        except ValueError:
+            return None
+        if parsed.tzinfo is None:
+            return parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc)
+    return None
+
+
+def _position_age_seconds_for_symbol(
+    positions: Optional[list[dict[str, Any]]],
+    symbol: str,
+    *,
+    signal_ts: datetime,
+) -> int | None:
+    opened_at = _position_opened_at_for_symbol(positions, symbol)
+    if opened_at is None:
+        return None
+    age_seconds = (
+        signal_ts.astimezone(timezone.utc) - opened_at.astimezone(timezone.utc)
+    ).total_seconds()
+    return max(0, int(age_seconds))
+
+
+def _count_open_long_positions(positions: Optional[list[dict[str, Any]]]) -> int:
+    if not positions:
+        return 0
+    open_symbols: set[str] = set()
+    for position in positions:
+        symbol = str(position.get("symbol") or "").strip().upper()
+        if not symbol:
+            continue
+        qty = _position_qty_from_payload(position)
+        if qty is not None:
+            if qty > 0:
+                open_symbols.add(symbol)
+            continue
+        raw_value = (
+            position.get("market_value")
+            or position.get("current_value")
+            or position.get("notional")
+        )
+        if raw_value is None:
+            continue
+        try:
+            market_value = Decimal(str(raw_value))
+        except (ArithmeticError, ValueError):
+            continue
+        if market_value > 0:
+            open_symbols.add(symbol)
+    return len(open_symbols)
+
+
+def _int_param(value: Any) -> int:
+    if value is None:
+        return 0
+    try:
+        return int(str(value))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _bool_param(value: Any) -> bool | None:
+    if value is None:
+        return None
+    normalized = str(value).strip().lower()
+    if normalized in {"1", "true", "t", "yes", "y", "on"}:
+        return True
+    if normalized in {"0", "false", "f", "no", "n", "off"}:
+        return False
+    return None
 
 
 def _resolve_signal_timeframe(signal: SignalEnvelope) -> Optional[str]:

--- a/services/torghut/app/trading/execution_adapters.py
+++ b/services/torghut/app/trading/execution_adapters.py
@@ -707,6 +707,42 @@ class LeanExecutionAdapter:
         items = cast(list[Any], positions)
         return [cast(dict[str, Any], item) for item in items if isinstance(item, Mapping)]
 
+    def get_account(self) -> dict[str, Any] | None:
+        if self.fallback is None:
+            return None
+        getter = getattr(self.fallback, 'get_account', None)
+        if not callable(getter):
+            return None
+        try:
+            payload = getter()
+        except Exception as exc:
+            logger.warning("Lean adapter fallback get_account failed: %s", exc)
+            return None
+        if not isinstance(payload, Mapping):
+            return None
+        account = cast(Mapping[str, Any], payload)
+        return {str(key): value for key, value in account.items()}
+
+    def get_asset(self, symbol_or_asset_id: str) -> dict[str, Any] | None:
+        if self.fallback is None:
+            return None
+        getter = getattr(self.fallback, 'get_asset', None)
+        if not callable(getter):
+            return None
+        try:
+            payload = getter(symbol_or_asset_id)
+        except Exception as exc:
+            logger.warning(
+                "Lean adapter fallback get_asset failed symbol=%s: %s",
+                symbol_or_asset_id,
+                exc,
+            )
+            return None
+        if not isinstance(payload, Mapping):
+            return None
+        asset = cast(Mapping[str, Any], payload)
+        return {str(key): value for key, value in asset.items()}
+
     def _request_json_with_headers(
         self,
         method: str,

--- a/services/torghut/app/trading/features.py
+++ b/services/torghut/app/trading/features.py
@@ -17,6 +17,7 @@ FEATURE_SCHEMA_VERSION_V3 = '3.0.0'
 FEATURE_VECTOR_V3_REQUIRED_FIELDS = ('price', 'macd', 'macd_signal', 'rsi14')
 FEATURE_VECTOR_V3_VALUE_FIELDS = (
     'price',
+    'mid_price',
     'ema12',
     'ema26',
     'macd',
@@ -30,7 +31,12 @@ FEATURE_VECTOR_V3_VALUE_FIELDS = (
     'boll_lower',
     'vol_realized_w60s',
     'imbalance_spread',
+    'imbalance_bid_px',
+    'imbalance_ask_px',
+    'imbalance_bid_sz',
+    'imbalance_ask_sz',
     'spread',
+    'spread_bps',
     'signal_quality_flag',
     'hmm_state_posterior',
     'hmm_entropy',
@@ -265,6 +271,7 @@ def map_feature_values_v3(signal: SignalEnvelope) -> dict[str, Any]:
 
     return {
         'price': extract_price(payload),
+        'mid_price': _extract_mid_price(payload),
         'ema12': optional_decimal(payload.get('ema12') or _nested(payload, 'ema', 'ema12')),
         'ema26': optional_decimal(payload.get('ema26') or _nested(payload, 'ema', 'ema26')),
         'macd': macd,
@@ -278,7 +285,12 @@ def map_feature_values_v3(signal: SignalEnvelope) -> dict[str, Any]:
         'boll_lower': optional_decimal(payload.get('boll_lower') or _nested(payload, 'boll', 'lower')),
         'vol_realized_w60s': extract_volatility(payload),
         'imbalance_spread': optional_decimal(payload.get('imbalance_spread') or _nested(payload, 'imbalance', 'spread')),
+        'imbalance_bid_px': optional_decimal(payload.get('imbalance_bid_px') or _nested(payload, 'imbalance', 'bid_px')),
+        'imbalance_ask_px': optional_decimal(payload.get('imbalance_ask_px') or _nested(payload, 'imbalance', 'ask_px')),
+        'imbalance_bid_sz': optional_decimal(payload.get('imbalance_bid_sz') or _nested(payload, 'imbalance', 'bid_sz')),
+        'imbalance_ask_sz': optional_decimal(payload.get('imbalance_ask_sz') or _nested(payload, 'imbalance', 'ask_sz')),
         'spread': optional_decimal(payload.get('spread')),
+        'spread_bps': _spread_bps(payload),
         'signal_quality_flag': payload.get('signal_quality_flag'),
         'hmm_state_posterior': regime_context.posterior,
         'hmm_entropy': regime_context.entropy,
@@ -362,6 +374,22 @@ def _route_regime_label(
     macd_signal: Decimal | None,
 ) -> str:
     return resolve_regime_route_label(payload, macd=macd, macd_signal=macd_signal)
+
+
+def _extract_mid_price(payload: dict[str, Any]) -> Decimal | None:
+    bid = optional_decimal(payload.get('imbalance_bid_px') or _nested(payload, 'imbalance', 'bid_px'))
+    ask = optional_decimal(payload.get('imbalance_ask_px') or _nested(payload, 'imbalance', 'ask_px'))
+    if bid is None or ask is None:
+        return None
+    return (bid + ask) / 2
+
+
+def _spread_bps(payload: dict[str, Any]) -> Decimal | None:
+    spread = optional_decimal(payload.get('spread') or payload.get('imbalance_spread') or _nested(payload, 'imbalance', 'spread'))
+    price = extract_price(payload)
+    if spread is None or price is None or price <= 0:
+        return None
+    return (spread / price) * Decimal('10000')
 
 
 def _validate_signal_schema_version(signal: SignalEnvelope) -> None:

--- a/services/torghut/app/trading/ingest.py
+++ b/services/torghut/app/trading/ingest.py
@@ -1293,24 +1293,23 @@ def _copy_row_value_if_missing(payload: dict[str, Any], row: dict[str, Any], key
 def _ensure_price_value(payload: dict[str, Any], row: dict[str, Any]) -> None:
     if "price" in payload:
         return
+    bid_px = row.get("imbalance_bid_px")
+    ask_px = row.get("imbalance_ask_px")
+    if bid_px is not None and ask_px is not None:
+        try:
+            payload["price"] = (float(bid_px) + float(ask_px)) / 2
+            return
+        except (TypeError, ValueError):
+            logger.debug(
+                'Unable to derive midpoint price from imbalance fields bid=%r ask=%r',
+                bid_px,
+                ask_px,
+            )
     for key in ("vwap_session", "vwap_w5m", "vwap"):
         candidate = row.get(key)
         if candidate is not None:
             payload["price"] = candidate
             return
-
-    bid_px = row.get("imbalance_bid_px")
-    ask_px = row.get("imbalance_ask_px")
-    if bid_px is None or ask_px is None:
-        return
-    try:
-        payload["price"] = (float(bid_px) + float(ask_px)) / 2
-    except (TypeError, ValueError):
-        logger.debug(
-            'Unable to derive midpoint price from imbalance fields bid=%r ask=%r',
-            bid_px,
-            ask_px,
-        )
 
 
 def _merge_imbalance_payload(payload: dict[str, Any], row: dict[str, Any]) -> None:

--- a/services/torghut/app/trading/intraday_tsmom_contract.py
+++ b/services/torghut/app/trading/intraday_tsmom_contract.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from decimal import Decimal
 from typing import Any, Literal, Mapping
 
@@ -78,15 +79,31 @@ def validate_intraday_tsmom_params(params: Mapping[str, Any]) -> None:
         "vol_floor",
         "vol_ceil",
         "low_vol_bonus_threshold",
+        "max_spread_bps",
+        "entry_start_minute_utc",
+        "entry_end_minute_utc",
         "max_price_above_ema12_bps",
         "min_price_below_ema12_bps",
         "max_price_below_ema12_bps",
         "long_stop_loss_bps",
+        "long_stop_loss_spread_bps_multiplier",
+        "long_stop_loss_volatility_bps_multiplier",
+        "long_trailing_stop_activation_profit_bps",
+        "long_trailing_stop_drawdown_bps",
+        "long_trailing_stop_spread_bps_multiplier",
+        "long_trailing_stop_volatility_bps_multiplier",
     ):
         _validate_optional_decimal_param(
             params=params,
             key=key,
             invalid_error=f"invalid_{key}",
+        )
+    for key in ("entry_start_minute_utc", "entry_end_minute_utc"):
+        _validate_optional_minute_param(
+            params=params,
+            key=key,
+            invalid_error=f"invalid_{key}",
+            out_of_range_error=f"{key}_out_of_range",
         )
     for key in ("min_bull_rsi", "max_bull_rsi", "min_bear_rsi", "max_bear_rsi"):
         _validate_optional_rsi_param(
@@ -182,7 +199,9 @@ def evaluate_intraday_tsmom_signal(
     *,
     timeframe: str | None,
     params: Mapping[str, Any],
+    event_ts: str | datetime | None,
     price: Decimal | None,
+    spread: Decimal | None,
     ema12: Decimal | None,
     ema26: Decimal | None,
     macd: Decimal | None,
@@ -199,18 +218,31 @@ def evaluate_intraday_tsmom_signal(
         or price is None
     ):
         return None
+    if not _within_entry_window(event_ts=event_ts, params=params):
+        return None
 
     thresholds = resolve_intraday_tsmom_thresholds(
         params=params,
         timeframe=timeframe,
     )
     macd_hist = macd - macd_signal
+    spread_bps = _spread_bps(price=price, spread=spread)
     trend_up = ema12 > ema26 and macd > macd_signal
     trend_down = ema12 < ema26 and macd < macd_signal
     vol_ok = _volatility_within_budget(
         vol_realized_w60s,
         floor=thresholds.vol_floor,
         ceil=thresholds.vol_ceil,
+    )
+    max_spread_bps = _optional_decimal_param(
+        params=params,
+        key='max_spread_bps',
+        default=None,
+    )
+    spread_ok = (
+        max_spread_bps is None
+        or spread_bps is None
+        or spread_bps <= max_spread_bps
     )
     price_not_overextended = _price_within_entry_band(
         price=price,
@@ -223,6 +255,7 @@ def evaluate_intraday_tsmom_signal(
     if (
         trend_up
         and vol_ok
+        and spread_ok
         and price_not_overextended
         and macd_hist >= thresholds.bullish_hist_min
         and (
@@ -257,6 +290,7 @@ def evaluate_intraday_tsmom_signal(
     bearish_hist = -macd_hist
     if (
         trend_down
+        and spread_ok
         and bearish_hist >= thresholds.bearish_hist_min
         and _rsi_within_bearish_bounds(
             rsi14,
@@ -357,6 +391,76 @@ def _decimal(value: Any) -> Decimal | None:
         return None
 
 
+def _minute_param(
+    *,
+    params: Mapping[str, Any],
+    key: str,
+) -> int | None:
+    raw_value = params.get(key)
+    if raw_value is None:
+        return None
+    try:
+        resolved = int(str(raw_value))
+    except (TypeError, ValueError):
+        return None
+    if resolved < 0 or resolved >= 24 * 60:
+        return None
+    return resolved
+
+
+def _validate_optional_minute_param(
+    *,
+    params: Mapping[str, Any],
+    key: str,
+    invalid_error: str,
+    out_of_range_error: str,
+) -> None:
+    if key not in params:
+        return
+    raw_value = params.get(key)
+    try:
+        resolved = int(str(raw_value))
+    except (TypeError, ValueError):
+        raise ValueError(invalid_error) from None
+    if resolved < 0 or resolved >= 24 * 60:
+        raise ValueError(out_of_range_error)
+
+
+def _within_entry_window(
+    *,
+    event_ts: str | datetime | None,
+    params: Mapping[str, Any],
+) -> bool:
+    if not event_ts:
+        return True
+    entry_start_minute = _minute_param(
+        params=params,
+        key="entry_start_minute_utc",
+    )
+    entry_end_minute = _minute_param(
+        params=params,
+        key="entry_end_minute_utc",
+    )
+    if entry_start_minute is None and entry_end_minute is None:
+        return True
+    if isinstance(event_ts, datetime):
+        event_dt = event_ts
+    else:
+        try:
+            event_dt = datetime.fromisoformat(event_ts.replace("Z", "+00:00"))
+        except ValueError:
+            return False
+    if event_dt.tzinfo is None:
+        event_dt = event_dt.replace(tzinfo=timezone.utc)
+    event_dt = event_dt.astimezone(timezone.utc)
+    minute_of_day = event_dt.hour * 60 + event_dt.minute
+    if entry_start_minute is not None and minute_of_day < entry_start_minute:
+        return False
+    if entry_end_minute is not None and minute_of_day > entry_end_minute:
+        return False
+    return True
+
+
 def _validate_optional_decimal_param(
     *,
     params: Mapping[str, Any],
@@ -398,6 +502,16 @@ def _volatility_within_budget(
     if ceil is not None and volatility > ceil:
         return False
     return True
+
+
+def _spread_bps(
+    *,
+    price: Decimal,
+    spread: Decimal | None,
+) -> Decimal | None:
+    if spread is None or spread <= 0 or price <= 0:
+        return None
+    return (spread / price) * Decimal('10000')
 
 
 def _rsi_within_bearish_bounds(

--- a/services/torghut/app/trading/intraday_tsmom_contract.py
+++ b/services/torghut/app/trading/intraday_tsmom_contract.py
@@ -10,6 +10,7 @@ from typing import Any, Literal, Mapping
 @dataclass(frozen=True)
 class IntradayTsmomThresholdProfile:
     bullish_hist_min: Decimal
+    bullish_hist_cap: Decimal | None
     bearish_hist_min: Decimal
     min_bull_rsi: Decimal
     max_bull_rsi: Decimal
@@ -19,6 +20,9 @@ class IntradayTsmomThresholdProfile:
     vol_ceil: Decimal | None
     bearish_hist_cap: Decimal | None
     low_vol_bonus_threshold: Decimal | None
+    max_price_above_ema12_bps: Decimal | None
+    min_price_below_ema12_bps: Decimal | None
+    max_price_below_ema12_bps: Decimal | None
 
 
 @dataclass(frozen=True)
@@ -32,6 +36,7 @@ class IntradayTsmomEvaluation:
 
 _ONE_SECOND_PROFILE = IntradayTsmomThresholdProfile(
     bullish_hist_min=Decimal("0.005"),
+    bullish_hist_cap=None,
     bearish_hist_min=Decimal("0.004"),
     min_bull_rsi=Decimal("52"),
     max_bull_rsi=Decimal("62"),
@@ -41,10 +46,14 @@ _ONE_SECOND_PROFILE = IntradayTsmomThresholdProfile(
     vol_ceil=Decimal("0.00030"),
     bearish_hist_cap=Decimal("0.03"),
     low_vol_bonus_threshold=Decimal("0.00020"),
+    max_price_above_ema12_bps=None,
+    min_price_below_ema12_bps=None,
+    max_price_below_ema12_bps=None,
 )
 
 _DEFAULT_PROFILE = IntradayTsmomThresholdProfile(
     bullish_hist_min=Decimal("0.04"),
+    bullish_hist_cap=None,
     bearish_hist_min=Decimal("0.06"),
     min_bull_rsi=Decimal("52"),
     max_bull_rsi=Decimal("62"),
@@ -54,17 +63,25 @@ _DEFAULT_PROFILE = IntradayTsmomThresholdProfile(
     vol_ceil=Decimal("0.012"),
     bearish_hist_cap=None,
     low_vol_bonus_threshold=Decimal("0.008"),
+    max_price_above_ema12_bps=None,
+    min_price_below_ema12_bps=None,
+    max_price_below_ema12_bps=None,
 )
 
 
 def validate_intraday_tsmom_params(params: Mapping[str, Any]) -> None:
     for key in (
         "bullish_hist_min",
+        "bullish_hist_cap",
         "bearish_hist_min",
         "bearish_hist_cap",
         "vol_floor",
         "vol_ceil",
         "low_vol_bonus_threshold",
+        "max_price_above_ema12_bps",
+        "min_price_below_ema12_bps",
+        "max_price_below_ema12_bps",
+        "long_stop_loss_bps",
     ):
         _validate_optional_decimal_param(
             params=params,
@@ -92,6 +109,11 @@ def resolve_intraday_tsmom_thresholds(
             params=params,
             key="bullish_hist_min",
             default=profile.bullish_hist_min,
+        ),
+        bullish_hist_cap=_optional_decimal_param(
+            params=params,
+            key="bullish_hist_cap",
+            default=profile.bullish_hist_cap,
         ),
         bearish_hist_min=_decimal_param(
             params=params,
@@ -138,6 +160,21 @@ def resolve_intraday_tsmom_thresholds(
             key="low_vol_bonus_threshold",
             default=profile.low_vol_bonus_threshold,
         ),
+        max_price_above_ema12_bps=_optional_decimal_param(
+            params=params,
+            key="max_price_above_ema12_bps",
+            default=profile.max_price_above_ema12_bps,
+        ),
+        min_price_below_ema12_bps=_optional_decimal_param(
+            params=params,
+            key="min_price_below_ema12_bps",
+            default=profile.min_price_below_ema12_bps,
+        ),
+        max_price_below_ema12_bps=_optional_decimal_param(
+            params=params,
+            key="max_price_below_ema12_bps",
+            default=profile.max_price_below_ema12_bps,
+        ),
     )
 
 
@@ -145,6 +182,7 @@ def evaluate_intraday_tsmom_signal(
     *,
     timeframe: str | None,
     params: Mapping[str, Any],
+    price: Decimal | None,
     ema12: Decimal | None,
     ema26: Decimal | None,
     macd: Decimal | None,
@@ -158,6 +196,7 @@ def evaluate_intraday_tsmom_signal(
         or macd is None
         or macd_signal is None
         or rsi14 is None
+        or price is None
     ):
         return None
 
@@ -173,11 +212,23 @@ def evaluate_intraday_tsmom_signal(
         floor=thresholds.vol_floor,
         ceil=thresholds.vol_ceil,
     )
+    price_not_overextended = _price_within_entry_band(
+        price=price,
+        ema12=ema12,
+        max_price_above_ema12_bps=thresholds.max_price_above_ema12_bps,
+        min_price_below_ema12_bps=thresholds.min_price_below_ema12_bps,
+        max_price_below_ema12_bps=thresholds.max_price_below_ema12_bps,
+    )
 
     if (
         trend_up
         and vol_ok
+        and price_not_overextended
         and macd_hist >= thresholds.bullish_hist_min
+        and (
+            thresholds.bullish_hist_cap is None
+            or macd_hist <= thresholds.bullish_hist_cap
+        )
         and thresholds.min_bull_rsi <= rsi14 <= thresholds.max_bull_rsi
     ):
         confidence = Decimal("0.64")
@@ -229,6 +280,30 @@ def evaluate_intraday_tsmom_signal(
         )
 
     return None
+
+
+def _price_within_entry_band(
+    *,
+    price: Decimal,
+    ema12: Decimal,
+    max_price_above_ema12_bps: Decimal | None,
+    min_price_below_ema12_bps: Decimal | None,
+    max_price_below_ema12_bps: Decimal | None,
+) -> bool:
+    if ema12 <= 0:
+        return True
+    if price > ema12:
+        if max_price_above_ema12_bps is None:
+            return True
+        price_gap_bps = ((price - ema12) / ema12) * Decimal("10000")
+        return price_gap_bps <= max_price_above_ema12_bps
+
+    price_gap_bps = ((ema12 - price) / ema12) * Decimal("10000")
+    if min_price_below_ema12_bps is not None and price_gap_bps < min_price_below_ema12_bps:
+        return False
+    if max_price_below_ema12_bps is not None and price_gap_bps > max_price_below_ema12_bps:
+        return False
+    return True
 
 
 def _profile_for_timeframe(timeframe: str | None) -> IntradayTsmomThresholdProfile:

--- a/services/torghut/app/trading/models.py
+++ b/services/torghut/app/trading/models.py
@@ -71,7 +71,12 @@ class ExecutionRequest(BaseModel):
 def decision_hash(
     decision: StrategyDecision, *, account_label: str | None = None
 ) -> str:
-    """Create an idempotency hash for a strategy decision."""
+    """Create an idempotency hash for the executable order intent.
+
+    The hash intentionally excludes auxiliary telemetry in ``decision.params`` so
+    repeated evaluations of the same order do not produce a different
+    client_order_id just because forecast or runtime audit metadata changed.
+    """
 
     params_payload = {
         "strategy_id": decision.strategy_id,
@@ -84,7 +89,6 @@ def decision_hash(
         "time_in_force": decision.time_in_force,
         "limit_price": str(decision.limit_price) if decision.limit_price is not None else None,
         "stop_price": str(decision.stop_price) if decision.stop_price is not None else None,
-        "params": decision.params,
         "account_label": account_label,
     }
     raw = json.dumps(params_payload, sort_keys=True, separators=(",", ":"), default=str)

--- a/services/torghut/app/trading/profitability_archive.py
+++ b/services/torghut/app/trading/profitability_archive.py
@@ -1,0 +1,1532 @@
+"""Archive bundle and proof helpers for historical profitability validation."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import random
+import shutil
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta, timezone
+from decimal import Decimal
+from pathlib import Path
+from statistics import NormalDist
+from typing import Any, Mapping, Sequence, cast
+
+import psycopg
+import yaml
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from ..models import VNextDatasetSnapshot
+from .evidence_contracts import ArtifactProvenance
+
+MARKET_DAY_INVENTORY_SCHEMA_VERSION = 'torghut.market-day-inventory.v1'
+EXECUTION_DAY_INVENTORY_SCHEMA_VERSION = 'torghut.execution-day-inventory.v1'
+REPLAY_DAY_MANIFEST_SCHEMA_VERSION = 'torghut.replay-day-manifest.v1'
+DATA_SUFFICIENCY_SCHEMA_VERSION = 'torghut.data-sufficiency.v1'
+TRIAL_LEDGER_SCHEMA_VERSION = 'torghut.trial-ledger.v1'
+STATISTICAL_VALIDITY_SCHEMA_VERSION = 'torghut.statistical-validity.v1'
+PROFITABILITY_CERTIFICATE_SCHEMA_VERSION = 'torghut.profitability-certificate.v1'
+
+SUFFICIENCY_STATUS_INSUFFICIENT_HISTORY = 'insufficient_history'
+SUFFICIENCY_STATUS_RESEARCH_ONLY = 'research_only'
+SUFFICIENCY_STATUS_HISTORICAL_READY = 'historical_ready'
+SUFFICIENCY_STATUS_PAPER_READY = 'paper_ready'
+
+CERTIFICATE_STATUS_INSUFFICIENT_HISTORY = 'insufficient_history'
+CERTIFICATE_STATUS_RESEARCH_ONLY = 'research_only'
+CERTIFICATE_STATUS_HISTORICAL_PROVEN = 'historical_proven'
+CERTIFICATE_STATUS_PAPER_PROVEN = 'paper_proven'
+CERTIFICATE_STATUS_LIVE_CAPPED = 'live_capped'
+CERTIFICATE_STATUS_LIVE_FULL = 'live_full'
+
+ARCHIVE_STATUS_ARCHIVED = 'archived'
+ARCHIVE_STATUS_PARTIAL = 'partial'
+ARCHIVE_STATUS_INSUFFICIENT = 'insufficient_history'
+
+_UTC = timezone.utc
+_NORMAL_DIST = NormalDist()
+_REALITY_CHECK_BOOTSTRAP_REPLICATES = 500
+_REALITY_CHECK_MIN_SAMPLE_DAYS = 20
+_DSR_MIN_SAMPLE_DAYS = 5
+_COPYABLE_ARTIFACTS: tuple[str, ...] = (
+    'run-manifest.json',
+    'replay-report.json',
+    'runtime-verify.json',
+    'signal-activity.json',
+    'decision-activity.json',
+    'execution-activity.json',
+    'activity-debug.json',
+    'strategy-proof.json',
+    'performance.json',
+    'run-summary.json',
+    'completion-trace.json',
+    'report/simulation-report.json',
+    'report/simulation-report.md',
+    'report/trade-pnl.csv',
+    'report/execution-latency.csv',
+    'report/llm-review-summary.csv',
+)
+
+
+@dataclass(frozen=True)
+class ArchiveWalkForwardFold:
+    name: str
+    train_days: list[str]
+    validation_days: list[str]
+    test_days: list[str]
+    embargo_days: list[str]
+
+    def to_payload(self) -> dict[str, object]:
+        return {
+            'name': self.name,
+            'train_days': list(self.train_days),
+            'validation_days': list(self.validation_days),
+            'test_days': list(self.test_days),
+            'embargo_days': list(self.embargo_days),
+        }
+
+
+@dataclass(frozen=True)
+class ArchivedTradingDayBundle:
+    trading_day: str
+    candidate_id: str
+    run_id: str
+    archived_run_dir: Path
+    original_run_dir: Path
+    market_day_inventory: dict[str, Any]
+    execution_day_inventory: dict[str, Any]
+    replay_day_manifest: dict[str, Any]
+
+    @property
+    def net_pnl_estimated(self) -> Decimal:
+        return _as_decimal(self.execution_day_inventory.get('net_pnl_estimated'))
+
+    @property
+    def estimated_cost_total(self) -> Decimal:
+        return _as_decimal(self.execution_day_inventory.get('estimated_cost_total'))
+
+    @property
+    def replayable_market_day(self) -> bool:
+        return bool(self.market_day_inventory.get('replayable_market_day', False))
+
+    @property
+    def execution_day_eligible(self) -> bool:
+        return bool(self.execution_day_inventory.get('execution_day_eligible', False))
+
+
+def _as_dict(value: object) -> dict[str, Any]:
+    return dict(cast(Mapping[str, Any], value)) if isinstance(value, Mapping) else {}
+
+
+def _as_list(value: object) -> list[Any]:
+    return list(cast(Sequence[Any], value)) if isinstance(value, list) else []
+
+
+def _as_text(value: object) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _as_int(value: object) -> int:
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if isinstance(value, str):
+        text = value.strip()
+        if text:
+            try:
+                return int(text)
+            except ValueError:
+                return 0
+    return 0
+
+
+def _as_float(value: object) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return float(value)
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        text = value.strip()
+        if text:
+            try:
+                return float(text)
+            except ValueError:
+                return None
+    return None
+
+
+def _as_decimal(value: object) -> Decimal:
+    try:
+        return Decimal(str(value))
+    except Exception:
+        return Decimal('0')
+
+
+def _json_default(value: object) -> str:
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            return value.replace(tzinfo=_UTC).isoformat()
+        return value.astimezone(_UTC).isoformat()
+    if isinstance(value, Decimal):
+        return format(value, 'f')
+    if isinstance(value, Path):
+        return str(value)
+    return str(value)
+
+
+def _stable_hash(payload: object) -> str:
+    encoded = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(',', ':'),
+        default=_json_default,
+    ).encode('utf-8')
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _write_json(path: Path, payload: Mapping[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True, default=_json_default),
+        encoding='utf-8',
+    )
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding='utf-8'))
+    if not isinstance(payload, Mapping):
+        raise RuntimeError(f'json_mapping_required:{path}')
+    return {str(key): value for key, value in cast(Mapping[str, Any], payload).items()}
+
+
+def _load_manifest(path: Path) -> dict[str, Any]:
+    raw = path.read_text(encoding='utf-8')
+    if path.suffix.lower() in {'.yaml', '.yml'}:
+        payload = yaml.safe_load(raw)
+    else:
+        payload = json.loads(raw)
+    if not isinstance(payload, Mapping):
+        raise RuntimeError(f'manifest_mapping_required:{path}')
+    return {str(key): value for key, value in cast(Mapping[str, Any], payload).items()}
+
+
+def _simulation_report_path(run_dir: Path) -> Path:
+    return run_dir / 'report' / 'simulation-report.json'
+
+
+def _manifest_trading_day(manifest: Mapping[str, Any], simulation_report: Mapping[str, Any]) -> str:
+    window = _as_dict(manifest.get('window'))
+    trading_day = _as_text(window.get('trading_day'))
+    if trading_day:
+        return trading_day
+    coverage = _as_dict(simulation_report.get('coverage'))
+    window_start = _as_text(coverage.get('window_start'))
+    if window_start is None:
+        raise RuntimeError('trading_day_missing')
+    return window_start.split('T', 1)[0]
+
+
+def _candidate_id(manifest: Mapping[str, Any], run_manifest: Mapping[str, Any]) -> str:
+    lineage = _as_dict(run_manifest.get('evidence_lineage'))
+    candidate_id = _as_text(lineage.get('candidate_id')) or _as_text(manifest.get('candidate_id'))
+    if candidate_id is None:
+        raise RuntimeError('candidate_id_missing')
+    return candidate_id
+
+
+def _source_topics_for_manifest(manifest: Mapping[str, Any]) -> list[str]:
+    from scripts.simulation_lane_contracts import simulation_lane_contract_for_manifest
+
+    contract = simulation_lane_contract_for_manifest(manifest)
+    return [contract.source_topic_by_role[role] for role in contract.replay_roles]
+
+
+def _source_roles_for_manifest(manifest: Mapping[str, Any]) -> list[str]:
+    from scripts.simulation_lane_contracts import simulation_lane_contract_for_manifest
+
+    contract = simulation_lane_contract_for_manifest(manifest)
+    return list(contract.replay_roles)
+
+
+def _artifacts_for_copy(run_dir: Path) -> list[Path]:
+    paths: dict[Path, Path] = {}
+    for relative in _COPYABLE_ARTIFACTS:
+        candidate = run_dir / relative
+        if candidate.exists() and candidate.is_file():
+            paths[candidate] = candidate
+    for candidate in sorted(run_dir.glob('source-dump*')):
+        if candidate.is_file():
+            paths[candidate] = candidate
+    return list(paths.values())
+
+
+def copy_archive_artifacts(
+    *,
+    run_dir: Path,
+    archive_run_dir: Path,
+    manifest_path: Path,
+) -> dict[str, dict[str, str]]:
+    copied: dict[str, dict[str, str]] = {}
+    archive_run_dir.mkdir(parents=True, exist_ok=True)
+
+    copied_manifest_path = archive_run_dir / f'source-manifest{manifest_path.suffix or ".json"}'
+    shutil.copy2(manifest_path, copied_manifest_path)
+    copied['source_manifest'] = {
+        'path': str(copied_manifest_path),
+        'sha256': hashlib.sha256(copied_manifest_path.read_bytes()).hexdigest(),
+    }
+
+    for source_path in _artifacts_for_copy(run_dir):
+        relative_path = source_path.relative_to(run_dir)
+        destination = archive_run_dir / relative_path
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source_path, destination)
+        copied[str(relative_path)] = {
+            'path': str(destination),
+            'sha256': hashlib.sha256(destination.read_bytes()).hexdigest(),
+        }
+
+    simulation_report_key = 'report/simulation-report.json'
+    simulation_report_entry = copied.get(simulation_report_key)
+    if simulation_report_entry is not None:
+        simulation_report_path = Path(simulation_report_entry['path'])
+        simulation_report = _load_json(simulation_report_path)
+        run_metadata = _as_dict(simulation_report.get('run_metadata'))
+        run_metadata['manifest_path'] = str(copied_manifest_path)
+        simulation_report['run_metadata'] = run_metadata
+        _write_json(simulation_report_path, simulation_report)
+        copied[simulation_report_key]['sha256'] = hashlib.sha256(
+            simulation_report_path.read_bytes()
+        ).hexdigest()
+
+    return copied
+
+
+def collect_simulation_postgres_counts(simulation_dsn: str) -> dict[str, int]:
+    dsn = simulation_dsn.strip()
+    if not dsn:
+        return {}
+
+    query = """
+        SELECT
+          CASE WHEN to_regclass('public.trade_decisions') IS NULL THEN 0 ELSE (SELECT count(*) FROM trade_decisions) END AS trade_decisions,
+          CASE WHEN to_regclass('public.executions') IS NULL THEN 0 ELSE (SELECT count(*) FROM executions) END AS executions,
+          CASE WHEN to_regclass('public.position_snapshots') IS NULL THEN 0 ELSE (SELECT count(*) FROM position_snapshots) END AS position_snapshots,
+          CASE WHEN to_regclass('public.execution_order_events') IS NULL THEN 0 ELSE (SELECT count(*) FROM execution_order_events) END AS execution_order_events,
+          CASE WHEN to_regclass('public.execution_tca_metrics') IS NULL THEN 0 ELSE (SELECT count(*) FROM execution_tca_metrics) END AS execution_tca_metrics
+    """
+    with psycopg.connect(dsn) as conn:
+        with conn.cursor() as cursor:
+            cursor.execute(query)
+            row = cursor.fetchone()
+    if row is None:
+        return {}
+    return {
+        'trade_decisions': _as_int(row[0]),
+        'executions': _as_int(row[1]),
+        'position_snapshots': _as_int(row[2]),
+        'execution_order_events': _as_int(row[3]),
+        'execution_tca_metrics': _as_int(row[4]),
+    }
+
+
+def build_market_day_inventory(
+    *,
+    manifest: Mapping[str, Any],
+    run_manifest: Mapping[str, Any],
+    replay_report: Mapping[str, Any],
+    simulation_report: Mapping[str, Any],
+    artifact_refs: Mapping[str, Mapping[str, str]],
+    topic_retention_ms_by_topic: Mapping[str, int] | None = None,
+    observed_at: datetime | None = None,
+) -> dict[str, Any]:
+    trading_day = _manifest_trading_day(manifest, simulation_report)
+    source_topics = _source_topics_for_manifest(manifest)
+    source_roles = _source_roles_for_manifest(manifest)
+    records_by_topic = _as_dict(_as_dict(run_manifest.get('dump')).get('records_by_topic'))
+    coverage = _as_dict(simulation_report.get('coverage'))
+    dump_coverage = _as_dict(run_manifest.get('dump_coverage'))
+    coverage_ratio = (
+        _as_float(dump_coverage.get('coverage_ratio'))
+        or _as_float(coverage.get('window_coverage_ratio_from_dump'))
+        or 0.0
+    )
+    required_topics: list[str] = []
+    for role in source_roles:
+        if role == 'status':
+            continue
+        from scripts.simulation_lane_contracts import simulation_lane_contract_for_manifest
+
+        contract = simulation_lane_contract_for_manifest(manifest)
+        required_topics.append(contract.source_topic_by_role[role])
+    missing_topics = [
+        topic
+        for topic in required_topics
+        if _as_int(records_by_topic.get(topic)) <= 0
+    ]
+    symbols = sorted(
+        {
+            str(item)
+            for item in _as_list(_as_dict(simulation_report.get('stability')).get('clickhouse', {}).get('symbols'))
+            if str(item).strip()
+        }
+    )
+    if not symbols:
+        stability_clickhouse = _as_dict(_as_dict(simulation_report.get('stability')).get('clickhouse'))
+        raw_symbols = stability_clickhouse.get('symbols')
+        if isinstance(raw_symbols, list):
+            normalized_symbols = [str(item) for item in cast(list[object], raw_symbols) if str(item).strip()]
+            symbols = sorted(set(normalized_symbols))
+    market_day_inventory: dict[str, Any] = {
+        'schema_version': MARKET_DAY_INVENTORY_SCHEMA_VERSION,
+        'trading_day': trading_day,
+        'window': dict(_as_dict(manifest.get('window'))),
+        'lane': _as_text(manifest.get('lane')) or 'equity',
+        'source_topics': source_topics,
+        'source_topic_retention_ms_by_topic': {
+            topic: int(value)
+            for topic, value in (topic_retention_ms_by_topic or {}).items()
+            if str(topic).strip()
+        },
+        'source_offsets': {},
+        'source_records_by_topic': {
+            str(topic): _as_int(value) for topic, value in records_by_topic.items()
+        },
+        'symbols': symbols,
+        'clickhouse_coverage': {
+            'window_coverage_ratio_from_dump': coverage.get('window_coverage_ratio_from_dump'),
+            'decision_signal_min_ts': coverage.get('decision_signal_min_ts'),
+            'decision_signal_max_ts': coverage.get('decision_signal_max_ts'),
+            'dump_signal_min_ts': coverage.get('dump_signal_min_ts'),
+            'dump_signal_max_ts': coverage.get('dump_signal_max_ts'),
+        },
+        'clickhouse_day_exports': {
+            key: value['path']
+            for key, value in artifact_refs.items()
+            if key.startswith('report/')
+        },
+        'replayable_market_day': (
+            _as_int(_as_dict(run_manifest.get('dump')).get('records')) > 0
+            and coverage_ratio >= (_as_float(_as_dict(run_manifest.get('window_policy')).get('strict_coverage_ratio')) or 0.95)
+            and not missing_topics
+        ),
+        'missing_topics': missing_topics,
+        'missing_partitions': [],
+        'missing_symbols': [],
+        'reconstruction_source_provenance': ArtifactProvenance.HISTORICAL_MARKET_REPLAY.value,
+        'observed_at': (observed_at or datetime.now(_UTC)).astimezone(_UTC).isoformat(),
+    }
+    return market_day_inventory
+
+
+def build_execution_day_inventory(
+    *,
+    manifest: Mapping[str, Any],
+    simulation_report: Mapping[str, Any],
+    artifact_refs: Mapping[str, Mapping[str, str]],
+    postgres_counts: Mapping[str, int] | None = None,
+    empirical_artifact_refs: Sequence[str] | None = None,
+    observed_at: datetime | None = None,
+) -> dict[str, Any]:
+    funnel = _as_dict(simulation_report.get('funnel'))
+    execution_quality = _as_dict(simulation_report.get('execution_quality'))
+    slippage = _as_dict(execution_quality.get('slippage_bps'))
+    pnl = _as_dict(simulation_report.get('pnl'))
+    counts = dict(postgres_counts or {})
+    trade_decisions = counts.get('trade_decisions', _as_int(funnel.get('trade_decisions')))
+    executions = counts.get('executions', _as_int(funnel.get('executions')))
+    position_snapshots = counts.get('position_snapshots', 0)
+    execution_order_events = counts.get(
+        'execution_order_events',
+        _as_int(funnel.get('execution_order_events_total') or funnel.get('execution_order_events')),
+    )
+    execution_tca_metrics = counts.get(
+        'execution_tca_metrics',
+        _as_int(funnel.get('execution_tca_metrics')),
+    )
+    missing_surfaces: list[str] = []
+    if trade_decisions <= 0:
+        missing_surfaces.append('trade_decisions')
+    if executions <= 0:
+        missing_surfaces.append('executions')
+    if position_snapshots <= 0:
+        missing_surfaces.append('position_snapshots')
+    if execution_order_events <= 0:
+        missing_surfaces.append('execution_order_events')
+    if execution_tca_metrics <= 0:
+        missing_surfaces.append('execution_tca_metrics')
+    if not counts:
+        missing_surfaces.append('simulation_postgres_snapshot_missing')
+
+    return {
+        'schema_version': EXECUTION_DAY_INVENTORY_SCHEMA_VERSION,
+        'trading_day': _manifest_trading_day(manifest, simulation_report),
+        'candidate_scope': {
+            'candidate_id': _as_text(manifest.get('candidate_id')),
+            'baseline_candidate_id': _as_text(manifest.get('baseline_candidate_id')),
+            'strategy_spec_ref': _as_text(manifest.get('strategy_spec_ref')),
+            'model_refs': [
+                str(item)
+                for item in _as_list(manifest.get('model_refs'))
+                if str(item).strip()
+            ],
+        },
+        'trade_decisions_present': trade_decisions > 0,
+        'executions_present': executions > 0,
+        'execution_order_events_present': execution_order_events > 0,
+        'position_snapshots_present': position_snapshots > 0,
+        'execution_tca_metrics_present': execution_tca_metrics > 0,
+        'postgres_day_exports': {
+            'counts': {
+                'trade_decisions': trade_decisions,
+                'executions': executions,
+                'position_snapshots': position_snapshots,
+                'execution_order_events': execution_order_events,
+                'execution_tca_metrics': execution_tca_metrics,
+            },
+            'report_paths': {
+                key: value['path']
+                for key, value in artifact_refs.items()
+                if key in {'run-summary.json', 'report/simulation-report.json', 'report/trade-pnl.csv'}
+            },
+        },
+        'empirical_artifact_refs': [str(item) for item in (empirical_artifact_refs or []) if str(item).strip()],
+        'rejections_by_reason': {},
+        'broker_failures_by_reason': {
+            str(key): _as_int(value)
+            for key, value in _as_dict(execution_quality.get('fallback_reason_counts')).items()
+        },
+        'decision_status_counts': {
+            str(key): _as_int(value)
+            for key, value in _as_dict(funnel.get('decision_status_counts')).items()
+        },
+        'net_pnl_estimated': format(_as_decimal(pnl.get('net_pnl_estimated')), 'f'),
+        'estimated_cost_total': format(_as_decimal(pnl.get('estimated_cost_total')), 'f'),
+        'execution_notional_total': format(_as_decimal(pnl.get('execution_notional_total')), 'f'),
+        'avg_abs_slippage_bps': slippage.get('avg_abs'),
+        'p95_abs_slippage_bps': slippage.get('p95_abs'),
+        'execution_day_eligible': not missing_surfaces,
+        'missing_execution_surfaces': missing_surfaces,
+        'observed_at': (observed_at or datetime.now(_UTC)).astimezone(_UTC).isoformat(),
+    }
+
+
+def build_replay_day_manifest(
+    *,
+    manifest: Mapping[str, Any],
+    run_manifest: Mapping[str, Any],
+    replay_report: Mapping[str, Any],
+    archive_dir: Path,
+    original_run_dir: Path,
+    artifact_refs: Mapping[str, Mapping[str, str]],
+    market_day_inventory: Mapping[str, Any],
+    execution_day_inventory: Mapping[str, Any],
+    observed_at: datetime | None = None,
+) -> dict[str, Any]:
+    evidence_lineage = _as_dict(run_manifest.get('evidence_lineage'))
+    bundle_inputs = {
+        'artifact_refs': artifact_refs,
+        'market_day_inventory': market_day_inventory,
+        'execution_day_inventory': execution_day_inventory,
+        'run_manifest_dump_sha256': _as_text(_as_dict(run_manifest.get('dump')).get('sha256')),
+        'replay_report_dump_sha256': _as_text(replay_report.get('dump_sha256')),
+    }
+    archive_status = ARCHIVE_STATUS_ARCHIVED
+    if not bool(market_day_inventory.get('replayable_market_day', False)):
+        archive_status = ARCHIVE_STATUS_PARTIAL
+    if not bool(execution_day_inventory.get('execution_day_eligible', False)):
+        archive_status = ARCHIVE_STATUS_PARTIAL if archive_status == ARCHIVE_STATUS_ARCHIVED else archive_status
+
+    return {
+        'schema_version': REPLAY_DAY_MANIFEST_SCHEMA_VERSION,
+        'run_id': _as_text(run_manifest.get('run_id')) or original_run_dir.name,
+        'dataset_id': _as_text(manifest.get('dataset_id')) or _as_text(run_manifest.get('dataset_id')) or original_run_dir.name,
+        'dataset_snapshot_ref': _as_text(manifest.get('dataset_snapshot_ref')),
+        'candidate_id': _as_text(evidence_lineage.get('candidate_id')) or _as_text(manifest.get('candidate_id')),
+        'baseline_candidate_id': _as_text(evidence_lineage.get('baseline_candidate_id')) or _as_text(manifest.get('baseline_candidate_id')),
+        'trading_day': _manifest_trading_day(manifest, market_day_inventory),
+        'window': dict(_as_dict(manifest.get('window'))),
+        'source_dump_ref': (
+            _as_text(_as_dict(artifact_refs.get('source-dump.jsonl.zst.manifest.json')).get('path'))
+            or _as_text(_as_dict(artifact_refs.get('source-dump.jsonl.gz.manifest.json')).get('path'))
+            or _as_text(_as_dict(artifact_refs.get('source-dump.ndjson.manifest.json')).get('path'))
+        ),
+        'source_dump_sha256': (
+            _as_text(replay_report.get('dump_sha256'))
+            or _as_text(_as_dict(run_manifest.get('dump')).get('sha256'))
+        ),
+        'run_manifest_ref': _as_text(_as_dict(artifact_refs.get('run-manifest.json')).get('path')),
+        'analysis_report_ref': _as_text(_as_dict(artifact_refs.get('report/simulation-report.json')).get('path')),
+        'simulation_database': _as_text(_as_dict(manifest.get('clickhouse')).get('simulation_database')),
+        'runtime_version_refs': [
+            str(item) for item in _as_list(evidence_lineage.get('runtime_version_refs')) if str(item).strip()
+        ],
+        'model_refs': [
+            str(item) for item in _as_list(evidence_lineage.get('model_refs')) if str(item).strip()
+        ],
+        'strategy_spec_ref': _as_text(evidence_lineage.get('strategy_spec_ref')) or _as_text(manifest.get('strategy_spec_ref')),
+        'artifact_bundle_sha256': _stable_hash(bundle_inputs),
+        'archive_status': archive_status,
+        'original_run_dir': str(original_run_dir),
+        'archived_run_dir': str(archive_dir),
+        'artifact_refs': {
+            key: value['path']
+            for key, value in artifact_refs.items()
+        },
+        'observed_at': (observed_at or datetime.now(_UTC)).astimezone(_UTC).isoformat(),
+    }
+
+
+def upsert_dataset_snapshot(
+    session: Session,
+    *,
+    run_id: str,
+    candidate_id: str | None,
+    dataset_id: str,
+    dataset_from: datetime | None,
+    dataset_to: datetime | None,
+    artifact_ref: str,
+    payload_json: Mapping[str, Any],
+) -> VNextDatasetSnapshot:
+    existing = session.execute(
+        select(VNextDatasetSnapshot).where(
+            VNextDatasetSnapshot.run_id == run_id,
+            VNextDatasetSnapshot.dataset_id == dataset_id,
+        )
+    ).scalar_one_or_none()
+    snapshot = existing or VNextDatasetSnapshot(
+        run_id=run_id,
+        candidate_id=candidate_id,
+        dataset_id=dataset_id,
+        source=ArtifactProvenance.HISTORICAL_MARKET_REPLAY.value,
+    )
+    snapshot.candidate_id = candidate_id
+    snapshot.dataset_version = run_id
+    snapshot.dataset_from = dataset_from
+    snapshot.dataset_to = dataset_to
+    snapshot.artifact_ref = artifact_ref
+    snapshot.payload_json = dict(payload_json)
+    if existing is None:
+        session.add(snapshot)
+    session.flush()
+    return snapshot
+
+
+def _resolve_manifest_path(run_dir: Path, manifest_path: Path) -> Path:
+    if manifest_path.is_absolute() and manifest_path.exists():
+        return manifest_path
+    for candidate in (run_dir / manifest_path, Path.cwd() / manifest_path):
+        if candidate.exists():
+            return candidate
+    return manifest_path
+
+
+def archive_historical_simulation_run(
+    *,
+    run_dir: Path,
+    archive_root: Path,
+    manifest_path: Path | None = None,
+    topic_retention_ms_by_topic: Mapping[str, int] | None = None,
+    postgres_counts: Mapping[str, int] | None = None,
+    session: Session | None = None,
+    observed_at: datetime | None = None,
+) -> dict[str, Any]:
+    simulation_report_path = _simulation_report_path(run_dir)
+    if not simulation_report_path.exists():
+        raise RuntimeError(f'simulation_report_missing:{run_dir}')
+    run_manifest_path = run_dir / 'run-manifest.json'
+    replay_report_path = run_dir / 'replay-report.json'
+    if not run_manifest_path.exists():
+        raise RuntimeError(f'run_manifest_missing:{run_dir}')
+    if not replay_report_path.exists():
+        raise RuntimeError(f'replay_report_missing:{run_dir}')
+
+    simulation_report = _load_json(simulation_report_path)
+    run_manifest = _load_json(run_manifest_path)
+    replay_report = _load_json(replay_report_path)
+    resolved_manifest_path = manifest_path
+    if resolved_manifest_path is None:
+        run_metadata = _as_dict(simulation_report.get('run_metadata'))
+        manifest_text = _as_text(run_metadata.get('manifest_path'))
+        if manifest_text is None:
+            raise RuntimeError(f'manifest_path_missing:{run_dir}')
+        resolved_manifest_path = Path(manifest_text)
+    resolved_manifest_path = _resolve_manifest_path(run_dir, resolved_manifest_path)
+    manifest = _load_manifest(resolved_manifest_path)
+    trading_day = _manifest_trading_day(manifest, simulation_report)
+    candidate_id = _candidate_id(manifest, run_manifest)
+    run_id = _as_text(run_manifest.get('run_id')) or run_dir.name
+    archive_dir = archive_root / trading_day / candidate_id / run_id
+    artifact_refs = copy_archive_artifacts(
+        run_dir=run_dir,
+        archive_run_dir=archive_dir,
+        manifest_path=resolved_manifest_path,
+    )
+    actual_postgres_counts = dict(postgres_counts or {})
+    if not actual_postgres_counts:
+        simulation_dsn = _as_text(_as_dict(manifest.get('postgres')).get('simulation_dsn')) or ''
+        if simulation_dsn:
+            try:
+                actual_postgres_counts = collect_simulation_postgres_counts(simulation_dsn)
+            except Exception:
+                actual_postgres_counts = {}
+    market_day_inventory = build_market_day_inventory(
+        manifest=manifest,
+        run_manifest=run_manifest,
+        replay_report=replay_report,
+        simulation_report=simulation_report,
+        artifact_refs=artifact_refs,
+        topic_retention_ms_by_topic=topic_retention_ms_by_topic,
+        observed_at=observed_at,
+    )
+    execution_day_inventory = build_execution_day_inventory(
+        manifest=manifest,
+        simulation_report=simulation_report,
+        artifact_refs=artifact_refs,
+        postgres_counts=actual_postgres_counts,
+        observed_at=observed_at,
+    )
+    replay_day_manifest = build_replay_day_manifest(
+        manifest=manifest,
+        run_manifest=run_manifest,
+        replay_report=replay_report,
+        archive_dir=archive_dir,
+        original_run_dir=run_dir,
+        artifact_refs=artifact_refs,
+        market_day_inventory=market_day_inventory,
+        execution_day_inventory=execution_day_inventory,
+        observed_at=observed_at,
+    )
+
+    market_day_inventory_path = archive_dir / 'market_day_inventory.json'
+    execution_day_inventory_path = archive_dir / 'execution_day_inventory.json'
+    replay_day_manifest_path = archive_dir / 'replay_day_manifest.json'
+    _write_json(market_day_inventory_path, market_day_inventory)
+    _write_json(execution_day_inventory_path, execution_day_inventory)
+    _write_json(replay_day_manifest_path, replay_day_manifest)
+
+    if session is not None:
+        window = _as_dict(manifest.get('window'))
+        dataset_from = _parse_optional_timestamp(_as_text(window.get('start')))
+        dataset_to = _parse_optional_timestamp(_as_text(window.get('end')))
+        upsert_dataset_snapshot(
+            session,
+            run_id=run_id,
+            candidate_id=candidate_id,
+            dataset_id=_as_text(manifest.get('dataset_id')) or run_id,
+            dataset_from=dataset_from,
+            dataset_to=dataset_to,
+            artifact_ref=str(archive_dir),
+            payload_json={
+                'market_day_inventory': market_day_inventory,
+                'execution_day_inventory': execution_day_inventory,
+                'replay_day_manifest': replay_day_manifest,
+            },
+        )
+
+    return {
+        'trading_day': trading_day,
+        'candidate_id': candidate_id,
+        'run_id': run_id,
+        'archive_dir': str(archive_dir),
+        'market_day_inventory_path': str(market_day_inventory_path),
+        'execution_day_inventory_path': str(execution_day_inventory_path),
+        'replay_day_manifest_path': str(replay_day_manifest_path),
+        'archive_status': replay_day_manifest['archive_status'],
+    }
+
+
+def _parse_optional_timestamp(value: str | None) -> datetime | None:
+    if value is None:
+        return None
+    cleaned = value.replace('Z', '+00:00')
+    try:
+        parsed = datetime.fromisoformat(cleaned)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=_UTC)
+    return parsed.astimezone(_UTC)
+
+
+def load_archived_trading_day_bundles(archive_root: Path) -> list[ArchivedTradingDayBundle]:
+    bundles: list[ArchivedTradingDayBundle] = []
+    for replay_manifest_path in sorted(archive_root.rglob('replay_day_manifest.json')):
+        archive_dir = replay_manifest_path.parent
+        replay_day_manifest = _load_json(replay_manifest_path)
+        market_day_inventory = _load_json(archive_dir / 'market_day_inventory.json')
+        execution_day_inventory = _load_json(archive_dir / 'execution_day_inventory.json')
+        trading_day = _as_text(replay_day_manifest.get('trading_day'))
+        candidate_id = _as_text(replay_day_manifest.get('candidate_id'))
+        run_id = _as_text(replay_day_manifest.get('run_id'))
+        original_run_dir = _as_text(replay_day_manifest.get('original_run_dir'))
+        archived_run_dir = _as_text(replay_day_manifest.get('archived_run_dir')) or str(archive_dir)
+        if trading_day is None or candidate_id is None or run_id is None or original_run_dir is None:
+            raise RuntimeError(f'archived_bundle_invalid:{archive_dir}')
+        bundles.append(
+            ArchivedTradingDayBundle(
+                trading_day=trading_day,
+                candidate_id=candidate_id,
+                run_id=run_id,
+                archived_run_dir=Path(archived_run_dir),
+                original_run_dir=Path(original_run_dir),
+                market_day_inventory=market_day_inventory,
+                execution_day_inventory=execution_day_inventory,
+                replay_day_manifest=replay_day_manifest,
+            )
+        )
+    return bundles
+
+
+def summarize_data_sufficiency(
+    bundles: Sequence[ArchivedTradingDayBundle],
+    *,
+    min_research_days: int = 20,
+    min_historical_days: int = 60,
+    min_execution_days: int = 20,
+    generated_at: datetime | None = None,
+) -> dict[str, Any]:
+    replayable = sorted(
+        {bundle.trading_day for bundle in bundles if bundle.replayable_market_day}
+    )
+    execution_days = sorted(
+        {bundle.trading_day for bundle in bundles if bundle.execution_day_eligible}
+    )
+    symbols = sorted(
+        {
+            symbol
+            for bundle in bundles
+            for symbol in cast(list[str], bundle.market_day_inventory.get('symbols') or [])
+            if str(symbol).strip()
+        }
+    )
+    missing_days = _missing_business_days(replayable)
+    retention_risk_days_remaining = _min_retention_days(bundles)
+    blockers: list[str] = []
+    status = SUFFICIENCY_STATUS_PAPER_READY
+    if len(replayable) < min_research_days:
+        status = SUFFICIENCY_STATUS_INSUFFICIENT_HISTORY
+        blockers.append('replay_ready_market_days_below_research_minimum')
+    elif len(replayable) < min_historical_days:
+        status = SUFFICIENCY_STATUS_RESEARCH_ONLY
+        blockers.append('replay_ready_market_days_below_historical_minimum')
+    elif len(execution_days) < min_execution_days:
+        status = SUFFICIENCY_STATUS_HISTORICAL_READY
+        blockers.append('execution_days_below_paper_minimum')
+    else:
+        status = SUFFICIENCY_STATUS_PAPER_READY
+    if missing_days:
+        blockers.append('missing_business_days_in_archive_window')
+    if not bundles:
+        blockers.append('archive_bundle_set_empty')
+        status = SUFFICIENCY_STATUS_INSUFFICIENT_HISTORY
+    return {
+        'schema_version': DATA_SUFFICIENCY_SCHEMA_VERSION,
+        'generated_at': (generated_at or datetime.now(_UTC)).astimezone(_UTC).isoformat(),
+        'market_days_available': len({bundle.trading_day for bundle in bundles}),
+        'execution_days_available': len(execution_days),
+        'replay_ready_market_days': len(replayable),
+        'proof_eligible_days': len(
+            {
+                bundle.trading_day
+                for bundle in bundles
+                if bundle.replayable_market_day and bundle.execution_day_eligible
+            }
+        ),
+        'symbol_coverage': {
+            'count': len(symbols),
+            'symbols': symbols,
+        },
+        'missing_days': missing_days,
+        'source_provenance': sorted(
+            {
+                str(bundle.market_day_inventory.get('reconstruction_source_provenance'))
+                for bundle in bundles
+                if str(bundle.market_day_inventory.get('reconstruction_source_provenance') or '').strip()
+            }
+        ),
+        'retention_risk_days_remaining': retention_risk_days_remaining,
+        'status': status,
+        'blockers': blockers,
+    }
+
+
+def build_trial_ledger(
+    bundles: Sequence[ArchivedTradingDayBundle],
+    *,
+    generated_at: datetime | None = None,
+) -> dict[str, Any]:
+    candidate_ids = sorted({bundle.candidate_id for bundle in bundles})
+    entries: list[dict[str, Any]] = []
+    selected_candidate_id: str | None = None
+    best_sort_key: tuple[Decimal, Decimal, Decimal] | None = None
+    for candidate_id in candidate_ids:
+        candidate_bundles = [bundle for bundle in bundles if bundle.candidate_id == candidate_id]
+        replayable_bundles = [bundle for bundle in candidate_bundles if bundle.replayable_market_day]
+        execution_bundles = [bundle for bundle in candidate_bundles if bundle.execution_day_eligible]
+        proof_eligible_bundles = [
+            bundle
+            for bundle in replayable_bundles
+            if bundle.execution_day_eligible
+        ]
+        daily_pnls = [bundle.net_pnl_estimated for bundle in proof_eligible_bundles]
+        average_daily = _decimal_mean(daily_pnls)
+        median_daily = _decimal_median(daily_pnls)
+        profitable_ratio = _safe_decimal_ratio(
+            Decimal(sum(1 for value in daily_pnls if value > 0)),
+            Decimal(len(daily_pnls)),
+        )
+        entry = {
+            'candidate_id': candidate_id,
+            'sleeve_id': candidate_id,
+            'parameter_hash': _stable_hash(candidate_id),
+            'search_batch_id': 'archive-bundle-v1',
+            'dataset_snapshot_refs': sorted(
+                {
+                    str(bundle.replay_day_manifest.get('dataset_snapshot_ref'))
+                    for bundle in candidate_bundles
+                    if str(bundle.replay_day_manifest.get('dataset_snapshot_ref') or '').strip()
+                }
+            ),
+            'trading_days': sorted({bundle.trading_day for bundle in candidate_bundles}),
+            'selection_status': 'rejected',
+            'selection_reason': 'not_selected',
+            'metrics_summary': {
+                'market_days_available': len({bundle.trading_day for bundle in replayable_bundles}),
+                'execution_days_available': len({bundle.trading_day for bundle in execution_bundles}),
+                'proof_eligible_days': len({bundle.trading_day for bundle in proof_eligible_bundles}),
+                'average_daily_net_pnl': format(average_daily, 'f'),
+                'median_daily_net_pnl': format(median_daily, 'f'),
+                'profitable_day_ratio': format(profitable_ratio, 'f'),
+                'total_net_pnl': format(sum(daily_pnls, Decimal('0')), 'f'),
+                'average_abs_slippage_bps': _mean_optional_floats(
+                    [
+                        _as_float(bundle.execution_day_inventory.get('avg_abs_slippage_bps'))
+                        for bundle in execution_bundles
+                    ]
+                ),
+            },
+        }
+        sort_key = (average_daily, median_daily, profitable_ratio)
+        if best_sort_key is None or sort_key > best_sort_key:
+            best_sort_key = sort_key
+            selected_candidate_id = candidate_id
+        entries.append(entry)
+    for entry in entries:
+        if entry['candidate_id'] == selected_candidate_id:
+            entry['selection_status'] = 'selected'
+            entry['selection_reason'] = 'highest_average_daily_net_pnl'
+    return {
+        'schema_version': TRIAL_LEDGER_SCHEMA_VERSION,
+        'generated_at': (generated_at or datetime.now(_UTC)).astimezone(_UTC).isoformat(),
+        'trial_count': len(entries),
+        'selected_candidate_id': selected_candidate_id,
+        'entries': entries,
+    }
+
+
+def generate_archive_walkforward_folds(
+    trading_days: Sequence[str],
+    *,
+    train_days: int,
+    validation_days: int,
+    test_days: int,
+    step_days: int,
+    embargo_days: int,
+) -> list[ArchiveWalkForwardFold]:
+    if train_days <= 0 or validation_days <= 0 or test_days <= 0 or step_days <= 0 or embargo_days < 0:
+        raise ValueError('invalid_walkforward_window')
+    ordered_days = sorted({str(day) for day in trading_days})
+    folds: list[ArchiveWalkForwardFold] = []
+    cursor = 0
+    fold_index = 1
+    while True:
+        train_start = cursor
+        train_end = train_start + train_days
+        validation_start = train_end + embargo_days
+        validation_end = validation_start + validation_days
+        test_start = validation_end + embargo_days
+        test_end = test_start + test_days
+        if test_end > len(ordered_days):
+            break
+        embargo_window = ordered_days[train_end:validation_start] + ordered_days[validation_end:test_start]
+        folds.append(
+            ArchiveWalkForwardFold(
+                name=f'fold_{fold_index}',
+                train_days=ordered_days[train_start:train_end],
+                validation_days=ordered_days[validation_start:validation_end],
+                test_days=ordered_days[test_start:test_end],
+                embargo_days=embargo_window,
+            )
+        )
+        fold_index += 1
+        cursor += step_days
+    return folds
+
+
+def _proof_eligible_bundles(
+    bundles: Sequence[ArchivedTradingDayBundle],
+    *,
+    candidate_id: str | None = None,
+) -> list[ArchivedTradingDayBundle]:
+    return [
+        bundle
+        for bundle in bundles
+        if bundle.replayable_market_day
+        and bundle.execution_day_eligible
+        and (candidate_id is None or bundle.candidate_id == candidate_id)
+    ]
+
+
+def _candidate_daily_net_pnl_by_day(
+    bundles: Sequence[ArchivedTradingDayBundle],
+) -> dict[str, dict[str, Decimal]]:
+    series: dict[str, dict[str, Decimal]] = {}
+    for bundle in _proof_eligible_bundles(bundles):
+        candidate_series = series.setdefault(bundle.candidate_id, {})
+        candidate_series[bundle.trading_day] = bundle.net_pnl_estimated
+    return series
+
+
+def _fold_selection_rows(
+    *,
+    candidate_daily_net_pnl_by_day: Mapping[str, Mapping[str, Decimal]],
+    folds: Sequence[ArchiveWalkForwardFold],
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    candidate_ids = sorted(candidate_daily_net_pnl_by_day)
+    for fold in folds:
+        is_days = [*fold.train_days, *fold.validation_days]
+        oos_days = list(fold.test_days)
+        candidate_metrics: list[dict[str, Any]] = []
+        for candidate_id in candidate_ids:
+            day_map = candidate_daily_net_pnl_by_day[candidate_id]
+            is_values = [day_map[day] for day in is_days if day in day_map]
+            oos_values = [day_map[day] for day in oos_days if day in day_map]
+            if not is_values or not oos_values:
+                continue
+            candidate_metrics.append(
+                {
+                    'candidate_id': candidate_id,
+                    'is_avg': _decimal_mean(is_values),
+                    'oos_avg': _decimal_mean(oos_values),
+                    'oos_sum': sum(oos_values, Decimal('0')),
+                }
+            )
+        if len(candidate_metrics) < 2:
+            continue
+        candidate_metrics.sort(
+            key=lambda item: (cast(Decimal, item['is_avg']), str(item['candidate_id'])),
+            reverse=True,
+        )
+        selected = candidate_metrics[0]
+        oos_ranked = sorted(
+            candidate_metrics,
+            key=lambda item: (cast(Decimal, item['oos_avg']), str(item['candidate_id'])),
+            reverse=True,
+        )
+        oos_rank_by_candidate = {
+            str(item['candidate_id']): len(oos_ranked) - index
+            for index, item in enumerate(oos_ranked)
+        }
+        selected_candidate_id = str(selected['candidate_id'])
+        relative_rank = Decimal(oos_rank_by_candidate[selected_candidate_id]) / Decimal(len(oos_ranked) + 1)
+        omega = min(max(float(relative_rank), 1e-6), 1 - 1e-6)
+        rows.append(
+            {
+                'fold_name': fold.name,
+                'selected_candidate_id': selected_candidate_id,
+                'is_avg_daily_net_pnl': format(cast(Decimal, selected['is_avg']), 'f'),
+                'oos_avg_daily_net_pnl': format(cast(Decimal, selected['oos_avg']), 'f'),
+                'oos_total_net_pnl': format(cast(Decimal, selected['oos_sum']), 'f'),
+                'oos_relative_rank': float(relative_rank),
+                'oos_logit': math.log(omega / (1.0 - omega)),
+                'candidate_count': len(oos_ranked),
+            }
+        )
+    return rows
+
+
+def _estimate_pbo(fold_rows: Sequence[Mapping[str, Any]]) -> float | None:
+    if not fold_rows:
+        return None
+    below_median = sum(1 for row in fold_rows if float(row.get('oos_logit') or 0.0) < 0.0)
+    return below_median / len(fold_rows)
+
+
+def _fit_slope(x_values: Sequence[float], y_values: Sequence[float]) -> float | None:
+    if len(x_values) != len(y_values) or len(x_values) < 2:
+        return None
+    mean_x = sum(x_values) / len(x_values)
+    mean_y = sum(y_values) / len(y_values)
+    numerator = sum((x_value - mean_x) * (y_value - mean_y) for x_value, y_value in zip(x_values, y_values, strict=True))
+    denominator = sum((x_value - mean_x) ** 2 for x_value in x_values)
+    if denominator <= 0:
+        return None
+    return numerator / denominator
+
+
+def _sample_stddev(values: Sequence[float]) -> float | None:
+    if len(values) < 2:
+        return None
+    mean_value = sum(values) / len(values)
+    variance = sum((value - mean_value) ** 2 for value in values) / (len(values) - 1)
+    if variance <= 0:
+        return None
+    return math.sqrt(variance)
+
+
+def _daily_sharpe_ratio(values: Sequence[Decimal]) -> float | None:
+    resolved = [float(value) for value in values]
+    stddev = _sample_stddev(resolved)
+    if stddev is None or stddev <= 0:
+        return None
+    return (sum(resolved) / len(resolved)) / stddev
+
+
+def _skewness_and_kurtosis(values: Sequence[Decimal]) -> tuple[float, float]:
+    resolved = [float(value) for value in values]
+    if len(resolved) < 3:
+        return (0.0, 3.0)
+    mean_value = sum(resolved) / len(resolved)
+    centered = [value - mean_value for value in resolved]
+    second = sum(value**2 for value in centered) / len(centered)
+    if second <= 0:
+        return (0.0, 3.0)
+    third = sum(value**3 for value in centered) / len(centered)
+    fourth = sum(value**4 for value in centered) / len(centered)
+    skewness = third / (second ** 1.5)
+    kurtosis = fourth / (second**2)
+    return (skewness, kurtosis)
+
+
+def _estimate_deflated_sharpe_ratio(
+    *,
+    selected_values: Sequence[Decimal],
+    candidate_daily_net_pnl_by_day: Mapping[str, Mapping[str, Decimal]],
+    oos_days: Sequence[str],
+    trial_count: int,
+) -> dict[str, float | int | None]:
+    if len(selected_values) < _DSR_MIN_SAMPLE_DAYS:
+        return {
+            'sample_size': len(selected_values),
+            'selected_daily_sharpe_ratio': None,
+            'benchmark_sharpe_threshold': None,
+            'deflated_sharpe_ratio': None,
+            'deflated_sharpe_z_score': None,
+        }
+
+    selected_sharpe = _daily_sharpe_ratio(selected_values)
+    if selected_sharpe is None:
+        return {
+            'sample_size': len(selected_values),
+            'selected_daily_sharpe_ratio': None,
+            'benchmark_sharpe_threshold': None,
+            'deflated_sharpe_ratio': None,
+            'deflated_sharpe_z_score': None,
+        }
+
+    trial_sharpes: list[float] = []
+    for day_map in candidate_daily_net_pnl_by_day.values():
+        candidate_values = [day_map[day] for day in oos_days if day in day_map]
+        candidate_sharpe = _daily_sharpe_ratio(candidate_values)
+        if candidate_sharpe is not None:
+            trial_sharpes.append(candidate_sharpe)
+    trial_reference_count = max(trial_count, len(trial_sharpes))
+    if trial_reference_count < 2:
+        return {
+            'sample_size': len(selected_values),
+            'selected_daily_sharpe_ratio': selected_sharpe,
+            'benchmark_sharpe_threshold': None,
+            'deflated_sharpe_ratio': None,
+            'deflated_sharpe_z_score': None,
+        }
+
+    trial_sharpe_mean = sum(trial_sharpes) / len(trial_sharpes) if trial_sharpes else 0.0
+    trial_sharpe_stddev = _sample_stddev(trial_sharpes) or 0.0
+    euler_gamma = 0.5772156649015329
+    first_extreme = _NORMAL_DIST.inv_cdf(1.0 - (1.0 / trial_reference_count))
+    second_extreme = _NORMAL_DIST.inv_cdf(1.0 - (1.0 / (trial_reference_count * math.e)))
+    benchmark_sharpe_threshold = trial_sharpe_mean + trial_sharpe_stddev * (
+        (1.0 - euler_gamma) * first_extreme + euler_gamma * second_extreme
+    )
+
+    skewness, kurtosis = _skewness_and_kurtosis(selected_values)
+    denominator = math.sqrt(
+        max(
+            1e-12,
+            1.0
+            - (skewness * selected_sharpe)
+            + (((kurtosis - 1.0) / 4.0) * (selected_sharpe**2)),
+        )
+    )
+    z_score = ((selected_sharpe - benchmark_sharpe_threshold) * math.sqrt(len(selected_values) - 1)) / denominator
+    return {
+        'sample_size': len(selected_values),
+        'selected_daily_sharpe_ratio': selected_sharpe,
+        'benchmark_sharpe_threshold': benchmark_sharpe_threshold,
+        'deflated_sharpe_ratio': _NORMAL_DIST.cdf(z_score),
+        'deflated_sharpe_z_score': z_score,
+    }
+
+
+def _moving_block_bootstrap_indices(
+    *,
+    length: int,
+    block_size: int,
+    rng: random.Random,
+) -> list[int]:
+    indices: list[int] = []
+    while len(indices) < length:
+        start = rng.randrange(length)
+        for offset in range(block_size):
+            indices.append((start + offset) % length)
+            if len(indices) >= length:
+                break
+    return indices
+
+
+def _estimate_reality_check_p_value(
+    *,
+    candidate_daily_net_pnl_by_day: Mapping[str, Mapping[str, Decimal]],
+    oos_days: Sequence[str],
+    bootstrap_replicates: int,
+) -> float | None:
+    if len(oos_days) < _REALITY_CHECK_MIN_SAMPLE_DAYS:
+        return None
+    aligned_series: list[list[float]] = []
+    for day_map in candidate_daily_net_pnl_by_day.values():
+        if all(day in day_map for day in oos_days):
+            aligned_series.append([float(day_map[day]) for day in oos_days])
+    if len(aligned_series) < 2:
+        return None
+
+    observed = max(sum(series) / len(series) for series in aligned_series)
+    if observed <= 0:
+        return 1.0
+
+    centered_series = [
+        [value - (sum(series) / len(series)) for value in series]
+        for series in aligned_series
+    ]
+    block_size = max(2, int(round(math.sqrt(len(oos_days)))))
+    rng = random.Random(0)
+    exceedances = 0
+    for _ in range(bootstrap_replicates):
+        sample_indices = _moving_block_bootstrap_indices(
+            length=len(oos_days),
+            block_size=block_size,
+            rng=rng,
+        )
+        bootstrap_statistic = max(
+            sum(series[index] for index in sample_indices) / len(sample_indices)
+            for series in centered_series
+        )
+        if bootstrap_statistic >= observed:
+            exceedances += 1
+    return (exceedances + 1) / (bootstrap_replicates + 1)
+
+
+def build_statistical_validity_report(
+    *,
+    selected_candidate_id: str | None,
+    bundles: Sequence[ArchivedTradingDayBundle],
+    trial_ledger: Mapping[str, Any],
+    data_sufficiency: Mapping[str, Any],
+    folds: Sequence[ArchiveWalkForwardFold],
+    profit_target_daily_net_usd: Decimal = Decimal('250'),
+    median_target_daily_net_usd: Decimal = Decimal('125'),
+    profitable_day_ratio_target: Decimal = Decimal('0.60'),
+    reality_check_bootstrap_replicates: int = _REALITY_CHECK_BOOTSTRAP_REPLICATES,
+    generated_at: datetime | None = None,
+) -> dict[str, Any]:
+    blockers: list[str] = []
+    if selected_candidate_id is None:
+        blockers.append('selected_candidate_missing')
+    selected_bundles = _proof_eligible_bundles(bundles, candidate_id=selected_candidate_id)
+    selected_by_day = {bundle.trading_day: bundle for bundle in selected_bundles}
+    if not folds:
+        blockers.append('walkforward_folds_unavailable')
+    test_day_values: list[Decimal] = []
+    for fold in folds:
+        for trading_day in fold.test_days:
+            bundle = selected_by_day.get(trading_day)
+            if bundle is not None:
+                test_day_values.append(bundle.net_pnl_estimated)
+    if not test_day_values:
+        blockers.append('walkforward_test_days_empty')
+
+    average_daily = _decimal_mean(test_day_values)
+    median_daily = _decimal_median(test_day_values)
+    profitable_ratio = _safe_decimal_ratio(
+        Decimal(sum(1 for value in test_day_values if value > 0)),
+        Decimal(len(test_day_values)),
+    )
+    after_cost_positive = sum(test_day_values, Decimal('0')) > 0
+
+    trial_count = _as_int(trial_ledger.get('trial_count'))
+    candidate_daily_net_pnl_by_day = _candidate_daily_net_pnl_by_day(bundles)
+    fold_rows = _fold_selection_rows(
+        candidate_daily_net_pnl_by_day=candidate_daily_net_pnl_by_day,
+        folds=folds,
+    )
+    pbo = _estimate_pbo(fold_rows)
+    selected_oos_days = sorted({day for fold in folds for day in fold.test_days if day in selected_by_day})
+    dsr_payload = _estimate_deflated_sharpe_ratio(
+        selected_values=test_day_values,
+        candidate_daily_net_pnl_by_day=candidate_daily_net_pnl_by_day,
+        oos_days=selected_oos_days,
+        trial_count=trial_count,
+    )
+    dsr = cast(float | None, dsr_payload.get('deflated_sharpe_ratio'))
+    dsr_z_score = cast(float | None, dsr_payload.get('deflated_sharpe_z_score'))
+    reality_check_p_value: float | None = None
+    if trial_count < 2:
+        blockers.append('selection_bias_metrics_unavailable_due_to_trial_count')
+    else:
+        reality_check_p_value = _estimate_reality_check_p_value(
+            candidate_daily_net_pnl_by_day=candidate_daily_net_pnl_by_day,
+            oos_days=selected_oos_days,
+            bootstrap_replicates=max(reality_check_bootstrap_replicates, 50),
+        )
+    if average_daily < profit_target_daily_net_usd:
+        blockers.append('average_daily_net_pnl_below_target')
+    if median_daily < median_target_daily_net_usd:
+        blockers.append('median_daily_net_pnl_below_target')
+    if profitable_ratio < profitable_day_ratio_target:
+        blockers.append('profitable_day_ratio_below_target')
+    if not after_cost_positive:
+        blockers.append('after_cost_net_pnl_not_positive')
+    if pbo is None:
+        blockers.append('pbo_unavailable')
+    elif pbo > 0.20:
+        blockers.append('pbo_above_threshold')
+    if dsr is None or dsr_z_score is None:
+        blockers.append('dsr_unavailable')
+    elif dsr_z_score <= 0:
+        blockers.append('dsr_below_threshold')
+    if reality_check_p_value is None:
+        blockers.append('reality_check_unavailable')
+    elif reality_check_p_value >= 0.05:
+        blockers.append('reality_check_p_value_above_threshold')
+    historical_gate_passed = not blockers
+
+    performance_degradation_beta = _fit_slope(
+        [float(row.get('is_avg_daily_net_pnl') or 0.0) for row in fold_rows],
+        [float(row.get('oos_avg_daily_net_pnl') or 0.0) for row in fold_rows],
+    )
+    probability_of_loss = None
+    if fold_rows:
+        probability_of_loss = sum(
+            1 for row in fold_rows if float(row.get('oos_avg_daily_net_pnl') or 0.0) < 0.0
+        ) / len(fold_rows)
+
+    return {
+        'schema_version': STATISTICAL_VALIDITY_SCHEMA_VERSION,
+        'generated_at': (generated_at or datetime.now(_UTC)).astimezone(_UTC).isoformat(),
+        'candidate_id': selected_candidate_id,
+        'status': 'passed' if historical_gate_passed else 'blocked',
+        'historical_gate_passed': historical_gate_passed,
+        'blockers': sorted(set(blockers)),
+        'proof_window': {
+            'fold_count': len(folds),
+            'folds': [fold.to_payload() for fold in folds],
+            'test_days': sorted({day for fold in folds for day in fold.test_days}),
+        },
+        'metrics': {
+            'average_daily_net_pnl': format(average_daily, 'f'),
+            'median_daily_net_pnl': format(median_daily, 'f'),
+            'profitable_day_ratio': format(profitable_ratio, 'f'),
+            'after_cost_net_pnl_positive': after_cost_positive,
+        },
+        'selection_bias_metrics': {
+            'trial_count': trial_count,
+            'fold_sample_size': len(fold_rows),
+            'pbo_method': 'forward_walk_relative_rank_logit',
+            'pbo': pbo,
+            'performance_degradation_beta': performance_degradation_beta,
+            'probability_of_loss': probability_of_loss,
+            'dsr_method': 'deflated_sharpe_ratio_daily_oos',
+            'dsr': dsr,
+            'dsr_z_score': dsr_z_score,
+            'selected_daily_sharpe_ratio': dsr_payload.get('selected_daily_sharpe_ratio'),
+            'benchmark_sharpe_threshold': dsr_payload.get('benchmark_sharpe_threshold'),
+            'reality_check_method': 'moving_block_bootstrap_max_mean',
+            'reality_check_p_value': reality_check_p_value,
+            'fold_rows': fold_rows,
+        },
+        'thresholds': {
+            'profit_target_daily_net_usd': format(profit_target_daily_net_usd, 'f'),
+            'median_target_daily_net_usd': format(median_target_daily_net_usd, 'f'),
+            'profitable_day_ratio_target': format(profitable_day_ratio_target, 'f'),
+            'pbo_max': '0.20',
+            'dsr_min': '0',
+            'reality_check_p_value_max': '0.05',
+        },
+        'data_sufficiency': dict(data_sufficiency),
+    }
+
+
+def build_profitability_certificate(
+    *,
+    selected_candidate_id: str | None,
+    data_sufficiency: Mapping[str, Any],
+    trial_ledger: Mapping[str, Any],
+    statistical_validity_report: Mapping[str, Any],
+    artifact_refs: Sequence[str],
+    profit_target_daily_net_usd: Decimal = Decimal('250'),
+    generated_at: datetime | None = None,
+) -> dict[str, Any]:
+    promotion_blockers = list(cast(list[str], statistical_validity_report.get('blockers') or []))
+    promotion_blockers.extend(
+        [str(item) for item in _as_list(data_sufficiency.get('blockers')) if str(item).strip()]
+    )
+    status = CERTIFICATE_STATUS_INSUFFICIENT_HISTORY
+    sufficiency_status = _as_text(data_sufficiency.get('status')) or SUFFICIENCY_STATUS_INSUFFICIENT_HISTORY
+    historical_gate_passed = bool(statistical_validity_report.get('historical_gate_passed', False))
+    if sufficiency_status == SUFFICIENCY_STATUS_RESEARCH_ONLY:
+        status = CERTIFICATE_STATUS_RESEARCH_ONLY
+    elif sufficiency_status == SUFFICIENCY_STATUS_HISTORICAL_READY:
+        status = (
+            CERTIFICATE_STATUS_HISTORICAL_PROVEN
+            if historical_gate_passed
+            else CERTIFICATE_STATUS_RESEARCH_ONLY
+        )
+    elif sufficiency_status == SUFFICIENCY_STATUS_PAPER_READY:
+        status = (
+            CERTIFICATE_STATUS_HISTORICAL_PROVEN
+            if historical_gate_passed
+            else CERTIFICATE_STATUS_RESEARCH_ONLY
+        )
+
+    return {
+        'schema_version': PROFITABILITY_CERTIFICATE_SCHEMA_VERSION,
+        'generated_at': (generated_at or datetime.now(_UTC)).astimezone(_UTC).isoformat(),
+        'status': status,
+        'candidate_id': selected_candidate_id,
+        'sleeve_ids': [selected_candidate_id] if selected_candidate_id else [],
+        'profit_target_daily_net_usd': format(profit_target_daily_net_usd, 'f'),
+        'data_sufficiency': dict(data_sufficiency),
+        'proof_window': dict(_as_dict(statistical_validity_report.get('proof_window'))),
+        'trial_count': _as_int(trial_ledger.get('trial_count')),
+        'promotion_blockers': sorted(set(promotion_blockers)),
+        'historical_metrics': dict(_as_dict(statistical_validity_report.get('metrics'))),
+        'paper_metrics': {},
+        'execution_realism_summary': {},
+        'dataset_snapshot_refs': sorted(
+            {
+                str(ref)
+                for entry in _as_list(trial_ledger.get('entries'))
+                for ref in _as_list(_as_dict(entry).get('dataset_snapshot_refs'))
+                if str(ref).strip()
+            }
+        ),
+        'artifact_refs': sorted({str(path) for path in artifact_refs if str(path).strip()}),
+    }
+
+
+def _min_retention_days(bundles: Sequence[ArchivedTradingDayBundle]) -> int | None:
+    days: list[int] = []
+    for bundle in bundles:
+        raw = _as_dict(bundle.market_day_inventory.get('source_topic_retention_ms_by_topic'))
+        for value in raw.values():
+            retention_ms = _as_int(value)
+            if retention_ms > 0:
+                days.append(max(retention_ms // 86_400_000, 0))
+    if not days:
+        return None
+    return min(days)
+
+
+def _missing_business_days(trading_days: Sequence[str]) -> list[str]:
+    if not trading_days:
+        return []
+    ordered = sorted({date.fromisoformat(item) for item in trading_days})
+    missing: list[str] = []
+    cursor = ordered[0]
+    end = ordered[-1]
+    available = set(ordered)
+    while cursor <= end:
+        if cursor.weekday() < 5 and cursor not in available:
+            missing.append(cursor.isoformat())
+        cursor += timedelta(days=1)
+    return missing
+
+
+def _decimal_mean(values: Sequence[Decimal]) -> Decimal:
+    if not values:
+        return Decimal('0')
+    return sum(values, Decimal('0')) / Decimal(len(values))
+
+
+def _decimal_median(values: Sequence[Decimal]) -> Decimal:
+    if not values:
+        return Decimal('0')
+    ordered = sorted(values)
+    midpoint = len(ordered) // 2
+    if len(ordered) % 2 == 1:
+        return ordered[midpoint]
+    return (ordered[midpoint - 1] + ordered[midpoint]) / Decimal('2')
+
+
+def _safe_decimal_ratio(numerator: Decimal, denominator: Decimal) -> Decimal:
+    if denominator <= 0:
+        return Decimal('0')
+    return numerator / denominator
+
+
+def _mean_optional_floats(values: Sequence[float | None]) -> float | None:
+    resolved = [value for value in values if value is not None]
+    if not resolved:
+        return None
+    return sum(resolved) / len(resolved)
+
+
+__all__ = [
+    'ARCHIVE_STATUS_ARCHIVED',
+    'ARCHIVE_STATUS_INSUFFICIENT',
+    'ARCHIVE_STATUS_PARTIAL',
+    'ArchiveWalkForwardFold',
+    'ArchivedTradingDayBundle',
+    'CERTIFICATE_STATUS_HISTORICAL_PROVEN',
+    'CERTIFICATE_STATUS_INSUFFICIENT_HISTORY',
+    'CERTIFICATE_STATUS_LIVE_CAPPED',
+    'CERTIFICATE_STATUS_LIVE_FULL',
+    'CERTIFICATE_STATUS_PAPER_PROVEN',
+    'CERTIFICATE_STATUS_RESEARCH_ONLY',
+    'DATA_SUFFICIENCY_SCHEMA_VERSION',
+    'EXECUTION_DAY_INVENTORY_SCHEMA_VERSION',
+    'MARKET_DAY_INVENTORY_SCHEMA_VERSION',
+    'PROFITABILITY_CERTIFICATE_SCHEMA_VERSION',
+    'REPLAY_DAY_MANIFEST_SCHEMA_VERSION',
+    'STATISTICAL_VALIDITY_SCHEMA_VERSION',
+    'SUFFICIENCY_STATUS_HISTORICAL_READY',
+    'SUFFICIENCY_STATUS_INSUFFICIENT_HISTORY',
+    'SUFFICIENCY_STATUS_PAPER_READY',
+    'SUFFICIENCY_STATUS_RESEARCH_ONLY',
+    'TRIAL_LEDGER_SCHEMA_VERSION',
+    'archive_historical_simulation_run',
+    'build_execution_day_inventory',
+    'build_market_day_inventory',
+    'build_profitability_certificate',
+    'build_replay_day_manifest',
+    'build_statistical_validity_report',
+    'build_trial_ledger',
+    'collect_simulation_postgres_counts',
+    'copy_archive_artifacts',
+    'generate_archive_walkforward_folds',
+    'load_archived_trading_day_bundles',
+    'summarize_data_sufficiency',
+    'upsert_dataset_snapshot',
+]

--- a/services/torghut/app/trading/research_sleeves.py
+++ b/services/torghut/app/trading/research_sleeves.py
@@ -1,0 +1,494 @@
+"""Research-backed intraday sleeve evaluations for the March profitability program."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Any, Literal, Mapping
+
+
+@dataclass(frozen=True)
+class SleeveSignalEvaluation:
+    action: Literal['buy', 'sell']
+    confidence: Decimal
+    rationale: tuple[str, ...]
+
+
+def evaluate_momentum_pullback_long(
+    *,
+    params: Mapping[str, Any],
+    event_ts: str,
+    price: Decimal | None,
+    ema12: Decimal | None,
+    ema26: Decimal | None,
+    macd: Decimal | None,
+    macd_signal: Decimal | None,
+    rsi14: Decimal | None,
+    vol_realized_w60s: Decimal | None,
+    spread: Decimal | None,
+    imbalance_bid_sz: Decimal | None,
+    imbalance_ask_sz: Decimal | None,
+) -> SleeveSignalEvaluation | None:
+    if (
+        price is None
+        or ema12 is None
+        or ema26 is None
+        or macd is None
+        or macd_signal is None
+        or rsi14 is None
+    ):
+        return None
+
+    ts = _parse_event_ts(event_ts)
+    if not _within_utc_window(
+        ts,
+        start_minute=_minute_param(params, 'entry_start_minute_utc', 14 * 60),
+        end_minute=_effective_entry_end_minute(
+            params,
+            default_end_minute=19 * 60 + 50,
+        ),
+    ):
+        return None
+
+    macd_hist = macd - macd_signal
+    price_vs_ema12_bps = _bps_delta(price, ema12)
+    spread_bps = _spread_bps(price, spread)
+    imbalance_pressure = _imbalance_pressure(imbalance_bid_sz, imbalance_ask_sz)
+
+    bullish_hist_min = _decimal_param(params, 'bullish_hist_min', Decimal('0.01'))
+    bullish_hist_cap = _decimal_param(params, 'bullish_hist_cap', Decimal('0.09'))
+    min_bull_rsi = _decimal_param(params, 'min_bull_rsi', Decimal('54'))
+    max_bull_rsi = _decimal_param(params, 'max_bull_rsi', Decimal('66'))
+    min_pullback_bps = _decimal_param(params, 'min_price_below_ema12_bps', Decimal('1'))
+    max_pullback_bps = _decimal_param(params, 'max_price_below_ema12_bps', Decimal('18'))
+    spread_cap_bps = _decimal_param(params, 'max_spread_bps', Decimal('7'))
+    imbalance_floor = _decimal_param(params, 'min_imbalance_pressure', Decimal('-0.05'))
+    vol_floor = _optional_decimal_param(params, 'vol_floor', Decimal('0.00003'))
+    vol_ceil = _optional_decimal_param(params, 'vol_ceil', Decimal('0.00035'))
+
+    if (
+        ema12 > ema26
+        and bullish_hist_min <= macd_hist <= bullish_hist_cap
+        and min_bull_rsi <= rsi14 <= max_bull_rsi
+        and -max_pullback_bps <= price_vs_ema12_bps <= -min_pullback_bps
+        and spread_bps <= spread_cap_bps
+        and imbalance_pressure >= imbalance_floor
+        and _vol_within_band(vol_realized_w60s, floor=vol_floor, ceil=vol_ceil)
+    ):
+        confidence = Decimal('0.66')
+        if imbalance_pressure > Decimal('0.05'):
+            confidence += Decimal('0.03')
+        if price_vs_ema12_bps <= -Decimal('4'):
+            confidence += Decimal('0.02')
+        return SleeveSignalEvaluation(
+            action='buy',
+            confidence=min(confidence, Decimal('0.82')),
+            rationale=(
+                'momentum_pullback_long',
+                'trend_up',
+                'pullback_entry',
+                'spread_ok',
+            ),
+        )
+
+    if (
+        ema12 < ema26
+        and macd_hist <= _decimal_param(params, 'exit_macd_hist_max', Decimal('-0.002'))
+        and rsi14 <= _decimal_param(params, 'exit_rsi_max', Decimal('49'))
+    ):
+        return SleeveSignalEvaluation(
+            action='sell',
+            confidence=Decimal('0.63'),
+            rationale=(
+                'momentum_pullback_exit',
+                'trend_lost',
+                'momentum_rollover',
+            ),
+        )
+    return None
+
+
+def evaluate_breakout_continuation_long(
+    *,
+    params: Mapping[str, Any],
+    event_ts: str,
+    price: Decimal | None,
+    ema12: Decimal | None,
+    ema26: Decimal | None,
+    macd: Decimal | None,
+    macd_signal: Decimal | None,
+    rsi14: Decimal | None,
+    vol_realized_w60s: Decimal | None,
+    vwap_session: Decimal | None,
+    spread: Decimal | None,
+    imbalance_bid_sz: Decimal | None,
+    imbalance_ask_sz: Decimal | None,
+) -> SleeveSignalEvaluation | None:
+    if (
+        price is None
+        or ema12 is None
+        or ema26 is None
+        or macd is None
+        or macd_signal is None
+        or rsi14 is None
+    ):
+        return None
+
+    ts = _parse_event_ts(event_ts)
+    if not _within_utc_window(
+        ts,
+        start_minute=_minute_param(params, 'entry_start_minute_utc', 14 * 60 + 15),
+        end_minute=_effective_entry_end_minute(
+            params,
+            default_end_minute=19 * 60 + 45,
+        ),
+    ):
+        return None
+
+    macd_hist = macd - macd_signal
+    price_vs_ema12_bps = _bps_delta(price, ema12)
+    price_vs_vwap_bps = _bps_delta(price, vwap_session) if vwap_session is not None else price_vs_ema12_bps
+    spread_bps = _spread_bps(price, spread)
+    imbalance_pressure = _imbalance_pressure(imbalance_bid_sz, imbalance_ask_sz)
+    price_below_ema12 = price < ema12
+    price_below_vwap = vwap_session is not None and price < vwap_session
+
+    if (
+        ema12 > ema26
+        and macd_hist >= _decimal_param(params, 'bullish_hist_min', Decimal('0.008'))
+        and _decimal_param(params, 'min_bull_rsi', Decimal('58')) <= rsi14 <= _decimal_param(params, 'max_bull_rsi', Decimal('72'))
+        and _decimal_param(params, 'min_price_above_ema12_bps', Decimal('0')) <= price_vs_ema12_bps <= _decimal_param(params, 'max_price_above_ema12_bps', Decimal('16'))
+        and _decimal_param(params, 'min_price_above_vwap_bps', Decimal('0')) <= price_vs_vwap_bps <= _decimal_param(params, 'max_price_above_vwap_bps', Decimal('30'))
+        and spread_bps <= _decimal_param(params, 'max_spread_bps', Decimal('6'))
+        and imbalance_pressure >= _decimal_param(params, 'min_imbalance_pressure', Decimal('0'))
+        and _vol_within_band(
+            vol_realized_w60s,
+            floor=_optional_decimal_param(params, 'vol_floor', Decimal('0.00004')),
+            ceil=_optional_decimal_param(params, 'vol_ceil', Decimal('0.00040')),
+        )
+    ):
+        confidence = Decimal('0.68')
+        if price_vs_vwap_bps >= Decimal('4'):
+            confidence += Decimal('0.03')
+        if imbalance_pressure >= Decimal('0.08'):
+            confidence += Decimal('0.03')
+        return SleeveSignalEvaluation(
+            action='buy',
+            confidence=min(confidence, Decimal('0.86')),
+            rationale=(
+                'breakout_continuation_long',
+                'trend_up',
+                'above_vwap',
+                'imbalance_confirmed',
+            ),
+        )
+
+    exit_macd_hist_max = _decimal_param(params, 'exit_macd_hist_max', Decimal('-0.003'))
+    exit_rsi_max = _decimal_param(params, 'exit_rsi_max', Decimal('56'))
+    breakout_failure_confirmed = (
+        (price_below_ema12 and price_below_vwap)
+        or (
+            macd_hist <= exit_macd_hist_max
+            and rsi14 <= exit_rsi_max
+            and (price_below_ema12 or price_below_vwap)
+        )
+    )
+    if breakout_failure_confirmed:
+        return SleeveSignalEvaluation(
+            action='sell',
+            confidence=Decimal('0.62'),
+            rationale=(
+                'breakout_continuation_exit',
+                'breakout_failed',
+            ),
+        )
+    return None
+
+
+def evaluate_mean_reversion_rebound_long(
+    *,
+    params: Mapping[str, Any],
+    event_ts: str,
+    price: Decimal | None,
+    ema12: Decimal | None,
+    macd: Decimal | None,
+    macd_signal: Decimal | None,
+    rsi14: Decimal | None,
+    vol_realized_w60s: Decimal | None,
+    vwap_session: Decimal | None,
+    spread: Decimal | None,
+    imbalance_bid_sz: Decimal | None,
+    imbalance_ask_sz: Decimal | None,
+) -> SleeveSignalEvaluation | None:
+    if (
+        price is None
+        or ema12 is None
+        or macd is None
+        or macd_signal is None
+        or rsi14 is None
+    ):
+        return None
+
+    ts = _parse_event_ts(event_ts)
+    if not _within_utc_window(
+        ts,
+        start_minute=_minute_param(params, 'entry_start_minute_utc', 14 * 60),
+        end_minute=_effective_entry_end_minute(
+            params,
+            default_end_minute=18 * 60 + 45,
+        ),
+    ):
+        return None
+
+    macd_hist = macd - macd_signal
+    price_vs_ema12_bps = _bps_delta(price, ema12)
+    price_vs_vwap_bps = _bps_delta(price, vwap_session) if vwap_session is not None else price_vs_ema12_bps
+    spread_bps = _spread_bps(price, spread)
+    imbalance_pressure = _imbalance_pressure(imbalance_bid_sz, imbalance_ask_sz)
+
+    if (
+        _decimal_param(params, 'min_price_below_vwap_bps', Decimal('8')) <= -price_vs_vwap_bps <= _decimal_param(params, 'max_price_below_vwap_bps', Decimal('70'))
+        and _decimal_param(params, 'min_price_below_ema12_bps', Decimal('2')) <= -price_vs_ema12_bps <= _decimal_param(params, 'max_price_below_ema12_bps', Decimal('35'))
+        and _decimal_param(params, 'min_bull_rsi', Decimal('40')) <= rsi14 <= _decimal_param(params, 'max_bull_rsi', Decimal('52'))
+        and _decimal_param(params, 'bullish_hist_min', Decimal('0.002')) <= macd_hist <= _decimal_param(params, 'bullish_hist_cap', Decimal('0.05'))
+        and spread_bps <= _decimal_param(params, 'max_spread_bps', Decimal('8'))
+        and imbalance_pressure >= _decimal_param(params, 'min_imbalance_pressure', Decimal('0'))
+        and _vol_within_band(
+            vol_realized_w60s,
+            floor=_optional_decimal_param(params, 'vol_floor', Decimal('0.00005')),
+            ceil=_optional_decimal_param(params, 'vol_ceil', Decimal('0.00055')),
+        )
+    ):
+        confidence = Decimal('0.64')
+        if -price_vs_vwap_bps >= Decimal('16'):
+            confidence += Decimal('0.03')
+        if imbalance_pressure >= Decimal('0.06'):
+            confidence += Decimal('0.02')
+        return SleeveSignalEvaluation(
+            action='buy',
+            confidence=min(confidence, Decimal('0.81')),
+            rationale=(
+                'mean_reversion_rebound_long',
+                'oversold_rebound',
+                'below_vwap',
+                'spread_normalized',
+            ),
+        )
+
+    if (
+        (vwap_session is not None and price >= vwap_session)
+        or (vwap_session is None and price >= ema12)
+        or rsi14 >= _decimal_param(params, 'exit_rsi_min', Decimal('61'))
+        or macd_hist <= _decimal_param(params, 'exit_macd_hist_max', Decimal('-0.002'))
+    ):
+        return SleeveSignalEvaluation(
+            action='sell',
+            confidence=Decimal('0.61'),
+            rationale=(
+                'mean_reversion_rebound_exit',
+                'rebound_complete',
+            ),
+        )
+    return None
+
+
+def evaluate_late_day_continuation_long(
+    *,
+    params: Mapping[str, Any],
+    event_ts: str,
+    price: Decimal | None,
+    ema12: Decimal | None,
+    ema26: Decimal | None,
+    macd: Decimal | None,
+    macd_signal: Decimal | None,
+    rsi14: Decimal | None,
+    vol_realized_w60s: Decimal | None,
+    vwap_session: Decimal | None,
+    spread: Decimal | None,
+    imbalance_bid_sz: Decimal | None,
+    imbalance_ask_sz: Decimal | None,
+) -> SleeveSignalEvaluation | None:
+    if (
+        price is None
+        or ema12 is None
+        or ema26 is None
+        or macd is None
+        or macd_signal is None
+        or rsi14 is None
+    ):
+        return None
+
+    ts = _parse_event_ts(event_ts)
+    if not _within_utc_window(
+        ts,
+        start_minute=_minute_param(params, 'entry_start_minute_utc', 18 * 60 + 15),
+        end_minute=_effective_entry_end_minute(
+            params,
+            default_end_minute=19 * 60 + 20,
+        ),
+    ):
+        return None
+
+    macd_hist = macd - macd_signal
+    price_vs_ema12_bps = _bps_delta(price, ema12)
+    price_vs_vwap_bps = _bps_delta(price, vwap_session) if vwap_session is not None else price_vs_ema12_bps
+    spread_bps = _spread_bps(price, spread)
+    imbalance_pressure = _imbalance_pressure(imbalance_bid_sz, imbalance_ask_sz)
+    price_below_ema12 = price < ema12
+    price_below_vwap = vwap_session is not None and price < vwap_session
+
+    if (
+        ema12 > ema26
+        and _decimal_param(params, 'bullish_hist_min', Decimal('0.006')) <= macd_hist <= _decimal_param(params, 'bullish_hist_cap', Decimal('0.05'))
+        and _decimal_param(params, 'min_bull_rsi', Decimal('57')) <= rsi14 <= _decimal_param(params, 'max_bull_rsi', Decimal('72'))
+        and _decimal_param(params, 'min_price_above_ema12_bps', Decimal('0')) <= price_vs_ema12_bps <= _decimal_param(params, 'max_price_above_ema12_bps', Decimal('14'))
+        and _decimal_param(params, 'min_price_above_vwap_bps', Decimal('2')) <= price_vs_vwap_bps <= _decimal_param(params, 'max_price_above_vwap_bps', Decimal('20'))
+        and spread_bps <= _decimal_param(params, 'max_spread_bps', Decimal('6'))
+        and imbalance_pressure >= _decimal_param(params, 'min_imbalance_pressure', Decimal('-0.01'))
+        and _vol_within_band(
+            vol_realized_w60s,
+            floor=_optional_decimal_param(params, 'vol_floor', Decimal('0.00005')),
+            ceil=_optional_decimal_param(params, 'vol_ceil', Decimal('0.00035')),
+        )
+    ):
+        confidence = Decimal('0.69')
+        if price_vs_vwap_bps >= Decimal('6'):
+            confidence += Decimal('0.03')
+        if spread_bps <= Decimal('3'):
+            confidence += Decimal('0.02')
+        if imbalance_pressure >= Decimal('0.04'):
+            confidence += Decimal('0.02')
+        return SleeveSignalEvaluation(
+            action='buy',
+            confidence=min(confidence, Decimal('0.87')),
+            rationale=(
+                'late_day_continuation_long',
+                'trend_up',
+                'late_day_strength',
+                'close_auction_setup',
+            ),
+        )
+
+    if (
+        (price_below_ema12 and price_below_vwap)
+        or (
+            macd_hist <= _decimal_param(params, 'exit_macd_hist_max', Decimal('-0.004'))
+            and rsi14 <= _decimal_param(params, 'exit_rsi_max', Decimal('55'))
+        )
+    ):
+        return SleeveSignalEvaluation(
+            action='sell',
+            confidence=Decimal('0.63'),
+            rationale=(
+                'late_day_continuation_exit',
+                'late_day_failure',
+            ),
+        )
+    return None
+
+
+def _parse_event_ts(raw: str) -> datetime:
+    normalized = raw.replace('Z', '+00:00')
+    parsed = datetime.fromisoformat(normalized)
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _minute_param(params: Mapping[str, Any], key: str, default: int) -> int:
+    raw = params.get(key)
+    if raw is None:
+        return default
+    try:
+        return int(str(raw))
+    except (TypeError, ValueError):
+        return default
+
+
+def _optional_minute_param(params: Mapping[str, Any], key: str) -> int | None:
+    raw = params.get(key)
+    if raw is None:
+        return None
+    try:
+        return int(str(raw))
+    except (TypeError, ValueError):
+        return None
+
+
+def _decimal_param(params: Mapping[str, Any], key: str, default: Decimal) -> Decimal:
+    raw = params.get(key)
+    if raw is None:
+        return default
+    try:
+        return Decimal(str(raw))
+    except Exception:
+        return default
+
+
+def _optional_decimal_param(params: Mapping[str, Any], key: str, default: Decimal | None) -> Decimal | None:
+    raw = params.get(key)
+    if raw is None:
+        return default
+    try:
+        return Decimal(str(raw))
+    except Exception:
+        return default
+
+
+def _within_utc_window(ts: datetime, *, start_minute: int, end_minute: int) -> bool:
+    minute = ts.hour * 60 + ts.minute
+    return start_minute <= minute <= end_minute
+
+
+def _effective_entry_end_minute(
+    params: Mapping[str, Any],
+    *,
+    default_end_minute: int,
+) -> int:
+    entry_end_minute = _minute_param(params, 'entry_end_minute_utc', default_end_minute)
+    flatten_start_minute = _optional_minute_param(params, 'session_flatten_start_minute_utc')
+    min_entry_minutes_before_flatten = _minute_param(
+        params,
+        'min_entry_minutes_before_flatten',
+        15,
+    )
+    if flatten_start_minute is None or min_entry_minutes_before_flatten <= 0:
+        return entry_end_minute
+    return min(entry_end_minute, flatten_start_minute - min_entry_minutes_before_flatten)
+
+
+def _bps_delta(price: Decimal, reference: Decimal) -> Decimal:
+    if reference == 0:
+        return Decimal('0')
+    return ((price - reference) / reference) * Decimal('10000')
+
+
+def _spread_bps(price: Decimal, spread: Decimal | None) -> Decimal:
+    if spread is None or price <= 0:
+        return Decimal('0')
+    return (spread / price) * Decimal('10000')
+
+
+def _imbalance_pressure(bid_sz: Decimal | None, ask_sz: Decimal | None) -> Decimal:
+    if bid_sz is None or ask_sz is None:
+        return Decimal('0')
+    total = bid_sz + ask_sz
+    if total <= 0:
+        return Decimal('0')
+    return (bid_sz - ask_sz) / total
+
+
+def _vol_within_band(
+    value: Decimal | None,
+    *,
+    floor: Decimal | None,
+    ceil: Decimal | None,
+) -> bool:
+    if value is None:
+        return True
+    if floor is not None and value < floor:
+        return False
+    if ceil is not None and value > ceil:
+        return False
+    return True

--- a/services/torghut/app/trading/scheduler/pipeline.py
+++ b/services/torghut/app/trading/scheduler/pipeline.py
@@ -96,6 +96,7 @@ from .pipeline_helpers import (
     _optional_decimal,
     _optional_int,
     _price_snapshot_payload,
+    _project_open_orders_onto_positions,
     _resolve_decision_regime_label_with_source,
     _resolve_llm_review_error_reject_reason,
     _resolve_llm_unavailable_reject_reason,
@@ -408,45 +409,90 @@ class TradingPipeline:
         self,
         snapshot_positions: list[dict[str, Any]],
     ) -> list[dict[str, Any]]:
+        normalized_positions = _clone_positions(snapshot_positions)
         seed_snapshot = getattr(self.execution_adapter, "seed_positions_snapshot", None)
-        if not callable(seed_snapshot):
-            return _clone_positions(snapshot_positions)
+        if callable(seed_snapshot):
+            try:
+                seed_snapshot(_clone_positions(snapshot_positions))
+            except Exception as exc:
+                logger.warning(
+                    "Failed to seed simulation execution positions account=%s error=%s",
+                    self.account_label,
+                    exc,
+                )
+            else:
+                list_positions = getattr(self.execution_adapter, "list_positions", None)
+                if callable(list_positions):
+                    try:
+                        seeded_positions = list_positions()
+                    except Exception as exc:
+                        logger.warning(
+                            "Failed to read simulation execution positions account=%s error=%s",
+                            self.account_label,
+                            exc,
+                        )
+                    else:
+                        if isinstance(seeded_positions, list):
+                            normalized_positions: list[dict[str, Any]] = []
+                            for raw_position in cast(list[Any], seeded_positions):
+                                if not isinstance(raw_position, Mapping):
+                                    continue
+                                normalized_positions.append(
+                                    {
+                                        str(key): value
+                                        for key, value in cast(Mapping[object, Any], raw_position).items()
+                                    }
+                                )
+        projected_open_orders = self._resolve_execution_context_open_orders()
+        if projected_open_orders:
+            projected_count = _project_open_orders_onto_positions(
+                normalized_positions,
+                projected_open_orders,
+            )
+            if projected_count > 0:
+                logger.info(
+                    "Projected open-order exposure into execution context account=%s orders=%s",
+                    self.account_label,
+                    projected_count,
+                )
+        return normalized_positions
+
+    def _resolve_execution_context_open_orders(self) -> list[dict[str, Any]]:
+        list_orders = getattr(self.execution_adapter, "list_orders", None)
+        if not callable(list_orders):
+            return []
         try:
-            seed_snapshot(_clone_positions(snapshot_positions))
+            raw_orders = list_orders(status="open")
+        except TypeError:
+            try:
+                raw_orders = list_orders()
+            except Exception as exc:
+                logger.warning(
+                    "Failed to read execution open orders account=%s error=%s",
+                    self.account_label,
+                    exc,
+                )
+                return []
         except Exception as exc:
             logger.warning(
-                "Failed to seed simulation execution positions account=%s error=%s",
+                "Failed to read execution open orders account=%s error=%s",
                 self.account_label,
                 exc,
             )
-            return _clone_positions(snapshot_positions)
-
-        list_positions = getattr(self.execution_adapter, "list_positions", None)
-        if not callable(list_positions):
-            return _clone_positions(snapshot_positions)
-        try:
-            seeded_positions = list_positions()
-        except Exception as exc:
-            logger.warning(
-                "Failed to read simulation execution positions account=%s error=%s",
-                self.account_label,
-                exc,
-            )
-            return _clone_positions(snapshot_positions)
-        if not isinstance(seeded_positions, list):
-            return _clone_positions(snapshot_positions)
-
-        normalized_positions: list[dict[str, Any]] = []
-        for raw_position in cast(list[Any], seeded_positions):
-            if not isinstance(raw_position, Mapping):
+            return []
+        if not isinstance(raw_orders, list):
+            return []
+        normalized_orders: list[dict[str, Any]] = []
+        for raw_order in cast(list[Any], raw_orders):
+            if not isinstance(raw_order, Mapping):
                 continue
-            normalized_positions.append(
+            normalized_orders.append(
                 {
                     str(key): value
-                    for key, value in cast(Mapping[object, Any], raw_position).items()
+                    for key, value in cast(Mapping[object, Any], raw_order).items()
                 }
             )
-        return normalized_positions
+        return normalized_orders
 
     def _process_batch_signals(
         self,

--- a/services/torghut/app/trading/scheduler/pipeline_helpers.py
+++ b/services/torghut/app/trading/scheduler/pipeline_helpers.py
@@ -9,7 +9,7 @@ import logging
 from collections.abc import Mapping
 from datetime import datetime, timezone
 from decimal import Decimal
-from typing import Any, Optional, cast
+from typing import Any, Literal, Optional, cast
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
@@ -34,6 +34,9 @@ from .state import (
 
 logger = logging.getLogger(__name__)
 _RUNTIME_UNCERTAINTY_GATE_MAX_STALENESS_SECONDS = 15 * 60
+_PROJECTED_ORDER_ACTIONS = {"buy", "sell"}
+_PROJECTED_ORDER_TYPES = {"market", "limit", "stop", "stop_limit"}
+_PROJECTED_ORDER_TIME_IN_FORCE = {"day", "gtc", "ioc", "fok"}
 
 def _runtime_uncertainty_gate_rank(action: RuntimeUncertaintyGateAction) -> int:
     ranking: dict[RuntimeUncertaintyGateAction, int] = {
@@ -543,6 +546,59 @@ def _apply_projected_position_decision(
     positions.append(projected_position)
 
 
+def _project_open_orders_onto_positions(
+    positions: list[dict[str, Any]],
+    open_orders: list[dict[str, Any]],
+) -> int:
+    projected_total = 0
+    projection_ts = datetime.now(timezone.utc)
+    for order in open_orders:
+        symbol = str(order.get("symbol") or "").strip().upper()
+        side = str(order.get("side") or "").strip().lower()
+        if not symbol or side not in {"buy", "sell"}:
+            continue
+        qty = _optional_decimal(order.get("qty"))
+        filled_qty = _optional_decimal(order.get("filled_qty")) or Decimal("0")
+        if qty is None or qty <= 0:
+            continue
+        remaining_qty = qty - max(filled_qty, Decimal("0"))
+        if remaining_qty <= 0:
+            continue
+        price = (
+            _optional_decimal(order.get("limit_price"))
+            or _optional_decimal(order.get("stop_price"))
+            or _optional_decimal(order.get("notional_price"))
+        )
+        params: dict[str, Any] = {}
+        if price is not None:
+            params["price"] = str(price)
+        action = str(side).strip().lower()
+        if action not in _PROJECTED_ORDER_ACTIONS:
+            continue
+        order_type = str(order.get("type") or order.get("order_type") or "market").strip().lower()
+        if order_type not in _PROJECTED_ORDER_TYPES:
+            order_type = "market"
+        time_in_force = str(order.get("time_in_force") or "day").strip().lower()
+        if time_in_force not in _PROJECTED_ORDER_TIME_IN_FORCE:
+            time_in_force = "day"
+        projected_total += 1
+        _apply_projected_position_decision(
+            positions,
+            StrategyDecision(
+                strategy_id="open_order_projection",
+                symbol=symbol,
+                event_ts=projection_ts,
+                timeframe="open_order",
+                action=cast(Literal["buy", "sell"], action),
+                qty=remaining_qty,
+                order_type=cast(Literal["market", "limit", "stop", "stop_limit"], order_type),
+                time_in_force=cast(Literal["day", "gtc", "ioc", "fok"], time_in_force),
+                params=params,
+            ),
+        )
+    return projected_total
+
+
 def _is_runtime_risk_increasing_entry(
     decision: StrategyDecision,
     positions: list[dict[str, Any]],
@@ -821,6 +877,7 @@ __all__ = [
     "_position_market_value",
     "_position_qty",
     "_price_snapshot_payload",
+    "_project_open_orders_onto_positions",
     "_resolve_decision_regime_label",
     "_resolve_decision_regime_label_with_source",
     "_resolve_llm_review_error_reject_reason",

--- a/services/torghut/app/trading/strategy_runtime.py
+++ b/services/torghut/app/trading/strategy_runtime.py
@@ -383,6 +383,7 @@ class IntradayTsmomPlugin:
     ) -> StrategyIntent | None:
         ema12 = _decimal(features.values.get("ema12"))
         ema26 = _decimal(features.values.get("ema26"))
+        price = _decimal(features.values.get("price"))
         macd = _decimal(features.values.get("macd"))
         macd_signal = _decimal(features.values.get("macd_signal"))
         rsi14 = _decimal(features.values.get("rsi14"))
@@ -390,6 +391,7 @@ class IntradayTsmomPlugin:
         evaluation = evaluate_intraday_tsmom_signal(
             timeframe=context.timeframe,
             params=context.params,
+            price=price,
             ema12=ema12,
             ema26=ema26,
             macd=macd,

--- a/services/torghut/app/trading/strategy_runtime.py
+++ b/services/torghut/app/trading/strategy_runtime.py
@@ -15,6 +15,12 @@ from ..models import Strategy
 from ..strategies.catalog import extract_catalog_metadata
 from .features import FeatureVectorV3, validate_declared_features
 from .intraday_tsmom_contract import evaluate_intraday_tsmom_signal
+from .research_sleeves import (
+    evaluate_breakout_continuation_long,
+    evaluate_late_day_continuation_long,
+    evaluate_mean_reversion_rebound_long,
+    evaluate_momentum_pullback_long,
+)
 from .strategy_specs import build_compiled_strategy_artifacts, strategy_type_supports_spec_v2
 
 
@@ -35,6 +41,7 @@ class StrategyDefinition:
     execution_profile: str
     enabled: bool
     base_timeframe: str
+    universe_symbols: tuple[str, ...] = field(default_factory=tuple)
     compiler_source: str = "legacy_runtime"
     strategy_spec: dict[str, Any] = field(default_factory=_empty_meta)
     compiled_targets: dict[str, Any] = field(default_factory=_empty_meta)
@@ -191,6 +198,10 @@ class StrategyRegistry:
         plugin_map = plugins or {
             "legacy_macd_rsi": LegacyMacdRsiPlugin(),
             "intraday_tsmom_v1": IntradayTsmomPlugin(),
+            "momentum_pullback_long_v1": MomentumPullbackLongPlugin(),
+            "breakout_continuation_long_v1": BreakoutContinuationLongPlugin(),
+            "mean_reversion_rebound_long_v1": MeanReversionReboundLongPlugin(),
+            "late_day_continuation_long_v1": LateDayContinuationLongPlugin(),
         }
         self._by_key: dict[tuple[str, str], StrategyPlugin] = {}
         self._type_alias: dict[str, tuple[str, str]] = {}
@@ -391,7 +402,9 @@ class IntradayTsmomPlugin:
         evaluation = evaluate_intraday_tsmom_signal(
             timeframe=context.timeframe,
             params=context.params,
+            event_ts=context.event_ts,
             price=price,
+            spread=_decimal(features.values.get("spread")),
             ema12=ema12,
             ema26=ema26,
             macd=macd,
@@ -418,6 +431,194 @@ class IntradayTsmomPlugin:
         )
 
 
+class MomentumPullbackLongPlugin:
+    plugin_id = "momentum_pullback_long"
+    version = "1.0.0"
+    required_features: tuple[str, ...] = (
+        "price",
+        "ema12",
+        "ema26",
+        "macd",
+        "macd_signal",
+        "rsi14",
+        "vol_realized_w60s",
+        "spread",
+    )
+
+    def evaluate(
+        self, context: StrategyContext, features: FeatureVectorV3
+    ) -> StrategyIntent | None:
+        evaluation = evaluate_momentum_pullback_long(
+            params=context.params,
+            event_ts=context.event_ts,
+            price=_decimal(features.values.get("price")),
+            ema12=_decimal(features.values.get("ema12")),
+            ema26=_decimal(features.values.get("ema26")),
+            macd=_decimal(features.values.get("macd")),
+            macd_signal=_decimal(features.values.get("macd_signal")),
+            rsi14=_decimal(features.values.get("rsi14")),
+            vol_realized_w60s=_decimal(features.values.get("vol_realized_w60s")),
+            spread=_decimal(features.values.get("spread")),
+            imbalance_bid_sz=_decimal(features.values.get("imbalance_bid_sz")),
+            imbalance_ask_sz=_decimal(features.values.get("imbalance_ask_sz")),
+        )
+        if evaluation is None:
+            return None
+        return StrategyIntent(
+            strategy_id=context.strategy_id,
+            symbol=context.symbol,
+            direction=evaluation.action,
+            confidence=evaluation.confidence,
+            target_notional=_target_notional(context.params),
+            horizon=context.timeframe,
+            explain=evaluation.rationale,
+            feature_snapshot_hash=features.normalization_hash,
+            required_features=self.required_features,
+        )
+
+
+class BreakoutContinuationLongPlugin:
+    plugin_id = "breakout_continuation_long"
+    version = "1.0.0"
+    required_features: tuple[str, ...] = (
+        "price",
+        "ema12",
+        "ema26",
+        "macd",
+        "macd_signal",
+        "rsi14",
+        "vol_realized_w60s",
+        "spread",
+    )
+
+    def evaluate(
+        self, context: StrategyContext, features: FeatureVectorV3
+    ) -> StrategyIntent | None:
+        evaluation = evaluate_breakout_continuation_long(
+            params=context.params,
+            event_ts=context.event_ts,
+            price=_decimal(features.values.get("price")),
+            ema12=_decimal(features.values.get("ema12")),
+            ema26=_decimal(features.values.get("ema26")),
+            macd=_decimal(features.values.get("macd")),
+            macd_signal=_decimal(features.values.get("macd_signal")),
+            rsi14=_decimal(features.values.get("rsi14")),
+            vol_realized_w60s=_decimal(features.values.get("vol_realized_w60s")),
+            vwap_session=_decimal(features.values.get("vwap_session")),
+            spread=_decimal(features.values.get("spread")),
+            imbalance_bid_sz=_decimal(features.values.get("imbalance_bid_sz")),
+            imbalance_ask_sz=_decimal(features.values.get("imbalance_ask_sz")),
+        )
+        if evaluation is None:
+            return None
+        return StrategyIntent(
+            strategy_id=context.strategy_id,
+            symbol=context.symbol,
+            direction=evaluation.action,
+            confidence=evaluation.confidence,
+            target_notional=_target_notional(context.params),
+            horizon=context.timeframe,
+            explain=evaluation.rationale,
+            feature_snapshot_hash=features.normalization_hash,
+            required_features=self.required_features,
+        )
+
+
+class MeanReversionReboundLongPlugin:
+    plugin_id = "mean_reversion_rebound_long"
+    version = "1.0.0"
+    required_features: tuple[str, ...] = (
+        "price",
+        "ema12",
+        "macd",
+        "macd_signal",
+        "rsi14",
+        "vol_realized_w60s",
+        "spread",
+    )
+
+    def evaluate(
+        self, context: StrategyContext, features: FeatureVectorV3
+    ) -> StrategyIntent | None:
+        evaluation = evaluate_mean_reversion_rebound_long(
+            params=context.params,
+            event_ts=context.event_ts,
+            price=_decimal(features.values.get("price")),
+            ema12=_decimal(features.values.get("ema12")),
+            macd=_decimal(features.values.get("macd")),
+            macd_signal=_decimal(features.values.get("macd_signal")),
+            rsi14=_decimal(features.values.get("rsi14")),
+            vol_realized_w60s=_decimal(features.values.get("vol_realized_w60s")),
+            vwap_session=_decimal(features.values.get("vwap_session")),
+            spread=_decimal(features.values.get("spread")),
+            imbalance_bid_sz=_decimal(features.values.get("imbalance_bid_sz")),
+            imbalance_ask_sz=_decimal(features.values.get("imbalance_ask_sz")),
+        )
+        if evaluation is None:
+            return None
+        return StrategyIntent(
+            strategy_id=context.strategy_id,
+            symbol=context.symbol,
+            direction=evaluation.action,
+            confidence=evaluation.confidence,
+            target_notional=_target_notional(context.params),
+            horizon=context.timeframe,
+            explain=evaluation.rationale,
+            feature_snapshot_hash=features.normalization_hash,
+            required_features=self.required_features,
+        )
+
+
+class LateDayContinuationLongPlugin:
+    plugin_id = "late_day_continuation_long"
+    version = "1.0.0"
+    required_features: tuple[str, ...] = (
+        "price",
+        "ema12",
+        "ema26",
+        "macd",
+        "macd_signal",
+        "rsi14",
+        "vol_realized_w60s",
+        "vwap_session",
+        "spread",
+        "imbalance_bid_sz",
+        "imbalance_ask_sz",
+    )
+
+    def evaluate(
+        self, context: StrategyContext, features: FeatureVectorV3
+    ) -> StrategyIntent | None:
+        evaluation = evaluate_late_day_continuation_long(
+            params=context.params,
+            event_ts=context.event_ts,
+            price=_decimal(features.values.get("price")),
+            ema12=_decimal(features.values.get("ema12")),
+            ema26=_decimal(features.values.get("ema26")),
+            macd=_decimal(features.values.get("macd")),
+            macd_signal=_decimal(features.values.get("macd_signal")),
+            rsi14=_decimal(features.values.get("rsi14")),
+            vol_realized_w60s=_decimal(features.values.get("vol_realized_w60s")),
+            vwap_session=_decimal(features.values.get("vwap_session")),
+            spread=_decimal(features.values.get("spread")),
+            imbalance_bid_sz=_decimal(features.values.get("imbalance_bid_sz")),
+            imbalance_ask_sz=_decimal(features.values.get("imbalance_ask_sz")),
+        )
+        if evaluation is None:
+            return None
+        return StrategyIntent(
+            strategy_id=context.strategy_id,
+            symbol=context.symbol,
+            direction=evaluation.action,
+            confidence=evaluation.confidence,
+            target_notional=_target_notional(context.params),
+            horizon=context.timeframe,
+            explain=evaluation.rationale,
+            feature_snapshot_hash=features.normalization_hash,
+            required_features=self.required_features,
+        )
+
+
 class StrategyRuntime:
     """Deterministic strategy plugin runtime with failure isolation."""
 
@@ -434,6 +635,8 @@ class StrategyRuntime:
         self, strategy: Strategy, features: FeatureVectorV3, *, timeframe: str
     ) -> RuntimeDecision | None:
         definition = self.definition_from_strategy(strategy)
+        if definition.universe_symbols and features.symbol not in definition.universe_symbols:
+            return None
         plugin = self.registry.resolve(definition)
         if plugin is None:
             return None
@@ -489,6 +692,8 @@ class StrategyRuntime:
         )
         for definition in sorted_definitions:
             if definition.base_timeframe != timeframe:
+                continue
+            if definition.universe_symbols and features.symbol not in definition.universe_symbols:
                 continue
             start = time.perf_counter()
             if self.registry.is_degraded(
@@ -641,6 +846,7 @@ class StrategyRuntime:
             execution_profile="market",
             enabled=bool(strategy.enabled),
             base_timeframe=str(strategy.base_timeframe),
+            universe_symbols=StrategyRuntime._normalized_universe_symbols(strategy),
             compiler_source=compiler_source,
             strategy_spec=strategy_spec,
             compiled_targets=compiled_targets,
@@ -711,6 +917,18 @@ class StrategyRuntime:
         params.setdefault("base_timeframe", strategy.base_timeframe)
         params.setdefault("universe_symbols", strategy.universe_symbols)
         return params
+
+    @staticmethod
+    def _normalized_universe_symbols(strategy: Strategy) -> tuple[str, ...]:
+        raw = strategy.universe_symbols
+        if not isinstance(raw, list):
+            return ()
+        values: list[str] = []
+        for item in cast(list[object], raw):
+            text = str(item).strip().upper()
+            if text:
+                values.append(text)
+        return tuple(values)
 
     @staticmethod
     def _catalog_metadata(strategy: Strategy) -> dict[str, Any]:

--- a/services/torghut/scripts/archive_recent_kafka_trading_days.py
+++ b/services/torghut/scripts/archive_recent_kafka_trading_days.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""Archive Kafka-backed historical simulation runs into immutable replay bundles."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+from app.trading.profitability_archive import archive_historical_simulation_run
+from scripts.start_historical_simulation import _build_resources, _load_manifest
+
+_SERVICE_ROOT = Path(__file__).resolve().parent.parent
+_SCRIPTS_ROOT = Path(__file__).resolve().parent
+_START_SIMULATION_SCRIPT = _SCRIPTS_ROOT / 'start_historical_simulation.py'
+_ANALYZE_SIMULATION_SCRIPT = _SCRIPTS_ROOT / 'analyze_historical_simulation.py'
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--archive-root', required=True, help='Archive root for immutable replay bundles.')
+    parser.add_argument('--run-dir', action='append', default=[], help='Existing historical simulation run directory.')
+    parser.add_argument(
+        '--scan-root',
+        action='append',
+        default=[],
+        help='Directory to scan recursively for historical simulation run directories.',
+    )
+    parser.add_argument(
+        '--manifest',
+        action='append',
+        default=[],
+        help='Historical simulation manifest to execute, analyze, and archive.',
+    )
+    parser.add_argument(
+        '--run-id-prefix',
+        default='archive',
+        help='Prefix for manifest-driven simulation run ids.',
+    )
+    parser.add_argument(
+        '--topic-retention-ms',
+        action='append',
+        default=[],
+        help='Topic retention mapping in topic=milliseconds format.',
+    )
+    parser.add_argument(
+        '--persist-dataset-snapshots',
+        action='store_true',
+        help='Persist archived replay bundles into vnext_dataset_snapshots.',
+    )
+    parser.add_argument(
+        '--python-bin',
+        default=sys.executable,
+        help='Python interpreter used when executing historical simulation manifests.',
+    )
+    parser.add_argument('--json', action='store_true')
+    return parser.parse_args()
+
+
+def _parse_topic_retention_ms(raw_values: Iterable[str]) -> dict[str, int]:
+    topic_retention_ms_by_topic: dict[str, int] = {}
+    for raw_value in raw_values:
+        topic, separator, value = raw_value.partition('=')
+        topic_name = topic.strip()
+        if separator != '=' or not topic_name:
+            raise RuntimeError(f'invalid_topic_retention_mapping:{raw_value}')
+        try:
+            topic_retention_ms_by_topic[topic_name] = int(value.strip())
+        except ValueError as exc:
+            raise RuntimeError(f'invalid_topic_retention_ms:{raw_value}') from exc
+    return topic_retention_ms_by_topic
+
+
+def _canonical_paths(paths: Iterable[Path]) -> list[Path]:
+    deduped: dict[Path, Path] = {}
+    for path in paths:
+        resolved = path.resolve()
+        deduped[resolved] = resolved
+    return sorted(deduped.values())
+
+
+def _discover_run_dirs(scan_roots: Iterable[Path]) -> list[Path]:
+    run_dirs: list[Path] = []
+    for scan_root in scan_roots:
+        for marker in sorted(scan_root.rglob('run-manifest.json')):
+            run_dir = marker.parent
+            if (run_dir / 'replay-report.json').exists() and (run_dir / 'report' / 'simulation-report.json').exists():
+                run_dirs.append(run_dir)
+    return _canonical_paths(run_dirs)
+
+
+def _normalized_manifest_run_id(*, manifest_path: Path, manifest: Mapping[str, Any], run_id_prefix: str) -> str:
+    raw_base = str(manifest.get('dataset_id') or manifest_path.stem).strip()
+    normalized = re.sub(r'[^a-z0-9]+', '-', raw_base.lower()).strip('-')
+    normalized = normalized or 'historical-simulation'
+    return f'{run_id_prefix.strip() or "archive"}-{normalized}'[:63]
+
+
+def _run_subprocess(command: list[str]) -> None:
+    subprocess.run(
+        command,
+        cwd=_SERVICE_ROOT,
+        check=True,
+    )
+
+
+def _execute_manifest_and_collect_run_dir(
+    *,
+    manifest_path: Path,
+    run_id_prefix: str,
+    python_bin: str,
+) -> Path:
+    manifest = _load_manifest(manifest_path)
+    run_id = _normalized_manifest_run_id(
+        manifest_path=manifest_path,
+        manifest=manifest,
+        run_id_prefix=run_id_prefix,
+    )
+    _run_subprocess(
+        [
+            python_bin,
+            str(_START_SIMULATION_SCRIPT),
+            '--run-id',
+            run_id,
+            '--dataset-manifest',
+            str(manifest_path),
+            '--json',
+        ]
+    )
+    _run_subprocess(
+        [
+            python_bin,
+            str(_ANALYZE_SIMULATION_SCRIPT),
+            '--run-id',
+            run_id,
+            '--dataset-manifest',
+            str(manifest_path),
+            '--json',
+        ]
+    )
+    resources = _build_resources(run_id, manifest)
+    return (resources.output_root / resources.run_token).resolve()
+
+
+def archive_recent_kafka_trading_days(
+    *,
+    archive_root: Path,
+    run_dirs: Iterable[Path] = (),
+    scan_roots: Iterable[Path] = (),
+    manifest_paths: Iterable[Path] = (),
+    run_id_prefix: str = 'archive',
+    topic_retention_ms_by_topic: Mapping[str, int] | None = None,
+    persist_dataset_snapshots: bool = False,
+    python_bin: str = sys.executable,
+) -> dict[str, Any]:
+    archive_root = archive_root.resolve()
+    explicit_run_dirs = _canonical_paths(run_dirs)
+    discovered_run_dirs = _discover_run_dirs(scan_roots)
+    manifest_run_dirs = [
+        _execute_manifest_and_collect_run_dir(
+            manifest_path=manifest_path.resolve(),
+            run_id_prefix=run_id_prefix,
+            python_bin=python_bin,
+        )
+        for manifest_path in manifest_paths
+    ]
+    run_dirs_to_archive = _canonical_paths([*explicit_run_dirs, *discovered_run_dirs, *manifest_run_dirs])
+
+    session = None
+    if persist_dataset_snapshots:
+        from app.db import SessionLocal
+
+        session = SessionLocal()
+    try:
+        results = [
+            archive_historical_simulation_run(
+                run_dir=run_dir,
+                archive_root=archive_root,
+                topic_retention_ms_by_topic=topic_retention_ms_by_topic,
+                session=session,
+            )
+            for run_dir in run_dirs_to_archive
+        ]
+        if session is not None:
+            session.commit()
+    finally:
+        if session is not None:
+            session.close()
+
+    return {
+        'archive_root': str(archive_root),
+        'run_dir_count': len(run_dirs_to_archive),
+        'archived_count': len(results),
+        'persist_dataset_snapshots': persist_dataset_snapshots,
+        'topic_retention_ms_by_topic': {
+            str(topic): int(value) for topic, value in (topic_retention_ms_by_topic or {}).items()
+        },
+        'results': results,
+    }
+
+
+def main() -> int:
+    args = _parse_args()
+    summary = archive_recent_kafka_trading_days(
+        archive_root=Path(args.archive_root),
+        run_dirs=[Path(path) for path in args.run_dir],
+        scan_roots=[Path(path) for path in args.scan_root],
+        manifest_paths=[Path(path) for path in args.manifest],
+        run_id_prefix=args.run_id_prefix,
+        topic_retention_ms_by_topic=_parse_topic_retention_ms(args.topic_retention_ms),
+        persist_dataset_snapshots=args.persist_dataset_snapshots,
+        python_bin=args.python_bin,
+    )
+    if args.json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    else:
+        print(json.dumps(summary))
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/services/torghut/scripts/local_intraday_tsmom_replay.py
+++ b/services/torghut/scripts/local_intraday_tsmom_replay.py
@@ -7,6 +7,7 @@ import argparse
 import csv
 import http.client
 import json
+import logging
 import os
 import time as time_mod
 import uuid
@@ -21,6 +22,8 @@ from urllib import error, request
 import yaml
 from unittest.mock import patch
 
+logging.getLogger('alembic').setLevel(logging.WARNING)
+
 from app.models import Strategy
 from app.strategies.catalog import StrategyCatalogConfig, _compose_strategy_description
 from app.config import settings
@@ -33,6 +36,17 @@ REGULAR_OPEN_UTC = time(hour=13, minute=30)
 REGULAR_CLOSE_UTC = time(hour=20, minute=0)
 DEFAULT_CHUNK_MINUTES = 10
 DEFAULT_START_EQUITY = Decimal('31590.02')
+DEFAULT_PROGRESS_LOG_INTERVAL_SECONDS = 15
+DEFAULT_MAX_EXECUTABLE_SPREAD_BPS = Decimal('50')
+DEFAULT_MAX_QUOTE_MID_JUMP_BPS = Decimal('150')
+DEFAULT_MAX_JUMP_WITH_WIDE_SPREAD_BPS = Decimal('25')
+
+logger = logging.getLogger(__name__)
+_SHARED_POSITION_OWNER = '__shared__'
+
+
+def _position_key(symbol: str, strategy_id: str) -> tuple[str, str]:
+    return (symbol.strip().upper(), strategy_id.strip())
 
 
 @dataclass(frozen=True)
@@ -46,15 +60,22 @@ class ReplayConfig:
     chunk_minutes: int
     flatten_eod: bool
     start_equity: Decimal
+    symbols: tuple[str, ...] = ()
+    progress_log_interval_seconds: int = DEFAULT_PROGRESS_LOG_INTERVAL_SECONDS
+    max_executable_spread_bps: Decimal = DEFAULT_MAX_EXECUTABLE_SPREAD_BPS
+    max_quote_mid_jump_bps: Decimal = DEFAULT_MAX_QUOTE_MID_JUMP_BPS
+    max_jump_with_wide_spread_bps: Decimal = DEFAULT_MAX_JUMP_WITH_WIDE_SPREAD_BPS
 
 
 @dataclass
 class PositionState:
+    strategy_id: str
     qty: Decimal
     avg_entry_price: Decimal
     opened_at: datetime
     entry_cost_total: Decimal
     decision_at: datetime
+    pending_entry: bool = False
 
 
 @dataclass
@@ -67,6 +88,7 @@ class PendingOrder:
 @dataclass
 class ClosedTrade:
     symbol: str
+    strategy_id: str
     decision_at: datetime
     opened_at: datetime
     closed_at: datetime
@@ -76,6 +98,14 @@ class ClosedTrade:
     gross_pnl: Decimal
     net_pnl: Decimal
     exit_reason: str
+
+
+@dataclass(frozen=True)
+class QuoteQualityStatus:
+    valid: bool
+    reason: str | None = None
+    spread_bps: Decimal | None = None
+    jump_bps: Decimal | None = None
 
 
 def _parse_args() -> argparse.Namespace:
@@ -105,6 +135,37 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument('--end-date', default='2026-03-27')
     parser.add_argument('--chunk-minutes', type=int, default=DEFAULT_CHUNK_MINUTES)
     parser.add_argument('--start-equity', default=str(DEFAULT_START_EQUITY))
+    parser.add_argument(
+        '--symbols',
+        default='',
+        help='Optional comma-separated symbol filter applied in the ClickHouse query.',
+    )
+    parser.add_argument(
+        '--progress-log-seconds',
+        type=int,
+        default=DEFAULT_PROGRESS_LOG_INTERVAL_SECONDS,
+        help='Emit replay heartbeat logs at most once per this many seconds.',
+    )
+    parser.add_argument(
+        '--max-executable-spread-bps',
+        default=str(DEFAULT_MAX_EXECUTABLE_SPREAD_BPS),
+        help='Reject quotes wider than this when evaluating, filling, or flattening.',
+    )
+    parser.add_argument(
+        '--max-quote-mid-jump-bps',
+        default=str(DEFAULT_MAX_QUOTE_MID_JUMP_BPS),
+        help='Reject wide-spread quotes whose midpoint jumps beyond this many bps from the last sane price.',
+    )
+    parser.add_argument(
+        '--max-jump-with-wide-spread-bps',
+        default=str(DEFAULT_MAX_JUMP_WITH_WIDE_SPREAD_BPS),
+        help='Minimum spread width required before the jump filter blocks a quote.',
+    )
+    parser.add_argument(
+        '--log-level',
+        default=os.environ.get('TORGHUT_REPLAY_LOG_LEVEL', 'INFO'),
+        help='Python logging level for replay progress logs.',
+    )
     parser.add_argument('--no-flatten-eod', action='store_true')
     parser.add_argument('--json', action='store_true')
     return parser.parse_args()
@@ -183,17 +244,44 @@ def _iter_signal_rows(config: ReplayConfig) -> Iterable[SignalEnvelope]:
     chunk_delta = timedelta(minutes=config.chunk_minutes)
     current_day = config.start_date
     while current_day <= config.end_date:
+        if current_day.weekday() >= 5:
+            logger.info('replay_day_skip day=%s reason=weekend', current_day.isoformat())
+            current_day += timedelta(days=1)
+            continue
         session_start = datetime.combine(current_day, REGULAR_OPEN_UTC, tzinfo=timezone.utc)
         session_end = datetime.combine(current_day, REGULAR_CLOSE_UTC, tzinfo=timezone.utc)
+        logger.info(
+            'replay_day_fetch_start day=%s session_start=%s session_end=%s',
+            current_day.isoformat(),
+            session_start.isoformat(),
+            session_end.isoformat(),
+        )
         chunk_start = session_start
         while chunk_start < session_end:
             chunk_end = min(chunk_start + chunk_delta, session_end)
+            fetch_started_at = time_mod.monotonic()
+            logger.debug(
+                'replay_chunk_fetch_start day=%s chunk_start=%s chunk_end=%s symbol_count=%s',
+                current_day.isoformat(),
+                chunk_start.isoformat(),
+                chunk_end.isoformat(),
+                len(config.symbols),
+            )
             rows = _fetch_chunk(
                 http_url=config.clickhouse_http_url,
                 username=config.clickhouse_username,
                 password=config.clickhouse_password,
                 chunk_start=chunk_start,
                 chunk_end=chunk_end,
+                symbols=config.symbols,
+            )
+            logger.debug(
+                'replay_chunk_fetch_done day=%s chunk_start=%s chunk_end=%s rows=%s elapsed_s=%.3f',
+                current_day.isoformat(),
+                chunk_start.isoformat(),
+                chunk_end.isoformat(),
+                len(rows),
+                time_mod.monotonic() - fetch_started_at,
             )
             rows.sort(key=lambda item: (item.event_ts, item.symbol, item.seq or 0))
             for row in rows:
@@ -209,7 +297,12 @@ def _fetch_chunk(
     password: str | None,
     chunk_start: datetime,
     chunk_end: datetime,
+    symbols: tuple[str, ...] = (),
 ) -> list[SignalEnvelope]:
+    symbol_filter = ''
+    if symbols:
+        rendered_symbols = ', '.join(f"'{symbol}'" for symbol in symbols)
+        symbol_filter = f'\n  AND symbol IN ({rendered_symbols})'
     query = f"""
 SELECT
   symbol,
@@ -224,12 +317,18 @@ SELECT
   toString(imbalance_bid_px) AS bid_px,
   toString(imbalance_ask_px) AS ask_px,
   toString(imbalance_ask_px - imbalance_bid_px) AS spread,
+  toString(imbalance_bid_sz) AS bid_sz,
+  toString(imbalance_ask_sz) AS ask_sz,
+  toString(imbalance_spread) AS imbalance_spread,
+  toString(vwap_session) AS vwap_session,
+  toString(vwap_w5m) AS vwap_w5m,
   toString(vol_realized_w60s) AS vol_realized_w60s
 FROM torghut.ta_signals
 WHERE source = 'ta'
   AND window_size = 'PT1S'
   AND event_ts >= toDateTime64('{chunk_start.strftime('%Y-%m-%d %H:%M:%S')}', 3, 'UTC')
   AND event_ts < toDateTime64('{chunk_end.strftime('%Y-%m-%d %H:%M:%S')}', 3, 'UTC')
+  {symbol_filter}
   AND isNotNull(imbalance_bid_px)
   AND isNotNull(imbalance_ask_px)
 FORMAT TSVRaw
@@ -243,38 +342,76 @@ FORMAT TSVRaw
     reader = csv.reader(raw.splitlines(), delimiter='\t')
     rows: list[SignalEnvelope] = []
     for parts in reader:
-        if len(parts) != 13:
-            continue
-        symbol, event_ts, seq, macd, macd_signal, ema12, ema26, rsi14, price, bid_px, ask_px, spread, vol = parts
-        payload = {
-            'macd': _to_decimal(macd),
-            'macd_signal': _to_decimal(macd_signal),
-            'ema12': _to_decimal(ema12),
-            'ema26': _to_decimal(ema26),
-            'rsi14': _to_decimal(rsi14),
-            'rsi': _to_decimal(rsi14),
-            'price': _to_decimal(price),
-            'vol_realized_w60s': _to_decimal(vol),
-            'imbalance': {
-                'bid_px': _to_decimal(bid_px),
-                'ask_px': _to_decimal(ask_px),
-                'spread': _to_decimal(spread),
-            },
-            'spread': _to_decimal(spread),
-            'window_size': 'PT1S',
-            'window_step': 'PT1S',
-        }
-        rows.append(
-            SignalEnvelope(
-                event_ts=_parse_clickhouse_ts(event_ts),
-                symbol=symbol,
-                timeframe='1Sec',
-                seq=int(seq),
-                source='ta',
-                payload=payload,
-            )
-        )
+        parsed = _parse_signal_row(parts)
+        if parsed is not None:
+            rows.append(parsed)
     return rows
+
+
+def _parse_signal_row(parts: list[str]) -> SignalEnvelope | None:
+    if len(parts) != 18:
+        return None
+    (
+        symbol,
+        event_ts,
+        seq,
+        macd,
+        macd_signal,
+        ema12,
+        ema26,
+        rsi14,
+        price,
+        bid_px,
+        ask_px,
+        spread,
+        bid_sz,
+        ask_sz,
+        imbalance_spread,
+        vwap_session,
+        vwap_w5m,
+        vol,
+    ) = parts
+    bid_px_value = _to_decimal(bid_px)
+    ask_px_value = _to_decimal(ask_px)
+    spread_value = _to_decimal(spread)
+    bid_sz_value = _to_decimal(bid_sz)
+    ask_sz_value = _to_decimal(ask_sz)
+    imbalance_spread_value = _to_decimal(imbalance_spread)
+    payload = {
+        'macd': _to_decimal(macd),
+        'macd_signal': _to_decimal(macd_signal),
+        'ema12': _to_decimal(ema12),
+        'ema26': _to_decimal(ema26),
+        'rsi14': _to_decimal(rsi14),
+        'rsi': _to_decimal(rsi14),
+        'price': _to_decimal(price),
+        'vwap_session': _to_decimal(vwap_session),
+        'vwap_w5m': _to_decimal(vwap_w5m),
+        'vol_realized_w60s': _to_decimal(vol),
+        'imbalance_bid_px': bid_px_value,
+        'imbalance_ask_px': ask_px_value,
+        'imbalance_bid_sz': bid_sz_value,
+        'imbalance_ask_sz': ask_sz_value,
+        'imbalance_spread': imbalance_spread_value,
+        'imbalance': {
+            'bid_px': bid_px_value,
+            'ask_px': ask_px_value,
+            'bid_sz': bid_sz_value,
+            'ask_sz': ask_sz_value,
+            'spread': imbalance_spread_value if imbalance_spread_value is not None else spread_value,
+        },
+        'spread': spread_value,
+        'window_size': 'PT1S',
+        'window_step': 'PT1S',
+    }
+    return SignalEnvelope(
+        event_ts=_parse_clickhouse_ts(event_ts),
+        symbol=symbol,
+        timeframe='1Sec',
+        seq=int(seq),
+        source='ta',
+        payload=payload,
+    )
 
 
 def _parse_clickhouse_ts(value: str) -> datetime:
@@ -293,19 +430,93 @@ def _to_decimal(value: str) -> Decimal | None:
 
 
 def _positions_payload(
-    positions: dict[str, PositionState],
+    positions: dict[tuple[str, str], PositionState],
     last_prices: dict[str, Decimal],
+    pending_orders: dict[tuple[str, str], PendingOrder] | None = None,
 ) -> list[dict[str, Any]]:
+    projected_positions: dict[tuple[str, str], PositionState] = {
+        key: PositionState(
+            strategy_id=position.strategy_id,
+            qty=position.qty,
+            avg_entry_price=position.avg_entry_price,
+            opened_at=position.opened_at,
+            entry_cost_total=position.entry_cost_total,
+            decision_at=position.decision_at,
+            pending_entry=position.pending_entry,
+        )
+        for key, position in positions.items()
+    }
+    projected_prices = dict(last_prices)
+
+    for pending in (pending_orders or {}).values():
+        decision = pending.decision
+        symbol = decision.symbol
+        owner_strategy_id = _decision_position_owner(decision)
+        position_key = _position_key(symbol, owner_strategy_id)
+        reference_price = (
+            decision.limit_price
+            or projected_prices.get(symbol)
+            or _extract_price(pending.signal)
+        )
+        projected_prices[symbol] = reference_price
+        existing = projected_positions.get(position_key)
+        if decision.action == 'buy':
+            if existing is None:
+                projected_positions[position_key] = PositionState(
+                    strategy_id=owner_strategy_id,
+                    qty=decision.qty,
+                    avg_entry_price=reference_price,
+                    opened_at=pending.signal.event_ts,
+                    entry_cost_total=Decimal('0'),
+                    decision_at=pending.created_at,
+                    pending_entry=True,
+                )
+                continue
+            new_qty = existing.qty + decision.qty
+            avg_entry = (
+                (existing.avg_entry_price * existing.qty)
+                + (reference_price * decision.qty)
+            ) / new_qty
+            projected_positions[position_key] = PositionState(
+                strategy_id=existing.strategy_id,
+                qty=new_qty,
+                avg_entry_price=avg_entry,
+                opened_at=existing.opened_at,
+                entry_cost_total=existing.entry_cost_total,
+                decision_at=existing.decision_at,
+                pending_entry=existing.pending_entry,
+            )
+            continue
+        if existing is None:
+            continue
+        remaining_qty = existing.qty - min(decision.qty, existing.qty)
+        if remaining_qty <= 0:
+            projected_positions.pop(position_key, None)
+            continue
+        projected_positions[position_key] = PositionState(
+            strategy_id=existing.strategy_id,
+            qty=remaining_qty,
+            avg_entry_price=existing.avg_entry_price,
+            opened_at=existing.opened_at,
+            entry_cost_total=existing.entry_cost_total,
+            decision_at=existing.decision_at,
+            pending_entry=existing.pending_entry,
+        )
+
     payload: list[dict[str, Any]] = []
-    for symbol, position in positions.items():
+    for (symbol, _owner_strategy_id), position in projected_positions.items():
         market_price = last_prices.get(symbol, position.avg_entry_price)
         payload.append(
             {
                 'symbol': symbol,
+                'strategy_id': position.strategy_id,
                 'qty': str(position.qty),
                 'side': 'long',
                 'market_value': str(position.qty * market_price),
                 'avg_entry_price': str(position.avg_entry_price),
+                'opened_at': position.opened_at.isoformat(),
+                'decision_at': position.decision_at.isoformat(),
+                'pending_entry': position.pending_entry,
             }
         )
     return payload
@@ -314,17 +525,35 @@ def _positions_payload(
 def _position_equity(
     *,
     cash: Decimal,
-    positions: dict[str, PositionState],
+    positions: dict[tuple[str, str], PositionState],
     last_prices: dict[str, Decimal],
 ) -> Decimal:
     equity = cash
-    for symbol, position in positions.items():
+    for (symbol, _owner_strategy_id), position in positions.items():
         equity += position.qty * last_prices.get(symbol, position.avg_entry_price)
     return equity
 
 
 def _extract_spread(signal: SignalEnvelope) -> Decimal | None:
     raw = signal.payload.get('spread')
+    if isinstance(raw, Decimal):
+        return raw
+    if raw is None:
+        return None
+    return Decimal(str(raw))
+
+
+def _extract_bid(signal: SignalEnvelope) -> Decimal | None:
+    raw = signal.payload.get('imbalance_bid_px')
+    if isinstance(raw, Decimal):
+        return raw
+    if raw is None:
+        return None
+    return Decimal(str(raw))
+
+
+def _extract_ask(signal: SignalEnvelope) -> Decimal | None:
+    raw = signal.payload.get('imbalance_ask_px')
     if isinstance(raw, Decimal):
         return raw
     if raw is None:
@@ -346,6 +575,79 @@ def _extract_volatility(signal: SignalEnvelope) -> Decimal | None:
     if isinstance(raw, Decimal):
         return raw
     return Decimal(str(raw))
+
+
+def _signal_spread_bps(*, signal: SignalEnvelope, price: Decimal | None = None) -> Decimal | None:
+    resolved_price = _extract_price(signal) if price is None else price
+    if resolved_price <= 0:
+        return None
+    spread = _extract_spread(signal)
+    if spread is None:
+        return None
+    return (abs(spread) / resolved_price) * Decimal('10000')
+
+
+def _signal_mid_jump_bps(*, price: Decimal, reference_price: Decimal | None) -> Decimal | None:
+    if reference_price is None or reference_price <= 0:
+        return None
+    return (abs(price - reference_price) / reference_price) * Decimal('10000')
+
+
+def _quote_quality_status(
+    *,
+    signal: SignalEnvelope,
+    previous_price: Decimal | None,
+    config: ReplayConfig,
+) -> QuoteQualityStatus:
+    price = _extract_price(signal)
+    bid = _extract_bid(signal)
+    ask = _extract_ask(signal)
+    if price <= 0:
+        return QuoteQualityStatus(valid=False, reason='non_positive_price')
+    if bid is not None and bid <= 0:
+        return QuoteQualityStatus(valid=False, reason='non_positive_bid')
+    if ask is not None and ask <= 0:
+        return QuoteQualityStatus(valid=False, reason='non_positive_ask')
+    if bid is not None and ask is not None and ask < bid:
+        return QuoteQualityStatus(valid=False, reason='crossed_quote')
+
+    spread_bps = _signal_spread_bps(signal=signal, price=price)
+    if spread_bps is not None and spread_bps > config.max_executable_spread_bps:
+        return QuoteQualityStatus(valid=False, reason='spread_bps_exceeded', spread_bps=spread_bps)
+
+    jump_bps = _signal_mid_jump_bps(price=price, reference_price=previous_price)
+    if (
+        jump_bps is not None
+        and jump_bps > config.max_quote_mid_jump_bps
+        and spread_bps is not None
+        and spread_bps > config.max_jump_with_wide_spread_bps
+    ):
+        return QuoteQualityStatus(
+            valid=False,
+            reason='wide_spread_midpoint_jump',
+            spread_bps=spread_bps,
+            jump_bps=jump_bps,
+        )
+    return QuoteQualityStatus(valid=True, spread_bps=spread_bps, jump_bps=jump_bps)
+
+
+def _log_quote_skipped(
+    *,
+    signal: SignalEnvelope,
+    status: QuoteQualityStatus,
+    has_open_position: bool,
+    has_pending_order: bool,
+) -> None:
+    logger.info(
+        'replay_quote_skipped ts=%s symbol=%s reason=%s spread_bps=%s jump_bps=%s open_position=%s pending_order=%s',
+        signal.event_ts.isoformat(),
+        signal.symbol,
+        status.reason or 'unknown',
+        _decimal_text(status.spread_bps) if status.spread_bps is not None else 'None',
+        _decimal_text(status.jump_bps) if status.jump_bps is not None else 'None',
+        has_open_position,
+        has_pending_order,
+    )
 
 
 def _estimate_trade_cost(
@@ -385,6 +687,11 @@ def _apply_order_preferences(
     decision: StrategyDecision,
     signal: SignalEnvelope,
 ) -> StrategyDecision:
+    position_exit = decision.params.get('position_exit')
+    if isinstance(position_exit, dict):
+        exit_type = str(position_exit.get('type') or '').strip()
+        if exit_type == 'session_flatten_minute_utc':
+            return decision
     if not settings.trading_execution_prefer_limit:
         return decision
     if decision.order_type != 'market':
@@ -412,6 +719,207 @@ def _init_day_stats() -> dict[str, Any]:
     }
 
 
+def _decimal_text(value: Decimal) -> str:
+    return format(value, 'f')
+
+
+def _log_decision_queued(decision: StrategyDecision, created_at: datetime) -> None:
+    logger.info(
+        'replay_decision_queued ts=%s strategy_id=%s symbol=%s action=%s qty=%s order_type=%s limit_price=%s rationale=%s',
+        created_at.isoformat(),
+        decision.strategy_id,
+        decision.symbol,
+        decision.action,
+        _decimal_text(decision.qty),
+        decision.order_type,
+        _decimal_text(decision.limit_price) if decision.limit_price is not None else 'None',
+        decision.rationale or '',
+    )
+
+
+def _log_trade_closed(trade: ClosedTrade) -> None:
+    logger.info(
+        'replay_trade_closed symbol=%s strategy_id=%s opened_at=%s closed_at=%s qty=%s entry=%s exit=%s gross_pnl=%s net_pnl=%s exit_reason=%s',
+        trade.symbol,
+        trade.strategy_id,
+        trade.opened_at.isoformat(),
+        trade.closed_at.isoformat(),
+        _decimal_text(trade.qty),
+        _decimal_text(trade.entry_price),
+        _decimal_text(trade.exit_price),
+        _decimal_text(trade.gross_pnl),
+        _decimal_text(trade.net_pnl),
+        trade.exit_reason,
+    )
+
+
+def _resolve_pending_fill_price(
+    decision: StrategyDecision,
+    signal: SignalEnvelope,
+) -> Decimal | None:
+    price = _extract_price(signal)
+    bid = _extract_bid(signal)
+    ask = _extract_ask(signal)
+    normalized_action = decision.action.strip().lower()
+
+    if decision.order_type == 'limit' and decision.limit_price is not None:
+        if normalized_action == 'buy':
+            executable_price = ask if ask is not None else price
+            if executable_price > decision.limit_price:
+                return None
+            return executable_price
+        executable_price = bid if bid is not None else price
+        if executable_price < decision.limit_price:
+            return None
+        return executable_price
+
+    if normalized_action == 'buy':
+        return ask if ask is not None else price
+    return bid if bid is not None else price
+
+
+def _decision_exit_reason(decision: StrategyDecision) -> str:
+    position_exit = decision.params.get('position_exit')
+    if isinstance(position_exit, dict):
+        exit_type = str(position_exit.get('type') or '').strip()
+        if exit_type:
+            return exit_type
+    rationale = str(decision.rationale or '').strip()
+    if rationale:
+        return rationale.split(',')[0]
+    return 'signal_exit'
+
+
+def _decision_position_owner(decision: StrategyDecision) -> str:
+    runtime_payload = decision.params.get('strategy_runtime')
+    if isinstance(runtime_payload, dict):
+        isolation_mode = str(runtime_payload.get('position_isolation_mode') or '').strip().lower()
+        if isolation_mode == 'per_strategy':
+            return decision.strategy_id
+    return _SHARED_POSITION_OWNER
+
+
+def _pending_order_priority(decision: StrategyDecision) -> int:
+    if decision.action.strip().lower() != 'sell':
+        return 0
+    position_exit = decision.params.get('position_exit')
+    exit_type = ''
+    if isinstance(position_exit, dict):
+        exit_type = str(position_exit.get('type') or '').strip()
+    if exit_type == 'session_flatten_minute_utc':
+        return 5
+    if exit_type in {'long_stop_loss_bps', 'long_trailing_stop_bps'}:
+        return 4
+    if decision.order_type == 'market':
+        return 3
+    if exit_type:
+        return 2
+    return 1
+
+
+def _should_replace_pending_order(
+    *,
+    existing: StrategyDecision,
+    replacement: StrategyDecision,
+) -> bool:
+    existing_priority = _pending_order_priority(existing)
+    replacement_priority = _pending_order_priority(replacement)
+    if replacement_priority != existing_priority:
+        return replacement_priority > existing_priority
+
+    existing_action = existing.action.strip().lower()
+    replacement_action = replacement.action.strip().lower()
+    if existing_action != replacement_action:
+        return False
+
+    if existing.order_type != replacement.order_type:
+        return existing.order_type == 'limit' and replacement.order_type == 'market'
+
+    if existing.order_type != 'limit':
+        return False
+
+    existing_limit = existing.limit_price
+    replacement_limit = replacement.limit_price
+    if existing_limit is None or replacement_limit is None:
+        return False
+
+    if replacement_action == 'sell':
+        return replacement_limit < existing_limit
+    if replacement_action == 'buy':
+        return replacement_limit > existing_limit
+    return False
+
+
+def _log_pending_order_replaced(
+    *,
+    created_at: datetime,
+    existing: StrategyDecision,
+    replacement: StrategyDecision,
+) -> None:
+    logger.info(
+        'replay_pending_order_replaced ts=%s symbol=%s existing_order_type=%s existing_limit=%s existing_exit=%s replacement_order_type=%s replacement_limit=%s replacement_exit=%s',
+        created_at.isoformat(),
+        replacement.symbol,
+        existing.order_type,
+        _decimal_text(existing.limit_price) if existing.limit_price is not None else 'None',
+        _decision_exit_reason(existing),
+        replacement.order_type,
+        _decimal_text(replacement.limit_price) if replacement.limit_price is not None else 'None',
+        _decision_exit_reason(replacement),
+    )
+
+
+def _log_day_summary(
+    *,
+    day: date,
+    stats: dict[str, Any],
+    cash: Decimal,
+    equity: Decimal,
+    open_positions: int,
+) -> None:
+    logger.info(
+        'replay_day_complete day=%s decisions=%s fills=%s wins=%s losses=%s gross_pnl=%s net_pnl=%s cost_total=%s cash=%s equity=%s open_positions=%s',
+        day.isoformat(),
+        stats['decision_count'],
+        stats['filled_count'],
+        stats['wins'],
+        stats['losses'],
+        _decimal_text(stats['gross_pnl']),
+        _decimal_text(stats['net_pnl']),
+        _decimal_text(stats['cost_total']),
+        _decimal_text(cash),
+        _decimal_text(equity),
+        open_positions,
+    )
+
+
+def _log_progress(
+    *,
+    signal_day: date,
+    signal_ts: datetime,
+    signals_seen: int,
+    day_bucket: dict[str, Any],
+    positions: dict[str, PositionState],
+    pending_orders: dict[str, PendingOrder],
+    cash: Decimal,
+    equity: Decimal,
+) -> None:
+    logger.info(
+        'replay_progress day=%s ts=%s signals=%s decisions=%s fills=%s wins=%s losses=%s pending_orders=%s open_positions=%s cash=%s equity=%s',
+        signal_day.isoformat(),
+        signal_ts.isoformat(),
+        signals_seen,
+        day_bucket['decision_count'],
+        day_bucket['filled_count'],
+        day_bucket['wins'],
+        day_bucket['losses'],
+        len(pending_orders),
+        len(positions),
+        _decimal_text(cash),
+        _decimal_text(equity),
+    )
+
+
 def _close_position(
     *,
     symbol: str,
@@ -429,14 +937,17 @@ def _close_position(
     remaining_position: PositionState | None = None
     if remaining_qty > 0:
         remaining_position = PositionState(
+            strategy_id=position.strategy_id,
             qty=remaining_qty,
             avg_entry_price=position.avg_entry_price,
             opened_at=position.opened_at,
             entry_cost_total=position.entry_cost_total - entry_cost_allocated,
             decision_at=position.decision_at,
+            pending_entry=False,
         )
     return remaining_position, ClosedTrade(
         symbol=symbol,
+        strategy_id=position.strategy_id,
         decision_at=position.decision_at,
         opened_at=position.opened_at,
         closed_at=closed_at,
@@ -453,14 +964,28 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
     strategies = _load_strategies(config.strategy_configmap_path)
     engine = DecisionEngine(price_fetcher=None)
     cost_model = TransactionCostModel()
-    positions: dict[str, PositionState] = {}
-    pending_orders: dict[str, PendingOrder] = {}
+    positions: dict[tuple[str, str], PositionState] = {}
+    pending_orders: dict[tuple[str, str], PendingOrder] = {}
     last_prices: dict[str, Decimal] = {}
     last_signals: dict[str, SignalEnvelope] = {}
     cash = config.start_equity
     day_stats: dict[str, dict[str, Any]] = {}
     all_closed_trades: list[ClosedTrade] = []
     current_day: date | None = None
+    signals_seen = 0
+    replay_started_at = time_mod.monotonic()
+    last_progress_at = replay_started_at
+
+    logger.info(
+        'replay_start start_date=%s end_date=%s chunk_minutes=%s flatten_eod=%s start_equity=%s symbol_count=%s symbols=%s',
+        config.start_date.isoformat(),
+        config.end_date.isoformat(),
+        config.chunk_minutes,
+        config.flatten_eod,
+        _decimal_text(config.start_equity),
+        len(config.symbols),
+        ','.join(config.symbols) if config.symbols else '*',
+    )
 
     def _active_day_stats(target_day: date) -> dict[str, Any]:
         return day_stats.setdefault(target_day.isoformat(), _init_day_stats())
@@ -475,6 +1000,7 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
             signal_day = signal.event_ts.date()
             if current_day is None:
                 current_day = signal_day
+                logger.info('replay_day_start day=%s', current_day.isoformat())
             if current_day != signal_day:
                 if config.flatten_eod:
                     cash_ref = [cash]
@@ -490,92 +1016,185 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
                     )
                     cash = cash_ref[0]
                 pending_orders.clear()
+                completed_day_stats = _active_day_stats(current_day)
+                completed_day_equity = _position_equity(
+                    cash=cash,
+                    positions=positions,
+                    last_prices=last_prices,
+                )
+                _log_day_summary(
+                    day=current_day,
+                    stats=completed_day_stats,
+                    cash=cash,
+                    equity=completed_day_equity,
+                    open_positions=len(positions),
+                )
                 current_day = signal_day
+                logger.info('replay_day_start day=%s', current_day.isoformat())
+
+            signals_seen += 1
+            day_bucket = _active_day_stats(signal_day)
+            quote_status = _quote_quality_status(
+                signal=signal,
+                previous_price=last_prices.get(signal.symbol),
+                config=config,
+            )
+            if not quote_status.valid:
+                has_open_position = any(symbol == signal.symbol for symbol, _ in positions)
+                has_pending_order = any(symbol == signal.symbol for symbol, _ in pending_orders)
+                if has_open_position or has_pending_order:
+                    _log_quote_skipped(
+                        signal=signal,
+                        status=quote_status,
+                        has_open_position=has_open_position,
+                        has_pending_order=has_pending_order,
+                    )
+                continue
 
             price = _extract_price(signal)
             last_prices[signal.symbol] = price
             last_signals[signal.symbol] = signal
-            day_bucket = _active_day_stats(signal_day)
 
-            pending = pending_orders.pop(signal.symbol, None)
-            if pending is not None:
-                fill_cost = _estimate_trade_cost(model=cost_model, decision=pending.decision, signal=signal)
+            matching_pending_keys = [
+                pending_key
+                for pending_key in sorted(pending_orders)
+                if pending_key[0] == signal.symbol
+            ]
+            for pending_key in matching_pending_keys:
+                pending = pending_orders.pop(pending_key, None)
+                if pending is None:
+                    continue
                 decision = pending.decision
-                day_bucket['cost_total'] += fill_cost
-                day_bucket['filled_count'] += 1
+                fill_price = _resolve_pending_fill_price(decision, signal)
+                if fill_price is None:
+                    pending_orders[pending_key] = pending
+                    continue
+                owner_strategy_id = _decision_position_owner(decision)
+                position_key = _position_key(decision.symbol, owner_strategy_id)
                 if decision.action == 'buy':
-                    cash -= (price * decision.qty) + fill_cost
-                    existing = positions.get(decision.symbol)
+                    fill_cost = _estimate_trade_cost(model=cost_model, decision=decision, signal=signal)
+                    day_bucket['cost_total'] += fill_cost
+                    day_bucket['filled_count'] += 1
+                    cash -= (fill_price * decision.qty) + fill_cost
+                    existing = positions.get(position_key)
                     if existing is None:
-                        positions[decision.symbol] = PositionState(
+                        positions[position_key] = PositionState(
+                            strategy_id=owner_strategy_id,
                             qty=decision.qty,
-                            avg_entry_price=price,
+                            avg_entry_price=fill_price,
                             opened_at=signal.event_ts,
                             entry_cost_total=fill_cost,
                             decision_at=pending.created_at,
+                            pending_entry=False,
                         )
                     else:
                         new_qty = existing.qty + decision.qty
                         avg_entry = (
-                            (existing.avg_entry_price * existing.qty) + (price * decision.qty)
+                            (existing.avg_entry_price * existing.qty) + (fill_price * decision.qty)
                         ) / new_qty
-                        positions[decision.symbol] = PositionState(
+                        positions[position_key] = PositionState(
+                            strategy_id=existing.strategy_id,
                             qty=new_qty,
                             avg_entry_price=avg_entry,
                             opened_at=existing.opened_at,
                             entry_cost_total=existing.entry_cost_total + fill_cost,
                             decision_at=existing.decision_at,
+                            pending_entry=False,
                         )
+                    continue
+                existing = positions.get(position_key)
+                if existing is None or existing.qty <= 0:
+                    continue
+                fill_cost = _estimate_trade_cost(model=cost_model, decision=decision, signal=signal)
+                day_bucket['cost_total'] += fill_cost
+                day_bucket['filled_count'] += 1
+                sell_qty = min(decision.qty, existing.qty)
+                cash += (fill_price * sell_qty) - fill_cost
+                entry_cost_allocated = existing.entry_cost_total * (
+                    sell_qty / existing.qty
+                )
+                remaining, trade = _close_position(
+                    symbol=decision.symbol,
+                    position=existing,
+                    sell_qty=sell_qty,
+                    fill_price=fill_price,
+                    closed_at=signal.event_ts,
+                    exit_reason=_decision_exit_reason(decision),
+                    entry_cost_allocated=entry_cost_allocated,
+                    exit_cost_total=fill_cost,
+                )
+                if remaining is None:
+                    positions.pop(position_key, None)
                 else:
-                    existing = positions.get(decision.symbol)
-                    if existing is not None and existing.qty > 0:
-                        sell_qty = min(decision.qty, existing.qty)
-                        cash += (price * sell_qty) - fill_cost
-                        entry_cost_allocated = existing.entry_cost_total * (
-                            sell_qty / existing.qty
-                        )
-                        remaining, trade = _close_position(
-                            symbol=decision.symbol,
-                            position=existing,
-                            sell_qty=sell_qty,
-                            fill_price=price,
-                            closed_at=signal.event_ts,
-                            exit_reason='signal_exit',
-                            entry_cost_allocated=entry_cost_allocated,
-                            exit_cost_total=fill_cost,
-                        )
-                        if remaining is None:
-                            positions.pop(decision.symbol, None)
-                        else:
-                            positions[decision.symbol] = remaining
-                        day_bucket['gross_pnl'] += trade.gross_pnl
-                        day_bucket['net_pnl'] += trade.net_pnl
-                        if trade.net_pnl > 0:
-                            day_bucket['wins'] += 1
-                        elif trade.net_pnl < 0:
-                            day_bucket['losses'] += 1
-                        day_bucket['closed_trades'].append(trade)
-                        all_closed_trades.append(trade)
+                    positions[position_key] = remaining
+                day_bucket['gross_pnl'] += trade.gross_pnl
+                day_bucket['net_pnl'] += trade.net_pnl
+                if trade.net_pnl > 0:
+                    day_bucket['wins'] += 1
+                elif trade.net_pnl < 0:
+                    day_bucket['losses'] += 1
+                day_bucket['closed_trades'].append(trade)
+                all_closed_trades.append(trade)
+                _log_trade_closed(trade)
 
             equity = _position_equity(cash=cash, positions=positions, last_prices=last_prices)
             decisions = engine.evaluate(
                 signal,
                 strategies,
                 equity=equity,
-                positions=_positions_payload(positions, last_prices),
+                positions=_positions_payload(
+                    positions,
+                    last_prices,
+                    pending_orders,
+                ),
             )
             for decision in decisions:
                 decision = _apply_order_preferences(decision, signal)
                 _record_decision(day_bucket, decision)
                 if decision.qty <= 0:
                     continue
-                if decision.symbol in pending_orders:
+                pending_key = _position_key(
+                    decision.symbol,
+                    _decision_position_owner(decision),
+                )
+                existing_pending = pending_orders.get(pending_key)
+                if existing_pending is not None:
+                    if _should_replace_pending_order(
+                        existing=existing_pending.decision,
+                        replacement=decision,
+                    ):
+                        pending_orders[pending_key] = PendingOrder(
+                            decision=decision,
+                            created_at=signal.event_ts,
+                            signal=signal,
+                        )
+                        _log_pending_order_replaced(
+                            created_at=signal.event_ts,
+                            existing=existing_pending.decision,
+                            replacement=decision,
+                        )
+                        _log_decision_queued(decision, signal.event_ts)
                     continue
-                pending_orders[decision.symbol] = PendingOrder(
+                pending_orders[pending_key] = PendingOrder(
                     decision=decision,
                     created_at=signal.event_ts,
                     signal=signal,
                 )
+                _log_decision_queued(decision, signal.event_ts)
+
+            now = time_mod.monotonic()
+            if now - last_progress_at >= config.progress_log_interval_seconds:
+                _log_progress(
+                    signal_day=signal_day,
+                    signal_ts=signal.event_ts,
+                    signals_seen=signals_seen,
+                    day_bucket=day_bucket,
+                    positions=positions,
+                    pending_orders=pending_orders,
+                    cash=cash,
+                    equity=equity,
+                )
+                last_progress_at = now
 
         if current_day is not None and config.flatten_eod:
             cash_ref = [cash]
@@ -590,6 +1209,16 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
                 all_closed_trades=all_closed_trades,
             )
             cash = cash_ref[0]
+        if current_day is not None:
+            final_day_stats = _active_day_stats(current_day)
+            final_day_equity = _position_equity(cash=cash, positions=positions, last_prices=last_prices)
+            _log_day_summary(
+                day=current_day,
+                stats=final_day_stats,
+                cash=cash,
+                equity=final_day_equity,
+                open_positions=len(positions),
+            )
 
     final_equity = _position_equity(cash=cash, positions=positions, last_prices=last_prices)
     total_decisions = sum(item['decision_count'] for item in day_stats.values())
@@ -603,6 +1232,19 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
         all_closed_trades,
         key=lambda item: item.net_pnl,
     )
+    logger.info(
+        'replay_complete elapsed_s=%.3f signals=%s decisions=%s fills=%s wins=%s losses=%s gross_pnl=%s net_pnl=%s total_cost=%s final_equity=%s',
+        time_mod.monotonic() - replay_started_at,
+        signals_seen,
+        total_decisions,
+        total_filled,
+        wins,
+        losses,
+        _decimal_text(total_gross),
+        _decimal_text(total_net),
+        _decimal_text(total_cost),
+        _decimal_text(final_equity),
+    )
     return {
         'start_equity': str(config.start_equity),
         'final_equity': str(final_equity),
@@ -614,12 +1256,13 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
         'wins': wins,
         'losses': losses,
         'open_positions': {
-            symbol: {
+            f'{symbol}|{owner_strategy_id}': {
+                'strategy_id': position.strategy_id,
                 'qty': str(position.qty),
                 'avg_entry_price': str(position.avg_entry_price),
                 'last_price': str(last_prices.get(symbol, position.avg_entry_price)),
             }
-            for symbol, position in positions.items()
+            for (symbol, owner_strategy_id), position in positions.items()
         },
         'daily': {
             key: {
@@ -636,6 +1279,7 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
         'largest_losses': [
             {
                 'symbol': item.symbol,
+                'strategy_id': item.strategy_id,
                 'decision_at': item.decision_at.isoformat(),
                 'opened_at': item.opened_at.isoformat(),
                 'closed_at': item.closed_at.isoformat(),
@@ -650,6 +1294,7 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
         'largest_wins': [
             {
                 'symbol': item.symbol,
+                'strategy_id': item.strategy_id,
                 'decision_at': item.decision_at.isoformat(),
                 'opened_at': item.opened_at.isoformat(),
                 'closed_at': item.closed_at.isoformat(),
@@ -668,7 +1313,7 @@ def _flatten_positions(
     *,
     day: date,
     stats: dict[str, Any],
-    positions: dict[str, PositionState],
+    positions: dict[tuple[str, str], PositionState],
     last_signals: dict[str, SignalEnvelope],
     last_prices: dict[str, Decimal],
     cost_model: TransactionCostModel,
@@ -678,14 +1323,15 @@ def _flatten_positions(
     if not positions:
         return
     current_cash = cash_ref[0]
-    for symbol in sorted(list(positions)):
-        position = positions.pop(symbol)
+    for position_key in sorted(list(positions)):
+        symbol, owner_strategy_id = position_key
+        position = positions.pop(position_key)
         last_signal = last_signals.get(symbol)
         if last_signal is None:
             continue
         fill_price = last_prices.get(symbol, position.avg_entry_price)
         synthetic_decision = StrategyDecision(
-            strategy_id='flatten',
+            strategy_id=owner_strategy_id if owner_strategy_id != _SHARED_POSITION_OWNER else 'flatten',
             symbol=symbol,
             event_ts=last_signal.event_ts,
             timeframe='1Sec',
@@ -704,6 +1350,7 @@ def _flatten_positions(
         current_cash += sell_value - exit_cost
         trade = ClosedTrade(
             symbol=symbol,
+            strategy_id=position.strategy_id,
             decision_at=position.decision_at,
             opened_at=position.opened_at,
             closed_at=datetime.combine(day, REGULAR_CLOSE_UTC, tzinfo=timezone.utc),
@@ -728,11 +1375,17 @@ def _flatten_positions(
             stats['losses'] += 1
         stats['closed_trades'].append(trade)
         all_closed_trades.append(trade)
+        _log_trade_closed(trade)
     cash_ref[0] = current_cash
 
 
 def main() -> None:
     args = _parse_args()
+    logging.basicConfig(
+        level=getattr(logging, str(args.log_level).upper(), logging.INFO),
+        format='%(asctime)s %(levelname)s %(message)s',
+    )
+    logging.getLogger('alembic').setLevel(logging.WARNING)
     config = ReplayConfig(
         strategy_configmap_path=Path(args.strategy_configmap).resolve(),
         clickhouse_http_url=str(args.clickhouse_http_url),
@@ -743,6 +1396,15 @@ def main() -> None:
         chunk_minutes=max(1, int(args.chunk_minutes)),
         flatten_eod=not args.no_flatten_eod,
         start_equity=Decimal(str(args.start_equity)),
+        symbols=tuple(
+            symbol.strip().upper()
+            for symbol in str(args.symbols or '').split(',')
+            if symbol.strip()
+        ),
+        progress_log_interval_seconds=max(1, int(args.progress_log_seconds)),
+        max_executable_spread_bps=Decimal(str(args.max_executable_spread_bps)),
+        max_quote_mid_jump_bps=Decimal(str(args.max_quote_mid_jump_bps)),
+        max_jump_with_wide_spread_bps=Decimal(str(args.max_jump_with_wide_spread_bps)),
     )
     payload = run_replay(config)
     if args.json:

--- a/services/torghut/scripts/local_intraday_tsmom_replay.py
+++ b/services/torghut/scripts/local_intraday_tsmom_replay.py
@@ -1,0 +1,755 @@
+#!/usr/bin/env python3
+"""Run a local deterministic intraday TSMOM replay against ClickHouse signals."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import http.client
+import json
+import os
+import time as time_mod
+import uuid
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import date, datetime, time, timedelta, timezone
+from decimal import Decimal
+from pathlib import Path
+from typing import Any, Iterable
+from urllib import error, request
+
+import yaml
+from unittest.mock import patch
+
+from app.models import Strategy
+from app.strategies.catalog import StrategyCatalogConfig, _compose_strategy_description
+from app.config import settings
+from app.trading.costs import CostModelInputs, OrderIntent, TransactionCostModel
+from app.trading.decisions import DecisionEngine
+from app.trading.execution_policy import _near_touch_limit_price
+from app.trading.models import SignalEnvelope, StrategyDecision
+
+REGULAR_OPEN_UTC = time(hour=13, minute=30)
+REGULAR_CLOSE_UTC = time(hour=20, minute=0)
+DEFAULT_CHUNK_MINUTES = 10
+DEFAULT_START_EQUITY = Decimal('31590.02')
+
+
+@dataclass(frozen=True)
+class ReplayConfig:
+    strategy_configmap_path: Path
+    clickhouse_http_url: str
+    clickhouse_username: str | None
+    clickhouse_password: str | None
+    start_date: date
+    end_date: date
+    chunk_minutes: int
+    flatten_eod: bool
+    start_equity: Decimal
+
+
+@dataclass
+class PositionState:
+    qty: Decimal
+    avg_entry_price: Decimal
+    opened_at: datetime
+    entry_cost_total: Decimal
+    decision_at: datetime
+
+
+@dataclass
+class PendingOrder:
+    decision: StrategyDecision
+    created_at: datetime
+    signal: SignalEnvelope
+
+
+@dataclass
+class ClosedTrade:
+    symbol: str
+    decision_at: datetime
+    opened_at: datetime
+    closed_at: datetime
+    qty: Decimal
+    entry_price: Decimal
+    exit_price: Decimal
+    gross_pnl: Decimal
+    net_pnl: Decimal
+    exit_reason: str
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description='Replay intraday TSMOM over a week of ClickHouse `ta_signals`.',
+    )
+    parser.add_argument(
+        '--strategy-configmap',
+        default='argocd/applications/torghut/strategy-configmap.yaml',
+    )
+    parser.add_argument(
+        '--clickhouse-http-url',
+        default=os.environ.get(
+            'TA_CLICKHOUSE_URL',
+            'http://torghut-clickhouse.torghut.svc.cluster.local:8123',
+        ),
+    )
+    parser.add_argument(
+        '--clickhouse-username',
+        default=os.environ.get('CLICKHOUSE_USERNAME', 'torghut'),
+    )
+    parser.add_argument(
+        '--clickhouse-password',
+        default=os.environ.get('CLICKHOUSE_PASSWORD', ''),
+    )
+    parser.add_argument('--start-date', default='2026-03-23')
+    parser.add_argument('--end-date', default='2026-03-27')
+    parser.add_argument('--chunk-minutes', type=int, default=DEFAULT_CHUNK_MINUTES)
+    parser.add_argument('--start-equity', default=str(DEFAULT_START_EQUITY))
+    parser.add_argument('--no-flatten-eod', action='store_true')
+    parser.add_argument('--json', action='store_true')
+    return parser.parse_args()
+
+
+def _load_strategies(path: Path) -> list[Strategy]:
+    root_payload = yaml.safe_load(path.read_text(encoding='utf-8'))
+    if not isinstance(root_payload, dict):
+        raise RuntimeError('strategy_configmap_not_mapping')
+    data = root_payload.get('data')
+    if not isinstance(data, dict):
+        raise RuntimeError('strategy_configmap_missing_data')
+    strategies_yaml = data.get('strategies.yaml')
+    if not isinstance(strategies_yaml, str):
+        raise RuntimeError('strategy_configmap_missing_strategies_yaml')
+    catalog = StrategyCatalogConfig.model_validate(yaml.safe_load(strategies_yaml))
+    strategies: list[Strategy] = []
+    for item in catalog.strategies:
+        if item.name is None:
+            continue
+        strategies.append(
+            Strategy(
+                id=uuid.uuid4(),
+                name=item.name,
+                description=_compose_strategy_description(item),
+                enabled=item.enabled,
+                base_timeframe=item.base_timeframe,
+                universe_type=item.universe_type,
+                universe_symbols=item.universe_symbols or None,
+                max_position_pct_equity=item.max_position_pct_equity,
+                max_notional_per_trade=item.max_notional_per_trade,
+            )
+        )
+    return strategies
+
+
+def _http_query(
+    *,
+    url: str,
+    username: str | None,
+    password: str | None,
+    query: str,
+) -> str:
+    body = query.encode('utf-8')
+    last_error: Exception | None = None
+    for attempt in range(3):
+        req = request.Request(url=url.rstrip('/') + '/', data=body, method='POST')
+        if username:
+            credentials = f'{username}:{password or ""}'.encode('utf-8')
+            req.add_header('Authorization', 'Basic ' + _b64(credentials))
+        try:
+            with request.urlopen(req, timeout=120) as resp:
+                return resp.read().decode('utf-8')
+        except error.HTTPError as exc:
+            payload = exc.read().decode('utf-8', errors='replace')
+            raise RuntimeError(f'clickhouse_http_error: {exc.code}: {payload}') from exc
+        except http.client.IncompleteRead as exc:
+            if exc.partial:
+                return exc.partial.decode('utf-8', errors='replace')
+            last_error = exc
+        except Exception as exc:  # pragma: no cover - retry path for flaky transport
+            last_error = exc
+        time_mod.sleep(0.5 * (attempt + 1))
+    if last_error is None:
+        raise RuntimeError('clickhouse_http_query_failed')
+    raise RuntimeError(f'clickhouse_http_query_failed: {last_error}') from last_error
+
+
+def _b64(raw: bytes) -> str:
+    import base64
+
+    return base64.b64encode(raw).decode('ascii')
+
+
+def _iter_signal_rows(config: ReplayConfig) -> Iterable[SignalEnvelope]:
+    chunk_delta = timedelta(minutes=config.chunk_minutes)
+    current_day = config.start_date
+    while current_day <= config.end_date:
+        session_start = datetime.combine(current_day, REGULAR_OPEN_UTC, tzinfo=timezone.utc)
+        session_end = datetime.combine(current_day, REGULAR_CLOSE_UTC, tzinfo=timezone.utc)
+        chunk_start = session_start
+        while chunk_start < session_end:
+            chunk_end = min(chunk_start + chunk_delta, session_end)
+            rows = _fetch_chunk(
+                http_url=config.clickhouse_http_url,
+                username=config.clickhouse_username,
+                password=config.clickhouse_password,
+                chunk_start=chunk_start,
+                chunk_end=chunk_end,
+            )
+            rows.sort(key=lambda item: (item.event_ts, item.symbol, item.seq or 0))
+            for row in rows:
+                yield row
+            chunk_start = chunk_end
+        current_day += timedelta(days=1)
+
+
+def _fetch_chunk(
+    *,
+    http_url: str,
+    username: str | None,
+    password: str | None,
+    chunk_start: datetime,
+    chunk_end: datetime,
+) -> list[SignalEnvelope]:
+    query = f"""
+SELECT
+  symbol,
+  event_ts,
+  seq,
+  toString(macd) AS macd,
+  toString(macd_signal) AS macd_signal,
+  toString(ema12) AS ema12,
+  toString(ema26) AS ema26,
+  toString(rsi14) AS rsi14,
+  toString((imbalance_bid_px + imbalance_ask_px) / 2) AS price,
+  toString(imbalance_bid_px) AS bid_px,
+  toString(imbalance_ask_px) AS ask_px,
+  toString(imbalance_ask_px - imbalance_bid_px) AS spread,
+  toString(vol_realized_w60s) AS vol_realized_w60s
+FROM torghut.ta_signals
+WHERE source = 'ta'
+  AND window_size = 'PT1S'
+  AND event_ts >= toDateTime64('{chunk_start.strftime('%Y-%m-%d %H:%M:%S')}', 3, 'UTC')
+  AND event_ts < toDateTime64('{chunk_end.strftime('%Y-%m-%d %H:%M:%S')}', 3, 'UTC')
+  AND isNotNull(imbalance_bid_px)
+  AND isNotNull(imbalance_ask_px)
+FORMAT TSVRaw
+""".strip()
+    raw = _http_query(
+        url=http_url,
+        username=username,
+        password=password,
+        query=query,
+    )
+    reader = csv.reader(raw.splitlines(), delimiter='\t')
+    rows: list[SignalEnvelope] = []
+    for parts in reader:
+        if len(parts) != 13:
+            continue
+        symbol, event_ts, seq, macd, macd_signal, ema12, ema26, rsi14, price, bid_px, ask_px, spread, vol = parts
+        payload = {
+            'macd': _to_decimal(macd),
+            'macd_signal': _to_decimal(macd_signal),
+            'ema12': _to_decimal(ema12),
+            'ema26': _to_decimal(ema26),
+            'rsi14': _to_decimal(rsi14),
+            'rsi': _to_decimal(rsi14),
+            'price': _to_decimal(price),
+            'vol_realized_w60s': _to_decimal(vol),
+            'imbalance': {
+                'bid_px': _to_decimal(bid_px),
+                'ask_px': _to_decimal(ask_px),
+                'spread': _to_decimal(spread),
+            },
+            'spread': _to_decimal(spread),
+            'window_size': 'PT1S',
+            'window_step': 'PT1S',
+        }
+        rows.append(
+            SignalEnvelope(
+                event_ts=_parse_clickhouse_ts(event_ts),
+                symbol=symbol,
+                timeframe='1Sec',
+                seq=int(seq),
+                source='ta',
+                payload=payload,
+            )
+        )
+    return rows
+
+
+def _parse_clickhouse_ts(value: str) -> datetime:
+    normalized = value.replace(' ', 'T')
+    parsed = datetime.fromisoformat(normalized)
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _to_decimal(value: str) -> Decimal | None:
+    stripped = value.strip()
+    if not stripped or stripped == '\\N':
+        return None
+    return Decimal(stripped)
+
+
+def _positions_payload(
+    positions: dict[str, PositionState],
+    last_prices: dict[str, Decimal],
+) -> list[dict[str, Any]]:
+    payload: list[dict[str, Any]] = []
+    for symbol, position in positions.items():
+        market_price = last_prices.get(symbol, position.avg_entry_price)
+        payload.append(
+            {
+                'symbol': symbol,
+                'qty': str(position.qty),
+                'side': 'long',
+                'market_value': str(position.qty * market_price),
+                'avg_entry_price': str(position.avg_entry_price),
+            }
+        )
+    return payload
+
+
+def _position_equity(
+    *,
+    cash: Decimal,
+    positions: dict[str, PositionState],
+    last_prices: dict[str, Decimal],
+) -> Decimal:
+    equity = cash
+    for symbol, position in positions.items():
+        equity += position.qty * last_prices.get(symbol, position.avg_entry_price)
+    return equity
+
+
+def _extract_spread(signal: SignalEnvelope) -> Decimal | None:
+    raw = signal.payload.get('spread')
+    if isinstance(raw, Decimal):
+        return raw
+    if raw is None:
+        return None
+    return Decimal(str(raw))
+
+
+def _extract_price(signal: SignalEnvelope) -> Decimal:
+    raw = signal.payload.get('price')
+    if isinstance(raw, Decimal):
+        return raw
+    return Decimal(str(raw))
+
+
+def _extract_volatility(signal: SignalEnvelope) -> Decimal | None:
+    raw = signal.payload.get('vol_realized_w60s')
+    if raw is None:
+        return None
+    if isinstance(raw, Decimal):
+        return raw
+    return Decimal(str(raw))
+
+
+def _estimate_trade_cost(
+    *,
+    model: TransactionCostModel,
+    decision: StrategyDecision,
+    signal: SignalEnvelope,
+) -> Decimal:
+    price = _extract_price(signal)
+    spread = _extract_spread(signal)
+    volatility = _extract_volatility(signal)
+    estimate = model.estimate_costs(
+        order=OrderIntent(
+            symbol=decision.symbol,
+            side=decision.action,
+            qty=decision.qty,
+            price=price,
+            order_type=decision.order_type,
+            time_in_force=decision.time_in_force,
+        ),
+        market=CostModelInputs(
+            price=price,
+            spread=spread,
+            volatility=volatility,
+        ),
+    )
+    return estimate.total_cost
+
+
+def _record_decision(stats: dict[str, Any], decision: StrategyDecision) -> None:
+    stats['decision_count'] += 1
+    symbol_counts = stats.setdefault('decision_symbols', defaultdict(int))
+    symbol_counts[decision.symbol] += 1
+
+
+def _apply_order_preferences(
+    decision: StrategyDecision,
+    signal: SignalEnvelope,
+) -> StrategyDecision:
+    if not settings.trading_execution_prefer_limit:
+        return decision
+    if decision.order_type != 'market':
+        return decision
+    price = _extract_price(signal)
+    spread = _extract_spread(signal)
+    return decision.model_copy(
+        update={
+            'order_type': 'limit',
+            'limit_price': _near_touch_limit_price(price, spread, decision.action),
+        }
+    )
+
+
+def _init_day_stats() -> dict[str, Any]:
+    return {
+        'decision_count': 0,
+        'filled_count': 0,
+        'gross_pnl': Decimal('0'),
+        'net_pnl': Decimal('0'),
+        'cost_total': Decimal('0'),
+        'wins': 0,
+        'losses': 0,
+        'closed_trades': [],
+    }
+
+
+def _close_position(
+    *,
+    symbol: str,
+    position: PositionState,
+    sell_qty: Decimal,
+    fill_price: Decimal,
+    closed_at: datetime,
+    exit_reason: str,
+    entry_cost_allocated: Decimal,
+    exit_cost_total: Decimal,
+) -> tuple[PositionState | None, ClosedTrade]:
+    remaining_qty = position.qty - sell_qty
+    gross_pnl = (fill_price - position.avg_entry_price) * sell_qty
+    net_pnl = gross_pnl - entry_cost_allocated - exit_cost_total
+    remaining_position: PositionState | None = None
+    if remaining_qty > 0:
+        remaining_position = PositionState(
+            qty=remaining_qty,
+            avg_entry_price=position.avg_entry_price,
+            opened_at=position.opened_at,
+            entry_cost_total=position.entry_cost_total - entry_cost_allocated,
+            decision_at=position.decision_at,
+        )
+    return remaining_position, ClosedTrade(
+        symbol=symbol,
+        decision_at=position.decision_at,
+        opened_at=position.opened_at,
+        closed_at=closed_at,
+        qty=sell_qty,
+        entry_price=position.avg_entry_price,
+        exit_price=fill_price,
+        gross_pnl=gross_pnl,
+        net_pnl=net_pnl,
+        exit_reason=exit_reason,
+    )
+
+
+def run_replay(config: ReplayConfig) -> dict[str, Any]:
+    strategies = _load_strategies(config.strategy_configmap_path)
+    engine = DecisionEngine(price_fetcher=None)
+    cost_model = TransactionCostModel()
+    positions: dict[str, PositionState] = {}
+    pending_orders: dict[str, PendingOrder] = {}
+    last_prices: dict[str, Decimal] = {}
+    last_signals: dict[str, SignalEnvelope] = {}
+    cash = config.start_equity
+    day_stats: dict[str, dict[str, Any]] = {}
+    all_closed_trades: list[ClosedTrade] = []
+    current_day: date | None = None
+
+    def _active_day_stats(target_day: date) -> dict[str, Any]:
+        return day_stats.setdefault(target_day.isoformat(), _init_day_stats())
+
+    with (
+        patch.object(settings, 'trading_strategy_runtime_mode', 'scheduler_v3'),
+        patch.object(settings, 'trading_strategy_scheduler_enabled', True),
+        patch.object(settings, 'trading_allow_shorts', True),
+        patch.object(settings, 'trading_fractional_equities_enabled', True),
+    ):
+        for signal in _iter_signal_rows(config):
+            signal_day = signal.event_ts.date()
+            if current_day is None:
+                current_day = signal_day
+            if current_day != signal_day:
+                if config.flatten_eod:
+                    cash_ref = [cash]
+                    _flatten_positions(
+                        day=current_day,
+                        stats=_active_day_stats(current_day),
+                        positions=positions,
+                        last_signals=last_signals,
+                        last_prices=last_prices,
+                        cost_model=cost_model,
+                        cash_ref=cash_ref,
+                        all_closed_trades=all_closed_trades,
+                    )
+                    cash = cash_ref[0]
+                pending_orders.clear()
+                current_day = signal_day
+
+            price = _extract_price(signal)
+            last_prices[signal.symbol] = price
+            last_signals[signal.symbol] = signal
+            day_bucket = _active_day_stats(signal_day)
+
+            pending = pending_orders.pop(signal.symbol, None)
+            if pending is not None:
+                fill_cost = _estimate_trade_cost(model=cost_model, decision=pending.decision, signal=signal)
+                decision = pending.decision
+                day_bucket['cost_total'] += fill_cost
+                day_bucket['filled_count'] += 1
+                if decision.action == 'buy':
+                    cash -= (price * decision.qty) + fill_cost
+                    existing = positions.get(decision.symbol)
+                    if existing is None:
+                        positions[decision.symbol] = PositionState(
+                            qty=decision.qty,
+                            avg_entry_price=price,
+                            opened_at=signal.event_ts,
+                            entry_cost_total=fill_cost,
+                            decision_at=pending.created_at,
+                        )
+                    else:
+                        new_qty = existing.qty + decision.qty
+                        avg_entry = (
+                            (existing.avg_entry_price * existing.qty) + (price * decision.qty)
+                        ) / new_qty
+                        positions[decision.symbol] = PositionState(
+                            qty=new_qty,
+                            avg_entry_price=avg_entry,
+                            opened_at=existing.opened_at,
+                            entry_cost_total=existing.entry_cost_total + fill_cost,
+                            decision_at=existing.decision_at,
+                        )
+                else:
+                    existing = positions.get(decision.symbol)
+                    if existing is not None and existing.qty > 0:
+                        sell_qty = min(decision.qty, existing.qty)
+                        cash += (price * sell_qty) - fill_cost
+                        entry_cost_allocated = existing.entry_cost_total * (
+                            sell_qty / existing.qty
+                        )
+                        remaining, trade = _close_position(
+                            symbol=decision.symbol,
+                            position=existing,
+                            sell_qty=sell_qty,
+                            fill_price=price,
+                            closed_at=signal.event_ts,
+                            exit_reason='signal_exit',
+                            entry_cost_allocated=entry_cost_allocated,
+                            exit_cost_total=fill_cost,
+                        )
+                        if remaining is None:
+                            positions.pop(decision.symbol, None)
+                        else:
+                            positions[decision.symbol] = remaining
+                        day_bucket['gross_pnl'] += trade.gross_pnl
+                        day_bucket['net_pnl'] += trade.net_pnl
+                        if trade.net_pnl > 0:
+                            day_bucket['wins'] += 1
+                        elif trade.net_pnl < 0:
+                            day_bucket['losses'] += 1
+                        day_bucket['closed_trades'].append(trade)
+                        all_closed_trades.append(trade)
+
+            equity = _position_equity(cash=cash, positions=positions, last_prices=last_prices)
+            decisions = engine.evaluate(
+                signal,
+                strategies,
+                equity=equity,
+                positions=_positions_payload(positions, last_prices),
+            )
+            for decision in decisions:
+                decision = _apply_order_preferences(decision, signal)
+                _record_decision(day_bucket, decision)
+                if decision.qty <= 0:
+                    continue
+                if decision.symbol in pending_orders:
+                    continue
+                pending_orders[decision.symbol] = PendingOrder(
+                    decision=decision,
+                    created_at=signal.event_ts,
+                    signal=signal,
+                )
+
+        if current_day is not None and config.flatten_eod:
+            cash_ref = [cash]
+            _flatten_positions(
+                day=current_day,
+                stats=_active_day_stats(current_day),
+                positions=positions,
+                last_signals=last_signals,
+                last_prices=last_prices,
+                cost_model=cost_model,
+                cash_ref=cash_ref,
+                all_closed_trades=all_closed_trades,
+            )
+            cash = cash_ref[0]
+
+    final_equity = _position_equity(cash=cash, positions=positions, last_prices=last_prices)
+    total_decisions = sum(item['decision_count'] for item in day_stats.values())
+    total_filled = sum(item['filled_count'] for item in day_stats.values())
+    total_gross = sum((item['gross_pnl'] for item in day_stats.values()), Decimal('0'))
+    total_net = final_equity - config.start_equity
+    total_cost = sum((item['cost_total'] for item in day_stats.values()), Decimal('0'))
+    wins = sum(item['wins'] for item in day_stats.values())
+    losses = sum(item['losses'] for item in day_stats.values())
+    closed_trade_payload = sorted(
+        all_closed_trades,
+        key=lambda item: item.net_pnl,
+    )
+    return {
+        'start_equity': str(config.start_equity),
+        'final_equity': str(final_equity),
+        'net_pnl': str(total_net),
+        'gross_pnl': str(total_gross),
+        'total_cost': str(total_cost),
+        'decision_count': total_decisions,
+        'filled_count': total_filled,
+        'wins': wins,
+        'losses': losses,
+        'open_positions': {
+            symbol: {
+                'qty': str(position.qty),
+                'avg_entry_price': str(position.avg_entry_price),
+                'last_price': str(last_prices.get(symbol, position.avg_entry_price)),
+            }
+            for symbol, position in positions.items()
+        },
+        'daily': {
+            key: {
+                'decision_count': value['decision_count'],
+                'filled_count': value['filled_count'],
+                'gross_pnl': str(value['gross_pnl']),
+                'net_pnl': str(value['net_pnl']),
+                'cost_total': str(value['cost_total']),
+                'wins': value['wins'],
+                'losses': value['losses'],
+            }
+            for key, value in sorted(day_stats.items())
+        },
+        'largest_losses': [
+            {
+                'symbol': item.symbol,
+                'decision_at': item.decision_at.isoformat(),
+                'opened_at': item.opened_at.isoformat(),
+                'closed_at': item.closed_at.isoformat(),
+                'qty': str(item.qty),
+                'entry_price': str(item.entry_price),
+                'exit_price': str(item.exit_price),
+                'net_pnl': str(item.net_pnl),
+                'exit_reason': item.exit_reason,
+            }
+            for item in closed_trade_payload[:10]
+        ],
+        'largest_wins': [
+            {
+                'symbol': item.symbol,
+                'decision_at': item.decision_at.isoformat(),
+                'opened_at': item.opened_at.isoformat(),
+                'closed_at': item.closed_at.isoformat(),
+                'qty': str(item.qty),
+                'entry_price': str(item.entry_price),
+                'exit_price': str(item.exit_price),
+                'net_pnl': str(item.net_pnl),
+                'exit_reason': item.exit_reason,
+            }
+            for item in list(reversed(closed_trade_payload[-10:]))
+        ],
+    }
+
+
+def _flatten_positions(
+    *,
+    day: date,
+    stats: dict[str, Any],
+    positions: dict[str, PositionState],
+    last_signals: dict[str, SignalEnvelope],
+    last_prices: dict[str, Decimal],
+    cost_model: TransactionCostModel,
+    cash_ref: list[Decimal],
+    all_closed_trades: list[ClosedTrade],
+) -> None:
+    if not positions:
+        return
+    current_cash = cash_ref[0]
+    for symbol in sorted(list(positions)):
+        position = positions.pop(symbol)
+        last_signal = last_signals.get(symbol)
+        if last_signal is None:
+            continue
+        fill_price = last_prices.get(symbol, position.avg_entry_price)
+        synthetic_decision = StrategyDecision(
+            strategy_id='flatten',
+            symbol=symbol,
+            event_ts=last_signal.event_ts,
+            timeframe='1Sec',
+            action='sell',
+            qty=position.qty,
+            order_type='market',
+            time_in_force='day',
+            params={},
+        )
+        exit_cost = _estimate_trade_cost(
+            model=cost_model,
+            decision=synthetic_decision,
+            signal=last_signal,
+        )
+        sell_value = fill_price * position.qty
+        current_cash += sell_value - exit_cost
+        trade = ClosedTrade(
+            symbol=symbol,
+            decision_at=position.decision_at,
+            opened_at=position.opened_at,
+            closed_at=datetime.combine(day, REGULAR_CLOSE_UTC, tzinfo=timezone.utc),
+            qty=position.qty,
+            entry_price=position.avg_entry_price,
+            exit_price=fill_price,
+            gross_pnl=(fill_price - position.avg_entry_price) * position.qty,
+            net_pnl=(
+                (fill_price - position.avg_entry_price) * position.qty
+                - position.entry_cost_total
+                - exit_cost
+            ),
+            exit_reason='eod_flatten',
+        )
+        stats['gross_pnl'] += trade.gross_pnl
+        stats['net_pnl'] += trade.net_pnl
+        stats['cost_total'] += exit_cost
+        stats['filled_count'] += 1
+        if trade.net_pnl > 0:
+            stats['wins'] += 1
+        elif trade.net_pnl < 0:
+            stats['losses'] += 1
+        stats['closed_trades'].append(trade)
+        all_closed_trades.append(trade)
+    cash_ref[0] = current_cash
+
+
+def main() -> None:
+    args = _parse_args()
+    config = ReplayConfig(
+        strategy_configmap_path=Path(args.strategy_configmap).resolve(),
+        clickhouse_http_url=str(args.clickhouse_http_url),
+        clickhouse_username=(str(args.clickhouse_username).strip() or None),
+        clickhouse_password=(str(args.clickhouse_password).strip() or None),
+        start_date=date.fromisoformat(args.start_date),
+        end_date=date.fromisoformat(args.end_date),
+        chunk_minutes=max(1, int(args.chunk_minutes)),
+        flatten_eod=not args.no_flatten_eod,
+        start_equity=Decimal(str(args.start_equity)),
+    )
+    payload = run_replay(config)
+    if args.json:
+        print(json.dumps(payload, sort_keys=True, separators=(',', ':')))
+        return
+    print(json.dumps(payload, indent=2, sort_keys=True))
+
+
+if __name__ == '__main__':
+    main()

--- a/services/torghut/scripts/run_archive_backed_profitability_proof.py
+++ b/services/torghut/scripts/run_archive_backed_profitability_proof.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""Build fail-closed profitability proof artifacts from archived replay bundles."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from decimal import Decimal
+from pathlib import Path
+from typing import Any, Sequence
+
+from app.trading.profitability_archive import (
+    build_profitability_certificate,
+    build_statistical_validity_report,
+    build_trial_ledger,
+    generate_archive_walkforward_folds,
+    load_archived_trading_day_bundles,
+    summarize_data_sufficiency,
+)
+from scripts.build_historical_profitability_proof import build_historical_profitability_bundle
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--archive-root', required=True, help='Root directory containing archived replay bundles.')
+    parser.add_argument('--output-dir', required=True, help='Directory where proof artifacts should be written.')
+    parser.add_argument('--selected-candidate-id', default='', help='Optional candidate override.')
+    parser.add_argument('--profit-target-daily-net-usd', default='250')
+    parser.add_argument('--median-target-daily-net-usd', default='125')
+    parser.add_argument('--profitable-day-ratio-target', default='0.60')
+    parser.add_argument('--min-research-days', type=int, default=20)
+    parser.add_argument('--min-historical-days', type=int, default=60)
+    parser.add_argument('--min-execution-days', type=int, default=20)
+    parser.add_argument('--train-days', type=int, default=40)
+    parser.add_argument('--validation-days', type=int, default=10)
+    parser.add_argument('--test-days', type=int, default=10)
+    parser.add_argument('--step-days', type=int, default=10)
+    parser.add_argument('--embargo-days', type=int, default=1)
+    parser.add_argument('--reality-check-bootstrap-replicates', type=int, default=500)
+    parser.add_argument('--json', action='store_true')
+    return parser.parse_args()
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True, default=str),
+        encoding='utf-8',
+    )
+
+
+def _candidate_run_dirs_for_test_days(
+    *,
+    bundles: Sequence[Any],
+    candidate_id: str,
+    trading_days: set[str],
+) -> list[Path]:
+    run_dirs = {
+        Path(bundle.archived_run_dir)
+        for bundle in bundles
+        if bundle.candidate_id == candidate_id and bundle.trading_day in trading_days
+    }
+    return sorted(run_dirs)
+
+
+def run_archive_backed_profitability_proof(
+    *,
+    archive_root: Path,
+    output_dir: Path,
+    selected_candidate_id: str | None = None,
+    profit_target_daily_net_usd: Decimal = Decimal('250'),
+    median_target_daily_net_usd: Decimal = Decimal('125'),
+    profitable_day_ratio_target: Decimal = Decimal('0.60'),
+    min_research_days: int = 20,
+    min_historical_days: int = 60,
+    min_execution_days: int = 20,
+    train_days: int = 40,
+    validation_days: int = 10,
+    test_days: int = 10,
+    step_days: int = 10,
+    embargo_days: int = 1,
+    reality_check_bootstrap_replicates: int = 500,
+) -> dict[str, Any]:
+    archive_root = archive_root.resolve()
+    output_dir = output_dir.resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    generated_at = datetime.now(timezone.utc)
+
+    bundles = load_archived_trading_day_bundles(archive_root)
+    data_sufficiency = summarize_data_sufficiency(
+        bundles,
+        min_research_days=min_research_days,
+        min_historical_days=min_historical_days,
+        min_execution_days=min_execution_days,
+        generated_at=generated_at,
+    )
+    trial_ledger = build_trial_ledger(
+        bundles,
+        generated_at=generated_at,
+    )
+
+    selected_candidate = selected_candidate_id or str(trial_ledger.get('selected_candidate_id') or '').strip() or None
+    proof_eligible_days = sorted(
+        {
+            bundle.trading_day
+            for bundle in bundles
+            if bundle.replayable_market_day and bundle.execution_day_eligible
+        }
+    )
+    folds = generate_archive_walkforward_folds(
+        proof_eligible_days,
+        train_days=train_days,
+        validation_days=validation_days,
+        test_days=test_days,
+        step_days=step_days,
+        embargo_days=embargo_days,
+    )
+
+    artifact_refs: list[str] = []
+    historical_bundle_summary: dict[str, Any] | None = None
+    if selected_candidate is not None and folds:
+        test_day_set = {day for fold in folds for day in fold.test_days}
+        selected_run_dirs = _candidate_run_dirs_for_test_days(
+            bundles=bundles,
+            candidate_id=selected_candidate,
+            trading_days=test_day_set,
+        )
+        if selected_run_dirs:
+            baseline_candidate_id = next(
+                (
+                    str(bundle.replay_day_manifest.get('baseline_candidate_id') or '').strip()
+                    for bundle in bundles
+                    if bundle.candidate_id == selected_candidate
+                    and str(bundle.replay_day_manifest.get('baseline_candidate_id') or '').strip()
+                ),
+                '',
+            )
+            baseline_run_dirs = (
+                _candidate_run_dirs_for_test_days(
+                    bundles=bundles,
+                    candidate_id=baseline_candidate_id,
+                    trading_days=test_day_set,
+                )
+                if baseline_candidate_id and baseline_candidate_id != selected_candidate
+                else []
+            )
+            historical_bundle_summary = build_historical_profitability_bundle(
+                run_dirs=selected_run_dirs,
+                baseline_run_dirs=baseline_run_dirs or None,
+                output_dir=output_dir / 'historical-proof',
+                hypothesis=(
+                    f'{selected_candidate} satisfies the archive-backed profitability gate '
+                    f'at ${format(profit_target_daily_net_usd, "f")} average daily net P&L'
+                ),
+                generated_at=generated_at,
+            )
+            artifact_refs.extend(
+                [
+                    str(path)
+                    for key, path in historical_bundle_summary.items()
+                    if key.endswith('_path') and str(path).strip()
+                ]
+            )
+
+    data_sufficiency_path = output_dir / 'data-sufficiency.json'
+    trial_ledger_path = output_dir / 'trial-ledger.json'
+    _write_json(data_sufficiency_path, data_sufficiency)
+    _write_json(trial_ledger_path, trial_ledger)
+    artifact_refs.extend([str(data_sufficiency_path), str(trial_ledger_path)])
+
+    statistical_validity_report = build_statistical_validity_report(
+        selected_candidate_id=selected_candidate,
+        bundles=bundles,
+        trial_ledger=trial_ledger,
+        data_sufficiency=data_sufficiency,
+        folds=folds,
+        profit_target_daily_net_usd=profit_target_daily_net_usd,
+        median_target_daily_net_usd=median_target_daily_net_usd,
+        profitable_day_ratio_target=profitable_day_ratio_target,
+        reality_check_bootstrap_replicates=reality_check_bootstrap_replicates,
+        generated_at=generated_at,
+    )
+    statistical_validity_report_path = output_dir / 'statistical-validity-report.json'
+    _write_json(statistical_validity_report_path, statistical_validity_report)
+    artifact_refs.append(str(statistical_validity_report_path))
+
+    profitability_certificate = build_profitability_certificate(
+        selected_candidate_id=selected_candidate,
+        data_sufficiency=data_sufficiency,
+        trial_ledger=trial_ledger,
+        statistical_validity_report=statistical_validity_report,
+        artifact_refs=artifact_refs,
+        profit_target_daily_net_usd=profit_target_daily_net_usd,
+        generated_at=generated_at,
+    )
+    profitability_certificate_path = output_dir / 'profitability-certificate.json'
+    _write_json(profitability_certificate_path, profitability_certificate)
+    artifact_refs.append(str(profitability_certificate_path))
+
+    return {
+        'archive_root': str(archive_root),
+        'output_dir': str(output_dir),
+        'selected_candidate_id': selected_candidate,
+        'data_sufficiency_path': str(data_sufficiency_path),
+        'trial_ledger_path': str(trial_ledger_path),
+        'statistical_validity_report_path': str(statistical_validity_report_path),
+        'profitability_certificate_path': str(profitability_certificate_path),
+        'certificate_status': profitability_certificate['status'],
+        'historical_bundle_summary': historical_bundle_summary,
+    }
+
+
+def main() -> int:
+    args = _parse_args()
+    summary = run_archive_backed_profitability_proof(
+        archive_root=Path(args.archive_root),
+        output_dir=Path(args.output_dir),
+        selected_candidate_id=args.selected_candidate_id.strip() or None,
+        profit_target_daily_net_usd=Decimal(args.profit_target_daily_net_usd),
+        median_target_daily_net_usd=Decimal(args.median_target_daily_net_usd),
+        profitable_day_ratio_target=Decimal(args.profitable_day_ratio_target),
+        min_research_days=args.min_research_days,
+        min_historical_days=args.min_historical_days,
+        min_execution_days=args.min_execution_days,
+        train_days=args.train_days,
+        validation_days=args.validation_days,
+        test_days=args.test_days,
+        step_days=args.step_days,
+        embargo_days=args.embargo_days,
+        reality_check_bootstrap_replicates=args.reality_check_bootstrap_replicates,
+    )
+    if args.json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    else:
+        print(json.dumps(summary))
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/services/torghut/tests/profitability_archive_test_utils.py
+++ b/services/torghut/tests/profitability_archive_test_utils.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+import json
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from typing import Sequence
+
+import yaml
+
+from app.trading.profitability_archive import ArchivedTradingDayBundle
+
+
+def iter_trading_days(*, start_day: date, count: int) -> list[str]:
+    trading_days: list[str] = []
+    cursor = start_day
+    while len(trading_days) < count:
+        if cursor.weekday() < 5:
+            trading_days.append(cursor.isoformat())
+        cursor += timedelta(days=1)
+    return trading_days
+
+
+def default_postgres_counts() -> dict[str, int]:
+    return {
+        'trade_decisions': 12,
+        'executions': 6,
+        'position_snapshots': 4,
+        'execution_order_events': 6,
+        'execution_tca_metrics': 6,
+    }
+
+
+def write_historical_run(
+    *,
+    root: Path,
+    run_name: str,
+    trading_day: str,
+    candidate_id: str,
+    baseline_candidate_id: str = 'cash-flat@baseline',
+    net_pnl: str,
+    avg_abs_slippage_bps: float = 6.0,
+    p95_abs_slippage_bps: float = 12.0,
+    strict_coverage_ratio: float = 0.95,
+    coverage_ratio: float = 1.0,
+    dump_records: int = 500,
+    symbols: Sequence[str] = ('AAPL', 'MSFT'),
+) -> tuple[Path, Path]:
+    run_dir = root / run_name
+    report_dir = run_dir / 'report'
+    report_dir.mkdir(parents=True, exist_ok=True)
+
+    manifest_path = root / f'{run_name}.yaml'
+    manifest_path.write_text(
+        yaml.safe_dump(
+            {
+                'dataset_id': f'dataset-{run_name}',
+                'dataset_snapshot_ref': f'snapshot-{run_name}',
+                'candidate_id': candidate_id,
+                'baseline_candidate_id': baseline_candidate_id,
+                'strategy_spec_ref': 'strategy-specs/intraday-proof-v1.json',
+                'model_refs': [f'rules/{candidate_id}'],
+                'runtime_version_refs': ['services/torghut@sha256:test'],
+                'window': {
+                    'trading_day': trading_day,
+                    'timezone': 'America/New_York',
+                    'start': f'{trading_day}T13:30:00Z',
+                    'end': f'{trading_day}T20:00:00Z',
+                    'strict_coverage_ratio': strict_coverage_ratio,
+                },
+                'clickhouse': {
+                    'simulation_database': f'torghut_sim_{run_name}',
+                },
+            },
+            sort_keys=False,
+        ),
+        encoding='utf-8',
+    )
+
+    (run_dir / 'run-manifest.json').write_text(
+        json.dumps(
+            {
+                'run_id': run_name,
+                'dataset_id': f'dataset-{run_name}',
+                'window_policy': {
+                    'strict_coverage_ratio': strict_coverage_ratio,
+                },
+                'dump': {
+                    'records': dump_records,
+                    'records_by_topic': {
+                        'torghut.trades.v1': dump_records,
+                        'torghut.quotes.v1': dump_records,
+                        'torghut.bars.1m.v1': dump_records,
+                        'torghut.status.v1': 1,
+                    },
+                    'sha256': f'dump-{run_name}',
+                },
+                'dump_coverage': {
+                    'coverage_ratio': coverage_ratio,
+                },
+                'evidence_lineage': {
+                    'candidate_id': candidate_id,
+                    'baseline_candidate_id': baseline_candidate_id,
+                    'strategy_spec_ref': 'strategy-specs/intraday-proof-v1.json',
+                    'model_refs': [f'rules/{candidate_id}'],
+                    'runtime_version_refs': ['services/torghut@sha256:test'],
+                },
+            }
+        ),
+        encoding='utf-8',
+    )
+    (run_dir / 'replay-report.json').write_text(
+        json.dumps(
+            {
+                'dump_sha256': f'dump-{run_name}',
+            }
+        ),
+        encoding='utf-8',
+    )
+    (run_dir / 'source-dump.jsonl.zst').write_bytes(b'synthetic-dump')
+    (run_dir / 'source-dump.jsonl.zst.manifest.json').write_text(
+        json.dumps(
+            {
+                'chunks': [
+                    {
+                        'payload_sha256': f'dump-{run_name}',
+                    }
+                ]
+            }
+        ),
+        encoding='utf-8',
+    )
+    (report_dir / 'trade-pnl.csv').write_text(
+        'avg_fill_price,created_at,execution_id,filled_qty,realized_pnl_contribution,side,symbol,trade_decision_id\n'
+        f'100,{trading_day}T14:00:00Z,exec-1,1,0,buy,{symbols[0]},td-1\n'
+        f'101,{trading_day}T15:00:00Z,exec-2,1,{net_pnl},sell,{symbols[0]},td-2\n',
+        encoding='utf-8',
+    )
+    (report_dir / 'simulation-report.json').write_text(
+        json.dumps(
+            {
+                'run_metadata': {
+                    'run_id': run_name,
+                    'manifest_path': str(manifest_path),
+                },
+                'coverage': {
+                    'window_start': f'{trading_day}T13:30:00+00:00',
+                    'window_coverage_ratio_from_dump': coverage_ratio,
+                    'decision_signal_min_ts': f'{trading_day}T13:30:00+00:00',
+                    'decision_signal_max_ts': f'{trading_day}T20:00:00+00:00',
+                    'dump_signal_min_ts': f'{trading_day}T13:30:00+00:00',
+                    'dump_signal_max_ts': f'{trading_day}T20:00:00+00:00',
+                },
+                'funnel': {
+                    'trade_decisions': 12,
+                    'executions': 6,
+                    'execution_order_events_total': 6,
+                    'execution_tca_metrics': 6,
+                    'decision_status_counts': {
+                        'filled': 6,
+                    },
+                },
+                'execution_quality': {
+                    'slippage_bps': {
+                        'avg_abs': avg_abs_slippage_bps,
+                        'p95_abs': p95_abs_slippage_bps,
+                    },
+                    'fallback_reason_counts': {},
+                },
+                'pnl': {
+                    'net_pnl_estimated': net_pnl,
+                    'estimated_cost_total': '5',
+                    'execution_notional_total': '1000',
+                },
+                'stability': {
+                    'clickhouse': {
+                        'symbols': list(symbols),
+                    }
+                },
+                'llm': {
+                    'avg_confidence': '0.8',
+                },
+                'verdict': {
+                    'status': 'PASS',
+                },
+            }
+        ),
+        encoding='utf-8',
+    )
+    return run_dir, manifest_path
+
+
+def make_archived_bundle(
+    *,
+    trading_day: str,
+    candidate_id: str,
+    net_pnl: str,
+    replayable_market_day: bool = True,
+    execution_day_eligible: bool = True,
+) -> ArchivedTradingDayBundle:
+    return ArchivedTradingDayBundle(
+        trading_day=trading_day,
+        candidate_id=candidate_id,
+        run_id=f'{candidate_id}-{trading_day}',
+        archived_run_dir=Path(f'/tmp/{candidate_id}/{trading_day}'),
+        original_run_dir=Path(f'/source/{candidate_id}/{trading_day}'),
+        market_day_inventory={
+            'trading_day': trading_day,
+            'replayable_market_day': replayable_market_day,
+            'symbols': ['AAPL'],
+            'reconstruction_source_provenance': 'historical_market_replay',
+            'source_topic_retention_ms_by_topic': {'torghut.trades.v1': 14 * 86_400_000},
+        },
+        execution_day_inventory={
+            'trading_day': trading_day,
+            'execution_day_eligible': execution_day_eligible,
+            'net_pnl_estimated': net_pnl,
+            'estimated_cost_total': '5',
+            'avg_abs_slippage_bps': 4.0,
+        },
+        replay_day_manifest={
+            'trading_day': trading_day,
+            'candidate_id': candidate_id,
+            'run_id': f'{candidate_id}-{trading_day}',
+            'dataset_snapshot_ref': f'snapshot-{candidate_id}-{trading_day}',
+            'baseline_candidate_id': 'cash-flat@baseline',
+        },
+    )
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)

--- a/services/torghut/tests/test_archive_recent_kafka_trading_days.py
+++ b/services/torghut/tests/test_archive_recent_kafka_trading_days.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import TestCase
+
+from scripts.archive_recent_kafka_trading_days import (
+    _parse_topic_retention_ms,
+    archive_recent_kafka_trading_days,
+)
+from tests.profitability_archive_test_utils import write_historical_run
+
+
+class TestArchiveRecentKafkaTradingDays(TestCase):
+    def test_parse_topic_retention_ms(self) -> None:
+        parsed = _parse_topic_retention_ms(['torghut.trades.v1=604800000'])
+        self.assertEqual(parsed, {'torghut.trades.v1': 604800000})
+
+    def test_archives_existing_run_dirs(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            run_dir, _manifest_path = write_historical_run(
+                root=root,
+                run_name='sim-existing-run',
+                trading_day='2026-03-27',
+                candidate_id='momentum_pullback_long',
+                net_pnl='275',
+            )
+            archive_root = root / 'archive'
+
+            summary = archive_recent_kafka_trading_days(
+                archive_root=archive_root,
+                run_dirs=[run_dir],
+                topic_retention_ms_by_topic={'torghut.trades.v1': 604800000},
+            )
+
+            self.assertEqual(summary['archived_count'], 1)
+            replay_manifest_path = (
+                archive_root
+                / '2026-03-27'
+                / 'momentum_pullback_long'
+                / 'sim-existing-run'
+                / 'replay_day_manifest.json'
+            )
+            replay_manifest = json.loads(replay_manifest_path.read_text(encoding='utf-8'))
+            self.assertEqual(replay_manifest['candidate_id'], 'momentum_pullback_long')

--- a/services/torghut/tests/test_decisions.py
+++ b/services/torghut/tests/test_decisions.py
@@ -689,6 +689,186 @@ class TestDecisionEngine(TestCase):
 
         self.assertEqual(decisions, [])
 
+    def test_scheduler_runtime_position_isolation_skips_unowned_sell_intent(self) -> None:
+        buy_strategy_id = uuid.uuid4()
+        sell_strategy_id = uuid.uuid4()
+        engine = DecisionEngine(price_fetcher=None)
+        engine.strategy_runtime = StrategyRuntime(
+            registry=StrategyRegistry(
+                plugins={
+                    "buy_plugin": _BuyPlugin(),
+                    "sell_plugin": _SellPlugin(),
+                }
+            )
+        )
+        buy_strategy = Strategy(
+            id=buy_strategy_id,
+            name="isolated-buy",
+            description=_compose_strategy_description(
+                StrategyConfig(
+                    name="isolated-buy",
+                    strategy_id="isolated-buy",
+                    strategy_type="buy_plugin",
+                    version="1.0.0",
+                    base_timeframe="1Sec",
+                    universe_type="breakout_continuation_long_v1",
+                    universe_symbols=["AAPL"],
+                    max_position_pct_equity=Decimal("1.0"),
+                    max_notional_per_trade=Decimal("1000"),
+                    params={"position_isolation_mode": "per_strategy"},
+                )
+            ),
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="breakout_continuation_long_v1",
+            universe_symbols=["AAPL"],
+            max_position_pct_equity=Decimal("1.0"),
+            max_notional_per_trade=Decimal("1000"),
+        )
+        sell_strategy = Strategy(
+            id=sell_strategy_id,
+            name="isolated-sell",
+            description=_compose_strategy_description(
+                StrategyConfig(
+                    name="isolated-sell",
+                    strategy_id="isolated-sell",
+                    strategy_type="sell_plugin",
+                    version="1.0.0",
+                    base_timeframe="1Sec",
+                    universe_type="breakout_continuation_long_v1",
+                    universe_symbols=["AAPL"],
+                    max_position_pct_equity=Decimal("1.0"),
+                    max_notional_per_trade=Decimal("1000"),
+                    params={"position_isolation_mode": "per_strategy"},
+                )
+            ),
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="breakout_continuation_long_v1",
+            universe_symbols=["AAPL"],
+            max_position_pct_equity=Decimal("1.0"),
+            max_notional_per_trade=Decimal("1000"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 27, 17, 30, 3, tzinfo=timezone.utc),
+            symbol="AAPL",
+            timeframe="1Sec",
+            seq=1,
+            payload={
+                "price": 101,
+                "macd": Decimal("0.12"),
+                "macd_signal": Decimal("0.08"),
+                "rsi14": Decimal("52"),
+            },
+        )
+
+        with (
+            patch.object(settings, "trading_strategy_runtime_mode", "scheduler_v3"),
+            patch.object(settings, "trading_strategy_scheduler_enabled", True),
+        ):
+            decisions = engine.evaluate(signal, [buy_strategy, sell_strategy], positions=[])
+
+        self.assertEqual(len(decisions), 1)
+        self.assertEqual(decisions[0].action, "buy")
+        runtime_payload = decisions[0].params.get("strategy_runtime")
+        assert isinstance(runtime_payload, dict)
+        self.assertEqual(runtime_payload.get("position_isolation_mode"), "per_strategy")
+
+    def test_scheduler_runtime_position_isolation_allows_owned_sell_intent(self) -> None:
+        buy_strategy_id = uuid.uuid4()
+        sell_strategy_id = uuid.uuid4()
+        engine = DecisionEngine(price_fetcher=None)
+        engine.strategy_runtime = StrategyRuntime(
+            registry=StrategyRegistry(
+                plugins={
+                    "buy_plugin": _BuyPlugin(),
+                    "sell_plugin": _SellPlugin(),
+                }
+            )
+        )
+        buy_strategy = Strategy(
+            id=buy_strategy_id,
+            name="isolated-buy",
+            description=_compose_strategy_description(
+                StrategyConfig(
+                    name="isolated-buy",
+                    strategy_id="isolated-buy",
+                    strategy_type="buy_plugin",
+                    version="1.0.0",
+                    base_timeframe="1Sec",
+                    universe_type="breakout_continuation_long_v1",
+                    universe_symbols=["AAPL"],
+                    max_position_pct_equity=Decimal("1.0"),
+                    max_notional_per_trade=Decimal("1000"),
+                    params={"position_isolation_mode": "per_strategy"},
+                )
+            ),
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="breakout_continuation_long_v1",
+            universe_symbols=["AAPL"],
+            max_position_pct_equity=Decimal("1.0"),
+            max_notional_per_trade=Decimal("1000"),
+        )
+        sell_strategy = Strategy(
+            id=sell_strategy_id,
+            name="isolated-sell",
+            description=_compose_strategy_description(
+                StrategyConfig(
+                    name="isolated-sell",
+                    strategy_id="isolated-sell",
+                    strategy_type="sell_plugin",
+                    version="1.0.0",
+                    base_timeframe="1Sec",
+                    universe_type="breakout_continuation_long_v1",
+                    universe_symbols=["AAPL"],
+                    max_position_pct_equity=Decimal("1.0"),
+                    max_notional_per_trade=Decimal("1000"),
+                    params={"position_isolation_mode": "per_strategy"},
+                )
+            ),
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="breakout_continuation_long_v1",
+            universe_symbols=["AAPL"],
+            max_position_pct_equity=Decimal("1.0"),
+            max_notional_per_trade=Decimal("1000"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 27, 17, 30, 3, tzinfo=timezone.utc),
+            symbol="AAPL",
+            timeframe="1Sec",
+            seq=1,
+            payload={
+                "price": 101,
+                "macd": Decimal("0.12"),
+                "macd_signal": Decimal("0.08"),
+                "rsi14": Decimal("52"),
+            },
+        )
+
+        with (
+            patch.object(settings, "trading_strategy_runtime_mode", "scheduler_v3"),
+            patch.object(settings, "trading_strategy_scheduler_enabled", True),
+        ):
+            decisions = engine.evaluate(
+                signal,
+                [buy_strategy, sell_strategy],
+                positions=[
+                    {
+                        "symbol": "AAPL",
+                        "strategy_id": str(sell_strategy_id),
+                        "qty": "5",
+                        "side": "long",
+                        "market_value": "500",
+                        "avg_entry_price": "100",
+                        "opened_at": "2026-03-27T17:20:00+00:00",
+                    }
+                ],
+            )
+
+        self.assertEqual({decision.action for decision in decisions}, {"buy", "sell"})
+
     def test_scheduler_runtime_intraday_tsmom_skips_exit_only_sell_without_long_inventory(
         self,
     ) -> None:
@@ -814,6 +994,7 @@ class TestDecisionEngine(TestCase):
         with (
             patch.object(settings, "trading_strategy_runtime_mode", "scheduler_v3"),
             patch.object(settings, "trading_strategy_scheduler_enabled", True),
+            patch.object(settings, "trading_execution_prefer_limit", False),
             patch.object(settings, "trading_fractional_equities_enabled", True),
         ):
             decisions = engine.evaluate(
@@ -832,6 +1013,653 @@ class TestDecisionEngine(TestCase):
         self.assertEqual(len(decisions), 1)
         self.assertEqual(decisions[0].action, "sell")
         self.assertEqual(decisions[0].qty, Decimal("1.9091"))
+
+    def test_scheduler_runtime_intraday_tsmom_skips_signal_exit_at_entry_price(
+        self,
+    ) -> None:
+        engine = DecisionEngine(price_fetcher=None)
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="intraday-tsmom-profit-protect",
+            description=_compose_strategy_description(
+                StrategyConfig(
+                    name="intraday-tsmom-profit-protect",
+                    strategy_id="intraday_tsmom_v1@prod",
+                    strategy_type="intraday_tsmom_v1",
+                    version="1.1.0",
+                    base_timeframe="1Sec",
+                    universe_type="intraday_tsmom_v1",
+                    universe_symbols=["META"],
+                    max_position_pct_equity=Decimal("0.08"),
+                    max_notional_per_trade=Decimal("1000"),
+                    params={"require_positive_price_for_signal_exit": "true"},
+                )
+            ),
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="intraday_tsmom_v1",
+            universe_symbols=["META"],
+            max_position_pct_equity=Decimal("0.08"),
+            max_notional_per_trade=Decimal("1000"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 17, 14, 29, 1, tzinfo=timezone.utc),
+            symbol="META",
+            timeframe="1Sec",
+            seq=2,
+            payload={
+                "price": 629.575,
+                "ema12": 629.10,
+                "ema26": 629.30,
+                "macd": -0.022,
+                "macd_signal": -0.010,
+                "rsi14": 41,
+                "vol_realized_w60s": 0.00016,
+            },
+        )
+
+        with (
+            patch.object(settings, "trading_strategy_runtime_mode", "scheduler_v3"),
+            patch.object(settings, "trading_strategy_scheduler_enabled", True),
+            patch.object(settings, "trading_execution_prefer_limit", False),
+            patch.object(settings, "trading_fractional_equities_enabled", True),
+        ):
+            decisions = engine.evaluate(
+                signal,
+                [strategy],
+                positions=[
+                    {
+                        "symbol": "META",
+                        "qty": "1.5884",
+                        "side": "long",
+                        "market_value": "1000",
+                        "avg_entry_price": "629.575",
+                    }
+                ],
+            )
+
+        self.assertEqual(decisions, [])
+
+    def test_scheduler_runtime_intraday_tsmom_allows_signal_exit_above_entry_price(
+        self,
+    ) -> None:
+        engine = DecisionEngine(price_fetcher=None)
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="intraday-tsmom-profit-protect",
+            description=_compose_strategy_description(
+                StrategyConfig(
+                    name="intraday-tsmom-profit-protect",
+                    strategy_id="intraday_tsmom_v1@prod",
+                    strategy_type="intraday_tsmom_v1",
+                    version="1.1.0",
+                    base_timeframe="1Sec",
+                    universe_type="intraday_tsmom_v1",
+                    universe_symbols=["META"],
+                    max_position_pct_equity=Decimal("0.08"),
+                    max_notional_per_trade=Decimal("1000"),
+                    params={"require_positive_price_for_signal_exit": "true"},
+                )
+            ),
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="intraday_tsmom_v1",
+            universe_symbols=["META"],
+            max_position_pct_equity=Decimal("0.08"),
+            max_notional_per_trade=Decimal("1000"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 27, 18, 29, 10, tzinfo=timezone.utc),
+            symbol="META",
+            timeframe="1Sec",
+            seq=11,
+            payload={
+                "price": 529.10,
+                "ema12": 528.80,
+                "ema26": 529.00,
+                "macd": -0.012,
+                "macd_signal": -0.004,
+                "rsi14": 42,
+                "vol_realized_w60s": 0.00018,
+            },
+        )
+
+        with (
+            patch.object(settings, "trading_strategy_runtime_mode", "scheduler_v3"),
+            patch.object(settings, "trading_strategy_scheduler_enabled", True),
+            patch.object(settings, "trading_fractional_equities_enabled", True),
+        ):
+            decisions = engine.evaluate(
+                signal,
+                [strategy],
+                positions=[
+                    {
+                        "symbol": "META",
+                        "qty": "1.9091",
+                        "side": "long",
+                        "market_value": "1010.47281",
+                        "avg_entry_price": "528.29",
+                    }
+                ],
+            )
+
+        self.assertEqual(len(decisions), 1)
+        self.assertEqual(decisions[0].action, "sell")
+        self.assertEqual(decisions[0].qty, Decimal("1.9091"))
+
+    def test_scheduler_runtime_intraday_tsmom_skips_signal_exit_when_executable_limit_below_entry_price(
+        self,
+    ) -> None:
+        engine = DecisionEngine(price_fetcher=None)
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="intraday-tsmom-profit-protect",
+            description=_compose_strategy_description(
+                StrategyConfig(
+                    name="intraday-tsmom-profit-protect",
+                    strategy_id="intraday_tsmom_v1@prod",
+                    strategy_type="intraday_tsmom_v1",
+                    version="1.1.0",
+                    base_timeframe="1Sec",
+                    universe_type="intraday_tsmom_v1",
+                    universe_symbols=["META"],
+                    max_position_pct_equity=Decimal("0.08"),
+                    max_notional_per_trade=Decimal("1000"),
+                    params={"require_positive_price_for_signal_exit": "true"},
+                )
+            ),
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="intraday_tsmom_v1",
+            universe_symbols=["META"],
+            max_position_pct_equity=Decimal("0.08"),
+            max_notional_per_trade=Decimal("1000"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 27, 18, 29, 10, tzinfo=timezone.utc),
+            symbol="META",
+            timeframe="1Sec",
+            seq=11,
+            payload={
+                "price": 529.10,
+                "spread": 2.00,
+                "ema12": 528.80,
+                "ema26": 529.00,
+                "macd": -0.012,
+                "macd_signal": -0.004,
+                "rsi14": 42,
+                "vol_realized_w60s": 0.00018,
+            },
+        )
+
+        with (
+            patch.object(settings, "trading_strategy_runtime_mode", "scheduler_v3"),
+            patch.object(settings, "trading_strategy_scheduler_enabled", True),
+            patch.object(settings, "trading_execution_prefer_limit", True),
+            patch.object(settings, "trading_fractional_equities_enabled", True),
+        ):
+            decisions = engine.evaluate(
+                signal,
+                [strategy],
+                positions=[
+                    {
+                        "symbol": "META",
+                        "qty": "1.9091",
+                        "side": "long",
+                        "market_value": "1010.47281",
+                        "avg_entry_price": "528.29",
+                    }
+                ],
+            )
+
+        self.assertEqual(decisions, [])
+
+    def test_scheduler_runtime_breakout_continuation_skips_exit_only_sell_without_long_inventory(
+        self,
+    ) -> None:
+        engine = DecisionEngine(price_fetcher=None)
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="breakout-continuation",
+            description="version=1.0.0",
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="breakout_continuation_long_v1",
+            universe_symbols=["META"],
+            max_position_pct_equity=Decimal("1.0"),
+            max_notional_per_trade=Decimal("14000"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 27, 17, 31, 10, tzinfo=timezone.utc),
+            symbol="META",
+            timeframe="1Sec",
+            seq=1,
+            payload={
+                "price": 522.85,
+                "ema12": 523.20,
+                "ema26": 523.05,
+                "macd": -0.004,
+                "macd_signal": 0.005,
+                "rsi14": 55,
+                "vol_realized_w60s": 0.00020,
+                "vwap_session": 523.05,
+                "spread": 0.04,
+                "imbalance_bid_sz": 4100,
+                "imbalance_ask_sz": 4900,
+            },
+        )
+
+        with (
+            patch.object(settings, "trading_strategy_runtime_mode", "scheduler_v3"),
+            patch.object(settings, "trading_strategy_scheduler_enabled", True),
+        ):
+            decisions = engine.evaluate(signal, [strategy], positions=[])
+
+        self.assertEqual(decisions, [])
+
+    def test_scheduler_runtime_late_day_continuation_skips_exit_only_sell_without_long_inventory(
+        self,
+    ) -> None:
+        engine = DecisionEngine(price_fetcher=None)
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="late-day-continuation",
+            description="version=1.0.0",
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="late_day_continuation_long_v1",
+            universe_symbols=["AAPL"],
+            max_position_pct_equity=Decimal("1.0"),
+            max_notional_per_trade=Decimal("14000"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 26, 19, 8, 3, tzinfo=timezone.utc),
+            symbol="AAPL",
+            timeframe="1Sec",
+            seq=1,
+            payload={
+                "price": 253.54,
+                "ema12": 253.72,
+                "ema26": 253.61,
+                "macd": 0.010,
+                "macd_signal": 0.016,
+                "rsi14": 53,
+                "vol_realized_w60s": 0.00018,
+                "vwap_session": 253.68,
+                "spread": 0.03,
+                "imbalance_bid_sz": 4500,
+                "imbalance_ask_sz": 4700,
+            },
+        )
+
+        with (
+            patch.object(settings, "trading_strategy_runtime_mode", "scheduler_v3"),
+            patch.object(settings, "trading_strategy_scheduler_enabled", True),
+        ):
+            decisions = engine.evaluate(signal, [strategy], positions=[])
+
+        self.assertEqual(decisions, [])
+
+    def test_scheduler_runtime_breakout_continuation_skips_exit_only_sell_for_pending_entry_only(
+        self,
+    ) -> None:
+        engine = DecisionEngine(price_fetcher=None)
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="breakout-continuation",
+            description="version=1.0.0",
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="breakout_continuation_long_v1",
+            universe_symbols=["META"],
+            max_position_pct_equity=Decimal("1.0"),
+            max_notional_per_trade=Decimal("14000"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 27, 17, 31, 10, tzinfo=timezone.utc),
+            symbol="META",
+            timeframe="1Sec",
+            seq=1,
+            payload={
+                "price": 522.85,
+                "ema12": 523.20,
+                "ema26": 523.05,
+                "macd": -0.004,
+                "macd_signal": 0.005,
+                "rsi14": 55,
+                "vol_realized_w60s": 0.00020,
+                "vwap_session": 523.05,
+                "spread": 0.04,
+                "imbalance_bid_sz": 4100,
+                "imbalance_ask_sz": 4900,
+            },
+        )
+
+        with (
+            patch.object(settings, "trading_strategy_runtime_mode", "scheduler_v3"),
+            patch.object(settings, "trading_strategy_scheduler_enabled", True),
+        ):
+            decisions = engine.evaluate(
+                signal,
+                [strategy],
+                positions=[
+                    {
+                        "symbol": "META",
+                        "strategy_id": str(strategy.id),
+                        "qty": "26.4",
+                        "side": "long",
+                        "market_value": "13803.24",
+                        "avg_entry_price": "522.85",
+                        "pending_entry": True,
+                    }
+                ],
+            )
+
+        self.assertEqual(decisions, [])
+
+    def test_scheduler_runtime_research_sleeve_buy_respects_entry_cooldown(self) -> None:
+        engine = DecisionEngine(price_fetcher=None)
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="breakout-continuation",
+            description=(
+                "version=1.0.0\n[catalog_metadata]\n"
+                '{"params":{"entry_cooldown_seconds":"300"},"strategy_type":"breakout_continuation_long_v1","version":"1.0.0"}'
+            ),
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="breakout_continuation_long_v1",
+            universe_symbols=["META"],
+            max_position_pct_equity=Decimal("1.0"),
+            max_notional_per_trade=Decimal("14000"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 27, 17, 30, 3, tzinfo=timezone.utc),
+            symbol="META",
+            timeframe="1Sec",
+            seq=1,
+            payload={
+                "price": 523.25,
+                "ema12": 523.10,
+                "ema26": 522.90,
+                "macd": 0.031,
+                "macd_signal": 0.012,
+                "rsi14": 62,
+                "vol_realized_w60s": 0.00017,
+                "spread": 0.04,
+            },
+        )
+
+        with (
+            patch.object(settings, "trading_strategy_runtime_mode", "scheduler_v3"),
+            patch.object(settings, "trading_strategy_scheduler_enabled", True),
+        ):
+            first = engine.evaluate(signal, [strategy], positions=[])
+            second = engine.evaluate(signal, [strategy], positions=[])
+
+        self.assertEqual(len(first), 1)
+        self.assertEqual(second, [])
+
+    def test_scheduler_runtime_research_sleeve_sell_respects_min_hold(self) -> None:
+        engine = DecisionEngine(price_fetcher=None)
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="breakout-continuation",
+            description=(
+                "version=1.0.0\n[catalog_metadata]\n"
+                '{"params":{"min_hold_seconds":"120"},"strategy_type":"breakout_continuation_long_v1","version":"1.0.0"}'
+            ),
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="breakout_continuation_long_v1",
+            universe_symbols=["META"],
+            max_position_pct_equity=Decimal("1.0"),
+            max_notional_per_trade=Decimal("14000"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 27, 17, 31, 10, tzinfo=timezone.utc),
+            symbol="META",
+            timeframe="1Sec",
+            seq=1,
+            payload={
+                "price": 522.85,
+                "ema12": 523.20,
+                "ema26": 523.05,
+                "macd": -0.004,
+                "macd_signal": 0.005,
+                "rsi14": 55,
+                "vol_realized_w60s": 0.00020,
+                "spread": 0.04,
+            },
+        )
+
+        with (
+            patch.object(settings, "trading_strategy_runtime_mode", "scheduler_v3"),
+            patch.object(settings, "trading_strategy_scheduler_enabled", True),
+        ):
+            decisions = engine.evaluate(
+                signal,
+                [strategy],
+                positions=[
+                    {
+                        "symbol": "META",
+                        "qty": "10",
+                        "side": "long",
+                        "market_value": "5228.5",
+                        "opened_at": "2026-03-27T17:30:40+00:00",
+                    }
+                ],
+            )
+
+        self.assertEqual(decisions, [])
+
+    def test_scheduler_runtime_research_sleeve_buy_respects_max_concurrent_positions(
+        self,
+    ) -> None:
+        engine = DecisionEngine(price_fetcher=None)
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="breakout-continuation",
+            description=(
+                "version=1.0.0\n[catalog_metadata]\n"
+                '{"params":{"max_concurrent_positions":"1"},"strategy_type":"breakout_continuation_long_v1","version":"1.0.0"}'
+            ),
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="breakout_continuation_long_v1",
+            universe_symbols=["META", "NVDA"],
+            max_position_pct_equity=Decimal("1.0"),
+            max_notional_per_trade=Decimal("14000"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 27, 17, 30, 3, tzinfo=timezone.utc),
+            symbol="META",
+            timeframe="1Sec",
+            seq=1,
+            payload={
+                "price": 523.25,
+                "ema12": 523.10,
+                "ema26": 522.90,
+                "macd": 0.031,
+                "macd_signal": 0.012,
+                "rsi14": 62,
+                "vol_realized_w60s": 0.00017,
+                "spread": 0.04,
+            },
+        )
+
+        with (
+            patch.object(settings, "trading_strategy_runtime_mode", "scheduler_v3"),
+            patch.object(settings, "trading_strategy_scheduler_enabled", True),
+        ):
+            decisions = engine.evaluate(
+                signal,
+                [strategy],
+                positions=[
+                    {
+                        "symbol": "NVDA",
+                        "qty": "75.0000",
+                        "side": "long",
+                        "market_value": "13650.00",
+                        "opened_at": "2026-03-27T17:20:00+00:00",
+                    }
+                ],
+            )
+
+        self.assertEqual(decisions, [])
+
+    def test_scheduler_runtime_intraday_tsmom_caps_buy_to_portfolio_gross_limit(
+        self,
+    ) -> None:
+        engine = DecisionEngine(price_fetcher=None)
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="intraday-tsmom-levered",
+            description=_compose_strategy_description(
+                StrategyConfig(
+                    name="intraday-tsmom-levered",
+                    strategy_id="intraday_tsmom_v1@prod",
+                    strategy_type="intraday_tsmom_v1",
+                    version="1.1.0",
+                    base_timeframe="1Sec",
+                    universe_type="intraday_tsmom_v1",
+                    universe_symbols=["META"],
+                    max_position_pct_equity=Decimal("3.0"),
+                    max_notional_per_trade=Decimal("30000"),
+                    params={
+                        "bullish_hist_min": "0.01",
+                        "min_bull_rsi": "55",
+                        "max_bull_rsi": "60",
+                        "vol_ceil": "0.01",
+                        "max_price_above_ema12_bps": "0",
+                        "min_price_below_ema12_bps": "0",
+                        "max_price_below_ema12_bps": "20",
+                        "max_gross_exposure_pct_equity": "1.5",
+                    },
+                )
+            ),
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="intraday_tsmom_v1",
+            universe_symbols=["META"],
+            max_position_pct_equity=Decimal("3.0"),
+            max_notional_per_trade=Decimal("30000"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 27, 17, 30, 3, tzinfo=timezone.utc),
+            symbol="META",
+            timeframe="1Sec",
+            seq=1,
+            payload={
+                "price": 100.0,
+                "ema12": 100.05,
+                "ema26": 99.95,
+                "macd": 0.05,
+                "macd_signal": 0.01,
+                "rsi14": 56,
+                "vol_realized_w60s": 0.0002,
+            },
+        )
+
+        with (
+            patch.object(settings, "trading_strategy_runtime_mode", "scheduler_v3"),
+            patch.object(settings, "trading_strategy_scheduler_enabled", True),
+            patch.object(settings, "trading_fractional_equities_enabled", True),
+        ):
+            decisions = engine.evaluate(
+                signal,
+                [strategy],
+                equity=Decimal("10000"),
+                positions=[
+                    {
+                        "symbol": "AAPL",
+                        "qty": "100",
+                        "side": "long",
+                        "market_value": "10000",
+                    }
+                ],
+            )
+
+        self.assertEqual(len(decisions), 1)
+        self.assertEqual(decisions[0].action, "buy")
+        self.assertEqual(decisions[0].qty, Decimal("50"))
+        sizing = decisions[0].params["sizing"]
+        self.assertEqual(sizing["portfolio_gross_cap"], "15000.0")
+        self.assertTrue(sizing["portfolio_gross_limited"])
+
+    def test_scheduler_runtime_intraday_tsmom_skips_buy_when_portfolio_gross_is_exhausted(
+        self,
+    ) -> None:
+        engine = DecisionEngine(price_fetcher=None)
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="intraday-tsmom-levered",
+            description=_compose_strategy_description(
+                StrategyConfig(
+                    name="intraday-tsmom-levered",
+                    strategy_id="intraday_tsmom_v1@prod",
+                    strategy_type="intraday_tsmom_v1",
+                    version="1.1.0",
+                    base_timeframe="1Sec",
+                    universe_type="intraday_tsmom_v1",
+                    universe_symbols=["META"],
+                    max_position_pct_equity=Decimal("3.0"),
+                    max_notional_per_trade=Decimal("30000"),
+                    params={
+                        "bullish_hist_min": "0.01",
+                        "min_bull_rsi": "55",
+                        "max_bull_rsi": "60",
+                        "vol_ceil": "0.01",
+                        "max_price_above_ema12_bps": "0",
+                        "min_price_below_ema12_bps": "0",
+                        "max_price_below_ema12_bps": "20",
+                        "max_gross_exposure_pct_equity": "1.5",
+                    },
+                )
+            ),
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="intraday_tsmom_v1",
+            universe_symbols=["META"],
+            max_position_pct_equity=Decimal("3.0"),
+            max_notional_per_trade=Decimal("30000"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 27, 17, 30, 3, tzinfo=timezone.utc),
+            symbol="META",
+            timeframe="1Sec",
+            seq=1,
+            payload={
+                "price": 100.0,
+                "ema12": 100.05,
+                "ema26": 99.95,
+                "macd": 0.05,
+                "macd_signal": 0.01,
+                "rsi14": 56,
+                "vol_realized_w60s": 0.0002,
+            },
+        )
+
+        with (
+            patch.object(settings, "trading_strategy_runtime_mode", "scheduler_v3"),
+            patch.object(settings, "trading_strategy_scheduler_enabled", True),
+            patch.object(settings, "trading_fractional_equities_enabled", True),
+        ):
+            decisions = engine.evaluate(
+                signal,
+                [strategy],
+                equity=Decimal("10000"),
+                positions=[
+                    {
+                        "symbol": "AAPL",
+                        "qty": "150",
+                        "side": "long",
+                        "market_value": "15000",
+                    }
+                ],
+            )
+
+        self.assertEqual(decisions, [])
 
     def test_scheduler_runtime_intraday_tsmom_emits_stop_loss_exit_overlay(self) -> None:
         engine = DecisionEngine(price_fetcher=None)
@@ -901,6 +1729,557 @@ class TestDecisionEngine(TestCase):
         position_exit = decisions[0].params.get("position_exit")
         assert isinstance(position_exit, dict)
         self.assertEqual(position_exit.get("type"), "long_stop_loss_bps")
+
+    def test_scheduler_runtime_position_exit_overlay_skips_hard_stop_on_wide_spread(
+        self,
+    ) -> None:
+        engine = DecisionEngine(price_fetcher=None)
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="intraday-tsmom-stop",
+            description=_compose_strategy_description(
+                StrategyConfig(
+                    name="intraday-tsmom-stop",
+                    strategy_id="intraday_tsmom_v1@prod",
+                    strategy_type="intraday_tsmom_v1",
+                    version="1.1.0",
+                    base_timeframe="1Sec",
+                    universe_type="intraday_tsmom_v1",
+                    universe_symbols=["META"],
+                    max_position_pct_equity=Decimal("0.08"),
+                    max_notional_per_trade=Decimal("1000"),
+                    params={
+                        "long_stop_loss_bps": "25",
+                        "long_stop_loss_spread_bps_multiplier": "0.50",
+                    },
+                )
+            ),
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="intraday_tsmom_v1",
+            universe_symbols=["META"],
+            max_position_pct_equity=Decimal("0.08"),
+            max_notional_per_trade=Decimal("1000"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 27, 18, 29, 10, tzinfo=timezone.utc),
+            symbol="META",
+            timeframe="1Sec",
+            seq=11,
+            payload={
+                "price": 526.70,
+                "spread": 5.00,
+                "ema12": 526.90,
+                "ema26": 526.85,
+                "macd": 0.010,
+                "macd_signal": 0.008,
+                "rsi14": 56.4,
+                "vol_realized_w60s": 0.00018,
+            },
+        )
+
+        with (
+            patch.object(settings, "trading_strategy_runtime_mode", "scheduler_v3"),
+            patch.object(settings, "trading_strategy_scheduler_enabled", True),
+            patch.object(settings, "trading_fractional_equities_enabled", True),
+        ):
+            decisions = engine.evaluate(
+                signal,
+                [strategy],
+                positions=[
+                    {
+                        "symbol": "META",
+                        "qty": "1.9091",
+                        "side": "long",
+                        "market_value": "1005.12497",
+                        "avg_entry_price": "528.29",
+                    }
+                ],
+            )
+
+        self.assertEqual(decisions, [])
+
+    def test_scheduler_runtime_position_trailing_stop_exit_after_peak_drawdown(
+        self,
+    ) -> None:
+        engine = DecisionEngine(price_fetcher=None)
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="intraday-tsmom-trailing-stop",
+            description=_compose_strategy_description(
+                StrategyConfig(
+                    name="intraday-tsmom-trailing-stop",
+                    strategy_id="intraday_tsmom_v1@prod",
+                    strategy_type="intraday_tsmom_v1",
+                    version="1.1.0",
+                    base_timeframe="1Sec",
+                    universe_type="intraday_tsmom_v1",
+                    universe_symbols=["META"],
+                    max_position_pct_equity=Decimal("0.08"),
+                    max_notional_per_trade=Decimal("1000"),
+                    params={
+                        "long_trailing_stop_activation_profit_bps": "20",
+                        "long_trailing_stop_drawdown_bps": "15",
+                    },
+                )
+            ),
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="intraday_tsmom_v1",
+            universe_symbols=["META"],
+            max_position_pct_equity=Decimal("0.08"),
+            max_notional_per_trade=Decimal("1000"),
+        )
+        peak_signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 27, 18, 29, 10, tzinfo=timezone.utc),
+            symbol="META",
+            timeframe="1Sec",
+            seq=11,
+            payload={
+                "price": 530.00,
+                "spread": 0.04,
+                "ema12": 529.50,
+                "ema26": 529.10,
+                "macd": 0.015,
+                "macd_signal": 0.010,
+                "rsi14": 58.0,
+                "vol_realized_w60s": 0.00018,
+            },
+        )
+        trailing_signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 27, 18, 30, 10, tzinfo=timezone.utc),
+            symbol="META",
+            timeframe="1Sec",
+            seq=12,
+            payload={
+                "price": 529.00,
+                "spread": 0.04,
+                "ema12": 529.30,
+                "ema26": 529.05,
+                "macd": 0.012,
+                "macd_signal": 0.009,
+                "rsi14": 56.5,
+                "vol_realized_w60s": 0.00018,
+            },
+        )
+        positions = [
+            {
+                "symbol": "META",
+                "qty": "1.9091",
+                "side": "long",
+                "market_value": "1009.5123",
+                "avg_entry_price": "528.29",
+            }
+        ]
+
+        with (
+            patch.object(settings, "trading_strategy_runtime_mode", "scheduler_v3"),
+            patch.object(settings, "trading_strategy_scheduler_enabled", True),
+            patch.object(settings, "trading_fractional_equities_enabled", True),
+        ):
+            initial_decisions = engine.evaluate(peak_signal, [strategy], positions=positions)
+            trailing_decisions = engine.evaluate(trailing_signal, [strategy], positions=positions)
+
+        self.assertEqual(initial_decisions, [])
+        self.assertEqual(len(trailing_decisions), 1)
+        self.assertEqual(trailing_decisions[0].action, "sell")
+        self.assertEqual(trailing_decisions[0].rationale, "position_trailing_stop_exit")
+        trailing_exit = trailing_decisions[0].params.get("position_exit")
+        assert isinstance(trailing_exit, dict)
+        self.assertEqual(trailing_exit.get("type"), "long_trailing_stop_bps")
+
+    def test_scheduler_runtime_position_trailing_stop_skips_non_profitable_exit(
+        self,
+    ) -> None:
+        engine = DecisionEngine(price_fetcher=None)
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="intraday-tsmom-trailing-stop-profit-floor",
+            description=_compose_strategy_description(
+                StrategyConfig(
+                    name="intraday-tsmom-trailing-stop-profit-floor",
+                    strategy_id="intraday_tsmom_v1@prod",
+                    strategy_type="intraday_tsmom_v1",
+                    version="1.1.0",
+                    base_timeframe="1Sec",
+                    universe_type="intraday_tsmom_v1",
+                    universe_symbols=["META"],
+                    max_position_pct_equity=Decimal("0.08"),
+                    max_notional_per_trade=Decimal("1000"),
+                    params={
+                        "require_positive_price_for_signal_exit": "true",
+                        "long_trailing_stop_activation_profit_bps": "20",
+                        "long_trailing_stop_drawdown_bps": "15",
+                    },
+                )
+            ),
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="intraday_tsmom_v1",
+            universe_symbols=["META"],
+            max_position_pct_equity=Decimal("0.08"),
+            max_notional_per_trade=Decimal("1000"),
+        )
+        peak_signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 27, 18, 29, 10, tzinfo=timezone.utc),
+            symbol="META",
+            timeframe="1Sec",
+            seq=11,
+            payload={
+                "price": 530.00,
+                "spread": 0.04,
+                "ema12": 529.50,
+                "ema26": 529.10,
+                "macd": 0.015,
+                "macd_signal": 0.010,
+                "rsi14": 58.0,
+                "vol_realized_w60s": 0.00018,
+            },
+        )
+        trailing_signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 27, 18, 30, 10, tzinfo=timezone.utc),
+            symbol="META",
+            timeframe="1Sec",
+            seq=12,
+            payload={
+                "price": 528.40,
+                "spread": 0.30,
+                "ema12": 529.10,
+                "ema26": 528.95,
+                "macd": 0.012,
+                "macd_signal": 0.009,
+                "rsi14": 56.5,
+                "vol_realized_w60s": 0.00018,
+            },
+        )
+        positions = [
+            {
+                "symbol": "META",
+                "qty": "1.9091",
+                "side": "long",
+                "market_value": "1009.5123",
+                "avg_entry_price": "528.29",
+            }
+        ]
+
+        with (
+            patch.object(settings, "trading_strategy_runtime_mode", "scheduler_v3"),
+            patch.object(settings, "trading_strategy_scheduler_enabled", True),
+            patch.object(settings, "trading_execution_prefer_limit", True),
+            patch.object(settings, "trading_fractional_equities_enabled", True),
+        ):
+            initial_decisions = engine.evaluate(peak_signal, [strategy], positions=positions)
+            trailing_decisions = engine.evaluate(trailing_signal, [strategy], positions=positions)
+
+        self.assertEqual(initial_decisions, [])
+        self.assertEqual(trailing_decisions, [])
+
+    def test_scheduler_runtime_position_exit_overlay_emits_session_flatten_exit(
+        self,
+    ) -> None:
+        engine = DecisionEngine(price_fetcher=None)
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="intraday-tsmom-session-flatten",
+            description=_compose_strategy_description(
+                StrategyConfig(
+                    name="intraday-tsmom-session-flatten",
+                    strategy_id="intraday_tsmom_v1@prod",
+                    strategy_type="intraday_tsmom_v1",
+                    version="1.1.0",
+                    base_timeframe="1Sec",
+                    universe_type="intraday_tsmom_v1",
+                    universe_symbols=["META"],
+                    max_position_pct_equity=Decimal("0.08"),
+                    max_notional_per_trade=Decimal("1000"),
+                    params={
+                        "session_flatten_start_minute_utc": "1170",
+                    },
+                )
+            ),
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="intraday_tsmom_v1",
+            universe_symbols=["META"],
+            max_position_pct_equity=Decimal("0.08"),
+            max_notional_per_trade=Decimal("1000"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 27, 19, 30, 0, tzinfo=timezone.utc),
+            symbol="META",
+            timeframe="1Sec",
+            seq=13,
+            payload={
+                "price": 525.10,
+                "spread": 0.20,
+                "ema12": 525.30,
+                "ema26": 525.25,
+                "macd": 0.001,
+                "macd_signal": 0.001,
+                "rsi14": 50.0,
+                "vol_realized_w60s": 0.00012,
+            },
+        )
+
+        with (
+            patch.object(settings, "trading_strategy_runtime_mode", "scheduler_v3"),
+            patch.object(settings, "trading_strategy_scheduler_enabled", True),
+            patch.object(settings, "trading_fractional_equities_enabled", True),
+        ):
+            decisions = engine.evaluate(
+                signal,
+                [strategy],
+                positions=[
+                    {
+                        "symbol": "META",
+                        "qty": "1.9091",
+                        "side": "long",
+                        "market_value": "1002.63",
+                        "avg_entry_price": "524.50",
+                    }
+                ],
+            )
+
+        self.assertEqual(len(decisions), 1)
+        self.assertEqual(decisions[0].action, "sell")
+        self.assertEqual(decisions[0].rationale, "session_flatten_exit")
+        session_exit = decisions[0].params.get("position_exit")
+        assert isinstance(session_exit, dict)
+        self.assertEqual(session_exit.get("type"), "session_flatten_minute_utc")
+
+    def test_scheduler_runtime_position_exit_overlay_session_flatten_bypasses_profit_floor(
+        self,
+    ) -> None:
+        engine = DecisionEngine(price_fetcher=None)
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="intraday-tsmom-session-flatten-loss",
+            description=_compose_strategy_description(
+                StrategyConfig(
+                    name="intraday-tsmom-session-flatten-loss",
+                    strategy_id="intraday_tsmom_v1@prod",
+                    strategy_type="intraday_tsmom_v1",
+                    version="1.1.0",
+                    base_timeframe="1Sec",
+                    universe_type="intraday_tsmom_v1",
+                    universe_symbols=["META"],
+                    max_position_pct_equity=Decimal("0.08"),
+                    max_notional_per_trade=Decimal("1000"),
+                    params={
+                        "session_flatten_start_minute_utc": "1170",
+                        "require_positive_price_for_signal_exit": "true",
+                        "min_signal_exit_profit_bps": "8",
+                    },
+                )
+            ),
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="intraday_tsmom_v1",
+            universe_symbols=["META"],
+            max_position_pct_equity=Decimal("0.08"),
+            max_notional_per_trade=Decimal("1000"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 27, 19, 30, 0, tzinfo=timezone.utc),
+            symbol="META",
+            timeframe="1Sec",
+            seq=13,
+            payload={
+                "price": 523.90,
+                "spread": 0.20,
+                "ema12": 524.20,
+                "ema26": 524.15,
+                "macd": -0.001,
+                "macd_signal": 0.001,
+                "rsi14": 48.0,
+                "vol_realized_w60s": 0.00012,
+            },
+        )
+
+        with (
+            patch.object(settings, "trading_strategy_runtime_mode", "scheduler_v3"),
+            patch.object(settings, "trading_strategy_scheduler_enabled", True),
+            patch.object(settings, "trading_fractional_equities_enabled", True),
+        ):
+            decisions = engine.evaluate(
+                signal,
+                [strategy],
+                positions=[
+                    {
+                        "symbol": "META",
+                        "qty": "1.9091",
+                        "side": "long",
+                        "market_value": "1000.00",
+                        "avg_entry_price": "524.50",
+                        "opened_at": "2026-03-27T18:15:00+00:00",
+                    }
+                ],
+            )
+
+        self.assertEqual(len(decisions), 1)
+        self.assertEqual(decisions[0].action, "sell")
+        self.assertEqual(decisions[0].rationale, "session_flatten_exit")
+
+    def test_scheduler_runtime_position_exit_overlay_emits_max_hold_exit(
+        self,
+    ) -> None:
+        engine = DecisionEngine(price_fetcher=None)
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="breakout-continuation-max-hold",
+            description=_compose_strategy_description(
+                StrategyConfig(
+                    name="breakout-continuation-max-hold",
+                    strategy_id="breakout_continuation_long_v1@research",
+                    strategy_type="breakout_continuation_long_v1",
+                    version="1.0.0",
+                    base_timeframe="1Sec",
+                    universe_type="breakout_continuation_long_v1",
+                    universe_symbols=["META"],
+                    max_position_pct_equity=Decimal("1.0"),
+                    max_notional_per_trade=Decimal("14000"),
+                    params={
+                        "max_hold_seconds": "300",
+                        "require_positive_price_for_signal_exit": "true",
+                        "min_signal_exit_profit_bps": "8",
+                    },
+                )
+            ),
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="breakout_continuation_long_v1",
+            universe_symbols=["META"],
+            max_position_pct_equity=Decimal("1.0"),
+            max_notional_per_trade=Decimal("14000"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 27, 17, 35, 30, tzinfo=timezone.utc),
+            symbol="META",
+            timeframe="1Sec",
+            seq=14,
+            payload={
+                "price": 522.90,
+                "spread": 0.08,
+                "ema12": 523.40,
+                "ema26": 523.10,
+                "macd": 0.006,
+                "macd_signal": 0.004,
+                "rsi14": 55.0,
+                "vol_realized_w60s": 0.00015,
+            },
+        )
+
+        with (
+            patch.object(settings, "trading_strategy_runtime_mode", "scheduler_v3"),
+            patch.object(settings, "trading_strategy_scheduler_enabled", True),
+            patch.object(settings, "trading_fractional_equities_enabled", True),
+        ):
+            decisions = engine.evaluate(
+                signal,
+                [strategy],
+                positions=[
+                    {
+                        "symbol": "META",
+                        "qty": "26.7624",
+                        "side": "long",
+                        "market_value": "13995.02",
+                        "avg_entry_price": "523.40",
+                        "opened_at": "2026-03-27T17:30:00+00:00",
+                    }
+                ],
+            )
+
+        self.assertEqual(len(decisions), 1)
+        self.assertEqual(decisions[0].action, "sell")
+        self.assertEqual(decisions[0].rationale, "position_time_exit")
+        max_hold_exit = decisions[0].params.get("position_exit")
+        assert isinstance(max_hold_exit, dict)
+        self.assertEqual(max_hold_exit.get("type"), "max_hold_seconds")
+
+    def test_scheduler_runtime_position_exit_overlay_emits_max_hold_exit_for_isolated_strategy(
+        self,
+    ) -> None:
+        strategy_id = uuid.uuid4()
+        engine = DecisionEngine(price_fetcher=None)
+        strategy = Strategy(
+            id=strategy_id,
+            name="breakout-continuation-max-hold-isolated",
+            description=_compose_strategy_description(
+                StrategyConfig(
+                    name="breakout-continuation-max-hold-isolated",
+                    strategy_id="breakout_continuation_long_v1@research",
+                    strategy_type="breakout_continuation_long_v1",
+                    version="1.0.0",
+                    base_timeframe="1Sec",
+                    universe_type="breakout_continuation_long_v1",
+                    universe_symbols=["META"],
+                    max_position_pct_equity=Decimal("1.0"),
+                    max_notional_per_trade=Decimal("14000"),
+                    params={
+                        "position_isolation_mode": "per_strategy",
+                        "max_hold_seconds": "300",
+                        "require_positive_price_for_signal_exit": "true",
+                        "min_signal_exit_profit_bps": "8",
+                    },
+                )
+            ),
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="breakout_continuation_long_v1",
+            universe_symbols=["META"],
+            max_position_pct_equity=Decimal("1.0"),
+            max_notional_per_trade=Decimal("14000"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 27, 17, 35, 30, tzinfo=timezone.utc),
+            symbol="META",
+            timeframe="1Sec",
+            seq=15,
+            payload={
+                "price": 522.90,
+                "spread": 0.08,
+                "ema12": 523.40,
+                "ema26": 523.10,
+                "macd": 0.006,
+                "macd_signal": 0.004,
+                "rsi14": 55.0,
+                "vol_realized_w60s": 0.00015,
+                "vwap_session": 523.05,
+                "imbalance_bid_sz": 4100,
+                "imbalance_ask_sz": 3900,
+            },
+        )
+
+        with (
+            patch.object(settings, "trading_strategy_runtime_mode", "scheduler_v3"),
+            patch.object(settings, "trading_strategy_scheduler_enabled", True),
+            patch.object(settings, "trading_fractional_equities_enabled", True),
+        ):
+            decisions = engine.evaluate(
+                signal,
+                [strategy],
+                positions=[
+                    {
+                        "symbol": "META",
+                        "strategy_id": str(strategy_id),
+                        "qty": "26.7624",
+                        "side": "long",
+                        "market_value": "13995.02",
+                        "avg_entry_price": "523.40",
+                        "opened_at": "2026-03-27T17:30:00+00:00",
+                    }
+                ],
+            )
+
+        self.assertEqual(len(decisions), 1)
+        self.assertEqual(decisions[0].action, "sell")
+        self.assertEqual(decisions[0].rationale, "position_time_exit")
+        runtime_payload = decisions[0].params.get("strategy_runtime")
+        assert isinstance(runtime_payload, dict)
+        self.assertEqual(runtime_payload.get("position_isolation_mode"), "per_strategy")
+        max_hold_exit = decisions[0].params.get("position_exit")
+        assert isinstance(max_hold_exit, dict)
+        self.assertEqual(max_hold_exit.get("type"), "max_hold_seconds")
 
     def test_scheduler_runtime_does_not_fallback_to_legacy_when_runtime_returns_no_intents(
         self,

--- a/services/torghut/tests/test_decisions.py
+++ b/services/torghut/tests/test_decisions.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 
 from app.config import settings
 from app.models import Strategy
+from app.strategies.catalog import StrategyConfig, _compose_strategy_description
 from app.trading.decisions import DecisionEngine
 from app.trading.models import SignalEnvelope
 from app.trading.prices import MarketSnapshot, PriceFetcher
@@ -561,6 +562,345 @@ class TestDecisionEngine(TestCase):
             )
 
         self.assertEqual(decisions, [])
+
+    def test_legacy_buy_clips_to_residual_symbol_capacity(self) -> None:
+        original_fractional = settings.trading_fractional_equities_enabled
+        original_max_pct = settings.trading_max_position_pct_equity
+        settings.trading_fractional_equities_enabled = True
+        settings.trading_max_position_pct_equity = 0.08
+        try:
+            engine = DecisionEngine(price_fetcher=None)
+            strategy = Strategy(
+                name="residual-cap-buy",
+                description=None,
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="static",
+                universe_symbols=None,
+                max_position_pct_equity=Decimal("0.08"),
+                max_notional_per_trade=Decimal("500"),
+            )
+            signal = SignalEnvelope(
+                event_ts=datetime(2026, 1, 1, tzinfo=timezone.utc),
+                symbol="AAPL",
+                payload={
+                    "macd": {"macd": Decimal("1.0"), "signal": Decimal("0.1")},
+                    "rsi14": Decimal("20"),
+                    "price": Decimal("100"),
+                },
+                timeframe="1Min",
+            )
+
+            decisions = engine.evaluate(
+                signal,
+                [strategy],
+                equity=Decimal("10000"),
+                positions=[{"symbol": "AAPL", "qty": "6.5", "market_value": "650"}],
+            )
+
+            self.assertEqual(len(decisions), 1)
+            self.assertEqual(decisions[0].qty, Decimal("1.5000"))
+            sizing = decisions[0].params.get("sizing")
+            assert isinstance(sizing, dict)
+            self.assertEqual(Decimal(str(sizing.get("requested_qty"))), Decimal("1.5"))
+            self.assertTrue(sizing.get("symbol_capacity_limited"))
+        finally:
+            settings.trading_fractional_equities_enabled = original_fractional
+            settings.trading_max_position_pct_equity = original_max_pct
+
+    def test_legacy_buy_skips_when_residual_symbol_capacity_is_below_min_qty(self) -> None:
+        original_fractional = settings.trading_fractional_equities_enabled
+        original_max_pct = settings.trading_max_position_pct_equity
+        settings.trading_fractional_equities_enabled = False
+        settings.trading_max_position_pct_equity = 0.08
+        try:
+            engine = DecisionEngine(price_fetcher=None)
+            strategy = Strategy(
+                name="residual-cap-min-qty",
+                description=None,
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="static",
+                universe_symbols=None,
+                max_position_pct_equity=Decimal("0.08"),
+                max_notional_per_trade=Decimal("500"),
+            )
+            signal = SignalEnvelope(
+                event_ts=datetime(2026, 1, 1, tzinfo=timezone.utc),
+                symbol="AAPL",
+                payload={
+                    "macd": {"macd": Decimal("1.0"), "signal": Decimal("0.1")},
+                    "rsi14": Decimal("20"),
+                    "price": Decimal("100"),
+                },
+                timeframe="1Min",
+            )
+
+            decisions = engine.evaluate(
+                signal,
+                [strategy],
+                equity=Decimal("10000"),
+                positions=[{"symbol": "AAPL", "qty": "7.95", "market_value": "795"}],
+            )
+
+            self.assertEqual(decisions, [])
+        finally:
+            settings.trading_fractional_equities_enabled = original_fractional
+            settings.trading_max_position_pct_equity = original_max_pct
+
+    def test_scheduler_runtime_intraday_tsmom_skips_same_direction_reentry(self) -> None:
+        engine = DecisionEngine(price_fetcher=None)
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="intraday-tsmom",
+            description="version=1.1.0",
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="intraday_tsmom_v1",
+            universe_symbols=["NVDA"],
+            max_position_pct_equity=Decimal("0.02"),
+            max_notional_per_trade=Decimal("2500"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 2, 10, tzinfo=timezone.utc),
+            symbol="NVDA",
+            timeframe="1Sec",
+            seq=7,
+            payload={
+                "price": 140.25,
+                "ema12": 140.40,
+                "ema26": 139.95,
+                "macd": 0.45,
+                "macd_signal": 0.30,
+                "rsi14": 56,
+                "vol_realized_w60s": 0.009,
+            },
+        )
+
+        with (
+            patch.object(settings, "trading_strategy_runtime_mode", "scheduler_v3"),
+            patch.object(settings, "trading_strategy_scheduler_enabled", True),
+        ):
+            decisions = engine.evaluate(
+                signal,
+                [strategy],
+                positions=[{"symbol": "NVDA", "qty": "3", "side": "long", "market_value": "420.75"}],
+            )
+
+        self.assertEqual(decisions, [])
+
+    def test_scheduler_runtime_intraday_tsmom_skips_exit_only_sell_without_long_inventory(
+        self,
+    ) -> None:
+        engine = DecisionEngine(price_fetcher=None)
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="intraday-tsmom",
+            description="version=1.1.0",
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="intraday_tsmom_v1",
+            universe_symbols=["NVDA"],
+            max_position_pct_equity=Decimal("0.02"),
+            max_notional_per_trade=Decimal("2500"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 2, 10, tzinfo=timezone.utc),
+            symbol="NVDA",
+            timeframe="1Sec",
+            seq=8,
+            payload={
+                "price": 140.25,
+                "ema12": 139.90,
+                "ema26": 140.40,
+                "macd": -0.205,
+                "macd_signal": -0.18,
+                "rsi14": 38,
+                "vol_realized_w60s": 0.009,
+            },
+        )
+
+        with (
+            patch.object(settings, "trading_strategy_runtime_mode", "scheduler_v3"),
+            patch.object(settings, "trading_strategy_scheduler_enabled", True),
+        ):
+            decisions = engine.evaluate(signal, [strategy], positions=[])
+
+        self.assertEqual(decisions, [])
+
+    def test_scheduler_runtime_intraday_tsmom_caps_exit_only_sell_to_long_inventory(
+        self,
+    ) -> None:
+        engine = DecisionEngine(price_fetcher=None)
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="intraday-tsmom",
+            description="version=1.1.0",
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="intraday_tsmom_v1",
+            universe_symbols=["NVDA"],
+            max_position_pct_equity=Decimal("0.02"),
+            max_notional_per_trade=Decimal("2500"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 2, 10, tzinfo=timezone.utc),
+            symbol="NVDA",
+            timeframe="1Sec",
+            seq=9,
+            payload={
+                "price": 140.25,
+                "ema12": 139.90,
+                "ema26": 140.40,
+                "macd": -0.205,
+                "macd_signal": -0.18,
+                "rsi14": 38,
+                "vol_realized_w60s": 0.009,
+            },
+        )
+
+        with (
+            patch.object(settings, "trading_strategy_runtime_mode", "scheduler_v3"),
+            patch.object(settings, "trading_strategy_scheduler_enabled", True),
+        ):
+            decisions = engine.evaluate(
+                signal,
+                [strategy],
+                positions=[
+                    {
+                        "symbol": "NVDA",
+                        "qty": "3",
+                        "side": "long",
+                        "market_value": "420.75",
+                    }
+                ],
+            )
+
+        self.assertEqual(len(decisions), 1)
+        self.assertEqual(decisions[0].action, "sell")
+        self.assertEqual(decisions[0].qty, Decimal("3"))
+
+    def test_scheduler_runtime_intraday_tsmom_exit_only_sell_ignores_entry_notional_budget(
+        self,
+    ) -> None:
+        engine = DecisionEngine(price_fetcher=None)
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="intraday-tsmom",
+            description="version=1.1.0",
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="intraday_tsmom_v1",
+            universe_symbols=["META"],
+            max_position_pct_equity=Decimal("0.08"),
+            max_notional_per_trade=Decimal("1000"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 2, 10, tzinfo=timezone.utc),
+            symbol="META",
+            timeframe="1Sec",
+            seq=10,
+            payload={
+                "price": 528.29,
+                "ema12": 527.90,
+                "ema26": 528.40,
+                "macd": -0.205,
+                "macd_signal": -0.18,
+                "rsi14": 38,
+                "vol_realized_w60s": 0.009,
+            },
+        )
+
+        with (
+            patch.object(settings, "trading_strategy_runtime_mode", "scheduler_v3"),
+            patch.object(settings, "trading_strategy_scheduler_enabled", True),
+            patch.object(settings, "trading_fractional_equities_enabled", True),
+        ):
+            decisions = engine.evaluate(
+                signal,
+                [strategy],
+                positions=[
+                    {
+                        "symbol": "META",
+                        "qty": "1.9091",
+                        "side": "long",
+                        "market_value": "1008.144239",
+                    }
+                ],
+            )
+
+        self.assertEqual(len(decisions), 1)
+        self.assertEqual(decisions[0].action, "sell")
+        self.assertEqual(decisions[0].qty, Decimal("1.9091"))
+
+    def test_scheduler_runtime_intraday_tsmom_emits_stop_loss_exit_overlay(self) -> None:
+        engine = DecisionEngine(price_fetcher=None)
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="intraday-tsmom-stop",
+            description=_compose_strategy_description(
+                StrategyConfig(
+                    name="intraday-tsmom-stop",
+                    strategy_id="intraday_tsmom_v1@prod",
+                    strategy_type="intraday_tsmom_v1",
+                    version="1.1.0",
+                    base_timeframe="1Sec",
+                    universe_type="intraday_tsmom_v1",
+                    universe_symbols=["META"],
+                    max_position_pct_equity=Decimal("0.08"),
+                    max_notional_per_trade=Decimal("1000"),
+                    params={"long_stop_loss_bps": "25"},
+                )
+            ),
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="intraday_tsmom_v1",
+            universe_symbols=["META"],
+            max_position_pct_equity=Decimal("0.08"),
+            max_notional_per_trade=Decimal("1000"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 27, 18, 29, 10, tzinfo=timezone.utc),
+            symbol="META",
+            timeframe="1Sec",
+            seq=11,
+            payload={
+                "price": 526.70,
+                "ema12": 526.90,
+                "ema26": 526.85,
+                "macd": 0.010,
+                "macd_signal": 0.008,
+                "rsi14": 56.4,
+                "vol_realized_w60s": 0.00018,
+            },
+        )
+
+        with (
+            patch.object(settings, "trading_strategy_runtime_mode", "scheduler_v3"),
+            patch.object(settings, "trading_strategy_scheduler_enabled", True),
+            patch.object(settings, "trading_fractional_equities_enabled", True),
+        ):
+            decisions = engine.evaluate(
+                signal,
+                [strategy],
+                positions=[
+                    {
+                        "symbol": "META",
+                        "qty": "1.9091",
+                        "side": "long",
+                        "market_value": "1005.12497",
+                        "avg_entry_price": "528.29",
+                    }
+                ],
+            )
+
+        self.assertEqual(len(decisions), 1)
+        self.assertEqual(decisions[0].action, "sell")
+        self.assertEqual(decisions[0].qty, Decimal("1.9091"))
+        self.assertEqual(decisions[0].rationale, "position_stop_loss_exit")
+        position_exit = decisions[0].params.get("position_exit")
+        assert isinstance(position_exit, dict)
+        self.assertEqual(position_exit.get("type"), "long_stop_loss_bps")
 
     def test_scheduler_runtime_does_not_fallback_to_legacy_when_runtime_returns_no_intents(
         self,

--- a/services/torghut/tests/test_execution_adapters.py
+++ b/services/torghut/tests/test_execution_adapters.py
@@ -68,6 +68,17 @@ class FakeFallbackAdapter:
     def list_positions(self) -> list[dict[str, str]]:
         return []
 
+    def get_account(self) -> dict[str, bool]:
+        return {'shorting_enabled': True}
+
+    def get_asset(self, symbol_or_asset_id: str) -> dict[str, str | bool]:
+        return {
+            'symbol': symbol_or_asset_id,
+            'tradable': True,
+            'shortable': True,
+            'easy_to_borrow': True,
+        }
+
 
 class FakeOrderFirewall:
     def submit_order(self, **kwargs):  # type: ignore[no-untyped-def]
@@ -718,6 +729,25 @@ class TestExecutionAdapters(TestCase):
             fallback=None,
         )
         self.assertIsNone(adapter.list_positions())
+
+    def test_lean_short_precheck_metadata_passthrough_uses_fallback(self) -> None:
+        fallback = FakeFallbackAdapter()
+        adapter = LeanExecutionAdapter(
+            base_url='http://lean.invalid',
+            timeout_seconds=1,
+            fallback=fallback,
+        )
+
+        self.assertEqual(adapter.get_account(), {'shorting_enabled': True})
+        self.assertEqual(
+            adapter.get_asset('AAPL'),
+            {
+                'symbol': 'AAPL',
+                'tradable': True,
+                'shortable': True,
+                'easy_to_borrow': True,
+            },
+        )
 
     def test_lean_submit_symbol_mismatch_triggers_fallback(self) -> None:
         class InvalidLeanAdapter(LeanExecutionAdapter):

--- a/services/torghut/tests/test_local_intraday_tsmom_replay.py
+++ b/services/torghut/tests/test_local_intraday_tsmom_replay.py
@@ -1,0 +1,363 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+from pathlib import Path
+from unittest import TestCase
+
+from app.trading.models import SignalEnvelope, StrategyDecision
+from scripts.local_intraday_tsmom_replay import (
+    PendingOrder,
+    PositionState,
+    ReplayConfig,
+    _SHARED_POSITION_OWNER,
+    _apply_order_preferences,
+    _parse_signal_row,
+    _positions_payload,
+    _quote_quality_status,
+    _resolve_pending_fill_price,
+    _should_replace_pending_order,
+)
+
+
+class TestLocalIntradayTsmomReplay(TestCase):
+    def _signal(self, *, bid: str, ask: str, price: str) -> SignalEnvelope:
+        return SignalEnvelope(
+            event_ts=datetime(2026, 3, 27, 17, 30, 24, tzinfo=timezone.utc),
+            symbol='META',
+            timeframe='1Sec',
+            seq=12,
+            payload={
+                'price': Decimal(price),
+                'imbalance_bid_px': Decimal(bid),
+                'imbalance_ask_px': Decimal(ask),
+                'spread': Decimal(ask) - Decimal(bid),
+            },
+        )
+
+    def _decision(
+        self,
+        *,
+        action: str,
+        order_type: str,
+        limit_price: str | None = None,
+    ) -> StrategyDecision:
+        return StrategyDecision(
+            strategy_id='intraday_tsmom_v1@prod',
+            symbol='META',
+            event_ts=datetime(2026, 3, 27, 17, 30, 3, tzinfo=timezone.utc),
+            timeframe='1Sec',
+            action=action,
+            qty=Decimal('10'),
+            order_type=order_type,
+            time_in_force='day',
+            limit_price=Decimal(limit_price) if limit_price is not None else None,
+            rationale='test',
+            params={},
+        )
+
+    def test_limit_sell_does_not_fill_below_limit(self) -> None:
+        decision = self._decision(action='sell', order_type='limit', limit_price='524.10')
+        signal = self._signal(bid='523.22', ask='523.28', price='523.25')
+
+        fill_price = _resolve_pending_fill_price(decision, signal)
+
+        self.assertIsNone(fill_price)
+
+    def test_limit_sell_fills_at_bid_when_bid_crosses_limit(self) -> None:
+        decision = self._decision(action='sell', order_type='limit', limit_price='524.10')
+        signal = self._signal(bid='524.18', ask='524.24', price='524.21')
+
+        fill_price = _resolve_pending_fill_price(decision, signal)
+
+        self.assertEqual(fill_price, Decimal('524.18'))
+
+    def test_limit_buy_fills_at_ask_when_ask_is_inside_limit(self) -> None:
+        decision = self._decision(action='buy', order_type='limit', limit_price='593.95')
+        signal = self._signal(bid='593.70', ask='593.80', price='593.75')
+
+        fill_price = _resolve_pending_fill_price(decision, signal)
+
+        self.assertEqual(fill_price, Decimal('593.80'))
+
+    def test_quote_quality_rejects_wide_spread_outlier(self) -> None:
+        signal = self._signal(bid='239.11', ask='253.69', price='246.40')
+        config = ReplayConfig(
+            strategy_configmap_path=Path('/tmp/strategies.yaml'),
+            clickhouse_http_url='http://localhost:8123',
+            clickhouse_username=None,
+            clickhouse_password=None,
+            start_date=datetime(2026, 3, 27, tzinfo=timezone.utc).date(),
+            end_date=datetime(2026, 3, 27, tzinfo=timezone.utc).date(),
+            chunk_minutes=10,
+            flatten_eod=True,
+            start_equity=Decimal('31590.02'),
+        )
+
+        status = _quote_quality_status(
+            signal=signal,
+            previous_price=Decimal('253.70'),
+            config=config,
+        )
+
+        self.assertFalse(status.valid)
+        self.assertEqual(status.reason, 'spread_bps_exceeded')
+
+    def test_quote_quality_accepts_normal_tight_quote(self) -> None:
+        signal = self._signal(bid='253.69', ask='253.72', price='253.705')
+        config = ReplayConfig(
+            strategy_configmap_path=Path('/tmp/strategies.yaml'),
+            clickhouse_http_url='http://localhost:8123',
+            clickhouse_username=None,
+            clickhouse_password=None,
+            start_date=datetime(2026, 3, 27, tzinfo=timezone.utc).date(),
+            end_date=datetime(2026, 3, 27, tzinfo=timezone.utc).date(),
+            chunk_minutes=10,
+            flatten_eod=True,
+            start_equity=Decimal('31590.02'),
+        )
+
+        status = _quote_quality_status(
+            signal=signal,
+            previous_price=Decimal('253.68'),
+            config=config,
+        )
+
+        self.assertTrue(status.valid)
+
+    def test_session_flatten_exit_keeps_market_order(self) -> None:
+        decision = StrategyDecision(
+            strategy_id='intraday_tsmom_v1@prod',
+            symbol='META',
+            event_ts=datetime(2026, 3, 27, 19, 30, 0, tzinfo=timezone.utc),
+            timeframe='1Sec',
+            action='sell',
+            qty=Decimal('10'),
+            order_type='market',
+            time_in_force='day',
+            rationale='session_flatten_exit',
+            params={'position_exit': {'type': 'session_flatten_minute_utc'}},
+        )
+        signal = self._signal(bid='524.90', ask='525.10', price='525.00')
+
+        updated = _apply_order_preferences(decision, signal)
+
+        self.assertEqual(updated.order_type, 'market')
+        self.assertIsNone(updated.limit_price)
+
+    def test_session_flatten_exit_replaces_resting_sell_limit(self) -> None:
+        existing = StrategyDecision(
+            strategy_id='intraday_tsmom_v1@prod',
+            symbol='META',
+            event_ts=datetime(2026, 3, 27, 19, 11, 0, tzinfo=timezone.utc),
+            timeframe='1Sec',
+            action='sell',
+            qty=Decimal('10'),
+            order_type='limit',
+            time_in_force='day',
+            limit_price=Decimal('524.10'),
+            rationale='signal_exit',
+            params={'position_exit': {'type': 'signal_exit'}},
+        )
+        replacement = StrategyDecision(
+            strategy_id='intraday_tsmom_v1@prod',
+            symbol='META',
+            event_ts=datetime(2026, 3, 27, 19, 30, 0, tzinfo=timezone.utc),
+            timeframe='1Sec',
+            action='sell',
+            qty=Decimal('10'),
+            order_type='market',
+            time_in_force='day',
+            rationale='session_flatten_exit',
+            params={'position_exit': {'type': 'session_flatten_minute_utc'}},
+        )
+
+        should_replace = _should_replace_pending_order(
+            existing=existing,
+            replacement=replacement,
+        )
+
+        self.assertTrue(should_replace)
+
+    def test_more_aggressive_sell_limit_replaces_resting_sell_limit(self) -> None:
+        existing = StrategyDecision(
+            strategy_id='intraday_tsmom_v1@prod',
+            symbol='META',
+            event_ts=datetime(2026, 3, 27, 19, 11, 0, tzinfo=timezone.utc),
+            timeframe='1Sec',
+            action='sell',
+            qty=Decimal('10'),
+            order_type='limit',
+            time_in_force='day',
+            limit_price=Decimal('524.10'),
+            rationale='signal_exit',
+            params={'position_exit': {'type': 'signal_exit'}},
+        )
+        replacement = StrategyDecision(
+            strategy_id='intraday_tsmom_v1@prod',
+            symbol='META',
+            event_ts=datetime(2026, 3, 27, 19, 12, 0, tzinfo=timezone.utc),
+            timeframe='1Sec',
+            action='sell',
+            qty=Decimal('10'),
+            order_type='limit',
+            time_in_force='day',
+            limit_price=Decimal('523.80'),
+            rationale='signal_exit',
+            params={'position_exit': {'type': 'signal_exit'}},
+        )
+
+        should_replace = _should_replace_pending_order(
+            existing=existing,
+            replacement=replacement,
+        )
+
+        self.assertTrue(should_replace)
+
+    def test_positions_payload_projects_pending_buy_exposure(self) -> None:
+        signal = self._signal(bid='523.22', ask='523.28', price='523.25')
+        pending_buy = PendingOrder(
+            decision=self._decision(action='buy', order_type='limit', limit_price='523.40'),
+            created_at=datetime(2026, 3, 27, 17, 30, 3, tzinfo=timezone.utc),
+            signal=signal,
+        )
+
+        payload = _positions_payload(
+            {},
+            {},
+            {('META', _SHARED_POSITION_OWNER): pending_buy},
+        )
+
+        self.assertEqual(payload, [
+            {
+                'symbol': 'META',
+                'strategy_id': _SHARED_POSITION_OWNER,
+                'qty': '10',
+                'side': 'long',
+                'market_value': '5234.00',
+                'avg_entry_price': '523.40',
+                'opened_at': signal.event_ts.isoformat(),
+                'decision_at': pending_buy.created_at.isoformat(),
+                'pending_entry': True,
+            }
+        ])
+
+    def test_positions_payload_projects_pending_sell_against_existing_long(self) -> None:
+        positions = {
+            ('META', _SHARED_POSITION_OWNER): PositionState(
+                strategy_id=_SHARED_POSITION_OWNER,
+                qty=Decimal('10'),
+                avg_entry_price=Decimal('520'),
+                opened_at=datetime(2026, 3, 27, 17, 0, 0, tzinfo=timezone.utc),
+                entry_cost_total=Decimal('0'),
+                decision_at=datetime(2026, 3, 27, 17, 0, 0, tzinfo=timezone.utc),
+            )
+        }
+        signal = self._signal(bid='523.22', ask='523.28', price='523.25')
+        pending_sell = PendingOrder(
+            decision=self._decision(action='sell', order_type='limit', limit_price='523.10'),
+            created_at=datetime(2026, 3, 27, 17, 30, 3, tzinfo=timezone.utc),
+            signal=signal,
+        )
+
+        payload = _positions_payload(
+            positions,
+            {'META': Decimal('523.25')},
+            {('META', _SHARED_POSITION_OWNER): pending_sell},
+        )
+
+        self.assertEqual(payload, [])
+
+    def test_positions_payload_keeps_other_strategy_position_when_isolated_sell_pending(self) -> None:
+        positions = {
+            ('META', 'breakout_continuation_long_v1@research'): PositionState(
+                strategy_id='breakout_continuation_long_v1@research',
+                qty=Decimal('10'),
+                avg_entry_price=Decimal('520'),
+                opened_at=datetime(2026, 3, 27, 17, 0, 0, tzinfo=timezone.utc),
+                entry_cost_total=Decimal('0'),
+                decision_at=datetime(2026, 3, 27, 17, 0, 0, tzinfo=timezone.utc),
+            ),
+            ('META', 'mean_reversion_rebound_long_v1@research'): PositionState(
+                strategy_id='mean_reversion_rebound_long_v1@research',
+                qty=Decimal('6'),
+                avg_entry_price=Decimal('521'),
+                opened_at=datetime(2026, 3, 27, 17, 5, 0, tzinfo=timezone.utc),
+                entry_cost_total=Decimal('0'),
+                decision_at=datetime(2026, 3, 27, 17, 5, 0, tzinfo=timezone.utc),
+            ),
+        }
+        signal = self._signal(bid='523.22', ask='523.28', price='523.25')
+        pending_sell = StrategyDecision(
+            strategy_id='mean_reversion_rebound_long_v1@research',
+            symbol='META',
+            event_ts=datetime(2026, 3, 27, 17, 30, 3, tzinfo=timezone.utc),
+            timeframe='1Sec',
+            action='sell',
+            qty=Decimal('6'),
+            order_type='limit',
+            time_in_force='day',
+            limit_price=Decimal('523.10'),
+            rationale='mean_reversion_rebound_exit',
+            params={'strategy_runtime': {'position_isolation_mode': 'per_strategy'}},
+        )
+
+        payload = _positions_payload(
+            positions,
+            {'META': Decimal('523.25')},
+            {
+                ('META', 'mean_reversion_rebound_long_v1@research'): PendingOrder(
+                    decision=pending_sell,
+                    created_at=datetime(2026, 3, 27, 17, 30, 3, tzinfo=timezone.utc),
+                    signal=signal,
+                )
+            },
+        )
+
+        self.assertEqual(payload, [
+            {
+                'symbol': 'META',
+                'strategy_id': 'breakout_continuation_long_v1@research',
+                'qty': '10',
+                'side': 'long',
+                'market_value': '5232.50',
+                'avg_entry_price': '520',
+                'opened_at': '2026-03-27T17:00:00+00:00',
+                'decision_at': '2026-03-27T17:00:00+00:00',
+                'pending_entry': False,
+            }
+        ])
+
+    def test_parse_signal_row_preserves_vwap_and_imbalance_sizes(self) -> None:
+        parsed = _parse_signal_row(
+            [
+                'META',
+                '2026-03-27 17:30:24.000',
+                '12',
+                '0.031',
+                '0.019',
+                '523.10',
+                '522.80',
+                '57',
+                '523.25',
+                '523.22',
+                '523.28',
+                '0.06',
+                '1200',
+                '800',
+                '0.06',
+                '522.95',
+                '523.05',
+                '0.00018',
+            ]
+        )
+
+        assert parsed is not None
+        self.assertEqual(parsed.payload['vwap_session'], Decimal('522.95'))
+        self.assertEqual(parsed.payload['vwap_w5m'], Decimal('523.05'))
+        self.assertEqual(parsed.payload['imbalance_bid_sz'], Decimal('1200'))
+        self.assertEqual(parsed.payload['imbalance_ask_sz'], Decimal('800'))
+        imbalance = parsed.payload['imbalance']
+        assert isinstance(imbalance, dict)
+        self.assertEqual(imbalance['bid_sz'], Decimal('1200'))
+        self.assertEqual(imbalance['ask_sz'], Decimal('800'))

--- a/services/torghut/tests/test_order_idempotency.py
+++ b/services/torghut/tests/test_order_idempotency.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import sessionmaker
 
 from app.models import Base, Execution, ExecutionOrderEvent, ExecutionTCAMetric, Strategy, TradeDecision
 from app.config import settings
+from app.trading.execution_adapters import LeanExecutionAdapter
 from app.trading.execution import OrderExecutor
 from app.trading.models import StrategyDecision, decision_hash
 from app.trading.reconcile import Reconciler
@@ -1236,6 +1237,54 @@ class TestOrderIdempotency(TestCase):
                 executor.submit_order(
                     session,
                     SymbolNotShortableClient(),
+                    decision,
+                    decision_row,
+                    "paper",
+                )
+
+            payload = json.loads(str(context.exception))
+            self.assertEqual(payload.get("source"), "local_pre_submit")
+            self.assertEqual(payload.get("code"), "local_symbol_not_shortable")
+
+    def test_submit_order_precheck_blocks_short_when_lean_fallback_symbol_not_shortable(
+        self,
+    ) -> None:
+        settings.trading_allow_shorts = True
+        settings.trading_mode = "live"
+        with self.session_local() as session:
+            strategy = Strategy(
+                name="demo",
+                description="demo",
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="static",
+                universe_symbols=["AAPL"],
+            )
+            session.add(strategy)
+            session.commit()
+            session.refresh(strategy)
+
+            decision = StrategyDecision(
+                strategy_id=str(strategy.id),
+                symbol="AAPL",
+                event_ts=datetime(2026, 2, 10, tzinfo=timezone.utc),
+                timeframe="1Min",
+                action="sell",
+                qty=Decimal("1"),
+                params={"price": Decimal("100")},
+            )
+            executor = OrderExecutor()
+            decision_row = executor.ensure_decision(session, decision, strategy, "paper")
+            execution_client = LeanExecutionAdapter(
+                base_url="http://lean.invalid",
+                timeout_seconds=1,
+                fallback=SymbolNotShortableClient(),
+            )
+
+            with self.assertRaises(RuntimeError) as context:
+                executor.submit_order(
+                    session,
+                    execution_client,
                     decision,
                     decision_row,
                     "paper",

--- a/services/torghut/tests/test_order_idempotency.py
+++ b/services/torghut/tests/test_order_idempotency.py
@@ -318,6 +318,41 @@ class TestOrderIdempotency(TestCase):
         hash_b = decision_hash(decision, account_label='paper-b')
         self.assertNotEqual(hash_a, hash_b)
 
+    def test_decision_hash_ignores_telemetry_only_params(self) -> None:
+        event_ts = datetime(2026, 2, 10, tzinfo=timezone.utc)
+        decision_a = StrategyDecision(
+            strategy_id='strategy-1',
+            symbol='AAPL',
+            event_ts=event_ts,
+            timeframe='1Min',
+            action='buy',
+            qty=Decimal('1.0'),
+            order_type='market',
+            time_in_force='day',
+            params={
+                'forecast': {'point_forecast': '101.0'},
+                'forecast_audit': {'inference_latency_ms': 114},
+                'strategy_runtime': {'intent_conflicts_total': 0},
+            },
+        )
+        decision_b = StrategyDecision(
+            strategy_id='strategy-1',
+            symbol='AAPL',
+            event_ts=event_ts,
+            timeframe='1Min',
+            action='buy',
+            qty=Decimal('1.0'),
+            order_type='market',
+            time_in_force='day',
+            params={
+                'forecast': {'point_forecast': '101.0'},
+                'forecast_audit': {'inference_latency_ms': 197},
+                'strategy_runtime': {'intent_conflicts_total': 1},
+            },
+        )
+
+        self.assertEqual(decision_hash(decision_a), decision_hash(decision_b))
+
     def test_execution_exists_ignores_unrelated_same_account_execution(self) -> None:
         with self.session_local() as session:
             strategy = Strategy(

--- a/services/torghut/tests/test_profitability_archive.py
+++ b/services/torghut/tests/test_profitability_archive.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import json
+from datetime import date
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import TestCase
+
+from app.trading.profitability_archive import (
+    ARCHIVE_STATUS_ARCHIVED,
+    archive_historical_simulation_run,
+    build_trial_ledger,
+    summarize_data_sufficiency,
+)
+from tests.profitability_archive_test_utils import (
+    default_postgres_counts,
+    iter_trading_days,
+    make_archived_bundle,
+    write_historical_run,
+)
+
+
+class TestProfitabilityArchive(TestCase):
+    def test_archive_historical_simulation_run_copies_source_dump_and_writes_bundle_contracts(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            run_dir, manifest_path = write_historical_run(
+                root=root,
+                run_name='sim-2026-03-27',
+                trading_day='2026-03-27',
+                candidate_id='momentum_pullback_long',
+                net_pnl='275',
+            )
+            archive_root = root / 'archive'
+
+            result = archive_historical_simulation_run(
+                run_dir=run_dir,
+                archive_root=archive_root,
+                manifest_path=manifest_path,
+                topic_retention_ms_by_topic={'torghut.trades.v1': 14 * 86_400_000},
+                postgres_counts=default_postgres_counts(),
+            )
+
+            self.assertEqual(result['archive_status'], ARCHIVE_STATUS_ARCHIVED)
+            archive_dir = Path(result['archive_dir'])
+            self.assertTrue((archive_dir / 'source-dump.jsonl.zst').exists())
+
+            replay_manifest = json.loads((archive_dir / 'replay_day_manifest.json').read_text(encoding='utf-8'))
+            self.assertEqual(replay_manifest['simulation_database'], 'torghut_sim_sim-2026-03-27')
+            self.assertEqual(replay_manifest['archive_status'], ARCHIVE_STATUS_ARCHIVED)
+
+            market_day_inventory = json.loads((archive_dir / 'market_day_inventory.json').read_text(encoding='utf-8'))
+            self.assertTrue(market_day_inventory['replayable_market_day'])
+
+            execution_day_inventory = json.loads(
+                (archive_dir / 'execution_day_inventory.json').read_text(encoding='utf-8')
+            )
+            self.assertTrue(execution_day_inventory['execution_day_eligible'])
+
+    def test_trial_ledger_selects_candidate_with_proof_eligible_days(self) -> None:
+        bundles = [
+            make_archived_bundle(
+                trading_day='2026-03-24',
+                candidate_id='candidate-a',
+                net_pnl='150',
+                execution_day_eligible=False,
+            ),
+            make_archived_bundle(
+                trading_day='2026-03-24',
+                candidate_id='candidate-b',
+                net_pnl='90',
+                execution_day_eligible=True,
+            ),
+        ]
+
+        ledger = build_trial_ledger(bundles)
+
+        self.assertEqual(ledger['selected_candidate_id'], 'candidate-b')
+
+    def test_data_sufficiency_marks_short_archive_insufficient(self) -> None:
+        trading_days = iter_trading_days(start_day=date(2026, 3, 2), count=10)
+        bundles = [
+            make_archived_bundle(
+                trading_day=trading_day,
+                candidate_id='candidate-a',
+                net_pnl='125',
+            )
+            for trading_day in trading_days
+        ]
+
+        summary = summarize_data_sufficiency(bundles)
+
+        self.assertEqual(summary['status'], 'insufficient_history')
+        self.assertIn('replay_ready_market_days_below_research_minimum', summary['blockers'])

--- a/services/torghut/tests/test_run_archive_backed_profitability_proof.py
+++ b/services/torghut/tests/test_run_archive_backed_profitability_proof.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import json
+from datetime import date
+from decimal import Decimal
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import TestCase
+
+from app.trading.profitability_archive import archive_historical_simulation_run
+from scripts.run_archive_backed_profitability_proof import run_archive_backed_profitability_proof
+from tests.profitability_archive_test_utils import (
+    default_postgres_counts,
+    iter_trading_days,
+    write_historical_run,
+)
+
+
+def _archive_candidate_days(
+    *,
+    root: Path,
+    archive_root: Path,
+    candidate_id: str,
+    trading_days: list[str],
+    daily_net_pnl_fn,
+) -> None:
+    for index, trading_day in enumerate(trading_days):
+        run_name = f'{candidate_id}-{trading_day}'
+        run_dir, manifest_path = write_historical_run(
+            root=root,
+            run_name=run_name,
+            trading_day=trading_day,
+            candidate_id=candidate_id,
+            net_pnl=format(Decimal(daily_net_pnl_fn(index)), 'f'),
+            avg_abs_slippage_bps=4.0 + float(index % 3),
+            p95_abs_slippage_bps=8.0 + float(index % 5),
+        )
+        archive_historical_simulation_run(
+            run_dir=run_dir,
+            archive_root=archive_root,
+            manifest_path=manifest_path,
+            topic_retention_ms_by_topic={'torghut.trades.v1': 14 * 86_400_000},
+            postgres_counts=default_postgres_counts(),
+        )
+
+
+class TestRunArchiveBackedProfitabilityProof(TestCase):
+    def test_short_archive_resolves_to_insufficient_history(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            archive_root = root / 'archive'
+            trading_days = iter_trading_days(start_day=date(2026, 3, 2), count=10)
+            _archive_candidate_days(
+                root=root,
+                archive_root=archive_root,
+                candidate_id='momentum_pullback_long',
+                trading_days=trading_days,
+                daily_net_pnl_fn=lambda _: Decimal('180'),
+            )
+
+            summary = run_archive_backed_profitability_proof(
+                archive_root=archive_root,
+                output_dir=root / 'proof',
+            )
+
+            self.assertEqual(summary['certificate_status'], 'insufficient_history')
+            certificate = json.loads(Path(summary['profitability_certificate_path']).read_text(encoding='utf-8'))
+            self.assertEqual(certificate['status'], 'insufficient_history')
+            self.assertIn('replay_ready_market_days_below_research_minimum', certificate['promotion_blockers'])
+
+    def test_positive_but_sub_target_candidate_fails_historical_gate(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            archive_root = root / 'archive'
+            trading_days = iter_trading_days(start_day=date(2026, 1, 5), count=30)
+            _archive_candidate_days(
+                root=root,
+                archive_root=archive_root,
+                candidate_id='momentum_pullback_long',
+                trading_days=trading_days,
+                daily_net_pnl_fn=lambda index: Decimal('100') + Decimal(index % 5),
+            )
+            _archive_candidate_days(
+                root=root,
+                archive_root=archive_root,
+                candidate_id='breakout_continuation_long',
+                trading_days=trading_days,
+                daily_net_pnl_fn=lambda index: Decimal('80') + Decimal(index % 5),
+            )
+
+            summary = run_archive_backed_profitability_proof(
+                archive_root=archive_root,
+                output_dir=root / 'proof',
+                profit_target_daily_net_usd=Decimal('250'),
+                median_target_daily_net_usd=Decimal('125'),
+                profitable_day_ratio_target=Decimal('0.60'),
+                min_research_days=10,
+                min_historical_days=10,
+                min_execution_days=10,
+                train_days=3,
+                validation_days=3,
+                test_days=3,
+                step_days=3,
+                embargo_days=0,
+                reality_check_bootstrap_replicates=100,
+            )
+
+            self.assertEqual(summary['certificate_status'], 'research_only')
+            self.assertIsNotNone(summary['historical_bundle_summary'])
+
+            statistical_validity = json.loads(
+                Path(summary['statistical_validity_report_path']).read_text(encoding='utf-8')
+            )
+            self.assertIn('average_daily_net_pnl_below_target', statistical_validity['blockers'])
+            self.assertIsNotNone(statistical_validity['selection_bias_metrics']['pbo'])
+            self.assertIsNotNone(statistical_validity['selection_bias_metrics']['dsr'])
+            self.assertIsNotNone(statistical_validity['selection_bias_metrics']['reality_check_p_value'])

--- a/services/torghut/tests/test_signal_ingest.py
+++ b/services/torghut/tests/test_signal_ingest.py
@@ -187,7 +187,7 @@ class TestSignalIngest(TestCase):
             "deeplob-bdlob-v1",
         )
 
-    def test_parse_flat_row_uses_vwap_as_price_fallback(self) -> None:
+    def test_parse_flat_row_prefers_midpoint_price_when_available(self) -> None:
         ingestor = ClickHouseSignalIngestor(schema="flat", fast_forward_stale_cursor=False)
         row = {
             "ts": "2026-01-01T00:00:02Z",
@@ -195,7 +195,7 @@ class TestSignalIngest(TestCase):
             "macd": 0.4,
             "signal": 0.2,
             "rsi14": 44,
-            "vwap_session": 125.75,
+            "vwap_session": 125.50,
             "spread": 0.08,
             "imbalance_bid_px": 125.70,
             "imbalance_ask_px": 125.80,
@@ -208,6 +208,21 @@ class TestSignalIngest(TestCase):
         self.assertEqual(signal.payload.get("imbalance", {}).get("bid_px"), 125.70)
         self.assertEqual(signal.payload.get("imbalance", {}).get("ask_px"), 125.80)
         self.assertEqual(signal.payload.get("imbalance", {}).get("spread"), 0.08)
+
+    def test_parse_flat_row_uses_vwap_as_price_fallback_without_midpoint(self) -> None:
+        ingestor = ClickHouseSignalIngestor(schema="flat", fast_forward_stale_cursor=False)
+        row = {
+            "ts": "2026-01-01T00:00:02Z",
+            "symbol": "NVDA",
+            "macd": 0.4,
+            "signal": 0.2,
+            "rsi14": 44,
+            "vwap_session": 125.75,
+        }
+        signal = ingestor.parse_row(row)
+        self.assertIsNotNone(signal)
+        assert signal is not None
+        self.assertEqual(signal.payload.get("price"), 125.75)
 
     def test_parse_row_attaches_simulation_context_from_row_fields(self) -> None:
         ingestor = ClickHouseSignalIngestor(schema='envelope', fast_forward_stale_cursor=False)

--- a/services/torghut/tests/test_strategy_runtime.py
+++ b/services/torghut/tests/test_strategy_runtime.py
@@ -6,6 +6,7 @@ from decimal import Decimal
 from unittest import TestCase
 
 from app.models import Strategy
+from app.strategies.catalog import StrategyConfig, _compose_strategy_description
 from app.trading.features import FeatureNormalizationError, normalize_feature_vector_v3
 from app.trading.models import SignalEnvelope
 from app.trading.strategy_runtime import (
@@ -238,6 +239,147 @@ class TestStrategyRuntime(TestCase):
         assert decision is not None
         self.assertEqual(decision.intent.action, "buy")
         self.assertIn("tsmom_trend_up", decision.intent.rationale)
+
+    def test_intraday_tsmom_plugin_skips_buy_when_price_is_above_ema12_band(self) -> None:
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="intraday-tsmom-1sec-band",
+            description=_compose_strategy_description(
+                StrategyConfig(
+                    name="intraday-tsmom-1sec-band",
+                    strategy_id="intraday_tsmom_v1@prod",
+                    strategy_type="intraday_tsmom_v1",
+                    version="1.1.0",
+                    base_timeframe="1Sec",
+                    universe_type="intraday_tsmom_v1",
+                    universe_symbols=["META"],
+                    max_position_pct_equity=Decimal("0.08"),
+                    max_notional_per_trade=Decimal("1000"),
+                    params={"max_price_above_ema12_bps": "0"},
+                )
+            ),
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="intraday_tsmom_v1",
+            universe_symbols=["META"],
+            max_position_pct_equity=Decimal("0.08"),
+            max_notional_per_trade=Decimal("1000"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 27, 18, 27, 27, tzinfo=timezone.utc),
+            symbol="META",
+            timeframe="1Sec",
+            seq=1,
+            payload={
+                "price": 528.29,
+                "ema12": 523.7876786224246,
+                "ema26": 523.7686581843907,
+                "macd": 0.019020438033943658,
+                "macd_signal": -0.03527149321001294,
+                "rsi14": 58.25782645382979,
+                "vol_realized_w60s": 0.00019104321463884983,
+            },
+        )
+        feature_contract = normalize_feature_vector_v3(signal)
+        runtime = StrategyRuntime()
+
+        decision = runtime.evaluate(strategy, feature_contract, timeframe="1Sec")
+
+        self.assertIsNone(decision)
+
+    def test_intraday_tsmom_plugin_skips_buy_when_pullback_is_too_shallow(self) -> None:
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="intraday-tsmom-1sec-pullback",
+            description=_compose_strategy_description(
+                StrategyConfig(
+                    name="intraday-tsmom-1sec-pullback",
+                    strategy_id="intraday_tsmom_v1@prod",
+                    strategy_type="intraday_tsmom_v1",
+                    version="1.1.0",
+                    base_timeframe="1Sec",
+                    universe_type="intraday_tsmom_v1",
+                    universe_symbols=["META"],
+                    max_position_pct_equity=Decimal("0.08"),
+                    max_notional_per_trade=Decimal("1000"),
+                    params={"min_price_below_ema12_bps": "2"},
+                )
+            ),
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="intraday_tsmom_v1",
+            universe_symbols=["META"],
+            max_position_pct_equity=Decimal("0.08"),
+            max_notional_per_trade=Decimal("1000"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 27, 18, 27, 36, tzinfo=timezone.utc),
+            symbol="META",
+            timeframe="1Sec",
+            seq=1,
+            payload={
+                "price": 523.78,
+                "ema12": 523.8487984735763,
+                "ema26": 523.8048007992227,
+                "macd": 0.04399767435360296,
+                "macd_signal": 0.001197208657777601,
+                "rsi14": 56.28545201421526,
+                "vol_realized_w60s": 0.00018957788471576266,
+            },
+        )
+        feature_contract = normalize_feature_vector_v3(signal)
+        runtime = StrategyRuntime()
+
+        decision = runtime.evaluate(strategy, feature_contract, timeframe="1Sec")
+
+        self.assertIsNone(decision)
+
+    def test_intraday_tsmom_plugin_skips_buy_when_bullish_hist_is_too_hot(self) -> None:
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="intraday-tsmom-1sec-hot-hist",
+            description=_compose_strategy_description(
+                StrategyConfig(
+                    name="intraday-tsmom-1sec-hot-hist",
+                    strategy_id="intraday_tsmom_v1@prod",
+                    strategy_type="intraday_tsmom_v1",
+                    version="1.1.0",
+                    base_timeframe="1Sec",
+                    universe_type="intraday_tsmom_v1",
+                    universe_symbols=["META"],
+                    max_position_pct_equity=Decimal("0.08"),
+                    max_notional_per_trade=Decimal("1000"),
+                    params={"bullish_hist_cap": "0.055"},
+                )
+            ),
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="intraday_tsmom_v1",
+            universe_symbols=["META"],
+            max_position_pct_equity=Decimal("0.08"),
+            max_notional_per_trade=Decimal("1000"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 24, 16, 56, 49, tzinfo=timezone.utc),
+            symbol="META",
+            timeframe="1Sec",
+            seq=1,
+            payload={
+                "price": 594.62,
+                "ema12": 595.2109424468129,
+                "ema26": 595.1980527414847,
+                "macd": 0.012889705328175226,
+                "macd_signal": -0.05243924370763675,
+                "rsi14": 57.950805218453446,
+                "vol_realized_w60s": 0.000188712908208969,
+            },
+        )
+        feature_contract = normalize_feature_vector_v3(signal)
+        runtime = StrategyRuntime()
+
+        decision = runtime.evaluate(strategy, feature_contract, timeframe="1Sec")
+
+        self.assertIsNone(decision)
 
     def test_intraday_tsmom_plugin_emits_sell_for_one_second_profile(self) -> None:
         strategy = Strategy(

--- a/services/torghut/tests/test_strategy_runtime.py
+++ b/services/torghut/tests/test_strategy_runtime.py
@@ -240,6 +240,101 @@ class TestStrategyRuntime(TestCase):
         self.assertEqual(decision.intent.action, "buy")
         self.assertIn("tsmom_trend_up", decision.intent.rationale)
 
+    def test_intraday_tsmom_plugin_skips_buy_outside_entry_window(self) -> None:
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="intraday-tsmom-1sec-window",
+            description=_compose_strategy_description(
+                StrategyConfig(
+                    name="intraday-tsmom-1sec-window",
+                    strategy_id="intraday_tsmom_v1@prod",
+                    strategy_type="intraday_tsmom_v1",
+                    version="1.1.0",
+                    base_timeframe="1Sec",
+                    universe_type="intraday_tsmom_v1",
+                    universe_symbols=["META"],
+                    max_position_pct_equity=Decimal("0.08"),
+                    max_notional_per_trade=Decimal("1000"),
+                    params={"entry_end_minute_utc": "1180"},
+                )
+            ),
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="intraday_tsmom_v1",
+            universe_symbols=["META"],
+            max_position_pct_equity=Decimal("0.08"),
+            max_notional_per_trade=Decimal("1000"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 24, 19, 45, 55, tzinfo=timezone.utc),
+            symbol="META",
+            timeframe="1Sec",
+            seq=1,
+            payload={
+                "price": 593.625,
+                "ema12": 593.70,
+                "ema26": 593.40,
+                "macd": 0.020,
+                "macd_signal": 0.010,
+                "rsi14": 57.0,
+                "vol_realized_w60s": 0.00018,
+            },
+        )
+        feature_contract = normalize_feature_vector_v3(signal)
+        runtime = StrategyRuntime()
+
+        decision = runtime.evaluate(strategy, feature_contract, timeframe="1Sec")
+
+        self.assertIsNone(decision)
+
+    def test_intraday_tsmom_plugin_skips_buy_when_spread_exceeds_cap(self) -> None:
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="intraday-tsmom-1sec-spread-cap",
+            description=_compose_strategy_description(
+                StrategyConfig(
+                    name="intraday-tsmom-1sec-spread-cap",
+                    strategy_id="intraday_tsmom_v1@prod",
+                    strategy_type="intraday_tsmom_v1",
+                    version="1.1.0",
+                    base_timeframe="1Sec",
+                    universe_type="intraday_tsmom_v1",
+                    universe_symbols=["META"],
+                    max_position_pct_equity=Decimal("0.08"),
+                    max_notional_per_trade=Decimal("1000"),
+                    params={"max_spread_bps": "60"},
+                )
+            ),
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="intraday_tsmom_v1",
+            universe_symbols=["META"],
+            max_position_pct_equity=Decimal("0.08"),
+            max_notional_per_trade=Decimal("1000"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 23, 19, 17, 55, tzinfo=timezone.utc),
+            symbol="META",
+            timeframe="1Sec",
+            seq=1,
+            payload={
+                "price": 604.815,
+                "spread": 5.77,
+                "ema12": 606.3602961607454,
+                "ema26": 606.3534338611167,
+                "macd": 0.006862299628771475,
+                "macd_signal": -0.04526378862269545,
+                "rsi14": 57.80709380988871,
+                "vol_realized_w60s": 0.00017176690067199733,
+            },
+        )
+        feature_contract = normalize_feature_vector_v3(signal)
+        runtime = StrategyRuntime()
+
+        decision = runtime.evaluate(strategy, feature_contract, timeframe="1Sec")
+
+        self.assertIsNone(decision)
+
     def test_intraday_tsmom_plugin_skips_buy_when_price_is_above_ema12_band(self) -> None:
         strategy = Strategy(
             id=uuid.uuid4(),
@@ -418,6 +513,358 @@ class TestStrategyRuntime(TestCase):
         self.assertEqual(decision.intent.action, "sell")
         self.assertIn("tsmom_trend_down", decision.intent.rationale)
 
+    def test_momentum_pullback_plugin_emits_buy_for_controlled_pullback(self) -> None:
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="momentum-pullback",
+            description="version=1.0.0",
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="momentum_pullback_long_v1",
+            universe_symbols=["META"],
+            max_position_pct_equity=Decimal("1.0"),
+            max_notional_per_trade=Decimal("14000"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 24, 19, 45, 55, tzinfo=timezone.utc),
+            symbol="META",
+            timeframe="1Sec",
+            seq=1,
+            payload={
+                "price": 593.62,
+                "ema12": 594.10,
+                "ema26": 593.70,
+                "macd": 0.041,
+                "macd_signal": 0.022,
+                "rsi14": 59,
+                "vol_realized_w60s": 0.00018,
+                "spread": 0.05,
+                "imbalance_bid_sz": 4200,
+                "imbalance_ask_sz": 3800,
+            },
+        )
+
+        feature_contract = normalize_feature_vector_v3(signal)
+        runtime = StrategyRuntime()
+        decision = runtime.evaluate(strategy, feature_contract, timeframe="1Sec")
+
+        self.assertIsNotNone(decision)
+        assert decision is not None
+        self.assertEqual(decision.intent.action, "buy")
+        self.assertEqual(decision.plugin_id, "momentum_pullback_long")
+        self.assertIn("pullback_entry", decision.intent.rationale)
+
+    def test_breakout_continuation_plugin_emits_buy_with_vwap_and_imbalance_confirmation(
+        self,
+    ) -> None:
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="breakout-continuation",
+            description="version=1.0.0",
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="breakout_continuation_long_v1",
+            universe_symbols=["META"],
+            max_position_pct_equity=Decimal("1.0"),
+            max_notional_per_trade=Decimal("14000"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 27, 17, 30, 3, tzinfo=timezone.utc),
+            symbol="META",
+            timeframe="1Sec",
+            seq=1,
+            payload={
+                "price": 523.25,
+                "ema12": 523.10,
+                "ema26": 522.90,
+                "macd": 0.031,
+                "macd_signal": 0.012,
+                "rsi14": 62,
+                "vol_realized_w60s": 0.00017,
+                "vwap_session": 522.10,
+                "spread": 0.04,
+                "imbalance_bid_sz": 5200,
+                "imbalance_ask_sz": 4300,
+            },
+        )
+
+        feature_contract = normalize_feature_vector_v3(signal)
+        runtime = StrategyRuntime()
+        decision = runtime.evaluate(strategy, feature_contract, timeframe="1Sec")
+
+        self.assertIsNotNone(decision)
+        assert decision is not None
+        self.assertEqual(decision.intent.action, "buy")
+        self.assertEqual(decision.plugin_id, "breakout_continuation_long")
+        self.assertIn("imbalance_confirmed", decision.intent.rationale)
+
+    def test_breakout_continuation_plugin_does_not_exit_on_single_reference_loss(self) -> None:
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="breakout-continuation",
+            description="version=1.0.0",
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="breakout_continuation_long_v1",
+            universe_symbols=["META"],
+            max_position_pct_equity=Decimal("1.0"),
+            max_notional_per_trade=Decimal("14000"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 27, 18, 4, 3, tzinfo=timezone.utc),
+            symbol="META",
+            timeframe="1Sec",
+            seq=2,
+            payload={
+                "price": 523.00,
+                "ema12": 523.10,
+                "ema26": 522.90,
+                "macd": 0.014,
+                "macd_signal": 0.015,
+                "rsi14": 58,
+                "vol_realized_w60s": 0.00017,
+                "vwap_session": 522.80,
+                "spread": 0.04,
+                "imbalance_bid_sz": 5200,
+                "imbalance_ask_sz": 4300,
+            },
+        )
+
+        feature_contract = normalize_feature_vector_v3(signal)
+        runtime = StrategyRuntime()
+        decision = runtime.evaluate(strategy, feature_contract, timeframe="1Sec")
+
+        self.assertIsNone(decision)
+
+    def test_breakout_continuation_plugin_emits_sell_on_confirmed_breakout_failure(
+        self,
+    ) -> None:
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="breakout-continuation",
+            description="version=1.0.0",
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="breakout_continuation_long_v1",
+            universe_symbols=["META"],
+            max_position_pct_equity=Decimal("1.0"),
+            max_notional_per_trade=Decimal("14000"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 27, 18, 5, 3, tzinfo=timezone.utc),
+            symbol="META",
+            timeframe="1Sec",
+            seq=3,
+            payload={
+                "price": 522.90,
+                "ema12": 523.10,
+                "ema26": 522.95,
+                "macd": 0.010,
+                "macd_signal": 0.012,
+                "rsi14": 54,
+                "vol_realized_w60s": 0.00017,
+                "vwap_session": 523.05,
+                "spread": 0.04,
+                "imbalance_bid_sz": 4700,
+                "imbalance_ask_sz": 5000,
+            },
+        )
+
+        feature_contract = normalize_feature_vector_v3(signal)
+        runtime = StrategyRuntime()
+        decision = runtime.evaluate(strategy, feature_contract, timeframe="1Sec")
+
+        self.assertIsNotNone(decision)
+        assert decision is not None
+        self.assertEqual(decision.intent.action, "sell")
+        self.assertEqual(decision.plugin_id, "breakout_continuation_long")
+        self.assertIn("breakout_failed", decision.intent.rationale)
+
+    def test_breakout_continuation_plugin_skips_late_entry_near_flatten(self) -> None:
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="breakout-continuation",
+            description=_compose_strategy_description(
+                StrategyConfig(
+                    name="breakout-continuation",
+                    strategy_id="breakout_continuation_long_v1@research",
+                    strategy_type="breakout_continuation_long_v1",
+                    version="1.0.0",
+                    base_timeframe="1Sec",
+                    universe_type="breakout_continuation_long_v1",
+                    universe_symbols=["META"],
+                    max_position_pct_equity=Decimal("1.0"),
+                    max_notional_per_trade=Decimal("14000"),
+                    params={
+                        "entry_start_minute_utc": "840",
+                        "entry_end_minute_utc": "1170",
+                        "session_flatten_start_minute_utc": "1170",
+                        "min_entry_minutes_before_flatten": "15",
+                        "min_price_above_vwap_bps": "1",
+                        "max_price_above_vwap_bps": "24",
+                        "min_imbalance_pressure": "0.02",
+                        "max_spread_bps": "6",
+                    },
+                )
+            ),
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="breakout_continuation_long_v1",
+            universe_symbols=["META"],
+            max_position_pct_equity=Decimal("1.0"),
+            max_notional_per_trade=Decimal("14000"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 27, 19, 20, 3, tzinfo=timezone.utc),
+            symbol="META",
+            timeframe="1Sec",
+            seq=4,
+            payload={
+                "price": 523.25,
+                "ema12": 523.10,
+                "ema26": 522.90,
+                "macd": 0.031,
+                "macd_signal": 0.012,
+                "rsi14": 62,
+                "vol_realized_w60s": 0.00017,
+                "vwap_session": 522.10,
+                "spread": 0.04,
+                "imbalance_bid_sz": 5200,
+                "imbalance_ask_sz": 4300,
+            },
+        )
+
+        feature_contract = normalize_feature_vector_v3(signal)
+        runtime = StrategyRuntime()
+        decision = runtime.evaluate(strategy, feature_contract, timeframe="1Sec")
+
+        self.assertIsNone(decision)
+
+    def test_late_day_continuation_plugin_emits_buy_on_late_strength(self) -> None:
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="late-day-continuation",
+            description="version=1.0.0",
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="late_day_continuation_long_v1",
+            universe_symbols=["AAPL"],
+            max_position_pct_equity=Decimal("1.0"),
+            max_notional_per_trade=Decimal("14000"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 26, 18, 58, 3, tzinfo=timezone.utc),
+            symbol="AAPL",
+            timeframe="1Sec",
+            seq=5,
+            payload={
+                "price": 253.93,
+                "ema12": 253.82,
+                "ema26": 253.60,
+                "macd": 0.028,
+                "macd_signal": 0.014,
+                "rsi14": 63,
+                "vol_realized_w60s": 0.00019,
+                "vwap_session": 253.74,
+                "spread": 0.03,
+                "imbalance_bid_sz": 5400,
+                "imbalance_ask_sz": 5000,
+            },
+        )
+
+        feature_contract = normalize_feature_vector_v3(signal)
+        runtime = StrategyRuntime()
+        decision = runtime.evaluate(strategy, feature_contract, timeframe="1Sec")
+
+        self.assertIsNotNone(decision)
+        assert decision is not None
+        self.assertEqual(decision.intent.action, "buy")
+        self.assertEqual(decision.plugin_id, "late_day_continuation_long")
+        self.assertIn("late_day_strength", decision.intent.rationale)
+
+    def test_late_day_continuation_plugin_emits_sell_on_late_failure(self) -> None:
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="late-day-continuation",
+            description="version=1.0.0",
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="late_day_continuation_long_v1",
+            universe_symbols=["AAPL"],
+            max_position_pct_equity=Decimal("1.0"),
+            max_notional_per_trade=Decimal("14000"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 26, 19, 8, 3, tzinfo=timezone.utc),
+            symbol="AAPL",
+            timeframe="1Sec",
+            seq=6,
+            payload={
+                "price": 253.54,
+                "ema12": 253.72,
+                "ema26": 253.61,
+                "macd": 0.010,
+                "macd_signal": 0.016,
+                "rsi14": 53,
+                "vol_realized_w60s": 0.00018,
+                "vwap_session": 253.68,
+                "spread": 0.03,
+                "imbalance_bid_sz": 4500,
+                "imbalance_ask_sz": 4700,
+            },
+        )
+
+        feature_contract = normalize_feature_vector_v3(signal)
+        runtime = StrategyRuntime()
+        decision = runtime.evaluate(strategy, feature_contract, timeframe="1Sec")
+
+        self.assertIsNotNone(decision)
+        assert decision is not None
+        self.assertEqual(decision.intent.action, "sell")
+        self.assertEqual(decision.plugin_id, "late_day_continuation_long")
+        self.assertIn("late_day_failure", decision.intent.rationale)
+
+    def test_mean_reversion_rebound_plugin_emits_buy_after_controlled_selloff(self) -> None:
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="mean-reversion-rebound",
+            description="version=1.0.0",
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="mean_reversion_rebound_long_v1",
+            universe_symbols=["META"],
+            max_position_pct_equity=Decimal("1.0"),
+            max_notional_per_trade=Decimal("12000"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 24, 17, 14, 12, tzinfo=timezone.utc),
+            symbol="META",
+            timeframe="1Sec",
+            seq=1,
+            payload={
+                "price": 593.90,
+                "ema12": 595.10,
+                "macd": 0.010,
+                "macd_signal": 0.004,
+                "rsi14": 45,
+                "vol_realized_w60s": 0.00022,
+                "vwap_session": 596.40,
+                "spread": 0.05,
+                "imbalance_bid_sz": 4700,
+                "imbalance_ask_sz": 4300,
+            },
+        )
+
+        feature_contract = normalize_feature_vector_v3(signal)
+        runtime = StrategyRuntime()
+        decision = runtime.evaluate(strategy, feature_contract, timeframe="1Sec")
+
+        self.assertIsNotNone(decision)
+        assert decision is not None
+        self.assertEqual(decision.intent.action, "buy")
+        self.assertEqual(decision.plugin_id, "mean_reversion_rebound_long")
+        self.assertIn("oversold_rebound", decision.intent.rationale)
+
     def test_runtime_isolates_plugin_failures_and_continues(self) -> None:
         healthy = Strategy(
             id=uuid.uuid4(),
@@ -577,6 +1024,40 @@ class TestStrategyRuntime(TestCase):
             evaluation.intents[0].source_strategy_ids,
             (str(buy_strategy.id),),
         )
+
+    def test_runtime_skips_strategy_when_signal_symbol_is_outside_universe(self) -> None:
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="momentum-pullback",
+            description="version=1.0.0",
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="momentum_pullback_long_v1",
+            universe_symbols=["META"],
+            max_position_pct_equity=Decimal("1.0"),
+            max_notional_per_trade=Decimal("14000"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 24, 19, 45, 55, tzinfo=timezone.utc),
+            symbol="AAPL",
+            timeframe="1Sec",
+            seq=1,
+            payload={
+                "price": 593.62,
+                "ema12": 594.10,
+                "ema26": 593.70,
+                "macd": 0.041,
+                "macd_signal": 0.022,
+                "rsi14": 59,
+                "vol_realized_w60s": 0.00018,
+                "spread": 0.05,
+            },
+        )
+
+        feature_contract = normalize_feature_vector_v3(signal)
+        runtime = StrategyRuntime()
+
+        self.assertIsNone(runtime.evaluate(strategy, feature_contract, timeframe="1Sec"))
 
     def test_runtime_rejects_plugin_with_undeclared_contract_feature(self) -> None:
         class InvalidPlugin:

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -55,6 +55,7 @@ from app.trading.scheduler.pipeline_helpers import (
     _apply_projected_position_decision,
     _build_dspy_lineage,
     _committee_trace_has_veto,
+    _project_open_orders_onto_positions,
 )
 from app.trading.scheduler.state import TradingState
 from app.trading.tca import AdaptiveExecutionPolicyDecision
@@ -242,6 +243,17 @@ class PositionedAlpacaClient(FakeAlpacaClient):
 
     def list_positions(self) -> list[dict[str, str]]:
         return list(self._positions)
+
+
+class OpenOrderAlpacaClient(FakeAlpacaClient):
+    def __init__(self, orders: list[dict[str, str]]) -> None:
+        super().__init__()
+        self._orders = orders
+
+    def list_orders(self, status: str = "all") -> list[dict[str, str]]:
+        if status == "open":
+            return [dict(order) for order in self._orders]
+        return super().list_orders(status=status)
 
 
 class SellInventoryConflictRetryClient(FakeAlpacaClient):
@@ -4753,6 +4765,84 @@ class TestTradingPipeline(TestCase):
         self.assertEqual(positions[0]["qty"], "7")
         self.assertEqual(positions[0]["side"], "long")
         self.assertEqual(positions[0]["market_value"], "700")
+
+    def test_project_open_orders_onto_positions_projects_buy_exposure(self) -> None:
+        positions: list[dict[str, Any]] = []
+
+        projected = _project_open_orders_onto_positions(
+            positions,
+            [
+                {
+                    "symbol": "AAPL",
+                    "side": "buy",
+                    "qty": "3",
+                    "filled_qty": "1",
+                    "limit_price": "100",
+                    "type": "limit",
+                    "time_in_force": "day",
+                }
+            ],
+        )
+
+        self.assertEqual(projected, 1)
+        self.assertEqual(positions, [
+            {"symbol": "AAPL", "qty": "2", "side": "long", "market_value": "200"}
+        ])
+
+    def test_project_open_orders_onto_positions_projects_sell_against_existing_long(self) -> None:
+        positions: list[dict[str, Any]] = [
+            {"symbol": "AAPL", "qty": "5", "side": "long", "market_value": "500"}
+        ]
+
+        projected = _project_open_orders_onto_positions(
+            positions,
+            [
+                {
+                    "symbol": "AAPL",
+                    "side": "sell",
+                    "qty": "4",
+                    "filled_qty": "1",
+                    "limit_price": "100",
+                    "type": "limit",
+                    "time_in_force": "day",
+                }
+            ],
+        )
+
+        self.assertEqual(projected, 1)
+        self.assertEqual(positions, [
+            {"symbol": "AAPL", "qty": "2", "side": "long", "market_value": "200"}
+        ])
+
+    def test_resolve_execution_context_positions_projects_open_orders(self) -> None:
+        pipeline = TradingPipeline.__new__(TradingPipeline)
+        pipeline.account_label = "paper"
+
+        class AdapterWithOpenOrders:
+            name = "test"
+
+            def list_orders(self, status: str = "all") -> list[dict[str, str]]:
+                if status == "open":
+                    return [
+                        {
+                            "symbol": "AAPL",
+                            "side": "buy",
+                            "qty": "3",
+                            "filled_qty": "1",
+                            "limit_price": "100",
+                            "type": "limit",
+                            "time_in_force": "day",
+                        }
+                    ]
+                return []
+
+        pipeline.execution_adapter = AdapterWithOpenOrders()
+
+        positions = pipeline._resolve_execution_context_positions([])
+
+        self.assertEqual(positions, [
+            {"symbol": "AAPL", "qty": "2", "side": "long", "market_value": "200"}
+        ])
 
     def test_pipeline_runtime_uncertainty_rechecks_after_llm_adjustment(self) -> None:
         from app import config


### PR DESCRIPTION
## Summary

- harden the Torghut local replay harness so quote-quality checks, executable fills, pending-order exposure, and exit replacement behave honestly under retained ClickHouse TA data
- add research-backed Torghut sleeves and runtime contracts for breakout and late-day continuation strategies, plus per-strategy isolation and exit-only handling for long-only sleeves
- tighten Torghut decision and scheduler behavior around executable profit floors, max hold/session flatten exits, order hashing, and open-order projection
- expand Torghut replay, decision, runtime, order-idempotency, and pipeline regression coverage and document the archive-backed profitability proof and weekly holdout design
- raise Torghut ClickHouse memory headroom to support broader retained-window replay and diagnostics

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_decisions.py tests/test_strategy_runtime.py tests/test_local_intraday_tsmom_replay.py -q`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
