### PR TITLE
chore(jangar): promote image d929a82e

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: bbb0fc32
-  digest: sha256:9494852f4efbbaba70bbfcd716da48086604a7c253092b8ef47b9f2edcd845c2
+  tag: d929a82e
+  digest: sha256:22d72b8132fe59f1aba358d073174d9f5730bccb724b0a4daf035ae293129f05
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: bbb0fc32
-    digest: sha256:8d082b562baa8bc3f75ac0fbe45afedbca40edfaaab12278aeb4a09eaaad1f11
+    tag: d929a82e
+    digest: sha256:f02100119986fa960b85995b3121dff5252ce5fea827cf3689a5d0e50c105cee
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: bbb0fc32
-    digest: sha256:9494852f4efbbaba70bbfcd716da48086604a7c253092b8ef47b9f2edcd845c2
+    tag: d929a82e
+    digest: sha256:22d72b8132fe59f1aba358d073174d9f5730bccb724b0a4daf035ae293129f05
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-04-10T04:13:02Z"
+    deploy.knative.dev/rollout: "2026-04-10T06:36:10Z"
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-04-10T04:13:02Z"
+        kubectl.kubernetes.io/restartedAt: "2026-04-10T06:36:10Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -62,5 +62,5 @@ helmCharts:
 
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "bbb0fc32"
-    digest: sha256:9494852f4efbbaba70bbfcd716da48086604a7c253092b8ef47b9f2edcd845c2
+    newTag: "d929a82e"
+    digest: sha256:22d72b8132fe59f1aba358d073174d9f5730bccb724b0a4daf035ae293129f05


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `d929a82e5b56b0a544616b8763913e11b886f54c`
- Image tag: `d929a82e`
- Image digest: `sha256:22d72b8132fe59f1aba358d073174d9f5730bccb724b0a4daf035ae293129f05`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`