### PR TITLE
chore(torghut): promote image f6aaf4b3

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:1338a3dafa17c35e49ac4b6da18e5c5e0882b18cabb7e0fe245ec9a222c2bc97
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:54070526a16b46b9a40864a64f37da947dd338efc2d92b3e783c5906cd7b7282
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -63,9 +63,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.566.0-302-g11809873c
+              value: v0.566.0-304-gf6aaf4b35
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 11809873cd2e0ecd32898d70081e6c11088e142a
+              value: f6aaf4b355c5d084b625c080aa67667186de2e7e
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:1338a3dafa17c35e49ac4b6da18e5c5e0882b18cabb7e0fe245ec9a222c2bc97
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:54070526a16b46b9a40864a64f37da947dd338efc2d92b3e783c5906cd7b7282
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -63,9 +63,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.566.0-302-g11809873c
+              value: v0.566.0-304-gf6aaf4b35
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 11809873cd2e0ecd32898d70081e6c11088e142a
+              value: f6aaf4b355c5d084b625c080aa67667186de2e7e
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -40,7 +40,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:1338a3dafa17c35e49ac4b6da18e5c5e0882b18cabb7e0fe245ec9a222c2bc97
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:54070526a16b46b9a40864a64f37da947dd338efc2d92b3e783c5906cd7b7282
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -21,7 +21,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:1338a3dafa17c35e49ac4b6da18e5c5e0882b18cabb7e0fe245ec9a222c2bc97
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:54070526a16b46b9a40864a64f37da947dd338efc2d92b3e783c5906cd7b7282
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -32,7 +32,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:1338a3dafa17c35e49ac4b6da18e5c5e0882b18cabb7e0fe245ec9a222c2bc97
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:54070526a16b46b9a40864a64f37da947dd338efc2d92b3e783c5906cd7b7282
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -30,7 +30,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:1338a3dafa17c35e49ac4b6da18e5c5e0882b18cabb7e0fe245ec9a222c2bc97
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:54070526a16b46b9a40864a64f37da947dd338efc2d92b3e783c5906cd7b7282
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:1338a3dafa17c35e49ac4b6da18e5c5e0882b18cabb7e0fe245ec9a222c2bc97
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:54070526a16b46b9a40864a64f37da947dd338efc2d92b3e783c5906cd7b7282
           command:
             - /opt/venv/bin/alembic
           args:

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -13,7 +13,7 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:1338a3dafa17c35e49ac4b6da18e5c5e0882b18cabb7e0fe245ec9a222c2bc97
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:54070526a16b46b9a40864a64f37da947dd338efc2d92b3e783c5906cd7b7282
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -21,7 +21,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:1338a3dafa17c35e49ac4b6da18e5c5e0882b18cabb7e0fe245ec9a222c2bc97
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:54070526a16b46b9a40864a64f37da947dd338efc2d92b3e783c5906cd7b7282
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -39,7 +39,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:1338a3dafa17c35e49ac4b6da18e5c5e0882b18cabb7e0fe245ec9a222c2bc97
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:54070526a16b46b9a40864a64f37da947dd338efc2d92b3e783c5906cd7b7282
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-04-11T06:52:48Z"
+        client.knative.dev/updateTimestamp: "2026-04-11T07:24:44Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:1338a3dafa17c35e49ac4b6da18e5c5e0882b18cabb7e0fe245ec9a222c2bc97
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:54070526a16b46b9a40864a64f37da947dd338efc2d92b3e783c5906cd7b7282
           ports:
             - name: http1
               containerPort: 8181
@@ -495,9 +495,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.566.0-302-g11809873c
+              value: v0.566.0-304-gf6aaf4b35
             - name: TORGHUT_COMMIT
-              value: 11809873cd2e0ecd32898d70081e6c11088e142a
+              value: f6aaf4b355c5d084b625c080aa67667186de2e7e
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-04-11T06:52:48Z"
+        client.knative.dev/updateTimestamp: "2026-04-11T07:24:44Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -26,7 +26,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:1338a3dafa17c35e49ac4b6da18e5c5e0882b18cabb7e0fe245ec9a222c2bc97
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:54070526a16b46b9a40864a64f37da947dd338efc2d92b3e783c5906cd7b7282
           ports:
             - name: http1
               containerPort: 8181
@@ -276,9 +276,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.566.0-302-g11809873c
+              value: v0.566.0-304-gf6aaf4b35
             - name: TORGHUT_COMMIT
-              value: 11809873cd2e0ecd32898d70081e6c11088e142a
+              value: f6aaf4b355c5d084b625c080aa67667186de2e7e
           livenessProbe:
             httpGet:
               path: /healthz


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `f6aaf4b355c5d084b625c080aa67667186de2e7e`
- Image tag: `f6aaf4b3`
- Image digest: `sha256:54070526a16b46b9a40864a64f37da947dd338efc2d92b3e783c5906cd7b7282`