### PR TITLE
fix(jangar): route semantic embeddings through saigak proxy

### DIFF
--- a/argocd/applications/argo-workflows/jangar-embeddings-config.yaml
+++ b/argocd/applications/argo-workflows/jangar-embeddings-config.yaml
@@ -4,7 +4,7 @@ metadata:
   name: jangar-embeddings-config
   namespace: argo-workflows
 data:
-  openaiApiBaseUrl: http://saigak.saigak.svc.cluster.local:11435/api
+  openaiApiBaseUrl: http://saigak.saigak.svc.cluster.local:11434/v1
   openaiEmbeddingModel: qwen3-embedding-saigak:8b
   openaiEmbeddingDimension: "4096"
   openaiEmbeddingTimeoutMs: "120000"

--- a/argocd/applications/bumba/deployment.yaml
+++ b/argocd/applications/bumba/deployment.yaml
@@ -165,7 +165,7 @@ spec:
             - name: OPENAI_EMBEDDING_DIMENSION
               value: "4096"
             - name: OPENAI_EMBEDDING_API_BASE_URL
-              value: http://saigak.saigak.svc.cluster.local:11435/api
+              value: http://saigak.saigak.svc.cluster.local:11434/v1
             - name: OPENAI_EMBEDDING_BATCH_SIZE
               value: "32"
             - name: OPENAI_EMBEDDING_KEEP_ALIVE

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -353,7 +353,7 @@ spec:
             - name: OPENAI_API_BASE_URL
               value: http://saigak.saigak.svc.cluster.local:11434/v1
             - name: OPENAI_EMBEDDING_API_BASE_URL
-              value: http://saigak.saigak.svc.cluster.local:11435/api
+              value: http://saigak.saigak.svc.cluster.local:11434/v1
             - name: OPENAI_EMBEDDING_MODEL
               value: qwen3-embedding-saigak:8b
             - name: OPENAI_EMBEDDING_DIMENSION

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -189,7 +189,7 @@ spec:
             - name: OPENAI_EMBEDDING_DIMENSION
               value: "4096"
             - name: OPENAI_EMBEDDING_API_BASE_URL
-              value: http://saigak.saigak.svc.cluster.local:11435/api
+              value: http://saigak.saigak.svc.cluster.local:11434/v1
             - name: OPENAI_EMBEDDING_BATCH_SIZE
               value: "32"
             - name: OPENAI_EMBEDDING_KEEP_ALIVE

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -368,11 +368,11 @@ spec:
             - name: WHITEPAPER_INNGEST_FINALIZE_FUNCTION_ID
               value: torghut-whitepaper-synthesis-index-v1
             - name: WHITEPAPER_SEMANTIC_INDEXING_ENABLED
-              value: "false"
+              value: "true"
             - name: WHITEPAPER_SEMANTIC_REQUIRED
               value: "false"
             - name: WHITEPAPER_EMBEDDING_API_BASE_URL
-              value: http://saigak.saigak.svc.cluster.local:11435/api
+              value: http://saigak.saigak.svc.cluster.local:11434/v1
             - name: WHITEPAPER_EMBEDDING_MODEL
               value: qwen3-embedding-saigak:8b
             - name: WHITEPAPER_EMBEDDING_DIMENSION

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -241,11 +241,11 @@ spec:
             - name: WHITEPAPER_INNGEST_FINALIZE_FUNCTION_ID
               value: torghut-whitepaper-synthesis-index-v1
             - name: WHITEPAPER_SEMANTIC_INDEXING_ENABLED
-              value: "false"
+              value: "true"
             - name: WHITEPAPER_SEMANTIC_REQUIRED
               value: "false"
             - name: WHITEPAPER_EMBEDDING_API_BASE_URL
-              value: http://saigak.saigak.svc.cluster.local:11435/api
+              value: http://saigak.saigak.svc.cluster.local:11434/v1
             - name: WHITEPAPER_EMBEDDING_MODEL
               value: qwen3-embedding-saigak:8b
             - name: WHITEPAPER_EMBEDDING_DIMENSION

--- a/argocd/applications/torghut/kustomization.yaml
+++ b/argocd/applications/torghut/kustomization.yaml
@@ -28,6 +28,7 @@ resources:
   - llm-guardrails-exporter.yaml
   - whitepapers-objectbucketclaim.yaml
   - whitepapers-bucket-bootstrap-job.yaml
+  - whitepaper-semantic-backfill-job.yaml
   - empirical-artifacts-objectbucketclaim.yaml
   - empirical-jobs-backfill-job.yaml
   - empirical-artifacts-retention-cronjob.yaml

