### PR TITLE
fix(jangar): stabilize account witness release gate

### DIFF
--- a/docs/agents/rollouts/2026-05-13-jangar-control-plane-verify.md
+++ b/docs/agents/rollouts/2026-05-13-jangar-control-plane-verify.md
@@ -6,27 +6,27 @@ Release engineer: Marco Silva
 
 ## Owner update message
 
-Rollout state is green for the selected Jangar control-plane release slice. Source PR #6414,
-`feat(jangar): add evidence pressure ledger`, merged as `07da331d95ca0ef2779108a00a877c5e718b2656`,
-and promotion PR #6420, `chore(jangar): promote image 07da331d`, merged as
-`3dbaa6d63cd21e6e082be094ab2c8ea1cecc1d40`.
+Rollout state is healthy for the selected Jangar source release, but the release gate needed a follow-up test fix before
+the promotion check history could be made green. Source PR #6440, `feat(jangar): add account-scoped quant witness`,
+merged as `590379886ae32e68013204094f67660b3879c4fe`. Jangar promotion PR #6446 promoted that image as `59037988`,
+and follow-on promotion PR #6447 promoted current main as `146bbce5`.
 
-The GitOps and workload rollout gate is green: Argo `jangar`, `agents`, and `torghut` are Synced/Healthy at
-`3b7277516fd31a9d74916202c81d5610e56afc19`, which includes the #6420 promotion commit, and
-`jangar-post-deploy-verify` run `25800868616` passed. Live `jangar`, `agents`, and `agents-controllers` workloads are
-ready on image tag `07da331d`.
+The GitOps and workload rollout gate is green for #6447: Argo `jangar`, `agents`, and `torghut` are Synced/Healthy at
+`fc0aaebeddd92dcdbca933aa03426bd8eb630736`; `jangar-post-deploy-verify` run `25811518735` passed; and the live
+`jangar`, `agents`, and `agents-controllers` deployments are ready on tag `146bbce5`.
 
-`jangar /health`, `jangar /ready`, and `agents /ready` returned HTTP 200. `/ready` reported
-`execution_trust=healthy`, `torghut_consumer_evidence=current`, and a fresh `evidence_pressure_ledger` in observe mode
-with calm watch backoff. The control-plane metric improved is `ready_status_truth`: the runtime now exposes the
-evidence pressure ledger and watch-backoff posture directly on readiness/status, making merge and dispatch gates easier
-to verify without inferring pressure from unrelated symptoms. `pr_to_rollout_latency` was 15m24s from source merge
-(`2026-05-13T12:52:48Z`) to post-deploy verifier completion (`2026-05-13T13:08:12Z`).
+The remaining blocker from the selected release slice was CI-only: `jangar-ci / lint-and-typecheck` failed on #6446 and
+#6447 because the account-witness regression used fixed fixture timestamps while reading the live wall clock. This verify
+branch pins that test clock and advances the intentional 1 ms timeout timer, making the regression deterministic.
+
+Control-plane value improved: `handoff_evidence_quality` and `ready_status_truth`. The selected source release adds a
+live account-scoped quant witness endpoint, and this verify PR records the exact CI blocker and fix needed to keep green
+promotion-to-rollout flow trustworthy.
 
 ## Governing requirements
 
-- `docs/agents/designs/188-jangar-evidence-pressure-ledger-and-watch-backoff-governor-2026-05-13.md`: publish the
-  Jangar evidence pressure ledger, watch-backoff policy, and deployer handoff in observe mode.
+- `docs/agents/designs/189-jangar-account-scoped-quant-witness-custody-and-route-reentry-2026-05-13.md`: account-scoped
+  quant witnesses must provide route-reentry evidence without widening capital exposure.
 - `docs/agents/designs/swarm-agentic-mission-architecture-2026-05-08.md`: verify stages must merge only green PRs and
   prove Argo sync, workload readiness, and service health after rollout.
 - Runtime acceptance contract: selected PRs must advance failed AgentRun reduction, PR-to-rollout latency,
