### PR TITLE
fix(torghut): address pr 4808 review feedback

### DIFF
--- a/services/torghut/app/trading/decisions.py
+++ b/services/torghut/app/trading/decisions.py
@@ -20,6 +20,7 @@ from .features import (
     optional_decimal,
 )
 from .microstructure import parse_microstructure_state
+from .evaluation_trace import StrategyTrace
 from .forecasting import ForecastRoutingTelemetry, build_default_forecast_router
 from .models import SignalEnvelope, StrategyDecision
 from .regime_hmm import (
@@ -57,6 +58,7 @@ class DecisionRuntimeTelemetry:
     fallback_to_legacy: bool
     errors: tuple[RuntimeErrorRecord, ...] = field(default_factory=tuple)
     observation: RuntimeObservation | None = None
+    traces: tuple[StrategyTrace, ...] = field(default_factory=tuple)
 
 
 @dataclass
@@ -73,13 +75,19 @@ class _RuntimeTradePolicySessionState:
 class DecisionEngine:
     """Evaluate TA signals against configured strategies."""
 
-    def __init__(self, price_fetcher: Optional[PriceFetcher] = None) -> None:
+    def __init__(
+        self,
+        price_fetcher: Optional[PriceFetcher] = None,
+        *,
+        runtime_trace_enabled: bool = False,
+    ) -> None:
         self.price_fetcher = price_fetcher
         self.strategy_runtime = StrategyRuntime(
             registry=StrategyRegistry(
                 circuit_error_threshold=settings.trading_strategy_runtime_circuit_errors,
                 cooldown_seconds=settings.trading_strategy_runtime_circuit_cooldown_seconds,
-            )
+            ),
+            trace_enabled=runtime_trace_enabled,
         )
         self._last_runtime_telemetry = DecisionRuntimeTelemetry(
             mode="legacy",
@@ -206,6 +214,7 @@ class DecisionEngine:
             fallback_to_legacy=False,
             errors=tuple(runtime_eval.errors),
             observation=runtime_eval.observation,
+            traces=tuple(runtime_eval.traces),
         )
 
         decisions: list[StrategyDecision] = []

