### PR TITLE
refactor(jangar): harden memory provider readiness

### DIFF
--- a/docs/jangar/application-architecture.md
+++ b/docs/jangar/application-architecture.md
@@ -36,11 +36,15 @@ The cleanup program moved the highest-risk application boundaries behind explici
   - `services/jangar/src/server/controller-runtime-config.ts`
   - `services/jangar/src/server/control-plane-config.ts`
   - `services/jangar/src/server/integrations-config.ts`
+  - `services/jangar/src/server/memory-config.ts`
   - `services/jangar/src/server/torghut-config.ts`
   - `services/jangar/src/server/agentctl-grpc-config.ts`
   - `services/jangar/src/server/terminals-config.ts`
   - `services/jangar/src/server/github-review-config.ts`
   - `services/jangar/src/server/metrics-config.ts`
+- Memory embeddings
+  - `services/jangar/src/server/memory-provider.ts`
+  - `services/jangar/src/server/memory-provider-health.ts`
 - Kubernetes
   - `services/jangar/src/server/kube-gateway.ts`
   - `services/jangar/src/server/primitives-kube.ts`

--- a/services/jangar/src/routes/ready.test.ts
+++ b/services/jangar/src/routes/ready.test.ts
@@ -26,10 +26,15 @@ const runtimeAdmissionMocks = vi.hoisted(() => ({
   findAdmissionPassport: vi.fn(),
 }))
 
+const memoryProviderHealthMocks = vi.hoisted(() => ({
+  getMemoryProviderHealth: vi.fn(),
+}))
+
 vi.mock('~/server/agents-controller', () => agentsControllerMocks)
 vi.mock('~/server/leader-election', () => leaderElectionMocks)
 vi.mock('~/server/orchestration-controller', () => orchestrationControllerMocks)
 vi.mock('~/server/supporting-primitives-controller', () => supportingControllerMocks)
