### PR TITLE
docs(torghut): add authority ledger plan

### DIFF
--- a/docs/agents/designs/70-jangar-promotion-authority-ledger-and-rollout-rehearsal-cells-2026-05-05.md
+++ b/docs/agents/designs/70-jangar-promotion-authority-ledger-and-rollout-rehearsal-cells-2026-05-05.md
@@ -1,0 +1,342 @@
+# 70. Jangar Promotion Authority Ledger and Rollout Rehearsal Cells (2026-05-05)
+
+Status: Approved for implementation (`plan`)
+Date: `2026-05-05`
+Owner: Gideon Park (Torghut Traders)
+Mission: `codex/swarm-torghut-quant-plan`
+Swarm impacts:
+
+- `jangar-control-plane`
+- `torghut-quant`
+
+Companion doc:
+
+- `docs/torghut/design-system/v6/75-torghut-profit-authority-ledger-and-rehearsal-cells-2026-05-05.md`
+
+Extends:
+
+- `docs/agents/designs/69-jangar-evidence-escrow-and-repair-cell-contract-2026-05-05.md`
+- `docs/agents/designs/67-jangar-evidence-epochs-and-proof-cell-rollout-contract-2026-05-05.md`
+- `docs/agents/designs/jangar-control-plane-failure-mode-reduction-and-safe-rollout-architecture-2026-03-16.md`
+- `docs/torghut/design-system/v6/74-torghut-profit-cells-and-evidence-escrow-promotion-veto-2026-05-05.md`
+
+## Executive Summary
+
+The decision is to make Jangar publish a durable **promotion authority ledger** and to require rollout rehearsal cells
+before any downstream system can treat a rollout, schedule, proof read, or Torghut capital promotion as authoritative.
+
+The evidence says Jangar is serving but still has mixed authority signals. On `2026-05-05`, the Jangar pod in namespace
+`jangar` was `2/2 Running`, the agents controllers had recovered to two `1/1 Running` replicas, and
+`/api/agents/control-plane/status?namespace=agents` reported healthy controller heartbeats. At the same time, the
+`agents` namespace still carried `210` Error pods, recent backoff-limit events, recurring OTLP export failures to
+Mimir, and repeated `workspace pvc watch failed warn: unsupported kubernetes resource: persistentvolumeclaim` log lines.
+The database tells the same story: current-state tables are fresh to the second, but `torghut_control_plane.quant_metrics_series`
+is about `109 GB` with an estimated `314,034,592` rows, and a bounded `max(created_at)` freshness probe timed out.
+
+The tradeoff is one more authority object for engineers and deployers to learn. I am accepting that cost because the
+alternative is worse: route-time summaries keep mixing serving health, observer noise, historical failure tails, and
+trading promotion truth into one ambiguous answer.
+
+## Decision
+
+Jangar will separate four authority classes:
+
+- `serving`: the API can answer requests.
+- `dispatch`: the scheduler may launch work.
+- `rollout`: deploy verification may widen or advance a revision.
+- `torghut_promotion`: Torghut may consume Jangar evidence for non-observe capital authority.
+
+Each class must be projected from the latest sealed `promotion_authority_ledger` entry. A ledger entry cites one evidence
+escrow, the accepted proof cells, rejected proof cells, read budgets, repair cells, and expiry. Request handlers may still
+serve additive diagnostics, but they must not invent promotion authority by recomputing broad state on demand.
+
+## Current Assessment
+
+### Cluster and Rollout Evidence
+
+Read-only cluster commands were run from the `agents` service account.
+
+- `kubectl get pods -n jangar -o wide`
+  - `jangar-675b5b8855-rwglb` was `2/2 Running`.
+  - `bumba`, `symphony`, `symphony-jangar`, Redis, Open WebUI, Alloy, and `jangar-db-1` were running.
+- `kubectl get pods -n agents --no-headers | awk ...`
+  - `Running 14`
+  - `Completed 16`
+  - `Error 210`
+- `kubectl get events -n agents --sort-by=.lastTimestamp | tail -100`
+  - old schedule jobs still had `BackoffLimitExceeded` events;
+  - the latest cron-created Torghut and Jangar plan jobs completed;
+  - controller rollout events showed new `agents` and `agents-controllers` images becoming ready.
+- `kubectl logs -n agents agents-controllers-6fc8799c76-46sj4 --tail=160`
+  - controller reconciliation was active;
+  - OTLP export to `observability-mimir-nginx` failed with socket and connection-refused errors;
+  - the workspace PVC watcher repeatedly reported unsupported `persistentvolumeclaim`.
+
+Interpretation:
+
+- Jangar is not down.
+- Active controllers and current heartbeats are useful truth.
+- Failed-run history, observer export failures, and unsupported watch resources need bounded repair ownership rather
+  than generic readiness erosion.
+
+### Source Architecture and Test Gaps
+
+Relevant source seams:
+
+- `services/jangar/src/server/torghut-quant-metrics-store.ts`
+  - `readQuantLatestStoreStatus()` uses the latest table for bounded current status.
+  - `listLatestQuantPipelineHealth()` still ranks over `torghut_control_plane.quant_pipeline_health`, so the projection
+    layer needs a materialized latest subject, not repeated wide ranking.
+- `services/jangar/src/routes/api/torghut/trading/control-plane/quant/health.ts`
+  - the typed route is the correct authority boundary for Torghut, but the live call for
+    `account=paper&window=15m` timed out at eight seconds during this assessment.
+- `services/jangar/src/server/primitives-kube.ts`
+  - the controller log proves PVC is not yet mapped as a supported watch resource.
+- `services/jangar/src/server/control-plane-execution-trust.ts`
+  - request-time trust reducers exist, but consumers cannot cite one durable authority id.
+
+Test gap:
+
+- There are route-level tests for quant control-plane APIs, but there is no end-to-end proof that `serving`, `dispatch`,
+  `rollout`, and `torghut_promotion` are projected from the same ledger entry while observer repair remains degraded.
+
+### Database and Data Quality
+
+Read-only Postgres evidence:
+
+- Jangar database version: PostgreSQL `17.0`.
+- Schemas present: `agents_control_plane`, `atlas`, `codex_judge`, `jangar_github`, `memories`, `public`,
+  `terminals`, `torghut_control_plane`, and `workflow_comms`.
+- Migration state:
+  - `public.alembic_version`: `56359461a091`
+  - latest Kysely rows included `20260418_embedding_dimension_4096`.
+  - `public.kysely_migration_lock` had one unlocked row.
+- Fresh current-state rows:
+  - `public.agent_runs.updated_at`: `2026-05-05 09:27:51.737328+00`
+  - `agents_control_plane.resources_current.updated_at`: `2026-05-05 09:27:51.768735+00`
+  - `agents_control_plane.component_heartbeats.observed_at`: `2026-05-05 09:27:49.025+00`
+  - `workflow_comms.agent_messages.created_at`: `2026-05-05 09:27:36.88803+00`
+  - `torghut_control_plane.quant_metrics_latest.updated_at`: `2026-05-05 09:27:51.433984+00`
+- Heavy surface:
+  - `torghut_control_plane.quant_metrics_series`: estimated `314,034,592` rows, `109 GB`.
+  - A `max(created_at)` probe against that table was canceled by the `4s` statement timeout.
+
+Interpretation:
+
+- Current-state projections are healthy and should be the authority substrate.
+- Broad historical tables are audit/replay assets, not request-path proof sources.
+- The ledger compiler must run with statement timeouts and must persist what it accepted or rejected.
+
+## Problem Statement
+
+The current control plane can be technically healthy and still ambiguous. A serving pod can be ready while old failed
+jobs dominate the namespace, an observer watch can be broken, a metrics exporter can fail, and a downstream Torghut proof
+route can time out. If each consumer recomputes its own interpretation, rollout safety depends on timing and luck.
+
+For the next six months, Jangar needs one durable authority spine. It should answer:
+
+- Which facts were accepted for this authority class?
+- Which facts were rejected?
+- Which repair cell owns each rejected fact?
+- Which read budget was spent?
+- Which consumers are allowed to proceed before the entry expires?
+
+## Alternatives Considered
+
+### Option A: Patch the Noisy Observers and Keep Request-Time Authority
+
+This option would add PVC watch support, tune OTLP exporter behavior, and leave readiness and Torghut consumers to keep
+calling current status routes.
+
+Pros:
+
+- Fastest operational cleanup.
+- Small schema surface.
+- Directly reduces log noise.
+
+Cons:
+
+- Does not give deployers or Torghut a durable authority id.
+- Keeps broad read mistakes possible.
+- Leaves old failed-run tails as a recurring interpretation problem.
+
+Decision: rejected as the primary architecture. These fixes are necessary maintenance, but they are not enough.
+
+### Option B: Make One Active Supervisor Own All Authority
+
+This option would centralize dispatch, rollout, repair, and Torghut promotion decisions in one active control loop.
+
+Pros:
+
+- Clear operator story.
+- Easier to reason about queue ownership.
+- Fewer projection tables.
+
+Cons:
+
+- Increases blast radius from a supervisor bug.
+- Couples trading economics too tightly to platform runtime state.
+- Makes partial RBAC and observer degradation harder to handle safely.
+
+Decision: rejected. Jangar should provide platform authority; Torghut should own economic authority.
+
+### Option C: Promotion Authority Ledger With Rehearsal Cells (Selected)
+
+This option compiles authority into durable ledger entries and requires every high-impact action to cite a successful
+rehearsal cell for its class.
+
+Pros:
+
+- Makes authority replayable and auditable.
+- Lets serving remain available while promotion is vetoed.
+- Turns observer problems into named repair cells.
+- Gives Torghut one stable platform proof id without letting Jangar own PnL.
+- Avoids broad historical scans in request paths.
+
+Cons:
+
+- Adds tables, compiler code, and route projection work.
+- Requires compatibility mode for existing consumers.
+- Requires deployer discipline during cutover.
+
+Decision: selected.
+
+## Target Architecture
+
+### Promotion Authority Ledger
+
+Add a Jangar-owned ledger with these logical fields:
+
+- `authority_ledger_id`
+- `authority_class`: `serving`, `dispatch`, `rollout`, or `torghut_promotion`
+- `namespace`
+- `subject_kind`: `controller`, `schedule`, `revision`, `proof_cell`, `torghut_lane`
+- `subject_name`
+- `evidence_escrow_id`
+- `generation`
+- `accepted_cells`
+- `rejected_cells`
+- `repair_cell_ids`
+- `read_budget_ms`
+- `read_budget_rows`
+- `status`: `allow`, `hold`, `veto`, `superseded`
+- `issued_at`
+- `expires_at`
+- `superseded_by`
+
+The ledger is append-only except for explicit supersession metadata. Consumers must never delete failed authority
+entries to make current status look better.
+
+### Rollout Rehearsal Cells
+
+A rehearsal cell is a precondition bundle for one authority class. Required initial cells:
+
+- `controller-heartbeat-cell`
+  - proves leader election, controller heartbeat freshness, and CRD discovery.
+- `schedule-dispatch-cell`
+  - proves generated CronJobs and current AgentRuns share one accepted runtime contract.
+- `image-portability-cell`
+  - proves the target image digest runs on every scheduled node class required by the rollout.
+- `observer-repair-cell`
+  - isolates OTLP, PVC watch, and optional observer failures from serving readiness while blocking rollout widening if
+    they hide required facts.
+- `torghut-proof-read-cell`
+  - proves typed quant-health and market-context consumers can read bounded current-state projections within budget.
+
+### Projection Rules
+
+- `/ready` may report `serving=allow` while `rollout=hold` or `torghut_promotion=veto`.
+- `/api/agents/control-plane/status` must include the latest ledger id per authority class.
+- Schedule dispatch may proceed only with a current `dispatch=allow`.
+- Deploy verification may widen a Jangar revision only with `rollout=allow`.
+- Torghut may treat Jangar evidence as promotion-eligible only with `torghut_promotion=allow`.
+
+### Failure-Mode Reduction
+
+This design removes four failure modes:
+
+1. Broad historical scans cannot be used as request-path proof.
+2. Observer failures cannot silently poison serving readiness or silently allow promotion.
+3. Old failed-run tails cannot override current controller heartbeats without a repair-cell reason.
+4. Image digest portability must be proven before rollout authority is widened.
+
+## Implementation Scope
+
+Engineer stage:
+
+1. Add Jangar tables and Kysely migration for `promotion_authority_ledger` and `rollout_rehearsal_cells`.
+2. Build a compiler that reads current-state tables with statement timeouts and emits one ledger entry per authority
+   class.
+3. Materialize latest `quant_pipeline_health` by `(strategy_id, account, stage, window)` so health routes do not rank
+   over history.
+4. Add PVC support to `primitives-kube.ts` or classify PVC watch as non-blocking observer repair when RBAC forbids it.
+5. Project ledger ids into `/ready`, `/api/agents/control-plane/status`, and the Torghut quant-health route.
+6. Add tests proving stale or timed-out proof cells block `torghut_promotion` but do not mark `serving` down.
+
+Deployer stage:
+
+1. Roll out schema and compiler in shadow mode.
+2. Compare legacy route decisions with ledger projections for 24 hours.
+3. Enable `dispatch` authority first, then `rollout`, then `torghut_promotion`.
+4. Keep rollback as a flag flip to legacy projections plus ledger supersession, not data deletion.
+
+## Validation Gates
+
+Required local and CI gates:
+
+- Jangar unit tests for ledger compiler, projection, and route compatibility.
+- A regression test where `quant_metrics_series` freshness scan times out but `quant_metrics_latest` permits bounded
+  current-state projection.
+- A regression test where OTLP export fails and serving remains `allow`, while rollout is `hold` if the observer failure
+  hides required evidence.
+- A route parity test proving `/ready`, control-plane status, and Torghut quant-health expose the same
+  `authority_ledger_id`.
+- Kysely migration tests and rollback tests.
+
+Required cluster gates:
+
+- `agents_control_plane.component_heartbeats` freshness under 30 seconds.
+- `resources_current` freshness under 30 seconds.
+- `torghut_control_plane.quant_metrics_latest` freshness under 60 seconds for promoted lanes.
+- zero broad-table freshness scans in live route handlers.
+- all active rollout rehearsal cells either `allow` or explicitly `hold` with repair ownership.
+
+## Rollout and Rollback
+
+Rollout:
+
+1. Land additive schema and compiler.
+2. Emit ledger entries in shadow mode.
+3. Add route fields without changing status codes.
+4. Switch scheduler dispatch to require `dispatch=allow`.
+5. Switch deploy widening to require `rollout=allow`.
+6. Switch Torghut promotion checks to require `torghut_promotion=allow`.
+
+Rollback:
+
+- Disable ledger enforcement flags.
+- Continue writing ledger diagnostics if safe.
+- Mark current ledger generation `superseded`.
+- Revert consumers to legacy route projection.
+- Do not delete ledger or repair-cell rows.
+
+## Risks and Tradeoffs
+
+- More schema and route surface: accepted because authority needs replay.
+- Initial false holds: accepted because false promotion is more expensive than delayed promotion.
+- Ledger compiler bugs: mitigated by shadow parity and legacy projection fallback.
+- Operator learning curve: mitigated by one authority id per class and repair-cell reason codes.
+
+## Handoff Gates
+
+Engineer acceptance:
+
+- A Torghut promotion request can cite one Jangar `authority_ledger_id`.
+- A timed-out typed quant-health read returns `hold` or `veto`, not an ambiguous operational error.
+- A PVC watch warning has a repair cell and does not by itself mark serving down.
+
+Deployer acceptance:
+
+- The active Jangar revision exposes ledger ids on readiness and control-plane status.
+- Dispatch and rollout enforcement can be enabled independently.
+- Rollback is a flag change plus supersession record.

