### PR TITLE
docs(jangar): define ready truth cutover

### DIFF
--- a/docs/agents/designs/188-jangar-ready-truth-arbiter-and-stage-credit-cutover-2026-05-13.md
+++ b/docs/agents/designs/188-jangar-ready-truth-arbiter-and-stage-credit-cutover-2026-05-13.md
@@ -1,0 +1,394 @@
+# 188. Jangar Ready Truth Arbiter And Stage Credit Cutover (2026-05-13)
+
+Status: Accepted for engineer and deployer handoff
+Date: 2026-05-13
+Owner: Victor Chen, Jangar Engineering Architecture
+Scope: Jangar control-plane readiness truth, stage-credit enforcement, AgentRun failure reduction, GitOps rollout
+settlement, Torghut repair custody, validation, rollback, and cross-stage handoff.
+
+Extends:
+
+- `187-jangar-stage-credit-ledger-and-runner-slot-futures-2026-05-13.md`
+- `187-jangar-main-source-ci-retention-and-source-serving-verdicts-2026-05-13.md`
+- `186-jangar-repair-bid-admission-and-settlement-custody-2026-05-13.md`
+- `185-jangar-clearance-market-and-rollout-truth-settlement-2026-05-12.md`
+- `184-jangar-stage-clearance-packets-and-freeze-aware-launch-governor-2026-05-12.md`
+- `docs/agents/runbooks.md`
+
+Companion Torghut contract:
+
+- `docs/torghut/design-system/v6/192-torghut-repair-receipt-frontier-and-profit-cutover-2026-05-13.md`
+
+## Decision
+
+I am selecting a **ready truth arbiter with staged stage-credit cutover** as the next Jangar control-plane architecture
+increment.
+
+The current live system is safer than it was, but it is not truthful enough at the boundary where humans and schedulers
+make decisions. On the 2026-05-13 read-only assessment, Argo reported `jangar`, `agents`, and `torghut` as
+`Synced/Healthy` at revision `1feb3fd8b727185dd014ec0f38481d1f2fb4be4b`. Jangar `/health` returned `status=ok`, and
+Jangar `/ready` returned `status=ok`. The richer control-plane status route told the harder truth: the `agents`
+namespace was degraded because `agents-controller`, `runtime:workflow`, and `runtime:job` were not started, empirical
+forecast evidence was degraded, and execution trust was degraded. The `jangar-control-plane` swarm itself was
+`Frozen`, `Ready=False`, with the freeze reason `StageStaleness`.
+
+That is the next reliability defect. The control plane can now compute stage credit, source-serving verdicts, repair
+bid admission, and rollout truth, but the public readiness surface still lets "serving process is alive" look like
+"the control plane is materially ready." Those are different claims. I want Jangar to keep serving read-only status
+when the UI is healthy, but I do not want a scheduler, deployer, or merge gate to treat that as permission to launch
+normal stage work.
+
+The selected design introduces a `ready_truth_arbiter` read model and a cutover ladder for `stage_credit_ledger`.
+The arbiter does not replace Kubernetes probes. It produces the material-action readiness verdict used by Jangar
+schedulers, deployers, PR merge gates, and swarm handoffs. Serving readiness can stay green while material readiness is
+`repair_only`, `hold`, or `block`. Stage credit then moves from `observe` to `shadow`, then to `hold` for launch
+admission, and only later to `enforce` for automatic schedule suppression.
+
+The tradeoff is direct: some stages will stop launching even though pods are up and Argo is healthy. I accept that
+because the business metric is to reduce failed AgentRuns and shorten green PR-to-healthy GitOps rollout time. A green
+pod is not enough if the controller witness, runtime adapter, source-serving verdict, Torghut repair receipt, and
+failure-debt settlement do not agree.
+
+## Governing Runtime Requirements
+
+This design binds to the current swarm validation contract:
+
+- every run must cite the governing design or runtime requirement before changing code;
+- implement stages must produce production PRs with tests or report the exact blocker to code;
+- verify stages must merge only green PRs and prove Argo, workload readiness, and service health after rollout;
+- final handoff must name the control-plane metric improved or the smallest blocker preventing improvement.
+
+Every milestone maps to at least one required value gate:
+
+- `failed_agentrun_rate`
+- `pr_to_rollout_latency`
+- `ready_status_truth`
+- `manual_intervention_count`
+- `handoff_evidence_quality`
+
+## Read-Only Evidence Snapshot
+
+All evidence below was collected read-only on 2026-05-13. I did not mutate Kubernetes resources, database records,
+GitOps resources, AgentRuns, Torghut trading flags, broker state, or data rows.
+
+### Cluster, Rollout, And Events
+
+- Runtime scope resolved to repository `proompteng/lab`, base `main`, head
+  `codex/swarm-jangar-control-plane-plan`, stage `plan`, owner channel `swarm://owner/platform`, live channel
+  `general`, mission ledger `/workspace/.agentrun/swarm/jangar-control-plane-mission-ledger.md`, and business metric
+  "reduce failed AgentRuns and shorten green PR-to-healthy GitOps rollout time for the Jangar control plane".
+- The working tree started clean on `codex/swarm-jangar-control-plane-plan`, aligned with `origin/main` at
+  `1feb3fd8b727185dd014ec0f38481d1f2fb4be4b`.
+- `kubectl -n argocd get applications jangar agents torghut -o wide` reported all three applications
+  `Synced/Healthy` at revision `1feb3fd8b727185dd014ec0f38481d1f2fb4be4b`.
+- Jangar workload evidence showed `deployment/jangar=1/1`, `deployment/agents=1/1`, and
+  `deployment/agents-controllers=2/2`. Recent Jangar events still included a readiness probe failure during rollout:
+  `Readiness probe failed: Get http://10.244.5.230:8080/health: connect: connection refused`.
+- Agents namespace events included recent `BackoffLimitExceeded` on a Jangar implement attempt and a Torghut verify
+  attempt, recent `agents-controllers` 503 readiness probe failures during rollout, and current schedule-runner pods.
+- AgentRun retention showed the contradiction at scale: Jangar control-plane retained `discover=2`, `implement=25`,
+  `plan=3`, and `verify=20` failed runs, while also retaining `discover=59`, `implement=92`, `plan=58`, and
+  `verify=73` succeeded runs. Torghut retained similar failure debt. A plain deployment health bit cannot price that
+  history.
+- Failed pods in `agents` showed Jangar plan/implement failures with exit code `1` and Torghut market-context jobs
+  with exit code `124`. Those are different failure classes and should not share one undifferentiated ready bit.
+
+### Jangar Runtime And Source
+
+- `curl http://jangar.jangar.svc.cluster.local/health` returned `status=ok`, with serving-process agents controller
+  disabled.
+- `curl http://jangar.jangar.svc.cluster.local/ready` returned `status=ok`, but its `execution_trust` section was
+  degraded because the `jangar-control-plane` swarm was frozen for `StageStaleness`, with discover, plan, implement,
+  and verify delayed by the freeze.
+- `curl http://jangar.jangar.svc.cluster.local/api/agents/control-plane/status` returned
+  `database.connected=true`, `database.status=healthy`, migration consistency `29/29`, and latency `12ms`.
+- The same control-plane status marked namespace `agents` as degraded with `degraded_components`:
+  `agents-controller`, `runtime:workflow`, `runtime:job`, `empirical:forecast`, and `execution_trust`.
+- `services/jangar/src/server/control-plane-status.ts` is the assembly point for this truth surface and is 795 lines.
+- `services/jangar/src/server/control-plane-stage-credit-ledger.ts` already exists at 481 lines and emits
+  `stage_credit_ledger` with governing design refs, credit accounts, runner slot futures, and the next implementation
+  milestone.
+- `services/jangar/src/server/control-plane-source-serving-contract-verdict.ts` exists at 456 lines and emits
+  `source_serving_contract_verdict_exchange` in observe mode.
+- `services/jangar/src/server/supporting-primitives-stage-clearance.ts` already stamps stage-credit trace data into
+  schedule-runner parameters when available.
+- `services/jangar/src/server/supporting-primitives-schedule-runner.ts` already contains the generated shell logic to
+  respect stage-credit mode and write `swarmStageCredit*` parameters.
+- Focused tests already exist for control-plane status, stage credit, source-serving verdicts, and supporting
+  primitives. The remaining gap is not projection coverage; it is cutover and settlement coverage across launch,
+  terminal AgentRun outcome, refund, burn, and swarm freeze release.
+
+### Database, Data Quality, And Freshness
+
+- The Jangar status route reported the database connected and migration consistency healthy, with 29 registered
+  migrations and 29 applied migrations. The latest registered and applied migration was
+  `20260508_torghut_quant_pipeline_health_account_window_created_at_index`.
+- Direct CNPG inspection was blocked by service-account permissions for CNPG resources and statefulsets. That is
+  acceptable for this architecture lane: the read model should not require every worker to have direct database
+  privileges.
+- Torghut `/readyz` returned `status=degraded` while Postgres, ClickHouse, Alpaca, universe loading, empirical jobs,
+  and database schema lineage were healthy.
+- Torghut schema was current at Alembic head `0031_autoresearch_candidate_spec_epoch_uniqueness`, with one expected
+  head and one current head. The payload still warned about known migration parent forks, which are lineage quality
+  signals, not current schema drift.
+- Torghut live submission stayed disabled with `simple_submit_disabled`, active capital stage `shadow`,
+  `promotion_eligible_total=0`, and `max_notional=0`.
+- Torghut profitability proof floor was `repair_only` with capital state `zero_notional`.
+- Torghut profit-window summary contained three windows: two `quarantined`, one `underfunded`, and all blocking.
+- Torghut data freshness blockers included `feature_rows_missing`, `required_feature_set_unavailable`,
+  `schema_lineage_missing`, `market_context_evidence_missing`, `research_candidates_empty`, `research_promotions_empty`,
+  `vnext_promotion_decisions_empty`, and `rejection_drag_unmeasured`.
+
+## Problem
+
+Jangar now has several specialized truth surfaces, but it still lacks one cutover-ready material readiness verdict.
+The failure modes are visible in the live system:
+
+1. Argo can be `Synced/Healthy` while material launch readiness is degraded.
+2. `/ready` can be `ok` while `agents-controller`, workflow runtime, and job runtime are not started.
+3. A swarm can be frozen for stage staleness while schedule-runner pods are still being created.
+4. Stage credit can be calculated and stamped while the system is still in observe mode.
+5. Source-serving verdicts can correctly identify missing contracts while deployer and merge gates still speak in
+   generic readiness terms.
+6. Torghut can be capital safe at zero notional while its repair receipts are not yet good enough to unlock paper
+   evidence.
+7. Retained failure debt can keep growing while the status surface says the deployment is healthy.
+
+That is why the next architecture step is not "add another health check." It is to name which readiness claim is being
+made and which actor is allowed to spend it.
+
+## Alternatives Considered
+
+### Option A: Make `/ready` Fail On Any Control-Plane Degradation
+
+This path treats the existing readiness probe as the full material readiness gate. If controller witness, runtime
+adapters, source-serving proof, Torghut proof floor, or execution trust are degraded, `/ready` returns non-OK.
+
+Advantages:
+
+- Simple mental model.
+- Kubernetes and Argo see the problem immediately.
+- Forces teams to retire degraded dependencies quickly.
+
+Disadvantages:
+
+- Conflates "Jangar can serve read-only evidence" with "Jangar can launch material work."
+- Risks restarting a useful status UI during exactly the incidents where operators need it.
+- Can create rollout churn if Torghut capital proof is intentionally zero-notional but Jangar serving is otherwise
+  healthy.
+- Does not define stage-credit refund, burn, or repair-only semantics.
+
+Decision: reject as the primary architecture. Keep `/ready` serving-safe; add material readiness as a separate truth
+contract.
+
+### Option B: Keep Observe Mode Until All Surfaces Are Healthy
+
+This path leaves stage credit, source-serving verdicts, repair-bid admission, and readiness truth as observe-only
+payloads until Jangar, Agents, and Torghut are simultaneously green.
+
+Advantages:
+
+- Lowest implementation risk.
+- Avoids breaking existing schedules.
+- Allows continued data collection.
+
+Disadvantages:
+
+- It permits the exact failure mode we are seeing: known-held stages continue to spend runner slots.
+- It makes failed AgentRun rate worse while waiting for perfect convergence.
+- It gives deployers no enforceable distinction between bounded repair and normal launch.
+- It relies on manual interpretation of a large status payload.
+
+Decision: reject. Observe mode is no longer enough for stage admission.
+
+### Option C: Ready Truth Arbiter With Stage-Credit Cutover
+
+This selected path keeps serving readiness and material readiness separate. Jangar emits a `ready_truth_arbiter`
+contract that reconciles Argo, workload rollout, control-plane status, stage credit, source-serving verdicts, retained
+failure debt, and Torghut repair receipts. Stage credit then cuts over by action class and evidence mode:
+
+- `serve_readonly`: always allowed when Jangar serving and database read are healthy.
+- `torghut_observe`: allowed when Torghut status is reachable and max notional is zero.
+- `dispatch_repair`: allowed only with current zero-notional repair receipt, runner slot future, and unexpired
+  stage-credit account.
+- `dispatch_normal`, `deploy_widen`, `merge_ready`: held until material readiness is `allow`.
+- `paper_canary`: held until Torghut source-serving proof and profit-window receipts are current.
+- `live_micro_canary`, `live_scale`: blocked until capital proof, source-serving proof, and human-approved cutover
+  thresholds are satisfied.
+
+Advantages:
+
+- Reduces failed AgentRuns by cutting off known-held normal launches.
+- Preserves the read-only UI and evidence API during repair states.
+- Lets one bounded repair run when it has value and no capital authority.
+- Gives deployers one material verdict instead of forcing them to reconcile many payloads.
+- Makes PR-to-rollout latency measurable: green PR, image promotion, Argo sync, material readiness, and health settle
+  at distinct timestamps.
+
+Disadvantages:
+
+- Requires one more read model and one more cutover flag.
+- Requires careful rollout so observe-mode dashboards and hold-mode schedulers do not disagree.
+- Requires terminal AgentRun settlement to burn or refund credit before `enforce` mode is safe.
+
+Decision: select Option C.
+
+## Architecture
+
+Jangar emits a `ready_truth_arbiter` object inside the control-plane status payload:
+
+```text
+ready_truth_arbiter
+  schema_version = jangar.ready-truth-arbiter.v1
+  verdict_id
+  generated_at
+  fresh_until
+  namespace
+  serving_readiness            # ok | degraded | down
+  material_readiness           # allow | repair_only | hold | block
+  argo_revision
+  argo_health
+  workload_rollout_ref
+  controller_witness_ref
+  runtime_adapter_refs[]
+  stage_credit_ledger_ref
+  source_serving_verdict_ref
+  torghut_repair_receipt_ref
+  retained_failure_debt_refs[]
+  ready_status_truth_reasons[]
+  allowed_action_classes[]
+  held_action_classes[]
+  blocked_action_classes[]
+  merge_gate_receipt
+  deployer_receipt
+  rollback_target
+```
+
+Decision rules:
+
+- `serving_readiness=ok` means Jangar can serve the UI and read-only APIs. It is not launch authority.
+- `material_readiness=allow` requires current controller witness, workflow/job runtime availability, database
+  migration consistency, no active swarm freeze, stage-credit decision `allow`, source-serving verdict `allow`, and no
+  active retained failure debt for the action class.
+- `material_readiness=repair_only` allows zero-notional repair work when a current repair lot names the value gate,
+  required output receipt, TTL, max runtime, and runner slot future.
+- `material_readiness=hold` prevents normal launches and merge/deploy widening while preserving read-only service.
+- `material_readiness=block` prevents capital-adjacent action and live cutover.
+- Argo `Synced/Healthy` contributes rollout evidence but never overrides a degraded controller witness or stage-credit
+  hold.
+- `/ready` remains a serving probe. Merge gates and deployer verification must use `ready_truth_arbiter` or the
+  existing control-plane status route until the arbiter is promoted to its own route.
+
+## Cutover Ladder
+
+The cutover happens in four steps. Each step has a metric and rollback.
+
+1. Observe, already present:
+   `stage_credit_ledger` and `source_serving_contract_verdict_exchange` are emitted and tested. No schedule is blocked
+   solely by them. Metric: `handoff_evidence_quality`.
+
+2. Shadow:
+   add `ready_truth_arbiter` and record what would have launched or held. Stamp every generated AgentRun with the
+   arbiter verdict and stage-credit account. Metric: `ready_status_truth`.
+
+3. Hold:
+   schedule-runner blocks `dispatch_normal`, `deploy_widen`, and `merge_ready` when material readiness is `hold` or
+   `block`, while preserving `serve_readonly`, `torghut_observe`, and one bounded `dispatch_repair` lane. Metric:
+   `failed_agentrun_rate`.
+
+4. Enforce:
+   terminal AgentRun settlement burns or refunds stage credit. Repeated failed stages lose credit for the next epoch;
+   successful repair receipts unlock normal admission only after source-serving and rollout truth settle. Metric:
+   `pr_to_rollout_latency` and `manual_intervention_count`.
+
+Rollback is explicit:
+
+- Set `JANGAR_READY_TRUTH_ARBITER_MODE=observe` to keep emitting evidence but stop gating.
+- Set `JANGAR_STAGE_CREDIT_LEDGER_MODE=observe` if stage-credit holds are incorrect.
+- Set `JANGAR_STAGE_CREDIT_LEDGER_ENABLED=false` only if the ledger payload itself is malformed.
+- Keep Torghut `max_notional=0` and live submission disabled while source-serving or profit repair receipts are
+  disputed.
+
+## Implementation Scope For Engineer Stage
+
+The next bounded engineering PR should not rewrite the controller. It should add one pure reducer and one narrow
+integration point.
+
+Required code changes:
+
+1. Add `services/jangar/src/server/control-plane-ready-truth-arbiter.ts`.
+2. Add types to `services/jangar/src/data/agents-control-plane.ts` and status types.
+3. Call the reducer from `control-plane-status.ts` after `stage_credit_ledger`, `source_serving_contract_verdict`, and
+   `repair_bid_admission` are built.
+4. Add tests in `services/jangar/src/server/__tests__/control-plane-ready-truth-arbiter.test.ts`.
+5. Extend `control-plane-status.test.ts` with the current live contradiction: serving readiness OK, material readiness
+   hold because agents controller/runtime and execution trust are degraded.
+6. Add schedule-runner hold-mode tests only after the arbiter is in shadow mode.
+
+Acceptance gates:
+
+- `bun run --filter @proompteng/jangar test -- src/server/__tests__/control-plane-ready-truth-arbiter.test.ts`
+- `bun run --filter @proompteng/jangar test -- src/server/__tests__/control-plane-status.test.ts -t ready`
+- `bun run --filter @proompteng/jangar lint`
+- `bun run --filter @proompteng/jangar tsc`
+
+The engineer must cite this design in the PR body and in any runtime parameter names. The first implementation PR must
+leave the arbiter in `observe` or `shadow`; hold-mode schedule suppression is a second PR unless the first PR proves
+the generated schedule-runner behavior with focused tests.
+
+## Deployment And Verification Gates
+
+The deployer stage must prove all of the following after merge and image promotion:
+
+- Argo `jangar` and `agents` are Synced/Healthy at the promoted revision.
+- `deployment/jangar`, `deployment/agents`, and `deployment/agents-controllers` are rolled out.
+- `curl /health` returns serving OK.
+- `curl /api/agents/control-plane/status?namespace=agents` exposes `ready_truth_arbiter`.
+- `ready_truth_arbiter.serving_readiness=ok` and material readiness is either `allow` or a named
+  `repair_only`/`hold` with reason codes.
+- `stage_credit_ledger` has fresh accounts and runner slot futures.
+- `source_serving_contract_verdict_exchange` is current and names missing contracts if any.
+- Jangar control-plane failed AgentRun rate does not increase in the verification window.
+- Torghut remains `max_notional=0` until the companion repair receipts graduate.
+
+## Handoff Contract
+
+Engineer handoff:
+
+- Build `ready_truth_arbiter` as a pure reducer first.
+- Do not make `/ready` fail on Torghut proof debt or normal stage holds.
+- Do not grant capital authority from Jangar status; Torghut capital gates remain authoritative for notional.
+- Keep mode flags explicit and default to non-destructive `observe` or `shadow`.
+- Add regression tests for the exact live split: Argo/serving OK, material readiness hold.
+
+Deployer handoff:
+
+- Treat Argo health as necessary but not sufficient.
+- Use `ready_truth_arbiter.material_readiness` as the merge/deploy widen gate once it exists.
+- Preserve read-only Jangar access during repair states.
+- Roll back by mode flag before reverting code unless the status payload is malformed.
+
+## Risks
+
+- The arbiter can become another large status object if it copies all upstream payloads. It must reference evidence
+  IDs and summarize only action-class decisions.
+- If hold mode is enabled before terminal settlement, repeated failed runs may stop but credit will not recover
+  automatically. That is why enforce mode waits for refund/burn settlement.
+- If teams continue to cite `/ready` as a launch gate, the readiness split will remain confusing. The PR template,
+  runbooks, and deployer checks must name material readiness explicitly.
+- Torghut can still be capital safe and unprofitable. This design reduces control-plane failures; the companion design
+  defines the profit repair receipts needed to unlock routeable candidates.
+
+## Next Milestone
+
+The next implementation milestone is:
+
+`feat(jangar): add ready truth arbiter read model`
+
+It improves:
+
+- `ready_status_truth` by separating serving readiness from material launch readiness;
+- `failed_agentrun_rate` by preparing hold-mode schedule suppression for known-held normal launches;
+- `pr_to_rollout_latency` by giving deployers one settled material readiness receipt;
+- `manual_intervention_count` by making repair-only launch authority explicit;
+- `handoff_evidence_quality` by binding every launch decision to a design and evidence ID.

