### PR TITLE
chore(torghut): promote image 92fbb178

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:2e62f5ce5e15823cb6b804e2de0c381f54708564f5a455cb5cd8de5788c8ba7c
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:e9c14e947c78c8f6da9d3ec11d50404f7a316987a283f43148e605ea56a03e6c
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -63,9 +63,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.566.0-215-gd1088a2b0
+              value: v0.566.0-262-g92fbb1786
             - name: TORGHUT_OPTIONS_COMMIT
-              value: d1088a2b007f208350651ad7a9b34291211b17e6
+              value: 92fbb1786d69cb1b104b3c931b7c4638e61ec692
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:2e62f5ce5e15823cb6b804e2de0c381f54708564f5a455cb5cd8de5788c8ba7c
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:e9c14e947c78c8f6da9d3ec11d50404f7a316987a283f43148e605ea56a03e6c
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -63,9 +63,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.566.0-215-gd1088a2b0
+              value: v0.566.0-262-g92fbb1786
             - name: TORGHUT_OPTIONS_COMMIT
-              value: d1088a2b007f208350651ad7a9b34291211b17e6
+              value: 92fbb1786d69cb1b104b3c931b7c4638e61ec692
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -40,7 +40,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:2e62f5ce5e15823cb6b804e2de0c381f54708564f5a455cb5cd8de5788c8ba7c
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:e9c14e947c78c8f6da9d3ec11d50404f7a316987a283f43148e605ea56a03e6c
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -21,7 +21,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:2e62f5ce5e15823cb6b804e2de0c381f54708564f5a455cb5cd8de5788c8ba7c
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:e9c14e947c78c8f6da9d3ec11d50404f7a316987a283f43148e605ea56a03e6c
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -32,7 +32,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:2e62f5ce5e15823cb6b804e2de0c381f54708564f5a455cb5cd8de5788c8ba7c
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:e9c14e947c78c8f6da9d3ec11d50404f7a316987a283f43148e605ea56a03e6c
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -30,7 +30,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:2e62f5ce5e15823cb6b804e2de0c381f54708564f5a455cb5cd8de5788c8ba7c
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:e9c14e947c78c8f6da9d3ec11d50404f7a316987a283f43148e605ea56a03e6c
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:2e62f5ce5e15823cb6b804e2de0c381f54708564f5a455cb5cd8de5788c8ba7c
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:e9c14e947c78c8f6da9d3ec11d50404f7a316987a283f43148e605ea56a03e6c
           command:
             - /opt/venv/bin/alembic
           args:

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -13,7 +13,7 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:2e62f5ce5e15823cb6b804e2de0c381f54708564f5a455cb5cd8de5788c8ba7c
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:e9c14e947c78c8f6da9d3ec11d50404f7a316987a283f43148e605ea56a03e6c
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -21,7 +21,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:2e62f5ce5e15823cb6b804e2de0c381f54708564f5a455cb5cd8de5788c8ba7c
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:e9c14e947c78c8f6da9d3ec11d50404f7a316987a283f43148e605ea56a03e6c
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -39,7 +39,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:2e62f5ce5e15823cb6b804e2de0c381f54708564f5a455cb5cd8de5788c8ba7c
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:e9c14e947c78c8f6da9d3ec11d50404f7a316987a283f43148e605ea56a03e6c
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-04-07T16:41:13Z"
+        client.knative.dev/updateTimestamp: "2026-04-08T15:41:32Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:2e62f5ce5e15823cb6b804e2de0c381f54708564f5a455cb5cd8de5788c8ba7c
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:e9c14e947c78c8f6da9d3ec11d50404f7a316987a283f43148e605ea56a03e6c
           ports:
             - name: http1
               containerPort: 8181
@@ -495,9 +495,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.566.0-215-gd1088a2b0
+              value: v0.566.0-262-g92fbb1786
             - name: TORGHUT_COMMIT
-              value: d1088a2b007f208350651ad7a9b34291211b17e6
+              value: 92fbb1786d69cb1b104b3c931b7c4638e61ec692
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-04-07T16:41:13Z"
+        client.knative.dev/updateTimestamp: "2026-04-08T15:41:32Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -26,7 +26,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:2e62f5ce5e15823cb6b804e2de0c381f54708564f5a455cb5cd8de5788c8ba7c
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:e9c14e947c78c8f6da9d3ec11d50404f7a316987a283f43148e605ea56a03e6c
           ports:
             - name: http1
               containerPort: 8181
@@ -276,9 +276,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.566.0-215-gd1088a2b0
+              value: v0.566.0-262-g92fbb1786
             - name: TORGHUT_COMMIT
-              value: d1088a2b007f208350651ad7a9b34291211b17e6
+              value: 92fbb1786d69cb1b104b3c931b7c4638e61ec692
           livenessProbe:
             httpGet:
               path: /healthz


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `92fbb1786d69cb1b104b3c931b7c4638e61ec692`
- Image tag: `92fbb178`
- Image digest: `sha256:e9c14e947c78c8f6da9d3ec11d50404f7a316987a283f43148e605ea56a03e6c`