### PR TITLE
chore(jangar): promote image 1794d8bf

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 5f707330
-  digest: sha256:23c4ae06e5ac2c64728ed0aa0001f126bf47556c79d8f147d97e0b3475a5d0a3
+  tag: 1794d8bf
+  digest: sha256:6ad8a8c867aba8274d2fa5344dae5adefb5d9020705407b61a7b0fcc40ad4661
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,8 +11,8 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 5f707330
-    digest: sha256:3e7f7c02fa085c058900af6edf54bce96f5c03beca0b1cfe92b6e6720ce659d7
+    tag: 1794d8bf
+    digest: sha256:8e6b213e3827063977f438dbf6fc6c065fe0c98919a8b87401ac7fd47ee72e68
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
@@ -21,8 +21,8 @@ controlPlane:
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 5f707330
-    digest: sha256:23c4ae06e5ac2c64728ed0aa0001f126bf47556c79d8f147d97e0b3475a5d0a3
+    tag: 1794d8bf
+    digest: sha256:6ad8a8c867aba8274d2fa5344dae5adefb5d9020705407b61a7b0fcc40ad4661
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-13T09:54:44Z
+    deploy.knative.dev/rollout: 2026-05-13T10:41:11Z
 spec:
   replicas: 1
   strategy:
@@ -57,11 +57,11 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_RUNTIME_IMAGE
-              value: registry.ide-newton.ts.net/lab/jangar:5f707330@sha256:23c4ae06e5ac2c64728ed0aa0001f126bf47556c79d8f147d97e0b3475a5d0a3
+              value: registry.ide-newton.ts.net/lab/jangar:1794d8bf@sha256:6ad8a8c867aba8274d2fa5344dae5adefb5d9020705407b61a7b0fcc40ad4661
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: 5f7073306a90f10587a4474fa93930e17b999242
+              value: 1794d8bfe0bc809c61f8da93c04d299d7cdf2c52
             - name: JANGAR_GITOPS_REVISION
-              value: 5f7073306a90f10587a4474fa93930e17b999242
+              value: 1794d8bfe0bc809c61f8da93c04d299d7cdf2c52
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_BUMBA_TASK_QUEUE

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -59,5 +59,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: 5f707330
-    digest: sha256:23c4ae06e5ac2c64728ed0aa0001f126bf47556c79d8f147d97e0b3475a5d0a3
+    newTag: 1794d8bf
+    digest: sha256:6ad8a8c867aba8274d2fa5344dae5adefb5d9020705407b61a7b0fcc40ad4661


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `1794d8bfe0bc809c61f8da93c04d299d7cdf2c52`
- Image tag: `1794d8bf`
- Image digest: `sha256:6ad8a8c867aba8274d2fa5344dae5adefb5d9020705407b61a7b0fcc40ad4661`
- Updated API rollout annotation
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`