### PR TITLE
fix(tailscale): install stable operator chart with crds

### DIFF
--- a/argocd/applications/tailscale/kustomization.yaml
+++ b/argocd/applications/tailscale/kustomization.yaml
@@ -1,71 +1,15 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+
+helmCharts:
+  - name: tailscale-operator
+    repo: https://pkgs.tailscale.com/helmcharts
+    version: 1.96.5
+    releaseName: tailscale-operator
+    namespace: tailscale
+    valuesFile: values.yaml
+
 resources:
-  - https://raw.githubusercontent.com/tailscale/tailscale/refs/tags/v1.94.2/cmd/k8s-operator/deploy/manifests/operator.yaml
   - base/secrets.yaml
   - base/coredns-custom.yaml
   - base/connector-subnet-router.yaml
-
-images:
-  - name: tailscale/k8s-operator
-    newTag: stable
-  - name: tailscale/tailscale
-    newTag: stable
-
-patches:
-  - target:
-      kind: Namespace
-      name: tailscale
-    patch: |-
-      apiVersion: v1
-      kind: Namespace
-      metadata:
-        name: tailscale
-      $patch: delete
-  - target:
-      group: rbac.authorization.k8s.io
-      version: v1
-      kind: ClusterRole
-      name: tailscale-operator
-    patch: |-
-      - op: add
-        path: /rules/-
-        value:
-          apiGroups:
-            - ""
-          resources:
-            - secrets
-          verbs:
-            - get
-            - list
-            - watch
-            - create
-            - update
-            - patch
-            - delete
-      - op: add
-        path: /rules/-
-        value:
-          apiGroups:
-            - ""
-          resources:
-            - nodes
-          verbs:
-            - get
-            - list
-            - watch
-  - target:
-      group: apps
-      version: v1
-      kind: Deployment
-      name: operator
-    patch: |-
-      - op: replace
-        path: /spec/template/spec/volumes/0/secret/secretName
-        value: operator-oauth-token
-      - op: replace
-        path: /spec/template/spec/containers/0/image
-        value: tailscale/k8s-operator:stable
-      - op: replace
-        path: /spec/template/spec/containers/0/env/9/value
-        value: tailscale/tailscale:stable

--- a/argocd/applications/tailscale/values.yaml
+++ b/argocd/applications/tailscale/values.yaml
@@ -1,0 +1,5 @@
+installCRDs: true
+
+oauthSecretVolume:
+  secret:
+    secretName: operator-oauth-token


### PR DESCRIPTION
## Summary

- switch the Tailscale app from a raw `v1.94.2` operator manifest to the official stable `tailscale-operator` Helm chart (`1.96.5`)
- enable chart-managed CRD installation so the operator and installed CRDs stay in sync
- mount the existing sealed `operator-oauth-token` secret through chart values and remove the raw manifest image/volume patches

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm /tmp/lab-tailscale-stable/argocd/applications/tailscale >/dev/null`
- `mise exec helm@3 -- sh -lc 'out=$(mktemp); kustomize build --enable-helm /tmp/lab-tailscale-stable/argocd/applications/tailscale > "$out"; rg -n "name: tailnets.tailscale.com|name: proxygrouppolicies.tailscale.com|secretName: operator-oauth-token" "$out"'`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