--- a/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
+++ b/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
@@ -1,0 +1,70 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: torghut-whitepaper-semantic-backfill
+  namespace: torghut
+  annotations:
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookSucceeded
+spec:
+  backoffLimit: 2
+  activeDeadlineSeconds: 1800
+  ttlSecondsAfterFinished: 600
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: torghut-whitepaper-semantic-backfill
+        app.kubernetes.io/part-of: lab
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: torghut-runtime
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 999
+        runAsGroup: 999
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: backfill
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:e36878bbac4be215f8fda81d928dfb0acf78c85e5760838c463d066194c71014
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          command:
+            - /bin/bash
+            - -lc
+          args:
+            - |
+              set -euo pipefail
+              cd /app
+              /opt/venv/bin/python scripts/backfill_whitepaper_semantic_index.py --limit 500 --concurrency 2
+          env:
+            - name: DB_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: torghut-db-app
+                  key: uri
+            - name: WHITEPAPER_EMBEDDING_API_BASE_URL
+              value: http://saigak.saigak.svc.cluster.local:11434/v1
+            - name: WHITEPAPER_EMBEDDING_MODEL
+              value: qwen3-embedding-saigak:8b
+            - name: WHITEPAPER_EMBEDDING_DIMENSION
+              value: "4096"
+            - name: WHITEPAPER_EMBEDDING_TIMEOUT_MS
+              value: "120000"
+            - name: WHITEPAPER_CHUNK_SIZE_CHARS
+              value: "2400"
+            - name: WHITEPAPER_CHUNK_OVERLAP_CHARS
+              value: "300"
+            - name: WHITEPAPER_EMBEDDING_BATCH_SIZE
+              value: "32"
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi

--- a/services/jangar/README.md
+++ b/services/jangar/README.md
@@ -88,7 +88,7 @@ tilt up -- --db_local_port 15433
 tilt up -- --enable_redis=false --enable_nats=false --enable_clickhouse=false
 
 # self-hosted embeddings (recommended if your DB schema uses vector(4096))
-tilt up -- --openai_api_base_url http://127.0.0.1:11434/v1 --openai_embedding_api_base_url http://127.0.0.1:11435/api --openai_embedding_model qwen3-embedding-saigak:8b --openai_embedding_dimension 4096
+tilt up -- --openai_api_base_url http://127.0.0.1:11434/v1 --openai_embedding_api_base_url http://127.0.0.1:11434/v1 --openai_embedding_model qwen3-embedding-saigak:8b --openai_embedding_dimension 4096
 ```
 
 Troubleshooting:
@@ -369,7 +369,7 @@ When cache reads are enabled for `/api/agents/control-plane/resource` and `/api/
 - `as_of`: original cache row timestamp when present
 - `OPENAI_API_KEY` (API key used for embedding calls; required for hosted OpenAI, optional for self-hosted OpenAI-compatible endpoints like Ollama)
 - `OPENAI_API_BASE_URL` / `OPENAI_API_BASE` (optional; defaults to `https://api.openai.com/v1`)
-- `OPENAI_EMBEDDING_API_BASE_URL` (optional; override specifically for embeddings. Use Ollama `/api` when you need self-hosted dimension control with `qwen3-embedding-saigak:8b`.)
+- `OPENAI_EMBEDDING_API_BASE_URL` (optional; override specifically for embeddings. Use the Saigak `/v1` proxy for deployed self-hosted embeddings with `qwen3-embedding-saigak:8b`.)
 - `OPENAI_EMBEDDING_MODEL` (optional; defaults to `text-embedding-3-small` on OpenAI, or `qwen3-embedding-saigak:8b` for self-hosted bases)
 - `OPENAI_EMBEDDING_DIMENSION` (optional; defaults to `1536` on OpenAI, or `4096` for the self-hosted model)
 - `OPENAI_EMBEDDING_TIMEOUT_MS` (optional; defaults to `15000`)
