### PR TITLE
ci(jangar): upgrade workflows to node24-native actions

### DIFF
--- a/.github/workflows/jangar-build-push.yaml
+++ b/.github/workflows/jangar-build-push.yaml
@@ -25,9 +25,6 @@ concurrency:
   group: jangar-build-${{ github.ref }}-${{ github.sha }}
   cancel-in-progress: true
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
-
 jobs:
   build-and-push:
     runs-on: arc-arm64
@@ -42,7 +39,7 @@ jobs:
           bun-version: 1.3.10
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
         with:
           cache-binary: false
 
@@ -160,7 +157,7 @@ jobs:
             --control-plane-digest "${{ steps.control_plane_digest.outputs.digest }}"
 
       - name: Upload release contract artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: jangar-release-contract
           path: jangar-release-contract.json

--- a/.github/workflows/jangar-post-deploy-verify.yml
+++ b/.github/workflows/jangar-post-deploy-verify.yml
@@ -17,9 +17,6 @@ concurrency:
   group: jangar-post-deploy-verify-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
-
 jobs:
   verify:
     runs-on: arc-arm64
@@ -38,7 +35,7 @@ jobs:
           bun-version: 1.3.10
 
       - name: Set up kubectl
-        uses: azure/setup-kubectl@v4
+        uses: azure/setup-kubectl@v5
         with:
           version: v1.31.2
 
@@ -176,7 +173,7 @@ jobs:
 
       - name: Open rollback pull request
         if: failure() && steps.rollback.outputs.should_rollback == 'true'
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.AGENTS_SPLIT_TOKEN || secrets.GITHUB_TOKEN }}
           branch: codex/jangar-rollback-${{ github.run_id }}-${{ github.run_attempt }}

--- a/.github/workflows/jangar-release.yml
+++ b/.github/workflows/jangar-release.yml
@@ -25,9 +25,6 @@ concurrency:
   group: jangar-release-${{ github.event.workflow_run.head_sha || inputs.commit_sha || github.ref }}
   cancel-in-progress: true
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
-
 jobs:
   promote:
     if: >-
@@ -53,11 +50,11 @@ jobs:
           bun-version: 1.3.10
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Download release contract artifact from triggering build
         if: github.event_name == 'workflow_run'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: jangar-release-contract
           path: .artifacts/jangar
@@ -192,7 +189,7 @@ jobs:
 
       - name: Create deploy pull request
         if: steps.meta.outputs.promote == 'true' && steps.changes.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.AGENTS_SPLIT_TOKEN || secrets.GITHUB_TOKEN }}
           branch: codex/jangar-release-${{ steps.meta.outputs.tag }}


### PR DESCRIPTION
## Summary

- replace the temporary Node 24 environment override with stable Node-24-native action majors in the Jangar build, release, and post-deploy workflows
- upgrade `docker/setup-buildx-action`, `actions/upload-artifact`, `actions/download-artifact`, `azure/setup-kubectl`, and `peter-evans/create-pull-request` where upstream now ships Node 24 runtimes
- keep the workflow behavior unchanged while eliminating the remaining forced-Node-24 compatibility warning from the Jangar CI/CD path

## Related Issues

None

## Testing

- `git diff --check`
- `rg -n "setup-buildx-action@|upload-artifact@|download-artifact@|setup-kubectl@|create-pull-request@|FORCE_JAVASCRIPT_ACTIONS_TO_NODE24" .github/workflows/jangar-build-push.yaml .github/workflows/jangar-release.yml .github/workflows/jangar-post-deploy-verify.yml`
- `curl -fsSL https://raw.githubusercontent.com/actions/upload-artifact/v6/action.yml | sed -n '1,80p'`
- `curl -fsSL https://raw.githubusercontent.com/actions/download-artifact/v7/action.yml | sed -n '1,80p'`
- `curl -fsSL https://raw.githubusercontent.com/docker/setup-buildx-action/v4/action.yml | tail -n 20`
- `curl -fsSL https://raw.githubusercontent.com/Azure/setup-kubectl/v5/action.yml | sed -n '1,80p'`
- `curl -fsSL https://raw.githubusercontent.com/peter-evans/create-pull-request/v8/action.yml | tail -n 20`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
