### PR TITLE
feat(torghut): wire shadow evidence into mlx closure

### DIFF
--- a/services/torghut/app/trading/discovery/autoresearch_notebooks.py
+++ b/services/torghut/app/trading/discovery/autoresearch_notebooks.py
@@ -493,6 +493,27 @@ HISTORY = [
     for line in (RUN_ROOT / 'history.jsonl').read_text(encoding='utf-8').splitlines()
     if line.strip()
 ]
+RUNTIME_CLOSURE = SUMMARY.get('runtime_closure') or {{}}
+
+def _load_optional_json(path_value: object) -> dict[str, object]:
+    raw = str(path_value or '').strip()
+    if not raw:
+        return {{}}
+    path = Path(raw)
+    if not path.is_absolute():
+        path = RUN_ROOT / path
+    if not path.exists():
+        return {{}}
+    try:
+        payload = json.loads(path.read_text(encoding='utf-8'))
+    except (OSError, json.JSONDecodeError):
+        return {{}}
+    return payload if isinstance(payload, dict) else {{}}
+
+RUNTIME_PARITY_REPORT = _load_optional_json(RUNTIME_CLOSURE.get('parity_report_path'))
+RUNTIME_APPROVAL_REPORT = _load_optional_json(RUNTIME_CLOSURE.get('approval_report_path'))
+RUNTIME_SHADOW_VALIDATION = _load_optional_json(RUNTIME_CLOSURE.get('shadow_validation_path'))
+RUNTIME_PROMOTION_PREREQUISITES = _load_optional_json(RUNTIME_CLOSURE.get('promotion_prerequisites_path'))
 
 def _ordered_keys(rows: list[dict[str, object]]) -> list[str]:
     keys: list[str] = []
@@ -699,6 +720,32 @@ if false_negatives:
     )
     display(Markdown('### Selection diversity'))
     _display_rows([DIAGNOSTICS.get('diversity_summary') or {}], columns=['selected_unique_family_count', 'selected_unique_side_count', 'selected_mean_pairwise_distance'])
+    if RUNTIME_CLOSURE:
+        display(Markdown('### Runtime closure evidence'))
+        _display_rows(
+            [
+                {
+                    'runtime_closure_status': RUNTIME_CLOSURE.get('status'),
+                    'next_required_steps': ', '.join(RUNTIME_CLOSURE.get('next_required_steps') or []),
+                    'parity_objective_met': RUNTIME_PARITY_REPORT.get('objective_met'),
+                    'approval_objective_met': RUNTIME_APPROVAL_REPORT.get('objective_met'),
+                    'shadow_validation_status': RUNTIME_SHADOW_VALIDATION.get('status'),
+                    'shadow_evidence_loaded': RUNTIME_SHADOW_VALIDATION.get('evidence_loaded'),
+                    'shadow_artifact_path': RUNTIME_SHADOW_VALIDATION.get('source_artifact_path'),
+                }
+            ]
+        )
+        if RUNTIME_PROMOTION_PREREQUISITES:
+            display(Markdown('### Promotion prerequisites'))
+            _display_rows(
+                [
+                    {
+                        'allowed': RUNTIME_PROMOTION_PREREQUISITES.get('allowed'),
+                        'reasons': ', '.join(RUNTIME_PROMOTION_PREREQUISITES.get('reasons') or []),
+                        'missing_artifacts': ', '.join(RUNTIME_PROMOTION_PREREQUISITES.get('missing_artifacts') or []),
+                    }
+                ]
+            )
 """
         ),
         _code_cell(
@@ -718,6 +765,16 @@ if HISTORY:
             if (not row.get('runtime_family')) or row.get('promotion_status') or row.get('hard_vetoes')
         ]
     )
+if RUNTIME_CLOSURE:
+    runtime_failures = [
+        {
+            'runtime_closure_status': RUNTIME_CLOSURE.get('status'),
+            'shadow_validation_status': RUNTIME_SHADOW_VALIDATION.get('status'),
+            'shadow_reasons': RUNTIME_SHADOW_VALIDATION.get('reasons'),
+            'promotion_prerequisite_reasons': RUNTIME_PROMOTION_PREREQUISITES.get('reasons'),
+        }
+    ]
+    _display_rows(runtime_failures)
 """
         ),
     ]

--- a/services/torghut/app/trading/discovery/runtime_closure.py
+++ b/services/torghut/app/trading/discovery/runtime_closure.py
@@ -144,6 +144,7 @@ class RuntimeClosureExecutionContext:
     chunk_minutes: int
     symbols: tuple[str, ...] = ()
     progress_log_interval_seconds: int = 30
