### PR TITLE
fix(jangar): skip pgvector ANN indexes at 4096

### DIFF
--- a/services/jangar/README.md
+++ b/services/jangar/README.md
@@ -374,6 +374,7 @@ When cache reads are enabled for `/api/agents/control-plane/resource` and `/api/
 - `OPENAI_EMBEDDING_DIMENSION` (optional; defaults to `1536` on OpenAI, or `4096` for the self-hosted model)
 - `OPENAI_EMBEDDING_TIMEOUT_MS` (optional; defaults to `15000`)
 - `OPENAI_EMBEDDING_MAX_INPUT_CHARS` (optional; defaults to `60000`)
+- With pgvector `0.8.0`, ANN indexes (`ivfflat` / `hnsw`) cannot be created above `2000` dimensions. The 4096d self-hosted path uses plain `vector(4096)` columns without ANN indexes.
 - `JANGAR_BUMBA_TASK_QUEUE` (optional; API queue for enqueued Bumba workflows)
 - `JANGAR_WORKER_TEMPORAL_TASK_QUEUE` (optional; worker queue override)
 - `JANGAR_WORKER_HEALTH_PORT` (optional; defaults to `3002`)

--- a/services/jangar/src/server/__tests__/pgvector-indexing.test.ts
+++ b/services/jangar/src/server/__tests__/pgvector-indexing.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+
+import { MAX_PGVECTOR_ANN_DIMENSION, supportsPgvectorAnnIndex } from '~/server/pgvector-indexing'
+
+describe('pgvector indexing', () => {
+  it('allows ANN indexes at or below the pgvector limit', () => {
+    expect(supportsPgvectorAnnIndex(MAX_PGVECTOR_ANN_DIMENSION)).toBe(true)
+    expect(supportsPgvectorAnnIndex(1536)).toBe(true)
+  })
+
+  it('disables ANN indexes above the pgvector limit', () => {
+    expect(supportsPgvectorAnnIndex(4096)).toBe(false)
+  })
+})

--- a/services/jangar/src/server/migrations/20251228_init.ts
+++ b/services/jangar/src/server/migrations/20251228_init.ts
@@ -2,6 +2,7 @@ import { type Kysely, sql } from 'kysely'
 
 import type { Database } from '../db'
 import { resolveEmbeddingConfig } from '../memory-config'
+import { createPgvectorAnnIndexIfSupported } from '../pgvector-indexing'
 
 const resolveEmbeddingDimension = () => resolveEmbeddingConfig(process.env).dimension
 
@@ -373,12 +374,12 @@ export const up = async (db: Kysely<Database>) => {
     ON ${sql.ref('atlas.enrichments')} USING GIN (metadata JSONB_PATH_OPS);
   `.execute(db)
 
-  await sql`
-    CREATE INDEX IF NOT EXISTS atlas_embeddings_embedding_idx
-    ON ${sql.ref('atlas.embeddings')}
-    USING ivfflat (embedding vector_cosine_ops)
-    WITH (lists = 100);
-  `.execute(db)
+  await createPgvectorAnnIndexIfSupported(
+    db,
+    embeddingDimension,
+    'CREATE INDEX IF NOT EXISTS atlas_embeddings_embedding_idx ON atlas.embeddings USING ivfflat (embedding vector_cosine_ops) WITH (lists = 100);',
+    'atlas.embeddings',
+  )
 
   await sql`
     CREATE INDEX IF NOT EXISTS atlas_symbols_lookup_idx
@@ -425,12 +426,12 @@ export const up = async (db: Kysely<Database>) => {
     ON ${sql.ref('memories.entries')} (encoder_model, encoder_version);
   `.execute(db)
 
