### PR TITLE
chore(jangar): promote image b9c34796

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: eb7143dc
-  digest: sha256:6002f310181c319e03ec3cc0dca027030ff5a08e7611ca4520e9c6682dfc0d02
+  tag: b9c34796
+  digest: sha256:932da28eb77437a8736d817089a67b57a7fb1c3b5bc42f428f8fccefaa977895
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: eb7143dc
-    digest: sha256:1fcb3ba65c752957c3a4583ca2adef01a039857f067d6138f24199b6bb9df8e3
+    tag: b9c34796
+    digest: sha256:c6f2f325bef18e201b5a7b3400baf8cf62abb0d5e6bb5418ff74407e5cbb52fc
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: eb7143dc
-    digest: sha256:6002f310181c319e03ec3cc0dca027030ff5a08e7611ca4520e9c6682dfc0d02
+    tag: b9c34796
+    digest: sha256:932da28eb77437a8736d817089a67b57a7fb1c3b5bc42f428f8fccefaa977895
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-04-10T18:21:52Z
+    deploy.knative.dev/rollout: 2026-04-10T18:39:40Z
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/name: jangar-worker
     app.kubernetes.io/part-of: lab
   annotations:
-    kubectl.kubernetes.io/restartedAt: 2026-04-10T18:21:52Z
+    kubectl.kubernetes.io/restartedAt: 2026-04-10T18:39:40Z
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -60,5 +60,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: eb7143dc
-    digest: sha256:6002f310181c319e03ec3cc0dca027030ff5a08e7611ca4520e9c6682dfc0d02
+    newTag: b9c34796
+    digest: sha256:932da28eb77437a8736d817089a67b57a7fb1c3b5bc42f428f8fccefaa977895


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `b9c347969ca33a92f673e0319b8798aa80aa1e31`
- Image tag: `b9c34796`
- Image digest: `sha256:932da28eb77437a8736d817089a67b57a7fb1c3b5bc42f428f8fccefaa977895`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`