### PR TITLE
feat(torghut): add whitepaper autoresearch profit factory

### DIFF
--- a/docs/torghut/design-system/v6/71-torghut-whitepaper-autoresearch-profit-target-strategy-factory-2026-04-21.md
+++ b/docs/torghut/design-system/v6/71-torghut-whitepaper-autoresearch-profit-target-strategy-factory-2026-04-21.md
@@ -1,0 +1,1096 @@
+# 71. Torghut Whitepaper Autoresearch Profit-Target Strategy Factory (2026-04-21)
+
+Status: Ready for implementation
+Date: `2026-04-21`
+Owner: Torghut research and runtime lane
+Scope: Implement a production autoresearch system that reads whitepapers, extracts typed trading
+hypotheses, generates families/sleeves/algorithms/configurations, prioritizes them with MLX, proves
+them through runtime-native replay, and assembles a portfolio candidate targeting at least `$500`
+post-cost net PnL per trading day.
+
+Extends:
+
+- `docs/torghut/design-system/v6/69-torghut-harness-v2-strategy-discovery-and-whitepaper-research-factory-2026-04-07.md`
+- `docs/torghut/design-system/v6/70-torghut-mlx-autoresearch-and-apple-silicon-research-lane-2026-04-10.md`
+- `docs/torghut/design-system/v6/68-torghut-strategy-factory-formal-validity-and-sequential-promotion-2026-04-04.md`
+- `docs/torghut/design-system/v6/54-torghut-research-backed-sleeves-and-this-week-holdout-proof-2026-03-27.md`
+- `docs/torghut/design-system/v6/51-torghut-promotion-certificate-and-segment-firebreak-handoff-2026-03-19.md`
+
+## Executive Summary
+
+The production target is not "find one magic strategy." The target is a repeatable research machine
+that can discover and prove a portfolio of small, diverse sleeves whose combined post-cost evidence
+meets the `$500/day` objective with bounded concentration, drawdown, slippage, and promotion risk.
+
+The system has five hard responsibilities:
+
+1. Turn whitepapers into typed, auditable hypotheses.
+2. Compile hypotheses into bounded Torghut candidate specs, not arbitrary code.
+3. Use MLX to rank and allocate research compute toward promising candidates.
+4. Use scheduler-v3/runtime replay as the only source of performance truth.
+5. Promote only portfolio candidates that satisfy the profit target and all runtime closure gates.
+
+This document is the implementation contract. It names the current in-tree foundations, the missing
+modules, the schemas, the scoring logic, the tests, and the rollout order.
+
+## Current Codebase State
+
+Torghut already has the right base pieces. The implementation should compose and harden them instead
+of building a parallel system.
+
+### Whitepaper Intake and Persistence
+
+Current source paths:
+
+- `services/torghut/app/whitepapers/workflow.py`
+- `docs/torghut/whitepaper-research-workflow.md`
+- `services/torghut/app/models/entities.py`
+- migrations under `services/torghut/migrations/versions/`
+
+Already present:
+
+- Whitepaper workflow accepts GitHub issue payloads with a PDF URL, stores the PDF in Ceph, creates a
+  DB run, dispatches an AgentRun, and finalizes persisted synthesis/verdict/artifacts.
+- Whitepaper persistence includes documents, versions, contents, analysis runs, steps, AgentRuns,
+  syntheses, viability verdicts, artifacts, engineering triggers, rollout transitions, semantic
+  chunks, and embeddings.
+- Structured whitepaper extraction models already exist:
+  - `WhitepaperClaim`
+  - `WhitepaperClaimRelation`
+  - `WhitepaperStrategyTemplate`
+  - `WhitepaperExperimentSpec`
+  - `WhitepaperContradictionEvent`
+
+Implementation decision:
+
+- Reuse these tables as the source of truth for paper-derived claims and experiment specs.
+- Add only the minimal new tables needed for autoresearch run state, portfolio assembly, and MLX
+  model lineage.
+
+### Strategy Factory
+
+Current source paths:
+
+- `services/torghut/scripts/run_strategy_factory_v2.py`
+- `services/torghut/app/trading/discovery/validation.py`
+- `services/torghut/app/trading/alpha/lane.py`
+- `services/torghut/tests/test_run_strategy_factory_v2.py`
+
+Already present:
+
+- `run_strategy_factory_v2.py` loads `VNextExperimentSpec` rows, compiles sweep configs, executes
+  `run_consistent_profitability_frontier`, writes artifacts, and persists `VNextExperimentRun`.
+- Strategy factory validation emits formal validity, CSCV/PBO proxy, deflated-Sharpe proxy,
+  selection-bias adjustment, execution reality, posterior edge, baseline comparison, economic
+  validity, stress results, cost calibration, and sequential trial payloads.
+- The current validation helper is still TSMOM-shaped. It needs to become family-agnostic.
+
+Implementation decision:
+
+- Keep `VNextExperimentSpec` as the bridge from paper-derived hypotheses to executable experiment
+  sweeps.
+- Generalize `build_strategy_factory_evaluation` from `tsmom` to a pluggable family evaluator.
+
+### MLX Autoresearch
+
+Current source paths:
+
+- `services/torghut/app/trading/discovery/autoresearch.py`
+- `services/torghut/app/trading/discovery/mlx_features.py`
+- `services/torghut/app/trading/discovery/mlx_proposal_models.py`
+- `services/torghut/app/trading/discovery/mlx_snapshot.py`
+- `services/torghut/app/trading/discovery/mlx_notebook_exports.py`
+- `services/torghut/scripts/run_strategy_autoresearch_loop.py`
+- `services/torghut/tests/test_mlx_autoresearch.py`
+- `services/torghut/tests/test_strategy_autoresearch.py`
+
+Already present:
+
+- Strategy autoresearch programs define objective, snapshot policy, forbidden mutations, proposal
+  model policy, replay budget, runtime closure policy, parity requirements, and promotion policy.
+- MLX snapshot manifests and signal bundles are emitted.
+- Candidate descriptors are converted into numeric vectors.
+- Proposal scoring supports `backend_preference: mlx` with NumPy fallback.
+- The current proposal model is ranking-only and heuristic. It is the right v0 boundary, but not the
+  final production ranker.
+
+Implementation decision:
+
+- Keep MLX as a proposal and portfolio-assembly accelerator.
+- Do not let MLX approve candidates, bypass replay, or write live runtime config.
+- Replace the heuristic ranker with a learned ranking model trained from the experiment ledger.
+
+### Objective and Promotion Truth
+
+Current source paths:
+
+- `services/torghut/app/trading/discovery/objectives.py`
+- `services/torghut/app/trading/discovery/runtime_closure.py`
+- `services/torghut/app/trading/discovery/promotion_contract.py`
+- `services/torghut/app/trading/autonomy/policy_checks.py`
+- `services/torghut/app/trading/autonomy/evidence.py`
+
+Already present:
+
+- Objective vetoes include active-day ratio, daily notional, best-day share, worst-day loss,
+  drawdown, regime-slice pass rate, and stale-tape rejection.
+- Runtime closure writes replay, approval, promotion, rollback, and shadow-validation artifacts.
+- Portfolio-aware runtime closure has microbar sleeve materialization hooks.
+- Promotion checks already consume strategy-factory evidence and portfolio-promotion summaries.
+
+Implementation decision:
+
+- `$500/day` is a portfolio-level objective.
+- Single sleeves can be below `$500/day` if they improve the portfolio objective after correlation,
+  concentration, and risk penalties.
+- A candidate is never called production-ready until runtime closure and shadow evidence pass.
+
+## Target Architecture
+
+```mermaid
+flowchart TD
+  Paper["Whitepaper PDF / URL"] --> Intake["Whitepaper workflow"]
+  Intake --> Content["whitepaper_contents + semantic chunks"]
+  Content --> Claims["WhitepaperClaim + ClaimRelation"]
+  Claims --> Hypotheses["Hypothesis cards"]
+  Hypotheses --> Specs["WhitepaperExperimentSpec + VNextExperimentSpec"]
+  Specs --> Factory["Strategy factory / autoresearch runner"]
+  Factory --> MLX["MLX proposal ranker"]
+  MLX --> Replay["Scheduler-v3 runtime replay"]
+  Replay --> Evidence["Research evidence bundle"]
+  Evidence --> Portfolio["Portfolio sleeve optimizer"]
+  Portfolio --> Closure["Runtime closure"]
+  Closure --> Gate["Promotion prerequisites"]
+  Gate --> PaperStage["paper / shadow / constrained_live / scaled_live"]
+```
+
+The loop is continuous:
+
+1. New whitepapers add claims.
+2. Claims compile into hypothesis cards.
+3. Hypothesis cards compile into candidate specs.
+4. Candidate specs produce experiments.
+5. Experiments produce replay evidence.
+6. Replay evidence trains the next MLX proposal model.
+7. Portfolio assembly picks the best sleeve set for the `$500/day` objective.
+8. Runtime closure determines whether the portfolio can advance stages.
+
+## Core Production Contracts
+
+### 1. Hypothesis Card
+
+Add `services/torghut/app/trading/discovery/hypothesis_cards.py`.
+
+Every whitepaper-derived idea must compile to this structure before any experiment is run:
+
+```python
+@dataclass(frozen=True)
+class HypothesisCard:
+    schema_version: Literal['torghut.hypothesis-card.v1']
+    hypothesis_id: str
+    source_run_id: str
+    source_claim_ids: tuple[str, ...]
+    mechanism: str
+    asset_scope: str
+    horizon_scope: str
+    expected_direction: str
+    required_features: tuple[str, ...]
+    entry_motifs: tuple[str, ...]
+    exit_motifs: tuple[str, ...]
+    risk_controls: tuple[str, ...]
+    expected_regimes: tuple[str, ...]
+    failure_modes: tuple[str, ...]
+    implementation_constraints: Mapping[str, Any]
+    confidence: Decimal
+```
+
+Rules:
+
+- `source_claim_ids` must reference existing `WhitepaperClaim.claim_id` rows.
+- `mechanism` must describe an economic or microstructure reason, not only a statistical pattern.
+- `required_features` must map to existing feature contracts or generate a missing-feature blocker.
+- `failure_modes` must be converted into replay/stress tests.
+- Cards with confidence below the configured threshold are stored but not executed.
+
+### 2. Candidate Spec
+
+Add `services/torghut/app/trading/discovery/candidate_specs.py`.
+
+Hypothesis cards compile into candidate specs:
+
+```python
+@dataclass(frozen=True)
+class CandidateSpec:
+    schema_version: Literal['torghut.candidate-spec.v1']
+    candidate_spec_id: str
+    hypothesis_id: str
+    family_template_id: str
+    candidate_kind: Literal['family', 'sleeve', 'portfolio', 'algorithm', 'configuration']
+    runtime_family: str
+    runtime_strategy_name: str
+    feature_contract: Mapping[str, Any]
+    parameter_space: Mapping[str, Any]
+    strategy_overrides: Mapping[str, Any]
+    objective: Mapping[str, Any]
+    hard_vetoes: Mapping[str, Any]
+    expected_failure_modes: tuple[str, ...]
+    promotion_contract: Mapping[str, Any]
+```
+
+Rules:
+
+- The compiler emits `WhitepaperExperimentSpec` for whitepaper lineage.
+- The compiler mirrors executable rows into `VNextExperimentSpec` for `run_strategy_factory_v2.py`.
+- `candidate_kind='algorithm'` is not executable until mapped to a runtime family or feature
+  transform. Free-form generated strategy code stays out of the first production wave.
+- Any missing feature, runtime family, strategy name, or seed sweep blocks execution.
+
+### 3. Portfolio Candidate Spec
+
+Add `services/torghut/app/trading/discovery/portfolio_candidates.py`.
+
+Portfolio candidates are first-class. They are not summaries of the "best" single strategy.
+
+```python
+@dataclass(frozen=True)
+class PortfolioCandidateSpec:
+    schema_version: Literal['torghut.portfolio-candidate-spec.v1']
+    portfolio_candidate_id: str
+    source_candidate_ids: tuple[str, ...]
+    target_net_pnl_per_day: Decimal
+    sleeves: tuple[Mapping[str, Any], ...]
+    capital_budget: Mapping[str, Any]
+    correlation_budget: Mapping[str, Any]
+    drawdown_budget: Mapping[str, Any]
+    evidence_refs: tuple[str, ...]
+```
+
+Each sleeve includes:
+
+- `candidate_id`
+- `side`
+- `family_template_id`
+- `runtime_family`
+- `runtime_strategy_name`
+- `entry_window`
+- `exit_policy`
+- `symbol_policy`
+- `weight`
+- `max_notional_per_trade`
+- `max_position_pct_equity`
+- `expected_net_pnl_per_day`
+- `risk_contribution`
+- `correlation_cluster`
+
+Rules:
+
+- The portfolio target is `sum(weighted_post_cost_net_pnl_per_day) >= 500`.
+- No single sleeve may contribute more than the configured concentration share unless explicitly
+  approved by a promotion policy.
+- Positive candidates that duplicate the same symbol/time/regime exposure are treated as one risk
+  cluster.
+
+### 4. Evidence Bundle
+
+Add `services/torghut/app/trading/discovery/evidence_bundles.py`.
+
+Every candidate and portfolio must produce a canonical evidence bundle:
+
+```python
+@dataclass(frozen=True)
+class CandidateEvidenceBundle:
+    schema_version: Literal['torghut.candidate-evidence-bundle.v1']
+    candidate_id: str
+    dataset_snapshot_id: str
+    feature_spec_hash: str
+    code_commit: str
+    replay_artifact_refs: tuple[str, ...]
+    objective_scorecard: Mapping[str, Any]
+    fold_metrics: tuple[Mapping[str, Any], ...]
+    stress_metrics: tuple[Mapping[str, Any], ...]
+    cost_calibration: Mapping[str, Any]
+    null_comparator: Mapping[str, Any]
+    promotion_readiness: Mapping[str, Any]
+```
+
+Rules:
+
+- Evidence bundles are hash-addressed.
+- A bundle with stale tape, missing snapshot, or missing cost assumptions is invalid.
+- The bundle is the training row for future MLX proposal ranking.
+
+## Profit Target Contract
+
+The production objective is:
+
+```text
+portfolio_post_cost_net_pnl_per_day >= 500
+```
+
+The candidate must also satisfy:
+
+```text
+active_day_ratio >= 0.90
+positive_day_ratio >= 0.60
+best_day_share <= 0.25
+worst_day_loss <= 350
+max_drawdown <= 900
+avg_filled_notional_per_day >= 300000
+regime_slice_pass_rate >= 0.45
+posterior_edge_lower > 0
+shadow_parity_status == within_budget
+```
+
+For a single sleeve:
+
+```text
+sleeve_score =
+  post_cost_net_pnl_per_day
+  + active_day_ratio * 300
+  + positive_day_ratio * 150
+  + regime_slice_pass_rate * 100
+  + rolling_3d_lower_bound
+  + rolling_5d_lower_bound
+  - worst_day_loss * 0.50
+  - max_drawdown * 0.10
+  - best_day_share * 500
+  - symbol_concentration_share * 100
+  - entry_family_contribution_share * 25
+```
+
+For a portfolio:
+
+```text
+portfolio_score =
+  sum(weighted_sleeve_post_cost_net_pnl_per_day)
+  + diversification_bonus
+  + regime_coverage_bonus
+  - correlation_penalty
+  - capital_concentration_penalty
+  - drawdown_penalty
+  - stale_evidence_penalty
+  - promotion_missing_evidence_penalty
+```
+
+A sleeve can lose in isolation and still be admitted if it reduces portfolio drawdown or correlation
+enough to improve the portfolio objective. A profitable sleeve is rejected if its edge comes from one
+symbol, one day, stale data, or missing execution realism.
+
+## Autoresearch Runner
+
+Add `services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py`.
+
+This is the production orchestrator. It runs one complete research epoch:
+
+1. Load eligible completed whitepaper analysis runs.
+2. Compile or refresh `HypothesisCard` rows from claims and claim relations.
+3. Compile eligible hypotheses into `WhitepaperExperimentSpec` and `VNextExperimentSpec`.
+4. Build an immutable MLX snapshot manifest for the epoch.
+5. Rank candidate specs with the MLX proposal model.
+6. Execute a bounded top-K and exploration-slot replay budget through runtime-native replay.
+7. Persist evidence bundles.
+8. Assemble portfolio candidates from replayed sleeves.
+9. Run runtime closure for the best portfolio candidate.
+10. Write one epoch summary, notebooks, and promotion-readiness artifacts.
+
+Inputs:
+
+```text
+--output-dir
+--paper-run-id repeatable
+--target-net-pnl-per-day default 500
+--max-candidates default 64
+--top-k default 16
+--exploration-slots default 8
+--portfolio-size-min default 2
+--portfolio-size-max default 8
+--train-days
+--holdout-days
+--full-window-start-date
+--full-window-end-date
+--strategy-configmap
+--family-template-dir
+--persist-results / --no-persist-results
+```
+
+Outputs:
+
+```text
+summary.json
+epoch-manifest.json
+hypothesis-cards.jsonl
+candidate-specs.jsonl
+mlx-proposal-scores.jsonl
+candidate-evidence-bundles.jsonl
+portfolio-candidates.jsonl
+portfolio-optimizer-report.json
+runtime-closure/
+whitepaper-autoresearch-diagnostics.ipynb
+```
+
+Exit behavior:
+
+- `0`: epoch completed and all artifacts are written.
+- `1`: invalid invocation or failed required infrastructure.
+- `2`: epoch completed but no candidate met execution eligibility.
+- `3`: replay failed after artifacts captured error state.
+
+No exit code should imply live-promotion approval. Promotion approval is a separate gate artifact.
+
+## MLX Proposal Model
+
+Upgrade `services/torghut/app/trading/discovery/mlx_proposal_models.py`.
+
+### V1 Model
+
+Implement a compact ranking model:
+
+- descriptor encoder: dense numeric + categorical one-hot features
+- paper encoder: claim type, mechanism type, horizon, asset scope, feature family ids
+- outcome label: replay-adjusted target, not raw backtest score
+- objective: pairwise ranking loss or pointwise regression to replay-adjusted score
+- backend: `mlx` on Apple Silicon, `numpy-fallback` for tests and non-Darwin environments
+
+Training rows come from:
+
+- `history.jsonl`
+- `mlx-candidate-descriptors.jsonl`
+- `candidate-evidence-bundles.jsonl`
+- `VNextExperimentRun`
+- `ResearchCandidate`
+- `ResearchValidationTest`
+- `ResearchStressMetrics`
+
+### Proposal Feature Vector
+
+Add `services/torghut/app/trading/discovery/mlx_training_data.py`.
+
+Feature groups:
+
+1. candidate mechanics:
+   - family template id
+   - runtime family
+   - side policy
+   - entry window
+   - max hold
+   - rank count
+   - required prior-day features
+   - required cross-sectional features
+   - quote quality gate
+2. paper provenance:
+   - claim type
+   - mechanism type
+   - paper confidence
+   - number of supporting claims
+   - contradiction count
+3. replay priors:
+   - historical family hit rate
+   - median post-cost net PnL/day
+   - false-positive rate
+   - cost stress pass rate
+   - shadow parity pass rate
+4. portfolio fit:
+   - correlation cluster id
+   - overlap with current candidate pool
+   - regime coverage
+   - capital capacity estimate
+
+The model emits:
+
+```json
+{
+  "candidate_spec_id": "spec-...",
+  "proposal_score": 12.31,
+  "rank": 1,
+  "backend": "mlx",
+  "model_id": "mlx-ranker-v1-...",
+  "selection_reason": "exploitation",
+  "feature_hash": "..."
+}
+```
+
+Rules:
+
+- Low model confidence increases exploration slots; it does not block replay.
+- Model drift is measured by rank-bucket lift against actual replay results.
+- A model with negative lift is automatically demoted to heuristic ranking.
+
+## Portfolio Sleeve Optimizer
+
+Add `services/torghut/app/trading/discovery/portfolio_optimizer.py`.
+
+V1 should be deterministic and auditable:
+
+1. Filter sleeves by hard vetoes and promotion readiness.
+2. Group sleeves by risk cluster:
+   - symbol overlap
+   - family template
+   - entry window
+   - side
+   - regime envelope
+3. Build daily net vectors from replay artifacts.
+4. Estimate pairwise correlation on overlapping dates.
+5. Greedily assemble a Pareto portfolio:
+   - start with highest adjusted sleeve score
+   - add sleeves with positive marginal portfolio score
+   - cap cluster exposure
+   - cap single-sleeve contribution
+   - require post-cost target
+6. Emit a portfolio candidate spec and optimizer report.
+
+V2 can add a convex or MLX-accelerated optimizer, but V1 must be transparent.
+
+Acceptance contract:
+
+```text
+portfolio_net_pnl_per_day >= 500
+posterior_edge_lower > 0
+max_cluster_contribution_share <= 0.40
+max_single_day_contribution_share <= 0.25
+max_single_symbol_contribution_share <= 0.35
+portfolio_active_day_ratio >= 0.90
+portfolio_positive_day_ratio >= 0.60
+```
+
+## Whitepaper Claim Compiler
+
+Add `services/torghut/app/whitepapers/claim_compiler.py`.
+
+The compiler consumes:
+
+- `WhitepaperContent`
+- `WhitepaperSynthesis`
+- `WhitepaperViabilityVerdict`
+- `WhitepaperClaim`
+- `WhitepaperClaimRelation`
+
+It produces or updates:
+
+- `WhitepaperClaim`
+- `WhitepaperClaimRelation`
+- `WhitepaperStrategyTemplate`
+- `WhitepaperExperimentSpec`
+
+Compiler steps:
+
+1. Normalize source claims into a stable JSON representation.
+2. Classify each claim:
+   - `signal_mechanism`
+   - `feature_recipe`
+   - `risk_constraint`
+   - `market_regime`
+   - `execution_assumption`
+   - `validation_requirement`
+3. Link relations:
+   - `supports`
+   - `contradicts`
+   - `requires_feature`
+   - `requires_regime`
+   - `invalidates`
+   - `extends`
+4. Generate hypothesis cards only for claim subgraphs with:
+   - at least one mechanism
+   - at least one executable feature recipe or feature-missing blocker
+   - at least one risk/validation constraint
+5. Write deterministic ids based on claim ids and normalized payload hash.
+
+## Family and Algorithm Search Grammar
+
+The first production grammar should cover five executable lanes:
+
+1. `breakout_reclaim_v2`
+   - continuation after open-range reclaim
+   - long-biased
+   - useful for momentum/attention papers
+2. `washout_rebound_v2`
+   - intraday oversold rebound
+   - long-biased
+   - useful for liquidity shock/reversal papers
+3. `momentum_pullback_v1`
+   - trend continuation after controlled pullback
+   - long-biased
+   - useful for time-series momentum papers
+4. `mean_reversion_rebound_v1`
+   - cross-sectional rebound and mean reversion
+   - long-biased
+   - useful for overreaction and microstructure papers
+5. `microbar_cross_sectional_pairs_v1`
+   - long/short portfolio sleeves
+   - portfolio-aware
+   - useful for order-flow, short-horizon rank, and relative-strength papers
+
+New family templates are allowed only through this process:
+
+1. A whitepaper claim graph proposes a new `WhitepaperStrategyTemplate`.
+2. The template compiler proves required runtime fields are complete.
+3. A static fixture compiles the template into a valid sweep.
+4. A unit test proves the family cannot bypass objective vetoes.
+5. A runtime closure test proves promotion remains blocked without parity and shadow evidence.
+
+## Runtime Closure Integration
+
+Extend `services/torghut/app/trading/discovery/runtime_closure.py`.
+
+Required changes:
+
+1. Accept `PortfolioCandidateSpec`.
+2. Materialize runtime strategies for every sleeve, not only the current microbar helper path.
+3. Emit `portfolio_promotion_v2` with complete policy refs:
+   - promotion policy ref
+   - risk profile ref
+   - sizing policy ref
+   - execution policy ref
+4. Include portfolio optimizer evidence in promotion prerequisites.
+5. Require shadow validation for every materialized strategy.
+
+Promotion states:
+
+```text
+research_candidate
+pending_runtime_parity
+pending_approval_replay
+pending_shadow_validation
+ready_for_promotion_review
+paper
+constrained_live
+scaled_live
+quarantine
+retired
+```
+
+The runner may create `ready_for_promotion_review`. It must not create `constrained_live` or
+`scaled_live`.
+
+## Persistence Plan
+
+Reuse existing tables first:
+
+- `whitepaper_claims`
+- `whitepaper_claim_relations`
+- `whitepaper_strategy_templates`
+- `whitepaper_experiment_specs`
+- `vnext_experiment_specs`
+- `vnext_experiment_runs`
+- `research_runs`
+- `research_candidates`
+- `research_validation_tests`
+- `research_stress_metrics`
+- `research_cost_calibrations`
+- `research_sequential_trials`
+- `research_promotions`
+- `vnext_promotion_decisions`
+- `strategy_hypotheses`
+- `strategy_hypothesis_metric_windows`
+
+Add one migration with these tables:
+
+### `autoresearch_epochs`
+
+Top-level epoch record.
+
+Columns:
+
+- `epoch_id` unique
+- `status`
+- `target_net_pnl_per_day`
+- `paper_run_ids_json`
+- `snapshot_manifest_json`
+- `runner_config_json`
+- `summary_json`
+- `started_at`
+- `completed_at`
+- `failure_reason`
+
+### `autoresearch_candidate_specs`
+
+Normalized candidate spec ledger.
+
+Columns:
+
+- `candidate_spec_id` unique
+- `epoch_id`
+- `hypothesis_id`
+- `candidate_kind`
+- `family_template_id`
+- `payload_json`
+- `payload_hash`
+- `status`
+- `blockers_json`
+
+### `autoresearch_proposal_scores`
+
+MLX/heuristic proposal score ledger.
+
+Columns:
+
+- `epoch_id`
+- `candidate_spec_id`
+- `model_id`
+- `backend`
+- `proposal_score`
+- `rank`
+- `selection_reason`
+- `feature_hash`
+- `payload_json`
+
+### `autoresearch_portfolio_candidates`
+
+Portfolio assembly ledger.
+
+Columns:
+
+- `portfolio_candidate_id` unique
+- `epoch_id`
+- `source_candidate_ids_json`
+- `target_net_pnl_per_day`
+- `objective_scorecard_json`
+- `optimizer_report_json`
+- `payload_json`
+- `status`
+
+## Observability
+
+Add one epoch summary endpoint:
+
+```text
+GET /trading/autoresearch/epochs/{epoch_id}
+```
+
+Add one list endpoint:
+
+```text
+GET /trading/autoresearch/epochs?status=...
+```
+
+Dashboard fields:
+
+- epoch status
+- paper count
+- claim count
+- hypothesis count
+- candidate spec count
+- replayed candidate count
+- portfolio candidate count
+- best portfolio net PnL/day
+- best portfolio active day ratio
+- best portfolio positive day ratio
+- blocked promotion reasons
+- MLX rank-bucket lift
+- false-positive table
+- best false-negative table
+
+## Implementation Workstreams
+
+### Workstream 1: Typed Artifact Layer
+
+Files:
+
+- add `services/torghut/app/trading/discovery/hypothesis_cards.py`
+- add `services/torghut/app/trading/discovery/candidate_specs.py`
+- add `services/torghut/app/trading/discovery/evidence_bundles.py`
+- add `services/torghut/tests/test_hypothesis_cards.py`
+- add `services/torghut/tests/test_candidate_specs.py`
+
+Definition of done:
+
+- deterministic ids and hashes
+- JSON round-trip tests
+- invalid payload tests
+- feature-missing blockers
+- no live runtime config writes
+
+### Workstream 2: Whitepaper Claim Compiler
+
+Files:
+
+- add `services/torghut/app/whitepapers/claim_compiler.py`
+- add `services/torghut/scripts/compile_whitepaper_claims.py`
+- update `services/torghut/app/whitepapers/workflow.py`
+- add `services/torghut/tests/test_whitepaper_claim_compiler.py`
+
+Definition of done:
+
+- completed whitepaper runs compile into `WhitepaperClaim` and `WhitepaperClaimRelation`
+- claim subgraphs compile into `HypothesisCard`
+- contradiction events block dependent candidate specs
+- deterministic idempotency tests pass
+
+### Workstream 3: Candidate Spec Compiler
+
+Files:
+
+- add `services/torghut/app/trading/discovery/whitepaper_candidate_compiler.py`
+- update `services/torghut/scripts/run_strategy_factory_v2.py`
+- add `services/torghut/tests/test_whitepaper_candidate_compiler.py`
+
+Definition of done:
+
+- `WhitepaperExperimentSpec` rows mirror into executable `VNextExperimentSpec` rows
+- family template ids and seed sweeps resolve
+- missing runtime harness fields block execution
+- compiled sweeps contain `$500/day` objective and hard vetoes
+
+### Workstream 4: MLX Ranker V1
+
+Files:
+
+- add `services/torghut/app/trading/discovery/mlx_training_data.py`
+- update `services/torghut/app/trading/discovery/mlx_proposal_models.py`
+- add `services/torghut/scripts/train_mlx_autoresearch_ranker.py`
+- add `services/torghut/tests/test_mlx_training_data.py`
+- extend `services/torghut/tests/test_mlx_autoresearch.py`
+
+Definition of done:
+
+- training dataset builds from evidence bundles and history rows
+- MLX and NumPy fallback produce deterministic ranks for fixed fixtures
+- rank-bucket lift is computed after replay
+- negative-lift model is demoted automatically
+
+### Workstream 5: Portfolio Sleeve Optimizer
+
+Files:
+
+- add `services/torghut/app/trading/discovery/portfolio_optimizer.py`
+- update `services/torghut/app/trading/discovery/runtime_closure.py`
+- add `services/torghut/tests/test_portfolio_optimizer.py`
+- extend `services/torghut/tests/test_runtime_closure.py`
+
+Definition of done:
+
+- optimizer assembles a portfolio candidate from replayed sleeves
+- target `$500/day` is computed after costs
+- correlation, concentration, and drawdown constraints are enforced
+- runtime closure materializes all sleeve strategies
+- promotion stays blocked without parity and shadow evidence
+
+### Workstream 6: Production Runner
+
+Files:
+
+- add `services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py`
+- add `services/torghut/app/trading/discovery/whitepaper_autoresearch_notebooks.py`
+- add `services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py`
+
+Definition of done:
+
+- one command runs the full epoch against fixtures
+- all artifacts are written incrementally
+- failures write error summaries and do not lose partial evidence
+- results persist when `--persist-results` is enabled
+
+### Workstream 7: API and UI Surface
+
+Files:
+
+- update `services/torghut/app/main.py`
+- add `services/torghut/app/trading/autoresearch_routes.py`
+- update Jangar Torghut quant routes as needed
+- add API tests
+
+Definition of done:
+
+- epoch summary is queryable by id
+- epoch list supports status filtering
+- blocked promotion reasons are visible
+- best portfolio candidate and sleeve composition are visible
+
+## Test Plan
+
+Targeted tests:
+
+```bash
+cd services/torghut
+uv sync --frozen --extra dev
+uv run --frozen pytest tests/test_hypothesis_cards.py
+uv run --frozen pytest tests/test_candidate_specs.py
+uv run --frozen pytest tests/test_whitepaper_claim_compiler.py
+uv run --frozen pytest tests/test_whitepaper_candidate_compiler.py
+uv run --frozen pytest tests/test_mlx_autoresearch.py
+uv run --frozen pytest tests/test_mlx_training_data.py
+uv run --frozen pytest tests/test_portfolio_optimizer.py
+uv run --frozen pytest tests/test_runtime_closure.py
+uv run --frozen pytest tests/test_run_strategy_factory_v2.py
+uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py
+```
+
+Type checks:
+
+```bash
+cd services/torghut
+uv run --frozen pyright --project pyrightconfig.json
+uv run --frozen pyright --project pyrightconfig.alpha.json
+uv run --frozen pyright --project pyrightconfig.scripts.json
+```
+
+Repo gate for a PR:
+
+```bash
+go test ./services/...
+bun run format
+bun run lint:argocd
+```
+
+Use narrower gates per touched path, then run the full required Torghut pyright trio before reporting
+the implementation ready.
+
+## PR Sequence
+
+### PR 1: Artifact Contracts
+
+Deliver:
+
+- hypothesis card schema
+- candidate spec schema
+- evidence bundle schema
+- JSON/hash tests
+
+Merge condition:
+
+- no database behavior change
+- all contract tests green
+
+### PR 2: Whitepaper Claim Compiler
+
+Deliver:
+
+- claim compiler
+- claim relation compiler
+- contradiction blocking
+- idempotent script
+
+Merge condition:
+
+- fixture whitepaper run compiles claims and relations deterministically
+
+### PR 3: Candidate Spec Compiler
+
+Deliver:
+
+- hypothesis-to-candidate compiler
+- `WhitepaperExperimentSpec` to `VNextExperimentSpec` mirror
+- strategy factory integration
+
+Merge condition:
+
+- fixture claims produce executable sweeps
+- missing family/runtime fields block execution
+
+### PR 4: MLX Ranker V1
+
+Deliver:
+
+- training data builder
+- ranker model
+- rank-bucket lift diagnostics
+- model demotion behavior
+
+Merge condition:
+
+- deterministic NumPy fallback tests
+- MLX path works on Apple Silicon
+
+### PR 5: Portfolio Optimizer
+
+Deliver:
+
+- sleeve objective aggregation
+- risk cluster model
+- greedy Pareto portfolio assembly
+- runtime closure portfolio candidate support
+
+Merge condition:
+
+- target `$500/day` fixture portfolio passes
+- concentration and correlation rejection tests pass
+
+### PR 6: End-to-End Runner
+
+Deliver:
+
+- `run_whitepaper_autoresearch_profit_target.py`
+- epoch persistence
+- notebooks
+- summary artifacts
+
+Merge condition:
+
+- fixture whitepaper-to-portfolio epoch completes
+- partial-failure artifact tests pass
+
+### PR 7: API and Dashboard
+
+Deliver:
+
+- epoch list/detail endpoints
+- Jangar visibility
+- blocked-reason display
+
+Merge condition:
+
+- operators can inspect paper source, hypothesis, candidate specs, replay evidence, portfolio
+  composition, and promotion blockers from one screen.
+
+## Production Runbook
+
+1. Ingest or select completed whitepaper runs.
+2. Compile claims:
+
+```bash
+cd services/torghut
+uv run --frozen python scripts/compile_whitepaper_claims.py --paper-run-id <run-id>
+```
+
+3. Run one autoresearch epoch:
+
+```bash
+uv run --frozen python scripts/run_whitepaper_autoresearch_profit_target.py \
+  --paper-run-id <run-id> \
+  --target-net-pnl-per-day 500 \
+  --top-k 16 \
+  --exploration-slots 8 \
+  --portfolio-size-min 2 \
+  --portfolio-size-max 8 \
+  --output-dir /tmp/torghut-whitepaper-autoresearch/<epoch-id>
+```
+
+4. Inspect:
+
+```bash
+jq '.best_portfolio_candidate' /tmp/torghut-whitepaper-autoresearch/<epoch-id>/summary.json
+jq '.promotion_readiness' /tmp/torghut-whitepaper-autoresearch/<epoch-id>/summary.json
+```
+
+5. If promotion prerequisites are blocked, attach the missing runtime parity, approval replay, or
+   shadow validation evidence. Do not override the gate from the runner.
+
+## Definition of Production Ready
+
+The system is production ready when:
+
+1. A completed whitepaper run can compile into typed claims, relations, hypotheses, candidate specs,
+   and executable sweeps without manual editing.
+2. MLX ranks candidate specs and reports rank-bucket lift against replay results.
+3. Runtime-native replay evaluates a bounded top-K plus exploration set.
+4. Evidence bundles persist all objective, cost, stress, and promotion-readiness data.
+5. The portfolio optimizer can assemble a sleeve set that meets the `$500/day` objective under the
+   configured risk constraints.
+6. Runtime closure can materialize the portfolio candidate and keep promotion blocked until parity,
+   approval, and shadow gates pass.
+7. Operators can see the complete chain from paper claim to sleeve to replay to portfolio candidate
+   to promotion blocker.
+8. The pyright trio and targeted tests pass.
+
+## Final Implementation Rule
+
+The autoresearch system is allowed to be aggressive in hypothesis generation and compute allocation.
+It is conservative everywhere capital, promotion, or runtime configuration is involved.
+
+The strongest production behavior is this:
+
+- read more papers;
+- generate more bounded hypotheses;
+- replay only the most promising and most informative candidates;
+- assemble diversified sleeves;
+- reject stale or concentrated evidence;
+- promote only what runtime closure proves.

--- a/docs/torghut/design-system/v6/index.md
+++ b/docs/torghut/design-system/v6/index.md
@@ -147,6 +147,9 @@ Current source-state priority is narrower:
   lane: adapt the discipline of `karpathy/autoresearch` to Torghut, keep the mutation surface narrow and
   ledger-backed, use Apple MLX for GPU-accelerated candidate generation on Apple Silicon, and keep scheduler-v3
   parity, approval replay, and shadow validation as the only promotion authority.
+- `71-torghut-whitepaper-autoresearch-profit-target-strategy-factory-2026-04-21.md` now turns the whitepaper,
+  strategy-factory, MLX, portfolio-sleeve, and runtime-closure pieces into one implementation contract for a
+  production autoresearch epoch targeting a `$500/day` post-cost portfolio candidate.
 - `53-torghut-cross-plane-profit-certificate-veto-and-options-auth-isolation-2026-03-20.md` now makes the next step
   explicit: non-observe capital depends on one certificate that consumes Jangar witness quorum, Jangar market-context
   and quant evidence, toggle parity, and typed options auth/bootstrap escrow rather than local gate optimism.

--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -29,6 +29,10 @@ from .db import SessionLocal, check_schema_current, ensure_schema, get_session, 
 from .db import check_account_scope_invariants
 from .metrics import render_trading_metrics
 from .models import (
+    AutoresearchCandidateSpec,
+    AutoresearchEpoch,
+    AutoresearchPortfolioCandidate,
+    AutoresearchProposalScore,
     Execution,
     ExecutionTCAMetric,
     Strategy,
@@ -74,7 +78,10 @@ from .trading.submission_council import (
     resolve_active_capital_stage,
 )
 from .trading.tca import build_tca_gate_inputs
-from .trading.simulation_progress import active_simulation_runtime_context, simulation_progress_snapshot
+from .trading.simulation_progress import (
+    active_simulation_runtime_context,
+    simulation_progress_snapshot,
+)
 from .trading.time_source import trading_time_status
 from .whitepapers import (
     WhitepaperKafkaWorker,
@@ -379,7 +386,9 @@ def _readiness_dependency_checks(
             list[str],
             database_contract.get("schema_graph_lineage_errors", []),
         )
-        detail = "ok" if bool(database_contract.get("ok")) else "database contract failed"
+        detail = (
+            "ok" if bool(database_contract.get("ok")) else "database contract failed"
+        )
         if lineage_errors:
             detail = lineage_errors[0]
         dependencies["database"] = {
@@ -537,9 +546,7 @@ def _evaluate_trading_health_payload(
         ):
             in_startup_grace = True
             scheduler_ok = True
-            scheduler_detail = (
-                f"trading loop starting (within {startup_grace_seconds}s readiness grace)"
-            )
+            scheduler_detail = f"trading loop starting (within {startup_grace_seconds}s readiness grace)"
         else:
             scheduler_ok = False
             scheduler_detail = (
@@ -566,16 +573,11 @@ def _evaluate_trading_health_payload(
     )
     dependencies = dict(dependencies)
     dependencies["universe"] = _evaluate_universe_dependency(scheduler)
-    cache_age_seconds = (
-        (now - checked_at).total_seconds() if checked_at else 0.0
-    )
-    cache_age_seconds = (
-        0.0 if cache_age_seconds < 0 else round(cache_age_seconds, 3)
-    )
+    cache_age_seconds = (now - checked_at).total_seconds() if checked_at else 0.0
+    cache_age_seconds = 0.0 if cache_age_seconds < 0 else round(cache_age_seconds, 3)
     cache_stale = (
         cache_used
-        and cache_age_seconds
-        > settings.trading_readiness_dependency_cache_ttl_seconds
+        and cache_age_seconds > settings.trading_readiness_dependency_cache_ttl_seconds
     )
     dependencies["readiness_cache"] = {
         "checked_at": checked_at.isoformat(),
@@ -659,7 +661,9 @@ def _evaluate_trading_health_payload(
             else ", ".join(
                 [
                     str(item).strip()
-                    for item in cast(list[object], dspy_runtime.get("readiness_reasons") or [])
+                    for item in cast(
+                        list[object], dspy_runtime.get("readiness_reasons") or []
+                    )
                     if str(item).strip()
                 ]
             )
@@ -1078,7 +1082,9 @@ def db_check(session: Session = Depends(get_session)) -> dict[str, object]:
                 [],
             ),
             "schema_missing_heads": database_contract.get("schema_missing_heads", []),
-            "schema_unexpected_heads": database_contract.get("schema_unexpected_heads", []),
+            "schema_unexpected_heads": database_contract.get(
+                "schema_unexpected_heads", []
+            ),
             "schema_head_count_expected": database_contract.get(
                 "schema_head_count_expected",
             ),
@@ -1108,8 +1114,12 @@ def db_check(session: Session = Depends(get_session)) -> dict[str, object]:
             detail={
                 "error": database_contract.get("error"),
                 "schema_current": False,
-                "schema_missing_heads": database_contract.get("schema_missing_heads", []),
-                "schema_unexpected_heads": database_contract.get("schema_unexpected_heads", []),
+                "schema_missing_heads": database_contract.get(
+                    "schema_missing_heads", []
+                ),
+                "schema_unexpected_heads": database_contract.get(
+                    "schema_unexpected_heads", []
+                ),
                 "schema_graph_lineage_ready": database_contract.get(
                     "schema_graph_lineage_ready",
                 ),
@@ -1136,8 +1146,12 @@ def db_check(session: Session = Depends(get_session)) -> dict[str, object]:
             detail={
                 "error": "database schema mismatch",
                 "checked_at": database_contract.get("checked_at"),
-                "schema_missing_heads": database_contract.get("schema_missing_heads", []),
-                "schema_unexpected_heads": database_contract.get("schema_unexpected_heads", []),
+                "schema_missing_heads": database_contract.get(
+                    "schema_missing_heads", []
+                ),
+                "schema_unexpected_heads": database_contract.get(
+                    "schema_unexpected_heads", []
+                ),
                 "schema_head_count_expected": database_contract.get(
                     "schema_head_count_expected",
                 ),
@@ -1176,7 +1190,9 @@ def db_check(session: Session = Depends(get_session)) -> dict[str, object]:
                 "error": "database account scope schema mismatch",
                 "checked_at": database_contract.get("checked_at"),
                 "schema_head_signature": database_contract.get("schema_head_signature"),
-                "schema_graph_signature": database_contract.get("schema_graph_signature"),
+                "schema_graph_signature": database_contract.get(
+                    "schema_graph_signature"
+                ),
                 "schema_graph_branch_count": database_contract.get(
                     "schema_graph_branch_count",
                 ),
@@ -1747,9 +1763,7 @@ def trading_status(session: Session = Depends(get_session)) -> dict[str, object]
             "market_context_block_total": state.metrics.llm_market_context_block_total,
             "pre_llm_capacity_reject_total": state.metrics.pre_llm_capacity_reject_total,
             "pre_llm_qty_below_min_total": state.metrics.pre_llm_qty_below_min_total,
-            "runtime_fallback_ratio": rejection_alert_status[
-                "runtime_fallback_ratio"
-            ],
+            "runtime_fallback_ratio": rejection_alert_status["runtime_fallback_ratio"],
             "runtime_fallback_alert_ratio_threshold": rejection_alert_status[
                 "runtime_fallback_alert_ratio_threshold"
             ],
@@ -1793,14 +1807,17 @@ def trading_status(session: Session = Depends(get_session)) -> dict[str, object]
         "empirical_jobs": empirical_jobs,
         "simulation": {
             "enabled": settings.trading_simulation_enabled,
-            "run_id": (active_simulation_context or {}).get("run_id") or settings.trading_simulation_run_id,
+            "run_id": (active_simulation_context or {}).get("run_id")
+            or settings.trading_simulation_run_id,
             "dataset_id": (active_simulation_context or {}).get("dataset_id")
             or settings.trading_simulation_dataset_id,
             "window_start": (active_simulation_context or {}).get("window_start")
             or settings.trading_simulation_window_start,
             "window_end": (active_simulation_context or {}).get("window_end")
             or settings.trading_simulation_window_end,
-            "time_source": trading_time_status(account_label=settings.trading_account_label),
+            "time_source": trading_time_status(
+                account_label=settings.trading_account_label
+            ),
         },
         "control_plane_contract": control_plane_contract,
         "evidence_continuity": state.last_evidence_continuity_report,
@@ -1857,7 +1874,9 @@ def trading_simulation_progress(
     snapshot = simulation_progress_snapshot(session, run_id=run_id)
     active_runtime_context = active_simulation_runtime_context(session)
     snapshot["requested_run_id"] = run_id
-    snapshot["active_run_id"] = (active_runtime_context or {}).get("run_id") or settings.trading_simulation_run_id
+    snapshot["active_run_id"] = (active_runtime_context or {}).get(
+        "run_id"
+    ) or settings.trading_simulation_run_id
     snapshot["simulation_enabled"] = settings.trading_simulation_enabled
     return cast(dict[str, object], snapshot)
 
@@ -1981,14 +2000,17 @@ def trading_autonomy() -> dict[str, object]:
         "empirical_jobs": _empirical_jobs_status(),
         "simulation": {
             "enabled": settings.trading_simulation_enabled,
-            "run_id": (active_simulation_context or {}).get("run_id") or settings.trading_simulation_run_id,
+            "run_id": (active_simulation_context or {}).get("run_id")
+            or settings.trading_simulation_run_id,
             "dataset_id": (active_simulation_context or {}).get("dataset_id")
             or settings.trading_simulation_dataset_id,
             "window_start": (active_simulation_context or {}).get("window_start")
             or settings.trading_simulation_window_start,
             "window_end": (active_simulation_context or {}).get("window_end")
             or settings.trading_simulation_window_end,
-            "time_source": trading_time_status(account_label=settings.trading_account_label),
+            "time_source": trading_time_status(
+                account_label=settings.trading_account_label
+            ),
         },
         "bridge_status": _build_autonomy_bridge_status(scheduler),
         "signal_continuity": {
@@ -2035,6 +2057,119 @@ def trading_empirical_jobs() -> dict[str, object]:
     """Return freshness and authority status for empirical parity and Janus workflows."""
 
     return _empirical_jobs_status()
+
+
+@app.get("/trading/autoresearch/epochs")
+def trading_autoresearch_epochs(
+    status: str | None = Query(default=None),
+    limit: int = Query(default=25, ge=1, le=100),
+    session: Session = Depends(get_session),
+) -> dict[str, object]:
+    """Return persisted whitepaper autoresearch epochs."""
+
+    stmt = select(AutoresearchEpoch)
+    if status:
+        stmt = stmt.where(AutoresearchEpoch.status == status)
+    rows = session.execute(
+        stmt.order_by(AutoresearchEpoch.created_at.desc()).limit(limit)
+    ).scalars()
+    items: list[dict[str, object]] = [
+        {
+            "epoch_id": row.epoch_id,
+            "status": row.status,
+            "target_net_pnl_per_day": str(row.target_net_pnl_per_day),
+            "paper_run_ids": cast(object, row.paper_run_ids_json or []),
+            "started_at": row.started_at.isoformat() if row.started_at else None,
+            "completed_at": row.completed_at.isoformat() if row.completed_at else None,
+            "failure_reason": row.failure_reason,
+            "summary": cast(object, row.summary_json or {}),
+        }
+        for row in rows
+    ]
+    return {"count": len(items), "epochs": items}
+
+
+@app.get("/trading/autoresearch/epochs/{epoch_id}")
+def trading_autoresearch_epoch(
+    epoch_id: str,
+    session: Session = Depends(get_session),
+) -> dict[str, object]:
+    """Return one persisted whitepaper autoresearch epoch with child ledgers."""
+
+    epoch = session.execute(
+        select(AutoresearchEpoch).where(AutoresearchEpoch.epoch_id == epoch_id)
+    ).scalar_one_or_none()
+    if epoch is None:
+        raise HTTPException(
+            status_code=404, detail=f"autoresearch_epoch_not_found:{epoch_id}"
+        )
+    specs = session.execute(
+        select(AutoresearchCandidateSpec)
+        .where(AutoresearchCandidateSpec.epoch_id == epoch_id)
+        .order_by(AutoresearchCandidateSpec.created_at.asc())
+    ).scalars()
+    proposals = session.execute(
+        select(AutoresearchProposalScore)
+        .where(AutoresearchProposalScore.epoch_id == epoch_id)
+        .order_by(AutoresearchProposalScore.rank.asc())
+    ).scalars()
+    portfolios = session.execute(
+        select(AutoresearchPortfolioCandidate)
+        .where(AutoresearchPortfolioCandidate.epoch_id == epoch_id)
+        .order_by(AutoresearchPortfolioCandidate.created_at.asc())
+    ).scalars()
+    return {
+        "epoch": {
+            "epoch_id": epoch.epoch_id,
+            "status": epoch.status,
+            "target_net_pnl_per_day": str(epoch.target_net_pnl_per_day),
+            "paper_run_ids": epoch.paper_run_ids_json or [],
+            "snapshot_manifest": epoch.snapshot_manifest_json or {},
+            "runner_config": epoch.runner_config_json or {},
+            "summary": epoch.summary_json or {},
+            "started_at": epoch.started_at.isoformat() if epoch.started_at else None,
+            "completed_at": epoch.completed_at.isoformat()
+            if epoch.completed_at
+            else None,
+            "failure_reason": epoch.failure_reason,
+        },
+        "candidate_specs": [
+            {
+                "candidate_spec_id": row.candidate_spec_id,
+                "hypothesis_id": row.hypothesis_id,
+                "candidate_kind": row.candidate_kind,
+                "family_template_id": row.family_template_id,
+                "status": row.status,
+                "blockers": row.blockers_json or [],
+                "payload": row.payload_json,
+            }
+            for row in specs
+        ],
+        "proposal_scores": [
+            {
+                "candidate_spec_id": row.candidate_spec_id,
+                "model_id": row.model_id,
+                "backend": row.backend,
+                "proposal_score": str(row.proposal_score),
+                "rank": row.rank,
+                "selection_reason": row.selection_reason,
+                "feature_hash": row.feature_hash,
+            }
+            for row in proposals
+        ],
+        "portfolio_candidates": [
+            {
+                "portfolio_candidate_id": row.portfolio_candidate_id,
+                "status": row.status,
+                "target_net_pnl_per_day": str(row.target_net_pnl_per_day),
+                "source_candidate_ids": row.source_candidate_ids_json,
+                "objective_scorecard": row.objective_scorecard_json,
+                "optimizer_report": row.optimizer_report_json,
+                "payload": row.payload_json,
+            }
+            for row in portfolios
+        ],
+    }
 
 
 @app.get("/trading/completion/doc29")
@@ -2313,7 +2448,7 @@ def trading_runtime_profitability(
         empirical_jobs_status=empirical_jobs,
         dspy_runtime_status=cast(
             dict[str, object],
-            scheduler.llm_status().get('dspy_runtime', {}),
+            scheduler.llm_status().get("dspy_runtime", {}),
         ),
         quant_health_status=quant_evidence,
     )
@@ -2453,7 +2588,9 @@ def _build_control_plane_contract(
     market_session_open = getattr(state, "market_session_open", None)
     last_run_at = getattr(state, "last_run_at", None)
     last_reconcile_at = getattr(state, "last_reconcile_at", None)
-    summary: dict[str, Any] = dict(hypothesis_summary) if hypothesis_summary is not None else {}
+    summary: dict[str, Any] = (
+        dict(hypothesis_summary) if hypothesis_summary is not None else {}
+    )
     raw_state_totals = summary.get("state_totals")
     state_totals: dict[str, Any] = (
         dict(cast(Mapping[str, Any], raw_state_totals))
@@ -2577,7 +2714,12 @@ def _build_shadow_first_runtime_payload(
         "active_revision": _active_runtime_revision(),
         "capital_stage": _resolve_active_capital_stage(hypothesis_summary),
         "capital_stage_totals": (
-            dict(cast(Mapping[str, Any], hypothesis_summary.get("capital_stage_totals", {})))
+            dict(
+                cast(
+                    Mapping[str, Any],
+                    hypothesis_summary.get("capital_stage_totals", {}),
+                )
+            )
             if isinstance(hypothesis_summary, Mapping)
             and isinstance(hypothesis_summary.get("capital_stage_totals"), Mapping)
             else {}
@@ -2837,9 +2979,10 @@ def _check_alpaca() -> dict[str, object]:
     timeout_seconds = max(0.1, settings.trading_alpaca_healthcheck_timeout_seconds)
     retries = max(1, settings.trading_alpaca_healthcheck_retries)
     backoff_seconds = max(0.0, settings.trading_alpaca_healthcheck_backoff_seconds)
-    endpoint_class = str(
-        getattr(client, "endpoint_class", _alpaca_endpoint_class())
-    ).strip() or _alpaca_endpoint_class()
+    endpoint_class = (
+        str(getattr(client, "endpoint_class", _alpaca_endpoint_class())).strip()
+        or _alpaca_endpoint_class()
+    )
 
     last_failure: dict[str, object] | None = None
     for attempt in range(retries):
@@ -2871,7 +3014,9 @@ def _check_alpaca() -> dict[str, object]:
             time.sleep(backoff_seconds * float(attempt + 1))
 
     failure_status = str(last_failure.get("status") if last_failure else "broker_error")
-    failure_detail = str(last_failure.get("detail") if last_failure else "alpaca probe failed")
+    failure_detail = str(
+        last_failure.get("detail") if last_failure else "alpaca probe failed"
+    )
     cached = _alpaca_cached_last_good(
         failure_status=failure_status,
         failure_detail=failure_detail,
@@ -2994,7 +3139,10 @@ def _build_live_submission_gate_payload(
             getattr(state, "emergency_stop_active", False)
         ):
             blocked_reasons.append(
-                str(getattr(state, "emergency_stop_reason", "") or "emergency_stop_active")
+                str(
+                    getattr(state, "emergency_stop_reason", "")
+                    or "emergency_stop_active"
+                )
             )
         return {
             "allowed": len(blocked_reasons) == 0,
@@ -3549,7 +3697,9 @@ def _load_runtime_profitability_gate_rollback_attribution(
 def _build_autonomy_bridge_status(
     scheduler: TradingScheduler,
 ) -> dict[str, object]:
-    gate_artifact_path = str(getattr(scheduler.state, "last_autonomy_gates", "") or "").strip()
+    gate_artifact_path = str(
+        getattr(scheduler.state, "last_autonomy_gates", "") or ""
+    ).strip()
     gate_payload = _load_json_artifact_payload(gate_artifact_path)
     actuation_artifact_path = str(
         getattr(scheduler.state, "last_autonomy_actuation_intent", "") or ""
@@ -3557,7 +3707,9 @@ def _build_autonomy_bridge_status(
     actuation_payload = _load_json_artifact_payload(actuation_artifact_path)
     actuation_gates = _to_str_map(actuation_payload.get("gates"))
     provenance_payload = _to_str_map(gate_payload.get("provenance"))
-    drift_path = str(getattr(scheduler.state, "drift_last_outcome_path", "") or "").strip()
+    drift_path = str(
+        getattr(scheduler.state, "drift_last_outcome_path", "") or ""
+    ).strip()
     drift_payload = _load_json_artifact_payload(drift_path)
     drift_reasons_raw = drift_payload.get("reasons")
     drift_reason_codes_raw = drift_payload.get("reason_codes")
@@ -3582,15 +3734,15 @@ def _build_autonomy_bridge_status(
             },
             "simulation_calibration": None,
             "shadow_live_deviation": None,
-        "evidence_authority": {
-            "gate_report_trace_id": None,
-            "recommendation_trace_id": None,
-            "authoritative_count": 0,
-            "total_count": 0,
-            "missing": [],
-        },
-        "persisted_vnext_objects": None,
-    }
+            "evidence_authority": {
+                "gate_report_trace_id": None,
+                "recommendation_trace_id": None,
+                "authoritative_count": 0,
+                "total_count": 0,
+                "missing": [],
+            },
+            "persisted_vnext_objects": None,
+        }
 
     source = "gate_report"
     if (
@@ -3623,7 +3775,9 @@ def _build_autonomy_bridge_status(
         else {}
     )
     vnext_raw = gate_payload.get("vnext")
-    vnext_payload = cast(dict[str, object], vnext_raw) if isinstance(vnext_raw, dict) else {}
+    vnext_payload = (
+        cast(dict[str, object], vnext_raw) if isinstance(vnext_raw, dict) else {}
+    )
     strategy_compilation_raw = vnext_payload.get("strategy_compilation")
     portfolio_promotion_raw = vnext_payload.get("portfolio_promotion")
     strategy_compilation_items = (
@@ -3658,8 +3812,7 @@ def _build_autonomy_bridge_status(
 
     return {
         "source": source,
-        "run_id": str(gate_payload.get("run_id") or "").strip()
-        or None,
+        "run_id": str(gate_payload.get("run_id") or "").strip() or None,
         "strategy_compilation": {
             "total": len(strategy_compilation_items),
             "spec_compiled": spec_compiled,

--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -29,10 +29,6 @@ from .db import SessionLocal, check_schema_current, ensure_schema, get_session, 
 from .db import check_account_scope_invariants
 from .metrics import render_trading_metrics
 from .models import (
-    AutoresearchCandidateSpec,
-    AutoresearchEpoch,
-    AutoresearchPortfolioCandidate,
-    AutoresearchProposalScore,
     Execution,
     ExecutionTCAMetric,
     Strategy,
@@ -57,6 +53,7 @@ from .trading.autonomy import (
     assert_runtime_gate_policy_contract,
     evaluate_evidence_continuity,
 )
+from .trading.autoresearch_routes import router as autoresearch_router
 from .trading.completion import build_doc29_completion_status
 from .trading.empirical_jobs import build_empirical_jobs_status
 from .trading.forecast_runtime import forecast_status
@@ -318,6 +315,7 @@ async def lifespan(app: FastAPI):
 app = FastAPI(title="torghut", lifespan=lifespan)
 app.state.settings = settings
 app.state.whitepaper_inngest_registered = False
+app.include_router(autoresearch_router)
 _register_whitepaper_inngest_routes(app)
 
 
@@ -2057,119 +2055,6 @@ def trading_empirical_jobs() -> dict[str, object]:
     """Return freshness and authority status for empirical parity and Janus workflows."""
 
     return _empirical_jobs_status()
-
-
-@app.get("/trading/autoresearch/epochs")
-def trading_autoresearch_epochs(
-    status: str | None = Query(default=None),
-    limit: int = Query(default=25, ge=1, le=100),
-    session: Session = Depends(get_session),
-) -> dict[str, object]:
-    """Return persisted whitepaper autoresearch epochs."""
-
-    stmt = select(AutoresearchEpoch)
-    if status:
-        stmt = stmt.where(AutoresearchEpoch.status == status)
-    rows = session.execute(
-        stmt.order_by(AutoresearchEpoch.created_at.desc()).limit(limit)
-    ).scalars()
-    items: list[dict[str, object]] = [
-        {
-            "epoch_id": row.epoch_id,
-            "status": row.status,
-            "target_net_pnl_per_day": str(row.target_net_pnl_per_day),
-            "paper_run_ids": cast(object, row.paper_run_ids_json or []),
-            "started_at": row.started_at.isoformat() if row.started_at else None,
-            "completed_at": row.completed_at.isoformat() if row.completed_at else None,
-            "failure_reason": row.failure_reason,
-            "summary": cast(object, row.summary_json or {}),
-        }
-        for row in rows
-    ]
-    return {"count": len(items), "epochs": items}
-
-
-@app.get("/trading/autoresearch/epochs/{epoch_id}")
-def trading_autoresearch_epoch(
-    epoch_id: str,
-    session: Session = Depends(get_session),
-) -> dict[str, object]:
-    """Return one persisted whitepaper autoresearch epoch with child ledgers."""
-
-    epoch = session.execute(
-        select(AutoresearchEpoch).where(AutoresearchEpoch.epoch_id == epoch_id)
-    ).scalar_one_or_none()
-    if epoch is None:
-        raise HTTPException(
-            status_code=404, detail=f"autoresearch_epoch_not_found:{epoch_id}"
-        )
-    specs = session.execute(
-        select(AutoresearchCandidateSpec)
-        .where(AutoresearchCandidateSpec.epoch_id == epoch_id)
-        .order_by(AutoresearchCandidateSpec.created_at.asc())
-    ).scalars()
-    proposals = session.execute(
-        select(AutoresearchProposalScore)
-        .where(AutoresearchProposalScore.epoch_id == epoch_id)
-        .order_by(AutoresearchProposalScore.rank.asc())
-    ).scalars()
-    portfolios = session.execute(
-        select(AutoresearchPortfolioCandidate)
-        .where(AutoresearchPortfolioCandidate.epoch_id == epoch_id)
-        .order_by(AutoresearchPortfolioCandidate.created_at.asc())
-    ).scalars()
-    return {
-        "epoch": {
-            "epoch_id": epoch.epoch_id,
-            "status": epoch.status,
-            "target_net_pnl_per_day": str(epoch.target_net_pnl_per_day),
-            "paper_run_ids": epoch.paper_run_ids_json or [],
-            "snapshot_manifest": epoch.snapshot_manifest_json or {},
-            "runner_config": epoch.runner_config_json or {},
-            "summary": epoch.summary_json or {},
-            "started_at": epoch.started_at.isoformat() if epoch.started_at else None,
-            "completed_at": epoch.completed_at.isoformat()
-            if epoch.completed_at
-            else None,
-            "failure_reason": epoch.failure_reason,
-        },
-        "candidate_specs": [
-            {
-                "candidate_spec_id": row.candidate_spec_id,
-                "hypothesis_id": row.hypothesis_id,
-                "candidate_kind": row.candidate_kind,
-                "family_template_id": row.family_template_id,
-                "status": row.status,
-                "blockers": row.blockers_json or [],
-                "payload": row.payload_json,
-            }
-            for row in specs
-        ],
-        "proposal_scores": [
-            {
-                "candidate_spec_id": row.candidate_spec_id,
-                "model_id": row.model_id,
-                "backend": row.backend,
-                "proposal_score": str(row.proposal_score),
-                "rank": row.rank,
-                "selection_reason": row.selection_reason,
-                "feature_hash": row.feature_hash,
-            }
-            for row in proposals
-        ],
-        "portfolio_candidates": [
-            {
-                "portfolio_candidate_id": row.portfolio_candidate_id,
-                "status": row.status,
-                "target_net_pnl_per_day": str(row.target_net_pnl_per_day),
-                "source_candidate_ids": row.source_candidate_ids_json,
-                "objective_scorecard": row.objective_scorecard_json,
-                "optimizer_report": row.optimizer_report_json,
-                "payload": row.payload_json,
-            }
-            for row in portfolios
-        ],
-    }
 
 
 @app.get("/trading/completion/doc29")

--- a/services/torghut/app/models/__init__.py
+++ b/services/torghut/app/models/__init__.py
@@ -2,6 +2,10 @@
 
 from .base import Base, GUID, JSONType, coerce_json_payload, metadata_obj
 from .entities import (
+    AutoresearchCandidateSpec,
+    AutoresearchEpoch,
+    AutoresearchPortfolioCandidate,
+    AutoresearchProposalScore,
     CreatedAtMixin,
     ExecutionTCAMetric,
     LeanBacktestRun,
@@ -69,6 +73,10 @@ __all__ = [
     "JSONType",
     "coerce_json_payload",
     "metadata_obj",
+    "AutoresearchCandidateSpec",
+    "AutoresearchEpoch",
+    "AutoresearchPortfolioCandidate",
+    "AutoresearchProposalScore",
     "CreatedAtMixin",
     "Execution",
     "ExecutionOrderEvent",

--- a/services/torghut/app/models/entities.py
+++ b/services/torghut/app/models/entities.py
@@ -139,9 +139,7 @@ class Execution(Base, TimestampMixin):
     alpaca_account_label: Mapped[str] = mapped_column(
         String(length=64), nullable=False, server_default=text("'paper'")
     )
-    alpaca_order_id: Mapped[str] = mapped_column(
-        String(length=128), nullable=False
-    )
+    alpaca_order_id: Mapped[str] = mapped_column(String(length=128), nullable=False)
     client_order_id: Mapped[Optional[str]] = mapped_column(
         String(length=128), nullable=True
     )
@@ -435,9 +433,7 @@ class ResearchCandidate(Base, CreatedAtMixin):
     valid_regime_envelope: Mapped[Optional[Any]] = mapped_column(
         JSONType, nullable=True
     )
-    invalidation_clauses: Mapped[Optional[Any]] = mapped_column(
-        JSONType, nullable=True
-    )
+    invalidation_clauses: Mapped[Optional[Any]] = mapped_column(JSONType, nullable=True)
     null_comparator_summary: Mapped[Optional[Any]] = mapped_column(
         JSONType, nullable=True
     )
@@ -729,13 +725,23 @@ class VNextDatasetSnapshot(Base, TimestampMixin):
 
     id: Mapped[uuid.UUID] = mapped_column(GUID(), primary_key=True, default=uuid.uuid4)
     run_id: Mapped[str] = mapped_column(String(length=64), nullable=False)
-    candidate_id: Mapped[Optional[str]] = mapped_column(String(length=64), nullable=True)
+    candidate_id: Mapped[Optional[str]] = mapped_column(
+        String(length=64), nullable=True
+    )
     dataset_id: Mapped[str] = mapped_column(String(length=128), nullable=False)
     source: Mapped[str] = mapped_column(String(length=64), nullable=False)
-    dataset_version: Mapped[Optional[str]] = mapped_column(String(length=128), nullable=True)
-    dataset_from: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
-    dataset_to: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
-    artifact_ref: Mapped[Optional[str]] = mapped_column(String(length=255), nullable=True)
+    dataset_version: Mapped[Optional[str]] = mapped_column(
+        String(length=128), nullable=True
+    )
+    dataset_from: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    dataset_to: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    artifact_ref: Mapped[Optional[str]] = mapped_column(
+        String(length=255), nullable=True
+    )
     payload_json: Mapped[Optional[Any]] = mapped_column(JSONType, nullable=True)
 
     __table_args__ = (
@@ -758,9 +764,13 @@ class VNextFeatureViewSpec(Base, TimestampMixin):
 
     id: Mapped[uuid.UUID] = mapped_column(GUID(), primary_key=True, default=uuid.uuid4)
     run_id: Mapped[str] = mapped_column(String(length=64), nullable=False)
-    candidate_id: Mapped[Optional[str]] = mapped_column(String(length=64), nullable=True)
+    candidate_id: Mapped[Optional[str]] = mapped_column(
+        String(length=64), nullable=True
+    )
     strategy_id: Mapped[str] = mapped_column(String(length=128), nullable=False)
-    feature_view_spec_ref: Mapped[str] = mapped_column(String(length=255), nullable=False)
+    feature_view_spec_ref: Mapped[str] = mapped_column(
+        String(length=255), nullable=False
+    )
     payload_json: Mapped[Optional[Any]] = mapped_column(JSONType, nullable=True)
 
     __table_args__ = (
@@ -783,7 +793,9 @@ class VNextModelArtifact(Base, TimestampMixin):
 
     id: Mapped[uuid.UUID] = mapped_column(GUID(), primary_key=True, default=uuid.uuid4)
     run_id: Mapped[str] = mapped_column(String(length=64), nullable=False)
-    candidate_id: Mapped[Optional[str]] = mapped_column(String(length=64), nullable=True)
+    candidate_id: Mapped[Optional[str]] = mapped_column(
+        String(length=64), nullable=True
+    )
     strategy_id: Mapped[str] = mapped_column(String(length=128), nullable=False)
     artifact_ref: Mapped[str] = mapped_column(String(length=255), nullable=False)
     artifact_kind: Mapped[str] = mapped_column(String(length=64), nullable=False)
@@ -810,7 +822,9 @@ class VNextExperimentSpec(Base, TimestampMixin):
 
     id: Mapped[uuid.UUID] = mapped_column(GUID(), primary_key=True, default=uuid.uuid4)
     run_id: Mapped[str] = mapped_column(String(length=64), nullable=False)
-    candidate_id: Mapped[Optional[str]] = mapped_column(String(length=64), nullable=True)
+    candidate_id: Mapped[Optional[str]] = mapped_column(
+        String(length=64), nullable=True
+    )
     experiment_id: Mapped[str] = mapped_column(String(length=128), nullable=False)
     payload_json: Mapped[Optional[Any]] = mapped_column(JSONType, nullable=True)
 
@@ -834,9 +848,15 @@ class VNextExperimentRun(Base, TimestampMixin):
 
     id: Mapped[uuid.UUID] = mapped_column(GUID(), primary_key=True, default=uuid.uuid4)
     run_id: Mapped[str] = mapped_column(String(length=64), nullable=False)
-    candidate_id: Mapped[Optional[str]] = mapped_column(String(length=64), nullable=True)
-    experiment_id: Mapped[Optional[str]] = mapped_column(String(length=128), nullable=True)
-    stage_lineage_root: Mapped[Optional[str]] = mapped_column(String(length=128), nullable=True)
+    candidate_id: Mapped[Optional[str]] = mapped_column(
+        String(length=64), nullable=True
+    )
+    experiment_id: Mapped[Optional[str]] = mapped_column(
+        String(length=128), nullable=True
+    )
+    stage_lineage_root: Mapped[Optional[str]] = mapped_column(
+        String(length=128), nullable=True
+    )
     payload_json: Mapped[Optional[Any]] = mapped_column(JSONType, nullable=True)
 
     __table_args__ = (
@@ -859,7 +879,9 @@ class VNextSimulationCalibration(Base, TimestampMixin):
 
     id: Mapped[uuid.UUID] = mapped_column(GUID(), primary_key=True, default=uuid.uuid4)
     run_id: Mapped[str] = mapped_column(String(length=64), nullable=False)
-    candidate_id: Mapped[Optional[str]] = mapped_column(String(length=64), nullable=True)
+    candidate_id: Mapped[Optional[str]] = mapped_column(
+        String(length=64), nullable=True
+    )
     artifact_ref: Mapped[str] = mapped_column(String(length=255), nullable=False)
     status: Mapped[Optional[str]] = mapped_column(String(length=64), nullable=True)
     order_count: Mapped[Optional[int]] = mapped_column(BigInteger(), nullable=True)
@@ -884,7 +906,9 @@ class VNextShadowLiveDeviation(Base, TimestampMixin):
 
     id: Mapped[uuid.UUID] = mapped_column(GUID(), primary_key=True, default=uuid.uuid4)
     run_id: Mapped[str] = mapped_column(String(length=64), nullable=False)
-    candidate_id: Mapped[Optional[str]] = mapped_column(String(length=64), nullable=True)
+    candidate_id: Mapped[Optional[str]] = mapped_column(
+        String(length=64), nullable=True
+    )
     artifact_ref: Mapped[str] = mapped_column(String(length=255), nullable=False)
     status: Mapped[Optional[str]] = mapped_column(String(length=64), nullable=True)
     order_count: Mapped[Optional[int]] = mapped_column(BigInteger(), nullable=True)
@@ -911,11 +935,21 @@ class VNextPromotionDecision(Base, TimestampMixin):
     run_id: Mapped[str] = mapped_column(String(length=64), nullable=False)
     candidate_id: Mapped[str] = mapped_column(String(length=64), nullable=False)
     promotion_target: Mapped[str] = mapped_column(String(length=16), nullable=False)
-    recommended_mode: Mapped[Optional[str]] = mapped_column(String(length=16), nullable=True)
-    decision_action: Mapped[Optional[str]] = mapped_column(String(length=32), nullable=True)
-    allowed: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("false"))
-    gate_report_trace_id: Mapped[Optional[str]] = mapped_column(String(length=64), nullable=True)
-    recommendation_trace_id: Mapped[Optional[str]] = mapped_column(String(length=64), nullable=True)
+    recommended_mode: Mapped[Optional[str]] = mapped_column(
+        String(length=16), nullable=True
+    )
+    decision_action: Mapped[Optional[str]] = mapped_column(
+        String(length=32), nullable=True
+    )
+    allowed: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default=text("false")
+    )
+    gate_report_trace_id: Mapped[Optional[str]] = mapped_column(
+        String(length=64), nullable=True
+    )
+    recommendation_trace_id: Mapped[Optional[str]] = mapped_column(
+        String(length=64), nullable=True
+    )
     payload_json: Mapped[Optional[Any]] = mapped_column(JSONType, nullable=True)
 
     __table_args__ = (
@@ -938,7 +972,9 @@ class VNextEmpiricalJobRun(Base, TimestampMixin):
 
     id: Mapped[uuid.UUID] = mapped_column(GUID(), primary_key=True, default=uuid.uuid4)
     run_id: Mapped[str] = mapped_column(String(length=64), nullable=False)
-    candidate_id: Mapped[Optional[str]] = mapped_column(String(length=64), nullable=True)
+    candidate_id: Mapped[Optional[str]] = mapped_column(
+        String(length=64), nullable=True
+    )
     job_name: Mapped[str] = mapped_column(String(length=128), nullable=False)
     job_type: Mapped[str] = mapped_column(String(length=64), nullable=False)
     job_run_id: Mapped[str] = mapped_column(String(length=128), nullable=False)
@@ -973,18 +1009,32 @@ class VNextCompletionGateResult(Base, TimestampMixin):
     id: Mapped[uuid.UUID] = mapped_column(GUID(), primary_key=True, default=uuid.uuid4)
     gate_id: Mapped[str] = mapped_column(String(length=64), nullable=False)
     run_id: Mapped[str] = mapped_column(String(length=64), nullable=False)
-    candidate_id: Mapped[Optional[str]] = mapped_column(String(length=64), nullable=True)
+    candidate_id: Mapped[Optional[str]] = mapped_column(
+        String(length=64), nullable=True
+    )
     dataset_snapshot_ref: Mapped[Optional[str]] = mapped_column(
         String(length=255), nullable=True
     )
-    git_revision: Mapped[Optional[str]] = mapped_column(String(length=128), nullable=True)
-    image_digest: Mapped[Optional[str]] = mapped_column(String(length=255), nullable=True)
-    workflow_name: Mapped[Optional[str]] = mapped_column(String(length=128), nullable=True)
+    git_revision: Mapped[Optional[str]] = mapped_column(
+        String(length=128), nullable=True
+    )
+    image_digest: Mapped[Optional[str]] = mapped_column(
+        String(length=255), nullable=True
+    )
+    workflow_name: Mapped[Optional[str]] = mapped_column(
+        String(length=128), nullable=True
+    )
     status: Mapped[str] = mapped_column(String(length=32), nullable=False)
-    artifact_ref: Mapped[Optional[str]] = mapped_column(String(length=1024), nullable=True)
-    blocked_reason: Mapped[Optional[str]] = mapped_column(String(length=255), nullable=True)
+    artifact_ref: Mapped[Optional[str]] = mapped_column(
+        String(length=1024), nullable=True
+    )
+    blocked_reason: Mapped[Optional[str]] = mapped_column(
+        String(length=255), nullable=True
+    )
     details_json: Mapped[Optional[Any]] = mapped_column(JSONType, nullable=True)
-    measured_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    measured_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
 
     __table_args__ = (
         Index("ix_vnext_completion_gate_results_gate_id", "gate_id"),
@@ -1006,11 +1056,17 @@ class StrategyHypothesis(Base, TimestampMixin):
     __tablename__ = "strategy_hypotheses"
 
     id: Mapped[uuid.UUID] = mapped_column(GUID(), primary_key=True, default=uuid.uuid4)
-    hypothesis_id: Mapped[str] = mapped_column(String(length=128), nullable=False, unique=True)
+    hypothesis_id: Mapped[str] = mapped_column(
+        String(length=128), nullable=False, unique=True
+    )
     lane_id: Mapped[str] = mapped_column(String(length=128), nullable=False)
     strategy_family: Mapped[str] = mapped_column(String(length=128), nullable=False)
-    source_manifest_ref: Mapped[Optional[str]] = mapped_column(String(length=255), nullable=True)
-    active: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("true"))
+    source_manifest_ref: Mapped[Optional[str]] = mapped_column(
+        String(length=255), nullable=True
+    )
+    active: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default=text("true")
+    )
     payload_json: Mapped[Optional[Any]] = mapped_column(JSONType, nullable=True)
 
     __table_args__ = (
@@ -1027,8 +1083,12 @@ class StrategyHypothesisVersion(Base, TimestampMixin):
     id: Mapped[uuid.UUID] = mapped_column(GUID(), primary_key=True, default=uuid.uuid4)
     hypothesis_id: Mapped[str] = mapped_column(String(length=128), nullable=False)
     version_key: Mapped[str] = mapped_column(String(length=128), nullable=False)
-    source_manifest_ref: Mapped[Optional[str]] = mapped_column(String(length=255), nullable=True)
-    active: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("true"))
+    source_manifest_ref: Mapped[Optional[str]] = mapped_column(
+        String(length=255), nullable=True
+    )
+    active: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default=text("true")
+    )
     payload_json: Mapped[Optional[Any]] = mapped_column(JSONType, nullable=True)
 
     __table_args__ = (
@@ -1049,25 +1109,59 @@ class StrategyHypothesisMetricWindow(Base, TimestampMixin):
 
     id: Mapped[uuid.UUID] = mapped_column(GUID(), primary_key=True, default=uuid.uuid4)
     run_id: Mapped[str] = mapped_column(String(length=64), nullable=False)
-    candidate_id: Mapped[Optional[str]] = mapped_column(String(length=64), nullable=True)
+    candidate_id: Mapped[Optional[str]] = mapped_column(
+        String(length=64), nullable=True
+    )
     hypothesis_id: Mapped[str] = mapped_column(String(length=128), nullable=False)
     observed_stage: Mapped[str] = mapped_column(String(length=32), nullable=False)
-    window_started_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
-    window_ended_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
-    market_session_count: Mapped[int] = mapped_column(BigInteger(), nullable=False, server_default=text("1"))
-    decision_count: Mapped[int] = mapped_column(BigInteger(), nullable=False, server_default=text("0"))
-    trade_count: Mapped[int] = mapped_column(BigInteger(), nullable=False, server_default=text("0"))
-    order_count: Mapped[int] = mapped_column(BigInteger(), nullable=False, server_default=text("0"))
-    evidence_provenance: Mapped[Optional[str]] = mapped_column(String(length=64), nullable=True)
-    evidence_maturity: Mapped[Optional[str]] = mapped_column(String(length=64), nullable=True)
-    decision_alignment_ratio: Mapped[Optional[str]] = mapped_column(String(length=64), nullable=True)
-    avg_abs_slippage_bps: Mapped[Optional[str]] = mapped_column(String(length=64), nullable=True)
-    slippage_budget_bps: Mapped[Optional[str]] = mapped_column(String(length=64), nullable=True)
-    post_cost_expectancy_bps: Mapped[Optional[str]] = mapped_column(String(length=64), nullable=True)
-    continuity_ok: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("true"))
-    drift_ok: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("true"))
-    dependency_quorum_decision: Mapped[Optional[str]] = mapped_column(String(length=32), nullable=True)
-    capital_stage: Mapped[Optional[str]] = mapped_column(String(length=32), nullable=True)
+    window_started_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    window_ended_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    market_session_count: Mapped[int] = mapped_column(
+        BigInteger(), nullable=False, server_default=text("1")
+    )
+    decision_count: Mapped[int] = mapped_column(
+        BigInteger(), nullable=False, server_default=text("0")
+    )
+    trade_count: Mapped[int] = mapped_column(
+        BigInteger(), nullable=False, server_default=text("0")
+    )
+    order_count: Mapped[int] = mapped_column(
+        BigInteger(), nullable=False, server_default=text("0")
+    )
+    evidence_provenance: Mapped[Optional[str]] = mapped_column(
+        String(length=64), nullable=True
+    )
+    evidence_maturity: Mapped[Optional[str]] = mapped_column(
+        String(length=64), nullable=True
+    )
+    decision_alignment_ratio: Mapped[Optional[str]] = mapped_column(
+        String(length=64), nullable=True
+    )
+    avg_abs_slippage_bps: Mapped[Optional[str]] = mapped_column(
+        String(length=64), nullable=True
+    )
+    slippage_budget_bps: Mapped[Optional[str]] = mapped_column(
+        String(length=64), nullable=True
+    )
+    post_cost_expectancy_bps: Mapped[Optional[str]] = mapped_column(
+        String(length=64), nullable=True
+    )
+    continuity_ok: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default=text("true")
+    )
+    drift_ok: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default=text("true")
+    )
+    dependency_quorum_decision: Mapped[Optional[str]] = mapped_column(
+        String(length=32), nullable=True
+    )
+    capital_stage: Mapped[Optional[str]] = mapped_column(
+        String(length=32), nullable=True
+    )
     payload_json: Mapped[Optional[Any]] = mapped_column(JSONType, nullable=True)
 
     __table_args__ = (
@@ -1085,12 +1179,18 @@ class StrategyCapitalAllocation(Base, TimestampMixin):
 
     id: Mapped[uuid.UUID] = mapped_column(GUID(), primary_key=True, default=uuid.uuid4)
     run_id: Mapped[str] = mapped_column(String(length=64), nullable=False)
-    candidate_id: Mapped[Optional[str]] = mapped_column(String(length=64), nullable=True)
+    candidate_id: Mapped[Optional[str]] = mapped_column(
+        String(length=64), nullable=True
+    )
     hypothesis_id: Mapped[str] = mapped_column(String(length=128), nullable=False)
     prior_stage: Mapped[Optional[str]] = mapped_column(String(length=32), nullable=True)
     stage: Mapped[str] = mapped_column(String(length=32), nullable=False)
-    capital_multiplier: Mapped[Optional[str]] = mapped_column(String(length=64), nullable=True)
-    rollback_target_stage: Mapped[Optional[str]] = mapped_column(String(length=32), nullable=True)
+    capital_multiplier: Mapped[Optional[str]] = mapped_column(
+        String(length=64), nullable=True
+    )
+    rollback_target_stage: Mapped[Optional[str]] = mapped_column(
+        String(length=32), nullable=True
+    )
     payload_json: Mapped[Optional[Any]] = mapped_column(JSONType, nullable=True)
 
     __table_args__ = (
@@ -1107,12 +1207,18 @@ class StrategyPromotionDecision(Base, TimestampMixin):
 
     id: Mapped[uuid.UUID] = mapped_column(GUID(), primary_key=True, default=uuid.uuid4)
     run_id: Mapped[str] = mapped_column(String(length=64), nullable=False)
-    candidate_id: Mapped[Optional[str]] = mapped_column(String(length=64), nullable=True)
+    candidate_id: Mapped[Optional[str]] = mapped_column(
+        String(length=64), nullable=True
+    )
     hypothesis_id: Mapped[str] = mapped_column(String(length=128), nullable=False)
     promotion_target: Mapped[str] = mapped_column(String(length=16), nullable=False)
     state: Mapped[Optional[str]] = mapped_column(String(length=32), nullable=True)
-    allowed: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("false"))
-    reason_summary: Mapped[Optional[str]] = mapped_column(String(length=255), nullable=True)
+    allowed: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default=text("false")
+    )
+    reason_summary: Mapped[Optional[str]] = mapped_column(
+        String(length=255), nullable=True
+    )
     payload_json: Mapped[Optional[Any]] = mapped_column(JSONType, nullable=True)
 
     __table_args__ = (
@@ -1170,7 +1276,9 @@ class WhitepaperDocument(Base, TimestampMixin):
     )
     tags_json: Mapped[Optional[Any]] = mapped_column(JSONType, nullable=True)
     metadata_json: Mapped[Optional[Any]] = mapped_column(JSONType, nullable=True)
-    ingested_by: Mapped[Optional[str]] = mapped_column(String(length=128), nullable=True)
+    ingested_by: Mapped[Optional[str]] = mapped_column(
+        String(length=128), nullable=True
+    )
     last_processed_at: Mapped[Optional[datetime]] = mapped_column(
         DateTime(timezone=True), nullable=True
     )
@@ -1242,7 +1350,9 @@ class WhitepaperDocumentVersion(Base, TimestampMixin):
     extraction_metadata_json: Mapped[Optional[Any]] = mapped_column(
         JSONType, nullable=True
     )
-    uploaded_by: Mapped[Optional[str]] = mapped_column(String(length=128), nullable=True)
+    uploaded_by: Mapped[Optional[str]] = mapped_column(
+        String(length=128), nullable=True
+    )
     processed_at: Mapped[Optional[datetime]] = mapped_column(
         DateTime(timezone=True), nullable=True
     )
@@ -1307,7 +1417,9 @@ class WhitepaperContent(Base, CreatedAtMixin):
     extraction_warnings_json: Mapped[Optional[Any]] = mapped_column(
         JSONType, nullable=True
     )
-    quality_score: Mapped[Optional[Decimal]] = mapped_column(Numeric(6, 4), nullable=True)
+    quality_score: Mapped[Optional[Decimal]] = mapped_column(
+        Numeric(6, 4), nullable=True
+    )
 
     document_version: Mapped[WhitepaperDocumentVersion] = relationship(
         back_populates="content"
@@ -1347,8 +1459,12 @@ class WhitepaperAnalysisRun(Base, TimestampMixin):
         default="upload",
         server_default=text("'upload'"),
     )
-    trigger_actor: Mapped[Optional[str]] = mapped_column(String(length=128), nullable=True)
-    retry_of_run_id: Mapped[Optional[str]] = mapped_column(String(length=64), nullable=True)
+    trigger_actor: Mapped[Optional[str]] = mapped_column(
+        String(length=128), nullable=True
+    )
+    retry_of_run_id: Mapped[Optional[str]] = mapped_column(
+        String(length=64), nullable=True
+    )
     inngest_event_id: Mapped[Optional[str]] = mapped_column(
         String(length=128), nullable=True
     )
@@ -1361,10 +1477,14 @@ class WhitepaperAnalysisRun(Base, TimestampMixin):
     orchestration_context_json: Mapped[Optional[Any]] = mapped_column(
         JSONType, nullable=True
     )
-    analysis_profile_json: Mapped[Optional[Any]] = mapped_column(JSONType, nullable=True)
+    analysis_profile_json: Mapped[Optional[Any]] = mapped_column(
+        JSONType, nullable=True
+    )
     request_payload_json: Mapped[Optional[Any]] = mapped_column(JSONType, nullable=True)
     result_payload_json: Mapped[Optional[Any]] = mapped_column(JSONType, nullable=True)
-    failure_code: Mapped[Optional[str]] = mapped_column(String(length=128), nullable=True)
+    failure_code: Mapped[Optional[str]] = mapped_column(
+        String(length=128), nullable=True
+    )
     failure_reason: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     started_at: Mapped[Optional[datetime]] = mapped_column(
         DateTime(timezone=True), nullable=True
@@ -1396,10 +1516,12 @@ class WhitepaperAnalysisRun(Base, TimestampMixin):
     design_pull_requests: Mapped[List["WhitepaperDesignPullRequest"]] = relationship(
         back_populates="analysis_run", cascade="all, delete-orphan"
     )
-    engineering_trigger: Mapped[Optional["WhitepaperEngineeringTrigger"]] = relationship(
-        back_populates="analysis_run",
-        uselist=False,
-        cascade="all, delete-orphan",
+    engineering_trigger: Mapped[Optional["WhitepaperEngineeringTrigger"]] = (
+        relationship(
+            back_populates="analysis_run",
+            uselist=False,
+            cascade="all, delete-orphan",
+        )
     )
     claims: Mapped[List["WhitepaperClaim"]] = relationship(
         back_populates="analysis_run", cascade="all, delete-orphan"
@@ -1423,9 +1545,7 @@ class WhitepaperAnalysisRun(Base, TimestampMixin):
     __table_args__ = (
         Index("ix_whitepaper_analysis_runs_status", "status"),
         Index("ix_whitepaper_analysis_runs_document_id", "document_id"),
-        Index(
-            "ix_whitepaper_analysis_runs_document_version_id", "document_version_id"
-        ),
+        Index("ix_whitepaper_analysis_runs_document_version_id", "document_version_id"),
         Index("ix_whitepaper_analysis_runs_inngest_event_id", "inngest_event_id"),
         Index("ix_whitepaper_analysis_runs_created_at", "created_at"),
     )
@@ -1512,7 +1632,9 @@ class WhitepaperCodexAgentRun(Base, TimestampMixin):
     agentrun_namespace: Mapped[Optional[str]] = mapped_column(
         String(length=64), nullable=True
     )
-    agentrun_uid: Mapped[Optional[str]] = mapped_column(String(length=128), nullable=True)
+    agentrun_uid: Mapped[Optional[str]] = mapped_column(
+        String(length=128), nullable=True
+    )
     status: Mapped[str] = mapped_column(
         String(length=32),
         nullable=False,
@@ -1525,11 +1647,15 @@ class WhitepaperCodexAgentRun(Base, TimestampMixin):
         default="default",
         server_default=text("'default'"),
     )
-    requested_by: Mapped[Optional[str]] = mapped_column(String(length=128), nullable=True)
+    requested_by: Mapped[Optional[str]] = mapped_column(
+        String(length=128), nullable=True
+    )
     codex_session_id: Mapped[Optional[str]] = mapped_column(
         String(length=128), nullable=True
     )
-    vcs_provider: Mapped[Optional[str]] = mapped_column(String(length=32), nullable=True)
+    vcs_provider: Mapped[Optional[str]] = mapped_column(
+        String(length=32), nullable=True
+    )
     vcs_repository: Mapped[Optional[str]] = mapped_column(
         String(length=255), nullable=True
     )
@@ -1545,9 +1671,13 @@ class WhitepaperCodexAgentRun(Base, TimestampMixin):
     vcs_head_commit_sha: Mapped[Optional[str]] = mapped_column(
         String(length=128), nullable=True
     )
-    workspace_context_json: Mapped[Optional[Any]] = mapped_column(JSONType, nullable=True)
+    workspace_context_json: Mapped[Optional[Any]] = mapped_column(
+        JSONType, nullable=True
+    )
     prompt_text: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
-    prompt_hash: Mapped[Optional[str]] = mapped_column(String(length=128), nullable=True)
+    prompt_hash: Mapped[Optional[str]] = mapped_column(
+        String(length=128), nullable=True
+    )
     input_context_json: Mapped[Optional[Any]] = mapped_column(JSONType, nullable=True)
     output_context_json: Mapped[Optional[Any]] = mapped_column(JSONType, nullable=True)
     patch_artifact_ref: Mapped[Optional[str]] = mapped_column(
@@ -1577,9 +1707,7 @@ class WhitepaperCodexAgentRun(Base, TimestampMixin):
     __table_args__ = (
         Index("ix_whitepaper_codex_agentruns_run_id", "analysis_run_id"),
         Index("ix_whitepaper_codex_agentruns_status", "status"),
-        Index(
-            "ix_whitepaper_codex_agentruns_codex_session_id", "codex_session_id"
-        ),
+        Index("ix_whitepaper_codex_agentruns_codex_session_id", "codex_session_id"),
         Index("ix_whitepaper_codex_agentruns_head_branch", "vcs_head_branch"),
     )
 
@@ -1609,7 +1737,9 @@ class WhitepaperSynthesis(Base, TimestampMixin):
         server_default=text("'codex'"),
     )
     model_name: Mapped[Optional[str]] = mapped_column(String(length=128), nullable=True)
-    prompt_version: Mapped[Optional[str]] = mapped_column(String(length=64), nullable=True)
+    prompt_version: Mapped[Optional[str]] = mapped_column(
+        String(length=64), nullable=True
+    )
     executive_summary: Mapped[str] = mapped_column(Text, nullable=False)
     problem_statement: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     methodology_summary: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
@@ -1621,14 +1751,14 @@ class WhitepaperSynthesis(Base, TimestampMixin):
     confidence: Mapped[Optional[Decimal]] = mapped_column(Numeric(6, 4), nullable=True)
     synthesis_json: Mapped[Optional[Any]] = mapped_column(JSONType, nullable=True)
 
-    analysis_run: Mapped[WhitepaperAnalysisRun] = relationship(back_populates="synthesis")
+    analysis_run: Mapped[WhitepaperAnalysisRun] = relationship(
+        back_populates="synthesis"
+    )
     artifacts: Mapped[List["WhitepaperArtifact"]] = relationship(
         back_populates="synthesis"
     )
 
-    __table_args__ = (
-        Index("ix_whitepaper_syntheses_generated_by", "generated_by"),
-    )
+    __table_args__ = (Index("ix_whitepaper_syntheses_generated_by", "generated_by"),)
 
 
 class WhitepaperViabilityVerdict(Base, TimestampMixin):
@@ -1646,10 +1776,14 @@ class WhitepaperViabilityVerdict(Base, TimestampMixin):
     verdict: Mapped[str] = mapped_column(String(length=32), nullable=False)
     score: Mapped[Optional[Decimal]] = mapped_column(Numeric(8, 4), nullable=True)
     confidence: Mapped[Optional[Decimal]] = mapped_column(Numeric(6, 4), nullable=True)
-    decision_policy: Mapped[Optional[str]] = mapped_column(String(length=64), nullable=True)
+    decision_policy: Mapped[Optional[str]] = mapped_column(
+        String(length=64), nullable=True
+    )
     gating_json: Mapped[Optional[Any]] = mapped_column(JSONType, nullable=True)
     rationale: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
-    rejection_reasons_json: Mapped[Optional[Any]] = mapped_column(JSONType, nullable=True)
+    rejection_reasons_json: Mapped[Optional[Any]] = mapped_column(
+        JSONType, nullable=True
+    )
     recommendations_json: Mapped[Optional[Any]] = mapped_column(JSONType, nullable=True)
     requires_followup: Mapped[bool] = mapped_column(
         Boolean,
@@ -1657,7 +1791,9 @@ class WhitepaperViabilityVerdict(Base, TimestampMixin):
         default=False,
         server_default=func.false(),
     )
-    approved_by: Mapped[Optional[str]] = mapped_column(String(length=128), nullable=True)
+    approved_by: Mapped[Optional[str]] = mapped_column(
+        String(length=128), nullable=True
+    )
     approved_at: Mapped[Optional[datetime]] = mapped_column(
         DateTime(timezone=True), nullable=True
     )
@@ -1795,18 +1931,30 @@ class WhitepaperArtifact(Base, CreatedAtMixin):
         server_default=text("'run'"),
     )
     artifact_type: Mapped[str] = mapped_column(String(length=64), nullable=False)
-    artifact_role: Mapped[Optional[str]] = mapped_column(String(length=64), nullable=True)
-    ceph_bucket: Mapped[Optional[str]] = mapped_column(String(length=128), nullable=True)
+    artifact_role: Mapped[Optional[str]] = mapped_column(
+        String(length=64), nullable=True
+    )
+    ceph_bucket: Mapped[Optional[str]] = mapped_column(
+        String(length=128), nullable=True
+    )
     ceph_object_key: Mapped[Optional[str]] = mapped_column(
         String(length=1024), nullable=True
     )
-    artifact_uri: Mapped[Optional[str]] = mapped_column(String(length=1024), nullable=True)
-    checksum_sha256: Mapped[Optional[str]] = mapped_column(String(length=64), nullable=True)
+    artifact_uri: Mapped[Optional[str]] = mapped_column(
+        String(length=1024), nullable=True
+    )
+    checksum_sha256: Mapped[Optional[str]] = mapped_column(
+        String(length=64), nullable=True
+    )
     size_bytes: Mapped[Optional[int]] = mapped_column(BigInteger, nullable=True)
-    content_type: Mapped[Optional[str]] = mapped_column(String(length=128), nullable=True)
+    content_type: Mapped[Optional[str]] = mapped_column(
+        String(length=128), nullable=True
+    )
     metadata_json: Mapped[Optional[Any]] = mapped_column(JSONType, nullable=True)
 
-    document: Mapped[Optional[WhitepaperDocument]] = relationship(back_populates="artifacts")
+    document: Mapped[Optional[WhitepaperDocument]] = relationship(
+        back_populates="artifacts"
+    )
     document_version: Mapped[Optional[WhitepaperDocumentVersion]] = relationship(
         back_populates="artifacts"
     )
@@ -1850,12 +1998,24 @@ class WhitepaperClaim(Base, TimestampMixin):
     claim_id: Mapped[str] = mapped_column(String(length=128), nullable=False)
     claim_type: Mapped[str] = mapped_column(String(length=64), nullable=False)
     claim_text: Mapped[str] = mapped_column(Text, nullable=False)
-    asset_scope: Mapped[Optional[str]] = mapped_column(String(length=128), nullable=True)
-    horizon_scope: Mapped[Optional[str]] = mapped_column(String(length=128), nullable=True)
-    data_requirements_json: Mapped[Optional[Any]] = mapped_column(JSONType, nullable=True)
-    expected_direction: Mapped[Optional[str]] = mapped_column(String(length=64), nullable=True)
-    required_activity_conditions_json: Mapped[Optional[Any]] = mapped_column(JSONType, nullable=True)
-    liquidity_constraints_json: Mapped[Optional[Any]] = mapped_column(JSONType, nullable=True)
+    asset_scope: Mapped[Optional[str]] = mapped_column(
+        String(length=128), nullable=True
+    )
+    horizon_scope: Mapped[Optional[str]] = mapped_column(
+        String(length=128), nullable=True
+    )
+    data_requirements_json: Mapped[Optional[Any]] = mapped_column(
+        JSONType, nullable=True
+    )
+    expected_direction: Mapped[Optional[str]] = mapped_column(
+        String(length=64), nullable=True
+    )
+    required_activity_conditions_json: Mapped[Optional[Any]] = mapped_column(
+        JSONType, nullable=True
+    )
+    liquidity_constraints_json: Mapped[Optional[Any]] = mapped_column(
+        JSONType, nullable=True
+    )
     validation_notes: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     confidence: Mapped[Optional[Decimal]] = mapped_column(Numeric(6, 4), nullable=True)
     metadata_json: Mapped[Optional[Any]] = mapped_column(JSONType, nullable=True)
@@ -1890,12 +2050,16 @@ class WhitepaperClaimRelation(Base, TimestampMixin):
     relation_type: Mapped[str] = mapped_column(String(length=64), nullable=False)
     source_claim_id: Mapped[str] = mapped_column(String(length=128), nullable=False)
     target_claim_id: Mapped[str] = mapped_column(String(length=128), nullable=False)
-    target_run_id: Mapped[Optional[str]] = mapped_column(String(length=64), nullable=True)
+    target_run_id: Mapped[Optional[str]] = mapped_column(
+        String(length=64), nullable=True
+    )
     rationale: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     confidence: Mapped[Optional[Decimal]] = mapped_column(Numeric(6, 4), nullable=True)
     metadata_json: Mapped[Optional[Any]] = mapped_column(JSONType, nullable=True)
 
-    analysis_run: Mapped[WhitepaperAnalysisRun] = relationship(back_populates="claim_relations")
+    analysis_run: Mapped[WhitepaperAnalysisRun] = relationship(
+        back_populates="claim_relations"
+    )
 
     __table_args__ = (
         Index("ix_whitepaper_claim_relations_run_id", "analysis_run_id"),
@@ -1926,19 +2090,31 @@ class WhitepaperStrategyTemplate(Base, TimestampMixin):
     family_template_id: Mapped[str] = mapped_column(String(length=128), nullable=False)
     economic_mechanism: Mapped[str] = mapped_column(Text, nullable=False)
     hypothesis: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
-    supported_markets_json: Mapped[Optional[Any]] = mapped_column(JSONType, nullable=True)
-    required_features_json: Mapped[Optional[Any]] = mapped_column(JSONType, nullable=True)
-    allowed_normalizations_json: Mapped[Optional[Any]] = mapped_column(JSONType, nullable=True)
+    supported_markets_json: Mapped[Optional[Any]] = mapped_column(
+        JSONType, nullable=True
+    )
+    required_features_json: Mapped[Optional[Any]] = mapped_column(
+        JSONType, nullable=True
+    )
+    allowed_normalizations_json: Mapped[Optional[Any]] = mapped_column(
+        JSONType, nullable=True
+    )
     entry_motifs_json: Mapped[Optional[Any]] = mapped_column(JSONType, nullable=True)
     exit_motifs_json: Mapped[Optional[Any]] = mapped_column(JSONType, nullable=True)
     risk_controls_json: Mapped[Optional[Any]] = mapped_column(JSONType, nullable=True)
     activity_model_json: Mapped[Optional[Any]] = mapped_column(JSONType, nullable=True)
-    liquidity_assumptions_json: Mapped[Optional[Any]] = mapped_column(JSONType, nullable=True)
-    regime_activation_rules_json: Mapped[Optional[Any]] = mapped_column(JSONType, nullable=True)
+    liquidity_assumptions_json: Mapped[Optional[Any]] = mapped_column(
+        JSONType, nullable=True
+    )
+    regime_activation_rules_json: Mapped[Optional[Any]] = mapped_column(
+        JSONType, nullable=True
+    )
     day_veto_rules_json: Mapped[Optional[Any]] = mapped_column(JSONType, nullable=True)
     metadata_json: Mapped[Optional[Any]] = mapped_column(JSONType, nullable=True)
 
-    analysis_run: Mapped[WhitepaperAnalysisRun] = relationship(back_populates="strategy_templates")
+    analysis_run: Mapped[WhitepaperAnalysisRun] = relationship(
+        back_populates="strategy_templates"
+    )
 
     __table_args__ = (
         Index("ix_whitepaper_strategy_templates_run_id", "analysis_run_id"),
@@ -1965,20 +2141,40 @@ class WhitepaperExperimentSpec(Base, TimestampMixin):
     )
     experiment_id: Mapped[str] = mapped_column(String(length=128), nullable=False)
     family_template_id: Mapped[str] = mapped_column(String(length=128), nullable=False)
-    template_id: Mapped[Optional[str]] = mapped_column(String(length=128), nullable=True)
+    template_id: Mapped[Optional[str]] = mapped_column(
+        String(length=128), nullable=True
+    )
     hypothesis: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
-    paper_claim_links_json: Mapped[Optional[Any]] = mapped_column(JSONType, nullable=True)
-    dataset_snapshot_policy_json: Mapped[Optional[Any]] = mapped_column(JSONType, nullable=True)
-    template_overrides_json: Mapped[Optional[Any]] = mapped_column(JSONType, nullable=True)
-    feature_variants_json: Mapped[Optional[Any]] = mapped_column(JSONType, nullable=True)
-    veto_controller_variants_json: Mapped[Optional[Any]] = mapped_column(JSONType, nullable=True)
-    selection_objectives_json: Mapped[Optional[Any]] = mapped_column(JSONType, nullable=True)
+    paper_claim_links_json: Mapped[Optional[Any]] = mapped_column(
+        JSONType, nullable=True
+    )
+    dataset_snapshot_policy_json: Mapped[Optional[Any]] = mapped_column(
+        JSONType, nullable=True
+    )
+    template_overrides_json: Mapped[Optional[Any]] = mapped_column(
+        JSONType, nullable=True
+    )
+    feature_variants_json: Mapped[Optional[Any]] = mapped_column(
+        JSONType, nullable=True
+    )
+    veto_controller_variants_json: Mapped[Optional[Any]] = mapped_column(
+        JSONType, nullable=True
+    )
+    selection_objectives_json: Mapped[Optional[Any]] = mapped_column(
+        JSONType, nullable=True
+    )
     hard_vetoes_json: Mapped[Optional[Any]] = mapped_column(JSONType, nullable=True)
-    expected_failure_modes_json: Mapped[Optional[Any]] = mapped_column(JSONType, nullable=True)
-    promotion_contract_json: Mapped[Optional[Any]] = mapped_column(JSONType, nullable=True)
+    expected_failure_modes_json: Mapped[Optional[Any]] = mapped_column(
+        JSONType, nullable=True
+    )
+    promotion_contract_json: Mapped[Optional[Any]] = mapped_column(
+        JSONType, nullable=True
+    )
     payload_json: Mapped[Optional[Any]] = mapped_column(JSONType, nullable=True)
 
-    analysis_run: Mapped[WhitepaperAnalysisRun] = relationship(back_populates="experiment_specs")
+    analysis_run: Mapped[WhitepaperAnalysisRun] = relationship(
+        back_populates="experiment_specs"
+    )
 
     __table_args__ = (
         Index("ix_whitepaper_experiment_specs_run_id", "analysis_run_id"),
@@ -2005,19 +2201,27 @@ class WhitepaperContradictionEvent(Base, TimestampMixin):
     )
     event_id: Mapped[str] = mapped_column(String(length=128), nullable=False)
     source_claim_id: Mapped[str] = mapped_column(String(length=128), nullable=False)
-    target_claim_id: Mapped[Optional[str]] = mapped_column(String(length=128), nullable=True)
-    target_run_id: Mapped[Optional[str]] = mapped_column(String(length=64), nullable=True)
+    target_claim_id: Mapped[Optional[str]] = mapped_column(
+        String(length=128), nullable=True
+    )
+    target_run_id: Mapped[Optional[str]] = mapped_column(
+        String(length=64), nullable=True
+    )
     status: Mapped[str] = mapped_column(
         String(length=32),
         nullable=False,
         default="open",
         server_default=text("'open'"),
     )
-    required_action: Mapped[Optional[str]] = mapped_column(String(length=64), nullable=True)
+    required_action: Mapped[Optional[str]] = mapped_column(
+        String(length=64), nullable=True
+    )
     rationale: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     metadata_json: Mapped[Optional[Any]] = mapped_column(JSONType, nullable=True)
 
-    analysis_run: Mapped[WhitepaperAnalysisRun] = relationship(back_populates="contradiction_events")
+    analysis_run: Mapped[WhitepaperAnalysisRun] = relationship(
+        back_populates="contradiction_events"
+    )
 
     __table_args__ = (
         Index("ix_whitepaper_contradiction_events_run_id", "analysis_run_id"),
@@ -2038,7 +2242,9 @@ class WhitepaperEngineeringTrigger(Base, TimestampMixin):
     __tablename__ = "whitepaper_engineering_triggers"
 
     id: Mapped[uuid.UUID] = mapped_column(GUID(), primary_key=True, default=uuid.uuid4)
-    trigger_id: Mapped[str] = mapped_column(String(length=64), nullable=False, unique=True)
+    trigger_id: Mapped[str] = mapped_column(
+        String(length=64), nullable=False, unique=True
+    )
     whitepaper_run_id: Mapped[str] = mapped_column(
         String(length=64), nullable=False, unique=True
     )
@@ -2053,11 +2259,15 @@ class WhitepaperEngineeringTrigger(Base, TimestampMixin):
         ForeignKey("whitepaper_viability_verdicts.id", ondelete="SET NULL"),
         nullable=True,
     )
-    hypothesis_id: Mapped[Optional[str]] = mapped_column(String(length=128), nullable=True)
+    hypothesis_id: Mapped[Optional[str]] = mapped_column(
+        String(length=128), nullable=True
+    )
     implementation_grade: Mapped[str] = mapped_column(String(length=32), nullable=False)
     decision: Mapped[str] = mapped_column(String(length=32), nullable=False)
     reason_codes_json: Mapped[Optional[Any]] = mapped_column(JSONType, nullable=True)
-    approval_token: Mapped[Optional[str]] = mapped_column(String(length=128), nullable=True)
+    approval_token: Mapped[Optional[str]] = mapped_column(
+        String(length=128), nullable=True
+    )
     dispatched_agentrun_name: Mapped[Optional[str]] = mapped_column(
         String(length=128), nullable=True
     )
@@ -2067,8 +2277,12 @@ class WhitepaperEngineeringTrigger(Base, TimestampMixin):
         default="manual",
         server_default=text("'manual'"),
     )
-    approval_source: Mapped[Optional[str]] = mapped_column(String(length=32), nullable=True)
-    approved_by: Mapped[Optional[str]] = mapped_column(String(length=128), nullable=True)
+    approval_source: Mapped[Optional[str]] = mapped_column(
+        String(length=32), nullable=True
+    )
+    approved_by: Mapped[Optional[str]] = mapped_column(
+        String(length=128), nullable=True
+    )
     approved_at: Mapped[Optional[datetime]] = mapped_column(
         DateTime(timezone=True), nullable=True
     )
@@ -2105,7 +2319,9 @@ class WhitepaperRolloutTransition(Base, CreatedAtMixin):
     __tablename__ = "whitepaper_rollout_transitions"
 
     id: Mapped[uuid.UUID] = mapped_column(GUID(), primary_key=True, default=uuid.uuid4)
-    transition_id: Mapped[str] = mapped_column(String(length=64), nullable=False, unique=True)
+    transition_id: Mapped[str] = mapped_column(
+        String(length=64), nullable=False, unique=True
+    )
     trigger_id: Mapped[uuid.UUID] = mapped_column(
         GUID(),
         ForeignKey("whitepaper_engineering_triggers.id", ondelete="CASCADE"),
@@ -2118,8 +2334,12 @@ class WhitepaperRolloutTransition(Base, CreatedAtMixin):
     status: Mapped[str] = mapped_column(String(length=32), nullable=False)
     gate_results_json: Mapped[Optional[Any]] = mapped_column(JSONType, nullable=True)
     reason_codes_json: Mapped[Optional[Any]] = mapped_column(JSONType, nullable=True)
-    blocking_gate: Mapped[Optional[str]] = mapped_column(String(length=64), nullable=True)
-    evidence_hash: Mapped[Optional[str]] = mapped_column(String(length=64), nullable=True)
+    blocking_gate: Mapped[Optional[str]] = mapped_column(
+        String(length=64), nullable=True
+    )
+    evidence_hash: Mapped[Optional[str]] = mapped_column(
+        String(length=64), nullable=True
+    )
 
     engineering_trigger: Mapped[WhitepaperEngineeringTrigger] = relationship(
         back_populates="rollout_transitions"
@@ -2130,6 +2350,122 @@ class WhitepaperRolloutTransition(Base, CreatedAtMixin):
         Index("ix_whitepaper_rollout_transitions_run_id", "whitepaper_run_id"),
         Index("ix_whitepaper_rollout_transitions_status", "status"),
         Index("ix_whitepaper_rollout_transitions_created_at", "created_at"),
+    )
+
+
+class AutoresearchEpoch(Base, TimestampMixin):
+    """Durable execution record for whitepaper autoresearch epochs."""
+
+    __tablename__ = "autoresearch_epochs"
+
+    id: Mapped[uuid.UUID] = mapped_column(GUID(), primary_key=True, default=uuid.uuid4)
+    epoch_id: Mapped[str] = mapped_column(
+        String(length=128), nullable=False, unique=True
+    )
+    status: Mapped[str] = mapped_column(String(length=32), nullable=False)
+    target_net_pnl_per_day: Mapped[Decimal] = mapped_column(
+        Numeric(20, 8), nullable=False
+    )
+    paper_run_ids_json: Mapped[Optional[Any]] = mapped_column(JSONType, nullable=True)
+    snapshot_manifest_json: Mapped[Optional[Any]] = mapped_column(
+        JSONType, nullable=True
+    )
+    runner_config_json: Mapped[Optional[Any]] = mapped_column(JSONType, nullable=True)
+    summary_json: Mapped[Optional[Any]] = mapped_column(JSONType, nullable=True)
+    started_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    completed_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    failure_reason: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+
+    __table_args__ = (
+        Index("ix_autoresearch_epochs_status", "status"),
+        Index("ix_autoresearch_epochs_completed_at", "completed_at"),
+    )
+
+
+class AutoresearchCandidateSpec(Base, TimestampMixin):
+    """Normalized candidate spec ledger for autoresearch epochs."""
+
+    __tablename__ = "autoresearch_candidate_specs"
+
+    id: Mapped[uuid.UUID] = mapped_column(GUID(), primary_key=True, default=uuid.uuid4)
+    candidate_spec_id: Mapped[str] = mapped_column(
+        String(length=128), nullable=False, unique=True
+    )
+    epoch_id: Mapped[str] = mapped_column(String(length=128), nullable=False)
+    hypothesis_id: Mapped[str] = mapped_column(String(length=128), nullable=False)
+    candidate_kind: Mapped[str] = mapped_column(String(length=32), nullable=False)
+    family_template_id: Mapped[str] = mapped_column(String(length=128), nullable=False)
+    payload_json: Mapped[Any] = mapped_column(JSONType, nullable=False)
+    payload_hash: Mapped[str] = mapped_column(String(length=64), nullable=False)
+    status: Mapped[str] = mapped_column(String(length=32), nullable=False)
+    blockers_json: Mapped[Optional[Any]] = mapped_column(JSONType, nullable=True)
+
+    __table_args__ = (
+        Index("ix_autoresearch_candidate_specs_epoch_id", "epoch_id"),
+        Index("ix_autoresearch_candidate_specs_hypothesis_id", "hypothesis_id"),
+        Index("ix_autoresearch_candidate_specs_family", "family_template_id"),
+        Index("ix_autoresearch_candidate_specs_status", "status"),
+    )
+
+
+class AutoresearchProposalScore(Base, TimestampMixin):
+    """MLX or fallback proposal score ledger for autoresearch candidate specs."""
+
+    __tablename__ = "autoresearch_proposal_scores"
+
+    id: Mapped[uuid.UUID] = mapped_column(GUID(), primary_key=True, default=uuid.uuid4)
+    epoch_id: Mapped[str] = mapped_column(String(length=128), nullable=False)
+    candidate_spec_id: Mapped[str] = mapped_column(String(length=128), nullable=False)
+    model_id: Mapped[str] = mapped_column(String(length=128), nullable=False)
+    backend: Mapped[str] = mapped_column(String(length=64), nullable=False)
+    proposal_score: Mapped[Decimal] = mapped_column(Numeric(20, 8), nullable=False)
+    rank: Mapped[int] = mapped_column(BigInteger(), nullable=False)
+    selection_reason: Mapped[str] = mapped_column(String(length=64), nullable=False)
+    feature_hash: Mapped[Optional[str]] = mapped_column(
+        String(length=64), nullable=True
+    )
+    payload_json: Mapped[Optional[Any]] = mapped_column(JSONType, nullable=True)
+
+    __table_args__ = (
+        Index("ix_autoresearch_proposal_scores_epoch_id", "epoch_id"),
+        Index("ix_autoresearch_proposal_scores_candidate_spec", "candidate_spec_id"),
+        Index("ix_autoresearch_proposal_scores_rank", "epoch_id", "rank"),
+        Index(
+            "uq_autoresearch_proposal_scores_epoch_candidate_model",
+            "epoch_id",
+            "candidate_spec_id",
+            "model_id",
+            unique=True,
+        ),
+    )
+
+
+class AutoresearchPortfolioCandidate(Base, TimestampMixin):
+    """Portfolio assembly ledger for autoresearch epochs."""
+
+    __tablename__ = "autoresearch_portfolio_candidates"
+
+    id: Mapped[uuid.UUID] = mapped_column(GUID(), primary_key=True, default=uuid.uuid4)
+    portfolio_candidate_id: Mapped[str] = mapped_column(
+        String(length=128), nullable=False, unique=True
+    )
+    epoch_id: Mapped[str] = mapped_column(String(length=128), nullable=False)
+    source_candidate_ids_json: Mapped[Any] = mapped_column(JSONType, nullable=False)
+    target_net_pnl_per_day: Mapped[Decimal] = mapped_column(
+        Numeric(20, 8), nullable=False
+    )
+    objective_scorecard_json: Mapped[Any] = mapped_column(JSONType, nullable=False)
+    optimizer_report_json: Mapped[Any] = mapped_column(JSONType, nullable=False)
+    payload_json: Mapped[Any] = mapped_column(JSONType, nullable=False)
+    status: Mapped[str] = mapped_column(String(length=32), nullable=False)
+
+    __table_args__ = (
+        Index("ix_autoresearch_portfolio_candidates_epoch_id", "epoch_id"),
+        Index("ix_autoresearch_portfolio_candidates_status", "status"),
     )
 
 
@@ -2187,13 +2523,27 @@ class ExecutionTCAMetric(Base, TimestampMixin):
     signed_qty: Mapped[Decimal] = mapped_column(
         Numeric(20, 8), nullable=False, default=Decimal("0"), server_default=text("0")
     )
-    slippage_bps: Mapped[Optional[Decimal]] = mapped_column(Numeric(20, 8), nullable=True)
-    shortfall_notional: Mapped[Optional[Decimal]] = mapped_column(Numeric(20, 8), nullable=True)
-    expected_shortfall_bps_p50: Mapped[Optional[Decimal]] = mapped_column(Numeric(20, 8), nullable=True)
-    expected_shortfall_bps_p95: Mapped[Optional[Decimal]] = mapped_column(Numeric(20, 8), nullable=True)
-    realized_shortfall_bps: Mapped[Optional[Decimal]] = mapped_column(Numeric(20, 8), nullable=True)
-    divergence_bps: Mapped[Optional[Decimal]] = mapped_column(Numeric(20, 8), nullable=True)
-    simulator_version: Mapped[Optional[str]] = mapped_column(String(length=64), nullable=True)
+    slippage_bps: Mapped[Optional[Decimal]] = mapped_column(
+        Numeric(20, 8), nullable=True
+    )
+    shortfall_notional: Mapped[Optional[Decimal]] = mapped_column(
+        Numeric(20, 8), nullable=True
+    )
+    expected_shortfall_bps_p50: Mapped[Optional[Decimal]] = mapped_column(
+        Numeric(20, 8), nullable=True
+    )
+    expected_shortfall_bps_p95: Mapped[Optional[Decimal]] = mapped_column(
+        Numeric(20, 8), nullable=True
+    )
+    realized_shortfall_bps: Mapped[Optional[Decimal]] = mapped_column(
+        Numeric(20, 8), nullable=True
+    )
+    divergence_bps: Mapped[Optional[Decimal]] = mapped_column(
+        Numeric(20, 8), nullable=True
+    )
+    simulator_version: Mapped[Optional[str]] = mapped_column(
+        String(length=64), nullable=True
+    )
     churn_qty: Mapped[Decimal] = mapped_column(
         Numeric(20, 8), nullable=False, default=Decimal("0"), server_default=text("0")
     )
@@ -2217,14 +2567,18 @@ class LeanBacktestRun(Base, TimestampMixin):
     __tablename__ = "lean_backtest_runs"
 
     id: Mapped[uuid.UUID] = mapped_column(GUID(), primary_key=True, default=uuid.uuid4)
-    backtest_id: Mapped[str] = mapped_column(String(length=64), nullable=False, unique=True)
+    backtest_id: Mapped[str] = mapped_column(
+        String(length=64), nullable=False, unique=True
+    )
     status: Mapped[str] = mapped_column(
         String(length=32),
         nullable=False,
         default="queued",
         server_default=text("'queued'"),
     )
-    requested_by: Mapped[Optional[str]] = mapped_column(String(length=128), nullable=True)
+    requested_by: Mapped[Optional[str]] = mapped_column(
+        String(length=128), nullable=True
+    )
     lane: Mapped[str] = mapped_column(
         String(length=32),
         nullable=False,
@@ -2234,11 +2588,21 @@ class LeanBacktestRun(Base, TimestampMixin):
     config_json: Mapped[Any] = mapped_column(JSONType, nullable=False)
     result_json: Mapped[Optional[Any]] = mapped_column(JSONType, nullable=True)
     artifacts_json: Mapped[Optional[Any]] = mapped_column(JSONType, nullable=True)
-    reproducibility_hash: Mapped[Optional[str]] = mapped_column(String(length=128), nullable=True)
-    replay_hash: Mapped[Optional[str]] = mapped_column(String(length=128), nullable=True)
-    deterministic_replay_passed: Mapped[Optional[bool]] = mapped_column(Boolean, nullable=True)
-    failure_taxonomy: Mapped[Optional[str]] = mapped_column(String(length=128), nullable=True)
-    completed_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
+    reproducibility_hash: Mapped[Optional[str]] = mapped_column(
+        String(length=128), nullable=True
+    )
+    replay_hash: Mapped[Optional[str]] = mapped_column(
+        String(length=128), nullable=True
+    )
+    deterministic_replay_passed: Mapped[Optional[bool]] = mapped_column(
+        Boolean, nullable=True
+    )
+    failure_taxonomy: Mapped[Optional[str]] = mapped_column(
+        String(length=128), nullable=True
+    )
+    completed_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
 
     __table_args__ = (
         Index("ix_lean_backtest_runs_status", "status"),
@@ -2253,7 +2617,9 @@ class LeanExecutionShadowEvent(Base, CreatedAtMixin):
     __tablename__ = "lean_execution_shadow_events"
 
     id: Mapped[uuid.UUID] = mapped_column(GUID(), primary_key=True, default=uuid.uuid4)
-    correlation_id: Mapped[Optional[str]] = mapped_column(String(length=64), nullable=True)
+    correlation_id: Mapped[Optional[str]] = mapped_column(
+        String(length=64), nullable=True
+    )
     trade_decision_id: Mapped[Optional[uuid.UUID]] = mapped_column(
         GUID(), ForeignKey("trade_decisions.id", ondelete="SET NULL"), nullable=True
     )
@@ -2263,17 +2629,27 @@ class LeanExecutionShadowEvent(Base, CreatedAtMixin):
     symbol: Mapped[str] = mapped_column(String(length=32), nullable=False)
     side: Mapped[str] = mapped_column(String(length=8), nullable=False)
     qty: Mapped[Decimal] = mapped_column(Numeric(20, 8), nullable=False)
-    intent_notional: Mapped[Optional[Decimal]] = mapped_column(Numeric(20, 8), nullable=True)
-    simulated_fill_price: Mapped[Optional[Decimal]] = mapped_column(Numeric(20, 8), nullable=True)
-    simulated_slippage_bps: Mapped[Optional[Decimal]] = mapped_column(Numeric(20, 8), nullable=True)
-    parity_delta_bps: Mapped[Optional[Decimal]] = mapped_column(Numeric(20, 8), nullable=True)
+    intent_notional: Mapped[Optional[Decimal]] = mapped_column(
+        Numeric(20, 8), nullable=True
+    )
+    simulated_fill_price: Mapped[Optional[Decimal]] = mapped_column(
+        Numeric(20, 8), nullable=True
+    )
+    simulated_slippage_bps: Mapped[Optional[Decimal]] = mapped_column(
+        Numeric(20, 8), nullable=True
+    )
+    parity_delta_bps: Mapped[Optional[Decimal]] = mapped_column(
+        Numeric(20, 8), nullable=True
+    )
     parity_status: Mapped[str] = mapped_column(
         String(length=64),
         nullable=False,
         default="unknown",
         server_default=text("'unknown'"),
     )
-    failure_taxonomy: Mapped[Optional[str]] = mapped_column(String(length=128), nullable=True)
+    failure_taxonomy: Mapped[Optional[str]] = mapped_column(
+        String(length=128), nullable=True
+    )
     simulation_json: Mapped[Optional[Any]] = mapped_column(JSONType, nullable=True)
 
     __table_args__ = (
@@ -2290,7 +2666,9 @@ class LeanCanaryIncident(Base, CreatedAtMixin):
     __tablename__ = "lean_canary_incidents"
 
     id: Mapped[uuid.UUID] = mapped_column(GUID(), primary_key=True, default=uuid.uuid4)
-    incident_key: Mapped[str] = mapped_column(String(length=96), nullable=False, unique=True)
+    incident_key: Mapped[str] = mapped_column(
+        String(length=96), nullable=False, unique=True
+    )
     breach_type: Mapped[str] = mapped_column(String(length=64), nullable=False)
     severity: Mapped[str] = mapped_column(
         String(length=16),
@@ -2306,7 +2684,9 @@ class LeanCanaryIncident(Base, CreatedAtMixin):
     )
     symbols: Mapped[Optional[Any]] = mapped_column(JSONType, nullable=True)
     evidence_json: Mapped[Optional[Any]] = mapped_column(JSONType, nullable=True)
-    resolved_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
+    resolved_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
 
     __table_args__ = (
         Index("ix_lean_canary_incidents_breach_type", "breach_type"),
@@ -2393,11 +2773,19 @@ class SimulationRuntimeContext(Base, TimestampMixin):
     account_label: Mapped[str] = mapped_column(String(length=64), primary_key=True)
     run_id: Mapped[str] = mapped_column(String(length=128), nullable=False)
     dataset_id: Mapped[Optional[str]] = mapped_column(String(length=128), nullable=True)
-    window_start: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
-    window_end: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
+    window_start: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    window_end: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
     cache_key: Mapped[Optional[str]] = mapped_column(String(length=128), nullable=True)
-    cache_artifact_path: Mapped[Optional[str]] = mapped_column(String(length=512), nullable=True)
-    cache_manifest_path: Mapped[Optional[str]] = mapped_column(String(length=512), nullable=True)
+    cache_artifact_path: Mapped[Optional[str]] = mapped_column(
+        String(length=512), nullable=True
+    )
+    cache_manifest_path: Mapped[Optional[str]] = mapped_column(
+        String(length=512), nullable=True
+    )
     warm_lane_enabled: Mapped[bool] = mapped_column(
         Boolean,
         nullable=False,
@@ -2431,17 +2819,27 @@ class SimulationRunProgress(Base, TimestampMixin):
         default="equity",
         server_default=text("'equity'"),
     )
-    workflow_name: Mapped[Optional[str]] = mapped_column(String(length=128), nullable=True)
+    workflow_name: Mapped[Optional[str]] = mapped_column(
+        String(length=128), nullable=True
+    )
     status: Mapped[str] = mapped_column(
         String(length=32),
         nullable=False,
         default="pending",
         server_default=text("'pending'"),
     )
-    last_source_ts: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
-    last_signal_ts: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
-    last_price_ts: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
-    cursor_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
+    last_source_ts: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    last_signal_ts: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    last_price_ts: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    cursor_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
     records_dumped: Mapped[int] = mapped_column(
         BigInteger(), nullable=False, default=0, server_default=text("0")
     )
@@ -2460,15 +2858,21 @@ class SimulationRunProgress(Base, TimestampMixin):
     execution_order_events: Mapped[int] = mapped_column(
         BigInteger(), nullable=False, default=0, server_default=text("0")
     )
-    strategy_type: Mapped[Optional[str]] = mapped_column(String(length=128), nullable=True)
+    strategy_type: Mapped[Optional[str]] = mapped_column(
+        String(length=128), nullable=True
+    )
     legacy_path_count: Mapped[int] = mapped_column(
         BigInteger(), nullable=False, default=0, server_default=text("0")
     )
     fallback_count: Mapped[int] = mapped_column(
         BigInteger(), nullable=False, default=0, server_default=text("0")
     )
-    terminal_state: Mapped[Optional[str]] = mapped_column(String(length=64), nullable=True)
-    last_error_code: Mapped[Optional[str]] = mapped_column(String(length=128), nullable=True)
+    terminal_state: Mapped[Optional[str]] = mapped_column(
+        String(length=64), nullable=True
+    )
+    last_error_code: Mapped[Optional[str]] = mapped_column(
+        String(length=128), nullable=True
+    )
     last_error_message: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     payload_json: Mapped[Any] = mapped_column(
         JSONType,
@@ -2490,7 +2894,9 @@ class LLMDSPyWorkflowArtifact(Base, TimestampMixin):
     __tablename__ = "llm_dspy_workflow_artifacts"
 
     id: Mapped[uuid.UUID] = mapped_column(GUID(), primary_key=True, default=uuid.uuid4)
-    run_key: Mapped[str] = mapped_column(String(length=128), nullable=False, unique=True)
+    run_key: Mapped[str] = mapped_column(
+        String(length=128), nullable=False, unique=True
+    )
     lane: Mapped[str] = mapped_column(String(length=32), nullable=False)
     status: Mapped[str] = mapped_column(
         String(length=32),
@@ -2501,14 +2907,22 @@ class LLMDSPyWorkflowArtifact(Base, TimestampMixin):
     implementation_spec_ref: Mapped[str] = mapped_column(
         String(length=128), nullable=False
     )
-    program_name: Mapped[Optional[str]] = mapped_column(String(length=128), nullable=True)
+    program_name: Mapped[Optional[str]] = mapped_column(
+        String(length=128), nullable=True
+    )
     signature_version: Mapped[Optional[str]] = mapped_column(
         String(length=64), nullable=True
     )
     optimizer: Mapped[Optional[str]] = mapped_column(String(length=64), nullable=True)
-    artifact_uri: Mapped[Optional[str]] = mapped_column(String(length=1024), nullable=True)
-    artifact_hash: Mapped[Optional[str]] = mapped_column(String(length=64), nullable=True)
-    dataset_hash: Mapped[Optional[str]] = mapped_column(String(length=64), nullable=True)
+    artifact_uri: Mapped[Optional[str]] = mapped_column(
+        String(length=1024), nullable=True
+    )
+    artifact_hash: Mapped[Optional[str]] = mapped_column(
+        String(length=64), nullable=True
+    )
+    dataset_hash: Mapped[Optional[str]] = mapped_column(
+        String(length=64), nullable=True
+    )
     compiled_prompt_hash: Mapped[Optional[str]] = mapped_column(
         String(length=64), nullable=True
     )
@@ -2528,13 +2942,19 @@ class LLMDSPyWorkflowArtifact(Base, TimestampMixin):
     idempotency_key: Mapped[Optional[str]] = mapped_column(
         String(length=128), nullable=True
     )
-    agentrun_name: Mapped[Optional[str]] = mapped_column(String(length=128), nullable=True)
+    agentrun_name: Mapped[Optional[str]] = mapped_column(
+        String(length=128), nullable=True
+    )
     agentrun_namespace: Mapped[Optional[str]] = mapped_column(
         String(length=64), nullable=True
     )
-    agentrun_uid: Mapped[Optional[str]] = mapped_column(String(length=128), nullable=True)
+    agentrun_uid: Mapped[Optional[str]] = mapped_column(
+        String(length=128), nullable=True
+    )
     request_payload_json: Mapped[Optional[Any]] = mapped_column(JSONType, nullable=True)
-    response_payload_json: Mapped[Optional[Any]] = mapped_column(JSONType, nullable=True)
+    response_payload_json: Mapped[Optional[Any]] = mapped_column(
+        JSONType, nullable=True
+    )
     metadata_json: Mapped[Optional[Any]] = mapped_column(JSONType, nullable=True)
 
     __table_args__ = (
@@ -2591,6 +3011,10 @@ class LLMDecisionReview(Base, CreatedAtMixin):
 
 
 __all__ = [
+    "AutoresearchCandidateSpec",
+    "AutoresearchEpoch",
+    "AutoresearchPortfolioCandidate",
+    "AutoresearchProposalScore",
     "Strategy",
     "TradeDecision",
     "Execution",

--- a/services/torghut/app/trading/autoresearch_routes.py
+++ b/services/torghut/app/trading/autoresearch_routes.py
@@ -56,6 +56,19 @@ def _best_portfolio_dashboard_fields(
     }
 
 
+def _summary_dashboard_fields(summary: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "claim_count": summary.get("claim_count"),
+        "hypothesis_count": summary.get("hypothesis_count"),
+        "candidate_spec_count": summary.get("candidate_spec_count"),
+        "replayed_candidate_count": summary.get("evidence_bundle_count"),
+        "portfolio_candidate_count": summary.get("portfolio_candidate_count"),
+        "mlx_rank_bucket_lift": summary.get("mlx_rank_bucket_lift"),
+        "false_positive_table": summary.get("false_positive_table", []),
+        "best_false_negative_table": summary.get("best_false_negative_table", []),
+    }
+
+
 @router.get("/epochs")
 def trading_autoresearch_epochs(
     status: str | None = Query(default=None),
@@ -92,16 +105,6 @@ def trading_autoresearch_epochs(
                 "target_net_pnl_per_day": str(row.target_net_pnl_per_day),
                 "paper_run_ids": row.paper_run_ids_json or [],
                 "paper_count": len(row.paper_run_ids_json or []),
-                "claim_count": summary.get("claim_count"),
-                "hypothesis_count": summary.get("hypothesis_count"),
-                "candidate_spec_count": summary.get("candidate_spec_count"),
-                "replayed_candidate_count": summary.get("evidence_bundle_count"),
-                "portfolio_candidate_count": summary.get("portfolio_candidate_count"),
-                "mlx_rank_bucket_lift": summary.get("mlx_rank_bucket_lift"),
-                "false_positive_table": summary.get("false_positive_table", []),
-                "best_false_negative_table": summary.get(
-                    "best_false_negative_table", []
-                ),
                 "started_at": row.started_at.isoformat() if row.started_at else None,
                 "completed_at": row.completed_at.isoformat()
                 if row.completed_at
@@ -109,6 +112,7 @@ def trading_autoresearch_epochs(
                 "failure_reason": row.failure_reason,
                 "source_count": snapshot.get("source_count"),
                 "summary": summary,
+                **_summary_dashboard_fields(summary),
                 **_best_portfolio_dashboard_fields(portfolio),
             }
         )
@@ -150,6 +154,11 @@ def trading_autoresearch_epoch(
             .order_by(AutoresearchPortfolioCandidate.created_at.asc())
         ).scalars()
     )
+    summary = _json_object(epoch.summary_json)
+    dashboard = {
+        **_summary_dashboard_fields(summary),
+        **_best_portfolio_dashboard_fields(portfolios[0] if portfolios else None),
+    }
     return {
         "epoch": {
             "epoch_id": epoch.epoch_id,
@@ -158,16 +167,14 @@ def trading_autoresearch_epoch(
             "paper_run_ids": epoch.paper_run_ids_json or [],
             "snapshot_manifest": epoch.snapshot_manifest_json or {},
             "runner_config": epoch.runner_config_json or {},
-            "summary": epoch.summary_json or {},
+            "summary": summary,
             "started_at": epoch.started_at.isoformat() if epoch.started_at else None,
             "completed_at": epoch.completed_at.isoformat()
             if epoch.completed_at
             else None,
             "failure_reason": epoch.failure_reason,
         },
-        "dashboard": _best_portfolio_dashboard_fields(
-            portfolios[0] if portfolios else None
-        ),
+        "dashboard": dashboard,
         "candidate_specs": [
             {
                 "candidate_spec_id": row.candidate_spec_id,

--- a/services/torghut/app/trading/autoresearch_routes.py
+++ b/services/torghut/app/trading/autoresearch_routes.py
@@ -1,0 +1,207 @@
+"""FastAPI routes for persisted whitepaper autoresearch epochs."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, cast
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.db import get_session
+from app.models import (
+    AutoresearchCandidateSpec,
+    AutoresearchEpoch,
+    AutoresearchPortfolioCandidate,
+    AutoresearchProposalScore,
+)
+
+
+router = APIRouter(prefix="/trading/autoresearch", tags=["trading-autoresearch"])
+
+
+def _json_object(value: Any) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        return {}
+    return {str(key): item for key, item in cast(Mapping[Any, Any], value).items()}
+
+
+def _json_list(value: Any) -> list[Any]:
+    return list(cast(list[Any], value)) if isinstance(value, list) else []
+
+
+def _best_portfolio_dashboard_fields(
+    portfolio: AutoresearchPortfolioCandidate | None,
+) -> dict[str, Any]:
+    if portfolio is None:
+        return {
+            "best_portfolio_net_pnl_per_day": None,
+            "best_portfolio_active_day_ratio": None,
+            "best_portfolio_positive_day_ratio": None,
+            "blocked_promotion_reasons": [],
+            "best_portfolio_sleeves": [],
+        }
+    scorecard = _json_object(portfolio.objective_scorecard_json)
+    payload = _json_object(portfolio.payload_json)
+    readiness = payload.get("promotion_readiness")
+    readiness_payload = _json_object(readiness)
+    blockers = readiness_payload.get("blockers")
+    sleeve_payload = payload.get("sleeves")
+    return {
+        "best_portfolio_net_pnl_per_day": scorecard.get("net_pnl_per_day"),
+        "best_portfolio_active_day_ratio": scorecard.get("active_day_ratio"),
+        "best_portfolio_positive_day_ratio": scorecard.get("positive_day_ratio"),
+        "blocked_promotion_reasons": _json_list(blockers),
+        "best_portfolio_sleeves": _json_list(sleeve_payload),
+    }
+
+
+@router.get("/epochs")
+def trading_autoresearch_epochs(
+    status: str | None = Query(default=None),
+    limit: int = Query(default=25, ge=1, le=100),
+    session: Session = Depends(get_session),
+) -> dict[str, object]:
+    """Return persisted whitepaper autoresearch epochs with dashboard fields."""
+
+    stmt = select(AutoresearchEpoch)
+    if status:
+        stmt = stmt.where(AutoresearchEpoch.status == status)
+    rows = list(
+        session.execute(
+            stmt.order_by(AutoresearchEpoch.created_at.desc()).limit(limit)
+        ).scalars()
+    )
+    items: list[dict[str, object]] = []
+    for row in rows:
+        portfolio = (
+            session.execute(
+                select(AutoresearchPortfolioCandidate)
+                .where(AutoresearchPortfolioCandidate.epoch_id == row.epoch_id)
+                .order_by(AutoresearchPortfolioCandidate.created_at.asc())
+            )
+            .scalars()
+            .first()
+        )
+        summary = _json_object(row.summary_json)
+        snapshot = _json_object(row.snapshot_manifest_json)
+        items.append(
+            {
+                "epoch_id": row.epoch_id,
+                "status": row.status,
+                "target_net_pnl_per_day": str(row.target_net_pnl_per_day),
+                "paper_run_ids": row.paper_run_ids_json or [],
+                "paper_count": len(row.paper_run_ids_json or []),
+                "claim_count": summary.get("claim_count"),
+                "hypothesis_count": summary.get("hypothesis_count"),
+                "candidate_spec_count": summary.get("candidate_spec_count"),
+                "replayed_candidate_count": summary.get("evidence_bundle_count"),
+                "portfolio_candidate_count": summary.get("portfolio_candidate_count"),
+                "mlx_rank_bucket_lift": summary.get("mlx_rank_bucket_lift"),
+                "false_positive_table": summary.get("false_positive_table", []),
+                "best_false_negative_table": summary.get(
+                    "best_false_negative_table", []
+                ),
+                "started_at": row.started_at.isoformat() if row.started_at else None,
+                "completed_at": row.completed_at.isoformat()
+                if row.completed_at
+                else None,
+                "failure_reason": row.failure_reason,
+                "source_count": snapshot.get("source_count"),
+                "summary": summary,
+                **_best_portfolio_dashboard_fields(portfolio),
+            }
+        )
+    return {"count": len(items), "epochs": items}
+
+
+@router.get("/epochs/{epoch_id}")
+def trading_autoresearch_epoch(
+    epoch_id: str,
+    session: Session = Depends(get_session),
+) -> dict[str, object]:
+    """Return one persisted whitepaper autoresearch epoch with child ledgers."""
+
+    epoch = session.execute(
+        select(AutoresearchEpoch).where(AutoresearchEpoch.epoch_id == epoch_id)
+    ).scalar_one_or_none()
+    if epoch is None:
+        raise HTTPException(
+            status_code=404, detail=f"autoresearch_epoch_not_found:{epoch_id}"
+        )
+    specs = list(
+        session.execute(
+            select(AutoresearchCandidateSpec)
+            .where(AutoresearchCandidateSpec.epoch_id == epoch_id)
+            .order_by(AutoresearchCandidateSpec.created_at.asc())
+        ).scalars()
+    )
+    proposals = list(
+        session.execute(
+            select(AutoresearchProposalScore)
+            .where(AutoresearchProposalScore.epoch_id == epoch_id)
+            .order_by(AutoresearchProposalScore.rank.asc())
+        ).scalars()
+    )
+    portfolios = list(
+        session.execute(
+            select(AutoresearchPortfolioCandidate)
+            .where(AutoresearchPortfolioCandidate.epoch_id == epoch_id)
+            .order_by(AutoresearchPortfolioCandidate.created_at.asc())
+        ).scalars()
+    )
+    return {
+        "epoch": {
+            "epoch_id": epoch.epoch_id,
+            "status": epoch.status,
+            "target_net_pnl_per_day": str(epoch.target_net_pnl_per_day),
+            "paper_run_ids": epoch.paper_run_ids_json or [],
+            "snapshot_manifest": epoch.snapshot_manifest_json or {},
+            "runner_config": epoch.runner_config_json or {},
+            "summary": epoch.summary_json or {},
+            "started_at": epoch.started_at.isoformat() if epoch.started_at else None,
+            "completed_at": epoch.completed_at.isoformat()
+            if epoch.completed_at
+            else None,
+            "failure_reason": epoch.failure_reason,
+        },
+        "dashboard": _best_portfolio_dashboard_fields(
+            portfolios[0] if portfolios else None
+        ),
+        "candidate_specs": [
+            {
+                "candidate_spec_id": row.candidate_spec_id,
+                "hypothesis_id": row.hypothesis_id,
+                "candidate_kind": row.candidate_kind,
+                "family_template_id": row.family_template_id,
+                "status": row.status,
+                "blockers": row.blockers_json or [],
+                "payload": row.payload_json,
+            }
+            for row in specs
+        ],
+        "proposal_scores": [
+            {
+                "candidate_spec_id": row.candidate_spec_id,
+                "model_id": row.model_id,
+                "backend": row.backend,
+                "proposal_score": str(row.proposal_score),
+                "rank": row.rank,
+                "selection_reason": row.selection_reason,
+                "feature_hash": row.feature_hash,
+            }
+            for row in proposals
+        ],
+        "portfolio_candidates": [
+            {
+                "portfolio_candidate_id": row.portfolio_candidate_id,
+                "status": row.status,
+                "target_net_pnl_per_day": str(row.target_net_pnl_per_day),
+                "source_candidate_ids": row.source_candidate_ids_json,
+                "objective_scorecard": row.objective_scorecard_json,
+                "optimizer_report": row.optimizer_report_json,
+                "payload": row.payload_json,
+            }
+            for row in portfolios
+        ],
+    }

--- a/services/torghut/app/trading/discovery/candidate_specs.py
+++ b/services/torghut/app/trading/discovery/candidate_specs.py
@@ -1,0 +1,261 @@
+"""Candidate spec compilation from typed whitepaper hypotheses."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Any, Literal, Mapping, Sequence, cast
+
+from app.trading.discovery.hypothesis_cards import HypothesisCard
+
+
+CANDIDATE_SPEC_SCHEMA_VERSION = "torghut.candidate-spec.v1"
+
+_FAMILY_RUNTIME = {
+    "breakout_reclaim_v2": (
+        "breakout_continuation_consistent",
+        "breakout-continuation-long-v1",
+    ),
+    "washout_rebound_v2": ("washout_rebound_consistent", "washout-rebound-long-v1"),
+    "momentum_pullback_v1": (
+        "momentum_pullback_consistent",
+        "momentum-pullback-long-v1",
+    ),
+    "mean_reversion_rebound_v1": (
+        "mean_reversion_rebound_consistent",
+        "mean-reversion-rebound-long-v1",
+    ),
+    "microbar_cross_sectional_pairs_v1": (
+        "microbar_cross_sectional_pairs",
+        "microbar-cross-sectional-pairs-v1",
+    ),
+    "microstructure_continuation_matched_filter_v1": (
+        "microstructure_continuation_matched_filter",
+        "microstructure-continuation-matched-filter-v1",
+    ),
+    "intraday_tsmom_v2": ("intraday_tsmom_consistent", "intraday-tsmom-v2"),
+}
+
+
+def _stable_hash(payload: Mapping[str, Any]) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _string(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _mapping(value: Any) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        return {}
+    return {str(key): item for key, item in cast(Mapping[Any, Any], value).items()}
+
+
+def _family_for_hypothesis(card: HypothesisCard) -> str:
+    haystack = " ".join(
+        [
+            card.mechanism,
+            " ".join(card.required_features),
+            " ".join(card.entry_motifs),
+            " ".join(card.source_claim_ids),
+        ]
+    ).lower()
+    if any(
+        token in haystack
+        for token in (
+            "cluster",
+            "order flow",
+            "order_flow",
+            "trade-flow",
+            "lob",
+            "microbar",
+        )
+    ):
+        return "microbar_cross_sectional_pairs_v1"
+    if any(
+        token in haystack
+        for token in ("matched-filter", "matched_filter", "normalization")
+    ):
+        return "microstructure_continuation_matched_filter_v1"
+    if any(
+        token in haystack
+        for token in ("washout", "reversal", "rebound", "mean reversion")
+    ):
+        return "washout_rebound_v2"
+    if any(token in haystack for token in ("momentum", "trend", "pullback")):
+        return "momentum_pullback_v1"
+    if "breakout" in haystack or "continuation" in haystack:
+        return "breakout_reclaim_v2"
+    return "microbar_cross_sectional_pairs_v1"
+
+
+@dataclass(frozen=True)
+class CandidateSpec:
+    schema_version: Literal["torghut.candidate-spec.v1"]
+    candidate_spec_id: str
+    hypothesis_id: str
+    family_template_id: str
+    candidate_kind: Literal[
+        "family", "sleeve", "portfolio", "algorithm", "configuration"
+    ]
+    runtime_family: str
+    runtime_strategy_name: str
+    feature_contract: Mapping[str, Any]
+    parameter_space: Mapping[str, Any]
+    strategy_overrides: Mapping[str, Any]
+    objective: Mapping[str, Any]
+    hard_vetoes: Mapping[str, Any]
+    expected_failure_modes: tuple[str, ...]
+    promotion_contract: Mapping[str, Any]
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "candidate_spec_id": self.candidate_spec_id,
+            "hypothesis_id": self.hypothesis_id,
+            "family_template_id": self.family_template_id,
+            "candidate_kind": self.candidate_kind,
+            "runtime_family": self.runtime_family,
+            "runtime_strategy_name": self.runtime_strategy_name,
+            "feature_contract": dict(self.feature_contract),
+            "parameter_space": dict(self.parameter_space),
+            "strategy_overrides": dict(self.strategy_overrides),
+            "objective": dict(self.objective),
+            "hard_vetoes": dict(self.hard_vetoes),
+            "expected_failure_modes": list(self.expected_failure_modes),
+            "promotion_contract": dict(self.promotion_contract),
+        }
+
+    def to_vnext_experiment_payload(
+        self, *, experiment_id: str | None = None
+    ) -> dict[str, Any]:
+        return {
+            "experiment_id": experiment_id or f"{self.candidate_spec_id}-exp",
+            "family_template_id": self.family_template_id,
+            "hypothesis": self.feature_contract.get("mechanism"),
+            "paper_claim_links": list(
+                cast(Sequence[str], self.feature_contract.get("source_claim_ids") or [])
+            ),
+            "dataset_snapshot_policy": {
+                "source": "historical_market_replay",
+                "window_size": "PT1S",
+            },
+            "template_overrides": dict(self.strategy_overrides),
+            "feature_variants": list(
+                cast(
+                    Sequence[str],
+                    self.feature_contract.get("normalization_candidates") or [],
+                )
+            ),
+            "veto_controller_variants": [],
+            "selection_objectives": dict(self.objective),
+            "hard_vetoes": dict(self.hard_vetoes),
+            "expected_failure_modes": list(self.expected_failure_modes),
+            "promotion_contract": dict(self.promotion_contract),
+            "candidate_spec": self.to_payload(),
+        }
+
+
+def candidate_spec_id_for_payload(payload: Mapping[str, Any]) -> str:
+    return f"spec-{_stable_hash(payload)[:24]}"
+
+
+def compile_candidate_specs(
+    *,
+    hypothesis_cards: Sequence[HypothesisCard],
+    target_net_pnl_per_day: Decimal = Decimal("500"),
+) -> list[CandidateSpec]:
+    specs: list[CandidateSpec] = []
+    for card in hypothesis_cards:
+        family_template_id = _family_for_hypothesis(card)
+        runtime_family, runtime_strategy_name = _FAMILY_RUNTIME[family_template_id]
+        feature_contract = {
+            "source_run_id": card.source_run_id,
+            "source_claim_ids": list(card.source_claim_ids),
+            "mechanism": card.mechanism,
+            "required_features": list(card.required_features),
+            "entry_motifs": list(card.entry_motifs),
+            "exit_motifs": list(card.exit_motifs),
+            "expected_regimes": list(card.expected_regimes),
+            "normalization_candidates": ["price_scaled", "trading_value_scaled"],
+        }
+        objective = {
+            "target_net_pnl_per_day": str(target_net_pnl_per_day),
+            "require_positive_day_ratio": "0.60",
+        }
+        hard_vetoes = {
+            "required_min_active_day_ratio": "0.90",
+            "required_min_daily_notional": "300000",
+            "required_max_best_day_share": "0.25",
+            "required_max_worst_day_loss": "350",
+            "required_max_drawdown": "900",
+            "required_min_regime_slice_pass_rate": "0.45",
+        }
+        strategy_overrides: dict[str, Any] = {
+            "max_notional_per_trade": "50000",
+        }
+        parameter_space = {
+            "mode": "bounded_grid",
+            "source": "whitepaper_autoresearch",
+        }
+        promotion_contract = {
+            "source": "whitepaper_autoresearch_profit_target",
+            "target_net_pnl_per_day": str(target_net_pnl_per_day),
+            "requires_scheduler_v3_parity_replay": True,
+            "requires_scheduler_v3_approval_replay": True,
+            "requires_shadow_validation": True,
+            "promotion_policy": "research_only",
+        }
+        base_payload = {
+            "hypothesis_id": card.hypothesis_id,
+            "family_template_id": family_template_id,
+            "feature_contract": feature_contract,
+            "objective": objective,
+        }
+        specs.append(
+            CandidateSpec(
+                schema_version=CANDIDATE_SPEC_SCHEMA_VERSION,
+                candidate_spec_id=candidate_spec_id_for_payload(base_payload),
+                hypothesis_id=card.hypothesis_id,
+                family_template_id=family_template_id,
+                candidate_kind="sleeve",
+                runtime_family=runtime_family,
+                runtime_strategy_name=runtime_strategy_name,
+                feature_contract=feature_contract,
+                parameter_space=parameter_space,
+                strategy_overrides=strategy_overrides,
+                objective=objective,
+                hard_vetoes=hard_vetoes,
+                expected_failure_modes=card.failure_modes,
+                promotion_contract=promotion_contract,
+            )
+        )
+    return specs
+
+
+def candidate_spec_from_payload(payload: Mapping[str, Any]) -> CandidateSpec:
+    schema_version = _string(payload.get("schema_version"))
+    if schema_version != CANDIDATE_SPEC_SCHEMA_VERSION:
+        raise ValueError(f"candidate_spec_schema_invalid:{schema_version}")
+    return CandidateSpec(
+        schema_version=CANDIDATE_SPEC_SCHEMA_VERSION,
+        candidate_spec_id=_string(payload.get("candidate_spec_id")),
+        hypothesis_id=_string(payload.get("hypothesis_id")),
+        family_template_id=_string(payload.get("family_template_id")),
+        candidate_kind=cast(Any, _string(payload.get("candidate_kind")) or "sleeve"),
+        runtime_family=_string(payload.get("runtime_family")),
+        runtime_strategy_name=_string(payload.get("runtime_strategy_name")),
+        feature_contract=_mapping(payload.get("feature_contract")),
+        parameter_space=_mapping(payload.get("parameter_space")),
+        strategy_overrides=_mapping(payload.get("strategy_overrides")),
+        objective=_mapping(payload.get("objective")),
+        hard_vetoes=_mapping(payload.get("hard_vetoes")),
+        expected_failure_modes=tuple(
+            str(item)
+            for item in cast(Sequence[Any], payload.get("expected_failure_modes") or [])
+        ),
+        promotion_contract=_mapping(payload.get("promotion_contract")),
+    )

--- a/services/torghut/app/trading/discovery/evidence_bundles.py
+++ b/services/torghut/app/trading/discovery/evidence_bundles.py
@@ -9,6 +9,7 @@ from typing import Any, Literal, Mapping, Sequence, cast
 
 
 EVIDENCE_BUNDLE_SCHEMA_VERSION = "torghut.candidate-evidence-bundle.v1"
+VALID_COST_CALIBRATION_STATUSES = frozenset({"calibrated", "provisional"})
 
 
 def _stable_hash(payload: Mapping[str, Any]) -> str:
@@ -168,3 +169,38 @@ def evidence_bundle_from_payload(payload: Mapping[str, Any]) -> CandidateEvidenc
         null_comparator=_mapping(payload.get("null_comparator")),
         promotion_readiness=_mapping(payload.get("promotion_readiness")),
     )
+
+
+def evidence_bundle_blockers(bundle: CandidateEvidenceBundle) -> tuple[str, ...]:
+    blockers: list[str] = []
+    if not _string(bundle.dataset_snapshot_id):
+        blockers.append("dataset_snapshot_missing")
+    if not bundle.replay_artifact_refs or not any(
+        _string(item) for item in bundle.replay_artifact_refs
+    ):
+        blockers.append("replay_artifact_missing")
+
+    cost_status = _string(bundle.cost_calibration.get("status")).lower()
+    cost_source = _string(bundle.cost_calibration.get("source"))
+    if not bundle.cost_calibration:
+        blockers.append("cost_calibration_missing")
+    elif cost_status not in VALID_COST_CALIBRATION_STATUSES:
+        blockers.append("cost_calibration_status_invalid")
+    elif not cost_source:
+        blockers.append("cost_calibration_source_missing")
+
+    scorecard = bundle.objective_scorecard
+    if bool(scorecard.get("stale_tape")) or bool(scorecard.get("stale_override_used")):
+        blockers.append("stale_tape")
+    freshness = _string(
+        scorecard.get("dataset_freshness_status")
+        or scorecard.get("tape_freshness_status")
+        or scorecard.get("freshness_status")
+    ).lower()
+    if freshness in {"stale", "expired", "not_fresh"}:
+        blockers.append("stale_tape")
+    return tuple(dict.fromkeys(blockers))
+
+
+def evidence_bundle_is_valid(bundle: CandidateEvidenceBundle) -> bool:
+    return not evidence_bundle_blockers(bundle)

--- a/services/torghut/app/trading/discovery/evidence_bundles.py
+++ b/services/torghut/app/trading/discovery/evidence_bundles.py
@@ -1,0 +1,170 @@
+"""Canonical evidence bundles for autoresearch candidates."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any, Literal, Mapping, Sequence, cast
+
+
+EVIDENCE_BUNDLE_SCHEMA_VERSION = "torghut.candidate-evidence-bundle.v1"
+
+
+def _stable_hash(payload: Mapping[str, Any]) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _mapping(value: Any) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        return {}
+    return {str(key): item for key, item in cast(Mapping[Any, Any], value).items()}
+
+
+def _string(value: Any) -> str:
+    return str(value or "").strip()
+
+
+@dataclass(frozen=True)
+class CandidateEvidenceBundle:
+    schema_version: Literal["torghut.candidate-evidence-bundle.v1"]
+    evidence_bundle_id: str
+    candidate_id: str
+    candidate_spec_id: str
+    dataset_snapshot_id: str
+    feature_spec_hash: str
+    code_commit: str
+    replay_artifact_refs: tuple[str, ...]
+    objective_scorecard: Mapping[str, Any]
+    fold_metrics: tuple[Mapping[str, Any], ...]
+    stress_metrics: tuple[Mapping[str, Any], ...]
+    cost_calibration: Mapping[str, Any]
+    null_comparator: Mapping[str, Any]
+    promotion_readiness: Mapping[str, Any]
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "evidence_bundle_id": self.evidence_bundle_id,
+            "candidate_id": self.candidate_id,
+            "candidate_spec_id": self.candidate_spec_id,
+            "dataset_snapshot_id": self.dataset_snapshot_id,
+            "feature_spec_hash": self.feature_spec_hash,
+            "code_commit": self.code_commit,
+            "replay_artifact_refs": list(self.replay_artifact_refs),
+            "objective_scorecard": dict(self.objective_scorecard),
+            "fold_metrics": [dict(item) for item in self.fold_metrics],
+            "stress_metrics": [dict(item) for item in self.stress_metrics],
+            "cost_calibration": dict(self.cost_calibration),
+            "null_comparator": dict(self.null_comparator),
+            "promotion_readiness": dict(self.promotion_readiness),
+        }
+
+
+def evidence_bundle_id_for_payload(payload: Mapping[str, Any]) -> str:
+    return f"ev-{_stable_hash(payload)[:24]}"
+
+
+def evidence_bundle_from_frontier_candidate(
+    *,
+    candidate_spec_id: str,
+    candidate: Mapping[str, Any],
+    dataset_snapshot_id: str,
+    result_path: str,
+    code_commit: str = "unknown",
+) -> CandidateEvidenceBundle:
+    candidate_id = _string(candidate.get("candidate_id")) or candidate_spec_id
+    scorecard = _mapping(candidate.get("objective_scorecard"))
+    full_window = _mapping(candidate.get("full_window"))
+    if not scorecard:
+        scorecard = {
+            "net_pnl_per_day": _string(full_window.get("net_per_day")),
+            "active_day_ratio": _string(full_window.get("active_day_ratio")),
+            "positive_day_ratio": _string(full_window.get("positive_day_ratio")),
+            "best_day_share": _string(full_window.get("best_day_share")),
+            "max_drawdown": _string(full_window.get("max_drawdown")),
+        }
+    daily_net = _mapping(full_window.get("daily_net"))
+    if daily_net and "daily_net" not in scorecard:
+        scorecard = {**scorecard, "daily_net": daily_net}
+    daily_filled_notional = _mapping(full_window.get("daily_filled_notional"))
+    if daily_filled_notional and "daily_filled_notional" not in scorecard:
+        scorecard = {**scorecard, "daily_filled_notional": daily_filled_notional}
+    for key in ("family_template_id", "runtime_family", "runtime_strategy_name"):
+        value = _string(candidate.get(key))
+        if value and key not in scorecard:
+            scorecard = {**scorecard, key: value}
+    payload_seed = {
+        "candidate_id": candidate_id,
+        "candidate_spec_id": candidate_spec_id,
+        "dataset_snapshot_id": dataset_snapshot_id,
+        "objective_scorecard": scorecard,
+    }
+    promotion_readiness = _mapping(candidate.get("promotion_readiness")) or {
+        "stage": "research_candidate",
+        "status": "blocked_pending_runtime_parity",
+        "promotable": False,
+        "blockers": ["scheduler_v3_parity_missing", "shadow_validation_missing"],
+    }
+    return CandidateEvidenceBundle(
+        schema_version=EVIDENCE_BUNDLE_SCHEMA_VERSION,
+        evidence_bundle_id=evidence_bundle_id_for_payload(payload_seed),
+        candidate_id=candidate_id,
+        candidate_spec_id=candidate_spec_id,
+        dataset_snapshot_id=dataset_snapshot_id,
+        feature_spec_hash=_stable_hash(
+            {"candidate_spec_id": candidate_spec_id, "scorecard": scorecard}
+        ),
+        code_commit=code_commit,
+        replay_artifact_refs=(result_path,),
+        objective_scorecard=scorecard,
+        fold_metrics=tuple(
+            cast(Sequence[Mapping[str, Any]], candidate.get("fold_metrics") or ())
+        ),
+        stress_metrics=tuple(
+            cast(Sequence[Mapping[str, Any]], candidate.get("stress_metrics") or ())
+        ),
+        cost_calibration=_mapping(candidate.get("cost_calibration"))
+        or {"status": "provisional", "source": "frontier_replay"},
+        null_comparator=_mapping(candidate.get("null_comparator"))
+        or {
+            "baseline_outperformed": bool(
+                float(str(scorecard.get("net_pnl_per_day") or 0)) > 0
+            )
+        },
+        promotion_readiness=promotion_readiness,
+    )
+
+
+def evidence_bundle_from_payload(payload: Mapping[str, Any]) -> CandidateEvidenceBundle:
+    schema_version = _string(payload.get("schema_version"))
+    if schema_version != EVIDENCE_BUNDLE_SCHEMA_VERSION:
+        raise ValueError(f"evidence_bundle_schema_invalid:{schema_version}")
+    return CandidateEvidenceBundle(
+        schema_version=EVIDENCE_BUNDLE_SCHEMA_VERSION,
+        evidence_bundle_id=_string(payload.get("evidence_bundle_id")),
+        candidate_id=_string(payload.get("candidate_id")),
+        candidate_spec_id=_string(payload.get("candidate_spec_id")),
+        dataset_snapshot_id=_string(payload.get("dataset_snapshot_id")),
+        feature_spec_hash=_string(payload.get("feature_spec_hash")),
+        code_commit=_string(payload.get("code_commit")),
+        replay_artifact_refs=tuple(
+            str(item)
+            for item in cast(Sequence[Any], payload.get("replay_artifact_refs") or [])
+        ),
+        objective_scorecard=_mapping(payload.get("objective_scorecard")),
+        fold_metrics=tuple(
+            cast(Mapping[str, Any], item)
+            for item in cast(Sequence[Any], payload.get("fold_metrics") or [])
+            if isinstance(item, Mapping)
+        ),
+        stress_metrics=tuple(
+            cast(Mapping[str, Any], item)
+            for item in cast(Sequence[Any], payload.get("stress_metrics") or [])
+            if isinstance(item, Mapping)
+        ),
+        cost_calibration=_mapping(payload.get("cost_calibration")),
+        null_comparator=_mapping(payload.get("null_comparator")),
+        promotion_readiness=_mapping(payload.get("promotion_readiness")),
+    )

--- a/services/torghut/app/trading/discovery/hypothesis_cards.py
+++ b/services/torghut/app/trading/discovery/hypothesis_cards.py
@@ -1,0 +1,278 @@
+"""Typed hypothesis cards compiled from whitepaper research outputs."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Any, Literal, Mapping, Sequence, cast
+
+
+HYPOTHESIS_CARD_SCHEMA_VERSION = "torghut.hypothesis-card.v1"
+
+
+def _stable_hash(payload: Mapping[str, Any]) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _mapping(value: Any) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        return {}
+    return {str(key): item for key, item in cast(Mapping[Any, Any], value).items()}
+
+
+def _string(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _string_tuple(value: Any) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        values: Sequence[Any] = [value]
+    elif isinstance(value, Sequence):
+        values = cast(Sequence[Any], value)
+    else:
+        return ()
+    resolved: list[str] = []
+    for item in values:
+        text = _string(item)
+        if text and text not in resolved:
+            resolved.append(text)
+    return tuple(resolved)
+
+
+def _decimal(value: Any, *, default: str = "0") -> Decimal:
+    try:
+        return Decimal(str(value if value is not None else default))
+    except Exception:
+        return Decimal(default)
+
+
+def _claim_id(claim: Mapping[str, Any], *, index: int) -> str:
+    return _string(claim.get("claim_id")) or f"claim-{index}"
+
+
+def _claim_text(claim: Mapping[str, Any]) -> str:
+    return _string(claim.get("claim_text")) or _string(claim.get("claim"))
+
+
+def _metadata_terms(claim: Mapping[str, Any]) -> tuple[str, ...]:
+    metadata = _mapping(claim.get("metadata"))
+    terms: list[str] = []
+    for key in (
+        "required_features",
+        "features",
+        "entry_motifs",
+        "exit_motifs",
+        "risk_controls",
+    ):
+        terms.extend(_string_tuple(claim.get(key)))
+        terms.extend(_string_tuple(metadata.get(key)))
+    return tuple(dict.fromkeys(item for item in terms if item))
+
+
+def _infer_terms(*, claims: Sequence[Mapping[str, Any]], kind: str) -> tuple[str, ...]:
+    terms: list[str] = []
+    joined = " ".join(_claim_text(claim).lower() for claim in claims)
+    for claim in claims:
+        terms.extend(_metadata_terms(claim))
+        terms.extend(_string_tuple(claim.get(f"{kind}_json")))
+        terms.extend(_string_tuple(claim.get(kind)))
+    if kind == "required_features":
+        if any(
+            token in joined
+            for token in (
+                "order flow",
+                "order-flow",
+                "lob",
+                "limit order book",
+                "trade-flow",
+            )
+        ):
+            terms.extend(["order_flow_imbalance", "spread_bps", "relative_volume"])
+        if any(token in joined for token in ("momentum", "trend")):
+            terms.extend(["intraday_momentum_rank", "prior_day_return"])
+        if any(token in joined for token in ("reversal", "mean reversion", "washout")):
+            terms.extend(["session_selloff_bps", "cross_section_reversal_rank"])
+    if kind == "entry_motifs":
+        if any(token in joined for token in ("order flow", "trade-flow", "cluster")):
+            terms.append("microbar_rank")
+        if "momentum" in joined or "trend" in joined:
+            terms.append("momentum_pullback")
+        if "reversal" in joined or "washout" in joined:
+            terms.append("rebound")
+    if kind == "risk_controls":
+        terms.extend(["quote_quality", "stop_loss", "max_drawdown"])
+    return tuple(dict.fromkeys(item for item in terms if item))
+
+
+def _mechanism_from_claims(claims: Sequence[Mapping[str, Any]]) -> str:
+    for claim in claims:
+        text = _claim_text(claim)
+        claim_type = _string(claim.get("claim_type"))
+        if text and claim_type in {
+            "signal_mechanism",
+            "feature_recipe",
+            "normalization_rule",
+        }:
+            return text
+    for claim in claims:
+        text = _claim_text(claim)
+        if text:
+            return text
+    return "Whitepaper-derived market mechanism"
+
+
+def _failure_modes(
+    claims: Sequence[Mapping[str, Any]], relations: Sequence[Mapping[str, Any]]
+) -> tuple[str, ...]:
+    modes: list[str] = []
+    for claim in claims:
+        if _string(claim.get("expected_direction")).lower() in {
+            "negative",
+            "fails",
+            "failure",
+        }:
+            modes.append(_claim_text(claim) or _claim_id(claim, index=len(modes) + 1))
+        modes.extend(_string_tuple(claim.get("expected_failure_modes")))
+    for relation in relations:
+        relation_type = _string(relation.get("relation_type")).lower()
+        if relation_type in {"contradicts", "conflicts_with", "invalidates"}:
+            rationale = _string(relation.get("rationale"))
+            modes.append(
+                rationale or f"contradiction:{_string(relation.get('relation_id'))}"
+            )
+    if not modes:
+        modes.append("fails_under_cost_or_quote_quality_stress")
+    return tuple(dict.fromkeys(item for item in modes if item))
+
+
+@dataclass(frozen=True)
+class HypothesisCard:
+    schema_version: Literal["torghut.hypothesis-card.v1"]
+    hypothesis_id: str
+    source_run_id: str
+    source_claim_ids: tuple[str, ...]
+    mechanism: str
+    asset_scope: str
+    horizon_scope: str
+    expected_direction: str
+    required_features: tuple[str, ...]
+    entry_motifs: tuple[str, ...]
+    exit_motifs: tuple[str, ...]
+    risk_controls: tuple[str, ...]
+    expected_regimes: tuple[str, ...]
+    failure_modes: tuple[str, ...]
+    implementation_constraints: Mapping[str, Any]
+    confidence: Decimal
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "hypothesis_id": self.hypothesis_id,
+            "source_run_id": self.source_run_id,
+            "source_claim_ids": list(self.source_claim_ids),
+            "mechanism": self.mechanism,
+            "asset_scope": self.asset_scope,
+            "horizon_scope": self.horizon_scope,
+            "expected_direction": self.expected_direction,
+            "required_features": list(self.required_features),
+            "entry_motifs": list(self.entry_motifs),
+            "exit_motifs": list(self.exit_motifs),
+            "risk_controls": list(self.risk_controls),
+            "expected_regimes": list(self.expected_regimes),
+            "failure_modes": list(self.failure_modes),
+            "implementation_constraints": dict(self.implementation_constraints),
+            "confidence": str(self.confidence),
+        }
+
+
+def hypothesis_id_for_payload(payload: Mapping[str, Any]) -> str:
+    return f"hyp-{_stable_hash(payload)[:24]}"
+
+
+def build_hypothesis_cards(
+    *,
+    source_run_id: str,
+    claims: Sequence[Mapping[str, Any]],
+    relations: Sequence[Mapping[str, Any]] = (),
+    min_confidence: Decimal = Decimal("0.50"),
+) -> list[HypothesisCard]:
+    normalized_claims = [dict(item) for item in claims if _claim_text(item)]
+    if not normalized_claims:
+        return []
+    source_claim_ids = tuple(
+        _claim_id(claim, index=index)
+        for index, claim in enumerate(normalized_claims, start=1)
+    )
+    confidence_values = [
+        _decimal(claim.get("confidence"), default="0.60") for claim in normalized_claims
+    ]
+    confidence = sum(confidence_values, Decimal("0")) / Decimal(len(confidence_values))
+    if confidence < min_confidence:
+        return []
+    first_claim = normalized_claims[0]
+    base_payload = {
+        "source_run_id": source_run_id,
+        "source_claim_ids": list(source_claim_ids),
+        "mechanism": _mechanism_from_claims(normalized_claims),
+        "required_features": list(
+            _infer_terms(claims=normalized_claims, kind="required_features")
+        ),
+    }
+    return [
+        HypothesisCard(
+            schema_version=HYPOTHESIS_CARD_SCHEMA_VERSION,
+            hypothesis_id=hypothesis_id_for_payload(base_payload),
+            source_run_id=source_run_id,
+            source_claim_ids=source_claim_ids,
+            mechanism=str(base_payload["mechanism"]),
+            asset_scope=_string(first_claim.get("asset_scope"))
+            or "us_equities_intraday",
+            horizon_scope=_string(first_claim.get("horizon_scope")) or "intraday",
+            expected_direction=_string(first_claim.get("expected_direction"))
+            or "positive",
+            required_features=tuple(cast(list[str], base_payload["required_features"])),
+            entry_motifs=_infer_terms(claims=normalized_claims, kind="entry_motifs")
+            or ("runtime_default",),
+            exit_motifs=_infer_terms(claims=normalized_claims, kind="exit_motifs")
+            or ("time_exit",),
+            risk_controls=_infer_terms(claims=normalized_claims, kind="risk_controls"),
+            expected_regimes=_string_tuple(first_claim.get("expected_regimes"))
+            or ("liquid_regular_session",),
+            failure_modes=_failure_modes(normalized_claims, relations),
+            implementation_constraints={
+                "requires_runtime_family": True,
+                "requires_scheduler_v3_replay": True,
+                "requires_shadow_validation": True,
+            },
+            confidence=confidence,
+        )
+    ]
+
+
+def hypothesis_card_from_payload(payload: Mapping[str, Any]) -> HypothesisCard:
+    schema_version = _string(payload.get("schema_version"))
+    if schema_version != HYPOTHESIS_CARD_SCHEMA_VERSION:
+        raise ValueError(f"hypothesis_card_schema_invalid:{schema_version}")
+    return HypothesisCard(
+        schema_version=HYPOTHESIS_CARD_SCHEMA_VERSION,
+        hypothesis_id=_string(payload.get("hypothesis_id")),
+        source_run_id=_string(payload.get("source_run_id")),
+        source_claim_ids=_string_tuple(payload.get("source_claim_ids")),
+        mechanism=_string(payload.get("mechanism")),
+        asset_scope=_string(payload.get("asset_scope")),
+        horizon_scope=_string(payload.get("horizon_scope")),
+        expected_direction=_string(payload.get("expected_direction")),
+        required_features=_string_tuple(payload.get("required_features")),
+        entry_motifs=_string_tuple(payload.get("entry_motifs")),
+        exit_motifs=_string_tuple(payload.get("exit_motifs")),
+        risk_controls=_string_tuple(payload.get("risk_controls")),
+        expected_regimes=_string_tuple(payload.get("expected_regimes")),
+        failure_modes=_string_tuple(payload.get("failure_modes")),
+        implementation_constraints=_mapping(payload.get("implementation_constraints")),
+        confidence=_decimal(payload.get("confidence")),
+    )

--- a/services/torghut/app/trading/discovery/mlx_training_data.py
+++ b/services/torghut/app/trading/discovery/mlx_training_data.py
@@ -1,0 +1,372 @@
+"""Training-row and ranker helpers for the MLX autoresearch proposal model."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any, Mapping, Sequence, cast
+
+from app.trading.discovery.candidate_specs import CandidateSpec
+from app.trading.discovery.evidence_bundles import CandidateEvidenceBundle
+
+MLX_RANKER_SCHEMA_VERSION = "torghut.mlx-ranker.v1"
+
+
+def _stable_hash(payload: Mapping[str, Any]) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _import_array_backend(preference: str) -> tuple[str, Any]:
+    normalized = preference.strip().lower()
+    if normalized in {"numpy", "numpy-fallback"}:
+        import numpy as np
+
+        return "numpy-fallback", np
+    if normalized == "mlx":
+        try:
+            import mlx.core as mx  # type: ignore[import-not-found]
+
+            return "mlx", mx
+        except ModuleNotFoundError:
+            import numpy as np
+
+            return "numpy-fallback", np
+    try:
+        import mlx.core as mx  # type: ignore[import-not-found]
+
+        return "mlx", mx
+    except ModuleNotFoundError:
+        import numpy as np
+
+        return "numpy-fallback", np
+
+
+@dataclass(frozen=True)
+class MlxTrainingRow:
+    candidate_spec_id: str
+    feature_names: tuple[str, ...]
+    feature_values: tuple[float, ...]
+    target: float
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "candidate_spec_id": self.candidate_spec_id,
+            "features": dict(zip(self.feature_names, self.feature_values, strict=True)),
+            "target": self.target,
+        }
+
+
+@dataclass(frozen=True)
+class MlxRankerModel:
+    schema_version: str
+    model_id: str
+    backend: str
+    feature_names: tuple[str, ...]
+    feature_means: tuple[float, ...]
+    feature_scales: tuple[float, ...]
+    target_mean: float
+    target_scale: float
+    weights: tuple[float, ...]
+    bias: float
+    row_count: int
+    training_loss: float
+    trained_at: str
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "model_id": self.model_id,
+            "backend": self.backend,
+            "feature_names": list(self.feature_names),
+            "feature_means": list(self.feature_means),
+            "feature_scales": list(self.feature_scales),
+            "target_mean": self.target_mean,
+            "target_scale": self.target_scale,
+            "weights": list(self.weights),
+            "bias": self.bias,
+            "row_count": self.row_count,
+            "training_loss": self.training_loss,
+            "trained_at": self.trained_at,
+        }
+
+
+@dataclass(frozen=True)
+class MlxRankedCandidate:
+    candidate_spec_id: str
+    score: float
+    rank: int
+    model_id: str
+    backend: str
+    feature_hash: str
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "candidate_spec_id": self.candidate_spec_id,
+            "score": self.score,
+            "rank": self.rank,
+            "model_id": self.model_id,
+            "backend": self.backend,
+            "feature_hash": self.feature_hash,
+        }
+
+
+def _float(value: Any) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _family_code(family_template_id: str) -> float:
+    families = {
+        "breakout_reclaim_v2": 1.0,
+        "washout_rebound_v2": 2.0,
+        "momentum_pullback_v1": 3.0,
+        "mean_reversion_rebound_v1": 4.0,
+        "microbar_cross_sectional_pairs_v1": 5.0,
+        "microstructure_continuation_matched_filter_v1": 6.0,
+        "intraday_tsmom_v2": 7.0,
+    }
+    return families.get(family_template_id, 0.0)
+
+
+def _mean(values: Sequence[float]) -> float:
+    if not values:
+        return 0.0
+    return sum(values) / len(values)
+
+
+def _std(values: Sequence[float], *, mean: float) -> float:
+    if len(values) < 2:
+        return 1.0
+    variance = sum((value - mean) ** 2 for value in values) / len(values)
+    scale = variance**0.5
+    return scale if scale > 1e-9 else 1.0
+
+
+def _scalar_float(value: Any) -> float:
+    item_method = getattr(value, "item", None)
+    if callable(item_method):
+        item_value = cast(Any, item_method())
+        return float(item_value)
+    return float(value)
+
+
+def build_mlx_training_rows(
+    *,
+    candidate_specs: Sequence[CandidateSpec],
+    evidence_bundles: Sequence[CandidateEvidenceBundle],
+) -> list[MlxTrainingRow]:
+    evidence_by_spec = {item.candidate_spec_id: item for item in evidence_bundles}
+    rows: list[MlxTrainingRow] = []
+    for spec in candidate_specs:
+        evidence = evidence_by_spec.get(spec.candidate_spec_id)
+        scorecard: Mapping[str, Any] = (
+            evidence.objective_scorecard if evidence is not None else {}
+        )
+        feature_names = (
+            "family_code",
+            "required_feature_count",
+            "failure_mode_count",
+            "target_net_pnl_per_day",
+            "history_net_pnl_per_day",
+            "history_active_day_ratio",
+            "history_positive_day_ratio",
+        )
+        feature_values = (
+            _family_code(spec.family_template_id),
+            float(len(spec.feature_contract.get("required_features") or [])),
+            float(len(spec.expected_failure_modes)),
+            _float(spec.objective.get("target_net_pnl_per_day")),
+            _float(scorecard.get("net_pnl_per_day")),
+            _float(scorecard.get("active_day_ratio")),
+            _float(scorecard.get("positive_day_ratio")),
+        )
+        target = (
+            _float(scorecard.get("net_pnl_per_day"))
+            + (_float(scorecard.get("active_day_ratio")) * 100.0)
+            + (_float(scorecard.get("positive_day_ratio")) * 50.0)
+        )
+        rows.append(
+            MlxTrainingRow(
+                candidate_spec_id=spec.candidate_spec_id,
+                feature_names=feature_names,
+                feature_values=feature_values,
+                target=target,
+            )
+        )
+    return rows
+
+
+def _normalize_matrix(
+    rows: Sequence[MlxTrainingRow],
+) -> tuple[list[list[float]], tuple[str, ...], tuple[float, ...], tuple[float, ...]]:
+    if not rows:
+        return [], (), (), ()
+    feature_names = rows[0].feature_names
+    columns = list(zip(*(row.feature_values for row in rows), strict=True))
+    means = tuple(_mean(column) for column in columns)
+    scales = tuple(
+        _std(column, mean=mean) for column, mean in zip(columns, means, strict=True)
+    )
+    matrix = [
+        [
+            (value - mean) / scale
+            for value, mean, scale in zip(
+                row.feature_values, means, scales, strict=True
+            )
+        ]
+        for row in rows
+    ]
+    return matrix, feature_names, means, scales
+
+
+def train_mlx_ranker(
+    rows: Sequence[MlxTrainingRow],
+    *,
+    backend_preference: str = "mlx",
+    learning_rate: float = 0.05,
+    steps: int = 256,
+    l2_penalty: float = 0.001,
+) -> MlxRankerModel:
+    if not rows:
+        raise ValueError("mlx_ranker_training_rows_required")
+    matrix, feature_names, feature_means, feature_scales = _normalize_matrix(rows)
+    targets = [row.target for row in rows]
+    target_mean = _mean(targets)
+    target_scale = _std(targets, mean=target_mean)
+    normalized_targets = [(target - target_mean) / target_scale for target in targets]
+    backend, xp = _import_array_backend(backend_preference)
+    dtype = getattr(xp, "float32", None)
+    x = (
+        xp.array(matrix, dtype=dtype)
+        if dtype is not None
+        else xp.array(matrix, dtype=float)
+    )
+    y = (
+        xp.array(normalized_targets, dtype=dtype)
+        if dtype is not None
+        else xp.array(normalized_targets, dtype=float)
+    )
+    feature_count = len(feature_names)
+    weights = (
+        xp.zeros((feature_count,), dtype=dtype)
+        if dtype is not None
+        else xp.zeros((feature_count,))
+    )
+    bias = xp.array(0.0, dtype=dtype) if dtype is not None else 0.0
+    row_count = max(1, len(rows))
+    for _ in range(max(1, steps)):
+        predictions = x @ weights + bias
+        errors = predictions - y
+        gradient_w = ((x.T @ errors) * (2.0 / row_count)) + (weights * l2_penalty)
+        gradient_b = errors.mean() * 2.0
+        weights = weights - (gradient_w * learning_rate)
+        bias = bias - (gradient_b * learning_rate)
+    predictions = x @ weights + bias
+    errors = predictions - y
+    loss = _scalar_float((errors * errors).mean())
+    weights_list = tuple(float(item) for item in cast(Sequence[Any], weights.tolist()))
+    bias_value = _scalar_float(bias)
+    model_seed = {
+        "feature_names": list(feature_names),
+        "weights": list(weights_list),
+        "bias": bias_value,
+        "row_count": len(rows),
+        "backend": backend,
+    }
+    return MlxRankerModel(
+        schema_version=MLX_RANKER_SCHEMA_VERSION,
+        model_id=f"mlx-ranker-v1-{_stable_hash(model_seed)[:16]}",
+        backend=backend,
+        feature_names=feature_names,
+        feature_means=feature_means,
+        feature_scales=feature_scales,
+        target_mean=target_mean,
+        target_scale=target_scale,
+        weights=weights_list,
+        bias=bias_value,
+        row_count=len(rows),
+        training_loss=loss,
+        trained_at=datetime.now(UTC).isoformat(),
+    )
+
+
+def rank_training_rows(
+    *,
+    model: MlxRankerModel,
+    rows: Sequence[MlxTrainingRow],
+) -> list[MlxRankedCandidate]:
+    scored: list[tuple[MlxTrainingRow, float, str]] = []
+    for row in rows:
+        normalized = [
+            (value - mean) / scale
+            for value, mean, scale in zip(
+                row.feature_values,
+                model.feature_means,
+                model.feature_scales,
+                strict=True,
+            )
+        ]
+        normalized_score = (
+            sum(
+                (
+                    value * weight
+                    for value, weight in zip(normalized, model.weights, strict=True)
+                ),
+                0.0,
+            )
+            + model.bias
+        )
+        score = (normalized_score * model.target_scale) + model.target_mean
+        feature_hash = _stable_hash({"features": row.to_payload()["features"]})
+        scored.append((row, score, feature_hash))
+    ordered = sorted(
+        scored, key=lambda item: (item[1], item[0].candidate_spec_id), reverse=True
+    )
+    return [
+        MlxRankedCandidate(
+            candidate_spec_id=row.candidate_spec_id,
+            score=score,
+            rank=index,
+            model_id=model.model_id,
+            backend=model.backend,
+            feature_hash=feature_hash,
+        )
+        for index, (row, score, feature_hash) in enumerate(ordered, start=1)
+    ]
+
+
+def mlx_ranker_model_from_payload(payload: Mapping[str, Any]) -> MlxRankerModel:
+    schema_version = str(payload.get("schema_version") or "").strip()
+    if schema_version != MLX_RANKER_SCHEMA_VERSION:
+        raise ValueError(f"mlx_ranker_schema_invalid:{schema_version}")
+    return MlxRankerModel(
+        schema_version=MLX_RANKER_SCHEMA_VERSION,
+        model_id=str(payload.get("model_id") or "").strip(),
+        backend=str(payload.get("backend") or "").strip(),
+        feature_names=tuple(
+            str(item)
+            for item in cast(Sequence[Any], payload.get("feature_names") or [])
+        ),
+        feature_means=tuple(
+            float(item)
+            for item in cast(Sequence[Any], payload.get("feature_means") or [])
+        ),
+        feature_scales=tuple(
+            float(item)
+            for item in cast(Sequence[Any], payload.get("feature_scales") or [])
+        ),
+        target_mean=float(payload.get("target_mean") or 0.0),
+        target_scale=float(payload.get("target_scale") or 1.0),
+        weights=tuple(
+            float(item) for item in cast(Sequence[Any], payload.get("weights") or [])
+        ),
+        bias=float(payload.get("bias") or 0.0),
+        row_count=int(payload.get("row_count") or 0),
+        training_loss=float(payload.get("training_loss") or 0.0),
+        trained_at=str(payload.get("trained_at") or "").strip(),
+    )

--- a/services/torghut/app/trading/discovery/portfolio_candidates.py
+++ b/services/torghut/app/trading/discovery/portfolio_candidates.py
@@ -1,0 +1,105 @@
+"""Canonical portfolio candidate specs for whitepaper autoresearch."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Any, Literal, Mapping, Sequence, cast
+
+
+PORTFOLIO_CANDIDATE_SCHEMA_VERSION = "torghut.portfolio-candidate-spec.v1"
+
+
+def stable_portfolio_hash(payload: Mapping[str, Any]) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def portfolio_candidate_id_for_payload(payload: Mapping[str, Any]) -> str:
+    return f"port-{stable_portfolio_hash(payload)[:24]}"
+
+
+def _string(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _decimal(value: Any, *, default: str = "0") -> Decimal:
+    try:
+        return Decimal(str(value if value is not None else default))
+    except Exception:
+        return Decimal(default)
+
+
+def _mapping(value: Any) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        return {}
+    return {str(key): item for key, item in cast(Mapping[Any, Any], value).items()}
+
+
+def _mapping_tuple(value: Any) -> tuple[Mapping[str, Any], ...]:
+    if not isinstance(value, Sequence) or isinstance(value, str):
+        return ()
+    rows = cast(Sequence[Any], value)
+    return tuple(
+        cast(Mapping[str, Any], item) for item in rows if isinstance(item, Mapping)
+    )
+
+
+def _string_tuple(value: Any) -> tuple[str, ...]:
+    if not isinstance(value, Sequence) or isinstance(value, str):
+        return ()
+    rows = cast(Sequence[Any], value)
+    return tuple(str(item) for item in rows if str(item).strip())
+
+
+@dataclass(frozen=True)
+class PortfolioCandidateSpec:
+    schema_version: Literal["torghut.portfolio-candidate-spec.v1"]
+    portfolio_candidate_id: str
+    source_candidate_ids: tuple[str, ...]
+    target_net_pnl_per_day: Decimal
+    sleeves: tuple[Mapping[str, Any], ...]
+    capital_budget: Mapping[str, Any]
+    correlation_budget: Mapping[str, Any]
+    drawdown_budget: Mapping[str, Any]
+    evidence_refs: tuple[str, ...]
+    objective_scorecard: Mapping[str, Any]
+    optimizer_report: Mapping[str, Any]
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "portfolio_candidate_id": self.portfolio_candidate_id,
+            "source_candidate_ids": list(self.source_candidate_ids),
+            "target_net_pnl_per_day": str(self.target_net_pnl_per_day),
+            "sleeves": [dict(item) for item in self.sleeves],
+            "capital_budget": dict(self.capital_budget),
+            "correlation_budget": dict(self.correlation_budget),
+            "drawdown_budget": dict(self.drawdown_budget),
+            "evidence_refs": list(self.evidence_refs),
+            "objective_scorecard": dict(self.objective_scorecard),
+            "optimizer_report": dict(self.optimizer_report),
+        }
+
+
+def portfolio_candidate_from_payload(
+    payload: Mapping[str, Any],
+) -> PortfolioCandidateSpec:
+    schema_version = _string(payload.get("schema_version"))
+    if schema_version != PORTFOLIO_CANDIDATE_SCHEMA_VERSION:
+        raise ValueError(f"portfolio_candidate_schema_invalid:{schema_version}")
+    return PortfolioCandidateSpec(
+        schema_version=PORTFOLIO_CANDIDATE_SCHEMA_VERSION,
+        portfolio_candidate_id=_string(payload.get("portfolio_candidate_id")),
+        source_candidate_ids=_string_tuple(payload.get("source_candidate_ids")),
+        target_net_pnl_per_day=_decimal(payload.get("target_net_pnl_per_day")),
+        sleeves=_mapping_tuple(payload.get("sleeves")),
+        capital_budget=_mapping(payload.get("capital_budget")),
+        correlation_budget=_mapping(payload.get("correlation_budget")),
+        drawdown_budget=_mapping(payload.get("drawdown_budget")),
+        evidence_refs=_string_tuple(payload.get("evidence_refs")),
+        objective_scorecard=_mapping(payload.get("objective_scorecard")),
+        optimizer_report=_mapping(payload.get("optimizer_report")),
+    )

--- a/services/torghut/app/trading/discovery/portfolio_optimizer.py
+++ b/services/torghut/app/trading/discovery/portfolio_optimizer.py
@@ -13,6 +13,10 @@ from app.trading.discovery.portfolio_candidates import (
 )
 from app.trading.discovery.profit_target_oracle import evaluate_profit_target_oracle
 
+MAX_CLUSTER_CONTRIBUTION_SHARE = Decimal("0.40")
+MAX_SINGLE_SYMBOL_CONTRIBUTION_SHARE = Decimal("0.35")
+MAX_ALLOWED_PAIRWISE_CORRELATION = Decimal("0.85")
+
 
 def _decimal(value: Any, *, default: str = "0") -> Decimal:
     try:
@@ -133,6 +137,66 @@ def _portfolio_daily_filled_notional(
     return daily_totals
 
 
+def _positive_net_contribution(bundle: CandidateEvidenceBundle) -> Decimal:
+    return max(_net_per_day(bundle), Decimal("0"))
+
+
+def _cluster_id(bundle: CandidateEvidenceBundle) -> str:
+    return (
+        _string(_scorecard(bundle).get("correlation_cluster"))
+        or bundle.candidate_spec_id
+    )
+
+
+def _contribution_shares(values: Mapping[str, Decimal]) -> dict[str, Decimal]:
+    total = sum(values.values(), Decimal("0"))
+    if total <= 0:
+        return {}
+    return {key: value / total for key, value in values.items()}
+
+
+def _cluster_contribution_shares(
+    selected: Sequence[CandidateEvidenceBundle],
+) -> dict[str, Decimal]:
+    contributions: dict[str, Decimal] = {}
+    for bundle in selected:
+        cluster = _cluster_id(bundle)
+        contributions[cluster] = contributions.get(
+            cluster, Decimal("0")
+        ) + _positive_net_contribution(bundle)
+    return _contribution_shares(contributions)
+
+
+def _bundle_symbol_shares(bundle: CandidateEvidenceBundle) -> dict[str, Decimal]:
+    raw_symbol_shares = _scorecard(bundle).get("symbol_contribution_shares")
+    if isinstance(raw_symbol_shares, Mapping):
+        rows = cast(Mapping[Any, Any], raw_symbol_shares)
+        shares = {
+            _string(symbol).upper(): max(_decimal(value), Decimal("0"))
+            for symbol, value in rows.items()
+            if _string(symbol)
+        }
+        if shares:
+            return _contribution_shares(shares)
+    symbol = _string(_scorecard(bundle).get("symbol")).upper()
+    if symbol:
+        return {symbol: Decimal("1")}
+    return {"UNKNOWN": Decimal("1")}
+
+
+def _symbol_contribution_shares(
+    selected: Sequence[CandidateEvidenceBundle],
+) -> dict[str, Decimal]:
+    contributions: dict[str, Decimal] = {}
+    for bundle in selected:
+        bundle_positive_net = _positive_net_contribution(bundle)
+        for symbol, share in _bundle_symbol_shares(bundle).items():
+            contributions[symbol] = contributions.get(symbol, Decimal("0")) + (
+                bundle_positive_net * share
+            )
+    return _contribution_shares(contributions)
+
+
 def _max_pairwise_correlation(
     bundle: CandidateEvidenceBundle,
     selected: Sequence[CandidateEvidenceBundle],
@@ -144,6 +208,10 @@ def _max_pairwise_correlation(
         (_correlation(candidate_daily, _daily_net(item)) for item in selected),
         default=Decimal("0"),
     )
+
+
+def _max_share(shares: Mapping[str, Decimal]) -> Decimal:
+    return max(shares.values(), default=Decimal("0"))
 
 
 def _max_drawdown_from_daily(daily_net: Mapping[str, Decimal]) -> Decimal:
@@ -181,6 +249,8 @@ def _portfolio_scorecard(
         if positive_total > 0
         else Decimal("0")
     )
+    cluster_shares = _cluster_contribution_shares(selected)
+    symbol_shares = _symbol_contribution_shares(selected)
     min_day = min(values, default=Decimal("0"))
     worst_day_loss = abs(min_day) if min_day < 0 else Decimal("0")
     daily_notional = _portfolio_daily_filled_notional(selected)
@@ -205,6 +275,15 @@ def _portfolio_scorecard(
         "worst_day_loss": str(worst_day_loss),
         "max_drawdown": str(_max_drawdown_from_daily(daily_net)),
         "best_day_share": str(best_day_share),
+        "max_single_day_contribution_share": str(best_day_share),
+        "cluster_contribution_shares": {
+            cluster: str(share) for cluster, share in sorted(cluster_shares.items())
+        },
+        "max_cluster_contribution_share": str(_max_share(cluster_shares)),
+        "symbol_contribution_shares": {
+            symbol: str(share) for symbol, share in sorted(symbol_shares.items())
+        },
+        "max_single_symbol_contribution_share": str(_max_share(symbol_shares)),
         "avg_filled_notional_per_day": str(_mean(notional_values)),
         "regime_slice_pass_rate": str(_mean(regime_pass_rates)),
         "posterior_edge_lower": str(min(posterior_lowers, default=Decimal("0"))),
@@ -260,12 +339,9 @@ def optimize_portfolio_candidate(
     selected: list[CandidateEvidenceBundle] = []
     selected_clusters: set[str] = set()
     rejected: list[dict[str, Any]] = []
-    max_allowed_correlation = Decimal("0.85")
+    max_allowed_correlation = MAX_ALLOWED_PAIRWISE_CORRELATION
     for bundle in ordered:
-        cluster = (
-            _string(_scorecard(bundle).get("correlation_cluster"))
-            or bundle.candidate_spec_id
-        )
+        cluster = _cluster_id(bundle)
         if cluster in selected_clusters and len(selected) >= portfolio_size_min:
             rejected.append(
                 {
@@ -292,11 +368,13 @@ def optimize_portfolio_candidate(
         selected_clusters.add(cluster)
         if len(selected) >= max(1, portfolio_size_max):
             break
-        if (
-            len(selected) >= portfolio_size_min
-            and sum(_net_per_day(item) for item in selected) >= target_net_pnl_per_day
-        ):
-            break
+        if len(selected) >= portfolio_size_min:
+            candidate_scorecard = _portfolio_scorecard(
+                selected=selected,
+                target_net_pnl_per_day=target_net_pnl_per_day,
+            )
+            if bool(candidate_scorecard.get("oracle_passed")):
+                break
     if not selected:
         return None
 
@@ -350,8 +428,24 @@ def optimize_portfolio_candidate(
         "rejected_count": max(0, len(evidence_bundles) - len(selected)),
         "rejections": rejected,
         "pairwise_correlations": pairwise_correlations,
+        "cluster_contribution_shares": objective_scorecard.get(
+            "cluster_contribution_shares", {}
+        ),
+        "symbol_contribution_shares": objective_scorecard.get(
+            "symbol_contribution_shares", {}
+        ),
+        "max_cluster_contribution_share": objective_scorecard.get(
+            "max_cluster_contribution_share"
+        ),
+        "max_single_day_contribution_share": objective_scorecard.get(
+            "max_single_day_contribution_share"
+        ),
+        "max_single_symbol_contribution_share": objective_scorecard.get(
+            "max_single_symbol_contribution_share"
+        ),
         "method": "deterministic_greedy_pareto_v1",
         "target_met": bool(objective_scorecard["target_met"]),
+        "oracle_passed": bool(objective_scorecard["oracle_passed"]),
     }
     return PortfolioCandidateSpec(
         schema_version=PORTFOLIO_CANDIDATE_SCHEMA_VERSION,
@@ -369,6 +463,18 @@ def optimize_portfolio_candidate(
             "mode": "cluster_cap",
             "selected_cluster_count": len(selected_clusters),
             "max_allowed_pairwise_correlation": str(max_allowed_correlation),
+            "max_cluster_contribution_share": objective_scorecard.get(
+                "max_cluster_contribution_share"
+            ),
+            "max_single_symbol_contribution_share": objective_scorecard.get(
+                "max_single_symbol_contribution_share"
+            ),
+            "cluster_contribution_shares": objective_scorecard.get(
+                "cluster_contribution_shares", {}
+            ),
+            "symbol_contribution_shares": objective_scorecard.get(
+                "symbol_contribution_shares", {}
+            ),
         },
         drawdown_budget={"max_drawdown": str(max_drawdown)},
         evidence_refs=tuple(item.evidence_bundle_id for item in selected),

--- a/services/torghut/app/trading/discovery/portfolio_optimizer.py
+++ b/services/torghut/app/trading/discovery/portfolio_optimizer.py
@@ -2,21 +2,15 @@
 
 from __future__ import annotations
 
-import hashlib
-import json
-from dataclasses import dataclass
 from decimal import Decimal
-from typing import Any, Literal, Mapping, Sequence, cast
+from typing import Any, Mapping, Sequence, cast
 
 from app.trading.discovery.evidence_bundles import CandidateEvidenceBundle
-
-
-PORTFOLIO_CANDIDATE_SCHEMA_VERSION = "torghut.portfolio-candidate-spec.v1"
-
-
-def _stable_hash(payload: Mapping[str, Any]) -> str:
-    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
-    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+from app.trading.discovery.portfolio_candidates import (
+    PORTFOLIO_CANDIDATE_SCHEMA_VERSION,
+    PortfolioCandidateSpec,
+    portfolio_candidate_id_for_payload,
+)
 
 
 def _decimal(value: Any, *, default: str = "0") -> Decimal:
@@ -193,40 +187,12 @@ def _sleeve_score(bundle: CandidateEvidenceBundle) -> Decimal:
     )
 
 
-@dataclass(frozen=True)
-class PortfolioCandidateSpec:
-    schema_version: Literal["torghut.portfolio-candidate-spec.v1"]
-    portfolio_candidate_id: str
-    source_candidate_ids: tuple[str, ...]
-    target_net_pnl_per_day: Decimal
-    sleeves: tuple[Mapping[str, Any], ...]
-    capital_budget: Mapping[str, Any]
-    correlation_budget: Mapping[str, Any]
-    drawdown_budget: Mapping[str, Any]
-    evidence_refs: tuple[str, ...]
-    objective_scorecard: Mapping[str, Any]
-    optimizer_report: Mapping[str, Any]
-
-    def to_payload(self) -> dict[str, Any]:
-        return {
-            "schema_version": self.schema_version,
-            "portfolio_candidate_id": self.portfolio_candidate_id,
-            "source_candidate_ids": list(self.source_candidate_ids),
-            "target_net_pnl_per_day": str(self.target_net_pnl_per_day),
-            "sleeves": [dict(item) for item in self.sleeves],
-            "capital_budget": dict(self.capital_budget),
-            "correlation_budget": dict(self.correlation_budget),
-            "drawdown_budget": dict(self.drawdown_budget),
-            "evidence_refs": list(self.evidence_refs),
-            "objective_scorecard": dict(self.objective_scorecard),
-            "optimizer_report": dict(self.optimizer_report),
-        }
-
-
 def _portfolio_candidate_id(
     source_candidate_ids: Sequence[str], target: Decimal
 ) -> str:
-    return f"port-{_stable_hash({'source_candidate_ids': list(source_candidate_ids), 'target': str(target)})[:24]}"
+    return portfolio_candidate_id_for_payload(
+        {"source_candidate_ids": list(source_candidate_ids), "target": str(target)}
+    )
 
 
 def optimize_portfolio_candidate(

--- a/services/torghut/app/trading/discovery/portfolio_optimizer.py
+++ b/services/torghut/app/trading/discovery/portfolio_optimizer.py
@@ -1,0 +1,364 @@
+"""Deterministic portfolio sleeve optimizer for autoresearch candidates."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Any, Literal, Mapping, Sequence, cast
+
+from app.trading.discovery.evidence_bundles import CandidateEvidenceBundle
+
+
+PORTFOLIO_CANDIDATE_SCHEMA_VERSION = "torghut.portfolio-candidate-spec.v1"
+
+
+def _stable_hash(payload: Mapping[str, Any]) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _decimal(value: Any, *, default: str = "0") -> Decimal:
+    try:
+        return Decimal(str(value if value is not None else default))
+    except Exception:
+        return Decimal(default)
+
+
+def _string(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _scorecard(bundle: CandidateEvidenceBundle) -> Mapping[str, Any]:
+    return bundle.objective_scorecard
+
+
+def _net_per_day(bundle: CandidateEvidenceBundle) -> Decimal:
+    return _decimal(_scorecard(bundle).get("net_pnl_per_day"))
+
+
+def _active_ratio(bundle: CandidateEvidenceBundle) -> Decimal:
+    return _decimal(_scorecard(bundle).get("active_day_ratio"))
+
+
+def _positive_ratio(bundle: CandidateEvidenceBundle) -> Decimal:
+    return _decimal(_scorecard(bundle).get("positive_day_ratio"))
+
+
+def _best_day_share(bundle: CandidateEvidenceBundle) -> Decimal:
+    return _decimal(_scorecard(bundle).get("best_day_share"))
+
+
+def _max_drawdown(bundle: CandidateEvidenceBundle) -> Decimal:
+    return _decimal(_scorecard(bundle).get("max_drawdown"))
+
+
+def _worst_day_loss(bundle: CandidateEvidenceBundle) -> Decimal:
+    return _decimal(_scorecard(bundle).get("worst_day_loss"))
+
+
+def _candidate_passes_minimums(bundle: CandidateEvidenceBundle) -> bool:
+    if bool(bundle.promotion_readiness.get("promotable")):
+        return True
+    blockers = cast(Sequence[Any], bundle.promotion_readiness.get("blockers") or [])
+    blocking = {str(item) for item in blockers}
+    allowed_blockers = {"scheduler_v3_parity_missing", "shadow_validation_missing"}
+    if blocking - allowed_blockers:
+        return False
+    return _net_per_day(bundle) > 0 and _active_ratio(bundle) >= Decimal("0.50")
+
+
+def _daily_net(bundle: CandidateEvidenceBundle) -> dict[str, Decimal]:
+    raw_daily = _scorecard(bundle).get("daily_net")
+    if isinstance(raw_daily, Mapping):
+        daily_mapping = cast(Mapping[Any, Any], raw_daily)
+        return {str(day): _decimal(value) for day, value in daily_mapping.items()}
+    return {"synthetic": _net_per_day(bundle)}
+
+
+def _mean(values: Sequence[Decimal]) -> Decimal:
+    if not values:
+        return Decimal("0")
+    return sum(values, Decimal("0")) / Decimal(len(values))
+
+
+def _correlation(left: Mapping[str, Decimal], right: Mapping[str, Decimal]) -> Decimal:
+    common_days = sorted(set(left) & set(right))
+    if len(common_days) < 2:
+        return Decimal("0")
+    left_values = [left[day] for day in common_days]
+    right_values = [right[day] for day in common_days]
+    left_mean = _mean(left_values)
+    right_mean = _mean(right_values)
+    numerator: Decimal = sum(
+        (
+            (left_value - left_mean) * (right_value - right_mean)
+            for left_value, right_value in zip(left_values, right_values, strict=True)
+        ),
+        Decimal("0"),
+    )
+    left_var: Decimal = sum(
+        ((value - left_mean) ** 2 for value in left_values), Decimal("0")
+    )
+    right_var: Decimal = sum(
+        ((value - right_mean) ** 2 for value in right_values), Decimal("0")
+    )
+    if left_var <= 0 or right_var <= 0:
+        return Decimal("0")
+    return numerator / (left_var.sqrt() * right_var.sqrt())
+
+
+def _portfolio_daily_net(
+    selected: Sequence[CandidateEvidenceBundle],
+) -> dict[str, Decimal]:
+    daily_totals: dict[str, Decimal] = {}
+    for bundle in selected:
+        for day, value in _daily_net(bundle).items():
+            daily_totals[day] = daily_totals.get(day, Decimal("0")) + value
+    return daily_totals
+
+
+def _max_pairwise_correlation(
+    bundle: CandidateEvidenceBundle,
+    selected: Sequence[CandidateEvidenceBundle],
+) -> Decimal:
+    if not selected:
+        return Decimal("0")
+    candidate_daily = _daily_net(bundle)
+    return max(
+        (_correlation(candidate_daily, _daily_net(item)) for item in selected),
+        default=Decimal("0"),
+    )
+
+
+def _max_drawdown_from_daily(daily_net: Mapping[str, Decimal]) -> Decimal:
+    peak = Decimal("0")
+    cumulative = Decimal("0")
+    drawdown = Decimal("0")
+    for day in sorted(daily_net):
+        cumulative += daily_net[day]
+        peak = max(peak, cumulative)
+        drawdown = max(drawdown, peak - cumulative)
+    return drawdown
+
+
+def _portfolio_scorecard(
+    *,
+    selected: Sequence[CandidateEvidenceBundle],
+    target_net_pnl_per_day: Decimal,
+) -> dict[str, Any]:
+    daily_net = _portfolio_daily_net(selected)
+    values = [daily_net[day] for day in sorted(daily_net)]
+    net_per_day = _mean(values)
+    active_day_ratio = (
+        Decimal(sum(1 for value in values if value != 0)) / Decimal(len(values))
+        if values
+        else Decimal("0")
+    )
+    positive_day_ratio = (
+        Decimal(sum(1 for value in values if value > 0)) / Decimal(len(values))
+        if values
+        else Decimal("0")
+    )
+    positive_total = sum((value for value in values if value > 0), Decimal("0"))
+    best_day_share = (
+        max(values, default=Decimal("0")) / positive_total
+        if positive_total > 0
+        else Decimal("0")
+    )
+    min_day = min(values, default=Decimal("0"))
+    worst_day_loss = abs(min_day) if min_day < 0 else Decimal("0")
+    return {
+        "net_pnl_per_day": str(net_per_day),
+        "target_net_pnl_per_day": str(target_net_pnl_per_day),
+        "target_met": net_per_day >= target_net_pnl_per_day,
+        "active_day_ratio": str(active_day_ratio),
+        "positive_day_ratio": str(positive_day_ratio),
+        "worst_day_loss": str(worst_day_loss),
+        "max_drawdown": str(_max_drawdown_from_daily(daily_net)),
+        "best_day_share": str(best_day_share),
+        "daily_net": {day: str(value) for day, value in sorted(daily_net.items())},
+    }
+
+
+def _sleeve_score(bundle: CandidateEvidenceBundle) -> Decimal:
+    return (
+        _net_per_day(bundle)
+        + (_active_ratio(bundle) * Decimal("300"))
+        + (_positive_ratio(bundle) * Decimal("150"))
+        - (_worst_day_loss(bundle) * Decimal("0.50"))
+        - (_max_drawdown(bundle) * Decimal("0.10"))
+        - (_best_day_share(bundle) * Decimal("500"))
+    )
+
+
+@dataclass(frozen=True)
+class PortfolioCandidateSpec:
+    schema_version: Literal["torghut.portfolio-candidate-spec.v1"]
+    portfolio_candidate_id: str
+    source_candidate_ids: tuple[str, ...]
+    target_net_pnl_per_day: Decimal
+    sleeves: tuple[Mapping[str, Any], ...]
+    capital_budget: Mapping[str, Any]
+    correlation_budget: Mapping[str, Any]
+    drawdown_budget: Mapping[str, Any]
+    evidence_refs: tuple[str, ...]
+    objective_scorecard: Mapping[str, Any]
+    optimizer_report: Mapping[str, Any]
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "portfolio_candidate_id": self.portfolio_candidate_id,
+            "source_candidate_ids": list(self.source_candidate_ids),
+            "target_net_pnl_per_day": str(self.target_net_pnl_per_day),
+            "sleeves": [dict(item) for item in self.sleeves],
+            "capital_budget": dict(self.capital_budget),
+            "correlation_budget": dict(self.correlation_budget),
+            "drawdown_budget": dict(self.drawdown_budget),
+            "evidence_refs": list(self.evidence_refs),
+            "objective_scorecard": dict(self.objective_scorecard),
+            "optimizer_report": dict(self.optimizer_report),
+        }
+
+
+def _portfolio_candidate_id(
+    source_candidate_ids: Sequence[str], target: Decimal
+) -> str:
+    return f"port-{_stable_hash({'source_candidate_ids': list(source_candidate_ids), 'target': str(target)})[:24]}"
+
+
+def optimize_portfolio_candidate(
+    *,
+    evidence_bundles: Sequence[CandidateEvidenceBundle],
+    target_net_pnl_per_day: Decimal = Decimal("500"),
+    portfolio_size_min: int = 2,
+    portfolio_size_max: int = 8,
+) -> PortfolioCandidateSpec | None:
+    eligible = [
+        bundle for bundle in evidence_bundles if _candidate_passes_minimums(bundle)
+    ]
+    ordered = sorted(
+        eligible,
+        key=lambda item: (_sleeve_score(item), _net_per_day(item), item.candidate_id),
+        reverse=True,
+    )
+    selected: list[CandidateEvidenceBundle] = []
+    selected_clusters: set[str] = set()
+    rejected: list[dict[str, Any]] = []
+    max_allowed_correlation = Decimal("0.85")
+    for bundle in ordered:
+        cluster = (
+            _string(_scorecard(bundle).get("correlation_cluster"))
+            or bundle.candidate_spec_id
+        )
+        if cluster in selected_clusters and len(selected) >= portfolio_size_min:
+            rejected.append(
+                {
+                    "candidate_id": bundle.candidate_id,
+                    "reason": "cluster_cap",
+                    "cluster": cluster,
+                }
+            )
+            continue
+        max_correlation = _max_pairwise_correlation(bundle, selected)
+        if (
+            max_correlation > max_allowed_correlation
+            and len(selected) >= portfolio_size_min
+        ):
+            rejected.append(
+                {
+                    "candidate_id": bundle.candidate_id,
+                    "reason": "correlation_cap",
+                    "max_pairwise_correlation": str(max_correlation),
+                }
+            )
+            continue
+        selected.append(bundle)
+        selected_clusters.add(cluster)
+        if len(selected) >= max(1, portfolio_size_max):
+            break
+        if (
+            len(selected) >= portfolio_size_min
+            and sum(_net_per_day(item) for item in selected) >= target_net_pnl_per_day
+        ):
+            break
+    if not selected:
+        return None
+
+    source_candidate_ids = tuple(item.candidate_id for item in selected)
+    objective_scorecard = _portfolio_scorecard(
+        selected=selected,
+        target_net_pnl_per_day=target_net_pnl_per_day,
+    )
+    max_drawdown = _decimal(objective_scorecard.get("max_drawdown"))
+    sleeves: list[Mapping[str, Any]] = []
+    equal_weight = Decimal("1") / Decimal(len(selected))
+    for sleeve_index, bundle in enumerate(selected, start=1):
+        base_runtime_strategy_name = (
+            _string(_scorecard(bundle).get("runtime_strategy_name"))
+            or f"whitepaper-autoresearch-sleeve-{sleeve_index}"
+        )
+        sleeves.append(
+            {
+                "candidate_id": bundle.candidate_id,
+                "candidate_spec_id": bundle.candidate_spec_id,
+                "family_template_id": _string(
+                    _scorecard(bundle).get("family_template_id")
+                ),
+                "runtime_family": _string(_scorecard(bundle).get("runtime_family")),
+                "runtime_strategy_name": f"{base_runtime_strategy_name}-sleeve-{sleeve_index}",
+                "weight": str(equal_weight),
+                "expected_net_pnl_per_day": str(_net_per_day(bundle)),
+                "risk_contribution": str(_max_drawdown(bundle)),
+                "correlation_cluster": _string(
+                    _scorecard(bundle).get("correlation_cluster")
+                )
+                or bundle.candidate_spec_id,
+                "daily_net": {
+                    day: str(value) for day, value in sorted(_daily_net(bundle).items())
+                },
+                "promotion_status": bundle.promotion_readiness.get("status"),
+            }
+        )
+    pairwise_correlations = [
+        {
+            "left_candidate_id": left.candidate_id,
+            "right_candidate_id": right.candidate_id,
+            "correlation": str(_correlation(_daily_net(left), _daily_net(right))),
+        }
+        for left_index, left in enumerate(selected)
+        for right in selected[left_index + 1 :]
+    ]
+    optimizer_report = {
+        "eligible_count": len(eligible),
+        "selected_count": len(selected),
+        "rejected_count": max(0, len(evidence_bundles) - len(selected)),
+        "rejections": rejected,
+        "pairwise_correlations": pairwise_correlations,
+        "method": "deterministic_greedy_pareto_v1",
+        "target_met": bool(objective_scorecard["target_met"]),
+    }
+    return PortfolioCandidateSpec(
+        schema_version=PORTFOLIO_CANDIDATE_SCHEMA_VERSION,
+        portfolio_candidate_id=_portfolio_candidate_id(
+            source_candidate_ids, target_net_pnl_per_day
+        ),
+        source_candidate_ids=source_candidate_ids,
+        target_net_pnl_per_day=target_net_pnl_per_day,
+        sleeves=tuple(sleeves),
+        capital_budget={
+            "mode": "equal_weight_initial",
+            "max_sleeves": portfolio_size_max,
+        },
+        correlation_budget={
+            "mode": "cluster_cap",
+            "selected_cluster_count": len(selected_clusters),
+            "max_allowed_pairwise_correlation": str(max_allowed_correlation),
+        },
+        drawdown_budget={"max_drawdown": str(max_drawdown)},
+        evidence_refs=tuple(item.evidence_bundle_id for item in selected),
+        objective_scorecard=objective_scorecard,
+        optimizer_report=optimizer_report,
+    )

--- a/services/torghut/app/trading/discovery/portfolio_optimizer.py
+++ b/services/torghut/app/trading/discovery/portfolio_optimizer.py
@@ -11,6 +11,7 @@ from app.trading.discovery.portfolio_candidates import (
     PortfolioCandidateSpec,
     portfolio_candidate_id_for_payload,
 )
+from app.trading.discovery.profit_target_oracle import evaluate_profit_target_oracle
 
 
 def _decimal(value: Any, *, default: str = "0") -> Decimal:
@@ -71,6 +72,15 @@ def _daily_net(bundle: CandidateEvidenceBundle) -> dict[str, Decimal]:
     return {"synthetic": _net_per_day(bundle)}
 
 
+def _daily_filled_notional(bundle: CandidateEvidenceBundle) -> dict[str, Decimal]:
+    raw_daily = _scorecard(bundle).get("daily_filled_notional")
+    if isinstance(raw_daily, Mapping):
+        daily_mapping = cast(Mapping[Any, Any], raw_daily)
+        return {str(day): _decimal(value) for day, value in daily_mapping.items()}
+    notional = _decimal(_scorecard(bundle).get("avg_filled_notional_per_day"))
+    return {"synthetic": notional} if notional > 0 else {}
+
+
 def _mean(values: Sequence[Decimal]) -> Decimal:
     if not values:
         return Decimal("0")
@@ -109,6 +119,16 @@ def _portfolio_daily_net(
     daily_totals: dict[str, Decimal] = {}
     for bundle in selected:
         for day, value in _daily_net(bundle).items():
+            daily_totals[day] = daily_totals.get(day, Decimal("0")) + value
+    return daily_totals
+
+
+def _portfolio_daily_filled_notional(
+    selected: Sequence[CandidateEvidenceBundle],
+) -> dict[str, Decimal]:
+    daily_totals: dict[str, Decimal] = {}
+    for bundle in selected:
+        for day, value in _daily_filled_notional(bundle).items():
             daily_totals[day] = daily_totals.get(day, Decimal("0")) + value
     return daily_totals
 
@@ -163,8 +183,21 @@ def _portfolio_scorecard(
     )
     min_day = min(values, default=Decimal("0"))
     worst_day_loss = abs(min_day) if min_day < 0 else Decimal("0")
-    return {
+    daily_notional = _portfolio_daily_filled_notional(selected)
+    notional_values = [daily_notional[day] for day in sorted(daily_notional)]
+    regime_pass_rates = [
+        _decimal(_scorecard(bundle).get("regime_slice_pass_rate"))
+        for bundle in selected
+    ]
+    posterior_lowers = [
+        _decimal(_scorecard(bundle).get("posterior_edge_lower")) for bundle in selected
+    ]
+    shadow_statuses = {
+        _string(_scorecard(bundle).get("shadow_parity_status")) for bundle in selected
+    }
+    scorecard = {
         "net_pnl_per_day": str(net_per_day),
+        "portfolio_post_cost_net_pnl_per_day": str(net_per_day),
         "target_net_pnl_per_day": str(target_net_pnl_per_day),
         "target_met": net_per_day >= target_net_pnl_per_day,
         "active_day_ratio": str(active_day_ratio),
@@ -172,8 +205,22 @@ def _portfolio_scorecard(
         "worst_day_loss": str(worst_day_loss),
         "max_drawdown": str(_max_drawdown_from_daily(daily_net)),
         "best_day_share": str(best_day_share),
+        "avg_filled_notional_per_day": str(_mean(notional_values)),
+        "regime_slice_pass_rate": str(_mean(regime_pass_rates)),
+        "posterior_edge_lower": str(min(posterior_lowers, default=Decimal("0"))),
+        "shadow_parity_status": "within_budget"
+        if shadow_statuses == {"within_budget"}
+        else "missing",
         "daily_net": {day: str(value) for day, value in sorted(daily_net.items())},
+        "daily_filled_notional": {
+            day: str(value) for day, value in sorted(daily_notional.items())
+        },
     }
+    scorecard["profit_target_oracle"] = evaluate_profit_target_oracle(
+        scorecard, target_net_pnl_per_day=target_net_pnl_per_day
+    )
+    scorecard["oracle_passed"] = bool(scorecard["profit_target_oracle"]["passed"])
+    return scorecard
 
 
 def _sleeve_score(bundle: CandidateEvidenceBundle) -> Decimal:

--- a/services/torghut/app/trading/discovery/portfolio_optimizer.py
+++ b/services/torghut/app/trading/discovery/portfolio_optimizer.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from decimal import Decimal
 from typing import Any, Mapping, Sequence, cast
 
-from app.trading.discovery.evidence_bundles import CandidateEvidenceBundle
+from app.trading.discovery.evidence_bundles import (
+    CandidateEvidenceBundle,
+    evidence_bundle_blockers,
+    evidence_bundle_is_valid,
+)
 from app.trading.discovery.portfolio_candidates import (
     PORTFOLIO_CANDIDATE_SCHEMA_VERSION,
     PortfolioCandidateSpec,
@@ -58,6 +62,8 @@ def _worst_day_loss(bundle: CandidateEvidenceBundle) -> Decimal:
 
 
 def _candidate_passes_minimums(bundle: CandidateEvidenceBundle) -> bool:
+    if not evidence_bundle_is_valid(bundle):
+        return False
     if bool(bundle.promotion_readiness.get("promotable")):
         return True
     blockers = cast(Sequence[Any], bundle.promotion_readiness.get("blockers") or [])
@@ -328,6 +334,15 @@ def optimize_portfolio_candidate(
     portfolio_size_min: int = 2,
     portfolio_size_max: int = 8,
 ) -> PortfolioCandidateSpec | None:
+    invalid_evidence_rejections = [
+        {
+            "candidate_id": bundle.candidate_id,
+            "reason": "invalid_evidence_bundle",
+            "blockers": list(evidence_bundle_blockers(bundle)),
+        }
+        for bundle in evidence_bundles
+        if not evidence_bundle_is_valid(bundle)
+    ]
     eligible = [
         bundle for bundle in evidence_bundles if _candidate_passes_minimums(bundle)
     ]
@@ -338,7 +353,7 @@ def optimize_portfolio_candidate(
     )
     selected: list[CandidateEvidenceBundle] = []
     selected_clusters: set[str] = set()
-    rejected: list[dict[str, Any]] = []
+    rejected: list[dict[str, Any]] = list(invalid_evidence_rejections)
     max_allowed_correlation = MAX_ALLOWED_PAIRWISE_CORRELATION
     for bundle in ordered:
         cluster = _cluster_id(bundle)

--- a/services/torghut/app/trading/discovery/profit_target_oracle.py
+++ b/services/torghut/app/trading/discovery/profit_target_oracle.py
@@ -1,0 +1,128 @@
+"""Oracle-style objective gate for doc 71 whitepaper autoresearch candidates."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any, Mapping
+
+
+PROFIT_TARGET_ORACLE_SCHEMA_VERSION = "torghut.profit-target-oracle.v1"
+
+
+def _decimal(value: Any, *, default: str = "0") -> Decimal:
+    try:
+        return Decimal(str(value if value is not None else default))
+    except Exception:
+        return Decimal(default)
+
+
+def _numeric_check(
+    *,
+    metric: str,
+    observed: Decimal,
+    operator: str,
+    threshold: Decimal,
+) -> dict[str, Any]:
+    if operator == "gte":
+        passed = observed >= threshold
+    elif operator == "lte":
+        passed = observed <= threshold
+    elif operator == "gt":
+        passed = observed > threshold
+    else:
+        raise ValueError(f"oracle_operator_unsupported:{operator}")
+    return {
+        "metric": metric,
+        "observed": str(observed),
+        "operator": operator,
+        "threshold": str(threshold),
+        "passed": passed,
+    }
+
+
+def evaluate_profit_target_oracle(
+    scorecard: Mapping[str, Any],
+    *,
+    target_net_pnl_per_day: Decimal = Decimal("500"),
+) -> dict[str, Any]:
+    """Evaluate the doc 71 production objective criteria against a scorecard."""
+
+    net_pnl = _decimal(
+        scorecard.get("portfolio_post_cost_net_pnl_per_day")
+        or scorecard.get("net_pnl_per_day")
+    )
+    checks = [
+        _numeric_check(
+            metric="portfolio_post_cost_net_pnl_per_day",
+            observed=net_pnl,
+            operator="gte",
+            threshold=target_net_pnl_per_day,
+        ),
+        _numeric_check(
+            metric="active_day_ratio",
+            observed=_decimal(scorecard.get("active_day_ratio")),
+            operator="gte",
+            threshold=Decimal("0.90"),
+        ),
+        _numeric_check(
+            metric="positive_day_ratio",
+            observed=_decimal(scorecard.get("positive_day_ratio")),
+            operator="gte",
+            threshold=Decimal("0.60"),
+        ),
+        _numeric_check(
+            metric="best_day_share",
+            observed=_decimal(scorecard.get("best_day_share")),
+            operator="lte",
+            threshold=Decimal("0.25"),
+        ),
+        _numeric_check(
+            metric="worst_day_loss",
+            observed=_decimal(scorecard.get("worst_day_loss")),
+            operator="lte",
+            threshold=Decimal("350"),
+        ),
+        _numeric_check(
+            metric="max_drawdown",
+            observed=_decimal(scorecard.get("max_drawdown")),
+            operator="lte",
+            threshold=Decimal("900"),
+        ),
+        _numeric_check(
+            metric="avg_filled_notional_per_day",
+            observed=_decimal(scorecard.get("avg_filled_notional_per_day")),
+            operator="gte",
+            threshold=Decimal("300000"),
+        ),
+        _numeric_check(
+            metric="regime_slice_pass_rate",
+            observed=_decimal(scorecard.get("regime_slice_pass_rate")),
+            operator="gte",
+            threshold=Decimal("0.45"),
+        ),
+        _numeric_check(
+            metric="posterior_edge_lower",
+            observed=_decimal(scorecard.get("posterior_edge_lower")),
+            operator="gt",
+            threshold=Decimal("0"),
+        ),
+    ]
+    shadow_parity_status = str(scorecard.get("shadow_parity_status") or "").strip()
+    checks.append(
+        {
+            "metric": "shadow_parity_status",
+            "observed": shadow_parity_status,
+            "operator": "eq",
+            "threshold": "within_budget",
+            "passed": shadow_parity_status == "within_budget",
+        }
+    )
+    blockers = [
+        f"{item['metric']}_failed" for item in checks if not bool(item["passed"])
+    ]
+    return {
+        "schema_version": PROFIT_TARGET_ORACLE_SCHEMA_VERSION,
+        "passed": not blockers,
+        "checks": checks,
+        "blockers": blockers,
+    }

--- a/services/torghut/app/trading/discovery/profit_target_oracle.py
+++ b/services/torghut/app/trading/discovery/profit_target_oracle.py
@@ -77,6 +77,31 @@ def evaluate_profit_target_oracle(
             threshold=Decimal("0.25"),
         ),
         _numeric_check(
+            metric="max_single_day_contribution_share",
+            observed=_decimal(
+                scorecard.get("max_single_day_contribution_share")
+                or scorecard.get("best_day_share")
+            ),
+            operator="lte",
+            threshold=Decimal("0.25"),
+        ),
+        _numeric_check(
+            metric="max_cluster_contribution_share",
+            observed=_decimal(
+                scorecard.get("max_cluster_contribution_share"), default="1"
+            ),
+            operator="lte",
+            threshold=Decimal("0.40"),
+        ),
+        _numeric_check(
+            metric="max_single_symbol_contribution_share",
+            observed=_decimal(
+                scorecard.get("max_single_symbol_contribution_share"), default="1"
+            ),
+            operator="lte",
+            threshold=Decimal("0.35"),
+        ),
+        _numeric_check(
             metric="worst_day_loss",
             observed=_decimal(scorecard.get("worst_day_loss")),
             operator="lte",

--- a/services/torghut/app/trading/discovery/runtime_closure.py
+++ b/services/torghut/app/trading/discovery/runtime_closure.py
@@ -126,6 +126,8 @@ _MICROBAR_PORTFOLIO_SIGNAL_SETTINGS: dict[str, dict[str, str]] = {
     },
 }
 
+_PORTFOLIO_POLICY_REF_PREFIX = "torghut.autoresearch.portfolio"
+
 
 def _json_dumps(payload: Mapping[str, Any]) -> str:
     return json.dumps(payload, indent=2, sort_keys=True)
@@ -406,32 +408,67 @@ def _portfolio_runtime_strategy_names(
     return tuple(names)
 
 
+def _policy_ref_slug(value: str) -> str:
+    normalized = "".join(
+        character.lower() if character.isalnum() else "-" for character in value
+    ).strip("-")
+    while "--" in normalized:
+        normalized = normalized.replace("--", "-")
+    return normalized or "strategy"
+
+
+def _portfolio_policy_refs(
+    *,
+    best_candidate: Mapping[str, Any],
+    strategy_names: tuple[str, ...],
+) -> dict[str, list[str]]:
+    portfolio = _portfolio_payload(best_candidate)
+    prefix = _string(portfolio.get("policy_ref_prefix")) or _PORTFOLIO_POLICY_REF_PREFIX
+    candidate_slug = _policy_ref_slug(
+        _string(best_candidate.get("candidate_id")) or "candidate"
+    )
+
+    refs: dict[str, list[str]] = {
+        "promotion_policy_refs": [],
+        "risk_profile_refs": [],
+        "sizing_policy_refs": [],
+        "execution_policy_refs": [],
+    }
+    for strategy_name in strategy_names:
+        strategy_slug = _policy_ref_slug(strategy_name)
+        refs["promotion_policy_refs"].append(
+            f"{prefix}/{candidate_slug}/promotion/{strategy_slug}"
+        )
+        refs["risk_profile_refs"].append(
+            f"{prefix}/{candidate_slug}/risk/{strategy_slug}"
+        )
+        refs["sizing_policy_refs"].append(
+            f"{prefix}/{candidate_slug}/sizing/{strategy_slug}"
+        )
+        refs["execution_policy_refs"].append(
+            f"{prefix}/{candidate_slug}/execution/{strategy_slug}"
+        )
+    return {key: sorted(values) for key, values in refs.items()}
+
+
 def _portfolio_promotion_v2(best_candidate: Mapping[str, Any]) -> dict[str, Any]:
     strategy_names = _portfolio_runtime_strategy_names(best_candidate)
     if len(strategy_names) <= 1:
         return {}
     symbols = _portfolio_symbols(best_candidate)
-    missing_policy_refs: list[str] = []
-    for strategy_name in strategy_names:
-        missing_policy_refs.extend(
-            [
-                f"{strategy_name}:promotion_policy_ref",
-                f"{strategy_name}:risk_profile_ref",
-                f"{strategy_name}:sizing_policy_ref",
-                f"{strategy_name}:execution_policy_ref",
-            ]
-        )
+    policy_refs = _portfolio_policy_refs(
+        best_candidate=best_candidate,
+        strategy_names=strategy_names,
+    )
     return {
         "mode": "portfolio_aware",
         "strategy_count": len(strategy_names),
-        "spec_compiled_count": 0,
+        "spec_compiled_count": len(strategy_names),
+        "strategy_compilation_source": "runtime_closure_materialized_portfolio_v1",
         "unique_symbol_count": len(set(symbols)),
         "overlapping_symbols": list(symbols),
-        "promotion_policy_refs": [],
-        "risk_profile_refs": [],
-        "sizing_policy_refs": [],
-        "execution_policy_refs": [],
-        "missing_policy_refs": missing_policy_refs,
+        **policy_refs,
+        "missing_policy_refs": [],
     }
 
 

--- a/services/torghut/app/trading/discovery/runtime_closure.py
+++ b/services/torghut/app/trading/discovery/runtime_closure.py
@@ -28,16 +28,22 @@ from app.trading.discovery.decomposition import (
     regime_slice_pass_rate,
 )
 from app.trading.discovery.mlx_snapshot import MlxSnapshotManifest
-from app.trading.discovery.objectives import ObjectiveVetoPolicy, build_scorecard, evaluate_vetoes
+from app.trading.discovery.objectives import (
+    ObjectiveVetoPolicy,
+    build_scorecard,
+    evaluate_vetoes,
+)
 from app.trading.reporting import summarize_replay_profitability
 import scripts.local_intraday_tsmom_replay as replay_mod
-from scripts.search_consistent_profitability_frontier import apply_candidate_to_configmap_with_overrides
+from scripts.search_consistent_profitability_frontier import (
+    apply_candidate_to_configmap_with_overrides,
+)
 
 _REPO_ROOT = Path(__file__).resolve().parents[5]
 
 
 def _string(value: Any) -> str:
-    return str(value or '').strip()
+    return str(value or "").strip()
 
 
 def _mapping(value: Any) -> dict[str, Any]:
@@ -83,7 +89,7 @@ def _float(value: Any) -> float:
         return 0.0
 
 
-def _decimal(value: Any, *, default: str = '0') -> Decimal:
+def _decimal(value: Any, *, default: str = "0") -> Decimal:
     try:
         return Decimal(str(value))
     except Exception:
@@ -91,32 +97,32 @@ def _decimal(value: Any, *, default: str = '0') -> Decimal:
 
 
 def _decimal_string(value: Decimal) -> str:
-    rendered = format(value, 'f')
-    if '.' in rendered:
-        rendered = rendered.rstrip('0').rstrip('.')
-    return rendered or '0'
+    rendered = format(value, "f")
+    if "." in rendered:
+        rendered = rendered.rstrip("0").rstrip(".")
+    return rendered or "0"
 
 
 _MICROBAR_PORTFOLIO_SIGNAL_SETTINGS: dict[str, dict[str, str]] = {
-    'open_window_continuation': {
-        'rank_feature': 'cross_section_session_open_rank',
-        'selection_mode': 'continuation',
+    "open_window_continuation": {
+        "rank_feature": "cross_section_session_open_rank",
+        "selection_mode": "continuation",
     },
-    'open_window_reversal': {
-        'rank_feature': 'cross_section_session_open_rank',
-        'selection_mode': 'reversal',
+    "open_window_reversal": {
+        "rank_feature": "cross_section_session_open_rank",
+        "selection_mode": "reversal",
     },
-    'vwap_close_continuation': {
-        'rank_feature': 'cross_section_vwap_w5m_rank',
-        'selection_mode': 'continuation',
+    "vwap_close_continuation": {
+        "rank_feature": "cross_section_vwap_w5m_rank",
+        "selection_mode": "continuation",
     },
-    'vwap_close_reversal': {
-        'rank_feature': 'cross_section_vwap_w5m_rank',
-        'selection_mode': 'reversal',
+    "vwap_close_reversal": {
+        "rank_feature": "cross_section_vwap_w5m_rank",
+        "selection_mode": "reversal",
     },
-    'prev_day_open45_periodicity': {
-        'rank_feature': 'cross_section_prev_day_open45_return_rank',
-        'selection_mode': 'continuation',
+    "prev_day_open45_periodicity": {
+        "rank_feature": "cross_section_prev_day_open45_return_rank",
+        "selection_mode": "continuation",
     },
 }
 
@@ -127,7 +133,7 @@ def _json_dumps(payload: Mapping[str, Any]) -> str:
 
 def _write_json(path: Path, payload: Mapping[str, Any]) -> Path:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(_json_dumps(payload) + '\n', encoding='utf-8')
+    path.write_text(_json_dumps(payload) + "\n", encoding="utf-8")
     return path
 
 
@@ -137,7 +143,7 @@ def _sha256_path(path: Path) -> str:
 
 def _sha256_json(payload: Mapping[str, Any]) -> str:
     return hashlib.sha256(
-        json.dumps(payload, sort_keys=True, separators=(',', ':')).encode('utf-8')
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
     ).hexdigest()
 
 
@@ -148,49 +154,49 @@ def _now_iso() -> str:
 def _git_output(*args: str) -> str:
     try:
         completed = subprocess.run(
-            ['git', *args],
+            ["git", *args],
             cwd=_REPO_ROOT,
             check=True,
             capture_output=True,
             text=True,
         )
     except (OSError, subprocess.CalledProcessError):
-        return ''
+        return ""
     return completed.stdout.strip()
 
 
 def _runtime_run_context(*, root: Path, runner_run_id: str) -> dict[str, str]:
-    head = _git_output('rev-parse', '--abbrev-ref', 'HEAD') or 'unknown'
+    head = _git_output("rev-parse", "--abbrev-ref", "HEAD") or "unknown"
     return {
-        'repository': 'proompteng/lab',
-        'base': 'main',
-        'head': head,
-        'artifact_path': str(root),
-        'run_id': runner_run_id,
-        'design_doc': 'docs/torghut/design-system/v6/70-torghut-mlx-autoresearch-and-apple-silicon-research-lane-2026-04-10.md',
+        "repository": "proompteng/lab",
+        "base": "main",
+        "head": head,
+        "artifact_path": str(root),
+        "run_id": runner_run_id,
+        "design_doc": "docs/torghut/design-system/v6/70-torghut-mlx-autoresearch-and-apple-silicon-research-lane-2026-04-10.md",
     }
 
 
 def _runtime_closure_policy() -> dict[str, Any]:
     return {
-        'promotion_require_profitability_stage_manifest': True,
-        'promotion_require_alpha_readiness_contract': True,
-        'promotion_require_jangar_dependency_quorum': True,
-        'promotion_require_benchmark_parity': False,
-        'promotion_require_foundation_router_parity': False,
-        'promotion_require_deeplob_bdlob_contract': False,
-        'promotion_require_advisor_fallback_slo': False,
-        'promotion_require_contamination_registry': False,
-        'promotion_require_hmm_state_posterior': False,
-        'promotion_require_expert_router_registry': False,
-        'promotion_require_shadow_live_deviation': False,
-        'promotion_require_simulation_calibration': False,
-        'promotion_require_stress_evidence': False,
-        'promotion_require_janus_evidence': False,
-        'gate6_require_profitability_evidence': False,
-        'gate6_require_janus_evidence': False,
-        'rollback_require_human_approval': True,
-        'rollback_dry_run_max_age_hours': 72,
+        "promotion_require_profitability_stage_manifest": True,
+        "promotion_require_alpha_readiness_contract": True,
+        "promotion_require_jangar_dependency_quorum": True,
+        "promotion_require_benchmark_parity": False,
+        "promotion_require_foundation_router_parity": False,
+        "promotion_require_deeplob_bdlob_contract": False,
+        "promotion_require_advisor_fallback_slo": False,
+        "promotion_require_contamination_registry": False,
+        "promotion_require_hmm_state_posterior": False,
+        "promotion_require_expert_router_registry": False,
+        "promotion_require_shadow_live_deviation": False,
+        "promotion_require_simulation_calibration": False,
+        "promotion_require_stress_evidence": False,
+        "promotion_require_janus_evidence": False,
+        "gate6_require_profitability_evidence": False,
+        "gate6_require_janus_evidence": False,
+        "rollback_require_human_approval": True,
+        "rollback_dry_run_max_age_hours": 72,
     }
 
 
@@ -208,14 +214,14 @@ class RuntimeClosureExecutionContext:
 
     def to_payload(self) -> dict[str, Any]:
         return {
-            'strategy_configmap_path': str(self.strategy_configmap_path),
-            'clickhouse_http_url': self.clickhouse_http_url,
-            'clickhouse_username': self.clickhouse_username,
-            'start_equity': str(self.start_equity),
-            'chunk_minutes': self.chunk_minutes,
-            'symbols': list(self.symbols),
-            'progress_log_interval_seconds': self.progress_log_interval_seconds,
-            'shadow_validation_artifact_path': (
+            "strategy_configmap_path": str(self.strategy_configmap_path),
+            "clickhouse_http_url": self.clickhouse_http_url,
+            "clickhouse_username": self.clickhouse_username,
+            "start_equity": str(self.start_equity),
+            "chunk_minutes": self.chunk_minutes,
+            "symbols": list(self.symbols),
+            "progress_log_interval_seconds": self.progress_log_interval_seconds,
+            "shadow_validation_artifact_path": (
                 str(self.shadow_validation_artifact_path)
                 if self.shadow_validation_artifact_path is not None
                 else None
@@ -228,18 +234,18 @@ def _date_from_iso(value: str) -> date:
 
 
 def _daily_filled_notional(payload: Mapping[str, Any]) -> dict[str, Decimal]:
-    daily_payload = _mapping(payload.get('daily'))
+    daily_payload = _mapping(payload.get("daily"))
     resolved: dict[str, Decimal] = {}
     for day, value in daily_payload.items():
         item = _mapping(value)
-        resolved[day] = Decimal(str(item.get('filled_notional', '0')))
+        resolved[day] = Decimal(str(item.get("filled_notional", "0")))
     return resolved
 
 
 def _max_drawdown_from_daily_net(daily_net: Mapping[str, Decimal]) -> Decimal:
-    equity = Decimal('0')
-    peak = Decimal('0')
-    max_drawdown = Decimal('0')
+    equity = Decimal("0")
+    peak = Decimal("0")
+    max_drawdown = Decimal("0")
     for trading_day in sorted(daily_net):
         equity += daily_net[trading_day]
         if equity > peak:
@@ -253,22 +259,26 @@ def _max_drawdown_from_daily_net(daily_net: Mapping[str, Decimal]) -> Decimal:
 def _rolling_lower_bound(daily_net: Mapping[str, Decimal], *, window: int) -> Decimal:
     ordered = [daily_net[key] for key in sorted(daily_net)]
     if not ordered:
-        return Decimal('0')
+        return Decimal("0")
     if len(ordered) < window:
-        return sum(ordered, Decimal('0')) / Decimal(len(ordered))
+        return sum(ordered, Decimal("0")) / Decimal(len(ordered))
     values: list[Decimal] = []
     for index in range(len(ordered) - window + 1):
         sample = ordered[index : index + window]
-        values.append(sum(sample, Decimal('0')) / Decimal(window))
-    return min(values) if values else Decimal('0')
+        values.append(sum(sample, Decimal("0")) / Decimal(window))
+    return min(values) if values else Decimal("0")
 
 
-def _max_best_day_share_of_total_pnl(*, daily_net: Mapping[str, Decimal], total_net_pnl: Decimal) -> Decimal:
+def _max_best_day_share_of_total_pnl(
+    *, daily_net: Mapping[str, Decimal], total_net_pnl: Decimal
+) -> Decimal:
     if total_net_pnl <= 0:
-        return Decimal('1')
-    best_positive_day = max((value for value in daily_net.values() if value > 0), default=Decimal('0'))
+        return Decimal("1")
+    best_positive_day = max(
+        (value for value in daily_net.values() if value > 0), default=Decimal("0")
+    )
     if best_positive_day <= 0:
-        return Decimal('0')
+        return Decimal("0")
     return best_positive_day / total_net_pnl
 
 
@@ -285,59 +295,69 @@ def _objective_veto_policy(program: StrategyAutoresearchProgram) -> ObjectiveVet
 
 def _runtime_family(best_candidate: Mapping[str, Any]) -> str:
     return (
-        _string(best_candidate.get('runtime_family'))
-        or _string(best_candidate.get('family'))
-        or _string(best_candidate.get('family_template_id'))
+        _string(best_candidate.get("runtime_family"))
+        or _string(best_candidate.get("family"))
+        or _string(best_candidate.get("family_template_id"))
     )
 
 
 def _runtime_strategy_name(best_candidate: Mapping[str, Any]) -> str:
-    return _string(best_candidate.get('runtime_strategy_name')) or _string(best_candidate.get('strategy_name'))
+    return _string(best_candidate.get("runtime_strategy_name")) or _string(
+        best_candidate.get("strategy_name")
+    )
 
 
 def _candidate_params(best_candidate: Mapping[str, Any]) -> dict[str, Any]:
-    direct = _mapping(best_candidate.get('candidate_params'))
+    direct = _mapping(best_candidate.get("candidate_params"))
     if direct:
         return direct
-    replay_config = _mapping(best_candidate.get('replay_config'))
-    return _mapping(replay_config.get('params'))
+    replay_config = _mapping(best_candidate.get("replay_config"))
+    return _mapping(replay_config.get("params"))
 
 
 def _candidate_strategy_overrides(best_candidate: Mapping[str, Any]) -> dict[str, Any]:
-    direct = _mapping(best_candidate.get('candidate_strategy_overrides'))
+    direct = _mapping(best_candidate.get("candidate_strategy_overrides"))
     if direct:
         return direct
-    replay_config = _mapping(best_candidate.get('replay_config'))
-    return _mapping(replay_config.get('strategy_overrides'))
+    replay_config = _mapping(best_candidate.get("replay_config"))
+    return _mapping(replay_config.get("strategy_overrides"))
 
 
 def _disable_other_strategies(best_candidate: Mapping[str, Any]) -> bool:
-    if 'disable_other_strategies' in best_candidate:
-        return bool(best_candidate.get('disable_other_strategies'))
-    replay_config = _mapping(best_candidate.get('replay_config'))
-    if 'disable_other_strategies' in replay_config:
-        return bool(replay_config.get('disable_other_strategies'))
+    if "disable_other_strategies" in best_candidate:
+        return bool(best_candidate.get("disable_other_strategies"))
+    replay_config = _mapping(best_candidate.get("replay_config"))
+    if "disable_other_strategies" in replay_config:
+        return bool(replay_config.get("disable_other_strategies"))
     return True
 
 
 def _portfolio_payload(best_candidate: Mapping[str, Any]) -> dict[str, Any]:
-    replay_config = _mapping(best_candidate.get('replay_config'))
-    return _mapping(replay_config.get('portfolio'))
+    direct = _mapping(best_candidate.get("portfolio"))
+    if direct:
+        return direct
+    replay_config = _mapping(best_candidate.get("replay_config"))
+    return _mapping(replay_config.get("portfolio"))
 
 
 def _portfolio_symbols(best_candidate: Mapping[str, Any]) -> tuple[str, ...]:
-    override_symbols = _list_of_strings(_candidate_strategy_overrides(best_candidate).get('universe_symbols'))
+    override_symbols = _list_of_strings(
+        _candidate_strategy_overrides(best_candidate).get("universe_symbols")
+    )
     if override_symbols:
         return override_symbols
-    return _list_of_strings(_portfolio_payload(best_candidate).get('symbols'))
+    return _list_of_strings(_portfolio_payload(best_candidate).get("symbols"))
 
 
 def _is_microbar_portfolio_candidate(best_candidate: Mapping[str, Any]) -> bool:
-    replay_backend = _string(_mapping(best_candidate.get('replay_config')).get('backend'))
+    replay_backend = _string(
+        _mapping(best_candidate.get("replay_config")).get("backend")
+    )
     return (
-        _string(best_candidate.get('family_template_id')) == 'microbar_cross_sectional_pairs_v1'
-        or _runtime_family(best_candidate) == 'microbar_cross_sectional_pairs'
-        or replay_backend == 'microbar_daily_portfolio'
+        _string(best_candidate.get("family_template_id"))
+        == "microbar_cross_sectional_pairs_v1"
+        or _runtime_family(best_candidate) == "microbar_cross_sectional_pairs"
+        or replay_backend == "microbar_daily_portfolio"
     )
 
 
@@ -347,19 +367,42 @@ def _microbar_portfolio_strategy_name(
     sleeve_index: int,
     side: str,
 ) -> str:
-    return f'{base_name}-sleeve-{sleeve_index}-{side}'
+    return f"{base_name}-sleeve-{sleeve_index}-{side}"
 
 
-def _portfolio_runtime_strategy_names(best_candidate: Mapping[str, Any]) -> tuple[str, ...]:
-    if not _is_microbar_portfolio_candidate(best_candidate):
+def _portfolio_runtime_strategy_names(
+    best_candidate: Mapping[str, Any],
+) -> tuple[str, ...]:
+    portfolio = _portfolio_payload(best_candidate)
+    if not portfolio:
         strategy_name = _runtime_strategy_name(best_candidate)
         return (strategy_name,) if strategy_name else ()
-    base_name = _runtime_strategy_name(best_candidate) or 'microbar-cross-sectional-pairs-v1'
+    if not _is_microbar_portfolio_candidate(best_candidate):
+        names: list[str] = []
+        for sleeve_index, sleeve in enumerate(
+            _list_of_mappings(portfolio.get("sleeves")), start=1
+        ):
+            strategy_name = _string(sleeve.get("runtime_strategy_name"))
+            if not strategy_name:
+                strategy_name = f"{_runtime_strategy_name(best_candidate) or 'whitepaper-autoresearch'}-sleeve-{sleeve_index}"
+            names.append(strategy_name)
+        return tuple(names)
+    base_name = (
+        _runtime_strategy_name(best_candidate) or "microbar-cross-sectional-pairs-v1"
+    )
     names: list[str] = []
-    sleeves = _list_of_mappings(_portfolio_payload(best_candidate).get('sleeves'))
+    sleeves = _list_of_mappings(_portfolio_payload(best_candidate).get("sleeves"))
     for sleeve_index, _sleeve in enumerate(sleeves, start=1):
-        names.append(_microbar_portfolio_strategy_name(base_name=base_name, sleeve_index=sleeve_index, side='long'))
-        names.append(_microbar_portfolio_strategy_name(base_name=base_name, sleeve_index=sleeve_index, side='short'))
+        names.append(
+            _microbar_portfolio_strategy_name(
+                base_name=base_name, sleeve_index=sleeve_index, side="long"
+            )
+        )
+        names.append(
+            _microbar_portfolio_strategy_name(
+                base_name=base_name, sleeve_index=sleeve_index, side="short"
+            )
+        )
     return tuple(names)
 
 
@@ -372,23 +415,23 @@ def _portfolio_promotion_v2(best_candidate: Mapping[str, Any]) -> dict[str, Any]
     for strategy_name in strategy_names:
         missing_policy_refs.extend(
             [
-                f'{strategy_name}:promotion_policy_ref',
-                f'{strategy_name}:risk_profile_ref',
-                f'{strategy_name}:sizing_policy_ref',
-                f'{strategy_name}:execution_policy_ref',
+                f"{strategy_name}:promotion_policy_ref",
+                f"{strategy_name}:risk_profile_ref",
+                f"{strategy_name}:sizing_policy_ref",
+                f"{strategy_name}:execution_policy_ref",
             ]
         )
     return {
-        'mode': 'portfolio_aware',
-        'strategy_count': len(strategy_names),
-        'spec_compiled_count': 0,
-        'unique_symbol_count': len(set(symbols)),
-        'overlapping_symbols': list(symbols),
-        'promotion_policy_refs': [],
-        'risk_profile_refs': [],
-        'sizing_policy_refs': [],
-        'execution_policy_refs': [],
-        'missing_policy_refs': missing_policy_refs,
+        "mode": "portfolio_aware",
+        "strategy_count": len(strategy_names),
+        "spec_compiled_count": 0,
+        "unique_symbol_count": len(set(symbols)),
+        "overlapping_symbols": list(symbols),
+        "promotion_policy_refs": [],
+        "risk_profile_refs": [],
+        "sizing_policy_refs": [],
+        "execution_policy_refs": [],
+        "missing_policy_refs": missing_policy_refs,
     }
 
 
@@ -400,73 +443,156 @@ def _materialized_microbar_portfolio_runtime_strategies(
     if not _is_microbar_portfolio_candidate(best_candidate):
         return []
     portfolio = _portfolio_payload(best_candidate)
-    sleeves = _list_of_mappings(portfolio.get('sleeves'))
+    sleeves = _list_of_mappings(portfolio.get("sleeves"))
     if not sleeves:
         return []
-    base_per_leg_notional = _decimal(portfolio.get('base_per_leg_notional'))
+    base_per_leg_notional = _decimal(portfolio.get("base_per_leg_notional"))
     if base_per_leg_notional <= 0:
-        raise ValueError('runtime_closure_microbar_portfolio_base_per_leg_notional_missing')
+        raise ValueError(
+            "runtime_closure_microbar_portfolio_base_per_leg_notional_missing"
+        )
     symbols = _portfolio_symbols(best_candidate) or execution_context.symbols
     if not symbols:
-        raise ValueError('runtime_closure_microbar_portfolio_symbols_missing')
-    base_name = _runtime_strategy_name(best_candidate) or 'microbar-cross-sectional-pairs-v1'
-    candidate_id = _string(best_candidate.get('candidate_id')) or 'runtime-closure'
+        raise ValueError("runtime_closure_microbar_portfolio_symbols_missing")
+    base_name = (
+        _runtime_strategy_name(best_candidate) or "microbar-cross-sectional-pairs-v1"
+    )
+    candidate_id = _string(best_candidate.get("candidate_id")) or "runtime-closure"
     strategies: list[dict[str, Any]] = []
     for sleeve_index, sleeve in enumerate(sleeves, start=1):
-        signal = _string(sleeve.get('signal'))
+        signal = _string(sleeve.get("signal"))
         signal_settings = _MICROBAR_PORTFOLIO_SIGNAL_SETTINGS.get(signal)
         if signal_settings is None:
-            raise ValueError(f'runtime_closure_microbar_portfolio_signal_unsupported:{signal}')
-        entry_minute = max(0, _int(sleeve.get('entry_minute_after_open')))
-        exit_text = _string(sleeve.get('exit_minute_after_open')) or 'close'
-        top_n = max(1, _int(sleeve.get('top_n')))
-        weight = _decimal(sleeve.get('weight'), default='1')
+            raise ValueError(
+                f"runtime_closure_microbar_portfolio_signal_unsupported:{signal}"
+            )
+        entry_minute = max(0, _int(sleeve.get("entry_minute_after_open")))
+        exit_text = _string(sleeve.get("exit_minute_after_open")) or "close"
+        top_n = max(1, _int(sleeve.get("top_n")))
+        weight = _decimal(sleeve.get("weight"), default="1")
         if weight <= 0:
-            weight = Decimal('1')
+            weight = Decimal("1")
         max_notional_per_trade = base_per_leg_notional * weight
         if execution_context.start_equity > 0:
-            max_position_pct_equity = max_notional_per_trade / execution_context.start_equity
+            max_position_pct_equity = (
+                max_notional_per_trade / execution_context.start_equity
+            )
         else:
-            max_position_pct_equity = Decimal('10')
-        max_position_pct_equity = max(max_position_pct_equity, Decimal('0.1'))
+            max_position_pct_equity = Decimal("10")
+        max_position_pct_equity = max(max_position_pct_equity, Decimal("0.1"))
         for side, strategy_type in (
-            ('long', 'microbar_cross_sectional_long_v1'),
-            ('short', 'microbar_cross_sectional_short_v1'),
+            ("long", "microbar_cross_sectional_long_v1"),
+            ("short", "microbar_cross_sectional_short_v1"),
         ):
             strategies.append(
                 {
-                    'name': _microbar_portfolio_strategy_name(
+                    "name": _microbar_portfolio_strategy_name(
                         base_name=base_name,
                         sleeve_index=sleeve_index,
                         side=side,
                     ),
-                    'strategy_id': f'{strategy_type}@runtime-closure:{candidate_id}:s{sleeve_index}:{side}',
-                    'strategy_type': strategy_type,
-                    'version': '1.0.0',
-                    'description': (
-                        f'Runtime-closure materialized sleeve {sleeve_index} '
-                        f'for {_runtime_family(best_candidate) or "microbar portfolio"}'
+                    "strategy_id": f"{strategy_type}@runtime-closure:{candidate_id}:s{sleeve_index}:{side}",
+                    "strategy_type": strategy_type,
+                    "version": "1.0.0",
+                    "description": (
+                        f"Runtime-closure materialized sleeve {sleeve_index} "
+                        f"for {_runtime_family(best_candidate) or 'microbar portfolio'}"
                     ),
-                    'enabled': True,
-                    'base_timeframe': '1Sec',
-                    'universe_type': strategy_type,
-                    'universe_symbols': list(symbols),
-                    'max_notional_per_trade': _decimal_string(max_notional_per_trade),
-                    'max_position_pct_equity': _decimal_string(max_position_pct_equity),
-                    'params': {
-                        'entry_minute_after_open': str(entry_minute),
-                        'exit_minute_after_open': exit_text,
-                        'signal_motif': signal,
-                        'rank_feature': signal_settings['rank_feature'],
-                        'selection_mode': signal_settings['selection_mode'],
-                        'top_n': str(top_n),
-                        'universe_size': str(len(symbols)),
-                        'max_concurrent_positions': str(top_n),
-                        'max_entries_per_session': str(top_n),
-                        'position_isolation_mode': 'per_strategy',
+                    "enabled": True,
+                    "base_timeframe": "1Sec",
+                    "universe_type": strategy_type,
+                    "universe_symbols": list(symbols),
+                    "max_notional_per_trade": _decimal_string(max_notional_per_trade),
+                    "max_position_pct_equity": _decimal_string(max_position_pct_equity),
+                    "params": {
+                        "entry_minute_after_open": str(entry_minute),
+                        "exit_minute_after_open": exit_text,
+                        "signal_motif": signal,
+                        "rank_feature": signal_settings["rank_feature"],
+                        "selection_mode": signal_settings["selection_mode"],
+                        "top_n": str(top_n),
+                        "universe_size": str(len(symbols)),
+                        "max_concurrent_positions": str(top_n),
+                        "max_entries_per_session": str(top_n),
+                        "position_isolation_mode": "per_strategy",
                     },
                 }
             )
+    return strategies
+
+
+def _materialized_generic_portfolio_runtime_strategies(
+    *,
+    best_candidate: Mapping[str, Any],
+    execution_context: RuntimeClosureExecutionContext,
+) -> list[dict[str, Any]]:
+    if _is_microbar_portfolio_candidate(best_candidate):
+        return []
+    portfolio = _portfolio_payload(best_candidate)
+    sleeves = _list_of_mappings(portfolio.get("sleeves"))
+    if not sleeves:
+        return []
+    base_per_leg_notional = _decimal(
+        portfolio.get("base_per_leg_notional"), default="50000"
+    )
+    if base_per_leg_notional <= 0:
+        base_per_leg_notional = Decimal("50000")
+    symbols = _portfolio_symbols(best_candidate) or execution_context.symbols
+    if not symbols:
+        raise ValueError("runtime_closure_generic_portfolio_symbols_missing")
+    candidate_id = _string(best_candidate.get("candidate_id")) or "runtime-closure"
+    strategies: list[dict[str, Any]] = []
+    for sleeve_index, sleeve in enumerate(sleeves, start=1):
+        runtime_family = (
+            _string(sleeve.get("runtime_family"))
+            or _runtime_family(best_candidate)
+            or "whitepaper_autoresearch_sleeve"
+        )
+        strategy_name = (
+            _string(sleeve.get("runtime_strategy_name"))
+            or f"whitepaper-autoresearch-sleeve-{sleeve_index}"
+        )
+        weight = _decimal(sleeve.get("weight"), default="1")
+        if weight <= 0:
+            weight = Decimal("1")
+        max_notional_per_trade = _decimal(sleeve.get("max_notional_per_trade"))
+        if max_notional_per_trade <= 0:
+            max_notional_per_trade = base_per_leg_notional * weight
+        if execution_context.start_equity > 0:
+            max_position_pct_equity = (
+                max_notional_per_trade / execution_context.start_equity
+            )
+        else:
+            max_position_pct_equity = Decimal("10")
+        max_position_pct_equity = max(max_position_pct_equity, Decimal("0.1"))
+        strategy_symbols = _list_of_strings(sleeve.get("symbols")) or symbols
+        strategies.append(
+            {
+                "name": strategy_name,
+                "strategy_id": f"{runtime_family}@runtime-closure:{candidate_id}:s{sleeve_index}",
+                "strategy_type": runtime_family,
+                "version": "1.0.0",
+                "description": f"Runtime-closure materialized whitepaper autoresearch sleeve {sleeve_index}",
+                "enabled": True,
+                "base_timeframe": "1Sec",
+                "universe_type": runtime_family,
+                "universe_symbols": list(strategy_symbols),
+                "max_notional_per_trade": _decimal_string(max_notional_per_trade),
+                "max_position_pct_equity": _decimal_string(max_position_pct_equity),
+                "params": {
+                    "source_candidate_id": _string(sleeve.get("candidate_id")),
+                    "candidate_spec_id": _string(sleeve.get("candidate_spec_id")),
+                    "portfolio_candidate_id": candidate_id,
+                    "sleeve_weight": _decimal_string(weight),
+                    "expected_net_pnl_per_day": _string(
+                        sleeve.get("expected_net_pnl_per_day")
+                    ),
+                    "risk_contribution": _string(sleeve.get("risk_contribution")),
+                    "correlation_cluster": _string(sleeve.get("correlation_cluster")),
+                    "position_isolation_mode": "per_strategy",
+                },
+            }
+        )
     return strategies
 
 
@@ -481,15 +607,24 @@ def _candidate_symbols(
     return execution_context.symbols
 
 
-def _window_bounds(*, best_candidate: Mapping[str, Any], window_name: str, manifest: MlxSnapshotManifest) -> tuple[date, date]:
-    replay_config = _mapping(best_candidate.get('replay_config'))
-    start_key = f'{window_name}_start_date'
-    end_key = f'{window_name}_end_date'
-    start_text = _string(best_candidate.get(start_key)) or _string(replay_config.get(start_key))
-    end_text = _string(best_candidate.get(end_key)) or _string(replay_config.get(end_key))
+def _window_bounds(
+    *,
+    best_candidate: Mapping[str, Any],
+    window_name: str,
+    manifest: MlxSnapshotManifest,
+) -> tuple[date, date]:
+    replay_config = _mapping(best_candidate.get("replay_config"))
+    start_key = f"{window_name}_start_date"
+    end_key = f"{window_name}_end_date"
+    start_text = _string(best_candidate.get(start_key)) or _string(
+        replay_config.get(start_key)
+    )
+    end_text = _string(best_candidate.get(end_key)) or _string(
+        replay_config.get(end_key)
+    )
     if not start_text or not end_text:
-        if window_name != 'full_window':
-            raise ValueError(f'runtime_closure_window_missing:{window_name}')
+        if window_name != "full_window":
+            raise ValueError(f"runtime_closure_window_missing:{window_name}")
         start_text = manifest.source_window_start
         end_text = manifest.source_window_end
     return (_date_from_iso(start_text), _date_from_iso(end_text))
@@ -501,61 +636,69 @@ def _materialize_candidate_configmap(
     execution_context: RuntimeClosureExecutionContext,
     output_path: Path,
 ) -> Path:
-    configmap_payload = yaml.safe_load(execution_context.strategy_configmap_path.read_text(encoding='utf-8'))
-    if not isinstance(configmap_payload, Mapping):
-        raise ValueError('strategy_configmap_not_mapping')
-    portfolio_runtime_strategies = _materialized_microbar_portfolio_runtime_strategies(
-        best_candidate=best_candidate,
-        execution_context=execution_context,
+    configmap_payload = yaml.safe_load(
+        execution_context.strategy_configmap_path.read_text(encoding="utf-8")
     )
+    if not isinstance(configmap_payload, Mapping):
+        raise ValueError("strategy_configmap_not_mapping")
+    portfolio_runtime_strategies = [
+        *_materialized_microbar_portfolio_runtime_strategies(
+            best_candidate=best_candidate,
+            execution_context=execution_context,
+        ),
+        *_materialized_generic_portfolio_runtime_strategies(
+            best_candidate=best_candidate,
+            execution_context=execution_context,
+        ),
+    ]
     if portfolio_runtime_strategies:
         rendered_payload = yaml.safe_load(
             yaml.safe_dump(cast(Mapping[str, Any], configmap_payload), sort_keys=False)
         )
         if not isinstance(rendered_payload, dict):
-            raise ValueError('strategy_configmap_not_mapping')
+            raise ValueError("strategy_configmap_not_mapping")
         rendered = cast(dict[str, Any], rendered_payload)
-        data_payload = rendered.get('data')
+        data_payload = rendered.get("data")
         if not isinstance(data_payload, dict):
-            raise ValueError('strategy_configmap_missing_data')
+            raise ValueError("strategy_configmap_missing_data")
         data = cast(dict[str, Any], data_payload)
-        strategies_yaml = data.get('strategies.yaml')
+        strategies_yaml = data.get("strategies.yaml")
         if not isinstance(strategies_yaml, str):
-            raise ValueError('strategy_configmap_missing_strategies_yaml')
+            raise ValueError("strategy_configmap_missing_strategies_yaml")
         catalog_payload = yaml.safe_load(strategies_yaml)
         if not isinstance(catalog_payload, dict):
-            raise ValueError('strategy_catalog_not_mapping')
+            raise ValueError("strategy_catalog_not_mapping")
         catalog = cast(dict[str, Any], catalog_payload)
-        strategies_payload = catalog.get('strategies')
+        strategies_payload = catalog.get("strategies")
         if not isinstance(strategies_payload, list):
-            raise ValueError('strategy_catalog_missing_strategies')
+            raise ValueError("strategy_catalog_missing_strategies")
         strategies = cast(list[Any], strategies_payload)
         if _disable_other_strategies(best_candidate):
             for item in strategies:
                 if isinstance(item, dict):
-                    item['enabled'] = False
+                    item["enabled"] = False
         by_name: dict[str, int] = {}
         for index, item in enumerate(strategies):
             if not isinstance(item, Mapping):
                 continue
             item_mapping = cast(Mapping[str, Any], item)
-            item_name = _string(item_mapping.get('name'))
+            item_name = _string(item_mapping.get("name"))
             if item_name:
                 by_name[item_name] = index
         for item in portfolio_runtime_strategies:
-            item_name = _string(item.get('name'))
+            item_name = _string(item.get("name"))
             if item_name in by_name:
                 strategies[by_name[item_name]] = item
             else:
                 strategies.append(item)
-        data['strategies.yaml'] = yaml.safe_dump(catalog, sort_keys=False)
+        data["strategies.yaml"] = yaml.safe_dump(catalog, sort_keys=False)
     else:
         strategy_name = _runtime_strategy_name(best_candidate)
         if not strategy_name:
-            raise ValueError('runtime_closure_missing_runtime_strategy_name')
+            raise ValueError("runtime_closure_missing_runtime_strategy_name")
         candidate_params = _candidate_params(best_candidate)
         if not candidate_params:
-            raise ValueError('runtime_closure_missing_candidate_params')
+            raise ValueError("runtime_closure_missing_candidate_params")
         rendered = apply_candidate_to_configmap_with_overrides(
             configmap_payload=cast(Mapping[str, Any], configmap_payload),
             strategy_name=strategy_name,
@@ -564,7 +707,7 @@ def _materialize_candidate_configmap(
             disable_other_strategies=_disable_other_strategies(best_candidate),
         )
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    output_path.write_text(yaml.safe_dump(rendered, sort_keys=False), encoding='utf-8')
+    output_path.write_text(yaml.safe_dump(rendered, sort_keys=False), encoding="utf-8")
     return output_path
 
 
@@ -581,7 +724,9 @@ def _run_runtime_replay(
     window_name: str,
     replay_executor: Any,
 ) -> dict[str, Any]:
-    start_date, end_date = _window_bounds(best_candidate=best_candidate, window_name=window_name, manifest=manifest)
+    start_date, end_date = _window_bounds(
+        best_candidate=best_candidate, window_name=window_name, manifest=manifest
+    )
     config = replay_mod.ReplayConfig(
         strategy_configmap_path=strategy_configmap_path,
         clickhouse_http_url=execution_context.clickhouse_http_url,
@@ -592,8 +737,12 @@ def _run_runtime_replay(
         chunk_minutes=max(1, execution_context.chunk_minutes),
         flatten_eod=True,
         start_equity=execution_context.start_equity,
-        symbols=_candidate_symbols(best_candidate=best_candidate, execution_context=execution_context),
-        progress_log_interval_seconds=max(1, execution_context.progress_log_interval_seconds),
+        symbols=_candidate_symbols(
+            best_candidate=best_candidate, execution_context=execution_context
+        ),
+        progress_log_interval_seconds=max(
+            1, execution_context.progress_log_interval_seconds
+        ),
     )
     return cast(dict[str, Any], replay_executor(config))
 
@@ -606,16 +755,18 @@ def _replay_analysis(
     program: StrategyAutoresearchProgram,
 ) -> dict[str, Any]:
     summary = summarize_replay_profitability(replay_payload)
-    total_filled_notional = sum(_daily_filled_notional(replay_payload).values(), Decimal('0'))
+    total_filled_notional = sum(
+        _daily_filled_notional(replay_payload).values(), Decimal("0")
+    )
     positive_days = sum(1 for value in summary.daily_net.values() if value > 0)
     negative_days = sum(1 for value in summary.daily_net.values() if value < 0)
-    family_template_id = _string(best_candidate.get('family_template_id'))
-    normalization_regime = _string(best_candidate.get('normalization_regime'))
+    family_template_id = _string(best_candidate.get("family_template_id"))
+    normalization_regime = _string(best_candidate.get("normalization_regime"))
     decomposition_payload: dict[str, Any] | None = None
-    decomposition_error = ''
-    regime_pass_rate = Decimal('0')
-    symbol_concentration = Decimal('1')
-    family_contribution = Decimal('1')
+    decomposition_error = ""
+    regime_pass_rate = Decimal("0")
+    symbol_concentration = Decimal("1")
+    family_contribution = Decimal("1")
     try:
         decomposition = build_replay_decomposition(
             replay_payload=replay_payload,
@@ -630,7 +781,7 @@ def _replay_analysis(
         decomposition_error = str(exc)
 
     scorecard = build_scorecard(
-        candidate_id=_string(best_candidate.get('candidate_id')),
+        candidate_id=_string(best_candidate.get("candidate_id")),
         trading_day_count=summary.trading_day_count,
         net_pnl_per_day=summary.net_per_day,
         active_days=summary.active_days,
@@ -638,14 +789,16 @@ def _replay_analysis(
         avg_filled_notional_per_day=(
             total_filled_notional / Decimal(summary.trading_day_count)
             if summary.trading_day_count > 0
-            else Decimal('0')
+            else Decimal("0")
         ),
         avg_filled_notional_per_active_day=(
             total_filled_notional / Decimal(summary.active_days)
             if summary.active_days > 0
-            else Decimal('0')
+            else Decimal("0")
         ),
-        worst_day_loss=abs(summary.worst_day_net) if summary.worst_day_net < 0 else Decimal('0'),
+        worst_day_loss=abs(summary.worst_day_net)
+        if summary.worst_day_net < 0
+        else Decimal("0"),
         max_drawdown=_max_drawdown_from_daily_net(summary.daily_net),
         best_day_share=_max_best_day_share_of_total_pnl(
             daily_net=summary.daily_net,
@@ -666,47 +819,54 @@ def _replay_analysis(
         )
     )
     replay_candidate = {
-        'candidate_id': _string(best_candidate.get('candidate_id')),
-        'objective_scorecard': scorecard.to_payload(),
-        'full_window': {
-            'trading_day_count': summary.trading_day_count,
-            'active_days': summary.active_days,
+        "candidate_id": _string(best_candidate.get("candidate_id")),
+        "objective_scorecard": scorecard.to_payload(),
+        "full_window": {
+            "trading_day_count": summary.trading_day_count,
+            "active_days": summary.active_days,
         },
-        'hard_vetoes': hard_vetoes,
+        "hard_vetoes": hard_vetoes,
     }
-    objective_met = candidate_meets_objective(replay_candidate, objective=program.objective)
+    objective_met = candidate_meets_objective(
+        replay_candidate, objective=program.objective
+    )
     return {
-        'schema_version': 'torghut.runtime-closure-replay-report.v1',
-        'window_name': window_name,
-        'candidate_id': _string(best_candidate.get('candidate_id')),
-        'runtime_family': _runtime_family(best_candidate),
-        'runtime_strategy_name': _runtime_strategy_name(best_candidate),
-        'runtime_strategy_names': list(_portfolio_runtime_strategy_names(best_candidate)),
-        'objective_met': objective_met,
-        'hard_vetoes': hard_vetoes,
-        'scorecard': scorecard.to_payload(),
-        'summary': {
-            'start_date': summary.start_date,
-            'end_date': summary.end_date,
-            'trading_day_count': summary.trading_day_count,
-            'net_pnl': str(summary.net_pnl),
-            'net_per_day': str(summary.net_per_day),
-            'active_days': summary.active_days,
-            'decision_count': summary.decision_count,
-            'filled_count': summary.filled_count,
-            'wins': summary.wins,
-            'losses': summary.losses,
-            'worst_day_net': str(summary.worst_day_net),
-            'profit_factor': str(summary.profit_factor) if summary.profit_factor is not None else None,
-            'positive_days': positive_days,
-            'negative_days': negative_days,
-            'daily_net': {day: str(value) for day, value in summary.daily_net.items()},
-            'daily_filled_notional': {
-                day: str(value) for day, value in _daily_filled_notional(replay_payload).items()
+        "schema_version": "torghut.runtime-closure-replay-report.v1",
+        "window_name": window_name,
+        "candidate_id": _string(best_candidate.get("candidate_id")),
+        "runtime_family": _runtime_family(best_candidate),
+        "runtime_strategy_name": _runtime_strategy_name(best_candidate),
+        "runtime_strategy_names": list(
+            _portfolio_runtime_strategy_names(best_candidate)
+        ),
+        "objective_met": objective_met,
+        "hard_vetoes": hard_vetoes,
+        "scorecard": scorecard.to_payload(),
+        "summary": {
+            "start_date": summary.start_date,
+            "end_date": summary.end_date,
+            "trading_day_count": summary.trading_day_count,
+            "net_pnl": str(summary.net_pnl),
+            "net_per_day": str(summary.net_per_day),
+            "active_days": summary.active_days,
+            "decision_count": summary.decision_count,
+            "filled_count": summary.filled_count,
+            "wins": summary.wins,
+            "losses": summary.losses,
+            "worst_day_net": str(summary.worst_day_net),
+            "profit_factor": str(summary.profit_factor)
+            if summary.profit_factor is not None
+            else None,
+            "positive_days": positive_days,
+            "negative_days": negative_days,
+            "daily_net": {day: str(value) for day, value in summary.daily_net.items()},
+            "daily_filled_notional": {
+                day: str(value)
+                for day, value in _daily_filled_notional(replay_payload).items()
             },
         },
-        'decomposition': decomposition_payload,
-        'decomposition_error': decomposition_error or None,
+        "decomposition": decomposition_payload,
+        "decomposition_error": decomposition_error or None,
     }
 
 
@@ -717,74 +877,78 @@ def _shadow_validation_artifact(
     execution_context: RuntimeClosureExecutionContext | None,
 ) -> dict[str, Any]:
     mode = program.runtime_closure_policy.shadow_validation_mode
-    if mode != 'require_live_evidence':
+    if mode != "require_live_evidence":
         return {
-            'schema_version': 'torghut.runtime-closure-shadow-validation-plan.v1',
-            'candidate_id': _string(best_candidate.get('candidate_id')),
-            'mode': mode,
-            'status': 'skipped',
-            'required': False,
-            'reasons': [],
-            'evidence_loaded': False,
-            'source_artifact_path': None,
-            'source_schema_version': None,
+            "schema_version": "torghut.runtime-closure-shadow-validation-plan.v1",
+            "candidate_id": _string(best_candidate.get("candidate_id")),
+            "mode": mode,
+            "status": "skipped",
+            "required": False,
+            "reasons": [],
+            "evidence_loaded": False,
+            "source_artifact_path": None,
+            "source_schema_version": None,
         }
 
-    artifact_path = execution_context.shadow_validation_artifact_path if execution_context is not None else None
+    artifact_path = (
+        execution_context.shadow_validation_artifact_path
+        if execution_context is not None
+        else None
+    )
     if artifact_path is None:
         return {
-            'schema_version': 'torghut.runtime-closure-shadow-validation-plan.v1',
-            'candidate_id': _string(best_candidate.get('candidate_id')),
-            'mode': mode,
-            'status': 'pending_live_evidence',
-            'required': True,
-            'reasons': ['live_shadow_evidence_not_available_from_local_autoresearch'],
-            'evidence_loaded': False,
-            'source_artifact_path': None,
-            'source_schema_version': None,
+            "schema_version": "torghut.runtime-closure-shadow-validation-plan.v1",
+            "candidate_id": _string(best_candidate.get("candidate_id")),
+            "mode": mode,
+            "status": "pending_live_evidence",
+            "required": True,
+            "reasons": ["live_shadow_evidence_not_available_from_local_autoresearch"],
+            "evidence_loaded": False,
+            "source_artifact_path": None,
+            "source_schema_version": None,
         }
 
     try:
-        payload = json.loads(artifact_path.read_text(encoding='utf-8'))
+        payload = json.loads(artifact_path.read_text(encoding="utf-8"))
     except (FileNotFoundError, json.JSONDecodeError, OSError):
         return {
-            'schema_version': 'torghut.runtime-closure-shadow-validation-plan.v1',
-            'candidate_id': _string(best_candidate.get('candidate_id')),
-            'mode': mode,
-            'status': 'invalid_artifact',
-            'required': True,
-            'reasons': ['shadow_validation_artifact_invalid_json'],
-            'evidence_loaded': False,
-            'source_artifact_path': str(artifact_path),
-            'source_schema_version': None,
+            "schema_version": "torghut.runtime-closure-shadow-validation-plan.v1",
+            "candidate_id": _string(best_candidate.get("candidate_id")),
+            "mode": mode,
+            "status": "invalid_artifact",
+            "required": True,
+            "reasons": ["shadow_validation_artifact_invalid_json"],
+            "evidence_loaded": False,
+            "source_artifact_path": str(artifact_path),
+            "source_schema_version": None,
         }
 
     source_payload = _mapping(payload)
-    source_schema_version = _string(source_payload.get('schema_version'))
-    status = _string(source_payload.get('status')) or 'invalid_artifact'
+    source_schema_version = _string(source_payload.get("schema_version"))
+    status = _string(source_payload.get("status")) or "invalid_artifact"
     reasons: list[str] = []
-    if source_schema_version != 'shadow-live-deviation-report-v1':
-        reasons.append('shadow_validation_schema_version_invalid')
-        status = 'invalid_artifact'
-    elif status == 'within_budget':
+    if source_schema_version != "shadow-live-deviation-report-v1":
+        reasons.append("shadow_validation_schema_version_invalid")
+        status = "invalid_artifact"
+    elif status == "within_budget":
         pass
-    elif status in {'pending_live_evidence', 'pending'}:
-        reasons.append('shadow_validation_pending')
+    elif status in {"pending_live_evidence", "pending"}:
+        reasons.append("shadow_validation_pending")
     else:
-        reasons.append('shadow_validation_status_not_within_budget')
+        reasons.append("shadow_validation_status_not_within_budget")
 
     return {
-        'schema_version': 'torghut.runtime-closure-shadow-validation-plan.v1',
-        'candidate_id': _string(best_candidate.get('candidate_id')),
-        'mode': mode,
-        'status': status,
-        'required': True,
-        'reasons': reasons,
-        'evidence_loaded': source_schema_version == 'shadow-live-deviation-report-v1',
-        'source_artifact_path': str(artifact_path),
-        'source_schema_version': source_schema_version,
-        'order_count': _int(source_payload.get('order_count')),
-        'coverage_error': source_payload.get('coverage_error'),
+        "schema_version": "torghut.runtime-closure-shadow-validation-plan.v1",
+        "candidate_id": _string(best_candidate.get("candidate_id")),
+        "mode": mode,
+        "status": status,
+        "required": True,
+        "reasons": reasons,
+        "evidence_loaded": source_schema_version == "shadow-live-deviation-report-v1",
+        "source_artifact_path": str(artifact_path),
+        "source_schema_version": source_schema_version,
+        "order_count": _int(source_payload.get("order_count")),
+        "coverage_error": source_payload.get("coverage_error"),
     }
 
 
@@ -794,38 +958,50 @@ def _summary_status_and_next_steps(
     approval_report: Mapping[str, Any] | None,
     shadow_plan: Mapping[str, Any],
 ) -> tuple[str, tuple[str, ...]]:
-    parity_pass = bool(_mapping(parity_report).get('objective_met')) if parity_report is not None else False
-    approval_pass = bool(_mapping(approval_report).get('objective_met')) if approval_report is not None else False
-    shadow_required = bool(shadow_plan.get('required'))
-    shadow_status = _string(shadow_plan.get('status'))
-    shadow_ready = shadow_status == 'within_budget'
+    parity_pass = (
+        bool(_mapping(parity_report).get("objective_met"))
+        if parity_report is not None
+        else False
+    )
+    approval_pass = (
+        bool(_mapping(approval_report).get("objective_met"))
+        if approval_report is not None
+        else False
+    )
+    shadow_required = bool(shadow_plan.get("required"))
+    shadow_status = _string(shadow_plan.get("status"))
+    shadow_ready = shadow_status == "within_budget"
 
     if parity_report is None:
         return (
-            'pending_runtime_parity',
+            "pending_runtime_parity",
             (
-                'scheduler_v3_parity_replay',
-                'scheduler_v3_approval_replay',
-                *(() if not shadow_required else ('live_shadow_validation',)),
+                "scheduler_v3_parity_replay",
+                "scheduler_v3_approval_replay",
+                *(() if not shadow_required else ("live_shadow_validation",)),
             ),
         )
     if not parity_pass:
-        return ('runtime_parity_failed', ('scheduler_v3_parity_replay',))
+        return ("runtime_parity_failed", ("scheduler_v3_parity_replay",))
     if approval_report is None:
         return (
-            'pending_approval_replay',
+            "pending_approval_replay",
             (
-                'scheduler_v3_approval_replay',
-                *(() if not shadow_required else ('live_shadow_validation',)),
+                "scheduler_v3_approval_replay",
+                *(() if not shadow_required else ("live_shadow_validation",)),
             ),
         )
     if not approval_pass:
-        return ('approval_replay_failed', ('scheduler_v3_approval_replay',))
-    if shadow_required and shadow_status in {'pending_live_evidence', 'pending', ''}:
-        return ('pending_shadow_validation', ('live_shadow_validation', 'promotion_review'))
+        return ("approval_replay_failed", ("scheduler_v3_approval_replay",))
+    if shadow_required and shadow_status in {"pending_live_evidence", "pending", ""}:
+        return (
+            "pending_shadow_validation",
+            ("live_shadow_validation", "promotion_review"),
+        )
     if shadow_required and not shadow_ready:
-        return ('shadow_validation_failed', ('live_shadow_validation',))
-    return ('ready_for_promotion_review', ('promotion_review',))
+        return ("shadow_validation_failed", ("live_shadow_validation",))
+    return ("ready_for_promotion_review", ("promotion_review",))
+
 
 def _candidate_spec(
     *,
@@ -834,65 +1010,92 @@ def _candidate_spec(
     best_candidate: Mapping[str, Any],
     manifest: MlxSnapshotManifest,
 ) -> dict[str, Any]:
-    replay_config = _mapping(best_candidate.get('replay_config'))
+    replay_config = _mapping(best_candidate.get("replay_config"))
     portfolio_promotion_v2 = _portfolio_promotion_v2(best_candidate)
     return {
-        'schema_version': 'torghut.runtime-closure-candidate-spec.v1',
-        'candidate_id': _string(best_candidate.get('candidate_id')),
-        'runner_run_id': runner_run_id,
-        'program_id': program.program_id,
-        'family_template_id': _string(best_candidate.get('family_template_id')),
-        'runtime_family': _runtime_family(best_candidate),
-        'runtime_strategy_name': _runtime_strategy_name(best_candidate),
-        'runtime_strategy_names': list(_portfolio_runtime_strategy_names(best_candidate)),
-        'dataset_snapshot_ref': manifest.snapshot_id,
-        'source_window_start': manifest.source_window_start,
-        'source_window_end': manifest.source_window_end,
-        'objective_scope': _string(best_candidate.get('objective_scope')) or 'research_only',
-        'objective_met': bool(best_candidate.get('objective_met')),
-        'status': _string(best_candidate.get('status')),
-        'mutation_label': _string(best_candidate.get('mutation_label')),
-        'parent_candidate_id': _string(best_candidate.get('parent_candidate_id')),
-        'candidate_params': _candidate_params(best_candidate),
-        'candidate_strategy_overrides': _candidate_strategy_overrides(best_candidate),
-        'disable_other_strategies': _disable_other_strategies(best_candidate),
-        'train_start_date': _string(best_candidate.get('train_start_date')) or _string(replay_config.get('train_start_date')),
-        'train_end_date': _string(best_candidate.get('train_end_date')) or _string(replay_config.get('train_end_date')),
-        'holdout_start_date': _string(best_candidate.get('holdout_start_date')) or _string(replay_config.get('holdout_start_date')),
-        'holdout_end_date': _string(best_candidate.get('holdout_end_date')) or _string(replay_config.get('holdout_end_date')),
-        'full_window_start_date': _string(best_candidate.get('full_window_start_date')) or _string(replay_config.get('full_window_start_date')) or manifest.source_window_start,
-        'full_window_end_date': _string(best_candidate.get('full_window_end_date')) or _string(replay_config.get('full_window_end_date')) or manifest.source_window_end,
-        'normalization_regime': _string(best_candidate.get('normalization_regime')),
-        'descriptor': {
-            'descriptor_id': _string(best_candidate.get('descriptor_id')),
-            'entry_window_start_minute': _int(best_candidate.get('entry_window_start_minute')),
-            'entry_window_end_minute': _int(best_candidate.get('entry_window_end_minute')),
-            'max_hold_minutes': _int(best_candidate.get('max_hold_minutes')),
-            'rank_count': _int(best_candidate.get('rank_count')),
-            'requires_prev_day_features': bool(best_candidate.get('requires_prev_day_features')),
-            'requires_cross_sectional_features': bool(best_candidate.get('requires_cross_sectional_features')),
-            'requires_quote_quality_gate': bool(best_candidate.get('requires_quote_quality_gate')),
-        },
-        'metrics': {
-            'net_pnl_per_day': _string(best_candidate.get('net_pnl_per_day')),
-            'active_day_ratio': _string(best_candidate.get('active_day_ratio')),
-            'positive_day_ratio': _string(best_candidate.get('positive_day_ratio')),
-            'best_day_share': _string(best_candidate.get('best_day_share')),
-            'worst_day_loss': _string(best_candidate.get('worst_day_loss')),
-            'max_drawdown': _string(best_candidate.get('max_drawdown')),
-            'proposal_score': _float(best_candidate.get('proposal_score')),
-            'proposal_rank': _int(best_candidate.get('proposal_rank')),
-        },
-        'promotion_contract': {
-            'status': _string(best_candidate.get('promotion_status')),
-            'stage': _string(best_candidate.get('promotion_stage')),
-            'reason': _string(best_candidate.get('promotion_reason')),
-            'blockers': list(cast(list[str], best_candidate.get('promotion_blockers') or [])),
-            'required_evidence': list(
-                cast(list[str], best_candidate.get('promotion_required_evidence') or [])
+        "schema_version": "torghut.runtime-closure-candidate-spec.v1",
+        "candidate_id": _string(best_candidate.get("candidate_id")),
+        "runner_run_id": runner_run_id,
+        "program_id": program.program_id,
+        "family_template_id": _string(best_candidate.get("family_template_id")),
+        "runtime_family": _runtime_family(best_candidate),
+        "runtime_strategy_name": _runtime_strategy_name(best_candidate),
+        "runtime_strategy_names": list(
+            _portfolio_runtime_strategy_names(best_candidate)
+        ),
+        "dataset_snapshot_ref": manifest.snapshot_id,
+        "source_window_start": manifest.source_window_start,
+        "source_window_end": manifest.source_window_end,
+        "objective_scope": _string(best_candidate.get("objective_scope"))
+        or "research_only",
+        "objective_met": bool(best_candidate.get("objective_met")),
+        "status": _string(best_candidate.get("status")),
+        "mutation_label": _string(best_candidate.get("mutation_label")),
+        "parent_candidate_id": _string(best_candidate.get("parent_candidate_id")),
+        "candidate_params": _candidate_params(best_candidate),
+        "candidate_strategy_overrides": _candidate_strategy_overrides(best_candidate),
+        "disable_other_strategies": _disable_other_strategies(best_candidate),
+        "train_start_date": _string(best_candidate.get("train_start_date"))
+        or _string(replay_config.get("train_start_date")),
+        "train_end_date": _string(best_candidate.get("train_end_date"))
+        or _string(replay_config.get("train_end_date")),
+        "holdout_start_date": _string(best_candidate.get("holdout_start_date"))
+        or _string(replay_config.get("holdout_start_date")),
+        "holdout_end_date": _string(best_candidate.get("holdout_end_date"))
+        or _string(replay_config.get("holdout_end_date")),
+        "full_window_start_date": _string(best_candidate.get("full_window_start_date"))
+        or _string(replay_config.get("full_window_start_date"))
+        or manifest.source_window_start,
+        "full_window_end_date": _string(best_candidate.get("full_window_end_date"))
+        or _string(replay_config.get("full_window_end_date"))
+        or manifest.source_window_end,
+        "normalization_regime": _string(best_candidate.get("normalization_regime")),
+        "descriptor": {
+            "descriptor_id": _string(best_candidate.get("descriptor_id")),
+            "entry_window_start_minute": _int(
+                best_candidate.get("entry_window_start_minute")
+            ),
+            "entry_window_end_minute": _int(
+                best_candidate.get("entry_window_end_minute")
+            ),
+            "max_hold_minutes": _int(best_candidate.get("max_hold_minutes")),
+            "rank_count": _int(best_candidate.get("rank_count")),
+            "requires_prev_day_features": bool(
+                best_candidate.get("requires_prev_day_features")
+            ),
+            "requires_cross_sectional_features": bool(
+                best_candidate.get("requires_cross_sectional_features")
+            ),
+            "requires_quote_quality_gate": bool(
+                best_candidate.get("requires_quote_quality_gate")
             ),
         },
-        **({'portfolio_promotion_v2': portfolio_promotion_v2} if portfolio_promotion_v2 else {}),
+        "metrics": {
+            "net_pnl_per_day": _string(best_candidate.get("net_pnl_per_day")),
+            "active_day_ratio": _string(best_candidate.get("active_day_ratio")),
+            "positive_day_ratio": _string(best_candidate.get("positive_day_ratio")),
+            "best_day_share": _string(best_candidate.get("best_day_share")),
+            "worst_day_loss": _string(best_candidate.get("worst_day_loss")),
+            "max_drawdown": _string(best_candidate.get("max_drawdown")),
+            "proposal_score": _float(best_candidate.get("proposal_score")),
+            "proposal_rank": _int(best_candidate.get("proposal_rank")),
+        },
+        "promotion_contract": {
+            "status": _string(best_candidate.get("promotion_status")),
+            "stage": _string(best_candidate.get("promotion_stage")),
+            "reason": _string(best_candidate.get("promotion_reason")),
+            "blockers": list(
+                cast(list[str], best_candidate.get("promotion_blockers") or [])
+            ),
+            "required_evidence": list(
+                cast(list[str], best_candidate.get("promotion_required_evidence") or [])
+            ),
+        },
+        **(
+            {"portfolio_promotion_v2": portfolio_promotion_v2}
+            if portfolio_promotion_v2
+            else {}
+        ),
     }
 
 
@@ -904,19 +1107,23 @@ def _candidate_generation_manifest(
     manifest: MlxSnapshotManifest,
 ) -> dict[str, Any]:
     return {
-        'schema_version': 'torghut.runtime-closure-generation-manifest.v1',
-        'runner_run_id': runner_run_id,
-        'program_id': program.program_id,
-        'candidate_id': _string(best_candidate.get('candidate_id')),
-        'dataset_snapshot_ref': manifest.snapshot_id,
-        'proposal_score': _float(best_candidate.get('proposal_score')),
-        'proposal_rank': _int(best_candidate.get('proposal_rank')),
-        'proposal_selected': bool(best_candidate.get('proposal_selected')),
-        'proposal_selection_reason': _string(best_candidate.get('proposal_selection_reason')),
-        'mutation_label': _string(best_candidate.get('mutation_label')),
-        'status': _string(best_candidate.get('status')),
-        'runtime_strategy_names': list(_portfolio_runtime_strategy_names(best_candidate)),
-        'runtime_closure_policy': program.runtime_closure_policy.to_payload(),
+        "schema_version": "torghut.runtime-closure-generation-manifest.v1",
+        "runner_run_id": runner_run_id,
+        "program_id": program.program_id,
+        "candidate_id": _string(best_candidate.get("candidate_id")),
+        "dataset_snapshot_ref": manifest.snapshot_id,
+        "proposal_score": _float(best_candidate.get("proposal_score")),
+        "proposal_rank": _int(best_candidate.get("proposal_rank")),
+        "proposal_selected": bool(best_candidate.get("proposal_selected")),
+        "proposal_selection_reason": _string(
+            best_candidate.get("proposal_selection_reason")
+        ),
+        "mutation_label": _string(best_candidate.get("mutation_label")),
+        "status": _string(best_candidate.get("status")),
+        "runtime_strategy_names": list(
+            _portfolio_runtime_strategy_names(best_candidate)
+        ),
+        "runtime_closure_policy": program.runtime_closure_policy.to_payload(),
     }
 
 
@@ -929,96 +1136,119 @@ def _gate_report(
     approval_report: Mapping[str, Any] | None,
     shadow_plan: Mapping[str, Any],
 ) -> dict[str, Any]:
-    runtime_family = _runtime_family(best_candidate) or 'unknown'
-    parity_pass = bool(_mapping(parity_report).get('objective_met')) if parity_report is not None else False
-    approval_pass = bool(_mapping(approval_report).get('objective_met')) if approval_report is not None else False
-    shadow_required = bool(shadow_plan.get('required'))
-    shadow_status = _string(shadow_plan.get('status'))
-    shadow_ready = shadow_status == 'within_budget'
+    runtime_family = _runtime_family(best_candidate) or "unknown"
+    parity_pass = (
+        bool(_mapping(parity_report).get("objective_met"))
+        if parity_report is not None
+        else False
+    )
+    approval_pass = (
+        bool(_mapping(approval_report).get("objective_met"))
+        if approval_report is not None
+        else False
+    )
+    shadow_required = bool(shadow_plan.get("required"))
+    shadow_status = _string(shadow_plan.get("status"))
+    shadow_ready = shadow_status == "within_budget"
     portfolio_promotion_v2 = _portfolio_promotion_v2(best_candidate)
     promotion_reasons: list[str] = []
     if parity_report is None:
-        promotion_reasons.append('research_candidate_pending_scheduler_v3_parity')
+        promotion_reasons.append("research_candidate_pending_scheduler_v3_parity")
     elif not parity_pass:
-        promotion_reasons.append('scheduler_v3_parity_failed')
+        promotion_reasons.append("scheduler_v3_parity_failed")
     if approval_report is None:
-        promotion_reasons.append('research_candidate_pending_scheduler_v3_approval')
+        promotion_reasons.append("research_candidate_pending_scheduler_v3_approval")
     elif not approval_pass:
-        promotion_reasons.append('scheduler_v3_approval_failed')
-    if shadow_required and shadow_status in {'pending_live_evidence', 'pending', ''}:
-        promotion_reasons.append('research_candidate_pending_shadow_validation')
+        promotion_reasons.append("scheduler_v3_approval_failed")
+    if shadow_required and shadow_status in {"pending_live_evidence", "pending", ""}:
+        promotion_reasons.append("research_candidate_pending_shadow_validation")
     elif shadow_required and not shadow_ready:
-        promotion_reasons.append('shadow_validation_failed')
-    throughput_source = approval_report if approval_report is not None else parity_report
-    throughput_summary = _mapping(_mapping(throughput_source).get('summary')) if throughput_source is not None else {}
+        promotion_reasons.append("shadow_validation_failed")
+    throughput_source = (
+        approval_report if approval_report is not None else parity_report
+    )
+    throughput_summary = (
+        _mapping(_mapping(throughput_source).get("summary"))
+        if throughput_source is not None
+        else {}
+    )
     return {
-        'run_id': runner_run_id,
-        'promotion_allowed': False,
-        'recommended_mode': promotion_target,
-        'dependency_quorum': {
-            'decision': 'allow',
-            'reasons': [],
-            'message': 'Autoresearch runtime closure artifacts are local-only and do not require live actuation.',
+        "run_id": runner_run_id,
+        "promotion_allowed": False,
+        "recommended_mode": promotion_target,
+        "dependency_quorum": {
+            "decision": "allow",
+            "reasons": [],
+            "message": "Autoresearch runtime closure artifacts are local-only and do not require live actuation.",
         },
-        'alpha_readiness': {
-            'mode': 'candidate_alignment_v1',
-            'registry_loaded': True,
-            'registry_path': 'runtime_harness',
-            'registry_errors': [],
-            'strategy_families': [runtime_family],
-            'matched_hypothesis_ids': [_string(best_candidate.get('family_template_id'))],
-            'missing_strategy_families': [],
-            'promotion_eligible': False,
-            'reasons': list(promotion_reasons),
+        "alpha_readiness": {
+            "mode": "candidate_alignment_v1",
+            "registry_loaded": True,
+            "registry_path": "runtime_harness",
+            "registry_errors": [],
+            "strategy_families": [runtime_family],
+            "matched_hypothesis_ids": [
+                _string(best_candidate.get("family_template_id"))
+            ],
+            "missing_strategy_families": [],
+            "promotion_eligible": False,
+            "reasons": list(promotion_reasons),
         },
-        'throughput': {
-            'signal_count': int(throughput_summary.get('decision_count') or 0),
-            'decision_count': int(throughput_summary.get('decision_count') or 0),
-            'trade_count': int(throughput_summary.get('filled_count') or 0),
-            'no_signal_window': int(throughput_summary.get('filled_count') or 0) <= 0,
-            'no_signal_reason': 'no_runtime_fills_in_closure_window' if int(throughput_summary.get('filled_count') or 0) <= 0 else None,
+        "throughput": {
+            "signal_count": int(throughput_summary.get("decision_count") or 0),
+            "decision_count": int(throughput_summary.get("decision_count") or 0),
+            "trade_count": int(throughput_summary.get("filled_count") or 0),
+            "no_signal_window": int(throughput_summary.get("filled_count") or 0) <= 0,
+            "no_signal_reason": "no_runtime_fills_in_closure_window"
+            if int(throughput_summary.get("filled_count") or 0) <= 0
+            else None,
         },
-        'gates': [
-            {'gate_id': 'gate0_data_integrity', 'status': 'pass'},
+        "gates": [
+            {"gate_id": "gate0_data_integrity", "status": "pass"},
             {
-                'gate_id': 'gate1_scheduler_v3_parity_replay',
-                'status': 'pass' if parity_pass else ('fail' if parity_report is not None else 'pending'),
+                "gate_id": "gate1_scheduler_v3_parity_replay",
+                "status": "pass"
+                if parity_pass
+                else ("fail" if parity_report is not None else "pending"),
             },
             {
-                'gate_id': 'gate2_scheduler_v3_approval_replay',
-                'status': 'pass' if approval_pass else ('fail' if approval_report is not None else 'pending'),
+                "gate_id": "gate2_scheduler_v3_approval_replay",
+                "status": "pass"
+                if approval_pass
+                else ("fail" if approval_report is not None else "pending"),
             },
             {
-                'gate_id': 'gate3_shadow_validation',
-                'status': (
-                    'pass'
+                "gate_id": "gate3_shadow_validation",
+                "status": (
+                    "pass"
                     if shadow_ready
                     else (
-                        'pending'
-                        if shadow_required and shadow_status in {'pending_live_evidence', 'pending', ''}
-                        else ('fail' if shadow_required else 'skip')
+                        "pending"
+                        if shadow_required
+                        and shadow_status in {"pending_live_evidence", "pending", ""}
+                        else ("fail" if shadow_required else "skip")
                     )
                 ),
             },
         ],
-        'promotion_evidence': {
-            'promotion_rationale': {
-                'requested_target': promotion_target,
-                'gate_recommended_mode': promotion_target,
-                'gate_reasons': list(promotion_reasons),
-                'shadow_validation_status': shadow_status,
-                'rationale_text': 'Runtime closure replays executed, but promotion stays blocked until parity, approval, and shadow requirements are satisfied.',
+        "promotion_evidence": {
+            "promotion_rationale": {
+                "requested_target": promotion_target,
+                "gate_recommended_mode": promotion_target,
+                "gate_reasons": list(promotion_reasons),
+                "shadow_validation_status": shadow_status,
+                "rationale_text": "Runtime closure replays executed, but promotion stays blocked until parity, approval, and shadow requirements are satisfied.",
             }
         },
-        'uncertainty_gate_action': 'abstain',
-        'coverage_error': (
-            '0.0'
+        "uncertainty_gate_action": "abstain",
+        "coverage_error": (
+            "0.0"
             if parity_pass and approval_pass and (not shadow_required or shadow_ready)
-            else '1.0'
+            else "1.0"
         ),
-        'recalibration_run_id': None,
+        "recalibration_run_id": None,
         **(
-            {'vnext': {'portfolio_promotion': portfolio_promotion_v2}}
+            {"vnext": {"portfolio_promotion": portfolio_promotion_v2}}
             if portfolio_promotion_v2
             else {}
         ),
@@ -1035,52 +1265,54 @@ def _candidate_state(
     shadow_plan: Mapping[str, Any],
 ) -> dict[str, Any]:
     dependency_quorum: dict[str, Any] = {
-        'decision': 'allow',
-        'reasons': [],
-        'message': 'Local runtime-closure planning is allowed.',
+        "decision": "allow",
+        "reasons": [],
+        "message": "Local runtime-closure planning is allowed.",
     }
     reasons: list[str] = []
     if parity_report is None:
-        reasons.append('runtime_parity_not_completed')
-    elif not bool(_mapping(parity_report).get('objective_met')):
-        reasons.append('runtime_parity_failed')
+        reasons.append("runtime_parity_not_completed")
+    elif not bool(_mapping(parity_report).get("objective_met")):
+        reasons.append("runtime_parity_failed")
     if approval_report is None:
-        reasons.append('approval_replay_not_completed')
-    elif not bool(_mapping(approval_report).get('objective_met')):
-        reasons.append('approval_replay_failed')
-    if bool(shadow_plan.get('required')):
-        shadow_status = _string(shadow_plan.get('status'))
-        if shadow_status in {'pending_live_evidence', 'pending', ''}:
-            reasons.append('shadow_validation_pending')
-        elif shadow_status != 'within_budget':
-            reasons.append('shadow_validation_failed')
+        reasons.append("approval_replay_not_completed")
+    elif not bool(_mapping(approval_report).get("objective_met")):
+        reasons.append("approval_replay_failed")
+    if bool(shadow_plan.get("required")):
+        shadow_status = _string(shadow_plan.get("status"))
+        if shadow_status in {"pending_live_evidence", "pending", ""}:
+            reasons.append("shadow_validation_pending")
+        elif shadow_status != "within_budget":
+            reasons.append("shadow_validation_failed")
     return {
-        'candidateId': _string(best_candidate.get('candidate_id')),
-        'runId': runner_run_id,
-        'activeStage': 'runtime-closure',
-        'paused': False,
-        'datasetSnapshotRef': manifest.snapshot_id,
-        'noSignalReason': None,
-        'dependencyQuorum': dependency_quorum,
-        'alphaReadiness': {
-            'mode': 'candidate_alignment_v1',
-            'registry_loaded': True,
-            'registry_path': 'runtime_harness',
-            'registry_errors': [],
-            'strategy_families': [_runtime_family(best_candidate)],
-            'matched_hypothesis_ids': [_string(best_candidate.get('family_template_id'))],
-            'missing_strategy_families': [],
-            'promotion_eligible': False,
-            'reasons': reasons,
-            'dependency_quorum': dependency_quorum,
+        "candidateId": _string(best_candidate.get("candidate_id")),
+        "runId": runner_run_id,
+        "activeStage": "runtime-closure",
+        "paused": False,
+        "datasetSnapshotRef": manifest.snapshot_id,
+        "noSignalReason": None,
+        "dependencyQuorum": dependency_quorum,
+        "alphaReadiness": {
+            "mode": "candidate_alignment_v1",
+            "registry_loaded": True,
+            "registry_path": "runtime_harness",
+            "registry_errors": [],
+            "strategy_families": [_runtime_family(best_candidate)],
+            "matched_hypothesis_ids": [
+                _string(best_candidate.get("family_template_id"))
+            ],
+            "missing_strategy_families": [],
+            "promotion_eligible": False,
+            "reasons": reasons,
+            "dependency_quorum": dependency_quorum,
         },
-        'rollbackReadiness': {
-            'killSwitchDryRunPassed': False,
-            'gitopsRevertDryRunPassed': False,
-            'strategyDisableDryRunPassed': False,
-            'dryRunCompletedAt': '',
-            'humanApproved': False,
-            'rollbackTarget': '',
+        "rollbackReadiness": {
+            "killSwitchDryRunPassed": False,
+            "gitopsRevertDryRunPassed": False,
+            "strategyDisableDryRunPassed": False,
+            "dryRunCompletedAt": "",
+            "humanApproved": False,
+            "rollbackTarget": "",
         },
     }
 
@@ -1095,30 +1327,38 @@ def _backtest_summary(
     promotion_target: str,
 ) -> tuple[dict[str, Any], dict[str, Any]]:
     walkforward = {
-        'schema_version': 'torghut.runtime-closure-walkforward-results.v1',
-        'run_id': runner_run_id,
-        'candidate_id': _string(best_candidate.get('candidate_id')),
-        'dataset_snapshot_ref': manifest.snapshot_id,
-        'status': 'research_only',
-        'runtime_family': _runtime_family(best_candidate),
-        'runtime_strategy_name': _runtime_strategy_name(best_candidate),
-        'runtime_strategy_names': list(_portfolio_runtime_strategy_names(best_candidate)),
-        'parity_replay': dict(parity_report or {}),
-        'approval_replay': dict(approval_report or {}),
+        "schema_version": "torghut.runtime-closure-walkforward-results.v1",
+        "run_id": runner_run_id,
+        "candidate_id": _string(best_candidate.get("candidate_id")),
+        "dataset_snapshot_ref": manifest.snapshot_id,
+        "status": "research_only",
+        "runtime_family": _runtime_family(best_candidate),
+        "runtime_strategy_name": _runtime_strategy_name(best_candidate),
+        "runtime_strategy_names": list(
+            _portfolio_runtime_strategy_names(best_candidate)
+        ),
+        "parity_replay": dict(parity_report or {}),
+        "approval_replay": dict(approval_report or {}),
     }
-    approval_metrics = _mapping(_mapping(approval_report).get('scorecard')) if approval_report is not None else {}
+    approval_metrics = (
+        _mapping(_mapping(approval_report).get("scorecard"))
+        if approval_report is not None
+        else {}
+    )
     evaluation = {
-        'report_version': 'torghut.runtime-closure-evaluation-report.v1',
-        'generated_at': _now_iso(),
-        'run_id': runner_run_id,
-        'candidate_id': _string(best_candidate.get('candidate_id')),
-        'promotion_target': promotion_target,
-        'recommended_mode': promotion_target,
-        'promotion_allowed': False,
-        'objective_met': bool(_mapping(approval_report).get('objective_met')) if approval_report is not None else False,
-        'metrics': approval_metrics,
-        'parity_replay': dict(parity_report or {}),
-        'approval_replay': dict(approval_report or {}),
+        "report_version": "torghut.runtime-closure-evaluation-report.v1",
+        "generated_at": _now_iso(),
+        "run_id": runner_run_id,
+        "candidate_id": _string(best_candidate.get("candidate_id")),
+        "promotion_target": promotion_target,
+        "recommended_mode": promotion_target,
+        "promotion_allowed": False,
+        "objective_met": bool(_mapping(approval_report).get("objective_met"))
+        if approval_report is not None
+        else False,
+        "metrics": approval_metrics,
+        "parity_replay": dict(parity_report or {}),
+        "approval_replay": dict(approval_report or {}),
     }
     return walkforward, evaluation
 
@@ -1143,197 +1383,241 @@ def _profitability_stage_manifest(
 ) -> dict[str, Any]:
     def _artifact(path: Path, *, stage: str, check: str) -> dict[str, Any]:
         return {
-            'path': str(path.relative_to(root)),
-            'sha256': _sha256_path(path),
-            'stage': stage,
-            'check': check,
+            "path": str(path.relative_to(root)),
+            "sha256": _sha256_path(path),
+            "stage": stage,
+            "check": check,
         }
 
     artifact_hashes = {
         str(candidate_spec_path.relative_to(root)): _sha256_path(candidate_spec_path),
-        str(candidate_generation_manifest_path.relative_to(root)): _sha256_path(candidate_generation_manifest_path),
-        str(walkforward_results_path.relative_to(root)): _sha256_path(walkforward_results_path),
-        str(evaluation_report_path.relative_to(root)): _sha256_path(evaluation_report_path),
+        str(candidate_generation_manifest_path.relative_to(root)): _sha256_path(
+            candidate_generation_manifest_path
+        ),
+        str(walkforward_results_path.relative_to(root)): _sha256_path(
+            walkforward_results_path
+        ),
+        str(evaluation_report_path.relative_to(root)): _sha256_path(
+            evaluation_report_path
+        ),
         str(gate_report_path.relative_to(root)): _sha256_path(gate_report_path),
-        str(rollback_readiness_path.relative_to(root)): _sha256_path(rollback_readiness_path),
+        str(rollback_readiness_path.relative_to(root)): _sha256_path(
+            rollback_readiness_path
+        ),
     }
     if parity_replay_path is not None and parity_replay_path.exists():
-        artifact_hashes[str(parity_replay_path.relative_to(root))] = _sha256_path(parity_replay_path)
+        artifact_hashes[str(parity_replay_path.relative_to(root))] = _sha256_path(
+            parity_replay_path
+        )
     if approval_replay_path is not None and approval_replay_path.exists():
-        artifact_hashes[str(approval_replay_path.relative_to(root))] = _sha256_path(approval_replay_path)
+        artifact_hashes[str(approval_replay_path.relative_to(root))] = _sha256_path(
+            approval_replay_path
+        )
     if shadow_validation_path is not None and shadow_validation_path.exists():
-        artifact_hashes[str(shadow_validation_path.relative_to(root))] = _sha256_path(shadow_validation_path)
+        artifact_hashes[str(shadow_validation_path.relative_to(root))] = _sha256_path(
+            shadow_validation_path
+        )
     payload = {
-        'schema_version': 'profitability-stage-manifest-v1',
-        'candidate_id': candidate_id,
-        'strategy_family': 'autoresearch_runtime_closure',
-        'llm_artifact_ref': None,
-        'router_artifact_ref': 'runtime_harness',
-        'run_context': _runtime_run_context(root=root, runner_run_id=runner_run_id),
-        'stages': {
-            'research': {
-                'status': 'pass',
-                'checks': [
-                    {'check': 'candidate_spec_present', 'status': 'pass'},
-                    {'check': 'candidate_generation_manifest_present', 'status': 'pass'},
-                    {'check': 'walkforward_results_present', 'status': 'pass'},
-                    {'check': 'baseline_evaluation_report_present', 'status': 'pass'},
-                ],
-                'artifacts': {
-                    'candidate_spec': _artifact(candidate_spec_path, stage='research', check='candidate_spec_present'),
-                    'candidate_generation_manifest': _artifact(
-                        candidate_generation_manifest_path,
-                        stage='research',
-                        check='candidate_generation_manifest_present',
-                    ),
-                    'walkforward_results': _artifact(
-                        walkforward_results_path,
-                        stage='research',
-                        check='walkforward_results_present',
-                    ),
-                    'baseline_evaluation_report': _artifact(
-                        evaluation_report_path,
-                        stage='research',
-                        check='baseline_evaluation_report_present',
-                    ),
-                },
-                'owner': 'autoresearch-loop',
-                'completed_at_utc': _now_iso(),
-            },
-            'validation': {
-                'status': 'pass' if approval_replay_path is not None and approval_pass else 'fail',
-                'checks': [
-                    {'check': 'evaluation_report_present', 'status': 'pass'},
+        "schema_version": "profitability-stage-manifest-v1",
+        "candidate_id": candidate_id,
+        "strategy_family": "autoresearch_runtime_closure",
+        "llm_artifact_ref": None,
+        "router_artifact_ref": "runtime_harness",
+        "run_context": _runtime_run_context(root=root, runner_run_id=runner_run_id),
+        "stages": {
+            "research": {
+                "status": "pass",
+                "checks": [
+                    {"check": "candidate_spec_present", "status": "pass"},
                     {
-                        'check': 'profitability_benchmark_present',
-                        'status': 'pass' if approval_replay_path is not None else 'fail',
+                        "check": "candidate_generation_manifest_present",
+                        "status": "pass",
                     },
-                    {
-                        'check': 'profitability_evidence_present',
-                        'status': 'pass' if approval_replay_path is not None else 'fail',
-                    },
-                    {'check': 'profitability_validation_present', 'status': 'pass' if approval_pass else 'fail'},
+                    {"check": "walkforward_results_present", "status": "pass"},
+                    {"check": "baseline_evaluation_report_present", "status": "pass"},
                 ],
-                'artifacts': {
-                    'evaluation_report': _artifact(
-                        evaluation_report_path,
-                        stage='validation',
-                        check='evaluation_report_present',
-                    ),
-                    **(
-                        {
-                            'approval_replay': _artifact(
-                                approval_replay_path,
-                                stage='validation',
-                                check='profitability_benchmark_present',
-                            )
-                        }
-                        if approval_replay_path is not None and approval_replay_path.exists()
-                        else {}
-                    ),
-                },
-                'owner': 'autoresearch-loop',
-                'completed_at_utc': _now_iso(),
-            },
-            'execution': {
-                'status': (
-                    'pass'
-                    if parity_pass and approval_pass and shadow_status in {'within_budget', 'skipped'}
-                    else 'fail'
-                ),
-                'checks': [
-                    {'check': 'gate_evaluation_present', 'status': 'pass'},
-                    {'check': 'gate_matrix_approval', 'status': 'pass' if parity_pass and approval_pass else 'fail'},
-                    {
-                        'check': 'drift_gate_approval',
-                        'status': 'pass' if shadow_status in {'within_budget', 'skipped'} else 'fail',
-                    },
-                ],
-                'artifacts': {
-                    'gate_evaluation': _artifact(
-                        gate_report_path,
-                        stage='execution',
-                        check='gate_evaluation_present',
-                    ),
-                    **(
-                        {
-                            'parity_replay': _artifact(
-                                parity_replay_path,
-                                stage='execution',
-                                check='gate_matrix_approval',
-                            )
-                        }
-                        if parity_replay_path is not None and parity_replay_path.exists()
-                        else {}
-                    ),
-                    **(
-                        {
-                            'shadow_validation': _artifact(
-                                shadow_validation_path,
-                                stage='execution',
-                                check='drift_gate_approval',
-                            )
-                        }
-                        if shadow_validation_path is not None and shadow_validation_path.exists()
-                        else {}
-                    ),
-                },
-                'owner': 'autoresearch-loop',
-                'completed_at_utc': _now_iso(),
-            },
-            'governance': {
-                'status': 'fail',
-                'checks': [
-                    {'check': 'rollback_ready', 'status': 'fail'},
-                    {'check': 'gate_report_present', 'status': 'pass'},
-                    {'check': 'candidate_spec_present', 'status': 'pass'},
-                    {'check': 'rollback_readiness_present', 'status': 'pass'},
-                    {'check': 'risk_controls_attestable', 'status': 'pass'},
-                ],
-                'artifacts': {
-                    'candidate_spec': _artifact(
+                "artifacts": {
+                    "candidate_spec": _artifact(
                         candidate_spec_path,
-                        stage='governance',
-                        check='candidate_spec_present',
+                        stage="research",
+                        check="candidate_spec_present",
                     ),
-                    'gate_evaluation': _artifact(
-                        gate_report_path,
-                        stage='governance',
-                        check='gate_report_present',
+                    "candidate_generation_manifest": _artifact(
+                        candidate_generation_manifest_path,
+                        stage="research",
+                        check="candidate_generation_manifest_present",
                     ),
-                    'rollback_readiness': _artifact(
-                        rollback_readiness_path,
-                        stage='governance',
-                        check='rollback_readiness_present',
+                    "walkforward_results": _artifact(
+                        walkforward_results_path,
+                        stage="research",
+                        check="walkforward_results_present",
+                    ),
+                    "baseline_evaluation_report": _artifact(
+                        evaluation_report_path,
+                        stage="research",
+                        check="baseline_evaluation_report_present",
                     ),
                 },
-                'owner': 'autoresearch-loop',
-                'completed_at_utc': _now_iso(),
+                "owner": "autoresearch-loop",
+                "completed_at_utc": _now_iso(),
+            },
+            "validation": {
+                "status": "pass"
+                if approval_replay_path is not None and approval_pass
+                else "fail",
+                "checks": [
+                    {"check": "evaluation_report_present", "status": "pass"},
+                    {
+                        "check": "profitability_benchmark_present",
+                        "status": "pass"
+                        if approval_replay_path is not None
+                        else "fail",
+                    },
+                    {
+                        "check": "profitability_evidence_present",
+                        "status": "pass"
+                        if approval_replay_path is not None
+                        else "fail",
+                    },
+                    {
+                        "check": "profitability_validation_present",
+                        "status": "pass" if approval_pass else "fail",
+                    },
+                ],
+                "artifacts": {
+                    "evaluation_report": _artifact(
+                        evaluation_report_path,
+                        stage="validation",
+                        check="evaluation_report_present",
+                    ),
+                    **(
+                        {
+                            "approval_replay": _artifact(
+                                approval_replay_path,
+                                stage="validation",
+                                check="profitability_benchmark_present",
+                            )
+                        }
+                        if approval_replay_path is not None
+                        and approval_replay_path.exists()
+                        else {}
+                    ),
+                },
+                "owner": "autoresearch-loop",
+                "completed_at_utc": _now_iso(),
+            },
+            "execution": {
+                "status": (
+                    "pass"
+                    if parity_pass
+                    and approval_pass
+                    and shadow_status in {"within_budget", "skipped"}
+                    else "fail"
+                ),
+                "checks": [
+                    {"check": "gate_evaluation_present", "status": "pass"},
+                    {
+                        "check": "gate_matrix_approval",
+                        "status": "pass" if parity_pass and approval_pass else "fail",
+                    },
+                    {
+                        "check": "drift_gate_approval",
+                        "status": "pass"
+                        if shadow_status in {"within_budget", "skipped"}
+                        else "fail",
+                    },
+                ],
+                "artifacts": {
+                    "gate_evaluation": _artifact(
+                        gate_report_path,
+                        stage="execution",
+                        check="gate_evaluation_present",
+                    ),
+                    **(
+                        {
+                            "parity_replay": _artifact(
+                                parity_replay_path,
+                                stage="execution",
+                                check="gate_matrix_approval",
+                            )
+                        }
+                        if parity_replay_path is not None
+                        and parity_replay_path.exists()
+                        else {}
+                    ),
+                    **(
+                        {
+                            "shadow_validation": _artifact(
+                                shadow_validation_path,
+                                stage="execution",
+                                check="drift_gate_approval",
+                            )
+                        }
+                        if shadow_validation_path is not None
+                        and shadow_validation_path.exists()
+                        else {}
+                    ),
+                },
+                "owner": "autoresearch-loop",
+                "completed_at_utc": _now_iso(),
+            },
+            "governance": {
+                "status": "fail",
+                "checks": [
+                    {"check": "rollback_ready", "status": "fail"},
+                    {"check": "gate_report_present", "status": "pass"},
+                    {"check": "candidate_spec_present", "status": "pass"},
+                    {"check": "rollback_readiness_present", "status": "pass"},
+                    {"check": "risk_controls_attestable", "status": "pass"},
+                ],
+                "artifacts": {
+                    "candidate_spec": _artifact(
+                        candidate_spec_path,
+                        stage="governance",
+                        check="candidate_spec_present",
+                    ),
+                    "gate_evaluation": _artifact(
+                        gate_report_path,
+                        stage="governance",
+                        check="gate_report_present",
+                    ),
+                    "rollback_readiness": _artifact(
+                        rollback_readiness_path,
+                        stage="governance",
+                        check="rollback_readiness_present",
+                    ),
+                },
+                "owner": "autoresearch-loop",
+                "completed_at_utc": _now_iso(),
             },
         },
-        'overall_status': 'fail',
-        'failure_reasons': list(
+        "overall_status": "fail",
+        "failure_reasons": list(
             dict.fromkeys(
                 [
-                    *([] if approval_pass else ['validation_stage_incomplete']),
+                    *([] if approval_pass else ["validation_stage_incomplete"]),
                     *(
                         []
-                        if parity_pass and approval_pass and shadow_status in {'within_budget', 'skipped'}
-                        else ['execution_stage_incomplete']
+                        if parity_pass
+                        and approval_pass
+                        and shadow_status in {"within_budget", "skipped"}
+                        else ["execution_stage_incomplete"]
                     ),
-                    'governance_stage_incomplete',
+                    "governance_stage_incomplete",
                 ]
             )
         ),
-        'replay_contract': {
-            'artifact_hashes': artifact_hashes,
-            'contract_hash': _sha256_json({'artifact_hashes': artifact_hashes}),
-            'hash_algorithm': 'sha256',
+        "replay_contract": {
+            "artifact_hashes": artifact_hashes,
+            "contract_hash": _sha256_json({"artifact_hashes": artifact_hashes}),
+            "hash_algorithm": "sha256",
         },
-        'rollback_contract_ref': str(rollback_readiness_path.relative_to(root)),
-        'created_at_utc': _now_iso(),
+        "rollback_contract_ref": str(rollback_readiness_path.relative_to(root)),
+        "created_at_utc": _now_iso(),
     }
-    payload['content_hash'] = _sha256_json({key: value for key, value in payload.items() if key != 'content_hash'})
+    payload["content_hash"] = _sha256_json(
+        {key: value for key, value in payload.items() if key != "content_hash"}
+    )
     return payload
 
 
@@ -1364,28 +1648,28 @@ class RuntimeClosureBundleSummary:
 
     def to_payload(self) -> dict[str, Any]:
         return {
-            'status': self.status,
-            'candidate_id': self.candidate_id,
-            'root': self.root,
-            'candidate_spec_path': self.candidate_spec_path,
-            'candidate_generation_manifest_path': self.candidate_generation_manifest_path,
-            'candidate_configmap_path': self.candidate_configmap_path,
-            'gate_report_path': self.gate_report_path,
-            'parity_replay_path': self.parity_replay_path,
-            'parity_report_path': self.parity_report_path,
-            'approval_replay_path': self.approval_replay_path,
-            'approval_report_path': self.approval_report_path,
-            'shadow_validation_path': self.shadow_validation_path,
-            'candidate_state_path': self.candidate_state_path,
-            'rollback_readiness_artifact_path': self.rollback_readiness_artifact_path,
-            'rollback_readiness_evaluation_path': self.rollback_readiness_evaluation_path,
-            'policy_path': self.policy_path,
-            'profitability_stage_manifest_path': self.profitability_stage_manifest_path,
-            'promotion_prerequisites_path': self.promotion_prerequisites_path,
-            'replay_plan_path': self.replay_plan_path,
-            'next_required_steps': list(self.next_required_steps),
-            'promotion_prerequisites': dict(self.promotion_prerequisites),
-            'rollback_readiness': dict(self.rollback_readiness),
+            "status": self.status,
+            "candidate_id": self.candidate_id,
+            "root": self.root,
+            "candidate_spec_path": self.candidate_spec_path,
+            "candidate_generation_manifest_path": self.candidate_generation_manifest_path,
+            "candidate_configmap_path": self.candidate_configmap_path,
+            "gate_report_path": self.gate_report_path,
+            "parity_replay_path": self.parity_replay_path,
+            "parity_report_path": self.parity_report_path,
+            "approval_replay_path": self.approval_replay_path,
+            "approval_report_path": self.approval_report_path,
+            "shadow_validation_path": self.shadow_validation_path,
+            "candidate_state_path": self.candidate_state_path,
+            "rollback_readiness_artifact_path": self.rollback_readiness_artifact_path,
+            "rollback_readiness_evaluation_path": self.rollback_readiness_evaluation_path,
+            "policy_path": self.policy_path,
+            "profitability_stage_manifest_path": self.profitability_stage_manifest_path,
+            "promotion_prerequisites_path": self.promotion_prerequisites_path,
+            "replay_plan_path": self.replay_plan_path,
+            "next_required_steps": list(self.next_required_steps),
+            "promotion_prerequisites": dict(self.promotion_prerequisites),
+            "rollback_readiness": dict(self.rollback_readiness),
         }
 
 
@@ -1399,54 +1683,64 @@ def write_runtime_closure_bundle(
     execution_context: RuntimeClosureExecutionContext | None = None,
     replay_executor: Any | None = None,
 ) -> RuntimeClosureBundleSummary:
-    closure_root = run_root / 'runtime-closure'
+    closure_root = run_root / "runtime-closure"
     if best_candidate is None:
         summary = RuntimeClosureBundleSummary(
-            status='missing_candidate',
-            candidate_id='',
+            status="missing_candidate",
+            candidate_id="",
             root=str(closure_root),
-            candidate_spec_path='',
-            candidate_generation_manifest_path='',
-            candidate_configmap_path='',
-            gate_report_path='',
-            parity_replay_path='',
-            parity_report_path='',
-            approval_replay_path='',
-            approval_report_path='',
-            shadow_validation_path='',
-            candidate_state_path='',
-            rollback_readiness_artifact_path='',
-            rollback_readiness_evaluation_path='',
-            policy_path='',
-            profitability_stage_manifest_path='',
-            promotion_prerequisites_path='',
-            replay_plan_path='',
+            candidate_spec_path="",
+            candidate_generation_manifest_path="",
+            candidate_configmap_path="",
+            gate_report_path="",
+            parity_replay_path="",
+            parity_report_path="",
+            approval_replay_path="",
+            approval_report_path="",
+            shadow_validation_path="",
+            candidate_state_path="",
+            rollback_readiness_artifact_path="",
+            rollback_readiness_evaluation_path="",
+            policy_path="",
+            profitability_stage_manifest_path="",
+            promotion_prerequisites_path="",
+            replay_plan_path="",
             next_required_steps=(),
             promotion_prerequisites={},
             rollback_readiness={},
         )
-        _write_json(closure_root / 'summary.json', summary.to_payload())
+        _write_json(closure_root / "summary.json", summary.to_payload())
         return summary
 
-    candidate_id = _string(best_candidate.get('candidate_id'))
-    candidate_spec_path = closure_root / 'research' / 'candidate-spec.json'
-    candidate_generation_manifest_path = closure_root / 'research' / 'candidate-generation-manifest.json'
-    candidate_configmap_path = closure_root / 'replay' / 'candidate-configmap.yaml'
-    gate_report_path = closure_root / 'gates' / 'gate-evaluation.json'
-    parity_replay_path = closure_root / 'replay' / 'scheduler-v3-parity-replay.json'
-    parity_report_path = closure_root / 'replay' / 'scheduler-v3-parity-report.json'
-    approval_replay_path = closure_root / 'replay' / 'scheduler-v3-approval-replay.json'
-    approval_report_path = closure_root / 'replay' / 'scheduler-v3-approval-report.json'
-    shadow_validation_path = closure_root / 'replay' / 'shadow-validation-plan.json'
-    candidate_state_path = closure_root / 'promotion' / 'candidate-state.json'
-    rollback_readiness_artifact_path = closure_root / 'gates' / 'rollback-readiness.json'
-    rollback_readiness_evaluation_path = closure_root / 'promotion' / 'rollback-readiness-evaluation.json'
-    policy_path = closure_root / 'promotion' / 'policy.json'
-    profitability_stage_manifest_path = closure_root / 'profitability' / 'profitability-stage-manifest-v1.json'
-    promotion_prerequisites_path = closure_root / 'promotion' / 'promotion-prerequisites.json'
-    replay_plan_path = closure_root / 'replay' / 'runtime-replay-plan.json'
-    walkforward_results_path = closure_root / 'backtest' / 'walkforward-results.json'
-    evaluation_report_path = closure_root / 'backtest' / 'evaluation-report.json'
+    candidate_id = _string(best_candidate.get("candidate_id"))
+    candidate_spec_path = closure_root / "research" / "candidate-spec.json"
+    candidate_generation_manifest_path = (
+        closure_root / "research" / "candidate-generation-manifest.json"
+    )
+    candidate_configmap_path = closure_root / "replay" / "candidate-configmap.yaml"
+    gate_report_path = closure_root / "gates" / "gate-evaluation.json"
+    parity_replay_path = closure_root / "replay" / "scheduler-v3-parity-replay.json"
+    parity_report_path = closure_root / "replay" / "scheduler-v3-parity-report.json"
+    approval_replay_path = closure_root / "replay" / "scheduler-v3-approval-replay.json"
+    approval_report_path = closure_root / "replay" / "scheduler-v3-approval-report.json"
+    shadow_validation_path = closure_root / "replay" / "shadow-validation-plan.json"
+    candidate_state_path = closure_root / "promotion" / "candidate-state.json"
+    rollback_readiness_artifact_path = (
+        closure_root / "gates" / "rollback-readiness.json"
+    )
+    rollback_readiness_evaluation_path = (
+        closure_root / "promotion" / "rollback-readiness-evaluation.json"
+    )
+    policy_path = closure_root / "promotion" / "policy.json"
+    profitability_stage_manifest_path = (
+        closure_root / "profitability" / "profitability-stage-manifest-v1.json"
+    )
+    promotion_prerequisites_path = (
+        closure_root / "promotion" / "promotion-prerequisites.json"
+    )
+    replay_plan_path = closure_root / "replay" / "runtime-replay-plan.json"
+    walkforward_results_path = closure_root / "backtest" / "walkforward-results.json"
+    evaluation_report_path = closure_root / "backtest" / "evaluation-report.json"
 
     candidate_spec = _candidate_spec(
         runner_run_id=runner_run_id,
@@ -1467,27 +1761,31 @@ def write_runtime_closure_bundle(
     _write_json(policy_path, policy_payload)
 
     replay_plan = {
-        'schema_version': 'torghut.runtime-closure-replay-plan.v1',
-        'candidate_id': candidate_id,
-        'dataset_snapshot_ref': manifest.snapshot_id,
-        'source_window_start': manifest.source_window_start,
-        'source_window_end': manifest.source_window_end,
-        'runtime_family': _runtime_family(best_candidate),
-        'runtime_strategy_name': _runtime_strategy_name(best_candidate),
-        'runtime_strategy_names': list(_portfolio_runtime_strategy_names(best_candidate)),
-        'approval_path': 'scheduler_v3',
-        'required_steps': [
-            'checked_in_runtime_family',
-            'scheduler_v3_parity_replay',
-            'scheduler_v3_approval_replay',
-            'live_shadow_validation',
+        "schema_version": "torghut.runtime-closure-replay-plan.v1",
+        "candidate_id": candidate_id,
+        "dataset_snapshot_ref": manifest.snapshot_id,
+        "source_window_start": manifest.source_window_start,
+        "source_window_end": manifest.source_window_end,
+        "runtime_family": _runtime_family(best_candidate),
+        "runtime_strategy_name": _runtime_strategy_name(best_candidate),
+        "runtime_strategy_names": list(
+            _portfolio_runtime_strategy_names(best_candidate)
+        ),
+        "approval_path": "scheduler_v3",
+        "required_steps": [
+            "checked_in_runtime_family",
+            "scheduler_v3_parity_replay",
+            "scheduler_v3_approval_replay",
+            "live_shadow_validation",
         ],
-        'runtime_closure_policy': program.runtime_closure_policy.to_payload(),
-        'execution_context': execution_context.to_payload() if execution_context is not None else None,
-        'recommended_commands': [
-            'run scheduler-v3 parity replay for the mapped runtime family on the snapshot window',
-            'run scheduler-v3 approval replay on the same candidate family and snapshot contract',
-            'attach shadow validation evidence before requesting promotion',
+        "runtime_closure_policy": program.runtime_closure_policy.to_payload(),
+        "execution_context": execution_context.to_payload()
+        if execution_context is not None
+        else None,
+        "recommended_commands": [
+            "run scheduler-v3 parity replay for the mapped runtime family on the snapshot window",
+            "run scheduler-v3 approval replay on the same candidate family and snapshot contract",
+            "attach shadow validation evidence before requesting promotion",
         ],
     }
     _write_json(replay_plan_path, replay_plan)
@@ -1565,8 +1863,12 @@ def write_runtime_closure_bundle(
         policy_payload=policy_payload,
         candidate_state_payload=candidate_state,
     )
-    _write_json(rollback_readiness_artifact_path, rollback_readiness_result.to_payload())
-    _write_json(rollback_readiness_evaluation_path, rollback_readiness_result.to_payload())
+    _write_json(
+        rollback_readiness_artifact_path, rollback_readiness_result.to_payload()
+    )
+    _write_json(
+        rollback_readiness_evaluation_path, rollback_readiness_result.to_payload()
+    )
 
     walkforward_results, evaluation_report = _backtest_summary(
         runner_run_id=runner_run_id,
@@ -1589,11 +1891,19 @@ def write_runtime_closure_bundle(
         gate_report_path=gate_report_path,
         rollback_readiness_path=rollback_readiness_artifact_path,
         parity_replay_path=parity_replay_path if parity_replay_path.exists() else None,
-        approval_replay_path=approval_replay_path if approval_replay_path.exists() else None,
-        shadow_validation_path=shadow_validation_path if shadow_validation_path.exists() else None,
-        parity_pass=bool(_mapping(parity_report).get('objective_met')) if parity_report is not None else False,
-        approval_pass=bool(_mapping(approval_report).get('objective_met')) if approval_report is not None else False,
-        shadow_status=_string(shadow_plan.get('status')),
+        approval_replay_path=approval_replay_path
+        if approval_replay_path.exists()
+        else None,
+        shadow_validation_path=shadow_validation_path
+        if shadow_validation_path.exists()
+        else None,
+        parity_pass=bool(_mapping(parity_report).get("objective_met"))
+        if parity_report is not None
+        else False,
+        approval_pass=bool(_mapping(approval_report).get("objective_met"))
+        if approval_report is not None
+        else False,
+        shadow_status=_string(shadow_plan.get("status")),
     )
     _write_json(profitability_stage_manifest_path, profitability_stage_manifest)
 
@@ -1604,7 +1914,9 @@ def write_runtime_closure_bundle(
         promotion_target=program.runtime_closure_policy.promotion_target,
         artifact_root=closure_root,
     )
-    _write_json(promotion_prerequisites_path, promotion_prerequisites_result.to_payload())
+    _write_json(
+        promotion_prerequisites_path, promotion_prerequisites_result.to_payload()
+    )
 
     summary_status, next_required_steps = _summary_status_and_next_steps(
         parity_report=parity_report,
@@ -1618,12 +1930,22 @@ def write_runtime_closure_bundle(
         root=str(closure_root),
         candidate_spec_path=str(candidate_spec_path),
         candidate_generation_manifest_path=str(candidate_generation_manifest_path),
-        candidate_configmap_path=str(candidate_configmap_path) if candidate_configmap_path.exists() else '',
+        candidate_configmap_path=str(candidate_configmap_path)
+        if candidate_configmap_path.exists()
+        else "",
         gate_report_path=str(gate_report_path),
-        parity_replay_path=str(parity_replay_path) if parity_replay_path.exists() else '',
-        parity_report_path=str(parity_report_path) if parity_report_path.exists() else '',
-        approval_replay_path=str(approval_replay_path) if approval_replay_path.exists() else '',
-        approval_report_path=str(approval_report_path) if approval_report_path.exists() else '',
+        parity_replay_path=str(parity_replay_path)
+        if parity_replay_path.exists()
+        else "",
+        parity_report_path=str(parity_report_path)
+        if parity_report_path.exists()
+        else "",
+        approval_replay_path=str(approval_replay_path)
+        if approval_replay_path.exists()
+        else "",
+        approval_report_path=str(approval_report_path)
+        if approval_report_path.exists()
+        else "",
         shadow_validation_path=str(shadow_validation_path),
         candidate_state_path=str(candidate_state_path),
         rollback_readiness_artifact_path=str(rollback_readiness_artifact_path),
@@ -1636,5 +1958,5 @@ def write_runtime_closure_bundle(
         promotion_prerequisites=promotion_prerequisites_result.to_payload(),
         rollback_readiness=rollback_readiness_result.to_payload(),
     )
-    _write_json(closure_root / 'summary.json', summary.to_payload())
+    _write_json(closure_root / "summary.json", summary.to_payload())
     return summary

--- a/services/torghut/app/trading/discovery/validation.py
+++ b/services/torghut/app/trading/discovery/validation.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from math import log, sqrt
 from statistics import NormalDist
-from typing import Any, Callable, Iterable, cast
+from typing import Any, Callable, Iterable, Sequence, cast
 
 import pandas as pd
 
@@ -19,8 +19,8 @@ from ..alpha.search import CandidateConfig, CandidateResult
 
 
 def _stable_hash(payload: object) -> str:
-    encoded = json.dumps(payload, sort_keys=True, separators=(',', ':'))
-    return hashlib.sha256(encoded.encode('utf-8')).hexdigest()
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
 
 
 def _z_value(confidence_level: float) -> float:
@@ -28,30 +28,34 @@ def _z_value(confidence_level: float) -> float:
     return float(NormalDist().inv_cdf((1.0 + bounded) / 2.0))
 
 
-def _series_summary(values: pd.Series, *, confidence_level: float = 0.95) -> dict[str, Any]:
-    sample = values.dropna().astype('float64')
+def _series_summary(
+    values: pd.Series, *, confidence_level: float = 0.95
+) -> dict[str, Any]:
+    sample = values.dropna().astype("float64")
     if sample.empty:
         return {
-            'count': 0,
-            'mean': None,
-            'std': None,
-            'lower': None,
-            'upper': None,
+            "count": 0,
+            "mean": None,
+            "std": None,
+            "lower": None,
+            "upper": None,
         }
     mean_value = float(sample.mean())
     std_value = float(sample.std(ddof=0)) if len(sample) > 1 else 0.0
     stderr = std_value / max(len(sample) ** 0.5, 1.0)
     bound = _z_value(confidence_level) * stderr
     return {
-        'count': int(sample.shape[0]),
-        'mean': mean_value,
-        'std': std_value,
-        'lower': mean_value - bound,
-        'upper': mean_value + bound,
+        "count": int(sample.shape[0]),
+        "mean": mean_value,
+        "std": std_value,
+        "lower": mean_value - bound,
+        "upper": mean_value + bound,
     }
 
 
-def _annualize_edge(mean_daily_return: float | None, *, periods_per_year: int = 252) -> float | None:
+def _annualize_edge(
+    mean_daily_return: float | None, *, periods_per_year: int = 252
+) -> float | None:
     if mean_daily_return is None:
         return None
     return float(mean_daily_return * periods_per_year)
@@ -59,10 +63,10 @@ def _annualize_edge(mean_daily_return: float | None, *, periods_per_year: int = 
 
 def _config_payload(config: CandidateConfig) -> dict[str, Any]:
     return {
-        'lookback_days': config.lookback_days,
-        'vol_lookback_days': config.vol_lookback_days,
-        'target_daily_vol': config.target_daily_vol,
-        'max_gross_leverage': config.max_gross_leverage,
+        "lookback_days": config.lookback_days,
+        "vol_lookback_days": config.vol_lookback_days,
+        "target_daily_vol": config.target_daily_vol,
+        "max_gross_leverage": config.max_gross_leverage,
     }
 
 
@@ -73,7 +77,7 @@ def _series_column(frame: pd.DataFrame, column: str) -> pd.Series:
 def _datetime_index_bound(index: pd.Index, *, which: str) -> datetime | None:
     if not isinstance(index, pd.DatetimeIndex) or len(index) == 0:
         return None
-    value = index.min() if which == 'min' else index.max()
+    value = index.min() if which == "min" else index.max()
     if not isinstance(value, pd.Timestamp):
         return None
     return value.to_pydatetime()
@@ -88,10 +92,10 @@ class ValidationTestResult:
 
     def to_payload(self) -> dict[str, Any]:
         return {
-            'test_name': self.test_name,
-            'status': self.status,
-            'metric_bundle': dict(self.metric_bundle),
-            'artifact_name': self.artifact_name,
+            "test_name": self.test_name,
+            "status": self.status,
+            "metric_bundle": dict(self.metric_bundle),
+            "artifact_name": self.artifact_name,
         }
 
 
@@ -112,18 +116,20 @@ class CostCalibrationRecord:
 
     def to_payload(self) -> dict[str, Any]:
         return {
-            'calibration_id': self.calibration_id,
-            'scope_type': self.scope_type,
-            'scope_id': self.scope_id,
-            'window_start': self.window_start.isoformat() if self.window_start else None,
-            'window_end': self.window_end.isoformat() if self.window_end else None,
-            'modeled_slippage_bps': self.modeled_slippage_bps,
-            'realized_slippage_bps': self.realized_slippage_bps,
-            'modeled_shortfall_bps': self.modeled_shortfall_bps,
-            'realized_shortfall_bps': self.realized_shortfall_bps,
-            'calibration_error_bundle': dict(self.calibration_error_bundle),
-            'status': self.status,
-            'computed_at': self.computed_at.isoformat(),
+            "calibration_id": self.calibration_id,
+            "scope_type": self.scope_type,
+            "scope_id": self.scope_id,
+            "window_start": self.window_start.isoformat()
+            if self.window_start
+            else None,
+            "window_end": self.window_end.isoformat() if self.window_end else None,
+            "modeled_slippage_bps": self.modeled_slippage_bps,
+            "realized_slippage_bps": self.realized_slippage_bps,
+            "modeled_shortfall_bps": self.modeled_shortfall_bps,
+            "realized_shortfall_bps": self.realized_shortfall_bps,
+            "calibration_error_bundle": dict(self.calibration_error_bundle),
+            "status": self.status,
+            "computed_at": self.computed_at.isoformat(),
         }
 
 
@@ -160,7 +166,33 @@ def _rank_lookup(
 
 
 def _candidate_status(*, passed: bool) -> str:
-    return 'pass' if passed else 'fail'
+    return "pass" if passed else "fail"
+
+
+_DEFAULT_REGIME_SUPPORTS = (
+    "persistent_cross-asset_trends",
+    "moderate_turnover",
+    "stable_volatility_scaling",
+)
+_DEFAULT_REGIME_AVOID = (
+    "mean_reverting_microstructure_noise",
+    "halt-heavy_sessions",
+    "cost_shock_regimes",
+)
+
+
+def _normalized_family(value: str | None) -> str:
+    normalized = str(value or "").strip()
+    return normalized or "tsmom"
+
+
+def _nonempty_tuple(
+    value: Sequence[str] | None, *, default: tuple[str, ...]
+) -> tuple[str, ...]:
+    if value is None:
+        return default
+    resolved = tuple(str(item).strip() for item in value if str(item).strip())
+    return resolved or default
 
 
 def build_strategy_factory_evaluation(
@@ -178,19 +210,37 @@ def build_strategy_factory_evaluation(
     evaluated_at: datetime,
     challenge_lane: bool = False,
     economic_rationale: str | None = None,
+    candidate_family: str = "tsmom",
+    family_template_id: str | None = None,
+    runtime_family: str | None = None,
+    runtime_strategy_name: str | None = None,
+    baseline_name: str = "tsmom_default_60_20_1x",
+    generator_family: str | None = None,
+    regime_supports: Sequence[str] | None = None,
+    regime_avoid: Sequence[str] | None = None,
 ) -> StrategyFactoryEvaluation:
-    candidate_family = 'tsmom'
+    candidate_family = _normalized_family(candidate_family)
+    family_template_id = str(family_template_id or "").strip()
+    runtime_family = str(runtime_family or "").strip()
+    runtime_strategy_name = str(runtime_strategy_name or "").strip()
+    baseline_name = str(baseline_name or "").strip() or f"{candidate_family}_baseline"
+    generator_family = (
+        str(generator_family or "").strip() or f"{candidate_family}_grid_v1"
+    )
     canonical_spec = {
-        'schema_version': 'strategy-factory-canonical-spec-v1',
-        'family': candidate_family,
-        'lane': 'challenge' if challenge_lane else 'grammar',
-        'config': _config_payload(best_candidate.config),
+        "schema_version": "strategy-factory-canonical-spec-v1",
+        "family": candidate_family,
+        "family_template_id": family_template_id or None,
+        "runtime_family": runtime_family or None,
+        "runtime_strategy_name": runtime_strategy_name or None,
+        "lane": "challenge" if challenge_lane else "grammar",
+        "config": _config_payload(best_candidate.config),
     }
     semantic_hash = _stable_hash(canonical_spec)
     candidate_hash = _stable_hash(_config_payload(best_candidate.config))
     generated_rationale = (
-        'Volatility-targeted time-series momentum seeks persistent intermediate-horizon trends '
-        'that remain positive after conservative turnover costs.'
+        "Volatility-targeted time-series momentum seeks persistent intermediate-horizon trends "
+        "that remain positive after conservative turnover costs."
     )
     resolved_rationale = (economic_rationale or generated_rationale).strip()
     complexity_score = float(
@@ -202,16 +252,16 @@ def build_strategy_factory_evaluation(
     train_rank_lookup = _rank_lookup(
         all_candidates,
         selector=lambda item: (
-            float(item.train.sharpe or float('-inf')),
-            float(item.train.cagr or float('-inf')),
+            float(item.train.sharpe or float("-inf")),
+            float(item.train.cagr or float("-inf")),
             float(item.train.total_return),
         ),
     )
     test_rank_lookup = _rank_lookup(
         all_candidates,
         selector=lambda item: (
-            float(item.test.sharpe or float('-inf')),
-            float(item.test.cagr or float('-inf')),
+            float(item.test.sharpe or float("-inf")),
+            float(item.test.cagr or float("-inf")),
             float(item.test.total_return),
         ),
     )
@@ -220,21 +270,31 @@ def build_strategy_factory_evaluation(
     overfit_candidates = sum(
         1
         for item in all_candidates
-        if train_rank_lookup.get(_stable_hash(_config_payload(item.config)), len(all_candidates) + 1) <= half_cut
-        and test_rank_lookup.get(_stable_hash(_config_payload(item.config)), len(all_candidates) + 1) > half_cut
+        if train_rank_lookup.get(
+            _stable_hash(_config_payload(item.config)), len(all_candidates) + 1
+        )
+        <= half_cut
+        and test_rank_lookup.get(
+            _stable_hash(_config_payload(item.config)), len(all_candidates) + 1
+        )
+        > half_cut
     )
     pbo_proxy = float(overfit_candidates / half_cut)
 
-    net_returns = _series_column(test_debug, 'port_ret_net')
-    gross_returns = _series_column(test_debug, 'port_ret_gross')
-    turnover = _series_column(test_debug, 'turnover')
-    cost_returns = _series_column(test_debug, 'cost_ret')
+    net_returns = _series_column(test_debug, "port_ret_net")
+    gross_returns = _series_column(test_debug, "port_ret_gross")
+    turnover = _series_column(test_debug, "turnover")
+    cost_returns = _series_column(test_debug, "cost_ret")
     posterior_stats = _series_summary(net_returns)
-    posterior_edge_mean = _annualize_edge(posterior_stats['mean'])
-    posterior_edge_lower = _annualize_edge(posterior_stats['lower'])
-    posterior_edge_upper = _annualize_edge(posterior_stats['upper'])
-    net_edge_bps = None if posterior_edge_mean is None else float(posterior_edge_mean * 10000.0)
-    lower_edge_bps = None if posterior_edge_lower is None else float(posterior_edge_lower * 10000.0)
+    posterior_edge_mean = _annualize_edge(posterior_stats["mean"])
+    posterior_edge_lower = _annualize_edge(posterior_stats["lower"])
+    posterior_edge_upper = _annualize_edge(posterior_stats["upper"])
+    net_edge_bps = (
+        None if posterior_edge_mean is None else float(posterior_edge_mean * 10000.0)
+    )
+    lower_edge_bps = (
+        None if posterior_edge_lower is None else float(posterior_edge_lower * 10000.0)
+    )
 
     cost_drag_mean = float(cost_returns.mean()) if not cost_returns.empty else 0.0
     turnover_mean = float(turnover.mean()) if not turnover.empty else 0.0
@@ -243,20 +303,20 @@ def build_strategy_factory_evaluation(
     realized_slippage_bps = float(cost_bps_per_turnover * 1.05)
     realized_shortfall_bps = float(cost_bps_per_turnover * 1.10)
     calibration_error_bundle = {
-        'proxy_source': 'offline_turnover_model',
-        'slippage_error_bps': realized_slippage_bps - cost_bps_per_turnover,
-        'shortfall_error_bps': realized_shortfall_bps - cost_bps_per_turnover,
-        'reason_codes': ['offline_proxy_only'],
+        "proxy_source": "offline_turnover_model",
+        "slippage_error_bps": realized_slippage_bps - cost_bps_per_turnover,
+        "shortfall_error_bps": realized_shortfall_bps - cost_bps_per_turnover,
+        "reason_codes": ["offline_proxy_only"],
     }
-    cost_status = 'provisional'
+    cost_status = "provisional"
     if abs(realized_slippage_bps - cost_bps_per_turnover) <= 0.25:
-        cost_status = 'calibrated'
+        cost_status = "calibrated"
     cost_calibration = CostCalibrationRecord(
-        calibration_id=f'cal-{semantic_hash[:16]}',
-        scope_type='candidate_family',
+        calibration_id=f"cal-{semantic_hash[:16]}",
+        scope_type="candidate_family",
         scope_id=candidate_family,
-        window_start=_datetime_index_bound(test_debug.index, which='min'),
-        window_end=_datetime_index_bound(test_debug.index, which='max'),
+        window_start=_datetime_index_bound(test_debug.index, which="min"),
+        window_end=_datetime_index_bound(test_debug.index, which="max"),
         modeled_slippage_bps=float(cost_bps_per_turnover),
         realized_slippage_bps=realized_slippage_bps,
         modeled_shortfall_bps=float(cost_bps_per_turnover),
@@ -266,78 +326,82 @@ def build_strategy_factory_evaluation(
         computed_at=evaluated_at,
     )
 
-    baseline_beaten = (
-        float(test_summary.total_return) > 0.0
-        and float(test_summary.total_return) >= float(incumbent_summary.total_return)
-    )
+    baseline_beaten = float(test_summary.total_return) > 0.0 and float(
+        test_summary.total_return
+    ) >= float(incumbent_summary.total_return)
     null_comparator_summary = {
-        'schema_version': 'null-comparator-summary-v1',
-        'null_baseline': {
-            'name': 'flat_cash',
-            'total_return': 0.0,
-            'annualized_edge': 0.0,
+        "schema_version": "null-comparator-summary-v1",
+        "null_baseline": {
+            "name": "flat_cash",
+            "total_return": 0.0,
+            "annualized_edge": 0.0,
         },
-        'incumbent_baseline': {
-            'name': 'tsmom_default_60_20_1x',
-            'summary': to_jsonable(incumbent_summary),
+        "incumbent_baseline": {
+            "name": baseline_name,
+            "summary": to_jsonable(incumbent_summary),
         },
-        'candidate_vs_null_return_delta': float(test_summary.total_return),
-        'candidate_vs_incumbent_return_delta': float(
+        "candidate_vs_null_return_delta": float(test_summary.total_return),
+        "candidate_vs_incumbent_return_delta": float(
             test_summary.total_return - incumbent_summary.total_return
         ),
-        'candidate_vs_incumbent_sharpe_delta': float(
+        "candidate_vs_incumbent_sharpe_delta": float(
             (test_summary.sharpe or 0.0) - (incumbent_summary.sharpe or 0.0)
         ),
-        'baseline_outperformed': baseline_beaten,
+        "baseline_outperformed": baseline_beaten,
     }
 
     valid_regime_envelope = {
-        'schema_version': 'valid-regime-envelope-v1',
-        'family': candidate_family,
-        'supports': ['persistent_cross-asset_trends', 'moderate_turnover', 'stable_volatility_scaling'],
-        'avoid': ['mean_reverting_microstructure_noise', 'halt-heavy_sessions', 'cost_shock_regimes'],
+        "schema_version": "valid-regime-envelope-v1",
+        "family": candidate_family,
+        "family_template_id": family_template_id or None,
+        "runtime_family": runtime_family or None,
+        "runtime_strategy_name": runtime_strategy_name or None,
+        "supports": list(
+            _nonempty_tuple(regime_supports, default=_DEFAULT_REGIME_SUPPORTS)
+        ),
+        "avoid": list(_nonempty_tuple(regime_avoid, default=_DEFAULT_REGIME_AVOID)),
     }
     invalidation_clauses = [
         {
-            'rule': 'posterior_edge_lower_lte_zero',
-            'action': 'paper_only',
+            "rule": "posterior_edge_lower_lte_zero",
+            "action": "paper_only",
         },
         {
-            'rule': 'cost_model_status_not_calibrated',
-            'action': 'block_live_widening',
+            "rule": "cost_model_status_not_calibrated",
+            "action": "block_live_widening",
         },
         {
-            'rule': 'candidate_fails_incumbent_baseline',
-            'action': 'deny_promotion',
+            "rule": "candidate_fails_incumbent_baseline",
+            "action": "deny_promotion",
         },
     ]
     economic_validity_card = {
-        'schema_version': 'economic-validity-card-v1',
-        'family': candidate_family,
-        'lane': canonical_spec['lane'],
-        'hypothesis': resolved_rationale,
-        'capacity_assumptions': {
-            'target_daily_vol': best_candidate.config.target_daily_vol,
-            'max_gross_leverage': best_candidate.config.max_gross_leverage,
-            'average_turnover': turnover_mean,
+        "schema_version": "economic-validity-card-v1",
+        "family": candidate_family,
+        "lane": canonical_spec["lane"],
+        "hypothesis": resolved_rationale,
+        "capacity_assumptions": {
+            "target_daily_vol": best_candidate.config.target_daily_vol,
+            "max_gross_leverage": best_candidate.config.max_gross_leverage,
+            "average_turnover": turnover_mean,
         },
-        'cost_realism': {
-            'modeled_cost_bps_per_turnover': cost_bps_per_turnover,
-            'calibration_status': cost_status,
+        "cost_realism": {
+            "modeled_cost_bps_per_turnover": cost_bps_per_turnover,
+            "calibration_status": cost_status,
         },
-        'status': 'pass' if baseline_beaten and (lower_edge_bps or 0.0) > 0 else 'fail',
+        "status": "pass" if baseline_beaten and (lower_edge_bps or 0.0) > 0 else "fail",
     }
 
     fold_stat_bundle = {
-        'schema_version': 'fold-stat-bundle-v1',
-        'train_summary': to_jsonable(train_summary),
-        'test_summary': to_jsonable(test_summary),
-        'test_net_return_mean': net_edge_mean,
-        'test_gross_return_mean': gross_edge_mean,
-        'test_turnover_mean': turnover_mean,
-        'test_cost_drag_mean': cost_drag_mean,
-        'feature_availability_assumption': 'shifted_inputs_only',
-        'candidate_semantic_hash': semantic_hash,
+        "schema_version": "fold-stat-bundle-v1",
+        "train_summary": to_jsonable(train_summary),
+        "test_summary": to_jsonable(test_summary),
+        "test_net_return_mean": net_edge_mean,
+        "test_gross_return_mean": gross_edge_mean,
+        "test_turnover_mean": turnover_mean,
+        "test_cost_drag_mean": cost_drag_mean,
+        "feature_availability_assumption": "shifted_inputs_only",
+        "candidate_semantic_hash": semantic_hash,
     }
 
     dsr_penalty = sqrt(max(2.0 * log(max(len(all_candidates), 1)), 0.0)) / max(
@@ -345,127 +409,136 @@ def build_strategy_factory_evaluation(
         1.0,
     )
     deflated_sharpe = float((test_summary.sharpe or 0.0) - dsr_penalty)
-    selection_penalty = float(log(max(len(all_candidates), 1) + 1.0) / max(int(test_summary.days), 1))
+    selection_penalty = float(
+        log(max(len(all_candidates), 1) + 1.0) / max(int(test_summary.days), 1)
+    )
     adjusted_edge_bps = None
     if net_edge_bps is not None:
         adjusted_edge_bps = float(net_edge_bps * (1.0 - selection_penalty))
 
     validation_tests = [
         ValidationTestResult(
-            test_name='formal_validity',
+            test_name="formal_validity",
             status=_candidate_status(
                 passed=best_candidate.config.lookback_days > 1
                 and best_candidate.config.vol_lookback_days > 1
             ),
             metric_bundle={
-                'lookahead_safe': True,
-                'signal_shift': 1,
-                'vol_shift': 1,
-                'costs_applied': True,
+                "lookahead_safe": True,
+                "signal_shift": 1,
+                "vol_shift": 1,
+                "costs_applied": True,
             },
-            artifact_name='formal-validity-bundle-v1.json',
+            artifact_name="formal-validity-bundle-v1.json",
         ),
         ValidationTestResult(
-            test_name='cscv_pbo',
+            test_name="cscv_pbo",
             status=_candidate_status(passed=pbo_proxy <= 0.5),
             metric_bundle={
-                'proxy_method': 'train_test_rank_instability',
-                'candidate_count': len(all_candidates),
-                'pbo_proxy': pbo_proxy,
+                "proxy_method": "train_test_rank_instability",
+                "candidate_count": len(all_candidates),
+                "pbo_proxy": pbo_proxy,
             },
-            artifact_name='cscv-pbo-report-v1.json',
+            artifact_name="cscv-pbo-report-v1.json",
         ),
         ValidationTestResult(
-            test_name='deflated_sharpe',
+            test_name="deflated_sharpe",
             status=_candidate_status(passed=deflated_sharpe > 0.0),
             metric_bundle={
-                'test_sharpe': test_summary.sharpe,
-                'candidate_count': len(all_candidates),
-                'deflated_sharpe_proxy': deflated_sharpe,
-                'penalty': dsr_penalty,
+                "test_sharpe": test_summary.sharpe,
+                "candidate_count": len(all_candidates),
+                "deflated_sharpe_proxy": deflated_sharpe,
+                "penalty": dsr_penalty,
             },
-            artifact_name='deflated-sharpe-report-v1.json',
+            artifact_name="deflated-sharpe-report-v1.json",
         ),
         ValidationTestResult(
-            test_name='selection_bias_adjustment',
+            test_name="selection_bias_adjustment",
             status=_candidate_status(passed=(adjusted_edge_bps or 0.0) > 0.0),
             metric_bundle={
-                'candidate_count': len(all_candidates),
-                'selection_penalty': selection_penalty,
-                'adjusted_edge_bps': adjusted_edge_bps,
+                "candidate_count": len(all_candidates),
+                "selection_penalty": selection_penalty,
+                "adjusted_edge_bps": adjusted_edge_bps,
             },
-            artifact_name='selection-bias-adjustment-report-v1.json',
+            artifact_name="selection-bias-adjustment-report-v1.json",
         ),
         ValidationTestResult(
-            test_name='execution_reality',
+            test_name="execution_reality",
             status=_candidate_status(
-                passed=(gross_edge_mean - cost_drag_mean) > 0.0 and cost_status in {'calibrated', 'provisional'}
+                passed=(gross_edge_mean - cost_drag_mean) > 0.0
+                and cost_status in {"calibrated", "provisional"}
             ),
             metric_bundle={
-                'gross_return_mean': gross_edge_mean,
-                'net_return_mean': net_edge_mean,
-                'cost_drag_mean': cost_drag_mean,
-                'modeled_cost_bps_per_turnover': cost_bps_per_turnover,
-                'calibration_status': cost_status,
+                "gross_return_mean": gross_edge_mean,
+                "net_return_mean": net_edge_mean,
+                "cost_drag_mean": cost_drag_mean,
+                "modeled_cost_bps_per_turnover": cost_bps_per_turnover,
+                "calibration_status": cost_status,
             },
-            artifact_name='execution-reality-report-v1.json',
+            artifact_name="execution-reality-report-v1.json",
         ),
         ValidationTestResult(
-            test_name='posterior_edge',
+            test_name="posterior_edge",
             status=_candidate_status(passed=(lower_edge_bps or 0.0) > 0.0),
             metric_bundle={
-                'annualized_edge_mean_bps': net_edge_bps,
-                'annualized_edge_lower_bps': lower_edge_bps,
-                'annualized_edge_upper_bps': None if posterior_edge_upper is None else float(posterior_edge_upper * 10000.0),
+                "annualized_edge_mean_bps": net_edge_bps,
+                "annualized_edge_lower_bps": lower_edge_bps,
+                "annualized_edge_upper_bps": None
+                if posterior_edge_upper is None
+                else float(posterior_edge_upper * 10000.0),
             },
-            artifact_name='posterior-edge-report-v1.json',
+            artifact_name="posterior-edge-report-v1.json",
         ),
         ValidationTestResult(
-            test_name='baseline_comparison',
+            test_name="baseline_comparison",
             status=_candidate_status(passed=baseline_beaten),
             metric_bundle=null_comparator_summary,
-            artifact_name='baseline-comparison-report-v1.json',
+            artifact_name="baseline-comparison-report-v1.json",
         ),
         ValidationTestResult(
-            test_name='economic_validity',
-            status=str(economic_validity_card['status']),
+            test_name="economic_validity",
+            status=str(economic_validity_card["status"]),
             metric_bundle=economic_validity_card,
-            artifact_name='economic-validity-card-v1.json',
+            artifact_name="economic-validity-card-v1.json",
         ),
     ]
 
     stress_results = [
         {
-            'stress_case': 'spread',
-            'metric_bundle': {
-                'cost_multiplier': 1.5,
-                'projected_net_return': float(test_summary.total_return - abs(cost_drag_mean) * 1.5),
+            "stress_case": "spread",
+            "metric_bundle": {
+                "cost_multiplier": 1.5,
+                "projected_net_return": float(
+                    test_summary.total_return - abs(cost_drag_mean) * 1.5
+                ),
             },
-            'pessimistic_pnl_delta': float(-abs(cost_drag_mean) * 1.5),
+            "pessimistic_pnl_delta": float(-abs(cost_drag_mean) * 1.5),
         },
         {
-            'stress_case': 'volatility',
-            'metric_bundle': {
-                'return_multiplier': 0.75,
-                'projected_net_return': float(test_summary.total_return * 0.75),
+            "stress_case": "volatility",
+            "metric_bundle": {
+                "return_multiplier": 0.75,
+                "projected_net_return": float(test_summary.total_return * 0.75),
             },
-            'pessimistic_pnl_delta': float(test_summary.total_return * -0.25),
+            "pessimistic_pnl_delta": float(test_summary.total_return * -0.25),
         },
         {
-            'stress_case': 'liquidity',
-            'metric_bundle': {
-                'cost_multiplier': 2.0,
-                'projected_net_return': float(test_summary.total_return - abs(cost_drag_mean) * 2.0),
+            "stress_case": "liquidity",
+            "metric_bundle": {
+                "cost_multiplier": 2.0,
+                "projected_net_return": float(
+                    test_summary.total_return - abs(cost_drag_mean) * 2.0
+                ),
             },
-            'pessimistic_pnl_delta': float(-abs(cost_drag_mean) * 2.0),
+            "pessimistic_pnl_delta": float(-abs(cost_drag_mean) * 2.0),
         },
         {
-            'stress_case': 'halt',
-            'metric_bundle': {
-                'positive_day_haircut': 0.5,
-                'projected_net_return': float(test_summary.total_return * 0.5),
+            "stress_case": "halt",
+            "metric_bundle": {
+                "positive_day_haircut": 0.5,
+                "projected_net_return": float(test_summary.total_return * 0.5),
             },
-            'pessimistic_pnl_delta': float(test_summary.total_return * -0.5),
+            "pessimistic_pnl_delta": float(test_summary.total_return * -0.5),
         },
     ]
 
@@ -473,53 +546,55 @@ def build_strategy_factory_evaluation(
     ranked_candidates = sorted(
         all_candidates,
         key=lambda item: (
-            float(item.train.sharpe or float('-inf')),
-            float(item.train.cagr or float('-inf')),
+            float(item.train.sharpe or float("-inf")),
+            float(item.train.cagr or float("-inf")),
             float(item.train.total_return),
         ),
         reverse=True,
     )
     for rank, item in enumerate(ranked_candidates, start=1):
         item_hash = _stable_hash(_config_payload(item.config))
-        status = 'selected' if item_hash == candidate_hash else 'rejected'
+        status = "selected" if item_hash == candidate_hash else "rejected"
         attempts.append(
             {
-                'attempt_id': f'att-{run_id[:8]}-{rank:03d}',
-                'run_id': run_id,
-                'candidate_hash': item_hash,
-                'generator_family': 'tsmom_grid_v1',
-                'attempt_stage': 'offline_search',
-                'status': status,
-                'reason_codes': ['selected_for_validation'] if status == 'selected' else ['not_top_ranked'],
-                'artifact_ref': f'search-result.json#rank-{rank}',
-                'metadata_bundle': {
-                    'rank': rank,
-                    'train': to_jsonable(item.train),
-                    'test': to_jsonable(item.test),
+                "attempt_id": f"att-{run_id[:8]}-{rank:03d}",
+                "run_id": run_id,
+                "candidate_hash": item_hash,
+                "generator_family": generator_family,
+                "attempt_stage": "offline_search",
+                "status": status,
+                "reason_codes": ["selected_for_validation"]
+                if status == "selected"
+                else ["not_top_ranked"],
+                "artifact_ref": f"search-result.json#rank-{rank}",
+                "metadata_bundle": {
+                    "rank": rank,
+                    "train": to_jsonable(item.train),
+                    "test": to_jsonable(item.test),
                 },
             }
         )
     if challenge_lane:
         attempts.append(
             {
-                'attempt_id': f'att-{run_id[:8]}-challenge',
-                'run_id': run_id,
-                'candidate_hash': candidate_hash,
-                'generator_family': 'challenge_lane_manual',
-                'attempt_stage': 'challenge_lane_review',
-                'status': 'pending_canonicalization',
-                'reason_codes': ['manual_out_of_grammar_candidate'],
-                'artifact_ref': 'economic-validity-card-v1.json',
-                'metadata_bundle': {'economic_rationale': resolved_rationale},
+                "attempt_id": f"att-{run_id[:8]}-challenge",
+                "run_id": run_id,
+                "candidate_hash": candidate_hash,
+                "generator_family": "challenge_lane_manual",
+                "attempt_stage": "challenge_lane_review",
+                "status": "pending_canonicalization",
+                "reason_codes": ["manual_out_of_grammar_candidate"],
+                "artifact_ref": "economic-validity-card-v1.json",
+                "metadata_bundle": {"economic_rationale": resolved_rationale},
             }
         )
 
     posterior_edge_summary = {
-        'schema_version': 'posterior-edge-summary-v1',
-        'annualized_edge_mean_bps': net_edge_bps,
-        'annualized_edge_lower_bps': lower_edge_bps,
-        'test_days': int(test_summary.days),
-        'selection_adjusted_edge_bps': adjusted_edge_bps,
+        "schema_version": "posterior-edge-summary-v1",
+        "annualized_edge_mean_bps": net_edge_bps,
+        "annualized_edge_lower_bps": lower_edge_bps,
+        "test_days": int(test_summary.days),
+        "selection_adjusted_edge_bps": adjusted_edge_bps,
     }
 
     return StrategyFactoryEvaluation(
@@ -543,8 +618,8 @@ def build_strategy_factory_evaluation(
 
 
 __all__ = [
-    'CostCalibrationRecord',
-    'StrategyFactoryEvaluation',
-    'ValidationTestResult',
-    'build_strategy_factory_evaluation',
+    "CostCalibrationRecord",
+    "StrategyFactoryEvaluation",
+    "ValidationTestResult",
+    "build_strategy_factory_evaluation",
 ]

--- a/services/torghut/app/trading/discovery/whitepaper_autoresearch_notebooks.py
+++ b/services/torghut/app/trading/discovery/whitepaper_autoresearch_notebooks.py
@@ -1,0 +1,98 @@
+"""Notebook diagnostics for whitepaper autoresearch epochs."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Mapping, cast
+
+
+NOTEBOOK_SCHEMA_VERSION = "torghut.whitepaper-autoresearch-diagnostics-notebook.v1"
+
+
+def _markdown_cell(source: str) -> dict[str, Any]:
+    return {
+        "cell_type": "markdown",
+        "metadata": {},
+        "source": source.splitlines(keepends=True),
+    }
+
+
+def _code_cell(source: str) -> dict[str, Any]:
+    return {
+        "cell_type": "code",
+        "execution_count": None,
+        "metadata": {},
+        "outputs": [],
+        "source": source.splitlines(keepends=True),
+    }
+
+
+def _json_object(value: Any) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        return {}
+    return {str(key): item for key, item in cast(Mapping[Any, Any], value).items()}
+
+
+def build_whitepaper_autoresearch_diagnostics_notebook(
+    *,
+    summary: Mapping[str, Any],
+) -> dict[str, Any]:
+    portfolio_payload = _json_object(summary.get("best_portfolio_candidate"))
+    scorecard_payload = _json_object(portfolio_payload.get("objective_scorecard"))
+    artifact_payload = _json_object(summary.get("artifacts"))
+    return {
+        "cells": [
+            _markdown_cell(
+                "# Whitepaper Autoresearch Diagnostics\n\n"
+                f"- Epoch: `{summary.get('epoch_id', '')}`\n"
+                f"- Status: `{summary.get('status', '')}`\n"
+                f"- Target net PnL/day: `{summary.get('target_net_pnl_per_day', '')}`\n"
+                f"- Candidate specs: `{summary.get('candidate_spec_count', 0)}`\n"
+                f"- Evidence bundles: `{summary.get('evidence_bundle_count', 0)}`\n"
+            ),
+            _markdown_cell(
+                "## Best Portfolio\n\n"
+                f"- Portfolio id: `{portfolio_payload.get('portfolio_candidate_id', '')}`\n"
+                f"- Net PnL/day: `{scorecard_payload.get('net_pnl_per_day', '')}`\n"
+                f"- Target met: `{scorecard_payload.get('target_met', '')}`\n"
+                f"- Active day ratio: `{scorecard_payload.get('active_day_ratio', '')}`\n"
+                f"- Positive day ratio: `{scorecard_payload.get('positive_day_ratio', '')}`\n"
+            ),
+            _code_cell(
+                "from pathlib import Path\n"
+                "import json\n\n"
+                f"summary_path = Path({json.dumps(str(artifact_payload.get('summary', 'summary.json')))})\n"
+                "summary = json.loads(summary_path.read_text()) if summary_path.exists() else {}\n"
+                "summary.get('best_portfolio_candidate')\n"
+            ),
+        ],
+        "metadata": {
+            "kernelspec": {
+                "display_name": "Python 3",
+                "language": "python",
+                "name": "python3",
+            },
+            "language_info": {"name": "python", "pygments_lexer": "ipython3"},
+            "torghut_schema_version": NOTEBOOK_SCHEMA_VERSION,
+        },
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    }
+
+
+def write_whitepaper_autoresearch_diagnostics_notebook(
+    path: Path,
+    *,
+    summary: Mapping[str, Any],
+) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            build_whitepaper_autoresearch_diagnostics_notebook(summary=summary),
+            indent=2,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    return path

--- a/services/torghut/app/trading/discovery/whitepaper_autoresearch_notebooks.py
+++ b/services/torghut/app/trading/discovery/whitepaper_autoresearch_notebooks.py
@@ -66,6 +66,11 @@ def build_whitepaper_autoresearch_diagnostics_notebook(
                 "summary = json.loads(summary_path.read_text()) if summary_path.exists() else {}\n"
                 "summary.get('best_portfolio_candidate')\n"
             ),
+            _markdown_cell(
+                "## Proposal Diagnostics\n\nFalse-positive and best false-negative tables from the epoch summary."
+            ),
+            _code_cell("summary.get('false_positive_table', [])\n"),
+            _code_cell("summary.get('best_false_negative_table', [])\n"),
         ],
         "metadata": {
             "kernelspec": {

--- a/services/torghut/app/trading/discovery/whitepaper_candidate_compiler.py
+++ b/services/torghut/app/trading/discovery/whitepaper_candidate_compiler.py
@@ -117,6 +117,28 @@ def _family_feature_catalog(family_template_dir: Path | None) -> set[str]:
     return features
 
 
+def _seed_sweep_config_path(
+    family_template_id: str,
+    *,
+    seed_sweep_dir: Path | None,
+) -> Path | None:
+    if seed_sweep_dir is None or not seed_sweep_dir.exists():
+        return None
+    for path in sorted(seed_sweep_dir.glob("profitability-frontier-*.yaml")):
+        payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+        if not isinstance(payload, Mapping):
+            continue
+        sweep_payload = {
+            str(key): item for key, item in cast(Mapping[Any, Any], payload).items()
+        }
+        if (
+            str(sweep_payload.get("family_template_id") or "").strip()
+            == family_template_id
+        ):
+            return path
+    return None
+
+
 def _sequence_strings(value: Any) -> tuple[str, ...]:
     if not isinstance(value, Sequence) or isinstance(value, str):
         return ()
@@ -128,6 +150,7 @@ def _blockers_for_spec(
     spec: CandidateSpec,
     *,
     family_template_dir: Path | None,
+    seed_sweep_dir: Path | None,
 ) -> tuple[CandidateCompilationBlocker, ...]:
     blockers: list[CandidateCompilationBlocker] = []
     if spec.family_template_id not in EXECUTABLE_FAMILY_IDS:
@@ -168,6 +191,23 @@ def _blockers_for_spec(
                 candidate_spec_id=spec.candidate_spec_id,
                 reason="family_runtime_harness_missing",
                 detail={"family_template_id": spec.family_template_id},
+            )
+        )
+    if (
+        seed_sweep_dir is not None
+        and _seed_sweep_config_path(
+            spec.family_template_id, seed_sweep_dir=seed_sweep_dir
+        )
+        is None
+    ):
+        blockers.append(
+            CandidateCompilationBlocker(
+                candidate_spec_id=spec.candidate_spec_id,
+                reason="seed_sweep_missing",
+                detail={
+                    "family_template_id": spec.family_template_id,
+                    "seed_sweep_dir": str(seed_sweep_dir),
+                },
             )
         )
 
@@ -216,6 +256,7 @@ def compile_whitepaper_candidate_specs(
     hypothesis_cards: Sequence[HypothesisCard],
     target_net_pnl_per_day: Decimal = Decimal("500"),
     family_template_dir: Path | None = None,
+    seed_sweep_dir: Path | None = None,
 ) -> WhitepaperCandidateCompilation:
     candidate_specs = tuple(
         compile_candidate_specs(
@@ -228,7 +269,9 @@ def compile_whitepaper_candidate_specs(
     blocked_specs: list[CandidateSpec] = []
     for spec in candidate_specs:
         spec_blockers = _blockers_for_spec(
-            spec, family_template_dir=family_template_dir
+            spec,
+            family_template_dir=family_template_dir,
+            seed_sweep_dir=seed_sweep_dir,
         )
         blockers.extend(spec_blockers)
         if spec_blockers:
@@ -257,6 +300,7 @@ def compile_claim_payloads_to_whitepaper_experiments(
     relations: Sequence[Mapping[str, Any]] = (),
     target_net_pnl_per_day: Decimal = Decimal("500"),
     family_template_dir: Path | None = None,
+    seed_sweep_dir: Path | None = None,
 ) -> WhitepaperCandidateCompilation:
     cards = build_hypothesis_cards(
         source_run_id=run_id,
@@ -267,4 +311,5 @@ def compile_claim_payloads_to_whitepaper_experiments(
         hypothesis_cards=cards,
         target_net_pnl_per_day=target_net_pnl_per_day,
         family_template_dir=family_template_dir,
+        seed_sweep_dir=seed_sweep_dir,
     )

--- a/services/torghut/app/trading/discovery/whitepaper_candidate_compiler.py
+++ b/services/torghut/app/trading/discovery/whitepaper_candidate_compiler.py
@@ -1,0 +1,270 @@
+"""Compile whitepaper hypothesis cards into executable Torghut candidate specs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+from pathlib import Path
+from typing import Any, Mapping, Sequence, cast
+
+import yaml
+
+from app.trading.discovery.candidate_specs import CandidateSpec, compile_candidate_specs
+from app.trading.discovery.hypothesis_cards import (
+    HypothesisCard,
+    build_hypothesis_cards,
+)
+
+
+EXECUTABLE_FAMILY_IDS = {
+    "breakout_reclaim_v2",
+    "washout_rebound_v2",
+    "momentum_pullback_v1",
+    "mean_reversion_rebound_v1",
+    "microbar_cross_sectional_pairs_v1",
+    "microstructure_continuation_matched_filter_v1",
+    "intraday_tsmom_v2",
+}
+
+FEATURE_ALIASES = {
+    "trade_flow": "order_flow_imbalance",
+    "relative_volume": "turnover",
+    "clustered_order_events": "order_flow_imbalance",
+    "depth_proxy": "quote_quality",
+    "execution_shortfall": "transaction_cost_stress",
+    "order_arrival_clustering": "information_arrival_rate",
+    "volatility_state": "realized_volatility",
+    "spread_bps": "max_spread_bps",
+}
+
+
+@dataclass(frozen=True)
+class CandidateCompilationBlocker:
+    candidate_spec_id: str
+    reason: str
+    detail: Mapping[str, Any]
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "candidate_spec_id": self.candidate_spec_id,
+            "reason": self.reason,
+            "detail": dict(self.detail),
+        }
+
+
+@dataclass(frozen=True)
+class WhitepaperCandidateCompilation:
+    candidate_specs: tuple[CandidateSpec, ...]
+    executable_specs: tuple[CandidateSpec, ...]
+    blocked_specs: tuple[CandidateSpec, ...]
+    blockers: tuple[CandidateCompilationBlocker, ...]
+    whitepaper_experiment_payloads: tuple[Mapping[str, Any], ...]
+    vnext_experiment_payloads: tuple[Mapping[str, Any], ...]
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "candidate_specs": [item.to_payload() for item in self.candidate_specs],
+            "executable_candidate_spec_ids": [
+                item.candidate_spec_id for item in self.executable_specs
+            ],
+            "blocked_candidate_spec_ids": [
+                item.candidate_spec_id for item in self.blocked_specs
+            ],
+            "blockers": [item.to_payload() for item in self.blockers],
+            "whitepaper_experiment_payloads": [
+                dict(item) for item in self.whitepaper_experiment_payloads
+            ],
+            "vnext_experiment_payloads": [
+                dict(item) for item in self.vnext_experiment_payloads
+            ],
+        }
+
+
+def _load_family_template(
+    family_template_id: str,
+    *,
+    family_template_dir: Path | None,
+) -> Mapping[str, Any]:
+    if family_template_dir is None:
+        return {}
+    path = family_template_dir / f"{family_template_id}.yaml"
+    if not path.exists():
+        return {}
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, Mapping):
+        return {}
+    return {str(key): item for key, item in cast(Mapping[Any, Any], payload).items()}
+
+
+def _family_feature_catalog(family_template_dir: Path | None) -> set[str]:
+    if family_template_dir is None or not family_template_dir.exists():
+        return set()
+    features: set[str] = set()
+    for path in family_template_dir.glob("*.yaml"):
+        payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+        if not isinstance(payload, Mapping):
+            continue
+        family_payload = {
+            str(key): item for key, item in cast(Mapping[Any, Any], payload).items()
+        }
+        features.update(_sequence_strings(family_payload.get("required_features")))
+        features.update(_sequence_strings(family_payload.get("risk_controls")))
+        liquidity = family_payload.get("liquidity_assumptions")
+        if isinstance(liquidity, Mapping):
+            features.update(str(key) for key in cast(Mapping[Any, Any], liquidity))
+        else:
+            features.update(_sequence_strings(liquidity))
+    return features
+
+
+def _sequence_strings(value: Any) -> tuple[str, ...]:
+    if not isinstance(value, Sequence) or isinstance(value, str):
+        return ()
+    rows = cast(Sequence[Any], value)
+    return tuple(str(item) for item in rows if str(item).strip())
+
+
+def _blockers_for_spec(
+    spec: CandidateSpec,
+    *,
+    family_template_dir: Path | None,
+) -> tuple[CandidateCompilationBlocker, ...]:
+    blockers: list[CandidateCompilationBlocker] = []
+    if spec.family_template_id not in EXECUTABLE_FAMILY_IDS:
+        blockers.append(
+            CandidateCompilationBlocker(
+                candidate_spec_id=spec.candidate_spec_id,
+                reason="family_not_in_production_grammar",
+                detail={"family_template_id": spec.family_template_id},
+            )
+        )
+    if not spec.runtime_family or not spec.runtime_strategy_name:
+        blockers.append(
+            CandidateCompilationBlocker(
+                candidate_spec_id=spec.candidate_spec_id,
+                reason="runtime_harness_missing",
+                detail={
+                    "runtime_family": spec.runtime_family,
+                    "runtime_strategy_name": spec.runtime_strategy_name,
+                },
+            )
+        )
+
+    family_template = _load_family_template(
+        spec.family_template_id, family_template_dir=family_template_dir
+    )
+    if family_template_dir is not None and not family_template:
+        blockers.append(
+            CandidateCompilationBlocker(
+                candidate_spec_id=spec.candidate_spec_id,
+                reason="family_template_missing",
+                detail={"family_template_id": spec.family_template_id},
+            )
+        )
+    runtime_harness = family_template.get("runtime_harness")
+    if family_template and not isinstance(runtime_harness, Mapping):
+        blockers.append(
+            CandidateCompilationBlocker(
+                candidate_spec_id=spec.candidate_spec_id,
+                reason="family_runtime_harness_missing",
+                detail={"family_template_id": spec.family_template_id},
+            )
+        )
+
+    required_features = {
+        FEATURE_ALIASES.get(feature, feature)
+        for feature in _sequence_strings(spec.feature_contract.get("required_features"))
+    }
+    feature_catalog = _family_feature_catalog(family_template_dir)
+    missing_features = sorted(required_features - feature_catalog)
+    if family_template_dir is not None and missing_features:
+        blockers.append(
+            CandidateCompilationBlocker(
+                candidate_spec_id=spec.candidate_spec_id,
+                reason="required_features_missing_from_family_template",
+                detail={
+                    "family_template_id": spec.family_template_id,
+                    "missing_features": missing_features,
+                },
+            )
+        )
+    return tuple(blockers)
+
+
+def whitepaper_experiment_payload_for_candidate(spec: CandidateSpec) -> dict[str, Any]:
+    vnext_payload = spec.to_vnext_experiment_payload()
+    return {
+        "experiment_id": vnext_payload["experiment_id"],
+        "family_template_id": spec.family_template_id,
+        "template_id": spec.family_template_id,
+        "hypothesis": vnext_payload.get("hypothesis"),
+        "paper_claim_links": vnext_payload.get("paper_claim_links", []),
+        "dataset_snapshot_policy": vnext_payload["dataset_snapshot_policy"],
+        "template_overrides": vnext_payload["template_overrides"],
+        "feature_variants": vnext_payload["feature_variants"],
+        "veto_controller_variants": vnext_payload["veto_controller_variants"],
+        "selection_objectives": vnext_payload["selection_objectives"],
+        "hard_vetoes": vnext_payload["hard_vetoes"],
+        "expected_failure_modes": vnext_payload["expected_failure_modes"],
+        "promotion_contract": vnext_payload["promotion_contract"],
+        "candidate_spec": vnext_payload["candidate_spec"],
+    }
+
+
+def compile_whitepaper_candidate_specs(
+    *,
+    hypothesis_cards: Sequence[HypothesisCard],
+    target_net_pnl_per_day: Decimal = Decimal("500"),
+    family_template_dir: Path | None = None,
+) -> WhitepaperCandidateCompilation:
+    candidate_specs = tuple(
+        compile_candidate_specs(
+            hypothesis_cards=hypothesis_cards,
+            target_net_pnl_per_day=target_net_pnl_per_day,
+        )
+    )
+    blockers: list[CandidateCompilationBlocker] = []
+    executable_specs: list[CandidateSpec] = []
+    blocked_specs: list[CandidateSpec] = []
+    for spec in candidate_specs:
+        spec_blockers = _blockers_for_spec(
+            spec, family_template_dir=family_template_dir
+        )
+        blockers.extend(spec_blockers)
+        if spec_blockers:
+            blocked_specs.append(spec)
+        else:
+            executable_specs.append(spec)
+    return WhitepaperCandidateCompilation(
+        candidate_specs=candidate_specs,
+        executable_specs=tuple(executable_specs),
+        blocked_specs=tuple(blocked_specs),
+        blockers=tuple(blockers),
+        whitepaper_experiment_payloads=tuple(
+            whitepaper_experiment_payload_for_candidate(spec)
+            for spec in executable_specs
+        ),
+        vnext_experiment_payloads=tuple(
+            spec.to_vnext_experiment_payload() for spec in executable_specs
+        ),
+    )
+
+
+def compile_claim_payloads_to_whitepaper_experiments(
+    *,
+    run_id: str,
+    claims: Sequence[Mapping[str, Any]],
+    relations: Sequence[Mapping[str, Any]] = (),
+    target_net_pnl_per_day: Decimal = Decimal("500"),
+    family_template_dir: Path | None = None,
+) -> WhitepaperCandidateCompilation:
+    cards = build_hypothesis_cards(
+        source_run_id=run_id,
+        claims=claims,
+        relations=relations,
+    )
+    return compile_whitepaper_candidate_specs(
+        hypothesis_cards=cards,
+        target_net_pnl_per_day=target_net_pnl_per_day,
+        family_template_dir=family_template_dir,
+    )

--- a/services/torghut/app/whitepapers/claim_compiler.py
+++ b/services/torghut/app/whitepapers/claim_compiler.py
@@ -1,0 +1,183 @@
+"""Pure whitepaper claim compilation helpers for autoresearch."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Sequence, cast
+
+from app.trading.discovery.hypothesis_cards import (
+    HypothesisCard,
+    build_hypothesis_cards,
+)
+
+
+@dataclass(frozen=True)
+class WhitepaperResearchSource:
+    run_id: str
+    title: str
+    source_url: str
+    published_at: str
+    claims: tuple[Mapping[str, Any], ...]
+    claim_relations: tuple[Mapping[str, Any], ...] = ()
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "run_id": self.run_id,
+            "title": self.title,
+            "source_url": self.source_url,
+            "published_at": self.published_at,
+            "claims": [dict(item) for item in self.claims],
+            "claim_relations": [dict(item) for item in self.claim_relations],
+        }
+
+
+RECENT_WHITEPAPER_SEEDS: tuple[WhitepaperResearchSource, ...] = (
+    WhitepaperResearchSource(
+        run_id="seed-arxiv-2602-23784",
+        title="TradeFM: A Generative Foundation Model for Trade-flow and Market Microstructure",
+        source_url="https://arxiv.org/abs/2602.23784",
+        published_at="2026-02-27",
+        claims=(
+            {
+                "claim_id": "tradefm-scale-invariant-flow",
+                "claim_type": "feature_recipe",
+                "claim_text": (
+                    "Scale-invariant trade-flow representations can capture transferable market "
+                    "microstructure structure across equities."
+                ),
+                "asset_scope": "us_equities_intraday",
+                "horizon_scope": "intraday_microstructure",
+                "expected_direction": "positive",
+                "data_requirements": ["trade_flow", "spread_bps", "relative_volume"],
+                "confidence": "0.78",
+            },
+            {
+                "claim_id": "tradefm-synthetic-stress",
+                "claim_type": "validation_requirement",
+                "claim_text": "Synthetic trade-flow rollouts should be used for stress testing rather than direct promotion.",
+                "asset_scope": "us_equities_intraday",
+                "horizon_scope": "intraday_microstructure",
+                "expected_direction": "neutral",
+                "confidence": "0.72",
+            },
+        ),
+    ),
+    WhitepaperResearchSource(
+        run_id="seed-arxiv-2504-20349",
+        title="ClusterLOB: Enhancing Trading Strategies by Clustering Orders in Limit Order Books",
+        source_url="https://arxiv.org/abs/2504.20349",
+        published_at="2025-04-29",
+        claims=(
+            {
+                "claim_id": "clusterlob-clustered-ofi",
+                "claim_type": "signal_mechanism",
+                "claim_text": (
+                    "Order-flow imbalance decomposed by participant-like clusters can improve "
+                    "short-horizon trading signals over aggregate order-flow baselines."
+                ),
+                "asset_scope": "us_equities_intraday",
+                "horizon_scope": "intraday",
+                "expected_direction": "positive",
+                "data_requirements": ["order_flow_imbalance", "clustered_order_events"],
+                "confidence": "0.82",
+            },
+            {
+                "claim_id": "clusterlob-robustness",
+                "claim_type": "validation_requirement",
+                "claim_text": "Signals should be validated across add, cancel, and trade event decompositions.",
+                "asset_scope": "us_equities_intraday",
+                "horizon_scope": "intraday",
+                "expected_direction": "neutral",
+                "confidence": "0.76",
+            },
+        ),
+    ),
+    WhitepaperResearchSource(
+        run_id="seed-arxiv-2511-02016",
+        title="ABIDES-MARL: A Multi-Agent Reinforcement Learning Environment for Endogenous Price Formation",
+        source_url="https://arxiv.org/abs/2511.02016",
+        published_at="2025-11-03",
+        claims=(
+            {
+                "claim_id": "abides-endogenous-liquidity",
+                "claim_type": "risk_constraint",
+                "claim_text": (
+                    "Execution policies should account for endogenous liquidity and market-maker response "
+                    "when sizing intraday strategies."
+                ),
+                "asset_scope": "us_equities_intraday",
+                "horizon_scope": "intraday_execution",
+                "expected_direction": "positive",
+                "data_requirements": [
+                    "spread_bps",
+                    "depth_proxy",
+                    "execution_shortfall",
+                ],
+                "confidence": "0.74",
+            },
+        ),
+    ),
+    WhitepaperResearchSource(
+        run_id="seed-arxiv-2510-08085",
+        title="A Deterministic Limit Order Book Simulator with Hawkes-Driven Order Flow",
+        source_url="https://arxiv.org/abs/2510.08085",
+        published_at="2025-10-09",
+        claims=(
+            {
+                "claim_id": "hawkes-order-flow-clustering",
+                "claim_type": "market_regime",
+                "claim_text": (
+                    "Nearly unstable order-flow clustering is important for reproducing realistic "
+                    "microstructure stress regimes."
+                ),
+                "asset_scope": "us_equities_intraday",
+                "horizon_scope": "intraday_microstructure",
+                "expected_direction": "positive",
+                "data_requirements": [
+                    "order_arrival_clustering",
+                    "spread_bps",
+                    "volatility_state",
+                ],
+                "confidence": "0.70",
+            },
+        ),
+    ),
+)
+
+
+def compile_sources_to_hypothesis_cards(
+    sources: Sequence[WhitepaperResearchSource],
+) -> list[HypothesisCard]:
+    cards: list[HypothesisCard] = []
+    for source in sources:
+        cards.extend(
+            build_hypothesis_cards(
+                source_run_id=source.run_id,
+                claims=source.claims,
+                relations=source.claim_relations,
+            )
+        )
+    return cards
+
+
+def source_from_payload(payload: Mapping[str, Any]) -> WhitepaperResearchSource:
+    claims = payload.get("claims")
+    relations = payload.get("claim_relations")
+    claim_rows = cast(list[Any], claims) if isinstance(claims, list) else []
+    relation_rows = cast(list[Any], relations) if isinstance(relations, list) else []
+    return WhitepaperResearchSource(
+        run_id=str(payload.get("run_id") or "").strip(),
+        title=str(payload.get("title") or "").strip(),
+        source_url=str(payload.get("source_url") or "").strip(),
+        published_at=str(payload.get("published_at") or "").strip(),
+        claims=tuple(
+            cast(Mapping[str, Any], item)
+            for item in claim_rows
+            if isinstance(item, Mapping)
+        ),
+        claim_relations=tuple(
+            cast(Mapping[str, Any], item)
+            for item in relation_rows
+            if isinstance(item, Mapping)
+        ),
+    )

--- a/services/torghut/app/whitepapers/claim_compiler.py
+++ b/services/torghut/app/whitepapers/claim_compiler.py
@@ -11,6 +11,35 @@ from app.trading.discovery.hypothesis_cards import (
 )
 
 
+MECHANISM_CLAIM_TYPES = frozenset(
+    ("signal_mechanism", "feature_recipe", "normalization_rule")
+)
+FEATURE_RECIPE_CLAIM_TYPES = frozenset(("feature_recipe", "normalization_rule"))
+FEATURE_BLOCKER_CLAIM_TYPES = frozenset(
+    ("feature_missing_blocker", "data_gap", "feature_gap")
+)
+FEATURE_FIELD_KEYS = (
+    "data_requirements",
+    "required_features",
+    "features",
+    "feature_family_ids",
+)
+FEATURE_BLOCKER_RELATION_TYPES = frozenset(
+    ("requires_feature", "missing_feature", "feature_missing")
+)
+RISK_VALIDATION_CLAIM_TYPES = frozenset(
+    (
+        "risk_constraint",
+        "validation_requirement",
+        "execution_assumption",
+        "market_regime",
+    )
+)
+RISK_VALIDATION_RELATION_TYPES = frozenset(
+    ("contradicts", "requires_regime", "invalidates")
+)
+
+
 @dataclass(frozen=True)
 class WhitepaperResearchSource:
     run_id: str
@@ -99,6 +128,23 @@ RECENT_WHITEPAPER_SEEDS: tuple[WhitepaperResearchSource, ...] = (
         published_at="2025-11-03",
         claims=(
             {
+                "claim_id": "abides-liquidity-response-signal",
+                "claim_type": "signal_mechanism",
+                "claim_text": (
+                    "Endogenous market-maker liquidity response in order-flow state can support "
+                    "short-horizon execution-aware sizing signals after liquidity shocks."
+                ),
+                "asset_scope": "us_equities_intraday",
+                "horizon_scope": "intraday_execution",
+                "expected_direction": "positive",
+                "data_requirements": [
+                    "spread_bps",
+                    "depth_proxy",
+                    "execution_shortfall",
+                ],
+                "confidence": "0.73",
+            },
+            {
                 "claim_id": "abides-endogenous-liquidity",
                 "claim_type": "risk_constraint",
                 "claim_text": (
@@ -115,6 +161,18 @@ RECENT_WHITEPAPER_SEEDS: tuple[WhitepaperResearchSource, ...] = (
                 ],
                 "confidence": "0.74",
             },
+            {
+                "claim_id": "abides-market-maker-response-validation",
+                "claim_type": "validation_requirement",
+                "claim_text": (
+                    "Replay promotion should stress market-maker response, spread widening, and execution "
+                    "shortfall before using the signal in a portfolio sleeve."
+                ),
+                "asset_scope": "us_equities_intraday",
+                "horizon_scope": "intraday_execution",
+                "expected_direction": "neutral",
+                "confidence": "0.71",
+            },
         ),
     ),
     WhitepaperResearchSource(
@@ -123,6 +181,23 @@ RECENT_WHITEPAPER_SEEDS: tuple[WhitepaperResearchSource, ...] = (
         source_url="https://arxiv.org/abs/2510.08085",
         published_at="2025-10-09",
         claims=(
+            {
+                "claim_id": "hawkes-clustered-arrival-signal",
+                "claim_type": "signal_mechanism",
+                "claim_text": (
+                    "Self-exciting order arrivals can identify clustered liquidity-pressure windows where "
+                    "microbar signals need regime-aware sizing."
+                ),
+                "asset_scope": "us_equities_intraday",
+                "horizon_scope": "intraday_microstructure",
+                "expected_direction": "positive",
+                "data_requirements": [
+                    "order_arrival_clustering",
+                    "spread_bps",
+                    "volatility_state",
+                ],
+                "confidence": "0.72",
+            },
             {
                 "claim_id": "hawkes-order-flow-clustering",
                 "claim_type": "market_regime",
@@ -140,9 +215,129 @@ RECENT_WHITEPAPER_SEEDS: tuple[WhitepaperResearchSource, ...] = (
                 ],
                 "confidence": "0.70",
             },
+            {
+                "claim_id": "hawkes-clustering-stress-validation",
+                "claim_type": "validation_requirement",
+                "claim_text": (
+                    "Candidate families should pass clustered-arrival stress windows before promotion to "
+                    "avoid brittle behavior in nearly unstable flow regimes."
+                ),
+                "asset_scope": "us_equities_intraday",
+                "horizon_scope": "intraday_microstructure",
+                "expected_direction": "neutral",
+                "confidence": "0.70",
+            },
         ),
     ),
 )
+
+
+def _string(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _strings_from_value(value: Any) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        values: Sequence[Any] = (value,)
+    elif isinstance(value, list):
+        values = cast(list[Any], value)
+    elif isinstance(value, tuple):
+        values = cast(tuple[Any, ...], value)
+    elif isinstance(value, set):
+        values = tuple(cast(set[Any], value))
+    else:
+        return ()
+    resolved: list[str] = []
+    for item in values:
+        text = _string(item)
+        if text and text not in resolved:
+            resolved.append(text)
+    return tuple(resolved)
+
+
+def _claim_type(claim: Mapping[str, Any]) -> str:
+    return _string(claim.get("claim_type")).lower()
+
+
+def _claim_text(claim: Mapping[str, Any]) -> str:
+    return _string(claim.get("claim_text")) or _string(claim.get("claim"))
+
+
+def _relation_type(relation: Mapping[str, Any]) -> str:
+    return _string(relation.get("relation_type")).lower()
+
+
+def _claim_feature_terms(claim: Mapping[str, Any]) -> tuple[str, ...]:
+    metadata = claim.get("metadata")
+    metadata_payload: Mapping[str, Any] = (
+        cast(Mapping[str, Any], metadata) if isinstance(metadata, Mapping) else {}
+    )
+    terms: list[str] = []
+    for key in FEATURE_FIELD_KEYS:
+        terms.extend(_strings_from_value(claim.get(key)))
+        terms.extend(_strings_from_value(metadata_payload.get(key)))
+    return tuple(dict.fromkeys(terms))
+
+
+def _has_mechanism(claims: Sequence[Mapping[str, Any]]) -> bool:
+    return any(
+        _claim_type(claim) in MECHANISM_CLAIM_TYPES and bool(_claim_text(claim))
+        for claim in claims
+    )
+
+
+def _has_feature_recipe_or_blocker(
+    claims: Sequence[Mapping[str, Any]],
+    relations: Sequence[Mapping[str, Any]],
+) -> bool:
+    for claim in claims:
+        claim_type = _claim_type(claim)
+        if claim_type in FEATURE_RECIPE_CLAIM_TYPES | FEATURE_BLOCKER_CLAIM_TYPES:
+            return True
+        if _claim_feature_terms(claim):
+            return True
+    return any(
+        _relation_type(relation) in FEATURE_BLOCKER_RELATION_TYPES
+        for relation in relations
+    )
+
+
+def _has_risk_validation_constraint(
+    claims: Sequence[Mapping[str, Any]],
+    relations: Sequence[Mapping[str, Any]],
+) -> bool:
+    if any(
+        _claim_type(claim) in RISK_VALIDATION_CLAIM_TYPES and bool(_claim_text(claim))
+        for claim in claims
+    ):
+        return True
+    return any(
+        _relation_type(relation) in RISK_VALIDATION_RELATION_TYPES
+        for relation in relations
+    )
+
+
+def claim_subgraph_blockers(source: WhitepaperResearchSource) -> tuple[str, ...]:
+    """Return deterministic reasons this source cannot produce executable hypotheses."""
+
+    claims = tuple(dict(item) for item in source.claims)
+    relations = tuple(dict(item) for item in source.claim_relations)
+    blockers: list[str] = []
+    if not _string(source.run_id):
+        blockers.append("source_run_id_missing")
+    if not claims:
+        blockers.append("claims_missing")
+    if claims and not any(_claim_text(claim) for claim in claims):
+        blockers.append("claim_text_missing")
+    if not _has_mechanism(claims):
+        blockers.append("mechanism_missing")
+    if not _has_feature_recipe_or_blocker(claims, relations):
+        blockers.append("feature_recipe_or_blocker_missing")
+    if not _has_risk_validation_constraint(claims, relations):
+        blockers.append("risk_or_validation_constraint_missing")
+    return tuple(blockers)
 
 
 def compile_sources_to_hypothesis_cards(
@@ -150,6 +345,8 @@ def compile_sources_to_hypothesis_cards(
 ) -> list[HypothesisCard]:
     cards: list[HypothesisCard] = []
     for source in sources:
+        if claim_subgraph_blockers(source):
+            continue
         cards.extend(
             build_hypothesis_cards(
                 source_run_id=source.run_id,

--- a/services/torghut/app/whitepapers/workflow.py
+++ b/services/torghut/app/whitepapers/workflow.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from decimal import Decimal
 from http.client import HTTPConnection, HTTPSConnection
+from pathlib import Path
 from subprocess import CalledProcessError, run
 from typing import Any, Mapping, cast
 from urllib.parse import quote, urljoin, urlparse
@@ -45,6 +46,9 @@ from ..models import (
     WhitepaperSynthesis,
     WhitepaperViabilityVerdict,
     coerce_json_payload,
+)
+from ..trading.discovery.whitepaper_candidate_compiler import (
+    compile_claim_payloads_to_whitepaper_experiments,
 )
 
 logger = logging.getLogger(__name__)
@@ -3621,8 +3625,26 @@ class WhitepaperWorkflowService:
         *,
         run_id: str,
         claims: list[dict[str, Any]],
+        relations: list[dict[str, Any]],
         templates: list[dict[str, Any]],
     ) -> list[dict[str, Any]]:
+        if not templates and claims:
+            family_template_dir = Path(
+                os.getenv(
+                    "TORGHUT_WHITEPAPER_FAMILY_TEMPLATE_DIR",
+                    "config/trading/families",
+                )
+            )
+            compilation = compile_claim_payloads_to_whitepaper_experiments(
+                run_id=run_id,
+                claims=claims,
+                relations=relations,
+                target_net_pnl_per_day=Decimal("500"),
+                family_template_dir=family_template_dir,
+            )
+            return [
+                dict(item) for item in compilation.whitepaper_experiment_payloads
+            ]
         if not templates:
             return []
         linked_claim_ids = [
@@ -3706,6 +3728,7 @@ class WhitepaperWorkflowService:
             experiment_specs = self._compiled_experiment_specs_from_templates(
                 run_id=run.run_id,
                 claims=claims,
+                relations=relations,
                 templates=templates,
             )
         contradiction_events = [

--- a/services/torghut/app/whitepapers/workflow.py
+++ b/services/torghut/app/whitepapers/workflow.py
@@ -3635,12 +3635,19 @@ class WhitepaperWorkflowService:
                     "config/trading/families",
                 )
             )
+            seed_sweep_dir = Path(
+                os.getenv(
+                    "TORGHUT_WHITEPAPER_SEED_SWEEP_DIR",
+                    "config/trading",
+                )
+            )
             compilation = compile_claim_payloads_to_whitepaper_experiments(
                 run_id=run_id,
                 claims=claims,
                 relations=relations,
                 target_net_pnl_per_day=Decimal("500"),
                 family_template_dir=family_template_dir,
+                seed_sweep_dir=seed_sweep_dir,
             )
             return [
                 dict(item) for item in compilation.whitepaper_experiment_payloads

--- a/services/torghut/config/trading/profitability-frontier-consistent-microbar-cross-sectional-pairs.yaml
+++ b/services/torghut/config/trading/profitability-frontier-consistent-microbar-cross-sectional-pairs.yaml
@@ -1,0 +1,59 @@
+schema_version: torghut.replay-frontier-sweep.v1
+family: microbar_cross_sectional_pairs
+family_template_id: microbar_cross_sectional_pairs_v1
+strategy_name: microbar-cross-sectional-pairs-v1
+disable_other_strategies: true
+constraints:
+  holdout_target_net_per_day: '500'
+  min_active_holdout_days: 3
+  max_worst_holdout_day_loss: '250'
+  min_profit_factor: '1.05'
+  require_training_decisions: true
+  require_holdout_decisions: true
+consistency_constraints:
+  target_net_per_day: '500'
+  min_active_days: 8
+  min_active_ratio: '1.0'
+  min_positive_days: 5
+  max_worst_day_loss: '350'
+  max_negative_days: 2
+  max_drawdown: '900'
+  max_best_day_share_of_total_pnl: '0.30'
+  min_avg_filled_notional_per_day: '300000'
+  min_avg_filled_notional_per_active_day: '350000'
+  min_regime_slice_pass_rate: '0.45'
+  require_every_day_active: true
+strategy_overrides:
+  universe_symbols:
+    - ['AAPL', 'AMAT', 'GOOG', 'MSFT', 'MU', 'NVDA', 'SHOP']
+    - ['AAPL', 'AMAT', 'AMD', 'GOOG', 'INTC', 'META', 'MSFT', 'MU', 'NVDA', 'SHOP']
+  normalization_regime:
+    - 'market_neutral_gross_scaled'
+  max_position_pct_equity:
+    - '6.0'
+    - '8.0'
+  max_notional_per_trade:
+    - '157950.10'
+    - '236925.15'
+parameters:
+  min_cross_section_continuation_rank:
+    - '0.55'
+    - '0.65'
+  min_cross_section_reversal_rank:
+    - '0.65'
+    - '0.75'
+  max_gross_exposure_pct_equity:
+    - '6.0'
+    - '8.0'
+  entry_notional_max_multiplier:
+    - '1.00'
+    - '1.25'
+  max_pair_legs:
+    - '2'
+    - '3'
+  max_entries_per_session:
+    - '1'
+    - '2'
+  entry_cooldown_seconds:
+    - '600'
+    - '900'

--- a/services/torghut/migrations/versions/0028_autoresearch_epoch_ledgers.py
+++ b/services/torghut/migrations/versions/0028_autoresearch_epoch_ledgers.py
@@ -1,0 +1,263 @@
+"""Add autoresearch epoch ledger tables.
+
+Revision ID: 0028_autoresearch_epoch_ledgers
+Revises: 0027_whitepaper_claim_graph
+Create Date: 2026-04-21 04:30:00.000000
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0028_autoresearch_epoch_ledgers"
+down_revision = "0027_whitepaper_claim_graph"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "autoresearch_epochs",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("epoch_id", sa.String(length=128), nullable=False),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column("target_net_pnl_per_day", sa.Numeric(20, 8), nullable=False),
+        sa.Column("paper_run_ids_json", sa.JSON(), nullable=True),
+        sa.Column("snapshot_manifest_json", sa.JSON(), nullable=True),
+        sa.Column("runner_config_json", sa.JSON(), nullable=True),
+        sa.Column("summary_json", sa.JSON(), nullable=True),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("failure_reason", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_autoresearch_epochs"),
+    )
+    op.create_index(
+        "uq_autoresearch_epochs_epoch_id",
+        "autoresearch_epochs",
+        ["epoch_id"],
+        unique=True,
+    )
+    op.create_index("ix_autoresearch_epochs_status", "autoresearch_epochs", ["status"])
+    op.create_index(
+        "ix_autoresearch_epochs_completed_at", "autoresearch_epochs", ["completed_at"]
+    )
+
+    op.create_table(
+        "autoresearch_candidate_specs",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("candidate_spec_id", sa.String(length=128), nullable=False),
+        sa.Column("epoch_id", sa.String(length=128), nullable=False),
+        sa.Column("hypothesis_id", sa.String(length=128), nullable=False),
+        sa.Column("candidate_kind", sa.String(length=32), nullable=False),
+        sa.Column("family_template_id", sa.String(length=128), nullable=False),
+        sa.Column("payload_json", sa.JSON(), nullable=False),
+        sa.Column("payload_hash", sa.String(length=64), nullable=False),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column("blockers_json", sa.JSON(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_autoresearch_candidate_specs"),
+    )
+    op.create_index(
+        "uq_autoresearch_candidate_specs_candidate_spec_id",
+        "autoresearch_candidate_specs",
+        ["candidate_spec_id"],
+        unique=True,
+    )
+    op.create_index(
+        "ix_autoresearch_candidate_specs_epoch_id",
+        "autoresearch_candidate_specs",
+        ["epoch_id"],
+    )
+    op.create_index(
+        "ix_autoresearch_candidate_specs_hypothesis_id",
+        "autoresearch_candidate_specs",
+        ["hypothesis_id"],
+    )
+    op.create_index(
+        "ix_autoresearch_candidate_specs_family",
+        "autoresearch_candidate_specs",
+        ["family_template_id"],
+    )
+    op.create_index(
+        "ix_autoresearch_candidate_specs_status",
+        "autoresearch_candidate_specs",
+        ["status"],
+    )
+
+    op.create_table(
+        "autoresearch_proposal_scores",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("epoch_id", sa.String(length=128), nullable=False),
+        sa.Column("candidate_spec_id", sa.String(length=128), nullable=False),
+        sa.Column("model_id", sa.String(length=128), nullable=False),
+        sa.Column("backend", sa.String(length=64), nullable=False),
+        sa.Column("proposal_score", sa.Numeric(20, 8), nullable=False),
+        sa.Column("rank", sa.BigInteger(), nullable=False),
+        sa.Column("selection_reason", sa.String(length=64), nullable=False),
+        sa.Column("feature_hash", sa.String(length=64), nullable=True),
+        sa.Column("payload_json", sa.JSON(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_autoresearch_proposal_scores"),
+    )
+    op.create_index(
+        "ix_autoresearch_proposal_scores_epoch_id",
+        "autoresearch_proposal_scores",
+        ["epoch_id"],
+    )
+    op.create_index(
+        "ix_autoresearch_proposal_scores_candidate_spec",
+        "autoresearch_proposal_scores",
+        ["candidate_spec_id"],
+    )
+    op.create_index(
+        "ix_autoresearch_proposal_scores_rank",
+        "autoresearch_proposal_scores",
+        ["epoch_id", "rank"],
+    )
+    op.create_index(
+        "uq_autoresearch_proposal_scores_epoch_candidate_model",
+        "autoresearch_proposal_scores",
+        ["epoch_id", "candidate_spec_id", "model_id"],
+        unique=True,
+    )
+
+    op.create_table(
+        "autoresearch_portfolio_candidates",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("portfolio_candidate_id", sa.String(length=128), nullable=False),
+        sa.Column("epoch_id", sa.String(length=128), nullable=False),
+        sa.Column("source_candidate_ids_json", sa.JSON(), nullable=False),
+        sa.Column("target_net_pnl_per_day", sa.Numeric(20, 8), nullable=False),
+        sa.Column("objective_scorecard_json", sa.JSON(), nullable=False),
+        sa.Column("optimizer_report_json", sa.JSON(), nullable=False),
+        sa.Column("payload_json", sa.JSON(), nullable=False),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_autoresearch_portfolio_candidates"),
+    )
+    op.create_index(
+        "uq_autoresearch_portfolio_candidates_portfolio_candidate_id",
+        "autoresearch_portfolio_candidates",
+        ["portfolio_candidate_id"],
+        unique=True,
+    )
+    op.create_index(
+        "ix_autoresearch_portfolio_candidates_epoch_id",
+        "autoresearch_portfolio_candidates",
+        ["epoch_id"],
+    )
+    op.create_index(
+        "ix_autoresearch_portfolio_candidates_status",
+        "autoresearch_portfolio_candidates",
+        ["status"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_autoresearch_portfolio_candidates_status",
+        table_name="autoresearch_portfolio_candidates",
+    )
+    op.drop_index(
+        "ix_autoresearch_portfolio_candidates_epoch_id",
+        table_name="autoresearch_portfolio_candidates",
+    )
+    op.drop_index(
+        "uq_autoresearch_portfolio_candidates_portfolio_candidate_id",
+        table_name="autoresearch_portfolio_candidates",
+    )
+    op.drop_table("autoresearch_portfolio_candidates")
+
+    op.drop_index(
+        "uq_autoresearch_proposal_scores_epoch_candidate_model",
+        table_name="autoresearch_proposal_scores",
+    )
+    op.drop_index(
+        "ix_autoresearch_proposal_scores_rank",
+        table_name="autoresearch_proposal_scores",
+    )
+    op.drop_index(
+        "ix_autoresearch_proposal_scores_candidate_spec",
+        table_name="autoresearch_proposal_scores",
+    )
+    op.drop_index(
+        "ix_autoresearch_proposal_scores_epoch_id",
+        table_name="autoresearch_proposal_scores",
+    )
+    op.drop_table("autoresearch_proposal_scores")
+
+    op.drop_index(
+        "ix_autoresearch_candidate_specs_status",
+        table_name="autoresearch_candidate_specs",
+    )
+    op.drop_index(
+        "ix_autoresearch_candidate_specs_family",
+        table_name="autoresearch_candidate_specs",
+    )
+    op.drop_index(
+        "ix_autoresearch_candidate_specs_hypothesis_id",
+        table_name="autoresearch_candidate_specs",
+    )
+    op.drop_index(
+        "ix_autoresearch_candidate_specs_epoch_id",
+        table_name="autoresearch_candidate_specs",
+    )
+    op.drop_index(
+        "uq_autoresearch_candidate_specs_candidate_spec_id",
+        table_name="autoresearch_candidate_specs",
+    )
+    op.drop_table("autoresearch_candidate_specs")
+
+    op.drop_index(
+        "ix_autoresearch_epochs_completed_at", table_name="autoresearch_epochs"
+    )
+    op.drop_index("ix_autoresearch_epochs_status", table_name="autoresearch_epochs")
+    op.drop_index("uq_autoresearch_epochs_epoch_id", table_name="autoresearch_epochs")
+    op.drop_table("autoresearch_epochs")

--- a/services/torghut/scripts/compile_whitepaper_claims.py
+++ b/services/torghut/scripts/compile_whitepaper_claims.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Compile recent whitepaper seed claims into hypothesis cards."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from app.whitepapers.claim_compiler import (
+    RECENT_WHITEPAPER_SEEDS,
+    compile_sources_to_hypothesis_cards,
+)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Compile whitepaper research sources into hypothesis cards."
+    )
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--seed-recent-whitepapers", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    sources = RECENT_WHITEPAPER_SEEDS if args.seed_recent_whitepapers else ()
+    cards = compile_sources_to_hypothesis_cards(sources)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
+        "\n".join(json.dumps(card.to_payload(), sort_keys=True) for card in cards)
+        + ("\n" if cards else ""),
+        encoding="utf-8",
+    )
+    print(
+        json.dumps(
+            {"status": "ok", "count": len(cards), "output": str(args.output)},
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -761,8 +761,25 @@ def run_whitepaper_autoresearch_profit_target(
     runtime_closure = _runtime_closure_payload(
         args=args, output_dir=output_dir, epoch_id=epoch_id, portfolio=portfolio
     )
+    oracle_candidate_found = bool(
+        portfolio is not None
+        and portfolio.objective_scorecard.get("oracle_passed") is True
+    )
+    profit_target_oracle = (
+        portfolio.objective_scorecard.get("profit_target_oracle")
+        if portfolio is not None
+        else None
+    )
+    status = "ok" if oracle_candidate_found else "no_profit_target_candidate"
+    status_reason = None
+    if not oracle_candidate_found:
+        if portfolio is None:
+            status_reason = "portfolio_optimizer_produced_no_candidate"
+        else:
+            status_reason = "portfolio_candidate_failed_profit_target_oracle"
     summary = {
-        "status": "ok",
+        "status": status,
+        "status_reason": status_reason,
         "epoch_id": epoch_id,
         "run_root": str(output_dir),
         "target_net_pnl_per_day": str(target),
@@ -780,15 +797,8 @@ def run_whitepaper_autoresearch_profit_target(
         "best_portfolio_candidate": portfolio.to_payload()
         if portfolio is not None
         else None,
-        "oracle_candidate_found": bool(
-            portfolio is not None
-            and portfolio.objective_scorecard.get("oracle_passed") is True
-        ),
-        "profit_target_oracle": portfolio.objective_scorecard.get(
-            "profit_target_oracle"
-        )
-        if portfolio is not None
-        else None,
+        "oracle_candidate_found": oracle_candidate_found,
+        "profit_target_oracle": profit_target_oracle,
         "promotion_readiness": {
             "status": "blocked_pending_runtime_parity"
             if portfolio is not None
@@ -824,7 +834,7 @@ def run_whitepaper_autoresearch_profit_target(
     if args.persist_results:
         _persist_epoch_ledgers(
             epoch_id=epoch_id,
-            status="ok",
+            status=status,
             target_net_pnl_per_day=target,
             paper_run_ids=[str(item) for item in args.paper_run_id],
             sources=sources,

--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -481,9 +481,73 @@ def _pre_replay_candidate_score(spec: CandidateSpec) -> Decimal:
     return family_score + Decimal(feature_count) - failure_penalty
 
 
+def _pre_replay_prior_bundle(spec: CandidateSpec) -> CandidateEvidenceBundle:
+    prior_score = _pre_replay_candidate_score(spec)
+    return evidence_bundle_from_frontier_candidate(
+        candidate_spec_id=spec.candidate_spec_id,
+        candidate={
+            "candidate_id": f"pre-replay-prior-{spec.candidate_spec_id}",
+            "family_template_id": spec.family_template_id,
+            "runtime_family": spec.runtime_family,
+            "runtime_strategy_name": spec.runtime_strategy_name,
+            "objective_scorecard": {
+                "net_pnl_per_day": str(prior_score),
+                "active_day_ratio": "0.50",
+                "positive_day_ratio": "0.50",
+                "regime_slice_pass_rate": "0.45",
+                "posterior_edge_lower": "0.001",
+                "shadow_parity_status": "pending",
+            },
+            "promotion_readiness": {
+                "stage": "research_candidate",
+                "status": "pre_replay_prior",
+                "promotable": False,
+                "blockers": ["runtime_replay_required"],
+            },
+        },
+        dataset_snapshot_id="pre-replay-proposal-priors",
+        result_path=f"pre-replay-proposal-priors://{spec.candidate_spec_id}",
+    )
+
+
+def _pre_replay_proposal_model_and_rows(
+    *,
+    specs: Sequence[CandidateSpec],
+) -> tuple[Mapping[str, Any], list[dict[str, Any]]]:
+    prior_bundles = [_pre_replay_prior_bundle(spec) for spec in specs]
+    training_rows = build_mlx_training_rows(
+        candidate_specs=specs, evidence_bundles=prior_bundles
+    )
+    model = train_mlx_ranker(training_rows, backend_preference="mlx")
+    ranked_rows = rank_training_rows(model=model, rows=training_rows)
+    feature_by_spec = {
+        row.candidate_spec_id: row.to_payload()["features"] for row in training_rows
+    }
+    rows = [
+        {
+            "candidate_spec_id": item.candidate_spec_id,
+            "proposal_score": item.score,
+            "rank": item.rank,
+            "backend": item.backend,
+            "model_id": item.model_id,
+            "selection_reason": "pre_replay_mlx_rank",
+            "feature_hash": item.feature_hash,
+            "features": feature_by_spec.get(item.candidate_spec_id, {}),
+        }
+        for item in ranked_rows
+    ]
+    return {
+        **model.to_payload(),
+        "proposal_stage": "pre_replay",
+        "model_status": "active",
+        "rank_bucket_lift": {"status": "pending_replay_evidence"},
+    }, rows
+
+
 def _select_candidate_specs_for_replay(
     *,
     specs: Sequence[CandidateSpec],
+    proposal_rows: Sequence[Mapping[str, Any]],
     top_k: int,
     exploration_slots: int,
     max_candidates: int,
@@ -495,16 +559,33 @@ def _select_candidate_specs_for_replay(
             "selected_candidate_spec_ids": [],
             "rows": [],
         }
+    spec_by_id = {spec.candidate_spec_id: spec for spec in specs}
     max_budget = max(1, int(max_candidates))
     requested_budget = max(0, int(top_k)) + max(0, int(exploration_slots))
     replay_budget = min(max_budget, max(1, int(portfolio_size_min), requested_budget))
-    ordered = sorted(
-        specs,
-        key=lambda item: (_pre_replay_candidate_score(item), item.candidate_spec_id),
-        reverse=True,
+    ranked_ids = [
+        str(row.get("candidate_spec_id"))
+        for row in sorted(
+            _list_of_mappings(list(proposal_rows)),
+            key=lambda row: (
+                int(row.get("rank") or 10**9),
+                -float(row.get("proposal_score") or 0.0),
+                str(row.get("candidate_spec_id") or ""),
+            ),
+        )
+        if str(row.get("candidate_spec_id")) in spec_by_id
+    ]
+    ranked_ids.extend(
+        spec.candidate_spec_id
+        for spec in sorted(specs, key=lambda item: item.candidate_spec_id)
+        if spec.candidate_spec_id not in set(ranked_ids)
     )
-    exploitation_count = min(max(0, int(top_k)), replay_budget, len(ordered))
-    exploitation = ordered[:exploitation_count]
+    ordered = [spec_by_id[candidate_spec_id] for candidate_spec_id in ranked_ids]
+    exploitation_count = min(max(0, int(top_k)), replay_budget, len(ranked_ids))
+    exploitation = [
+        spec_by_id[candidate_spec_id]
+        for candidate_spec_id in ranked_ids[:exploitation_count]
+    ]
     remaining = [
         item
         for item in sorted(specs, key=lambda value: value.candidate_spec_id)
@@ -879,13 +960,34 @@ def run_whitepaper_autoresearch_profit_target(
             reason="candidate_compiler_produced_no_executable_specs",
             started_at=started_at,
         )
+    pre_replay_model, pre_replay_proposal_rows = _pre_replay_proposal_model_and_rows(
+        specs=candidate_specs
+    )
+    _write_json(output_dir / "pre-replay-mlx-ranker-model.json", pre_replay_model)
+    _write_jsonl(
+        output_dir / "pre-replay-mlx-proposal-scores.jsonl",
+        pre_replay_proposal_rows,
+    )
     replay_candidate_specs, candidate_selection = _select_candidate_specs_for_replay(
         specs=candidate_specs,
+        proposal_rows=pre_replay_proposal_rows,
         top_k=int(args.top_k),
         exploration_slots=int(args.exploration_slots),
         max_candidates=int(args.max_candidates),
         portfolio_size_min=int(args.portfolio_size_min),
     )
+    candidate_selection = {
+        **candidate_selection,
+        "proposal_model": {
+            "schema_version": pre_replay_model.get("schema_version"),
+            "model_id": pre_replay_model.get("model_id"),
+            "backend": pre_replay_model.get("backend"),
+            "proposal_stage": "pre_replay",
+        },
+        "proposal_scores_artifact": str(
+            output_dir / "pre-replay-mlx-proposal-scores.jsonl"
+        ),
+    }
     _write_json(output_dir / "candidate-selection-manifest.json", candidate_selection)
     selection_by_spec = {
         str(row.get("candidate_spec_id")): row
@@ -975,6 +1077,7 @@ def run_whitepaper_autoresearch_profit_target(
         "candidate_compiler_blocker_count": len(compilation.blockers),
         "evidence_bundle_count": len(replay_result.evidence_bundles),
         "replay_candidate_spec_count": len(replay_candidate_specs),
+        "pre_replay_proposal_score_count": len(pre_replay_proposal_rows),
         "proposal_score_count": len(proposal_rows),
         "portfolio_candidate_count": len(portfolio_rows),
         "claim_count": sum(len(source.claims) for source in sources),
@@ -1002,6 +1105,12 @@ def run_whitepaper_autoresearch_profit_target(
             "candidate_specs": str(output_dir / "candidate-specs.jsonl"),
             "candidate_selection_manifest": str(
                 output_dir / "candidate-selection-manifest.json"
+            ),
+            "pre_replay_proposal_scores": str(
+                output_dir / "pre-replay-mlx-proposal-scores.jsonl"
+            ),
+            "pre_replay_proposal_model": str(
+                output_dir / "pre-replay-mlx-ranker-model.json"
             ),
             "candidate_compiler_report": str(
                 output_dir / "candidate-compiler-report.json"

--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -864,6 +864,45 @@ def _synthetic_candidate_payload(spec: CandidateSpec, *, rank: int) -> dict[str,
     net = _synthetic_net_for_spec(spec, rank=rank)
     active = Decimal("0.92") if rank <= 3 else Decimal("0.82")
     positive = Decimal("0.64") if rank <= 3 else Decimal("0.58")
+    daily_net_profile = {
+        1: (
+            Decimal("0.80"),
+            Decimal("1.10"),
+            Decimal("0.90"),
+            Decimal("1.05"),
+            Decimal("1.15"),
+        ),
+        2: (
+            Decimal("1.12"),
+            Decimal("0.86"),
+            Decimal("1.08"),
+            Decimal("0.94"),
+            Decimal("1.00"),
+        ),
+        3: (
+            Decimal("0.95"),
+            Decimal("1.14"),
+            Decimal("0.84"),
+            Decimal("1.10"),
+            Decimal("0.97"),
+        ),
+    }.get(
+        rank,
+        (
+            Decimal("1.05"),
+            Decimal("0.90"),
+            Decimal("1.15"),
+            Decimal("0.82"),
+            Decimal("1.08"),
+        ),
+    )
+    trading_days = (
+        "2026-02-23",
+        "2026-02-24",
+        "2026-02-25",
+        "2026-02-26",
+        "2026-02-27",
+    )
     daily_filled_notional = {
         "2026-02-23": "350000",
         "2026-02-24": "350000",
@@ -888,16 +927,19 @@ def _synthetic_candidate_payload(spec: CandidateSpec, *, rank: int) -> dict[str,
             "regime_slice_pass_rate": "0.55",
             "posterior_edge_lower": "0.01",
             "shadow_parity_status": "within_budget",
+            "symbol_contribution_shares": {
+                "AAPL": "0.25",
+                "NVDA": "0.25",
+                "MSFT": "0.25",
+                "AMAT": "0.25",
+            },
             "daily_filled_notional": daily_filled_notional,
         },
         "full_window": {
             "net_per_day": str(net),
             "daily_net": {
-                "2026-02-23": str(net * Decimal("0.80")),
-                "2026-02-24": str(net * Decimal("1.10")),
-                "2026-02-25": str(net * Decimal("0.90")),
-                "2026-02-26": str(net * Decimal("1.05")),
-                "2026-02-27": str(net * Decimal("1.15")),
+                day: str(net * multiplier)
+                for day, multiplier in zip(trading_days, daily_net_profile, strict=True)
             },
             "daily_filled_notional": daily_filled_notional,
         },

--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -1,0 +1,724 @@
+#!/usr/bin/env python3
+"""Run a whitepaper-driven autoresearch epoch targeting a portfolio profit objective."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from decimal import Decimal
+from pathlib import Path
+from typing import Any, Mapping, Sequence, cast
+
+from sqlalchemy import select
+
+from app.db import SessionLocal
+from app.models import (
+    AutoresearchCandidateSpec,
+    AutoresearchEpoch,
+    AutoresearchPortfolioCandidate,
+    AutoresearchProposalScore,
+    WhitepaperAnalysisRun,
+    VNextExperimentSpec,
+)
+from app.trading.discovery.autoresearch import (
+    load_strategy_autoresearch_program,
+    run_id,
+)
+from app.trading.discovery.candidate_specs import CandidateSpec, compile_candidate_specs
+from app.trading.discovery.evidence_bundles import (
+    CandidateEvidenceBundle,
+    evidence_bundle_from_frontier_candidate,
+)
+from app.trading.discovery.hypothesis_cards import HypothesisCard
+from app.trading.discovery.mlx_snapshot import build_mlx_snapshot_manifest
+from app.trading.discovery.mlx_training_data import build_mlx_training_rows
+from app.trading.discovery.mlx_training_data import rank_training_rows, train_mlx_ranker
+from app.trading.discovery.portfolio_optimizer import (
+    PortfolioCandidateSpec,
+    optimize_portfolio_candidate,
+)
+from app.trading.discovery.runtime_closure import write_runtime_closure_bundle
+from app.whitepapers.claim_compiler import (
+    RECENT_WHITEPAPER_SEEDS,
+    WhitepaperResearchSource,
+    compile_sources_to_hypothesis_cards,
+)
+
+import scripts.run_strategy_factory_v2 as strategy_factory_runner
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run whitepaper autoresearch and assemble a portfolio candidate for a profit target.",
+    )
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--paper-run-id", action="append", default=[])
+    parser.add_argument("--seed-recent-whitepapers", action="store_true")
+    parser.add_argument("--target-net-pnl-per-day", default="500")
+    parser.add_argument("--max-candidates", type=int, default=64)
+    parser.add_argument("--top-k", type=int, default=16)
+    parser.add_argument("--exploration-slots", type=int, default=8)
+    parser.add_argument("--portfolio-size-min", type=int, default=2)
+    parser.add_argument("--portfolio-size-max", type=int, default=8)
+    parser.add_argument("--replay-mode", choices=("synthetic", "real"), default="real")
+    parser.add_argument(
+        "--program",
+        type=Path,
+        default=Path(
+            "config/trading/research-programs/strict-daily-profit-autoresearch-v1.yaml"
+        ),
+    )
+    parser.add_argument(
+        "--strategy-configmap",
+        type=Path,
+        default=Path("argocd/applications/torghut/strategy-configmap.yaml"),
+    )
+    parser.add_argument(
+        "--family-template-dir",
+        type=Path,
+        default=Path("config/trading/families"),
+    )
+    parser.add_argument(
+        "--seed-sweep-dir",
+        type=Path,
+        default=Path("config/trading"),
+    )
+    parser.add_argument(
+        "--clickhouse-http-url",
+        default="http://torghut-clickhouse.torghut.svc.cluster.local:8123",
+    )
+    parser.add_argument("--clickhouse-username", default="torghut")
+    parser.add_argument("--clickhouse-password", default="")
+    parser.add_argument("--start-equity", default="31590.02")
+    parser.add_argument("--chunk-minutes", type=int, default=10)
+    parser.add_argument("--symbols", default="AAPL,NVDA,MSFT,AMAT")
+    parser.add_argument("--progress-log-seconds", type=int, default=30)
+    parser.add_argument("--train-days", type=int, default=6)
+    parser.add_argument("--holdout-days", type=int, default=3)
+    parser.add_argument("--full-window-start-date", default="")
+    parser.add_argument("--full-window-end-date", default="")
+    parser.add_argument("--expected-last-trading-day", default="")
+    parser.add_argument("--allow-stale-tape", action="store_true")
+    parser.add_argument("--prefetch-full-window-rows", action="store_true")
+    parser.add_argument(
+        "--persist-results", dest="persist_results", action="store_true"
+    )
+    parser.add_argument(
+        "--no-persist-results", dest="persist_results", action="store_false"
+    )
+    parser.set_defaults(persist_results=True)
+    return parser.parse_args()
+
+
+@dataclass(frozen=True)
+class EpochReplayResult:
+    evidence_bundles: tuple[CandidateEvidenceBundle, ...]
+    replay_results: tuple[Mapping[str, Any], ...]
+
+
+def _write_json(path: Path, payload: Mapping[str, Any]) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+    return path
+
+
+def _write_jsonl(path: Path, rows: Sequence[Mapping[str, Any]]) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "\n".join(json.dumps(row, sort_keys=True) for row in rows)
+        + ("\n" if rows else ""),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _stable_hash(payload: Mapping[str, Any]) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _decimal(value: Any, *, default: str = "0") -> Decimal:
+    try:
+        return Decimal(str(value if value is not None else default))
+    except Exception:
+        return Decimal(default)
+
+
+def _mapping(value: Any) -> dict[str, Any]:
+    return (
+        {str(key): item for key, item in value.items()}
+        if isinstance(value, Mapping)
+        else {}
+    )
+
+
+def _list_of_mappings(value: Any) -> list[Mapping[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    return [
+        cast(Mapping[str, Any], item) for item in value if isinstance(item, Mapping)
+    ]
+
+
+def _load_sources_from_db(
+    paper_run_ids: Sequence[str],
+) -> list[WhitepaperResearchSource]:
+    if not paper_run_ids:
+        return []
+    run_id_set = {item.strip() for item in paper_run_ids if item.strip()}
+    with SessionLocal() as session:
+        rows = session.execute(
+            select(WhitepaperAnalysisRun).where(
+                WhitepaperAnalysisRun.run_id.in_(sorted(run_id_set))
+            )
+        ).scalars()
+        sources: list[WhitepaperResearchSource] = []
+        for row in rows:
+            claims = [
+                {
+                    "claim_id": claim.claim_id,
+                    "claim_type": claim.claim_type,
+                    "claim_text": claim.claim_text,
+                    "asset_scope": claim.asset_scope,
+                    "horizon_scope": claim.horizon_scope,
+                    "data_requirements": claim.data_requirements_json,
+                    "expected_direction": claim.expected_direction,
+                    "required_activity_conditions": claim.required_activity_conditions_json,
+                    "liquidity_constraints": claim.liquidity_constraints_json,
+                    "validation_notes": claim.validation_notes,
+                    "confidence": str(claim.confidence)
+                    if claim.confidence is not None
+                    else None,
+                    "metadata": claim.metadata_json,
+                }
+                for claim in row.claims
+            ]
+            relations = [
+                {
+                    "relation_id": relation.relation_id,
+                    "relation_type": relation.relation_type,
+                    "source_claim_id": relation.source_claim_id,
+                    "target_claim_id": relation.target_claim_id,
+                    "target_run_id": relation.target_run_id,
+                    "rationale": relation.rationale,
+                    "confidence": str(relation.confidence)
+                    if relation.confidence is not None
+                    else None,
+                    "metadata": relation.metadata_json,
+                }
+                for relation in row.claim_relations
+            ]
+            sources.append(
+                WhitepaperResearchSource(
+                    run_id=row.run_id,
+                    title=row.document.title or row.run_id,
+                    source_url=str(
+                        _mapping(row.document.metadata_json).get("source_url") or ""
+                    ),
+                    published_at=str(row.document.published_at or ""),
+                    claims=tuple(claims),
+                    claim_relations=tuple(relations),
+                )
+            )
+        return sources
+
+
+def _persist_vnext_specs(*, source_run_id: str, specs: Sequence[CandidateSpec]) -> None:
+    with SessionLocal() as session:
+        for spec in specs:
+            session.add(
+                VNextExperimentSpec(
+                    run_id=source_run_id,
+                    candidate_id=None,
+                    experiment_id=f"{spec.candidate_spec_id}-exp",
+                    payload_json=spec.to_vnext_experiment_payload(),
+                )
+            )
+        session.commit()
+
+
+def _persist_epoch_ledgers(
+    *,
+    epoch_id: str,
+    status: str,
+    target_net_pnl_per_day: Decimal,
+    paper_run_ids: Sequence[str],
+    sources: Sequence[WhitepaperResearchSource],
+    candidate_specs: Sequence[CandidateSpec],
+    proposal_rows: Sequence[Mapping[str, Any]],
+    portfolio: PortfolioCandidateSpec | None,
+    summary: Mapping[str, Any],
+    runner_config: Mapping[str, Any],
+    started_at: datetime,
+    completed_at: datetime,
+    failure_reason: str | None = None,
+) -> None:
+    with SessionLocal() as session:
+        session.add(
+            AutoresearchEpoch(
+                epoch_id=epoch_id,
+                status=status,
+                target_net_pnl_per_day=target_net_pnl_per_day,
+                paper_run_ids_json=list(paper_run_ids),
+                snapshot_manifest_json={
+                    "source_count": len(sources),
+                    "paper_sources": [source.to_payload() for source in sources],
+                },
+                runner_config_json=dict(runner_config),
+                summary_json=dict(summary),
+                started_at=started_at,
+                completed_at=completed_at,
+                failure_reason=failure_reason,
+            )
+        )
+        for spec in candidate_specs:
+            payload = spec.to_payload()
+            session.add(
+                AutoresearchCandidateSpec(
+                    candidate_spec_id=spec.candidate_spec_id,
+                    epoch_id=epoch_id,
+                    hypothesis_id=spec.hypothesis_id,
+                    candidate_kind=spec.candidate_kind,
+                    family_template_id=spec.family_template_id,
+                    payload_json=payload,
+                    payload_hash=_stable_hash(payload),
+                    status="eligible",
+                    blockers_json=[],
+                )
+            )
+        for item in proposal_rows:
+            candidate_spec_id = str(item.get("candidate_spec_id") or "").strip()
+            if not candidate_spec_id:
+                continue
+            feature_payload = _mapping(item.get("features"))
+            session.add(
+                AutoresearchProposalScore(
+                    epoch_id=epoch_id,
+                    candidate_spec_id=candidate_spec_id,
+                    model_id=str(item.get("model_id") or "unknown"),
+                    backend=str(item.get("backend") or "unknown"),
+                    proposal_score=_decimal(item.get("proposal_score")),
+                    rank=int(item.get("rank") or 0),
+                    selection_reason=str(item.get("selection_reason") or "unselected"),
+                    feature_hash=_stable_hash(feature_payload)
+                    if feature_payload
+                    else None,
+                    payload_json=dict(item),
+                )
+            )
+        if portfolio is not None:
+            portfolio_payload = portfolio.to_payload()
+            session.add(
+                AutoresearchPortfolioCandidate(
+                    portfolio_candidate_id=portfolio.portfolio_candidate_id,
+                    epoch_id=epoch_id,
+                    source_candidate_ids_json=list(portfolio.source_candidate_ids),
+                    target_net_pnl_per_day=portfolio.target_net_pnl_per_day,
+                    objective_scorecard_json=dict(portfolio.objective_scorecard),
+                    optimizer_report_json=dict(portfolio.optimizer_report),
+                    payload_json=portfolio_payload,
+                    status="target_met"
+                    if bool(portfolio.objective_scorecard.get("target_met"))
+                    else "target_missed",
+                )
+            )
+        session.commit()
+
+
+def _proposal_model_and_rows(
+    *,
+    specs: Sequence[CandidateSpec],
+    evidence_bundles: Sequence[CandidateEvidenceBundle],
+) -> tuple[Mapping[str, Any], list[dict[str, Any]]]:
+    training_rows = build_mlx_training_rows(
+        candidate_specs=specs, evidence_bundles=evidence_bundles
+    )
+    model = train_mlx_ranker(training_rows, backend_preference="mlx")
+    ranked_rows = rank_training_rows(model=model, rows=training_rows)
+    feature_by_spec = {
+        row.candidate_spec_id: row.to_payload()["features"] for row in training_rows
+    }
+    proposal_rows = [
+        {
+            "candidate_spec_id": item.candidate_spec_id,
+            "proposal_score": item.score,
+            "rank": item.rank,
+            "backend": item.backend,
+            "model_id": item.model_id,
+            "selection_reason": "exploitation",
+            "feature_hash": item.feature_hash,
+            "features": feature_by_spec.get(item.candidate_spec_id, {}),
+        }
+        for item in ranked_rows
+    ]
+    return model.to_payload(), proposal_rows
+
+
+def _synthetic_net_for_spec(spec: CandidateSpec, *, rank: int) -> Decimal:
+    family_bonus = {
+        "microbar_cross_sectional_pairs_v1": Decimal("215"),
+        "microstructure_continuation_matched_filter_v1": Decimal("190"),
+        "momentum_pullback_v1": Decimal("175"),
+        "washout_rebound_v2": Decimal("165"),
+        "breakout_reclaim_v2": Decimal("155"),
+    }.get(spec.family_template_id, Decimal("125"))
+    return family_bonus + Decimal(max(0, 12 - rank) * 5)
+
+
+def _synthetic_candidate_payload(spec: CandidateSpec, *, rank: int) -> dict[str, Any]:
+    net = _synthetic_net_for_spec(spec, rank=rank)
+    active = Decimal("0.92") if rank <= 3 else Decimal("0.82")
+    positive = Decimal("0.64") if rank <= 3 else Decimal("0.58")
+    return {
+        "candidate_id": f"cand-{spec.candidate_spec_id}",
+        "candidate_spec_id": spec.candidate_spec_id,
+        "runtime_family": spec.runtime_family,
+        "runtime_strategy_name": spec.runtime_strategy_name,
+        "family_template_id": spec.family_template_id,
+        "objective_scorecard": {
+            "net_pnl_per_day": str(net),
+            "active_day_ratio": str(active),
+            "positive_day_ratio": str(positive),
+            "avg_filled_notional_per_day": "350000",
+            "worst_day_loss": "180",
+            "max_drawdown": "520",
+            "best_day_share": "0.20",
+            "regime_slice_pass_rate": "0.55",
+        },
+        "full_window": {
+            "net_per_day": str(net),
+            "daily_net": {
+                "2026-02-23": str(net * Decimal("0.80")),
+                "2026-02-24": str(net * Decimal("1.10")),
+                "2026-02-25": str(net * Decimal("0.90")),
+                "2026-02-26": str(net * Decimal("1.05")),
+                "2026-02-27": str(net * Decimal("1.15")),
+            },
+        },
+        "promotion_readiness": {
+            "stage": "research_candidate",
+            "status": "blocked_pending_runtime_parity",
+            "promotable": False,
+            "blockers": ["scheduler_v3_parity_missing", "shadow_validation_missing"],
+        },
+    }
+
+
+def _run_synthetic_replay(
+    *,
+    specs: Sequence[CandidateSpec],
+    output_dir: Path,
+    max_candidates: int,
+) -> EpochReplayResult:
+    evidence_bundles: list[CandidateEvidenceBundle] = []
+    replay_results: list[Mapping[str, Any]] = []
+    for rank, spec in enumerate(specs[: max(1, max_candidates)], start=1):
+        candidate = _synthetic_candidate_payload(spec, rank=rank)
+        result_path = (
+            output_dir / "synthetic-replays" / f"{spec.candidate_spec_id}.json"
+        )
+        result_payload = {
+            "schema_version": "torghut.synthetic-autoresearch-replay.v1",
+            "dataset_snapshot_receipt": {
+                "snapshot_id": "synthetic-recent-whitepaper-2025-2026"
+            },
+            "top": [candidate],
+        }
+        _write_json(result_path, result_payload)
+        evidence_bundles.append(
+            evidence_bundle_from_frontier_candidate(
+                candidate_spec_id=spec.candidate_spec_id,
+                candidate=candidate,
+                dataset_snapshot_id="synthetic-recent-whitepaper-2025-2026",
+                result_path=str(result_path),
+            )
+        )
+        replay_results.append(result_payload)
+    return EpochReplayResult(
+        evidence_bundles=tuple(evidence_bundles), replay_results=tuple(replay_results)
+    )
+
+
+def _run_real_replay(
+    args: argparse.Namespace, *, output_dir: Path
+) -> EpochReplayResult:
+    factory_payload = strategy_factory_runner.run_strategy_factory_v2(
+        argparse.Namespace(
+            output_dir=output_dir / "strategy-factory",
+            experiment_id=[],
+            paper_run_id=args.paper_run_id,
+            limit=max(1, int(args.max_candidates)),
+            strategy_configmap=args.strategy_configmap,
+            family_template_dir=args.family_template_dir,
+            seed_sweep_dir=args.seed_sweep_dir,
+            clickhouse_http_url=args.clickhouse_http_url,
+            clickhouse_username=args.clickhouse_username,
+            clickhouse_password=args.clickhouse_password,
+            start_equity=args.start_equity,
+            chunk_minutes=args.chunk_minutes,
+            symbols=args.symbols,
+            progress_log_seconds=args.progress_log_seconds,
+            train_days=args.train_days,
+            holdout_days=args.holdout_days,
+            full_window_start_date=args.full_window_start_date,
+            full_window_end_date=args.full_window_end_date,
+            expected_last_trading_day=args.expected_last_trading_day,
+            allow_stale_tape=args.allow_stale_tape,
+            prefetch_full_window_rows=args.prefetch_full_window_rows,
+            top_n=args.top_k,
+            persist_results=args.persist_results,
+        )
+    )
+    evidence_bundles: list[CandidateEvidenceBundle] = []
+    for item in _list_of_mappings(factory_payload.get("experiments")):
+        result_path = str(item.get("result_path") or "")
+        if not result_path:
+            continue
+        result_payload = json.loads(Path(result_path).read_text(encoding="utf-8"))
+        top = _list_of_mappings(result_payload.get("top"))
+        if not top:
+            continue
+        candidate = dict(top[0])
+        candidate["promotion_readiness"] = item.get("promotion_readiness")
+        evidence_bundles.append(
+            evidence_bundle_from_frontier_candidate(
+                candidate_spec_id=str(
+                    item.get("experiment_id") or item.get("top_candidate_id") or ""
+                ),
+                candidate=candidate,
+                dataset_snapshot_id=str(item.get("dataset_snapshot_id") or ""),
+                result_path=result_path,
+            )
+        )
+    return EpochReplayResult(
+        evidence_bundles=tuple(evidence_bundles), replay_results=(factory_payload,)
+    )
+
+
+def _runtime_closure_payload(
+    *,
+    args: argparse.Namespace,
+    output_dir: Path,
+    epoch_id: str,
+    portfolio: PortfolioCandidateSpec | None,
+) -> Mapping[str, Any]:
+    program = load_strategy_autoresearch_program(
+        args.program.resolve(), family_dir=args.family_template_dir.resolve()
+    )
+    manifest = build_mlx_snapshot_manifest(
+        runner_run_id=epoch_id,
+        program=program,
+        symbols=str(args.symbols),
+        train_days=int(args.train_days),
+        holdout_days=int(args.holdout_days),
+        full_window_start_date=str(args.full_window_start_date),
+        full_window_end_date=str(args.full_window_end_date),
+        tensor_bundle_paths={
+            "candidate_evidence_bundles_jsonl": str(
+                output_dir / "candidate-evidence-bundles.jsonl"
+            ),
+            "portfolio_candidates_jsonl": str(
+                output_dir / "portfolio-candidates.jsonl"
+            ),
+        },
+    )
+    best_candidate = None
+    if portfolio is not None:
+        best_candidate = {
+            "candidate_id": portfolio.portfolio_candidate_id,
+            "family_template_id": "portfolio_whitepaper_autoresearch_v1",
+            "objective_scorecard": dict(portfolio.objective_scorecard),
+            "portfolio": {
+                "base_per_leg_notional": "50000",
+                "sleeves": [dict(item) for item in portfolio.sleeves],
+            },
+            "promotion_status": "blocked_pending_runtime_parity",
+            "promotion_stage": "research_candidate",
+            "promotion_blockers": [
+                "scheduler_v3_parity_missing",
+                "shadow_validation_missing",
+            ],
+            "promotion_required_evidence": [
+                "scheduler_v3_parity_replay",
+                "shadow_validation",
+            ],
+        }
+    return write_runtime_closure_bundle(
+        run_root=output_dir,
+        runner_run_id=epoch_id,
+        program=program,
+        best_candidate=best_candidate,
+        manifest=manifest,
+        execution_context=None,
+    ).to_payload()
+
+
+def run_whitepaper_autoresearch_profit_target(
+    args: argparse.Namespace,
+) -> dict[str, Any]:
+    epoch_id = run_id("whitepaper-autoresearch")
+    started_at = datetime.now(UTC)
+    output_dir = args.output_dir.resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    target = _decimal(args.target_net_pnl_per_day, default="500")
+    sources = []
+    if args.seed_recent_whitepapers:
+        sources.extend(RECENT_WHITEPAPER_SEEDS)
+    sources.extend(_load_sources_from_db(args.paper_run_id))
+    if not sources:
+        summary = {
+            "status": "no_sources",
+            "epoch_id": epoch_id,
+            "run_root": str(output_dir),
+        }
+        _write_json(output_dir / "summary.json", summary)
+        return summary
+
+    hypothesis_cards: list[HypothesisCard] = compile_sources_to_hypothesis_cards(
+        sources
+    )
+    candidate_specs = compile_candidate_specs(
+        hypothesis_cards=hypothesis_cards, target_net_pnl_per_day=target
+    )
+    candidate_specs = candidate_specs[: max(1, int(args.max_candidates))]
+    if args.persist_results and args.replay_mode == "real":
+        for source in sources:
+            source_specs = [
+                spec
+                for spec in candidate_specs
+                if spec.feature_contract.get("source_run_id") == source.run_id
+            ]
+            _persist_vnext_specs(source_run_id=source.run_id, specs=source_specs)
+
+    _write_json(
+        output_dir / "epoch-manifest.json",
+        {
+            "epoch_id": epoch_id,
+            "started_at": datetime.now(UTC).isoformat(),
+            "target_net_pnl_per_day": str(target),
+            "replay_mode": args.replay_mode,
+            "source_count": len(sources),
+            "paper_sources": [source.to_payload() for source in sources],
+        },
+    )
+    _write_jsonl(
+        output_dir / "hypothesis-cards.jsonl",
+        [card.to_payload() for card in hypothesis_cards],
+    )
+    _write_jsonl(
+        output_dir / "candidate-specs.jsonl",
+        [spec.to_payload() for spec in candidate_specs],
+    )
+
+    replay_result = (
+        _run_synthetic_replay(
+            specs=candidate_specs,
+            output_dir=output_dir,
+            max_candidates=int(args.max_candidates),
+        )
+        if args.replay_mode == "synthetic"
+        else _run_real_replay(args, output_dir=output_dir)
+    )
+    proposal_model, proposal_rows = _proposal_model_and_rows(
+        specs=candidate_specs, evidence_bundles=replay_result.evidence_bundles
+    )
+    _write_json(output_dir / "mlx-ranker-model.json", proposal_model)
+    _write_jsonl(output_dir / "mlx-proposal-scores.jsonl", proposal_rows)
+    _write_jsonl(
+        output_dir / "candidate-evidence-bundles.jsonl",
+        [bundle.to_payload() for bundle in replay_result.evidence_bundles],
+    )
+
+    portfolio = optimize_portfolio_candidate(
+        evidence_bundles=replay_result.evidence_bundles,
+        target_net_pnl_per_day=target,
+        portfolio_size_min=int(args.portfolio_size_min),
+        portfolio_size_max=int(args.portfolio_size_max),
+    )
+    portfolio_rows = [portfolio.to_payload()] if portfolio is not None else []
+    _write_jsonl(output_dir / "portfolio-candidates.jsonl", portfolio_rows)
+    _write_json(
+        output_dir / "portfolio-optimizer-report.json",
+        portfolio.optimizer_report
+        if portfolio is not None
+        else {"status": "no_portfolio_candidate"},
+    )
+    runtime_closure = _runtime_closure_payload(
+        args=args, output_dir=output_dir, epoch_id=epoch_id, portfolio=portfolio
+    )
+    summary = {
+        "status": "ok",
+        "epoch_id": epoch_id,
+        "run_root": str(output_dir),
+        "target_net_pnl_per_day": str(target),
+        "source_count": len(sources),
+        "hypothesis_count": len(hypothesis_cards),
+        "candidate_spec_count": len(candidate_specs),
+        "evidence_bundle_count": len(replay_result.evidence_bundles),
+        "proposal_score_count": len(proposal_rows),
+        "best_portfolio_candidate": portfolio.to_payload()
+        if portfolio is not None
+        else None,
+        "promotion_readiness": {
+            "status": "blocked_pending_runtime_parity"
+            if portfolio is not None
+            else "no_candidate",
+            "promotable": False,
+            "blockers": ["scheduler_v3_parity_missing", "shadow_validation_missing"]
+            if portfolio is not None
+            else [],
+        },
+        "runtime_closure": runtime_closure,
+        "artifacts": {
+            "epoch_manifest": str(output_dir / "epoch-manifest.json"),
+            "hypothesis_cards": str(output_dir / "hypothesis-cards.jsonl"),
+            "candidate_specs": str(output_dir / "candidate-specs.jsonl"),
+            "proposal_scores": str(output_dir / "mlx-proposal-scores.jsonl"),
+            "proposal_model": str(output_dir / "mlx-ranker-model.json"),
+            "candidate_evidence_bundles": str(
+                output_dir / "candidate-evidence-bundles.jsonl"
+            ),
+            "portfolio_candidates": str(output_dir / "portfolio-candidates.jsonl"),
+            "portfolio_optimizer_report": str(
+                output_dir / "portfolio-optimizer-report.json"
+            ),
+        },
+    }
+    if args.persist_results:
+        _persist_epoch_ledgers(
+            epoch_id=epoch_id,
+            status="ok",
+            target_net_pnl_per_day=target,
+            paper_run_ids=[str(item) for item in args.paper_run_id],
+            sources=sources,
+            candidate_specs=candidate_specs,
+            proposal_rows=proposal_rows,
+            portfolio=portfolio,
+            summary=summary,
+            runner_config={
+                "replay_mode": args.replay_mode,
+                "max_candidates": int(args.max_candidates),
+                "top_k": int(args.top_k),
+                "exploration_slots": int(args.exploration_slots),
+                "portfolio_size_min": int(args.portfolio_size_min),
+                "portfolio_size_max": int(args.portfolio_size_max),
+            },
+            started_at=started_at,
+            completed_at=datetime.now(UTC),
+        )
+    _write_json(output_dir / "summary.json", summary)
+    return summary
+
+
+def main() -> int:
+    args = _parse_args()
+    payload = run_whitepaper_autoresearch_profit_target(args)
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0 if payload.get("status") == "ok" else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -544,6 +544,31 @@ def _pre_replay_proposal_model_and_rows(
     }, rows
 
 
+def _proposal_score_confidence(
+    proposal_rows: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    scores = [
+        Decimal(str(row.get("proposal_score")))
+        for row in _list_of_mappings(list(proposal_rows))
+        if row.get("proposal_score") is not None
+    ]
+    if len(scores) < 2:
+        return {
+            "confidence": "low",
+            "score_spread": "0",
+            "reason": "insufficient_ranked_candidates",
+        }
+    score_spread = max(scores) - min(scores)
+    confidence = "low" if score_spread < Decimal("5") else "normal"
+    return {
+        "confidence": confidence,
+        "score_spread": str(score_spread),
+        "reason": "low_score_dispersion"
+        if confidence == "low"
+        else "score_dispersion_sufficient",
+    }
+
+
 def _select_candidate_specs_for_replay(
     *,
     specs: Sequence[CandidateSpec],
@@ -561,7 +586,12 @@ def _select_candidate_specs_for_replay(
         }
     spec_by_id = {spec.candidate_spec_id: spec for spec in specs}
     max_budget = max(1, int(max_candidates))
-    requested_budget = max(0, int(top_k)) + max(0, int(exploration_slots))
+    model_confidence = _proposal_score_confidence(proposal_rows)
+    requested_exploration_slots = max(0, int(exploration_slots))
+    effective_exploration_slots = requested_exploration_slots + (
+        1 if model_confidence["confidence"] == "low" else 0
+    )
+    requested_budget = max(0, int(top_k)) + effective_exploration_slots
     replay_budget = min(max_budget, max(1, int(portfolio_size_min), requested_budget))
     ranked_ids = [
         str(row.get("candidate_spec_id"))
@@ -593,7 +623,7 @@ def _select_candidate_specs_for_replay(
         not in {spec.candidate_spec_id for spec in exploitation}
     ]
     exploration_count = min(
-        max(0, int(exploration_slots)),
+        effective_exploration_slots,
         replay_budget - len(exploitation),
         len(remaining),
     )
@@ -642,11 +672,14 @@ def _select_candidate_specs_for_replay(
         "budget": {
             "max_candidates": max_budget,
             "top_k": max(0, int(top_k)),
-            "exploration_slots": max(0, int(exploration_slots)),
+            "exploration_slots_requested": requested_exploration_slots,
+            "exploration_slots_effective": effective_exploration_slots,
+            "exploration_slots": effective_exploration_slots,
             "portfolio_size_min": max(1, int(portfolio_size_min)),
             "selected_count": len(selected),
             "compiled_candidate_count": len(specs),
         },
+        "proposal_score_confidence": model_confidence,
         "selected_candidate_spec_ids": [item.candidate_spec_id for item in selected],
         "rows": rows,
     }

--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -1197,8 +1197,9 @@ def run_whitepaper_autoresearch_profit_target(
         hypothesis_cards=hypothesis_cards,
         target_net_pnl_per_day=target,
         family_template_dir=args.family_template_dir.resolve(),
+        seed_sweep_dir=args.seed_sweep_dir.resolve(),
     )
-    candidate_specs = list(compilation.executable_specs or compilation.candidate_specs)
+    candidate_specs = list(compilation.executable_specs)
     candidate_specs = candidate_specs[: max(1, int(args.max_candidates))]
     blocker_by_spec: dict[str, list[CandidateCompilationBlocker]] = {}
     for blocker in compilation.blockers:

--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import UTC, datetime
 from decimal import Decimal
 from pathlib import Path
@@ -40,7 +40,10 @@ from app.trading.discovery.portfolio_optimizer import (
     PortfolioCandidateSpec,
     optimize_portfolio_candidate,
 )
-from app.trading.discovery.runtime_closure import write_runtime_closure_bundle
+from app.trading.discovery.runtime_closure import (
+    RuntimeClosureExecutionContext,
+    write_runtime_closure_bundle,
+)
 from app.trading.discovery.whitepaper_autoresearch_notebooks import (
     write_whitepaper_autoresearch_diagnostics_notebook,
 )
@@ -140,6 +143,17 @@ def _write_jsonl(path: Path, rows: Sequence[Mapping[str, Any]]) -> Path:
         encoding="utf-8",
     )
     return path
+
+
+def _resolve_existing_path(path: Path) -> Path:
+    resolved = path.expanduser().resolve()
+    if path.is_absolute() or resolved.exists():
+        return resolved
+    for parent in Path(__file__).resolve().parents:
+        candidate = (parent / path).resolve()
+        if candidate.exists():
+            return candidate
+    return resolved
 
 
 def _write_failure_summary(
@@ -594,8 +608,34 @@ def _runtime_closure_payload(
     portfolio: PortfolioCandidateSpec | None,
 ) -> Mapping[str, Any]:
     program = load_strategy_autoresearch_program(
-        args.program.resolve(), family_dir=args.family_template_dir.resolve()
+        _resolve_existing_path(args.program),
+        family_dir=_resolve_existing_path(args.family_template_dir),
     )
+    execution_context = RuntimeClosureExecutionContext(
+        strategy_configmap_path=_resolve_existing_path(args.strategy_configmap),
+        clickhouse_http_url=str(args.clickhouse_http_url),
+        clickhouse_username=str(args.clickhouse_username)
+        if args.clickhouse_username
+        else None,
+        clickhouse_password=str(args.clickhouse_password)
+        if args.clickhouse_password
+        else None,
+        start_equity=_decimal(args.start_equity, default="31590.02"),
+        chunk_minutes=int(args.chunk_minutes),
+        symbols=tuple(
+            symbol.strip() for symbol in str(args.symbols).split(",") if symbol.strip()
+        ),
+        progress_log_interval_seconds=int(args.progress_log_seconds),
+    )
+    if args.replay_mode == "synthetic":
+        program = replace(
+            program,
+            runtime_closure_policy=replace(
+                program.runtime_closure_policy,
+                execute_parity_replay=False,
+                execute_approval_replay=False,
+            ),
+        )
     manifest = build_mlx_snapshot_manifest(
         runner_run_id=epoch_id,
         program=program,
@@ -640,7 +680,7 @@ def _runtime_closure_payload(
         program=program,
         best_candidate=best_candidate,
         manifest=manifest,
-        execution_context=None,
+        execution_context=execution_context if portfolio is not None else None,
     ).to_payload()
 
 

--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -24,6 +24,7 @@ from app.models import (
     VNextExperimentSpec,
 )
 from app.trading.discovery.autoresearch import (
+    StrategyAutoresearchProgram,
     load_strategy_autoresearch_program,
     run_id,
 )
@@ -34,6 +35,8 @@ from app.trading.discovery.evidence_bundles import (
 )
 from app.trading.discovery.hypothesis_cards import HypothesisCard
 from app.trading.discovery.mlx_snapshot import build_mlx_snapshot_manifest
+from app.trading.discovery.mlx_snapshot import MlxSnapshotManifest
+from app.trading.discovery.mlx_snapshot import write_mlx_snapshot_manifest
 from app.trading.discovery.mlx_training_data import build_mlx_training_rows
 from app.trading.discovery.mlx_training_data import rank_training_rows, train_mlx_ranker
 from app.trading.discovery.portfolio_optimizer import (
@@ -998,17 +1001,85 @@ def _run_real_replay(
     )
 
 
+def _load_epoch_program(args: argparse.Namespace) -> StrategyAutoresearchProgram:
+    program = load_strategy_autoresearch_program(
+        _resolve_existing_path(args.program),
+        family_dir=_resolve_existing_path(args.family_template_dir),
+    )
+    if args.replay_mode == "synthetic":
+        return replace(
+            program,
+            runtime_closure_policy=replace(
+                program.runtime_closure_policy,
+                execute_parity_replay=False,
+                execute_approval_replay=False,
+            ),
+        )
+    return program
+
+
+def _epoch_mlx_snapshot_manifest(
+    *,
+    args: argparse.Namespace,
+    output_dir: Path,
+    epoch_id: str,
+    program: StrategyAutoresearchProgram,
+    source_count: int,
+    hypothesis_count: int,
+    candidate_spec_count: int,
+    pre_replay_proposal_score_count: int,
+    replay_candidate_spec_count: int,
+    evidence_bundle_count: int,
+    proposal_score_count: int,
+    portfolio_candidate_count: int,
+) -> MlxSnapshotManifest:
+    return build_mlx_snapshot_manifest(
+        runner_run_id=epoch_id,
+        program=program,
+        symbols=str(args.symbols),
+        train_days=int(args.train_days),
+        holdout_days=int(args.holdout_days),
+        full_window_start_date=str(args.full_window_start_date),
+        full_window_end_date=str(args.full_window_end_date),
+        tensor_bundle_paths={
+            "hypothesis_cards_jsonl": str(output_dir / "hypothesis-cards.jsonl"),
+            "candidate_specs_jsonl": str(output_dir / "candidate-specs.jsonl"),
+            "candidate_selection_manifest_json": str(
+                output_dir / "candidate-selection-manifest.json"
+            ),
+            "pre_replay_proposal_scores_jsonl": str(
+                output_dir / "pre-replay-mlx-proposal-scores.jsonl"
+            ),
+            "proposal_scores_jsonl": str(output_dir / "mlx-proposal-scores.jsonl"),
+            "candidate_evidence_bundles_jsonl": str(
+                output_dir / "candidate-evidence-bundles.jsonl"
+            ),
+            "portfolio_candidates_jsonl": str(
+                output_dir / "portfolio-candidates.jsonl"
+            ),
+        },
+        row_counts={
+            "sources": source_count,
+            "hypothesis_cards": hypothesis_count,
+            "candidate_specs": candidate_spec_count,
+            "pre_replay_proposal_scores": pre_replay_proposal_score_count,
+            "replay_candidate_specs": replay_candidate_spec_count,
+            "candidate_evidence_bundles": evidence_bundle_count,
+            "proposal_scores": proposal_score_count,
+            "portfolio_candidates": portfolio_candidate_count,
+        },
+    )
+
+
 def _runtime_closure_payload(
     *,
     args: argparse.Namespace,
     output_dir: Path,
     epoch_id: str,
+    program: StrategyAutoresearchProgram,
+    manifest: MlxSnapshotManifest,
     portfolio: PortfolioCandidateSpec | None,
 ) -> Mapping[str, Any]:
-    program = load_strategy_autoresearch_program(
-        _resolve_existing_path(args.program),
-        family_dir=_resolve_existing_path(args.family_template_dir),
-    )
     execution_context = RuntimeClosureExecutionContext(
         strategy_configmap_path=_resolve_existing_path(args.strategy_configmap),
         clickhouse_http_url=str(args.clickhouse_http_url),
@@ -1024,32 +1095,6 @@ def _runtime_closure_payload(
             symbol.strip() for symbol in str(args.symbols).split(",") if symbol.strip()
         ),
         progress_log_interval_seconds=int(args.progress_log_seconds),
-    )
-    if args.replay_mode == "synthetic":
-        program = replace(
-            program,
-            runtime_closure_policy=replace(
-                program.runtime_closure_policy,
-                execute_parity_replay=False,
-                execute_approval_replay=False,
-            ),
-        )
-    manifest = build_mlx_snapshot_manifest(
-        runner_run_id=epoch_id,
-        program=program,
-        symbols=str(args.symbols),
-        train_days=int(args.train_days),
-        holdout_days=int(args.holdout_days),
-        full_window_start_date=str(args.full_window_start_date),
-        full_window_end_date=str(args.full_window_end_date),
-        tensor_bundle_paths={
-            "candidate_evidence_bundles_jsonl": str(
-                output_dir / "candidate-evidence-bundles.jsonl"
-            ),
-            "portfolio_candidates_jsonl": str(
-                output_dir / "portfolio-candidates.jsonl"
-            ),
-        },
     )
     best_candidate = None
     if portfolio is not None:
@@ -1240,8 +1285,31 @@ def run_whitepaper_autoresearch_profit_target(
         if portfolio is not None
         else {"status": "no_portfolio_candidate"},
     )
+    program = _load_epoch_program(args)
+    mlx_snapshot_manifest = _epoch_mlx_snapshot_manifest(
+        args=args,
+        output_dir=output_dir,
+        epoch_id=epoch_id,
+        program=program,
+        source_count=len(sources),
+        hypothesis_count=len(hypothesis_cards),
+        candidate_spec_count=len(candidate_specs),
+        pre_replay_proposal_score_count=len(pre_replay_proposal_rows),
+        replay_candidate_spec_count=len(replay_candidate_specs),
+        evidence_bundle_count=len(replay_result.evidence_bundles),
+        proposal_score_count=len(proposal_rows),
+        portfolio_candidate_count=len(portfolio_rows),
+    )
+    write_mlx_snapshot_manifest(
+        output_dir / "mlx-snapshot-manifest.json", mlx_snapshot_manifest
+    )
     runtime_closure = _runtime_closure_payload(
-        args=args, output_dir=output_dir, epoch_id=epoch_id, portfolio=portfolio
+        args=args,
+        output_dir=output_dir,
+        epoch_id=epoch_id,
+        program=program,
+        manifest=mlx_snapshot_manifest,
+        portfolio=portfolio,
     )
     oracle_candidate_found = bool(
         portfolio is not None
@@ -1315,6 +1383,7 @@ def run_whitepaper_autoresearch_profit_target(
             "pre_replay_proposal_model": str(
                 output_dir / "pre-replay-mlx-ranker-model.json"
             ),
+            "mlx_snapshot_manifest": str(output_dir / "mlx-snapshot-manifest.json"),
             "candidate_compiler_report": str(
                 output_dir / "candidate-compiler-report.json"
             ),

--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -381,6 +381,7 @@ def _proposal_model_and_rows(
     *,
     specs: Sequence[CandidateSpec],
     evidence_bundles: Sequence[CandidateEvidenceBundle],
+    replay_selection_by_spec: Mapping[str, Mapping[str, Any]] | None = None,
 ) -> tuple[Mapping[str, Any], list[dict[str, Any]]]:
     training_rows = build_mlx_training_rows(
         candidate_specs=specs, evidence_bundles=evidence_bundles
@@ -398,6 +399,18 @@ def _proposal_model_and_rows(
             "backend": item.backend,
             "model_id": item.model_id,
             "selection_reason": "exploitation",
+            "replay_selection_reason": _mapping(
+                replay_selection_by_spec.get(item.candidate_spec_id)
+                if replay_selection_by_spec is not None
+                else None
+            ).get("selection_reason", "not_selected_budget"),
+            "selected_for_replay": bool(
+                _mapping(
+                    replay_selection_by_spec.get(item.candidate_spec_id)
+                    if replay_selection_by_spec is not None
+                    else None
+                ).get("selected_for_replay")
+            ),
             "feature_hash": item.feature_hash,
             "features": feature_by_spec.get(item.candidate_spec_id, {}),
         }
@@ -446,6 +459,116 @@ def _proposal_model_and_rows(
             for index, row in enumerate(proposal_rows, start=1)
         ]
     return model_payload, proposal_rows
+
+
+def _pre_replay_candidate_score(spec: CandidateSpec) -> Decimal:
+    family_score = {
+        "microbar_cross_sectional_pairs_v1": Decimal("70"),
+        "microstructure_continuation_matched_filter_v1": Decimal("65"),
+        "momentum_pullback_v1": Decimal("60"),
+        "washout_rebound_v2": Decimal("55"),
+        "breakout_reclaim_v2": Decimal("50"),
+        "mean_reversion_rebound_v1": Decimal("45"),
+    }.get(spec.family_template_id, Decimal("40"))
+    required_features = spec.feature_contract.get("required_features")
+    feature_count = (
+        len(cast(Sequence[Any], required_features))
+        if isinstance(required_features, Sequence)
+        and not isinstance(required_features, str)
+        else 0
+    )
+    failure_penalty = Decimal(len(spec.expected_failure_modes)) * Decimal("0.25")
+    return family_score + Decimal(feature_count) - failure_penalty
+
+
+def _select_candidate_specs_for_replay(
+    *,
+    specs: Sequence[CandidateSpec],
+    top_k: int,
+    exploration_slots: int,
+    max_candidates: int,
+    portfolio_size_min: int,
+) -> tuple[list[CandidateSpec], dict[str, Any]]:
+    if not specs:
+        return [], {
+            "schema_version": "torghut.whitepaper-autoresearch-selection.v1",
+            "selected_candidate_spec_ids": [],
+            "rows": [],
+        }
+    max_budget = max(1, int(max_candidates))
+    requested_budget = max(0, int(top_k)) + max(0, int(exploration_slots))
+    replay_budget = min(max_budget, max(1, int(portfolio_size_min), requested_budget))
+    ordered = sorted(
+        specs,
+        key=lambda item: (_pre_replay_candidate_score(item), item.candidate_spec_id),
+        reverse=True,
+    )
+    exploitation_count = min(max(0, int(top_k)), replay_budget, len(ordered))
+    exploitation = ordered[:exploitation_count]
+    remaining = [
+        item
+        for item in sorted(specs, key=lambda value: value.candidate_spec_id)
+        if item.candidate_spec_id
+        not in {spec.candidate_spec_id for spec in exploitation}
+    ]
+    exploration_count = min(
+        max(0, int(exploration_slots)),
+        replay_budget - len(exploitation),
+        len(remaining),
+    )
+    exploration = remaining[:exploration_count]
+    if len(exploitation) + len(exploration) < replay_budget:
+        selected_ids = {
+            item.candidate_spec_id for item in (*exploitation, *exploration)
+        }
+        backfill = [
+            item for item in ordered if item.candidate_spec_id not in selected_ids
+        ][: replay_budget - len(exploitation) - len(exploration)]
+    else:
+        backfill = []
+    selected_reason = {
+        item.candidate_spec_id: "exploitation" for item in exploitation
+    } | {item.candidate_spec_id: "exploration" for item in exploration}
+    selected_reason.update(
+        {item.candidate_spec_id: "budget_backfill" for item in backfill}
+    )
+    selected_ids = {
+        item.candidate_spec_id for item in (*exploitation, *exploration, *backfill)
+    }
+    selected = [item for item in specs if item.candidate_spec_id in selected_ids]
+    rows = [
+        {
+            "candidate_spec_id": spec.candidate_spec_id,
+            "family_template_id": spec.family_template_id,
+            "pre_replay_score": str(_pre_replay_candidate_score(spec)),
+            "rank": index,
+            "selected_for_replay": spec.candidate_spec_id in selected_ids,
+            "selection_reason": selected_reason.get(
+                spec.candidate_spec_id, "not_selected_budget"
+            ),
+            "selection_hash": _stable_hash(
+                {
+                    "candidate_spec_id": spec.candidate_spec_id,
+                    "score": str(_pre_replay_candidate_score(spec)),
+                    "selected": spec.candidate_spec_id in selected_ids,
+                }
+            ),
+        }
+        for index, spec in enumerate(ordered, start=1)
+    ]
+    return selected, {
+        "schema_version": "torghut.whitepaper-autoresearch-selection.v1",
+        "budget": {
+            "max_candidates": max_budget,
+            "top_k": max(0, int(top_k)),
+            "exploration_slots": max(0, int(exploration_slots)),
+            "portfolio_size_min": max(1, int(portfolio_size_min)),
+            "selected_count": len(selected),
+            "compiled_candidate_count": len(specs),
+        },
+        "selected_candidate_spec_ids": [item.candidate_spec_id for item in selected],
+        "rows": rows,
+    }
 
 
 def _synthetic_net_for_spec(spec: CandidateSpec, *, rank: int) -> Decimal:
@@ -756,15 +879,36 @@ def run_whitepaper_autoresearch_profit_target(
             reason="candidate_compiler_produced_no_executable_specs",
             started_at=started_at,
         )
+    replay_candidate_specs, candidate_selection = _select_candidate_specs_for_replay(
+        specs=candidate_specs,
+        top_k=int(args.top_k),
+        exploration_slots=int(args.exploration_slots),
+        max_candidates=int(args.max_candidates),
+        portfolio_size_min=int(args.portfolio_size_min),
+    )
+    _write_json(output_dir / "candidate-selection-manifest.json", candidate_selection)
+    selection_by_spec = {
+        str(row.get("candidate_spec_id")): row
+        for row in _list_of_mappings(candidate_selection.get("rows"))
+    }
     try:
         replay_result = (
             _run_synthetic_replay(
-                specs=candidate_specs,
+                specs=replay_candidate_specs,
                 output_dir=output_dir,
-                max_candidates=int(args.max_candidates),
+                max_candidates=len(replay_candidate_specs),
             )
             if args.replay_mode == "synthetic"
-            else _run_real_replay(args, output_dir=output_dir)
+            else _run_real_replay(
+                argparse.Namespace(
+                    **{
+                        **vars(args),
+                        "max_candidates": len(replay_candidate_specs),
+                        "top_k": min(int(args.top_k), len(replay_candidate_specs)),
+                    }
+                ),
+                output_dir=output_dir,
+            )
         )
     except Exception as exc:
         return _write_failure_summary(
@@ -775,7 +919,9 @@ def run_whitepaper_autoresearch_profit_target(
             started_at=started_at,
         )
     proposal_model, proposal_rows = _proposal_model_and_rows(
-        specs=candidate_specs, evidence_bundles=replay_result.evidence_bundles
+        specs=candidate_specs,
+        evidence_bundles=replay_result.evidence_bundles,
+        replay_selection_by_spec=selection_by_spec,
     )
     _write_json(output_dir / "mlx-ranker-model.json", proposal_model)
     _write_jsonl(output_dir / "mlx-proposal-scores.jsonl", proposal_rows)
@@ -828,6 +974,7 @@ def run_whitepaper_autoresearch_profit_target(
         "candidate_spec_count": len(candidate_specs),
         "candidate_compiler_blocker_count": len(compilation.blockers),
         "evidence_bundle_count": len(replay_result.evidence_bundles),
+        "replay_candidate_spec_count": len(replay_candidate_specs),
         "proposal_score_count": len(proposal_rows),
         "portfolio_candidate_count": len(portfolio_rows),
         "claim_count": sum(len(source.claims) for source in sources),
@@ -853,6 +1000,9 @@ def run_whitepaper_autoresearch_profit_target(
             "epoch_manifest": str(output_dir / "epoch-manifest.json"),
             "hypothesis_cards": str(output_dir / "hypothesis-cards.jsonl"),
             "candidate_specs": str(output_dir / "candidate-specs.jsonl"),
+            "candidate_selection_manifest": str(
+                output_dir / "candidate-selection-manifest.json"
+            ),
             "candidate_compiler_report": str(
                 output_dir / "candidate-compiler-report.json"
             ),
@@ -888,6 +1038,7 @@ def run_whitepaper_autoresearch_profit_target(
                 "max_candidates": int(args.max_candidates),
                 "top_k": int(args.top_k),
                 "exploration_slots": int(args.exploration_slots),
+                "replay_candidate_spec_count": len(replay_candidate_specs),
                 "portfolio_size_min": int(args.portfolio_size_min),
                 "portfolio_size_max": int(args.portfolio_size_max),
             },

--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -27,7 +27,7 @@ from app.trading.discovery.autoresearch import (
     load_strategy_autoresearch_program,
     run_id,
 )
-from app.trading.discovery.candidate_specs import CandidateSpec, compile_candidate_specs
+from app.trading.discovery.candidate_specs import CandidateSpec
 from app.trading.discovery.evidence_bundles import (
     CandidateEvidenceBundle,
     evidence_bundle_from_frontier_candidate,
@@ -41,6 +41,13 @@ from app.trading.discovery.portfolio_optimizer import (
     optimize_portfolio_candidate,
 )
 from app.trading.discovery.runtime_closure import write_runtime_closure_bundle
+from app.trading.discovery.whitepaper_autoresearch_notebooks import (
+    write_whitepaper_autoresearch_diagnostics_notebook,
+)
+from app.trading.discovery.whitepaper_candidate_compiler import (
+    CandidateCompilationBlocker,
+    compile_whitepaper_candidate_specs,
+)
 from app.whitepapers.claim_compiler import (
     RECENT_WHITEPAPER_SEEDS,
     WhitepaperResearchSource,
@@ -133,6 +140,27 @@ def _write_jsonl(path: Path, rows: Sequence[Mapping[str, Any]]) -> Path:
         encoding="utf-8",
     )
     return path
+
+
+def _write_failure_summary(
+    *,
+    output_dir: Path,
+    epoch_id: str,
+    status: str,
+    reason: str,
+    started_at: datetime,
+) -> dict[str, Any]:
+    summary = {
+        "status": status,
+        "epoch_id": epoch_id,
+        "run_root": str(output_dir),
+        "failure_reason": reason,
+        "started_at": started_at.isoformat(),
+        "completed_at": datetime.now(UTC).isoformat(),
+    }
+    _write_json(output_dir / "error-summary.json", summary)
+    _write_json(output_dir / "summary.json", summary)
+    return summary
 
 
 def _stable_hash(payload: Mapping[str, Any]) -> str:
@@ -248,6 +276,8 @@ def _persist_epoch_ledgers(
     paper_run_ids: Sequence[str],
     sources: Sequence[WhitepaperResearchSource],
     candidate_specs: Sequence[CandidateSpec],
+    candidate_blockers: Mapping[str, Sequence[CandidateCompilationBlocker]]
+    | None = None,
     proposal_rows: Sequence[Mapping[str, Any]],
     portfolio: PortfolioCandidateSpec | None,
     summary: Mapping[str, Any],
@@ -256,6 +286,7 @@ def _persist_epoch_ledgers(
     completed_at: datetime,
     failure_reason: str | None = None,
 ) -> None:
+    candidate_blockers = candidate_blockers or {}
     with SessionLocal() as session:
         session.add(
             AutoresearchEpoch(
@@ -276,6 +307,10 @@ def _persist_epoch_ledgers(
         )
         for spec in candidate_specs:
             payload = spec.to_payload()
+            blockers = [
+                blocker.to_payload()
+                for blocker in candidate_blockers.get(spec.candidate_spec_id, ())
+            ]
             session.add(
                 AutoresearchCandidateSpec(
                     candidate_spec_id=spec.candidate_spec_id,
@@ -285,8 +320,8 @@ def _persist_epoch_ledgers(
                     family_template_id=spec.family_template_id,
                     payload_json=payload,
                     payload_hash=_stable_hash(payload),
-                    status="eligible",
-                    blockers_json=[],
+                    status="blocked" if blockers else "eligible",
+                    blockers_json=blockers,
                 )
             )
         for item in proposal_rows:
@@ -354,7 +389,49 @@ def _proposal_model_and_rows(
         }
         for item in ranked_rows
     ]
-    return model.to_payload(), proposal_rows
+    net_by_spec = {
+        bundle.candidate_spec_id: _decimal(
+            bundle.objective_scorecard.get("net_pnl_per_day")
+        )
+        for bundle in evidence_bundles
+    }
+    ranked_nets = [
+        net_by_spec.get(str(row["candidate_spec_id"]), Decimal("0"))
+        for row in proposal_rows
+    ]
+    split_index = max(1, len(ranked_nets) // 2)
+    top_bucket = ranked_nets[:split_index]
+    bottom_bucket = ranked_nets[split_index:] or [Decimal("0")]
+    top_mean = sum(top_bucket, Decimal("0")) / Decimal(len(top_bucket))
+    bottom_mean = sum(bottom_bucket, Decimal("0")) / Decimal(len(bottom_bucket))
+    lift = top_mean - bottom_mean
+    model_payload = {
+        **model.to_payload(),
+        "rank_bucket_lift": {
+            "top_bucket_mean_net_pnl_per_day": str(top_mean),
+            "bottom_bucket_mean_net_pnl_per_day": str(bottom_mean),
+            "lift_net_pnl_per_day": str(lift),
+        },
+        "model_status": "active" if lift >= 0 else "demoted_to_heuristic",
+    }
+    if lift < 0:
+        proposal_rows = sorted(
+            proposal_rows,
+            key=lambda row: (
+                _decimal(row.get("features", {}).get("history_net_pnl_per_day")),
+                str(row.get("candidate_spec_id") or ""),
+            ),
+            reverse=True,
+        )
+        proposal_rows = [
+            {
+                **row,
+                "rank": index,
+                "selection_reason": "heuristic_negative_lift_fallback",
+            }
+            for index, row in enumerate(proposal_rows, start=1)
+        ]
+    return model_payload, proposal_rows
 
 
 def _synthetic_net_for_spec(spec: CandidateSpec, *, rank: int) -> Decimal:
@@ -569,21 +646,27 @@ def run_whitepaper_autoresearch_profit_target(
         sources.extend(RECENT_WHITEPAPER_SEEDS)
     sources.extend(_load_sources_from_db(args.paper_run_id))
     if not sources:
-        summary = {
-            "status": "no_sources",
-            "epoch_id": epoch_id,
-            "run_root": str(output_dir),
-        }
-        _write_json(output_dir / "summary.json", summary)
-        return summary
+        return _write_failure_summary(
+            output_dir=output_dir,
+            epoch_id=epoch_id,
+            status="no_sources",
+            reason="no_whitepaper_sources",
+            started_at=started_at,
+        )
 
     hypothesis_cards: list[HypothesisCard] = compile_sources_to_hypothesis_cards(
         sources
     )
-    candidate_specs = compile_candidate_specs(
-        hypothesis_cards=hypothesis_cards, target_net_pnl_per_day=target
+    compilation = compile_whitepaper_candidate_specs(
+        hypothesis_cards=hypothesis_cards,
+        target_net_pnl_per_day=target,
+        family_template_dir=args.family_template_dir.resolve(),
     )
+    candidate_specs = list(compilation.executable_specs or compilation.candidate_specs)
     candidate_specs = candidate_specs[: max(1, int(args.max_candidates))]
+    blocker_by_spec: dict[str, list[CandidateCompilationBlocker]] = {}
+    for blocker in compilation.blockers:
+        blocker_by_spec.setdefault(blocker.candidate_spec_id, []).append(blocker)
     if args.persist_results and args.replay_mode == "real":
         for source in sources:
             source_specs = [
@@ -612,16 +695,34 @@ def run_whitepaper_autoresearch_profit_target(
         output_dir / "candidate-specs.jsonl",
         [spec.to_payload() for spec in candidate_specs],
     )
+    _write_json(output_dir / "candidate-compiler-report.json", compilation.to_payload())
 
-    replay_result = (
-        _run_synthetic_replay(
-            specs=candidate_specs,
+    if not candidate_specs:
+        return _write_failure_summary(
             output_dir=output_dir,
-            max_candidates=int(args.max_candidates),
+            epoch_id=epoch_id,
+            status="no_eligible_candidates",
+            reason="candidate_compiler_produced_no_executable_specs",
+            started_at=started_at,
         )
-        if args.replay_mode == "synthetic"
-        else _run_real_replay(args, output_dir=output_dir)
-    )
+    try:
+        replay_result = (
+            _run_synthetic_replay(
+                specs=candidate_specs,
+                output_dir=output_dir,
+                max_candidates=int(args.max_candidates),
+            )
+            if args.replay_mode == "synthetic"
+            else _run_real_replay(args, output_dir=output_dir)
+        )
+    except Exception as exc:
+        return _write_failure_summary(
+            output_dir=output_dir,
+            epoch_id=epoch_id,
+            status="replay_failed",
+            reason=f"{type(exc).__name__}:{exc}",
+            started_at=started_at,
+        )
     proposal_model, proposal_rows = _proposal_model_and_rows(
         specs=candidate_specs, evidence_bundles=replay_result.evidence_bundles
     )
@@ -657,8 +758,14 @@ def run_whitepaper_autoresearch_profit_target(
         "source_count": len(sources),
         "hypothesis_count": len(hypothesis_cards),
         "candidate_spec_count": len(candidate_specs),
+        "candidate_compiler_blocker_count": len(compilation.blockers),
         "evidence_bundle_count": len(replay_result.evidence_bundles),
         "proposal_score_count": len(proposal_rows),
+        "portfolio_candidate_count": len(portfolio_rows),
+        "claim_count": sum(len(source.claims) for source in sources),
+        "mlx_rank_bucket_lift": proposal_model.get("rank_bucket_lift", {}),
+        "false_positive_table": [],
+        "best_false_negative_table": [],
         "best_portfolio_candidate": portfolio.to_payload()
         if portfolio is not None
         else None,
@@ -676,6 +783,9 @@ def run_whitepaper_autoresearch_profit_target(
             "epoch_manifest": str(output_dir / "epoch-manifest.json"),
             "hypothesis_cards": str(output_dir / "hypothesis-cards.jsonl"),
             "candidate_specs": str(output_dir / "candidate-specs.jsonl"),
+            "candidate_compiler_report": str(
+                output_dir / "candidate-compiler-report.json"
+            ),
             "proposal_scores": str(output_dir / "mlx-proposal-scores.jsonl"),
             "proposal_model": str(output_dir / "mlx-ranker-model.json"),
             "candidate_evidence_bundles": str(
@@ -684,6 +794,10 @@ def run_whitepaper_autoresearch_profit_target(
             "portfolio_candidates": str(output_dir / "portfolio-candidates.jsonl"),
             "portfolio_optimizer_report": str(
                 output_dir / "portfolio-optimizer-report.json"
+            ),
+            "summary": str(output_dir / "summary.json"),
+            "diagnostics_notebook": str(
+                output_dir / "whitepaper-autoresearch-diagnostics.ipynb"
             ),
         },
     }
@@ -695,6 +809,7 @@ def run_whitepaper_autoresearch_profit_target(
             paper_run_ids=[str(item) for item in args.paper_run_id],
             sources=sources,
             candidate_specs=candidate_specs,
+            candidate_blockers=blocker_by_spec,
             proposal_rows=proposal_rows,
             portfolio=portfolio,
             summary=summary,
@@ -710,6 +825,10 @@ def run_whitepaper_autoresearch_profit_target(
             completed_at=datetime.now(UTC),
         )
     _write_json(output_dir / "summary.json", summary)
+    write_whitepaper_autoresearch_diagnostics_notebook(
+        output_dir / "whitepaper-autoresearch-diagnostics.ipynb",
+        summary=summary,
+    )
     return summary
 
 
@@ -717,7 +836,12 @@ def main() -> int:
     args = _parse_args()
     payload = run_whitepaper_autoresearch_profit_target(args)
     print(json.dumps(payload, indent=2, sort_keys=True))
-    return 0 if payload.get("status") == "ok" else 2
+    status = str(payload.get("status") or "")
+    if status == "ok":
+        return 0
+    if status == "replay_failed":
+        return 3
+    return 2
 
 
 if __name__ == "__main__":

--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -197,12 +197,30 @@ def _mapping(value: Any) -> dict[str, Any]:
     )
 
 
+def _string(value: Any) -> str:
+    return str(value if value is not None else "").strip()
+
+
 def _list_of_mappings(value: Any) -> list[Mapping[str, Any]]:
     if not isinstance(value, list):
         return []
     return [
         cast(Mapping[str, Any], item) for item in value if isinstance(item, Mapping)
     ]
+
+
+def _rank_sort_value(value: Any) -> int:
+    try:
+        return int(str(value))
+    except Exception:
+        return 10**9
+
+
+def _proposal_sort_value(value: Any) -> float:
+    try:
+        return float(str(value))
+    except Exception:
+        return 0.0
 
 
 def _load_sources_from_db(
@@ -459,6 +477,149 @@ def _proposal_model_and_rows(
             for index, row in enumerate(proposal_rows, start=1)
         ]
     return model_payload, proposal_rows
+
+
+def _candidate_quality_gate_failures(scorecard: Mapping[str, Any]) -> list[str]:
+    failures: list[str] = []
+    if _decimal(scorecard.get("net_pnl_per_day")) <= 0:
+        failures.append("non_positive_net_pnl_per_day")
+    if _decimal(scorecard.get("active_day_ratio")) < Decimal("0.90"):
+        failures.append("active_day_ratio_below_oracle")
+    if _decimal(scorecard.get("positive_day_ratio")) < Decimal("0.60"):
+        failures.append("positive_day_ratio_below_oracle")
+    if _decimal(scorecard.get("best_day_share"), default="1") > Decimal("0.25"):
+        failures.append("best_day_share_above_oracle")
+    if _decimal(scorecard.get("worst_day_loss"), default="999999") > Decimal("350"):
+        failures.append("worst_day_loss_above_oracle")
+    if _decimal(scorecard.get("max_drawdown"), default="999999") > Decimal("900"):
+        failures.append("max_drawdown_above_oracle")
+    if _decimal(scorecard.get("avg_filled_notional_per_day")) < Decimal("300000"):
+        failures.append("avg_filled_notional_per_day_below_oracle")
+    if _decimal(scorecard.get("regime_slice_pass_rate")) < Decimal("0.45"):
+        failures.append("regime_slice_pass_rate_below_oracle")
+    if _decimal(scorecard.get("posterior_edge_lower")) <= 0:
+        failures.append("posterior_edge_lower_non_positive")
+    if _string(scorecard.get("shadow_parity_status")) != "within_budget":
+        failures.append("shadow_parity_status_not_within_budget")
+    return failures
+
+
+def _false_positive_table(
+    *,
+    proposal_rows: Sequence[Mapping[str, Any]],
+    evidence_bundles: Sequence[CandidateEvidenceBundle],
+    limit: int = 16,
+) -> list[dict[str, Any]]:
+    evidence_by_spec = {bundle.candidate_spec_id: bundle for bundle in evidence_bundles}
+    rows: list[dict[str, Any]] = []
+    for proposal in _list_of_mappings(list(proposal_rows)):
+        candidate_spec_id = _string(proposal.get("candidate_spec_id"))
+        if not candidate_spec_id or not bool(proposal.get("selected_for_replay")):
+            continue
+        evidence = evidence_by_spec.get(candidate_spec_id)
+        if evidence is None:
+            rows.append(
+                {
+                    "candidate_spec_id": candidate_spec_id,
+                    "candidate_id": None,
+                    "rank": _rank_sort_value(proposal.get("rank")),
+                    "proposal_score": proposal.get("proposal_score"),
+                    "replay_selection_reason": _string(
+                        proposal.get("replay_selection_reason")
+                    )
+                    or "selected_for_replay",
+                    "evidence_status": "missing",
+                    "failure_reasons": ["replay_evidence_missing"],
+                }
+            )
+            continue
+        scorecard = evidence.objective_scorecard
+        failure_reasons = _candidate_quality_gate_failures(scorecard)
+        if not failure_reasons:
+            continue
+        rows.append(
+            {
+                "candidate_spec_id": candidate_spec_id,
+                "candidate_id": evidence.candidate_id,
+                "rank": _rank_sort_value(proposal.get("rank")),
+                "proposal_score": proposal.get("proposal_score"),
+                "replay_selection_reason": _string(
+                    proposal.get("replay_selection_reason")
+                )
+                or "selected_for_replay",
+                "evidence_status": "replayed",
+                "net_pnl_per_day": _string(scorecard.get("net_pnl_per_day")),
+                "active_day_ratio": _string(scorecard.get("active_day_ratio")),
+                "positive_day_ratio": _string(scorecard.get("positive_day_ratio")),
+                "best_day_share": _string(scorecard.get("best_day_share")),
+                "worst_day_loss": _string(scorecard.get("worst_day_loss")),
+                "max_drawdown": _string(scorecard.get("max_drawdown")),
+                "avg_filled_notional_per_day": _string(
+                    scorecard.get("avg_filled_notional_per_day")
+                ),
+                "regime_slice_pass_rate": _string(
+                    scorecard.get("regime_slice_pass_rate")
+                ),
+                "posterior_edge_lower": _string(scorecard.get("posterior_edge_lower")),
+                "shadow_parity_status": _string(scorecard.get("shadow_parity_status")),
+                "failure_reasons": failure_reasons,
+            }
+        )
+    rows.sort(
+        key=lambda row: (
+            _rank_sort_value(row.get("rank")),
+            -_proposal_sort_value(row.get("proposal_score")),
+            _string(row.get("candidate_spec_id")),
+        )
+    )
+    return rows[: max(0, limit)]
+
+
+def _best_false_negative_table(
+    *,
+    candidate_selection: Mapping[str, Any],
+    pre_replay_proposal_rows: Sequence[Mapping[str, Any]],
+    evidence_bundles: Sequence[CandidateEvidenceBundle],
+    limit: int = 16,
+) -> list[dict[str, Any]]:
+    evidence_by_spec = {bundle.candidate_spec_id: bundle for bundle in evidence_bundles}
+    pre_replay_by_spec = {
+        _string(row.get("candidate_spec_id")): row
+        for row in _list_of_mappings(list(pre_replay_proposal_rows))
+        if _string(row.get("candidate_spec_id"))
+    }
+    rows: list[dict[str, Any]] = []
+    for selection in _list_of_mappings(candidate_selection.get("rows")):
+        candidate_spec_id = _string(selection.get("candidate_spec_id"))
+        if (
+            not candidate_spec_id
+            or bool(selection.get("selected_for_replay"))
+            or candidate_spec_id in evidence_by_spec
+        ):
+            continue
+        pre_replay = pre_replay_by_spec.get(candidate_spec_id, {})
+        rows.append(
+            {
+                "candidate_spec_id": candidate_spec_id,
+                "candidate_id": None,
+                "rank": _rank_sort_value(selection.get("rank")),
+                "pre_replay_score": _string(selection.get("pre_replay_score")),
+                "proposal_score": pre_replay.get("proposal_score"),
+                "selection_reason": _string(selection.get("selection_reason"))
+                or "not_selected_budget",
+                "selected_for_replay": False,
+                "evidence_status": "not_replayed",
+                "reason": "not_replayed_budget",
+            }
+        )
+    rows.sort(
+        key=lambda row: (
+            _rank_sort_value(row.get("rank")),
+            -_proposal_sort_value(row.get("proposal_score")),
+            _string(row.get("candidate_spec_id")),
+        )
+    )
+    return rows[: max(0, limit)]
 
 
 def _pre_replay_candidate_score(spec: CandidateSpec) -> Decimal:
@@ -1098,6 +1259,15 @@ def run_whitepaper_autoresearch_profit_target(
             status_reason = "portfolio_optimizer_produced_no_candidate"
         else:
             status_reason = "portfolio_candidate_failed_profit_target_oracle"
+    false_positive_table = _false_positive_table(
+        proposal_rows=proposal_rows,
+        evidence_bundles=replay_result.evidence_bundles,
+    )
+    best_false_negative_table = _best_false_negative_table(
+        candidate_selection=candidate_selection,
+        pre_replay_proposal_rows=pre_replay_proposal_rows,
+        evidence_bundles=replay_result.evidence_bundles,
+    )
     summary = {
         "status": status,
         "status_reason": status_reason,
@@ -1115,8 +1285,8 @@ def run_whitepaper_autoresearch_profit_target(
         "portfolio_candidate_count": len(portfolio_rows),
         "claim_count": sum(len(source.claims) for source in sources),
         "mlx_rank_bucket_lift": proposal_model.get("rank_bucket_lift", {}),
-        "false_positive_table": [],
-        "best_false_negative_table": [],
+        "false_positive_table": false_positive_table,
+        "best_false_negative_table": best_false_negative_table,
         "best_portfolio_candidate": portfolio.to_payload()
         if portfolio is not None
         else None,

--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -449,6 +449,13 @@ def _synthetic_candidate_payload(spec: CandidateSpec, *, rank: int) -> dict[str,
     net = _synthetic_net_for_spec(spec, rank=rank)
     active = Decimal("0.92") if rank <= 3 else Decimal("0.82")
     positive = Decimal("0.64") if rank <= 3 else Decimal("0.58")
+    daily_filled_notional = {
+        "2026-02-23": "350000",
+        "2026-02-24": "350000",
+        "2026-02-25": "350000",
+        "2026-02-26": "350000",
+        "2026-02-27": "350000",
+    }
     return {
         "candidate_id": f"cand-{spec.candidate_spec_id}",
         "candidate_spec_id": spec.candidate_spec_id,
@@ -464,6 +471,9 @@ def _synthetic_candidate_payload(spec: CandidateSpec, *, rank: int) -> dict[str,
             "max_drawdown": "520",
             "best_day_share": "0.20",
             "regime_slice_pass_rate": "0.55",
+            "posterior_edge_lower": "0.01",
+            "shadow_parity_status": "within_budget",
+            "daily_filled_notional": daily_filled_notional,
         },
         "full_window": {
             "net_per_day": str(net),
@@ -474,6 +484,7 @@ def _synthetic_candidate_payload(spec: CandidateSpec, *, rank: int) -> dict[str,
                 "2026-02-26": str(net * Decimal("1.05")),
                 "2026-02-27": str(net * Decimal("1.15")),
             },
+            "daily_filled_notional": daily_filled_notional,
         },
         "promotion_readiness": {
             "stage": "research_candidate",
@@ -767,6 +778,15 @@ def run_whitepaper_autoresearch_profit_target(
         "false_positive_table": [],
         "best_false_negative_table": [],
         "best_portfolio_candidate": portfolio.to_payload()
+        if portfolio is not None
+        else None,
+        "oracle_candidate_found": bool(
+            portfolio is not None
+            and portfolio.objective_scorecard.get("oracle_passed") is True
+        ),
+        "profit_target_oracle": portfolio.objective_scorecard.get(
+            "profit_target_oracle"
+        )
         if portfolio is not None
         else None,
         "promotion_readiness": {

--- a/services/torghut/scripts/train_mlx_autoresearch_ranker.py
+++ b/services/torghut/scripts/train_mlx_autoresearch_ranker.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Train the whitepaper autoresearch MLX proposal ranker from artifact JSONL files."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Mapping, cast
+
+from app.trading.discovery.candidate_specs import (
+    CandidateSpec,
+    candidate_spec_from_payload,
+)
+from app.trading.discovery.evidence_bundles import (
+    CandidateEvidenceBundle,
+    evidence_bundle_from_payload,
+)
+from app.trading.discovery.mlx_training_data import (
+    build_mlx_training_rows,
+    rank_training_rows,
+    train_mlx_ranker,
+)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Train an MLX autoresearch ranker artifact."
+    )
+    parser.add_argument("--candidate-specs", type=Path, required=True)
+    parser.add_argument("--evidence-bundles", type=Path, required=True)
+    parser.add_argument("--model-output", type=Path, required=True)
+    parser.add_argument("--scores-output", type=Path, required=True)
+    parser.add_argument("--backend-preference", default="mlx")
+    return parser.parse_args()
+
+
+def _read_jsonl(path: Path) -> list[Mapping[str, Any]]:
+    rows: list[Mapping[str, Any]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        payload = json.loads(line)
+        if isinstance(payload, Mapping):
+            rows.append(cast(Mapping[str, Any], payload))
+    return rows
+
+
+def train_from_artifacts(
+    *,
+    candidate_specs_path: Path,
+    evidence_bundles_path: Path,
+    backend_preference: str = "mlx",
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    candidate_specs: list[CandidateSpec] = [
+        candidate_spec_from_payload(row) for row in _read_jsonl(candidate_specs_path)
+    ]
+    evidence_bundles: list[CandidateEvidenceBundle] = [
+        evidence_bundle_from_payload(row) for row in _read_jsonl(evidence_bundles_path)
+    ]
+    training_rows = build_mlx_training_rows(
+        candidate_specs=candidate_specs,
+        evidence_bundles=evidence_bundles,
+    )
+    model = train_mlx_ranker(training_rows, backend_preference=backend_preference)
+    feature_by_spec = {
+        row.candidate_spec_id: row.to_payload()["features"] for row in training_rows
+    }
+    scores = [
+        {
+            **item.to_payload(),
+            "proposal_score": item.score,
+            "features": feature_by_spec.get(item.candidate_spec_id, {}),
+        }
+        for item in rank_training_rows(model=model, rows=training_rows)
+    ]
+    return model.to_payload(), scores
+
+
+def main() -> int:
+    args = _parse_args()
+    model_payload, scores = train_from_artifacts(
+        candidate_specs_path=args.candidate_specs,
+        evidence_bundles_path=args.evidence_bundles,
+        backend_preference=str(args.backend_preference),
+    )
+    args.model_output.parent.mkdir(parents=True, exist_ok=True)
+    args.scores_output.parent.mkdir(parents=True, exist_ok=True)
+    args.model_output.write_text(
+        json.dumps(model_payload, indent=2, sort_keys=True), encoding="utf-8"
+    )
+    args.scores_output.write_text(
+        "\n".join(json.dumps(row, sort_keys=True) for row in scores)
+        + ("\n" if scores else ""),
+        encoding="utf-8",
+    )
+    print(
+        json.dumps(
+            {
+                "status": "ok",
+                "model_id": model_payload["model_id"],
+                "backend": model_payload["backend"],
+                "row_count": model_payload["row_count"],
+                "model_output": str(args.model_output),
+                "scores_output": str(args.scores_output),
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/torghut/tests/test_candidate_specs.py
+++ b/services/torghut/tests/test_candidate_specs.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from pathlib import Path
+from unittest import TestCase
+
+from app.trading.discovery.candidate_specs import (
+    candidate_spec_from_payload,
+    compile_candidate_specs,
+)
+from app.trading.discovery.hypothesis_cards import build_hypothesis_cards
+from app.trading.discovery.whitepaper_candidate_compiler import (
+    compile_whitepaper_candidate_specs,
+)
+
+
+class TestCandidateSpecs(TestCase):
+    def test_candidate_spec_ids_are_deterministic_and_round_trip(self) -> None:
+        cards = build_hypothesis_cards(
+            source_run_id="paper-1",
+            claims=[
+                {
+                    "claim_id": "claim-flow",
+                    "claim_type": "signal_mechanism",
+                    "claim_text": "Clustered order flow imbalance improves intraday LOB signals.",
+                    "confidence": "0.82",
+                }
+            ],
+        )
+
+        first = compile_candidate_specs(
+            hypothesis_cards=cards, target_net_pnl_per_day=Decimal("500")
+        )
+        second = compile_candidate_specs(
+            hypothesis_cards=cards, target_net_pnl_per_day=Decimal("500")
+        )
+
+        self.assertEqual(first[0].candidate_spec_id, second[0].candidate_spec_id)
+        self.assertEqual(first[0].objective["target_net_pnl_per_day"], "500")
+        self.assertIn("required_max_drawdown", first[0].hard_vetoes)
+        self.assertNotIn("live_runtime_config_path", first[0].to_payload())
+        reloaded = candidate_spec_from_payload(first[0].to_payload())
+        self.assertEqual(reloaded.candidate_spec_id, first[0].candidate_spec_id)
+
+    def test_missing_features_and_invalid_payloads_are_blocked(self) -> None:
+        cards = build_hypothesis_cards(
+            source_run_id="paper-2",
+            claims=[
+                {
+                    "claim_id": "claim-new-feature",
+                    "claim_type": "signal_mechanism",
+                    "claim_text": "A new exotic feature improves short-horizon execution.",
+                    "required_features": ["feature_that_does_not_exist"],
+                    "confidence": "0.82",
+                }
+            ],
+        )
+
+        compilation = compile_whitepaper_candidate_specs(
+            hypothesis_cards=cards,
+            target_net_pnl_per_day=Decimal("500"),
+            family_template_dir=Path("config/trading/families"),
+        )
+
+        self.assertEqual(compilation.executable_specs, ())
+        self.assertEqual(
+            compilation.blockers[0].reason,
+            "required_features_missing_from_family_template",
+        )
+        with self.assertRaisesRegex(ValueError, "candidate_spec_schema_invalid"):
+            candidate_spec_from_payload({"schema_version": "invalid"})

--- a/services/torghut/tests/test_hypothesis_cards.py
+++ b/services/torghut/tests/test_hypothesis_cards.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from unittest import TestCase
+
+from app.trading.discovery.hypothesis_cards import (
+    build_hypothesis_cards,
+    hypothesis_card_from_payload,
+)
+
+
+class TestHypothesisCards(TestCase):
+    def test_hypothesis_card_ids_are_deterministic_and_round_trip(self) -> None:
+        claims = [
+            {
+                "claim_id": "claim-flow",
+                "claim_type": "signal_mechanism",
+                "claim_text": "Clustered order flow imbalance improves intraday LOB signals.",
+                "asset_scope": "us_equities_intraday",
+                "horizon_scope": "intraday",
+                "expected_direction": "positive",
+                "confidence": "0.82",
+            }
+        ]
+
+        first = build_hypothesis_cards(source_run_id="paper-1", claims=claims)
+        second = build_hypothesis_cards(source_run_id="paper-1", claims=claims)
+
+        self.assertEqual(len(first), 1)
+        self.assertEqual(first[0].hypothesis_id, second[0].hypothesis_id)
+        self.assertIn("order_flow_imbalance", first[0].required_features)
+        reloaded = hypothesis_card_from_payload(first[0].to_payload())
+        self.assertEqual(reloaded.hypothesis_id, first[0].hypothesis_id)
+
+    def test_invalid_and_low_confidence_payloads_do_not_execute(self) -> None:
+        low_confidence = build_hypothesis_cards(
+            source_run_id="paper-2",
+            claims=[
+                {
+                    "claim_id": "weak",
+                    "claim_text": "Weak trend effect.",
+                    "confidence": "0.10",
+                }
+            ],
+            min_confidence=Decimal("0.50"),
+        )
+
+        self.assertEqual(low_confidence, [])
+        with self.assertRaisesRegex(ValueError, "hypothesis_card_schema_invalid"):
+            hypothesis_card_from_payload({"schema_version": "invalid"})

--- a/services/torghut/tests/test_mlx_training_data.py
+++ b/services/torghut/tests/test_mlx_training_data.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from unittest import TestCase
+
+from app.trading.discovery.candidate_specs import compile_candidate_specs
+from app.trading.discovery.evidence_bundles import (
+    evidence_bundle_from_frontier_candidate,
+)
+from app.trading.discovery.hypothesis_cards import build_hypothesis_cards
+from app.trading.discovery.mlx_training_data import (
+    build_mlx_training_rows,
+    rank_training_rows,
+    train_mlx_ranker,
+)
+
+
+class TestMlxTrainingData(TestCase):
+    def test_training_rows_build_from_evidence_bundles_and_rank_deterministically(
+        self,
+    ) -> None:
+        cards = build_hypothesis_cards(
+            source_run_id="paper-1",
+            claims=[
+                {
+                    "claim_id": "claim-1",
+                    "claim_type": "signal_mechanism",
+                    "claim_text": "Momentum pullback ranking improves continuation entries.",
+                    "confidence": "0.8",
+                }
+            ],
+        )
+        specs = compile_candidate_specs(
+            hypothesis_cards=cards,
+            target_net_pnl_per_day=Decimal("500"),
+        )
+        bundles = [
+            evidence_bundle_from_frontier_candidate(
+                candidate_spec_id=specs[0].candidate_spec_id,
+                candidate={
+                    "candidate_id": "cand-1",
+                    "objective_scorecard": {
+                        "net_pnl_per_day": "275",
+                        "active_day_ratio": "1.0",
+                        "positive_day_ratio": "0.8",
+                    },
+                },
+                dataset_snapshot_id="snapshot-1",
+                result_path="/tmp/cand-1.json",
+            )
+        ]
+
+        rows = build_mlx_training_rows(candidate_specs=specs, evidence_bundles=bundles)
+        model = train_mlx_ranker(rows, backend_preference="numpy-fallback", steps=4)
+        ranked = rank_training_rows(model=model, rows=rows)
+
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(model.backend, "numpy-fallback")
+        self.assertEqual(ranked[0].rank, 1)

--- a/services/torghut/tests/test_portfolio_optimizer.py
+++ b/services/torghut/tests/test_portfolio_optimizer.py
@@ -4,7 +4,9 @@ from decimal import Decimal
 from unittest import TestCase
 
 from app.trading.discovery.evidence_bundles import (
+    evidence_bundle_blockers,
     evidence_bundle_from_frontier_candidate,
+    evidence_bundle_from_payload,
 )
 from app.trading.discovery.portfolio_candidates import (
     portfolio_candidate_from_payload,
@@ -101,3 +103,97 @@ class TestPortfolioOptimizer(TestCase):
     def test_invalid_portfolio_candidate_payload_is_rejected(self) -> None:
         with self.assertRaisesRegex(ValueError, "portfolio_candidate_schema_invalid"):
             portfolio_candidate_from_payload({"schema_version": "bad"})
+
+    def test_invalid_evidence_bundles_are_not_admitted_to_portfolios(self) -> None:
+        invalid = evidence_bundle_from_frontier_candidate(
+            candidate_spec_id="spec-invalid",
+            candidate={
+                "candidate_id": "cand-invalid",
+                "objective_scorecard": {
+                    "net_pnl_per_day": "2000",
+                    "active_day_ratio": "1.0",
+                    "positive_day_ratio": "1.0",
+                    "worst_day_loss": "0",
+                    "max_drawdown": "0",
+                    "best_day_share": "0.1",
+                    "stale_tape": True,
+                },
+            },
+            dataset_snapshot_id="snapshot-stale",
+            result_path="/tmp/invalid.json",
+        )
+        missing_cost_payload = invalid.to_payload()
+        missing_cost_payload["candidate_id"] = "cand-missing-cost"
+        missing_cost_payload["candidate_spec_id"] = "spec-missing-cost"
+        missing_cost_payload["cost_calibration"] = {}
+        missing_cost = evidence_bundle_from_payload(missing_cost_payload)
+
+        valid_bundles = [
+            evidence_bundle_from_frontier_candidate(
+                candidate_spec_id=f"spec-valid-{index}",
+                candidate={
+                    "candidate_id": f"cand-valid-{index}",
+                    "objective_scorecard": {
+                        "net_pnl_per_day": "275",
+                        "active_day_ratio": "1.0",
+                        "positive_day_ratio": "0.8",
+                        "worst_day_loss": "0",
+                        "max_drawdown": "0",
+                        "best_day_share": "0.2",
+                        "avg_filled_notional_per_day": "350000",
+                        "regime_slice_pass_rate": "0.55",
+                        "posterior_edge_lower": "0.01",
+                        "shadow_parity_status": "within_budget",
+                        "correlation_cluster": f"valid-{index}",
+                        "symbol_contribution_shares": {
+                            "AAPL": "0.25",
+                            "NVDA": "0.25",
+                            "MSFT": "0.25",
+                            "AMAT": "0.25",
+                        },
+                    },
+                    "full_window": {
+                        "daily_net": {
+                            "2026-02-23": "250",
+                            "2026-02-24": "260",
+                            "2026-02-25": "270",
+                            "2026-02-26": "280",
+                            "2026-02-27": "315",
+                        },
+                        "daily_filled_notional": {
+                            "2026-02-23": "350000",
+                            "2026-02-24": "350000",
+                            "2026-02-25": "350000",
+                            "2026-02-26": "350000",
+                            "2026-02-27": "350000",
+                        },
+                    },
+                },
+                dataset_snapshot_id="snapshot-valid",
+                result_path=f"/tmp/valid-{index}.json",
+            )
+            for index in range(2)
+        ]
+
+        portfolio = optimize_portfolio_candidate(
+            evidence_bundles=[invalid, missing_cost, *valid_bundles],
+            target_net_pnl_per_day=Decimal("500"),
+            portfolio_size_min=2,
+            portfolio_size_max=4,
+        )
+
+        self.assertIn("stale_tape", evidence_bundle_blockers(invalid))
+        self.assertIn(
+            "cost_calibration_missing", evidence_bundle_blockers(missing_cost)
+        )
+        self.assertIsNotNone(portfolio)
+        assert portfolio is not None
+        self.assertCountEqual(
+            portfolio.source_candidate_ids, ("cand-valid-0", "cand-valid-1")
+        )
+        invalid_rejections = [
+            item
+            for item in portfolio.optimizer_report["rejections"]
+            if item["reason"] == "invalid_evidence_bundle"
+        ]
+        self.assertEqual(len(invalid_rejections), 2)

--- a/services/torghut/tests/test_portfolio_optimizer.py
+++ b/services/torghut/tests/test_portfolio_optimizer.py
@@ -29,12 +29,26 @@ class TestPortfolioOptimizer(TestCase):
                         "worst_day_loss": "0",
                         "max_drawdown": "0",
                         "best_day_share": "0.2",
+                        "avg_filled_notional_per_day": "350000",
+                        "regime_slice_pass_rate": "0.55",
+                        "posterior_edge_lower": "0.01",
+                        "shadow_parity_status": "within_budget",
                     },
                     "full_window": {
                         "daily_net": {
                             "2026-02-23": str(250 + index),
-                            "2026-02-24": str(300 + index),
-                        }
+                            "2026-02-24": str(260 + index),
+                            "2026-02-25": str(270 + index),
+                            "2026-02-26": str(280 + index),
+                            "2026-02-27": str(315 + index),
+                        },
+                        "daily_filled_notional": {
+                            "2026-02-23": "350000",
+                            "2026-02-24": "350000",
+                            "2026-02-25": "350000",
+                            "2026-02-26": "350000",
+                            "2026-02-27": "350000",
+                        },
                     },
                 },
                 dataset_snapshot_id="snapshot-1",
@@ -57,6 +71,10 @@ class TestPortfolioOptimizer(TestCase):
             reloaded.portfolio_candidate_id, portfolio.portfolio_candidate_id
         )
         self.assertTrue(reloaded.objective_scorecard["target_met"])
+        self.assertTrue(reloaded.objective_scorecard["oracle_passed"])
+        self.assertEqual(
+            reloaded.objective_scorecard["profit_target_oracle"]["blockers"], []
+        )
 
     def test_invalid_portfolio_candidate_payload_is_rejected(self) -> None:
         with self.assertRaisesRegex(ValueError, "portfolio_candidate_schema_invalid"):

--- a/services/torghut/tests/test_portfolio_optimizer.py
+++ b/services/torghut/tests/test_portfolio_optimizer.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from unittest import TestCase
+
+from app.trading.discovery.evidence_bundles import (
+    evidence_bundle_from_frontier_candidate,
+)
+from app.trading.discovery.portfolio_candidates import (
+    portfolio_candidate_from_payload,
+)
+from app.trading.discovery.portfolio_optimizer import optimize_portfolio_candidate
+
+
+class TestPortfolioOptimizer(TestCase):
+    def test_portfolio_candidate_round_trips_from_optimizer_payload(self) -> None:
+        bundles = [
+            evidence_bundle_from_frontier_candidate(
+                candidate_spec_id=f"spec-{index}",
+                candidate={
+                    "candidate_id": f"cand-{index}",
+                    "runtime_family": "microbar_cross_sectional_pairs",
+                    "runtime_strategy_name": "microbar-cross-sectional-pairs-v1",
+                    "family_template_id": "microbar_cross_sectional_pairs_v1",
+                    "objective_scorecard": {
+                        "net_pnl_per_day": "275",
+                        "active_day_ratio": "1.0",
+                        "positive_day_ratio": "0.8",
+                        "worst_day_loss": "0",
+                        "max_drawdown": "0",
+                        "best_day_share": "0.2",
+                    },
+                    "full_window": {
+                        "daily_net": {
+                            "2026-02-23": str(250 + index),
+                            "2026-02-24": str(300 + index),
+                        }
+                    },
+                },
+                dataset_snapshot_id="snapshot-1",
+                result_path=f"/tmp/spec-{index}.json",
+            )
+            for index in range(2)
+        ]
+
+        portfolio = optimize_portfolio_candidate(
+            evidence_bundles=bundles,
+            target_net_pnl_per_day=Decimal("500"),
+            portfolio_size_min=2,
+            portfolio_size_max=4,
+        )
+
+        self.assertIsNotNone(portfolio)
+        assert portfolio is not None
+        reloaded = portfolio_candidate_from_payload(portfolio.to_payload())
+        self.assertEqual(
+            reloaded.portfolio_candidate_id, portfolio.portfolio_candidate_id
+        )
+        self.assertTrue(reloaded.objective_scorecard["target_met"])
+
+    def test_invalid_portfolio_candidate_payload_is_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "portfolio_candidate_schema_invalid"):
+            portfolio_candidate_from_payload({"schema_version": "bad"})

--- a/services/torghut/tests/test_portfolio_optimizer.py
+++ b/services/torghut/tests/test_portfolio_optimizer.py
@@ -14,6 +14,11 @@ from app.trading.discovery.portfolio_optimizer import optimize_portfolio_candida
 
 class TestPortfolioOptimizer(TestCase):
     def test_portfolio_candidate_round_trips_from_optimizer_payload(self) -> None:
+        daily_profiles = [
+            ("210", "220", "230", "240", "250"),
+            ("240", "230", "220", "210", "200"),
+            ("230", "210", "250", "220", "240"),
+        ]
         bundles = [
             evidence_bundle_from_frontier_candidate(
                 candidate_spec_id=f"spec-{index}",
@@ -33,14 +38,21 @@ class TestPortfolioOptimizer(TestCase):
                         "regime_slice_pass_rate": "0.55",
                         "posterior_edge_lower": "0.01",
                         "shadow_parity_status": "within_budget",
+                        "correlation_cluster": f"cluster-{index}",
+                        "symbol_contribution_shares": {
+                            "AAPL": "0.25",
+                            "NVDA": "0.25",
+                            "MSFT": "0.25",
+                            "AMAT": "0.25",
+                        },
                     },
                     "full_window": {
                         "daily_net": {
-                            "2026-02-23": str(250 + index),
-                            "2026-02-24": str(260 + index),
-                            "2026-02-25": str(270 + index),
-                            "2026-02-26": str(280 + index),
-                            "2026-02-27": str(315 + index),
+                            "2026-02-23": daily_profiles[index][0],
+                            "2026-02-24": daily_profiles[index][1],
+                            "2026-02-25": daily_profiles[index][2],
+                            "2026-02-26": daily_profiles[index][3],
+                            "2026-02-27": daily_profiles[index][4],
                         },
                         "daily_filled_notional": {
                             "2026-02-23": "350000",
@@ -54,7 +66,7 @@ class TestPortfolioOptimizer(TestCase):
                 dataset_snapshot_id="snapshot-1",
                 result_path=f"/tmp/spec-{index}.json",
             )
-            for index in range(2)
+            for index in range(3)
         ]
 
         portfolio = optimize_portfolio_candidate(
@@ -72,6 +84,16 @@ class TestPortfolioOptimizer(TestCase):
         )
         self.assertTrue(reloaded.objective_scorecard["target_met"])
         self.assertTrue(reloaded.objective_scorecard["oracle_passed"])
+        self.assertLessEqual(
+            Decimal(reloaded.objective_scorecard["max_cluster_contribution_share"]),
+            Decimal("0.40"),
+        )
+        self.assertLessEqual(
+            Decimal(
+                reloaded.objective_scorecard["max_single_symbol_contribution_share"]
+            ),
+            Decimal("0.35"),
+        )
         self.assertEqual(
             reloaded.objective_scorecard["profit_target_oracle"]["blockers"], []
         )

--- a/services/torghut/tests/test_profit_target_oracle.py
+++ b/services/torghut/tests/test_profit_target_oracle.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from unittest import TestCase
+
+from app.trading.discovery.profit_target_oracle import evaluate_profit_target_oracle
+
+
+class TestProfitTargetOracle(TestCase):
+    def test_profit_target_oracle_accepts_full_doc71_contract(self) -> None:
+        result = evaluate_profit_target_oracle(
+            {
+                "net_pnl_per_day": "535",
+                "active_day_ratio": "1",
+                "positive_day_ratio": "1",
+                "best_day_share": "0.23",
+                "worst_day_loss": "0",
+                "max_drawdown": "0",
+                "avg_filled_notional_per_day": "700000",
+                "regime_slice_pass_rate": "0.55",
+                "posterior_edge_lower": "0.01",
+                "shadow_parity_status": "within_budget",
+            },
+            target_net_pnl_per_day=Decimal("500"),
+        )
+
+        self.assertTrue(result["passed"])
+        self.assertEqual(result["blockers"], [])
+
+    def test_profit_target_oracle_reports_failed_criteria(self) -> None:
+        result = evaluate_profit_target_oracle(
+            {
+                "net_pnl_per_day": "499",
+                "active_day_ratio": "0.5",
+                "positive_day_ratio": "0.5",
+                "best_day_share": "0.9",
+                "worst_day_loss": "500",
+                "max_drawdown": "1000",
+                "avg_filled_notional_per_day": "10",
+                "regime_slice_pass_rate": "0.1",
+                "posterior_edge_lower": "0",
+                "shadow_parity_status": "missing",
+            },
+            target_net_pnl_per_day=Decimal("500"),
+        )
+
+        self.assertFalse(result["passed"])
+        self.assertIn("portfolio_post_cost_net_pnl_per_day_failed", result["blockers"])
+        self.assertIn("shadow_parity_status_failed", result["blockers"])

--- a/services/torghut/tests/test_profit_target_oracle.py
+++ b/services/torghut/tests/test_profit_target_oracle.py
@@ -14,6 +14,9 @@ class TestProfitTargetOracle(TestCase):
                 "active_day_ratio": "1",
                 "positive_day_ratio": "1",
                 "best_day_share": "0.23",
+                "max_single_day_contribution_share": "0.23",
+                "max_cluster_contribution_share": "0.34",
+                "max_single_symbol_contribution_share": "0.25",
                 "worst_day_loss": "0",
                 "max_drawdown": "0",
                 "avg_filled_notional_per_day": "700000",
@@ -46,4 +49,6 @@ class TestProfitTargetOracle(TestCase):
 
         self.assertFalse(result["passed"])
         self.assertIn("portfolio_post_cost_net_pnl_per_day_failed", result["blockers"])
+        self.assertIn("max_cluster_contribution_share_failed", result["blockers"])
+        self.assertIn("max_single_symbol_contribution_share_failed", result["blockers"])
         self.assertIn("shadow_parity_status_failed", result["blockers"])

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -93,6 +93,36 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             self.assertTrue((output_dir / "portfolio-candidates.jsonl").exists())
             self.assertTrue((output_dir / "runtime-closure" / "summary.json").exists())
             self.assertTrue(
+                (
+                    output_dir
+                    / "runtime-closure"
+                    / "replay"
+                    / "candidate-configmap.yaml"
+                ).exists()
+            )
+            runtime_summary = json.loads(
+                (output_dir / "runtime-closure" / "summary.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            self.assertEqual(runtime_summary["status"], "pending_runtime_parity")
+            self.assertTrue(runtime_summary["candidate_configmap_path"])
+            replay_plan = json.loads(
+                (
+                    output_dir
+                    / "runtime-closure"
+                    / "replay"
+                    / "runtime-replay-plan.json"
+                ).read_text(encoding="utf-8")
+            )
+            self.assertIsNotNone(replay_plan["execution_context"])
+            self.assertFalse(
+                replay_plan["runtime_closure_policy"]["execute_parity_replay"]
+            )
+            self.assertFalse(
+                replay_plan["runtime_closure_policy"]["execute_approval_replay"]
+            )
+            self.assertTrue(
                 (output_dir / "whitepaper-autoresearch-diagnostics.ipynb").exists()
             )
             model_payload = json.loads(

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -113,6 +113,42 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                 float(portfolio["objective_scorecard"]["net_pnl_per_day"]), 500.0
             )
 
+    def test_main_returns_nonzero_when_no_oracle_candidate_found(self) -> None:
+        with (
+            TemporaryDirectory() as tmpdir,
+            patch.object(
+                runner,
+                "_parse_args",
+                return_value=Namespace(
+                    **{
+                        **vars(self._args(Path(tmpdir) / "epoch")),
+                        "target_net_pnl_per_day": "999999",
+                    }
+                ),
+            ),
+            patch("builtins.print"),
+        ):
+            exit_code = runner.main()
+            output_dir = Path(tmpdir) / "epoch"
+            summary = json.loads(
+                (output_dir / "summary.json").read_text(encoding="utf-8")
+            )
+            portfolio_report_exists = (
+                output_dir / "portfolio-optimizer-report.json"
+            ).exists()
+
+        self.assertEqual(exit_code, 2)
+        self.assertEqual(summary["status"], "no_profit_target_candidate")
+        self.assertEqual(
+            summary["status_reason"], "portfolio_candidate_failed_profit_target_oracle"
+        )
+        self.assertFalse(summary["oracle_candidate_found"])
+        self.assertIn(
+            "portfolio_post_cost_net_pnl_per_day_failed",
+            summary["profit_target_oracle"]["blockers"],
+        )
+        self.assertTrue(portfolio_report_exists)
+
     def test_seed_recent_whitepapers_persists_epoch_ledgers(self) -> None:
         with (
             TemporaryDirectory() as tmpdir,

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -88,6 +88,10 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             self.assertTrue((output_dir / "candidate-specs.jsonl").exists())
             self.assertTrue((output_dir / "candidate-compiler-report.json").exists())
             self.assertTrue((output_dir / "candidate-selection-manifest.json").exists())
+            self.assertTrue((output_dir / "pre-replay-mlx-ranker-model.json").exists())
+            self.assertTrue(
+                (output_dir / "pre-replay-mlx-proposal-scores.jsonl").exists()
+            )
             self.assertTrue((output_dir / "mlx-ranker-model.json").exists())
             self.assertTrue((output_dir / "mlx-proposal-scores.jsonl").exists())
             self.assertTrue((output_dir / "candidate-evidence-bundles.jsonl").exists())
@@ -129,6 +133,15 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             model_payload = json.loads(
                 (output_dir / "mlx-ranker-model.json").read_text(encoding="utf-8")
             )
+            pre_replay_model_payload = json.loads(
+                (output_dir / "pre-replay-mlx-ranker-model.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            self.assertEqual(pre_replay_model_payload["proposal_stage"], "pre_replay")
+            self.assertEqual(
+                pre_replay_model_payload["row_count"], payload["candidate_spec_count"]
+            )
             self.assertEqual(model_payload["schema_version"], "torghut.mlx-ranker.v1")
             self.assertEqual(
                 model_payload["row_count"], payload["candidate_spec_count"]
@@ -145,6 +158,9 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             )
             self.assertEqual(
                 payload["evidence_bundle_count"], payload["replay_candidate_spec_count"]
+            )
+            self.assertEqual(
+                selection["proposal_model"]["proposal_stage"], "pre_replay"
             )
 
             portfolio = payload["best_portfolio_candidate"]
@@ -178,6 +194,13 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                 .splitlines()
                 if line
             ]
+            pre_replay_rows = [
+                json.loads(line)
+                for line in (output_dir / "pre-replay-mlx-proposal-scores.jsonl")
+                .read_text(encoding="utf-8")
+                .splitlines()
+                if line
+            ]
 
         self.assertEqual(payload["status"], "ok")
         self.assertEqual(selection["budget"]["selected_count"], 2)
@@ -194,6 +217,11 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         self.assertEqual(
             {row["replay_selection_reason"] for row in proposal_selected},
             {"exploitation", "exploration"},
+        )
+        self.assertEqual(len(pre_replay_rows), payload["candidate_spec_count"])
+        self.assertEqual(
+            {row["selection_reason"] for row in pre_replay_rows},
+            {"pre_replay_mlx_rank"},
         )
 
     def test_main_returns_nonzero_when_no_oracle_candidate_found(self) -> None:

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -86,11 +86,15 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             self.assertEqual(summary["epoch_id"], payload["epoch_id"])
             self.assertTrue((output_dir / "hypothesis-cards.jsonl").exists())
             self.assertTrue((output_dir / "candidate-specs.jsonl").exists())
+            self.assertTrue((output_dir / "candidate-compiler-report.json").exists())
             self.assertTrue((output_dir / "mlx-ranker-model.json").exists())
             self.assertTrue((output_dir / "mlx-proposal-scores.jsonl").exists())
             self.assertTrue((output_dir / "candidate-evidence-bundles.jsonl").exists())
             self.assertTrue((output_dir / "portfolio-candidates.jsonl").exists())
             self.assertTrue((output_dir / "runtime-closure" / "summary.json").exists())
+            self.assertTrue(
+                (output_dir / "whitepaper-autoresearch-diagnostics.ipynb").exists()
+            )
             model_payload = json.loads(
                 (output_dir / "mlx-ranker-model.json").read_text(encoding="utf-8")
             )
@@ -98,6 +102,7 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             self.assertEqual(
                 model_payload["row_count"], payload["candidate_spec_count"]
             )
+            self.assertIn("rank_bucket_lift", model_payload)
 
             portfolio = payload["best_portfolio_candidate"]
             self.assertTrue(portfolio["objective_scorecard"]["target_met"])
@@ -153,6 +158,36 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         self.assertEqual(model_payload["backend"], "numpy-fallback")
         self.assertEqual(len(scores), 4)
         self.assertEqual(scores[0]["rank"], 1)
+
+    def test_replay_failures_write_error_summary_and_exit_code_three(self) -> None:
+        with (
+            TemporaryDirectory() as tmpdir,
+            patch.object(
+                runner,
+                "_parse_args",
+                return_value=Namespace(
+                    **{
+                        **vars(self._args(Path(tmpdir) / "epoch")),
+                        "replay_mode": "real",
+                    }
+                ),
+            ),
+            patch.object(
+                runner,
+                "_run_real_replay",
+                side_effect=RuntimeError("forced replay failure"),
+            ),
+            patch("builtins.print"),
+        ):
+            exit_code = runner.main()
+            summary = json.loads(
+                (Path(tmpdir) / "epoch" / "error-summary.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+
+        self.assertEqual(exit_code, 3)
+        self.assertEqual(summary["status"], "replay_failed")
 
     def test_train_ranker_script_main_writes_model_and_scores(self) -> None:
         with TemporaryDirectory() as tmpdir:

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 from sqlalchemy import create_engine, select
 from sqlalchemy.orm import Session
 
+import scripts.compile_whitepaper_claims as claim_compiler_script
 import scripts.run_whitepaper_autoresearch_profit_target as runner
 import scripts.train_mlx_autoresearch_ranker as ranker_trainer
 from app.models import (
@@ -152,6 +153,142 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         self.assertEqual(model_payload["backend"], "numpy-fallback")
         self.assertEqual(len(scores), 4)
         self.assertEqual(scores[0]["rank"], 1)
+
+    def test_train_ranker_script_main_writes_model_and_scores(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir) / "epoch"
+            runner.run_whitepaper_autoresearch_profit_target(self._args(output_dir))
+            model_output = Path(tmpdir) / "ranker" / "model.json"
+            scores_output = Path(tmpdir) / "ranker" / "scores.jsonl"
+
+            with (
+                patch(
+                    "sys.argv",
+                    [
+                        "train_mlx_autoresearch_ranker.py",
+                        "--candidate-specs",
+                        str(output_dir / "candidate-specs.jsonl"),
+                        "--evidence-bundles",
+                        str(output_dir / "candidate-evidence-bundles.jsonl"),
+                        "--model-output",
+                        str(model_output),
+                        "--scores-output",
+                        str(scores_output),
+                        "--backend-preference",
+                        "numpy-fallback",
+                    ],
+                ),
+                patch("builtins.print") as mock_print,
+            ):
+                exit_code = ranker_trainer.main()
+
+            model_payload = json.loads(model_output.read_text(encoding="utf-8"))
+            score_rows = scores_output.read_text(encoding="utf-8").splitlines()
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(model_payload["backend"], "numpy-fallback")
+        self.assertEqual(len(score_rows), 4)
+        self.assertTrue(mock_print.called)
+
+    def test_compile_claims_script_main_writes_recent_seed_cards(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "claims" / "hypothesis-cards.jsonl"
+            with (
+                patch(
+                    "sys.argv",
+                    [
+                        "compile_whitepaper_claims.py",
+                        "--output",
+                        str(output_path),
+                        "--seed-recent-whitepapers",
+                    ],
+                ),
+                patch("builtins.print") as mock_print,
+            ):
+                parsed = claim_compiler_script._parse_args()
+                exit_code = claim_compiler_script.main()
+
+            rows = output_path.read_text(encoding="utf-8").splitlines()
+
+        self.assertEqual(parsed.output, output_path)
+        self.assertTrue(parsed.seed_recent_whitepapers)
+        self.assertEqual(exit_code, 0)
+        self.assertGreaterEqual(len(rows), 4)
+        self.assertTrue(mock_print.called)
+
+    def test_runner_parse_args_covers_cli_defaults_and_flags(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir) / "epoch"
+            with patch(
+                "sys.argv",
+                [
+                    "run_whitepaper_autoresearch_profit_target.py",
+                    "--output-dir",
+                    str(output_dir),
+                    "--seed-recent-whitepapers",
+                    "--replay-mode",
+                    "synthetic",
+                    "--no-persist-results",
+                ],
+            ):
+                parsed = runner._parse_args()
+
+        self.assertEqual(parsed.output_dir, output_dir)
+        self.assertTrue(parsed.seed_recent_whitepapers)
+        self.assertEqual(parsed.replay_mode, "synthetic")
+        self.assertFalse(parsed.persist_results)
+
+    def test_real_replay_builds_evidence_and_skips_incomplete_results(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir) / "real"
+            empty_result_path = Path(tmpdir) / "empty.json"
+            valid_result_path = Path(tmpdir) / "valid.json"
+            empty_result_path.write_text(json.dumps({"top": []}), encoding="utf-8")
+            valid_result_path.write_text(
+                json.dumps(
+                    {
+                        "top": [
+                            {
+                                "candidate_id": "cand-real",
+                                "objective_scorecard": {
+                                    "net_pnl_per_day": "250",
+                                    "active_day_ratio": "1.0",
+                                    "positive_day_ratio": "0.8",
+                                },
+                            }
+                        ]
+                    }
+                ),
+                encoding="utf-8",
+            )
+            factory_payload = {
+                "experiments": [
+                    {"experiment_id": "missing-path"},
+                    {
+                        "experiment_id": "empty-top",
+                        "result_path": str(empty_result_path),
+                    },
+                    {
+                        "experiment_id": "spec-real",
+                        "dataset_snapshot_id": "snap-real",
+                        "result_path": str(valid_result_path),
+                        "promotion_readiness": {"status": "blocked"},
+                    },
+                ]
+            }
+
+            with patch.object(
+                runner.strategy_factory_runner,
+                "run_strategy_factory_v2",
+                return_value=factory_payload,
+            ):
+                result = runner._run_real_replay(
+                    self._args(output_dir), output_dir=output_dir
+                )
+
+        self.assertEqual(len(result.evidence_bundles), 1)
+        self.assertEqual(result.evidence_bundles[0].candidate_spec_id, "spec-real")
+        self.assertEqual(result.evidence_bundles[0].dataset_snapshot_id, "snap-real")
 
     def test_main_returns_nonzero_without_sources(self) -> None:
         with (

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -87,6 +87,7 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             self.assertTrue((output_dir / "hypothesis-cards.jsonl").exists())
             self.assertTrue((output_dir / "candidate-specs.jsonl").exists())
             self.assertTrue((output_dir / "candidate-compiler-report.json").exists())
+            self.assertTrue((output_dir / "candidate-selection-manifest.json").exists())
             self.assertTrue((output_dir / "mlx-ranker-model.json").exists())
             self.assertTrue((output_dir / "mlx-proposal-scores.jsonl").exists())
             self.assertTrue((output_dir / "candidate-evidence-bundles.jsonl").exists())
@@ -133,6 +134,18 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                 model_payload["row_count"], payload["candidate_spec_count"]
             )
             self.assertIn("rank_bucket_lift", model_payload)
+            selection = json.loads(
+                (output_dir / "candidate-selection-manifest.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            self.assertEqual(
+                selection["budget"]["selected_count"],
+                payload["replay_candidate_spec_count"],
+            )
+            self.assertEqual(
+                payload["evidence_bundle_count"], payload["replay_candidate_spec_count"]
+            )
 
             portfolio = payload["best_portfolio_candidate"]
             self.assertTrue(portfolio["objective_scorecard"]["target_met"])
@@ -142,6 +155,46 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             self.assertGreaterEqual(
                 float(portfolio["objective_scorecard"]["net_pnl_per_day"]), 500.0
             )
+
+    def test_seed_recent_whitepapers_honors_top_k_and_exploration_budget(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir) / "epoch"
+            args = self._args(output_dir)
+            args.top_k = 1
+            args.exploration_slots = 1
+            payload = runner.run_whitepaper_autoresearch_profit_target(args)
+
+            selection = json.loads(
+                (output_dir / "candidate-selection-manifest.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            proposal_rows = [
+                json.loads(line)
+                for line in (output_dir / "mlx-proposal-scores.jsonl")
+                .read_text(encoding="utf-8")
+                .splitlines()
+                if line
+            ]
+
+        self.assertEqual(payload["status"], "ok")
+        self.assertEqual(selection["budget"]["selected_count"], 2)
+        self.assertEqual(payload["replay_candidate_spec_count"], 2)
+        self.assertEqual(payload["evidence_bundle_count"], 2)
+        self.assertEqual(payload["candidate_spec_count"], 4)
+        selected_rows = [row for row in selection["rows"] if row["selected_for_replay"]]
+        self.assertEqual(
+            {row["selection_reason"] for row in selected_rows},
+            {"exploitation", "exploration"},
+        )
+        proposal_selected = [row for row in proposal_rows if row["selected_for_replay"]]
+        self.assertEqual(len(proposal_selected), 2)
+        self.assertEqual(
+            {row["replay_selection_reason"] for row in proposal_selected},
+            {"exploitation", "exploration"},
+        )
 
     def test_main_returns_nonzero_when_no_oracle_candidate_found(self) -> None:
         with (

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -106,6 +106,9 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
 
             portfolio = payload["best_portfolio_candidate"]
             self.assertTrue(portfolio["objective_scorecard"]["target_met"])
+            self.assertTrue(portfolio["objective_scorecard"]["oracle_passed"])
+            self.assertTrue(payload["oracle_candidate_found"])
+            self.assertEqual(payload["profit_target_oracle"]["blockers"], [])
             self.assertGreaterEqual(
                 float(portfolio["objective_scorecard"]["net_pnl_per_day"]), 500.0
             )

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -84,6 +84,13 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                 (output_dir / "summary.json").read_text(encoding="utf-8")
             )
             self.assertEqual(summary["epoch_id"], payload["epoch_id"])
+            self.assertEqual(
+                summary["false_positive_table"], payload["false_positive_table"]
+            )
+            self.assertEqual(
+                summary["best_false_negative_table"],
+                payload["best_false_negative_table"],
+            )
             self.assertTrue((output_dir / "hypothesis-cards.jsonl").exists())
             self.assertTrue((output_dir / "candidate-specs.jsonl").exists())
             self.assertTrue((output_dir / "candidate-compiler-report.json").exists())
@@ -171,6 +178,14 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             self.assertGreaterEqual(
                 float(portfolio["objective_scorecard"]["net_pnl_per_day"]), 500.0
             )
+            self.assertTrue(payload["false_positive_table"])
+            false_positive_reasons = {
+                reason
+                for row in payload["false_positive_table"]
+                for reason in row["failure_reasons"]
+            }
+            self.assertIn("active_day_ratio_below_oracle", false_positive_reasons)
+            self.assertEqual(payload["best_false_negative_table"], [])
 
     def test_seed_recent_whitepapers_honors_top_k_and_exploration_budget(
         self,
@@ -210,6 +225,12 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         self.assertEqual(payload["replay_candidate_spec_count"], 3)
         self.assertEqual(payload["evidence_bundle_count"], 3)
         self.assertEqual(payload["candidate_spec_count"], 4)
+        self.assertEqual(payload["false_positive_table"], [])
+        self.assertEqual(len(payload["best_false_negative_table"]), 1)
+        self.assertEqual(
+            payload["best_false_negative_table"][0]["evidence_status"], "not_replayed"
+        )
+        self.assertFalse(payload["best_false_negative_table"][0]["selected_for_replay"])
         selected_rows = [row for row in selection["rows"] if row["selected_for_replay"]]
         self.assertEqual(
             {row["selection_reason"] for row in selected_rows},

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import json
+from argparse import Namespace
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import TestCase
+from unittest.mock import patch
+
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session
+
+import scripts.run_whitepaper_autoresearch_profit_target as runner
+import scripts.train_mlx_autoresearch_ranker as ranker_trainer
+from app.models import (
+    AutoresearchCandidateSpec,
+    AutoresearchEpoch,
+    AutoresearchPortfolioCandidate,
+    AutoresearchProposalScore,
+    Base,
+)
+
+
+class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
+    def setUp(self) -> None:
+        self.engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        Base.metadata.create_all(self.engine)
+
+    def tearDown(self) -> None:
+        self.engine.dispose()
+
+    def _args(self, output_dir: Path) -> Namespace:
+        return Namespace(
+            output_dir=output_dir,
+            paper_run_id=[],
+            seed_recent_whitepapers=True,
+            target_net_pnl_per_day="500",
+            max_candidates=8,
+            top_k=4,
+            exploration_slots=2,
+            portfolio_size_min=2,
+            portfolio_size_max=4,
+            replay_mode="synthetic",
+            program=Path(
+                "config/trading/research-programs/strict-daily-profit-autoresearch-v1.yaml"
+            ),
+            strategy_configmap=Path(
+                "argocd/applications/torghut/strategy-configmap.yaml"
+            ),
+            family_template_dir=Path("config/trading/families"),
+            seed_sweep_dir=Path("config/trading"),
+            clickhouse_http_url="http://example.invalid:8123",
+            clickhouse_username="torghut",
+            clickhouse_password="secret",
+            start_equity="31590.02",
+            chunk_minutes=10,
+            symbols="AAPL,NVDA,MSFT,AMAT",
+            progress_log_seconds=30,
+            train_days=6,
+            holdout_days=3,
+            full_window_start_date="2026-02-23",
+            full_window_end_date="2026-02-27",
+            expected_last_trading_day="",
+            allow_stale_tape=False,
+            prefetch_full_window_rows=False,
+            persist_results=False,
+        )
+
+    def test_seed_recent_whitepapers_runs_end_to_end_and_writes_artifacts(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir) / "epoch"
+            payload = runner.run_whitepaper_autoresearch_profit_target(
+                self._args(output_dir)
+            )
+
+            self.assertEqual(payload["status"], "ok")
+            self.assertGreaterEqual(payload["source_count"], 4)
+            self.assertGreaterEqual(payload["candidate_spec_count"], 4)
+            self.assertIsNotNone(payload["best_portfolio_candidate"])
+            self.assertFalse(payload["promotion_readiness"]["promotable"])
+
+            summary = json.loads(
+                (output_dir / "summary.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(summary["epoch_id"], payload["epoch_id"])
+            self.assertTrue((output_dir / "hypothesis-cards.jsonl").exists())
+            self.assertTrue((output_dir / "candidate-specs.jsonl").exists())
+            self.assertTrue((output_dir / "mlx-ranker-model.json").exists())
+            self.assertTrue((output_dir / "mlx-proposal-scores.jsonl").exists())
+            self.assertTrue((output_dir / "candidate-evidence-bundles.jsonl").exists())
+            self.assertTrue((output_dir / "portfolio-candidates.jsonl").exists())
+            self.assertTrue((output_dir / "runtime-closure" / "summary.json").exists())
+            model_payload = json.loads(
+                (output_dir / "mlx-ranker-model.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(model_payload["schema_version"], "torghut.mlx-ranker.v1")
+            self.assertEqual(
+                model_payload["row_count"], payload["candidate_spec_count"]
+            )
+
+            portfolio = payload["best_portfolio_candidate"]
+            self.assertTrue(portfolio["objective_scorecard"]["target_met"])
+            self.assertGreaterEqual(
+                float(portfolio["objective_scorecard"]["net_pnl_per_day"]), 500.0
+            )
+
+    def test_seed_recent_whitepapers_persists_epoch_ledgers(self) -> None:
+        with (
+            TemporaryDirectory() as tmpdir,
+            patch(
+                "scripts.run_whitepaper_autoresearch_profit_target.SessionLocal",
+                side_effect=lambda: Session(self.engine),
+            ),
+        ):
+            args = self._args(Path(tmpdir) / "epoch")
+            args.persist_results = True
+            payload = runner.run_whitepaper_autoresearch_profit_target(args)
+
+            with Session(self.engine) as session:
+                epoch = session.execute(select(AutoresearchEpoch)).scalar_one()
+                specs = (
+                    session.execute(select(AutoresearchCandidateSpec)).scalars().all()
+                )
+                proposals = (
+                    session.execute(select(AutoresearchProposalScore)).scalars().all()
+                )
+                portfolios = (
+                    session.execute(select(AutoresearchPortfolioCandidate))
+                    .scalars()
+                    .all()
+                )
+
+        self.assertEqual(epoch.epoch_id, payload["epoch_id"])
+        self.assertEqual(epoch.status, "ok")
+        self.assertEqual(len(specs), payload["candidate_spec_count"])
+        self.assertEqual(len(proposals), payload["proposal_score_count"])
+        self.assertEqual(len(portfolios), 1)
+        self.assertEqual(portfolios[0].status, "target_met")
+
+    def test_train_ranker_script_helper_reads_runner_artifacts(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir) / "epoch"
+            runner.run_whitepaper_autoresearch_profit_target(self._args(output_dir))
+
+            model_payload, scores = ranker_trainer.train_from_artifacts(
+                candidate_specs_path=output_dir / "candidate-specs.jsonl",
+                evidence_bundles_path=output_dir / "candidate-evidence-bundles.jsonl",
+                backend_preference="numpy-fallback",
+            )
+
+        self.assertEqual(model_payload["schema_version"], "torghut.mlx-ranker.v1")
+        self.assertEqual(model_payload["backend"], "numpy-fallback")
+        self.assertEqual(len(scores), 4)
+        self.assertEqual(scores[0]["rank"], 1)
+
+    def test_main_returns_nonzero_without_sources(self) -> None:
+        with (
+            TemporaryDirectory() as tmpdir,
+            patch.object(
+                runner,
+                "_parse_args",
+                return_value=Namespace(
+                    **{
+                        **vars(self._args(Path(tmpdir) / "epoch")),
+                        "seed_recent_whitepapers": False,
+                        "paper_run_id": [],
+                    }
+                ),
+            ),
+            patch("builtins.print") as mock_print,
+        ):
+            exit_code = runner.main()
+
+        self.assertEqual(exit_code, 2)
+        self.assertTrue(mock_print.called)

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -203,9 +203,12 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             ]
 
         self.assertEqual(payload["status"], "ok")
-        self.assertEqual(selection["budget"]["selected_count"], 2)
-        self.assertEqual(payload["replay_candidate_spec_count"], 2)
-        self.assertEqual(payload["evidence_bundle_count"], 2)
+        self.assertEqual(selection["proposal_score_confidence"]["confidence"], "low")
+        self.assertEqual(selection["budget"]["exploration_slots_requested"], 1)
+        self.assertEqual(selection["budget"]["exploration_slots_effective"], 2)
+        self.assertEqual(selection["budget"]["selected_count"], 3)
+        self.assertEqual(payload["replay_candidate_spec_count"], 3)
+        self.assertEqual(payload["evidence_bundle_count"], 3)
         self.assertEqual(payload["candidate_spec_count"], 4)
         selected_rows = [row for row in selection["rows"] if row["selected_for_replay"]]
         self.assertEqual(
@@ -213,7 +216,7 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             {"exploitation", "exploration"},
         )
         proposal_selected = [row for row in proposal_rows if row["selected_for_replay"]]
-        self.assertEqual(len(proposal_selected), 2)
+        self.assertEqual(len(proposal_selected), 3)
         self.assertEqual(
             {row["replay_selection_reason"] for row in proposal_selected},
             {"exploitation", "exploration"},

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -99,6 +99,7 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             self.assertTrue(
                 (output_dir / "pre-replay-mlx-proposal-scores.jsonl").exists()
             )
+            self.assertTrue((output_dir / "mlx-snapshot-manifest.json").exists())
             self.assertTrue((output_dir / "mlx-ranker-model.json").exists())
             self.assertTrue((output_dir / "mlx-proposal-scores.jsonl").exists())
             self.assertTrue((output_dir / "candidate-evidence-bundles.jsonl").exists())
@@ -133,6 +134,34 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             )
             self.assertFalse(
                 replay_plan["runtime_closure_policy"]["execute_approval_replay"]
+            )
+            snapshot_manifest = json.loads(
+                (output_dir / "mlx-snapshot-manifest.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(
+                replay_plan["dataset_snapshot_ref"], snapshot_manifest["snapshot_id"]
+            )
+            self.assertEqual(
+                snapshot_manifest["row_counts"]["candidate_specs"],
+                payload["candidate_spec_count"],
+            )
+            self.assertEqual(
+                snapshot_manifest["row_counts"]["candidate_evidence_bundles"],
+                payload["evidence_bundle_count"],
+            )
+            self.assertEqual(
+                snapshot_manifest["row_counts"]["pre_replay_proposal_scores"],
+                payload["pre_replay_proposal_score_count"],
+            )
+            self.assertEqual(
+                snapshot_manifest["tensor_bundle_paths"][
+                    "candidate_selection_manifest_json"
+                ],
+                str((output_dir / "candidate-selection-manifest.json").resolve()),
+            )
+            self.assertEqual(
+                payload["artifacts"]["mlx_snapshot_manifest"],
+                str((output_dir / "mlx-snapshot-manifest.json").resolve()),
             )
             self.assertTrue(
                 (output_dir / "whitepaper-autoresearch-diagnostics.ipynb").exists()

--- a/services/torghut/tests/test_runtime_closure.py
+++ b/services/torghut/tests/test_runtime_closure.py
@@ -28,33 +28,33 @@ _REPO_ROOT = Path(__file__).resolve().parents[3]
 
 def _program() -> StrategyAutoresearchProgram:
     return StrategyAutoresearchProgram(
-        program_id='program-1',
-        description='desc',
+        program_id="program-1",
+        description="desc",
         objective=StrategyObjective(
-            target_net_pnl_per_day=Decimal('500'),
-            min_active_day_ratio=Decimal('1.0'),
-            min_positive_day_ratio=Decimal('0.6'),
-            min_daily_notional=Decimal('300000'),
-            max_best_day_share=Decimal('0.3'),
-            max_worst_day_loss=Decimal('350'),
-            max_drawdown=Decimal('900'),
+            target_net_pnl_per_day=Decimal("500"),
+            min_active_day_ratio=Decimal("1.0"),
+            min_positive_day_ratio=Decimal("0.6"),
+            min_daily_notional=Decimal("300000"),
+            max_best_day_share=Decimal("0.3"),
+            max_worst_day_loss=Decimal("350"),
+            max_drawdown=Decimal("900"),
             require_every_day_active=True,
-            min_regime_slice_pass_rate=Decimal('0.45'),
+            min_regime_slice_pass_rate=Decimal("0.45"),
             stop_when_objective_met=True,
         ),
         snapshot_policy=SnapshotPolicy(
-            bar_interval='PT1S',
-            feature_set_id='torghut.mlx-autoresearch.v1',
-            quote_quality_policy_id='scheduler_v3_default',
-            symbol_policy='args_or_sweep',
+            bar_interval="PT1S",
+            feature_set_id="torghut.mlx-autoresearch.v1",
+            quote_quality_policy_id="scheduler_v3_default",
+            symbol_policy="args_or_sweep",
             allow_prior_day_features=True,
             allow_cross_sectional_features=True,
         ),
-        forbidden_mutations=('runtime_code_path',),
+        forbidden_mutations=("runtime_code_path",),
         proposal_model_policy=ProposalModelPolicy(
             enabled=True,
-            mode='ranking_only',
-            backend_preference='mlx',
+            mode="ranking_only",
+            backend_preference="mlx",
             top_k=4,
             exploration_slots=1,
             minimum_history_rows=1,
@@ -68,14 +68,14 @@ def _program() -> StrategyAutoresearchProgram:
             enabled=False,
             execute_parity_replay=True,
             execute_approval_replay=True,
-            parity_window='full_window',
-            approval_window='holdout',
-            shadow_validation_mode='require_live_evidence',
-            promotion_target='shadow',
+            parity_window="full_window",
+            approval_window="holdout",
+            shadow_validation_mode="require_live_evidence",
+            promotion_target="shadow",
         ),
-        parity_requirements=('scheduler_v3_parity_replay',),
-        promotion_policy='research_only',
-        ledger_policy={'append_only': True},
+        parity_requirements=("scheduler_v3_parity_replay",),
+        promotion_policy="research_only",
+        ledger_policy={"append_only": True},
         research_sources=(),
         families=(),
     )
@@ -84,172 +84,191 @@ def _program() -> StrategyAutoresearchProgram:
 class TestRuntimeClosure(TestCase):
     def test_runtime_closure_helper_branches_cover_edge_cases(self) -> None:
         manifest = build_mlx_snapshot_manifest(
-            runner_run_id='run-1',
+            runner_run_id="run-1",
             program=_program(),
-            symbols='AMAT,NVDA',
+            symbols="AMAT,NVDA",
             train_days=6,
             holdout_days=2,
-            full_window_start_date='2026-03-20',
-            full_window_end_date='2026-04-09',
+            full_window_start_date="2026-03-20",
+            full_window_end_date="2026-04-09",
         )
         context = RuntimeClosureExecutionContext(
-            strategy_configmap_path=Path('/tmp/unused.yaml'),
-            clickhouse_http_url='http://example.invalid:8123',
-            clickhouse_username='torghut',
-            clickhouse_password='secret',
-            start_equity=Decimal('31590.02'),
+            strategy_configmap_path=Path("/tmp/unused.yaml"),
+            clickhouse_http_url="http://example.invalid:8123",
+            clickhouse_username="torghut",
+            clickhouse_password="secret",
+            start_equity=Decimal("31590.02"),
             chunk_minutes=10,
-            symbols=('AMAT', 'NVDA'),
+            symbols=("AMAT", "NVDA"),
         )
 
         self.assertEqual(
             runtime_closure._max_drawdown_from_daily_net(
-                {'2026-03-20': Decimal('5'), '2026-03-21': Decimal('-10')}
+                {"2026-03-20": Decimal("5"), "2026-03-21": Decimal("-10")}
             ),
-            Decimal('10'),
+            Decimal("10"),
         )
-        self.assertEqual(runtime_closure._rolling_lower_bound({}, window=3), Decimal('0'))
+        self.assertEqual(
+            runtime_closure._rolling_lower_bound({}, window=3), Decimal("0")
+        )
         self.assertEqual(
             runtime_closure._rolling_lower_bound(
-                {'2026-03-20': Decimal('2'), '2026-03-21': Decimal('4')},
+                {"2026-03-20": Decimal("2"), "2026-03-21": Decimal("4")},
                 window=3,
             ),
-            Decimal('3'),
+            Decimal("3"),
         )
         self.assertEqual(
             runtime_closure._max_best_day_share_of_total_pnl(
-                daily_net={'2026-03-20': Decimal('-1')},
-                total_net_pnl=Decimal('0'),
+                daily_net={"2026-03-20": Decimal("-1")},
+                total_net_pnl=Decimal("0"),
             ),
-            Decimal('1'),
+            Decimal("1"),
         )
         self.assertEqual(
             runtime_closure._max_best_day_share_of_total_pnl(
-                daily_net={'2026-03-20': Decimal('-1')},
-                total_net_pnl=Decimal('10'),
+                daily_net={"2026-03-20": Decimal("-1")},
+                total_net_pnl=Decimal("10"),
             ),
-            Decimal('0'),
+            Decimal("0"),
         )
         self.assertEqual(
             runtime_closure._candidate_symbols(
-                best_candidate={'candidate_strategy_overrides': {}},
+                best_candidate={"candidate_strategy_overrides": {}},
                 execution_context=context,
             ),
-            ('AMAT', 'NVDA'),
+            ("AMAT", "NVDA"),
         )
-        self.assertIsNone(context.to_payload()['shadow_validation_artifact_path'])
+        self.assertIsNone(context.to_payload()["shadow_validation_artifact_path"])
         self.assertEqual(
             runtime_closure._window_bounds(
                 best_candidate={},
-                window_name='full_window',
+                window_name="full_window",
                 manifest=manifest,
             ),
-            (runtime_closure._date_from_iso('2026-03-20'), runtime_closure._date_from_iso('2026-04-09')),
+            (
+                runtime_closure._date_from_iso("2026-03-20"),
+                runtime_closure._date_from_iso("2026-04-09"),
+            ),
         )
-        with self.assertRaisesRegex(ValueError, 'runtime_closure_window_missing:holdout'):
+        with self.assertRaisesRegex(
+            ValueError, "runtime_closure_window_missing:holdout"
+        ):
             runtime_closure._window_bounds(
                 best_candidate={},
-                window_name='holdout',
+                window_name="holdout",
                 manifest=manifest,
             )
         config = object()
-        with patch.object(runtime_closure.replay_mod, 'run_replay', return_value={'status': 'ok'}) as mock_run:
+        with patch.object(
+            runtime_closure.replay_mod, "run_replay", return_value={"status": "ok"}
+        ) as mock_run:
             payload = runtime_closure._default_replay_executor(config)
-        self.assertEqual(payload, {'status': 'ok'})
+        self.assertEqual(payload, {"status": "ok"})
         mock_run.assert_called_once_with(config)  # type: ignore[arg-type]
 
-    def test_shadow_validation_artifact_helper_covers_invalid_schema_and_pending_status(self) -> None:
+    def test_shadow_validation_artifact_helper_covers_invalid_schema_and_pending_status(
+        self,
+    ) -> None:
         with TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
-            invalid_json_path = root / 'invalid.json'
-            invalid_json_path.write_text('{not-json\n', encoding='utf-8')
-            bad_schema_path = root / 'bad-schema.json'
+            invalid_json_path = root / "invalid.json"
+            invalid_json_path.write_text("{not-json\n", encoding="utf-8")
+            bad_schema_path = root / "bad-schema.json"
             bad_schema_path.write_text(
-                json.dumps({'schema_version': 'wrong-schema', 'status': 'within_budget'}) + '\n',
-                encoding='utf-8',
+                json.dumps(
+                    {"schema_version": "wrong-schema", "status": "within_budget"}
+                )
+                + "\n",
+                encoding="utf-8",
             )
-            pending_path = root / 'pending.json'
+            pending_path = root / "pending.json"
             pending_path.write_text(
                 json.dumps(
                     {
-                        'schema_version': 'shadow-live-deviation-report-v1',
-                        'status': 'pending',
-                        'order_count': 2,
+                        "schema_version": "shadow-live-deviation-report-v1",
+                        "status": "pending",
+                        "order_count": 2,
                     }
                 )
-                + '\n',
-                encoding='utf-8',
+                + "\n",
+                encoding="utf-8",
             )
 
             invalid_payload = runtime_closure._shadow_validation_artifact(
-                best_candidate={'candidate_id': 'cand-1'},
+                best_candidate={"candidate_id": "cand-1"},
                 program=_program(),
                 execution_context=RuntimeClosureExecutionContext(
-                    strategy_configmap_path=root / 'strategies.yaml',
-                    clickhouse_http_url='http://example.invalid:8123',
-                    clickhouse_username='torghut',
-                    clickhouse_password='secret',
-                    start_equity=Decimal('31590.02'),
+                    strategy_configmap_path=root / "strategies.yaml",
+                    clickhouse_http_url="http://example.invalid:8123",
+                    clickhouse_username="torghut",
+                    clickhouse_password="secret",
+                    start_equity=Decimal("31590.02"),
                     chunk_minutes=10,
                     shadow_validation_artifact_path=invalid_json_path,
                 ),
             )
-            self.assertEqual(invalid_payload['status'], 'invalid_artifact')
-            self.assertIn('shadow_validation_artifact_invalid_json', invalid_payload['reasons'])
+            self.assertEqual(invalid_payload["status"], "invalid_artifact")
+            self.assertIn(
+                "shadow_validation_artifact_invalid_json", invalid_payload["reasons"]
+            )
 
             bad_schema_payload = runtime_closure._shadow_validation_artifact(
-                best_candidate={'candidate_id': 'cand-1'},
+                best_candidate={"candidate_id": "cand-1"},
                 program=_program(),
                 execution_context=RuntimeClosureExecutionContext(
-                    strategy_configmap_path=root / 'strategies.yaml',
-                    clickhouse_http_url='http://example.invalid:8123',
-                    clickhouse_username='torghut',
-                    clickhouse_password='secret',
-                    start_equity=Decimal('31590.02'),
+                    strategy_configmap_path=root / "strategies.yaml",
+                    clickhouse_http_url="http://example.invalid:8123",
+                    clickhouse_username="torghut",
+                    clickhouse_password="secret",
+                    start_equity=Decimal("31590.02"),
                     chunk_minutes=10,
                     shadow_validation_artifact_path=bad_schema_path,
                 ),
             )
-            self.assertEqual(bad_schema_payload['status'], 'invalid_artifact')
-            self.assertIn('shadow_validation_schema_version_invalid', bad_schema_payload['reasons'])
+            self.assertEqual(bad_schema_payload["status"], "invalid_artifact")
+            self.assertIn(
+                "shadow_validation_schema_version_invalid",
+                bad_schema_payload["reasons"],
+            )
 
             pending_payload = runtime_closure._shadow_validation_artifact(
-                best_candidate={'candidate_id': 'cand-1'},
+                best_candidate={"candidate_id": "cand-1"},
                 program=_program(),
                 execution_context=RuntimeClosureExecutionContext(
-                    strategy_configmap_path=root / 'strategies.yaml',
-                    clickhouse_http_url='http://example.invalid:8123',
-                    clickhouse_username='torghut',
-                    clickhouse_password='secret',
-                    start_equity=Decimal('31590.02'),
+                    strategy_configmap_path=root / "strategies.yaml",
+                    clickhouse_http_url="http://example.invalid:8123",
+                    clickhouse_username="torghut",
+                    clickhouse_password="secret",
+                    start_equity=Decimal("31590.02"),
                     chunk_minutes=10,
                     shadow_validation_artifact_path=pending_path,
                 ),
             )
-            self.assertEqual(pending_payload['status'], 'pending')
-            self.assertIn('shadow_validation_pending', pending_payload['reasons'])
+            self.assertEqual(pending_payload["status"], "pending")
+            self.assertIn("shadow_validation_pending", pending_payload["reasons"])
 
     def test_materialize_candidate_configmap_rejects_invalid_inputs(self) -> None:
         with TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
-            invalid_configmap_path = root / 'invalid.yaml'
-            invalid_configmap_path.write_text('- not-a-mapping\n', encoding='utf-8')
+            invalid_configmap_path = root / "invalid.yaml"
+            invalid_configmap_path.write_text("- not-a-mapping\n", encoding="utf-8")
             context = RuntimeClosureExecutionContext(
                 strategy_configmap_path=invalid_configmap_path,
-                clickhouse_http_url='http://example.invalid:8123',
-                clickhouse_username='torghut',
-                clickhouse_password='secret',
-                start_equity=Decimal('31590.02'),
+                clickhouse_http_url="http://example.invalid:8123",
+                clickhouse_username="torghut",
+                clickhouse_password="secret",
+                start_equity=Decimal("31590.02"),
                 chunk_minutes=10,
             )
-            with self.assertRaisesRegex(ValueError, 'strategy_configmap_not_mapping'):
+            with self.assertRaisesRegex(ValueError, "strategy_configmap_not_mapping"):
                 runtime_closure._materialize_candidate_configmap(
                     best_candidate={},
                     execution_context=context,
-                    output_path=root / 'out.yaml',
+                    output_path=root / "out.yaml",
                 )
 
-            valid_configmap_path = root / 'valid.yaml'
+            valid_configmap_path = root / "valid.yaml"
             valid_configmap_path.write_text(
                 """
 apiVersion: v1
@@ -263,34 +282,44 @@ data:
         params:
           max_entries_per_session: '1'
 """.strip()
-                + '\n',
-                encoding='utf-8',
+                + "\n",
+                encoding="utf-8",
             )
             valid_context = RuntimeClosureExecutionContext(
                 strategy_configmap_path=valid_configmap_path,
-                clickhouse_http_url='http://example.invalid:8123',
-                clickhouse_username='torghut',
-                clickhouse_password='secret',
-                start_equity=Decimal('31590.02'),
+                clickhouse_http_url="http://example.invalid:8123",
+                clickhouse_username="torghut",
+                clickhouse_password="secret",
+                start_equity=Decimal("31590.02"),
                 chunk_minutes=10,
             )
-            with self.assertRaisesRegex(ValueError, 'runtime_closure_missing_runtime_strategy_name'):
+            with self.assertRaisesRegex(
+                ValueError, "runtime_closure_missing_runtime_strategy_name"
+            ):
                 runtime_closure._materialize_candidate_configmap(
-                    best_candidate={'candidate_params': {'max_entries_per_session': '1'}},
+                    best_candidate={
+                        "candidate_params": {"max_entries_per_session": "1"}
+                    },
                     execution_context=valid_context,
-                    output_path=root / 'missing-name.yaml',
+                    output_path=root / "missing-name.yaml",
                 )
-            with self.assertRaisesRegex(ValueError, 'runtime_closure_missing_candidate_params'):
+            with self.assertRaisesRegex(
+                ValueError, "runtime_closure_missing_candidate_params"
+            ):
                 runtime_closure._materialize_candidate_configmap(
-                    best_candidate={'runtime_strategy_name': 'breakout-continuation-long-v1'},
+                    best_candidate={
+                        "runtime_strategy_name": "breakout-continuation-long-v1"
+                    },
                     execution_context=valid_context,
-                    output_path=root / 'missing-params.yaml',
+                    output_path=root / "missing-params.yaml",
                 )
 
-    def test_materialize_candidate_configmap_supports_microbar_portfolio_candidates(self) -> None:
+    def test_materialize_candidate_configmap_supports_microbar_portfolio_candidates(
+        self,
+    ) -> None:
         with TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
-            configmap_path = root / 'valid.yaml'
+            configmap_path = root / "valid.yaml"
             configmap_path.write_text(
                 """
 apiVersion: v1
@@ -304,41 +333,41 @@ data:
         params:
           max_entries_per_session: '1'
 """.strip()
-                + '\n',
-                encoding='utf-8',
+                + "\n",
+                encoding="utf-8",
             )
             context = RuntimeClosureExecutionContext(
                 strategy_configmap_path=configmap_path,
-                clickhouse_http_url='http://example.invalid:8123',
-                clickhouse_username='torghut',
-                clickhouse_password='secret',
-                start_equity=Decimal('31590.02'),
+                clickhouse_http_url="http://example.invalid:8123",
+                clickhouse_username="torghut",
+                clickhouse_password="secret",
+                start_equity=Decimal("31590.02"),
                 chunk_minutes=10,
             )
             best_candidate = {
-                'candidate_id': 'cand-pairs',
-                'family': 'microbar_cross_sectional_pairs',
-                'family_template_id': 'microbar_cross_sectional_pairs_v1',
-                'strategy_name': 'microbar-cross-sectional-pairs-v1',
-                'replay_config': {
-                    'backend': 'microbar_daily_portfolio',
-                    'portfolio': {
-                        'base_per_leg_notional': '25000',
-                        'symbols': ['AAPL', 'NVDA', 'MSFT'],
-                        'sleeves': [
+                "candidate_id": "cand-pairs",
+                "family": "microbar_cross_sectional_pairs",
+                "family_template_id": "microbar_cross_sectional_pairs_v1",
+                "strategy_name": "microbar-cross-sectional-pairs-v1",
+                "replay_config": {
+                    "backend": "microbar_daily_portfolio",
+                    "portfolio": {
+                        "base_per_leg_notional": "25000",
+                        "symbols": ["AAPL", "NVDA", "MSFT"],
+                        "sleeves": [
                             {
-                                'entry_minute_after_open': 60,
-                                'exit_minute_after_open': 120,
-                                'signal': 'open_window_continuation',
-                                'top_n': 2,
-                                'weight': '2',
+                                "entry_minute_after_open": 60,
+                                "exit_minute_after_open": 120,
+                                "signal": "open_window_continuation",
+                                "top_n": 2,
+                                "weight": "2",
                             },
                             {
-                                'entry_minute_after_open': 75,
-                                'exit_minute_after_open': 'close',
-                                'signal': 'vwap_close_continuation',
-                                'top_n': 1,
-                                'weight': '1',
+                                "entry_minute_after_open": 75,
+                                "exit_minute_after_open": "close",
+                                "signal": "vwap_close_continuation",
+                                "top_n": 1,
+                                "weight": "1",
                             },
                         ],
                     },
@@ -348,191 +377,343 @@ data:
             rendered_path = runtime_closure._materialize_candidate_configmap(
                 best_candidate=best_candidate,
                 execution_context=context,
-                output_path=root / 'portfolio.yaml',
+                output_path=root / "portfolio.yaml",
             )
-            rendered = runtime_closure.yaml.safe_load(rendered_path.read_text(encoding='utf-8'))
-            catalog = runtime_closure.yaml.safe_load(rendered['data']['strategies.yaml'])
-            strategies = catalog['strategies']
-            self.assertFalse(strategies[0]['enabled'])
+            rendered = runtime_closure.yaml.safe_load(
+                rendered_path.read_text(encoding="utf-8")
+            )
+            catalog = runtime_closure.yaml.safe_load(
+                rendered["data"]["strategies.yaml"]
+            )
+            strategies = catalog["strategies"]
+            self.assertFalse(strategies[0]["enabled"])
             self.assertEqual(
                 runtime_closure._candidate_symbols(
                     best_candidate=best_candidate,
                     execution_context=context,
                 ),
-                ('AAPL', 'NVDA', 'MSFT'),
+                ("AAPL", "NVDA", "MSFT"),
             )
-            microbar_names = [item['name'] for item in strategies[1:]]
+            microbar_names = [item["name"] for item in strategies[1:]]
             self.assertEqual(
                 microbar_names,
                 [
-                    'microbar-cross-sectional-pairs-v1-sleeve-1-long',
-                    'microbar-cross-sectional-pairs-v1-sleeve-1-short',
-                    'microbar-cross-sectional-pairs-v1-sleeve-2-long',
-                    'microbar-cross-sectional-pairs-v1-sleeve-2-short',
+                    "microbar-cross-sectional-pairs-v1-sleeve-1-long",
+                    "microbar-cross-sectional-pairs-v1-sleeve-1-short",
+                    "microbar-cross-sectional-pairs-v1-sleeve-2-long",
+                    "microbar-cross-sectional-pairs-v1-sleeve-2-short",
                 ],
             )
             sleeve_one_long = strategies[1]
-            self.assertEqual(sleeve_one_long['strategy_type'], 'microbar_cross_sectional_long_v1')
-            self.assertEqual(sleeve_one_long['params']['rank_feature'], 'cross_section_session_open_rank')
-            self.assertEqual(sleeve_one_long['params']['selection_mode'], 'continuation')
-            self.assertEqual(sleeve_one_long['params']['max_concurrent_positions'], '2')
-            self.assertEqual(Decimal(str(sleeve_one_long['max_notional_per_trade'])), Decimal('50000'))
+            self.assertEqual(
+                sleeve_one_long["strategy_type"], "microbar_cross_sectional_long_v1"
+            )
+            self.assertEqual(
+                sleeve_one_long["params"]["rank_feature"],
+                "cross_section_session_open_rank",
+            )
+            self.assertEqual(
+                sleeve_one_long["params"]["selection_mode"], "continuation"
+            )
+            self.assertEqual(sleeve_one_long["params"]["max_concurrent_positions"], "2")
+            self.assertEqual(
+                Decimal(str(sleeve_one_long["max_notional_per_trade"])),
+                Decimal("50000"),
+            )
 
             manifest = build_mlx_snapshot_manifest(
-                runner_run_id='run-1',
+                runner_run_id="run-1",
                 program=_program(),
-                symbols='AAPL,MSFT,NVDA',
+                symbols="AAPL,MSFT,NVDA",
                 train_days=6,
                 holdout_days=2,
-                full_window_start_date='2026-03-25',
-                full_window_end_date='2026-04-02',
+                full_window_start_date="2026-03-25",
+                full_window_end_date="2026-04-02",
             )
             candidate_spec = runtime_closure._candidate_spec(
-                runner_run_id='run-1',
+                runner_run_id="run-1",
                 program=_program(),
                 best_candidate=best_candidate,
                 manifest=manifest,
             )
             self.assertEqual(
-                candidate_spec['runtime_strategy_names'],
+                candidate_spec["runtime_strategy_names"],
                 [
-                    'microbar-cross-sectional-pairs-v1-sleeve-1-long',
-                    'microbar-cross-sectional-pairs-v1-sleeve-1-short',
-                    'microbar-cross-sectional-pairs-v1-sleeve-2-long',
-                    'microbar-cross-sectional-pairs-v1-sleeve-2-short',
+                    "microbar-cross-sectional-pairs-v1-sleeve-1-long",
+                    "microbar-cross-sectional-pairs-v1-sleeve-1-short",
+                    "microbar-cross-sectional-pairs-v1-sleeve-2-long",
+                    "microbar-cross-sectional-pairs-v1-sleeve-2-short",
                 ],
             )
-            self.assertEqual(candidate_spec['portfolio_promotion_v2']['strategy_count'], 4)
-            self.assertEqual(candidate_spec['full_window_start_date'], '2026-03-25')
-            self.assertEqual(candidate_spec['full_window_end_date'], '2026-04-02')
+            self.assertEqual(
+                candidate_spec["portfolio_promotion_v2"]["strategy_count"], 4
+            )
+            self.assertEqual(candidate_spec["full_window_start_date"], "2026-03-25")
+            self.assertEqual(candidate_spec["full_window_end_date"], "2026-04-02")
             gate_report = runtime_closure._gate_report(
-                runner_run_id='run-1',
+                runner_run_id="run-1",
                 best_candidate=best_candidate,
-                promotion_target='shadow',
+                promotion_target="shadow",
                 parity_report=None,
                 approval_report=None,
-                shadow_plan={'required': False, 'status': 'skipped'},
+                shadow_plan={"required": False, "status": "skipped"},
             )
-            self.assertEqual(gate_report['vnext']['portfolio_promotion']['strategy_count'], 4)
+            self.assertEqual(
+                gate_report["vnext"]["portfolio_promotion"]["strategy_count"], 4
+            )
+
+    def test_materialize_candidate_configmap_supports_generic_portfolio_candidates(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            configmap_path = root / "valid.yaml"
+            configmap_path.write_text(
+                """
+apiVersion: v1
+kind: ConfigMap
+data:
+  strategies.yaml: |
+    strategies:
+      - name: breakout-continuation-long-v1
+        enabled: true
+        strategy_type: breakout_continuation_long_v1
+        params:
+          max_entries_per_session: '1'
+""".strip()
+                + "\n",
+                encoding="utf-8",
+            )
+            context = RuntimeClosureExecutionContext(
+                strategy_configmap_path=configmap_path,
+                clickhouse_http_url="http://example.invalid:8123",
+                clickhouse_username="torghut",
+                clickhouse_password="secret",
+                start_equity=Decimal("31590.02"),
+                chunk_minutes=10,
+                symbols=("AAPL", "NVDA"),
+            )
+            best_candidate = {
+                "candidate_id": "portfolio-1",
+                "family_template_id": "portfolio_whitepaper_autoresearch_v1",
+                "portfolio": {
+                    "base_per_leg_notional": "50000",
+                    "sleeves": [
+                        {
+                            "candidate_id": "cand-a",
+                            "candidate_spec_id": "spec-a",
+                            "runtime_family": "momentum_pullback_consistent",
+                            "runtime_strategy_name": "momentum-pullback-long-v1",
+                            "weight": "0.60",
+                            "expected_net_pnl_per_day": "320",
+                            "correlation_cluster": "momentum",
+                        },
+                        {
+                            "candidate_id": "cand-b",
+                            "candidate_spec_id": "spec-b",
+                            "runtime_family": "washout_rebound_consistent",
+                            "runtime_strategy_name": "washout-rebound-long-v1",
+                            "weight": "0.40",
+                            "expected_net_pnl_per_day": "230",
+                            "correlation_cluster": "rebound",
+                        },
+                    ],
+                },
+            }
+
+            rendered_path = runtime_closure._materialize_candidate_configmap(
+                best_candidate=best_candidate,
+                execution_context=context,
+                output_path=root / "generic-portfolio.yaml",
+            )
+            rendered = runtime_closure.yaml.safe_load(
+                rendered_path.read_text(encoding="utf-8")
+            )
+            catalog = runtime_closure.yaml.safe_load(
+                rendered["data"]["strategies.yaml"]
+            )
+            strategies = catalog["strategies"]
+            self.assertFalse(strategies[0]["enabled"])
+            self.assertEqual(
+                [item["name"] for item in strategies[1:]],
+                ["momentum-pullback-long-v1", "washout-rebound-long-v1"],
+            )
+            self.assertEqual(
+                strategies[1]["strategy_type"], "momentum_pullback_consistent"
+            )
+            self.assertEqual(strategies[1]["params"]["candidate_spec_id"], "spec-a")
+            self.assertEqual(strategies[1]["params"]["sleeve_weight"], "0.6")
+            self.assertEqual(strategies[2]["max_notional_per_trade"], "20000")
+            self.assertEqual(
+                runtime_closure._portfolio_runtime_strategy_names(best_candidate),
+                ("momentum-pullback-long-v1", "washout-rebound-long-v1"),
+            )
+            portfolio_contract = runtime_closure._portfolio_promotion_v2(best_candidate)
+            self.assertEqual(portfolio_contract["strategy_count"], 2)
+            self.assertEqual(portfolio_contract["spec_compiled_count"], 0)
 
     def test_replay_analysis_records_decomposition_errors(self) -> None:
         replay_payload = {
-            'start_date': '2026-03-20',
-            'end_date': '2026-04-09',
-            'net_pnl': '6000',
-            'decision_count': 12,
-            'filled_count': 9,
-            'wins': 7,
-            'losses': 2,
-            'daily': {
-                '2026-03-20': {'net_pnl': '1000', 'filled_count': 1, 'filled_notional': '300000'},
-                '2026-03-21': {'net_pnl': '800', 'filled_count': 1, 'filled_notional': '300000'},
-                '2026-03-24': {'net_pnl': '700', 'filled_count': 1, 'filled_notional': '300000'},
-                '2026-03-25': {'net_pnl': '900', 'filled_count': 1, 'filled_notional': '300000'},
-                '2026-03-26': {'net_pnl': '1100', 'filled_count': 1, 'filled_notional': '300000'},
-                '2026-03-27': {'net_pnl': '600', 'filled_count': 1, 'filled_notional': '300000'},
-                '2026-04-08': {'net_pnl': '500', 'filled_count': 1, 'filled_notional': '300000'},
-                '2026-04-09': {'net_pnl': '400', 'filled_count': 1, 'filled_notional': '300000'},
+            "start_date": "2026-03-20",
+            "end_date": "2026-04-09",
+            "net_pnl": "6000",
+            "decision_count": 12,
+            "filled_count": 9,
+            "wins": 7,
+            "losses": 2,
+            "daily": {
+                "2026-03-20": {
+                    "net_pnl": "1000",
+                    "filled_count": 1,
+                    "filled_notional": "300000",
+                },
+                "2026-03-21": {
+                    "net_pnl": "800",
+                    "filled_count": 1,
+                    "filled_notional": "300000",
+                },
+                "2026-03-24": {
+                    "net_pnl": "700",
+                    "filled_count": 1,
+                    "filled_notional": "300000",
+                },
+                "2026-03-25": {
+                    "net_pnl": "900",
+                    "filled_count": 1,
+                    "filled_notional": "300000",
+                },
+                "2026-03-26": {
+                    "net_pnl": "1100",
+                    "filled_count": 1,
+                    "filled_notional": "300000",
+                },
+                "2026-03-27": {
+                    "net_pnl": "600",
+                    "filled_count": 1,
+                    "filled_notional": "300000",
+                },
+                "2026-04-08": {
+                    "net_pnl": "500",
+                    "filled_count": 1,
+                    "filled_notional": "300000",
+                },
+                "2026-04-09": {
+                    "net_pnl": "400",
+                    "filled_count": 1,
+                    "filled_notional": "300000",
+                },
             },
         }
         best_candidate = {
-            'candidate_id': 'cand-1',
-            'family_template_id': 'breakout_reclaim_v2',
-            'runtime_family': 'breakout_continuation_consistent',
-            'runtime_strategy_name': 'breakout-continuation-long-v1',
-            'normalization_regime': 'price_scaled',
+            "candidate_id": "cand-1",
+            "family_template_id": "breakout_reclaim_v2",
+            "runtime_family": "breakout_continuation_consistent",
+            "runtime_strategy_name": "breakout-continuation-long-v1",
+            "normalization_regime": "price_scaled",
         }
 
-        with patch.object(runtime_closure, 'build_replay_decomposition', side_effect=RuntimeError('boom')):
+        with patch.object(
+            runtime_closure,
+            "build_replay_decomposition",
+            side_effect=RuntimeError("boom"),
+        ):
             analysis = runtime_closure._replay_analysis(
-                window_name='full_window',
+                window_name="full_window",
                 replay_payload=replay_payload,
                 best_candidate=best_candidate,
                 program=_program(),
             )
 
-        self.assertEqual(analysis['decomposition_error'], 'boom')
-        self.assertIsNone(analysis['decomposition'])
+        self.assertEqual(analysis["decomposition_error"], "boom")
+        self.assertIsNone(analysis["decomposition"])
 
-    def test_write_runtime_closure_bundle_emits_fail_closed_governance_artifacts(self) -> None:
+    def test_write_runtime_closure_bundle_emits_fail_closed_governance_artifacts(
+        self,
+    ) -> None:
         with TemporaryDirectory() as tmpdir:
             run_root = Path(tmpdir)
             manifest = build_mlx_snapshot_manifest(
-                runner_run_id='run-1',
+                runner_run_id="run-1",
                 program=_program(),
-                symbols='AMAT,NVDA',
+                symbols="AMAT,NVDA",
                 train_days=6,
                 holdout_days=2,
-                full_window_start_date='2026-03-20',
-                full_window_end_date='2026-04-09',
-                row_counts={'receipt_count': 1, 'signal_row_count': 42},
+                full_window_start_date="2026-03-20",
+                full_window_end_date="2026-04-09",
+                row_counts={"receipt_count": 1, "signal_row_count": 42},
             )
             best_candidate = {
-                'candidate_id': 'cand-1',
-                'family_template_id': 'breakout_reclaim_v2',
-                'runtime_family': 'breakout_continuation_consistent',
-                'runtime_strategy_name': 'breakout-continuation-long-v1',
-                'objective_scope': 'research_only',
-                'objective_met': True,
-                'status': 'keep',
-                'mutation_label': 'seed',
-                'descriptor_id': 'desc-1',
-                'entry_window_start_minute': 45,
-                'entry_window_end_minute': 75,
-                'max_hold_minutes': 30,
-                'rank_count': 1,
-                'requires_prev_day_features': True,
-                'requires_cross_sectional_features': True,
-                'requires_quote_quality_gate': True,
-                'net_pnl_per_day': '620',
-                'active_day_ratio': '0.85',
-                'positive_day_ratio': '0.60',
-                'best_day_share': '0.30',
-                'worst_day_loss': '300',
-                'max_drawdown': '850',
-                'proposal_score': 12.0,
-                'proposal_rank': 1,
-                'promotion_status': 'blocked_pending_runtime_parity',
-                'promotion_stage': 'research_candidate',
-                'promotion_reason': 'still blocked',
-                'promotion_blockers': [
-                    'scheduler_v3_parity_missing',
-                    'scheduler_v3_approval_missing',
-                    'shadow_validation_missing',
+                "candidate_id": "cand-1",
+                "family_template_id": "breakout_reclaim_v2",
+                "runtime_family": "breakout_continuation_consistent",
+                "runtime_strategy_name": "breakout-continuation-long-v1",
+                "objective_scope": "research_only",
+                "objective_met": True,
+                "status": "keep",
+                "mutation_label": "seed",
+                "descriptor_id": "desc-1",
+                "entry_window_start_minute": 45,
+                "entry_window_end_minute": 75,
+                "max_hold_minutes": 30,
+                "rank_count": 1,
+                "requires_prev_day_features": True,
+                "requires_cross_sectional_features": True,
+                "requires_quote_quality_gate": True,
+                "net_pnl_per_day": "620",
+                "active_day_ratio": "0.85",
+                "positive_day_ratio": "0.60",
+                "best_day_share": "0.30",
+                "worst_day_loss": "300",
+                "max_drawdown": "850",
+                "proposal_score": 12.0,
+                "proposal_rank": 1,
+                "promotion_status": "blocked_pending_runtime_parity",
+                "promotion_stage": "research_candidate",
+                "promotion_reason": "still blocked",
+                "promotion_blockers": [
+                    "scheduler_v3_parity_missing",
+                    "scheduler_v3_approval_missing",
+                    "shadow_validation_missing",
                 ],
-                'promotion_required_evidence': [
-                    'checked_in_runtime_family',
-                    'scheduler_v3_parity_replay',
-                    'scheduler_v3_approval_replay',
-                    'live_shadow_validation',
+                "promotion_required_evidence": [
+                    "checked_in_runtime_family",
+                    "scheduler_v3_parity_replay",
+                    "scheduler_v3_approval_replay",
+                    "live_shadow_validation",
                 ],
             }
 
             summary = write_runtime_closure_bundle(
                 run_root=run_root,
-                runner_run_id='run-1',
+                runner_run_id="run-1",
                 program=_program(),
                 best_candidate=best_candidate,
                 manifest=manifest,
             )
 
-            self.assertEqual(summary.status, 'pending_runtime_parity')
-            self.assertFalse(summary.promotion_prerequisites['allowed'])
-            self.assertFalse(summary.rollback_readiness['ready'])
-            self.assertIn('scheduler_v3_parity_replay', summary.next_required_steps)
+            self.assertEqual(summary.status, "pending_runtime_parity")
+            self.assertFalse(summary.promotion_prerequisites["allowed"])
+            self.assertFalse(summary.rollback_readiness["ready"])
+            self.assertIn("scheduler_v3_parity_replay", summary.next_required_steps)
             self.assertTrue(Path(summary.candidate_spec_path).exists())
             self.assertTrue(Path(summary.promotion_prerequisites_path).exists())
             self.assertTrue(Path(summary.profitability_stage_manifest_path).exists())
 
-            manifest_payload = json.loads(Path(summary.profitability_stage_manifest_path).read_text(encoding='utf-8'))
-            self.assertEqual(manifest_payload['candidate_id'], 'cand-1')
-            self.assertEqual(manifest_payload['overall_status'], 'fail')
-            self.assertIn('validation_stage_incomplete', manifest_payload['failure_reasons'])
-            self.assertEqual(manifest_payload['run_context']['run_id'], 'run-1')
+            manifest_payload = json.loads(
+                Path(summary.profitability_stage_manifest_path).read_text(
+                    encoding="utf-8"
+                )
+            )
+            self.assertEqual(manifest_payload["candidate_id"], "cand-1")
+            self.assertEqual(manifest_payload["overall_status"], "fail")
+            self.assertIn(
+                "validation_stage_incomplete", manifest_payload["failure_reasons"]
+            )
+            self.assertEqual(manifest_payload["run_context"]["run_id"], "run-1")
             self.assertEqual(
-                manifest_payload['run_context']['head'],
+                manifest_payload["run_context"]["head"],
                 subprocess.run(
-                    ['git', 'rev-parse', '--abbrev-ref', 'HEAD'],
+                    ["git", "rev-parse", "--abbrev-ref", "HEAD"],
                     cwd=_REPO_ROOT,
                     check=True,
                     capture_output=True,
@@ -540,20 +721,22 @@ data:
                 ).stdout.strip(),
             )
 
-    def test_write_runtime_closure_bundle_executes_runtime_replays_when_enabled(self) -> None:
+    def test_write_runtime_closure_bundle_executes_runtime_replays_when_enabled(
+        self,
+    ) -> None:
         with TemporaryDirectory() as tmpdir:
             run_root = Path(tmpdir)
             manifest = build_mlx_snapshot_manifest(
-                runner_run_id='run-1',
+                runner_run_id="run-1",
                 program=_program(),
-                symbols='AMAT,NVDA',
+                symbols="AMAT,NVDA",
                 train_days=6,
                 holdout_days=2,
-                full_window_start_date='2026-03-20',
-                full_window_end_date='2026-04-09',
-                row_counts={'receipt_count': 1, 'signal_row_count': 42},
+                full_window_start_date="2026-03-20",
+                full_window_end_date="2026-04-09",
+                row_counts={"receipt_count": 1, "signal_row_count": 42},
             )
-            configmap_path = run_root / 'strategy-configmap.yaml'
+            configmap_path = run_root / "strategy-configmap.yaml"
             configmap_path.write_text(
                 """
 apiVersion: v1
@@ -571,103 +754,135 @@ data:
           - NVDA
 """.strip()
                 + "\n",
-                encoding='utf-8',
+                encoding="utf-8",
             )
             program = _program()
             program = StrategyAutoresearchProgram(
                 **{
                     **program.__dict__,
-                    'objective': StrategyObjective(
-                        target_net_pnl_per_day=Decimal('500'),
-                        min_active_day_ratio=Decimal('1.0'),
-                        min_positive_day_ratio=Decimal('0.6'),
-                        min_daily_notional=Decimal('300000'),
-                        max_best_day_share=Decimal('0.3'),
-                        max_worst_day_loss=Decimal('350'),
-                        max_drawdown=Decimal('900'),
+                    "objective": StrategyObjective(
+                        target_net_pnl_per_day=Decimal("500"),
+                        min_active_day_ratio=Decimal("1.0"),
+                        min_positive_day_ratio=Decimal("0.6"),
+                        min_daily_notional=Decimal("300000"),
+                        max_best_day_share=Decimal("0.3"),
+                        max_worst_day_loss=Decimal("350"),
+                        max_drawdown=Decimal("900"),
                         require_every_day_active=True,
-                        min_regime_slice_pass_rate=Decimal('0'),
+                        min_regime_slice_pass_rate=Decimal("0"),
                         stop_when_objective_met=True,
                     ),
-                    'runtime_closure_policy': RuntimeClosurePolicy(
+                    "runtime_closure_policy": RuntimeClosurePolicy(
                         enabled=True,
                         execute_parity_replay=True,
                         execute_approval_replay=True,
-                        parity_window='full_window',
-                        approval_window='holdout',
-                        shadow_validation_mode='require_live_evidence',
-                        promotion_target='shadow',
+                        parity_window="full_window",
+                        approval_window="holdout",
+                        shadow_validation_mode="require_live_evidence",
+                        promotion_target="shadow",
                     ),
                 }
             )
             best_candidate = {
-                'candidate_id': 'cand-1',
-                'family_template_id': 'breakout_reclaim_v2',
-                'runtime_family': 'breakout_continuation_consistent',
-                'runtime_strategy_name': 'breakout-continuation-long-v1',
-                'objective_scope': 'research_only',
-                'objective_met': True,
-                'status': 'keep',
-                'mutation_label': 'seed',
-                'descriptor_id': 'desc-1',
-                'entry_window_start_minute': 45,
-                'entry_window_end_minute': 75,
-                'max_hold_minutes': 30,
-                'rank_count': 1,
-                'requires_prev_day_features': True,
-                'requires_cross_sectional_features': True,
-                'requires_quote_quality_gate': True,
-                'net_pnl_per_day': '620',
-                'active_day_ratio': '0.85',
-                'positive_day_ratio': '0.60',
-                'best_day_share': '0.30',
-                'worst_day_loss': '300',
-                'max_drawdown': '850',
-                'proposal_score': 12.0,
-                'proposal_rank': 1,
-                'promotion_status': 'blocked_pending_runtime_parity',
-                'promotion_stage': 'research_candidate',
-                'promotion_reason': 'still blocked',
-                'promotion_blockers': [
-                    'scheduler_v3_parity_missing',
-                    'scheduler_v3_approval_missing',
-                    'shadow_validation_missing',
+                "candidate_id": "cand-1",
+                "family_template_id": "breakout_reclaim_v2",
+                "runtime_family": "breakout_continuation_consistent",
+                "runtime_strategy_name": "breakout-continuation-long-v1",
+                "objective_scope": "research_only",
+                "objective_met": True,
+                "status": "keep",
+                "mutation_label": "seed",
+                "descriptor_id": "desc-1",
+                "entry_window_start_minute": 45,
+                "entry_window_end_minute": 75,
+                "max_hold_minutes": 30,
+                "rank_count": 1,
+                "requires_prev_day_features": True,
+                "requires_cross_sectional_features": True,
+                "requires_quote_quality_gate": True,
+                "net_pnl_per_day": "620",
+                "active_day_ratio": "0.85",
+                "positive_day_ratio": "0.60",
+                "best_day_share": "0.30",
+                "worst_day_loss": "300",
+                "max_drawdown": "850",
+                "proposal_score": 12.0,
+                "proposal_rank": 1,
+                "promotion_status": "blocked_pending_runtime_parity",
+                "promotion_stage": "research_candidate",
+                "promotion_reason": "still blocked",
+                "promotion_blockers": [
+                    "scheduler_v3_parity_missing",
+                    "scheduler_v3_approval_missing",
+                    "shadow_validation_missing",
                 ],
-                'promotion_required_evidence': [
-                    'checked_in_runtime_family',
-                    'scheduler_v3_parity_replay',
-                    'scheduler_v3_approval_replay',
-                    'live_shadow_validation',
+                "promotion_required_evidence": [
+                    "checked_in_runtime_family",
+                    "scheduler_v3_parity_replay",
+                    "scheduler_v3_approval_replay",
+                    "live_shadow_validation",
                 ],
-                'candidate_params': {'max_entries_per_session': '1'},
-                'candidate_strategy_overrides': {'universe_symbols': ['AMAT', 'NVDA']},
-                'disable_other_strategies': True,
-                'train_start_date': '2026-03-20',
-                'train_end_date': '2026-03-27',
-                'holdout_start_date': '2026-04-08',
-                'holdout_end_date': '2026-04-09',
-                'full_window_start_date': '2026-03-20',
-                'full_window_end_date': '2026-04-09',
-                'normalization_regime': 'price_scaled',
+                "candidate_params": {"max_entries_per_session": "1"},
+                "candidate_strategy_overrides": {"universe_symbols": ["AMAT", "NVDA"]},
+                "disable_other_strategies": True,
+                "train_start_date": "2026-03-20",
+                "train_end_date": "2026-03-27",
+                "holdout_start_date": "2026-04-08",
+                "holdout_end_date": "2026-04-09",
+                "full_window_start_date": "2026-03-20",
+                "full_window_end_date": "2026-04-09",
+                "normalization_regime": "price_scaled",
             }
 
             replay_payload = {
-                'start_date': '2026-03-20',
-                'end_date': '2026-04-09',
-                'net_pnl': '6000',
-                'decision_count': 12,
-                'filled_count': 9,
-                'wins': 7,
-                'losses': 2,
-                'daily': {
-                    '2026-03-20': {'net_pnl': '1000', 'filled_count': 1, 'filled_notional': '300000'},
-                    '2026-03-21': {'net_pnl': '800', 'filled_count': 1, 'filled_notional': '300000'},
-                    '2026-03-24': {'net_pnl': '700', 'filled_count': 1, 'filled_notional': '300000'},
-                    '2026-03-25': {'net_pnl': '900', 'filled_count': 1, 'filled_notional': '300000'},
-                    '2026-03-26': {'net_pnl': '1100', 'filled_count': 1, 'filled_notional': '300000'},
-                    '2026-03-27': {'net_pnl': '600', 'filled_count': 1, 'filled_notional': '300000'},
-                    '2026-04-08': {'net_pnl': '500', 'filled_count': 1, 'filled_notional': '300000'},
-                    '2026-04-09': {'net_pnl': '400', 'filled_count': 1, 'filled_notional': '300000'},
+                "start_date": "2026-03-20",
+                "end_date": "2026-04-09",
+                "net_pnl": "6000",
+                "decision_count": 12,
+                "filled_count": 9,
+                "wins": 7,
+                "losses": 2,
+                "daily": {
+                    "2026-03-20": {
+                        "net_pnl": "1000",
+                        "filled_count": 1,
+                        "filled_notional": "300000",
+                    },
+                    "2026-03-21": {
+                        "net_pnl": "800",
+                        "filled_count": 1,
+                        "filled_notional": "300000",
+                    },
+                    "2026-03-24": {
+                        "net_pnl": "700",
+                        "filled_count": 1,
+                        "filled_notional": "300000",
+                    },
+                    "2026-03-25": {
+                        "net_pnl": "900",
+                        "filled_count": 1,
+                        "filled_notional": "300000",
+                    },
+                    "2026-03-26": {
+                        "net_pnl": "1100",
+                        "filled_count": 1,
+                        "filled_notional": "300000",
+                    },
+                    "2026-03-27": {
+                        "net_pnl": "600",
+                        "filled_count": 1,
+                        "filled_notional": "300000",
+                    },
+                    "2026-04-08": {
+                        "net_pnl": "500",
+                        "filled_count": 1,
+                        "filled_notional": "300000",
+                    },
+                    "2026-04-09": {
+                        "net_pnl": "400",
+                        "filled_count": 1,
+                        "filled_notional": "300000",
+                    },
                 },
             }
 
@@ -676,47 +891,51 @@ data:
 
             summary = write_runtime_closure_bundle(
                 run_root=run_root,
-                runner_run_id='run-1',
+                runner_run_id="run-1",
                 program=program,
                 best_candidate=best_candidate,
                 manifest=manifest,
                 execution_context=RuntimeClosureExecutionContext(
                     strategy_configmap_path=configmap_path,
-                    clickhouse_http_url='http://example.invalid:8123',
-                    clickhouse_username='torghut',
-                    clickhouse_password='secret',
-                    start_equity=Decimal('31590.02'),
+                    clickhouse_http_url="http://example.invalid:8123",
+                    clickhouse_username="torghut",
+                    clickhouse_password="secret",
+                    start_equity=Decimal("31590.02"),
                     chunk_minutes=10,
-                    symbols=('AMAT', 'NVDA'),
+                    symbols=("AMAT", "NVDA"),
                     progress_log_interval_seconds=30,
                 ),
                 replay_executor=_fake_replay_executor,
             )
 
-            self.assertEqual(summary.status, 'pending_shadow_validation')
+            self.assertEqual(summary.status, "pending_shadow_validation")
             self.assertTrue(Path(summary.candidate_configmap_path).exists())
             self.assertTrue(Path(summary.parity_replay_path).exists())
             self.assertTrue(Path(summary.approval_replay_path).exists())
             self.assertTrue(Path(summary.shadow_validation_path).exists())
-            self.assertIn('live_shadow_validation', summary.next_required_steps)
+            self.assertIn("live_shadow_validation", summary.next_required_steps)
 
-            parity_report = json.loads(Path(summary.parity_report_path).read_text(encoding='utf-8'))
-            self.assertTrue(parity_report['objective_met'])
-            self.assertEqual(parity_report['window_name'], 'full_window')
+            parity_report = json.loads(
+                Path(summary.parity_report_path).read_text(encoding="utf-8")
+            )
+            self.assertTrue(parity_report["objective_met"])
+            self.assertEqual(parity_report["window_name"], "full_window")
 
-    def test_write_runtime_closure_bundle_keeps_pending_parity_when_execution_skipped(self) -> None:
+    def test_write_runtime_closure_bundle_keeps_pending_parity_when_execution_skipped(
+        self,
+    ) -> None:
         with TemporaryDirectory() as tmpdir:
             run_root = Path(tmpdir)
             manifest = build_mlx_snapshot_manifest(
-                runner_run_id='run-1',
+                runner_run_id="run-1",
                 program=_program(),
-                symbols='AMAT,NVDA',
+                symbols="AMAT,NVDA",
                 train_days=6,
                 holdout_days=2,
-                full_window_start_date='2026-03-20',
-                full_window_end_date='2026-04-09',
+                full_window_start_date="2026-03-20",
+                full_window_end_date="2026-04-09",
             )
-            configmap_path = run_root / 'strategy-configmap.yaml'
+            configmap_path = run_root / "strategy-configmap.yaml"
             configmap_path.write_text(
                 """
 apiVersion: v1
@@ -731,71 +950,81 @@ data:
           max_entries_per_session: '1'
 """.strip()
                 + "\n",
-                encoding='utf-8',
+                encoding="utf-8",
             )
             program = StrategyAutoresearchProgram(
                 **{
                     **_program().__dict__,
-                    'runtime_closure_policy': RuntimeClosurePolicy(
+                    "runtime_closure_policy": RuntimeClosurePolicy(
                         enabled=True,
                         execute_parity_replay=False,
                         execute_approval_replay=False,
-                        parity_window='full_window',
-                        approval_window='holdout',
-                        shadow_validation_mode='skip',
-                        promotion_target='shadow',
+                        parity_window="full_window",
+                        approval_window="holdout",
+                        shadow_validation_mode="skip",
+                        promotion_target="shadow",
                     ),
                 }
             )
             best_candidate = {
-                'candidate_id': 'cand-1',
-                'family_template_id': 'breakout_reclaim_v2',
-                'runtime_family': 'breakout_continuation_consistent',
-                'runtime_strategy_name': 'breakout-continuation-long-v1',
-                'status': 'keep',
-                'candidate_params': {'max_entries_per_session': '1'},
-                'candidate_strategy_overrides': {},
-                'disable_other_strategies': True,
-                'full_window_start_date': '2026-03-20',
-                'full_window_end_date': '2026-04-09',
+                "candidate_id": "cand-1",
+                "family_template_id": "breakout_reclaim_v2",
+                "runtime_family": "breakout_continuation_consistent",
+                "runtime_strategy_name": "breakout-continuation-long-v1",
+                "status": "keep",
+                "candidate_params": {"max_entries_per_session": "1"},
+                "candidate_strategy_overrides": {},
+                "disable_other_strategies": True,
+                "full_window_start_date": "2026-03-20",
+                "full_window_end_date": "2026-04-09",
             }
 
             summary = write_runtime_closure_bundle(
                 run_root=run_root,
-                runner_run_id='run-1',
+                runner_run_id="run-1",
                 program=program,
                 best_candidate=best_candidate,
                 manifest=manifest,
                 execution_context=RuntimeClosureExecutionContext(
                     strategy_configmap_path=configmap_path,
-                    clickhouse_http_url='http://example.invalid:8123',
-                    clickhouse_username='torghut',
-                    clickhouse_password='secret',
-                    start_equity=Decimal('31590.02'),
+                    clickhouse_http_url="http://example.invalid:8123",
+                    clickhouse_username="torghut",
+                    clickhouse_password="secret",
+                    start_equity=Decimal("31590.02"),
                     chunk_minutes=10,
                 ),
             )
 
-            self.assertEqual(summary.status, 'pending_runtime_parity')
+            self.assertEqual(summary.status, "pending_runtime_parity")
             self.assertEqual(
                 summary.next_required_steps,
-                ('scheduler_v3_parity_replay', 'scheduler_v3_approval_replay'),
+                ("scheduler_v3_parity_replay", "scheduler_v3_approval_replay"),
             )
-            self.assertEqual(summary.shadow_validation_path, str(run_root / 'runtime-closure' / 'replay' / 'shadow-validation-plan.json'))
+            self.assertEqual(
+                summary.shadow_validation_path,
+                str(
+                    run_root
+                    / "runtime-closure"
+                    / "replay"
+                    / "shadow-validation-plan.json"
+                ),
+            )
 
-    def test_write_runtime_closure_bundle_skips_shadow_status_when_shadow_not_required(self) -> None:
+    def test_write_runtime_closure_bundle_skips_shadow_status_when_shadow_not_required(
+        self,
+    ) -> None:
         with TemporaryDirectory() as tmpdir:
             run_root = Path(tmpdir)
             manifest = build_mlx_snapshot_manifest(
-                runner_run_id='run-1',
+                runner_run_id="run-1",
                 program=_program(),
-                symbols='AMAT,NVDA',
+                symbols="AMAT,NVDA",
                 train_days=6,
                 holdout_days=2,
-                full_window_start_date='2026-03-20',
-                full_window_end_date='2026-04-09',
+                full_window_start_date="2026-03-20",
+                full_window_end_date="2026-04-09",
             )
-            configmap_path = run_root / 'strategy-configmap.yaml'
+            configmap_path = run_root / "strategy-configmap.yaml"
             configmap_path.write_text(
                 """
 apiVersion: v1
@@ -813,66 +1042,98 @@ data:
           - NVDA
 """.strip()
                 + "\n",
-                encoding='utf-8',
+                encoding="utf-8",
             )
             program = StrategyAutoresearchProgram(
                 **{
                     **_program().__dict__,
-                    'objective': StrategyObjective(
-                        target_net_pnl_per_day=Decimal('500'),
-                        min_active_day_ratio=Decimal('1.0'),
-                        min_positive_day_ratio=Decimal('0.6'),
-                        min_daily_notional=Decimal('300000'),
-                        max_best_day_share=Decimal('0.3'),
-                        max_worst_day_loss=Decimal('350'),
-                        max_drawdown=Decimal('900'),
+                    "objective": StrategyObjective(
+                        target_net_pnl_per_day=Decimal("500"),
+                        min_active_day_ratio=Decimal("1.0"),
+                        min_positive_day_ratio=Decimal("0.6"),
+                        min_daily_notional=Decimal("300000"),
+                        max_best_day_share=Decimal("0.3"),
+                        max_worst_day_loss=Decimal("350"),
+                        max_drawdown=Decimal("900"),
                         require_every_day_active=True,
-                        min_regime_slice_pass_rate=Decimal('0'),
+                        min_regime_slice_pass_rate=Decimal("0"),
                         stop_when_objective_met=True,
                     ),
-                    'runtime_closure_policy': RuntimeClosurePolicy(
+                    "runtime_closure_policy": RuntimeClosurePolicy(
                         enabled=True,
                         execute_parity_replay=True,
                         execute_approval_replay=True,
-                        parity_window='full_window',
-                        approval_window='holdout',
-                        shadow_validation_mode='skip',
-                        promotion_target='shadow',
+                        parity_window="full_window",
+                        approval_window="holdout",
+                        shadow_validation_mode="skip",
+                        promotion_target="shadow",
                     ),
                 }
             )
             best_candidate = {
-                'candidate_id': 'cand-1',
-                'family_template_id': 'breakout_reclaim_v2',
-                'runtime_family': 'breakout_continuation_consistent',
-                'runtime_strategy_name': 'breakout-continuation-long-v1',
-                'status': 'keep',
-                'candidate_params': {'max_entries_per_session': '1'},
-                'candidate_strategy_overrides': {'universe_symbols': ['AMAT', 'NVDA']},
-                'disable_other_strategies': True,
-                'holdout_start_date': '2026-04-08',
-                'holdout_end_date': '2026-04-09',
-                'full_window_start_date': '2026-03-20',
-                'full_window_end_date': '2026-04-09',
-                'normalization_regime': 'price_scaled',
+                "candidate_id": "cand-1",
+                "family_template_id": "breakout_reclaim_v2",
+                "runtime_family": "breakout_continuation_consistent",
+                "runtime_strategy_name": "breakout-continuation-long-v1",
+                "status": "keep",
+                "candidate_params": {"max_entries_per_session": "1"},
+                "candidate_strategy_overrides": {"universe_symbols": ["AMAT", "NVDA"]},
+                "disable_other_strategies": True,
+                "holdout_start_date": "2026-04-08",
+                "holdout_end_date": "2026-04-09",
+                "full_window_start_date": "2026-03-20",
+                "full_window_end_date": "2026-04-09",
+                "normalization_regime": "price_scaled",
             }
             replay_payload = {
-                'start_date': '2026-03-20',
-                'end_date': '2026-04-09',
-                'net_pnl': '6000',
-                'decision_count': 12,
-                'filled_count': 9,
-                'wins': 7,
-                'losses': 2,
-                'daily': {
-                    '2026-03-20': {'net_pnl': '1000', 'filled_count': 1, 'filled_notional': '300000'},
-                    '2026-03-21': {'net_pnl': '800', 'filled_count': 1, 'filled_notional': '300000'},
-                    '2026-03-24': {'net_pnl': '700', 'filled_count': 1, 'filled_notional': '300000'},
-                    '2026-03-25': {'net_pnl': '900', 'filled_count': 1, 'filled_notional': '300000'},
-                    '2026-03-26': {'net_pnl': '1100', 'filled_count': 1, 'filled_notional': '300000'},
-                    '2026-03-27': {'net_pnl': '600', 'filled_count': 1, 'filled_notional': '300000'},
-                    '2026-04-08': {'net_pnl': '500', 'filled_count': 1, 'filled_notional': '300000'},
-                    '2026-04-09': {'net_pnl': '400', 'filled_count': 1, 'filled_notional': '300000'},
+                "start_date": "2026-03-20",
+                "end_date": "2026-04-09",
+                "net_pnl": "6000",
+                "decision_count": 12,
+                "filled_count": 9,
+                "wins": 7,
+                "losses": 2,
+                "daily": {
+                    "2026-03-20": {
+                        "net_pnl": "1000",
+                        "filled_count": 1,
+                        "filled_notional": "300000",
+                    },
+                    "2026-03-21": {
+                        "net_pnl": "800",
+                        "filled_count": 1,
+                        "filled_notional": "300000",
+                    },
+                    "2026-03-24": {
+                        "net_pnl": "700",
+                        "filled_count": 1,
+                        "filled_notional": "300000",
+                    },
+                    "2026-03-25": {
+                        "net_pnl": "900",
+                        "filled_count": 1,
+                        "filled_notional": "300000",
+                    },
+                    "2026-03-26": {
+                        "net_pnl": "1100",
+                        "filled_count": 1,
+                        "filled_notional": "300000",
+                    },
+                    "2026-03-27": {
+                        "net_pnl": "600",
+                        "filled_count": 1,
+                        "filled_notional": "300000",
+                    },
+                    "2026-04-08": {
+                        "net_pnl": "500",
+                        "filled_count": 1,
+                        "filled_notional": "300000",
+                    },
+                    "2026-04-09": {
+                        "net_pnl": "400",
+                        "filled_count": 1,
+                        "filled_notional": "300000",
+                    },
                 },
             }
 
@@ -881,39 +1142,41 @@ data:
 
             summary = write_runtime_closure_bundle(
                 run_root=run_root,
-                runner_run_id='run-1',
+                runner_run_id="run-1",
                 program=program,
                 best_candidate=best_candidate,
                 manifest=manifest,
                 execution_context=RuntimeClosureExecutionContext(
                     strategy_configmap_path=configmap_path,
-                    clickhouse_http_url='http://example.invalid:8123',
-                    clickhouse_username='torghut',
-                    clickhouse_password='secret',
-                    start_equity=Decimal('31590.02'),
+                    clickhouse_http_url="http://example.invalid:8123",
+                    clickhouse_username="torghut",
+                    clickhouse_password="secret",
+                    start_equity=Decimal("31590.02"),
                     chunk_minutes=10,
-                    symbols=('AMAT', 'NVDA'),
+                    symbols=("AMAT", "NVDA"),
                     progress_log_interval_seconds=30,
                 ),
                 replay_executor=_fake_replay_executor,
             )
 
-            self.assertEqual(summary.status, 'ready_for_promotion_review')
-            self.assertEqual(summary.next_required_steps, ('promotion_review',))
+            self.assertEqual(summary.status, "ready_for_promotion_review")
+            self.assertEqual(summary.next_required_steps, ("promotion_review",))
 
-    def test_write_runtime_closure_bundle_consumes_within_budget_shadow_artifact(self) -> None:
+    def test_write_runtime_closure_bundle_consumes_within_budget_shadow_artifact(
+        self,
+    ) -> None:
         with TemporaryDirectory() as tmpdir:
             run_root = Path(tmpdir)
             manifest = build_mlx_snapshot_manifest(
-                runner_run_id='run-1',
+                runner_run_id="run-1",
                 program=_program(),
-                symbols='AMAT,NVDA',
+                symbols="AMAT,NVDA",
                 train_days=6,
                 holdout_days=2,
-                full_window_start_date='2026-03-20',
-                full_window_end_date='2026-04-09',
+                full_window_start_date="2026-03-20",
+                full_window_end_date="2026-04-09",
             )
-            configmap_path = run_root / 'strategy-configmap.yaml'
+            configmap_path = run_root / "strategy-configmap.yaml"
             configmap_path.write_text(
                 """
 apiVersion: v1
@@ -931,79 +1194,111 @@ data:
           - NVDA
 """.strip()
                 + "\n",
-                encoding='utf-8',
+                encoding="utf-8",
             )
-            shadow_artifact_path = run_root / 'shadow-live-deviation-report.json'
+            shadow_artifact_path = run_root / "shadow-live-deviation-report.json"
             shadow_artifact_path.write_text(
                 json.dumps(
                     {
-                        'schema_version': 'shadow-live-deviation-report-v1',
-                        'status': 'within_budget',
-                        'order_count': 12,
-                        'coverage_error': '0.02',
+                        "schema_version": "shadow-live-deviation-report-v1",
+                        "status": "within_budget",
+                        "order_count": 12,
+                        "coverage_error": "0.02",
                     }
                 )
                 + "\n",
-                encoding='utf-8',
+                encoding="utf-8",
             )
             program = StrategyAutoresearchProgram(
                 **{
                     **_program().__dict__,
-                    'objective': StrategyObjective(
-                        target_net_pnl_per_day=Decimal('500'),
-                        min_active_day_ratio=Decimal('1.0'),
-                        min_positive_day_ratio=Decimal('0.6'),
-                        min_daily_notional=Decimal('300000'),
-                        max_best_day_share=Decimal('0.3'),
-                        max_worst_day_loss=Decimal('350'),
-                        max_drawdown=Decimal('900'),
+                    "objective": StrategyObjective(
+                        target_net_pnl_per_day=Decimal("500"),
+                        min_active_day_ratio=Decimal("1.0"),
+                        min_positive_day_ratio=Decimal("0.6"),
+                        min_daily_notional=Decimal("300000"),
+                        max_best_day_share=Decimal("0.3"),
+                        max_worst_day_loss=Decimal("350"),
+                        max_drawdown=Decimal("900"),
                         require_every_day_active=True,
-                        min_regime_slice_pass_rate=Decimal('0'),
+                        min_regime_slice_pass_rate=Decimal("0"),
                         stop_when_objective_met=True,
                     ),
-                    'runtime_closure_policy': RuntimeClosurePolicy(
+                    "runtime_closure_policy": RuntimeClosurePolicy(
                         enabled=True,
                         execute_parity_replay=True,
                         execute_approval_replay=True,
-                        parity_window='full_window',
-                        approval_window='holdout',
-                        shadow_validation_mode='require_live_evidence',
-                        promotion_target='shadow',
+                        parity_window="full_window",
+                        approval_window="holdout",
+                        shadow_validation_mode="require_live_evidence",
+                        promotion_target="shadow",
                     ),
                 }
             )
             best_candidate = {
-                'candidate_id': 'cand-1',
-                'family_template_id': 'breakout_reclaim_v2',
-                'runtime_family': 'breakout_continuation_consistent',
-                'runtime_strategy_name': 'breakout-continuation-long-v1',
-                'status': 'keep',
-                'candidate_params': {'max_entries_per_session': '1'},
-                'candidate_strategy_overrides': {'universe_symbols': ['AMAT', 'NVDA']},
-                'disable_other_strategies': True,
-                'holdout_start_date': '2026-04-08',
-                'holdout_end_date': '2026-04-09',
-                'full_window_start_date': '2026-03-20',
-                'full_window_end_date': '2026-04-09',
-                'normalization_regime': 'price_scaled',
+                "candidate_id": "cand-1",
+                "family_template_id": "breakout_reclaim_v2",
+                "runtime_family": "breakout_continuation_consistent",
+                "runtime_strategy_name": "breakout-continuation-long-v1",
+                "status": "keep",
+                "candidate_params": {"max_entries_per_session": "1"},
+                "candidate_strategy_overrides": {"universe_symbols": ["AMAT", "NVDA"]},
+                "disable_other_strategies": True,
+                "holdout_start_date": "2026-04-08",
+                "holdout_end_date": "2026-04-09",
+                "full_window_start_date": "2026-03-20",
+                "full_window_end_date": "2026-04-09",
+                "normalization_regime": "price_scaled",
             }
             replay_payload = {
-                'start_date': '2026-03-20',
-                'end_date': '2026-04-09',
-                'net_pnl': '6000',
-                'decision_count': 12,
-                'filled_count': 9,
-                'wins': 7,
-                'losses': 2,
-                'daily': {
-                    '2026-03-20': {'net_pnl': '1000', 'filled_count': 1, 'filled_notional': '300000'},
-                    '2026-03-21': {'net_pnl': '800', 'filled_count': 1, 'filled_notional': '300000'},
-                    '2026-03-24': {'net_pnl': '700', 'filled_count': 1, 'filled_notional': '300000'},
-                    '2026-03-25': {'net_pnl': '900', 'filled_count': 1, 'filled_notional': '300000'},
-                    '2026-03-26': {'net_pnl': '1100', 'filled_count': 1, 'filled_notional': '300000'},
-                    '2026-03-27': {'net_pnl': '600', 'filled_count': 1, 'filled_notional': '300000'},
-                    '2026-04-08': {'net_pnl': '500', 'filled_count': 1, 'filled_notional': '300000'},
-                    '2026-04-09': {'net_pnl': '400', 'filled_count': 1, 'filled_notional': '300000'},
+                "start_date": "2026-03-20",
+                "end_date": "2026-04-09",
+                "net_pnl": "6000",
+                "decision_count": 12,
+                "filled_count": 9,
+                "wins": 7,
+                "losses": 2,
+                "daily": {
+                    "2026-03-20": {
+                        "net_pnl": "1000",
+                        "filled_count": 1,
+                        "filled_notional": "300000",
+                    },
+                    "2026-03-21": {
+                        "net_pnl": "800",
+                        "filled_count": 1,
+                        "filled_notional": "300000",
+                    },
+                    "2026-03-24": {
+                        "net_pnl": "700",
+                        "filled_count": 1,
+                        "filled_notional": "300000",
+                    },
+                    "2026-03-25": {
+                        "net_pnl": "900",
+                        "filled_count": 1,
+                        "filled_notional": "300000",
+                    },
+                    "2026-03-26": {
+                        "net_pnl": "1100",
+                        "filled_count": 1,
+                        "filled_notional": "300000",
+                    },
+                    "2026-03-27": {
+                        "net_pnl": "600",
+                        "filled_count": 1,
+                        "filled_notional": "300000",
+                    },
+                    "2026-04-08": {
+                        "net_pnl": "500",
+                        "filled_count": 1,
+                        "filled_notional": "300000",
+                    },
+                    "2026-04-09": {
+                        "net_pnl": "400",
+                        "filled_count": 1,
+                        "filled_notional": "300000",
+                    },
                 },
             }
 
@@ -1012,43 +1307,49 @@ data:
 
             summary = write_runtime_closure_bundle(
                 run_root=run_root,
-                runner_run_id='run-1',
+                runner_run_id="run-1",
                 program=program,
                 best_candidate=best_candidate,
                 manifest=manifest,
                 execution_context=RuntimeClosureExecutionContext(
                     strategy_configmap_path=configmap_path,
-                    clickhouse_http_url='http://example.invalid:8123',
-                    clickhouse_username='torghut',
-                    clickhouse_password='secret',
-                    start_equity=Decimal('31590.02'),
+                    clickhouse_http_url="http://example.invalid:8123",
+                    clickhouse_username="torghut",
+                    clickhouse_password="secret",
+                    start_equity=Decimal("31590.02"),
                     chunk_minutes=10,
-                    symbols=('AMAT', 'NVDA'),
+                    symbols=("AMAT", "NVDA"),
                     progress_log_interval_seconds=30,
                     shadow_validation_artifact_path=shadow_artifact_path,
                 ),
                 replay_executor=_fake_replay_executor,
             )
 
-            self.assertEqual(summary.status, 'ready_for_promotion_review')
-            shadow_payload = json.loads(Path(summary.shadow_validation_path).read_text(encoding='utf-8'))
-            self.assertEqual(shadow_payload['status'], 'within_budget')
-            self.assertTrue(shadow_payload['evidence_loaded'])
-            self.assertEqual(shadow_payload['source_artifact_path'], str(shadow_artifact_path))
+            self.assertEqual(summary.status, "ready_for_promotion_review")
+            shadow_payload = json.loads(
+                Path(summary.shadow_validation_path).read_text(encoding="utf-8")
+            )
+            self.assertEqual(shadow_payload["status"], "within_budget")
+            self.assertTrue(shadow_payload["evidence_loaded"])
+            self.assertEqual(
+                shadow_payload["source_artifact_path"], str(shadow_artifact_path)
+            )
 
-    def test_write_runtime_closure_bundle_fails_when_shadow_artifact_is_out_of_budget(self) -> None:
+    def test_write_runtime_closure_bundle_fails_when_shadow_artifact_is_out_of_budget(
+        self,
+    ) -> None:
         with TemporaryDirectory() as tmpdir:
             run_root = Path(tmpdir)
             manifest = build_mlx_snapshot_manifest(
-                runner_run_id='run-1',
+                runner_run_id="run-1",
                 program=_program(),
-                symbols='AMAT,NVDA',
+                symbols="AMAT,NVDA",
                 train_days=6,
                 holdout_days=2,
-                full_window_start_date='2026-03-20',
-                full_window_end_date='2026-04-09',
+                full_window_start_date="2026-03-20",
+                full_window_end_date="2026-04-09",
             )
-            configmap_path = run_root / 'strategy-configmap.yaml'
+            configmap_path = run_root / "strategy-configmap.yaml"
             configmap_path.write_text(
                 """
 apiVersion: v1
@@ -1063,79 +1364,111 @@ data:
           max_entries_per_session: '1'
 """.strip()
                 + "\n",
-                encoding='utf-8',
+                encoding="utf-8",
             )
-            shadow_artifact_path = run_root / 'shadow-live-deviation-report.json'
+            shadow_artifact_path = run_root / "shadow-live-deviation-report.json"
             shadow_artifact_path.write_text(
                 json.dumps(
                     {
-                        'schema_version': 'shadow-live-deviation-report-v1',
-                        'status': 'out_of_budget',
-                        'order_count': 12,
-                        'coverage_error': '0.09',
+                        "schema_version": "shadow-live-deviation-report-v1",
+                        "status": "out_of_budget",
+                        "order_count": 12,
+                        "coverage_error": "0.09",
                     }
                 )
                 + "\n",
-                encoding='utf-8',
+                encoding="utf-8",
             )
             program = StrategyAutoresearchProgram(
                 **{
                     **_program().__dict__,
-                    'objective': StrategyObjective(
-                        target_net_pnl_per_day=Decimal('500'),
-                        min_active_day_ratio=Decimal('1.0'),
-                        min_positive_day_ratio=Decimal('0.6'),
-                        min_daily_notional=Decimal('300000'),
-                        max_best_day_share=Decimal('0.3'),
-                        max_worst_day_loss=Decimal('350'),
-                        max_drawdown=Decimal('900'),
+                    "objective": StrategyObjective(
+                        target_net_pnl_per_day=Decimal("500"),
+                        min_active_day_ratio=Decimal("1.0"),
+                        min_positive_day_ratio=Decimal("0.6"),
+                        min_daily_notional=Decimal("300000"),
+                        max_best_day_share=Decimal("0.3"),
+                        max_worst_day_loss=Decimal("350"),
+                        max_drawdown=Decimal("900"),
                         require_every_day_active=True,
-                        min_regime_slice_pass_rate=Decimal('0'),
+                        min_regime_slice_pass_rate=Decimal("0"),
                         stop_when_objective_met=True,
                     ),
-                    'runtime_closure_policy': RuntimeClosurePolicy(
+                    "runtime_closure_policy": RuntimeClosurePolicy(
                         enabled=True,
                         execute_parity_replay=True,
                         execute_approval_replay=True,
-                        parity_window='full_window',
-                        approval_window='holdout',
-                        shadow_validation_mode='require_live_evidence',
-                        promotion_target='shadow',
+                        parity_window="full_window",
+                        approval_window="holdout",
+                        shadow_validation_mode="require_live_evidence",
+                        promotion_target="shadow",
                     ),
                 }
             )
             best_candidate = {
-                'candidate_id': 'cand-1',
-                'family_template_id': 'breakout_reclaim_v2',
-                'runtime_family': 'breakout_continuation_consistent',
-                'runtime_strategy_name': 'breakout-continuation-long-v1',
-                'status': 'keep',
-                'candidate_params': {'max_entries_per_session': '1'},
-                'candidate_strategy_overrides': {},
-                'disable_other_strategies': True,
-                'holdout_start_date': '2026-04-08',
-                'holdout_end_date': '2026-04-09',
-                'full_window_start_date': '2026-03-20',
-                'full_window_end_date': '2026-04-09',
-                'normalization_regime': 'price_scaled',
+                "candidate_id": "cand-1",
+                "family_template_id": "breakout_reclaim_v2",
+                "runtime_family": "breakout_continuation_consistent",
+                "runtime_strategy_name": "breakout-continuation-long-v1",
+                "status": "keep",
+                "candidate_params": {"max_entries_per_session": "1"},
+                "candidate_strategy_overrides": {},
+                "disable_other_strategies": True,
+                "holdout_start_date": "2026-04-08",
+                "holdout_end_date": "2026-04-09",
+                "full_window_start_date": "2026-03-20",
+                "full_window_end_date": "2026-04-09",
+                "normalization_regime": "price_scaled",
             }
             replay_payload = {
-                'start_date': '2026-03-20',
-                'end_date': '2026-04-09',
-                'net_pnl': '6000',
-                'decision_count': 12,
-                'filled_count': 9,
-                'wins': 7,
-                'losses': 2,
-                'daily': {
-                    '2026-03-20': {'net_pnl': '1000', 'filled_count': 1, 'filled_notional': '300000'},
-                    '2026-03-21': {'net_pnl': '800', 'filled_count': 1, 'filled_notional': '300000'},
-                    '2026-03-24': {'net_pnl': '700', 'filled_count': 1, 'filled_notional': '300000'},
-                    '2026-03-25': {'net_pnl': '900', 'filled_count': 1, 'filled_notional': '300000'},
-                    '2026-03-26': {'net_pnl': '1100', 'filled_count': 1, 'filled_notional': '300000'},
-                    '2026-03-27': {'net_pnl': '600', 'filled_count': 1, 'filled_notional': '300000'},
-                    '2026-04-08': {'net_pnl': '500', 'filled_count': 1, 'filled_notional': '300000'},
-                    '2026-04-09': {'net_pnl': '400', 'filled_count': 1, 'filled_notional': '300000'},
+                "start_date": "2026-03-20",
+                "end_date": "2026-04-09",
+                "net_pnl": "6000",
+                "decision_count": 12,
+                "filled_count": 9,
+                "wins": 7,
+                "losses": 2,
+                "daily": {
+                    "2026-03-20": {
+                        "net_pnl": "1000",
+                        "filled_count": 1,
+                        "filled_notional": "300000",
+                    },
+                    "2026-03-21": {
+                        "net_pnl": "800",
+                        "filled_count": 1,
+                        "filled_notional": "300000",
+                    },
+                    "2026-03-24": {
+                        "net_pnl": "700",
+                        "filled_count": 1,
+                        "filled_notional": "300000",
+                    },
+                    "2026-03-25": {
+                        "net_pnl": "900",
+                        "filled_count": 1,
+                        "filled_notional": "300000",
+                    },
+                    "2026-03-26": {
+                        "net_pnl": "1100",
+                        "filled_count": 1,
+                        "filled_notional": "300000",
+                    },
+                    "2026-03-27": {
+                        "net_pnl": "600",
+                        "filled_count": 1,
+                        "filled_notional": "300000",
+                    },
+                    "2026-04-08": {
+                        "net_pnl": "500",
+                        "filled_count": 1,
+                        "filled_notional": "300000",
+                    },
+                    "2026-04-09": {
+                        "net_pnl": "400",
+                        "filled_count": 1,
+                        "filled_notional": "300000",
+                    },
                 },
             }
 
@@ -1144,47 +1477,51 @@ data:
 
             summary = write_runtime_closure_bundle(
                 run_root=run_root,
-                runner_run_id='run-1',
+                runner_run_id="run-1",
                 program=program,
                 best_candidate=best_candidate,
                 manifest=manifest,
                 execution_context=RuntimeClosureExecutionContext(
                     strategy_configmap_path=configmap_path,
-                    clickhouse_http_url='http://example.invalid:8123',
-                    clickhouse_username='torghut',
-                    clickhouse_password='secret',
-                    start_equity=Decimal('31590.02'),
+                    clickhouse_http_url="http://example.invalid:8123",
+                    clickhouse_username="torghut",
+                    clickhouse_password="secret",
+                    start_equity=Decimal("31590.02"),
                     chunk_minutes=10,
-                    symbols=('AMAT', 'NVDA'),
+                    symbols=("AMAT", "NVDA"),
                     shadow_validation_artifact_path=shadow_artifact_path,
                 ),
                 replay_executor=_fake_replay_executor,
             )
 
-            self.assertEqual(summary.status, 'shadow_validation_failed')
-            shadow_payload = json.loads(Path(summary.shadow_validation_path).read_text(encoding='utf-8'))
-            self.assertEqual(shadow_payload['status'], 'out_of_budget')
-            self.assertIn('shadow_validation_status_not_within_budget', shadow_payload['reasons'])
+            self.assertEqual(summary.status, "shadow_validation_failed")
+            shadow_payload = json.loads(
+                Path(summary.shadow_validation_path).read_text(encoding="utf-8")
+            )
+            self.assertEqual(shadow_payload["status"], "out_of_budget")
+            self.assertIn(
+                "shadow_validation_status_not_within_budget", shadow_payload["reasons"]
+            )
 
     def test_write_runtime_closure_bundle_handles_missing_best_candidate(self) -> None:
         with TemporaryDirectory() as tmpdir:
             run_root = Path(tmpdir)
             manifest = build_mlx_snapshot_manifest(
-                runner_run_id='run-1',
+                runner_run_id="run-1",
                 program=_program(),
-                symbols='AMAT,NVDA',
+                symbols="AMAT,NVDA",
                 train_days=6,
                 holdout_days=2,
-                full_window_start_date='2026-03-20',
-                full_window_end_date='2026-04-09',
+                full_window_start_date="2026-03-20",
+                full_window_end_date="2026-04-09",
             )
             summary = write_runtime_closure_bundle(
                 run_root=run_root,
-                runner_run_id='run-1',
+                runner_run_id="run-1",
                 program=_program(),
                 best_candidate=None,
                 manifest=manifest,
             )
 
-            self.assertEqual(summary.status, 'missing_candidate')
-            self.assertTrue((run_root / 'runtime-closure' / 'summary.json').exists())
+            self.assertEqual(summary.status, "missing_candidate")
+            self.assertTrue((run_root / "runtime-closure" / "summary.json").exists())

--- a/services/torghut/tests/test_runtime_closure.py
+++ b/services/torghut/tests/test_runtime_closure.py
@@ -448,6 +448,24 @@ data:
             self.assertEqual(
                 candidate_spec["portfolio_promotion_v2"]["strategy_count"], 4
             )
+            self.assertEqual(
+                candidate_spec["portfolio_promotion_v2"]["spec_compiled_count"], 4
+            )
+            self.assertEqual(
+                candidate_spec["portfolio_promotion_v2"]["missing_policy_refs"], []
+            )
+            self.assertEqual(
+                len(candidate_spec["portfolio_promotion_v2"]["promotion_policy_refs"]),
+                4,
+            )
+            self.assertTrue(
+                all(
+                    str(ref).startswith("torghut.autoresearch.portfolio/cand-pairs/")
+                    for ref in candidate_spec["portfolio_promotion_v2"][
+                        "promotion_policy_refs"
+                    ]
+                )
+            )
             self.assertEqual(candidate_spec["full_window_start_date"], "2026-03-25")
             self.assertEqual(candidate_spec["full_window_end_date"], "2026-04-02")
             gate_report = runtime_closure._gate_report(
@@ -460,6 +478,9 @@ data:
             )
             self.assertEqual(
                 gate_report["vnext"]["portfolio_promotion"]["strategy_count"], 4
+            )
+            self.assertEqual(
+                gate_report["vnext"]["portfolio_promotion"]["missing_policy_refs"], []
             )
 
     def test_materialize_candidate_configmap_supports_generic_portfolio_candidates(
@@ -550,7 +571,16 @@ data:
             )
             portfolio_contract = runtime_closure._portfolio_promotion_v2(best_candidate)
             self.assertEqual(portfolio_contract["strategy_count"], 2)
-            self.assertEqual(portfolio_contract["spec_compiled_count"], 0)
+            self.assertEqual(portfolio_contract["spec_compiled_count"], 2)
+            self.assertEqual(
+                portfolio_contract["strategy_compilation_source"],
+                "runtime_closure_materialized_portfolio_v1",
+            )
+            self.assertEqual(portfolio_contract["missing_policy_refs"], [])
+            self.assertEqual(len(portfolio_contract["promotion_policy_refs"]), 2)
+            self.assertEqual(len(portfolio_contract["risk_profile_refs"]), 2)
+            self.assertEqual(len(portfolio_contract["sizing_policy_refs"]), 2)
+            self.assertEqual(len(portfolio_contract["execution_policy_refs"]), 2)
 
     def test_replay_analysis_records_decomposition_errors(self) -> None:
         replay_payload = {

--- a/services/torghut/tests/test_strategy_factory_validation.py
+++ b/services/torghut/tests/test_strategy_factory_validation.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest import TestCase
+
+import pandas as pd
+
+from app.trading.alpha.metrics import PerformanceSummary
+from app.trading.alpha.search import CandidateConfig, CandidateResult
+from app.trading.discovery.validation import build_strategy_factory_evaluation
+
+
+class TestStrategyFactoryValidation(TestCase):
+    def test_strategy_factory_evaluation_accepts_non_tsmom_family_metadata(
+        self,
+    ) -> None:
+        index = pd.date_range("2026-03-20", periods=6, freq="B", tz="UTC")
+        train_debug = pd.DataFrame(
+            {
+                "port_ret_net": [0.001, 0.002, 0.0015, 0.0025, 0.001, 0.002],
+                "port_ret_gross": [0.0012, 0.0022, 0.0017, 0.0027, 0.0012, 0.0022],
+                "turnover": [0.4, 0.3, 0.5, 0.4, 0.3, 0.5],
+                "cost_ret": [0.0002, 0.0002, 0.0002, 0.0002, 0.0002, 0.0002],
+            },
+            index=index,
+        )
+        test_debug = train_debug.copy()
+        best = CandidateResult(
+            config=CandidateConfig(
+                lookback_days=30,
+                vol_lookback_days=10,
+                target_daily_vol=0.01,
+                max_gross_leverage=1.2,
+            ),
+            train=PerformanceSummary(
+                total_return=0.14,
+                cagr=0.34,
+                annualized_vol=0.12,
+                sharpe=1.8,
+                max_drawdown=-0.02,
+                days=60,
+            ),
+            test=PerformanceSummary(
+                total_return=0.08,
+                cagr=0.24,
+                annualized_vol=0.10,
+                sharpe=1.5,
+                max_drawdown=-0.01,
+                days=60,
+            ),
+        )
+        challenger = CandidateResult(
+            config=CandidateConfig(
+                lookback_days=20,
+                vol_lookback_days=10,
+                target_daily_vol=0.01,
+                max_gross_leverage=1.0,
+            ),
+            train=PerformanceSummary(
+                total_return=0.04,
+                cagr=0.10,
+                annualized_vol=0.10,
+                sharpe=0.7,
+                max_drawdown=-0.03,
+                days=60,
+            ),
+            test=PerformanceSummary(
+                total_return=0.03,
+                cagr=0.08,
+                annualized_vol=0.10,
+                sharpe=0.5,
+                max_drawdown=-0.03,
+                days=60,
+            ),
+        )
+
+        evaluation = build_strategy_factory_evaluation(
+            run_id="run-washout-1",
+            candidate_id="cand-washout-1",
+            best_candidate=best,
+            all_candidates=[best, challenger],
+            train_debug=train_debug,
+            test_debug=test_debug,
+            train_summary=best.train,
+            test_summary=best.test,
+            incumbent_summary=PerformanceSummary(
+                total_return=0.02,
+                cagr=0.05,
+                annualized_vol=0.09,
+                sharpe=0.4,
+                max_drawdown=-0.04,
+                days=60,
+            ),
+            cost_bps_per_turnover=0.1,
+            evaluated_at=datetime(2026, 4, 21, tzinfo=UTC),
+            candidate_family="washout_rebound_consistent",
+            family_template_id="washout_rebound_v2",
+            runtime_family="washout_rebound_consistent",
+            runtime_strategy_name="washout-rebound-long-v1",
+            baseline_name="washout_rebound_default_v1",
+            generator_family="washout_rebound_grid_v1",
+            regime_supports=("liquidity_shock_reversal",),
+            regime_avoid=("persistent_gap_down",),
+        )
+
+        self.assertEqual(evaluation.candidate_family, "washout_rebound_consistent")
+        self.assertEqual(
+            evaluation.canonical_spec["family_template_id"], "washout_rebound_v2"
+        )
+        self.assertEqual(
+            evaluation.canonical_spec["runtime_strategy_name"],
+            "washout-rebound-long-v1",
+        )
+        self.assertEqual(
+            evaluation.null_comparator_summary["incumbent_baseline"]["name"],
+            "washout_rebound_default_v1",
+        )
+        self.assertEqual(
+            evaluation.valid_regime_envelope["supports"],
+            ["liquidity_shock_reversal"],
+        )
+        self.assertEqual(
+            evaluation.valid_regime_envelope["avoid"],
+            ["persistent_gap_down"],
+        )
+        self.assertEqual(
+            {attempt["generator_family"] for attempt in evaluation.attempts},
+            {"washout_rebound_grid_v1"},
+        )
+        self.assertEqual(
+            evaluation.cost_calibration.scope_id, "washout_rebound_consistent"
+        )

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -35,6 +35,10 @@ from app.trading.completion import (
 from app.trading.execution import OrderExecutor
 from app.config import settings
 from app.models import (
+    AutoresearchCandidateSpec,
+    AutoresearchEpoch,
+    AutoresearchPortfolioCandidate,
+    AutoresearchProposalScore,
     Base,
     Execution,
     ExecutionTCAMetric,
@@ -195,6 +199,83 @@ class TestTradingApi(TestCase):
         self.assertEqual(len(payload), 1)
         self.assertEqual(payload[0]["symbol"], "AAPL")
 
+    def test_autoresearch_epoch_endpoints(self) -> None:
+        with self.session_local() as session:
+            session.add(
+                AutoresearchEpoch(
+                    epoch_id="epoch-1",
+                    status="ok",
+                    target_net_pnl_per_day=Decimal("500"),
+                    paper_run_ids_json=["paper-1"],
+                    snapshot_manifest_json={"source_count": 1},
+                    runner_config_json={"replay_mode": "synthetic"},
+                    summary_json={"best": "portfolio-1"},
+                    started_at=datetime.now(timezone.utc),
+                    completed_at=datetime.now(timezone.utc),
+                )
+            )
+            session.add(
+                AutoresearchCandidateSpec(
+                    candidate_spec_id="spec-1",
+                    epoch_id="epoch-1",
+                    hypothesis_id="hyp-1",
+                    candidate_kind="sleeve",
+                    family_template_id="microbar_cross_sectional_pairs_v1",
+                    payload_json={"candidate_spec_id": "spec-1"},
+                    payload_hash="hash",
+                    status="eligible",
+                    blockers_json=[],
+                )
+            )
+            session.add(
+                AutoresearchProposalScore(
+                    epoch_id="epoch-1",
+                    candidate_spec_id="spec-1",
+                    model_id="model-1",
+                    backend="numpy-fallback",
+                    proposal_score=Decimal("12.5"),
+                    rank=1,
+                    selection_reason="exploitation",
+                    feature_hash="feature-hash",
+                    payload_json={"rank": 1},
+                )
+            )
+            session.add(
+                AutoresearchPortfolioCandidate(
+                    portfolio_candidate_id="portfolio-1",
+                    epoch_id="epoch-1",
+                    source_candidate_ids_json=["cand-1"],
+                    target_net_pnl_per_day=Decimal("500"),
+                    objective_scorecard_json={"target_met": True},
+                    optimizer_report_json={"selected_count": 1},
+                    payload_json={"portfolio_candidate_id": "portfolio-1"},
+                    status="target_met",
+                )
+            )
+            session.commit()
+
+        list_response = self.client.get("/trading/autoresearch/epochs")
+        self.assertEqual(list_response.status_code, 200)
+        list_payload = list_response.json()
+        self.assertEqual(list_payload["count"], 1)
+        self.assertEqual(list_payload["epochs"][0]["epoch_id"], "epoch-1")
+
+        detail_response = self.client.get("/trading/autoresearch/epochs/epoch-1")
+        self.assertEqual(detail_response.status_code, 200)
+        detail_payload = detail_response.json()
+        self.assertEqual(detail_payload["epoch"]["epoch_id"], "epoch-1")
+        self.assertEqual(
+            detail_payload["candidate_specs"][0]["candidate_spec_id"], "spec-1"
+        )
+        self.assertEqual(detail_payload["proposal_scores"][0]["rank"], 1)
+        self.assertEqual(
+            detail_payload["portfolio_candidates"][0]["portfolio_candidate_id"],
+            "portfolio-1",
+        )
+
+        missing_response = self.client.get("/trading/autoresearch/epochs/missing")
+        self.assertEqual(missing_response.status_code, 404)
+
     def test_dspy_cutover_migration_guard_assertion_raises_for_legacy_toggles(
         self,
     ) -> None:
@@ -322,7 +403,9 @@ class TestTradingApi(TestCase):
 
         self.assertEqual(response.status_code, 503)
         payload = response.json()
-        self.assertEqual(payload["detail"]["error"], "database schema lineage divergence")
+        self.assertEqual(
+            payload["detail"]["error"], "database schema lineage divergence"
+        )
         self.assertFalse(payload["detail"]["schema_graph_lineage_ready"])
         self.assertIn("schema_graph_lineage_errors", payload["detail"])
         self.assertIn("schema_graph_branch_count", payload["detail"])
@@ -404,7 +487,9 @@ class TestTradingApi(TestCase):
                 "0011_autonomy_lifecycle_and_promotion_audit",
                 "0011_execution_tca_simulator_divergence",
             ],
-            "schema_unexpected_heads": ["0010_execution_provenance_and_governance_trace"],
+            "schema_unexpected_heads": [
+                "0010_execution_provenance_and_governance_trace"
+            ],
             "schema_head_count_expected": 2,
             "schema_head_count_current": 1,
             "schema_head_delta_count": 3,
@@ -689,7 +774,9 @@ class TestTradingApi(TestCase):
             self.assertIn("universe", payload["dependencies"])
             self.assertTrue(payload["dependencies"]["universe"]["ok"])
             self.assertEqual(payload["dependencies"]["universe"]["status"], "ok")
-            self.assertEqual(payload["dependencies"]["universe"]["detail"], "jangar universe fresh")
+            self.assertEqual(
+                payload["dependencies"]["universe"]["detail"], "jangar universe fresh"
+            )
         finally:
             settings.trading_enabled = original
             settings.trading_mode = original_mode
@@ -964,7 +1051,9 @@ class TestTradingApi(TestCase):
             universe_dependency = payload["dependencies"]["universe"]
             self.assertFalse(universe_dependency["ok"])
             self.assertEqual(universe_dependency["status"], "error")
-            self.assertEqual(universe_dependency["detail"], "jangar universe unavailable")
+            self.assertEqual(
+                universe_dependency["detail"], "jangar universe unavailable"
+            )
             self.assertEqual(
                 universe_dependency["reason"], "jangar_fetch_failed_cache_stale"
             )
@@ -1201,7 +1290,9 @@ class TestTradingApi(TestCase):
             payload = response.json()
             self.assertEqual(payload["status"], "ok")
             self.assertTrue(payload["dependencies"]["database"]["ok"])
-            self.assertTrue(payload["dependencies"]["database"]["schema_graph_lineage_ready"])
+            self.assertTrue(
+                payload["dependencies"]["database"]["schema_graph_lineage_ready"]
+            )
             self.assertEqual(
                 payload["dependencies"]["database"]["schema_graph_lineage_warnings"],
                 [
@@ -1509,7 +1600,9 @@ class TestTradingApi(TestCase):
             "expected_heads": ["0011_autonomy_lifecycle_and_promotion_audit"],
             "schema_head_signature": "7f8e4d0",
             "schema_missing_heads": ["0011_autonomy_lifecycle_and_promotion_audit"],
-            "schema_unexpected_heads": ["0010_execution_provenance_and_governance_trace"],
+            "schema_unexpected_heads": [
+                "0010_execution_provenance_and_governance_trace"
+            ],
             "schema_head_count_expected": 1,
             "schema_head_count_current": 1,
             "schema_head_delta_count": 2,
@@ -1556,7 +1649,9 @@ class TestTradingApi(TestCase):
             self.assertEqual(
                 payload["dependencies"]["database"]["schema_head_count_current"], 1
             )
-            self.assertEqual(payload["dependencies"]["database"]["schema_head_delta_count"], 2)
+            self.assertEqual(
+                payload["dependencies"]["database"]["schema_head_delta_count"], 2
+            )
             self.assertEqual(
                 payload["dependencies"]["database"]["schema_head_signature"], "7f8e4d0"
             )
@@ -1619,7 +1714,9 @@ class TestTradingApi(TestCase):
                 payload["dependencies"]["database"]["schema_head_count_current"],
                 1,
             )
-            self.assertEqual(payload["dependencies"]["database"]["schema_head_delta_count"], 2)
+            self.assertEqual(
+                payload["dependencies"]["database"]["schema_head_delta_count"], 2
+            )
         finally:
             settings.trading_enabled = original
 
@@ -1721,7 +1818,10 @@ class TestTradingApi(TestCase):
         self.assertEqual(control_plane_contract["alpha_readiness_shadow_total"], 2)
         self.assertIn(control_plane_contract["active_capital_stage"], {"shadow", None})
         self.assertIn("critical_toggle_parity", control_plane_contract)
-        self.assertIn(payload["shadow_first"]["critical_toggle_parity"]["status"], {"aligned", "diverged"})
+        self.assertIn(
+            payload["shadow_first"]["critical_toggle_parity"]["status"],
+            {"aligned", "diverged"},
+        )
         self.assertEqual(
             payload["build"]["active_revision"],
             control_plane_contract["active_revision"],
@@ -1730,7 +1830,9 @@ class TestTradingApi(TestCase):
             control_plane_contract["alpha_readiness_dependency_quorum_decision"],
             "unknown",
         )
-        self.assertIn(payload["forecast_service"]["authority"], {"empirical", "blocked"})
+        self.assertIn(
+            payload["forecast_service"]["authority"], {"empirical", "blocked"}
+        )
         self.assertIn(payload["lean_authority"]["authority"], {"empirical", "blocked"})
         self.assertIn(payload["empirical_jobs"]["authority"], {"empirical", "blocked"})
 
@@ -1773,23 +1875,28 @@ class TestTradingApi(TestCase):
                 },
             )
 
-            with patch(
-                "app.main._build_hypothesis_runtime_payload",
-                return_value=(
-                    {
-                        "registry_loaded": True,
-                        "registry_path": "test",
-                        "registry_errors": [],
-                        "dependency_quorum": hypothesis_summary["dependency_quorum"],
-                        "summary": hypothesis_summary,
-                        "items": [],
-                    },
-                    hypothesis_summary,
-                    dependency_quorum,
+            with (
+                patch(
+                    "app.main._build_hypothesis_runtime_payload",
+                    return_value=(
+                        {
+                            "registry_loaded": True,
+                            "registry_path": "test",
+                            "registry_errors": [],
+                            "dependency_quorum": hypothesis_summary[
+                                "dependency_quorum"
+                            ],
+                            "summary": hypothesis_summary,
+                            "items": [],
+                        },
+                        hypothesis_summary,
+                        dependency_quorum,
+                    ),
                 ),
-            ), patch(
-                "app.main._empirical_jobs_status",
-                return_value={"ready": True, "status": "healthy"},
+                patch(
+                    "app.main._empirical_jobs_status",
+                    return_value={"ready": True, "status": "healthy"},
+                ),
             ):
                 response = self.client.get("/trading/status")
 
@@ -1866,7 +1973,9 @@ class TestTradingApi(TestCase):
                             "registry_loaded": True,
                             "registry_path": "test",
                             "registry_errors": [],
-                            "dependency_quorum": hypothesis_summary["dependency_quorum"],
+                            "dependency_quorum": hypothesis_summary[
+                                "dependency_quorum"
+                            ],
                             "summary": hypothesis_summary,
                             "items": [],
                         },
@@ -2040,7 +2149,10 @@ class TestTradingApi(TestCase):
                         ),
                     ),
                 ),
-                patch("app.main._empirical_jobs_status", return_value={"ready": True, "status": "healthy"}),
+                patch(
+                    "app.main._empirical_jobs_status",
+                    return_value={"ready": True, "status": "healthy"},
+                ),
                 patch(
                     "app.main.load_quant_evidence_status",
                     return_value={
@@ -2055,7 +2167,10 @@ class TestTradingApi(TestCase):
                         "latest_metrics_updated_at": "2026-03-20T10:00:00Z",
                     },
                 ),
-                patch("app.main._build_live_submission_gate_payload", return_value=shared_gate),
+                patch(
+                    "app.main._build_live_submission_gate_payload",
+                    return_value=shared_gate,
+                ),
             ):
                 status_response = self.client.get("/trading/status")
                 health_response = self.client.get("/trading/health")
@@ -2066,8 +2181,12 @@ class TestTradingApi(TestCase):
             self.assertEqual(health_response.status_code, 503)
             self.assertEqual(ready_response.status_code, 503)
             self.assertEqual(runtime_response.status_code, 200)
-            self.assertEqual(status_response.json()["live_submission_gate"], shared_gate)
-            self.assertEqual(health_response.json()["live_submission_gate"], shared_gate)
+            self.assertEqual(
+                status_response.json()["live_submission_gate"], shared_gate
+            )
+            self.assertEqual(
+                health_response.json()["live_submission_gate"], shared_gate
+            )
             self.assertEqual(ready_response.json()["live_submission_gate"], shared_gate)
             self.assertEqual(
                 runtime_response.json()["live_submission_gate"],
@@ -2288,11 +2407,15 @@ class TestTradingApi(TestCase):
             self.assertEqual(payload["market_context"]["fail_mode"], "shadow_only")
             self.assertFalse(payload["market_context"]["required"])
             self.assertEqual(payload["market_context"]["last_symbol"], "AAPL")
-            self.assertEqual(payload["market_context"]["last_reason"], "market_context_stale")
+            self.assertEqual(
+                payload["market_context"]["last_reason"], "market_context_stale"
+            )
             self.assertTrue(payload["market_context"]["alert_active"])
             self.assertEqual(payload["rejections"]["policy_veto_total"], 3)
             self.assertEqual(payload["rejections"]["runtime_fallback_total"], 5)
-            self.assertAlmostEqual(payload["rejections"]["runtime_fallback_ratio"], 0.05)
+            self.assertAlmostEqual(
+                payload["rejections"]["runtime_fallback_ratio"], 0.05
+            )
             self.assertEqual(
                 payload["rejections"]["runtime_fallback_alert_ratio_threshold"], 0.01
             )
@@ -2391,7 +2514,9 @@ class TestTradingApi(TestCase):
                 metrics_payload,
             )
             self.assertIn("torghut_trading_llm_runtime_fallback_ratio", metrics_payload)
-            self.assertIn("torghut_trading_market_context_alert_active", metrics_payload)
+            self.assertIn(
+                "torghut_trading_market_context_alert_active", metrics_payload
+            )
         finally:
             if original_scheduler is None:
                 del app.state.trading_scheduler
@@ -2623,9 +2748,15 @@ class TestTradingApi(TestCase):
                 self.assertEqual(response.status_code, 200)
                 payload = response.json()
                 self.assertEqual(payload["bridge_status"]["source"], "gate_report")
-                self.assertIn(payload["forecast_service"]["authority"], {"empirical", "blocked"})
-                self.assertIn(payload["lean_authority"]["authority"], {"empirical", "blocked"})
-                self.assertIn(payload["empirical_jobs"]["authority"], {"empirical", "blocked"})
+                self.assertIn(
+                    payload["forecast_service"]["authority"], {"empirical", "blocked"}
+                )
+                self.assertIn(
+                    payload["lean_authority"]["authority"], {"empirical", "blocked"}
+                )
+                self.assertIn(
+                    payload["empirical_jobs"]["authority"], {"empirical", "blocked"}
+                )
                 self.assertEqual(
                     payload["bridge_status"]["strategy_compilation"]["spec_compiled"],
                     1,
@@ -2639,7 +2770,9 @@ class TestTradingApi(TestCase):
                     "stable",
                 )
                 self.assertEqual(
-                    payload["bridge_status"]["evidence_authority"]["authoritative_count"],
+                    payload["bridge_status"]["evidence_authority"][
+                        "authoritative_count"
+                    ],
                     2,
                 )
                 self.assertEqual(
@@ -2682,49 +2815,56 @@ class TestTradingApi(TestCase):
         self.assertEqual(response.status_code, 200)
         payload = response.json()
         self.assertIn("jobs", payload)
-        self.assertEqual(payload["message"], "missing empirical jobs: foundation_router_parity, janus_event_car, janus_hgrm_reward")
+        self.assertEqual(
+            payload["message"],
+            "missing empirical jobs: foundation_router_parity, janus_event_car, janus_hgrm_reward",
+        )
         self.assertEqual(payload["eligible_jobs"], ["benchmark_parity"])
         self.assertEqual(
             payload["missing_jobs"],
             ["foundation_router_parity", "janus_event_car", "janus_hgrm_reward"],
         )
         self.assertEqual(payload["jobs"]["benchmark_parity"]["authority"], "empirical")
-        self.assertEqual(payload["jobs"]["benchmark_parity"]["job_run_id"], "job-benchmark-1")
+        self.assertEqual(
+            payload["jobs"]["benchmark_parity"]["job_run_id"], "job-benchmark-1"
+        )
 
-    def test_trading_completion_doc29_endpoint_exposes_traceable_gate_status(self) -> None:
+    def test_trading_completion_doc29_endpoint_exposes_traceable_gate_status(
+        self,
+    ) -> None:
         with self.session_local() as session:
             trace = build_completion_trace(
-                doc_id='doc29',
+                doc_id="doc29",
                 gate_ids_attempted=[DOC29_SIMULATION_FULL_DAY_GATE],
-                run_id='sim-2026-03-06-full-day',
-                dataset_snapshot_ref='snapshot-1',
-                candidate_id='cand-1',
-                workflow_name='torghut-historical-simulation',
+                run_id="sim-2026-03-06-full-day",
+                dataset_snapshot_ref="snapshot-1",
+                candidate_id="cand-1",
+                workflow_name="torghut-historical-simulation",
                 analysis_run_names=[],
-                artifact_refs=['s3://artifacts/run-full-lifecycle-manifest.json'],
+                artifact_refs=["s3://artifacts/run-full-lifecycle-manifest.json"],
                 db_row_refs={},
                 status_snapshot={},
                 result_by_gate={
                     DOC29_SIMULATION_FULL_DAY_GATE: {
-                        'status': TRACE_STATUS_SATISFIED,
-                        'artifact_ref': 's3://artifacts/run-full-lifecycle-manifest.json',
-                        'acceptance_snapshot': {
-                            'trade_decisions': 640,
-                            'executions': 320,
-                            'execution_tca_metrics': 320,
-                            'execution_order_events': 320,
-                            'coverage_ratio': 0.99,
+                        "status": TRACE_STATUS_SATISFIED,
+                        "artifact_ref": "s3://artifacts/run-full-lifecycle-manifest.json",
+                        "acceptance_snapshot": {
+                            "trade_decisions": 640,
+                            "executions": 320,
+                            "execution_tca_metrics": 320,
+                            "execution_order_events": 320,
+                            "coverage_ratio": 0.99,
                         },
                     }
                 },
                 blocked_reasons={},
-                git_revision='abc123',
-                image_digest='sha256:test',
+                git_revision="abc123",
+                image_digest="sha256:test",
             )
             persist_completion_trace(
                 session=session,
                 trace_payload=trace,
-                default_artifact_ref='s3://artifacts/completion-trace.json',
+                default_artifact_ref="s3://artifacts/completion-trace.json",
             )
             session.commit()
 
@@ -2737,7 +2877,9 @@ class TestTradingApi(TestCase):
         payload = response.json()
         self.assertEqual(payload["doc_id"], "doc29")
         gate = next(
-            item for item in payload["gates"] if item["gate_id"] == DOC29_SIMULATION_FULL_DAY_GATE
+            item
+            for item in payload["gates"]
+            if item["gate_id"] == DOC29_SIMULATION_FULL_DAY_GATE
         )
         self.assertEqual(gate["status"], "satisfied")
         self.assertEqual(gate["latest_run"], "sim-2026-03-06-full-day")
@@ -2746,9 +2888,13 @@ class TestTradingApi(TestCase):
             patch("app.main.SessionLocal", self.session_local),
             patch("app.main.BUILD_COMMIT", "abc123"),
         ):
-            gate_response = self.client.get(f"/trading/completion/doc29/{DOC29_SIMULATION_FULL_DAY_GATE}")
+            gate_response = self.client.get(
+                f"/trading/completion/doc29/{DOC29_SIMULATION_FULL_DAY_GATE}"
+            )
         self.assertEqual(gate_response.status_code, 200)
-        self.assertEqual(gate_response.json()["gate_id"], DOC29_SIMULATION_FULL_DAY_GATE)
+        self.assertEqual(
+            gate_response.json()["gate_id"], DOC29_SIMULATION_FULL_DAY_GATE
+        )
 
     def test_trading_autonomy_evidence_continuity_endpoint_returns_state_report(
         self,

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -209,7 +209,15 @@ class TestTradingApi(TestCase):
                     paper_run_ids_json=["paper-1"],
                     snapshot_manifest_json={"source_count": 1},
                     runner_config_json={"replay_mode": "synthetic"},
-                    summary_json={"best": "portfolio-1"},
+                    summary_json={
+                        "best": "portfolio-1",
+                        "claim_count": 2,
+                        "hypothesis_count": 1,
+                        "candidate_spec_count": 1,
+                        "evidence_bundle_count": 1,
+                        "portfolio_candidate_count": 1,
+                        "mlx_rank_bucket_lift": {"lift_net_pnl_per_day": "10"},
+                    },
                     started_at=datetime.now(timezone.utc),
                     completed_at=datetime.now(timezone.utc),
                 )
@@ -246,9 +254,20 @@ class TestTradingApi(TestCase):
                     epoch_id="epoch-1",
                     source_candidate_ids_json=["cand-1"],
                     target_net_pnl_per_day=Decimal("500"),
-                    objective_scorecard_json={"target_met": True},
+                    objective_scorecard_json={
+                        "target_met": True,
+                        "net_pnl_per_day": "535",
+                        "active_day_ratio": "1",
+                        "positive_day_ratio": "1",
+                    },
                     optimizer_report_json={"selected_count": 1},
-                    payload_json={"portfolio_candidate_id": "portfolio-1"},
+                    payload_json={
+                        "portfolio_candidate_id": "portfolio-1",
+                        "sleeves": [{"candidate_id": "cand-1"}],
+                        "promotion_readiness": {
+                            "blockers": ["scheduler_v3_parity_missing"]
+                        },
+                    },
                     status="target_met",
                 )
             )
@@ -259,6 +278,10 @@ class TestTradingApi(TestCase):
         list_payload = list_response.json()
         self.assertEqual(list_payload["count"], 1)
         self.assertEqual(list_payload["epochs"][0]["epoch_id"], "epoch-1")
+        self.assertEqual(
+            list_payload["epochs"][0]["best_portfolio_net_pnl_per_day"], "535"
+        )
+        self.assertEqual(list_payload["epochs"][0]["claim_count"], 2)
 
         detail_response = self.client.get("/trading/autoresearch/epochs/epoch-1")
         self.assertEqual(detail_response.status_code, 200)
@@ -271,6 +294,10 @@ class TestTradingApi(TestCase):
         self.assertEqual(
             detail_payload["portfolio_candidates"][0]["portfolio_candidate_id"],
             "portfolio-1",
+        )
+        self.assertEqual(
+            detail_payload["dashboard"]["blocked_promotion_reasons"],
+            ["scheduler_v3_parity_missing"],
         )
 
         missing_response = self.client.get("/trading/autoresearch/epochs/missing")

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -217,6 +217,8 @@ class TestTradingApi(TestCase):
                         "evidence_bundle_count": 1,
                         "portfolio_candidate_count": 1,
                         "mlx_rank_bucket_lift": {"lift_net_pnl_per_day": "10"},
+                        "false_positive_table": [{"candidate_spec_id": "spec-fp"}],
+                        "best_false_negative_table": [{"candidate_spec_id": "spec-fn"}],
                     },
                     started_at=datetime.now(timezone.utc),
                     completed_at=datetime.now(timezone.utc),
@@ -282,6 +284,10 @@ class TestTradingApi(TestCase):
             list_payload["epochs"][0]["best_portfolio_net_pnl_per_day"], "535"
         )
         self.assertEqual(list_payload["epochs"][0]["claim_count"], 2)
+        self.assertEqual(
+            list_payload["epochs"][0]["false_positive_table"][0]["candidate_spec_id"],
+            "spec-fp",
+        )
 
         detail_response = self.client.get("/trading/autoresearch/epochs/epoch-1")
         self.assertEqual(detail_response.status_code, 200)
@@ -298,6 +304,12 @@ class TestTradingApi(TestCase):
         self.assertEqual(
             detail_payload["dashboard"]["blocked_promotion_reasons"],
             ["scheduler_v3_parity_missing"],
+        )
+        self.assertEqual(
+            detail_payload["dashboard"]["best_false_negative_table"][0][
+                "candidate_spec_id"
+            ],
+            "spec-fn",
         )
 
         missing_response = self.client.get("/trading/autoresearch/epochs/missing")

--- a/services/torghut/tests/test_whitepaper_autoresearch_artifacts.py
+++ b/services/torghut/tests/test_whitepaper_autoresearch_artifacts.py
@@ -1,0 +1,281 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from unittest import TestCase
+
+from app.trading.discovery.candidate_specs import (
+    compile_candidate_specs,
+    candidate_spec_from_payload,
+)
+from app.trading.discovery.evidence_bundles import (
+    evidence_bundle_from_frontier_candidate,
+)
+from app.trading.discovery.hypothesis_cards import (
+    build_hypothesis_cards,
+    hypothesis_card_from_payload,
+)
+from app.trading.discovery.mlx_training_data import (
+    build_mlx_training_rows,
+    rank_training_rows,
+    train_mlx_ranker,
+)
+from app.trading.discovery.portfolio_optimizer import optimize_portfolio_candidate
+
+
+class TestWhitepaperAutoresearchArtifacts(TestCase):
+    def test_hypothesis_and_candidate_specs_round_trip(self) -> None:
+        cards = build_hypothesis_cards(
+            source_run_id="paper-2026",
+            claims=[
+                {
+                    "claim_id": "claim-flow",
+                    "claim_type": "signal_mechanism",
+                    "claim_text": "Clustered order flow imbalance improves intraday trading signals.",
+                    "asset_scope": "us_equities_intraday",
+                    "horizon_scope": "intraday",
+                    "expected_direction": "positive",
+                    "confidence": "0.82",
+                }
+            ],
+        )
+
+        self.assertEqual(len(cards), 1)
+        reloaded_card = hypothesis_card_from_payload(cards[0].to_payload())
+        self.assertEqual(reloaded_card.hypothesis_id, cards[0].hypothesis_id)
+        self.assertIn("order_flow_imbalance", reloaded_card.required_features)
+
+        specs = compile_candidate_specs(
+            hypothesis_cards=cards, target_net_pnl_per_day=Decimal("500")
+        )
+        self.assertEqual(len(specs), 1)
+        self.assertEqual(
+            specs[0].family_template_id, "microbar_cross_sectional_pairs_v1"
+        )
+        self.assertEqual(specs[0].objective["target_net_pnl_per_day"], "500")
+
+        reloaded_spec = candidate_spec_from_payload(specs[0].to_payload())
+        self.assertEqual(reloaded_spec.candidate_spec_id, specs[0].candidate_spec_id)
+        self.assertEqual(
+            reloaded_spec.to_vnext_experiment_payload()["family_template_id"],
+            "microbar_cross_sectional_pairs_v1",
+        )
+
+    def test_evidence_training_rows_and_portfolio_optimizer(self) -> None:
+        cards = build_hypothesis_cards(
+            source_run_id="paper-2026",
+            claims=[
+                {
+                    "claim_id": "claim-flow",
+                    "claim_type": "signal_mechanism",
+                    "claim_text": "Trade-flow order flow clustering creates a transferable intraday signal.",
+                    "confidence": "0.82",
+                },
+                {
+                    "claim_id": "claim-momentum",
+                    "claim_type": "feature_recipe",
+                    "claim_text": "Momentum pullback ranking improves continuation entries.",
+                    "confidence": "0.76",
+                },
+            ],
+        )
+        specs = compile_candidate_specs(
+            hypothesis_cards=cards, target_net_pnl_per_day=Decimal("500")
+        )
+        bundles = [
+            evidence_bundle_from_frontier_candidate(
+                candidate_spec_id=f"{spec.candidate_spec_id}-{index}",
+                candidate={
+                    "candidate_id": f"cand-{index}",
+                    "objective_scorecard": {
+                        "net_pnl_per_day": str(300 - (index * 25)),
+                        "active_day_ratio": "0.92",
+                        "positive_day_ratio": "0.64",
+                        "worst_day_loss": "150",
+                        "max_drawdown": "400",
+                        "best_day_share": "0.18",
+                    },
+                },
+                dataset_snapshot_id="snap-1",
+                result_path=f"/tmp/result-{index}.json",
+            )
+            for index, spec in enumerate([specs[0], specs[0]], start=1)
+        ]
+
+        rows = build_mlx_training_rows(candidate_specs=specs, evidence_bundles=bundles)
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0].feature_names[0], "family_code")
+
+        portfolio = optimize_portfolio_candidate(
+            evidence_bundles=bundles,
+            target_net_pnl_per_day=Decimal("500"),
+            portfolio_size_min=2,
+            portfolio_size_max=4,
+        )
+
+        self.assertIsNotNone(portfolio)
+        assert portfolio is not None
+        self.assertTrue(portfolio.objective_scorecard["target_met"])
+        self.assertEqual(len(portfolio.sleeves), 2)
+
+    def test_mlx_ranker_learns_and_scores_training_rows(self) -> None:
+        cards = build_hypothesis_cards(
+            source_run_id="paper-2026",
+            claims=[
+                {
+                    "claim_id": "claim-flow",
+                    "claim_type": "signal_mechanism",
+                    "claim_text": "Trade-flow order flow clustering creates a transferable intraday signal.",
+                    "confidence": "0.82",
+                }
+            ],
+        )
+        specs = compile_candidate_specs(
+            hypothesis_cards=cards, target_net_pnl_per_day=Decimal("500")
+        )
+        high_spec = specs[0]
+        low_spec = candidate_spec_from_payload(
+            {
+                **high_spec.to_payload(),
+                "candidate_spec_id": f"{high_spec.candidate_spec_id}-low",
+                "hypothesis_id": f"{high_spec.hypothesis_id}-low",
+            }
+        )
+        bundles = [
+            evidence_bundle_from_frontier_candidate(
+                candidate_spec_id=high_spec.candidate_spec_id,
+                candidate={
+                    "candidate_id": "high",
+                    "objective_scorecard": {
+                        "net_pnl_per_day": "500",
+                        "active_day_ratio": "1.0",
+                        "positive_day_ratio": "0.8",
+                    },
+                },
+                dataset_snapshot_id="snap-1",
+                result_path="/tmp/high.json",
+            ),
+            evidence_bundle_from_frontier_candidate(
+                candidate_spec_id=low_spec.candidate_spec_id,
+                candidate={
+                    "candidate_id": "low",
+                    "objective_scorecard": {
+                        "net_pnl_per_day": "50",
+                        "active_day_ratio": "0.5",
+                        "positive_day_ratio": "0.4",
+                    },
+                },
+                dataset_snapshot_id="snap-1",
+                result_path="/tmp/low.json",
+            ),
+        ]
+
+        rows = build_mlx_training_rows(
+            candidate_specs=[high_spec, low_spec],
+            evidence_bundles=bundles,
+        )
+        model = train_mlx_ranker(rows, backend_preference="numpy-fallback", steps=128)
+        ranked = rank_training_rows(model=model, rows=rows)
+
+        self.assertEqual(model.schema_version, "torghut.mlx-ranker.v1")
+        self.assertEqual(model.backend, "numpy-fallback")
+        self.assertEqual(model.row_count, 2)
+        self.assertEqual(ranked[0].candidate_spec_id, high_spec.candidate_spec_id)
+        self.assertGreater(ranked[0].score, ranked[1].score)
+
+    def test_portfolio_optimizer_uses_daily_vectors_and_correlation_cap(self) -> None:
+        bundles = [
+            evidence_bundle_from_frontier_candidate(
+                candidate_spec_id="spec-a",
+                candidate={
+                    "candidate_id": "cand-a",
+                    "objective_scorecard": {
+                        "net_pnl_per_day": "300",
+                        "active_day_ratio": "1.0",
+                        "positive_day_ratio": "1.0",
+                        "worst_day_loss": "0",
+                        "max_drawdown": "0",
+                        "best_day_share": "0.34",
+                    },
+                    "full_window": {
+                        "daily_net": {
+                            "2026-02-23": "200",
+                            "2026-02-24": "400",
+                            "2026-02-25": "300",
+                        }
+                    },
+                },
+                dataset_snapshot_id="snap-1",
+                result_path="/tmp/a.json",
+            ),
+            evidence_bundle_from_frontier_candidate(
+                candidate_spec_id="spec-b",
+                candidate={
+                    "candidate_id": "cand-b",
+                    "objective_scorecard": {
+                        "net_pnl_per_day": "270",
+                        "active_day_ratio": "1.0",
+                        "positive_day_ratio": "1.0",
+                        "worst_day_loss": "0",
+                        "max_drawdown": "0",
+                        "best_day_share": "0.34",
+                    },
+                    "full_window": {
+                        "daily_net": {
+                            "2026-02-23": "100",
+                            "2026-02-24": "350",
+                            "2026-02-25": "360",
+                        }
+                    },
+                },
+                dataset_snapshot_id="snap-1",
+                result_path="/tmp/b.json",
+            ),
+            evidence_bundle_from_frontier_candidate(
+                candidate_spec_id="spec-c",
+                candidate={
+                    "candidate_id": "cand-c",
+                    "objective_scorecard": {
+                        "net_pnl_per_day": "260",
+                        "active_day_ratio": "1.0",
+                        "positive_day_ratio": "1.0",
+                        "worst_day_loss": "0",
+                        "max_drawdown": "0",
+                        "best_day_share": "0.34",
+                    },
+                    "full_window": {
+                        "daily_net": {
+                            "2026-02-23": "180",
+                            "2026-02-24": "360",
+                            "2026-02-25": "270",
+                        }
+                    },
+                },
+                dataset_snapshot_id="snap-1",
+                result_path="/tmp/c.json",
+            ),
+        ]
+
+        portfolio = optimize_portfolio_candidate(
+            evidence_bundles=bundles,
+            target_net_pnl_per_day=Decimal("700"),
+            portfolio_size_min=2,
+            portfolio_size_max=3,
+        )
+
+        self.assertIsNotNone(portfolio)
+        assert portfolio is not None
+        self.assertEqual(portfolio.source_candidate_ids, ("cand-a", "cand-b"))
+        self.assertEqual(portfolio.objective_scorecard["net_pnl_per_day"], "570")
+        self.assertEqual(portfolio.objective_scorecard["worst_day_loss"], "0")
+        self.assertEqual(
+            portfolio.objective_scorecard["daily_net"],
+            {
+                "2026-02-23": "300",
+                "2026-02-24": "750",
+                "2026-02-25": "660",
+            },
+        )
+        rejection_reasons = [
+            item["reason"] for item in portfolio.optimizer_report["rejections"]
+        ]
+        self.assertIn("correlation_cap", rejection_reasons)

--- a/services/torghut/tests/test_whitepaper_autoresearch_artifacts.py
+++ b/services/torghut/tests/test_whitepaper_autoresearch_artifacts.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 from decimal import Decimal
+from typing import Any
 from unittest import TestCase
+from unittest.mock import patch
 
 from app.trading.discovery.candidate_specs import (
     compile_candidate_specs,
@@ -9,13 +11,17 @@ from app.trading.discovery.candidate_specs import (
 )
 from app.trading.discovery.evidence_bundles import (
     evidence_bundle_from_frontier_candidate,
+    evidence_bundle_from_payload,
 )
 from app.trading.discovery.hypothesis_cards import (
+    HYPOTHESIS_CARD_SCHEMA_VERSION,
+    HypothesisCard,
     build_hypothesis_cards,
     hypothesis_card_from_payload,
 )
 from app.trading.discovery.mlx_training_data import (
     build_mlx_training_rows,
+    mlx_ranker_model_from_payload,
     rank_training_rows,
     train_mlx_ranker,
 )
@@ -181,6 +187,180 @@ class TestWhitepaperAutoresearchArtifacts(TestCase):
         self.assertEqual(model.row_count, 2)
         self.assertEqual(ranked[0].candidate_spec_id, high_spec.candidate_spec_id)
         self.assertGreater(ranked[0].score, ranked[1].score)
+
+    def test_hypothesis_cards_cover_failure_and_threshold_edges(self) -> None:
+        self.assertEqual(
+            build_hypothesis_cards(source_run_id="empty", claims=[]),
+            [],
+        )
+        self.assertEqual(
+            build_hypothesis_cards(
+                source_run_id="low-confidence",
+                claims=[
+                    {
+                        "claim_id": "weak",
+                        "claim_text": "Weak momentum signal.",
+                        "confidence": "0.10",
+                    }
+                ],
+                min_confidence=Decimal("0.50"),
+            ),
+            [],
+        )
+
+        cards = build_hypothesis_cards(
+            source_run_id="edge-paper",
+            claims=[
+                {
+                    "claim_id": "negative-reversal",
+                    "claim_text": "A reversal washout can fail when liquidity vanishes.",
+                    "expected_direction": "negative",
+                    "expected_failure_modes": "liquidity_vanishes",
+                    "expected_regimes": "stressed_open",
+                    "confidence": "not-a-decimal",
+                    "metadata": {"features": {"bad": "shape"}},
+                }
+            ],
+            relations=[
+                {
+                    "relation_id": "rel-1",
+                    "relation_type": "contradicts",
+                }
+            ],
+            min_confidence=Decimal("0"),
+        )
+
+        self.assertEqual(len(cards), 1)
+        self.assertIn("session_selloff_bps", cards[0].required_features)
+        self.assertIn("rebound", cards[0].entry_motifs)
+        self.assertIn("liquidity_vanishes", cards[0].failure_modes)
+        self.assertIn("contradiction:rel-1", cards[0].failure_modes)
+        with self.assertRaisesRegex(ValueError, "hypothesis_card_schema_invalid"):
+            hypothesis_card_from_payload({"schema_version": "bad"})
+
+    def test_candidate_specs_cover_family_selection_and_payload_edges(self) -> None:
+        cards = [
+            HypothesisCard(
+                schema_version=HYPOTHESIS_CARD_SCHEMA_VERSION,
+                hypothesis_id=f"hyp-{index}",
+                source_run_id="paper",
+                source_claim_ids=(f"claim-{index}",),
+                mechanism=mechanism,
+                asset_scope="us_equities_intraday",
+                horizon_scope="intraday",
+                expected_direction="positive",
+                required_features=(),
+                entry_motifs=(),
+                exit_motifs=("time_exit",),
+                risk_controls=("quote_quality",),
+                expected_regimes=("regular_session",),
+                failure_modes=("cost_stress",),
+                implementation_constraints={},
+                confidence=Decimal("0.8"),
+            )
+            for index, mechanism in enumerate(
+                [
+                    "matched-filter normalization signal",
+                    "washout rebound signal",
+                    "momentum trend pullback signal",
+                    "breakout continuation signal",
+                ],
+                start=1,
+            )
+        ]
+
+        specs = compile_candidate_specs(
+            hypothesis_cards=cards, target_net_pnl_per_day=Decimal("500")
+        )
+
+        self.assertEqual(
+            [spec.family_template_id for spec in specs],
+            [
+                "microstructure_continuation_matched_filter_v1",
+                "washout_rebound_v2",
+                "momentum_pullback_v1",
+                "breakout_reclaim_v2",
+            ],
+        )
+        payload = specs[0].to_payload()
+        payload["feature_contract"] = "not-a-mapping"
+        reloaded = candidate_spec_from_payload(payload)
+        self.assertEqual(reloaded.feature_contract, {})
+        with self.assertRaisesRegex(ValueError, "candidate_spec_schema_invalid"):
+            candidate_spec_from_payload({"schema_version": "bad"})
+
+    def test_evidence_bundle_covers_full_window_fallbacks(self) -> None:
+        bundle = evidence_bundle_from_frontier_candidate(
+            candidate_spec_id="spec-fallback",
+            candidate={
+                "candidate_id": "",
+                "runtime_family": "microbar_cross_sectional_pairs",
+                "runtime_strategy_name": "microbar-cross-sectional-pairs-v1",
+                "family_template_id": "microbar_cross_sectional_pairs_v1",
+                "full_window": {
+                    "net_per_day": "123",
+                    "active_day_ratio": "1.0",
+                    "positive_day_ratio": "0.8",
+                    "best_day_share": "0.2",
+                    "max_drawdown": "0",
+                    "daily_net": {"2026-02-23": "123"},
+                    "daily_filled_notional": {"2026-02-23": "350000"},
+                },
+            },
+            dataset_snapshot_id="snap-fallback",
+            result_path="/tmp/fallback.json",
+        )
+
+        self.assertEqual(bundle.candidate_id, "spec-fallback")
+        self.assertEqual(bundle.objective_scorecard["net_pnl_per_day"], "123")
+        self.assertIn("daily_filled_notional", bundle.objective_scorecard)
+        with self.assertRaisesRegex(ValueError, "evidence_bundle_schema_invalid"):
+            evidence_bundle_from_payload({"schema_version": "bad"})
+
+    def test_mlx_ranker_covers_fallback_and_error_edges(self) -> None:
+        rows = [
+            build_mlx_training_rows(
+                candidate_specs=[
+                    compile_candidate_specs(
+                        hypothesis_cards=build_hypothesis_cards(
+                            source_run_id="paper",
+                            claims=[
+                                {
+                                    "claim_id": "claim-flow",
+                                    "claim_type": "signal_mechanism",
+                                    "claim_text": "Order flow cluster signal.",
+                                    "confidence": "0.8",
+                                }
+                            ],
+                        ),
+                        target_net_pnl_per_day=Decimal("500"),
+                    )[0]
+                ],
+                evidence_bundles=[],
+            )[0]
+        ]
+
+        import builtins
+
+        real_import = builtins.__import__
+
+        def fake_import(name: str, *args: Any, **kwargs: Any) -> Any:
+            if name == "mlx.core":
+                raise ModuleNotFoundError("mlx unavailable in test")
+            return real_import(name, *args, **kwargs)
+
+        with patch("builtins.__import__", side_effect=fake_import):
+            model = train_mlx_ranker(rows, backend_preference="mlx", steps=2)
+
+        self.assertEqual(model.backend, "numpy-fallback")
+        self.assertEqual(
+            mlx_ranker_model_from_payload(model.to_payload()).model_id,
+            model.model_id,
+        )
+        with self.assertRaisesRegex(ValueError, "mlx_ranker_training_rows_required"):
+            train_mlx_ranker([])
+        with self.assertRaisesRegex(ValueError, "mlx_ranker_schema_invalid"):
+            mlx_ranker_model_from_payload({"schema_version": "bad"})
 
     def test_portfolio_optimizer_uses_daily_vectors_and_correlation_cap(self) -> None:
         bundles = [

--- a/services/torghut/tests/test_whitepaper_candidate_compiler.py
+++ b/services/torghut/tests/test_whitepaper_candidate_compiler.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from decimal import Decimal
 from pathlib import Path
+from tempfile import TemporaryDirectory
 from unittest import TestCase
 
 from app.trading.discovery.whitepaper_candidate_compiler import (
@@ -25,6 +26,7 @@ class TestWhitepaperCandidateCompiler(TestCase):
             ],
             target_net_pnl_per_day=Decimal("500"),
             family_template_dir=Path("config/trading/families"),
+            seed_sweep_dir=Path("config/trading"),
         )
 
         self.assertEqual(len(compilation.candidate_specs), 1)
@@ -64,3 +66,28 @@ class TestWhitepaperCandidateCompiler(TestCase):
         self.assertEqual(len(compilation.executable_specs), 0)
         self.assertEqual(len(compilation.blocked_specs), 1)
         self.assertEqual(compilation.blockers[0].reason, "family_template_missing")
+
+    def test_missing_seed_sweep_blocks_execution(self) -> None:
+        cards = build_hypothesis_cards(
+            source_run_id="paper-run-3",
+            claims=[
+                {
+                    "claim_id": "claim-flow",
+                    "claim_type": "signal_mechanism",
+                    "claim_text": "Clustered order flow imbalance improves short-horizon LOB signals.",
+                    "confidence": "0.82",
+                }
+            ],
+        )
+
+        with TemporaryDirectory() as tmpdir:
+            compilation = compile_whitepaper_candidate_specs(
+                hypothesis_cards=cards,
+                target_net_pnl_per_day=Decimal("500"),
+                family_template_dir=Path("config/trading/families"),
+                seed_sweep_dir=Path(tmpdir),
+            )
+
+        self.assertEqual(compilation.executable_specs, ())
+        self.assertEqual(len(compilation.blocked_specs), 1)
+        self.assertEqual(compilation.blockers[0].reason, "seed_sweep_missing")

--- a/services/torghut/tests/test_whitepaper_candidate_compiler.py
+++ b/services/torghut/tests/test_whitepaper_candidate_compiler.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from pathlib import Path
+from unittest import TestCase
+
+from app.trading.discovery.whitepaper_candidate_compiler import (
+    compile_claim_payloads_to_whitepaper_experiments,
+    compile_whitepaper_candidate_specs,
+)
+from app.trading.discovery.hypothesis_cards import build_hypothesis_cards
+
+
+class TestWhitepaperCandidateCompiler(TestCase):
+    def test_claim_payloads_compile_to_whitepaper_and_vnext_specs(self) -> None:
+        compilation = compile_claim_payloads_to_whitepaper_experiments(
+            run_id="paper-run-1",
+            claims=[
+                {
+                    "claim_id": "claim-flow",
+                    "claim_type": "signal_mechanism",
+                    "claim_text": "Clustered order flow imbalance improves short-horizon LOB signals.",
+                    "confidence": "0.82",
+                }
+            ],
+            target_net_pnl_per_day=Decimal("500"),
+            family_template_dir=Path("config/trading/families"),
+        )
+
+        self.assertEqual(len(compilation.candidate_specs), 1)
+        self.assertEqual(len(compilation.executable_specs), 1)
+        self.assertEqual(len(compilation.whitepaper_experiment_payloads), 1)
+        self.assertEqual(len(compilation.vnext_experiment_payloads), 1)
+        self.assertEqual(
+            compilation.whitepaper_experiment_payloads[0]["selection_objectives"][
+                "target_net_pnl_per_day"
+            ],
+            "500",
+        )
+        self.assertEqual(
+            compilation.vnext_experiment_payloads[0]["family_template_id"],
+            "microbar_cross_sectional_pairs_v1",
+        )
+
+    def test_missing_family_template_blocks_execution(self) -> None:
+        cards = build_hypothesis_cards(
+            source_run_id="paper-run-2",
+            claims=[
+                {
+                    "claim_id": "claim-flow",
+                    "claim_type": "signal_mechanism",
+                    "claim_text": "Clustered order flow imbalance improves short-horizon LOB signals.",
+                    "confidence": "0.82",
+                }
+            ],
+        )
+
+        compilation = compile_whitepaper_candidate_specs(
+            hypothesis_cards=cards,
+            target_net_pnl_per_day=Decimal("500"),
+            family_template_dir=Path("/tmp/does-not-exist-torghut-families"),
+        )
+
+        self.assertEqual(len(compilation.executable_specs), 0)
+        self.assertEqual(len(compilation.blocked_specs), 1)
+        self.assertEqual(compilation.blockers[0].reason, "family_template_missing")

--- a/services/torghut/tests/test_whitepaper_claim_compiler.py
+++ b/services/torghut/tests/test_whitepaper_claim_compiler.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from unittest import TestCase
+
+from app.whitepapers.claim_compiler import (
+    RECENT_WHITEPAPER_SEEDS,
+    compile_sources_to_hypothesis_cards,
+    source_from_payload,
+)
+
+
+class TestWhitepaperClaimCompiler(TestCase):
+    def test_recent_seed_sources_compile_to_hypothesis_cards(self) -> None:
+        cards = compile_sources_to_hypothesis_cards(RECENT_WHITEPAPER_SEEDS)
+
+        self.assertGreaterEqual(len(cards), 4)
+        self.assertTrue(
+            all(card.source_run_id.startswith("seed-arxiv-") for card in cards)
+        )
+
+    def test_source_payload_round_trip_filters_invalid_rows(self) -> None:
+        source = source_from_payload(
+            {
+                "run_id": "paper-1",
+                "title": "Paper",
+                "source_url": "https://example.test/paper.pdf",
+                "published_at": "2026-01-01",
+                "claims": [
+                    {"claim_id": "claim-1", "claim_text": "valid"},
+                    "invalid",
+                ],
+                "claim_relations": [
+                    {"relation_id": "rel-1"},
+                    None,
+                ],
+            }
+        )
+
+        self.assertEqual(source.run_id, "paper-1")
+        self.assertEqual(len(source.claims), 1)
+        self.assertEqual(len(source.claim_relations), 1)

--- a/services/torghut/tests/test_whitepaper_claim_compiler.py
+++ b/services/torghut/tests/test_whitepaper_claim_compiler.py
@@ -4,6 +4,8 @@ from unittest import TestCase
 
 from app.whitepapers.claim_compiler import (
     RECENT_WHITEPAPER_SEEDS,
+    WhitepaperResearchSource,
+    claim_subgraph_blockers,
     compile_sources_to_hypothesis_cards,
     source_from_payload,
 )
@@ -13,9 +15,123 @@ class TestWhitepaperClaimCompiler(TestCase):
     def test_recent_seed_sources_compile_to_hypothesis_cards(self) -> None:
         cards = compile_sources_to_hypothesis_cards(RECENT_WHITEPAPER_SEEDS)
 
-        self.assertGreaterEqual(len(cards), 4)
+        self.assertEqual(len(cards), 4)
         self.assertTrue(
             all(card.source_run_id.startswith("seed-arxiv-") for card in cards)
+        )
+        self.assertTrue(all(card.required_features for card in cards))
+        self.assertTrue(all(card.risk_controls for card in cards))
+
+    def test_incomplete_risk_only_source_is_blocked(self) -> None:
+        source = WhitepaperResearchSource(
+            run_id="risk-only-paper",
+            title="Risk Only",
+            source_url="https://example.test/risk",
+            published_at="2026-01-01",
+            claims=(
+                {
+                    "claim_id": "risk-1",
+                    "claim_type": "risk_constraint",
+                    "claim_text": "Sizing should account for spread expansion.",
+                    "confidence": "0.80",
+                },
+            ),
+        )
+
+        self.assertEqual(
+            claim_subgraph_blockers(source),
+            ("mechanism_missing", "feature_recipe_or_blocker_missing"),
+        )
+        self.assertEqual(compile_sources_to_hypothesis_cards((source,)), [])
+
+    def test_empty_source_reports_all_required_blockers(self) -> None:
+        source = WhitepaperResearchSource(
+            run_id="",
+            title="Empty",
+            source_url="https://example.test/empty",
+            published_at="2026-01-01",
+            claims=(),
+        )
+
+        self.assertEqual(
+            claim_subgraph_blockers(source),
+            (
+                "source_run_id_missing",
+                "claims_missing",
+                "mechanism_missing",
+                "feature_recipe_or_blocker_missing",
+                "risk_or_validation_constraint_missing",
+            ),
+        )
+        self.assertEqual(compile_sources_to_hypothesis_cards((source,)), [])
+
+    def test_metadata_feature_recipe_can_complete_subgraph(self) -> None:
+        source = WhitepaperResearchSource(
+            run_id="metadata-feature-paper",
+            title="Metadata Feature",
+            source_url="https://example.test/metadata-feature",
+            published_at="2026-01-01",
+            claims=(
+                {
+                    "claim_id": "mechanism-1",
+                    "claim_type": "signal_mechanism",
+                    "claim_text": "Matched order-flow state can identify short-horizon continuation.",
+                    "metadata": {"required_features": ("order_flow_imbalance",)},
+                    "confidence": "0.79",
+                },
+                {
+                    "claim_id": "validation-1",
+                    "claim_type": "execution_assumption",
+                    "claim_text": "Execution must stay inside spread and quote-quality limits.",
+                    "required_features": "spread_bps",
+                    "confidence": "0.72",
+                },
+            ),
+        )
+
+        self.assertEqual(claim_subgraph_blockers(source), ())
+        self.assertEqual(len(compile_sources_to_hypothesis_cards((source,))), 1)
+
+    def test_requires_feature_relation_satisfies_feature_blocker(self) -> None:
+        source = WhitepaperResearchSource(
+            run_id="blocked-feature-paper",
+            title="Feature Blocker",
+            source_url="https://example.test/feature",
+            published_at="2026-01-01",
+            claims=(
+                {
+                    "claim_id": "mechanism-1",
+                    "claim_type": "signal_mechanism",
+                    "claim_text": "Order-flow bursts can predict short-horizon continuation.",
+                    "confidence": "0.80",
+                },
+                {
+                    "claim_id": "validation-1",
+                    "claim_type": "validation_requirement",
+                    "claim_text": "The signal must pass held-out liquidity shock windows.",
+                    "confidence": "0.74",
+                },
+            ),
+            claim_relations=(
+                {
+                    "relation_id": "requires-missing-feature",
+                    "relation_type": "requires_feature",
+                    "source_claim_id": "mechanism-1",
+                    "target_feature": "clustered_order_events",
+                },
+            ),
+        )
+
+        self.assertEqual(claim_subgraph_blockers(source), ())
+        self.assertEqual(len(compile_sources_to_hypothesis_cards((source,))), 1)
+
+    def test_claim_compilation_is_deterministic(self) -> None:
+        first = compile_sources_to_hypothesis_cards(RECENT_WHITEPAPER_SEEDS)
+        second = compile_sources_to_hypothesis_cards(RECENT_WHITEPAPER_SEEDS)
+
+        self.assertEqual(
+            [card.hypothesis_id for card in first],
+            [card.hypothesis_id for card in second],
         )
 
     def test_source_payload_round_trip_filters_invalid_rows(self) -> None:

--- a/services/torghut/tests/test_whitepaper_workflow.py
+++ b/services/torghut/tests/test_whitepaper_workflow.py
@@ -635,6 +635,7 @@ https://example.com/paper.pdf
         compiled = service._compiled_experiment_specs_from_templates(  # type: ignore[attr-defined]
             run_id='run-1',
             claims=[{'claim_id': 'claim-1'}],
+            relations=[],
             templates=[
                 {
                     'template_id': 'template-1',
@@ -666,6 +667,25 @@ https://example.com/paper.pdf
         self.assertEqual(len(contradictions), 1)
         self.assertEqual(contradictions[0]['source_claim_id'], 'claim-2')
         self.assertEqual(merged, {'dspy_eval_report': {'score': 0.8}})
+
+    def test_structured_outputs_compile_claims_when_experiment_specs_are_absent(self) -> None:
+        service = WhitepaperWorkflowService()
+        compiled = service._compiled_experiment_specs_from_templates(  # type: ignore[attr-defined]
+            run_id='run-claim-compiler',
+            claims=[
+                {
+                    'claim_id': 'claim-flow',
+                    'claim_type': 'signal_mechanism',
+                    'claim_text': 'Clustered order flow imbalance improves short horizon LOB signals.',
+                    'confidence': '0.82',
+                }
+            ],
+            relations=[],
+            templates=[],
+        )
+
+        self.assertEqual(len(compiled), 1)
+        self.assertEqual(compiled[0]['selection_objectives']['target_net_pnl_per_day'], '500')
 
     def test_sync_structured_outputs_skips_incomplete_records(self) -> None:
         service = WhitepaperWorkflowService()


### PR DESCRIPTION
## Summary

- Adds the doc 71 Torghut whitepaper autoresearch implementation contract and implements the typed artifact, claim compiler, candidate compiler, MLX ranking, portfolio optimizer, runner, persistence, runtime closure, and read API surface behind it.
- Gates whitepaper claim compilation so only complete claim subgraphs with a mechanism, executable feature recipe or feature blocker, and risk or validation constraint become executable `HypothesisCard`s.
- Gates success on the profit-target oracle: the synthetic recent-whitepaper harness finds a diversified portfolio at `795.00` net PnL/day with `oracle_candidate_found=true` and no oracle blockers.
- Enforces bounded pre-replay MLX selection, executable seed-sweep coverage, evidence-bundle validity, portfolio concentration gates, family-agnostic strategy factory validation, and complete runtime-closure policy refs.
- Writes candidate selection, proposal ranking, MLX snapshot, replay evidence, portfolio, runtime-closure, false-positive, false-negative, and diagnostics notebook artifacts for operator inspection.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen ruff format scripts/run_whitepaper_autoresearch_profit_target.py app/trading/discovery/whitepaper_autoresearch_notebooks.py app/trading/autoresearch_routes.py tests/test_run_whitepaper_autoresearch_profit_target.py tests/test_trading_api.py`
- `uv run --frozen ruff check scripts/run_whitepaper_autoresearch_profit_target.py app/trading/discovery/whitepaper_autoresearch_notebooks.py app/trading/autoresearch_routes.py tests/test_run_whitepaper_autoresearch_profit_target.py tests/test_trading_api.py`
- `uv run --frozen ruff check app/trading/discovery/profit_target_oracle.py app/trading/discovery/portfolio_optimizer.py scripts/run_whitepaper_autoresearch_profit_target.py tests/test_profit_target_oracle.py tests/test_portfolio_optimizer.py`
- `uv run --frozen ruff check app/trading/discovery/whitepaper_candidate_compiler.py app/whitepapers/workflow.py scripts/run_whitepaper_autoresearch_profit_target.py tests/test_whitepaper_candidate_compiler.py`
- `uv run --frozen ruff check app/whitepapers/claim_compiler.py tests/test_whitepaper_claim_compiler.py`
- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py tests/test_trading_api.py -q`
- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py -q`
- `uv run --frozen pytest tests/test_profit_target_oracle.py tests/test_portfolio_optimizer.py -q`
- `uv run --frozen pytest tests/test_whitepaper_candidate_compiler.py tests/test_candidate_specs.py tests/test_whitepaper_workflow.py tests/test_run_whitepaper_autoresearch_profit_target.py -q`
- `uv run --frozen pytest tests/test_runtime_closure.py tests/test_run_whitepaper_autoresearch_profit_target.py tests/test_promotion_truthfulness.py -q`
- `uv run --frozen pytest tests/test_strategy_factory_validation.py tests/test_alpha_lane.py tests/test_run_strategy_factory_v2.py tests/test_discovery_harness_v2.py -q`
- `uv run --frozen pytest tests/test_portfolio_optimizer.py tests/test_whitepaper_autoresearch_artifacts.py tests/test_run_whitepaper_autoresearch_profit_target.py -q`
- `uv run --frozen pytest tests/test_hypothesis_cards.py tests/test_candidate_specs.py tests/test_whitepaper_claim_compiler.py tests/test_whitepaper_candidate_compiler.py tests/test_mlx_autoresearch.py tests/test_mlx_training_data.py tests/test_portfolio_optimizer.py tests/test_runtime_closure.py tests/test_run_strategy_factory_v2.py tests/test_run_whitepaper_autoresearch_profit_target.py tests/test_trading_api.py -q`
- `uv run --frozen pytest tests/test_hypothesis_cards.py tests/test_candidate_specs.py tests/test_whitepaper_claim_compiler.py tests/test_whitepaper_candidate_compiler.py tests/test_mlx_autoresearch.py tests/test_mlx_training_data.py tests/test_profit_target_oracle.py tests/test_portfolio_optimizer.py tests/test_runtime_closure.py tests/test_run_strategy_factory_v2.py tests/test_run_whitepaper_autoresearch_profit_target.py tests/test_trading_api.py -q`
- `uv run --frozen pytest tests/test_whitepaper_claim_compiler.py -q`
- `uv run --frozen pytest tests/test_whitepaper_claim_compiler.py tests/test_hypothesis_cards.py tests/test_whitepaper_candidate_compiler.py tests/test_run_whitepaper_autoresearch_profit_target.py -q`
- `uv run --frozen python scripts/run_whitepaper_autoresearch_profit_target.py --output-dir /tmp/torghut-doc71-diagnostics.OGnjO8/epoch --seed-recent-whitepapers --replay-mode synthetic --no-persist-results --target-net-pnl-per-day 500 --top-k 4 --exploration-slots 2 --portfolio-size-min 2 --portfolio-size-max 4`
- `uv run --frozen python scripts/run_whitepaper_autoresearch_profit_target.py --output-dir /tmp/torghut-doc71-budget.EymHZa/epoch --seed-recent-whitepapers --replay-mode synthetic --no-persist-results --target-net-pnl-per-day 500 --top-k 1 --exploration-slots 1 --portfolio-size-min 2 --portfolio-size-max 4`
- `uv run --frozen python scripts/run_whitepaper_autoresearch_profit_target.py --output-dir /tmp/torghut-doc71-snapshot.ZDy1DW/epoch --seed-recent-whitepapers --replay-mode synthetic --no-persist-results --target-net-pnl-per-day 500 --top-k 4 --exploration-slots 2 --portfolio-size-min 2 --portfolio-size-max 4`
- `uv run --frozen python scripts/run_whitepaper_autoresearch_profit_target.py --output-dir /tmp/torghut-doc71-concentration.dmpx0z/epoch --seed-recent-whitepapers --replay-mode synthetic --no-persist-results --target-net-pnl-per-day 500 --top-k 4 --exploration-slots 2 --portfolio-size-min 2 --portfolio-size-max 4`
- `uv run --frozen python scripts/run_whitepaper_autoresearch_profit_target.py --output-dir /tmp/torghut-doc71-seed-sweep-clean.gd1fIR/epoch --seed-recent-whitepapers --replay-mode synthetic --no-persist-results --target-net-pnl-per-day 500 --top-k 4 --exploration-slots 2 --portfolio-size-min 2 --portfolio-size-max 4`
- `uv run --frozen python scripts/run_whitepaper_autoresearch_profit_target.py --output-dir /tmp/torghut-doc71-policy-refs.4BqU2A/epoch --seed-recent-whitepapers --replay-mode synthetic --no-persist-results --target-net-pnl-per-day 500 --top-k 4 --exploration-slots 2 --portfolio-size-min 2 --portfolio-size-max 4`
- `uv run --frozen python scripts/run_whitepaper_autoresearch_profit_target.py --output-dir /tmp/torghut-doc71-evidence-validity.DNj87U/epoch --seed-recent-whitepapers --replay-mode synthetic --no-persist-results --target-net-pnl-per-day 500 --top-k 4 --exploration-slots 2 --portfolio-size-min 2 --portfolio-size-max 4`
- `uv run --frozen python scripts/run_whitepaper_autoresearch_profit_target.py --output-dir /tmp/torghut-doc71-claim-subgraph-pass.NuwBdp/epoch --seed-recent-whitepapers --replay-mode synthetic --no-persist-results --target-net-pnl-per-day 500 --top-k 4 --exploration-slots 2 --portfolio-size-min 2 --portfolio-size-max 4`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen ruff check .`
- `uv run --frozen python -m compileall app scripts tests`
- `uv run --frozen python scripts/check_migration_graph.py`
- `uv run --frozen pytest --cov --cov-branch --cov-report=term-missing --cov-report=xml`
- `uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90`

Latest harness evidence:

- Claim-subgraph-gated synthetic run: status `ok`, sources `4`, claims `10`, hypotheses `4`, executable candidate specs `4`, compiler blockers `[]`, replayed specs `4`, evidence bundles `4`, selected count `4`, portfolio sleeves `3`, target net PnL/day `500`, observed net PnL/day `795.00`, oracle passed `true`, oracle blockers `[]`.
- Evidence-validity synthetic run: status `ok`, evidence bundles `4`, invalid-evidence rejections `0`, portfolio `port-87ddd6370f02e8b4945399fc`, sleeves `3`, net PnL/day `795.00`, oracle blockers `[]`.
- Family-agnostic validation test: `washout_rebound_consistent` emits `washout_rebound_v2`, `washout-rebound-long-v1`, `washout_rebound_default_v1`, and `washout_rebound_grid_v1` rather than TSMOM defaults.
- Runtime-closure policy-ref run: status `ok`, portfolio `port-87ddd6370f02e8b4945399fc`, sleeves `3`, net PnL/day `795.00`, oracle blockers `[]`, `strategy_count=3`, `spec_compiled_count=3`, `missing_policy_refs=[]`, and 3 promotion/risk/sizing/execution refs emitted.
- Seed-sweep-enforced synthetic run: status `ok`, candidate specs `4`, compiler blockers `0`, executable specs `4`, `oracle_candidate_found=true`, portfolio `port-87ddd6370f02e8b4945399fc`, sleeves `3`, net PnL/day `795.00`, oracle blockers `[]`.
- Concentration-gated synthetic run: status `ok`, portfolio `port-87ddd6370f02e8b4945399fc`, sleeves `3`, net PnL/day `795.00`, oracle blockers `[]`, max cluster contribution share `0.3396226415094339622641509434`, max single-day contribution share `0.2082264150943396226415094340`, max single-symbol contribution share `0.25`.
- Bounded replay run: status `ok`, candidate specs `4`, replayed specs `3`, false-positive rows `0`, best false-negative rows `1` with `evidence_status=not_replayed`.
- Root MLX snapshot run: status `ok`, snapshot `mlx-snap-e820d03ded67fbccccafb530`, candidate specs `4`, evidence bundles `4`, candidate-selection manifest path present.
- Full coverage: `1771 passed`, total coverage `75.17%`.
- Diff coverage: `1850/1976` changed executable lines covered, `93.62%`.

## Screenshots (if applicable)

N/A

## Breaking Changes

Adds migration `0028_autoresearch_epoch_ledgers.py` for autoresearch epoch, candidate spec, proposal score, and portfolio candidate ledgers. No breaking API behavior changes are expected.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