+vi.mock('~/server/memory-provider-health', () => memoryProviderHealthMocks)
 vi.mock('~/server/control-plane-status', async () => {
   const actual = await vi.importActual<typeof import('~/server/control-plane-status')>('~/server/control-plane-status')
   return {
@@ -120,6 +125,20 @@ describe('getReadyHandler', () => {
     runtimeAdmissionMocks.findAdmissionPassport.mockImplementation(({ admissionPassports, consumerClass }) =>
       admissionPassports.find((passport: { consumer_class?: string }) => passport.consumer_class === consumerClass),
     )
+    memoryProviderHealthMocks.getMemoryProviderHealth.mockReturnValue({
+      status: 'healthy',
+      reason: 'memory embeddings configured for an explicit OpenAI-compatible endpoint',
+      mode: 'self-hosted',
+      fallbackActive: false,
+      config: {
+        apiBaseUrl: 'http://saigak.jangar.svc.cluster.local:11434/v1',
+        model: 'qwen3-embedding-saigak:0.6b',
+        dimension: 1024,
+        timeoutMs: 15000,
+        maxInputChars: 60000,
+        hosted: false,
+      },
+    })
 
     agentsControllerMocks.getAgentsControllerHealth.mockReturnValue({
       enabled: true,
@@ -178,6 +197,9 @@ describe('getReadyHandler', () => {
     expect(response.status).toBe(200)
     const body = await response.json()
     expect(body.status).toBe('ok')
+    expect(body.memory_provider).toMatchObject({
+      status: 'healthy',
+    })
   })
 
   it('returns 200 and exposes a serving passport when only collaboration runtime debt is blocked', async () => {
@@ -532,5 +554,34 @@ describe('getReadyHandler', () => {
     })
     expect(body.execution_trust.reason).toContain('execution trust check failed for namespace agents')
     expect(controlPlaneStatusMocks.buildExecutionTrust).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns 503 when memory provider health is blocked', async () => {
+    memoryProviderHealthMocks.getMemoryProviderHealth.mockReturnValue({
+      status: 'blocked',
+      reason:
+        'missing OPENAI_API_KEY; set it or point OPENAI_EMBEDDING_API_BASE_URL/OPENAI_API_BASE_URL at an OpenAI-compatible endpoint',
+      mode: 'hosted',
+      fallbackActive: false,
+      config: {
+        apiBaseUrl: 'https://api.openai.com/v1',
+        model: 'text-embedding-3-small',
+        dimension: 1536,
+        timeoutMs: 15000,
+        maxInputChars: 60000,
+        hosted: true,
+      },
+    })
+
+    const { getReadyHandler } = await import('./ready')
+
+    const response = await getReadyHandler()
+
+    expect(response.status).toBe(503)
+    const body = await response.json()
+    expect(body.status).toBe('degraded')
+    expect(body.memory_provider).toMatchObject({
+      status: 'blocked',
+    })
   })
 })

--- a/services/jangar/src/routes/ready.tsx
+++ b/services/jangar/src/routes/ready.tsx
@@ -4,6 +4,7 @@ import type { ExecutionTrustStatus } from '~/data/agents-control-plane'
 import { assessAgentRunIngestion, getAgentsControllerHealth } from '~/server/agents-controller'
 import { buildRuntimeAdmissionSnapshot, findAdmissionPassport } from '~/server/control-plane-runtime-admission'
 import { getLeaderElectionStatus } from '~/server/leader-election'
+import { getMemoryProviderHealth } from '~/server/memory-provider-health'
 import { getOrchestrationControllerHealth } from '~/server/orchestration-controller'
 import { getSupportingControllerHealth } from '~/server/supporting-primitives-controller'
 import { buildExecutionTrust } from '~/server/control-plane-status'
@@ -122,6 +123,7 @@ export const getReadyHandler = async () => {
   const supportingController = getSupportingControllerHealth()
   const namespaces = agentsController.namespaces?.length ? agentsController.namespaces : ['agents']
   const trust = await executionTrustStatus(namespaces)
+  const memoryProvider = getMemoryProviderHealth()
   const runtimeAdmission = buildRuntimeAdmissionSnapshot({
     now: new Date(),
     executionTrust: trust,
@@ -143,7 +145,8 @@ export const getReadyHandler = async () => {
     : leaderElectionReady
   const servingPassportReady =
     servingPassport !== undefined && servingPassport.decision !== 'block' && servingPassport.decision !== 'hold'
-  const ready = controllersOk && agentsControllerReady && servingPassportReady
+  const memoryProviderReady = memoryProvider.status !== 'blocked'
+  const ready = controllersOk && agentsControllerReady && servingPassportReady && memoryProviderReady
 
   const body = JSON.stringify({
     status: ready ? 'ok' : 'degraded',
@@ -153,6 +156,7 @@ export const getReadyHandler = async () => {
     orchestrationController,
     supportingController,
     execution_trust: trust,
+    memory_provider: memoryProvider,
     runtime_kits: runtimeAdmission.runtimeKits,
     admission_passports: runtimeAdmission.admissionPassports,
     serving_passport_id: runtimeAdmission.servingPassportId,

--- a/services/jangar/src/server/__tests__/memory-provider-health.test.ts
+++ b/services/jangar/src/server/__tests__/memory-provider-health.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+
+import { getMemoryProviderHealth, MEMORY_PROVIDER_MISSING_API_KEY_MESSAGE } from '~/server/memory-provider-health'
+
+describe('memory-provider-health', () => {
+  it('reports development fallback mode when no endpoint is configured outside production', () => {
+    const health = getMemoryProviderHealth({
+      NODE_ENV: 'development',
+    })
+
+    expect(health).toMatchObject({
+      status: 'degraded',
+      mode: 'development-fallback',
+      fallbackActive: true,
+    })
+  })
+
+  it('reports blocked when the hosted provider is selected without an API key in production', () => {
+    const health = getMemoryProviderHealth({
+      NODE_ENV: 'production',
+    })
+
+    expect(health).toMatchObject({
+      status: 'blocked',
+      mode: 'hosted',
+      fallbackActive: false,
+      reason: MEMORY_PROVIDER_MISSING_API_KEY_MESSAGE,
+    })
+  })
+
+  it('reports healthy for an explicit self-hosted endpoint without an API key', () => {
+    const health = getMemoryProviderHealth({
+      NODE_ENV: 'production',
+      OPENAI_API_BASE_URL: 'http://saigak.jangar.svc.cluster.local:11434/v1',
+      OPENAI_EMBEDDING_MODEL: 'qwen3-embedding-saigak:0.6b',
+      OPENAI_EMBEDDING_DIMENSION: '1024',
+    })
+
+    expect(health).toMatchObject({
+      status: 'healthy',
+      mode: 'self-hosted',
+      fallbackActive: false,
+      config: {
+        hosted: false,
+        dimension: 1024,
+      },
+    })
+  })
+
+  it('reports blocked for invalid embedding configuration values', () => {
+    const health = getMemoryProviderHealth({
+      NODE_ENV: 'production',
+      OPENAI_API_BASE_URL: 'http://saigak.jangar.svc.cluster.local:11434/v1',
+      OPENAI_EMBEDDING_DIMENSION: '0',
+    })
+
+    expect(health).toMatchObject({
+      status: 'blocked',
+      mode: 'invalid',
+      fallbackActive: false,
+      config: null,
+    })
+    expect(health.reason).toMatch(/OPENAI_EMBEDDING_DIMENSION/)
+  })
+})

--- a/services/jangar/src/server/__tests__/memory-provider.test.ts
+++ b/services/jangar/src/server/__tests__/memory-provider.test.ts
@@ -72,6 +72,41 @@ describe('memory-provider', () => {
     await expect(writeMemoryEmbedding(connection, 'key-1', 'hello world')).rejects.toThrow(/missing OPENAI_API_KEY/i)
   })
 
+  it('fails when the embedding input exceeds the configured maximum length', async () => {
+    process.env.NODE_ENV = 'production'
+    process.env.OPENAI_API_KEY = 'test-key'
+    process.env.OPENAI_EMBEDDING_DIMENSION = '3'
+    process.env.OPENAI_EMBEDDING_MAX_INPUT_CHARS = '5'
+
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(writeMemoryEmbedding(connection, 'key-1', 'hello world')).rejects.toThrow(/input too large/i)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('fails when the embedding request exceeds the configured timeout', async () => {
+    process.env.NODE_ENV = 'production'
+    process.env.OPENAI_API_KEY = 'test-key'
+    process.env.OPENAI_EMBEDDING_DIMENSION = '3'
+    process.env.OPENAI_EMBEDDING_TIMEOUT_MS = '5'
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((_input: RequestInfo | URL, init?: RequestInit) => {
+        return new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () => {
+            const error = new Error('aborted')
+            error.name = 'AbortError'
+            reject(error)
+          })
+        })
+      }),
+    )
+
+    await expect(writeMemoryEmbedding(connection, 'key-1', 'hello world')).rejects.toThrow(/timed out/i)
+  })
+
   it('reuses pooled postgres clients across repeated writes', async () => {
     process.env.NODE_ENV = 'development'
 

--- a/services/jangar/src/server/memory-provider-health.ts
+++ b/services/jangar/src/server/memory-provider-health.ts
@@ -1,0 +1,80 @@
+import { resolveEmbeddingConfig } from './memory-config'
+
+type EnvSource = Record<string, string | undefined>
+
+export type MemoryProviderHealthStatus = 'healthy' | 'degraded' | 'blocked'
+
+export type MemoryProviderHealthMode = 'hosted' | 'self-hosted' | 'development-fallback' | 'invalid'
+
+export type MemoryProviderHealth = {
+  status: MemoryProviderHealthStatus
+  reason: string
+  mode: MemoryProviderHealthMode
+  fallbackActive: boolean
+  config: {
+    apiBaseUrl: string
+    model: string
+    dimension: number
+    timeoutMs: number
+    maxInputChars: number
+    hosted: boolean
+  } | null
+}
+
+const MISSING_API_KEY_MESSAGE =
+  'missing OPENAI_API_KEY; set it or point OPENAI_EMBEDDING_API_BASE_URL/OPENAI_API_BASE_URL at an OpenAI-compatible endpoint'
+
+export const getMemoryProviderHealth = (env: EnvSource = process.env): MemoryProviderHealth => {
+  try {
+    const config = resolveEmbeddingConfig(env)
+    const summary = {
+      apiBaseUrl: config.apiBaseUrl,
+      model: config.model,
+      dimension: config.dimension,
+      timeoutMs: config.timeoutMs,
+      maxInputChars: config.maxInputChars,
+      hosted: config.hosted,
+    }
+
+    if (!config.hasExplicitBaseUrl && !config.apiKey && config.allowDevFallback) {
+      return {
+        status: 'degraded',
+        reason:
+          'memory embeddings are running in development fallback mode; configure OPENAI_API_KEY or OPENAI_EMBEDDING_API_BASE_URL for live embeddings',
+        mode: 'development-fallback',
+        fallbackActive: true,
+        config: summary,
+      }
+    }
+
+    if (config.hosted && !config.apiKey) {
+      return {
+        status: 'blocked',
+        reason: MISSING_API_KEY_MESSAGE,
+        mode: 'hosted',
+        fallbackActive: false,
+        config: summary,
+      }
+    }
+
+    return {
+      status: 'healthy',
+      reason: config.hosted
+        ? 'memory embeddings configured for the hosted OpenAI endpoint'
+        : 'memory embeddings configured for an explicit OpenAI-compatible endpoint',
+      mode: config.hosted ? 'hosted' : 'self-hosted',
+      fallbackActive: false,
+      config: summary,
+    }
+  } catch (error) {
+    return {
+      status: 'blocked',
+      reason: error instanceof Error ? error.message : 'invalid memory provider configuration',
+      mode: 'invalid',
+      fallbackActive: false,
+      config: null,
+    }
+  }
+}
+
+export const MEMORY_PROVIDER_MISSING_API_KEY_MESSAGE = MISSING_API_KEY_MESSAGE

--- a/services/jangar/src/server/memory-provider.ts
+++ b/services/jangar/src/server/memory-provider.ts
@@ -20,12 +20,6 @@ type MemoryQueryResult = {
 
 type EnvSource = Record<string, string | undefined>
 
-const DEFAULT_EMBEDDING_DIMENSION = 1536
-const DEFAULT_OPENAI_API_BASE_URL = 'https://api.openai.com/v1'
-const DEFAULT_OPENAI_EMBEDDING_MODEL = 'text-embedding-3-small'
-const DEFAULT_SELF_HOSTED_EMBEDDING_MODEL = 'qwen3-embedding-saigak:0.6b'
-const DEFAULT_SELF_HOSTED_EMBEDDING_DIMENSION = 1024
-
 const globalState = globalThis as typeof globalThis & {
   __jangarMemoryProviderPools?: Map<string, Pool>
 }
@@ -82,33 +76,6 @@ const generateFallbackEmbedding = (text: string, dimension: number) => {
   return vector
 }
 
-const isHostedOpenAiBaseUrl = (rawBaseUrl: string) => {
-  try {
-    return new URL(rawBaseUrl).hostname === 'api.openai.com'
-  } catch {
-    return rawBaseUrl.includes('api.openai.com')
-  }
-}
-
-const resolveEmbeddingDefaults = (apiBaseUrl: string) => {
-  const hosted = isHostedOpenAiBaseUrl(apiBaseUrl)
-  return {
-    model: hosted ? DEFAULT_OPENAI_EMBEDDING_MODEL : DEFAULT_SELF_HOSTED_EMBEDDING_MODEL,
-    dimension: hosted ? DEFAULT_EMBEDDING_DIMENSION : DEFAULT_SELF_HOSTED_EMBEDDING_DIMENSION,
-  }
-}
-
-const loadEmbeddingDimension = (env: EnvSource, fallback: number) => {
-  const dimension = Number.parseInt(env.OPENAI_EMBEDDING_DIMENSION ?? String(fallback), 10)
-  if (!Number.isFinite(dimension) || dimension <= 0) {
-    throw new Error('OPENAI_EMBEDDING_DIMENSION must be a positive integer')
-  }
-  return dimension
-}
-
-const resolveEmbeddingApiBaseUrl = (env: EnvSource) =>
-  env.OPENAI_EMBEDDING_API_BASE_URL ?? env.OPENAI_API_BASE_URL ?? env.OPENAI_API_BASE ?? DEFAULT_OPENAI_API_BASE_URL
-
 export const loadEmbeddingConfig = (env: EnvSource = process.env) => resolveEmbeddingConfig(env)
 
 const getPoolCache = () => {
@@ -141,11 +108,14 @@ const embedText = async (text: string, dimension: number) => {
     return generateFallbackEmbedding(text, dimension)
   }
 
-  const { apiBaseUrl, apiKey, model, dimension: configuredDimension } = embeddingConfig
+  const { apiBaseUrl, apiKey, model, dimension: configuredDimension, timeoutMs, maxInputChars } = embeddingConfig
   if (embeddingConfig.hosted && !apiKey) {
     throw new Error(
       'missing OPENAI_API_KEY; set it or point OPENAI_EMBEDDING_API_BASE_URL/OPENAI_API_BASE_URL at an OpenAI-compatible endpoint',
     )
+  }
+  if (text.length > maxInputChars) {
+    throw new Error(`embedding input too large (${text.length} chars; max ${maxInputChars})`)
   }
   if (configuredDimension !== dimension) {
     const error = new Error(
@@ -158,6 +128,8 @@ const embedText = async (text: string, dimension: number) => {
     throw error
   }
 
+  const controller = new AbortController()
+  const timeoutHandle = setTimeout(() => controller.abort(), timeoutMs)
   const headers: Record<string, string> = {
     'content-type': 'application/json',
   }
@@ -165,31 +137,41 @@ const embedText = async (text: string, dimension: number) => {
     headers.authorization = `Bearer ${apiKey}`
   }
 
-  const response = await fetch(`${apiBaseUrl.replace(/\/+$/, '')}/embeddings`, {
-    method: 'POST',
-    headers,
-    body: JSON.stringify({ model, input: text }),
-  })
+  try {
+    const response = await fetch(`${apiBaseUrl.replace(/\/+$/, '')}/embeddings`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ model, input: text }),
+      signal: controller.signal,
+    })
 
-  if (!response.ok) {
-    const body = await response.text()
-    throw new Error(`embedding request failed (${response.status}): ${body}`)
-  }
+    if (!response.ok) {
+      const body = await response.text()
+      throw new Error(`embedding request failed (${response.status}): ${body}`)
+    }
 
-  const json = (await response.json()) as { data?: { embedding?: number[] }[] }
-  const embedding = json.data?.[0]?.embedding
-  if (!embedding || !Array.isArray(embedding)) {
-    throw new Error('embedding response missing data[0].embedding')
-  }
-  if (embedding.length !== dimension) {
-    const error = new Error(`embedding dimension mismatch: expected ${dimension} but got ${embedding.length}`)
-    if (embeddingConfig.allowDevFallback) {
-      console.warn('[jangar] memory provider using fallback embeddings', error.message)
-      return generateFallbackEmbedding(text, dimension)
+    const json = (await response.json()) as { data?: { embedding?: number[] }[] }
+    const embedding = json.data?.[0]?.embedding
+    if (!embedding || !Array.isArray(embedding)) {
+      throw new Error('embedding response missing data[0].embedding')
+    }
+    if (embedding.length !== dimension) {
+      const error = new Error(`embedding dimension mismatch: expected ${dimension} but got ${embedding.length}`)
+      if (embeddingConfig.allowDevFallback) {
+        console.warn('[jangar] memory provider using fallback embeddings', error.message)
+        return generateFallbackEmbedding(text, dimension)
+      }
+      throw error
+    }
+    return embedding
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw new Error(`embedding request timed out after ${timeoutMs}ms`)
     }
     throw error
+  } finally {
+    clearTimeout(timeoutHandle)
   }
-  return embedding
 }
 
 const vectorToPg = (vector: number[]) => `[${vector.join(',')}]`
@@ -233,10 +215,7 @@ export const resolveMemoryConnection = async (
   }
 
   const connectionString = buildConnectionString(decodedSecret, secretKey)
-  const embeddingDimension = loadEmbeddingDimension(
-    process.env,
-    resolveEmbeddingDefaults(resolveEmbeddingApiBaseUrl(process.env)).dimension,
-  )
+  const embeddingDimension = resolveEmbeddingConfig(process.env).dimension
 
   return { dataset, schema, embeddingDimension, connectionString }
 }


### PR DESCRIPTION
## Summary

- add a typed memory-provider health contract so Jangar can surface healthy, degraded, or blocked embedding readiness explicitly
- wire memory-provider health into `/ready` and degrade readiness when production embeddings are blocked
- align `memory-provider.ts` with the existing embedding config contract by enforcing configured input-size and timeout limits, and add regression coverage

## Related Issues

None

## Testing

- `cd services/jangar && ~/.bun/bin/bunx vitest run src/server/__tests__/memory-provider.test.ts src/server/__tests__/memory-provider-health.test.ts src/routes/ready.test.ts`
- `~/.bun/bin/bun run --cwd services/jangar build`
- `cd services/jangar && ~/.bun/bin/bunx tsc --noEmit --project tsconfig.paths.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
