### PR TITLE
fix(jangar): resolve client shell path in bundle

### DIFF
--- a/services/jangar/src/server/__tests__/app.test.ts
+++ b/services/jangar/src/server/__tests__/app.test.ts
@@ -25,7 +25,7 @@ vi.mock('~/server/terminal-pty-manager', () => ({
   resetTerminalPtyManager: vi.fn(),
 }))
 
-import { createJangarRuntime } from '../app'
+import { createJangarRuntime, getClientOutputDirCandidates } from '../app'
 
 const clientDir = fileURLToPath(new URL('../../../.output/public/', import.meta.url))
 const indexPath = resolve(clientDir, 'index.html')
@@ -75,6 +75,15 @@ const withTempFile = async (path: string, contents: string) => {
 }
 
 describe('createJangarRuntime client serving', () => {
+  it('finds the client output directory for bundled server chunks', () => {
+    const candidates = getClientOutputDirCandidates({
+      cwd: '/tmp/jangar-test-cwd',
+      moduleUrl: 'file:///app/services/jangar/.output/server/chunks/app-123.mjs',
+    })
+
+    expect(candidates).toContain('/app/services/jangar/.output/public')
+  })
+
   it('serves the client shell for SPA routes but not API namespaces', async () => {
     const restoreIndex = await withTempFile(indexPath, clientIndexHtml)
 

--- a/services/jangar/src/server/app.ts
+++ b/services/jangar/src/server/app.ts
@@ -105,7 +105,21 @@ const hasRegularFile = async (path: string) => {
   }
 }
 
-const getClientOutputDir = () => resolve(fileURLToPath(new URL('../../.output/public/', import.meta.url)))
+export const getClientOutputDirCandidates = ({
+  cwd = process.cwd(),
+  moduleUrl = import.meta.url,
+}: {
+  cwd?: string
+  moduleUrl?: string
+} = {}) =>
+  Array.from(
+    new Set([
+      resolve(cwd, '.output/public'),
+      resolve(fileURLToPath(new URL('../../.output/public/', moduleUrl))),
+      resolve(fileURLToPath(new URL('../public/', moduleUrl))),
+      resolve(fileURLToPath(new URL('../../public/', moduleUrl))),
+    ]),
+  )
 
 const isPathInsideDirectory = (rootDir: string, targetPath: string) => {
   const relativePath = relative(rootDir, targetPath)
@@ -126,8 +140,16 @@ const shouldServeClientPath = (pathname: string, serverRouteRoots: ReadonlySet<s
   return firstSegment === null || !serverRouteRoots.has(firstSegment)
 }
 
+const resolveClientIndexPath = async () => {
+  for (const clientDir of getClientOutputDirCandidates()) {
+    const indexPath = resolve(clientDir, 'index.html')
+    if (await hasRegularFile(indexPath)) return indexPath
+  }
+
+  return null
+}
+
 const resolveStaticFile = async (pathname: string) => {
-  const clientDir = getClientOutputDir()
   let decodedPath: string
   try {
     decodedPath = decodeURIComponent(pathname)
@@ -135,14 +157,17 @@ const resolveStaticFile = async (pathname: string) => {
     return null
   }
 
-  if (decodedPath === '/') {
-    const indexPath = resolve(clientDir, 'index.html')
-    return (await hasRegularFile(indexPath)) ? indexPath : null
-  }
+  for (const clientDir of getClientOutputDirCandidates()) {
+    if (decodedPath === '/') {
+      const indexPath = resolve(clientDir, 'index.html')
+      if (await hasRegularFile(indexPath)) return indexPath
+      continue
+    }
 
-  const target = resolve(clientDir, `.${decodedPath}`)
-  if (!isPathInsideDirectory(clientDir, target)) return null
-  if (await hasRegularFile(target)) return target
+    const target = resolve(clientDir, `.${decodedPath}`)
+    if (!isPathInsideDirectory(clientDir, target)) continue
+    if (await hasRegularFile(target)) return target
+  }
 
   return null
 }
@@ -157,8 +182,8 @@ const serveClientResponse = async (request: Request) => {
     })
   }
 
-  const indexPath = resolve(getClientOutputDir(), 'index.html')
-  if (!(await hasRegularFile(indexPath))) {
+  const indexPath = await resolveClientIndexPath()
+  if (!indexPath) {
     return new Response('Client build output missing. Run `bun run build` for services/jangar.', { status: 503 })
   }
 


### PR DESCRIPTION
## Summary

- fix the production SPA root path so bundled server chunks still resolve the Vite client output directory
- add a regression test that models the `.output/server/chunks/...` runtime layout that broke `/`
- keep the typed-config tranche roll-forward intact while repairing the rollout blocker discovered during production verification

## Related Issues

None

## Testing

- `cd services/jangar && bunx vitest run --config vitest.config.ts src/server/__tests__/app.test.ts src/server/__tests__/runtime-validation.test.ts`
- `cd services/jangar && bunx tsc --noEmit -p tsconfig.app.json`
- `cd services/jangar && bun run build`
- `cd services/jangar && PORT=4010 JANGAR_OPENWEBUI_RICH_RENDER_ENABLED=0 bun .output/server/index.mjs` then `curl http://127.0.0.1:4010/`, `/health`, and `/openai/v1/models`
- `cd services/jangar && bun run docs:inventory:write && bun run docs:inventory:check`
- `cd services/jangar && bun run test`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
