### PR TITLE
feat(torghut): add source-serving proof ledger

### DIFF
--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -485,6 +485,8 @@ spec:
               value: v0.569.1-170-gd28fd2509
             - name: TORGHUT_COMMIT
               value: d28fd2509af33fd8b751f8222ca41dd172384c00
+            - name: TORGHUT_IMAGE_DIGEST
+              value: sha256:2c3f6bd7af6058ccad135a26740bdedb6cd3b9c9222af1d2dd7ccb6d6cb3bd51
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -301,6 +301,8 @@ spec:
               value: v0.569.1-170-gd28fd2509
             - name: TORGHUT_COMMIT
               value: d28fd2509af33fd8b751f8222ca41dd172384c00
+            - name: TORGHUT_IMAGE_DIGEST
+              value: sha256:2c3f6bd7af6058ccad135a26740bdedb6cd3b9c9222af1d2dd7ccb6d6cb3bd51
           livenessProbe:
             httpGet:
               path: /healthz

--- a/docs/torghut/README.md
+++ b/docs/torghut/README.md
@@ -4,6 +4,14 @@
 
 Start here:
 
+- `docs/torghut/design-system/v6/191-torghut-source-serving-proof-and-repair-receipt-promotion-2026-05-13.md`
+  (current source-serving proof and repair-receipt promotion contract)
+- `docs/agents/designs/187-jangar-main-source-ci-retention-and-source-serving-verdicts-2026-05-13.md`
+  (current Jangar source-serving verdict contract)
+- `docs/torghut/design-system/v6/190-torghut-repair-bid-settlement-and-routeability-proof-compaction-2026-05-13.md`
+  (current repair-bid settlement and routeability proof compaction contract)
+- `docs/agents/designs/186-jangar-repair-bid-admission-and-settlement-custody-2026-05-13.md`
+  (current Jangar repair-bid admission and settlement custody contract)
 - `docs/torghut/design-system/v6/188-torghut-evidence-clock-arbiter-and-routeable-profit-candidate-exchange-2026-05-12.md`
   (current evidence-clock arbiter and routeable profit candidate exchange contract)
 - `docs/agents/designs/184-jangar-rollout-custody-and-evidence-clock-dispatch-2026-05-12.md`
@@ -149,6 +157,11 @@ Start here:
   `/trading/revenue-repair`, and `/trading/consumer-evidence`. The ledger preserves raw clearinghouse reasons but
   compacts them into bounded zero-notional repair lots with one required output receipt and at most three
   Jangar-dispatchable lots per account/window.
+- Current implementation contract: doc 191 adds `source_serving_repair_receipt_ledger` to status, health, readyz, and
+  `/trading/consumer-evidence`. The ledger compares source/build commit, manifest and serving image digests, and
+  required route contract canaries before any repair receipt can be treated as source-serving-current evidence.
+  Missing image digest, missing required contracts, schema mismatches, or source/serving commit splits keep
+  `max_notional=0` and classify the payload as repair-only evidence.
 - Current implementation contract: doc 189 adds `clock_settlement_receipt` beside the evidence-clock arbiter on
   status, health, readyz, and `/trading/consumer-evidence`. The receipt compares direct ClickHouse TA freshness, Jangar
   scoped quant, TCA, empirical, promotion, and rollout witnesses against the published clocks, emits zero-notional

--- a/docs/torghut/design-system/current-source-of-truth-and-priority-guide-2026-03-09.md
+++ b/docs/torghut/design-system/current-source-of-truth-and-priority-guide-2026-03-09.md
@@ -34,6 +34,8 @@ If the question is "what should I trust right now?", start here:
    - `docs/torghut/design-system/v1/historical-dataset-simulation.md`
    - `docs/torghut/design-system/v1/trading-day-simulation-automation.md`
 3. current autonomy/promotion contract source of truth:
+   - `docs/torghut/design-system/v6/191-torghut-source-serving-proof-and-repair-receipt-promotion-2026-05-13.md`
+   - `docs/agents/designs/187-jangar-main-source-ci-retention-and-source-serving-verdicts-2026-05-13.md`
    - `docs/torghut/design-system/v6/190-torghut-repair-bid-settlement-and-routeability-proof-compaction-2026-05-13.md`
    - `docs/agents/designs/186-jangar-repair-bid-admission-and-settlement-custody-2026-05-13.md`
    - `docs/agents/designs/184-jangar-reliability-settlement-ledger-and-rollout-slo-escrow-2026-05-12.md`
@@ -131,7 +133,16 @@ If the question is "what should I trust right now?", start here:
 
 The current highest-priority work is:
 
-The May 13 repair-bid settlement handoff is the current top priority:
+The May 13 source-serving proof handoff is the current top priority:
+
+- make Torghut publish `source_serving_repair_receipt_ledger` from status and consumer-evidence surfaces so repair
+  receipts cite source commit, serving build commit, serving image digest, manifest image digest, and required contract
+  canaries before stale evidence can graduate in
+  `docs/torghut/design-system/v6/191-torghut-source-serving-proof-and-repair-receipt-promotion-2026-05-13.md`;
+- make Jangar consume source-serving verdicts before deploy widening, merge-ready, paper support, or live support in
+  `docs/agents/designs/187-jangar-main-source-ci-retention-and-source-serving-verdicts-2026-05-13.md`.
+
+The May 13 repair-bid settlement handoff remains the next supporting priority:
 
 - make Torghut preserve the raw route evidence clearinghouse packet while compacting broad negative evidence into
   bounded, deduped, zero-notional repair lots in

--- a/docs/torghut/design-system/v6/191-torghut-source-serving-proof-and-repair-receipt-promotion-2026-05-13.md
+++ b/docs/torghut/design-system/v6/191-torghut-source-serving-proof-and-repair-receipt-promotion-2026-05-13.md
@@ -283,6 +283,19 @@ Engineer milestone 1:
 - Add tests that prove `serving_build_commit != source_commit`, null image digest, and missing
   `repair_bid_settlement_ledger` all keep `max_notional=0`.
 