@@ -36,92 +36,119 @@ to verify without inferring pressure from unrelated symptoms. `pr_to_rollout_lat
 
 ## PRs touched
 
-- #6414 `feat(jangar): add evidence pressure ledger`
-  - Purpose: add `evidence_pressure_ledger` to control-plane status and `/ready`, including watch reason-code aging,
-    pressure summaries, UI rendering, docs, and regressions.
+- #6440 `feat(jangar): add account-scoped quant witness`
+  - Purpose: add account-scoped quant witness evidence for Torghut routeability re-entry, including endpoint docs,
+    route wiring, witness builder, and regression coverage.
   - Merge gate: non-draft, no review threads, no requested changes, CLEAN/MERGEABLE, and all visible checks green or
     intentionally skipped before merge.
-  - Checks before merge: `jangar-ci / lint-and-typecheck / run`, `agents-ci / validate`, `agents-ci / integration`,
-    `CI / check_changed_files`, semantic title, and semantic commits passed; unrelated matrix/deploy enable jobs were
-    skipped.
-  - Merge outcome: squash-merged at `2026-05-13T12:52:48Z` as
-    `07da331d95ca0ef2779108a00a877c5e718b2656`.
-  - Post-merge checks: `Docker Build and Push` run `25800308156`, `jangar-build-push` run `25800308052`,
-    `agents-ci` run `25800308019`, and `jangar-release` run `25800808195` passed.
-- #6420 `chore(jangar): promote image 07da331d`
-  - Purpose: promote the #6414 image through GitOps.
-  - Image tag: `07da331d`.
-  - Jangar image digest: `sha256:d0a61187c54f063d6f3f875a6760b3202ff8f7733b2f7977ff06a39d1a3e3c90`.
+  - Merge outcome: squash-merged at `2026-05-13T15:53:51Z` as
+    `590379886ae32e68013204094f67660b3879c4fe`.
+  - Post-merge checks: `jangar-build-push` run `25810435329` passed, and `jangar-release` run `25811085370` passed.
+- #6446 `chore(jangar): promote image 59037988`
+  - Purpose: promote the #6440 image through GitOps.
+  - Image tag: `59037988`.
+  - Jangar image digest: `sha256:d36014cfdf350b30a8c10ef4238c1e6fdd51e6e6f390b2b012d070f99560035e`.
   - Agents control-plane image digest:
-    `sha256:ee5c618919f28cdb3f62440f0ef8b280ec18e2fb42b4d784b067af74f3927110`.
-  - Promotion checks: `argo-lint / lint`, `kubeconform / validate`, `jangar-ci / lint-and-typecheck / run`, semantic
-    title, semantic commits, and Jangar deploy automerge enable check passed; unrelated deploy enable jobs skipped.
-  - Merge outcome: auto-merged at `2026-05-13T13:03:30Z` as
-    `3dbaa6d63cd21e6e082be094ab2c8ea1cecc1d40`.
+    `sha256:b4e388efb61593dbb3798a2510fc76b600c08b0fd699b922e6edc9fa945a0a3d`.
+  - Merge outcome: auto-merged at `2026-05-13T16:07:28Z` as
+    `8caf6b7b0b7974d5f59a075ea3f44c72c1ef70a1`.
+  - Rollout check: `jangar-post-deploy-verify` run `25811195082` passed.
+  - CI blocker found after merge: `jangar-ci / lint-and-typecheck` run `25811174446` failed in
+    `src/routes/api/torghut/trading/control-plane/quant/-account-witness.test.ts`.
+- #6447 `chore(jangar): promote image 146bbce5`
+  - Purpose: promote current main after a Torghut source merge advanced the branch past #6446.
+  - Image tag: `146bbce5`.
+  - Jangar image digest: `sha256:5a333a5d3a631ec2e16a2681b443d3a9309e080bd2216c2756e67f83be0b6157`.
+  - Agents control-plane image digest:
+    `sha256:e2b2a6bc2c5cf7cae253e1dd17b080ff206b1e46fe75d71a3592a039aa9a2675`.
+  - Merge outcome: auto-merged at `2026-05-13T16:13:31Z` as
+    `fc0aaebeddd92dcdbca933aa03426bd8eb630736`.
+  - Rollout check: `jangar-post-deploy-verify` run `25811518735` passed.
+  - CI blocker repeated: `jangar-ci / lint-and-typecheck` run `25811494156` failed on the same account-witness
+    assertion.
 - #6399 `docs(jangar): record control-plane release gate`
-  - Purpose: durable handoff for this verify run.
-  - Change: replaced the earlier #6401/#6409 handoff with this bounded #6414/#6420 release record.
+  - Purpose: durable handoff and repair PR for this verify run.
+  - Change: records the #6440/#6446/#6447 release slice and pins the account-witness timeout regression clock so Jangar
+    promotion CI can return green.
 
 ## Comments and conflicts
 
-- #6414 had no review threads, no requested changes, and no merge conflicts when selected.
-- #6420 had no review threads or requested changes. It auto-merged only after promotion checks were green.
+- #6440 had no review threads, no requested changes, and no merge conflicts when selected.
+- #6446 and #6447 had no review threads or requested changes. They auto-merged after GitOps validation checks passed.
 - Progress comments were kept current with `services/jangar/scripts/codex/codex-progress-comment.ts` after merge and
   rollout state changed.
 - No direct production mutation was made from this shell. All production changes landed through PR merge and GitOps.
 
 ## Deployment evidence
 
-- Argo:
-  - `jangar sync=Synced health=Healthy rev=3b7277516fd31a9d74916202c81d5610e56afc19`
-  - `agents sync=Synced health=Healthy rev=3b7277516fd31a9d74916202c81d5610e56afc19`
-  - `torghut sync=Synced health=Healthy rev=3b7277516fd31a9d74916202c81d5610e56afc19`
-  - `symphony-jangar sync=Synced health=Healthy rev=07da331d95ca0ef2779108a00a877c5e718b2656`
-  - `symphony-torghut sync=Synced health=Healthy rev=07da331d95ca0ef2779108a00a877c5e718b2656`
+- Argo after #6447:
+  - `jangar sync=Synced health=Healthy rev=fc0aaebeddd92dcdbca933aa03426bd8eb630736`
+  - `agents sync=Synced health=Healthy rev=fc0aaebeddd92dcdbca933aa03426bd8eb630736`
+  - `torghut sync=Synced health=Healthy rev=fc0aaebeddd92dcdbca933aa03426bd8eb630736`
 - Workloads:
-  - `deployment/jangar -n jangar`: 1/1 ready, 0 restarts, image
-    `registry.ide-newton.ts.net/lab/jangar:07da331d@sha256:d0a61187c54f063d6f3f875a6760b3202ff8f7733b2f7977ff06a39d1a3e3c90`.
-  - `deployment/agents -n agents`: 1/1 ready, 0 restarts, image
-    `registry.ide-newton.ts.net/lab/jangar-control-plane:07da331d@sha256:ee5c618919f28cdb3f62440f0ef8b280ec18e2fb42b4d784b067af74f3927110`.
-  - `deployment/agents-controllers -n agents`: 2/2 ready, 0 restarts, image
-    `registry.ide-newton.ts.net/lab/jangar:07da331d@sha256:d0a61187c54f063d6f3f875a6760b3202ff8f7733b2f7977ff06a39d1a3e3c90`.
+  - `deployment/jangar -n jangar`: 1/1 ready, image
+    `registry.ide-newton.ts.net/lab/jangar:146bbce5@sha256:5a333a5d3a631ec2e16a2681b443d3a9309e080bd2216c2756e67f83be0b6157`.
+  - `deployment/agents -n agents`: 1/1 ready, image
+    `registry.ide-newton.ts.net/lab/jangar-control-plane:146bbce5@sha256:e2b2a6bc2c5cf7cae253e1dd17b080ff206b1e46fe75d71a3592a039aa9a2675`.
+  - `deployment/agents-controllers -n agents`: 2/2 ready, image
+    `registry.ide-newton.ts.net/lab/jangar:146bbce5@sha256:5a333a5d3a631ec2e16a2681b443d3a9309e080bd2216c2756e67f83be0b6157`.
 - Service health:
+  - `deployment/jangar`, `deployment/agents`, and `deployment/agents-controllers` rollout status succeeded.
   - `http://jangar.jangar.svc.cluster.local/health`: HTTP 200, `status=ok`.
