### PR TITLE
fix(jangar): request storage for agent runners

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -92,6 +92,14 @@ controller:
   defaultWorkload:
     nodeSelector:
       kubernetes.io/arch: arm64
+    resources:
+      requests:
+        cpu: "1"
+        memory: 2Gi
+        ephemeral-storage: 8Gi
+      limits:
+        memory: 8Gi
+        ephemeral-storage: 16Gi
   namespaces:
     - agents
   concurrency:

--- a/charts/agents/templates/deployment-controllers.yaml
+++ b/charts/agents/templates/deployment-controllers.yaml
@@ -243,6 +243,10 @@ spec:
             - name: JANGAR_AGENT_RUNNER_POD_SECURITY_CONTEXT
               value: {{ .Values.controller.defaultWorkload.podSecurityContext | toJson | quote }}
             {{- end }}
+            {{- if and .Values.controller.defaultWorkload.resources (gt (len .Values.controller.defaultWorkload.resources) 0) }}
+            - name: JANGAR_AGENT_RUNNER_RESOURCES
+              value: {{ .Values.controller.defaultWorkload.resources | toJson | quote }}
+            {{- end }}
             {{- if and $workloadImagePullSecrets (gt (len $workloadImagePullSecrets) 0) }}
             - name: JANGAR_AGENT_RUNNER_IMAGE_PULL_SECRETS
               value: {{ $workloadImagePullSecrets | toJson | quote }}

--- a/charts/agents/templates/deployment.yaml
+++ b/charts/agents/templates/deployment.yaml
@@ -228,6 +228,10 @@ spec:
             - name: JANGAR_AGENT_RUNNER_POD_SECURITY_CONTEXT
               value: {{ .Values.controller.defaultWorkload.podSecurityContext | toJson | quote }}
             {{- end }}
+            {{- if and .Values.controller.defaultWorkload.resources (gt (len .Values.controller.defaultWorkload.resources) 0) }}
+            - name: JANGAR_AGENT_RUNNER_RESOURCES
+              value: {{ .Values.controller.defaultWorkload.resources | toJson | quote }}
+            {{- end }}
             {{- if and $workloadImagePullSecrets (gt (len $workloadImagePullSecrets) 0) }}
             - name: JANGAR_AGENT_RUNNER_IMAGE_PULL_SECRETS
               value: {{ $workloadImagePullSecrets | toJson | quote }}

--- a/charts/agents/values.schema.json
+++ b/charts/agents/values.schema.json
@@ -901,6 +901,14 @@
             "affinity": { "type": "object" },
             "topologySpreadConstraints": { "type": "array", "items": { "type": "object" } },
             "podSecurityContext": { "type": "object" },
+            "resources": {
+              "type": "object",
+              "properties": {
+                "requests": { "type": "object", "additionalProperties": { "type": "string" } },
+                "limits": { "type": "object", "additionalProperties": { "type": "string" } }
+              },
+              "additionalProperties": false
+            },
             "imagePullSecrets": { "type": "array", "items": { "type": "string" } },
             "priorityClassName": { "type": "string" },
             "schedulerName": { "type": "string" }

--- a/charts/agents/values.yaml
+++ b/charts/agents/values.yaml
@@ -343,6 +343,7 @@ controller:
     affinity: {}
     topologySpreadConstraints: []
     podSecurityContext: {}
+    resources: {}
     imagePullSecrets: []
     priorityClassName: ''
     schedulerName: ''

