### PR TITLE
chore(jangar): promote image 70844912

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 92fbb178
-  digest: sha256:3d24f8b5de3c35703c66b954be6e486ed139b62e2fb5550cb2198e237b8f9777
+  tag: "70844912"
+  digest: sha256:722e584172fcfd8243ae87c486f4517493cea8cb6ea88fe8502c7a7e5a2b6b3b
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 92fbb178
-    digest: sha256:2d25226424b01c678cf1a993368d57b7a38fb1a19850f9aa199029c91df38251
+    tag: "70844912"
+    digest: sha256:f7565659665417c17ef6032eabad9d3e3adfee183eed552da2631fb162056908
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 92fbb178
-    digest: sha256:3d24f8b5de3c35703c66b954be6e486ed139b62e2fb5550cb2198e237b8f9777
+    tag: "70844912"
+    digest: sha256:722e584172fcfd8243ae87c486f4517493cea8cb6ea88fe8502c7a7e5a2b6b3b
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-04-08T15:41:31Z"
+    deploy.knative.dev/rollout: "2026-04-10T01:58:07Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-04-08T15:41:31Z"
+        kubectl.kubernetes.io/restartedAt: "2026-04-10T01:58:07Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -62,5 +62,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "92fbb178"
-    digest: sha256:3d24f8b5de3c35703c66b954be6e486ed139b62e2fb5550cb2198e237b8f9777
+    newTag: "70844912"
+    digest: sha256:722e584172fcfd8243ae87c486f4517493cea8cb6ea88fe8502c7a7e5a2b6b3b


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `708449122ccb06128b5f10e5a5b5c988760f93f4`
- Image tag: `70844912`
- Image digest: `sha256:722e584172fcfd8243ae87c486f4517493cea8cb6ea88fe8502c7a7e5a2b6b3b`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`