### PR TITLE
fix(torghut): close autoresearch runtime proof loop

### DIFF
--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -56,7 +56,10 @@ from app.trading.discovery.portfolio_optimizer import (
     PortfolioCandidateSpec,
     optimize_portfolio_candidate,
 )
-from app.trading.discovery.profit_target_oracle import ProfitTargetOraclePolicy
+from app.trading.discovery.profit_target_oracle import (
+    ProfitTargetOraclePolicy,
+    evaluate_profit_target_oracle,
+)
 from app.trading.discovery.runtime_closure import (
     RuntimeClosureExecutionContext,
     write_runtime_closure_bundle,
@@ -85,6 +88,17 @@ _DEFAULT_STRICT_DAILY_PROFIT_PROGRAM = Path(
 )
 _DEFAULT_MAX_FRONTIER_CANDIDATES_PER_SPEC = 8
 _PROGRAM_SOURCE_DEFAULT_CONFIDENCE = "0.70"
+_RUNTIME_CLOSURE_PROOF_ORACLE_BLOCKERS = frozenset(
+    {
+        "shadow_parity_status_failed",
+        "executable_replay_passed_failed",
+        "executable_replay_artifact_present_failed",
+        "executable_replay_order_count_failed",
+        "executable_replay_account_buying_power_failed",
+        "executable_replay_max_notional_per_trade_failed",
+        "executable_replay_notional_within_buying_power_failed",
+    }
+)
 
 
 def _default_strategy_config_path() -> Path:
@@ -152,6 +166,15 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--chunk-minutes", type=int, default=10)
     parser.add_argument("--symbols", default=_DEFAULT_CHIP_UNIVERSE_CSV)
     parser.add_argument("--progress-log-seconds", type=int, default=30)
+    parser.add_argument(
+        "--shadow-validation-artifact",
+        type=Path,
+        default=None,
+        help=(
+            "Optional real shadow/live deviation artifact to attach to runtime "
+            "closure. Missing or invalid artifacts stay fail-closed."
+        ),
+    )
     parser.add_argument(
         "--max-frontier-candidates-per-spec",
         type=int,
@@ -1585,6 +1608,9 @@ def _profitability_next_epoch_plan(
     real_replay_shard_workers = _int_arg(args, "real_replay_shard_workers", 1)
     if real_replay_shard_workers > 1:
         flags["--real-replay-shard-workers"] = str(real_replay_shard_workers)
+    shadow_validation_artifact = getattr(args, "shadow_validation_artifact", None)
+    if shadow_validation_artifact is not None:
+        flags["--shadow-validation-artifact"] = str(shadow_validation_artifact)
 
     applied_recommended_flags: list[dict[str, str]] = []
     rejected_recommended_flags: list[dict[str, str]] = []
@@ -2794,6 +2820,11 @@ def _runtime_closure_payload(
             symbol.strip() for symbol in str(args.symbols).split(",") if symbol.strip()
         ),
         progress_log_interval_seconds=int(args.progress_log_seconds),
+        shadow_validation_artifact_path=_resolve_existing_path(
+            cast(Path, getattr(args, "shadow_validation_artifact"))
+        )
+        if getattr(args, "shadow_validation_artifact", None) is not None
+        else None,
     )
     return write_runtime_closure_bundle(
         run_root=output_dir,
@@ -2805,6 +2836,210 @@ def _runtime_closure_payload(
     ).to_payload()
 
 
+def _boolish(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    return _string(value).lower() in {"1", "true", "yes", "y", "passed"}
+
+
+def _oracle_blockers(scorecard: Mapping[str, Any]) -> frozenset[str]:
+    raw_blockers = _mapping(scorecard.get("profit_target_oracle")).get("blockers")
+    if not isinstance(raw_blockers, Sequence) or isinstance(raw_blockers, str):
+        return frozenset()
+    return frozenset(
+        blocker
+        for blocker in (_string(item) for item in cast(Sequence[Any], raw_blockers))
+        if blocker
+    )
+
+
+def _portfolio_needs_runtime_closure_proof(portfolio: PortfolioCandidateSpec) -> bool:
+    scorecard = _mapping(portfolio.objective_scorecard)
+    if _boolish(scorecard.get("oracle_passed")):
+        return False
+    if not _boolish(scorecard.get("target_met")):
+        return False
+    blockers = _oracle_blockers(scorecard)
+    return bool(blockers) and blockers <= _RUNTIME_CLOSURE_PROOF_ORACLE_BLOCKERS
+
+
+def _load_json_mapping_artifact(path_value: Any) -> dict[str, Any]:
+    path_text = _string(path_value)
+    if not path_text:
+        return {}
+    try:
+        payload = json.loads(Path(path_text).read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return {}
+    return _mapping(payload)
+
+
+def _runtime_closure_artifact_refs(
+    runtime_closure: Mapping[str, Any],
+) -> tuple[str, ...]:
+    refs: list[str] = []
+    root = _string(runtime_closure.get("root"))
+    if root:
+        summary_path = Path(root) / "summary.json"
+        if summary_path.exists():
+            refs.append(str(summary_path))
+    for key in (
+        "candidate_configmap_path",
+        "gate_report_path",
+        "parity_replay_path",
+        "parity_report_path",
+        "approval_replay_path",
+        "approval_report_path",
+        "shadow_validation_path",
+        "portfolio_proof_receipt_path",
+        "profitability_stage_manifest_path",
+        "promotion_prerequisites_path",
+        "replay_plan_path",
+    ):
+        ref = _string(runtime_closure.get(key))
+        if ref and Path(ref).exists() and ref not in refs:
+            refs.append(ref)
+    return tuple(refs)
+
+
+def _runtime_report_summary_int(
+    report: Mapping[str, Any], key: str, *, default: int = 0
+) -> int:
+    value = _mapping(report.get("summary")).get(key)
+    try:
+        return max(0, int(Decimal(str(value if value is not None else default))))
+    except Exception:
+        return default
+
+
+def _runtime_closure_start_equity(runtime_closure: Mapping[str, Any]) -> Decimal:
+    replay_plan = _load_json_mapping_artifact(runtime_closure.get("replay_plan_path"))
+    execution_context = _mapping(replay_plan.get("execution_context"))
+    return _decimal(execution_context.get("start_equity"))
+
+
+def _portfolio_executable_max_notional(portfolio: PortfolioCandidateSpec) -> Decimal:
+    max_notional = Decimal("0")
+    base_per_leg_notional = Decimal("50000")
+    for sleeve in portfolio.sleeves:
+        explicit_max = _decimal(sleeve.get("max_notional_per_trade"))
+        if explicit_max > 0:
+            max_notional = max(max_notional, explicit_max)
+            continue
+        weight = _decimal(sleeve.get("weight"), default="1")
+        if weight <= 0:
+            weight = Decimal("1")
+        max_notional = max(max_notional, base_per_leg_notional * weight)
+    return max_notional
+
+
+def _runtime_closure_scorecard_update(
+    *,
+    portfolio: PortfolioCandidateSpec,
+    runtime_closure: Mapping[str, Any],
+) -> dict[str, Any]:
+    parity_report = _load_json_mapping_artifact(
+        runtime_closure.get("parity_report_path")
+    )
+    approval_report = _load_json_mapping_artifact(
+        runtime_closure.get("approval_report_path")
+    )
+    shadow_validation = _load_json_mapping_artifact(
+        runtime_closure.get("shadow_validation_path")
+    )
+    parity_pass = _boolish(parity_report.get("objective_met"))
+    approval_pass = _boolish(approval_report.get("objective_met"))
+    artifact_refs = _runtime_closure_artifact_refs(runtime_closure)
+    executable_artifact_refs = tuple(
+        ref
+        for ref in (
+            _string(runtime_closure.get("parity_replay_path")),
+            _string(runtime_closure.get("approval_replay_path")),
+        )
+        if ref and Path(ref).exists()
+    )
+    executable_report = approval_report if approval_report else parity_report
+    filled_order_count = _runtime_report_summary_int(executable_report, "filled_count")
+    submitted_order_count = _runtime_report_summary_int(
+        executable_report, "decision_count"
+    )
+    shadow_status = _string(shadow_validation.get("status")) or "missing"
+    return {
+        "runtime_closure_proof": {
+            "status": _string(runtime_closure.get("status")) or "missing",
+            "parity_objective_met": parity_pass,
+            "approval_objective_met": approval_pass,
+            "shadow_status": shadow_status,
+            "artifact_refs": list(artifact_refs),
+            "executable_replay_artifact_refs": list(executable_artifact_refs),
+        },
+        "runtime_closure_artifact_refs": list(artifact_refs),
+        "shadow_parity_status": "within_budget"
+        if shadow_status == "within_budget"
+        else shadow_status,
+        "executable_replay_passed": (
+            parity_pass and approval_pass and bool(executable_artifact_refs)
+        ),
+        "executable_replay_artifact_refs": list(executable_artifact_refs),
+        "executable_replay_artifact_ref": executable_artifact_refs[-1]
+        if executable_artifact_refs
+        else "",
+        "executable_replay_order_count": filled_order_count,
+        "executable_replay_submitted_order_count": submitted_order_count,
+        "executable_replay_account_buying_power": str(
+            _runtime_closure_start_equity(runtime_closure)
+        ),
+        "executable_replay_max_notional_per_trade": str(
+            _portfolio_executable_max_notional(portfolio)
+        ),
+    }
+
+
+def _portfolio_with_runtime_closure_proof(
+    *,
+    portfolio: PortfolioCandidateSpec,
+    runtime_closure: Mapping[str, Any],
+    target: Decimal,
+    oracle_policy: ProfitTargetOraclePolicy,
+) -> PortfolioCandidateSpec:
+    proof_update = _runtime_closure_scorecard_update(
+        portfolio=portfolio, runtime_closure=runtime_closure
+    )
+    proof_payload = _mapping(proof_update.get("runtime_closure_proof"))
+    if not proof_payload.get("executable_replay_artifact_refs") and proof_payload.get(
+        "shadow_status"
+    ) not in {"within_budget", "invalid_artifact"}:
+        return portfolio
+
+    scorecard = {**dict(portfolio.objective_scorecard), **proof_update}
+    scorecard["profit_target_oracle"] = evaluate_profit_target_oracle(
+        scorecard,
+        target_net_pnl_per_day=target,
+        policy=oracle_policy,
+    )
+    scorecard["oracle_passed"] = bool(scorecard["profit_target_oracle"]["passed"])
+    runtime_refs = tuple(
+        ref
+        for ref in cast(
+            Sequence[Any], scorecard.get("runtime_closure_artifact_refs") or ()
+        )
+        if _string(ref)
+    )
+    evidence_refs = tuple(dict.fromkeys((*portfolio.evidence_refs, *runtime_refs)))
+    optimizer_report = {
+        **dict(portfolio.optimizer_report),
+        "runtime_closure_proof_status": proof_payload.get("status"),
+        "runtime_closure_artifact_count": len(runtime_refs),
+        "oracle_passed_after_runtime_closure": scorecard["oracle_passed"],
+    }
+    return replace(
+        portfolio,
+        objective_scorecard=scorecard,
+        evidence_refs=evidence_refs,
+        optimizer_report=optimizer_report,
+    )
+
+
 def _runtime_closure_program_for_candidate(
     *,
     program: StrategyAutoresearchProgram,
@@ -2812,10 +3047,13 @@ def _runtime_closure_program_for_candidate(
     portfolio: PortfolioCandidateSpec | None,
     oracle_candidate_found: bool,
 ) -> StrategyAutoresearchProgram:
-    if portfolio is None or (
-        oracle_candidate_found
-        and bool(manifest.source_window_start)
-        and bool(manifest.source_window_end)
+    runtime_window_available = bool(manifest.source_window_start) and bool(
+        manifest.source_window_end
+    )
+    if portfolio is None:
+        return program
+    if runtime_window_available and (
+        oracle_candidate_found or _portfolio_needs_runtime_closure_proof(portfolio)
     ):
         return program
     return replace(
@@ -3200,6 +3438,38 @@ def run_whitepaper_autoresearch_profit_target(
     write_mlx_snapshot_manifest(
         output_dir / "mlx-snapshot-manifest.json", mlx_snapshot_manifest
     )
+    initial_oracle_candidate_found = bool(
+        portfolio is not None
+        and portfolio.objective_scorecard.get("oracle_passed") is True
+        and not replay_result.incomplete
+    )
+    runtime_closure_program = _runtime_closure_program_for_candidate(
+        program=program,
+        manifest=mlx_snapshot_manifest,
+        portfolio=portfolio,
+        oracle_candidate_found=initial_oracle_candidate_found,
+    )
+    runtime_closure = _runtime_closure_payload(
+        args=args,
+        output_dir=output_dir,
+        epoch_id=epoch_id,
+        program=runtime_closure_program,
+        manifest=mlx_snapshot_manifest,
+        portfolio=portfolio,
+    )
+    if portfolio is not None:
+        portfolio = _portfolio_with_runtime_closure_proof(
+            portfolio=portfolio,
+            runtime_closure=runtime_closure,
+            target=target,
+            oracle_policy=oracle_policy,
+        )
+        portfolio_rows = [portfolio.to_payload()]
+        _write_jsonl(output_dir / "portfolio-candidates.jsonl", portfolio_rows)
+        _write_json(
+            output_dir / "portfolio-optimizer-report.json", portfolio.optimizer_report
+        )
+
     oracle_candidate_found = bool(
         portfolio is not None
         and portfolio.objective_scorecard.get("oracle_passed") is True
@@ -3217,26 +3487,36 @@ def run_whitepaper_autoresearch_profit_target(
     elif replay_result.incomplete:
         promotion_status = "blocked_pending_complete_replay"
         promotion_blockers = ["selected_replay_incomplete", *replay_failure_reasons]
-    else:
-        promotion_status = "blocked_pending_runtime_parity"
+    elif oracle_candidate_found:
+        runtime_status = _string(runtime_closure.get("status"))
+        promotion_status = runtime_status or "ready_for_promotion_review"
         promotion_blockers = [
+            _string(item)
+            for item in cast(
+                Sequence[Any], runtime_closure.get("next_required_steps") or ()
+            )
+            if _string(item) and _string(item) != "promotion_review"
+        ]
+    else:
+        runtime_next_steps = [
+            _string(item)
+            for item in cast(
+                Sequence[Any], runtime_closure.get("next_required_steps") or ()
+            )
+            if _string(item)
+        ]
+        promotion_status = "blocked_pending_runtime_closure_or_oracle"
+        promotion_blockers = list(
+            dict.fromkeys(
+                (
+                    *sorted(_oracle_blockers(_mapping(portfolio.objective_scorecard))),
+                    *runtime_next_steps,
+                )
+            )
+        ) or [
             "scheduler_v3_parity_missing",
             "shadow_validation_missing",
         ]
-    runtime_closure_program = _runtime_closure_program_for_candidate(
-        program=program,
-        manifest=mlx_snapshot_manifest,
-        portfolio=portfolio,
-        oracle_candidate_found=oracle_candidate_found,
-    )
-    runtime_closure = _runtime_closure_payload(
-        args=args,
-        output_dir=output_dir,
-        epoch_id=epoch_id,
-        program=runtime_closure_program,
-        manifest=mlx_snapshot_manifest,
-        portfolio=portfolio,
-    )
     status = "ok" if oracle_candidate_found else "no_profit_target_candidate"
     status_reason = None
     if not oracle_candidate_found:

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -469,6 +469,286 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         self.assertFalse(runtime_program.runtime_closure_policy.execute_parity_replay)
         self.assertFalse(runtime_program.runtime_closure_policy.execute_approval_replay)
 
+    def test_runtime_closure_replay_stays_enabled_for_proof_only_oracle_failure(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as tmpdir:
+            args = self._args(Path(tmpdir) / "epoch")
+            args.program = Path(
+                "config/trading/research-programs/strict-daily-profit-autoresearch-500-v1.yaml"
+            )
+            args.replay_mode = "real"
+            program = runner._load_epoch_program(args)
+
+        manifest = runner.MlxSnapshotManifest(
+            snapshot_id="mlx-snap-test",
+            created_at="2026-05-06T00:00:00+00:00",
+            source_window_start="2026-03-20",
+            source_window_end="2026-04-09",
+            train_days=6,
+            holdout_days=3,
+            full_window_days=9,
+            symbols=tuple(_CHIP_UNIVERSE),
+            bar_interval="PT1S",
+            quote_quality_policy_id="scheduler_v3_default",
+            feature_set_id="torghut.mlx-autoresearch.v1",
+            cross_sectional_feature_flags={},
+            prior_day_feature_flags={},
+            tape_freshness_receipts=(),
+            row_counts={},
+            tensor_bundle_paths={},
+            manifest_hash="hash",
+        )
+        portfolio = runner.PortfolioCandidateSpec(
+            schema_version="torghut.portfolio-candidate-spec.v1",
+            portfolio_candidate_id="portfolio-test",
+            source_candidate_ids=("candidate-test",),
+            target_net_pnl_per_day=Decimal("500"),
+            sleeves=(),
+            capital_budget={},
+            correlation_budget={},
+            drawdown_budget={},
+            evidence_refs=(),
+            objective_scorecard={
+                "target_met": True,
+                "oracle_passed": False,
+                "profit_target_oracle": {
+                    "passed": False,
+                    "blockers": [
+                        "shadow_parity_status_failed",
+                        "executable_replay_passed_failed",
+                        "executable_replay_artifact_present_failed",
+                    ],
+                },
+            },
+            optimizer_report={},
+        )
+
+        runtime_program = runner._runtime_closure_program_for_candidate(
+            program=program,
+            manifest=manifest,
+            portfolio=portfolio,
+            oracle_candidate_found=False,
+        )
+
+        self.assertTrue(runtime_program.runtime_closure_policy.execute_parity_replay)
+        self.assertTrue(runtime_program.runtime_closure_policy.execute_approval_replay)
+
+    def test_runtime_closure_proof_updates_portfolio_oracle_from_real_artifacts(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as tmpdir:
+            run_root = Path(tmpdir)
+            runtime_root = run_root / "runtime-closure"
+            replay_dir = runtime_root / "replay"
+            gates_dir = runtime_root / "gates"
+            promotion_dir = runtime_root / "promotion"
+            replay_dir.mkdir(parents=True)
+            gates_dir.mkdir(parents=True)
+            promotion_dir.mkdir(parents=True)
+            parity_replay_path = replay_dir / "scheduler-v3-parity-replay.json"
+            approval_replay_path = replay_dir / "scheduler-v3-approval-replay.json"
+            parity_report_path = replay_dir / "scheduler-v3-parity-report.json"
+            approval_report_path = replay_dir / "scheduler-v3-approval-report.json"
+            shadow_path = replay_dir / "shadow-validation-plan.json"
+            replay_plan_path = replay_dir / "runtime-replay-plan.json"
+            gate_path = gates_dir / "gate-evaluation.json"
+            proof_path = promotion_dir / "portfolio-proof-receipt.json"
+            summary_path = runtime_root / "summary.json"
+            for artifact_path in (
+                parity_replay_path,
+                approval_replay_path,
+                gate_path,
+                proof_path,
+                summary_path,
+            ):
+                artifact_path.write_text("{}\n", encoding="utf-8")
+            parity_report_path.write_text(
+                json.dumps(
+                    {
+                        "objective_met": True,
+                        "summary": {"filled_count": 3, "decision_count": 4},
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            approval_report_path.write_text(
+                json.dumps(
+                    {
+                        "objective_met": True,
+                        "summary": {"filled_count": 2, "decision_count": 3},
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            shadow_path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": "torghut.runtime-closure-shadow-validation-plan.v1",
+                        "status": "within_budget",
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            replay_plan_path.write_text(
+                json.dumps({"execution_context": {"start_equity": "31590.02"}}) + "\n",
+                encoding="utf-8",
+            )
+            policy = runner.ProfitTargetOraclePolicy()
+            scorecard: dict[str, object] = {
+                "net_pnl_per_day": "620",
+                "portfolio_post_cost_net_pnl_per_day": "620",
+                "target_met": True,
+                "active_day_ratio": "1",
+                "positive_day_ratio": "1",
+                "daily_net": {"2026-03-20": "620", "2026-03-21": "620"},
+                "trading_day_count": 2,
+                "best_day_share": "0.25",
+                "max_single_day_contribution_share": "0.25",
+                "max_cluster_contribution_share": "0.30",
+                "max_single_symbol_contribution_share": "0.30",
+                "worst_day_loss": "0",
+                "max_drawdown": "0",
+                "avg_filled_notional_per_day": "300000",
+                "regime_slice_pass_rate": "0.60",
+                "posterior_edge_lower": "0.01",
+                "shadow_parity_status": "missing",
+                "executable_replay_passed": False,
+                "executable_replay_artifact_ref": "",
+                "executable_replay_order_count": 0,
+                "executable_replay_account_buying_power": "0",
+                "executable_replay_max_notional_per_trade": "0",
+            }
+            scorecard["profit_target_oracle"] = runner.evaluate_profit_target_oracle(
+                scorecard,
+                target_net_pnl_per_day=Decimal("500"),
+                policy=policy,
+            )
+            scorecard["oracle_passed"] = False
+            portfolio = runner.PortfolioCandidateSpec(
+                schema_version="torghut.portfolio-candidate-spec.v1",
+                portfolio_candidate_id="portfolio-test",
+                source_candidate_ids=("candidate-test",),
+                target_net_pnl_per_day=Decimal("500"),
+                sleeves=(
+                    {
+                        "candidate_id": "candidate-test",
+                        "candidate_spec_id": "spec-test",
+                        "runtime_family": "breakout_continuation_consistent",
+                        "runtime_strategy_name": "breakout-sleeve-1",
+                        "weight": "0.5",
+                    },
+                ),
+                capital_budget={},
+                correlation_budget={},
+                drawdown_budget={},
+                evidence_refs=(),
+                objective_scorecard=scorecard,
+                optimizer_report={},
+            )
+
+            updated = runner._portfolio_with_runtime_closure_proof(
+                portfolio=portfolio,
+                runtime_closure={
+                    "status": "ready_for_promotion_review",
+                    "root": str(runtime_root),
+                    "gate_report_path": str(gate_path),
+                    "parity_replay_path": str(parity_replay_path),
+                    "parity_report_path": str(parity_report_path),
+                    "approval_replay_path": str(approval_replay_path),
+                    "approval_report_path": str(approval_report_path),
+                    "shadow_validation_path": str(shadow_path),
+                    "portfolio_proof_receipt_path": str(proof_path),
+                    "replay_plan_path": str(replay_plan_path),
+                },
+                target=Decimal("500"),
+                oracle_policy=policy,
+            )
+
+        self.assertTrue(updated.objective_scorecard["oracle_passed"])
+        self.assertTrue(updated.objective_scorecard["executable_replay_passed"])
+        self.assertEqual(
+            updated.objective_scorecard["shadow_parity_status"], "within_budget"
+        )
+        self.assertEqual(
+            updated.objective_scorecard["executable_replay_order_count"], 2
+        )
+        self.assertEqual(
+            updated.objective_scorecard["executable_replay_artifact_ref"],
+            str(approval_replay_path),
+        )
+        self.assertIn(str(approval_replay_path), updated.evidence_refs)
+
+    def test_runtime_closure_proof_helpers_stay_fail_closed_on_edge_inputs(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as tmpdir:
+            invalid_json_path = Path(tmpdir) / "invalid.json"
+            invalid_json_path.write_text("{", encoding="utf-8")
+            args = self._args(Path(tmpdir) / "epoch")
+            program = runner._load_epoch_program(args)
+
+        portfolio = runner.PortfolioCandidateSpec(
+            schema_version="torghut.portfolio-candidate-spec.v1",
+            portfolio_candidate_id="portfolio-test",
+            source_candidate_ids=("candidate-test",),
+            target_net_pnl_per_day=Decimal("500"),
+            sleeves=(
+                {"candidate_id": "candidate-test", "max_notional_per_trade": "123"},
+                {"candidate_id": "candidate-two", "weight": "-1"},
+            ),
+            capital_budget={},
+            correlation_budget={},
+            drawdown_budget={},
+            evidence_refs=(),
+            objective_scorecard={"target_met": True, "oracle_passed": True},
+            optimizer_report={},
+        )
+        manifest = runner.MlxSnapshotManifest(
+            snapshot_id="mlx-snap-test",
+            created_at="2026-05-06T00:00:00+00:00",
+            source_window_start="2026-03-20",
+            source_window_end="2026-04-09",
+            train_days=6,
+            holdout_days=3,
+            full_window_days=9,
+            symbols=tuple(_CHIP_UNIVERSE),
+            bar_interval="PT1S",
+            quote_quality_policy_id="scheduler_v3_default",
+            feature_set_id="torghut.mlx-autoresearch.v1",
+            cross_sectional_feature_flags={},
+            prior_day_feature_flags={},
+            tape_freshness_receipts=(),
+            row_counts={},
+            tensor_bundle_paths={},
+            manifest_hash="hash",
+        )
+
+        self.assertEqual(runner._oracle_blockers({}), frozenset())
+        self.assertEqual(runner._load_json_mapping_artifact(invalid_json_path), {})
+        self.assertEqual(
+            runner._runtime_report_summary_int(
+                {"summary": {"filled_count": "bad"}}, "filled_count", default=7
+            ),
+            7,
+        )
+        self.assertEqual(
+            runner._portfolio_executable_max_notional(portfolio), Decimal("50000")
+        )
+        self.assertFalse(runner._portfolio_needs_runtime_closure_proof(portfolio))
+        self.assertIs(
+            runner._runtime_closure_program_for_candidate(
+                program=program,
+                manifest=manifest,
+                portfolio=None,
+                oracle_candidate_found=False,
+            ),
+            program,
+        )
+
     def test_candidate_universe_symbols_default_to_chip_coverage_when_empty(
         self,
     ) -> None:
@@ -1173,6 +1453,7 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             args.real_replay_shard_size = 2
             args.real_replay_shard_timeout_seconds = 900
             args.real_replay_shard_workers = 3
+            args.shadow_validation_artifact = Path("/tmp/shadow-validation.json")
             remediation = {
                 "next_actions": [
                     {
@@ -1200,6 +1481,10 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         self.assertEqual(plan["flags"]["--real-replay-shard-size"], "2")
         self.assertEqual(plan["flags"]["--real-replay-shard-timeout-seconds"], "900")
         self.assertEqual(plan["flags"]["--real-replay-shard-workers"], "3")
+        self.assertEqual(
+            plan["flags"]["--shadow-validation-artifact"],
+            "/tmp/shadow-validation.json",
+        )
         self.assertIn(
             {
                 "action": "increase_breadth_and_portfolio_diversity",


### PR DESCRIPTION
## Summary

- Breaks the proof deadlock in the `$500/day` autoresearch runner by allowing runtime closure replay when a portfolio only fails oracle proof fields.
- Feeds real runtime closure artifacts back into the portfolio scorecard, then reruns the profit-target oracle without changing the target or bypassing gates.
- Adds an optional `--shadow-validation-artifact` input so real shadow/live deviation evidence can be attached fail-closed.
- Adds regression coverage for proof-only runtime replay, scorecard proof updates, and fail-closed helper edge cases.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv run --frozen ruff format --check scripts/run_whitepaper_autoresearch_profit_target.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv run --frozen ruff check scripts/run_whitepaper_autoresearch_profit_target.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen coverage run -m pytest tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv run --frozen coverage xml --fail-under=0`
- `GITHUB_BASE_REF=main GITHUB_EVENT_NAME=pull_request uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