-  - `http://jangar.jangar.svc.cluster.local/ready`: HTTP 200, `status=ok`,
-    `execution_trust=healthy`, `torghut_consumer_evidence=current`, `serving_runtime_proof_cells_healthy=true`.
-  - `http://agents.agents.svc.cluster.local/ready`: HTTP 200, `status=ok`,
-    `execution_trust=healthy`, `torghut_consumer_evidence=current`.
-  - `evidence_pressure_ledger`: present on `/ready`, `schema_version=jangar.evidence-pressure-ledger.v1`,
-    `evidence_mode=observe`, `watch_backoff_policy.state=calm`, and
-    `observed_revision.source_head_sha=07da331d95ca0ef2779108a00a877c5e718b2656`.
-- Post-deploy verifier: `jangar-post-deploy-verify` run `25800868616` passed at `2026-05-13T13:08:12Z`.
-- Events: recent warning events were readiness probes during startup or replacement of old pods. Current Jangar and
-  Agents deployment pods are Running and ready with zero restarts.
+  - `http://jangar.jangar.svc.cluster.local/ready`: HTTP 200, `status=ok`, `torghut_consumer_evidence=current`,
+    `evidence_pressure_ledger=jangar.evidence-pressure-ledger.v1`.
+  - `http://agents.agents.svc.cluster.local/ready`: HTTP 200, `status=ok`, `torghut_consumer_evidence=current`.
+  - Account witness endpoint:
+    `GET /api/torghut/trading/control-plane/quant/account-witness?account=paper&window=15m&timeout_ms=2000`
+    returned `ok=true`, `schema_version=jangar.quant-account-witness.v1`, `aggregate_latest_store=current`,
+    `account_latest_store=empty`, `pipeline_health=missing`, and `max_notional=0`.
+- Events: recent warning events were readiness probes during replacement of the old Jangar pod. Current Jangar and
+  Agents deployments are rolled out and ready.
+
+## Validation
+
+- Reproduced CI failure:
+  - `bun run --cwd services/jangar test -- src/routes/api/torghut/trading/control-plane/quant/-account-witness.test.ts -t "keeps aggregate latest-store timeout advisory"`
+  - Failed before the fix with `expected 'stale' to be 'current'`.
+- Passing local checks after the fix:
+  - `bun run --cwd services/jangar test -- src/routes/api/torghut/trading/control-plane/quant/-account-witness.test.ts -t "keeps aggregate latest-store timeout advisory"`
+  - `bun run --cwd services/jangar test -- src/routes/api/torghut/trading/control-plane/quant/-account-witness.test.ts`
+  - `bunx oxfmt --check services/jangar packages/scripts/src/jangar argocd/applications/jangar`
+  - `bun run --cwd services/jangar lint:oxlint`
+  - `bun run --cwd services/jangar lint:oxlint:type`
+  - `bash -lc 'for name in $(env | cut -d= -f1 | grep -E "^(CODEX_|SWARM_|OWNER_CHANNEL$|PR_NUMBER_PATH$|PR_URL_PATH$|NATS_|JANGAR_|AGENT_PROVIDER|AGENT_RUN)"); do unset "$name"; done; cd services/jangar && bun run test && bunx tsc --noEmit --project tsconfig.paths.json && bun run docs:inventory:check && bun run check:module-sizes'`
+  - `bun run --cwd services/jangar build`
+- Note: the unstripped full test command fails locally because this AgentRun exports release/deployer environment
+  variables that change `scripts/codex/__tests__/codex-implement.test.ts` lane resolution. The clean-env rerun matches
+  CI behavior and passed.
 
 ## Metrics and value gates
 
-- `ready_status_truth`: improved. `/ready` now exposes an evidence pressure ledger bound to the merged source SHA, so
-  release and scheduler decisions can read observe-mode pressure directly.
-- `pr_to_rollout_latency`: 15m24s from #6414 source merge to post-deploy verifier completion; 4m42s from #6420
-  promotion merge to post-deploy verifier completion.
-- `failed_agentrun_rate`: expected improvement is fewer false verify-stage holds from missing pressure/watch-backoff
-  context; the smallest runtime proof in this run is the healthy `/ready` ledger in observe/calm mode after promotion.
+- `ready_status_truth`: improved. `/ready` exposes account-witness and evidence-pressure state directly, including the
+  live degraded trust reason from pre-existing Torghut quant stage freezes.
+- `handoff_evidence_quality`: improved. The handoff now names the exact failed promotion check, failing assertion,
+  deterministic test fix, local validation commands, rollout revision, image digests, and rollback path.
 - `manual_intervention_count`: zero direct production mutations.
