### PR TITLE
docs(torghut): define post-cost alpha reentry architecture

### DIFF
--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -18,6 +18,8 @@ clear entrypoints, clear “source of truth”, and a complete catalog of relate
 - Fast Jangar/Torghut live analysis workflow: `designs/jangar-torghut-live-analysis-playbook.md`
 - Autonomous Jangar/Torghut production system design: `designs/autonomous-jangar-torghut-production-system.md`
 - Current Jangar/Torghut architecture contracts:
+  - `designs/136-jangar-verification-trust-escrow-and-query-budgeted-evidence-settlement-2026-05-07.md`
+  - `../torghut/design-system/v6/140-torghut-post-cost-alpha-reentry-and-proof-query-market-2026-05-07.md`
   - `designs/136-jangar-controller-authority-settlement-and-endpoint-parity-ledger-2026-05-07.md`
   - `../torghut/design-system/v6/140-torghut-endpoint-parity-profit-repair-and-capital-route-auction-2026-05-07.md`
   - `designs/134-jangar-evidence-census-and-projection-settlement-exchange-2026-05-07.md`

--- a/docs/agents/designs/136-jangar-verification-trust-escrow-and-query-budgeted-evidence-settlement-2026-05-07.md
+++ b/docs/agents/designs/136-jangar-verification-trust-escrow-and-query-budgeted-evidence-settlement-2026-05-07.md
@@ -1,0 +1,318 @@
+# 136. Jangar Verification Trust Escrow And Query-Budgeted Evidence Settlement (2026-05-07)
+
+Status: Accepted for engineer and deployer handoff
+Date: 2026-05-07
+Owner: Gideon Park, Torghut Traders Architecture
+Scope: Jangar control-plane execution trust, verify-stage freshness, bounded evidence reads, rollout safety,
+Torghut quant evidence custody, validation, rollout, and rollback.
+
+Companion Torghut contract:
+
+- `docs/torghut/design-system/v6/140-torghut-post-cost-alpha-reentry-and-proof-query-market-2026-05-07.md`
+
+Extends:
+
+- `135-jangar-rollout-availability-escrow-and-consumer-evidence-custody-2026-05-07.md`
+- `135-jangar-database-witness-and-schema-authority-exchange-2026-05-07.md`
+- `134-jangar-evidence-census-and-projection-settlement-exchange-2026-05-07.md`
+- `129-jangar-consumer-evidence-return-ledger-and-rollout-settlement-2026-05-06.md`
+
+## Decision
+
+I am selecting **verification trust escrow with query-budgeted evidence settlement** as the next Jangar control-plane
+architecture step.
+
+The refreshed read-only pass at `2026-05-07T08:12Z` shows a system that is serving, but still not trustworthy enough
+to let downstream capital consumers infer safety from live HTTP aggregation. Jangar is on image
+`1744b973@sha256:fe165d874349d309ae43fdeedd64934f0dde6cd748c92dade8992e86c2dfbaa3`; `deployment/jangar` is `1/1`
+available and `deployment/agents-controllers` is `2/2` available. `/ready` returns `status=ok`, healthy serving and
+collaboration runtime kits, and proof that `bun`, `codex-nats-publish`, `codex-nats-soak`, `nats`, the Jangar
+workspace, and `NATS_URL` are present.
+
+The same `/ready` payload degrades execution trust because the verify stage is stale. `GET
+/api/agents/control-plane/status` timed out under a 15 second client budget, while `/ready` had enough settled data to
+answer. Jangar also holds roughly `51M` rows in `torghut_control_plane.quant_pipeline_health`; a direct recent
+15-minute aggregation over that table timed out under a 5 second statement budget, even after recent index work.
+Those are not just endpoint bugs. They are a proof-shape problem: request-time readers are still allowed to do too
+much evidence interpretation against hot production tables.
+
+I am not choosing another one-off status optimization. Jangar needs to settle execution trust, query cost, and
+consumer evidence into small receipts before serving routes and material-action gates consume them. The tradeoff is
+one more internal receipt family and stricter freshness deadlines for verify-stage proof. I accept that because the
+observed failure mode is exactly stale or expensive evidence being discovered late, at the HTTP or capital boundary,
+instead of being converted into a current hold/repair decision ahead of time.
+
+## Runtime Objective And Success Metrics
+
+This contract increases control-plane resilience by moving expensive and stale-prone evidence work out of user-facing
+reads and into bounded settlement loops.
+
+Success means:
+
+- `/ready` and `/api/agents/control-plane/status` read a settled verification trust receipt, not live-scan verify jobs
+  or high-cardinality quant tables.
+- Verify-stage staleness is represented as an escrowed repair debt with owner, deadline, last good receipt, and action
+  effects.
+- Jangar refuses deploy widening, merge-ready claims, and Torghut paper/live custody when the verify trust receipt is
+  stale, while still allowing read-only serving and zero-notional repair.
+- Query budgets are explicit: status routes cannot run unbounded aggregation over `quant_pipeline_health`,
+  `quant_metrics_series`, AgentRun history, or Torghut data-plane proof tables.
+- A slow proof query produces `query_budget_exhausted` evidence and a repair bid instead of timing out the control
+  surface.
+- Engineer and deployer stages can validate the contract with bounded HTTP checks, migration checks, and receipt
+  freshness checks without database mutation.
+
+Initial SLOs:
+
+- `/ready` p95 under `1s` and `/api/agents/control-plane/status` p95 under `2s` for a 10 request smoke.
+- Verification trust receipts refresh at least every `5m`; stale after `2` missed verify windows.
+- Query-budgeted settlement records the largest bounded proof query per cycle and caps route-time DB work at `250ms`
+  per evidence family.
+- No material-action receipt may widen from `repair_only` to `paper_hold` or `current` while verify trust is stale.
+
+## Evidence Snapshot
+
+All evidence was collected read-only. I did not mutate Kubernetes resources, database rows, GitOps manifests,
+AgentRuns, broker state, or Torghut trading flags.
+
+### Cluster And Rollout Evidence
+
+- `kubectl config current-context` was initially unset; I created a local `in-cluster` kubeconfig context from the
+  service-account token so follow-up reads are reproducible.
+- `kubectl auth whoami` identified the caller as `system:serviceaccount:agents:agents-sa`.
+- Jangar namespace pods were Running: `bumba`, `jangar`, `jangar-alloy`, `jangar-db-1`, Redis, Open WebUI, Symphony,
+  and `symphony-jangar`.
+- `deployment/jangar` was `1/1` available on image `1744b973`; recent events still showed readiness probe failures
+  during image replacement and `NoPods` events for an Elasticsearch PDB with no matching pods.
+- Agents controllers recovered from the earlier teammate soak: `deployment/agents-controllers` was `2/2` available,
+  but the namespace still contained several recent failed scheduled jobs followed by successful reruns.
+- Torghut serving and sim revisions were Running, but its events repeatedly warned that ClickHouse pods match multiple
+  PDBs. The current service account cannot list PDBs, Argo Rollouts, Knative services, CNPG clusters, or exec into DB
+  pods, so the design must not depend on manual privileged inspection as the normal validation path.
+
+### Route And Runtime Evidence
+
+- `GET http://jangar.ide-newton.ts.net/ready` returned `status=ok` with healthy runtime kits and fresh projection
+  watermarks, while `execution_trust.status=degraded` because `jangar-control-plane:verify` is stale.
+- The same `/ready` payload shows in-process agents and supporting controllers disabled while the orchestration
+  controller is enabled; split authority must therefore be read from receipts, not guessed from one process.
+- `GET http://jangar.ide-newton.ts.net/api/agents/control-plane/status` timed out after `15s`.
+- `GET http://jangar.ide-newton.ts.net/api/torghut/trading/control-plane/quant/health` returned `ok=true`,
+  `latestMetricsCount=4032`, `metricsPipelineLagSeconds=0`, and `pipelineHealthSkippedReason=account_and_window_required`
+  for the unscoped route.
+- Runtime proof for NATS is now healthy: the collaboration kit includes `codex-nats-publish`, `codex-nats-soak`,
+  `nats`, workspace, and `NATS_URL`.
+
+### Database And Data Evidence
+
+- Jangar DB connected as application user `jangar`.
+- `pg_stat_user_tables` estimates:
+  - `torghut_control_plane.quant_pipeline_health`: about `50,969,757` rows.
+  - `torghut_control_plane.quant_metrics_series`: about `3,722,580` rows.
+  - `torghut_control_plane.quant_metrics_latest`: `4,032` rows.
+  - `agent_runs`: estimate `783`, exact application count `469`.
+- Small freshness reads are current enough for custody:
+  - `quant_metrics_latest` exact rows `4032`, latest update `2026-05-07 08:19:03+00`.
+  - `agent_runs` exact rows `469`, latest update `2026-05-07 08:19:06+00`.
+- A recent aggregation over `quant_pipeline_health` grouped by account/stage for the last 15 minutes timed out under a
+  5 second statement budget. That table must be treated as an input to settlement, not as a route-time dependency.
+
+### Source Evidence
+
+- `services/jangar/src/server/control-plane-status.ts` is `781` lines and already composes execution trust, dependency
+  quorum, runtime admission, material action, Torghut empirical services, and rollout health.
+- `services/jangar/src/server/torghut-quant-runtime.ts` is `817` lines and computes live metrics continuously.
+- `services/jangar/src/server/torghut-quant-metrics-store.ts` is `399` lines and owns writes into the quant control
+  plane tables.
+- Existing tests cover control-plane status, runtime admission, negative evidence routing, action clocks, and quant
+  metrics store migrations. The missing test surface is a route-independent settlement receipt that proves status
+  routes can stay bounded when a large evidence table is slow.
+
+## Problem
+
+Jangar is doing two jobs at the same boundary: presenting control-plane truth and discovering whether control-plane
+truth is cheap, fresh, and safe enough to consume.
+
+That creates four failure modes:
+
+1. **Stage trust becomes a late read failure.** A stale verify stage can degrade `/ready`, while another status route
+   times out instead of serving the same stale-trust decision from a receipt.
+2. **Hot evidence tables leak into the route path.** A table with tens of millions of quant stage rows can still be
+   queried in ways that exceed a normal operator HTTP budget.
+3. **Runtime-kit health is not enough.** Helper binaries and NATS can be present while verify evidence is stale.
+4. **Consumers get data instead of custody.** Torghut needs an action-class answer: observe, repair, paper hold, or
+   live block. It should not re-interpret Jangar stage staleness, runtime proof, and query pressure itself.
+
+## Alternatives Considered
+
+### Option A: Fix The Verify Cron And Add A Faster Status Query
+
+Pros:
+
+- Fastest tactical remediation.
+- Likely removes the current `verify stage is stale` reason.
+- Keeps the existing public payload shape mostly intact.
+
+Cons:
+
+- Does not prevent the next large table or slow proof read from timing out the route.
+- Does not create a durable query-budget audit trail.
+- Leaves Torghut to interpret multiple Jangar internals for capital decisions.
+
+Decision: reject as the architecture answer. Keep it as an engineer repair task under the selected design.
+
+### Option B: Put All Control-Plane Reads Behind A Single Cache
+
+Pros:
+
+- Simple latency improvement.
+- Reduces repeated DB/API work.
+- Easy to deploy incrementally.
+
+Cons:
+
+- Caches can preserve bad or stale interpretations without naming the trust debt.
+- It does not separate execution trust, query budget, and consumer custody.
+- It can mask a stale verify stage until the cache expires.
+
+Decision: reject.
+
+### Option C: Verification Trust Escrow With Query-Budgeted Evidence Settlement
+
+Pros:
+
+- Converts stale verify evidence into an explicit escrow state with action effects.
+- Converts slow proof queries into `query_budget_exhausted` repair evidence before route timeout.
+- Gives Torghut a small custody receipt rather than a large status payload to reinterpret.
+- Keeps Jangar read-only and repair surfaces available while holding deploy widening and capital authority.
+
+Cons:
+
+- Adds a settlement loop and one receipt family.
+- Requires careful query-budget calibration so it does not over-hold routine operations.
+- Requires both Jangar and Torghut code to prefer receipts over direct live aggregation.
+
+Decision: select Option C.
+
+## Architecture
+
+Jangar emits one verification trust escrow receipt per swarm/stage and one query-budget settlement receipt per evidence
+family.
+
+```text
+verification_trust_escrow_receipt
+  receipt_id
+  generated_at
+  swarm_name
+  stage
+  stage_owner
+  last_good_run_ref
+  last_good_completed_at
+  expected_interval_seconds
+  stale_after_seconds
+  trust_state              # current, stale, missing, blocked
+  action_effects           # serve_readonly, repair_only, hold_dispatch, hold_capital
+  repair_bid_ref
+  reason_codes
+  fresh_until
+```
+
+```text
+query_budget_settlement_receipt
+  receipt_id
+  generated_at
+  evidence_family          # control_plane_status, quant_pipeline_health, agent_runs, torghut_custody
+  source_table_or_route
+  row_estimate
+  query_budget_ms
+  observed_query_ms
+  result_state             # current, stale, skipped, query_budget_exhausted
+  route_consumers
+  fallback_receipt_ref
+  required_index_or_rollup
+  reason_codes
+  fresh_until
+```
+
+Material action consumers use the receipts, not the underlying heavy tables:
+
+- `serve_readonly`: allowed when runtime kits are current and verification trust is not `blocked`.
+- `dispatch_repair`: allowed under `stale` verify when the repair bid is scoped and query budgets are not exhausted
+  for the repair family.
+- `dispatch_normal`: requires current verification trust and no query-budget exhaustion on control-plane status.
+- `deploy_widen` and `merge_ready`: require current verification trust, current rollout availability escrow, and
+  bounded status route receipts.
+- `torghut_observe`: allowed with `max_notional=0` under stale verify.
+- `paper_canary` and live actions: require current verification trust plus current Torghut custody receipts.
+
+## Implementation Scope
+
+Engineer stage should implement the smallest production slice:
+
+- Add a Jangar settlement module that materializes verification trust escrow from stage schedule/result state already
+  exposed in control-plane status.
+- Add query-budget settlement for control-plane status, quant latest, quant pipeline health, and AgentRun history.
+- Change `/api/agents/control-plane/status` to consume settled receipts for expensive evidence families and to emit a
+  bounded degraded response when a settlement receipt is stale.
+- Keep `/ready` as the compact serving readiness surface, but include receipt ids for stale verify and query-budget
+  holds.
+- Add route tests proving that stale verify produces a bounded degraded payload without route-time large-table
+  aggregation.
+- Add store tests proving that a query timeout becomes `query_budget_exhausted` and a repair bid, not an unhandled
+  route timeout.
+
+Do not mutate cluster resources or database rows in the design phase. The deployer may later apply GitOps changes
+only after the engineer receipts and tests exist.
+
+## Validation Gates
+
+Engineer acceptance:
+
+- `bun run --filter jangar test -- services/jangar/src/server/__tests__/control-plane-status.test.ts`
+- `bun run --filter jangar test -- services/jangar/src/server/__tests__/torghut-quant-metrics-store.test.ts`
+- New tests cover stale verify, query-budget exhaustion, and bounded status response.
+- `curl -m 5 http://jangar.ide-newton.ts.net/ready` returns a compact receipt-backed answer.
+- `curl -m 5 http://jangar.ide-newton.ts.net/api/agents/control-plane/status` returns within budget, even when a
+  heavy proof family is stale or skipped.
+
+Deployer acceptance:
+
+- Jangar rollout stays `1/1` or better during the deploy window.
+- Verification trust receipt is `current` before merge-ready or deploy-widen action classes are released.
+- Query-budget receipts are `current` or explicitly `skipped` with a valid fallback for every public status route.
+- Torghut custody receipt remains `observe_only` or `repair_only` until the companion Torghut post-cost gates pass.
+
+## Rollout
+
+1. Ship the settlement module behind a read-only feature flag that emits receipts without changing action decisions.
+2. Compare receipt decisions against current `/ready` and control-plane status for one full verify cycle.
+3. Switch status routes to receipt-backed reads for high-cardinality evidence families.
+4. Enforce action-class holds for stale verify and query-budget exhaustion.
+5. Allow Torghut to consume the custody receipt for observe and repair first; paper/live remain blocked.
+
+## Rollback
+
+Rollback does not require database mutation.
+
+- Disable enforcement and keep receipt emission read-only if route latency worsens.
+- Revert status routes to the previous reducer while keeping the settlement table ignored.
+- Force material actions to `serve_readonly` and `repair_only` if receipts contradict current `/ready` evidence.
+- Do not widen deploy or capital classes while rollback evidence is being collected.
+
+## Risks
+
+- Query budgets may initially be too strict and over-hold repair work.
+- Existing indexes may still be insufficient for some settlement reads; the receipt should say so rather than hiding
+  timeout.
+- Split controller authority can confuse operators if the receipt does not name which process or deployment owns the
+  evidence.
+- Route-level caching must not bypass receipt freshness.
+
+## Handoff Contract
+
+Engineer owns the Jangar receipt implementation, bounded route behavior, and tests. Deployer owns GitOps rollout and
+the validation evidence. Torghut consumers may treat stale verify as `max_notional=0`, not as a full outage, until the
+receipt becomes `current`.
+
+The next stage is done only when stale verify and slow proof queries are visible as settled receipts and no public
+status route needs an unbounded scan to answer a capital or rollout question.