-  await sql`
-    CREATE INDEX IF NOT EXISTS memories_entries_embedding_idx
-    ON ${sql.ref('memories.entries')}
-    USING ivfflat (embedding vector_cosine_ops)
-    WITH (lists = 100);
-  `.execute(db)
+  await createPgvectorAnnIndexIfSupported(
+    db,
+    embeddingDimension,
+    'CREATE INDEX IF NOT EXISTS memories_entries_embedding_idx ON memories.entries USING ivfflat (embedding vector_cosine_ops) WITH (lists = 100);',
+    'memories.entries',
+  )
 
   await sql`
     CREATE INDEX IF NOT EXISTS torghut_symbols_enabled_idx

--- a/services/jangar/src/server/migrations/20260209_atlas_chunk_search.ts
+++ b/services/jangar/src/server/migrations/20260209_atlas_chunk_search.ts
@@ -2,6 +2,7 @@ import { type Kysely, sql } from 'kysely'
 
 import type { Database } from '../db'
 import { resolveEmbeddingConfig } from '../memory-config'
+import { createPgvectorAnnIndexIfSupported } from '../pgvector-indexing'
 
 const resolveEmbeddingDimension = () => resolveEmbeddingConfig(process.env).dimension
 
@@ -38,12 +39,12 @@ export const up = async (db: Kysely<Database>) => {
     ON ${sql.ref('atlas.chunk_embeddings')} (model, dimension);
   `.execute(db)
 
-  await sql`
-    CREATE INDEX IF NOT EXISTS atlas_chunk_embeddings_embedding_idx
-    ON ${sql.ref('atlas.chunk_embeddings')}
-    USING ivfflat (embedding vector_cosine_ops)
-    WITH (lists = 100);
-  `.execute(db)
+  await createPgvectorAnnIndexIfSupported(
+    db,
+    embeddingDimension,
+    'CREATE INDEX IF NOT EXISTS atlas_chunk_embeddings_embedding_idx ON atlas.chunk_embeddings USING ivfflat (embedding vector_cosine_ops) WITH (lists = 100);',
+    'atlas.chunk_embeddings',
+  )
 }
 
 export const down = async (_db: Kysely<Database>) => {}

--- a/services/jangar/src/server/migrations/20260418_embedding_dimension_4096.ts
+++ b/services/jangar/src/server/migrations/20260418_embedding_dimension_4096.ts
@@ -3,6 +3,7 @@ import { type Kysely, sql } from 'kysely'
 import type { Database } from '../db'
 import { requestEmbeddings } from '../embedding-client'
 import { resolveEmbeddingConfig } from '../memory-config'
+import { createPgvectorAnnIndexIfSupported } from '../pgvector-indexing'
 
 const TARGET_DIMENSION = 4096
 const BATCH_SIZE = 32
@@ -211,11 +212,12 @@ const rebuildMemoriesEntries = async (db: Kysely<Database>, embeddingConfig: Mig
       'CREATE INDEX memories_entries_4096_next_encoder_idx ON memories.entries_4096_next (encoder_model, encoder_version)',
     )
     .execute(db)
