### PR TITLE
chore(torghut): promote image 42404bd2

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:cc3918979fa7e5a88ba190f54c529b6af9d74eb758f5609c8f1b8ad1df2e0f1c
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:bd791099b00b63667a5038ab3293084b0889f0e8914671c9c4049b4492b07b64
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.569.1-122-g1d8f6345b
+              value: v0.569.1-125-g42404bd28
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 1d8f6345b3d93b27691509ca7724e97041131686
+              value: 42404bd2803529dc7802deb0e96c1c9fb4e859ce
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:cc3918979fa7e5a88ba190f54c529b6af9d74eb758f5609c8f1b8ad1df2e0f1c
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:bd791099b00b63667a5038ab3293084b0889f0e8914671c9c4049b4492b07b64
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.569.1-122-g1d8f6345b
+              value: v0.569.1-125-g42404bd28
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 1d8f6345b3d93b27691509ca7724e97041131686
+              value: 42404bd2803529dc7802deb0e96c1c9fb4e859ce
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:cc3918979fa7e5a88ba190f54c529b6af9d74eb758f5609c8f1b8ad1df2e0f1c
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:bd791099b00b63667a5038ab3293084b0889f0e8914671c9c4049b4492b07b64
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:cc3918979fa7e5a88ba190f54c529b6af9d74eb758f5609c8f1b8ad1df2e0f1c
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:bd791099b00b63667a5038ab3293084b0889f0e8914671c9c4049b4492b07b64
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:cc3918979fa7e5a88ba190f54c529b6af9d74eb758f5609c8f1b8ad1df2e0f1c
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:bd791099b00b63667a5038ab3293084b0889f0e8914671c9c4049b4492b07b64
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:cc3918979fa7e5a88ba190f54c529b6af9d74eb758f5609c8f1b8ad1df2e0f1c
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:bd791099b00b63667a5038ab3293084b0889f0e8914671c9c4049b4492b07b64
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:cc3918979fa7e5a88ba190f54c529b6af9d74eb758f5609c8f1b8ad1df2e0f1c
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:bd791099b00b63667a5038ab3293084b0889f0e8914671c9c4049b4492b07b64
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -15,7 +15,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:cc3918979fa7e5a88ba190f54c529b6af9d74eb758f5609c8f1b8ad1df2e0f1c
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:bd791099b00b63667a5038ab3293084b0889f0e8914671c9c4049b4492b07b64
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -23,7 +23,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:cc3918979fa7e5a88ba190f54c529b6af9d74eb758f5609c8f1b8ad1df2e0f1c
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:bd791099b00b63667a5038ab3293084b0889f0e8914671c9c4049b4492b07b64
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:cc3918979fa7e5a88ba190f54c529b6af9d74eb758f5609c8f1b8ad1df2e0f1c
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:bd791099b00b63667a5038ab3293084b0889f0e8914671c9c4049b4492b07b64
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-13T05:22:15Z"
+        client.knative.dev/updateTimestamp: "2026-05-13T05:33:40Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -27,7 +27,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:cc3918979fa7e5a88ba190f54c529b6af9d74eb758f5609c8f1b8ad1df2e0f1c
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:bd791099b00b63667a5038ab3293084b0889f0e8914671c9c4049b4492b07b64
           ports:
             - name: http1
               containerPort: 8181
@@ -482,9 +482,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.569.1-122-g1d8f6345b
+              value: v0.569.1-125-g42404bd28
             - name: TORGHUT_COMMIT
-              value: 1d8f6345b3d93b27691509ca7724e97041131686
+              value: 42404bd2803529dc7802deb0e96c1c9fb4e859ce
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-13T05:22:15Z"
+        client.knative.dev/updateTimestamp: "2026-05-13T05:33:40Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:cc3918979fa7e5a88ba190f54c529b6af9d74eb758f5609c8f1b8ad1df2e0f1c
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:bd791099b00b63667a5038ab3293084b0889f0e8914671c9c4049b4492b07b64
           ports:
             - name: http1
               containerPort: 8181
@@ -298,9 +298,9 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.569.1-122-g1d8f6345b
+              value: v0.569.1-125-g42404bd28
             - name: TORGHUT_COMMIT
-              value: 1d8f6345b3d93b27691509ca7724e97041131686
+              value: 42404bd2803529dc7802deb0e96c1c9fb4e859ce
           livenessProbe:
             httpGet:
               path: /healthz

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -86,7 +86,7 @@ spec:
           - name: allowStaleTape
           - name: persistResults
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:cc3918979fa7e5a88ba190f54c529b6af9d74eb758f5609c8f1b8ad1df2e0f1c
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:bd791099b00b63667a5038ab3293084b0889f0e8914671c9c4049b4492b07b64
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
+++ b/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:cc3918979fa7e5a88ba190f54c529b6af9d74eb758f5609c8f1b8ad1df2e0f1c
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:bd791099b00b63667a5038ab3293084b0889f0e8914671c9c4049b4492b07b64
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `42404bd2803529dc7802deb0e96c1c9fb4e859ce`
- Image tag: `42404bd2`
- Image digest: `sha256:bd791099b00b63667a5038ab3293084b0889f0e8914671c9c4049b4492b07b64`