### PR TITLE
docs(jangar): define projection foreclosure notary

### DIFF
--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -19,6 +19,8 @@ clear entrypoints, clear “source of truth”, and a complete catalog of relate
 - Autonomous Jangar/Torghut production system design: `designs/autonomous-jangar-torghut-production-system.md`
 - Swarm agentic mission architecture notes: `designs/swarm-agentic-mission-architecture-2026-05-08.md`
 - Current Jangar/Torghut architecture contracts:
+  - `designs/190-jangar-projection-foreclosure-notary-and-stage-custody-repair-2026-05-13.md`
+  - `../torghut/design-system/v6/195-torghut-stale-projection-foreclosure-and-route-custody-2026-05-13.md`
   - `designs/189-jangar-authority-provenance-settlement-and-rollout-reentry-windows-2026-05-13.md`
   - `../torghut/design-system/v6/193-torghut-route-repair-yield-board-and-hypothesis-reentry-guardrails-2026-05-13.md`
   - `designs/189-jangar-terminal-debt-compaction-and-repair-outcome-escrow-2026-05-13.md`

--- a/docs/agents/designs/190-jangar-projection-foreclosure-notary-and-stage-custody-repair-2026-05-13.md
+++ b/docs/agents/designs/190-jangar-projection-foreclosure-notary-and-stage-custody-repair-2026-05-13.md
@@ -1,0 +1,522 @@
+# 190. Jangar Projection Foreclosure Notary And Stage Custody Repair (2026-05-13)
+
+Status: Accepted for engineer and deployer handoff
+Date: 2026-05-13
+Owner: Victor Chen, Jangar Engineering Architecture
+Scope: Jangar stale projection foreclosure, stage custody repair, AgentRun and market-context data authority, ready truth,
+stage credit, Torghut repair-only route custody, validation, rollout, rollback, and cross-stage handoff.
+
+Companion Torghut contract:
+
+- `docs/torghut/design-system/v6/195-torghut-stale-projection-foreclosure-and-route-custody-2026-05-13.md`
+
+Extends:
+
+- `docs/agents/designs/189-jangar-terminal-debt-compaction-and-repair-outcome-escrow-2026-05-13.md`
+- `docs/agents/designs/189-jangar-authority-provenance-settlement-and-rollout-reentry-windows-2026-05-13.md`
+- `docs/agents/designs/188-jangar-ready-truth-arbiter-and-stage-credit-cutover-2026-05-13.md`
+- `docs/agents/designs/187-jangar-stage-credit-ledger-and-runner-slot-futures-2026-05-13.md`
+- `docs/agents/designs/123-jangar-market-context-contradiction-ledger-and-lane-capital-holds-2026-05-06.md`
+
+## Decision
+
+I am selecting a **projection foreclosure notary** as the next Jangar control-plane architecture increment.
+
+The previous discover increments moved the system from broad failure counting toward typed stage credit, ready truth,
+terminal debt compaction, and repair outcome escrow. That was necessary, but the current read-only assessment shows one
+remaining reliability gap: old database and evidence projections can still look active after the live authority surface
+has moved on.
+
+On 2026-05-13 the rollout surface was mostly healthy. The `jangar` namespace deployments were ready, the `agents`
+controller deployments were ready, and Torghut serving deployments were ready after their latest rollout. Jangar
+control-plane status reported healthy database, healthy watch reliability, healthy execution trust, and healthy
+controller heartbeats from the active controller deployment. At the same time, the state stores still carried stale
+active claims. Jangar Postgres had `31` `agent_runs` rows marked `Running`, with the oldest created on
+`2026-03-11T03:36:00Z`, and `5` rows marked `Pending`. Jangar market-context run tables still contained
+`running` and `started` rows whose heartbeats ranged from hours old to weeks old. Torghut Postgres had current TCA and
+options watermark activity, but `evidence_epochs` and `evidence_receipts` were empty while Jangar route custody
+reported `repair_only`, evidence-clock custody `blocked`, and required receipts that did not yet exist.
+
+The selected design makes that split explicit. A projection can be current, grace-period current, stale-foreclosed,
+contradictory, terminal audit, or missing-receipt. Foreclosure is not cleanup and does not mutate source rows. It is a
+read-side notarization that says "this row or projection is still preserved, but it is no longer live authority for
+stage credit, ready truth, rollout admission, or Torghut capital-adjacent repair."
+
+The tradeoff is that implementation must carry another typed status object through Jangar. I accept that cost because
+the business metric is reducing failed AgentRuns and shortening green PR-to-healthy GitOps rollout time. The fastest
+way to improve both is to stop asking deployers and scheduled lanes to manually decide whether an old `Running` row,
+old market-context batch, or empty receipt ledger is still authoritative.
+
+## Governing Runtime Requirements
+
+This design binds to the current Jangar swarm validation contract:
+
+- every run must cite the governing design or runtime requirement before changing code;
+- implement stages must produce production PRs with tests or report the exact blocker to code;
+- verify stages must merge only green PRs and prove Argo, workload readiness, and service health after rollout;
+- final handoff must name the control-plane metric improved or the smallest blocker preventing improvement.
+
+Every milestone in this document maps to at least one required Jangar value gate:
+
+- `failed_agentrun_rate`
+- `pr_to_rollout_latency`
+- `ready_status_truth`
+- `manual_intervention_count`
+- `handoff_evidence_quality`
+
+## Read-Only Evidence Snapshot
+
+All evidence in this pass was collected read-only on 2026-05-13. I did not mutate Kubernetes resources, database rows,
+GitOps resources, AgentRuns, trading flags, broker state, or market data.
+
+### Cluster, Rollout, And Events
+
+- The working branch was `codex/swarm-jangar-control-plane-discover`, aligned with `origin/main` before this document
+  was authored.
+- Kubernetes auth resolved to `system:serviceaccount:agents:agents-sa`. The workspace kube context was bootstrapped to
+  `in-cluster` from the mounted service-account token and CA before read-only checks.
+- `jangar` namespace deployments were ready. `jangar` was `1/1` ready on image
+  `registry.ide-newton.ts.net/lab/jangar:3382549b@sha256:1c72...`; `bumba`, `symphony`, `symphony-jangar`, and
+  `jangar-alloy` were also ready.
+- `agents` namespace deployments were ready. `agents` was `1/1`, `agents-controllers` was `2/2`, and `agents-alloy`
+  was `1/1`.
+- `torghut` namespace serving deployments were ready, including `torghut-00359-deployment` and
+  `torghut-sim-00457-deployment`. Older Knative revisions remained scaled to `0/0`.
+- Retained `agents` jobs summarized to `155` complete, `35` failed, and `3` running. Jangar lane jobs summarized to
+  discover `10` complete and `1` running, implement `31` complete, `6` failed, and `1` running, plan `8` complete, and
+  verify `25` complete, `1` failed, and `1` running.
+- Retained AgentRun CR phases summarized to `598` Succeeded, `115` Failed, `11` Pending, `3` Running, and
+  `12` Template. Jangar retained phases included discover `2` Failed and `61` Succeeded, implement `26` Failed and
+  `98` Succeeded, plan `3` Failed and `60` Succeeded, and verify `21` Failed and `77` Succeeded.
+- Market-context scheduled jobs were noisy: fundamentals summarized to `8` complete and `10` failed, while news
+  summarized to `16` complete and `2` failed.
+- Recent events showed transient rollout readiness probe failures, a `BackoffLimitExceeded` market-context
+  fundamentals batch, and a temporary `FailedMount` for a discover CronJob schedule template ConfigMap. Those events
+  had to be interpreted alongside later healthy deployments and completed scheduled work.
+- Current Jangar discover AgentRun stage annotations held the lane with reason codes including
+  `controller_heartbeat_not_current`, `controller_witness_allow_with_split`, `evidence_clock_custody_blocked`,
+  `route_stability_hold`, and `source_rollout_truth_hold`. The required repair action named Torghut stage-custody
+  settlement.
+
+### Source Architecture And Test Surface
+
+- `services/jangar/src/server/control-plane-status.ts` is the central status reducer. It is large enough to be a
+  high-risk source of hidden coupling at `766` lines, even before consuming new projection state.
+- `services/jangar/src/server/control-plane-terminal-debt-compaction.ts` already classifies failed AgentRuns, jobs, and
+  pods into active windows and retained audit debt. It is the right place to extend the concept from terminal Kubernetes
+  objects to stale database projections.
+- `services/jangar/src/server/control-plane-stage-credit-ledger.ts` is `481` lines and already emits stage accounts,
+  stage credit decisions, and debt refs. It does not yet require a projection foreclosure verdict before treating old
+  state-store rows as non-authoritative.
+- `services/jangar/src/server/control-plane-ready-truth-arbiter.ts` is `442` lines and correctly aggregates material
+  readiness. It needs a typed projection verdict so ready truth can explain whether a hold comes from live authority,
+  stale projection custody, or missing repair receipts.
+- `services/jangar/src/server/control-plane-torghut-stage-custody.ts` is small at `114` lines and is the correct
+  integration point for turning Torghut route-custody blockers into stage-local projection receipts.
+- `services/jangar/src/server/agents-controller/index.ts`, `agent-run-reconciler.ts`, and
+  `supporting-primitives-controller.ts` remain the highest-risk workflow surfaces at `1827`, `1190`, and `3351` lines.
+  They own the live AgentRun and Job authority that the notary must compare against database projections.
+- `services/jangar/src/server/torghut-market-context-agents.ts` is `1980` lines and currently handles market-context
+  run lifecycle states, finalization, and evidence emission. It lacks a lane-local stale-run foreclosure contract for
+  `running` or `started` records whose heartbeat has expired.
+- Existing tests cover terminal debt compaction, stage credit, ready truth, control-plane status, Torghut consumer
+  evidence, and market-context agents. The missing test family is stale projection foreclosure: old DB rows must remain
+  queryable while losing authority over current launch and repair decisions.
+
+### Database And Data Evidence
+
+- Direct CNPG `psql` through `kubectl cnpg psql` was blocked by RBAC because this service account cannot exec into
+  database pods. The assessment therefore used application read credentials and service endpoints for read-only
+  database evidence.
+- Jangar Postgres was reachable through the read service. Database time was `2026-05-13T16:11:39Z`. Extensions
+  included `pgcrypto`, `plpgsql`, and `vector`.
+- Jangar migrations were current. The latest applied migration was
+  `20260508_torghut_quant_pipeline_health_account_window_created_at_index`.
+- `agent_runs` in Jangar Postgres summarized to `655` Succeeded, `246` Failed, `31` Running, and `5` Pending. The
+  oldest `Running` row was created on `2026-03-11T03:36:00Z`; the oldest `Pending` row was created on
+  `2026-05-12T16:01:14Z`.
+- `orchestration_runs` was empty, which means current orchestration truth comes from AgentRun/Kubernetes and status
+  reducers rather than a populated orchestration ledger.
+- `torghut_market_context_runs` in Jangar Postgres summarized fundamentals as `26` succeeded, `12` running,
+  `6` failed, and `2` started. News summarized to `226` succeeded, `16` running, `7` failed, `4` started, and
+  `2` partial.
+- Market-context snapshots were recent in aggregate, but the projection rows were not clean. Fundamentals snapshots had
+  newest `as_of` `2026-05-13T15:45:29Z`; news snapshots had newest `as_of` `2026-05-13T15:43:50Z`. At the same time,
+  stale `running` and `started` records persisted with old update timestamps.
+- Market-context evidence showed a domain split. Fundamentals had `95` evidence rows with newest published
+  `2026-05-13T01:04:57Z` and ingested `2026-05-13T01:05:12Z`. News had `1167` rows with newest published
+  `2026-05-13T16:00:00Z` and newest ingested `2026-05-13T04:20:39Z`.
+- Torghut Postgres was reachable through the read service. Database time was `2026-05-13T16:13:32Z`, and Alembic head
+  was `0031_autoresearch_candidate_spec_epoch_uniqueness`.
+- Torghut `trade_decisions` still carried a large rejected and blocked surface: `69909` rejected decisions, newest
+  `2026-05-04`, and `63665` blocked decisions, newest `2026-05-13T15:26Z`. Filled executions were stale at
+  `13555`, newest `2026-04-02`.
+- Torghut TCA metrics were active with `13775` rows and newest computed timestamp `2026-05-13T15:29:49Z`, but
+  `evidence_epochs` and `evidence_receipts` were empty.
+- Torghut autoresearch and empirical evidence was active but not promotion-ready: `342` eligible candidate specs,
+  `32` completed empirical job runs marked promotion-authority eligible, and latest autoresearch epoch status
+  `no_profit_target_candidate`.
+- Torghut `/readyz` returned HTTP `503` with `status=degraded`. Scheduler, Postgres, ClickHouse, Alpaca, database,
+  universe, and empirical jobs were healthy. Live submission was blocked by `simple_submit_disabled`, profitability
+  proof floor was `repair_only`, capital state was `zero_notional`, and `alpha_readiness` had `3` shadow hypotheses,
+  `0` promotion eligible, and `2` rollback required.
+
+## Problem
+
+Jangar has multiple sources that can describe the same operational fact:
+
+- live Kubernetes AgentRun, Job, Pod, and Deployment objects;
+- Jangar Postgres `agent_runs` and market-context run rows;
+- control-plane status reducers;
+- Torghut health, consumer-evidence, and route-custody endpoints;
+- stage clearance annotations on active AgentRuns.
+
+The control plane already knows how to stay conservative when these sources disagree. The missing behavior is how to
+retire stale projections without deleting them and without asking humans to re-interpret them every run.
+
+The concrete failure modes are:
+
+1. A stale Jangar `agent_runs.running` row can outlive the live Kubernetes AgentRun and remain indistinguishable from
+   an active run to downstream readers.
+2. A stale market-context `running` or `started` row can coexist with newer snapshots and evidence, which lets one
+   segment look healthy while another surface says freshness custody is blocked.
+3. Torghut can show fresh TCA and options watermarks while empty evidence receipt tables keep route custody in
+   repair-only mode.
+4. Stage credit can hold because a projection is old, but the status route cannot prove whether the old projection is
+   still live authority, stale debt, or missing receipt evidence.
+5. Verify and deployer stages cannot shorten green PR-to-healthy rollout time while every stale state-store projection
+   requires manual explanation.
+6. Failed AgentRun rate is inflated by repeat repair runs that rediscover stale projections rather than retiring their
+   authority.
+
+## Alternatives Considered
+
+### Option A: Preserve The Current Conservative Interpretation
+
+This path keeps stale rows and missing receipts inside the existing status and stage-credit reason lists. Operators keep
+using evidence context to decide which stale items matter.
+
+Advantages:
+
+- No new reducer or schema work.
+- Keeps all old blockers visible.
+- Lowest immediate implementation cost.
+
+Disadvantages:
+
+- Keeps manual interpretation in the critical path.
+- Makes old state-store rows look like live authority.
+- Does not reduce repeated repair AgentRuns.
+- Does not improve green PR-to-healthy rollout time because every stale projection can still require human judgment.
+
+Decision: reject. This path preserves safety but does not improve the business metric.
+
+### Option B: Mutate Or Cleanup Stale Rows
+
+This path marks old `Running` or `Pending` records terminal, deletes old market-context rows, or rewrites receipt state
+when the control plane decides a projection is stale.
+
+Advantages:
+
+- Reduces noisy counts quickly.
+- Makes simple dashboards easier to read.
+- Could be implemented as a database maintenance job.
+
+Disadvantages:
+
+- Mutates history without the original owner completing its lifecycle.
+- Risks closing real in-flight work during watch or database lag.
+- Hides provenance that verify and incident reviews need.
+- Violates the read-side nature of the discover evidence gathered here.
+
+Decision: reject. Cleanup is useful only after a typed foreclosure receipt exists.
+
+### Option C: Projection Foreclosure Notary
+
+The selected path adds a read-side notary. It reads live authority, database projections, market-context lifecycle rows,
+and Torghut receipt state, then emits a typed foreclosure verdict. Stale projections stay stored and auditable, but
+their authority expires unless a live owner renews them.
+
+Advantages:
+
+- Preserves evidence while removing stale authority.
+- Gives ready truth and stage credit one typed explanation for stale active claims.
+- Lets implementation reduce manual repair loops before deleting any row.
+- Creates a Torghut handoff that separates observe-mode evidence from capital-adjacent route custody.
+
+Disadvantages:
+
+- Adds another status object and test surface.
+- Requires careful grace periods to avoid foreclosing legitimate long-running work.
+- Needs Torghut companion receipts before paper or live capital can consume the verdict.
+
+Decision: select Option C.
+
+## Architecture
+
+The projection foreclosure notary is a control-plane reducer. It does not own scheduling, cleanup, or trading. It owns
+the statement of whether a projected claim is still authoritative.
+
+```text
+projection_foreclosure_notary
+  schema_version = jangar.projection-foreclosure-notary.v1
+  generated_at
+  namespace
+  source_revision
+  decision = allow | observe_only | repair_only | hold
+  active_authority_summary
+  stale_projection_summary
+  stage_custody_verdict
+  claims[]
+  foreclosure_receipts[]
+  missing_receipts[]
+  required_repair_actions[]
+```
+
+Each claim records:
+
+```text
+projection_claim
+  claim_id
+  claim_class
+  source_ref
+  source_owner
+  lane
+  status
+  observed_at
+  last_heartbeat_at
+  fresh_until
+  live_authority_ref
+  projection_ref
+  authority_state
+  reason_codes[]
+  value_gates[]
+```
+
+Initial `claim_class` values:
+
+- `agentrun_execution`: a Jangar DB `agent_runs` projection compared to live AgentRun, Job, and Pod authority;
+- `workflow_schedule`: a CronJob or schedule-template projection compared to the currently launched AgentRun;
+- `market_context_fundamentals`: a fundamentals run or snapshot freshness projection;
+- `market_context_news`: a news run or snapshot freshness projection;
+- `torghut_route_custody`: a Torghut route, TCA, and repair receipt projection;
+- `source_rollout_truth`: a source revision, image, deployment, and status-route projection;
+- `stage_clearance`: an AgentRun stage annotation compared to the latest lane-local clearance packet.
+
+Initial `authority_state` values:
+
+- `authoritative`: live source, projection row, and freshness budget agree;
+- `grace`: live source is still within a configured renewal budget;
+- `stale_foreclosed`: projection exists but its owner did not renew inside the budget;
+- `contradictory`: two current surfaces disagree and material action must hold;
+- `missing_receipt`: a claim requires a typed receipt that does not exist;
+- `terminal_audit`: old terminal evidence is preserved but cannot block current launch by itself;
+- `unknown`: the notary could not inspect the required source and must hold material action.
+
+The notary starts with read-only evidence. It can be implemented without database mutation by deriving claims from the
+same readers that already feed `control-plane-status`, terminal debt compaction, stage credit, and Torghut stage
+custody.
+
+## Authority Budgets
+
+Authority budgets must be explicit and lane-local. The first implementation should use conservative defaults and expose
+them in status output:
+
+- `agentrun_execution` claims are stale-foreclosed when a Jangar DB `Running` or `Pending` row is older than the
+  larger of the AgentRun requested timeout, two schedule intervals, or six hours, and there is no matching live
+  Kubernetes AgentRun or Job in a non-terminal phase.
+- `workflow_schedule` claims are stale-foreclosed when a CronJob launched work, the schedule template has not changed,
+  and the corresponding AgentRun is terminal or missing past its configured schedule interval plus grace.
+- `market_context_fundamentals` claims are stale-foreclosed when `running` or `started` rows exceed their domain
+  freshness SLO and newer snapshots cannot be tied to a completed run receipt.
+- `market_context_news` claims are stale-foreclosed independently from fundamentals. A fresh news article timestamp
+  cannot renew a stale fundamentals claim, and a fresh fundamentals snapshot cannot renew stale news ingestion.
+- `torghut_route_custody` claims are stale-foreclosed when route evidence depends on receipts such as
+  `torghut.execution-tca-refresh-receipt.v1` or `torghut.market-context-freshness-receipt.v1` and those receipts are
+  absent, expired, or not bound to the current account/window.
+- `source_rollout_truth` claims are contradictory rather than stale when source revision, running image, and status
+  route disagree inside the active rollout window.
+
+Budgets are not global. Discover, plan, implement, and verify can carry different grace periods because their cost of
+staleness differs. Capital-adjacent Torghut claims get the strictest budget.
+
+## Control-Plane Contracts
+
+### Stage Credit
+
+`control-plane-stage-credit-ledger` must consume the notary before issuing a stage account verdict.
+
+- `stale_foreclosed` projections do not burn active stage credit by themselves.
+- `contradictory`, `missing_receipt`, and `unknown` projections keep material stage credit in `hold`.
+- A stage can launch observe-mode work when all material blockers are either `terminal_audit` or
+  `stale_foreclosed`, and the lane has enough runner capacity.
+- A stage cannot promote paper/live capital-adjacent work until Torghut route custody has current receipts for every
+  required route dependency.
+
+### Ready Truth
+
+`control-plane-ready-truth-arbiter` must report projection authority separately from service health.
+
+- Service health can be green while projection authority is `repair_only`.
+- `/ready` should stay conservative for material serving semantics, but the status route must identify whether the
+  readiness hold is caused by live service failure, stale projection custody, missing receipts, or rollout
+  contradiction.
+- The ready truth payload should include `projection_foreclosure_notary.decision`, `claim_totals_by_state`, and the
+  top repair actions.
+
+### Terminal Debt Compaction
+
+Terminal debt compaction must link retained failed AgentRuns, jobs, and pods to notary receipts.
+
+- A retained terminal object stays audit-visible.
+- A failed repair run that did not retire a reason code becomes active debt until it emits a no-delta receipt.
+- Old terminal debt can become `terminal_audit` only when no live projection points at it as current authority.
+
+### Torghut Stage Custody
+
+Torghut stage custody must stop treating "segment projected healthy" as sufficient for capital-adjacent work.
+
+- Observe-mode market-context work can continue when stale projections are foreclosed and repair actions are named.
+- Paper/live capital and promotion require current route-custody receipts bound to account, window, hypothesis, and
+  data domain.
+- Empty `evidence_epochs` or `evidence_receipts` tables must be represented as `missing_receipt`, not as generic
+  degraded readiness.
+
+## Implementation Milestones
+
+### Milestone 1: Notary Reader And Schema
+
+Value gates: `ready_status_truth`, `handoff_evidence_quality`, `manual_intervention_count`.
+
+- Add `control-plane-projection-foreclosure-notary.ts`.
+- Define claim and receipt types in the local Jangar status domain.
+- Read AgentRun DB projections, live AgentRun/Job authority, market-context run rows, Torghut route custody, and source
+  rollout truth without mutating those sources.
+- Add fixtures for old `Running`, old `Pending`, current live run, stale market-context run, missing Torghut receipt,
+  and current route receipt.
+- Unit tests must prove that stale rows remain visible but lose authority.
+
+### Milestone 2: Stage Credit And Ready Truth Consumption
+
+Value gates: `failed_agentrun_rate`, `pr_to_rollout_latency`, `ready_status_truth`.
+
+- Wire the notary into stage credit and ready truth.
+- Split active blockers from stale-foreclosed projections in the status route.
+- Add regression tests where old `Running` DB rows no longer force a material hold after live authority is terminal or
+  absent.
+- Add regression tests where missing Torghut receipts still hold capital-adjacent work even when service health is OK.
+
+### Milestone 3: Market-Context Foreclosure
+
+Value gates: `failed_agentrun_rate`, `manual_intervention_count`, `ready_status_truth`.
+
+- Add market-context domain budgets for fundamentals and news.
+- Require completed run receipts before stale `running` or `started` rows can be marked foreclosed.
+- Emit domain-specific repair actions: fundamentals repair, news repair, or cross-domain receipt reconciliation.
+- Add tests around stale fundamentals with fresh news, stale news with fresh fundamentals, and both stale.
+
+### Milestone 4: Torghut Route-Custody Receipt Bridge
+
+Value gates: `failed_agentrun_rate`, `ready_status_truth`, `handoff_evidence_quality`.
+
+- Consume the companion Torghut stale projection foreclosure ledger.
+- Require `torghut.execution-tca-refresh-receipt.v1` and
+  `torghut.market-context-freshness-receipt.v1` for route-custody promotion.
+- Keep observe-mode repair dispatch allowed when receipts are missing but repair lots are explicit.
+- Add tests proving `max_notional=0` remains enforced through missing-receipt states.
+
+### Milestone 5: Deployer Cutover
+
+Value gates: `pr_to_rollout_latency`, `manual_intervention_count`, `handoff_evidence_quality`.
+
+- Update deployer runbooks to check the projection notary, not raw stale row counts, before declaring a rollout
+  healthy.
+- Verify after rollout: Argo healthy, workload readiness healthy or explicitly held by projection custody, Jangar
+  `/health`, Jangar status route, Torghut `/db-check`, Torghut `/readyz`, and Torghut route-custody receipts.
+- Record before/after counts for stale active projections and repeated repair runs.
+
+## Validation Gates
+
+The engineer stage is not complete until these checks pass:
+
+- Unit tests for the notary claim classifier.
+- Unit tests for stage credit and ready truth consumption.
+- Regression tests for stale Jangar `agent_runs` rows older than the authority budget.
+- Regression tests for stale market-context fundamentals and news rows.
+- Regression tests for missing Torghut route-custody receipts preserving zero-notional safety.
+- `bunx oxfmt --check` on touched TypeScript and Markdown paths.
+- The relevant Jangar test command from the nearest package or service README.
+
+The verify stage is not complete until these runtime checks are recorded:
+
+- Argo reports `jangar`, `agents`, and `torghut` synced and healthy, or the exact non-healthy application and reason.
+- Jangar `/health` is OK.
+- Jangar control-plane status includes `projection_foreclosure_notary` with claim totals by authority state.
+- Stage credit and ready truth name stale projections separately from live service blockers.
+- Torghut `/db-check` is schema-current.
+- Torghut `/readyz` can remain degraded only if the degradation is explained by capital/profit guards and not by
+  unknown projection authority.
+- No paper or live notional is enabled by this change.
+
+## Rollout Plan
+
+1. Ship the notary in observe-only status output with no admission behavior change.
+2. Add stage credit and ready truth consumption behind a configuration flag.
+3. Enable the flag for discover and plan lanes first.
+4. Enable implement and verify once stale projection counts and live authority comparisons match for one full schedule
+   cycle.
+5. Keep Torghut capital-adjacent promotion blocked until the companion route-custody receipt bridge is present.
+
+## Rollback Plan
+
+Rollback is configuration-first:
+
+- disable notary consumption in stage credit and ready truth;
+- keep the status payload emitted for audit if it is not causing failures;
+- fall back to existing terminal debt compaction and stage credit behavior;
+- preserve all foreclosure receipts generated during the rollout for incident review;
+- do not delete or mutate Jangar or Torghut state-store rows during rollback.
+
+If the notary itself causes status-route instability, roll back the deployment image and use the previous design
+contracts: terminal debt compaction, ready truth, and repair outcome escrow.
+
+## Risks And Mitigations
+
+- Risk: foreclosing a legitimate long-running AgentRun. Mitigation: compare DB rows to live Kubernetes authority and
+  use the larger of requested timeout, schedule interval, and a six-hour default before foreclosure.
+- Risk: hiding a real market-context outage. Mitigation: domain-specific foreclosure keeps fundamentals and news
+  separate and requires completed receipts before stale rows lose authority.
+- Risk: deployers read `stale_foreclosed` as fixed. Mitigation: status wording must say preserved, non-authoritative,
+  and repair-required when a receipt is missing.
+- Risk: Torghut route custody becomes more restrictive. Mitigation: observe-mode repair stays allowed, but paper/live
+  capital remains blocked until current receipts exist.
+- Risk: additional status complexity slows implementation. Mitigation: implement the notary as a narrow reducer first,
+  then wire consumers in later milestones.
+
+## Handoff To Engineer
+
+Build the notary as a small reducer with strong fixtures before touching scheduler behavior. The first production PR
+should not mutate database rows or delete Kubernetes objects. It should make stale projection authority visible and
+testable, then feed that verdict into ready truth and stage credit behind a safe flag.
+
+Acceptance gates:
+
+- stale Jangar `agent_runs.running` rows older than the authority budget produce `stale_foreclosed` claims;
+- live Kubernetes AgentRuns inside their timeout remain `authoritative` or `grace`;
+- missing Torghut receipts produce `missing_receipt` and keep capital-adjacent work held;
+- old terminal objects remain audit-visible;
+- tests cover each authority state.
+
+## Handoff To Deployer
+
+Deployers should stop using raw retained failure or stale row counts as the rollout truth once this lands. Use the
+notary verdict to decide whether a rollout is healthy, held by live blockers, or held by stale projection custody.
+
+Rollout acceptance gates:
+
+- Argo and deployments are healthy for `jangar`, `agents`, and `torghut`;
+- Jangar status route emits the notary payload;
+- no stale projection is treated as authoritative without a live owner or fresh receipt;
+- Torghut route custody remains `repair_only` with `max_notional=0` until required receipts are current;
+- handoff evidence records the control-plane metric improved: lower manual interpretation count, lower repeated repair
+  AgentRun rate, or the exact stale projection blocker that prevented improvement.