-- `handoff_evidence_quality`: progress comments, this rollout doc, NATS updates, and swarm handoff artifacts carry the
-  same merge, rollout, residual-risk, and rollback evidence.
+- `pr_to_rollout_latency`: #6440 source merge to #6446 post-deploy verifier completion was 17m32s. #6447 post-deploy
+  verifier completed 3m33s after the #6447 promotion merge.
+- `failed_agentrun_rate`: expected improvement is fewer verify-stage reruns caused by ambiguous account-scoped quant
+  evidence and by the now-deterministic account-witness timeout regression.
 
 ## Risks and rollback path
 
-- Residual risk: #6420 auto-merged after its required promotion checks were green while post-deploy verification was
-  still running; final post-deploy verification passed before this handoff was recorded.
-- Runtime risk is limited by observe mode. The new pressure ledger reports and gates visibility; it does not widen
-  production mutation behavior by itself.
-- Roll back through GitOps by reverting #6420 to restore the previous `f5ed7394` image. Revert #6414 only if the
-  runtime regression follows the evidence-pressure-ledger implementation rather than the image promotion.
+- Residual risk: #6446 and #6447 promotion PRs are already merged and deployed healthy, but their historical
+  `jangar-ci / lint-and-typecheck` runs are red until this verify fix lands and the next Jangar promotion proves the
+  corrected regression on GitHub.
+- Runtime risk is bounded by zero-notional witness behavior. The live endpoint reports `max_notional=0` and does not
+  clear routeability when account evidence is empty or stale.
+- Pre-existing runtime risk remains: `/ready` reports `execution_trust=degraded` due Torghut quant stage freezes, while
+  Jangar/Agents service readiness and GitOps rollout are healthy.
+- Roll back through GitOps by reverting #6447 to restore image `59037988`, or by reverting #6446 to restore the prior
+  Jangar image. Revert #6440 only if the account-scoped witness implementation itself causes runtime regression.
 - Do not patch live Deployments directly except under an explicit emergency procedure; Argo should remain the source of
   truth.
 
 ## Next action
 
-Monitor the next Jangar verify-stage windows for fewer pressure/watch-backoff ambiguity holds and confirm the ledger
-stays fresh while `evidence_mode=observe`.
+Merge #6399 after green checks, then verify the next Jangar image promotion and rollout so the promotion check history is
+green again with the deterministic account-witness regression.

--- a/docs/agents/rollouts/2026-05-13-jangar-control-plane-verify.md
+++ b/docs/agents/rollouts/2026-05-13-jangar-control-plane-verify.md
@@ -6,153 +6,122 @@ Release engineer: Marco Silva
 
 ## Owner update message
 
-Rollout state is green for the selected Jangar control-plane release lane, with one runtime gate held for evidence.
-I moved or verified the Jangar lane through #6363, #6367, #6378, and #6373 after the earlier #6324, #6330, #6339,
-#6343, and #6349 batch. The latest deployed Jangar image is `45710e0b`: `deployment/jangar` and
-`deployment/agents-controllers` run digest `sha256:1348bdb0571ee61c3c3005186261a422f4bc754bc19380f842577a9e694950c8`,
-and `deployment/agents` runs control-plane digest
-`sha256:533c8be4f98731a49bcf50039559ff2b5eae712280ef074b84711a2824d89cdf`.
+Rollout state is green for the selected Jangar control-plane release slice. Source PR #6414,
+`feat(jangar): add evidence pressure ledger`, merged as `07da331d95ca0ef2779108a00a877c5e718b2656`,
+and promotion PR #6420, `chore(jangar): promote image 07da331d`, merged as
+`3dbaa6d63cd21e6e082be094ab2c8ea1cecc1d40`.
 
-The GitOps and workload rollout gate is green: Argo `jangar` and `agents` are Synced/Healthy, the three workloads are
-available, `jangar /health` returns 200, and the post-deploy verifier for #6378 passed. The business metric that
-improved is `ready_status_truth`, with supporting progress on `pr_to_rollout_latency` and
-`handoff_evidence_quality`. The remaining blocker is not a deployment failure: a pre-existing implement AgentRun on
-the older `5d89ac24` image was evicted for node ephemeral-storage pressure and froze the swarm until
-2026-05-13T09:20:50.975Z, so material actions remain held while `serve_readonly` and `torghut_observe` stay allowed.
+The GitOps and workload rollout gate is green: Argo `jangar`, `agents`, and `torghut` are Synced/Healthy at
+`3b7277516fd31a9d74916202c81d5610e56afc19`, which includes the #6420 promotion commit, and
+`jangar-post-deploy-verify` run `25800868616` passed. Live `jangar`, `agents`, and `agents-controllers` workloads are
+ready on image tag `07da331d`.
+
+`jangar /health`, `jangar /ready`, and `agents /ready` returned HTTP 200. `/ready` reported
+`execution_trust=healthy`, `torghut_consumer_evidence=current`, and a fresh `evidence_pressure_ledger` in observe mode
+with calm watch backoff. The control-plane metric improved is `ready_status_truth`: the runtime now exposes the
+evidence pressure ledger and watch-backoff posture directly on readiness/status, making merge and dispatch gates easier
+to verify without inferring pressure from unrelated symptoms. `pr_to_rollout_latency` was 15m24s from source merge
+(`2026-05-13T12:52:48Z`) to post-deploy verifier completion (`2026-05-13T13:08:12Z`).
 
 ## Governing requirements
 
