### PR TITLE
fix(torghut): require repair dispatch tickets

### DIFF
--- a/docs/agents/designs/186-jangar-repair-bid-admission-and-settlement-custody-2026-05-13.md
+++ b/docs/agents/designs/186-jangar-repair-bid-admission-and-settlement-custody-2026-05-13.md
@@ -242,6 +242,19 @@ Engineer milestone 2:
 - Add deployer validation output that ties Argo, runtime kit, Torghut `/readyz`, settlement ledger, and dispatch ticket
   refs together.
 
+### Implementation Note (2026-05-13, Torghut Dispatch Guard)
+
+Torghut milestone 2 now starts at the zero-notional repair executor boundary. Runner-backed repair actions that require
+Jangar admission fail closed unless the caller supplies a `jangar.repair-lot-dispatch-ticket.v1` body proving launch is
+allowed for the selected compacted lot, `max_notional=0`, a dedupe key, a target value gate, a required output receipt,
+and an explicit TTL through `max_runtime_seconds`.
+
+The `/trading/profit-freshness/zero-notional-repair` endpoint accepts that dispatch ticket as the POST body and passes it
+into `run_zero_notional_repair`. Missing, denied, mismatched, malformed, nonzero-notional, or wrong-value-gate tickets
+return `repair_lot_dispatch_ticket_required` before any local runner is invoked; matching tickets still preserve the
+existing zero-capital receipt invariants. This closes the raw-bid execution path while leaving non-admission repairs such
+as TCA recompute and drift replay unchanged.
+
 ## Validation Gates
 
 Local validation for Jangar PRs:

--- a/docs/torghut/design-system/v6/190-torghut-repair-bid-settlement-and-routeability-proof-compaction-2026-05-13.md
+++ b/docs/torghut/design-system/v6/190-torghut-repair-bid-settlement-and-routeability-proof-compaction-2026-05-13.md
@@ -296,6 +296,14 @@ one `required_output_receipt`, a dedupe key, TTL, validation command, and dispat
 account/window. `routeable_candidate_count` remains zero while any compacted lot is unsettled, preserving the capital
 safety gate until receipt validators land in milestone 2.
 
+### Implementation Note (2026-05-13, Dispatch Ticket Enforcement)
+
+Torghut now enforces the first milestone 2 receipt validator in the zero-notional repair executor. Runner-backed repairs
+that require Jangar admission require a `jangar.repair-lot-dispatch-ticket.v1` proving the selected compacted lot id,
+launch allowance, `max_notional=0`, dedupe key, target value gate, required output receipt, and `max_runtime_seconds`
+TTL before a local runner can execute. The `/trading/profit-freshness/zero-notional-repair` POST body carries that ticket
+through to the executor, and missing or mismatched tickets return a fail-closed receipt without widening capital.
+
 ## Validation Gates
 
 Local validation for Torghut PRs:

--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -1457,6 +1457,13 @@ def trading_profit_freshness_zero_notional_repair(
     ),
     tca_limit: int = Query(default=250, ge=1, le=5000),
     drift_limit: int = Query(default=500, ge=1, le=5000),
+    repair_lot_dispatch_ticket: dict[str, Any] | None = Body(
+        default=None,
+        description=(
+            "Jangar repair_lot_dispatch_ticket authorizing runner-required "
+            "zero-notional repair execution."
+        ),
+    ),
 ) -> dict[str, object]:
     """Plan or run an allowlisted zero-notional repair from the freshness frontier."""
 