@@ -385,7 +385,7 @@ To use the self-hosted embeddings model on `saigak`:
 
 ```bash
 export OPENAI_API_BASE_URL='http://saigak.saigak.svc.cluster.local:11434/v1'
-export OPENAI_EMBEDDING_API_BASE_URL='http://saigak.saigak.svc.cluster.local:11435/api'
+export OPENAI_EMBEDDING_API_BASE_URL='http://saigak.saigak.svc.cluster.local:11434/v1'
 export OPENAI_EMBEDDING_MODEL='qwen3-embedding-saigak:8b'
 export OPENAI_EMBEDDING_DIMENSION='4096'
 # OPENAI_API_KEY is optional for Ollama

--- a/services/jangar/src/server/__tests__/memory-config.test.ts
+++ b/services/jangar/src/server/__tests__/memory-config.test.ts
@@ -5,7 +5,7 @@ import { resolveEmbeddingConfig } from '~/server/memory-config'
 describe('memory-config', () => {
   it('defaults self-hosted embeddings to 4096 dimensions', () => {
     const config = resolveEmbeddingConfig({
-      OPENAI_EMBEDDING_API_BASE_URL: 'http://saigak.saigak.svc.cluster.local:11435/api',
+      OPENAI_EMBEDDING_API_BASE_URL: 'http://saigak.saigak.svc.cluster.local:11434/v1',
     })
 
     expect(config).toMatchObject({

--- a/services/torghut/migrations/versions/0017_whitepaper_semantic_indexing.py
+++ b/services/torghut/migrations/versions/0017_whitepaper_semantic_indexing.py
@@ -108,14 +108,15 @@ def upgrade() -> None:
         "whitepaper_semantic_embeddings",
         ["model", "dimension"],
     )
-    op.execute(
-        """
-        CREATE INDEX IF NOT EXISTS ix_whitepaper_semantic_embeddings_embedding_ivfflat
-        ON whitepaper_semantic_embeddings
-        USING ivfflat (embedding vector_cosine_ops)
-        WITH (lists = 100)
-        """
-    )
+    if embedding_dimension <= 2000:
+        op.execute(
+            """
+            CREATE INDEX IF NOT EXISTS ix_whitepaper_semantic_embeddings_embedding_ivfflat
+            ON whitepaper_semantic_embeddings
+            USING ivfflat (embedding vector_cosine_ops)
+            WITH (lists = 100)
+            """
+        )
 
 
 def downgrade() -> None:

--- a/services/torghut/migrations/versions/0029_whitepaper_embedding_dimension_4096.py
+++ b/services/torghut/migrations/versions/0029_whitepaper_embedding_dimension_4096.py
@@ -1,0 +1,76 @@
+"""Keep whitepaper semantic embeddings at 4096 dimensions.
+
+Revision ID: 0029_whitepaper_embedding_dimension_4096
+Revises: 0028_autoresearch_epoch_ledgers
+Create Date: 2026-04-26 13:50:00.000000
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+
+revision = "0029_whitepaper_embedding_dimension_4096"
+down_revision = "0028_autoresearch_epoch_ledgers"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        DO $$
+        DECLARE
+          current_type text;
+        BEGIN
+          SELECT format_type(a.atttypid, a.atttypmod)
+          INTO current_type
+          FROM pg_attribute a
+          JOIN pg_class c ON c.oid = a.attrelid
+          JOIN pg_namespace n ON n.oid = c.relnamespace
+          WHERE n.nspname = 'public'
+            AND c.relname = 'whitepaper_semantic_embeddings'
+            AND a.attname = 'embedding';
+
+          IF current_type IS DISTINCT FROM 'vector(4096)' THEN
+            DELETE FROM whitepaper_semantic_embeddings;
+            DROP INDEX IF EXISTS ix_whitepaper_semantic_embeddings_embedding_ivfflat;
+            ALTER TABLE whitepaper_semantic_embeddings
+              ALTER COLUMN embedding TYPE vector(4096)
+              USING embedding::vector(4096);
+          END IF;
+        END $$;
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        DO $$
+        DECLARE
+          current_type text;
+        BEGIN
+          SELECT format_type(a.atttypid, a.atttypmod)
+          INTO current_type
+          FROM pg_attribute a
+          JOIN pg_class c ON c.oid = a.attrelid
+          JOIN pg_namespace n ON n.oid = c.relnamespace
+          WHERE n.nspname = 'public'
+            AND c.relname = 'whitepaper_semantic_embeddings'
+            AND a.attname = 'embedding';
+
+          IF current_type IS DISTINCT FROM 'vector(1024)' THEN
+            DELETE FROM whitepaper_semantic_embeddings;
+            DROP INDEX IF EXISTS ix_whitepaper_semantic_embeddings_embedding_ivfflat;
+            ALTER TABLE whitepaper_semantic_embeddings
+              ALTER COLUMN embedding TYPE vector(1024)
+              USING embedding::vector(1024);
+            CREATE INDEX IF NOT EXISTS ix_whitepaper_semantic_embeddings_embedding_ivfflat
+              ON whitepaper_semantic_embeddings
+              USING ivfflat (embedding vector_cosine_ops)
+              WITH (lists = 100);
+          END IF;
+        END $$;
+        """
+    )


### PR DESCRIPTION
## Summary

- Route Jangar, Bumba, and Argo workflow embedding clients through the working Saigak OpenAI-compatible `/v1` proxy.
- Enable Torghut whitepaper semantic indexing and add a PostSync backfill job for existing whitepaper runs.
- Keep Torghut whitepaper embeddings at 4096 dimensions, with a migration that moves the existing vector column to `vector(4096)` and omits the unsupported ivfflat index at that size.

## Related Issues

None

## Testing

- `git diff --check`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/jangar`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/torghut`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/bumba`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/argo-workflows`
- `bunx vitest run --config vitest.config.ts src/server/__tests__/embedding-client.test.ts src/server/__tests__/memory-config.test.ts src/server/__tests__/memories-rest.test.ts src/routes/api/whitepapers/-search.test.ts`
- `uv run --frozen --extra dev pytest tests/test_backfill_whitepaper_semantic_index.py`
- `uv run --frozen --extra dev python scripts/check_migration_graph.py`
- Live rollout checks: Torghut backfill job indexed `wp-a81e1f4238ee82eafa084ea5`; live Torghut semantic DB has 254 chunks, 254 embeddings, and `vector(4096)`.

## Screenshots (if applicable)

N/A

## Breaking Changes

The Torghut migration deletes existing whitepaper semantic embeddings if the column is not already `vector(4096)` so they can be regenerated at 4096 dimensions. The live rollout already performed and backfilled this successfully.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
