### PR TITLE
fix(torghut): execute feature coverage repair lots

### DIFF
--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -83,6 +83,10 @@ from .trading.evidence_receipts import (
     build_service_health_receipt,
 )
 from .trading.executable_alpha_receipts import build_capital_replay_projection
+from .trading.feature_quality import (
+    FeatureQualityThresholds,
+    evaluate_feature_batch_quality,
+)
 from .trading.forecast_runtime import forecast_status
 from .trading.freshness_carry import build_freshness_carry_ledger
 from .trading.hypotheses import (
@@ -126,6 +130,7 @@ from .trading.submission_council import (
     resolve_active_capital_stage,
 )
 from .trading.ingest import ClickHouseSignalIngestor
+from .trading.models import SignalEnvelope
 from .trading.tca import build_tca_gate_inputs, refresh_execution_tca_metrics
 from .trading.simulation_progress import (
     active_simulation_runtime_context,
@@ -1488,6 +1493,7 @@ def trading_profit_freshness_zero_notional_repair(
     ),
     tca_limit: int = Query(default=250, ge=1, le=5000),
     drift_limit: int = Query(default=500, ge=1, le=5000),
+    feature_limit: int = Query(default=500, ge=1, le=5000),
     repair_lot_dispatch_ticket: dict[str, Any] | None = Body(
         default=None,
         description=(
@@ -1649,6 +1655,142 @@ def trading_profit_freshness_zero_notional_repair(
             },
         }
 
+    def run_feature_coverage_replay(repair: Mapping[str, Any]) -> Mapping[str, object]:
+        scheduler: TradingScheduler | None = getattr(
+            app.state, "trading_scheduler", None
+        )
+        pipeline = getattr(scheduler, "_pipeline", None) if scheduler else None
+        ingestor = getattr(pipeline, "ingestor", None)
+        fetch_with_reason = getattr(ingestor, "fetch_signals_with_reason", None)
+        if not callable(fetch_with_reason) or scheduler is None:
+            return {
+                "execution_state": "runner_failed",
+                "command_exit_code": 78,
+                "blocked_reasons": ["feature_coverage_runner_unavailable"],
+                "after_refs": [],
+            }
+
+        now = datetime.now(timezone.utc)
+        lookback_minutes = max(1, int(settings.trading_signal_lookback_minutes))
+        symbol_set = {
+            str(symbol).strip().upper()
+            for symbol in cast(Sequence[object], repair.get("symbol_set") or [])
+            if str(symbol).strip()
+        }
+
+        def select_signals(batch: Any) -> list[Any]:
+            return [
+                signal
+                for signal in cast(Sequence[Any], getattr(batch, "signals", []))
+                if not symbol_set
+                or str(getattr(signal, "symbol", "")).strip().upper() in symbol_set
+            ]
+
+        def replay_window_from_latest_signal() -> tuple[Any | None, list[Any]]:
+            latest_status_fn = getattr(ingestor, "latest_signal_status", None)
+            if not callable(latest_status_fn):
+                return None, []
+            latest_status = latest_status_fn()
+            if not isinstance(latest_status, Mapping):
+                return None, []
+            latest_status_mapping = cast(Mapping[str, object], latest_status)
+            latest_signal_at = latest_status_mapping.get("latest_signal_at")
+            if not isinstance(latest_signal_at, datetime):
+                return None, []
+            if latest_signal_at.tzinfo is None:
+                latest_signal_at = latest_signal_at.replace(tzinfo=timezone.utc)
+            else:
+                latest_signal_at = latest_signal_at.astimezone(timezone.utc)
+            fallback_batch = fetch_with_reason(
+                start=latest_signal_at - timedelta(minutes=lookback_minutes),
+                end=latest_signal_at,
+                limit=feature_limit,
+            )
+            return fallback_batch, select_signals(fallback_batch)
+
+        try:
+            batch = fetch_with_reason(
+                start=now - timedelta(minutes=lookback_minutes),
+                end=now,
+                limit=feature_limit,
+            )
+            signals = select_signals(batch)
+            replay_window = "current"
+            if not signals:
+                fallback_batch, fallback_signals = replay_window_from_latest_signal()
+                if fallback_signals:
+                    batch = fallback_batch
+                    signals = fallback_signals
+                    replay_window = "latest_signal"
+            if not signals:
+                no_signal_reason = str(
+                    getattr(batch, "no_signal_reason", None) or "no_signals"
+                )
+                return {
+                    "execution_state": "runner_blocked",
+                    "command_exit_code": 78,
+                    "blocked_reasons": [
+                        f"feature_coverage_no_signals:{no_signal_reason}"
+                    ],
+                    "after_refs": [],
+                    "result": {
+                        "query_start": getattr(batch, "query_start", None),
+                        "query_end": getattr(batch, "query_end", None),
+                        "symbol_set": sorted(symbol_set),
+                        "replay_window": replay_window,
+                    },
+                }
+
+            quality_report = evaluate_feature_batch_quality(
+                cast(list[SignalEnvelope], signals),
+                thresholds=FeatureQualityThresholds(
+                    max_required_null_rate=settings.trading_feature_max_required_null_rate,
+                    max_staleness_ms=settings.trading_feature_max_staleness_ms,
+                    max_duplicate_ratio=settings.trading_feature_max_duplicate_ratio,
+                ),
+            )
+            metrics = scheduler.state.metrics
+            metrics.feature_batch_rows_total = max(
+                int(getattr(metrics, "feature_batch_rows_total", 0) or 0),
+                quality_report.rows_total,
+            )
+            metrics.feature_null_rate = dict(quality_report.null_rate_by_field)
+            metrics.feature_staleness_ms_p95 = quality_report.staleness_ms_p95
+            metrics.feature_duplicate_ratio = quality_report.duplicate_ratio
+            metrics.feature_schema_mismatch_total += (
+                quality_report.schema_mismatch_total
+            )
+            if not quality_report.accepted:
+                metrics.feature_quality_rejections_total += 1
+                metrics.record_feature_quality_rejection(quality_report.reasons)
+        except Exception as exc:  # pragma: no cover - fail-closed receipt path
+            logger.exception("Zero-notional feature-coverage repair failed")
+            return {
+                "execution_state": "runner_failed",
+                "command_exit_code": 1,
+                "blocked_reasons": [
+                    f"feature_coverage_replay_failed:{type(exc).__name__}"
+                ],
+                "after_refs": [],
+            }
+
+        return {
+            "execution_state": "executed",
+            "command_exit_code": 0,
+            "after_refs": ["feature_coverage_rows"],
+            "result": {
+                "signals_evaluated": len(signals),
+                "rows_total": quality_report.rows_total,
+                "accepted": quality_report.accepted,
+                "reason_codes": list(quality_report.reasons),
+                "symbol_set": sorted(symbol_set),
+                "replay_window": replay_window,
+                "query_start": getattr(batch, "query_start", None),
+                "query_end": getattr(batch, "query_end", None),
+                "feature_batch_rows_total": metrics.feature_batch_rows_total,
+            },
+        }
+
     receipt = run_zero_notional_repair(
         account_label=settings.trading_account_label,
         trading_mode=settings.trading_mode,
@@ -1661,6 +1803,7 @@ def trading_profit_freshness_zero_notional_repair(
         runners={
             "recompute_route_tca_and_fill_quality": run_tca_recompute,
             "rerun_drift_checks_for_blocked_hypotheses": run_drift_check_replay,
+            "rebuild_required_feature_rows": run_feature_coverage_replay,
         },
     )
     return cast(dict[str, object], jsonable_encoder(receipt))

--- a/services/torghut/app/trading/zero_notional_repair_executor.py
+++ b/services/torghut/app/trading/zero_notional_repair_executor.py
@@ -45,6 +45,13 @@ _ALLOWLIST: Mapping[str, Mapping[str, object]] = {
         "value_gate": "zero_notional_or_stale_evidence_rate",
         "rollback_path": "discard replayed drift receipt and keep the hypothesis repair lot queued",
     },
+    "rebuild_required_feature_rows": {
+        "executor": "hypothesis_feature_coverage_replay",
+        "runner_required": False,
+        "requires_torghut_admission": False,
+        "value_gate": "zero_notional_or_stale_evidence_rate",
+        "rollback_path": "discard replayed feature coverage receipt and keep the hypothesis repair lot queued",
+    },
 }
 
 

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -35,6 +35,7 @@ from app.main import (
     app,
 )
 from app.trading.scheduler import TradingScheduler
+from app.trading.feature_quality import FeatureQualityReport
 from app.trading.completion import (
     DOC29_SIMULATION_FULL_DAY_GATE,
     TRACE_STATUS_SATISFIED,
@@ -4275,6 +4276,349 @@ class TestTradingApi(TestCase):
             "latest_signal",
         )
         self.assertEqual(replayed, [["AAPL"]])
+        self.assertFalse(payload["order_submission_enabled"])
+
+    def test_zero_notional_repair_endpoint_rebuilds_feature_rows_from_latest_window(
+        self,
+    ) -> None:
+        status_payload = {
+            "active_revision": "torghut-00320",
+            "profit_freshness_frontier": {
+                "frontier_id": "profit-freshness-frontier:test",
+                "capital_posture": {
+                    "capital_state": "zero_notional",
+                    "paper_notional_limit": "0",
+                    "live_notional_limit": "0",
+                    "capital_behavior_changed": False,
+                },
+                "selected_zero_notional_repairs": [
+                    {
+                        "lot_id": "profit-freshness-repair-lot:features",
+                        "candidate_id": "candidate-a",
+                        "hypothesis_id": "H-AAPL",
+                        "blocked_dimension": "feature_coverage",
+                        "zero_notional_action": "rebuild_required_feature_rows",
+                        "before_refs": ["feature_coverage:AAPL:missing"],
+                        "symbol_set": ["AAPL"],
+                        "paper_notional_limit": "0",
+                        "live_notional_limit": "0",
+                        "state": "selected_zero_notional_repair",
+                    }
+                ],
+            },
+        }
+        fetched: list[dict[str, object]] = []
+        latest_signal_at = datetime(2026, 5, 12, 20, 57, tzinfo=timezone.utc)
+
+        def fetch_signals_with_reason(**kwargs: object) -> SimpleNamespace:
+            fetched.append(kwargs)
+            if len(fetched) == 1:
+                return SimpleNamespace(
+                    signals=[],
+                    no_signal_reason="cursor_ahead_of_stream",
+                    query_start=kwargs["start"],
+                    query_end=kwargs["end"],
+                )
+            return SimpleNamespace(
+                signals=[
+                    SimpleNamespace(symbol="AAPL"),
+                    SimpleNamespace(symbol="MSFT"),
+                ],
+                no_signal_reason=None,
+                query_start=kwargs["start"],
+                query_end=kwargs["end"],
+            )
+
+        metrics = SimpleNamespace(
+            feature_batch_rows_total=0,
+            feature_null_rate={},
+            feature_staleness_ms_p95=0,
+            feature_duplicate_ratio=0.0,
+            feature_schema_mismatch_total=0,
+            feature_quality_rejections_total=0,
+        )
+        scheduler = SimpleNamespace(
+            _pipeline=SimpleNamespace(
+                ingestor=SimpleNamespace(
+                    fetch_signals_with_reason=fetch_signals_with_reason,
+                    latest_signal_status=lambda: {"latest_signal_at": latest_signal_at},
+                ),
+            ),
+            state=SimpleNamespace(metrics=metrics),
+        )
+        app.state.trading_scheduler = scheduler
+        quality_report = FeatureQualityReport(
+            accepted=True,
+            rows_total=2,
+            null_rate_by_field={"macd": 0.0},
+            staleness_ms_p95=200,
+            duplicate_ratio=0.0,
+            schema_mismatch_total=0,
+            reasons=[],
+        )
+
+        with (
+            patch("app.main.trading_status", return_value=status_payload),
+            patch(
+                "app.main.evaluate_feature_batch_quality", return_value=quality_report
+            ),
+        ):
+            response = self.client.post(
+                "/trading/profit-freshness/zero-notional-repair"
+                "?action=rebuild_required_feature_rows&execute=true&feature_limit=25"
+            )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["execution_state"], "executed")
+        self.assertEqual(payload["command_exit_code"], 0)
+        self.assertEqual(payload["after_refs"], ["feature_coverage_rows"])
+        self.assertEqual(payload["runner_result"]["result"]["signals_evaluated"], 1)
+        self.assertEqual(payload["runner_result"]["result"]["rows_total"], 2)
+        self.assertEqual(
+            payload["runner_result"]["result"]["replay_window"],
+            "latest_signal",
+        )
+        self.assertEqual(metrics.feature_batch_rows_total, 2)
+        self.assertEqual(len(fetched), 2)
+        self.assertEqual(fetched[0]["limit"], 25)
+        self.assertEqual(fetched[1]["start"], latest_signal_at - timedelta(minutes=15))
+        self.assertEqual(fetched[1]["end"], latest_signal_at)
+        self.assertFalse(payload["order_submission_enabled"])
+
+    def test_zero_notional_repair_endpoint_fails_closed_without_feature_runner(
+        self,
+    ) -> None:
+        status_payload = {
+            "active_revision": "torghut-00320",
+            "profit_freshness_frontier": {
+                "frontier_id": "profit-freshness-frontier:test",
+                "capital_posture": {
+                    "capital_state": "zero_notional",
+                    "paper_notional_limit": "0",
+                    "live_notional_limit": "0",
+                    "capital_behavior_changed": False,
+                },
+                "selected_zero_notional_repairs": [
+                    {
+                        "lot_id": "profit-freshness-repair-lot:features",
+                        "candidate_id": "candidate-a",
+                        "hypothesis_id": "H-AAPL",
+                        "blocked_dimension": "feature_coverage",
+                        "zero_notional_action": "rebuild_required_feature_rows",
+                        "before_refs": ["feature_coverage:AAPL:missing"],
+                        "symbol_set": ["AAPL"],
+                        "paper_notional_limit": "0",
+                        "live_notional_limit": "0",
+                        "state": "selected_zero_notional_repair",
+                    }
+                ],
+            },
+        }
+        app.state.trading_scheduler = SimpleNamespace(
+            _pipeline=SimpleNamespace(ingestor=SimpleNamespace()),
+        )
+
+        with patch("app.main.trading_status", return_value=status_payload):
+            response = self.client.post(
+                "/trading/profit-freshness/zero-notional-repair"
+                "?action=rebuild_required_feature_rows&execute=true"
+            )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["execution_state"], "runner_failed")
+        self.assertEqual(payload["command_exit_code"], 78)
+        self.assertEqual(
+            payload["blocked_reasons"],
+            ["feature_coverage_runner_unavailable"],
+        )
+        self.assertEqual(payload["after_refs"], [])
+        self.assertFalse(payload["order_submission_enabled"])
+
+    def test_zero_notional_repair_endpoint_blocks_feature_replay_without_latest_window(
+        self,
+    ) -> None:
+        status_payload = {
+            "active_revision": "torghut-00320",
+            "profit_freshness_frontier": {
+                "frontier_id": "profit-freshness-frontier:test",
+                "capital_posture": {
+                    "capital_state": "zero_notional",
+                    "paper_notional_limit": "0",
+                    "live_notional_limit": "0",
+                    "capital_behavior_changed": False,
+                },
+                "selected_zero_notional_repairs": [
+                    {
+                        "lot_id": "profit-freshness-repair-lot:features",
+                        "candidate_id": "candidate-a",
+                        "hypothesis_id": "H-AAPL",
+                        "blocked_dimension": "feature_coverage",
+                        "zero_notional_action": "rebuild_required_feature_rows",
+                        "before_refs": ["feature_coverage:AAPL:missing"],
+                        "symbol_set": ["AAPL"],
+                        "paper_notional_limit": "0",
+                        "live_notional_limit": "0",
+                        "state": "selected_zero_notional_repair",
+                    }
+                ],
+            },
+        }
+
+        latest_status_variants = (
+            None,
+            lambda: [],
+            lambda: {"latest_signal_at": "not-a-datetime"},
+        )
+        for latest_status in latest_status_variants:
+            with self.subTest(latest_status=latest_status):
+                ingestor_attrs = {
+                    "fetch_signals_with_reason": lambda **kwargs: SimpleNamespace(
+                        signals=[],
+                        no_signal_reason="window_empty",
+                        query_start=kwargs["start"],
+                        query_end=kwargs["end"],
+                    ),
+                }
+                if latest_status is not None:
+                    ingestor_attrs["latest_signal_status"] = latest_status
+                app.state.trading_scheduler = SimpleNamespace(
+                    _pipeline=SimpleNamespace(
+                        ingestor=SimpleNamespace(**ingestor_attrs),
+                    ),
+                    state=SimpleNamespace(metrics=SimpleNamespace()),
+                )
+
+                with patch("app.main.trading_status", return_value=status_payload):
+                    response = self.client.post(
+                        "/trading/profit-freshness/zero-notional-repair"
+                        "?action=rebuild_required_feature_rows&execute=true"
+                    )
+
+                self.assertEqual(response.status_code, 200)
+                payload = response.json()
+                self.assertEqual(payload["execution_state"], "runner_blocked")
+                self.assertEqual(payload["command_exit_code"], 78)
+                self.assertEqual(
+                    payload["blocked_reasons"],
+                    ["feature_coverage_no_signals:window_empty"],
+                )
+                self.assertEqual(payload["after_refs"], [])
+                self.assertEqual(
+                    payload["runner_result"]["result"]["replay_window"],
+                    "current",
+                )
+                self.assertFalse(payload["order_submission_enabled"])
+
+    def test_zero_notional_repair_endpoint_records_feature_quality_rejection(
+        self,
+    ) -> None:
+        status_payload = {
+            "active_revision": "torghut-00320",
+            "profit_freshness_frontier": {
+                "frontier_id": "profit-freshness-frontier:test",
+                "capital_posture": {
+                    "capital_state": "zero_notional",
+                    "paper_notional_limit": "0",
+                    "live_notional_limit": "0",
+                    "capital_behavior_changed": False,
+                },
+                "selected_zero_notional_repairs": [
+                    {
+                        "lot_id": "profit-freshness-repair-lot:features",
+                        "candidate_id": "candidate-a",
+                        "hypothesis_id": "H-AAPL",
+                        "blocked_dimension": "feature_coverage",
+                        "zero_notional_action": "rebuild_required_feature_rows",
+                        "before_refs": ["feature_coverage:AAPL:missing"],
+                        "symbol_set": ["AAPL"],
+                        "paper_notional_limit": "0",
+                        "live_notional_limit": "0",
+                        "state": "selected_zero_notional_repair",
+                    }
+                ],
+            },
+        }
+        rejected_reasons: list[list[str]] = []
+        fetched: list[dict[str, object]] = []
+        naive_latest_signal_at = datetime(2026, 5, 12, 20, 57)
+
+        def fetch_signals_with_reason(**kwargs: object) -> SimpleNamespace:
+            fetched.append(kwargs)
+            if len(fetched) == 1:
+                return SimpleNamespace(
+                    signals=[],
+                    no_signal_reason="cursor_ahead_of_stream",
+                    query_start=kwargs["start"],
+                    query_end=kwargs["end"],
+                )
+            return SimpleNamespace(
+                signals=[SimpleNamespace(symbol="AAPL")],
+                no_signal_reason=None,
+                query_start=kwargs["start"],
+                query_end=kwargs["end"],
+            )
+
+        metrics = SimpleNamespace(
+            feature_batch_rows_total=0,
+            feature_null_rate={},
+            feature_staleness_ms_p95=0,
+            feature_duplicate_ratio=0.0,
+            feature_schema_mismatch_total=0,
+            feature_quality_rejections_total=0,
+            record_feature_quality_rejection=lambda reasons: rejected_reasons.append(
+                list(reasons),
+            ),
+        )
+        scheduler = SimpleNamespace(
+            _pipeline=SimpleNamespace(
+                ingestor=SimpleNamespace(
+                    fetch_signals_with_reason=fetch_signals_with_reason,
+                    latest_signal_status=lambda: {
+                        "latest_signal_at": naive_latest_signal_at,
+                    },
+                ),
+            ),
+            state=SimpleNamespace(metrics=metrics),
+        )
+        app.state.trading_scheduler = scheduler
+        quality_report = FeatureQualityReport(
+            accepted=False,
+            rows_total=1,
+            null_rate_by_field={"macd": 1.0},
+            staleness_ms_p95=200,
+            duplicate_ratio=0.0,
+            schema_mismatch_total=0,
+            reasons=["required_feature_null_rate_high"],
+        )
+
+        with (
+            patch("app.main.trading_status", return_value=status_payload),
+            patch(
+                "app.main.evaluate_feature_batch_quality", return_value=quality_report
+            ),
+        ):
+            response = self.client.post(
+                "/trading/profit-freshness/zero-notional-repair"
+                "?action=rebuild_required_feature_rows&execute=true"
+            )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["execution_state"], "executed")
+        self.assertFalse(payload["runner_result"]["result"]["accepted"])
+        self.assertEqual(
+            payload["runner_result"]["result"]["reason_codes"],
+            ["required_feature_null_rate_high"],
+        )
+        self.assertEqual(len(fetched), 2)
+        self.assertEqual(
+            fetched[1]["start"],
+            naive_latest_signal_at.replace(tzinfo=timezone.utc) - timedelta(minutes=15),
+        )
+        self.assertEqual(metrics.feature_quality_rejections_total, 1)
+        self.assertEqual(rejected_reasons, [["required_feature_null_rate_high"]])
         self.assertFalse(payload["order_submission_enabled"])
 
     def test_zero_notional_repair_endpoint_blocks_drift_replay_without_signals(

--- a/services/torghut/tests/test_zero_notional_repair_executor.py
+++ b/services/torghut/tests/test_zero_notional_repair_executor.py
@@ -165,6 +165,47 @@ def test_execute_runs_allowlisted_drift_runner_without_widening_notional() -> No
     assert receipt["live_notional_limit"] == "0"
 
 
+def test_execute_runs_feature_coverage_runner_without_widening_notional() -> None:
+    called: list[Mapping[str, Any]] = []
+
+    def runner(repair: Mapping[str, Any]) -> Mapping[str, object]:
+        called.append(repair)
+        return {
+            "execution_state": "executed",
+            "command_exit_code": 0,
+            "after_refs": ["feature_coverage_rows"],
+            "result": {"rows_total": 12},
+        }
+
+    receipt = run_zero_notional_repair(
+        account_label="paper",
+        trading_mode="live",
+        torghut_revision="torghut-00320",
+        source_commit="abc123",
+        profit_freshness_frontier=_frontier("rebuild_required_feature_rows"),
+        execute=True,
+        runners={"rebuild_required_feature_rows": runner},
+        now=NOW,
+    )
+
+    assert len(called) == 1
+    assert receipt["execution_state"] == "executed"
+    assert receipt["command_exit_code"] == 0
+    assert receipt["executor"] == "hypothesis_feature_coverage_replay"
+    assert receipt["value_gate"] == "zero_notional_or_stale_evidence_rate"
+    assert receipt["after_refs"] == ["feature_coverage_rows"]
+    assert receipt["runner_result"] == {
+        "execution_state": "executed",
+        "command_exit_code": 0,
+        "after_refs": ["feature_coverage_rows"],
+        "result": {"rows_total": 12},
+    }
+    assert receipt["capital_behavior_changed"] is False
+    assert receipt["order_submission_enabled"] is False
+    assert receipt["paper_notional_limit"] == "0"
+    assert receipt["live_notional_limit"] == "0"
+
+
 def test_preferred_action_can_execute_queued_route_tca_repair() -> None:
     frontier = _frontier("renew_empirical_proof_jobs")
     frontier["repair_lots"] = [


### PR DESCRIPTION
## Summary

- Allow Torghut zero-notional repair execution for `rebuild_required_feature_rows` lots.
- Add a bounded feature-coverage replay runner that uses the current signal window or latest available signal window, updates feature coverage metrics, and keeps order submission/notional unchanged.
- Add regression coverage for the executor allowlist and `/trading/profit-freshness/zero-notional-repair` endpoint execution path.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_zero_notional_repair_executor.py tests/test_trading_api.py -k 'zero_notional_repair'`
- `uv run --frozen ruff check app/main.py app/trading/zero_notional_repair_executor.py tests/test_zero_notional_repair_executor.py tests/test_trading_api.py`
- `uv run --frozen ruff format --check app/main.py app/trading/zero_notional_repair_executor.py tests/test_zero_notional_repair_executor.py tests/test_trading_api.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
