### PR TITLE
fix(torghut): prioritize feature coverage repair lots

### DIFF
--- a/services/torghut/app/trading/repair_bid_settlement.py
+++ b/services/torghut/app/trading/repair_bid_settlement.py
@@ -68,6 +68,13 @@ _LOT_RECEIPT = {
     "feature_lineage": "torghut.feature-lineage-current-receipt.v1",
 }
 
+_FEATURE_COVERAGE_BLOCKERS = {
+    "feature_rows_missing",
+    "required_feature_set_unavailable",
+    "equity_ta_rows_missing",
+    "options_feature_rows_missing",
+}
+
 _LOT_VALIDATION = {
     "quant_pipeline": "pytest services/torghut/tests/test_repair_bid_settlement.py -k quant_pipeline",
     "execution_tca": "pytest services/torghut/tests/test_repair_bid_settlement.py -k execution_tca",
@@ -371,6 +378,15 @@ def _expected_gate_delta(lot_class: str, reason_codes: Sequence[str]) -> str:
     return f"settle_{lot_class}"
 
 
+def _lot_priority(lot_class: str, reason_codes: Sequence[str]) -> int:
+    priority = _LOT_PRIORITY[lot_class]
+    if lot_class != "feature_lineage":
+        return priority
+    if any(reason in _FEATURE_COVERAGE_BLOCKERS for reason in reason_codes):
+        return 95
+    return priority
+
+
 def _build_lot(
     *,
     account_id: str,
@@ -408,7 +424,7 @@ def _build_lot(
         "lot_id": _ref("compacted-repair-lot", lot_payload),
         "lot_class": lot_class,
         "target_value_gate": _LOT_VALUE_GATE[lot_class],
-        "priority": _LOT_PRIORITY[lot_class],
+        "priority": _lot_priority(lot_class, reason_codes),
         "expected_gate_delta": _expected_gate_delta(lot_class, reason_codes),
         "raw_reason_codes": list(reason_codes),
         "root_cause_hypothesis": _root_cause(lot_class),

--- a/services/torghut/tests/test_repair_bid_settlement.py
+++ b/services/torghut/tests/test_repair_bid_settlement.py
@@ -181,6 +181,42 @@ def test_degraded_jangar_scoped_quant_status_creates_typed_dispatchable_lot() ->
     assert lot["required_output_receipt"] == "torghut.quant-pipeline-current-receipt.v1"
 
 
+def test_feature_coverage_preempts_generic_rollout_repair() -> None:
+    ledger = _build(
+        reason_codes=[
+            "quant_pipeline_degraded",
+            "execution_tca_stale",
+            "route_adjacent_workload_proof_missing",
+            "post_cost_expectancy_non_positive",
+            "alpha_readiness_not_promotion_eligible",
+            "feature_rows_missing",
+            "required_feature_set_unavailable",
+        ]
+    )
+    lots_by_class = {lot["lot_class"]: lot for lot in ledger["compacted_lots"]}
+    dispatchable_classes = [
+        lot["lot_class"]
+        for lot in ledger["compacted_lots"]
+        if lot.get("dispatchable") is True
+    ]
+
+    assert lots_by_class["feature_lineage"]["state"] == "selected"
+    assert lots_by_class["feature_lineage"]["dispatchable"] is True
+    assert lots_by_class["feature_lineage"]["priority"] == 95
+    assert (
+        "feature_rows_missing" in lots_by_class["feature_lineage"]["raw_reason_codes"]
+    )
+    assert (
+        "required_feature_set_unavailable"
+        in lots_by_class["feature_lineage"]["raw_reason_codes"]
+    )
+    assert dispatchable_classes == [
+        "quant_pipeline",
+        "feature_lineage",
+        "execution_tca",
+    ]
+
+
 def test_string_booleans_and_rollout_workload_gaps_create_typed_lots() -> None:
     ledger = _build(
         jangar_status={


### PR DESCRIPTION
## Summary

- Prioritizes Torghut feature-coverage repair lots when live alpha readiness is blocked by missing feature rows or required feature sets.
- Keeps all repair lots zero-notional and preserves capital safety while steering implementer work toward the current revenue blocker.
- Adds regression coverage proving feature-lineage repair is selected and dispatchable ahead of generic rollout repair work.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_repair_bid_settlement.py`
- `uv run --frozen ruff check app/trading/repair_bid_settlement.py tests/test_repair_bid_settlement.py`
- `uv run --frozen ruff format --check app/trading/repair_bid_settlement.py tests/test_repair_bid_settlement.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
