### PR TITLE
fix(jangar): align agents artifacthub version

### DIFF
--- a/charts/agents/artifacthub-pkg.yml
+++ b/charts/agents/artifacthub-pkg.yml
@@ -1,4 +1,4 @@
-version: 0.9.15
+version: 0.9.16
 name: agents
 displayName: Agents Control Plane (Jangar)
 description: Minimal Agents control plane with CRDs and native workflow runtime.


### PR DESCRIPTION
## Summary

- Aligns `charts/agents/artifacthub-pkg.yml` with the `0.9.16` agents chart version.
- Unblocks the agents chart publish workflow after #6383 bumped `Chart.yaml`.
- Keeps the change limited to release metadata required by the existing chart publisher.

## Related Issues

Follow-up to #6381 and #6383

## Testing

- `scripts/agents/validate-agents.sh`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
