### PR TITLE
chore(jangar): promote image 829ff535

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 640cb586
-  digest: sha256:78913053b4bd222d01d2351eb19136edfda3fa4cb8253541b4ac0736f092ac26
+  tag: 829ff535
+  digest: sha256:9031dfe675ad6a07e2c5720159bb223d7c9b5724d413ed3ff53e5dfcf0b3a0c8
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 640cb586
-    digest: sha256:68801ca6665749061f0151378bd63ce2afd3a48d336b181e6bf0c86a88359a93
+    tag: 829ff535
+    digest: sha256:5bcaf633025a4b6fd2dd40894cce39800ef6559304fcb89c95ecabfd0b1b4bd3
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 640cb586
-    digest: sha256:78913053b4bd222d01d2351eb19136edfda3fa4cb8253541b4ac0736f092ac26
+    tag: 829ff535
+    digest: sha256:9031dfe675ad6a07e2c5720159bb223d7c9b5724d413ed3ff53e5dfcf0b3a0c8
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-04-19T01:07:46Z
+    deploy.knative.dev/rollout: 2026-04-22T01:05:44Z
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/name: jangar-worker
     app.kubernetes.io/part-of: lab
   annotations:
-    kubectl.kubernetes.io/restartedAt: 2026-04-19T01:07:46Z
+    kubectl.kubernetes.io/restartedAt: 2026-04-22T01:05:44Z
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -60,5 +60,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: 640cb586
-    digest: sha256:78913053b4bd222d01d2351eb19136edfda3fa4cb8253541b4ac0736f092ac26
+    newTag: 829ff535
+    digest: sha256:9031dfe675ad6a07e2c5720159bb223d7c9b5724d413ed3ff53e5dfcf0b3a0c8


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `829ff535bea644b9a0131c7249ef7db71f57a39b`
- Image tag: `829ff535`
- Image digest: `sha256:9031dfe675ad6a07e2c5720159bb223d7c9b5724d413ed3ff53e5dfcf0b3a0c8`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`