--- a/docs/torghut/design-system/v6/75-torghut-profit-authority-ledger-and-rehearsal-cells-2026-05-05.md
+++ b/docs/torghut/design-system/v6/75-torghut-profit-authority-ledger-and-rehearsal-cells-2026-05-05.md
@@ -1,0 +1,423 @@
+# 75. Torghut Profit Authority Ledger and Rehearsal Cells (2026-05-05)
+
+Status: Approved for implementation (`plan`)
+Date: `2026-05-05`
+Owner: Gideon Park (Torghut Traders)
+Mission: `codex/swarm-torghut-quant-plan`
+Swarm impacts:
+
+- `torghut-quant`
+- `jangar-control-plane`
+
+Companion doc:
+
+- `docs/agents/designs/70-jangar-promotion-authority-ledger-and-rollout-rehearsal-cells-2026-05-05.md`
+
+Extends:
+
+- `74-torghut-profit-cells-and-evidence-escrow-promotion-veto-2026-05-05.md`
+- `73-torghut-profit-evidence-clock-and-capital-veto-contract-2026-05-05.md`
+- `72-torghut-profit-proof-exchange-and-query-firebreak-contract-2026-05-05.md`
+- `71-torghut-whitepaper-autoresearch-profit-target-strategy-factory-2026-04-21.md`
+
+## Executive Summary
+
+The decision is to introduce a Torghut **profit authority ledger** and **rehearsal cells**. Torghut can keep serving,
+observing, and researching while evidence is stale, but no non-observe capital movement may proceed without a current
+profit authority entry that cites Jangar rollout authority, fresh lane-local proof, bounded query evidence, and a
+successful rehearsal cell for the target capital state.
+
+The reason is the May 5 live state. Torghut is alive and measuring: `/healthz` returned `200`, `/trading/health`
+returned `200`, schema is on Alembic head `0029_whitepaper_embedding_dimension_4096`, and `trade_decisions` has
+`147,606` rows with the newest decision at `2026-05-04 17:25:57.901670+00`. But the profitable truth surface is narrower:
+`/readyz` timed out at 12 seconds, logs showed repeated `IdleInTransactionSessionTimeout` on
+`SELECT max(trade_decisions.created_at) FROM trade_decisions`, typed Jangar quant-health timed out at eight seconds,
+market-context for `AAPL` and `NVDA` is degraded, empirical jobs are truthful but stale from March 21, and the strategy
+hypothesis, promotion, autoresearch, and simulation progress tables are present with zero rows.
+
+The tradeoff is deliberate friction. This will slow broad promotion. I am choosing that because profitable autonomy
+needs precise authority over stale proof, simulation portability, and route-time query pressure, not a larger green
+button.
+
+## Decision
+
+Torghut will make the profit authority ledger the only valid source for non-observe capital authority. The ledger does
+not replace profit cells or Jangar evidence escrows; it binds them into one economic decision that can be replayed,
+invalidated, and rolled back.
+
+A capital state is valid only when:
+
+- Torghut has a current `profit_authority_id`.
+- The entry cites one Jangar `authority_ledger_id` with `torghut_promotion=allow`.
+- The lane has a successful rehearsal cell for the target state: `shadow`, `canary`, `live`, or `scale`.
+- Required proof cells are fresh within their lane policy.
+- Query budgets are met from current projections, not broad historical scans.
+- Rollback instructions are attached before the state is activated.
+
+## Current Assessment
+
+### Cluster, Rollout, and Events
+
+Read-only cluster evidence:
+
+- Torghut pod status:
+  - `Running 17`
+  - `Completed 2`
+  - `ImagePullBackOff 1`
+- The main service pod `torghut-00202-deployment-677db4fc7f-5cqgl` was `2/2 Running`.
+- The simulation revision was split:
+  - `torghut-sim-00280-deployment-77d5694d7b-6zvfs` was `2/2 Running`.
+  - `torghut-sim-00280-deployment-6f844b4647-np4x6` was `0/2 ImagePullBackOff`.
+- Recent Torghut events showed:
+  - `no match for platform in manifest` for image digest
+    `registry.ide-newton.ts.net/lab/torghut@sha256:d278a4d4267f011ba559dc51401acc6ac8f43d44a766b61f29a4d01859cce5cf`;
+  - `configuration/torghut-sim` reporting `LatestReadyFailed`;
+  - main Torghut revisions `00201` and `00202` recovering after startup and readiness timeouts;
+  - `torghut-db-migrations` completing successfully.
+- RBAC limitations:
+  - the assessment account can list pods and services and get named secrets;
+  - it cannot list Knative services, FlinkDeployments, PDBs, CNPG clusters, or Argo CD Applications;
+  - it cannot exec into database pods.
+
+Interpretation:
+
+- Main Torghut is live.
+- Simulation proof is not portable across the current node set.
+- Deploy verification must work with partial RBAC and must not infer promotion authority from one healthy pod.
+
+### Runtime Routes and Logs
+
+Route evidence:
+
+- `GET /healthz`: `{"status":"ok","service":"torghut"}`
+- `GET /readyz`: timed out after 12 seconds.
+- `GET /db-check`: returned `ok=true`, schema current, single expected head, and lineage warnings for known parent forks.
+- `GET /trading/health`: returned `status=ok`, but its own payload showed:
+  - `alpha_readiness.dependency_quorum.decision="block"`;
+  - `alpha_readiness.dependency_quorum.reasons=["empirical_jobs_degraded"]`;
+  - `promotion_eligible_total=0`;
+  - `rollback_required_total=3`;
+  - `live_submission_gate.allowed=true`;
+  - `quant_evidence.reason="quant_health_not_configured"` and `required=false`.
+- `GET /trading/autonomy` and `GET /trading/empirical-jobs` showed empirical jobs are `ready=false`,
+  `status="degraded"`, and stale for `benchmark_parity`, `foundation_router_parity`, `janus_event_car`, and
+  `janus_hgrm_reward`.
+- Torghut logs showed repeated idle transaction timeouts on `SELECT max(trade_decisions.created_at) FROM trade_decisions`
+  during the same assessment window.
+
+Interpretation:
+
+- Serving, readiness, live submission, alpha readiness, empirical proof, and quant proof are not yet one coherent
+  capital authority surface.
+- The system is honest enough to expose the contradictions; the architecture should preserve that honesty and make it
+  enforceable.
+
+### Source Architecture and Test Gaps
+
+High-risk source paths:
+
+- `services/torghut/app/main.py`
+  - `3,959` lines.
+  - `_evaluate_trading_health_payload()` assembles scheduler state, database dependency checks, hypothesis payloads,
+    market-context status, empirical job status, quant evidence, and live submission gate state.
+  - `/readyz` calls that payload with database contract checks and stale-cache allowance.
+  - `/trading/health` calls the same evaluator without database contract checks.
+  - `/db-check` validates schema separately.
+- `services/torghut/app/trading/submission_council.py`
+  - `1,196` lines.
+  - `load_quant_evidence_status()` treats missing typed quant-health as `ok` when the requirement flag is false.
+  - `build_live_submission_gate_payload()` can compose strong certificate logic, but live route outputs still showed
+    `allowed=true` while alpha readiness and empirical truth were degraded.
+- `services/torghut/app/whitepapers/workflow.py`
+  - `4,473` lines.
+  - Whitepaper ingestion is active, but runtime logs showed many ignored Kafka messages and no accepted work during the
+    sampled window.
+- `services/torghut/scripts/start_historical_simulation.py`
+  - `8,197` lines.
+  - Simulation orchestration is powerful but too broad to be the only proof path for day-to-day promotion.
+- Tests:
+  - `146` Python test files exist under `services/torghut/tests`.
+  - `7` files are property or stateful tests.
+  - Missing coverage is cross-surface: no single regression proves `/readyz`, `/trading/health`, `/trading/status`,
+    Jangar typed quant-health, and empirical job freshness all project the same profit authority entry.
+
+### Database and Data Quality
+
+Torghut Postgres evidence:
+
+- PostgreSQL version: `17.0`.
+- Schema: `public`.
+- Alembic head: `0029_whitepaper_embedding_dimension_4096`.
+- Fresh or useful tables:
+  - `trade_decisions`: `147,606` exact rows, `1182 MB`, latest `created_at` at
+    `2026-05-04 17:25:57.901670+00`.
+  - `position_snapshots`: `39,695` exact rows, latest `created_at` at `2026-05-04 20:59:06.489364+00`.
+  - `trade_cursor`: one row, latest `updated_at` at `2026-05-04 20:59:12.575466+00`.
+  - `torghut_options_contract_catalog`: estimated `1,710,579` rows, latest `expiration_date` `2028-02-18`.
+- Stale or empty proof surfaces:
+  - `executions`: latest `updated_at` `2026-04-03 05:32:36.212112+00`.
+  - `llm_decision_reviews`: latest `created_at` `2026-03-19 20:13:45.326646+00`.
+  - `vnext_empirical_job_runs`: `16` exact rows, latest `updated_at` `2026-03-21 09:03:22.150009+00`.
+  - `torghut_options_watermarks`: `1,213` rows, latest `last_event_ts` `2026-03-11 01:08:11.973321+00`.
+  - `torghut_options_subscription_state`: `1,948` rows, latest `last_ranked_ts`
+    `2026-03-11 01:06:33.304365+00`.
+  - `strategy_hypotheses`, `strategy_hypothesis_metric_windows`, `strategy_promotion_decisions`,
+    `autoresearch_epochs`, `autoresearch_candidate_specs`, `autoresearch_portfolio_candidates`, and
+    `simulation_run_progress`: all existed and had zero rows.
+- ClickHouse:
+  - direct unauthenticated HTTP probes reached ClickHouse but failed with `REQUIRED_PASSWORD`.
+  - Jangar market-context health reported ClickHouse ingestion configured and successful, which is useful but not a
+    substitute for Torghut promotion proof.
+
+Interpretation:
+
+- Torghut has live data and production schema.
+- The profit authority path is not populated enough for non-observe promotion.
+- Options and empirical surfaces need lane-local vetoes, not global optimism.
+
+## Problem Statement
+
+Torghut's current architecture is close to a strong autonomous trading system, but the authority boundary is still too
+diffuse. A route can report live submission ready while the evidence required for profitable promotion is stale,
+unconfigured, or missing. A database check can be correct while a readiness path times out. A simulation revision can be
+half-portable. A strategy family can have a large options catalog but stale options watermarks.
+
+Profitability will not come from loosening these gates. It will come from making the gates precise enough that healthy
+cells keep learning while stale cells cannot spend capital.
+
+## Alternatives Considered
+
+### Option A: Increase Timeouts, Pools, and Cache TTLs
+
+Summary:
+
+- Increase route budgets and database pool capacity.
+- Keep the current route composition.
+- Treat stale proof as operational debt rather than authority structure.
+
+Pros:
+
+- Fastest local relief.
+- Low implementation complexity.
+- Less schema work.
+
+Cons:
+
+- Scales the expensive pattern.
+- Does not fix contradictory capital authority.
+- Encourages teams to bypass proof when proof gets slow.
+
+Decision: rejected as the primary architecture. It may be useful as tactical maintenance, but it does not create
+profitable autonomy.
+
+### Option B: Let Jangar Be the Final Capital Arbiter
+
+Summary:
+
+- Jangar evidence escrow becomes final authority for Torghut capital movement.
+- Torghut consumes platform decisions.
+
+Pros:
+
+- One platform gate.
+- Simple deployer story.
+- Strong centralized rollback.
+
+Cons:
+
+- Jangar does not own PnL, slippage, fills, or trading economics.
+- Platform health would be overfit to one trading system.
+- Torghut would lose lane-local falsification and experiment accounting.
+
+Decision: rejected. Jangar should veto platform evidence; Torghut must own economic authority.
+
+### Option C: Profit Authority Ledger With Rehearsal Cells (Selected)
+
+Summary:
+
+- Torghut writes one durable authority entry per capital decision.
+- The entry cites Jangar authority, profit cells, proof cells, data freshness, query budgets, and rollback instructions.
+- Rehearsal cells prove a lane can safely enter the requested capital state before it does so.
+
+Pros:
+
+- Makes non-observe capital replayable and falsifiable.
+- Preserves serving availability while blocking promotion.
+- Lets stale options, empirical, market-context, or simulation proof block only dependent lanes.
+- Creates measurable profitability hypotheses with explicit guardrails.
+- Gives engineer and deployer stages concrete acceptance gates.
+
+Cons:
+
+- Adds schema and route work.
+- Requires migration of status consumers to ledger ids.
+- Broad portfolio promotion will initially be slower.
+
+Decision: selected.
+
+## Target Architecture
+
+### Profit Authority Ledger
+
+Add a Torghut-owned ledger with these logical fields:
+
+- `profit_authority_id`
+- `jangar_authority_ledger_id`
+- `profit_cell_id`
+- `hypothesis_id`
+- `strategy_family`
+- `strategy_variant`
+- `account`
+- `market_segment`
+- `capital_state`: `observe`, `shadow`, `canary`, `live`, `scale`, `rollback`
+- `status`: `allow`, `hold`, `veto`, `superseded`
+- `proof_cell_refs`
+- `rehearsal_cell_ref`
+- `dataset_snapshot_ref`
+- `market_context_ref`
+- `quant_health_ref`
+- `empirical_job_refs`
+- `query_budget_ref`
+- `post_cost_metrics`
+- `guardrail_results`
+- `issued_at`
+- `expires_at`
+- `rollback_plan_ref`
+- `superseded_by`
+
+The ledger is append-only. A rollback writes a new authority entry and supersedes the old one.
+
+### Rehearsal Cells
+
+Initial rehearsal cells:
+
+- `shadow-rehearsal`
+  - requires schema head current, strategy manifest loaded, and no missing required proof cells for observe/shadow.
+- `canary-rehearsal`
+  - requires fresh market-context for required domains, fresh quant latest projection, current empirical proof, and
+    positive post-cost replay on the lane's frozen holdout.
+- `live-rehearsal`
+  - requires canary pass, live image portability, bounded query proof, TCA/fill-quality proof, and Jangar
+    `torghut_promotion=allow`.
+- `scale-rehearsal`
+  - requires live pass, drawdown under policy, turnover under policy, concentration under policy, and no stale
+    dependent data segment.
+- `rollback-rehearsal`
+  - proves a lane can return to observe/shadow without deleting evidence.
+
+### Trading Hypotheses
+
+The first authority entries should target concrete hypotheses:
+
+- `H-CONT-01`: high-volume intraday continuation.
+  - Hypothesis: continuation can contribute positive post-cost PnL when technicals/regime freshness is current and
+    signal lag is under policy.
+  - Guardrails: max drawdown, slippage budget, turnover cap, no promotion during market-context stale state.
+- `H-BREAK-01`: opening-drive breakout.
+  - Hypothesis: early liquidity expansion can produce positive expectancy on high-relative-volume names when empirical
+    proof is current.
+  - Guardrails: first-hour freshness, gap-risk cap, concentration cap.
+- `H-REV-01`: event-driven reversion.
+  - Hypothesis: reversion can work only when news/fundamentals freshness is current.
+  - Guardrails: no promotion while news or fundamentals are stale.
+- `H-OPT-BOOT-01`: options bootstrap lane.
+  - Hypothesis: options-derived features can improve trade selection only after watermarks and ranked subscriptions are
+    current.
+  - Guardrails: stale options watermarks force observe-only state.
+
+### Projection Rules
+
+- `/healthz` remains serving liveness.
+- `/readyz` must project readiness from latest proof authority and must not run broad freshness scans.
+- `/db-check` remains schema lineage and account-scope proof, not profitability proof.
+- `/trading/status`, `/trading/health`, `/trading/autonomy`, and scheduler decisions must expose the same
+  `profit_authority_id` for the active lane.
+- A missing typed quant-health URL is a promotion veto for non-observe capital, not an informational footnote.
+- Empirical jobs marked stale block only hypotheses that require that empirical job family.
+- Stale options watermarks block options-dependent lanes, not equities-only observation.
+
+## Implementation Scope
+
+Engineer stage:
+
+1. Add Alembic migration and SQLAlchemy models for `profit_authority_ledger` and `profit_rehearsal_cells`.
+2. Build a proof compiler that reads current projections with statement timeouts and writes authority entries.
+3. Update `submission_council.py` so non-observe capital requires a current `profit_authority_id`.
+4. Update `/trading/status`, `/trading/health`, `/trading/autonomy`, and scheduler payloads to expose the same
+   authority id and reason codes.
+5. Make typed Jangar quant-health required for non-observe capital once ledger shadow parity is enabled.
+6. Add regression tests for stale empirical jobs, stale market-context, missing quant-health, stale options watermarks,
+   and simulation image non-portability.
+7. Add one property or stateful test proving stale proof cannot promote while unrelated lanes remain observable.
+
+Deployer stage:
+
+1. Run migration and compiler in shadow mode.
+2. Compare current route outputs with ledger outputs.
+3. Enable `shadow` enforcement first.
+4. Enable `canary` only when rehearsal cells are green.
+5. Enable `live` only after Jangar authority and Torghut profit authority agree for the lane.
+
+## Validation Gates
+
+Required local checks:
+
+- `cd services/torghut && uv sync --frozen --extra dev`
+- `cd services/torghut && uv run --frozen python scripts/check_migration_graph.py`
+- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
+- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
+- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
+- targeted pytest for submission council, readiness, empirical jobs, options lane, and authority ledger tests
+- property/stateful test for stale-proof non-promotion
+
+Required cluster gates:
+
+- `/readyz` responds within 2 seconds from inside the cluster.
+- `/trading/health` and `/trading/status` cite the same `profit_authority_id`.
+- Jangar typed quant-health responds within 2 seconds from current-state projections.
+- `trade_decisions` freshness is read from a projection or indexed current table, not a route-time broad aggregate.
+- all non-observe lanes have current empirical, market-context, quant, simulation, and options proof where required.
+- simulation image portability is green across the node classes used by Torghut and `torghut-sim`.
+
+## Rollout
+
+1. Land schema and compiler behind `TRADING_PROFIT_AUTHORITY_LEDGER_ENABLED=false`.
+2. Emit shadow authority entries for seven trading sessions or until every active lane has at least five successful
+   rehearsals, whichever is later.
+3. Enable route projection fields while keeping legacy decisions.
+4. Enforce observe/shadow decisions.
+5. Enforce canary decisions.
+6. Enforce live decisions only after Jangar `torghut_promotion=allow` and Torghut profit authority agree.
+
+## Rollback
+
+Rollback is a first-class ledger action:
+
+- write a new `capital_state=rollback` authority entry;
+- freeze affected lanes at observe or shadow;
+- preserve stale and failed proof rows;
+- supersede the previous authority id;
+- disable enforcement flags if the compiler is the failure source;
+- never delete evidence to unblock a lane.
+
+## Risks and Tradeoffs
+
+- Promotion slows down while evidence is rebuilt. Accepted.
+- More state exists. Mitigated by append-only design and explicit supersession.
+- Engineers must migrate status consumers. Mitigated by shadow parity and route-level compatibility fields.
+- Initial ledger entries may be mostly `hold`. That is truthful and useful because it names the missing proof.
+
+## Handoff Gates
+
+Engineer acceptance:
+
+- A missing typed quant-health URL or timeout cannot allow non-observe capital.
+- Stale empirical jobs from March 21 block only lanes that require those jobs.
+- Stale options watermarks from March 11 block `H-OPT-BOOT-01` and do not poison equities-only observation.
+- `/trading/status`, `/trading/health`, scheduler state, and `/trading/autonomy` expose the same authority id.
+
+Deployer acceptance:
+
+- Shadow ledger projection runs without route-time broad scans.
+- Rehearsal cells are visible before enforcement.
+- Rollback writes a superseding ledger entry and demotes the lane without deleting evidence.

