### PR TITLE
fix(torghut): select executable routeability repairs

### DIFF
--- a/services/torghut/app/trading/profit_freshness_frontier.py
+++ b/services/torghut/app/trading/profit_freshness_frontier.py
@@ -99,6 +99,10 @@ _NONBLOCKING_JANGAR_RELIABILITY_REASONS = {
 _NONBLOCKING_QUANT_HEALTH_REASONS = {
     "quant_health_not_configured",
 }
+_ROUTEABILITY_TCA_REPAIR_LOT_TYPES = {"route_universe_tca_repair"}
+_ROUTEABILITY_TCA_REPAIR_ACTION = "recompute_route_tca_and_fill_quality"
+_ROUTEABILITY_TCA_REPAIR_REASON_PREFIXES = ("execution_tca_", "route_tca_")
+_ROUTEABILITY_TCA_REPAIR_REASON_FRAGMENTS = ("slippage", "route_universe")
 
 
 def _mapping(value: object) -> Mapping[str, Any]:
@@ -701,6 +705,38 @@ def _route_readiness_dimension(
     )
 
 
+def _is_routeability_tca_repair_reason(reason: str) -> bool:
+    normalized = reason.strip().lower()
+    return normalized.startswith(_ROUTEABILITY_TCA_REPAIR_REASON_PREFIXES) or any(
+        fragment in normalized for fragment in _ROUTEABILITY_TCA_REPAIR_REASON_FRAGMENTS
+    )
+
+
+def _route_readiness_action(routeability_ledger: Mapping[str, Any]) -> str:
+    for raw_lot in _sequence(routeability_ledger.get("lots")):
+        lot = _mapping(raw_lot)
+        if _text(lot.get("lot_type")) not in _ROUTEABILITY_TCA_REPAIR_LOT_TYPES:
+            continue
+        if _text(lot.get("current_state")).lower() in _CURRENT_STATES:
+            continue
+        if any(
+            _is_routeability_tca_repair_reason(reason)
+            for reason in _strings(lot.get("blocking_reason_codes"))
+        ):
+            return _ROUTEABILITY_TCA_REPAIR_ACTION
+    return _DIMENSION_ACTION["route_readiness"]
+
+
+def _zero_notional_action(
+    dimension_name: str,
+    *,
+    routeability_ledger: Mapping[str, Any],
+) -> str:
+    if dimension_name == "route_readiness":
+        return _route_readiness_action(routeability_ledger)
+    return _DIMENSION_ACTION.get(dimension_name, "observe_profit_freshness_frontier")
+
+
 def _schema_dimension(
     *,
     proof_floor_receipt: Mapping[str, Any],
@@ -969,8 +1005,9 @@ def _repair_lot(
         "symbol_set": symbol_set,
         "blocked_dimension": dimension_name,
         "before_refs": _strings(dimension.get("evidence_refs")),
-        "zero_notional_action": _DIMENSION_ACTION.get(
-            dimension_name, "observe_profit_freshness_frontier"
+        "zero_notional_action": _zero_notional_action(
+            dimension_name,
+            routeability_ledger=routeability_ledger,
         ),
         "expected_profit_unlock_bps": float(expected_bps),
         "expected_daily_net_pnl_unlock": _decimal_text(expected_daily_net_pnl_unlock),

--- a/services/torghut/tests/test_profit_freshness_frontier.py
+++ b/services/torghut/tests/test_profit_freshness_frontier.py
@@ -656,6 +656,13 @@ def test_fresh_execution_tca_does_not_inherit_routeability_blockers() -> None:
             ],
             "lots": [
                 {
+                    "lot_id": "routeability-repair-lot:alpha",
+                    "lot_type": "alpha_readiness_repair",
+                    "current_state": "blocked",
+                    "blocking_reason_codes": ["alpha_readiness_fail"],
+                    "hypothesis_ids": ["H-AAPL"],
+                },
+                {
                     "lot_id": "routeability-repair-lot:tca",
                     "lot_type": "route_universe_tca_repair",
                     "current_state": "blocked",
@@ -664,7 +671,7 @@ def test_fresh_execution_tca_does_not_inherit_routeability_blockers() -> None:
                         "execution_tca_symbol_missing",
                     ],
                     "hypothesis_ids": ["H-AAPL", "H-AMD", "H-AMZN"],
-                }
+                },
             ],
         },
         route_reacquisition_board={
@@ -741,6 +748,104 @@ def test_fresh_execution_tca_does_not_inherit_routeability_blockers() -> None:
         in route_dimension["reason_codes"]
     )
     assert (
-        frontier["next_zero_notional_action"] == "settle_routeability_acceptance_lots"
+        frontier["next_zero_notional_action"] == "recompute_route_tca_and_fill_quality"
+    )
+    assert (
+        frontier["selected_zero_notional_repairs"][0]["zero_notional_action"]
+        == "recompute_route_tca_and_fill_quality"
     )
     assert frontier["capital_posture"]["paper_replay_candidate_count"] == 0
