### PR TITLE
revert(observability): remove unsupported mimir OTLP delta setting

### DIFF
--- a/argocd/applications/observability/mimir-values.yaml
+++ b/argocd/applications/observability/mimir-values.yaml
@@ -23,8 +23,6 @@ global:
 
 mimir:
   structuredConfig:
-    distributor:
-      otel_native_delta_ingestion: true
     limits:
       ingestion_rate: 20000
       ingestion_burst_size: 400000


### PR DESCRIPTION
## Summary

- revert the unsupported `otel_native_delta_ingestion` Mimir distributor setting
- restore compatibility with the deployed Mimir version, which crashes on that unknown field during config load
- recover observability health before pursuing a version-compatible OTLP metrics fix

## Related Issues

None

## Testing

- `bun run lint:argocd`
- `mise exec helm@3 -- kubectl kustomize --enable-helm argocd/applications/observability >/tmp/observability-render-revert.yaml`
- verified rendered output no longer contains `otel_native_delta_ingestion`
- `kubectl -n observability logs pod/observability-mimir-distributor-6664dd6459-nhq9w --previous`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
