### PR TITLE
fix(torghut): ignore nonblocking jangar settlement reasons

### DIFF
--- a/services/torghut/app/trading/profit_freshness_frontier.py
+++ b/services/torghut/app/trading/profit_freshness_frontier.py
@@ -93,6 +93,9 @@ _ROUTEABILITY_ONLY_TCA_REASON_CODES = {
     "route_tca_passed_but_dependency_receipts_block_capital",
 }
 _ROUTEABILITY_ONLY_TCA_REASON_PREFIXES = ("capital_state_", "proof_floor_")
+_NONBLOCKING_JANGAR_RELIABILITY_REASONS = {
+    "torghut_dependency_quorum_not_required",
+}
 
 
 def _mapping(value: object) -> Mapping[str, Any]:
@@ -711,10 +714,15 @@ def _jangar_dimension(
     state = _text(
         jangar_reliability_settlement_ref.get("state") or decision, "missing"
     ).lower()
-    reasons = [
+    raw_reasons = [
         *_strings(jangar_reliability_settlement_ref.get("reason_codes")),
         *_strings(jangar_reliability_settlement_ref.get("blocking_reasons")),
         *_strings(jangar_reliability_settlement_ref.get("reasons")),
+    ]
+    reasons = [
+        reason
+        for reason in raw_reasons
+        if reason not in _NONBLOCKING_JANGAR_RELIABILITY_REASONS
     ]
     if decision not in _CURRENT_STATES:
         reasons.append(f"jangar_reliability_settlement_{decision}")
@@ -740,6 +748,11 @@ def _jangar_dimension(
             "decision": decision,
             "state": state,
             "source": jangar_reliability_settlement_ref.get("source"),
+            "informational_reason_codes": [
+                reason
+                for reason in raw_reasons
+                if reason in _NONBLOCKING_JANGAR_RELIABILITY_REASONS
+            ],
         },
     )
 

--- a/services/torghut/tests/test_profit_freshness_frontier.py
+++ b/services/torghut/tests/test_profit_freshness_frontier.py
@@ -256,6 +256,101 @@ def test_positive_partial_signal_does_not_create_paper_candidate_when_jangar_hol
     assert frontier["capital_posture"]["capital_behavior_changed"] is False
 
 
+def test_jangar_not_required_allow_reason_does_not_hold_frontier() -> None:
+    frontier = _frontier(
+        quant_evidence={
+            "ok": True,
+            "status": "healthy",
+            "latest_metrics_count": 144,
+            "stage_count": 4,
+        },
+        market_context_status={"status": "healthy", "last_domain_states": {}},
+        empirical_jobs_status={
+            "ready": True,
+            "status": "healthy",
+            "eligible_jobs": [
+                "benchmark_parity",
+                "foundation_router_parity",
+                "janus_event_car",
+                "janus_hgrm_reward",
+            ],
+            "candidate_ids": ["candidate-nvda"],
+            "dataset_snapshot_refs": ["dataset-nvda"],
+        },
+        jangar_reliability_settlement_ref={
+            "settlement_ref": (
+                "jangar-reliability-settlement:"
+                "dependency-quorum:allow:torghut_dependency_quorum_not_required"
+            ),
+            "decision": "allow",
+            "state": "current",
+            "reason_codes": ["torghut_dependency_quorum_not_required"],
+            "source": "dependency_quorum_proxy",
+        },
+    )
+
+    jangar = _dimension(frontier, "jangar_settlement")
+
+    assert jangar["state"] == "current"
+    assert jangar["reason_codes"] == []
+    assert jangar["details"]["informational_reason_codes"] == [
+        "torghut_dependency_quorum_not_required"
+    ]
+    assert all(
+        repair["blocked_dimension"] != "jangar_settlement"
+        for repair in cast(
+            list[Mapping[str, Any]], frontier["selected_zero_notional_repairs"]
+        )
+    )
+    assert frontier["frontier_state"] != "held"
+    assert (
+        frontier["next_zero_notional_action"] != "refresh_jangar_reliability_settlement"
+    )
+
+
+def test_jangar_allow_with_real_blocking_reason_still_holds_frontier() -> None:
+    frontier = _frontier(
+        quant_evidence={
+            "ok": True,
+            "status": "healthy",
+            "latest_metrics_count": 144,
+            "stage_count": 4,
+        },
+        market_context_status={"status": "healthy", "last_domain_states": {}},
+        empirical_jobs_status={
+            "ready": True,
+            "status": "healthy",
+            "eligible_jobs": [
+                "benchmark_parity",
+                "foundation_router_parity",
+                "janus_event_car",
+                "janus_hgrm_reward",
+            ],
+            "candidate_ids": ["candidate-nvda"],
+            "dataset_snapshot_refs": ["dataset-nvda"],
+        },
+        jangar_reliability_settlement_ref={
+            "settlement_ref": "jangar-reliability-settlement:blocking",
+            "decision": "allow",
+            "state": "current",
+            "reason_codes": [
+                "torghut_dependency_quorum_not_required",
+                "jangar_controller_unavailable",
+            ],
+            "source": "dependency_quorum_proxy",
+        },
+    )
+
+    jangar = _dimension(frontier, "jangar_settlement")
+
+    assert jangar["state"] == "blocked"
+    assert jangar["reason_codes"] == ["jangar_controller_unavailable"]
+    assert jangar["details"]["informational_reason_codes"] == [
+        "torghut_dependency_quorum_not_required"
+    ]
+    assert frontier["frontier_state"] == "held"
+
+
 def test_closed_frontier_still_does_not_widen_capital_limits() -> None:
     frontier = _frontier(
         proof_floor_receipt={


### PR DESCRIPTION
## Summary

- Stops treating the informational `torghut_dependency_quorum_not_required` Jangar reason as a blocking profit-frontier repair.
- Preserves true Jangar settlement blockers, including controller/runtime failures, as `jangar_settlement` holds.
- Adds regression coverage so Torghut moves from fake Jangar-reliability repair lots to the next real routeability/profit blockers.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_profit_freshness_frontier.py -q`
- `uv run --frozen pytest tests/test_profit_freshness_frontier.py tests/test_repair_receipt_frontier.py -q`
- `uv run --frozen ruff format --check app/trading/profit_freshness_frontier.py tests/test_profit_freshness_frontier.py`
- `uv run --frozen ruff check app/trading/profit_freshness_frontier.py tests/test_profit_freshness_frontier.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`
- `uv run --frozen pytest tests/test_profit_freshness_frontier.py tests/test_repair_receipt_frontier.py --cov=app --cov-report=xml -q` produced `coverage.xml`; expected local total-coverage failure because only the focused subset ran.
- `uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90 --base-ref origin/main` passed with 3/3 changed executable lines covered.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
