### PR TITLE
chore(jangar): promote image 5ddf1f0c

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 3dec9638
-  digest: sha256:ccdef8eb458c5bfd99ee9b11c8bdda84f6d2c4f21d5ca1d4b11e3359083917f2
+  tag: 5ddf1f0c
+  digest: sha256:4131f6b48fd87243ad22782c1d5b5e35e26a3720b23b8c0e5627e282e87dd6af
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 3dec9638
-    digest: sha256:485ff5cdde09ab83828e61fe13943553c6d42b44951f7353523ca1558e1f0314
+    tag: 5ddf1f0c
+    digest: sha256:d7a8d173c75296aa7f11c363c9f169f4a289c3bdf6a97a7da5d804f60a3a0d00
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 3dec9638
-    digest: sha256:ccdef8eb458c5bfd99ee9b11c8bdda84f6d2c4f21d5ca1d4b11e3359083917f2
+    tag: 5ddf1f0c
+    digest: sha256:4131f6b48fd87243ad22782c1d5b5e35e26a3720b23b8c0e5627e282e87dd6af
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-04-10T17:01:03Z
+    deploy.knative.dev/rollout: 2026-04-10T17:32:42Z
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/name: jangar-worker
     app.kubernetes.io/part-of: lab
   annotations:
-    kubectl.kubernetes.io/restartedAt: 2026-04-10T17:01:03Z
+    kubectl.kubernetes.io/restartedAt: 2026-04-10T17:32:42Z
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -60,5 +60,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: 3dec9638
-    digest: sha256:ccdef8eb458c5bfd99ee9b11c8bdda84f6d2c4f21d5ca1d4b11e3359083917f2
+    newTag: 5ddf1f0c
+    digest: sha256:4131f6b48fd87243ad22782c1d5b5e35e26a3720b23b8c0e5627e282e87dd6af


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `5ddf1f0ca35ecc9c9db7525bb46c55d636f9d1b4`
- Image tag: `5ddf1f0c`
- Image digest: `sha256:4131f6b48fd87243ad22782c1d5b5e35e26a3720b23b8c0e5627e282e87dd6af`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`