+- `docs/agents/designs/188-jangar-evidence-pressure-ledger-and-watch-backoff-governor-2026-05-13.md`: publish the
+  Jangar evidence pressure ledger, watch-backoff policy, and deployer handoff in observe mode.
 - `docs/agents/designs/swarm-agentic-mission-architecture-2026-05-08.md`: verify stages must merge only green PRs and
   prove Argo sync, workload readiness, and service health after rollout.
-- `docs/agents/designs/129-jangar-consumer-evidence-leases-and-readiness-decoupling-2026-05-06.md`: governs #6324.
-- `docs/agents/designs/187-jangar-stage-credit-ledger-and-runner-slot-futures-2026-05-13.md`: governs #6330 and #6363.
-- `docs/agents/designs/187-jangar-main-source-ci-retention-and-source-serving-verdicts-2026-05-13.md`: governs #6339.
-- `docs/agents/designs/186-jangar-repair-bid-admission-and-settlement-custody-2026-05-13.md`: governs #6343.
-- `docs/agents/designs/116-jangar-controller-witness-quorum-and-capital-activation-receipts-2026-05-06.md` and
-  `docs/agents/designs/121-jangar-material-action-repair-clearing-lane-and-profit-proof-ledger-2026-05-06.md`:
-  govern #6349.
-- `docs/agents/designs/188-jangar-evidence-pressure-ledger-and-watch-backoff-governor-2026-05-13.md`: governs #6373.
+- Runtime acceptance contract: selected PRs must advance failed AgentRun reduction, PR-to-rollout latency,
+  ready-status truth, manual-intervention reduction, or handoff evidence quality.
+- GitOps safety requirement: no direct production mutation from the local shell; promotion happens through PR merge and
+  Argo reconciliation.
 
 ## PRs touched
 