+### Implementation Note (2026-05-13)
+
+Engineer milestone 1 is implemented in observe mode. Torghut now publishes
+`torghut.source-serving-repair-receipt-ledger.v1` on `/trading/status`, `/trading/health`, `/readyz`, and
+`/trading/consumer-evidence`. The reducer compares the source commit, serving build commit, serving image digest,
+manifest image digest, route warrant, repair-bid settlement ledger, route-evidence clearinghouse packet, and
+consumer-evidence contract schemas. Source/serving commit splits, missing image digests, missing contract canaries, or
+schema mismatches all keep `max_notional=0` and mark the ledger as repair-only evidence.
+
+The Torghut release manifest updater now also writes `TORGHUT_IMAGE_DIGEST` into the live and sim Knative services so
+newly promoted images can report the serving digest required by the ledger. Existing route warrants remain the capital
+gate; the source-serving ledger adds contract convergence evidence without authorizing paper or live notional.
+
 Engineer milestone 2:
 
 - Bind `run_zero_notional_repair` receipts to the source-serving ledger.

--- a/packages/scripts/src/torghut/__tests__/update-manifests.test.ts
+++ b/packages/scripts/src/torghut/__tests__/update-manifests.test.ts
@@ -242,9 +242,13 @@ describe('update-manifests', () => {
     expect(serviceManifest).not.toContain('serving.knative.dev/lastModifier:')
     expect(serviceManifest).toContain('value: v0.600.0')
     expect(serviceManifest).toContain('value: 1234567890abcdef1234567890abcdef12345678')
+    expect(serviceManifest).toContain('value: sha256:430763ebeeda8734e1da3ae8c6b665bcc1b380fb815317fffc98371cccea219e')
     expect(simulationServiceManifest).toContain('client.knative.dev/updateTimestamp: "2026-02-21T04:00:00Z"')
     expect(simulationServiceManifest).toContain('value: v0.600.0')
     expect(simulationServiceManifest).toContain('value: 1234567890abcdef1234567890abcdef12345678')
+    expect(simulationServiceManifest).toContain(
+      'value: sha256:430763ebeeda8734e1da3ae8c6b665bcc1b380fb815317fffc98371cccea219e',
+    )
     expect(migrationManifest).toContain(
       'image: registry.ide-newton.ts.net/lab/torghut@sha256:430763ebeeda8734e1da3ae8c6b665bcc1b380fb815317fffc98371cccea219e',
     )

--- a/packages/scripts/src/torghut/update-manifests.ts
+++ b/packages/scripts/src/torghut/update-manifests.ts
@@ -120,6 +120,20 @@ const upsertKnativeRolloutTimestamp = (source: string, rolloutTimestamp: string)
   )
 }
 
