### PR TITLE
fix(torghut): enforce portfolio sleeve minimum

### DIFF
--- a/services/torghut/app/trading/discovery/portfolio_optimizer.py
+++ b/services/torghut/app/trading/discovery/portfolio_optimizer.py
@@ -349,7 +349,9 @@ def _portfolio_scorecard(
         _string(_scorecard(bundle).get("shadow_parity_status")) for bundle in selected
     }
     executable_artifact_refs = [
-        ref for ref in (_executable_replay_artifact_ref(bundle) for bundle in selected) if ref
+        ref
+        for ref in (_executable_replay_artifact_ref(bundle) for bundle in selected)
+        if ref
     ]
     executable_order_count = sum(
         _executable_replay_order_count(bundle) for bundle in selected
@@ -443,6 +445,8 @@ def optimize_portfolio_candidate(
     portfolio_size_max: int = 8,
 ) -> PortfolioCandidateSpec | None:
     oracle_policy = oracle_policy or ProfitTargetOraclePolicy()
+    requested_portfolio_size_min = max(1, int(portfolio_size_min))
+    requested_portfolio_size_max = max(1, int(portfolio_size_max))
     invalid_evidence_rejections = [
         {
             "candidate_id": bundle.candidate_id,
@@ -466,7 +470,10 @@ def optimize_portfolio_candidate(
     max_allowed_correlation = MAX_ALLOWED_PAIRWISE_CORRELATION
     for bundle in ordered:
         cluster = _cluster_id(bundle)
-        if cluster in selected_clusters and len(selected) >= portfolio_size_min:
+        if (
+            cluster in selected_clusters
+            and len(selected) >= requested_portfolio_size_min
+        ):
             rejected.append(
                 {
                     "candidate_id": bundle.candidate_id,
@@ -478,7 +485,7 @@ def optimize_portfolio_candidate(
         max_correlation = _max_pairwise_correlation(bundle, selected)
         if (
             max_correlation > max_allowed_correlation
-            and len(selected) >= portfolio_size_min
+            and len(selected) >= requested_portfolio_size_min
         ):
             rejected.append(
                 {
@@ -490,9 +497,9 @@ def optimize_portfolio_candidate(
             continue
         selected.append(bundle)
         selected_clusters.add(cluster)
-        if len(selected) >= max(1, portfolio_size_max):
+        if len(selected) >= requested_portfolio_size_max:
             break
-        if len(selected) >= portfolio_size_min:
+        if len(selected) >= requested_portfolio_size_min:
             candidate_scorecard = _portfolio_scorecard(
                 selected=selected,
                 target_net_pnl_per_day=target_net_pnl_per_day,
@@ -500,7 +507,7 @@ def optimize_portfolio_candidate(
             )
             if bool(candidate_scorecard.get("oracle_passed")):
                 break
-    if not selected:
+    if not selected or len(selected) < requested_portfolio_size_min:
         return None
 
     source_candidate_ids = tuple(item.candidate_id for item in selected)

--- a/services/torghut/tests/test_portfolio_optimizer.py
+++ b/services/torghut/tests/test_portfolio_optimizer.py
@@ -111,6 +111,55 @@ class TestPortfolioOptimizer(TestCase):
             reloaded.objective_scorecard["profit_target_oracle"]["blockers"], []
         )
 
+    def test_optimizer_rejects_undersized_portfolio_candidate(self) -> None:
+        bundle = evidence_bundle_from_frontier_candidate(
+            candidate_spec_id="spec-single-sleeve",
+            candidate={
+                "candidate_id": "cand-single-sleeve",
+                "runtime_family": "microbar_cross_sectional_pairs",
+                "runtime_strategy_name": "microbar-cross-sectional-pairs-v1",
+                "family_template_id": "microbar_cross_sectional_pairs_v1",
+                "objective_scorecard": {
+                    "net_pnl_per_day": "2100",
+                    "active_day_ratio": "1.0",
+                    "positive_day_ratio": "0.33",
+                    "worst_day_loss": "447",
+                    "max_drawdown": "548",
+                    "best_day_share": "1.0",
+                    "avg_filled_notional_per_day": "318444",
+                    "regime_slice_pass_rate": "0.55",
+                    "posterior_edge_lower": "0.01",
+                    "shadow_parity_status": "within_budget",
+                    "correlation_cluster": "single-sleeve-cluster",
+                    "symbol_contribution_shares": {"NVDA": "1.0"},
+                    **_executable_scorecard_fields("single-sleeve"),
+                },
+                "full_window": {
+                    "daily_net": {
+                        "2026-04-29": "-100.37",
+                        "2026-04-30": "-447.41",
+                        "2026-05-01": "6835.18",
+                    },
+                    "daily_filled_notional": {
+                        "2026-04-29": "318444",
+                        "2026-04-30": "318444",
+                        "2026-05-01": "318444",
+                    },
+                },
+            },
+            dataset_snapshot_id="snapshot-single-sleeve",
+            result_path="/tmp/single-sleeve.json",
+        )
+
+        portfolio = optimize_portfolio_candidate(
+            evidence_bundles=[bundle],
+            target_net_pnl_per_day=Decimal("500"),
+            portfolio_size_min=3,
+            portfolio_size_max=3,
+        )
+
+        self.assertIsNone(portfolio)
+
     def test_invalid_portfolio_candidate_payload_is_rejected(self) -> None:
         with self.assertRaisesRegex(ValueError, "portfolio_candidate_schema_invalid"):
             portfolio_candidate_from_payload({"schema_version": "bad"})


### PR DESCRIPTION
## Summary

- Enforces `portfolio_size_min` in the Torghut deterministic portfolio optimizer before returning a candidate.
- Prevents autoresearch from emitting undersized one-sleeve portfolios when a diversified portfolio is explicitly required.
- Adds a regression test for the live failure shape where only one eligible sleeve exists while the requested minimum is three.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_portfolio_optimizer.py`
- `uv run --frozen ruff format --check app/trading/discovery/portfolio_optimizer.py tests/test_portfolio_optimizer.py`
- `uv run --frozen ruff check app/trading/discovery/portfolio_optimizer.py tests/test_portfolio_optimizer.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py tests/test_whitepaper_autoresearch_artifacts.py`
- `git diff --check`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
