### PR TITLE
fix(bumba): stabilize worker build ids

### DIFF
--- a/argocd/applications/bumba/deployment.yaml
+++ b/argocd/applications/bumba/deployment.yaml
@@ -22,7 +22,7 @@ spec:
         app.kubernetes.io/name: bumba
         app.kubernetes.io/part-of: lab
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-04-19T02:59:12.139Z"
+        kubectl.kubernetes.io/restartedAt: "2026-04-19T03:05:32.057Z"
     spec:
       initContainers:
         - name: bootstrap-workspace

--- a/argocd/applications/bumba/kustomization.yaml
+++ b/argocd/applications/bumba/kustomization.yaml
@@ -6,5 +6,5 @@ resources:
   - deployment.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/bumba
-    newTag: sha-a30048c
+    newTag: "854e98138"
     newName: registry.ide-newton.ts.net/lab/bumba

--- a/packages/scripts/src/bumba/__tests__/build-image.test.ts
+++ b/packages/scripts/src/bumba/__tests__/build-image.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, beforeAll, describe, expect, it } from 'bun:test'
+
+let originalSpawnSync: typeof Bun.spawnSync
+
+beforeAll(() => {
+  originalSpawnSync = Bun.spawnSync
+})
+
+afterEach(() => {
+  Bun.spawnSync = originalSpawnSync
+})
+
+describe('bumba build-image internals', () => {
+  it('includes LAB_GIT_SHA in build args so the worker build id is stable', async () => {
+    const { __private } = await import('../build-image')
+
+    expect(__private.resolveBuildArgs('v0.1.0', 'abc123def456')).toEqual({
+      BUMBA_VERSION: 'v0.1.0',
+      BUMBA_COMMIT: 'abc123def456',
+      LAB_GIT_SHA: 'abc123def456',
+    })
+  })
+
+  it('execGit returns trimmed output', async () => {
+    Bun.spawnSync = ((..._args: Parameters<typeof Bun.spawnSync>) => ({
+      exitCode: 0,
+      stdout: Buffer.from('abc123\n'),
+      stderr: new Uint8Array(),
+    })) as typeof Bun.spawnSync
+
+    const { __private } = await import('../build-image')
+    expect(__private.execGit(['rev-parse', 'HEAD'])).toBe('abc123')
+  })
+
+  it('execGit throws on failure', async () => {
+    Bun.spawnSync = ((..._args: Parameters<typeof Bun.spawnSync>) => ({
+      exitCode: 1,
+      stdout: new Uint8Array(),
+      stderr: Buffer.from('error'),
+    })) as typeof Bun.spawnSync
+
+    const { __private } = await import('../build-image')
+    expect(() => __private.execGit(['describe'])).toThrow(/git describe failed/)
+  })
+})

--- a/packages/scripts/src/bumba/build-image.ts
+++ b/packages/scripts/src/bumba/build-image.ts
@@ -38,6 +38,12 @@ const createPrunedContext = async (): Promise<{ dir: string; cleanup: () => void
   }
 }
 
+const resolveBuildArgs = (version: string, commit: string) => ({
+  BUMBA_VERSION: version,
+  BUMBA_COMMIT: commit,
+  LAB_GIT_SHA: commit,
+})
+
 export const buildImage = async (options: BuildImageOptions = {}) => {
   const registry = options.registry ?? process.env.BUMBA_IMAGE_REGISTRY ?? 'registry.ide-newton.ts.net'
   const repository = options.repository ?? process.env.BUMBA_IMAGE_REPOSITORY ?? 'lab/bumba'
@@ -70,10 +76,7 @@ export const buildImage = async (options: BuildImageOptions = {}) => {
       tag,
       context,
       dockerfile,
-      buildArgs: {
-        BUMBA_VERSION: version,
-        BUMBA_COMMIT: commit,
-      },
+      buildArgs: resolveBuildArgs(version, commit),
       cacheRef,
     })
 
@@ -92,4 +95,5 @@ if (import.meta.main) {
 
 export const __private = {
   execGit,
+  resolveBuildArgs,
 }


### PR DESCRIPTION
## Summary

- pass `LAB_GIT_SHA` into the Bumba Docker build so `TEMPORAL_WORKER_BUILD_ID` is derived from the git commit instead of defaulting to `bumba@dev`
- add a targeted regression test for the Bumba build-image helper
- promote the corrected Bumba image `854e98138` and refresh the rollout annotation

## Related Issues

None

## Testing

- `bun test packages/scripts/src/bumba/__tests__/build-image.test.ts`
- `bunx oxfmt --check packages/scripts/src/bumba/build-image.ts packages/scripts/src/bumba/__tests__/build-image.test.ts`
- `bun run packages/scripts/src/bumba/deploy-service.ts`
- `kubectl logs -n jangar deploy/bumba --tail=80`
- `kubectl get rs -n jangar -l app.kubernetes.io/name=bumba --sort-by=.metadata.creationTimestamp -o 'custom-columns=NAME:.metadata.name,DESIRED:.spec.replicas,CURRENT:.status.replicas,READY:.status.readyReplicas,IMAGE:.spec.template.spec.containers[0].image,RESTARTED:.spec.template.metadata.annotations.kubectl\.kubernetes\.io/restartedAt'`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
