### PR TITLE
chore(jangar): promote image 2ab2218f

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: b31e2844
-  digest: sha256:b712cfdc484bbd5db6235b1b50290abd1df3eb2638f3a9f342625764f7892b74
+  tag: 2ab2218f
+  digest: sha256:d76341d4122dc206383a654b6ff88e26b69c2cc81041cc0264c520cbe10cb57e
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: b31e2844
-    digest: sha256:4d519067f48c381b4565bc8db152023d384bfafba85403b8388c64a9d15357b1
+    tag: 2ab2218f
+    digest: sha256:752c09c2c0d91cb145706105a92a82d8ed72ccc2f7f82fa939eff10c499c2177
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: b31e2844
-    digest: sha256:b712cfdc484bbd5db6235b1b50290abd1df3eb2638f3a9f342625764f7892b74
+    tag: 2ab2218f
+    digest: sha256:d76341d4122dc206383a654b6ff88e26b69c2cc81041cc0264c520cbe10cb57e
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-04-11T08:20:04Z
+    deploy.knative.dev/rollout: 2026-04-18T21:35:49Z
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/name: jangar-worker
     app.kubernetes.io/part-of: lab
   annotations:
-    kubectl.kubernetes.io/restartedAt: 2026-04-11T08:20:04Z
+    kubectl.kubernetes.io/restartedAt: 2026-04-18T21:35:49Z
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -60,5 +60,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: b31e2844
-    digest: sha256:b712cfdc484bbd5db6235b1b50290abd1df3eb2638f3a9f342625764f7892b74
+    newTag: 2ab2218f
+    digest: sha256:d76341d4122dc206383a654b6ff88e26b69c2cc81041cc0264c520cbe10cb57e


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `2ab2218fd2564c1148a293515949aa3bc1025a3a`
- Image tag: `2ab2218f`
- Image digest: `sha256:d76341d4122dc206383a654b6ff88e26b69c2cc81041cc0264c520cbe10cb57e`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`