### PR TITLE
ci(agents): reuse published jangar image for workflow-only changes

### DIFF
--- a/packages/scripts/src/agents/__tests__/resolve-jangar-image-mode.test.ts
+++ b/packages/scripts/src/agents/__tests__/resolve-jangar-image-mode.test.ts
@@ -28,6 +28,20 @@ describe('classifyJangarImageMode', () => {
     })
   })
 
+  it('reuses the published image for jangar build workflow-only changes', () => {
+    expect(
+      classifyJangarImageMode([
+        '.github/workflows/jangar-build-push.yaml',
+        '.github/workflows/jangar-release.yml',
+        '.github/workflows/jangar-post-deploy-verify.yml',
+      ]),
+    ).toEqual({
+      mode: 'reuse-published-image',
+      needsLocalJangarImage: false,
+      matchedPaths: [],
+    })
+  })
+
   it('builds a local image for jangar changes', () => {
     const result = classifyJangarImageMode(['services/jangar/src/server/control-plane-status.ts'])
     expect(result.mode).toBe('build-local-image')

--- a/packages/scripts/src/agents/resolve-jangar-image-mode.ts
+++ b/packages/scripts/src/agents/resolve-jangar-image-mode.ts
@@ -15,7 +15,6 @@ const LOCAL_IMAGE_PREFIXES = [
 const LOCAL_IMAGE_EXACT_PATHS = new Set([
   'bun.lock',
   'package.json',
-  '.github/workflows/jangar-build-push.yaml',
   'packages/scripts/src/jangar/build-control-plane-image.ts',
   'packages/scripts/src/jangar/build-image.ts',
   'packages/scripts/src/shared/docker.ts',


### PR DESCRIPTION
## Summary

- stop treating `.github/workflows/jangar-build-push.yaml` as a local Jangar image rebuild trigger inside `agents-ci`
- keep local image rebuilds for real Jangar/runtime/build-script changes while reusing the published image for workflow-only edits
- add a regression test covering Jangar workflow-only path classification

## Related Issues

None

## Testing

- `~/.bun/bin/bun test packages/scripts/src/agents/__tests__/resolve-jangar-image-mode.test.ts`
- `printf '%s\n' '.github/workflows/jangar-build-push.yaml' | ~/.bun/bin/bun packages/scripts/src/agents/resolve-jangar-image-mode.ts`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
