### PR TITLE
ci(torghut): parallelize whitepaper autoresearch shards

### DIFF
--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -47,9 +47,11 @@ spec:
       - name: realReplayTimeoutSeconds
         value: '7200'
       - name: realReplayShardSize
-        value: '2'
+        value: '1'
       - name: realReplayShardTimeoutSeconds
         value: '900'
+      - name: realReplayShardWorkers
+        value: '3'
       - name: prefetchFullWindowRows
         value: 'true'
       - name: allowStaleTape
@@ -82,6 +84,7 @@ spec:
           - name: realReplayTimeoutSeconds
           - name: realReplayShardSize
           - name: realReplayShardTimeoutSeconds
+          - name: realReplayShardWorkers
           - name: prefetchFullWindowRows
           - name: allowStaleTape
           - name: persistResults
@@ -158,6 +161,7 @@ spec:
               --real-replay-timeout-seconds "{{inputs.parameters.realReplayTimeoutSeconds}}"
               --real-replay-shard-size "{{inputs.parameters.realReplayShardSize}}"
               --real-replay-shard-timeout-seconds "{{inputs.parameters.realReplayShardTimeoutSeconds}}"
+              --real-replay-shard-workers "{{inputs.parameters.realReplayShardWorkers}}"
               --train-days 6
               --holdout-days 3
               --full-window-start-date "{{inputs.parameters.fullWindowStartDate}}"

--- a/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
+++ b/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
@@ -118,6 +118,7 @@ describe('Torghut manifest scheduling', () => {
     expect(JSON.stringify(template)).toContain('--require-no-flat-days')
     expect(JSON.stringify(template)).toContain('--real-replay-shard-size')
     expect(JSON.stringify(template)).toContain('--real-replay-shard-timeout-seconds')
+    expect(JSON.stringify(template)).toContain('--real-replay-shard-workers')
   })
 
   it('bounds whitepaper autoresearch real replay so profit runs emit evidence before timeout', () => {
@@ -127,6 +128,8 @@ describe('Torghut manifest scheduling', () => {
     expect(parameterValue(manifest, 'maxFrontierCandidatesPerSpec')).toBe('2')
     expect(parameterValue(manifest, 'maxTotalFrontierCandidates')).toBe('24')
     expect(parameterValue(manifest, 'realReplayTimeoutSeconds')).toBe('7200')
+    expect(parameterValue(manifest, 'realReplayShardSize')).toBe('1')
+    expect(parameterValue(manifest, 'realReplayShardWorkers')).toBe('3')
     expect(template.activeDeadlineSeconds).toBe(10800)
   })
 })


### PR DESCRIPTION
## Summary

- Parallelizes the Torghut whitepaper autoresearch replay shards by wiring the existing runner worker flag into the Argo WorkflowTemplate.
- Changes the default replay shard size from 2 to 1 so the worker pool can balance long-running candidate replays more evenly.
- Extends manifest scheduling coverage so the `$500/day` workflow keeps the bounded replay settings and worker flag in CI.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts`
- `bunx oxfmt --check packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts`
- `bun run lint:argocd`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
