### PR TITLE
fix(torghut): cast whitepaper search filters

### DIFF
--- a/services/torghut/app/whitepapers/workflow.py
+++ b/services/torghut/app/whitepapers/workflow.py
@@ -1962,9 +1962,9 @@ class WhitepaperWorkflowService:
                 JOIN whitepaper_documents d ON d.id = r.document_id
                 WHERE se.model = :embedding_model
                   AND se.dimension = :embedding_dimension
-                  AND (:status_filter IS NULL OR r.status = :status_filter)
-                  AND (:scope_filter IS NULL OR sc.source_scope = :scope_filter)
-                  AND (:subject_filter IS NULL OR (d.metadata_json ->> 'subject') = :subject_filter)
+                  AND (CAST(:status_filter AS text) IS NULL OR r.status = CAST(:status_filter AS text))
+                  AND (CAST(:scope_filter AS text) IS NULL OR sc.source_scope = CAST(:scope_filter AS text))
+                  AND (CAST(:subject_filter AS text) IS NULL OR (d.metadata_json ->> 'subject') = CAST(:subject_filter AS text))
                 ORDER BY se.embedding <=> CAST(:query_vector AS vector) ASC
                 LIMIT :semantic_limit
                 """
@@ -2003,9 +2003,9 @@ class WhitepaperWorkflowService:
                 FROM whitepaper_semantic_chunks sc
                 JOIN whitepaper_analysis_runs r ON r.id = sc.analysis_run_id
                 JOIN whitepaper_documents d ON d.id = r.document_id
-                WHERE (:status_filter IS NULL OR r.status = :status_filter)
-                  AND (:scope_filter IS NULL OR sc.source_scope = :scope_filter)
-                  AND (:subject_filter IS NULL OR (d.metadata_json ->> 'subject') = :subject_filter)
+                WHERE (CAST(:status_filter AS text) IS NULL OR r.status = CAST(:status_filter AS text))
+                  AND (CAST(:scope_filter AS text) IS NULL OR sc.source_scope = CAST(:scope_filter AS text))
+                  AND (CAST(:subject_filter AS text) IS NULL OR (d.metadata_json ->> 'subject') = CAST(:subject_filter AS text))
                   AND sc.text_tsvector @@ websearch_to_tsquery('simple', :lexical_query)
                 ORDER BY lexical_score DESC
                 LIMIT :lexical_limit


### PR DESCRIPTION
## Summary

- Cast nullable whitepaper semantic search filters to text before comparing them in SQL.
- Fixes PostgreSQL parameter inference failures when optional `scope` or `subject` filters are omitted.
- Completes the live whitepaper semantic search rollout after enabling 4096-dimensional embeddings.

## Related Issues

None

## Testing

- `git diff --check`
- `uv run --frozen --extra dev pytest tests/test_whitepaper_api.py tests/test_whitepaper_workflow.py -k 'semantic or search'`
- `uv run --frozen --extra dev pyright --project pyrightconfig.json`
- `uv run --frozen --extra dev pyright --project pyrightconfig.alpha.json`
- `uv run --frozen --extra dev pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
