### PR TITLE
feat(torghut): support portfolio runtime closure candidates

### DIFF
--- a/services/torghut/app/trading/discovery/runtime_closure.py
+++ b/services/torghut/app/trading/discovery/runtime_closure.py
@@ -47,6 +47,28 @@ def _mapping(value: Any) -> dict[str, Any]:
     return {str(key): item for key, item in mapping_value.items()}
 
 
+def _list_of_mappings(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    resolved: list[dict[str, Any]] = []
+    for item in cast(list[Any], value):
+        mapping = _mapping(item)
+        if mapping:
+            resolved.append(mapping)
+    return resolved
+
+
+def _list_of_strings(value: Any) -> tuple[str, ...]:
+    if not isinstance(value, list):
+        return ()
+    resolved: list[str] = []
+    for item in cast(list[Any], value):
+        normalized = _string(item).upper()
+        if normalized:
+            resolved.append(normalized)
+    return tuple(resolved)
+
+
 def _int(value: Any) -> int:
     try:
         return int(float(str(value or 0)))
@@ -59,6 +81,44 @@ def _float(value: Any) -> float:
         return float(value)
     except (TypeError, ValueError):
         return 0.0
+
+
+def _decimal(value: Any, *, default: str = '0') -> Decimal:
+    try:
+        return Decimal(str(value))
+    except Exception:
+        return Decimal(default)
+
+
+def _decimal_string(value: Decimal) -> str:
+    rendered = format(value, 'f')
+    if '.' in rendered:
+        rendered = rendered.rstrip('0').rstrip('.')
+    return rendered or '0'
+
+
+_MICROBAR_PORTFOLIO_SIGNAL_SETTINGS: dict[str, dict[str, str]] = {
+    'open_window_continuation': {
+        'rank_feature': 'cross_section_session_open_rank',
+        'selection_mode': 'continuation',
+    },
+    'open_window_reversal': {
+        'rank_feature': 'cross_section_session_open_rank',
+        'selection_mode': 'reversal',
+    },
+    'vwap_close_continuation': {
+        'rank_feature': 'cross_section_vwap_w5m_rank',
+        'selection_mode': 'continuation',
+    },
+    'vwap_close_reversal': {
+        'rank_feature': 'cross_section_vwap_w5m_rank',
+        'selection_mode': 'reversal',
+    },
+    'prev_day_open45_periodicity': {
+        'rank_feature': 'cross_section_prev_day_open45_return_rank',
+        'selection_mode': 'continuation',
+    },
+}
 
 
 def _json_dumps(payload: Mapping[str, Any]) -> str:
@@ -223,22 +283,201 @@ def _objective_veto_policy(program: StrategyAutoresearchProgram) -> ObjectiveVet
     )
 
 
+def _runtime_family(best_candidate: Mapping[str, Any]) -> str:
+    return (
+        _string(best_candidate.get('runtime_family'))
+        or _string(best_candidate.get('family'))
+        or _string(best_candidate.get('family_template_id'))
+    )
+
+
+def _runtime_strategy_name(best_candidate: Mapping[str, Any]) -> str:
+    return _string(best_candidate.get('runtime_strategy_name')) or _string(best_candidate.get('strategy_name'))
+
+
+def _candidate_params(best_candidate: Mapping[str, Any]) -> dict[str, Any]:
+    direct = _mapping(best_candidate.get('candidate_params'))
+    if direct:
+        return direct
+    replay_config = _mapping(best_candidate.get('replay_config'))
+    return _mapping(replay_config.get('params'))
+
+
+def _candidate_strategy_overrides(best_candidate: Mapping[str, Any]) -> dict[str, Any]:
+    direct = _mapping(best_candidate.get('candidate_strategy_overrides'))
+    if direct:
+        return direct
+    replay_config = _mapping(best_candidate.get('replay_config'))
+    return _mapping(replay_config.get('strategy_overrides'))
+
+
+def _disable_other_strategies(best_candidate: Mapping[str, Any]) -> bool:
+    if 'disable_other_strategies' in best_candidate:
+        return bool(best_candidate.get('disable_other_strategies'))
+    replay_config = _mapping(best_candidate.get('replay_config'))
+    if 'disable_other_strategies' in replay_config:
+        return bool(replay_config.get('disable_other_strategies'))
+    return True
+
+
+def _portfolio_payload(best_candidate: Mapping[str, Any]) -> dict[str, Any]:
+    replay_config = _mapping(best_candidate.get('replay_config'))
+    return _mapping(replay_config.get('portfolio'))
+
+
+def _portfolio_symbols(best_candidate: Mapping[str, Any]) -> tuple[str, ...]:
+    override_symbols = _list_of_strings(_candidate_strategy_overrides(best_candidate).get('universe_symbols'))
+    if override_symbols:
+        return override_symbols
+    return _list_of_strings(_portfolio_payload(best_candidate).get('symbols'))
+
+
+def _is_microbar_portfolio_candidate(best_candidate: Mapping[str, Any]) -> bool:
+    replay_backend = _string(_mapping(best_candidate.get('replay_config')).get('backend'))
+    return (
+        _string(best_candidate.get('family_template_id')) == 'microbar_cross_sectional_pairs_v1'
+        or _runtime_family(best_candidate) == 'microbar_cross_sectional_pairs'
+        or replay_backend == 'microbar_daily_portfolio'
+    )
+
+
+def _microbar_portfolio_strategy_name(
+    *,
+    base_name: str,
+    sleeve_index: int,
+    side: str,
+) -> str:
+    return f'{base_name}-sleeve-{sleeve_index}-{side}'
+
+
+def _portfolio_runtime_strategy_names(best_candidate: Mapping[str, Any]) -> tuple[str, ...]:
+    if not _is_microbar_portfolio_candidate(best_candidate):
+        strategy_name = _runtime_strategy_name(best_candidate)
+        return (strategy_name,) if strategy_name else ()
+    base_name = _runtime_strategy_name(best_candidate) or 'microbar-cross-sectional-pairs-v1'
+    names: list[str] = []
+    sleeves = _list_of_mappings(_portfolio_payload(best_candidate).get('sleeves'))
+    for sleeve_index, _sleeve in enumerate(sleeves, start=1):
+        names.append(_microbar_portfolio_strategy_name(base_name=base_name, sleeve_index=sleeve_index, side='long'))
+        names.append(_microbar_portfolio_strategy_name(base_name=base_name, sleeve_index=sleeve_index, side='short'))
+    return tuple(names)
+
+
+def _portfolio_promotion_v2(best_candidate: Mapping[str, Any]) -> dict[str, Any]:
+    strategy_names = _portfolio_runtime_strategy_names(best_candidate)
+    if len(strategy_names) <= 1:
+        return {}
+    symbols = _portfolio_symbols(best_candidate)
+    missing_policy_refs: list[str] = []
+    for strategy_name in strategy_names:
+        missing_policy_refs.extend(
+            [
+                f'{strategy_name}:promotion_policy_ref',
+                f'{strategy_name}:risk_profile_ref',
+                f'{strategy_name}:sizing_policy_ref',
+                f'{strategy_name}:execution_policy_ref',
+            ]
+        )
+    return {
+        'mode': 'portfolio_aware',
+        'strategy_count': len(strategy_names),
+        'spec_compiled_count': 0,
+        'unique_symbol_count': len(set(symbols)),
+        'overlapping_symbols': list(symbols),
+        'promotion_policy_refs': [],
+        'risk_profile_refs': [],
+        'sizing_policy_refs': [],
+        'execution_policy_refs': [],
+        'missing_policy_refs': missing_policy_refs,
+    }
+
+
+def _materialized_microbar_portfolio_runtime_strategies(
+    *,
+    best_candidate: Mapping[str, Any],
+    execution_context: RuntimeClosureExecutionContext,
+) -> list[dict[str, Any]]:
+    if not _is_microbar_portfolio_candidate(best_candidate):
+        return []
+    portfolio = _portfolio_payload(best_candidate)
+    sleeves = _list_of_mappings(portfolio.get('sleeves'))
+    if not sleeves:
+        return []
+    base_per_leg_notional = _decimal(portfolio.get('base_per_leg_notional'))
+    if base_per_leg_notional <= 0:
+        raise ValueError('runtime_closure_microbar_portfolio_base_per_leg_notional_missing')
+    symbols = _portfolio_symbols(best_candidate) or execution_context.symbols
+    if not symbols:
+        raise ValueError('runtime_closure_microbar_portfolio_symbols_missing')
+    base_name = _runtime_strategy_name(best_candidate) or 'microbar-cross-sectional-pairs-v1'
+    candidate_id = _string(best_candidate.get('candidate_id')) or 'runtime-closure'
+    strategies: list[dict[str, Any]] = []
+    for sleeve_index, sleeve in enumerate(sleeves, start=1):
+        signal = _string(sleeve.get('signal'))
+        signal_settings = _MICROBAR_PORTFOLIO_SIGNAL_SETTINGS.get(signal)
+        if signal_settings is None:
+            raise ValueError(f'runtime_closure_microbar_portfolio_signal_unsupported:{signal}')
+        entry_minute = max(0, _int(sleeve.get('entry_minute_after_open')))
+        exit_text = _string(sleeve.get('exit_minute_after_open')) or 'close'
+        top_n = max(1, _int(sleeve.get('top_n')))
+        weight = _decimal(sleeve.get('weight'), default='1')
+        if weight <= 0:
+            weight = Decimal('1')
+        max_notional_per_trade = base_per_leg_notional * weight
+        if execution_context.start_equity > 0:
+            max_position_pct_equity = max_notional_per_trade / execution_context.start_equity
+        else:
+            max_position_pct_equity = Decimal('10')
+        max_position_pct_equity = max(max_position_pct_equity, Decimal('0.1'))
+        for side, strategy_type in (
+            ('long', 'microbar_cross_sectional_long_v1'),
+            ('short', 'microbar_cross_sectional_short_v1'),
+        ):
+            strategies.append(
+                {
+                    'name': _microbar_portfolio_strategy_name(
+                        base_name=base_name,
+                        sleeve_index=sleeve_index,
+                        side=side,
+                    ),
+                    'strategy_id': f'{strategy_type}@runtime-closure:{candidate_id}:s{sleeve_index}:{side}',
+                    'strategy_type': strategy_type,
+                    'version': '1.0.0',
+                    'description': (
+                        f'Runtime-closure materialized sleeve {sleeve_index} '
+                        f'for {_runtime_family(best_candidate) or "microbar portfolio"}'
+                    ),
+                    'enabled': True,
+                    'base_timeframe': '1Sec',
+                    'universe_type': strategy_type,
+                    'universe_symbols': list(symbols),
+                    'max_notional_per_trade': _decimal_string(max_notional_per_trade),
+                    'max_position_pct_equity': _decimal_string(max_position_pct_equity),
+                    'params': {
+                        'entry_minute_after_open': str(entry_minute),
+                        'exit_minute_after_open': exit_text,
+                        'signal_motif': signal,
+                        'rank_feature': signal_settings['rank_feature'],
+                        'selection_mode': signal_settings['selection_mode'],
+                        'top_n': str(top_n),
+                        'universe_size': str(len(symbols)),
+                        'max_concurrent_positions': str(top_n),
+                        'max_entries_per_session': str(top_n),
+                        'position_isolation_mode': 'per_strategy',
+                    },
+                }
+            )
+    return strategies
+
+
 def _candidate_symbols(
     *,
     best_candidate: Mapping[str, Any],
     execution_context: RuntimeClosureExecutionContext,
 ) -> tuple[str, ...]:
