### PR TITLE
fix(torghut): ignore optional quant health blockers

### DIFF
--- a/services/torghut/app/trading/profit_freshness_frontier.py
+++ b/services/torghut/app/trading/profit_freshness_frontier.py
@@ -96,6 +96,9 @@ _ROUTEABILITY_ONLY_TCA_REASON_PREFIXES = ("capital_state_", "proof_floor_")
 _NONBLOCKING_JANGAR_RELIABILITY_REASONS = {
     "torghut_dependency_quorum_not_required",
 }
+_NONBLOCKING_QUANT_HEALTH_REASONS = {
+    "quant_health_not_configured",
+}
 
 
 def _mapping(value: object) -> Mapping[str, Any]:
@@ -404,9 +407,13 @@ def _signal_dimension(
     hypothesis_payload: Mapping[str, Any],
     generated_at: datetime,
 ) -> dict[str, object]:
+    informational_reasons = [
+        reason
+        for reason in _strings(quant_evidence.get("informational_reasons"))
+        if reason in _NONBLOCKING_QUANT_HEALTH_REASONS
+    ]
     reasons = [
         *_strings(quant_evidence.get("blocking_reasons")),
-        *_strings(quant_evidence.get("informational_reasons")),
         *_strings(quant_evidence.get("non_promoting_receipts")),
     ]
     latest_count = _int(
@@ -427,9 +434,17 @@ def _signal_dimension(
         ),
     )
     status = _text(quant_evidence.get("status") or quant_evidence.get("state")).lower()
-    if latest_count <= 0:
+    quant_required = quant_evidence.get("required") is True
+    quant_is_not_required = quant_evidence.get("required") is False and (
+        status == "not_required"
+        or not _text(
+            quant_evidence.get("source_url") or quant_evidence.get("sourceUrl")
+        )
+    )
+    quant_counts_are_authoritative = quant_required or not quant_is_not_required
+    if quant_counts_are_authoritative and latest_count <= 0:
         reasons.append("signal_latest_metrics_missing")
-    if stage_count <= 0:
+    if quant_counts_are_authoritative and stage_count <= 0:
         reasons.append("signal_pipeline_stages_missing")
     if quant_evidence.get("ok") is False:
         reasons.append(_text(quant_evidence.get("reason"), "quant_health_degraded"))
@@ -454,6 +469,11 @@ def _signal_dimension(
         details={
             "latest_metrics_count": latest_count if latest_count >= 0 else None,
             "stage_count": stage_count,
+            **(
+                {"informational_reason_codes": informational_reasons}
+                if informational_reasons
+                else {}
+            ),
         },
     )
 

--- a/services/torghut/app/trading/profit_repair_settlement.py
+++ b/services/torghut/app/trading/profit_repair_settlement.py
@@ -34,6 +34,9 @@ _SCHEMA_REJECTION_FRAGMENTS = (
     "strategy_promotion_decisions",
     "vnext_promotion_decisions",
 )
+_NONBLOCKING_QUANT_HEALTH_REASONS = {
+    "quant_health_not_configured",
+}
 
 
 def _mapping(value: object) -> Mapping[str, Any]:
@@ -158,10 +161,20 @@ def _execution_trust_blockers(ref: Mapping[str, Any]) -> list[str]:
 def _quant_blockers(quant: Mapping[str, Any]) -> list[str]:
     blockers = [
         *_strings(quant.get("blocking_reasons")),
-        *_strings(quant.get("informational_reasons")),
         *_strings(quant.get("non_promoting_receipts")),
     ]
-    if _int(quant.get("stage_count"), default=-1) == 0:
+    status = _text(quant.get("status") or quant.get("state")).lower()
+    source_url = _text(quant.get("source_url") or quant.get("sourceUrl"))
+    quant_counts_are_authoritative = (
+        quant.get("required") is True
+        or bool(source_url)
+        or bool(blockers)
+        or (bool(status) and status != "not_required")
+    )
+    if (
+        quant_counts_are_authoritative
+        and _int(quant.get("stage_count"), default=-1) == 0
+    ):
         blockers.append("quant_pipeline_stages_missing")
     degraded_count = _int(
         quant.get("degraded_latest_metrics_count")
@@ -170,9 +183,15 @@ def _quant_blockers(quant: Mapping[str, Any]) -> list[str]:
     )
     if degraded_count > 0:
         blockers.append("quant_latest_metrics_degraded")
-    if quant.get("ok") is False and not blockers:
+    if quant_counts_are_authoritative and quant.get("ok") is False and not blockers:
         blockers.append(_text(quant.get("reason"), "quant_health_degraded"))
