### PR TITLE
fix(jangar): ship worker runtime config in image

### DIFF
--- a/services/jangar/Dockerfile
+++ b/services/jangar/Dockerfile
@@ -558,6 +558,7 @@ WORKDIR /app/services/jangar
 COPY --from=jangar-build /app/services/jangar/.output ./.output
 COPY --from=jangar-build /app/services/jangar/package.json ./package.json
 COPY --from=jangar-build /app/services/jangar/src/worker.ts ./src/worker.ts
+COPY --from=jangar-build /app/services/jangar/src/server/runtime-entry-config.ts ./src/server/runtime-entry-config.ts
 COPY --from=jangar-pty /tmp/node-pty/build /app/services/jangar/.output/server/node_modules/node-pty/build
 COPY --from=jangar-pty /tmp/node-pty/prebuilds /app/services/jangar/.output/server/node_modules/node-pty/prebuilds
 WORKDIR /app
@@ -606,6 +607,7 @@ WORKDIR /app/services/jangar
 COPY --from=jangar-build /app/services/jangar/.output ./.output
 COPY --from=jangar-build /app/services/jangar/package.json ./package.json
 COPY --from=jangar-build /app/services/jangar/src/worker.ts ./src/worker.ts
+COPY --from=jangar-build /app/services/jangar/src/server/runtime-entry-config.ts ./src/server/runtime-entry-config.ts
 COPY --from=jangar-pty /tmp/node-pty/build /app/services/jangar/.output/server/node_modules/node-pty/build
 COPY --from=jangar-pty /tmp/node-pty/prebuilds /app/services/jangar/.output/server/node_modules/node-pty/prebuilds
 WORKDIR /app

--- a/services/jangar/src/__tests__/worker-entrypoint.test.ts
+++ b/services/jangar/src/__tests__/worker-entrypoint.test.ts
@@ -1,7 +1,20 @@
-import { readFileSync } from 'node:fs'
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 
 describe('worker entrypoint', () => {
+  it('uses a runtime-resolvable local import for worker config', () => {
+    const workerUrl = new URL('../worker.ts', import.meta.url)
+    const workerPath = fileURLToPath(workerUrl)
+    const source = readFileSync(workerUrl, 'utf8')
+    const importMatch = source.match(/from '(\.\/server\/runtime-entry-config(?:\.ts)?)'/)
+    const importPath = importMatch?.[1]
+
+    expect(importPath).toBe('./server/runtime-entry-config')
+    expect(existsSync(resolve(dirname(workerPath), `${importPath!}.ts`))).toBe(true)
+  })
+
   it('avoids tsconfig path aliases that bun cannot resolve at runtime', () => {
     const source = readFileSync(new URL('../worker.ts', import.meta.url), 'utf8')
 
@@ -9,5 +22,14 @@ describe('worker entrypoint', () => {
     expect(source).not.toContain('from "~/')
     expect(source).not.toContain("from '@/")
     expect(source).not.toContain('from "@/')
+  })
+
+  it('copies worker runtime config into both runtime images', () => {
+    const dockerfile = readFileSync(new URL('../../Dockerfile', import.meta.url), 'utf8')
+    const copyDirective =
+      'COPY --from=jangar-build /app/services/jangar/src/server/runtime-entry-config.ts ./src/server/runtime-entry-config.ts'
+    const matches = dockerfile.match(new RegExp(copyDirective.replaceAll('/', '\\/'), 'g')) ?? []
+
+    expect(matches).toHaveLength(2)
   })
 })


### PR DESCRIPTION
## Summary

- copy `src/server/runtime-entry-config.ts` into the Jangar runtime and control-plane images alongside `src/worker.ts`
- keep the worker entrypoint on a relative local import and add a regression test that guards the runtime image copy contract
- fix the production `jangar-worker` CrashLoopBackOff caused by the image missing the worker runtime config module

## Related Issues

None

## Testing

- `cd services/jangar && bunx vitest run src/__tests__/worker-entrypoint.test.ts`
- `cd services/jangar && bun run test && bunx tsc --noEmit --project tsconfig.paths.json && bun run docs:inventory:check && bun run check:module-sizes && bun run build`
- `kubectl logs -n jangar pod/jangar-worker-6559bd6cb9-wpjdt --tail=200`
- `kubectl get applications.argoproj.io -n argocd jangar symphony-jangar -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.sync.status}{"\t"}{.status.health.status}{"\t"}{.status.sync.revision}{"\n"}{end}'`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
