### PR TITLE
feat(torghut): tighten mlx autoresearch loop progress

### DIFF
--- a/services/torghut/app/trading/discovery/autoresearch.py
+++ b/services/torghut/app/trading/discovery/autoresearch.py
@@ -179,11 +179,13 @@ class ProposalModelPolicy:
 class ReplayBudget:
     max_candidates_per_round: int
     exploration_slots: int
+    max_candidates_per_frontier_run: int
 
     def to_payload(self) -> dict[str, Any]:
         return {
             'max_candidates_per_round': self.max_candidates_per_round,
             'exploration_slots': self.exploration_slots,
+            'max_candidates_per_frontier_run': self.max_candidates_per_frontier_run,
         }
 
 
@@ -475,6 +477,10 @@ def load_strategy_autoresearch_program(
     replay_budget = ReplayBudget(
         max_candidates_per_round=max(1, int(replay_budget_payload.get('max_candidates_per_round', 8))),
         exploration_slots=max(0, int(replay_budget_payload.get('exploration_slots', 1))),
+        max_candidates_per_frontier_run=max(
+            0,
+            int(replay_budget_payload.get('max_candidates_per_frontier_run', 96)),
+        ),
     )
     runtime_closure_policy = _load_runtime_closure_policy(_mapping(payload.get('runtime_closure_policy')))
     forbidden_mutations = _string_list(

--- a/services/torghut/app/trading/discovery/autoresearch_notebooks.py
+++ b/services/torghut/app/trading/discovery/autoresearch_notebooks.py
@@ -78,6 +78,7 @@ except ModuleNotFoundError:
 RUN_ROOT = Path('{resolved}')
 SUMMARY = json.loads((RUN_ROOT / 'summary.json').read_text(encoding='utf-8'))
 RESEARCH = json.loads((RUN_ROOT / 'research_dossier.json').read_text(encoding='utf-8'))
+LIVE_PROGRESS = SUMMARY.get('live_progress') or {{}}
 HISTORY = [
     json.loads(line)
     for line in (RUN_ROOT / 'history.jsonl').read_text(encoding='utf-8').splitlines()
@@ -210,6 +211,27 @@ _display_rows(objective_rows, columns=['metric', 'target'])
 best = SUMMARY.get('best_candidate') or {}
 display(Markdown('## Best Candidate Summary'))
 _display_rows([best])
+
+if LIVE_PROGRESS:
+    display(Markdown('## Live Progress'))
+    _display_rows(
+        [
+            {
+                'frontier_runs_started': LIVE_PROGRESS.get('frontier_runs_started'),
+                'pending_work_items': LIVE_PROGRESS.get('pending_work_items'),
+                'history_row_count': LIVE_PROGRESS.get('history_row_count'),
+                'descriptor_count': LIVE_PROGRESS.get('descriptor_count'),
+                'proposal_score_count': LIVE_PROGRESS.get('proposal_score_count'),
+                'experiment_result_count': LIVE_PROGRESS.get('experiment_result_count'),
+            }
+        ]
+    )
+    if LIVE_PROGRESS.get('selected_for_replay'):
+        display(Markdown('### Selected for replay'))
+        _display_rows([LIVE_PROGRESS.get('selected_for_replay') or {}])
+    if LIVE_PROGRESS.get('best_experiment_candidate'):
+        display(Markdown('### Best provisional experiment snapshot'))
+        _display_rows([LIVE_PROGRESS.get('best_experiment_candidate') or {}])
 
 promotion = SUMMARY.get('promotion_readiness') or {}
 if promotion:
@@ -477,6 +499,7 @@ except ModuleNotFoundError:
 RUN_ROOT = Path('{resolved}')
 SUMMARY = json.loads((RUN_ROOT / 'summary.json').read_text(encoding='utf-8'))
 MANIFEST = json.loads((RUN_ROOT / 'mlx-snapshot-manifest.json').read_text(encoding='utf-8'))
+LIVE_PROGRESS = SUMMARY.get('live_progress') or {{}}
 DESCRIPTORS = [
     json.loads(line)
     for line in (RUN_ROOT / 'mlx-candidate-descriptors.jsonl').read_text(encoding='utf-8').splitlines()
@@ -611,6 +634,9 @@ _display_rows(
             'train_days': MANIFEST.get('train_days'),
             'holdout_days': MANIFEST.get('holdout_days'),
             'full_window_days': MANIFEST.get('full_window_days'),
+            'pending_work_items': LIVE_PROGRESS.get('pending_work_items'),
+            'proposal_score_count': LIVE_PROGRESS.get('proposal_score_count'),
+            'experiment_result_count': LIVE_PROGRESS.get('experiment_result_count'),
         }
     ]
 )
@@ -661,6 +687,9 @@ _display_rows(
     if selected:
         display(Markdown('### Selected proposal batch'))
         _display_rows([{column: row.get(column) for column in selected_columns} for row in selected], columns=selected_columns)
+    if LIVE_PROGRESS.get('selected_for_replay'):
+        display(Markdown('### Current replay selection'))
+        _display_rows([LIVE_PROGRESS.get('selected_for_replay') or {}])
 """
         ),
         _code_cell(

--- a/services/torghut/config/trading/research-programs/strict-daily-profit-autoresearch-v1.yaml
+++ b/services/torghut/config/trading/research-programs/strict-daily-profit-autoresearch-v1.yaml
@@ -24,6 +24,7 @@ proposal_model_policy:
 replay_budget:
   max_candidates_per_round: 8
   exploration_slots: 1
+  max_candidates_per_frontier_run: 96
 runtime_closure_policy:
   enabled: true
   execute_parity_replay: true

--- a/services/torghut/scripts/run_strategy_autoresearch_loop.py
+++ b/services/torghut/scripts/run_strategy_autoresearch_loop.py
@@ -188,6 +188,21 @@ def _keep_candidate_limit(*, family_plan: FamilyAutoresearchPlan, replay_budget_
     return max(1, min(family_plan.keep_top_candidates, replay_budget_max_candidates_per_round))
 
 
+def _frontier_candidate_budget(
+    *,
+    family_plan: FamilyAutoresearchPlan,
+    replay_budget_max_candidates_per_frontier_run: int,
+) -> int:
+    if replay_budget_max_candidates_per_frontier_run <= 0:
+        return 0
+    minimum_budget = max(
+        family_plan.frontier_top_n,
+        family_plan.keep_top_candidates,
+        family_plan.symbol_prune_candidates + 1,
+    )
+    return max(minimum_budget, replay_budget_max_candidates_per_frontier_run)
+
+
 def _work_item_candidate_id(work_item: WorkItem) -> str:
     return _slug(
         f'{work_item.family_plan.family_template.family_id}-iter-{work_item.iteration}-{work_item.mutation_label}'
@@ -205,11 +220,16 @@ def _promotion_readiness_payload(*, family_plan: FamilyAutoresearchPlan) -> dict
 def _frontier_args(
     *,
     args: argparse.Namespace,
+    program: StrategyAutoresearchProgram,
     family_plan: FamilyAutoresearchPlan,
     sweep_config_path: Path,
     json_output_path: Path,
 ) -> argparse.Namespace:
     top_n = max(family_plan.frontier_top_n, family_plan.keep_top_candidates)
+    max_candidates_to_evaluate = _frontier_candidate_budget(
+        family_plan=family_plan,
+        replay_budget_max_candidates_per_frontier_run=int(program.replay_budget.max_candidates_per_frontier_run),
+    )
     return argparse.Namespace(
         strategy_configmap=args.strategy_configmap.resolve(),
         sweep_config=sweep_config_path,
@@ -229,6 +249,7 @@ def _frontier_args(
         family_template_dir=args.family_template_dir.resolve(),
         prefetch_full_window_rows=bool(args.prefetch_full_window_rows),
         top_n=top_n,
+        max_candidates_to_evaluate=max_candidates_to_evaluate,
         json_output=json_output_path,
         symbol_prune_iterations=family_plan.symbol_prune_iterations,
         symbol_prune_candidates=family_plan.symbol_prune_candidates,
@@ -486,6 +507,107 @@ def _proposal_diagnostics(
     )
 
 
+def _experiment_snapshot_from_payload(
+    *,
+    payload: Mapping[str, Any],
+    experiment: str,
+    result_path: Path,
+) -> dict[str, Any] | None:
+    top_candidates = cast(list[dict[str, Any]], payload.get('top') or [])
+    if not top_candidates:
+        return None
+    top_row = _mapping(top_candidates[0])
+    scorecard = _mapping(top_row.get('objective_scorecard'))
+    progress = _mapping(payload.get('progress'))
+    return {
+        'experiment': experiment,
+        'path': str(result_path),
+        'status': _string(payload.get('status')),
+        'candidate_count': int(payload.get('candidate_count') or 0),
+        'evaluated_candidates': int(progress.get('evaluated_candidates') or 0),
+        'pending_candidates': int(progress.get('pending_candidates') or 0),
+        'top_candidate_id': _string(top_row.get('candidate_id')),
+        'top_net_pnl_per_day': _string(scorecard.get('net_pnl_per_day')),
+        'top_active_day_ratio': _string(scorecard.get('active_day_ratio')),
+        'top_best_day_share': _string(scorecard.get('best_day_share')),
+        'top_hard_vetoes': list(cast(list[str], top_row.get('hard_vetoes') or [])),
+    }
+
+
+def _load_experiment_snapshots(run_root: Path) -> list[dict[str, Any]]:
+    snapshots: list[dict[str, Any]] = []
+    for result_path in sorted((run_root / 'experiments').glob('*/result.json')):
+        try:
+            payload = json.loads(result_path.read_text(encoding='utf-8'))
+        except (FileNotFoundError, json.JSONDecodeError):
+            continue
+        if not isinstance(payload, Mapping):
+            continue
+        snapshot = _experiment_snapshot_from_payload(
+            payload=cast(Mapping[str, Any], payload),
+            experiment=result_path.parent.name,
+            result_path=result_path,
+        )
+        if snapshot is not None:
+            snapshots.append(snapshot)
+    return snapshots
+
+
+def _best_experiment_snapshot(snapshots: list[dict[str, Any]]) -> dict[str, Any] | None:
+    if not snapshots:
+        return None
+    return max(
+        snapshots,
+        key=lambda item: (
+            Decimal(_string(item.get('top_net_pnl_per_day')) or '0'),
+            Decimal(_string(item.get('top_active_day_ratio')) or '0'),
+            -Decimal(_string(item.get('top_best_day_share')) or '0'),
+            -int(item.get('pending_candidates') or 0),
+        ),
+    )
+
+
+def _live_progress_payload(
+    *,
+    run_root: Path,
+    frontier_runs: int,
+    worklist: list[WorkItem],
+    history: list[dict[str, Any]],
+    descriptors: list[MlxCandidateDescriptor],
+    proposal_scores: list[ProposalScore],
+    selected_for_replay: ProposalSelectionEntry | None = None,
+    selected_descriptor: MlxCandidateDescriptor | None = None,
+) -> dict[str, Any]:
+    snapshots = _load_experiment_snapshots(run_root)
+    payload: dict[str, Any] = {
+        'frontier_runs_started': frontier_runs,
+        'pending_work_items': len(worklist),
+        'history_row_count': len(history),
+        'descriptor_count': len(descriptors),
+        'proposal_score_count': len(proposal_scores),
+        'experiment_result_count': len(snapshots),
+        'latest_experiment': snapshots[-1] if snapshots else None,
+        'best_experiment_candidate': _best_experiment_snapshot(snapshots),
+    }
+    if selected_for_replay is not None:
+        payload['selected_for_replay'] = {
+            'candidate_id': selected_for_replay.candidate_id,
+            'descriptor_id': selected_for_replay.descriptor_id,
+            'selection_reason': selected_for_replay.selection_reason,
+            'score': selected_for_replay.score,
+            'rank': selected_for_replay.rank,
+            'family_template_id': selected_for_replay.family_template_id,
+            'side_policy': selected_for_replay.side_policy,
+            'entry_window_start_minute': (
+                selected_descriptor.entry_window_start_minute if selected_descriptor is not None else 0
+            ),
+            'entry_window_end_minute': (
+                selected_descriptor.entry_window_end_minute if selected_descriptor is not None else 0
+            ),
+        }
+    return payload
+
+
 def _persist_run_outputs(
     *,
     run_root: Path,
@@ -499,7 +621,10 @@ def _persist_run_outputs(
     manifest: MlxSnapshotManifest,
     descriptors: list[MlxCandidateDescriptor],
     proposal_scores: list[ProposalScore],
+    worklist: list[WorkItem],
     status: str,
+    selected_for_replay: ProposalSelectionEntry | None = None,
+    selected_descriptor: MlxCandidateDescriptor | None = None,
     closure_execution_context: RuntimeClosureExecutionContext | None = None,
     error: Mapping[str, str] | None = None,
 ) -> dict[str, Any]:
@@ -545,6 +670,16 @@ def _persist_run_outputs(
         'mlx_exports': dict(mlx_exports),
         'notebooks': [str(path) for path in notebook_paths],
         'best_candidate': _best_history_record(history),
+        'live_progress': _live_progress_payload(
+            run_root=run_root,
+            frontier_runs=frontier_runs,
+            worklist=worklist,
+            history=history,
+            descriptors=descriptors,
+            proposal_scores=proposal_scores,
+            selected_for_replay=selected_for_replay,
+            selected_descriptor=selected_descriptor,
+        ),
     }
     best_candidate = cast(dict[str, Any] | None, summary['best_candidate'])
     summary['promotion_readiness'] = summary_promotion_readiness(best_candidate)
@@ -663,6 +798,7 @@ def run_strategy_autoresearch_loop(args: argparse.Namespace) -> dict[str, Any]:
         manifest=manifest,
         descriptors=descriptors,
         proposal_scores=proposal_scores,
+        worklist=worklist,
         status='running',
         closure_execution_context=closure_execution_context,
     )
@@ -687,7 +823,9 @@ def run_strategy_autoresearch_loop(args: argparse.Namespace) -> dict[str, Any]:
         manifest=manifest,
         descriptors=descriptors,
         proposal_scores=proposal_scores,
+        worklist=worklist,
         status='running',
+        closure_execution_context=closure_execution_context,
     )
     try:
         while worklist:
@@ -735,9 +873,42 @@ def run_strategy_autoresearch_loop(args: argparse.Namespace) -> dict[str, Any]:
                 encoding='utf-8',
             )
             result_path = experiment_root / 'result.json'
+            selected_score = score_by_candidate.get(current_descriptor.candidate_id)
+            selected_for_replay = (
+                ProposalSelectionEntry(
+                    candidate_id=current_descriptor.candidate_id,
+                    descriptor_id=current_descriptor.descriptor_id,
+                    selection_reason='frontier_seed',
+                    score=selected_score.score,
+                    rank=selected_score.rank,
+                    family_template_id=current_descriptor.family_template_id,
+                    side_policy=current_descriptor.side_policy,
+                )
+                if selected_score is not None
+                else None
+            )
+            _persist_run_outputs(
+                run_root=run_root,
+                program=program,
+                program_payload=program.to_payload(),
+                runner_run_id=runner_run_id,
+                program_id=program.program_id,
+                frontier_runs=frontier_runs,
+                objective_met=objective_met,
+                history=history,
+                manifest=manifest,
+                descriptors=descriptors,
+                proposal_scores=proposal_scores,
+                worklist=worklist,
+                status='running',
+                selected_for_replay=selected_for_replay,
+                selected_descriptor=current_descriptor,
+                closure_execution_context=closure_execution_context,
+            )
             frontier_payload = run_consistent_profitability_frontier(
                 _frontier_args(
                     args=args,
+                    program=program,
                     family_plan=current.family_plan,
                     sweep_config_path=sweep_config_path,
                     json_output_path=result_path,
@@ -901,6 +1072,7 @@ def run_strategy_autoresearch_loop(args: argparse.Namespace) -> dict[str, Any]:
                 manifest=manifest,
                 descriptors=descriptors,
                 proposal_scores=proposal_scores,
+                worklist=worklist,
                 status='running',
                 closure_execution_context=closure_execution_context,
             )
@@ -919,6 +1091,7 @@ def run_strategy_autoresearch_loop(args: argparse.Namespace) -> dict[str, Any]:
             manifest=manifest,
             descriptors=descriptors,
             proposal_scores=proposal_scores,
+            worklist=worklist,
             status='error',
             closure_execution_context=closure_execution_context,
             error={
@@ -939,6 +1112,7 @@ def run_strategy_autoresearch_loop(args: argparse.Namespace) -> dict[str, Any]:
         manifest=manifest,
         descriptors=descriptors,
         proposal_scores=proposal_scores,
+        worklist=worklist,
         status='ok',
         closure_execution_context=closure_execution_context,
     )

--- a/services/torghut/scripts/search_consistent_profitability_frontier.py
+++ b/services/torghut/scripts/search_consistent_profitability_frontier.py
@@ -166,6 +166,12 @@ def _parse_args() -> argparse.Namespace:
         help='Fetch full-window replay rows once and reuse them for every candidate replay.',
     )
     parser.add_argument('--top-n', type=int, default=10)
+    parser.add_argument(
+        '--max-candidates-to-evaluate',
+        type=int,
+        default=0,
+        help='Optional cap on evaluated candidates inside one frontier run. 0 means unbounded.',
+    )
     parser.add_argument('--json-output', type=Path)
     parser.add_argument(
         '--symbol-prune-iterations',
@@ -1022,7 +1028,11 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
         cache_context: contextlib.AbstractContextManager[None]
         cache_context = _cached_signal_rows_patch(cached_rows) if cached_rows is not None else contextlib.nullcontext()
         with cache_context:
+            budget_exhausted = False
             while worklist:
+                if int(args.max_candidates_to_evaluate) > 0 and len(scored) >= int(args.max_candidates_to_evaluate):
+                    budget_exhausted = True
+                    break
                 params_candidate, override_candidate, prune_iteration, pruned_symbol, parent_candidate_id = worklist.pop(0)
                 candidate_key = _candidate_search_key(
                     params_candidate=params_candidate,
@@ -1247,8 +1257,8 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
         consistency_policy=consistency_policy,
         objective_veto_policy=objective_veto_policy,
         top_n=max(1, int(args.top_n)),
-        status='completed',
-        pending_candidates=0,
+        status='candidate_budget_exhausted' if budget_exhausted and worklist else 'completed',
+        pending_candidates=len(worklist),
     )
     if args.json_output is not None:
         args.json_output.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding='utf-8')

--- a/services/torghut/tests/test_search_consistent_profitability_frontier.py
+++ b/services/torghut/tests/test_search_consistent_profitability_frontier.py
@@ -42,6 +42,8 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
                     '--allow-stale-tape',
                     '--family-template-dir',
                     str(family_dir),
+                    '--max-candidates-to-evaluate',
+                    '12',
                 ],
             ):
                 args = frontier._parse_args()
@@ -49,6 +51,7 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
         self.assertEqual(args.expected_last_trading_day, '2026-04-07')
         self.assertTrue(args.allow_stale_tape)
         self.assertEqual(args.family_template_dir, family_dir)
+        self.assertEqual(args.max_candidates_to_evaluate, 12)
 
     def test_rolling_lower_bound_handles_empty_and_short_windows(self) -> None:
         self.assertEqual(frontier._rolling_lower_bound({}, window=3), Decimal('0'))
@@ -233,6 +236,7 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
             family_template_dir=Path(__file__).resolve().parents[1] / 'config' / 'trading' / 'families',
             prefetch_full_window_rows=False,
             top_n=10,
+            max_candidates_to_evaluate=0,
             json_output=json_output,
             symbol_prune_iterations=0,
             symbol_prune_candidates=1,
@@ -796,6 +800,63 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
             persisted = json.loads(json_output.read_text(encoding='utf-8'))
             self.assertEqual(persisted['status'], 'completed')
             self.assertEqual(persisted['candidate_count'], 2)
+
+    def test_run_frontier_respects_candidate_budget(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            strategy_configmap = self._write_strategy_configmap(root)
+            sweep_config = self._write_sweep_config(root)
+            json_output = root / 'frontier.json'
+            args = self._make_args(
+                strategy_configmap=strategy_configmap,
+                sweep_config=sweep_config,
+                json_output=json_output,
+            )
+            args.max_candidates_to_evaluate = 1
+            recent_days = tuple(date(2026, 3, 18) + timedelta(days=index) for index in range(6))
+            snapshot_receipt = SimpleNamespace(
+                snapshot_id='snap-budget',
+                is_fresh=True,
+                stale_override_used=False,
+                to_payload=lambda: {
+                    'snapshot_id': 'snap-budget',
+                    'source': 'ta',
+                    'window_size': 'PT1S',
+                    'start_day': '2026-03-18',
+                    'end_day': '2026-03-23',
+                    'expected_last_trading_day': '2026-03-23',
+                    'is_fresh': True,
+                    'missing_days': [],
+                    'row_count': 123,
+                    'stale_override_used': False,
+                    'witnesses': [],
+                },
+            )
+
+            def fake_run_replay(config: object) -> dict[str, object]:
+                return self._payload(
+                    start_date=str(getattr(config, 'start_date')),
+                    end_date=str(getattr(config, 'end_date')),
+                    daily_net={'2026-03-18': '100', '2026-03-19': '110', '2026-03-20': '120'},
+                    decision_count=3,
+                    filled_count=3,
+                    wins=3,
+                    losses=0,
+                )
+
+            with (
+                patch('scripts.search_consistent_profitability_frontier._resolve_recent_trading_days', return_value=recent_days),
+                patch('scripts.search_consistent_profitability_frontier.build_dataset_snapshot_receipt', return_value=snapshot_receipt),
+                patch('scripts.search_consistent_profitability_frontier.ensure_fresh_snapshot'),
+                patch('scripts.search_consistent_profitability_frontier.run_replay', side_effect=fake_run_replay),
+            ):
+                payload = frontier.run_consistent_profitability_frontier(args)
+
+            self.assertEqual(payload['status'], 'candidate_budget_exhausted')
+            self.assertEqual(payload['candidate_count'], 1)
+            self.assertGreater(payload['progress']['pending_candidates'], 0)
+            persisted = json.loads(json_output.read_text(encoding='utf-8'))
+            self.assertEqual(persisted['status'], 'candidate_budget_exhausted')
 
     def test_main_symbol_pruning_promotes_pruned_universe(self) -> None:
         with TemporaryDirectory() as tmpdir:

--- a/services/torghut/tests/test_strategy_autoresearch.py
+++ b/services/torghut/tests/test_strategy_autoresearch.py
@@ -120,6 +120,7 @@ class TestStrategyAutoresearch(TestCase):
         self.assertFalse(program.runtime_closure_policy.enabled)
         self.assertEqual(program.runtime_closure_policy.parity_window, 'full_window')
         self.assertEqual(program.runtime_closure_policy.approval_window, 'holdout')
+        self.assertEqual(program.replay_budget.max_candidates_per_frontier_run, 96)
         self.assertTrue(program.ledger_policy['append_only'])
 
     def _write_program_fixture(self, root: Path) -> tuple[Path, Path]:
@@ -890,6 +891,13 @@ class TestStrategyAutoresearch(TestCase):
             self.assertIn('mlx_exports', summary)
             self.assertIn('snapshot_manifest_path', summary)
             self.assertIn('runtime_closure', summary)
+            self.assertIn('live_progress', summary)
+            self.assertEqual(summary['live_progress']['frontier_runs_started'], 2)
+            self.assertGreaterEqual(summary['live_progress']['proposal_score_count'], 2)
+            self.assertEqual(
+                summary['live_progress']['best_experiment_candidate']['top_candidate_id'],
+                'mutated-1',
+            )
             self.assertIn('descriptor_id', summary['best_candidate'])
             self.assertIn('proposal_score', summary['best_candidate'])
             self.assertEqual(
@@ -1225,7 +1233,17 @@ class TestStrategyAutoresearch(TestCase):
                     run_root = run_roots[0]
                     summary = json.loads((run_root / 'summary.json').read_text(encoding='utf-8'))
                     self.assertEqual(summary['status'], 'running')
-                    self.assertEqual(summary['frontier_run_count'], 1)
+                    self.assertEqual(summary['frontier_run_count'], 2)
+                    self.assertEqual(summary['live_progress']['frontier_runs_started'], 2)
+                    self.assertTrue(summary['live_progress']['selected_for_replay']['candidate_id'])
+                    self.assertEqual(
+                        summary['live_progress']['selected_for_replay']['family_template_id'],
+                        'breakout_reclaim_v2',
+                    )
+                    self.assertEqual(
+                        summary['live_progress']['latest_experiment']['top_candidate_id'],
+                        'seed-1',
+                    )
                     history_lines = (run_root / 'history.jsonl').read_text(encoding='utf-8').splitlines()
                     self.assertEqual(len(history_lines), 1)
                     self.assertTrue((run_root / 'strategy-discovery-history.ipynb').exists())


### PR DESCRIPTION
## Summary

- flush MLX autoresearch live progress into `summary.json` before each frontier replay so notebooks can show proposal and provisional experiment state earlier
- add a bounded inner frontier candidate budget and wire it from the strict autoresearch program to stop replay-heavy experiments from monopolizing the loop
- extend notebooks and tests to surface live progress, selected replay candidates, and candidate-budget exhaustion behavior

## Related Issues

None

## Testing

- `cd services/torghut && /opt/homebrew/bin/mise exec uv -- uv run --frozen python -m pytest tests/test_strategy_autoresearch.py tests/test_search_consistent_profitability_frontier.py -q`
- `cd services/torghut && /opt/homebrew/bin/mise exec uv -- uv run --frozen python -m ruff check app/trading/discovery/autoresearch.py app/trading/discovery/autoresearch_notebooks.py scripts/run_strategy_autoresearch_loop.py scripts/search_consistent_profitability_frontier.py tests/test_strategy_autoresearch.py tests/test_search_consistent_profitability_frontier.py`
- `cd services/torghut && /opt/homebrew/bin/mise exec uv -- uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && /opt/homebrew/bin/mise exec uv -- uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && /opt/homebrew/bin/mise exec uv -- uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
