### PR TITLE
chore(jangar): promote image fdc164d7

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 5d89ac24
-  digest: sha256:e677e2e203bc7583ac9274f798d54e95398afff2d927d04632ff5a1a978fcf6b
+  tag: fdc164d7
+  digest: sha256:5060397d1b7b9d93cb51b14815f94bbaf720b5bd53fceb366d38b351f070953d
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,8 +11,8 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 5d89ac24
-    digest: sha256:d5d7dd9aa26703eb2a2100b05a7cf2fbb92e1a89151bb0c4355f18f2681c7835
+    tag: fdc164d7
+    digest: sha256:8777533cbe3fe21445d6ac486ca106881b726ea66a35947ec1c9f8afa25170f7
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
@@ -21,8 +21,8 @@ controlPlane:
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 5d89ac24
-    digest: sha256:e677e2e203bc7583ac9274f798d54e95398afff2d927d04632ff5a1a978fcf6b
+    tag: fdc164d7
+    digest: sha256:5060397d1b7b9d93cb51b14815f94bbaf720b5bd53fceb366d38b351f070953d
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-13T06:39:06Z
+    deploy.knative.dev/rollout: 2026-05-13T08:14:52Z
 spec:
   replicas: 1
   strategy:
@@ -57,11 +57,11 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_RUNTIME_IMAGE
-              value: registry.ide-newton.ts.net/lab/jangar:5d89ac24@sha256:e677e2e203bc7583ac9274f798d54e95398afff2d927d04632ff5a1a978fcf6b
+              value: registry.ide-newton.ts.net/lab/jangar:fdc164d7@sha256:5060397d1b7b9d93cb51b14815f94bbaf720b5bd53fceb366d38b351f070953d
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: 5d89ac24819d84632873caf046cd0a1ff111db95
+              value: fdc164d70ae04f1d7defc8496c1a233685a3d0c2
             - name: JANGAR_GITOPS_REVISION
-              value: 5d89ac24819d84632873caf046cd0a1ff111db95
+              value: fdc164d70ae04f1d7defc8496c1a233685a3d0c2
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_BUMBA_TASK_QUEUE

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -59,5 +59,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: 5d89ac24
-    digest: sha256:e677e2e203bc7583ac9274f798d54e95398afff2d927d04632ff5a1a978fcf6b
+    newTag: fdc164d7
+    digest: sha256:5060397d1b7b9d93cb51b14815f94bbaf720b5bd53fceb366d38b351f070953d


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `fdc164d70ae04f1d7defc8496c1a233685a3d0c2`
- Image tag: `fdc164d7`
- Image digest: `sha256:5060397d1b7b9d93cb51b14815f94bbaf720b5bd53fceb366d38b351f070953d`
- Updated API rollout annotation
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`