### PR TITLE
feat(torghut): broaden portfolio autoresearch sleeves

### DIFF
--- a/services/torghut/app/trading/discovery/candidate_specs.py
+++ b/services/torghut/app/trading/discovery/candidate_specs.py
@@ -67,6 +67,19 @@ _FAMILY_TIEBREAK = {
     )
 }
 _MAX_FAMILIES_PER_HYPOTHESIS = 3
+_PORTFOLIO_TARGET_NET_PNL_PER_DAY = Decimal("500")
+_PORTFOLIO_SLEEVE_FAMILY_TARGET = len(_FAMILY_RUNTIME)
+_PORTFOLIO_SLEEVE_FAMILY_ORDER = (
+    "microstructure_continuation_matched_filter_v1",
+    "microbar_cross_sectional_pairs_v1",
+    "intraday_tsmom_v2",
+    "momentum_pullback_v1",
+    "late_day_continuation_v1",
+    "end_of_day_reversal_v1",
+    "breakout_reclaim_v2",
+    "washout_rebound_v2",
+    "mean_reversion_rebound_v1",
+)
 _DEFAULT_PROFILE_COUNT = 3
 
 _RESEARCHED_SEMICONDUCTOR_TECH_UNIVERSE = RESEARCHED_SEMICONDUCTOR_TECH_UNIVERSE