--- a/docs/torghut/design-system/v6/index.md
+++ b/docs/torghut/design-system/v6/index.md
@@ -10,6 +10,8 @@
 - Implementation status (strict, core 01-13 docs, source-state refresh `2026-03-09`): `Implemented=7`, `Partial=5`, `Completed=1`
 - Evidence (historical closure): `13-production-gap-closure-master-plan-2026-03-03.md` (Wave 0-6 closure + DoD)
 - Evidence (current next-work priority):
+  - `75-torghut-profit-authority-ledger-and-rehearsal-cells-2026-05-05.md`
+  - `docs/agents/designs/70-jangar-promotion-authority-ledger-and-rollout-rehearsal-cells-2026-05-05.md`
   - `75-torghut-cross-plane-evidence-epochs-and-profit-cell-governor-2026-05-05.md`
   - `docs/agents/designs/70-jangar-evidence-epoch-admission-and-rollout-quarantine-2026-05-05.md`
   - `72-torghut-cross-plane-evidence-epochs-and-portfolio-proof-lanes-2026-05-05.md`
@@ -58,8 +60,11 @@
 - `51-torghut-promotion-certificate-and-segment-firebreak-handoff-2026-03-19.md`
 - `72-torghut-proof-exchange-and-data-firebreak-contract-2026-05-05.md`
 - `73-torghut-profit-evidence-clock-and-capital-veto-contract-2026-05-05.md`
