### PR TITLE
chore(jangar): promote image ae73112d

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 07da331d
-  digest: sha256:d0a61187c54f063d6f3f875a6760b3202ff8f7733b2f7977ff06a39d1a3e3c90
+  tag: ae73112d
+  digest: sha256:ce5e5782cd2c1479dfac043dacdab56abbeb2b2a918e92b1ed27970b27e6bf45
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,8 +11,8 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 07da331d
-    digest: sha256:ee5c618919f28cdb3f62440f0ef8b280ec18e2fb42b4d784b067af74f3927110
+    tag: ae73112d
+    digest: sha256:0725a922f4ad0273555f3fa88b46894b8a8d8f2b2c3b638a4b4fce9c4fd13c4e
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
@@ -21,8 +21,8 @@ controlPlane:
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 07da331d
-    digest: sha256:d0a61187c54f063d6f3f875a6760b3202ff8f7733b2f7977ff06a39d1a3e3c90
+    tag: ae73112d
+    digest: sha256:ce5e5782cd2c1479dfac043dacdab56abbeb2b2a918e92b1ed27970b27e6bf45
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-13T13:03:06Z
+    deploy.knative.dev/rollout: 2026-05-13T14:05:42Z
 spec:
   replicas: 1
   strategy:
@@ -57,11 +57,11 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_RUNTIME_IMAGE
-              value: registry.ide-newton.ts.net/lab/jangar:07da331d@sha256:d0a61187c54f063d6f3f875a6760b3202ff8f7733b2f7977ff06a39d1a3e3c90
+              value: registry.ide-newton.ts.net/lab/jangar:ae73112d@sha256:ce5e5782cd2c1479dfac043dacdab56abbeb2b2a918e92b1ed27970b27e6bf45
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: 07da331d95ca0ef2779108a00a877c5e718b2656
+              value: ae73112d6a8ca5aed3e9f78c4a76355f62fa3d93
             - name: JANGAR_GITOPS_REVISION
-              value: 07da331d95ca0ef2779108a00a877c5e718b2656
+              value: ae73112d6a8ca5aed3e9f78c4a76355f62fa3d93
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_BUMBA_TASK_QUEUE

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -59,5 +59,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: 07da331d
-    digest: sha256:d0a61187c54f063d6f3f875a6760b3202ff8f7733b2f7977ff06a39d1a3e3c90
+    newTag: ae73112d
+    digest: sha256:ce5e5782cd2c1479dfac043dacdab56abbeb2b2a918e92b1ed27970b27e6bf45


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `ae73112d6a8ca5aed3e9f78c4a76355f62fa3d93`
- Image tag: `ae73112d`
- Image digest: `sha256:ce5e5782cd2c1479dfac043dacdab56abbeb2b2a918e92b1ed27970b27e6bf45`
- Updated API rollout annotation
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`