### PR TITLE
chore(torghut): promote image 5bc4cdf5

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:c249650f9d498da61ac732f7ead1c7b62ba83392df871a6328595dc350ac02a2
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8ee839c2f169656dc3f07c16dcec8a3f4fb1d69b3f7a128d4674ed813ca66f84
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -63,9 +63,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.566.0-288-g917141341
+              value: v0.566.0-290-g5bc4cdf51
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 9171413416f3acc7e622558752eb0b825aad408d
+              value: 5bc4cdf510383dd133ac1e5a3073eb46021ad8c7
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:c249650f9d498da61ac732f7ead1c7b62ba83392df871a6328595dc350ac02a2
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8ee839c2f169656dc3f07c16dcec8a3f4fb1d69b3f7a128d4674ed813ca66f84
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -63,9 +63,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.566.0-288-g917141341
+              value: v0.566.0-290-g5bc4cdf51
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 9171413416f3acc7e622558752eb0b825aad408d
+              value: 5bc4cdf510383dd133ac1e5a3073eb46021ad8c7
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -40,7 +40,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:c249650f9d498da61ac732f7ead1c7b62ba83392df871a6328595dc350ac02a2
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:8ee839c2f169656dc3f07c16dcec8a3f4fb1d69b3f7a128d4674ed813ca66f84
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -21,7 +21,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:c249650f9d498da61ac732f7ead1c7b62ba83392df871a6328595dc350ac02a2
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:8ee839c2f169656dc3f07c16dcec8a3f4fb1d69b3f7a128d4674ed813ca66f84
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -32,7 +32,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:c249650f9d498da61ac732f7ead1c7b62ba83392df871a6328595dc350ac02a2
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:8ee839c2f169656dc3f07c16dcec8a3f4fb1d69b3f7a128d4674ed813ca66f84
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -30,7 +30,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:c249650f9d498da61ac732f7ead1c7b62ba83392df871a6328595dc350ac02a2
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:8ee839c2f169656dc3f07c16dcec8a3f4fb1d69b3f7a128d4674ed813ca66f84
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:c249650f9d498da61ac732f7ead1c7b62ba83392df871a6328595dc350ac02a2
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8ee839c2f169656dc3f07c16dcec8a3f4fb1d69b3f7a128d4674ed813ca66f84
           command:
             - /opt/venv/bin/alembic
           args:

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -13,7 +13,7 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:c249650f9d498da61ac732f7ead1c7b62ba83392df871a6328595dc350ac02a2
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8ee839c2f169656dc3f07c16dcec8a3f4fb1d69b3f7a128d4674ed813ca66f84
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -21,7 +21,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:c249650f9d498da61ac732f7ead1c7b62ba83392df871a6328595dc350ac02a2
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:8ee839c2f169656dc3f07c16dcec8a3f4fb1d69b3f7a128d4674ed813ca66f84
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -39,7 +39,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:c249650f9d498da61ac732f7ead1c7b62ba83392df871a6328595dc350ac02a2
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:8ee839c2f169656dc3f07c16dcec8a3f4fb1d69b3f7a128d4674ed813ca66f84
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-04-11T02:47:17Z"
+        client.knative.dev/updateTimestamp: "2026-04-11T03:56:43Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:c249650f9d498da61ac732f7ead1c7b62ba83392df871a6328595dc350ac02a2
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8ee839c2f169656dc3f07c16dcec8a3f4fb1d69b3f7a128d4674ed813ca66f84
           ports:
             - name: http1
               containerPort: 8181
@@ -495,9 +495,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.566.0-288-g917141341
+              value: v0.566.0-290-g5bc4cdf51
             - name: TORGHUT_COMMIT
-              value: 9171413416f3acc7e622558752eb0b825aad408d
+              value: 5bc4cdf510383dd133ac1e5a3073eb46021ad8c7
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-04-11T02:47:17Z"
+        client.knative.dev/updateTimestamp: "2026-04-11T03:56:43Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -26,7 +26,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:c249650f9d498da61ac732f7ead1c7b62ba83392df871a6328595dc350ac02a2
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8ee839c2f169656dc3f07c16dcec8a3f4fb1d69b3f7a128d4674ed813ca66f84
           ports:
             - name: http1
               containerPort: 8181
@@ -276,9 +276,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.566.0-288-g917141341
+              value: v0.566.0-290-g5bc4cdf51
             - name: TORGHUT_COMMIT
-              value: 9171413416f3acc7e622558752eb0b825aad408d
+              value: 5bc4cdf510383dd133ac1e5a3073eb46021ad8c7
           livenessProbe:
             httpGet:
               path: /healthz


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `5bc4cdf510383dd133ac1e5a3073eb46021ad8c7`
- Image tag: `5bc4cdf5`
- Image digest: `sha256:8ee839c2f169656dc3f07c16dcec8a3f4fb1d69b3f7a128d4674ed813ca66f84`