### PR TITLE
fix(jangar): refresh active workflow stage freshness

### DIFF
--- a/services/jangar/src/server/__tests__/supporting-primitives-controller.test.ts
+++ b/services/jangar/src/server/__tests__/supporting-primitives-controller.test.ts
@@ -2119,6 +2119,124 @@ describe('supporting primitives controller', () => {
     })
   })
 
+  it('uses active workflow step attempts for stage freshness when AgentRun start time is stale', async () => {
+    vi.setSystemTime(new Date('2026-01-20T03:00:00Z'))
+
+    const applyStatus = vi.fn().mockResolvedValue({})
+    const apply = vi.fn().mockResolvedValue({})
+    const deleteFn = vi.fn().mockResolvedValue(null)
+    const staleStartedAt = '2026-01-20T00:00:00Z'
+    const recentStepStartedAt = '2026-01-20T02:30:00Z'
+    const recentJobObservedAt = '2026-01-20T02:31:00Z'
+    const staleScheduleRunAt = '2026-01-20T00:00:00Z'
+    const stageRuns = ['discover', 'plan', 'implement', 'verify'].map((stage) => ({
+      kind: 'AgentRun',
+      metadata: {
+        name: `jangar-control-plane-${stage}-retry-active`,
+        namespace: 'agents',
+        labels: {
+          'swarm.proompteng.ai/name': 'jangar-control-plane',
+          'swarm.proompteng.ai/stage': stage,
+          'swarm.proompteng.ai/uid': 'swarm-uid',
+        },
+        creationTimestamp: staleStartedAt,
+      },
+      status: {
+        phase: 'Running',
+        startedAt: staleStartedAt,
+        workflow: {
+          steps: [
+            {
+              attempt: 2,
+              name: stage,
+              phase: 'Running',
+              startedAt: recentStepStartedAt,
+              jobObservedAt: recentJobObservedAt,
+            },
+          ],
+        },
+      },
+    }))
+    const get = vi.fn(async (resource: string) => {
+      if (resource === RESOURCE_MAP.Schedule) {
+        return { status: { phase: 'Active', lastRunTime: staleScheduleRunAt } }
+      }
+      if (resource === RESOURCE_MAP.AgentRun) {
+        return {
+          kind: 'AgentRun',
+          metadata: { name: 'agentrun-sample', namespace: 'agents' },
+          spec: {
+            agentRef: { name: 'codex-spark-agent' },
+            runtime: { type: 'job' },
+            parameters: {},
+          },
+        }
+      }
+      return null
+    })
+    const list = vi.fn(async (resource: string) => {
+      if (resource === RESOURCE_MAP.AgentRun) return { items: stageRuns }
+      return { items: [] }
+    })
+    const kube = { applyStatus, apply, get, list, delete: deleteFn } as unknown as KubernetesClient
+
+    const swarm = {
+      apiVersion: 'swarm.proompteng.ai/v1alpha1',
+      kind: 'Swarm',
+      metadata: { name: 'jangar-control-plane', namespace: 'agents', generation: 2, uid: 'swarm-uid' },
+      spec: {
+        owner: { id: 'platform-owner', channel: 'swarm://owner/platform' },
+        domains: ['platform-reliability'],
+        objectives: ['improve reliability'],
+        mode: 'lights-out',
+        timezone: 'UTC',
+        cadence: {
+          discoverEvery: '1h',
+          planEvery: '1h',
+          implementEvery: '1h',
+          verifyEvery: '1h',
+        },
+        discovery: { sources: [{ name: 'github-issues' }] },
+        delivery: { deploymentTargets: ['agents'] },
+        mission: {
+          ledgerRef: '/workspace/.agentrun/swarm/jangar-control-plane-mission-ledger.md',
+          businessMetric: 'reduce failed AgentRuns',
+          validationContract: ['dispatch requirements only when business value is named'],
+          valueGates: ['failed_agentrun_rate'],
+        },
+        execution: {
+          discover: { targetRef: { kind: 'AgentRun', name: 'agentrun-sample' } },
+          plan: { targetRef: { kind: 'AgentRun', name: 'agentrun-sample' } },
+          implement: { targetRef: { kind: 'AgentRun', name: 'agentrun-sample' } },
+          verify: { targetRef: { kind: 'AgentRun', name: 'agentrun-sample' } },
+        },
+      },
+    }
+
+    await __test__.reconcileSwarm(kube, swarm, 'agents')
+
+    expect(applyStatus).toHaveBeenCalledTimes(1)
+    const status = (applyStatus.mock.calls[0]?.[0] as { status?: Record<string, unknown> } | undefined)?.status ?? {}
+    const stageStates = (status.stageStates ?? {}) as Record<string, Record<string, unknown>>
+    for (const stage of ['discover', 'plan', 'implement', 'verify']) {
+      expect(stageStates[stage]?.fresh).toBe(true)
+      expect(stageStates[stage]?.healthy).toBe(true)
+      expect(stageStates[stage]?.recentActiveAt).toBe(new Date(recentJobObservedAt).toISOString())
+      expect(stageStates[stage]?.recentSuccessAt).toBeNull()
+    }
+    expect(status.lastVerifyAt).toBe(new Date(recentJobObservedAt).toISOString())
+
+    const conditions = Array.isArray(status.conditions) ? status.conditions : []
+    const ready = conditions.find((condition) => condition.type === 'Ready')
+    const degraded = conditions.find((condition) => condition.type === 'Degraded')
+    expect(ready).toMatchObject({ status: 'True', reason: 'Active', message: 'swarm active' })
+    expect(degraded).toMatchObject({
+      status: 'False',
+      reason: 'Healthy',
+      message: 'all stage and requirement health checks passing',
+    })
+  })
+
   it('dispatches NATS requirement signals into implement runs', async () => {
     const applyStatus = vi.fn().mockResolvedValue({})
     const apply = vi.fn().mockResolvedValue({})

--- a/services/jangar/src/server/supporting-primitives-swarm-analysis.ts
+++ b/services/jangar/src/server/supporting-primitives-swarm-analysis.ts
@@ -137,12 +137,38 @@ export const getRunTimestamp = (resource: Record<string, unknown>) => {
     )
   }
 
+  const workflowStepTimestamp = resolveLatestWorkflowStepTimestamp(resource)
   return (
+    workflowStepTimestamp ??
     asString(readNested(resource, ['status', 'startedAt'])) ??
     asString(readNested(resource, ['status', 'finishedAt'])) ??
     asString(readNested(resource, ['status', 'updatedAt'])) ??
     asString(readNested(resource, ['metadata', 'creationTimestamp']))
   )
+}
+
+const resolveLatestWorkflowStepTimestamp = (resource: Record<string, unknown>) => {
+  const steps = readNested(resource, ['status', 'workflow', 'steps'])
+  if (!Array.isArray(steps)) return null
+
+  let latestMs: number | null = null
+  for (const step of steps) {
+    const record = asRecord(step)
+    if (!record) continue
+    const phase = (asString(record.phase) ?? '').toLowerCase()
+    if (!ACTIVE_PHASES.has(phase)) continue
+    for (const candidate of [
+      asString(record.jobObservedAt),
+      asString(record.startedAt),
+      asString(record.lastTransitionTime),
+    ]) {
+      const parsed = parseTimeOrNull(candidate)
+      if (parsed === null) continue
+      latestMs = latestMs === null ? parsed : Math.max(latestMs, parsed)
+    }
+  }
+
+  return latestMs === null ? null : new Date(latestMs).toISOString()
 }
 
 export const parseTimeOrNull = (value: string | null | undefined) => {


### PR DESCRIPTION
## Summary

- Use active workflow step timestamps when calculating swarm stage freshness for running AgentRuns.
- Prevent retrying deployer/implementer workflows from looking stale just because the parent AgentRun started before the retry attempt.
- Add a Jangar regression that keeps all swarm stages healthy when stale AgentRun `startedAt` is superseded by a fresh active workflow step attempt.

## Related Issues

None

## Testing

- `bunx vitest run --config vitest.config.ts src/server/__tests__/supporting-primitives-controller.test.ts -t 'active workflow step attempts'`
- `bunx vitest run --config vitest.config.ts src/server/__tests__/supporting-primitives-controller.test.ts`
- `bun run --cwd services/jangar tsc`
- `bun run --cwd services/jangar lint`
- `bun run --cwd services/jangar lint:oxlint`
- `bun run --cwd services/jangar lint:oxlint:type`
- `bunx oxfmt --check services/jangar/src/server/supporting-primitives-swarm-analysis.ts services/jangar/src/server/__tests__/supporting-primitives-controller.test.ts`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
