### PR TITLE
fix(torghut): settle tca freshness blockers

### DIFF
--- a/services/torghut/app/trading/profit_freshness_frontier.py
+++ b/services/torghut/app/trading/profit_freshness_frontier.py
@@ -87,6 +87,12 @@ _DIMENSION_SUCCESS: Mapping[str, str] = {
     "schema_migration_state": "schema and migration lineage blockers are absent",
     "jangar_settlement": "Jangar reliability settlement allows paper canary consideration",
 }
+_ROUTEABILITY_ONLY_TCA_REASON_CODES = {
+    "execution_tca_route_universe_exclusions_applied",
+    "execution_tca_symbol_missing",
+    "route_tca_passed_but_dependency_receipts_block_capital",
+}
+_ROUTEABILITY_ONLY_TCA_REASON_PREFIXES = ("capital_state_", "proof_floor_")
 
 
 def _mapping(value: object) -> Mapping[str, Any]:
@@ -559,6 +565,12 @@ def _route_symbols(route_reacquisition_board: Mapping[str, Any]) -> list[str]:
     )
 
 
+def _routeability_only_tca_reason(reason: str) -> bool:
+    return reason in _ROUTEABILITY_ONLY_TCA_REASON_CODES or reason.startswith(
+        _ROUTEABILITY_ONLY_TCA_REASON_PREFIXES
+    )
+
+
 def _tca_dimension(
     *,
     proof_floor_receipt: Mapping[str, Any],
@@ -573,28 +585,48 @@ def _tca_dimension(
         if _text(lot.get("lot_type")) == "route_universe_tca_repair":
             route_lot = lot
             break
-    reasons = [
-        *_strings(execution_tca.get("blocking_reason_codes")),
+    proof_state = _text(execution_tca.get("state"), "missing").lower()
+    reasons: list[str] = []
+    if not execution_tca:
+        reasons.append("execution_tca_missing")
+    else:
+        for reason in _strings(execution_tca.get("blocking_reason_codes")):
+            if proof_state not in _CURRENT_STATES or not _routeability_only_tca_reason(
+                reason
+            ):
+                reasons.append(reason)
+    proof_reason = _text(execution_tca.get("reason"))
+    if proof_state not in _CURRENT_STATES:
+        if proof_reason:
+            reasons.append(proof_reason)
+        elif proof_state == "missing":
+            reasons.append("execution_tca_missing")
+        elif proof_state == "stale":
+            reasons.append("execution_tca_stale")
+        elif proof_state:
+            reasons.append(f"execution_tca_{proof_state}")
+    routeability_reasons: list[str] = [
+        *_strings(routeability_ledger.get("aggregate_blocking_reason_codes")),
         *_strings(route_lot.get("blocking_reason_codes")),
     ]
-    proof_reason = _text(execution_tca.get("reason"))
-    if (
-        proof_reason
-        and _text(execution_tca.get("state")).lower() not in _CURRENT_STATES
-    ):
-        reasons.append(proof_reason)
+    blocked_symbols: list[str] = []
     for row in _route_rows(route_reacquisition_board):
         row_state = _text(row.get("state")).lower()
         blocker = _text(row.get("current_blocker"))
         if blocker and row_state not in _ROUTE_SETTLED_ROW_STATES:
-            reasons.append(blocker)
+            routeability_reasons.append(blocker)
+            if symbol := _text(row.get("symbol")).upper():
+                blocked_symbols.append(symbol)
     freshness_seconds = _int(execution_tca.get("freshness_seconds"), default=-1)
+    missing = proof_state == "missing" or any("missing" in reason for reason in reasons)
+    stale = proof_state == "stale"
     return _dimension(
         name="tca_fill_quality",
         state=_state_from_reasons(
             reasons,
-            missing=any("missing" in reason for reason in reasons),
-            stale=_text(execution_tca.get("state")).lower() == "stale",
+            missing=missing,
+            stale=stale,
+            blocked=proof_state in _BAD_STATES and not missing and not stale,
         ),
         generated_at=generated_at,
         reason_codes=reasons,
@@ -602,10 +634,16 @@ def _tca_dimension(
             _text(routeability_ledger.get("ledger_id"), "routeability_acceptance"),
             "execution_tca",
         ],
-        blocking_hypotheses=_strings(route_lot.get("hypothesis_ids")),
+        blocking_hypotheses=_strings(route_lot.get("hypothesis_ids"))
+        if reasons
+        else [],
         staleness_seconds=None if freshness_seconds < 0 else freshness_seconds,
         observed_at=_mapping(execution_tca.get("source_ref")).get("last_computed_at"),
-        details={"symbols": _route_symbols(route_reacquisition_board)},
+        details={
+            "symbols": _route_symbols(route_reacquisition_board),
+            "routeability_blocker_codes": _unique(routeability_reasons),
+            "routeability_blocked_symbols": _unique(blocked_symbols),
+        },
     )
 
 

--- a/services/torghut/tests/test_profit_freshness_frontier.py
+++ b/services/torghut/tests/test_profit_freshness_frontier.py
@@ -338,3 +338,221 @@ def test_closed_frontier_still_does_not_widen_capital_limits() -> None:
     assert frontier["capital_posture"]["paper_replay_candidate_count"] == 1
     assert frontier["capital_posture"]["paper_notional_limit"] == "0"
     assert frontier["capital_posture"]["live_notional_limit"] == "0"
+
+
+def test_tca_dimension_reports_missing_when_proof_dimension_is_absent() -> None:
+    frontier = _frontier(
+        proof_floor_receipt={
+            "schema_version": "torghut.profitability-proof-floor.v1",
+            "account_label": "PA3SX7FYNUTF",
+            "route_state": "repair_only",
+            "capital_state": "zero_notional",
+            "max_notional": "0",
+            "blocking_reasons": [],
+            "proof_dimensions": [],
+        }
+    )
+
+    tca_dimension = _dimension(frontier, "tca_fill_quality")
+
+    assert tca_dimension["state"] == "missing"
+    assert tca_dimension["reason_codes"] == ["execution_tca_missing"]
+
+
+def test_tca_dimension_keeps_non_routeability_proof_blockers() -> None:
+    frontier = _frontier(
+        proof_floor_receipt={
+            "schema_version": "torghut.profitability-proof-floor.v1",
+            "account_label": "PA3SX7FYNUTF",
+            "route_state": "repair_only",
+            "capital_state": "zero_notional",
+            "max_notional": "0",
+            "blocking_reasons": [],
+            "proof_dimensions": [
+                {
+                    "dimension": "execution_tca",
+                    "state": "pass",
+                    "blocking_reason_codes": [
+                        "capital_state_zero_notional",
+                        "fill_quality_guardrail_failed",
+                    ],
+                }
+            ],
+        }
+    )
+
+    tca_dimension = _dimension(frontier, "tca_fill_quality")
+
+    assert tca_dimension["state"] == "degraded"
+    assert tca_dimension["reason_codes"] == ["fill_quality_guardrail_failed"]
+
+
+def test_tca_dimension_derives_stale_and_failed_reasons_without_explicit_reason() -> (
+    None
+):
+    stale_frontier = _frontier(
+        proof_floor_receipt={
+            "schema_version": "torghut.profitability-proof-floor.v1",
+            "account_label": "PA3SX7FYNUTF",
+            "route_state": "repair_only",
+            "capital_state": "zero_notional",
+            "max_notional": "0",
+            "blocking_reasons": [],
+            "proof_dimensions": [
+                {
+                    "dimension": "execution_tca",
+                    "state": "stale",
+                    "freshness_seconds": 330_000,
+                }
+            ],
+        }
+    )
+    failed_frontier = _frontier(
+        proof_floor_receipt={
+            "schema_version": "torghut.profitability-proof-floor.v1",
+            "account_label": "PA3SX7FYNUTF",
+            "route_state": "repair_only",
+            "capital_state": "zero_notional",
+            "max_notional": "0",
+            "blocking_reasons": [],
+            "proof_dimensions": [
+                {
+                    "dimension": "execution_tca",
+                    "state": "fail",
+                }
+            ],
+        }
+    )
+
+    stale_dimension = _dimension(stale_frontier, "tca_fill_quality")
+    failed_dimension = _dimension(failed_frontier, "tca_fill_quality")
+
+    assert stale_dimension["state"] == "stale"
+    assert stale_dimension["reason_codes"] == ["execution_tca_stale"]
+    assert failed_dimension["state"] == "blocked"
+    assert failed_dimension["reason_codes"] == ["execution_tca_fail"]
+
+
+def test_fresh_execution_tca_does_not_inherit_routeability_blockers() -> None:
+    frontier = _frontier(
+        proof_floor_receipt={
+            "schema_version": "torghut.profitability-proof-floor.v1",
+            "account_label": "PA3SX7FYNUTF",
+            "route_state": "repair_only",
+            "capital_state": "zero_notional",
+            "max_notional": "0",
+            "blocking_reasons": [],
+            "proof_dimensions": [
+                {
+                    "dimension": "execution_tca",
+                    "state": "pass",
+                    "reason": "execution_tca_route_universe_exclusions_applied",
+                    "freshness_seconds": 71,
+                    "source_ref": {
+                        "last_computed_at": "2026-05-12T15:08:49+00:00",
+                    },
+                }
+            ],
+        },
+        routeability_repair_acceptance_ledger={
+            "schema_version": "torghut.routeability-repair-acceptance-ledger.v1",
+            "ledger_id": "routeability-acceptance-ledger:route-blocked",
+            "aggregate_state": "blocked",
+            "accepted_routeable_candidate_count": 0,
+            "aggregate_blocking_reason_codes": [
+                "proof_floor_repair_only",
+                "capital_state_zero_notional",
+                "route_tca_passed_but_dependency_receipts_block_capital",
+                "execution_tca_route_universe_exclusions_applied",
+                "execution_tca_symbol_missing",
+            ],
+            "lots": [
+                {
+                    "lot_id": "routeability-repair-lot:tca",
+                    "lot_type": "route_universe_tca_repair",
+                    "current_state": "blocked",
+                    "blocking_reason_codes": [
+                        "execution_tca_route_universe_exclusions_applied",
+                        "execution_tca_symbol_missing",
+                    ],
+                    "hypothesis_ids": ["H-AAPL", "H-AMD", "H-AMZN"],
+                }
+            ],
+        },
+        route_reacquisition_board={
+            "summary": {"capital_eligible_symbol_count": 0},
+            "rows": [
+                {
+                    "symbol": "AAPL",
+                    "state": "probing",
+                    "current_blocker": (
+                        "route_tca_passed_but_dependency_receipts_block_capital"
+                    ),
+                    "hypothesis_ids": ["H-AAPL"],
+                },
+                {
+                    "symbol": "AMD",
+                    "state": "blocked",
+                    "current_blocker": "execution_tca_route_universe_exclusions_applied",
+                    "hypothesis_ids": ["H-AMD"],
+                },
+                {
+                    "symbol": "AMZN",
+                    "state": "missing",
+                    "current_blocker": "execution_tca_symbol_missing",
+                    "hypothesis_ids": ["H-AMZN"],
+                },
+            ],
+        },
+        quant_evidence={
+            "ok": True,
+            "status": "healthy",
+            "latest_metrics_count": 144,
+            "stage_count": 4,
+        },
+        market_context_status={"status": "healthy", "last_domain_states": {}},
+        empirical_jobs_status={
+            "ready": True,
+            "status": "healthy",
+            "eligible_jobs": [
+                "benchmark_parity",
+                "foundation_router_parity",
+                "janus_event_car",
+                "janus_hgrm_reward",
+            ],
+            "candidate_ids": ["candidate-aapl"],
+            "dataset_snapshot_refs": ["dataset-aapl"],
+        },
+        hypothesis_payload={
+            "summary": {"promotion_eligible_total": 0, "reason_totals": {}},
+            "items": [{"hypothesis_id": "H-AAPL", "reasons": []}],
+        },
+        jangar_reliability_settlement_ref={
+            "settlement_ref": "jangar-reliability-settlement:ready",
+            "decision": "allow",
+            "state": "current",
+            "reason_codes": [],
+        },
+    )
+
+    tca_dimension = _dimension(frontier, "tca_fill_quality")
+    route_dimension = _dimension(frontier, "route_readiness")
+
+    assert tca_dimension["state"] == "current"
+    assert tca_dimension["reason_codes"] == []
+    assert tca_dimension["blocking_hypotheses"] == []
+    assert tca_dimension["details"]["routeability_blocked_symbols"] == [
+        "AAPL",
+        "AMD",
+        "AMZN",
+    ]
+    assert route_dimension["state"] == "blocked"
+    assert "capital_state_zero_notional" in route_dimension["reason_codes"]
+    assert (
+        "route_tca_passed_but_dependency_receipts_block_capital"
+        in route_dimension["reason_codes"]
+    )
+    assert (
+        frontier["next_zero_notional_action"] == "settle_routeability_acceptance_lots"
+    )
+    assert frontier["capital_posture"]["paper_replay_candidate_count"] == 0


### PR DESCRIPTION
## Summary

- Treat execution TCA freshness as a proof-floor receipt state instead of inheriting routeability and capital blockers.
- Keep routeability/capital blockers visible in TCA details while preserving `route_readiness` as the blocking dimension.
- Add a regression for fresh execution TCA with blocked routeability lots so the next zero-notional action advances correctly.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_profit_freshness_frontier.py -q`
- `cd services/torghut && uv run --frozen pytest tests/test_repair_receipt_frontier.py tests/test_profit_freshness_frontier.py -q`
- `cd services/torghut && ruff format --check app/trading/profit_freshness_frontier.py tests/test_profit_freshness_frontier.py`
- `cd services/torghut && ruff check app/trading/profit_freshness_frontier.py tests/test_profit_freshness_frontier.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A - backend projection behavior only.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
