### PR TITLE
fix(torghut): prioritize actionable repair lots

### DIFF
--- a/services/torghut/app/trading/repair_receipt_frontier.py
+++ b/services/torghut/app/trading/repair_receipt_frontier.py
@@ -27,6 +27,13 @@ _VALUE_GATES = [
     "fill_tca_or_slippage_quality",
     "capital_gate_safety",
 ]
+_VALUE_GATE_SORT_RANK = {
+    "post_cost_daily_net_pnl": 0,
+    "routeable_candidate_count": 1,
+    "fill_tca_or_slippage_quality": 2,
+    "zero_notional_or_stale_evidence_rate": 3,
+    "capital_gate_safety": 4,
+}
 _LOT_CLASS_MAP = {
     "quant_pipeline": "signal_ingestion",
     "execution_tca": "execution_tca",
@@ -77,6 +84,7 @@ _SOURCE_REASON_VALUE_GATE = {
     "required_contract_missing": "zero_notional_or_stale_evidence_rate",
     "contract_schema_mismatch": "zero_notional_or_stale_evidence_rate",
 }
+_SOURCE_SERVING_REASON_CODES = frozenset(_SOURCE_REASON_VALUE_GATE)
 
 
 def _mapping(value: object) -> Mapping[str, Any]:
@@ -170,6 +178,14 @@ def _reason_value_gate(reason: str) -> str:
         reason.split(":", 1)[0],
         "zero_notional_or_stale_evidence_rate",
     )
+
+
+def _source_serving_reasons(reason_codes: Sequence[str]) -> list[str]:
+    return [
+        reason
+        for reason in reason_codes
+        if reason.split(":", 1)[0] in _SOURCE_SERVING_REASON_CODES
+    ]
 
 
 def _required_input_refs(*values: object) -> list[str]:
@@ -352,10 +368,12 @@ def _source_serving_lot(
     source_serving_ledger: Mapping[str, Any],
 ) -> dict[str, object] | None:
     reason_codes = _strings(source_serving_ledger.get("reason_codes"))
-    if _source_is_current(source_serving_ledger) and not reason_codes:
+    source_reasons = _source_serving_reasons(reason_codes)
+    if _source_is_current(source_serving_ledger) and not source_reasons:
         return None
     state = _source_state(source_serving_ledger)
