### PR TITLE
fix(observability): accept OTLP delta metrics in mimir

### DIFF
--- a/argocd/applications/observability/mimir-values.yaml
+++ b/argocd/applications/observability/mimir-values.yaml
@@ -23,6 +23,8 @@ global:
 
 mimir:
   structuredConfig:
+    distributor:
+      otel_native_delta_ingestion: true
     limits:
       ingestion_rate: 20000
       ingestion_burst_size: 400000


### PR DESCRIPTION
## Summary

- enable `distributor.otel_native_delta_ingestion` in the observability Mimir values
- allow Mimir OTLP ingestion to accept Codex delta metrics instead of rejecting them with `invalid temporality and type combination`
- keep the existing `/otlp/v1/metrics` GitOps routing unchanged and fix the issue at the actual distributor ingestion layer

## Related Issues

None

## Testing

- `bun run lint:argocd`
- `mise exec helm@3 -- kubectl kustomize --enable-helm argocd/applications/observability >/tmp/observability-render.yaml`
- verified rendered output contains `distributor.otel_native_delta_ingestion: true`
- `kubectl -n observability logs deploy/observability-mimir-distributor --since=30m | rg -i 'otlp|invalid temporality|parse error|invalidargument|metrics'`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
