### PR TITLE
fix(feature-flags): manage flipt configmap in argocd

### DIFF
--- a/argocd/applications/feature-flags/kustomization.yaml
+++ b/argocd/applications/feature-flags/kustomization.yaml
@@ -13,3 +13,13 @@ helmCharts:
     releaseName: feature-flags
     namespace: feature-flags
     valuesFile: flipt-values.yaml
+
+patches:
+  - target:
+      kind: ConfigMap
+      name: feature-flags
+    patch: |-
+      - op: remove
+        path: /metadata/annotations/helm.sh~1hook
+      - op: remove
+        path: /metadata/annotations/helm.sh~1hook-weight


### PR DESCRIPTION
## Summary

- patch the rendered `feature-flags` Flipt configmap to remove Helm hook annotations
- make Argo CD manage the required configmap as a normal steady-state resource instead of a pre-install/pre-upgrade hook
- prevent a repeat of the outage mode where the workload can be broken while the app still reports `Synced`

## Related Issues

None

## Testing

- `mise exec helm@3 -- sh -lc 'out=$(mktemp); kustomize build --enable-helm /tmp/lab-feature-flags-configmap/argocd/applications/feature-flags > "$out"; rg -n "^kind: ConfigMap$|^  name: feature-flags$|helm.sh/hook|helm.sh/hook-weight" "$out"'`
- `kubectl get application -n argocd feature-flags -o jsonpath='{.status.sync.status}{"\t"}{.status.health.status}{"\n"}'`
- `kubectl get pods,svc,endpoints -n feature-flags`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
