### PR TITLE
chore(jangar): promote image 59037988

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 3382549b
-  digest: sha256:1c72a548ba5a55cf4bcc3a986966ff753ff574583ccad330fddcb32333dd2288
+  tag: "59037988"
+  digest: sha256:d36014cfdf350b30a8c10ef4238c1e6fdd51e6e6f390b2b012d070f99560035e
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,8 +11,8 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 3382549b
-    digest: sha256:9c311a8a6aa36f3ccf3187548ccdfe298ca334b7c954a1ff3d38e99405a1bff2
+    tag: "59037988"
+    digest: sha256:b4e388efb61593dbb3798a2510fc76b600c08b0fd699b922e6edc9fa945a0a3d
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
@@ -21,8 +21,8 @@ controlPlane:
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 3382549b
-    digest: sha256:1c72a548ba5a55cf4bcc3a986966ff753ff574583ccad330fddcb32333dd2288
+    tag: "59037988"
+    digest: sha256:d36014cfdf350b30a8c10ef4238c1e6fdd51e6e6f390b2b012d070f99560035e
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-13T15:43:47Z
+    deploy.knative.dev/rollout: 2026-05-13T16:06:58Z
 spec:
   replicas: 1
   strategy:
@@ -57,11 +57,11 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_RUNTIME_IMAGE
-              value: registry.ide-newton.ts.net/lab/jangar:3382549b@sha256:1c72a548ba5a55cf4bcc3a986966ff753ff574583ccad330fddcb32333dd2288
+              value: registry.ide-newton.ts.net/lab/jangar:59037988@sha256:d36014cfdf350b30a8c10ef4238c1e6fdd51e6e6f390b2b012d070f99560035e
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: 3382549b8cd192956c9cde89caa9f53849a77208
+              value: 590379886ae32e68013204094f67660b3879c4fe
             - name: JANGAR_GITOPS_REVISION
-              value: 3382549b8cd192956c9cde89caa9f53849a77208
+              value: 590379886ae32e68013204094f67660b3879c4fe
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_BUMBA_TASK_QUEUE

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -59,5 +59,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: 3382549b
-    digest: sha256:1c72a548ba5a55cf4bcc3a986966ff753ff574583ccad330fddcb32333dd2288
+    newTag: "59037988"
+    digest: sha256:d36014cfdf350b30a8c10ef4238c1e6fdd51e6e6f390b2b012d070f99560035e


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `590379886ae32e68013204094f67660b3879c4fe`
- Image tag: `59037988`
- Image digest: `sha256:d36014cfdf350b30a8c10ef4238c1e6fdd51e6e6f390b2b012d070f99560035e`
- Updated API rollout annotation
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`