### PR TITLE
fix(jangar): bump agents chart version

### DIFF
--- a/charts/agents/artifacthub-pkg.yml
+++ b/charts/agents/artifacthub-pkg.yml
@@ -1,4 +1,4 @@
-version: 0.9.15
+version: 0.9.16
 name: agents
 displayName: Agents Control Plane (Jangar)
 description: Minimal Agents control plane with CRDs and native workflow runtime.


### PR DESCRIPTION
## Summary

- Aligns Artifact Hub package metadata with the Agents Helm chart version 0.9.16 now on `main`.
- Fixes the remaining chart metadata mismatch after the direct mainline chart-version hotfix.
- Unblocks the mainline `agents-sync` release gate that failed after #6381 and the partial chart-version follow-up.

## Related Issues

None

## Testing

- PASS: `bunx oxfmt --check charts/agents/artifacthub-pkg.yml`
- PASS: `PATH="/tmp/codex-pyyaml/bin:/tmp/codex-bin:$PATH" scripts/agents/validate-agents.sh`
- PASS: `PATH="/tmp/codex-bin:$PATH" AGENTS_CHART_DRY_RUN=true bun packages/scripts/src/agents/publish-chart.ts --chart-dir charts/agents`
- PASS: `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
