### PR TITLE
feat(jangar): add account-scoped quant witness

### DIFF
--- a/services/jangar/README.md
+++ b/services/jangar/README.md
@@ -303,6 +303,21 @@ Rollback: set `JANGAR_SWARM_RUNTIME_PROOF_ENFORCEMENT=false` to return launch be
 set `JANGAR_SWARM_RUNTIME_ADMISSION_ENFORCEMENT=false` on the control-plane runtime to return launch behavior to the
 previous advisory-only passport mode while keeping status and `/ready` passport/proof projection visible for forensics.
 
+## Account-scoped quant witness
+
+Jangar exposes `/api/torghut/trading/control-plane/quant/account-witness` from
+`docs/agents/designs/189-jangar-account-scoped-quant-witness-custody-and-route-reentry-2026-05-13.md`. The route
+returns `jangar.quant-account-witness.v1` for a required `account` and `window`, with optional `strategy_id` and
+account aliases. It separates aggregate latest-store health from the account/window latest store, classifies required
+pipeline stages, and emits explicit `current`, `empty`, `stale`, or `timeout` route-warrant usability.
+
+The route uses cached latest-store and pipeline-health rows only; it does not trigger on-demand materialization or start
+the quant runtime. A slow account/window read returns a timeout witness inside the service budget so repair dispatch can
+act on `quant_account_witness_timeout` without mistaking aggregate freshness for routeable account proof. The witness is
+zero-notional evidence only: `capital_safety.max_notional` remains `0`, and Torghut must still clear proof floor, TCA,
+source-serving, routeability, and live submission gates before capital can widen. Rollback is to stop consuming the
+witness route and retain existing `/quant/health` diagnostics.
+
 ## Source rollout truth exchange
 
 Control-plane status includes a `source_rollout_truth_exchange` projection from

--- a/services/jangar/src/routeTree.gen.ts
+++ b/services/jangar/src/routeTree.gen.ts
@@ -175,6 +175,7 @@ import { Route as ApiTorghutTradingControlPlaneQuantSnapshotRouteImport } from '
 import { Route as ApiTorghutTradingControlPlaneQuantSeriesRouteImport } from './routes/api/torghut/trading/control-plane/quant/series'
 import { Route as ApiTorghutTradingControlPlaneQuantHealthRouteImport } from './routes/api/torghut/trading/control-plane/quant/health'
 import { Route as ApiTorghutTradingControlPlaneQuantAlertsRouteImport } from './routes/api/torghut/trading/control-plane/quant/alerts'
+import { Route as ApiTorghutTradingControlPlaneQuantAccountWitnessRouteImport } from './routes/api/torghut/trading/control-plane/quant/account-witness'
 import { Route as ApiTorghutTradingControlPlaneLlmRolloutRouteImport } from './routes/api/torghut/trading/control-plane/llm/rollout'
 import { Route as ApiGithubPullsOwnerRepoNumberRouteImport } from './routes/api/github/pulls/$owner/$repo/$number'
 import { Route as ApiGithubPullsOwnerRepoNumberWriteActionsRouteImport } from './routes/api/github/pulls/$owner/$repo/$number/write-actions'
@@ -1098,6 +1099,12 @@ const ApiTorghutTradingControlPlaneQuantAlertsRoute =
     path: '/api/torghut/trading/control-plane/quant/alerts',
     getParentRoute: () => rootRouteImport,
   } as any)
