### PR TITLE
chore(jangar): promote image 3394723b

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 45710e0b
-  digest: sha256:1348bdb0571ee61c3c3005186261a422f4bc754bc19380f842577a9e694950c8
+  tag: 3394723b
+  digest: sha256:bb2e03007287d1f2b78b05538f119df3a40cc250a45f82c095a564d41fe22335
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,8 +11,8 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 45710e0b
-    digest: sha256:533c8be4f98731a49bcf50039559ff2b5eae712280ef074b84711a2824d89cdf
+    tag: 3394723b
+    digest: sha256:7b5bea438425e6d51c94ad440227070a770d79f0733ba4ea6d2f04ff96b008fc
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
@@ -21,8 +21,8 @@ controlPlane:
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 45710e0b
-    digest: sha256:1348bdb0571ee61c3c3005186261a422f4bc754bc19380f842577a9e694950c8
+    tag: 3394723b
+    digest: sha256:bb2e03007287d1f2b78b05538f119df3a40cc250a45f82c095a564d41fe22335
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-13T08:53:28Z
+    deploy.knative.dev/rollout: 2026-05-13T09:15:24Z
 spec:
   replicas: 1
   strategy:
@@ -57,11 +57,11 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_RUNTIME_IMAGE
-              value: registry.ide-newton.ts.net/lab/jangar:45710e0b@sha256:1348bdb0571ee61c3c3005186261a422f4bc754bc19380f842577a9e694950c8
+              value: registry.ide-newton.ts.net/lab/jangar:3394723b@sha256:bb2e03007287d1f2b78b05538f119df3a40cc250a45f82c095a564d41fe22335
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: 45710e0bb070144dc8f7c25bd855221ca3c4e02a
+              value: 3394723b5f07dfc9ff807f5ff29d112eaf6f8c20
             - name: JANGAR_GITOPS_REVISION
-              value: 45710e0bb070144dc8f7c25bd855221ca3c4e02a
+              value: 3394723b5f07dfc9ff807f5ff29d112eaf6f8c20
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_BUMBA_TASK_QUEUE

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -59,5 +59,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: 45710e0b
-    digest: sha256:1348bdb0571ee61c3c3005186261a422f4bc754bc19380f842577a9e694950c8
+    newTag: 3394723b
+    digest: sha256:bb2e03007287d1f2b78b05538f119df3a40cc250a45f82c095a564d41fe22335


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `3394723b5f07dfc9ff807f5ff29d112eaf6f8c20`
- Image tag: `3394723b`
- Image digest: `sha256:bb2e03007287d1f2b78b05538f119df3a40cc250a45f82c095a564d41fe22335`
- Updated API rollout annotation
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`