### PR TITLE
fix(jangar): ignore inactive swarm freeze records

### DIFF
--- a/services/jangar/src/server/__tests__/control-plane-status.test.ts
+++ b/services/jangar/src/server/__tests__/control-plane-status.test.ts
@@ -2695,6 +2695,39 @@ describe('control-plane status', () => {
     )
   })
 
+  it('buildExecutionTrust ignores inactive NotFrozen freeze records with future timestamps', async () => {
+    const kubeGateway = createTestKubeGateway({
+      listSwarms: vi.fn(async () => [
+        buildExecutionTrustSwarmResource({
+          phase: 'Active',
+          freezeReason: 'NotFrozen',
+          freezeUntil: '2026-01-20T00:40:00Z',
+          requirementsPending: 0,
+          requirementsLastSeen: '2026-01-20T00:19:00Z',
+        }),
+      ]),
+    })
+
+    const snapshot = await buildExecutionTrust({
+      namespace: 'agents',
+      now: new Date('2026-01-20T00:20:00Z'),
+      swarms: ['jangar-control-plane'],
+      kube: kubeGateway,
+      summaryLimit: 20,
+    })
+
+    expect(snapshot.executionTrust.status).toBe('healthy')
+    expect(snapshot.executionTrust.blocking_windows).toEqual([])
+    expect(snapshot.swarms[0]).toMatchObject({
+      phase: 'Active',
+      ready: true,
+      freeze: {
+        reason: 'NotFrozen',
+        until: '2026-01-20T00:40:00Z',
+      },
+    })
+  })
+
   it('buildExecutionTrust degrades when freeze expiry is unreconciled', async () => {
     const kubeGateway = createTestKubeGateway({
       listSwarms: vi.fn(async () => [

--- a/services/jangar/src/server/control-plane-execution-trust.ts
+++ b/services/jangar/src/server/control-plane-execution-trust.ts
@@ -98,6 +98,11 @@ const isBlockingFreezeReason = (reason: string | null) => {
   return reasons.some((entry) => entry !== 'StageStaleness')
 }
 
+const isInactiveFreezeReason = (reason: string | null) => {
+  const reasons = splitFreezeReasons(reason).map((entry) => entry.toLowerCase())
+  return reasons.length > 0 && reasons.every((entry) => entry === 'notfrozen')
+}
+
 const readRequirementsPending = (raw: unknown): number => {
   if (typeof raw === 'number' && Number.isFinite(raw)) return Math.max(0, Math.floor(raw))
   if (typeof raw === 'string' && raw.trim() !== '') {
@@ -333,10 +338,11 @@ export const buildExecutionTrust = async ({
     const freezeRaw = asRecord(status.freeze) ?? {}
     const freezeUntil = asString(freezeRaw.until)
     const freezeUntilMs = parseDateMs(freezeUntil)
-    const freezeActive = freezeUntilMs !== null && freezeUntilMs > nowMs
-    const freezeExpiredUnreconciled =
-      phase.toLowerCase() === 'frozen' && freezeUntilMs !== null && freezeUntilMs <= nowMs
     const freezeReason = asString(freezeRaw.reason) ?? null
+    const inactiveFreeze = isInactiveFreezeReason(freezeReason)
+    const freezeActive = !inactiveFreeze && freezeUntilMs !== null && freezeUntilMs > nowMs
+    const freezeExpiredUnreconciled =
+      !inactiveFreeze && phase.toLowerCase() === 'frozen' && freezeUntilMs !== null && freezeUntilMs <= nowMs
     const freezeBlocking = freezeActive && isBlockingFreezeReason(freezeReason)
     const projectedPhase = freezeExpiredUnreconciled ? 'Recovering' : phase
     const ready =


### PR DESCRIPTION
## Summary

- Treat `status.freeze.reason: NotFrozen` as an inactive swarm freeze record even when the CRD still carries a future `freeze.until`.
- Keep active freeze handling unchanged for blocking freezes and `StageStaleness` recovery freezes.
- Add regression coverage so execution trust stays healthy for active swarms with inactive freeze records.

## Related Issues

None

## Testing

- `bunx vitest run --config vitest.config.ts src/server/__tests__/control-plane-status.test.ts -t 'NotFrozen'`
- `bunx vitest run --config vitest.config.ts src/server/__tests__/control-plane-status.test.ts`
- `bunx oxfmt --check services/jangar/src/server/control-plane-execution-trust.ts services/jangar/src/server/__tests__/control-plane-status.test.ts`
- `git diff --check`
- `bun run --cwd services/jangar tsc`
- `bun run --cwd services/jangar lint`
- `bun run --cwd services/jangar lint:oxlint` (passes with existing warnings)

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