@@ -1619,6 +1626,7 @@ def trading_profit_freshness_zero_notional_repair(
         profit_freshness_frontier=frontier,
         execute=execute,
         preferred_action=action,
+        repair_lot_dispatch_ticket=repair_lot_dispatch_ticket,
         runners={
             "recompute_route_tca_and_fill_quality": run_tca_recompute,
             "rerun_drift_checks_for_blocked_hypotheses": run_drift_check_replay,

--- a/services/torghut/app/trading/zero_notional_repair_executor.py
+++ b/services/torghut/app/trading/zero_notional_repair_executor.py
@@ -12,8 +12,10 @@ from typing import Any, cast
 ZERO_NOTIONAL_REPAIR_EXECUTION_SCHEMA_VERSION = (
     "torghut.zero-notional-repair-execution-receipt.v1"
 )
+REPAIR_LOT_DISPATCH_TICKET_SCHEMA_VERSION = "jangar.repair-lot-dispatch-ticket.v1"
 
 _ZERO_VALUES = {"", "0", "0.0", "0.00", "0.0000"}
+_TRUE_VALUES = {"1", "true", "yes", "on", "allow", "allowed"}
 _ALLOWLIST: Mapping[str, Mapping[str, object]] = {
     "renew_empirical_proof_jobs": {
         "executor": "empirical_proof_renewal",
@@ -77,6 +79,19 @@ def _strings(value: object) -> list[str]:
     return result
 
 
+def _bool(value: object) -> bool:
+    if isinstance(value, bool):
+        return value
+    return _text(value).lower() in _TRUE_VALUES
+
+
+def _positive_number(value: object) -> bool:
+    try:
+        return float(_text(value)) > 0
+    except ValueError:
+        return False
+
+
 def _stable_ref(prefix: str, payload: Mapping[str, object]) -> str:
     encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
     return f"{prefix}:{sha256(encoded.encode()).hexdigest()[:20]}"
@@ -127,6 +142,75 @@ def _is_zero(value: object) -> bool:
     return _text(value, "0") in _ZERO_VALUES
 
 
+def _requires_dispatch_ticket(action_contract: Mapping[str, object]) -> bool:
+    return bool(action_contract.get("requires_torghut_admission", False))
+
+
+def _selected_repair_lot_refs(repair: Mapping[str, Any]) -> set[str]:
+    return {
+        ref
+        for ref in (
+            _text(repair.get("lot_id")),
+            _text(repair.get("compacted_lot_ref")),
+            _text(repair.get("torghut_compacted_lot_ref")),
+            _text(repair.get("repair_bid_settlement_lot_ref")),
+        )
+        if ref
+    }
+
+
+def _dispatch_ticket_reasons(
+    repair: Mapping[str, Any],
+    action_contract: Mapping[str, object],
+    ticket: Mapping[str, Any],
+) -> list[str]:
+    if not _requires_dispatch_ticket(action_contract):
+        return []
+
+    reasons: list[str] = []
+    if not ticket:
+        return ["repair_lot_dispatch_ticket_missing"]
+    if _text(ticket.get("schema_version")) != REPAIR_LOT_DISPATCH_TICKET_SCHEMA_VERSION:
+        reasons.append("repair_lot_dispatch_ticket_schema_mismatch")
+    if not _text(ticket.get("ticket_id")):
+        reasons.append("repair_lot_dispatch_ticket_id_missing")
+    if not _bool(ticket.get("launch_allowed")):
+        reasons.append("repair_lot_dispatch_ticket_not_allowed")
+    if "max_notional" not in ticket:
+        reasons.append("repair_lot_dispatch_ticket_notional_missing")
+    elif not _is_zero(ticket.get("max_notional")):
+        reasons.append("repair_lot_dispatch_ticket_notional_nonzero")
+    if not _text(ticket.get("dedupe_key")):
+        reasons.append("repair_lot_dispatch_ticket_dedupe_key_missing")
+    if not _text(ticket.get("required_output_receipt")):
+        reasons.append("repair_lot_dispatch_ticket_output_receipt_missing")
+    if not _positive_number(ticket.get("max_runtime_seconds")):
+        reasons.append("repair_lot_dispatch_ticket_ttl_invalid")
+
+    ticket_value_gate = _text(ticket.get("target_value_gate"))
+    accepted_value_gates = {
+        value_gate
+        for value_gate in (
+            _text(action_contract.get("value_gate")),
+            _text(repair.get("value_gate")),
+        )
+        if value_gate
+    }
+    if not ticket_value_gate:
+        reasons.append("repair_lot_dispatch_ticket_value_gate_missing")
+    elif accepted_value_gates and ticket_value_gate not in accepted_value_gates:
+        reasons.append("repair_lot_dispatch_ticket_value_gate_mismatch")
+
+    ticket_lot_ref = _text(ticket.get("torghut_lot_id"))
+    accepted_lot_refs = _selected_repair_lot_refs(repair)
+    if not ticket_lot_ref:
+        reasons.append("repair_lot_dispatch_ticket_lot_missing")
+    elif accepted_lot_refs and ticket_lot_ref not in accepted_lot_refs:
+        reasons.append("repair_lot_dispatch_ticket_lot_mismatch")
+
+    return _strings(reasons)
+
+
 def _capital_safety_reasons(
     frontier: Mapping[str, Any], repair: Mapping[str, Any]
 ) -> list[str]:
@@ -155,6 +239,7 @@ def build_zero_notional_repair_execution_receipt(
     execute: bool = False,
     preferred_action: str | None = None,
     action_result: Mapping[str, object] | None = None,
+    repair_lot_dispatch_ticket: Mapping[str, object] | None = None,
     now: datetime | None = None,
 ) -> dict[str, object]:
     """Build a receipt for the selected frontier repair without granting capital."""
@@ -169,7 +254,13 @@ def build_zero_notional_repair_execution_receipt(
     action = _text(repair.get("zero_notional_action"))
     action_contract = _mapping(_ALLOWLIST.get(action))
     result = _mapping(action_result)
+    dispatch_ticket = _mapping(repair_lot_dispatch_ticket)
     blocked_reasons = _capital_safety_reasons(frontier, repair)
+    dispatch_ticket_reasons = _dispatch_ticket_reasons(
+        repair,
+        action_contract,
+        dispatch_ticket,
+    )
     execution_state = "dry_run_ready"
     command_exit_code: int | None = 0
 
@@ -187,6 +278,10 @@ def build_zero_notional_repair_execution_receipt(
         command_exit_code = 78
     elif blocked_reasons:
         execution_state = "capital_safety_blocked"
+        command_exit_code = 78
+    elif execute and dispatch_ticket_reasons:
+        execution_state = "repair_lot_dispatch_ticket_required"
+        blocked_reasons.extend(dispatch_ticket_reasons)
         command_exit_code = 78
     elif execute and result:
         execution_state = _text(result.get("execution_state"), "executed")
@@ -242,6 +337,14 @@ def build_zero_notional_repair_execution_receipt(
         "requires_torghut_admission": bool(
             action_contract.get("requires_torghut_admission", False)
         ),
+        "requires_repair_lot_dispatch_ticket": _requires_dispatch_ticket(
+            action_contract
+        ),
+        "repair_lot_dispatch_ticket_ref": dispatch_ticket.get("ticket_id"),
+        "repair_lot_dispatch_ticket_lot_ref": dispatch_ticket.get("torghut_lot_id"),
+        "repair_lot_dispatch_ticket_launch_allowed": (
+            _bool(dispatch_ticket.get("launch_allowed")) if dispatch_ticket else None
+        ),
         "paper_notional_limit": "0",
         "live_notional_limit": "0",
         "capital_behavior_changed": False,
@@ -265,6 +368,7 @@ def run_zero_notional_repair(
     profit_freshness_frontier: Mapping[str, Any],
     execute: bool,
     preferred_action: str | None = None,
+    repair_lot_dispatch_ticket: Mapping[str, object] | None = None,
     runners: Mapping[str, RepairRunner] | None = None,
     now: datetime | None = None,
 ) -> dict[str, object]:
@@ -278,6 +382,12 @@ def run_zero_notional_repair(
     )
     action = _text(repair.get("zero_notional_action"))
     action_contract = _ALLOWLIST.get(action)
+    dispatch_ticket = _mapping(repair_lot_dispatch_ticket)
+    dispatch_ticket_reasons = _dispatch_ticket_reasons(
+        repair,
+        _mapping(action_contract),
+        dispatch_ticket,
+    )
     action_result: Mapping[str, object] | None = None
 
     if (
@@ -285,6 +395,7 @@ def run_zero_notional_repair(
         and repair
         and action_contract
         and not _capital_safety_reasons(frontier, repair)
+        and not dispatch_ticket_reasons
         and action in (runners or {})
     ):
         runner = cast(Mapping[str, RepairRunner], runners)[action]
@@ -299,12 +410,14 @@ def run_zero_notional_repair(
         execute=execute,
         preferred_action=normalized_preferred_action or None,
         action_result=action_result,
+        repair_lot_dispatch_ticket=dispatch_ticket,
         now=now,
     )
 
 
 __all__ = [
     "ZERO_NOTIONAL_REPAIR_EXECUTION_SCHEMA_VERSION",
+    "REPAIR_LOT_DISPATCH_TICKET_SCHEMA_VERSION",
     "build_zero_notional_repair_execution_receipt",
     "run_zero_notional_repair",
 ]

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -3908,6 +3908,70 @@ class TestTradingApi(TestCase):
         self.assertEqual(payload["live_notional_limit"], "0")
         self.assertEqual(payload["before_refs"], ["market_context:AAPL"])
 
+    def test_zero_notional_repair_endpoint_accepts_dispatch_ticket_body(self) -> None:
+        status_payload = {
+            "active_revision": "torghut-00320",
+            "profit_freshness_frontier": {
+                "frontier_id": "profit-freshness-frontier:test",
+                "capital_posture": {
+                    "capital_state": "zero_notional",
+                    "paper_notional_limit": "0",
+                    "live_notional_limit": "0",
+                    "capital_behavior_changed": False,
+                },
+                "selected_zero_notional_repairs": [
+                    {
+                        "lot_id": "profit-freshness-repair-lot:test",
+                        "candidate_id": "candidate-a",
+                        "hypothesis_id": "H-AAPL",
+                        "blocked_dimension": "market_context",
+                        "zero_notional_action": "refresh_stale_market_context_domains",
+                        "before_refs": ["market_context:AAPL"],
+                        "paper_notional_limit": "0",
+                        "live_notional_limit": "0",
+                        "state": "selected_zero_notional_repair",
+                    }
+                ],
+            },
+        }
+        repair_lot_dispatch_ticket = {
+            "schema_version": "jangar.repair-lot-dispatch-ticket.v1",
+            "ticket_id": "repair-lot-dispatch-ticket:test",
+            "admission_receipt_id": "repair-bid-admission-receipt:test",
+            "torghut_lot_id": "profit-freshness-repair-lot:test",
+            "lot_class": "market_context_refresh",
+            "target_value_gate": "zero_notional_or_stale_evidence_rate",
+            "dedupe_key": "torghut-repair:test",
+            "required_output_receipt": "torghut.market-context-current-receipt.v1",
+            "launch_allowed": True,
+            "launch_reason": "current_zero_notional_compacted_lot",
+            "stop_conditions": ["fresh_until_expired", "dedupe_key_became_active"],
+            "max_runtime_seconds": 1200,
+            "max_notional": 0,
+            "expected_gate_delta": 1,
+            "rollback_target": "keep Torghut max_notional=0",
+        }
+        with patch("app.main.trading_status", return_value=status_payload):
+            response = self.client.post(
+                "/trading/profit-freshness/zero-notional-repair?execute=true",
+                json=repair_lot_dispatch_ticket,
+            )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["execution_state"], "runner_admission_required")
+        self.assertEqual(payload["command_exit_code"], 78)
+        self.assertEqual(
+            payload["blocked_reasons"],
+            ["zero_notional_runner_admission_required"],
+        )
+        self.assertEqual(
+            payload["repair_lot_dispatch_ticket_ref"],
+            "repair-lot-dispatch-ticket:test",
+        )
+        self.assertTrue(payload["repair_lot_dispatch_ticket_launch_allowed"])
+        self.assertFalse(payload["order_submission_enabled"])
+
     def test_zero_notional_repair_endpoint_can_select_queued_route_tca_action(
         self,
     ) -> None:

--- a/services/torghut/tests/test_zero_notional_repair_executor.py
+++ b/services/torghut/tests/test_zero_notional_repair_executor.py
@@ -5,6 +5,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 from app.trading.zero_notional_repair_executor import (
+    REPAIR_LOT_DISPATCH_TICKET_SCHEMA_VERSION,
     ZERO_NOTIONAL_REPAIR_EXECUTION_SCHEMA_VERSION,
     build_zero_notional_repair_execution_receipt,
     run_zero_notional_repair,
@@ -40,6 +41,32 @@ def _frontier(action: str = "refresh_stale_market_context_domains") -> dict[str,
     }
 
 
+def _dispatch_ticket(
+    lot_id: str = "profit-freshness-repair-lot:test",
+    overrides: Mapping[str, object] | None = None,
+) -> dict[str, object]:
+    ticket: dict[str, object] = {
+        "schema_version": REPAIR_LOT_DISPATCH_TICKET_SCHEMA_VERSION,
+        "ticket_id": "repair-lot-dispatch-ticket:test",
+        "admission_receipt_id": "repair-bid-admission-receipt:test",
+        "torghut_lot_id": lot_id,
+        "lot_class": "market_context_refresh",
+        "target_value_gate": "zero_notional_or_stale_evidence_rate",
+        "dedupe_key": "torghut-repair:test",
+        "required_output_receipt": "torghut.market-context-current-receipt.v1",
+        "launch_allowed": True,
+        "launch_reason": "current_zero_notional_compacted_lot",
+        "stop_conditions": ["fresh_until_expired", "dedupe_key_became_active"],
+        "max_runtime_seconds": 1200,
+        "max_notional": 0,
+        "expected_gate_delta": 1,
+        "rollback_target": "keep Torghut max_notional=0",
+    }
+    if overrides:
+        ticket.update(overrides)
+    return ticket
+
+
 def test_dry_run_receipt_keeps_selected_repair_zero_notional() -> None:
     receipt = build_zero_notional_repair_execution_receipt(
         account_label="paper",
@@ -59,6 +86,8 @@ def test_dry_run_receipt_keeps_selected_repair_zero_notional() -> None:
     assert receipt["live_notional_limit"] == "0"
     assert receipt["before_refs"] == ["market_context:AAPL"]
     assert receipt["value_gate"] == "zero_notional_or_stale_evidence_rate"
+    assert receipt["requires_repair_lot_dispatch_ticket"] is True
+    assert receipt["repair_lot_dispatch_ticket_ref"] is None
 
 
 def test_execute_runs_allowlisted_tca_runner_without_widening_notional() -> None:
@@ -221,7 +250,7 @@ def test_preferred_action_missing_is_fail_closed() -> None:
     assert receipt["order_submission_enabled"] is False
 
 
-def test_runner_required_action_reports_admission_block_when_executed_without_runner() -> (
+def test_runner_required_action_requires_dispatch_ticket_before_runner_admission() -> (
     None
 ):
     receipt = run_zero_notional_repair(
@@ -235,11 +264,181 @@ def test_runner_required_action_reports_admission_block_when_executed_without_ru
         now=NOW,
     )
 
-    assert receipt["execution_state"] == "runner_admission_required"
+    assert receipt["execution_state"] == "repair_lot_dispatch_ticket_required"
     assert receipt["command_exit_code"] == 78
     assert receipt["requires_torghut_admission"] is True
-    assert "zero_notional_runner_admission_required" in receipt["blocked_reasons"]
+    assert receipt["requires_repair_lot_dispatch_ticket"] is True
+    assert "repair_lot_dispatch_ticket_missing" in receipt["blocked_reasons"]
     assert receipt["order_submission_enabled"] is False
+
+
+def test_runner_required_action_does_not_call_runner_without_dispatch_ticket() -> None:
+    called: list[Mapping[str, Any]] = []
+
+    receipt = run_zero_notional_repair(
+        account_label="paper",
+        trading_mode="live",
+        torghut_revision="torghut-00320",
+        source_commit="abc123",
+        profit_freshness_frontier=_frontier("refresh_stale_market_context_domains"),
+        execute=True,
+        runners={
+            "refresh_stale_market_context_domains": lambda repair: (
+                called.append(repair)
+                or {
+                    "execution_state": "executed",
+                    "command_exit_code": 0,
+                }
+            ),
+        },
+        now=NOW,
+    )
+
+    assert called == []
+    assert receipt["execution_state"] == "repair_lot_dispatch_ticket_required"
+    assert receipt["command_exit_code"] == 78
+    assert receipt["blocked_reasons"] == ["repair_lot_dispatch_ticket_missing"]
+    assert receipt["repair_lot_dispatch_ticket_ref"] is None
+    assert receipt["order_submission_enabled"] is False
+
+
+def test_runner_required_action_executes_with_matching_dispatch_ticket() -> None:
+    called: list[Mapping[str, Any]] = []
+
+    receipt = run_zero_notional_repair(
+        account_label="paper",
+        trading_mode="live",
+        torghut_revision="torghut-00320",
+        source_commit="abc123",
+        profit_freshness_frontier=_frontier("refresh_stale_market_context_domains"),
+        execute=True,
+        repair_lot_dispatch_ticket=_dispatch_ticket(),
+        runners={
+            "refresh_stale_market_context_domains": lambda repair: (
+                called.append(repair)
+                or {
+                    "execution_state": "executed",
+                    "command_exit_code": 0,
+                    "after_refs": ["market_context:AAPL:refreshed"],
+                }
+            ),
+        },
+        now=NOW,
+    )
+
+    assert [repair["lot_id"] for repair in called] == [
+        "profit-freshness-repair-lot:test"
+    ]
+    assert receipt["execution_state"] == "executed"
+    assert receipt["command_exit_code"] == 0
+    assert receipt["after_refs"] == ["market_context:AAPL:refreshed"]
+    assert receipt["requires_repair_lot_dispatch_ticket"] is True
+    assert (
+        receipt["repair_lot_dispatch_ticket_ref"] == "repair-lot-dispatch-ticket:test"
+    )
+    assert (
+        receipt["repair_lot_dispatch_ticket_lot_ref"]
+        == "profit-freshness-repair-lot:test"
+    )
+    assert receipt["repair_lot_dispatch_ticket_launch_allowed"] is True
+    assert receipt["paper_notional_limit"] == "0"
+    assert receipt["live_notional_limit"] == "0"
+    assert receipt["order_submission_enabled"] is False
+
+
+def test_runner_required_action_rejects_mismatched_dispatch_ticket() -> None:
+    called: list[Mapping[str, Any]] = []
+
+    receipt = run_zero_notional_repair(
+        account_label="paper",
+        trading_mode="live",
+        torghut_revision="torghut-00320",
+        source_commit="abc123",
+        profit_freshness_frontier=_frontier("refresh_stale_market_context_domains"),
+        execute=True,
+        repair_lot_dispatch_ticket=_dispatch_ticket(
+            "profit-freshness-repair-lot:other",
+            {
+                "launch_allowed": False,
+                "max_notional": 1,
+                "target_value_gate": "capital_gate_safety",
+            },
+        ),
+        runners={
+            "refresh_stale_market_context_domains": lambda repair: (
+                called.append(repair)
+                or {
+                    "execution_state": "executed",
+                    "command_exit_code": 0,
+                }
+            ),
+        },
+        now=NOW,
+    )
+
+    assert called == []
+    assert receipt["execution_state"] == "repair_lot_dispatch_ticket_required"
+    assert receipt["command_exit_code"] == 78
+    assert receipt["blocked_reasons"] == [
+        "repair_lot_dispatch_ticket_not_allowed",
+        "repair_lot_dispatch_ticket_notional_nonzero",
+        "repair_lot_dispatch_ticket_value_gate_mismatch",
+        "repair_lot_dispatch_ticket_lot_mismatch",
+    ]
+    assert (
+        receipt["repair_lot_dispatch_ticket_ref"] == "repair-lot-dispatch-ticket:test"
+    )
+    assert receipt["repair_lot_dispatch_ticket_launch_allowed"] is False
+
+
+def test_runner_required_action_rejects_malformed_dispatch_ticket() -> None:
+    called: list[Mapping[str, Any]] = []
+
+    receipt = run_zero_notional_repair(
+        account_label="paper",
+        trading_mode="live",
+        torghut_revision="torghut-00320",
+        source_commit="abc123",
+        profit_freshness_frontier=_frontier("refresh_stale_market_context_domains"),
+        execute=True,
+        repair_lot_dispatch_ticket={
+            "schema_version": "jangar.repair-lot-dispatch-ticket.v0",
+            "ticket_id": "",
+            "torghut_lot_id": "",
+            "target_value_gate": "",
+            "dedupe_key": "",
+            "required_output_receipt": "",
+            "launch_allowed": "no",
+            "max_runtime_seconds": "not-a-ttl",
+        },
+        runners={
+            "refresh_stale_market_context_domains": lambda repair: (
+                called.append(repair)
+                or {
+                    "execution_state": "executed",
+                    "command_exit_code": 0,
+                }
+            ),
+        },
+        now=NOW,
+    )
+
+    assert called == []
+    assert receipt["execution_state"] == "repair_lot_dispatch_ticket_required"
+    assert receipt["command_exit_code"] == 78
+    assert receipt["blocked_reasons"] == [
+        "repair_lot_dispatch_ticket_schema_mismatch",
+        "repair_lot_dispatch_ticket_id_missing",
+        "repair_lot_dispatch_ticket_not_allowed",
+        "repair_lot_dispatch_ticket_notional_missing",
+        "repair_lot_dispatch_ticket_dedupe_key_missing",
+        "repair_lot_dispatch_ticket_output_receipt_missing",
+        "repair_lot_dispatch_ticket_ttl_invalid",
+        "repair_lot_dispatch_ticket_value_gate_missing",
+        "repair_lot_dispatch_ticket_lot_missing",
+    ]
+    assert receipt["repair_lot_dispatch_ticket_ref"] == ""
+    assert receipt["repair_lot_dispatch_ticket_launch_allowed"] is False
 
 
 def test_nonzero_frontier_notional_blocks_repair_execution() -> None:


### PR DESCRIPTION
## Summary

- Enforces the May 13 Torghut/Jangar milestone 2 dispatch contract at the Torghut zero-notional repair executor boundary.
- Requires `jangar.repair-lot-dispatch-ticket.v1` before runner-backed repairs that need Jangar admission can execute, validating selected compact lot id, launch allowance, `max_notional=0`, dedupe key, target value gate, required output receipt, and `max_runtime_seconds`.
- Wires `/trading/profit-freshness/zero-notional-repair` to accept the dispatch ticket as the POST body and returns fail-closed receipts before invoking local runners when the ticket is missing or invalid.
- Updates the governing design notes and regression coverage for missing, denied, mismatched, malformed, and matching ticket paths.

## Related Issues

None

## Testing

- `python3 -m compileall -q services/torghut/app/trading/zero_notional_repair_executor.py services/torghut/app/main.py services/torghut/tests/test_zero_notional_repair_executor.py services/torghut/tests/test_trading_api.py` - pass
- `uv sync --frozen --extra dev` - pass
- `uv run --frozen ruff format --check app/main.py app/trading/zero_notional_repair_executor.py tests/test_zero_notional_repair_executor.py tests/test_trading_api.py` - pass
- `uv run --frozen ruff check app/main.py app/trading/zero_notional_repair_executor.py tests/test_zero_notional_repair_executor.py tests/test_trading_api.py` - pass
- `uv run --frozen pytest -q tests/test_zero_notional_repair_executor.py tests/test_trading_api.py -k zero_notional_repair` - pass, 21 passed and 77 deselected
- `uv run --frozen pytest --cov --cov-branch --cov-report=term-missing --cov-report=xml` - pass, 2,189 passed, total coverage 78.53%
- `uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90` - pass, `app/trading/zero_notional_repair_executor.py` 58/58 changed lines covered
- `uv run --frozen pyright --project pyrightconfig.json` - pass, 0 errors
- `uv run --frozen pyright --project pyrightconfig.alpha.json` - pass, 0 errors
- `uv run --frozen pyright --project pyrightconfig.scripts.json` - pass, 0 errors
- `bunx oxfmt --check docs/agents/designs/186-jangar-repair-bid-admission-and-settlement-custody-2026-05-13.md docs/torghut/design-system/v6/190-torghut-repair-bid-settlement-and-routeability-proof-compaction-2026-05-13.md` - pass
- GitHub CI on PR #6361 - pass: changed-file plan, lint commit messages, validate PR title, bytecode/lint/migration guard, Pyright, quality signals, pytest shards 0-3, aggregate bytecode/pytest/coverage, and changed-files checks are green

## Screenshots (if applicable)

N/A

## Breaking Changes

None. Runner-backed zero-notional repair execution now requires the Jangar dispatch ticket for admission-required repair actions. Dry runs and non-admission repair runners keep their existing behavior.

## Design And Requirement Provenance

- Governing design: `docs/agents/designs/186-jangar-repair-bid-admission-and-settlement-custody-2026-05-13.md`, engineer milestone 2: require `repair_lot_dispatch_ticket` and reject raw-bid dispatch without a compacted lot id.
- Torghut system design: `docs/torghut/design-system/v6/190-torghut-repair-bid-settlement-and-routeability-proof-compaction-2026-05-13.md`, bounded zero-notional compacted lots with dedupe key, TTL, value gate, output receipt, and `max_notional=0`.
- Value gates improved: `capital_gate_safety` and `zero_notional_or_stale_evidence_rate`.

## Risk And Rollback

- Risk: callers that attempted to execute runner-backed admitted repairs without the Jangar ticket will now receive `repair_lot_dispatch_ticket_required` instead of reaching a local runner.
- Safety: receipts preserve `paper_notional_limit=0`, `live_notional_limit=0`, `order_submission_enabled=false`, and no runner is invoked on invalid ticket paths.
- Rollback: revert this commit to restore the prior executor behavior while leaving Torghut capital at zero-notional and continuing to rely on Jangar admission visibility.

## Release Note

Torghut zero-notional repair execution now enforces the Jangar compact-lot dispatch ticket before admitted runner-backed repairs can run. The shipped guard follows design 186 and Torghut design 190, improving `capital_gate_safety` and `zero_notional_or_stale_evidence_rate` by blocking raw or stale repair execution without weakening capital safety.

Owner-facing status: PR #6361 is open, CI-green, cleanly mergeable, and ready for release/deployer handoff. This run did not merge because the objective requested a ready PR rather than a merge.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
