### PR TITLE
chore(jangar): promote image 92fbb178

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: e76afa97
-  digest: sha256:35f67c14d8d80b8cde6e9922707415b88ed13e438a6040fdd4621f224455c97f
+  tag: 92fbb178
+  digest: sha256:3d24f8b5de3c35703c66b954be6e486ed139b62e2fb5550cb2198e237b8f9777
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: e76afa97
-    digest: sha256:d70a72b93b7ab70fa9eef5b2d7dc629feff0b85bc90fe7ff2852ee0603cad463
+    tag: 92fbb178
+    digest: sha256:2d25226424b01c678cf1a993368d57b7a38fb1a19850f9aa199029c91df38251
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: e76afa97
-    digest: sha256:35f67c14d8d80b8cde6e9922707415b88ed13e438a6040fdd4621f224455c97f
+    tag: 92fbb178
+    digest: sha256:3d24f8b5de3c35703c66b954be6e486ed139b62e2fb5550cb2198e237b8f9777
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-04-08T07:52:20Z"
+    deploy.knative.dev/rollout: "2026-04-08T15:41:31Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-04-08T07:52:20Z"
+        kubectl.kubernetes.io/restartedAt: "2026-04-08T15:41:31Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -62,5 +62,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "e76afa97"
-    digest: sha256:35f67c14d8d80b8cde6e9922707415b88ed13e438a6040fdd4621f224455c97f
+    newTag: "92fbb178"
+    digest: sha256:3d24f8b5de3c35703c66b954be6e486ed139b62e2fb5550cb2198e237b8f9777


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `92fbb1786d69cb1b104b3c931b7c4638e61ec692`
- Image tag: `92fbb178`
- Image digest: `sha256:3d24f8b5de3c35703c66b954be6e486ed139b62e2fb5550cb2198e237b8f9777`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`