### PR TITLE
feat(torghut): add pytest property testing and coverage gates

### DIFF
--- a/.github/workflows/torghut-ci.yml
+++ b/.github/workflows/torghut-ci.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -51,12 +53,14 @@ jobs:
         run: uv run --frozen pyright --project pyrightconfig.scripts.json
 
   lint-and-tests:
-    name: Bytecode + unit tests
+    name: Bytecode + pytest + coverage
     needs: pyright
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -82,9 +86,22 @@ jobs:
         working-directory: services/torghut
         run: uv run --frozen python scripts/check_migration_graph.py
 
-      - name: Unit tests
+      - name: Pytest + branch coverage
         working-directory: services/torghut
-        run: uv run --frozen python -m unittest discover -s tests -p "test_*.py"
+        run: >
+          uv run --frozen pytest
+          --cov
+          --cov-branch
+          --cov-report=term-missing
+          --cov-report=xml
+          --cov-fail-under=70
+
+      - name: Changed-file coverage
+        working-directory: services/torghut
+        env:
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+        run: uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90
 
   quality-signals:
     name: Quality signals (complexity + security)
@@ -93,6 +110,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/docs/torghut/design-system/current-source-of-truth-and-priority-guide-2026-03-09.md
+++ b/docs/torghut/design-system/current-source-of-truth-and-priority-guide-2026-03-09.md
@@ -78,6 +78,7 @@ If the question is "what should I trust right now?", start here:
    - `docs/torghut/design-system/v6/52-torghut-profit-sleeves-segment-scoped-deallocation-and-evidence-decay-2026-03-19.md`
    - `docs/torghut/design-system/v6/53-torghut-kafka-retention-bootstrap-and-archive-backed-profitability-proof-2026-03-27.md`
    - `docs/torghut/design-system/v6/54-torghut-research-backed-sleeves-and-this-week-holdout-proof-2026-03-27.md`
+   - `docs/torghut/design-system/v6/66-torghut-property-based-testing-coverage-and-lint-hardening-2026-03-28.md`
    - `docs/torghut/design-system/v6/53-torghut-cross-plane-profit-certificate-veto-and-options-auth-isolation-2026-03-20.md`
    - `docs/torghut/design-system/v6/53-torghut-capital-leases-and-profit-trial-firebreaks-2026-03-20.md`
    - `docs/torghut/design-system/v6/54-torghut-capital-lease-receipts-and-profit-falsification-ledger-2026-03-20.md`
@@ -103,6 +104,11 @@ The March 27 profitability-proof contracts are also active operator work for the
   `docs/torghut/design-system/v6/53-torghut-kafka-retention-bootstrap-and-archive-backed-profitability-proof-2026-03-27.md`;
 - turn the retained March 16 through March 27 internal window into a frozen selection/holdout sleeve-proof contract in
   `docs/torghut/design-system/v6/54-torghut-research-backed-sleeves-and-this-week-holdout-proof-2026-03-27.md`.
+
+The March 28 service-quality contract is also active engineering work for Torghut's trading core:
+
+- move Torghut to Hypothesis-backed property/stateful testing, branch-coverage enforcement, and stricter lint gates in
+  `docs/torghut/design-system/v6/66-torghut-property-based-testing-coverage-and-lint-hardening-2026-03-28.md`.
 
 1. cut Jangar over to shadow-compiled, sealed recovery epochs and enforce backlog-seat ownership before rollout in
    `docs/agents/designs/65-jangar-recovery-epoch-cutover-and-backlog-seat-enforcement-contract-2026-03-21.md`;

--- a/docs/torghut/design-system/v6/66-torghut-property-based-testing-coverage-and-lint-hardening-2026-03-28.md
+++ b/docs/torghut/design-system/v6/66-torghut-property-based-testing-coverage-and-lint-hardening-2026-03-28.md
@@ -1,0 +1,660 @@
+# Torghut Property-Based Testing, Coverage, and Lint Hardening (2026-03-28)
+
+## Summary
+
+Torghut should adopt **Hypothesis** as its primary property-based testing framework and move the service test runner to
+**pytest + pytest-cov + coverage.py** while keeping **Ruff** and the three existing **Pyright** profiles as mandatory
+quality gates.
+
+The goal is not to add a second testing culture beside the current suite. The goal is to turn Torghut's most fragile,
+stateful trading logic into a system that is:
+
+- checked against invariants over large input spaces,
+- checked against state-machine transitions for replay and execution flows,
+- covered with enforced branch coverage thresholds,
+- blocked from merging when changed high-risk code lacks test evidence.
+
+This plan is intentionally **single-service** and Torghut-local. It integrates into `services/torghut/**`,
+`.github/workflows/torghut-ci.yml`, and the current Torghut test layout. It does not require new microservices.
+
+## Current state
+
+As of `2026-03-28`, Torghut has:
+
+- `110` `test_*.py` files under `services/torghut/tests`
+- `109` of those files still using `unittest` / `TestCase`
+- mandatory local and CI checks for:
+  - `ruff check`
+  - `pyrightconfig.json`
+  - `pyrightconfig.alpha.json`
+  - `pyrightconfig.scripts.json`
+  - `python -m unittest discover -s tests -p "test_*.py"`
+- no checked-in Hypothesis dependency
+- no service-local pytest configuration
+- no enforced line or branch coverage threshold
+- no diff-coverage gate for changed files
+- no mutation-testing safety net for high-risk trading modules
+
+That means Torghut can pass CI while still having:
+
+- narrow hand-authored example coverage,
+- insufficient branch exploration in risk logic,
+- replay/execution state regressions that only appear under odd sequences,
+- weak guarantees that new code meaningfully increases tested behavior.
+
+## Framework choice
+
+### Primary framework: Hypothesis
+
+Hypothesis is the right primary property-based framework for Torghut.
+
+Reasons:
+
+- It is the canonical Python property-based testing library.
+- It works directly with both `pytest` and `unittest`.
+- It supports custom strategies, composite strategies, and stateful testing.
+- It is a strong fit for Torghut’s pure functions, typed payload transforms, and replay/runtime state machines.
+
+The upstream docs explicitly position Hypothesis around writing tests that should hold **for all inputs in a described
+range**, not just a few examples. The quickstart also notes that a Hypothesis test is still a normal Python function,
+so `pytest` or `unittest` will collect it normally. The settings docs also make `max_examples` and profile-based
+configuration first-class, which is important for separating fast PR checks from deeper nightly sweeps.
+
+### Secondary complement: CrossHair
+
+CrossHair is useful, but not as Torghut’s primary framework.
+
+It should be used only for **targeted contract analysis** on small, pure, type-annotated helpers such as:
+
+- quantity quantization,
+- monotonic cap enforcement,
+- ratio/rank normalization helpers,
+- pure regime and feature coercion helpers.
+
+Reasons it is secondary:
+
+- it requires explicit contract entry points,
+- it is best on deterministic, side-effect-free code,
+- it is not a replacement for replay- and execution-oriented property testing,
+- Torghut’s highest-risk surfaces are sequence- and state-based, where Hypothesis state machines are the better fit.
+
+### Narrow optional add-on: Schemathesis
+
+Schemathesis is appropriate only for Torghut’s HTTP contract surface.
+
+It is valuable for:
+
+- `GET /healthz`
+- `GET /trading/status`
+- `GET /trading/health`
+- selected whitepaper workflow endpoints
+
+It is not the core framework because Torghut’s largest correctness risk is not request/response fuzzing. It is
+decision logic, replay correctness, sizing, and exit behavior.
+
+### Mutation testing add-on: mutmut
+
+`mutmut` should be added after the Hypothesis/coverage migration starts landing.
+
+It is useful as a **quality amplifier**, not as the first migration step. For Torghut, the most important value is
+targeted mutation runs on the deterministic trading core once those modules have better property coverage.
+
+## Why this is the right Torghut strategy
+
+Torghut’s bugs tend to be one of four types:
+
+1. quantization and cap bugs in pure arithmetic helpers;
+2. missing-field, contradictory-field, or zero-value bugs in payload normalization;
+3. state-transition bugs in replay / fill / cancel / replace / flatten flows;
+4. logic-gating bugs where one guard silently disables a strategy or wrongly emits an exit.
+
+Example-based tests catch some of these, but they are weak against broad input surfaces and long state transitions.
+
+Hypothesis gives Torghut the missing layer:
+
+- randomized but reproducible coverage of edge cases,
+- shrinking to minimal failing examples,
+- state-machine exploration for replay and position flows,
+- reusable strategy builders for the service’s typed financial payloads.
+
+## Core integration design
+
+### 1. Keep the current suite running, but switch the runner to pytest
+
+Torghut should not do a flag-day rewrite from `unittest` to raw pytest functions.
+
+Instead:
+
+- keep existing `unittest.TestCase` files running under pytest,
+- add new property tests as native pytest modules,
+- migrate old tests opportunistically only when they are already being touched.
+
+This is the safest path because pytest already supports running `unittest` suites while immediately unlocking:
+
+- fixture composition,
+- marker-based test selection,
+- Hypothesis integration,
+- better failure output,
+- coverage tooling that fits modern Python CI.
+
+### 2. Add a Torghut-local Hypothesis profile layer
+
+Check in a Torghut profile module, for example:
+
+- `services/torghut/tests/hypothesis_profiles.py`
+
+Profiles should be explicit and environment-aware:
+
+- `ci_fast`
+  - smaller `max_examples`
+  - no global deadline disable
+  - used for PR CI
+- `ci_stateful`
+  - moderate example counts for rule-based state machines
+  - stricter health-check handling
+- `nightly_deep`
+  - higher `max_examples`
+  - extended state-machine steps
+  - used by scheduled CI only
+- `local_debug`
+  - verbose output
+  - easier reproduction and replay
+
+The service should load profiles through pytest startup rather than ad hoc per-file settings, while still allowing
+file-local overrides where justified.
+
+### 3. Introduce shared Torghut data strategies
+
+Add a central strategy module, for example:
+
+- `services/torghut/tests/strategies/trading.py`
+- `services/torghut/tests/strategies/signals.py`
+- `services/torghut/tests/strategies/replay.py`
+
+These should generate:
+
+- symbols from the Jangar/Torghut equity universe shape
+- valid and invalid quote payloads
+- realistic `Decimal` prices, spreads, notionals, qty values
+- feature payloads with controlled missing/contradictory fields
+- signal envelopes with chronological and out-of-order timestamps
+- account / position / pending-order states
+
+The rule is:
+
+- do not let every test file invent its own random payloads
+- centralize generators so Torghut’s test semantics stay coherent
+
+### 4. Use stateful testing where Torghut is truly stateful
+
+Rule-based state machines should be introduced for:
+
+- replay pending-order management,
+- same-tick immediate fill behavior,
+- replace/cancel/flatten interactions,
+- session-context day rollover,
+- strategy-local cooldown and max-entry tracking,
+- allocator exposure accounting across multiple decisions.
+
+This is where Hypothesis materially improves Torghut over example-based tests.
+
+## High-priority target modules and required invariants
+
+### A. Quantity and execution constraints
+
+Primary files:
+
+- `services/torghut/app/trading/quantity_rules.py`
+- `services/torghut/app/trading/portfolio.py`
+
+Required property tests:
+
+- quantization is idempotent:
+  - quantizing an already quantized qty must return the same qty
+- valid increment equivalence:
+  - `qty_has_valid_increment(...)` must agree with quantization equality
+- min qty consistency:
+  - `min_qty_for_symbol(...)` must equal the chosen `qty_step`
+- sell reduction monotonicity:
+  - reducing-long sells may preserve fractional behavior
+  - short-increasing sells must never silently become fractional
+- cap monotonicity:
+  - tighter symbol/gross/strategy caps must never increase approved qty or notional
+- approved size soundness:
+  - approved qty must never exceed requested economic intent after quantization and caps
+
+### B. Quote and feature normalization
+
+Primary files:
+
+- `services/torghut/app/trading/features.py`
+- `services/torghut/app/trading/quote_quality.py`
+- `services/torghut/app/trading/session_context.py`
+
+Required property tests:
+
+- executable price soundness:
+  - crossed or non-positive quotes must not yield a valid executable state
+- top-level value precedence:
+  - explicit zero-valued top-level market fields must not silently fall back to nested fields
+- ratio/rank bounds:
+  - ranks and positive-ratio features must stay in `[0, 1]`
+- midpoint/microprice coherence:
+  - valid bid/ask inputs must yield deterministic midpoint and bounded microprice bias behavior
+- session range coherence:
+  - `session_high >= session_low`
+  - `opening_range_high >= opening_range_low`
+  - price position in range must remain in `[0, 1]` when range is non-zero
+- new-day reset correctness:
+  - premarket ticks must not establish the regular-session open anchor
+
+### C. Strategy runtime and decision engine behavior
+
+Primary files:
+
+- `services/torghut/app/trading/strategy_runtime.py`
+- `services/torghut/app/trading/research_sleeves.py`
+- `services/torghut/app/trading/decisions.py`
+
+Required property tests:
+
+- missing required features must fail closed
+- isolated strategies must not exit inventory they do not own
+- exit-only sleeves must never generate new net-long exposure through sell paths
+- cooldown enforcement must be monotonic across repeated same-strategy inputs
+- changing one guard should not cause contradictory buy and sell outputs for the same isolated owner in one evaluation
+- profitable exit floors must never approve a sell at a non-executable or loss-inducing limit when the policy forbids it
+- max-hold and session-flatten overlays must dominate normal hold logic when their trigger conditions are met
+
+### D. Replay correctness
+
+Primary file:
+
+- `services/torghut/scripts/local_intraday_tsmom_replay.py`
+
+Required property tests:
+
+- no stale pending order may survive an immediate fill for the same `(symbol, position_owner)`
+- a pending sell may not over-close beyond the owned long quantity
+- a pending buy must reserve projected exposure for subsequent sizing decisions
+- non-executable quotes must not advance last-valid executable price
+- replacing an order with a more urgent exit must remove the stale resting order
+- same input stream must produce deterministic replay output
+
+This file is the best candidate for a `RuleBasedStateMachine`.
+
+### E. Scheduler pipeline and execution routing
+
+Primary files:
+
+- `services/torghut/app/trading/scheduler/pipeline.py`
+- `services/torghut/app/trading/scheduler/simple_pipeline.py`
+- `services/torghut/app/trading/execution_adapters.py`
+
+Required property tests:
+
+- backfilled price/spread enrichment must not fabricate a valid decision from contradictory quote state
+- simulation and non-simulation routing must preserve their execution policy invariants
+- a valid price-fetch backfill must not be dropped by later quote gating when the backfilled state is executable
+- adapter payload validation must reject structurally inconsistent order payloads rather than coerce them silently
+
+## Stateful testing plan
+
+### Replay state machine
+
+Create a `RuleBasedStateMachine` around replay order flow with rules such as:
+
+- create buy intent
+- create sell intent
+- immediate-fill order
+- rest passive limit
+- replace with more aggressive exit
+- cancel pending order
+- flatten position
+- ingest invalid quote
+- ingest executable quote
+
+Invariants:
+
+- net position per `(symbol, position_owner)` never becomes impossible under the applied fills
+- pending order book contains at most one active logical order per `(symbol, position_owner, side)` where policy says replacement semantics should apply
+- realized P&L only changes on executed fills
+- fill counts and cost counts only change on actual fills
+
+### Session-context state machine
+
+Rules:
+
+- ingest premarket tick
+- ingest regular-session tick
+- advance time within opening window
+- advance beyond opening window
+- roll to next trading day
+
+Invariants:
+
+- opening anchor is never set by premarket data
+- previous close is carried only across session boundaries
+- session highs and lows remain monotonic within a day
+- quote-quality windows never exceed configured max length
+
+### Strategy/cooldown state machine
+
+Rules:
+
+- emit buy from strategy A
+- emit buy from strategy B
+- attempt same-direction reentry
+- trigger stop loss
+- trigger max hold
+- trigger session flatten
+
+Invariants:
+
+- isolated owner cooldowns remain strategy-scoped
+- stop-loss lockout is honored once triggered
+- exit-only rules cannot create inventory
+- `max_concurrent_positions` cannot be exceeded by accepted entries
+
+## Coverage strategy
+
+### Coverage toolchain
+
+Use:
+
+- `pytest`
+- `coverage.py`
+- `pytest-cov`
+
+Coverage must be **branch coverage**, not statement-only coverage.
+
+The minimum checked-in configuration should live in `services/torghut/pyproject.toml` under:
+
+- `[tool.pytest.ini_options]`
+- `[tool.coverage.run]`
+- `[tool.coverage.report]`
+- `[tool.coverage.html]`
+
+### Coverage policy
+
+Phase 1 thresholds:
+
+- service-wide branch coverage fail-under: `70`
+- changed-files coverage fail-under: `90`
+- no uncovered lines in newly added property-test target modules unless explicitly excluded
+
+Phase 2 thresholds:
+
+- service-wide branch coverage fail-under: `78`
+- changed-files coverage fail-under: `92`
+
+Phase 3 thresholds:
+
+- service-wide branch coverage fail-under: `85`
+- changed-files coverage fail-under: `95`
+
+Coverage exclusions must be minimal:
+
+- `# pragma: no cover` only for true unreachable/defensive branches
+- `# pragma: no branch` only when branch coverage would otherwise report structurally impossible control flow
+
+### Why changed-files coverage matters
+
+Torghut is too large to demand an immediate full-suite `90%+` branch number without causing fake exclusions.
+
+The correct rollout is:
+
+- ratchet overall coverage gradually,
+- enforce very high coverage on touched files now,
+- require property tests for touched files in the trading core.
+
+## Lint and static-analysis hardening
+
+### Mandatory blockers
+
+Keep these mandatory:
+
+- `ruff check app tests scripts migrations`
+- `pyright --project pyrightconfig.json`
+- `pyright --project pyrightconfig.alpha.json`
+- `pyright --project pyrightconfig.scripts.json`
+
+Add these mandatory:
+
+- `pytest` on the Torghut suite
+- branch coverage fail-under
+- changed-files coverage gate
+
+### Ruff tightening plan
+
+Current Torghut already uses Ruff, but the service should make the following explicit in checked-in config:
+
+- complexity and security scans should graduate from non-blocking signal to enforced gate for touched files
+- import-order, unused-code, and assertion-style rules should stay enforced
+- production exceptions should be documented inline, not silently ignored globally
+
+Recommended rule posture:
+
+- keep `C901` as a reported metric immediately
+- require complexity cleanup for new or heavily modified trading modules
+- fail CI when touched files add new `C901` violations
+- make `S` security rules blocking for new violations in `app/` and `scripts/`
+
+### Dead-code and stale-path control
+
+Torghut already has Vulture configuration. Keep it as part of the quality stack:
+
+- Vulture remains the `100%`-confidence dead-code pass
+- Hypothesis + coverage become the semantic regression pass
+- Ruff + Pyright remain the syntactic and typed discipline pass
+
+These are complementary, not overlapping.
+
+## CI design
+
+### Replace the current unit-test command
+
+Current:
+
+```bash
+uv run --frozen python -m unittest discover -s tests -p "test_*.py"
+```
+
+Target:
+
+```bash
+uv run --frozen pytest
+```
+
+This should happen early because pytest can already run the existing `unittest` suite.
+
+### Proposed CI stages
+
+#### Stage 1: Type and lint
+
+- `uv sync --frozen --extra dev`
+- `ruff check app tests scripts migrations`
+- all three Pyright profiles
+
+#### Stage 2: Core tests with coverage
+
+- `uv run --frozen pytest --cov --cov-branch --cov-report=term-missing --cov-fail-under=<threshold>`
+
+#### Stage 3: Property-focused shard
+
+- run a marked subset such as:
+  - `-m property`
+  - `-m stateful`
+- use the Torghut `ci_fast` or `ci_stateful` Hypothesis profile
+
+#### Stage 4: Optional nightly deep quality
+
+- Hypothesis deep profile
+- state-machine suites with larger budgets
+- mutmut on a curated module set
+- optional CrossHair checks on targeted pure helpers
+- optional Schemathesis on public Torghut endpoints
+
+## File-level implementation plan
+
+### Phase 0: Harness and non-breaking migration
+
+Files:
+
+- `services/torghut/pyproject.toml`
+- `.github/workflows/torghut-ci.yml`
+- `services/torghut/README.md`
+- `services/torghut/tests/conftest.py`
+- `services/torghut/tests/hypothesis_profiles.py`
+
+Changes:
+
+- add `pytest`, `hypothesis`, `pytest-cov`, and `coverage[toml]` to dev dependencies
+- move test execution to pytest
+- add pytest markers:
+  - `property`
+  - `stateful`
+  - `slow`
+  - `mutation`
+- add coverage configuration and initial thresholds
+
+### Phase 1: Pure-function property layer
+
+Files:
+
+- `services/torghut/app/trading/quantity_rules.py`
+- `services/torghut/app/trading/features.py`
+- `services/torghut/app/trading/quote_quality.py`
+- `services/torghut/app/trading/session_context.py`
+- `services/torghut/tests/property/test_quantity_rules_properties.py`
+- `services/torghut/tests/property/test_feature_contract_properties.py`
+- `services/torghut/tests/property/test_quote_quality_properties.py`
+- `services/torghut/tests/property/test_session_context_properties.py`
+
+### Phase 2: Stateful runtime and replay layer
+
+Files:
+
+- `services/torghut/scripts/local_intraday_tsmom_replay.py`
+- `services/torghut/app/trading/decisions.py`
+- `services/torghut/app/trading/strategy_runtime.py`
+- `services/torghut/app/trading/portfolio.py`
+- `services/torghut/tests/stateful/test_replay_state_machine.py`
+- `services/torghut/tests/stateful/test_strategy_runtime_state_machine.py`
+- `services/torghut/tests/property/test_portfolio_allocator_properties.py`
+
+### Phase 3: Scheduler and API hardening
+
+Files:
+
+- `services/torghut/app/trading/scheduler/pipeline.py`
+- `services/torghut/app/trading/execution_adapters.py`
+- `services/torghut/tests/property/test_pipeline_properties.py`
+- `services/torghut/tests/api/test_trading_status_schemathesis.py`
+
+### Phase 4: Mutation testing on curated targets
+
+Files/config:
+
+- `services/torghut/pyproject.toml`
+- optional `services/torghut/mutmut_pytest.ini`
+
+Initial mutation target set:
+
+- `app/trading/quantity_rules.py`
+- `app/trading/quote_quality.py`
+- `app/trading/features.py`
+- `app/trading/session_context.py`
+
+Do not start mutation testing on:
+
+- broad scheduler end-to-end paths,
+- whitepaper workflows,
+- large DB-heavy integration areas.
+
+Start where determinism is strongest.
+
+## Strict rules Torghut should adopt
+
+1. Every change to `app/trading/**` must add or touch tests unless the change is comment-only or pure dead-code removal.
+2. Every change to these files must include at least one property-based test:
+   - `quantity_rules.py`
+   - `features.py`
+   - `quote_quality.py`
+   - `session_context.py`
+   - `portfolio.py`
+   - `decisions.py`
+   - `strategy_runtime.py`
+   - `local_intraday_tsmom_replay.py`
+3. New branches in high-risk trading code must not be merged under coverage unless they are justified with explicit `pragma` usage.
+4. New global Ruff ignores should be treated as design regressions and require justification in the PR.
+5. New Pyright suppressions in trading-core files should be treated as design regressions and require justification in the PR.
+6. Property tests must use centralized Torghut strategies, not ad hoc random payload generation.
+7. Stateful tests must assert invariants after every rule, not only at final teardown.
+8. Mutation testing is required for curated high-risk pure modules before calling the property-testing rollout complete.
+
+## Acceptance criteria
+
+The migration is successful when all of the following are true:
+
+- Torghut CI uses `pytest` instead of `unittest discover`
+- Hypothesis is a checked-in dev dependency
+- property-test directories exist and are populated for trading-core modules
+- at least one `RuleBasedStateMachine` suite protects replay behavior
+- branch coverage is enforced in CI
+- changed-files coverage is enforced in CI
+- Ruff and all three Pyright profiles remain green
+- mutmut is documented and runs on the curated pure-module slice
+- touching high-risk trading files without test evidence is no longer possible in normal CI
+
+## Recommended commands
+
+Local fast path:
+
+```bash
+cd services/torghut
+uv sync --frozen --extra dev
+uv run --frozen pytest -m "not slow" --cov --cov-branch --cov-report=term-missing
+```
+
+Property-only:
+
+```bash
+cd services/torghut
+uv run --frozen pytest -m property
+```
+
+Stateful-only:
+
+```bash
+cd services/torghut
+uv run --frozen pytest -m stateful
+```
+
+Targeted CrossHair pass on pure helpers:
+
+```bash
+cd services/torghut
+uvx --from crosshair-tool crosshair check --analysis_kind=asserts app/trading/quantity_rules.py
+```
+
+Targeted mutation pass:
+
+```bash
+cd services/torghut
+uvx --from mutmut mutmut run app.trading.quantity_rules*
+```
+
+## Decision
+
+Torghut should standardize on:
+
+- **Hypothesis** for property-based and stateful testing
+- **pytest** as the unified test runner
+- **coverage.py + pytest-cov** for branch and diff coverage enforcement
+- **Ruff + Pyright** as non-negotiable static gates
+- **mutmut** as the follow-on mutation-quality amplifier
+- **CrossHair** only for selective pure-function contract analysis
+- **Schemathesis** only for selective HTTP contract fuzzing
+
+That is the highest-leverage, lowest-bullshit path to materially stronger Torghut quality.

