### PR TITLE
fix(sag): isolate ssr query cache

### DIFF
--- a/argocd/sag/kustomization.yaml
+++ b/argocd/sag/kustomization.yaml
@@ -11,4 +11,4 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/sag
     newName: registry.ide-newton.ts.net/lab/sag
-    newTag: "sag-20260513010817"
+    newTag: "sag-20260513084116"

--- a/services/sag/src/router.tsx
+++ b/services/sag/src/router.tsx
@@ -2,16 +2,19 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { createRouter as createTanStackRouter } from '@tanstack/react-router'
 import { routeTree } from './routeTree.gen'
 
-export const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      staleTime: 15_000,
-      refetchOnWindowFocus: false,
+const createQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 15_000,
+        refetchOnWindowFocus: false,
+      },
     },
-  },
-})
+  })
 
 export function createRouter() {
+  const queryClient = createQueryClient()
+
   return createTanStackRouter({
     routeTree,
     defaultPreload: 'intent',


### PR DESCRIPTION
## Summary

- Creates a fresh React Query client per TanStack router instance so SSR cannot leak stale SAG snapshots between requests.
- Bumps the SAG GitOps image tag to `sag-20260513084116`, the image built from the cache-isolation fix.
- Keeps the public root page tied to the current Postgres-backed snapshot instead of prior request state.

## Related Issues

None

## Testing

- `bun run --filter @proompteng/sag tsc`
- `bun run --filter @proompteng/sag test`
- `bun run --filter @proompteng/sag lint`
- `bun run --filter @proompteng/sag lint:oxlint`
- `bun run --filter @proompteng/sag build`
- `bun run lint:argocd`
- `SAG_IMAGE_TAG=sag-20260513084116 bun run sag:deploy`
- `curl -fsSL --compressed https://sag.proompteng.ai/api/health`
- `curl -fsSL --compressed https://sag.proompteng.ai/` checked for stale validation state and forbidden fake/demo terms

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
