### PR TITLE
chore(torghut): promote image 4bcf9c38

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:8ee839c2f169656dc3f07c16dcec8a3f4fb1d69b3f7a128d4674ed813ca66f84
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:43a1186fcbda4565ef056e4151f14c72162a028437e57323ce10d897c00d5d30
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -63,9 +63,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.566.0-290-g5bc4cdf51
+              value: v0.566.0-294-g4bcf9c385
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 5bc4cdf510383dd133ac1e5a3073eb46021ad8c7
+              value: 4bcf9c385fb815f359f2c1e600ffdcb0cbbd2ea3
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:8ee839c2f169656dc3f07c16dcec8a3f4fb1d69b3f7a128d4674ed813ca66f84
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:43a1186fcbda4565ef056e4151f14c72162a028437e57323ce10d897c00d5d30
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -63,9 +63,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.566.0-290-g5bc4cdf51
+              value: v0.566.0-294-g4bcf9c385
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 5bc4cdf510383dd133ac1e5a3073eb46021ad8c7
+              value: 4bcf9c385fb815f359f2c1e600ffdcb0cbbd2ea3
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -40,7 +40,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:8ee839c2f169656dc3f07c16dcec8a3f4fb1d69b3f7a128d4674ed813ca66f84
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:43a1186fcbda4565ef056e4151f14c72162a028437e57323ce10d897c00d5d30
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -21,7 +21,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:8ee839c2f169656dc3f07c16dcec8a3f4fb1d69b3f7a128d4674ed813ca66f84
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:43a1186fcbda4565ef056e4151f14c72162a028437e57323ce10d897c00d5d30
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -32,7 +32,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:8ee839c2f169656dc3f07c16dcec8a3f4fb1d69b3f7a128d4674ed813ca66f84
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:43a1186fcbda4565ef056e4151f14c72162a028437e57323ce10d897c00d5d30
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -30,7 +30,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:8ee839c2f169656dc3f07c16dcec8a3f4fb1d69b3f7a128d4674ed813ca66f84
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:43a1186fcbda4565ef056e4151f14c72162a028437e57323ce10d897c00d5d30
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:8ee839c2f169656dc3f07c16dcec8a3f4fb1d69b3f7a128d4674ed813ca66f84
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:43a1186fcbda4565ef056e4151f14c72162a028437e57323ce10d897c00d5d30
           command:
             - /opt/venv/bin/alembic
           args:

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -13,7 +13,7 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:8ee839c2f169656dc3f07c16dcec8a3f4fb1d69b3f7a128d4674ed813ca66f84
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:43a1186fcbda4565ef056e4151f14c72162a028437e57323ce10d897c00d5d30
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -21,7 +21,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:8ee839c2f169656dc3f07c16dcec8a3f4fb1d69b3f7a128d4674ed813ca66f84
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:43a1186fcbda4565ef056e4151f14c72162a028437e57323ce10d897c00d5d30
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -39,7 +39,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:8ee839c2f169656dc3f07c16dcec8a3f4fb1d69b3f7a128d4674ed813ca66f84
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:43a1186fcbda4565ef056e4151f14c72162a028437e57323ce10d897c00d5d30
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-04-11T03:56:43Z"
+        client.knative.dev/updateTimestamp: "2026-04-11T04:55:31Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:8ee839c2f169656dc3f07c16dcec8a3f4fb1d69b3f7a128d4674ed813ca66f84
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:43a1186fcbda4565ef056e4151f14c72162a028437e57323ce10d897c00d5d30
           ports:
             - name: http1
               containerPort: 8181
@@ -495,9 +495,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.566.0-290-g5bc4cdf51
+              value: v0.566.0-294-g4bcf9c385
             - name: TORGHUT_COMMIT
-              value: 5bc4cdf510383dd133ac1e5a3073eb46021ad8c7
+              value: 4bcf9c385fb815f359f2c1e600ffdcb0cbbd2ea3
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-04-11T03:56:43Z"
+        client.knative.dev/updateTimestamp: "2026-04-11T04:55:31Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -26,7 +26,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:8ee839c2f169656dc3f07c16dcec8a3f4fb1d69b3f7a128d4674ed813ca66f84
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:43a1186fcbda4565ef056e4151f14c72162a028437e57323ce10d897c00d5d30
           ports:
             - name: http1
               containerPort: 8181
@@ -276,9 +276,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.566.0-290-g5bc4cdf51
+              value: v0.566.0-294-g4bcf9c385
             - name: TORGHUT_COMMIT
-              value: 5bc4cdf510383dd133ac1e5a3073eb46021ad8c7
+              value: 4bcf9c385fb815f359f2c1e600ffdcb0cbbd2ea3
           livenessProbe:
             httpGet:
               path: /healthz


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `4bcf9c385fb815f359f2c1e600ffdcb0cbbd2ea3`
- Image tag: `4bcf9c38`
- Image digest: `sha256:43a1186fcbda4565ef056e4151f14c72162a028437e57323ce10d897c00d5d30`