-    strategy_overrides = _mapping(best_candidate.get('candidate_strategy_overrides'))
-    override_symbols = strategy_overrides.get('universe_symbols')
-    if isinstance(override_symbols, list):
-        resolved: list[str] = []
-        for item in cast(list[Any], override_symbols):
-            if isinstance(item, str):
-                normalized = item.strip().upper()
-                if normalized:
-                    resolved.append(normalized)
-        if resolved:
-            return tuple(resolved)
+    override_symbols = _portfolio_symbols(best_candidate)
+    if override_symbols:
+        return override_symbols
     return execution_context.symbols
 
 
@@ -265,19 +504,65 @@ def _materialize_candidate_configmap(
     configmap_payload = yaml.safe_load(execution_context.strategy_configmap_path.read_text(encoding='utf-8'))
     if not isinstance(configmap_payload, Mapping):
         raise ValueError('strategy_configmap_not_mapping')
-    strategy_name = _string(best_candidate.get('runtime_strategy_name'))
-    if not strategy_name:
-        raise ValueError('runtime_closure_missing_runtime_strategy_name')
-    candidate_params = _mapping(best_candidate.get('candidate_params'))
-    if not candidate_params:
-        raise ValueError('runtime_closure_missing_candidate_params')
-    rendered = apply_candidate_to_configmap_with_overrides(
-        configmap_payload=cast(Mapping[str, Any], configmap_payload),
-        strategy_name=strategy_name,
-        candidate_params=candidate_params,
-        strategy_overrides=_mapping(best_candidate.get('candidate_strategy_overrides')),
-        disable_other_strategies=bool(best_candidate.get('disable_other_strategies', True)),
+    portfolio_runtime_strategies = _materialized_microbar_portfolio_runtime_strategies(
+        best_candidate=best_candidate,
+        execution_context=execution_context,
     )
+    if portfolio_runtime_strategies:
+        rendered_payload = yaml.safe_load(
+            yaml.safe_dump(cast(Mapping[str, Any], configmap_payload), sort_keys=False)
+        )
+        if not isinstance(rendered_payload, dict):
+            raise ValueError('strategy_configmap_not_mapping')
+        rendered = cast(dict[str, Any], rendered_payload)
+        data_payload = rendered.get('data')
+        if not isinstance(data_payload, dict):
+            raise ValueError('strategy_configmap_missing_data')
+        data = cast(dict[str, Any], data_payload)
+        strategies_yaml = data.get('strategies.yaml')
+        if not isinstance(strategies_yaml, str):
+            raise ValueError('strategy_configmap_missing_strategies_yaml')
+        catalog_payload = yaml.safe_load(strategies_yaml)
+        if not isinstance(catalog_payload, dict):
+            raise ValueError('strategy_catalog_not_mapping')
+        catalog = cast(dict[str, Any], catalog_payload)
+        strategies_payload = catalog.get('strategies')
+        if not isinstance(strategies_payload, list):
+            raise ValueError('strategy_catalog_missing_strategies')
+        strategies = cast(list[Any], strategies_payload)
+        if _disable_other_strategies(best_candidate):
+            for item in strategies:
+                if isinstance(item, dict):
+                    item['enabled'] = False
+        by_name: dict[str, int] = {}
+        for index, item in enumerate(strategies):
+            if not isinstance(item, Mapping):
+                continue
+            item_mapping = cast(Mapping[str, Any], item)
+            item_name = _string(item_mapping.get('name'))
+            if item_name:
+                by_name[item_name] = index
+        for item in portfolio_runtime_strategies:
+            item_name = _string(item.get('name'))
+            if item_name in by_name:
+                strategies[by_name[item_name]] = item
+            else:
+                strategies.append(item)
+        data['strategies.yaml'] = yaml.safe_dump(catalog, sort_keys=False)
+    else:
+        strategy_name = _runtime_strategy_name(best_candidate)
+        if not strategy_name:
+            raise ValueError('runtime_closure_missing_runtime_strategy_name')
+        candidate_params = _candidate_params(best_candidate)
+        if not candidate_params:
+            raise ValueError('runtime_closure_missing_candidate_params')
+        rendered = apply_candidate_to_configmap_with_overrides(
+            configmap_payload=cast(Mapping[str, Any], configmap_payload),
+            strategy_name=strategy_name,
+            candidate_params=candidate_params,
+            strategy_overrides=_candidate_strategy_overrides(best_candidate),
+            disable_other_strategies=_disable_other_strategies(best_candidate),
+        )
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(yaml.safe_dump(rendered, sort_keys=False), encoding='utf-8')
     return output_path
@@ -394,8 +679,9 @@ def _replay_analysis(
         'schema_version': 'torghut.runtime-closure-replay-report.v1',
         'window_name': window_name,
         'candidate_id': _string(best_candidate.get('candidate_id')),
-        'runtime_family': _string(best_candidate.get('runtime_family')),
-        'runtime_strategy_name': _string(best_candidate.get('runtime_strategy_name')),
+        'runtime_family': _runtime_family(best_candidate),
+        'runtime_strategy_name': _runtime_strategy_name(best_candidate),
+        'runtime_strategy_names': list(_portfolio_runtime_strategy_names(best_candidate)),
         'objective_met': objective_met,
         'hard_vetoes': hard_vetoes,
         'scorecard': scorecard.to_payload(),
@@ -548,14 +834,17 @@ def _candidate_spec(
     best_candidate: Mapping[str, Any],
     manifest: MlxSnapshotManifest,
 ) -> dict[str, Any]:
+    replay_config = _mapping(best_candidate.get('replay_config'))
+    portfolio_promotion_v2 = _portfolio_promotion_v2(best_candidate)
     return {
         'schema_version': 'torghut.runtime-closure-candidate-spec.v1',
         'candidate_id': _string(best_candidate.get('candidate_id')),
         'runner_run_id': runner_run_id,
         'program_id': program.program_id,
         'family_template_id': _string(best_candidate.get('family_template_id')),
-        'runtime_family': _string(best_candidate.get('runtime_family')),
-        'runtime_strategy_name': _string(best_candidate.get('runtime_strategy_name')),
+        'runtime_family': _runtime_family(best_candidate),
+        'runtime_strategy_name': _runtime_strategy_name(best_candidate),
+        'runtime_strategy_names': list(_portfolio_runtime_strategy_names(best_candidate)),
         'dataset_snapshot_ref': manifest.snapshot_id,
         'source_window_start': manifest.source_window_start,
         'source_window_end': manifest.source_window_end,
@@ -564,15 +853,15 @@ def _candidate_spec(
         'status': _string(best_candidate.get('status')),
         'mutation_label': _string(best_candidate.get('mutation_label')),
         'parent_candidate_id': _string(best_candidate.get('parent_candidate_id')),
-        'candidate_params': _mapping(best_candidate.get('candidate_params')),
-        'candidate_strategy_overrides': _mapping(best_candidate.get('candidate_strategy_overrides')),
-        'disable_other_strategies': bool(best_candidate.get('disable_other_strategies', True)),
-        'train_start_date': _string(best_candidate.get('train_start_date')),
-        'train_end_date': _string(best_candidate.get('train_end_date')),
-        'holdout_start_date': _string(best_candidate.get('holdout_start_date')),
-        'holdout_end_date': _string(best_candidate.get('holdout_end_date')),
-        'full_window_start_date': _string(best_candidate.get('full_window_start_date')) or manifest.source_window_start,
-        'full_window_end_date': _string(best_candidate.get('full_window_end_date')) or manifest.source_window_end,
+        'candidate_params': _candidate_params(best_candidate),
+        'candidate_strategy_overrides': _candidate_strategy_overrides(best_candidate),
+        'disable_other_strategies': _disable_other_strategies(best_candidate),
+        'train_start_date': _string(best_candidate.get('train_start_date')) or _string(replay_config.get('train_start_date')),
+        'train_end_date': _string(best_candidate.get('train_end_date')) or _string(replay_config.get('train_end_date')),
+        'holdout_start_date': _string(best_candidate.get('holdout_start_date')) or _string(replay_config.get('holdout_start_date')),
+        'holdout_end_date': _string(best_candidate.get('holdout_end_date')) or _string(replay_config.get('holdout_end_date')),
+        'full_window_start_date': _string(best_candidate.get('full_window_start_date')) or _string(replay_config.get('full_window_start_date')) or manifest.source_window_start,
+        'full_window_end_date': _string(best_candidate.get('full_window_end_date')) or _string(replay_config.get('full_window_end_date')) or manifest.source_window_end,
         'normalization_regime': _string(best_candidate.get('normalization_regime')),
         'descriptor': {
             'descriptor_id': _string(best_candidate.get('descriptor_id')),
@@ -603,6 +892,7 @@ def _candidate_spec(
                 cast(list[str], best_candidate.get('promotion_required_evidence') or [])
             ),
         },
+        **({'portfolio_promotion_v2': portfolio_promotion_v2} if portfolio_promotion_v2 else {}),
     }
 
 
@@ -625,6 +915,7 @@ def _candidate_generation_manifest(
         'proposal_selection_reason': _string(best_candidate.get('proposal_selection_reason')),
         'mutation_label': _string(best_candidate.get('mutation_label')),
         'status': _string(best_candidate.get('status')),
+        'runtime_strategy_names': list(_portfolio_runtime_strategy_names(best_candidate)),
         'runtime_closure_policy': program.runtime_closure_policy.to_payload(),
     }
 
@@ -638,12 +929,13 @@ def _gate_report(
     approval_report: Mapping[str, Any] | None,
     shadow_plan: Mapping[str, Any],
 ) -> dict[str, Any]:
-    runtime_family = _string(best_candidate.get('runtime_family')) or 'unknown'
+    runtime_family = _runtime_family(best_candidate) or 'unknown'
     parity_pass = bool(_mapping(parity_report).get('objective_met')) if parity_report is not None else False
     approval_pass = bool(_mapping(approval_report).get('objective_met')) if approval_report is not None else False
     shadow_required = bool(shadow_plan.get('required'))
     shadow_status = _string(shadow_plan.get('status'))
     shadow_ready = shadow_status == 'within_budget'
+    portfolio_promotion_v2 = _portfolio_promotion_v2(best_candidate)
     promotion_reasons: list[str] = []
     if parity_report is None:
         promotion_reasons.append('research_candidate_pending_scheduler_v3_parity')
@@ -725,6 +1017,11 @@ def _gate_report(
             else '1.0'
         ),
         'recalibration_run_id': None,
+        **(
+            {'vnext': {'portfolio_promotion': portfolio_promotion_v2}}
+            if portfolio_promotion_v2
+            else {}
+        ),
     }
 
 
@@ -770,7 +1067,7 @@ def _candidate_state(
             'registry_loaded': True,
             'registry_path': 'runtime_harness',
             'registry_errors': [],
-            'strategy_families': [_string(best_candidate.get('runtime_family'))],
+            'strategy_families': [_runtime_family(best_candidate)],
             'matched_hypothesis_ids': [_string(best_candidate.get('family_template_id'))],
             'missing_strategy_families': [],
             'promotion_eligible': False,
@@ -803,8 +1100,9 @@ def _backtest_summary(
         'candidate_id': _string(best_candidate.get('candidate_id')),
         'dataset_snapshot_ref': manifest.snapshot_id,
         'status': 'research_only',
-        'runtime_family': _string(best_candidate.get('runtime_family')),
-        'runtime_strategy_name': _string(best_candidate.get('runtime_strategy_name')),
+        'runtime_family': _runtime_family(best_candidate),
+        'runtime_strategy_name': _runtime_strategy_name(best_candidate),
+        'runtime_strategy_names': list(_portfolio_runtime_strategy_names(best_candidate)),
         'parity_replay': dict(parity_report or {}),
         'approval_replay': dict(approval_report or {}),
     }
@@ -1174,8 +1472,9 @@ def write_runtime_closure_bundle(
         'dataset_snapshot_ref': manifest.snapshot_id,
         'source_window_start': manifest.source_window_start,
         'source_window_end': manifest.source_window_end,
-        'runtime_family': _string(best_candidate.get('runtime_family')),
-        'runtime_strategy_name': _string(best_candidate.get('runtime_strategy_name')),
+        'runtime_family': _runtime_family(best_candidate),
+        'runtime_strategy_name': _runtime_strategy_name(best_candidate),
+        'runtime_strategy_names': list(_portfolio_runtime_strategy_names(best_candidate)),
         'approval_path': 'scheduler_v3',
         'required_steps': [
             'checked_in_runtime_family',

--- a/services/torghut/config/trading/families/microbar_cross_sectional_pairs_v1.yaml
+++ b/services/torghut/config/trading/families/microbar_cross_sectional_pairs_v1.yaml
@@ -1,0 +1,49 @@
+schema_version: torghut.family-template.v1
+family_id: microbar_cross_sectional_pairs_v1
+economic_mechanism: Market-neutral intraday cross-sectional continuation and reversal pairs on authoritative minute bars.
+supported_markets:
+  - us_equities_intraday
+required_features:
+  - session_open_price
+  - vwap_session
+  - cross_section_rank
+allowed_normalizations:
+  - market_neutral_gross_scaled
+entry_motifs:
+  - open_window_continuation
+  - open_window_reversal
+  - vwap_close_continuation
+  - vwap_close_reversal
+exit_motifs:
+  - time_exit
+risk_controls:
+  - market_neutral_pairing
+  - gross_notional_cap
+  - transaction_cost_stress
+activity_model:
+  min_active_day_ratio: '1.0'
+  min_daily_notional: '300000'
+liquidity_assumptions:
+  max_bar_staleness_minutes: '5'
+  max_cost_bps_per_side: '5'
+regime_activation_rules:
+  - metric: market_neutral_pair_book
+    comparator: gte
+    threshold: '1'
+day_veto_rules:
+  - rule: missing_microbars
+    action: block_day
+default_hard_vetoes:
+  required_min_active_day_ratio: '1.0'
+  required_min_daily_notional: '300000'
+  required_max_best_day_share: '0.35'
+  required_max_worst_day_loss: '250'
+  required_max_drawdown: '700'
+  required_min_regime_slice_pass_rate: '0'
+default_selection_objectives:
+  target_net_pnl_per_day: '500'
+  require_positive_day_ratio: '0.75'
+runtime_harness:
+  family: microbar_cross_sectional_pairs
+  strategy_name: microbar-cross-sectional-pairs-v1
+  disable_other_strategies: true

--- a/services/torghut/config/trading/research-programs/strict-daily-profit-autoresearch-focused-v1.yaml
+++ b/services/torghut/config/trading/research-programs/strict-daily-profit-autoresearch-focused-v1.yaml
@@ -1,0 +1,289 @@
+schema_version: torghut.strategy-autoresearch.v1
+program_id: strict_daily_profit_autoresearch_focused_v1
+description: >
+  Focused strict outer loop for daily-active strategy discovery using the MLX harness: bias toward
+  runtime-native long families with a plausible path to the $500/day target, while excluding the
+  known-dead exhaustion short lane and shrinking replay budgets for faster iteration.
+snapshot_policy:
+  bar_interval: PT1S
+  feature_set_id: torghut.mlx-autoresearch.v1
+  quote_quality_policy_id: scheduler_v3_default
+  symbol_policy: args_or_sweep
+  allow_prior_day_features: true
+  allow_cross_sectional_features: true
+forbidden_mutations:
+  - runtime_code_path
+  - evaluator_logic
+  - live_strategy_config
+proposal_model_policy:
+  enabled: true
+  mode: ranking_only
+  backend_preference: mlx
+  top_k: 4
+  exploration_slots: 1
+  minimum_history_rows: 2
+replay_budget:
+  max_candidates_per_round: 4
+  exploration_slots: 1
+  max_candidates_per_frontier_run: 48
+runtime_closure_policy:
+  enabled: true
+  execute_parity_replay: true
+  execute_approval_replay: true
+  parity_window: full_window
+  approval_window: holdout
+  shadow_validation_mode: require_live_evidence
+  promotion_target: shadow
+parity_requirements:
+  - checked_in_runtime_family
+  - scheduler_v3_parity_replay
+  - scheduler_v3_approval_replay
+  - live_shadow_validation
+promotion_policy: research_only
+ledger_policy:
+  append_only: true
+objective:
+  target_net_pnl_per_day: '500'
+  min_active_day_ratio: '1.0'
+  min_positive_day_ratio: '0.625'
+  min_daily_notional: '300000'
+  max_best_day_share: '0.30'
+  max_worst_day_loss: '350'
+  max_drawdown: '900'
+  require_every_day_active: true
+  min_regime_slice_pass_rate: '0.45'
+  stop_when_objective_met: true
+research_sources:
+  - source_id: interpretable_hypothesis_driven_trading_2025
+    title: Interpretable Hypothesis-Driven Trading
+    url: https://arxiv.org/abs/2512.12924
+    published_at: '2025-12-15'
+    claims:
+      - claim_id: walk_forward_honesty
+        summary: Honest walk-forward validation with realistic costs matters more than headline returns.
+        implication: Reject candidates that only look good in aggregate or depend on one day.
+      - claim_id: interpretability_over_noise
+        summary: Interpretable families age better than opaque threshold soup.
+        implication: Prefer bounded family search over unconstrained parameter hacking.
+  - source_id: optimal_signal_extraction_order_flow_2026
+    title: Optimal Signal Extraction from Order Flow
+    url: https://arxiv.org/abs/2512.18648
+    published_at: '2026-02-20'
+    claims:
+      - claim_id: matched_filter_normalization
+        summary: Feature normalization should match the signal-generation mechanism.
+        implication: Search allowed normalization regimes directly.
+  - source_id: liquidity_constrained_portfolio_2025
+    title: Sharpe-Driven Stock Selection and Liquidity-Constrained Portfolio Optimization
+    url: https://arxiv.org/abs/2511.13251
+    published_at: '2025-11-17'
+    claims:
+      - claim_id: liquidity_upstream
+        summary: Liquidity and notional constraints belong upstream in candidate definition.
+        implication: Reject low-notional or low-participation families directly in the objective.
+families:
+  - family_template_id: breakout_reclaim_v2
+    seed_sweep_config: ../profitability-frontier-strict-daily-breakout-reclaim.yaml
+    max_iterations: 2
+    keep_top_candidates: 1
+    frontier_top_n: 4
+    force_keep_top_candidate_if_all_vetoed: true
+    symbol_prune_iterations: 1
+    symbol_prune_candidates: 1
+    symbol_prune_min_universe_size: 5
+    parameter_mutations:
+      max_entries_per_session:
+        mode: numeric_step
+        deltas: ['-1', '0', '1']
+        minimum: '1'
+        maximum: '4'
+      entry_cooldown_seconds:
+        mode: numeric_step
+        deltas: ['-300', '0', '300']
+        minimum: '300'
+        maximum: '1500'
+      long_stop_loss_bps:
+        mode: numeric_step
+        deltas: ['-2', '0', '2']
+        minimum: '8'
+        maximum: '16'
+      long_trailing_stop_activation_profit_bps:
+        mode: numeric_step
+        deltas: ['-2', '0', '2']
+        minimum: '4'
+        maximum: '12'
+      long_trailing_stop_drawdown_bps:
+        mode: numeric_step
+        deltas: ['-1', '0', '1']
+        minimum: '2'
+        maximum: '6'
+    strategy_override_mutations:
+      normalization_regime:
+        mode: allowed_normalizations
+  - family_template_id: momentum_pullback_v1
+    seed_sweep_config: ../profitability-frontier-strict-daily-momentum-pullback.yaml
+    max_iterations: 2
+    keep_top_candidates: 2
+    frontier_top_n: 5
+    force_keep_top_candidate_if_all_vetoed: true
+    symbol_prune_iterations: 1
+    symbol_prune_candidates: 2
+    symbol_prune_min_universe_size: 5
+    parameter_mutations:
+      exit_macd_hist_max:
+        mode: numeric_step
+        deltas: ['-0.002', '0', '0.002']
+        minimum: '-0.010'
+        maximum: '-0.001'
+      max_hold_seconds:
+        mode: numeric_step
+        deltas: ['-120', '0', '120']
+        minimum: '300'
+        maximum: '1200'
+      long_stop_loss_bps:
+        mode: numeric_step
+        deltas: ['-4', '0', '4']
+        minimum: '12'
+        maximum: '32'
+      long_trailing_stop_activation_profit_bps:
+        mode: numeric_step
+        deltas: ['-2', '0', '2']
+        minimum: '6'
+        maximum: '20'
+      long_trailing_stop_drawdown_bps:
+        mode: numeric_step
+        deltas: ['-1', '0', '1']
+        minimum: '3'
+        maximum: '10'
+    strategy_override_mutations:
+      max_notional_per_trade:
+        mode: explicit_values
+        values: ['63180', '126360', '189540']
+      max_position_pct_equity:
+        mode: explicit_values
+        values: ['2.0', '4.0']
+  - family_template_id: mean_reversion_rebound_v1
+    seed_sweep_config: ../profitability-frontier-strict-daily-mean-reversion.yaml
+    max_iterations: 2
+    keep_top_candidates: 2
+    frontier_top_n: 5
+    force_keep_top_candidate_if_all_vetoed: true
+    symbol_prune_iterations: 1
+    symbol_prune_candidates: 2
+    symbol_prune_min_universe_size: 5
+    parameter_mutations:
+      min_bull_rsi:
+        mode: numeric_step
+        deltas: ['-2', '0', '2']
+        minimum: '34'
+        maximum: '48'
+      min_price_below_vwap_bps:
+        mode: numeric_step
+        deltas: ['-4', '0', '4']
+        minimum: '6'
+        maximum: '20'
+      max_price_vs_session_open_bps:
+        mode: numeric_step
+        deltas: ['-10', '0', '10']
+        minimum: '-45'
+        maximum: '-10'
+      min_cross_section_reversal_rank:
+        mode: numeric_step
+        deltas: ['-0.05', '0', '0.05']
+        minimum: '0.60'
+        maximum: '0.90'
+    strategy_override_mutations:
+      max_notional_per_trade:
+        mode: explicit_values
+        values: ['63180', '126360', '189540']
+      max_position_pct_equity:
+        mode: explicit_values
+        values: ['2.0', '4.0']
+  - family_template_id: intraday_tsmom_v2
+    seed_sweep_config: ../profitability-frontier-strict-daily-tsmom.yaml
+    max_iterations: 3
+    keep_top_candidates: 2
+    frontier_top_n: 5
+    force_keep_top_candidate_if_all_vetoed: true
+    symbol_prune_iterations: 1
+    symbol_prune_candidates: 2
+    symbol_prune_min_universe_size: 5
+    parameter_mutations:
+      long_stop_loss_bps:
+        mode: numeric_step
+        deltas: ['-2', '0', '2']
+        minimum: '8'
+        maximum: '20'
+      long_trailing_stop_activation_profit_bps:
+        mode: numeric_step
+        deltas: ['-2', '0', '2']
+        minimum: '4'
+        maximum: '16'
+      long_trailing_stop_drawdown_bps:
+        mode: numeric_step
+        deltas: ['-1', '0', '1']
+        minimum: '2'
+        maximum: '8'
+      max_session_negative_exit_bps:
+        mode: numeric_step
+        deltas: ['-2', '0', '2']
+        minimum: '6'
+        maximum: '16'
+      min_cross_section_continuation_rank:
+        mode: numeric_step
+        deltas: ['-0.05', '0', '0.05']
+        minimum: '0.45'
+        maximum: '0.75'
+    strategy_override_mutations:
+      normalization_regime:
+        mode: allowed_normalizations
+      max_notional_per_trade:
+        mode: explicit_values
+        values: ['63180', '126360', '189540', '252720']
+      max_position_pct_equity:
+        mode: explicit_values
+        values: ['2.0', '3.0', '4.0']
+  - family_template_id: microstructure_continuation_matched_filter_v1
+    seed_sweep_config: ../profitability-frontier-strict-daily-microstructure.yaml
+    max_iterations: 2
+    keep_top_candidates: 1
+    frontier_top_n: 4
+    force_keep_top_candidate_if_all_vetoed: true
+    symbol_prune_iterations: 1
+    symbol_prune_candidates: 1
+    symbol_prune_min_universe_size: 4
+    parameter_mutations:
+      max_entries_per_session:
+        mode: numeric_step
+        deltas: ['-1', '0', '1']
+        minimum: '1'
+        maximum: '4'
+      entry_cooldown_seconds:
+        mode: numeric_step
+        deltas: ['-300', '0', '300']
+        minimum: '300'
+        maximum: '1800'
+    strategy_override_mutations:
+      normalization_regime:
+        mode: allowed_normalizations
+  - family_template_id: opening_drive_leader_reclaim_v1
+    seed_sweep_config: ../profitability-frontier-strict-daily-opening-drive.yaml
+    max_iterations: 2
+    keep_top_candidates: 1
+    frontier_top_n: 4
+    force_keep_top_candidate_if_all_vetoed: true
+    symbol_prune_iterations: 0
+    symbol_prune_candidates: 1
+    symbol_prune_min_universe_size: 4
+    parameter_mutations:
+      leader_reclaim_start_minutes_since_open:
+        mode: explicit_values
+        values: ['30', '45', '60']
+      entry_cooldown_seconds:
+        mode: numeric_step
+        deltas: ['-300', '0', '300']
+        minimum: '300'
+        maximum: '1200'
+    strategy_override_mutations:
+      normalization_regime:
+        mode: allowed_normalizations

--- a/services/torghut/config/trading/research-programs/strict-daily-profit-autoresearch-liquid6-momentum-v1.yaml
+++ b/services/torghut/config/trading/research-programs/strict-daily-profit-autoresearch-liquid6-momentum-v1.yaml
@@ -1,0 +1,118 @@
+schema_version: torghut.strategy-autoresearch.v1
+program_id: strict_daily_profit_autoresearch_liquid6_momentum_v1
+description: >
+  Narrow MLX autoresearch program for the liquid six-symbol momentum lane. Bias toward fast,
+  stable iteration on the highest-liquidity names with enough sizing room to still clear the
+  $500/day target if the family is real.
+snapshot_policy:
+  bar_interval: PT1S
+  feature_set_id: torghut.mlx-autoresearch.v1
+  quote_quality_policy_id: scheduler_v3_default
+  symbol_policy: args_or_sweep
+  allow_prior_day_features: true
+  allow_cross_sectional_features: true
+forbidden_mutations:
+  - runtime_code_path
+  - evaluator_logic
+  - live_strategy_config
+proposal_model_policy:
+  enabled: true
+  mode: ranking_only
+  backend_preference: mlx
+  top_k: 2
+  exploration_slots: 1
+  minimum_history_rows: 1
+replay_budget:
+  max_candidates_per_round: 2
+  exploration_slots: 1
+  max_candidates_per_frontier_run: 24
+runtime_closure_policy:
+  enabled: true
+  execute_parity_replay: true
+  execute_approval_replay: true
+  parity_window: full_window
+  approval_window: holdout
+  shadow_validation_mode: require_live_evidence
+  promotion_target: shadow
+parity_requirements:
+  - checked_in_runtime_family
+  - scheduler_v3_parity_replay
+  - scheduler_v3_approval_replay
+  - live_shadow_validation
+promotion_policy: research_only
+ledger_policy:
+  append_only: true
+objective:
+  target_net_pnl_per_day: '500'
+  min_active_day_ratio: '1.0'
+  min_positive_day_ratio: '0.625'
+  min_daily_notional: '250000'
+  max_best_day_share: '0.30'
+  max_worst_day_loss: '350'
+  max_drawdown: '900'
+  require_every_day_active: true
+  min_regime_slice_pass_rate: '0.45'
+  stop_when_objective_met: true
+research_sources:
+  - source_id: interpretable_hypothesis_driven_trading_2025
+    title: Interpretable Hypothesis-Driven Trading
+    url: https://arxiv.org/abs/2512.12924
+    published_at: '2025-12-15'
+    claims:
+      - claim_id: walk_forward_honesty
+        summary: Honest walk-forward validation with realistic costs matters more than headline returns.
+        implication: Reject candidates that only look good in aggregate or depend on one day.
+      - claim_id: interpretability_over_noise
+        summary: Interpretable families age better than opaque threshold soup.
+        implication: Prefer bounded family search over unconstrained parameter hacking.
+  - source_id: liquidity_constrained_portfolio_2025
+    title: Sharpe-Driven Stock Selection and Liquidity-Constrained Portfolio Optimization
+    url: https://arxiv.org/abs/2511.13251
+    published_at: '2025-11-17'
+    claims:
+      - claim_id: liquidity_upstream
+        summary: Liquidity and notional constraints belong upstream in candidate definition.
+        implication: Prefer the deepest names and cut dead liquidity early.
+families:
+  - family_template_id: momentum_pullback_v1
+    seed_sweep_config: ../profitability-frontier-strict-daily-momentum-composite.yaml
+    max_iterations: 3
+    keep_top_candidates: 2
+    frontier_top_n: 4
+    force_keep_top_candidate_if_all_vetoed: true
+    symbol_prune_iterations: 0
+    symbol_prune_candidates: 1
+    symbol_prune_min_universe_size: 6
+    parameter_mutations:
+      exit_macd_hist_max:
+        mode: numeric_step
+        deltas: ['-0.002', '0', '0.002']
+        minimum: '-0.010'
+        maximum: '-0.001'
+      max_hold_seconds:
+        mode: numeric_step
+        deltas: ['-120', '0', '120']
+        minimum: '240'
+        maximum: '720'
+      long_stop_loss_bps:
+        mode: numeric_step
+        deltas: ['-2', '0', '2']
+        minimum: '8'
+        maximum: '18'
+      long_trailing_stop_activation_profit_bps:
+        mode: numeric_step
+        deltas: ['-2', '0', '2']
+        minimum: '6'
+        maximum: '14'
+      long_trailing_stop_drawdown_bps:
+        mode: numeric_step
+        deltas: ['-1', '0', '1']
+        minimum: '3'
+        maximum: '8'
+    strategy_override_mutations:
+      max_notional_per_trade:
+        mode: explicit_values
+        values: ['31590', '47385', '63180', '94770']
+      max_position_pct_equity:
+        mode: explicit_values
+        values: ['1.0', '1.5', '2.0']

--- a/services/torghut/config/trading/research-programs/strict-daily-profit-autoresearch-no-breakout-v1.yaml
+++ b/services/torghut/config/trading/research-programs/strict-daily-profit-autoresearch-no-breakout-v1.yaml
@@ -1,0 +1,251 @@
+schema_version: torghut.strategy-autoresearch.v1
+program_id: strict_daily_profit_autoresearch_no_breakout_v1
+description: >
+  Focused strict outer loop for daily-active strategy discovery using the MLX harness: exclude the
+  breakout reclaim lane after repeated stability failures and concentrate replay budget on the
+  remaining runtime-native long families with a plausible path to the $500/day target.
+snapshot_policy:
+  bar_interval: PT1S
+  feature_set_id: torghut.mlx-autoresearch.v1
+  quote_quality_policy_id: scheduler_v3_default
+  symbol_policy: args_or_sweep
+  allow_prior_day_features: true
+  allow_cross_sectional_features: true
+forbidden_mutations:
+  - runtime_code_path
+  - evaluator_logic
+  - live_strategy_config
+proposal_model_policy:
+  enabled: true
+  mode: ranking_only
+  backend_preference: mlx
+  top_k: 4
+  exploration_slots: 1
+  minimum_history_rows: 2
+replay_budget:
+  max_candidates_per_round: 4
+  exploration_slots: 1
+  max_candidates_per_frontier_run: 48
+runtime_closure_policy:
+  enabled: true
+  execute_parity_replay: true
+  execute_approval_replay: true
+  parity_window: full_window
+  approval_window: holdout
+  shadow_validation_mode: require_live_evidence
+  promotion_target: shadow
+parity_requirements:
+  - checked_in_runtime_family
+  - scheduler_v3_parity_replay
+  - scheduler_v3_approval_replay
+  - live_shadow_validation
+promotion_policy: research_only
+ledger_policy:
+  append_only: true
+objective:
+  target_net_pnl_per_day: '500'
+  min_active_day_ratio: '1.0'
+  min_positive_day_ratio: '0.625'
+  min_daily_notional: '300000'
+  max_best_day_share: '0.30'
+  max_worst_day_loss: '350'
+  max_drawdown: '900'
+  require_every_day_active: true
+  min_regime_slice_pass_rate: '0.45'
+  stop_when_objective_met: true
+research_sources:
+  - source_id: interpretable_hypothesis_driven_trading_2025
+    title: Interpretable Hypothesis-Driven Trading
+    url: https://arxiv.org/abs/2512.12924
+    published_at: '2025-12-15'
+    claims:
+      - claim_id: walk_forward_honesty
+        summary: Honest walk-forward validation with realistic costs matters more than headline returns.
+        implication: Reject candidates that only look good in aggregate or depend on one day.
+      - claim_id: interpretability_over_noise
+        summary: Interpretable families age better than opaque threshold soup.
+        implication: Prefer bounded family search over unconstrained parameter hacking.
+  - source_id: optimal_signal_extraction_order_flow_2026
+    title: Optimal Signal Extraction from Order Flow
+    url: https://arxiv.org/abs/2512.18648
+    published_at: '2026-02-20'
+    claims:
+      - claim_id: matched_filter_normalization
+        summary: Feature normalization should match the signal-generation mechanism.
+        implication: Search allowed normalization regimes directly.
+  - source_id: liquidity_constrained_portfolio_2025
+    title: Sharpe-Driven Stock Selection and Liquidity-Constrained Portfolio Optimization
+    url: https://arxiv.org/abs/2511.13251
+    published_at: '2025-11-17'
+    claims:
+      - claim_id: liquidity_upstream
+        summary: Liquidity and notional constraints belong upstream in candidate definition.
+        implication: Reject low-notional or low-participation families directly in the objective.
+families:
+  - family_template_id: momentum_pullback_v1
+    seed_sweep_config: ../profitability-frontier-strict-daily-momentum-pullback.yaml
+    max_iterations: 2
+    keep_top_candidates: 2
+    frontier_top_n: 5
+    force_keep_top_candidate_if_all_vetoed: true
+    symbol_prune_iterations: 1
+    symbol_prune_candidates: 2
+    symbol_prune_min_universe_size: 5
+    parameter_mutations:
+      exit_macd_hist_max:
+        mode: numeric_step
+        deltas: ['-0.002', '0', '0.002']
+        minimum: '-0.010'
+        maximum: '-0.001'
+      max_hold_seconds:
+        mode: numeric_step
+        deltas: ['-120', '0', '120']
+        minimum: '300'
+        maximum: '1200'
+      long_stop_loss_bps:
+        mode: numeric_step
+        deltas: ['-4', '0', '4']
+        minimum: '12'
+        maximum: '32'
+      long_trailing_stop_activation_profit_bps:
+        mode: numeric_step
+        deltas: ['-2', '0', '2']
+        minimum: '6'
+        maximum: '20'
+      long_trailing_stop_drawdown_bps:
+        mode: numeric_step
+        deltas: ['-1', '0', '1']
+        minimum: '3'
+        maximum: '10'
+    strategy_override_mutations:
+      max_notional_per_trade:
+        mode: explicit_values
+        values: ['63180', '126360', '189540']
+      max_position_pct_equity:
+        mode: explicit_values
+        values: ['2.0', '4.0']
+  - family_template_id: mean_reversion_rebound_v1
+    seed_sweep_config: ../profitability-frontier-strict-daily-mean-reversion.yaml
+    max_iterations: 2
+    keep_top_candidates: 2
+    frontier_top_n: 5
+    force_keep_top_candidate_if_all_vetoed: true
+    symbol_prune_iterations: 1
+    symbol_prune_candidates: 2
+    symbol_prune_min_universe_size: 5
+    parameter_mutations:
+      min_bull_rsi:
+        mode: numeric_step
+        deltas: ['-2', '0', '2']
+        minimum: '34'
+        maximum: '48'
+      min_price_below_vwap_bps:
+        mode: numeric_step
+        deltas: ['-4', '0', '4']
+        minimum: '6'
+        maximum: '20'
+      max_price_vs_session_open_bps:
+        mode: numeric_step
+        deltas: ['-10', '0', '10']
+        minimum: '-45'
+        maximum: '-10'
+      min_cross_section_reversal_rank:
+        mode: numeric_step
+        deltas: ['-0.05', '0', '0.05']
+        minimum: '0.60'
+        maximum: '0.90'
+    strategy_override_mutations:
+      max_notional_per_trade:
+        mode: explicit_values
+        values: ['63180', '126360', '189540']
+      max_position_pct_equity:
+        mode: explicit_values
+        values: ['2.0', '4.0']
+  - family_template_id: intraday_tsmom_v2
+    seed_sweep_config: ../profitability-frontier-strict-daily-tsmom.yaml
+    max_iterations: 3
+    keep_top_candidates: 2
+    frontier_top_n: 5
+    force_keep_top_candidate_if_all_vetoed: true
+    symbol_prune_iterations: 1
+    symbol_prune_candidates: 2
+    symbol_prune_min_universe_size: 5
+    parameter_mutations:
+      long_stop_loss_bps:
+        mode: numeric_step
+        deltas: ['-2', '0', '2']
+        minimum: '8'
+        maximum: '20'
+      long_trailing_stop_activation_profit_bps:
+        mode: numeric_step
+        deltas: ['-2', '0', '2']
+        minimum: '4'
+        maximum: '16'
+      long_trailing_stop_drawdown_bps:
+        mode: numeric_step
+        deltas: ['-1', '0', '1']
+        minimum: '2'
+        maximum: '8'
+      max_session_negative_exit_bps:
+        mode: numeric_step
+        deltas: ['-2', '0', '2']
+        minimum: '6'
+        maximum: '16'
+      min_cross_section_continuation_rank:
+        mode: numeric_step
+        deltas: ['-0.05', '0', '0.05']
+        minimum: '0.45'
+        maximum: '0.75'
+    strategy_override_mutations:
+      normalization_regime:
+        mode: allowed_normalizations
+      max_notional_per_trade:
+        mode: explicit_values
+        values: ['63180', '126360', '189540', '252720']
+      max_position_pct_equity:
+        mode: explicit_values
+        values: ['2.0', '3.0', '4.0']
+  - family_template_id: microstructure_continuation_matched_filter_v1
+    seed_sweep_config: ../profitability-frontier-strict-daily-microstructure.yaml
+    max_iterations: 2
+    keep_top_candidates: 1
+    frontier_top_n: 4
+    force_keep_top_candidate_if_all_vetoed: true
+    symbol_prune_iterations: 1
+    symbol_prune_candidates: 1
+    symbol_prune_min_universe_size: 4
+    parameter_mutations:
+      max_entries_per_session:
+        mode: numeric_step
+        deltas: ['-1', '0', '1']
+        minimum: '1'
+        maximum: '4'
+      entry_cooldown_seconds:
+        mode: numeric_step
+        deltas: ['-300', '0', '300']
+        minimum: '300'
+        maximum: '1800'
+    strategy_override_mutations:
+      normalization_regime:
+        mode: allowed_normalizations
+  - family_template_id: opening_drive_leader_reclaim_v1
+    seed_sweep_config: ../profitability-frontier-strict-daily-opening-drive.yaml
+    max_iterations: 2
+    keep_top_candidates: 1
+    frontier_top_n: 4
+    force_keep_top_candidate_if_all_vetoed: true
+    symbol_prune_iterations: 0
+    symbol_prune_candidates: 1
+    symbol_prune_min_universe_size: 4
+    parameter_mutations:
+      leader_reclaim_start_minutes_since_open:
+        mode: explicit_values
+        values: ['30', '45', '60']
+      entry_cooldown_seconds:
+        mode: numeric_step
+        deltas: ['-300', '0', '300']
+        minimum: '300'
+        maximum: '1200'
+    strategy_override_mutations:
+      normalization_regime:
+        mode: allowed_normalizations

--- a/services/torghut/tests/test_discovery_harness_v2.py
+++ b/services/torghut/tests/test_discovery_harness_v2.py
@@ -218,6 +218,16 @@ class TestDiscoveryHarnessV2(TestCase):
             short_template.runtime_harness['strategy_name'],
             'mean-reversion-exhaustion-short-v1',
         )
+        portfolio_template = load_family_template('microbar_cross_sectional_pairs_v1', directory=root)
+        self.assertEqual(portfolio_template.family_id, 'microbar_cross_sectional_pairs_v1')
+        self.assertEqual(
+            portfolio_template.runtime_harness['strategy_name'],
+            'microbar-cross-sectional-pairs-v1',
+        )
+        self.assertEqual(
+            portfolio_template.allowed_normalizations,
+            ('market_neutral_gross_scaled',),
+        )
         self.assertEqual(
             derive_family_template_id(explicit_id=' custom ', family='ignored'),
             'custom',

--- a/services/torghut/tests/test_mlx_autoresearch.py
+++ b/services/torghut/tests/test_mlx_autoresearch.py
@@ -93,7 +93,11 @@ def _program() -> StrategyAutoresearchProgram:
             exploration_slots=1,
             minimum_history_rows=1,
         ),
-        replay_budget=ReplayBudget(max_candidates_per_round=8, exploration_slots=1),
+        replay_budget=ReplayBudget(
+            max_candidates_per_round=8,
+            exploration_slots=1,
+            max_candidates_per_frontier_run=16,
+        ),
         runtime_closure_policy=RuntimeClosurePolicy(
             enabled=False,
             execute_parity_replay=True,

--- a/services/torghut/tests/test_runtime_closure.py
+++ b/services/torghut/tests/test_runtime_closure.py
@@ -59,7 +59,11 @@ def _program() -> StrategyAutoresearchProgram:
             exploration_slots=1,
             minimum_history_rows=1,
         ),
-        replay_budget=ReplayBudget(max_candidates_per_round=8, exploration_slots=1),
+        replay_budget=ReplayBudget(
+            max_candidates_per_round=8,
+            exploration_slots=1,
+            max_candidates_per_frontier_run=16,
+        ),
         runtime_closure_policy=RuntimeClosurePolicy(
             enabled=False,
             execute_parity_replay=True,
@@ -282,6 +286,134 @@ data:
                     execution_context=valid_context,
                     output_path=root / 'missing-params.yaml',
                 )
+
+    def test_materialize_candidate_configmap_supports_microbar_portfolio_candidates(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            configmap_path = root / 'valid.yaml'
+            configmap_path.write_text(
+                """
+apiVersion: v1
+kind: ConfigMap
+data:
+  strategies.yaml: |
+    strategies:
+      - name: breakout-continuation-long-v1
+        enabled: true
+        strategy_type: breakout_continuation_long_v1
+        params:
+          max_entries_per_session: '1'
+""".strip()
+                + '\n',
+                encoding='utf-8',
+            )
+            context = RuntimeClosureExecutionContext(
+                strategy_configmap_path=configmap_path,
+                clickhouse_http_url='http://example.invalid:8123',
+                clickhouse_username='torghut',
+                clickhouse_password='secret',
+                start_equity=Decimal('31590.02'),
+                chunk_minutes=10,
+            )
+            best_candidate = {
+                'candidate_id': 'cand-pairs',
+                'family': 'microbar_cross_sectional_pairs',
+                'family_template_id': 'microbar_cross_sectional_pairs_v1',
+                'strategy_name': 'microbar-cross-sectional-pairs-v1',
+                'replay_config': {
+                    'backend': 'microbar_daily_portfolio',
+                    'portfolio': {
+                        'base_per_leg_notional': '25000',
+                        'symbols': ['AAPL', 'NVDA', 'MSFT'],
+                        'sleeves': [
+                            {
+                                'entry_minute_after_open': 60,
+                                'exit_minute_after_open': 120,
+                                'signal': 'open_window_continuation',
+                                'top_n': 2,
+                                'weight': '2',
+                            },
+                            {
+                                'entry_minute_after_open': 75,
+                                'exit_minute_after_open': 'close',
+                                'signal': 'vwap_close_continuation',
+                                'top_n': 1,
+                                'weight': '1',
+                            },
+                        ],
+                    },
+                },
+            }
+
+            rendered_path = runtime_closure._materialize_candidate_configmap(
+                best_candidate=best_candidate,
+                execution_context=context,
+                output_path=root / 'portfolio.yaml',
+            )
+            rendered = runtime_closure.yaml.safe_load(rendered_path.read_text(encoding='utf-8'))
+            catalog = runtime_closure.yaml.safe_load(rendered['data']['strategies.yaml'])
+            strategies = catalog['strategies']
+            self.assertFalse(strategies[0]['enabled'])
+            self.assertEqual(
+                runtime_closure._candidate_symbols(
+                    best_candidate=best_candidate,
+                    execution_context=context,
+                ),
+                ('AAPL', 'NVDA', 'MSFT'),
+            )
+            microbar_names = [item['name'] for item in strategies[1:]]
+            self.assertEqual(
+                microbar_names,
+                [
+                    'microbar-cross-sectional-pairs-v1-sleeve-1-long',
+                    'microbar-cross-sectional-pairs-v1-sleeve-1-short',
+                    'microbar-cross-sectional-pairs-v1-sleeve-2-long',
+                    'microbar-cross-sectional-pairs-v1-sleeve-2-short',
+                ],
+            )
+            sleeve_one_long = strategies[1]
+            self.assertEqual(sleeve_one_long['strategy_type'], 'microbar_cross_sectional_long_v1')
+            self.assertEqual(sleeve_one_long['params']['rank_feature'], 'cross_section_session_open_rank')
+            self.assertEqual(sleeve_one_long['params']['selection_mode'], 'continuation')
+            self.assertEqual(sleeve_one_long['params']['max_concurrent_positions'], '2')
+            self.assertEqual(Decimal(str(sleeve_one_long['max_notional_per_trade'])), Decimal('50000'))
+
+            manifest = build_mlx_snapshot_manifest(
+                runner_run_id='run-1',
+                program=_program(),
+                symbols='AAPL,MSFT,NVDA',
+                train_days=6,
+                holdout_days=2,
+                full_window_start_date='2026-03-25',
+                full_window_end_date='2026-04-02',
+            )
+            candidate_spec = runtime_closure._candidate_spec(
+                runner_run_id='run-1',
+                program=_program(),
+                best_candidate=best_candidate,
+                manifest=manifest,
+            )
+            self.assertEqual(
+                candidate_spec['runtime_strategy_names'],
+                [
+                    'microbar-cross-sectional-pairs-v1-sleeve-1-long',
+                    'microbar-cross-sectional-pairs-v1-sleeve-1-short',
+                    'microbar-cross-sectional-pairs-v1-sleeve-2-long',
+                    'microbar-cross-sectional-pairs-v1-sleeve-2-short',
+                ],
+            )
+            self.assertEqual(candidate_spec['portfolio_promotion_v2']['strategy_count'], 4)
+            self.assertEqual(candidate_spec['full_window_start_date'], '2026-03-25')
+            self.assertEqual(candidate_spec['full_window_end_date'], '2026-04-02')
+            gate_report = runtime_closure._gate_report(
+                runner_run_id='run-1',
+                best_candidate=best_candidate,
+                promotion_target='shadow',
+                parity_report=None,
+                approval_report=None,
+                shadow_plan={'required': False, 'status': 'skipped'},
+            )
+            self.assertEqual(gate_report['vnext']['portfolio_promotion']['strategy_count'], 4)
 
     def test_replay_analysis_records_decomposition_errors(self) -> None:
         replay_payload = {


### PR DESCRIPTION
## Summary

- add a checked-in `microbar_cross_sectional_pairs_v1` family template and three focused strict autoresearch program variants used to isolate MLX search lanes
- teach runtime closure to consume frontier-style candidates, derive microbar portfolio sleeves into concrete runtime strategies, and emit portfolio-aware closure metadata instead of forcing a single strategy name
- add regression coverage for portfolio candidate materialization and load the new family template in discovery harness tests

## Related Issues

None

## Testing

- `cd services/torghut && /opt/homebrew/bin/mise exec uv -- uv run --frozen python -m pytest tests/test_runtime_closure.py tests/test_discovery_harness_v2.py -q`
- `cd services/torghut && /opt/homebrew/bin/mise exec uv -- uv run --frozen python -m ruff check app/trading/discovery/runtime_closure.py tests/test_runtime_closure.py tests/test_discovery_harness_v2.py`
- `cd services/torghut && /opt/homebrew/bin/mise exec uv -- uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && /opt/homebrew/bin/mise exec uv -- uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && /opt/homebrew/bin/mise exec uv -- uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && python - <<'PY' ... load_strategy_autoresearch_program(...) for the three new strict research-program YAMLs ... PY`
- `cd services/torghut && python - <<'PY' ... materialize candidate b7af1ea4bdbececee44c05a6 from /private/tmp/torghut-microbar-strict-mar25-apr02-v2.json and verify six enabled runtime sleeve strategies ... PY`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
