### PR TITLE
fix(jangar): attach torghut stage custody evidence

### DIFF
--- a/docs/agents/runbooks.md
+++ b/docs/agents/runbooks.md
@@ -135,6 +135,7 @@ curl -fsS http://localhost:8080/api/agents/control-plane/status?namespace=agents
 curl -fsS http://localhost:8080/api/agents/control-plane/status?namespace=agents | jq '.negative_evidence_router'
 curl -fsS http://localhost:8080/api/agents/control-plane/status?namespace=agents | jq '.action_slo_budgets'
 curl -fsS http://localhost:8080/api/agents/control-plane/status?namespace=agents | jq '.torghut_action_slo_budgets'
+curl -fsS http://localhost:8080/api/agents/control-plane/status?namespace=agents | jq '.torghut_consumer_evidence | {evidence_clock_arbiter_id,evidence_clock_custody_status,evidence_clock_custody_ref}'
 curl -fsS http://localhost:8080/api/agents/control-plane/status?namespace=agents | jq '.ready_action_exchange'
 curl -fsS http://localhost:8080/api/agents/control-plane/status?namespace=agents | jq '.action_custody_receipts[] | {action_class,decision,blocking_debt_classes,receipt_id}'
 curl -fsS http://localhost:8080/api/agents/control-plane/status?namespace=agents | jq '.dependency_verdict_exchange | {status,torghut_route_warrant_ref,repair_only_action_classes,held_action_classes,blocked_action_classes}'
@@ -171,6 +172,10 @@ Expected outcomes:
 - `torghut_action_slo_budgets` is the filtered consumer view for Torghut sizing decisions. Read-only
   `torghut_observe` can remain allowed while stale market context, open quant alerts, or readiness debt hold/block
   paper and live capital budgets.
+- `torghut_consumer_evidence.evidence_clock_custody_status` follows design doc 188. If the Torghut evidence-clock
+  arbiter omits a Jangar custody ref but Jangar has a fresh local Torghut stage-clearance packet, the status is
+  normalized to `blocked` or `stale` with `evidence_clock_custody_ref` set to that packet id. `missing` means no local
+  packet is available. Capital actions still require `allow` verdicts and non-zero Torghut notional before widening.
 - `repair_warrant_exchange.mode` is `observe`; active warrants are zero-notional repair permissions only and include
   `warrant_id`, `repair_code`, `admission_state`, `fresh_until`, validation refs, closure requirements, and rollback
   target. Paper/live gates must remain held or blocked until the matching repair warrant closes inside a fresh evidence

--- a/services/jangar/README.md
+++ b/services/jangar/README.md
@@ -513,6 +513,20 @@ Rollback: ignore `ready_action_exchange` and `action_custody_receipts` consumers
 material-action verdicts, route-stability escrow, repair-warrant exchange, runtime-admission passports, and Torghut
 proof-floor/notional gates remain the fallback safety boundary.
 
+## Torghut stage-custody evidence
+
+Design doc `docs/agents/designs/188-jangar-typed-torghut-evidence-admission-and-repair-dispatch-2026-05-13.md`
+requires Jangar to expose typed Torghut custody evidence from the non-recursive `/trading/consumer-evidence` route.
+When Torghut reports an evidence-clock arbiter but does not publish a `required_jangar_custody_ref`, control-plane
+status attaches Jangar's current local `stage_clearance_packets[]` entry for the Torghut paper-capital lane to
+`torghut_consumer_evidence.evidence_clock_custody_*`. A fresh held packet is reported as blocked custody with the
+packet id; only absence of a local packet stays `missing`.
+
+This is a status normalization, not a capital override. Paper and live Torghut actions still use material verdicts,
+stage-clearance packets, repair warrants, and `max_notional=0` as their safety boundary. Rollback is to ignore the
+normalized `evidence_clock_custody_*` fields or revert the attachment helper; the existing Torghut proof-floor and
+notional gates continue to hold unsafe capital actions.
+
 ## Workspace storage proof
 
 The supporting-primitives controller reconciles `Workspace` CRs by creating and reading the backing

--- a/services/jangar/src/server/__tests__/control-plane-status.test.ts
+++ b/services/jangar/src/server/__tests__/control-plane-status.test.ts
@@ -1141,6 +1141,94 @@ describe('control-plane status', () => {
     expect(status.torghut_consumer_evidence.status).toBe('disabled')
   })
 