-- #6324 `feat(jangar): add consumer evidence leases`
-  - Fixed blockers: stale architecture inventory, rebase conflicts, and the Jangar module-size violation.
-  - Merge outcome: merged at 2026-05-13T04:51:12Z as `6596b581321ab05168ed663a506e10e3893043d7`.
-  - Promotion: #6335 `chore(jangar): promote image 6596b581`, post-deploy verifier `25779478472` passed.
-- #6330 `feat(jangar): add stage credit ledger read model`
-  - Fixed blockers: rebased onto #6324/main and preserved the consumer-evidence status helper imports.
-  - Merge outcome: merged at 2026-05-13T05:11:23Z as `97a20bc4f6d2b6d6198372870795ad8ddce54a74`.
-  - Promotion: #6342 `chore(jangar): promote image 97a20bc4`, post-deploy verifier `25780107631` passed.
-- #6339 `feat(jangar): add source-serving verdict status`
-  - Selected because it surfaced source-serving allow/hold/block readiness truth.
-  - Merge outcome: merged at 2026-05-13T05:41:19Z as `99063cb4c14e0c22633f6d2a63391ca59ee6a6b3`.
-  - Promotion: #6347 `chore(jangar): promote image 99063cb4`, post-deploy verifier `25781202876` passed.
-- #6343 `feat(jangar): admit settled torghut repair lots`
-  - Selected because source-serving verdicts named missing repair-bid settlement evidence.
-  - Merge outcome: merged at 2026-05-13T06:04:51Z as `f18b66fdbc4e55bc2ef7177fc17fd86ea8a491b2`.
-  - Promotion: #6350 `chore(jangar): promote image f18b66fd`, post-deploy verifier `25782031603` passed.
-- #6349 `fix(jangar): preserve controller heartbeat witnesses`
-  - Selected because live status still showed controller heartbeat truth as a runtime blocker.
-  - Merge outcome: merged at 2026-05-13T06:28:30Z as `5d89ac24819d84632873caf046cd0a1ff111db95`.
-  - Promotion: #6355 `chore(jangar): promote image 5d89ac24`, post-deploy verifier `25782868775` passed.
-- #6363 `fix(jangar): stamp stage credit launch evidence`
-  - Selected because the active controller `/ready` path was degraded by stale verify-stage evidence even though
-    workloads were serving.
-  - Checks before merge: `agents-ci / validate`, `agents-ci / integration`, `jangar-ci / lint-and-typecheck`,
-    `CI / check_changed_files`, semantic commits, and semantic PR title all passed.
-  - Merge outcome: merged at 2026-05-13T08:04:46Z as `fdc164d70ae04f1d7defc8496c1a233685a3d0c2`.
-  - Mainline build: `jangar-build-push` run `25786518304` passed and produced image tag `fdc164d7`.
-  - Promotion: #6365 `chore(jangar): promote image fdc164d7`, merged as
-    `1feb3fd8b727185dd014ec0f38481d1f2fb4be4b`; post-deploy verifier `25786999729` passed.
-- #6367 `fix(jangar): credit terminal swarm stage completions`
-  - Selected because terminal run freshness accounting directly affects failed-run and ready-status truth.
-  - PR checks before merge: `agents-ci / validate`, `agents-ci / integration`, `jangar-ci / lint-and-typecheck`,
-    `CI / check_changed_files`, semantic commits, and semantic PR title all passed.
-  - Merge outcome: merged at 2026-05-13T08:32:20Z as `45710e0bb070144dc8f7c25bd855221ca3c4e02a`.
-  - Mainline validation: `jangar-build-push` run `25787811627` passed and produced image tag `45710e0b`;
-    `agents-ci` run `25787811625` passed.
-  - Promotion: #6378 `chore(jangar): promote image 45710e0b`, merged as
-    `270bb6740ca9b38d0d38de1020c73719b78bbac0`; `jangar-ci / lint-and-typecheck`, `argo-lint`, `kubeconform`,
-    semantic checks, and post-deploy verifier `25788838577` all passed.
-- #6373 `docs(jangar): define evidence pressure ledger`
-  - Selected because it records the evidence-pressure and watch-backoff governance needed to reduce failed AgentRuns.
-  - Checks before merge: `agents-ci / validate`, `agents-ci / integration`, `jangar-ci / lint-and-typecheck`,
-    `CI / check_changed_files`, semantic commits, and semantic PR title all passed.
-  - Merge outcome: merged at 2026-05-13T09:00:24Z as `3394723b5f07dfc9ff807f5ff29d112eaf6f8c20`.
-- Current residual Jangar PR blocker: #6372 `fix(jangar): consume torghut typed evidence` remains open and not
-  selected for merge because it is conflict-blocked. `git merge-tree origin/main origin/pr-6372` reports a content
-  conflict in `docs/torghut/design-system/v6/index.md`.
+- #6414 `feat(jangar): add evidence pressure ledger`
+  - Purpose: add `evidence_pressure_ledger` to control-plane status and `/ready`, including watch reason-code aging,
+    pressure summaries, UI rendering, docs, and regressions.
+  - Merge gate: non-draft, no review threads, no requested changes, CLEAN/MERGEABLE, and all visible checks green or
+    intentionally skipped before merge.
+  - Checks before merge: `jangar-ci / lint-and-typecheck / run`, `agents-ci / validate`, `agents-ci / integration`,
+    `CI / check_changed_files`, semantic title, and semantic commits passed; unrelated matrix/deploy enable jobs were
+    skipped.
+  - Merge outcome: squash-merged at `2026-05-13T12:52:48Z` as
+    `07da331d95ca0ef2779108a00a877c5e718b2656`.
+  - Post-merge checks: `Docker Build and Push` run `25800308156`, `jangar-build-push` run `25800308052`,
+    `agents-ci` run `25800308019`, and `jangar-release` run `25800808195` passed.
+- #6420 `chore(jangar): promote image 07da331d`
+  - Purpose: promote the #6414 image through GitOps.
+  - Image tag: `07da331d`.
+  - Jangar image digest: `sha256:d0a61187c54f063d6f3f875a6760b3202ff8f7733b2f7977ff06a39d1a3e3c90`.
+  - Agents control-plane image digest:
+    `sha256:ee5c618919f28cdb3f62440f0ef8b280ec18e2fb42b4d784b067af74f3927110`.
+  - Promotion checks: `argo-lint / lint`, `kubeconform / validate`, `jangar-ci / lint-and-typecheck / run`, semantic
+    title, semantic commits, and Jangar deploy automerge enable check passed; unrelated deploy enable jobs skipped.
+  - Merge outcome: auto-merged at `2026-05-13T13:03:30Z` as
+    `3dbaa6d63cd21e6e082be094ab2c8ea1cecc1d40`.
+- #6399 `docs(jangar): record control-plane release gate`
+  - Purpose: durable handoff for this verify run.
+  - Change: replaced the earlier #6401/#6409 handoff with this bounded #6414/#6420 release record.
 
 ## Comments and conflicts
 
-- Progress comments were kept current with `services/jangar/scripts/codex/codex-progress-comment.ts` on selected PRs,
-  including #6363 and this audit PR.
-- #6324 and #6330 required real conflict/module-size fixes before merge.
-- #6363, #6367, and #6373 had no blocking review threads when selected and had green PR checks before merge.
-- #6365 and #6378 promotion PRs were generated by release automation. In both cases the deploy automerge path merged
-  before the non-required `jangar-ci / lint-and-typecheck` check completed; those checks later passed, and each
-  post-deploy verifier passed. This is a residual branch-protection risk to track separately.
-- No direct production mutation was made from this shell. Promotion was via merged PRs and GitOps reconciliation.
+- #6414 had no review threads, no requested changes, and no merge conflicts when selected.
+- #6420 had no review threads or requested changes. It auto-merged only after promotion checks were green.
+- Progress comments were kept current with `services/jangar/scripts/codex/codex-progress-comment.ts` after merge and
+  rollout state changed.
+- No direct production mutation was made from this shell. All production changes landed through PR merge and GitOps.
 
 ## Deployment evidence
 