+const ApiTorghutTradingControlPlaneQuantAccountWitnessRoute =
+  ApiTorghutTradingControlPlaneQuantAccountWitnessRouteImport.update({
+    id: '/api/torghut/trading/control-plane/quant/account-witness',
+    path: '/api/torghut/trading/control-plane/quant/account-witness',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const ApiTorghutTradingControlPlaneLlmRolloutRoute =
   ApiTorghutTradingControlPlaneLlmRolloutRouteImport.update({
     id: '/api/torghut/trading/control-plane/llm/rollout',
@@ -1335,6 +1342,7 @@ export interface FileRoutesByFullPath {
   '/github/pulls/$owner/$repo/$number': typeof GithubPullsOwnerRepoNumberRoute
   '/api/github/pulls/$owner/$repo/$number': typeof ApiGithubPullsOwnerRepoNumberRouteWithChildren
   '/api/torghut/trading/control-plane/llm/rollout': typeof ApiTorghutTradingControlPlaneLlmRolloutRoute
+  '/api/torghut/trading/control-plane/quant/account-witness': typeof ApiTorghutTradingControlPlaneQuantAccountWitnessRoute
   '/api/torghut/trading/control-plane/quant/alerts': typeof ApiTorghutTradingControlPlaneQuantAlertsRoute
   '/api/torghut/trading/control-plane/quant/health': typeof ApiTorghutTradingControlPlaneQuantHealthRoute
   '/api/torghut/trading/control-plane/quant/series': typeof ApiTorghutTradingControlPlaneQuantSeriesRoute
@@ -1513,6 +1521,7 @@ export interface FileRoutesByTo {
   '/github/pulls/$owner/$repo/$number': typeof GithubPullsOwnerRepoNumberRoute
   '/api/github/pulls/$owner/$repo/$number': typeof ApiGithubPullsOwnerRepoNumberRouteWithChildren
   '/api/torghut/trading/control-plane/llm/rollout': typeof ApiTorghutTradingControlPlaneLlmRolloutRoute
+  '/api/torghut/trading/control-plane/quant/account-witness': typeof ApiTorghutTradingControlPlaneQuantAccountWitnessRoute
   '/api/torghut/trading/control-plane/quant/alerts': typeof ApiTorghutTradingControlPlaneQuantAlertsRoute
   '/api/torghut/trading/control-plane/quant/health': typeof ApiTorghutTradingControlPlaneQuantHealthRoute
   '/api/torghut/trading/control-plane/quant/series': typeof ApiTorghutTradingControlPlaneQuantSeriesRoute
@@ -1694,6 +1703,7 @@ export interface FileRoutesById {
   '/github/pulls/$owner/$repo/$number': typeof GithubPullsOwnerRepoNumberRoute
   '/api/github/pulls/$owner/$repo/$number': typeof ApiGithubPullsOwnerRepoNumberRouteWithChildren
   '/api/torghut/trading/control-plane/llm/rollout': typeof ApiTorghutTradingControlPlaneLlmRolloutRoute
+  '/api/torghut/trading/control-plane/quant/account-witness': typeof ApiTorghutTradingControlPlaneQuantAccountWitnessRoute
   '/api/torghut/trading/control-plane/quant/alerts': typeof ApiTorghutTradingControlPlaneQuantAlertsRoute
   '/api/torghut/trading/control-plane/quant/health': typeof ApiTorghutTradingControlPlaneQuantHealthRoute
   '/api/torghut/trading/control-plane/quant/series': typeof ApiTorghutTradingControlPlaneQuantSeriesRoute
@@ -1876,6 +1886,7 @@ export interface FileRouteTypes {
     | '/github/pulls/$owner/$repo/$number'
     | '/api/github/pulls/$owner/$repo/$number'
     | '/api/torghut/trading/control-plane/llm/rollout'
+    | '/api/torghut/trading/control-plane/quant/account-witness'
     | '/api/torghut/trading/control-plane/quant/alerts'
     | '/api/torghut/trading/control-plane/quant/health'
     | '/api/torghut/trading/control-plane/quant/series'
@@ -2054,6 +2065,7 @@ export interface FileRouteTypes {
     | '/github/pulls/$owner/$repo/$number'
     | '/api/github/pulls/$owner/$repo/$number'
     | '/api/torghut/trading/control-plane/llm/rollout'
+    | '/api/torghut/trading/control-plane/quant/account-witness'
     | '/api/torghut/trading/control-plane/quant/alerts'
     | '/api/torghut/trading/control-plane/quant/health'
     | '/api/torghut/trading/control-plane/quant/series'
@@ -2234,6 +2246,7 @@ export interface FileRouteTypes {
     | '/github/pulls/$owner/$repo/$number'
     | '/api/github/pulls/$owner/$repo/$number'
     | '/api/torghut/trading/control-plane/llm/rollout'
+    | '/api/torghut/trading/control-plane/quant/account-witness'
     | '/api/torghut/trading/control-plane/quant/alerts'
     | '/api/torghut/trading/control-plane/quant/health'
     | '/api/torghut/trading/control-plane/quant/series'
@@ -2388,6 +2401,7 @@ export interface RootRouteChildren {
   ApiTorghutMarketContextRunsProgressRoute: typeof ApiTorghutMarketContextRunsProgressRoute
   ApiTorghutMarketContextRunsStartRoute: typeof ApiTorghutMarketContextRunsStartRoute
   ApiTorghutTradingControlPlaneLlmRolloutRoute: typeof ApiTorghutTradingControlPlaneLlmRolloutRoute
+  ApiTorghutTradingControlPlaneQuantAccountWitnessRoute: typeof ApiTorghutTradingControlPlaneQuantAccountWitnessRoute
   ApiTorghutTradingControlPlaneQuantAlertsRoute: typeof ApiTorghutTradingControlPlaneQuantAlertsRoute
   ApiTorghutTradingControlPlaneQuantHealthRoute: typeof ApiTorghutTradingControlPlaneQuantHealthRoute
   ApiTorghutTradingControlPlaneQuantSeriesRoute: typeof ApiTorghutTradingControlPlaneQuantSeriesRoute
@@ -3559,6 +3573,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiTorghutTradingControlPlaneQuantAlertsRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/torghut/trading/control-plane/quant/account-witness': {
+      id: '/api/torghut/trading/control-plane/quant/account-witness'
+      path: '/api/torghut/trading/control-plane/quant/account-witness'
+      fullPath: '/api/torghut/trading/control-plane/quant/account-witness'
+      preLoaderRoute: typeof ApiTorghutTradingControlPlaneQuantAccountWitnessRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/torghut/trading/control-plane/llm/rollout': {
       id: '/api/torghut/trading/control-plane/llm/rollout'
       path: '/api/torghut/trading/control-plane/llm/rollout'
@@ -4082,6 +4103,8 @@ const rootRouteChildren: RootRouteChildren = {
   ApiTorghutMarketContextRunsStartRoute: ApiTorghutMarketContextRunsStartRoute,
   ApiTorghutTradingControlPlaneLlmRolloutRoute:
     ApiTorghutTradingControlPlaneLlmRolloutRoute,
+  ApiTorghutTradingControlPlaneQuantAccountWitnessRoute:
+    ApiTorghutTradingControlPlaneQuantAccountWitnessRoute,
   ApiTorghutTradingControlPlaneQuantAlertsRoute:
     ApiTorghutTradingControlPlaneQuantAlertsRoute,
   ApiTorghutTradingControlPlaneQuantHealthRoute:

--- a/services/jangar/src/routes/api/torghut/trading/control-plane/quant/-account-witness.test.ts
+++ b/services/jangar/src/routes/api/torghut/trading/control-plane/quant/-account-witness.test.ts
@@ -1,0 +1,250 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const getQuantLatestStoreStatus = vi.fn()
+const listLatestQuantPipelineHealth = vi.fn()
+
+vi.mock('~/server/torghut-quant-metrics-store', () => ({
+  getQuantLatestStoreStatus,
+  listLatestQuantPipelineHealth,
+}))
+
+describe('getQuantAccountWitnessHandler', () => {
+  beforeEach(() => {
+    getQuantLatestStoreStatus.mockReset()
+    listLatestQuantPipelineHealth.mockReset()
+    process.env.JANGAR_TORGHUT_QUANT_HEALTH_MISSING_UPDATE_SECONDS = '15'
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    delete process.env.JANGAR_TORGHUT_QUANT_HEALTH_MISSING_UPDATE_SECONDS
+    delete process.env.JANGAR_QUANT_ACCOUNT_WITNESS_TIMEOUT_MS
+  })
+
+  it('returns 400 when account scope is missing', async () => {
+    const { getQuantAccountWitnessHandler } = await import('./account-witness')
+
+    const response = await getQuantAccountWitnessHandler(
+      new Request('http://localhost/api/torghut/trading/control-plane/quant/account-witness?window=15m'),
+    )
+
+    expect(response.status).toBe(400)
+    expect(getQuantLatestStoreStatus).not.toHaveBeenCalled()
+  })
+
+  it('keeps aggregate health advisory when the account latest store is empty', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-13T15:00:00.000Z'))
+    const { getQuantAccountWitnessHandler } = await import('./account-witness')
+
+    getQuantLatestStoreStatus
+      .mockResolvedValueOnce({
+        updatedAt: '2026-05-13T14:59:58.000Z',
+        count: 4536,
+      })
+      .mockResolvedValueOnce({
+        updatedAt: null,
+        count: 0,
+      })
+    listLatestQuantPipelineHealth.mockResolvedValueOnce([])
+
+    const response = await getQuantAccountWitnessHandler(
+      new Request('http://localhost/api/torghut/trading/control-plane/quant/account-witness?account=paper&window=15m'),
+    )
+
+    expect(response.status).toBe(200)
+    expect(getQuantLatestStoreStatus).toHaveBeenNthCalledWith(1, {})
+    expect(getQuantLatestStoreStatus).toHaveBeenNthCalledWith(2, {
+      account: 'paper',
+      window: '15m',
+    })
+    expect(listLatestQuantPipelineHealth).toHaveBeenCalledWith({
+      account: 'paper',
+      window: '15m',
+      minCreatedAt: '2026-05-13T14:59:00.000Z',
+    })
+
+    const body = await response.json()
+    expect(body.ok).toBe(true)
+    expect(body.witness.schema_version).toBe('jangar.quant-account-witness.v1')
+    expect(body.witness.aggregate_latest_store.status).toBe('current')
+    expect(body.witness.account_latest_store.status).toBe('empty')
+    expect(body.witness.route_warrant_usability).toMatchObject({
+      state: 'empty',
+      reason_codes: expect.arrayContaining([
+        'quant_account_witness_latest_store_empty',
+        'quant_pipeline_ingestion_missing',
+        'quant_pipeline_compute_missing',
+        'quant_pipeline_materialization_missing',
+        'quant_account_witness_not_current',
+      ]),
+    })
+    expect(body.witness.capital_safety).toEqual({
+      max_notional: '0',
+      can_clear_routeability: false,
+      reason_codes: ['zero_notional_safe', 'quant_account_witness_not_current'],
+    })
+  })
+
+  it('returns a stale timeout witness instead of failing the request', async () => {
+    const { getQuantAccountWitnessHandler } = await import('./account-witness')
+
+    getQuantLatestStoreStatus
+      .mockResolvedValueOnce({
+        updatedAt: '2026-05-13T14:59:58.000Z',
+        count: 4536,
+      })
+      .mockImplementationOnce(() => new Promise(() => {}))
+    listLatestQuantPipelineHealth.mockImplementationOnce(() => new Promise(() => {}))
+
+    const response = await getQuantAccountWitnessHandler(
+      new Request(
+        'http://localhost/api/torghut/trading/control-plane/quant/account-witness?account=PA3SX7FYNUTF&window=15m&timeout_ms=1',
+      ),
+    )
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.witness.service_budget_ms).toBe(1)
+    expect(body.witness.account_latest_store).toMatchObject({
+      status: 'timeout',
+      timeout_observed: true,
+      reason_codes: ['quant_account_witness_timeout'],
+    })
+    expect(body.witness.pipeline_health).toMatchObject({
+      status: 'timeout',
+      timeout_observed: true,
+      reason_codes: ['quant_account_witness_timeout'],
+    })
+    expect(body.witness.route_warrant_usability.state).toBe('timeout')
+    expect(body.witness.capital_safety.can_clear_routeability).toBe(false)
+  })
+
+  it('keeps aggregate latest-store timeout advisory when scoped account evidence is current', async () => {
+    process.env.JANGAR_TORGHUT_QUANT_HEALTH_MISSING_UPDATE_SECONDS = '3600'
+    const { getQuantAccountWitnessHandler } = await import('./account-witness')
+
+    getQuantLatestStoreStatus
+      .mockImplementationOnce(() => new Promise(() => {}))
+      .mockResolvedValueOnce({
+        updatedAt: '2026-05-13T14:59:59.000Z',
+        count: 24,
+      })
+    listLatestQuantPipelineHealth.mockResolvedValueOnce([
+      {
+        strategyId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+        account: 'paper',
+        stage: 'ingestion',
+        ok: true,
+        lagSeconds: 1,
+        asOf: '2026-05-13T14:59:59.000Z',
+      },
+      {
+        strategyId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+        account: 'paper',
+        stage: 'compute',
+        ok: true,
+        lagSeconds: 2,
+        asOf: '2026-05-13T14:59:58.000Z',
+      },
+      {
+        strategyId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+        account: 'paper',
+        stage: 'materialization',
+        ok: true,
+        lagSeconds: 1,
+        asOf: '2026-05-13T14:59:59.000Z',
+      },
+    ])
+
+    const response = await getQuantAccountWitnessHandler(
+      new Request(
+        'http://localhost/api/torghut/trading/control-plane/quant/account-witness?account=paper&window=15m&timeout_ms=1',
+      ),
+    )
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.witness.aggregate_latest_store).toMatchObject({
+      status: 'unavailable',
+      reason_codes: ['quant_aggregate_latest_store_timeout'],
+    })
+    expect(body.witness.account_latest_store.status).toBe('current')
+    expect(body.witness.pipeline_health.status).toBe('current')
+    expect(body.witness.route_warrant_usability.state).toBe('current')
+  })
+
+  it('returns current route-warrant usability only when account store and required stages are current', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-13T15:00:00.000Z'))
+    const { getQuantAccountWitnessHandler } = await import('./account-witness')
+
+    getQuantLatestStoreStatus
+      .mockResolvedValueOnce({
+        updatedAt: '2026-05-13T14:59:58.000Z',
+        count: 4536,
+      })
+      .mockResolvedValueOnce({
+        updatedAt: '2026-05-13T14:59:59.000Z',
+        count: 24,
+      })
+    listLatestQuantPipelineHealth.mockResolvedValueOnce([
+      {
+        strategyId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+        account: 'paper',
+        stage: 'ingestion',
+        ok: true,
+        lagSeconds: 1,
+        asOf: '2026-05-13T14:59:59.000Z',
+        recordedAt: '2026-05-13T14:59:59.500Z',
+        details: { window: '15m' },
+      },
+      {
+        strategyId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+        account: 'paper',
+        stage: 'compute',
+        ok: true,
+        lagSeconds: 2,
+        asOf: '2026-05-13T14:59:58.000Z',
+        recordedAt: '2026-05-13T14:59:59.500Z',
+        details: { window: '15m' },
+      },
+      {
+        strategyId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+        account: 'paper',
+        stage: 'materialization',
+        ok: true,
+        lagSeconds: 1,
+        asOf: '2026-05-13T14:59:59.000Z',
+        recordedAt: '2026-05-13T14:59:59.500Z',
+        details: { window: '15m' },
+      },
+    ])
+
+    const response = await getQuantAccountWitnessHandler(
+      new Request(
+        'http://localhost/api/torghut/trading/control-plane/quant/account-witness?strategy_id=aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa&account=paper&account_alias=paper-main&account_aliases=paper-shadow&window=15m',
+      ),
+    )
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.witness.account_aliases).toEqual(['paper', 'paper-main', 'paper-shadow'])
+    expect(body.witness.strategy_scope).toEqual({
+      strategy_id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      scope: 'strategy',
+    })
+    expect(body.witness.account_latest_store.status).toBe('current')
+    expect(body.witness.pipeline_health.status).toBe('current')
+    expect(body.witness.route_warrant_usability).toEqual({
+      state: 'current',
+      reason_codes: [],
+      target_value_gates: ['zero_notional_or_stale_evidence_rate', 'routeable_candidate_count', 'capital_gate_safety'],
+    })
+    expect(body.witness.capital_safety).toEqual({
+      max_notional: '0',
+      can_clear_routeability: true,
+      reason_codes: ['zero_notional_quant_witness_only'],
+    })
+  })
+})

--- a/services/jangar/src/routes/api/torghut/trading/control-plane/quant/account-witness.ts
+++ b/services/jangar/src/routes/api/torghut/trading/control-plane/quant/account-witness.ts
@@ -1,0 +1,70 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import { buildQuantAccountWitness } from '~/server/torghut-quant-account-witness'
+import { parseQuantAccount, parseQuantStrategyId, parseQuantWindow } from '~/server/torghut-quant-http'
+import { getQuantLatestStoreStatus, listLatestQuantPipelineHealth } from '~/server/torghut-quant-metrics-store'
+
+export const Route = createFileRoute('/api/torghut/trading/control-plane/quant/account-witness')({
+  server: {
+    handlers: {
+      GET: async ({ request }: JangarServerRouteArgs) => getQuantAccountWitnessHandler(request),
+    },
+  },
+})
+
+const jsonResponse = (payload: unknown, status = 200) => {
+  const body = JSON.stringify(payload)
+  return new Response(body, {
+    status,
+    headers: {
+      'content-type': 'application/json',
+      'content-length': Buffer.byteLength(body).toString(),
+    },
+  })
+}
+
+const parseAccountAliases = (url: URL) => {
+  const repeated = url.searchParams.getAll('account_alias')
+  const commaSeparated = (url.searchParams.get('account_aliases') ?? '')
+    .split(',')
+    .map((value) => value.trim())
+    .filter(Boolean)
+  return [...repeated, ...commaSeparated]
+}
+
+const parseTimeoutMs = (url: URL) => {
+  const raw = url.searchParams.get('timeout_ms') ?? process.env.JANGAR_QUANT_ACCOUNT_WITNESS_TIMEOUT_MS
+  if (!raw) return undefined
+  const parsed = Number(raw)
+  return Number.isFinite(parsed) ? parsed : undefined
+}
+
+export const getQuantAccountWitnessHandler = async (request: Request) => {
+  const url = new URL(request.url)
+  const strategyIdParam = url.searchParams.get('strategy_id') ?? url.searchParams.get('strategyId')
+  const strategyIdResult = strategyIdParam ? parseQuantStrategyId(url) : { ok: true as const, value: undefined }
+  if (!strategyIdResult.ok) return jsonResponse({ ok: false, message: strategyIdResult.message }, 400)
+
+  const account = parseQuantAccount(url).value
+  if (!account) return jsonResponse({ ok: false, message: 'Missing required query param: account' }, 400)
+
+  const windowResult = parseQuantWindow(url)
+  if (!windowResult.ok) return jsonResponse({ ok: false, message: windowResult.message }, 400)
+
+  try {
+    const witness = await buildQuantAccountWitness({
+      strategyId: strategyIdResult.value,
+      account,
+      accountAliases: parseAccountAliases(url),
+      window: windowResult.value,
+      timeoutMs: parseTimeoutMs(url),
+      getLatestStoreStatus: getQuantLatestStoreStatus,
+      listLatestPipelineHealth: listLatestQuantPipelineHealth,
+    })
+
+    return jsonResponse({ ok: true, witness })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Quant account witness failed'
+    return jsonResponse({ ok: false, message }, 503)
+  }
+}

--- a/services/jangar/src/server/torghut-quant-account-witness.ts
+++ b/services/jangar/src/server/torghut-quant-account-witness.ts
@@ -1,0 +1,399 @@
+import { createHash } from 'node:crypto'
+
+import { resolveTorghutEndpointsConfig } from './torghut-config'
+import type {
+  QuantPipelineHealth,
+  QuantPipelineHealthStage,
+  QuantLatestStoreStatus,
+} from './torghut-quant-metrics-store'
+
+export const QUANT_ACCOUNT_WITNESS_SCHEMA_VERSION = 'jangar.quant-account-witness.v1'
+
+const DESIGN_REF = 'docs/agents/designs/189-jangar-account-scoped-quant-witness-custody-and-route-reentry-2026-05-13.md'
+const DEFAULT_TIMEOUT_MS = 2_000
+const MARKET_HOURS_TTL_SECONDS = 60
+const OFF_HOURS_TTL_SECONDS = 300
+const REQUIRED_PIPELINE_STAGES: QuantPipelineHealthStage[] = ['ingestion', 'compute', 'materialization']
+const TARGET_VALUE_GATES = ['zero_notional_or_stale_evidence_rate', 'routeable_candidate_count', 'capital_gate_safety']
+
+export type QuantAccountWitnessRouteState = 'current' | 'stale' | 'empty' | 'timeout' | 'not_scoped'
+
+export type QuantAccountWitnessStoreState = 'current' | 'stale' | 'empty' | 'timeout' | 'unavailable'
+
+export type QuantAccountWitnessPipelineStage = {
+  stage: QuantPipelineHealthStage
+  status: 'current' | 'stale' | 'missing'
+  ok: boolean
+  lag_seconds: number | null
+  as_of: string | null
+  recorded_at: string | null
+  reason_codes: string[]
+}
+
+export type QuantAccountWitnessPayload = {
+  schema_version: typeof QUANT_ACCOUNT_WITNESS_SCHEMA_VERSION
+  design_ref: typeof DESIGN_REF
+  witness_id: string
+  generated_at: string
+  fresh_until: string
+  account: string
+  account_aliases: string[]
+  window: string
+  strategy_scope: {
+    strategy_id: string | null
+    scope: 'strategy' | 'all_strategies'
+  }
+  service_budget_ms: number
+  elapsed_ms: number
+  aggregate_latest_store: {
+    status: Exclude<QuantAccountWitnessStoreState, 'timeout'>
+    latest_metrics_count: number
+    latest_metrics_updated_at: string | null
+    metrics_pipeline_lag_seconds: number | null
+    reason_codes: string[]
+  }
+  account_latest_store: {
+    status: QuantAccountWitnessStoreState
+    latest_metrics_count: number
+    latest_metrics_updated_at: string | null
+    metrics_pipeline_lag_seconds: number | null
+    timeout_observed: boolean
+    reason_codes: string[]
+  }
+  pipeline_health: {
+    status: 'current' | 'stale' | 'missing' | 'timeout'
+    stages: QuantAccountWitnessPipelineStage[]
+    missing_stages: QuantPipelineHealthStage[]
+    timeout_observed: boolean
+    reason_codes: string[]
+  }
+  route_warrant_usability: {
+    state: QuantAccountWitnessRouteState
+    reason_codes: string[]
+    target_value_gates: string[]
+  }
+  capital_safety: {
+    max_notional: '0'
+    can_clear_routeability: boolean
+    reason_codes: string[]
+  }
+}
+
+type QueryInput = {
+  strategyId?: string
+  account: string
+  accountAliases?: string[]
+  window: string
+  now?: Date
+  timeoutMs?: number
+  getLatestStoreStatus: (params?: {
+    strategyId?: string
+    account?: string
+    window?: string
+  }) => Promise<QuantLatestStoreStatus>
+  listLatestPipelineHealth: (params: {
+    strategyId?: string
+    account?: string
+    window?: string
+    minCreatedAt?: string
+  }) => Promise<QuantPipelineHealth[]>
+  env?: NodeJS.ProcessEnv
+}
+
+type TimeoutResult = {
+  timedOut: true
+}
+
+const isTimedOut = <T>(result: T | TimeoutResult): result is TimeoutResult =>
+  typeof result === 'object' && result !== null && 'timedOut' in result
+
+const withTimeout = async <T>(promise: Promise<T>, timeoutMs: number): Promise<T | TimeoutResult> => {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const timeout = new Promise<TimeoutResult>((resolve) => {
+    timer = setTimeout(() => resolve({ timedOut: true }), timeoutMs)
+  })
+
+  try {
+    return await Promise.race([promise, timeout])
+  } finally {
+    if (timer) clearTimeout(timer)
+  }
+}
+
+const uniqueValues = (values: string[]) => {
+  const seen = new Set<string>()
+  const result: string[] = []
+  for (const value of values) {
+    const trimmed = value.trim()
+    if (!trimmed || seen.has(trimmed)) continue
+    seen.add(trimmed)
+    result.push(trimmed)
+  }
+  return result
+}
+
+const lagSeconds = (now: Date, updatedAt: string | null) =>
+  updatedAt ? Math.max(0, Math.floor((now.getTime() - Date.parse(updatedAt)) / 1000)) : null
+
+const isMarketHoursNy = (now = new Date()) => {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: 'America/New_York',
+    weekday: 'short',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  }).formatToParts(now)
+
+  const record: Record<string, string> = {}
+  for (const part of parts) {
+    if (part.type !== 'literal') record[part.type] = part.value
+  }
+  const weekday = record.weekday ?? ''
+  if (weekday === 'Sat' || weekday === 'Sun') return false
+  const hour = Number(record.hour ?? '0')
+  const minute = Number(record.minute ?? '0')
+  const minutes = hour * 60 + minute
+  return minutes >= 9 * 60 + 30 && minutes <= 16 * 60
+}
+
+const classifyLatestStore = (params: {
+  status: QuantLatestStoreStatus
+  now: Date
+  staleAfterSeconds: number
+  marketHours: boolean
+}) => {
+  const lag = lagSeconds(params.now, params.status.updatedAt)
+  const reasonCodes: string[] = []
+  let state: Exclude<QuantAccountWitnessStoreState, 'timeout' | 'unavailable'> = 'current'
+
+  if (params.status.count === 0) {
+    state = 'empty'
+    reasonCodes.push('quant_account_witness_latest_store_empty')
+  } else if (params.marketHours && lag !== null && lag > params.staleAfterSeconds) {
+    state = 'stale'
+    reasonCodes.push('quant_account_witness_latest_store_stale')
+  }
+
+  return {
+    status: state,
+    latest_metrics_count: params.status.count,
+    latest_metrics_updated_at: params.status.updatedAt,
+    metrics_pipeline_lag_seconds: lag,
+    reason_codes: reasonCodes,
+  }
+}
+
+const buildPipelineStage = (
+  stage: QuantPipelineHealthStage,
+  receipt: QuantPipelineHealth | undefined,
+): QuantAccountWitnessPipelineStage => {
+  if (!receipt) {
+    return {
+      stage,
+      status: 'missing',
+      ok: false,
+      lag_seconds: null,
+      as_of: null,
+      recorded_at: null,
+      reason_codes: [`quant_pipeline_${stage}_missing`],
+    }
+  }
+
+  return {
+    stage,
+    status: receipt.ok ? 'current' : 'stale',
+    ok: receipt.ok,
+    lag_seconds: receipt.lagSeconds,
+    as_of: receipt.asOf,
+    recorded_at: receipt.recordedAt ?? null,
+    reason_codes: receipt.ok ? [] : [`quant_pipeline_${stage}_degraded`],
+  }
+}
+
+const witnessId = (params: {
+  generatedAt: string
+  account: string
+  window: string
+  strategyId?: string
+  accountStoreStatus: QuantAccountWitnessStoreState
+  pipelineStatus: QuantAccountWitnessPayload['pipeline_health']['status']
+}) => {
+  const digest = createHash('sha256')
+    .update(
+      JSON.stringify({
+        generatedAt: params.generatedAt,
+        account: params.account,
+        window: params.window,
+        strategyId: params.strategyId ?? null,
+        accountStoreStatus: params.accountStoreStatus,
+        pipelineStatus: params.pipelineStatus,
+      }),
+    )
+    .digest('hex')
+    .slice(0, 16)
+  return `quant-account-witness:${params.account}:${params.window}:${digest}`
+}
+
+export const buildQuantAccountWitness = async (input: QueryInput): Promise<QuantAccountWitnessPayload> => {
+  const startedAt = Date.now()
+  const now = input.now ?? new Date()
+  const generatedAt = now.toISOString()
+  const marketHours = isMarketHoursNy(now)
+  const ttlSeconds = marketHours ? MARKET_HOURS_TTL_SECONDS : OFF_HOURS_TTL_SECONDS
+  const freshUntil = new Date(now.getTime() + ttlSeconds * 1000).toISOString()
+  const endpointConfig = resolveTorghutEndpointsConfig(input.env ?? process.env)
+  const staleAfterSeconds = Number.isFinite(endpointConfig.quantHealthMissingUpdateSeconds)
+    ? endpointConfig.quantHealthMissingUpdateSeconds
+    : 15
+  const timeoutMs = Math.max(1, Math.min(input.timeoutMs ?? DEFAULT_TIMEOUT_MS, DEFAULT_TIMEOUT_MS))
+  const stageLookbackSeconds = Math.max(60, staleAfterSeconds * 4)
+  const stageMinRecordedAt = new Date(now.getTime() - stageLookbackSeconds * 1000).toISOString()
+  const aliases = uniqueValues([input.account, ...(input.accountAliases ?? [])])
+  const strategyScopeParams = input.strategyId ? { strategyId: input.strategyId } : {}
+
+  const [aggregateResult, accountResult, pipelineResult] = await Promise.all([
+    withTimeout(input.getLatestStoreStatus(strategyScopeParams), timeoutMs),
+    withTimeout(
+      input.getLatestStoreStatus({
+        ...strategyScopeParams,
+        account: input.account,
+        window: input.window,
+      }),
+      timeoutMs,
+    ),
+    withTimeout(
+      input.listLatestPipelineHealth({
+        ...strategyScopeParams,
+        account: input.account,
+        window: input.window,
+        minCreatedAt: stageMinRecordedAt,
+      }),
+      timeoutMs,
+    ),
+  ])
+
+  const aggregateStore = isTimedOut(aggregateResult)
+    ? {
+        status: 'unavailable' as const,
+        latest_metrics_count: 0,
+        latest_metrics_updated_at: null,
+        metrics_pipeline_lag_seconds: null,
+        reason_codes: ['quant_aggregate_latest_store_timeout'],
+      }
+    : classifyLatestStore({
+        status: aggregateResult,
+        now,
+        staleAfterSeconds,
+        marketHours,
+      })
+
+  const accountStore = isTimedOut(accountResult)
+    ? {
+        status: 'timeout' as const,
+        latest_metrics_count: 0,
+        latest_metrics_updated_at: null,
+        metrics_pipeline_lag_seconds: null,
+        timeout_observed: true,
+        reason_codes: ['quant_account_witness_timeout'],
+      }
+    : {
+        ...classifyLatestStore({
+          status: accountResult,
+          now,
+          staleAfterSeconds,
+          marketHours,
+        }),
+        timeout_observed: false,
+      }
+
+  const pipelineStages = isTimedOut(pipelineResult)
+    ? REQUIRED_PIPELINE_STAGES.map((stage) => ({
+        stage,
+        status: 'missing' as const,
+        ok: false,
+        lag_seconds: null,
+        as_of: null,
+        recorded_at: null,
+        reason_codes: ['quant_account_witness_timeout'],
+      }))
+    : REQUIRED_PIPELINE_STAGES.map((stage) =>
+        buildPipelineStage(
+          stage,
+          pipelineResult.find((receipt) => receipt.stage === stage),
+        ),
+      )
+  const missingStages = pipelineStages.filter((stage) => stage.status === 'missing').map((stage) => stage.stage)
+  const pipelineReasonCodes = uniqueValues(pipelineStages.flatMap((stage) => stage.reason_codes))
+  const pipelineStatus = isTimedOut(pipelineResult)
+    ? 'timeout'
+    : missingStages.length > 0
+      ? 'missing'
+      : pipelineStages.some((stage) => !stage.ok)
+        ? 'stale'
+        : 'current'
+
+  const routeReasonCodes = uniqueValues([
+    ...accountStore.reason_codes,
+    ...pipelineReasonCodes,
+    ...(accountStore.status === 'current' && pipelineStatus === 'current' ? [] : ['quant_account_witness_not_current']),
+  ])
+  const routeState: QuantAccountWitnessRouteState =
+    accountStore.status === 'timeout' || pipelineStatus === 'timeout'
+      ? 'timeout'
+      : accountStore.status === 'empty'
+        ? 'empty'
+        : accountStore.status === 'current' && pipelineStatus === 'current'
+          ? 'current'
+          : 'stale'
+
+  const witness = {
+    schema_version: QUANT_ACCOUNT_WITNESS_SCHEMA_VERSION,
+    design_ref: DESIGN_REF,
+    witness_id: witnessId({
+      generatedAt,
+      account: input.account,
+      window: input.window,
+      strategyId: input.strategyId,
+      accountStoreStatus: accountStore.status,
+      pipelineStatus,
+    }),
+    generated_at: generatedAt,
+    fresh_until: freshUntil,
+    account: input.account,
+    account_aliases: aliases,
+    window: input.window,
+    strategy_scope: {
+      strategy_id: input.strategyId ?? null,
+      scope: input.strategyId ? 'strategy' : 'all_strategies',
+    },
+    service_budget_ms: timeoutMs,
+    elapsed_ms: Math.max(0, Date.now() - startedAt),
+    aggregate_latest_store: {
+      ...aggregateStore,
+      status: aggregateStore.status,
+    },
+    account_latest_store: accountStore,
+    pipeline_health: {
+      status: pipelineStatus,
+      stages: pipelineStages,
+      missing_stages: missingStages,
+      timeout_observed: isTimedOut(pipelineResult),
+      reason_codes: pipelineReasonCodes,
+    },
+    route_warrant_usability: {
+      state: routeState,
+      reason_codes: routeReasonCodes,
+      target_value_gates: TARGET_VALUE_GATES,
+    },
+    capital_safety: {
+      max_notional: '0',
+      can_clear_routeability: routeState === 'current',
+      reason_codes:
+        routeState === 'current'
+          ? ['zero_notional_quant_witness_only']
+          : ['zero_notional_safe', 'quant_account_witness_not_current'],
+    },
+  } satisfies QuantAccountWitnessPayload
+
+  return witness
+}


### PR DESCRIPTION
## Summary

- Adds the Jangar account-scoped quant witness route at `/api/torghut/trading/control-plane/quant/account-witness`.
- Implements `jangar.quant-account-witness.v1` from `docs/agents/designs/189-jangar-account-scoped-quant-witness-custody-and-route-reentry-2026-05-13.md`, with aggregate latest-store health kept advisory and account/window store plus pipeline stages treated as the route-warrant custody surface.
- Returns explicit `empty`, `timeout`, `stale`, and `current` witness states inside a bounded cached-read budget, including advisory aggregate timeout handling.
- Documents rollout risk and rollback in `services/jangar/README.md`; the witness remains zero-notional evidence and cannot grant capital by itself.

## Related Issues

None.

Design provenance: `docs/agents/designs/189-jangar-account-scoped-quant-witness-custody-and-route-reentry-2026-05-13.md`.

Runtime requirement provenance: Jangar control-plane implement stage for `codex/swarm-jangar-control-plane`; value gates improved are `handoff_evidence_quality` and `manual_intervention_count` by replacing manual aggregate-vs-account quant interpretation with a typed route-warrant witness.

Risk and rollback: consumers could over-read a current witness as capital permission, so the payload always reports `capital_safety.max_notional = "0"` and documents that proof floor, TCA, source-serving, routeability, and live submission gates remain independent blockers. Rollback is to stop consuming `/api/torghut/trading/control-plane/quant/account-witness` and retain existing `/quant/health` diagnostics.

## Testing

- `bun install --frozen-lockfile` failed before validation because the `tree-sitter-json` install script could not resolve `abbrev` through `node-gyp` in this fresh workspace.
- `bun install --frozen-lockfile --ignore-scripts` passed and installed pinned JS tooling without lockfile changes.
- `bun run --filter @proompteng/otel build` passed.
- `bun run --filter @proompteng/temporal-bun-sdk build` passed.
- `bunx vitest run --config vitest.config.ts src/routes/api/torghut/trading/control-plane/quant/-account-witness.test.ts src/routes/api/torghut/trading/control-plane/quant/-health.test.ts` passed, 2 files / 12 tests.
- `bun run --cwd services/jangar tsc` passed.
- `bun run --cwd services/jangar lint` passed.
- `bun run --cwd services/jangar lint:oxlint` passed with existing warnings only and 0 errors.
- `bun run --cwd services/jangar test` passed, 187 files / 1159 tests.
- `bun run --cwd services/jangar lint:oxlint:type` passed with existing warnings only and 0 errors.
- `bunx vitest run --config vitest.config.ts src/routes/api/torghut/trading/control-plane/quant/-account-witness.test.ts` passed after final helper cleanup, 1 file / 5 tests.
- `bun run --cwd services/jangar build` passed.
- `bunx oxfmt --check services/jangar/src/server/torghut-quant-account-witness.ts services/jangar/src/routes/api/torghut/trading/control-plane/quant/account-witness.ts services/jangar/src/routes/api/torghut/trading/control-plane/quant/-account-witness.test.ts services/jangar/README.md services/jangar/src/routeTree.gen.ts` passed.
- `git diff --check` passed.

## Screenshots (if applicable)

N/A - API route and server contract only.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