-    return _unique(blockers)
+    return _unique(
+        [
+            blocker
+            for blocker in blockers
+            if blocker not in _NONBLOCKING_QUANT_HEALTH_REASONS
+        ]
+    )
 
 
 def _state(blockers: Sequence[str], *, paper_candidate: bool = False) -> str:

--- a/services/torghut/app/trading/profit_signal_quorum.py
+++ b/services/torghut/app/trading/profit_signal_quorum.py
@@ -19,6 +19,9 @@ _ALLOW_DECISIONS = {"allow", "allowed", "approved", "current", "ok", "pass"}
 _REPAIR_DECISIONS = {*_ALLOW_DECISIONS, "dispatch_repair", "repair", "repair_only"}
 _ROUTE_REPAIR_STATES = {"blocked", "missing", "probing"}
 _REJECTION_DRAG_FRAGMENTS = ("rejection_drag", "schema_lineage")
+_NONBLOCKING_QUANT_HEALTH_REASONS = {
+    "quant_health_not_configured",
+}
 
 
 def _mapping(value: object) -> Mapping[str, Any]:
@@ -109,7 +112,6 @@ def _signal(
 def _quant_reason_codes(quant: Mapping[str, Any]) -> list[str]:
     reasons = [
         *_strings(quant.get("blocking_reasons")),
-        *_strings(quant.get("informational_reasons")),
         *_strings(quant.get("non_promoting_receipts")),
     ]
     status = _first(quant, "status", "state", default="unknown").lower()
@@ -135,7 +137,13 @@ def _quant_reason_codes(quant: Mapping[str, Any]) -> list[str]:
     )
     if degraded_count > 0:
         reasons.append("quant_latest_metrics_degraded")
-    return _unique(reasons)
+    return _unique(
+        [
+            reason
+            for reason in reasons
+            if reason not in _NONBLOCKING_QUANT_HEALTH_REASONS
+        ]
+    )
 
 
 def _quant_signal(quant: Mapping[str, Any]) -> dict[str, object]:

