### PR TITLE
fix(torghut): make strategy factory persistence idempotent

### DIFF
--- a/services/torghut/scripts/run_strategy_factory_v2.py
+++ b/services/torghut/scripts/run_strategy_factory_v2.py
@@ -473,6 +473,13 @@ def _persist_result(
         "promotion_readiness": promotion_readiness,
         "result": result_payload,
     }
+    run_payload = {
+        "compiled_sweep_path": str(compiled_sweep_path),
+        "result_path": str(result_path),
+        "dataset_snapshot_receipt": result_payload.get("dataset_snapshot_receipt"),
+        "top_candidate": top_candidates[0] if top_candidates else None,
+        "promotion_readiness": promotion_readiness,
+    }
     with SessionLocal() as session:
         session.execute(
             delete(VNextExperimentRun).where(
@@ -480,37 +487,55 @@ def _persist_result(
                 VNextExperimentRun.experiment_id == experiment.experiment_id,
             )
         )
-        session.execute(
-            delete(VNextExperimentSpec).where(
-                VNextExperimentSpec.run_id == runner_run_id,
-                VNextExperimentSpec.experiment_id == experiment.experiment_id,
+        existing_spec = None
+        if best_candidate_id is not None:
+            existing_spec = session.execute(
+                select(VNextExperimentSpec).where(
+                    VNextExperimentSpec.candidate_id == best_candidate_id,
+                    VNextExperimentSpec.experiment_id == experiment.experiment_id,
+                )
+            ).scalar_one_or_none()
+        if existing_spec is not None:
+            existing_spec.run_id = runner_run_id
+            existing_spec.payload_json = experiment_payload
+        else:
+            session.execute(
+                delete(VNextExperimentSpec).where(
+                    VNextExperimentSpec.run_id == runner_run_id,
+                    VNextExperimentSpec.experiment_id == experiment.experiment_id,
+                )
             )
-        )
-        session.add(
-            VNextExperimentSpec(
-                run_id=runner_run_id,
-                candidate_id=best_candidate_id,
-                experiment_id=experiment.experiment_id,
-                payload_json=experiment_payload,
+            session.add(
+                VNextExperimentSpec(
+                    run_id=runner_run_id,
+                    candidate_id=best_candidate_id,
+                    experiment_id=experiment.experiment_id,
+                    payload_json=experiment_payload,
+                )
             )
-        )
-        session.add(
-            VNextExperimentRun(
-                run_id=runner_run_id,
-                candidate_id=best_candidate_id,
-                experiment_id=experiment.experiment_id,
-                stage_lineage_root=None,
-                payload_json={
-                    "compiled_sweep_path": str(compiled_sweep_path),
-                    "result_path": str(result_path),
-                    "dataset_snapshot_receipt": result_payload.get(
-                        "dataset_snapshot_receipt"
-                    ),
-                    "top_candidate": top_candidates[0] if top_candidates else None,
-                    "promotion_readiness": promotion_readiness,
-                },
+
+        existing_run = None
+        if best_candidate_id is not None:
+            existing_run = session.execute(
+                select(VNextExperimentRun).where(
+                    VNextExperimentRun.candidate_id == best_candidate_id,
+                    VNextExperimentRun.run_id == runner_run_id,
+                )
+            ).scalar_one_or_none()
+        if existing_run is not None:
+            existing_run.experiment_id = experiment.experiment_id
+            existing_run.stage_lineage_root = None
+            existing_run.payload_json = run_payload
+        else:
+            session.add(
+                VNextExperimentRun(
+                    run_id=runner_run_id,
+                    candidate_id=best_candidate_id,
+                    experiment_id=experiment.experiment_id,
+                    stage_lineage_root=None,
+                    payload_json=run_payload,
+                )
             )
-        )
         session.commit()
 
 

--- a/services/torghut/tests/test_run_strategy_factory_v2.py
+++ b/services/torghut/tests/test_run_strategy_factory_v2.py
@@ -482,6 +482,104 @@ class TestRunStrategyFactoryV2(TestCase):
                     "blocked_pending_runtime_parity",
                 )
 
+    def test_persist_result_updates_existing_candidate_experiment_pair(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            family_template_dir = self._write_family_template(root)
+            seed_sweep_dir = self._write_seed_sweep(root)
+            output_dir = root / "artifacts"
+            output_dir.mkdir()
+
+            experiment_row = VNextExperimentSpec(
+                run_id="paper-run-1",
+                candidate_id=None,
+                experiment_id="exp-breakout-1",
+                payload_json={"family_template_id": "breakout_reclaim_v2"},
+            )
+            compiled = runner._compile_sweep_config(
+                experiment_row=experiment_row,
+                family_dir=family_template_dir,
+                seed_dir=seed_sweep_dir,
+                train_days=6,
+                holdout_days=3,
+            )
+            duplicate_run_experiment = runner._compile_sweep_config(
+                experiment_row=VNextExperimentSpec(
+                    run_id="paper-run-1",
+                    candidate_id=None,
+                    experiment_id="exp-breakout-2",
+                    payload_json={"family_template_id": "breakout_reclaim_v2"},
+                ),
+                family_dir=family_template_dir,
+                seed_dir=seed_sweep_dir,
+                train_days=6,
+                holdout_days=3,
+            )
+            experiment_root = output_dir / compiled.experiment_id
+            experiment_root.mkdir()
+            compiled_sweep_path = experiment_root / "compiled-sweep.yaml"
+            result_path = experiment_root / "result.json"
+            result_payload = {
+                "dataset_snapshot_receipt": {"snapshot_id": "snap-1"},
+                "top": [
+                    {
+                        "candidate_id": "cand-duplicate",
+                        "full_window": {"net_per_day": "501"},
+                    }
+                ],
+            }
+
+            with patch(
+                "scripts.run_strategy_factory_v2.SessionLocal",
+                side_effect=lambda: Session(self.engine),
+            ):
+                runner._persist_result(
+                    runner_run_id="strategy-factory-v2-old",
+                    experiment=compiled,
+                    result_payload=result_payload,
+                    compiled_sweep_path=compiled_sweep_path,
+                    result_path=result_path,
+                )
+                runner._persist_result(
+                    runner_run_id="strategy-factory-v2-new",
+                    experiment=compiled,
+                    result_payload=result_payload,
+                    compiled_sweep_path=compiled_sweep_path,
+                    result_path=result_path,
+                )
+                runner._persist_result(
+                    runner_run_id="strategy-factory-v2-new",
+                    experiment=duplicate_run_experiment,
+                    result_payload=result_payload,
+                    compiled_sweep_path=compiled_sweep_path,
+                    result_path=result_path,
+                )
+
+            with Session(self.engine) as session:
+                persisted_specs = (
+                    session.execute(
+                        select(VNextExperimentSpec).where(
+                            VNextExperimentSpec.candidate_id == "cand-duplicate",
+                            VNextExperimentSpec.experiment_id == "exp-breakout-1",
+                        )
+                    )
+                    .scalars()
+                    .all()
+                )
+                self.assertEqual(len(persisted_specs), 1)
+                self.assertEqual(persisted_specs[0].run_id, "strategy-factory-v2-new")
+                self.assertEqual(
+                    persisted_specs[0].payload_json["runner_run_id"],
+                    "strategy-factory-v2-new",
+                )
+                run_row = session.execute(
+                    select(VNextExperimentRun).where(
+                        VNextExperimentRun.candidate_id == "cand-duplicate",
+                        VNextExperimentRun.run_id == "strategy-factory-v2-new",
+                    )
+                ).scalar_one()
+                self.assertEqual(run_row.experiment_id, "exp-breakout-2")
+
     def test_run_strategy_factory_v2_respects_global_candidate_budget(self) -> None:
         with TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)


### PR DESCRIPTION
## Summary

- Makes strategy-factory result persistence idempotent for repeated `(candidate_id, experiment_id)` outputs.
- Updates existing experiment-spec rows instead of failing on the global uniqueness constraint during autoresearch reruns.
- Coalesces duplicate candidate/run experiment-run rows so one duplicated candidate cannot abort the `$500/day` pipeline.
- Adds regression coverage for both duplicate candidate/experiment persistence and same-run duplicate candidate persistence.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_run_strategy_factory_v2.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv run --frozen ruff format --check scripts/run_strategy_factory_v2.py tests/test_run_strategy_factory_v2.py`
- `uv run --frozen ruff check scripts/run_strategy_factory_v2.py tests/test_run_strategy_factory_v2.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen coverage run -m pytest tests/test_run_strategy_factory_v2.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv run --frozen coverage xml --fail-under=0`
- `GITHUB_BASE_REF=main GITHUB_EVENT_NAME=pull_request uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90`
- `git diff --check origin/main...HEAD`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
