### PR TITLE
feat(torghut): publish freshness carry ledger

### DIFF
--- a/docs/torghut/README.md
+++ b/docs/torghut/README.md
@@ -8,6 +8,10 @@ Start here:
   (current source-serving proof and repair-receipt promotion contract)
 - `docs/agents/designs/187-jangar-main-source-ci-retention-and-source-serving-verdicts-2026-05-13.md`
   (current Jangar source-serving verdict contract)
+- `docs/torghut/design-system/v6/192-torghut-freshness-carry-and-repair-proof-slo-2026-05-13.md`
+  (current freshness carry and repair proof SLO contract)
+- `docs/agents/designs/188-jangar-evidence-pressure-ledger-and-watch-backoff-governor-2026-05-13.md`
+  (current Jangar evidence pressure and watch backoff contract)
 - `docs/torghut/design-system/v6/190-torghut-repair-bid-settlement-and-routeability-proof-compaction-2026-05-13.md`
   (current repair-bid settlement and routeability proof compaction contract)
 - `docs/agents/designs/186-jangar-repair-bid-admission-and-settlement-custody-2026-05-13.md`
@@ -162,6 +166,11 @@ Start here:
   required route contract canaries before any repair receipt can be treated as source-serving-current evidence.
   Missing image digest, missing required contracts, schema mismatches, or source/serving commit splits keep
   `max_notional=0` and classify the payload as repair-only evidence.
+- Current implementation contract: doc 192 adds `freshness_carry_ledger` to status, health, readyz, and
+  `/trading/consumer-evidence`. The ledger prices TA signal, TCA, empirical, market-context, quant-evidence, and
+  source-serving freshness as explicit dimensions with bounded zero-notional repair SLOs. Partial, stale, or
+  low-confidence freshness keeps `max_notional=0`; source-serving proof, route warrants, live submission, and required
+  freshness must agree before routeable candidates can move toward paper capital.
 - Current implementation contract: doc 189 adds `clock_settlement_receipt` beside the evidence-clock arbiter on
   status, health, readyz, and `/trading/consumer-evidence`. The receipt compares direct ClickHouse TA freshness, Jangar
   scoped quant, TCA, empirical, promotion, and rollout witnesses against the published clocks, emits zero-notional

--- a/docs/torghut/design-system/current-source-of-truth-and-priority-guide-2026-03-09.md
+++ b/docs/torghut/design-system/current-source-of-truth-and-priority-guide-2026-03-09.md
@@ -1,8 +1,8 @@
-# Torghut Design-System Current Source-of-Truth and Priority Guide (updated 2026-05-12)
+# Torghut Design-System Current Source-of-Truth and Priority Guide (updated 2026-05-13)
 
 ## Status
 
-- Date: `2026-05-12`
+- Date: `2026-05-13`
 - Purpose: distinguish live source-of-truth docs from historical milestone records and identify the current highest-priority work
 - Scope: `docs/torghut/design-system/**`, `docs/torghut/**`, `argocd/applications/torghut/**`, `services/torghut/**`, `services/jangar/**`
 
@@ -36,6 +36,8 @@ If the question is "what should I trust right now?", start here:
 3. current autonomy/promotion contract source of truth:
    - `docs/torghut/design-system/v6/191-torghut-source-serving-proof-and-repair-receipt-promotion-2026-05-13.md`
    - `docs/agents/designs/187-jangar-main-source-ci-retention-and-source-serving-verdicts-2026-05-13.md`
+   - `docs/torghut/design-system/v6/192-torghut-freshness-carry-and-repair-proof-slo-2026-05-13.md`
+   - `docs/agents/designs/188-jangar-evidence-pressure-ledger-and-watch-backoff-governor-2026-05-13.md`
    - `docs/torghut/design-system/v6/190-torghut-repair-bid-settlement-and-routeability-proof-compaction-2026-05-13.md`
    - `docs/agents/designs/186-jangar-repair-bid-admission-and-settlement-custody-2026-05-13.md`
    - `docs/agents/designs/184-jangar-reliability-settlement-ledger-and-rollout-slo-escrow-2026-05-12.md`
@@ -133,7 +135,17 @@ If the question is "what should I trust right now?", start here:
 
 The current highest-priority work is:
 
-The May 13 source-serving proof handoff is the current top priority:
+The May 13 freshness-carry handoff is the current top priority after the source-serving proof ledger landed:
+
+- make Torghut publish `freshness_carry_ledger` from status, health, readyz, and consumer-evidence surfaces so TA
+  signal, TCA, empirical, market-context, quant-evidence, and source-serving freshness are priced as explicit repair
+  dimensions in
+  `docs/torghut/design-system/v6/192-torghut-freshness-carry-and-repair-proof-slo-2026-05-13.md`;
+- keep partial or stale freshness at `max_notional=0` while exposing bounded zero-notional repair SLOs that Jangar can
+  pressure-budget through
+  `docs/agents/designs/188-jangar-evidence-pressure-ledger-and-watch-backoff-governor-2026-05-13.md`.
+
+The May 13 source-serving proof handoff remains an active supporting priority:
 
 - make Torghut publish `source_serving_repair_receipt_ledger` from status and consumer-evidence surfaces so repair
   receipts cite source commit, serving build commit, serving image digest, manifest image digest, and required contract

--- a/docs/torghut/design-system/v6/192-torghut-freshness-carry-and-repair-proof-slo-2026-05-13.md
+++ b/docs/torghut/design-system/v6/192-torghut-freshness-carry-and-repair-proof-slo-2026-05-13.md
@@ -260,6 +260,18 @@ Engineer milestone 1:
 - Expose the ledger on `/trading/consumer-evidence`, `/trading/status`, and `/readyz` in observe mode.
 - Add tests proving partial freshness keeps `max_notional=0` while admitting a bounded zero-notional repair SLO.
 
+Implementation status:
+
+- Phase 1 is implemented in `services/torghut/app/trading/freshness_carry.py` as a pure read-model reducer with no
+  database writes, broker actions, or scheduler dispatch.
+- Runtime surfaces now include `freshness_carry_ledger` on `/trading/consumer-evidence`, `/trading/status`,
+  `/trading/health`, and `/readyz`.
+- The first shipped dimensions are `ta_signals`, `tca`, `empirical`, `market_context`, `quant_evidence`, and
+  `source_serving`. Any non-current dimension keeps `capital_posture.max_notional=0` and emits bounded repair SLOs
+  with required output receipts.
+- Source-serving proof is a dispatch precondition for non-source freshness repairs; if source-serving proof is stale,
+  only the source-serving repair SLO is dispatchable.
+
 Engineer milestone 2:
 
 - Require zero-notional repair receipts to cite a freshness dimension and repair proof SLO when the repair target is

