### PR TITLE
feat(torghut): execute mlx runtime closure replays

### DIFF
--- a/services/torghut/app/trading/discovery/autoresearch.py
+++ b/services/torghut/app/trading/discovery/autoresearch.py
@@ -188,6 +188,28 @@ class ReplayBudget:
 
 
 @dataclass(frozen=True)
+class RuntimeClosurePolicy:
+    enabled: bool
+    execute_parity_replay: bool
+    execute_approval_replay: bool
+    parity_window: str
+    approval_window: str
+    shadow_validation_mode: str
+    promotion_target: str
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            'enabled': self.enabled,
+            'execute_parity_replay': self.execute_parity_replay,
+            'execute_approval_replay': self.execute_approval_replay,
+            'parity_window': self.parity_window,
+            'approval_window': self.approval_window,
+            'shadow_validation_mode': self.shadow_validation_mode,
+            'promotion_target': self.promotion_target,
+        }
+
+
+@dataclass(frozen=True)
 class ResearchClaim:
     claim_id: str
     summary: str
@@ -287,6 +309,7 @@ class StrategyAutoresearchProgram:
     forbidden_mutations: tuple[str, ...]
     proposal_model_policy: ProposalModelPolicy
     replay_budget: ReplayBudget
+    runtime_closure_policy: RuntimeClosurePolicy
     parity_requirements: tuple[str, ...]
     promotion_policy: str
     ledger_policy: Mapping[str, Any]
@@ -304,6 +327,7 @@ class StrategyAutoresearchProgram:
             'forbidden_mutations': list(self.forbidden_mutations),
             'proposal_model_policy': self.proposal_model_policy.to_payload(),
             'replay_budget': self.replay_budget.to_payload(),
+            'runtime_closure_policy': self.runtime_closure_policy.to_payload(),
             'parity_requirements': list(self.parity_requirements),
             'promotion_policy': self.promotion_policy,
             'ledger_policy': dict(self.ledger_policy),
@@ -347,6 +371,34 @@ def _resolve_seed_sweep_path(*, program_path: Path, raw_path: str) -> Path:
     if candidate.is_absolute():
         return candidate
     return (program_path.parent / candidate).resolve()