-    primary_reason = reason_codes[0] if reason_codes else f"source_serving_{state}"
+    lot_reasons = source_reasons or [f"source_serving_{state}"]
+    primary_reason = lot_reasons[0]
     ledger_id = _text(source_serving_ledger.get("ledger_id"))
     return {
         "lot_id": _stable_ref(
@@ -373,7 +391,7 @@ def _source_serving_lot(
         "target_hypothesis_ids": [],
         "target_value_gate": _reason_value_gate(primary_reason),
         "expected_gate_delta": f"retire_{primary_reason}",
-        "expected_unblock_value": len(reason_codes) or 1,
+        "expected_unblock_value": len(lot_reasons) or 1,
         "cost_class": "low",
         "source_serving_epoch_ref": ledger_id or None,
         "required_input_refs": _required_input_refs(
@@ -410,10 +428,21 @@ def _dedupe_lots(lots: Sequence[dict[str, object]]) -> list[dict[str, object]]:
     return deduped
 
 
-def _lot_sort_key(lot: Mapping[str, object]) -> tuple[int, int, str]:
-    dispatch_rank = 1 if lot.get("dispatchable") is True else 0
-    source_rank = 1 if _text(lot.get("lot_class")) == "source_serving" else 0
-    return (-dispatch_rank, -source_rank, _text(lot.get("lot_id")))
+def _lot_sort_key(lot: Mapping[str, object]) -> tuple[int, int, int, Decimal, str]:
+    dispatch_rank = 0 if lot.get("dispatchable") is True else 1
+    source_rank = 0 if _text(lot.get("lot_class")) == "source_serving" else 1
+    value_gate_rank = _VALUE_GATE_SORT_RANK.get(
+        _text(lot.get("target_value_gate")),
+        len(_VALUE_GATE_SORT_RANK),
+    )
+    expected_unblock = _decimal(lot.get("expected_unblock_value")) or Decimal("0")
+    return (
+        dispatch_rank,
+        source_rank,
+        value_gate_rank,
+        -expected_unblock,
+        _text(lot.get("lot_id")),
+    )
 
 
 def _dimension_state(

--- a/services/torghut/tests/test_repair_receipt_frontier.py
+++ b/services/torghut/tests/test_repair_receipt_frontier.py
@@ -152,6 +152,13 @@ def _lots_by_class(frontier: Mapping[str, object]) -> dict[str, Mapping[str, Any
     }
 
 
+def _lot_by_id(frontier: Mapping[str, object], lot_id: object) -> Mapping[str, Any]:
+    for lot in cast(list[Mapping[str, Any]], frontier["lots"]):
+        if lot["lot_id"] == lot_id:
+            return lot
+    raise AssertionError(f"missing lot {lot_id}")
+
+
 def test_source_serving_gap_preempts_non_source_repair_dispatch() -> None:
     frontier = _build()
 
@@ -185,6 +192,63 @@ def test_converged_source_allows_compacted_lot_dispatch_without_notional() -> No
     assert feature_lot["target_value_gate"] == "zero_notional_or_stale_evidence_rate"
     assert feature_lot["lot_id"] in frontier["dispatchable_lot_ids"]
     assert frontier["selected_lot_id"] in frontier["dispatchable_lot_ids"]
+
+
+def test_paper_cutover_blocking_lots_rank_ahead_of_generic_stale_evidence() -> None:
+    frontier = _build(
+        source_ledger=_source_ledger(state="converged", reasons=[]),
+        repair_bid_ledger=_repair_bid_ledger(
+            compacted_lots=[
+                _compacted_lot(
+                    lot_id="compacted-repair-lot:feature",
+                    lot_class="feature_lineage",
+                    target_value_gate="zero_notional_or_stale_evidence_rate",
+                    expected_gate_delta="retire_feature_rows_missing",
+                    priority=95,
+                ),
+                _compacted_lot(
+                    lot_id="compacted-repair-lot:tca",
+                    lot_class="execution_tca",
+                    target_value_gate="fill_tca_or_slippage_quality",
+                    expected_gate_delta="retire_execution_tca_not_current",
+                    priority=90,
+                ),
+            ]
+        ),
+        profit_frontier=_profit_frontier(selected_repairs=[]),
+    )
+    lots_by_class = _lots_by_class(frontier)
+    tca_lot = lots_by_class["execution_tca"]
+
+    assert tca_lot["dispatchable"] is True
+    assert tca_lot["target_value_gate"] == "fill_tca_or_slippage_quality"
+    assert frontier["selected_lot_id"] == tca_lot["lot_id"]
+
+
+def test_converged_source_does_not_select_route_warrant_as_source_repair() -> None:
+    frontier = _build(
+        source_ledger=_source_ledger(
+            state="converged",
+            reasons=["route_warrant_repair_only"],
+        ),
+    )
+    lots_by_class = _lots_by_class(frontier)
+    feature_lot = lots_by_class["feature_rows"]
+    selected_lot = _lot_by_id(frontier, frontier["selected_lot_id"])
+
+    assert "source_serving" not in lots_by_class
+    assert feature_lot["dispatchable"] is True
+    assert feature_lot["target_value_gate"] == "zero_notional_or_stale_evidence_rate"
+    assert selected_lot["dispatchable"] is True
+    assert selected_lot["lot_class"] != "source_serving"
+    assert frontier["summary"]["source_serving_state"] == "converged"
+    assert any(
+        requirement["requirement"] == "routeable_candidate_available"
+        and requirement["state"] == "block"
+        for requirement in cast(
+            list[Mapping[str, Any]], frontier["paper_cutover_requirements"]
+        )
+    )
 
 
 def test_nonzero_input_lot_is_rejected_but_frontier_stays_zero_notional() -> None:


### PR DESCRIPTION
## Summary

- Stops route-warrant repair-only from being treated as a source-serving repair when source serving is already converged.
- Ranks dispatchable repair frontier lots by business gate priority so paper cutover blockers like execution TCA outrank generic stale-evidence work.
- Adds regression coverage for both ranking behavior and the live-shape route-warrant/source-serving case while keeping all repair lots zero-notional.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_repair_receipt_frontier.py -q`
- `uv run --frozen pytest tests/test_trading_api.py::TestTradingApi::test_trading_consumer_evidence_avoids_recursive_jangar_status_fetch tests/test_trading_api.py::TestTradingApi::test_trading_status_and_health_include_profit_signal_quorum tests/test_trading_api.py::TestTradingApi::test_live_submission_gate_matches_status_health_and_readyz -q`
- `ruff format --check app/trading/repair_receipt_frontier.py tests/test_repair_receipt_frontier.py`
- `ruff check app/trading/repair_receipt_frontier.py tests/test_repair_receipt_frontier.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
