### PR TITLE
fix(jangar): credit terminal swarm stage completions

### DIFF
--- a/services/jangar/src/routes/index.tsx
+++ b/services/jangar/src/routes/index.tsx
@@ -181,10 +181,7 @@ function MemoriesByDayChart({ data }: { data: { day: string; count: number }[] }
           minTickGap={24}
           tickFormatter={(value: string) => formatShortDay(value)}
         />
-        <ChartTooltip
-          cursor={false}
-          content={({ content: _content, ...props }) => <ChartTooltipContent {...props} />}
-        />
+        <ChartTooltip cursor={false} content={<ChartTooltipContent />} />
         <Line
           dataKey="count"
           type="monotone"
@@ -220,10 +217,7 @@ function MemoriesTopNamespacesChart({ data }: { data: { namespace: string; count
           tickMargin={8}
           tickFormatter={(value: string) => truncateLabel(value)}
         />
-        <ChartTooltip
-          cursor={false}
-          content={({ content: _content, ...props }) => <ChartTooltipContent {...props} />}
-        />
+        <ChartTooltip cursor={false} content={<ChartTooltipContent />} />
         <Bar dataKey="count" fill="var(--color-count)" radius={4} />
       </BarChart>
     </ChartContainer>

--- a/services/jangar/src/routes/torghut/trading.tsx
+++ b/services/jangar/src/routes/torghut/trading.tsx
@@ -602,10 +602,7 @@ function TorghutTrading() {
                       tickMargin={8}
                       tickFormatter={(value: string) => truncateLabel(value)}
                     />
-                    <ChartTooltip
-                      cursor={false}
-                      content={({ content: _content, ...props }) => <ChartTooltipContent {...props} />}
-                    />
+                    <ChartTooltip cursor={false} content={<ChartTooltipContent />} />
                     <Bar dataKey="count" fill="var(--color-count)" radius={4} />
                   </BarChart>
                 </ChartContainer>
@@ -772,10 +769,7 @@ function RealizedPnlChart({ series }: { series: { ts: string; realizedPnl: numbe
           tickFormatter={(value: string) => formatShortTime(value)}
         />
         <YAxis tickLine={false} axisLine={false} width={72} tickFormatter={(value: number) => currency.format(value)} />
-        <ChartTooltip
-          cursor={false}
-          content={({ content: _content, ...props }) => <ChartTooltipContent {...props} />}
-        />
+        <ChartTooltip cursor={false} content={<ChartTooltipContent />} />
         <Line dataKey="realizedPnl" type="monotone" stroke="var(--color-realizedPnl)" strokeWidth={2} dot={false} />
       </LineChart>
     </ChartContainer>
@@ -836,10 +830,7 @@ function EquityChart({
           tickFormatter={(value: string) => formatShortTime(value)}
         />
         <YAxis tickLine={false} axisLine={false} width={72} tickFormatter={(value: number) => currency.format(value)} />
-        <ChartTooltip
-          cursor={false}
-          content={({ content: _content, ...props }) => <ChartTooltipContent {...props} />}
-        />
+        <ChartTooltip cursor={false} content={<ChartTooltipContent />} />
         {seriesKeys.map((item) => (
           <Line
             key={item.key}

--- a/services/jangar/src/server/__tests__/supporting-primitives-controller.test.ts
+++ b/services/jangar/src/server/__tests__/supporting-primitives-controller.test.ts
@@ -1906,6 +1906,113 @@ describe('supporting primitives controller', () => {
     })
   })
 
+  it('uses terminal finish time for long-running successful swarm stages', async () => {
+    vi.setSystemTime(new Date('2026-01-20T03:00:00Z'))
+
+    const applyStatus = vi.fn().mockResolvedValue({})
+    const apply = vi.fn().mockResolvedValue({})
+    const deleteFn = vi.fn().mockResolvedValue(null)
+    const staleStartedAt = '2026-01-20T00:00:00Z'
+    const recentFinishedAt = '2026-01-20T02:40:00Z'
+    const staleScheduleRunAt = '2026-01-20T00:00:00Z'
+    const stageRuns = ['discover', 'plan', 'implement', 'verify'].map((stage) => ({
+      kind: 'AgentRun',
+      metadata: {
+        name: `jangar-control-plane-${stage}-long-success`,
+        namespace: 'agents',
+        labels: {
+          'swarm.proompteng.ai/name': 'jangar-control-plane',
+          'swarm.proompteng.ai/stage': stage,
+          'swarm.proompteng.ai/uid': 'swarm-uid',
+        },
+        creationTimestamp: staleStartedAt,
+      },
+      status: {
+        phase: 'Succeeded',
+        startedAt: staleStartedAt,
+        finishedAt: recentFinishedAt,
+        updatedAt: recentFinishedAt,
+      },
+    }))
+    const get = vi.fn(async (resource: string) => {
+      if (resource === RESOURCE_MAP.Schedule) {
+        return { status: { phase: 'Active', lastRunTime: staleScheduleRunAt } }
+      }
+      if (resource === RESOURCE_MAP.AgentRun) {
+        return {
+          kind: 'AgentRun',
+          metadata: { name: 'agentrun-sample', namespace: 'agents' },
+          spec: {
+            agentRef: { name: 'codex-spark-agent' },
+            runtime: { type: 'job' },
+            parameters: {},
+          },
+        }
+      }
+      return null
+    })
+    const list = vi.fn(async (resource: string) => {
+      if (resource === RESOURCE_MAP.AgentRun) return { items: stageRuns }
+      return { items: [] }
+    })
+    const kube = { applyStatus, apply, get, list, delete: deleteFn } as unknown as KubernetesClient
+
+    const swarm = {
+      apiVersion: 'swarm.proompteng.ai/v1alpha1',
+      kind: 'Swarm',
+      metadata: { name: 'jangar-control-plane', namespace: 'agents', generation: 2, uid: 'swarm-uid' },
+      spec: {
+        owner: { id: 'platform-owner', channel: 'swarm://owner/platform' },
+        domains: ['platform-reliability'],
+        objectives: ['improve reliability'],
+        mode: 'lights-out',
+        timezone: 'UTC',
+        cadence: {
+          discoverEvery: '1h',
+          planEvery: '1h',
+          implementEvery: '1h',
+          verifyEvery: '1h',
+        },
+        discovery: { sources: [{ name: 'github-issues' }] },
+        delivery: { deploymentTargets: ['agents'] },
+        mission: {
+          ledgerRef: '/workspace/.agentrun/swarm/jangar-control-plane-mission-ledger.md',
+          businessMetric: 'reduce failed AgentRuns',
+          validationContract: ['dispatch requirements only when business value is named'],
+          valueGates: ['failed_agentrun_rate'],
+        },
+        execution: {
+          discover: { targetRef: { kind: 'AgentRun', name: 'agentrun-sample' } },
+          plan: { targetRef: { kind: 'AgentRun', name: 'agentrun-sample' } },
+          implement: { targetRef: { kind: 'AgentRun', name: 'agentrun-sample' } },
+          verify: { targetRef: { kind: 'AgentRun', name: 'agentrun-sample' } },
+        },
+      },
+    }
+
+    await __test__.reconcileSwarm(kube, swarm, 'agents')
+
+    expect(applyStatus).toHaveBeenCalledTimes(1)
+    const status = (applyStatus.mock.calls[0]?.[0] as { status?: Record<string, unknown> } | undefined)?.status ?? {}
+    const stageStates = (status.stageStates ?? {}) as Record<string, Record<string, unknown>>
+    for (const stage of ['discover', 'plan', 'implement', 'verify']) {
+      expect(stageStates[stage]?.fresh).toBe(true)
+      expect(stageStates[stage]?.healthy).toBe(true)
+      expect(stageStates[stage]?.recentSuccessAt).toBe(new Date(recentFinishedAt).toISOString())
+    }
+    expect(status.lastVerifyAt).toBe(new Date(recentFinishedAt).toISOString())
+
+    const conditions = Array.isArray(status.conditions) ? status.conditions : []
+    const ready = conditions.find((condition) => condition.type === 'Ready')
+    const degraded = conditions.find((condition) => condition.type === 'Degraded')
+    expect(ready).toMatchObject({ status: 'True', reason: 'Active', message: 'swarm active' })
+    expect(degraded).toMatchObject({
+      status: 'False',
+      reason: 'Healthy',
+      message: 'all stage and requirement health checks passing',
+    })
+  })
+
   it('keeps swarm ready when schedule timestamps are stale but stage runs are active recently', async () => {
     vi.setSystemTime(new Date('2026-01-20T03:00:00Z'))
 

--- a/services/jangar/src/server/supporting-primitives-swarm-analysis.ts
+++ b/services/jangar/src/server/supporting-primitives-swarm-analysis.ts
@@ -127,9 +127,20 @@ export const resolveStageApiVersion = (kind: string) => {
 export const stageScheduleName = (swarmName: string, stage: StageName) => makeHashedName(swarmName, `${stage}-sched`)
 
 export const getRunTimestamp = (resource: Record<string, unknown>) => {
+  const phase = (asString(readNested(resource, ['status', 'phase'])) ?? '').toLowerCase()
+  if (TERMINAL_SUCCESS_PHASES.has(phase) || TERMINAL_FAILURE_PHASES.has(phase)) {
+    return (
+      asString(readNested(resource, ['status', 'finishedAt'])) ??
+      asString(readNested(resource, ['status', 'updatedAt'])) ??
+      asString(readNested(resource, ['status', 'startedAt'])) ??
+      asString(readNested(resource, ['metadata', 'creationTimestamp']))
+    )
+  }
+
   return (
     asString(readNested(resource, ['status', 'startedAt'])) ??
     asString(readNested(resource, ['status', 'finishedAt'])) ??
+    asString(readNested(resource, ['status', 'updatedAt'])) ??
     asString(readNested(resource, ['metadata', 'creationTimestamp']))
   )
 }


### PR DESCRIPTION
## Summary

- Fixes swarm stage freshness accounting so terminal AgentRuns use `finishedAt`/`updatedAt` before `startedAt`; long-running successful verify jobs no longer get marked stale from their launch time.
- Adds a regression covering long-running successful discover/plan/implement/verify stages and the resulting Healthy/Active swarm status.
- Simplifies Jangar chart tooltip render props that broke the current Jangar TypeScript gate after the Recharts type update.

## Related Issues

None.

## Testing

- `cd services/jangar && bunx vitest run --config vitest.config.ts src/server/__tests__/supporting-primitives-controller.test.ts`
- `bun run --cwd services/jangar tsc`
- `bun run --cwd services/jangar lint`
- `bun run --cwd services/jangar lint:oxlint`
- `bunx oxfmt --check services/jangar/src/server/supporting-primitives-swarm-analysis.ts services/jangar/src/server/__tests__/supporting-primitives-controller.test.ts services/jangar/src/routes/index.tsx services/jangar/src/routes/torghut/trading.tsx`
- `git diff --check`
- `bun run --filter @proompteng/jangar pretest`

## Screenshots (if applicable)

N/A. Server-side freshness accounting and typecheck cleanup only.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
