### PR TITLE
chore(jangar): promote image 3dec9638

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: d929a82e
-  digest: sha256:22d72b8132fe59f1aba358d073174d9f5730bccb724b0a4daf035ae293129f05
+  tag: 3dec9638
+  digest: sha256:ccdef8eb458c5bfd99ee9b11c8bdda84f6d2c4f21d5ca1d4b11e3359083917f2
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: d929a82e
-    digest: sha256:f02100119986fa960b85995b3121dff5252ce5fea827cf3689a5d0e50c105cee
+    tag: 3dec9638
+    digest: sha256:485ff5cdde09ab83828e61fe13943553c6d42b44951f7353523ca1558e1f0314
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: d929a82e
-    digest: sha256:22d72b8132fe59f1aba358d073174d9f5730bccb724b0a4daf035ae293129f05
+    tag: 3dec9638
+    digest: sha256:ccdef8eb458c5bfd99ee9b11c8bdda84f6d2c4f21d5ca1d4b11e3359083917f2
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: "2026-04-10T06:36:10Z"
+    deploy.knative.dev/rollout: 2026-04-10T17:01:03Z
 spec:
   replicas: 1
   strategy:
@@ -28,15 +28,20 @@ spec:
         - name: bootstrap-workspace
           image: registry.ide-newton.ts.net/lab/jangar
           imagePullPolicy: IfNotPresent
-          command: ['sh', '-c']
+          command:
+            - sh
+            - -c
           args:
-            - |
+            - >
               set -eu
+
               if [ ! -d /workspace/lab/.git ]; then
                 rm -rf /workspace/lab
                 git clone --depth 1 https://github.com/proompteng/lab.git /workspace/lab
               fi
-              mkdir -p /workspace/lab/.worktrees /workspace/lab/torghut /workspace/.bun-install-cache /workspace/.ovscode
+
+              mkdir -p /workspace/lab/.worktrees /workspace/lab/torghut /workspace/.bun-install-cache
+              /workspace/.ovscode
           volumeMounts:
             - name: workspace
               mountPath: /workspace
@@ -150,7 +155,7 @@ spec:
             - name: JANGAR_CODEX_MAX_ATTEMPTS
               value: "3"
             - name: JANGAR_CODEX_BACKOFF_SCHEDULE_MS
-              value: "300000,900000,2700000"
+              value: 300000,900000,2700000
             - name: FACTEUR_INTERNAL_URL
               value: http://facteur-internal.facteur.svc.cluster.local
             - name: MINIO_ENDPOINT
@@ -395,9 +400,10 @@ spec:
         - name: docker
           image: docker:25.0-dind
           imagePullPolicy: IfNotPresent
-          command: ["dockerd-entrypoint.sh"]
+          command:
+            - dockerd-entrypoint.sh
           args:
-            - "--host=unix:///var/run/docker.sock"
+            - --host=unix:///var/run/docker.sock
           env:
             - name: DOCKER_TLS_CERTDIR
               value: ""

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -6,6 +6,8 @@ metadata:
   labels:
     app.kubernetes.io/name: jangar-worker
     app.kubernetes.io/part-of: lab
+  annotations:
+    kubectl.kubernetes.io/restartedAt: 2026-04-10T17:01:03Z
 spec:
   replicas: 1
   strategy:
@@ -20,13 +22,15 @@ spec:
         app.kubernetes.io/name: jangar-worker
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-04-10T06:36:10Z"
+        kubectl.kubernetes.io/restartedAt: 2026-04-10T06:36:10Z
     spec:
       initContainers:
         - name: bootstrap-workspace
           image: registry.ide-newton.ts.net/lab/jangar
           imagePullPolicy: IfNotPresent
-          command: ['sh', '-c']
+          command:
+            - sh
+            - -c
           args:
             - |
               set -eu
@@ -56,7 +60,9 @@ spec:
         - name: jangar-worker
           image: registry.ide-newton.ts.net/lab/jangar:latest
           imagePullPolicy: Always
-          command: ['bun', '/app/services/jangar/src/worker.ts']
+          command:
+            - bun
+            - /app/services/jangar/src/worker.ts
           ports:
             - name: health
               containerPort: 3002

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -51,7 +51,6 @@ resources:
   - jangar-primitives-sub-orchestration.yaml
   - jangar-primitives-orchestrationrun.yaml
   - jangar-primitives-agentrun.yaml
-
 helmCharts:
   - name: open-webui
     repo: https://helm.openwebui.com
@@ -59,8 +58,7 @@ helmCharts:
     releaseName: jangar-openwebui
     namespace: jangar
     valuesFile: openwebui-values.yaml
-
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "d929a82e"
-    digest: sha256:22d72b8132fe59f1aba358d073174d9f5730bccb724b0a4daf035ae293129f05
+    newTag: 3dec9638
+    digest: sha256:ccdef8eb458c5bfd99ee9b11c8bdda84f6d2c4f21d5ca1d4b11e3359083917f2


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `3dec963879f4242f40a4f50c5348dca0816666d9`
- Image tag: `3dec9638`
- Image digest: `sha256:ccdef8eb458c5bfd99ee9b11c8bdda84f6d2c4f21d5ca1d4b11e3359083917f2`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`