--- a/docs/torghut/design-system/v6/195-torghut-stale-projection-foreclosure-and-route-custody-2026-05-13.md
+++ b/docs/torghut/design-system/v6/195-torghut-stale-projection-foreclosure-and-route-custody-2026-05-13.md
@@ -1,0 +1,413 @@
+# 195. Torghut Stale Projection Foreclosure And Route Custody (2026-05-13)
+
+Status: Accepted for Jangar engineer and deployer handoff
+Date: 2026-05-13
+Owner: Victor Chen, Jangar Engineering Architecture
+Scope: Torghut stale market, route, execution, and repair receipt projections; Jangar projection foreclosure notary
+integration; zero-notional route custody; measurable trading hypotheses; validation; rollout; rollback; and handoff.
+
+Companion Jangar contract:
+
+- `docs/agents/designs/190-jangar-projection-foreclosure-notary-and-stage-custody-repair-2026-05-13.md`
+
+Extends:
+
+- `193-torghut-repair-outcome-dividend-ledger-and-capital-reentry-frontier-2026-05-13.md`
+- `193-torghut-route-repair-yield-board-and-hypothesis-reentry-guardrails-2026-05-13.md`
+- `192-torghut-freshness-carry-and-repair-proof-slo-2026-05-13.md`
+- `192-torghut-typed-consumer-evidence-route-and-capital-safe-repair-dispatch-2026-05-13.md`
+- `127-torghut-market-context-claims-and-lane-profit-settlement-2026-05-06.md`
+
+## Decision
+
+I am selecting a **stale projection foreclosure ledger** for Torghut route custody.
+
+Torghut is not failing as a service. On 2026-05-13, `/readyz` returned `status=degraded`, but the dependency picture was
+specific: scheduler OK, Postgres OK, ClickHouse OK, Alpaca broker OK, schema current at
+`0031_autoresearch_candidate_spec_epoch_uniqueness`, universe loaded with `8` static symbols, and empirical jobs
+healthy. The degradation was capital and proof-floor related: live submission blocked by `simple_submit_disabled`,
+capital stage `shadow`, profitability proof floor `repair_only`, promotion eligible hypotheses `0`, and
+`ta-core` blocked by `signal_lag_exceeded`.
+
+The state-store evidence showed why Jangar cannot treat projected health as route authority. Torghut TCA was active
+with `13775` metrics and newest computed timestamp `2026-05-13T15:29:49Z`, options watermarks were current, and
+empirical job runs were present. At the same time, Torghut `evidence_epochs` and `evidence_receipts` were empty, filled
+execution state was stale at `2026-04-02`, and route custody required receipt classes that were not yet present. From
+Jangar's side, market-context rows carried stale `running` and `started` projections even while newer snapshots existed.
+
+The selected design preserves zero-notional repair. It does not promote paper or live capital. It adds a ledger that
+classifies Torghut projections as current, stale-foreclosed, missing-receipt, contradictory, or terminal-audit before
+Jangar may use them for stage custody, repair dispatch priority, or any future capital-adjacent gate.
+
+The tradeoff is that Torghut will expose less optimistic route health. That is the right tradeoff. A route that has
+fresh TCA but missing receipts is useful for repair, not for promotion.
+
+## Governing Runtime Requirements
+
+This companion contract follows the Jangar swarm validation contract:
+
+- every run must cite the governing design or runtime requirement before changing code;
+- implement stages must produce production PRs with tests or report the exact blocker to code;
+- verify stages must merge only green PRs and prove Argo, workload readiness, and service health after rollout;
+- final handoff must name the control-plane metric improved or the smallest blocker preventing improvement.
+
+Torghut value gates for this contract:
+
+- `zero_notional_or_stale_evidence_rate`
+- `routeable_candidate_count`
+- `fill_tca_or_slippage_quality`
+- `post_cost_daily_net_pnl`
+- `capital_gate_safety`
+
+Jangar cross-plane value gates affected by this contract:
+
+- `failed_agentrun_rate`
+- `pr_to_rollout_latency`
+- `ready_status_truth`
+- `manual_intervention_count`
+- `handoff_evidence_quality`
+
+## Current Evidence
+
+Evidence was collected read-only on 2026-05-13.
+
+- Torghut deployments were ready after the current rollout. Older Knative revisions remained scaled down.
+- Torghut `/db-check` returned schema current with expected and current head
+  `0031_autoresearch_candidate_spec_epoch_uniqueness`, no missing heads, no unexpected heads, and lineage ready with
+  only known parent-fork warnings.
+- Torghut `/readyz` returned HTTP `503` and `status=degraded`.
+- Scheduler, Postgres, ClickHouse, Alpaca, universe, database, and empirical jobs were OK.
+- Live submission was blocked by `simple_submit_disabled`; capital stage was `shadow`; capital state was
+  `zero_notional`; profitability proof floor was `repair_only`.
+- `alpha_readiness` showed `3` shadow hypotheses, `0` promotion eligible, and `2` rollback required.
+- Segment summary showed empirical, execution, llm-review, and market-context OK, while `ta-core` was blocked by
+  `signal_lag_exceeded`.
+- Torghut Postgres `trade_decisions` summarized to `69909` rejected decisions, newest `2026-05-04`, and `63665`
+  blocked decisions, newest `2026-05-13T15:26Z`.
+- Torghut `executions` had `13555` filled rows, but newest update was `2026-04-02`. The current route must therefore
+  distinguish fresh analysis from stale fill evidence.
+- Torghut `execution_tca_metrics` had `13775` rows, newest computed `2026-05-13T15:29:49Z`, and observed slippage
+  range from about `-302.83` bps to `609.20` bps.
+- Torghut `evidence_epochs` and `evidence_receipts` were empty.
+- Torghut `autoresearch_candidate_specs` had `342` eligible candidates and latest autoresearch epoch status
+  `no_profit_target_candidate`.
+- Torghut `vnext_empirical_job_runs` had `32` completed rows marked promotion-authority eligible, newest
+  `2026-05-13T04:24:33Z`.
+- Torghut options watermarks were current for `7198` contract-symbol rows, newest success `2026-05-13T16:14:03Z`, and
+  maximum retry count `0`.
+- Jangar route custody saw repair-only evidence and required receipt classes including
+  `torghut.execution-tca-refresh-receipt.v1` and `torghut.market-context-freshness-receipt.v1`.
+
+## Problem
+
+Torghut has enough evidence to do useful zero-notional repair work, but not enough settled receipt evidence to promote
+routes or let Jangar stage custody consider route projections current.
+
+The concrete failure modes are:
+
+1. A route can show a healthy segment summary while its required receipt ledger is empty.
+2. Fresh TCA metrics can coexist with stale fill execution evidence.
+3. Market-context snapshots can be recent in aggregate while individual domain run projections remain stale.
+4. Repair lots can be dispatched repeatedly when the missing receipt is the real blocker.
+5. Jangar can block on broad `market_context_stale` or `route_stability_hold` reason codes without knowing which
+   Torghut projection lost authority.
+6. Trading hypotheses remain shadow-only because route custody cannot prove which blockers were retired.
+
+## Alternatives Considered
+
+### Option A: Treat Segment Health As Route Authority
+
+This path allows a route segment marked OK in `/readyz` or consumer evidence to satisfy Jangar route custody.
+
+Advantages:
+
+- Simple to consume.
+- Keeps the route surface optimistic.
+- Avoids new receipt work.
+
+Disadvantages:
+
+- Hides missing receipt ledgers.
+- Lets fresh snapshots mask stale domain projections.
+- Does not explain why promotion eligibility is still zero.
+- Could pressure Jangar to release capital-adjacent work without proof.
+
+Decision: reject. Segment health is not enough for route authority.
+
+### Option B: Freeze All Route Repair Until Receipts Exist
+
+This path blocks Torghut repair dispatch until every receipt table and route proof is populated.
+
+Advantages:
+
+- Maximally conservative for capital safety.
+- Easy to explain.
+- Prevents repeated no-delta repair runs.
+
+Disadvantages:
+
+- Creates deadlock because repair lanes are how receipts get produced.
+- Wastes the fresh TCA, options, and empirical signals already available.
+- Increases manual intervention.
+
+Decision: reject. Zero-notional repair must stay available.
+
+### Option C: Stale Projection Foreclosure Ledger
+
+The selected path emits a route-custody ledger that separates current route authority from stale or missing projection
+authority. Repair stays allowed when explicitly zero-notional, but promotion remains blocked until current receipts
+exist.
+
+Advantages:
+
+- Makes Jangar stage custody deterministic.
+- Preserves observe-mode repair throughput.
+- Converts stale or missing projections into named repair actions.
+- Gives trading hypotheses a clear path from repair-only to paper candidate.
+
+Disadvantages:
+
+- Adds schema, endpoint, and test work.
+- Can make current readiness look worse by exposing missing receipts directly.
+- Requires careful account/window binding for every receipt.
+
+Decision: select Option C.
+
+## Architecture
+
+Torghut emits `stale_projection_foreclosure_ledger` through `/trading/consumer-evidence` first, then optionally
+`/readyz` and `/trading/health` once the payload is stable.
+
+```text
+stale_projection_foreclosure_ledger
+  schema_version = torghut.stale-projection-foreclosure-ledger.v1
+  generated_at
+  fresh_until
+  account
+  window
+  capital_stage = shadow
+  max_notional = 0
+  route_custody_decision = current | repair_only | hold
+  projection_claims[]
+  foreclosure_receipts[]
+  missing_receipts[]
+  required_repair_actions[]
+  hypothesis_impacts[]
+```
+
+Each projection claim records:
+
+```text
+torghut_projection_claim
+  claim_id
+  claim_class
+  source_ref
+  account
+  window
+  hypothesis_id
+  strategy_id
+  observed_at
+  fresh_until
+  authority_state
+  reason_codes[]
+  value_gates[]
+  required_receipt_schema
+  repair_lot_id
+```
+
+Initial `claim_class` values:
+
+- `market_context_fundamentals`: fundamentals freshness, snapshot quality, and completed-run receipt;
+- `market_context_news`: news freshness, ingestion watermark, and completed-run receipt;
+- `execution_tca`: TCA metric recency and route-level slippage guardrail;
+- `execution_fill_sample`: filled execution sample recency and order lifecycle evidence;
+- `empirical_job`: empirical job completion and promotion-authority eligibility;
+- `research_candidate`: autoresearch candidate and promotion table proof;
+- `route_custody_receipt`: the receipt that binds the above claims into a Jangar-consumable route verdict.
+
+Initial `authority_state` values:
+
+- `authoritative`: required source and receipt are current for account, window, and hypothesis;
+- `repair_only`: source is useful for zero-notional repair but cannot support promotion;
+- `stale_foreclosed`: source exists but exceeded its freshness or renewal budget;
+- `missing_receipt`: source may be present, but required receipt schema is absent;
+- `contradictory`: current sources disagree;
+- `terminal_audit`: old terminal evidence is retained for review but cannot renew route authority;
+- `unknown`: Torghut could not inspect the source.
+
+## Route Custody Rules
+
+The ledger must enforce these route rules:
+
+- `max_notional` remains `0` for all `repair_only`, `stale_foreclosed`, `missing_receipt`, `contradictory`, and
+  `unknown` states.
+- A fresh segment summary cannot renew a missing receipt.
+- A fresh TCA metric cannot renew stale fill execution evidence.
+- Fresh news cannot renew stale fundamentals, and fresh fundamentals cannot renew stale news.
+- Empirical job eligibility can support repair priority, but it cannot promote a hypothesis without route-custody
+  receipts.
+- A repair lot may be dispatchable only when it names the expected receipt schema and the reason code it is expected to
+  retire.
+- A repeated repair lot without a new receipt becomes no-delta debt for Jangar terminal compaction.
+
+## Measurable Trading Hypotheses
+
+This contract does not invent a new trading strategy. It turns current Torghut blockers into measurable promotion
+hypotheses:
+
+1. **TCA receipt repair hypothesis**: if `torghut.execution-tca-refresh-receipt.v1` is produced for the active account
+   and 15 minute window, route custody can retire `tca_evidence_stale` and reduce repair-only rejections without
+   increasing slippage guardrail breaches.
+2. **Market-context receipt repair hypothesis**: if fundamentals and news receipts are produced independently, the
+   route can retire `market_context_stale` without letting one domain mask the other.
+3. **Fill-sample evidence hypothesis**: if fresh fill or paper-fill sample receipts are bound to execution TCA,
+   `active_session_execution_samples_stale` can be replaced by a measured execution-quality verdict.
+4. **Research promotion evidence hypothesis**: if autoresearch candidates produce current promotion receipts,
+   `research_candidates_empty`, `research_promotions_empty`, and `vnext_promotion_decisions_empty` can become
+   hypothesis-scoped repair outcomes instead of global route blockers.
+
+Each hypothesis must be evaluated with zero notional until capital contracts outside this document authorize a wider
+stage.
+
+## Jangar Integration
+
+Jangar consumes the ledger through the projection foreclosure notary.
+
+- `missing_receipt` becomes a Jangar `torghut_route_custody` claim with material action `hold` for paper/live and
+  `repair_only` for zero-notional repair.
+- `stale_foreclosed` becomes a named repair action and cannot be counted as a current healthy projection.
+- `authoritative` can satisfy route custody only when account, window, hypothesis, and receipt schema match the current
+  Jangar stage.
+- `terminal_audit` can inform incident review but cannot block a clean current rollout by itself.
+- `unknown` holds material action because Jangar cannot prove safety.
+
+The first integration should be read-only and additive. It should not change broker submission flags, order routing, or
+capital limits.
+
+## Implementation Milestones
+
+### Milestone 1: Ledger Payload And Fixtures
+
+Value gates: `capital_gate_safety`, `handoff_evidence_quality`, `ready_status_truth`.
+
+- Add typed ledger schema to Torghut consumer-evidence payloads.
+- Build fixtures for fresh TCA with missing receipt, stale fill sample, fresh options watermark, stale market-context
+  domain, and current empirical job.
+- Prove `max_notional=0` is emitted for every non-authoritative state.
+
+### Milestone 2: Receipt Binding
+
+Value gates: `zero_notional_or_stale_evidence_rate`, `routeable_candidate_count`, `manual_intervention_count`.
+
+- Bind TCA, market-context, fill-sample, empirical, and research candidate claims to receipt schemas.
+- Emit explicit missing receipt records for empty `evidence_epochs` and `evidence_receipts`.
+- Add tests that fresh source data without receipts remains repair-only.
+
+### Milestone 3: Repair Lot Prioritization
+
+Value gates: `failed_agentrun_rate`, `routeable_candidate_count`, `fill_tca_or_slippage_quality`.
+
+- Prioritize repair lots by expected receipt and reason-code delta.
+- Mark repeated lots without new receipts as no-delta debt.
+- Preserve dispatch only for zero-notional repair work.
+
+### Milestone 4: Jangar Consumption
+
+Value gates: `ready_status_truth`, `pr_to_rollout_latency`, `handoff_evidence_quality`.
+
+- Feed the ledger into Jangar projection foreclosure notary.
+- Expose route custody claim totals by authority state.
+- Ensure stage credit and ready truth separate Torghut missing receipts from live service failure.
+
+### Milestone 5: Deployer Verification
+
+Value gates: `manual_intervention_count`, `capital_gate_safety`, `post_cost_daily_net_pnl`.
+
+- Verify Torghut `/db-check`, `/readyz`, and `/trading/consumer-evidence` after rollout.
+- Verify Jangar status consumes the ledger and keeps capital-adjacent work held.
+- Record which receipt blocker prevents paper promotion, or which receipt was produced and which reason code retired.
+
+## Validation Gates
+
+The engineer stage is not complete until:
+
+- unit tests cover every `authority_state`;
+- endpoint tests prove `max_notional=0` for repair-only, missing receipt, stale, contradictory, and unknown states;
+- tests prove fresh TCA without a receipt cannot satisfy route authority;
+- tests prove fresh news cannot renew stale fundamentals and fresh fundamentals cannot renew stale news;
+- tests prove a repeated repair lot without a new receipt is surfaced as no-delta debt;
+- formatting and relevant Torghut checks pass.
+
+The verify stage is not complete until:
+
+- Torghut schema is current at the expected Alembic head;
+- Torghut readiness degradation is explained by named capital/proof guards rather than unknown route authority;
+- Jangar status receives the ledger and reports route-custody claim totals;
+- repair dispatch remains zero-notional;
+- no paper/live capital gate opens because of this change;
+- the handoff names the specific receipt blocker or retired reason code.
+
+## Rollout Plan
+
+1. Emit the ledger in consumer evidence as observe-only metadata.
+2. Add Jangar read-side consumption while keeping existing route-custody decisions unchanged.
+3. Enable Jangar stage custody to use missing-receipt and stale-foreclosed states for explanation.
+4. Let repair lot prioritization use the ledger after one clean schedule cycle.
+5. Defer any paper/live promotion change to a separate capital proof PR.
+
+## Rollback Plan
+
+Rollback is safe because this design is additive and zero-notional:
+
+- remove the ledger from Jangar consumption first;
+- keep Torghut emitting it for audit if endpoint compatibility is stable;
+- fall back to the previous consumer-evidence route-custody payload;
+- keep `simple_submit_disabled`, `capital_stage=shadow`, and `max_notional=0`;
+- preserve any emitted receipts for incident review.
+
+If the ledger destabilizes Torghut readiness, roll back the serving image and use the previous repair outcome dividend
+ledger until the endpoint tests are fixed.
+
+## Risks And Mitigations
+
+- Risk: route custody becomes harder to satisfy. Mitigation: that is acceptable for paper/live; zero-notional repair
+  stays available.
+- Risk: receipt schemas drift between Jangar and Torghut. Mitigation: schema names are explicit and must be tested in
+  both services before stage custody consumes them.
+- Risk: old fill evidence blocks all progress. Mitigation: classify stale fill evidence as repair-only and give it a
+  specific receipt target instead of a global route hold.
+- Risk: market-context domains mask each other. Mitigation: fundamentals and news have independent claims and cannot
+  renew each other.
+- Risk: operators confuse degraded readiness with broken infrastructure. Mitigation: `/readyz` and Jangar status must
+  distinguish healthy dependencies from capital/proof-floor holds.
+
+## Handoff To Engineer
+
+Implement the ledger as an additive endpoint payload first. Do not change order submission, broker flags, notional
+limits, or capital stage. The first PR should make stale route projections visible, bind missing receipts to repair
+lots, and prove zero-notional safety with tests.
+
+Acceptance gates:
+
+- `evidence_epochs` or `evidence_receipts` empty produces `missing_receipt`;
+- fresh TCA without the required receipt remains `repair_only`;
+- stale fill evidence is separate from TCA freshness;
+- fundamentals and news claims are independent;
+- every non-authoritative claim emits `max_notional=0`;
+- repeated no-receipt repair lots become no-delta debt.
+
+## Handoff To Deployer
+
+After deployment, treat Torghut `status=degraded` as actionable only after checking the ledger. If infrastructure
+dependencies are healthy and the ledger says missing receipt or stale-foreclosed, the system is in controlled repair,
+not serving failure. Keep capital closed until the ledger reports authoritative route custody for the current account,
+window, hypothesis, and receipt schema.
+
+Rollout acceptance gates:
+
+- `/db-check` schema current;
+- `/readyz` dependency health recorded;
+- `/trading/consumer-evidence` includes the stale projection foreclosure ledger;
+- Jangar projection notary consumes the ledger;
+- `max_notional=0` preserved;
+- handoff names either the receipt blocker or the retired reason code.

