### PR TITLE
fix(sag): schedule on amd64 worker

### DIFF
--- a/argocd/sag/deployment.yaml
+++ b/argocd/sag/deployment.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       serviceAccountName: sag
       nodeSelector:
-        kubernetes.io/arch: arm64
+        kubernetes.io/arch: amd64
       securityContext:
         runAsUser: 1000
         runAsGroup: 1000

--- a/argocd/sag/kustomization.yaml
+++ b/argocd/sag/kustomization.yaml
@@ -11,4 +11,4 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/sag
     newName: registry.ide-newton.ts.net/lab/sag
-    newTag: "sag-20260513084116"
+    newTag: "sag-20260513085024"

--- a/packages/scripts/src/sag/build-image.ts
+++ b/packages/scripts/src/sag/build-image.ts
@@ -23,7 +23,7 @@ export const buildImage = async (options: BuildImageOptions = {}) => {
   const context = resolve(repoRoot, options.context ?? process.env.SAG_BUILD_CONTEXT ?? '.')
   const dockerfile = resolve(repoRoot, options.dockerfile ?? process.env.SAG_DOCKERFILE ?? 'services/sag/Dockerfile')
   const platforms = options.platforms ??
-    process.env.SAG_IMAGE_PLATFORMS?.split(',').map((platform) => platform.trim()) ?? ['linux/arm64']
+    process.env.SAG_IMAGE_PLATFORMS?.split(',').map((platform) => platform.trim()) ?? ['linux/amd64']
   const cacheRef = options.cacheRef ?? process.env.SAG_BUILD_CACHE_REF ?? `${registry}/${repository}:buildcache`
 
   return buildAndPushDockerImage({


### PR DESCRIPTION
## Summary

- Pins the SAG deployment to the available amd64 worker architecture.
- Changes the SAG image builder default to publish linux/amd64 images for that workload target.
- Bumps the SAG GitOps image tag to `sag-20260513085024`, the amd64 image built from the current service.

## Related Issues

None

## Testing

- `bunx oxfmt --check packages/scripts/src/sag/build-image.ts argocd/sag/deployment.yaml`
- `bun run --filter @proompteng/sag tsc`
- `bun run --filter @proompteng/sag test`
- `bun run lint:argocd`
- `SAG_IMAGE_TAG=sag-20260513085024 bun run sag:deploy`
- `curl -fsSL --compressed https://sag.proompteng.ai/api/health`
- `curl -fsSL --compressed https://sag.proompteng.ai/api/snapshot`
- `curl -fsSL --compressed https://sag.proompteng.ai/` checked for stale validation state and forbidden fake/demo terms

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
