### PR TITLE
ci(torghut): fix post-deploy verifier scope

### DIFF
--- a/.github/workflows/torghut-post-deploy-verify.yml
+++ b/.github/workflows/torghut-post-deploy-verify.yml
@@ -6,7 +6,6 @@ on:
       - main
     paths:
       - 'argocd/applications/torghut/**'
-      - 'argocd/applications/torghut-forecast/**'
   workflow_dispatch:
     inputs:
       expected_revision:
@@ -105,7 +104,7 @@ jobs:
             EXPECTED_REVISION="${EXPECTED_REVISION_INPUT}"
           fi
 
-          for app in torghut torghut-forecast; do
+          for app in torghut; do
             for attempt in $(seq 1 90); do
               STATUS="$(kubectl get application "${app}" -n argocd -o jsonpath='{.status.sync.status} {.status.health.status} {.status.sync.revision} {.status.operationState.phase} {.status.operationState.syncResult.revision} {.status.history[-1].revision}')"
               SYNC_STATUS="$(echo "${STATUS}" | awk '{print $1}')"
@@ -146,7 +145,6 @@ jobs:
           done
 
           kubectl rollout status deployment/torghut-ws -n torghut --timeout=10m
-          kubectl rollout status deployment/torghut-forecast -n torghut --timeout=10m
 
           set +e
           KNSVC_READY="$(kubectl get ksvc torghut -n torghut -o jsonpath='{.status.conditions[?(@.type==\"Ready\")].status}' 2> /tmp/torghut-ksvc-ready.err)"
@@ -171,7 +169,6 @@ jobs:
 
           curl -fsS http://torghut.torghut.svc.cluster.local/trading/status >/tmp/torghut-status.json
           curl -fsS http://torghut-ws.torghut.svc.cluster.local/readyz >/tmp/torghut-ws-ready.json
-          curl -fsS http://torghut-forecast.torghut.svc.cluster.local:8089/readyz >/tmp/torghut-forecast-ready.json
 
       - name: Prepare rollback manifests
         if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -194,12 +191,10 @@ jobs:
           fi
 
           git checkout --quiet HEAD^ -- \
-            argocd/applications/torghut \
-            argocd/applications/torghut-forecast
+            argocd/applications/torghut
 
           if git diff --quiet -- \
-            argocd/applications/torghut \
-            argocd/applications/torghut-forecast; then
+            argocd/applications/torghut; then
             echo "No rollback diff detected"
             echo "should_rollback=false" >> "$GITHUB_OUTPUT"
             exit 0
@@ -219,7 +214,6 @@ jobs:
           delete-branch: true
           add-paths: |
             argocd/applications/torghut
-            argocd/applications/torghut-forecast
           body: |
             ## Summary
             Automatic rollback created because `torghut-post-deploy-verify` failed on `main`.


### PR DESCRIPTION
## Summary

- Removes stale `torghut-forecast` Argo app, workload, service, and manifest rollback references from the Torghut post-deploy verifier.
- Keeps the verifier focused on the live Torghut rollout: Argo sync/health, Knative readiness, `torghut-ws` rollout, `/trading/status`, and `torghut-ws /readyz`.
- Restricts automatic rollback manifest handling to `argocd/applications/torghut`, which is the path present in this repo.

## Related Issues

None

## Testing

- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/torghut-post-deploy-verify.yml"); puts "yaml ok"'`
- `actionlint -ignore 'label "arc-arm64" is unknown' .github/workflows/torghut-post-deploy-verify.yml`
- `kubectl get application torghut -n argocd -o jsonpath='{.status.sync.status} {.status.health.status} {.status.sync.revision} {.status.operationState.phase} {.status.operationState.syncResult.revision}{"\n"}'`
- `kubectl rollout status deployment/torghut-ws -n torghut --timeout=60s`
- `kubectl get ksvc torghut -n torghut -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}{"\n"}'`
- `kubectl exec -n jangar jangar-7d88dbdffc-lbxt2 -c app -- curl -fsS --max-time 20 http://torghut.torghut.svc.cluster.local/trading/status`
- `kubectl exec -n jangar jangar-7d88dbdffc-lbxt2 -c app -- curl -fsS --max-time 20 http://torghut-ws.torghut.svc.cluster.local/readyz`
- `gh workflow run torghut-post-deploy-verify.yml -R proompteng/lab --ref codex/torghut-post-deploy-verify -f expected_revision=cd4948c824edfbbb1e36065a0e97619a6c21f936`
- `gh run watch 24967862745 -R proompteng/lab --interval 10`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
