### PR TITLE
ci(jangar): opt workflows into node 24 actions

### DIFF
--- a/.github/workflows/jangar-build-push.yaml
+++ b/.github/workflows/jangar-build-push.yaml
@@ -25,6 +25,9 @@ concurrency:
   group: jangar-build-${{ github.ref }}-${{ github.sha }}
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   build-and-push:
     runs-on: arc-arm64

--- a/.github/workflows/jangar-post-deploy-verify.yml
+++ b/.github/workflows/jangar-post-deploy-verify.yml
@@ -17,6 +17,9 @@ concurrency:
   group: jangar-post-deploy-verify-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   verify:
     runs-on: arc-arm64

--- a/.github/workflows/jangar-release.yml
+++ b/.github/workflows/jangar-release.yml
@@ -25,6 +25,9 @@ concurrency:
   group: jangar-release-${{ github.event.workflow_run.head_sha || inputs.commit_sha || github.ref }}
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   promote:
     if: >-


### PR DESCRIPTION
## Summary

- opt the Jangar build, release, and post-deploy workflows into Node 24 for JavaScript-based GitHub Actions
- remove the current Node 20 deprecation warnings from the Jangar production CI/CD path before the runner default flips
- leave the actual Jangar build and rollout logic unchanged because the latest 11m49s regression came from a transient Bun setup download, not the Docker pipeline

## Related Issues

None

## Testing

- `git diff --check`
- `rg -n "FORCE_JAVASCRIPT_ACTIONS_TO_NODE24" .github/workflows/jangar-build-push.yaml .github/workflows/jangar-release.yml .github/workflows/jangar-post-deploy-verify.yml`
- `gh run view 24256333593 --json jobs -R proompteng/lab`
- `gh run view 24255392334 --json jobs -R proompteng/lab`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