--- a/docs/torghut/design-system/v6/index.md
+++ b/docs/torghut/design-system/v6/index.md
@@ -12,6 +12,8 @@
 - Implementation status (strict, core 01-13 docs, source-state refresh `2026-03-09`): `Implemented=7`, `Partial=5`, `Completed=1`
 - Evidence (historical closure): `13-production-gap-closure-master-plan-2026-03-03.md` (Wave 0-6 closure + DoD)
 - Evidence (current next-work priority, refreshed `2026-05-13T12:27Z`):
+  - `195-torghut-stale-projection-foreclosure-and-route-custody-2026-05-13.md`
+  - `docs/agents/designs/190-jangar-projection-foreclosure-notary-and-stage-custody-repair-2026-05-13.md`
   - `193-torghut-route-repair-yield-board-and-hypothesis-reentry-guardrails-2026-05-13.md`
   - `docs/agents/designs/189-jangar-authority-provenance-settlement-and-rollout-reentry-windows-2026-05-13.md`
   - `194-torghut-quant-plan-closeout-and-repair-only-handoff-2026-05-13.md`


### PR DESCRIPTION
## Summary

- Adds the Jangar projection foreclosure notary architecture contract for stale AgentRun, market-context, source rollout, and Torghut route-custody projections.
- Adds the Torghut stale projection foreclosure companion contract with zero-notional route-custody receipt rules and measurable repair hypotheses.
- Updates the Agents and Torghut design indexes so the new contracts are the current next-work priority for engineer and deployer handoff.

## Related Issues

None. This PR fulfills the `jangar-control-plane` discover swarm requirement on branch `codex/swarm-jangar-control-plane-discover`.

## Testing

- PASS: `bunx oxfmt --check docs/agents/README.md docs/agents/designs/190-jangar-projection-foreclosure-notary-and-stage-custody-repair-2026-05-13.md docs/torghut/design-system/v6/index.md docs/torghut/design-system/v6/195-torghut-stale-projection-foreclosure-and-route-custody-2026-05-13.md`
- PASS: `git diff --check`

## Screenshots (if applicable)

N/A. Documentation-only architecture change.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
