### PR TITLE
chore(torghut): promote image f7784c62

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:e36878bbac4be215f8fda81d928dfb0acf78c85e5760838c463d066194c71014
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:81785d38a8b42d62d6361e7b54f27eaac3185568c8cc667b5390b7f48574dccd
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -63,9 +63,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.566.0-444-g829ff535b
+              value: v0.566.0-454-gf7784c62e
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 829ff535bea644b9a0131c7249ef7db71f57a39b
+              value: f7784c62efd1254615fbc6437db29a1b8bff466b
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:e36878bbac4be215f8fda81d928dfb0acf78c85e5760838c463d066194c71014
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:81785d38a8b42d62d6361e7b54f27eaac3185568c8cc667b5390b7f48574dccd
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -63,9 +63,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.566.0-444-g829ff535b
+              value: v0.566.0-454-gf7784c62e
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 829ff535bea644b9a0131c7249ef7db71f57a39b
+              value: f7784c62efd1254615fbc6437db29a1b8bff466b
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -40,7 +40,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:e36878bbac4be215f8fda81d928dfb0acf78c85e5760838c463d066194c71014
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:81785d38a8b42d62d6361e7b54f27eaac3185568c8cc667b5390b7f48574dccd
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -21,7 +21,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:e36878bbac4be215f8fda81d928dfb0acf78c85e5760838c463d066194c71014
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:81785d38a8b42d62d6361e7b54f27eaac3185568c8cc667b5390b7f48574dccd
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -32,7 +32,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:e36878bbac4be215f8fda81d928dfb0acf78c85e5760838c463d066194c71014
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:81785d38a8b42d62d6361e7b54f27eaac3185568c8cc667b5390b7f48574dccd
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -30,7 +30,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:e36878bbac4be215f8fda81d928dfb0acf78c85e5760838c463d066194c71014
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:81785d38a8b42d62d6361e7b54f27eaac3185568c8cc667b5390b7f48574dccd
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:e36878bbac4be215f8fda81d928dfb0acf78c85e5760838c463d066194c71014
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:81785d38a8b42d62d6361e7b54f27eaac3185568c8cc667b5390b7f48574dccd
           command:
             - /opt/venv/bin/alembic
           args:

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -13,7 +13,7 @@ spec:
       serviceAccountName: torghut-runtime
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:e36878bbac4be215f8fda81d928dfb0acf78c85e5760838c463d066194c71014
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:81785d38a8b42d62d6361e7b54f27eaac3185568c8cc667b5390b7f48574dccd
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -21,7 +21,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:e36878bbac4be215f8fda81d928dfb0acf78c85e5760838c463d066194c71014
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:81785d38a8b42d62d6361e7b54f27eaac3185568c8cc667b5390b7f48574dccd
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -39,7 +39,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:e36878bbac4be215f8fda81d928dfb0acf78c85e5760838c463d066194c71014
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:81785d38a8b42d62d6361e7b54f27eaac3185568c8cc667b5390b7f48574dccd
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-04-22T01:02:25Z"
+        client.knative.dev/updateTimestamp: "2026-04-26T19:44:03Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:e36878bbac4be215f8fda81d928dfb0acf78c85e5760838c463d066194c71014
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:81785d38a8b42d62d6361e7b54f27eaac3185568c8cc667b5390b7f48574dccd
           ports:
             - name: http1
               containerPort: 8181
@@ -495,9 +495,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.566.0-444-g829ff535b
+              value: v0.566.0-454-gf7784c62e
             - name: TORGHUT_COMMIT
-              value: 829ff535bea644b9a0131c7249ef7db71f57a39b
+              value: f7784c62efd1254615fbc6437db29a1b8bff466b
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-04-22T01:02:25Z"
+        client.knative.dev/updateTimestamp: "2026-04-26T19:44:03Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -26,7 +26,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:e36878bbac4be215f8fda81d928dfb0acf78c85e5760838c463d066194c71014
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:81785d38a8b42d62d6361e7b54f27eaac3185568c8cc667b5390b7f48574dccd
           ports:
             - name: http1
               containerPort: 8181
@@ -276,9 +276,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.566.0-444-g829ff535b
+              value: v0.566.0-454-gf7784c62e
             - name: TORGHUT_COMMIT
-              value: 829ff535bea644b9a0131c7249ef7db71f57a39b
+              value: f7784c62efd1254615fbc6437db29a1b8bff466b
           livenessProbe:
             httpGet:
               path: /healthz


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `f7784c62efd1254615fbc6437db29a1b8bff466b`
- Image tag: `f7784c62`
- Image digest: `sha256:81785d38a8b42d62d6361e7b54f27eaac3185568c8cc667b5390b7f48574dccd`