--- a/docs/torghut/design-system/v6/index.md
+++ b/docs/torghut/design-system/v6/index.md
@@ -380,6 +380,7 @@ This pack is positioned as the next architecture layer above:
 46. `51-torghut-profit-reservations-schema-witness-and-simulation-slot-ledger-2026-03-19.md`
 47. `51-torghut-promotion-certificate-and-segment-firebreak-handoff-2026-03-19.md`
 48. `53-torghut-cross-plane-profit-certificate-veto-and-options-auth-isolation-2026-03-20.md`
+49. `66-torghut-property-based-testing-coverage-and-lint-hardening-2026-03-28.md`
 
 ## Why This Sequence
 
@@ -426,3 +427,6 @@ This pack is positioned as the next architecture layer above:
 - `46-torghut-probability-and-capital-mesh-for-profitable-autonomy-2026-03-16.md` and
   `47-torghut-quant-plan-merge-contract-and-handoff-implementation-2026-03-16.md` convert the historical discovery stack into
   explicit per-hypothesis and per-lane profitability execution contracts for plan-stage implementation.
+- `66-torghut-property-based-testing-coverage-and-lint-hardening-2026-03-28.md` adds the missing test-quality layer:
+  property-based invariants, state-machine replay/runtime checks, and hard branch-coverage / lint gates for the
+  service's trading core.

--- a/services/torghut/README.md
+++ b/services/torghut/README.md
@@ -71,6 +71,83 @@ The current config follows the upstream Vulture guidance for conservative cleanu
 
 After removing findings, rerun Vulture because additional dead code may become visible once the first layer is gone.
 
+## Pytest, Hypothesis, and coverage
+
+Torghut now uses `pytest` as the canonical test runner. The existing `unittest.TestCase` suite still runs under pytest,
+and new property/stateful tests live under `tests/property/` and `tests/stateful/`.
+
+Install and sync dev tooling:
+
+```bash
+cd services/torghut
+uv sync --frozen --extra dev
+```
+
+Run the full suite with branch coverage:
+
+```bash
+cd services/torghut
+uv run --frozen pytest --cov --cov-branch --cov-report=term-missing --cov-report=xml
+```
+
+Run only property-based tests:
+
+```bash
+cd services/torghut
+uv run --frozen pytest -m property
+```
+
+Run only state-machine tests:
+
+```bash
+cd services/torghut
+uv run --frozen pytest -m stateful
+```
+
+Hypothesis profiles are loaded from `tests/hypothesis_profiles.py`.
+
+- default local profile: `local_debug`
+- CI profile: `ci_fast`
+- deeper state-machine profile: `ci_stateful`
+- nightly/deep profile: `nightly_deep`
+
+Override locally with:
+
+```bash
+cd services/torghut
+TORGHUT_HYPOTHESIS_PROFILE=ci_stateful uv run --frozen pytest -m stateful
+```
+
+Validate changed-file coverage locally after generating `coverage.xml`:
+
+```bash
+cd services/torghut
+uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90
+```
+
+Curated mutation-testing entrypoint:
+
+```bash
+cd services/torghut
+uvx --from mutmut mutmut run app.trading.quantity_rules*
+```
+
+Curated CrossHair check for pure helpers:
+
+```bash
+cd services/torghut
+uvx --from crosshair-tool crosshair check --analysis_kind=asserts app/trading/quantity_rules.py
+```
+
+Testing rules for the trading core:
+
+- changes to `app/trading/**` should add or modify tests unless they are comment-only or dead-code removal
+- changes to `quantity_rules.py`, `features.py`, `quote_quality.py`, `session_context.py`, `portfolio.py`,
+  `decisions.py`, `strategy_runtime.py`, or `scripts/local_intraday_tsmom_replay.py` should include at least one
+  property-based or stateful test
+- new global Ruff ignores or Pyright suppressions in trading-core files require explicit justification
+- new property tests should use the centralized strategies in `tests/strategies/` instead of ad hoc payload builders
+
 ## Hypothesis readiness and dependency quorum
 
 - Hypothesis manifests live under `config/trading/hypotheses/` and are loaded at startup from

--- a/services/torghut/pyproject.toml
+++ b/services/torghut/pyproject.toml
@@ -28,13 +28,71 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pyright>=1.1.389,<2.0", "ruff>=0.9.0,<1.0"]
+dev = [
+  "coverage[toml]>=7.10.0,<8.0",
+  "crosshair-tool>=0.0.95,<1.0",
+  "hypothesis>=6.151.0,<7.0",
+  "mutmut>=3.3.1,<4.0",
+  "pyright>=1.1.389,<2.0",
+  "pytest>=8.4.0,<9.0",
+  "pytest-cov>=7.0.0,<8.0",
+  "ruff>=0.9.0,<1.0",
+]
+
+[tool.pytest.ini_options]
+addopts = "-ra --strict-markers"
+python_files = ["test_*.py"]
+python_functions = ["test_*"]
+testpaths = ["tests"]
+markers = [
+  "property: property-based tests backed by Hypothesis",
+  "stateful: state-machine or sequence-based tests",
+  "slow: longer-running checks reserved for selective execution",
+  "mutation: mutation-testing focused suites or helpers",
+]
+
+[tool.coverage.run]
+branch = true
+source = ["app", "scripts"]
+omit = ["tests/*", "migrations/*"]
+
+[tool.coverage.report]
+fail_under = 70
+show_missing = true
+skip_covered = false
+precision = 2
+exclude_also = [
+  "pragma: no cover",
+  "if TYPE_CHECKING:",
+  "raise NotImplementedError",
+]
+
+[tool.coverage.xml]
+output = "coverage.xml"
 
 [tool.vulture]
 paths = ["app", "scripts"]
 exclude = ["*/tests/*", "*/.venv/*", "*/migrations/*"]
 min_confidence = 100
 sort_by_size = true
+
+[tool.mutmut]
+paths_to_mutate = [
+  "app/trading/quantity_rules.py",
+  "app/trading/features.py",
+  "app/trading/quote_quality.py",
+  "app/trading/session_context.py",
+]
+pytest_add_cli_args_test_selection = [
+  "tests/property",
+  "tests/stateful",
+  "tests/test_feature_contract_v3.py",
+  "tests/test_local_intraday_tsmom_replay.py",
+  "tests/test_portfolio_sizing.py",
+  "tests/test_quote_quality.py",
+  "tests/test_session_context.py",
+]
+mutate_only_covered_lines = true
 
 [tool.hatch.build.targets.wheel]
 packages = ["app"]

