### PR TITLE
fix(torghut): prevent autoresearch breadth fast paths

### DIFF
--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -1080,6 +1080,11 @@ def _candidate_search_remediation(
     best_false_negative_table: Sequence[Mapping[str, Any]],
     replay_timeout_seconds: int,
     max_frontier_candidates_per_spec: int,
+    current_top_k: int = 16,
+    current_exploration_slots: int = 8,
+    current_portfolio_size_min: int = 2,
+    current_max_candidates: int = 64,
+    current_max_total_frontier_candidates: int = 0,
 ) -> dict[str, Any]:
     failure_counts: dict[str, int] = {}
     for row in _list_of_mappings(list(false_positive_table)):
@@ -1173,16 +1178,38 @@ def _candidate_search_remediation(
             "positive_day_ratio_below_oracle",
         )
     ):
+        next_top_k = min(
+            max(1, current_max_candidates),
+            max(16, current_top_k + max(4, current_exploration_slots)),
+        )
+        next_exploration_slots = min(
+            max(1, current_max_candidates),
+            max(8, current_exploration_slots + max(4, current_exploration_slots)),
+        )
+        next_max_candidates = max(
+            current_max_candidates,
+            next_top_k + next_exploration_slots,
+            min(128, current_max_candidates + 32),
+        )
+        recommended_flags = {
+            "--max-candidates": str(next_max_candidates),
+            "--top-k": str(next_top_k),
+            "--exploration-slots": str(next_exploration_slots),
+            "--portfolio-size-min": str(max(3, current_portfolio_size_min)),
+        }
+        if current_max_total_frontier_candidates > 0:
+            recommended_flags["--max-total-frontier-candidates"] = str(
+                max(
+                    current_max_total_frontier_candidates,
+                    min(128, current_max_total_frontier_candidates * 2),
+                )
+            )
         next_actions.append(
             {
                 "priority": 4,
                 "action": "increase_breadth_and_portfolio_diversity",
                 "reason": "replayed candidates had flat or non-positive days",
-                "recommended_flags": {
-                    "--top-k": str(max(4, len(selected_rows))),
-                    "--exploration-slots": "4",
-                    "--portfolio-size-min": "3",
-                },
+                "recommended_flags": recommended_flags,
             }
         )
     if any(
@@ -1486,42 +1513,161 @@ def _profitability_next_epoch_flags(
     target: Decimal,
     remediation: Mapping[str, Any] | None,
 ) -> dict[str, str]:
+    return cast(
+        dict[str, str],
+        _profitability_next_epoch_plan(
+            args=args, target=target, remediation=remediation
+        )["flags"],
+    )
+
+
+def _int_arg(args: argparse.Namespace, name: str, default: int) -> int:
+    try:
+        return int(getattr(args, name, default) or default)
+    except (TypeError, ValueError):
+        return default
+
+
+def _flag_int(value: Any) -> int | None:
+    text = _string(value)
+    if not text:
+        return None
+    try:
+        return int(text)
+    except ValueError:
+        return None
+
+
+def _profitability_next_epoch_plan(
+    *,
+    args: argparse.Namespace,
+    target: Decimal,
+    remediation: Mapping[str, Any] | None,
+) -> dict[str, Any]:
     flags: dict[str, str] = {
         "--target-net-pnl-per-day": str(target),
         "--program": str(
             getattr(args, "program", _DEFAULT_STRICT_DAILY_PROFIT_PROGRAM)
         ),
         "--replay-mode": "real",
-        "--top-k": str(max(16, int(getattr(args, "top_k", 16) or 16))),
-        "--exploration-slots": str(
-            max(8, int(getattr(args, "exploration_slots", 8) or 8))
-        ),
-        "--portfolio-size-min": str(
-            max(2, int(getattr(args, "portfolio_size_min", 2) or 2))
-        ),
-        "--portfolio-size-max": str(
-            max(8, int(getattr(args, "portfolio_size_max", 8) or 8))
-        ),
+        "--max-candidates": str(max(64, _int_arg(args, "max_candidates", 64))),
+        "--top-k": str(max(16, _int_arg(args, "top_k", 16))),
+        "--exploration-slots": str(max(8, _int_arg(args, "exploration_slots", 8))),
+        "--portfolio-size-min": str(max(2, _int_arg(args, "portfolio_size_min", 2))),
+        "--portfolio-size-max": str(max(8, _int_arg(args, "portfolio_size_max", 8))),
         "--max-frontier-candidates-per-spec": str(
             max(
                 1,
-                int(
-                    getattr(
-                        args,
-                        "max_frontier_candidates_per_spec",
-                        _DEFAULT_MAX_FRONTIER_CANDIDATES_PER_SPEC,
-                    )
-                    or _DEFAULT_MAX_FRONTIER_CANDIDATES_PER_SPEC
+                _int_arg(
+                    args,
+                    "max_frontier_candidates_per_spec",
+                    _DEFAULT_MAX_FRONTIER_CANDIDATES_PER_SPEC,
                 ),
             )
         ),
     }
+    max_total_frontier_candidates = _int_arg(args, "max_total_frontier_candidates", 0)
+    if max_total_frontier_candidates > 0:
+        flags["--max-total-frontier-candidates"] = str(max_total_frontier_candidates)
+    real_replay_timeout_seconds = _int_arg(args, "real_replay_timeout_seconds", 0)
+    if real_replay_timeout_seconds > 0:
+        flags["--real-replay-timeout-seconds"] = str(real_replay_timeout_seconds)
+    real_replay_shard_size = _int_arg(args, "real_replay_shard_size", 0)
+    if real_replay_shard_size > 0:
+        flags["--real-replay-shard-size"] = str(real_replay_shard_size)
+    real_replay_shard_timeout_seconds = _int_arg(
+        args, "real_replay_shard_timeout_seconds", 0
+    )
+    if real_replay_shard_timeout_seconds > 0:
+        flags["--real-replay-shard-timeout-seconds"] = str(
+            real_replay_shard_timeout_seconds
+        )
+    real_replay_shard_workers = _int_arg(args, "real_replay_shard_workers", 1)
+    if real_replay_shard_workers > 1:
+        flags["--real-replay-shard-workers"] = str(real_replay_shard_workers)
+
+    applied_recommended_flags: list[dict[str, str]] = []
+    rejected_recommended_flags: list[dict[str, str]] = []
+    monotonic_int_flags = {
+        "--max-candidates",
+        "--top-k",
+        "--exploration-slots",
+        "--portfolio-size-min",
+        "--portfolio-size-max",
+        "--max-total-frontier-candidates",
+        "--real-replay-timeout-seconds",
+    }
     if remediation is not None:
         for action in _list_of_mappings(remediation.get("next_actions")):
+            action_name = _string(action.get("action"))
             for key, value in _mapping(action.get("recommended_flags")).items():
                 if key.startswith("--") and _string(value):
+                    current_value = flags.get(key)
+                    current_int = _flag_int(current_value)
+                    recommended_int = _flag_int(value)
+                    if key in monotonic_int_flags and recommended_int is None:
+                        rejected_recommended_flags.append(
+                            {
+                                "action": action_name,
+                                "flag": key,
+                                "current_value": str(current_value or ""),
+                                "recommended_value": _string(value),
+                                "reason": "rejected_invalid_numeric_remediation_flag",
+                            }
+                        )
+                        continue
+                    if (
+                        key in monotonic_int_flags
+                        and current_int is not None
+                        and recommended_int is not None
+                        and recommended_int < current_int
+                    ):
+                        rejected_recommended_flags.append(
+                            {
+                                "action": action_name,
+                                "flag": key,
+                                "current_value": str(current_int),
+                                "recommended_value": str(recommended_int),
+                                "reason": (
+                                    "rejected_to_preserve_or_increase_search_breadth"
+                                ),
+                            }
+                        )
+                        continue
                     flags[key] = _string(value)
-    return flags
+                    applied_recommended_flags.append(
+                        {
+                            "action": action_name,
+                            "flag": key,
+                            "value": _string(value),
+                        }
+                    )
+    argv: list[str] = [
+        "python",
+        "services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py",
+        "--output-dir",
+        "<next-epoch-output-dir>",
+    ]
+    for key, value in flags.items():
+        argv.extend([key, value])
+    return {
+        "entrypoint": "services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py",
+        "flags": flags,
+        "argv": argv,
+        "applied_recommended_flags": applied_recommended_flags,
+        "rejected_recommended_flags": rejected_recommended_flags,
+        "no_fast_path_policy": {
+            "target_net_pnl_per_day_is_fixed": str(target),
+            "replay_mode": "real",
+            "monotonic_search_flags": sorted(monotonic_int_flags),
+            "allowed_decreases": [
+                (
+                    "timeout remediation may reduce "
+                    "--max-frontier-candidates-per-spec only to finish complete evidence"
+                )
+            ],
+        },
+    }
 
 
 def _profitability_search_goal(
@@ -1548,7 +1694,7 @@ def _profitability_search_goal(
     remediation: Mapping[str, Any] | None,
 ) -> dict[str, Any]:
     replay_mode = _string(getattr(args, "replay_mode", "")) or "real"
-    next_epoch_flags = _profitability_next_epoch_flags(
+    next_epoch_plan = _profitability_next_epoch_plan(
         args=args, target=target, remediation=remediation
     )
     return {
@@ -1633,10 +1779,7 @@ def _profitability_search_goal(
             "program_forbidden_mutations": list(program.forbidden_mutations),
             "promotion_policy": program.promotion_policy,
         },
-        "recommended_next_epoch": {
-            "entrypoint": "services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py",
-            "flags": next_epoch_flags,
-        },
+        "recommended_next_epoch": next_epoch_plan,
         "profit_target_oracle": dict(profit_target_oracle or {}),
         "candidate_search_remediation": dict(remediation or {}),
         "artifacts": {
@@ -2940,6 +3083,13 @@ def run_whitepaper_autoresearch_profit_target(
                 )
                 or _DEFAULT_MAX_FRONTIER_CANDIDATES_PER_SPEC
             ),
+            current_top_k=int(getattr(args, "top_k", 16) or 16),
+            current_exploration_slots=int(getattr(args, "exploration_slots", 8) or 8),
+            current_portfolio_size_min=int(getattr(args, "portfolio_size_min", 2) or 2),
+            current_max_candidates=int(getattr(args, "max_candidates", 64) or 64),
+            current_max_total_frontier_candidates=int(
+                getattr(args, "max_total_frontier_candidates", 0) or 0
+            ),
         )
         remediation_path = output_dir / "candidate-search-remediation.json"
         _write_json(remediation_path, remediation)
@@ -3125,6 +3275,13 @@ def run_whitepaper_autoresearch_profit_target(
                     _DEFAULT_MAX_FRONTIER_CANDIDATES_PER_SPEC,
                 )
                 or _DEFAULT_MAX_FRONTIER_CANDIDATES_PER_SPEC
+            ),
+            current_top_k=int(getattr(args, "top_k", 16) or 16),
+            current_exploration_slots=int(getattr(args, "exploration_slots", 8) or 8),
+            current_portfolio_size_min=int(getattr(args, "portfolio_size_min", 2) or 2),
+            current_max_candidates=int(getattr(args, "max_candidates", 64) or 64),
+            current_max_total_frontier_candidates=int(
+                getattr(args, "max_total_frontier_candidates", 0) or 0
             ),
         )
         _write_json(remediation_path, candidate_search_remediation)

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -1033,6 +1033,184 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             proof_action["required_scorecard_fields"],
         )
 
+    def test_remediation_increases_breadth_from_current_epoch(self) -> None:
+        remediation = runner._candidate_search_remediation(
+            failure_reason="portfolio_optimizer_produced_no_candidate",
+            candidate_selection={
+                "rows": [
+                    {
+                        "candidate_spec_id": "spec-selected",
+                        "selected_for_replay": True,
+                    }
+                ]
+            },
+            evidence_bundles=(),
+            false_positive_table=(
+                {
+                    "candidate_spec_id": "spec-selected",
+                    "evidence_status": "replayed",
+                    "failure_reasons": [
+                        "active_day_ratio_below_oracle",
+                        "positive_day_ratio_below_oracle",
+                    ],
+                },
+            ),
+            best_false_negative_table=(),
+            replay_timeout_seconds=7200,
+            max_frontier_candidates_per_spec=2,
+            current_top_k=16,
+            current_exploration_slots=8,
+            current_portfolio_size_min=2,
+            current_max_candidates=64,
+            current_max_total_frontier_candidates=24,
+        )
+
+        breadth_action = remediation["next_actions"][0]
+        self.assertEqual(
+            breadth_action["action"], "increase_breadth_and_portfolio_diversity"
+        )
+        self.assertEqual(breadth_action["recommended_flags"]["--top-k"], "24")
+        self.assertEqual(
+            breadth_action["recommended_flags"]["--exploration-slots"], "16"
+        )
+        self.assertEqual(breadth_action["recommended_flags"]["--max-candidates"], "96")
+        self.assertEqual(
+            breadth_action["recommended_flags"]["--max-total-frontier-candidates"],
+            "48",
+        )
+        self.assertEqual(
+            breadth_action["recommended_flags"]["--portfolio-size-min"], "3"
+        )
+
+    def test_next_epoch_plan_rejects_breadth_shrinking_remediation_flags(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            args = self._args(Path(tmpdir) / "epoch")
+            args.max_candidates = 64
+            args.top_k = 16
+            args.exploration_slots = 8
+            args.portfolio_size_min = 2
+            args.replay_mode = "real"
+            remediation = {
+                "next_actions": [
+                    {
+                        "action": "increase_breadth_and_portfolio_diversity",
+                        "recommended_flags": {
+                            "--top-k": "11",
+                            "--exploration-slots": "4",
+                            "--portfolio-size-min": "3",
+                        },
+                    }
+                ]
+            }
+
+            plan = runner._profitability_next_epoch_plan(
+                args=args, target=Decimal("500"), remediation=remediation
+            )
+
+        self.assertEqual(plan["flags"]["--target-net-pnl-per-day"], "500")
+        self.assertEqual(plan["flags"]["--replay-mode"], "real")
+        self.assertEqual(plan["flags"]["--max-candidates"], "64")
+        self.assertEqual(plan["flags"]["--top-k"], "16")
+        self.assertEqual(plan["flags"]["--exploration-slots"], "8")
+        self.assertEqual(plan["flags"]["--portfolio-size-min"], "3")
+        self.assertIn(
+            {
+                "action": "increase_breadth_and_portfolio_diversity",
+                "flag": "--top-k",
+                "current_value": "16",
+                "recommended_value": "11",
+                "reason": "rejected_to_preserve_or_increase_search_breadth",
+            },
+            plan["rejected_recommended_flags"],
+        )
+        self.assertIn(
+            {
+                "action": "increase_breadth_and_portfolio_diversity",
+                "flag": "--exploration-slots",
+                "current_value": "8",
+                "recommended_value": "4",
+                "reason": "rejected_to_preserve_or_increase_search_breadth",
+            },
+            plan["rejected_recommended_flags"],
+        )
+        self.assertIn(
+            "timeout remediation may reduce --max-frontier-candidates-per-spec only to finish complete evidence",
+            plan["no_fast_path_policy"]["allowed_decreases"],
+        )
+
+    def test_next_epoch_plan_allows_timeout_frontier_shrink_only(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            args = self._args(Path(tmpdir) / "epoch")
+            args.max_frontier_candidates_per_spec = 8
+            remediation = {
+                "next_actions": [
+                    {
+                        "action": "shrink_per_spec_frontier_or_extend_timeout",
+                        "recommended_flags": {
+                            "--max-frontier-candidates-per-spec": "2",
+                            "--real-replay-timeout-seconds": "7200",
+                        },
+                    }
+                ]
+            }
+
+            plan = runner._profitability_next_epoch_plan(
+                args=args, target=Decimal("500"), remediation=remediation
+            )
+
+        self.assertEqual(plan["flags"]["--max-frontier-candidates-per-spec"], "2")
+        self.assertEqual(plan["flags"]["--real-replay-timeout-seconds"], "7200")
+        self.assertFalse(plan["rejected_recommended_flags"])
+
+    def test_next_epoch_plan_preserves_runtime_flags_and_rejects_invalid_numbers(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as tmpdir:
+            args = self._args(Path(tmpdir) / "epoch")
+            args.max_candidates = "not-a-number"
+            args.max_total_frontier_candidates = 24
+            args.real_replay_timeout_seconds = 7200
+            args.real_replay_shard_size = 2
+            args.real_replay_shard_timeout_seconds = 900
+            args.real_replay_shard_workers = 3
+            remediation = {
+                "next_actions": [
+                    {
+                        "action": "increase_breadth_and_portfolio_diversity",
+                        "recommended_flags": {
+                            "--top-k": "not-a-number",
+                            "--max-total-frontier-candidates": "48",
+                        },
+                    }
+                ]
+            }
+
+            plan = runner._profitability_next_epoch_plan(
+                args=args, target=Decimal("500"), remediation=remediation
+            )
+            flags = runner._profitability_next_epoch_flags(
+                args=args, target=Decimal("500"), remediation=remediation
+            )
+
+        self.assertEqual(flags, plan["flags"])
+        self.assertEqual(plan["flags"]["--max-candidates"], "64")
+        self.assertEqual(plan["flags"]["--top-k"], "16")
+        self.assertEqual(plan["flags"]["--max-total-frontier-candidates"], "48")
+        self.assertEqual(plan["flags"]["--real-replay-timeout-seconds"], "7200")
+        self.assertEqual(plan["flags"]["--real-replay-shard-size"], "2")
+        self.assertEqual(plan["flags"]["--real-replay-shard-timeout-seconds"], "900")
+        self.assertEqual(plan["flags"]["--real-replay-shard-workers"], "3")
+        self.assertIn(
+            {
+                "action": "increase_breadth_and_portfolio_diversity",
+                "flag": "--top-k",
+                "current_value": "16",
+                "recommended_value": "not-a-number",
+                "reason": "rejected_invalid_numeric_remediation_flag",
+            },
+            plan["rejected_recommended_flags"],
+        )
+
     def test_train_ranker_script_main_writes_model_and_scores(self) -> None:
         with TemporaryDirectory() as tmpdir:
             output_dir = Path(tmpdir) / "epoch"


### PR DESCRIPTION
## Summary

- Corrects Torghut autoresearch remediation so `increase_breadth_and_portfolio_diversity` grows search breadth from the current epoch instead of emitting smaller `top-k` or exploration settings.
- Adds an auditable recommended next-epoch plan with command argv, applied/rejected remediation flags, preserved `$500/day` target, real replay, and an explicit no-fast-path policy.
- Adds regression coverage for breadth growth, rejected breadth-shrinking recommendations, and timeout-only frontier shrinking.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py -k 'next_epoch_plan or remediation_increases_breadth or remediation_prioritizes_missing_promotion_proof or timeout_remediation'`
- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv run --frozen ruff format --check scripts/run_whitepaper_autoresearch_profit_target.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv run --frozen ruff check scripts/run_whitepaper_autoresearch_profit_target.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen coverage run -m pytest tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv run --frozen coverage xml --fail-under=0`
- `GITHUB_BASE_REF=main GITHUB_EVENT_NAME=pull_request uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
