### PR TITLE
fix(jangar): bump agents chart version

### DIFF
--- a/charts/agents/Chart.yaml
+++ b/charts/agents/Chart.yaml
@@ -6,7 +6,7 @@ sources:
   - https://github.com/proompteng/charts/tree/main/charts/agents
 type: application
 kubeVersion: '>=1.25.0-0'
-version: 0.9.15
+version: 0.9.16
 appVersion: '0.9.0'
 icon: https://avatars.githubusercontent.com/u/234536857
 keywords:


### PR DESCRIPTION
## Summary

- Bumps the agents Helm chart version from `0.9.15` to `0.9.16`.
- Unblocks chart publication for the runner resource defaults merged in #6381.
- Keeps the rollout path scoped to packaging metadata; no runtime behavior changes beyond publishing the already-merged chart contents.

## Related Issues

Follow-up to #6381

## Testing

- `scripts/agents/validate-agents.sh`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
