### PR TITLE
fix(torghut): require freshness slo repair receipts

### DIFF
--- a/docs/torghut/design-system/v6/192-torghut-freshness-carry-and-repair-proof-slo-2026-05-13.md
+++ b/docs/torghut/design-system/v6/192-torghut-freshness-carry-and-repair-proof-slo-2026-05-13.md
@@ -271,6 +271,10 @@ Implementation status:
   with required output receipts.
 - Source-serving proof is a dispatch precondition for non-source freshness repairs; if source-serving proof is stale,
   only the source-serving repair SLO is dispatchable.
+- Phase 2 has started in `services/torghut/app/trading/zero_notional_repair_executor.py`: zero-notional execution
+  receipts now cite the matching `freshness_carry_ledger` dimension and `repair_proof_slo` for market-context,
+  empirical, and TCA freshness repairs. `execute=true` fails closed before runner invocation when that citation is
+  missing or the SLO is not dispatchable.
 
 Engineer milestone 2:
 

--- a/services/torghut/README.md
+++ b/services/torghut/README.md
@@ -244,7 +244,9 @@ Testing rules for the trading core:
   `torghut.zero-notional-repair-execution-receipt.v1` executor receipt for the selected frontier repair. The default
   mode is a dry run. With `execute=true`, the only local runner is bounded route/TCA recompute; empirical proof renewal
   and market-context refresh remain admission-gated receipt plans until their external runners are wired. The receipt
-  always reports `order_submission_enabled=false`, `paper_notional_limit=0`, and `live_notional_limit=0`.
+  cites the May 13 doc 192 `freshness_carry_ledger` dimension and repair proof SLO for market-context, empirical, and
+  TCA freshness repairs; execution fails closed when the SLO is missing or not dispatchable. It always reports
+  `order_submission_enabled=false`, `paper_notional_limit=0`, and `live_notional_limit=0`.
 - `GET /trading/status`, `GET /trading/health`, and `GET /readyz` also expose the May 8 doc 184
   `torghut.profit-signal-quorum.v1` shadow receipt. It evaluates each hypothesis against scoped quant latest metrics,
   quant pipeline stages, market-context route health, hypothesis lineage, promotion-decision evidence, route/TCA,

