### PR TITLE
chore(jangar): promote image b31e2844

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 2a76ed34
-  digest: sha256:d86be27465e66dd35a8a6835b5e9c484f94c162726a21ff6650b83c14a2bc671
+  tag: b31e2844
+  digest: sha256:b712cfdc484bbd5db6235b1b50290abd1df3eb2638f3a9f342625764f7892b74
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 2a76ed34
-    digest: sha256:510acc602ed0f0433ace28946e5ea4c718cbcb5f3f727f96adbc729dd5055c44
+    tag: b31e2844
+    digest: sha256:4d519067f48c381b4565bc8db152023d384bfafba85403b8388c64a9d15357b1
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 2a76ed34
-    digest: sha256:d86be27465e66dd35a8a6835b5e9c484f94c162726a21ff6650b83c14a2bc671
+    tag: b31e2844
+    digest: sha256:b712cfdc484bbd5db6235b1b50290abd1df3eb2638f3a9f342625764f7892b74
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-04-11T06:36:20Z
+    deploy.knative.dev/rollout: 2026-04-11T08:20:04Z
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/name: jangar-worker
     app.kubernetes.io/part-of: lab
   annotations:
-    kubectl.kubernetes.io/restartedAt: 2026-04-11T06:36:20Z
+    kubectl.kubernetes.io/restartedAt: 2026-04-11T08:20:04Z
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -60,5 +60,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: 2a76ed34
-    digest: sha256:d86be27465e66dd35a8a6835b5e9c484f94c162726a21ff6650b83c14a2bc671
+    newTag: b31e2844
+    digest: sha256:b712cfdc484bbd5db6235b1b50290abd1df3eb2638f3a9f342625764f7892b74


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `b31e2844ba9c35f33a83ff7261b7ee22b7213eca`
- Image tag: `b31e2844`
- Image digest: `sha256:b712cfdc484bbd5db6235b1b50290abd1df3eb2638f3a9f342625764f7892b74`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`