--- a/services/torghut/scripts/check_diff_coverage.py
+++ b/services/torghut/scripts/check_diff_coverage.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+"""Fail when changed Torghut Python source lines are under the required coverage threshold."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import os
+import re
+import subprocess
+import sys
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from pathlib import Path
+
+SERVICE_PREFIX = 'services/torghut/'
+TRACKED_PREFIXES = (
+    'services/torghut/app/',
+    'services/torghut/scripts/',
+)
+_HUNK_RE = re.compile(r'^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@')
+
+
+@dataclass(frozen=True)
+class FileDiffCoverage:
+    filename: str
+    executable_changed_lines: int
+    covered_lines: int
+    missing_lines: tuple[int, ...]
+    missing_from_coverage: bool = False
+
+    @property
+    def coverage_ratio(self) -> float:
+        if self.executable_changed_lines <= 0:
+            return 1.0
+        return self.covered_lines / self.executable_changed_lines
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description='Validate changed-file coverage for Torghut Python source files.',
+    )
+    parser.add_argument('--coverage-xml', default='coverage.xml')
+    parser.add_argument('--threshold', type=float, default=90.0)
+    parser.add_argument('--base-ref', default='')
+    return parser.parse_args()
+
+
+def _repo_root(start: Path) -> Path:
+    current = start.resolve()
+    for candidate in (current, *current.parents):
+        if (candidate / '.git').exists():
+            return candidate
+    raise RuntimeError('repo_root_not_found')
+
+
+def _git(cwd: Path, *args: str) -> str:
+    result = subprocess.run(
+        ['git', *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _git_optional(cwd: Path, *args: str) -> str | None:
+    try:
+        return _git(cwd, *args)
+    except subprocess.CalledProcessError:
+        return None
+
+
+def _resolve_base_spec(explicit_base_ref: str) -> str | None:
+    if explicit_base_ref.strip():
+        return explicit_base_ref.strip()
+    github_base_ref = os.environ.get('GITHUB_BASE_REF', '').strip()
+    if github_base_ref:
+        return f'origin/{github_base_ref}'
+    return None
+
+
+def _resolve_diff_base(repo_root: Path, explicit_base_ref: str) -> str | None:
+    base_spec = _resolve_base_spec(explicit_base_ref)
+    if base_spec is not None:
+        return _git_optional(repo_root, 'merge-base', base_spec, 'HEAD')
+    for fallback_ref in ('origin/main', 'main'):
+        merge_base = _git_optional(repo_root, 'merge-base', fallback_ref, 'HEAD')
+        if merge_base is not None:
+            return merge_base
+    return _git_optional(repo_root, 'rev-parse', 'HEAD^')
+
+
+def _parse_changed_python_lines(diff_text: str) -> dict[str, set[int]]:
+    changed_lines: dict[str, set[int]] = {}
+    current_filename: str | None = None
+
+    for line in diff_text.splitlines():
+        if line.startswith('+++ b/'):
+            candidate = line[len('+++ b/') :].strip()
+            current_filename = None
+            if not candidate.endswith('.py'):
+                continue
+            if not candidate.startswith(TRACKED_PREFIXES):
+                continue
+            current_filename = candidate[len(SERVICE_PREFIX) :]
+            changed_lines.setdefault(current_filename, set())
+            continue
+        if current_filename is None:
+            continue
+        match = _HUNK_RE.match(line)
+        if not match:
+            continue
+        start_line = int(match.group(1))
+        count = int(match.group(2) or '1')
+        if count <= 0:
+            continue
+        changed_lines[current_filename].update(range(start_line, start_line + count))
+    return changed_lines
+
+
+def _list_untracked_python_files(repo_root: Path) -> tuple[str, ...]:
+    output = _git_optional(
+        repo_root,
+        'ls-files',
+        '--others',
+        '--exclude-standard',
+        '--',
+        *TRACKED_PREFIXES,
+    )
+    if not output:
+        return ()
+    files: list[str] = []
+    for candidate in output.splitlines():
+        normalized = candidate.strip().replace('\\', '/')
+        if not normalized.endswith('.py'):
+            continue
+        if not normalized.startswith(TRACKED_PREFIXES):
+            continue
+        files.append(normalized[len(SERVICE_PREFIX) :])
+    return tuple(sorted(files))
+
+
+def _executable_source_lines(path: Path) -> set[int]:
+    tree = ast.parse(path.read_text(encoding='utf-8'))
+    line_numbers: set[int] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.stmt) and hasattr(node, 'lineno'):
+            if isinstance(node, ast.Expr) and isinstance(node.value, ast.Constant) and isinstance(node.value.value, str):
+                continue
+            line_numbers.add(node.lineno)
+    return line_numbers
+
+
+def _include_untracked_python_files(
+    *,
+    changed_lines: dict[str, set[int]],
+    coverage_index: dict[str, dict[int, int]],
+    service_root: Path,
+    repo_root: Path,
+) -> dict[str, set[int]]:
+    combined = {filename: set(lines) for filename, lines in changed_lines.items()}
+    for filename in _list_untracked_python_files(repo_root):
+        if filename in coverage_index:
+            combined.setdefault(filename, set()).update(coverage_index[filename])
+            continue
+        combined.setdefault(filename, set()).update(
+            _executable_source_lines(service_root / filename)
+        )
+    return combined
+
+
+def _load_coverage_index(xml_path: Path) -> dict[str, dict[int, int]]:
+    tree = ET.parse(xml_path)
+    root = tree.getroot()
+    service_root = xml_path.resolve().parent
+    coverage_index: dict[str, dict[int, int]] = {}
+    for package_node in root.findall('.//package'):
+        package_name = (package_node.get('name') or '').strip()
+        for class_node in package_node.findall('./classes/class'):
+            filename = class_node.get('filename')
+            if not filename:
+                continue
+            normalized = filename.replace('\\', '/').lstrip('./')
+            if '/' not in normalized and package_name in {'app', 'scripts'}:
+                normalized = f'{package_name}/{normalized}'
+            elif '/' not in normalized and package_name == '.':
+                script_path = service_root / 'scripts' / normalized
+                app_path = service_root / 'app' / normalized
+                if script_path.exists() and not app_path.exists():
+                    normalized = f'scripts/{normalized}'
+                elif app_path.exists() and not script_path.exists():
+                    normalized = f'app/{normalized}'
+            line_hits = coverage_index.setdefault(normalized, {})
+            for line_node in class_node.findall('./lines/line'):
+                number = line_node.get('number')
+                hits = line_node.get('hits')
+                if number is None or hits is None:
+                    continue
+                line_hits[int(number)] = int(hits)
+    return coverage_index
+
+
+def summarize_changed_coverage(
+    *,
+    changed_lines: dict[str, set[int]],
+    coverage_index: dict[str, dict[int, int]],
+) -> list[FileDiffCoverage]:
+    summary: list[FileDiffCoverage] = []
+    for filename in sorted(changed_lines):
+        changed = sorted(changed_lines[filename])
+        line_hits = coverage_index.get(filename)
+        if line_hits is None:
+            summary.append(
+                FileDiffCoverage(
+                    filename=filename,
+                    executable_changed_lines=len(changed),
+                    covered_lines=0,
+                    missing_lines=tuple(changed),
+                    missing_from_coverage=True,
+                )
+            )
+            continue
+        executable_changed = sorted(line for line in changed if line in line_hits)
+        if not executable_changed:
+            continue
+        missing = tuple(line for line in executable_changed if line_hits.get(line, 0) <= 0)
+        summary.append(
+            FileDiffCoverage(
+                filename=filename,
+                executable_changed_lines=len(executable_changed),
+                covered_lines=len(executable_changed) - len(missing),
+                missing_lines=missing,
+            )
+        )
+    return summary
+
+
+def _format_summary(summary: list[FileDiffCoverage]) -> str:
+    lines: list[str] = []
+    for item in summary:
+        coverage_pct = item.coverage_ratio * 100
+        suffix = ' missing-from-coverage' if item.missing_from_coverage else ''
+        lines.append(
+            f'{item.filename}: {item.covered_lines}/{item.executable_changed_lines} '
+            f'lines covered ({coverage_pct:.2f}%){suffix}'
+        )
+        if item.missing_lines:
+            lines.append(f'  missing lines: {", ".join(str(line) for line in item.missing_lines)}')
+    return '\n'.join(lines)
+
+
+def main() -> int:
+    args = _parse_args()
+    service_root = Path(__file__).resolve().parents[1]
+    repo_root = _repo_root(service_root)
+    base_commit = _resolve_diff_base(repo_root, args.base_ref)
+    if base_commit is None:
+        print('diff coverage skipped: no base commit available')
+        return 0
+
+    diff_text = _git(
+        repo_root,
+        'diff',
+        '--unified=0',
+        base_commit,
+        '--',
+        'services/torghut/app',
+        'services/torghut/scripts',
+    )
+    changed_lines = _parse_changed_python_lines(diff_text)
+
+    coverage_index = _load_coverage_index(Path(args.coverage_xml))
+    changed_with_untracked = _include_untracked_python_files(
+        changed_lines=changed_lines,
+        coverage_index=coverage_index,
+        service_root=service_root,
+        repo_root=repo_root,
+    )
+    if not changed_with_untracked:
+        print('diff coverage passed: no changed Torghut Python source lines')
+        return 0
+    summary = summarize_changed_coverage(
+        changed_lines=changed_with_untracked,
+        coverage_index=coverage_index,
+    )
+    if not summary:
+        print('diff coverage passed: no changed executable Torghut Python source lines')
+        return 0
+
+    total_executable = sum(item.executable_changed_lines for item in summary)
+    total_covered = sum(item.covered_lines for item in summary)
+    coverage_pct = (total_covered / total_executable) * 100 if total_executable else 100.0
+    print(_format_summary(summary))
+    print(f'total changed-line coverage: {total_covered}/{total_executable} ({coverage_pct:.2f}%)')
+
+    missing_files = [item.filename for item in summary if item.missing_from_coverage]
+    if missing_files:
+        print(
+            'diff coverage failed: changed files missing from coverage.xml: '
+            + ', '.join(missing_files),
+            file=sys.stderr,
+        )
+        return 1
+    if coverage_pct < args.threshold:
+        print(
+            f'diff coverage failed: {coverage_pct:.2f}% below threshold {args.threshold:.2f}%',
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/services/torghut/tests/conftest.py
+++ b/services/torghut/tests/conftest.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from tests.hypothesis_profiles import default_profile_name, load_default_hypothesis_profile
+
+_ACTIVE_HYPOTHESIS_PROFILE = load_default_hypothesis_profile()
+
+
+def pytest_report_header() -> list[str]:
+    return [f'torghut hypothesis profile: {_ACTIVE_HYPOTHESIS_PROFILE or default_profile_name()}']

--- a/services/torghut/tests/hypothesis_profiles.py
+++ b/services/torghut/tests/hypothesis_profiles.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import os
+
+from hypothesis import HealthCheck, Verbosity, settings
+
+_REGISTERED = False
+
+
+def register_hypothesis_profiles() -> None:
+    global _REGISTERED
+    if _REGISTERED:
+        return
+    settings.register_profile(
+        'ci_fast',
+        max_examples=50,
+        deadline=1000,
+        suppress_health_check=[HealthCheck.function_scoped_fixture],
+    )
+    settings.register_profile(
+        'ci_stateful',
+        max_examples=40,
+        stateful_step_count=25,
+        deadline=1000,
+        suppress_health_check=[HealthCheck.function_scoped_fixture],
+    )
+    settings.register_profile(
+        'nightly_deep',
+        max_examples=200,
+        stateful_step_count=75,
+        deadline=None,
+        suppress_health_check=[HealthCheck.function_scoped_fixture],
+    )
+    settings.register_profile(
+        'local_debug',
+        max_examples=75,
+        stateful_step_count=35,
+        deadline=1000,
+        print_blob=True,
+        verbosity=Verbosity.verbose,
+        suppress_health_check=[HealthCheck.function_scoped_fixture],
+    )
+    _REGISTERED = True
+
+
+def default_profile_name() -> str:
+    explicit = os.environ.get('TORGHUT_HYPOTHESIS_PROFILE')
+    if explicit:
+        return explicit
+    if os.environ.get('GITHUB_ACTIONS') == 'true' or os.environ.get('CI') == 'true':
+        return 'ci_fast'
+    return 'local_debug'
+
+
+def load_default_hypothesis_profile() -> str:
+    register_hypothesis_profiles()
+    profile_name = default_profile_name()
+    settings.load_profile(profile_name)
+    return profile_name

--- a/services/torghut/tests/property/test_feature_contract_properties.py
+++ b/services/torghut/tests/property/test_feature_contract_properties.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+from hypothesis import given
+
+from app.trading.features import normalize_feature_vector_v3
+from tests.strategies.signals import feature_contract_signals, valid_quote_signals
+
+pytestmark = pytest.mark.property
+
+
+@given(signal=valid_quote_signals())
+def test_normalization_uses_top_level_midpoint_when_trade_price_missing(signal) -> None:
+    payload = dict(signal.payload)
+    payload.pop('price', None)
+    payload['vwap_session'] = Decimal('999.0')
+    payload['vwap_w5m'] = Decimal('998.0')
+    rewritten = signal.model_copy(update={'payload': payload})
+
+    feature_vector = normalize_feature_vector_v3(rewritten)
+    expected_midpoint = (payload['imbalance_bid_px'] + payload['imbalance_ask_px']) / 2
+
+    assert feature_vector.values['price'] == expected_midpoint
+
+
+@given(signal=feature_contract_signals())
+def test_normalization_preserves_rank_and_ratio_bounds(signal) -> None:
+    feature_vector = normalize_feature_vector_v3(signal)
+
+    assert Decimal('0') <= feature_vector.values['recent_quote_invalid_ratio'] <= Decimal('1')
+    assert Decimal('0') <= feature_vector.values['cross_section_prev_session_close_rank'] <= Decimal('1')
+    assert Decimal('0') <= feature_vector.values['cross_section_positive_session_open_ratio'] <= Decimal('1')
+
+
+@given(signal=valid_quote_signals())
+def test_zero_valued_top_level_fields_win_over_nested_fallback(signal) -> None:
+    payload = dict(signal.payload)
+    payload.update(
+        {
+            'spread': Decimal('0'),
+            'imbalance_spread': Decimal('0'),
+            'imbalance_bid_sz': Decimal('0'),
+            'imbalance_ask_sz': Decimal('10'),
+            'imbalance': {
+                'spread': Decimal('0.5'),
+                'bid_px': Decimal('98'),
+                'ask_px': Decimal('102'),
+                'bid_sz': Decimal('5'),
+                'ask_sz': Decimal('5'),
+            },
+        }
+    )
+    rewritten = signal.model_copy(update={'payload': payload})
+
+    feature_vector = normalize_feature_vector_v3(rewritten)
+
+    assert feature_vector.values['spread'] == Decimal('0')
+    assert feature_vector.values['imbalance_spread'] == Decimal('0')
+    assert feature_vector.values['imbalance_bid_sz'] == Decimal('0')
+    assert feature_vector.values['imbalance_ask_sz'] == Decimal('10')

--- a/services/torghut/tests/property/test_portfolio_allocator_properties.py
+++ b/services/torghut/tests/property/test_portfolio_allocator_properties.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from app.trading.models import StrategyDecision
+from app.trading.portfolio import AllocationConfig, PortfolioAllocator
+
+pytestmark = pytest.mark.property
+
+
+def _allocator(symbol_cap_pct: Decimal) -> PortfolioAllocator:
+    return PortfolioAllocator(
+        AllocationConfig(
+            enabled=True,
+            default_regime='neutral',
+            default_budget_multiplier=Decimal('1.0'),
+            default_capacity_multiplier=Decimal('1.0'),
+            min_multiplier=Decimal('0'),
+            max_multiplier=Decimal('2'),
+            max_symbol_pct_equity=symbol_cap_pct,
+            max_symbol_notional=None,
+            max_gross_exposure=None,
+            strategy_notional_caps={},
+            symbol_notional_caps={},
+            correlation_group_caps={},
+            symbol_correlation_groups={},
+            regime_budget_multipliers={},
+            regime_capacity_multipliers={},
+        )
+    )
+
+
+def _decision(price: Decimal, qty: Decimal) -> StrategyDecision:
+    return StrategyDecision(
+        strategy_id='s1',
+        symbol='AAPL',
+        event_ts=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        timeframe='1Min',
+        action='buy',
+        qty=qty,
+        order_type='market',
+        time_in_force='day',
+        params={
+            'price': price,
+            'fragility_state': 'normal',
+            'spread_acceleration': Decimal('0'),
+            'liquidity_compression': Decimal('0'),
+            'crowding_proxy': Decimal('0'),
+            'correlation_concentration': Decimal('0'),
+        },
+    )
+
+
+@given(
+    price=st.decimals(
+        min_value=Decimal('10'),
+        max_value=Decimal('1000'),
+        allow_nan=False,
+        allow_infinity=False,
+        places=2,
+    ),
+    qty=st.integers(min_value=1, max_value=500).map(Decimal),
+    loose_cap=st.decimals(
+        min_value=Decimal('0.05'),
+        max_value=Decimal('0.50'),
+        allow_nan=False,
+        allow_infinity=False,
+        places=2,
+    ),
+    tight_cap=st.decimals(
+        min_value=Decimal('0.01'),
+        max_value=Decimal('0.25'),
+        allow_nan=False,
+        allow_infinity=False,
+        places=2,
+    ),
+)
+def test_tighter_symbol_cap_never_increases_allocated_qty(
+    price: Decimal,
+    qty: Decimal,
+    loose_cap: Decimal,
+    tight_cap: Decimal,
+) -> None:
+    assume_tight = tight_cap <= loose_cap
+    if not assume_tight:
+        tight_cap, loose_cap = loose_cap, tight_cap
+
+    decision = _decision(price, qty)
+    account = {'equity': '10000', 'buying_power': '10000', 'cash': '10000'}
+    loose_result = _allocator(loose_cap).allocate(
+        [decision],
+        account=account,
+        positions=[],
+        regime_label='neutral',
+    )[0]
+    tight_result = _allocator(tight_cap).allocate(
+        [decision],
+        account=account,
+        positions=[],
+        regime_label='neutral',
+    )[0]
+
+    assert tight_result.decision.qty <= loose_result.decision.qty

--- a/services/torghut/tests/property/test_quantity_rules_properties.py
+++ b/services/torghut/tests/property/test_quantity_rules_properties.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+from hypothesis import assume, given
+from hypothesis import strategies as st
+
+from app.trading.quantity_rules import (
+    fractional_equities_enabled_for_trade,
+    min_qty_for_symbol,
+    qty_has_valid_increment,
+    qty_step_for_symbol,
+    quantize_qty_for_symbol,
+    resolve_quantity_resolution,
+)
+from tests.strategies.trading import position_quantities, positive_quantities, trading_symbols
+
+pytestmark = pytest.mark.property
+
+
+@given(
+    symbol=trading_symbols(include_crypto=True),
+    qty=st.decimals(
+        min_value=Decimal('0'),
+        max_value=Decimal('1000'),
+        allow_nan=False,
+        allow_infinity=False,
+        places=8,
+    ),
+    fractional_enabled=st.booleans(),
+)
+def test_quantize_qty_for_symbol_is_idempotent(
+    symbol: str,
+    qty: Decimal,
+    fractional_enabled: bool,
+) -> None:
+    first = quantize_qty_for_symbol(
+        symbol,
+        qty,
+        fractional_equities_enabled=fractional_enabled,
+    )
+    second = quantize_qty_for_symbol(
+        symbol,
+        first,
+        fractional_equities_enabled=fractional_enabled,
+    )
+
+    assert first == second
+
+
+@given(
+    symbol=trading_symbols(include_crypto=True),
+    qty=st.decimals(
+        min_value=Decimal('0'),
+        max_value=Decimal('1000'),
+        allow_nan=False,
+        allow_infinity=False,
+        places=8,
+    ),
+    fractional_enabled=st.booleans(),
+)
+def test_qty_has_valid_increment_matches_quantized_equality(
+    symbol: str,
+    qty: Decimal,
+    fractional_enabled: bool,
+) -> None:
+    quantized = quantize_qty_for_symbol(
+        symbol,
+        qty,
+        fractional_equities_enabled=fractional_enabled,
+    )
+
+    assert qty_has_valid_increment(
+        symbol,
+        qty,
+        fractional_equities_enabled=fractional_enabled,
+    ) == (quantized == qty)
+
+
+@given(symbol=trading_symbols(include_crypto=True), fractional_enabled=st.booleans())
+def test_min_qty_matches_qty_step(symbol: str, fractional_enabled: bool) -> None:
+    assert min_qty_for_symbol(
+        symbol,
+        fractional_equities_enabled=fractional_enabled,
+    ) == qty_step_for_symbol(
+        symbol,
+        fractional_equities_enabled=fractional_enabled,
+    )
+
+
+@given(
+    position_qty=position_quantities(),
+    requested_qty=positive_quantities(),
+    allow_shorts=st.booleans(),
+)
+def test_short_increasing_sell_never_becomes_fractional(
+    position_qty: Decimal,
+    requested_qty: Decimal,
+    allow_shorts: bool,
+) -> None:
+    assume(position_qty <= 0 or requested_qty > position_qty)
+
+    resolution = resolve_quantity_resolution(
+        'AAPL',
+        action='sell',
+        global_enabled=True,
+        allow_shorts=allow_shorts,
+        position_qty=position_qty,
+        requested_qty=requested_qty,
+    )
+
+    assert resolution.short_increasing is True
+    assert resolution.fractional_allowed is False
+    assert resolution.qty_step == Decimal('1')
+
+
+@given(position_qty=positive_quantities(), requested_qty=positive_quantities())
+def test_reducing_long_sell_keeps_fractional_behavior(
+    position_qty: Decimal,
+    requested_qty: Decimal,
+) -> None:
+    assume(requested_qty <= position_qty)
+
+    resolution = resolve_quantity_resolution(
+        'AAPL',
+        action='sell',
+        global_enabled=True,
+        allow_shorts=False,
+        position_qty=position_qty,
+        requested_qty=requested_qty,
+    )
+
+    assert resolution.short_increasing is False
+    assert resolution.fractional_allowed is True
+    assert fractional_equities_enabled_for_trade(
+        action='sell',
+        global_enabled=True,
+        allow_shorts=False,
+        position_qty=position_qty,
+        requested_qty=requested_qty,
+    )

--- a/services/torghut/tests/property/test_quote_quality_properties.py
+++ b/services/torghut/tests/property/test_quote_quality_properties.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from app.trading.models import SignalEnvelope
+from app.trading.quote_quality import assess_signal_quote_quality
+from tests.strategies.signals import crossed_quote_signals, valid_quote_signals
+from tests.strategies.trading import positive_prices
+
+pytestmark = pytest.mark.property
+
+
+@given(signal=valid_quote_signals())
+def test_tight_positive_quotes_remain_executable(signal: SignalEnvelope) -> None:
+    previous_price = Decimal(signal.payload['price'])
+
+    status = assess_signal_quote_quality(
+        signal=signal,
+        previous_price=previous_price,
+    )
+
+    assert status.valid is True
+    assert status.reason is None
+    assert status.spread_bps is not None
+    assert status.spread_bps >= 0
+
+
+@given(signal=crossed_quote_signals())
+def test_crossed_quotes_always_reject(signal: SignalEnvelope) -> None:
+    status = assess_signal_quote_quality(
+        signal=signal,
+        previous_price=Decimal('100'),
+    )
+
+    assert status.valid is False
+    assert status.reason == 'crossed_quote'
+
+
+@given(ask=positive_prices())
+def test_zero_top_level_bid_does_not_fall_back_to_nested_bid(ask: Decimal) -> None:
+    signal = SignalEnvelope(
+        event_ts=datetime(2026, 3, 27, 17, 30, 24, tzinfo=timezone.utc),
+        symbol='META',
+        timeframe='1Sec',
+        seq=14,
+        payload={
+            'price': ask,
+            'imbalance_bid_px': Decimal('0'),
+            'imbalance_ask_px': ask,
+            'imbalance': {
+                'bid_px': ask - Decimal('0.01'),
+                'ask_px': ask,
+            },
+        },
+    )
+
+    status = assess_signal_quote_quality(
+        signal=signal,
+        previous_price=ask,
+    )
+
+    assert status.valid is False
+    assert status.reason == 'non_positive_bid'
+
+
+@given(
+    bid=st.decimals(
+        min_value=Decimal('-10'),
+        max_value=Decimal('0'),
+        allow_nan=False,
+        allow_infinity=False,
+        places=4,
+    ),
+    ask=positive_prices(),
+)
+def test_non_positive_bid_is_never_executable(bid: Decimal, ask: Decimal) -> None:
+    signal = SignalEnvelope(
+        event_ts=datetime(2026, 3, 27, 17, 30, 24, tzinfo=timezone.utc),
+        symbol='META',
+        timeframe='1Sec',
+        seq=99,
+        payload={
+            'price': ask,
+            'imbalance_bid_px': bid,
+            'imbalance_ask_px': ask,
+            'spread': ask - bid,
+        },
+    )
+
+    status = assess_signal_quote_quality(
+        signal=signal,
+        previous_price=ask,
+    )
+
+    assert status.valid is False
+    assert status.reason == 'non_positive_bid'

--- a/services/torghut/tests/property/test_session_context_properties.py
+++ b/services/torghut/tests/property/test_session_context_properties.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+
+import pytest
+from hypothesis import given
+
+from app.trading.models import SignalEnvelope
+from app.trading.session_context import SessionContextTracker
+from tests.strategies.signals import regular_session_signal_series
+from tests.strategies.trading import positive_prices
+
+pytestmark = pytest.mark.property
+
+
+def _session_signal(
+    *,
+    event_ts: datetime,
+    price: Decimal,
+    spread: Decimal,
+    bid_sz: Decimal,
+    ask_sz: Decimal,
+) -> SignalEnvelope:
+    bid = price - (spread / 2)
+    ask = price + (spread / 2)
+    return SignalEnvelope(
+        event_ts=event_ts,
+        symbol='META',
+        timeframe='1Sec',
+        seq=1,
+        source='ta',
+        payload={
+            'price': price,
+            'spread': ask - bid,
+            'imbalance_bid_px': bid,
+            'imbalance_ask_px': ask,
+            'imbalance_bid_sz': bid_sz,
+            'imbalance_ask_sz': ask_sz,
+            'vwap_w5m': price,
+        },
+    )
+
+
+@given(previous_close=positive_prices(), premarket_price=positive_prices())
+def test_premarket_tick_never_sets_regular_session_open_anchor(
+    previous_close: Decimal,
+    premarket_price: Decimal,
+) -> None:
+    tracker = SessionContextTracker()
+    tracker.enrich_signal_payload(
+        _session_signal(
+            event_ts=datetime(2026, 3, 24, 19, 59, 0, tzinfo=timezone.utc),
+            price=previous_close,
+            spread=Decimal('0.02'),
+            bid_sz=Decimal('4000'),
+            ask_sz=Decimal('3800'),
+        )
+    )
+    premarket_payload = tracker.enrich_signal_payload(
+        _session_signal(
+            event_ts=datetime(2026, 3, 25, 12, 45, 0, tzinfo=timezone.utc),
+            price=premarket_price,
+            spread=Decimal('0.02'),
+            bid_sz=Decimal('3900'),
+            ask_sz=Decimal('4200'),
+        )
+    )
+
+    assert 'session_open_price' not in premarket_payload
+    assert premarket_payload['prev_session_close_price'] == previous_close
+
+
+@given(signals=regular_session_signal_series())
+def test_session_context_series_preserves_range_and_ratio_invariants(signals: list[SignalEnvelope]) -> None:
+    tracker = SessionContextTracker()
+
+    for signal in signals:
+        payload = tracker.enrich_signal_payload(signal)
+        assert payload['session_high_price'] >= payload['session_low_price']
+        assert payload['opening_range_high'] >= payload['opening_range_low']
+        if 'price_position_in_session_range' in payload:
+            assert Decimal('0') <= payload['price_position_in_session_range'] <= Decimal('1')
+        assert payload['session_minutes_elapsed'] >= 0

--- a/services/torghut/tests/stateful/test_replay_state_machine.py
+++ b/services/torghut/tests/stateful/test_replay_state_machine.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+
+import pytest
+from hypothesis import settings
+from hypothesis.stateful import RuleBasedStateMachine, invariant, rule, run_state_machine_as_test
+
+from app.trading.costs import TransactionCostModel
+from app.trading.models import StrategyDecision
+from scripts.local_intraday_tsmom_replay import (
+    _apply_filled_decision,
+    _decision_position_owner,
+    _positions_payload,
+    _reconcile_pending_order_before_immediate_fill,
+)
+from tests.strategies.replay import pending_order, position_state, replay_signals
+from tests.strategies.trading import positive_prices, positive_quantities, strategy_ids
+
+pytestmark = [pytest.mark.property, pytest.mark.stateful]
+
+
+class ReplayStateMachine(RuleBasedStateMachine):
+    def __init__(self) -> None:
+        super().__init__()
+        self.positions = {}
+        self.pending_orders = {}
+        self.last_prices = {'META': Decimal('100')}
+        self.day_bucket = {
+            'decision_count': 0,
+            'filled_count': 0,
+            'gross_pnl': Decimal('0'),
+            'net_pnl': Decimal('0'),
+            'cost_total': Decimal('0'),
+            'wins': 0,
+            'losses': 0,
+            'closed_trades': [],
+        }
+        self.cash = Decimal('100000')
+        self.closed_trades = []
+
+    @staticmethod
+    def _runtime_params() -> dict[str, object]:
+        return {'strategy_runtime': {'position_isolation_mode': 'per_strategy'}}
+
+    @rule(
+        strategy_id=strategy_ids(),
+        qty=positive_quantities(),
+        entry_price=positive_prices(),
+    )
+    def seed_long_position(self, strategy_id: str, qty: Decimal, entry_price: Decimal) -> None:
+        self.positions[('META', strategy_id)] = position_state(
+            strategy_id=strategy_id,
+            qty=qty,
+            entry_price=entry_price,
+            event_ts=datetime(2026, 3, 27, 17, 30, tzinfo=timezone.utc),
+        )
+        self.last_prices['META'] = entry_price
+
+    @rule(
+        strategy_id=strategy_ids(),
+        qty=positive_quantities(),
+        limit_price=positive_prices(),
+        signal=replay_signals(symbol='META'),
+    )
+    def queue_pending_buy(
+        self,
+        strategy_id: str,
+        qty: Decimal,
+        limit_price: Decimal,
+        signal,
+    ) -> None:
+        decision = StrategyDecision(
+            strategy_id=strategy_id,
+            symbol='META',
+            event_ts=signal.event_ts,
+            timeframe='1Sec',
+            action='buy',
+            qty=qty,
+            order_type='limit',
+            time_in_force='day',
+            limit_price=limit_price,
+            rationale='hypothesis_pending_buy',
+            params=self._runtime_params(),
+        )
+        self.pending_orders[('META', strategy_id)] = pending_order(
+            decision=decision,
+            signal=signal,
+        )
+
+    @rule(
+        strategy_id=strategy_ids(),
+        qty=positive_quantities(),
+        limit_price=positive_prices(),
+        signal=replay_signals(symbol='META'),
+    )
+    def queue_pending_sell(
+        self,
+        strategy_id: str,
+        qty: Decimal,
+        limit_price: Decimal,
+        signal,
+    ) -> None:
+        existing = self.positions.get(('META', strategy_id))
+        if existing is None:
+            self.positions[('META', strategy_id)] = position_state(
+                strategy_id=strategy_id,
+                qty=qty,
+                entry_price=limit_price,
+                event_ts=datetime(2026, 3, 27, 17, 30, tzinfo=timezone.utc),
+            )
+        decision = StrategyDecision(
+            strategy_id=strategy_id,
+            symbol='META',
+            event_ts=signal.event_ts,
+            timeframe='1Sec',
+            action='sell',
+            qty=qty,
+            order_type='limit',
+            time_in_force='day',
+            limit_price=limit_price,
+            rationale='hypothesis_pending_sell',
+            params=self._runtime_params(),
+        )
+        self.pending_orders[('META', strategy_id)] = pending_order(
+            decision=decision,
+            signal=signal,
+        )
+
+    @rule(
+        strategy_id=strategy_ids(),
+        qty=positive_quantities(),
+        fill_price=positive_prices(),
+        signal=replay_signals(symbol='META'),
+    )
+    def immediate_fill_buy_clears_same_owner_pending_order(
+        self,
+        strategy_id: str,
+        qty: Decimal,
+        fill_price: Decimal,
+        signal,
+    ) -> None:
+        decision = StrategyDecision(
+            strategy_id=strategy_id,
+            symbol='META',
+            event_ts=signal.event_ts,
+            timeframe='1Sec',
+            action='buy',
+            qty=qty,
+            order_type='market',
+            time_in_force='day',
+            rationale='hypothesis_immediate_fill',
+            params=self._runtime_params(),
+        )
+        self.pending_orders.setdefault(
+            ('META', strategy_id),
+            pending_order(
+                decision=StrategyDecision(
+                    strategy_id=strategy_id,
+                    symbol='META',
+                    event_ts=signal.event_ts,
+                    timeframe='1Sec',
+                    action='buy',
+                    qty=qty,
+                    order_type='limit',
+                    time_in_force='day',
+                    limit_price=fill_price,
+                    rationale='resting',
+                    params=self._runtime_params(),
+                ),
+                signal=signal,
+            ),
+        )
+
+        _reconcile_pending_order_before_immediate_fill(
+            decision=decision,
+            pending_orders=self.pending_orders,
+            created_at=signal.event_ts,
+        )
+        self.cash = _apply_filled_decision(
+            decision=decision,
+            signal=signal,
+            fill_price=fill_price,
+            filled_at=signal.event_ts,
+            created_at=signal.event_ts,
+            positions=self.positions,
+            day_bucket=self.day_bucket,
+            cost_model=TransactionCostModel(),
+            cash=self.cash,
+            all_closed_trades=self.closed_trades,
+        )
+
+        assert ('META', _decision_position_owner(decision)) not in self.pending_orders
+
+    @invariant()
+    def projected_positions_never_go_negative(self) -> None:
+        payload = _positions_payload(
+            self.positions,
+            self.last_prices,
+            self.pending_orders,
+        )
+        for position in self.positions.values():
+            assert position.qty > 0
+        for row in payload:
+            assert Decimal(row['qty']) > 0
+            assert row['side'] == 'long'
+
+
+def test_replay_state_machine() -> None:
+    run_state_machine_as_test(
+        ReplayStateMachine,
+        settings=settings(max_examples=20, stateful_step_count=20, deadline=None),
+    )

--- a/services/torghut/tests/stateful/test_session_context_state_machine.py
+++ b/services/torghut/tests/stateful/test_session_context_state_machine.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+from datetime import date, datetime, time, timedelta, timezone
+from decimal import Decimal
+
+import pytest
+from hypothesis import settings
+from hypothesis import strategies as st
+from hypothesis.stateful import RuleBasedStateMachine, invariant, precondition, rule, run_state_machine_as_test
+
+from app.trading.models import SignalEnvelope
+from app.trading.session_context import SessionContextTracker
+from tests.strategies.trading import non_negative_spreads, positive_prices, size_decimals
+
+pytestmark = [pytest.mark.property, pytest.mark.stateful]
+
+
+def _signal(
+    *,
+    day: date,
+    event_time: time,
+    price: Decimal,
+    spread: Decimal,
+    bid_sz: Decimal,
+    ask_sz: Decimal,
+) -> SignalEnvelope:
+    bid = price - (spread / 2)
+    ask = price + (spread / 2)
+    if bid <= 0:
+        bid = Decimal('0.0001')
+        ask = bid + spread
+        price = (bid + ask) / 2
+    return SignalEnvelope(
+        event_ts=datetime.combine(day, event_time, tzinfo=timezone.utc),
+        symbol='META',
+        timeframe='1Sec',
+        seq=1,
+        source='ta',
+        payload={
+            'price': price,
+            'spread': ask - bid,
+            'imbalance_bid_px': bid,
+            'imbalance_ask_px': ask,
+            'imbalance_bid_sz': bid_sz,
+            'imbalance_ask_sz': ask_sz,
+            'vwap_w5m': price,
+        },
+    )
+
+
+class SessionContextStateMachine(RuleBasedStateMachine):
+    def __init__(self) -> None:
+        super().__init__()
+        self.tracker = SessionContextTracker()
+        self.current_day = date(2026, 3, 24)
+        self.expected_prev_close: Decimal | None = None
+        self.expected_open_price: Decimal | None = None
+        self.opened_today = False
+        self.closed_today = False
+        self.last_payload: dict[str, object] | None = None
+
+    @precondition(lambda self: self.opened_today and not self.closed_today)
+    @rule(price=positive_prices(), spread=non_negative_spreads(), bid_sz=size_decimals(), ask_sz=size_decimals())
+    def close_session(self, price: Decimal, spread: Decimal, bid_sz: Decimal, ask_sz: Decimal) -> None:
+        self.last_payload = self.tracker.enrich_signal_payload(
+            _signal(
+                day=self.current_day,
+                event_time=time(19, 59),
+                price=price,
+                spread=spread,
+                bid_sz=bid_sz,
+                ask_sz=ask_sz,
+            )
+        )
+        state = self.tracker._state_by_symbol['META']
+        self.expected_prev_close = (
+            state.last_valid_quote_price
+            or state.opening_window_close_price
+            or state.session_open_price
+        )
+        self.closed_today = True
+
+    @precondition(lambda self: self.closed_today or self.last_payload is None)
+    @rule()
+    def advance_day(self) -> None:
+        self.current_day = self.current_day + timedelta(days=1)
+        self.expected_open_price = None
+        self.opened_today = False
+        self.closed_today = False
+        self.last_payload = None
+
+    @precondition(lambda self: not self.opened_today and not self.closed_today)
+    @rule(price=positive_prices(), spread=non_negative_spreads(), bid_sz=size_decimals(), ask_sz=size_decimals())
+    def premarket_tick(self, price: Decimal, spread: Decimal, bid_sz: Decimal, ask_sz: Decimal) -> None:
+        payload = self.tracker.enrich_signal_payload(
+            _signal(
+                day=self.current_day,
+                event_time=time(12, 45),
+                price=price,
+                spread=spread,
+                bid_sz=bid_sz,
+                ask_sz=ask_sz,
+            )
+        )
+        self.last_payload = payload
+        assert 'session_open_price' not in payload
+        if self.expected_prev_close is not None:
+            assert payload['prev_session_close_price'] == self.expected_prev_close
+
+    @precondition(lambda self: not self.closed_today)
+    @rule(price=positive_prices(), spread=non_negative_spreads(), bid_sz=size_decimals(), ask_sz=size_decimals())
+    def regular_open_tick(self, price: Decimal, spread: Decimal, bid_sz: Decimal, ask_sz: Decimal) -> None:
+        payload = self.tracker.enrich_signal_payload(
+            _signal(
+                day=self.current_day,
+                event_time=time(13, 30, 5),
+                price=price,
+                spread=spread,
+                bid_sz=bid_sz,
+                ask_sz=ask_sz,
+            )
+        )
+        if not self.opened_today:
+            self.expected_open_price = payload['session_open_price']
+            self.opened_today = True
+        self.last_payload = payload
+        assert payload['session_open_price'] == self.expected_open_price
+
+    @precondition(lambda self: not self.closed_today)
+    @rule(
+        price=positive_prices(),
+        spread=non_negative_spreads(),
+        bid_sz=size_decimals(),
+        ask_sz=size_decimals(),
+        minute_offset=st.integers(min_value=1, max_value=180),
+    )
+    def regular_session_tick(
+        self,
+        price: Decimal,
+        spread: Decimal,
+        bid_sz: Decimal,
+        ask_sz: Decimal,
+        minute_offset: int,
+    ) -> None:
+        if not self.opened_today:
+            self.regular_open_tick(price, spread, bid_sz, ask_sz)
+            return
+        payload = self.tracker.enrich_signal_payload(
+            _signal(
+                day=self.current_day,
+                event_time=(datetime(2026, 1, 1, 13, 30, tzinfo=timezone.utc) + timedelta(minutes=minute_offset)).time(),
+                price=price,
+                spread=spread,
+                bid_sz=bid_sz,
+                ask_sz=ask_sz,
+            )
+        )
+        self.last_payload = payload
+        assert payload['session_open_price'] == self.expected_open_price
+
+    @invariant()
+    def payload_invariants_hold(self) -> None:
+        if self.last_payload is None or 'session_open_price' not in self.last_payload:
+            return
+        payload = self.last_payload
+        assert payload['session_high_price'] >= payload['session_low_price']
+        assert payload['opening_range_high'] >= payload['opening_range_low']
+        if 'price_position_in_session_range' in payload:
+            assert Decimal('0') <= payload['price_position_in_session_range'] <= Decimal('1')
+
+
+def test_session_context_state_machine() -> None:
+    run_state_machine_as_test(
+        SessionContextStateMachine,
+        settings=settings(max_examples=20, stateful_step_count=20, deadline=None),
+    )

--- a/services/torghut/tests/strategies/__init__.py
+++ b/services/torghut/tests/strategies/__init__.py
@@ -1,0 +1,1 @@
+"""Shared Hypothesis strategies for Torghut tests."""

--- a/services/torghut/tests/strategies/replay.py
+++ b/services/torghut/tests/strategies/replay.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from typing import Any
+
+from hypothesis import strategies as st
+
+from app.trading.models import SignalEnvelope, StrategyDecision
+from scripts.local_intraday_tsmom_replay import PendingOrder, PositionState
+
+from .trading import equity_symbols, positive_prices, positive_quantities, strategy_ids, utc_datetimes
+
+
+@st.composite
+def replay_decisions(
+    draw: Any,
+    *,
+    action: str | None = None,
+    order_type: str | None = None,
+) -> StrategyDecision:
+    resolved_action = action or draw(st.sampled_from(('buy', 'sell')))
+    resolved_order_type = order_type or draw(st.sampled_from(('market', 'limit')))
+    qty = draw(positive_quantities())
+    limit_price = draw(positive_prices()) if resolved_order_type == 'limit' else None
+    return StrategyDecision(
+        strategy_id=draw(strategy_ids()),
+        symbol=draw(equity_symbols()),
+        event_ts=draw(utc_datetimes()),
+        timeframe='1Sec',
+        action=resolved_action,
+        qty=qty,
+        order_type=resolved_order_type,
+        time_in_force='day',
+        limit_price=limit_price,
+        rationale='hypothesis',
+        params={},
+    )
+
+
+@st.composite
+def replay_signals(draw: Any, *, symbol: str | None = None) -> SignalEnvelope:
+    resolved_symbol = symbol or draw(equity_symbols())
+    price = draw(positive_prices())
+    spread = draw(st.decimals(min_value=Decimal('0.0000'), max_value=Decimal('1.0000'), allow_nan=False, allow_infinity=False, places=4))
+    bid = price - (spread / 2)
+    ask = price + (spread / 2)
+    if bid <= 0:
+        bid = Decimal('0.0001')
+        ask = bid + spread
+        price = (bid + ask) / 2
+    return SignalEnvelope(
+        event_ts=draw(utc_datetimes()),
+        symbol=resolved_symbol,
+        timeframe='1Sec',
+        seq=draw(st.integers(min_value=1, max_value=1_000_000)),
+        source='ta',
+        payload={
+            'price': price,
+            'imbalance_bid_px': bid,
+            'imbalance_ask_px': ask,
+            'spread': ask - bid,
+        },
+    )
+
+
+def position_state(*, strategy_id: str, qty: Decimal, entry_price: Decimal, event_ts: datetime) -> PositionState:
+    return PositionState(
+        strategy_id=strategy_id,
+        qty=qty,
+        avg_entry_price=entry_price,
+        opened_at=event_ts,
+        entry_cost_total=Decimal('0'),
+        decision_at=event_ts,
+        pending_entry=False,
+    )
+
+
+def pending_order(*, decision: StrategyDecision, signal: SignalEnvelope) -> PendingOrder:
+    return PendingOrder(
+        decision=decision,
+        created_at=signal.event_ts,
+        signal=signal,
+    )

--- a/services/torghut/tests/strategies/signals.py
+++ b/services/torghut/tests/strategies/signals.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from typing import Any
+
+from hypothesis import strategies as st
+
+from app.trading.models import SignalEnvelope
+
+from .trading import (
+    equity_symbols,
+    executable_spread_bps,
+    non_negative_spreads,
+    positive_prices,
+    size_decimals,
+    utc_datetimes,
+)
+
+
+@st.composite
+def valid_quote_signals(draw: Any, *, symbol: str | None = None) -> SignalEnvelope:
+    resolved_symbol = symbol or draw(equity_symbols())
+    price = draw(positive_prices())
+    spread_bps = draw(executable_spread_bps())
+    spread = (price * spread_bps) / Decimal('10000')
+    half_spread = spread / 2
+    bid = price - half_spread
+    ask = price + half_spread
+    if bid <= 0:
+        bid = Decimal('0.0001')
+        ask = bid + spread
+        price = (bid + ask) / 2
+    event_ts = draw(utc_datetimes())
+    bid_sz = draw(size_decimals())
+    ask_sz = draw(size_decimals())
+    return SignalEnvelope(
+        event_ts=event_ts,
+        symbol=resolved_symbol,
+        timeframe='1Sec',
+        seq=draw(st.integers(min_value=1, max_value=1_000_000)),
+        source='ta',
+        payload={
+            'price': price,
+            'spread': ask - bid,
+            'imbalance_bid_px': bid,
+            'imbalance_ask_px': ask,
+            'imbalance_bid_sz': bid_sz,
+            'imbalance_ask_sz': ask_sz,
+            'vwap_w5m': price,
+            'macd': Decimal('0.5'),
+            'macd_signal': Decimal('0.2'),
+            'rsi14': Decimal('55'),
+        },
+    )
+
+
+@st.composite
+def crossed_quote_signals(draw: Any, *, symbol: str | None = None) -> SignalEnvelope:
+    resolved_symbol = symbol or draw(equity_symbols())
+    base_price = draw(positive_prices())
+    positive_offset = draw(non_negative_spreads().filter(lambda value: value > 0))
+    ask = base_price
+    bid = base_price + positive_offset
+    return SignalEnvelope(
+        event_ts=draw(utc_datetimes()),
+        symbol=resolved_symbol,
+        timeframe='1Sec',
+        seq=draw(st.integers(min_value=1, max_value=1_000_000)),
+        source='ta',
+        payload={
+            'price': (bid + ask) / 2,
+            'spread': ask - bid,
+            'imbalance_bid_px': bid,
+            'imbalance_ask_px': ask,
+            'macd': Decimal('0.5'),
+            'macd_signal': Decimal('0.2'),
+            'rsi14': Decimal('55'),
+        },
+    )
+
+
+@st.composite
+def regular_session_signal_series(draw: Any) -> list[SignalEnvelope]:
+    symbol = draw(equity_symbols())
+    day = draw(st.dates(min_value=datetime(2026, 1, 1).date(), max_value=datetime(2026, 12, 31).date()))
+    minutes = draw(
+        st.lists(
+            st.integers(min_value=0, max_value=180),
+            min_size=1,
+            max_size=12,
+            unique=True,
+        ).map(sorted)
+    )
+    prices = draw(st.lists(positive_prices(), min_size=len(minutes), max_size=len(minutes)))
+    spreads = draw(st.lists(non_negative_spreads(), min_size=len(minutes), max_size=len(minutes)))
+    bid_sizes = draw(st.lists(size_decimals(), min_size=len(minutes), max_size=len(minutes)))
+    ask_sizes = draw(st.lists(size_decimals(), min_size=len(minutes), max_size=len(minutes)))
+    signals: list[SignalEnvelope] = []
+    for index, minute in enumerate(minutes, start=1):
+        price = prices[index - 1]
+        spread = spreads[index - 1]
+        bid = price - (spread / 2)
+        ask = price + (spread / 2)
+        if bid <= 0:
+            bid = Decimal('0.0001')
+            ask = bid + spread
+            price = (bid + ask) / 2
+        event_ts = datetime(day.year, day.month, day.day, 13, 30, tzinfo=timezone.utc) + timedelta(
+            minutes=minute,
+            seconds=index % 60,
+        )
+        signals.append(
+            SignalEnvelope(
+                event_ts=event_ts,
+                symbol=symbol,
+                timeframe='1Sec',
+                seq=index,
+                source='ta',
+                payload={
+                    'price': price,
+                    'spread': ask - bid,
+                    'imbalance_bid_px': bid,
+                    'imbalance_ask_px': ask,
+                    'imbalance_bid_sz': bid_sizes[index - 1],
+                    'imbalance_ask_sz': ask_sizes[index - 1],
+                    'vwap_w5m': price,
+                },
+            )
+        )
+    return signals
+
+
+@st.composite
+def feature_contract_signals(draw: Any) -> SignalEnvelope:
+    signal = draw(valid_quote_signals())
+    payload = dict(signal.payload)
+    payload.update(
+        {
+            'vwap_session': draw(positive_prices()),
+            'vwap_w5m': draw(positive_prices()),
+            'recent_quote_invalid_ratio': draw(st.decimals(min_value=Decimal('0'), max_value=Decimal('1'), allow_nan=False, allow_infinity=False, places=4)),
+            'cross_section_prev_session_close_rank': draw(st.decimals(min_value=Decimal('0'), max_value=Decimal('1'), allow_nan=False, allow_infinity=False, places=4)),
+            'cross_section_positive_session_open_ratio': draw(st.decimals(min_value=Decimal('0'), max_value=Decimal('1'), allow_nan=False, allow_infinity=False, places=4)),
+        }
+    )
+    return signal.model_copy(update={'payload': payload})

--- a/services/torghut/tests/strategies/trading.py
+++ b/services/torghut/tests/strategies/trading.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+
+from hypothesis import strategies as st
+
+JANGAR_EQUITY_SYMBOLS = (
+    'AAPL',
+    'AMAT',
+    'AMD',
+    'AVGO',
+    'GOOG',
+    'INTC',
+    'META',
+    'MSFT',
+    'MU',
+    'NVDA',
+    'PLTR',
+    'SHOP',
+)
+CRYPTO_SYMBOLS = ('BTC/USD', 'ETH/USD')
+
+_UTC_MIN = datetime(2026, 1, 1, tzinfo=timezone.utc)
+_UTC_MAX = datetime(2026, 12, 31, 23, 59, 59, tzinfo=timezone.utc)
+
+
+def quantized_decimals(
+    *,
+    min_value: str,
+    max_value: str,
+    places: int,
+) -> st.SearchStrategy[Decimal]:
+    return st.decimals(
+        min_value=Decimal(min_value),
+        max_value=Decimal(max_value),
+        allow_infinity=False,
+        allow_nan=False,
+        places=places,
+    )
+
+
+def positive_prices() -> st.SearchStrategy[Decimal]:
+    return quantized_decimals(min_value='1.00', max_value='1000.00', places=4)
+
+
+def non_negative_spreads() -> st.SearchStrategy[Decimal]:
+    return quantized_decimals(min_value='0.0000', max_value='5.0000', places=4)
+
+
+def executable_spread_bps() -> st.SearchStrategy[Decimal]:
+    return quantized_decimals(min_value='0', max_value='50', places=4)
+
+
+def positive_quantities() -> st.SearchStrategy[Decimal]:
+    return quantized_decimals(min_value='0.0001', max_value='500.0000', places=4)
+
+
+def position_quantities() -> st.SearchStrategy[Decimal]:
+    return quantized_decimals(min_value='-500.0000', max_value='500.0000', places=4)
+
+
+def size_decimals() -> st.SearchStrategy[Decimal]:
+    return quantized_decimals(min_value='0', max_value='100000', places=0)
+
+
+def utc_datetimes() -> st.SearchStrategy[datetime]:
+    return st.datetimes(
+        min_value=_UTC_MIN.replace(tzinfo=None),
+        max_value=_UTC_MAX.replace(tzinfo=None),
+        timezones=st.just(timezone.utc),
+    )
+
+
+def regular_session_datetimes() -> st.SearchStrategy[datetime]:
+    return st.builds(
+        lambda base_day, minute_offset, second_offset: datetime(
+            base_day.year,
+            base_day.month,
+            base_day.day,
+            13,
+            30,
+            tzinfo=timezone.utc,
+        )
+        + timedelta(minutes=minute_offset, seconds=second_offset),
+        st.dates(min_value=_UTC_MIN.date(), max_value=_UTC_MAX.date()),
+        st.integers(min_value=0, max_value=390),
+        st.integers(min_value=0, max_value=59),
+    )
+
+
+def equity_symbols() -> st.SearchStrategy[str]:
+    return st.sampled_from(JANGAR_EQUITY_SYMBOLS)
+
+
+def crypto_symbols() -> st.SearchStrategy[str]:
+    return st.sampled_from(CRYPTO_SYMBOLS)
+
+
+def trading_symbols(*, include_crypto: bool = True) -> st.SearchStrategy[str]:
+    if include_crypto:
+        return st.sampled_from(JANGAR_EQUITY_SYMBOLS + CRYPTO_SYMBOLS)
+    return equity_symbols()
+
+
+def strategy_ids() -> st.SearchStrategy[str]:
+    return st.sampled_from(
+        (
+            'intraday_tsmom_v1@prod',
+            'breakout_continuation_long_v1@paper',
+            'late_day_continuation_long_v1@paper',
+            'mean_reversion_rebound_long_v1@paper',
+        )
+    )

--- a/services/torghut/tests/test_check_diff_coverage.py
+++ b/services/torghut/tests/test_check_diff_coverage.py
@@ -1,0 +1,477 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import TestCase
+from unittest.mock import Mock
+from unittest.mock import patch
+
+from scripts.check_diff_coverage import (
+    FileDiffCoverage,
+    _executable_source_lines,
+    _format_summary,
+    _git,
+    _git_optional,
+    _include_untracked_python_files,
+    _load_coverage_index,
+    _list_untracked_python_files,
+    _parse_args,
+    _parse_changed_python_lines,
+    _repo_root,
+    _resolve_base_spec,
+    _resolve_diff_base,
+    main,
+    summarize_changed_coverage,
+)
+
+
+class TestCheckDiffCoverage(TestCase):
+    def test_file_diff_coverage_ratio_defaults_to_one_for_zero_executable_lines(self) -> None:
+        item = FileDiffCoverage(
+            filename='app/trading/foo.py',
+            executable_changed_lines=0,
+            covered_lines=0,
+            missing_lines=(),
+        )
+
+        self.assertEqual(item.coverage_ratio, 1.0)
+
+    def test_parse_args_uses_expected_defaults(self) -> None:
+        with patch.object(sys, 'argv', ['check_diff_coverage.py']):
+            args = _parse_args()
+
+        self.assertEqual(args.coverage_xml, 'coverage.xml')
+        self.assertEqual(args.threshold, 90.0)
+        self.assertEqual(args.base_ref, '')
+
+    def test_parse_args_accepts_explicit_values(self) -> None:
+        with patch.object(
+            sys,
+            'argv',
+            ['check_diff_coverage.py', '--coverage-xml', 'custom.xml', '--threshold', '95', '--base-ref', 'origin/main'],
+        ):
+            args = _parse_args()
+
+        self.assertEqual(args.coverage_xml, 'custom.xml')
+        self.assertEqual(args.threshold, 95.0)
+        self.assertEqual(args.base_ref, 'origin/main')
+
+    def test_repo_root_finds_nearest_git_directory(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            repo_root = Path(tmpdir)
+            (repo_root / '.git').mkdir()
+            nested = repo_root / 'services' / 'torghut'
+            nested.mkdir(parents=True, exist_ok=True)
+
+            resolved = _repo_root(nested)
+
+        self.assertEqual(resolved, repo_root.resolve())
+
+    def test_repo_root_raises_when_git_directory_missing(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            start = Path(tmpdir)
+            with self.assertRaisesRegex(RuntimeError, 'repo_root_not_found'):
+                _repo_root(start)
+
+    @patch('scripts.check_diff_coverage.subprocess.run')
+    def test_git_returns_stripped_stdout(self, run_mock: object) -> None:
+        run_mock.return_value = Mock(stdout=' abc123 \n')
+
+        result = _git(Path('/tmp/repo'), 'rev-parse', 'HEAD')
+
+        self.assertEqual(result, 'abc123')
+        run_mock.assert_called_once()
+
+    @patch('scripts.check_diff_coverage._git')
+    def test_git_optional_returns_none_on_called_process_error(self, git_mock: object) -> None:
+        git_mock.side_effect = subprocess.CalledProcessError(1, ['git'])
+
+        result = _git_optional(Path('/tmp/repo'), 'rev-parse', 'HEAD')
+
+        self.assertIsNone(result)
+
+    @patch.dict('os.environ', {'GITHUB_BASE_REF': 'main'})
+    def test_resolve_base_spec_uses_explicit_then_env(self) -> None:
+        self.assertEqual(_resolve_base_spec('origin/release'), 'origin/release')
+        self.assertEqual(_resolve_base_spec(''), 'origin/main')
+
+    @patch.dict('os.environ', {}, clear=True)
+    def test_resolve_base_spec_returns_none_without_inputs(self) -> None:
+        self.assertIsNone(_resolve_base_spec(''))
+
+    def test_parse_changed_python_lines_extracts_added_source_lines(self) -> None:
+        diff_text = '''
+diff --git a/services/torghut/app/trading/foo.py b/services/torghut/app/trading/foo.py
+index 1111111..2222222 100644
+--- a/services/torghut/app/trading/foo.py
++++ b/services/torghut/app/trading/foo.py
+@@ -10,0 +11,2 @@
++first = 1
++second = 2
+@@ -20 +23 @@
++third = 3
+diff --git a/services/torghut/tests/test_foo.py b/services/torghut/tests/test_foo.py
+--- a/services/torghut/tests/test_foo.py
++++ b/services/torghut/tests/test_foo.py
+@@ -1 +1 @@
++ignored = True
+'''.strip()
+
+        changed_lines = _parse_changed_python_lines(diff_text)
+
+        self.assertEqual(
+            changed_lines,
+            {'app/trading/foo.py': {11, 12, 23}},
+        )
+
+    def test_parse_changed_python_lines_ignores_zero_count_hunks(self) -> None:
+        diff_text = '''
+diff --git a/services/torghut/scripts/foo.py b/services/torghut/scripts/foo.py
++++ b/services/torghut/scripts/foo.py
+@@ -10,0 +11,0 @@
+'''.strip()
+
+        changed_lines = _parse_changed_python_lines(diff_text)
+
+        self.assertEqual(changed_lines, {'scripts/foo.py': set()})
+
+    def test_load_coverage_index_reads_line_hits(self) -> None:
+        xml_text = '''
+<coverage>
+  <packages>
+    <package name="app">
+      <classes>
+        <class filename="app/trading/foo.py">
+          <lines>
+            <line number="11" hits="1"/>
+            <line number="12" hits="0"/>
+          </lines>
+        </class>
+      </classes>
+    </package>
+  </packages>
+</coverage>
+'''.strip()
+        with TemporaryDirectory() as tmpdir:
+            xml_path = Path(tmpdir) / 'coverage.xml'
+            xml_path.write_text(xml_text, encoding='utf-8')
+
+            coverage_index = _load_coverage_index(xml_path)
+
+        self.assertEqual(coverage_index['app/trading/foo.py'][11], 1)
+        self.assertEqual(coverage_index['app/trading/foo.py'][12], 0)
+
+    def test_load_coverage_index_prefixes_bare_script_filenames(self) -> None:
+        xml_text = '''
+<coverage>
+  <packages>
+    <package name=".">
+      <classes>
+        <class filename="check_diff_coverage.py">
+          <lines>
+            <line number="20" hits="1"/>
+          </lines>
+        </class>
+      </classes>
+    </package>
+  </packages>
+</coverage>
+'''.strip()
+        with TemporaryDirectory() as tmpdir:
+            scripts_dir = Path(tmpdir) / 'scripts'
+            scripts_dir.mkdir(parents=True, exist_ok=True)
+            (scripts_dir / 'check_diff_coverage.py').write_text('print("ok")\n', encoding='utf-8')
+            xml_path = Path(tmpdir) / 'coverage.xml'
+            xml_path.write_text(xml_text, encoding='utf-8')
+
+            coverage_index = _load_coverage_index(xml_path)
+
+        self.assertEqual(coverage_index['scripts/check_diff_coverage.py'][20], 1)
+
+    def test_summarize_changed_coverage_uses_only_executable_changed_lines(self) -> None:
+        summary = summarize_changed_coverage(
+            changed_lines={'app/trading/foo.py': {11, 12, 99}},
+            coverage_index={'app/trading/foo.py': {11: 1, 12: 0, 30: 1}},
+        )
+
+        self.assertEqual(len(summary), 1)
+        self.assertEqual(summary[0].filename, 'app/trading/foo.py')
+        self.assertEqual(summary[0].covered_lines, 1)
+        self.assertEqual(summary[0].executable_changed_lines, 2)
+        self.assertEqual(summary[0].missing_lines, (12,))
+
+    def test_summarize_changed_coverage_flags_files_missing_from_coverage(self) -> None:
+        summary = summarize_changed_coverage(
+            changed_lines={'app/trading/foo.py': {11, 12}},
+            coverage_index={},
+        )
+
+        self.assertEqual(len(summary), 1)
+        self.assertTrue(summary[0].missing_from_coverage)
+        self.assertEqual(summary[0].missing_lines, (11, 12))
+
+    @patch('scripts.check_diff_coverage._git_optional')
+    def test_resolve_diff_base_prefers_origin_main_when_no_explicit_base(self, git_optional: object) -> None:
+        git_optional.side_effect = ['base-from-origin-main']
+
+        resolved = _resolve_diff_base(Path('/tmp/repo'), '')
+
+        self.assertEqual(resolved, 'base-from-origin-main')
+        git_optional.assert_called_once_with(Path('/tmp/repo'), 'merge-base', 'origin/main', 'HEAD')
+
+    @patch('scripts.check_diff_coverage._git_optional')
+    def test_resolve_diff_base_falls_back_to_head_parent(self, git_optional: object) -> None:
+        git_optional.side_effect = [None, None, 'parent-commit']
+
+        resolved = _resolve_diff_base(Path('/tmp/repo'), '')
+
+        self.assertEqual(resolved, 'parent-commit')
+        self.assertEqual(
+            git_optional.call_args_list[-1].args,
+            (Path('/tmp/repo'), 'rev-parse', 'HEAD^'),
+        )
+
+    @patch('scripts.check_diff_coverage._git_optional')
+    def test_list_untracked_python_files_filters_tracked_prefixes(self, git_optional: object) -> None:
+        git_optional.return_value = '\n'.join(
+            (
+                'services/torghut/scripts/check_diff_coverage.py',
+                'services/torghut/app/trading/new_module.py',
+                'services/torghut/tests/test_foo.py',
+                'README.md',
+            )
+        )
+
+        files = _list_untracked_python_files(Path('/tmp/repo'))
+
+        self.assertEqual(
+            files,
+            ('app/trading/new_module.py', 'scripts/check_diff_coverage.py'),
+        )
+
+    @patch('scripts.check_diff_coverage._git_optional')
+    def test_list_untracked_python_files_returns_empty_tuple_when_git_has_no_output(self, git_optional: object) -> None:
+        git_optional.return_value = ''
+
+        files = _list_untracked_python_files(Path('/tmp/repo'))
+
+        self.assertEqual(files, ())
+
+    def test_executable_source_lines_extracts_statement_line_numbers(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            source_path = Path(tmpdir) / 'module.py'
+            source_path.write_text(
+                '\n'.join(
+                    (
+                        '"""module docstring"""',
+                        '',
+                        'def build() -> int:',
+                        '    value = 1',
+                        '    return value',
+                    )
+                ),
+                encoding='utf-8',
+            )
+
+            executable_lines = _executable_source_lines(source_path)
+
+        self.assertEqual(executable_lines, {3, 4, 5})
+
+    @patch('scripts.check_diff_coverage._list_untracked_python_files')
+    def test_include_untracked_python_files_uses_coverage_lines_when_present(self, list_untracked: object) -> None:
+        list_untracked.return_value = ('scripts/check_diff_coverage.py',)
+        changed_lines = {'app/trading/foo.py': {10}}
+        coverage_index = {'scripts/check_diff_coverage.py': {20: 1, 21: 0}}
+
+        with TemporaryDirectory() as tmpdir:
+            combined = _include_untracked_python_files(
+                changed_lines=changed_lines,
+                coverage_index=coverage_index,
+                service_root=Path(tmpdir),
+                repo_root=Path(tmpdir),
+            )
+
+        self.assertEqual(combined['app/trading/foo.py'], {10})
+        self.assertEqual(combined['scripts/check_diff_coverage.py'], {20, 21})
+
+    @patch('scripts.check_diff_coverage._list_untracked_python_files')
+    def test_include_untracked_python_files_falls_back_to_ast_lines(self, list_untracked: object) -> None:
+        list_untracked.return_value = ('scripts/new_tool.py',)
+
+        with TemporaryDirectory() as tmpdir:
+            service_root = Path(tmpdir)
+            script_path = service_root / 'scripts' / 'new_tool.py'
+            script_path.parent.mkdir(parents=True, exist_ok=True)
+            script_path.write_text(
+                '\n'.join(
+                    (
+                        'def main() -> int:',
+                        '    return 1',
+                    )
+                ),
+                encoding='utf-8',
+            )
+
+            combined = _include_untracked_python_files(
+                changed_lines={},
+                coverage_index={},
+                service_root=service_root,
+                repo_root=service_root,
+            )
+
+        self.assertEqual(combined['scripts/new_tool.py'], {1, 2})
+
+    def test_summarize_changed_coverage_skips_non_executable_changed_lines(self) -> None:
+        summary = summarize_changed_coverage(
+            changed_lines={'app/trading/foo.py': {90}},
+            coverage_index={'app/trading/foo.py': {11: 1, 12: 0}},
+        )
+
+        self.assertEqual(summary, [])
+
+    def test_format_summary_includes_missing_from_coverage_suffix(self) -> None:
+        text = _format_summary(
+            [
+                FileDiffCoverage(
+                    filename='scripts/check_diff_coverage.py',
+                    executable_changed_lines=2,
+                    covered_lines=1,
+                    missing_lines=(20,),
+                    missing_from_coverage=True,
+                )
+            ]
+        )
+
+        self.assertIn('missing-from-coverage', text)
+        self.assertIn('missing lines: 20', text)
+
+    @patch('scripts.check_diff_coverage._parse_args')
+    @patch('scripts.check_diff_coverage._repo_root')
+    @patch('scripts.check_diff_coverage._resolve_diff_base')
+    def test_main_skips_when_no_base_commit(
+        self,
+        resolve_diff_base: object,
+        repo_root: object,
+        parse_args: object,
+    ) -> None:
+        parse_args.return_value = Mock(coverage_xml='coverage.xml', threshold=90.0, base_ref='')
+        repo_root.return_value = Path('/tmp/repo')
+        resolve_diff_base.return_value = None
+
+        with patch('sys.stdout.write') as stdout_write:
+            exit_code = main()
+
+        self.assertEqual(exit_code, 0)
+        self.assertTrue(any('no base commit available' in call.args[0] for call in stdout_write.call_args_list))
+
+    @patch('scripts.check_diff_coverage._parse_args')
+    @patch('scripts.check_diff_coverage._repo_root')
+    @patch('scripts.check_diff_coverage._resolve_diff_base')
+    @patch('scripts.check_diff_coverage._git')
+    @patch('scripts.check_diff_coverage._load_coverage_index')
+    @patch('scripts.check_diff_coverage._include_untracked_python_files')
+    def test_main_skips_when_no_changed_python_source_lines(
+        self,
+        include_untracked: object,
+        load_coverage: object,
+        git_mock: object,
+        resolve_diff_base: object,
+        repo_root: object,
+        parse_args: object,
+    ) -> None:
+        parse_args.return_value = Mock(coverage_xml='coverage.xml', threshold=90.0, base_ref='')
+        repo_root.return_value = Path('/tmp/repo')
+        resolve_diff_base.return_value = 'base'
+        git_mock.return_value = ''
+        load_coverage.return_value = {}
+        include_untracked.return_value = {}
+
+        with patch('sys.stdout.write') as stdout_write:
+            exit_code = main()
+
+        self.assertEqual(exit_code, 0)
+        self.assertTrue(any('no changed Torghut Python source lines' in call.args[0] for call in stdout_write.call_args_list))
+
+    @patch('scripts.check_diff_coverage._parse_args')
+    @patch('scripts.check_diff_coverage._repo_root')
+    @patch('scripts.check_diff_coverage._resolve_diff_base')
+    @patch('scripts.check_diff_coverage._git')
+    @patch('scripts.check_diff_coverage._load_coverage_index')
+    @patch('scripts.check_diff_coverage._include_untracked_python_files')
+    def test_main_fails_for_missing_coverage_files(
+        self,
+        include_untracked: object,
+        load_coverage: object,
+        git_mock: object,
+        resolve_diff_base: object,
+        repo_root: object,
+        parse_args: object,
+    ) -> None:
+        parse_args.return_value = Mock(coverage_xml='coverage.xml', threshold=90.0, base_ref='')
+        repo_root.return_value = Path('/tmp/repo')
+        resolve_diff_base.return_value = 'base'
+        git_mock.return_value = ''
+        load_coverage.return_value = {}
+        include_untracked.return_value = {'scripts/check_diff_coverage.py': {20, 21}}
+
+        with patch('sys.stderr.write') as stderr_write:
+            exit_code = main()
+
+        self.assertEqual(exit_code, 1)
+        self.assertTrue(any('missing from coverage.xml' in call.args[0] for call in stderr_write.call_args_list))
+
+    @patch('scripts.check_diff_coverage._parse_args')
+    @patch('scripts.check_diff_coverage._repo_root')
+    @patch('scripts.check_diff_coverage._resolve_diff_base')
+    @patch('scripts.check_diff_coverage._git')
+    @patch('scripts.check_diff_coverage._load_coverage_index')
+    @patch('scripts.check_diff_coverage._include_untracked_python_files')
+    def test_main_fails_when_threshold_not_met(
+        self,
+        include_untracked: object,
+        load_coverage: object,
+        git_mock: object,
+        resolve_diff_base: object,
+        repo_root: object,
+        parse_args: object,
+    ) -> None:
+        parse_args.return_value = Mock(coverage_xml='coverage.xml', threshold=95.0, base_ref='')
+        repo_root.return_value = Path('/tmp/repo')
+        resolve_diff_base.return_value = 'base'
+        git_mock.return_value = ''
+        load_coverage.return_value = {'scripts/check_diff_coverage.py': {20: 1, 21: 0}}
+        include_untracked.return_value = {'scripts/check_diff_coverage.py': {20, 21}}
+
+        with patch('sys.stderr.write') as stderr_write:
+            exit_code = main()
+
+        self.assertEqual(exit_code, 1)
+        self.assertTrue(any('below threshold 95.00%' in call.args[0] for call in stderr_write.call_args_list))
+
+    @patch('scripts.check_diff_coverage._parse_args')
+    @patch('scripts.check_diff_coverage._repo_root')
+    @patch('scripts.check_diff_coverage._resolve_diff_base')
+    @patch('scripts.check_diff_coverage._git')
+    @patch('scripts.check_diff_coverage._load_coverage_index')
+    @patch('scripts.check_diff_coverage._include_untracked_python_files')
+    def test_main_succeeds_when_threshold_is_met(
+        self,
+        include_untracked: object,
+        load_coverage: object,
+        git_mock: object,
+        resolve_diff_base: object,
+        repo_root: object,
+        parse_args: object,
+    ) -> None:
+        parse_args.return_value = Mock(coverage_xml='coverage.xml', threshold=50.0, base_ref='')
+        repo_root.return_value = Path('/tmp/repo')
+        resolve_diff_base.return_value = 'base'
+        git_mock.return_value = ''
+        load_coverage.return_value = {'scripts/check_diff_coverage.py': {20: 1, 21: 0}}
+        include_untracked.return_value = {'scripts/check_diff_coverage.py': {20, 21}}
+
+        exit_code = main()
+
+        self.assertEqual(exit_code, 0)

--- a/services/torghut/uv.lock
+++ b/services/torghut/uv.lock
@@ -172,6 +172,19 @@ wheels = [
 ]
 
 [[package]]
+name = "cattrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a0/ec/ba18945e7d6e55a58364d9fb2e46049c1c2998b3d805f19b703f14e81057/cattrs-26.1.0.tar.gz", hash = "sha256:fa239e0f0ec0715ba34852ce813986dfed1e12117e209b816ab87401271cdd40", size = 495672, upload-time = "2026-02-18T22:15:19.406Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/56/60547f7801b97c67e97491dc3d9ade9fbccbd0325058fd3dfcb2f5d98d90/cattrs-26.1.0-py3-none-any.whl", hash = "sha256:d1e0804c42639494d469d08d4f26d6b9de9b8ab26b446db7b5f8c2e97f7c3096", size = 73054, upload-time = "2026-02-18T22:15:17.958Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.1.4"
 source = { registry = "https://pypi.org/simple" }
@@ -261,6 +274,81 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a2/61/f083b5ac52e505dfc1c624eafbf8c7589a0d7f32daa398d2e7590efa5fda/colorlog-6.10.1.tar.gz", hash = "sha256:eb4ae5cb65fe7fec7773c2306061a8e63e02efc2c72eba9d27b0fa23c94f1321", size = 17162, upload-time = "2025-10-16T16:14:11.978Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6d/c1/e419ef3723a074172b68aaa89c9f3de486ed4c2399e2dbd8113a4fdcaf9e/colorlog-6.10.1-py3-none-any.whl", hash = "sha256:2d7e8348291948af66122cff006c9f8da6255d224e7cf8e37d8de2df3bad8c9c", size = 11743, upload-time = "2025-10-16T16:14:10.512Z" },
+]
+
+[[package]]
+name = "coverage"
+version = "7.13.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/e0/70553e3000e345daff267cec284ce4cbf3fc141b6da229ac52775b5428f1/coverage-7.13.5.tar.gz", hash = "sha256:c81f6515c4c40141f83f502b07bbfa5c240ba25bbe73da7b33f1e5b6120ff179", size = 915967, upload-time = "2026-03-17T10:33:18.341Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/37/d24c8f8220ff07b839b2c043ea4903a33b0f455abe673ae3c03bbdb7f212/coverage-7.13.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:66a80c616f80181f4d643b0f9e709d97bcea413ecd9631e1dedc7401c8e6695d", size = 219381, upload-time = "2026-03-17T10:30:14.68Z" },
+    { url = "https://files.pythonhosted.org/packages/35/8b/cd129b0ca4afe886a6ce9d183c44d8301acbd4ef248622e7c49a23145605/coverage-7.13.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:145ede53ccbafb297c1c9287f788d1bc3efd6c900da23bf6931b09eafc931587", size = 219880, upload-time = "2026-03-17T10:30:16.231Z" },
+    { url = "https://files.pythonhosted.org/packages/55/2f/e0e5b237bffdb5d6c530ce87cc1d413a5b7d7dfd60fb067ad6d254c35c76/coverage-7.13.5-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:0672854dc733c342fa3e957e0605256d2bf5934feeac328da9e0b5449634a642", size = 250303, upload-time = "2026-03-17T10:30:17.748Z" },
+    { url = "https://files.pythonhosted.org/packages/92/be/b1afb692be85b947f3401375851484496134c5554e67e822c35f28bf2fbc/coverage-7.13.5-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:ec10e2a42b41c923c2209b846126c6582db5e43a33157e9870ba9fb70dc7854b", size = 252218, upload-time = "2026-03-17T10:30:19.804Z" },
+    { url = "https://files.pythonhosted.org/packages/da/69/2f47bb6fa1b8d1e3e5d0c4be8ccb4313c63d742476a619418f85740d597b/coverage-7.13.5-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:be3d4bbad9d4b037791794ddeedd7d64a56f5933a2c1373e18e9e568b9141686", size = 254326, upload-time = "2026-03-17T10:30:21.321Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/d0/79db81da58965bd29dabc8f4ad2a2af70611a57cba9d1ec006f072f30a54/coverage-7.13.5-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4d2afbc5cc54d286bfb54541aa50b64cdb07a718227168c87b9e2fb8f25e1743", size = 256267, upload-time = "2026-03-17T10:30:23.094Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/32/d0d7cc8168f91ddab44c0ce4806b969df5f5fdfdbb568eaca2dbc2a04936/coverage-7.13.5-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3ad050321264c49c2fa67bb599100456fc51d004b82534f379d16445da40fb75", size = 250430, upload-time = "2026-03-17T10:30:25.311Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/06/a055311d891ddbe231cd69fdd20ea4be6e3603ffebddf8704b8ca8e10a3c/coverage-7.13.5-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:7300c8a6d13335b29bb76d7651c66af6bd8658517c43499f110ddc6717bfc209", size = 252017, upload-time = "2026-03-17T10:30:27.284Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f6/d0fd2d21e29a657b5f77a2fe7082e1568158340dceb941954f776dce1b7b/coverage-7.13.5-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:eb07647a5738b89baab047f14edd18ded523de60f3b30e75c2acc826f79c839a", size = 250080, upload-time = "2026-03-17T10:30:29.481Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/ab/0d7fb2efc2e9a5eb7ddcc6e722f834a69b454b7e6e5888c3a8567ecffb31/coverage-7.13.5-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:9adb6688e3b53adffefd4a52d72cbd8b02602bfb8f74dcd862337182fd4d1a4e", size = 253843, upload-time = "2026-03-17T10:30:31.301Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/6f/7467b917bbf5408610178f62a49c0ed4377bb16c1657f689cc61470da8ce/coverage-7.13.5-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:7c8d4bc913dd70b93488d6c496c77f3aff5ea99a07e36a18f865bca55adef8bd", size = 249802, upload-time = "2026-03-17T10:30:33.358Z" },
+    { url = "https://files.pythonhosted.org/packages/75/2c/1172fb689df92135f5bfbbd69fc83017a76d24ea2e2f3a1154007e2fb9f8/coverage-7.13.5-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0e3c426ffc4cd952f54ee9ffbdd10345709ecc78a3ecfd796a57236bfad0b9b8", size = 250707, upload-time = "2026-03-17T10:30:35.2Z" },
+    { url = "https://files.pythonhosted.org/packages/67/21/9ac389377380a07884e3b48ba7a620fcd9dbfaf1d40565facdc6b36ec9ef/coverage-7.13.5-cp311-cp311-win32.whl", hash = "sha256:259b69bb83ad9894c4b25be2528139eecba9a82646ebdda2d9db1ba28424a6bf", size = 221880, upload-time = "2026-03-17T10:30:36.775Z" },
+    { url = "https://files.pythonhosted.org/packages/af/7f/4cd8a92531253f9d7c1bbecd9fa1b472907fb54446ca768c59b531248dc5/coverage-7.13.5-cp311-cp311-win_amd64.whl", hash = "sha256:258354455f4e86e3e9d0d17571d522e13b4e1e19bf0f8596bcf9476d61e7d8a9", size = 222816, upload-time = "2026-03-17T10:30:38.891Z" },
+    { url = "https://files.pythonhosted.org/packages/12/a6/1d3f6155fb0010ca68eba7fe48ca6c9da7385058b77a95848710ecf189b1/coverage-7.13.5-cp311-cp311-win_arm64.whl", hash = "sha256:bff95879c33ec8da99fc9b6fe345ddb5be6414b41d6d1ad1c8f188d26f36e028", size = 221483, upload-time = "2026-03-17T10:30:40.463Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/c3/a396306ba7db865bf96fc1fb3b7fd29bcbf3d829df642e77b13555163cd6/coverage-7.13.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:460cf0114c5016fa841214ff5564aa4864f11948da9440bc97e21ad1f4ba1e01", size = 219554, upload-time = "2026-03-17T10:30:42.208Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/16/a68a19e5384e93f811dccc51034b1fd0b865841c390e3c931dcc4699e035/coverage-7.13.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0e223ce4b4ed47f065bfb123687686512e37629be25cc63728557ae7db261422", size = 219908, upload-time = "2026-03-17T10:30:43.906Z" },
+    { url = "https://files.pythonhosted.org/packages/29/72/20b917c6793af3a5ceb7fb9c50033f3ec7865f2911a1416b34a7cfa0813b/coverage-7.13.5-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:6e3370441f4513c6252bf042b9c36d22491142385049243253c7e48398a15a9f", size = 251419, upload-time = "2026-03-17T10:30:45.545Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/49/cd14b789536ac6a4778c453c6a2338bc0a2fb60c5a5a41b4008328b9acc1/coverage-7.13.5-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:03ccc709a17a1de074fb1d11f217342fb0d2b1582ed544f554fc9fc3f07e95f5", size = 254159, upload-time = "2026-03-17T10:30:47.204Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/00/7b0edcfe64e2ed4c0340dac14a52ad0f4c9bd0b8b5e531af7d55b703db7c/coverage-7.13.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3f4818d065964db3c1c66dc0fbdac5ac692ecbc875555e13374fdbe7eedb4376", size = 255270, upload-time = "2026-03-17T10:30:48.812Z" },
+    { url = "https://files.pythonhosted.org/packages/93/89/7ffc4ba0f5d0a55c1e84ea7cee39c9fc06af7b170513d83fbf3bbefce280/coverage-7.13.5-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:012d5319e66e9d5a218834642d6c35d265515a62f01157a45bcc036ecf947256", size = 257538, upload-time = "2026-03-17T10:30:50.77Z" },
+    { url = "https://files.pythonhosted.org/packages/81/bd/73ddf85f93f7e6fa83e77ccecb6162d9415c79007b4bc124008a4995e4a7/coverage-7.13.5-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:8dd02af98971bdb956363e4827d34425cb3df19ee550ef92855b0acb9c7ce51c", size = 251821, upload-time = "2026-03-17T10:30:52.5Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/81/278aff4e8dec4926a0bcb9486320752811f543a3ce5b602cc7a29978d073/coverage-7.13.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f08fd75c50a760c7eb068ae823777268daaf16a80b918fa58eea888f8e3919f5", size = 253191, upload-time = "2026-03-17T10:30:54.543Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ee/fe1621488e2e0a58d7e94c4800f0d96f79671553488d401a612bebae324b/coverage-7.13.5-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:843ea8643cf967d1ac7e8ecd4bb00c99135adf4816c0c0593fdcc47b597fcf09", size = 251337, upload-time = "2026-03-17T10:30:56.663Z" },
+    { url = "https://files.pythonhosted.org/packages/37/a6/f79fb37aa104b562207cc23cb5711ab6793608e246cae1e93f26b2236ed9/coverage-7.13.5-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:9d44d7aa963820b1b971dbecd90bfe5fe8f81cff79787eb6cca15750bd2f79b9", size = 255404, upload-time = "2026-03-17T10:30:58.427Z" },
+    { url = "https://files.pythonhosted.org/packages/75/f0/ed15262a58ec81ce457ceb717b7f78752a1713556b19081b76e90896e8d4/coverage-7.13.5-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:7132bed4bd7b836200c591410ae7d97bf7ae8be6fc87d160b2bd881df929e7bf", size = 250903, upload-time = "2026-03-17T10:31:00.093Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/e9/9129958f20e7e9d4d56d51d42ccf708d15cac355ff4ac6e736e97a9393d2/coverage-7.13.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a698e363641b98843c517817db75373c83254781426e94ada3197cabbc2c919c", size = 252780, upload-time = "2026-03-17T10:31:01.916Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/d7/0ad9b15812d81272db94379fe4c6df8fd17781cc7671fdfa30c76ba5ff7b/coverage-7.13.5-cp312-cp312-win32.whl", hash = "sha256:bdba0a6b8812e8c7df002d908a9a2ea3c36e92611b5708633c50869e6d922fdf", size = 222093, upload-time = "2026-03-17T10:31:03.642Z" },
+    { url = "https://files.pythonhosted.org/packages/29/3d/821a9a5799fac2556bcf0bd37a70d1d11fa9e49784b6d22e92e8b2f85f18/coverage-7.13.5-cp312-cp312-win_amd64.whl", hash = "sha256:d2c87e0c473a10bffe991502eac389220533024c8082ec1ce849f4218dded810", size = 222900, upload-time = "2026-03-17T10:31:05.651Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/fa/2238c2ad08e35cf4f020ea721f717e09ec3152aea75d191a7faf3ef009a8/coverage-7.13.5-cp312-cp312-win_arm64.whl", hash = "sha256:bf69236a9a81bdca3bff53796237aab096cdbf8d78a66ad61e992d9dac7eb2de", size = 221515, upload-time = "2026-03-17T10:31:07.293Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/ee/a4cf96b8ce1e566ed238f0659ac2d3f007ed1d14b181bcb684e19561a69a/coverage-7.13.5-py3-none-any.whl", hash = "sha256:34b02417cf070e173989b3db962f7ed56d2f644307b2cf9d5a0f258e13084a61", size = 211346, upload-time = "2026-03-17T10:33:15.691Z" },
+]
+
+[package.optional-dependencies]
+toml = [
+    { name = "tomli", marker = "python_full_version <= '3.11'" },
+]
+
+[[package]]
+name = "crosshair-tool"
+version = "0.0.102"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-metadata" },
+    { name = "packaging" },
+    { name = "pygls" },
+    { name = "typeshed-client" },
+    { name = "typing-extensions" },
+    { name = "typing-inspect" },
+    { name = "z3-solver" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7c/bd/3afb64fe1579be13b3199b659276c7c5be4303e0c578afa9c0ba1d6720f2/crosshair_tool-0.0.102.tar.gz", hash = "sha256:665aed0492618d9ae61a7f17d5d32ea2a7182c04d5a39ae81b5e3e519a7869ba", size = 476874, upload-time = "2026-01-19T21:02:23.452Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/a1/8ce819e5cfd20a533ea173de38b2e57e5dfff44bb249cbf933e0f5cabe8d/crosshair_tool-0.0.102-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:bf5932ba3fdf57e6879fd6f9895b180b6f572b0d600e3bf401d569780107f331", size = 540002, upload-time = "2026-01-19T21:01:27.171Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/4c/1fa9523024406679bbc2ca1a79bf533373a9d1b88c990cf48b197b112170/crosshair_tool-0.0.102-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:11f8ce72f847aa03e74b5e2f084f2c0ef870c4a4238c0eb998bb5f9d18c18291", size = 531978, upload-time = "2026-01-19T21:01:28.375Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/85/4d63b863b4c3312a0a186cffb618ae68f0ade285dd4e26b8b02c26d887c8/crosshair_tool-0.0.102-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:9bbea24684025b1fdf3deeddfc9cca08afa0a51ecb96c5022e487d8e9c954536", size = 532730, upload-time = "2026-01-19T21:01:29.722Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/c1/dcb89dc2a58d8160c5b7fe52754c08399270e927f9606ca85ceff354e06a/crosshair_tool-0.0.102-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0a67f76708e640b2128eb46cf887452b513c6b56ad62305320ca410055304c69", size = 555964, upload-time = "2026-01-19T21:01:30.879Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/83/5a4243079c5ce13f74b1de2fc736411dc70d82352cbb758186c7b45e7684/crosshair_tool-0.0.102-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:220a1e611979832c00f4c035df0fc280c4967c111e4bf729a223b4b0d58b0b6d", size = 555962, upload-time = "2026-01-19T21:01:32.461Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/12/8a40ea9e2fcef2d8068c1ce1f60657d82ea474a644136625c54d2db230ae/crosshair_tool-0.0.102-cp311-cp311-win32.whl", hash = "sha256:5cfe0c2268aad0afb22523b8c787d2e8d8afa49b28da55ffb012402ea240a643", size = 535071, upload-time = "2026-01-19T21:01:33.664Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/fd/27e79263caecc93a5fc88f91a0adddbe8719864d07cb9c7a6989685e1e81/crosshair_tool-0.0.102-cp311-cp311-win_amd64.whl", hash = "sha256:88315c978dcfecb11182c5aec5dfca79f03760e6333f103d30699363333b7c83", size = 536071, upload-time = "2026-01-19T21:01:34.781Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/ea/0d72bf6ed09dbbab3ed3ccdc8b92b10cb71cf558e0cc91a883aabca5f362/crosshair_tool-0.0.102-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:2855af2e407e9647efad0b68f6450e550b5317b4835f2524e259470a4db10e7e", size = 543893, upload-time = "2026-01-19T21:01:35.921Z" },
+    { url = "https://files.pythonhosted.org/packages/df/21/b86dc8560b012a26fab476f2d40dcb1c1f9bf9cea8e5724fc47bd9e29267/crosshair_tool-0.0.102-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2b27cad5da5aaa380901c45763c5761a0adc6b810143ec79ad63a325bda1c891", size = 534418, upload-time = "2026-01-19T21:01:36.973Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/05/4108662d96649f615d7b5cf7b5a79c3ef41b9c45ff46f902a801dc735ce6/crosshair_tool-0.0.102-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1794248011f3e8acab24c7d9adc49756b486e9c7ff952588f925d25976d1fc0a", size = 535002, upload-time = "2026-01-19T21:01:38.121Z" },
+    { url = "https://files.pythonhosted.org/packages/46/92/0b7bb56176dedb848ec874a18a4714169c0055b935209e00124f93913953/crosshair_tool-0.0.102-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:e04218a46fc32dd298b17f8a2e223f6caf037f91e024d7eb4bbbcf6a30e963d5", size = 565951, upload-time = "2026-01-19T21:01:39.247Z" },
+    { url = "https://files.pythonhosted.org/packages/df/fb/e758194361a40893957158982523f8933ffe7dc5b27795c1d4bfe296d4a4/crosshair_tool-0.0.102-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77742e809d6d98bea94e9f1fcbaf2320ae72d45a6a31ac4268fab669e428fdb9", size = 565010, upload-time = "2026-01-19T21:01:40.34Z" },
+    { url = "https://files.pythonhosted.org/packages/34/f9/6572e7396da2f61fd707475ac14e92446b827ad2bed970c512d2ab9bf6c2/crosshair_tool-0.0.102-cp312-cp312-win32.whl", hash = "sha256:9d71370d16c9d8d54deef97fe629d6e46108babbdb3272396ad923f8489be3a7", size = 536764, upload-time = "2026-01-19T21:01:41.47Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/b3/28a4cd102955bff40f43de0f5f21d4e1d1423c1fc22327d08b878ed7452a/crosshair_tool-0.0.102-cp312-cp312-win_amd64.whl", hash = "sha256:62dc6ae10e612b6b0796a16992edc26763712a1dc574308da0a16b9eedc20ecd", size = 537879, upload-time = "2026-01-19T21:01:42.8Z" },
 ]
 
 [[package]]
@@ -558,6 +646,18 @@ wheels = [
 ]
 
 [[package]]
+name = "hypothesis"
+version = "6.151.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/dd/633e2cd62377333b7681628aee2ec1d88166f5bdf916b08c98b1e8288ad3/hypothesis-6.151.10.tar.gz", hash = "sha256:6c9565af8b4aa3a080b508f66ce9c2a77dd613c7e9073e27fc7e4ef9f45f8a27", size = 463762, upload-time = "2026-03-29T01:06:22.19Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/40/da/439bb2e451979f5e88c13bbebc3e9e17754429cfb528c93677b2bd81783b/hypothesis-6.151.10-py3-none-any.whl", hash = "sha256:b0d7728f0c8c2be009f89fcdd6066f70c5439aa0f94adbb06e98261d05f49b05", size = 529493, upload-time = "2026-03-29T01:06:19.161Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.11"
 source = { registry = "https://pypi.org/simple" }
@@ -576,6 +676,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fa/5e/f8e9a1d23b9c20a551a8a02ea3637b4642e22c2626e3a13a9a29cdea99eb/importlib_metadata-8.7.1-py3-none-any.whl", hash = "sha256:5a1f80bf1daa489495071efbb095d75a634cf28a8bc299581244063b53176151", size = 27865, upload-time = "2025-12-21T10:00:18.329Z" },
+]
+
+[[package]]
+name = "importlib-resources"
+version = "6.5.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cf/8c/f834fbf984f691b4f7ff60f50b514cc3de5cc08abfc3295564dd89c5e2e7/importlib_resources-6.5.2.tar.gz", hash = "sha256:185f87adef5bcc288449d98fb4fba07cea78bc036455dd44c5fc4a2fe78fed2c", size = 44693, upload-time = "2025-01-03T18:51:56.698Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/ed/1f1afb2e9e7f38a545d628f864d562a5ae64fe6f7a10e28ffb9b185b4e89/importlib_resources-6.5.2-py3-none-any.whl", hash = "sha256:789cfdc3ed28c78b67a06acb8126751ced69a3d5f79c095a98298cd8a760ccec", size = 37461, upload-time = "2025-01-03T18:51:54.306Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -702,6 +820,45 @@ wheels = [
 ]
 
 [[package]]
+name = "libcst"
+version = "1.8.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/cd/337df968b38d94c5aabd3e1b10630f047a2b345f6e1d4456bd9fe7417537/libcst-1.8.6.tar.gz", hash = "sha256:f729c37c9317126da9475bdd06a7208eb52fcbd180a6341648b45a56b4ba708b", size = 891354, upload-time = "2025-11-03T22:33:30.621Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/15/95c2ecadc0fb4af8a7057ac2012a4c0ad5921b9ef1ace6c20006b56d3b5f/libcst-1.8.6-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:3649a813660fbffd7bc24d3f810b1f75ac98bd40d9d6f56d1f0ee38579021073", size = 2211289, upload-time = "2025-11-03T22:32:04.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c3/7e1107acd5ed15cf60cc07c7bb64498a33042dc4821874aea3ec4942f3cd/libcst-1.8.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0cbe17067055829607c5ba4afa46bfa4d0dd554c0b5a583546e690b7367a29b6", size = 2092927, upload-time = "2025-11-03T22:32:06.209Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ff/0d2be87f67e2841a4a37d35505e74b65991d30693295c46fc0380ace0454/libcst-1.8.6-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:59a7e388c57d21d63722018978a8ddba7b176e3a99bd34b9b84a576ed53f2978", size = 2237002, upload-time = "2025-11-03T22:32:07.559Z" },
+    { url = "https://files.pythonhosted.org/packages/69/99/8c4a1b35c7894ccd7d33eae01ac8967122f43da41325223181ca7e4738fe/libcst-1.8.6-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:b6c1248cc62952a3a005792b10cdef2a4e130847be9c74f33a7d617486f7e532", size = 2301048, upload-time = "2025-11-03T22:32:08.869Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/8b/d1aa811eacf936cccfb386ae0585aa530ea1221ccf528d67144e041f5915/libcst-1.8.6-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6421a930b028c5ef4a943b32a5a78b7f1bf15138214525a2088f11acbb7d3d64", size = 2300675, upload-time = "2025-11-03T22:32:10.579Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/6b/7b65cd41f25a10c1fef2389ddc5c2b2cc23dc4d648083fa3e1aa7e0eeac2/libcst-1.8.6-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:6d8b67874f2188399a71a71731e1ba2d1a2c3173b7565d1cc7ffb32e8fbaba5b", size = 2407934, upload-time = "2025-11-03T22:32:11.856Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/8b/401cfff374bb3b785adfad78f05225225767ee190997176b2a9da9ed9460/libcst-1.8.6-cp311-cp311-win_amd64.whl", hash = "sha256:b0d8c364c44ae343937f474b2e492c1040df96d94530377c2f9263fb77096e4f", size = 2119247, upload-time = "2025-11-03T22:32:13.279Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/17/085f59eaa044b6ff6bc42148a5449df2b7f0ba567307de7782fe85c39ee2/libcst-1.8.6-cp311-cp311-win_arm64.whl", hash = "sha256:5dcaaebc835dfe5755bc85f9b186fb7e2895dda78e805e577fef1011d51d5a5c", size = 2001774, upload-time = "2025-11-03T22:32:14.647Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/3c/93365c17da3d42b055a8edb0e1e99f1c60c776471db6c9b7f1ddf6a44b28/libcst-1.8.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:0c13d5bd3d8414a129e9dccaf0e5785108a4441e9b266e1e5e9d1f82d1b943c9", size = 2206166, upload-time = "2025-11-03T22:32:16.012Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/cb/7530940e6ac50c6dd6022349721074e19309eb6aa296e942ede2213c1a19/libcst-1.8.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f1472eeafd67cdb22544e59cf3bfc25d23dc94058a68cf41f6654ff4fcb92e09", size = 2083726, upload-time = "2025-11-03T22:32:17.312Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/cf/7e5eaa8c8f2c54913160671575351d129170db757bb5e4b7faffed022271/libcst-1.8.6-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:089c58e75cb142ec33738a1a4ea7760a28b40c078ab2fd26b270dac7d2633a4d", size = 2235755, upload-time = "2025-11-03T22:32:18.859Z" },
+    { url = "https://files.pythonhosted.org/packages/55/54/570ec2b0e9a3de0af9922e3bb1b69a5429beefbc753a7ea770a27ad308bd/libcst-1.8.6-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:c9d7aeafb1b07d25a964b148c0dda9451efb47bbbf67756e16eeae65004b0eb5", size = 2301473, upload-time = "2025-11-03T22:32:20.499Z" },
+    { url = "https://files.pythonhosted.org/packages/11/4c/163457d1717cd12181c421a4cca493454bcabd143fc7e53313bc6a4ad82a/libcst-1.8.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:207481197afd328aa91d02670c15b48d0256e676ce1ad4bafb6dc2b593cc58f1", size = 2298899, upload-time = "2025-11-03T22:32:21.765Z" },
+    { url = "https://files.pythonhosted.org/packages/35/1d/317ddef3669883619ef3d3395ea583305f353ef4ad87d7a5ac1c39be38e3/libcst-1.8.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:375965f34cc6f09f5f809244d3ff9bd4f6cb6699f571121cebce53622e7e0b86", size = 2408239, upload-time = "2025-11-03T22:32:23.275Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a1/f47d8cccf74e212dd6044b9d6dbc223636508da99acff1d54786653196bc/libcst-1.8.6-cp312-cp312-win_amd64.whl", hash = "sha256:da95b38693b989eaa8d32e452e8261cfa77fe5babfef1d8d2ac25af8c4aa7e6d", size = 2119660, upload-time = "2025-11-03T22:32:24.822Z" },
+    { url = "https://files.pythonhosted.org/packages/19/d0/dd313bf6a7942cdf951828f07ecc1a7695263f385065edc75ef3016a3cb5/libcst-1.8.6-cp312-cp312-win_arm64.whl", hash = "sha256:bff00e1c766658adbd09a175267f8b2f7616e5ee70ce45db3d7c4ce6d9f6bec7", size = 1999824, upload-time = "2025-11-03T22:32:26.131Z" },
+]
+
+[[package]]
+name = "linkify-it-py"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "uc-micro-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2e/c9/06ea13676ef354f0af6169587ae292d3e2406e212876a413bf9eece4eb23/linkify_it_py-2.1.0.tar.gz", hash = "sha256:43360231720999c10e9328dc3691160e27a718e280673d444c38d7d3aaa3b98b", size = 29158, upload-time = "2026-03-01T07:48:47.683Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/de/88b3be5c31b22333b3ca2f6ff1de4e863d8fe45aaea7485f591970ec1d3e/linkify_it_py-2.1.0-py3-none-any.whl", hash = "sha256:0d252c1594ecba2ecedc444053db5d3a9b7ec1b0dd929c8f1d74dce89f86c05e", size = 19878, upload-time = "2026-03-01T07:48:46.098Z" },
+]
+
+[[package]]
 name = "litellm"
 version = "1.80.0"
 source = { registry = "https://pypi.org/simple" }
@@ -722,6 +879,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/bd/8c/48d533affdbc6d485b7ad4221cd3b40b8c12f9f5568edfe0be0b11e7b945/litellm-1.80.0.tar.gz", hash = "sha256:eeac733eb6b226f9e5fb020f72fe13a32b3354b001dc62bcf1bc4d9b526d6231", size = 11591976, upload-time = "2025-11-16T00:03:51.812Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ea/53/aa31e4d057b3746b3c323ca993003d6cf15ef987e7fe7ceb53681695ae87/litellm-1.80.0-py3-none-any.whl", hash = "sha256:fd0009758f4772257048d74bf79bb64318859adb4ea49a8b66fdbc718cd80b6e", size = 10492975, upload-time = "2025-11-16T00:03:49.182Z" },
+]
+
+[[package]]
+name = "lsprotocol"
+version = "2025.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "cattrs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/26/67b84e6ec1402f0e6764ef3d2a0aaf9a79522cc1d37738f4e5bb0b21521a/lsprotocol-2025.0.0.tar.gz", hash = "sha256:e879da2b9301e82cfc3e60d805630487ac2f7ab17492f4f5ba5aaba94fe56c29", size = 74896, upload-time = "2025-06-17T21:30:18.156Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/f0/92f2d609d6642b5f30cb50a885d2bf1483301c69d5786286500d15651ef2/lsprotocol-2025.0.0-py3-none-any.whl", hash = "sha256:f9d78f25221f2a60eaa4a96d3b4ffae011b107537facee61d3da3313880995c7", size = 76250, upload-time = "2025-06-17T21:30:19.455Z" },
 ]
 
 [[package]]
@@ -772,6 +942,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
 ]
 
+[package.optional-dependencies]
+linkify = [
+    { name = "linkify-it-py" },
+]
+
 [[package]]
 name = "markupsafe"
 version = "3.0.3"
@@ -800,6 +975,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
     { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
     { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
+]
+
+[[package]]
+name = "mdit-py-plugins"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b2/fd/a756d36c0bfba5f6e39a1cdbdbfdd448dc02692467d83816dff4592a1ebc/mdit_py_plugins-0.5.0.tar.gz", hash = "sha256:f4918cb50119f50446560513a8e311d574ff6aaed72606ddae6d35716fe809c6", size = 44655, upload-time = "2025-08-11T07:25:49.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl", hash = "sha256:07a08422fc1936a5d26d146759e9155ea466e842f5ab2f7d2266dd084c8dab1f", size = 57205, upload-time = "2025-08-11T07:25:47.597Z" },
 ]
 
 [[package]]
@@ -880,6 +1067,32 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/80/31/0b2517913687895f5904325c2069d6a3b78f66cc641a86a2baf75a05dcbb/multidict-6.7.1-cp312-cp312-win_amd64.whl", hash = "sha256:fcee94dfbd638784645b066074b338bc9cc155d4b4bffa4adce1615c5a426c19", size = 46053, upload-time = "2026-01-26T02:44:15.371Z" },
     { url = "https://files.pythonhosted.org/packages/0c/5b/aba28e4ee4006ae4c7df8d327d31025d760ffa992ea23812a601d226e682/multidict-6.7.1-cp312-cp312-win_arm64.whl", hash = "sha256:ba0a9fb644d0c1a2194cf7ffb043bd852cea63a57f66fbd33959f7dae18517bf", size = 43307, upload-time = "2026-01-26T02:44:16.852Z" },
     { url = "https://files.pythonhosted.org/packages/81/08/7036c080d7117f28a4af526d794aab6a84463126db031b007717c1a6676e/multidict-6.7.1-py3-none-any.whl", hash = "sha256:55d97cc6dae627efa6a6e548885712d4864b81110ac76fa4e534c03819fa4a56", size = 12319, upload-time = "2026-01-26T02:46:44.004Z" },
+]
+
+[[package]]
+name = "mutmut"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "coverage" },
+    { name = "libcst" },
+    { name = "pytest" },
+    { name = "setproctitle" },
+    { name = "textual" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/0d/9ce4fc8b219504a336eb814c5a7ea8e379ad93ce05327ff3842aea93bf0b/mutmut-3.5.0.tar.gz", hash = "sha256:548186d4b0c494b7b9895db82871cb1f229b9271c9ff7cd633e348dd9afcc772", size = 36389, upload-time = "2026-02-22T18:46:41.824Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/23/ac475f6db39643946feb09290a2178d603d2b623034d56d3f5059cddb769/mutmut-3.5.0-py3-none-any.whl", hash = "sha256:f19f2dd2e977eb9dc17255d8cb11e24fbfc3191620fba3108cac25779c9d78c9", size = 34242, upload-time = "2026-02-22T18:46:43.113Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
 ]
 
 [[package]]
@@ -1038,6 +1251,24 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a6/de/8b1895b107277d52f2b42d3a6806e69cfef0d5cf1d0ba343470b9d8e0a04/pandas-2.3.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a68e15f780eddf2b07d242e17a04aa187a7ee12b40b930bfdd78070556550e98", size = 12771002, upload-time = "2025-09-29T23:20:26.76Z" },
     { url = "https://files.pythonhosted.org/packages/87/21/84072af3187a677c5893b170ba2c8fbe450a6ff911234916da889b698220/pandas-2.3.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:371a4ab48e950033bcf52b6527eccb564f52dc826c02afd9a1bc0ab731bba084", size = 13450971, upload-time = "2025-09-29T23:20:41.344Z" },
     { url = "https://files.pythonhosted.org/packages/86/41/585a168330ff063014880a80d744219dbf1dd7a1c706e75ab3425a987384/pandas-2.3.3-cp312-cp312-win_amd64.whl", hash = "sha256:a16dcec078a01eeef8ee61bf64074b4e524a2a3f4b3be9326420cabe59c4778b", size = 10992722, upload-time = "2025-09-29T23:20:54.139Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.9.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/56/8d4c30c8a1d07013911a8fdbd8f89440ef9f08d07a1b50ab8ca8be5a20f9/platformdirs-4.9.4.tar.gz", hash = "sha256:1ec356301b7dc906d83f371c8f487070e99d3ccf9e501686456394622a01a934", size = 28737, upload-time = "2026-03-05T18:34:13.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/d7/97f7e3a6abb67d8080dd406fd4df842c2be0efaf712d1c899c32a075027c/platformdirs-4.9.4-py3-none-any.whl", hash = "sha256:68a9a4619a666ea6439f2ff250c12a853cd1cbd5158d258bd824a7df6be2f868", size = 21216, upload-time = "2026-03-05T18:34:12.172Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -1211,6 +1442,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pygls"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "cattrs" },
+    { name = "lsprotocol" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/2e/7bbe061d175c0baddde8fc9edb908a4c31ba5d9165b8c68e3439c3a9f138/pygls-2.1.1.tar.gz", hash = "sha256:1da03ba9053201bb337dcdd8d121df70feb2a91e1a0dcc74de5da79755b1a201", size = 55091, upload-time = "2026-03-25T11:19:10.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/1a/208293b6c350f5abea6941d5606080d4a492644052504f5312e5de30a902/pygls-2.1.1-py3-none-any.whl", hash = "sha256:510a6dea2476177230c7d851125e5948efdf3fdb9ebfd8543fc434972f8faed4", size = 68975, upload-time = "2026-03-25T11:19:11.374Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1230,6 +1475,36 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/74/b2/5db700e52554b8f025faa9c3c624c59f1f6c8841ba81ab97641b54322f16/pyright-1.1.408.tar.gz", hash = "sha256:f28f2321f96852fa50b5829ea492f6adb0e6954568d1caa3f3af3a5f555eb684", size = 4400578, upload-time = "2026-01-08T08:07:38.795Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/82/a2c93e32800940d9573fb28c346772a14778b84ba7524e691b324620ab89/pyright-1.1.408-py3-none-any.whl", hash = "sha256:090b32865f4fdb1e0e6cd82bf5618480d48eecd2eb2e70f960982a3d9a4c17c1", size = 6399144, upload-time = "2026-01-08T08:07:37.082Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "8.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage", extra = ["toml"] },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
 ]
 
 [[package]]
@@ -1447,6 +1722,37 @@ wheels = [
 ]
 
 [[package]]
+name = "setproctitle"
+version = "1.3.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8d/48/49393a96a2eef1ab418b17475fb92b8fcfad83d099e678751b05472e69de/setproctitle-1.3.7.tar.gz", hash = "sha256:bc2bc917691c1537d5b9bca1468437176809c7e11e5694ca79a9ca12345dcb9e", size = 27002, upload-time = "2025-09-05T12:51:25.278Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/cd/1b7ba5cad635510720ce19d7122154df96a2387d2a74217be552887c93e5/setproctitle-1.3.7-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:a600eeb4145fb0ee6c287cb82a2884bd4ec5bbb076921e287039dcc7b7cc6dd0", size = 18085, upload-time = "2025-09-05T12:49:22.183Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/1a/b2da0a620490aae355f9d72072ac13e901a9fec809a6a24fc6493a8f3c35/setproctitle-1.3.7-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:97a090fed480471bb175689859532709e28c085087e344bca45cf318034f70c4", size = 13097, upload-time = "2025-09-05T12:49:23.322Z" },
+    { url = "https://files.pythonhosted.org/packages/18/2e/bd03ff02432a181c1787f6fc2a678f53b7dacdd5ded69c318fe1619556e8/setproctitle-1.3.7-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:1607b963e7b53e24ec8a2cb4e0ab3ae591d7c6bf0a160feef0551da63452b37f", size = 32191, upload-time = "2025-09-05T12:49:24.567Z" },
+    { url = "https://files.pythonhosted.org/packages/28/78/1e62fc0937a8549f2220445ed2175daacee9b6764c7963b16148119b016d/setproctitle-1.3.7-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a20fb1a3974e2dab857870cf874b325b8705605cb7e7e8bcbb915bca896f52a9", size = 33203, upload-time = "2025-09-05T12:49:25.871Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/3c/65edc65db3fa3df400cf13b05e9d41a3c77517b4839ce873aa6b4043184f/setproctitle-1.3.7-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f8d961bba676e07d77665204f36cffaa260f526e7b32d07ab3df6a2c1dfb44ba", size = 34963, upload-time = "2025-09-05T12:49:27.044Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/32/89157e3de997973e306e44152522385f428e16f92f3cf113461489e1e2ee/setproctitle-1.3.7-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:db0fd964fbd3a9f8999b502f65bd2e20883fdb5b1fae3a424e66db9a793ed307", size = 32398, upload-time = "2025-09-05T12:49:28.909Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/18/77a765a339ddf046844cb4513353d8e9dcd8183da9cdba6e078713e6b0b2/setproctitle-1.3.7-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:db116850fcf7cca19492030f8d3b4b6e231278e8fe097a043957d22ce1bdf3ee", size = 33657, upload-time = "2025-09-05T12:49:30.323Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/63/f0b6205c64d74d2a24a58644a38ec77bdbaa6afc13747e75973bf8904932/setproctitle-1.3.7-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:316664d8b24a5c91ee244460bdaf7a74a707adaa9e14fbe0dc0a53168bb9aba1", size = 31836, upload-time = "2025-09-05T12:49:32.309Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/51/e1277f9ba302f1a250bbd3eedbbee747a244b3cc682eb58fb9733968f6d8/setproctitle-1.3.7-cp311-cp311-win32.whl", hash = "sha256:b74774ca471c86c09b9d5037c8451fff06bb82cd320d26ae5a01c758088c0d5d", size = 12556, upload-time = "2025-09-05T12:49:33.529Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/7b/822a23f17e9003dfdee92cd72758441ca2a3680388da813a371b716fb07f/setproctitle-1.3.7-cp311-cp311-win_amd64.whl", hash = "sha256:acb9097213a8dd3410ed9f0dc147840e45ca9797785272928d4be3f0e69e3be4", size = 13243, upload-time = "2025-09-05T12:49:34.553Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/f0/2dc88e842077719d7384d86cc47403e5102810492b33680e7dadcee64cd8/setproctitle-1.3.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:2dc99aec591ab6126e636b11035a70991bc1ab7a261da428491a40b84376654e", size = 18049, upload-time = "2025-09-05T12:49:36.241Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/b4/50940504466689cda65680c9e9a1e518e5750c10490639fa687489ac7013/setproctitle-1.3.7-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:cdd8aa571b7aa39840fdbea620e308a19691ff595c3a10231e9ee830339dd798", size = 13079, upload-time = "2025-09-05T12:49:38.088Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/99/71630546b9395b095f4082be41165d1078204d1696c2d9baade3de3202d0/setproctitle-1.3.7-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2906b6c7959cdb75f46159bf0acd8cc9906cf1361c9e1ded0d065fe8f9039629", size = 32932, upload-time = "2025-09-05T12:49:39.271Z" },
+    { url = "https://files.pythonhosted.org/packages/50/22/cee06af4ffcfb0e8aba047bd44f5262e644199ae7527ae2c1f672b86495c/setproctitle-1.3.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6915964a6dda07920a1159321dcd6d94fc7fc526f815ca08a8063aeca3c204f1", size = 33736, upload-time = "2025-09-05T12:49:40.565Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/00/a5949a8bb06ef5e7df214fc393bb2fb6aedf0479b17214e57750dfdd0f24/setproctitle-1.3.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cff72899861c765bd4021d1ff1c68d60edc129711a2fdba77f9cb69ef726a8b6", size = 35605, upload-time = "2025-09-05T12:49:42.362Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3a/50caca532a9343828e3bf5778c7a84d6c737a249b1796d50dd680290594d/setproctitle-1.3.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b7cb05bd446687ff816a3aaaf831047fc4c364feff7ada94a66024f1367b448c", size = 33143, upload-time = "2025-09-05T12:49:43.515Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/14/b843a251296ce55e2e17c017d6b9f11ce0d3d070e9265de4ecad948b913d/setproctitle-1.3.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:3a57b9a00de8cae7e2a1f7b9f0c2ac7b69372159e16a7708aa2f38f9e5cc987a", size = 34434, upload-time = "2025-09-05T12:49:45.31Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/b7/06145c238c0a6d2c4bc881f8be230bb9f36d2bf51aff7bddcb796d5eed67/setproctitle-1.3.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:d8828b356114f6b308b04afe398ed93803d7fca4a955dd3abe84430e28d33739", size = 32795, upload-time = "2025-09-05T12:49:46.419Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/dc/ef76a81fac9bf27b84ed23df19c1f67391a753eed6e3c2254ebcb5133f56/setproctitle-1.3.7-cp312-cp312-win32.whl", hash = "sha256:b0304f905efc845829ac2bc791ddebb976db2885f6171f4a3de678d7ee3f7c9f", size = 12552, upload-time = "2025-09-05T12:49:47.635Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/5b/a9fe517912cd6e28cf43a212b80cb679ff179a91b623138a99796d7d18a0/setproctitle-1.3.7-cp312-cp312-win_amd64.whl", hash = "sha256:9888ceb4faea3116cf02a920ff00bfbc8cc899743e4b4ac914b03625bdc3c300", size = 13247, upload-time = "2025-09-05T12:49:49.16Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/5b/5e1c117ac84e3cefcf8d7a7f6b2461795a87e20869da065a5c087149060b/setproctitle-1.3.7-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:b1cac6a4b0252b8811d60b6d8d0f157c0fdfed379ac89c25a914e6346cf355a1", size = 12587, upload-time = "2025-09-05T12:51:21.195Z" },
+    { url = "https://files.pythonhosted.org/packages/73/02/b9eadc226195dcfa90eed37afe56b5dd6fa2f0e5220ab8b7867b8862b926/setproctitle-1.3.7-pp311-pypy311_pp73-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f1704c9e041f2b1dc38f5be4552e141e1432fba3dd52c72eeffd5bc2db04dc65", size = 14286, upload-time = "2025-09-05T12:51:22.61Z" },
+    { url = "https://files.pythonhosted.org/packages/28/26/1be1d2a53c2a91ec48fa2ff4a409b395f836798adf194d99de9c059419ea/setproctitle-1.3.7-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:b08b61976ffa548bd5349ce54404bf6b2d51bd74d4f1b241ed1b0f25bce09c3a", size = 13282, upload-time = "2025-09-05T12:51:24.094Z" },
+]
+
+[[package]]
 name = "shellingham"
 version = "1.5.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1471,6 +1777,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
 ]
 
 [[package]]
@@ -1531,6 +1846,23 @@ wheels = [
 ]
 
 [[package]]
+name = "textual"
+version = "8.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py", extra = ["linkify"] },
+    { name = "mdit-py-plugins" },
+    { name = "platformdirs" },
+    { name = "pygments" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4f/07/766ad19cf2b15cae2d79e0db46a1b783b62316e9ff3e058e7424b2a4398b/textual-8.2.1.tar.gz", hash = "sha256:4176890e9cd5c95dcdd206541b2956b0808e74c8c36381c88db53dcb45237451", size = 1848386, upload-time = "2026-03-29T03:57:32.242Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/25/09/c6f000c2e3702036e593803319af02feee58a662528d0d5728a37e1cf81b/textual-8.2.1-py3-none-any.whl", hash = "sha256:746cbf947a8ca875afc09779ef38cadbc7b9f15ac886a5090f7099fef5ade990", size = 723871, upload-time = "2026-03-29T03:57:34.334Z" },
+]
+
+[[package]]
 name = "tiktoken"
 version = "0.12.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1583,6 +1915,33 @@ wheels = [
 ]
 
 [[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30", size = 154704, upload-time = "2026-03-25T20:21:10.473Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a", size = 149454, upload-time = "2026-03-25T20:21:12.036Z" },
+    { url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076", size = 237561, upload-time = "2026-03-25T20:21:13.098Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9", size = 243824, upload-time = "2026-03-25T20:21:14.569Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c", size = 242227, upload-time = "2026-03-25T20:21:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc", size = 247859, upload-time = "2026-03-25T20:21:17.001Z" },
+    { url = "https://files.pythonhosted.org/packages/83/bd/6c1a630eaca337e1e78c5903104f831bda934c426f9231429396ce3c3467/tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049", size = 97204, upload-time = "2026-03-25T20:21:18.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e", size = 108084, upload-time = "2026-03-25T20:21:18.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/83/dceca96142499c069475b790e7913b1044c1a4337e700751f48ed723f883/tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece", size = 95285, upload-time = "2026-03-25T20:21:20.309Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
 name = "torghut"
 version = "0.1.0"
 source = { editable = "." }
@@ -1607,7 +1966,13 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
+    { name = "coverage", extra = ["toml"] },
+    { name = "crosshair-tool" },
+    { name = "hypothesis" },
+    { name = "mutmut" },
     { name = "pyright" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
     { name = "ruff" },
 ]
 
@@ -1615,11 +1980,15 @@ dev = [
 requires-dist = [
     { name = "alembic", specifier = ">=1.13.2,<2.0" },
     { name = "alpaca-py", specifier = ">=0.33.0,<1.0" },
+    { name = "coverage", extras = ["toml"], marker = "extra == 'dev'", specifier = ">=7.10.0,<8.0" },
+    { name = "crosshair-tool", marker = "extra == 'dev'", specifier = ">=0.0.95,<1.0" },
     { name = "dspy-ai", specifier = ">=2.6.27,<3.0" },
     { name = "fastapi", specifier = ">=0.115.0,<1.0" },
+    { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.151.0,<7.0" },
     { name = "inngest", specifier = ">=0.5.15,<1.0" },
     { name = "kafka-python", specifier = ">=2.2.0,<3.0" },
     { name = "lz4", specifier = ">=4.3.3,<5.0" },
+    { name = "mutmut", marker = "extra == 'dev'", specifier = ">=3.3.1,<4.0" },
     { name = "numpy", specifier = ">=2.1.2,<3.0" },
     { name = "openai", specifier = ">=1.55.3,<2.0" },
     { name = "pandas", specifier = ">=2.2.3,<3.0" },
@@ -1627,6 +1996,8 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.9.0,<3.0" },
     { name = "pydantic-settings", specifier = ">=2.6.0,<3.0" },
     { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.389,<2.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.4.0,<9.0" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=7.0.0,<8.0" },
     { name = "pyyaml", specifier = ">=6.0.2,<7.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.9.0,<1.0" },
     { name = "sqlalchemy", specifier = ">=2.0.36,<3.0" },
@@ -1662,12 +2033,38 @@ wheels = [
 ]
 
 [[package]]
+name = "typeshed-client"
+version = "2.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-resources" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/34/e9fcb7ebbace96b6ab0f397df47dad7e42d8819aa091bc6c4ea1e7f9226b/typeshed_client-2.9.0.tar.gz", hash = "sha256:9c2659a4ba11a9d8597d63770416b42c69861189bf861809f6443d329c84be3a", size = 521553, upload-time = "2026-03-01T18:25:57.658Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/86/50/42c0cadd4d62b0d98929db479346b7da6e4ab8346a4de39ed80176fb39b7/typeshed_client-2.9.0-py3-none-any.whl", hash = "sha256:9383660241a4864fd4af971e533b735bd8c5b3d2f88f7ac279e41699ebe1369c", size = 786547, upload-time = "2026-03-01T18:25:55.976Z" },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspect"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mypy-extensions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dc/74/1789779d91f1961fa9438e9a8710cdae6bd138c80d7303996933d117264a/typing_inspect-0.9.0.tar.gz", hash = "sha256:b23fc42ff6f6ef6954e4852c1fb512cdd18dbea03134f91f856a95ccc9461f78", size = 13825, upload-time = "2023-05-24T20:25:47.612Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/f3/107a22063bf27bdccf2024833d3445f4eea42b2e598abfbd46f6a63b6cb0/typing_inspect-0.9.0-py3-none-any.whl", hash = "sha256:9ee6fc59062311ef8547596ab6b955e1b8aa46242d854bfc78f4f6b0eff35f9f", size = 8827, upload-time = "2023-05-24T20:25:45.287Z" },
 ]
 
 [[package]]
@@ -1689,6 +2086,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5e/a7/c202b344c5ca7daf398f3b8a477eeb205cf3b6f32e7ec3a6bac0629ca975/tzdata-2025.3.tar.gz", hash = "sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7", size = 196772, upload-time = "2025-12-13T17:45:35.667Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/b0/003792df09decd6849a5e39c28b513c06e84436a54440380862b5aeff25d/tzdata-2025.3-py2.py3-none-any.whl", hash = "sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1", size = 348521, upload-time = "2025-12-13T17:45:33.889Z" },
+]
+
+[[package]]
+name = "uc-micro-py"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/67/9a363818028526e2d4579334460df777115bdec1bb77c08f9db88f6389f2/uc_micro_py-2.0.0.tar.gz", hash = "sha256:c53691e495c8db60e16ffc4861a35469b0ba0821fe409a8a7a0a71864d33a811", size = 6611, upload-time = "2026-03-01T06:31:27.526Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/73/d21edf5b204d1467e06500080a50f79d49ef2b997c79123a536d4a17d97c/uc_micro_py-2.0.0-py3-none-any.whl", hash = "sha256:3603a3859af53e5a39bc7677713c78ea6589ff188d70f4fee165db88e22b242c", size = 6383, upload-time = "2026-03-01T06:31:26.257Z" },
 ]
 
 [[package]]
@@ -1904,6 +2310,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/9a/6ad1a9b37c2f72874f93e691b2e7ecb6137fb2b899983125db4204e47575/yarl-1.22.0-cp312-cp312-win_amd64.whl", hash = "sha256:8884d8b332a5e9b88e23f60bb166890009429391864c685e17bd73a9eda9105c", size = 87213, upload-time = "2025-10-06T14:10:11.369Z" },
     { url = "https://files.pythonhosted.org/packages/44/c5/c21b562d1680a77634d748e30c653c3ca918beb35555cff24986fff54598/yarl-1.22.0-cp312-cp312-win_arm64.whl", hash = "sha256:ea70f61a47f3cc93bdf8b2f368ed359ef02a01ca6393916bc8ff877427181e74", size = 81330, upload-time = "2025-10-06T14:10:13.112Z" },
     { url = "https://files.pythonhosted.org/packages/73/ae/b48f95715333080afb75a4504487cbe142cae1268afc482d06692d605ae6/yarl-1.22.0-py3-none-any.whl", hash = "sha256:1380560bdba02b6b6c90de54133c81c9f2a453dee9912fe58c1dcced1edb7cff", size = 46814, upload-time = "2025-10-06T14:12:53.872Z" },
+]
+
+[[package]]
+name = "z3-solver"
+version = "4.16.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/93/3b/2b714c40ef2ecf6d8aa080056b9c24a77fe4ca2c83abd83e9c93d34212ac/z3_solver-4.16.0.0.tar.gz", hash = "sha256:263d9ad668966e832c2b246ba0389298a599637793da2dc01cc5e4ef4b0b6c78", size = 5098891, upload-time = "2026-02-19T04:14:08.818Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2d/5d/9b277a80333db6b85fedd0f5082e311efcbaec47f2c44c57d38953c2d4d9/z3_solver-4.16.0.0-py3-none-macosx_15_0_arm64.whl", hash = "sha256:cc52843cfdd3d3f2cd24bedc62e71c18af8c8b7b23fb05e639ab60b01b5f8f2f", size = 36963251, upload-time = "2026-02-19T04:13:44.303Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/c4/fc99aa544930fb7bfcd88947c2788f318acaf1b9704a7a914445e204436a/z3_solver-4.16.0.0-py3-none-macosx_15_0_x86_64.whl", hash = "sha256:e292df40951523e4ecfbc8dee549d93dee00a3fe4ee4833270d19876b713e210", size = 47523873, upload-time = "2026-02-19T04:13:48.154Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/e6/98741b086b6e01630a55db1fbda596949f738204aac14ef35e64a9526ccb/z3_solver-4.16.0.0-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:afae2551f795670f0522cfce82132d129c408a2694adff71eb01ba0f2ece44f9", size = 31741807, upload-time = "2026-02-19T04:13:52.283Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/2e/295d467c7c796c01337bff790dbedc28cf279f9d365ed64aa9f8ca6b2ba1/z3_solver-4.16.0.0-py3-none-manylinux_2_38_aarch64.whl", hash = "sha256:358648c3b5ef82b9ec9a25711cf4fc498c7881f03a9f4a2ea6ffa9304ca65d94", size = 27326531, upload-time = "2026-02-19T04:13:55.787Z" },
+    { url = "https://files.pythonhosted.org/packages/34/df/29816ce4de24cca3acb007412f9c6fba603e55fcc27ce8c2aade0939057a/z3_solver-4.16.0.0-py3-none-win32.whl", hash = "sha256:cc64c4d41fbebe419fccddb044979c3d95b41214547db65eecdaa67fafef7fe0", size = 13341643, upload-time = "2026-02-19T04:13:58.88Z" },
+    { url = "https://files.pythonhosted.org/packages/86/20/cef4f4d70845df24572d005d19995f92b7f527eb2ffb63a3f5f938a0de2e/z3_solver-4.16.0.0-py3-none-win_amd64.whl", hash = "sha256:eb5df383cb6a3d6b7767dbdca348ac71f6f41e82f76c9ac42002a1f55e35f462", size = 16419861, upload-time = "2026-02-19T04:14:03.232Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/18/7dc1051093abfd6db56ce9addb63c624bfa31946ccb9cfc9be5e75237a26/z3_solver-4.16.0.0-py3-none-win_arm64.whl", hash = "sha256:28729eae2c89112e37697acce4d4517f5e44c6c54d36fed9cf914b06f380cbd6", size = 15084866, upload-time = "2026-02-19T04:14:06.355Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- switch Torghut CI from `unittest discover` to `pytest` with branch coverage and a 70% global coverage gate
- add Hypothesis profiles, shared data strategies, and new property/stateful tests for trading-core invariants
- add `scripts/check_diff_coverage.py` and enforce 90% changed-file coverage for Torghut Python source changes

## Related Issues
- None

## Testing
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen ruff check app tests scripts migrations`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen pytest --cov --cov-branch --cov-report=term-missing --cov-report=xml --cov-fail-under=70`
- `cd services/torghut && uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90`

## Breaking Changes
- None

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
