### PR TITLE
fix(torghut): add profitability proof floor receipt

### DIFF
--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -68,6 +68,7 @@ from .trading.hypotheses import (
 from .trading.lean_lanes import LeanLaneManager
 from .trading.lean_runtime import lean_authority_status
 from .trading.llm.evaluation import build_llm_evaluation_metrics
+from .trading.proof_floor import build_profitability_proof_floor_receipt
 from .trading.submission_council import (
     build_live_submission_gate_payload,
     build_shadow_first_toggle_parity,
@@ -96,6 +97,7 @@ BUILD_COMMIT = os.getenv("TORGHUT_COMMIT", "unknown")
 BUILD_IMAGE_DIGEST = os.getenv("TORGHUT_IMAGE_DIGEST", "").strip() or None
 RUNTIME_PROFITABILITY_LOOKBACK_HOURS = 72
 RUNTIME_PROFITABILITY_SCHEMA_VERSION = "torghut.runtime-profitability.v1"
+PROFITABILITY_PROOF_FLOOR_TCA_MAX_AGE_SECONDS = 86_400
 LEAN_LANE_MANAGER = LeanLaneManager()
 WHITEPAPER_WORKFLOW = WhitepaperWorkflowService()
 _TRADING_DEPENDENCY_HEALTH_CACHE_LOCK = Lock()
@@ -588,6 +590,8 @@ def _evaluate_trading_health_payload(
     }
 
     alpha_readiness: dict[str, object]
+    tca_summary: dict[str, object] = {}
+    market_context_status = scheduler.market_context_status()
     _hypothesis_payload: Mapping[str, object] = {}
     try:
         with SessionLocal() as session:
@@ -596,7 +600,7 @@ def _evaluate_trading_health_payload(
             _build_hypothesis_runtime_payload(
                 scheduler,
                 tca_summary=tca_summary,
-                market_context_status=scheduler.market_context_status(),
+                market_context_status=market_context_status,
                 dependency_quorum=dependency_quorum,
             )
         )
@@ -644,6 +648,16 @@ def _evaluate_trading_health_payload(
             dspy_runtime_status=dspy_runtime,
             quant_health_status=quant_evidence,
         )
+    proof_floor = _build_profitability_proof_floor_payload(
+        state=scheduler.state,
+        torghut_revision=BUILD_COMMIT,
+        live_submission_gate=live_submission_gate,
+        hypothesis_payload=_hypothesis_payload,
+        empirical_jobs_status=empirical_jobs,
+        quant_evidence=quant_evidence,
+        market_context_status=market_context_status,
+        tca_summary=tca_summary,
+    )
     live_mode = settings.trading_mode == "live"
     empirical_jobs_required = (
         live_mode and settings.trading_empirical_jobs_health_required
@@ -683,6 +697,16 @@ def _evaluate_trading_health_payload(
         "detail": str(live_submission_gate.get("reason") or "unknown"),
         "capital_stage": live_submission_gate.get("capital_stage"),
     }
+    dependencies["profitability_proof_floor"] = {
+        "ok": (
+            str(proof_floor.get("route_state") or "") != "repair_only"
+            if live_mode
+            else True
+        ),
+        "detail": str(proof_floor.get("route_state") or "unknown"),
+        "capital_state": proof_floor.get("capital_state"),
+        "required": live_mode,
+    }
     dependencies["quant_evidence"] = {
         "ok": (
             bool(quant_evidence.get("ok", True))
@@ -714,6 +738,7 @@ def _evaluate_trading_health_payload(
             "dependencies": dependencies,
             "alpha_readiness": alpha_readiness,
             "live_submission_gate": live_submission_gate,
+            "proof_floor": proof_floor,
             "quant_evidence": quant_evidence,
         },
         status_code,
@@ -1748,6 +1773,18 @@ def trading_status() -> dict[str, object]:
             quant_health_status=quant_evidence,
         )
     simple_lane_reject_reason_totals = _simple_lane_reject_reason_totals(state)
+    simple_lane_status = _build_simple_lane_status_payload()
+    proof_floor = _build_profitability_proof_floor_payload(
+        state=state,
+        torghut_revision=str(shadow_first_runtime["active_revision"]),
+        live_submission_gate=live_submission_gate,
+        hypothesis_payload=hypothesis_payload,
+        empirical_jobs_status=empirical_jobs,
+        quant_evidence=quant_evidence,
+        market_context_status=market_context_status,
+        tca_summary=tca_summary,
+        simple_lane_status=simple_lane_status,
+    )
     return {
         "enabled": settings.trading_enabled,
         "autonomy_enabled": settings.trading_autonomy_enabled,
@@ -1770,18 +1807,10 @@ def trading_status() -> dict[str, object]:
         },
         "running": state.running,
         "live_submission_gate": live_submission_gate,
+        "proof_floor": proof_floor,
         "quant_evidence": quant_evidence,
         "last_decision_at": last_decision_at,
-        "simple_lane_status": {
-            "enabled": settings.trading_pipeline_mode == "simple",
-            "submit_enabled": settings.trading_simple_submit_enabled,
-            "order_feed_telemetry_enabled": (
-                settings.trading_simple_order_feed_telemetry_enabled
-            ),
-            "max_notional_per_order": settings.trading_simple_max_notional_per_order,
-            "max_notional_per_symbol": settings.trading_simple_max_notional_per_symbol,
-            "allowed_reject_reasons": sorted(_SIMPLE_LANE_ALLOWED_REJECT_REASONS),
-        },
+        "simple_lane_status": simple_lane_status,
         "simple_lane_reject_reason_totals": simple_lane_reject_reason_totals,
         "simple_lane_orders_submitted_total": (
             state.metrics.orders_submitted_total
@@ -3159,6 +3188,50 @@ _SIMPLE_LANE_ALLOWED_REJECT_REASONS = {
     "broker_precheck_failed",
     "broker_submit_failed",
 }
+
+
+def _build_simple_lane_status_payload() -> dict[str, object]:
+    return {
+        "enabled": settings.trading_pipeline_mode == "simple",
+        "submit_enabled": settings.trading_simple_submit_enabled,
+        "order_feed_telemetry_enabled": (
+            settings.trading_simple_order_feed_telemetry_enabled
+        ),
+        "max_notional_per_order": settings.trading_simple_max_notional_per_order,
+        "max_notional_per_symbol": settings.trading_simple_max_notional_per_symbol,
+        "allowed_reject_reasons": sorted(_SIMPLE_LANE_ALLOWED_REJECT_REASONS),
+    }
+
+
+def _build_profitability_proof_floor_payload(
+    *,
+    state: object,
+    torghut_revision: str | None,
+    live_submission_gate: Mapping[str, Any],
+    hypothesis_payload: Mapping[str, Any],
+    empirical_jobs_status: Mapping[str, Any],
+    quant_evidence: Mapping[str, Any],
+    market_context_status: Mapping[str, Any],
+    tca_summary: Mapping[str, Any],
+    simple_lane_status: Mapping[str, Any] | None = None,
+) -> dict[str, object]:
+    return build_profitability_proof_floor_receipt(
+        account_label=settings.trading_account_label,
+        torghut_revision=torghut_revision,
+        trading_mode=settings.trading_mode,
+        market_session_open=cast(
+            bool | None,
+            getattr(state, "market_session_open", None),
+        ),
+        live_submission_gate=live_submission_gate,
+        hypothesis_payload=hypothesis_payload,
+        empirical_jobs_status=empirical_jobs_status,
+        quant_evidence=quant_evidence,
+        market_context_status=market_context_status,
+        tca_summary=tca_summary,
+        simple_lane_status=simple_lane_status or _build_simple_lane_status_payload(),
+        tca_max_age_seconds=PROFITABILITY_PROOF_FLOOR_TCA_MAX_AGE_SECONDS,
+    )
 
 
 def _simple_lane_reject_reason_totals(state: object) -> dict[str, int]:

--- a/services/torghut/app/trading/proof_floor.py
+++ b/services/torghut/app/trading/proof_floor.py
@@ -1,0 +1,552 @@
+"""Profitability proof-floor receipts for capital-qualified trading routes."""
+
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from datetime import datetime, timezone
+from decimal import Decimal, InvalidOperation
+from typing import Any, cast
+
+
+_BLOCKING_STATES = {"degraded", "fail", "missing", "stale"}
+_LIVE_MICRO_STAGES = {"0.10x canary", "0.25x canary"}
+_LIVE_SCALE_STAGES = {"0.50x live", "1.00x live"}
+
+
+def _text(value: object, default: str = "") -> str:
+    if value is None:
+        return default
+    normalized = str(value).strip()
+    return normalized or default
+
+
+def _bool(value: object) -> bool:
+    return bool(value)
+
+
+def _int(value: object, default: int = 0) -> int:
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if isinstance(value, str) and value.strip():
+        try:
+            return int(float(value.strip()))
+        except ValueError:
+            return default
+    return default
+
+
+def _decimal(value: object) -> Decimal | None:
+    if isinstance(value, Decimal):
+        return value
+    if isinstance(value, (int, float)):
+        return Decimal(str(value))
+    if isinstance(value, str) and value.strip():
+        try:
+            return Decimal(value.strip())
+        except InvalidOperation:
+            return None
+    return None
+
+
+def _decimal_text(value: Decimal | None) -> str | None:
+    if value is None:
+        return None
+    normalized = value.normalize()
+    rendered = format(normalized, "f")
+    return rendered.rstrip("0").rstrip(".") if "." in rendered else rendered
+
+
+def _parse_timestamp(value: object) -> datetime | None:
+    if isinstance(value, datetime):
+        parsed = value
+    elif isinstance(value, str) and value.strip():
+        raw = value.strip()
+        if raw.endswith("Z"):
+            raw = f"{raw[:-1]}+00:00"
+        try:
+            parsed = datetime.fromisoformat(raw)
+        except ValueError:
+            return None
+    else:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _mapping(value: object) -> Mapping[str, Any]:
+    if isinstance(value, Mapping):
+        return cast(Mapping[str, Any], value)
+    return {}
+
+
+def _sequence(value: object) -> Sequence[object]:
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return cast(Sequence[object], value)
+    return []
+
+
+def _hypothesis_summary(hypothesis_payload: Mapping[str, Any]) -> Mapping[str, Any]:
+    summary = hypothesis_payload.get("summary")
+    if isinstance(summary, Mapping):
+        return cast(Mapping[str, Any], summary)
+    return hypothesis_payload
+
+
+def _hypothesis_items(hypothesis_payload: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    return [
+        item
+        for item in _sequence(hypothesis_payload.get("items"))
+        if isinstance(item, Mapping)
+    ]
+
+
+def _reason_counts(hypothesis_payload: Mapping[str, Any]) -> Counter[str]:
+    counts: Counter[str] = Counter()
+    for item in _hypothesis_items(hypothesis_payload):
+        for reason in _sequence(item.get("reasons")):
+            normalized = _text(reason)
+            if normalized:
+                counts[normalized] += 1
+    return counts
+
+
+def _slippage_guardrail(hypothesis_payload: Mapping[str, Any]) -> Decimal | None:
+    guardrails: list[Decimal] = []
+    for item in _hypothesis_items(hypothesis_payload):
+        contract = _mapping(item.get("promotion_contract"))
+        value = _decimal(contract.get("max_avg_abs_slippage_bps"))
+        if value is not None:
+            guardrails.append(value)
+    return min(guardrails) if guardrails else None
+
+
+def _add_repair(
+    repairs: list[dict[str, object]],
+    *,
+    code: str,
+    dimension: str,
+    action: str,
+    reason: str,
+    priority: int,
+    expected_unblock_value: int = 1,
+    max_notional: str = "0",
+) -> None:
+    repairs.append(
+        {
+            "code": code,
+            "dimension": dimension,
+            "action": action,
+            "reason": reason,
+            "priority": priority,
+            "expected_unblock_value": expected_unblock_value,
+            "max_notional": max_notional,
+        }
+    )
+
+
+def build_profitability_proof_floor_receipt(
+    *,
+    account_label: str | None,
+    torghut_revision: str | None,
+    trading_mode: str,
+    market_session_open: bool | None,
+    live_submission_gate: Mapping[str, Any],
+    hypothesis_payload: Mapping[str, Any],
+    empirical_jobs_status: Mapping[str, Any],
+    quant_evidence: Mapping[str, Any],
+    market_context_status: Mapping[str, Any],
+    tca_summary: Mapping[str, Any],
+    simple_lane_status: Mapping[str, Any] | None = None,
+    now: datetime | None = None,
+    tca_max_age_seconds: int = 86400,
+) -> dict[str, object]:
+    """Build an auditable proof-floor receipt before paper/live capital routing.
+
+    The reducer is intentionally conservative: any degraded proof dimension keeps
+    capital at zero and emits ranked repair work instead of authorizing notional.
+    """
+
+    generated_at = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    summary = _hypothesis_summary(hypothesis_payload)
+    reasons = _reason_counts(hypothesis_payload)
+    dimensions: list[dict[str, object]] = []
+    repairs: list[dict[str, object]] = []
+
+    def add_dimension(
+        *,
+        dimension: str,
+        state: str,
+        reason: str,
+        capital_effect: str,
+        source_ref: Mapping[str, object] | None = None,
+        freshness_seconds: int | None = None,
+        threshold_seconds: int | None = None,
+    ) -> None:
+        dimensions.append(
+            {
+                "dimension": dimension,
+                "state": state,
+                "reason": reason,
+                "capital_effect": capital_effect,
+                "source_ref": dict(source_ref or {}),
+                "freshness_seconds": freshness_seconds,
+                "threshold_seconds": threshold_seconds,
+            }
+        )
+
+    gate_allowed = _bool(live_submission_gate.get("allowed"))
+    gate_reason = _text(live_submission_gate.get("reason"), "unknown")
+    live_mode = trading_mode == "live"
+    if live_mode and not gate_allowed:
+        add_dimension(
+            dimension="live_submission_gate",
+            state="fail",
+            reason=gate_reason,
+            capital_effect="live_hold",
+            source_ref={
+                "capital_stage": live_submission_gate.get("capital_stage"),
+                "blocked_reasons": live_submission_gate.get("blocked_reasons") or [],
+            },
+        )
+        _add_repair(
+            repairs,
+            code="live_submit_gate_closed",
+            dimension="live_submission_gate",
+            action="keep_submit_disabled_until_proof_floor_passes",
+            reason=gate_reason,
+            priority=80,
+        )
+    else:
+        add_dimension(
+            dimension="live_submission_gate",
+            state="pass",
+            reason=gate_reason or "allowed",
+            capital_effect="none",
+            source_ref={"capital_stage": live_submission_gate.get("capital_stage")},
+        )
+
+    promotion_eligible_total = _int(summary.get("promotion_eligible_total"))
+    rollback_required_total = _int(summary.get("rollback_required_total"))
+    if promotion_eligible_total <= 0:
+        add_dimension(
+            dimension="alpha_readiness",
+            state="fail",
+            reason="alpha_readiness_not_promotion_eligible",
+            capital_effect="paper_hold" if not live_mode else "live_hold",
+            source_ref={
+                "promotion_eligible_total": promotion_eligible_total,
+                "rollback_required_total": rollback_required_total,
+                "state_totals": summary.get("state_totals") or {},
+            },
+        )
+        _add_repair(
+            repairs,
+            code="repair_alpha_readiness",
+            dimension="alpha_readiness",
+            action="clear_hypothesis_blockers_before_capital",
+            reason="alpha_readiness_not_promotion_eligible",
+            priority=70,
+            expected_unblock_value=max(1, len(reasons)),
+        )
+    else:
+        add_dimension(
+            dimension="alpha_readiness",
+            state="pass",
+            reason="promotion_eligible",
+            capital_effect="none",
+            source_ref={"promotion_eligible_total": promotion_eligible_total},
+        )
+
+    empirical_ready = _bool(empirical_jobs_status.get("ready"))
+    empirical_status = _text(empirical_jobs_status.get("status"), "unknown")
+    if empirical_ready:
+        empirical_state = "pass"
+        empirical_effect = "none"
+    else:
+        empirical_state = "degraded"
+        empirical_effect = "paper_hold" if not live_mode else "live_hold"
+        _add_repair(
+            repairs,
+            code="repair_empirical_jobs",
+            dimension="empirical",
+            action="refresh_empirical_job_receipts",
+            reason=empirical_status,
+            priority=50,
+        )
+    add_dimension(
+        dimension="empirical",
+        state=empirical_state,
+        reason=empirical_status,
+        capital_effect=empirical_effect,
+        source_ref={
+            "candidate_ids": empirical_jobs_status.get("candidate_ids") or [],
+            "dataset_snapshot_refs": empirical_jobs_status.get("dataset_snapshot_refs")
+            or [],
+        },
+    )
+
+    quant_status = _text(quant_evidence.get("status"), "unknown").lower()
+    quant_reason = _text(quant_evidence.get("reason"), quant_status or "unknown")
+    if not _bool(quant_evidence.get("ok")):
+        quant_state = "fail"
+    elif quant_status in {"ok", "healthy", "pass", "not_required"}:
+        quant_state = "pass"
+    else:
+        quant_state = "degraded"
+    if quant_state != "pass":
+        _add_repair(
+            repairs,
+            code="repair_quant_ingestion",
+            dimension="quant_ingestion",
+            action="settle_quant_pipeline_stage_lag",
+            reason=quant_reason,
+            priority=60,
+        )
+    add_dimension(
+        dimension="quant_ingestion",
+        state=quant_state,
+        reason=quant_reason,
+        capital_effect="none"
+        if quant_state == "pass"
+        else "paper_hold"
+        if not live_mode
+        else "live_hold",
+        source_ref={
+            "account": quant_evidence.get("account"),
+            "window": quant_evidence.get("window"),
+            "latest_metrics_updated_at": quant_evidence.get(
+                "latest_metrics_updated_at"
+            ),
+            "max_stage_lag_seconds": quant_evidence.get("max_stage_lag_seconds"),
+        },
+    )
+
+    market_alert = _bool(market_context_status.get("alert_active"))
+    market_reason = _text(
+        market_context_status.get("alert_reason")
+        or market_context_status.get("last_reason"),
+        "ok",
+    )
+    if market_alert:
+        market_state = "stale" if "stale" in market_reason else "degraded"
+        _add_repair(
+            repairs,
+            code="repair_market_context",
+            dimension="market_context",
+            action="refresh_market_context_domains",
+            reason=market_reason,
+            priority=55,
+            expected_unblock_value=max(1, reasons.get("market_context_stale", 0)),
+        )
+    else:
+        market_state = "pass"
+    add_dimension(
+        dimension="market_context",
+        state=market_state,
+        reason=market_reason,
+        capital_effect="none"
+        if market_state == "pass"
+        else "paper_hold"
+        if not live_mode
+        else "live_hold",
+        source_ref={
+            "last_freshness_seconds": market_context_status.get(
+                "last_freshness_seconds"
+            ),
+            "last_quality_score": market_context_status.get("last_quality_score"),
+            "last_domain_states": market_context_status.get("last_domain_states") or {},
+        },
+        freshness_seconds=_int(market_context_status.get("last_freshness_seconds"), -1),
+    )
+
+    tca_last_computed_at = _parse_timestamp(tca_summary.get("last_computed_at"))
+    tca_age_seconds = (
+        max(0, int((generated_at - tca_last_computed_at).total_seconds()))
+        if tca_last_computed_at is not None
+        else None
+    )
+    tca_order_count = _int(tca_summary.get("order_count"))
+    avg_abs_slippage_bps = _decimal(tca_summary.get("avg_abs_slippage_bps"))
+    slippage_guardrail = _slippage_guardrail(hypothesis_payload)
+    tca_state = "pass"
+    tca_reason = "fresh"
+    if tca_order_count <= 0:
+        tca_state = "missing"
+        tca_reason = "execution_tca_missing"
+    elif tca_age_seconds is None or tca_age_seconds > max(0, tca_max_age_seconds):
+        tca_state = "stale"
+        tca_reason = "execution_tca_stale"
+    elif (
+        avg_abs_slippage_bps is not None
+        and slippage_guardrail is not None
+        and avg_abs_slippage_bps > slippage_guardrail
+    ):
+        tca_state = "fail"
+        tca_reason = "execution_tca_slippage_guardrail_exceeded"
+    if tca_state != "pass":
+        _add_repair(
+            repairs,
+            code="repair_execution_tca",
+            dimension="execution_tca",
+            action="refresh_execution_tca_settlement",
+            reason=tca_reason,
+            priority=65,
+            expected_unblock_value=max(1, reasons.get("tca_evidence_stale", 0)),
+        )
+    add_dimension(
+        dimension="execution_tca",
+        state=tca_state,
+        reason=tca_reason,
+        capital_effect="none"
+        if tca_state == "pass"
+        else "paper_hold"
+        if not live_mode
+        else "live_hold",
+        source_ref={
+            "order_count": tca_order_count,
+            "last_computed_at": tca_summary.get("last_computed_at"),
+            "avg_abs_slippage_bps": _decimal_text(avg_abs_slippage_bps),
+            "slippage_guardrail_bps": _decimal_text(slippage_guardrail),
+        },
+        freshness_seconds=tca_age_seconds,
+        threshold_seconds=max(0, tca_max_age_seconds),
+    )
+
+    feature_rows_missing = reasons.get("feature_rows_missing", 0)
+    required_feature_set_unavailable = reasons.get(
+        "required_feature_set_unavailable",
+        0,
+    )
+    if feature_rows_missing or required_feature_set_unavailable:
+        _add_repair(
+            repairs,
+            code="repair_feature_coverage",
+            dimension="features",
+            action="backfill_hypothesis_feature_rows",
+            reason="feature_rows_missing",
+            priority=45,
+            expected_unblock_value=feature_rows_missing
+            + required_feature_set_unavailable,
+        )
+    drift_checks_missing = reasons.get("drift_checks_missing", 0)
+    if drift_checks_missing:
+        _add_repair(
+            repairs,
+            code="repair_drift_governance",
+            dimension="drift",
+            action="run_hypothesis_drift_checks",
+            reason="drift_checks_missing",
+            priority=40,
+            expected_unblock_value=drift_checks_missing,
+        )
+    signal_lag_exceeded = reasons.get("signal_lag_exceeded", 0)
+    if signal_lag_exceeded:
+        if market_session_open:
+            _add_repair(
+                repairs,
+                code="repair_signal_freshness",
+                dimension="signal_continuity",
+                action="restore_actionable_signal_ingestion",
+                reason="signal_lag_exceeded",
+                priority=75,
+                expected_unblock_value=signal_lag_exceeded,
+            )
+        else:
+            _add_repair(
+                repairs,
+                code="closed_session_signal_hold",
+                dimension="signal_continuity",
+                action="verify_signal_freshness_at_next_market_open",
+                reason="expected_market_closed_staleness",
+                priority=15,
+                expected_unblock_value=signal_lag_exceeded,
+            )
+
+    blocking_dimensions = [
+        item for item in dimensions if _text(item.get("state")) in _BLOCKING_STATES
+    ]
+    active_stage = _text(
+        live_submission_gate.get("active_capital_stage")
+        or live_submission_gate.get("capital_stage"),
+        "shadow",
+    )
+    configured_max_notional = None
+    if isinstance(simple_lane_status, Mapping):
+        configured_max_notional = simple_lane_status.get("max_notional_per_order")
+
+    if blocking_dimensions:
+        route_state = "repair_only"
+        capital_state = "zero_notional"
+        floor_state = "repair_only"
+        max_notional = "0"
+    elif market_session_open is False:
+        route_state = "observe_only"
+        capital_state = "closed_session_hold"
+        floor_state = "shadow_ready"
+        max_notional = "0"
+    elif live_mode:
+        if active_stage in _LIVE_SCALE_STAGES:
+            route_state = "live_scale_candidate"
+        elif active_stage in _LIVE_MICRO_STAGES:
+            route_state = "live_micro_candidate"
+        else:
+            route_state = "live_micro_candidate"
+        capital_state = "live_allowed"
+        floor_state = (
+            "live_micro_ready"
+            if route_state == "live_micro_candidate"
+            else "live_scale_ready"
+        )
+        max_notional = _text(configured_max_notional, "configured_by_risk")
+    else:
+        route_state = "paper_candidate"
+        capital_state = "paper_allowed"
+        floor_state = "paper_ready"
+        max_notional = _text(configured_max_notional, "configured_by_risk")
+
+    ordered_repairs = sorted(
+        repairs,
+        key=lambda item: (
+            -_int(item.get("priority")),
+            -_int(item.get("expected_unblock_value")),
+            _text(item.get("code")),
+        ),
+    )
+    blocking_codes = sorted(
+        {
+            _text(item.get("reason"))
+            for item in blocking_dimensions
+            if _text(item.get("reason"))
+        }
+    )
+
+    return {
+        "schema_version": "torghut.profitability-proof-floor.v1",
+        "generated_at": generated_at.isoformat(),
+        "account_label": account_label,
+        "torghut_revision": torghut_revision,
+        "market_window": {
+            "session_open": market_session_open,
+        },
+        "floor_state": floor_state,
+        "route_state": route_state,
+        "capital_state": capital_state,
+        "max_notional": max_notional,
+        "blocking_reasons": blocking_codes,
+        "proof_dimensions": dimensions,
+        "repair_ladder": ordered_repairs,
+        "fresh_until": None if blocking_dimensions else generated_at.isoformat(),
+        "rollback_target": {
+            "capital_state": "zero_notional",
+            "live_submit_enabled": False,
+        },
+    }
+
+
+__all__ = ["build_profitability_proof_floor_receipt"]

--- a/services/torghut/tests/test_profitability_proof_floor.py
+++ b/services/torghut/tests/test_profitability_proof_floor.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from app.trading.proof_floor import build_profitability_proof_floor_receipt
+
+
+NOW = datetime(2026, 5, 6, 21, 27, tzinfo=timezone.utc)
+
+
+def _healthy_hypothesis_payload() -> dict[str, object]:
+    return {
+        "summary": {
+            "hypotheses_total": 1,
+            "promotion_eligible_total": 1,
+            "rollback_required_total": 0,
+            "state_totals": {"promotion_eligible": 1},
+        },
+        "items": [
+            {
+                "hypothesis_id": "chip-paper-microbar-composite",
+                "reasons": [],
+                "promotion_contract": {"max_avg_abs_slippage_bps": "20"},
+            }
+        ],
+    }
+
+
+def _healthy_empirical_jobs() -> dict[str, object]:
+    return {
+        "ready": True,
+        "status": "healthy",
+        "candidate_ids": ["chip-paper-microbar-composite@execution-proof"],
+        "dataset_snapshot_refs": ["torghut-chip-full-day-20260505-5e447b6d-r1"],
+    }
+
+
+def _healthy_quant_evidence() -> dict[str, object]:
+    return {
+        "ok": True,
+        "status": "healthy",
+        "reason": "ready",
+        "account": "paper",
+        "window": "15m",
+        "latest_metrics_updated_at": NOW.isoformat(),
+        "max_stage_lag_seconds": 5,
+    }
+
+
+def _healthy_market_context() -> dict[str, object]:
+    return {
+        "alert_active": False,
+        "last_reason": "ok",
+        "last_freshness_seconds": 30,
+        "last_quality_score": 0.99,
+        "last_domain_states": {"macro": "fresh"},
+    }
+
+
+def _fresh_tca_summary(*, avg_abs_slippage_bps: str = "5") -> dict[str, object]:
+    return {
+        "order_count": 12,
+        "last_computed_at": (NOW - timedelta(minutes=5)).isoformat(),
+        "avg_abs_slippage_bps": avg_abs_slippage_bps,
+    }
+
+
+def _simple_lane_status() -> dict[str, object]:
+    return {
+        "enabled": True,
+        "submit_enabled": True,
+        "max_notional_per_order": "250",
+        "max_notional_per_symbol": "750",
+    }
+
+
+def test_live_degraded_evidence_routes_to_repair_only() -> None:
+    receipt = build_profitability_proof_floor_receipt(
+        account_label="PA3SX7FYNUTF",
+        torghut_revision="torghut-00245",
+        trading_mode="live",
+        market_session_open=False,
+        live_submission_gate={
+            "allowed": False,
+            "reason": "simple_submit_disabled",
+            "blocked_reasons": ["simple_submit_disabled"],
+            "capital_stage": "shadow",
+        },
+        hypothesis_payload={
+            "summary": {
+                "hypotheses_total": 3,
+                "promotion_eligible_total": 0,
+                "rollback_required_total": 3,
+                "state_totals": {"blocked": 1, "shadow": 2},
+            },
+            "items": [
+                {
+                    "hypothesis_id": "chip-paper-microbar-composite",
+                    "reasons": [
+                        "tca_evidence_stale",
+                        "signal_lag_exceeded",
+                        "feature_rows_missing",
+                    ],
+                    "promotion_contract": {"max_avg_abs_slippage_bps": "20"},
+                }
+            ],
+        },
+        empirical_jobs_status=_healthy_empirical_jobs(),
+        quant_evidence={
+            "ok": False,
+            "status": "degraded",
+            "reason": "quant_pipeline_degraded",
+            "max_stage_lag_seconds": 13354,
+        },
+        market_context_status=_healthy_market_context(),
+        tca_summary={
+            "order_count": 13775,
+            "last_computed_at": "2026-04-02T20:59:45.136640+00:00",
+            "avg_abs_slippage_bps": "568.6138848199565249",
+        },
+        simple_lane_status=_simple_lane_status(),
+        now=NOW,
+    )
+
+    assert receipt["route_state"] == "repair_only"
+    assert receipt["capital_state"] == "zero_notional"
+    assert receipt["max_notional"] == "0"
+    assert set(receipt["blocking_reasons"]) >= {
+        "simple_submit_disabled",
+        "alpha_readiness_not_promotion_eligible",
+        "quant_pipeline_degraded",
+        "execution_tca_stale",
+    }
+
+    repair_codes = [repair["code"] for repair in receipt["repair_ladder"]]
+    assert repair_codes[:4] == [
+        "live_submit_gate_closed",
+        "repair_alpha_readiness",
+        "repair_execution_tca",
+        "repair_quant_ingestion",
+    ]
+    assert repair_codes[-1] == "closed_session_signal_hold"
+
+
+def test_live_all_clear_routes_to_micro_candidate_with_configured_notional() -> None:
+    receipt = build_profitability_proof_floor_receipt(
+        account_label="PA3SX7FYNUTF",
+        torghut_revision="torghut-00245",
+        trading_mode="live",
+        market_session_open=True,
+        live_submission_gate={
+            "allowed": True,
+            "reason": "ready",
+            "blocked_reasons": [],
+            "capital_stage": "0.10x canary",
+        },
+        hypothesis_payload=_healthy_hypothesis_payload(),
+        empirical_jobs_status=_healthy_empirical_jobs(),
+        quant_evidence=_healthy_quant_evidence(),
+        market_context_status=_healthy_market_context(),
+        tca_summary=_fresh_tca_summary(),
+        simple_lane_status=_simple_lane_status(),
+        now=NOW,
+    )
+
+    assert receipt["route_state"] == "live_micro_candidate"
+    assert receipt["floor_state"] == "live_micro_ready"
+    assert receipt["capital_state"] == "live_allowed"
+    assert receipt["max_notional"] == "250"
+    assert receipt["blocking_reasons"] == []
+    assert receipt["repair_ladder"] == []
+
+
+def test_paper_all_clear_routes_to_paper_candidate() -> None:
+    receipt = build_profitability_proof_floor_receipt(
+        account_label="TORGHUT_SIM",
+        torghut_revision="torghut-sim-00345",
+        trading_mode="paper",
+        market_session_open=True,
+        live_submission_gate={
+            "allowed": True,
+            "reason": "non_live_mode",
+            "blocked_reasons": [],
+            "capital_stage": "paper",
+        },
+        hypothesis_payload=_healthy_hypothesis_payload(),
+        empirical_jobs_status=_healthy_empirical_jobs(),
+        quant_evidence=_healthy_quant_evidence(),
+        market_context_status=_healthy_market_context(),
+        tca_summary=_fresh_tca_summary(),
+        simple_lane_status=_simple_lane_status(),
+        now=NOW,
+    )
+
+    assert receipt["route_state"] == "paper_candidate"
+    assert receipt["floor_state"] == "paper_ready"
+    assert receipt["capital_state"] == "paper_allowed"
+    assert receipt["max_notional"] == "250"
+
+
+def test_live_submit_disabled_fails_closed_even_when_other_dimensions_pass() -> None:
+    receipt = build_profitability_proof_floor_receipt(
+        account_label="PA3SX7FYNUTF",
+        torghut_revision="torghut-00245",
+        trading_mode="live",
+        market_session_open=True,
+        live_submission_gate={
+            "allowed": False,
+            "reason": "simple_submit_disabled",
+            "blocked_reasons": ["simple_submit_disabled"],
+            "capital_stage": "shadow",
+        },
+        hypothesis_payload=_healthy_hypothesis_payload(),
+        empirical_jobs_status=_healthy_empirical_jobs(),
+        quant_evidence=_healthy_quant_evidence(),
+        market_context_status=_healthy_market_context(),
+        tca_summary=_fresh_tca_summary(),
+        simple_lane_status=_simple_lane_status(),
+        now=NOW,
+    )
+
+    assert receipt["route_state"] == "repair_only"
+    assert receipt["capital_state"] == "zero_notional"
+    assert receipt["blocking_reasons"] == ["simple_submit_disabled"]
+
+
+def test_tca_slippage_guardrail_failure_keeps_capital_at_zero() -> None:
+    receipt = build_profitability_proof_floor_receipt(
+        account_label="PA3SX7FYNUTF",
+        torghut_revision="torghut-00245",
+        trading_mode="live",
+        market_session_open=True,
+        live_submission_gate={
+            "allowed": True,
+            "reason": "ready",
+            "blocked_reasons": [],
+            "capital_stage": "0.10x canary",
+        },
+        hypothesis_payload=_healthy_hypothesis_payload(),
+        empirical_jobs_status=_healthy_empirical_jobs(),
+        quant_evidence=_healthy_quant_evidence(),
+        market_context_status=_healthy_market_context(),
+        tca_summary=_fresh_tca_summary(avg_abs_slippage_bps="25"),
+        simple_lane_status=_simple_lane_status(),
+        now=NOW,
+    )
+
+    assert receipt["route_state"] == "repair_only"
+    assert receipt["capital_state"] == "zero_notional"
+    assert receipt["blocking_reasons"] == ["execution_tca_slippage_guardrail_exceeded"]

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -906,6 +906,114 @@ class TestTradingApi(TestCase):
             settings.trading_simple_submit_enabled = original_simple_submit_enabled
             settings.trading_kill_switch_enabled = original_kill_switch_enabled
 
+    def test_trading_status_and_health_include_profitability_proof_floor(
+        self,
+    ) -> None:
+        proof_floor = {
+            "schema_version": "torghut.profitability-proof-floor.v1",
+            "route_state": "repair_only",
+            "capital_state": "zero_notional",
+            "repair_ladder": [{"code": "repair_execution_tca"}],
+        }
+
+        with patch(
+            "app.main.build_profitability_proof_floor_receipt",
+            return_value=proof_floor,
+        ):
+            status_response = self.client.get("/trading/status")
+            health_response = self.client.get("/trading/health")
+
+        self.assertEqual(status_response.status_code, 200)
+        self.assertIn(health_response.status_code, {200, 503})
+        self.assertEqual(status_response.json()["proof_floor"], proof_floor)
+        self.assertEqual(health_response.json()["proof_floor"], proof_floor)
+        self.assertEqual(
+            health_response.json()["dependencies"]["profitability_proof_floor"][
+                "detail"
+            ],
+            "repair_only",
+        )
+
+    def test_trading_health_requires_profitability_proof_floor_in_live(self) -> None:
+        original_enabled = settings.trading_enabled
+        original_mode = settings.trading_mode
+        original_source = settings.trading_universe_source
+        original_empirical_required = settings.trading_empirical_jobs_health_required
+        settings.trading_enabled = True
+        settings.trading_mode = "live"
+        settings.trading_universe_source = "static"
+        settings.trading_empirical_jobs_health_required = False
+        try:
+            scheduler = TradingScheduler()
+            scheduler.state.running = True
+            scheduler.state.last_run_at = datetime.now(timezone.utc)
+            app.state.trading_scheduler = scheduler
+
+            with (
+                patch("app.main._check_alpaca", return_value={"ok": True}),
+                patch("app.main._check_clickhouse", return_value={"ok": True}),
+                patch("app.main._check_postgres", return_value={"ok": True}),
+                patch(
+                    "app.main.check_account_scope_invariants",
+                    return_value={
+                        "account_scope_ready": True,
+                        "account_scope_errors": [],
+                    },
+                ),
+                patch(
+                    "app.main.check_schema_current",
+                    return_value={
+                        "schema_current": True,
+                        "current_heads": ["0011_execution_tca_simulator_divergence"],
+                        "expected_heads": ["0011_execution_tca_simulator_divergence"],
+                        "schema_head_signature": "7f8e4d0",
+                    },
+                ),
+                patch(
+                    "app.main._build_live_submission_gate_payload",
+                    return_value={
+                        "allowed": True,
+                        "reason": "ready",
+                        "blocked_reasons": [],
+                        "capital_stage": "live",
+                    },
+                ),
+                patch(
+                    "app.main._empirical_jobs_status",
+                    return_value={"ready": False, "status": "degraded"},
+                ),
+                patch(
+                    "app.main.load_quant_evidence_status",
+                    return_value={
+                        "required": False,
+                        "ok": True,
+                        "status": "not_required",
+                        "reason": "quant_health_not_configured",
+                    },
+                ),
+                patch(
+                    "app.main._build_profitability_proof_floor_payload",
+                    return_value={
+                        "route_state": "repair_only",
+                        "capital_state": "zero_notional",
+                    },
+                ),
+            ):
+                response = self.client.get("/trading/health")
+
+            self.assertEqual(response.status_code, 503)
+            dependency = response.json()["dependencies"]["profitability_proof_floor"]
+            self.assertFalse(dependency["ok"])
+            self.assertEqual(dependency["detail"], "repair_only")
+            self.assertTrue(dependency["required"])
+        finally:
+            settings.trading_enabled = original_enabled
+            settings.trading_mode = original_mode
+            settings.trading_universe_source = original_source
+            settings.trading_empirical_jobs_health_required = (
+                original_empirical_required
+            )
+
     @patch("app.main._check_alpaca", return_value={"ok": True, "detail": "ok"})
     @patch("app.main._check_clickhouse", return_value={"ok": True, "detail": "ok"})
     @patch(
@@ -1230,7 +1338,14 @@ class TestTradingApi(TestCase):
             scheduler.state.last_run_at = datetime.now(timezone.utc)
             app.state.trading_scheduler = scheduler
 
-            response = self.client.get("/trading/health")
+            with patch(
+                "app.main._build_profitability_proof_floor_payload",
+                return_value={
+                    "route_state": "live_micro_candidate",
+                    "capital_state": "live_allowed",
+                },
+            ):
+                response = self.client.get("/trading/health")
 
             self.assertEqual(response.status_code, 200)
             payload = response.json()
@@ -1239,6 +1354,7 @@ class TestTradingApi(TestCase):
             self.assertFalse(payload["dependencies"]["empirical_jobs"]["required"])
             self.assertTrue(payload["dependencies"]["quant_evidence"]["ok"])
             self.assertFalse(payload["dependencies"]["quant_evidence"]["required"])
+            self.assertTrue(payload["dependencies"]["profitability_proof_floor"]["ok"])
         finally:
             settings.trading_enabled = original_enabled
             settings.trading_mode = original_mode


### PR DESCRIPTION
## Summary

- Adds a conservative profitability proof-floor receipt reducer for Torghut paper/live routing.
- Surfaces the receipt on `/trading/status` and `/trading/health`, including a live-mode health dependency that fails closed on `repair_only` evidence.
- Reuses the simple-lane status payload and adds regression coverage for live-blocked, live-ready, paper-ready, submit-disabled, and TCA guardrail cases.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_trading_api.py tests/test_profitability_proof_floor.py -q`
- `uv run --frozen pytest tests/test_profitability_proof_floor.py -q`
- `uv run --frozen ruff check app/trading/proof_floor.py app/main.py tests/test_profitability_proof_floor.py tests/test_trading_api.py`
- `uv run --frozen ruff format --check app/trading/proof_floor.py app/main.py tests/test_profitability_proof_floor.py tests/test_trading_api.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
