### PR TITLE
chore(torghut): promote image 4e1430e5

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:38018216ef767d66f1efc0f52526d3c93b5cae1b89a29bb525c63b49fa97d8bb
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:ab0bd92d641618b02699fb635ae5606c53d93a47ed4f87d25722cbf7929db969
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.569.1-208-gaec41babd
+              value: v0.569.1-212-g4e1430e5a
             - name: TORGHUT_OPTIONS_COMMIT
-              value: aec41babd20ac4f91f8a71186adec0b3c7d73130
+              value: 4e1430e5a16b317c0645334bd5d840422bf4a6e8
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:38018216ef767d66f1efc0f52526d3c93b5cae1b89a29bb525c63b49fa97d8bb
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:ab0bd92d641618b02699fb635ae5606c53d93a47ed4f87d25722cbf7929db969
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.569.1-208-gaec41babd
+              value: v0.569.1-212-g4e1430e5a
             - name: TORGHUT_OPTIONS_COMMIT
-              value: aec41babd20ac4f91f8a71186adec0b3c7d73130
+              value: 4e1430e5a16b317c0645334bd5d840422bf4a6e8
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:38018216ef767d66f1efc0f52526d3c93b5cae1b89a29bb525c63b49fa97d8bb
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:ab0bd92d641618b02699fb635ae5606c53d93a47ed4f87d25722cbf7929db969
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:38018216ef767d66f1efc0f52526d3c93b5cae1b89a29bb525c63b49fa97d8bb
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:ab0bd92d641618b02699fb635ae5606c53d93a47ed4f87d25722cbf7929db969
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:38018216ef767d66f1efc0f52526d3c93b5cae1b89a29bb525c63b49fa97d8bb
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:ab0bd92d641618b02699fb635ae5606c53d93a47ed4f87d25722cbf7929db969
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:38018216ef767d66f1efc0f52526d3c93b5cae1b89a29bb525c63b49fa97d8bb
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:ab0bd92d641618b02699fb635ae5606c53d93a47ed4f87d25722cbf7929db969
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:38018216ef767d66f1efc0f52526d3c93b5cae1b89a29bb525c63b49fa97d8bb
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:ab0bd92d641618b02699fb635ae5606c53d93a47ed4f87d25722cbf7929db969
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -15,7 +15,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:38018216ef767d66f1efc0f52526d3c93b5cae1b89a29bb525c63b49fa97d8bb
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:ab0bd92d641618b02699fb635ae5606c53d93a47ed4f87d25722cbf7929db969
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -23,7 +23,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:38018216ef767d66f1efc0f52526d3c93b5cae1b89a29bb525c63b49fa97d8bb
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:ab0bd92d641618b02699fb635ae5606c53d93a47ed4f87d25722cbf7929db969
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:38018216ef767d66f1efc0f52526d3c93b5cae1b89a29bb525c63b49fa97d8bb
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:ab0bd92d641618b02699fb635ae5606c53d93a47ed4f87d25722cbf7929db969
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-13T13:59:25Z"
+        client.knative.dev/updateTimestamp: "2026-05-13T14:11:07Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -27,7 +27,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:38018216ef767d66f1efc0f52526d3c93b5cae1b89a29bb525c63b49fa97d8bb
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:ab0bd92d641618b02699fb635ae5606c53d93a47ed4f87d25722cbf7929db969
           ports:
             - name: http1
               containerPort: 8181
@@ -482,11 +482,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.569.1-208-gaec41babd
+              value: v0.569.1-212-g4e1430e5a
             - name: TORGHUT_COMMIT
-              value: aec41babd20ac4f91f8a71186adec0b3c7d73130
+              value: 4e1430e5a16b317c0645334bd5d840422bf4a6e8
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:38018216ef767d66f1efc0f52526d3c93b5cae1b89a29bb525c63b49fa97d8bb
+              value: sha256:ab0bd92d641618b02699fb635ae5606c53d93a47ed4f87d25722cbf7929db969
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-13T13:59:25Z"
+        client.knative.dev/updateTimestamp: "2026-05-13T14:11:07Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:38018216ef767d66f1efc0f52526d3c93b5cae1b89a29bb525c63b49fa97d8bb
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:ab0bd92d641618b02699fb635ae5606c53d93a47ed4f87d25722cbf7929db969
           ports:
             - name: http1
               containerPort: 8181
@@ -298,11 +298,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.569.1-208-gaec41babd
+              value: v0.569.1-212-g4e1430e5a
             - name: TORGHUT_COMMIT
-              value: aec41babd20ac4f91f8a71186adec0b3c7d73130
+              value: 4e1430e5a16b317c0645334bd5d840422bf4a6e8
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:38018216ef767d66f1efc0f52526d3c93b5cae1b89a29bb525c63b49fa97d8bb
+              value: sha256:ab0bd92d641618b02699fb635ae5606c53d93a47ed4f87d25722cbf7929db969
           livenessProbe:
             httpGet:
               path: /healthz

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -89,7 +89,7 @@ spec:
           - name: allowStaleTape
           - name: persistResults
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:38018216ef767d66f1efc0f52526d3c93b5cae1b89a29bb525c63b49fa97d8bb
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:ab0bd92d641618b02699fb635ae5606c53d93a47ed4f87d25722cbf7929db969
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
+++ b/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:38018216ef767d66f1efc0f52526d3c93b5cae1b89a29bb525c63b49fa97d8bb
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:ab0bd92d641618b02699fb635ae5606c53d93a47ed4f87d25722cbf7929db969
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `4e1430e5a16b317c0645334bd5d840422bf4a6e8`
- Image tag: `4e1430e5`
- Image digest: `sha256:ab0bd92d641618b02699fb635ae5606c53d93a47ed4f87d25722cbf7929db969`