-  await sql
-    .raw(
-      'CREATE INDEX memories_entries_4096_next_embedding_idx ON memories.entries_4096_next USING ivfflat (embedding vector_cosine_ops) WITH (lists = 100)',
-    )
-    .execute(db)
+  await createPgvectorAnnIndexIfSupported(
+    db,
+    TARGET_DIMENSION,
+    'CREATE INDEX memories_entries_4096_next_embedding_idx ON memories.entries_4096_next USING ivfflat (embedding vector_cosine_ops) WITH (lists = 100)',
+    'memories.entries_4096_next',
+  )
 
   for (let start = 0; start < rows.length; start += BATCH_SIZE) {
     const batch = rows.slice(start, start + BATCH_SIZE)
@@ -271,11 +273,12 @@ const resetAtlasEmbeddings = async (db: Kysely<Database>) => {
     )
   `)
     .execute(db)
-  await sql
-    .raw(
-      'CREATE INDEX atlas_embeddings_4096_next_embedding_idx ON atlas.embeddings_4096_next USING ivfflat (embedding vector_cosine_ops) WITH (lists = 100)',
-    )
-    .execute(db)
+  await createPgvectorAnnIndexIfSupported(
+    db,
+    TARGET_DIMENSION,
+    'CREATE INDEX atlas_embeddings_4096_next_embedding_idx ON atlas.embeddings_4096_next USING ivfflat (embedding vector_cosine_ops) WITH (lists = 100)',
+    'atlas.embeddings_4096_next',
+  )
 
   await db.transaction().execute(async (trx) => {
     await sql.raw('LOCK TABLE atlas.embeddings IN ACCESS EXCLUSIVE MODE').execute(trx)
@@ -323,11 +326,12 @@ const resetAtlasChunkEmbeddings = async (db: Kysely<Database>) => {
       'CREATE INDEX atlas_chunk_embeddings_4096_next_model_dimension_idx ON atlas.chunk_embeddings_4096_next (model, dimension)',
     )
     .execute(db)
-  await sql
-    .raw(
-      'CREATE INDEX atlas_chunk_embeddings_4096_next_embedding_idx ON atlas.chunk_embeddings_4096_next USING ivfflat (embedding vector_cosine_ops) WITH (lists = 100)',
-    )
-    .execute(db)
+  await createPgvectorAnnIndexIfSupported(
+    db,
+    TARGET_DIMENSION,
+    'CREATE INDEX atlas_chunk_embeddings_4096_next_embedding_idx ON atlas.chunk_embeddings_4096_next USING ivfflat (embedding vector_cosine_ops) WITH (lists = 100)',
+    'atlas.chunk_embeddings_4096_next',
+  )
 
   await db.transaction().execute(async (trx) => {
     await sql.raw('LOCK TABLE atlas.chunk_embeddings IN ACCESS EXCLUSIVE MODE').execute(trx)

--- a/services/jangar/src/server/pgvector-indexing.ts
+++ b/services/jangar/src/server/pgvector-indexing.ts
@@ -1,0 +1,28 @@
+import { type Kysely, sql } from 'kysely'
+
+import type { Database } from './db'
+
+export const MAX_PGVECTOR_ANN_DIMENSION = 2000
+
+export const supportsPgvectorAnnIndex = (dimension: number) =>
+  Number.isFinite(dimension) && dimension > 0 && dimension <= MAX_PGVECTOR_ANN_DIMENSION
+
+export const createPgvectorAnnIndexIfSupported = async (
+  db: Kysely<Database>,
+  dimension: number,
+  ddl: string,
+  context: string,
+) => {
+  if (!supportsPgvectorAnnIndex(dimension)) {
+    console.log('[jangar:pgvector]', {
+      event: 'skip_ann_index',
+      context,
+      dimension,
+      maxSupportedDimension: MAX_PGVECTOR_ANN_DIMENSION,
+    })
+    return false
+  }
+
+  await sql.raw(ddl).execute(db)
+  return true
+}


### PR DESCRIPTION
## Summary

- make Jangar's pgvector ANN index creation conditional on the live pgvector dimension limit instead of attempting `ivfflat` on 4096d vectors
- fix the fresh-schema migrations plus the 4096 hard-migration path so `memories.entries`, `atlas.embeddings`, and `atlas.chunk_embeddings` can use `vector(4096)` without blowing up on index creation
- document the pgvector `0.8.0` 2000-dimension ANN limit and add a regression test for the guard

## Related Issues

None

## Testing

- `bunx tsc -p services/jangar/tsconfig.json --noEmit`
- `bunx vitest run --config vitest.config.ts src/server/__tests__/kysely-migrations.test.ts src/server/__tests__/memory-config.test.ts src/server/__tests__/memory-provider-health.test.ts src/server/__tests__/pgvector-indexing.test.ts src/routes/ready.test.ts` (from `services/jangar`)
- `bun run test` (from `services/jangar`)
- live DB probe: pgvector `0.8.0` rejected both `ivfflat` and `hnsw` on `vector(4096)` with `column cannot have more than 2000 dimensions`

## Screenshots (if applicable)

N/A

## Breaking Changes

None beyond the already-merged 4096 hard migration. This PR makes that rollout viable on the live pgvector build by skipping ANN index creation when the configured embedding dimension exceeds pgvector's supported limit.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
