### PR TITLE
chore(jangar): promote image 2a76ed34

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 33de6185
-  digest: sha256:b343d3f01c2d70f1bd1b78dd0482f7b486d14ae47471448f52ed648e5fbe0003
+  tag: 2a76ed34
+  digest: sha256:d86be27465e66dd35a8a6835b5e9c484f94c162726a21ff6650b83c14a2bc671
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 33de6185
-    digest: sha256:67966400c0203a83d1279b2beb6a0365a37d612472921199e2e9de00a17ecc6d
+    tag: 2a76ed34
+    digest: sha256:510acc602ed0f0433ace28946e5ea4c718cbcb5f3f727f96adbc729dd5055c44
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 33de6185
-    digest: sha256:b343d3f01c2d70f1bd1b78dd0482f7b486d14ae47471448f52ed648e5fbe0003
+    tag: 2a76ed34
+    digest: sha256:d86be27465e66dd35a8a6835b5e9c484f94c162726a21ff6650b83c14a2bc671
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-04-11T05:20:15Z
+    deploy.knative.dev/rollout: 2026-04-11T06:36:20Z
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/name: jangar-worker
     app.kubernetes.io/part-of: lab
   annotations:
-    kubectl.kubernetes.io/restartedAt: 2026-04-11T05:20:15Z
+    kubectl.kubernetes.io/restartedAt: 2026-04-11T06:36:20Z
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -60,5 +60,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: 33de6185
-    digest: sha256:b343d3f01c2d70f1bd1b78dd0482f7b486d14ae47471448f52ed648e5fbe0003
+    newTag: 2a76ed34
+    digest: sha256:d86be27465e66dd35a8a6835b5e9c484f94c162726a21ff6650b83c14a2bc671


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `2a76ed34b207fa94f5baa875607227a133c92317`
- Image tag: `2a76ed34`
- Image digest: `sha256:d86be27465e66dd35a8a6835b5e9c484f94c162726a21ff6650b83c14a2bc671`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`