+
+
+def _load_runtime_closure_policy(payload: Mapping[str, Any]) -> RuntimeClosurePolicy:
+    parity_window = _string(payload.get('parity_window')) or 'full_window'
+    approval_window = _string(payload.get('approval_window')) or 'holdout'
+    if parity_window not in {'train', 'holdout', 'full_window'}:
+        raise ValueError(f'autoresearch_runtime_closure_parity_window_invalid:{parity_window}')
+    if approval_window not in {'train', 'holdout', 'full_window'}:
+        raise ValueError(f'autoresearch_runtime_closure_approval_window_invalid:{approval_window}')
+    shadow_validation_mode = (
+        _string(payload.get('shadow_validation_mode')) or 'require_live_evidence'
+    )
+    if shadow_validation_mode not in {'require_live_evidence', 'skip'}:
+        raise ValueError(
+            f'autoresearch_runtime_closure_shadow_validation_mode_invalid:{shadow_validation_mode}'
+        )
+    promotion_target = _string(payload.get('promotion_target')) or 'shadow'
+    if promotion_target not in {'shadow', 'paper', 'live'}:
+        raise ValueError(f'autoresearch_runtime_closure_promotion_target_invalid:{promotion_target}')
+    return RuntimeClosurePolicy(
+        enabled=bool(payload.get('enabled', False)),
+        execute_parity_replay=bool(payload.get('execute_parity_replay', True)),
+        execute_approval_replay=bool(payload.get('execute_approval_replay', True)),
+        parity_window=parity_window,
+        approval_window=approval_window,
+        shadow_validation_mode=shadow_validation_mode,
+        promotion_target=promotion_target,
+    )
 
 
 def load_strategy_autoresearch_program(
@@ -424,6 +476,7 @@ def load_strategy_autoresearch_program(
         max_candidates_per_round=max(1, int(replay_budget_payload.get('max_candidates_per_round', 8))),
         exploration_slots=max(0, int(replay_budget_payload.get('exploration_slots', 1))),
     )
+    runtime_closure_policy = _load_runtime_closure_policy(_mapping(payload.get('runtime_closure_policy')))
     forbidden_mutations = _string_list(
         payload.get('forbidden_mutations')
         or ['runtime_code_path', 'evaluator_logic', 'live_strategy_config']
@@ -531,6 +584,7 @@ def load_strategy_autoresearch_program(
         forbidden_mutations=forbidden_mutations,
         proposal_model_policy=proposal_model_policy,
         replay_budget=replay_budget,
+        runtime_closure_policy=runtime_closure_policy,
         parity_requirements=parity_requirements,
         promotion_policy=promotion_policy,
         ledger_policy=ledger_policy,

--- a/services/torghut/app/trading/discovery/runtime_closure.py
+++ b/services/torghut/app/trading/discovery/runtime_closure.py
@@ -6,22 +6,45 @@ import hashlib
 import json
 import subprocess
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
+from decimal import Decimal
 from pathlib import Path
 from typing import Any, Mapping, cast
+
+import yaml
 
 from app.trading.autonomy.policy_checks import (
     evaluate_promotion_prerequisites,
     evaluate_rollback_readiness,
 )
-from app.trading.discovery.autoresearch import StrategyAutoresearchProgram
+from app.trading.discovery.autoresearch import (
+    StrategyAutoresearchProgram,
+    candidate_meets_objective,
+)
+from app.trading.discovery.decomposition import (
+    build_replay_decomposition,
+    max_family_contribution_share,
+    max_symbol_concentration_share,
+    regime_slice_pass_rate,
+)
 from app.trading.discovery.mlx_snapshot import MlxSnapshotManifest
+from app.trading.discovery.objectives import ObjectiveVetoPolicy, build_scorecard, evaluate_vetoes
+from app.trading.reporting import summarize_replay_profitability
+import scripts.local_intraday_tsmom_replay as replay_mod
+from scripts.search_consistent_profitability_frontier import apply_candidate_to_configmap_with_overrides
 
 _REPO_ROOT = Path(__file__).resolve().parents[5]
 
 
 def _string(value: Any) -> str:
     return str(value or '').strip()
+
+
+def _mapping(value: Any) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        return {}
+    mapping_value = cast(Mapping[Any, Any], value)
+    return {str(key): item for key, item in mapping_value.items()}
 
 
 def _int(value: Any) -> int:
@@ -111,6 +134,307 @@ def _runtime_closure_policy() -> dict[str, Any]:
     }
 
 
+@dataclass(frozen=True)
+class RuntimeClosureExecutionContext:
+    strategy_configmap_path: Path
+    clickhouse_http_url: str
+    clickhouse_username: str | None
+    clickhouse_password: str | None
+    start_equity: Decimal
+    chunk_minutes: int
+    symbols: tuple[str, ...] = ()
+    progress_log_interval_seconds: int = 30
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            'strategy_configmap_path': str(self.strategy_configmap_path),
+            'clickhouse_http_url': self.clickhouse_http_url,
+            'clickhouse_username': self.clickhouse_username,
+            'start_equity': str(self.start_equity),
+            'chunk_minutes': self.chunk_minutes,
+            'symbols': list(self.symbols),
+            'progress_log_interval_seconds': self.progress_log_interval_seconds,
+        }
+
+
+def _date_from_iso(value: str) -> date:
+    return date.fromisoformat(value)
+
+
+def _daily_filled_notional(payload: Mapping[str, Any]) -> dict[str, Decimal]:
+    daily_payload = _mapping(payload.get('daily'))
+    resolved: dict[str, Decimal] = {}
+    for day, value in daily_payload.items():
+        item = _mapping(value)
+        resolved[day] = Decimal(str(item.get('filled_notional', '0')))
+    return resolved
+
+
+def _max_drawdown_from_daily_net(daily_net: Mapping[str, Decimal]) -> Decimal:
+    equity = Decimal('0')
+    peak = Decimal('0')
+    max_drawdown = Decimal('0')
+    for trading_day in sorted(daily_net):
+        equity += daily_net[trading_day]
+        if equity > peak:
+            peak = equity
+        drawdown = peak - equity
+        if drawdown > max_drawdown:
+            max_drawdown = drawdown
+    return max_drawdown
+
+
+def _rolling_lower_bound(daily_net: Mapping[str, Decimal], *, window: int) -> Decimal:
+    ordered = [daily_net[key] for key in sorted(daily_net)]
+    if not ordered:
+        return Decimal('0')
+    if len(ordered) < window:
+        return sum(ordered, Decimal('0')) / Decimal(len(ordered))
+    values: list[Decimal] = []
+    for index in range(len(ordered) - window + 1):
+        sample = ordered[index : index + window]
+        values.append(sum(sample, Decimal('0')) / Decimal(window))
+    return min(values) if values else Decimal('0')
+
+
+def _max_best_day_share_of_total_pnl(*, daily_net: Mapping[str, Decimal], total_net_pnl: Decimal) -> Decimal:
+    if total_net_pnl <= 0:
+        return Decimal('1')
+    best_positive_day = max((value for value in daily_net.values() if value > 0), default=Decimal('0'))
+    if best_positive_day <= 0:
+        return Decimal('0')
+    return best_positive_day / total_net_pnl
+
+
+def _objective_veto_policy(program: StrategyAutoresearchProgram) -> ObjectiveVetoPolicy:
+    return ObjectiveVetoPolicy(
+        required_min_active_day_ratio=program.objective.min_active_day_ratio,
+        required_min_daily_notional=program.objective.min_daily_notional,
+        required_max_best_day_share=program.objective.max_best_day_share,
+        required_max_worst_day_loss=program.objective.max_worst_day_loss,
+        required_max_drawdown=program.objective.max_drawdown,
+        required_min_regime_slice_pass_rate=program.objective.min_regime_slice_pass_rate,
+    )
+
+
+def _candidate_symbols(
+    *,
+    best_candidate: Mapping[str, Any],
+    execution_context: RuntimeClosureExecutionContext,
+) -> tuple[str, ...]:
+    strategy_overrides = _mapping(best_candidate.get('candidate_strategy_overrides'))
+    override_symbols = strategy_overrides.get('universe_symbols')
+    if isinstance(override_symbols, list):
+        resolved: list[str] = []
+        for item in cast(list[Any], override_symbols):
+            if isinstance(item, str):
+                normalized = item.strip().upper()
+                if normalized:
+                    resolved.append(normalized)
+        if resolved:
+            return tuple(resolved)
+    return execution_context.symbols
+
+
+def _window_bounds(*, best_candidate: Mapping[str, Any], window_name: str, manifest: MlxSnapshotManifest) -> tuple[date, date]:
+    replay_config = _mapping(best_candidate.get('replay_config'))
+    start_key = f'{window_name}_start_date'
+    end_key = f'{window_name}_end_date'
+    start_text = _string(best_candidate.get(start_key)) or _string(replay_config.get(start_key))
+    end_text = _string(best_candidate.get(end_key)) or _string(replay_config.get(end_key))
+    if not start_text or not end_text:
+        if window_name != 'full_window':
+            raise ValueError(f'runtime_closure_window_missing:{window_name}')
+        start_text = manifest.source_window_start
+        end_text = manifest.source_window_end
+    return (_date_from_iso(start_text), _date_from_iso(end_text))
+
+
+def _materialize_candidate_configmap(
+    *,
+    best_candidate: Mapping[str, Any],
+    execution_context: RuntimeClosureExecutionContext,
+    output_path: Path,
+) -> Path:
+    configmap_payload = yaml.safe_load(execution_context.strategy_configmap_path.read_text(encoding='utf-8'))
+    if not isinstance(configmap_payload, Mapping):
+        raise ValueError('strategy_configmap_not_mapping')
+    strategy_name = _string(best_candidate.get('runtime_strategy_name'))
+    if not strategy_name:
+        raise ValueError('runtime_closure_missing_runtime_strategy_name')
+    candidate_params = _mapping(best_candidate.get('candidate_params'))
+    if not candidate_params:
+        raise ValueError('runtime_closure_missing_candidate_params')
+    rendered = apply_candidate_to_configmap_with_overrides(
+        configmap_payload=cast(Mapping[str, Any], configmap_payload),
+        strategy_name=strategy_name,
+        candidate_params=candidate_params,
+        strategy_overrides=_mapping(best_candidate.get('candidate_strategy_overrides')),
+        disable_other_strategies=bool(best_candidate.get('disable_other_strategies', True)),
+    )
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(yaml.safe_dump(rendered, sort_keys=False), encoding='utf-8')
+    return output_path
+
+
+def _default_replay_executor(config: replay_mod.ReplayConfig) -> dict[str, Any]:
+    return replay_mod.run_replay(config)
+
+
+def _run_runtime_replay(
+    *,
+    best_candidate: Mapping[str, Any],
+    manifest: MlxSnapshotManifest,
+    execution_context: RuntimeClosureExecutionContext,
+    strategy_configmap_path: Path,
+    window_name: str,
+    replay_executor: Any,
+) -> dict[str, Any]:
+    start_date, end_date = _window_bounds(best_candidate=best_candidate, window_name=window_name, manifest=manifest)
+    config = replay_mod.ReplayConfig(
+        strategy_configmap_path=strategy_configmap_path,
+        clickhouse_http_url=execution_context.clickhouse_http_url,
+        clickhouse_username=execution_context.clickhouse_username,
+        clickhouse_password=execution_context.clickhouse_password,
+        start_date=start_date,
+        end_date=end_date,
+        chunk_minutes=max(1, execution_context.chunk_minutes),
+        flatten_eod=True,
+        start_equity=execution_context.start_equity,
+        symbols=_candidate_symbols(best_candidate=best_candidate, execution_context=execution_context),
+        progress_log_interval_seconds=max(1, execution_context.progress_log_interval_seconds),
+    )
+    return cast(dict[str, Any], replay_executor(config))
+
+
+def _replay_analysis(
+    *,
+    window_name: str,
+    replay_payload: Mapping[str, Any],
+    best_candidate: Mapping[str, Any],
+    program: StrategyAutoresearchProgram,
+) -> dict[str, Any]:
+    summary = summarize_replay_profitability(replay_payload)
+    total_filled_notional = sum(_daily_filled_notional(replay_payload).values(), Decimal('0'))
+    positive_days = sum(1 for value in summary.daily_net.values() if value > 0)
+    negative_days = sum(1 for value in summary.daily_net.values() if value < 0)
+    family_template_id = _string(best_candidate.get('family_template_id'))
+    normalization_regime = _string(best_candidate.get('normalization_regime'))
+    decomposition_payload: dict[str, Any] | None = None
+    decomposition_error = ''
+    regime_pass_rate = Decimal('0')
+    symbol_concentration = Decimal('1')
+    family_contribution = Decimal('1')
+    try:
+        decomposition = build_replay_decomposition(
+            replay_payload=replay_payload,
+            family_id=family_template_id,
+            normalization_regime=normalization_regime or None,
+        )
+        decomposition_payload = decomposition.to_payload()
+        regime_pass_rate = regime_slice_pass_rate(decomposition)
+        symbol_concentration = max_symbol_concentration_share(decomposition)
+        family_contribution = max_family_contribution_share(decomposition)
+    except Exception as exc:
+        decomposition_error = str(exc)
+
+    scorecard = build_scorecard(
+        candidate_id=_string(best_candidate.get('candidate_id')),
+        trading_day_count=summary.trading_day_count,
+        net_pnl_per_day=summary.net_per_day,
+        active_days=summary.active_days,
+        positive_days=positive_days,
+        avg_filled_notional_per_day=(
+            total_filled_notional / Decimal(summary.trading_day_count)
+            if summary.trading_day_count > 0
+            else Decimal('0')
+        ),
+        avg_filled_notional_per_active_day=(
+            total_filled_notional / Decimal(summary.active_days)
+            if summary.active_days > 0
+            else Decimal('0')
+        ),
+        worst_day_loss=abs(summary.worst_day_net) if summary.worst_day_net < 0 else Decimal('0'),
+        max_drawdown=_max_drawdown_from_daily_net(summary.daily_net),
+        best_day_share=_max_best_day_share_of_total_pnl(
+            daily_net=summary.daily_net,
+            total_net_pnl=summary.net_pnl,
+        ),
+        negative_day_count=negative_days,
+        rolling_3d_lower_bound=_rolling_lower_bound(summary.daily_net, window=3),
+        rolling_5d_lower_bound=_rolling_lower_bound(summary.daily_net, window=5),
+        regime_slice_pass_rate=regime_pass_rate,
+        symbol_concentration_share=symbol_concentration,
+        entry_family_contribution_share=family_contribution,
+    )
+    hard_vetoes = list(
+        evaluate_vetoes(
+            scorecard,
+            policy=_objective_veto_policy(program),
+            is_fresh=True,
+        )
+    )
+    replay_candidate = {
+        'candidate_id': _string(best_candidate.get('candidate_id')),
+        'objective_scorecard': scorecard.to_payload(),
+        'full_window': {
+            'trading_day_count': summary.trading_day_count,
+            'active_days': summary.active_days,
+        },
+        'hard_vetoes': hard_vetoes,
+    }
+    objective_met = candidate_meets_objective(replay_candidate, objective=program.objective)
+    return {
+        'schema_version': 'torghut.runtime-closure-replay-report.v1',
+        'window_name': window_name,
+        'candidate_id': _string(best_candidate.get('candidate_id')),
+        'runtime_family': _string(best_candidate.get('runtime_family')),
+        'runtime_strategy_name': _string(best_candidate.get('runtime_strategy_name')),
+        'objective_met': objective_met,
+        'hard_vetoes': hard_vetoes,
+        'scorecard': scorecard.to_payload(),
+        'summary': {
+            'start_date': summary.start_date,
+            'end_date': summary.end_date,
+            'trading_day_count': summary.trading_day_count,
+            'net_pnl': str(summary.net_pnl),
+            'net_per_day': str(summary.net_per_day),
+            'active_days': summary.active_days,
+            'decision_count': summary.decision_count,
+            'filled_count': summary.filled_count,
+            'wins': summary.wins,
+            'losses': summary.losses,
+            'worst_day_net': str(summary.worst_day_net),
+            'profit_factor': str(summary.profit_factor) if summary.profit_factor is not None else None,
+            'positive_days': positive_days,
+            'negative_days': negative_days,
+            'daily_net': {day: str(value) for day, value in summary.daily_net.items()},
+            'daily_filled_notional': {
+                day: str(value) for day, value in _daily_filled_notional(replay_payload).items()
+            },
+        },
+        'decomposition': decomposition_payload,
+        'decomposition_error': decomposition_error or None,
+    }
+
+
+def _shadow_validation_plan(
+    *,
+    best_candidate: Mapping[str, Any],
+    program: StrategyAutoresearchProgram,
+) -> dict[str, Any]:
+    mode = program.runtime_closure_policy.shadow_validation_mode
+    pending = mode == 'require_live_evidence'
+    reasons = ['live_shadow_evidence_not_available_from_local_autoresearch'] if pending else []
+    return {
+        'schema_version': 'torghut.runtime-closure-shadow-validation-plan.v1',
+        'candidate_id': _string(best_candidate.get('candidate_id')),
+        'mode': mode,
+        'status': 'pending_live_evidence' if pending else 'skipped',
+        'required': pending,
+        'reasons': reasons,
+    }
+
 def _candidate_spec(
     *,
     runner_run_id: str,
@@ -134,6 +458,16 @@ def _candidate_spec(
         'status': _string(best_candidate.get('status')),
         'mutation_label': _string(best_candidate.get('mutation_label')),
         'parent_candidate_id': _string(best_candidate.get('parent_candidate_id')),
+        'candidate_params': _mapping(best_candidate.get('candidate_params')),
+        'candidate_strategy_overrides': _mapping(best_candidate.get('candidate_strategy_overrides')),
+        'disable_other_strategies': bool(best_candidate.get('disable_other_strategies', True)),
+        'train_start_date': _string(best_candidate.get('train_start_date')),
+        'train_end_date': _string(best_candidate.get('train_end_date')),
+        'holdout_start_date': _string(best_candidate.get('holdout_start_date')),
+        'holdout_end_date': _string(best_candidate.get('holdout_end_date')),
+        'full_window_start_date': _string(best_candidate.get('full_window_start_date')) or manifest.source_window_start,
+        'full_window_end_date': _string(best_candidate.get('full_window_end_date')) or manifest.source_window_end,
+        'normalization_regime': _string(best_candidate.get('normalization_regime')),
         'descriptor': {
             'descriptor_id': _string(best_candidate.get('descriptor_id')),
             'entry_window_start_minute': _int(best_candidate.get('entry_window_start_minute')),
@@ -185,6 +519,7 @@ def _candidate_generation_manifest(
         'proposal_selection_reason': _string(best_candidate.get('proposal_selection_reason')),
         'mutation_label': _string(best_candidate.get('mutation_label')),
         'status': _string(best_candidate.get('status')),
+        'runtime_closure_policy': program.runtime_closure_policy.to_payload(),
     }
 
 
@@ -192,19 +527,33 @@ def _gate_report(
     *,
     runner_run_id: str,
     best_candidate: Mapping[str, Any],
+    promotion_target: str,
+    parity_report: Mapping[str, Any] | None,
+    approval_report: Mapping[str, Any] | None,
+    shadow_plan: Mapping[str, Any],
 ) -> dict[str, Any]:
     runtime_family = _string(best_candidate.get('runtime_family')) or 'unknown'
-    active_day_ratio = _float(best_candidate.get('active_day_ratio'))
-    throughput_count = max(0, int(round(active_day_ratio * 10)))
-    promotion_reasons = [
-        'research_candidate_pending_scheduler_v3_parity',
-        'research_candidate_pending_scheduler_v3_approval',
-        'research_candidate_pending_shadow_validation',
-    ]
+    parity_pass = bool(_mapping(parity_report).get('objective_met')) if parity_report is not None else False
+    approval_pass = bool(_mapping(approval_report).get('objective_met')) if approval_report is not None else False
+    shadow_required = bool(shadow_plan.get('required'))
+    shadow_ready = _string(shadow_plan.get('status')) == 'within_budget'
+    promotion_reasons: list[str] = []
+    if parity_report is None:
+        promotion_reasons.append('research_candidate_pending_scheduler_v3_parity')
+    elif not parity_pass:
+        promotion_reasons.append('scheduler_v3_parity_failed')
+    if approval_report is None:
+        promotion_reasons.append('research_candidate_pending_scheduler_v3_approval')
+    elif not approval_pass:
+        promotion_reasons.append('scheduler_v3_approval_failed')
+    if shadow_required and not shadow_ready:
+        promotion_reasons.append('research_candidate_pending_shadow_validation')
+    throughput_source = approval_report if approval_report is not None else parity_report
+    throughput_summary = _mapping(_mapping(throughput_source).get('summary')) if throughput_source is not None else {}
     return {
         'run_id': runner_run_id,
         'promotion_allowed': False,
-        'recommended_mode': 'shadow',
+        'recommended_mode': promotion_target,
         'dependency_quorum': {
             'decision': 'allow',
             'reasons': [],
@@ -222,31 +571,37 @@ def _gate_report(
             'reasons': list(promotion_reasons),
         },
         'throughput': {
-            'signal_count': throughput_count,
-            'decision_count': throughput_count,
-            'trade_count': throughput_count,
-            'no_signal_window': active_day_ratio <= 0,
-            'no_signal_reason': (
-                'no_active_days_in_research_window'
-                if active_day_ratio <= 0
-                else None
-            ),
+            'signal_count': int(throughput_summary.get('decision_count') or 0),
+            'decision_count': int(throughput_summary.get('decision_count') or 0),
+            'trade_count': int(throughput_summary.get('filled_count') or 0),
+            'no_signal_window': int(throughput_summary.get('filled_count') or 0) <= 0,
+            'no_signal_reason': 'no_runtime_fills_in_closure_window' if int(throughput_summary.get('filled_count') or 0) <= 0 else None,
         },
         'gates': [
             {'gate_id': 'gate0_data_integrity', 'status': 'pass'},
-            {'gate_id': 'gate1_statistical_robustness', 'status': 'pass'},
-            {'gate_id': 'gate2_risk_capacity', 'status': 'pass'},
+            {
+                'gate_id': 'gate1_scheduler_v3_parity_replay',
+                'status': 'pass' if parity_pass else ('fail' if parity_report is not None else 'pending'),
+            },
+            {
+                'gate_id': 'gate2_scheduler_v3_approval_replay',
+                'status': 'pass' if approval_pass else ('fail' if approval_report is not None else 'pending'),
+            },
+            {
+                'gate_id': 'gate3_shadow_validation',
+                'status': 'pass' if shadow_ready else ('pending' if shadow_required else 'skip'),
+            },
         ],
         'promotion_evidence': {
             'promotion_rationale': {
-                'requested_target': 'shadow',
-                'gate_recommended_mode': 'shadow',
+                'requested_target': promotion_target,
+                'gate_recommended_mode': promotion_target,
                 'gate_reasons': list(promotion_reasons),
-                'rationale_text': 'Research candidate is mapped to runtime, but parity, approval replay, and shadow validation are still missing.',
+                'rationale_text': 'Runtime closure replays executed, but promotion stays blocked until parity, approval, and shadow requirements are satisfied.',
             }
         },
         'uncertainty_gate_action': 'abstain',
-        'coverage_error': '1.0',
+        'coverage_error': '0.0' if parity_pass and approval_pass else '1.0',
         'recalibration_run_id': None,
     }
 
@@ -256,12 +611,26 @@ def _candidate_state(
     runner_run_id: str,
     best_candidate: Mapping[str, Any],
     manifest: MlxSnapshotManifest,
+    parity_report: Mapping[str, Any] | None,
+    approval_report: Mapping[str, Any] | None,
+    shadow_plan: Mapping[str, Any],
 ) -> dict[str, Any]:
     dependency_quorum: dict[str, Any] = {
         'decision': 'allow',
         'reasons': [],
         'message': 'Local runtime-closure planning is allowed.',
     }
+    reasons: list[str] = []
+    if parity_report is None:
+        reasons.append('runtime_parity_not_completed')
+    elif not bool(_mapping(parity_report).get('objective_met')):
+        reasons.append('runtime_parity_failed')
+    if approval_report is None:
+        reasons.append('approval_replay_not_completed')
+    elif not bool(_mapping(approval_report).get('objective_met')):
+        reasons.append('approval_replay_failed')
+    if bool(shadow_plan.get('required')) and _string(shadow_plan.get('status')) != 'within_budget':
+        reasons.append('shadow_validation_pending')
     return {
         'candidateId': _string(best_candidate.get('candidate_id')),
         'runId': runner_run_id,
@@ -279,7 +648,7 @@ def _candidate_state(
             'matched_hypothesis_ids': [_string(best_candidate.get('family_template_id'))],
             'missing_strategy_families': [],
             'promotion_eligible': False,
-            'reasons': ['runtime_parity_not_completed'],
+            'reasons': reasons,
             'dependency_quorum': dependency_quorum,
         },
         'rollbackReadiness': {
@@ -298,28 +667,34 @@ def _backtest_summary(
     runner_run_id: str,
     best_candidate: Mapping[str, Any],
     manifest: MlxSnapshotManifest,
+    parity_report: Mapping[str, Any] | None,
+    approval_report: Mapping[str, Any] | None,
+    promotion_target: str,
 ) -> tuple[dict[str, Any], dict[str, Any]]:
     walkforward = {
-        'schema_version': 'torghut.walkforward-results.v1',
+        'schema_version': 'torghut.runtime-closure-walkforward-results.v1',
         'run_id': runner_run_id,
         'candidate_id': _string(best_candidate.get('candidate_id')),
         'dataset_snapshot_ref': manifest.snapshot_id,
         'status': 'research_only',
-        'metrics': {
-            'net_pnl_per_day': _string(best_candidate.get('net_pnl_per_day')),
-            'active_day_ratio': _string(best_candidate.get('active_day_ratio')),
-            'best_day_share': _string(best_candidate.get('best_day_share')),
-        },
+        'runtime_family': _string(best_candidate.get('runtime_family')),
+        'runtime_strategy_name': _string(best_candidate.get('runtime_strategy_name')),
+        'parity_replay': dict(parity_report or {}),
+        'approval_replay': dict(approval_report or {}),
     }
+    approval_metrics = _mapping(_mapping(approval_report).get('scorecard')) if approval_report is not None else {}
     evaluation = {
-        'report_version': 'torghut.evaluation-report.v1',
+        'report_version': 'torghut.runtime-closure-evaluation-report.v1',
         'generated_at': _now_iso(),
         'run_id': runner_run_id,
         'candidate_id': _string(best_candidate.get('candidate_id')),
-        'promotion_target': 'shadow',
-        'recommended_mode': 'shadow',
+        'promotion_target': promotion_target,
+        'recommended_mode': promotion_target,
         'promotion_allowed': False,
-        'metrics': walkforward['metrics'],
+        'objective_met': bool(_mapping(approval_report).get('objective_met')) if approval_report is not None else False,
+        'metrics': approval_metrics,
+        'parity_replay': dict(parity_report or {}),
+        'approval_replay': dict(approval_report or {}),
     }
     return walkforward, evaluation
 
@@ -335,6 +710,12 @@ def _profitability_stage_manifest(
     evaluation_report_path: Path,
     gate_report_path: Path,
     rollback_readiness_path: Path,
+    parity_replay_path: Path | None,
+    approval_replay_path: Path | None,
+    shadow_validation_path: Path | None,
+    parity_pass: bool,
+    approval_pass: bool,
+    shadow_pending: bool,
 ) -> dict[str, Any]:
     def _artifact(path: Path, *, stage: str, check: str) -> dict[str, Any]:
         return {
@@ -352,6 +733,12 @@ def _profitability_stage_manifest(
         str(gate_report_path.relative_to(root)): _sha256_path(gate_report_path),
         str(rollback_readiness_path.relative_to(root)): _sha256_path(rollback_readiness_path),
     }
+    if parity_replay_path is not None and parity_replay_path.exists():
+        artifact_hashes[str(parity_replay_path.relative_to(root))] = _sha256_path(parity_replay_path)
+    if approval_replay_path is not None and approval_replay_path.exists():
+        artifact_hashes[str(approval_replay_path.relative_to(root))] = _sha256_path(approval_replay_path)
+    if shadow_validation_path is not None and shadow_validation_path.exists():
+        artifact_hashes[str(shadow_validation_path.relative_to(root))] = _sha256_path(shadow_validation_path)
     payload = {
         'schema_version': 'profitability-stage-manifest-v1',
         'candidate_id': candidate_id,
@@ -390,12 +777,18 @@ def _profitability_stage_manifest(
                 'completed_at_utc': _now_iso(),
             },
             'validation': {
-                'status': 'fail',
+                'status': 'pass' if approval_replay_path is not None and approval_pass else 'fail',
                 'checks': [
                     {'check': 'evaluation_report_present', 'status': 'pass'},
-                    {'check': 'profitability_benchmark_present', 'status': 'fail'},
-                    {'check': 'profitability_evidence_present', 'status': 'fail'},
-                    {'check': 'profitability_validation_present', 'status': 'fail'},
+                    {
+                        'check': 'profitability_benchmark_present',
+                        'status': 'pass' if approval_replay_path is not None else 'fail',
+                    },
+                    {
+                        'check': 'profitability_evidence_present',
+                        'status': 'pass' if approval_replay_path is not None else 'fail',
+                    },
+                    {'check': 'profitability_validation_present', 'status': 'pass' if approval_pass else 'fail'},
                 ],
                 'artifacts': {
                     'evaluation_report': _artifact(
@@ -403,22 +796,55 @@ def _profitability_stage_manifest(
                         stage='validation',
                         check='evaluation_report_present',
                     ),
+                    **(
+                        {
+                            'approval_replay': _artifact(
+                                approval_replay_path,
+                                stage='validation',
+                                check='profitability_benchmark_present',
+                            )
+                        }
+                        if approval_replay_path is not None and approval_replay_path.exists()
+                        else {}
+                    ),
                 },
                 'owner': 'autoresearch-loop',
                 'completed_at_utc': _now_iso(),
             },
             'execution': {
-                'status': 'fail',
+                'status': 'pass' if parity_pass and approval_pass and not shadow_pending else 'fail',
                 'checks': [
                     {'check': 'gate_evaluation_present', 'status': 'pass'},
-                    {'check': 'gate_matrix_approval', 'status': 'fail'},
-                    {'check': 'drift_gate_approval', 'status': 'fail'},
+                    {'check': 'gate_matrix_approval', 'status': 'pass' if parity_pass and approval_pass else 'fail'},
+                    {'check': 'drift_gate_approval', 'status': 'pass' if not shadow_pending else 'fail'},
                 ],
                 'artifacts': {
                     'gate_evaluation': _artifact(
                         gate_report_path,
                         stage='execution',
                         check='gate_evaluation_present',
+                    ),
+                    **(
+                        {
+                            'parity_replay': _artifact(
+                                parity_replay_path,
+                                stage='execution',
+                                check='gate_matrix_approval',
+                            )
+                        }
+                        if parity_replay_path is not None and parity_replay_path.exists()
+                        else {}
+                    ),
+                    **(
+                        {
+                            'shadow_validation': _artifact(
+                                shadow_validation_path,
+                                stage='execution',
+                                check='drift_gate_approval',
+                            )
+                        }
+                        if shadow_validation_path is not None and shadow_validation_path.exists()
+                        else {}
                     ),
                 },
                 'owner': 'autoresearch-loop',
@@ -455,11 +881,15 @@ def _profitability_stage_manifest(
             },
         },
         'overall_status': 'fail',
-        'failure_reasons': [
-            'validation_stage_incomplete',
-            'execution_stage_incomplete',
-            'governance_stage_incomplete',
-        ],
+        'failure_reasons': list(
+            dict.fromkeys(
+                [
+                    *([] if approval_pass else ['validation_stage_incomplete']),
+                    *([] if parity_pass and approval_pass and not shadow_pending else ['execution_stage_incomplete']),
+                    'governance_stage_incomplete',
+                ]
+            )
+        ),
         'replay_contract': {
             'artifact_hashes': artifact_hashes,
             'contract_hash': _sha256_json({'artifact_hashes': artifact_hashes}),
@@ -479,7 +909,13 @@ class RuntimeClosureBundleSummary:
     root: str
     candidate_spec_path: str
     candidate_generation_manifest_path: str
+    candidate_configmap_path: str
     gate_report_path: str
+    parity_replay_path: str
+    parity_report_path: str
+    approval_replay_path: str
+    approval_report_path: str
+    shadow_validation_path: str
     candidate_state_path: str
     rollback_readiness_artifact_path: str
     rollback_readiness_evaluation_path: str
@@ -498,7 +934,13 @@ class RuntimeClosureBundleSummary:
             'root': self.root,
             'candidate_spec_path': self.candidate_spec_path,
             'candidate_generation_manifest_path': self.candidate_generation_manifest_path,
+            'candidate_configmap_path': self.candidate_configmap_path,
             'gate_report_path': self.gate_report_path,
+            'parity_replay_path': self.parity_replay_path,
+            'parity_report_path': self.parity_report_path,
+            'approval_replay_path': self.approval_replay_path,
+            'approval_report_path': self.approval_report_path,
+            'shadow_validation_path': self.shadow_validation_path,
             'candidate_state_path': self.candidate_state_path,
             'rollback_readiness_artifact_path': self.rollback_readiness_artifact_path,
             'rollback_readiness_evaluation_path': self.rollback_readiness_evaluation_path,
@@ -519,6 +961,8 @@ def write_runtime_closure_bundle(
     program: StrategyAutoresearchProgram,
     best_candidate: Mapping[str, Any] | None,
     manifest: MlxSnapshotManifest,
+    execution_context: RuntimeClosureExecutionContext | None = None,
+    replay_executor: Any | None = None,
 ) -> RuntimeClosureBundleSummary:
     closure_root = run_root / 'runtime-closure'
     if best_candidate is None:
@@ -528,7 +972,13 @@ def write_runtime_closure_bundle(
             root=str(closure_root),
             candidate_spec_path='',
             candidate_generation_manifest_path='',
+            candidate_configmap_path='',
             gate_report_path='',
+            parity_replay_path='',
+            parity_report_path='',
+            approval_replay_path='',
+            approval_report_path='',
+            shadow_validation_path='',
             candidate_state_path='',
             rollback_readiness_artifact_path='',
             rollback_readiness_evaluation_path='',
@@ -546,7 +996,13 @@ def write_runtime_closure_bundle(
     candidate_id = _string(best_candidate.get('candidate_id'))
     candidate_spec_path = closure_root / 'research' / 'candidate-spec.json'
     candidate_generation_manifest_path = closure_root / 'research' / 'candidate-generation-manifest.json'
+    candidate_configmap_path = closure_root / 'replay' / 'candidate-configmap.yaml'
     gate_report_path = closure_root / 'gates' / 'gate-evaluation.json'
+    parity_replay_path = closure_root / 'replay' / 'scheduler-v3-parity-replay.json'
+    parity_report_path = closure_root / 'replay' / 'scheduler-v3-parity-report.json'
+    approval_replay_path = closure_root / 'replay' / 'scheduler-v3-approval-replay.json'
+    approval_report_path = closure_root / 'replay' / 'scheduler-v3-approval-report.json'
+    shadow_validation_path = closure_root / 'replay' / 'shadow-validation-plan.json'
     candidate_state_path = closure_root / 'promotion' / 'candidate-state.json'
     rollback_readiness_artifact_path = closure_root / 'gates' / 'rollback-readiness.json'
     rollback_readiness_evaluation_path = closure_root / 'promotion' / 'rollback-readiness-evaluation.json'
@@ -569,55 +1025,11 @@ def write_runtime_closure_bundle(
         best_candidate=best_candidate,
         manifest=manifest,
     )
-    gate_report = _gate_report(runner_run_id=runner_run_id, best_candidate=best_candidate)
-    candidate_state = _candidate_state(
-        runner_run_id=runner_run_id,
-        best_candidate=best_candidate,
-        manifest=manifest,
-    )
     policy_payload = _runtime_closure_policy()
 
     _write_json(candidate_spec_path, candidate_spec)
     _write_json(candidate_generation_manifest_path, candidate_generation_manifest)
-    _write_json(gate_report_path, gate_report)
-    _write_json(candidate_state_path, candidate_state)
-
-    rollback_readiness_result = evaluate_rollback_readiness(
-        policy_payload=policy_payload,
-        candidate_state_payload=candidate_state,
-    )
-    _write_json(rollback_readiness_artifact_path, rollback_readiness_result.to_payload())
-    _write_json(rollback_readiness_evaluation_path, rollback_readiness_result.to_payload())
     _write_json(policy_path, policy_payload)
-
-    walkforward_results, evaluation_report = _backtest_summary(
-        runner_run_id=runner_run_id,
-        best_candidate=best_candidate,
-        manifest=manifest,
-    )
-    _write_json(walkforward_results_path, walkforward_results)
-    _write_json(evaluation_report_path, evaluation_report)
-    profitability_stage_manifest = _profitability_stage_manifest(
-        root=closure_root,
-        runner_run_id=runner_run_id,
-        candidate_id=candidate_id,
-        candidate_spec_path=candidate_spec_path,
-        candidate_generation_manifest_path=candidate_generation_manifest_path,
-        walkforward_results_path=walkforward_results_path,
-        evaluation_report_path=evaluation_report_path,
-        gate_report_path=gate_report_path,
-        rollback_readiness_path=rollback_readiness_artifact_path,
-    )
-    _write_json(profitability_stage_manifest_path, profitability_stage_manifest)
-
-    promotion_prerequisites_result = evaluate_promotion_prerequisites(
-        policy_payload=policy_payload,
-        gate_report_payload=gate_report,
-        candidate_state_payload=candidate_state,
-        promotion_target='shadow',
-        artifact_root=closure_root,
-    )
-    _write_json(promotion_prerequisites_path, promotion_prerequisites_result.to_payload())
 
     replay_plan = {
         'schema_version': 'torghut.runtime-closure-replay-plan.v1',
@@ -634,6 +1046,8 @@ def write_runtime_closure_bundle(
             'scheduler_v3_approval_replay',
             'live_shadow_validation',
         ],
+        'runtime_closure_policy': program.runtime_closure_policy.to_payload(),
+        'execution_context': execution_context.to_payload() if execution_context is not None else None,
         'recommended_commands': [
             'run scheduler-v3 parity replay for the mapped runtime family on the snapshot window',
             'run scheduler-v3 approval replay on the same candidate family and snapshot contract',
@@ -642,13 +1056,138 @@ def write_runtime_closure_bundle(
     }
     _write_json(replay_plan_path, replay_plan)
 
+    parity_report: dict[str, Any] | None = None
+    approval_report: dict[str, Any] | None = None
+    summary_status = 'pending_runtime_parity'
+    if program.runtime_closure_policy.enabled and execution_context is not None:
+        replay_runner = replay_executor or _default_replay_executor
+        rendered_configmap_path = _materialize_candidate_configmap(
+            best_candidate=best_candidate,
+            execution_context=execution_context,
+            output_path=candidate_configmap_path,
+        )
+        if program.runtime_closure_policy.execute_parity_replay:
+            parity_payload = _run_runtime_replay(
+                best_candidate=best_candidate,
+                manifest=manifest,
+                execution_context=execution_context,
+                strategy_configmap_path=rendered_configmap_path,
+                window_name=program.runtime_closure_policy.parity_window,
+                replay_executor=replay_runner,
+            )
+            _write_json(parity_replay_path, parity_payload)
+            parity_report = _replay_analysis(
+                window_name=program.runtime_closure_policy.parity_window,
+                replay_payload=parity_payload,
+                best_candidate=best_candidate,
+                program=program,
+            )
+            _write_json(parity_report_path, parity_report)
+        if program.runtime_closure_policy.execute_approval_replay:
+            approval_payload = _run_runtime_replay(
+                best_candidate=best_candidate,
+                manifest=manifest,
+                execution_context=execution_context,
+                strategy_configmap_path=rendered_configmap_path,
+                window_name=program.runtime_closure_policy.approval_window,
+                replay_executor=replay_runner,
+            )
+            _write_json(approval_replay_path, approval_payload)
+            approval_report = _replay_analysis(
+                window_name=program.runtime_closure_policy.approval_window,
+                replay_payload=approval_payload,
+                best_candidate=best_candidate,
+                program=program,
+            )
+            _write_json(approval_report_path, approval_report)
+        summary_status = 'pending_shadow_validation'
+
+    shadow_plan = _shadow_validation_plan(best_candidate=best_candidate, program=program)
+    _write_json(shadow_validation_path, shadow_plan)
+    gate_report = _gate_report(
+        runner_run_id=runner_run_id,
+        best_candidate=best_candidate,
+        promotion_target=program.runtime_closure_policy.promotion_target,
+        parity_report=parity_report,
+        approval_report=approval_report,
+        shadow_plan=shadow_plan,
+    )
+    _write_json(gate_report_path, gate_report)
+    candidate_state = _candidate_state(
+        runner_run_id=runner_run_id,
+        best_candidate=best_candidate,
+        manifest=manifest,
+        parity_report=parity_report,
+        approval_report=approval_report,
+        shadow_plan=shadow_plan,
+    )
+    _write_json(candidate_state_path, candidate_state)
+
+    rollback_readiness_result = evaluate_rollback_readiness(
+        policy_payload=policy_payload,
+        candidate_state_payload=candidate_state,
+    )
+    _write_json(rollback_readiness_artifact_path, rollback_readiness_result.to_payload())
+    _write_json(rollback_readiness_evaluation_path, rollback_readiness_result.to_payload())
+
+    walkforward_results, evaluation_report = _backtest_summary(
+        runner_run_id=runner_run_id,
+        best_candidate=best_candidate,
+        manifest=manifest,
+        parity_report=parity_report,
+        approval_report=approval_report,
+        promotion_target=program.runtime_closure_policy.promotion_target,
+    )
+    _write_json(walkforward_results_path, walkforward_results)
+    _write_json(evaluation_report_path, evaluation_report)
+    profitability_stage_manifest = _profitability_stage_manifest(
+        root=closure_root,
+        runner_run_id=runner_run_id,
+        candidate_id=candidate_id,
+        candidate_spec_path=candidate_spec_path,
+        candidate_generation_manifest_path=candidate_generation_manifest_path,
+        walkforward_results_path=walkforward_results_path,
+        evaluation_report_path=evaluation_report_path,
+        gate_report_path=gate_report_path,
+        rollback_readiness_path=rollback_readiness_artifact_path,
+        parity_replay_path=parity_replay_path if parity_replay_path.exists() else None,
+        approval_replay_path=approval_replay_path if approval_replay_path.exists() else None,
+        shadow_validation_path=shadow_validation_path if shadow_validation_path.exists() else None,
+        parity_pass=bool(_mapping(parity_report).get('objective_met')) if parity_report is not None else False,
+        approval_pass=bool(_mapping(approval_report).get('objective_met')) if approval_report is not None else False,
+        shadow_pending=bool(shadow_plan.get('required')),
+    )
+    _write_json(profitability_stage_manifest_path, profitability_stage_manifest)
+
+    promotion_prerequisites_result = evaluate_promotion_prerequisites(
+        policy_payload=policy_payload,
+        gate_report_payload=gate_report,
+        candidate_state_payload=candidate_state,
+        promotion_target=program.runtime_closure_policy.promotion_target,
+        artifact_root=closure_root,
+    )
+    _write_json(promotion_prerequisites_path, promotion_prerequisites_result.to_payload())
+
+    if parity_report is not None and not bool(_mapping(parity_report).get('objective_met')):
+        summary_status = 'runtime_parity_failed'
+    elif approval_report is not None and not bool(_mapping(approval_report).get('objective_met')):
+        summary_status = 'approval_replay_failed'
+    elif not program.runtime_closure_policy.enabled:
+        summary_status = 'pending_runtime_parity'
+
     summary = RuntimeClosureBundleSummary(
-        status='pending_runtime_parity',
+        status=summary_status,
         candidate_id=candidate_id,
         root=str(closure_root),
         candidate_spec_path=str(candidate_spec_path),
         candidate_generation_manifest_path=str(candidate_generation_manifest_path),
+        candidate_configmap_path=str(candidate_configmap_path) if candidate_configmap_path.exists() else '',
         gate_report_path=str(gate_report_path),
+        parity_replay_path=str(parity_replay_path) if parity_replay_path.exists() else '',
+        parity_report_path=str(parity_report_path) if parity_report_path.exists() else '',
+        approval_replay_path=str(approval_replay_path) if approval_replay_path.exists() else '',
+        approval_report_path=str(approval_report_path) if approval_report_path.exists() else '',
+        shadow_validation_path=str(shadow_validation_path),
         candidate_state_path=str(candidate_state_path),
         rollback_readiness_artifact_path=str(rollback_readiness_artifact_path),
         rollback_readiness_evaluation_path=str(rollback_readiness_evaluation_path),
@@ -657,6 +1196,11 @@ def write_runtime_closure_bundle(
         promotion_prerequisites_path=str(promotion_prerequisites_path),
         replay_plan_path=str(replay_plan_path),
         next_required_steps=(
+            'live_shadow_validation',
+            'promotion_review',
+        )
+        if summary_status == 'pending_shadow_validation'
+        else (
             'checked_in_runtime_family',
             'scheduler_v3_parity_replay',
             'scheduler_v3_approval_replay',

--- a/services/torghut/app/trading/discovery/runtime_closure.py
+++ b/services/torghut/app/trading/discovery/runtime_closure.py
@@ -435,6 +435,43 @@ def _shadow_validation_plan(
         'reasons': reasons,
     }
 
+
+def _summary_status_and_next_steps(
+    *,
+    parity_report: Mapping[str, Any] | None,
+    approval_report: Mapping[str, Any] | None,
+    shadow_plan: Mapping[str, Any],
+) -> tuple[str, tuple[str, ...]]:
+    parity_pass = bool(_mapping(parity_report).get('objective_met')) if parity_report is not None else False
+    approval_pass = bool(_mapping(approval_report).get('objective_met')) if approval_report is not None else False
+    shadow_required = bool(shadow_plan.get('required'))
+    shadow_ready = _string(shadow_plan.get('status')) == 'within_budget'
+
+    if parity_report is None:
+        return (
+            'pending_runtime_parity',
+            (
+                'scheduler_v3_parity_replay',
+                'scheduler_v3_approval_replay',
+                *(() if not shadow_required else ('live_shadow_validation',)),
+            ),
+        )
+    if not parity_pass:
+        return ('runtime_parity_failed', ('scheduler_v3_parity_replay',))
+    if approval_report is None:
+        return (
+            'pending_approval_replay',
+            (
+                'scheduler_v3_approval_replay',
+                *(() if not shadow_required else ('live_shadow_validation',)),
+            ),
+        )
+    if not approval_pass:
+        return ('approval_replay_failed', ('scheduler_v3_approval_replay',))
+    if shadow_required and not shadow_ready:
+        return ('pending_shadow_validation', ('live_shadow_validation', 'promotion_review'))
+    return ('ready_for_promotion_review', ('promotion_review',))
+
 def _candidate_spec(
     *,
     runner_run_id: str,
@@ -1058,7 +1095,6 @@ def write_runtime_closure_bundle(
 
     parity_report: dict[str, Any] | None = None
     approval_report: dict[str, Any] | None = None
-    summary_status = 'pending_runtime_parity'
     if program.runtime_closure_policy.enabled and execution_context is not None:
         replay_runner = replay_executor or _default_replay_executor
         rendered_configmap_path = _materialize_candidate_configmap(
@@ -1100,7 +1136,6 @@ def write_runtime_closure_bundle(
                 program=program,
             )
             _write_json(approval_report_path, approval_report)
-        summary_status = 'pending_shadow_validation'
 
     shadow_plan = _shadow_validation_plan(best_candidate=best_candidate, program=program)
     _write_json(shadow_validation_path, shadow_plan)
@@ -1168,12 +1203,11 @@ def write_runtime_closure_bundle(
     )
     _write_json(promotion_prerequisites_path, promotion_prerequisites_result.to_payload())
 
-    if parity_report is not None and not bool(_mapping(parity_report).get('objective_met')):
-        summary_status = 'runtime_parity_failed'
-    elif approval_report is not None and not bool(_mapping(approval_report).get('objective_met')):
-        summary_status = 'approval_replay_failed'
-    elif not program.runtime_closure_policy.enabled:
-        summary_status = 'pending_runtime_parity'
+    summary_status, next_required_steps = _summary_status_and_next_steps(
+        parity_report=parity_report,
+        approval_report=approval_report,
+        shadow_plan=shadow_plan,
+    )
 
     summary = RuntimeClosureBundleSummary(
         status=summary_status,
@@ -1195,17 +1229,7 @@ def write_runtime_closure_bundle(
         profitability_stage_manifest_path=str(profitability_stage_manifest_path),
         promotion_prerequisites_path=str(promotion_prerequisites_path),
         replay_plan_path=str(replay_plan_path),
-        next_required_steps=(
-            'live_shadow_validation',
-            'promotion_review',
-        )
-        if summary_status == 'pending_shadow_validation'
-        else (
-            'checked_in_runtime_family',
-            'scheduler_v3_parity_replay',
-            'scheduler_v3_approval_replay',
-            'live_shadow_validation',
-        ),
+        next_required_steps=next_required_steps,
         promotion_prerequisites=promotion_prerequisites_result.to_payload(),
         rollback_readiness=rollback_readiness_result.to_payload(),
     )

--- a/services/torghut/config/trading/research-programs/strict-daily-profit-autoresearch-v1.yaml
+++ b/services/torghut/config/trading/research-programs/strict-daily-profit-autoresearch-v1.yaml
@@ -24,6 +24,14 @@ proposal_model_policy:
 replay_budget:
   max_candidates_per_round: 8
   exploration_slots: 1
+runtime_closure_policy:
+  enabled: true
+  execute_parity_replay: true
+  execute_approval_replay: true
+  parity_window: full_window
+  approval_window: holdout
+  shadow_validation_mode: require_live_evidence
+  promotion_target: shadow
 parity_requirements:
   - checked_in_runtime_family
   - scheduler_v3_parity_replay

--- a/services/torghut/scripts/run_strategy_autoresearch_loop.py
+++ b/services/torghut/scripts/run_strategy_autoresearch_loop.py
@@ -52,6 +52,7 @@ from app.trading.discovery.promotion_contract import (
     summary_promotion_readiness,
 )
 from app.trading.discovery.runtime_closure import write_runtime_closure_bundle
+from app.trading.discovery.runtime_closure import RuntimeClosureExecutionContext
 import scripts.local_intraday_tsmom_replay as replay_mod
 from scripts.search_consistent_profitability_frontier import run_consistent_profitability_frontier
 
@@ -300,10 +301,12 @@ def _history_record(
     proposal_score: ProposalScore | None = None,
     proposal_selected: bool = False,
     proposal_selection_reason: str = '',
+    disable_other_strategies: bool = True,
 ) -> dict[str, Any]:
     full_window = _mapping(candidate_payload.get('full_window'))
     scorecard = _mapping(candidate_payload.get('objective_scorecard'))
     ranking = _mapping(candidate_payload.get('ranking'))
+    replay_config = _mapping(candidate_payload.get('replay_config'))
     promotion_readiness = _promotion_readiness_payload(family_plan=family_plan)
     return {
         'runner_run_id': runner_run_id,
@@ -319,6 +322,16 @@ def _history_record(
         'dataset_snapshot_id': dataset_snapshot_id,
         'sweep_config_path': str(sweep_config_path),
         'result_path': str(result_path),
+        'candidate_params': _mapping(replay_config.get('params')),
+        'candidate_strategy_overrides': _mapping(replay_config.get('strategy_overrides')),
+        'disable_other_strategies': disable_other_strategies,
+        'train_start_date': _string(replay_config.get('train_start_date')),
+        'train_end_date': _string(replay_config.get('train_end_date')),
+        'holdout_start_date': _string(replay_config.get('holdout_start_date')),
+        'holdout_end_date': _string(replay_config.get('holdout_end_date')),
+        'full_window_start_date': _string(replay_config.get('full_window_start_date')),
+        'full_window_end_date': _string(replay_config.get('full_window_end_date')),
+        'normalization_regime': _string(candidate_payload.get('normalization_regime')),
         'net_pnl_per_day': _string(scorecard.get('net_pnl_per_day') or full_window.get('net_per_day')),
         'active_day_ratio': _string(scorecard.get('active_day_ratio')),
         'positive_day_ratio': _string(scorecard.get('positive_day_ratio')),
@@ -481,6 +494,7 @@ def _persist_run_outputs(
     descriptors: list[MlxCandidateDescriptor],
     proposal_scores: list[ProposalScore],
     status: str,
+    closure_execution_context: RuntimeClosureExecutionContext | None = None,
     error: Mapping[str, str] | None = None,
 ) -> dict[str, Any]:
     history_path = run_root / 'history.jsonl'
@@ -534,6 +548,7 @@ def _persist_run_outputs(
         program=program,
         best_candidate=best_candidate,
         manifest=manifest,
+        execution_context=closure_execution_context,
     )
     summary['runtime_closure'] = runtime_closure.to_payload()
     if error is not None:
@@ -589,6 +604,16 @@ def run_strategy_autoresearch_loop(args: argparse.Namespace) -> dict[str, Any]:
     resolved_full_window_start_date = _string(args.full_window_start_date)
     resolved_full_window_end_date = _string(args.full_window_end_date)
     signal_bundle_stats: MlxSignalBundleStats | None = None
+    closure_execution_context = RuntimeClosureExecutionContext(
+        strategy_configmap_path=args.strategy_configmap.resolve(),
+        clickhouse_http_url=str(args.clickhouse_http_url),
+        clickhouse_username=(_string(args.clickhouse_username) or None),
+        clickhouse_password=(_string(args.clickhouse_password) or None),
+        start_equity=Decimal(str(args.start_equity)),
+        chunk_minutes=max(1, int(args.chunk_minutes)),
+        symbols=snapshot_symbols,
+        progress_log_interval_seconds=max(1, int(args.progress_log_seconds)),
+    )
 
     def _refresh_manifest() -> MlxSnapshotManifest:
         latest_receipt = tape_freshness_receipts[-1] if tape_freshness_receipts else {}
@@ -628,6 +653,7 @@ def run_strategy_autoresearch_loop(args: argparse.Namespace) -> dict[str, Any]:
         descriptors=descriptors,
         proposal_scores=proposal_scores,
         status='running',
+        closure_execution_context=closure_execution_context,
     )
     signal_bundle_stats = _maybe_write_signal_bundle(
         args=args,
@@ -822,6 +848,7 @@ def run_strategy_autoresearch_loop(args: argparse.Namespace) -> dict[str, Any]:
                         proposal_score=frontier_score_by_candidate.get(candidate_id),
                         proposal_selected=candidate_id in keep_ids,
                         proposal_selection_reason=keep_reason_by_candidate.get(candidate_id, ''),
+                        disable_other_strategies=bool(current.sweep_config.get('disable_other_strategies', True)),
                     )
                 )
                 if candidate_objective_met:
@@ -864,6 +891,7 @@ def run_strategy_autoresearch_loop(args: argparse.Namespace) -> dict[str, Any]:
                 descriptors=descriptors,
                 proposal_scores=proposal_scores,
                 status='running',
+                closure_execution_context=closure_execution_context,
             )
             if objective_met and program.objective.stop_when_objective_met:
                 break
@@ -881,6 +909,7 @@ def run_strategy_autoresearch_loop(args: argparse.Namespace) -> dict[str, Any]:
             descriptors=descriptors,
             proposal_scores=proposal_scores,
             status='error',
+            closure_execution_context=closure_execution_context,
             error={
                 'type': exc.__class__.__name__,
                 'message': str(exc),
@@ -900,6 +929,7 @@ def run_strategy_autoresearch_loop(args: argparse.Namespace) -> dict[str, Any]:
         descriptors=descriptors,
         proposal_scores=proposal_scores,
         status='ok',
+        closure_execution_context=closure_execution_context,
     )
 
 

--- a/services/torghut/tests/test_mlx_autoresearch.py
+++ b/services/torghut/tests/test_mlx_autoresearch.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from argparse import Namespace
 from datetime import UTC, datetime
+from decimal import Decimal
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest import TestCase
@@ -10,6 +11,7 @@ from unittest.mock import patch
 from app.trading.discovery.autoresearch import (
     ProposalModelPolicy,
     ReplayBudget,
+    RuntimeClosurePolicy,
     SnapshotPolicy,
     StrategyAutoresearchProgram,
     StrategyObjective,
@@ -63,15 +65,15 @@ def _program() -> StrategyAutoresearchProgram:
         program_id='program-1',
         description='desc',
         objective=StrategyObjective(
-            target_net_pnl_per_day='500',  # type: ignore[arg-type]
-            min_active_day_ratio='1.0',  # type: ignore[arg-type]
-            min_positive_day_ratio='0.6',  # type: ignore[arg-type]
-            min_daily_notional='300000',  # type: ignore[arg-type]
-            max_best_day_share='0.3',  # type: ignore[arg-type]
-            max_worst_day_loss='350',  # type: ignore[arg-type]
-            max_drawdown='900',  # type: ignore[arg-type]
+            target_net_pnl_per_day=Decimal('500'),
+            min_active_day_ratio=Decimal('1.0'),
+            min_positive_day_ratio=Decimal('0.6'),
+            min_daily_notional=Decimal('300000'),
+            max_best_day_share=Decimal('0.3'),
+            max_worst_day_loss=Decimal('350'),
+            max_drawdown=Decimal('900'),
             require_every_day_active=True,
-            min_regime_slice_pass_rate='0.45',  # type: ignore[arg-type]
+            min_regime_slice_pass_rate=Decimal('0.45'),
             stop_when_objective_met=True,
         ),
         snapshot_policy=SnapshotPolicy(
@@ -92,6 +94,15 @@ def _program() -> StrategyAutoresearchProgram:
             minimum_history_rows=1,
         ),
         replay_budget=ReplayBudget(max_candidates_per_round=8, exploration_slots=1),
+        runtime_closure_policy=RuntimeClosurePolicy(
+            enabled=False,
+            execute_parity_replay=True,
+            execute_approval_replay=True,
+            parity_window='full_window',
+            approval_window='holdout',
+            shadow_validation_mode='require_live_evidence',
+            promotion_target='shadow',
+        ),
         parity_requirements=('scheduler_v3_parity_replay',),
         promotion_policy='research_only',
         ledger_policy={'append_only': True},

--- a/services/torghut/tests/test_runtime_closure.py
+++ b/services/torghut/tests/test_runtime_closure.py
@@ -6,7 +6,9 @@ from decimal import Decimal
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest import TestCase
+from unittest.mock import patch
 
+import app.trading.discovery.runtime_closure as runtime_closure
 from app.trading.discovery.autoresearch import (
     ProposalModelPolicy,
     ReplayBudget,
@@ -76,6 +78,178 @@ def _program() -> StrategyAutoresearchProgram:
 
 
 class TestRuntimeClosure(TestCase):
+    def test_runtime_closure_helper_branches_cover_edge_cases(self) -> None:
+        manifest = build_mlx_snapshot_manifest(
+            runner_run_id='run-1',
+            program=_program(),
+            symbols='AMAT,NVDA',
+            train_days=6,
+            holdout_days=2,
+            full_window_start_date='2026-03-20',
+            full_window_end_date='2026-04-09',
+        )
+        context = RuntimeClosureExecutionContext(
+            strategy_configmap_path=Path('/tmp/unused.yaml'),
+            clickhouse_http_url='http://example.invalid:8123',
+            clickhouse_username='torghut',
+            clickhouse_password='secret',
+            start_equity=Decimal('31590.02'),
+            chunk_minutes=10,
+            symbols=('AMAT', 'NVDA'),
+        )
+
+        self.assertEqual(
+            runtime_closure._max_drawdown_from_daily_net(
+                {'2026-03-20': Decimal('5'), '2026-03-21': Decimal('-10')}
+            ),
+            Decimal('10'),
+        )
+        self.assertEqual(runtime_closure._rolling_lower_bound({}, window=3), Decimal('0'))
+        self.assertEqual(
+            runtime_closure._rolling_lower_bound(
+                {'2026-03-20': Decimal('2'), '2026-03-21': Decimal('4')},
+                window=3,
+            ),
+            Decimal('3'),
+        )
+        self.assertEqual(
+            runtime_closure._max_best_day_share_of_total_pnl(
+                daily_net={'2026-03-20': Decimal('-1')},
+                total_net_pnl=Decimal('0'),
+            ),
+            Decimal('1'),
+        )
+        self.assertEqual(
+            runtime_closure._max_best_day_share_of_total_pnl(
+                daily_net={'2026-03-20': Decimal('-1')},
+                total_net_pnl=Decimal('10'),
+            ),
+            Decimal('0'),
+        )
+        self.assertEqual(
+            runtime_closure._candidate_symbols(
+                best_candidate={'candidate_strategy_overrides': {}},
+                execution_context=context,
+            ),
+            ('AMAT', 'NVDA'),
+        )
+        self.assertEqual(
+            runtime_closure._window_bounds(
+                best_candidate={},
+                window_name='full_window',
+                manifest=manifest,
+            ),
+            (runtime_closure._date_from_iso('2026-03-20'), runtime_closure._date_from_iso('2026-04-09')),
+        )
+        with self.assertRaisesRegex(ValueError, 'runtime_closure_window_missing:holdout'):
+            runtime_closure._window_bounds(
+                best_candidate={},
+                window_name='holdout',
+                manifest=manifest,
+            )
+        config = object()
+        with patch.object(runtime_closure.replay_mod, 'run_replay', return_value={'status': 'ok'}) as mock_run:
+            payload = runtime_closure._default_replay_executor(config)
+        self.assertEqual(payload, {'status': 'ok'})
+        mock_run.assert_called_once_with(config)  # type: ignore[arg-type]
+
+    def test_materialize_candidate_configmap_rejects_invalid_inputs(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            invalid_configmap_path = root / 'invalid.yaml'
+            invalid_configmap_path.write_text('- not-a-mapping\n', encoding='utf-8')
+            context = RuntimeClosureExecutionContext(
+                strategy_configmap_path=invalid_configmap_path,
+                clickhouse_http_url='http://example.invalid:8123',
+                clickhouse_username='torghut',
+                clickhouse_password='secret',
+                start_equity=Decimal('31590.02'),
+                chunk_minutes=10,
+            )
+            with self.assertRaisesRegex(ValueError, 'strategy_configmap_not_mapping'):
+                runtime_closure._materialize_candidate_configmap(
+                    best_candidate={},
+                    execution_context=context,
+                    output_path=root / 'out.yaml',
+                )
+
+            valid_configmap_path = root / 'valid.yaml'
+            valid_configmap_path.write_text(
+                """
+apiVersion: v1
+kind: ConfigMap
+data:
+  strategies.yaml: |
+    strategies:
+      - name: breakout-continuation-long-v1
+        enabled: true
+        family: breakout_continuation_consistent
+        params:
+          max_entries_per_session: '1'
+""".strip()
+                + '\n',
+                encoding='utf-8',
+            )
+            valid_context = RuntimeClosureExecutionContext(
+                strategy_configmap_path=valid_configmap_path,
+                clickhouse_http_url='http://example.invalid:8123',
+                clickhouse_username='torghut',
+                clickhouse_password='secret',
+                start_equity=Decimal('31590.02'),
+                chunk_minutes=10,
+            )
+            with self.assertRaisesRegex(ValueError, 'runtime_closure_missing_runtime_strategy_name'):
+                runtime_closure._materialize_candidate_configmap(
+                    best_candidate={'candidate_params': {'max_entries_per_session': '1'}},
+                    execution_context=valid_context,
+                    output_path=root / 'missing-name.yaml',
+                )
+            with self.assertRaisesRegex(ValueError, 'runtime_closure_missing_candidate_params'):
+                runtime_closure._materialize_candidate_configmap(
+                    best_candidate={'runtime_strategy_name': 'breakout-continuation-long-v1'},
+                    execution_context=valid_context,
+                    output_path=root / 'missing-params.yaml',
+                )
+
+    def test_replay_analysis_records_decomposition_errors(self) -> None:
+        replay_payload = {
+            'start_date': '2026-03-20',
+            'end_date': '2026-04-09',
+            'net_pnl': '6000',
+            'decision_count': 12,
+            'filled_count': 9,
+            'wins': 7,
+            'losses': 2,
+            'daily': {
+                '2026-03-20': {'net_pnl': '1000', 'filled_count': 1, 'filled_notional': '300000'},
+                '2026-03-21': {'net_pnl': '800', 'filled_count': 1, 'filled_notional': '300000'},
+                '2026-03-24': {'net_pnl': '700', 'filled_count': 1, 'filled_notional': '300000'},
+                '2026-03-25': {'net_pnl': '900', 'filled_count': 1, 'filled_notional': '300000'},
+                '2026-03-26': {'net_pnl': '1100', 'filled_count': 1, 'filled_notional': '300000'},
+                '2026-03-27': {'net_pnl': '600', 'filled_count': 1, 'filled_notional': '300000'},
+                '2026-04-08': {'net_pnl': '500', 'filled_count': 1, 'filled_notional': '300000'},
+                '2026-04-09': {'net_pnl': '400', 'filled_count': 1, 'filled_notional': '300000'},
+            },
+        }
+        best_candidate = {
+            'candidate_id': 'cand-1',
+            'family_template_id': 'breakout_reclaim_v2',
+            'runtime_family': 'breakout_continuation_consistent',
+            'runtime_strategy_name': 'breakout-continuation-long-v1',
+            'normalization_regime': 'price_scaled',
+        }
+
+        with patch.object(runtime_closure, 'build_replay_decomposition', side_effect=RuntimeError('boom')):
+            analysis = runtime_closure._replay_analysis(
+                window_name='full_window',
+                replay_payload=replay_payload,
+                best_candidate=best_candidate,
+                program=_program(),
+            )
+
+        self.assertEqual(analysis['decomposition_error'], 'boom')
+        self.assertIsNone(analysis['decomposition'])
+
     def test_write_runtime_closure_bundle_emits_fail_closed_governance_artifacts(self) -> None:
         with TemporaryDirectory() as tmpdir:
             run_root = Path(tmpdir)

--- a/services/torghut/tests/test_runtime_closure.py
+++ b/services/torghut/tests/test_runtime_closure.py
@@ -326,6 +326,203 @@ data:
             self.assertTrue(parity_report['objective_met'])
             self.assertEqual(parity_report['window_name'], 'full_window')
 
+    def test_write_runtime_closure_bundle_keeps_pending_parity_when_execution_skipped(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            run_root = Path(tmpdir)
+            manifest = build_mlx_snapshot_manifest(
+                runner_run_id='run-1',
+                program=_program(),
+                symbols='AMAT,NVDA',
+                train_days=6,
+                holdout_days=2,
+                full_window_start_date='2026-03-20',
+                full_window_end_date='2026-04-09',
+            )
+            configmap_path = run_root / 'strategy-configmap.yaml'
+            configmap_path.write_text(
+                """
+apiVersion: v1
+kind: ConfigMap
+data:
+  strategies.yaml: |
+    strategies:
+      - name: breakout-continuation-long-v1
+        enabled: true
+        family: breakout_continuation_consistent
+        params:
+          max_entries_per_session: '1'
+""".strip()
+                + "\n",
+                encoding='utf-8',
+            )
+            program = StrategyAutoresearchProgram(
+                **{
+                    **_program().__dict__,
+                    'runtime_closure_policy': RuntimeClosurePolicy(
+                        enabled=True,
+                        execute_parity_replay=False,
+                        execute_approval_replay=False,
+                        parity_window='full_window',
+                        approval_window='holdout',
+                        shadow_validation_mode='skip',
+                        promotion_target='shadow',
+                    ),
+                }
+            )
+            best_candidate = {
+                'candidate_id': 'cand-1',
+                'family_template_id': 'breakout_reclaim_v2',
+                'runtime_family': 'breakout_continuation_consistent',
+                'runtime_strategy_name': 'breakout-continuation-long-v1',
+                'status': 'keep',
+                'candidate_params': {'max_entries_per_session': '1'},
+                'candidate_strategy_overrides': {},
+                'disable_other_strategies': True,
+                'full_window_start_date': '2026-03-20',
+                'full_window_end_date': '2026-04-09',
+            }
+
+            summary = write_runtime_closure_bundle(
+                run_root=run_root,
+                runner_run_id='run-1',
+                program=program,
+                best_candidate=best_candidate,
+                manifest=manifest,
+                execution_context=RuntimeClosureExecutionContext(
+                    strategy_configmap_path=configmap_path,
+                    clickhouse_http_url='http://example.invalid:8123',
+                    clickhouse_username='torghut',
+                    clickhouse_password='secret',
+                    start_equity=Decimal('31590.02'),
+                    chunk_minutes=10,
+                ),
+            )
+
+            self.assertEqual(summary.status, 'pending_runtime_parity')
+            self.assertEqual(
+                summary.next_required_steps,
+                ('scheduler_v3_parity_replay', 'scheduler_v3_approval_replay'),
+            )
+            self.assertEqual(summary.shadow_validation_path, str(run_root / 'runtime-closure' / 'replay' / 'shadow-validation-plan.json'))
+
+    def test_write_runtime_closure_bundle_skips_shadow_status_when_shadow_not_required(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            run_root = Path(tmpdir)
+            manifest = build_mlx_snapshot_manifest(
+                runner_run_id='run-1',
+                program=_program(),
+                symbols='AMAT,NVDA',
+                train_days=6,
+                holdout_days=2,
+                full_window_start_date='2026-03-20',
+                full_window_end_date='2026-04-09',
+            )
+            configmap_path = run_root / 'strategy-configmap.yaml'
+            configmap_path.write_text(
+                """
+apiVersion: v1
+kind: ConfigMap
+data:
+  strategies.yaml: |
+    strategies:
+      - name: breakout-continuation-long-v1
+        enabled: true
+        family: breakout_continuation_consistent
+        params:
+          max_entries_per_session: '1'
+        universe_symbols:
+          - AMAT
+          - NVDA
+""".strip()
+                + "\n",
+                encoding='utf-8',
+            )
+            program = StrategyAutoresearchProgram(
+                **{
+                    **_program().__dict__,
+                    'objective': StrategyObjective(
+                        target_net_pnl_per_day=Decimal('500'),
+                        min_active_day_ratio=Decimal('1.0'),
+                        min_positive_day_ratio=Decimal('0.6'),
+                        min_daily_notional=Decimal('300000'),
+                        max_best_day_share=Decimal('0.3'),
+                        max_worst_day_loss=Decimal('350'),
+                        max_drawdown=Decimal('900'),
+                        require_every_day_active=True,
+                        min_regime_slice_pass_rate=Decimal('0'),
+                        stop_when_objective_met=True,
+                    ),
+                    'runtime_closure_policy': RuntimeClosurePolicy(
+                        enabled=True,
+                        execute_parity_replay=True,
+                        execute_approval_replay=True,
+                        parity_window='full_window',
+                        approval_window='holdout',
+                        shadow_validation_mode='skip',
+                        promotion_target='shadow',
+                    ),
+                }
+            )
+            best_candidate = {
+                'candidate_id': 'cand-1',
+                'family_template_id': 'breakout_reclaim_v2',
+                'runtime_family': 'breakout_continuation_consistent',
+                'runtime_strategy_name': 'breakout-continuation-long-v1',
+                'status': 'keep',
+                'candidate_params': {'max_entries_per_session': '1'},
+                'candidate_strategy_overrides': {'universe_symbols': ['AMAT', 'NVDA']},
+                'disable_other_strategies': True,
+                'holdout_start_date': '2026-04-08',
+                'holdout_end_date': '2026-04-09',
+                'full_window_start_date': '2026-03-20',
+                'full_window_end_date': '2026-04-09',
+                'normalization_regime': 'price_scaled',
+            }
+            replay_payload = {
+                'start_date': '2026-03-20',
+                'end_date': '2026-04-09',
+                'net_pnl': '6000',
+                'decision_count': 12,
+                'filled_count': 9,
+                'wins': 7,
+                'losses': 2,
+                'daily': {
+                    '2026-03-20': {'net_pnl': '1000', 'filled_count': 1, 'filled_notional': '300000'},
+                    '2026-03-21': {'net_pnl': '800', 'filled_count': 1, 'filled_notional': '300000'},
+                    '2026-03-24': {'net_pnl': '700', 'filled_count': 1, 'filled_notional': '300000'},
+                    '2026-03-25': {'net_pnl': '900', 'filled_count': 1, 'filled_notional': '300000'},
+                    '2026-03-26': {'net_pnl': '1100', 'filled_count': 1, 'filled_notional': '300000'},
+                    '2026-03-27': {'net_pnl': '600', 'filled_count': 1, 'filled_notional': '300000'},
+                    '2026-04-08': {'net_pnl': '500', 'filled_count': 1, 'filled_notional': '300000'},
+                    '2026-04-09': {'net_pnl': '400', 'filled_count': 1, 'filled_notional': '300000'},
+                },
+            }
+
+            def _fake_replay_executor(_: object) -> dict[str, object]:
+                return dict(replay_payload)
+
+            summary = write_runtime_closure_bundle(
+                run_root=run_root,
+                runner_run_id='run-1',
+                program=program,
+                best_candidate=best_candidate,
+                manifest=manifest,
+                execution_context=RuntimeClosureExecutionContext(
+                    strategy_configmap_path=configmap_path,
+                    clickhouse_http_url='http://example.invalid:8123',
+                    clickhouse_username='torghut',
+                    clickhouse_password='secret',
+                    start_equity=Decimal('31590.02'),
+                    chunk_minutes=10,
+                    symbols=('AMAT', 'NVDA'),
+                    progress_log_interval_seconds=30,
+                ),
+                replay_executor=_fake_replay_executor,
+            )
+
+            self.assertEqual(summary.status, 'ready_for_promotion_review')
+            self.assertEqual(summary.next_required_steps, ('promotion_review',))
+
     def test_write_runtime_closure_bundle_handles_missing_best_candidate(self) -> None:
         with TemporaryDirectory() as tmpdir:
             run_root = Path(tmpdir)

--- a/services/torghut/tests/test_runtime_closure.py
+++ b/services/torghut/tests/test_runtime_closure.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+from decimal import Decimal
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest import TestCase
@@ -9,12 +10,16 @@ from unittest import TestCase
 from app.trading.discovery.autoresearch import (
     ProposalModelPolicy,
     ReplayBudget,
+    RuntimeClosurePolicy,
     SnapshotPolicy,
     StrategyAutoresearchProgram,
     StrategyObjective,
 )
 from app.trading.discovery.mlx_snapshot import build_mlx_snapshot_manifest
-from app.trading.discovery.runtime_closure import write_runtime_closure_bundle
+from app.trading.discovery.runtime_closure import (
+    RuntimeClosureExecutionContext,
+    write_runtime_closure_bundle,
+)
 
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 
@@ -24,15 +29,15 @@ def _program() -> StrategyAutoresearchProgram:
         program_id='program-1',
         description='desc',
         objective=StrategyObjective(
-            target_net_pnl_per_day='500',  # type: ignore[arg-type]
-            min_active_day_ratio='1.0',  # type: ignore[arg-type]
-            min_positive_day_ratio='0.6',  # type: ignore[arg-type]
-            min_daily_notional='300000',  # type: ignore[arg-type]
-            max_best_day_share='0.3',  # type: ignore[arg-type]
-            max_worst_day_loss='350',  # type: ignore[arg-type]
-            max_drawdown='900',  # type: ignore[arg-type]
+            target_net_pnl_per_day=Decimal('500'),
+            min_active_day_ratio=Decimal('1.0'),
+            min_positive_day_ratio=Decimal('0.6'),
+            min_daily_notional=Decimal('300000'),
+            max_best_day_share=Decimal('0.3'),
+            max_worst_day_loss=Decimal('350'),
+            max_drawdown=Decimal('900'),
             require_every_day_active=True,
-            min_regime_slice_pass_rate='0.45',  # type: ignore[arg-type]
+            min_regime_slice_pass_rate=Decimal('0.45'),
             stop_when_objective_met=True,
         ),
         snapshot_policy=SnapshotPolicy(
@@ -53,6 +58,15 @@ def _program() -> StrategyAutoresearchProgram:
             minimum_history_rows=1,
         ),
         replay_budget=ReplayBudget(max_candidates_per_round=8, exploration_slots=1),
+        runtime_closure_policy=RuntimeClosurePolicy(
+            enabled=False,
+            execute_parity_replay=True,
+            execute_approval_replay=True,
+            parity_window='full_window',
+            approval_window='holdout',
+            shadow_validation_mode='require_live_evidence',
+            promotion_target='shadow',
+        ),
         parity_requirements=('scheduler_v3_parity_replay',),
         promotion_policy='research_only',
         ledger_policy={'append_only': True},
@@ -147,6 +161,170 @@ class TestRuntimeClosure(TestCase):
                     text=True,
                 ).stdout.strip(),
             )
+
+    def test_write_runtime_closure_bundle_executes_runtime_replays_when_enabled(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            run_root = Path(tmpdir)
+            manifest = build_mlx_snapshot_manifest(
+                runner_run_id='run-1',
+                program=_program(),
+                symbols='AMAT,NVDA',
+                train_days=6,
+                holdout_days=2,
+                full_window_start_date='2026-03-20',
+                full_window_end_date='2026-04-09',
+                row_counts={'receipt_count': 1, 'signal_row_count': 42},
+            )
+            configmap_path = run_root / 'strategy-configmap.yaml'
+            configmap_path.write_text(
+                """
+apiVersion: v1
+kind: ConfigMap
+data:
+  strategies.yaml: |
+    strategies:
+      - name: breakout-continuation-long-v1
+        enabled: true
+        family: breakout_continuation_consistent
+        params:
+          max_entries_per_session: '1'
+        universe_symbols:
+          - AMAT
+          - NVDA
+""".strip()
+                + "\n",
+                encoding='utf-8',
+            )
+            program = _program()
+            program = StrategyAutoresearchProgram(
+                **{
+                    **program.__dict__,
+                    'objective': StrategyObjective(
+                        target_net_pnl_per_day=Decimal('500'),
+                        min_active_day_ratio=Decimal('1.0'),
+                        min_positive_day_ratio=Decimal('0.6'),
+                        min_daily_notional=Decimal('300000'),
+                        max_best_day_share=Decimal('0.3'),
+                        max_worst_day_loss=Decimal('350'),
+                        max_drawdown=Decimal('900'),
+                        require_every_day_active=True,
+                        min_regime_slice_pass_rate=Decimal('0'),
+                        stop_when_objective_met=True,
+                    ),
+                    'runtime_closure_policy': RuntimeClosurePolicy(
+                        enabled=True,
+                        execute_parity_replay=True,
+                        execute_approval_replay=True,
+                        parity_window='full_window',
+                        approval_window='holdout',
+                        shadow_validation_mode='require_live_evidence',
+                        promotion_target='shadow',
+                    ),
+                }
+            )
+            best_candidate = {
+                'candidate_id': 'cand-1',
+                'family_template_id': 'breakout_reclaim_v2',
+                'runtime_family': 'breakout_continuation_consistent',
+                'runtime_strategy_name': 'breakout-continuation-long-v1',
+                'objective_scope': 'research_only',
+                'objective_met': True,
+                'status': 'keep',
+                'mutation_label': 'seed',
+                'descriptor_id': 'desc-1',
+                'entry_window_start_minute': 45,
+                'entry_window_end_minute': 75,
+                'max_hold_minutes': 30,
+                'rank_count': 1,
+                'requires_prev_day_features': True,
+                'requires_cross_sectional_features': True,
+                'requires_quote_quality_gate': True,
+                'net_pnl_per_day': '620',
+                'active_day_ratio': '0.85',
+                'positive_day_ratio': '0.60',
+                'best_day_share': '0.30',
+                'worst_day_loss': '300',
+                'max_drawdown': '850',
+                'proposal_score': 12.0,
+                'proposal_rank': 1,
+                'promotion_status': 'blocked_pending_runtime_parity',
+                'promotion_stage': 'research_candidate',
+                'promotion_reason': 'still blocked',
+                'promotion_blockers': [
+                    'scheduler_v3_parity_missing',
+                    'scheduler_v3_approval_missing',
+                    'shadow_validation_missing',
+                ],
+                'promotion_required_evidence': [
+                    'checked_in_runtime_family',
+                    'scheduler_v3_parity_replay',
+                    'scheduler_v3_approval_replay',
+                    'live_shadow_validation',
+                ],
+                'candidate_params': {'max_entries_per_session': '1'},
+                'candidate_strategy_overrides': {'universe_symbols': ['AMAT', 'NVDA']},
+                'disable_other_strategies': True,
+                'train_start_date': '2026-03-20',
+                'train_end_date': '2026-03-27',
+                'holdout_start_date': '2026-04-08',
+                'holdout_end_date': '2026-04-09',
+                'full_window_start_date': '2026-03-20',
+                'full_window_end_date': '2026-04-09',
+                'normalization_regime': 'price_scaled',
+            }
+
+            replay_payload = {
+                'start_date': '2026-03-20',
+                'end_date': '2026-04-09',
+                'net_pnl': '6000',
+                'decision_count': 12,
+                'filled_count': 9,
+                'wins': 7,
+                'losses': 2,
+                'daily': {
+                    '2026-03-20': {'net_pnl': '1000', 'filled_count': 1, 'filled_notional': '300000'},
+                    '2026-03-21': {'net_pnl': '800', 'filled_count': 1, 'filled_notional': '300000'},
+                    '2026-03-24': {'net_pnl': '700', 'filled_count': 1, 'filled_notional': '300000'},
+                    '2026-03-25': {'net_pnl': '900', 'filled_count': 1, 'filled_notional': '300000'},
+                    '2026-03-26': {'net_pnl': '1100', 'filled_count': 1, 'filled_notional': '300000'},
+                    '2026-03-27': {'net_pnl': '600', 'filled_count': 1, 'filled_notional': '300000'},
+                    '2026-04-08': {'net_pnl': '500', 'filled_count': 1, 'filled_notional': '300000'},
+                    '2026-04-09': {'net_pnl': '400', 'filled_count': 1, 'filled_notional': '300000'},
+                },
+            }
+
+            def _fake_replay_executor(_: object) -> dict[str, object]:
+                return dict(replay_payload)
+
+            summary = write_runtime_closure_bundle(
+                run_root=run_root,
+                runner_run_id='run-1',
+                program=program,
+                best_candidate=best_candidate,
+                manifest=manifest,
+                execution_context=RuntimeClosureExecutionContext(
+                    strategy_configmap_path=configmap_path,
+                    clickhouse_http_url='http://example.invalid:8123',
+                    clickhouse_username='torghut',
+                    clickhouse_password='secret',
+                    start_equity=Decimal('31590.02'),
+                    chunk_minutes=10,
+                    symbols=('AMAT', 'NVDA'),
+                    progress_log_interval_seconds=30,
+                ),
+                replay_executor=_fake_replay_executor,
+            )
+
+            self.assertEqual(summary.status, 'pending_shadow_validation')
+            self.assertTrue(Path(summary.candidate_configmap_path).exists())
+            self.assertTrue(Path(summary.parity_replay_path).exists())
+            self.assertTrue(Path(summary.approval_replay_path).exists())
+            self.assertTrue(Path(summary.shadow_validation_path).exists())
+            self.assertIn('live_shadow_validation', summary.next_required_steps)
+
+            parity_report = json.loads(Path(summary.parity_report_path).read_text(encoding='utf-8'))
+            self.assertTrue(parity_report['objective_met'])
+            self.assertEqual(parity_report['window_name'], 'full_window')
 
     def test_write_runtime_closure_bundle_handles_missing_best_candidate(self) -> None:
         with TemporaryDirectory() as tmpdir:

--- a/services/torghut/tests/test_strategy_autoresearch.py
+++ b/services/torghut/tests/test_strategy_autoresearch.py
@@ -302,6 +302,38 @@ class TestStrategyAutoresearch(TestCase):
             with self.assertRaisesRegex(ValueError, 'autoresearch_program_missing_families'):
                 load_strategy_autoresearch_program(program_path, family_dir=root)
 
+    def test_load_program_rejects_invalid_runtime_closure_policy_values(self) -> None:
+        invalid_cases = [
+            ({'parity_window': 'bad'}, 'autoresearch_runtime_closure_parity_window_invalid'),
+            ({'approval_window': 'bad'}, 'autoresearch_runtime_closure_approval_window_invalid'),
+            (
+                {'shadow_validation_mode': 'bad'},
+                'autoresearch_runtime_closure_shadow_validation_mode_invalid',
+            ),
+            ({'promotion_target': 'bad'}, 'autoresearch_runtime_closure_promotion_target_invalid'),
+        ]
+
+        for overrides, expected_error in invalid_cases:
+            with self.subTest(overrides=overrides):
+                with TemporaryDirectory() as tmpdir:
+                    root = Path(tmpdir)
+                    program_path, family_dir = self._write_program_fixture(root)
+                    payload = yaml.safe_load(program_path.read_text(encoding='utf-8'))
+                    payload['runtime_closure_policy'] = {
+                        'enabled': False,
+                        'execute_parity_replay': True,
+                        'execute_approval_replay': True,
+                        'parity_window': 'full_window',
+                        'approval_window': 'holdout',
+                        'shadow_validation_mode': 'require_live_evidence',
+                        'promotion_target': 'shadow',
+                    }
+                    payload['runtime_closure_policy'].update(overrides)
+                    program_path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding='utf-8')
+
+                    with self.assertRaisesRegex(ValueError, expected_error):
+                        load_strategy_autoresearch_program(program_path, family_dir=family_dir)
+
     def test_load_program_skips_invalid_source_and_claim_entries(self) -> None:
         with TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)

--- a/services/torghut/tests/test_strategy_autoresearch.py
+++ b/services/torghut/tests/test_strategy_autoresearch.py
@@ -116,6 +116,9 @@ class TestStrategyAutoresearch(TestCase):
         self.assertEqual(program.proposal_model_policy.mode, 'ranking_only')
         self.assertEqual(program.promotion_policy, 'research_only')
         self.assertIn('scheduler_v3_parity_replay', program.parity_requirements)
+        self.assertFalse(program.runtime_closure_policy.enabled)
+        self.assertEqual(program.runtime_closure_policy.parity_window, 'full_window')
+        self.assertEqual(program.runtime_closure_policy.approval_window, 'holdout')
         self.assertTrue(program.ledger_policy['append_only'])
 
     def _write_program_fixture(self, root: Path) -> tuple[Path, Path]:
@@ -189,6 +192,15 @@ class TestStrategyAutoresearch(TestCase):
                         'max_worst_day_loss': '450',
                         'max_drawdown': '1000',
                         'min_regime_slice_pass_rate': '0.40',
+                    },
+                    'runtime_closure_policy': {
+                        'enabled': False,
+                        'execute_parity_replay': True,
+                        'execute_approval_replay': True,
+                        'parity_window': 'full_window',
+                        'approval_window': 'holdout',
+                        'shadow_validation_mode': 'require_live_evidence',
+                        'promotion_target': 'shadow',
                     },
                     'research_sources': [
                         {
@@ -846,6 +858,14 @@ class TestStrategyAutoresearch(TestCase):
             self.assertIn('runtime_closure', summary)
             self.assertIn('descriptor_id', summary['best_candidate'])
             self.assertIn('proposal_score', summary['best_candidate'])
+            self.assertEqual(
+                summary['best_candidate']['candidate_params'],
+                {'max_entries_per_session': '1', 'entry_cooldown_seconds': '600'},
+            )
+            self.assertEqual(
+                summary['best_candidate']['candidate_strategy_overrides'],
+                {'universe_symbols': ['AMAT', 'NVDA']},
+            )
             self.assertEqual(summary['runtime_closure']['status'], 'pending_runtime_parity')
             self.assertFalse(summary['runtime_closure']['promotion_prerequisites']['allowed'])
             self.assertFalse(summary['runtime_closure']['rollback_readiness']['ready'])


### PR DESCRIPTION
## Summary

- add an explicit `runtime_closure_policy` to the Torghut autoresearch contract and enable it in the strict daily profit program
- preserve exact candidate params, strategy overrides, and replay windows in the append-only autoresearch ledger so closure replay can faithfully reconstruct candidates
- upgrade MLX runtime closure bundles to materialize candidate configmaps and execute runtime-native parity and approval replays, while keeping shadow validation fail-closed and explicit

## Related Issues

None

## Testing

- `cd services/torghut && /opt/homebrew/bin/mise exec uv -- uv sync --frozen --extra dev`
- `cd services/torghut && /opt/homebrew/bin/mise exec uv -- uv run --frozen python -m pytest tests/test_runtime_closure.py tests/test_strategy_autoresearch.py tests/test_mlx_autoresearch.py -q`
- `cd services/torghut && /opt/homebrew/bin/mise exec uv -- uv run --frozen python -m ruff check app/trading/discovery/autoresearch.py app/trading/discovery/runtime_closure.py scripts/run_strategy_autoresearch_loop.py tests/test_runtime_closure.py tests/test_strategy_autoresearch.py tests/test_mlx_autoresearch.py`
- `cd services/torghut && /opt/homebrew/bin/mise exec uv -- uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && /opt/homebrew/bin/mise exec uv -- uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && /opt/homebrew/bin/mise exec uv -- uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
