### PR TITLE
fix(torghut): defer proof remediation until profit gates pass

### DIFF
--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -1177,23 +1177,38 @@ def _candidate_search_remediation(
         for reason, count in failure_counts.items()
         if reason in promotion_proof_failures
     }
+    non_proof_failure_counts = {
+        reason: count
+        for reason, count in failure_counts.items()
+        if reason not in promotion_proof_failures
+    }
     if proof_failure_counts:
-        next_actions.append(
-            {
-                "priority": 3,
-                "action": "complete_executable_replay_and_shadow_parity_evidence",
-                "reason": "replayed candidates are missing promotion-closure evidence required by the oracle",
-                "blocking_failure_counts": proof_failure_counts,
-                "required_scorecard_fields": [
-                    "shadow_parity_status",
-                    "executable_replay_passed",
-                    "executable_replay_artifact_ref",
-                    "executable_replay_order_count",
-                    "executable_replay_account_buying_power",
-                    "executable_replay_max_notional_per_trade",
-                ],
-            }
-        )
+        proof_action: dict[str, Any] = {
+            "priority": 3 if not non_proof_failure_counts else 7,
+            "action": "complete_executable_replay_and_shadow_parity_evidence",
+            "reason": (
+                "replayed candidates are missing promotion-closure evidence required by the oracle"
+                if not non_proof_failure_counts
+                else "promotion-closure evidence is required, but current candidates still fail profit or risk gates"
+            ),
+            "blocking_failure_counts": proof_failure_counts,
+            "required_scorecard_fields": [
+                "shadow_parity_status",
+                "executable_replay_passed",
+                "executable_replay_artifact_ref",
+                "executable_replay_order_count",
+                "executable_replay_account_buying_power",
+                "executable_replay_max_notional_per_trade",
+            ],
+        }
+        if non_proof_failure_counts:
+            proof_action["deferred_until"] = (
+                "portfolio_profit_and_risk_oracle_failures_clear"
+            )
+            proof_action["blocked_by_non_proof_failure_counts"] = dict(
+                sorted(non_proof_failure_counts.items())
+            )
+        next_actions.append(proof_action)
     if any(
         reason in failure_counts
         for reason in (

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -1285,7 +1285,6 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                     "candidate_spec_id": "spec-selected",
                     "evidence_status": "replayed",
                     "failure_reasons": [
-                        "active_day_ratio_below_oracle",
                         "shadow_parity_status_not_within_budget",
                         "executable_replay_not_passed",
                         "executable_replay_artifact_missing",
@@ -1312,6 +1311,62 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             "executable_replay_artifact_ref",
             proof_action["required_scorecard_fields"],
         )
+
+    def test_remediation_defers_promotion_proof_until_profit_gates_pass(self) -> None:
+        remediation = runner._candidate_search_remediation(
+            failure_reason="portfolio_candidate_failed_profit_target_oracle",
+            candidate_selection={
+                "rows": [
+                    {
+                        "candidate_spec_id": "spec-selected",
+                        "selected_for_replay": True,
+                    }
+                ]
+            },
+            evidence_bundles=(),
+            false_positive_table=(
+                {
+                    "candidate_spec_id": "spec-selected",
+                    "evidence_status": "replayed",
+                    "failure_reasons": [
+                        "positive_day_ratio_below_oracle",
+                        "max_drawdown_above_oracle",
+                        "shadow_parity_status_not_within_budget",
+                        "executable_replay_not_passed",
+                    ],
+                },
+            ),
+            best_false_negative_table=(),
+            replay_timeout_seconds=7200,
+            max_frontier_candidates_per_spec=2,
+            current_top_k=24,
+            current_exploration_slots=16,
+            current_portfolio_size_min=3,
+            current_max_candidates=96,
+            current_max_total_frontier_candidates=48,
+        )
+
+        self.assertEqual(
+            remediation["next_actions"][0]["action"],
+            "increase_breadth_and_portfolio_diversity",
+        )
+        proof_action = next(
+            action
+            for action in remediation["next_actions"]
+            if action["action"]
+            == "complete_executable_replay_and_shadow_parity_evidence"
+        )
+        self.assertEqual(
+            proof_action["deferred_until"],
+            "portfolio_profit_and_risk_oracle_failures_clear",
+        )
+        self.assertEqual(
+            proof_action["blocked_by_non_proof_failure_counts"][
+                "positive_day_ratio_below_oracle"
+            ],
+            1,
+        )
+        self.assertEqual(proof_action["priority"], 7)
 
     def test_remediation_increases_breadth_from_current_epoch(self) -> None:
         remediation = runner._candidate_search_remediation(


### PR DESCRIPTION
## Summary

- Defers executable replay and shadow parity remediation when candidates still fail non-proof profit or risk oracle checks.
- Keeps proof remediation first only for proof-only failures, so autoresearch guidance stays aligned with the real blocker.
- Adds regression coverage for mixed profit/risk plus proof failures.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv run --frozen ruff format --check scripts/run_whitepaper_autoresearch_profit_target.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv run --frozen ruff check scripts/run_whitepaper_autoresearch_profit_target.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
