### PR TITLE
feat(torghut): harden continuation runtime and replay validation

### DIFF
--- a/services/torghut/app/trading/decisions.py
+++ b/services/torghut/app/trading/decisions.py
@@ -327,7 +327,13 @@ class DecisionEngine:
                     action=cast(Literal["buy", "sell"], direction),
                     qty=qty,
                     order_type="market",
-                    time_in_force="day",
+                    time_in_force=cast(
+                        Literal["day", "gtc", "ioc", "fok"],
+                        _resolve_strategy_time_in_force(
+                            strategies=source_strategies,
+                            action=direction,
+                        ),
+                    ),
                     rationale=",".join(explain),
                     params=_build_params(
                         signal=signal,
@@ -498,22 +504,38 @@ class DecisionEngine:
                 position_isolation_mode="per_strategy",
             )
             if overlay_decision is not None:
+                overlay_policy = _resolve_runtime_trade_policy([strategy])
+                overlay_positions = _positions_for_strategy_action(
+                    actual_positions,
+                    strategy_id=isolated_strategy_id,
+                    action="sell",
+                )
+                overlay_position_owner = _runtime_trade_policy_owner(
+                    primary_strategy_id=isolated_strategy_id,
+                    position_isolation_mode="per_strategy",
+                )
+                if not _passes_runtime_trade_policy(
+                    last_emitted_action_at=self._last_emitted_action_at,
+                    runtime_trade_policy_state=self._runtime_trade_policy_state,
+                    signal_ts=signal.event_ts,
+                    symbol=signal.symbol,
+                    action=overlay_decision.action,
+                    position_owner=overlay_position_owner,
+                    positions=overlay_positions,
+                    policy=overlay_policy,
+                    position_exit_type=_decision_position_exit_type(overlay_decision),
+                    state_scope_key=isolated_strategy_id,
+                ):
+                    continue
                 decisions.append(overlay_decision)
                 _record_runtime_trade_policy_decision(
                     runtime_trade_policy_state=self._runtime_trade_policy_state,
                     signal_ts=signal.event_ts,
                     symbol=signal.symbol,
-                    position_owner=_runtime_trade_policy_owner(
-                        primary_strategy_id=isolated_strategy_id,
-                        position_isolation_mode="per_strategy",
-                    ),
+                    position_owner=overlay_position_owner,
                     action=overlay_decision.action,
-                    policy=_resolve_runtime_trade_policy([strategy]),
-                    positions=_positions_for_strategy_action(
-                        actual_positions,
-                        strategy_id=isolated_strategy_id,
-                        action="sell",
-                    ),
+                    policy=overlay_policy,
+                    positions=overlay_positions,
                     signal=signal,
                     price=price,
                     decision=overlay_decision,
@@ -559,6 +581,25 @@ class DecisionEngine:
             position_peak_price=aggregated_position_peak_price,
         )
         if overlay_decision is not None:
