### PR TITLE
chore(jangar): promote image f8ba9e06

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 1794d8bf
-  digest: sha256:6ad8a8c867aba8274d2fa5344dae5adefb5d9020705407b61a7b0fcc40ad4661
+  tag: f8ba9e06
+  digest: sha256:1fb6337ce8a1d7b1fad5b67999acc0a278287f3d48e1531297af4e7b05cd5206
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,8 +11,8 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 1794d8bf
-    digest: sha256:8e6b213e3827063977f438dbf6fc6c065fe0c98919a8b87401ac7fd47ee72e68
+    tag: f8ba9e06
+    digest: sha256:3ef54b24ace957088d7ec2ba13cf61a1cafbeaabad78d14006da756567808eb7
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
@@ -21,8 +21,8 @@ controlPlane:
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 1794d8bf
-    digest: sha256:6ad8a8c867aba8274d2fa5344dae5adefb5d9020705407b61a7b0fcc40ad4661
+    tag: f8ba9e06
+    digest: sha256:1fb6337ce8a1d7b1fad5b67999acc0a278287f3d48e1531297af4e7b05cd5206
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-13T10:41:11Z
+    deploy.knative.dev/rollout: 2026-05-13T11:04:24Z
 spec:
   replicas: 1
   strategy:
@@ -57,11 +57,11 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_RUNTIME_IMAGE
-              value: registry.ide-newton.ts.net/lab/jangar:1794d8bf@sha256:6ad8a8c867aba8274d2fa5344dae5adefb5d9020705407b61a7b0fcc40ad4661
+              value: registry.ide-newton.ts.net/lab/jangar:f8ba9e06@sha256:1fb6337ce8a1d7b1fad5b67999acc0a278287f3d48e1531297af4e7b05cd5206
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: 1794d8bfe0bc809c61f8da93c04d299d7cdf2c52
+              value: f8ba9e06bd71ca28a9c44b7edf089319854b5d4d
             - name: JANGAR_GITOPS_REVISION
-              value: 1794d8bfe0bc809c61f8da93c04d299d7cdf2c52
+              value: f8ba9e06bd71ca28a9c44b7edf089319854b5d4d
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_BUMBA_TASK_QUEUE

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -59,5 +59,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: 1794d8bf
-    digest: sha256:6ad8a8c867aba8274d2fa5344dae5adefb5d9020705407b61a7b0fcc40ad4661
+    newTag: f8ba9e06
+    digest: sha256:1fb6337ce8a1d7b1fad5b67999acc0a278287f3d48e1531297af4e7b05cd5206


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `f8ba9e06bd71ca28a9c44b7edf089319854b5d4d`
- Image tag: `f8ba9e06`
- Image digest: `sha256:1fb6337ce8a1d7b1fad5b67999acc0a278287f3d48e1531297af4e7b05cd5206`
- Updated API rollout annotation
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`