### PR TITLE
fix(torghut): run autoresearch workflow against 500 target

### DIFF
--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -29,7 +29,7 @@ spec:
       - name: expectedLastTradingDay
         value: '2026-05-01'
       - name: targetNetPnlPerDay
-        value: '300'
+        value: '500'
       - name: maxCandidates
         value: '64'
       - name: topK
@@ -144,7 +144,7 @@ spec:
               --portfolio-size-min "{{inputs.parameters.portfolioSizeMin}}"
               --portfolio-size-max "{{inputs.parameters.portfolioSizeMax}}"
               --replay-mode real
-              --program config/trading/research-programs/strict-daily-profit-autoresearch-300-v1.yaml
+              --program config/trading/research-programs/strict-daily-profit-autoresearch-500-v1.yaml
               --strategy-configmap /etc/torghut/strategies.yaml
               --clickhouse-http-url "${TA_CLICKHOUSE_URL}"
               --clickhouse-username "${TA_CLICKHOUSE_USERNAME}"

--- a/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
+++ b/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
@@ -108,6 +108,13 @@ describe('Torghut manifest scheduling', () => {
       }),
     )
     expect(JSON.stringify(template)).toContain('run_whitepaper_autoresearch_profit_target.py')
+    expect(parameterValue(manifest, 'targetNetPnlPerDay')).toBe('500')
+    expect(JSON.stringify(template)).toContain(
+      'config/trading/research-programs/strict-daily-profit-autoresearch-500-v1.yaml',
+    )
+    expect(JSON.stringify(template)).not.toContain(
+      'config/trading/research-programs/strict-daily-profit-autoresearch-300-v1.yaml',
+    )
     expect(JSON.stringify(template)).toContain('--require-no-flat-days')
     expect(JSON.stringify(template)).toContain('--real-replay-shard-size')
     expect(JSON.stringify(template)).toContain('--real-replay-shard-timeout-seconds')


### PR DESCRIPTION
## Summary

- Update the Torghut whitepaper autoresearch WorkflowTemplate default target from `$300/day` to `$500/day`.
- Point the deployed workflow at `strict-daily-profit-autoresearch-500-v1.yaml` instead of the old 300-dollar research program.
- Add manifest scheduling assertions so the workflow cannot silently drift back to the 300-dollar profile.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts`
- `bunx oxfmt --check packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts`
- `bunx oxlint --config .oxlintrc.json packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts`
- `git diff --check`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
