### PR TITLE
fix(jangar): preserve controller heartbeat witnesses

### DIFF
--- a/docs/agents/runbooks.md
+++ b/docs/agents/runbooks.md
@@ -184,6 +184,9 @@ Expected outcomes:
   route-stability contracts, retained workflow failure debt, and Torghut consumer/profit-window evidence.
   `serve_readonly` may remain `allow` while `dispatch_normal`, `deploy_widen`, `merge_ready`, and capital actions are
   held or blocked.
+- Controller-process heartbeat rows are positive authority only when the component is enabled in that process. Disabled
+  rows are intentionally skipped so a serving or alternate controller process cannot overwrite the current
+  `agents-controllers` ingestion witness; missing or stale rows still keep normal dispatch in repair/hold.
 - `dependency_verdict_exchange` cites design doc 186 and exposes the Torghut route-warrant dispatch verdicts.
   Read-only service may stay `allow`; bounded repair is only `repair_only` when a fresh Torghut warrant names
   zero-notional repair packets and target value gates. `implement`, `deploy_widen`, `merge_ready`, paper, and live

--- a/services/jangar/README.md
+++ b/services/jangar/README.md
@@ -407,7 +407,9 @@ controller-process heartbeats, `agents-controllers` rollout evidence, watch epoc
 When the serving process is not the controller, a healthy controller heartbeat can satisfy controller self-report. If
 only the controller deployment and watch epoch are current, Jangar records `controller_witness_split`, keeps bounded
 repair dispatch available, and downgrades normal dispatch to `repair_only` until a controller-process ingestion
-witness is current. A true AgentRun ingestion stall records `controller_ingestion_stalled` and holds normal dispatch.
+witness is current. Disabled component state from a non-authoritative process is not written as a heartbeat row, so it
+cannot overwrite a current controller-process witness for the same component. A true AgentRun ingestion stall records
+`controller_ingestion_stalled` and holds normal dispatch.
 
 `material_action_activation_receipts` mirror each action SLO budget with controller witness refs, negative evidence
 refs, max dispatch/runtime/notional limits, expiry, and rollback target. Rollback: keep the witness contract in shadow

--- a/services/jangar/src/server/__tests__/control-plane-heartbeat-publisher.test.ts
+++ b/services/jangar/src/server/__tests__/control-plane-heartbeat-publisher.test.ts
@@ -104,10 +104,10 @@ describe('control-plane heartbeat publisher', () => {
     expect(upsertHeartbeat).not.toHaveBeenCalled()
   })
 
-  it('publishes disabled rows when the authoritative workload disables a component', async () => {
+  it('skips disabled rows so non-authoritative workloads do not overwrite controller witnesses', async () => {
     const upsertHeartbeat = vi.fn(async () => undefined)
 
-    await publishControlPlaneHeartbeatsOnce({
+    const published = await publishControlPlaneHeartbeatsOnce({
       now: () => new Date('2026-03-08T12:00:00Z'),
       getLeaderStatus: () => leaderStatus,
       getAgentsHealth: () => ({
@@ -125,21 +125,14 @@ describe('control-plane heartbeat publisher', () => {
       }),
     })
 
+    expect(published).toBe(2)
+    expect(upsertHeartbeat).not.toHaveBeenCalledWith(expect.objectContaining({ component: 'agents-controller' }))
+    expect(upsertHeartbeat).not.toHaveBeenCalledWith(expect.objectContaining({ component: 'workflow-runtime' }))
     expect(upsertHeartbeat).toHaveBeenCalledWith(
-      expect.objectContaining({
-        component: 'agents-controller',
-        enabled: false,
-        status: 'disabled',
-        message: 'agents controller disabled',
-      }),
+      expect.objectContaining({ component: 'supporting-controller', status: 'healthy' }),
     )
     expect(upsertHeartbeat).toHaveBeenCalledWith(
-      expect.objectContaining({
-        component: 'workflow-runtime',
-        enabled: false,
-        status: 'disabled',
-        message: 'workflow runtime disabled',
-      }),
+      expect.objectContaining({ component: 'orchestration-controller', status: 'healthy' }),
     )
   })
 

--- a/services/jangar/src/server/control-plane-heartbeat-publisher.ts
+++ b/services/jangar/src/server/control-plane-heartbeat-publisher.ts
@@ -224,6 +224,9 @@ export const buildControlPlaneHeartbeatInputs = ({
 
   return componentStates.flatMap(({ component, health, namespaces }) => {
     const state = buildComponentState(component, health)
+    if (!state.enabled) {
+      return []
+    }
     return namespaces.map((namespace) => ({
       namespace,
       component,


### PR DESCRIPTION
## Summary

- Shipped a controller heartbeat repair for Jangar: disabled component state is no longer written as a heartbeat row, so a serving or alternate process cannot overwrite the active `agents-controllers` ingestion witness.
- Updated regression coverage for heartbeat publishing to prove disabled components are skipped while enabled supporting/orchestration controller components still publish.
- Updated `services/jangar/README.md` and `docs/agents/runbooks.md` with the controller-witness authority rule and conservative repair/hold behavior.
- Design provenance: `docs/agents/designs/swarm-agentic-mission-architecture-2026-05-08.md`, `docs/agents/designs/116-jangar-controller-witness-quorum-and-capital-activation-receipts-2026-05-06.md`, and `docs/agents/designs/121-jangar-material-action-repair-clearing-lane-and-profit-proof-ledger-2026-05-06.md`.
- Runtime requirement provenance: live status on deployed `99063cb4` reported `agentrun_ingestion_not_current`, `controller_heartbeat_not_current`, `controller_witness_split`, and repair action `publish a fresh controller-process ingestion witness` while Argo apps were `Synced/Healthy` and `agents-controllers` was available.

## Related Issues

None

## Testing

- `bun run --filter @proompteng/jangar pretest` passed.
- `bunx vitest run --config vitest.config.ts src/server/__tests__/control-plane-heartbeat-publisher.test.ts` passed in `services/jangar` with 4 tests.
- `bunx vitest run --config vitest.config.ts src/server/__tests__/control-plane-heartbeat-publisher.test.ts src/server/__tests__/control-plane-status.test.ts` passed in `services/jangar` with 31 tests.
- `bun run --filter @proompteng/jangar test` passed with 181 files and 1126 tests.
- `bun run --filter @proompteng/jangar tsc` passed.
- `bun run --filter @proompteng/jangar lint` passed.
- `bun run --filter @proompteng/jangar lint:oxlint` passed with existing warnings and zero errors.
- `bun run --cwd services/jangar docs:inventory:check` passed.
- `bun run --cwd services/jangar check:module-sizes` passed.
- `bunx oxfmt --check services/jangar/src/server/control-plane-heartbeat-publisher.ts services/jangar/src/server/__tests__/control-plane-heartbeat-publisher.test.ts services/jangar/README.md docs/agents/runbooks.md` passed.
- `git diff --check` passed.

## Breaking Changes

None

## Risk And Rollback

Risk is low and intentionally conservative: disabled local component state stops overwriting positive controller-process evidence, while missing or stale enabled heartbeats still hold normal dispatch in repair mode. Rollback is a revert of `fix(jangar): preserve controller heartbeat witnesses`; the pre-existing witness contract remains conservative and continues to hold normal dispatch when controller ingestion evidence is missing or stale.

## Release Note

Jangar now preserves controller-process heartbeat truth by skipping disabled component heartbeat rows from non-authoritative processes. This improves `ready_status_truth`, `failed_agentrun_rate`, and `handoff_evidence_quality` by reducing false controller-witness split/repair states after green rollout.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