--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -1813,6 +1813,10 @@ def trading_profit_freshness_zero_notional_repair(
         execute=execute,
         preferred_action=action,
         repair_lot_dispatch_ticket=repair_lot_dispatch_ticket,
+        freshness_carry_ledger=cast(
+            Mapping[str, Any],
+            status_payload.get("freshness_carry_ledger") or {},
+        ),
         runners={
             "recompute_route_tca_and_fill_quality": run_tca_recompute,
             "rerun_drift_checks_for_blocked_hypotheses": run_drift_check_replay,

--- a/services/torghut/app/trading/zero_notional_repair_executor.py
+++ b/services/torghut/app/trading/zero_notional_repair_executor.py
@@ -53,7 +53,11 @@ _ALLOWLIST: Mapping[str, Mapping[str, object]] = {
         "rollback_path": "discard replayed feature coverage receipt and keep the hypothesis repair lot queued",
     },
 }
-
+_FRESHNESS_DIMENSION_BY_ACTION: Mapping[str, str] = {
+    "renew_empirical_proof_jobs": "empirical",
+    "refresh_stale_market_context_domains": "market_context",
+    "recompute_route_tca_and_fill_quality": "tca",
+}
 
 RepairRunner = Callable[[Mapping[str, Any]], Mapping[str, object]]
 
@@ -218,6 +222,105 @@ def _dispatch_ticket_reasons(
     return _strings(reasons)
 
 
+def _freshness_dimension_id(
+    action: str, action_contract: Mapping[str, object]
+) -> str | None:
+    configured_dimension = _text(action_contract.get("freshness_dimension_id"))
+    if configured_dimension:
+        return configured_dimension
+    action_dimension = _FRESHNESS_DIMENSION_BY_ACTION.get(action)
+    if action_dimension:
+        return action_dimension
+    return None
+
+
+def _freshness_carry_citation(
+    *,
+    action: str,
+    action_contract: Mapping[str, object],
+    freshness_carry_ledger: Mapping[str, Any],
+) -> dict[str, object]:
+    dimension_id = _freshness_dimension_id(action, action_contract)
+    if not dimension_id:
+        return {
+            "required": False,
+            "state": "not_required",
+            "ledger_ref": None,
+            "dimension_id": None,
+            "dimension_state": None,
+            "dimension_proof_authority": None,
+            "dimension_stale_reason_codes": [],
+            "repair_proof_slo_ref": None,
+            "repair_proof_slo_dispatchable": None,
+            "target_value_gate": None,
+            "required_output_receipts": [],
+            "blocking_reasons": [],
+        }
+
+    ledger_ref = freshness_carry_ledger.get("ledger_id")
+    blocking_reasons: list[str] = []
+    citation_state = "cited"
+    matched_dimension: Mapping[str, Any] = {}
+    matched_slo: Mapping[str, Any] = {}
+
+    if not freshness_carry_ledger:
+        citation_state = "missing_ledger"
+        blocking_reasons.append("freshness_carry_ledger_missing")
+    else:
+        for raw_dimension in _sequence(freshness_carry_ledger.get("dimensions")):
+            dimension = _mapping(raw_dimension)
+            if _text(dimension.get("dimension_id")) == dimension_id:
+                matched_dimension = dimension
+                break
+        if not matched_dimension:
+            citation_state = "missing_dimension"
+            blocking_reasons.append(f"freshness_dimension_missing:{dimension_id}")
+
+        for raw_slo in _sequence(freshness_carry_ledger.get("repair_proof_slos")):
+            slo = _mapping(raw_slo)
+            if _text(slo.get("target_dimension_id")) == dimension_id:
+                matched_slo = slo
+                break
+        if not matched_slo:
+            citation_state = "missing_slo"
+            blocking_reasons.append(
+                f"freshness_repair_proof_slo_missing:{dimension_id}"
+            )
+        elif not _bool(matched_slo.get("dispatchable")):
+            citation_state = "not_dispatchable"
+            blocking_reasons.append(
+                f"freshness_repair_proof_slo_not_dispatchable:{dimension_id}"
+            )
+            blocking_reasons.extend(_strings(matched_slo.get("hold_reason_codes")))
+
+    return {
+        "required": True,
+        "state": citation_state,
+        "ledger_ref": ledger_ref,
+        "dimension_id": dimension_id,
+        "dimension_state": matched_dimension.get("state"),
+        "dimension_proof_authority": matched_dimension.get("proof_authority"),
+        "dimension_stale_reason_codes": _strings(
+            matched_dimension.get("stale_reason_codes")
+        ),
+        "repair_proof_slo_ref": matched_slo.get("repair_id"),
+        "repair_proof_slo_dispatchable": _bool(matched_slo.get("dispatchable"))
+        if matched_slo
+        else None,
+        "target_value_gate": matched_slo.get("target_value_gate"),
+        "required_output_receipts": _strings(
+            matched_slo.get("required_output_receipts")
+        ),
+        "blocking_reasons": _strings(blocking_reasons),
+    }
+
+
+def _freshness_citation_blocking_reasons(citation: Mapping[str, object]) -> list[str]:
+    if not bool(citation.get("required")):
+        return []
+    return _strings(citation.get("blocking_reasons"))
+
+
 def _capital_safety_reasons(
     frontier: Mapping[str, Any], repair: Mapping[str, Any]
 ) -> list[str]:
@@ -247,6 +350,7 @@ def build_zero_notional_repair_execution_receipt(
     preferred_action: str | None = None,
     action_result: Mapping[str, object] | None = None,
     repair_lot_dispatch_ticket: Mapping[str, object] | None = None,
+    freshness_carry_ledger: Mapping[str, Any] | None = None,
     now: datetime | None = None,
 ) -> dict[str, object]:
     """Build a receipt for the selected frontier repair without granting capital."""
@@ -267,6 +371,14 @@ def build_zero_notional_repair_execution_receipt(
         repair,
         action_contract,
         dispatch_ticket,
+    )
+    freshness_citation = _freshness_carry_citation(
+        action=action,
+        action_contract=action_contract,
+        freshness_carry_ledger=_mapping(freshness_carry_ledger),
+    )
+    freshness_citation_reasons = _freshness_citation_blocking_reasons(
+        freshness_citation
     )
     execution_state = "dry_run_ready"
     command_exit_code: int | None = 0
@@ -289,6 +401,10 @@ def build_zero_notional_repair_execution_receipt(
     elif execute and dispatch_ticket_reasons:
         execution_state = "repair_lot_dispatch_ticket_required"
         blocked_reasons.extend(dispatch_ticket_reasons)
+        command_exit_code = 78
+    elif execute and freshness_citation_reasons:
+        execution_state = "freshness_repair_slo_required"
+        blocked_reasons.extend(freshness_citation_reasons)
         command_exit_code = 78
     elif execute and result:
         execution_state = _text(result.get("execution_state"), "executed")
@@ -329,6 +445,25 @@ def build_zero_notional_repair_execution_receipt(
         "blocked_dimension": repair.get("blocked_dimension"),
         "zero_notional_action": action or None,
         "preferred_zero_notional_action": normalized_preferred_action or None,
+        "freshness_carry_ledger_ref": freshness_citation["ledger_ref"],
+        "freshness_citation_required": freshness_citation["required"],
+        "freshness_citation_state": freshness_citation["state"],
+        "freshness_dimension_id": freshness_citation["dimension_id"],
+        "freshness_dimension_state": freshness_citation["dimension_state"],
+        "freshness_dimension_proof_authority": freshness_citation[
+            "dimension_proof_authority"
+        ],
+        "freshness_dimension_stale_reason_codes": freshness_citation[
+            "dimension_stale_reason_codes"
+        ],
+        "freshness_repair_proof_slo_ref": freshness_citation["repair_proof_slo_ref"],
+        "freshness_repair_proof_slo_dispatchable": freshness_citation[
+            "repair_proof_slo_dispatchable"
+        ],
+        "freshness_target_value_gate": freshness_citation["target_value_gate"],
+        "freshness_required_output_receipts": freshness_citation[
+            "required_output_receipts"
+        ],
         "executor": action_contract.get("executor"),
         "value_gate": action_contract.get("value_gate")
         or repair.get("value_gate")
@@ -376,6 +511,7 @@ def run_zero_notional_repair(
     execute: bool,
     preferred_action: str | None = None,
     repair_lot_dispatch_ticket: Mapping[str, object] | None = None,
+    freshness_carry_ledger: Mapping[str, Any] | None = None,
     runners: Mapping[str, RepairRunner] | None = None,
     now: datetime | None = None,
 ) -> dict[str, object]:
@@ -395,6 +531,14 @@ def run_zero_notional_repair(
         _mapping(action_contract),
         dispatch_ticket,
     )
+    freshness_citation = _freshness_carry_citation(
+        action=action,
+        action_contract=_mapping(action_contract),
+        freshness_carry_ledger=_mapping(freshness_carry_ledger),
+    )
+    freshness_citation_reasons = _freshness_citation_blocking_reasons(
+        freshness_citation
+    )
     action_result: Mapping[str, object] | None = None
 
     if (
@@ -403,6 +547,7 @@ def run_zero_notional_repair(
         and action_contract
         and not _capital_safety_reasons(frontier, repair)
         and not dispatch_ticket_reasons
+        and not freshness_citation_reasons
         and action in (runners or {})
     ):
         runner = cast(Mapping[str, RepairRunner], runners)[action]
@@ -418,6 +563,7 @@ def run_zero_notional_repair(
         preferred_action=normalized_preferred_action or None,
         action_result=action_result,
         repair_lot_dispatch_ticket=dispatch_ticket,
+        freshness_carry_ledger=freshness_carry_ledger,
         now=now,
     )
 

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -90,6 +90,41 @@ def _install_pipeline_universe_resolver(
     setattr(scheduler, "_pipeline", SimpleNamespace(universe_resolver=resolver))
 
 
+def _freshness_carry_ledger_for_test(dimension_id: str) -> dict[str, object]:
+    output_receipt_by_dimension = {
+        "empirical": "torghut.empirical-proof-refresh-receipt.v1",
+        "market_context": "torghut.market-context-freshness-receipt.v1",
+        "tca": "torghut.execution-tca-refresh-receipt.v1",
+    }
+    value_gate_by_dimension = {
+        "empirical": "post_cost_daily_net_pnl",
+        "market_context": "zero_notional_or_stale_evidence_rate",
+        "tca": "fill_tca_or_slippage_quality",
+    }
+    return {
+        "schema_version": "torghut.freshness-carry-ledger.v1",
+        "ledger_id": "freshness-carry-ledger:test",
+        "dimensions": [
+            {
+                "dimension_id": dimension_id,
+                "state": "stale",
+                "proof_authority": "app_health",
+                "stale_reason_codes": [f"{dimension_id}_stale"],
+            }
+        ],
+        "repair_proof_slos": [
+            {
+                "repair_id": f"freshness-repair-slo:{dimension_id}",
+                "target_dimension_id": dimension_id,
+                "target_value_gate": value_gate_by_dimension[dimension_id],
+                "required_output_receipts": [output_receipt_by_dimension[dimension_id]],
+                "dispatchable": True,
+                "hold_reason_codes": [],
+            }
+        ],
+    }
+
+
 def _mark_static_universe_loaded(scheduler: TradingScheduler) -> None:
     scheduler.state.universe_source_status = "ok"
     scheduler.state.universe_source_reason = "static_symbols_loaded"
@@ -3984,6 +4019,9 @@ class TestTradingApi(TestCase):
     def test_zero_notional_repair_endpoint_returns_dry_run_receipt(self) -> None:
         status_payload = {
             "active_revision": "torghut-00320",
+            "freshness_carry_ledger": _freshness_carry_ledger_for_test(
+                "market_context"
+            ),
             "profit_freshness_frontier": {
                 "frontier_id": "profit-freshness-frontier:test",
                 "capital_posture": {
@@ -4024,10 +4062,23 @@ class TestTradingApi(TestCase):
         self.assertEqual(payload["paper_notional_limit"], "0")
         self.assertEqual(payload["live_notional_limit"], "0")
         self.assertEqual(payload["before_refs"], ["market_context:AAPL"])
+        self.assertEqual(
+            payload["freshness_carry_ledger_ref"],
+            "freshness-carry-ledger:test",
+        )
+        self.assertEqual(payload["freshness_citation_state"], "cited")
+        self.assertEqual(payload["freshness_dimension_id"], "market_context")
+        self.assertEqual(
+            payload["freshness_repair_proof_slo_ref"],
+            "freshness-repair-slo:market_context",
+        )
 
     def test_zero_notional_repair_endpoint_accepts_dispatch_ticket_body(self) -> None:
         status_payload = {
             "active_revision": "torghut-00320",
+            "freshness_carry_ledger": _freshness_carry_ledger_for_test(
+                "market_context"
+            ),
             "profit_freshness_frontier": {
                 "frontier_id": "profit-freshness-frontier:test",
                 "capital_posture": {
@@ -4086,6 +4137,8 @@ class TestTradingApi(TestCase):
             payload["repair_lot_dispatch_ticket_ref"],
             "repair-lot-dispatch-ticket:test",
         )
+        self.assertEqual(payload["freshness_citation_state"], "cited")
+        self.assertEqual(payload["freshness_dimension_id"], "market_context")
         self.assertTrue(payload["repair_lot_dispatch_ticket_launch_allowed"])
         self.assertFalse(payload["order_submission_enabled"])
 
@@ -4094,6 +4147,7 @@ class TestTradingApi(TestCase):
     ) -> None:
         status_payload = {
             "active_revision": "torghut-00320",
+            "freshness_carry_ledger": _freshness_carry_ledger_for_test("tca"),
             "profit_freshness_frontier": {
                 "frontier_id": "profit-freshness-frontier:test",
                 "capital_posture": {
@@ -4149,6 +4203,8 @@ class TestTradingApi(TestCase):
         )
         self.assertEqual(payload["repair_lot_ref"], "profit-freshness-repair-lot:tca")
         self.assertEqual(payload["before_refs"], ["execution_tca:NVDA"])
+        self.assertEqual(payload["freshness_citation_state"], "cited")
+        self.assertEqual(payload["freshness_dimension_id"], "tca")
         self.assertFalse(payload["order_submission_enabled"])
 
     def test_zero_notional_repair_endpoint_executes_drift_replay(self) -> None:

--- a/services/torghut/tests/test_zero_notional_repair_executor.py
+++ b/services/torghut/tests/test_zero_notional_repair_executor.py
@@ -67,6 +67,47 @@ def _dispatch_ticket(
     return ticket
 
 
+def _freshness_carry_ledger(
+    dimension_id: str = "market_context",
+    *,
+    dispatchable: bool = True,
+) -> dict[str, object]:
+    output_receipt_by_dimension = {
+        "empirical": "torghut.empirical-proof-refresh-receipt.v1",
+        "market_context": "torghut.market-context-freshness-receipt.v1",
+        "tca": "torghut.execution-tca-refresh-receipt.v1",
+    }
+    value_gate_by_dimension = {
+        "empirical": "post_cost_daily_net_pnl",
+        "market_context": "zero_notional_or_stale_evidence_rate",
+        "tca": "fill_tca_or_slippage_quality",
+    }
+    return {
+        "schema_version": "torghut.freshness-carry-ledger.v1",
+        "ledger_id": "freshness-carry-ledger:test",
+        "dimensions": [
+            {
+                "dimension_id": dimension_id,
+                "state": "stale",
+                "proof_authority": "app_health",
+                "stale_reason_codes": [f"{dimension_id}_stale"],
+            }
+        ],
+        "repair_proof_slos": [
+            {
+                "repair_id": f"freshness-repair-slo:{dimension_id}",
+                "target_dimension_id": dimension_id,
+                "target_value_gate": value_gate_by_dimension[dimension_id],
+                "required_output_receipts": [output_receipt_by_dimension[dimension_id]],
+                "dispatchable": dispatchable,
+                "hold_reason_codes": []
+                if dispatchable
+                else ["source_serving_not_current"],
+            }
+        ],
+    }
+
+
 def test_dry_run_receipt_keeps_selected_repair_zero_notional() -> None:
     receipt = build_zero_notional_repair_execution_receipt(
         account_label="paper",
@@ -75,6 +116,7 @@ def test_dry_run_receipt_keeps_selected_repair_zero_notional() -> None:
         source_commit="abc123",
         profit_freshness_frontier=_frontier(),
         execute=False,
+        freshness_carry_ledger=_freshness_carry_ledger(),
         now=NOW,
     )
 
@@ -86,6 +128,16 @@ def test_dry_run_receipt_keeps_selected_repair_zero_notional() -> None:
     assert receipt["live_notional_limit"] == "0"
     assert receipt["before_refs"] == ["market_context:AAPL"]
     assert receipt["value_gate"] == "zero_notional_or_stale_evidence_rate"
+    assert receipt["freshness_carry_ledger_ref"] == "freshness-carry-ledger:test"
+    assert receipt["freshness_citation_required"] is True
+    assert receipt["freshness_citation_state"] == "cited"
+    assert receipt["freshness_dimension_id"] == "market_context"
+    assert receipt["freshness_repair_proof_slo_ref"] == (
+        "freshness-repair-slo:market_context"
+    )
+    assert receipt["freshness_required_output_receipts"] == [
+        "torghut.market-context-freshness-receipt.v1"
+    ]
     assert receipt["requires_repair_lot_dispatch_ticket"] is True
     assert receipt["repair_lot_dispatch_ticket_ref"] is None
 
@@ -108,6 +160,7 @@ def test_execute_runs_allowlisted_tca_runner_without_widening_notional() -> None
         source_commit="abc123",
         profit_freshness_frontier=_frontier("recompute_route_tca_and_fill_quality"),
         execute=True,
+        freshness_carry_ledger=_freshness_carry_ledger("tca"),
         runners={"recompute_route_tca_and_fill_quality": runner},
         now=NOW,
     )
@@ -236,6 +289,7 @@ def test_preferred_action_can_execute_queued_route_tca_repair() -> None:
         profit_freshness_frontier=frontier,
         execute=True,
         preferred_action="recompute_route_tca_and_fill_quality",
+        freshness_carry_ledger=_freshness_carry_ledger("tca"),
         runners={
             "recompute_route_tca_and_fill_quality": lambda repair: (
                 called.append(repair)
@@ -354,6 +408,7 @@ def test_runner_required_action_executes_with_matching_dispatch_ticket() -> None
         profit_freshness_frontier=_frontier("refresh_stale_market_context_domains"),
         execute=True,
         repair_lot_dispatch_ticket=_dispatch_ticket(),
+        freshness_carry_ledger=_freshness_carry_ledger(),
         runners={
             "refresh_stale_market_context_domains": lambda repair: (
                 called.append(repair)
@@ -382,6 +437,9 @@ def test_runner_required_action_executes_with_matching_dispatch_ticket() -> None
         == "profit-freshness-repair-lot:test"
     )
     assert receipt["repair_lot_dispatch_ticket_launch_allowed"] is True
+    assert receipt["freshness_citation_state"] == "cited"
+    assert receipt["freshness_dimension_id"] == "market_context"
+    assert receipt["freshness_repair_proof_slo_dispatchable"] is True
     assert receipt["paper_notional_limit"] == "0"
     assert receipt["live_notional_limit"] == "0"
     assert receipt["order_submission_enabled"] is False
@@ -601,6 +659,7 @@ def test_execute_without_local_runner_is_fail_closed() -> None:
         source_commit="abc123",
         profit_freshness_frontier=_frontier("recompute_route_tca_and_fill_quality"),
         execute=True,
+        freshness_carry_ledger=_freshness_carry_ledger("tca"),
         runners={},
         now=NOW,
     )
@@ -608,6 +667,44 @@ def test_execute_without_local_runner_is_fail_closed() -> None:
     assert receipt["execution_state"] == "runner_not_configured"
     assert receipt["command_exit_code"] == 78
     assert "zero_notional_runner_not_configured" in receipt["blocked_reasons"]
+    assert receipt["order_submission_enabled"] is False
+
+
+def test_execute_freshness_targeted_repair_requires_dispatchable_freshness_slo() -> (
+    None
+):
+    called: list[Mapping[str, Any]] = []
+
+    receipt = run_zero_notional_repair(
+        account_label="paper",
+        trading_mode="live",
+        torghut_revision="torghut-00320",
+        source_commit="abc123",
+        profit_freshness_frontier=_frontier("recompute_route_tca_and_fill_quality"),
+        execute=True,
+        freshness_carry_ledger=_freshness_carry_ledger("tca", dispatchable=False),
+        runners={
+            "recompute_route_tca_and_fill_quality": lambda repair: (
+                called.append(repair)
+                or {
+                    "execution_state": "executed",
+                    "command_exit_code": 0,
+                }
+            ),
+        },
+        now=NOW,
+    )
+
+    assert called == []
+    assert receipt["execution_state"] == "freshness_repair_slo_required"
+    assert receipt["command_exit_code"] == 78
+    assert receipt["freshness_citation_state"] == "not_dispatchable"
+    assert receipt["freshness_dimension_id"] == "tca"
+    assert receipt["freshness_repair_proof_slo_ref"] == "freshness-repair-slo:tca"
+    assert receipt["blocked_reasons"] == [
+        "freshness_repair_proof_slo_not_dispatchable:tca",
+        "source_serving_not_current",
+    ]
     assert receipt["order_submission_enabled"] is False
 
 


### PR DESCRIPTION
## Summary

- Adds freshness-carry provenance to Torghut zero-notional repair execution receipts for market-context, empirical, and TCA freshness repairs.
- Fails `execute=true` closed before runner invocation when the matching `freshness_carry_ledger` dimension or repair proof SLO is missing or not dispatchable.
- Threads the runtime `freshness_carry_ledger` through `/trading/profit-freshness/zero-notional-repair` and documents the doc 192 phase-2 behavior.
- Preserves capital safety: repair receipts still report zero paper/live notional and `order_submission_enabled=false`.

## Related Issues

None. Requirement provenance is `docs/torghut/design-system/current-source-of-truth-and-priority-guide-2026-03-09.md`, the cross-swarm Torghut quant runtime objective, and governing design doc `docs/torghut/design-system/v6/192-torghut-freshness-carry-and-repair-proof-slo-2026-05-13.md`.

## Testing

- PASS: `cd services/torghut && /tmp/codex-uv-venv/bin/uv sync --frozen --extra dev`
- PASS: `cd services/torghut && /tmp/codex-uv-venv/bin/uv lock --check`
- PASS: `cd services/torghut && /tmp/codex-uv-venv/bin/uv run --frozen --extra dev ruff format --check app/main.py app/trading/zero_notional_repair_executor.py tests/test_zero_notional_repair_executor.py tests/test_trading_api.py`
- PASS: `cd services/torghut && /tmp/codex-uv-venv/bin/uv run --frozen --extra dev ruff check app tests scripts migrations`
- PASS: `cd services/torghut && /tmp/codex-uv-venv/bin/uv run --frozen --extra dev pytest -q tests/test_zero_notional_repair_executor.py tests/test_trading_api.py -k zero_notional_repair` with `27 passed`, `77 deselected`
- PASS: `cd services/torghut && /tmp/codex-uv-venv/bin/uv run --frozen --extra dev pyright --project pyrightconfig.json`
- PASS: `cd services/torghut && /tmp/codex-uv-venv/bin/uv run --frozen --extra dev pyright --project pyrightconfig.alpha.json`
- PASS: `cd services/torghut && /tmp/codex-uv-venv/bin/uv run --frozen --extra dev pyright --project pyrightconfig.scripts.json`
- PASS: `cd services/torghut && /tmp/codex-uv-venv/bin/uv run --frozen --extra dev python -m compileall app`
- PASS: `cd services/torghut && /tmp/codex-uv-venv/bin/uv run --frozen --extra dev pytest --cov --cov-branch --cov-report=term-missing --cov-report=xml` with `2226 passed`, coverage `78.75%`
- PASS: `git diff --check`
- PASS: hosted PR CI for head `fd6f2cdbc37b9276b0357fd88ec87e0674191015`: Changed-file plan, Bytecode + lint + migration guard, Pyright, Pytest shards 0-3, Quality signals, Bytecode + pytest + coverage, semantic commits, semantic PR title, and check_changed_files.
- PASS: post-merge Torghut image promotion PR #6428 for image `aec41bab` passed argo-lint, kubeconform, torghut-ci, and torghut-post-deploy-verify. The deploy verify run observed Argo syncing the desired revision, `torghut-ws` rollout success, Knative `torghut` readiness, `/readyz` HTTP 503 accepted as `repair_only_zero_notional`, and uploaded trading status plus revenue-repair evidence artifact `torghut-revenue-repair-25804065778-1`.

## Screenshots (if applicable)

N/A. Backend API receipt, tests, and documentation changes only.

## Breaking Changes

None. Receipt fields are additive, and freshness-SLO enforcement only blocks `execute=true` repair runner invocation when required provenance is missing or not dispatchable. Paper/live notional and order submission remain held at zero.

## Release Note

Design provenance: doc 192 requires zero-notional repair receipts to cite a freshness dimension and repair proof SLO before stale market-context, TCA, or empirical evidence can be retired. This PR ships that citation path for Torghut repair execution receipts and keeps capital safety unchanged.

Risk: downstream consumers could misread citation fields as authorization. Mitigation: receipts continue to report `order_submission_enabled=false`, `paper_notional_limit=0`, and `live_notional_limit=0`; runner execution fails closed when freshness-carry provenance is missing or non-dispatchable.

Rollback path: revert squash merge `aec41babd20ac4f91f8a71186adec0b3c7d73130` or ignore the new `freshness_*` receipt fields. Existing profit-freshness, source-serving, route-warrant, and repair-bid payloads remain intact, and existing capital gates continue to hold paper/live notional.

Owner-facing status: improves `zero_notional_or_stale_evidence_rate` and `fill_tca_or_slippage_quality` evidence by making repair receipts auditable against doc 192 SLOs while preserving `capital_gate_safety`. PR #6422 was squash-merged after green PR checks; follow-on image promotion PR #6428 merged and post-deploy verification passed with Torghut still in repair-only zero-notional posture.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
