### PR TITLE
feat(torghut): start runtime parity promotion safeguards

### DIFF
--- a/services/torghut/app/trading/discovery/autoresearch_notebooks.py
+++ b/services/torghut/app/trading/discovery/autoresearch_notebooks.py
@@ -195,7 +195,9 @@ def build_strategy_discovery_history_notebook(run_root: Path) -> dict[str, Any]:
         _markdown_cell(
             '# Strategy Discovery History\n\n'
             'This notebook shows the autoresearch loop over time: which candidates were kept, '
-            'how the frontier improved, and where concentration or inactivity still remains.'
+            'how the frontier improved, and where concentration or inactivity still remains.\n\n'
+            '> Results in this notebook are research candidates only. They are not promotable until '
+            'the same family passes runtime parity, scheduler-v3 approval replay, and shadow validation.'
         ),
         _code_cell(_shared_loader_code(run_root)),
         _code_cell(
@@ -208,6 +210,28 @@ _display_rows(objective_rows, columns=['metric', 'target'])
 best = SUMMARY.get('best_candidate') or {}
 display(Markdown('## Best Candidate Summary'))
 _display_rows([best])
+
+promotion = SUMMARY.get('promotion_readiness') or {}
+if promotion:
+    display(Markdown('## Promotion Guardrail'))
+    _display_rows(
+        [
+            {
+                'candidate_id': promotion.get('candidate_id'),
+                'family_template_id': promotion.get('family_template_id'),
+                'status': promotion.get('status'),
+                'stage': promotion.get('stage'),
+                'promotable': promotion.get('promotable'),
+                'runtime_family': promotion.get('runtime_family'),
+                'runtime_strategy_name': promotion.get('runtime_strategy_name'),
+                'reason': promotion.get('reason'),
+            }
+        ]
+    )
+    blockers = promotion.get('blockers') or []
+    if blockers:
+        display(Markdown('### Missing Promotion Evidence'))
+        _display_rows([{'blocker': blocker} for blocker in blockers], columns=['blocker'])
 """
         ),
         _code_cell(
@@ -264,6 +288,8 @@ else:
         'max_drawdown',
         'pareto_tier',
         'mutation_label',
+        'promotion_status',
+        'runtime_strategy_name',
     ]
     _display_rows(_project_rows(HISTORY, ledger_columns), columns=ledger_columns)
 """
@@ -336,7 +362,9 @@ def build_strategy_research_dossier_notebook(run_root: Path) -> dict[str, Any]:
     cells = [
         _markdown_cell(
             '# Strategy Research Dossier\n\n'
-            'This notebook focuses on the paper claims and family plans that drove the discovery loop.'
+            'This notebook focuses on the paper claims and family plans that drove the discovery loop.\n\n'
+            '> Discovery evidence is not promotion evidence. Use runtime parity and scheduler-v3 approval replay '
+            'before calling any candidate a winner.'
         ),
         _code_cell(_shared_loader_code(run_root)),
         _code_cell(
@@ -360,6 +388,11 @@ for family in RESEARCH.get('families', []):
         }
     )
 _display_rows(family_rows)
+
+promotion = SUMMARY.get('promotion_readiness') or {}
+if promotion:
+    display(Markdown('## Promotion Status'))
+    _display_rows([promotion])
 """
         ),
         _code_cell(

--- a/services/torghut/app/trading/discovery/promotion_contract.py
+++ b/services/torghut/app/trading/discovery/promotion_contract.py
@@ -1,0 +1,102 @@
+"""Promotion-readiness contracts for discovery outputs."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, cast
+
+PROMOTION_STAGE_RESEARCH = 'research_candidate'
+PROMOTION_STATUS_BLOCKED_PENDING_RUNTIME_PARITY = 'blocked_pending_runtime_parity'
+PROMOTION_STATUS_BLOCKED_NO_CANDIDATE = 'blocked_no_candidate'
+PROMOTION_REQUIRED_EVIDENCE = (
+    'checked_in_runtime_family',
+    'scheduler_v3_parity_replay',
+    'scheduler_v3_approval_replay',
+    'live_shadow_validation',
+)
+
+
+def _string(value: Any) -> str:
+    return str(value or '').strip()
+
+
+def runtime_harness_payload(runtime_harness: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        'family': _string(runtime_harness.get('family')),
+        'strategy_name': _string(runtime_harness.get('strategy_name')),
+        'disable_other_strategies': bool(runtime_harness.get('disable_other_strategies')),
+    }
+
+
+def blocked_research_candidate_promotion_readiness(
+    *,
+    candidate_id: str,
+    family_template_id: str,
+    runtime_harness: Mapping[str, Any],
+) -> dict[str, Any]:
+    resolved_runtime_harness = runtime_harness_payload(runtime_harness)
+    blockers = [
+        'scheduler_v3_parity_missing',
+        'scheduler_v3_approval_missing',
+        'shadow_validation_missing',
+    ]
+    if not resolved_runtime_harness['family'] or not resolved_runtime_harness['strategy_name']:
+        blockers.insert(0, 'runtime_family_mapping_missing')
+    return {
+        'candidate_id': candidate_id,
+        'family_template_id': family_template_id,
+        'stage': PROMOTION_STAGE_RESEARCH,
+        'status': PROMOTION_STATUS_BLOCKED_PENDING_RUNTIME_PARITY,
+        'promotable': False,
+        'reason': (
+            'Discovery output is a research-only candidate until the same family is checked into '
+            'runtime code/config, replayed through scheduler-v3 for parity, approved on '
+            'scheduler-v3 metrics, and validated in shadow.'
+        ),
+        'required_evidence': list(PROMOTION_REQUIRED_EVIDENCE),
+        'blockers': blockers,
+        'runtime_family': resolved_runtime_harness['family'],
+        'runtime_strategy_name': resolved_runtime_harness['strategy_name'],
+        'runtime_harness': resolved_runtime_harness,
+    }
+
+
+def missing_candidate_promotion_readiness() -> dict[str, Any]:
+    return {
+        'candidate_id': '',
+        'family_template_id': '',
+        'stage': PROMOTION_STAGE_RESEARCH,
+        'status': PROMOTION_STATUS_BLOCKED_NO_CANDIDATE,
+        'promotable': False,
+        'reason': (
+            'No best candidate exists yet. Even once a research candidate appears, promotion remains '
+            'blocked until runtime parity, scheduler-v3 approval replay, and shadow validation are complete.'
+        ),
+        'required_evidence': list(PROMOTION_REQUIRED_EVIDENCE),
+        'blockers': [
+            'best_candidate_missing',
+            'checked_in_runtime_family_missing',
+            'scheduler_v3_parity_missing',
+            'scheduler_v3_approval_missing',
+            'shadow_validation_missing',
+        ],
+        'runtime_family': '',
+        'runtime_strategy_name': '',
+        'runtime_harness': runtime_harness_payload({}),
+    }
+
+
+def summary_promotion_readiness(best_candidate: Mapping[str, Any] | None) -> dict[str, Any]:
+    if best_candidate is None:
+        return missing_candidate_promotion_readiness()
+    return {
+        'candidate_id': _string(best_candidate.get('candidate_id')),
+        'family_template_id': _string(best_candidate.get('family_template_id')),
+        'status': _string(best_candidate.get('promotion_status')),
+        'stage': _string(best_candidate.get('promotion_stage')),
+        'promotable': bool(best_candidate.get('promotable')),
+        'reason': _string(best_candidate.get('promotion_reason')),
+        'blockers': list(cast(list[str], best_candidate.get('promotion_blockers') or [])),
+        'required_evidence': list(cast(list[str], best_candidate.get('promotion_required_evidence') or [])),
+        'runtime_family': _string(best_candidate.get('runtime_family')),
+        'runtime_strategy_name': _string(best_candidate.get('runtime_strategy_name')),
+    }

--- a/services/torghut/notebooks/strategy-autoresearch-loop.ipynb
+++ b/services/torghut/notebooks/strategy-autoresearch-loop.ipynb
@@ -8,7 +8,9 @@
     "# Strategy Autoresearch Loop\n",
     "\n",
     "This notebook auto-discovers the latest completed output directory from `scripts/run_strategy_autoresearch_loop.py` when one exists.\n",
-    "If no completed run exists yet, it still opens cleanly and tells you what artifacts are missing.\n"
+    "If no completed run exists yet, it still opens cleanly and tells you what artifacts are missing.\n",
+    "\n",
+    "> Results shown here are research candidates only. They are not promotable until the same family passes runtime parity, scheduler-v3 approval replay, and shadow validation.\n"
    ]
   },
   {
@@ -234,7 +236,15 @@
     "    display(Markdown('> `pandas` is not installed in this kernel, so the notebook is using a lightweight HTML table renderer.'))\n",
     "display(Markdown(f'## Program\\n`{RESEARCH.get(\"program_id\", \"<none>\")}`'))\n",
     "_display_rows([RESEARCH.get('objective', {})])\n",
-    "_display_rows([SUMMARY.get('best_candidate') or {}])\n"
+    "best = SUMMARY.get('best_candidate') or {}\n",
+    "_display_rows([best])\n",
+    "promotion = SUMMARY.get('promotion_readiness') or {}\n",
+    "if promotion:\n",
+    "    display(Markdown('## Promotion Guardrail'))\n",
+    "    _display_rows([promotion])\n",
+    "    blockers = promotion.get('blockers') or []\n",
+    "    if blockers:\n",
+    "        _display_rows([{'blocker': blocker} for blocker in blockers], columns=['blocker'])\n"
    ]
   },
   {
@@ -322,6 +332,8 @@
     "    'max_drawdown',\n",
     "    'pareto_tier',\n",
     "    'mutation_label',\n",
+    "    'promotion_status',\n",
+    "    'runtime_strategy_name',\n",
     "]\n",
     "display(Markdown('## Experiment Ledger'))\n",
     "_display_rows(_project_rows(HISTORY, ledger_columns), columns=ledger_columns)\n"

--- a/services/torghut/scripts/run_strategy_autoresearch_loop.py
+++ b/services/torghut/scripts/run_strategy_autoresearch_loop.py
@@ -22,6 +22,10 @@ from app.trading.discovery.autoresearch import (
 )
 from app.trading.discovery.autoresearch_notebooks import write_autoresearch_notebooks
 from app.trading.discovery.family_templates import family_template_dir
+from app.trading.discovery.promotion_contract import (
+    blocked_research_candidate_promotion_readiness,
+    summary_promotion_readiness,
+)
 from scripts.search_consistent_profitability_frontier import run_consistent_profitability_frontier
 
 _REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -102,6 +106,14 @@ def _slug(value: str) -> str:
     return '-'.join(part for part in normalized.split('-') if part)
 
 
+def _promotion_readiness_payload(*, family_plan: FamilyAutoresearchPlan) -> dict[str, Any]:
+    return blocked_research_candidate_promotion_readiness(
+        candidate_id='',
+        family_template_id=family_plan.family_template.family_id,
+        runtime_harness=family_plan.family_template.runtime_harness,
+    )
+
+
 def _frontier_args(
     *,
     args: argparse.Namespace,
@@ -171,6 +183,7 @@ def _history_record(
     full_window = _mapping(candidate_payload.get('full_window'))
     scorecard = _mapping(candidate_payload.get('objective_scorecard'))
     ranking = _mapping(candidate_payload.get('ranking'))
+    promotion_readiness = _promotion_readiness_payload(family_plan=family_plan)
     return {
         'runner_run_id': runner_run_id,
         'experiment_index': experiment_index,
@@ -200,6 +213,15 @@ def _history_record(
         'daily_net': _mapping(full_window.get('daily_net')),
         'daily_filled_notional': _mapping(full_window.get('daily_filled_notional')),
         'pruned_symbol': _string(candidate_payload.get('pruned_symbol')),
+        'objective_scope': 'research_only',
+        'promotion_stage': promotion_readiness['stage'],
+        'promotion_status': promotion_readiness['status'],
+        'promotable': promotion_readiness['promotable'],
+        'promotion_reason': promotion_readiness['reason'],
+        'promotion_blockers': list(cast(list[str], promotion_readiness['blockers'])),
+        'promotion_required_evidence': list(cast(list[str], promotion_readiness['required_evidence'])),
+        'runtime_family': _string(_mapping(promotion_readiness['runtime_harness']).get('family')),
+        'runtime_strategy_name': _string(_mapping(promotion_readiness['runtime_harness']).get('strategy_name')),
     }
 
 
@@ -278,6 +300,7 @@ def _persist_run_outputs(
     results_tsv_path = run_root / 'results.tsv'
     research_dossier_path = run_root / 'research_dossier.json'
     summary_path = run_root / 'summary.json'
+    promotion_readiness_path = run_root / 'promotion_readiness.json'
     _write_history_jsonl(history_path, history)
     _write_results_tsv(results_tsv_path, history)
     research_dossier_path.write_text(
@@ -292,14 +315,22 @@ def _persist_run_outputs(
         'run_root': str(run_root),
         'frontier_run_count': frontier_runs,
         'objective_met': objective_met,
+        'objective_scope': 'research_only',
         'history_path': str(history_path),
         'results_tsv_path': str(results_tsv_path),
         'research_dossier_path': str(research_dossier_path),
+        'promotion_readiness_path': str(promotion_readiness_path),
         'notebooks': [str(path) for path in notebook_paths],
         'best_candidate': _best_history_record(history),
     }
+    best_candidate = cast(dict[str, Any] | None, summary['best_candidate'])
+    summary['promotion_readiness'] = summary_promotion_readiness(best_candidate)
     if error is not None:
         summary['error'] = dict(error)
+    promotion_readiness_path.write_text(
+        json.dumps(summary['promotion_readiness'], indent=2, sort_keys=True),
+        encoding='utf-8',
+    )
     summary_path.write_text(
         json.dumps(summary, indent=2, sort_keys=True),
         encoding='utf-8',

--- a/services/torghut/scripts/run_strategy_factory_v2.py
+++ b/services/torghut/scripts/run_strategy_factory_v2.py
@@ -17,6 +17,7 @@ from sqlalchemy import delete, select
 from app.db import SessionLocal
 from app.models import VNextExperimentRun, VNextExperimentSpec
 from app.trading.discovery.family_templates import FamilyTemplate, family_template_dir, load_family_template
+from app.trading.discovery.promotion_contract import blocked_research_candidate_promotion_readiness
 from scripts.search_consistent_profitability_frontier import (
     run_consistent_profitability_frontier,
 )
@@ -357,6 +358,11 @@ def _persist_result(
         if top_candidates
         else None
     ) or None
+    promotion_readiness = blocked_research_candidate_promotion_readiness(
+        candidate_id=best_candidate_id or '',
+        family_template_id=experiment.family_template.family_id,
+        runtime_harness=experiment.family_template.runtime_harness,
+    )
     experiment_payload = {
         **experiment.experiment_payload,
         'compiled_family_template': experiment.family_template.to_payload(),
@@ -364,6 +370,7 @@ def _persist_result(
         'result_path': str(result_path),
         'runner': 'run_strategy_factory_v2',
         'runner_run_id': runner_run_id,
+        'promotion_readiness': promotion_readiness,
         'result': result_payload,
     }
     with SessionLocal() as session:
@@ -398,6 +405,7 @@ def _persist_result(
                     'result_path': str(result_path),
                     'dataset_snapshot_receipt': result_payload.get('dataset_snapshot_receipt'),
                     'top_candidate': top_candidates[0] if top_candidates else None,
+                    'promotion_readiness': promotion_readiness,
                 },
             )
         )
@@ -450,6 +458,16 @@ def run_strategy_factory_v2(args: argparse.Namespace) -> dict[str, Any]:
                 result_path=result_path,
             )
         top_candidates = cast(list[dict[str, Any]], frontier_payload.get('top') or [])
+        top_candidate_id = (
+            str(top_candidates[0].get('candidate_id') or '').strip()
+            if top_candidates
+            else ''
+        )
+        promotion_readiness = blocked_research_candidate_promotion_readiness(
+            candidate_id=top_candidate_id,
+            family_template_id=compiled.family_template.family_id,
+            runtime_harness=compiled.family_template.runtime_harness,
+        )
         results.append(
             {
                 'source_run_id': compiled.source_run_id,
@@ -460,16 +478,13 @@ def run_strategy_factory_v2(args: argparse.Namespace) -> dict[str, Any]:
                 'dataset_snapshot_id': str(
                     _mapping(frontier_payload.get('dataset_snapshot_receipt')).get('snapshot_id') or ''
                 ),
-                'top_candidate_id': (
-                    str(top_candidates[0].get('candidate_id') or '').strip()
-                    if top_candidates
-                    else ''
-                ),
+                'top_candidate_id': top_candidate_id,
                 'top_net_per_day': (
                     str(_mapping(top_candidates[0].get('full_window')).get('net_per_day') or '')
                     if top_candidates
                     else ''
                 ),
+                'promotion_readiness': promotion_readiness,
             }
         )
 

--- a/services/torghut/tests/test_run_strategy_factory_v2.py
+++ b/services/torghut/tests/test_run_strategy_factory_v2.py
@@ -373,6 +373,11 @@ class TestRunStrategyFactoryV2(TestCase):
             self.assertEqual(result['experiments'][0]['experiment_id'], 'exp-breakout-1')
             self.assertEqual(result['experiments'][0]['top_candidate_id'], 'cand-1')
             self.assertEqual(result['experiments'][0]['dataset_snapshot_id'], 'snap-1')
+            self.assertFalse(result['experiments'][0]['promotion_readiness']['promotable'])
+            self.assertEqual(
+                result['experiments'][0]['promotion_readiness']['runtime_strategy_name'],
+                'breakout-continuation-long-v1',
+            )
             mock_frontier.assert_called_once()
 
             compiled_sweep_path = output_dir / 'exp-breakout-1' / 'compiled-sweep.yaml'
@@ -403,6 +408,11 @@ class TestRunStrategyFactoryV2(TestCase):
                     .where(VNextExperimentSpec.run_id != 'paper-run-1')
                 ).scalar_one()
                 self.assertEqual(persisted_spec.candidate_id, 'cand-1')
+                self.assertFalse(persisted_spec.payload_json['promotion_readiness']['promotable'])
+                self.assertEqual(
+                    persisted_spec.payload_json['promotion_readiness']['status'],
+                    'blocked_pending_runtime_parity',
+                )
 
     def test_run_strategy_factory_v2_returns_no_experiments_when_source_empty(self) -> None:
         with TemporaryDirectory() as tmpdir:

--- a/services/torghut/tests/test_strategy_autoresearch.py
+++ b/services/torghut/tests/test_strategy_autoresearch.py
@@ -532,7 +532,22 @@ class TestStrategyAutoresearch(TestCase):
         with TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
             (root / 'summary.json').write_text(
-                json.dumps({'best_candidate': {'candidate_id': 'c-1'}, 'program_id': 'program-1'}),
+                json.dumps(
+                    {
+                        'best_candidate': {'candidate_id': 'c-1'},
+                        'program_id': 'program-1',
+                        'promotion_readiness': {
+                            'candidate_id': 'c-1',
+                            'status': 'blocked_pending_runtime_parity',
+                            'stage': 'research_candidate',
+                            'promotable': False,
+                            'runtime_family': 'breakout_continuation_consistent',
+                            'runtime_strategy_name': 'breakout-continuation-long-v1',
+                            'reason': 'research only',
+                            'blockers': ['scheduler_v3_parity_missing'],
+                        },
+                    }
+                ),
                 encoding='utf-8',
             )
             (root / 'research_dossier.json').write_text(
@@ -581,6 +596,8 @@ class TestStrategyAutoresearch(TestCase):
             self.assertIn('except ModuleNotFoundError', joined_source)
             all_sources = '\n'.join(''.join(cell.get('source', [])) for cell in payload['cells'])
             self.assertIn('Live Experiment Snapshots', all_sources)
+            self.assertIn('Promotion Guardrail', all_sources)
+            self.assertIn('research candidates only', all_sources)
 
     def test_generated_history_notebook_avoids_hard_pandas_dependency(self) -> None:
         payload = build_strategy_discovery_history_notebook(Path('/tmp/example-run'))
@@ -768,8 +785,18 @@ class TestStrategyAutoresearch(TestCase):
             self.assertTrue((run_root / 'history.jsonl').exists())
             self.assertTrue((run_root / 'results.tsv').exists())
             self.assertTrue((run_root / 'strategy-discovery-history.ipynb').exists())
+            self.assertTrue((run_root / 'promotion_readiness.json').exists())
             summary = json.loads((run_root / 'summary.json').read_text(encoding='utf-8'))
             self.assertEqual(summary['best_candidate']['candidate_id'], 'mutated-1')
+            self.assertEqual(summary['objective_scope'], 'research_only')
+            self.assertFalse(summary['promotion_readiness']['promotable'])
+            self.assertEqual(summary['promotion_readiness']['stage'], 'research_candidate')
+            self.assertIn('scheduler_v3_parity_missing', summary['promotion_readiness']['blockers'])
+            self.assertEqual(summary['best_candidate']['promotion_status'], 'blocked_pending_runtime_parity')
+            self.assertEqual(summary['best_candidate']['runtime_strategy_name'], 'breakout-continuation-long-v1')
+            promotion_readiness = json.loads((run_root / 'promotion_readiness.json').read_text(encoding='utf-8'))
+            self.assertEqual(promotion_readiness['candidate_id'], 'mutated-1')
+            self.assertFalse(promotion_readiness['promotable'])
 
     def test_run_strategy_autoresearch_loop_flushes_visible_progress_between_experiments(self) -> None:
         with TemporaryDirectory() as tmpdir:
@@ -1065,6 +1092,10 @@ class TestStrategyAutoresearch(TestCase):
             self.assertTrue((run_root / 'results.tsv').exists())
             self.assertTrue((run_root / 'research_dossier.json').exists())
             self.assertTrue((run_root / 'strategy-discovery-history.ipynb').exists())
+            self.assertTrue((run_root / 'promotion_readiness.json').exists())
+            promotion_readiness = json.loads((run_root / 'promotion_readiness.json').read_text(encoding='utf-8'))
+            self.assertEqual(promotion_readiness['status'], 'blocked_no_candidate')
+            self.assertIn('best_candidate_missing', promotion_readiness['blockers'])
 
     def test_run_strategy_autoresearch_loop_honors_max_frontier_runs_and_dedupes_seen_sweeps(self) -> None:
         with TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary

- add a shared Torghut promotion-readiness contract for discovery outputs that marks research results as non-promotable until runtime parity, scheduler-v3 approval replay, and shadow validation exist
- stamp autoresearch summaries, history rows, dedicated promotion-readiness artifacts, and notebooks with the blocked promotion state so research runs stop implying rollout readiness
- thread the same blocked-by-default contract into strategy-factory v2 results and persisted experiment payloads so approval-facing consumers see the same guardrail

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_strategy_autoresearch.py tests/test_run_strategy_factory_v2.py -q`
- `cd services/torghut && uv run --frozen ruff check app/trading/discovery/promotion_contract.py app/trading/discovery/autoresearch_notebooks.py scripts/run_strategy_autoresearch_loop.py scripts/run_strategy_factory_v2.py tests/test_strategy_autoresearch.py tests/test_run_strategy_factory_v2.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
