### PR TITLE
chore(jangar): promote image f18b66fd

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 99063cb4
-  digest: sha256:e4a0bb4550412477c894630552ce48f5dfa69636e02c80e65a42abb78a6da1c8
+  tag: f18b66fd
+  digest: sha256:12ef2baa2e6e83562bb817246de6aaed64bb9cfd332057dd9c7275cdcbf773ea
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,8 +11,8 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 99063cb4
-    digest: sha256:0d5bf746728f842e1112270809ff5bc52fa369ad248ad39588803a2e3dee86b9
+    tag: f18b66fd
+    digest: sha256:5afc401d5e7712b29d4efccfd0e1be6f52aafa5d027e965cd7849fea510963f6
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
@@ -21,8 +21,8 @@ controlPlane:
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 99063cb4
-    digest: sha256:e4a0bb4550412477c894630552ce48f5dfa69636e02c80e65a42abb78a6da1c8
+    tag: f18b66fd
+    digest: sha256:12ef2baa2e6e83562bb817246de6aaed64bb9cfd332057dd9c7275cdcbf773ea
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-13T05:54:32Z
+    deploy.knative.dev/rollout: 2026-05-13T06:17:09Z
 spec:
   replicas: 1
   strategy:
@@ -57,11 +57,11 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_RUNTIME_IMAGE
-              value: registry.ide-newton.ts.net/lab/jangar:99063cb4@sha256:e4a0bb4550412477c894630552ce48f5dfa69636e02c80e65a42abb78a6da1c8
+              value: registry.ide-newton.ts.net/lab/jangar:f18b66fd@sha256:12ef2baa2e6e83562bb817246de6aaed64bb9cfd332057dd9c7275cdcbf773ea
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: 99063cb4c14e0c22633f6d2a63391ca59ee6a6b3
+              value: f18b66fdbc4e55bc2ef7177fc17fd86ea8a491b2
             - name: JANGAR_GITOPS_REVISION
-              value: 99063cb4c14e0c22633f6d2a63391ca59ee6a6b3
+              value: f18b66fdbc4e55bc2ef7177fc17fd86ea8a491b2
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_BUMBA_TASK_QUEUE

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -59,5 +59,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: 99063cb4
-    digest: sha256:e4a0bb4550412477c894630552ce48f5dfa69636e02c80e65a42abb78a6da1c8
+    newTag: f18b66fd
+    digest: sha256:12ef2baa2e6e83562bb817246de6aaed64bb9cfd332057dd9c7275cdcbf773ea


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `f18b66fdbc4e55bc2ef7177fc17fd86ea8a491b2`
- Image tag: `f18b66fd`
- Image digest: `sha256:12ef2baa2e6e83562bb817246de6aaed64bb9cfd332057dd9c7275cdcbf773ea`
- Updated API rollout annotation
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`