### PR TITLE
chore(jangar): promote image 640cb586

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: a30048cb
-  digest: sha256:575490c30f381a921ef4da53de4631c08ddbcf1e50fa13e424e4d31e1f6cc940
+  tag: 640cb586
+  digest: sha256:78913053b4bd222d01d2351eb19136edfda3fa4cb8253541b4ac0736f092ac26
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: a30048cb
-    digest: sha256:d6030b04b9f76cbc470e81c6660135a520995a6937145e8558fa1edaf74b55ec
+    tag: 640cb586
+    digest: sha256:68801ca6665749061f0151378bd63ce2afd3a48d336b181e6bf0c86a88359a93
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: a30048cb
-    digest: sha256:575490c30f381a921ef4da53de4631c08ddbcf1e50fa13e424e4d31e1f6cc940
+    tag: 640cb586
+    digest: sha256:78913053b4bd222d01d2351eb19136edfda3fa4cb8253541b4ac0736f092ac26
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-04-19T00:47:12Z
+    deploy.knative.dev/rollout: 2026-04-19T01:07:46Z
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/name: jangar-worker
     app.kubernetes.io/part-of: lab
   annotations:
-    kubectl.kubernetes.io/restartedAt: 2026-04-19T00:47:12Z
+    kubectl.kubernetes.io/restartedAt: 2026-04-19T01:07:46Z
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -60,5 +60,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: a30048cb
-    digest: sha256:575490c30f381a921ef4da53de4631c08ddbcf1e50fa13e424e4d31e1f6cc940
+    newTag: 640cb586
+    digest: sha256:78913053b4bd222d01d2351eb19136edfda3fa4cb8253541b4ac0736f092ac26


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `640cb586496c42c03c6f253f80f59a65f556726f`
- Image tag: `640cb586`
- Image digest: `sha256:78913053b4bd222d01d2351eb19136edfda3fa4cb8253541b4ac0736f092ac26`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`