### PR TITLE
chore(jangar): promote image 8837399a

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 24533eea
-  digest: sha256:79aef9cf07c140d80fcde2276f3ff781d95800f59f8d9154cc9200ff056c1412
+  tag: 8837399a
+  digest: sha256:1e8c30278f5bc00cb637ab52553b59950502d85f9407c88e38893193ad77c654
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 24533eea
-    digest: sha256:97b3b2caaeec82c23135defec70829cb81852fbf4435c1a19dee8267da02db1f
+    tag: 8837399a
+    digest: sha256:3eccce345de2ab5da8c815b99fc6a56fd084c2bc7db2f0ca534f0d09276990a8
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 24533eea
-    digest: sha256:79aef9cf07c140d80fcde2276f3ff781d95800f59f8d9154cc9200ff056c1412
+    tag: 8837399a
+    digest: sha256:1e8c30278f5bc00cb637ab52553b59950502d85f9407c88e38893193ad77c654
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-04-10T02:43:01Z"
+    deploy.knative.dev/rollout: "2026-04-10T03:11:20Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-04-10T02:43:01Z"
+        kubectl.kubernetes.io/restartedAt: "2026-04-10T03:11:20Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -62,5 +62,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "24533eea"
-    digest: sha256:79aef9cf07c140d80fcde2276f3ff781d95800f59f8d9154cc9200ff056c1412
+    newTag: "8837399a"
+    digest: sha256:1e8c30278f5bc00cb637ab52553b59950502d85f9407c88e38893193ad77c654


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `8837399a1fc4d7d26fa89ac242acbda52b92913b`
- Image tag: `8837399a`
- Image digest: `sha256:1e8c30278f5bc00cb637ab52553b59950502d85f9407c88e38893193ad77c654`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`