### PR TITLE
build(bumba): promote f1d7c590 image

### DIFF
--- a/argocd/applications/bumba/deployment.yaml
+++ b/argocd/applications/bumba/deployment.yaml
@@ -22,7 +22,7 @@ spec:
         app.kubernetes.io/name: bumba
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-04-18T20:21:30.540Z"
+        kubectl.kubernetes.io/restartedAt: "2026-04-19T02:59:12.139Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/bumba/kustomization.yaml
+++ b/argocd/applications/bumba/kustomization.yaml
@@ -6,5 +6,5 @@ resources:
   - deployment.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/bumba
-    newTag: sha-a30048c
+    newTag: "f1d7c590f"
     newName: registry.ide-newton.ts.net/lab/bumba


### PR DESCRIPTION
## Summary

- promote Bumba to the freshly built `f1d7c590f` image
- update the rollout annotation so the Deployment restarts onto the promoted image
- keep the existing 4096 embedding config on `main` while making the live worker image match it

## Related Issues

None

## Testing

- `bun run packages/scripts/src/bumba/deploy-service.ts`
- `kubectl kustomize /Users/gregkonush/.codex/worktrees/bumba-deploy-4096/argocd/applications/bumba | rg -n "image:|OPENAI_EMBEDDING_DIMENSION|OPENAI_EMBEDDING_API_BASE_URL" -A1 -B1 -S`
- `kubectl describe deploy -n jangar bumba`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