@@ -1150,9 +1163,33 @@ def _family_scores_for_hypothesis(
 
 
 def _families_for_hypothesis(
-    card: HypothesisCard,
+    card: HypothesisCard, *, target_net_pnl_per_day: Decimal = Decimal("300")
 ) -> tuple[tuple[str, int, tuple[str, ...]], ...]:
-    return tuple(_family_scores_for_hypothesis(card)[:_MAX_FAMILIES_PER_HYPOTHESIS])
+    scored = _family_scores_for_hypothesis(card)
+    family_limit = (
+        _PORTFOLIO_SLEEVE_FAMILY_TARGET
+        if target_net_pnl_per_day >= _PORTFOLIO_TARGET_NET_PNL_PER_DAY
+        else _MAX_FAMILIES_PER_HYPOTHESIS
+    )
+    selected = list(scored[:family_limit])
+    if family_limit <= _MAX_FAMILIES_PER_HYPOTHESIS:
+        return tuple(selected)
+
+    selected_family_ids = {family_template_id for family_template_id, _, _ in selected}
+    for family_template_id in _PORTFOLIO_SLEEVE_FAMILY_ORDER:
+        if len(selected) >= family_limit:
+            break
+        if family_template_id in selected_family_ids:
+            continue
+        selected.append(
+            (
+                family_template_id,
+                0,
+                ("portfolio_sleeve_diversification",),
+            )
+        )
+        selected_family_ids.add(family_template_id)
+    return tuple(selected)
 
 
 def _execution_profile_index(
@@ -1300,7 +1337,12 @@ def compile_candidate_specs(
             family_template_id,
             family_score,
             family_reasons,
-        ) in enumerate(_families_for_hypothesis(card), start=1):
+        ) in enumerate(
+            _families_for_hypothesis(
+                card, target_net_pnl_per_day=target_net_pnl_per_day
+            ),
+            start=1,
+        ):
             runtime_family, runtime_strategy_name = _FAMILY_RUNTIME[family_template_id]
             for execution_profile_index in _execution_profile_indexes(
                 card=card,

--- a/services/torghut/tests/test_candidate_specs.py
+++ b/services/torghut/tests/test_candidate_specs.py
@@ -132,6 +132,49 @@ class TestCandidateSpecs(TestCase):
             len(specs),
         )
 
+    def test_portfolio_profit_target_adds_diversified_sleeve_families(self) -> None:
+        cards = build_hypothesis_cards(
+            source_run_id="paper-portfolio-sleeves",
+            claims=[
+                {
+                    "claim_id": "claim-flow-sleeves",
+                    "claim_type": "signal_mechanism",
+                    "claim_text": "Clustered order flow imbalance improves intraday LOB continuation signals.",
+                    "confidence": "0.82",
+                }
+            ],
+        )
+
+        baseline_specs = compile_candidate_specs(
+            hypothesis_cards=cards, target_net_pnl_per_day=Decimal("300")
+        )
+        portfolio_specs = compile_candidate_specs(
+            hypothesis_cards=cards, target_net_pnl_per_day=Decimal("500")
+        )
+
+        self.assertEqual(
+            {spec.family_template_id for spec in baseline_specs},
+            {
+                "intraday_tsmom_v2",
+                "microbar_cross_sectional_pairs_v1",
+                "microstructure_continuation_matched_filter_v1",
+            },
+        )
+        self.assertEqual(
+            {spec.family_template_id for spec in portfolio_specs},
+            set(candidate_specs_module._FAMILY_EXECUTION_PROFILES),
+        )
+        self.assertGreater(len(portfolio_specs), len(baseline_specs))
+        complementary_spec = next(
+            spec
+            for spec in portfolio_specs
+            if spec.family_template_id == "end_of_day_reversal_v1"
+        )
+        self.assertEqual(
+            complementary_spec.feature_contract["family_selection"]["reasons"],
+            ["portfolio_sleeve_diversification"],
+        )
+
     def test_same_family_whitepaper_hypotheses_get_distinct_execution_profiles(
         self,
     ) -> None:

--- a/services/torghut/tests/test_whitepaper_autoresearch_artifacts.py
+++ b/services/torghut/tests/test_whitepaper_autoresearch_artifacts.py
@@ -64,13 +64,8 @@ class TestWhitepaperAutoresearchArtifacts(TestCase):
             hypothesis_cards=cards, target_net_pnl_per_day=Decimal("500")
         )
         expected_family_profiles = {
-            "microstructure_continuation_matched_filter_v1": _profile_ids_for_family(
-                "microstructure_continuation_matched_filter_v1"
-            ),
-            "microbar_cross_sectional_pairs_v1": _profile_ids_for_family(
-                "microbar_cross_sectional_pairs_v1"
-            ),
-            "intraday_tsmom_v2": _profile_ids_for_family("intraday_tsmom_v2"),
+            family_template_id: _profile_ids_for_family(family_template_id)
+            for family_template_id in candidate_specs_module._FAMILY_EXECUTION_PROFILES
         }
         self.assertEqual(
             len(specs),

--- a/services/torghut/tests/test_whitepaper_candidate_compiler.py
+++ b/services/torghut/tests/test_whitepaper_candidate_compiler.py
@@ -13,21 +13,19 @@ from app.trading.discovery.whitepaper_candidate_compiler import (
 )
 
 
-_FLOW_CLAIM_FAMILIES = {
-    "intraday_tsmom_v2",
-    "microbar_cross_sectional_pairs_v1",
-    "microstructure_continuation_matched_filter_v1",
-}
+_PORTFOLIO_TARGET_FAMILIES = set(candidate_specs_module._FAMILY_EXECUTION_PROFILES)
 
 
 def _profile_count_for_family(family_template_id: str) -> int:
     return len(candidate_specs_module._FAMILY_EXECUTION_PROFILES[family_template_id])
 
 
-def _expected_flow_candidate_count() -> int:
-    return sum(
-        _profile_count_for_family(family_id) for family_id in _FLOW_CLAIM_FAMILIES
-    )
+def _expected_candidate_count(family_ids: set[str]) -> int:
+    return sum(_profile_count_for_family(family_id) for family_id in family_ids)
+
+
+def _expected_portfolio_target_candidate_count() -> int:
+    return _expected_candidate_count(_PORTFOLIO_TARGET_FAMILIES)
 
 
 class TestWhitepaperCandidateCompiler(TestCase):
@@ -47,7 +45,7 @@ class TestWhitepaperCandidateCompiler(TestCase):
             seed_sweep_dir=Path("config/trading"),
         )
 
-        expected_spec_count = _expected_flow_candidate_count()
+        expected_spec_count = _expected_portfolio_target_candidate_count()
         self.assertEqual(len(compilation.candidate_specs), expected_spec_count)
         self.assertEqual(len(compilation.executable_specs), expected_spec_count)
         self.assertEqual(
@@ -57,7 +55,7 @@ class TestWhitepaperCandidateCompiler(TestCase):
             len(compilation.vnext_experiment_payloads), expected_spec_count
         )
         family_ids = {spec.family_template_id for spec in compilation.executable_specs}
