### PR TITLE
fix(bilig): gate rollout on zero data migrations

### DIFF
--- a/argocd/applications/bilig/kustomization.yaml
+++ b/argocd/applications/bilig/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - bilig-cert-tls.yaml
   - zero-admin-sealedsecret.yaml
   - zero-strip-prefix-middleware.yaml
+  - zero-data-migration-job.yaml
   - app-deployment.yaml
   - app-pdb.yaml
   - app-service.yaml

--- a/argocd/applications/bilig/zero-data-migration-job.yaml
+++ b/argocd/applications/bilig/zero-data-migration-job.yaml
@@ -1,0 +1,65 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: bilig-zero-data-migrate
+  namespace: bilig
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookSucceeded
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 600
+  activeDeadlineSeconds: 900
+  template:
+    spec:
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: migrate
+          image: registry.ide-newton.ts.net/lab/bilig-app
+          imagePullPolicy: IfNotPresent
+          command:
+            - node
+            - --input-type=module
+            - -e
+            - |
+              import { createZeroPool, resolveZeroDatabaseUrl } from "./dist/zero/db.js";
+              import { runPendingZeroDataMigrations } from "./dist/zero/data-migration-runner.js";
+
+              const connectionString = resolveZeroDatabaseUrl();
+              if (!connectionString) {
+                throw new Error("DATABASE_URL missing");
+              }
+
+              const pool = createZeroPool(connectionString);
+              try {
+                const result = await runPendingZeroDataMigrations(pool);
+                console.log(JSON.stringify(result));
+              } finally {
+                await pool.end();
+              }
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: bilig-db-app
+                  key: uri
+                  optional: true
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL


### PR DESCRIPTION
## Summary
- add an Argo CD PreSync job for bilig Zero data migrations
- run the migration job with the bilig app image before deployment rollout
- keep the job idempotent and auto-cleaned after success

## Why
Recent bilig app rollouts crashed in startup with PendingZeroDataMigrationsError because required Zero data migrations were not run before the new app pod started.

## Validation
- bun run lint:argocd
- live emergency migration run completed successfully in-cluster
- kubectl -n bilig rollout status deployment/bilig-app
- argocd app get bilig