--- a/services/torghut/app/trading/evaluation_trace.py
+++ b/services/torghut/app/trading/evaluation_trace.py
@@ -1,0 +1,314 @@
+"""Structured evaluation tracing for runtime and replay research flows."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, replace
+from datetime import date, datetime
+from decimal import Decimal
+from typing import Any, Literal, Mapping, cast
+
+GateCategory = Literal[
+    'eligibility',
+    'feed_quality',
+    'structure',
+    'confirmation',
+    'risk',
+    'execution',
+    'exit',
+]
+MissingPolicy = Literal['fail_open', 'fail_closed']
+FillStatus = Literal['none', 'pending', 'filled']
+
+_TRACE_SCHEMA_VERSION = 'torghut.strategy-trace.v1'
+_REPLAY_TRACE_SCHEMA_VERSION = 'torghut.replay-trace.v1'
+_REPLAY_FUNNEL_SCHEMA_VERSION = 'torghut.replay-funnel.v1'
+_SWEEP_RESULT_SCHEMA_VERSION = 'torghut.sweep-candidate-result.v1'
+
+
+def _empty_context() -> dict[str, Any]:
+    return {}
+
+
+def _serialize_trace_value(value: Any) -> Any:
+    if isinstance(value, Decimal):
+        return str(value)
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, date):
+        return value.isoformat()
+    if isinstance(value, tuple):
+        tuple_value = cast(tuple[Any, ...], value)
+        return [_serialize_trace_value(item) for item in tuple_value]
+    if isinstance(value, list):
+        list_value = cast(list[Any], value)
+        return [_serialize_trace_value(item) for item in list_value]
+    if isinstance(value, dict):
+        dict_value = cast(dict[Any, Any], value)
+        return {
+            str(key): _serialize_trace_value(item)
+            for key, item in dict_value.items()
+        }
+    return value
+
+
+@dataclass(frozen=True)
+class ThresholdTrace:
+    metric: str
+    comparator: str
+    value: Any
+    threshold: Any
+    passed: bool
+    missing_policy: MissingPolicy
+    distance_to_pass: Decimal | None = None
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            'metric': self.metric,
+            'comparator': self.comparator,
+            'value': _serialize_trace_value(self.value),
+            'threshold': _serialize_trace_value(self.threshold),
+            'passed': self.passed,
+            'missing_policy': self.missing_policy,
+            'distance_to_pass': (
+                str(self.distance_to_pass) if self.distance_to_pass is not None else None
+            ),
+        }
+
+
+@dataclass(frozen=True)
+class GateTrace:
+    gate: str
+    category: GateCategory
+    passed: bool
+    thresholds: tuple[ThresholdTrace, ...] = ()
+    context: dict[str, Any] = field(default_factory=_empty_context)
+
+    def failing_thresholds(self) -> tuple[ThresholdTrace, ...]:
+        return tuple(item for item in self.thresholds if not item.passed)
+
+    def distance_score(self) -> Decimal:
+        score = Decimal('0')
+        for threshold in self.failing_thresholds():
+            if threshold.distance_to_pass is None:
+                score += Decimal('1')
+            else:
+                score += threshold.distance_to_pass
+        return score
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            'gate': self.gate,
+            'category': self.category,
+            'passed': self.passed,
+            'thresholds': [item.to_payload() for item in self.thresholds],
+            'context': _serialize_trace_value(self.context),
+        }
+
+
+@dataclass(frozen=True)
+class StrategyTrace:
+    strategy_id: str
+    strategy_type: str
+    symbol: str
+    event_ts: str
+    timeframe: str
+    passed: bool
+    action: Literal['buy', 'sell'] | None
+    rationale: tuple[str, ...] = ()
+    gates: tuple[GateTrace, ...] = ()
+    first_failed_gate: str | None = None
+    context: dict[str, Any] = field(default_factory=_empty_context)
+    schema_version: str = _TRACE_SCHEMA_VERSION
+
+    def with_updates(self, **updates: Any) -> StrategyTrace:
+        return replace(self, **updates)
+
+    def with_context(self, **context: Any) -> StrategyTrace:
+        merged = dict(self.context)
+        merged.update(context)
+        return replace(self, context=merged)
+
+    def failed_gate(self) -> GateTrace | None:
+        if not self.first_failed_gate:
+            return None
+        for gate in self.gates:
+            if gate.gate == self.first_failed_gate:
+                return gate
+        return None
+
+    def distance_score(self) -> Decimal:
+        failed_gate = self.failed_gate()
+        if failed_gate is None:
+            return Decimal('0')
+        return failed_gate.distance_score()
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            'schema_version': self.schema_version,
+            'strategy_id': self.strategy_id,
+            'strategy_type': self.strategy_type,
+            'symbol': self.symbol,
+            'event_ts': self.event_ts,
+            'timeframe': self.timeframe,
+            'passed': self.passed,
+            'action': self.action,
+            'rationale': list(self.rationale),
+            'first_failed_gate': self.first_failed_gate,
+            'gates': [gate.to_payload() for gate in self.gates],
+            'context': _serialize_trace_value(self.context),
+        }
+
+
+@dataclass(frozen=True)
+class ReplayTraceRecord:
+    trading_day: str
+    strategy_trace: StrategyTrace
+    decision_emitted: bool
+    fill_status: FillStatus
+    decision_strategy_id: str | None = None
+    block_reason: str | None = None
+    fill_price: Decimal | None = None
+    schema_version: str = _REPLAY_TRACE_SCHEMA_VERSION
+
+    def with_updates(self, **updates: Any) -> ReplayTraceRecord:
+        return replace(self, **updates)
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            'schema_version': self.schema_version,
+            'trading_day': self.trading_day,
+            'decision_emitted': self.decision_emitted,
+            'fill_status': self.fill_status,
+            'decision_strategy_id': self.decision_strategy_id,
+            'block_reason': self.block_reason,
+            'fill_price': str(self.fill_price) if self.fill_price is not None else None,
+            'strategy_trace': self.strategy_trace.to_payload(),
+        }
+
+
+@dataclass(frozen=True)
+class ReplayFunnelBucket:
+    trading_day: str
+    symbol: str
+    retained_rows: int
+    runtime_evaluable_rows: int
+    quote_valid_rows: int
+    strategy_evaluations: int
+    gate_pass_counts: dict[str, int]
+    decision_count: int
+    filled_count: int
+    closed_trade_count: int
+    gross_pnl: Decimal
+    net_pnl: Decimal
+    cost_total: Decimal
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            'trading_day': self.trading_day,
+            'symbol': self.symbol,
+            'retained_rows': self.retained_rows,
+            'runtime_evaluable_rows': self.runtime_evaluable_rows,
+            'quote_valid_rows': self.quote_valid_rows,
+            'strategy_evaluations': self.strategy_evaluations,
+            'gate_pass_counts': dict(sorted(self.gate_pass_counts.items())),
+            'decision_count': self.decision_count,
+            'filled_count': self.filled_count,
+            'closed_trade_count': self.closed_trade_count,
+            'gross_pnl': str(self.gross_pnl),
+            'net_pnl': str(self.net_pnl),
+            'cost_total': str(self.cost_total),
+        }
+
+
+@dataclass(frozen=True)
+class ReplayFunnelReport:
+    start_date: str
+    end_date: str
+    buckets: tuple[ReplayFunnelBucket, ...]
+    schema_version: str = _REPLAY_FUNNEL_SCHEMA_VERSION
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            'schema_version': self.schema_version,
+            'start_date': self.start_date,
+            'end_date': self.end_date,
+            'buckets': [bucket.to_payload() for bucket in self.buckets],
+        }
+
+
+@dataclass(frozen=True)
+class NearMissRecord:
+    trading_day: str
+    symbol: str
+    strategy_id: str
+    strategy_type: str
+    event_ts: str
+    action: Literal['buy', 'sell'] | None
+    first_failed_gate: str
+    distance_score: Decimal
+    thresholds: tuple[ThresholdTrace, ...]
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            'trading_day': self.trading_day,
+            'symbol': self.symbol,
+            'strategy_id': self.strategy_id,
+            'strategy_type': self.strategy_type,
+            'event_ts': self.event_ts,
+            'action': self.action,
+            'first_failed_gate': self.first_failed_gate,
+            'distance_score': str(self.distance_score),
+            'thresholds': [item.to_payload() for item in self.thresholds],
+        }
+
+
+@dataclass(frozen=True)
+class SweepCandidateResult:
+    candidate_id: str
+    family: str
+    strategy_name: str
+    train_net_per_day: Decimal
+    holdout_net_per_day: Decimal
+    train_total_net: Decimal
+    holdout_total_net: Decimal
+    active_holdout_days: int
+    max_holdout_drawdown_day: Decimal
+    profit_factor: Decimal | None
+    wins: int
+    losses: int
+    score: Decimal
+    replay_config: Mapping[str, Any]
+    schema_version: str = _SWEEP_RESULT_SCHEMA_VERSION
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            'schema_version': self.schema_version,
+            'candidate_id': self.candidate_id,
+            'family': self.family,
+            'strategy_name': self.strategy_name,
+            'train_net_per_day': str(self.train_net_per_day),
+            'holdout_net_per_day': str(self.holdout_net_per_day),
+            'train_total_net': str(self.train_total_net),
+            'holdout_total_net': str(self.holdout_total_net),
+            'active_holdout_days': self.active_holdout_days,
+            'max_holdout_drawdown_day': str(self.max_holdout_drawdown_day),
+            'profit_factor': str(self.profit_factor) if self.profit_factor is not None else None,
+            'wins': self.wins,
+            'losses': self.losses,
+            'score': str(self.score),
+            'replay_config': _serialize_trace_value(dict(self.replay_config)),
+        }
+
+
+__all__ = [
+    'FillStatus',
+    'GateCategory',
+    'GateTrace',
+    'NearMissRecord',
+    'ReplayFunnelBucket',
+    'ReplayFunnelReport',
+    'ReplayTraceRecord',
+    'StrategyTrace',
+    'SweepCandidateResult',
+    'ThresholdTrace',
+]

--- a/services/torghut/app/trading/reporting.py
+++ b/services/torghut/app/trading/reporting.py
@@ -13,6 +13,7 @@ from typing import Any, Literal, Mapping, Optional, cast
 from ..models import Strategy
 from .costs import CostModelConfig, CostModelInputs, OrderIntent, TransactionCostModel
 from .evaluation import WalkForwardDecision, WalkForwardResults
+from .evaluation_trace import SweepCandidateResult
 from .regime import RegimeLabel, classify_regime
 
 
@@ -949,6 +950,147 @@ def _decimal_std(values: list[Decimal], mean: Decimal) -> Decimal:
     return variance.sqrt()
 
 
+@dataclass(frozen=True)
+class ProfitabilityConstraintPolicy:
+    holdout_target_net_per_day: Decimal = Decimal("250")
+    min_active_holdout_days: int = 3
+    max_worst_holdout_day_loss: Decimal = Decimal("150")
+    min_profit_factor: Decimal = Decimal("1.5")
+    require_training_decisions: bool = True
+    require_holdout_decisions: bool = True
+
+
+@dataclass(frozen=True)
+class ReplayProfitabilitySummary:
+    start_date: str
+    end_date: str
+    trading_day_count: int
+    net_pnl: Decimal
+    net_per_day: Decimal
+    active_days: int
+    decision_count: int
+    filled_count: int
+    wins: int
+    losses: int
+    worst_day_net: Decimal
+    profit_factor: Decimal | None
+    daily_net: dict[str, Decimal]
+
+
+def summarize_replay_profitability(payload: Mapping[str, Any]) -> ReplayProfitabilitySummary:
+    daily_payload = cast(Mapping[str, Any], payload.get("daily") or {})
+    daily_net: dict[str, Decimal] = {}
+    for day, value in daily_payload.items():
+        if not isinstance(value, Mapping):
+            continue
+        value_mapping = cast(Mapping[str, Any], value)
+        daily_net[str(day)] = _decimal(value_mapping.get("net_pnl")) or Decimal("0")
+
+    trading_day_count = len(daily_net)
+    net_pnl = _decimal(payload.get("net_pnl")) or Decimal("0")
+    active_days = sum(
+        1
+        for value in daily_payload.values()
+        if isinstance(value, Mapping)
+        and int(cast(Mapping[str, Any], value).get("filled_count", 0)) > 0
+    )
+    positive_total = sum((value for value in daily_net.values() if value > 0), Decimal("0"))
+    negative_total = sum((-value for value in daily_net.values() if value < 0), Decimal("0"))
+    profit_factor = (
+        (positive_total / negative_total)
+        if negative_total > 0
+        else (Decimal("999999") if positive_total > 0 else None)
+    )
+    worst_day_net = min(daily_net.values()) if daily_net else Decimal("0")
+    net_per_day = (
+        net_pnl / Decimal(trading_day_count)
+        if trading_day_count > 0
+        else Decimal("0")
+    )
+    return ReplayProfitabilitySummary(
+        start_date=str(payload.get("start_date") or ""),
+        end_date=str(payload.get("end_date") or ""),
+        trading_day_count=trading_day_count,
+        net_pnl=net_pnl,
+        net_per_day=net_per_day,
+        active_days=active_days,
+        decision_count=int(payload.get("decision_count", 0)),
+        filled_count=int(payload.get("filled_count", 0)),
+        wins=int(payload.get("wins", 0)),
+        losses=int(payload.get("losses", 0)),
+        worst_day_net=worst_day_net,
+        profit_factor=profit_factor,
+        daily_net=daily_net,
+    )
+
+
+def score_replay_profitability_candidate(
+    *,
+    family: str,
+    strategy_name: str,
+    replay_config: Mapping[str, Any],
+    train_payload: Mapping[str, Any],
+    holdout_payload: Mapping[str, Any],
+    policy: ProfitabilityConstraintPolicy = ProfitabilityConstraintPolicy(),
+) -> SweepCandidateResult:
+    train = summarize_replay_profitability(train_payload)
+    holdout = summarize_replay_profitability(holdout_payload)
+
+    penalties = Decimal("0")
+    if holdout.active_days < policy.min_active_holdout_days:
+        penalties += Decimal(policy.min_active_holdout_days - holdout.active_days) * Decimal("250")
+    if holdout.worst_day_net < -policy.max_worst_holdout_day_loss:
+        penalties += abs(holdout.worst_day_net + policy.max_worst_holdout_day_loss)
+    if holdout.profit_factor is None:
+        penalties += Decimal("250")
+    elif holdout.profit_factor < policy.min_profit_factor:
+        penalties += (policy.min_profit_factor - holdout.profit_factor) * Decimal("250")
+    if policy.require_training_decisions and train.decision_count <= 0:
+        penalties += Decimal("250")
+    if policy.require_holdout_decisions and holdout.decision_count <= 0:
+        penalties += Decimal("500")
+    if holdout.net_per_day < policy.holdout_target_net_per_day:
+        penalties += policy.holdout_target_net_per_day - holdout.net_per_day
+
+    score = holdout.net_per_day - penalties
+    candidate_key = json.dumps(
+        {
+            "family": family,
+            "strategy_name": strategy_name,
+            "replay_config": dict(replay_config),
+            "train": {
+                "start_date": train.start_date,
+                "end_date": train.end_date,
+                "net_per_day": str(train.net_per_day),
+            },
+            "holdout": {
+                "start_date": holdout.start_date,
+                "end_date": holdout.end_date,
+                "net_per_day": str(holdout.net_per_day),
+            },
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    candidate_id = hashlib.sha256(candidate_key.encode("utf-8")).hexdigest()[:24]
+    return SweepCandidateResult(
+        candidate_id=candidate_id,
+        family=family,
+        strategy_name=strategy_name,
+        train_net_per_day=train.net_per_day,
+        holdout_net_per_day=holdout.net_per_day,
+        train_total_net=train.net_pnl,
+        holdout_total_net=holdout.net_pnl,
+        active_holdout_days=holdout.active_days,
+        max_holdout_drawdown_day=abs(min(holdout.worst_day_net, Decimal("0"))),
+        profit_factor=holdout.profit_factor,
+        wins=holdout.wins,
+        losses=holdout.losses,
+        score=score,
+        replay_config=dict(replay_config),
+    )
+
+
 __all__ = [
     "EvaluationImpactAssumptions",
     "EvaluationGateOutcome",
@@ -957,11 +1099,15 @@ __all__ = [
     "EvaluationReport",
     "EvaluationReportConfig",
     "MultipleTestingSummary",
+    "ProfitabilityConstraintPolicy",
     "PromotionEvidenceSummary",
     "PromotionRecommendation",
+    "ReplayProfitabilitySummary",
     "RobustnessFoldMetrics",
     "RobustnessReport",
     "build_promotion_recommendation",
     "generate_evaluation_report",
+    "score_replay_profitability_candidate",
+    "summarize_replay_profitability",
     "write_evaluation_report",
 ]

--- a/services/torghut/app/trading/research_sleeves.py
+++ b/services/torghut/app/trading/research_sleeves.py
@@ -7,6 +7,8 @@ from datetime import datetime, timezone
 from decimal import Decimal
 from typing import Any, Literal, Mapping
 
+from .evaluation_trace import GateCategory, GateTrace, StrategyTrace, ThresholdTrace
+
 
 @dataclass(frozen=True)
 class SleeveSignalEvaluation:
@@ -16,10 +18,267 @@ class SleeveSignalEvaluation:
     notional_multiplier: Decimal = Decimal('1')
 
 
+@dataclass(frozen=True)
+class SleeveSignalResult:
+    signal: SleeveSignalEvaluation | None
+    trace: StrategyTrace | None = None
+
+
+def _make_strategy_trace(
+    *,
+    strategy_id: str | None,
+    strategy_type: str | None,
+    symbol: str,
+    event_ts: str,
+    timeframe: str | None,
+    passed: bool,
+    action: Literal['buy', 'sell'] | None,
+    rationale: tuple[str, ...],
+    gates: tuple[GateTrace, ...],
+    trace_enabled: bool,
+    context: dict[str, Any] | None = None,
+) -> StrategyTrace | None:
+    if not trace_enabled:
+        return None
+    first_failed_gate = next((gate.gate for gate in gates if not gate.passed), None)
+    return StrategyTrace(
+        strategy_id=(strategy_id or '').strip() or 'unknown',
+        strategy_type=(strategy_type or '').strip() or 'unknown',
+        symbol=symbol,
+        event_ts=event_ts,
+        timeframe=(timeframe or '').strip() or 'unknown',
+        passed=passed,
+        action=action,
+        rationale=rationale,
+        gates=gates,
+        first_failed_gate=first_failed_gate,
+        context=context or {},
+    )
+
+
+def _threshold_min(
+    *,
+    metric: str,
+    value: Decimal | None,
+    floor: Decimal | None,
+    required: bool,
+) -> ThresholdTrace:
+    if floor is None:
+        return ThresholdTrace(
+            metric=metric,
+            comparator='optional_min',
+            value=value,
+            threshold=floor,
+            passed=True,
+            missing_policy='fail_open' if not required else 'fail_closed',
+            distance_to_pass=Decimal('0'),
+        )
+    if value is None:
+        return ThresholdTrace(
+            metric=metric,
+            comparator='min_gte',
+            value=value,
+            threshold=floor,
+            passed=not required,
+            missing_policy='fail_closed' if required else 'fail_open',
+            distance_to_pass=(floor if required else Decimal('0')),
+        )
+    passed = value >= floor
+    return ThresholdTrace(
+        metric=metric,
+        comparator='min_gte',
+        value=value,
+        threshold=floor,
+        passed=passed,
+        missing_policy='fail_closed' if required else 'fail_open',
+        distance_to_pass=Decimal('0') if passed else (floor - value),
+    )
+
+
+def _threshold_max(
+    *,
+    metric: str,
+    value: Decimal | None,
+    ceil: Decimal | None,
+    required: bool,
+) -> ThresholdTrace:
+    if ceil is None:
+        return ThresholdTrace(
+            metric=metric,
+            comparator='optional_max',
+            value=value,
+            threshold=ceil,
+            passed=True,
+            missing_policy='fail_open' if not required else 'fail_closed',
+            distance_to_pass=Decimal('0'),
+        )
+    if value is None:
+        return ThresholdTrace(
+            metric=metric,
+            comparator='max_lte',
+            value=value,
+            threshold=ceil,
+            passed=not required,
+            missing_policy='fail_closed' if required else 'fail_open',
+            distance_to_pass=(ceil if required else Decimal('0')),
+        )
+    passed = value <= ceil
+    return ThresholdTrace(
+        metric=metric,
+        comparator='max_lte',
+        value=value,
+        threshold=ceil,
+        passed=passed,
+        missing_policy='fail_closed' if required else 'fail_open',
+        distance_to_pass=Decimal('0') if passed else (value - ceil),
+    )
+
+
+def _threshold_range(
+    *,
+    metric: str,
+    value: Decimal | None,
+    floor: Decimal | None,
+    ceil: Decimal | None,
+    required: bool,
+) -> tuple[ThresholdTrace, ThresholdTrace]:
+    return (
+        _threshold_min(metric=metric, value=value, floor=floor, required=required),
+        _threshold_max(metric=metric, value=value, ceil=ceil, required=required),
+    )
+
+
+def _threshold_bool(
+    *,
+    metric: str,
+    passed: bool,
+    threshold: Any,
+    value: Any = True,
+) -> ThresholdTrace:
+    return ThresholdTrace(
+        metric=metric,
+        comparator='bool',
+        value=value,
+        threshold=threshold,
+        passed=passed,
+        missing_policy='fail_closed',
+        distance_to_pass=Decimal('0') if passed else Decimal('1'),
+    )
+
+
+def _gate(
+    *,
+    name: str,
+    category: GateCategory,
+    thresholds: tuple[ThresholdTrace, ...],
+    context: dict[str, Any] | None = None,
+) -> GateTrace:
+    return GateTrace(
+        gate=name,
+        category=category,
+        passed=all(item.passed for item in thresholds),
+        thresholds=thresholds,
+        context=context or {},
+    )
+
+
+def _sleeve_result(
+    *,
+    strategy_id: str | None,
+    strategy_type: str | None,
+    symbol: str,
+    event_ts: str,
+    timeframe: str | None,
+    signal: SleeveSignalEvaluation | None,
+    gates: tuple[GateTrace, ...],
+    trace_enabled: bool,
+    context: dict[str, Any] | None = None,
+) -> SleeveSignalResult:
+    trace = _make_strategy_trace(
+        strategy_id=strategy_id,
+        strategy_type=strategy_type,
+        symbol=symbol,
+        event_ts=event_ts,
+        timeframe=timeframe,
+        passed=signal is not None,
+        action=signal.action if signal is not None else None,
+        rationale=signal.rationale if signal is not None else (),
+        gates=gates,
+        trace_enabled=trace_enabled,
+        context=context,
+    )
+    return SleeveSignalResult(signal=signal, trace=trace)
+
+
+def _required_inputs_gate(
+    *,
+    fields: Mapping[str, bool],
+) -> GateTrace:
+    return _gate(
+        name='eligibility',
+        category='eligibility',
+        thresholds=(
+            _threshold_bool(
+                metric='required_inputs_present',
+                passed=all(fields.values()),
+                threshold=True,
+                value=dict(fields),
+            ),
+        ),
+    )
+
+
+def _entry_window_gate(
+    *,
+    within_window: bool,
+    start_minute: int,
+    end_minute: int,
+) -> GateTrace:
+    return _gate(
+        name='eligibility',
+        category='eligibility',
+        thresholds=(
+            _threshold_bool(
+                metric='within_entry_window',
+                passed=within_window,
+                threshold='entry_window',
+            ),
+        ),
+        context={
+            'entry_start_minute_utc': start_minute,
+            'entry_end_minute_utc': end_minute,
+        },
+    )
+
+
+def _exit_trigger_gate(
+    *,
+    reason_flags: Mapping[str, bool],
+) -> GateTrace:
+    return _gate(
+        name='exit',
+        category='exit',
+        thresholds=(
+            _threshold_bool(
+                metric='exit_triggered',
+                passed=any(reason_flags.values()),
+                threshold='any_exit_reason',
+                value=dict(reason_flags),
+            ),
+        ),
+        context={'reasons': dict(reason_flags)},
+    )
+
+
 def evaluate_momentum_pullback_long(
     *,
     params: Mapping[str, Any],
+    strategy_id: str | None,
+    strategy_type: str | None,
+    symbol: str,
     event_ts: str,
+    timeframe: str | None,
+    trace_enabled: bool,
     price: Decimal | None,
     ema12: Decimal | None,
     ema26: Decimal | None,
@@ -37,7 +296,10 @@ def evaluate_momentum_pullback_long(
     recent_quote_jump_bps_max: Decimal | None,
     recent_microprice_bias_bps_avg: Decimal | None,
     cross_section_continuation_rank: Decimal | None,
-) -> SleeveSignalEvaluation | None:
+) -> SleeveSignalResult:
+    trace_context = {
+        'family': 'momentum_pullback_long',
+    }
     if (
         price is None
         or ema12 is None
@@ -46,7 +308,37 @@ def evaluate_momentum_pullback_long(
         or macd_signal is None
         or rsi14 is None
     ):
-        return None
+        return _sleeve_result(
+            strategy_id=strategy_id,
+            strategy_type=strategy_type,
+            symbol=symbol,
+            event_ts=event_ts,
+            timeframe=timeframe,
+            signal=None,
+            gates=(
+                _gate(
+                    name='eligibility',
+                    category='eligibility',
+                    thresholds=(
+                        _threshold_bool(
+                            metric='required_inputs_present',
+                            passed=False,
+                            threshold=True,
+                            value={
+                                'price': price is not None,
+                                'ema12': ema12 is not None,
+                                'ema26': ema26 is not None,
+                                'macd': macd is not None,
+                                'macd_signal': macd_signal is not None,
+                                'rsi14': rsi14 is not None,
+                            },
+                        ),
+                    ),
+                ),
+            ),
+            trace_enabled=trace_enabled,
+            context=trace_context,
+        )
 
     ts = _parse_event_ts(event_ts)
     if not _within_utc_window(
@@ -57,7 +349,30 @@ def evaluate_momentum_pullback_long(
             default_end_minute=19 * 60 + 50,
         ),
     ):
-        return None
+        return _sleeve_result(
+            strategy_id=strategy_id,
+            strategy_type=strategy_type,
+            symbol=symbol,
+            event_ts=event_ts,
+            timeframe=timeframe,
+            signal=None,
+            gates=(
+                _gate(
+                    name='eligibility',
+                    category='eligibility',
+                    thresholds=(
+                        _threshold_bool(
+                            metric='within_entry_window',
+                            passed=False,
+                            threshold='entry_window',
+                        ),
+                    ),
+                    context={'entry_start_minute_utc': _minute_param(params, 'entry_start_minute_utc', 14 * 60)},
+                ),
+            ),
+            trace_enabled=trace_enabled,
+            context=trace_context,
+        )
 
     macd_hist = macd - macd_signal
     price_vs_ema12_bps = _bps_delta(price, ema12)
@@ -98,39 +413,111 @@ def evaluate_momentum_pullback_long(
         None,
     )
 
-    if (
-        ema12 > ema26
-        and bullish_hist_min <= macd_hist <= bullish_hist_cap
-        and min_bull_rsi <= rsi14 <= max_bull_rsi
-        and _optional_min_threshold(
-            -price_vs_ema12_bps if price_vs_ema12_bps is not None else None,
-            min_pullback_bps,
-        )
-        and _optional_max_threshold(
-            -price_vs_ema12_bps if price_vs_ema12_bps is not None else None,
-            max_pullback_bps,
-        )
-        and effective_spread_bps <= spread_cap_bps
-        and imbalance_pressure >= imbalance_floor
-        and _optional_min_threshold(price_vs_session_open_bps, min_session_open_drive_bps)
-        and _optional_max_threshold(recent_spread_bps_avg, max_recent_spread_bps)
-        and _optional_min_threshold(recent_imbalance_pressure_avg, min_recent_imbalance_pressure)
-        and _quote_stability_passes(
-            recent_quote_invalid_ratio=recent_quote_invalid_ratio,
-            max_recent_quote_invalid_ratio=max_recent_quote_invalid_ratio,
-            recent_quote_jump_bps_max=recent_quote_jump_bps_max,
-            max_recent_quote_jump_bps=max_recent_quote_jump_bps,
-        )
-        and _optional_min_threshold(
-            recent_microprice_bias_bps_avg,
-            min_recent_microprice_bias_bps,
-        )
-        and _optional_min_threshold(
-            cross_section_continuation_rank,
-            min_cross_section_continuation_rank,
-        )
-        and _vol_within_band(vol_realized_w60s, floor=vol_floor, ceil=vol_ceil)
-    ):
+    pullback_bps = -price_vs_ema12_bps if price_vs_ema12_bps is not None else None
+    buy_gates = (
+        _gate(
+            name='structure',
+            category='structure',
+            thresholds=(
+                _threshold_bool(metric='ema12_gt_ema26', passed=ema12 > ema26, threshold=True),
+                *_threshold_range(
+                    metric='macd_hist',
+                    value=macd_hist,
+                    floor=bullish_hist_min,
+                    ceil=bullish_hist_cap,
+                    required=True,
+                ),
+                *_threshold_range(
+                    metric='rsi14',
+                    value=rsi14,
+                    floor=min_bull_rsi,
+                    ceil=max_bull_rsi,
+                    required=True,
+                ),
+                *_threshold_range(
+                    metric='pullback_bps',
+                    value=pullback_bps,
+                    floor=min_pullback_bps,
+                    ceil=max_pullback_bps,
+                    required=False,
+                ),
+                _threshold_min(
+                    metric='price_vs_session_open_bps',
+                    value=price_vs_session_open_bps,
+                    floor=min_session_open_drive_bps,
+                    required=False,
+                ),
+            ),
+        ),
+        _gate(
+            name='feed_quality',
+            category='feed_quality',
+            thresholds=(
+                _threshold_max(
+                    metric='spread_bps',
+                    value=effective_spread_bps,
+                    ceil=spread_cap_bps,
+                    required=True,
+                ),
+                _threshold_max(
+                    metric='recent_spread_bps_avg',
+                    value=recent_spread_bps_avg,
+                    ceil=max_recent_spread_bps,
+                    required=False,
+                ),
+                _threshold_max(
+                    metric='recent_quote_invalid_ratio',
+                    value=recent_quote_invalid_ratio,
+                    ceil=max_recent_quote_invalid_ratio,
+                    required=False,
+                ),
+                _threshold_max(
+                    metric='recent_quote_jump_bps_max',
+                    value=recent_quote_jump_bps_max,
+                    ceil=max_recent_quote_jump_bps,
+                    required=False,
+                ),
+                *_threshold_range(
+                    metric='vol_realized_w60s',
+                    value=vol_realized_w60s,
+                    floor=vol_floor,
+                    ceil=vol_ceil,
+                    required=False,
+                ),
+            ),
+        ),
+        _gate(
+            name='confirmation',
+            category='confirmation',
+            thresholds=(
+                _threshold_min(
+                    metric='imbalance_pressure',
+                    value=imbalance_pressure,
+                    floor=imbalance_floor,
+                    required=True,
+                ),
+                _threshold_min(
+                    metric='recent_imbalance_pressure_avg',
+                    value=recent_imbalance_pressure_avg,
+                    floor=min_recent_imbalance_pressure,
+                    required=False,
+                ),
+                _threshold_min(
+                    metric='recent_microprice_bias_bps_avg',
+                    value=recent_microprice_bias_bps_avg,
+                    floor=min_recent_microprice_bias_bps,
+                    required=False,
+                ),
+                _threshold_min(
+                    metric='cross_section_continuation_rank',
+                    value=cross_section_continuation_rank,
+                    floor=min_cross_section_continuation_rank,
+                    required=False,
+                ),
+            ),
+        ),
+    )
+    if all(gate.passed for gate in buy_gates):
         confidence = Decimal('0.66')
         if imbalance_pressure > Decimal('0.05'):
             confidence += Decimal('0.03')
@@ -146,45 +533,96 @@ def evaluate_momentum_pullback_long(
             and recent_microprice_bias_bps_avg >= Decimal('0.60')
         ):
             confidence += Decimal('0.02')
-        return SleeveSignalEvaluation(
-            action='buy',
-            confidence=min(confidence, Decimal('0.82')),
-            rationale=(
-                'momentum_pullback_long',
-                'trend_up',
-                'pullback_entry',
-                'spread_ok',
-            ),
-            notional_multiplier=_resolve_entry_notional_multiplier(
-                params=params,
+        return _sleeve_result(
+            strategy_id=strategy_id,
+            strategy_type=strategy_type,
+            symbol=symbol,
+            event_ts=event_ts,
+            timeframe=timeframe,
+            signal=SleeveSignalEvaluation(
+                action='buy',
                 confidence=min(confidence, Decimal('0.82')),
-                rank=cross_section_continuation_rank,
-                spread_bps=effective_spread_bps,
-                spread_cap_bps=spread_cap_bps,
+                rationale=(
+                    'momentum_pullback_long',
+                    'trend_up',
+                    'pullback_entry',
+                    'spread_ok',
+                ),
+                notional_multiplier=_resolve_entry_notional_multiplier(
+                    params=params,
+                    confidence=min(confidence, Decimal('0.82')),
+                    rank=cross_section_continuation_rank,
+                    spread_bps=effective_spread_bps,
+                    spread_cap_bps=spread_cap_bps,
+                ),
             ),
+            gates=buy_gates,
+            trace_enabled=trace_enabled,
+            context=trace_context,
         )
 
-    if (
-        ema12 < ema26
-        and macd_hist <= _decimal_param(params, 'exit_macd_hist_max', Decimal('-0.002'))
-        and rsi14 <= _decimal_param(params, 'exit_rsi_max', Decimal('49'))
-    ):
-        return SleeveSignalEvaluation(
-            action='sell',
-            confidence=Decimal('0.63'),
-            rationale=(
-                'momentum_pullback_exit',
-                'trend_lost',
-                'momentum_rollover',
+    exit_gate = _gate(
+        name='exit',
+        category='exit',
+        thresholds=(
+            _threshold_bool(metric='ema12_lt_ema26', passed=ema12 < ema26, threshold=True),
+            _threshold_max(
+                metric='macd_hist',
+                value=macd_hist,
+                ceil=_decimal_param(params, 'exit_macd_hist_max', Decimal('-0.002')),
+                required=True,
             ),
+            _threshold_max(
+                metric='rsi14',
+                value=rsi14,
+                ceil=_decimal_param(params, 'exit_rsi_max', Decimal('49')),
+                required=True,
+            ),
+        ),
+    )
+    if exit_gate.passed:
+        return _sleeve_result(
+            strategy_id=strategy_id,
+            strategy_type=strategy_type,
+            symbol=symbol,
+            event_ts=event_ts,
+            timeframe=timeframe,
+            signal=SleeveSignalEvaluation(
+                action='sell',
+                confidence=Decimal('0.63'),
+                rationale=(
+                    'momentum_pullback_exit',
+                    'trend_lost',
+                    'momentum_rollover',
+                ),
+            ),
+            gates=(exit_gate,),
+            trace_enabled=trace_enabled,
+            context=trace_context,
         )
-    return None
+
+    return _sleeve_result(
+        strategy_id=strategy_id,
+        strategy_type=strategy_type,
+        symbol=symbol,
+        event_ts=event_ts,
+        timeframe=timeframe,
+        signal=None,
+        gates=buy_gates,
+        trace_enabled=trace_enabled,
+        context=trace_context,
+    )
 
 
 def evaluate_breakout_continuation_long(
     *,
     params: Mapping[str, Any],
+    strategy_id: str | None,
+    strategy_type: str | None,
+    symbol: str,
     event_ts: str,
+    timeframe: str | None,
+    trace_enabled: bool,
     price: Decimal | None,
     ema12: Decimal | None,
     ema26: Decimal | None,
@@ -230,7 +668,8 @@ def evaluate_breakout_continuation_long(
     cross_section_vwap_w5m_rank: Decimal | None,
     cross_section_recent_imbalance_rank: Decimal | None,
     cross_section_continuation_rank: Decimal | None,
-) -> SleeveSignalEvaluation | None:
+) -> SleeveSignalResult:
+    trace_context = {'family': 'breakout_continuation_long'}
     if (
         price is None
         or ema12 is None
@@ -239,7 +678,37 @@ def evaluate_breakout_continuation_long(
         or macd_signal is None
         or rsi14 is None
     ):
-        return None
+        return _sleeve_result(
+            strategy_id=strategy_id,
+            strategy_type=strategy_type,
+            symbol=symbol,
+            event_ts=event_ts,
+            timeframe=timeframe,
+            signal=None,
+            gates=(
+                _gate(
+                    name='eligibility',
+                    category='eligibility',
+                    thresholds=(
+                        _threshold_bool(
+                            metric='required_inputs_present',
+                            passed=False,
+                            threshold=True,
+                            value={
+                                'price': price is not None,
+                                'ema12': ema12 is not None,
+                                'ema26': ema26 is not None,
+                                'macd': macd is not None,
+                                'macd_signal': macd_signal is not None,
+                                'rsi14': rsi14 is not None,
+                            },
+                        ),
+                    ),
+                ),
+            ),
+            trace_enabled=trace_enabled,
+            context=trace_context,
+        )
 
     ts = _parse_event_ts(event_ts)
     entry_start_minute = _minute_param(params, 'entry_start_minute_utc', 14 * 60 + 15)
@@ -258,7 +727,33 @@ def evaluate_breakout_continuation_long(
         start_minute=entry_start_minute,
         end_minute=entry_end_minute,
     ):
-        return None
+        return _sleeve_result(
+            strategy_id=strategy_id,
+            strategy_type=strategy_type,
+            symbol=symbol,
+            event_ts=event_ts,
+            timeframe=timeframe,
+            signal=None,
+            gates=(
+                _gate(
+                    name='eligibility',
+                    category='eligibility',
+                    thresholds=(
+                        _threshold_bool(
+                            metric='within_entry_window',
+                            passed=False,
+                            threshold='entry_window',
+                        ),
+                    ),
+                    context={
+                        'entry_start_minute_utc': entry_start_minute,
+                        'entry_end_minute_utc': entry_end_minute,
+                    },
+                ),
+            ),
+            trace_enabled=trace_enabled,
+            context=trace_context,
+        )
 
     macd_hist = macd - macd_signal
     price_vs_ema12_bps = _bps_delta(price, ema12)
@@ -818,95 +1313,211 @@ def evaluate_breakout_continuation_long(
         recent_above_opening_window_close_ratio=recent_above_opening_window_close_ratio,
         min_recent_above_opening_window_close_ratio=min_recent_above_opening_window_close_ratio,
     )
+    buy_gates = (
+        _gate(
+            name='structure',
+            category='structure',
+            thresholds=(
+                _threshold_bool(metric='ema12_gt_ema26', passed=ema12 > ema26, threshold=True),
+                _threshold_min(
+                    metric='macd_hist',
+                    value=macd_hist,
+                    floor=effective_bullish_hist_min,
+                    required=True,
+                ),
+                *_threshold_range(
+                    metric='rsi14',
+                    value=rsi14,
+                    floor=effective_min_bull_rsi,
+                    ceil=effective_max_bull_rsi,
+                    required=True,
+                ),
+                _threshold_min(
+                    metric='price_vs_ema12_bps',
+                    value=price_vs_ema12_bps,
+                    floor=_decimal_param(params, 'min_price_above_ema12_bps', Decimal('0')),
+                    required=False,
+                ),
+                _threshold_max(
+                    metric='price_vs_ema12_bps',
+                    value=price_vs_ema12_bps,
+                    ceil=ema_extension_cap_bps,
+                    required=False,
+                ),
+                _threshold_min(
+                    metric='price_vs_vwap_w5m_bps',
+                    value=price_vs_vwap_w5m_bps,
+                    floor=min_price_vs_vwap_w5m_bps,
+                    required=False,
+                ),
+                _threshold_max(
+                    metric='price_vs_vwap_w5m_bps',
+                    value=price_vs_vwap_w5m_bps,
+                    ceil=vwap_w5m_extension_cap_bps,
+                    required=False,
+                ),
+                _threshold_min(
+                    metric='effective_price_drive_bps',
+                    value=effective_price_drive_bps,
+                    floor=min_session_open_drive_bps,
+                    required=False,
+                ),
+                _threshold_min(
+                    metric='effective_opening_window_return_bps',
+                    value=effective_opening_window_return_bps,
+                    floor=min_opening_window_return_bps,
+                    required=False,
+                ),
+                _threshold_min(
+                    metric='session_open_return_efficiency',
+                    value=session_open_return_efficiency,
+                    floor=min_session_open_return_efficiency,
+                    required=False,
+                ),
+                _threshold_bool(
+                    metric='shape_passes',
+                    passed=classical_breakout_shape_passes or isolated_continuation_shape_passes,
+                    threshold=True,
+                ),
+                *_threshold_range(
+                    metric='vol_realized_w60s',
+                    value=vol_realized_w60s,
+                    floor=_optional_decimal_param(params, 'vol_floor', Decimal('0.00004')),
+                    ceil=effective_vol_ceil,
+                    required=False,
+                ),
+            ),
+        ),
+        _gate(
+            name='feed_quality',
+            category='feed_quality',
+            thresholds=(
+                _threshold_max(
+                    metric='spread_bps',
+                    value=effective_spread_bps,
+                    ceil=spread_cap_bps,
+                    required=True,
+                ),
+                _threshold_max(
+                    metric='recent_spread_bps_avg',
+                    value=recent_spread_bps_avg,
+                    ceil=max_recent_spread_bps,
+                    required=False,
+                ),
+                _threshold_max(
+                    metric='recent_spread_bps_max',
+                    value=recent_spread_bps_max,
+                    ceil=max_recent_spread_bps_max,
+                    required=False,
+                ),
+                _threshold_max(
+                    metric='recent_quote_invalid_ratio_hard',
+                    value=recent_quote_invalid_ratio,
+                    ceil=hard_max_recent_quote_invalid_ratio,
+                    required=False,
+                ),
+                _threshold_max(
+                    metric='recent_quote_invalid_ratio',
+                    value=recent_quote_invalid_ratio,
+                    ceil=max_recent_quote_invalid_ratio,
+                    required=False,
+                ),
+                _threshold_max(
+                    metric='recent_quote_jump_bps_max',
+                    value=recent_quote_jump_bps_max,
+                    ceil=max_recent_quote_jump_bps,
+                    required=False,
+                ),
+            ),
+        ),
+        _gate(
+            name='confirmation',
+            category='confirmation',
+            thresholds=(
+                _threshold_min(
+                    metric='imbalance_pressure',
+                    value=imbalance_pressure,
+                    floor=effective_min_imbalance_pressure,
+                    required=True,
+                ),
+                _threshold_min(
+                    metric='recent_imbalance_pressure_avg',
+                    value=recent_imbalance_pressure_avg,
+                    floor=min_recent_imbalance_pressure,
+                    required=False,
+                ),
+                _threshold_min(
+                    metric='recent_microprice_bias_bps_avg',
+                    value=recent_microprice_bias_bps_avg,
+                    floor=min_recent_microprice_bias_bps,
+                    required=False,
+                ),
+                _threshold_bool(
+                    metric='recent_breakout_reference_hold_passes',
+                    passed=recent_breakout_reference_hold_passes,
+                    threshold=True,
+                ),
+                _threshold_min(
+                    metric='recent_above_vwap_w5m_ratio',
+                    value=recent_above_vwap_w5m_ratio,
+                    floor=min_recent_above_vwap_w5m_ratio,
+                    required=False,
+                ),
+                _threshold_min(
+                    metric='effective_continuation_rank',
+                    value=effective_continuation_rank,
+                    floor=min_cross_section_continuation_rank,
+                    required=False,
+                ),
+                _threshold_min(
+                    metric='effective_opening_window_return_rank',
+                    value=effective_opening_window_return_rank,
+                    floor=min_cross_section_opening_window_return_rank,
+                    required=False,
+                ),
+                _threshold_min(
+                    metric='effective_positive_session_open_ratio',
+                    value=effective_positive_session_open_ratio,
+                    floor=min_cross_section_positive_session_open_ratio,
+                    required=False,
+                ),
+                _threshold_min(
+                    metric='effective_positive_opening_window_return_ratio',
+                    value=effective_positive_opening_window_return_ratio,
+                    floor=min_cross_section_positive_opening_window_return_ratio,
+                    required=False,
+                ),
+                _threshold_min(
+                    metric='cross_section_above_vwap_w5m_ratio',
+                    value=cross_section_above_vwap_w5m_ratio,
+                    floor=min_cross_section_above_vwap_w5m_ratio,
+                    required=False,
+                ),
+                _threshold_min(
+                    metric='cross_section_continuation_breadth',
+                    value=cross_section_continuation_breadth,
+                    floor=min_cross_section_continuation_breadth,
+                    required=False,
+                ),
+                _threshold_bool(
+                    metric='early_breakout_quality_passes',
+                    passed=_early_breakout_quality_passes(
+                        event_ts=event_ts,
+                        cutoff_minutes=early_breakout_quality_cutoff_minutes,
+                        continuation_rank=effective_continuation_rank,
+                        elite_continuation_rank=early_breakout_elite_continuation_rank,
+                        continuation_breadth=cross_section_continuation_breadth,
+                        min_continuation_breadth=min_early_breakout_continuation_breadth,
+                        microprice_bias_bps=recent_microprice_bias_bps_avg,
+                        min_microprice_bias_bps=min_early_breakout_microprice_bias_bps,
+                    ),
+                    threshold=True,
+                ),
+            ),
+        ),
+    )
 
-    if (
-        ema12 > ema26
-        and macd_hist >= effective_bullish_hist_min
-        and effective_min_bull_rsi <= rsi14 <= effective_max_bull_rsi
-        and _optional_min_threshold(
-            price_vs_ema12_bps,
-            _decimal_param(params, 'min_price_above_ema12_bps', Decimal('0')),
-        )
-        and _optional_max_threshold(price_vs_ema12_bps, ema_extension_cap_bps)
-        and _optional_min_threshold(price_vs_vwap_w5m_bps, min_price_vs_vwap_w5m_bps)
-        and _optional_max_threshold(price_vs_vwap_w5m_bps, vwap_w5m_extension_cap_bps)
-        and effective_spread_bps <= spread_cap_bps
-        and imbalance_pressure >= effective_min_imbalance_pressure
-        and _optional_min_threshold(effective_price_drive_bps, min_session_open_drive_bps)
-        and _optional_min_threshold(
-            effective_opening_window_return_bps,
-            min_opening_window_return_bps,
-        )
-        and _optional_min_threshold(
-            session_open_return_efficiency,
-            min_session_open_return_efficiency,
-        )
-        and (
-            classical_breakout_shape_passes
-            or isolated_continuation_shape_passes
-        )
-        and _optional_max_threshold(recent_spread_bps_avg, max_recent_spread_bps)
-        and _optional_max_threshold(recent_spread_bps_max, max_recent_spread_bps_max)
-        and _optional_min_threshold(recent_imbalance_pressure_avg, min_recent_imbalance_pressure)
-        and _optional_max_threshold(
-            recent_quote_invalid_ratio,
-            hard_max_recent_quote_invalid_ratio,
-        )
-        and _quote_stability_passes(
-            recent_quote_invalid_ratio=recent_quote_invalid_ratio,
-            max_recent_quote_invalid_ratio=max_recent_quote_invalid_ratio,
-            recent_quote_jump_bps_max=recent_quote_jump_bps_max,
-            max_recent_quote_jump_bps=max_recent_quote_jump_bps,
-        )
-        and _optional_min_threshold(
-            recent_microprice_bias_bps_avg,
-            min_recent_microprice_bias_bps,
-        )
-        and recent_breakout_reference_hold_passes
-        and _optional_min_threshold(
-            recent_above_vwap_w5m_ratio,
-            min_recent_above_vwap_w5m_ratio,
-        )
-        and _optional_min_threshold(
-            effective_continuation_rank,
-            min_cross_section_continuation_rank,
-        )
-        and _optional_min_threshold(
-            effective_opening_window_return_rank,
-            min_cross_section_opening_window_return_rank,
-        )
-        and _optional_min_threshold(
-            effective_positive_session_open_ratio,
-            min_cross_section_positive_session_open_ratio,
-        )
-        and _optional_min_threshold(
-            effective_positive_opening_window_return_ratio,
-            min_cross_section_positive_opening_window_return_ratio,
-        )
-        and _optional_min_threshold(
-            cross_section_above_vwap_w5m_ratio,
-            min_cross_section_above_vwap_w5m_ratio,
-        )
-        and _optional_min_threshold(
-            cross_section_continuation_breadth,
-            min_cross_section_continuation_breadth,
-        )
-        and _early_breakout_quality_passes(
-            event_ts=event_ts,
-            cutoff_minutes=early_breakout_quality_cutoff_minutes,
-            continuation_rank=effective_continuation_rank,
-            elite_continuation_rank=early_breakout_elite_continuation_rank,
-            continuation_breadth=cross_section_continuation_breadth,
-            min_continuation_breadth=min_early_breakout_continuation_breadth,
-            microprice_bias_bps=recent_microprice_bias_bps_avg,
-            min_microprice_bias_bps=min_early_breakout_microprice_bias_bps,
-        )
-        and _vol_within_band(
-            vol_realized_w60s,
-            floor=_optional_decimal_param(params, 'vol_floor', Decimal('0.00004')),
-            ceil=effective_vol_ceil,
-        )
-    ):
+    if all(gate.passed for gate in buy_gates):
         confidence = Decimal('0.68')
         if price_vs_opening_range_high_bps is not None and price_vs_opening_range_high_bps >= 0:
             confidence += Decimal('0.03')
@@ -941,24 +1552,34 @@ def evaluate_breakout_continuation_long(
             and cross_section_continuation_breadth >= Decimal('0.65')
         ):
             confidence += Decimal('0.02')
-        return SleeveSignalEvaluation(
-            action='buy',
-            confidence=min(confidence, Decimal('0.86')),
-            rationale=(
-                'breakout_continuation_long',
-                'trend_up',
-                'session_drive_confirmed',
-                'opening_range_breakout',
-                'above_vwap',
-                'leader_reclaim_confirmed' if leader_reclaim_confirmed else 'imbalance_confirmed',
-            ),
-            notional_multiplier=_resolve_entry_notional_multiplier(
-                params=params,
+        return _sleeve_result(
+            strategy_id=strategy_id,
+            strategy_type=strategy_type,
+            symbol=symbol,
+            event_ts=event_ts,
+            timeframe=timeframe,
+            signal=SleeveSignalEvaluation(
+                action='buy',
                 confidence=min(confidence, Decimal('0.86')),
-                rank=effective_continuation_rank,
-                spread_bps=effective_spread_bps,
-                spread_cap_bps=spread_cap_bps,
+                rationale=(
+                    'breakout_continuation_long',
+                    'trend_up',
+                    'session_drive_confirmed',
+                    'opening_range_breakout',
+                    'above_vwap',
+                    'leader_reclaim_confirmed' if leader_reclaim_confirmed else 'imbalance_confirmed',
+                ),
+                notional_multiplier=_resolve_entry_notional_multiplier(
+                    params=params,
+                    confidence=min(confidence, Decimal('0.86')),
+                    rank=effective_continuation_rank,
+                    spread_bps=effective_spread_bps,
+                    spread_cap_bps=spread_cap_bps,
+                ),
             ),
+            gates=buy_gates,
+            trace_enabled=trace_enabled,
+            context=trace_context,
         )
 
     exit_macd_hist_max = _decimal_param(params, 'exit_macd_hist_max', Decimal('-0.003'))
@@ -1037,15 +1658,6 @@ def evaluate_breakout_continuation_long(
         )
         or momentum_rollover_failure_confirmed
     )
-    if breakout_failure_confirmed:
-        return SleeveSignalEvaluation(
-            action='sell',
-            confidence=Decimal('0.62'),
-            rationale=(
-                'breakout_continuation_exit',
-                'breakout_failed',
-            ),
-        )
     session_strength_reversal_confirmed = (
         recent_imbalance_pressure_avg is not None
         and recent_imbalance_pressure_avg
@@ -1074,6 +1686,38 @@ def evaluate_breakout_continuation_long(
             )
         )
     )
+    exit_gate = _gate(
+        name='exit',
+        category='exit',
+        thresholds=(
+            _threshold_bool(metric='breakout_failure_confirmed', passed=breakout_failure_confirmed, threshold=True),
+            _threshold_bool(
+                metric='session_strength_reversal_confirmed',
+                passed=session_strength_reversal_confirmed,
+                threshold=False,
+                value=session_strength_reversal_confirmed,
+            ),
+        ),
+    )
+    if breakout_failure_confirmed:
+        return _sleeve_result(
+            strategy_id=strategy_id,
+            strategy_type=strategy_type,
+            symbol=symbol,
+            event_ts=event_ts,
+            timeframe=timeframe,
+            signal=SleeveSignalEvaluation(
+                action='sell',
+                confidence=Decimal('0.62'),
+                rationale=(
+                    'breakout_continuation_exit',
+                    'breakout_failed',
+                ),
+            ),
+            gates=(exit_gate,),
+            trace_enabled=trace_enabled,
+            context=trace_context,
+        )
     price_below_opening_range_high = (
         price_vs_opening_range_high_bps is not None
         and _optional_max_threshold(
@@ -1082,21 +1726,46 @@ def evaluate_breakout_continuation_long(
         )
     )
     if price_below_opening_range_high or session_strength_reversal_confirmed:
-        return SleeveSignalEvaluation(
-            action='sell',
-            confidence=Decimal('0.63'),
-            rationale=(
-                'breakout_continuation_exit',
-                'session_strength_reversal',
+        return _sleeve_result(
+            strategy_id=strategy_id,
+            strategy_type=strategy_type,
+            symbol=symbol,
+            event_ts=event_ts,
+            timeframe=timeframe,
+            signal=SleeveSignalEvaluation(
+                action='sell',
+                confidence=Decimal('0.63'),
+                rationale=(
+                    'breakout_continuation_exit',
+                    'session_strength_reversal',
+                ),
             ),
+            gates=(exit_gate,),
+            trace_enabled=trace_enabled,
+            context=trace_context,
         )
-    return None
+    return _sleeve_result(
+        strategy_id=strategy_id,
+        strategy_type=strategy_type,
+        symbol=symbol,
+        event_ts=event_ts,
+        timeframe=timeframe,
+        signal=None,
+        gates=buy_gates,
+        trace_enabled=trace_enabled,
+        context=trace_context,
+    )
 
 
 def evaluate_mean_reversion_rebound_long(
     *,
     params: Mapping[str, Any],
+    strategy_id: str | None,
+    strategy_type: str | None,
+    symbol: str,
     event_ts: str,
+    timeframe: str | None,
+    trace_enabled: bool,
     price: Decimal | None,
     ema12: Decimal | None,
     macd: Decimal | None,
@@ -1124,27 +1793,63 @@ def evaluate_mean_reversion_rebound_long(
     cross_section_opening_window_return_from_prev_close_rank: Decimal | None,
     cross_section_continuation_rank: Decimal | None,
     cross_section_reversal_rank: Decimal | None,
-) -> SleeveSignalEvaluation | None:
-    if (
-        price is None
-        or ema12 is None
-        or macd is None
-        or macd_signal is None
-        or rsi14 is None
-    ):
-        return None
+) -> SleeveSignalResult:
+    trace_context = {'family': 'mean_reversion_rebound_long'}
+    required_fields = {
+        'price': price is not None,
+        'ema12': ema12 is not None,
+        'macd': macd is not None,
+        'macd_signal': macd_signal is not None,
+        'rsi14': rsi14 is not None,
+    }
+    if not all(required_fields.values()):
+        return _sleeve_result(
+            strategy_id=strategy_id,
+            strategy_type=strategy_type,
+            symbol=symbol,
+            event_ts=event_ts,
+            timeframe=timeframe,
+            signal=None,
+            gates=(_required_inputs_gate(fields=required_fields),),
+            trace_enabled=trace_enabled,
+            context=trace_context,
+        )
 
     ts = _parse_event_ts(event_ts)
-    if not _within_utc_window(
+    entry_start_minute = _minute_param(params, 'entry_start_minute_utc', 14 * 60)
+    entry_end_minute = _effective_entry_end_minute(
+        params,
+        default_end_minute=18 * 60 + 45,
+    )
+    within_window = _within_utc_window(
         ts,
-        start_minute=_minute_param(params, 'entry_start_minute_utc', 14 * 60),
-        end_minute=_effective_entry_end_minute(
-            params,
-            default_end_minute=18 * 60 + 45,
-        ),
-    ):
-        return None
+        start_minute=entry_start_minute,
+        end_minute=entry_end_minute,
+    )
+    if not within_window:
+        return _sleeve_result(
+            strategy_id=strategy_id,
+            strategy_type=strategy_type,
+            symbol=symbol,
+            event_ts=event_ts,
+            timeframe=timeframe,
+            signal=None,
+            gates=(
+                _entry_window_gate(
+                    within_window=within_window,
+                    start_minute=entry_start_minute,
+                    end_minute=entry_end_minute,
+                ),
+            ),
+            trace_enabled=trace_enabled,
+            context=trace_context,
+        )
 
+    assert price is not None
+    assert ema12 is not None
+    assert macd is not None
+    assert macd_signal is not None
+    assert rsi14 is not None
     macd_hist = macd - macd_signal
     price_vs_ema12_bps = _bps_delta(price, ema12)
     price_vs_vwap_bps = _bps_delta(price, vwap_session) if vwap_session is not None else price_vs_ema12_bps
@@ -1218,68 +1923,167 @@ def evaluate_mean_reversion_rebound_long(
         'max_cross_section_opening_window_return_rank',
         None,
     )
+    price_below_vwap_bps = -price_vs_vwap_bps if price_vs_vwap_bps is not None else None
+    price_below_ema12_bps = -price_vs_ema12_bps if price_vs_ema12_bps is not None else None
+    buy_gates = (
+        _gate(
+            name='structure',
+            category='structure',
+            thresholds=(
+                *_threshold_range(
+                    metric='price_below_vwap_bps',
+                    value=price_below_vwap_bps,
+                    floor=_decimal_param(params, 'min_price_below_vwap_bps', Decimal('8')),
+                    ceil=_decimal_param(params, 'max_price_below_vwap_bps', Decimal('70')),
+                    required=True,
+                ),
+                *_threshold_range(
+                    metric='price_below_ema12_bps',
+                    value=price_below_ema12_bps,
+                    floor=_decimal_param(params, 'min_price_below_ema12_bps', Decimal('2')),
+                    ceil=_decimal_param(params, 'max_price_below_ema12_bps', Decimal('35')),
+                    required=True,
+                ),
+                *_threshold_range(
+                    metric='rsi14',
+                    value=rsi14,
+                    floor=_decimal_param(params, 'min_bull_rsi', Decimal('40')),
+                    ceil=_decimal_param(params, 'max_bull_rsi', Decimal('52')),
+                    required=True,
+                ),
+                *_threshold_range(
+                    metric='macd_hist',
+                    value=macd_hist,
+                    floor=_decimal_param(params, 'bullish_hist_min', Decimal('0.002')),
+                    ceil=_decimal_param(params, 'bullish_hist_cap', Decimal('0.05')),
+                    required=True,
+                ),
+                _threshold_max(
+                    metric='effective_price_drive_bps',
+                    value=effective_price_drive_bps,
+                    ceil=max_session_open_drive_bps,
+                    required=False,
+                ),
+                _threshold_max(
+                    metric='effective_opening_window_return_bps',
+                    value=effective_opening_window_return_bps,
+                    ceil=max_opening_window_return_bps,
+                    required=False,
+                ),
+                _threshold_max(
+                    metric='price_position_in_session_range',
+                    value=price_position_in_session_range,
+                    ceil=max_session_range_position,
+                    required=False,
+                ),
+                _threshold_min(
+                    metric='session_range_bps',
+                    value=session_range_bps,
+                    floor=min_session_range_bps,
+                    required=False,
+                ),
+                _threshold_min(
+                    metric='price_vs_opening_range_low_bps',
+                    value=price_vs_opening_range_low_bps,
+                    floor=min_price_vs_opening_range_low_bps,
+                    required=False,
+                ),
+                _threshold_max(
+                    metric='price_vs_opening_range_low_bps',
+                    value=price_vs_opening_range_low_bps,
+                    ceil=max_price_vs_opening_range_low_bps,
+                    required=False,
+                ),
+            ),
+        ),
+        _gate(
+            name='feed_quality',
+            category='feed_quality',
+            thresholds=(
+                _threshold_max(
+                    metric='spread_bps',
+                    value=effective_spread_bps,
+                    ceil=spread_cap_bps,
+                    required=True,
+                ),
+                _threshold_max(
+                    metric='recent_spread_bps_avg',
+                    value=recent_spread_bps_avg,
+                    ceil=max_recent_spread_bps,
+                    required=False,
+                ),
+                _threshold_max(
+                    metric='recent_spread_bps_max',
+                    value=recent_spread_bps_max,
+                    ceil=max_recent_spread_bps_max,
+                    required=False,
+                ),
+                _threshold_max(
+                    metric='recent_quote_invalid_ratio',
+                    value=recent_quote_invalid_ratio,
+                    ceil=max_recent_quote_invalid_ratio,
+                    required=False,
+                ),
+                _threshold_max(
+                    metric='recent_quote_jump_bps_max',
+                    value=recent_quote_jump_bps_max,
+                    ceil=max_recent_quote_jump_bps,
+                    required=False,
+                ),
+                *_threshold_range(
+                    metric='vol_realized_w60s',
+                    value=vol_realized_w60s,
+                    floor=_optional_decimal_param(params, 'vol_floor', Decimal('0.00005')),
+                    ceil=_optional_decimal_param(params, 'vol_ceil', Decimal('0.00055')),
+                    required=False,
+                ),
+            ),
+        ),
+        _gate(
+            name='confirmation',
+            category='confirmation',
+            thresholds=(
+                _threshold_min(
+                    metric='imbalance_pressure',
+                    value=imbalance_pressure,
+                    floor=_decimal_param(params, 'min_imbalance_pressure', Decimal('0')),
+                    required=True,
+                ),
+                _threshold_min(
+                    metric='recent_imbalance_pressure_avg',
+                    value=recent_imbalance_pressure_avg,
+                    floor=min_recent_imbalance_pressure,
+                    required=False,
+                ),
+                _threshold_min(
+                    metric='recent_microprice_bias_bps_avg',
+                    value=recent_microprice_bias_bps_avg,
+                    floor=min_recent_microprice_bias_bps,
+                    required=False,
+                ),
+                _threshold_max(
+                    metric='cross_section_continuation_rank',
+                    value=cross_section_continuation_rank,
+                    ceil=max_cross_section_continuation_rank,
+                    required=False,
+                ),
+                _threshold_min(
+                    metric='cross_section_reversal_rank',
+                    value=cross_section_reversal_rank,
+                    floor=min_cross_section_reversal_rank,
+                    required=False,
+                ),
+                _threshold_max(
+                    metric='effective_opening_window_return_rank',
+                    value=effective_opening_window_return_rank,
+                    ceil=max_cross_section_opening_window_return_rank,
+                    required=False,
+                ),
+            ),
+        ),
+    )
 
-    if (
-        _optional_min_threshold(
-            -price_vs_vwap_bps if price_vs_vwap_bps is not None else None,
-            _decimal_param(params, 'min_price_below_vwap_bps', Decimal('8')),
-        )
-        and _optional_max_threshold(
-            -price_vs_vwap_bps if price_vs_vwap_bps is not None else None,
-            _decimal_param(params, 'max_price_below_vwap_bps', Decimal('70')),
-        )
-        and _optional_min_threshold(
-            -price_vs_ema12_bps if price_vs_ema12_bps is not None else None,
-            _decimal_param(params, 'min_price_below_ema12_bps', Decimal('2')),
-        )
-        and _optional_max_threshold(
-            -price_vs_ema12_bps if price_vs_ema12_bps is not None else None,
-            _decimal_param(params, 'max_price_below_ema12_bps', Decimal('35')),
-        )
-        and _decimal_param(params, 'min_bull_rsi', Decimal('40')) <= rsi14 <= _decimal_param(params, 'max_bull_rsi', Decimal('52'))
-        and _decimal_param(params, 'bullish_hist_min', Decimal('0.002')) <= macd_hist <= _decimal_param(params, 'bullish_hist_cap', Decimal('0.05'))
-        and effective_spread_bps <= spread_cap_bps
-        and imbalance_pressure >= _decimal_param(params, 'min_imbalance_pressure', Decimal('0'))
-        and _optional_max_threshold(effective_price_drive_bps, max_session_open_drive_bps)
-        and _optional_max_threshold(
-            effective_opening_window_return_bps,
-            max_opening_window_return_bps,
-        )
-        and _optional_max_threshold(price_position_in_session_range, max_session_range_position)
-        and _optional_min_threshold(session_range_bps, min_session_range_bps)
-        and _optional_min_threshold(price_vs_opening_range_low_bps, min_price_vs_opening_range_low_bps)
-        and _optional_max_threshold(price_vs_opening_range_low_bps, max_price_vs_opening_range_low_bps)
-        and _optional_max_threshold(recent_spread_bps_avg, max_recent_spread_bps)
-        and _optional_max_threshold(recent_spread_bps_max, max_recent_spread_bps_max)
-        and _optional_min_threshold(recent_imbalance_pressure_avg, min_recent_imbalance_pressure)
-        and _quote_stability_passes(
-            recent_quote_invalid_ratio=recent_quote_invalid_ratio,
-            max_recent_quote_invalid_ratio=max_recent_quote_invalid_ratio,
-            recent_quote_jump_bps_max=recent_quote_jump_bps_max,
-            max_recent_quote_jump_bps=max_recent_quote_jump_bps,
-        )
-        and _optional_min_threshold(
-            recent_microprice_bias_bps_avg,
-            min_recent_microprice_bias_bps,
-        )
-        and _optional_max_threshold(
-            cross_section_continuation_rank,
-            max_cross_section_continuation_rank,
-        )
-        and _optional_min_threshold(
-            cross_section_reversal_rank,
-            min_cross_section_reversal_rank,
-        )
-        and _optional_max_threshold(
-            effective_opening_window_return_rank,
-            max_cross_section_opening_window_return_rank,
-        )
-        and _vol_within_band(
-            vol_realized_w60s,
-            floor=_optional_decimal_param(params, 'vol_floor', Decimal('0.00005')),
-            ceil=_optional_decimal_param(params, 'vol_ceil', Decimal('0.00055')),
-        )
-    ):
+    if all(gate.passed for gate in buy_gates):
         confidence = Decimal('0.64')
         if price_vs_vwap_bps is not None and -price_vs_vwap_bps >= Decimal('16'):
             confidence += Decimal('0.03')
@@ -1299,54 +2103,93 @@ def evaluate_mean_reversion_rebound_long(
             and recent_microprice_bias_bps_avg >= Decimal('0.75')
         ):
             confidence += Decimal('0.02')
-        return SleeveSignalEvaluation(
-            action='buy',
-            confidence=min(confidence, Decimal('0.81')),
-            rationale=(
-                'mean_reversion_rebound_long',
-                'oversold_rebound',
-                'below_vwap',
-                'session_dislocation',
-                'spread_normalized',
-            ),
-            notional_multiplier=_resolve_entry_notional_multiplier(
-                params=params,
+        return _sleeve_result(
+            strategy_id=strategy_id,
+            strategy_type=strategy_type,
+            symbol=symbol,
+            event_ts=event_ts,
+            timeframe=timeframe,
+            signal=SleeveSignalEvaluation(
+                action='buy',
                 confidence=min(confidence, Decimal('0.81')),
-                rank=cross_section_reversal_rank,
-                spread_bps=effective_spread_bps,
-                spread_cap_bps=spread_cap_bps,
+                rationale=(
+                    'mean_reversion_rebound_long',
+                    'oversold_rebound',
+                    'below_vwap',
+                    'session_dislocation',
+                    'spread_normalized',
+                ),
+                notional_multiplier=_resolve_entry_notional_multiplier(
+                    params=params,
+                    confidence=min(confidence, Decimal('0.81')),
+                    rank=cross_section_reversal_rank,
+                    spread_bps=effective_spread_bps,
+                    spread_cap_bps=spread_cap_bps,
+                ),
             ),
+            gates=buy_gates,
+            trace_enabled=trace_enabled,
+            context=trace_context,
         )
 
-    if (
-        (vwap_session is not None and price >= vwap_session)
-        or (vwap_session is None and price >= ema12)
-        or rsi14 >= _decimal_param(params, 'exit_rsi_min', Decimal('61'))
-        or macd_hist <= _decimal_param(params, 'exit_macd_hist_max', Decimal('-0.002'))
-        or (
+    exit_reasons: dict[str, bool] = {
+        'vwap_recovery': (vwap_session is not None and price >= vwap_session)
+        or (vwap_session is None and price >= ema12),
+        'rsi_recovered': rsi14 >= _decimal_param(params, 'exit_rsi_min', Decimal('61')),
+        'macd_rollover': macd_hist <= _decimal_param(params, 'exit_macd_hist_max', Decimal('-0.002')),
+        'imbalance_reversal': (
             recent_imbalance_pressure_avg is not None
-            and recent_imbalance_pressure_avg <= _decimal_param(params, 'exit_recent_imbalance_pressure_max', Decimal('-0.02'))
-        )
-        or (
+            and recent_imbalance_pressure_avg
+            <= _decimal_param(params, 'exit_recent_imbalance_pressure_max', Decimal('-0.02'))
+        ),
+        'range_recovery': (
             price_position_in_session_range is not None
-            and price_position_in_session_range >= _decimal_param(params, 'exit_session_range_position_min', Decimal('0.58'))
-        )
-    ):
-        return SleeveSignalEvaluation(
-            action='sell',
-            confidence=Decimal('0.61'),
-            rationale=(
-                'mean_reversion_rebound_exit',
-                'rebound_complete',
+            and price_position_in_session_range
+            >= _decimal_param(params, 'exit_session_range_position_min', Decimal('0.58'))
+        ),
+    }
+    exit_gate = _exit_trigger_gate(reason_flags=exit_reasons)
+    if exit_gate.passed:
+        return _sleeve_result(
+            strategy_id=strategy_id,
+            strategy_type=strategy_type,
+            symbol=symbol,
+            event_ts=event_ts,
+            timeframe=timeframe,
+            signal=SleeveSignalEvaluation(
+                action='sell',
+                confidence=Decimal('0.61'),
+                rationale=(
+                    'mean_reversion_rebound_exit',
+                    'rebound_complete',
+                ),
             ),
+            gates=(exit_gate,),
+            trace_enabled=trace_enabled,
+            context=trace_context,
         )
-    return None
+    return _sleeve_result(
+        strategy_id=strategy_id,
+        strategy_type=strategy_type,
+        symbol=symbol,
+        event_ts=event_ts,
+        timeframe=timeframe,
+        signal=None,
+        gates=buy_gates,
+        trace_enabled=trace_enabled,
+        context=trace_context,
+    )
 
 
 def evaluate_late_day_continuation_long(
     *,
     params: Mapping[str, Any],
+    strategy_id: str | None,
+    strategy_type: str | None,
+    symbol: str,
     event_ts: str,
+    timeframe: str | None,
+    trace_enabled: bool,
     price: Decimal | None,
     ema12: Decimal | None,
     ema26: Decimal | None,
@@ -1390,28 +2233,65 @@ def evaluate_late_day_continuation_long(
     cross_section_vwap_w5m_rank: Decimal | None,
     cross_section_recent_imbalance_rank: Decimal | None,
     cross_section_continuation_rank: Decimal | None,
-) -> SleeveSignalEvaluation | None:
-    if (
-        price is None
-        or ema12 is None
-        or ema26 is None
-        or macd is None
-        or macd_signal is None
-        or rsi14 is None
-    ):
-        return None
+) -> SleeveSignalResult:
+    trace_context = {'family': 'late_day_continuation_long'}
+    required_fields = {
+        'price': price is not None,
+        'ema12': ema12 is not None,
+        'ema26': ema26 is not None,
+        'macd': macd is not None,
+        'macd_signal': macd_signal is not None,
+        'rsi14': rsi14 is not None,
+    }
+    if not all(required_fields.values()):
+        return _sleeve_result(
+            strategy_id=strategy_id,
+            strategy_type=strategy_type,
+            symbol=symbol,
+            event_ts=event_ts,
+            timeframe=timeframe,
+            signal=None,
+            gates=(_required_inputs_gate(fields=required_fields),),
+            trace_enabled=trace_enabled,
+            context=trace_context,
+        )
 
     ts = _parse_event_ts(event_ts)
-    if not _within_utc_window(
+    entry_start_minute = _minute_param(params, 'entry_start_minute_utc', 18 * 60 + 15)
+    entry_end_minute = _effective_entry_end_minute(
+        params,
+        default_end_minute=19 * 60 + 20,
+    )
+    within_window = _within_utc_window(
         ts,
-        start_minute=_minute_param(params, 'entry_start_minute_utc', 18 * 60 + 15),
-        end_minute=_effective_entry_end_minute(
-            params,
-            default_end_minute=19 * 60 + 20,
-        ),
-    ):
-        return None
+        start_minute=entry_start_minute,
+        end_minute=entry_end_minute,
+    )
+    if not within_window:
+        return _sleeve_result(
+            strategy_id=strategy_id,
+            strategy_type=strategy_type,
+            symbol=symbol,
+            event_ts=event_ts,
+            timeframe=timeframe,
+            signal=None,
+            gates=(
+                _entry_window_gate(
+                    within_window=within_window,
+                    start_minute=entry_start_minute,
+                    end_minute=entry_end_minute,
+                ),
+            ),
+            trace_enabled=trace_enabled,
+            context=trace_context,
+        )
 
+    assert price is not None
+    assert ema12 is not None
+    assert ema26 is not None
+    assert macd is not None
+    assert macd_signal is not None
+    assert rsi14 is not None
     macd_hist = macd - macd_signal
     price_vs_ema12_bps = _bps_delta(price, ema12)
     effective_spread_bps = _nonnegative_decimal(spread_bps)
@@ -1929,86 +2809,200 @@ def evaluate_late_day_continuation_long(
             max_price_vs_opening_window_close_bps,
         )
     )
+    buy_gates = (
+        _gate(
+            name='structure',
+            category='structure',
+            thresholds=(
+                _threshold_bool(metric='ema12_gt_ema26', passed=ema12 > ema26, threshold=True),
+                *_threshold_range(
+                    metric='macd_hist',
+                    value=macd_hist,
+                    floor=_decimal_param(params, 'bullish_hist_min', Decimal('0.006')),
+                    ceil=_decimal_param(params, 'bullish_hist_cap', Decimal('0.05')),
+                    required=True,
+                ),
+                *_threshold_range(
+                    metric='rsi14',
+                    value=rsi14,
+                    floor=_decimal_param(params, 'min_bull_rsi', Decimal('57')),
+                    ceil=_decimal_param(params, 'max_bull_rsi', Decimal('72')),
+                    required=True,
+                ),
+                _threshold_min(
+                    metric='price_vs_ema12_bps',
+                    value=price_vs_ema12_bps,
+                    floor=_decimal_param(params, 'min_price_above_ema12_bps', Decimal('0')),
+                    required=True,
+                ),
+                _threshold_max(
+                    metric='price_vs_ema12_bps',
+                    value=price_vs_ema12_bps,
+                    ceil=_decimal_param(params, 'max_price_above_ema12_bps', Decimal('14')),
+                    required=True,
+                ),
+                _threshold_min(
+                    metric='price_vs_vwap_w5m_bps',
+                    value=price_vs_vwap_w5m_bps,
+                    floor=min_price_vs_vwap_w5m_bps,
+                    required=False,
+                ),
+                _threshold_max(
+                    metric='price_vs_vwap_w5m_bps',
+                    value=price_vs_vwap_w5m_bps,
+                    ceil=max_price_vs_vwap_w5m_bps,
+                    required=False,
+                ),
+                _threshold_min(
+                    metric='effective_price_drive_bps',
+                    value=effective_price_drive_bps,
+                    floor=min_session_open_drive_bps,
+                    required=False,
+                ),
+                _threshold_min(
+                    metric='effective_opening_window_return_bps',
+                    value=effective_opening_window_return_bps,
+                    floor=min_opening_window_return_bps,
+                    required=False,
+                ),
+                _threshold_bool(
+                    metric='same_day_opening_window_confirmed',
+                    passed=same_day_opening_window_confirmed,
+                    threshold=True,
+                ),
+                _threshold_bool(
+                    metric='late_day_shape_passes',
+                    passed=(
+                        classical_late_day_shape_passes
+                        or isolated_late_day_shape_passes
+                        or opening_drive_late_day_shape_passes
+                    ),
+                    threshold=True,
+                ),
+                *_threshold_range(
+                    metric='vol_realized_w60s',
+                    value=vol_realized_w60s,
+                    floor=_optional_decimal_param(params, 'vol_floor', Decimal('0.00005')),
+                    ceil=_optional_decimal_param(params, 'vol_ceil', Decimal('0.00035')),
+                    required=False,
+                ),
+            ),
+        ),
+        _gate(
+            name='feed_quality',
+            category='feed_quality',
+            thresholds=(
+                _threshold_max(
+                    metric='spread_bps',
+                    value=effective_spread_bps,
+                    ceil=spread_cap_bps,
+                    required=True,
+                ),
+                _threshold_min(
+                    metric='imbalance_pressure',
+                    value=imbalance_pressure,
+                    floor=_decimal_param(params, 'min_imbalance_pressure', Decimal('-0.01')),
+                    required=True,
+                ),
+                _threshold_max(
+                    metric='recent_spread_bps_avg',
+                    value=recent_spread_bps_avg,
+                    ceil=max_recent_spread_bps,
+                    required=False,
+                ),
+                _threshold_min(
+                    metric='recent_imbalance_pressure_avg',
+                    value=recent_imbalance_pressure_avg,
+                    floor=min_recent_imbalance_pressure,
+                    required=False,
+                ),
+                _threshold_max(
+                    metric='recent_quote_invalid_ratio_hard',
+                    value=recent_quote_invalid_ratio,
+                    ceil=hard_max_recent_quote_invalid_ratio,
+                    required=False,
+                ),
+                _threshold_max(
+                    metric='recent_quote_invalid_ratio',
+                    value=recent_quote_invalid_ratio,
+                    ceil=max_recent_quote_invalid_ratio,
+                    required=False,
+                ),
+                _threshold_max(
+                    metric='recent_quote_jump_bps_max',
+                    value=recent_quote_jump_bps_max,
+                    ceil=max_recent_quote_jump_bps,
+                    required=False,
+                ),
+                _threshold_min(
+                    metric='recent_microprice_bias_bps_avg',
+                    value=recent_microprice_bias_bps_avg,
+                    floor=min_recent_microprice_bias_bps,
+                    required=False,
+                ),
+            ),
+        ),
+        _gate(
+            name='confirmation',
+            category='confirmation',
+            thresholds=(
+                _threshold_bool(
+                    metric='recent_late_day_reference_hold_passes',
+                    passed=recent_late_day_reference_hold_passes,
+                    threshold=True,
+                ),
+                _threshold_bool(
+                    metric='late_day_opening_window_close_hold_passes',
+                    passed=late_day_opening_window_close_hold_passes,
+                    threshold=True,
+                ),
+                _threshold_min(
+                    metric='recent_above_vwap_w5m_ratio',
+                    value=recent_above_vwap_w5m_ratio,
+                    floor=min_recent_above_vwap_w5m_ratio,
+                    required=False,
+                ),
+                _threshold_min(
+                    metric='effective_continuation_rank',
+                    value=effective_continuation_rank,
+                    floor=min_cross_section_continuation_rank,
+                    required=False,
+                ),
+                _threshold_min(
+                    metric='effective_opening_window_return_rank',
+                    value=effective_opening_window_return_rank,
+                    floor=min_cross_section_opening_window_return_rank,
+                    required=False,
+                ),
+                _threshold_min(
+                    metric='effective_positive_session_open_ratio',
+                    value=effective_positive_session_open_ratio,
+                    floor=min_cross_section_positive_session_open_ratio,
+                    required=False,
+                ),
+                _threshold_min(
+                    metric='effective_positive_opening_window_return_ratio',
+                    value=effective_positive_opening_window_return_ratio,
+                    floor=min_cross_section_positive_opening_window_return_ratio,
+                    required=False,
+                ),
+                _threshold_min(
+                    metric='cross_section_above_vwap_w5m_ratio',
+                    value=cross_section_above_vwap_w5m_ratio,
+                    floor=min_cross_section_above_vwap_w5m_ratio,
+                    required=False,
+                ),
+                _threshold_min(
+                    metric='cross_section_continuation_breadth',
+                    value=cross_section_continuation_breadth,
+                    floor=min_cross_section_continuation_breadth,
+                    required=False,
+                ),
+            ),
+        ),
+    )
 
-    if (
-        ema12 > ema26
-        and _decimal_param(params, 'bullish_hist_min', Decimal('0.006')) <= macd_hist <= _decimal_param(params, 'bullish_hist_cap', Decimal('0.05'))
-        and _decimal_param(params, 'min_bull_rsi', Decimal('57')) <= rsi14 <= _decimal_param(params, 'max_bull_rsi', Decimal('72'))
-        and _optional_min_threshold(
-            price_vs_ema12_bps,
-            _decimal_param(params, 'min_price_above_ema12_bps', Decimal('0')),
-        )
-        and _optional_max_threshold(
-            price_vs_ema12_bps,
-            _decimal_param(params, 'max_price_above_ema12_bps', Decimal('14')),
-        )
-        and _optional_min_threshold(price_vs_vwap_w5m_bps, min_price_vs_vwap_w5m_bps)
-        and _optional_max_threshold(price_vs_vwap_w5m_bps, max_price_vs_vwap_w5m_bps)
-        and effective_spread_bps <= spread_cap_bps
-        and imbalance_pressure >= _decimal_param(params, 'min_imbalance_pressure', Decimal('-0.01'))
-        and _optional_min_threshold(effective_price_drive_bps, min_session_open_drive_bps)
-        and _optional_min_threshold(
-            effective_opening_window_return_bps,
-            min_opening_window_return_bps,
-        )
-        and same_day_opening_window_confirmed
-        and (
-            classical_late_day_shape_passes
-            or isolated_late_day_shape_passes
-            or opening_drive_late_day_shape_passes
-        )
-        and _optional_max_threshold(recent_spread_bps_avg, max_recent_spread_bps)
-        and _optional_min_threshold(recent_imbalance_pressure_avg, min_recent_imbalance_pressure)
-        and _optional_max_threshold(
-            recent_quote_invalid_ratio,
-            hard_max_recent_quote_invalid_ratio,
-        )
-        and _quote_stability_passes(
-            recent_quote_invalid_ratio=recent_quote_invalid_ratio,
-            max_recent_quote_invalid_ratio=max_recent_quote_invalid_ratio,
-            recent_quote_jump_bps_max=recent_quote_jump_bps_max,
-            max_recent_quote_jump_bps=max_recent_quote_jump_bps,
-        )
-        and _optional_min_threshold(
-            recent_microprice_bias_bps_avg,
-            min_recent_microprice_bias_bps,
-        )
-        and recent_late_day_reference_hold_passes
-        and late_day_opening_window_close_hold_passes
-        and _optional_min_threshold(
-            recent_above_vwap_w5m_ratio,
-            min_recent_above_vwap_w5m_ratio,
-        )
-        and _optional_min_threshold(
-            effective_continuation_rank,
-            min_cross_section_continuation_rank,
-        )
-        and _optional_min_threshold(
-            effective_opening_window_return_rank,
-            min_cross_section_opening_window_return_rank,
-        )
-        and _optional_min_threshold(
-            effective_positive_session_open_ratio,
-            min_cross_section_positive_session_open_ratio,
-        )
-        and _optional_min_threshold(
-            effective_positive_opening_window_return_ratio,
-            min_cross_section_positive_opening_window_return_ratio,
-        )
-        and _optional_min_threshold(
-            cross_section_above_vwap_w5m_ratio,
-            min_cross_section_above_vwap_w5m_ratio,
-        )
-        and _optional_min_threshold(
-            cross_section_continuation_breadth,
-            min_cross_section_continuation_breadth,
-        )
-        and _vol_within_band(
-            vol_realized_w60s,
-            floor=_optional_decimal_param(params, 'vol_floor', Decimal('0.00005')),
-            ceil=_optional_decimal_param(params, 'vol_ceil', Decimal('0.00035')),
-        )
-    ):
+    if all(gate.passed for gate in buy_gates):
         confidence = Decimal('0.69')
         if price_vs_vwap_w5m_bps is not None and price_vs_vwap_w5m_bps >= Decimal('4'):
             confidence += Decimal('0.03')
@@ -2043,66 +3037,108 @@ def evaluate_late_day_continuation_long(
             and cross_section_continuation_breadth >= Decimal('0.60')
         ):
             confidence += Decimal('0.02')
-        return SleeveSignalEvaluation(
-            action='buy',
-            confidence=min(confidence, Decimal('0.87')),
-            rationale=(
-                'late_day_continuation_long',
-                'trend_up',
-                'session_strength_confirmed',
-                'late_day_strength',
-                'close_auction_setup',
-            ),
-            notional_multiplier=_resolve_entry_notional_multiplier(
-                params=params,
+        return _sleeve_result(
+            strategy_id=strategy_id,
+            strategy_type=strategy_type,
+            symbol=symbol,
+            event_ts=event_ts,
+            timeframe=timeframe,
+            signal=SleeveSignalEvaluation(
+                action='buy',
                 confidence=min(confidence, Decimal('0.87')),
-                rank=effective_continuation_rank,
-                spread_bps=effective_spread_bps,
-                spread_cap_bps=spread_cap_bps,
+                rationale=(
+                    'late_day_continuation_long',
+                    'trend_up',
+                    'session_strength_confirmed',
+                    'late_day_strength',
+                    'close_auction_setup',
+                ),
+                notional_multiplier=_resolve_entry_notional_multiplier(
+                    params=params,
+                    confidence=min(confidence, Decimal('0.87')),
+                    rank=effective_continuation_rank,
+                    spread_bps=effective_spread_bps,
+                    spread_cap_bps=spread_cap_bps,
+                ),
             ),
+            gates=buy_gates,
+            trace_enabled=trace_enabled,
+            context=trace_context,
         )
 
-    if (
-        (
+    exit_reasons: dict[str, bool] = {
+        'below_vwap': (
             price_vs_vwap_w5m_bps is not None
-            and price_vs_vwap_w5m_bps <= _decimal_param(params, 'exit_price_vs_vwap_w5m_bps', Decimal('-10'))
-        )
-        or (
+            and price_vs_vwap_w5m_bps
+            <= _decimal_param(params, 'exit_price_vs_vwap_w5m_bps', Decimal('-10'))
+        ),
+        'range_position_lost': (
             price_position_in_session_range is not None
-            and price_position_in_session_range <= _decimal_param(params, 'exit_session_range_position_min', Decimal('0.58'))
-        )
-        or (
+            and price_position_in_session_range
+            <= _decimal_param(params, 'exit_session_range_position_min', Decimal('0.58'))
+        ),
+        'session_drive_lost': (
             price_vs_session_open_bps is not None
-            and price_vs_session_open_bps <= _decimal_param(params, 'exit_session_open_drive_bps', Decimal('24'))
-        )
-        or (
+            and price_vs_session_open_bps
+            <= _decimal_param(params, 'exit_session_open_drive_bps', Decimal('24'))
+        ),
+        'momentum_rollover': (
             macd_hist <= _decimal_param(params, 'exit_macd_hist_max', Decimal('-0.004'))
             and rsi14 <= _decimal_param(params, 'exit_rsi_max', Decimal('55'))
-        )
-        or (
+        ),
+        'below_opening_range_high': (
             price_vs_opening_range_high_bps is not None
-            and price_vs_opening_range_high_bps <= _decimal_param(params, 'exit_price_below_opening_range_high_bps', Decimal('-16'))
-        )
-        or (
+            and price_vs_opening_range_high_bps
+            <= _decimal_param(params, 'exit_price_below_opening_range_high_bps', Decimal('-16'))
+        ),
+        'imbalance_reversal': (
             recent_imbalance_pressure_avg is not None
-            and recent_imbalance_pressure_avg <= _decimal_param(params, 'exit_recent_imbalance_pressure_max', Decimal('-0.02'))
-        )
-    ):
-        return SleeveSignalEvaluation(
-            action='sell',
-            confidence=Decimal('0.63'),
-            rationale=(
-                'late_day_continuation_exit',
-                'late_day_failure',
+            and recent_imbalance_pressure_avg
+            <= _decimal_param(params, 'exit_recent_imbalance_pressure_max', Decimal('-0.02'))
+        ),
+    }
+    exit_gate = _exit_trigger_gate(reason_flags=exit_reasons)
+    if exit_gate.passed:
+        return _sleeve_result(
+            strategy_id=strategy_id,
+            strategy_type=strategy_type,
+            symbol=symbol,
+            event_ts=event_ts,
+            timeframe=timeframe,
+            signal=SleeveSignalEvaluation(
+                action='sell',
+                confidence=Decimal('0.63'),
+                rationale=(
+                    'late_day_continuation_exit',
+                    'late_day_failure',
+                ),
             ),
+            gates=(exit_gate,),
+            trace_enabled=trace_enabled,
+            context=trace_context,
         )
-    return None
+    return _sleeve_result(
+        strategy_id=strategy_id,
+        strategy_type=strategy_type,
+        symbol=symbol,
+        event_ts=event_ts,
+        timeframe=timeframe,
+        signal=None,
+        gates=buy_gates,
+        trace_enabled=trace_enabled,
+        context=trace_context,
+    )
 
 
 def evaluate_end_of_day_reversal_long(
     *,
     params: Mapping[str, Any],
+    strategy_id: str | None,
+    strategy_type: str | None,
+    symbol: str,
     event_ts: str,
+    timeframe: str | None,
+    trace_enabled: bool,
     price: Decimal | None,
     ema12: Decimal | None,
     ema26: Decimal | None,
@@ -2131,28 +3167,65 @@ def evaluate_end_of_day_reversal_long(
     cross_section_opening_window_return_from_prev_close_rank: Decimal | None,
     cross_section_continuation_rank: Decimal | None,
     cross_section_reversal_rank: Decimal | None,
-) -> SleeveSignalEvaluation | None:
-    if (
-        price is None
-        or ema12 is None
-        or ema26 is None
-        or macd is None
-        or macd_signal is None
-        or rsi14 is None
-    ):
-        return None
+) -> SleeveSignalResult:
+    trace_context = {'family': 'end_of_day_reversal_long'}
+    required_fields = {
+        'price': price is not None,
+        'ema12': ema12 is not None,
+        'ema26': ema26 is not None,
+        'macd': macd is not None,
+        'macd_signal': macd_signal is not None,
+        'rsi14': rsi14 is not None,
+    }
+    if not all(required_fields.values()):
+        return _sleeve_result(
+            strategy_id=strategy_id,
+            strategy_type=strategy_type,
+            symbol=symbol,
+            event_ts=event_ts,
+            timeframe=timeframe,
+            signal=None,
+            gates=(_required_inputs_gate(fields=required_fields),),
+            trace_enabled=trace_enabled,
+            context=trace_context,
+        )
 
     ts = _parse_event_ts(event_ts)
-    if not _within_utc_window(
+    entry_start_minute = _minute_param(params, 'entry_start_minute_utc', 19 * 60 + 20)
+    entry_end_minute = _effective_entry_end_minute(
+        params,
+        default_end_minute=19 * 60 + 48,
+    )
+    within_window = _within_utc_window(
         ts,
-        start_minute=_minute_param(params, 'entry_start_minute_utc', 19 * 60 + 20),
-        end_minute=_effective_entry_end_minute(
-            params,
-            default_end_minute=19 * 60 + 48,
-        ),
-    ):
-        return None
+        start_minute=entry_start_minute,
+        end_minute=entry_end_minute,
+    )
+    if not within_window:
+        return _sleeve_result(
+            strategy_id=strategy_id,
+            strategy_type=strategy_type,
+            symbol=symbol,
+            event_ts=event_ts,
+            timeframe=timeframe,
+            signal=None,
+            gates=(
+                _entry_window_gate(
+                    within_window=within_window,
+                    start_minute=entry_start_minute,
+                    end_minute=entry_end_minute,
+                ),
+            ),
+            trace_enabled=trace_enabled,
+            context=trace_context,
+        )
 
+    assert price is not None
+    assert ema12 is not None
+    assert ema26 is not None
+    assert macd is not None
+    assert macd_signal is not None
+    assert rsi14 is not None
     macd_hist = macd - macd_signal
     price_vs_ema12_bps = _bps_delta(price, ema12)
     price_vs_vwap_bps = _bps_delta(price, vwap_session) if vwap_session is not None else price_vs_ema12_bps
@@ -2206,97 +3279,168 @@ def evaluate_end_of_day_reversal_long(
         'max_cross_section_opening_window_return_rank',
         None,
     )
+    price_below_vwap_bps = -price_vs_vwap_bps if price_vs_vwap_bps is not None else None
+    price_below_ema12_bps = -price_vs_ema12_bps if price_vs_ema12_bps is not None else None
+    buy_gates = (
+        _gate(
+            name='structure',
+            category='structure',
+            thresholds=(
+                _threshold_max(
+                    metric='effective_price_drive_bps',
+                    value=effective_price_drive_bps,
+                    ceil=_optional_decimal_param(params, 'max_price_vs_session_open_bps', Decimal('-45')),
+                    required=False,
+                ),
+                _threshold_max(
+                    metric='effective_opening_window_return_bps',
+                    value=effective_opening_window_return_bps,
+                    ceil=max_opening_window_return_bps,
+                    required=False,
+                ),
+                _threshold_max(
+                    metric='price_position_in_session_range',
+                    value=price_position_in_session_range,
+                    ceil=_optional_decimal_param(params, 'max_session_range_position', Decimal('0.40')),
+                    required=False,
+                ),
+                _threshold_min(
+                    metric='session_range_bps',
+                    value=session_range_bps,
+                    floor=_optional_decimal_param(params, 'min_session_range_bps', Decimal('40')),
+                    required=False,
+                ),
+                _threshold_min(
+                    metric='price_vs_opening_range_low_bps',
+                    value=price_vs_opening_range_low_bps,
+                    floor=_optional_decimal_param(params, 'min_price_vs_opening_range_low_bps', Decimal('-6')),
+                    required=False,
+                ),
+                _threshold_max(
+                    metric='price_vs_opening_range_low_bps',
+                    value=price_vs_opening_range_low_bps,
+                    ceil=_optional_decimal_param(params, 'max_price_vs_opening_range_low_bps', Decimal('16')),
+                    required=False,
+                ),
+                *_threshold_range(
+                    metric='price_below_vwap_bps',
+                    value=price_below_vwap_bps,
+                    floor=_optional_decimal_param(params, 'min_price_below_vwap_bps', Decimal('8')),
+                    ceil=_optional_decimal_param(params, 'max_price_below_vwap_bps', Decimal('40')),
+                    required=False,
+                ),
+                *_threshold_range(
+                    metric='price_below_ema12_bps',
+                    value=price_below_ema12_bps,
+                    floor=_optional_decimal_param(params, 'min_price_below_ema12_bps', Decimal('4')),
+                    ceil=_optional_decimal_param(params, 'max_price_below_ema12_bps', Decimal('28')),
+                    required=False,
+                ),
+                *_threshold_range(
+                    metric='rsi14',
+                    value=rsi14,
+                    floor=_decimal_param(params, 'min_bull_rsi', Decimal('34')),
+                    ceil=_decimal_param(params, 'max_bull_rsi', Decimal('48')),
+                    required=True,
+                ),
+                *_threshold_range(
+                    metric='macd_hist',
+                    value=macd_hist,
+                    floor=_decimal_param(params, 'min_macd_hist', Decimal('-0.010')),
+                    ceil=_decimal_param(params, 'max_macd_hist', Decimal('0.012')),
+                    required=True,
+                ),
+                _threshold_bool(metric='ema12_lte_ema26', passed=ema12 <= ema26, threshold=True),
+                *_threshold_range(
+                    metric='vol_realized_w60s',
+                    value=vol_realized_w60s,
+                    floor=_optional_decimal_param(params, 'vol_floor', Decimal('0.00005')),
+                    ceil=_optional_decimal_param(params, 'vol_ceil', Decimal('0.00050')),
+                    required=False,
+                ),
+            ),
+        ),
+        _gate(
+            name='feed_quality',
+            category='feed_quality',
+            thresholds=(
+                _threshold_max(
+                    metric='spread_bps',
+                    value=effective_spread_bps,
+                    ceil=spread_cap_bps,
+                    required=True,
+                ),
+                _threshold_min(
+                    metric='imbalance_pressure',
+                    value=imbalance_pressure,
+                    floor=_decimal_param(params, 'min_imbalance_pressure', Decimal('0.02')),
+                    required=True,
+                ),
+                _threshold_max(
+                    metric='recent_spread_bps_avg',
+                    value=recent_spread_bps_avg,
+                    ceil=_optional_decimal_param(params, 'max_recent_spread_bps', Decimal('8')),
+                    required=False,
+                ),
+                _threshold_max(
+                    metric='recent_spread_bps_max',
+                    value=recent_spread_bps_max,
+                    ceil=_optional_decimal_param(params, 'max_recent_spread_bps_max', Decimal('16')),
+                    required=False,
+                ),
+                _threshold_min(
+                    metric='recent_imbalance_pressure_avg',
+                    value=recent_imbalance_pressure_avg,
+                    floor=_optional_decimal_param(params, 'min_recent_imbalance_pressure', Decimal('0.03')),
+                    required=False,
+                ),
+                _threshold_max(
+                    metric='recent_quote_invalid_ratio',
+                    value=recent_quote_invalid_ratio,
+                    ceil=max_recent_quote_invalid_ratio,
+                    required=False,
+                ),
+                _threshold_max(
+                    metric='recent_quote_jump_bps_max',
+                    value=recent_quote_jump_bps_max,
+                    ceil=max_recent_quote_jump_bps,
+                    required=False,
+                ),
+                _threshold_min(
+                    metric='recent_microprice_bias_bps_avg',
+                    value=recent_microprice_bias_bps_avg,
+                    floor=min_recent_microprice_bias_bps,
+                    required=False,
+                ),
+            ),
+        ),
+        _gate(
+            name='confirmation',
+            category='confirmation',
+            thresholds=(
+                _threshold_max(
+                    metric='cross_section_continuation_rank',
+                    value=cross_section_continuation_rank,
+                    ceil=max_cross_section_continuation_rank,
+                    required=False,
+                ),
+                _threshold_min(
+                    metric='cross_section_reversal_rank',
+                    value=cross_section_reversal_rank,
+                    floor=min_cross_section_reversal_rank,
+                    required=False,
+                ),
+                _threshold_max(
+                    metric='effective_opening_window_return_rank',
+                    value=effective_opening_window_return_rank,
+                    ceil=max_cross_section_opening_window_return_rank,
+                    required=False,
+                ),
+            ),
+        ),
+    )
 
-    if (
-        _optional_max_threshold(
-            effective_price_drive_bps,
-            _optional_decimal_param(params, 'max_price_vs_session_open_bps', Decimal('-45')),
-        )
-        and _optional_max_threshold(
-            effective_opening_window_return_bps,
-            max_opening_window_return_bps,
-        )
-        and _optional_max_threshold(
-            price_position_in_session_range,
-            _optional_decimal_param(params, 'max_session_range_position', Decimal('0.40')),
-        )
-        and _optional_min_threshold(
-            session_range_bps,
-            _optional_decimal_param(params, 'min_session_range_bps', Decimal('40')),
-        )
-        and _optional_min_threshold(
-            price_vs_opening_range_low_bps,
-            _optional_decimal_param(params, 'min_price_vs_opening_range_low_bps', Decimal('-6')),
-        )
-        and _optional_max_threshold(
-            price_vs_opening_range_low_bps,
-            _optional_decimal_param(params, 'max_price_vs_opening_range_low_bps', Decimal('16')),
-        )
-        and _optional_min_threshold(
-            -price_vs_vwap_bps if price_vs_vwap_bps is not None else None,
-            _optional_decimal_param(params, 'min_price_below_vwap_bps', Decimal('8')),
-        )
-        and _optional_max_threshold(
-            -price_vs_vwap_bps if price_vs_vwap_bps is not None else None,
-            _optional_decimal_param(params, 'max_price_below_vwap_bps', Decimal('40')),
-        )
-        and _optional_min_threshold(
-            -price_vs_ema12_bps if price_vs_ema12_bps is not None else None,
-            _optional_decimal_param(params, 'min_price_below_ema12_bps', Decimal('4')),
-        )
-        and _optional_max_threshold(
-            -price_vs_ema12_bps if price_vs_ema12_bps is not None else None,
-            _optional_decimal_param(params, 'max_price_below_ema12_bps', Decimal('28')),
-        )
-        and _decimal_param(params, 'min_bull_rsi', Decimal('34'))
-        <= rsi14
-        <= _decimal_param(params, 'max_bull_rsi', Decimal('48'))
-        and _decimal_param(params, 'min_macd_hist', Decimal('-0.010'))
-        <= macd_hist
-        <= _decimal_param(params, 'max_macd_hist', Decimal('0.012'))
-        and ema12 <= ema26
-        and effective_spread_bps <= spread_cap_bps
-        and imbalance_pressure >= _decimal_param(params, 'min_imbalance_pressure', Decimal('0.02'))
-        and _optional_max_threshold(
-            recent_spread_bps_avg,
-            _optional_decimal_param(params, 'max_recent_spread_bps', Decimal('8')),
-        )
-        and _optional_max_threshold(
-            recent_spread_bps_max,
-            _optional_decimal_param(params, 'max_recent_spread_bps_max', Decimal('16')),
-        )
-        and _optional_min_threshold(
-            recent_imbalance_pressure_avg,
-            _optional_decimal_param(params, 'min_recent_imbalance_pressure', Decimal('0.03')),
-        )
-        and _quote_stability_passes(
-            recent_quote_invalid_ratio=recent_quote_invalid_ratio,
-            max_recent_quote_invalid_ratio=max_recent_quote_invalid_ratio,
-            recent_quote_jump_bps_max=recent_quote_jump_bps_max,
-            max_recent_quote_jump_bps=max_recent_quote_jump_bps,
-        )
-        and _optional_min_threshold(
-            recent_microprice_bias_bps_avg,
-            min_recent_microprice_bias_bps,
-        )
-        and _optional_max_threshold(
-            cross_section_continuation_rank,
-            max_cross_section_continuation_rank,
-        )
-        and _optional_min_threshold(
-            cross_section_reversal_rank,
-            min_cross_section_reversal_rank,
-        )
-        and _optional_max_threshold(
-            effective_opening_window_return_rank,
-            max_cross_section_opening_window_return_rank,
-        )
-        and _vol_within_band(
-            vol_realized_w60s,
-            floor=_optional_decimal_param(params, 'vol_floor', Decimal('0.00005')),
-            ceil=_optional_decimal_param(params, 'vol_ceil', Decimal('0.00050')),
-        )
-    ):
+    if all(gate.passed for gate in buy_gates):
         confidence = Decimal('0.67')
         if effective_price_drive_bps is not None and effective_price_drive_bps <= Decimal('-70'):
             confidence += Decimal('0.03')
@@ -2314,47 +3458,80 @@ def evaluate_end_of_day_reversal_long(
             and recent_microprice_bias_bps_avg >= Decimal('0.50')
         ):
             confidence += Decimal('0.02')
-        return SleeveSignalEvaluation(
-            action='buy',
-            confidence=min(confidence, Decimal('0.84')),
-            rationale=(
-                'end_of_day_reversal_long',
-                'intraday_loser',
-                'close_reversion_setup',
-                'spread_normalized',
-                'rebid_confirmed',
-            ),
-            notional_multiplier=_resolve_entry_notional_multiplier(
-                params=params,
+        return _sleeve_result(
+            strategy_id=strategy_id,
+            strategy_type=strategy_type,
+            symbol=symbol,
+            event_ts=event_ts,
+            timeframe=timeframe,
+            signal=SleeveSignalEvaluation(
+                action='buy',
                 confidence=min(confidence, Decimal('0.84')),
-                rank=cross_section_reversal_rank,
-                spread_bps=effective_spread_bps,
-                spread_cap_bps=spread_cap_bps,
+                rationale=(
+                    'end_of_day_reversal_long',
+                    'intraday_loser',
+                    'close_reversion_setup',
+                    'spread_normalized',
+                    'rebid_confirmed',
+                ),
+                notional_multiplier=_resolve_entry_notional_multiplier(
+                    params=params,
+                    confidence=min(confidence, Decimal('0.84')),
+                    rank=cross_section_reversal_rank,
+                    spread_bps=effective_spread_bps,
+                    spread_cap_bps=spread_cap_bps,
+                ),
             ),
+            gates=buy_gates,
+            trace_enabled=trace_enabled,
+            context=trace_context,
         )
 
-    if (
-        (vwap_session is not None and price >= vwap_session)
-        or price >= ema12
-        or rsi14 >= _decimal_param(params, 'exit_rsi_min', Decimal('56'))
-        or (
+    exit_reasons: dict[str, bool] = {
+        'vwap_recovered': (vwap_session is not None and price >= vwap_session) or price >= ema12,
+        'rsi_recovered': rsi14 >= _decimal_param(params, 'exit_rsi_min', Decimal('56')),
+        'imbalance_reversal': (
             recent_imbalance_pressure_avg is not None
-            and recent_imbalance_pressure_avg <= _decimal_param(params, 'exit_recent_imbalance_pressure_max', Decimal('-0.02'))
-        )
-        or (
+            and recent_imbalance_pressure_avg
+            <= _decimal_param(params, 'exit_recent_imbalance_pressure_max', Decimal('-0.02'))
+        ),
+        'range_recovery': (
             price_position_in_session_range is not None
-            and price_position_in_session_range >= _decimal_param(params, 'exit_session_range_position_min', Decimal('0.58'))
-        )
-    ):
-        return SleeveSignalEvaluation(
-            action='sell',
-            confidence=Decimal('0.62'),
-            rationale=(
-                'end_of_day_reversal_exit',
-                'reversion_complete',
+            and price_position_in_session_range
+            >= _decimal_param(params, 'exit_session_range_position_min', Decimal('0.58'))
+        ),
+    }
+    exit_gate = _exit_trigger_gate(reason_flags=exit_reasons)
+    if exit_gate.passed:
+        return _sleeve_result(
+            strategy_id=strategy_id,
+            strategy_type=strategy_type,
+            symbol=symbol,
+            event_ts=event_ts,
+            timeframe=timeframe,
+            signal=SleeveSignalEvaluation(
+                action='sell',
+                confidence=Decimal('0.62'),
+                rationale=(
+                    'end_of_day_reversal_exit',
+                    'reversion_complete',
+                ),
             ),
+            gates=(exit_gate,),
+            trace_enabled=trace_enabled,
+            context=trace_context,
         )
-    return None
+    return _sleeve_result(
+        strategy_id=strategy_id,
+        strategy_type=strategy_type,
+        symbol=symbol,
+        event_ts=event_ts,
+        timeframe=timeframe,
+        signal=None,
+        gates=buy_gates,
+        trace_enabled=trace_enabled,
+        context=trace_context,
+    )
 
 
 def _parse_event_ts(raw: str) -> datetime:
@@ -2878,21 +4055,6 @@ def _imbalance_pressure(bid_sz: Decimal | None, ask_sz: Decimal | None) -> Decim
     return (bid_sz - ask_sz) / total
 
 
-def _vol_within_band(
-    value: Decimal | None,
-    *,
-    floor: Decimal | None,
-    ceil: Decimal | None,
-) -> bool:
-    if value is None:
-        return True
-    if floor is not None and value < floor:
-        return False
-    if ceil is not None and value > ceil:
-        return False
-    return True
-
-
 def _optional_min_threshold(value: Decimal | None, floor: Decimal | None) -> bool:
     if floor is None or value is None:
         return True
@@ -2938,22 +4100,6 @@ def _optional_max_threshold(value: Decimal | None, ceil: Decimal | None) -> bool
     if ceil is None or value is None:
         return True
     return value <= ceil
-
-
-def _quote_stability_passes(
-    *,
-    recent_quote_invalid_ratio: Decimal | None,
-    max_recent_quote_invalid_ratio: Decimal | None,
-    recent_quote_jump_bps_max: Decimal | None,
-    max_recent_quote_jump_bps: Decimal | None,
-) -> bool:
-    return _optional_max_threshold(
-        recent_quote_invalid_ratio,
-        max_recent_quote_invalid_ratio,
-    ) and _optional_max_threshold(
-        recent_quote_jump_bps_max,
-        max_recent_quote_jump_bps,
-    )
 
 
 def _resolve_entry_notional_multiplier(

--- a/services/torghut/app/trading/strategy_runtime.py
+++ b/services/torghut/app/trading/strategy_runtime.py
@@ -13,9 +13,12 @@ from typing import Any, Literal, Protocol, cast
 
 from ..models import Strategy
 from ..strategies.catalog import extract_catalog_metadata
+from .evaluation_trace import GateTrace, StrategyTrace, ThresholdTrace
 from .features import FeatureVectorV3, validate_declared_features
 from .intraday_tsmom_contract import evaluate_intraday_tsmom_signal
 from .research_sleeves import (
+    SleeveSignalEvaluation,
+    SleeveSignalResult,
     evaluate_breakout_continuation_long,
     evaluate_end_of_day_reversal_long,
     evaluate_late_day_continuation_long,
@@ -27,6 +30,72 @@ from .strategy_specs import build_compiled_strategy_artifacts, strategy_type_sup
 
 def _empty_meta() -> dict[str, Any]:
     return {}
+
+
+def _generic_plugin_trace(
+    *,
+    context: "StrategyContext",
+    gate: str,
+    passed: bool,
+    action: Literal["buy", "sell"] | None = None,
+    rationale: tuple[str, ...] = (),
+    thresholds: tuple[ThresholdTrace, ...] = (),
+    gate_context: dict[str, Any] | None = None,
+) -> StrategyTrace | None:
+    if not context.trace_enabled:
+        return None
+    return StrategyTrace(
+        strategy_id=context.strategy_id,
+        strategy_type=context.strategy_type,
+        symbol=context.symbol,
+        event_ts=context.event_ts,
+        timeframe=context.timeframe,
+        passed=passed,
+        action=action,
+        rationale=rationale,
+        gates=(
+            GateTrace(
+                gate=gate,
+                category='structure',
+                passed=passed,
+                thresholds=thresholds,
+                context=gate_context or {},
+            ),
+        ),
+        first_failed_gate=None if passed else gate,
+    )
+
+
+def _plugin_result_from_sleeve_result(
+    *,
+    context: "StrategyContext",
+    features: FeatureVectorV3,
+    required_features: tuple[str, ...],
+    evaluation: SleeveSignalResult | SleeveSignalEvaluation | None,
+) -> PluginEvaluationResult:
+    if evaluation is None:
+        return PluginEvaluationResult(intent=None, trace=None)
+    if isinstance(evaluation, SleeveSignalEvaluation):
+        evaluation = SleeveSignalResult(signal=evaluation, trace=None)
+    if evaluation.signal is None:
+        return PluginEvaluationResult(intent=None, trace=evaluation.trace)
+    return PluginEvaluationResult(
+        intent=StrategyIntent(
+            strategy_id=context.strategy_id,
+            symbol=context.symbol,
+            direction=evaluation.signal.action,
+            confidence=evaluation.signal.confidence,
+            target_notional=_resolved_target_notional(
+                context.params,
+                multiplier=evaluation.signal.notional_multiplier,
+            ),
+            horizon=context.timeframe,
+            explain=evaluation.signal.rationale,
+            feature_snapshot_hash=features.normalization_hash,
+            required_features=required_features,
+        ),
+        trace=evaluation.trace,
+    )
 
 
 @dataclass(frozen=True)
@@ -59,6 +128,7 @@ class StrategyContext:
     symbol: str
     timeframe: str
     params: dict[str, Any]
+    trace_enabled: bool = False
     strategy_spec: dict[str, Any] = field(default_factory=_empty_meta)
 
 
@@ -98,6 +168,7 @@ class AggregatedIntent:
 @dataclass(frozen=True)
 class RuntimeDecision:
     intent: StrategyIntent
+    trace: StrategyTrace | None
     strategy_row_id: str
     declared_strategy_id: str
     strategy_name: str
@@ -112,7 +183,7 @@ class RuntimeDecision:
     compiled_targets: dict[str, Any] = field(default_factory=_empty_meta)
 
     def metadata(self) -> dict[str, Any]:
-        return {
+        payload = {
             "strategy_row_id": self.strategy_row_id,
             "declared_strategy_id": self.declared_strategy_id,
             "strategy_name": self.strategy_name,
@@ -131,6 +202,9 @@ class RuntimeDecision:
             "strategy_spec_v2": dict(self.strategy_spec),
             "compiled_targets": dict(self.compiled_targets),
         }
+        if self.trace is not None:
+            payload["strategy_trace"] = self.trace.to_payload()
+        return payload
 
 
 @dataclass(frozen=True)
@@ -172,6 +246,7 @@ class RuntimeObservation:
 class RuntimeEvaluation:
     intents: list[AggregatedIntent]
     raw_intents: list[RuntimeDecision]
+    traces: list[StrategyTrace]
     errors: list[RuntimeErrorRecord]
     observation: RuntimeObservation
 
@@ -183,7 +258,21 @@ class StrategyPlugin(Protocol):
 
     def evaluate(
         self, context: StrategyContext, features: FeatureVectorV3
-    ) -> StrategyIntent | None: ...
+    ) -> "PluginEvaluationResult": ...
+
+
+@dataclass(frozen=True)
+class PluginEvaluationResult:
+    intent: StrategyIntent | None
+    trace: StrategyTrace | None = None
+
+
+def _coerce_plugin_result(result: PluginEvaluationResult | StrategyIntent | None) -> PluginEvaluationResult:
+    if isinstance(result, PluginEvaluationResult):
+        return result
+    if result is None:
+        return PluginEvaluationResult(intent=None, trace=None)
+    return PluginEvaluationResult(intent=result, trace=None)
 
 
 @dataclass
@@ -346,38 +435,98 @@ class LegacyMacdRsiPlugin:
 
     def evaluate(
         self, context: StrategyContext, features: FeatureVectorV3
-    ) -> StrategyIntent | None:
+    ) -> PluginEvaluationResult:
         macd = _decimal(features.values.get("macd"))
         macd_signal = _decimal(features.values.get("macd_signal"))
         rsi14 = _decimal(features.values.get("rsi14"))
         target_notional = _target_notional(context.params)
         if macd is None or macd_signal is None or rsi14 is None:
-            return None
+            return PluginEvaluationResult(
+                intent=None,
+                trace=_generic_plugin_trace(
+                    context=context,
+                    gate='legacy_required_inputs',
+                    passed=False,
+                    thresholds=(
+                        ThresholdTrace(
+                            metric='required_inputs_present',
+                            comparator='all_present',
+                            value={
+                                'macd': macd is not None,
+                                'macd_signal': macd_signal is not None,
+                                'rsi14': rsi14 is not None,
+                            },
+                            threshold=True,
+                            passed=False,
+                            missing_policy='fail_closed',
+                        ),
+                    ),
+                ),
+            )
         if macd > macd_signal and rsi14 < Decimal("35"):
-            return StrategyIntent(
-                strategy_id=context.strategy_id,
-                symbol=context.symbol,
-                direction="buy",
-                confidence=Decimal("0.65"),
-                target_notional=target_notional,
-                horizon=context.timeframe,
-                explain=("macd_cross_up", "rsi_oversold"),
-                feature_snapshot_hash=features.normalization_hash,
-                required_features=self.required_features,
+            return PluginEvaluationResult(
+                intent=StrategyIntent(
+                    strategy_id=context.strategy_id,
+                    symbol=context.symbol,
+                    direction="buy",
+                    confidence=Decimal("0.65"),
+                    target_notional=target_notional,
+                    horizon=context.timeframe,
+                    explain=("macd_cross_up", "rsi_oversold"),
+                    feature_snapshot_hash=features.normalization_hash,
+                    required_features=self.required_features,
+                ),
+                trace=_generic_plugin_trace(
+                    context=context,
+                    gate='legacy_macd_rsi_signal',
+                    passed=True,
+                    action='buy',
+                    rationale=('macd_cross_up', 'rsi_oversold'),
+                ),
             )
         if macd < macd_signal and rsi14 > Decimal("65"):
-            return StrategyIntent(
-                strategy_id=context.strategy_id,
-                symbol=context.symbol,
-                direction="sell",
-                confidence=Decimal("0.65"),
-                target_notional=target_notional,
-                horizon=context.timeframe,
-                explain=("macd_cross_down", "rsi_overbought"),
-                feature_snapshot_hash=features.normalization_hash,
-                required_features=self.required_features,
+            return PluginEvaluationResult(
+                intent=StrategyIntent(
+                    strategy_id=context.strategy_id,
+                    symbol=context.symbol,
+                    direction="sell",
+                    confidence=Decimal("0.65"),
+                    target_notional=target_notional,
+                    horizon=context.timeframe,
+                    explain=("macd_cross_down", "rsi_overbought"),
+                    feature_snapshot_hash=features.normalization_hash,
+                    required_features=self.required_features,
+                ),
+                trace=_generic_plugin_trace(
+                    context=context,
+                    gate='legacy_macd_rsi_signal',
+                    passed=True,
+                    action='sell',
+                    rationale=('macd_cross_down', 'rsi_overbought'),
+                ),
             )
-        return None
+        return PluginEvaluationResult(
+            intent=None,
+            trace=_generic_plugin_trace(
+                context=context,
+                gate='legacy_macd_rsi_signal',
+                passed=False,
+                thresholds=(
+                    ThresholdTrace(
+                        metric='signal_condition',
+                        comparator='legacy_macd_rsi',
+                        value={
+                            'macd': macd,
+                            'macd_signal': macd_signal,
+                            'rsi14': rsi14,
+                        },
+                        threshold='cross_and_rsi',
+                        passed=False,
+                        missing_policy='fail_open',
+                    ),
+                ),
+            ),
+        )
 
 
 class IntradayTsmomPlugin:
@@ -418,7 +567,7 @@ class IntradayTsmomPlugin:
 
     def evaluate(
         self, context: StrategyContext, features: FeatureVectorV3
-    ) -> StrategyIntent | None:
+    ) -> PluginEvaluationResult:
         ema12 = _decimal(features.values.get("ema12"))
         ema26 = _decimal(features.values.get("ema26"))
         price = _decimal(features.values.get("price"))
@@ -493,12 +642,19 @@ class IntradayTsmomPlugin:
             ),
         )
         if evaluation is None:
-            return None
+            return PluginEvaluationResult(
+                intent=None,
+                trace=_generic_plugin_trace(
+                    context=context,
+                    gate='intraday_tsmom_contract',
+                    passed=False,
+                ),
+            )
 
         target_notional = _target_notional(context.params)
         direction = "buy" if evaluation.direction == "long" else "sell"
         confidence_cap = Decimal("0.84") if evaluation.direction == "long" else Decimal("0.80")
-        return StrategyIntent(
+        intent = StrategyIntent(
             strategy_id=context.strategy_id,
             symbol=context.symbol,
             direction=direction,
@@ -508,6 +664,16 @@ class IntradayTsmomPlugin:
             explain=evaluation.rationale,
             feature_snapshot_hash=features.normalization_hash,
             required_features=self.required_features,
+        )
+        return PluginEvaluationResult(
+            intent=intent,
+            trace=_generic_plugin_trace(
+                context=context,
+                gate='intraday_tsmom_contract',
+                passed=True,
+                action=intent.direction,
+                rationale=intent.explain,
+            ),
         )
 
 
@@ -534,10 +700,15 @@ class MomentumPullbackLongPlugin:
 
     def evaluate(
         self, context: StrategyContext, features: FeatureVectorV3
-    ) -> StrategyIntent | None:
+    ) -> PluginEvaluationResult:
         evaluation = evaluate_momentum_pullback_long(
             params=context.params,
+            strategy_id=context.strategy_id,
+            strategy_type=context.strategy_type,
+            symbol=context.symbol,
             event_ts=context.event_ts,
+            timeframe=context.timeframe,
+            trace_enabled=context.trace_enabled,
             price=_decimal(features.values.get("price")),
             ema12=_decimal(features.values.get("ema12")),
             ema26=_decimal(features.values.get("ema26")),
@@ -560,21 +731,11 @@ class MomentumPullbackLongPlugin:
                 features.values.get("cross_section_continuation_rank")
             ),
         )
-        if evaluation is None:
-            return None
-        return StrategyIntent(
-            strategy_id=context.strategy_id,
-            symbol=context.symbol,
-            direction=evaluation.action,
-            confidence=evaluation.confidence,
-            target_notional=_resolved_target_notional(
-                context.params,
-                multiplier=evaluation.notional_multiplier,
-            ),
-            horizon=context.timeframe,
-            explain=evaluation.rationale,
-            feature_snapshot_hash=features.normalization_hash,
+        return _plugin_result_from_sleeve_result(
+            context=context,
+            features=features,
             required_features=self.required_features,
+            evaluation=evaluation,
         )
 
 
@@ -627,10 +788,15 @@ class BreakoutContinuationLongPlugin:
 
     def evaluate(
         self, context: StrategyContext, features: FeatureVectorV3
-    ) -> StrategyIntent | None:
+    ) -> PluginEvaluationResult:
         evaluation = evaluate_breakout_continuation_long(
             params=context.params,
+            strategy_id=context.strategy_id,
+            strategy_type=context.strategy_type,
+            symbol=context.symbol,
             event_ts=context.event_ts,
+            timeframe=context.timeframe,
+            trace_enabled=context.trace_enabled,
             price=_decimal(features.values.get("price")),
             ema12=_decimal(features.values.get("ema12")),
             ema26=_decimal(features.values.get("ema26")),
@@ -719,21 +885,11 @@ class BreakoutContinuationLongPlugin:
                 features.values.get("cross_section_continuation_rank")
             ),
         )
-        if evaluation is None:
-            return None
-        return StrategyIntent(
-            strategy_id=context.strategy_id,
-            symbol=context.symbol,
-            direction=evaluation.action,
-            confidence=evaluation.confidence,
-            target_notional=_resolved_target_notional(
-                context.params,
-                multiplier=evaluation.notional_multiplier,
-            ),
-            horizon=context.timeframe,
-            explain=evaluation.rationale,
-            feature_snapshot_hash=features.normalization_hash,
+        return _plugin_result_from_sleeve_result(
+            context=context,
+            features=features,
             required_features=self.required_features,
+            evaluation=evaluation,
         )
 
 
@@ -772,10 +928,15 @@ class MeanReversionReboundLongPlugin:
 
     def evaluate(
         self, context: StrategyContext, features: FeatureVectorV3
-    ) -> StrategyIntent | None:
+    ) -> PluginEvaluationResult:
         evaluation = evaluate_mean_reversion_rebound_long(
             params=context.params,
+            strategy_id=context.strategy_id,
+            strategy_type=context.strategy_type,
+            symbol=context.symbol,
             event_ts=context.event_ts,
+            timeframe=context.timeframe,
+            trace_enabled=context.trace_enabled,
             price=_decimal(features.values.get("price")),
             ema12=_decimal(features.values.get("ema12")),
             macd=_decimal(features.values.get("macd")),
@@ -818,21 +979,11 @@ class MeanReversionReboundLongPlugin:
                 features.values.get("cross_section_reversal_rank")
             ),
         )
-        if evaluation is None:
-            return None
-        return StrategyIntent(
-            strategy_id=context.strategy_id,
-            symbol=context.symbol,
-            direction=evaluation.action,
-            confidence=evaluation.confidence,
-            target_notional=_resolved_target_notional(
-                context.params,
-                multiplier=evaluation.notional_multiplier,
-            ),
-            horizon=context.timeframe,
-            explain=evaluation.rationale,
-            feature_snapshot_hash=features.normalization_hash,
+        return _plugin_result_from_sleeve_result(
+            context=context,
+            features=features,
             required_features=self.required_features,
+            evaluation=evaluation,
         )
 
 
@@ -885,10 +1036,15 @@ class LateDayContinuationLongPlugin:
 
     def evaluate(
         self, context: StrategyContext, features: FeatureVectorV3
-    ) -> StrategyIntent | None:
+    ) -> PluginEvaluationResult:
         evaluation = evaluate_late_day_continuation_long(
             params=context.params,
+            strategy_id=context.strategy_id,
+            strategy_type=context.strategy_type,
+            symbol=context.symbol,
             event_ts=context.event_ts,
+            timeframe=context.timeframe,
+            trace_enabled=context.trace_enabled,
             price=_decimal(features.values.get("price")),
             ema12=_decimal(features.values.get("ema12")),
             ema26=_decimal(features.values.get("ema26")),
@@ -975,21 +1131,11 @@ class LateDayContinuationLongPlugin:
                 features.values.get("cross_section_continuation_rank")
             ),
         )
-        if evaluation is None:
-            return None
-        return StrategyIntent(
-            strategy_id=context.strategy_id,
-            symbol=context.symbol,
-            direction=evaluation.action,
-            confidence=evaluation.confidence,
-            target_notional=_resolved_target_notional(
-                context.params,
-                multiplier=evaluation.notional_multiplier,
-            ),
-            horizon=context.timeframe,
-            explain=evaluation.rationale,
-            feature_snapshot_hash=features.normalization_hash,
+        return _plugin_result_from_sleeve_result(
+            context=context,
+            features=features,
             required_features=self.required_features,
+            evaluation=evaluation,
         )
 
 
@@ -1029,10 +1175,15 @@ class EndOfDayReversalLongPlugin:
 
     def evaluate(
         self, context: StrategyContext, features: FeatureVectorV3
-    ) -> StrategyIntent | None:
+    ) -> PluginEvaluationResult:
         evaluation = evaluate_end_of_day_reversal_long(
             params=context.params,
+            strategy_id=context.strategy_id,
+            strategy_type=context.strategy_type,
+            symbol=context.symbol,
             event_ts=context.event_ts,
+            timeframe=context.timeframe,
+            trace_enabled=context.trace_enabled,
             price=_decimal(features.values.get("price")),
             ema12=_decimal(features.values.get("ema12")),
             ema26=_decimal(features.values.get("ema26")),
@@ -1076,21 +1227,11 @@ class EndOfDayReversalLongPlugin:
                 features.values.get("cross_section_reversal_rank")
             ),
         )
-        if evaluation is None:
-            return None
-        return StrategyIntent(
-            strategy_id=context.strategy_id,
-            symbol=context.symbol,
-            direction=evaluation.action,
-            confidence=evaluation.confidence,
-            target_notional=_resolved_target_notional(
-                context.params,
-                multiplier=evaluation.notional_multiplier,
-            ),
-            horizon=context.timeframe,
-            explain=evaluation.rationale,
-            feature_snapshot_hash=features.normalization_hash,
+        return _plugin_result_from_sleeve_result(
+            context=context,
+            features=features,
             required_features=self.required_features,
+            evaluation=evaluation,
         )
 
 
@@ -1102,9 +1243,11 @@ class StrategyRuntime:
         *,
         registry: StrategyRegistry | None = None,
         aggregator: IntentAggregator | None = None,
+        trace_enabled: bool = False,
     ) -> None:
         self.registry = registry or StrategyRegistry()
         self.aggregator = aggregator or IntentAggregator()
+        self.trace_enabled = trace_enabled
 
     def evaluate(
         self, strategy: Strategy, features: FeatureVectorV3, *, timeframe: str
@@ -1128,13 +1271,15 @@ class StrategyRuntime:
             symbol=features.symbol,
             timeframe=timeframe,
             params=definition.params,
+            trace_enabled=self.trace_enabled,
             strategy_spec=dict(definition.strategy_spec),
         )
-        intent = plugin.evaluate(context, features)
-        if intent is None:
+        plugin_result = _coerce_plugin_result(plugin.evaluate(context, features))
+        if plugin_result.intent is None:
             return None
         return RuntimeDecision(
-            intent=intent,
+            intent=plugin_result.intent,
+            trace=plugin_result.trace,
             strategy_row_id=definition.strategy_id,
             declared_strategy_id=definition.declared_strategy_id,
             strategy_name=definition.strategy_name,
@@ -1153,6 +1298,7 @@ class StrategyRuntime:
         self, strategies: list[Strategy], features: FeatureVectorV3, *, timeframe: str
     ) -> RuntimeEvaluation:
         raw_intents: list[RuntimeDecision] = []
+        traces: list[StrategyTrace] = []
         errors: list[RuntimeErrorRecord] = []
         observation = RuntimeObservation()
         all_intents: list[StrategyIntent] = []
@@ -1208,18 +1354,22 @@ class StrategyRuntime:
                 symbol=features.symbol,
                 timeframe=timeframe,
                 params=definition.params,
+                trace_enabled=self.trace_enabled,
                 strategy_spec=dict(definition.strategy_spec),
             )
 
             try:
-                intent = plugin.evaluate(context, features)
+                plugin_result = _coerce_plugin_result(plugin.evaluate(context, features))
                 latency_ms = int((time.perf_counter() - start) * 1000)
                 observation.record_event(definition.strategy_id, latency_ms)
                 self.registry.record_success(definition.strategy_id)
-                if intent is None:
+                if plugin_result.trace is not None:
+                    traces.append(plugin_result.trace)
+                if plugin_result.intent is None:
                     continue
                 decision = RuntimeDecision(
-                    intent=intent,
+                    intent=plugin_result.intent,
+                    trace=plugin_result.trace,
                     strategy_row_id=definition.strategy_id,
                     declared_strategy_id=definition.declared_strategy_id,
                     strategy_name=definition.strategy_name,
@@ -1234,7 +1384,7 @@ class StrategyRuntime:
                     compiled_targets=dict(definition.compiled_targets),
                 )
                 raw_intents.append(decision)
-                all_intents.append(intent)
+                all_intents.append(plugin_result.intent)
                 observation.record_intent(definition.strategy_id)
             except Exception as exc:
                 latency_ms = int((time.perf_counter() - start) * 1000)
@@ -1257,6 +1407,7 @@ class StrategyRuntime:
         return RuntimeEvaluation(
             intents=aggregated_intents,
             raw_intents=raw_intents,
+            traces=traces,
             errors=errors,
             observation=observation,
         )

--- a/services/torghut/config/trading/profitability-frontier-breakout.yaml
+++ b/services/torghut/config/trading/profitability-frontier-breakout.yaml
@@ -1,0 +1,28 @@
+schema_version: torghut.replay-frontier-sweep.v1
+family: breakout_continuation
+strategy_name: breakout-continuation-long-v1
+disable_other_strategies: true
+constraints:
+  holdout_target_net_per_day: '250'
+  min_active_holdout_days: 3
+  max_worst_holdout_day_loss: '150'
+  min_profit_factor: '1.5'
+  require_training_decisions: true
+  require_holdout_decisions: true
+parameters:
+  min_cross_section_continuation_rank:
+    - '0.45'
+    - '0.55'
+    - '0.65'
+  min_cross_section_continuation_breadth:
+    - '0.20'
+    - '0.30'
+    - '0.40'
+  min_recent_above_opening_window_close_ratio:
+    - '0.55'
+    - '0.65'
+    - '0.75'
+  min_recent_microprice_bias_bps:
+    - '0.05'
+    - '0.20'
+    - '0.35'

--- a/services/torghut/scripts/local_intraday_tsmom_replay.py
+++ b/services/torghut/scripts/local_intraday_tsmom_replay.py
@@ -27,6 +27,13 @@ from app.strategies.catalog import StrategyCatalogConfig, _compose_strategy_desc
 from app.config import settings
 from app.trading.costs import CostModelInputs, OrderIntent, TransactionCostModel
 from app.trading.decisions import DecisionEngine
+from app.trading.evaluation_trace import (
+    NearMissRecord,
+    ReplayFunnelBucket,
+    ReplayFunnelReport,
+    ReplayTraceRecord,
+    StrategyTrace,
+)
 from app.trading.execution_policy import _near_touch_limit_price
 from app.trading.models import SignalEnvelope, StrategyDecision
 from app.trading.portfolio import allocator_from_settings, sizer_from_settings
@@ -165,6 +172,21 @@ def _parse_args() -> argparse.Namespace:
         '--log-level',
         default=os.environ.get('TORGHUT_REPLAY_LOG_LEVEL', 'INFO'),
         help='Python logging level for replay progress logs.',
+    )
+    parser.add_argument(
+        '--trace-output',
+        type=Path,
+        help='Optional path to write replay trace JSONL.',
+    )
+    parser.add_argument(
+        '--funnel-output',
+        type=Path,
+        help='Optional path to write replay funnel JSON.',
+    )
+    parser.add_argument(
+        '--near-misses-output',
+        type=Path,
+        help='Optional path to write replay near-miss JSON.',
     )
     parser.add_argument('--no-flatten-eod', action='store_true')
     parser.add_argument('--json', action='store_true')
@@ -698,6 +720,75 @@ def _init_day_stats() -> dict[str, Any]:
     }
 
 
+def _init_funnel_stats() -> dict[str, Any]:
+    return {
+        'retained_rows': 0,
+        'runtime_evaluable_rows': 0,
+        'quote_valid_rows': 0,
+        'strategy_evaluations': 0,
+        'gate_pass_counts': defaultdict(int),
+        'decision_count': 0,
+        'filled_count': 0,
+        'closed_trade_count': 0,
+        'gross_pnl': Decimal('0'),
+        'net_pnl': Decimal('0'),
+        'cost_total': Decimal('0'),
+    }
+
+
+def _record_trace_for_funnel(
+    stats: dict[str, Any],
+    trace: StrategyTrace,
+) -> None:
+    stats['strategy_evaluations'] += 1
+    for gate in trace.gates:
+        if not gate.passed:
+            break
+        gate_key = f'{trace.strategy_type}:{gate.gate}'
+        stats['gate_pass_counts'][gate_key] += 1
+
+
+def _build_near_miss(trace: StrategyTrace, *, trading_day: str) -> NearMissRecord | None:
+    if trace.passed or trace.first_failed_gate is None:
+        return None
+    failed_gate = trace.failed_gate()
+    if failed_gate is None:
+        return None
+    failing_thresholds = failed_gate.failing_thresholds()
+    if not failing_thresholds:
+        return None
+    return NearMissRecord(
+        trading_day=trading_day,
+        symbol=trace.symbol,
+        strategy_id=trace.strategy_id,
+        strategy_type=trace.strategy_type,
+        event_ts=trace.event_ts,
+        action=trace.action,
+        first_failed_gate=trace.first_failed_gate,
+        distance_score=trace.distance_score(),
+        thresholds=failing_thresholds,
+    )
+
+
+def _insert_near_miss(
+    near_misses: dict[str, list[NearMissRecord]],
+    record: NearMissRecord,
+    *,
+    limit: int = 20,
+) -> None:
+    bucket = near_misses.setdefault(record.trading_day, [])
+    bucket.append(record)
+    bucket.sort(
+        key=lambda item: (
+            item.distance_score,
+            item.event_ts,
+            item.strategy_id,
+            item.symbol,
+        )
+    )
+    del bucket[limit:]
+
+
 def _decimal_text(value: Decimal) -> str:
     return format(value, 'f')
 
@@ -974,6 +1065,7 @@ def _apply_filled_decision(
     created_at: datetime,
     positions: dict[tuple[str, str], PositionState],
     day_bucket: dict[str, Any],
+    symbol_bucket: dict[str, Any] | None = None,
     cost_model: TransactionCostModel,
     cash: Decimal,
     all_closed_trades: list[ClosedTrade],
@@ -984,6 +1076,9 @@ def _apply_filled_decision(
         fill_cost = _estimate_trade_cost(model=cost_model, decision=decision, signal=signal)
         day_bucket['cost_total'] += fill_cost
         day_bucket['filled_count'] += 1
+        if symbol_bucket is not None:
+            symbol_bucket['cost_total'] += fill_cost
+            symbol_bucket['filled_count'] += 1
         cash -= (fill_price * decision.qty) + fill_cost
         existing = positions.get(position_key)
         if existing is None:
@@ -1018,6 +1113,9 @@ def _apply_filled_decision(
     fill_cost = _estimate_trade_cost(model=cost_model, decision=decision, signal=signal)
     day_bucket['cost_total'] += fill_cost
     day_bucket['filled_count'] += 1
+    if symbol_bucket is not None:
+        symbol_bucket['cost_total'] += fill_cost
+        symbol_bucket['filled_count'] += 1
     sell_qty = min(decision.qty, existing.qty)
     cash += (fill_price * sell_qty) - fill_cost
     entry_cost_allocated = existing.entry_cost_total * (sell_qty / existing.qty)
@@ -1037,6 +1135,10 @@ def _apply_filled_decision(
         positions[position_key] = remaining
     day_bucket['gross_pnl'] += trade.gross_pnl
     day_bucket['net_pnl'] += trade.net_pnl
+    if symbol_bucket is not None:
+        symbol_bucket['gross_pnl'] += trade.gross_pnl
+        symbol_bucket['net_pnl'] += trade.net_pnl
+        symbol_bucket['closed_trade_count'] += 1
     if trade.net_pnl > 0:
         day_bucket['wins'] += 1
     elif trade.net_pnl < 0:
@@ -1050,7 +1152,7 @@ def _apply_filled_decision(
 def run_replay(config: ReplayConfig) -> dict[str, Any]:
     strategies = _load_strategies(config.strategy_configmap_path)
     strategies_by_id = {str(strategy.id): strategy for strategy in strategies}
-    engine = DecisionEngine(price_fetcher=None)
+    engine = DecisionEngine(price_fetcher=None, runtime_trace_enabled=True)
     quote_quality = SignalQuoteQualityTracker(
         policy=QuoteQualityPolicy(
             max_executable_spread_bps=config.max_executable_spread_bps,
@@ -1065,6 +1167,9 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
     last_signals: dict[str, SignalEnvelope] = {}
     cash = config.start_equity
     day_stats: dict[str, dict[str, Any]] = {}
+    funnel_stats: dict[tuple[str, str], dict[str, Any]] = {}
+    trace_records: list[ReplayTraceRecord] = []
+    near_misses: dict[str, list[NearMissRecord]] = {}
     all_closed_trades: list[ClosedTrade] = []
     current_day: date | None = None
     signals_seen = 0
@@ -1085,6 +1190,9 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
     def _active_day_stats(target_day: date) -> dict[str, Any]:
         return day_stats.setdefault(target_day.isoformat(), _init_day_stats())
 
+    def _active_symbol_funnel(target_day: date, symbol: str) -> dict[str, Any]:
+        return funnel_stats.setdefault((target_day.isoformat(), symbol), _init_funnel_stats())
+
     with (
         patch.object(settings, 'trading_strategy_runtime_mode', 'scheduler_v3'),
         patch.object(settings, 'trading_strategy_scheduler_enabled', True),
@@ -1102,6 +1210,7 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
                     _flatten_positions(
                         day=current_day,
                         stats=_active_day_stats(current_day),
+                        funnel_stats=funnel_stats,
                         positions=positions,
                         last_signals=last_signals,
                         last_prices=last_prices,
@@ -1129,6 +1238,8 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
 
             signals_seen += 1
             day_bucket = _active_day_stats(signal_day)
+            symbol_bucket = _active_symbol_funnel(signal_day, signal.symbol)
+            symbol_bucket['retained_rows'] += 1
             quote_status = quote_quality.assess(signal)
             if not quote_status.valid:
                 engine.observe_signal(signal)
@@ -1144,6 +1255,7 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
                 continue
 
             price = _extract_price(signal)
+            symbol_bucket['quote_valid_rows'] += 1
             last_prices[signal.symbol] = price
             last_signals[signal.symbol] = signal
 
@@ -1169,6 +1281,7 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
                     created_at=pending.created_at,
                     positions=positions,
                     day_bucket=day_bucket,
+                    symbol_bucket=symbol_bucket,
                     cost_model=cost_model,
                     cash=cash,
                     all_closed_trades=all_closed_trades,
@@ -1186,6 +1299,13 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
                 equity=equity,
                 positions=live_positions,
             )
+            telemetry = engine.consume_runtime_telemetry()
+            symbol_bucket['runtime_evaluable_rows'] += 1
+            for trace in telemetry.traces:
+                _record_trace_for_funnel(symbol_bucket, trace)
+                near_miss = _build_near_miss(trace, trading_day=signal_day.isoformat())
+                if near_miss is not None:
+                    _insert_near_miss(near_misses, near_miss)
             regime_label = _signal_regime_label(signal)
             allocator = allocator_from_settings(equity)
             account = {'equity': str(equity)}
@@ -1212,9 +1332,20 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
                     continue
                 executable_decisions.append(sizing_result.decision)
 
+            emitted_strategy_ids = {decision.strategy_id for decision in executable_decisions}
+            fill_status_by_strategy_id: dict[str, str] = {}
+            block_reason_by_strategy_id: dict[str, str] = {}
+            for trace in telemetry.traces:
+                if trace.passed and trace.strategy_id not in emitted_strategy_ids:
+                    block_reason_by_strategy_id[trace.strategy_id] = 'post_runtime_filter_rejected'
+                elif not trace.passed and trace.first_failed_gate is not None:
+                    block_reason_by_strategy_id[trace.strategy_id] = trace.first_failed_gate
+
             for decision in executable_decisions:
                 decision = _apply_order_preferences(decision, signal)
                 _record_decision(day_bucket, decision)
+                decision_symbol_bucket = _active_symbol_funnel(signal_day, decision.symbol)
+                decision_symbol_bucket['decision_count'] += 1
                 if decision.qty <= 0:
                     continue
                 immediate_fill_price = _resolve_pending_fill_price(decision, signal)
@@ -1232,10 +1363,12 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
                         created_at=signal.event_ts,
                         positions=positions,
                         day_bucket=day_bucket,
+                        symbol_bucket=decision_symbol_bucket,
                         cost_model=cost_model,
                         cash=cash,
                         all_closed_trades=all_closed_trades,
                     )
+                    fill_status_by_strategy_id[decision.strategy_id] = 'filled'
                     continue
                 pending_key = _position_key(
                     decision.symbol,
@@ -1258,6 +1391,7 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
                             replacement=decision,
                         )
                         _log_decision_queued(decision, signal.event_ts)
+                        fill_status_by_strategy_id[decision.strategy_id] = 'pending'
                     continue
                 pending_orders[pending_key] = PendingOrder(
                     decision=decision,
@@ -1265,6 +1399,19 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
                     signal=signal,
                 )
                 _log_decision_queued(decision, signal.event_ts)
+                fill_status_by_strategy_id[decision.strategy_id] = 'pending'
+
+            for trace in telemetry.traces:
+                trace_records.append(
+                    ReplayTraceRecord(
+                        trading_day=signal_day.isoformat(),
+                        strategy_trace=trace,
+                        decision_emitted=trace.strategy_id in emitted_strategy_ids,
+                        fill_status=fill_status_by_strategy_id.get(trace.strategy_id, 'none'),
+                        decision_strategy_id=trace.strategy_id if trace.strategy_id in emitted_strategy_ids else None,
+                        block_reason=block_reason_by_strategy_id.get(trace.strategy_id),
+                    )
+                )
 
             now = time_mod.monotonic()
             if now - last_progress_at >= config.progress_log_interval_seconds:
@@ -1285,6 +1432,7 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
             _flatten_positions(
                 day=current_day,
                 stats=_active_day_stats(current_day),
+                funnel_stats=funnel_stats,
                 positions=positions,
                 last_signals=last_signals,
                 last_prices=last_prices,
@@ -1312,6 +1460,33 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
     total_cost = sum((item['cost_total'] for item in day_stats.values()), Decimal('0'))
     wins = sum(item['wins'] for item in day_stats.values())
     losses = sum(item['losses'] for item in day_stats.values())
+    funnel_report = ReplayFunnelReport(
+        start_date=config.start_date.isoformat(),
+        end_date=config.end_date.isoformat(),
+        buckets=tuple(
+            ReplayFunnelBucket(
+                trading_day=trading_day,
+                symbol=symbol,
+                retained_rows=int(bucket['retained_rows']),
+                runtime_evaluable_rows=int(bucket['runtime_evaluable_rows']),
+                quote_valid_rows=int(bucket['quote_valid_rows']),
+                strategy_evaluations=int(bucket['strategy_evaluations']),
+                gate_pass_counts=dict(bucket['gate_pass_counts']),
+                decision_count=int(bucket['decision_count']),
+                filled_count=int(bucket['filled_count']),
+                closed_trade_count=int(bucket['closed_trade_count']),
+                gross_pnl=bucket['gross_pnl'],
+                net_pnl=bucket['net_pnl'],
+                cost_total=bucket['cost_total'],
+            )
+            for (trading_day, symbol), bucket in sorted(funnel_stats.items())
+        ),
+    )
+    near_miss_payload = [
+        item.to_payload()
+        for trading_day in sorted(near_misses)
+        for item in near_misses[trading_day]
+    ]
     closed_trade_payload = sorted(
         all_closed_trades,
         key=lambda item: item.net_pnl,
@@ -1330,6 +1505,8 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
         _decimal_text(final_equity),
     )
     return {
+        'start_date': config.start_date.isoformat(),
+        'end_date': config.end_date.isoformat(),
         'start_equity': str(config.start_equity),
         'final_equity': str(final_equity),
         'net_pnl': str(total_net),
@@ -1390,6 +1567,9 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
             }
             for item in list(reversed(closed_trade_payload[-10:]))
         ],
+        'trace': [item.to_payload() for item in trace_records],
+        'funnel': funnel_report.to_payload(),
+        'near_misses': near_miss_payload,
     }
 
 
@@ -1409,6 +1589,7 @@ def _flatten_positions(
     *,
     day: date,
     stats: dict[str, Any],
+    funnel_stats: dict[tuple[str, str], dict[str, Any]],
     positions: dict[tuple[str, str], PositionState],
     last_signals: dict[str, SignalEnvelope],
     last_prices: dict[str, Decimal],
@@ -1465,6 +1646,12 @@ def _flatten_positions(
         stats['net_pnl'] += trade.net_pnl
         stats['cost_total'] += exit_cost
         stats['filled_count'] += 1
+        symbol_bucket = funnel_stats.setdefault((day.isoformat(), symbol), _init_funnel_stats())
+        symbol_bucket['gross_pnl'] += trade.gross_pnl
+        symbol_bucket['net_pnl'] += trade.net_pnl
+        symbol_bucket['cost_total'] += exit_cost
+        symbol_bucket['filled_count'] += 1
+        symbol_bucket['closed_trade_count'] += 1
         if trade.net_pnl > 0:
             stats['wins'] += 1
         elif trade.net_pnl < 0:
@@ -1503,6 +1690,21 @@ def main() -> None:
         max_jump_with_wide_spread_bps=Decimal(str(args.max_jump_with_wide_spread_bps)),
     )
     payload = run_replay(config)
+    if args.trace_output:
+        args.trace_output.write_text(
+            ''.join(json.dumps(item, sort_keys=True) + '\n' for item in payload['trace']),
+            encoding='utf-8',
+        )
+    if args.funnel_output:
+        args.funnel_output.write_text(
+            json.dumps(payload['funnel'], indent=2, sort_keys=True),
+            encoding='utf-8',
+        )
+    if args.near_misses_output:
+        args.near_misses_output.write_text(
+            json.dumps(payload['near_misses'], indent=2, sort_keys=True),
+            encoding='utf-8',
+        )
     if args.json:
         print(json.dumps(payload, sort_keys=True, separators=(',', ':')))
         return

--- a/services/torghut/scripts/local_intraday_tsmom_replay.py
+++ b/services/torghut/scripts/local_intraday_tsmom_replay.py
@@ -77,6 +77,7 @@ class ReplayConfig:
     start_equity: Decimal
     symbols: tuple[str, ...] = ()
     progress_log_interval_seconds: int = DEFAULT_PROGRESS_LOG_INTERVAL_SECONDS
+    capture_traces: bool = False
     max_executable_spread_bps: Decimal = DEFAULT_MAX_EXECUTABLE_SPREAD_BPS
     max_quote_mid_jump_bps: Decimal = DEFAULT_MAX_QUOTE_MID_JUMP_BPS
     max_jump_with_wide_spread_bps: Decimal = DEFAULT_MAX_JUMP_WITH_WIDE_SPREAD_BPS
@@ -187,6 +188,11 @@ def _parse_args() -> argparse.Namespace:
         '--near-misses-output',
         type=Path,
         help='Optional path to write replay near-miss JSON.',
+    )
+    parser.add_argument(
+        '--collect-traces',
+        action='store_true',
+        help='Capture per-strategy runtime traces and emit them in payload trace output.',
     )
     parser.add_argument('--no-flatten-eod', action='store_true')
     parser.add_argument('--json', action='store_true')
@@ -1152,7 +1158,7 @@ def _apply_filled_decision(
 def run_replay(config: ReplayConfig) -> dict[str, Any]:
     strategies = _load_strategies(config.strategy_configmap_path)
     strategies_by_id = {str(strategy.id): strategy for strategy in strategies}
-    engine = DecisionEngine(price_fetcher=None, runtime_trace_enabled=True)
+    engine = DecisionEngine(price_fetcher=None, runtime_trace_enabled=config.capture_traces)
     quote_quality = SignalQuoteQualityTracker(
         policy=QuoteQualityPolicy(
             max_executable_spread_bps=config.max_executable_spread_bps,
@@ -1301,7 +1307,8 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
             )
             telemetry = engine.consume_runtime_telemetry()
             symbol_bucket['runtime_evaluable_rows'] += 1
-            for trace in telemetry.traces:
+            telemetry_traces = telemetry.traces if config.capture_traces else ()
+            for trace in telemetry_traces:
                 _record_trace_for_funnel(symbol_bucket, trace)
                 near_miss = _build_near_miss(trace, trading_day=signal_day.isoformat())
                 if near_miss is not None:
@@ -1335,11 +1342,12 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
             emitted_strategy_ids = {decision.strategy_id for decision in executable_decisions}
             fill_status_by_strategy_id: dict[str, str] = {}
             block_reason_by_strategy_id: dict[str, str] = {}
-            for trace in telemetry.traces:
-                if trace.passed and trace.strategy_id not in emitted_strategy_ids:
-                    block_reason_by_strategy_id[trace.strategy_id] = 'post_runtime_filter_rejected'
-                elif not trace.passed and trace.first_failed_gate is not None:
-                    block_reason_by_strategy_id[trace.strategy_id] = trace.first_failed_gate
+            if config.capture_traces:
+                for trace in telemetry_traces:
+                    if trace.passed and trace.strategy_id not in emitted_strategy_ids:
+                        block_reason_by_strategy_id[trace.strategy_id] = 'post_runtime_filter_rejected'
+                    elif not trace.passed and trace.first_failed_gate is not None:
+                        block_reason_by_strategy_id[trace.strategy_id] = trace.first_failed_gate
 
             for decision in executable_decisions:
                 decision = _apply_order_preferences(decision, signal)
@@ -1401,17 +1409,18 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
                 _log_decision_queued(decision, signal.event_ts)
                 fill_status_by_strategy_id[decision.strategy_id] = 'pending'
 
-            for trace in telemetry.traces:
-                trace_records.append(
-                    ReplayTraceRecord(
-                        trading_day=signal_day.isoformat(),
-                        strategy_trace=trace,
-                        decision_emitted=trace.strategy_id in emitted_strategy_ids,
-                        fill_status=fill_status_by_strategy_id.get(trace.strategy_id, 'none'),
-                        decision_strategy_id=trace.strategy_id if trace.strategy_id in emitted_strategy_ids else None,
-                        block_reason=block_reason_by_strategy_id.get(trace.strategy_id),
+            if config.capture_traces:
+                for trace in telemetry_traces:
+                    trace_records.append(
+                        ReplayTraceRecord(
+                            trading_day=signal_day.isoformat(),
+                            strategy_trace=trace,
+                            decision_emitted=trace.strategy_id in emitted_strategy_ids,
+                            fill_status=fill_status_by_strategy_id.get(trace.strategy_id, 'none'),
+                            decision_strategy_id=trace.strategy_id if trace.strategy_id in emitted_strategy_ids else None,
+                            block_reason=block_reason_by_strategy_id.get(trace.strategy_id),
+                        )
                     )
-                )
 
             now = time_mod.monotonic()
             if now - last_progress_at >= config.progress_log_interval_seconds:
@@ -1685,6 +1694,7 @@ def main() -> None:
             if symbol.strip()
         ),
         progress_log_interval_seconds=max(1, int(args.progress_log_seconds)),
+        capture_traces=bool(getattr(args, 'collect_traces', False)) or args.trace_output is not None,
         max_executable_spread_bps=Decimal(str(args.max_executable_spread_bps)),
         max_quote_mid_jump_bps=Decimal(str(args.max_quote_mid_jump_bps)),
         max_jump_with_wide_spread_bps=Decimal(str(args.max_jump_with_wide_spread_bps)),

--- a/services/torghut/scripts/run_walkforward.py
+++ b/services/torghut/scripts/run_walkforward.py
@@ -172,7 +172,7 @@ def main() -> int:
         folds,
         strategies=strategies,
         signal_source=signal_source,
-        decision_engine=DecisionEngine(),
+        decision_engine=DecisionEngine(runtime_trace_enabled=True),
     )
     write_walk_forward_results(results, args.output)
 

--- a/services/torghut/scripts/search_profitability_frontier.py
+++ b/services/torghut/scripts/search_profitability_frontier.py
@@ -139,7 +139,16 @@ def _load_sweep_config(path: Path) -> dict[str, Any]:
 def iter_parameter_candidates(
     parameter_grid: Mapping[str, Iterable[Any]],
 ) -> list[dict[str, Any]]:
-    items = [(str(key), list(values)) for key, values in parameter_grid.items()]
+    items = []
+    for key, values in parameter_grid.items():
+        if isinstance(values, (str, bytes)):
+            raise ValueError(f'parameter_values_not_sequence:{key}')
+        if isinstance(values, Mapping):
+            raise ValueError(f'parameter_values_not_sequence:{key}')
+        if not isinstance(values, Iterable):
+            raise ValueError(f'parameter_values_not_iterable:{key}')
+        value_list = list(values)
+        items.append((str(key), value_list))
     if not items:
         return [{}]
     names = [name for name, _ in items]
@@ -251,7 +260,13 @@ def main() -> int:
     if not isinstance(parameter_grid, Mapping):
         raise ValueError('sweep_config_parameters_not_mapping')
 
-    constraints = cast(Mapping[str, Any], sweep_config.get('constraints') or {})
+    constraints_value = sweep_config.get('constraints')
+    if constraints_value is None:
+        constraints: Mapping[str, Any] = {}
+    elif isinstance(constraints_value, Mapping):
+        constraints = cast(Mapping[str, Any], constraints_value)
+    else:
+        raise ValueError('sweep_config_constraints_not_mapping')
     policy = ProfitabilityConstraintPolicy(
         holdout_target_net_per_day=Decimal(str(constraints.get('holdout_target_net_per_day', '250'))),
         min_active_holdout_days=int(constraints.get('min_active_holdout_days', 3)),

--- a/services/torghut/scripts/search_profitability_frontier.py
+++ b/services/torghut/scripts/search_profitability_frontier.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import itertools
 import json
+import sys
 import tempfile
 from dataclasses import dataclass
 from datetime import date
@@ -355,5 +356,13 @@ def main() -> int:
     return 0
 
 
+def cli_main() -> int:
+    try:
+        return main()
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+
 if __name__ == '__main__':
-    raise SystemExit(main())
+    raise SystemExit(cli_main())

--- a/services/torghut/scripts/search_profitability_frontier.py
+++ b/services/torghut/scripts/search_profitability_frontier.py
@@ -1,0 +1,359 @@
+#!/usr/bin/env python3
+"""Deterministically search Torghut replay configs on a 10d train / 5d holdout window."""
+
+from __future__ import annotations
+
+import argparse
+import itertools
+import json
+import tempfile
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+from pathlib import Path
+from typing import Any, Iterable, Mapping, cast
+
+import yaml
+
+from app.trading.reporting import (
+    ProfitabilityConstraintPolicy,
+    score_replay_profitability_candidate,
+)
+from scripts.local_intraday_tsmom_replay import ReplayConfig, _http_query, run_replay
+
+_SWEEP_SCHEMA_VERSION = 'torghut.replay-frontier-sweep.v1'
+_REPLAY_SIGNAL_TABLE = 'torghut.ta_signals'
+
+
+@dataclass(frozen=True)
+class SweepWindow:
+    train_days: tuple[date, ...]
+    holdout_days: tuple[date, ...]
+
+    @property
+    def train_start(self) -> date:
+        return self.train_days[0]
+
+    @property
+    def train_end(self) -> date:
+        return self.train_days[-1]
+
+    @property
+    def holdout_start(self) -> date:
+        return self.holdout_days[0]
+
+    @property
+    def holdout_end(self) -> date:
+        return self.holdout_days[-1]
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description='Search profitability frontier candidates using the local Torghut replay.',
+    )
+    parser.add_argument(
+        '--strategy-configmap',
+        type=Path,
+        default=Path('argocd/applications/torghut/strategy-configmap.yaml'),
+    )
+    parser.add_argument(
+        '--sweep-config',
+        type=Path,
+        default=Path('config/trading/profitability-frontier-breakout.yaml'),
+    )
+    parser.add_argument(
+        '--clickhouse-http-url',
+        default='http://torghut-clickhouse.torghut.svc.cluster.local:8123',
+    )
+    parser.add_argument('--clickhouse-username', default='torghut')
+    parser.add_argument('--clickhouse-password', default='')
+    parser.add_argument('--start-equity', default='31590.02')
+    parser.add_argument('--chunk-minutes', type=int, default=10)
+    parser.add_argument('--symbols', default='')
+    parser.add_argument('--progress-log-seconds', type=int, default=30)
+    parser.add_argument('--train-days', type=int, default=10)
+    parser.add_argument('--holdout-days', type=int, default=5)
+    parser.add_argument('--top-n', type=int, default=10)
+    parser.add_argument('--json-output', type=Path)
+    return parser.parse_args()
+
+
+def _resolve_recent_trading_days(
+    *,
+    clickhouse_http_url: str,
+    clickhouse_username: str | None,
+    clickhouse_password: str | None,
+    limit: int,
+) -> tuple[date, ...]:
+    raw = _http_query(
+        url=clickhouse_http_url,
+        username=clickhouse_username,
+        password=clickhouse_password,
+        query=(
+            'SELECT DISTINCT toDate(event_ts) AS trading_day '
+            f'FROM {_REPLAY_SIGNAL_TABLE} '
+            "WHERE source = 'ta' "
+            "  AND window_size = 'PT1S' "
+            'ORDER BY trading_day DESC '
+            f'LIMIT {max(1, int(limit))} '
+            'FORMAT TSVRaw'
+        ),
+    )
+    values = [
+        date.fromisoformat(line.strip())
+        for line in raw.splitlines()
+        if line.strip()
+    ]
+    values.sort()
+    return tuple(values)
+
+
+def resolve_sweep_window(
+    recent_days: Iterable[date],
+    *,
+    train_days: int,
+    holdout_days: int,
+) -> SweepWindow:
+    ordered = sorted(dict.fromkeys(recent_days))
+    required = max(1, train_days) + max(1, holdout_days)
+    if len(ordered) < required:
+        raise ValueError(f'insufficient_recent_trading_days:{len(ordered)}<{required}')
+    selected = ordered[-required:]
+    return SweepWindow(
+        train_days=tuple(selected[:train_days]),
+        holdout_days=tuple(selected[train_days:]),
+    )
+
+
+def _load_sweep_config(path: Path) -> dict[str, Any]:
+    payload = yaml.safe_load(path.read_text(encoding='utf-8'))
+    if not isinstance(payload, dict):
+        raise ValueError('sweep_config_not_mapping')
+    schema_version = str(payload.get('schema_version') or '').strip()
+    if schema_version != _SWEEP_SCHEMA_VERSION:
+        raise ValueError(f'sweep_config_schema_version_invalid:{schema_version}')
+    return payload
+
+
+def iter_parameter_candidates(
+    parameter_grid: Mapping[str, Iterable[Any]],
+) -> list[dict[str, Any]]:
+    items = [(str(key), list(values)) for key, values in parameter_grid.items()]
+    if not items:
+        return [{}]
+    names = [name for name, _ in items]
+    value_sets = [values for _, values in items]
+    candidates: list[dict[str, Any]] = []
+    for combination in itertools.product(*value_sets):
+        candidates.append({name: value for name, value in zip(names, combination, strict=True)})
+    return candidates
+
+
+def apply_candidate_to_configmap(
+    *,
+    configmap_payload: Mapping[str, Any],
+    strategy_name: str,
+    candidate_params: Mapping[str, Any],
+    disable_other_strategies: bool,
+) -> dict[str, Any]:
+    root = json.loads(json.dumps(configmap_payload))
+    if not isinstance(root, dict):
+        raise ValueError('strategy_configmap_not_mapping')
+    data = root.get('data')
+    if not isinstance(data, dict):
+        raise ValueError('strategy_configmap_missing_data')
+    strategies_yaml = data.get('strategies.yaml')
+    if not isinstance(strategies_yaml, str):
+        raise ValueError('strategy_configmap_missing_strategies_yaml')
+    catalog = yaml.safe_load(strategies_yaml)
+    if not isinstance(catalog, dict):
+        raise ValueError('strategy_catalog_not_mapping')
+    strategies = catalog.get('strategies')
+    if not isinstance(strategies, list):
+        raise ValueError('strategy_catalog_missing_strategies')
+
+    matched = False
+    for item in strategies:
+        if not isinstance(item, dict):
+            continue
+        item_name = str(item.get('name') or '').strip()
+        if item_name == strategy_name:
+            params = item.setdefault('params', {})
+            if not isinstance(params, dict):
+                params = {}
+                item['params'] = params
+            params.update(dict(candidate_params))
+            item['enabled'] = True
+            matched = True
+        elif disable_other_strategies:
+            item['enabled'] = False
+    if not matched:
+        raise ValueError(f'strategy_not_found:{strategy_name}')
+
+    data['strategies.yaml'] = yaml.safe_dump(catalog, sort_keys=False)
+    return root
+
+
+def _build_replay_config(
+    *,
+    strategy_configmap_path: Path,
+    clickhouse_http_url: str,
+    clickhouse_username: str | None,
+    clickhouse_password: str | None,
+    start_date: date,
+    end_date: date,
+    start_equity: Decimal,
+    chunk_minutes: int,
+    symbols: tuple[str, ...],
+    progress_log_interval_seconds: int,
+) -> ReplayConfig:
+    return ReplayConfig(
+        strategy_configmap_path=strategy_configmap_path,
+        clickhouse_http_url=clickhouse_http_url,
+        clickhouse_username=clickhouse_username,
+        clickhouse_password=clickhouse_password,
+        start_date=start_date,
+        end_date=end_date,
+        chunk_minutes=chunk_minutes,
+        flatten_eod=True,
+        start_equity=start_equity,
+        symbols=symbols,
+        progress_log_interval_seconds=progress_log_interval_seconds,
+    )
+
+
+def main() -> int:
+    args = _parse_args()
+    sweep_config = _load_sweep_config(args.sweep_config.resolve())
+    recent_days = _resolve_recent_trading_days(
+        clickhouse_http_url=str(args.clickhouse_http_url),
+        clickhouse_username=(str(args.clickhouse_username).strip() or None),
+        clickhouse_password=(str(args.clickhouse_password).strip() or None),
+        limit=max(1, int(args.train_days)) + max(1, int(args.holdout_days)),
+    )
+    window = resolve_sweep_window(
+        recent_days,
+        train_days=max(1, int(args.train_days)),
+        holdout_days=max(1, int(args.holdout_days)),
+    )
+
+    base_configmap = yaml.safe_load(args.strategy_configmap.resolve().read_text(encoding='utf-8'))
+    if not isinstance(base_configmap, dict):
+        raise ValueError('base_strategy_configmap_not_mapping')
+
+    family = str(sweep_config.get('family') or '').strip()
+    strategy_name = str(sweep_config.get('strategy_name') or '').strip()
+    if not family or not strategy_name:
+        raise ValueError('sweep_config_missing_family_or_strategy_name')
+    disable_other_strategies = bool(sweep_config.get('disable_other_strategies', True))
+    parameter_grid = sweep_config.get('parameters')
+    if not isinstance(parameter_grid, Mapping):
+        raise ValueError('sweep_config_parameters_not_mapping')
+
+    constraints = cast(Mapping[str, Any], sweep_config.get('constraints') or {})
+    policy = ProfitabilityConstraintPolicy(
+        holdout_target_net_per_day=Decimal(str(constraints.get('holdout_target_net_per_day', '250'))),
+        min_active_holdout_days=int(constraints.get('min_active_holdout_days', 3)),
+        max_worst_holdout_day_loss=Decimal(str(constraints.get('max_worst_holdout_day_loss', '150'))),
+        min_profit_factor=Decimal(str(constraints.get('min_profit_factor', '1.5'))),
+        require_training_decisions=bool(constraints.get('require_training_decisions', True)),
+        require_holdout_decisions=bool(constraints.get('require_holdout_decisions', True)),
+    )
+    symbols = tuple(
+        symbol.strip().upper()
+        for symbol in str(args.symbols or '').split(',')
+        if symbol.strip()
+    )
+    candidates = iter_parameter_candidates(parameter_grid)
+    scored = []
+
+    with tempfile.TemporaryDirectory(prefix='torghut-profitability-frontier-') as tmpdir:
+        root = Path(tmpdir)
+        for index, candidate in enumerate(candidates, start=1):
+            candidate_configmap = apply_candidate_to_configmap(
+                configmap_payload=base_configmap,
+                strategy_name=strategy_name,
+                candidate_params=candidate,
+                disable_other_strategies=disable_other_strategies,
+            )
+            candidate_configmap_path = root / f'candidate-{index:04d}.yaml'
+            candidate_configmap_path.write_text(
+                yaml.safe_dump(candidate_configmap, sort_keys=False),
+                encoding='utf-8',
+            )
+
+            train_payload = run_replay(
+                _build_replay_config(
+                    strategy_configmap_path=candidate_configmap_path,
+                    clickhouse_http_url=str(args.clickhouse_http_url),
+                    clickhouse_username=(str(args.clickhouse_username).strip() or None),
+                    clickhouse_password=(str(args.clickhouse_password).strip() or None),
+                    start_date=window.train_start,
+                    end_date=window.train_end,
+                    start_equity=Decimal(str(args.start_equity)),
+                    chunk_minutes=max(1, int(args.chunk_minutes)),
+                    symbols=symbols,
+                    progress_log_interval_seconds=max(1, int(args.progress_log_seconds)),
+                )
+            )
+            holdout_payload = run_replay(
+                _build_replay_config(
+                    strategy_configmap_path=candidate_configmap_path,
+                    clickhouse_http_url=str(args.clickhouse_http_url),
+                    clickhouse_username=(str(args.clickhouse_username).strip() or None),
+                    clickhouse_password=(str(args.clickhouse_password).strip() or None),
+                    start_date=window.holdout_start,
+                    end_date=window.holdout_end,
+                    start_equity=Decimal(str(args.start_equity)),
+                    chunk_minutes=max(1, int(args.chunk_minutes)),
+                    symbols=symbols,
+                    progress_log_interval_seconds=max(1, int(args.progress_log_seconds)),
+                )
+            )
+            scored.append(
+                score_replay_profitability_candidate(
+                    family=family,
+                    strategy_name=strategy_name,
+                    replay_config={
+                        'candidate_index': index,
+                        'params': candidate,
+                        'train_start_date': window.train_start.isoformat(),
+                        'train_end_date': window.train_end.isoformat(),
+                        'holdout_start_date': window.holdout_start.isoformat(),
+                        'holdout_end_date': window.holdout_end.isoformat(),
+                    },
+                    train_payload=train_payload,
+                    holdout_payload=holdout_payload,
+                    policy=policy,
+                )
+            )
+
+    scored.sort(key=lambda item: (item.score, item.holdout_net_per_day, item.profit_factor or Decimal('-1')), reverse=True)
+    payload = {
+        'schema_version': _SWEEP_SCHEMA_VERSION,
+        'family': family,
+        'strategy_name': strategy_name,
+        'window': {
+            'train_days': [item.isoformat() for item in window.train_days],
+            'holdout_days': [item.isoformat() for item in window.holdout_days],
+        },
+        'constraints': {
+            'holdout_target_net_per_day': str(policy.holdout_target_net_per_day),
+            'min_active_holdout_days': policy.min_active_holdout_days,
+            'max_worst_holdout_day_loss': str(policy.max_worst_holdout_day_loss),
+            'min_profit_factor': str(policy.min_profit_factor),
+            'require_training_decisions': policy.require_training_decisions,
+            'require_holdout_decisions': policy.require_holdout_decisions,
+        },
+        'candidate_count': len(scored),
+        'top': [item.to_payload() for item in scored[: max(1, int(args.top_n))]],
+    }
+
+    if args.json_output:
+        args.json_output.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding='utf-8')
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/services/torghut/tests/test_evaluation_report.py
+++ b/services/torghut/tests/test_evaluation_report.py
@@ -9,7 +9,14 @@ from unittest import TestCase
 from app.models import Strategy
 from app.trading.decisions import DecisionEngine
 from app.trading.evaluation import FixtureSignalSource, generate_walk_forward_folds, run_walk_forward
-from app.trading.reporting import EvaluationGatePolicy, EvaluationReportConfig, generate_evaluation_report
+from app.trading.reporting import (
+    EvaluationGatePolicy,
+    EvaluationReportConfig,
+    ProfitabilityConstraintPolicy,
+    generate_evaluation_report,
+    score_replay_profitability_candidate,
+    summarize_replay_profitability,
+)
 
 
 class TestEvaluationReport(TestCase):
@@ -183,3 +190,78 @@ class TestEvaluationReport(TestCase):
         report = generate_evaluation_report(results, config=config, gate_policy=EvaluationGatePolicy())
 
         self.assertEqual(report.impact_assumptions.default_execution_seconds, 60)
+
+    def test_summarize_replay_profitability_uses_daily_net_and_activity(self) -> None:
+        summary = summarize_replay_profitability(
+            {
+                'start_date': '2026-03-10',
+                'end_date': '2026-03-14',
+                'net_pnl': '500',
+                'decision_count': 8,
+                'filled_count': 5,
+                'wins': 3,
+                'losses': 1,
+                'daily': {
+                    '2026-03-10': {'net_pnl': '300', 'filled_count': 2},
+                    '2026-03-11': {'net_pnl': '-100', 'filled_count': 1},
+                    '2026-03-12': {'net_pnl': '0', 'filled_count': 0},
+                    '2026-03-13': {'net_pnl': '300', 'filled_count': 2},
+                },
+            }
+        )
+
+        self.assertEqual(summary.trading_day_count, 4)
+        self.assertEqual(summary.active_days, 3)
+        self.assertEqual(summary.net_pnl, Decimal('500'))
+        self.assertEqual(summary.net_per_day, Decimal('125'))
+        self.assertEqual(summary.worst_day_net, Decimal('-100'))
+        self.assertEqual(summary.profit_factor, Decimal('6'))
+
+    def test_score_replay_profitability_candidate_penalizes_constraint_failures(self) -> None:
+        candidate = score_replay_profitability_candidate(
+            family='breakout_continuation',
+            strategy_name='breakout-continuation-long-v1',
+            replay_config={'params': {'min_cross_section_continuation_rank': '0.55'}},
+            train_payload={
+                'start_date': '2026-03-03',
+                'end_date': '2026-03-14',
+                'net_pnl': '100',
+                'decision_count': 3,
+                'filled_count': 3,
+                'wins': 2,
+                'losses': 1,
+                'daily': {
+                    '2026-03-03': {'net_pnl': '50', 'filled_count': 1},
+                    '2026-03-04': {'net_pnl': '50', 'filled_count': 2},
+                },
+            },
+            holdout_payload={
+                'start_date': '2026-03-17',
+                'end_date': '2026-03-21',
+                'net_pnl': '200',
+                'decision_count': 2,
+                'filled_count': 2,
+                'wins': 1,
+                'losses': 1,
+                'daily': {
+                    '2026-03-17': {'net_pnl': '250', 'filled_count': 1},
+                    '2026-03-18': {'net_pnl': '-50', 'filled_count': 1},
+                    '2026-03-19': {'net_pnl': '0', 'filled_count': 0},
+                    '2026-03-20': {'net_pnl': '0', 'filled_count': 0},
+                    '2026-03-21': {'net_pnl': '0', 'filled_count': 0},
+                },
+            },
+            policy=ProfitabilityConstraintPolicy(
+                holdout_target_net_per_day=Decimal('250'),
+                min_active_holdout_days=3,
+                max_worst_holdout_day_loss=Decimal('150'),
+                min_profit_factor=Decimal('1.5'),
+            ),
+        )
+
+        self.assertEqual(candidate.train_net_per_day, Decimal('50'))
+        self.assertEqual(candidate.holdout_net_per_day, Decimal('40'))
+        self.assertEqual(candidate.active_holdout_days, 2)
+        self.assertEqual(candidate.max_holdout_drawdown_day, Decimal('50'))
+        self.assertEqual(candidate.profit_factor, Decimal('5'))
+        self.assertLess(candidate.score, candidate.holdout_net_per_day)

--- a/services/torghut/tests/test_evaluation_report.py
+++ b/services/torghut/tests/test_evaluation_report.py
@@ -217,6 +217,23 @@ class TestEvaluationReport(TestCase):
         self.assertEqual(summary.worst_day_net, Decimal('-100'))
         self.assertEqual(summary.profit_factor, Decimal('6'))
 
+    def test_summarize_replay_profitability_ignores_non_mapping_daily_rows(self) -> None:
+        summary = summarize_replay_profitability(
+            {
+                'start_date': '2026-03-10',
+                'end_date': '2026-03-12',
+                'net_pnl': '200',
+                'daily': {
+                    '2026-03-10': {'net_pnl': '200', 'filled_count': 1},
+                    '2026-03-11': 'not-a-mapping',
+                },
+            }
+        )
+
+        self.assertEqual(summary.trading_day_count, 1)
+        self.assertEqual(summary.daily_net, {'2026-03-10': Decimal('200')})
+        self.assertEqual(summary.profit_factor, Decimal('999999'))
+
     def test_score_replay_profitability_candidate_penalizes_constraint_failures(self) -> None:
         candidate = score_replay_profitability_candidate(
             family='breakout_continuation',
@@ -265,3 +282,85 @@ class TestEvaluationReport(TestCase):
         self.assertEqual(candidate.max_holdout_drawdown_day, Decimal('50'))
         self.assertEqual(candidate.profit_factor, Decimal('5'))
         self.assertLess(candidate.score, candidate.holdout_net_per_day)
+
+    def test_score_replay_profitability_candidate_penalizes_missing_profit_factor_and_decisions(self) -> None:
+        candidate = score_replay_profitability_candidate(
+            family='breakout_continuation',
+            strategy_name='breakout-continuation-long-v1',
+            replay_config={'params': {'min_cross_section_continuation_rank': '0.45'}},
+            train_payload={
+                'start_date': '2026-03-03',
+                'end_date': '2026-03-07',
+                'net_pnl': '0',
+                'decision_count': 0,
+                'filled_count': 0,
+                'wins': 0,
+                'losses': 0,
+                'daily': {
+                    '2026-03-03': {'net_pnl': '0', 'filled_count': 0},
+                    '2026-03-04': {'net_pnl': '0', 'filled_count': 0},
+                },
+            },
+            holdout_payload={
+                'start_date': '2026-03-10',
+                'end_date': '2026-03-14',
+                'net_pnl': '0',
+                'decision_count': 0,
+                'filled_count': 0,
+                'wins': 0,
+                'losses': 0,
+                'daily': {
+                    '2026-03-10': {'net_pnl': '0', 'filled_count': 0},
+                    '2026-03-11': {'net_pnl': '0', 'filled_count': 0},
+                    '2026-03-12': {'net_pnl': '0', 'filled_count': 0},
+                    '2026-03-13': {'net_pnl': '0', 'filled_count': 0},
+                    '2026-03-14': {'net_pnl': '0', 'filled_count': 0},
+                },
+            },
+            policy=ProfitabilityConstraintPolicy(),
+        )
+
+        self.assertIsNone(candidate.profit_factor)
+        self.assertEqual(candidate.active_holdout_days, 0)
+        self.assertEqual(candidate.score, Decimal('-2000'))
+
+    def test_score_replay_profitability_candidate_penalizes_drawdown_and_low_profit_factor(self) -> None:
+        candidate = score_replay_profitability_candidate(
+            family='breakout_continuation',
+            strategy_name='breakout-continuation-long-v1',
+            replay_config={'params': {'min_cross_section_continuation_rank': '0.65'}},
+            train_payload={
+                'start_date': '2026-03-03',
+                'end_date': '2026-03-07',
+                'net_pnl': '100',
+                'decision_count': 2,
+                'filled_count': 2,
+                'wins': 1,
+                'losses': 1,
+                'daily': {
+                    '2026-03-03': {'net_pnl': '75', 'filled_count': 1},
+                    '2026-03-04': {'net_pnl': '25', 'filled_count': 1},
+                },
+            },
+            holdout_payload={
+                'start_date': '2026-03-10',
+                'end_date': '2026-03-14',
+                'net_pnl': '-150',
+                'decision_count': 2,
+                'filled_count': 2,
+                'wins': 1,
+                'losses': 1,
+                'daily': {
+                    '2026-03-10': {'net_pnl': '50', 'filled_count': 1},
+                    '2026-03-11': {'net_pnl': '-200', 'filled_count': 1},
+                    '2026-03-12': {'net_pnl': '0', 'filled_count': 0},
+                    '2026-03-13': {'net_pnl': '0', 'filled_count': 0},
+                    '2026-03-14': {'net_pnl': '0', 'filled_count': 0},
+                },
+            },
+            policy=ProfitabilityConstraintPolicy(),
+        )
+
+        self.assertEqual(candidate.profit_factor, Decimal('0.25'))
+        self.assertEqual(candidate.max_holdout_drawdown_day, Decimal('200'))
+        self.assertEqual(candidate.score, Decimal('-922.50'))

--- a/services/torghut/tests/test_evaluation_trace.py
+++ b/services/torghut/tests/test_evaluation_trace.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from decimal import Decimal
+from unittest import TestCase
+
+from app.trading.evaluation_trace import (
+    GateTrace,
+    NearMissRecord,
+    ReplayFunnelBucket,
+    ReplayFunnelReport,
+    ReplayTraceRecord,
+    StrategyTrace,
+    SweepCandidateResult,
+    ThresholdTrace,
+)
+
+
+class TestEvaluationTrace(TestCase):
+    def test_strategy_trace_helpers_and_payload_serialize_nested_values(self) -> None:
+        failed_threshold = ThresholdTrace(
+            metric='recent_quote_invalid_ratio',
+            comparator='max_lte',
+            value=Decimal('0.22'),
+            threshold=Decimal('0.10'),
+            passed=False,
+            missing_policy='fail_closed',
+            distance_to_pass=None,
+        )
+        passed_threshold = ThresholdTrace(
+            metric='recent_microprice_bias_bps_avg',
+            comparator='min_gte',
+            value=Decimal('0.45'),
+            threshold=Decimal('0.10'),
+            passed=True,
+            missing_policy='fail_closed',
+            distance_to_pass=Decimal('0'),
+        )
+        trace = StrategyTrace(
+            strategy_id='breakout@prod',
+            strategy_type='breakout_continuation_long',
+            symbol='AAPL',
+            event_ts='2026-03-27T17:30:24+00:00',
+            timeframe='1Sec',
+            passed=False,
+            action=None,
+            rationale=('near_miss',),
+            gates=(
+                GateTrace(
+                    gate='feed_quality',
+                    category='feed_quality',
+                    passed=False,
+                    thresholds=(failed_threshold, passed_threshold),
+                    context={
+                        'captured_at': datetime(2026, 3, 27, 17, 30, 24, tzinfo=timezone.utc),
+                        'window_day': date(2026, 3, 27),
+                        'bands': (Decimal('0.10'), Decimal('0.20')),
+                        'flags': [True, False],
+                        'nested': {'score': Decimal('1.25')},
+                    },
+                ),
+            ),
+            first_failed_gate='feed_quality',
+            context={'family': 'breakout'},
+        )
+
+        updated = trace.with_context(region='US').with_updates(action='buy')
+
+        self.assertEqual(updated.action, 'buy')
+        self.assertEqual(updated.failed_gate(), trace.gates[0])
+        self.assertEqual(updated.distance_score(), Decimal('1'))
+
+        payload = updated.to_payload()
+        gate_payload = payload['gates'][0]
+        threshold_payload = gate_payload['thresholds'][0]
+        self.assertEqual(payload['schema_version'], 'torghut.strategy-trace.v1')
+        self.assertEqual(payload['context']['region'], 'US')
+        self.assertEqual(gate_payload['context']['captured_at'], '2026-03-27T17:30:24+00:00')
+        self.assertEqual(gate_payload['context']['window_day'], '2026-03-27')
+        self.assertEqual(gate_payload['context']['bands'], ['0.10', '0.20'])
+        self.assertEqual(gate_payload['context']['nested']['score'], '1.25')
+        self.assertEqual(threshold_payload['value'], '0.22')
+        self.assertEqual(threshold_payload['distance_to_pass'], None)
+
+    def test_trace_records_and_reports_payloads_cover_optional_paths(self) -> None:
+        no_failed_gate = StrategyTrace(
+            strategy_id='late-day@prod',
+            strategy_type='late_day_continuation_long',
+            symbol='MSFT',
+            event_ts='2026-03-27T19:05:00+00:00',
+            timeframe='1Sec',
+            passed=True,
+            action='buy',
+            gates=(),
+        )
+        missing_failed_gate = StrategyTrace(
+            strategy_id='mean-reversion@prod',
+            strategy_type='mean_reversion_rebound_long',
+            symbol='META',
+            event_ts='2026-03-27T18:15:00+00:00',
+            timeframe='1Sec',
+            passed=False,
+            action=None,
+            first_failed_gate='confirmation',
+            gates=(),
+        )
+
+        self.assertIsNone(no_failed_gate.failed_gate())
+        self.assertEqual(no_failed_gate.distance_score(), Decimal('0'))
+        self.assertIsNone(missing_failed_gate.failed_gate())
+        self.assertEqual(missing_failed_gate.distance_score(), Decimal('0'))
+
+        replay_trace = ReplayTraceRecord(
+            trading_day='2026-03-27',
+            strategy_trace=no_failed_gate,
+            decision_emitted=True,
+            fill_status='filled',
+            decision_strategy_id='late-day@prod',
+            fill_price=Decimal('451.25'),
+        ).with_updates(block_reason='filled_same_tick')
+        replay_payload = replay_trace.to_payload()
+        self.assertEqual(replay_payload['schema_version'], 'torghut.replay-trace.v1')
+        self.assertEqual(replay_payload['fill_price'], '451.25')
+        self.assertEqual(replay_payload['block_reason'], 'filled_same_tick')
+
+        bucket = ReplayFunnelBucket(
+            trading_day='2026-03-27',
+            symbol='AAPL',
+            retained_rows=10,
+            runtime_evaluable_rows=8,
+            quote_valid_rows=9,
+            strategy_evaluations=5,
+            gate_pass_counts={'b:confirmation': 2, 'a:eligibility': 4},
+            decision_count=2,
+            filled_count=1,
+            closed_trade_count=1,
+            gross_pnl=Decimal('10.50'),
+            net_pnl=Decimal('9.75'),
+            cost_total=Decimal('0.75'),
+        )
+        report = ReplayFunnelReport(
+            start_date='2026-03-24',
+            end_date='2026-03-27',
+            buckets=(bucket,),
+        )
+        report_payload = report.to_payload()
+        self.assertEqual(report_payload['schema_version'], 'torghut.replay-funnel.v1')
+        self.assertEqual(
+            report_payload['buckets'][0]['gate_pass_counts'],
+            {'a:eligibility': 4, 'b:confirmation': 2},
+        )
+
+        near_miss = NearMissRecord(
+            trading_day='2026-03-27',
+            symbol='AAPL',
+            strategy_id='breakout@prod',
+            strategy_type='breakout_continuation_long',
+            event_ts='2026-03-27T18:00:00+00:00',
+            action='buy',
+            first_failed_gate='confirmation',
+            distance_score=Decimal('0.15'),
+            thresholds=(
+                ThresholdTrace(
+                    metric='continuation_rank',
+                    comparator='min_gte',
+                    value=Decimal('0.70'),
+                    threshold=Decimal('0.85'),
+                    passed=False,
+                    missing_policy='fail_closed',
+                    distance_to_pass=Decimal('0.15'),
+                ),
+            ),
+        )
+        near_miss_payload = near_miss.to_payload()
+        self.assertEqual(near_miss_payload['distance_score'], '0.15')
+        self.assertEqual(near_miss_payload['thresholds'][0]['threshold'], '0.85')
+
+        candidate = SweepCandidateResult(
+            candidate_id='candidate-1',
+            family='breakout_continuation',
+            strategy_name='breakout-continuation-long-v1',
+            train_net_per_day=Decimal('12.5'),
+            holdout_net_per_day=Decimal('51.6'),
+            train_total_net=Decimal('62.5'),
+            holdout_total_net=Decimal('258.0'),
+            active_holdout_days=2,
+            max_holdout_drawdown_day=Decimal('0'),
+            profit_factor=None,
+            wins=2,
+            losses=0,
+            score=Decimal('-646.6'),
+            replay_config={'params': {'rank': Decimal('0.45')}},
+        )
+        candidate_payload = candidate.to_payload()
+        self.assertEqual(candidate_payload['schema_version'], 'torghut.sweep-candidate-result.v1')
+        self.assertEqual(candidate_payload['profit_factor'], None)
+        self.assertEqual(candidate_payload['replay_config']['params']['rank'], '0.45')

--- a/services/torghut/tests/test_local_intraday_tsmom_replay.py
+++ b/services/torghut/tests/test_local_intraday_tsmom_replay.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
+import json
 from datetime import datetime, timezone
 from decimal import Decimal
 from pathlib import Path
+from tempfile import TemporaryDirectory
+from argparse import Namespace
 from unittest import TestCase
+from unittest.mock import patch
 
 from app.trading.costs import TransactionCostModel
-from app.trading.evaluation_trace import GateTrace, StrategyTrace, ThresholdTrace
+from app.trading.evaluation_trace import GateTrace, NearMissRecord, StrategyTrace, ThresholdTrace
+from app.models import Strategy
 from app.trading.models import SignalEnvelope, StrategyDecision
 from scripts.local_intraday_tsmom_replay import (
     PendingOrder,
@@ -17,6 +22,7 @@ from scripts.local_intraday_tsmom_replay import (
     _apply_order_preferences,
     _build_near_miss,
     _init_funnel_stats,
+    _insert_near_miss,
     _parse_signal_row,
     _positions_payload,
     _quote_quality_status,
@@ -24,6 +30,8 @@ from scripts.local_intraday_tsmom_replay import (
     _reconcile_pending_order_before_immediate_fill,
     _resolve_pending_fill_price,
     _should_replace_pending_order,
+    main as replay_main,
+    run_replay,
 )
 
 
@@ -505,3 +513,371 @@ class TestLocalIntradayTsmomReplay(TestCase):
         self.assertEqual(near_miss.first_failed_gate, 'confirmation')
         self.assertEqual(near_miss.distance_score, Decimal('0.08'))
         self.assertEqual(len(near_miss.thresholds), 1)
+
+    def test_build_near_miss_returns_none_for_non_rejectable_traces(self) -> None:
+        passed_trace = StrategyTrace(
+            strategy_id='breakout@prod',
+            strategy_type='breakout_continuation_long',
+            symbol='AAPL',
+            event_ts='2026-03-26T18:07:12+00:00',
+            timeframe='1Sec',
+            passed=True,
+            action='buy',
+            first_failed_gate=None,
+            gates=(),
+        )
+        missing_gate_trace = StrategyTrace(
+            strategy_id='breakout@prod',
+            strategy_type='breakout_continuation_long',
+            symbol='AAPL',
+            event_ts='2026-03-26T18:07:12+00:00',
+            timeframe='1Sec',
+            passed=False,
+            action=None,
+            first_failed_gate='confirmation',
+            gates=(),
+        )
+        no_thresholds_trace = StrategyTrace(
+            strategy_id='breakout@prod',
+            strategy_type='breakout_continuation_long',
+            symbol='AAPL',
+            event_ts='2026-03-26T18:07:12+00:00',
+            timeframe='1Sec',
+            passed=False,
+            action=None,
+            first_failed_gate='confirmation',
+            gates=(
+                GateTrace(
+                    gate='confirmation',
+                    category='confirmation',
+                    passed=False,
+                    thresholds=(),
+                ),
+            ),
+        )
+
+        self.assertIsNone(_build_near_miss(passed_trace, trading_day='2026-03-26'))
+        self.assertIsNone(_build_near_miss(missing_gate_trace, trading_day='2026-03-26'))
+        self.assertIsNone(_build_near_miss(no_thresholds_trace, trading_day='2026-03-26'))
+
+    def test_insert_near_miss_sorts_and_limits_bucket(self) -> None:
+        near_misses: dict[str, list[NearMissRecord]] = {}
+        for symbol, score in [('MSFT', '0.30'), ('AAPL', '0.10'), ('NVDA', '0.20')]:
+            _insert_near_miss(
+                near_misses,
+                NearMissRecord(
+                    trading_day='2026-03-27',
+                    symbol=symbol,
+                    strategy_id=f'{symbol.lower()}@prod',
+                    strategy_type='breakout_continuation_long',
+                    event_ts=f'2026-03-27T18:0{len(near_misses)}:00+00:00',
+                    action='buy',
+                    first_failed_gate='confirmation',
+                    distance_score=Decimal(score),
+                    thresholds=(),
+                ),
+                limit=2,
+            )
+
+        self.assertEqual(
+            [item.symbol for item in near_misses['2026-03-27']],
+            ['AAPL', 'NVDA'],
+        )
+
+    def test_apply_filled_decision_updates_symbol_bucket_for_buy_and_sell(self) -> None:
+        signal = self._signal(bid='523.22', ask='523.28', price='523.25')
+        positions: dict[tuple[str, str], PositionState] = {}
+        day_bucket = {
+            'decision_count': 1,
+            'filled_count': 0,
+            'gross_pnl': Decimal('0'),
+            'net_pnl': Decimal('0'),
+            'cost_total': Decimal('0'),
+            'wins': 0,
+            'losses': 0,
+            'closed_trades': [],
+        }
+        symbol_bucket = _init_funnel_stats()
+
+        cash = _apply_filled_decision(
+            decision=self._decision(action='buy', order_type='limit', limit_price='523.28'),
+            signal=signal,
+            fill_price=Decimal('523.28'),
+            filled_at=signal.event_ts,
+            created_at=signal.event_ts,
+            positions=positions,
+            day_bucket=day_bucket,
+            symbol_bucket=symbol_bucket,
+            cost_model=TransactionCostModel(),
+            cash=Decimal('10000'),
+            all_closed_trades=[],
+        )
+
+        self.assertEqual(symbol_bucket['filled_count'], 1)
+        self.assertGreaterEqual(symbol_bucket['cost_total'], Decimal('0'))
+
+        cash = _apply_filled_decision(
+            decision=self._decision(action='sell', order_type='market'),
+            signal=signal,
+            fill_price=Decimal('523.22'),
+            filled_at=signal.event_ts,
+            created_at=signal.event_ts,
+            positions=positions,
+            day_bucket=day_bucket,
+            symbol_bucket=symbol_bucket,
+            cost_model=TransactionCostModel(),
+            cash=cash,
+            all_closed_trades=[],
+        )
+
+        self.assertGreater(symbol_bucket['gross_pnl'], Decimal('-1'))
+        self.assertNotEqual(symbol_bucket['net_pnl'], Decimal('0'))
+        self.assertEqual(symbol_bucket['closed_trade_count'], 1)
+        self.assertGreater(cash, Decimal('0'))
+
+    def test_replay_main_writes_trace_funnel_and_near_miss_outputs(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            trace_output = root / 'trace.jsonl'
+            funnel_output = root / 'funnel.json'
+            near_misses_output = root / 'near-misses.json'
+
+            args = Namespace(
+                strategy_configmap='/tmp/strategies.yaml',
+                clickhouse_http_url='http://example.invalid:8123',
+                clickhouse_username='',
+                clickhouse_password='',
+                start_date='2026-03-26',
+                end_date='2026-03-27',
+                chunk_minutes=10,
+                no_flatten_eod=False,
+                start_equity='31590.02',
+                symbols='',
+                progress_log_seconds=30,
+                max_executable_spread_bps='12',
+                max_quote_mid_jump_bps='150',
+                max_jump_with_wide_spread_bps='40',
+                log_level='INFO',
+                trace_output=trace_output,
+                funnel_output=funnel_output,
+                near_misses_output=near_misses_output,
+                json=False,
+            )
+
+            payload = {
+                'trace': [{'strategy_id': 'breakout@prod', 'passed': True}],
+                'funnel': {'schema_version': 'torghut.replay-funnel.v1', 'buckets': []},
+                'near_misses': [{'symbol': 'AAPL'}],
+            }
+            with (
+                patch('scripts.local_intraday_tsmom_replay._parse_args', return_value=args),
+                patch('scripts.local_intraday_tsmom_replay.run_replay', return_value=payload),
+                patch('builtins.print'),
+            ):
+                replay_main()
+
+            self.assertEqual(
+                trace_output.read_text(encoding='utf-8'),
+                json.dumps(payload['trace'][0], sort_keys=True) + '\n',
+            )
+            self.assertEqual(
+                json.loads(funnel_output.read_text(encoding='utf-8')),
+                payload['funnel'],
+            )
+            self.assertEqual(
+                json.loads(near_misses_output.read_text(encoding='utf-8')),
+                payload['near_misses'],
+            )
+
+    def test_run_replay_emits_trace_funnel_and_near_misses(self) -> None:
+        strategy = Strategy(
+            name='breakout-continuation-long-v1',
+            description=None,
+            enabled=True,
+            base_timeframe='1Sec',
+            universe_type='static',
+            universe_symbols=['AAPL'],
+            max_position_pct_equity=None,
+            max_notional_per_trade=None,
+        )
+        decision_strategy_id = str(strategy.id)
+
+        signal_open = SignalEnvelope(
+            event_ts=datetime(2026, 3, 26, 17, 30, 0, tzinfo=timezone.utc),
+            symbol='AAPL',
+            timeframe='1Sec',
+            seq=1,
+            payload={
+                'price': Decimal('99.95'),
+                'imbalance_bid_px': Decimal('99.90'),
+                'imbalance_ask_px': Decimal('100.00'),
+                'spread': Decimal('0.10'),
+            },
+        )
+        signal_fill = SignalEnvelope(
+            event_ts=datetime(2026, 3, 26, 17, 31, 0, tzinfo=timezone.utc),
+            symbol='AAPL',
+            timeframe='1Sec',
+            seq=2,
+            payload={
+                'price': Decimal('99.45'),
+                'imbalance_bid_px': Decimal('99.40'),
+                'imbalance_ask_px': Decimal('99.50'),
+                'spread': Decimal('0.10'),
+            },
+        )
+        signal_follow = SignalEnvelope(
+            event_ts=datetime(2026, 3, 27, 17, 30, 0, tzinfo=timezone.utc),
+            symbol='AAPL',
+            timeframe='1Sec',
+            seq=3,
+            payload={
+                'price': Decimal('101.50'),
+                'imbalance_bid_px': Decimal('101.40'),
+                'imbalance_ask_px': Decimal('101.50'),
+                'spread': Decimal('0.10'),
+            },
+        )
+
+        decision_one = StrategyDecision(
+            strategy_id=decision_strategy_id,
+            symbol='AAPL',
+            event_ts=signal_open.event_ts,
+            timeframe='1Sec',
+            action='buy',
+            qty=Decimal('2'),
+            order_type='limit',
+            time_in_force='day',
+            limit_price=Decimal('99.00'),
+            rationale='candidate_one',
+            params={},
+        )
+        decision_two = StrategyDecision(
+            strategy_id='replacement-strategy',
+            symbol='AAPL',
+            event_ts=signal_open.event_ts,
+            timeframe='1Sec',
+            action='buy',
+            qty=Decimal('2'),
+            order_type='limit',
+            time_in_force='day',
+            limit_price=Decimal('99.50'),
+            rationale='candidate_two',
+            params={},
+        )
+
+        passed_trace = StrategyTrace(
+            strategy_id='replacement-strategy',
+            strategy_type='breakout_continuation_long',
+            symbol='AAPL',
+            event_ts=signal_open.event_ts.isoformat(),
+            timeframe='1Sec',
+            passed=True,
+            action='buy',
+            gates=(
+                GateTrace(gate='eligibility', category='eligibility', passed=True, thresholds=()),
+            ),
+        )
+        failed_trace = StrategyTrace(
+            strategy_id='late-day-blocked',
+            strategy_type='late_day_continuation_long',
+            symbol='AAPL',
+            event_ts=signal_fill.event_ts.isoformat(),
+            timeframe='1Sec',
+            passed=False,
+            action=None,
+            first_failed_gate='feed_quality',
+            gates=(
+                GateTrace(
+                    gate='feed_quality',
+                    category='feed_quality',
+                    passed=False,
+                    thresholds=(
+                        ThresholdTrace(
+                            metric='recent_quote_invalid_ratio',
+                            comparator='max_lte',
+                            value=Decimal('0.22'),
+                            threshold=Decimal('0.10'),
+                            passed=False,
+                            missing_policy='fail_closed',
+                            distance_to_pass=Decimal('0.12'),
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        class _Engine:
+            def __init__(self, *args, **kwargs) -> None:  # type: ignore[no-untyped-def]
+                _ = args
+                _ = kwargs
+                self._call_index = 0
+
+            def observe_signal(self, signal: SignalEnvelope) -> None:
+                _ = signal
+
+            def evaluate(self, signal: SignalEnvelope, strategies, *, equity, positions):  # type: ignore[no-untyped-def]
+                _ = signal
+                _ = strategies
+                _ = equity
+                _ = positions
+                self._call_index += 1
+                if self._call_index == 1:
+                    return [decision_one, decision_two]
+                return []
+
+            def consume_runtime_telemetry(self):  # type: ignore[no-untyped-def]
+                if self._call_index == 1:
+                    traces = [passed_trace]
+                elif self._call_index == 2:
+                    traces = [failed_trace]
+                else:
+                    traces = []
+                return type('Telemetry', (), {'traces': traces})()
+
+        class _Allocator:
+            def allocate(self, raw_decisions, **kwargs):  # type: ignore[no-untyped-def]
+                _ = kwargs
+                return [
+                    type('AllocationResult', (), {'approved': True, 'decision': decision})()
+                    for decision in raw_decisions
+                ]
+
+        class _Sizer:
+            def size(self, decision, **kwargs):  # type: ignore[no-untyped-def]
+                _ = kwargs
+                return type('SizingResult', (), {'approved': True, 'decision': decision})()
+
+        config = ReplayConfig(
+            strategy_configmap_path=Path('/tmp/strategies.yaml'),
+            clickhouse_http_url='http://example.invalid:8123',
+            clickhouse_username=None,
+            clickhouse_password=None,
+            start_date=datetime(2026, 3, 26, tzinfo=timezone.utc).date(),
+            end_date=datetime(2026, 3, 27, tzinfo=timezone.utc).date(),
+            chunk_minutes=10,
+            flatten_eod=True,
+            start_equity=Decimal('10000'),
+        )
+
+        with (
+            patch('scripts.local_intraday_tsmom_replay._load_strategies', return_value=[strategy]),
+            patch(
+                'scripts.local_intraday_tsmom_replay._iter_signal_rows',
+                return_value=iter([signal_open, signal_fill, signal_follow]),
+            ),
+            patch('scripts.local_intraday_tsmom_replay.DecisionEngine', _Engine),
+            patch('scripts.local_intraday_tsmom_replay.allocator_from_settings', return_value=_Allocator()),
+            patch('scripts.local_intraday_tsmom_replay.sizer_from_settings', return_value=_Sizer()),
+        ):
+            payload = run_replay(config)
+
+        self.assertEqual(payload['start_date'], '2026-03-26')
+        self.assertEqual(payload['end_date'], '2026-03-27')
+        self.assertEqual(len(payload['trace']), 2)
+        self.assertEqual(payload['trace'][0]['fill_status'], 'pending')
+        self.assertEqual(payload['trace'][1]['block_reason'], 'feed_quality')
+        self.assertEqual(payload['near_misses'][0]['first_failed_gate'], 'feed_quality')
+        self.assertEqual(payload['funnel']['schema_version'], 'torghut.replay-funnel.v1')
+        self.assertEqual(payload['funnel']['buckets'][0]['trading_day'], '2026-03-26')
+        self.assertGreaterEqual(payload['filled_count'], 2)

--- a/services/torghut/tests/test_local_intraday_tsmom_replay.py
+++ b/services/torghut/tests/test_local_intraday_tsmom_replay.py
@@ -858,6 +858,7 @@ class TestLocalIntradayTsmomReplay(TestCase):
             chunk_minutes=10,
             flatten_eod=True,
             start_equity=Decimal('10000'),
+            capture_traces=True,
         )
 
         with (

--- a/services/torghut/tests/test_local_intraday_tsmom_replay.py
+++ b/services/torghut/tests/test_local_intraday_tsmom_replay.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from unittest import TestCase
 
 from app.trading.costs import TransactionCostModel
+from app.trading.evaluation_trace import GateTrace, StrategyTrace, ThresholdTrace
 from app.trading.models import SignalEnvelope, StrategyDecision
 from scripts.local_intraday_tsmom_replay import (
     PendingOrder,
@@ -14,9 +15,12 @@ from scripts.local_intraday_tsmom_replay import (
     _SHARED_POSITION_OWNER,
     _apply_filled_decision,
     _apply_order_preferences,
+    _build_near_miss,
+    _init_funnel_stats,
     _parse_signal_row,
     _positions_payload,
     _quote_quality_status,
+    _record_trace_for_funnel,
     _reconcile_pending_order_before_immediate_fill,
     _resolve_pending_fill_price,
     _should_replace_pending_order,
@@ -417,3 +421,87 @@ class TestLocalIntradayTsmomReplay(TestCase):
         assert isinstance(imbalance, dict)
         self.assertEqual(imbalance['bid_sz'], Decimal('1200'))
         self.assertEqual(imbalance['ask_sz'], Decimal('800'))
+
+    def test_record_trace_for_funnel_stops_at_first_failed_gate(self) -> None:
+        funnel = _init_funnel_stats()
+        trace = StrategyTrace(
+            strategy_id='breakout@prod',
+            strategy_type='breakout_continuation_long',
+            symbol='META',
+            event_ts='2026-03-27T17:30:24+00:00',
+            timeframe='1Sec',
+            passed=False,
+            action=None,
+            first_failed_gate='feed_quality',
+            gates=(
+                GateTrace(
+                    gate='structure',
+                    category='structure',
+                    passed=True,
+                    thresholds=(),
+                ),
+                GateTrace(
+                    gate='feed_quality',
+                    category='feed_quality',
+                    passed=False,
+                    thresholds=(
+                        ThresholdTrace(
+                            metric='recent_quote_invalid_ratio',
+                            comparator='max_lte',
+                            value=Decimal('0.20'),
+                            threshold=Decimal('0.10'),
+                            passed=False,
+                            missing_policy='fail_closed',
+                            distance_to_pass=Decimal('0.10'),
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        _record_trace_for_funnel(funnel, trace)
+
+        self.assertEqual(funnel['strategy_evaluations'], 1)
+        self.assertEqual(
+            dict(funnel['gate_pass_counts']),
+            {'breakout_continuation_long:structure': 1},
+        )
+
+    def test_build_near_miss_uses_failed_gate_thresholds(self) -> None:
+        trace = StrategyTrace(
+            strategy_id='breakout@prod',
+            strategy_type='breakout_continuation_long',
+            symbol='AAPL',
+            event_ts='2026-03-26T18:07:12+00:00',
+            timeframe='1Sec',
+            passed=False,
+            action=None,
+            first_failed_gate='confirmation',
+            gates=(
+                GateTrace(
+                    gate='confirmation',
+                    category='confirmation',
+                    passed=False,
+                    thresholds=(
+                        ThresholdTrace(
+                            metric='cross_section_continuation_breadth',
+                            comparator='min_gte',
+                            value=Decimal('0.42'),
+                            threshold=Decimal('0.50'),
+                            passed=False,
+                            missing_policy='fail_closed',
+                            distance_to_pass=Decimal('0.08'),
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        near_miss = _build_near_miss(trace, trading_day='2026-03-26')
+
+        self.assertIsNotNone(near_miss)
+        assert near_miss is not None
+        self.assertEqual(near_miss.symbol, 'AAPL')
+        self.assertEqual(near_miss.first_failed_gate, 'confirmation')
+        self.assertEqual(near_miss.distance_score, Decimal('0.08'))
+        self.assertEqual(len(near_miss.thresholds), 1)

--- a/services/torghut/tests/test_search_profitability_frontier.py
+++ b/services/torghut/tests/test_search_profitability_frontier.py
@@ -171,6 +171,10 @@ class TestSearchProfitabilityFrontier(TestCase):
             ],
         )
 
+    def test_iter_parameter_candidates_rejects_scalar_sequence_values(self) -> None:
+        with self.assertRaisesRegex(ValueError, 'parameter_values_not_sequence:min_rank'):
+            iter_parameter_candidates({'min_rank': '0.55'})
+
     def test_iter_parameter_candidates_returns_single_empty_candidate_for_empty_grid(self) -> None:
         self.assertEqual(iter_parameter_candidates({}), [{}])
 
@@ -655,3 +659,37 @@ class TestSearchProfitabilityFrontier(TestCase):
 
         self.assertEqual(exit_code, 1)
         self.assertIn('sweep_config_parameters_not_mapping', stderr.getvalue())
+
+    def test_cli_main_reports_non_mapping_constraints(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            strategy_configmap = self._write_strategy_configmap(root)
+            sweep_config = root / 'sweep.yaml'
+            sweep_config.write_text(
+                yaml.safe_dump(
+                    {
+                        'schema_version': 'torghut.replay-frontier-sweep.v1',
+                        'family': 'breakout_continuation',
+                        'strategy_name': 'breakout-continuation-long-v1',
+                        'constraints': 'invalid',
+                        'parameters': {},
+                    }
+                ),
+                encoding='utf-8',
+            )
+            args = self._make_args(
+                strategy_configmap=strategy_configmap,
+                sweep_config=sweep_config,
+                json_output=root / 'frontier.json',
+            )
+            stderr = io.StringIO()
+            recent_days = tuple(date(2026, 3, 16) + timedelta(days=index) for index in range(10))
+            with (
+                patch('scripts.search_profitability_frontier._parse_args', return_value=args),
+                patch('scripts.search_profitability_frontier._resolve_recent_trading_days', return_value=recent_days),
+                redirect_stderr(stderr),
+            ):
+                exit_code = frontier.cli_main()
+
+        self.assertEqual(exit_code, 1)
+        self.assertIn('sweep_config_constraints_not_mapping', stderr.getvalue())

--- a/services/torghut/tests/test_search_profitability_frontier.py
+++ b/services/torghut/tests/test_search_profitability_frontier.py
@@ -1,18 +1,145 @@
 from __future__ import annotations
 
+import io
+import json
+from argparse import Namespace
+from contextlib import redirect_stderr, redirect_stdout
 from datetime import date, timedelta
+from pathlib import Path
+from tempfile import TemporaryDirectory
 from unittest import TestCase
+from unittest.mock import patch
 
 import yaml
 
-from scripts.search_profitability_frontier import (
-    apply_candidate_to_configmap,
-    iter_parameter_candidates,
-    resolve_sweep_window,
-)
+import scripts.search_profitability_frontier as frontier
+from scripts.search_profitability_frontier import apply_candidate_to_configmap, iter_parameter_candidates, resolve_sweep_window
 
 
 class TestSearchProfitabilityFrontier(TestCase):
+    def _write_strategy_configmap(self, root: Path) -> Path:
+        path = root / 'strategy-configmap.yaml'
+        path.write_text(
+            yaml.safe_dump(
+                {
+                    'apiVersion': 'v1',
+                    'kind': 'ConfigMap',
+                    'data': {
+                        'strategies.yaml': yaml.safe_dump(
+                            {
+                                'strategies': [
+                                    {
+                                        'name': 'breakout-continuation-long-v1',
+                                        'enabled': True,
+                                        'params': {
+                                            'min_cross_section_continuation_rank': '0.45',
+                                            'min_cross_section_continuation_breadth': '0.20',
+                                            'min_recent_above_opening_window_close_ratio': '0.55',
+                                            'min_recent_microprice_bias_bps': '0.05',
+                                        },
+                                    },
+                                    {
+                                        'name': 'late-day-continuation-long-v1',
+                                        'enabled': True,
+                                        'params': {'min_recent_microprice_bias_bps': '0.20'},
+                                    },
+                                ]
+                            },
+                            sort_keys=False,
+                        ),
+                    },
+                },
+                sort_keys=False,
+            ),
+            encoding='utf-8',
+        )
+        return path
+
+    def _write_sweep_config(
+        self,
+        root: Path,
+        *,
+        ranks: list[str],
+        hold_ratios: list[str] | None = None,
+    ) -> Path:
+        path = root / 'sweep.yaml'
+        path.write_text(
+            yaml.safe_dump(
+                {
+                    'schema_version': 'torghut.replay-frontier-sweep.v1',
+                    'family': 'breakout_continuation',
+                    'strategy_name': 'breakout-continuation-long-v1',
+                    'disable_other_strategies': True,
+                    'constraints': {
+                        'holdout_target_net_per_day': '250',
+                        'min_active_holdout_days': 3,
+                        'max_worst_holdout_day_loss': '150',
+                        'min_profit_factor': '1.5',
+                        'require_training_decisions': True,
+                        'require_holdout_decisions': True,
+                    },
+                    'parameters': {
+                        'min_cross_section_continuation_rank': ranks,
+                        'min_recent_above_opening_window_close_ratio': hold_ratios or ['0.55'],
+                    },
+                },
+                sort_keys=False,
+            ),
+            encoding='utf-8',
+        )
+        return path
+
+    @staticmethod
+    def _payload(
+        *,
+        start_date: str,
+        end_date: str,
+        daily_net: dict[str, str],
+        decision_count: int,
+        filled_count: int,
+        wins: int,
+        losses: int,
+    ) -> dict[str, object]:
+        return {
+            'start_date': start_date,
+            'end_date': end_date,
+            'net_pnl': str(sum(float(value) for value in daily_net.values())),
+            'decision_count': decision_count,
+            'filled_count': filled_count,
+            'wins': wins,
+            'losses': losses,
+            'daily': {
+                day: {
+                    'net_pnl': value,
+                    'filled_count': 1 if float(value) != 0 else 0,
+                }
+                for day, value in daily_net.items()
+            },
+        }
+
+    def _make_args(
+        self,
+        *,
+        strategy_configmap: Path,
+        sweep_config: Path,
+        json_output: Path,
+    ) -> Namespace:
+        return Namespace(
+            strategy_configmap=strategy_configmap,
+            sweep_config=sweep_config,
+            clickhouse_http_url='http://example.invalid:8123',
+            clickhouse_username='torghut',
+            clickhouse_password='secret',
+            start_equity='31590.02',
+            chunk_minutes=10,
+            symbols='',
+            progress_log_seconds=30,
+            train_days=5,
+            holdout_days=5,
+            top_n=10,
+            json_output=json_output,
+        )
+
     def test_resolve_sweep_window_uses_latest_train_and_holdout_days(self) -> None:
         days = [date(2026, 3, 2) + timedelta(days=index) for index in range(20)]
 
@@ -90,3 +217,244 @@ class TestSearchProfitabilityFrontier(TestCase):
             '0.75',
         )
         self.assertFalse(strategies['late-day-continuation-long-v1']['enabled'])
+
+    def test_resolve_recent_trading_days_uses_qualified_signal_query(self) -> None:
+        with patch('scripts.search_profitability_frontier._http_query', return_value='2026-03-27\n2026-03-26\n') as query:
+            days = frontier._resolve_recent_trading_days(
+                clickhouse_http_url='http://example.invalid:8123',
+                clickhouse_username='torghut',
+                clickhouse_password='secret',
+                limit=2,
+            )
+
+        self.assertEqual(days, (date(2026, 3, 26), date(2026, 3, 27)))
+        sql = query.call_args.kwargs['query']
+        self.assertIn('FROM torghut.ta_signals', sql)
+        self.assertIn("source = 'ta'", sql)
+        self.assertIn("window_size = 'PT1S'", sql)
+
+    def test_main_writes_frontier_json_and_stdout_payload(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            strategy_configmap = self._write_strategy_configmap(root)
+            sweep_config = self._write_sweep_config(root, ranks=['0.45', '0.55'])
+            json_output = root / 'frontier.json'
+            args = self._make_args(
+                strategy_configmap=strategy_configmap,
+                sweep_config=sweep_config,
+                json_output=json_output,
+            )
+            recent_days = tuple(date(2026, 3, 16) + timedelta(days=index) for index in range(10))
+
+            def fake_run_replay(config: object) -> dict[str, object]:
+                replay_config = config
+                configmap_path = Path(getattr(replay_config, 'strategy_configmap_path'))
+                payload = yaml.safe_load(configmap_path.read_text(encoding='utf-8'))
+                strategies = yaml.safe_load(payload['data']['strategies.yaml'])['strategies']
+                params = next(item['params'] for item in strategies if item['name'] == 'breakout-continuation-long-v1')
+                rank = str(params['min_cross_section_continuation_rank'])
+                start_date = str(getattr(replay_config, 'start_date'))
+                if start_date == '2026-03-16':
+                    return self._payload(
+                        start_date='2026-03-16',
+                        end_date='2026-03-20',
+                        daily_net={
+                            '2026-03-16': '0',
+                            '2026-03-17': '10',
+                            '2026-03-18': '0',
+                            '2026-03-19': '0',
+                            '2026-03-20': '0',
+                        },
+                        decision_count=2,
+                        filled_count=1,
+                        wins=1,
+                        losses=0,
+                    )
+                if rank == '0.45':
+                    return self._payload(
+                        start_date='2026-03-21',
+                        end_date='2026-03-25',
+                        daily_net={
+                            '2026-03-21': '0',
+                            '2026-03-22': '50',
+                            '2026-03-23': '0',
+                            '2026-03-24': '0',
+                            '2026-03-25': '0',
+                        },
+                        decision_count=2,
+                        filled_count=1,
+                        wins=1,
+                        losses=0,
+                    )
+                return self._payload(
+                    start_date='2026-03-21',
+                    end_date='2026-03-25',
+                    daily_net={
+                        '2026-03-21': '0',
+                        '2026-03-22': '400',
+                        '2026-03-23': '300',
+                        '2026-03-24': '350',
+                        '2026-03-25': '0',
+                    },
+                    decision_count=6,
+                    filled_count=3,
+                    wins=3,
+                    losses=0,
+                )
+
+            stdout = io.StringIO()
+            with (
+                patch('scripts.search_profitability_frontier._parse_args', return_value=args),
+                patch('scripts.search_profitability_frontier._resolve_recent_trading_days', return_value=recent_days),
+                patch('scripts.search_profitability_frontier.run_replay', side_effect=fake_run_replay),
+                redirect_stdout(stdout),
+            ):
+                exit_code = frontier.main()
+
+            self.assertEqual(exit_code, 0)
+            payload = json.loads(json_output.read_text(encoding='utf-8'))
+            stdout_payload = json.loads(stdout.getvalue())
+            self.assertEqual(payload, stdout_payload)
+            self.assertEqual(payload['schema_version'], 'torghut.replay-frontier-sweep.v1')
+            self.assertEqual(payload['family'], 'breakout_continuation')
+            self.assertEqual(payload['strategy_name'], 'breakout-continuation-long-v1')
+            self.assertEqual(
+                payload['window'],
+                {
+                    'train_days': ['2026-03-16', '2026-03-17', '2026-03-18', '2026-03-19', '2026-03-20'],
+                    'holdout_days': ['2026-03-21', '2026-03-22', '2026-03-23', '2026-03-24', '2026-03-25'],
+                },
+            )
+            self.assertEqual(payload['candidate_count'], 2)
+            self.assertGreaterEqual(len(payload['top']), 2)
+            top_scores = [float(item['score']) for item in payload['top']]
+            self.assertEqual(top_scores, sorted(top_scores, reverse=True))
+            self.assertEqual(
+                payload['top'][0]['replay_config']['params']['min_cross_section_continuation_rank'],
+                '0.55',
+            )
+
+    def test_main_ranks_three_candidates_deterministically(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            strategy_configmap = self._write_strategy_configmap(root)
+            sweep_config = self._write_sweep_config(root, ranks=['0.45', '0.55', '0.65'])
+            json_output = root / 'frontier.json'
+            args = self._make_args(
+                strategy_configmap=strategy_configmap,
+                sweep_config=sweep_config,
+                json_output=json_output,
+            )
+            recent_days = tuple(date(2026, 3, 16) + timedelta(days=index) for index in range(10))
+            holdout_payloads = {
+                '0.45': self._payload(
+                    start_date='2026-03-21',
+                    end_date='2026-03-25',
+                    daily_net={
+                        '2026-03-21': '0',
+                        '2026-03-22': '120',
+                        '2026-03-23': '0',
+                        '2026-03-24': '0',
+                        '2026-03-25': '0',
+                    },
+                    decision_count=2,
+                    filled_count=1,
+                    wins=1,
+                    losses=0,
+                ),
+                '0.55': self._payload(
+                    start_date='2026-03-21',
+                    end_date='2026-03-25',
+                    daily_net={
+                        '2026-03-21': '0',
+                        '2026-03-22': '300',
+                        '2026-03-23': '300',
+                        '2026-03-24': '0',
+                        '2026-03-25': '0',
+                    },
+                    decision_count=4,
+                    filled_count=2,
+                    wins=2,
+                    losses=0,
+                ),
+                '0.65': self._payload(
+                    start_date='2026-03-21',
+                    end_date='2026-03-25',
+                    daily_net={
+                        '2026-03-21': '0',
+                        '2026-03-22': '500',
+                        '2026-03-23': '500',
+                        '2026-03-24': '500',
+                        '2026-03-25': '0',
+                    },
+                    decision_count=6,
+                    filled_count=3,
+                    wins=3,
+                    losses=0,
+                ),
+            }
+
+            def fake_run_replay(config: object) -> dict[str, object]:
+                replay_config = config
+                configmap_path = Path(getattr(replay_config, 'strategy_configmap_path'))
+                payload = yaml.safe_load(configmap_path.read_text(encoding='utf-8'))
+                strategies = yaml.safe_load(payload['data']['strategies.yaml'])['strategies']
+                params = next(item['params'] for item in strategies if item['name'] == 'breakout-continuation-long-v1')
+                rank = str(params['min_cross_section_continuation_rank'])
+                start_date = str(getattr(replay_config, 'start_date'))
+                if start_date == '2026-03-16':
+                    return self._payload(
+                        start_date='2026-03-16',
+                        end_date='2026-03-20',
+                        daily_net={
+                            '2026-03-16': '0',
+                            '2026-03-17': '20',
+                            '2026-03-18': '0',
+                            '2026-03-19': '0',
+                            '2026-03-20': '0',
+                        },
+                        decision_count=2,
+                        filled_count=1,
+                        wins=1,
+                        losses=0,
+                    )
+                return holdout_payloads[rank]
+
+            with (
+                patch('scripts.search_profitability_frontier._parse_args', return_value=args),
+                patch('scripts.search_profitability_frontier._resolve_recent_trading_days', return_value=recent_days),
+                patch('scripts.search_profitability_frontier.run_replay', side_effect=fake_run_replay),
+                redirect_stdout(io.StringIO()),
+            ):
+                frontier.main()
+
+            payload = json.loads(json_output.read_text(encoding='utf-8'))
+            ranked = [
+                item['replay_config']['params']['min_cross_section_continuation_rank']
+                for item in payload['top'][:3]
+            ]
+            self.assertEqual(ranked, ['0.65', '0.55', '0.45'])
+
+    def test_cli_main_reports_insufficient_recent_days(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            strategy_configmap = self._write_strategy_configmap(root)
+            sweep_config = self._write_sweep_config(root, ranks=['0.45'])
+            args = self._make_args(
+                strategy_configmap=strategy_configmap,
+                sweep_config=sweep_config,
+                json_output=root / 'frontier.json',
+            )
+            stderr = io.StringIO()
+            with (
+                patch('scripts.search_profitability_frontier._parse_args', return_value=args),
+                patch(
+                    'scripts.search_profitability_frontier._resolve_recent_trading_days',
+                    return_value=tuple(date(2026, 3, 16) + timedelta(days=index) for index in range(9)),
+                ),
+                redirect_stderr(stderr),
+            ):
+                exit_code = frontier.cli_main()
+
+        self.assertEqual(exit_code, 1)
+        self.assertIn('insufficient_recent_trading_days:9<10', stderr.getvalue())

--- a/services/torghut/tests/test_search_profitability_frontier.py
+++ b/services/torghut/tests/test_search_profitability_frontier.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import io
 import json
+import sys
 from argparse import Namespace
 from contextlib import redirect_stderr, redirect_stdout
 from datetime import date, timedelta
@@ -170,6 +171,9 @@ class TestSearchProfitabilityFrontier(TestCase):
             ],
         )
 
+    def test_iter_parameter_candidates_returns_single_empty_candidate_for_empty_grid(self) -> None:
+        self.assertEqual(iter_parameter_candidates({}), [{}])
+
     def test_apply_candidate_to_configmap_updates_target_and_disables_others(self) -> None:
         configmap_payload = {
             'apiVersion': 'v1',
@@ -218,6 +222,94 @@ class TestSearchProfitabilityFrontier(TestCase):
         )
         self.assertFalse(strategies['late-day-continuation-long-v1']['enabled'])
 
+    def test_apply_candidate_to_configmap_coerces_non_mapping_params(self) -> None:
+        configmap_payload = {
+            'data': {
+                'strategies.yaml': yaml.safe_dump(
+                    {
+                        'strategies': [
+                            {
+                                'name': 'breakout-continuation-long-v1',
+                                'enabled': True,
+                                'params': ['not-a-mapping'],
+                            }
+                        ]
+                    },
+                    sort_keys=False,
+                )
+            }
+        }
+
+        updated = apply_candidate_to_configmap(
+            configmap_payload=configmap_payload,
+            strategy_name='breakout-continuation-long-v1',
+            candidate_params={'min_cross_section_continuation_rank': '0.65'},
+            disable_other_strategies=False,
+        )
+
+        catalog = yaml.safe_load(updated['data']['strategies.yaml'])
+        strategy = catalog['strategies'][0]
+        self.assertEqual(strategy['params'], {'min_cross_section_continuation_rank': '0.65'})
+
+    def test_apply_candidate_to_configmap_raises_for_missing_strategy(self) -> None:
+        with self.assertRaisesRegex(ValueError, 'strategy_not_found:missing'):
+            apply_candidate_to_configmap(
+                configmap_payload={
+                    'data': {
+                        'strategies.yaml': yaml.safe_dump({'strategies': []}, sort_keys=False),
+                    }
+                },
+                strategy_name='missing',
+                candidate_params={},
+                disable_other_strategies=False,
+            )
+
+    def test_apply_candidate_to_configmap_rejects_invalid_shapes(self) -> None:
+        with self.assertRaisesRegex(ValueError, 'strategy_configmap_missing_data'):
+            apply_candidate_to_configmap(
+                configmap_payload={},
+                strategy_name='breakout-continuation-long-v1',
+                candidate_params={},
+                disable_other_strategies=False,
+            )
+        with self.assertRaisesRegex(ValueError, 'strategy_configmap_missing_strategies_yaml'):
+            apply_candidate_to_configmap(
+                configmap_payload={'data': {}},
+                strategy_name='breakout-continuation-long-v1',
+                candidate_params={},
+                disable_other_strategies=False,
+            )
+        with self.assertRaisesRegex(ValueError, 'strategy_catalog_not_mapping'):
+            apply_candidate_to_configmap(
+                configmap_payload={'data': {'strategies.yaml': yaml.safe_dump(['bad'], sort_keys=False)}},
+                strategy_name='breakout-continuation-long-v1',
+                candidate_params={},
+                disable_other_strategies=False,
+            )
+        with self.assertRaisesRegex(ValueError, 'strategy_catalog_missing_strategies'):
+            apply_candidate_to_configmap(
+                configmap_payload={'data': {'strategies.yaml': yaml.safe_dump({}, sort_keys=False)}},
+                strategy_name='breakout-continuation-long-v1',
+                candidate_params={},
+                disable_other_strategies=False,
+            )
+
+    def test_parse_args_uses_frontier_defaults(self) -> None:
+        with patch.object(sys, 'argv', ['search_profitability_frontier.py']):
+            args = frontier._parse_args()
+
+        self.assertEqual(args.clickhouse_http_url, 'http://torghut-clickhouse.torghut.svc.cluster.local:8123')
+        self.assertEqual(args.clickhouse_username, 'torghut')
+        self.assertEqual(args.clickhouse_password, '')
+        self.assertEqual(args.start_equity, '31590.02')
+        self.assertEqual(args.chunk_minutes, 10)
+        self.assertEqual(args.symbols, '')
+        self.assertEqual(args.progress_log_seconds, 30)
+        self.assertEqual(args.train_days, 10)
+        self.assertEqual(args.holdout_days, 5)
+        self.assertEqual(args.top_n, 10)
+        self.assertIsNone(args.json_output)
+
     def test_resolve_recent_trading_days_uses_qualified_signal_query(self) -> None:
         with patch('scripts.search_profitability_frontier._http_query', return_value='2026-03-27\n2026-03-26\n') as query:
             days = frontier._resolve_recent_trading_days(
@@ -232,6 +324,22 @@ class TestSearchProfitabilityFrontier(TestCase):
         self.assertIn('FROM torghut.ta_signals', sql)
         self.assertIn("source = 'ta'", sql)
         self.assertIn("window_size = 'PT1S'", sql)
+
+    def test_load_sweep_config_rejects_non_mapping_payload(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / 'invalid-sweep.yaml'
+            path.write_text('- nope\n', encoding='utf-8')
+
+            with self.assertRaisesRegex(ValueError, 'sweep_config_not_mapping'):
+                frontier._load_sweep_config(path)
+
+    def test_load_sweep_config_rejects_invalid_schema(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / 'invalid-sweep.yaml'
+            path.write_text(yaml.safe_dump({'schema_version': 'wrong'}), encoding='utf-8')
+
+            with self.assertRaisesRegex(ValueError, 'sweep_config_schema_version_invalid:wrong'):
+                frontier._load_sweep_config(path)
 
     def test_main_writes_frontier_json_and_stdout_payload(self) -> None:
         with TemporaryDirectory() as tmpdir:
@@ -458,3 +566,92 @@ class TestSearchProfitabilityFrontier(TestCase):
 
         self.assertEqual(exit_code, 1)
         self.assertIn('insufficient_recent_trading_days:9<10', stderr.getvalue())
+
+    def test_cli_main_reports_invalid_base_configmap_shape(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            strategy_configmap = root / 'strategy-configmap.yaml'
+            strategy_configmap.write_text('- invalid\n', encoding='utf-8')
+            sweep_config = self._write_sweep_config(root, ranks=['0.45'])
+            args = self._make_args(
+                strategy_configmap=strategy_configmap,
+                sweep_config=sweep_config,
+                json_output=root / 'frontier.json',
+            )
+            stderr = io.StringIO()
+            recent_days = tuple(date(2026, 3, 16) + timedelta(days=index) for index in range(10))
+            with (
+                patch('scripts.search_profitability_frontier._parse_args', return_value=args),
+                patch('scripts.search_profitability_frontier._resolve_recent_trading_days', return_value=recent_days),
+                redirect_stderr(stderr),
+            ):
+                exit_code = frontier.cli_main()
+
+        self.assertEqual(exit_code, 1)
+        self.assertIn('base_strategy_configmap_not_mapping', stderr.getvalue())
+
+    def test_cli_main_reports_missing_family_or_strategy_name(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            strategy_configmap = self._write_strategy_configmap(root)
+            sweep_config = root / 'sweep.yaml'
+            sweep_config.write_text(
+                yaml.safe_dump(
+                    {
+                        'schema_version': 'torghut.replay-frontier-sweep.v1',
+                        'family': '',
+                        'strategy_name': '',
+                        'parameters': {},
+                    }
+                ),
+                encoding='utf-8',
+            )
+            args = self._make_args(
+                strategy_configmap=strategy_configmap,
+                sweep_config=sweep_config,
+                json_output=root / 'frontier.json',
+            )
+            stderr = io.StringIO()
+            recent_days = tuple(date(2026, 3, 16) + timedelta(days=index) for index in range(10))
+            with (
+                patch('scripts.search_profitability_frontier._parse_args', return_value=args),
+                patch('scripts.search_profitability_frontier._resolve_recent_trading_days', return_value=recent_days),
+                redirect_stderr(stderr),
+            ):
+                exit_code = frontier.cli_main()
+
+        self.assertEqual(exit_code, 1)
+        self.assertIn('sweep_config_missing_family_or_strategy_name', stderr.getvalue())
+
+    def test_cli_main_reports_non_mapping_parameter_grid(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            strategy_configmap = self._write_strategy_configmap(root)
+            sweep_config = root / 'sweep.yaml'
+            sweep_config.write_text(
+                yaml.safe_dump(
+                    {
+                        'schema_version': 'torghut.replay-frontier-sweep.v1',
+                        'family': 'breakout_continuation',
+                        'strategy_name': 'breakout-continuation-long-v1',
+                        'parameters': ['not-a-mapping'],
+                    }
+                ),
+                encoding='utf-8',
+            )
+            args = self._make_args(
+                strategy_configmap=strategy_configmap,
+                sweep_config=sweep_config,
+                json_output=root / 'frontier.json',
+            )
+            stderr = io.StringIO()
+            recent_days = tuple(date(2026, 3, 16) + timedelta(days=index) for index in range(10))
+            with (
+                patch('scripts.search_profitability_frontier._parse_args', return_value=args),
+                patch('scripts.search_profitability_frontier._resolve_recent_trading_days', return_value=recent_days),
+                redirect_stderr(stderr),
+            ):
+                exit_code = frontier.cli_main()
+
+        self.assertEqual(exit_code, 1)
+        self.assertIn('sweep_config_parameters_not_mapping', stderr.getvalue())

--- a/services/torghut/tests/test_search_profitability_frontier.py
+++ b/services/torghut/tests/test_search_profitability_frontier.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from datetime import date, timedelta
+from unittest import TestCase
+
+import yaml
+
+from scripts.search_profitability_frontier import (
+    apply_candidate_to_configmap,
+    iter_parameter_candidates,
+    resolve_sweep_window,
+)
+
+
+class TestSearchProfitabilityFrontier(TestCase):
+    def test_resolve_sweep_window_uses_latest_train_and_holdout_days(self) -> None:
+        days = [date(2026, 3, 2) + timedelta(days=index) for index in range(20)]
+
+        window = resolve_sweep_window(days, train_days=10, holdout_days=5)
+
+        self.assertEqual(len(window.train_days), 10)
+        self.assertEqual(len(window.holdout_days), 5)
+        self.assertEqual(window.train_days[0], days[5])
+        self.assertEqual(window.train_days[-1], days[14])
+        self.assertEqual(window.holdout_days[0], days[15])
+        self.assertEqual(window.holdout_days[-1], days[19])
+
+    def test_iter_parameter_candidates_is_deterministic(self) -> None:
+        candidates = iter_parameter_candidates(
+            {
+                'min_rank': ['0.4', '0.5'],
+                'min_hold_ratio': ['0.6', '0.7'],
+            }
+        )
+
+        self.assertEqual(
+            candidates,
+            [
+                {'min_rank': '0.4', 'min_hold_ratio': '0.6'},
+                {'min_rank': '0.4', 'min_hold_ratio': '0.7'},
+                {'min_rank': '0.5', 'min_hold_ratio': '0.6'},
+                {'min_rank': '0.5', 'min_hold_ratio': '0.7'},
+            ],
+        )
+
+    def test_apply_candidate_to_configmap_updates_target_and_disables_others(self) -> None:
+        configmap_payload = {
+            'apiVersion': 'v1',
+            'kind': 'ConfigMap',
+            'data': {
+                'strategies.yaml': yaml.safe_dump(
+                    {
+                        'strategies': [
+                            {
+                                'name': 'breakout-continuation-long-v1',
+                                'enabled': False,
+                                'params': {'min_cross_section_continuation_rank': '0.55'},
+                            },
+                            {
+                                'name': 'late-day-continuation-long-v1',
+                                'enabled': True,
+                                'params': {'min_recent_microprice_bias_bps': '0.20'},
+                            },
+                        ]
+                    },
+                    sort_keys=False,
+                )
+            },
+        }
+
+        updated = apply_candidate_to_configmap(
+            configmap_payload=configmap_payload,
+            strategy_name='breakout-continuation-long-v1',
+            candidate_params={
+                'min_cross_section_continuation_rank': '0.65',
+                'min_recent_above_opening_window_close_ratio': '0.75',
+            },
+            disable_other_strategies=True,
+        )
+
+        catalog = yaml.safe_load(updated['data']['strategies.yaml'])
+        strategies = {item['name']: item for item in catalog['strategies']}
+        self.assertTrue(strategies['breakout-continuation-long-v1']['enabled'])
+        self.assertEqual(
+            strategies['breakout-continuation-long-v1']['params']['min_cross_section_continuation_rank'],
+            '0.65',
+        )
+        self.assertEqual(
+            strategies['breakout-continuation-long-v1']['params']['min_recent_above_opening_window_close_ratio'],
+            '0.75',
+        )
+        self.assertFalse(strategies['late-day-continuation-long-v1']['enabled'])

--- a/services/torghut/tests/test_strategy_runtime.py
+++ b/services/torghut/tests/test_strategy_runtime.py
@@ -240,6 +240,48 @@ class TestStrategyRuntime(TestCase):
         self.assertEqual(decision.intent.action, "buy")
         self.assertIn("tsmom_trend_up", decision.intent.rationale)
 
+    def test_runtime_decision_metadata_includes_trace_when_enabled(self) -> None:
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="intraday-tsmom-trace",
+            description="version=1.0.0",
+            enabled=True,
+            base_timeframe="1Min",
+            universe_type="intraday_tsmom_v1",
+            universe_symbols=["NVDA"],
+            max_position_pct_equity=Decimal("0.02"),
+            max_notional_per_trade=Decimal("2500"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 2, 10, tzinfo=timezone.utc),
+            symbol="NVDA",
+            timeframe="1Min",
+            seq=7,
+            payload={
+                "price": 140.25,
+                "ema12": 140.40,
+                "ema26": 139.95,
+                "macd": 0.45,
+                "macd_signal": 0.30,
+                "rsi14": 56,
+                "vol_realized_w60s": 0.009,
+            },
+        )
+        feature_contract = normalize_feature_vector_v3(signal)
+        runtime = StrategyRuntime(trace_enabled=True)
+
+        decision = runtime.evaluate(strategy, feature_contract, timeframe="1Min")
+
+        self.assertIsNotNone(decision)
+        assert decision is not None
+        self.assertIsNotNone(decision.trace)
+        metadata = decision.metadata()
+        self.assertIn("strategy_trace", metadata)
+        strategy_trace = metadata["strategy_trace"]
+        assert isinstance(strategy_trace, dict)
+        self.assertEqual(strategy_trace["strategy_id"], str(strategy.id))
+        self.assertTrue(strategy_trace["passed"])
+
     def test_intraday_tsmom_plugin_skips_buy_outside_entry_window(self) -> None:
         strategy = Strategy(
             id=uuid.uuid4(),


### PR DESCRIPTION
## Summary

- Gate runtime trace capture in `local_intraday_tsmom_replay.py` behind an explicit `capture_traces` path, including a new CLI flag and compatibility fallback for trace output.
- Add `search_profitability_frontier` input validation for `constraints` shape and non-sequence parameter sweep values to avoid silent misconfiguration and runtime attribute errors.
- Extend Torghut tests to cover the new validation paths and maintain trace-related behavior in diagnostic replay output.

## Related Issues

Closes #4808

## Testing

- `uv sync --frozen --extra dev` (services/torghut)
- `cd services/torghut && uv run --frozen pytest tests/test_local_intraday_tsmom_replay.py tests/test_search_profitability_frontier.py`
  - Result: `40 passed`

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
