### PR TITLE
chore(jangar): promote image 5f707330

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 8edecd27
-  digest: sha256:319463590bb17de7f1caf99a0e03da802b11cc292312c721e1f2289743cff0e5
+  tag: 5f707330
+  digest: sha256:23c4ae06e5ac2c64728ed0aa0001f126bf47556c79d8f147d97e0b3475a5d0a3
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,8 +11,8 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 8edecd27
-    digest: sha256:c924a8d380de01f0112a83a94d2fd06b1c2d5c5e9f721e9d3cda93456de3d0c9
+    tag: 5f707330
+    digest: sha256:3e7f7c02fa085c058900af6edf54bce96f5c03beca0b1cfe92b6e6720ce659d7
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
@@ -21,8 +21,8 @@ controlPlane:
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 8edecd27
-    digest: sha256:319463590bb17de7f1caf99a0e03da802b11cc292312c721e1f2289743cff0e5
+    tag: 5f707330
+    digest: sha256:23c4ae06e5ac2c64728ed0aa0001f126bf47556c79d8f147d97e0b3475a5d0a3
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-13T09:38:36Z
+    deploy.knative.dev/rollout: 2026-05-13T09:54:44Z
 spec:
   replicas: 1
   strategy:
@@ -57,11 +57,11 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_RUNTIME_IMAGE
-              value: registry.ide-newton.ts.net/lab/jangar:8edecd27@sha256:319463590bb17de7f1caf99a0e03da802b11cc292312c721e1f2289743cff0e5
+              value: registry.ide-newton.ts.net/lab/jangar:5f707330@sha256:23c4ae06e5ac2c64728ed0aa0001f126bf47556c79d8f147d97e0b3475a5d0a3
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: 8edecd27e6fe57f8d5754cba6569520d0c9bd3b9
+              value: 5f7073306a90f10587a4474fa93930e17b999242
             - name: JANGAR_GITOPS_REVISION
-              value: 8edecd27e6fe57f8d5754cba6569520d0c9bd3b9
+              value: 5f7073306a90f10587a4474fa93930e17b999242
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_BUMBA_TASK_QUEUE

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -59,5 +59,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: 8edecd27
-    digest: sha256:319463590bb17de7f1caf99a0e03da802b11cc292312c721e1f2289743cff0e5
+    newTag: 5f707330
+    digest: sha256:23c4ae06e5ac2c64728ed0aa0001f126bf47556c79d8f147d97e0b3475a5d0a3


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `5f7073306a90f10587a4474fa93930e17b999242`
- Image tag: `5f707330`
- Image digest: `sha256:23c4ae06e5ac2c64728ed0aa0001f126bf47556c79d8f147d97e0b3475a5d0a3`
- Updated API rollout annotation
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`