+  it('attaches Torghut stage-clearance custody before publishing material status', async () => {
+    process.env.JANGAR_SOURCE_HEAD_SHA = '99470fcfa0000000000000000000000000000000'
+    process.env.JANGAR_GITOPS_REVISION = '99470fcfa0000000000000000000000000000000'
+    setRolloutDeploymentList(
+      [healthyRolloutDeployment, healthyAgentsControllersRolloutDeployment],
+      [healthyRuntimePod()],
+    )
+
+    const status = await buildStatus(
+      {
+        namespace: 'agents',
+        grpc: {
+          enabled: true,
+          address: '127.0.0.1:50051',
+          status: 'healthy',
+          message: '',
+        },
+      },
+      {
+        now: () => new Date('2026-05-13T06:00:30.000Z'),
+        getHeartbeat: createHeartbeatResolver(),
+        getAgentsControllerHealth: () => healthyController,
+        getSupportingControllerHealth: () => healthyController,
+        getOrchestrationControllerHealth: () => healthyController,
+        resolveTemporalAdapter: async () => buildTemporalAdapter(),
+        checkDatabase: async () => buildDatabaseStatus(),
+        getWatchReliabilitySummary: () => watchReliabilityHealthy,
+        getWorkflowsReliabilityStatus: async () => buildWorkflowsReliabilityStatus(),
+        resolveTorghutConsumerEvidence: async () => ({
+          status: {
+            status: 'current',
+            endpoint: 'http://torghut/trading/consumer-evidence',
+            receipt_id: 'torghut-route-proven-profit:clock-custody',
+            generated_at: '2026-05-13T06:00:00.000Z',
+            fresh_until: '2026-05-13T06:02:00.000Z',
+            candidate_id: null,
+            dataset_snapshot_ref: null,
+            max_notional: '0',
+            decision: 'repair_only',
+            reason_codes: [],
+            message: 'current',
+            evidence_clock_arbiter_id: 'evidence-clock-arbiter:clock-custody',
+            evidence_clock_state: 'current',
+            evidence_clock_custody_status: 'missing',
+            evidence_clock_custody_ref: null,
+            routeable_profit_candidate_exchange_id: 'routeable-profit-candidate-exchange:clock-custody',
+            routeable_exchange_routeable_candidate_count: 0,
+            routeable_exchange_zero_notional_repair_lot_ids: ['evidence-clock-repair-lot:stage-custody'],
+            routeable_exchange_rejected_candidate_count: 1,
+          },
+          negativeEvidence: {
+            readiness_status: 'degraded',
+            paper_settlement_clean: false,
+            consumer_evidence_receipt_id: 'torghut-route-proven-profit:clock-custody',
+            consumer_evidence_status: 'current',
+            consumer_evidence_fresh_until: '2026-05-13T06:02:00.000Z',
+            consumer_evidence_reason_codes: [],
+            evidence_clock_arbiter_id: 'evidence-clock-arbiter:clock-custody',
+            evidence_clock_status: 'current',
+            evidence_clock_custody_status: 'missing',
+            evidence_clock_custody_ref: null,
+            evidence_clock_custody_reason_codes: ['evidence_clock_custody_receipt_missing'],
+            routeable_profit_candidate_exchange_id: 'routeable-profit-candidate-exchange:clock-custody',
+            routeable_exchange_zero_notional_repair_lot_ids: ['evidence-clock-repair-lot:stage-custody'],
+            routeable_exchange_routeable_candidate_count: 0,
+            routeable_exchange_rejected_candidate_count: 1,
+          },
+        }),
+      },
+    )
+
+    const torghutPaperPacket = status.stage_clearance_packets.find(
+      (packet) => packet.stage === 'torghut' && packet.action_class === 'paper_canary',
+    )
+
+    expect(torghutPaperPacket).toMatchObject({
+      decision: 'hold',
+      max_notional: 0,
+    })
+    expect(status.torghut_consumer_evidence).toMatchObject({
+      evidence_clock_arbiter_id: 'evidence-clock-arbiter:clock-custody',
+      evidence_clock_custody_status: 'blocked',
+      evidence_clock_custody_ref: torghutPaperPacket?.packet_id,
+    })
+    expect(torghutPaperPacket?.reason_codes).not.toContain('evidence_clock_custody_missing')
+    expect(torghutPaperPacket?.reason_codes).toEqual(expect.arrayContaining(['evidence_clock_custody_blocked']))
+  })
+
   it('projects clearance market authority splits while holding normal dispatch', async () => {
     setRolloutDeploymentList(
       [unavailableAgentsRolloutDeployment, healthyAgentsControllersRolloutDeployment],

--- a/services/jangar/src/server/__tests__/control-plane-torghut-consumer-evidence.test.ts
+++ b/services/jangar/src/server/__tests__/control-plane-torghut-consumer-evidence.test.ts
@@ -3,7 +3,9 @@ import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
+import type { StageClearancePacket } from '~/data/agents-control-plane'
 import { resolveTorghutConsumerEvidence } from '~/server/control-plane-torghut-consumer-evidence'
+import { attachStageClearanceCustodyToTorghutEvidence } from '~/server/control-plane-torghut-stage-custody'
 
 const REPO_ROOT = fileURLToPath(new URL('../../../../../', import.meta.url))
 
@@ -422,6 +424,87 @@ describe('control-plane Torghut consumer evidence', () => {
       consumer_evidence_status: 'route_missing',
       consumer_evidence_reason_codes: ['torghut_consumer_evidence_route_missing'],
       paper_settlement_clean: false,
+    })
+  })
+
+  it('attaches a local Torghut stage-clearance packet as typed custody evidence', () => {
+    const packet: StageClearancePacket = {
+      schema_version: 'jangar.stage-clearance-packet.v1',
+      packet_id: 'stage-clearance:torghut:paper_canary:fresh-hold',
+      generated_at: '2026-05-13T06:00:00.000Z',
+      fresh_until: '2026-05-13T06:02:00.000Z',
+      namespace: 'agents',
+      swarm_name: 'jangar-control-plane',
+      stage: 'torghut',
+      action_class: 'paper_canary',
+      governing_requirement_refs: [
+        'docs/agents/designs/188-jangar-typed-torghut-evidence-admission-and-repair-dispatch-2026-05-13.md',
+      ],
+      source_rollout_truth_ref: 'source-rollout-truth-exchange:test',
+      controller_witness_ref: 'controller-witness:test',
+      agentrun_ingestion_ref: 'agentrun-ingestion:test',
+      execution_trust_ref: 'execution-trust:test',
+      material_action_verdict_ref: 'material-action-verdict:paper_canary:test',
+      route_stability_ref: 'route-stability:test',
+      torghut_consumer_evidence_ref: 'torghut-route-proven-profit:test',
+      dependency_verdict_ref: null,
+      dependency_verdict_decision: null,
+      failure_domain_leases: [],
+      provider_capacity_ref: null,
+      decision: 'hold',
+      max_launches: 0,
+      max_notional: 0,
+      ttl_seconds: 120,
+      reason_codes: ['torghut_max_notional_zero'],
+      required_repair_action: 'close Torghut zero-notional repair blockers',
+      rollback_target:
+        'set JANGAR_STAGE_CLEARANCE_ENFORCEMENT=shadow and fall back to material action verdicts plus runtime admission passports',
+    }
+
+    const result = attachStageClearanceCustodyToTorghutEvidence(
+      {
+        status: {
+          status: 'current',
+          endpoint: 'http://torghut/trading/consumer-evidence',
+          receipt_id: 'torghut-route-proven-profit:test',
+          generated_at: '2026-05-13T06:00:00.000Z',
+          fresh_until: '2026-05-13T06:02:00.000Z',
+          candidate_id: null,
+          dataset_snapshot_ref: null,
+          max_notional: '0',
+          reason_codes: [],
+          message: 'current',
+          evidence_clock_arbiter_id: 'evidence-clock-arbiter:test',
+          evidence_clock_custody_status: 'missing',
+          evidence_clock_custody_ref: null,
+        },
+        negativeEvidence: {
+          readiness_status: 'degraded',
+          paper_settlement_clean: false,
+          consumer_evidence_receipt_id: 'torghut-route-proven-profit:test',
+          consumer_evidence_status: 'current',
+          consumer_evidence_fresh_until: '2026-05-13T06:02:00.000Z',
+          consumer_evidence_reason_codes: [],
+          evidence_clock_arbiter_id: 'evidence-clock-arbiter:test',
+          evidence_clock_status: 'current',
+          evidence_clock_custody_status: 'missing',
+          evidence_clock_custody_ref: null,
+          evidence_clock_custody_reason_codes: ['evidence_clock_custody_receipt_missing'],
+        },
+      },
+      [packet],
+      new Date('2026-05-13T06:00:30.000Z'),
+    )
+
+    expect(result.attached).toBe(true)
+    expect(result.resolution.status).toMatchObject({
+      evidence_clock_custody_status: 'blocked',
+      evidence_clock_custody_ref: 'stage-clearance:torghut:paper_canary:fresh-hold',
+    })
+    expect(result.resolution.negativeEvidence).toMatchObject({
+      evidence_clock_custody_status: 'blocked',
+      evidence_clock_custody_ref: 'stage-clearance:torghut:paper_canary:fresh-hold',
+      evidence_clock_custody_reason_codes: ['evidence_clock_custody_stage_clearance_hold'],
     })
   })
 

--- a/services/jangar/src/server/control-plane-negative-evidence-router-torghut.ts
+++ b/services/jangar/src/server/control-plane-negative-evidence-router-torghut.ts
@@ -67,7 +67,6 @@ export const addTorghutEvidenceClockNegativeEvidence = (input: {
   const evidenceClockRefs = uniqueStrings([
     input.torghut.evidence_clock_arbiter_id ?? '',
     input.torghut.routeable_profit_candidate_exchange_id ?? '',
-    input.torghut.evidence_clock_custody_ref ?? '',
     ...(input.torghut.routeable_exchange_zero_notional_repair_lot_ids ?? []),
   ])
   const refs = evidenceClockRefs.length > 0 ? evidenceClockRefs : [input.consumerEvidenceRef]

--- a/services/jangar/src/server/control-plane-negative-evidence-router.ts
+++ b/services/jangar/src/server/control-plane-negative-evidence-router.ts
@@ -466,7 +466,13 @@ const buildRequiredRepairs = (reasons: string[]) =>
     reasons.map((reason) => {
       if (reason.includes('market_context')) return 'refresh Torghut market-context snapshots'
       if (reason.includes('quant_alert')) return 'resolve or supersede open quant alerts'
-      if (reason.includes('evidence_clock_custody')) return 'attach fresh Torghut stage-custody evidence'
+      if (
+        reason.includes('evidence_clock_custody_missing') ||
+        reason.includes('evidence_clock_custody_receipt_missing')
+      )
+        return 'attach fresh Torghut stage-custody evidence'
+      if (reason.includes('evidence_clock_custody_stale')) return 'refresh Torghut stage-custody evidence'
+      if (reason.includes('evidence_clock_custody')) return 'settle Torghut stage-custody hold'
       if (reason.includes('evidence_clock')) return 'repair Torghut evidence-clock split before widening'
       if (reason.includes('torghut_readiness')) return 'restore Torghut readiness before capital action'
       if (reason.includes('watch_reliability')) return 'stabilize controller watch streams'

--- a/services/jangar/src/server/control-plane-status.ts
+++ b/services/jangar/src/server/control-plane-status.ts
@@ -52,7 +52,11 @@ import {
   resolveSourceRolloutTruthEnvironment,
 } from '~/server/control-plane-source-rollout-truth-exchange'
 import { buildSourceServingContractVerdictExchange } from '~/server/control-plane-source-serving-contract-verdict'
-import { resolveTorghutConsumerEvidence } from '~/server/control-plane-torghut-consumer-evidence'
+import {
+  resolveTorghutConsumerEvidence,
+  type TorghutConsumerEvidenceResolution,
+} from '~/server/control-plane-torghut-consumer-evidence'
+import { attachStageClearanceCustodyToTorghutEvidence } from '~/server/control-plane-torghut-stage-custody'
 import type {
   AgentRunIngestionStatus,
   ControlPlaneStatus,
@@ -485,42 +489,85 @@ export const buildControlPlaneStatus = async (
     watchReliabilityBlockRestartsThreshold,
     executionTrust: executionTrust.executionTrust,
   })
-  const torghutConsumerEvidence = await (deps.resolveTorghutConsumerEvidence ?? resolveTorghutConsumerEvidence)(now)
-  const repairBidAdmission = buildDefaultRepairBidAdmissionState(now, options.namespace, torghutConsumerEvidence.status)
-  const negativeEvidenceRouter = buildNegativeEvidenceRouterStatus({
-    now,
-    namespace: options.namespace,
-    service,
-    workflows,
-    watchReliability: watchReliabilityStatus,
-    agentRunIngestion,
-    database,
-    rolloutHealth,
-    dependencyQuorum,
-    failureDomainLeases,
-    empiricalServices,
-    executionTrust: executionTrust.executionTrust,
-    runtimeKits: runtimeAdmission.runtimeKits,
-    controllerWitness,
-    torghut: torghutConsumerEvidence.negativeEvidence,
-  })
   const sourceRolloutTruthEnvironment = resolveSourceRolloutTruthEnvironment()
-  const sourceRolloutTruthExchange = buildSourceRolloutTruthExchange({
+  const buildMaterialStatus = async (torghutConsumerEvidence: TorghutConsumerEvidenceResolution) => {
+    const negativeEvidenceRouter = buildNegativeEvidenceRouterStatus({
+      now,
+      namespace: options.namespace,
+      service,
+      workflows,
+      watchReliability: watchReliabilityStatus,
+      agentRunIngestion,
+      database,
+      rolloutHealth,
+      dependencyQuorum,
+      failureDomainLeases,
+      empiricalServices,
+      executionTrust: executionTrust.executionTrust,
+      runtimeKits: runtimeAdmission.runtimeKits,
+      controllerWitness,
+      torghut: torghutConsumerEvidence.negativeEvidence,
+    })
+    const sourceRolloutTruthExchange = buildSourceRolloutTruthExchange({
+      now,
+      namespace: options.namespace,
+      service,
+      sourceHeadSha: sourceRolloutTruthEnvironment.sourceHeadSha,
+      gitopsRevision: sourceRolloutTruthEnvironment.gitopsRevision,
+      runtimeKits: runtimeAdmission.runtimeKits,
+      kubernetesEvidence: failureDomainKubernetesEvidence,
+      controllerWitness,
+      routeProbe,
+      database,
+      watchReliability: watchReliabilityStatus,
+      rolloutHealth,
+      actionSloBudgets: negativeEvidenceRouter.budgets,
+      torghutActionSloBudgets: negativeEvidenceRouter.torghutBudgets,
+    })
+    const materialArtifacts = await buildControlPlaneMaterialActionArtifacts({
+      now,
+      namespace: options.namespace,
+      service,
+      kube: kubeGateway,
+      agentRunIngestion,
+      admissionPassports: runtimeAdmission.admissionPassports,
+      dependencyQuorum,
+      workflows,
+      negativeEvidenceRouter,
+      reconciledActionClocks,
+      rolloutHealth,
+      controllerWitness,
+      database,
+      watchReliability: watchReliabilityStatus,
+      empiricalServices,
+      sourceRolloutTruthExchange,
+      failureDomainLeases,
+      executionTrust,
+      routeProbe,
+      torghutConsumerEvidence: torghutConsumerEvidence.status,
+      resolveRepairScheduleAttempts: deps.resolveRepairScheduleAttempts,
+    })
+
+    return { negativeEvidenceRouter, sourceRolloutTruthExchange, materialArtifacts }
+  }
+
+  let torghutConsumerEvidence = await (deps.resolveTorghutConsumerEvidence ?? resolveTorghutConsumerEvidence)(now)
+  let materialStatus = await buildMaterialStatus(torghutConsumerEvidence)
+  const attachedStageCustody = attachStageClearanceCustodyToTorghutEvidence(
+    torghutConsumerEvidence,
+    materialStatus.materialArtifacts.stageClearancePackets,
     now,
-    namespace: options.namespace,
-    service,
-    sourceHeadSha: sourceRolloutTruthEnvironment.sourceHeadSha,
-    gitopsRevision: sourceRolloutTruthEnvironment.gitopsRevision,
-    runtimeKits: runtimeAdmission.runtimeKits,
-    kubernetesEvidence: failureDomainKubernetesEvidence,
-    controllerWitness,
-    routeProbe,
-    database,
-    watchReliability: watchReliabilityStatus,
-    rolloutHealth,
-    actionSloBudgets: negativeEvidenceRouter.budgets,
-    torghutActionSloBudgets: negativeEvidenceRouter.torghutBudgets,
-  })
+  )
+  if (attachedStageCustody.attached) {
+    torghutConsumerEvidence = attachedStageCustody.resolution
+    materialStatus = await buildMaterialStatus(torghutConsumerEvidence)
+    torghutConsumerEvidence = attachStageClearanceCustodyToTorghutEvidence(
+      torghutConsumerEvidence,
+      materialStatus.materialArtifacts.stageClearancePackets,
+      now,
+    ).resolution
+  }
+  const { negativeEvidenceRouter, sourceRolloutTruthExchange } = materialStatus
   const {
     repairWarrantExchange,
     materialActionVerdictEpoch,
@@ -532,29 +579,8 @@ export const buildControlPlaneStatus = async (
     dependencyVerdictExchange,
     clearanceMarketLedger,
     stageCreditLedger,
-  } = await buildControlPlaneMaterialActionArtifacts({
-    now,
-    namespace: options.namespace,
-    service,
-    kube: kubeGateway,
-    agentRunIngestion,
-    admissionPassports: runtimeAdmission.admissionPassports,
-    dependencyQuorum,
-    workflows,
-    negativeEvidenceRouter,
-    reconciledActionClocks,
-    rolloutHealth,
-    controllerWitness,
-    database,
-    watchReliability: watchReliabilityStatus,
-    empiricalServices,
-    sourceRolloutTruthExchange,
-    failureDomainLeases,
-    executionTrust,
-    routeProbe,
-    torghutConsumerEvidence: torghutConsumerEvidence.status,
-    resolveRepairScheduleAttempts: deps.resolveRepairScheduleAttempts,
-  })
+  } = materialStatus.materialArtifacts
+  const repairBidAdmission = buildDefaultRepairBidAdmissionState(now, options.namespace, torghutConsumerEvidence.status)
   const sourceServingContractVerdictExchange = buildSourceServingContractVerdictExchange({
     now,
     namespace: options.namespace,

--- a/services/jangar/src/server/control-plane-torghut-stage-custody.ts
+++ b/services/jangar/src/server/control-plane-torghut-stage-custody.ts
@@ -1,0 +1,114 @@
+import type { StageClearancePacket } from '~/data/agents-control-plane'
+import type {
+  TorghutConsumerEvidenceResolution,
+  TorghutConsumerEvidenceStatus,
+} from '~/server/control-plane-torghut-consumer-evidence'
+
+export type TorghutStageCustodyAttachmentResult = {
+  resolution: TorghutConsumerEvidenceResolution
+  attached: boolean
+}
+
+const paperActionStates = new Set(['allow', 'allowed', 'current', 'paper_canary', 'paper_candidate', 'ready'])
+
+const STAGE_CUSTODY_PACKET_PREFERENCE: Array<StageClearancePacket['action_class']> = [
+  'paper_canary',
+  'torghut_observe',
+  'live_micro_canary',
+  'live_scale',
+]
+
+const parseTimestampMs = (value: string | null | undefined) => {
+  if (!value) return null
+  const parsed = Date.parse(value)
+  return Number.isNaN(parsed) ? null : parsed
+}
+
+const findTorghutStageCustodyPacket = (packets: StageClearancePacket[]) => {
+  for (const actionClass of STAGE_CUSTODY_PACKET_PREFERENCE) {
+    const packet = packets.find((entry) => entry.stage === 'torghut' && entry.action_class === actionClass)
+    if (packet) return packet
+  }
+  return null
+}
+
+const stageCustodyStatusFromPacket = (packet: StageClearancePacket, now: Date) => {
+  const freshUntilMs = parseTimestampMs(packet.fresh_until)
+  if (!freshUntilMs) {
+    return {
+      status: 'stale',
+      reasonCodes: ['evidence_clock_custody_fresh_until_missing'],
+    }
+  }
+  if (freshUntilMs <= now.getTime()) {
+    return {
+      status: 'stale',
+      reasonCodes: ['evidence_clock_custody_stale'],
+    }
+  }
+  if (paperActionStates.has(packet.decision)) {
+    return {
+      status: 'current',
+      reasonCodes: [],
+    }
+  }
+  return {
+    status: 'blocked',
+    reasonCodes: [`evidence_clock_custody_stage_clearance_${packet.decision}`],
+  }
+}
+
+const custodyFieldsChanged = (status: TorghutConsumerEvidenceStatus, nextStatus: string, nextRef: string) =>
+  status.evidence_clock_custody_status !== nextStatus || status.evidence_clock_custody_ref !== nextRef
+
+const isLocalTorghutStageCustodyRef = (ref: string | null | undefined) => ref?.startsWith('stage-clearance:torghut:')
+
+export const attachStageClearanceCustodyToTorghutEvidence = (
+  resolution: TorghutConsumerEvidenceResolution,
+  packets: StageClearancePacket[],
+  now = new Date(),
+): TorghutStageCustodyAttachmentResult => {
+  const status = resolution.status
+  const localStageCustodyRef = isLocalTorghutStageCustodyRef(status.evidence_clock_custody_ref)
+  if (
+    !status.evidence_clock_arbiter_id ||
+    (status.evidence_clock_custody_status === 'current' && !localStageCustodyRef)
+  ) {
+    return { resolution, attached: false }
+  }
+  if (
+    status.evidence_clock_custody_ref &&
+    status.evidence_clock_custody_status !== 'missing' &&
+    !localStageCustodyRef
+  ) {
+    return { resolution, attached: false }
+  }
+
+  const packet = findTorghutStageCustodyPacket(packets)
+  if (!packet) return { resolution, attached: false }
+
+  const custody = stageCustodyStatusFromPacket(packet, now)
+  const packetRef = packet.packet_id
+  if (!custodyFieldsChanged(status, custody.status, packetRef)) {
+    return { resolution, attached: false }
+  }
+
+  return {
+    attached: true,
+    resolution: {
+      status: {
+        ...status,
+        evidence_clock_custody_status: custody.status,
+        evidence_clock_custody_ref: packetRef,
+      },
+      negativeEvidence: resolution.negativeEvidence
+        ? {
+            ...resolution.negativeEvidence,
+            evidence_clock_custody_status: custody.status,
+            evidence_clock_custody_ref: packetRef,
+            evidence_clock_custody_reason_codes: custody.reasonCodes,
+          }
+        : undefined,
+    },
+  }
+}


### PR DESCRIPTION
## Summary

- Implements design doc `docs/agents/designs/188-jangar-typed-torghut-evidence-admission-and-repair-dispatch-2026-05-13.md` for Jangar-side Torghut custody normalization.
- Attaches Jangar's current local Torghut `stage_clearance_packets[]` entry to `torghut_consumer_evidence.evidence_clock_custody_*` when Torghut's consumer evidence has an arbiter but no Jangar custody ref.
- Rebuilds material action artifacts after attachment so repair output distinguishes missing custody evidence from a real blocked/stale Torghut stage hold.
- Updates operator docs with the status contract, validation query, risk notes, and rollback path.

## Related Issues

None

Requirement provenance: `/workspace/.agentrun/run.json` required `attach fresh Torghut stage-custody evidence` for the implement stage and reported `evidence_clock_custody_missing`.

## Testing

- PASS `bun test services/jangar/src/server/__tests__/control-plane-torghut-consumer-evidence.test.ts services/jangar/src/server/__tests__/control-plane-status.test.ts`
- PASS `bun run --filter @proompteng/jangar tsc`
- PASS `bun run --filter @proompteng/jangar lint`
- PASS `bun run --filter @proompteng/jangar lint:oxlint` (79 existing warnings, 0 errors)
- PASS `bun run --filter @proompteng/jangar lint:oxlint:type` (288 existing warnings, 0 errors)
- PASS `bun run --filter @proompteng/jangar test` (183 files, 1142 tests)
- PASS `bun run --filter @proompteng/jangar check:module-sizes`
- PASS GitHub `jangar-ci / lint-and-typecheck / run`
- PASS GitHub `agents-ci / validate`
- PASS GitHub `agents-ci / integration`
- PASS GitHub `CI / check_changed_files`
- PASS GitHub semantic PR title and commit checks

## Screenshots (if applicable)

N/A

## Breaking Changes

None. Risk is limited to the control-plane status projection. Rollback is to ignore the normalized `torghut_consumer_evidence.evidence_clock_custody_*` fields or revert `attachStageClearanceCustodyToTorghutEvidence`; material-action verdicts, stage-clearance packets, repair warrants, source-rollout truth, and `max_notional=0` remain the safety boundary.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
