### PR TITLE
chore(jangar): promote image 33de6185

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 38c3b6ce
-  digest: sha256:659988d25bbbe98f0f0af6190d670c784d2a0bbbc1c4f9f936cda37286abe1b8
+  tag: 33de6185
+  digest: sha256:b343d3f01c2d70f1bd1b78dd0482f7b486d14ae47471448f52ed648e5fbe0003
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 38c3b6ce
-    digest: sha256:44dc86ab60ec97dca45183aba996ff1f6a385ca27b9b2025d2149e39f3726736
+    tag: 33de6185
+    digest: sha256:67966400c0203a83d1279b2beb6a0365a37d612472921199e2e9de00a17ecc6d
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 38c3b6ce
-    digest: sha256:659988d25bbbe98f0f0af6190d670c784d2a0bbbc1c4f9f936cda37286abe1b8
+    tag: 33de6185
+    digest: sha256:b343d3f01c2d70f1bd1b78dd0482f7b486d14ae47471448f52ed648e5fbe0003
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-04-11T04:41:06Z
+    deploy.knative.dev/rollout: 2026-04-11T05:20:15Z
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/name: jangar-worker
     app.kubernetes.io/part-of: lab
   annotations:
-    kubectl.kubernetes.io/restartedAt: 2026-04-11T04:41:06Z
+    kubectl.kubernetes.io/restartedAt: 2026-04-11T05:20:15Z
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -60,5 +60,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: 38c3b6ce
-    digest: sha256:659988d25bbbe98f0f0af6190d670c784d2a0bbbc1c4f9f936cda37286abe1b8
+    newTag: 33de6185
+    digest: sha256:b343d3f01c2d70f1bd1b78dd0482f7b486d14ae47471448f52ed648e5fbe0003


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `33de6185090ebb04d23b42dd4abe30c54930d464`
- Image tag: `33de6185`
- Image digest: `sha256:b343d3f01c2d70f1bd1b78dd0482f7b486d14ae47471448f52ed648e5fbe0003`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`