### PR TITLE
fix(jangar): use runtime-safe worker imports

### DIFF
--- a/services/jangar/src/__tests__/worker-entrypoint.test.ts
+++ b/services/jangar/src/__tests__/worker-entrypoint.test.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+describe('worker entrypoint', () => {
+  it('avoids tsconfig path aliases that bun cannot resolve at runtime', () => {
+    const source = readFileSync(new URL('../worker.ts', import.meta.url), 'utf8')
+
+    expect(source).not.toContain("from '~/")
+    expect(source).not.toContain('from "~/')
+    expect(source).not.toContain("from '@/")
+    expect(source).not.toContain('from "@/')
+  })
+})

--- a/services/jangar/src/worker.ts
+++ b/services/jangar/src/worker.ts
@@ -4,7 +4,7 @@ import workflows from '@proompteng/bumba/src/workflows/index'
 import { createTemporalClient, type TemporalConfig, temporalCallOptions } from '@proompteng/temporal-bun-sdk'
 import { createWorker } from '@proompteng/temporal-bun-sdk/worker'
 import type { WorkflowDefinitions } from '@proompteng/temporal-bun-sdk/workflow'
-import { resolveWorkerRuntimeConfig } from '~/server/runtime-entry-config'
+import { resolveWorkerRuntimeConfig } from './server/runtime-entry-config'
 
 type ActivityHandler = (...args: unknown[]) => unknown | Promise<unknown>
 


### PR DESCRIPTION
## Summary

- replace the Jangar worker entrypoint alias import with a relative runtime-safe import
- add a regression test that blocks tsconfig-path aliases in the directly executed worker entrypoint
- restore the production rollout by preventing the worker CrashLoopBackOff on the promoted image

## Related Issues

None

## Testing

- `cd services/jangar && bunx vitest run src/__tests__/worker-entrypoint.test.ts src/server/__tests__/leader-election.test.ts src/server/__tests__/kube-gateway.test.ts`
- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `cd services/jangar && bun run test && bunx tsc --noEmit --project tsconfig.paths.json && bun run docs:inventory:check && bun run check:module-sizes && bun run build`
- `kubectl logs -n jangar pod/jangar-worker-dc7754ddf-5btp8 --tail=200`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
