### PR TITLE
fix(jangar): restore terminal websocket route hooks

### DIFF
--- a/services/jangar/src/server/__tests__/app.test.ts
+++ b/services/jangar/src/server/__tests__/app.test.ts
@@ -4,6 +4,29 @@ import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+const crosswsMock = vi.hoisted(() => {
+  let lastOptions: unknown
+  const handleUpgrade = vi.fn(async () => null)
+  const factory = vi.fn((options: unknown) => {
+    lastOptions = options
+    return {
+      handleUpgrade,
+      websocket: {},
+    }
+  })
+
+  return {
+    handleUpgrade,
+    factory,
+    getLastOptions: () => lastOptions,
+    reset: () => {
+      lastOptions = undefined
+      handleUpgrade.mockClear()
+      factory.mockClear()
+    },
+  }
+})
+
 vi.mock('../metrics', () => ({
   getPrometheusMetricsPath: () => '/metrics',
   isPrometheusMetricsEnabled: () => false,
@@ -11,10 +34,7 @@ vi.mock('../metrics', () => ({
 }))
 
 vi.mock('crossws/adapters/bun', () => ({
-  default: vi.fn(() => ({
-    handleUpgrade: vi.fn(async () => null),
-    websocket: {},
-  })),
+  default: crosswsMock.factory,
 }))
 
 vi.mock('~/server/terminal-pty-manager', () => ({
@@ -72,6 +92,7 @@ describe('createJangarRuntime client serving', () => {
     })) as typeof Bun.file
 
   beforeEach(() => {
+    crosswsMock.reset()
     hadBun = 'Bun' in globalThis
     originalBunFile = hadBun ? Bun.file : undefined
 
@@ -154,5 +175,51 @@ describe('createJangarRuntime client serving', () => {
     } finally {
       await restoreIndex()
     }
+  })
+
+  it('does not blindly upgrade websocket requests for non-websocket routes', async () => {
+    const restoreIndex = await withTempFile(indexPath, clientIndexHtml)
+
+    try {
+      const runtime = await createJangarRuntime({ serveClient: true })
+      const result = await runtime.handleUpgrade(
+        new Request('http://localhost/dashboard', {
+          headers: { upgrade: 'websocket' },
+        }),
+        {} as Bun.Server<unknown>,
+      )
+
+      expect(result.kind).toBe('response')
+      if (result.kind !== 'response') throw new Error('Expected websocket upgrade to return a normal response')
+      expect(result.response.status).toBe(200)
+      expect(await result.response.text()).toBe(clientIndexHtml)
+      expect(crosswsMock.handleUpgrade).not.toHaveBeenCalled()
+    } finally {
+      await restoreIndex()
+    }
+  })
+
+  it('resolves route websocket hooks before upgrading terminal sessions', async () => {
+    const runtime = await createJangarRuntime()
+    const request = new Request('http://localhost/api/terminals/jangar-terminal-codex-test/ws?reconnect=test-token', {
+      headers: { upgrade: 'websocket' },
+    })
+
+    const result = await runtime.handleUpgrade(request, {} as Bun.Server<unknown>)
+
+    expect(result.kind).toBe('handled')
+    expect(crosswsMock.handleUpgrade).toHaveBeenCalledOnce()
+
+    const adapterOptions = crosswsMock.getLastOptions() as { resolve?: (request: Request) => unknown }
+    expect(adapterOptions.resolve).toBeTypeOf('function')
+    const hooks = adapterOptions.resolve ? await adapterOptions.resolve(request) : undefined
+
+    expect(hooks).toMatchObject({
+      close: expect.any(Function),
+      error: expect.any(Function),
+      message: expect.any(Function),
+      open: expect.any(Function),
+      upgrade: expect.any(Function),
+    })
   })
 })

--- a/services/jangar/src/server/app.ts
+++ b/services/jangar/src/server/app.ts
@@ -33,6 +33,13 @@ type JangarRuntime = {
   websocket: Bun.WebSocketHandler<unknown>
 }
 
+type WebSocketAdapterOptions = NonNullable<Parameters<typeof wsAdapter>[0]>
+type ResolvedWebSocketHooks = NonNullable<WebSocketAdapterOptions['hooks']>
+type WebSocketRouteProbeResponse = Response & { crossws?: ResolvedWebSocketHooks }
+type WebSocketRequest = Request & {
+  context?: Record<string, unknown> & { __jangarResolvedWebSocketHooks?: ResolvedWebSocketHooks }
+}
+
 const serverRouteModules = import.meta.glob([
   '../routes/api/**/*.{ts,tsx}',
   '../routes/v1/**/*.{ts,tsx}',
@@ -138,6 +145,17 @@ const getServerRouteRoots = (definitions: ServerRouteDefinition[]) =>
 const shouldServeClientPath = (pathname: string, serverRouteRoots: ReadonlySet<string>) => {
   const firstSegment = getFirstPathSegment(pathname)
   return firstSegment === null || !serverRouteRoots.has(firstSegment)
+}
+
+const getResolvedWebSocketHooks = (request: Request) =>
+  (request as WebSocketRequest).context?.__jangarResolvedWebSocketHooks
+
+const storeResolvedWebSocketHooks = (request: Request, hooks: ResolvedWebSocketHooks) => {
+  const websocketRequest = request as WebSocketRequest
+  websocketRequest.context = {
+    ...(websocketRequest.context ?? {}),
+    __jangarResolvedWebSocketHooks: hooks,
+  }
 }
 
 const resolveClientIndexPath = async () => {
@@ -300,8 +318,9 @@ export const createJangarRuntime = async (options: { serveClient?: boolean } = {
   }
 
   const handleRequest = toWebHandler(app)
-  const appWithWebsocket = app as typeof app & { websocket: Parameters<typeof wsAdapter>[0] }
-  const adapter = wsAdapter(appWithWebsocket.websocket)
+  const adapter = wsAdapter({
+    resolve: (request) => getResolvedWebSocketHooks(request) ?? {},
+  })
 
   return {
     handleRequest,
@@ -309,6 +328,14 @@ export const createJangarRuntime = async (options: { serveClient?: boolean } = {
       if (!isWebSocketUpgradeRequest(request)) {
         return { kind: 'skip' }
       }
+
+      const upgradeProbeResponse = (await handleRequest(request)) as WebSocketRouteProbeResponse
+      const routeHooks = upgradeProbeResponse.crossws
+      if (!routeHooks) {
+        return { kind: 'response', response: upgradeProbeResponse }
+      }
+
+      storeResolvedWebSocketHooks(request, routeHooks)
 
       const response = await adapter.handleUpgrade(request, server)
       if (response) {


### PR DESCRIPTION
## Summary

- fix Bun websocket upgrades in Jangar so terminal websocket requests resolve the matched route hooks before upgrading
- stop blindly upgrading non-websocket routes, which was creating inert open sockets with no terminal `upgrade/open/message` handlers attached
- add regression coverage for both unmatched websocket requests and terminal websocket hook resolution

## Related Issues

None

## Testing

- `cd services/jangar && ~/.bun/bin/bunx vitest run src/server/__tests__/app.test.ts`
- `cd services/jangar && ~/.bun/bin/bunx tsc --noEmit --project tsconfig.paths.json`
- `cd services/jangar && ~/.bun/bin/bun run build`
- Manual investigation: reproduced the blank terminal behavior against the live `jangar` service via port-forward, confirmed websocket `OPEN` with no frames, and traced it to the runtime upgrading requests without route websocket hooks.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
