### PR TITLE
chore(jangar): promote image 8edecd27

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 3394723b
-  digest: sha256:bb2e03007287d1f2b78b05538f119df3a40cc250a45f82c095a564d41fe22335
+  tag: 8edecd27
+  digest: sha256:319463590bb17de7f1caf99a0e03da802b11cc292312c721e1f2289743cff0e5
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,8 +11,8 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 3394723b
-    digest: sha256:7b5bea438425e6d51c94ad440227070a770d79f0733ba4ea6d2f04ff96b008fc
+    tag: 8edecd27
+    digest: sha256:c924a8d380de01f0112a83a94d2fd06b1c2d5c5e9f721e9d3cda93456de3d0c9
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
@@ -21,8 +21,8 @@ controlPlane:
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 3394723b
-    digest: sha256:bb2e03007287d1f2b78b05538f119df3a40cc250a45f82c095a564d41fe22335
+    tag: 8edecd27
+    digest: sha256:319463590bb17de7f1caf99a0e03da802b11cc292312c721e1f2289743cff0e5
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-13T09:15:24Z
+    deploy.knative.dev/rollout: 2026-05-13T09:38:36Z
 spec:
   replicas: 1
   strategy:
@@ -57,11 +57,11 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_RUNTIME_IMAGE
-              value: registry.ide-newton.ts.net/lab/jangar:3394723b@sha256:bb2e03007287d1f2b78b05538f119df3a40cc250a45f82c095a564d41fe22335
+              value: registry.ide-newton.ts.net/lab/jangar:8edecd27@sha256:319463590bb17de7f1caf99a0e03da802b11cc292312c721e1f2289743cff0e5
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: 3394723b5f07dfc9ff807f5ff29d112eaf6f8c20
+              value: 8edecd27e6fe57f8d5754cba6569520d0c9bd3b9
             - name: JANGAR_GITOPS_REVISION
-              value: 3394723b5f07dfc9ff807f5ff29d112eaf6f8c20
+              value: 8edecd27e6fe57f8d5754cba6569520d0c9bd3b9
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_BUMBA_TASK_QUEUE

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -59,5 +59,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: 3394723b
-    digest: sha256:bb2e03007287d1f2b78b05538f119df3a40cc250a45f82c095a564d41fe22335
+    newTag: 8edecd27
+    digest: sha256:319463590bb17de7f1caf99a0e03da802b11cc292312c721e1f2289743cff0e5


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `8edecd27e6fe57f8d5754cba6569520d0c9bd3b9`
- Image tag: `8edecd27`
- Image digest: `sha256:319463590bb17de7f1caf99a0e03da802b11cc292312c721e1f2289743cff0e5`
- Updated API rollout annotation
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`