### PR TITLE
fix(torghut): repair runtime research replay parity

### DIFF
--- a/services/torghut/app/trading/decisions.py
+++ b/services/torghut/app/trading/decisions.py
@@ -48,6 +48,7 @@ logger = logging.getLogger(__name__)
 _SHORT_ENTRY_BELOW_MIN_QTY_REASON = "short_entry_below_min_qty"
 _SAME_DIRECTION_REENTRY_REASON = "same_direction_reentry"
 _EXIT_ONLY_SELL_FLAT_REASON = "exit_only_sell_without_long_position"
+_EXIT_ONLY_BUY_FLAT_REASON = "exit_only_buy_without_short_position"
 _RUNTIME_TRADE_POLICY_SHARED_OWNER = "__shared__"
 
 
@@ -305,6 +306,7 @@ class DecisionEngine:
                 strategy_id=primary_strategy_id,
             )
             if not _passes_runtime_trade_policy(
+                strategies=source_strategies,
                 last_emitted_action_at=self._last_emitted_action_at,
                 runtime_trade_policy_state=self._runtime_trade_policy_state,
                 signal_ts=signal.event_ts,
@@ -410,6 +412,7 @@ class DecisionEngine:
                 )
             ] = signal.event_ts
             _record_runtime_trade_policy_decision(
+                strategies=source_strategies,
                 runtime_trade_policy_state=self._runtime_trade_policy_state,
                 signal_ts=signal.event_ts,
                 symbol=symbol,
@@ -524,6 +527,7 @@ class DecisionEngine:
                     position_isolation_mode="per_strategy",
                 )
                 if not _passes_runtime_trade_policy(
+                    strategies=[strategy],
                     last_emitted_action_at=self._last_emitted_action_at,
                     runtime_trade_policy_state=self._runtime_trade_policy_state,
                     signal_ts=signal.event_ts,
@@ -538,6 +542,7 @@ class DecisionEngine:
                     continue
                 decisions.append(overlay_decision)
                 _record_runtime_trade_policy_decision(
+                    strategies=[strategy],
                     runtime_trade_policy_state=self._runtime_trade_policy_state,
                     signal_ts=signal.event_ts,
                     symbol=signal.symbol,
@@ -598,6 +603,11 @@ class DecisionEngine:
                 ]
             )
             if not _passes_runtime_trade_policy(
+                strategies=[
+                    strategy
+                    for strategy in strategies
+                    if str(strategy.id) in non_isolated_strategy_ids
+                ],
                 last_emitted_action_at=self._last_emitted_action_at,
                 runtime_trade_policy_state=self._runtime_trade_policy_state,
                 signal_ts=signal.event_ts,
@@ -611,6 +621,11 @@ class DecisionEngine:
                 return decisions
             decisions.append(overlay_decision)
             _record_runtime_trade_policy_decision(
+                strategies=[
+                    strategy
+                    for strategy in strategies
+                    if str(strategy.id) in non_isolated_strategy_ids
+                ],
                 runtime_trade_policy_state=self._runtime_trade_policy_state,
                 signal_ts=signal.event_ts,
                 symbol=signal.symbol,
@@ -1165,10 +1180,19 @@ def _resolve_qty(
     position_qty = _position_qty_for_symbol(positions, symbol)
     normalized_action = action.strip().lower()
     exit_only_sell = _treats_sell_as_exit_only(strategy) and normalized_action == "sell"
+    exit_only_buy = _treats_buy_as_exit_only(strategy) and normalized_action == "buy"
     if exit_only_sell and position_qty is not None and position_qty <= 0:
         return Decimal("0"), {
             "method": method,
             "reason": _EXIT_ONLY_SELL_FLAT_REASON,
+            "notional_budget": str(notional_budget),
+            "price": str(price),
+            "position_qty": str(position_qty),
+        }
+    if exit_only_buy and position_qty is not None and position_qty >= 0:
+        return Decimal("0"), {
+            "method": method,
+            "reason": _EXIT_ONLY_BUY_FLAT_REASON,
             "notional_budget": str(notional_budget),
             "price": str(price),
             "position_qty": str(position_qty),
@@ -1190,6 +1214,8 @@ def _resolve_qty(
     requested_qty = notional_budget / price
     if exit_only_sell and position_qty is not None and position_qty > 0:
         requested_qty = position_qty
+    if exit_only_buy and position_qty is not None and position_qty < 0:
+        requested_qty = abs(position_qty)
     capped_requested_qty = _cap_requested_qty_by_symbol_cap(
         action=normalized_action,
         requested_qty=requested_qty,
@@ -1376,10 +1402,21 @@ def _resolve_qty_for_aggregated(
     exit_only_sell = (
         _treats_sell_as_exit_only_any(strategies) and normalized_action == "sell"
     )
+    exit_only_buy = (
+        _treats_buy_as_exit_only_any(strategies) and normalized_action == "buy"
+    )
     if exit_only_sell and position_qty is not None and position_qty <= 0:
         return Decimal("0"), {
             "method": budget_method,
             "reason": _EXIT_ONLY_SELL_FLAT_REASON,
+            "notional_budget": str(total_budget),
+            "price": str(price),
+            "position_qty": str(position_qty),
+        }
+    if exit_only_buy and position_qty is not None and position_qty >= 0:
+        return Decimal("0"), {
+            "method": budget_method,
+            "reason": _EXIT_ONLY_BUY_FLAT_REASON,
             "notional_budget": str(total_budget),
             "price": str(price),
             "position_qty": str(position_qty),
@@ -1401,6 +1438,8 @@ def _resolve_qty_for_aggregated(
     requested_qty = total_budget / price
     if exit_only_sell and position_qty is not None and position_qty > 0:
         requested_qty = position_qty
+    if exit_only_buy and position_qty is not None and position_qty < 0:
+        requested_qty = abs(position_qty)
     capped_requested_qty = _cap_requested_qty_by_symbol_cap(
         action=normalized_action,
         requested_qty=requested_qty,
@@ -1544,6 +1583,7 @@ def _skip_non_executable_decision_qty(
     reason = str(sizing_meta.get("reason") or "").strip()
     return qty <= 0 and reason in {
         _EXIT_ONLY_SELL_FLAT_REASON,
+        _EXIT_ONLY_BUY_FLAT_REASON,
         _SHORT_ENTRY_BELOW_MIN_QTY_REASON,
         _SAME_DIRECTION_REENTRY_REASON,
         "symbol_capacity_exhausted",
@@ -1859,6 +1899,7 @@ def _blocks_same_direction_reentry(strategy: Strategy) -> bool:
         "intraday_tsmom",
         "tsmom_intraday",
         "momentum_pullback_long_v1",
+        "microbar_cross_sectional_long_v1",
         "breakout_continuation_long_v1",
         "washout_rebound_long_v1",
         "mean_reversion_rebound_long_v1",
@@ -1949,11 +1990,20 @@ def _treats_sell_as_exit_only(strategy: Strategy) -> bool:
         "intraday_tsmom",
         "tsmom_intraday",
         "momentum_pullback_long_v1",
+        "microbar_cross_sectional_long_v1",
         "breakout_continuation_long_v1",
         "washout_rebound_long_v1",
         "mean_reversion_rebound_long_v1",
         "late_day_continuation_long_v1",
         "end_of_day_reversal_long_v1",
+    }
+
+
+def _treats_buy_as_exit_only(strategy: Strategy) -> bool:
+    normalized = str(strategy.universe_type or "").strip().lower()
+    return normalized in {
+        "mean_reversion_exhaustion_short_v1",
+        "microbar_cross_sectional_short_v1",
     }
 
 
@@ -1963,6 +2013,39 @@ def _blocks_same_direction_reentry_any(strategies: list[Strategy]) -> bool:
 
 def _treats_sell_as_exit_only_any(strategies: list[Strategy]) -> bool:
     return any(_treats_sell_as_exit_only(strategy) for strategy in strategies)
+
+
+def _treats_buy_as_exit_only_any(strategies: list[Strategy]) -> bool:
+    return any(_treats_buy_as_exit_only(strategy) for strategy in strategies)
+
+
+def _is_entry_action_for_strategies(*, strategies: list[Strategy], action: str) -> bool:
+    normalized_action = action.strip().lower()
+    if normalized_action == "buy":
+        return not _treats_buy_as_exit_only_any(strategies)
+    if normalized_action == "sell":
+        return not _treats_sell_as_exit_only_any(strategies)
+    return False
+
+
+def _is_exit_action_for_strategies(*, strategies: list[Strategy], action: str) -> bool:
+    normalized_action = action.strip().lower()
+    if normalized_action == "buy":
+        return _treats_buy_as_exit_only_any(strategies)
+    if normalized_action == "sell":
+        return _treats_sell_as_exit_only_any(strategies)
+    return False
+
+
+def _exit_position_side_for_strategies(
+    *, strategies: list[Strategy], action: str
+) -> Literal["long", "short"] | None:
+    normalized_action = action.strip().lower()
+    if normalized_action == "sell" and _treats_sell_as_exit_only_any(strategies):
+        return "long"
+    if normalized_action == "buy" and _treats_buy_as_exit_only_any(strategies):
+        return "short"
+    return None
 
 
 def _same_direction_reentry_exists(
@@ -2275,7 +2358,10 @@ def _realized_exit_bps(
     *,
     avg_entry_price: Decimal,
     exit_price: Decimal,
+    position_side: Literal["long", "short"] = "long",
 ) -> Decimal:
+    if position_side == "short":
+        return ((avg_entry_price - exit_price) / avg_entry_price) * Decimal("10000")
     return ((exit_price - avg_entry_price) / avg_entry_price) * Decimal("10000")
 
 
@@ -2513,6 +2599,7 @@ def _resolve_runtime_trade_policy(strategies: list[Strategy]) -> dict[str, int |
 
 def _passes_runtime_trade_policy(
     *,
+    strategies: list[Strategy],
     last_emitted_action_at: dict[tuple[str, str, str | None], datetime],
     runtime_trade_policy_state: dict[tuple[str, str], _RuntimeTradePolicySessionState],
     signal_ts: datetime,
@@ -2531,11 +2618,28 @@ def _passes_runtime_trade_policy(
         symbol=symbol,
         position_owner=position_owner,
     )
-    if normalized_action == "buy":
+    entry_action = _is_entry_action_for_strategies(
+        strategies=strategies,
+        action=normalized_action,
+    )
+    exit_action = _is_exit_action_for_strategies(
+        strategies=strategies,
+        action=normalized_action,
+    )
+    if entry_action:
         max_concurrent_positions = max(0, int(policy.get("max_concurrent_positions", 0)))
         if (
             max_concurrent_positions > 0
-            and _count_open_long_positions(positions) >= max_concurrent_positions
+            and (
+                (
+                    normalized_action == "buy"
+                    and _count_open_long_positions(positions) >= max_concurrent_positions
+                )
+                or (
+                    normalized_action == "sell"
+                    and _count_open_short_positions(positions) >= max_concurrent_positions
+                )
+            )
         ):
             return False
         max_entries_per_session = max(0, int(policy.get("max_entries_per_session", 0)))
@@ -2588,9 +2692,7 @@ def _passes_runtime_trade_policy(
             return False
 
     cooldown_key = (
-        "entry_cooldown_seconds"
-        if normalized_action == "buy"
-        else "exit_cooldown_seconds"
+        "entry_cooldown_seconds" if entry_action else "exit_cooldown_seconds"
     )
     cooldown_seconds = max(0, int(policy.get(cooldown_key, 0)))
     last_emitted = last_emitted_action_at.get(
@@ -2608,7 +2710,7 @@ def _passes_runtime_trade_policy(
     ):
         return False
 
-    if normalized_action != "sell":
+    if not exit_action:
         return True
 
     if _position_exit_bypasses_min_hold(position_exit_type):
@@ -2650,7 +2752,11 @@ def _resolve_strategy_time_in_force(
     action: str,
 ) -> str:
     normalized_action = str(action or "").strip().lower()
-    param_key = "entry_time_in_force" if normalized_action == "buy" else "exit_time_in_force"
+    param_key = (
+        "entry_time_in_force"
+        if _is_entry_action_for_strategies(strategies=strategies, action=normalized_action)
+        else "exit_time_in_force"
+    )
     supported_values = {"day", "gtc", "ioc", "fok"}
     for strategy in strategies:
         params = StrategyRuntime.definition_from_strategy(strategy).params
@@ -2699,6 +2805,7 @@ def _resolve_runtime_trade_policy_session_state(
 
 def _record_runtime_trade_policy_decision(
     *,
+    strategies: list[Strategy],
     runtime_trade_policy_state: dict[tuple[str, str], _RuntimeTradePolicySessionState],
     signal_ts: datetime,
     symbol: str,
@@ -2717,10 +2824,18 @@ def _record_runtime_trade_policy_decision(
         symbol=symbol,
         position_owner=position_owner,
     )
-    if normalized_action == "buy":
+    entry_action = _is_entry_action_for_strategies(
+        strategies=strategies,
+        action=normalized_action,
+    )
+    exit_side = _exit_position_side_for_strategies(
+        strategies=strategies,
+        action=normalized_action,
+    )
+    if entry_action:
         state.entry_count += 1
         return
-    if normalized_action != "sell" or price is None or price <= 0:
+    if exit_side is None or price is None or price <= 0:
         return
 
     position_exit = decision.params.get("position_exit")
@@ -2738,7 +2853,12 @@ def _record_runtime_trade_policy_decision(
         return
     realized_bps = _realized_exit_bps(
         avg_entry_price=avg_entry_price,
-        exit_price=_reference_exit_price(price=price, signal=signal, action="sell"),
+        exit_price=_reference_exit_price(
+            price=price,
+            signal=signal,
+            action=normalized_action,
+        ),
+        position_side=exit_side,
     )
     if realized_bps >= 0:
         return
@@ -2762,16 +2882,18 @@ def _passes_signal_exit_policy(
     positions: Optional[list[dict[str, Any]]],
 ) -> bool:
     normalized_action = action.strip().lower()
-    if (
-        normalized_action != "sell"
-        or price is None
-        or price <= 0
-        or not _treats_sell_as_exit_only_any(strategies)
-    ):
+    exit_side = _exit_position_side_for_strategies(
+        strategies=strategies,
+        action=normalized_action,
+    )
+    if exit_side is None or price is None or price <= 0:
         return True
 
     position_qty = _position_qty_for_symbol(positions, symbol)
-    if position_qty is None or position_qty <= 0:
+    if (
+        (exit_side == "long" and (position_qty is None or position_qty <= 0))
+        or (exit_side == "short" and (position_qty is None or position_qty >= 0))
+    ):
         return True
 
     avg_entry_price = _position_avg_entry_price_for_symbol(positions, symbol)
@@ -2786,6 +2908,7 @@ def _passes_signal_exit_policy(
     realized_bps = _realized_exit_bps(
         avg_entry_price=avg_entry_price,
         exit_price=reference_exit_price,
+        position_side=exit_side,
     )
     return _passes_exit_profit_policy(
         strategies=strategies,
@@ -2981,6 +3104,36 @@ def _count_open_long_positions(positions: Optional[list[dict[str, Any]]]) -> int
         except (ArithmeticError, ValueError):
             continue
         if market_value > 0:
+            open_symbols.add(symbol)
+    return len(open_symbols)
+
+
+def _count_open_short_positions(positions: Optional[list[dict[str, Any]]]) -> int:
+    if not positions:
+        return 0
+    open_symbols: set[str] = set()
+    for position in positions:
+        symbol = str(position.get("symbol") or "").strip().upper()
+        if not symbol:
+            continue
+        qty = _position_qty_from_payload(position)
+        if qty is not None:
+            if qty < 0:
+                open_symbols.add(symbol)
+            continue
+        raw_value = (
+            position.get("market_value")
+            or position.get("current_value")
+            or position.get("notional")
+        )
+        if raw_value is None:
+            continue
+        try:
+            market_value = Decimal(str(raw_value))
+        except (ArithmeticError, ValueError):
+            continue
+        side = str(position.get("side") or "").strip().lower()
+        if side == "short" and market_value != 0:
             open_symbols.add(symbol)
     return len(open_symbols)
 

--- a/services/torghut/app/trading/execution_policy.py
+++ b/services/torghut/app/trading/execution_policy.py
@@ -851,7 +851,7 @@ def _should_keep_market_order_for_high_conviction_entry(
     price: Decimal | None,
     spread: Decimal | None,
 ) -> bool:
-    if decision.action != "buy" or decision.order_type != "market":
+    if decision.order_type != "market":
         return False
     if decision.params.get("position_exit") is not None:
         return False
@@ -924,6 +924,17 @@ def _should_keep_market_order_for_high_conviction_entry(
         ):
             return False
         return True
+
+    if {
+        "microbar_cross_sectional_long_v1",
+        "microbar_cross_sectional_short_v1",
+    } & strategy_types:
+        rationale_tokens = {
+            token.strip().lower()
+            for token in str(decision.rationale or "").split(",")
+            if token.strip()
+        }
+        return "microbar_cross_sectional_entry" in rationale_tokens
 
     return False
 

--- a/services/torghut/app/trading/features.py
+++ b/services/torghut/app/trading/features.py
@@ -73,6 +73,8 @@ FEATURE_VECTOR_V3_VALUE_FIELDS = (
     'cross_section_prev_session_close_rank',
     'cross_section_opening_window_return_rank',
     'cross_section_opening_window_return_from_prev_close_rank',
+    'cross_section_prev_day_open45_return_rank',
+    'cross_section_prev_day_open60_return_rank',
     'cross_section_range_position_rank',
     'cross_section_vwap_w5m_rank',
     'cross_section_recent_imbalance_rank',
@@ -80,6 +82,8 @@ FEATURE_VECTOR_V3_VALUE_FIELDS = (
     'cross_section_positive_prev_session_close_ratio',
     'cross_section_positive_opening_window_return_ratio',
     'cross_section_positive_opening_window_return_from_prev_close_ratio',
+    'cross_section_positive_prev_day_open45_return_ratio',
+    'cross_section_positive_prev_day_open60_return_ratio',
     'cross_section_above_vwap_w5m_ratio',
     'cross_section_positive_recent_imbalance_ratio',
     'cross_section_continuation_breadth',
@@ -415,6 +419,12 @@ def map_feature_values_v3(signal: SignalEnvelope) -> dict[str, Any]:
         'cross_section_opening_window_return_from_prev_close_rank': optional_decimal(
             payload.get('cross_section_opening_window_return_from_prev_close_rank')
         ),
+        'cross_section_prev_day_open45_return_rank': optional_decimal(
+            payload.get('cross_section_prev_day_open45_return_rank')
+        ),
+        'cross_section_prev_day_open60_return_rank': optional_decimal(
+            payload.get('cross_section_prev_day_open60_return_rank')
+        ),
         'cross_section_range_position_rank': optional_decimal(payload.get('cross_section_range_position_rank')),
         'cross_section_vwap_w5m_rank': optional_decimal(payload.get('cross_section_vwap_w5m_rank')),
         'cross_section_recent_imbalance_rank': optional_decimal(payload.get('cross_section_recent_imbalance_rank')),
@@ -427,6 +437,12 @@ def map_feature_values_v3(signal: SignalEnvelope) -> dict[str, Any]:
         ),
         'cross_section_positive_opening_window_return_from_prev_close_ratio': optional_decimal(
             payload.get('cross_section_positive_opening_window_return_from_prev_close_ratio')
+        ),
+        'cross_section_positive_prev_day_open45_return_ratio': optional_decimal(
+            payload.get('cross_section_positive_prev_day_open45_return_ratio')
+        ),
+        'cross_section_positive_prev_day_open60_return_ratio': optional_decimal(
+            payload.get('cross_section_positive_prev_day_open60_return_ratio')
         ),
         'cross_section_above_vwap_w5m_ratio': optional_decimal(payload.get('cross_section_above_vwap_w5m_ratio')),
         'cross_section_positive_recent_imbalance_ratio': optional_decimal(

--- a/services/torghut/app/trading/research_sleeves.py
+++ b/services/torghut/app/trading/research_sleeves.py
@@ -270,6 +270,20 @@ def _exit_trigger_gate(
     )
 
 
+def _rank_thresholds(
+    *,
+    universe_size: int,
+    top_n: int,
+) -> tuple[Decimal, Decimal]:
+    if universe_size <= 1:
+        return (Decimal('0'), Decimal('1'))
+    resolved_top_n = min(max(1, top_n), universe_size)
+    denominator = Decimal(universe_size - 1)
+    low_threshold = Decimal(resolved_top_n - 1) / denominator
+    high_threshold = Decimal(universe_size - resolved_top_n) / denominator
+    return (low_threshold, high_threshold)
+
+
 def evaluate_momentum_pullback_long(
     *,
     params: Mapping[str, Any],
@@ -2230,6 +2244,11 @@ def evaluate_mean_reversion_exhaustion_short(
     cross_section_opening_window_return_from_prev_close_rank: Decimal | None,
     cross_section_continuation_rank: Decimal | None,
     cross_section_reversal_rank: Decimal | None,
+    cross_section_session_open_rank: Decimal | None,
+    cross_section_prev_session_close_rank: Decimal | None,
+    cross_section_range_position_rank: Decimal | None,
+    cross_section_vwap_w5m_rank: Decimal | None,
+    cross_section_recent_imbalance_rank: Decimal | None,
 ) -> SleeveSignalResult:
     trace_context = {'family': 'mean_reversion_exhaustion_short'}
     required_fields = {
@@ -2538,6 +2557,84 @@ def evaluate_mean_reversion_exhaustion_short(
     )
 
     if all(gate.passed for gate in sell_gates):
+        rank_gates: tuple[GateTrace, ...] = ()
+        rank_feature = str(params.get('rank_feature') or '').strip()
+        rank_lookup = {
+            'cross_section_session_open_rank': cross_section_session_open_rank,
+            'cross_section_opening_window_return_rank': cross_section_opening_window_return_rank,
+            'cross_section_prev_session_close_rank': cross_section_prev_session_close_rank,
+            'cross_section_opening_window_return_from_prev_close_rank': cross_section_opening_window_return_from_prev_close_rank,
+            'cross_section_range_position_rank': cross_section_range_position_rank,
+            'cross_section_vwap_w5m_rank': cross_section_vwap_w5m_rank,
+            'cross_section_recent_imbalance_rank': cross_section_recent_imbalance_rank,
+            'cross_section_continuation_rank': cross_section_continuation_rank,
+            'cross_section_reversal_rank': cross_section_reversal_rank,
+        }
+        rank_value = rank_lookup.get(rank_feature)
+        if rank_feature:
+            universe_size = max(2, int(_optional_decimal_param(params, 'universe_size', Decimal('2')) or Decimal('2')))
+            top_n = max(1, int(_optional_decimal_param(params, 'top_n', Decimal('1')) or Decimal('1')))
+            selection_mode = str(params.get('selection_mode') or 'reversal').strip().lower()
+            low_threshold, high_threshold = _rank_thresholds(
+                universe_size=universe_size,
+                top_n=top_n,
+            )
+            should_trade = False
+            comparator = 'gte'
+            threshold_value = high_threshold
+            if selection_mode == 'continuation':
+                comparator = 'lte'
+                threshold_value = low_threshold
+                should_trade = rank_value is not None and rank_value <= low_threshold
+            else:
+                comparator = 'gte'
+                threshold_value = high_threshold
+                should_trade = rank_value is not None and rank_value >= high_threshold
+            rank_gate = _gate(
+                name='rank_selection',
+                category='structure',
+                thresholds=(
+                    ThresholdTrace(
+                        metric=rank_feature,
+                        comparator='min_gte' if comparator == 'gte' else 'max_lte',
+                        value=rank_value,
+                        threshold=threshold_value,
+                        passed=should_trade,
+                        missing_policy='fail_closed',
+                        distance_to_pass=(
+                            Decimal('0')
+                            if should_trade
+                            else (
+                                threshold_value
+                                if rank_value is None
+                                else (
+                                    max(Decimal('0'), threshold_value - rank_value)
+                                    if comparator == 'gte'
+                                    else max(Decimal('0'), rank_value - threshold_value)
+                                )
+                            )
+                        ),
+                    ),
+                ),
+                context={
+                    'selection_mode': selection_mode,
+                    'top_n': top_n,
+                    'universe_size': universe_size,
+                },
+            )
+            rank_gates = (rank_gate,)
+            if not should_trade:
+                return _sleeve_result(
+                    strategy_id=strategy_id,
+                    strategy_type=strategy_type,
+                    symbol=symbol,
+                    event_ts=event_ts,
+                    timeframe=timeframe,
+                    signal=None,
+                    gates=sell_gates + rank_gates,
+                    trace_enabled=trace_enabled,
+                    context=trace_context,
+                )
         confidence = Decimal('0.64')
         if price_vs_vwap_bps is not None and price_vs_vwap_bps >= Decimal('16'):
             confidence += Decimal('0.03')
@@ -2576,6 +2673,10 @@ def evaluate_mean_reversion_exhaustion_short(
                     'above_vwap',
                     'session_overextension',
                     'offer_pressure_confirmed',
+                    *((
+                        f"selection_mode:{str(params.get('selection_mode') or 'reversal').strip().lower()}",
+                        f"rank_feature:{rank_feature}",
+                    ) if rank_feature else ()),
                 ),
                 notional_multiplier=_resolve_entry_notional_multiplier(
                     params=params,
@@ -2585,7 +2686,7 @@ def evaluate_mean_reversion_exhaustion_short(
                     spread_cap_bps=spread_cap_bps,
                 ),
             ),
-            gates=sell_gates,
+            gates=sell_gates + rank_gates,
             trace_enabled=trace_enabled,
             context=trace_context,
         )

--- a/services/torghut/app/trading/session_context.py
+++ b/services/torghut/app/trading/session_context.py
@@ -174,6 +174,8 @@ class _SymbolSessionState:
     latest_recent_quote_jump_bps_max: Decimal | None = None
     latest_recent_microprice_bias_bps_avg: Decimal | None = None
     last_valid_quote_price: Decimal | None = None
+    opening_45_return_bps: Decimal | None = None
+    opening_60_return_bps: Decimal | None = None
 
 
 class SessionContextTracker:
@@ -191,6 +193,8 @@ class SessionContextTracker:
         self.quote_quality_policy = quote_quality_policy or QuoteQualityPolicy()
         self._state_by_symbol: dict[str, _SymbolSessionState] = {}
         self._last_session_close_by_symbol: dict[str, Decimal] = {}
+        self._last_opening_45_return_by_symbol: dict[str, Decimal] = {}
+        self._last_opening_60_return_by_symbol: dict[str, Decimal] = {}
 
     def enrich_signal_payload(self, signal: SignalEnvelope) -> dict[str, Any]:
         payload = dict(signal.payload)
@@ -207,16 +211,8 @@ class SessionContextTracker:
             tzinfo=timezone.utc,
         )
         regular_session_started = signal_ts_utc >= session_open_ts
+        self._roll_forward_completed_sessions(next_session_day=session_day)
         state = self._state_by_symbol.get(symbol)
-        if state is not None and state.session_day != session_day:
-            previous_close = (
-                state.last_valid_quote_price
-                or state.opening_window_close_price
-                or state.session_open_price
-            )
-            if previous_close > 0:
-                self._last_session_close_by_symbol[symbol] = previous_close
-            state = None
         quote_quality = assess_signal_quote_quality(
             signal=signal,
             previous_price=(state.last_valid_quote_price if state is not None else None),
@@ -356,6 +352,10 @@ class SessionContextTracker:
         state.latest_recent_quote_jump_bps_avg = recent_quote_jump_bps_avg
         state.latest_recent_quote_jump_bps_max = recent_quote_jump_bps_max
         state.latest_recent_microprice_bias_bps_avg = recent_microprice_bias_bps_avg
+        if minutes_elapsed >= 45 and state.opening_45_return_bps is None:
+            state.opening_45_return_bps = price_vs_session_open_bps
+        if minutes_elapsed >= 60 and state.opening_60_return_bps is None:
+            state.opening_60_return_bps = price_vs_session_open_bps
 
         session_open_rank = self._rank_latest_metric(
             current_day=session_day,
@@ -392,6 +392,14 @@ class SessionContextTracker:
             symbol=symbol,
             accessor='latest_opening_window_return_from_prev_close_bps',
         )
+        prev_day_open45_return_rank = _percentile_rank(
+            self._last_opening_45_return_by_symbol,
+            symbol=symbol,
+        )
+        prev_day_open60_return_rank = _percentile_rank(
+            self._last_opening_60_return_by_symbol,
+            symbol=symbol,
+        )
         positive_session_open_ratio = self._positive_ratio_latest_metric(
             current_day=session_day,
             accessor='latest_price_vs_session_open_bps',
@@ -417,6 +425,12 @@ class SessionContextTracker:
         positive_recent_imbalance_ratio = self._positive_ratio_latest_metric(
             current_day=session_day,
             accessor='latest_recent_imbalance_pressure_avg',
+        )
+        positive_prev_day_open45_return_ratio = _ratio_decimal(
+            [value > 0 for value in self._last_opening_45_return_by_symbol.values()]
+        )
+        positive_prev_day_open60_return_ratio = _ratio_decimal(
+            [value > 0 for value in self._last_opening_60_return_by_symbol.values()]
         )
         effective_session_drive_rank = (
             prev_session_close_rank
@@ -518,6 +532,8 @@ class SessionContextTracker:
                 'cross_section_opening_window_return_from_prev_close_rank': (
                     opening_window_prev_close_return_rank
                 ),
+                'cross_section_prev_day_open45_return_rank': prev_day_open45_return_rank,
+                'cross_section_prev_day_open60_return_rank': prev_day_open60_return_rank,
                 'cross_section_range_position_rank': range_position_rank,
                 'cross_section_vwap_w5m_rank': vwap_w5m_rank,
                 'cross_section_recent_imbalance_rank': recent_imbalance_rank,
@@ -526,6 +542,12 @@ class SessionContextTracker:
                 'cross_section_positive_opening_window_return_ratio': positive_opening_window_return_ratio,
                 'cross_section_positive_opening_window_return_from_prev_close_ratio': (
                     positive_opening_window_return_from_prev_close_ratio
+                ),
+                'cross_section_positive_prev_day_open45_return_ratio': (
+                    positive_prev_day_open45_return_ratio
+                ),
+                'cross_section_positive_prev_day_open60_return_ratio': (
+                    positive_prev_day_open60_return_ratio
                 ),
                 'cross_section_above_vwap_w5m_ratio': above_vwap_w5m_ratio,
                 'cross_section_positive_recent_imbalance_ratio': positive_recent_imbalance_ratio,
@@ -536,6 +558,23 @@ class SessionContextTracker:
             }
         )
         return payload
+
+    def _roll_forward_completed_sessions(self, *, next_session_day: date) -> None:
+        for candidate_symbol, state in list(self._state_by_symbol.items()):
+            if state.session_day >= next_session_day:
+                continue
+            previous_close = (
+                state.last_valid_quote_price
+                or state.opening_window_close_price
+                or state.session_open_price
+            )
+            if previous_close > 0:
+                self._last_session_close_by_symbol[candidate_symbol] = previous_close
+            if state.opening_45_return_bps is not None:
+                self._last_opening_45_return_by_symbol[candidate_symbol] = state.opening_45_return_bps
+            if state.opening_60_return_bps is not None:
+                self._last_opening_60_return_by_symbol[candidate_symbol] = state.opening_60_return_bps
+            del self._state_by_symbol[candidate_symbol]
 
     def _rank_latest_metric(
         self,

--- a/services/torghut/app/trading/strategy_runtime.py
+++ b/services/torghut/app/trading/strategy_runtime.py
@@ -1343,6 +1343,11 @@ class MeanReversionExhaustionShortPlugin:
         "cross_section_opening_window_return_from_prev_close_rank",
         "cross_section_continuation_rank",
         "cross_section_reversal_rank",
+        "cross_section_session_open_rank",
+        "cross_section_prev_session_close_rank",
+        "cross_section_range_position_rank",
+        "cross_section_vwap_w5m_rank",
+        "cross_section_recent_imbalance_rank",
     )
 
     def evaluate(
@@ -1398,6 +1403,21 @@ class MeanReversionExhaustionShortPlugin:
             ),
             cross_section_reversal_rank=_decimal(
                 features.values.get("cross_section_reversal_rank")
+            ),
+            cross_section_session_open_rank=_decimal(
+                features.values.get("cross_section_session_open_rank")
+            ),
+            cross_section_prev_session_close_rank=_decimal(
+                features.values.get("cross_section_prev_session_close_rank")
+            ),
+            cross_section_range_position_rank=_decimal(
+                features.values.get("cross_section_range_position_rank")
+            ),
+            cross_section_vwap_w5m_rank=_decimal(
+                features.values.get("cross_section_vwap_w5m_rank")
+            ),
+            cross_section_recent_imbalance_rank=_decimal(
+                features.values.get("cross_section_recent_imbalance_rank")
             ),
         )
         return _plugin_result_from_sleeve_result(

--- a/services/torghut/config/trading/families/mean_reversion_exhaustion_short_v1.yaml
+++ b/services/torghut/config/trading/families/mean_reversion_exhaustion_short_v1.yaml
@@ -1,0 +1,53 @@
+schema_version: torghut.family-template.v1
+family_id: mean_reversion_exhaustion_short_v1
+economic_mechanism: Controlled intraday short fade after upside exhaustion with offer-pressure and quote-quality confirmation.
+supported_markets:
+  - us_equities_intraday
+required_features:
+  - session_open_extension
+  - reversal_rank
+  - quote_quality
+  - offer_pressure
+  - session_range_position
+allowed_normalizations:
+  - price_scaled
+  - opening_window_scaled
+entry_motifs:
+  - mean_reversion_exhaustion_short
+  - upside_exhaustion
+  - overbought_fade
+exit_motifs:
+  - vwap_reversion
+  - fade_complete
+  - close_flatten
+risk_controls:
+  - quote_quality_veto
+  - max_hold_seconds
+  - max_session_negative_exit_bps
+activity_model:
+  min_active_day_ratio: '0.55'
+  min_daily_notional: '250000'
+liquidity_assumptions:
+  max_spread_bps: '12'
+  min_quote_valid_ratio: '0.88'
+regime_activation_rules:
+  - metric: market_breadth
+    comparator: gte
+    threshold: '0.35'
+day_veto_rules:
+  - rule: quote_quality
+    action: block_day
+default_hard_vetoes:
+  required_min_active_day_ratio: '0.55'
+  required_min_daily_notional: '250000'
+  required_max_best_day_share: '0.45'
+  required_max_worst_day_loss: '500'
+  required_max_drawdown: '1000'
+  required_min_regime_slice_pass_rate: '0.35'
+default_selection_objectives:
+  target_net_pnl_per_day: '250'
+  require_positive_day_ratio: '0.50'
+runtime_harness:
+  family: mean_reversion_exhaustion_short_consistent
+  strategy_name: mean-reversion-exhaustion-short-v1
+  disable_other_strategies: true

--- a/services/torghut/config/trading/profitability-frontier-strict-daily-exhaustion-short.yaml
+++ b/services/torghut/config/trading/profitability-frontier-strict-daily-exhaustion-short.yaml
@@ -1,0 +1,92 @@
+schema_version: torghut.replay-frontier-sweep.v1
+family: mean_reversion_exhaustion_short_consistent
+family_template_id: mean_reversion_exhaustion_short_v1
+strategy_name: mean-reversion-exhaustion-short-v1
+disable_other_strategies: true
+constraints:
+  holdout_target_net_per_day: '500'
+  min_active_holdout_days: 2
+  max_worst_holdout_day_loss: '250'
+  min_profit_factor: '1.05'
+  require_training_decisions: true
+  require_holdout_decisions: true
+consistency_constraints:
+  target_net_per_day: '500'
+  min_active_days: 8
+  min_active_ratio: '1.0'
+  min_positive_days: 5
+  max_worst_day_loss: '350'
+  max_negative_days: 2
+  max_drawdown: '900'
+  max_best_day_share_of_total_pnl: '0.30'
+  min_avg_filled_notional_per_day: '250000'
+  min_avg_filled_notional_per_active_day: '300000'
+  min_regime_slice_pass_rate: '0.45'
+  require_every_day_active: true
+strategy_overrides:
+  universe_symbols:
+    - ['AAPL', 'AMAT', 'AMD', 'AVGO', 'GOOG', 'INTC', 'META', 'MSFT', 'MU', 'NVDA', 'PLTR', 'SHOP']
+  max_position_pct_equity:
+    - '1.0'
+  max_notional_per_trade:
+    - '30000'
+parameters:
+  min_price_vs_session_open_bps:
+    - '20'
+    - '30'
+    - '40'
+  min_opening_window_return_bps:
+    - '5'
+    - '10'
+    - '15'
+  min_session_range_position:
+    - '0.68'
+    - '0.76'
+    - '0.84'
+  min_price_vs_opening_range_high_bps:
+    - '-8'
+    - '-4'
+    - '0'
+  max_price_vs_opening_range_high_bps:
+    - '8'
+    - '12'
+  max_recent_spread_bps:
+    - '4'
+    - '8'
+  max_recent_quote_invalid_ratio:
+    - '0.12'
+    - '0.18'
+    - '0.30'
+  max_recent_quote_jump_bps:
+    - '35'
+    - '55'
+  max_recent_microprice_bias_bps:
+    - '-0.10'
+    - '0.00'
+  min_cross_section_reversal_rank:
+    - '0.65'
+    - '0.75'
+    - '0.85'
+  max_cross_section_continuation_rank:
+    - '0.45'
+    - '0.60'
+  rank_feature:
+    - 'cross_section_reversal_rank'
+    - 'cross_section_recent_imbalance_rank'
+    - 'cross_section_range_position_rank'
+  selection_mode:
+    - 'reversal'
+  top_n:
+    - '1'
+  universe_size:
+    - '12'
+  entry_start_minute_utc:
+    - '840'
+    - '855'
+  entry_end_minute_utc:
+    - '1080'
+    - '1125'
+  max_entries_per_session:
+    - '1'
+  max_concurrent_positions:
+    - '1'

--- a/services/torghut/config/trading/research-programs/strict-daily-profit-autoresearch-v1.yaml
+++ b/services/torghut/config/trading/research-programs/strict-daily-profit-autoresearch-v1.yaml
@@ -228,6 +228,44 @@ families:
       max_position_pct_equity:
         mode: explicit_values
         values: ['2.0', '4.0']
+  - family_template_id: mean_reversion_exhaustion_short_v1
+    seed_sweep_config: ../profitability-frontier-strict-daily-exhaustion-short.yaml
+    max_iterations: 2
+    keep_top_candidates: 2
+    frontier_top_n: 5
+    force_keep_top_candidate_if_all_vetoed: true
+    symbol_prune_iterations: 1
+    symbol_prune_candidates: 2
+    symbol_prune_min_universe_size: 5
+    parameter_mutations:
+      min_price_vs_session_open_bps:
+        mode: numeric_step
+        deltas: ['-5', '0', '5']
+        minimum: '15'
+        maximum: '50'
+      min_session_range_position:
+        mode: numeric_step
+        deltas: ['-0.05', '0', '0.05']
+        minimum: '0.60'
+        maximum: '0.90'
+      min_cross_section_reversal_rank:
+        mode: numeric_step
+        deltas: ['-0.05', '0', '0.05']
+        minimum: '0.55'
+        maximum: '0.90'
+      entry_start_minute_utc:
+        mode: numeric_step
+        deltas: ['-15', '0', '15']
+        minimum: '825'
+        maximum: '900'
+      max_recent_quote_invalid_ratio:
+        mode: numeric_step
+        deltas: ['-0.06', '0', '0.06']
+        minimum: '0.06'
+        maximum: '0.36'
+    strategy_override_mutations:
+      normalization_regime:
+        mode: allowed_normalizations
   - family_template_id: end_of_day_reversal_v1
     seed_sweep_config: ../profitability-frontier-strict-daily-end-of-day-reversal.yaml
     max_iterations: 2

--- a/services/torghut/scripts/local_intraday_tsmom_replay.py
+++ b/services/torghut/scripts/local_intraday_tsmom_replay.py
@@ -516,6 +516,21 @@ def _positions_payload(
                     pending_entry=True,
                 )
                 continue
+            if existing.qty < 0:
+                remaining_abs_qty = abs(existing.qty) - min(decision.qty, abs(existing.qty))
+                if remaining_abs_qty <= 0:
+                    projected_positions.pop(position_key, None)
+                    continue
+                projected_positions[position_key] = PositionState(
+                    strategy_id=existing.strategy_id,
+                    qty=-remaining_abs_qty,
+                    avg_entry_price=existing.avg_entry_price,
+                    opened_at=existing.opened_at,
+                    entry_cost_total=existing.entry_cost_total,
+                    decision_at=existing.decision_at,
+                    pending_entry=existing.pending_entry,
+                )
+                continue
             new_qty = existing.qty + decision.qty
             avg_entry = (
                 (existing.avg_entry_price * existing.qty)

--- a/services/torghut/scripts/local_intraday_tsmom_replay.py
+++ b/services/torghut/scripts/local_intraday_tsmom_replay.py
@@ -49,6 +49,7 @@ from app.trading.quote_quality import (
     SignalQuoteQualityTracker,
     assess_signal_quote_quality,
 )
+from app.trading.session_context import SessionContextTracker
 
 logging.getLogger('alembic').setLevel(logging.WARNING)
 
@@ -526,11 +527,36 @@ def _positions_payload(
                 avg_entry_price=avg_entry,
                 opened_at=existing.opened_at,
                 entry_cost_total=existing.entry_cost_total,
+                    decision_at=existing.decision_at,
+                    pending_entry=existing.pending_entry,
+                )
+            continue
+        if existing is None:
+            projected_positions[position_key] = PositionState(
+                strategy_id=owner_strategy_id,
+                qty=-decision.qty,
+                avg_entry_price=reference_price,
+                opened_at=pending.signal.event_ts,
+                entry_cost_total=Decimal('0'),
+                decision_at=pending.created_at,
+                pending_entry=True,
+            )
+            continue
+        if existing.qty < 0:
+            new_abs_qty = abs(existing.qty) + decision.qty
+            avg_entry = (
+                (existing.avg_entry_price * abs(existing.qty))
+                + (reference_price * decision.qty)
+            ) / new_abs_qty
+            projected_positions[position_key] = PositionState(
+                strategy_id=existing.strategy_id,
+                qty=-new_abs_qty,
+                avg_entry_price=avg_entry,
+                opened_at=existing.opened_at,
+                entry_cost_total=existing.entry_cost_total,
                 decision_at=existing.decision_at,
                 pending_entry=existing.pending_entry,
             )
-            continue
-        if existing is None:
             continue
         remaining_qty = existing.qty - min(decision.qty, existing.qty)
         if remaining_qty <= 0:
@@ -549,13 +575,14 @@ def _positions_payload(
     payload: list[dict[str, Any]] = []
     for (symbol, _owner_strategy_id), position in projected_positions.items():
         market_price = last_prices.get(symbol, position.avg_entry_price)
+        signed_qty = position.qty
         payload.append(
             {
                 'symbol': symbol,
                 'strategy_id': position.strategy_id,
-                'qty': str(position.qty),
-                'side': 'long',
-                'market_value': str(position.qty * market_price),
+                'qty': str(abs(signed_qty)),
+                'side': 'short' if signed_qty < 0 else 'long',
+                'market_value': str(signed_qty * market_price),
                 'avg_entry_price': str(position.avg_entry_price),
                 'opened_at': position.opened_at.isoformat(),
                 'decision_at': position.decision_at.isoformat(),
@@ -1094,18 +1121,22 @@ def _close_position(
     *,
     symbol: str,
     position: PositionState,
-    sell_qty: Decimal,
+    close_qty: Decimal,
     fill_price: Decimal,
     closed_at: datetime,
     exit_reason: str,
     entry_cost_allocated: Decimal,
     exit_cost_total: Decimal,
 ) -> tuple[PositionState | None, ClosedTrade]:
-    remaining_qty = position.qty - sell_qty
-    gross_pnl = (fill_price - position.avg_entry_price) * sell_qty
+    if position.qty < 0:
+        remaining_qty = position.qty + close_qty
+        gross_pnl = (position.avg_entry_price - fill_price) * close_qty
+    else:
+        remaining_qty = position.qty - close_qty
+        gross_pnl = (fill_price - position.avg_entry_price) * close_qty
     net_pnl = gross_pnl - entry_cost_allocated - exit_cost_total
     remaining_position: PositionState | None = None
-    if remaining_qty > 0:
+    if remaining_qty != 0:
         remaining_position = PositionState(
             strategy_id=position.strategy_id,
             qty=remaining_qty,
@@ -1121,7 +1152,7 @@ def _close_position(
         decision_at=position.decision_at,
         opened_at=position.opened_at,
         closed_at=closed_at,
-        qty=sell_qty,
+        qty=close_qty,
         entry_price=position.avg_entry_price,
         exit_price=fill_price,
         gross_pnl=gross_pnl,
@@ -1147,11 +1178,8 @@ def _apply_filled_decision(
     day_bucket = _ensure_replay_stats_bucket(day_bucket)
     if symbol_bucket is not None:
         symbol_bucket = _ensure_replay_stats_bucket(symbol_bucket)
-    owner_strategy_id = _decision_position_owner(decision)
-    position_key = _position_key(decision.symbol, owner_strategy_id)
-    if decision.action == 'buy':
-        fill_cost = _estimate_trade_cost(model=cost_model, decision=decision, signal=signal)
-        fill_notional = fill_price * decision.qty
+
+    def _record_fill(fill_notional: Decimal, fill_cost: Decimal) -> None:
         day_bucket['cost_total'] += fill_cost
         day_bucket['filled_count'] += 1
         day_bucket['filled_notional'] += fill_notional
@@ -1159,8 +1187,50 @@ def _apply_filled_decision(
             symbol_bucket['cost_total'] += fill_cost
             symbol_bucket['filled_count'] += 1
             symbol_bucket['filled_notional'] += fill_notional
-        cash -= (fill_price * decision.qty) + fill_cost
-        existing = positions.get(position_key)
+
+    owner_strategy_id = _decision_position_owner(decision)
+    position_key = _position_key(decision.symbol, owner_strategy_id)
+    existing = positions.get(position_key)
+    fill_cost = _estimate_trade_cost(model=cost_model, decision=decision, signal=signal)
+    if decision.action == 'buy':
+        if existing is not None and existing.qty < 0:
+            cover_qty = min(decision.qty, abs(existing.qty))
+            fill_notional = fill_price * cover_qty
+            _record_fill(fill_notional, fill_cost)
+            cash -= fill_notional + fill_cost
+            entry_cost_allocated = existing.entry_cost_total * (cover_qty / abs(existing.qty))
+            remaining, trade = _close_position(
+                symbol=decision.symbol,
+                position=existing,
+                close_qty=cover_qty,
+                fill_price=fill_price,
+                closed_at=filled_at,
+                exit_reason=_decision_exit_reason(decision),
+                entry_cost_allocated=entry_cost_allocated,
+                exit_cost_total=fill_cost,
+            )
+            if remaining is None:
+                positions.pop(position_key, None)
+            else:
+                positions[position_key] = remaining
+            day_bucket['gross_pnl'] += trade.gross_pnl
+            day_bucket['net_pnl'] += trade.net_pnl
+            if symbol_bucket is not None:
+                symbol_bucket['gross_pnl'] += trade.gross_pnl
+                symbol_bucket['net_pnl'] += trade.net_pnl
+                symbol_bucket['closed_trade_count'] += 1
+            if trade.net_pnl > 0:
+                day_bucket['wins'] += 1
+            elif trade.net_pnl < 0:
+                day_bucket['losses'] += 1
+            day_bucket['closed_trades'].append(trade)
+            all_closed_trades.append(trade)
+            _log_trade_closed(trade)
+            return cash
+
+        fill_notional = fill_price * decision.qty
+        _record_fill(fill_notional, fill_cost)
+        cash -= fill_notional + fill_cost
         if existing is None:
             positions[position_key] = PositionState(
                 strategy_id=owner_strategy_id,
@@ -1187,25 +1257,49 @@ def _apply_filled_decision(
         )
         return cash
 
-    existing = positions.get(position_key)
-    if existing is None or existing.qty <= 0:
+    if existing is None:
+        fill_notional = fill_price * decision.qty
+        _record_fill(fill_notional, fill_cost)
+        cash += fill_notional - fill_cost
+        positions[position_key] = PositionState(
+            strategy_id=owner_strategy_id,
+            qty=-decision.qty,
+            avg_entry_price=fill_price,
+            opened_at=filled_at,
+            entry_cost_total=fill_cost,
+            decision_at=created_at,
+            pending_entry=False,
+        )
         return cash
+
+    if existing.qty < 0:
+        fill_notional = fill_price * decision.qty
+        _record_fill(fill_notional, fill_cost)
+        cash += fill_notional - fill_cost
+        new_abs_qty = abs(existing.qty) + decision.qty
+        avg_entry = (
+            (existing.avg_entry_price * abs(existing.qty)) + (fill_price * decision.qty)
+        ) / new_abs_qty
+        positions[position_key] = PositionState(
+            strategy_id=existing.strategy_id,
+            qty=-new_abs_qty,
+            avg_entry_price=avg_entry,
+            opened_at=existing.opened_at,
+            entry_cost_total=existing.entry_cost_total + fill_cost,
+            decision_at=existing.decision_at,
+            pending_entry=False,
+        )
+        return cash
+
     sell_qty = min(decision.qty, existing.qty)
-    fill_cost = _estimate_trade_cost(model=cost_model, decision=decision, signal=signal)
     fill_notional = fill_price * sell_qty
-    day_bucket['cost_total'] += fill_cost
-    day_bucket['filled_count'] += 1
-    day_bucket['filled_notional'] += fill_notional
-    if symbol_bucket is not None:
-        symbol_bucket['cost_total'] += fill_cost
-        symbol_bucket['filled_count'] += 1
-        symbol_bucket['filled_notional'] += fill_notional
-    cash += (fill_price * sell_qty) - fill_cost
+    _record_fill(fill_notional, fill_cost)
+    cash += fill_notional - fill_cost
     entry_cost_allocated = existing.entry_cost_total * (sell_qty / existing.qty)
     remaining, trade = _close_position(
         symbol=decision.symbol,
         position=existing,
-        sell_qty=sell_qty,
+        close_qty=sell_qty,
         fill_price=fill_price,
         closed_at=filled_at,
         exit_reason=_decision_exit_reason(decision),
@@ -1242,6 +1336,9 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
             max_quote_mid_jump_bps=config.max_quote_mid_jump_bps,
             max_jump_with_wide_spread_bps=config.max_jump_with_wide_spread_bps,
         )
+    )
+    session_context = SessionContextTracker(
+        quote_quality_policy=quote_quality.policy,
     )
     cost_model = TransactionCostModel()
     positions: dict[tuple[str, str], PositionState] = {}
@@ -1283,6 +1380,9 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
         patch.object(settings, 'trading_fractional_equities_enabled', True),
     ):
         for signal in _iter_signal_rows(config):
+            signal = signal.model_copy(
+                update={"payload": session_context.enrich_signal_payload(signal)}
+            )
             signal_day = signal.event_ts.date()
             if current_day is None:
                 current_day = signal_day
@@ -1714,6 +1814,7 @@ def _flatten_positions(
 ) -> None:
     if not positions:
         return
+    stats = _ensure_replay_stats_bucket(stats)
     current_cash = cash_ref[0]
     for position_key in sorted(list(positions)):
         symbol, owner_strategy_id = position_key
@@ -1722,13 +1823,15 @@ def _flatten_positions(
         if last_signal is None:
             continue
         fill_price = last_prices.get(symbol, position.avg_entry_price)
+        exit_action = 'buy' if position.qty < 0 else 'sell'
+        exit_qty = abs(position.qty)
         synthetic_decision = StrategyDecision(
             strategy_id=owner_strategy_id if owner_strategy_id != _SHARED_POSITION_OWNER else 'flatten',
             symbol=symbol,
             event_ts=last_signal.event_ts,
             timeframe='1Sec',
-            action='sell',
-            qty=position.qty,
+            action=exit_action,
+            qty=exit_qty,
             order_type='market',
             time_in_force='day',
             params={},
@@ -1738,20 +1841,31 @@ def _flatten_positions(
             decision=synthetic_decision,
             signal=last_signal,
         )
-        sell_value = fill_price * position.qty
-        current_cash += sell_value - exit_cost
+        exit_notional = fill_price * exit_qty
+        if position.qty < 0:
+            current_cash -= exit_notional + exit_cost
+        else:
+            current_cash += exit_notional - exit_cost
         trade = ClosedTrade(
             symbol=symbol,
             strategy_id=position.strategy_id,
             decision_at=position.decision_at,
             opened_at=position.opened_at,
             closed_at=datetime.combine(day, REGULAR_CLOSE_UTC, tzinfo=timezone.utc),
-            qty=position.qty,
+            qty=exit_qty,
             entry_price=position.avg_entry_price,
             exit_price=fill_price,
-            gross_pnl=(fill_price - position.avg_entry_price) * position.qty,
+            gross_pnl=(
+                (position.avg_entry_price - fill_price) * exit_qty
+                if position.qty < 0
+                else (fill_price - position.avg_entry_price) * exit_qty
+            ),
             net_pnl=(
-                (fill_price - position.avg_entry_price) * position.qty
+                (
+                    (position.avg_entry_price - fill_price) * exit_qty
+                    if position.qty < 0
+                    else (fill_price - position.avg_entry_price) * exit_qty
+                )
                 - position.entry_cost_total
                 - exit_cost
             ),
@@ -1761,13 +1875,13 @@ def _flatten_positions(
         stats['net_pnl'] += trade.net_pnl
         stats['cost_total'] += exit_cost
         stats['filled_count'] += 1
-        stats['filled_notional'] += sell_value
+        stats['filled_notional'] += exit_notional
         symbol_bucket = funnel_stats.setdefault((day.isoformat(), symbol), _init_funnel_stats())
         symbol_bucket['gross_pnl'] += trade.gross_pnl
         symbol_bucket['net_pnl'] += trade.net_pnl
         symbol_bucket['cost_total'] += exit_cost
         symbol_bucket['filled_count'] += 1
-        symbol_bucket['filled_notional'] += sell_value
+        symbol_bucket['filled_notional'] += exit_notional
         symbol_bucket['closed_trade_count'] += 1
         if trade.net_pnl > 0:
             stats['wins'] += 1

--- a/services/torghut/tests/test_decisions.py
+++ b/services/torghut/tests/test_decisions.py
@@ -10,9 +10,16 @@ from unittest.mock import patch
 from app.config import settings
 from app.models import Strategy
 from app.strategies.catalog import StrategyConfig, _compose_strategy_description
-from app.trading.decisions import DecisionEngine, _build_runtime_position_exit_overlay
+from app.trading.decisions import (
+    DecisionEngine,
+    _build_runtime_position_exit_overlay,
+    _passes_runtime_trade_policy,
+    _record_runtime_trade_policy_decision,
+    _resolve_qty_for_aggregated,
+    _resolve_strategy_time_in_force,
+)
 from app.trading.features import extract_signal_features
-from app.trading.models import SignalEnvelope
+from app.trading.models import SignalEnvelope, StrategyDecision
 from app.trading.prices import MarketSnapshot, PriceFetcher
 from app.trading.strategy_runtime import (
     StrategyContext,
@@ -1552,6 +1559,215 @@ class TestDecisionEngine(TestCase):
 
         self.assertEqual(decisions, [])
 
+    def test_scheduler_runtime_mean_reversion_exhaustion_short_skips_exit_only_buy_without_short_inventory(
+        self,
+    ) -> None:
+        engine = DecisionEngine(price_fetcher=None)
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="mean-reversion-exhaustion-short",
+            description="version=1.0.0",
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="mean_reversion_exhaustion_short_v1",
+            universe_symbols=["META"],
+            max_position_pct_equity=Decimal("1.0"),
+            max_notional_per_trade=Decimal("12000"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 24, 17, 26, 12, tzinfo=timezone.utc),
+            symbol="META",
+            timeframe="1Sec",
+            seq=22,
+            payload={
+                "price": 595.80,
+                "ema12": 596.20,
+                "macd": 0.004,
+                "macd_signal": 0.000,
+                "rsi14": 41,
+                "vol_realized_w60s": 0.00022,
+                "vwap_session": 596.40,
+                "spread": 0.05,
+                "imbalance_bid_sz": 4700,
+                "imbalance_ask_sz": 4300,
+                "price_vs_session_open_bps": 8,
+                "price_position_in_session_range": 0.38,
+                "price_vs_opening_range_high_bps": -22,
+                "session_range_bps": 88,
+                "recent_spread_bps_avg": 0.82,
+                "recent_spread_bps_max": 1.44,
+                "recent_imbalance_pressure_avg": 0.04,
+            },
+        )
+
+        with (
+            patch.object(settings, "trading_strategy_runtime_mode", "scheduler_v3"),
+            patch.object(settings, "trading_strategy_scheduler_enabled", True),
+        ):
+            decisions = engine.evaluate(signal, [strategy], positions=[])
+
+        self.assertEqual(decisions, [])
+
+    def test_scheduler_runtime_mean_reversion_exhaustion_short_caps_exit_only_buy_to_short_inventory(
+        self,
+    ) -> None:
+        engine = DecisionEngine(price_fetcher=None)
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="mean-reversion-exhaustion-short",
+            description="version=1.0.0",
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="mean_reversion_exhaustion_short_v1",
+            universe_symbols=["META"],
+            max_position_pct_equity=Decimal("1.0"),
+            max_notional_per_trade=Decimal("12000"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 24, 17, 26, 12, tzinfo=timezone.utc),
+            symbol="META",
+            timeframe="1Sec",
+            seq=22,
+            payload={
+                "price": 595.80,
+                "ema12": 596.20,
+                "macd": 0.004,
+                "macd_signal": 0.000,
+                "rsi14": 41,
+                "vol_realized_w60s": 0.00022,
+                "vwap_session": 596.40,
+                "spread": 0.05,
+                "imbalance_bid_sz": 4700,
+                "imbalance_ask_sz": 4300,
+                "price_vs_session_open_bps": 8,
+                "price_position_in_session_range": 0.38,
+                "price_vs_opening_range_high_bps": -22,
+                "session_range_bps": 88,
+                "recent_spread_bps_avg": 0.82,
+                "recent_spread_bps_max": 1.44,
+                "recent_imbalance_pressure_avg": 0.04,
+            },
+        )
+
+        with (
+            patch.object(settings, "trading_strategy_runtime_mode", "scheduler_v3"),
+            patch.object(settings, "trading_strategy_scheduler_enabled", True),
+        ):
+            decisions = engine.evaluate(
+                signal,
+                [strategy],
+                positions=[
+                    {
+                        "symbol": "META",
+                        "qty": "3",
+                        "side": "short",
+                        "market_value": "1787.40",
+                        "avg_entry_price": "598.40",
+                    }
+                ],
+            )
+
+        self.assertEqual(len(decisions), 1)
+        self.assertEqual(decisions[0].action, "buy")
+        self.assertEqual(decisions[0].qty, Decimal("3"))
+
+    def test_scheduler_runtime_mean_reversion_exhaustion_short_sell_respects_entry_policy(
+        self,
+    ) -> None:
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="mean-reversion-exhaustion-short",
+            description=_compose_strategy_description(
+                StrategyConfig(
+                    name="mean-reversion-exhaustion-short",
+                    strategy_id="mean_reversion_exhaustion_short_v1@policy",
+                    strategy_type="sell_plugin",
+                    version="1.0.0",
+                    base_timeframe="1Sec",
+                    universe_type="mean_reversion_exhaustion_short_v1",
+                    universe_symbols=["META"],
+                    max_position_pct_equity=Decimal("1.0"),
+                    max_notional_per_trade=Decimal("12000"),
+                    params={
+                        "max_entries_per_session": "1",
+                        "entry_time_in_force": "ioc",
+                    },
+                )
+            ),
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="mean_reversion_exhaustion_short_v1",
+            universe_symbols=["META"],
+            max_position_pct_equity=Decimal("1.0"),
+            max_notional_per_trade=Decimal("12000"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 24, 17, 18, 12, tzinfo=timezone.utc),
+            symbol="META",
+            timeframe="1Sec",
+            seq=21,
+            payload={"price": 598.40},
+        )
+        decision = StrategyDecision(
+            strategy_id=str(strategy.id),
+            symbol="META",
+            event_ts=signal.event_ts,
+            timeframe="1Sec",
+            action="sell",
+            qty=Decimal("20"),
+            order_type="market",
+            time_in_force="day",
+            rationale="sell_signal",
+            params={},
+        )
+        state = {}
+
+        self.assertTrue(
+            _passes_runtime_trade_policy(
+                strategies=[strategy],
+                last_emitted_action_at={},
+                runtime_trade_policy_state=state,
+                signal_ts=signal.event_ts,
+                symbol="META",
+                action="sell",
+                position_owner="shared",
+                positions=[],
+                policy={"max_entries_per_session": 1},
+            )
+        )
+        self.assertEqual(
+            _resolve_strategy_time_in_force(strategies=[strategy], action="sell"),
+            "ioc",
+        )
+
+        _record_runtime_trade_policy_decision(
+            strategies=[strategy],
+            runtime_trade_policy_state=state,
+            signal_ts=signal.event_ts,
+            symbol="META",
+            position_owner="shared",
+            action="sell",
+            policy={"max_entries_per_session": 1},
+            positions=[],
+            signal=signal,
+            price=Decimal("598.40"),
+            decision=decision,
+        )
+
+        self.assertFalse(
+            _passes_runtime_trade_policy(
+                strategies=[strategy],
+                last_emitted_action_at={},
+                runtime_trade_policy_state=state,
+                signal_ts=datetime(2026, 3, 24, 17, 19, 12, tzinfo=timezone.utc),
+                symbol="META",
+                action="sell",
+                position_owner="shared",
+                positions=[],
+                policy={"max_entries_per_session": 1},
+            )
+        )
+
     def test_scheduler_runtime_breakout_continuation_skips_exit_only_sell_for_pending_entry_only(
         self,
     ) -> None:
@@ -1867,6 +2083,96 @@ class TestDecisionEngine(TestCase):
 
         self.assertEqual(len(first), 1)
         self.assertEqual(second, [])
+
+    def test_scheduler_runtime_microbar_long_sell_does_not_open_short_when_flat(self) -> None:
+        engine = DecisionEngine(price_fetcher=None)
+        engine.strategy_runtime = StrategyRuntime(
+            registry=StrategyRegistry(
+                plugins={
+                    "sell_plugin": _SellPlugin(),
+                }
+            )
+        )
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="microbar-long-flat-exit",
+            description=_compose_strategy_description(
+                StrategyConfig(
+                    name="microbar-long-flat-exit",
+                    strategy_id="microbar_cross_sectional_long_v1@research",
+                    strategy_type="sell_plugin",
+                    version="1.0.0",
+                    base_timeframe="1Sec",
+                    universe_type="microbar_cross_sectional_long_v1",
+                    universe_symbols=["META"],
+                    max_position_pct_equity=Decimal("1.0"),
+                    max_notional_per_trade=Decimal("15000"),
+                )
+            ),
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="microbar_cross_sectional_long_v1",
+            universe_symbols=["META"],
+            max_position_pct_equity=Decimal("1.0"),
+            max_notional_per_trade=Decimal("15000"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 30, 14, 20, 0, tzinfo=timezone.utc),
+            symbol="META",
+            timeframe="1Sec",
+            seq=1,
+            payload={
+                "price": 525.00,
+                "spread": 0.20,
+            },
+        )
+
+        with (
+            patch.object(settings, "trading_strategy_runtime_mode", "scheduler_v3"),
+            patch.object(settings, "trading_strategy_scheduler_enabled", True),
+            patch.object(settings, "trading_fractional_equities_enabled", True),
+        ):
+            decisions = engine.evaluate(signal, [strategy], positions=[])
+
+        self.assertEqual(decisions, [])
+
+    def test_resolve_qty_for_aggregated_blocks_flat_microbar_long_time_exit(self) -> None:
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="microbar-long-flat-exit",
+            description=_compose_strategy_description(
+                StrategyConfig(
+                    name="microbar-long-flat-exit",
+                    strategy_id="microbar_cross_sectional_long_v1@research",
+                    strategy_type="microbar_cross_sectional_long_v1",
+                    version="1.0.0",
+                    base_timeframe="1Sec",
+                    universe_type="microbar_cross_sectional_long_v1",
+                    universe_symbols=["NVDA"],
+                    max_notional_per_trade=Decimal("15000"),
+                )
+            ),
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="microbar_cross_sectional_long_v1",
+            universe_symbols=["NVDA"],
+            max_position_pct_equity=None,
+            max_notional_per_trade=Decimal("15000"),
+        )
+
+        qty, sizing_meta = _resolve_qty_for_aggregated(
+            [strategy],
+            symbol="NVDA",
+            action="sell",
+            price=Decimal("167.90"),
+            equity=None,
+            positions=[],
+            capacity_positions=[],
+            runtime_target_notional=Decimal("15000"),
+        )
+
+        self.assertEqual(qty, Decimal("0"))
+        self.assertEqual(sizing_meta.get("reason"), "exit_only_sell_without_long_position")
 
     def test_scheduler_runtime_isolated_buy_cooldown_is_scoped_per_strategy(self) -> None:
         first_strategy_id = uuid.uuid4()

--- a/services/torghut/tests/test_decisions.py
+++ b/services/torghut/tests/test_decisions.py
@@ -13,8 +13,13 @@ from app.strategies.catalog import StrategyConfig, _compose_strategy_description
 from app.trading.decisions import (
     DecisionEngine,
     _build_runtime_position_exit_overlay,
+    _count_open_short_positions,
+    _exit_position_side_for_strategies,
+    _is_entry_action_for_strategies,
+    _is_exit_action_for_strategies,
     _passes_runtime_trade_policy,
     _record_runtime_trade_policy_decision,
+    _resolve_qty,
     _resolve_qty_for_aggregated,
     _resolve_strategy_time_in_force,
 )
@@ -1766,6 +1771,68 @@ class TestDecisionEngine(TestCase):
                 positions=[],
                 policy={"max_entries_per_session": 1},
             )
+        )
+
+    def test_short_side_runtime_helpers_cover_exit_only_and_short_position_fallbacks(
+        self,
+    ) -> None:
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="mean-reversion-exhaustion-short",
+            description="version=1.0.0",
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="mean_reversion_exhaustion_short_v1",
+            universe_symbols=["META"],
+            max_position_pct_equity=Decimal("1.0"),
+            max_notional_per_trade=Decimal("12000"),
+        )
+
+        blocked_qty, blocked_meta = _resolve_qty(
+            strategy,
+            symbol="META",
+            action="buy",
+            price=Decimal("100"),
+            equity=Decimal("10000"),
+            positions=[{"symbol": "META", "qty": "2", "side": "long"}],
+        )
+        self.assertEqual(blocked_qty, Decimal("0"))
+        self.assertEqual(blocked_meta["reason"], "exit_only_buy_without_short_position")
+
+        cover_qty, cover_meta = _resolve_qty(
+            strategy,
+            symbol="META",
+            action="buy",
+            price=Decimal("100"),
+            equity=Decimal("10000"),
+            positions=[{"symbol": "META", "qty": "3", "side": "short"}],
+        )
+        self.assertEqual(cover_qty, Decimal("3"))
+        self.assertEqual(cover_meta["method"], "min(max_notional,pct_equity)")
+
+        self.assertFalse(
+            _is_entry_action_for_strategies(strategies=[strategy], action="hold")
+        )
+        self.assertFalse(
+            _is_exit_action_for_strategies(strategies=[strategy], action="hold")
+        )
+        self.assertIsNone(
+            _exit_position_side_for_strategies(strategies=[strategy], action="hold")
+        )
+
+        self.assertEqual(_count_open_short_positions(None), 0)
+        self.assertEqual(
+            _count_open_short_positions(
+                [
+                    {"symbol": "META", "qty": "3", "side": "short"},
+                    {"symbol": "", "qty": "2", "side": "short"},
+                    {"symbol": "AAPL", "qty": "bad", "side": "short", "market_value": "-50"},
+                    {"symbol": "NVDA", "qty": "bad", "side": "short", "market_value": "bad"},
+                    {"symbol": "MSFT", "side": "short", "market_value": "0"},
+                    {"symbol": "TSLA", "qty": "1", "side": "long"},
+                ]
+            ),
+            2,
         )
 
     def test_scheduler_runtime_breakout_continuation_skips_exit_only_sell_for_pending_entry_only(

--- a/services/torghut/tests/test_discovery_harness_v2.py
+++ b/services/torghut/tests/test_discovery_harness_v2.py
@@ -211,6 +211,13 @@ class TestDiscoveryHarnessV2(TestCase):
             template.runtime_harness['strategy_name'],
             'breakout-continuation-long-v1',
         )
+        short_template = load_family_template('mean_reversion_exhaustion_short_v1', directory=root)
+        self.assertEqual(short_template.family_id, 'mean_reversion_exhaustion_short_v1')
+        self.assertIn('max_hold_seconds', short_template.risk_controls)
+        self.assertEqual(
+            short_template.runtime_harness['strategy_name'],
+            'mean-reversion-exhaustion-short-v1',
+        )
         self.assertEqual(
             derive_family_template_id(explicit_id=' custom ', family='ignored'),
             'custom',

--- a/services/torghut/tests/test_execution_policy.py
+++ b/services/torghut/tests/test_execution_policy.py
@@ -402,6 +402,41 @@ class TestExecutionPolicy(TestCase):
         self.assertEqual(outcome.decision.order_type, "market")
         self.assertIsNone(outcome.decision.limit_price)
 
+    def test_microbar_cross_sectional_short_entry_keeps_market_order(self) -> None:
+        policy = ExecutionPolicy(config=_config(prefer_limit=True))
+        decision = _decision(
+            action="sell",
+            qty=Decimal("1"),
+            price=Decimal("524.995"),
+            order_type="market",
+        ).model_copy(
+            update={
+                "rationale": "microbar_cross_sectional_entry,rank=1",
+                "params": {
+                    "price": Decimal("524.995"),
+                    "spread": Decimal("0.20"),
+                    "execution_features": {
+                        "spread_bps": Decimal("3.81"),
+                    },
+                    "strategy_runtime": {
+                        "source_strategy_runtime": [
+                            {"strategy_type": "microbar_cross_sectional_short_v1"}
+                        ]
+                    },
+                }
+            }
+        )
+
+        outcome = policy.evaluate(
+            decision,
+            strategy=None,
+            positions=[],
+            market_snapshot=None,
+        )
+
+        self.assertEqual(outcome.decision.order_type, "market")
+        self.assertIsNone(outcome.decision.limit_price)
+
     def test_limit_and_stop_prices_are_quantized(self) -> None:
         decision = _decision(
             action="sell",

--- a/services/torghut/tests/test_local_intraday_tsmom_replay.py
+++ b/services/torghut/tests/test_local_intraday_tsmom_replay.py
@@ -584,6 +584,92 @@ class TestLocalIntradayTsmomReplay(TestCase):
             ],
         )
 
+    def test_positions_payload_projects_pending_buy_cover_against_existing_short(
+        self,
+    ) -> None:
+        positions = {
+            ("META", _SHARED_POSITION_OWNER): PositionState(
+                strategy_id=_SHARED_POSITION_OWNER,
+                qty=Decimal("-10"),
+                avg_entry_price=Decimal("520"),
+                opened_at=datetime(2026, 3, 27, 17, 0, 0, tzinfo=timezone.utc),
+                entry_cost_total=Decimal("0"),
+                decision_at=datetime(2026, 3, 27, 17, 0, 0, tzinfo=timezone.utc),
+            )
+        }
+        signal = self._signal(bid="523.22", ask="523.28", price="523.25")
+        pending_buy = PendingOrder(
+            decision=self._decision(
+                action="buy", order_type="limit", limit_price="523.28"
+            ),
+            created_at=datetime(2026, 3, 27, 17, 30, 3, tzinfo=timezone.utc),
+            signal=signal,
+        )
+
+        payload = _positions_payload(
+            positions,
+            {"META": Decimal("523.25")},
+            {("META", _SHARED_POSITION_OWNER): pending_buy},
+        )
+
+        self.assertEqual(payload, [])
+
+    def test_positions_payload_projects_partial_pending_buy_cover_against_existing_short(
+        self,
+    ) -> None:
+        positions = {
+            ("META", _SHARED_POSITION_OWNER): PositionState(
+                strategy_id=_SHARED_POSITION_OWNER,
+                qty=Decimal("-10"),
+                avg_entry_price=Decimal("520"),
+                opened_at=datetime(2026, 3, 27, 17, 0, 0, tzinfo=timezone.utc),
+                entry_cost_total=Decimal("0"),
+                decision_at=datetime(2026, 3, 27, 17, 0, 0, tzinfo=timezone.utc),
+            )
+        }
+        signal = self._signal(bid="523.22", ask="523.28", price="523.25")
+        partial_cover = StrategyDecision(
+            strategy_id="intraday_tsmom_v1@prod",
+            symbol="META",
+            event_ts=datetime(2026, 3, 27, 17, 30, 3, tzinfo=timezone.utc),
+            timeframe="1Sec",
+            action="buy",
+            qty=Decimal("4"),
+            order_type="limit",
+            time_in_force="day",
+            limit_price=Decimal("523.28"),
+            rationale="test",
+            params={},
+        )
+        pending_buy = PendingOrder(
+            decision=partial_cover,
+            created_at=datetime(2026, 3, 27, 17, 30, 3, tzinfo=timezone.utc),
+            signal=signal,
+        )
+
+        payload = _positions_payload(
+            positions,
+            {"META": Decimal("523.25")},
+            {("META", _SHARED_POSITION_OWNER): pending_buy},
+        )
+
+        self.assertEqual(
+            payload,
+            [
+                {
+                    "symbol": "META",
+                    "strategy_id": _SHARED_POSITION_OWNER,
+                    "qty": "6",
+                    "side": "short",
+                    "market_value": "-3139.50",
+                    "avg_entry_price": "520",
+                    "opened_at": "2026-03-27T17:00:00+00:00",
+                    "decision_at": "2026-03-27T17:00:00+00:00",
+                    "pending_entry": False,
+                }
+            ],
+        )
+
     def test_positions_payload_keeps_other_strategy_position_when_isolated_sell_pending(
         self,
     ) -> None:

--- a/services/torghut/tests/test_local_intraday_tsmom_replay.py
+++ b/services/torghut/tests/test_local_intraday_tsmom_replay.py
@@ -670,6 +670,59 @@ class TestLocalIntradayTsmomReplay(TestCase):
             ],
         )
 
+    def test_positions_payload_projects_pending_sell_against_existing_short(self) -> None:
+        positions = {
+            ("META", _SHARED_POSITION_OWNER): PositionState(
+                strategy_id=_SHARED_POSITION_OWNER,
+                qty=Decimal("-5"),
+                avg_entry_price=Decimal("520"),
+                opened_at=datetime(2026, 3, 27, 17, 0, 0, tzinfo=timezone.utc),
+                entry_cost_total=Decimal("0"),
+                decision_at=datetime(2026, 3, 27, 17, 0, 0, tzinfo=timezone.utc),
+            )
+        }
+        signal = self._signal(bid="523.22", ask="523.28", price="523.25")
+        pending_sell = PendingOrder(
+            decision=StrategyDecision(
+                strategy_id="intraday_tsmom_v1@prod",
+                symbol="META",
+                event_ts=datetime(2026, 3, 27, 17, 30, 3, tzinfo=timezone.utc),
+                timeframe="1Sec",
+                action="sell",
+                qty=Decimal("4"),
+                order_type="limit",
+                time_in_force="day",
+                limit_price=Decimal("523.22"),
+                rationale="test",
+                params={},
+            ),
+            created_at=datetime(2026, 3, 27, 17, 30, 3, tzinfo=timezone.utc),
+            signal=signal,
+        )
+
+        payload = _positions_payload(
+            positions,
+            {"META": Decimal("523.25")},
+            {("META", _SHARED_POSITION_OWNER): pending_sell},
+        )
+
+        self.assertEqual(
+            payload,
+            [
+                {
+                    "symbol": "META",
+                    "strategy_id": _SHARED_POSITION_OWNER,
+                    "qty": "9",
+                    "side": "short",
+                    "market_value": "-4709.25",
+                    "avg_entry_price": "521.4311111111111111111111111",
+                    "opened_at": "2026-03-27T17:00:00+00:00",
+                    "decision_at": "2026-03-27T17:00:00+00:00",
+                    "pending_entry": False,
+                }
+            ],
+        )
+
     def test_positions_payload_keeps_other_strategy_position_when_isolated_sell_pending(
         self,
     ) -> None:
@@ -1026,6 +1079,129 @@ class TestLocalIntradayTsmomReplay(TestCase):
         self.assertEqual(symbol_bucket["closed_trade_count"], 1)
         self.assertEqual(symbol_bucket["filled_notional"], Decimal("10465.00"))
         self.assertGreater(cash, Decimal("0"))
+
+    def test_apply_filled_decision_partial_buy_cover_updates_symbol_bucket_and_losses(
+        self,
+    ) -> None:
+        signal = self._signal(bid="523.90", ask="524.00", price="523.95")
+        positions = {
+            ("META", _SHARED_POSITION_OWNER): PositionState(
+                strategy_id=_SHARED_POSITION_OWNER,
+                qty=Decimal("-10"),
+                avg_entry_price=Decimal("523.22"),
+                opened_at=datetime(2026, 3, 27, 17, 0, 0, tzinfo=timezone.utc),
+                entry_cost_total=Decimal("1.00"),
+                decision_at=datetime(2026, 3, 27, 17, 0, 0, tzinfo=timezone.utc),
+            )
+        }
+        day_bucket = {
+            "decision_count": 1,
+            "filled_count": 0,
+            "filled_notional": Decimal("0"),
+            "gross_pnl": Decimal("0"),
+            "net_pnl": Decimal("0"),
+            "cost_total": Decimal("0"),
+            "wins": 0,
+            "losses": 0,
+            "closed_trades": [],
+        }
+        symbol_bucket = _init_funnel_stats()
+        partial_cover = StrategyDecision(
+            strategy_id="intraday_tsmom_v1@prod",
+            symbol="META",
+            event_ts=signal.event_ts,
+            timeframe="1Sec",
+            action="buy",
+            qty=Decimal("4"),
+            order_type="limit",
+            time_in_force="day",
+            limit_price=Decimal("524.00"),
+            rationale="test",
+            params={},
+        )
+        all_closed_trades: list[object] = []
+
+        cash = _apply_filled_decision(
+            decision=partial_cover,
+            signal=signal,
+            fill_price=Decimal("524.00"),
+            filled_at=signal.event_ts,
+            created_at=signal.event_ts,
+            positions=positions,
+            day_bucket=day_bucket,
+            symbol_bucket=symbol_bucket,
+            cost_model=TransactionCostModel(),
+            cash=Decimal("15231.20"),
+            all_closed_trades=all_closed_trades,
+        )
+
+        self.assertIn(("META", _SHARED_POSITION_OWNER), positions)
+        self.assertEqual(positions[("META", _SHARED_POSITION_OWNER)].qty, Decimal("-6"))
+        self.assertLess(day_bucket["net_pnl"], Decimal("0"))
+        self.assertEqual(day_bucket["losses"], 1)
+        self.assertEqual(symbol_bucket["closed_trade_count"], 1)
+        self.assertLess(symbol_bucket["net_pnl"], Decimal("0"))
+        self.assertEqual(len(all_closed_trades), 1)
+        self.assertLess(cash, Decimal("15231.20"))
+
+    def test_apply_filled_decision_sell_adds_to_existing_short(self) -> None:
+        signal = self._signal(bid="523.90", ask="524.00", price="523.95")
+        decision = StrategyDecision(
+            strategy_id="intraday_tsmom_v1@prod",
+            symbol="META",
+            event_ts=signal.event_ts,
+            timeframe="1Sec",
+            action="sell",
+            qty=Decimal("5"),
+            order_type="limit",
+            time_in_force="day",
+            limit_price=Decimal("523.90"),
+            rationale="test",
+            params={},
+        )
+        positions = {
+            ("META", _SHARED_POSITION_OWNER): PositionState(
+                strategy_id=_SHARED_POSITION_OWNER,
+                qty=Decimal("-10"),
+                avg_entry_price=Decimal("523.22"),
+                opened_at=datetime(2026, 3, 27, 17, 0, 0, tzinfo=timezone.utc),
+                entry_cost_total=Decimal("1.00"),
+                decision_at=datetime(2026, 3, 27, 17, 0, 0, tzinfo=timezone.utc),
+            )
+        }
+        day_bucket = {
+            "decision_count": 1,
+            "filled_count": 0,
+            "filled_notional": Decimal("0"),
+            "gross_pnl": Decimal("0"),
+            "net_pnl": Decimal("0"),
+            "cost_total": Decimal("0"),
+            "wins": 0,
+            "losses": 0,
+            "closed_trades": [],
+        }
+
+        cash = _apply_filled_decision(
+            decision=decision,
+            signal=signal,
+            fill_price=Decimal("523.90"),
+            filled_at=signal.event_ts,
+            created_at=signal.event_ts,
+            positions=positions,
+            day_bucket=day_bucket,
+            cost_model=TransactionCostModel(),
+            cash=Decimal("15231.20"),
+            all_closed_trades=[],
+        )
+
+        self.assertEqual(positions[("META", _SHARED_POSITION_OWNER)].qty, Decimal("-15"))
+        self.assertEqual(
+            positions[("META", _SHARED_POSITION_OWNER)].avg_entry_price,
+            Decimal("523.4466666666666666666666667"),
+        )
+        self.assertEqual(day_bucket["filled_count"], 1)
+        self.assertEqual(day_bucket["filled_notional"], Decimal("2619.50"))
+        self.assertGreater(cash, Decimal("15231.20"))
 
     def test_replay_main_writes_trace_funnel_and_near_miss_outputs(self) -> None:
         with TemporaryDirectory() as tmpdir:

--- a/services/torghut/tests/test_local_intraday_tsmom_replay.py
+++ b/services/torghut/tests/test_local_intraday_tsmom_replay.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import os
 import sys
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from decimal import Decimal
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -28,6 +28,7 @@ from scripts.local_intraday_tsmom_replay import (
     _apply_filled_decision,
     _apply_order_preferences,
     _build_near_miss,
+    _flatten_positions,
     _init_funnel_stats,
     _insert_near_miss,
     _parse_signal_row,
@@ -181,6 +182,94 @@ class TestLocalIntradayTsmomReplay(TestCase):
         self.assertEqual(day_bucket["filled_notional"], Decimal("5232.80"))
         self.assertLess(cash, Decimal("10000"))
 
+    def test_apply_filled_decision_opens_short_position_on_sell_entry(self) -> None:
+        signal = self._signal(bid="523.22", ask="523.28", price="523.25")
+        decision = self._decision(
+            action="sell", order_type="limit", limit_price="523.22"
+        )
+        positions: dict[tuple[str, str], PositionState] = {}
+        day_bucket = {
+            "decision_count": 1,
+            "filled_count": 0,
+            "filled_notional": Decimal("0"),
+            "gross_pnl": Decimal("0"),
+            "net_pnl": Decimal("0"),
+            "cost_total": Decimal("0"),
+            "wins": 0,
+            "losses": 0,
+            "closed_trades": [],
+        }
+
+        cash = _apply_filled_decision(
+            decision=decision,
+            signal=signal,
+            fill_price=Decimal("523.22"),
+            filled_at=signal.event_ts,
+            created_at=signal.event_ts,
+            positions=positions,
+            day_bucket=day_bucket,
+            cost_model=TransactionCostModel(),
+            cash=Decimal("10000"),
+            all_closed_trades=[],
+        )
+
+        self.assertIn(("META", _SHARED_POSITION_OWNER), positions)
+        position = positions[("META", _SHARED_POSITION_OWNER)]
+        self.assertEqual(position.avg_entry_price, Decimal("523.22"))
+        self.assertEqual(position.qty, Decimal("-10"))
+        self.assertEqual(day_bucket["filled_count"], 1)
+        self.assertEqual(day_bucket["filled_notional"], Decimal("5232.20"))
+        self.assertGreater(cash, Decimal("10000"))
+
+    def test_apply_filled_decision_buy_covers_existing_short(self) -> None:
+        signal = self._signal(bid="522.90", ask="523.00", price="522.95")
+        decision = self._decision(
+            action="buy", order_type="limit", limit_price="523.00"
+        )
+        positions = {
+            ("META", _SHARED_POSITION_OWNER): PositionState(
+                strategy_id=_SHARED_POSITION_OWNER,
+                qty=Decimal("-10"),
+                avg_entry_price=Decimal("523.22"),
+                opened_at=datetime(2026, 3, 27, 17, 0, 0, tzinfo=timezone.utc),
+                entry_cost_total=Decimal("1.00"),
+                decision_at=datetime(2026, 3, 27, 17, 0, 0, tzinfo=timezone.utc),
+            )
+        }
+        day_bucket = {
+            "decision_count": 1,
+            "filled_count": 0,
+            "filled_notional": Decimal("0"),
+            "gross_pnl": Decimal("0"),
+            "net_pnl": Decimal("0"),
+            "cost_total": Decimal("0"),
+            "wins": 0,
+            "losses": 0,
+            "closed_trades": [],
+        }
+        all_closed_trades: list[object] = []
+
+        cash = _apply_filled_decision(
+            decision=decision,
+            signal=signal,
+            fill_price=Decimal("523.00"),
+            filled_at=signal.event_ts,
+            created_at=signal.event_ts,
+            positions=positions,
+            day_bucket=day_bucket,
+            cost_model=TransactionCostModel(),
+            cash=Decimal("15231.20"),
+            all_closed_trades=all_closed_trades,
+        )
+
+        self.assertNotIn(("META", _SHARED_POSITION_OWNER), positions)
+        self.assertEqual(day_bucket["filled_count"], 1)
+        self.assertGreater(day_bucket["gross_pnl"], Decimal("0"))
+        self.assertGreater(day_bucket["net_pnl"], Decimal("0"))
+        self.assertEqual(day_bucket["wins"], 1)
+        self.assertEqual(len(all_closed_trades), 1)
+        self.assertLess(cash, Decimal("15231.20"))
+
     def test_quote_quality_rejects_wide_spread_outlier(self) -> None:
         signal = self._signal(bid="239.11", ask="253.69", price="246.40")
         config = ReplayConfig(
@@ -266,6 +355,35 @@ class TestLocalIntradayTsmomReplay(TestCase):
                 "strategy_runtime": {
                     "source_strategy_runtime": [
                         {"strategy_type": "breakout_continuation_long_v1"}
+                    ]
+                },
+            },
+        )
+        signal = self._signal(bid="524.90", ask="525.10", price="525.00")
+
+        updated = _apply_order_preferences(decision, signal)
+
+        self.assertEqual(updated.order_type, "market")
+        self.assertIsNone(updated.limit_price)
+
+    def test_microbar_cross_sectional_short_entry_keeps_market_order(self) -> None:
+        decision = StrategyDecision(
+            strategy_id="short-cross-row-id",
+            symbol="META",
+            event_ts=datetime(2026, 3, 27, 13, 30, 1, tzinfo=timezone.utc),
+            timeframe="1Sec",
+            action="sell",
+            qty=Decimal("10"),
+            order_type="market",
+            time_in_force="day",
+            rationale="microbar_cross_sectional_entry,rank=1",
+            params={
+                "execution_features": {
+                    "spread_bps": Decimal("4"),
+                },
+                "strategy_runtime": {
+                    "source_strategy_runtime": [
+                        {"strategy_type": "microbar_cross_sectional_short_v1"}
                     ]
                 },
             },
@@ -433,6 +551,39 @@ class TestLocalIntradayTsmomReplay(TestCase):
 
         self.assertEqual(payload, [])
 
+    def test_positions_payload_projects_pending_short_entry(self) -> None:
+        signal = self._signal(bid="523.22", ask="523.28", price="523.25")
+        pending_sell = PendingOrder(
+            decision=self._decision(
+                action="sell", order_type="limit", limit_price="523.22"
+            ),
+            created_at=datetime(2026, 3, 27, 17, 30, 3, tzinfo=timezone.utc),
+            signal=signal,
+        )
+
+        payload = _positions_payload(
+            {},
+            {"META": Decimal("523.25")},
+            {("META", _SHARED_POSITION_OWNER): pending_sell},
+        )
+
+        self.assertEqual(
+            payload,
+            [
+                {
+                    "symbol": "META",
+                    "strategy_id": _SHARED_POSITION_OWNER,
+                    "qty": "10",
+                    "side": "short",
+                    "market_value": "-5232.50",
+                    "avg_entry_price": "523.22",
+                    "opened_at": signal.event_ts.isoformat(),
+                    "decision_at": pending_sell.created_at.isoformat(),
+                    "pending_entry": True,
+                }
+            ],
+        )
+
     def test_positions_payload_keeps_other_strategy_position_when_isolated_sell_pending(
         self,
     ) -> None:
@@ -497,6 +648,50 @@ class TestLocalIntradayTsmomReplay(TestCase):
                 }
             ],
         )
+
+    def test_flatten_positions_closes_short_and_books_pnl(self) -> None:
+        day = date(2026, 4, 2)
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 4, 2, 19, 59, 59, tzinfo=timezone.utc),
+            symbol="META",
+            timeframe="1Sec",
+            seq=1,
+            payload={"price": Decimal("520.50")},
+        )
+        positions = {
+            ("META", _SHARED_POSITION_OWNER): PositionState(
+                strategy_id=_SHARED_POSITION_OWNER,
+                qty=Decimal("-10"),
+                avg_entry_price=Decimal("523.22"),
+                opened_at=datetime(2026, 4, 2, 14, 30, 0, tzinfo=timezone.utc),
+                entry_cost_total=Decimal("1.00"),
+                decision_at=datetime(2026, 4, 2, 14, 30, 0, tzinfo=timezone.utc),
+            )
+        }
+        stats = _init_funnel_stats()
+        stats["closed_trades"] = []
+        funnel_stats: dict[tuple[str, str], dict[str, object]] = {}
+        cash_ref = [Decimal("15231.20")]
+        all_closed_trades: list[object] = []
+
+        _flatten_positions(
+            day=day,
+            stats=stats,
+            funnel_stats=funnel_stats,
+            positions=positions,
+            last_signals={"META": signal},
+            last_prices={"META": Decimal("520.50")},
+            cost_model=TransactionCostModel(),
+            cash_ref=cash_ref,
+            all_closed_trades=all_closed_trades,
+        )
+
+        self.assertEqual(positions, {})
+        self.assertEqual(stats["filled_count"], 1)
+        self.assertGreater(stats["gross_pnl"], Decimal("0"))
+        self.assertGreater(stats["net_pnl"], Decimal("0"))
+        self.assertEqual(stats["wins"], 1)
+        self.assertEqual(len(all_closed_trades), 1)
 
     def test_parse_signal_row_preserves_vwap_and_imbalance_sizes(self) -> None:
         parsed = _parse_signal_row(
@@ -1105,6 +1300,171 @@ class TestLocalIntradayTsmomReplay(TestCase):
         )
         self.assertEqual(payload["funnel"]["buckets"][0]["trading_day"], "2026-03-26")
         self.assertGreaterEqual(payload["filled_count"], 2)
+
+    def test_run_replay_enriches_day_two_open_with_prev_day_open45_ranks(self) -> None:
+        strategy = Strategy(
+            name="observer",
+            description=None,
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="static",
+            universe_symbols=["AAPL", "META"],
+            max_position_pct_equity=None,
+            max_notional_per_trade=None,
+        )
+        observed_signals: list[SignalEnvelope] = []
+
+        day_one_aapl_open = SignalEnvelope(
+            event_ts=datetime(2026, 3, 27, 13, 30, 1, tzinfo=timezone.utc),
+            symbol="AAPL",
+            timeframe="1Sec",
+            seq=1,
+            payload={
+                "price": Decimal("100"),
+                "imbalance_bid_px": Decimal("99.95"),
+                "imbalance_ask_px": Decimal("100.05"),
+                "imbalance_bid_sz": Decimal("100"),
+                "imbalance_ask_sz": Decimal("100"),
+                "spread": Decimal("0.10"),
+            },
+        )
+        day_one_meta_open = SignalEnvelope(
+            event_ts=datetime(2026, 3, 27, 13, 30, 1, tzinfo=timezone.utc),
+            symbol="META",
+            timeframe="1Sec",
+            seq=2,
+            payload={
+                "price": Decimal("100"),
+                "imbalance_bid_px": Decimal("99.95"),
+                "imbalance_ask_px": Decimal("100.05"),
+                "imbalance_bid_sz": Decimal("100"),
+                "imbalance_ask_sz": Decimal("100"),
+                "spread": Decimal("0.10"),
+            },
+        )
+        day_one_aapl_45 = day_one_aapl_open.model_copy(
+            update={
+                "event_ts": datetime(2026, 3, 27, 14, 15, 0, tzinfo=timezone.utc),
+                "seq": 3,
+                "payload": {
+                    **day_one_aapl_open.payload,
+                    "price": Decimal("105"),
+                    "imbalance_bid_px": Decimal("104.95"),
+                    "imbalance_ask_px": Decimal("105.05"),
+                },
+            }
+        )
+        day_one_meta_45 = day_one_meta_open.model_copy(
+            update={
+                "event_ts": datetime(2026, 3, 27, 14, 15, 0, tzinfo=timezone.utc),
+                "seq": 4,
+                "payload": {
+                    **day_one_meta_open.payload,
+                    "price": Decimal("95"),
+                    "imbalance_bid_px": Decimal("94.95"),
+                    "imbalance_ask_px": Decimal("95.05"),
+                },
+            }
+        )
+        day_two_aapl_open = day_one_aapl_open.model_copy(
+            update={
+                "event_ts": datetime(2026, 3, 30, 13, 30, 1, tzinfo=timezone.utc),
+                "seq": 5,
+            }
+        )
+        day_two_meta_open = day_one_meta_open.model_copy(
+            update={
+                "event_ts": datetime(2026, 3, 30, 13, 30, 1, tzinfo=timezone.utc),
+                "seq": 6,
+            }
+        )
+
+        class _Engine:
+            def __init__(self, *args, **kwargs) -> None:  # type: ignore[no-untyped-def]
+                _ = args
+                _ = kwargs
+
+            def observe_signal(self, signal: SignalEnvelope) -> None:
+                _ = signal
+
+            def evaluate(
+                self, signal: SignalEnvelope, strategies, *, equity, positions
+            ):  # type: ignore[no-untyped-def]
+                _ = strategies
+                _ = equity
+                _ = positions
+                observed_signals.append(signal)
+                return []
+
+            def consume_runtime_telemetry(self):  # type: ignore[no-untyped-def]
+                return type("Telemetry", (), {"traces": []})()
+
+        class _Allocator:
+            def allocate(self, raw_decisions, **kwargs):  # type: ignore[no-untyped-def]
+                _ = raw_decisions
+                _ = kwargs
+                return []
+
+        config = ReplayConfig(
+            strategy_configmap_path=Path("/tmp/strategies.yaml"),
+            clickhouse_http_url="http://example.invalid:8123",
+            clickhouse_username=None,
+            clickhouse_password=None,
+            start_date=datetime(2026, 3, 27, tzinfo=timezone.utc).date(),
+            end_date=datetime(2026, 3, 30, tzinfo=timezone.utc).date(),
+            chunk_minutes=10,
+            flatten_eod=True,
+            start_equity=Decimal("10000"),
+            capture_traces=False,
+        )
+
+        with (
+            patch(
+                "scripts.local_intraday_tsmom_replay._load_strategies",
+                return_value=[strategy],
+            ),
+            patch(
+                "scripts.local_intraday_tsmom_replay._iter_signal_rows",
+                return_value=iter(
+                    [
+                        day_one_aapl_open,
+                        day_one_meta_open,
+                        day_one_aapl_45,
+                        day_one_meta_45,
+                        day_two_aapl_open,
+                        day_two_meta_open,
+                    ]
+                ),
+            ),
+            patch("scripts.local_intraday_tsmom_replay.DecisionEngine", _Engine),
+            patch(
+                "scripts.local_intraday_tsmom_replay.allocator_from_settings",
+                return_value=_Allocator(),
+            ),
+        ):
+            run_replay(config)
+
+        aapl_day_two = next(
+            signal
+            for signal in observed_signals
+            if signal.symbol == "AAPL"
+            and signal.event_ts == datetime(2026, 3, 30, 13, 30, 1, tzinfo=timezone.utc)
+        )
+        meta_day_two = next(
+            signal
+            for signal in observed_signals
+            if signal.symbol == "META"
+            and signal.event_ts == datetime(2026, 3, 30, 13, 30, 1, tzinfo=timezone.utc)
+        )
+
+        self.assertEqual(
+            aapl_day_two.payload["cross_section_prev_day_open45_return_rank"],
+            Decimal("1"),
+        )
+        self.assertEqual(
+            meta_day_two.payload["cross_section_prev_day_open45_return_rank"],
+            Decimal("0"),
+        )
 
     def test_run_replay_marks_passed_trace_with_sizer_reject_reason(self) -> None:
         strategy = Strategy(

--- a/services/torghut/tests/test_session_context.py
+++ b/services/torghut/tests/test_session_context.py
@@ -607,3 +607,74 @@ class TestSessionContextTracker(TestCase):
             cast(Decimal, aapl_payload['cross_section_continuation_rank']),
             cast(Decimal, meta_payload['cross_section_continuation_rank']),
         )
+
+    def test_tracker_carries_prev_day_open45_cross_section_ranks_into_next_open(self) -> None:
+        tracker = SessionContextTracker()
+        tracker.enrich_signal_payload(
+            _signal(
+                event_ts=datetime(2026, 3, 24, 13, 30, 0, tzinfo=timezone.utc),
+                symbol='AAPL',
+                price='100.00',
+                spread='0.03',
+                bid_sz='5000',
+                ask_sz='4000',
+            )
+        )
+        tracker.enrich_signal_payload(
+            _signal(
+                event_ts=datetime(2026, 3, 24, 13, 30, 1, tzinfo=timezone.utc),
+                symbol='META',
+                price='100.00',
+                spread='0.03',
+                bid_sz='5000',
+                ask_sz='4000',
+            )
+        )
+        tracker.enrich_signal_payload(
+            _signal(
+                event_ts=datetime(2026, 3, 24, 14, 15, 0, tzinfo=timezone.utc),
+                symbol='AAPL',
+                price='102.00',
+                spread='0.03',
+                bid_sz='5200',
+                ask_sz='3900',
+            )
+        )
+        tracker.enrich_signal_payload(
+            _signal(
+                event_ts=datetime(2026, 3, 24, 14, 15, 1, tzinfo=timezone.utc),
+                symbol='META',
+                price='98.00',
+                spread='0.03',
+                bid_sz='4800',
+                ask_sz='4300',
+            )
+        )
+
+        aapl_open_payload = tracker.enrich_signal_payload(
+            _signal(
+                event_ts=datetime(2026, 3, 25, 13, 30, 0, tzinfo=timezone.utc),
+                symbol='AAPL',
+                price='101.00',
+                spread='0.03',
+                bid_sz='5100',
+                ask_sz='4100',
+            )
+        )
+        meta_open_payload = tracker.enrich_signal_payload(
+            _signal(
+                event_ts=datetime(2026, 3, 25, 13, 30, 1, tzinfo=timezone.utc),
+                symbol='META',
+                price='99.00',
+                spread='0.03',
+                bid_sz='4900',
+                ask_sz='4200',
+            )
+        )
+
+        self.assertEqual(aapl_open_payload['cross_section_prev_day_open45_return_rank'], Decimal('1'))
+        self.assertEqual(meta_open_payload['cross_section_prev_day_open45_return_rank'], Decimal('0'))
+        self.assertEqual(
+            aapl_open_payload['cross_section_positive_prev_day_open45_return_ratio'],
+            Decimal('0.5'),
+        )

--- a/services/torghut/tests/test_strategy_runtime.py
+++ b/services/torghut/tests/test_strategy_runtime.py
@@ -5570,6 +5570,30 @@ class TestStrategyRuntimeMicrobarCoverage(TestCase):
         assert continuation_buy.intent is not None
         self.assertEqual(continuation_buy.intent.action, "buy")
 
+        periodicity_buy = long_plugin.evaluate(
+            self._context(
+                params={
+                    "entry_minute_after_open": "0",
+                    "exit_minute_after_open": "45",
+                    "signal_motif": "prev_day_open45_periodicity",
+                    "rank_feature": "cross_section_prev_day_open45_return_rank",
+                    "selection_mode": "continuation",
+                    "top_n": "1",
+                    "universe_size": "12",
+                },
+                event_ts="2026-03-25T13:30:00+00:00",
+            ),
+            _test_feature_vector(
+                {
+                    "session_minutes_elapsed": 0,
+                    "cross_section_prev_day_open45_return_rank": Decimal("1"),
+                }
+            ),
+        )
+        self.assertIsNotNone(periodicity_buy.intent)
+        assert periodicity_buy.intent is not None
+        self.assertEqual(periodicity_buy.intent.action, "buy")
+
         continuation_skip = _evaluate_microbar_cross_sectional(
             context=self._context(
                 params={
@@ -5702,6 +5726,11 @@ class TestMeanReversionExhaustionShortSleeveCoverage(TestCase):
             "cross_section_opening_window_return_from_prev_close_rank": None,
             "cross_section_continuation_rank": Decimal("0.38"),
             "cross_section_reversal_rank": Decimal("0.80"),
+            "cross_section_session_open_rank": Decimal("0.84"),
+            "cross_section_prev_session_close_rank": Decimal("0.81"),
+            "cross_section_range_position_rank": Decimal("0.78"),
+            "cross_section_vwap_w5m_rank": Decimal("0.76"),
+            "cross_section_recent_imbalance_rank": Decimal("0.73"),
         }
 
     def test_mean_reversion_exhaustion_short_evaluator_covers_required_and_window_guards(self) -> None:
@@ -5753,3 +5782,40 @@ class TestMeanReversionExhaustionShortSleeveCoverage(TestCase):
         self.assertIsNone(no_signal_result.signal)
         assert no_signal_result.trace is not None
         self.assertEqual(no_signal_result.trace.first_failed_gate, "structure")
+
+    def test_mean_reversion_exhaustion_short_evaluator_supports_rank_selection(self) -> None:
+        ranked_sell = evaluate_mean_reversion_exhaustion_short(
+            **(
+                self._base_kwargs()
+                | {
+                    "params": {
+                        "rank_feature": "cross_section_reversal_rank",
+                        "selection_mode": "reversal",
+                        "top_n": "2",
+                        "universe_size": "6",
+                    },
+                    "cross_section_reversal_rank": Decimal("0.85"),
+                }
+            )
+        )
+        self.assertIsNotNone(ranked_sell.signal)
+        assert ranked_sell.signal is not None
+        self.assertIn("rank_feature:cross_section_reversal_rank", ranked_sell.signal.rationale)
+
+        filtered_sell = evaluate_mean_reversion_exhaustion_short(
+            **(
+                self._base_kwargs()
+                | {
+                    "params": {
+                        "rank_feature": "cross_section_reversal_rank",
+                        "selection_mode": "reversal",
+                        "top_n": "2",
+                        "universe_size": "6",
+                    },
+                    "cross_section_reversal_rank": Decimal("0.60"),
+                }
+            )
+        )
+        self.assertIsNone(filtered_sell.signal)
+        assert filtered_sell.trace is not None
+        self.assertEqual(filtered_sell.trace.first_failed_gate, "rank_selection")

--- a/services/torghut/tests/test_strategy_runtime.py
+++ b/services/torghut/tests/test_strategy_runtime.py
@@ -13,7 +13,10 @@ from app.strategies.catalog import (
 )
 from app.trading.features import FeatureNormalizationError, FeatureVectorV3, normalize_feature_vector_v3
 from app.trading.models import SignalEnvelope
-from app.trading.research_sleeves import evaluate_mean_reversion_exhaustion_short
+from app.trading.research_sleeves import (
+    _rank_thresholds,
+    evaluate_mean_reversion_exhaustion_short,
+)
 from app.trading.strategy_runtime import (
     LegacyMacdRsiPlugin,
     MicrobarCrossSectionalLongPlugin,
@@ -5784,6 +5787,8 @@ class TestMeanReversionExhaustionShortSleeveCoverage(TestCase):
         self.assertEqual(no_signal_result.trace.first_failed_gate, "structure")
 
     def test_mean_reversion_exhaustion_short_evaluator_supports_rank_selection(self) -> None:
+        self.assertEqual(_rank_thresholds(universe_size=1, top_n=4), (Decimal("0"), Decimal("1")))
+
         ranked_sell = evaluate_mean_reversion_exhaustion_short(
             **(
                 self._base_kwargs()
@@ -5819,3 +5824,21 @@ class TestMeanReversionExhaustionShortSleeveCoverage(TestCase):
         self.assertIsNone(filtered_sell.signal)
         assert filtered_sell.trace is not None
         self.assertEqual(filtered_sell.trace.first_failed_gate, "rank_selection")
+
+        continuation_sell = evaluate_mean_reversion_exhaustion_short(
+            **(
+                self._base_kwargs()
+                | {
+                    "params": {
+                        "rank_feature": "cross_section_reversal_rank",
+                        "selection_mode": "continuation",
+                        "top_n": "2",
+                        "universe_size": "6",
+                    },
+                    "cross_section_reversal_rank": Decimal("0.20"),
+                }
+            )
+        )
+        self.assertIsNotNone(continuation_sell.signal)
+        assert continuation_sell.signal is not None
+        self.assertIn("selection_mode:continuation", continuation_sell.signal.rationale)


### PR DESCRIPTION
## Summary

- fix Torghut runtime decision handling so short-family buy exits stay exit-only, runtime trade policy accounts for short entries and exits symmetrically, and replay position accounting preserves short state correctly
- carry prior-day opening-period cross-sectional features through `SessionContextTracker` and `local_intraday_tsmom_replay.py` so runtime replay uses the same authoritative signal context as discovery
- add the checked-in `mean_reversion_exhaustion_short_v1` family, strict frontier sweep config, and regression coverage for the repaired runtime/discovery parity path

## Related Issues

None

## Testing

- `/opt/homebrew/bin/mise exec uv -- uv sync --frozen --extra dev`
- `/opt/homebrew/bin/mise exec uv -- uv run --frozen pytest tests/test_decisions.py tests/test_strategy_runtime.py tests/test_local_intraday_tsmom_replay.py tests/test_execution_policy.py tests/test_session_context.py tests/test_discovery_harness_v2.py -q`
- `/opt/homebrew/bin/mise exec uv -- uv run --frozen ruff check app/trading/decisions.py app/trading/execution_policy.py app/trading/features.py app/trading/research_sleeves.py app/trading/session_context.py app/trading/strategy_runtime.py scripts/local_intraday_tsmom_replay.py tests/test_decisions.py tests/test_discovery_harness_v2.py tests/test_execution_policy.py tests/test_local_intraday_tsmom_replay.py tests/test_session_context.py tests/test_strategy_runtime.py`
- `/opt/homebrew/bin/mise exec uv -- uv run --frozen pyright --project pyrightconfig.json`
- `/opt/homebrew/bin/mise exec uv -- uv run --frozen pyright --project pyrightconfig.alpha.json`
- `/opt/homebrew/bin/mise exec uv -- uv run --frozen pyright --project pyrightconfig.scripts.json`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