--- a/docs/torghut/design-system/v6/140-torghut-post-cost-alpha-reentry-and-proof-query-market-2026-05-07.md
+++ b/docs/torghut/design-system/v6/140-torghut-post-cost-alpha-reentry-and-proof-query-market-2026-05-07.md
@@ -1,0 +1,351 @@
+# 140. Torghut Post-Cost Alpha Reentry And Proof-Query Market (2026-05-07)
+
+Status: Accepted for engineer and deployer handoff
+Date: 2026-05-07
+Owner: Gideon Park, Torghut Traders Architecture
+Scope: Torghut quant profitability, post-cost alpha evidence, proof-query budgets, TCA refresh, hypothesis parity,
+capital reentry, validation, rollout, and rollback.
+
+Companion Jangar contract:
+
+- `docs/agents/designs/136-jangar-verification-trust-escrow-and-query-budgeted-evidence-settlement-2026-05-07.md`
+
+Extends:
+
+- `139-torghut-profit-evidence-custody-and-capital-reentry-auction-2026-05-07.md`
+- `139-torghut-profit-data-witness-and-forecast-repair-exchange-2026-05-07.md`
+- `138-torghut-profit-stats-census-and-tca-reactivation-market-2026-05-07.md`
+- `129-torghut-bidirectional-quant-proof-receipts-and-profit-reentry-ledger-2026-05-06.md`
+
+## Decision
+
+I am selecting **post-cost alpha reentry with a proof-query market** as Torghut's next quant profitability architecture
+step.
+
+Torghut is alive and running, but it is still correctly refusing capital. At `2026-05-07T08:12Z`,
+`GET /healthz` returned `ok`; `GET /db-check` returned `ok=true`, schema current, and Alembic head
+`0029_whitepaper_embedding_dimension_4096`. `GET /trading/status` returned live revision `torghut-00251`,
+`mode=live`, `enabled=true`, `running=true`, `kill_switch_enabled=false`, and aligned critical toggles. Empirical jobs
+were fresh and truthful for `chip-paper-microbar-composite@execution-proof`.
+
+The blockers are capital blockers, not uptime blockers. `/trading/health` timed out after 10 seconds. The proof floor
+is `repair_only`, route state `repair_only`, capital state `zero_notional`, and max notional `0`. The live submission
+gate is closed for `simple_submit_disabled`. Alpha readiness has `3` runtime hypotheses, `0` promotion eligible, and
+`3` rollback required. Execution TCA is stale from `2026-04-02T20:59:45.136640Z`; the status payload reports `13775`
+orders and average absolute slippage around `568.61` bps against an `8` bps guardrail. Jangar dependency quorum delays
+promotion because execution trust is degraded.
+
+The database adds two important contradictions. Torghut Postgres has `147,623` trade decisions and `13,775` TCA rows,
+but `execution_order_events` has `0` rows and table statistics estimate only `17` trade decisions and `0` TCA rows.
+Runtime status exposes three active hypotheses from source manifests, while `strategy_hypotheses` contains one
+persisted row. Jangar's latest quant metrics are fresh, but many account/window metrics are still
+`insufficient_data`, market-context snapshots are from `2026-05-06T13:44Z`, and simulation runs in Jangar's control
+plane last updated on `2026-03-19`.
+
+I am not choosing direct paper promotion and I am not choosing a blanket freeze. I am choosing a market that prices
+proof queries and post-cost repairs before capital reentry. The tradeoff is that fresh empirical evidence becomes
+repair priority, not paper authority. That is the right tradeoff because Torghut's next profitable move is to retire
+TCA, hypothesis-parity, market-context, and proof-query debt in the order most likely to unblock capital safely.
+
+## Runtime Objective And Success Metrics
+
+This contract increases profitability by making post-cost alpha the first capital gate and by making expensive proof
+queries compete for bounded repair budget.
+
+Success means:
+
+- Empirical jobs can nominate repair candidates but cannot bypass stale TCA, missing order-feed evidence, stale
+  market context, or Jangar stale-verify custody.
+- Each hypothesis gets a reentry state: `research_only`, `repair_bid`, `shadow_ready`, `paper_ready`,
+  `live_micro_ready`, or `blocked`.
+- TCA refresh, order-feed backfill, hypothesis source/DB parity, and market-context freshness are measurable repair
+  bids with expected capital unblock value.
+- `/trading/health` uses precomputed proof receipts and returns within `5s`; slow proof families become
+  `query_budget_exhausted` bids instead of endpoint timeouts.
+- Paper canary remains impossible until post-cost expectancy is positive after slippage, order-feed coverage is
+  non-zero, the relevant hypothesis is promotion eligible, and Jangar verification trust is current.
+
+Initial success thresholds:
+
+- TCA freshness under `24h` before paper, under `4h` before live micro.
+- Average absolute slippage at or below the hypothesis budget: `12` bps for continuation and reversion, `8` bps for
+  microstructure.
+- Order-feed coverage above `95%` for executions used in TCA.
+- Hypothesis source/DB parity at `100%` for active candidates before paper.
+- Market-context freshness under `300s` for context-using hypotheses during market hours.
+- `/trading/health` route budget under `5s`.
+
+## Evidence Snapshot
+
+All evidence was collected read-only. I did not mutate Kubernetes resources, database rows, broker state, empirical
+artifacts, GitOps resources, ClickHouse data, or trading flags.
+
+### Cluster And Service Evidence
+
+- Torghut pods were Running: live `torghut-00251-deployment`, sim `torghut-sim-00351-deployment`, Postgres,
+  ClickHouse, Keeper, TA, TA sim, options TA, options catalog/enricher, WebSocket services, guardrail exporters,
+  Alloy, and Symphony.
+- Several old Knative revisions were scaled to `0/0`; current live and sim revisions were `1/1`.
+- Recent events repeatedly warned that ClickHouse pods match multiple PodDisruptionBudgets. The service account cannot
+  list PDBs, Knative services, Argo Rollouts, or CNPG clusters, so the deployer validation path must use permitted
+  Kubernetes reads and service routes.
+- Jangar is serving, but its `/ready` payload degrades execution trust because the verify stage is stale. That makes
+  Torghut's dependency quorum a capital hold.
+
+### Route Evidence
+
+- `/healthz`: `{"status":"ok","service":"torghut"}`.
+- `/db-check`: `ok=true`, `schema_current=true`, current and expected Alembic head
+  `0029_whitepaper_embedding_dimension_4096`, one schema head, and known lineage warnings for parent forks around
+  revisions `0010` and `0015`.
+- `/trading/health`: client timeout after `10s`.
+- `/trading/status`: running live revision `torghut-00251`, submit disabled, zero notional, no promotion-eligible
+  hypotheses, and Jangar dependency quorum `delay`.
+- Quant evidence: not required, `status=degraded`, `reason=quant_pipeline_stages_missing`, latest metrics updated
+  `2026-05-07T08:11:27Z`, and metrics lag `32s` for the scoped account/window in the status payload.
+- Empirical jobs: `healthy`, with `benchmark_parity`, `foundation_router_parity`, `janus_event_car`, and
+  `janus_hgrm_reward` fresh for the chip dataset.
+- Forecast service: `degraded`, authority `blocked`, message `registry_empty`.
+- Market context: optional in current config, but no last symbol/as-of/quality on the live status payload.
+
+### Database And Data Evidence
+
+- Torghut DB connected as application user `torghut_app`.
+- Actual row counts and freshness:
+  - `trade_decisions`: `147,623`, latest `2026-05-06 17:44:19+00`.
+  - `executions`: `13,778`, latest `2026-04-03 05:32:38+00`.
+  - `execution_tca_metrics`: `13,775`, latest `2026-04-02 20:59:45+00`.
+  - `execution_order_events`: `0`.
+  - `position_snapshots`: `42,186`, latest `2026-05-06 20:58:44+00`.
+  - `vnext_empirical_job_runs`: `20`, latest `2026-05-06 16:27:32+00`.
+  - `strategy_hypothesis_metric_windows`: `3`, latest `2026-05-06 18:01:00+00`.
+  - `strategy_hypotheses`: `1`, latest `2026-05-06 22:34:19+00`.
+- Postgres table estimates are stale for key proof tables: `pg_stat_user_tables` estimated `17` trade decisions and
+  `0` TCA rows despite the actual counts above. Proof queries and planners need stats custody, not just schema
+  custody.
+- Jangar DB estimates `50,969,757` quant pipeline health rows, `3,722,580` quant metrics series rows, and `4,032`
+  latest metrics rows. A recent pipeline aggregation timed out under a 5 second statement budget.
+
+### Source Evidence
+
+- `services/torghut/app/main.py` is `4124` lines and currently composes readiness, trading status, empirical jobs,
+  quant evidence, live submission gate, and proof floor.
+- `services/torghut/app/trading/submission_council.py` is `1199` lines and owns quant health and live gate evaluation.
+- `services/torghut/app/trading/proof_floor.py` is `558` lines and already turns blockers into repair ladder items.
+- `services/torghut/app/trading/scheduler/simple_pipeline.py` is `683` lines and should not absorb more proof
+  branching.
+- The test surface is broad: `149` Python test files under `services/torghut/tests`, plus focused coverage for proof
+  floor, empirical jobs, hypotheses, trading API, submission council, policy checks, TCA, and scheduler safety.
+- The missing source layer is a bounded post-cost proof receipt that the health route can read cheaply and the capital
+  gate can trust.
+
+## Problem
+
+Torghut has enough data to explain why capital is blocked, but not enough settled proof to rank the repairs that would
+make capital profitable again.
+
+Fresh empirical jobs are useful but insufficient. They say a candidate deserves attention; they do not prove that the
+candidate survives live slippage, that order-feed evidence covers the executions, that source and database hypotheses
+agree, or that Jangar is current enough to custody the decision.
+
+The current system also makes some proof reads too expensive or too late:
+
+- `/trading/health` can time out while `/trading/status` eventually emits the needed blockers.
+- TCA evidence is stale by more than a month.
+- Order-feed normalized events are empty.
+- Runtime and DB hypothesis counts disagree.
+- Database statistics are stale enough to mislead query planning.
+- Jangar quant pipeline history is large enough that direct aggregations can exceed operator budgets.
+
+The next architecture needs to convert these facts into an ordered, measurable repair market.
+
+## Alternatives Considered
+
+### Option A: Promote The Fresh Empirical Candidate To Paper
+
+Pros:
+
+- Fastest way to collect new observations.
+- Uses the fresh Janus and parity evidence before it decays.
+- Keeps the quant lane visibly active.
+
+Cons:
+
+- Ignores stale TCA and high slippage.
+- Ignores empty order-feed coverage.
+- Ignores zero promotion eligibility.
+- Ignores stale Jangar verify trust.
+
+Decision: reject.
+
+### Option B: Run A One-Off TCA And Market-Context Backfill
+
+Pros:
+
+- Directly addresses two concrete blockers.
+- Operationally familiar.
+- May unblock some shadow readiness quickly.
+
+Cons:
+
+- Does not fix `/trading/health` timeout behavior.
+- Does not price proof-query cost or DB stats drift.
+- Does not settle source/DB hypothesis parity.
+- Likely repeats as soon as evidence ages again.
+
+Decision: reject as the system design.
+
+### Option C: Post-Cost Alpha Reentry With A Proof-Query Market
+
+Pros:
+
+- Treats empirical evidence as a repair bid, not as capital authority.
+- Makes TCA, order-feed coverage, hypothesis parity, market context, and Jangar custody explicit bids.
+- Gives `/trading/health` a small settled proof payload.
+- Prioritizes repairs by expected capital unblock value and operational risk.
+- Keeps observe and zero-notional repair active while holding paper/live capital.
+
+Cons:
+
+- Requires one reducer and one persisted receipt family.
+- Requires calibration of expected unblock value.
+- May keep paper blocked longer than a manual one-off repair.
+
+Decision: select Option C.
+
+## Architecture
+
+Torghut emits one post-cost alpha reentry receipt per account, revision, and market window.
+
+```text
+post_cost_alpha_reentry_receipt
+  receipt_id
+  generated_at
+  account_label
+  torghut_revision
+  market_window
+  proof_floor_ref
+  jangar_verification_trust_ref
+  health_route_budget_ref
+  capital_state                 # zero_notional, repair_only, shadow_ready, paper_ready, live_micro_ready
+  max_notional
+  selected_repair_bid_refs
+  blocked_repair_bid_refs
+  hypothesis_states
+  reason_codes
+  fresh_until
+  rollback_target
+```
+
+Each proof repair becomes a bid.
+
+```text
+proof_query_market_bid
+  bid_id
+  evidence_family               # tca, order_feed, hypothesis_parity, market_context, quant_pipeline, db_stats
+  blocker_code
+  current_value
+  threshold
+  query_budget_ms
+  observed_query_ms
+  expected_unblock_value
+  empirical_support_refs
+  validation_command_ref
+  capital_effect                # observe_only, shadow_ready, paper_hold_removed, live_hold_removed
+  selected
+  reason_codes
+```
+
+Initial repair order under the current evidence:
+
+1. `tca_refresh`: stale since `2026-04-02`, highest capital impact.
+2. `order_feed_coverage`: `execution_order_events=0`, required to trust TCA and reconciliation.
+3. `hypothesis_parity`: runtime has three hypotheses; DB has one persisted hypothesis row.
+4. `health_route_budget`: `/trading/health` must answer from settled receipts within `5s`.
+5. `market_context_freshness`: required for event reversion and LLM/context-using lanes.
+6. `quant_pipeline_stage_rollup`: Jangar latest metrics are fresh, but stage proof must be scoped and cheap.
+
+## Hypotheses And Guardrails
+
+- `H-CONT-01` continuation: stays `repair_bid` until signal lag is under `90s`, TCA is fresher than `24h`, average
+  absolute slippage is at most `12` bps, and Jangar verification trust is current.
+- `H-MICRO-01` microstructure breakout: stays `blocked` until feature rows and drift checks exist, order-feed coverage
+  is above `95%`, TCA is fresher than `24h`, and average absolute slippage is at most `8` bps.
+- `H-REV-01` event reversion: stays `repair_bid` until market context freshness is under `120s` during market hours,
+  TCA is fresher than `24h`, and Jangar verification trust is current.
+
+Paper canary requires all of the following:
+
+- live submit still intentionally enabled by deployer, not inferred from proof;
+- selected hypothesis state `paper_ready`;
+- post-cost expectancy positive after slippage and fees;
+- order-feed coverage above `95%`;
+- no `query_budget_exhausted` on selected evidence families;
+- Jangar verification trust receipt `current`;
+- rollback target `zero_notional`.
+
+## Implementation Scope
+
+Engineer stage should implement the minimum production slice:
+
+- Add a post-cost alpha reentry reducer beside `proof_floor.py` and `submission_council.py`.
+- Persist or expose a compact receipt that `/trading/health` and `/trading/status` can both read without recomputing
+  heavy proof families.
+- Add repair bids for TCA freshness, order-feed coverage, hypothesis parity, health route budget, market context, and
+  Jangar quant pipeline stage rollups.
+- Add source/DB hypothesis parity checks using active source manifests and persisted strategy hypothesis rows.
+- Add DB stats custody checks for the proof tables whose actual counts diverge materially from planner estimates.
+- Keep the scheduler in zero-notional repair mode until receipts reach `paper_ready`.
+
+## Validation Gates
+
+Engineer acceptance:
+
+- `uv run --frozen pytest services/torghut/tests/test_profitability_proof_floor.py`
+- `uv run --frozen pytest services/torghut/tests/test_trading_api.py -k "trading_health or proof_floor"`
+- New tests prove stale TCA, empty order-feed events, hypothesis parity mismatch, and query-budget exhaustion keep
+  `max_notional=0`.
+- `curl -m 5 http://torghut.ide-newton.ts.net/trading/health` returns a receipt-backed payload or a bounded degraded
+  payload.
+- `curl -m 5 http://torghut.ide-newton.ts.net/trading/status` includes the same receipt id as health for the current
+  proof floor.
+
+Deployer acceptance:
+
+- `/db-check` remains schema-current.
+- TCA receipt is fresher than `24h` before paper and `4h` before live micro.
+- `execution_order_events` coverage for TCA-backed executions is above `95%`.
+- Active hypothesis source and DB parity is `100%`.
+- Jangar verification trust is current.
+- Live submit remains disabled until all gates pass and an explicit deployer action widens paper.
+
+## Rollout
+
+1. Emit the post-cost receipt read-only and compare it with the existing proof floor.
+2. Serve `/trading/health` from the receipt while preserving current status payload fields.
+3. Start selecting repair bids but keep `max_notional=0`.
+4. After TCA, order-feed, parity, and Jangar trust gates pass, allow paper canary for one hypothesis and one account.
+5. Keep live micro and scale blocked until paper canary has fresh post-cost settlement.
+
+## Rollback
+
+Rollback target is always `zero_notional`.
+
+- Disable receipt enforcement if it disagrees with the existing proof floor and keep receipt emission for diagnosis.
+- Close paper canary by setting the capital state back to `repair_only`; do not delete evidence rows.
+- Hold all live actions if `/trading/health` exceeds `5s`, Jangar verification trust is stale, or TCA freshness exceeds
+  the threshold.
+- Do not mutate database rows by hand to clear a blocker; repair through the owning job or GitOps-controlled rollout.
+
+## Risks
+
+- DB stats custody may require an operational ANALYZE path that the current app role cannot perform.
+- Order-feed coverage may expose older execution data that cannot be fully reconstructed.
+- Health route receipts can become stale if the reducer fails; freshness and last-good semantics must be visible.
+- Expected unblock value can be gamed unless it is tied to concrete gates and post-cost thresholds.
+
+## Handoff Contract
+
+Engineer owns the reducer, receipt payload, tests, and bounded route behavior. Deployer owns GitOps rollout and the
+paper-widen decision after gates pass. Until the receipt says `paper_ready`, Torghut remains in observe and
+zero-notional repair mode, no matter how fresh empirical proof looks.