+const upsertKnativeEnvValue = (source: string, envName: string, value: string): string => {
+  const envPattern = new RegExp(`(- name:\\s*${escapeRegex(envName)}\\s*\\n\\s*value:\\s*)([^\\n]+)`)
+  if (envPattern.test(source)) {
+    return source.replace(envPattern, `$1${value}`)
+  }
+
+  const commitEnvPattern = /(- name:\s*TORGHUT_COMMIT\s*\n\s*value:\s*[^\n]+\n)/
+  if (!commitEnvPattern.test(source)) {
+    throw new Error(`Unable to locate TORGHUT_COMMIT env anchor for ${envName} in torghut manifest`)
+  }
+
+  return source.replace(commitEnvPattern, `$1            - name: ${envName}\n              value: ${value}\n`)
+}
+
 const updateTorghutManifest = (options: UpdateManifestsOptions) => {
   const manifestPath = resolvePath(options.manifestPath ?? defaultManifestPath)
   const source = readFileSync(manifestPath, 'utf8')
@@ -135,6 +149,7 @@ const updateTorghutManifest = (options: UpdateManifestsOptions) => {
   )
   updated = replaceIfPresent(updated, /(- name:\s*TORGHUT_VERSION\s*\n\s*value:\s*)([^\n]+)/, `$1${options.version}`)
   updated = replaceIfPresent(updated, /(- name:\s*TORGHUT_COMMIT\s*\n\s*value:\s*)([^\n]+)/, `$1${options.commit}`)
+  updated = upsertKnativeEnvValue(updated, 'TORGHUT_IMAGE_DIGEST', options.digest)
   updated = updated.replace(/^\s*serving\.knative\.dev\/lastModifier:\s*[^\n]+\n/gm, '')
 
   if (updated !== source) {

--- a/services/torghut/README.md
+++ b/services/torghut/README.md
@@ -269,6 +269,12 @@ Testing rules for the trading core:
   warrant keeps `max_notional=0`; stale or split dependencies produce zero-notional repair packets mapped to one value
   gate and one expected output receipt. Active-session TCA must also publish a slippage-quality verdict inside the
   route guardrail, with the doc 188 `8` bps average absolute slippage limit as the conservative fallback.
+- `GET /trading/status`, `GET /trading/health`, `GET /readyz`, and `GET /trading/consumer-evidence` now expose the
+  May 13 doc 191 `torghut.source-serving-repair-receipt-ledger.v1` ledger. It binds repair and routeability evidence
+  to the source commit, serving build commit, serving image digest, manifest image digest, and required contract
+  canaries. Missing or mismatched source-serving proof keeps the ledger in repair-only zero-notional mode; the Torghut
+  release manifest updater now writes `TORGHUT_IMAGE_DIGEST` into live and sim Knative env so runtime payloads can
+  report the promoted digest.
 - The simple direct-submit lane is no longer an authority bypass in live mode. Before submitting to Alpaca it evaluates
   the same live-submission gate as the scheduler path and persists the gate payload in decision metadata when a
   submission is blocked. Paper-mode simple execution remains unchanged.

--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -115,6 +115,9 @@ from .trading.routeability_repair_acceptance import (
     build_routeability_repair_acceptance_ledger,
 )
 from .trading.route_reacquisition_board import build_route_reacquisition_board
+from .trading.source_serving_repair_receipt import (
+    build_source_serving_repair_receipt_ledger,
+)
 from .trading.submission_council import (
     build_live_submission_gate_payload,
     build_shadow_first_toggle_parity,
@@ -143,6 +146,13 @@ logger = logging.getLogger(__name__)
 BUILD_VERSION = os.getenv("TORGHUT_VERSION", "dev")
 BUILD_COMMIT = os.getenv("TORGHUT_COMMIT", "unknown")
 BUILD_IMAGE_DIGEST = os.getenv("TORGHUT_IMAGE_DIGEST", "").strip() or None
+BUILD_SOURCE_CI_REF = os.getenv("TORGHUT_SOURCE_CI_REF", "").strip() or None
+BUILD_MANIFEST_COMMIT = os.getenv("TORGHUT_MANIFEST_COMMIT", "").strip() or None
+BUILD_MANIFEST_IMAGE_DIGEST = (
+    os.getenv("TORGHUT_MANIFEST_IMAGE_DIGEST", "").strip() or BUILD_IMAGE_DIGEST
+)
+BUILD_ARGO_SYNC_REVISION = os.getenv("TORGHUT_ARGO_SYNC_REVISION", "").strip() or None
+BUILD_ARGO_HEALTH = os.getenv("TORGHUT_ARGO_HEALTH", "").strip() or None
 RUNTIME_PROFITABILITY_LOOKBACK_HOURS = 72
 RUNTIME_PROFITABILITY_SCHEMA_VERSION = "torghut.runtime-profitability.v1"
 PROFITABILITY_PROOF_FLOOR_TCA_MAX_AGE_SECONDS = 86_400
@@ -928,6 +938,14 @@ def _evaluate_trading_health_payload(
         empirical_jobs_status=empirical_jobs,
         market_context_status=market_context_status,
     )
+    source_serving_repair_receipt_ledger = _build_source_serving_repair_receipt_payload(
+        source_commit=BUILD_COMMIT,
+        build=build_payload,
+        consumer_evidence_receipt=consumer_evidence_receipt,
+        route_evidence_clearinghouse_packet=route_evidence_clearinghouse_packet,
+        repair_bid_settlement_ledger=repair_bid_settlement_ledger,
+        route_warrant_exchange=route_warrant_exchange,
+    )
     live_mode = settings.trading_mode == "live"
     empirical_jobs_required = (
         live_mode and settings.trading_empirical_jobs_health_required
@@ -1029,6 +1047,7 @@ def _evaluate_trading_health_payload(
             "route_evidence_clearinghouse_packet": route_evidence_clearinghouse_packet,
             "repair_bid_settlement_ledger": repair_bid_settlement_ledger,
             "route_warrant_exchange": route_warrant_exchange,
+            "source_serving_repair_receipt_ledger": source_serving_repair_receipt_ledger,
             "route_reacquisition_book": proof_floor.get("route_reacquisition_book"),
             "route_reacquisition_board": route_reacquisition_board,
             "quant_evidence": quant_evidence,
@@ -2477,6 +2496,14 @@ def trading_status() -> dict[str, object]:
         empirical_jobs_status=empirical_jobs,
         market_context_status=market_context_status,
     )
+    source_serving_repair_receipt_ledger = _build_source_serving_repair_receipt_payload(
+        source_commit=BUILD_COMMIT,
+        build=build_payload,
+        consumer_evidence_receipt=consumer_evidence_receipt,
+        route_evidence_clearinghouse_packet=route_evidence_clearinghouse_packet,
+        repair_bid_settlement_ledger=repair_bid_settlement_ledger,
+        route_warrant_exchange=route_warrant_exchange,
+    )
     return {
         "enabled": settings.trading_enabled,
         "autonomy_enabled": settings.trading_autonomy_enabled,
@@ -2516,6 +2543,7 @@ def trading_status() -> dict[str, object]:
         "route_evidence_clearinghouse_packet": route_evidence_clearinghouse_packet,
         "repair_bid_settlement_ledger": repair_bid_settlement_ledger,
         "route_warrant_exchange": route_warrant_exchange,
+        "source_serving_repair_receipt_ledger": source_serving_repair_receipt_ledger,
         "route_reacquisition_book": proof_floor.get("route_reacquisition_book"),
         "route_reacquisition_board": route_reacquisition_board,
         "quant_evidence": quant_evidence,
@@ -2902,6 +2930,14 @@ def _build_trading_consumer_evidence_payload() -> dict[str, object]:
         empirical_jobs_status=empirical_jobs,
         market_context_status=market_context_status,
     )
+    source_serving_repair_receipt_ledger = _build_source_serving_repair_receipt_payload(
+        source_commit=BUILD_COMMIT,
+        build=build_payload,
+        consumer_evidence_receipt=consumer_evidence_receipt,
+        route_evidence_clearinghouse_packet=route_evidence_clearinghouse_packet,
+        repair_bid_settlement_ledger=repair_bid_settlement_ledger,
+        route_warrant_exchange=route_warrant_exchange,
+    )
     return {
         "schema_version": "torghut.consumer-evidence-status.v1",
         "generated_at": datetime.now(timezone.utc).isoformat(),
@@ -2933,6 +2969,7 @@ def _build_trading_consumer_evidence_payload() -> dict[str, object]:
         "route_evidence_clearinghouse_packet": route_evidence_clearinghouse_packet,
         "repair_bid_settlement_ledger": repair_bid_settlement_ledger,
         "route_warrant_exchange": route_warrant_exchange,
+        "source_serving_repair_receipt_ledger": source_serving_repair_receipt_ledger,
     }
 
 
@@ -5147,6 +5184,40 @@ def _build_route_warrant_exchange_payload(*, torghut_revision: str | None, sourc
         tca_summary=tca_summary,
         empirical_jobs_status=empirical_jobs_status,
         market_context_status=market_context_status,
+    )
+
+
+def _build_source_serving_repair_receipt_payload(
+    *,
+    source_commit: str | None,
+    build: Mapping[str, Any],
+    consumer_evidence_receipt: Mapping[str, Any],
+    route_evidence_clearinghouse_packet: Mapping[str, Any],
+    repair_bid_settlement_ledger: Mapping[str, Any],
+    route_warrant_exchange: Mapping[str, Any],
+) -> dict[str, object]:
+    return build_source_serving_repair_receipt_ledger(
+        account_label=settings.trading_account_label,
+        window=settings.trading_jangar_quant_window,
+        source_commit=source_commit,
+        source_ci_ref=BUILD_SOURCE_CI_REF,
+        manifest_commit=BUILD_MANIFEST_COMMIT,
+        manifest_image_digest=BUILD_MANIFEST_IMAGE_DIGEST,
+        argo_sync_revision=BUILD_ARGO_SYNC_REVISION,
+        argo_health=BUILD_ARGO_HEALTH,
+        build=build,
+        observed_contract_payloads={
+            "consumer_evidence_status": {
+                "schema_version": "torghut.consumer-evidence-status.v1",
+            },
+            "consumer_evidence_receipt": consumer_evidence_receipt,
+            "route_evidence_clearinghouse_packet": route_evidence_clearinghouse_packet,
+            "repair_bid_settlement_ledger": repair_bid_settlement_ledger,
+            "route_warrant_exchange": route_warrant_exchange,
+        },
+        route_warrant_exchange=route_warrant_exchange,
+        repair_bid_settlement_ledger=repair_bid_settlement_ledger,
+        route_evidence_clearinghouse_packet=route_evidence_clearinghouse_packet,
     )
 
 

--- a/services/torghut/app/trading/source_serving_repair_receipt.py
+++ b/services/torghut/app/trading/source_serving_repair_receipt.py
@@ -1,0 +1,389 @@
+"""Source-serving proof ledger for Torghut repair receipt promotion."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from datetime import datetime, timedelta, timezone
+from hashlib import sha256
+import json
+from typing import Any, cast
+
+
+SOURCE_SERVING_REPAIR_RECEIPT_LEDGER_SCHEMA_VERSION = (
+    "torghut.source-serving-repair-receipt-ledger.v1"
+)
+
+_FRESHNESS_SECONDS = 60
+_ZERO_NOTIONAL = "0"
+_DEFAULT_REQUIRED_CONTRACTS = {
+    "consumer_evidence_status": "torghut.consumer-evidence-status.v1",
+    "consumer_evidence_receipt": "torghut.consumer-evidence-receipt.v1",
+    "route_evidence_clearinghouse_packet": "torghut.route-evidence-clearinghouse-packet.v1",
+    "repair_bid_settlement_ledger": "torghut.repair-bid-settlement-ledger.v1",
+    "route_warrant_exchange": "torghut.route-warrant-exchange.v1",
+    "source_serving_repair_receipt_ledger": SOURCE_SERVING_REPAIR_RECEIPT_LEDGER_SCHEMA_VERSION,
+}
+_VALUE_GATE_BY_REASON = {
+    "serving_build_commit_mismatch": "capital_gate_safety",
+    "serving_build_commit_missing": "capital_gate_safety",
+    "source_commit_missing": "capital_gate_safety",
+    "manifest_image_digest_missing": "capital_gate_safety",
+    "serving_image_digest_missing": "capital_gate_safety",
+    "manifest_serving_image_digest_mismatch": "capital_gate_safety",
+    "required_contract_missing": "zero_notional_or_stale_evidence_rate",
+    "contract_schema_mismatch": "zero_notional_or_stale_evidence_rate",
+    "route_warrant_repair_only": "routeable_candidate_count",
+}
+
+
+def _mapping(value: object) -> Mapping[str, Any]:
+    return cast(Mapping[str, Any], value) if isinstance(value, Mapping) else {}
+
+
+def _sequence(value: object) -> Sequence[object]:
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return cast(Sequence[object], value)
+    return ()
+
+
+def _text(value: object, default: str = "") -> str:
+    if value is None:
+        return default
+    text = str(value).strip()
+    return text or default
+
+
+def _unique(values: Sequence[str]) -> list[str]:
+    result: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        normalized = value.strip()
+        if normalized and normalized not in seen:
+            result.append(normalized)
+            seen.add(normalized)
+    return result
+
+
+def _strings(value: object) -> list[str]:
+    return _unique([_text(item) for item in _sequence(value)])
+
+
+def _stable_ref(prefix: str, payload: Mapping[str, object]) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return f"{prefix}:{sha256(encoded.encode()).hexdigest()[:20]}"
+
+
+def _required_contracts(
+    required_contracts: Mapping[str, object] | None,
+) -> dict[str, str]:
+    contracts = dict(_DEFAULT_REQUIRED_CONTRACTS)
+    for contract_name, schema in _mapping(required_contracts).items():
+        normalized_name = _text(contract_name)
+        normalized_schema = _text(schema)
+        if normalized_name and normalized_schema:
+            contracts[normalized_name] = normalized_schema
+    return contracts
+
+
+def _observed_contracts(
+    *,
+    observed_contract_payloads: Mapping[str, object],
+    include_self: bool,
+) -> dict[str, str]:
+    observed: dict[str, str] = {}
+    for contract_name, payload in observed_contract_payloads.items():
+        normalized_name = _text(contract_name)
+        schema = _text(_mapping(payload).get("schema_version"))
+        if normalized_name and schema:
+            observed[normalized_name] = schema
+    if include_self:
+        observed["source_serving_repair_receipt_ledger"] = (
+            SOURCE_SERVING_REPAIR_RECEIPT_LEDGER_SCHEMA_VERSION
+        )
+    return observed
+
+
+def _source_serving_state(
+    *,
+    source_commit: str,
+    serving_build_commit: str,
+    manifest_image_digest: str,
+    serving_image_digest: str,
+    missing_contracts: Sequence[str],
+    contract_schema_mismatches: Sequence[Mapping[str, object]],
+) -> tuple[str, list[str]]:
+    reasons: list[str] = []
+    if not source_commit or source_commit == "unknown":
+        reasons.append("source_commit_missing")
+    if not serving_build_commit or serving_build_commit == "unknown":
+        reasons.append("serving_build_commit_missing")
+    if source_commit and serving_build_commit and source_commit != serving_build_commit:
+        reasons.append("serving_build_commit_mismatch")
+    if not manifest_image_digest:
+        reasons.append("manifest_image_digest_missing")
+    if not serving_image_digest:
+        reasons.append("serving_image_digest_missing")
+    if (
+        manifest_image_digest
+        and serving_image_digest
+        and manifest_image_digest != serving_image_digest
+    ):
+        reasons.append("manifest_serving_image_digest_mismatch")
+    if missing_contracts:
+        reasons.append("required_contract_missing")
+    if contract_schema_mismatches:
+        reasons.append("contract_schema_mismatch")
+
+    reason_set = set(reasons)
+    if (
+        "required_contract_missing" in reason_set
+        or "contract_schema_mismatch" in reason_set
+    ):
+        return "contract_missing", _unique(reasons)
+    if (
+        "manifest_image_digest_missing" in reason_set
+        or "serving_image_digest_missing" in reason_set
+        or "manifest_serving_image_digest_mismatch" in reason_set
+    ):
+        return "digest_unknown", _unique(reasons)
+    if "serving_build_commit_mismatch" in reason_set:
+        return "source_ahead", _unique(reasons)
+    if reason_set:
+        return "unknown", _unique(reasons)
+    return "converged", []
+
+
+def _route_warrant_reasons(route_warrant_exchange: Mapping[str, Any]) -> list[str]:
+    warrant_state = _text(route_warrant_exchange.get("warrant_state"), "missing")
+    if warrant_state in {
+        "paper_candidate",
+        "live_candidate",
+        "live_micro_candidate",
+        "live_scale_candidate",
+    }:
+        return []
+    return [f"route_warrant_{warrant_state}"]
+
+
+def _value_gate_impacts(reason_codes: Sequence[str]) -> list[dict[str, object]]:
+    impacts: list[dict[str, object]] = []
+    for reason in reason_codes:
+        normalized = reason.split(":", 1)[0]
+        gate = _VALUE_GATE_BY_REASON.get(
+            normalized, "zero_notional_or_stale_evidence_rate"
+        )
+        impacts.append(
+            {
+                "value_gate": gate,
+                "reason_code": reason,
+                "capital_effect": "max_notional_held_at_zero",
+            }
+        )
+    return impacts
+
+
+def _repair_receipt_bindings(
+    *,
+    repair_receipts: Sequence[Mapping[str, object]],
+    ledger_ref: str,
+    serving_build_commit: str,
+    serving_image_digest: str,
+    source_serving_state: str,
+) -> list[dict[str, object]]:
+    bindings: list[dict[str, object]] = []
+    for receipt in repair_receipts:
+        receipt_id = _text(receipt.get("receipt_id"))
+        if not receipt_id:
+            continue
+        bindings.append(
+            {
+                "receipt_id": receipt_id,
+                "receipt_schema": _text(receipt.get("schema_version"), "unknown"),
+                "generated_at": receipt.get("generated_at"),
+                "target_value_gate": receipt.get("value_gate"),
+                "target_dependency": receipt.get("zero_notional_action")
+                or receipt.get("target_dependency"),
+                "source_serving_ledger_ref": ledger_ref,
+                "serving_build_commit": serving_build_commit or None,
+                "serving_image_digest": serving_image_digest or None,
+                "required_input_contracts": _strings(
+                    receipt.get("required_input_contracts")
+                ),
+                "produced_output_contracts": _strings(
+                    receipt.get("produced_output_contracts")
+                ),
+                "stale_reasons_retired": _strings(receipt.get("stale_reasons_retired")),
+                "stale_reasons_remaining": _strings(receipt.get("blocked_reasons")),
+                "source_serving_state": source_serving_state,
+                "max_notional": _ZERO_NOTIONAL,
+                "routeable_candidate_delta": 0,
+                "rollback_target": receipt.get("rollback_path")
+                or "leave stale reason active and keep repair packet queued at max_notional=0",
+            }
+        )
+    return bindings
+
+
+def build_source_serving_repair_receipt_ledger(
+    *,
+    account_label: str,
+    window: str,
+    source_commit: str | None,
+    source_ci_ref: str | None = None,
+    manifest_commit: str | None = None,
+    manifest_image_digest: str | None = None,
+    argo_sync_revision: str | None = None,
+    argo_health: str | None = None,
+    build: Mapping[str, Any] | None = None,
+    route_ref: str = "/trading/consumer-evidence",
+    required_contracts: Mapping[str, object] | None = None,
+    observed_contract_payloads: Mapping[str, object] | None = None,
+    route_warrant_exchange: Mapping[str, Any] | None = None,
+    repair_bid_settlement_ledger: Mapping[str, Any] | None = None,
+    route_evidence_clearinghouse_packet: Mapping[str, Any] | None = None,
+    repair_receipts: Sequence[Mapping[str, object]] | None = None,
+    now: datetime | None = None,
+) -> dict[str, object]:
+    """Build a source-serving proof ledger without widening notional authority."""
+
+    generated_at = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    build_payload = _mapping(build)
+    warrant = _mapping(route_warrant_exchange)
+    repair_bid_settlement = _mapping(repair_bid_settlement_ledger)
+    clearinghouse_packet = _mapping(route_evidence_clearinghouse_packet)
+    required = _required_contracts(required_contracts)
+    observed = _observed_contracts(
+        observed_contract_payloads=_mapping(observed_contract_payloads),
+        include_self=True,
+    )
+    missing_contracts = [name for name in required if name not in observed]
+    schema_mismatches = [
+        {
+            "contract": contract,
+            "expected_schema": expected_schema,
+            "observed_schema": observed[contract],
+        }
+        for contract, expected_schema in required.items()
+        if contract in observed and observed[contract] != expected_schema
+    ]
+    source_ref = _text(source_commit)
+    serving_build_commit = _text(build_payload.get("commit"))
+    serving_image_digest = _text(build_payload.get("image_digest"))
+    manifest_digest = _text(
+        manifest_image_digest or build_payload.get("manifest_image_digest")
+    )
+    state, proof_reasons = _source_serving_state(
+        source_commit=source_ref,
+        serving_build_commit=serving_build_commit,
+        manifest_image_digest=manifest_digest,
+        serving_image_digest=serving_image_digest,
+        missing_contracts=missing_contracts,
+        contract_schema_mismatches=schema_mismatches,
+    )
+    reason_codes = _unique(
+        [
+            *proof_reasons,
+            *[f"missing_contract:{contract}" for contract in missing_contracts],
+            *[
+                f"contract_schema_mismatch:{mismatch['contract']}"
+                for mismatch in schema_mismatches
+            ],
+            *_route_warrant_reasons(warrant),
+        ]
+    )
+    ledger_payload = {
+        "account_label": account_label,
+        "window": window,
+        "source_commit": source_ref,
+        "serving_build_commit": serving_build_commit,
+        "serving_image_digest": serving_image_digest,
+        "route_ref": route_ref,
+        "source_serving_state": state,
+        "missing_contracts": missing_contracts,
+        "contract_schema_mismatches": schema_mismatches,
+        "route_warrant_ref": warrant.get("warrant_id"),
+    }
+    ledger_id = _stable_ref("source-serving-repair-receipt-ledger", ledger_payload)
+    bindings = _repair_receipt_bindings(
+        repair_receipts=list(repair_receipts or ()),
+        ledger_ref=ledger_id,
+        serving_build_commit=serving_build_commit,
+        serving_image_digest=serving_image_digest,
+        source_serving_state=state,
+    )
+    route_warrant_state = _text(warrant.get("warrant_state"), "missing")
+    max_notional = _text(warrant.get("max_notional"), _ZERO_NOTIONAL)
+    capital_decision = "observe"
+    if state != "converged" or route_warrant_state not in {
+        "paper_candidate",
+        "live_candidate",
+        "live_micro_candidate",
+        "live_scale_candidate",
+    }:
+        capital_decision = "repair_only"
+        max_notional = _ZERO_NOTIONAL
+
+    return {
+        "schema_version": SOURCE_SERVING_REPAIR_RECEIPT_LEDGER_SCHEMA_VERSION,
+        "ledger_id": ledger_id,
+        "generated_at": generated_at.isoformat(),
+        "fresh_until": (
+            generated_at + timedelta(seconds=_FRESHNESS_SECONDS)
+        ).isoformat(),
+        "account": account_label,
+        "window": window,
+        "source_commit": source_ref or None,
+        "source_ci_ref": source_ci_ref,
+        "manifest_commit": _text(manifest_commit) or None,
+        "manifest_image_digest": manifest_digest or None,
+        "argo_sync_revision": _text(argo_sync_revision) or None,
+        "argo_health": _text(argo_health) or None,
+        "serving_revision": build_payload.get("active_revision"),
+        "serving_build_commit": serving_build_commit or None,
+        "serving_image_digest": serving_image_digest or None,
+        "route_ref": route_ref,
+        "required_contracts": [
+            {"contract": contract, "schema_version": schema_version}
+            for contract, schema_version in required.items()
+        ],
+        "observed_contracts": [
+            {"contract": contract, "schema_version": schema_version}
+            for contract, schema_version in observed.items()
+        ],
+        "missing_contracts": missing_contracts,
+        "contract_schema_mismatches": schema_mismatches,
+        "route_warrant_ref": warrant.get("warrant_id"),
+        "route_warrant_state": route_warrant_state,
+        "repair_bid_settlement_ref": repair_bid_settlement.get("ledger_id"),
+        "route_evidence_clearinghouse_ref": clearinghouse_packet.get("packet_id"),
+        "repair_receipt_refs": [binding["receipt_id"] for binding in bindings],
+        "repair_receipt_source_bindings": bindings,
+        "source_serving_state": state,
+        "capital_decision": capital_decision,
+        "max_notional": max_notional
+        if capital_decision != "repair_only"
+        else _ZERO_NOTIONAL,
+        "reason_codes": reason_codes,
+        "value_gate_impacts": _value_gate_impacts(reason_codes),
+        "summary": {
+            "required_contract_count": len(required),
+            "observed_contract_count": len(observed),
+            "missing_contract_count": len(missing_contracts),
+            "schema_mismatch_count": len(schema_mismatches),
+            "repair_receipt_binding_count": len(bindings),
+            "source_serving_state": state,
+            "capital_decision": capital_decision,
+        },
+        "rollback_target": {
+            "source_serving_ledger_consumption_enabled": False,
+            "capital_state": "zero_notional",
+            "live_submit_enabled": False,
+            "fallback_payload": "torghut.route-warrant-exchange.v1",
+        },
+    }
+
+
+__all__ = [
+    "SOURCE_SERVING_REPAIR_RECEIPT_LEDGER_SCHEMA_VERSION",
+    "build_source_serving_repair_receipt_ledger",
+]

--- a/services/torghut/tests/test_source_serving_repair_receipt.py
+++ b/services/torghut/tests/test_source_serving_repair_receipt.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from app.trading.source_serving_repair_receipt import (
+    SOURCE_SERVING_REPAIR_RECEIPT_LEDGER_SCHEMA_VERSION,
+    build_source_serving_repair_receipt_ledger,
+)
+
+
+NOW = datetime(2026, 5, 13, 8, 20, tzinfo=timezone.utc)
+DIGEST = "sha256:" + "a" * 64
+
+
+def _observed_contracts() -> dict[str, object]:
+    return {
+        "consumer_evidence_status": {
+            "schema_version": "torghut.consumer-evidence-status.v1",
+        },
+        "consumer_evidence_receipt": {
+            "schema_version": "torghut.consumer-evidence-receipt.v1",
+            "receipt_id": "torghut-consumer-evidence:test",
+        },
+        "route_evidence_clearinghouse_packet": {
+            "schema_version": "torghut.route-evidence-clearinghouse-packet.v1",
+            "packet_id": "route-evidence-clearinghouse:test",
+        },
+        "repair_bid_settlement_ledger": {
+            "schema_version": "torghut.repair-bid-settlement-ledger.v1",
+            "ledger_id": "repair-bid-settlement-ledger:test",
+        },
+        "route_warrant_exchange": {
+            "schema_version": "torghut.route-warrant-exchange.v1",
+            "warrant_id": "route-warrant-exchange:test",
+            "warrant_state": "paper_candidate",
+            "max_notional": "25",
+        },
+    }
+
+
+def _build(
+    *,
+    source_commit: str = "abc123",
+    serving_commit: str = "abc123",
+    serving_image_digest: str | None = DIGEST,
+    manifest_image_digest: str | None = DIGEST,
+    observed_contracts: dict[str, object] | None = None,
+    warrant_state: str = "paper_candidate",
+) -> dict[str, object]:
+    contracts = observed_contracts or _observed_contracts()
+    route_warrant = dict(contracts["route_warrant_exchange"])
+    route_warrant["warrant_state"] = warrant_state
+    repair_bid_settlement = contracts.get("repair_bid_settlement_ledger")
+    clearinghouse_packet = contracts.get("route_evidence_clearinghouse_packet")
+    return build_source_serving_repair_receipt_ledger(
+        account_label="PA3SX7FYNUTF",
+        window="15m",
+        source_commit=source_commit,
+        manifest_image_digest=manifest_image_digest,
+        build={
+            "commit": serving_commit,
+            "image_digest": serving_image_digest,
+            "active_revision": "torghut-00333",
+        },
+        observed_contract_payloads=contracts,
+        route_warrant_exchange=route_warrant,
+        repair_bid_settlement_ledger=repair_bid_settlement
+        if isinstance(repair_bid_settlement, dict)
+        else {},
+        route_evidence_clearinghouse_packet=clearinghouse_packet
+        if isinstance(clearinghouse_packet, dict)
+        else {},
+        now=NOW,
+    )
+
+
+def test_converged_source_serving_proof_preserves_warrant_notional() -> None:
+    ledger = _build()
+
+    assert (
+        ledger["schema_version"] == SOURCE_SERVING_REPAIR_RECEIPT_LEDGER_SCHEMA_VERSION
+    )
+    assert ledger["source_serving_state"] == "converged"
+    assert ledger["capital_decision"] == "observe"
+    assert ledger["max_notional"] == "25"
+    assert ledger["reason_codes"] == []
+    assert ledger["summary"]["missing_contract_count"] == 0
+
+
+def test_serving_build_mismatch_keeps_capital_zero_notional() -> None:
+    ledger = _build(serving_commit="def456")
+
+    assert ledger["source_serving_state"] == "source_ahead"
+    assert ledger["capital_decision"] == "repair_only"
+    assert ledger["max_notional"] == "0"
+    assert "serving_build_commit_mismatch" in ledger["reason_codes"]
+    assert {
+        "value_gate": "capital_gate_safety",
+        "reason_code": "serving_build_commit_mismatch",
+        "capital_effect": "max_notional_held_at_zero",
+    } in ledger["value_gate_impacts"]
+
+
+def test_missing_serving_image_digest_keeps_capital_zero_notional() -> None:
+    ledger = _build(serving_image_digest=None, manifest_image_digest=DIGEST)
+
+    assert ledger["source_serving_state"] == "digest_unknown"
+    assert ledger["capital_decision"] == "repair_only"
+    assert ledger["max_notional"] == "0"
+    assert "serving_image_digest_missing" in ledger["reason_codes"]
+
+
+def test_missing_manifest_image_digest_keeps_capital_zero_notional() -> None:
+    ledger = _build(serving_image_digest=DIGEST, manifest_image_digest=None)
+
+    assert ledger["source_serving_state"] == "digest_unknown"
+    assert ledger["capital_decision"] == "repair_only"
+    assert ledger["max_notional"] == "0"
+    assert "manifest_image_digest_missing" in ledger["reason_codes"]
+
+
+def test_missing_required_contract_keeps_capital_zero_notional() -> None:
+    contracts = _observed_contracts()
+    contracts.pop("repair_bid_settlement_ledger")
+    ledger = _build(observed_contracts=contracts)
+
+    assert ledger["source_serving_state"] == "contract_missing"
+    assert ledger["capital_decision"] == "repair_only"
+    assert "repair_bid_settlement_ledger" in ledger["missing_contracts"]
+    assert "missing_contract:repair_bid_settlement_ledger" in ledger["reason_codes"]
+
+
+def test_schema_mismatch_keeps_capital_zero_notional() -> None:
+    contracts = _observed_contracts()
+    contracts["route_warrant_exchange"] = {
+        **dict(contracts["route_warrant_exchange"]),
+        "schema_version": "torghut.route-warrant-exchange.v0",
+    }
+    ledger = _build(observed_contracts=contracts)
+
+    assert ledger["source_serving_state"] == "contract_missing"
+    assert ledger["capital_decision"] == "repair_only"
+    assert ledger["contract_schema_mismatches"] == [
+        {
+            "contract": "route_warrant_exchange",
+            "expected_schema": "torghut.route-warrant-exchange.v1",
+            "observed_schema": "torghut.route-warrant-exchange.v0",
+        }
+    ]
+    assert "contract_schema_mismatch:route_warrant_exchange" in ledger["reason_codes"]
+
+
+def test_repair_only_warrant_keeps_source_serving_ledger_repair_only() -> None:
+    ledger = _build(warrant_state="repair_only")
+
+    assert ledger["source_serving_state"] == "converged"
+    assert ledger["capital_decision"] == "repair_only"
+    assert ledger["max_notional"] == "0"
+    assert "route_warrant_repair_only" in ledger["reason_codes"]

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -1096,6 +1096,26 @@ class TestTradingApi(TestCase):
         )
         self.assertEqual(warrant["accepted_routeable_candidate_count"], 0)
         self.assertEqual(warrant["max_notional"], "0")
+        source_serving = payload["source_serving_repair_receipt_ledger"]
+        self.assertEqual(
+            source_serving["schema_version"],
+            "torghut.source-serving-repair-receipt-ledger.v1",
+        )
+        self.assertEqual(source_serving["max_notional"], "0")
+        self.assertIn(
+            source_serving["source_serving_state"],
+            {
+                "converged",
+                "digest_unknown",
+                "contract_missing",
+                "source_ahead",
+                "unknown",
+            },
+        )
+        self.assertEqual(
+            source_serving["route_warrant_ref"],
+            warrant["warrant_id"],
+        )
         frontier = payload["profit_freshness_frontier"]
         self.assertEqual(
             frontier["schema_version"],
@@ -1596,6 +1616,25 @@ class TestTradingApi(TestCase):
         self.assertEqual(
             health_warrant["schema_version"],
             status_warrant["schema_version"],
+        )
+        status_source_serving = status_response.json()[
+            "source_serving_repair_receipt_ledger"
+        ]
+        health_source_serving = health_response.json()[
+            "source_serving_repair_receipt_ledger"
+        ]
+        self.assertEqual(
+            status_source_serving["schema_version"],
+            "torghut.source-serving-repair-receipt-ledger.v1",
+        )
+        self.assertEqual(status_source_serving["max_notional"], "0")
+        self.assertEqual(
+            status_source_serving["route_warrant_ref"],
+            status_warrant["warrant_id"],
+        )
+        self.assertEqual(
+            health_source_serving["schema_version"],
+            status_source_serving["schema_version"],
         )
         status_frontier = status_response.json()["profit_freshness_frontier"]
         health_frontier = health_response.json()["profit_freshness_frontier"]


### PR DESCRIPTION
## Summary

- Implements doc 191 engineer milestone 1 in observe mode: Torghut now publishes `torghut.source-serving-repair-receipt-ledger.v1` on `/trading/status`, `/trading/health`, `/readyz`, and `/trading/consumer-evidence`.
- Adds fail-closed source-serving proof checks for source commit, serving build commit, serving image digest, manifest image digest, required contract schemas, repair-bid settlement, route-evidence clearinghouse, and route warrant state. Missing or mismatched proof keeps `max_notional=0` and classifies the ledger as repair-only evidence.
- Updates the Torghut manifest updater and live/sim Knative service manifests to carry `TORGHUT_IMAGE_DIGEST`. After rebasing on current main, the manifests keep promoted image `sha256:2c3f6bd7af6058ccad135a26740bdedb6cd3b9c9222af1d2dd7ccb6d6cb3bd51`, build commit `d28fd2509af33fd8b751f8222ca41dd172384c00`, and expose that same digest to runtime evidence.
- Updates Torghut docs and source-of-truth guidance with design provenance, implementation status, risk, and rollback behavior.

## Related Issues

None. Runtime requirement source is the torghut-quant swarm objective payload plus `docs/torghut/design-system/v6/191-torghut-source-serving-proof-and-repair-receipt-promotion-2026-05-13.md`; companion Jangar contract is `docs/agents/designs/187-jangar-main-source-ci-retention-and-source-serving-verdicts-2026-05-13.md`.

## Testing

- PASS: NATS context soak read before action; latest shared state said main advanced after the previous green run and `codex/swarm-torghut-quant` needed refresh.
- PASS: `bun test packages/scripts/src/torghut/__tests__/update-manifests.test.ts` (5 passed).
- PASS: `bunx oxfmt --check packages/scripts/src/torghut/update-manifests.ts packages/scripts/src/torghut/__tests__/update-manifests.test.ts docs/torghut/README.md docs/torghut/design-system/current-source-of-truth-and-priority-guide-2026-03-09.md docs/torghut/design-system/v6/191-torghut-source-serving-proof-and-repair-receipt-promotion-2026-05-13.md services/torghut/README.md`.
- PASS: `git diff --check origin/main...HEAD`.
- PASS: `/root/.local/bin/uv sync --frozen --extra dev`.
- PASS: `/root/.local/bin/uv run --frozen ruff format --check app/trading/source_serving_repair_receipt.py tests/test_source_serving_repair_receipt.py app/main.py tests/test_trading_api.py`.
- PASS: `/root/.local/bin/uv run --frozen ruff check app/trading/source_serving_repair_receipt.py tests/test_source_serving_repair_receipt.py app/main.py tests/test_trading_api.py`.
- PASS: `/root/.local/bin/uv run --frozen pytest tests/test_source_serving_repair_receipt.py tests/test_repair_bid_settlement.py tests/test_zero_notional_repair_executor.py tests/test_consumer_evidence.py tests/test_route_warrant_exchange.py tests/test_trading_api.py` (122 passed, 1 existing warning).
- PASS: `/root/.local/bin/uv run --frozen pyright --project pyrightconfig.json`.
- PASS: `/root/.local/bin/uv run --frozen pyright --project pyrightconfig.alpha.json`.
- PASS: `/root/.local/bin/uv run --frozen pyright --project pyrightconfig.scripts.json`.
- PASS: `PATH="$PATH:/root/go/bin" bun run lint:argocd` (812 resources, 0 invalid, 0 errors).
- PASS: GitHub CI on head `da26b7b9c2393e702780b23bbf88e4bd57b49772`: Semantic PR, Semantic Commits, argo-lint, kubeconform, packages-scripts, repo changed-file check, Torghut changed-file plan, Pyright, Bytecode + lint + migration guard, Pytest shards 0-3, Bytecode + pytest + coverage, and Quality signals.

## Screenshots (if applicable)

N/A.

## Breaking Changes

None. This is additive observe-mode evidence. Risk: if the promoted runtime lacks `TORGHUT_IMAGE_DIGEST`, reports a different build commit, omits a required contract canary, or returns a schema mismatch, the new ledger reports repair-only and holds `max_notional=0`; that is intentional capital safety behavior. Rollback path: stop consuming `source_serving_repair_receipt_ledger` and keep `torghut.route-warrant-exchange.v1` as the capital gate, or revert this PR while leaving live submission disabled for malformed source-serving proof.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