+
+
+def test_route_readiness_uses_settlement_action_without_unsettled_tca_lot() -> None:
+    frontier = _frontier(
+        proof_floor_receipt={
+            "schema_version": "torghut.profitability-proof-floor.v1",
+            "account_label": "PA3SX7FYNUTF",
+            "route_state": "repair_only",
+            "capital_state": "zero_notional",
+            "max_notional": "0",
+            "blocking_reasons": [],
+            "proof_dimensions": [
+                {
+                    "dimension": "execution_tca",
+                    "state": "pass",
+                    "reason": "route_tca_passed",
+                    "freshness_seconds": 71,
+                    "source_ref": {
+                        "last_computed_at": "2026-05-12T15:08:49+00:00",
+                    },
+                }
+            ],
+        },
+        routeability_repair_acceptance_ledger={
+            "schema_version": "torghut.routeability-repair-acceptance-ledger.v1",
+            "ledger_id": "routeability-acceptance-ledger:route-alpha-blocked",
+            "aggregate_state": "blocked",
+            "accepted_routeable_candidate_count": 0,
+            "aggregate_blocking_reason_codes": ["alpha_readiness_fail"],
+            "lots": [
+                {
+                    "lot_id": "routeability-repair-lot:tca",
+                    "lot_type": "route_universe_tca_repair",
+                    "current_state": "accepted",
+                    "blocking_reason_codes": [],
+                },
+                {
+                    "lot_id": "routeability-repair-lot:alpha",
+                    "lot_type": "alpha_readiness_repair",
+                    "current_state": "blocked",
+                    "blocking_reason_codes": ["alpha_readiness_fail"],
+                    "hypothesis_ids": ["H-AAPL"],
+                },
+            ],
+        },
+        route_reacquisition_board={
+            "summary": {"capital_eligible_symbol_count": 0},
+            "rows": [
+                {
+                    "symbol": "AAPL",
+                    "state": "routeable",
+                    "current_blocker": "",
+                    "hypothesis_ids": ["H-AAPL"],
+                }
+            ],
+        },
+        quant_evidence={
+            "ok": True,
+            "status": "healthy",
+            "latest_metrics_count": 144,
+            "stage_count": 4,
+        },
+        market_context_status={"status": "healthy", "last_domain_states": {}},
+        empirical_jobs_status={
+            "ready": True,
+            "status": "healthy",
+            "eligible_jobs": [
+                "benchmark_parity",
+                "foundation_router_parity",
+                "janus_event_car",
+                "janus_hgrm_reward",
+            ],
+            "candidate_ids": ["candidate-aapl"],
+            "dataset_snapshot_refs": ["dataset-aapl"],
+        },
+        hypothesis_payload={
+            "summary": {"promotion_eligible_total": 0, "reason_totals": {}},
+            "items": [{"hypothesis_id": "H-AAPL", "reasons": []}],
+        },
+        jangar_reliability_settlement_ref={
+            "settlement_ref": "jangar-reliability-settlement:ready",
+            "decision": "allow",
+            "state": "current",
+            "reason_codes": [],
+        },
+    )
+
+    route_dimension = _dimension(frontier, "route_readiness")
+
+    assert route_dimension["state"] == "blocked"
+    assert "alpha_readiness_fail" in route_dimension["reason_codes"]
+    assert (
+        frontier["next_zero_notional_action"] == "settle_routeability_acceptance_lots"
+    )


### PR DESCRIPTION
## Summary

- Routes unsettled routeability TCA lots to the existing executable `recompute_route_tca_and_fill_quality` zero-notional repair action instead of the non-allowlisted generic settlement action.
- Keeps the generic `settle_routeability_acceptance_lots` action only when route/TCA evidence is already accepted and the remaining routeability blocker is not executable by the TCA repair runner.
- Adds regression coverage for the live failure shape where route-readiness selected an unsupported repair despite an unsettled `route_universe_tca_repair` lot.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_profit_freshness_frontier.py -q`
- `uv run --frozen pytest tests/test_profit_freshness_frontier.py tests/test_zero_notional_repair_executor.py tests/test_trading_api.py -k 'profit_freshness or zero_notional_repair' -q`
- `uv run --frozen pytest tests/test_profit_freshness_frontier.py --cov=app --cov-report=xml --cov-fail-under=0 -q`
- `uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90 --base-ref origin/main`
- `uv run --frozen ruff format --check app/trading/profit_freshness_frontier.py tests/test_profit_freshness_frontier.py`
- `uv run --frozen ruff check app/trading/profit_freshness_frontier.py tests/test_profit_freshness_frontier.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`
- Live pre-fix verification: `POST /trading/profit-freshness/zero-notional-repair` returned `unsupported_action` for `settle_routeability_acceptance_lots`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