+- `75-torghut-profit-authority-ledger-and-rehearsal-cells-2026-05-05.md`
 - `75-torghut-cross-plane-evidence-epochs-and-profit-cell-governor-2026-05-05.md`
 - Cross-system source of truth:
+  - `docs/agents/designs/70-jangar-promotion-authority-ledger-and-rollout-rehearsal-cells-2026-05-05.md`
+  - `75-torghut-profit-authority-ledger-and-rehearsal-cells-2026-05-05.md`
   - `docs/agents/designs/70-jangar-evidence-epoch-admission-and-rollout-quarantine-2026-05-05.md`
   - `75-torghut-cross-plane-evidence-epochs-and-profit-cell-governor-2026-05-05.md`
   - `docs/agents/designs/67-jangar-runtime-evidence-epochs-and-artifact-parity-gates-2026-05-05.md`
@@ -219,6 +224,12 @@ Current source-state priority is narrower:
 - `75-torghut-profit-actuation-cells-and-capital-guardrail-marketplace-2026-05-05.md` now turns Torghut profit cells
   into capital actuation candidates whose marketplace score consumes Jangar actuation, cell-local freshness, empirical
   proof, simulation parity, post-cost edge, slippage, and rollback readiness.
+- `75-torghut-profit-authority-ledger-and-rehearsal-cells-2026-05-05.md` now turns the latest plan assessment into the
+  active Torghut implementation contract: non-observe capital requires one profit authority ledger entry, one Jangar
+  authority ledger id, and a successful rehearsal cell for the requested capital state.
+- `docs/agents/designs/70-jangar-promotion-authority-ledger-and-rollout-rehearsal-cells-2026-05-05.md` now defines
+  the companion Jangar contract: serving, dispatch, rollout, and Torghut promotion authority must project from a
+  durable promotion authority ledger with bounded read budgets and repair cells.
 - `53-torghut-cross-plane-profit-certificate-veto-and-options-auth-isolation-2026-03-20.md` now makes the next step
   explicit: non-observe capital depends on one certificate that consumes Jangar witness quorum, Jangar market-context
   and quant evidence, toggle parity, and typed options auth/bootstrap escrow rather than local gate optimism.


### PR DESCRIPTION
## Summary

- Adds a Jangar promotion authority ledger design that separates serving, dispatch, rollout, and Torghut-promotion authority classes.
- Adds a Torghut profit authority ledger design that binds capital movement to Jangar authority, proof cells, rehearsal cells, and rollback instructions.
- Updates the Torghut v6 design-system index so the new authority-ledger contracts are part of the current source-of-truth reading path.

## Related Issues

Refs swarm-torghut-quant-plan.

## Testing

- `bunx oxfmt --check docs/agents/designs/70-jangar-promotion-authority-ledger-and-rollout-rehearsal-cells-2026-05-05.md docs/torghut/design-system/v6/75-torghut-profit-authority-ledger-and-rehearsal-cells-2026-05-05.md docs/torghut/design-system/v6/index.md` - pass.
- Template-token scan across the three touched markdown files - pass, no matches.
- `git diff --cached --check` - pass.
- Read-only assessment commands for Kubernetes, service HTTP routes, and direct Postgres queries were run to ground the design evidence; no cluster resources or database records were mutated.

## Screenshots (if applicable)

N/A - documentation-only architecture change.

## Breaking Changes

None - documentation-only change. The documents define future additive implementation work and rollout gates.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