--- a/services/torghut/README.md
+++ b/services/torghut/README.md
@@ -275,6 +275,12 @@ Testing rules for the trading core:
   canaries. Missing or mismatched source-serving proof keeps the ledger in repair-only zero-notional mode; the Torghut
   release manifest updater now writes `TORGHUT_IMAGE_DIGEST` into live and sim Knative env so runtime payloads can
   report the promoted digest.
+- `GET /trading/status`, `GET /trading/health`, `GET /readyz`, and `GET /trading/consumer-evidence` now expose the
+  May 13 doc 192 `torghut.freshness-carry-ledger.v1` ledger. It derives TA signal, TCA, empirical, market-context,
+  quant-evidence, and source-serving freshness dimensions from existing status inputs, emits bounded zero-notional
+  repair proof SLOs for non-current dimensions, and keeps `max_notional=0` whenever freshness is partial or
+  source-serving proof is not current. It is observe-mode evidence only; route warrants and live-submission gates remain
+  the capital authority.
 - The simple direct-submit lane is no longer an authority bypass in live mode. Before submitting to Alpaca it evaluates
   the same live-submission gate as the scheduler path and persists the gate payload in decision metadata when a
   submission is blocked. Paper-mode simple execution remains unchanged.

--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -84,6 +84,7 @@ from .trading.evidence_receipts import (
 )
 from .trading.executable_alpha_receipts import build_capital_replay_projection
 from .trading.forecast_runtime import forecast_status