-- Final Jangar promotion:
-  - #6378 merged at 2026-05-13T08:53:45Z as `270bb6740ca9b38d0d38de1020c73719b78bbac0`.
-  - #6378 `jangar-ci / lint-and-typecheck` passed at 2026-05-13T08:55:53Z.
-  - `jangar-post-deploy-verify` run `25788838577` passed from 2026-05-13T08:53:52Z to 08:56:35Z.
-- Argo state after the rollout:
-  - `agents`: Synced, Healthy, operation Succeeded.
-  - `jangar`: Synced, Healthy, operation Succeeded.
-- Workload state:
-  - `deployment/jangar -n jangar`: 1/1 available on
-    `registry.ide-newton.ts.net/lab/jangar:45710e0b@sha256:1348bdb0571ee61c3c3005186261a422f4bc754bc19380f842577a9e694950c8`.
-  - `deployment/agents -n agents`: 1/1 available on
-    `registry.ide-newton.ts.net/lab/jangar-control-plane:45710e0b@sha256:533c8be4f98731a49bcf50039559ff2b5eae712280ef074b84711a2824d89cdf`.
-  - `deployment/agents-controllers -n agents`: 2/2 available on
-    `registry.ide-newton.ts.net/lab/jangar:45710e0b@sha256:1348bdb0571ee61c3c3005186261a422f4bc754bc19380f842577a9e694950c8`.
+- Argo:
+  - `jangar sync=Synced health=Healthy rev=3b7277516fd31a9d74916202c81d5610e56afc19`
+  - `agents sync=Synced health=Healthy rev=3b7277516fd31a9d74916202c81d5610e56afc19`
+  - `torghut sync=Synced health=Healthy rev=3b7277516fd31a9d74916202c81d5610e56afc19`
+  - `symphony-jangar sync=Synced health=Healthy rev=07da331d95ca0ef2779108a00a877c5e718b2656`
+  - `symphony-torghut sync=Synced health=Healthy rev=07da331d95ca0ef2779108a00a877c5e718b2656`
+- Workloads:
+  - `deployment/jangar -n jangar`: 1/1 ready, 0 restarts, image
+    `registry.ide-newton.ts.net/lab/jangar:07da331d@sha256:d0a61187c54f063d6f3f875a6760b3202ff8f7733b2f7977ff06a39d1a3e3c90`.
+  - `deployment/agents -n agents`: 1/1 ready, 0 restarts, image
+    `registry.ide-newton.ts.net/lab/jangar-control-plane:07da331d@sha256:ee5c618919f28cdb3f62440f0ef8b280ec18e2fb42b4d784b067af74f3927110`.
+  - `deployment/agents-controllers -n agents`: 2/2 ready, 0 restarts, image
+    `registry.ide-newton.ts.net/lab/jangar:07da331d@sha256:d0a61187c54f063d6f3f875a6760b3202ff8f7733b2f7977ff06a39d1a3e3c90`.
 - Service health:
   - `http://jangar.jangar.svc.cluster.local/health`: HTTP 200, `status=ok`.
-  - `http://agents.agents.svc.cluster.local/ready`: HTTP 200, with runtime status `degraded` because execution trust
-    is blocked by the current swarm freeze.
-- Runtime status after rollout:
-  - Swarm phase: `Frozen`, `Ready=False`, frozen until `2026-05-13T09:20:50.975Z`.
-  - Freeze evidence: `jangar-control-plane-implement-sched-8b575` failed with `BackoffLimitExceeded`.
-  - Pod evidence: attempt 2 ran old image `5d89ac24` and was evicted because node ephemeral storage was low; the pod
-    used 3925420Ki ephemeral storage with no request.
-  - The failure is a runtime capacity/runner resource blocker, not a failed GitOps rollout of `45710e0b`.
-- Events:
-  - Recent warnings are rollout-time readiness probe failures on old or starting pods and the old implement-run
-    eviction. Current Jangar and agents deployments are available.
+  - `http://jangar.jangar.svc.cluster.local/ready`: HTTP 200, `status=ok`,
+    `execution_trust=healthy`, `torghut_consumer_evidence=current`, `serving_runtime_proof_cells_healthy=true`.
+  - `http://agents.agents.svc.cluster.local/ready`: HTTP 200, `status=ok`,
+    `execution_trust=healthy`, `torghut_consumer_evidence=current`.
+  - `evidence_pressure_ledger`: present on `/ready`, `schema_version=jangar.evidence-pressure-ledger.v1`,
+    `evidence_mode=observe`, `watch_backoff_policy.state=calm`, and
+    `observed_revision.source_head_sha=07da331d95ca0ef2779108a00a877c5e718b2656`.
+- Post-deploy verifier: `jangar-post-deploy-verify` run `25800868616` passed at `2026-05-13T13:08:12Z`.
+- Events: recent warning events were readiness probes during startup or replacement of old pods. Current Jangar and
+  Agents deployment pods are Running and ready with zero restarts.
 
 ## Metrics and value gates
 
-- `failed_agentrun_rate`: no Jangar AgentRun created after #6363 merged has failed. Counting by finish time, one
-  pre-existing implement run created at 2026-05-13T07:00:05Z failed at 2026-05-13T08:56:46.964Z because the old
-  runner pod was evicted for node ephemeral-storage pressure.
-- `pr_to_rollout_latency`: #6367 merged at 2026-05-13T08:32:20Z and #6378 post-deploy verification completed at
-  2026-05-13T08:56:35Z, for about 24m15s from source merge to verified rollout. #6363 took about 15m47s from merge
-  to post-deploy verification.
-- `ready_status_truth`: improved because stale terminal-stage accounting and stage-credit launch evidence are now
-  explicit. The runtime surface is not falsely green: it reports the swarm freeze and material-action holds.
-- `manual_intervention_count`: zero direct cluster mutations from the local shell.
-- `handoff_evidence_quality`: PR progress comments, this rollout doc, the mission ledger, the verify handoff, and NATS
-  updates carry the same merge/rollout/runtime blocker evidence.
+- `ready_status_truth`: improved. `/ready` now exposes an evidence pressure ledger bound to the merged source SHA, so
+  release and scheduler decisions can read observe-mode pressure directly.
+- `pr_to_rollout_latency`: 15m24s from #6414 source merge to post-deploy verifier completion; 4m42s from #6420
+  promotion merge to post-deploy verifier completion.
+- `failed_agentrun_rate`: expected improvement is fewer false verify-stage holds from missing pressure/watch-backoff
+  context; the smallest runtime proof in this run is the healthy `/ready` ledger in observe/calm mode after promotion.
+- `manual_intervention_count`: zero direct production mutations.
+- `handoff_evidence_quality`: progress comments, this rollout doc, NATS updates, and swarm handoff artifacts carry the
+  same merge, rollout, residual-risk, and rollback evidence.
 