--- a/services/torghut/app/trading/routeability_repair_acceptance.py
+++ b/services/torghut/app/trading/routeability_repair_acceptance.py
@@ -16,6 +16,9 @@ ROUTEABILITY_REPAIR_ACCEPTANCE_LEDGER_SCHEMA_VERSION = (
 
 _FRESHNESS_SECONDS = 60
 _ACCEPTED_STATES = {"allow", "approved", "current", "healthy", "ok", "pass", "ready"}
+_NONBLOCKING_QUANT_HEALTH_REASONS = {
+    "quant_health_not_configured",
+}
 _FORECAST_READY = {
     "disabled",
     "healthy",
@@ -167,12 +170,11 @@ def _profit_lease_blockers(live_submission_gate: Mapping[str, Any]) -> list[str]
 
 
 def _quant_blockers(quant_evidence: Mapping[str, Any]) -> list[str]:
+    status = _text(quant_evidence.get("status") or quant_evidence.get("state")).lower()
     blockers = [
         *_strings(quant_evidence.get("blocking_reasons")),
-        *_strings(quant_evidence.get("informational_reasons")),
         *_strings(quant_evidence.get("non_promoting_receipts")),
     ]
-    status = _text(quant_evidence.get("status") or quant_evidence.get("state")).lower()
     reason = _text(quant_evidence.get("reason"))
     latest_count = _int(
         _first_present(
@@ -189,19 +191,46 @@ def _quant_blockers(quant_evidence: Mapping[str, Any]) -> list[str]:
         ),
         default=-1,
     )
+    source_url = _text(
+        quant_evidence.get("source_url") or quant_evidence.get("sourceUrl")
+    )
+    quant_counts_are_authoritative = (
+        quant_evidence.get("required") is True
+        or bool(source_url)
+        or bool(blockers)
+        or (bool(status) and status != "not_required")
+    )
 
-    if latest_count == 0:
+    if quant_counts_are_authoritative and latest_count == 0:
         blockers.append("quant_latest_metrics_empty")
-    if stage_count == 0 or _bool(
-        quant_evidence.get("missingPipelineHealthStages")
-        or quant_evidence.get("missing_pipeline_health_stages")
+    if quant_counts_are_authoritative and (
+        stage_count == 0
+        or _bool(
+            quant_evidence.get("missingPipelineHealthStages")
+            or quant_evidence.get("missing_pipeline_health_stages")
+        )
     ):
         blockers.append("quant_pipeline_stages_missing")
-    if status and status not in _ACCEPTED_STATES and status != "not_required":
+    if (
+        quant_counts_are_authoritative
+        and status
+        and status not in _ACCEPTED_STATES
+        and status != "not_required"
+    ):
         blockers.append(reason or f"quant_health_{status}")
-    if quant_evidence.get("ok") is False and not blockers:
+    if (
+        quant_counts_are_authoritative
+        and quant_evidence.get("ok") is False
+        and not blockers
+    ):
         blockers.append(reason or "quant_health_degraded")
-    return _unique(blockers)
+    return _unique(
+        [
+            blocker
+            for blocker in blockers
+            if blocker not in _NONBLOCKING_QUANT_HEALTH_REASONS
+        ]
+    )
 
 
 def _market_domain_states(

--- a/services/torghut/tests/test_profit_freshness_frontier.py
+++ b/services/torghut/tests/test_profit_freshness_frontier.py
@@ -351,6 +351,99 @@ def test_jangar_allow_with_real_blocking_reason_still_holds_frontier() -> None:
     assert frontier["frontier_state"] == "held"
 
 
+def test_optional_unconfigured_quant_health_does_not_select_signal_repair() -> None:
+    frontier = _frontier(
+        quant_evidence={
+            "required": False,
+            "ok": True,
+            "status": "not_required",
+            "reason": "quant_health_not_configured",
+            "blocking_reasons": [],
+            "informational_reasons": ["quant_health_not_configured"],
+            "source_url": None,
+        },
+        market_context_status={"status": "healthy", "last_domain_states": {}},
+        empirical_jobs_status={
+            "ready": True,
+            "status": "healthy",
+            "eligible_jobs": [
+                "benchmark_parity",
+                "foundation_router_parity",
+                "janus_event_car",
+                "janus_hgrm_reward",
+            ],
+            "candidate_ids": ["candidate-nvda"],
+            "dataset_snapshot_refs": ["dataset-nvda"],
+        },
+        jangar_reliability_settlement_ref={
+            "settlement_ref": (
+                "jangar-reliability-settlement:"
+                "dependency-quorum:allow:torghut_dependency_quorum_not_required"
+            ),
+            "decision": "allow",
+            "state": "current",
+            "reason_codes": ["torghut_dependency_quorum_not_required"],
+            "source": "dependency_quorum_proxy",
+        },
+    )
+
+    signal = _dimension(frontier, "signal_ingestion")
+
+    assert signal["state"] == "current"
+    assert signal["reason_codes"] == []
+    assert signal["details"]["informational_reason_codes"] == [
+        "quant_health_not_configured"
+    ]
+    assert all(
+        repair["blocked_dimension"] != "signal_ingestion"
+        for repair in cast(
+            list[Mapping[str, Any]], frontier["selected_zero_notional_repairs"]
+        )
+    )
+
+
+def test_required_unconfigured_quant_health_still_selects_signal_repair() -> None:
+    frontier = _frontier(
+        quant_evidence={
+            "required": True,
+            "ok": False,
+            "status": "unknown",
+            "reason": "quant_health_not_configured",
+            "blocking_reasons": ["quant_health_not_configured"],
+            "informational_reasons": [],
+            "source_url": None,
+        },
+        market_context_status={"status": "healthy", "last_domain_states": {}},
+        empirical_jobs_status={
+            "ready": True,
+            "status": "healthy",
+            "eligible_jobs": [
+                "benchmark_parity",
+                "foundation_router_parity",
+                "janus_event_car",
+                "janus_hgrm_reward",
+            ],
+            "candidate_ids": ["candidate-nvda"],
+            "dataset_snapshot_refs": ["dataset-nvda"],
+        },
+        jangar_reliability_settlement_ref={
+            "settlement_ref": "jangar-reliability-settlement:ready",
+            "decision": "allow",
+            "state": "current",
+            "reason_codes": [],
+        },
+    )
+
+    signal = _dimension(frontier, "signal_ingestion")
+
+    assert signal["state"] == "missing"
+    assert "quant_health_not_configured" in signal["reason_codes"]
+    assert any(
+        lot["blocked_dimension"] == "signal_ingestion"
+        for lot in cast(list[Mapping[str, Any]], frontier["repair_lots"])
+    )
+
+
 def test_closed_frontier_still_does_not_widen_capital_limits() -> None:
     frontier = _frontier(
         proof_floor_receipt={

--- a/services/torghut/tests/test_profit_repair_settlement.py
+++ b/services/torghut/tests/test_profit_repair_settlement.py
@@ -147,3 +147,22 @@ def test_profit_repair_settlement_groups_execution_trust_lots_at_zero_notional()
     schema = _lot(ledger, "schema_lineage")
     assert "schema_lineage_missing" in schema["blocking_reason_codes"]
     assert "rejection_drag_unmeasured" in schema["blocking_reason_codes"]
+
+
+def test_optional_unconfigured_quant_health_does_not_create_quant_repair() -> None:
+    ledger = _ledger(
+        quant_evidence={
+            "required": False,
+            "ok": True,
+            "status": "not_required",
+            "reason": "quant_health_not_configured",
+            "blocking_reasons": [],
+            "informational_reasons": ["quant_health_not_configured"],
+            "source_url": None,
+        }
+    )
+
+    quant = _lot(ledger, "quant_freshness")
+
+    assert quant["current_state"] == "observe"
+    assert quant["blocking_reason_codes"] == []

--- a/services/torghut/tests/test_profit_signal_quorum.py
+++ b/services/torghut/tests/test_profit_signal_quorum.py
@@ -85,6 +85,27 @@ def test_global_quant_green_but_scoped_pipeline_degraded_stays_zero_notional():
     assert quorum["required_repair_action"] == "refresh_scoped_quant_pipeline_stages"
 
 
+def test_optional_unconfigured_quant_health_does_not_degrade_quorum():
+    quorum = _only_quorum(
+        _build(
+            quant=dict(
+                required=False,
+                ok=True,
+                status="not_required",
+                reason="quant_health_not_configured",
+                blocking_reasons=[],
+                informational_reasons=["quant_health_not_configured"],
+                source_url=None,
+            )
+        )
+    )
+
+    assert quorum["decision"] == "paper_candidate"
+    assert quorum["quant_signal"]["state"] == "fresh"
+    assert quorum["quant_signal"]["reason_codes"] == []
+    assert "quant_health_not_configured" not in quorum["reason_codes"]
+
+
 def test_degraded_inputs_emit_scoped_repair_reasons_without_capital():
     quorum = _only_quorum(
         _build(

--- a/services/torghut/tests/test_routeability_repair_acceptance.py
+++ b/services/torghut/tests/test_routeability_repair_acceptance.py
@@ -184,6 +184,28 @@ def test_quant_latest_metrics_do_not_accept_routeability_without_scoped_stages()
     assert ledger["accepted_routeable_candidate_count"] == 0
 
 
+def test_optional_unconfigured_quant_health_does_not_create_routeability_lot() -> None:
+    ledger = _ledger(
+        quant_evidence={
+            "required": False,
+            "ok": True,
+            "status": "not_required",
+            "reason": "quant_health_not_configured",
+            "blocking_reasons": [],
+            "informational_reasons": ["quant_health_not_configured"],
+            "source_url": None,
+        }
+    )
+
+    quant_lot = _lot(ledger, "quant_scoped_stage_repair")
+
+    assert quant_lot["current_state"] == "accepted"
+    assert quant_lot["blocking_reason_codes"] == []
+    assert (
+        "quant_health_not_configured" not in ledger["aggregate_blocking_reason_codes"]
+    )
+
+
 def test_stale_market_context_domains_keep_acceptance_unsettled() -> None:
     ledger = _ledger()
     market_lot = _lot(ledger, "market_context_domain_repair")


### PR DESCRIPTION
## Summary

- Stops optional, unconfigured Jangar quant-health from being treated as actionable Torghut signal-ingestion repair debt.
- Keeps required quant-health and real non-promoting quant receipts blocking across profit freshness, routeability acceptance, profit-signal quorum, and profit-repair settlement.
- Adds regressions for the live production payload shape where `required=false`, `status=not_required`, and `quant_health_not_configured` is informational only.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_profit_freshness_frontier.py tests/test_routeability_repair_acceptance.py tests/test_profit_signal_quorum.py tests/test_profit_repair_settlement.py -q`
- `uv run --frozen ruff format --check app/trading/profit_freshness_frontier.py app/trading/routeability_repair_acceptance.py app/trading/profit_signal_quorum.py app/trading/profit_repair_settlement.py tests/test_profit_freshness_frontier.py tests/test_routeability_repair_acceptance.py tests/test_profit_signal_quorum.py tests/test_profit_repair_settlement.py`
- `uv run --frozen ruff check app/trading/profit_freshness_frontier.py app/trading/routeability_repair_acceptance.py app/trading/profit_signal_quorum.py app/trading/profit_repair_settlement.py tests/test_profit_freshness_frontier.py tests/test_routeability_repair_acceptance.py tests/test_profit_signal_quorum.py tests/test_profit_repair_settlement.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen pytest tests/test_profit_freshness_frontier.py tests/test_routeability_repair_acceptance.py tests/test_profit_signal_quorum.py tests/test_profit_repair_settlement.py --cov=app --cov-report=xml -q` (tests passed and wrote coverage XML; expected total coverage fail for focused subset)
- `uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90 --base-ref origin/main`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