+            overlay_policy = _resolve_runtime_trade_policy(
+                [
+                    strategy
+                    for strategy in strategies
+                    if str(strategy.id) in non_isolated_strategy_ids
+                ]
+            )
+            if not _passes_runtime_trade_policy(
+                last_emitted_action_at=self._last_emitted_action_at,
+                runtime_trade_policy_state=self._runtime_trade_policy_state,
+                signal_ts=signal.event_ts,
+                symbol=signal.symbol,
+                action=overlay_decision.action,
+                position_owner=_RUNTIME_TRADE_POLICY_SHARED_OWNER,
+                positions=actual_positions,
+                policy=overlay_policy,
+                position_exit_type=_decision_position_exit_type(overlay_decision),
+            ):
+                return decisions
             decisions.append(overlay_decision)
             _record_runtime_trade_policy_decision(
                 runtime_trade_policy_state=self._runtime_trade_policy_state,
@@ -566,13 +607,7 @@ class DecisionEngine:
                 symbol=signal.symbol,
                 position_owner=_RUNTIME_TRADE_POLICY_SHARED_OWNER,
                 action=overlay_decision.action,
-                policy=_resolve_runtime_trade_policy(
-                    [
-                        strategy
-                        for strategy in strategies
-                        if str(strategy.id) in non_isolated_strategy_ids
-                    ]
-                ),
+                policy=overlay_policy,
                 positions=actual_positions,
                 signal=signal,
                 price=price,
@@ -1558,6 +1593,16 @@ def _build_runtime_position_exit_overlay(
         volatility_bps=volatility_bps,
         volatility_multiplier_key="long_trailing_stop_volatility_bps_multiplier",
     )
+    trailing_stop_requires_structure_loss = _resolve_bool_strategy_param(
+        strategies=eligible_strategies,
+        key="long_trailing_stop_requires_structure_loss",
+        default=_default_trailing_stop_requires_structure_loss(eligible_strategies),
+    )
+    trailing_stop_structure_loss_confirmed = _trailing_stop_structure_loss_confirmed(
+        signal=signal,
+        price=price,
+        strategies=eligible_strategies,
+    )
 
     exit_type: str | None = None
     exit_rationale: str | None = None
@@ -1590,7 +1635,13 @@ def _build_runtime_position_exit_overlay(
         peak_profit_bps = ((position_peak_price - avg_entry_price) / avg_entry_price) * Decimal("10000")
         if peak_profit_bps >= trailing_activation_profit_bps and price < position_peak_price:
             peak_drawdown_bps = ((position_peak_price - price) / position_peak_price) * Decimal("10000")
-            if peak_drawdown_bps >= trailing_stop_threshold_bps:
+            if (
+                peak_drawdown_bps >= trailing_stop_threshold_bps
+                and (
+                    not trailing_stop_requires_structure_loss
+                    or trailing_stop_structure_loss_confirmed
+                )
+            ):
                 exit_type = "long_trailing_stop_bps"
                 exit_rationale = "position_trailing_stop_exit"
                 trigger_threshold_bps = trailing_stop_threshold_bps
@@ -2407,6 +2458,7 @@ def _passes_runtime_trade_policy(
     position_owner: str,
     positions: Optional[list[dict[str, Any]]],
     policy: Mapping[str, int | Decimal],
+    position_exit_type: str | None = None,
     state_scope_key: str | None = None,
 ) -> bool:
     normalized_action = action.strip().lower()
@@ -2496,6 +2548,9 @@ def _passes_runtime_trade_policy(
     if normalized_action != "sell":
         return True
 
+    if _position_exit_bypasses_min_hold(position_exit_type):
+        return True
+
     min_hold_seconds = max(0, int(policy.get("min_hold_seconds", 0)))
     if min_hold_seconds <= 0:
         return True
@@ -2507,6 +2562,50 @@ def _passes_runtime_trade_policy(
         - position_opened_at.astimezone(timezone.utc)
     ).total_seconds()
     return age_seconds >= min_hold_seconds
+
+
+def _decision_position_exit_type(decision: StrategyDecision) -> str | None:
+    position_exit = decision.params.get("position_exit")
+    if not isinstance(position_exit, Mapping):
+        return None
+    normalized = str(cast(Mapping[str, Any], position_exit).get("type") or "").strip()
+    return normalized or None
+
+
+def _position_exit_bypasses_min_hold(position_exit_type: str | None) -> bool:
+    normalized = str(position_exit_type or "").strip().lower()
+    return normalized in {
+        "long_stop_loss_bps",
+        "max_hold_seconds",
+        "session_flatten_minute_utc",
+    }
+
+
+def _resolve_strategy_time_in_force(
+    *,
+    strategies: list[Strategy],
+    action: str,
+) -> str:
+    normalized_action = str(action or "").strip().lower()
+    param_key = "entry_time_in_force" if normalized_action == "buy" else "exit_time_in_force"
+    supported_values = {"day", "gtc", "ioc", "fok"}
+    for strategy in strategies:
+        params = StrategyRuntime.definition_from_strategy(strategy).params
+        candidate = str(params.get(param_key) or "").strip().lower()
+        if candidate in supported_values:
+            return candidate
+    if normalized_action == "buy":
+        continuation_strategy_types = {
+            "breakout_continuation_long_v1",
+            "late_day_continuation_long_v1",
+        }
+        if any(
+            str(strategy.universe_type or "").strip().lower()
+            in continuation_strategy_types
+            for strategy in strategies
+        ):
+            return "ioc"
+    return "day"
 
 
 def _runtime_trade_policy_owner(
@@ -2631,6 +2730,73 @@ def _passes_signal_exit_policy(
     )
 
 
+def _default_trailing_stop_requires_structure_loss(
+    strategies: list[Strategy],
+) -> bool:
+    continuation_strategy_types = {
+        "breakout_continuation_long_v1",
+        "late_day_continuation_long_v1",
+    }
+    return any(
+        str(strategy.universe_type or "").strip().lower() in continuation_strategy_types
+        for strategy in strategies
+    )
+
+
+def _trailing_stop_structure_loss_confirmed(
+    *,
+    signal: SignalEnvelope,
+    price: Decimal,
+    strategies: list[Strategy],
+) -> bool:
+    payload = signal.payload or {}
+    vwap_threshold = _resolve_max_nonnegative_strategy_param(
+        strategies=strategies,
+        key="long_trailing_stop_structure_loss_vwap_bps",
+    )
+    if vwap_threshold is None:
+        vwap_threshold = Decimal("0")
+    opening_range_high_threshold = _resolve_max_nonnegative_strategy_param(
+        strategies=strategies,
+        key="long_trailing_stop_structure_loss_price_vs_opening_range_high_bps",
+    )
+    if opening_range_high_threshold is None:
+        opening_range_high_threshold = Decimal("0")
+    session_range_position_max = _resolve_max_nonnegative_strategy_param(
+        strategies=strategies,
+        key="long_trailing_stop_structure_loss_session_range_position_max",
+    )
+    if session_range_position_max is None:
+        session_range_position_max = Decimal("0.80")
+    price_vs_vwap_w5m_bps = _signal_decimal_feature_bps(
+        signal,
+        key="price_vs_vwap_w5m_bps",
+        price=price,
+        reference_key="vwap_w5m",
+    )
+    price_vs_opening_range_high_bps = _signal_decimal_feature_bps(
+        signal,
+        key="price_vs_opening_range_high_bps",
+        price=price,
+        reference_key="opening_range_high",
+    )
+    price_position_in_session_range = optional_decimal(
+        payload.get("price_position_in_session_range")
+    )
+    return (
+        (
+            price_vs_opening_range_high_bps is not None
+            and price_vs_opening_range_high_bps <= opening_range_high_threshold
+        )
+        or (
+            price_vs_vwap_w5m_bps is not None
+            and price_vs_vwap_w5m_bps <= vwap_threshold
+            and price_position_in_session_range is not None
+            and price_position_in_session_range <= session_range_position_max
+        )
+    )
+
+
 def _signal_spread(signal: SignalEnvelope) -> Decimal | None:
     payload = signal.payload or {}
     spread = optional_decimal(payload.get("spread"))
@@ -2653,6 +2819,23 @@ def _signal_spread(signal: SignalEnvelope) -> Decimal | None:
     if bid is None or ask is None or ask <= bid:
         return None
     return ask - bid
+
+
+def _signal_decimal_feature_bps(
+    signal: SignalEnvelope,
+    *,
+    key: str,
+    price: Decimal,
+    reference_key: str,
+) -> Decimal | None:
+    payload = signal.payload or {}
+    direct_value = optional_decimal(payload.get(key))
+    if direct_value is not None:
+        return direct_value
+    reference_value = optional_decimal(payload.get(reference_key))
+    if reference_value is None or reference_value <= 0 or price <= 0:
+        return None
+    return ((price - reference_value) / reference_value) * Decimal("10000")
 
 
 def _near_touch_exit_price(

--- a/services/torghut/app/trading/features.py
+++ b/services/torghut/app/trading/features.py
@@ -218,19 +218,12 @@ def _extract_price_from_vwap_keys(payload: dict[str, Any]) -> Decimal | None:
 
 
 def _extract_price_from_imbalance(payload: dict[str, Any]) -> Decimal | None:
-    imbalance = payload.get('imbalance')
-    if not isinstance(imbalance, dict):
-        return None
-    imbalance_payload = cast(dict[str, Any], imbalance)
-    bid_px = imbalance_payload.get('bid_px')
-    ask_px = imbalance_payload.get('ask_px')
-    if bid_px is None or ask_px is None:
-        return None
-    try:
-        bid = optional_decimal(bid_px)
-        ask = optional_decimal(ask_px)
-    except (TypeError, ArithmeticError):
-        return None
+    bid = optional_decimal(
+        payload_value(payload, 'imbalance_bid_px', block='imbalance', nested_key='bid_px')
+    )
+    ask = optional_decimal(
+        payload_value(payload, 'imbalance_ask_px', block='imbalance', nested_key='ask_px')
+    )
     if bid is None or ask is None:
         return None
     return (bid + ask) / 2

--- a/services/torghut/app/trading/intraday_tsmom_contract.py
+++ b/services/torghut/app/trading/intraday_tsmom_contract.py
@@ -102,6 +102,22 @@ def validate_intraday_tsmom_params(params: Mapping[str, Any]) -> None:
         "long_trailing_stop_drawdown_bps",
         "long_trailing_stop_spread_bps_multiplier",
         "long_trailing_stop_volatility_bps_multiplier",
+        "late_session_floor_multiplier",
+        "isolated_flow_min_live_continuation_rank",
+        "isolated_flow_rank_relaxation",
+        "isolated_flow_breadth_relaxation",
+        "isolated_flow_session_drive_relaxation_bps",
+        "isolated_flow_opening_window_return_relaxation_bps",
+        "isolated_flow_max_price_above_ema12_bps",
+        "isolated_flow_min_recent_microprice_bias_bps",
+        "isolated_flow_min_range_position_rank",
+        "isolated_flow_min_vwap_w5m_rank",
+        "isolated_flow_min_recent_imbalance_rank",
+        "late_session_hist_floor_multiplier",
+        "isolated_flow_hist_floor_relaxation",
+        "isolated_flow_bullish_hist_cap",
+        "isolated_flow_vol_ceil_multiplier",
+        "isolated_flow_min_vol_ceil",
     ):
         _validate_optional_decimal_param(
             params=params,
@@ -236,6 +252,9 @@ def evaluate_intraday_tsmom_signal(
     cross_section_opening_window_return_from_prev_close_rank: Decimal | None = None,
     cross_section_continuation_rank: Decimal | None = None,
     cross_section_continuation_breadth: Decimal | None = None,
+    cross_section_range_position_rank: Decimal | None = None,
+    cross_section_vwap_w5m_rank: Decimal | None = None,
+    cross_section_recent_imbalance_rank: Decimal | None = None,
 ) -> IntradayTsmomEvaluation | None:
     if (
         ema12 is None
@@ -257,11 +276,6 @@ def evaluate_intraday_tsmom_signal(
     spread_bps = _spread_bps(price=price, spread=spread)
     trend_up = ema12 > ema26 and macd > macd_signal
     trend_down = ema12 < ema26 and macd < macd_signal
-    vol_ok = _volatility_within_budget(
-        vol_realized_w60s,
-        floor=thresholds.vol_floor,
-        ceil=thresholds.vol_ceil,
-    )
     max_spread_bps = _optional_decimal_param(
         params=params,
         key='max_spread_bps',
@@ -357,6 +371,11 @@ def evaluate_intraday_tsmom_signal(
         key='min_cross_section_continuation_breadth',
         default=None,
     )
+    late_session_floor_multiplier = _optional_decimal_param(
+        params=params,
+        key='late_session_floor_multiplier',
+        default=Decimal('0.50'),
+    )
     effective_price_drive_bps = (
         price_vs_prev_session_close_bps
         if price_vs_prev_session_close_bps is not None
@@ -372,29 +391,163 @@ def evaluate_intraday_tsmom_signal(
         if cross_section_opening_window_return_from_prev_close_rank is not None
         else cross_section_opening_window_return_rank
     )
+    effective_live_continuation_rank = _resolve_live_continuation_rank(
+        event_ts=event_ts,
+        cross_section_opening_window_return_rank=cross_section_opening_window_return_rank,
+        cross_section_opening_window_return_from_prev_close_rank=(
+            cross_section_opening_window_return_from_prev_close_rank
+        ),
+        cross_section_range_position_rank=cross_section_range_position_rank,
+        cross_section_vwap_w5m_rank=cross_section_vwap_w5m_rank,
+        cross_section_recent_imbalance_rank=cross_section_recent_imbalance_rank,
+        fallback_rank=cross_section_continuation_rank,
+    )
+    isolated_strength_confirmed = _isolated_continuation_strength_confirmed(
+        params=params,
+        live_continuation_rank=effective_live_continuation_rank,
+        range_position_rank=cross_section_range_position_rank,
+        vwap_w5m_rank=cross_section_vwap_w5m_rank,
+        recent_imbalance_rank=cross_section_recent_imbalance_rank,
+        recent_microprice_bias_bps_avg=recent_microprice_bias_bps_avg,
+    )
+    effective_min_session_open_drive_bps = _relax_floor_for_isolated_strength(
+        floor=_decayed_minimum(
+            event_ts=event_ts,
+            early_floor=min_session_open_drive_bps,
+            late_session_floor_multiplier=late_session_floor_multiplier,
+        ),
+        isolated_strength_confirmed=isolated_strength_confirmed,
+        relaxation=_optional_decimal_param(
+            params=params,
+            key='isolated_flow_session_drive_relaxation_bps',
+            default=Decimal('18'),
+        ),
+    )
+    effective_min_opening_window_return_bps = _relax_floor_for_isolated_strength(
+        floor=_decayed_minimum(
+            event_ts=event_ts,
+            early_floor=min_opening_window_return_bps,
+            late_session_floor_multiplier=late_session_floor_multiplier,
+        ),
+        isolated_strength_confirmed=isolated_strength_confirmed,
+        relaxation=_optional_decimal_param(
+            params=params,
+            key='isolated_flow_opening_window_return_relaxation_bps',
+            default=Decimal('12'),
+        ),
+    )
+    effective_min_cross_section_opening_window_return_rank = _relax_floor_for_isolated_strength(
+        floor=_decayed_minimum(
+            event_ts=event_ts,
+            early_floor=min_cross_section_opening_window_return_rank,
+            late_session_floor_multiplier=late_session_floor_multiplier,
+        ),
+        isolated_strength_confirmed=isolated_strength_confirmed,
+        relaxation=_optional_decimal_param(
+            params=params,
+            key='isolated_flow_rank_relaxation',
+            default=Decimal('0.18'),
+        ),
+    )
+    effective_min_cross_section_continuation_breadth = _relax_floor_for_isolated_strength(
+        floor=_decayed_minimum(
+            event_ts=event_ts,
+            early_floor=min_cross_section_continuation_breadth,
+            late_session_floor_multiplier=late_session_floor_multiplier,
+        ),
+        isolated_strength_confirmed=isolated_strength_confirmed,
+        relaxation=_optional_decimal_param(
+            params=params,
+            key='isolated_flow_breadth_relaxation',
+            default=Decimal('0.18'),
+        ),
+    )
+    effective_max_price_above_ema12_bps = thresholds.max_price_above_ema12_bps
+    effective_min_price_below_ema12_bps = thresholds.min_price_below_ema12_bps
+    effective_bullish_hist_min = _decayed_minimum(
+        event_ts=event_ts,
+        early_floor=thresholds.bullish_hist_min,
+        late_session_floor_multiplier=_optional_decimal_param(
+            params=params,
+            key='late_session_hist_floor_multiplier',
+            default=Decimal('0.50'),
+        ),
+    )
+    effective_bullish_hist_min = _relax_floor_for_isolated_strength(
+        floor=effective_bullish_hist_min,
+        isolated_strength_confirmed=isolated_strength_confirmed,
+        relaxation=_optional_decimal_param(
+            params=params,
+            key='isolated_flow_hist_floor_relaxation',
+            default=Decimal('0.018'),
+        ),
+    )
+    effective_bullish_hist_cap = thresholds.bullish_hist_cap
+    effective_vol_ceil = thresholds.vol_ceil
+    if isolated_strength_confirmed:
+        base_cap = effective_max_price_above_ema12_bps or Decimal('0')
+        isolated_cap = _optional_decimal_param(
+            params=params,
+            key='isolated_flow_max_price_above_ema12_bps',
+            default=Decimal('12'),
+        )
+        if isolated_cap is not None:
+            effective_max_price_above_ema12_bps = max(base_cap, isolated_cap)
+        effective_min_price_below_ema12_bps = _relax_floor_for_isolated_strength(
+            floor=effective_min_price_below_ema12_bps,
+            isolated_strength_confirmed=True,
+            relaxation=thresholds.min_price_below_ema12_bps,
+        )
+        if effective_bullish_hist_cap is not None:
+            isolated_hist_cap = _optional_decimal_param(
+                params=params,
+                key='isolated_flow_bullish_hist_cap',
+                default=max(effective_bullish_hist_cap, Decimal('0.09')),
+            )
+            if isolated_hist_cap is not None:
+                effective_bullish_hist_cap = max(effective_bullish_hist_cap, isolated_hist_cap)
+        if effective_vol_ceil is not None:
+            vol_ceil_multiplier = _optional_decimal_param(
+                params=params,
+                key='isolated_flow_vol_ceil_multiplier',
+                default=Decimal('1.75'),
+            ) or Decimal('1.75')
+            isolated_min_vol_ceil = _optional_decimal_param(
+                params=params,
+                key='isolated_flow_min_vol_ceil',
+                default=_profile_for_timeframe(timeframe).vol_ceil,
+            )
+            effective_vol_ceil = max(
+                effective_vol_ceil * vol_ceil_multiplier,
+                isolated_min_vol_ceil or effective_vol_ceil,
+            )
     price_not_overextended = _price_within_entry_band(
         price=price,
         ema12=ema12,
-        max_price_above_ema12_bps=thresholds.max_price_above_ema12_bps,
-        min_price_below_ema12_bps=thresholds.min_price_below_ema12_bps,
+        max_price_above_ema12_bps=effective_max_price_above_ema12_bps,
+        min_price_below_ema12_bps=effective_min_price_below_ema12_bps,
         max_price_below_ema12_bps=thresholds.max_price_below_ema12_bps,
     )
 
     if (
         trend_up
-        and vol_ok
+        and _volatility_within_budget(
+            vol_realized_w60s,
+            floor=thresholds.vol_floor,
+            ceil=effective_vol_ceil,
+        )
         and spread_ok
         and price_not_overextended
-        and macd_hist >= thresholds.bullish_hist_min
+        and macd_hist >= (effective_bullish_hist_min or Decimal('0'))
         and (
-            thresholds.bullish_hist_cap is None
-            or macd_hist <= thresholds.bullish_hist_cap
+            effective_bullish_hist_cap is None
+            or macd_hist <= effective_bullish_hist_cap
         )
         and thresholds.min_bull_rsi <= rsi14 <= thresholds.max_bull_rsi
-        and _optional_min_threshold(effective_price_drive_bps, min_session_open_drive_bps)
+        and _optional_min_threshold(effective_price_drive_bps, effective_min_session_open_drive_bps)
         and _optional_min_threshold(
             effective_opening_window_return_bps,
-            min_opening_window_return_bps,
+            effective_min_opening_window_return_bps,
         )
         and _optional_min_threshold(session_range_bps, min_session_range_bps)
         and _optional_min_threshold(price_position_in_session_range, min_session_range_position)
@@ -425,19 +578,19 @@ def evaluate_intraday_tsmom_signal(
         )
         and _optional_min_threshold(
             effective_opening_window_return_rank,
-            min_cross_section_opening_window_return_rank,
+            effective_min_cross_section_opening_window_return_rank,
         )
         and _optional_min_threshold(
-            cross_section_continuation_rank,
+            effective_live_continuation_rank,
             min_cross_section_continuation_rank,
         )
         and _optional_min_threshold(
             cross_section_continuation_breadth,
-            min_cross_section_continuation_breadth,
+            effective_min_cross_section_continuation_breadth,
         )
     ):
         confidence = Decimal("0.64")
-        if macd_hist >= thresholds.bullish_hist_min * Decimal("2"):
+        if effective_bullish_hist_min is not None and macd_hist >= effective_bullish_hist_min * Decimal("2"):
             confidence += Decimal("0.05")
         if (
             vol_realized_w60s is not None
@@ -451,8 +604,8 @@ def evaluate_intraday_tsmom_signal(
         ):
             confidence += Decimal("0.02")
         if (
-            cross_section_continuation_rank is not None
-            and cross_section_continuation_rank >= Decimal("0.80")
+            effective_live_continuation_rank is not None
+            and effective_live_continuation_rank >= Decimal("0.80")
         ):
             confidence += Decimal("0.02")
         if (
@@ -739,6 +892,168 @@ def _optional_max_threshold(
     if value is None:
         return False
     return value <= threshold
+
+
+def _weighted_average_decimal(
+    weighted_values: list[tuple[Decimal | None, Decimal]],
+) -> Decimal | None:
+    weighted_sum = Decimal('0')
+    total_weight = Decimal('0')
+    for value, weight in weighted_values:
+        if value is None or weight <= 0:
+            continue
+        weighted_sum += value * weight
+        total_weight += weight
+    if total_weight <= 0:
+        return None
+    return weighted_sum / total_weight
+
+
+def _session_minutes_elapsed(event_ts: str | datetime | None) -> int:
+    if event_ts is None:
+        return 0
+    if isinstance(event_ts, datetime):
+        event_dt = event_ts
+    else:
+        try:
+            event_dt = datetime.fromisoformat(event_ts.replace("Z", "+00:00"))
+        except ValueError:
+            return 0
+    if event_dt.tzinfo is None:
+        event_dt = event_dt.replace(tzinfo=timezone.utc)
+    event_dt = event_dt.astimezone(timezone.utc)
+    open_minute = 13 * 60 + 30
+    current_minute = event_dt.hour * 60 + event_dt.minute
+    return max(0, current_minute - open_minute)
+
+
+def _resolve_live_continuation_rank(
+    *,
+    event_ts: str | datetime | None,
+    cross_section_opening_window_return_rank: Decimal | None,
+    cross_section_opening_window_return_from_prev_close_rank: Decimal | None,
+    cross_section_range_position_rank: Decimal | None,
+    cross_section_vwap_w5m_rank: Decimal | None,
+    cross_section_recent_imbalance_rank: Decimal | None,
+    fallback_rank: Decimal | None,
+) -> Decimal | None:
+    effective_opening_window_rank = (
+        cross_section_opening_window_return_from_prev_close_rank
+        if cross_section_opening_window_return_from_prev_close_rank is not None
+        else cross_section_opening_window_return_rank
+    )
+    if (
+        effective_opening_window_rank is None
+        and cross_section_range_position_rank is None
+        and cross_section_vwap_w5m_rank is None
+        and cross_section_recent_imbalance_rank is None
+    ):
+        return fallback_rank
+    minutes_elapsed = _session_minutes_elapsed(event_ts)
+    structural_progress = Decimal(
+        max(0, min(minutes_elapsed - 30, 90))
+    ) / Decimal('90')
+    resolved = _weighted_average_decimal(
+        [
+            (effective_opening_window_rank, Decimal('0.30') - (Decimal('0.15') * structural_progress)),
+            (cross_section_range_position_rank, Decimal('0.25') + (Decimal('0.08') * structural_progress)),
+            (cross_section_vwap_w5m_rank, Decimal('0.25')),
+            (cross_section_recent_imbalance_rank, Decimal('0.20') + (Decimal('0.07') * structural_progress)),
+        ]
+    )
+    return resolved if resolved is not None else fallback_rank
+
+
+def _decayed_minimum(
+    *,
+    event_ts: str | datetime | None,
+    early_floor: Decimal | None,
+    late_session_floor_multiplier: Decimal | None,
+    decay_start_minutes: int = 60,
+    decay_duration_minutes: int = 120,
+) -> Decimal | None:
+    if early_floor is None:
+        return None
+    if late_session_floor_multiplier is None:
+        return early_floor
+    effective_multiplier = min(max(late_session_floor_multiplier, Decimal('0')), Decimal('1'))
+    late_floor = early_floor * effective_multiplier
+    if decay_duration_minutes <= 0:
+        return late_floor
+    minutes_elapsed = _session_minutes_elapsed(event_ts)
+    if minutes_elapsed <= decay_start_minutes:
+        return early_floor
+    progress = Decimal(
+        min(max(minutes_elapsed - decay_start_minutes, 0), decay_duration_minutes)
+    ) / Decimal(decay_duration_minutes)
+    return early_floor - ((early_floor - late_floor) * progress)
+
+
+def _isolated_continuation_strength_confirmed(
+    *,
+    params: Mapping[str, Any],
+    live_continuation_rank: Decimal | None,
+    range_position_rank: Decimal | None,
+    vwap_w5m_rank: Decimal | None,
+    recent_imbalance_rank: Decimal | None,
+    recent_microprice_bias_bps_avg: Decimal | None,
+) -> bool:
+    return (
+        _optional_min_threshold(
+            live_continuation_rank,
+            _optional_decimal_param(
+                params=params,
+                key='isolated_flow_min_live_continuation_rank',
+                default=Decimal('0.82'),
+            ),
+        )
+        and _optional_min_threshold(
+            range_position_rank,
+            _optional_decimal_param(
+                params=params,
+                key='isolated_flow_min_range_position_rank',
+                default=Decimal('0.88'),
+            ),
+        )
+        and _optional_min_threshold(
+            vwap_w5m_rank,
+            _optional_decimal_param(
+                params=params,
+                key='isolated_flow_min_vwap_w5m_rank',
+                default=Decimal('0.80'),
+            ),
+        )
+        and _optional_min_threshold(
+            recent_imbalance_rank,
+            _optional_decimal_param(
+                params=params,
+                key='isolated_flow_min_recent_imbalance_rank',
+                default=Decimal('0.75'),
+            ),
+        )
+        and _optional_min_threshold(
+            recent_microprice_bias_bps_avg,
+            _optional_decimal_param(
+                params=params,
+                key='isolated_flow_min_recent_microprice_bias_bps',
+                default=Decimal('0.20'),
+            ),
+        )
+    )
+
+
+def _relax_floor_for_isolated_strength(
+    *,
+    floor: Decimal | None,
+    isolated_strength_confirmed: bool,
+    relaxation: Decimal | None,
+) -> Decimal | None:
+    if floor is None or not isolated_strength_confirmed:
+        return floor
+    effective_relaxation = relaxation or Decimal('0')
+    if effective_relaxation <= 0:
+        return floor
+    return max(Decimal('0'), floor - effective_relaxation)
 
 
 __all__ = [

--- a/services/torghut/app/trading/research_sleeves.py
+++ b/services/torghut/app/trading/research_sleeves.py
@@ -219,12 +219,15 @@ def evaluate_breakout_continuation_long(
     cross_section_positive_opening_window_return_from_prev_close_ratio: Decimal | None,
     cross_section_above_vwap_w5m_ratio: Decimal | None,
     cross_section_continuation_breadth: Decimal | None,
+    cross_section_session_open_rank: Decimal | None,
     cross_section_opening_window_return_rank: Decimal | None,
     cross_section_prev_session_close_rank: Decimal | None,
     cross_section_opening_window_return_from_prev_close_rank: Decimal | None,
+    cross_section_range_position_rank: Decimal | None,
+    cross_section_vwap_w5m_rank: Decimal | None,
+    cross_section_recent_imbalance_rank: Decimal | None,
     cross_section_continuation_rank: Decimal | None,
 ) -> SleeveSignalEvaluation | None:
-    del cross_section_prev_session_close_rank
     if (
         price is None
         or ema12 is None
@@ -258,6 +261,10 @@ def evaluate_breakout_continuation_long(
         opening_window_return_from_prev_close_bps,
         opening_window_return_bps,
     )
+    session_open_return_efficiency = _ratio_decimal_over_bps(
+        opening_window_return_bps,
+        opening_range_width_bps,
+    )
     effective_positive_session_open_ratio = _prefer_primary_decimal(
         cross_section_positive_prev_session_close_ratio,
         cross_section_positive_session_open_ratio,
@@ -270,15 +277,61 @@ def evaluate_breakout_continuation_long(
         cross_section_opening_window_return_from_prev_close_rank,
         cross_section_opening_window_return_rank,
     )
+    effective_continuation_rank = _resolve_live_continuation_rank(
+        event_ts=event_ts,
+        cross_section_session_open_rank=cross_section_session_open_rank,
+        cross_section_prev_session_close_rank=cross_section_prev_session_close_rank,
+        cross_section_opening_window_return_rank=cross_section_opening_window_return_rank,
+        cross_section_opening_window_return_from_prev_close_rank=(
+            cross_section_opening_window_return_from_prev_close_rank
+        ),
+        cross_section_range_position_rank=cross_section_range_position_rank,
+        cross_section_vwap_w5m_rank=cross_section_vwap_w5m_rank,
+        cross_section_recent_imbalance_rank=cross_section_recent_imbalance_rank,
+        fallback_rank=cross_section_continuation_rank,
+    )
     session_high_vs_opening_range_high_bps = _bps_delta(
         session_high_price,
         opening_range_high,
     )
-    min_session_open_drive_bps = _decimal_param(params, 'min_session_open_drive_bps', Decimal('20'))
-    min_opening_window_return_bps = _optional_decimal_param(
-        params,
-        'min_opening_window_return_bps',
-        Decimal('12'),
+    min_session_open_drive_bps = _decayed_minimum(
+        event_ts=event_ts,
+        early_floor=_optional_decimal_param(
+            params,
+            'min_session_open_drive_bps',
+            Decimal('20'),
+        ),
+        late_floor=_optional_decimal_param(
+            params,
+            'late_session_min_session_open_drive_bps',
+            None,
+        ),
+    )
+    min_opening_window_return_bps = _decayed_minimum(
+        event_ts=event_ts,
+        early_floor=_optional_decimal_param(
+            params,
+            'min_opening_window_return_bps',
+            Decimal('12'),
+        ),
+        late_floor=_optional_decimal_param(
+            params,
+            'late_session_min_opening_window_return_bps',
+            None,
+        ),
+    )
+    min_session_open_return_efficiency = _decayed_minimum(
+        event_ts=event_ts,
+        early_floor=_optional_decimal_param(
+            params,
+            'min_session_open_return_efficiency',
+            Decimal('0.60'),
+        ),
+        late_floor=_optional_decimal_param(
+            params,
+            'late_session_min_session_open_return_efficiency',
+            Decimal('0.45'),
+        ),
     )
     min_session_high_above_opening_range_high_bps = _optional_decimal_param(
         params,
@@ -342,20 +395,36 @@ def evaluate_breakout_continuation_long(
         'min_cross_section_continuation_rank',
         None,
     )
-    min_cross_section_opening_window_return_rank = _optional_decimal_param(
-        params,
-        'min_cross_section_opening_window_return_rank',
-        None,
+    min_cross_section_opening_window_return_rank = _decayed_minimum(
+        event_ts=event_ts,
+        early_floor=_optional_decimal_param(
+            params,
+            'min_cross_section_opening_window_return_rank',
+            None,
+        ),
+        late_floor=_optional_decimal_param(
+            params,
+            'late_session_min_cross_section_opening_window_return_rank',
+            None,
+        ),
     )
     min_cross_section_positive_session_open_ratio = _optional_decimal_param(
         params,
         'min_cross_section_positive_session_open_ratio',
         None,
     )
-    min_cross_section_positive_opening_window_return_ratio = _optional_decimal_param(
-        params,
-        'min_cross_section_positive_opening_window_return_ratio',
-        None,
+    min_cross_section_positive_opening_window_return_ratio = _decayed_minimum(
+        event_ts=event_ts,
+        early_floor=_optional_decimal_param(
+            params,
+            'min_cross_section_positive_opening_window_return_ratio',
+            None,
+        ),
+        late_floor=_optional_decimal_param(
+            params,
+            'late_session_min_cross_section_positive_opening_window_return_ratio',
+            None,
+        ),
     )
     min_cross_section_above_vwap_w5m_ratio = _optional_decimal_param(
         params,
@@ -367,6 +436,26 @@ def evaluate_breakout_continuation_long(
         'min_cross_section_continuation_breadth',
         None,
     )
+    early_breakout_quality_cutoff_minutes = _minute_param(
+        params,
+        'early_breakout_quality_cutoff_minutes',
+        90,
+    )
+    early_breakout_elite_continuation_rank = _optional_decimal_param(
+        params,
+        'early_breakout_elite_continuation_rank',
+        Decimal('0.90'),
+    )
+    min_early_breakout_continuation_breadth = _optional_decimal_param(
+        params,
+        'min_early_breakout_continuation_breadth',
+        Decimal('0.75'),
+    )
+    min_early_breakout_microprice_bias_bps = _optional_decimal_param(
+        params,
+        'min_early_breakout_microprice_bias_bps',
+        Decimal('0.60'),
+    )
     ema_extension_cap_bps = _scaled_extension_cap(
         base_cap=_decimal_param(params, 'max_price_above_ema12_bps', Decimal('16')),
         reference_bps=session_range_bps or opening_range_width_bps,
@@ -376,6 +465,181 @@ def evaluate_breakout_continuation_long(
         base_cap=max_price_vs_vwap_w5m_bps,
         reference_bps=session_range_bps or opening_range_width_bps,
         multiplier=_optional_decimal_param(params, 'vwap_w5m_range_multiplier', Decimal('0.45')),
+    )
+    isolated_strength_confirmed = _isolated_breakout_strength_confirmed(
+        params=params,
+        range_position_rank=cross_section_range_position_rank,
+        vwap_w5m_rank=cross_section_vwap_w5m_rank,
+        recent_imbalance_rank=cross_section_recent_imbalance_rank,
+    )
+    min_session_open_drive_bps = _relax_floor_for_isolated_strength(
+        floor=min_session_open_drive_bps,
+        isolated_strength_confirmed=isolated_strength_confirmed,
+        relaxation=_optional_decimal_param(
+            params,
+            'isolated_flow_session_open_drive_relaxation_bps',
+            Decimal('8'),
+        ),
+    )
+    min_opening_window_return_bps = _relax_floor_for_isolated_strength(
+        floor=min_opening_window_return_bps,
+        isolated_strength_confirmed=isolated_strength_confirmed,
+        relaxation=_optional_decimal_param(
+            params,
+            'isolated_flow_opening_window_return_relaxation_bps',
+            Decimal('6'),
+        ),
+    )
+    min_session_open_return_efficiency = _relax_floor_for_isolated_strength(
+        floor=min_session_open_return_efficiency,
+        isolated_strength_confirmed=isolated_strength_confirmed,
+        relaxation=_optional_decimal_param(
+            params,
+            'isolated_flow_session_open_return_efficiency_relaxation',
+            Decimal('0.10'),
+        ),
+    )
+    min_cross_section_positive_session_open_ratio = _relax_floor_for_isolated_strength(
+        floor=min_cross_section_positive_session_open_ratio,
+        isolated_strength_confirmed=isolated_strength_confirmed,
+        relaxation=_optional_decimal_param(
+            params,
+            'isolated_flow_session_open_ratio_relaxation',
+            Decimal('0.12'),
+        ),
+    )
+    min_cross_section_positive_opening_window_return_ratio = _relax_floor_for_isolated_strength(
+        floor=min_cross_section_positive_opening_window_return_ratio,
+        isolated_strength_confirmed=isolated_strength_confirmed,
+        relaxation=_optional_decimal_param(
+            params,
+            'isolated_flow_opening_window_ratio_relaxation',
+            Decimal('0.15'),
+        ),
+    )
+    min_cross_section_above_vwap_w5m_ratio = _relax_floor_for_isolated_strength(
+        floor=min_cross_section_above_vwap_w5m_ratio,
+        isolated_strength_confirmed=isolated_strength_confirmed,
+        relaxation=_optional_decimal_param(
+            params,
+            'isolated_flow_above_vwap_ratio_relaxation',
+            Decimal('0.15'),
+        ),
+    )
+    min_cross_section_continuation_breadth = _relax_floor_for_isolated_strength(
+        floor=min_cross_section_continuation_breadth,
+        isolated_strength_confirmed=isolated_strength_confirmed,
+        relaxation=_optional_decimal_param(
+            params,
+            'isolated_flow_continuation_breadth_relaxation',
+            Decimal('0.15'),
+        ),
+    )
+    max_recent_spread_bps = _widen_cap_for_isolated_strength(
+        cap=max_recent_spread_bps,
+        isolated_strength_confirmed=isolated_strength_confirmed,
+        extension=_optional_decimal_param(
+            params,
+            'isolated_flow_recent_spread_bps_extension',
+            Decimal('4'),
+        ),
+    )
+    max_recent_spread_bps_max = _widen_cap_for_isolated_strength(
+        cap=max_recent_spread_bps_max,
+        isolated_strength_confirmed=isolated_strength_confirmed,
+        extension=_optional_decimal_param(
+            params,
+            'isolated_flow_recent_spread_bps_max_extension',
+            Decimal('18'),
+        ),
+    )
+    max_recent_quote_invalid_ratio = _widen_cap_for_isolated_strength(
+        cap=max_recent_quote_invalid_ratio,
+        isolated_strength_confirmed=isolated_strength_confirmed,
+        extension=_optional_decimal_param(
+            params,
+            'isolated_flow_recent_quote_invalid_ratio_extension',
+            Decimal('0.10'),
+        ),
+    )
+    min_recent_microprice_bias_bps = _relax_floor_for_isolated_strength(
+        floor=min_recent_microprice_bias_bps,
+        isolated_strength_confirmed=isolated_strength_confirmed,
+        relaxation=_optional_decimal_param(
+            params,
+            'isolated_flow_recent_microprice_bias_relaxation_bps',
+            Decimal('0.15'),
+        ),
+    )
+    min_session_high_above_opening_range_high_bps = _relax_floor_for_isolated_strength(
+        floor=min_session_high_above_opening_range_high_bps,
+        isolated_strength_confirmed=isolated_strength_confirmed,
+        relaxation=_optional_decimal_param(
+            params,
+            'isolated_flow_session_high_above_orh_relaxation_bps',
+            Decimal('4'),
+        ),
+    )
+    min_price_vs_opening_range_high_bps = _relax_floor_for_isolated_strength(
+        floor=min_price_vs_opening_range_high_bps,
+        isolated_strength_confirmed=isolated_strength_confirmed,
+        relaxation=_optional_decimal_param(
+            params,
+            'isolated_flow_price_vs_orh_relaxation_bps',
+            Decimal('12'),
+        ),
+    )
+    min_price_vs_opening_window_close_bps = _relax_floor_for_isolated_strength(
+        floor=min_price_vs_opening_window_close_bps,
+        isolated_strength_confirmed=isolated_strength_confirmed,
+        relaxation=_optional_decimal_param(
+            params,
+            'isolated_flow_price_vs_open_close_min_relaxation_bps',
+            Decimal('4'),
+        ),
+    )
+    max_price_vs_opening_range_high_bps = _widen_cap_for_isolated_strength(
+        cap=max_price_vs_opening_range_high_bps,
+        isolated_strength_confirmed=isolated_strength_confirmed,
+        extension=_optional_decimal_param(
+            params,
+            'isolated_flow_price_vs_orh_cap_extension_bps',
+            Decimal('8'),
+        ),
+    )
+    max_price_vs_opening_window_close_bps = _widen_cap_for_isolated_strength(
+        cap=max_price_vs_opening_window_close_bps,
+        isolated_strength_confirmed=isolated_strength_confirmed,
+        extension=_optional_decimal_param(
+            params,
+            'isolated_flow_price_vs_open_close_cap_extension_bps',
+            Decimal('14'),
+        ),
+    )
+
+    classical_breakout_shape_passes = (
+        _optional_min_threshold(session_high_vs_opening_range_high_bps, min_session_high_above_opening_range_high_bps)
+        and _optional_min_threshold(price_vs_opening_range_high_bps, min_price_vs_opening_range_high_bps)
+        and _optional_max_threshold(price_vs_opening_range_high_bps, max_price_vs_opening_range_high_bps)
+        and _optional_min_threshold(
+            price_vs_opening_window_close_bps,
+            min_price_vs_opening_window_close_bps,
+        )
+        and _optional_max_threshold(
+            price_vs_opening_window_close_bps,
+            max_price_vs_opening_window_close_bps,
+        )
+        and _optional_min_threshold(opening_range_width_bps, min_opening_range_width_bps)
+        and _optional_min_threshold(session_range_bps, min_session_range_bps)
+        and _optional_min_threshold(price_position_in_session_range, min_session_range_position)
+    )
+    isolated_continuation_shape_passes = _isolated_leader_continuation_shape_passes(
+        params=params,
+        isolated_strength_confirmed=isolated_strength_confirmed,
+        price_position_in_session_range=price_position_in_session_range,
+        price_vs_opening_range_high_bps=price_vs_opening_range_high_bps,
+        opening_range_width_bps=opening_range_width_bps,
+        session_range_bps=session_range_bps,
     )
 
     if (
@@ -396,20 +660,14 @@ def evaluate_breakout_continuation_long(
             effective_opening_window_return_bps,
             min_opening_window_return_bps,
         )
-        and _optional_min_threshold(session_high_vs_opening_range_high_bps, min_session_high_above_opening_range_high_bps)
-        and _optional_min_threshold(price_vs_opening_range_high_bps, min_price_vs_opening_range_high_bps)
-        and _optional_max_threshold(price_vs_opening_range_high_bps, max_price_vs_opening_range_high_bps)
         and _optional_min_threshold(
-            price_vs_opening_window_close_bps,
-            min_price_vs_opening_window_close_bps,
+            session_open_return_efficiency,
+            min_session_open_return_efficiency,
         )
-        and _optional_max_threshold(
-            price_vs_opening_window_close_bps,
-            max_price_vs_opening_window_close_bps,
+        and (
+            classical_breakout_shape_passes
+            or isolated_continuation_shape_passes
         )
-        and _optional_min_threshold(opening_range_width_bps, min_opening_range_width_bps)
-        and _optional_min_threshold(session_range_bps, min_session_range_bps)
-        and _optional_min_threshold(price_position_in_session_range, min_session_range_position)
         and _optional_max_threshold(recent_spread_bps_avg, max_recent_spread_bps)
         and _optional_max_threshold(recent_spread_bps_max, max_recent_spread_bps_max)
         and _optional_min_threshold(recent_imbalance_pressure_avg, min_recent_imbalance_pressure)
@@ -424,7 +682,7 @@ def evaluate_breakout_continuation_long(
             min_recent_microprice_bias_bps,
         )
         and _optional_min_threshold(
-            cross_section_continuation_rank,
+            effective_continuation_rank,
             min_cross_section_continuation_rank,
         )
         and _optional_min_threshold(
@@ -447,6 +705,16 @@ def evaluate_breakout_continuation_long(
             cross_section_continuation_breadth,
             min_cross_section_continuation_breadth,
         )
+        and _early_breakout_quality_passes(
+            event_ts=event_ts,
+            cutoff_minutes=early_breakout_quality_cutoff_minutes,
+            continuation_rank=effective_continuation_rank,
+            elite_continuation_rank=early_breakout_elite_continuation_rank,
+            continuation_breadth=cross_section_continuation_breadth,
+            min_continuation_breadth=min_early_breakout_continuation_breadth,
+            microprice_bias_bps=recent_microprice_bias_bps_avg,
+            min_microprice_bias_bps=min_early_breakout_microprice_bias_bps,
+        )
         and _vol_within_band(
             vol_realized_w60s,
             floor=_optional_decimal_param(params, 'vol_floor', Decimal('0.00004')),
@@ -468,8 +736,8 @@ def evaluate_breakout_continuation_long(
         ):
             confidence += Decimal('0.02')
         if (
-            cross_section_continuation_rank is not None
-            and cross_section_continuation_rank >= Decimal('0.85')
+            effective_continuation_rank is not None
+            and effective_continuation_rank >= Decimal('0.85')
         ):
             confidence += Decimal('0.03')
         if (
@@ -501,7 +769,7 @@ def evaluate_breakout_continuation_long(
             notional_multiplier=_resolve_entry_notional_multiplier(
                 params=params,
                 confidence=min(confidence, Decimal('0.86')),
-                rank=cross_section_continuation_rank,
+                rank=effective_continuation_rank,
                 spread_bps=effective_spread_bps,
                 spread_cap_bps=spread_cap_bps,
             ),
@@ -509,11 +777,70 @@ def evaluate_breakout_continuation_long(
 
     exit_macd_hist_max = _decimal_param(params, 'exit_macd_hist_max', Decimal('-0.003'))
     exit_rsi_max = _decimal_param(params, 'exit_rsi_max', Decimal('56'))
-    breakout_failure_confirmed = (
-        (
-            price_vs_vwap_w5m_bps is not None
-            and price_vs_vwap_w5m_bps <= _decimal_param(params, 'exit_price_vs_vwap_w5m_bps', Decimal('-10'))
+    exit_price_below_opening_range_high_bps = _relax_floor_for_isolated_strength(
+        floor=_decimal_param(params, 'exit_price_below_opening_range_high_bps', Decimal('-6')),
+        isolated_strength_confirmed=isolated_strength_confirmed,
+        relaxation=_optional_decimal_param(
+            params,
+            'isolated_flow_price_vs_orh_relaxation_bps',
+            Decimal('12'),
+        ),
+    )
+    momentum_rollover_failure_confirmed = (
+        macd_hist <= exit_macd_hist_max
+        and rsi14 <= exit_rsi_max
+        and price < ema12
+        and (
+            (
+                price_vs_opening_range_high_bps is not None
+                and price_vs_opening_range_high_bps
+                <= _decimal_param(
+                    params,
+                    'exit_momentum_rollover_price_vs_opening_range_high_bps',
+                    Decimal('0'),
+                )
+            )
+            or (
+                price_vs_vwap_w5m_bps is not None
+                and price_vs_vwap_w5m_bps
+                <= _decimal_param(params, 'exit_momentum_rollover_vwap_bps', Decimal('0'))
+                and price_position_in_session_range is not None
+                and price_position_in_session_range
+                <= _decimal_param(
+                    params,
+                    'exit_momentum_rollover_session_range_position_max',
+                    Decimal('0.80'),
+                )
+            )
         )
+    )
+    vwap_breakout_failure_confirmed = (
+        price_vs_vwap_w5m_bps is not None
+        and price_vs_vwap_w5m_bps
+        <= _decimal_param(params, 'exit_price_vs_vwap_w5m_bps', Decimal('-10'))
+        and (
+            (
+                price_vs_opening_range_high_bps is not None
+                and price_vs_opening_range_high_bps
+                <= _decimal_param(
+                    params,
+                    'exit_breakout_failure_price_vs_opening_range_high_bps',
+                    Decimal('0'),
+                )
+            )
+            or (
+                price_position_in_session_range is not None
+                and price_position_in_session_range
+                <= _decimal_param(
+                    params,
+                    'exit_breakout_failure_session_range_position_min',
+                    _decimal_param(params, 'exit_session_range_position_min', Decimal('0.48')),
+                )
+            )
+        )
+    )
+    breakout_failure_confirmed = (
+        vwap_breakout_failure_confirmed
         or (
             price_position_in_session_range is not None
             and price_position_in_session_range <= _decimal_param(params, 'exit_session_range_position_min', Decimal('0.48'))
@@ -522,11 +849,7 @@ def evaluate_breakout_continuation_long(
             price_vs_session_open_bps is not None
             and price_vs_session_open_bps <= _decimal_param(params, 'exit_session_open_drive_bps', Decimal('18'))
         )
-        or (
-            macd_hist <= exit_macd_hist_max
-            and rsi14 <= exit_rsi_max
-            and price < ema12
-        )
+        or momentum_rollover_failure_confirmed
     )
     if breakout_failure_confirmed:
         return SleeveSignalEvaluation(
@@ -537,13 +860,40 @@ def evaluate_breakout_continuation_long(
                 'breakout_failed',
             ),
         )
-    if (
-        price_vs_opening_range_high_bps is not None
-        and price_vs_opening_range_high_bps <= _decimal_param(params, 'exit_price_below_opening_range_high_bps', Decimal('-6'))
-    ) or (
+    session_strength_reversal_confirmed = (
         recent_imbalance_pressure_avg is not None
-        and recent_imbalance_pressure_avg <= _decimal_param(params, 'exit_recent_imbalance_pressure_max', Decimal('-0.03'))
-    ):
+        and recent_imbalance_pressure_avg
+        <= _decimal_param(params, 'exit_recent_imbalance_pressure_max', Decimal('-0.03'))
+        and (
+            (
+                price_vs_opening_range_high_bps is not None
+                and price_vs_opening_range_high_bps
+                <= _decimal_param(
+                    params,
+                    'exit_session_strength_reversal_price_vs_opening_range_high_bps',
+                    Decimal('0'),
+                )
+            )
+            or (
+                price_vs_vwap_w5m_bps is not None
+                and price_vs_vwap_w5m_bps
+                <= _decimal_param(params, 'exit_session_strength_reversal_vwap_bps', Decimal('0'))
+                and price_position_in_session_range is not None
+                and price_position_in_session_range
+                <= _decimal_param(
+                    params,
+                    'exit_session_strength_reversal_session_range_position_max',
+                    Decimal('0.80'),
+                )
+            )
+        )
+    )
+    if (
+        _optional_max_threshold(
+            price_vs_opening_range_high_bps,
+            exit_price_below_opening_range_high_bps,
+        )
+    ) or session_strength_reversal_confirmed:
         return SleeveSignalEvaluation(
             action='sell',
             confidence=Decimal('0.63'),
@@ -841,12 +1191,15 @@ def evaluate_late_day_continuation_long(
     cross_section_positive_opening_window_return_from_prev_close_ratio: Decimal | None,
     cross_section_above_vwap_w5m_ratio: Decimal | None,
     cross_section_continuation_breadth: Decimal | None,
+    cross_section_session_open_rank: Decimal | None,
     cross_section_opening_window_return_rank: Decimal | None,
     cross_section_prev_session_close_rank: Decimal | None,
     cross_section_opening_window_return_from_prev_close_rank: Decimal | None,
+    cross_section_range_position_rank: Decimal | None,
+    cross_section_vwap_w5m_rank: Decimal | None,
+    cross_section_recent_imbalance_rank: Decimal | None,
     cross_section_continuation_rank: Decimal | None,
 ) -> SleeveSignalEvaluation | None:
-    del cross_section_prev_session_close_rank
     if (
         price is None
         or ema12 is None
@@ -892,17 +1245,54 @@ def evaluate_late_day_continuation_long(
         cross_section_opening_window_return_from_prev_close_rank,
         cross_section_opening_window_return_rank,
     )
+    effective_continuation_rank = _resolve_live_continuation_rank(
+        event_ts=event_ts,
+        cross_section_session_open_rank=cross_section_session_open_rank,
+        cross_section_prev_session_close_rank=cross_section_prev_session_close_rank,
+        cross_section_opening_window_return_rank=cross_section_opening_window_return_rank,
+        cross_section_opening_window_return_from_prev_close_rank=(
+            cross_section_opening_window_return_from_prev_close_rank
+        ),
+        cross_section_range_position_rank=cross_section_range_position_rank,
+        cross_section_vwap_w5m_rank=cross_section_vwap_w5m_rank,
+        cross_section_recent_imbalance_rank=cross_section_recent_imbalance_rank,
+        fallback_rank=cross_section_continuation_rank,
+    )
     session_high_vs_opening_range_high_bps = _bps_delta(
         session_high_price,
         opening_range_high,
     )
-    min_session_open_drive_bps = _decimal_param(params, 'min_session_open_drive_bps', Decimal('35'))
-    min_opening_window_return_bps = _optional_decimal_param(
-        params,
-        'min_opening_window_return_bps',
-        Decimal('18'),
+    min_session_open_drive_bps = _decayed_minimum(
+        event_ts=event_ts,
+        early_floor=_optional_decimal_param(
+            params,
+            'min_session_open_drive_bps',
+            Decimal('35'),
+        ),
+        late_floor=_optional_decimal_param(
+            params,
+            'late_session_min_session_open_drive_bps',
+            None,
+        ),
     )
-    min_session_range_position = _optional_decimal_param(params, 'min_session_range_position', Decimal('0.74'))
+    min_opening_window_return_bps = _decayed_minimum(
+        event_ts=event_ts,
+        early_floor=_optional_decimal_param(
+            params,
+            'min_opening_window_return_bps',
+            Decimal('18'),
+        ),
+        late_floor=_optional_decimal_param(
+            params,
+            'late_session_min_opening_window_return_bps',
+            None,
+        ),
+    )
+    min_session_range_position = _optional_decimal_param(
+        params,
+        'min_session_range_position',
+        Decimal('0.74'),
+    )
     min_session_high_above_opening_range_high_bps = _optional_decimal_param(
         params,
         'min_session_high_above_opening_range_high_bps',
@@ -962,20 +1352,36 @@ def evaluate_late_day_continuation_long(
         'min_cross_section_continuation_rank',
         None,
     )
-    min_cross_section_opening_window_return_rank = _optional_decimal_param(
-        params,
-        'min_cross_section_opening_window_return_rank',
-        None,
+    min_cross_section_opening_window_return_rank = _decayed_minimum(
+        event_ts=event_ts,
+        early_floor=_optional_decimal_param(
+            params,
+            'min_cross_section_opening_window_return_rank',
+            None,
+        ),
+        late_floor=_optional_decimal_param(
+            params,
+            'late_session_min_cross_section_opening_window_return_rank',
+            None,
+        ),
     )
     min_cross_section_positive_session_open_ratio = _optional_decimal_param(
         params,
         'min_cross_section_positive_session_open_ratio',
         None,
     )
-    min_cross_section_positive_opening_window_return_ratio = _optional_decimal_param(
-        params,
-        'min_cross_section_positive_opening_window_return_ratio',
-        None,
+    min_cross_section_positive_opening_window_return_ratio = _decayed_minimum(
+        event_ts=event_ts,
+        early_floor=_optional_decimal_param(
+            params,
+            'min_cross_section_positive_opening_window_return_ratio',
+            None,
+        ),
+        late_floor=_optional_decimal_param(
+            params,
+            'late_session_min_cross_section_positive_opening_window_return_ratio',
+            None,
+        ),
     )
     min_cross_section_above_vwap_w5m_ratio = _optional_decimal_param(
         params,
@@ -986,6 +1392,132 @@ def evaluate_late_day_continuation_long(
         params,
         'min_cross_section_continuation_breadth',
         None,
+    )
+    isolated_strength_confirmed = _isolated_breakout_strength_confirmed(
+        params=params,
+        range_position_rank=cross_section_range_position_rank,
+        vwap_w5m_rank=cross_section_vwap_w5m_rank,
+        recent_imbalance_rank=cross_section_recent_imbalance_rank,
+    )
+    min_session_open_drive_bps = _relax_floor_for_isolated_strength(
+        floor=min_session_open_drive_bps,
+        isolated_strength_confirmed=isolated_strength_confirmed,
+        relaxation=_optional_decimal_param(
+            params,
+            'isolated_flow_session_open_drive_relaxation_bps',
+            Decimal('10'),
+        ),
+    )
+    min_opening_window_return_bps = _relax_floor_for_isolated_strength(
+        floor=min_opening_window_return_bps,
+        isolated_strength_confirmed=isolated_strength_confirmed,
+        relaxation=_optional_decimal_param(
+            params,
+            'isolated_flow_opening_window_return_relaxation_bps',
+            Decimal('8'),
+        ),
+    )
+    max_recent_spread_bps = _widen_cap_for_isolated_strength(
+        cap=max_recent_spread_bps,
+        isolated_strength_confirmed=isolated_strength_confirmed,
+        extension=_optional_decimal_param(
+            params,
+            'isolated_flow_recent_spread_bps_extension',
+            Decimal('4'),
+        ),
+    )
+    max_recent_quote_invalid_ratio = _widen_cap_for_isolated_strength(
+        cap=max_recent_quote_invalid_ratio,
+        isolated_strength_confirmed=isolated_strength_confirmed,
+        extension=_optional_decimal_param(
+            params,
+            'isolated_flow_recent_quote_invalid_ratio_extension',
+            Decimal('0.10'),
+        ),
+    )
+    min_recent_microprice_bias_bps = _relax_floor_for_isolated_strength(
+        floor=min_recent_microprice_bias_bps,
+        isolated_strength_confirmed=isolated_strength_confirmed,
+        relaxation=_optional_decimal_param(
+            params,
+            'isolated_flow_recent_microprice_bias_relaxation_bps',
+            Decimal('0.15'),
+        ),
+    )
+    min_session_high_above_opening_range_high_bps = _relax_floor_for_isolated_strength(
+        floor=min_session_high_above_opening_range_high_bps,
+        isolated_strength_confirmed=isolated_strength_confirmed,
+        relaxation=_optional_decimal_param(
+            params,
+            'isolated_flow_session_high_above_orh_relaxation_bps',
+            Decimal('4'),
+        ),
+    )
+    min_price_vs_opening_range_high_bps = _relax_floor_for_isolated_strength(
+        floor=min_price_vs_opening_range_high_bps,
+        isolated_strength_confirmed=isolated_strength_confirmed,
+        relaxation=_optional_decimal_param(
+            params,
+            'isolated_flow_price_vs_orh_relaxation_bps',
+            Decimal('12'),
+        ),
+    )
+    min_price_vs_opening_window_close_bps = _relax_floor_for_isolated_strength(
+        floor=min_price_vs_opening_window_close_bps,
+        isolated_strength_confirmed=isolated_strength_confirmed,
+        relaxation=_optional_decimal_param(
+            params,
+            'isolated_flow_price_vs_open_close_min_relaxation_bps',
+            Decimal('4'),
+        ),
+    )
+    max_price_vs_opening_range_high_bps = _widen_cap_for_isolated_strength(
+        cap=max_price_vs_opening_range_high_bps,
+        isolated_strength_confirmed=isolated_strength_confirmed,
+        extension=_optional_decimal_param(
+            params,
+            'isolated_flow_price_vs_orh_cap_extension_bps',
+            Decimal('8'),
+        ),
+    )
+    max_price_vs_opening_window_close_bps = _widen_cap_for_isolated_strength(
+        cap=max_price_vs_opening_window_close_bps,
+        isolated_strength_confirmed=isolated_strength_confirmed,
+        extension=_optional_decimal_param(
+            params,
+            'isolated_flow_price_vs_open_close_cap_extension_bps',
+            Decimal('14'),
+        ),
+    )
+
+    classical_late_day_shape_passes = (
+        _optional_min_threshold(price_position_in_session_range, min_session_range_position)
+        and _optional_min_threshold(session_high_vs_opening_range_high_bps, min_session_high_above_opening_range_high_bps)
+        and _optional_min_threshold(price_vs_opening_range_high_bps, min_price_vs_opening_range_high_bps)
+        and _optional_max_threshold(price_vs_opening_range_high_bps, max_price_vs_opening_range_high_bps)
+        and _optional_min_threshold(
+            price_vs_opening_window_close_bps,
+            min_price_vs_opening_window_close_bps,
+        )
+        and _optional_max_threshold(
+            price_vs_opening_window_close_bps,
+            max_price_vs_opening_window_close_bps,
+        )
+        and _optional_min_threshold(session_range_bps, min_session_range_bps)
+    )
+    isolated_late_day_shape_passes = _isolated_leader_continuation_shape_passes(
+        params=params,
+        isolated_strength_confirmed=isolated_strength_confirmed,
+        price_position_in_session_range=price_position_in_session_range,
+        price_vs_opening_range_high_bps=price_vs_opening_range_high_bps,
+        opening_range_width_bps=None,
+        session_range_bps=session_range_bps,
+        min_session_range_position_key='isolated_flow_min_late_day_session_range_position',
+        default_min_session_range_position=Decimal('0.88'),
+        min_price_vs_opening_range_high_key='isolated_flow_min_late_day_price_vs_opening_range_high_bps',
+        default_min_price_vs_opening_range_high_bps=Decimal('-24'),
+        min_session_range_bps_key='isolated_flow_min_late_day_session_range_bps',
+        default_min_session_range_bps=min_session_range_bps or Decimal('20'),
     )
 
     if (
@@ -1009,21 +1541,12 @@ def evaluate_late_day_continuation_long(
             effective_opening_window_return_bps,
             min_opening_window_return_bps,
         )
-        and _optional_min_threshold(price_position_in_session_range, min_session_range_position)
-        and _optional_min_threshold(session_high_vs_opening_range_high_bps, min_session_high_above_opening_range_high_bps)
-        and _optional_min_threshold(price_vs_opening_range_high_bps, min_price_vs_opening_range_high_bps)
-        and _optional_max_threshold(price_vs_opening_range_high_bps, max_price_vs_opening_range_high_bps)
-        and _optional_min_threshold(
-            price_vs_opening_window_close_bps,
-            min_price_vs_opening_window_close_bps,
-        )
-        and _optional_max_threshold(
-            price_vs_opening_window_close_bps,
-            max_price_vs_opening_window_close_bps,
+        and (
+            classical_late_day_shape_passes
+            or isolated_late_day_shape_passes
         )
         and _optional_max_threshold(recent_spread_bps_avg, max_recent_spread_bps)
         and _optional_min_threshold(recent_imbalance_pressure_avg, min_recent_imbalance_pressure)
-        and _optional_min_threshold(session_range_bps, min_session_range_bps)
         and _quote_stability_passes(
             recent_quote_invalid_ratio=recent_quote_invalid_ratio,
             max_recent_quote_invalid_ratio=max_recent_quote_invalid_ratio,
@@ -1035,7 +1558,7 @@ def evaluate_late_day_continuation_long(
             min_recent_microprice_bias_bps,
         )
         and _optional_min_threshold(
-            cross_section_continuation_rank,
+            effective_continuation_rank,
             min_cross_section_continuation_rank,
         )
         and _optional_min_threshold(
@@ -1079,8 +1602,8 @@ def evaluate_late_day_continuation_long(
         ):
             confidence += Decimal('0.02')
         if (
-            cross_section_continuation_rank is not None
-            and cross_section_continuation_rank >= Decimal('0.85')
+            effective_continuation_rank is not None
+            and effective_continuation_rank >= Decimal('0.85')
         ):
             confidence += Decimal('0.03')
         if (
@@ -1111,7 +1634,7 @@ def evaluate_late_day_continuation_long(
             notional_multiplier=_resolve_entry_notional_multiplier(
                 params=params,
                 confidence=min(confidence, Decimal('0.87')),
-                rank=cross_section_continuation_rank,
+                rank=effective_continuation_rank,
                 spread_bps=effective_spread_bps,
                 spread_cap_bps=spread_cap_bps,
             ),
@@ -1488,8 +2011,280 @@ def _bps_delta(price: Decimal | None, reference: Decimal | None) -> Decimal | No
     return ((price - reference) / reference) * Decimal('10000')
 
 
+def _ratio_decimal_over_bps(
+    value_bps: Decimal | None,
+    reference_bps: Decimal | None,
+) -> Decimal | None:
+    if value_bps is None or reference_bps is None or reference_bps <= 0:
+        return None
+    return value_bps / reference_bps
+
+
 def _prefer_primary_decimal(primary: Decimal | None, fallback: Decimal | None) -> Decimal | None:
     return primary if primary is not None else fallback
+
+
+def _weighted_average_decimal(
+    weighted_values: list[tuple[Decimal | None, Decimal]],
+) -> Decimal | None:
+    weighted_sum = Decimal('0')
+    total_weight = Decimal('0')
+    for value, weight in weighted_values:
+        if value is None or weight <= 0:
+            continue
+        weighted_sum += value * weight
+        total_weight += weight
+    if total_weight <= 0:
+        return None
+    return weighted_sum / total_weight
+
+
+def _session_minutes_elapsed(event_ts: str) -> int:
+    ts = _parse_event_ts(event_ts)
+    open_minute = 13 * 60 + 30
+    current_minute = ts.hour * 60 + ts.minute
+    return max(0, current_minute - open_minute)
+
+
+def _resolve_live_continuation_rank(
+    *,
+    event_ts: str,
+    cross_section_session_open_rank: Decimal | None,
+    cross_section_prev_session_close_rank: Decimal | None,
+    cross_section_opening_window_return_rank: Decimal | None,
+    cross_section_opening_window_return_from_prev_close_rank: Decimal | None,
+    cross_section_range_position_rank: Decimal | None,
+    cross_section_vwap_w5m_rank: Decimal | None,
+    cross_section_recent_imbalance_rank: Decimal | None,
+    fallback_rank: Decimal | None,
+) -> Decimal | None:
+    effective_session_drive_rank = _prefer_primary_decimal(
+        cross_section_prev_session_close_rank,
+        cross_section_session_open_rank,
+    )
+    effective_opening_window_rank = _prefer_primary_decimal(
+        cross_section_opening_window_return_from_prev_close_rank,
+        cross_section_opening_window_return_rank,
+    )
+    if (
+        effective_session_drive_rank is None
+        and effective_opening_window_rank is None
+        and cross_section_range_position_rank is None
+        and cross_section_vwap_w5m_rank is None
+        and cross_section_recent_imbalance_rank is None
+    ):
+        return fallback_rank
+    if (
+        cross_section_range_position_rank is None
+        and cross_section_vwap_w5m_rank is None
+        and cross_section_recent_imbalance_rank is None
+        and fallback_rank is not None
+    ):
+        return fallback_rank
+
+    # Opening-window leadership matters at the open, but breakout continuation
+    # should increasingly follow live range/VWAP/imbalance structure once the
+    # opening auction is behind us.
+    minutes_elapsed = _session_minutes_elapsed(event_ts)
+    structural_progress = Decimal(
+        max(0, min(minutes_elapsed - 30, 60))
+    ) / Decimal('60')
+    weights = {
+        'session_drive': Decimal('0.18'),
+        'opening_window': Decimal('0.16') - (Decimal('0.10') * structural_progress),
+        'range_position': Decimal('0.26') + (Decimal('0.10') * structural_progress),
+        'vwap': Decimal('0.20'),
+        'imbalance': Decimal('0.20'),
+    }
+    resolved = _weighted_average_decimal(
+        [
+            (effective_session_drive_rank, weights['session_drive']),
+            (effective_opening_window_rank, weights['opening_window']),
+            (cross_section_range_position_rank, weights['range_position']),
+            (cross_section_vwap_w5m_rank, weights['vwap']),
+            (cross_section_recent_imbalance_rank, weights['imbalance']),
+        ]
+    )
+    if resolved is None:
+        return fallback_rank
+    if fallback_rank is None:
+        return resolved
+    # The live-structure blend should improve rank fidelity, not silently
+    # downgrade a symbol that already looks strong under the existing
+    # continuation composite.
+    return max(resolved, fallback_rank)
+
+
+def _decayed_minimum(
+    *,
+    event_ts: str,
+    early_floor: Decimal | None,
+    late_floor: Decimal | None,
+    decay_start_minutes: int = 60,
+    decay_duration_minutes: int = 120,
+) -> Decimal | None:
+    if early_floor is None:
+        return None
+    if decay_duration_minutes <= 0:
+        return late_floor if late_floor is not None else early_floor
+    resolved_late_floor = late_floor
+    if resolved_late_floor is None:
+        resolved_late_floor = early_floor * Decimal('0.5')
+    if resolved_late_floor > early_floor:
+        resolved_late_floor = early_floor
+    minutes_elapsed = _session_minutes_elapsed(event_ts)
+    if minutes_elapsed <= decay_start_minutes:
+        return early_floor
+    progress = Decimal(
+        min(max(minutes_elapsed - decay_start_minutes, 0), decay_duration_minutes)
+    ) / Decimal(decay_duration_minutes)
+    return early_floor - ((early_floor - resolved_late_floor) * progress)
+
+
+def _early_breakout_quality_passes(
+    *,
+    event_ts: str,
+    cutoff_minutes: int,
+    continuation_rank: Decimal | None,
+    elite_continuation_rank: Decimal | None,
+    continuation_breadth: Decimal | None,
+    min_continuation_breadth: Decimal | None,
+    microprice_bias_bps: Decimal | None,
+    min_microprice_bias_bps: Decimal | None,
+) -> bool:
+    minutes_elapsed = _session_minutes_elapsed(event_ts)
+    if minutes_elapsed > cutoff_minutes:
+        return True
+    if _optional_min_threshold(continuation_rank, elite_continuation_rank):
+        return True
+    return _optional_min_threshold(
+        continuation_breadth,
+        min_continuation_breadth,
+    ) and _optional_min_threshold(
+        microprice_bias_bps,
+        min_microprice_bias_bps,
+    )
+
+
+def _isolated_breakout_strength_confirmed(
+    *,
+    params: Mapping[str, Any],
+    range_position_rank: Decimal | None,
+    vwap_w5m_rank: Decimal | None,
+    recent_imbalance_rank: Decimal | None,
+) -> bool:
+    return (
+        _optional_min_threshold(
+            range_position_rank,
+            _optional_decimal_param(
+                params,
+                'isolated_flow_min_range_position_rank',
+                Decimal('0.85'),
+            ),
+        )
+        and _optional_min_threshold(
+            vwap_w5m_rank,
+            _optional_decimal_param(
+                params,
+                'isolated_flow_min_vwap_w5m_rank',
+                Decimal('0.75'),
+            ),
+        )
+        and _optional_min_threshold(
+            recent_imbalance_rank,
+            _optional_decimal_param(
+                params,
+                'isolated_flow_min_recent_imbalance_rank',
+                Decimal('0.75'),
+            ),
+        )
+    )
+
+
+def _relax_floor_for_isolated_strength(
+    *,
+    floor: Decimal | None,
+    isolated_strength_confirmed: bool,
+    relaxation: Decimal | None,
+) -> Decimal | None:
+    if floor is None or not isolated_strength_confirmed:
+        return floor
+    effective_relaxation = relaxation or Decimal('0')
+    if effective_relaxation <= 0:
+        return floor
+    relaxed_floor = floor - effective_relaxation
+    if floor >= 0:
+        return max(Decimal('0'), relaxed_floor)
+    return relaxed_floor
+
+
+def _widen_cap_for_isolated_strength(
+    *,
+    cap: Decimal | None,
+    isolated_strength_confirmed: bool,
+    extension: Decimal | None,
+) -> Decimal | None:
+    if cap is None or not isolated_strength_confirmed:
+        return cap
+    effective_extension = extension or Decimal('0')
+    if effective_extension <= 0:
+        return cap
+    return cap + effective_extension
+
+
+def _isolated_leader_continuation_shape_passes(
+    *,
+    params: Mapping[str, Any],
+    isolated_strength_confirmed: bool,
+    price_position_in_session_range: Decimal | None,
+    price_vs_opening_range_high_bps: Decimal | None,
+    opening_range_width_bps: Decimal | None,
+    session_range_bps: Decimal | None,
+    min_session_range_position_key: str = 'isolated_flow_min_session_range_position',
+    default_min_session_range_position: Decimal = Decimal('0.88'),
+    min_price_vs_opening_range_high_key: str = 'isolated_flow_min_price_vs_opening_range_high_bps',
+    default_min_price_vs_opening_range_high_bps: Decimal = Decimal('-24'),
+    min_opening_range_width_bps_key: str = 'isolated_flow_min_opening_range_width_bps',
+    default_min_opening_range_width_bps: Decimal = Decimal('8'),
+    min_session_range_bps_key: str = 'isolated_flow_min_session_range_bps',
+    default_min_session_range_bps: Decimal = Decimal('18'),
+) -> bool:
+    if not isolated_strength_confirmed:
+        return False
+    return (
+        _optional_min_threshold(
+            price_position_in_session_range,
+            _optional_decimal_param(
+                params,
+                min_session_range_position_key,
+                default_min_session_range_position,
+            ),
+        )
+        and _optional_min_threshold(
+            price_vs_opening_range_high_bps,
+            _optional_decimal_param(
+                params,
+                min_price_vs_opening_range_high_key,
+                default_min_price_vs_opening_range_high_bps,
+            ),
+        )
+        and _optional_min_threshold(
+            opening_range_width_bps,
+            _optional_decimal_param(
+                params,
+                min_opening_range_width_bps_key,
+                default_min_opening_range_width_bps,
+            ),
+        )
+        and _optional_min_threshold(
+            session_range_bps,
+            _optional_decimal_param(
+                params,
+                min_session_range_bps_key,
+                default_min_session_range_bps,
+            ),
+        )
+    )
 
 
 def _nonnegative_decimal(value: Decimal | None) -> Decimal:

--- a/services/torghut/app/trading/session_context.py
+++ b/services/torghut/app/trading/session_context.py
@@ -248,18 +248,18 @@ class SessionContextTracker:
             previous_price=state.last_valid_quote_price,
             policy=self.quote_quality_policy,
         )
-        if spread_bps is not None:
-            state.spread_bps_window.append(spread_bps)
-        if imbalance_pressure is not None:
-            state.imbalance_pressure_window.append(imbalance_pressure)
-        if microprice_bias_bps is not None:
-            state.microprice_bias_bps_window.append(microprice_bias_bps)
         state.quote_validity_window.append(
             Decimal('1') if quote_quality.valid else Decimal('0')
         )
         if quote_quality.jump_bps is not None:
             state.quote_jump_bps_window.append(quote_quality.jump_bps)
         if quote_quality.valid:
+            if spread_bps is not None:
+                state.spread_bps_window.append(spread_bps)
+            if imbalance_pressure is not None:
+                state.imbalance_pressure_window.append(imbalance_pressure)
+            if microprice_bias_bps is not None:
+                state.microprice_bias_bps_window.append(microprice_bias_bps)
             state.last_valid_quote_price = price
 
         session_range = state.session_high_price - state.session_low_price

--- a/services/torghut/app/trading/strategy_runtime.py
+++ b/services/torghut/app/trading/strategy_runtime.py
@@ -411,6 +411,9 @@ class IntradayTsmomPlugin:
         "cross_section_opening_window_return_from_prev_close_rank",
         "cross_section_continuation_rank",
         "cross_section_continuation_breadth",
+        "cross_section_range_position_rank",
+        "cross_section_vwap_w5m_rank",
+        "cross_section_recent_imbalance_rank",
     )
 
     def evaluate(
@@ -478,6 +481,15 @@ class IntradayTsmomPlugin:
             ),
             cross_section_continuation_breadth=_decimal(
                 features.values.get("cross_section_continuation_breadth")
+            ),
+            cross_section_range_position_rank=_decimal(
+                features.values.get("cross_section_range_position_rank")
+            ),
+            cross_section_vwap_w5m_rank=_decimal(
+                features.values.get("cross_section_vwap_w5m_rank")
+            ),
+            cross_section_recent_imbalance_rank=_decimal(
+                features.values.get("cross_section_recent_imbalance_rank")
             ),
         )
         if evaluation is None:
@@ -602,9 +614,13 @@ class BreakoutContinuationLongPlugin:
         "cross_section_positive_opening_window_return_from_prev_close_ratio",
         "cross_section_above_vwap_w5m_ratio",
         "cross_section_continuation_breadth",
+        "cross_section_session_open_rank",
         "cross_section_opening_window_return_rank",
         "cross_section_prev_session_close_rank",
         "cross_section_opening_window_return_from_prev_close_rank",
+        "cross_section_range_position_rank",
+        "cross_section_vwap_w5m_rank",
+        "cross_section_recent_imbalance_rank",
         "cross_section_continuation_rank",
     )
 
@@ -668,6 +684,9 @@ class BreakoutContinuationLongPlugin:
             cross_section_continuation_breadth=_decimal(
                 features.values.get("cross_section_continuation_breadth")
             ),
+            cross_section_session_open_rank=_decimal(
+                features.values.get("cross_section_session_open_rank")
+            ),
             cross_section_opening_window_return_rank=_decimal(
                 features.values.get("cross_section_opening_window_return_rank")
             ),
@@ -676,6 +695,15 @@ class BreakoutContinuationLongPlugin:
             ),
             cross_section_opening_window_return_from_prev_close_rank=_decimal(
                 features.values.get("cross_section_opening_window_return_from_prev_close_rank")
+            ),
+            cross_section_range_position_rank=_decimal(
+                features.values.get("cross_section_range_position_rank")
+            ),
+            cross_section_vwap_w5m_rank=_decimal(
+                features.values.get("cross_section_vwap_w5m_rank")
+            ),
+            cross_section_recent_imbalance_rank=_decimal(
+                features.values.get("cross_section_recent_imbalance_rank")
             ),
             cross_section_continuation_rank=_decimal(
                 features.values.get("cross_section_continuation_rank")
@@ -834,9 +862,13 @@ class LateDayContinuationLongPlugin:
         "cross_section_positive_opening_window_return_from_prev_close_ratio",
         "cross_section_above_vwap_w5m_ratio",
         "cross_section_continuation_breadth",
+        "cross_section_session_open_rank",
         "cross_section_opening_window_return_rank",
         "cross_section_prev_session_close_rank",
         "cross_section_opening_window_return_from_prev_close_rank",
+        "cross_section_range_position_rank",
+        "cross_section_vwap_w5m_rank",
+        "cross_section_recent_imbalance_rank",
         "cross_section_continuation_rank",
     )
 
@@ -898,6 +930,9 @@ class LateDayContinuationLongPlugin:
             cross_section_continuation_breadth=_decimal(
                 features.values.get("cross_section_continuation_breadth")
             ),
+            cross_section_session_open_rank=_decimal(
+                features.values.get("cross_section_session_open_rank")
+            ),
             cross_section_opening_window_return_rank=_decimal(
                 features.values.get("cross_section_opening_window_return_rank")
             ),
@@ -906,6 +941,15 @@ class LateDayContinuationLongPlugin:
             ),
             cross_section_opening_window_return_from_prev_close_rank=_decimal(
                 features.values.get("cross_section_opening_window_return_from_prev_close_rank")
+            ),
+            cross_section_range_position_rank=_decimal(
+                features.values.get("cross_section_range_position_rank")
+            ),
+            cross_section_vwap_w5m_rank=_decimal(
+                features.values.get("cross_section_vwap_w5m_rank")
+            ),
+            cross_section_recent_imbalance_rank=_decimal(
+                features.values.get("cross_section_recent_imbalance_rank")
             ),
             cross_section_continuation_rank=_decimal(
                 features.values.get("cross_section_continuation_rank")

--- a/services/torghut/scripts/local_intraday_tsmom_replay.py
+++ b/services/torghut/scripts/local_intraday_tsmom_replay.py
@@ -939,6 +939,88 @@ def _close_position(
     )
 
 
+def _apply_filled_decision(
+    *,
+    decision: StrategyDecision,
+    signal: SignalEnvelope,
+    fill_price: Decimal,
+    filled_at: datetime,
+    created_at: datetime,
+    positions: dict[tuple[str, str], PositionState],
+    day_bucket: dict[str, Any],
+    cost_model: TransactionCostModel,
+    cash: Decimal,
+    all_closed_trades: list[ClosedTrade],
+) -> Decimal:
+    owner_strategy_id = _decision_position_owner(decision)
+    position_key = _position_key(decision.symbol, owner_strategy_id)
+    if decision.action == 'buy':
+        fill_cost = _estimate_trade_cost(model=cost_model, decision=decision, signal=signal)
+        day_bucket['cost_total'] += fill_cost
+        day_bucket['filled_count'] += 1
+        cash -= (fill_price * decision.qty) + fill_cost
+        existing = positions.get(position_key)
+        if existing is None:
+            positions[position_key] = PositionState(
+                strategy_id=owner_strategy_id,
+                qty=decision.qty,
+                avg_entry_price=fill_price,
+                opened_at=filled_at,
+                entry_cost_total=fill_cost,
+                decision_at=created_at,
+                pending_entry=False,
+            )
+            return cash
+        new_qty = existing.qty + decision.qty
+        avg_entry = (
+            (existing.avg_entry_price * existing.qty) + (fill_price * decision.qty)
+        ) / new_qty
+        positions[position_key] = PositionState(
+            strategy_id=existing.strategy_id,
+            qty=new_qty,
+            avg_entry_price=avg_entry,
+            opened_at=existing.opened_at,
+            entry_cost_total=existing.entry_cost_total + fill_cost,
+            decision_at=existing.decision_at,
+            pending_entry=False,
+        )
+        return cash
+
+    existing = positions.get(position_key)
+    if existing is None or existing.qty <= 0:
+        return cash
+    fill_cost = _estimate_trade_cost(model=cost_model, decision=decision, signal=signal)
+    day_bucket['cost_total'] += fill_cost
+    day_bucket['filled_count'] += 1
+    sell_qty = min(decision.qty, existing.qty)
+    cash += (fill_price * sell_qty) - fill_cost
+    entry_cost_allocated = existing.entry_cost_total * (sell_qty / existing.qty)
+    remaining, trade = _close_position(
+        symbol=decision.symbol,
+        position=existing,
+        sell_qty=sell_qty,
+        fill_price=fill_price,
+        closed_at=filled_at,
+        exit_reason=_decision_exit_reason(decision),
+        entry_cost_allocated=entry_cost_allocated,
+        exit_cost_total=fill_cost,
+    )
+    if remaining is None:
+        positions.pop(position_key, None)
+    else:
+        positions[position_key] = remaining
+    day_bucket['gross_pnl'] += trade.gross_pnl
+    day_bucket['net_pnl'] += trade.net_pnl
+    if trade.net_pnl > 0:
+        day_bucket['wins'] += 1
+    elif trade.net_pnl < 0:
+        day_bucket['losses'] += 1
+    day_bucket['closed_trades'].append(trade)
+    all_closed_trades.append(trade)
+    _log_trade_closed(trade)
+    return cash
+
+
 def run_replay(config: ReplayConfig) -> dict[str, Any]:
     strategies = _load_strategies(config.strategy_configmap_path)
     strategies_by_id = {str(strategy.id): strategy for strategy in strategies}
@@ -1053,73 +1135,18 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
                 if fill_price is None:
                     pending_orders[pending_key] = pending
                     continue
-                owner_strategy_id = _decision_position_owner(decision)
-                position_key = _position_key(decision.symbol, owner_strategy_id)
-                if decision.action == 'buy':
-                    fill_cost = _estimate_trade_cost(model=cost_model, decision=decision, signal=signal)
-                    day_bucket['cost_total'] += fill_cost
-                    day_bucket['filled_count'] += 1
-                    cash -= (fill_price * decision.qty) + fill_cost
-                    existing = positions.get(position_key)
-                    if existing is None:
-                        positions[position_key] = PositionState(
-                            strategy_id=owner_strategy_id,
-                            qty=decision.qty,
-                            avg_entry_price=fill_price,
-                            opened_at=signal.event_ts,
-                            entry_cost_total=fill_cost,
-                            decision_at=pending.created_at,
-                            pending_entry=False,
-                        )
-                    else:
-                        new_qty = existing.qty + decision.qty
-                        avg_entry = (
-                            (existing.avg_entry_price * existing.qty) + (fill_price * decision.qty)
-                        ) / new_qty
-                        positions[position_key] = PositionState(
-                            strategy_id=existing.strategy_id,
-                            qty=new_qty,
-                            avg_entry_price=avg_entry,
-                            opened_at=existing.opened_at,
-                            entry_cost_total=existing.entry_cost_total + fill_cost,
-                            decision_at=existing.decision_at,
-                            pending_entry=False,
-                        )
-                    continue
-                existing = positions.get(position_key)
-                if existing is None or existing.qty <= 0:
-                    continue
-                fill_cost = _estimate_trade_cost(model=cost_model, decision=decision, signal=signal)
-                day_bucket['cost_total'] += fill_cost
-                day_bucket['filled_count'] += 1
-                sell_qty = min(decision.qty, existing.qty)
-                cash += (fill_price * sell_qty) - fill_cost
-                entry_cost_allocated = existing.entry_cost_total * (
-                    sell_qty / existing.qty
-                )
-                remaining, trade = _close_position(
-                    symbol=decision.symbol,
-                    position=existing,
-                    sell_qty=sell_qty,
+                cash = _apply_filled_decision(
+                    decision=decision,
+                    signal=signal,
                     fill_price=fill_price,
-                    closed_at=signal.event_ts,
-                    exit_reason=_decision_exit_reason(decision),
-                    entry_cost_allocated=entry_cost_allocated,
-                    exit_cost_total=fill_cost,
+                    filled_at=signal.event_ts,
+                    created_at=pending.created_at,
+                    positions=positions,
+                    day_bucket=day_bucket,
+                    cost_model=cost_model,
+                    cash=cash,
+                    all_closed_trades=all_closed_trades,
                 )
-                if remaining is None:
-                    positions.pop(position_key, None)
-                else:
-                    positions[position_key] = remaining
-                day_bucket['gross_pnl'] += trade.gross_pnl
-                day_bucket['net_pnl'] += trade.net_pnl
-                if trade.net_pnl > 0:
-                    day_bucket['wins'] += 1
-                elif trade.net_pnl < 0:
-                    day_bucket['losses'] += 1
-                day_bucket['closed_trades'].append(trade)
-                all_closed_trades.append(trade)
-                _log_trade_closed(trade)
 
             equity = _position_equity(cash=cash, positions=positions, last_prices=last_prices)
             live_positions = _positions_payload(
@@ -1163,6 +1190,21 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
                 decision = _apply_order_preferences(decision, signal)
                 _record_decision(day_bucket, decision)
                 if decision.qty <= 0:
+                    continue
+                immediate_fill_price = _resolve_pending_fill_price(decision, signal)
+                if immediate_fill_price is not None:
+                    cash = _apply_filled_decision(
+                        decision=decision,
+                        signal=signal,
+                        fill_price=immediate_fill_price,
+                        filled_at=signal.event_ts,
+                        created_at=signal.event_ts,
+                        positions=positions,
+                        day_bucket=day_bucket,
+                        cost_model=cost_model,
+                        cash=cash,
+                        all_closed_trades=all_closed_trades,
+                    )
                     continue
                 pending_key = _position_key(
                     decision.symbol,

--- a/services/torghut/tests/test_decisions.py
+++ b/services/torghut/tests/test_decisions.py
@@ -3,13 +3,15 @@ from __future__ import annotations
 import uuid
 from datetime import datetime, timezone
 from decimal import Decimal
+from types import SimpleNamespace
 from unittest import TestCase
 from unittest.mock import patch
 
 from app.config import settings
 from app.models import Strategy
 from app.strategies.catalog import StrategyConfig, _compose_strategy_description
-from app.trading.decisions import DecisionEngine
+from app.trading.decisions import DecisionEngine, _build_runtime_position_exit_overlay
+from app.trading.features import extract_signal_features
 from app.trading.models import SignalEnvelope
 from app.trading.prices import MarketSnapshot, PriceFetcher
 from app.trading.strategy_runtime import (
@@ -1603,6 +1605,89 @@ class TestDecisionEngine(TestCase):
         self.assertEqual(len(first), 1)
         self.assertEqual(second, [])
 
+    def test_scheduler_runtime_continuation_buy_defaults_to_ioc_time_in_force(self) -> None:
+        engine = DecisionEngine(price_fetcher=None)
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="breakout-continuation",
+            description=(
+                "version=1.0.0\n[catalog_metadata]\n"
+                '{"params":{"bullish_hist_min":"0.001","min_bull_rsi":"50","max_bull_rsi":"80","max_spread_bps":"100","min_session_open_drive_bps":"0","min_opening_window_return_bps":"0","min_session_high_above_opening_range_high_bps":"0","min_price_vs_opening_range_high_bps":"-100","max_price_vs_opening_range_high_bps":"100","min_price_vs_opening_window_close_bps":"-100","max_price_vs_opening_window_close_bps":"100","min_opening_range_width_bps":"0","min_session_range_bps":"0","min_session_range_position":"0","min_price_vs_vwap_w5m_bps":"-100","max_price_vs_vwap_w5m_bps":"100","max_recent_spread_bps":"100","max_recent_spread_bps_max":"200","max_recent_quote_jump_bps":"200","min_recent_imbalance_pressure":"-1"},"strategy_type":"breakout_continuation_long_v1","version":"1.0.0"}'
+            ),
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="breakout_continuation_long_v1",
+            universe_symbols=["META"],
+            max_position_pct_equity=Decimal("1.0"),
+            max_notional_per_trade=Decimal("14000"),
+        )
+        seed_signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 27, 14, 0, 3, tzinfo=timezone.utc),
+            symbol="META",
+            timeframe="1Sec",
+            seq=0,
+            payload={
+                "price": 521.40,
+                "ema12": 521.30,
+                "ema26": 521.10,
+                "macd": 0.010,
+                "macd_signal": 0.008,
+                "rsi14": 58,
+                "vol_realized_w60s": 0.00015,
+                "spread": 0.03,
+                "vwap_w5m": 521.28,
+                "imbalance_bid_sz": 5000,
+                "imbalance_ask_sz": 4600,
+            },
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 27, 17, 30, 3, tzinfo=timezone.utc),
+            symbol="META",
+            timeframe="1Sec",
+            seq=1,
+            payload={
+                "price": 523.25,
+                "ema12": 523.10,
+                "ema26": 522.90,
+                "macd": 0.031,
+                "macd_signal": 0.012,
+                "rsi14": 62,
+                "vol_realized_w60s": 0.00017,
+                "spread": 0.04,
+                "vwap_w5m": 523.10,
+                "imbalance_bid_sz": 5200,
+                "imbalance_ask_sz": 4300,
+                "price_vs_session_open_bps": 46,
+                "price_vs_prev_session_close_bps": 46,
+                "opening_window_return_from_prev_close_bps": 28,
+                "session_high_price": 523.70,
+                "opening_range_high": 523.10,
+                "price_vs_opening_range_high_bps": 3,
+                "opening_range_width_bps": 22,
+                "session_range_bps": 61,
+                "price_position_in_session_range": 0.89,
+                "recent_spread_bps_avg": 0.76,
+                "recent_spread_bps_max": 1.32,
+                "recent_imbalance_pressure_avg": 0.09,
+                "recent_quote_invalid_ratio": 0.02,
+                "recent_quote_jump_bps_max": 8,
+                "recent_microprice_bias_bps_avg": 0.65,
+                "cross_section_opening_window_return_from_prev_close_rank": 0.82,
+                "cross_section_continuation_rank": 0.84,
+                "cross_section_continuation_breadth": 0.61,
+            },
+        )
+
+        with (
+            patch.object(settings, "trading_strategy_runtime_mode", "scheduler_v3"),
+            patch.object(settings, "trading_strategy_scheduler_enabled", True),
+        ):
+            engine.evaluate(seed_signal, [strategy], positions=[])
+            decisions = engine.evaluate(signal, [strategy], positions=[])
+
+        self.assertEqual(len(decisions), 1)
+        self.assertEqual(decisions[0].time_in_force, "ioc")
+
     def test_scheduler_runtime_research_sleeve_buy_respects_max_entries_per_session(
         self,
     ) -> None:
@@ -2459,6 +2544,90 @@ class TestDecisionEngine(TestCase):
         assert isinstance(trailing_exit, dict)
         self.assertEqual(trailing_exit.get("type"), "long_trailing_stop_bps")
 
+    def test_scheduler_runtime_position_trailing_stop_respects_min_hold(self) -> None:
+        engine = DecisionEngine(price_fetcher=None)
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="intraday-tsmom-trailing-stop-min-hold",
+            description=_compose_strategy_description(
+                StrategyConfig(
+                    name="intraday-tsmom-trailing-stop-min-hold",
+                    strategy_id="intraday_tsmom_v1@prod",
+                    strategy_type="intraday_tsmom_v1",
+                    version="1.1.0",
+                    base_timeframe="1Sec",
+                    universe_type="intraday_tsmom_v1",
+                    universe_symbols=["META"],
+                    max_position_pct_equity=Decimal("0.08"),
+                    max_notional_per_trade=Decimal("1000"),
+                    params={
+                        "min_hold_seconds": "120",
+                        "long_trailing_stop_activation_profit_bps": "20",
+                        "long_trailing_stop_drawdown_bps": "15",
+                    },
+                )
+            ),
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="intraday_tsmom_v1",
+            universe_symbols=["META"],
+            max_position_pct_equity=Decimal("0.08"),
+            max_notional_per_trade=Decimal("1000"),
+        )
+        peak_signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 27, 18, 29, 10, tzinfo=timezone.utc),
+            symbol="META",
+            timeframe="1Sec",
+            seq=11,
+            payload={
+                "price": 530.00,
+                "spread": 0.04,
+                "ema12": 529.50,
+                "ema26": 529.10,
+                "macd": 0.015,
+                "macd_signal": 0.010,
+                "rsi14": 58.0,
+                "vol_realized_w60s": 0.00018,
+            },
+        )
+        trailing_signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 27, 18, 30, 10, tzinfo=timezone.utc),
+            symbol="META",
+            timeframe="1Sec",
+            seq=12,
+            payload={
+                "price": 529.00,
+                "spread": 0.04,
+                "ema12": 529.30,
+                "ema26": 529.05,
+                "macd": 0.012,
+                "macd_signal": 0.009,
+                "rsi14": 56.5,
+                "vol_realized_w60s": 0.00018,
+            },
+        )
+        positions = [
+            {
+                "symbol": "META",
+                "qty": "1.9091",
+                "side": "long",
+                "market_value": "1009.5123",
+                "avg_entry_price": "528.29",
+                "opened_at": "2026-03-27T18:28:50+00:00",
+            }
+        ]
+
+        with (
+            patch.object(settings, "trading_strategy_runtime_mode", "scheduler_v3"),
+            patch.object(settings, "trading_strategy_scheduler_enabled", True),
+            patch.object(settings, "trading_fractional_equities_enabled", True),
+        ):
+            initial_decisions = engine.evaluate(peak_signal, [strategy], positions=positions)
+            trailing_decisions = engine.evaluate(trailing_signal, [strategy], positions=positions)
+
+        self.assertEqual(initial_decisions, [])
+        self.assertEqual(trailing_decisions, [])
+
     def test_scheduler_runtime_position_trailing_stop_skips_non_profitable_exit(
         self,
     ) -> None:
@@ -2545,6 +2714,182 @@ class TestDecisionEngine(TestCase):
         self.assertEqual(initial_decisions, [])
         self.assertEqual(trailing_decisions, [])
 
+    def test_scheduler_runtime_breakout_trailing_stop_holds_above_structure(
+        self,
+    ) -> None:
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="breakout-trailing-stop-structure-aware",
+            description=_compose_strategy_description(
+                StrategyConfig(
+                    name="breakout-trailing-stop-structure-aware",
+                    strategy_id="breakout_continuation_long_v1@research",
+                    strategy_type="breakout_continuation_long_v1",
+                    version="1.0.0",
+                    base_timeframe="1Sec",
+                    universe_type="breakout_continuation_long_v1",
+                    universe_symbols=["AAPL"],
+                    max_position_pct_equity=Decimal("1.5"),
+                    max_notional_per_trade=Decimal("14000"),
+                    params={
+                        "long_trailing_stop_activation_profit_bps": "18",
+                        "long_trailing_stop_drawdown_bps": "10",
+                    },
+                )
+            ),
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="breakout_continuation_long_v1",
+            universe_symbols=["AAPL"],
+            max_position_pct_equity=Decimal("1.5"),
+            max_notional_per_trade=Decimal("14000"),
+        )
+        trailing_signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 26, 14, 19, 7, tzinfo=timezone.utc),
+            symbol="AAPL",
+            timeframe="1Sec",
+            seq=22,
+            payload={
+                "price": 255.32,
+                "spread": 0.03,
+                "ema12": 255.18,
+                "ema26": 255.10,
+                "macd": 0.028,
+                "macd_signal": 0.026,
+                "rsi14": 58.2,
+                "vol_realized_w60s": 0.00017,
+                "vwap_w5m": 255.18,
+                "opening_range_high": 255.26,
+                "price_vs_session_open_bps": 60,
+                "price_position_in_session_range": 0.95,
+                "recent_imbalance_pressure_avg": 0.02,
+            },
+        )
+        positions = [
+            {
+                "symbol": "AAPL",
+                "strategy_id": str(strategy.id),
+                "qty": "138.8497",
+                "side": "long",
+                "market_value": "35443.5014",
+                "avg_entry_price": "254.69",
+                "opened_at": "2026-03-26T14:13:18+00:00",
+            }
+        ]
+
+        decision = _build_runtime_position_exit_overlay(
+            signal=trailing_signal,
+            strategies=[strategy],
+            timeframe="1Sec",
+            decisions=[],
+            positions=positions,
+            equity=Decimal("31590.02"),
+            price=Decimal("255.32"),
+            features=extract_signal_features(trailing_signal),
+            snapshot=None,
+            raw_runtime_by_strategy_id={},
+            runtime_eval=SimpleNamespace(
+                observation=SimpleNamespace(intent_conflicts_total=0),
+                errors=[],
+            ),
+            position_peak_price=Decimal("255.80"),
+            aggregated=False,
+            position_isolation_mode="per_strategy",
+        )
+
+        self.assertIsNone(decision)
+
+    def test_scheduler_runtime_breakout_trailing_stop_exits_after_structure_loss(
+        self,
+    ) -> None:
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="breakout-trailing-stop-structure-loss",
+            description=_compose_strategy_description(
+                StrategyConfig(
+                    name="breakout-trailing-stop-structure-loss",
+                    strategy_id="breakout_continuation_long_v1@research",
+                    strategy_type="breakout_continuation_long_v1",
+                    version="1.0.0",
+                    base_timeframe="1Sec",
+                    universe_type="breakout_continuation_long_v1",
+                    universe_symbols=["AAPL"],
+                    max_position_pct_equity=Decimal("1.5"),
+                    max_notional_per_trade=Decimal("14000"),
+                    params={
+                        "long_trailing_stop_activation_profit_bps": "18",
+                        "long_trailing_stop_drawdown_bps": "10",
+                    },
+                )
+            ),
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="breakout_continuation_long_v1",
+            universe_symbols=["AAPL"],
+            max_position_pct_equity=Decimal("1.5"),
+            max_notional_per_trade=Decimal("14000"),
+        )
+        trailing_signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 26, 14, 19, 7, tzinfo=timezone.utc),
+            symbol="AAPL",
+            timeframe="1Sec",
+            seq=24,
+            payload={
+                "price": 255.30,
+                "spread": 0.03,
+                "ema12": 255.18,
+                "ema26": 255.10,
+                "macd": 0.028,
+                "macd_signal": 0.026,
+                "rsi14": 58.2,
+                "vol_realized_w60s": 0.00017,
+                "vwap_w5m": 255.36,
+                "opening_range_high": 255.26,
+                "price_vs_session_open_bps": 60,
+                "price_position_in_session_range": 0.70,
+                "recent_imbalance_pressure_avg": 0.02,
+            },
+        )
+        positions = [
+            {
+                "symbol": "AAPL",
+                "strategy_id": str(strategy.id),
+                "qty": "138.8497",
+                "side": "long",
+                "market_value": "35440.7244",
+                "avg_entry_price": "254.69",
+                "opened_at": "2026-03-26T14:13:18+00:00",
+            }
+        ]
+
+        decision = _build_runtime_position_exit_overlay(
+            signal=trailing_signal,
+            strategies=[strategy],
+            timeframe="1Sec",
+            decisions=[],
+            positions=positions,
+            equity=Decimal("31590.02"),
+            price=Decimal("255.30"),
+            features=extract_signal_features(trailing_signal),
+            snapshot=None,
+            raw_runtime_by_strategy_id={},
+            runtime_eval=SimpleNamespace(
+                observation=SimpleNamespace(intent_conflicts_total=0),
+                errors=[],
+            ),
+            position_peak_price=Decimal("255.80"),
+            aggregated=False,
+            position_isolation_mode="per_strategy",
+        )
+
+        self.assertIsNotNone(decision)
+        assert decision is not None
+        self.assertEqual(decision.action, "sell")
+        self.assertEqual(decision.rationale, "position_trailing_stop_exit")
+        trailing_exit = decision.params.get("position_exit")
+        assert isinstance(trailing_exit, dict)
+        self.assertEqual(trailing_exit.get("type"), "long_trailing_stop_bps")
+
     def test_scheduler_runtime_position_exit_overlay_emits_session_flatten_exit(
         self,
     ) -> None:
@@ -2607,6 +2952,81 @@ class TestDecisionEngine(TestCase):
                         "side": "long",
                         "market_value": "1002.63",
                         "avg_entry_price": "524.50",
+                    }
+                ],
+            )
+
+        self.assertEqual(len(decisions), 1)
+        self.assertEqual(decisions[0].action, "sell")
+        self.assertEqual(decisions[0].rationale, "session_flatten_exit")
+        session_exit = decisions[0].params.get("position_exit")
+        assert isinstance(session_exit, dict)
+        self.assertEqual(session_exit.get("type"), "session_flatten_minute_utc")
+
+    def test_scheduler_runtime_position_exit_overlay_session_flatten_bypasses_min_hold(
+        self,
+    ) -> None:
+        engine = DecisionEngine(price_fetcher=None)
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="intraday-tsmom-session-flatten-min-hold",
+            description=_compose_strategy_description(
+                StrategyConfig(
+                    name="intraday-tsmom-session-flatten-min-hold",
+                    strategy_id="intraday_tsmom_v1@prod",
+                    strategy_type="intraday_tsmom_v1",
+                    version="1.1.0",
+                    base_timeframe="1Sec",
+                    universe_type="intraday_tsmom_v1",
+                    universe_symbols=["META"],
+                    max_position_pct_equity=Decimal("0.08"),
+                    max_notional_per_trade=Decimal("1000"),
+                    params={
+                        "min_hold_seconds": "3600",
+                        "session_flatten_start_minute_utc": "1170",
+                    },
+                )
+            ),
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="intraday_tsmom_v1",
+            universe_symbols=["META"],
+            max_position_pct_equity=Decimal("0.08"),
+            max_notional_per_trade=Decimal("1000"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 27, 19, 30, 0, tzinfo=timezone.utc),
+            symbol="META",
+            timeframe="1Sec",
+            seq=13,
+            payload={
+                "price": 525.10,
+                "spread": 0.20,
+                "ema12": 525.30,
+                "ema26": 525.25,
+                "macd": 0.001,
+                "macd_signal": 0.001,
+                "rsi14": 50.0,
+                "vol_realized_w60s": 0.00012,
+            },
+        )
+
+        with (
+            patch.object(settings, "trading_strategy_runtime_mode", "scheduler_v3"),
+            patch.object(settings, "trading_strategy_scheduler_enabled", True),
+            patch.object(settings, "trading_fractional_equities_enabled", True),
+        ):
+            decisions = engine.evaluate(
+                signal,
+                [strategy],
+                positions=[
+                    {
+                        "symbol": "META",
+                        "qty": "1.9091",
+                        "side": "long",
+                        "market_value": "1002.63",
+                        "avg_entry_price": "524.50",
+                        "opened_at": "2026-03-27T19:29:15+00:00",
                     }
                 ],
             )

--- a/services/torghut/tests/test_feature_contract_v3.py
+++ b/services/torghut/tests/test_feature_contract_v3.py
@@ -77,6 +77,31 @@ class TestFeatureContractV3(TestCase):
         self.assertEqual(feature_vector.values.get('vwap_session'), Decimal('100.0'))
         self.assertEqual(feature_vector.values.get('price_vs_vwap_w5m_bps'), Decimal('149.2537313432835820895522388'))
 
+    def test_normalization_prefers_top_level_imbalance_midpoint_over_vwap_keys(self) -> None:
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc),
+            symbol='AAPL',
+            timeframe='1Sec',
+            payload={
+                'macd': '0.4',
+                'macd_signal': '0.2',
+                'rsi14': '50',
+                'vwap_session': '109.0',
+                'vwap_w5m': '108.5',
+                'imbalance_bid_px': '100.0',
+                'imbalance_ask_px': '102.0',
+            },
+            seq=2,
+            source='fixture',
+        )
+
+        feature_vector = normalize_feature_vector_v3(signal)
+        self.assertEqual(feature_vector.values.get('price'), Decimal('101'))
+        self.assertEqual(
+            feature_vector.values.get('price_vs_vwap_w5m_bps'),
+            Decimal('-691.2442396313364055299539171'),
+        )
+
     def test_normalization_maps_nested_schema_fields(self) -> None:
         signal = SignalEnvelope(
             event_ts=datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc),

--- a/services/torghut/tests/test_local_intraday_tsmom_replay.py
+++ b/services/torghut/tests/test_local_intraday_tsmom_replay.py
@@ -5,12 +5,14 @@ from decimal import Decimal
 from pathlib import Path
 from unittest import TestCase
 
+from app.trading.costs import TransactionCostModel
 from app.trading.models import SignalEnvelope, StrategyDecision
 from scripts.local_intraday_tsmom_replay import (
     PendingOrder,
     PositionState,
     ReplayConfig,
     _SHARED_POSITION_OWNER,
+    _apply_filled_decision,
     _apply_order_preferences,
     _parse_signal_row,
     _positions_payload,
@@ -79,6 +81,41 @@ class TestLocalIntradayTsmomReplay(TestCase):
         fill_price = _resolve_pending_fill_price(decision, signal)
 
         self.assertEqual(fill_price, Decimal('593.80'))
+
+    def test_apply_filled_decision_opens_position_on_same_signal(self) -> None:
+        signal = self._signal(bid='523.22', ask='523.28', price='523.25')
+        decision = self._decision(action='buy', order_type='limit', limit_price='523.28')
+        positions: dict[tuple[str, str], PositionState] = {}
+        day_bucket = {
+            'decision_count': 1,
+            'filled_count': 0,
+            'gross_pnl': Decimal('0'),
+            'net_pnl': Decimal('0'),
+            'cost_total': Decimal('0'),
+            'wins': 0,
+            'losses': 0,
+            'closed_trades': [],
+        }
+
+        cash = _apply_filled_decision(
+            decision=decision,
+            signal=signal,
+            fill_price=Decimal('523.28'),
+            filled_at=signal.event_ts,
+            created_at=signal.event_ts,
+            positions=positions,
+            day_bucket=day_bucket,
+            cost_model=TransactionCostModel(),
+            cash=Decimal('10000'),
+            all_closed_trades=[],
+        )
+
+        self.assertIn(('META', _SHARED_POSITION_OWNER), positions)
+        position = positions[('META', _SHARED_POSITION_OWNER)]
+        self.assertEqual(position.avg_entry_price, Decimal('523.28'))
+        self.assertEqual(position.qty, Decimal('10'))
+        self.assertEqual(day_bucket['filled_count'], 1)
+        self.assertLess(cash, Decimal('10000'))
 
     def test_quote_quality_rejects_wide_spread_outlier(self) -> None:
         signal = self._signal(bid='239.11', ask='253.69', price='246.40')

--- a/services/torghut/tests/test_session_context.py
+++ b/services/torghut/tests/test_session_context.py
@@ -246,8 +246,8 @@ class TestSessionContextTracker(TestCase):
 
         payload = tracker.enrich_signal_payload(signal)
         self.assertEqual(payload['session_open_price'], Decimal('102.0'))
-        self.assertEqual(payload['recent_spread_bps_avg'], Decimal('196.0784313725490196078431373'))
-        self.assertGreater(payload['recent_imbalance_pressure_avg'], Decimal('0'))
+        self.assertIsNone(payload['recent_spread_bps_avg'])
+        self.assertIsNone(payload['recent_imbalance_pressure_avg'])
 
     def test_tracker_emits_cross_section_continuation_and_reversal_ranks(self) -> None:
         tracker = SessionContextTracker()
@@ -377,6 +377,10 @@ class TestSessionContextTracker(TestCase):
         self.assertEqual(first_payload['recent_quote_invalid_ratio'], Decimal('0'))
         self.assertEqual(unstable_payload['recent_quote_invalid_ratio'], Decimal('0.5'))
         self.assertIsNone(unstable_payload['recent_quote_jump_bps_max'])
+        self.assertEqual(
+            unstable_payload['recent_spread_bps_avg'],
+            first_payload['recent_spread_bps_avg'],
+        )
         self.assertGreater(
             cast(Decimal, unstable_payload['recent_microprice_bias_bps_avg']),
             Decimal('0'),

--- a/services/torghut/tests/test_strategy_runtime.py
+++ b/services/torghut/tests/test_strategy_runtime.py
@@ -804,6 +804,222 @@ class TestStrategyRuntime(TestCase):
 
         self.assertIsNone(decision)
 
+    def test_intraday_tsmom_plugin_decays_early_drive_floors_late_session(self) -> None:
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="intraday-tsmom-1sec-late-session-decay",
+            description=_compose_strategy_description(
+                StrategyConfig(
+                    name="intraday-tsmom-1sec-late-session-decay",
+                    strategy_id="intraday_tsmom_v1@prod",
+                    strategy_type="intraday_tsmom_v1",
+                    version="1.1.0",
+                    base_timeframe="1Sec",
+                    universe_type="intraday_tsmom_v1",
+                    universe_symbols=["AAPL"],
+                    max_position_pct_equity=Decimal("3.0"),
+                    max_notional_per_trade=Decimal("94770"),
+                    params={
+                        "entry_start_minute_utc": "845",
+                        "entry_end_minute_utc": "1160",
+                        "min_session_open_drive_bps": "40",
+                        "min_opening_window_return_bps": "20",
+                        "late_session_floor_multiplier": "0.5",
+                    },
+                )
+            ),
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="intraday_tsmom_v1",
+            universe_symbols=["AAPL"],
+            max_position_pct_equity=Decimal("3.0"),
+            max_notional_per_trade=Decimal("94770"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 24, 18, 30, 44, tzinfo=timezone.utc),
+            symbol="AAPL",
+            timeframe="1Sec",
+            seq=1,
+            payload={
+                "price": 254.02,
+                "ema12": 254.08,
+                "ema26": 253.90,
+                "macd": 0.062,
+                "macd_signal": 0.020,
+                "rsi14": 57.0,
+                "vol_realized_w60s": 0.00017,
+                "price_vs_prev_session_close_bps": 24,
+                "opening_window_return_from_prev_close_bps": 11,
+            },
+        )
+        feature_contract = normalize_feature_vector_v3(signal)
+        runtime = StrategyRuntime()
+
+        decision = runtime.evaluate(strategy, feature_contract, timeframe="1Sec")
+
+        self.assertIsNotNone(decision)
+        assert decision is not None
+        self.assertEqual(decision.intent.action, "buy")
+
+    def test_intraday_tsmom_plugin_allows_late_isolated_leader_above_ema12(self) -> None:
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="intraday-tsmom-1sec-isolated-extension",
+            description=_compose_strategy_description(
+                StrategyConfig(
+                    name="intraday-tsmom-1sec-isolated-extension",
+                    strategy_id="intraday_tsmom_v1@prod",
+                    strategy_type="intraday_tsmom_v1",
+                    version="1.1.0",
+                    base_timeframe="1Sec",
+                    universe_type="intraday_tsmom_v1",
+                    universe_symbols=["AAPL"],
+                    max_position_pct_equity=Decimal("3.0"),
+                    max_notional_per_trade=Decimal("94770"),
+                    params={
+                        "entry_start_minute_utc": "845",
+                        "entry_end_minute_utc": "1160",
+                        "max_price_above_ema12_bps": "0",
+                        "min_price_below_ema12_bps": "2",
+                        "min_session_open_drive_bps": "45",
+                        "min_opening_window_return_bps": "20",
+                        "min_cross_section_opening_window_return_rank": "0.70",
+                        "min_cross_section_continuation_rank": "0.75",
+                        "min_cross_section_continuation_breadth": "0.55",
+                    },
+                )
+            ),
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="intraday_tsmom_v1",
+            universe_symbols=["AAPL"],
+            max_position_pct_equity=Decimal("3.0"),
+            max_notional_per_trade=Decimal("94770"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 24, 18, 16, 44, tzinfo=timezone.utc),
+            symbol="AAPL",
+            timeframe="1Sec",
+            seq=1,
+            payload={
+                "price": 254.18,
+                "spread": 0.14,
+                "ema12": 254.08,
+                "ema26": 253.90,
+                "vwap_w5m": 254.02,
+                "macd": 0.062,
+                "macd_signal": 0.020,
+                "rsi14": 56.9,
+                "vol_realized_w60s": 0.00017,
+                "price_vs_prev_session_close_bps": 32,
+                "opening_window_return_from_prev_close_bps": 12,
+                "session_range_bps": 64,
+                "price_position_in_session_range": 0.86,
+                "price_vs_opening_range_high_bps": 4,
+                "recent_spread_bps_avg": 5,
+                "recent_spread_bps_max": 9,
+                "recent_imbalance_pressure_avg": 0.05,
+                "recent_quote_invalid_ratio": 0.01,
+                "recent_quote_jump_bps_max": 6,
+                "recent_microprice_bias_bps_avg": 0.45,
+                "cross_section_opening_window_return_from_prev_close_rank": 0.55,
+                "cross_section_continuation_rank": 0.88,
+                "cross_section_continuation_breadth": 0.42,
+                "cross_section_range_position_rank": 0.94,
+                "cross_section_vwap_w5m_rank": 0.91,
+                "cross_section_recent_imbalance_rank": 0.83,
+            },
+        )
+        feature_contract = normalize_feature_vector_v3(signal)
+        runtime = StrategyRuntime()
+
+        decision = runtime.evaluate(strategy, feature_contract, timeframe="1Sec")
+
+        self.assertIsNotNone(decision)
+        assert decision is not None
+        self.assertEqual(decision.intent.action, "buy")
+
+    def test_intraday_tsmom_plugin_allows_isolated_leader_with_hot_hist_and_vol(self) -> None:
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="intraday-tsmom-1sec-isolated-hot",
+            description=_compose_strategy_description(
+                StrategyConfig(
+                    name="intraday-tsmom-1sec-isolated-hot",
+                    strategy_id="intraday_tsmom_v1@prod",
+                    strategy_type="intraday_tsmom_v1",
+                    version="1.1.0",
+                    base_timeframe="1Sec",
+                    universe_type="intraday_tsmom_v1",
+                    universe_symbols=["AAPL"],
+                    max_position_pct_equity=Decimal("3.0"),
+                    max_notional_per_trade=Decimal("94770"),
+                    params={
+                        "entry_start_minute_utc": "845",
+                        "entry_end_minute_utc": "1160",
+                        "bullish_hist_min": "0.04",
+                        "bullish_hist_cap": "0.055",
+                        "vol_ceil": "0.00019",
+                        "max_price_above_ema12_bps": "0",
+                        "min_price_below_ema12_bps": "2",
+                        "min_session_open_drive_bps": "45",
+                        "min_opening_window_return_bps": "20",
+                        "min_cross_section_opening_window_return_rank": "0.70",
+                        "min_cross_section_continuation_rank": "0.75",
+                        "min_cross_section_continuation_breadth": "0.55",
+                    },
+                )
+            ),
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="intraday_tsmom_v1",
+            universe_symbols=["AAPL"],
+            max_position_pct_equity=Decimal("3.0"),
+            max_notional_per_trade=Decimal("94770"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 24, 18, 18, 44, tzinfo=timezone.utc),
+            symbol="AAPL",
+            timeframe="1Sec",
+            seq=1,
+            payload={
+                "price": 254.20,
+                "spread": 0.14,
+                "ema12": 254.08,
+                "ema26": 253.90,
+                "vwap_w5m": 254.03,
+                "macd": 0.090,
+                "macd_signal": 0.020,
+                "rsi14": 57.2,
+                "vol_realized_w60s": 0.00027,
+                "price_vs_prev_session_close_bps": 38,
+                "opening_window_return_from_prev_close_bps": 14,
+                "session_range_bps": 72,
+                "price_position_in_session_range": 0.88,
+                "price_vs_opening_range_high_bps": 6,
+                "recent_spread_bps_avg": 5,
+                "recent_spread_bps_max": 10,
+                "recent_imbalance_pressure_avg": 0.06,
+                "recent_quote_invalid_ratio": 0.01,
+                "recent_quote_jump_bps_max": 6,
+                "recent_microprice_bias_bps_avg": 0.55,
+                "cross_section_opening_window_return_from_prev_close_rank": 0.58,
+                "cross_section_continuation_rank": 0.91,
+                "cross_section_continuation_breadth": 0.43,
+                "cross_section_range_position_rank": 0.96,
+                "cross_section_vwap_w5m_rank": 0.92,
+                "cross_section_recent_imbalance_rank": 0.84,
+            },
+        )
+        feature_contract = normalize_feature_vector_v3(signal)
+        runtime = StrategyRuntime()
+
+        decision = runtime.evaluate(strategy, feature_contract, timeframe="1Sec")
+
+        self.assertIsNotNone(decision)
+        assert decision is not None
+        self.assertEqual(decision.intent.action, "buy")
+
     def test_intraday_tsmom_plugin_emits_sell_for_one_second_profile(self) -> None:
         strategy = Strategy(
             id=uuid.uuid4(),
@@ -941,6 +1157,181 @@ class TestStrategyRuntime(TestCase):
         self.assertEqual(decision.intent.action, "buy")
         self.assertEqual(decision.plugin_id, "breakout_continuation_long")
         self.assertIn("imbalance_confirmed", decision.intent.rationale)
+
+    def test_breakout_continuation_plugin_skips_early_breakout_without_elite_rank_or_microstructure(
+        self,
+    ) -> None:
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="breakout-continuation",
+            description=_compose_strategy_description(
+                StrategyConfig(
+                    name="breakout-continuation",
+                    strategy_id="breakout_continuation_long_v1@research",
+                    strategy_type="breakout_continuation_long_v1",
+                    version="1.0.0",
+                    base_timeframe="1Sec",
+                    universe_type="breakout_continuation_long_v1",
+                    universe_symbols=["INTC"],
+                    max_position_pct_equity=Decimal("1.0"),
+                    max_notional_per_trade=Decimal("14000"),
+                    params={
+                        "entry_start_minute_utc": "845",
+                        "max_spread_bps": "20",
+                        "max_recent_spread_bps": "18",
+                        "max_recent_spread_bps_max": "60",
+                        "min_recent_imbalance_pressure": "-0.12",
+                        "min_cross_section_continuation_rank": "0.72",
+                        "min_cross_section_opening_window_return_rank": "0.60",
+                        "early_breakout_elite_continuation_rank": "0.90",
+                        "min_early_breakout_continuation_breadth": "0.75",
+                        "min_early_breakout_microprice_bias_bps": "0.60",
+                    },
+                )
+            ),
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="breakout_continuation_long_v1",
+            universe_symbols=["INTC"],
+            max_position_pct_equity=Decimal("1.0"),
+            max_notional_per_trade=Decimal("14000"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 23, 14, 47, 24, tzinfo=timezone.utc),
+            symbol="INTC",
+            timeframe="1Sec",
+            seq=1,
+            payload={
+                "price": 45.335,
+                "ema12": 45.30,
+                "ema26": 45.22,
+                "macd": 0.012,
+                "macd_signal": 0.003,
+                "rsi14": 61,
+                "vol_realized_w60s": 0.00028951446164855916,
+                "spread": 0.016,
+                "vwap_w5m": 45.30,
+                "imbalance_bid_sz": 1800,
+                "imbalance_ask_sz": 300,
+                "price_vs_session_open_bps": 178.49,
+                "opening_window_return_bps": 127.97,
+                "session_high_price": 45.47,
+                "opening_range_high": 45.20,
+                "price_vs_opening_range_high_bps": 29.86,
+                "price_vs_opening_window_close_bps": 49.87,
+                "opening_range_width_bps": 228.55,
+                "session_range_bps": 289.65,
+                "price_position_in_session_range": 0.8945,
+                "recent_spread_bps_avg": 3.53,
+                "recent_spread_bps_max": 11.02,
+                "recent_imbalance_pressure_avg": 0.209,
+                "recent_quote_invalid_ratio": 0,
+                "recent_quote_jump_bps_max": 11.04,
+                "recent_microprice_bias_bps_avg": 0.52,
+                "cross_section_opening_window_return_rank": 0.82,
+                "cross_section_session_open_rank": 0.82,
+                "cross_section_continuation_rank": 0.87,
+                "cross_section_continuation_breadth": 0.67,
+                "cross_section_above_vwap_w5m_ratio": 0.75,
+                "cross_section_range_position_rank": 1,
+                "cross_section_vwap_w5m_rank": 0.82,
+                "cross_section_recent_imbalance_rank": 0.91,
+            },
+        )
+
+        runtime = StrategyRuntime()
+        decision = runtime.evaluate(strategy, normalize_feature_vector_v3(signal), timeframe="1Sec")
+
+        self.assertIsNone(decision)
+
+    def test_breakout_continuation_plugin_allows_early_breakout_with_strong_microstructure_confirmation(
+        self,
+    ) -> None:
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="breakout-continuation",
+            description=_compose_strategy_description(
+                StrategyConfig(
+                    name="breakout-continuation",
+                    strategy_id="breakout_continuation_long_v1@research",
+                    strategy_type="breakout_continuation_long_v1",
+                    version="1.0.0",
+                    base_timeframe="1Sec",
+                    universe_type="breakout_continuation_long_v1",
+                    universe_symbols=["AAPL"],
+                    max_position_pct_equity=Decimal("1.0"),
+                    max_notional_per_trade=Decimal("14000"),
+                    params={
+                        "entry_start_minute_utc": "845",
+                        "max_spread_bps": "20",
+                        "max_recent_spread_bps": "18",
+                        "max_recent_spread_bps_max": "60",
+                        "min_recent_imbalance_pressure": "-0.12",
+                        "min_cross_section_continuation_rank": "0.72",
+                        "min_cross_section_opening_window_return_rank": "0.60",
+                        "early_breakout_elite_continuation_rank": "0.90",
+                        "min_early_breakout_continuation_breadth": "0.75",
+                        "min_early_breakout_microprice_bias_bps": "0.60",
+                    },
+                )
+            ),
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="breakout_continuation_long_v1",
+            universe_symbols=["AAPL"],
+            max_position_pct_equity=Decimal("1.0"),
+            max_notional_per_trade=Decimal("14000"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 26, 14, 13, 8, tzinfo=timezone.utc),
+            symbol="AAPL",
+            timeframe="1Sec",
+            seq=1,
+            payload={
+                "price": 254.79,
+                "ema12": 254.62,
+                "ema26": 254.11,
+                "macd": 0.019,
+                "macd_signal": 0.007,
+                "rsi14": 64,
+                "vol_realized_w60s": 0.0002841520287386722,
+                "spread": 0.12,
+                "vwap_w5m": 254.70,
+                "imbalance_bid_sz": 200,
+                "imbalance_ask_sz": 100,
+                "price_vs_session_open_bps": 396.62,
+                "opening_window_return_bps": 376.63,
+                "session_high_price": 254.80,
+                "opening_range_high": 254.30,
+                "price_vs_opening_range_high_bps": 19.27,
+                "price_vs_opening_window_close_bps": 19.27,
+                "opening_range_width_bps": 376.63,
+                "session_range_bps": 397.03,
+                "price_position_in_session_range": 0.999,
+                "recent_spread_bps_avg": 8.18,
+                "recent_spread_bps_max": 23.56,
+                "recent_imbalance_pressure_avg": 0.139,
+                "recent_quote_invalid_ratio": 0.0667,
+                "recent_quote_jump_bps_max": 10.99,
+                "recent_microprice_bias_bps_avg": 0.80,
+                "cross_section_opening_window_return_rank": 1.0,
+                "cross_section_session_open_rank": 1.0,
+                "cross_section_continuation_rank": 0.88,
+                "cross_section_continuation_breadth": 0.82,
+                "cross_section_above_vwap_w5m_ratio": 1.0,
+                "cross_section_range_position_rank": 1.0,
+                "cross_section_vwap_w5m_rank": 1.0,
+                "cross_section_recent_imbalance_rank": 1.0,
+            },
+        )
+
+        runtime = StrategyRuntime()
+        decision = runtime.evaluate(strategy, normalize_feature_vector_v3(signal), timeframe="1Sec")
+
+        self.assertIsNotNone(decision)
+        assert decision is not None
+        self.assertEqual(decision.intent.action, "buy")
+        self.assertEqual(decision.plugin_id, "breakout_continuation_long")
 
     def test_breakout_continuation_plugin_scales_target_notional_by_cross_section_rank(
         self,
@@ -1095,6 +1486,163 @@ class TestStrategyRuntime(TestCase):
 
         self.assertIsNone(decision)
 
+    def test_breakout_continuation_plugin_prefers_live_structure_rank_late_in_session(self) -> None:
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="breakout-continuation",
+            description=_compose_strategy_description(
+                StrategyConfig(
+                    name="breakout-continuation",
+                    strategy_id="breakout_continuation_long_v1@research",
+                    strategy_type="breakout_continuation_long_v1",
+                    version="1.0.0",
+                    base_timeframe="1Sec",
+                    universe_type="breakout_continuation_long_v1",
+                    universe_symbols=["NVDA"],
+                    max_position_pct_equity=Decimal("1.0"),
+                    max_notional_per_trade=Decimal("14000"),
+                    params={
+                        "min_opening_window_return_bps": "20",
+                        "min_cross_section_opening_window_return_rank": "0.65",
+                        "min_cross_section_continuation_rank": "0.75",
+                    },
+                )
+            ),
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="breakout_continuation_long_v1",
+            universe_symbols=["NVDA"],
+            max_position_pct_equity=Decimal("1.0"),
+            max_notional_per_trade=Decimal("14000"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 23, 17, 30, 3, tzinfo=timezone.utc),
+            symbol="NVDA",
+            timeframe="1Sec",
+            seq=31,
+            payload={
+                "price": 969.40,
+                "ema12": 968.92,
+                "ema26": 968.35,
+                "macd": 0.044,
+                "macd_signal": 0.018,
+                "rsi14": 64,
+                "vol_realized_w60s": 0.00020,
+                "spread": 0.08,
+                "vwap_w5m": 968.95,
+                "imbalance_bid_sz": 6800,
+                "imbalance_ask_sz": 5200,
+                "price_vs_session_open_bps": 63,
+                "opening_window_return_bps": 12,
+                "session_high_price": 969.90,
+                "opening_range_high": 968.70,
+                "price_vs_opening_range_high_bps": 7,
+                "price_vs_opening_window_close_bps": 14,
+                "opening_range_width_bps": 24,
+                "session_range_bps": 66,
+                "price_position_in_session_range": 0.93,
+                "recent_spread_bps_avg": 0.82,
+                "recent_spread_bps_max": 1.41,
+                "recent_imbalance_pressure_avg": 0.09,
+                "recent_microprice_bias_bps_avg": 1.2,
+                "cross_section_session_open_rank": 0.45,
+                "cross_section_opening_window_return_rank": 0.35,
+                "cross_section_range_position_rank": 0.98,
+                "cross_section_vwap_w5m_rank": 0.94,
+                "cross_section_recent_imbalance_rank": 0.92,
+                "cross_section_continuation_rank": 0.40,
+            },
+        )
+
+        feature_contract = normalize_feature_vector_v3(signal)
+        runtime = StrategyRuntime()
+        decision = runtime.evaluate(strategy, feature_contract, timeframe="1Sec")
+
+        self.assertIsNotNone(decision)
+        assert decision is not None
+        self.assertEqual(decision.intent.action, "buy")
+        self.assertEqual(decision.plugin_id, "breakout_continuation_long")
+        self.assertIn("opening_range_breakout", decision.intent.rationale)
+
+    def test_breakout_continuation_plugin_preserves_stronger_fallback_rank(self) -> None:
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="breakout-continuation",
+            description=_compose_strategy_description(
+                StrategyConfig(
+                    name="breakout-continuation",
+                    strategy_id="breakout_continuation_long_v1@research",
+                    strategy_type="breakout_continuation_long_v1",
+                    version="1.0.0",
+                    base_timeframe="1Sec",
+                    universe_type="breakout_continuation_long_v1",
+                    universe_symbols=["META"],
+                    max_position_pct_equity=Decimal("1.0"),
+                    max_notional_per_trade=Decimal("14000"),
+                    params={
+                        "min_cross_section_continuation_rank": "0.80",
+                        "min_cross_section_opening_window_return_rank": "0.55",
+                    },
+                )
+            ),
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="breakout_continuation_long_v1",
+            universe_symbols=["META"],
+            max_position_pct_equity=Decimal("1.0"),
+            max_notional_per_trade=Decimal("14000"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 24, 17, 48, 3, tzinfo=timezone.utc),
+            symbol="META",
+            timeframe="1Sec",
+            seq=77,
+            payload={
+                "price": 523.40,
+                "ema12": 523.18,
+                "ema26": 522.84,
+                "macd": 0.028,
+                "macd_signal": 0.011,
+                "rsi14": 62,
+                "vol_realized_w60s": 0.00016,
+                "spread": 0.04,
+                "vwap_w5m": 523.22,
+                "imbalance_bid_sz": 4900,
+                "imbalance_ask_sz": 4200,
+                "price_vs_session_open_bps": 44,
+                "opening_window_return_bps": 22,
+                "session_high_price": 523.62,
+                "opening_range_high": 523.05,
+                "price_vs_opening_range_high_bps": 7,
+                "price_vs_opening_window_close_bps": 11,
+                "opening_range_width_bps": 24,
+                "session_range_bps": 62,
+                "price_position_in_session_range": 0.88,
+                "recent_spread_bps_avg": 0.80,
+                "recent_spread_bps_max": 1.36,
+                "recent_imbalance_pressure_avg": 0.06,
+                "recent_microprice_bias_bps_avg": 0.92,
+                "cross_section_positive_session_open_ratio": 0.34,
+                "cross_section_positive_opening_window_return_ratio": 0.46,
+                "cross_section_above_vwap_w5m_ratio": 0.50,
+                "cross_section_continuation_breadth": 0.52,
+                "cross_section_session_open_rank": 0.46,
+                "cross_section_opening_window_return_rank": 0.57,
+                "cross_section_range_position_rank": 0.67,
+                "cross_section_vwap_w5m_rank": 0.69,
+                "cross_section_recent_imbalance_rank": 0.66,
+                "cross_section_continuation_rank": 0.84,
+            },
+        )
+
+        runtime = StrategyRuntime()
+        decision = runtime.evaluate(strategy, normalize_feature_vector_v3(signal), timeframe="1Sec")
+
+        self.assertIsNotNone(decision)
+        assert decision is not None
+        self.assertEqual(decision.intent.action, "buy")
+        self.assertEqual(decision.plugin_id, "breakout_continuation_long")
+
     def test_breakout_continuation_plugin_skips_weak_opening_window_drive(self) -> None:
         strategy = Strategy(
             id=uuid.uuid4(),
@@ -1112,7 +1660,9 @@ class TestStrategyRuntime(TestCase):
                     max_notional_per_trade=Decimal("14000"),
                     params={
                         "min_opening_window_return_bps": "20",
+                        "late_session_min_opening_window_return_bps": "15",
                         "min_cross_section_opening_window_return_rank": "0.70",
+                        "late_session_min_session_open_return_efficiency": "0.20",
                     },
                 )
             ),
@@ -1161,6 +1711,438 @@ class TestStrategyRuntime(TestCase):
 
         self.assertIsNone(decision)
 
+    def test_breakout_continuation_plugin_allows_late_isolated_leader_with_relaxed_drive_requirements(
+        self,
+    ) -> None:
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="breakout-continuation",
+            description=_compose_strategy_description(
+                StrategyConfig(
+                    name="breakout-continuation",
+                    strategy_id="breakout_continuation_long_v1@research",
+                    strategy_type="breakout_continuation_long_v1",
+                    version="1.0.0",
+                    base_timeframe="1Sec",
+                    universe_type="breakout_continuation_long_v1",
+                    universe_symbols=["NVDA"],
+                    max_position_pct_equity=Decimal("1.0"),
+                    max_notional_per_trade=Decimal("14000"),
+                    params={
+                        "min_session_open_drive_bps": "35",
+                        "late_session_min_session_open_drive_bps": "18",
+                        "min_opening_window_return_bps": "20",
+                        "late_session_min_opening_window_return_bps": "10",
+                    },
+                )
+            ),
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="breakout_continuation_long_v1",
+            universe_symbols=["NVDA"],
+            max_position_pct_equity=Decimal("1.0"),
+            max_notional_per_trade=Decimal("14000"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 24, 18, 6, 3, tzinfo=timezone.utc),
+            symbol="NVDA",
+            timeframe="1Sec",
+            seq=58,
+            payload={
+                "price": 969.32,
+                "ema12": 968.98,
+                "ema26": 968.20,
+                "macd": 0.046,
+                "macd_signal": 0.019,
+                "rsi14": 64,
+                "vol_realized_w60s": 0.00020,
+                "spread": 0.08,
+                "vwap_w5m": 968.99,
+                "imbalance_bid_sz": 7100,
+                "imbalance_ask_sz": 5000,
+                "price_vs_session_open_bps": 21,
+                "opening_window_return_bps": 10,
+                "session_high_price": 969.70,
+                "opening_range_high": 968.84,
+                "price_vs_opening_range_high_bps": 5,
+                "price_vs_opening_window_close_bps": 14,
+                "opening_range_width_bps": 24,
+                "session_range_bps": 64,
+                "price_position_in_session_range": 0.91,
+                "recent_spread_bps_avg": 0.82,
+                "recent_spread_bps_max": 1.41,
+                "recent_imbalance_pressure_avg": 0.08,
+                "recent_microprice_bias_bps_avg": 1.1,
+                "cross_section_range_position_rank": 0.97,
+                "cross_section_vwap_w5m_rank": 0.94,
+                "cross_section_recent_imbalance_rank": 0.92,
+                "cross_section_continuation_rank": 0.83,
+            },
+        )
+
+        runtime = StrategyRuntime()
+        decision = runtime.evaluate(strategy, normalize_feature_vector_v3(signal), timeframe="1Sec")
+
+        self.assertIsNotNone(decision)
+        assert decision is not None
+        self.assertEqual(decision.intent.action, "buy")
+        self.assertEqual(decision.plugin_id, "breakout_continuation_long")
+
+    def test_breakout_continuation_plugin_allows_isolated_flow_breakout_when_breadth_is_middling(
+        self,
+    ) -> None:
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="breakout-continuation",
+            description=_compose_strategy_description(
+                StrategyConfig(
+                    name="breakout-continuation",
+                    strategy_id="breakout_continuation_long_v1@research",
+                    strategy_type="breakout_continuation_long_v1",
+                    version="1.0.0",
+                    base_timeframe="1Sec",
+                    universe_type="breakout_continuation_long_v1",
+                    universe_symbols=["NVDA"],
+                    max_position_pct_equity=Decimal("1.0"),
+                    max_notional_per_trade=Decimal("14000"),
+                    params={
+                        "min_cross_section_positive_session_open_ratio": "0.50",
+                        "min_cross_section_positive_opening_window_return_ratio": "0.55",
+                        "min_cross_section_above_vwap_w5m_ratio": "0.60",
+                        "min_cross_section_continuation_breadth": "0.65",
+                        "isolated_flow_session_open_ratio_relaxation": "0.12",
+                        "isolated_flow_opening_window_ratio_relaxation": "0.15",
+                        "isolated_flow_above_vwap_ratio_relaxation": "0.15",
+                        "isolated_flow_continuation_breadth_relaxation": "0.15",
+                    },
+                )
+            ),
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="breakout_continuation_long_v1",
+            universe_symbols=["NVDA"],
+            max_position_pct_equity=Decimal("1.0"),
+            max_notional_per_trade=Decimal("14000"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 23, 17, 30, 3, tzinfo=timezone.utc),
+            symbol="NVDA",
+            timeframe="1Sec",
+            seq=41,
+            payload={
+                "price": 969.40,
+                "ema12": 968.92,
+                "ema26": 968.35,
+                "macd": 0.044,
+                "macd_signal": 0.018,
+                "rsi14": 64,
+                "vol_realized_w60s": 0.00020,
+                "spread": 0.08,
+                "vwap_w5m": 968.95,
+                "imbalance_bid_sz": 6800,
+                "imbalance_ask_sz": 5200,
+                "price_vs_session_open_bps": 63,
+                "opening_window_return_bps": 24,
+                "session_high_price": 969.90,
+                "opening_range_high": 968.70,
+                "price_vs_opening_range_high_bps": 7,
+                "price_vs_opening_window_close_bps": 14,
+                "opening_range_width_bps": 24,
+                "session_range_bps": 66,
+                "price_position_in_session_range": 0.93,
+                "recent_spread_bps_avg": 0.82,
+                "recent_spread_bps_max": 1.41,
+                "recent_imbalance_pressure_avg": 0.09,
+                "recent_microprice_bias_bps_avg": 1.2,
+                "cross_section_positive_session_open_ratio": 0.42,
+                "cross_section_positive_opening_window_return_ratio": 0.42,
+                "cross_section_above_vwap_w5m_ratio": 0.48,
+                "cross_section_continuation_breadth": 0.50,
+                "cross_section_session_open_rank": 0.45,
+                "cross_section_opening_window_return_rank": 0.55,
+                "cross_section_range_position_rank": 0.98,
+                "cross_section_vwap_w5m_rank": 0.94,
+                "cross_section_recent_imbalance_rank": 0.92,
+                "cross_section_continuation_rank": 0.77,
+            },
+        )
+
+        feature_contract = normalize_feature_vector_v3(signal)
+        runtime = StrategyRuntime()
+        decision = runtime.evaluate(strategy, feature_contract, timeframe="1Sec")
+
+        self.assertIsNotNone(decision)
+        assert decision is not None
+        self.assertEqual(decision.intent.action, "buy")
+        self.assertEqual(decision.plugin_id, "breakout_continuation_long")
+        self.assertIn("opening_range_breakout", decision.intent.rationale)
+
+    def test_breakout_continuation_plugin_allows_isolated_flow_without_clean_orh_rebreak(
+        self,
+    ) -> None:
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="breakout-continuation",
+            description=_compose_strategy_description(
+                StrategyConfig(
+                    name="breakout-continuation",
+                    strategy_id="breakout_continuation_long_v1@research",
+                    strategy_type="breakout_continuation_long_v1",
+                    version="1.0.0",
+                    base_timeframe="1Sec",
+                    universe_type="breakout_continuation_long_v1",
+                    universe_symbols=["NVDA"],
+                    max_position_pct_equity=Decimal("1.0"),
+                    max_notional_per_trade=Decimal("14000"),
+                    params={
+                        "min_session_high_above_opening_range_high_bps": "4",
+                        "min_price_vs_opening_range_high_bps": "-12",
+                        "max_price_vs_opening_window_close_bps": "18",
+                    },
+                )
+            ),
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="breakout_continuation_long_v1",
+            universe_symbols=["NVDA"],
+            max_position_pct_equity=Decimal("1.0"),
+            max_notional_per_trade=Decimal("14000"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 24, 18, 3, 3, tzinfo=timezone.utc),
+            symbol="NVDA",
+            timeframe="1Sec",
+            seq=57,
+            payload={
+                "price": 969.28,
+                "ema12": 968.96,
+                "ema26": 968.25,
+                "macd": 0.047,
+                "macd_signal": 0.018,
+                "rsi14": 65,
+                "vol_realized_w60s": 0.00019,
+                "spread": 0.08,
+                "vwap_w5m": 968.98,
+                "imbalance_bid_sz": 7200,
+                "imbalance_ask_sz": 5100,
+                "price_vs_session_open_bps": 56,
+                "opening_window_return_bps": 20,
+                "session_high_price": 969.44,
+                "opening_range_high": 969.40,
+                "price_vs_opening_range_high_bps": -12.38208687933863171653008561,
+                "price_vs_opening_window_close_bps": 24.0,
+                "opening_range_width_bps": 24,
+                "session_range_bps": 63,
+                "price_position_in_session_range": 0.92,
+                "recent_spread_bps_avg": 0.82,
+                "recent_spread_bps_max": 1.41,
+                "recent_imbalance_pressure_avg": 0.10,
+                "recent_microprice_bias_bps_avg": 1.15,
+                "cross_section_positive_session_open_ratio": 0.42,
+                "cross_section_positive_opening_window_return_ratio": 0.46,
+                "cross_section_above_vwap_w5m_ratio": 0.48,
+                "cross_section_continuation_breadth": 0.52,
+                "cross_section_session_open_rank": 0.48,
+                "cross_section_opening_window_return_rank": 0.54,
+                "cross_section_range_position_rank": 0.98,
+                "cross_section_vwap_w5m_rank": 0.95,
+                "cross_section_recent_imbalance_rank": 0.93,
+                "cross_section_continuation_rank": 0.79,
+            },
+        )
+
+        feature_contract = normalize_feature_vector_v3(signal)
+        runtime = StrategyRuntime()
+        decision = runtime.evaluate(strategy, feature_contract, timeframe="1Sec")
+
+        self.assertIsNotNone(decision)
+        assert decision is not None
+        self.assertEqual(decision.intent.action, "buy")
+        self.assertEqual(decision.plugin_id, "breakout_continuation_long")
+
+    def test_breakout_continuation_plugin_allows_isolated_leader_near_high_shape(self) -> None:
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="breakout-continuation",
+            description="version=1.0.0",
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="breakout_continuation_long_v1",
+            universe_symbols=["NVDA"],
+            max_position_pct_equity=Decimal("1.0"),
+            max_notional_per_trade=Decimal("14000"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 24, 18, 8, 3, tzinfo=timezone.utc),
+            symbol="NVDA",
+            timeframe="1Sec",
+            seq=61,
+            payload={
+                "price": 969.28,
+                "ema12": 968.96,
+                "ema26": 968.25,
+                "macd": 0.047,
+                "macd_signal": 0.018,
+                "rsi14": 65,
+                "vol_realized_w60s": 0.00019,
+                "spread": 0.08,
+                "vwap_w5m": 968.98,
+                "imbalance_bid_sz": 7200,
+                "imbalance_ask_sz": 5100,
+                "price_vs_session_open_bps": 56,
+                "opening_window_return_bps": 20,
+                "session_high_price": 969.40,
+                "opening_range_high": 969.40,
+                "price_vs_opening_range_high_bps": -17.5,
+                "price_vs_opening_window_close_bps": 44.0,
+                "opening_range_width_bps": 24,
+                "session_range_bps": 63,
+                "price_position_in_session_range": 0.94,
+                "recent_spread_bps_avg": 0.82,
+                "recent_spread_bps_max": 1.41,
+                "recent_imbalance_pressure_avg": 0.10,
+                "recent_microprice_bias_bps_avg": 1.15,
+                "cross_section_session_open_rank": 0.48,
+                "cross_section_opening_window_return_rank": 0.54,
+                "cross_section_range_position_rank": 0.98,
+                "cross_section_vwap_w5m_rank": 0.95,
+                "cross_section_recent_imbalance_rank": 0.93,
+                "cross_section_continuation_rank": 0.79,
+            },
+        )
+
+        feature_contract = normalize_feature_vector_v3(signal)
+        runtime = StrategyRuntime()
+        decision = runtime.evaluate(strategy, feature_contract, timeframe="1Sec")
+
+        self.assertIsNotNone(decision)
+        assert decision is not None
+        self.assertEqual(decision.intent.action, "buy")
+        self.assertEqual(decision.plugin_id, "breakout_continuation_long")
+
+    def test_breakout_continuation_plugin_allows_relaxed_isolated_strength_thresholds(
+        self,
+    ) -> None:
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="breakout-continuation",
+            description="version=1.0.0",
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="breakout_continuation_long_v1",
+            universe_symbols=["NVDA"],
+            max_position_pct_equity=Decimal("1.0"),
+            max_notional_per_trade=Decimal("14000"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 24, 18, 11, 3, tzinfo=timezone.utc),
+            symbol="NVDA",
+            timeframe="1Sec",
+            seq=63,
+            payload={
+                "price": 969.36,
+                "ema12": 968.98,
+                "ema26": 968.31,
+                "macd": 0.046,
+                "macd_signal": 0.018,
+                "rsi14": 65,
+                "vol_realized_w60s": 0.00019,
+                "spread": 0.08,
+                "vwap_w5m": 969.02,
+                "imbalance_bid_sz": 7000,
+                "imbalance_ask_sz": 5100,
+                "price_vs_session_open_bps": 55,
+                "opening_window_return_bps": 20,
+                "session_high_price": 969.40,
+                "opening_range_high": 969.40,
+                "price_vs_opening_range_high_bps": -17.5,
+                "price_vs_opening_window_close_bps": 42.0,
+                "opening_range_width_bps": 24,
+                "session_range_bps": 63,
+                "price_position_in_session_range": 0.92,
+                "recent_spread_bps_avg": 0.82,
+                "recent_spread_bps_max": 1.41,
+                "recent_imbalance_pressure_avg": 0.10,
+                "recent_microprice_bias_bps_avg": 1.15,
+                "cross_section_session_open_rank": 0.48,
+                "cross_section_opening_window_return_rank": 0.54,
+                "cross_section_range_position_rank": 0.86,
+                "cross_section_vwap_w5m_rank": 0.76,
+                "cross_section_recent_imbalance_rank": 0.77,
+                "cross_section_continuation_rank": 0.79,
+            },
+        )
+
+        runtime = StrategyRuntime()
+        decision = runtime.evaluate(strategy, normalize_feature_vector_v3(signal), timeframe="1Sec")
+
+        self.assertIsNotNone(decision)
+        assert decision is not None
+        self.assertEqual(decision.intent.action, "buy")
+        self.assertEqual(decision.plugin_id, "breakout_continuation_long")
+
+    def test_breakout_continuation_plugin_relaxes_recent_microstructure_for_isolated_leader(
+        self,
+    ) -> None:
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="breakout-continuation",
+            description="version=1.0.0",
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="breakout_continuation_long_v1",
+            universe_symbols=["AAPL"],
+            max_position_pct_equity=Decimal("1.0"),
+            max_notional_per_trade=Decimal("14000"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 24, 16, 7, 34, tzinfo=timezone.utc),
+            symbol="AAPL",
+            timeframe="1Sec",
+            seq=62,
+            payload={
+                "price": 254.10,
+                "ema12": 253.96,
+                "ema26": 253.70,
+                "macd": 0.036,
+                "macd_signal": 0.018,
+                "rsi14": 64,
+                "vol_realized_w60s": 0.00014,
+                "spread": 0.03,
+                "vwap_w5m": 253.99,
+                "imbalance_bid_sz": 5600,
+                "imbalance_ask_sz": 4700,
+                "price_vs_session_open_bps": 52,
+                "opening_window_return_bps": 20,
+                "session_high_price": 254.16,
+                "opening_range_high": 254.20,
+                "price_vs_opening_range_high_bps": -4,
+                "price_vs_opening_window_close_bps": 10,
+                "opening_range_width_bps": 20,
+                "session_range_bps": 44,
+                "price_position_in_session_range": 0.93,
+                "recent_spread_bps_avg": 7.7,
+                "recent_spread_bps_max": 24.4,
+                "recent_imbalance_pressure_avg": 0.05,
+                "recent_quote_invalid_ratio": 0.20,
+                "recent_quote_jump_bps_max": 12.8,
+                "recent_microprice_bias_bps_avg": 0.37,
+                "cross_section_range_position_rank": 0.95,
+                "cross_section_vwap_w5m_rank": 0.93,
+                "cross_section_recent_imbalance_rank": 0.91,
+                "cross_section_continuation_rank": 0.89,
+            },
+        )
+
+        feature_contract = normalize_feature_vector_v3(signal)
+        runtime = StrategyRuntime()
+        decision = runtime.evaluate(strategy, feature_contract, timeframe="1Sec")
+
+        self.assertIsNotNone(decision)
+        assert decision is not None
+        self.assertEqual(decision.intent.action, "buy")
+        self.assertEqual(decision.plugin_id, "breakout_continuation_long")
+
     def test_breakout_continuation_plugin_prefers_prev_close_opening_drive(self) -> None:
         strategy = Strategy(
             id=uuid.uuid4(),
@@ -1179,6 +2161,7 @@ class TestStrategyRuntime(TestCase):
                     params={
                         "min_opening_window_return_bps": "20",
                         "min_cross_section_opening_window_return_rank": "0.70",
+                        "late_session_min_session_open_return_efficiency": "0.20",
                     },
                 )
             ),
@@ -1342,6 +2325,214 @@ class TestStrategyRuntime(TestCase):
         self.assertEqual(decision.plugin_id, "breakout_continuation_long")
         self.assertIn("breakout_failed", decision.intent.rationale)
 
+    def test_breakout_continuation_plugin_does_not_exit_on_momentum_rollover_above_structure(
+        self,
+    ) -> None:
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="breakout-continuation",
+            description="version=1.0.0",
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="breakout_continuation_long_v1",
+            universe_symbols=["AAPL"],
+            max_position_pct_equity=Decimal("1.0"),
+            max_notional_per_trade=Decimal("14000"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 26, 14, 18, 40, tzinfo=timezone.utc),
+            symbol="AAPL",
+            timeframe="1Sec",
+            seq=4,
+            payload={
+                "price": 255.415,
+                "ema12": 255.4872,
+                "ema26": 255.4381,
+                "macd": 0.0491,
+                "macd_signal": 0.0600,
+                "rsi14": 47.16,
+                "vol_realized_w60s": 0.000167,
+                "spread": 0.03,
+                "vwap_w5m": 255.1747,
+                "imbalance_bid_sz": 100,
+                "imbalance_ask_sz": 200,
+                "price_vs_session_open_bps": 68,
+                "price_vs_opening_range_high_bps": 6,
+                "session_high_price": 255.74,
+                "opening_range_high": 255.26,
+                "opening_range_width_bps": 376.63,
+                "session_range_bps": 508.52,
+                "price_position_in_session_range": 0.83,
+                "recent_spread_bps_avg": 6.38,
+                "recent_spread_bps_max": 23.56,
+                "recent_imbalance_pressure_avg": 0.07,
+                "recent_microprice_bias_bps_avg": 0.54,
+            },
+        )
+
+        feature_contract = normalize_feature_vector_v3(signal)
+        runtime = StrategyRuntime()
+        decision = runtime.evaluate(strategy, feature_contract, timeframe="1Sec")
+
+        self.assertIsNone(decision)
+
+    def test_breakout_continuation_plugin_does_not_exit_on_negative_imbalance_above_structure(
+        self,
+    ) -> None:
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="breakout-continuation",
+            description="version=1.0.0",
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="breakout_continuation_long_v1",
+            universe_symbols=["AAPL"],
+            max_position_pct_equity=Decimal("1.0"),
+            max_notional_per_trade=Decimal("14000"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 26, 14, 18, 55, tzinfo=timezone.utc),
+            symbol="AAPL",
+            timeframe="1Sec",
+            seq=5,
+            payload={
+                "price": 255.42,
+                "ema12": 255.4845,
+                "ema26": 255.4544,
+                "macd": 0.0301,
+                "macd_signal": 0.0372,
+                "rsi14": 52.05,
+                "vol_realized_w60s": 0.000167,
+                "spread": 0.03,
+                "vwap_w5m": 255.1920,
+                "imbalance_bid_sz": 100,
+                "imbalance_ask_sz": 200,
+                "price_vs_session_open_bps": 68,
+                "price_vs_opening_range_high_bps": 6,
+                "session_high_price": 255.74,
+                "opening_range_high": 255.26,
+                "opening_range_width_bps": 376.63,
+                "session_range_bps": 508.52,
+                "price_position_in_session_range": 0.83,
+                "recent_spread_bps_avg": 6.38,
+                "recent_spread_bps_max": 23.56,
+                "recent_imbalance_pressure_avg": -0.04,
+                "recent_microprice_bias_bps_avg": 0.54,
+            },
+        )
+
+        feature_contract = normalize_feature_vector_v3(signal)
+        runtime = StrategyRuntime()
+        decision = runtime.evaluate(strategy, feature_contract, timeframe="1Sec")
+
+        self.assertIsNone(decision)
+
+    def test_breakout_continuation_plugin_does_not_exit_on_vwap_dip_above_structure(
+        self,
+    ) -> None:
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="breakout-continuation",
+            description="version=1.0.0",
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="breakout_continuation_long_v1",
+            universe_symbols=["AAPL"],
+            max_position_pct_equity=Decimal("1.0"),
+            max_notional_per_trade=Decimal("14000"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 26, 14, 19, 23, tzinfo=timezone.utc),
+            symbol="AAPL",
+            timeframe="1Sec",
+            seq=6,
+            payload={
+                "price": 255.21,
+                "ema12": 255.3729,
+                "ema26": 255.4043,
+                "macd": -0.0313,
+                "macd_signal": -0.0057,
+                "rsi14": 31.4,
+                "vol_realized_w60s": 0.00017,
+                "spread": 0.03,
+                "vwap_w5m": 255.2437,
+                "imbalance_bid_sz": 100,
+                "imbalance_ask_sz": 200,
+                "price_vs_session_open_bps": 413.76,
+                "price_vs_opening_range_high_bps": 35.78,
+                "session_high_price": 255.765,
+                "opening_range_high": 254.3,
+                "opening_range_width_bps": 376.63,
+                "session_range_bps": 436.41,
+                "price_position_in_session_range": 0.948,
+                "recent_spread_bps_avg": 6.95,
+                "recent_spread_bps_max": 28.16,
+                "recent_imbalance_pressure_avg": -0.111,
+                "recent_microprice_bias_bps_avg": -0.074,
+            },
+        )
+
+        feature_contract = normalize_feature_vector_v3(signal)
+        runtime = StrategyRuntime()
+        decision = runtime.evaluate(strategy, feature_contract, timeframe="1Sec")
+
+        self.assertIsNone(decision)
+
+    def test_breakout_continuation_plugin_exits_on_negative_imbalance_after_structure_loss(
+        self,
+    ) -> None:
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="breakout-continuation",
+            description="version=1.0.0",
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="breakout_continuation_long_v1",
+            universe_symbols=["AAPL"],
+            max_position_pct_equity=Decimal("1.0"),
+            max_notional_per_trade=Decimal("14000"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 26, 14, 24, 5, tzinfo=timezone.utc),
+            symbol="AAPL",
+            timeframe="1Sec",
+            seq=6,
+            payload={
+                "price": 255.16,
+                "ema12": 255.10,
+                "ema26": 255.22,
+                "macd": 0.028,
+                "macd_signal": 0.026,
+                "rsi14": 58.2,
+                "vol_realized_w60s": 0.000170,
+                "spread": 0.03,
+                "vwap_w5m": 255.19,
+                "imbalance_bid_sz": 100,
+                "imbalance_ask_sz": 200,
+                "price_vs_session_open_bps": 54,
+                "price_vs_opening_range_high_bps": 2,
+                "session_high_price": 255.74,
+                "opening_range_high": 255.26,
+                "opening_range_width_bps": 376.63,
+                "session_range_bps": 508.52,
+                "price_position_in_session_range": 0.74,
+                "recent_spread_bps_avg": 5.9,
+                "recent_spread_bps_max": 12.5,
+                "recent_imbalance_pressure_avg": -0.05,
+                "recent_microprice_bias_bps_avg": 0.12,
+            },
+        )
+
+        feature_contract = normalize_feature_vector_v3(signal)
+        runtime = StrategyRuntime()
+        decision = runtime.evaluate(strategy, feature_contract, timeframe="1Sec")
+
+        self.assertIsNotNone(decision)
+        assert decision is not None
+        self.assertEqual(decision.intent.action, "sell")
+        self.assertEqual(decision.plugin_id, "breakout_continuation_long")
+        self.assertIn("session_strength_reversal", decision.intent.rationale)
+
     def test_breakout_continuation_plugin_skips_late_entry_near_flatten(self) -> None:
         strategy = Strategy(
             id=uuid.uuid4(),
@@ -1469,6 +2660,358 @@ class TestStrategyRuntime(TestCase):
         self.assertEqual(decision.intent.action, "buy")
         self.assertEqual(decision.plugin_id, "late_day_continuation_long")
         self.assertIn("late_day_strength", decision.intent.rationale)
+
+    def test_late_day_continuation_plugin_prefers_live_structure_rank(self) -> None:
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="late-day-continuation",
+            description=_compose_strategy_description(
+                StrategyConfig(
+                    name="late-day-continuation",
+                    strategy_id="late_day_continuation_long_v1@research",
+                    strategy_type="late_day_continuation_long_v1",
+                    version="1.0.0",
+                    base_timeframe="1Sec",
+                    universe_type="late_day_continuation_long_v1",
+                    universe_symbols=["AAPL"],
+                    max_position_pct_equity=Decimal("1.0"),
+                    max_notional_per_trade=Decimal("14000"),
+                    params={
+                        "min_opening_window_return_bps": "18",
+                        "min_cross_section_opening_window_return_rank": "0.65",
+                        "min_cross_section_continuation_rank": "0.78",
+                    },
+                )
+            ),
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="late_day_continuation_long_v1",
+            universe_symbols=["AAPL"],
+            max_position_pct_equity=Decimal("1.0"),
+            max_notional_per_trade=Decimal("14000"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 26, 18, 58, 3, tzinfo=timezone.utc),
+            symbol="AAPL",
+            timeframe="1Sec",
+            seq=55,
+            payload={
+                "price": 253.93,
+                "ema12": 253.82,
+                "ema26": 253.60,
+                "macd": 0.028,
+                "macd_signal": 0.014,
+                "rsi14": 63,
+                "vol_realized_w60s": 0.00019,
+                "spread": 0.03,
+                "vwap_w5m": 253.88,
+                "imbalance_bid_sz": 5400,
+                "imbalance_ask_sz": 5000,
+                "price_vs_session_open_bps": 58,
+                "opening_window_return_bps": 24,
+                "price_position_in_session_range": 0.92,
+                "session_high_price": 254.02,
+                "opening_range_high": 253.86,
+                "price_vs_opening_range_high_bps": 2.8,
+                "price_vs_opening_window_close_bps": 9.5,
+                "recent_spread_bps_avg": 0.61,
+                "recent_imbalance_pressure_avg": 0.03,
+                "recent_microprice_bias_bps_avg": 0.9,
+                "session_range_bps": 48,
+                "cross_section_positive_session_open_ratio": 0.58,
+                "cross_section_positive_opening_window_return_ratio": 0.66,
+                "cross_section_above_vwap_w5m_ratio": 0.50,
+                "cross_section_continuation_breadth": 0.62,
+                "cross_section_session_open_rank": 0.42,
+                "cross_section_opening_window_return_rank": 0.35,
+                "cross_section_range_position_rank": 0.95,
+                "cross_section_vwap_w5m_rank": 0.93,
+                "cross_section_recent_imbalance_rank": 0.91,
+                "cross_section_continuation_rank": 0.45,
+            },
+        )
+
+        feature_contract = normalize_feature_vector_v3(signal)
+        runtime = StrategyRuntime()
+        decision = runtime.evaluate(strategy, feature_contract, timeframe="1Sec")
+
+        self.assertIsNotNone(decision)
+        assert decision is not None
+        self.assertEqual(decision.intent.action, "buy")
+        self.assertEqual(decision.plugin_id, "late_day_continuation_long")
+        self.assertIn("late_day_strength", decision.intent.rationale)
+
+    def test_late_day_continuation_plugin_allows_late_isolated_leader_with_relaxed_drive_requirements(
+        self,
+    ) -> None:
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="late-day-continuation",
+            description=_compose_strategy_description(
+                StrategyConfig(
+                    name="late-day-continuation",
+                    strategy_id="late_day_continuation_long_v1@research",
+                    strategy_type="late_day_continuation_long_v1",
+                    version="1.0.0",
+                    base_timeframe="1Sec",
+                    universe_type="late_day_continuation_long_v1",
+                    universe_symbols=["AAPL"],
+                    max_position_pct_equity=Decimal("1.0"),
+                    max_notional_per_trade=Decimal("14000"),
+                    params={
+                        "min_session_open_drive_bps": "35",
+                        "late_session_min_session_open_drive_bps": "18",
+                        "min_opening_window_return_bps": "20",
+                        "late_session_min_opening_window_return_bps": "10",
+                    },
+                )
+            ),
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="late_day_continuation_long_v1",
+            universe_symbols=["AAPL"],
+            max_position_pct_equity=Decimal("1.0"),
+            max_notional_per_trade=Decimal("14000"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 26, 19, 6, 3, tzinfo=timezone.utc),
+            symbol="AAPL",
+            timeframe="1Sec",
+            seq=91,
+            payload={
+                "price": 253.98,
+                "ema12": 253.85,
+                "ema26": 253.62,
+                "macd": 0.029,
+                "macd_signal": 0.014,
+                "rsi14": 63,
+                "vol_realized_w60s": 0.00018,
+                "spread": 0.03,
+                "vwap_w5m": 253.90,
+                "imbalance_bid_sz": 5600,
+                "imbalance_ask_sz": 4700,
+                "price_vs_session_open_bps": 19,
+                "opening_window_return_bps": 10,
+                "price_position_in_session_range": 0.92,
+                "session_high_price": 254.03,
+                "opening_range_high": 254.00,
+                "price_vs_opening_range_high_bps": -1,
+                "price_vs_opening_window_close_bps": 12,
+                "recent_spread_bps_avg": 0.61,
+                "recent_imbalance_pressure_avg": 0.04,
+                "recent_microprice_bias_bps_avg": 0.92,
+                "session_range_bps": 48,
+                "cross_section_range_position_rank": 0.95,
+                "cross_section_vwap_w5m_rank": 0.93,
+                "cross_section_recent_imbalance_rank": 0.91,
+                "cross_section_continuation_rank": 0.86,
+            },
+        )
+
+        runtime = StrategyRuntime()
+        decision = runtime.evaluate(strategy, normalize_feature_vector_v3(signal), timeframe="1Sec")
+
+        self.assertIsNotNone(decision)
+        assert decision is not None
+        self.assertEqual(decision.intent.action, "buy")
+        self.assertEqual(decision.plugin_id, "late_day_continuation_long")
+
+    def test_late_day_continuation_plugin_allows_isolated_flow_without_clean_orh_rebreak(
+        self,
+    ) -> None:
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="late-day-continuation",
+            description=_compose_strategy_description(
+                StrategyConfig(
+                    name="late-day-continuation",
+                    strategy_id="late_day_continuation_long_v1@research",
+                    strategy_type="late_day_continuation_long_v1",
+                    version="1.0.0",
+                    base_timeframe="1Sec",
+                    universe_type="late_day_continuation_long_v1",
+                    universe_symbols=["AAPL"],
+                    max_position_pct_equity=Decimal("1.0"),
+                    max_notional_per_trade=Decimal("14000"),
+                    params={
+                        "min_session_high_above_opening_range_high_bps": "4",
+                        "min_price_vs_opening_range_high_bps": "-10",
+                        "max_price_vs_opening_window_close_bps": "18",
+                    },
+                )
+            ),
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="late_day_continuation_long_v1",
+            universe_symbols=["AAPL"],
+            max_position_pct_equity=Decimal("1.0"),
+            max_notional_per_trade=Decimal("14000"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 26, 19, 1, 3, tzinfo=timezone.utc),
+            symbol="AAPL",
+            timeframe="1Sec",
+            seq=88,
+            payload={
+                "price": 253.94,
+                "ema12": 253.82,
+                "ema26": 253.61,
+                "macd": 0.030,
+                "macd_signal": 0.014,
+                "rsi14": 63,
+                "vol_realized_w60s": 0.00018,
+                "spread": 0.03,
+                "vwap_w5m": 253.88,
+                "imbalance_bid_sz": 5600,
+                "imbalance_ask_sz": 4700,
+                "price_vs_session_open_bps": 58,
+                "opening_window_return_bps": 22,
+                "price_position_in_session_range": 0.91,
+                "session_high_price": 254.00,
+                "opening_range_high": 253.98,
+                "price_vs_opening_range_high_bps": -1.574927159618867627372233170,
+                "price_vs_opening_window_close_bps": 23,
+                "recent_spread_bps_avg": 0.61,
+                "recent_imbalance_pressure_avg": 0.04,
+                "recent_microprice_bias_bps_avg": 0.92,
+                "session_range_bps": 48,
+                "cross_section_positive_session_open_ratio": 0.58,
+                "cross_section_positive_opening_window_return_ratio": 0.66,
+                "cross_section_above_vwap_w5m_ratio": 0.50,
+                "cross_section_continuation_breadth": 0.62,
+                "cross_section_session_open_rank": 0.42,
+                "cross_section_opening_window_return_rank": 0.35,
+                "cross_section_range_position_rank": 0.95,
+                "cross_section_vwap_w5m_rank": 0.93,
+                "cross_section_recent_imbalance_rank": 0.91,
+                "cross_section_continuation_rank": 0.45,
+            },
+        )
+
+        feature_contract = normalize_feature_vector_v3(signal)
+        runtime = StrategyRuntime()
+        decision = runtime.evaluate(strategy, feature_contract, timeframe="1Sec")
+
+        self.assertIsNotNone(decision)
+        assert decision is not None
+        self.assertEqual(decision.intent.action, "buy")
+        self.assertEqual(decision.plugin_id, "late_day_continuation_long")
+
+    def test_late_day_continuation_plugin_allows_isolated_leader_near_high_shape(self) -> None:
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="late-day-continuation",
+            description="version=1.0.0",
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="late_day_continuation_long_v1",
+            universe_symbols=["AAPL"],
+            max_position_pct_equity=Decimal("1.0"),
+            max_notional_per_trade=Decimal("14000"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 26, 19, 4, 3, tzinfo=timezone.utc),
+            symbol="AAPL",
+            timeframe="1Sec",
+            seq=89,
+            payload={
+                "price": 253.94,
+                "ema12": 253.82,
+                "ema26": 253.61,
+                "macd": 0.030,
+                "macd_signal": 0.014,
+                "rsi14": 63,
+                "vol_realized_w60s": 0.00018,
+                "spread": 0.03,
+                "vwap_w5m": 253.88,
+                "imbalance_bid_sz": 5600,
+                "imbalance_ask_sz": 4700,
+                "price_vs_session_open_bps": 58,
+                "opening_window_return_bps": 22,
+                "price_position_in_session_range": 0.93,
+                "session_high_price": 253.98,
+                "opening_range_high": 253.98,
+                "price_vs_opening_range_high_bps": -12,
+                "price_vs_opening_window_close_bps": 36,
+                "recent_spread_bps_avg": 0.61,
+                "recent_imbalance_pressure_avg": 0.04,
+                "recent_microprice_bias_bps_avg": 0.92,
+                "session_range_bps": 48,
+                "cross_section_range_position_rank": 0.95,
+                "cross_section_vwap_w5m_rank": 0.93,
+                "cross_section_recent_imbalance_rank": 0.91,
+                "cross_section_continuation_rank": 0.45,
+            },
+        )
+
+        feature_contract = normalize_feature_vector_v3(signal)
+        runtime = StrategyRuntime()
+        decision = runtime.evaluate(strategy, feature_contract, timeframe="1Sec")
+
+        self.assertIsNotNone(decision)
+        assert decision is not None
+        self.assertEqual(decision.intent.action, "buy")
+        self.assertEqual(decision.plugin_id, "late_day_continuation_long")
+
+    def test_late_day_continuation_plugin_relaxes_recent_microstructure_for_isolated_leader(
+        self,
+    ) -> None:
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="late-day-continuation",
+            description="version=1.0.0",
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="late_day_continuation_long_v1",
+            universe_symbols=["AAPL"],
+            max_position_pct_equity=Decimal("1.0"),
+            max_notional_per_trade=Decimal("14000"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 26, 19, 7, 34, tzinfo=timezone.utc),
+            symbol="AAPL",
+            timeframe="1Sec",
+            seq=90,
+            payload={
+                "price": 254.10,
+                "ema12": 253.96,
+                "ema26": 253.70,
+                "macd": 0.030,
+                "macd_signal": 0.014,
+                "rsi14": 64,
+                "vol_realized_w60s": 0.00014,
+                "spread": 0.03,
+                "vwap_w5m": 253.99,
+                "imbalance_bid_sz": 5600,
+                "imbalance_ask_sz": 4700,
+                "price_vs_session_open_bps": 52,
+                "opening_window_return_bps": 22,
+                "session_high_price": 254.16,
+                "opening_range_high": 254.20,
+                "price_vs_opening_range_high_bps": -4,
+                "price_vs_opening_window_close_bps": 10,
+                "session_range_bps": 44,
+                "price_position_in_session_range": 0.93,
+                "recent_spread_bps_avg": 7.7,
+                "recent_imbalance_pressure_avg": 0.05,
+                "recent_quote_invalid_ratio": 0.20,
+                "recent_quote_jump_bps_max": 12.8,
+                "recent_microprice_bias_bps_avg": 0.37,
+                "cross_section_range_position_rank": 0.95,
+                "cross_section_vwap_w5m_rank": 0.93,
+                "cross_section_recent_imbalance_rank": 0.91,
+                "cross_section_continuation_rank": 0.89,
+            },
+        )
+
+        feature_contract = normalize_feature_vector_v3(signal)
+        runtime = StrategyRuntime()
+        decision = runtime.evaluate(strategy, feature_contract, timeframe="1Sec")
+
+        self.assertIsNotNone(decision)
+        assert decision is not None
+        self.assertEqual(decision.intent.action, "buy")
+        self.assertEqual(decision.plugin_id, "late_day_continuation_long")
 
     def test_late_day_continuation_plugin_skips_quote_unstable_symbol(self) -> None:
         strategy = Strategy(


### PR DESCRIPTION
## Summary

- harden Torghut continuation entries with research-backed session-context, microstructure, and cross-sectional quality gates in the live strategy runtime
- make the local replay execution path more faithful by fixing same-signal marketable fills, pending-order exposure accounting, and urgent exit replacement behavior
- add regression coverage for the new breakout quality filters, replay fill behavior, session-context enrichment, and runtime decision contracts
- improve the honest retained-week replay by removing the March 23 false-positive INTC breakout while preserving the March 26 AAPL winner

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_decisions.py tests/test_session_context.py tests/test_strategy_runtime.py tests/test_local_intraday_tsmom_replay.py -q`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen ruff check app tests scripts`
- `cd services/torghut && uv run --frozen scripts/local_intraday_tsmom_replay.py --strategy-configmap /tmp/torghut-breakout-late-day.yaml --start-date 2026-03-23 --end-date 2026-03-27 --clickhouse-password 0d6148b1a4a16ffb057710ad3e1c258f --json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
