### PR TITLE
chore(torghut): promote image 5885a8eb

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:259fcfc68c1fa99128268d27bdf8c942a3a4eed19b14d469f4f86b92c6270ad7
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:bc52f7830b8415fb24d92ce7babcfee8a91f872776472f2cf21cb809a0249c2a
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.569.1-191-gf8ca89ff9
+              value: v0.569.1-195-g5885a8ebb
             - name: TORGHUT_OPTIONS_COMMIT
-              value: f8ca89ff98d754e18962ae72157ce8603303185b
+              value: 5885a8ebb7bde476edc98c01e5a5bb0d2e238f93
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:259fcfc68c1fa99128268d27bdf8c942a3a4eed19b14d469f4f86b92c6270ad7
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:bc52f7830b8415fb24d92ce7babcfee8a91f872776472f2cf21cb809a0249c2a
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.569.1-191-gf8ca89ff9
+              value: v0.569.1-195-g5885a8ebb
             - name: TORGHUT_OPTIONS_COMMIT
-              value: f8ca89ff98d754e18962ae72157ce8603303185b
+              value: 5885a8ebb7bde476edc98c01e5a5bb0d2e238f93
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:259fcfc68c1fa99128268d27bdf8c942a3a4eed19b14d469f4f86b92c6270ad7
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:bc52f7830b8415fb24d92ce7babcfee8a91f872776472f2cf21cb809a0249c2a
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:259fcfc68c1fa99128268d27bdf8c942a3a4eed19b14d469f4f86b92c6270ad7
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:bc52f7830b8415fb24d92ce7babcfee8a91f872776472f2cf21cb809a0249c2a
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:259fcfc68c1fa99128268d27bdf8c942a3a4eed19b14d469f4f86b92c6270ad7
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:bc52f7830b8415fb24d92ce7babcfee8a91f872776472f2cf21cb809a0249c2a
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:259fcfc68c1fa99128268d27bdf8c942a3a4eed19b14d469f4f86b92c6270ad7
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:bc52f7830b8415fb24d92ce7babcfee8a91f872776472f2cf21cb809a0249c2a
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:259fcfc68c1fa99128268d27bdf8c942a3a4eed19b14d469f4f86b92c6270ad7
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:bc52f7830b8415fb24d92ce7babcfee8a91f872776472f2cf21cb809a0249c2a
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -15,7 +15,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:259fcfc68c1fa99128268d27bdf8c942a3a4eed19b14d469f4f86b92c6270ad7
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:bc52f7830b8415fb24d92ce7babcfee8a91f872776472f2cf21cb809a0249c2a
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -23,7 +23,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:259fcfc68c1fa99128268d27bdf8c942a3a4eed19b14d469f4f86b92c6270ad7
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:bc52f7830b8415fb24d92ce7babcfee8a91f872776472f2cf21cb809a0249c2a
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:259fcfc68c1fa99128268d27bdf8c942a3a4eed19b14d469f4f86b92c6270ad7
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:bc52f7830b8415fb24d92ce7babcfee8a91f872776472f2cf21cb809a0249c2a
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-13T12:21:40Z"
+        client.knative.dev/updateTimestamp: "2026-05-13T12:33:55Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -27,7 +27,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:259fcfc68c1fa99128268d27bdf8c942a3a4eed19b14d469f4f86b92c6270ad7
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:bc52f7830b8415fb24d92ce7babcfee8a91f872776472f2cf21cb809a0249c2a
           ports:
             - name: http1
               containerPort: 8181
@@ -482,11 +482,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.569.1-191-gf8ca89ff9
+              value: v0.569.1-195-g5885a8ebb
             - name: TORGHUT_COMMIT
-              value: f8ca89ff98d754e18962ae72157ce8603303185b
+              value: 5885a8ebb7bde476edc98c01e5a5bb0d2e238f93
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:259fcfc68c1fa99128268d27bdf8c942a3a4eed19b14d469f4f86b92c6270ad7
+              value: sha256:bc52f7830b8415fb24d92ce7babcfee8a91f872776472f2cf21cb809a0249c2a
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-13T12:21:40Z"
+        client.knative.dev/updateTimestamp: "2026-05-13T12:33:55Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:259fcfc68c1fa99128268d27bdf8c942a3a4eed19b14d469f4f86b92c6270ad7
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:bc52f7830b8415fb24d92ce7babcfee8a91f872776472f2cf21cb809a0249c2a
           ports:
             - name: http1
               containerPort: 8181
@@ -298,11 +298,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.569.1-191-gf8ca89ff9
+              value: v0.569.1-195-g5885a8ebb
             - name: TORGHUT_COMMIT
-              value: f8ca89ff98d754e18962ae72157ce8603303185b
+              value: 5885a8ebb7bde476edc98c01e5a5bb0d2e238f93
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:259fcfc68c1fa99128268d27bdf8c942a3a4eed19b14d469f4f86b92c6270ad7
+              value: sha256:bc52f7830b8415fb24d92ce7babcfee8a91f872776472f2cf21cb809a0249c2a
           livenessProbe:
             httpGet:
               path: /healthz

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -89,7 +89,7 @@ spec:
           - name: allowStaleTape
           - name: persistResults
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:259fcfc68c1fa99128268d27bdf8c942a3a4eed19b14d469f4f86b92c6270ad7
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:bc52f7830b8415fb24d92ce7babcfee8a91f872776472f2cf21cb809a0249c2a
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
+++ b/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:259fcfc68c1fa99128268d27bdf8c942a3a4eed19b14d469f4f86b92c6270ad7
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:bc52f7830b8415fb24d92ce7babcfee8a91f872776472f2cf21cb809a0249c2a
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `5885a8ebb7bde476edc98c01e5a5bb0d2e238f93`
- Image tag: `5885a8eb`
- Image digest: `sha256:bc52f7830b8415fb24d92ce7babcfee8a91f872776472f2cf21cb809a0249c2a`