--- a/docs/torghut/design-system/v6/192-torghut-repair-receipt-frontier-and-profit-cutover-2026-05-13.md
+++ b/docs/torghut/design-system/v6/192-torghut-repair-receipt-frontier-and-profit-cutover-2026-05-13.md
@@ -1,0 +1,354 @@
+# 192. Torghut Repair Receipt Frontier And Profit Cutover (2026-05-13)
+
+Status: Accepted for engineer and deployer handoff
+Date: 2026-05-13
+Owner: Victor Chen, Jangar Engineering Architecture
+Scope: Torghut quant repair receipts, source-serving proof, profit frontier graduation, zero-notional safety,
+validation, rollout, rollback, and Jangar material-readiness handoff.
+
+Companion Jangar contract:
+
+- `docs/agents/designs/188-jangar-ready-truth-arbiter-and-stage-credit-cutover-2026-05-13.md`
+
+Extends:
+
+- `191-torghut-source-serving-proof-and-repair-receipt-promotion-2026-05-13.md`
+- `190-torghut-repair-bid-settlement-and-routeability-proof-compaction-2026-05-13.md`
+- `190-torghut-route-warrant-exchange-and-ingestion-proof-reentry-2026-05-13.md`
+- `188-torghut-profit-repair-clearance-packets-and-market-context-slos-2026-05-12.md`
+- `188-torghut-route-evidence-clearinghouse-and-execution-freshness-market-2026-05-12.md`
+
+## Decision
+
+I am selecting a **repair receipt frontier with a profit cutover ladder** as Torghut's next architecture step.
+
+The current live system is doing the right safety thing: it is degraded, but it is not taking notional risk. On the
+2026-05-13 read-only pass, Torghut `/readyz` and `/trading/health` returned `status=degraded`, while Postgres,
+ClickHouse, Alpaca, universe loading, empirical jobs, and schema lineage were healthy. Live submission was disabled
+with `simple_submit_disabled`, capital stage was `shadow`, promotion eligible count was zero, and the profitability
+proof floor was `repair_only` with capital state `zero_notional`. That is a safe state, not a profitable state.
+
+The problem is that Torghut's repair evidence is not yet organized as a frontier. It names many blockers, but it does
+not give Jangar one compact answer to this question: which zero-notional repair receipt would most likely reduce stale
+evidence and move the system toward routeable post-cost profit without weakening capital safety? The route evidence
+surface reports eight symbols, all zero-notional, with `state_counts` of four blocked, three missing, and one probing.
+It names an expected unblock value of `14` and top repair symbols `AAPL`, `AMD`, `AVGO`, `INTC`, and `NVDA`. That is
+enough information to build a frontier, but it is not yet a promotion contract.
+
+The selected design turns Torghut repair receipts into frontier lots. Each lot must state the hypothesis, target
+symbol or route family, source-serving epoch, expected value-gate delta, cost class, required output receipt, freshness
+TTL, and rollback target. Jangar can admit exactly one bounded zero-notional repair at a time from the frontier. Paper
+or live capital remains blocked until the frontier produces current source-serving proof, current execution/TCA proof,
+current feature rows, and positive post-cost profit evidence.
+
+The tradeoff is slower promotion from repair to paper. I accept that because the goal is profitability with guardrails,
+not activity. A repair that does not retire a named blocker should not consume runner capacity or weaken the proof
+floor.
+
+## Governing Runtime Requirements
+
+Every Torghut quant run must cite the governing design or runtime requirement before changing code. Implementation
+stages must improve readiness, profit evidence, data freshness, execution quality, or capital safety. Verify stages
+must merge only green PRs and prove image promotion, Argo sync, live service health, and trading or evidence status
+after rollout. Final handoff must name the revenue metric improved or the smallest blocker preventing revenue impact.
+
+This design maps to the required value gates:
+
+- `zero_notional_or_stale_evidence_rate`: every frontier lot must name the stale evidence it retires.
+- `routeable_candidate_count`: a repair can graduate only if it creates or refreshes routeable candidates.
+- `fill_tca_or_slippage_quality`: execution/TCA receipts must be current before paper canary.
+- `post_cost_daily_net_pnl`: promotion requires positive post-cost proof, not just route availability.
+- `capital_gate_safety`: `max_notional=0` until the frontier and Jangar material readiness both pass.
+
+## Read-Only Evidence Snapshot
+
+All evidence below was collected read-only on 2026-05-13. I did not mutate Kubernetes resources, database records,
+GitOps resources, broker state, trading flags, or data rows.
+
+### Runtime And Cluster
+
+- Argo reported `torghut` `Synced/Healthy` at revision `1feb3fd8b727185dd014ec0f38481d1f2fb4be4b`.
+- Torghut core had a current Knative revision `torghut-00339` with one ready pod, and the sim service had
+  `torghut-sim-00437` with one ready pod.
+- Postgres, ClickHouse, Keeper, TA, TA sim, options catalog, options enricher, WebSocket, and guardrail exporters were
+  running.
+- A recent Torghut whitepaper autoresearch pod was in `Error`, but the trading health blocker was not a core service
+  crash.
+- `/readyz` and `/trading/health` returned `status=degraded`.
+- `/readyz` reported Postgres, ClickHouse, Alpaca, empirical jobs, and static universe loading healthy.
+- `/readyz` reported `live_submission_gate.ok=false`, detail `simple_submit_disabled`, capital stage `shadow`.
+- `/readyz` reported `profitability_proof_floor.ok=false`, detail `repair_only`, capital state `zero_notional`.
+- `/readyz` reported `quant_evidence.ok=true` but only because quant evidence was `not_required` and
+  `quant_health_not_configured`, which is not a profit proof.
+
+### Source And Contract State
+
+- Jangar already exposes `source_serving_contract_verdict_exchange` in source and tests.
+- Jangar already exposes `stage_credit_ledger` in source and tests.
+- The companion Jangar design now requires a `ready_truth_arbiter` before material launch readiness can be claimed.
+- Torghut source-serving proof exists as a design contract, but the frontier must define which repair receipt buys down
+  the current proof gap and what validates it.
+- The current live Torghut status shows source-serving and repair evidence are present enough for observe/repair, but
+  not enough for paper/live cutover.
+
+### Database And Data Quality
+
+- Torghut database schema was current at expected Alembic head `0031_autoresearch_candidate_spec_epoch_uniqueness`.
+- Schema head count current and expected were both `1`.
+- Schema lineage was ready, with warnings for known parent forks:
+  `0010_execution_provenance_and_governance_trace` and `0015_whitepaper_workflow_tables`.
+- Account-scope checks were ready, with a warning that checks are bypassed while multi-account trading is disabled.
+- Profit window contract showed three windows total: two `quarantined` and one `underfunded`.
+- The blocked windows cited `schema_lineage_missing`, `drift_checks_missing`, `feature_rows_missing`,
+  `required_feature_set_unavailable`, `market_context_evidence_missing`, `post_cost_expectancy_non_positive`, and
+  `quant_health_not_configured`.
+- Profit lease projection showed three leases, all `repair_only`, all proof state `missing`.
+- Promotion table counts showed `research_candidates=0`, `research_promotions=0`, `strategy_promotion_decisions=1`,
+  and `vnext_promotion_decisions=0`.
+- Route repair packets showed eight symbols, zero capital-eligible symbols, and `max_notional=0` throughout.
+
+## Problem
+
+Torghut has moved from unsafe ambiguity to safe repair-only operation. That is progress, but it is not a profit
+engine. The current blockers are specific:
+
+1. `simple_submit_disabled` correctly prevents live submission.
+2. `profitability_proof_floor=repair_only` correctly keeps notional at zero.
+3. `feature_rows_missing` and `required_feature_set_unavailable` block the TA core.
+4. `schema_lineage_missing` appears in profit-window escrows even though schema heads are current, which means the
+   proof receipt is missing or not joined to the profit window.
+5. `research_candidates_empty`, `research_promotions_empty`, and `vnext_promotion_decisions_empty` prevent a candidate
+   from graduating.
+6. `rejection_drag_unmeasured` prevents the system from knowing whether a route is operationally expensive.
+7. Execution/TCA proof for some symbols is stale or missing.
+
+Without a frontier, every repair looks urgent. With a frontier, the next repair must prove why it is the most valuable
+zero-notional move and how Jangar can verify it without granting capital authority.
+
+## Alternatives Considered
+
+### Option A: Continue Broad Repair Batches
+
+Let implement stages keep repairing any failing Torghut surface: feature rows, TCA, market context, source-serving,
+research candidates, or promotion tables.
+
+Advantages:
+
+- Maximizes engineering parallelism.
+- Keeps all known blockers visible.
+- Avoids premature optimization of the repair queue.
+
+Disadvantages:
+
+- Consumes runner capacity without pricing repairs by expected unblock value.
+- Does not reduce failed AgentRuns when many repairs target stale or already-held surfaces.
+- Makes Jangar material readiness noisy because receipts are not comparable.
+- Can produce activity without improving routeable candidates or post-cost profit.
+
+Decision: reject as the default. Broad repair remains useful only during incident recovery.
+
+### Option B: Block All Torghut Work Until Profit Floor Passes
+
+Do not run Torghut repair or paper work until the profit proof floor is no longer `repair_only`.
+
+Advantages:
+
+- Strongest capital safety posture.
+- Simple deployer rule.
+- Avoids wasting capacity on uncertain repairs.
+
+Disadvantages:
+
+- The proof floor cannot pass without repair work.
+- Keeps stale evidence high.
+- Increases manual intervention because engineers have to bypass the gate to produce the evidence it requires.
+
+Decision: reject. Capital remains blocked, but zero-notional repair must stay available.
+
+### Option C: Repair Receipt Frontier With Profit Cutover Ladder
+
+Create a ranked frontier of zero-notional repair lots. Admit only frontier lots that name a value gate, expected gate
+delta, required output receipt, source-serving epoch, max runtime, and rollback. Promote to paper only after receipt
+settlement proves routeability, TCA quality, feature freshness, and post-cost profit.
+
+Advantages:
+
+- Preserves `max_notional=0` while allowing high-value repair.
+- Gives Jangar a compact repair receipt for stage-credit and material readiness.
+- Makes profitability hypotheses measurable before paper/live cutover.
+- Reduces manual triage because low-value or unverified repairs do not launch.
+- Produces a clear deployer contract for green PR-to-healthy rollout.
+
+Disadvantages:
+
+- Requires repair receipts to be stricter and more structured.
+- Slower for opportunistic fixes that do not map to a frontier lot.
+- Needs settlement logic before the frontier can automatically unlock paper canaries.
+
+Decision: select Option C.
+
+## Architecture
+
+Torghut publishes `repair_receipt_frontier` alongside readiness, trading health, consumer evidence, and source-serving
+proof:
+
+```text
+repair_receipt_frontier
+  schema_version = torghut.repair-receipt-frontier.v1
+  frontier_id
+  generated_at
+  fresh_until
+  account
+  window
+  source_serving_ledger_ref
+  capital_state                 # zero_notional | shadow | paper_candidate | live_candidate
+  max_notional
+  frontier_state                # repair_only | paper_blocked | paper_candidate | live_blocked | live_candidate
+  lots[]
+  paper_cutover_requirements[]
+  live_cutover_requirements[]
+  rollback_target
+```
+
+Each lot is a measurable repair hypothesis:
+
+```text
+repair_frontier_lot
+  lot_id
+  lot_class                     # feature_rows | execution_tca | research_candidate | source_serving | rejection_drag
+  target_symbols[]
+  target_hypothesis_ids[]
+  target_value_gate             # zero_notional_or_stale_evidence_rate | routeable_candidate_count | ...
+  expected_gate_delta
+  expected_unblock_value
+  cost_class
+  source_serving_epoch_ref
+  required_input_refs[]
+  required_output_receipt
+  validation_commands[]
+  max_runtime_seconds
+  max_notional = 0
+  dispatchable
+  hold_reason_codes[]
+  settlement_status             # pending | settled | rejected | expired
+```
+
+Graduation rules:
+
+- A frontier lot can be dispatched only when `max_notional=0`, source-serving proof is current or the lot explicitly
+  repairs source-serving proof, and the required output receipt is named.
+- A frontier lot settles only when the output receipt retires at least one blocking reason and remains fresh through
+  the next Jangar material readiness evaluation.
+- Paper cutover requires current source-serving proof, current feature rows, current execution/TCA receipt, at least
+  one routeable candidate, and non-negative post-cost expectancy for the candidate window.
+- Live cutover additionally requires human-approved capital limits, live submission enabled by configuration, and no
+  unresolved capital safety blockers.
+- If any receipt is malformed, expired, or claims notional above zero during repair, frontier state becomes
+  `paper_blocked` and Jangar material readiness stays `hold` or `block`.
+
+## Profit Hypotheses
+
+The frontier must keep the hypotheses small enough to falsify:
+
+- H1: Refreshing missing feature rows for the active eight-symbol universe reduces
+  `zero_notional_or_stale_evidence_rate` by at least 25 percentage points without increasing `max_notional`.
+- H2: Recomputing execution/TCA receipts for `AAPL`, `AMD`, `AVGO`, `INTC`, and `NVDA` raises
+  `routeable_candidate_count` from `0` to at least `2` while slippage and expected shortfall stay inside configured
+  paper thresholds.
+- H3: Creating research candidate and promotion receipts for one active hypothesis reduces
+  `research_candidates_empty`, `research_promotions_empty`, and `vnext_promotion_decisions_empty` without enabling
+  live submission.
+- H4: Measuring rejection drag for the top repair symbols produces a paper/no-paper decision that is more valuable
+  than another generic market-context refresh.
+- H5: Source-serving repair receipts reduce Jangar material-readiness holds by giving the ready truth arbiter a current
+  contract canary and runtime source epoch.
+
+Every implementation PR must name which hypothesis it tests and which receipt proves success.
+
+## Implementation Scope For Engineer Stage
+
+The next bounded Torghut engineering PR should add the read model first and leave capital behavior unchanged.
+
+Required code changes:
+
+1. Add `repair_receipt_frontier` construction in Torghut readiness/trading status code.
+2. Reuse existing repair-bid settlement, route warrant, source-serving, TCA, feature freshness, and profit-window
+   inputs; do not introduce a new database write path for the first PR.
+3. Include the frontier in `/readyz`, `/trading/health`, and `/trading/consumer-evidence`.
+4. Add tests that prove the current live shape produces `frontier_state=repair_only`, `max_notional=0`, no paper
+   candidate, and dispatchable zero-notional lots only when required output receipts are named.
+5. Add tests for malformed receipt, expired receipt, and nonzero notional repair rejection.
+
+Acceptance gates:
+
+- `uv run --frozen pytest services/torghut/tests/test_trading_api.py -k repair_receipt_frontier`
+- `uv run --frozen pytest services/torghut/tests/test_repair_bid_settlement.py`
+- `uv run --frozen pyright --project pyrightconfig.json`
+- `uv run --frozen pyright --project pyrightconfig.alpha.json`
+- `uv run --frozen pyright --project pyrightconfig.scripts.json`
+
+The PR must cite this design and the companion Jangar design. It must keep live submission disabled and `max_notional=0`.
+
+## Deployment And Verification Gates
+
+The deployer stage must prove:
+
+- Argo `torghut` is Synced/Healthy at the promoted revision.
+- The active Knative revision is ready.
+- `/readyz` and `/trading/health` expose `repair_receipt_frontier`.
+- `repair_receipt_frontier.max_notional=0` until paper cutover.
+- The frontier has at least one lot with a named value gate and output receipt, or names the exact blocker preventing
+  lot dispatch.
+- Source-serving proof is current or a source-serving repair lot is the selected frontier lot.
+- Jangar `ready_truth_arbiter` consumes the Torghut frontier as repair evidence, not capital authority.
+
+## Rollback
+
+Rollback stays simple:
+
+- Keep `TRADING_AUTONOMY_ALLOW_LIVE_PROMOTION=false`.
+- Keep `TRADING_AUTONOMY_ENABLED=false` for live promotion until paper cutover passes.
+- Keep `max_notional=0` for every repair frontier lot.
+- If the frontier payload is malformed, omit it from readiness and let Jangar fall back to existing route warrants and
+  repair-bid settlement holds.
+- If a repair receipt is disputed, mark the lot `rejected` or `expired`; do not widen capital.
+
+## Handoff Contract
+
+Engineer handoff:
+
+- Build the frontier as a read model first.
+- Do not add new writes or broker actions in the first PR.
+- Every frontier lot must name a value gate, expected gate delta, output receipt, max runtime, and notional cap.
+- Tests must cover current degraded-but-safe state.
+
+Deployer handoff:
+
+- Treat a visible frontier as repair evidence, not paper authority.
+- Paper cutover requires source-serving proof, routeability, TCA quality, feature freshness, and post-cost profit.
+- Live cutover remains blocked without explicit capital gate approval and live submission configuration.
+
+## Risks
+
+- The frontier can become another dumping ground for every blocker. Limit the first version to the top few lots ranked
+  by expected unblock value and receipt quality.
+- A repair receipt can retire one reason while another reason still blocks paper. The frontier must show remaining
+  reasons clearly.
+- Jangar must not turn a Torghut repair lot into capital authority. The companion ready truth arbiter keeps repair,
+  paper, and live action classes separate.
+- If source-serving proof remains missing, the frontier should prioritize source-serving repair before routeable
+  candidate claims.
+
+## Next Milestone
+
+The next implementation milestone is:
+
+`feat(torghut): publish repair receipt frontier`
+
+It improves:
+
+- `zero_notional_or_stale_evidence_rate` by ranking stale-evidence repairs;
+- `routeable_candidate_count` by requiring a routeability delta before paper promotion;
+- `fill_tca_or_slippage_quality` by requiring current execution/TCA receipts;
+- `post_cost_daily_net_pnl` by making profit evidence a cutover requirement;
+- `capital_gate_safety` by keeping every repair lot at `max_notional=0`.

