### PR TITLE
chore(jangar): promote image 24533eea

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: "70844912"
-  digest: sha256:722e584172fcfd8243ae87c486f4517493cea8cb6ea88fe8502c7a7e5a2b6b3b
+  tag: 24533eea
+  digest: sha256:79aef9cf07c140d80fcde2276f3ff781d95800f59f8d9154cc9200ff056c1412
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: "70844912"
-    digest: sha256:f7565659665417c17ef6032eabad9d3e3adfee183eed552da2631fb162056908
+    tag: 24533eea
+    digest: sha256:97b3b2caaeec82c23135defec70829cb81852fbf4435c1a19dee8267da02db1f
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: "70844912"
-    digest: sha256:722e584172fcfd8243ae87c486f4517493cea8cb6ea88fe8502c7a7e5a2b6b3b
+    tag: 24533eea
+    digest: sha256:79aef9cf07c140d80fcde2276f3ff781d95800f59f8d9154cc9200ff056c1412
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-04-10T01:58:07Z"
+    deploy.knative.dev/rollout: "2026-04-10T02:43:01Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-04-10T01:58:07Z"
+        kubectl.kubernetes.io/restartedAt: "2026-04-10T02:43:01Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -62,5 +62,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "70844912"
-    digest: sha256:722e584172fcfd8243ae87c486f4517493cea8cb6ea88fe8502c7a7e5a2b6b3b
+    newTag: "24533eea"
+    digest: sha256:79aef9cf07c140d80fcde2276f3ff781d95800f59f8d9154cc9200ff056c1412


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `24533eea01b0bfa89a3bb4677d8c1fcd6daf3f47`
- Image tag: `24533eea`
- Image digest: `sha256:79aef9cf07c140d80fcde2276f3ff781d95800f59f8d9154cc9200ff056c1412`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`