### PR TITLE
chore(torghut): promote image aec41bab

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:88cd77f121dc79c6c514e09d38b4f19a83f33cc3d4df59f856d4953e69dbc1e6
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:38018216ef767d66f1efc0f52526d3c93b5cae1b89a29bb525c63b49fa97d8bb
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.569.1-206-gc2c800816
+              value: v0.569.1-208-gaec41babd
             - name: TORGHUT_OPTIONS_COMMIT
-              value: c2c800816d817093d80331dbc847799e0c4fe4a2
+              value: aec41babd20ac4f91f8a71186adec0b3c7d73130
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:88cd77f121dc79c6c514e09d38b4f19a83f33cc3d4df59f856d4953e69dbc1e6
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:38018216ef767d66f1efc0f52526d3c93b5cae1b89a29bb525c63b49fa97d8bb
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.569.1-206-gc2c800816
+              value: v0.569.1-208-gaec41babd
             - name: TORGHUT_OPTIONS_COMMIT
-              value: c2c800816d817093d80331dbc847799e0c4fe4a2
+              value: aec41babd20ac4f91f8a71186adec0b3c7d73130
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:88cd77f121dc79c6c514e09d38b4f19a83f33cc3d4df59f856d4953e69dbc1e6
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:38018216ef767d66f1efc0f52526d3c93b5cae1b89a29bb525c63b49fa97d8bb
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:88cd77f121dc79c6c514e09d38b4f19a83f33cc3d4df59f856d4953e69dbc1e6
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:38018216ef767d66f1efc0f52526d3c93b5cae1b89a29bb525c63b49fa97d8bb
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:88cd77f121dc79c6c514e09d38b4f19a83f33cc3d4df59f856d4953e69dbc1e6
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:38018216ef767d66f1efc0f52526d3c93b5cae1b89a29bb525c63b49fa97d8bb
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:88cd77f121dc79c6c514e09d38b4f19a83f33cc3d4df59f856d4953e69dbc1e6
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:38018216ef767d66f1efc0f52526d3c93b5cae1b89a29bb525c63b49fa97d8bb
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:88cd77f121dc79c6c514e09d38b4f19a83f33cc3d4df59f856d4953e69dbc1e6
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:38018216ef767d66f1efc0f52526d3c93b5cae1b89a29bb525c63b49fa97d8bb
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -15,7 +15,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:88cd77f121dc79c6c514e09d38b4f19a83f33cc3d4df59f856d4953e69dbc1e6
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:38018216ef767d66f1efc0f52526d3c93b5cae1b89a29bb525c63b49fa97d8bb
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -23,7 +23,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:88cd77f121dc79c6c514e09d38b4f19a83f33cc3d4df59f856d4953e69dbc1e6
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:38018216ef767d66f1efc0f52526d3c93b5cae1b89a29bb525c63b49fa97d8bb
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:88cd77f121dc79c6c514e09d38b4f19a83f33cc3d4df59f856d4953e69dbc1e6
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:38018216ef767d66f1efc0f52526d3c93b5cae1b89a29bb525c63b49fa97d8bb
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-13T13:55:17Z"
+        client.knative.dev/updateTimestamp: "2026-05-13T13:59:25Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -27,7 +27,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:88cd77f121dc79c6c514e09d38b4f19a83f33cc3d4df59f856d4953e69dbc1e6
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:38018216ef767d66f1efc0f52526d3c93b5cae1b89a29bb525c63b49fa97d8bb
           ports:
             - name: http1
               containerPort: 8181
@@ -482,11 +482,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.569.1-206-gc2c800816
+              value: v0.569.1-208-gaec41babd
             - name: TORGHUT_COMMIT
-              value: c2c800816d817093d80331dbc847799e0c4fe4a2
+              value: aec41babd20ac4f91f8a71186adec0b3c7d73130
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:88cd77f121dc79c6c514e09d38b4f19a83f33cc3d4df59f856d4953e69dbc1e6
+              value: sha256:38018216ef767d66f1efc0f52526d3c93b5cae1b89a29bb525c63b49fa97d8bb
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-13T13:55:17Z"
+        client.knative.dev/updateTimestamp: "2026-05-13T13:59:25Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:88cd77f121dc79c6c514e09d38b4f19a83f33cc3d4df59f856d4953e69dbc1e6
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:38018216ef767d66f1efc0f52526d3c93b5cae1b89a29bb525c63b49fa97d8bb
           ports:
             - name: http1
               containerPort: 8181
@@ -298,11 +298,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.569.1-206-gc2c800816
+              value: v0.569.1-208-gaec41babd
             - name: TORGHUT_COMMIT
-              value: c2c800816d817093d80331dbc847799e0c4fe4a2
+              value: aec41babd20ac4f91f8a71186adec0b3c7d73130
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:88cd77f121dc79c6c514e09d38b4f19a83f33cc3d4df59f856d4953e69dbc1e6
+              value: sha256:38018216ef767d66f1efc0f52526d3c93b5cae1b89a29bb525c63b49fa97d8bb
           livenessProbe:
             httpGet:
               path: /healthz

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -89,7 +89,7 @@ spec:
           - name: allowStaleTape
           - name: persistResults
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:88cd77f121dc79c6c514e09d38b4f19a83f33cc3d4df59f856d4953e69dbc1e6
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:38018216ef767d66f1efc0f52526d3c93b5cae1b89a29bb525c63b49fa97d8bb
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
+++ b/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:88cd77f121dc79c6c514e09d38b4f19a83f33cc3d4df59f856d4953e69dbc1e6
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:38018216ef767d66f1efc0f52526d3c93b5cae1b89a29bb525c63b49fa97d8bb
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `aec41babd20ac4f91f8a71186adec0b3c7d73130`
- Image tag: `aec41bab`
- Image digest: `sha256:38018216ef767d66f1efc0f52526d3c93b5cae1b89a29bb525c63b49fa97d8bb`