--- a/docs/torghut/design-system/v6/index.md
+++ b/docs/torghut/design-system/v6/index.md
@@ -8,10 +8,12 @@
 - Scope: intraday strategy architecture upgrade beyond static TSMOM, with regime-adaptive routing, DSPy-governed LLM
   reasoning, contamination-safe evaluation, and production rollout controls
 - Implementation status: `Mixed` (historical program closure recorded on `2026-03-03`; source-state refreshed on
-  `2026-03-09`; active proof/capital authority evidence refreshed on `2026-05-13T04:13Z`)
+  `2026-03-09`; active proof/capital authority evidence refreshed on `2026-05-13T08:28Z`)
 - Implementation status (strict, core 01-13 docs, source-state refresh `2026-03-09`): `Implemented=7`, `Partial=5`, `Completed=1`
 - Evidence (historical closure): `13-production-gap-closure-master-plan-2026-03-03.md` (Wave 0-6 closure + DoD)
-- Evidence (current next-work priority, refreshed `2026-05-13T04:13Z`):
+- Evidence (current next-work priority, refreshed `2026-05-13T08:28Z`):
+  - `192-torghut-repair-receipt-frontier-and-profit-cutover-2026-05-13.md`
+  - `docs/agents/designs/188-jangar-ready-truth-arbiter-and-stage-credit-cutover-2026-05-13.md`
   - `191-torghut-source-serving-proof-and-repair-receipt-promotion-2026-05-13.md`
   - `docs/agents/designs/187-jangar-main-source-ci-retention-and-source-serving-verdicts-2026-05-13.md`
   - `190-torghut-repair-bid-settlement-and-routeability-proof-compaction-2026-05-13.md`


### PR DESCRIPTION
## Summary

- Added Jangar design doc 188 for a ready truth arbiter that separates serving readiness from material launch readiness.
- Added Torghut design doc 192 for a repair receipt frontier that ranks zero-notional repairs before paper/live cutover.
- Updated the Torghut v6 index so the current priority evidence points to the new Jangar/Torghut cutover contracts.

## Related Issues

None

## Testing

- `git diff --cached --check` before commit: pass
- `bunx oxfmt --check docs/agents/designs/188-jangar-ready-truth-arbiter-and-stage-credit-cutover-2026-05-13.md docs/torghut/design-system/v6/192-torghut-repair-receipt-frontier-and-profit-cutover-2026-05-13.md docs/torghut/design-system/v6/index.md`: pass

## Screenshots (if applicable)

N/A, documentation-only architecture update.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
