### PR TITLE
chore(symphony): promote image 57bfbc7f

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-05-05T16:05:17Z"
+        kubectl.kubernetes.io/restartedAt: "2026-05-13T08:36:13Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -23,5 +23,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "2ea968af"
-    digest: sha256:dcd024f0abcb0615f698211df530056b196f0e050cedd19c118ac566eb415243
+    newTag: "57bfbc7f"
+    digest: sha256:902d8fea1a97d97d55c8ceb41c3008d564f72d471314cdf528ef487c98aa197b

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-05-05T16:05:17Z"
+        kubectl.kubernetes.io/restartedAt: "2026-05-13T08:36:13Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -25,5 +25,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "2ea968af"
-    digest: sha256:dcd024f0abcb0615f698211df530056b196f0e050cedd19c118ac566eb415243
+    newTag: "57bfbc7f"
+    digest: sha256:902d8fea1a97d97d55c8ceb41c3008d564f72d471314cdf528ef487c98aa197b

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-05-05T16:05:17Z"
+        kubectl.kubernetes.io/restartedAt: "2026-05-13T08:36:13Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -18,5 +18,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "2ea968af"
-    digest: sha256:dcd024f0abcb0615f698211df530056b196f0e050cedd19c118ac566eb415243
+    newTag: "57bfbc7f"
+    digest: sha256:902d8fea1a97d97d55c8ceb41c3008d564f72d471314cdf528ef487c98aa197b


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `57bfbc7f32c7bc6f05233da18e575c08cf879fbf`
- Image tag: `57bfbc7f`
- Image digest: `sha256:902d8fea1a97d97d55c8ceb41c3008d564f72d471314cdf528ef487c98aa197b`