-        self.assertEqual(family_ids, _FLOW_CLAIM_FAMILIES)
+        self.assertEqual(family_ids, _PORTFOLIO_TARGET_FAMILIES)
         self.assertEqual(
             {
                 family_id: sum(
@@ -69,7 +67,7 @@ class TestWhitepaperCandidateCompiler(TestCase):
             },
             {
                 family_id: _profile_count_for_family(family_id)
-                for family_id in _FLOW_CLAIM_FAMILIES
+                for family_id in _PORTFOLIO_TARGET_FAMILIES
             },
         )
         self.assertTrue(
@@ -110,7 +108,7 @@ class TestWhitepaperCandidateCompiler(TestCase):
 
         self.assertEqual(len(compilation.executable_specs), 0)
         self.assertEqual(
-            len(compilation.blocked_specs), _expected_flow_candidate_count()
+            len(compilation.blocked_specs), _expected_portfolio_target_candidate_count()
         )
         self.assertEqual(compilation.blockers[0].reason, "family_template_missing")
 
@@ -332,7 +330,7 @@ class TestWhitepaperCandidateCompiler(TestCase):
 
         self.assertEqual(compilation.executable_specs, ())
         self.assertEqual(
-            len(compilation.blocked_specs), _expected_flow_candidate_count()
+            len(compilation.blocked_specs), _expected_portfolio_target_candidate_count()
         )
         self.assertEqual(compilation.blockers[0].reason, "seed_sweep_missing")
 
@@ -370,11 +368,12 @@ class TestWhitepaperCandidateCompiler(TestCase):
         )
 
         self.assertEqual(
-            len(compilation.candidate_specs), _expected_flow_candidate_count()
+            len(compilation.candidate_specs),
+            _expected_portfolio_target_candidate_count(),
         )
         self.assertEqual(compilation.executable_specs, ())
         self.assertEqual(
-            len(compilation.blocked_specs), _expected_flow_candidate_count()
+            len(compilation.blocked_specs), _expected_portfolio_target_candidate_count()
         )
         self.assertTrue(
             all(

--- a/services/torghut/tests/test_whitepaper_workflow.py
+++ b/services/torghut/tests/test_whitepaper_workflow.py
@@ -780,13 +780,8 @@ https://example.com/paper.pdf
         )
 
         expected_family_profiles = {
-            "microstructure_continuation_matched_filter_v1": _profile_ids_for_family(
-                "microstructure_continuation_matched_filter_v1"
-            ),
-            "microbar_cross_sectional_pairs_v1": _profile_ids_for_family(
-                "microbar_cross_sectional_pairs_v1"
-            ),
-            "intraday_tsmom_v2": _profile_ids_for_family("intraday_tsmom_v2"),
+            family_template_id: _profile_ids_for_family(family_template_id)
+            for family_template_id in candidate_specs_module._FAMILY_EXECUTION_PROFILES
         }
         self.assertEqual(
             len(compiled),


### PR DESCRIPTION
## Summary

- Broadens Torghut `$500/day` autoresearch candidate compilation into a portfolio-sleeve surface instead of replaying only the top single-family matches.
- Keeps smaller `$300/day` compilation behavior narrow, while `$500/day` runs now include all executable sleeve families with their existing execution profiles.
- Marks complementary sleeves with `portfolio_sleeve_diversification` so run artifacts distinguish source-ranked families from portfolio diversification coverage.
- Updates candidate/compiler/workflow tests to assert the expanded `$500/day` surface and unchanged baseline behavior.

## Related Issues

None

## Testing

- Smoke count with `compile_candidate_specs` and `_candidate_spec_execution_signature`: `$300` compiled 15 specs / 15 unique signatures across 3 families; `$500` compiled 36 specs / 36 unique signatures across 9 families.
- `cd services/torghut && uv run --frozen pytest tests/test_candidate_specs.py tests/test_whitepaper_autoresearch_artifacts.py tests/test_whitepaper_candidate_compiler.py tests/test_whitepaper_workflow.py tests/test_run_whitepaper_autoresearch_profit_target.py -q`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/discovery/candidate_specs.py tests/test_candidate_specs.py tests/test_whitepaper_autoresearch_artifacts.py tests/test_whitepaper_candidate_compiler.py tests/test_whitepaper_workflow.py`
- `cd services/torghut && uv run --frozen ruff check app/trading/discovery/candidate_specs.py tests/test_candidate_specs.py tests/test_whitepaper_autoresearch_artifacts.py tests/test_whitepaper_candidate_compiler.py tests/test_whitepaper_workflow.py`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
