### PR TITLE
chore(jangar): promote image 07da331d

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: f5ed7394
-  digest: sha256:f8dcf217b832522358e62bf081b397b0d7c866df4b819f4d82ee6ff098918a98
+  tag: 07da331d
+  digest: sha256:d0a61187c54f063d6f3f875a6760b3202ff8f7733b2f7977ff06a39d1a3e3c90
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,8 +11,8 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: f5ed7394
-    digest: sha256:4086748d59302101e8ab80816a7a5059d85a2bb4a4e333d4ab6e9001e2154c68
+    tag: 07da331d
+    digest: sha256:ee5c618919f28cdb3f62440f0ef8b280ec18e2fb42b4d784b067af74f3927110
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
@@ -21,8 +21,8 @@ controlPlane:
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: f5ed7394
-    digest: sha256:f8dcf217b832522358e62bf081b397b0d7c866df4b819f4d82ee6ff098918a98
+    tag: 07da331d
+    digest: sha256:d0a61187c54f063d6f3f875a6760b3202ff8f7733b2f7977ff06a39d1a3e3c90
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-13T12:04:50Z
+    deploy.knative.dev/rollout: 2026-05-13T13:03:06Z
 spec:
   replicas: 1
   strategy:
@@ -57,11 +57,11 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_RUNTIME_IMAGE
-              value: registry.ide-newton.ts.net/lab/jangar:f5ed7394@sha256:f8dcf217b832522358e62bf081b397b0d7c866df4b819f4d82ee6ff098918a98
+              value: registry.ide-newton.ts.net/lab/jangar:07da331d@sha256:d0a61187c54f063d6f3f875a6760b3202ff8f7733b2f7977ff06a39d1a3e3c90
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: f5ed73941c4b372e9312535592677e8f7ba4a46b
+              value: 07da331d95ca0ef2779108a00a877c5e718b2656
             - name: JANGAR_GITOPS_REVISION
-              value: f5ed73941c4b372e9312535592677e8f7ba4a46b
+              value: 07da331d95ca0ef2779108a00a877c5e718b2656
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_BUMBA_TASK_QUEUE

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -59,5 +59,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: f5ed7394
-    digest: sha256:f8dcf217b832522358e62bf081b397b0d7c866df4b819f4d82ee6ff098918a98
+    newTag: 07da331d
+    digest: sha256:d0a61187c54f063d6f3f875a6760b3202ff8f7733b2f7977ff06a39d1a3e3c90


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `07da331d95ca0ef2779108a00a877c5e718b2656`
- Image tag: `07da331d`
- Image digest: `sha256:d0a61187c54f063d6f3f875a6760b3202ff8f7733b2f7977ff06a39d1a3e3c90`
- Updated API rollout annotation
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`