+from .trading.freshness_carry import build_freshness_carry_ledger
 from .trading.hypotheses import (
     JangarDependencyQuorumStatus,
     compile_hypothesis_runtime_statuses,
@@ -946,6 +947,16 @@ def _evaluate_trading_health_payload(
         repair_bid_settlement_ledger=repair_bid_settlement_ledger,
         route_warrant_exchange=route_warrant_exchange,
     )
+    freshness_carry_ledger = _build_freshness_carry_ledger_payload(
+        source_serving_repair_receipt_ledger=source_serving_repair_receipt_ledger,
+        route_warrant_exchange=route_warrant_exchange,
+        clickhouse_ta_status=clickhouse_ta_status,
+        tca_summary=tca_summary,
+        empirical_jobs_status=empirical_jobs,
+        market_context_status=market_context_status,
+        quant_evidence=quant_evidence,
+        live_submission_gate=live_submission_gate,
+    )
     live_mode = settings.trading_mode == "live"
     empirical_jobs_required = (
         live_mode and settings.trading_empirical_jobs_health_required
@@ -1048,6 +1059,7 @@ def _evaluate_trading_health_payload(
             "repair_bid_settlement_ledger": repair_bid_settlement_ledger,
             "route_warrant_exchange": route_warrant_exchange,
             "source_serving_repair_receipt_ledger": source_serving_repair_receipt_ledger,
+            "freshness_carry_ledger": freshness_carry_ledger,
             "route_reacquisition_book": proof_floor.get("route_reacquisition_book"),
             "route_reacquisition_board": route_reacquisition_board,
             "quant_evidence": quant_evidence,
@@ -2504,6 +2516,16 @@ def trading_status() -> dict[str, object]:
         repair_bid_settlement_ledger=repair_bid_settlement_ledger,
         route_warrant_exchange=route_warrant_exchange,
     )
+    freshness_carry_ledger = _build_freshness_carry_ledger_payload(
+        source_serving_repair_receipt_ledger=source_serving_repair_receipt_ledger,
+        route_warrant_exchange=route_warrant_exchange,
+        clickhouse_ta_status=clickhouse_ta_status,
+        tca_summary=tca_summary,
+        empirical_jobs_status=empirical_jobs,
+        market_context_status=market_context_status,
+        quant_evidence=quant_evidence,
+        live_submission_gate=live_submission_gate,
+    )
     return {
         "enabled": settings.trading_enabled,
         "autonomy_enabled": settings.trading_autonomy_enabled,
@@ -2544,6 +2566,7 @@ def trading_status() -> dict[str, object]:
         "repair_bid_settlement_ledger": repair_bid_settlement_ledger,
         "route_warrant_exchange": route_warrant_exchange,
         "source_serving_repair_receipt_ledger": source_serving_repair_receipt_ledger,
+        "freshness_carry_ledger": freshness_carry_ledger,
         "route_reacquisition_book": proof_floor.get("route_reacquisition_book"),
         "route_reacquisition_board": route_reacquisition_board,
         "quant_evidence": quant_evidence,
@@ -2938,6 +2961,16 @@ def _build_trading_consumer_evidence_payload() -> dict[str, object]:
         repair_bid_settlement_ledger=repair_bid_settlement_ledger,
         route_warrant_exchange=route_warrant_exchange,
     )
+    freshness_carry_ledger = _build_freshness_carry_ledger_payload(
+        source_serving_repair_receipt_ledger=source_serving_repair_receipt_ledger,
+        route_warrant_exchange=route_warrant_exchange,
+        clickhouse_ta_status=clickhouse_ta_status,
+        tca_summary=tca_summary,
+        empirical_jobs_status=empirical_jobs,
+        market_context_status=market_context_status,
+        quant_evidence=quant_evidence,
+        live_submission_gate=live_submission_gate,
+    )
     return {
         "schema_version": "torghut.consumer-evidence-status.v1",
         "generated_at": datetime.now(timezone.utc).isoformat(),
@@ -2970,6 +3003,7 @@ def _build_trading_consumer_evidence_payload() -> dict[str, object]:
         "repair_bid_settlement_ledger": repair_bid_settlement_ledger,
         "route_warrant_exchange": route_warrant_exchange,
         "source_serving_repair_receipt_ledger": source_serving_repair_receipt_ledger,
+        "freshness_carry_ledger": freshness_carry_ledger,
     }
 
 
@@ -5218,6 +5252,31 @@ def _build_source_serving_repair_receipt_payload(
         route_warrant_exchange=route_warrant_exchange,
         repair_bid_settlement_ledger=repair_bid_settlement_ledger,
         route_evidence_clearinghouse_packet=route_evidence_clearinghouse_packet,
+    )
+
+
+def _build_freshness_carry_ledger_payload(
+    *,
+    source_serving_repair_receipt_ledger: Mapping[str, Any],
+    route_warrant_exchange: Mapping[str, Any],
+    clickhouse_ta_status: Mapping[str, Any],
+    tca_summary: Mapping[str, Any],
+    empirical_jobs_status: Mapping[str, Any],
+    market_context_status: Mapping[str, Any],
+    quant_evidence: Mapping[str, Any],
+    live_submission_gate: Mapping[str, Any],
+) -> dict[str, object]:
+    return build_freshness_carry_ledger(
+        account_label=settings.trading_account_label,
+        window=settings.trading_jangar_quant_window,
+        source_serving_repair_receipt_ledger=source_serving_repair_receipt_ledger,
+        route_warrant_exchange=route_warrant_exchange,
+        clickhouse_ta_status=clickhouse_ta_status,
+        tca_summary=tca_summary,
+        empirical_jobs_status=empirical_jobs_status,
+        market_context_status=market_context_status,
+        quant_evidence=quant_evidence,
+        live_submission_gate=live_submission_gate,
     )
 
 

--- a/services/torghut/app/trading/freshness_carry.py
+++ b/services/torghut/app/trading/freshness_carry.py
@@ -1,0 +1,619 @@
+"""Freshness carry ledger for zero-notional Torghut repair proof SLOs."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal, InvalidOperation
+from hashlib import sha256
+import json
+from typing import Any, cast
+
+
+FRESHNESS_CARRY_LEDGER_SCHEMA_VERSION = "torghut.freshness-carry-ledger.v1"
+
+_FRESHNESS_SECONDS = 60
+_ZERO_NOTIONAL = "0"
+_CURRENT_STATES = {"ok", "ready", "healthy", "current", "pass", "allow", "converged"}
+_NON_CURRENT_STATES = {"missing", "stale", "low_confidence", "unknown"}
+_TA_MAX_LAG_SECONDS = 900
+_TCA_MAX_AGE_SECONDS = 86_400
+_MARKET_CONTEXT_DEFAULT_MAX_STALENESS_SECONDS = 900
+_MIN_EXPECTED_SHORTFALL_COVERAGE = Decimal("0.50")
+
+_VALUE_GATE_BY_DIMENSION = {
+    "ta_signals": "zero_notional_or_stale_evidence_rate",
+    "market_context": "zero_notional_or_stale_evidence_rate",
+    "tca": "fill_tca_or_slippage_quality",
+    "empirical": "post_cost_daily_net_pnl",
+    "quant_evidence": "routeable_candidate_count",
+    "source_serving": "capital_gate_safety",
+}
+
+_OUTPUT_RECEIPT_BY_DIMENSION = {
+    "ta_signals": "torghut.ta-freshness-repair-receipt.v1",
+    "market_context": "torghut.market-context-freshness-receipt.v1",
+    "tca": "torghut.execution-tca-refresh-receipt.v1",
+    "empirical": "torghut.empirical-proof-refresh-receipt.v1",
+    "quant_evidence": "torghut.quant-evidence-refresh-receipt.v1",
+    "source_serving": "torghut.source-serving-repair-receipt-ledger.v1",
+}
+
+
+def _sequence(value: object) -> Sequence[object]:
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return cast(Sequence[object], value)
+    return ()
+
+
+def _text(value: object, default: str = "") -> str:
+    if value is None:
+        return default
+    text = str(value).strip()
+    return text or default
+
+
+def _bool(value: object) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "y", "on"}
+    return bool(value)
+
+
+def _int(value: object, default: int = 0) -> int:
+    try:
+        if isinstance(value, bool):
+            return int(value)
+        return int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return default
+
+
+def _decimal(value: object) -> Decimal | None:
+    if value is None:
+        return None
+    if isinstance(value, Decimal):
+        return value
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, ValueError):
+        return None
+
+
+def _strings(value: object) -> list[str]:
+    result: list[str] = []
+    seen: set[str] = set()
+    for item in _sequence(value):
+        normalized = _text(item)
+        if normalized and normalized not in seen:
+            result.append(normalized)
+            seen.add(normalized)
+    return result
+
+
+def _parse_datetime(value: object) -> datetime | None:
+    if isinstance(value, datetime):
+        parsed = value
+    elif isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None
+        if text.endswith("Z"):
+            text = f"{text[:-1]}+00:00"
+        try:
+            parsed = datetime.fromisoformat(text)
+        except ValueError:
+            return None
+    else:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _iso(value: object) -> str | None:
+    parsed = _parse_datetime(value)
+    if parsed is None:
+        return None
+    return parsed.isoformat()
+
+
+def _lag_seconds(now: datetime, event_at: datetime | None) -> int | None:
+    if event_at is None:
+        return None
+    return max(0, int((now - event_at).total_seconds()))
+
+
+def _stable_ref(prefix: str, payload: Mapping[str, object]) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return f"{prefix}:{sha256(encoded.encode()).hexdigest()[:20]}"
+
+
+def _dimension(
+    *,
+    dimension_id: str,
+    state: str,
+    proof_authority: str,
+    observed_at: object = None,
+    max_event_at: object = None,
+    lag_seconds: int | None = None,
+    low_memory_fallback_count: int = 0,
+    stale_reason_codes: Sequence[str] = (),
+    source_ref: object = None,
+) -> dict[str, object]:
+    if state in _CURRENT_STATES:
+        normalized_state = "current"
+    elif state in _NON_CURRENT_STATES:
+        normalized_state = state
+    else:
+        normalized_state = "unknown"
+    reasons = [reason for reason in stale_reason_codes if reason]
+    if normalized_state == "current":
+        reasons = []
+    if normalized_state != "current" and not reasons:
+        reasons = [f"{dimension_id}_{normalized_state}"]
+    return {
+        "dimension_id": dimension_id,
+        "state": normalized_state,
+        "proof_authority": proof_authority,
+        "observed_at": _iso(observed_at),
+        "max_event_at": _iso(max_event_at),
+        "lag_seconds": lag_seconds,
+        "low_memory_fallback_count": low_memory_fallback_count,
+        "stale_reason_codes": reasons,
+        "required_repair_receipt": _OUTPUT_RECEIPT_BY_DIMENSION[dimension_id],
+        "source_ref": _text(source_ref) or None,
+        "max_notional": _ZERO_NOTIONAL,
+    }
+
+
+def _ta_signal_dimension(
+    *,
+    clickhouse_ta_status: Mapping[str, Any],
+    now: datetime,
+) -> dict[str, object]:
+    latest_signal_at = _parse_datetime(clickhouse_ta_status.get("latest_signal_at"))
+    lag = _lag_seconds(now, latest_signal_at)
+    raw_state = _text(clickhouse_ta_status.get("state"), "unknown").lower()
+    reasons = _strings(clickhouse_ta_status.get("reason_codes"))
+    if latest_signal_at is None:
+        state = "missing"
+        reasons.append("ta_signal_timestamp_missing")
+    elif raw_state not in _CURRENT_STATES:
+        state = "stale" if raw_state == "stale" else "unknown"
+        reasons.append(f"clickhouse_ta_{raw_state}")
+    elif lag is not None and lag > _TA_MAX_LAG_SECONDS:
+        state = "stale"
+        reasons.append("ta_signal_lag_exceeded")
+    else:
+        state = "current"
+    return _dimension(
+        dimension_id="ta_signals",
+        state=state,
+        proof_authority=_text(
+            clickhouse_ta_status.get("proof_authority"), "direct_sql"
+        ),
+        observed_at=now,
+        max_event_at=latest_signal_at,
+        lag_seconds=lag,
+        low_memory_fallback_count=_int(
+            clickhouse_ta_status.get("low_memory_fallback_count")
+        ),
+        stale_reason_codes=reasons,
+        source_ref=clickhouse_ta_status.get("source_ref"),
+    )
+
+
+def _tca_dimension(
+    *,
+    tca_summary: Mapping[str, Any],
+    now: datetime,
+) -> dict[str, object]:
+    last_computed_at = _parse_datetime(tca_summary.get("last_computed_at"))
+    lag = _lag_seconds(now, last_computed_at)
+    order_count = _int(tca_summary.get("order_count"))
+    expected_coverage = _decimal(tca_summary.get("expected_shortfall_coverage"))
+    reasons: list[str] = []
+    if order_count <= 0:
+        state = "missing"
+        reasons.append("tca_orders_missing")
+    elif last_computed_at is None:
+        state = "missing"
+        reasons.append("tca_computed_at_missing")
+    elif lag is not None and lag > _TCA_MAX_AGE_SECONDS:
+        state = "stale"
+        reasons.append("tca_computed_at_stale")
+    elif (
+        expected_coverage is None
+        or expected_coverage < _MIN_EXPECTED_SHORTFALL_COVERAGE
+    ):
+        state = "low_confidence"
+        reasons.append("expected_shortfall_coverage_low")
+    else:
+        state = "current"
+    return _dimension(
+        dimension_id="tca",
+        state=state,
+        proof_authority="app_health",
+        observed_at=now,
+        max_event_at=last_computed_at or tca_summary.get("latest_execution_created_at"),
+        lag_seconds=lag,
+        stale_reason_codes=reasons,
+        source_ref="execution_tca_metrics",
+    )
+
+
+def _empirical_dimension(empirical_jobs_status: Mapping[str, Any]) -> dict[str, object]:
+    ready = _bool(empirical_jobs_status.get("ready"))
+    status = _text(empirical_jobs_status.get("status"), "unknown").lower()
+    stale_jobs = _strings(empirical_jobs_status.get("stale_jobs"))
+    missing_jobs = _strings(empirical_jobs_status.get("missing_jobs"))
+    ineligible_jobs = _strings(empirical_jobs_status.get("ineligible_jobs"))
+    reasons = [
+        *[f"empirical_job_stale:{job}" for job in stale_jobs],
+        *[f"empirical_job_missing:{job}" for job in missing_jobs],
+        *[f"empirical_job_ineligible:{job}" for job in ineligible_jobs],
+        *_strings(empirical_jobs_status.get("blocked_reasons")),
+    ]
+    if ready and status in _CURRENT_STATES:
+        state = "current"
+    elif missing_jobs:
+        state = "missing"
+    elif stale_jobs:
+        state = "stale"
+    else:
+        state = "unknown"
+        if status:
+            reasons.append(f"empirical_jobs_{status}")
+    return _dimension(
+        dimension_id="empirical",
+        state=state,
+        proof_authority=_text(empirical_jobs_status.get("authority"), "app_health"),
+        observed_at=None,
+        stale_reason_codes=reasons,
+        source_ref="vnext_empirical_job_runs",
+    )
+
+
+def _market_context_dimension(
+    *,
+    market_context_status: Mapping[str, Any],
+    now: datetime,
+) -> dict[str, object]:
+    max_staleness = _int(
+        market_context_status.get("max_staleness_seconds"),
+        _MARKET_CONTEXT_DEFAULT_MAX_STALENESS_SECONDS,
+    )
+    freshness_seconds = _int(market_context_status.get("last_freshness_seconds"), -1)
+    last_checked_at = market_context_status.get(
+        "last_checked_at"
+    ) or market_context_status.get("last_as_of")
+    reasons = [
+        *_strings(market_context_status.get("last_risk_flags")),
+        *_strings(market_context_status.get("reason_codes")),
+        *_strings(market_context_status.get("blocking_reasons")),
+    ]
+    if _bool(market_context_status.get("alert_active")):
+        reasons.append(
+            _text(
+                market_context_status.get("alert_reason"), "market_context_alert_active"
+            )
+        )
+    if market_context_status.get("health_error"):
+        reasons.append("market_context_health_error")
+    if freshness_seconds < 0:
+        state = "missing"
+        reasons.append("market_context_freshness_missing")
+    elif freshness_seconds > max_staleness:
+        state = "stale"
+        reasons.append("market_context_staleness_exceeded")
+    elif reasons:
+        state = "low_confidence"
+    else:
+        state = "current"
+    return _dimension(
+        dimension_id="market_context",
+        state=state,
+        proof_authority="app_health",
+        observed_at=last_checked_at or now,
+        max_event_at=last_checked_at,
+        lag_seconds=freshness_seconds if freshness_seconds >= 0 else None,
+        stale_reason_codes=reasons,
+        source_ref=market_context_status.get("last_symbol") or "market_context",
+    )
+
+
+def _quant_evidence_dimension(quant_evidence: Mapping[str, Any]) -> dict[str, object]:
+    ok = _bool(quant_evidence.get("ok", True))
+    required = _bool(quant_evidence.get("required"))
+    reason = _text(quant_evidence.get("reason"))
+    if ok or not required:
+        state = "current"
+        reasons: list[str] = []
+    else:
+        state = "stale"
+        reasons = [reason or "quant_evidence_not_ok"]
+    return _dimension(
+        dimension_id="quant_evidence",
+        state=state,
+        proof_authority=_text(quant_evidence.get("authority"), "app_health"),
+        observed_at=quant_evidence.get("checked_at"),
+        stale_reason_codes=reasons,
+        source_ref=quant_evidence.get("source_ref") or quant_evidence.get("window"),
+    )
+
+
+def _source_serving_dimension(
+    source_serving_repair_receipt_ledger: Mapping[str, Any],
+) -> dict[str, object]:
+    source_state = _text(
+        source_serving_repair_receipt_ledger.get("source_serving_state"), "unknown"
+    )
+    reasons = _strings(source_serving_repair_receipt_ledger.get("reason_codes"))
+    if source_state == "converged":
+        state = "current"
+    elif source_state in {"contract_missing", "digest_unknown", "source_ahead"}:
+        state = "stale"
+    else:
+        state = "unknown"
+    return _dimension(
+        dimension_id="source_serving",
+        state=state,
+        proof_authority="app_health",
+        observed_at=source_serving_repair_receipt_ledger.get("generated_at"),
+        max_event_at=source_serving_repair_receipt_ledger.get("generated_at"),
+        stale_reason_codes=reasons or [f"source_serving_{source_state}"],
+        source_ref=source_serving_repair_receipt_ledger.get("ledger_id"),
+    )
+
+
+def _repair_slos(
+    *,
+    ledger_id: str,
+    dimensions: Sequence[Mapping[str, object]],
+    source_serving_current: bool,
+) -> list[dict[str, object]]:
+    slos: list[dict[str, object]] = []
+    for dimension in dimensions:
+        dimension_id = _text(dimension.get("dimension_id"))
+        state = _text(dimension.get("state"))
+        if not dimension_id or state == "current":
+            continue
+        output_receipt = _OUTPUT_RECEIPT_BY_DIMENSION[dimension_id]
+        dispatchable = source_serving_current or dimension_id == "source_serving"
+        slos.append(
+            {
+                "repair_id": _stable_ref(
+                    "freshness-repair-slo",
+                    {
+                        "ledger_id": ledger_id,
+                        "dimension_id": dimension_id,
+                        "state": state,
+                        "output_receipt": output_receipt,
+                    },
+                ),
+                "target_dimension_id": dimension_id,
+                "target_value_gate": _VALUE_GATE_BY_DIMENSION[dimension_id],
+                "expected_delta": "0.25",
+                "max_runtime_seconds": 900,
+                "max_retries": 1,
+                "required_output_receipts": [output_receipt],
+                "stop_conditions": [
+                    "max_notional_nonzero",
+                    "source_serving_state_conflict",
+                    "repair_receipt_expired",
+                ],
+                "promotion_condition": "freshness_dimension_current_with_source_serving_epoch",
+                "rollback_target": "keep paper/live disabled and retain existing route warrant hold",
+                "dispatchable": dispatchable,
+                "max_notional": _ZERO_NOTIONAL,
+                "hold_reason_codes": []
+                if dispatchable
+                else ["source_serving_not_current"],
+                "settlement_status": "pending",
+            }
+        )
+    return slos
+
+
+def _route_warrant_reason(route_warrant_exchange: Mapping[str, Any]) -> str | None:
+    state = _text(route_warrant_exchange.get("warrant_state"), "missing")
+    if state in {
+        "paper_candidate",
+        "live_candidate",
+        "live_micro_candidate",
+        "live_scale_candidate",
+    }:
+        return None
+    return f"route_warrant_{state}"
+
+
+def _capital_posture(
+    *,
+    dimensions: Sequence[Mapping[str, object]],
+    source_serving_dimension: Mapping[str, object],
+    route_warrant_exchange: Mapping[str, Any],
+    live_submission_gate: Mapping[str, Any],
+) -> dict[str, object]:
+    non_current_dimensions = [
+        _text(dimension.get("dimension_id"))
+        for dimension in dimensions
+        if _text(dimension.get("state")) != "current"
+    ]
+    reason_codes = [
+        reason
+        for dimension in dimensions
+        for reason in _strings(dimension.get("stale_reason_codes"))
+    ]
+    route_reason = _route_warrant_reason(route_warrant_exchange)
+    if route_reason:
+        reason_codes.append(route_reason)
+    if not _bool(live_submission_gate.get("allowed")):
+        reason_codes.append(
+            _text(live_submission_gate.get("reason"), "live_submission_gate_closed")
+        )
+    decision = "observe"
+    route_warrant_state = _text(route_warrant_exchange.get("warrant_state"), "missing")
+    if (
+        non_current_dimensions
+        or route_reason
+        or not _bool(live_submission_gate.get("allowed"))
+    ):
+        decision = "repair_only"
+    elif route_warrant_state == "paper_candidate":
+        decision = "paper_candidate"
+    elif route_warrant_state in {
+        "live_candidate",
+        "live_micro_candidate",
+        "live_scale_candidate",
+    }:
+        decision = "live_candidate"
+
+    return {
+        "decision": decision,
+        "max_notional": _ZERO_NOTIONAL
+        if decision == "repair_only"
+        else _text(route_warrant_exchange.get("max_notional"), _ZERO_NOTIONAL),
+        "reason_codes": sorted(set(reason_codes)),
+        "required_freshness_dimensions": [
+            _text(dimension.get("dimension_id")) for dimension in dimensions
+        ],
+        "required_source_serving_state": "converged",
+        "source_serving_state": _text(source_serving_dimension.get("state")),
+        "non_current_dimension_ids": non_current_dimensions,
+    }
+
+
+def _value_gate_impacts(
+    dimensions: Sequence[Mapping[str, object]],
+) -> list[dict[str, object]]:
+    impacts: list[dict[str, object]] = []
+    for dimension in dimensions:
+        dimension_id = _text(dimension.get("dimension_id"))
+        state = _text(dimension.get("state"))
+        if not dimension_id:
+            continue
+        impacts.append(
+            {
+                "value_gate": _VALUE_GATE_BY_DIMENSION[dimension_id],
+                "dimension_id": dimension_id,
+                "state": state,
+                "capital_effect": "max_notional_held_at_zero"
+                if state != "current"
+                else "no_capital_change",
+            }
+        )
+    return impacts
+
+
+def build_freshness_carry_ledger(
+    *,
+    account_label: str,
+    window: str,
+    source_serving_repair_receipt_ledger: Mapping[str, Any],
+    route_warrant_exchange: Mapping[str, Any],
+    clickhouse_ta_status: Mapping[str, Any],
+    tca_summary: Mapping[str, Any],
+    empirical_jobs_status: Mapping[str, Any],
+    market_context_status: Mapping[str, Any],
+    quant_evidence: Mapping[str, Any],
+    live_submission_gate: Mapping[str, Any],
+    jangar_pressure_refs: Sequence[Mapping[str, object]] | None = None,
+    now: datetime | None = None,
+) -> dict[str, object]:
+    """Build an observe-mode freshness carry ledger without changing capital gates."""
+
+    generated_at = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    source_dimension = _source_serving_dimension(source_serving_repair_receipt_ledger)
+    dimensions = [
+        _ta_signal_dimension(
+            clickhouse_ta_status=clickhouse_ta_status,
+            now=generated_at,
+        ),
+        _tca_dimension(tca_summary=tca_summary, now=generated_at),
+        _empirical_dimension(empirical_jobs_status),
+        _market_context_dimension(
+            market_context_status=market_context_status,
+            now=generated_at,
+        ),
+        _quant_evidence_dimension(quant_evidence),
+        source_dimension,
+    ]
+    ledger_payload = {
+        "account_label": account_label,
+        "window": window,
+        "source_serving_ledger_ref": source_serving_repair_receipt_ledger.get(
+            "ledger_id"
+        ),
+        "route_warrant_ref": route_warrant_exchange.get("warrant_id"),
+        "dimensions": [
+            {
+                "dimension_id": dimension["dimension_id"],
+                "state": dimension["state"],
+                "stale_reason_codes": dimension["stale_reason_codes"],
+            }
+            for dimension in dimensions
+        ],
+    }
+    ledger_id = _stable_ref("freshness-carry-ledger", ledger_payload)
+    source_current = _text(source_dimension.get("state")) == "current"
+    repair_proof_slos = _repair_slos(
+        ledger_id=ledger_id,
+        dimensions=dimensions,
+        source_serving_current=source_current,
+    )
+    non_current_count = sum(
+        1 for dimension in dimensions if _text(dimension.get("state")) != "current"
+    )
+    capital_posture = _capital_posture(
+        dimensions=dimensions,
+        source_serving_dimension=source_dimension,
+        route_warrant_exchange=route_warrant_exchange,
+        live_submission_gate=live_submission_gate,
+    )
+
+    return {
+        "schema_version": FRESHNESS_CARRY_LEDGER_SCHEMA_VERSION,
+        "ledger_id": ledger_id,
+        "generated_at": generated_at.isoformat(),
+        "fresh_until": (
+            generated_at + timedelta(seconds=_FRESHNESS_SECONDS)
+        ).isoformat(),
+        "account": account_label,
+        "window": window,
+        "source_serving_ledger_ref": source_serving_repair_receipt_ledger.get(
+            "ledger_id"
+        ),
+        "route_warrant_ref": route_warrant_exchange.get("warrant_id"),
+        "dimensions": dimensions,
+        "repair_proof_slos": repair_proof_slos,
+        "capital_posture": capital_posture,
+        "jangar_pressure_refs": [dict(item) for item in jangar_pressure_refs or ()],
+        "value_gate_impacts": _value_gate_impacts(dimensions),
+        "summary": {
+            "dimension_count": len(dimensions),
+            "non_current_dimension_count": non_current_count,
+            "dispatchable_repair_slo_count": sum(
+                1 for slo in repair_proof_slos if _bool(slo.get("dispatchable"))
+            ),
+            "zero_notional_or_stale_evidence_rate": (
+                str(Decimal(non_current_count) / Decimal(len(dimensions)))
+                if dimensions
+                else "0"
+            ),
+            "capital_posture": capital_posture["decision"],
+            "max_notional": capital_posture["max_notional"],
+        },
+        "rollback_target": {
+            "freshness_carry_ledger_enabled": False,
+            "capital_state": "zero_notional",
+            "fallback_payload": "torghut.source-serving-repair-receipt-ledger.v1",
+        },
+    }
+
+
+__all__ = [
+    "FRESHNESS_CARRY_LEDGER_SCHEMA_VERSION",
+    "build_freshness_carry_ledger",
+]

--- a/services/torghut/tests/test_freshness_carry.py
+++ b/services/torghut/tests/test_freshness_carry.py
@@ -163,3 +163,122 @@ def test_source_serving_gap_holds_non_source_freshness_repairs() -> None:
     assert source_slo["dispatchable"] is True
     assert tca_slo["dispatchable"] is False
     assert tca_slo["hold_reason_codes"] == ["source_serving_not_current"]
+
+
+def test_malformed_freshness_inputs_are_repair_only_with_typed_reasons() -> None:
+    ledger = _build(
+        source_serving_repair_receipt_ledger={
+            "schema_version": "torghut.source-serving-repair-receipt-ledger.v1",
+            "ledger_id": "source-serving:unknown",
+            "source_serving_state": "booting",
+            "generated_at": "not-a-date",
+            "reason_codes": [],
+        },
+        clickhouse_ta_status={
+            "state": "warming",
+            "latest_signal_at": "2026-05-13T09:14:40Z",
+            "low_memory_fallback_count": True,
+            "source_ref": "torghut.ta_signals",
+        },
+        tca_summary={
+            "order_count": True,
+            "expected_shortfall_coverage": "not-a-decimal",
+            "last_computed_at": "",
+        },
+        empirical_jobs_status={
+            "ready": "false",
+            "status": "degraded",
+            "authority": "empirical",
+            "stale_jobs": ["ranker"],
+            "missing_jobs": [],
+            "ineligible_jobs": [],
+        },
+        market_context_status={
+            "last_checked_at": "not-a-date",
+            "last_freshness_seconds": 1_200,
+            "max_staleness_seconds": 900,
+            "last_risk_flags": [],
+            "health_error": "timeout",
+            "last_symbol": "AAPL",
+        },
+        quant_evidence={
+            "ok": "false",
+            "required": "true",
+            "reason": "quant_evidence_stale",
+            "checked_at": "not-a-date",
+            "window": "15m",
+        },
+        live_submission_gate={
+            "allowed": "false",
+            "reason": "",
+        },
+    )
+
+    assert ledger["capital_posture"]["decision"] == "repair_only"
+    assert ledger["capital_posture"]["max_notional"] == "0"
+    assert "live_submission_gate_closed" in ledger["capital_posture"]["reason_codes"]
+
+    ta_dimension = _dimension(ledger, "ta_signals")
+    assert ta_dimension["state"] == "unknown"
+    assert ta_dimension["low_memory_fallback_count"] == 1
+    assert ta_dimension["max_event_at"] == "2026-05-13T09:14:40+00:00"
+    assert "clickhouse_ta_warming" in ta_dimension["stale_reason_codes"]
+
+    assert _dimension(ledger, "tca")["state"] == "missing"
+    assert "tca_computed_at_missing" in _dimension(ledger, "tca")["stale_reason_codes"]
+    assert _dimension(ledger, "empirical")["state"] == "stale"
+    assert _dimension(ledger, "market_context")["state"] == "stale"
+    assert (
+        "market_context_health_error"
+        in _dimension(ledger, "market_context")["stale_reason_codes"]
+    )
+    assert _dimension(ledger, "quant_evidence")["state"] == "stale"
+    assert _dimension(ledger, "source_serving")["state"] == "unknown"
+    assert (
+        "source_serving_booting"
+        in _dimension(ledger, "source_serving")["stale_reason_codes"]
+    )
+
+
+def test_tca_missing_timestamp_and_stale_receipts_open_repair_slos() -> None:
+    missing_timestamp_ledger = _build(
+        tca_summary={
+            "order_count": 8,
+            "expected_shortfall_coverage": "0.75",
+            "last_computed_at": "",
+        }
+    )
+    stale_ledger = _build(
+        tca_summary={
+            "order_count": 8,
+            "expected_shortfall_coverage": "0.75",
+            "last_computed_at": (NOW - timedelta(days=2)).isoformat(),
+        }
+    )
+
+    missing_tca = _dimension(missing_timestamp_ledger, "tca")
+    stale_tca = _dimension(stale_ledger, "tca")
+    assert missing_tca["state"] == "missing"
+    assert missing_tca["stale_reason_codes"] == ["tca_computed_at_missing"]
+    assert stale_tca["state"] == "stale"
+    assert stale_tca["stale_reason_codes"] == ["tca_computed_at_stale"]
+    assert any(
+        slo["target_dimension_id"] == "tca" for slo in stale_ledger["repair_proof_slos"]
+    )
+
+
+def test_current_freshness_can_be_live_candidate_without_widening_route_warrant() -> (
+    None
+):
+    ledger = _build(
+        route_warrant_exchange={
+            "schema_version": "torghut.route-warrant-exchange.v1",
+            "warrant_id": "route-warrant:live",
+            "warrant_state": "live_micro_candidate",
+            "max_notional": "5",
+        }
+    )
+
+    assert ledger["capital_posture"]["decision"] == "live_candidate"
+    assert ledger["capital_posture"]["max_notional"] == "5"
+    assert ledger["repair_proof_slos"] == []

--- a/services/torghut/tests/test_freshness_carry.py
+++ b/services/torghut/tests/test_freshness_carry.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any, cast
+
+from app.trading.freshness_carry import (
+    FRESHNESS_CARRY_LEDGER_SCHEMA_VERSION,
+    build_freshness_carry_ledger,
+)
+
+
+NOW = datetime(2026, 5, 13, 9, 15, tzinfo=timezone.utc)
+
+
+def _base_inputs() -> dict[str, object]:
+    return {
+        "account_label": "PA3SX7FYNUTF",
+        "window": "15m",
+        "source_serving_repair_receipt_ledger": {
+            "schema_version": "torghut.source-serving-repair-receipt-ledger.v1",
+            "ledger_id": "source-serving:current",
+            "source_serving_state": "converged",
+            "generated_at": NOW.isoformat(),
+            "reason_codes": [],
+        },
+        "route_warrant_exchange": {
+            "schema_version": "torghut.route-warrant-exchange.v1",
+            "warrant_id": "route-warrant:current",
+            "warrant_state": "paper_candidate",
+            "max_notional": "25",
+        },
+        "clickhouse_ta_status": {
+            "state": "current",
+            "latest_signal_at": (NOW - timedelta(seconds=30)).isoformat(),
+            "source_ref": "torghut.ta_signals",
+        },
+        "tca_summary": {
+            "order_count": 24,
+            "expected_shortfall_coverage": "0.75",
+            "last_computed_at": (NOW - timedelta(minutes=5)).isoformat(),
+        },
+        "empirical_jobs_status": {
+            "ready": True,
+            "status": "healthy",
+            "authority": "empirical",
+            "stale_jobs": [],
+            "missing_jobs": [],
+            "ineligible_jobs": [],
+        },
+        "market_context_status": {
+            "last_checked_at": (NOW - timedelta(seconds=20)).isoformat(),
+            "last_freshness_seconds": 20,
+            "max_staleness_seconds": 900,
+            "last_risk_flags": [],
+            "alert_active": False,
+            "last_symbol": "AAPL",
+        },
+        "quant_evidence": {
+            "ok": True,
+            "required": True,
+            "window": "15m",
+        },
+        "live_submission_gate": {
+            "allowed": True,
+            "reason": "ok",
+        },
+        "now": NOW,
+    }
+
+
+def _build(**overrides: object) -> dict[str, object]:
+    payload = _base_inputs()
+    payload.update(overrides)
+    return build_freshness_carry_ledger(**payload)  # type: ignore[arg-type]
+
+
+def _dimension(ledger: dict[str, object], dimension_id: str) -> dict[str, Any]:
+    dimensions = cast(list[dict[str, Any]], ledger["dimensions"])
+    return next(
+        dimension
+        for dimension in dimensions
+        if dimension["dimension_id"] == dimension_id
+    )
+
+
+def test_partial_ta_freshness_keeps_capital_zero_and_opens_repair_slo() -> None:
+    ledger = _build(
+        clickhouse_ta_status={
+            "state": "current",
+            "latest_signal_at": (NOW - timedelta(hours=2)).isoformat(),
+            "source_ref": "torghut.ta_signals",
+        }
+    )
+
+    assert ledger["schema_version"] == FRESHNESS_CARRY_LEDGER_SCHEMA_VERSION
+    assert ledger["capital_posture"]["decision"] == "repair_only"
+    assert ledger["capital_posture"]["max_notional"] == "0"
+    assert _dimension(ledger, "ta_signals")["state"] == "stale"
+    assert "ta_signal_lag_exceeded" in ledger["capital_posture"]["reason_codes"]
+    assert (
+        ledger["summary"]["zero_notional_or_stale_evidence_rate"]
+        == "0.1666666666666666666666666667"
+    )
+
+    ta_slo = next(
+        slo
+        for slo in ledger["repair_proof_slos"]
+        if slo["target_dimension_id"] == "ta_signals"
+    )
+    assert ta_slo["dispatchable"] is True
+    assert ta_slo["max_notional"] == "0"
+    assert ta_slo["target_value_gate"] == "zero_notional_or_stale_evidence_rate"
+    assert ta_slo["required_output_receipts"] == [
+        "torghut.ta-freshness-repair-receipt.v1"
+    ]
+
+
+def test_current_freshness_can_be_paper_candidate_without_widening_route_warrant() -> (
+    None
+):
+    ledger = _build()
+
+    assert ledger["capital_posture"]["decision"] == "paper_candidate"
+    assert ledger["capital_posture"]["max_notional"] == "25"
+    assert ledger["capital_posture"]["reason_codes"] == []
+    assert ledger["repair_proof_slos"] == []
+    assert ledger["summary"]["zero_notional_or_stale_evidence_rate"] == "0"
+    assert all(
+        dimension["stale_reason_codes"] == [] for dimension in ledger["dimensions"]
+    )
+
+
+def test_source_serving_gap_holds_non_source_freshness_repairs() -> None:
+    ledger = _build(
+        source_serving_repair_receipt_ledger={
+            "schema_version": "torghut.source-serving-repair-receipt-ledger.v1",
+            "ledger_id": "source-serving:stale",
+            "source_serving_state": "digest_unknown",
+            "generated_at": NOW.isoformat(),
+            "reason_codes": ["serving_image_digest_missing"],
+        },
+        tca_summary={
+            "order_count": 24,
+            "expected_shortfall_coverage": "0.10",
+            "last_computed_at": (NOW - timedelta(minutes=5)).isoformat(),
+        },
+    )
+
+    assert ledger["capital_posture"]["decision"] == "repair_only"
+    assert _dimension(ledger, "source_serving")["state"] == "stale"
+    assert _dimension(ledger, "tca")["state"] == "low_confidence"
+
+    source_slo = next(
+        slo
+        for slo in ledger["repair_proof_slos"]
+        if slo["target_dimension_id"] == "source_serving"
+    )
+    tca_slo = next(
+        slo
+        for slo in ledger["repair_proof_slos"]
+        if slo["target_dimension_id"] == "tca"
+    )
+    assert source_slo["dispatchable"] is True
+    assert tca_slo["dispatchable"] is False
+    assert tca_slo["hold_reason_codes"] == ["source_serving_not_current"]

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -1116,6 +1116,22 @@ class TestTradingApi(TestCase):
             source_serving["route_warrant_ref"],
             warrant["warrant_id"],
         )
+        freshness_carry = payload["freshness_carry_ledger"]
+        self.assertEqual(
+            freshness_carry["schema_version"],
+            "torghut.freshness-carry-ledger.v1",
+        )
+        self.assertEqual(freshness_carry["capital_posture"]["max_notional"], "0")
+        self.assertIn("dimensions", freshness_carry)
+        self.assertIn("repair_proof_slos", freshness_carry)
+        self.assertEqual(
+            freshness_carry["source_serving_ledger_ref"],
+            source_serving["ledger_id"],
+        )
+        self.assertEqual(
+            freshness_carry["route_warrant_ref"],
+            warrant["warrant_id"],
+        )
         frontier = payload["profit_freshness_frontier"]
         self.assertEqual(
             frontier["schema_version"],
@@ -1635,6 +1651,22 @@ class TestTradingApi(TestCase):
         self.assertEqual(
             health_source_serving["schema_version"],
             status_source_serving["schema_version"],
+        )
+        status_freshness_carry = status_response.json()["freshness_carry_ledger"]
+        health_freshness_carry = health_response.json()["freshness_carry_ledger"]
+        self.assertEqual(
+            status_freshness_carry["schema_version"],
+            "torghut.freshness-carry-ledger.v1",
+        )
+        self.assertEqual(
+            status_freshness_carry["capital_posture"]["max_notional"],
+            "0",
+        )
+        self.assertIn("dimensions", status_freshness_carry)
+        self.assertIn("repair_proof_slos", status_freshness_carry)
+        self.assertEqual(
+            health_freshness_carry["schema_version"],
+            status_freshness_carry["schema_version"],
         )
         status_frontier = status_response.json()["profit_freshness_frontier"]
         health_frontier = health_response.json()["profit_freshness_frontier"]


### PR DESCRIPTION
## Summary

- Implements the May 13 Torghut doc 192 engineer milestone 1 by publishing `torghut.freshness-carry-ledger.v1` as an observe-mode runtime ledger.
- Exposes `freshness_carry_ledger` on `/trading/consumer-evidence`, `/trading/status`, `/trading/health`, and `/readyz`.
- Prices TA signal, TCA, empirical, market-context, quant-evidence, and source-serving freshness as explicit dimensions with bounded zero-notional repair proof SLOs.
- Updates Torghut source-of-truth docs and service README so freshness-carry is documented as the current post-source-serving readiness handoff.

## Design and Requirement Provenance

Governing design: `docs/torghut/design-system/v6/192-torghut-freshness-carry-and-repair-proof-slo-2026-05-13.md`.

Swarm runtime baseline: `docs/agents/designs/swarm-agentic-mission-architecture-2026-05-08.md`.

Runtime requirement source: torghut-quant swarm objective payload for increasing routeable post-cost profit evidence and live trading readiness without weakening capital safety.

Value gates improved: `zero_notional_or_stale_evidence_rate`, `routeable_candidate_count`, `fill_tca_or_slippage_quality`, `capital_gate_safety`, and `post_cost_daily_net_pnl`.

## Related Issues

None. Runtime requirement provenance is the torghut-quant swarm objective payload and the governing Torghut design document above.

## Testing

- PASS: `/root/.local/bin/uv sync --frozen --extra dev`
- PASS: `/root/.local/bin/uv run --frozen ruff format app/trading/freshness_carry.py tests/test_freshness_carry.py tests/test_trading_api.py app/main.py`
- PASS: `/root/.local/bin/uv run --frozen ruff format app/trading/freshness_carry.py tests/test_freshness_carry.py`
- PASS: `/root/.local/bin/uv run --frozen ruff check app/trading/freshness_carry.py tests/test_freshness_carry.py app/main.py tests/test_trading_api.py`
- PASS: `/root/.local/bin/uv run --frozen pytest tests/test_freshness_carry.py`
- PASS: `/root/.local/bin/uv run --frozen pytest tests/test_trading_api.py -k 'test_trading_status_and_health_include_profitability_proof_floor or test_trading_consumer_evidence'`
- PASS: `/root/.local/bin/uv run --frozen pytest tests/test_freshness_carry.py tests/test_source_serving_repair_receipt.py tests/test_repair_bid_settlement.py tests/test_zero_notional_repair_executor.py tests/test_consumer_evidence.py tests/test_route_warrant_exchange.py tests/test_trading_api.py::TestTradingApi::test_trading_consumer_evidence_avoids_recursive_jangar_status_fetch tests/test_trading_api.py::TestTradingApi::test_trading_status_and_health_include_profitability_proof_floor`
- PASS: `/root/.local/bin/uv run --frozen pytest --cov --cov-branch --cov-fail-under=0 --cov-report=xml tests/test_freshness_carry.py tests/test_source_serving_repair_receipt.py tests/test_repair_bid_settlement.py tests/test_zero_notional_repair_executor.py tests/test_consumer_evidence.py tests/test_route_warrant_exchange.py tests/test_trading_api.py::TestTradingApi::test_trading_consumer_evidence_avoids_recursive_jangar_status_fetch tests/test_trading_api.py::TestTradingApi::test_trading_status_and_health_include_profitability_proof_floor`
- PASS: `/root/.local/bin/uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90` with changed-line coverage at 96.80%
- PASS: `/root/.local/bin/uv run --frozen pyright --project pyrightconfig.json`
- PASS: `/root/.local/bin/uv run --frozen pyright --project pyrightconfig.alpha.json`
- PASS: `/root/.local/bin/uv run --frozen pyright --project pyrightconfig.scripts.json`
- PASS: `bunx oxfmt --check docs/torghut/README.md docs/torghut/design-system/current-source-of-truth-and-priority-guide-2026-03-09.md docs/torghut/design-system/v6/192-torghut-freshness-carry-and-repair-proof-slo-2026-05-13.md services/torghut/README.md`
- PASS: `git diff --cached --check`

## Risk and Rollback

Risk is limited to read-model payload shape and endpoint response size. The new ledger does not write to storage, submit orders, mutate route warrants, or widen live-submission gates.

Rollback path: revert this PR, or have consumers ignore `freshness_carry_ledger` and continue relying on existing source-serving, route-warrant, and live-submission gate payloads.

## Screenshots (if applicable)

N/A.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