-## Rollback path
+## Risks and rollback path
 
-- Roll back through GitOps by reverting the relevant feature PR and its promotion PR, not by mutating live workloads
-  directly.
-- Latest full Jangar image rollback target: revert #6378 or promote the prior known-good `fdc164d7` image from #6365.
-- Feature-level rollback options:
-  - Revert #6367 if terminal-run freshness accounting regresses swarm status.
-  - Revert #6363 if stage-credit launch evidence regresses controller readiness.
-  - Revert #6349, #6343, #6339, #6330, or #6324 in reverse order if their status surfaces regress.
-- Runtime safety fallback is already conservative: dispatch, paper, and live actions are held or blocked while Torghut
-  route/settlement evidence and source-serving receipts are missing or while the swarm is frozen.
+- Residual risk: #6420 auto-merged after its required promotion checks were green while post-deploy verification was
+  still running; final post-deploy verification passed before this handoff was recorded.
+- Runtime risk is limited by observe mode. The new pressure ledger reports and gates visibility; it does not widen
+  production mutation behavior by itself.
+- Roll back through GitOps by reverting #6420 to restore the previous `f5ed7394` image. Revert #6414 only if the
+  runtime regression follows the evidence-pressure-ledger implementation rather than the image promotion.
+- Do not patch live Deployments directly except under an explicit emergency procedure; Argo should remain the source of
+  truth.
 
 ## Next action
 
-Smallest blocker preventing full business-metric improvement: stop implement-run evictions by adding an evidence-backed
-runner ephemeral-storage request/limit or workspace cleanup path, then re-run the implement stage after the freeze
-expires. The next PR blocker is #6372, which needs a conflict resolution in
-`docs/torghut/design-system/v6/index.md` before its typed Torghut evidence intake can proceed.
+Monitor the next Jangar verify-stage windows for fewer pressure/watch-backoff ambiguity holds and confirm the ledger
+stays fresh while `evidence_mode=observe`.

--- a/services/jangar/src/routes/api/torghut/trading/control-plane/quant/-account-witness.test.ts
+++ b/services/jangar/src/routes/api/torghut/trading/control-plane/quant/-account-witness.test.ts
@@ -121,6 +121,8 @@ describe('getQuantAccountWitnessHandler', () => {
   })
 
   it('keeps aggregate latest-store timeout advisory when scoped account evidence is current', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-13T15:00:00.000Z'))
     process.env.JANGAR_TORGHUT_QUANT_HEALTH_MISSING_UPDATE_SECONDS = '3600'
     const { getQuantAccountWitnessHandler } = await import('./account-witness')
 
@@ -157,11 +159,13 @@ describe('getQuantAccountWitnessHandler', () => {
       },
     ])
 
-    const response = await getQuantAccountWitnessHandler(
+    const responsePromise = getQuantAccountWitnessHandler(
       new Request(
         'http://localhost/api/torghut/trading/control-plane/quant/account-witness?account=paper&window=15m&timeout_ms=1',
       ),
     )
+    await vi.advanceTimersByTimeAsync(1)
+    const response = await responsePromise
 
     expect(response.status).toBe(200)
     const body = await response.json()


### PR DESCRIPTION
## Summary

- Pins the account-witness timeout regression to the intended 2026-05-13 fixture clock and advances the explicit 1 ms timeout timer.
- Records the #6440 source merge, #6446/#6447 promotions, rollout evidence, failed promotion CI signal, and rollback path.
- Keeps the Jangar release handoff scoped to the current blocker: healthy GitOps rollout with red historical promotion CI until this fix lands.

## Related Issues

Refs #6440, #6446, #6447.

## Testing

- `bun run --cwd services/jangar test -- src/routes/api/torghut/trading/control-plane/quant/-account-witness.test.ts -t "keeps aggregate latest-store timeout advisory"`
- `bun run --cwd services/jangar test -- src/routes/api/torghut/trading/control-plane/quant/-account-witness.test.ts`
- `bunx oxfmt --check services/jangar packages/scripts/src/jangar argocd/applications/jangar`
- `bun run --cwd services/jangar lint:oxlint`
- `bun run --cwd services/jangar lint:oxlint:type`
- `bash -lc 'for name in $(env | cut -d= -f1 | grep -E "^(CODEX_|SWARM_|OWNER_CHANNEL$|PR_NUMBER_PATH$|PR_URL_PATH$|NATS_|JANGAR_|AGENT_PROVIDER|AGENT_RUN)"); do unset "$name"; done; cd services/jangar && bun run test && bunx tsc --noEmit --project tsconfig.paths.json && bun run docs:inventory:check && bun run check:module-sizes'`
- `bun run --cwd services/jangar build`
- `bunx oxfmt --check services/jangar/src/routes/api/torghut/trading/control-plane/quant/-account-witness.test.ts docs/agents/rollouts/2026-05-13-jangar-control-plane-verify.md`

## Screenshots (if applicable)

N/A.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