--- a/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
+++ b/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
@@ -215,6 +215,21 @@ const objectAt = (value: unknown, key: string) =>
   value && typeof value === 'object' ? ((value as Record<string, unknown>)[key] as unknown) : undefined
 
 describe('scheduled AgentRun templates', () => {
+  it('configures default runner resource requests for swarm jobs', () => {
+    const values = readYamlObjects('argocd/applications/agents/values.yaml')[0]
+    const controller = objectAt(values, 'controller')
+    const defaultWorkload = objectAt(controller, 'defaultWorkload')
+    const resources = objectAt(defaultWorkload, 'resources')
+    const requests = objectAt(resources, 'requests')
+    const limits = objectAt(resources, 'limits')
+
+    expect(objectAt(requests, 'cpu')).toBe('1')
+    expect(objectAt(requests, 'memory')).toBe('2Gi')
+    expect(objectAt(requests, 'ephemeral-storage')).toBe('8Gi')
+    expect(objectAt(limits, 'memory')).toBe('8Gi')
+    expect(objectAt(limits, 'ephemeral-storage')).toBe('16Gi')
+  })
+
   it('disable retention so schedules can always resolve their template targets', () => {
     const manifestPaths = [
       'argocd/applications/agents/swarm-agentrun-templates.yaml',

--- a/services/jangar/src/server/__tests__/agents-controller.test.ts
+++ b/services/jangar/src/server/__tests__/agents-controller.test.ts
@@ -1365,6 +1365,83 @@ describe('agents controller reconcileAgentRun', () => {
     expect(findCondition(status, 'Accepted')?.status).toBe('True')
   })
 
+  it('applies configured runner resource defaults when an AgentRun omits workload resources', async () => {
+    const previousResources = process.env.JANGAR_AGENT_RUNNER_RESOURCES
+    process.env.JANGAR_AGENT_RUNNER_RESOURCES = JSON.stringify({
+      requests: {
+        cpu: '1',
+        memory: '2Gi',
+        'ephemeral-storage': '8Gi',
+      },
+      limits: {
+        memory: '8Gi',
+        'ephemeral-storage': '16Gi',
+      },
+    })
+
+    try {
+      const apply = vi.fn(async (resource: Record<string, unknown>) => {
+        const metadata = (resource.metadata ?? {}) as Record<string, unknown>
+        const uid = metadata.uid ?? `uid-${String(resource.kind ?? 'resource').toLowerCase()}`
+        return { ...resource, metadata: { ...metadata, uid } }
+      })
+      const kube = buildKube({
+        apply,
+        get: vi.fn(async (resource: string) => {
+          if (resource === RESOURCE_MAP.Agent) {
+            return {
+              metadata: { name: 'agent-1' },
+              spec: { providerRef: { name: 'provider-1' }, defaults: { systemPrompt: 'default-agent-prompt' } },
+            }
+          }
+          if (resource === RESOURCE_MAP.AgentProvider) {
+            return { metadata: { name: 'provider-1' }, spec: { binary: '/usr/local/bin/agent-runner' } }
+          }
+          if (resource === RESOURCE_MAP.ImplementationSpec) {
+            return { metadata: { name: 'impl-1' }, spec: { text: 'demo' } }
+          }
+          return null
+        }),
+      })
+
+      await __test.reconcileAgentRun(
+        kube as never,
+        buildAgentRun(),
+        'agents',
+        [],
+        [],
+        defaultConcurrency,
+        buildInFlight(),
+        0,
+      )
+
+      const appliedResources = apply.mock.calls.map((call) => call[0]) as Record<string, unknown>[]
+      const job = appliedResources.find((resource) => resource.kind === 'Job')
+      const jobSpec = (job?.spec ?? {}) as Record<string, unknown>
+      const template = (jobSpec.template ?? {}) as Record<string, unknown>
+      const podSpec = (template.spec ?? {}) as Record<string, unknown>
+      const containers = (podSpec.containers ?? []) as Record<string, unknown>[]
+
+      expect(containers[0]?.resources).toEqual({
+        requests: {
+          cpu: '1',
+          memory: '2Gi',
+          'ephemeral-storage': '8Gi',
+        },
+        limits: {
+          memory: '8Gi',
+          'ephemeral-storage': '16Gi',
+        },
+      })
+    } finally {
+      if (previousResources === undefined) {
+        delete process.env.JANGAR_AGENT_RUNNER_RESOURCES
+      } else {
+        process.env.JANGAR_AGENT_RUNNER_RESOURCES = previousResources
+      }
+    }
+  })
+
   it('allows immutable spec mutations before Accepted', async () => {
     const kube = buildKube({
       get: vi.fn(async (resource: string) => {

--- a/services/jangar/src/server/agents-controller/job-runtime.ts
+++ b/services/jangar/src/server/agents-controller/job-runtime.ts
@@ -111,13 +111,36 @@ export const resolveRunnerServiceAccount = (runtimeConfig: Record<string, unknow
   asString(runtimeConfig.serviceAccountName) ??
   resolveAgentRunnerDefaultsConfig(process.env).serviceAccount
 
+const normalizeResourceQuantityMap = (value: unknown) => {
+  const resourceMap = asRecord(value)
+  if (!resourceMap) return {}
+  return Object.fromEntries(
+    Object.entries(resourceMap)
+      .map(([key, quantity]) => {
+        const normalizedKey = key.trim()
+        const normalizedQuantity = asString(quantity)?.trim()
+        return normalizedKey && normalizedQuantity ? [normalizedKey, normalizedQuantity] : null
+      })
+      .filter((entry): entry is [string, string] => entry !== null),
+  )
+}
+
 const buildJobResources = (workload: Record<string, unknown>) => {
+  const defaultResources = resolveAgentRunnerDefaultsConfig(process.env).resources ?? {}
   const resources = asRecord(workload.resources) ?? {}
-  const requests = asRecord(resources.requests) ?? {}
-  const limits = asRecord(resources.limits) ?? {}
+  const workloadRequests = asRecord(resources.requests) ?? {}
+  const workloadLimits = asRecord(resources.limits) ?? {}
+  const requests = {
+    ...normalizeResourceQuantityMap(readNested(defaultResources, ['requests'])),
+    ...normalizeResourceQuantityMap(workloadRequests),
+  }
+  const limits = {
+    ...normalizeResourceQuantityMap(readNested(defaultResources, ['limits'])),
+    ...normalizeResourceQuantityMap(workloadLimits),
+  }
   return {
-    requests,
-    limits,
+    ...(Object.keys(requests).length > 0 ? { requests } : {}),
+    ...(Object.keys(limits).length > 0 ? { limits } : {}),
   }
 }
 

--- a/services/jangar/src/server/agents-controller/runtime-config.ts
+++ b/services/jangar/src/server/agents-controller/runtime-config.ts
@@ -1,4 +1,4 @@
-import { asRecord, asString } from '~/server/primitives-http'
+import { asRecord } from '~/server/primitives-http'
 
 type EnvSource = Record<string, string | undefined>
 
@@ -77,6 +77,7 @@ export type AgentRunnerDefaultsConfig = {
   affinity: Record<string, unknown> | null
   podSecurityContext: Record<string, unknown> | null
   imagePullSecrets: unknown[] | null
+  resources: Record<string, unknown> | null
   defaultRunnerImage: string | null
 }
 
@@ -139,6 +140,7 @@ export const resolveAgentRunnerDefaultsConfig = (env: EnvSource = process.env): 
   const tolerations = parseJson(env.JANGAR_AGENT_RUNNER_TOLERATIONS)
   const topologySpreadConstraints = parseJson(env.JANGAR_AGENT_RUNNER_TOPOLOGY_SPREAD_CONSTRAINTS)
   const imagePullSecrets = parseJson(env.JANGAR_AGENT_RUNNER_IMAGE_PULL_SECRETS)
+  const resources = asRecord(parseJson(env.JANGAR_AGENT_RUNNER_RESOURCES))
 
   return {
     serviceAccount: normalizeNonEmpty(env.JANGAR_AGENT_RUNNER_SERVICE_ACCOUNT),
@@ -164,6 +166,7 @@ export const resolveAgentRunnerDefaultsConfig = (env: EnvSource = process.env): 
     affinity,
     podSecurityContext,
     imagePullSecrets: Array.isArray(imagePullSecrets) ? imagePullSecrets : null,
+    resources,
     defaultRunnerImage:
       normalizeNonEmpty(env.JANGAR_AGENT_RUNNER_IMAGE) ?? normalizeNonEmpty(env.JANGAR_AGENT_IMAGE) ?? null,
   }


### PR DESCRIPTION
## Summary

- Adds configurable default resources for Jangar AgentRun runner jobs through `JANGAR_AGENT_RUNNER_RESOURCES`.
- Wires the agents chart and GitOps values so production swarm jobs request CPU, memory, and ephemeral storage before they start.
- Preserves per-AgentRun workload resource overrides while applying safe defaults when a run omits resources.
- Adds controller and GitOps regression coverage for default runner resource projection.

## Related Issues

None

## Testing

- `bunx vitest run --config vitest.config.ts src/server/__tests__/agents-controller.test.ts -t "runner resource defaults"` from `services/jangar`
- `bunx vitest run --config vitest.config.ts src/server/__tests__/agents-controller.test.ts` from `services/jangar`
- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts -t "default runner resource"`
- `bun run --filter @proompteng/jangar pretest`
- `bun run --cwd services/jangar tsc`
- `bun run --cwd services/jangar lint`
- `bun run --cwd services/jangar lint:oxlint`
- `scripts/agents/validate-agents.sh`
- `mise exec helm@3 -- helm template agents charts/agents --namespace agents --values argocd/applications/agents/values.yaml | rg -n "JANGAR_AGENT_RUNNER_RESOURCES|ephemeral-storage"`
- `bunx oxfmt --check services/jangar/src/server/agents-controller/runtime-config.ts services/jangar/src/server/agents-controller/job-runtime.ts services/jangar/src/server/__tests__/agents-controller.test.ts charts/agents/templates/deployment.yaml charts/agents/templates/deployment-controllers.yaml charts/agents/values.yaml charts/agents/values.schema.json argocd/applications/agents/values.yaml packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `git diff --check origin/main...HEAD`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