+    shadow_validation_artifact_path: Path | None = None
 
     def to_payload(self) -> dict[str, Any]:
         return {
@@ -154,6 +155,11 @@ class RuntimeClosureExecutionContext:
             'chunk_minutes': self.chunk_minutes,
             'symbols': list(self.symbols),
             'progress_log_interval_seconds': self.progress_log_interval_seconds,
+            'shadow_validation_artifact_path': (
+                str(self.shadow_validation_artifact_path)
+                if self.shadow_validation_artifact_path is not None
+                else None
+            ),
         }
 
 
@@ -418,21 +424,81 @@ def _replay_analysis(
     }
 
 
-def _shadow_validation_plan(
+def _shadow_validation_artifact(
     *,
     best_candidate: Mapping[str, Any],
     program: StrategyAutoresearchProgram,
+    execution_context: RuntimeClosureExecutionContext | None,
 ) -> dict[str, Any]:
     mode = program.runtime_closure_policy.shadow_validation_mode
-    pending = mode == 'require_live_evidence'
-    reasons = ['live_shadow_evidence_not_available_from_local_autoresearch'] if pending else []
+    if mode != 'require_live_evidence':
+        return {
+            'schema_version': 'torghut.runtime-closure-shadow-validation-plan.v1',
+            'candidate_id': _string(best_candidate.get('candidate_id')),
+            'mode': mode,
+            'status': 'skipped',
+            'required': False,
+            'reasons': [],
+            'evidence_loaded': False,
+            'source_artifact_path': None,
+            'source_schema_version': None,
+        }
+
+    artifact_path = execution_context.shadow_validation_artifact_path if execution_context is not None else None
+    if artifact_path is None:
+        return {
+            'schema_version': 'torghut.runtime-closure-shadow-validation-plan.v1',
+            'candidate_id': _string(best_candidate.get('candidate_id')),
+            'mode': mode,
+            'status': 'pending_live_evidence',
+            'required': True,
+            'reasons': ['live_shadow_evidence_not_available_from_local_autoresearch'],
+            'evidence_loaded': False,
+            'source_artifact_path': None,
+            'source_schema_version': None,
+        }
+
+    try:
+        payload = json.loads(artifact_path.read_text(encoding='utf-8'))
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return {
+            'schema_version': 'torghut.runtime-closure-shadow-validation-plan.v1',
+            'candidate_id': _string(best_candidate.get('candidate_id')),
+            'mode': mode,
+            'status': 'invalid_artifact',
+            'required': True,
+            'reasons': ['shadow_validation_artifact_invalid_json'],
+            'evidence_loaded': False,
+            'source_artifact_path': str(artifact_path),
+            'source_schema_version': None,
+        }
+
+    source_payload = _mapping(payload)
+    source_schema_version = _string(source_payload.get('schema_version'))
+    status = _string(source_payload.get('status')) or 'invalid_artifact'
+    reasons: list[str] = []
+    if source_schema_version != 'shadow-live-deviation-report-v1':
+        reasons.append('shadow_validation_schema_version_invalid')
+        status = 'invalid_artifact'
+    elif status == 'within_budget':
+        pass
+    elif status in {'pending_live_evidence', 'pending'}:
+        reasons.append('shadow_validation_pending')
+    else:
+        reasons.append('shadow_validation_status_not_within_budget')
+
     return {
         'schema_version': 'torghut.runtime-closure-shadow-validation-plan.v1',
         'candidate_id': _string(best_candidate.get('candidate_id')),
         'mode': mode,
-        'status': 'pending_live_evidence' if pending else 'skipped',
-        'required': pending,
+        'status': status,
+        'required': True,
         'reasons': reasons,
+        'evidence_loaded': source_schema_version == 'shadow-live-deviation-report-v1',
+        'source_artifact_path': str(artifact_path),
+        'source_schema_version': source_schema_version,
+        'order_count': _int(source_payload.get('order_count')),
+        'coverage_error': source_payload.get('coverage_error'),
     }
 
 
@@ -445,7 +511,8 @@ def _summary_status_and_next_steps(
     parity_pass = bool(_mapping(parity_report).get('objective_met')) if parity_report is not None else False
     approval_pass = bool(_mapping(approval_report).get('objective_met')) if approval_report is not None else False
     shadow_required = bool(shadow_plan.get('required'))
-    shadow_ready = _string(shadow_plan.get('status')) == 'within_budget'
+    shadow_status = _string(shadow_plan.get('status'))
+    shadow_ready = shadow_status == 'within_budget'
 
     if parity_report is None:
         return (
@@ -468,8 +535,10 @@ def _summary_status_and_next_steps(
         )
     if not approval_pass:
         return ('approval_replay_failed', ('scheduler_v3_approval_replay',))
-    if shadow_required and not shadow_ready:
+    if shadow_required and shadow_status in {'pending_live_evidence', 'pending', ''}:
         return ('pending_shadow_validation', ('live_shadow_validation', 'promotion_review'))
+    if shadow_required and not shadow_ready:
+        return ('shadow_validation_failed', ('live_shadow_validation',))
     return ('ready_for_promotion_review', ('promotion_review',))
 
 def _candidate_spec(
@@ -573,7 +642,8 @@ def _gate_report(
     parity_pass = bool(_mapping(parity_report).get('objective_met')) if parity_report is not None else False
     approval_pass = bool(_mapping(approval_report).get('objective_met')) if approval_report is not None else False
     shadow_required = bool(shadow_plan.get('required'))
-    shadow_ready = _string(shadow_plan.get('status')) == 'within_budget'
+    shadow_status = _string(shadow_plan.get('status'))
+    shadow_ready = shadow_status == 'within_budget'
     promotion_reasons: list[str] = []
     if parity_report is None:
         promotion_reasons.append('research_candidate_pending_scheduler_v3_parity')
@@ -583,8 +653,10 @@ def _gate_report(
         promotion_reasons.append('research_candidate_pending_scheduler_v3_approval')
     elif not approval_pass:
         promotion_reasons.append('scheduler_v3_approval_failed')
-    if shadow_required and not shadow_ready:
+    if shadow_required and shadow_status in {'pending_live_evidence', 'pending', ''}:
         promotion_reasons.append('research_candidate_pending_shadow_validation')
+    elif shadow_required and not shadow_ready:
+        promotion_reasons.append('shadow_validation_failed')
     throughput_source = approval_report if approval_report is not None else parity_report
     throughput_summary = _mapping(_mapping(throughput_source).get('summary')) if throughput_source is not None else {}
     return {
@@ -626,7 +698,15 @@ def _gate_report(
             },
             {
                 'gate_id': 'gate3_shadow_validation',
-                'status': 'pass' if shadow_ready else ('pending' if shadow_required else 'skip'),
+                'status': (
+                    'pass'
+                    if shadow_ready
+                    else (
+                        'pending'
+                        if shadow_required and shadow_status in {'pending_live_evidence', 'pending', ''}
+                        else ('fail' if shadow_required else 'skip')
+                    )
+                ),
             },
         ],
         'promotion_evidence': {
@@ -634,11 +714,16 @@ def _gate_report(
                 'requested_target': promotion_target,
                 'gate_recommended_mode': promotion_target,
                 'gate_reasons': list(promotion_reasons),
+                'shadow_validation_status': shadow_status,
                 'rationale_text': 'Runtime closure replays executed, but promotion stays blocked until parity, approval, and shadow requirements are satisfied.',
             }
         },
         'uncertainty_gate_action': 'abstain',
-        'coverage_error': '0.0' if parity_pass and approval_pass else '1.0',
+        'coverage_error': (
+            '0.0'
+            if parity_pass and approval_pass and (not shadow_required or shadow_ready)
+            else '1.0'
+        ),
         'recalibration_run_id': None,
     }
 
@@ -666,8 +751,12 @@ def _candidate_state(
         reasons.append('approval_replay_not_completed')
     elif not bool(_mapping(approval_report).get('objective_met')):
         reasons.append('approval_replay_failed')
-    if bool(shadow_plan.get('required')) and _string(shadow_plan.get('status')) != 'within_budget':
-        reasons.append('shadow_validation_pending')
+    if bool(shadow_plan.get('required')):
+        shadow_status = _string(shadow_plan.get('status'))
+        if shadow_status in {'pending_live_evidence', 'pending', ''}:
+            reasons.append('shadow_validation_pending')
+        elif shadow_status != 'within_budget':
+            reasons.append('shadow_validation_failed')
     return {
         'candidateId': _string(best_candidate.get('candidate_id')),
         'runId': runner_run_id,
@@ -752,7 +841,7 @@ def _profitability_stage_manifest(
     shadow_validation_path: Path | None,
     parity_pass: bool,
     approval_pass: bool,
-    shadow_pending: bool,
+    shadow_status: str,
 ) -> dict[str, Any]:
     def _artifact(path: Path, *, stage: str, check: str) -> dict[str, Any]:
         return {
@@ -849,11 +938,18 @@ def _profitability_stage_manifest(
                 'completed_at_utc': _now_iso(),
             },
             'execution': {
-                'status': 'pass' if parity_pass and approval_pass and not shadow_pending else 'fail',
+                'status': (
+                    'pass'
+                    if parity_pass and approval_pass and shadow_status in {'within_budget', 'skipped'}
+                    else 'fail'
+                ),
                 'checks': [
                     {'check': 'gate_evaluation_present', 'status': 'pass'},
                     {'check': 'gate_matrix_approval', 'status': 'pass' if parity_pass and approval_pass else 'fail'},
-                    {'check': 'drift_gate_approval', 'status': 'pass' if not shadow_pending else 'fail'},
+                    {
+                        'check': 'drift_gate_approval',
+                        'status': 'pass' if shadow_status in {'within_budget', 'skipped'} else 'fail',
+                    },
                 ],
                 'artifacts': {
                     'gate_evaluation': _artifact(
@@ -922,7 +1018,11 @@ def _profitability_stage_manifest(
             dict.fromkeys(
                 [
                     *([] if approval_pass else ['validation_stage_incomplete']),
-                    *([] if parity_pass and approval_pass and not shadow_pending else ['execution_stage_incomplete']),
+                    *(
+                        []
+                        if parity_pass and approval_pass and shadow_status in {'within_budget', 'skipped'}
+                        else ['execution_stage_incomplete']
+                    ),
                     'governance_stage_incomplete',
                 ]
             )
@@ -1137,7 +1237,11 @@ def write_runtime_closure_bundle(
             )
             _write_json(approval_report_path, approval_report)
 
-    shadow_plan = _shadow_validation_plan(best_candidate=best_candidate, program=program)
+    shadow_plan = _shadow_validation_artifact(
+        best_candidate=best_candidate,
+        program=program,
+        execution_context=execution_context,
+    )
     _write_json(shadow_validation_path, shadow_plan)
     gate_report = _gate_report(
         runner_run_id=runner_run_id,
@@ -1190,7 +1294,7 @@ def write_runtime_closure_bundle(
         shadow_validation_path=shadow_validation_path if shadow_validation_path.exists() else None,
         parity_pass=bool(_mapping(parity_report).get('objective_met')) if parity_report is not None else False,
         approval_pass=bool(_mapping(approval_report).get('objective_met')) if approval_report is not None else False,
-        shadow_pending=bool(shadow_plan.get('required')),
+        shadow_status=_string(shadow_plan.get('status')),
     )
     _write_json(profitability_stage_manifest_path, profitability_stage_manifest)
 

--- a/services/torghut/scripts/run_strategy_autoresearch_loop.py
+++ b/services/torghut/scripts/run_strategy_autoresearch_loop.py
@@ -95,6 +95,12 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument('--chunk-minutes', type=int, default=10)
     parser.add_argument('--symbols', default='')
     parser.add_argument('--progress-log-seconds', type=int, default=30)
+    parser.add_argument(
+        '--shadow-validation-artifact',
+        type=Path,
+        default=None,
+        help='Optional path to an existing shadow-live-deviation-report-v1 artifact.',
+    )
     parser.add_argument('--train-days', type=int, default=6)
     parser.add_argument('--holdout-days', type=int, default=3)
     parser.add_argument('--full-window-start-date', default='')
@@ -613,6 +619,11 @@ def run_strategy_autoresearch_loop(args: argparse.Namespace) -> dict[str, Any]:
         chunk_minutes=max(1, int(args.chunk_minutes)),
         symbols=snapshot_symbols,
         progress_log_interval_seconds=max(1, int(args.progress_log_seconds)),
+        shadow_validation_artifact_path=(
+            args.shadow_validation_artifact.resolve()
+            if args.shadow_validation_artifact is not None
+            else None
+        ),
     )
 
     def _refresh_manifest() -> MlxSnapshotManifest:

--- a/services/torghut/tests/test_runtime_closure.py
+++ b/services/torghut/tests/test_runtime_closure.py
@@ -133,6 +133,7 @@ class TestRuntimeClosure(TestCase):
             ),
             ('AMAT', 'NVDA'),
         )
+        self.assertIsNone(context.to_payload()['shadow_validation_artifact_path'])
         self.assertEqual(
             runtime_closure._window_bounds(
                 best_candidate={},
@@ -152,6 +153,77 @@ class TestRuntimeClosure(TestCase):
             payload = runtime_closure._default_replay_executor(config)
         self.assertEqual(payload, {'status': 'ok'})
         mock_run.assert_called_once_with(config)  # type: ignore[arg-type]
+
+    def test_shadow_validation_artifact_helper_covers_invalid_schema_and_pending_status(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            invalid_json_path = root / 'invalid.json'
+            invalid_json_path.write_text('{not-json\n', encoding='utf-8')
+            bad_schema_path = root / 'bad-schema.json'
+            bad_schema_path.write_text(
+                json.dumps({'schema_version': 'wrong-schema', 'status': 'within_budget'}) + '\n',
+                encoding='utf-8',
+            )
+            pending_path = root / 'pending.json'
+            pending_path.write_text(
+                json.dumps(
+                    {
+                        'schema_version': 'shadow-live-deviation-report-v1',
+                        'status': 'pending',
+                        'order_count': 2,
+                    }
+                )
+                + '\n',
+                encoding='utf-8',
+            )
+
+            invalid_payload = runtime_closure._shadow_validation_artifact(
+                best_candidate={'candidate_id': 'cand-1'},
+                program=_program(),
+                execution_context=RuntimeClosureExecutionContext(
+                    strategy_configmap_path=root / 'strategies.yaml',
+                    clickhouse_http_url='http://example.invalid:8123',
+                    clickhouse_username='torghut',
+                    clickhouse_password='secret',
+                    start_equity=Decimal('31590.02'),
+                    chunk_minutes=10,
+                    shadow_validation_artifact_path=invalid_json_path,
+                ),
+            )
+            self.assertEqual(invalid_payload['status'], 'invalid_artifact')
+            self.assertIn('shadow_validation_artifact_invalid_json', invalid_payload['reasons'])
+
+            bad_schema_payload = runtime_closure._shadow_validation_artifact(
+                best_candidate={'candidate_id': 'cand-1'},
+                program=_program(),
+                execution_context=RuntimeClosureExecutionContext(
+                    strategy_configmap_path=root / 'strategies.yaml',
+                    clickhouse_http_url='http://example.invalid:8123',
+                    clickhouse_username='torghut',
+                    clickhouse_password='secret',
+                    start_equity=Decimal('31590.02'),
+                    chunk_minutes=10,
+                    shadow_validation_artifact_path=bad_schema_path,
+                ),
+            )
+            self.assertEqual(bad_schema_payload['status'], 'invalid_artifact')
+            self.assertIn('shadow_validation_schema_version_invalid', bad_schema_payload['reasons'])
+
+            pending_payload = runtime_closure._shadow_validation_artifact(
+                best_candidate={'candidate_id': 'cand-1'},
+                program=_program(),
+                execution_context=RuntimeClosureExecutionContext(
+                    strategy_configmap_path=root / 'strategies.yaml',
+                    clickhouse_http_url='http://example.invalid:8123',
+                    clickhouse_username='torghut',
+                    clickhouse_password='secret',
+                    start_equity=Decimal('31590.02'),
+                    chunk_minutes=10,
+                    shadow_validation_artifact_path=pending_path,
+                ),
+            )
+            self.assertEqual(pending_payload['status'], 'pending')
+            self.assertIn('shadow_validation_pending', pending_payload['reasons'])
 
     def test_materialize_candidate_configmap_rejects_invalid_inputs(self) -> None:
         with TemporaryDirectory() as tmpdir:
@@ -696,6 +768,271 @@ data:
 
             self.assertEqual(summary.status, 'ready_for_promotion_review')
             self.assertEqual(summary.next_required_steps, ('promotion_review',))
+
+    def test_write_runtime_closure_bundle_consumes_within_budget_shadow_artifact(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            run_root = Path(tmpdir)
+            manifest = build_mlx_snapshot_manifest(
+                runner_run_id='run-1',
+                program=_program(),
+                symbols='AMAT,NVDA',
+                train_days=6,
+                holdout_days=2,
+                full_window_start_date='2026-03-20',
+                full_window_end_date='2026-04-09',
+            )
+            configmap_path = run_root / 'strategy-configmap.yaml'
+            configmap_path.write_text(
+                """
+apiVersion: v1
+kind: ConfigMap
+data:
+  strategies.yaml: |
+    strategies:
+      - name: breakout-continuation-long-v1
+        enabled: true
+        family: breakout_continuation_consistent
+        params:
+          max_entries_per_session: '1'
+        universe_symbols:
+          - AMAT
+          - NVDA
+""".strip()
+                + "\n",
+                encoding='utf-8',
+            )
+            shadow_artifact_path = run_root / 'shadow-live-deviation-report.json'
+            shadow_artifact_path.write_text(
+                json.dumps(
+                    {
+                        'schema_version': 'shadow-live-deviation-report-v1',
+                        'status': 'within_budget',
+                        'order_count': 12,
+                        'coverage_error': '0.02',
+                    }
+                )
+                + "\n",
+                encoding='utf-8',
+            )
+            program = StrategyAutoresearchProgram(
+                **{
+                    **_program().__dict__,
+                    'objective': StrategyObjective(
+                        target_net_pnl_per_day=Decimal('500'),
+                        min_active_day_ratio=Decimal('1.0'),
+                        min_positive_day_ratio=Decimal('0.6'),
+                        min_daily_notional=Decimal('300000'),
+                        max_best_day_share=Decimal('0.3'),
+                        max_worst_day_loss=Decimal('350'),
+                        max_drawdown=Decimal('900'),
+                        require_every_day_active=True,
+                        min_regime_slice_pass_rate=Decimal('0'),
+                        stop_when_objective_met=True,
+                    ),
+                    'runtime_closure_policy': RuntimeClosurePolicy(
+                        enabled=True,
+                        execute_parity_replay=True,
+                        execute_approval_replay=True,
+                        parity_window='full_window',
+                        approval_window='holdout',
+                        shadow_validation_mode='require_live_evidence',
+                        promotion_target='shadow',
+                    ),
+                }
+            )
+            best_candidate = {
+                'candidate_id': 'cand-1',
+                'family_template_id': 'breakout_reclaim_v2',
+                'runtime_family': 'breakout_continuation_consistent',
+                'runtime_strategy_name': 'breakout-continuation-long-v1',
+                'status': 'keep',
+                'candidate_params': {'max_entries_per_session': '1'},
+                'candidate_strategy_overrides': {'universe_symbols': ['AMAT', 'NVDA']},
+                'disable_other_strategies': True,
+                'holdout_start_date': '2026-04-08',
+                'holdout_end_date': '2026-04-09',
+                'full_window_start_date': '2026-03-20',
+                'full_window_end_date': '2026-04-09',
+                'normalization_regime': 'price_scaled',
+            }
+            replay_payload = {
+                'start_date': '2026-03-20',
+                'end_date': '2026-04-09',
+                'net_pnl': '6000',
+                'decision_count': 12,
+                'filled_count': 9,
+                'wins': 7,
+                'losses': 2,
+                'daily': {
+                    '2026-03-20': {'net_pnl': '1000', 'filled_count': 1, 'filled_notional': '300000'},
+                    '2026-03-21': {'net_pnl': '800', 'filled_count': 1, 'filled_notional': '300000'},
+                    '2026-03-24': {'net_pnl': '700', 'filled_count': 1, 'filled_notional': '300000'},
+                    '2026-03-25': {'net_pnl': '900', 'filled_count': 1, 'filled_notional': '300000'},
+                    '2026-03-26': {'net_pnl': '1100', 'filled_count': 1, 'filled_notional': '300000'},
+                    '2026-03-27': {'net_pnl': '600', 'filled_count': 1, 'filled_notional': '300000'},
+                    '2026-04-08': {'net_pnl': '500', 'filled_count': 1, 'filled_notional': '300000'},
+                    '2026-04-09': {'net_pnl': '400', 'filled_count': 1, 'filled_notional': '300000'},
+                },
+            }
+
+            def _fake_replay_executor(_: object) -> dict[str, object]:
+                return dict(replay_payload)
+
+            summary = write_runtime_closure_bundle(
+                run_root=run_root,
+                runner_run_id='run-1',
+                program=program,
+                best_candidate=best_candidate,
+                manifest=manifest,
+                execution_context=RuntimeClosureExecutionContext(
+                    strategy_configmap_path=configmap_path,
+                    clickhouse_http_url='http://example.invalid:8123',
+                    clickhouse_username='torghut',
+                    clickhouse_password='secret',
+                    start_equity=Decimal('31590.02'),
+                    chunk_minutes=10,
+                    symbols=('AMAT', 'NVDA'),
+                    progress_log_interval_seconds=30,
+                    shadow_validation_artifact_path=shadow_artifact_path,
+                ),
+                replay_executor=_fake_replay_executor,
+            )
+
+            self.assertEqual(summary.status, 'ready_for_promotion_review')
+            shadow_payload = json.loads(Path(summary.shadow_validation_path).read_text(encoding='utf-8'))
+            self.assertEqual(shadow_payload['status'], 'within_budget')
+            self.assertTrue(shadow_payload['evidence_loaded'])
+            self.assertEqual(shadow_payload['source_artifact_path'], str(shadow_artifact_path))
+
+    def test_write_runtime_closure_bundle_fails_when_shadow_artifact_is_out_of_budget(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            run_root = Path(tmpdir)
+            manifest = build_mlx_snapshot_manifest(
+                runner_run_id='run-1',
+                program=_program(),
+                symbols='AMAT,NVDA',
+                train_days=6,
+                holdout_days=2,
+                full_window_start_date='2026-03-20',
+                full_window_end_date='2026-04-09',
+            )
+            configmap_path = run_root / 'strategy-configmap.yaml'
+            configmap_path.write_text(
+                """
+apiVersion: v1
+kind: ConfigMap
+data:
+  strategies.yaml: |
+    strategies:
+      - name: breakout-continuation-long-v1
+        enabled: true
+        family: breakout_continuation_consistent
+        params:
+          max_entries_per_session: '1'
+""".strip()
+                + "\n",
+                encoding='utf-8',
+            )
+            shadow_artifact_path = run_root / 'shadow-live-deviation-report.json'
+            shadow_artifact_path.write_text(
+                json.dumps(
+                    {
+                        'schema_version': 'shadow-live-deviation-report-v1',
+                        'status': 'out_of_budget',
+                        'order_count': 12,
+                        'coverage_error': '0.09',
+                    }
+                )
+                + "\n",
+                encoding='utf-8',
+            )
+            program = StrategyAutoresearchProgram(
+                **{
+                    **_program().__dict__,
+                    'objective': StrategyObjective(
+                        target_net_pnl_per_day=Decimal('500'),
+                        min_active_day_ratio=Decimal('1.0'),
+                        min_positive_day_ratio=Decimal('0.6'),
+                        min_daily_notional=Decimal('300000'),
+                        max_best_day_share=Decimal('0.3'),
+                        max_worst_day_loss=Decimal('350'),
+                        max_drawdown=Decimal('900'),
+                        require_every_day_active=True,
+                        min_regime_slice_pass_rate=Decimal('0'),
+                        stop_when_objective_met=True,
+                    ),
+                    'runtime_closure_policy': RuntimeClosurePolicy(
+                        enabled=True,
+                        execute_parity_replay=True,
+                        execute_approval_replay=True,
+                        parity_window='full_window',
+                        approval_window='holdout',
+                        shadow_validation_mode='require_live_evidence',
+                        promotion_target='shadow',
+                    ),
+                }
+            )
+            best_candidate = {
+                'candidate_id': 'cand-1',
+                'family_template_id': 'breakout_reclaim_v2',
+                'runtime_family': 'breakout_continuation_consistent',
+                'runtime_strategy_name': 'breakout-continuation-long-v1',
+                'status': 'keep',
+                'candidate_params': {'max_entries_per_session': '1'},
+                'candidate_strategy_overrides': {},
+                'disable_other_strategies': True,
+                'holdout_start_date': '2026-04-08',
+                'holdout_end_date': '2026-04-09',
+                'full_window_start_date': '2026-03-20',
+                'full_window_end_date': '2026-04-09',
+                'normalization_regime': 'price_scaled',
+            }
+            replay_payload = {
+                'start_date': '2026-03-20',
+                'end_date': '2026-04-09',
+                'net_pnl': '6000',
+                'decision_count': 12,
+                'filled_count': 9,
+                'wins': 7,
+                'losses': 2,
+                'daily': {
+                    '2026-03-20': {'net_pnl': '1000', 'filled_count': 1, 'filled_notional': '300000'},
+                    '2026-03-21': {'net_pnl': '800', 'filled_count': 1, 'filled_notional': '300000'},
+                    '2026-03-24': {'net_pnl': '700', 'filled_count': 1, 'filled_notional': '300000'},
+                    '2026-03-25': {'net_pnl': '900', 'filled_count': 1, 'filled_notional': '300000'},
+                    '2026-03-26': {'net_pnl': '1100', 'filled_count': 1, 'filled_notional': '300000'},
+                    '2026-03-27': {'net_pnl': '600', 'filled_count': 1, 'filled_notional': '300000'},
+                    '2026-04-08': {'net_pnl': '500', 'filled_count': 1, 'filled_notional': '300000'},
+                    '2026-04-09': {'net_pnl': '400', 'filled_count': 1, 'filled_notional': '300000'},
+                },
+            }
+
+            def _fake_replay_executor(_: object) -> dict[str, object]:
+                return dict(replay_payload)
+
+            summary = write_runtime_closure_bundle(
+                run_root=run_root,
+                runner_run_id='run-1',
+                program=program,
+                best_candidate=best_candidate,
+                manifest=manifest,
+                execution_context=RuntimeClosureExecutionContext(
+                    strategy_configmap_path=configmap_path,
+                    clickhouse_http_url='http://example.invalid:8123',
+                    clickhouse_username='torghut',
+                    clickhouse_password='secret',
+                    start_equity=Decimal('31590.02'),
+                    chunk_minutes=10,
+                    symbols=('AMAT', 'NVDA'),
+                    shadow_validation_artifact_path=shadow_artifact_path,
+                ),
+                replay_executor=_fake_replay_executor,
+            )
+
+            self.assertEqual(summary.status, 'shadow_validation_failed')
+            shadow_payload = json.loads(Path(summary.shadow_validation_path).read_text(encoding='utf-8'))
+            self.assertEqual(shadow_payload['status'], 'out_of_budget')
+            self.assertIn('shadow_validation_status_not_within_budget', shadow_payload['reasons'])
 
     def test_write_runtime_closure_bundle_handles_missing_best_candidate(self) -> None:
         with TemporaryDirectory() as tmpdir:

--- a/services/torghut/tests/test_strategy_autoresearch.py
+++ b/services/torghut/tests/test_strategy_autoresearch.py
@@ -103,6 +103,7 @@ class TestStrategyAutoresearch(TestCase):
             args.strategy_configmap,
             runner._REPO_ROOT / 'argocd/applications/torghut/strategy-configmap.yaml',
         )
+        self.assertIsNone(args.shadow_validation_artifact)
 
     def test_program_defaults_include_mlx_contract(self) -> None:
         with TemporaryDirectory() as tmpdir:
@@ -844,6 +845,7 @@ class TestStrategyAutoresearch(TestCase):
                 chunk_minutes=10,
                 symbols='',
                 progress_log_seconds=30,
+                shadow_validation_artifact=None,
                 train_days=6,
                 holdout_days=3,
                 full_window_start_date='',
@@ -901,6 +903,9 @@ class TestStrategyAutoresearch(TestCase):
             self.assertEqual(summary['runtime_closure']['status'], 'pending_runtime_parity')
             self.assertFalse(summary['runtime_closure']['promotion_prerequisites']['allowed'])
             self.assertFalse(summary['runtime_closure']['rollback_readiness']['ready'])
+            mlx_notebook = (run_root / 'mlx-autoresearch-diagnostics.ipynb').read_text(encoding='utf-8')
+            self.assertIn('Runtime closure evidence', mlx_notebook)
+            self.assertIn('RUNTIME_SHADOW_VALIDATION', mlx_notebook)
             self.assertTrue((run_root / 'runtime-closure' / 'summary.json').exists())
             self.assertTrue((run_root / 'runtime-closure' / 'promotion' / 'promotion-prerequisites.json').exists())
             manifest = json.loads((run_root / 'mlx-snapshot-manifest.json').read_text(encoding='utf-8'))
@@ -1063,6 +1068,7 @@ class TestStrategyAutoresearch(TestCase):
                 chunk_minutes=10,
                 symbols='',
                 progress_log_seconds=30,
+                shadow_validation_artifact=None,
                 train_days=6,
                 holdout_days=3,
                 full_window_start_date='',
@@ -1198,6 +1204,7 @@ class TestStrategyAutoresearch(TestCase):
                 chunk_minutes=10,
                 symbols='',
                 progress_log_seconds=30,
+                shadow_validation_artifact=None,
                 train_days=6,
                 holdout_days=3,
                 full_window_start_date='',
@@ -1264,6 +1271,7 @@ class TestStrategyAutoresearch(TestCase):
                 chunk_minutes=10,
                 symbols='',
                 progress_log_seconds=30,
+                shadow_validation_artifact=None,
                 train_days=6,
                 holdout_days=3,
                 full_window_start_date='',
@@ -1373,6 +1381,7 @@ class TestStrategyAutoresearch(TestCase):
                 chunk_minutes=10,
                 symbols='',
                 progress_log_seconds=30,
+                shadow_validation_artifact=None,
                 train_days=6,
                 holdout_days=3,
                 full_window_start_date='',
@@ -1431,6 +1440,7 @@ class TestStrategyAutoresearch(TestCase):
                 chunk_minutes=10,
                 symbols='',
                 progress_log_seconds=30,
+                shadow_validation_artifact=None,
                 train_days=6,
                 holdout_days=3,
                 full_window_start_date='2026-03-20',
@@ -1480,6 +1490,7 @@ class TestStrategyAutoresearch(TestCase):
                 chunk_minutes=10,
                 symbols='',
                 progress_log_seconds=30,
+                shadow_validation_artifact=None,
                 train_days=6,
                 holdout_days=3,
                 full_window_start_date='',


### PR DESCRIPTION
## Summary

- wire optional shadow-live-deviation evidence into the MLX runtime-closure bundle instead of always emitting a pending-only shadow plan
- propagate shadow evidence status through runtime closure summaries, gate reports, candidate state, and profitability stage artifacts
- expose runtime-closure and shadow-evidence details in the MLX diagnostics notebook and thread the optional artifact path through the autoresearch loop CLI
- add targeted runtime-closure and autoresearch regressions covering within-budget, invalid, pending, and failed shadow evidence branches

## Related Issues

None

## Testing

- `cd /Users/gregkonush/.codex/worktrees/dbbf/lab/services/torghut && /opt/homebrew/bin/mise exec uv -- uv run --frozen pytest tests/test_runtime_closure.py tests/test_strategy_autoresearch.py tests/test_mlx_autoresearch.py -q`
- `cd /Users/gregkonush/.codex/worktrees/dbbf/lab/services/torghut && /opt/homebrew/bin/mise exec uv -- uv run --frozen ruff check app/trading/discovery/runtime_closure.py app/trading/discovery/autoresearch_notebooks.py scripts/run_strategy_autoresearch_loop.py tests/test_runtime_closure.py tests/test_strategy_autoresearch.py`
- `cd /Users/gregkonush/.codex/worktrees/dbbf/lab/services/torghut && /opt/homebrew/bin/mise exec uv -- uv run --frozen pyright --project pyrightconfig.json`
- `cd /Users/gregkonush/.codex/worktrees/dbbf/lab/services/torghut && /opt/homebrew/bin/mise exec uv -- uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd /Users/gregkonush/.codex/worktrees/dbbf/lab/services/torghut && /opt/homebrew/bin/mise exec uv -- uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd /Users/gregkonush/.codex/worktrees/dbbf/lab/services/torghut && /opt/homebrew/bin/mise exec uv -- uv run --frozen python -m pytest --cov=app --cov=scripts --cov-report=xml --cov-fail-under=0 tests/test_runtime_closure.py tests/test_strategy_autoresearch.py tests/test_mlx_autoresearch.py -q`
- `cd /Users/gregkonush/.codex/worktrees/dbbf/lab/services/torghut && /opt/homebrew/bin/mise exec uv -- uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90 --base-ref origin/main`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
