### PR TITLE
feat(torghut): publish repair receipt frontier

### DIFF
--- a/docs/torghut/design-system/v6/192-torghut-repair-receipt-frontier-and-profit-cutover-2026-05-13.md
+++ b/docs/torghut/design-system/v6/192-torghut-repair-receipt-frontier-and-profit-cutover-2026-05-13.md
@@ -289,6 +289,16 @@ Acceptance gates:
 
 The PR must cite this design and the companion Jangar design. It must keep live submission disabled and `max_notional=0`.
 
+Implementation note, 2026-05-13:
+
+- `services/torghut/app/trading/repair_receipt_frontier.py` now builds the
+  `torghut.repair-receipt-frontier.v1` read model from source-serving proof, freshness carry, repair-bid settlement,
+  profit-freshness frontier, route warrants, live submission, and proof-floor inputs.
+- `/trading/status`, `/trading/health`, `/readyz`, and `/trading/consumer-evidence` expose the frontier as additive
+  evidence. It does not authorize order submission; every lot is projected with `max_notional=0`.
+- Source-serving gaps produce a selected `source_serving` repair lot, and non-source lots are held until source-serving
+  proof converges.
+
 ## Deployment And Verification Gates
 
 The deployer stage must prove:

--- a/services/torghut/README.md
+++ b/services/torghut/README.md
@@ -234,6 +234,12 @@ Testing rules for the trading core:
   falls back to the existing bps proxy. The frontier names one selected repair when proof is stale, but
   `paper_notional_limit=0`, `live_notional_limit=0`, and existing proof-floor/submission gates remain the only capital
   authority.
+- `GET /trading/status`, `GET /trading/health`, `GET /readyz`, and `GET /trading/consumer-evidence` now surface the
+  May 13 doc 192 `torghut.repair-receipt-frontier.v1` projection. It compacts source-serving proof, freshness carry,
+  repair-bid settlement, route warrants, and profit-freshness repairs into one ranked zero-notional frontier with paper
+  and live cutover requirements. Non-source repairs are held until source-serving proof converges, every frontier lot
+  reports `max_notional=0`, and rollback is to ignore the projection while consuming the existing source-serving,
+  repair-bid, and profit-freshness payloads.
 - `POST /trading/profit-freshness/zero-notional-repair` returns the May 12 doc 188
   `torghut.zero-notional-repair-execution-receipt.v1` executor receipt for the selected frontier repair. The default
   mode is a dry run. With `execute=true`, the only local runner is bounded route/TCA recompute; empirical proof renewal

