### PR TITLE
chore(jangar): promote image f5ed7394

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: f8ba9e06
-  digest: sha256:1fb6337ce8a1d7b1fad5b67999acc0a278287f3d48e1531297af4e7b05cd5206
+  tag: f5ed7394
+  digest: sha256:f8dcf217b832522358e62bf081b397b0d7c866df4b819f4d82ee6ff098918a98
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,8 +11,8 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: f8ba9e06
-    digest: sha256:3ef54b24ace957088d7ec2ba13cf61a1cafbeaabad78d14006da756567808eb7
+    tag: f5ed7394
+    digest: sha256:4086748d59302101e8ab80816a7a5059d85a2bb4a4e333d4ab6e9001e2154c68
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
@@ -21,8 +21,8 @@ controlPlane:
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: f8ba9e06
-    digest: sha256:1fb6337ce8a1d7b1fad5b67999acc0a278287f3d48e1531297af4e7b05cd5206
+    tag: f5ed7394
+    digest: sha256:f8dcf217b832522358e62bf081b397b0d7c866df4b819f4d82ee6ff098918a98
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-13T11:04:24Z
+    deploy.knative.dev/rollout: 2026-05-13T12:04:50Z
 spec:
   replicas: 1
   strategy:
@@ -57,11 +57,11 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_RUNTIME_IMAGE
-              value: registry.ide-newton.ts.net/lab/jangar:f8ba9e06@sha256:1fb6337ce8a1d7b1fad5b67999acc0a278287f3d48e1531297af4e7b05cd5206
+              value: registry.ide-newton.ts.net/lab/jangar:f5ed7394@sha256:f8dcf217b832522358e62bf081b397b0d7c866df4b819f4d82ee6ff098918a98
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: f8ba9e06bd71ca28a9c44b7edf089319854b5d4d
+              value: f5ed73941c4b372e9312535592677e8f7ba4a46b
             - name: JANGAR_GITOPS_REVISION
-              value: f8ba9e06bd71ca28a9c44b7edf089319854b5d4d
+              value: f5ed73941c4b372e9312535592677e8f7ba4a46b
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_BUMBA_TASK_QUEUE

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -59,5 +59,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: f8ba9e06
-    digest: sha256:1fb6337ce8a1d7b1fad5b67999acc0a278287f3d48e1531297af4e7b05cd5206
+    newTag: f5ed7394
+    digest: sha256:f8dcf217b832522358e62bf081b397b0d7c866df4b819f4d82ee6ff098918a98


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `f5ed73941c4b372e9312535592677e8f7ba4a46b`
- Image tag: `f5ed7394`
- Image digest: `sha256:f8dcf217b832522358e62bf081b397b0d7c866df4b819f4d82ee6ff098918a98`
- Updated API rollout annotation
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`