### PR TITLE
chore(jangar): promote image f563e792

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,22 +1,22 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 829ff535
-  digest: sha256:9031dfe675ad6a07e2c5720159bb223d7c9b5724d413ed3ff53e5dfcf0b3a0c8
+  tag: f563e792
+  digest: sha256:c63f96c1617ba58edb0a4892dcd5f9df447accc4f997adab574f2e5f4c1d1bac
   pullPolicy: IfNotPresent
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 829ff535
-    digest: sha256:5bcaf633025a4b6fd2dd40894cce39800ef6559304fcb89c95ecabfd0b1b4bd3
+    tag: f563e792
+    digest: sha256:2f62757e97e2a26492ab99b5b1e41d3ddb4dfde16f6d6f02eda9dc5caf81079a
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 829ff535
-    digest: sha256:9031dfe675ad6a07e2c5720159bb223d7c9b5724d413ed3ff53e5dfcf0b3a0c8
+    tag: f563e792
+    digest: sha256:c63f96c1617ba58edb0a4892dcd5f9df447accc4f997adab574f2e5f4c1d1bac
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-04-22T01:05:44Z
+    deploy.knative.dev/rollout: 2026-04-26T21:16:00Z
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/jangar-worker-deployment.yaml
+++ b/argocd/applications/jangar/jangar-worker-deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/name: jangar-worker
     app.kubernetes.io/part-of: lab
   annotations:
-    kubectl.kubernetes.io/restartedAt: 2026-04-22T01:05:44Z
+    kubectl.kubernetes.io/restartedAt: 2026-04-26T21:16:00Z
 spec:
   replicas: 1
   strategy:

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -60,5 +60,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: 829ff535
-    digest: sha256:9031dfe675ad6a07e2c5720159bb223d7c9b5724d413ed3ff53e5dfcf0b3a0c8
+    newTag: f563e792
+    digest: sha256:c63f96c1617ba58edb0a4892dcd5f9df447accc4f997adab574f2e5f4c1d1bac


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `f563e7922d14b1228e0e0a75688cc1d7ace5049a`
- Image tag: `f563e792`
- Image digest: `sha256:c63f96c1617ba58edb0a4892dcd5f9df447accc4f997adab574f2e5f4c1d1bac`
- Updated API and worker rollout annotations
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`