--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -108,6 +108,7 @@ from .trading.quality_adjusted_profit_frontier import (
 from .trading.renewal_bond_profit_escrow import build_renewal_bond_profit_escrow
 from .trading.revenue_repair import build_revenue_repair_digest
 from .trading.repair_bid_settlement import build_repair_bid_settlement_ledger
+from .trading.repair_receipt_frontier import build_repair_receipt_frontier
 from .trading.route_evidence_clearinghouse import (
     build_route_evidence_clearinghouse_packet,
 )
@@ -957,6 +958,17 @@ def _evaluate_trading_health_payload(
         quant_evidence=quant_evidence,
         live_submission_gate=live_submission_gate,
     )
+    repair_receipt_frontier = _build_repair_receipt_frontier_payload(
+        torghut_revision=BUILD_COMMIT,
+        source_commit=BUILD_COMMIT,
+        source_serving_repair_receipt_ledger=source_serving_repair_receipt_ledger,
+        freshness_carry_ledger=freshness_carry_ledger,
+        repair_bid_settlement_ledger=repair_bid_settlement_ledger,
+        profit_freshness_frontier=profit_freshness_frontier,
+        route_warrant_exchange=route_warrant_exchange,
+        live_submission_gate=live_submission_gate,
+        proof_floor=proof_floor,
+    )
     live_mode = settings.trading_mode == "live"
     empirical_jobs_required = (
         live_mode and settings.trading_empirical_jobs_health_required
@@ -1060,6 +1072,7 @@ def _evaluate_trading_health_payload(
             "route_warrant_exchange": route_warrant_exchange,
             "source_serving_repair_receipt_ledger": source_serving_repair_receipt_ledger,
             "freshness_carry_ledger": freshness_carry_ledger,
+            "repair_receipt_frontier": repair_receipt_frontier,
             "route_reacquisition_book": proof_floor.get("route_reacquisition_book"),
             "route_reacquisition_board": route_reacquisition_board,
             "quant_evidence": quant_evidence,
@@ -2526,6 +2539,17 @@ def trading_status() -> dict[str, object]:
         quant_evidence=quant_evidence,
         live_submission_gate=live_submission_gate,
     )
+    repair_receipt_frontier = _build_repair_receipt_frontier_payload(
+        torghut_revision=cast(str | None, shadow_first_runtime["active_revision"]),
+        source_commit=BUILD_COMMIT,
+        source_serving_repair_receipt_ledger=source_serving_repair_receipt_ledger,
+        freshness_carry_ledger=freshness_carry_ledger,
+        repair_bid_settlement_ledger=repair_bid_settlement_ledger,
+        profit_freshness_frontier=profit_freshness_frontier,
+        route_warrant_exchange=route_warrant_exchange,
+        live_submission_gate=live_submission_gate,
+        proof_floor=proof_floor,
+    )
     return {
         "enabled": settings.trading_enabled,
         "autonomy_enabled": settings.trading_autonomy_enabled,
@@ -2567,6 +2591,7 @@ def trading_status() -> dict[str, object]:
         "route_warrant_exchange": route_warrant_exchange,
         "source_serving_repair_receipt_ledger": source_serving_repair_receipt_ledger,
         "freshness_carry_ledger": freshness_carry_ledger,
+        "repair_receipt_frontier": repair_receipt_frontier,
         "route_reacquisition_book": proof_floor.get("route_reacquisition_book"),
         "route_reacquisition_board": route_reacquisition_board,
         "quant_evidence": quant_evidence,
@@ -2971,6 +2996,17 @@ def _build_trading_consumer_evidence_payload() -> dict[str, object]:
         quant_evidence=quant_evidence,
         live_submission_gate=live_submission_gate,
     )
+    repair_receipt_frontier = _build_repair_receipt_frontier_payload(
+        torghut_revision=cast(str | None, shadow_first_runtime["active_revision"]),
+        source_commit=BUILD_COMMIT,
+        source_serving_repair_receipt_ledger=source_serving_repair_receipt_ledger,
+        freshness_carry_ledger=freshness_carry_ledger,
+        repair_bid_settlement_ledger=repair_bid_settlement_ledger,
+        profit_freshness_frontier=profit_freshness_frontier,
+        route_warrant_exchange=route_warrant_exchange,
+        live_submission_gate=live_submission_gate,
+        proof_floor=proof_floor,
+    )
     return {
         "schema_version": "torghut.consumer-evidence-status.v1",
         "generated_at": datetime.now(timezone.utc).isoformat(),
@@ -3004,6 +3040,7 @@ def _build_trading_consumer_evidence_payload() -> dict[str, object]:
         "route_warrant_exchange": route_warrant_exchange,
         "source_serving_repair_receipt_ledger": source_serving_repair_receipt_ledger,
         "freshness_carry_ledger": freshness_carry_ledger,
+        "repair_receipt_frontier": repair_receipt_frontier,
     }
 
 
@@ -5277,6 +5314,34 @@ def _build_freshness_carry_ledger_payload(
         market_context_status=market_context_status,
         quant_evidence=quant_evidence,
         live_submission_gate=live_submission_gate,
+    )
+
+
+def _build_repair_receipt_frontier_payload(
+    *,
+    torghut_revision: str | None,
+    source_commit: str | None,
+    source_serving_repair_receipt_ledger: Mapping[str, Any],
+    freshness_carry_ledger: Mapping[str, Any],
+    repair_bid_settlement_ledger: Mapping[str, Any],
+    profit_freshness_frontier: Mapping[str, Any],
+    route_warrant_exchange: Mapping[str, Any],
+    live_submission_gate: Mapping[str, Any],
+    proof_floor: Mapping[str, Any],
+) -> dict[str, object]:
+    return build_repair_receipt_frontier(
+        account_label=settings.trading_account_label,
+        window=settings.trading_jangar_quant_window,
+        trading_mode=settings.trading_mode,
+        torghut_revision=torghut_revision,
+        source_commit=source_commit,
+        source_serving_repair_receipt_ledger=source_serving_repair_receipt_ledger,
+        freshness_carry_ledger=freshness_carry_ledger,
+        repair_bid_settlement_ledger=repair_bid_settlement_ledger,
+        profit_freshness_frontier=profit_freshness_frontier,
+        route_warrant_exchange=route_warrant_exchange,
+        live_submission_gate=live_submission_gate,
+        proof_floor_receipt=proof_floor,
     )
 
 

--- a/services/torghut/app/trading/repair_receipt_frontier.py
+++ b/services/torghut/app/trading/repair_receipt_frontier.py
@@ -1,0 +1,733 @@
+"""Repair receipt frontier projection for Torghut profit cutover."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal, InvalidOperation
+from hashlib import sha256
+import json
+from typing import Any, cast
+
+
+REPAIR_RECEIPT_FRONTIER_SCHEMA_VERSION = "torghut.repair-receipt-frontier.v1"
+
+_FRESHNESS_SECONDS = 60
+_DEFAULT_MAX_RUNTIME_SECONDS = 20 * 60
+_ZERO_NOTIONAL = "0"
+_SOURCE_CURRENT_STATES = {"converged", "current", "healthy", "ok", "ready"}
+_DOC_REF = (
+    "docs/torghut/design-system/v6/"
+    "192-torghut-repair-receipt-frontier-and-profit-cutover-2026-05-13.md"
+)
+_VALUE_GATES = [
+    "post_cost_daily_net_pnl",
+    "routeable_candidate_count",
+    "zero_notional_or_stale_evidence_rate",
+    "fill_tca_or_slippage_quality",
+    "capital_gate_safety",
+]
+_LOT_CLASS_MAP = {
+    "quant_pipeline": "signal_ingestion",
+    "execution_tca": "execution_tca",
+    "rollout_image": "source_serving",
+    "empirical_replay": "empirical_proof",
+    "promotion_custody": "research_candidate",
+    "feature_lineage": "feature_rows",
+}
+_DIMENSION_LOT_CLASS = {
+    "signal_ingestion": "signal_ingestion",
+    "market_context": "market_context",
+    "empirical_proof": "empirical_proof",
+    "feature_coverage": "feature_rows",
+    "drift_checks": "feature_rows",
+    "tca_fill_quality": "execution_tca",
+    "route_readiness": "research_candidate",
+    "schema_migration_state": "source_serving",
+    "jangar_settlement": "source_serving",
+}
+_DIMENSION_VALUE_GATE = {
+    "signal_ingestion": "zero_notional_or_stale_evidence_rate",
+    "market_context": "zero_notional_or_stale_evidence_rate",
+    "empirical_proof": "post_cost_daily_net_pnl",
+    "feature_coverage": "zero_notional_or_stale_evidence_rate",
+    "drift_checks": "zero_notional_or_stale_evidence_rate",
+    "tca_fill_quality": "fill_tca_or_slippage_quality",
+    "route_readiness": "routeable_candidate_count",
+    "schema_migration_state": "capital_gate_safety",
+    "jangar_settlement": "capital_gate_safety",
+}
+_LOT_COST_CLASS = {
+    "source_serving": "low",
+    "signal_ingestion": "medium",
+    "market_context": "low",
+    "empirical_proof": "medium",
+    "feature_rows": "medium",
+    "execution_tca": "medium",
+    "research_candidate": "medium",
+    "rejection_drag": "low",
+}
+_SOURCE_REASON_VALUE_GATE = {
+    "serving_build_commit_mismatch": "capital_gate_safety",
+    "serving_build_commit_missing": "capital_gate_safety",
+    "source_commit_missing": "capital_gate_safety",
+    "manifest_image_digest_missing": "capital_gate_safety",
+    "serving_image_digest_missing": "capital_gate_safety",
+    "manifest_serving_image_digest_mismatch": "capital_gate_safety",
+    "required_contract_missing": "zero_notional_or_stale_evidence_rate",
+    "contract_schema_mismatch": "zero_notional_or_stale_evidence_rate",
+}
+
+
+def _mapping(value: object) -> Mapping[str, Any]:
+    return cast(Mapping[str, Any], value) if isinstance(value, Mapping) else {}
+
+
+def _sequence(value: object) -> Sequence[object]:
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return cast(Sequence[object], value)
+    return ()
+
+
+def _text(value: object, default: str = "") -> str:
+    if value is None:
+        return default
+    text = str(value).strip()
+    return text or default
+
+
+def _unique(values: Sequence[str]) -> list[str]:
+    result: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        normalized = value.strip()
+        if normalized and normalized not in seen:
+            result.append(normalized)
+            seen.add(normalized)
+    return result
+
+
+def _strings(value: object) -> list[str]:
+    return _unique([_text(item) for item in _sequence(value)])
+
+
+def _symbols(value: object) -> list[str]:
+    if isinstance(value, str):
+        return _unique([value.upper()])
+    return _unique([_text(item).upper() for item in _sequence(value)])
+
+
+def _stable_ref(prefix: str, payload: Mapping[str, object]) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return f"{prefix}:{sha256(encoded.encode()).hexdigest()[:20]}"
+
+
+def _decimal(value: object) -> Decimal | None:
+    if value is None:
+        return None
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, ValueError):
+        return None
+
+
+def _int(value: object, default: int = 0) -> int:
+    parsed = _decimal(value)
+    return default if parsed is None else int(parsed)
+
+
+def _bool(value: object, default: bool = False) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on", "allow", "allowed", "ok"}:
+            return True
+        if normalized in {"0", "false", "no", "off", "block", "blocked", "hold"}:
+            return False
+    return default
+
+
+def _decimal_text(value: Decimal | None) -> str | None:
+    if value is None:
+        return None
+    text = format(value, "f")
+    if "." in text:
+        text = text.rstrip("0").rstrip(".")
+    return "0" if text in {"", "-0"} else text
+
+
+def _source_state(source_serving_ledger: Mapping[str, Any]) -> str:
+    return _text(source_serving_ledger.get("source_serving_state"), "missing").lower()
+
+
+def _source_is_current(source_serving_ledger: Mapping[str, Any]) -> bool:
+    return _source_state(source_serving_ledger) in _SOURCE_CURRENT_STATES
+
+
+def _reason_value_gate(reason: str) -> str:
+    return _SOURCE_REASON_VALUE_GATE.get(
+        reason.split(":", 1)[0],
+        "zero_notional_or_stale_evidence_rate",
+    )
+
+
+def _required_input_refs(*values: object) -> list[str]:
+    refs: list[str] = []
+    for value in values:
+        if isinstance(value, str):
+            refs.append(value)
+        else:
+            refs.extend(_strings(value))
+    return _unique(refs)
+
+
+def _settlement_status(state: str, hold_reasons: Sequence[str]) -> str:
+    normalized = state.lower()
+    if "expired" in hold_reasons or normalized == "expired":
+        return "expired"
+    if "notional_nonzero" in hold_reasons or normalized in {"rejected", "blocked"}:
+        return "rejected"
+    if normalized in {"settled", "accepted"}:
+        return "settled"
+    return "pending"
+
+
+def _lot_dispatchable(
+    *,
+    lot_class: str,
+    source_current: bool,
+    requested_dispatchable: bool,
+    hold_reason_codes: Sequence[str],
+) -> tuple[bool, list[str]]:
+    reasons = list(hold_reason_codes)
+    if not source_current and lot_class != "source_serving":
+        reasons.append("source_serving_not_converged")
+    dispatchable = requested_dispatchable and not reasons
+    return dispatchable, _unique(reasons)
+
+
+def _frontier_lot_from_compacted(
+    *,
+    raw_lot: Mapping[str, Any],
+    source_serving_ledger: Mapping[str, Any],
+    source_current: bool,
+) -> dict[str, object]:
+    original_class = _text(raw_lot.get("lot_class"), "feature_lineage")
+    lot_class = _LOT_CLASS_MAP.get(original_class, original_class)
+    hold_reasons = _strings(raw_lot.get("hold_reason_codes"))
+    if _text(raw_lot.get("max_notional"), _ZERO_NOTIONAL) != _ZERO_NOTIONAL:
+        hold_reasons.append("notional_nonzero")
+    dispatchable, hold_reasons = _lot_dispatchable(
+        lot_class=lot_class,
+        source_current=source_current,
+        requested_dispatchable=_bool(raw_lot.get("dispatchable")),
+        hold_reason_codes=hold_reasons,
+    )
+    lot_id = _stable_ref(
+        "repair-receipt-frontier-lot",
+        {
+            "source": raw_lot.get("lot_id"),
+            "lot_class": lot_class,
+            "value_gate": raw_lot.get("target_value_gate"),
+        },
+    )
+    return {
+        "lot_id": lot_id,
+        "source_lot_ref": raw_lot.get("lot_id"),
+        "source_lot_class": original_class,
+        "lot_class": lot_class,
+        "target_symbols": _symbols(
+            raw_lot.get("target_symbols")
+            or raw_lot.get("symbols")
+            or raw_lot.get("symbol_set")
+        ),
+        "target_hypothesis_ids": _strings(
+            raw_lot.get("target_hypothesis_ids")
+            or raw_lot.get("hypothesis_ids")
+            or raw_lot.get("candidate_ids")
+        ),
+        "target_value_gate": raw_lot.get("target_value_gate")
+        or "zero_notional_or_stale_evidence_rate",
+        "expected_gate_delta": raw_lot.get("expected_gate_delta")
+        or f"settle_{lot_class}",
+        "expected_unblock_value": raw_lot.get("expected_unblock_value")
+        or raw_lot.get("priority")
+        or 0,
+        "cost_class": _LOT_COST_CLASS.get(lot_class, "medium"),
+        "source_serving_epoch_ref": source_serving_ledger.get("ledger_id"),
+        "required_input_refs": _required_input_refs(
+            raw_lot.get("required_input_refs"),
+            raw_lot.get("source_bid_ids"),
+            source_serving_ledger.get("ledger_id"),
+        ),
+        "required_output_receipt": raw_lot.get("required_output_receipt")
+        or "torghut.zero-notional-repair-execution-receipt.v1",
+        "validation_commands": _strings(raw_lot.get("validation_commands")),
+        "max_runtime_seconds": _int(
+            raw_lot.get("max_runtime_seconds"), _DEFAULT_MAX_RUNTIME_SECONDS
+        ),
+        "max_notional": _ZERO_NOTIONAL,
+        "dispatchable": dispatchable,
+        "hold_reason_codes": hold_reasons,
+        "settlement_status": _settlement_status(
+            _text(raw_lot.get("state"), "pending"), hold_reasons
+        ),
+        "dedupe_key": raw_lot.get("dedupe_key"),
+    }
+
+
+def _frontier_lot_from_profit_repair(
+    *,
+    repair: Mapping[str, Any],
+    source_serving_ledger: Mapping[str, Any],
+    source_current: bool,
+) -> dict[str, object]:
+    dimension = _text(repair.get("blocked_dimension"), "unknown")
+    lot_class = _DIMENSION_LOT_CLASS.get(dimension, "feature_rows")
+    hold_reasons: list[str] = []
+    dispatchable, hold_reasons = _lot_dispatchable(
+        lot_class=lot_class,
+        source_current=source_current,
+        requested_dispatchable=True,
+        hold_reason_codes=hold_reasons,
+    )
+    value_gate = _DIMENSION_VALUE_GATE.get(
+        dimension, "zero_notional_or_stale_evidence_rate"
+    )
+    action = _text(
+        repair.get("zero_notional_action"), "observe_profit_freshness_frontier"
+    )
+    expected_daily_net_pnl = _decimal(repair.get("expected_daily_net_pnl_unlock"))
+    expected_bps = _decimal(repair.get("expected_profit_unlock_bps"))
+    return {
+        "lot_id": _stable_ref(
+            "repair-receipt-frontier-lot",
+            {
+                "source": repair.get("lot_id"),
+                "dimension": dimension,
+                "action": action,
+            },
+        ),
+        "source_lot_ref": repair.get("lot_id"),
+        "source_lot_class": "profit_freshness_frontier",
+        "lot_class": lot_class,
+        "target_symbols": _symbols(repair.get("symbol_set") or repair.get("symbols")),
+        "target_hypothesis_ids": _required_input_refs(
+            repair.get("hypothesis_id"),
+            repair.get("candidate_id"),
+        ),
+        "target_value_gate": value_gate,
+        "expected_gate_delta": f"retire_{dimension}",
+        "expected_unblock_value": _decimal_text(expected_daily_net_pnl)
+        or _decimal_text(expected_bps)
+        or "0",
+        "expected_daily_net_pnl_unlock": _decimal_text(expected_daily_net_pnl),
+        "expected_profit_unlock_bps": _decimal_text(expected_bps),
+        "cost_class": _text(
+            repair.get("repair_cost_class"), _LOT_COST_CLASS.get(lot_class, "medium")
+        ),
+        "source_serving_epoch_ref": source_serving_ledger.get("ledger_id"),
+        "required_input_refs": _required_input_refs(
+            repair.get("before_refs"),
+            repair.get("profit_unlock_refs"),
+            source_serving_ledger.get("ledger_id"),
+        ),
+        "required_output_receipt": "torghut.zero-notional-repair-execution-receipt.v1",
+        "validation_commands": [
+            f"POST /trading/profit-freshness/zero-notional-repair?execute=false&action={action}"
+        ],
+        "max_runtime_seconds": _DEFAULT_MAX_RUNTIME_SECONDS,
+        "max_notional": _ZERO_NOTIONAL,
+        "dispatchable": dispatchable,
+        "hold_reason_codes": hold_reasons,
+        "settlement_status": _settlement_status(
+            _text(repair.get("state"), "pending"), hold_reasons
+        ),
+        "zero_notional_action": action,
+    }
+
+
+def _source_serving_lot(
+    source_serving_ledger: Mapping[str, Any],
+) -> dict[str, object] | None:
+    reason_codes = _strings(source_serving_ledger.get("reason_codes"))
+    if _source_is_current(source_serving_ledger) and not reason_codes:
+        return None
+    state = _source_state(source_serving_ledger)
+    primary_reason = reason_codes[0] if reason_codes else f"source_serving_{state}"
+    ledger_id = _text(source_serving_ledger.get("ledger_id"))
+    return {
+        "lot_id": _stable_ref(
+            "repair-receipt-frontier-lot",
+            {
+                "source": ledger_id,
+                "lot_class": "source_serving",
+                "reason": primary_reason,
+            },
+        ),
+        "source_lot_ref": ledger_id or None,
+        "source_lot_class": "source_serving_repair_receipt_ledger",
+        "lot_class": "source_serving",
+        "target_symbols": [],
+        "target_hypothesis_ids": [],
+        "target_value_gate": _reason_value_gate(primary_reason),
+        "expected_gate_delta": f"retire_{primary_reason}",
+        "expected_unblock_value": len(reason_codes) or 1,
+        "cost_class": "low",
+        "source_serving_epoch_ref": ledger_id or None,
+        "required_input_refs": _required_input_refs(
+            ledger_id,
+            source_serving_ledger.get("route_warrant_ref"),
+            source_serving_ledger.get("repair_bid_settlement_ref"),
+            source_serving_ledger.get("route_evidence_clearinghouse_ref"),
+        ),
+        "required_output_receipt": "torghut.source-serving-convergence-receipt.v1",
+        "validation_commands": [
+            "GET /trading/consumer-evidence#source_serving_repair_receipt_ledger"
+        ],
+        "max_runtime_seconds": _DEFAULT_MAX_RUNTIME_SECONDS,
+        "max_notional": _ZERO_NOTIONAL,
+        "dispatchable": True,
+        "hold_reason_codes": [],
+        "settlement_status": "pending",
+    }
+
+
+def _dedupe_lots(lots: Sequence[dict[str, object]]) -> list[dict[str, object]]:
+    deduped: list[dict[str, object]] = []
+    seen: set[tuple[str, str, str]] = set()
+    for lot in lots:
+        key = (
+            _text(lot.get("lot_class")),
+            _text(lot.get("target_value_gate")),
+            _text(lot.get("expected_gate_delta")),
+        )
+        if key in seen:
+            continue
+        deduped.append(lot)
+        seen.add(key)
+    return deduped
+
+
+def _lot_sort_key(lot: Mapping[str, object]) -> tuple[int, int, str]:
+    dispatch_rank = 1 if lot.get("dispatchable") is True else 0
+    source_rank = 1 if _text(lot.get("lot_class")) == "source_serving" else 0
+    return (-dispatch_rank, -source_rank, _text(lot.get("lot_id")))
+
+
+def _dimension_state(
+    profit_freshness_frontier: Mapping[str, Any], dimension_name: str
+) -> str:
+    for raw_dimension in _sequence(
+        profit_freshness_frontier.get("freshness_dimensions")
+    ):
+        dimension = _mapping(raw_dimension)
+        if _text(dimension.get("dimension")) == dimension_name:
+            return _text(dimension.get("state"), "missing").lower()
+    return "missing"
+
+
+def _has_reason(
+    profit_freshness_frontier: Mapping[str, Any], reason_tokens: Sequence[str]
+) -> bool:
+    for reason in _strings(
+        profit_freshness_frontier.get("aggregate_blocking_reason_codes")
+    ):
+        if any(token in reason for token in reason_tokens):
+            return True
+    return False
+
+
+def _requirement(
+    *,
+    requirement: str,
+    passed: bool,
+    evidence_ref: object,
+    value_gate: str,
+    reason_codes: Sequence[str],
+) -> dict[str, object]:
+    return {
+        "requirement": requirement,
+        "state": "pass" if passed else "block",
+        "evidence_ref": evidence_ref,
+        "value_gate": value_gate,
+        "reason_codes": [] if passed else _unique(list(reason_codes)),
+    }
+
+
+def _paper_requirements(
+    *,
+    source_serving_ledger: Mapping[str, Any],
+    freshness_carry_ledger: Mapping[str, Any],
+    profit_freshness_frontier: Mapping[str, Any],
+    route_warrant_exchange: Mapping[str, Any],
+) -> list[dict[str, object]]:
+    source_current = _source_is_current(source_serving_ledger)
+    feature_current = _dimension_state(profit_freshness_frontier, "feature_coverage")
+    tca_current = _dimension_state(profit_freshness_frontier, "tca_fill_quality")
+    routeable_count = _int(
+        route_warrant_exchange.get("accepted_routeable_candidate_count")
+        or route_warrant_exchange.get("routeable_candidate_count")
+    )
+    post_cost_blocked = _has_reason(
+        profit_freshness_frontier,
+        ("post_cost_expectancy_non_positive", "post_cost", "expectancy_non_positive"),
+    )
+    selected_expected_pnl = _decimal(
+        _mapping(profit_freshness_frontier.get("summary")).get(
+            "selected_expected_daily_net_pnl_unlock"
+        )
+    )
+    positive_repair_unlock = (
+        selected_expected_pnl is not None and selected_expected_pnl > Decimal("0")
+    )
+    return [
+        _requirement(
+            requirement="source_serving_current",
+            passed=source_current,
+            evidence_ref=source_serving_ledger.get("ledger_id"),
+            value_gate="capital_gate_safety",
+            reason_codes=_strings(source_serving_ledger.get("reason_codes"))
+            or [f"source_serving_{_source_state(source_serving_ledger)}"],
+        ),
+        _requirement(
+            requirement="feature_rows_current",
+            passed=feature_current == "current",
+            evidence_ref=profit_freshness_frontier.get("frontier_id"),
+            value_gate="zero_notional_or_stale_evidence_rate",
+            reason_codes=["feature_rows_missing"],
+        ),
+        _requirement(
+            requirement="execution_tca_current",
+            passed=tca_current == "current",
+            evidence_ref=profit_freshness_frontier.get("frontier_id"),
+            value_gate="fill_tca_or_slippage_quality",
+            reason_codes=["execution_tca_not_current"],
+        ),
+        _requirement(
+            requirement="routeable_candidate_available",
+            passed=routeable_count > 0,
+            evidence_ref=route_warrant_exchange.get("warrant_id"),
+            value_gate="routeable_candidate_count",
+            reason_codes=["routeable_candidate_count_zero"],
+        ),
+        _requirement(
+            requirement="post_cost_profit_non_negative",
+            passed=not post_cost_blocked
+            and (routeable_count > 0 or positive_repair_unlock),
+            evidence_ref=freshness_carry_ledger.get("ledger_id"),
+            value_gate="post_cost_daily_net_pnl",
+            reason_codes=["post_cost_profit_proof_missing_or_non_positive"],
+        ),
+    ]
+
+
+def _live_requirements(
+    *,
+    paper_requirements: Sequence[Mapping[str, object]],
+    live_submission_gate: Mapping[str, Any],
+    proof_floor_receipt: Mapping[str, Any],
+) -> list[dict[str, object]]:
+    paper_pass = all(_text(item.get("state")) == "pass" for item in paper_requirements)
+    gate_allowed = _bool(live_submission_gate.get("allowed"))
+    proof_route_state = _text(proof_floor_receipt.get("route_state"), "missing").lower()
+    capital_state = _text(proof_floor_receipt.get("capital_state"), "missing").lower()
+    human_approved = _bool(
+        live_submission_gate.get("human_approved_capital_limits")
+        or live_submission_gate.get("human_approved_capital_limit")
+        or proof_floor_receipt.get("human_approved_capital_limits")
+    )
+    return [
+        _requirement(
+            requirement="paper_cutover_requirements_pass",
+            passed=paper_pass,
+            evidence_ref="repair_receipt_frontier.paper_cutover_requirements",
+            value_gate="capital_gate_safety",
+            reason_codes=["paper_cutover_requirements_blocking"],
+        ),
+        _requirement(
+            requirement="live_submission_enabled",
+            passed=gate_allowed,
+            evidence_ref=live_submission_gate.get("gate_id")
+            or live_submission_gate.get("reason"),
+            value_gate="capital_gate_safety",
+            reason_codes=_strings(live_submission_gate.get("blocked_reasons"))
+            or [_text(live_submission_gate.get("reason"), "live_submission_blocked")],
+        ),
+        _requirement(
+            requirement="human_capital_limit_approved",
+            passed=human_approved,
+            evidence_ref=proof_floor_receipt.get("receipt_id")
+            or proof_floor_receipt.get("schema_version"),
+            value_gate="capital_gate_safety",
+            reason_codes=["human_capital_limit_missing"],
+        ),
+        _requirement(
+            requirement="profitability_proof_floor_allows_capital",
+            passed=proof_route_state not in {"missing", "repair_only"}
+            and capital_state not in {"missing", "zero_notional"},
+            evidence_ref=proof_floor_receipt.get("receipt_id")
+            or proof_floor_receipt.get("schema_version"),
+            value_gate="post_cost_daily_net_pnl",
+            reason_codes=[f"proof_floor_{proof_route_state}_{capital_state}"],
+        ),
+    ]
+
+
+def _frontier_state(
+    *,
+    lots: Sequence[Mapping[str, object]],
+    paper_requirements: Sequence[Mapping[str, object]],
+    live_requirements: Sequence[Mapping[str, object]],
+) -> str:
+    if lots:
+        return "repair_only"
+    if not all(_text(item.get("state")) == "pass" for item in paper_requirements):
+        return "paper_blocked"
+    if all(_text(item.get("state")) == "pass" for item in live_requirements):
+        return "live_candidate"
+    return "paper_candidate"
+
+
+def build_repair_receipt_frontier(
+    *,
+    account_label: str | None,
+    window: str | None,
+    trading_mode: str,
+    torghut_revision: str | None,
+    source_commit: str | None,
+    source_serving_repair_receipt_ledger: Mapping[str, Any],
+    freshness_carry_ledger: Mapping[str, Any],
+    repair_bid_settlement_ledger: Mapping[str, Any],
+    profit_freshness_frontier: Mapping[str, Any],
+    route_warrant_exchange: Mapping[str, Any],
+    live_submission_gate: Mapping[str, Any],
+    proof_floor_receipt: Mapping[str, Any],
+    now: datetime | None = None,
+) -> dict[str, object]:
+    """Build a compact zero-notional repair frontier and cutover ladder."""
+
+    generated_at = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    source_ledger = _mapping(source_serving_repair_receipt_ledger)
+    source_current = _source_is_current(source_ledger)
+    compacted_lots = [
+        _frontier_lot_from_compacted(
+            raw_lot=_mapping(raw_lot),
+            source_serving_ledger=source_ledger,
+            source_current=source_current,
+        )
+        for raw_lot in _sequence(repair_bid_settlement_ledger.get("compacted_lots"))
+        if _mapping(raw_lot)
+    ]
+    profit_lots = [
+        _frontier_lot_from_profit_repair(
+            repair=_mapping(raw_repair),
+            source_serving_ledger=source_ledger,
+            source_current=source_current,
+        )
+        for raw_repair in _sequence(
+            profit_freshness_frontier.get("selected_zero_notional_repairs")
+        )
+        if _mapping(raw_repair)
+    ]
+    source_lot = _source_serving_lot(source_ledger)
+    lots = _dedupe_lots(
+        [*([source_lot] if source_lot else []), *compacted_lots, *profit_lots]
+    )
+    lots = sorted(lots, key=_lot_sort_key)
+    dispatchable_ids = [
+        _text(lot.get("lot_id")) for lot in lots if lot.get("dispatchable") is True
+    ]
+    selected_lot_id = dispatchable_ids[0] if dispatchable_ids else None
+    paper_requirements = _paper_requirements(
+        source_serving_ledger=source_ledger,
+        freshness_carry_ledger=freshness_carry_ledger,
+        profit_freshness_frontier=profit_freshness_frontier,
+        route_warrant_exchange=route_warrant_exchange,
+    )
+    live_requirements = _live_requirements(
+        paper_requirements=paper_requirements,
+        live_submission_gate=live_submission_gate,
+        proof_floor_receipt=proof_floor_receipt,
+    )
+    state = _frontier_state(
+        lots=lots,
+        paper_requirements=paper_requirements,
+        live_requirements=live_requirements,
+    )
+    frontier_id = _stable_ref(
+        "repair-receipt-frontier",
+        {
+            "account": account_label,
+            "window": window,
+            "torghut_revision": torghut_revision,
+            "source_ledger": source_ledger.get("ledger_id"),
+            "repair_bid_ledger": repair_bid_settlement_ledger.get("ledger_id"),
+            "profit_freshness_frontier": profit_freshness_frontier.get("frontier_id"),
+            "lot_ids": [_text(lot.get("lot_id")) for lot in lots],
+        },
+    )
+    return {
+        "schema_version": REPAIR_RECEIPT_FRONTIER_SCHEMA_VERSION,
+        "frontier_id": frontier_id,
+        "generated_at": generated_at.isoformat(),
+        "fresh_until": (
+            generated_at + timedelta(seconds=_FRESHNESS_SECONDS)
+        ).isoformat(),
+        "account": account_label,
+        "window": window,
+        "trading_mode": trading_mode,
+        "torghut_revision": torghut_revision,
+        "source_commit": source_commit,
+        "governing_design_ref": _DOC_REF,
+        "source_serving_ledger_ref": source_ledger.get("ledger_id"),
+        "freshness_carry_ledger_ref": freshness_carry_ledger.get("ledger_id"),
+        "repair_bid_settlement_ledger_ref": repair_bid_settlement_ledger.get(
+            "ledger_id"
+        ),
+        "profit_freshness_frontier_ref": profit_freshness_frontier.get("frontier_id"),
+        "route_warrant_ref": route_warrant_exchange.get("warrant_id"),
+        "capital_state": "zero_notional",
+        "max_notional": _ZERO_NOTIONAL,
+        "frontier_state": state,
+        "selected_lot_id": selected_lot_id,
+        "dispatchable_lot_ids": dispatchable_ids,
+        "held_lot_ids": [
+            _text(lot.get("lot_id"))
+            for lot in lots
+            if lot.get("dispatchable") is not True
+        ],
+        "lots": lots,
+        "paper_cutover_requirements": paper_requirements,
+        "live_cutover_requirements": live_requirements,
+        "summary": {
+            "lot_count": len(lots),
+            "dispatchable_lot_count": len(dispatchable_ids),
+            "held_lot_count": len(lots) - len(dispatchable_ids),
+            "paper_requirement_pass_count": sum(
+                1 for item in paper_requirements if item["state"] == "pass"
+            ),
+            "live_requirement_pass_count": sum(
+                1 for item in live_requirements if item["state"] == "pass"
+            ),
+            "source_serving_state": _source_state(source_ledger),
+            "value_gates": _VALUE_GATES,
+        },
+        "rollback_target": {
+            "repair_receipt_frontier_projection_enabled": False,
+            "capital_state": "zero_notional",
+            "live_submit_enabled": False,
+            "fallback_payloads": [
+                "torghut.profit-freshness-frontier.v1",
+                "torghut.repair-bid-settlement-ledger.v1",
+                "torghut.source-serving-repair-receipt-ledger.v1",
+            ],
+        },
+    }
+
+
+__all__ = [
+    "REPAIR_RECEIPT_FRONTIER_SCHEMA_VERSION",
+    "build_repair_receipt_frontier",
+]

--- a/services/torghut/tests/test_repair_receipt_frontier.py
+++ b/services/torghut/tests/test_repair_receipt_frontier.py
@@ -1,0 +1,247 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import datetime, timezone
+from typing import Any, cast
+
+from app.trading.repair_receipt_frontier import (
+    REPAIR_RECEIPT_FRONTIER_SCHEMA_VERSION,
+    build_repair_receipt_frontier,
+)
+
+
+NOW = datetime(2026, 5, 13, 12, 30, tzinfo=timezone.utc)
+
+
+def _source_ledger(
+    *,
+    state: str = "digest_unknown",
+    reasons: list[str] | None = None,
+) -> dict[str, object]:
+    return {
+        "schema_version": "torghut.source-serving-repair-receipt-ledger.v1",
+        "ledger_id": f"source-serving-repair-receipt-ledger:{state}",
+        "source_serving_state": state,
+        "reason_codes": reasons
+        if reasons is not None
+        else ["serving_image_digest_missing"],
+        "route_warrant_ref": "route-warrant:test",
+        "repair_bid_settlement_ref": "repair-bid-settlement-ledger:test",
+        "route_evidence_clearinghouse_ref": "route-evidence-clearinghouse:test",
+        "max_notional": "0",
+    }
+
+
+def _repair_bid_ledger(*, compacted_lots: list[dict[str, object]]) -> dict[str, object]:
+    return {
+        "schema_version": "torghut.repair-bid-settlement-ledger.v1",
+        "ledger_id": "repair-bid-settlement-ledger:test",
+        "compacted_lots": compacted_lots,
+        "max_notional": "0",
+    }
+
+
+def _compacted_lot(**overrides: object) -> dict[str, object]:
+    lot: dict[str, object] = {
+        "lot_id": "compacted-repair-lot:feature",
+        "lot_class": "feature_lineage",
+        "target_value_gate": "zero_notional_or_stale_evidence_rate",
+        "expected_gate_delta": "retire_feature_rows_missing",
+        "priority": 95,
+        "required_input_refs": ["route-evidence-clearinghouse:test"],
+        "required_output_receipt": "torghut.feature-lineage-current-receipt.v1",
+        "validation_commands": [
+            "pytest services/torghut/tests/test_repair_bid_settlement.py -k feature_lineage"
+        ],
+        "max_runtime_seconds": 1200,
+        "max_notional": "0",
+        "dispatchable": True,
+        "hold_reason_codes": [],
+        "state": "selected",
+    }
+    lot.update(overrides)
+    return lot
+
+
+def _profit_frontier(
+    *, selected_repairs: list[dict[str, object]] | None = None
+) -> dict[str, object]:
+    return {
+        "schema_version": "torghut.profit-freshness-frontier.v1",
+        "frontier_id": "profit-freshness-frontier:test",
+        "freshness_dimensions": [
+            {"dimension": "feature_coverage", "state": "missing"},
+            {"dimension": "tca_fill_quality", "state": "stale"},
+        ],
+        "aggregate_blocking_reason_codes": [
+            "feature_rows_missing",
+            "execution_tca_stale",
+        ],
+        "selected_zero_notional_repairs": selected_repairs
+        if selected_repairs is not None
+        else [
+            {
+                "lot_id": "profit-freshness-repair-lot:feature",
+                "blocked_dimension": "feature_coverage",
+                "symbol_set": ["NVDA"],
+                "hypothesis_id": "H-NVDA",
+                "zero_notional_action": "rebuild_required_feature_rows",
+                "expected_profit_unlock_bps": 16,
+                "repair_cost_class": "medium",
+                "before_refs": ["hypothesis:H-NVDA"],
+                "state": "selected_zero_notional_repair",
+            }
+        ],
+        "summary": {
+            "accepted_routeable_candidate_count": 0,
+            "selected_expected_daily_net_pnl_unlock": None,
+        },
+    }
+
+
+def _route_warrant(*, routeable_count: int = 0) -> dict[str, object]:
+    return {
+        "schema_version": "torghut.route-warrant-exchange.v1",
+        "warrant_id": "route-warrant:test",
+        "warrant_state": "repair_only" if routeable_count == 0 else "paper_candidate",
+        "accepted_routeable_candidate_count": routeable_count,
+        "max_notional": "0",
+    }
+
+
+def _build(
+    *,
+    source_ledger: Mapping[str, Any] | None = None,
+    repair_bid_ledger: Mapping[str, Any] | None = None,
+    profit_frontier: Mapping[str, Any] | None = None,
+    route_warrant: Mapping[str, Any] | None = None,
+    live_submission_gate: Mapping[str, Any] | None = None,
+    proof_floor: Mapping[str, Any] | None = None,
+) -> dict[str, object]:
+    return build_repair_receipt_frontier(
+        account_label="PA3SX7FYNUTF",
+        window="15m",
+        trading_mode="live",
+        torghut_revision="torghut-00340",
+        source_commit="abc123",
+        source_serving_repair_receipt_ledger=source_ledger or _source_ledger(),
+        freshness_carry_ledger={
+            "schema_version": "torghut.freshness-carry-ledger.v1",
+            "ledger_id": "freshness-carry-ledger:test",
+        },
+        repair_bid_settlement_ledger=repair_bid_ledger
+        or _repair_bid_ledger(compacted_lots=[_compacted_lot()]),
+        profit_freshness_frontier=profit_frontier or _profit_frontier(),
+        route_warrant_exchange=route_warrant or _route_warrant(),
+        live_submission_gate=live_submission_gate
+        or {"allowed": False, "reason": "simple_submit_disabled"},
+        proof_floor_receipt=proof_floor
+        or {
+            "schema_version": "torghut.profitability-proof-floor.v1",
+            "route_state": "repair_only",
+            "capital_state": "zero_notional",
+        },
+        now=NOW,
+    )
+
+
+def _lots_by_class(frontier: Mapping[str, object]) -> dict[str, Mapping[str, Any]]:
+    return {
+        cast(str, lot["lot_class"]): cast(Mapping[str, Any], lot)
+        for lot in cast(list[Mapping[str, Any]], frontier["lots"])
+    }
+
+
+def test_source_serving_gap_preempts_non_source_repair_dispatch() -> None:
+    frontier = _build()
+
+    assert frontier["schema_version"] == REPAIR_RECEIPT_FRONTIER_SCHEMA_VERSION
+    assert frontier["frontier_state"] == "repair_only"
+    assert frontier["max_notional"] == "0"
+    assert frontier["capital_state"] == "zero_notional"
+
+    lots_by_class = _lots_by_class(frontier)
+    source_lot = lots_by_class["source_serving"]
+    feature_lot = lots_by_class["feature_rows"]
+
+    assert source_lot["dispatchable"] is True
+    assert frontier["selected_lot_id"] == source_lot["lot_id"]
+    assert feature_lot["dispatchable"] is False
+    assert "source_serving_not_converged" in feature_lot["hold_reason_codes"]
+    assert feature_lot["max_notional"] == "0"
+    assert source_lot["target_value_gate"] == "capital_gate_safety"
+    assert frontier["summary"]["source_serving_state"] == "digest_unknown"
+
+
+def test_converged_source_allows_compacted_lot_dispatch_without_notional() -> None:
+    frontier = _build(
+        source_ledger=_source_ledger(state="converged", reasons=[]),
+    )
+    lots_by_class = _lots_by_class(frontier)
+    feature_lot = lots_by_class["feature_rows"]
+
+    assert feature_lot["dispatchable"] is True
+    assert feature_lot["max_notional"] == "0"
+    assert feature_lot["target_value_gate"] == "zero_notional_or_stale_evidence_rate"
+    assert feature_lot["lot_id"] in frontier["dispatchable_lot_ids"]
+    assert frontier["selected_lot_id"] in frontier["dispatchable_lot_ids"]
+
+
+def test_nonzero_input_lot_is_rejected_but_frontier_stays_zero_notional() -> None:
+    frontier = _build(
+        source_ledger=_source_ledger(state="converged", reasons=[]),
+        repair_bid_ledger=_repair_bid_ledger(
+            compacted_lots=[_compacted_lot(max_notional="25")]
+        ),
+        profit_frontier=_profit_frontier(selected_repairs=[]),
+    )
+    feature_lot = _lots_by_class(frontier)["feature_rows"]
+
+    assert frontier["max_notional"] == "0"
+    assert feature_lot["max_notional"] == "0"
+    assert feature_lot["dispatchable"] is False
+    assert "notional_nonzero" in feature_lot["hold_reason_codes"]
+    assert feature_lot["settlement_status"] == "rejected"
+
+
+def test_empty_frontier_promotes_only_to_paper_candidate_until_live_requirements_pass() -> (
+    None
+):
+    frontier = _build(
+        source_ledger=_source_ledger(state="converged", reasons=[]),
+        repair_bid_ledger=_repair_bid_ledger(compacted_lots=[]),
+        profit_frontier={
+            "schema_version": "torghut.profit-freshness-frontier.v1",
+            "frontier_id": "profit-freshness-frontier:ready",
+            "freshness_dimensions": [
+                {"dimension": "feature_coverage", "state": "current"},
+                {"dimension": "tca_fill_quality", "state": "current"},
+            ],
+            "aggregate_blocking_reason_codes": [],
+            "selected_zero_notional_repairs": [],
+            "summary": {"selected_expected_daily_net_pnl_unlock": None},
+        },
+        route_warrant=_route_warrant(routeable_count=2),
+        live_submission_gate={"allowed": False, "reason": "simple_submit_disabled"},
+        proof_floor={
+            "route_state": "paper_candidate",
+            "capital_state": "paper_allowed",
+        },
+    )
+
+    assert frontier["lots"] == []
+    assert frontier["frontier_state"] == "paper_candidate"
+    assert all(
+        requirement["state"] == "pass"
+        for requirement in cast(
+            list[Mapping[str, Any]], frontier["paper_cutover_requirements"]
+        )
+    )
+    live_requirements = cast(
+        list[Mapping[str, Any]], frontier["live_cutover_requirements"]
+    )
+    assert any(
+        requirement["requirement"] == "live_submission_enabled"
+        and requirement["state"] == "block"
+        for requirement in live_requirements
+    )

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -1132,6 +1132,24 @@ class TestTradingApi(TestCase):
             freshness_carry["route_warrant_ref"],
             warrant["warrant_id"],
         )
+        repair_receipt_frontier = payload["repair_receipt_frontier"]
+        self.assertEqual(
+            repair_receipt_frontier["schema_version"],
+            "torghut.repair-receipt-frontier.v1",
+        )
+        self.assertEqual(repair_receipt_frontier["max_notional"], "0")
+        self.assertEqual(
+            repair_receipt_frontier["source_serving_ledger_ref"],
+            source_serving["ledger_id"],
+        )
+        self.assertEqual(
+            repair_receipt_frontier["freshness_carry_ledger_ref"],
+            freshness_carry["ledger_id"],
+        )
+        self.assertIn(
+            repair_receipt_frontier["frontier_state"],
+            {"repair_only", "paper_blocked", "paper_candidate", "live_candidate"},
+        )
         frontier = payload["profit_freshness_frontier"]
         self.assertEqual(
             frontier["schema_version"],
@@ -1667,6 +1685,25 @@ class TestTradingApi(TestCase):
         self.assertEqual(
             health_freshness_carry["schema_version"],
             status_freshness_carry["schema_version"],
+        )
+        status_repair_receipt_frontier = status_response.json()[
+            "repair_receipt_frontier"
+        ]
+        health_repair_receipt_frontier = health_response.json()[
+            "repair_receipt_frontier"
+        ]
+        self.assertEqual(
+            status_repair_receipt_frontier["schema_version"],
+            "torghut.repair-receipt-frontier.v1",
+        )
+        self.assertEqual(status_repair_receipt_frontier["max_notional"], "0")
+        self.assertEqual(
+            status_repair_receipt_frontier["source_serving_ledger_ref"],
+            status_source_serving["ledger_id"],
+        )
+        self.assertEqual(
+            health_repair_receipt_frontier["schema_version"],
+            status_repair_receipt_frontier["schema_version"],
         )
         status_frontier = status_response.json()["profit_freshness_frontier"]
         health_frontier = health_response.json()["profit_freshness_frontier"]
@@ -3772,6 +3809,14 @@ class TestTradingApi(TestCase):
             self.assertEqual(
                 runtime_response.json()["live_submission_gate"],
                 shared_gate,
+            )
+            self.assertEqual(
+                ready_response.json()["repair_receipt_frontier"]["schema_version"],
+                "torghut.repair-receipt-frontier.v1",
+            )
+            self.assertEqual(
+                ready_response.json()["repair_receipt_frontier"]["max_notional"],
+                "0",
             )
         finally:
             settings.trading_mode = original_mode


### PR DESCRIPTION
## Summary

- Adds the May 13 doc 192 `torghut.repair-receipt-frontier.v1` read model for Torghut repair receipt ranking and profit cutover.
- Exposes `repair_receipt_frontier` on `/trading/status`, `/trading/health`, `/readyz`, and `/trading/consumer-evidence`.
- Keeps the surface capital-safe: every lot reports `max_notional=0`, source-serving gaps select a source-serving lot, and non-source repairs hold until source-serving proof converges.
- Updates Torghut README/design provenance and adds reducer/API tests for zero-notional safety, source-serving holds, malformed nonzero input, and paper/live cutover gating.

## Related Issues

None. Requirement provenance is the Torghut quant NATS handoff and `docs/torghut/design-system/v6/192-torghut-repair-receipt-frontier-and-profit-cutover-2026-05-13.md`, with companion Jangar contract `docs/agents/designs/188-jangar-ready-truth-arbiter-and-stage-credit-cutover-2026-05-13.md`.

## Testing

- PASS: `/tmp/codex-uv-venv/bin/uv sync --python 3.11 --frozen --extra dev`
- PASS: `/tmp/codex-uv-venv/bin/uv lock --check`
- PASS: `/tmp/codex-uv-venv/bin/uv run --frozen ruff format --check app/trading/repair_receipt_frontier.py tests/test_repair_receipt_frontier.py tests/test_trading_api.py app/main.py`
- PASS: `/tmp/codex-uv-venv/bin/uv run --frozen ruff check app tests scripts migrations`
- PASS: `/tmp/codex-uv-venv/bin/uv run --frozen python -m compileall app`
- PASS: `/tmp/codex-uv-venv/bin/uv run --frozen pytest -q tests/test_repair_receipt_frontier.py tests/test_repair_bid_settlement.py tests/test_trading_api.py::TestTradingApi::test_trading_consumer_evidence_avoids_recursive_jangar_status_fetch tests/test_trading_api.py::TestTradingApi::test_trading_status_and_health_include_profitability_proof_floor tests/test_trading_api.py::TestTradingApi::test_live_submission_gate_matches_status_health_and_readyz` (`16 passed`)
- PASS: `/tmp/codex-uv-venv/bin/uv run --frozen pyright --project pyrightconfig.json`
- PASS: `/tmp/codex-uv-venv/bin/uv run --frozen pyright --project pyrightconfig.alpha.json`
- PASS: `/tmp/codex-uv-venv/bin/uv run --frozen pyright --project pyrightconfig.scripts.json`
- PASS: `git diff --check`

## Screenshots (if applicable)

N/A. Backend runtime projection, API payload, tests, and documentation only.

## Breaking Changes

None. The new payload is additive and read-only. It does not enable paper or live submission and does not add a database write path.

## Release Note

Design provenance: `docs/torghut/design-system/v6/192-torghut-repair-receipt-frontier-and-profit-cutover-2026-05-13.md` requires a repair receipt frontier that ranks zero-notional lots, names value gates and output receipts, and separates repair evidence from paper/live authority. This PR ships that first read model.

What shipped: Torghut now compacts source-serving proof, freshness carry, repair-bid settlement, route warrants, proof floor, live submission, and profit-freshness repair evidence into `repair_receipt_frontier`. Source-serving gaps become the selected source-serving repair lot. Non-source lots hold until source proof converges. Paper/live cutover requirements are explicit and blocking.

Key risks: payload size and interpretation complexity increase for consumers. The mitigation is additive exposure only, stable schema/version fields, explicit `governing_design_ref`, and hard zero-notional output.

Rollback path: revert this PR or ignore `repair_receipt_frontier`; existing `source_serving_repair_receipt_ledger`, `repair_bid_settlement_ledger`, and `profit_freshness_frontier` payloads remain available and capital gates remain unchanged.

Owner-facing status: this improves `zero_notional_or_stale_evidence_rate`, `routeable_candidate_count`, and `capital_gate_safety` by giving Jangar one compact repair frontier while keeping every repair lot at `max_notional=0`.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
