### PR TITLE
chore(jangar): promote image 45710e0b

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: fdc164d7
-  digest: sha256:5060397d1b7b9d93cb51b14815f94bbaf720b5bd53fceb366d38b351f070953d
+  tag: 45710e0b
+  digest: sha256:1348bdb0571ee61c3c3005186261a422f4bc754bc19380f842577a9e694950c8
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,8 +11,8 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: fdc164d7
-    digest: sha256:8777533cbe3fe21445d6ac486ca106881b726ea66a35947ec1c9f8afa25170f7
+    tag: 45710e0b
+    digest: sha256:533c8be4f98731a49bcf50039559ff2b5eae712280ef074b84711a2824d89cdf
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
@@ -21,8 +21,8 @@ controlPlane:
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: fdc164d7
-    digest: sha256:5060397d1b7b9d93cb51b14815f94bbaf720b5bd53fceb366d38b351f070953d
+    tag: 45710e0b
+    digest: sha256:1348bdb0571ee61c3c3005186261a422f4bc754bc19380f842577a9e694950c8
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-13T08:14:52Z
+    deploy.knative.dev/rollout: 2026-05-13T08:53:28Z
 spec:
   replicas: 1
   strategy:
@@ -57,11 +57,11 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_RUNTIME_IMAGE
-              value: registry.ide-newton.ts.net/lab/jangar:fdc164d7@sha256:5060397d1b7b9d93cb51b14815f94bbaf720b5bd53fceb366d38b351f070953d
+              value: registry.ide-newton.ts.net/lab/jangar:45710e0b@sha256:1348bdb0571ee61c3c3005186261a422f4bc754bc19380f842577a9e694950c8
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: fdc164d70ae04f1d7defc8496c1a233685a3d0c2
+              value: 45710e0bb070144dc8f7c25bd855221ca3c4e02a
             - name: JANGAR_GITOPS_REVISION
-              value: fdc164d70ae04f1d7defc8496c1a233685a3d0c2
+              value: 45710e0bb070144dc8f7c25bd855221ca3c4e02a
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_BUMBA_TASK_QUEUE

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -59,5 +59,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: fdc164d7
-    digest: sha256:5060397d1b7b9d93cb51b14815f94bbaf720b5bd53fceb366d38b351f070953d
+    newTag: 45710e0b
+    digest: sha256:1348bdb0571ee61c3c3005186261a422f4bc754bc19380f842577a9e694950c8


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `45710e0bb070144dc8f7c25bd855221ca3c4e02a`
- Image tag: `45710e0b`
- Image digest: `sha256:1348bdb0571ee61c3c3005186261a422f4bc754bc19380f842577a9e694950c8`
- Updated API rollout annotation
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`