--- a/docs/torghut/design-system/v6/index.md
+++ b/docs/torghut/design-system/v6/index.md
@@ -8,10 +8,12 @@
 - Scope: intraday strategy architecture upgrade beyond static TSMOM, with regime-adaptive routing, DSPy-governed LLM
   reasoning, contamination-safe evaluation, and production rollout controls
 - Implementation status: `Mixed` (historical program closure recorded on `2026-03-03`; source-state refreshed on
-  `2026-03-09`; active proof/capital authority evidence refreshed on `2026-05-07T06:29Z`)
+  `2026-03-09`; active proof/capital authority evidence refreshed on `2026-05-07T08:20Z`)
 - Implementation status (strict, core 01-13 docs, source-state refresh `2026-03-09`): `Implemented=7`, `Partial=5`, `Completed=1`
 - Evidence (historical closure): `13-production-gap-closure-master-plan-2026-03-03.md` (Wave 0-6 closure + DoD)
-- Evidence (current next-work priority, refreshed `2026-05-07T06:29Z`):
+- Evidence (current next-work priority, refreshed `2026-05-07T08:20Z`):
+  - `140-torghut-post-cost-alpha-reentry-and-proof-query-market-2026-05-07.md`
+  - `docs/agents/designs/136-jangar-verification-trust-escrow-and-query-budgeted-evidence-settlement-2026-05-07.md`
   - `140-torghut-endpoint-parity-profit-repair-and-capital-route-auction-2026-05-07.md`
   - `docs/agents/designs/136-jangar-controller-authority-settlement-and-endpoint-parity-ledger-2026-05-07.md`
   - `139-torghut-profit-evidence-custody-and-capital-reentry-auction-2026-05-07.md`


### PR DESCRIPTION
## Summary

- Added a Jangar architecture contract for verification trust escrow and query-budgeted evidence settlement.
- Added a Torghut companion contract for post-cost alpha reentry and a proof-query repair market.
- Updated the Agents and Torghut design indexes so the new contracts are the current handoff entry points.

## Related Issues

None

## Testing

- `git diff --check`
- `bunx oxfmt --check docs/agents/README.md docs/agents/designs/136-jangar-verification-trust-escrow-and-query-budgeted-evidence-settlement-2026-05-07.md docs/torghut/design-system/v6/index.md docs/torghut/design-system/v6/140-torghut-post-cost-alpha-reentry-and-proof-query-market-2026-05-07.md`

## Screenshots (if applicable)

N/A: documentation-only architecture change.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
