### PR TITLE
build(jangar): pin 640cb586 hotfix image

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -26,7 +26,7 @@ spec:
       serviceAccountName: jangar-inspector
       initContainers:
         - name: bootstrap-workspace
-          image: registry.ide-newton.ts.net/lab/jangar
+          image: registry.ide-newton.ts.net/lab/jangar:640cb586@sha256:78913053b4bd222d01d2351eb19136edfda3fa4cb8253541b4ac0736f092ac26
           imagePullPolicy: IfNotPresent
           command:
             - sh
@@ -47,7 +47,7 @@ spec:
               mountPath: /workspace
       containers:
         - name: app
-          image: registry.ide-newton.ts.net/lab/jangar:latest
+          image: registry.ide-newton.ts.net/lab/jangar:640cb586@sha256:78913053b4bd222d01d2351eb19136edfda3fa4cb8253541b4ac0736f092ac26
           imagePullPolicy: Always
           env:
             - name: NODE_ENV

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       initContainers:
         - name: bootstrap-workspace
-          image: registry.ide-newton.ts.net/lab/jangar
+          image: registry.ide-newton.ts.net/lab/jangar:640cb586@sha256:78913053b4bd222d01d2351eb19136edfda3fa4cb8253541b4ac0736f092ac26
           imagePullPolicy: IfNotPresent
           command:
             - sh
@@ -58,7 +58,7 @@ spec:
               mountPath: /workspace
       containers:
         - name: jangar-worker
-          image: registry.ide-newton.ts.net/lab/jangar:latest
+          image: registry.ide-newton.ts.net/lab/jangar:640cb586@sha256:78913053b4bd222d01d2351eb19136edfda3fa4cb8253541b4ac0736f092ac26
           imagePullPolicy: Always
           command:
             - bun


### PR DESCRIPTION
## Summary

- pin `argocd/applications/jangar` app and worker images to the already-built `640cb586` Jangar hotfix digest
- unblock the 4096 embedding migration rollout while the automated `jangar-release` promotion workflow is stuck
- keep the live cluster on a declarative desired image instead of depending on mutable tag timing

## Related Issues

None

## Testing

- verified the published Jangar hotfix image digest from `jangar-build-push` run `24617613678`
- verified the live cluster was still pinned to the old `a30048cb` digest before this manifest bump
- manual validation pending after merge: Argo sync `jangar`, trigger `/api/memories`, confirm `vector(4096)` schema and successful live write

## Screenshots (if applicable)

N/A

## Breaking Changes

None. This is a manifest promotion to the already-built hotfix image.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
