### PR TITLE
feat(jangar): stamp evidence pressure scheduler handoffs

### DIFF
--- a/services/jangar/README.md
+++ b/services/jangar/README.md
@@ -429,12 +429,15 @@ Control-plane status and `/ready` also emit `evidence_pressure_ledger` from
 `docs/agents/designs/188-jangar-evidence-pressure-ledger-and-watch-backoff-governor-2026-05-13.md`. The ledger is an
 observe-mode proof-transport budget below stage credit: Kubernetes watch 429s, controller replica splits, metrics-sink
 failures, GitHub review-ingest missing refs, database evidence authority, and Torghut freshness debt become typed
-pressure sources with TTLs, reason codes, and action-class decisions. In observe mode it does not block schedule
-runners, but it already names when `dispatch_normal`, `deploy_widen`, and `merge_ready` would be held while
-`serve_readonly`, `torghut_observe`, and bounded zero-notional repairs remain open. Torghut freshness debt is priced
-from `freshness_carry_ledger.jangar_pressure_refs` when present, so a fresh consumer-evidence receipt can still hold
-normal dispatch if a current zero-notional freshness repair SLO names stale TCA, TA, empirical, market-context, quant,
-or source-serving proof. Rollback is
+pressure sources with TTLs, reason codes, and action-class decisions. Fire-time schedule runners refresh the same
+status payload before creating scheduled AgentRuns and stamp `swarmEvidencePressureLedgerId`,
+`swarmEvidencePressureDecision`, `swarmEvidencePressureReasonCodes`, and the watch backoff state on the launch. In
+`observe` or `shadow` mode the runner records pressure as handoff evidence only; when
+`JANGAR_EVIDENCE_PRESSURE_LEDGER_MODE=hold` or `enforce`, stale ledgers or held `dispatch_normal` budgets fail closed
+before AgentRun creation while read-only status serving remains separate. Torghut freshness debt is priced from
+`freshness_carry_ledger.jangar_pressure_refs` when present, so a fresh consumer-evidence receipt can still hold normal
+dispatch if a current zero-notional freshness repair SLO names stale TCA, TA, empirical, market-context, quant, or
+source-serving proof. Rollback is
 `JANGAR_EVIDENCE_PRESSURE_LEDGER_MODE=observe`; if the payload itself regresses status generation, set
 `JANGAR_EVIDENCE_PRESSURE_LEDGER_ENABLED=false` and continue relying on stage credit, ready-truth, clearance market,
 source-serving verdicts, and runtime-admission passports.

--- a/services/jangar/src/server/__tests__/supporting-primitives-controller.test.ts
+++ b/services/jangar/src/server/__tests__/supporting-primitives-controller.test.ts
@@ -333,10 +333,55 @@ const buildStageCreditSnapshot = (
   }
 }
 
+const buildEvidencePressureLedger = (
+  decision: 'allow' | 'repair_only' | 'hold' | 'block' = 'allow',
+  evidenceMode: 'observe' | 'shadow' | 'hold' | 'enforce' = 'shadow',
+  freshUntil = '2026-01-20T00:05:00.000Z',
+) => ({
+  ledger_id: 'evidence-pressure-ledger:agents:test',
+  evidence_mode: evidenceMode,
+  fresh_until: freshUntil,
+  watch_backoff_policy: {
+    state: decision === 'allow' ? 'calm' : 'pressured',
+  },
+  action_pressure_budget: [
+    {
+      action_class: 'dispatch_normal' as ActionSloBudgetActionClass,
+      decision,
+      reason_codes: decision === 'allow' ? [] : ['kubernetes_watch_rate_limited'],
+      required_repair_receipts: decision === 'repair_only' ? ['repair-receipt:watch'] : [],
+    },
+  ],
+})
+
+const buildEvidencePressureSnapshot = (
+  decision: 'allow' | 'repair_only' | 'hold' | 'block' = 'allow',
+  evidenceMode: 'observe' | 'shadow' | 'hold' | 'enforce' = 'shadow',
+  freshUntil = '2026-01-20T00:05:00.000Z',
+) => {
+  const ledger = buildEvidencePressureLedger(decision, evidenceMode, freshUntil)
+  const budget = ledger.action_pressure_budget[0]
+  return {
+    ledgerId: ledger.ledger_id,
+    evidenceMode: ledger.evidence_mode,
+    freshUntil: ledger.fresh_until,
+    watchBackoffState: ledger.watch_backoff_policy.state,
+    budgets: [
+      {
+        actionClass: budget.action_class,
+        decision: budget.decision,
+        reasonCodes: budget.reason_codes,
+        requiredRepairReceipts: budget.required_repair_receipts,
+      },
+    ],
+  }
+}
+
 const mockStageClearanceStatus = (
   packets: Array<Record<string, unknown>>,
   clearanceMarketLedger?: Record<string, unknown>,
   stageCreditLedger?: Record<string, unknown>,
+  evidencePressureLedger?: Record<string, unknown>,
 ) =>
   vi.spyOn(globalThis, 'fetch').mockResolvedValue(
     new Response(
@@ -344,6 +389,7 @@ const mockStageClearanceStatus = (
         stage_clearance_packets: packets,
         clearance_market_ledger: clearanceMarketLedger,
         stage_credit_ledger: stageCreditLedger,
+        evidence_pressure_ledger: evidencePressureLedger,
       }),
       {
         status: 200,
@@ -523,13 +569,16 @@ describe('supporting primitives controller', () => {
     expect(command).toContain('JANGAR_SWARM_RUNTIME_PROOF_ENFORCEMENT')
     expect(command).toContain('JANGAR_SCHEDULE_RUNNER_ADMISSION_STATUS_URL')
     expect(command).toContain('JANGAR_STAGE_CLEARANCE_ENFORCEMENT')
+    expect(command).toContain('JANGAR_EVIDENCE_PRESSURE_LEDGER_MODE')
     expect(command).toContain('missing schedule admission passport annotation for')
     expect(command).toContain('stage_clearance_packets')
     expect(command).toContain('clearance_market_ledger')
     expect(command).toContain('stage_credit_ledger')
+    expect(command).toContain('evidence_pressure_ledger')
     expect(command).toContain('current stage clearance packet')
     expect(command).toContain('current clearance market stage admission')
     expect(command).toContain('current stage credit account')
+    expect(command).toContain('current evidence pressure budget')
     expect(command).toContain('runner slot future')
     expect(command).toContain('stage clearance shadow evidence unavailable')
     expect(command).not.toContain('stale schedule admission passport')
@@ -551,6 +600,9 @@ describe('supporting primitives controller', () => {
     expect(command).toContain('writeNestedRecordValue(manifest, ["spec", "parameters"], "swarmStageCreditLedgerId"')
     expect(command).toContain('writeNestedRecordValue(manifest, ["spec", "parameters"], "swarmStageCreditAccountId"')
     expect(command).toContain('writeNestedRecordValue(manifest, ["spec", "parameters"], "swarmRunnerSlotFutureId"')
+    expect(command).toContain(
+      'writeNestedRecordValue(manifest, ["spec", "parameters"], "swarmEvidencePressureLedgerId"',
+    )
     expect(command).toContain('writeNestedRecordValue(manifest, ["spec", "parameters"], "swarmRecoveryWarrantId"')
     expect(command).toContain('writeNestedRecordValue(manifest, ["spec", "parameters"], "swarmRuntimeKitSetDigest"')
     expect(command).toContain('current schedule recovery warrant')
@@ -645,6 +697,75 @@ describe('supporting primitives controller', () => {
     })
     expect(admission.parameters).not.toHaveProperty('swarmRunnerSlotFutureId')
     expect(admission.annotations).not.toHaveProperty('swarm.proompteng.ai/runner-slot-future-id')
+  })
+
+  it('stamps evidence pressure ledger handoff fields into launch traces', () => {
+    const admission = resolveStageClearanceAdmissionFromPackets({
+      namespace: 'agents',
+      swarmName: 'jangar-control-plane',
+      stage: 'implement',
+      mode: 'hold',
+      packets: [buildStageClearancePacket('implement')],
+      clearanceMarket: {
+        clearanceMarketLedgerId: 'clearance-market:agents:test',
+        stageAdmissions: buildClearanceMarketLedger('implement').stage_admission,
+        stageCredit: buildStageCreditSnapshot('implement'),
+        evidencePressure: buildEvidencePressureSnapshot('hold', 'shadow'),
+      },
+      nowMs: Date.parse('2026-01-20T00:00:00.000Z'),
+    })
+
+    expect(admission.admitted).toBe(true)
+    expect(admission.evidencePressure).toMatchObject({
+      ledgerId: 'evidence-pressure-ledger:agents:test',
+      decision: 'hold',
+      mode: 'shadow',
+      reasonCodes: ['kubernetes_watch_rate_limited'],
+      watchBackoffState: 'pressured',
+    })
+    expect(admission.annotations).toMatchObject({
+      'swarm.proompteng.ai/evidence-pressure-ledger-id': 'evidence-pressure-ledger:agents:test',
+      'swarm.proompteng.ai/evidence-pressure-decision': 'hold',
+      'swarm.proompteng.ai/evidence-pressure-mode': 'shadow',
+      'swarm.proompteng.ai/evidence-pressure-reason-codes': 'kubernetes_watch_rate_limited',
+      'swarm.proompteng.ai/evidence-pressure-watch-backoff-state': 'pressured',
+    })
+    expect(admission.parameters).toMatchObject({
+      swarmEvidencePressureLedgerId: 'evidence-pressure-ledger:agents:test',
+      swarmEvidencePressureDecision: 'hold',
+      swarmEvidencePressureMode: 'shadow',
+      swarmEvidencePressureReasonCodes: 'kubernetes_watch_rate_limited',
+      swarmEvidencePressureWatchBackoffState: 'pressured',
+    })
+  })
+
+  it('blocks launches when hold-mode evidence pressure holds normal dispatch', () => {
+    const admission = resolveStageClearanceAdmissionFromPackets({
+      namespace: 'agents',
+      swarmName: 'jangar-control-plane',
+      stage: 'verify',
+      mode: 'hold',
+      packets: [buildStageClearancePacket('verify')],
+      clearanceMarket: {
+        clearanceMarketLedgerId: 'clearance-market:agents:test',
+        stageAdmissions: buildClearanceMarketLedger('verify').stage_admission,
+        stageCredit: buildStageCreditSnapshot('verify'),
+        evidencePressure: buildEvidencePressureSnapshot('hold', 'hold'),
+      },
+      nowMs: Date.parse('2026-01-20T00:00:00.000Z'),
+    })
+
+    expect(admission.admitted).toBe(false)
+    expect(admission.reason).toBe('EvidencePressureHeld')
+    expect(admission.message).toContain(
+      'evidence pressure budget evidence-pressure-ledger:agents:test/dispatch_normal is hold',
+    )
+    expect(admission.parameters).toMatchObject({
+      swarmEvidencePressureLedgerId: 'evidence-pressure-ledger:agents:test',
+      swarmEvidencePressureDecision: 'hold',
+      swarmEvidencePressureMode: 'hold',
+      swarmEvidencePressureReasonCodes: 'kubernetes_watch_rate_limited',
+    })
   })
 
   it('staggers hourly stage cadence deterministically per stage', () => {
@@ -1098,6 +1219,7 @@ describe('supporting primitives controller', () => {
         { name: 'JANGAR_SCHEDULE_RUNNER_ADMISSION_STATUS_TIMEOUT_MS', value: '2500' },
         { name: 'JANGAR_STAGE_CLEARANCE_ENFORCEMENT', value: 'hold' },
         { name: 'JANGAR_STAGE_CLEARANCE_HOLD_STAGES', value: 'implement,verify' },
+        { name: 'JANGAR_EVIDENCE_PRESSURE_LEDGER_MODE', value: 'observe' },
       ]),
     )
   })

--- a/services/jangar/src/server/supporting-primitives-config.ts
+++ b/services/jangar/src/server/supporting-primitives-config.ts
@@ -30,6 +30,16 @@ const parseStageClearanceEnforcement = (
   return 'shadow'
 }
 
+const parseEvidencePressureLedgerMode = (
+  value: string | undefined,
+): SupportingPrimitivesConfig['evidencePressureLedgerMode'] => {
+  const normalized = normalizeNonEmpty(value)?.toLowerCase()
+  if (normalized === 'observe' || normalized === 'shadow' || normalized === 'hold' || normalized === 'enforce') {
+    return normalized
+  }
+  return 'observe'
+}
+
 const parseStringList = (value: string | undefined) =>
   (normalizeNonEmpty(value) ?? '')
     .split(',')
@@ -56,6 +66,7 @@ export type SupportingPrimitivesConfig = {
   swarmRuntimeProofEnforcement: boolean
   stageClearanceEnforcement: 'disabled' | 'shadow' | 'hold'
   stageClearanceHoldStages: string[]
+  evidencePressureLedgerMode: 'observe' | 'shadow' | 'hold' | 'enforce'
   scheduleRunnerAdmissionCheck: boolean
   scheduleRunnerAdmissionStatusUrl: string
   scheduleRunnerAdmissionStatusTimeoutMs: number
@@ -78,6 +89,7 @@ export const resolveSupportingPrimitivesConfig = (env: EnvSource = process.env):
   swarmRuntimeProofEnforcement: parseBoolean(env.JANGAR_SWARM_RUNTIME_PROOF_ENFORCEMENT, true),
   stageClearanceEnforcement: parseStageClearanceEnforcement(env.JANGAR_STAGE_CLEARANCE_ENFORCEMENT),
   stageClearanceHoldStages: parseStringList(env.JANGAR_STAGE_CLEARANCE_HOLD_STAGES),
+  evidencePressureLedgerMode: parseEvidencePressureLedgerMode(env.JANGAR_EVIDENCE_PRESSURE_LEDGER_MODE),
   scheduleRunnerAdmissionCheck: parseBoolean(env.JANGAR_SCHEDULE_RUNNER_ADMISSION_CHECK, true),
   scheduleRunnerAdmissionStatusUrl:
     normalizeNonEmpty(env.JANGAR_SCHEDULE_RUNNER_ADMISSION_STATUS_URL) ??

--- a/services/jangar/src/server/supporting-primitives-controller.ts
+++ b/services/jangar/src/server/supporting-primitives-controller.ts
@@ -1672,6 +1672,10 @@ const reconcileSchedule = async (
                         name: SCHEDULE_RUNNER_STAGE_CLEARANCE_HOLD_STAGES_ENV,
                         value: supportingConfig.stageClearanceHoldStages.join(','),
                       },
+                      {
+                        name: 'JANGAR_EVIDENCE_PRESSURE_LEDGER_MODE',
+                        value: supportingConfig.evidencePressureLedgerMode,
+                      },
                     ],
                     volumeMounts: [{ name: 'schedule-template', mountPath: '/config' }],
                   },
@@ -1979,17 +1983,13 @@ const reconcileSwarm = async (
     ]),
   ) as Record<StageName, StageClearanceMode>
   let stageClearancePackets: StageClearancePacket[] = []
-  let stageClearanceMarket: Pick<StageClearanceStatusSnapshot, 'clearanceMarketLedgerId' | 'stageAdmissions'> | null =
-    null
+  let stageClearanceMarket: StageClearanceStatusSnapshot | null = null
   let stageClearanceUnavailableMessage: string | null = null
   if (STAGE_NAMES.some((stage) => stageClearanceModes[stage] === 'hold')) {
     try {
       const stageClearanceSnapshot = await fetchStageClearanceStatusSnapshot(swarmNamespace, supportingConfig)
       stageClearancePackets = stageClearanceSnapshot.packets
-      stageClearanceMarket = {
-        clearanceMarketLedgerId: stageClearanceSnapshot.clearanceMarketLedgerId,
-        stageAdmissions: stageClearanceSnapshot.stageAdmissions,
-      }
+      stageClearanceMarket = stageClearanceSnapshot
     } catch (error) {
       stageClearanceUnavailableMessage = summarizeRuntimeAdmissionError(error)
       console.warn('[jangar] stage clearance snapshot unavailable for swarm launchers', {

--- a/services/jangar/src/server/supporting-primitives-evidence-pressure.ts
+++ b/services/jangar/src/server/supporting-primitives-evidence-pressure.ts
@@ -1,0 +1,139 @@
+import type { ActionSloBudgetActionClass, EvidencePressureDecision } from '~/data/agents-control-plane'
+import { asRecord, asString } from '~/server/primitives-http'
+import {
+  SWARM_EVIDENCE_PRESSURE_ANNOTATION_DECISION,
+  SWARM_EVIDENCE_PRESSURE_ANNOTATION_FRESH_UNTIL,
+  SWARM_EVIDENCE_PRESSURE_ANNOTATION_LEDGER_ID,
+  SWARM_EVIDENCE_PRESSURE_ANNOTATION_MODE,
+  SWARM_EVIDENCE_PRESSURE_ANNOTATION_REASON_CODES,
+  SWARM_EVIDENCE_PRESSURE_ANNOTATION_REQUIRED_REPAIR_RECEIPTS,
+  SWARM_EVIDENCE_PRESSURE_ANNOTATION_WATCH_BACKOFF_STATE,
+} from '~/server/supporting-primitives-schedule-runner'
+
+export type EvidencePressureTrace = {
+  ledgerId: string
+  decision: EvidencePressureDecision | null
+  mode: string | null
+  freshUntil: string | null
+  reasonCodes: string[]
+  requiredRepairReceipts: string[]
+  watchBackoffState: string | null
+}
+
+export type EvidencePressureBudgetSnapshot = {
+  actionClass: ActionSloBudgetActionClass
+  decision: EvidencePressureDecision | null
+  reasonCodes: string[]
+  requiredRepairReceipts: string[]
+}
+
+export type EvidencePressureStatusSnapshot = {
+  ledgerId: string
+  evidenceMode: string | null
+  freshUntil: string | null
+  watchBackoffState: string | null
+  budgets: EvidencePressureBudgetSnapshot[]
+}
+
+const asArray = (value: unknown) => (Array.isArray(value) ? value : [])
+
+const isPresent = <T>(value: T | null | undefined): value is T => value != null
+
+const compactStrings = (values: unknown[]) => values.map(asString).filter(isPresent)
+
+const parseEvidencePressureDecision = (value: unknown): EvidencePressureDecision | null => {
+  const normalized = asString(value)
+  if (normalized === 'allow' || normalized === 'repair_only' || normalized === 'hold' || normalized === 'block') {
+    return normalized
+  }
+  return null
+}
+
+const readEvidencePressureBudgetSnapshot = (value: unknown): EvidencePressureBudgetSnapshot | null => {
+  const record = asRecord(value)
+  if (!record) return null
+  const actionClass = asString(record.action_class)
+  if (!actionClass) return null
+
+  return {
+    actionClass: actionClass as ActionSloBudgetActionClass,
+    decision: parseEvidencePressureDecision(record.decision),
+    reasonCodes: compactStrings(asArray(record.reason_codes)),
+    requiredRepairReceipts: compactStrings(asArray(record.required_repair_receipts)),
+  }
+}
+
+export const readEvidencePressureStatusSnapshot = (value: unknown): EvidencePressureStatusSnapshot | null => {
+  const record = asRecord(value)
+  if (!record) return null
+  const ledgerId = asString(record.ledger_id)
+  if (!ledgerId) return null
+  const watchBackoff = asRecord(record.watch_backoff_policy)
+
+  return {
+    ledgerId,
+    evidenceMode: asString(record.evidence_mode),
+    freshUntil: asString(record.fresh_until),
+    watchBackoffState: asString(watchBackoff?.state),
+    budgets: asArray(record.action_pressure_budget).map(readEvidencePressureBudgetSnapshot).filter(isPresent),
+  }
+}
+
+export const evidencePressureTraceForAction = (
+  snapshot: { evidencePressure?: EvidencePressureStatusSnapshot | null } | null | undefined,
+  actionClass: ActionSloBudgetActionClass,
+): EvidencePressureTrace | null => {
+  const ledger = snapshot?.evidencePressure
+  if (!ledger) return null
+  const budget = ledger.budgets.find((entry) => entry.actionClass === actionClass) ?? null
+
+  return {
+    ledgerId: ledger.ledgerId,
+    decision: budget?.decision ?? null,
+    mode: ledger.evidenceMode,
+    freshUntil: ledger.freshUntil,
+    reasonCodes: budget?.reasonCodes ?? [],
+    requiredRepairReceipts: budget?.requiredRepairReceipts ?? [],
+    watchBackoffState: ledger.watchBackoffState,
+  }
+}
+
+export const evidencePressureEnforced = (trace: EvidencePressureTrace | null) =>
+  trace?.mode === 'hold' || trace?.mode === 'enforce'
+
+export const applyEvidencePressureTrace = (
+  annotations: Record<string, string>,
+  parameters: Record<string, string>,
+  evidencePressure: EvidencePressureTrace | null,
+) => {
+  if (!evidencePressure) return
+  annotations[SWARM_EVIDENCE_PRESSURE_ANNOTATION_LEDGER_ID] = evidencePressure.ledgerId
+  parameters.swarmEvidencePressureLedgerId = evidencePressure.ledgerId
+
+  if (evidencePressure.decision) {
+    annotations[SWARM_EVIDENCE_PRESSURE_ANNOTATION_DECISION] = evidencePressure.decision
+    parameters.swarmEvidencePressureDecision = evidencePressure.decision
+  }
+  if (evidencePressure.mode) {
+    annotations[SWARM_EVIDENCE_PRESSURE_ANNOTATION_MODE] = evidencePressure.mode
+    parameters.swarmEvidencePressureMode = evidencePressure.mode
+  }
+  if (evidencePressure.freshUntil) {
+    annotations[SWARM_EVIDENCE_PRESSURE_ANNOTATION_FRESH_UNTIL] = evidencePressure.freshUntil
+    parameters.swarmEvidencePressureFreshUntil = evidencePressure.freshUntil
+  }
+  if (evidencePressure.reasonCodes.length > 0) {
+    const reasonCodes = evidencePressure.reasonCodes.join(',')
+    annotations[SWARM_EVIDENCE_PRESSURE_ANNOTATION_REASON_CODES] = reasonCodes
+    parameters.swarmEvidencePressureReasonCodes = reasonCodes
+  }
+  if (evidencePressure.watchBackoffState) {
+    annotations[SWARM_EVIDENCE_PRESSURE_ANNOTATION_WATCH_BACKOFF_STATE] = evidencePressure.watchBackoffState
+    parameters.swarmEvidencePressureWatchBackoffState = evidencePressure.watchBackoffState
+  }
+  if (evidencePressure.requiredRepairReceipts.length > 0) {
+    const requiredRepairReceipts = evidencePressure.requiredRepairReceipts.join(',')
+    annotations[SWARM_EVIDENCE_PRESSURE_ANNOTATION_REQUIRED_REPAIR_RECEIPTS] = requiredRepairReceipts
+    parameters.swarmEvidencePressureRequiredRepairReceipts = requiredRepairReceipts
+  }
+}

--- a/services/jangar/src/server/supporting-primitives-schedule-runner.ts
+++ b/services/jangar/src/server/supporting-primitives-schedule-runner.ts
@@ -18,6 +18,7 @@ export const SCHEDULE_RUNNER_ADMISSION_STATUS_URL_ENV = 'JANGAR_SCHEDULE_RUNNER_
 export const SCHEDULE_RUNNER_ADMISSION_STATUS_TIMEOUT_MS_ENV = 'JANGAR_SCHEDULE_RUNNER_ADMISSION_STATUS_TIMEOUT_MS'
 export const SCHEDULE_RUNNER_STAGE_CLEARANCE_ENFORCEMENT_ENV = 'JANGAR_STAGE_CLEARANCE_ENFORCEMENT'
 export const SCHEDULE_RUNNER_STAGE_CLEARANCE_HOLD_STAGES_ENV = 'JANGAR_STAGE_CLEARANCE_HOLD_STAGES'
+export const SCHEDULE_RUNNER_EVIDENCE_PRESSURE_MODE_ENV = 'JANGAR_EVIDENCE_PRESSURE_LEDGER_MODE'
 
 const KUBERNETES_SERVICE_HOST_ENV = 'KUBERNETES_SERVICE_HOST'
 const KUBERNETES_SERVICE_PORT_ENV = 'KUBERNETES_SERVICE_PORT'
@@ -52,6 +53,15 @@ export const SWARM_STAGE_CREDIT_ANNOTATION_RUNNER_SLOT_FUTURE_ID = 'swarm.proomp
 export const SWARM_STAGE_CREDIT_ANNOTATION_RUNNER_SLOT_FUTURE_EXPIRES_AT =
   'swarm.proompteng.ai/runner-slot-future-expires-at'
 export const SWARM_STAGE_CREDIT_ANNOTATION_SELECTED_REPAIR_LOT = 'swarm.proompteng.ai/stage-credit-selected-repair-lot'
+export const SWARM_EVIDENCE_PRESSURE_ANNOTATION_LEDGER_ID = 'swarm.proompteng.ai/evidence-pressure-ledger-id'
+export const SWARM_EVIDENCE_PRESSURE_ANNOTATION_DECISION = 'swarm.proompteng.ai/evidence-pressure-decision'
+export const SWARM_EVIDENCE_PRESSURE_ANNOTATION_MODE = 'swarm.proompteng.ai/evidence-pressure-mode'
+export const SWARM_EVIDENCE_PRESSURE_ANNOTATION_FRESH_UNTIL = 'swarm.proompteng.ai/evidence-pressure-fresh-until'
+export const SWARM_EVIDENCE_PRESSURE_ANNOTATION_REASON_CODES = 'swarm.proompteng.ai/evidence-pressure-reason-codes'
+export const SWARM_EVIDENCE_PRESSURE_ANNOTATION_WATCH_BACKOFF_STATE =
+  'swarm.proompteng.ai/evidence-pressure-watch-backoff-state'
+export const SWARM_EVIDENCE_PRESSURE_ANNOTATION_REQUIRED_REPAIR_RECEIPTS =
+  'swarm.proompteng.ai/evidence-pressure-required-repair-receipts'
 
 export const buildScheduleRunnerCommand = (): string =>
   [
@@ -96,6 +106,15 @@ export const buildScheduleRunnerCommand = (): string =>
       runnerSlotFutureExpiresAt: SWARM_STAGE_CREDIT_ANNOTATION_RUNNER_SLOT_FUTURE_EXPIRES_AT,
       selectedRepairLot: SWARM_STAGE_CREDIT_ANNOTATION_SELECTED_REPAIR_LOT,
     })};`,
+    `  const evidencePressureAnnotations = ${JSON.stringify({
+      ledgerId: SWARM_EVIDENCE_PRESSURE_ANNOTATION_LEDGER_ID,
+      decision: SWARM_EVIDENCE_PRESSURE_ANNOTATION_DECISION,
+      mode: SWARM_EVIDENCE_PRESSURE_ANNOTATION_MODE,
+      freshUntil: SWARM_EVIDENCE_PRESSURE_ANNOTATION_FRESH_UNTIL,
+      reasonCodes: SWARM_EVIDENCE_PRESSURE_ANNOTATION_REASON_CODES,
+      watchBackoffState: SWARM_EVIDENCE_PRESSURE_ANNOTATION_WATCH_BACKOFF_STATE,
+      requiredRepairReceipts: SWARM_EVIDENCE_PRESSURE_ANNOTATION_REQUIRED_REPAIR_RECEIPTS,
+    })};`,
     `  const swarmNameLabelName = ${JSON.stringify(SWARM_NAME_LABEL)};`,
     `  const stageLabelName = ${JSON.stringify(SWARM_STAGE_LABEL)};`,
     `  const scheduleNamespaceEnv = ${JSON.stringify(SCHEDULE_RUNNER_SCHEDULE_NAMESPACE_ENV)};`,
@@ -105,6 +124,7 @@ export const buildScheduleRunnerCommand = (): string =>
     `  const admissionStatusTimeoutEnv = ${JSON.stringify(SCHEDULE_RUNNER_ADMISSION_STATUS_TIMEOUT_MS_ENV)};`,
     `  const stageClearanceEnforcementEnv = ${JSON.stringify(SCHEDULE_RUNNER_STAGE_CLEARANCE_ENFORCEMENT_ENV)};`,
     `  const stageClearanceHoldStagesEnv = ${JSON.stringify(SCHEDULE_RUNNER_STAGE_CLEARANCE_HOLD_STAGES_ENV)};`,
+    `  const evidencePressureModeEnv = ${JSON.stringify(SCHEDULE_RUNNER_EVIDENCE_PRESSURE_MODE_ENV)};`,
     "  const manifest = JSON.parse(readFileSync('/config/run.json', 'utf8').replaceAll('__JANGAR_DELIVERY_ID__', randomUUID()));",
     '  const terminalRunPhases = new Set(["succeeded", "failed", "error", "errored", "cancelled", "canceled", "completed"]);',
     "  const readEnv = (name) => process.env[name]?.trim() ?? '';",
@@ -160,6 +180,12 @@ export const buildScheduleRunnerCommand = (): string =>
     '    return "shadow";',
     '  };',
     '  const isStageCreditEnforced = (mode) => mode === "hold" || mode === "enforce";',
+    '  const normalizeEvidencePressureMode = (value) => {',
+    '    const normalized = String(value ?? "").trim().toLowerCase();',
+    '    if (["observe", "shadow", "hold", "enforce"].includes(normalized)) return normalized;',
+    '    return "observe";',
+    '  };',
+    '  const isEvidencePressureEnforced = (mode) => mode === "hold" || mode === "enforce";',
     '  const fetchControlPlaneStatus = async (namespace) => {',
     '    const statusUrlValue = readEnv(admissionStatusUrlEnv);',
     '    if (!statusUrlValue) {',
@@ -311,6 +337,20 @@ export const buildScheduleRunnerCommand = (): string =>
     '    const runnerSlotFutureExpiresAtMs = Date.parse(runnerSlotFutureExpiresAt);',
     '    const runnerSlotFutureCurrent = Boolean(stageCreditLedgerCurrent && runnerSlotFutureId && Number.isFinite(runnerSlotFutureExpiresAtMs) && runnerSlotFutureExpiresAtMs > Date.now());',
     '    const stageCreditEnforced = isStageCreditEnforced(stageCreditMode);',
+    '    const configuredEvidencePressureMode = normalizeEvidencePressureMode(readEnv(evidencePressureModeEnv));',
+    '    const evidencePressureLedger = asRecord(status.evidence_pressure_ledger);',
+    '    const evidencePressureLedgerId = asString(evidencePressureLedger?.ledger_id);',
+    '    const evidencePressureMode = normalizeEvidencePressureMode(asString(evidencePressureLedger?.evidence_mode) || configuredEvidencePressureMode);',
+    '    const evidencePressureFreshUntil = asString(evidencePressureLedger?.fresh_until);',
+    '    const evidencePressureFreshUntilMs = Date.parse(evidencePressureFreshUntil);',
+    '    const evidencePressureLedgerCurrent = Boolean(evidencePressureLedgerId && Number.isFinite(evidencePressureFreshUntilMs) && evidencePressureFreshUntilMs > Date.now());',
+    '    const evidencePressureBudget = asArray(evidencePressureLedger?.action_pressure_budget).map(asRecord).filter(Boolean).find((entry) => asString(entry?.action_class) === actionClass);',
+    '    const evidencePressureDecision = asString(evidencePressureBudget?.decision);',
+    '    const evidencePressureReasonCodes = normalizeRuntimeKits(asArray(evidencePressureBudget?.reason_codes).map(asString).filter(Boolean));',
+    '    const evidencePressureRequiredRepairReceipts = normalizeRuntimeKits(asArray(evidencePressureBudget?.required_repair_receipts).map(asString).filter(Boolean));',
+    '    const evidencePressureWatchBackoff = asRecord(evidencePressureLedger?.watch_backoff_policy);',
+    '    const evidencePressureWatchBackoffState = asString(evidencePressureWatchBackoff?.state);',
+    '    const evidencePressureEnforced = isEvidencePressureEnforced(evidencePressureMode) || isEvidencePressureEnforced(configuredEvidencePressureMode);',
     '    if (stageCreditLedgerId) {',
     '      if (!stageCreditLedgerCurrent) {',
     '        const message = `current stage credit ledger ${stageCreditLedgerId} is stale`;',
@@ -338,6 +378,27 @@ export const buildScheduleRunnerCommand = (): string =>
     '          if (stageCreditEnforced) throw new Error(message);',
     '          console.warn(`[jangar] ${message}`);',
     '        }',
+    '      }',
+    '    }',
+    '    if (!evidencePressureLedgerId) {',
+    '      const message = `missing current evidence pressure ledger for ${swarmName}/${stage}/${actionClass}`;',
+    '      if (evidencePressureEnforced) throw new Error(message);',
+    '      if (isEvidencePressureEnforced(configuredEvidencePressureMode)) console.warn(`[jangar] ${message}`);',
+    '    } else {',
+    '      if (!evidencePressureLedgerCurrent) {',
+    '        const message = `current evidence pressure ledger ${evidencePressureLedgerId} is stale`;',
+    '        if (evidencePressureEnforced) throw new Error(message);',
+    '        console.warn(`[jangar] ${message}`);',
+    '      }',
+    '      if (!evidencePressureBudget) {',
+    '        const message = `missing current evidence pressure budget for ${swarmName}/${stage}/${actionClass}`;',
+    '        if (evidencePressureEnforced) throw new Error(message);',
+    '        console.warn(`[jangar] ${message}`);',
+    '      } else if (evidencePressureDecision !== "allow") {',
+    '        const suffix = evidencePressureReasonCodes ? `: ${evidencePressureReasonCodes}` : "";',
+    '        const message = `current evidence pressure budget ${evidencePressureLedgerId}/${actionClass} is ${evidencePressureDecision || "missing"}${suffix}`;',
+    '        if (evidencePressureEnforced) throw new Error(message);',
+    '        console.warn(`[jangar] ${message}`);',
     '      }',
     '    }',
     '    const freshUntilMs = Date.parse(freshUntil);',
@@ -376,6 +437,13 @@ export const buildScheduleRunnerCommand = (): string =>
     '    if (runnerSlotFutureCurrent) writeNestedRecordValue(manifest, ["metadata", "annotations"], stageCreditAnnotations.runnerSlotFutureId, runnerSlotFutureId);',
     '    if (runnerSlotFutureCurrent) writeNestedRecordValue(manifest, ["metadata", "annotations"], stageCreditAnnotations.runnerSlotFutureExpiresAt, runnerSlotFutureExpiresAt);',
     '    if (stageCreditSelectedRepairLot) writeNestedRecordValue(manifest, ["metadata", "annotations"], stageCreditAnnotations.selectedRepairLot, stageCreditSelectedRepairLot);',
+    '    if (evidencePressureLedgerId) writeNestedRecordValue(manifest, ["metadata", "annotations"], evidencePressureAnnotations.ledgerId, evidencePressureLedgerId);',
+    '    if (evidencePressureDecision) writeNestedRecordValue(manifest, ["metadata", "annotations"], evidencePressureAnnotations.decision, evidencePressureDecision);',
+    '    if (evidencePressureMode) writeNestedRecordValue(manifest, ["metadata", "annotations"], evidencePressureAnnotations.mode, evidencePressureMode);',
+    '    if (evidencePressureFreshUntil) writeNestedRecordValue(manifest, ["metadata", "annotations"], evidencePressureAnnotations.freshUntil, evidencePressureFreshUntil);',
+    '    if (evidencePressureReasonCodes) writeNestedRecordValue(manifest, ["metadata", "annotations"], evidencePressureAnnotations.reasonCodes, evidencePressureReasonCodes);',
+    '    if (evidencePressureWatchBackoffState) writeNestedRecordValue(manifest, ["metadata", "annotations"], evidencePressureAnnotations.watchBackoffState, evidencePressureWatchBackoffState);',
+    '    if (evidencePressureRequiredRepairReceipts) writeNestedRecordValue(manifest, ["metadata", "annotations"], evidencePressureAnnotations.requiredRepairReceipts, evidencePressureRequiredRepairReceipts);',
     '    writeNestedRecordValue(manifest, ["spec", "parameters"], "swarmStageClearancePacketId", packetId);',
     '    writeNestedRecordValue(manifest, ["spec", "parameters"], "swarmStageClearanceDecision", decision);',
     '    writeNestedRecordValue(manifest, ["spec", "parameters"], "swarmStageClearanceActionClass", actionClass);',
@@ -398,6 +466,13 @@ export const buildScheduleRunnerCommand = (): string =>
     '    if (runnerSlotFutureCurrent) writeNestedRecordValue(manifest, ["spec", "parameters"], "swarmRunnerSlotFutureId", runnerSlotFutureId);',
     '    if (runnerSlotFutureCurrent) writeNestedRecordValue(manifest, ["spec", "parameters"], "swarmRunnerSlotFutureExpiresAt", runnerSlotFutureExpiresAt);',
     '    if (stageCreditSelectedRepairLot) writeNestedRecordValue(manifest, ["spec", "parameters"], "swarmCreditSelectedRepairLotRef", stageCreditSelectedRepairLot);',
+    '    if (evidencePressureLedgerId) writeNestedRecordValue(manifest, ["spec", "parameters"], "swarmEvidencePressureLedgerId", evidencePressureLedgerId);',
+    '    if (evidencePressureDecision) writeNestedRecordValue(manifest, ["spec", "parameters"], "swarmEvidencePressureDecision", evidencePressureDecision);',
+    '    if (evidencePressureMode) writeNestedRecordValue(manifest, ["spec", "parameters"], "swarmEvidencePressureMode", evidencePressureMode);',
+    '    if (evidencePressureFreshUntil) writeNestedRecordValue(manifest, ["spec", "parameters"], "swarmEvidencePressureFreshUntil", evidencePressureFreshUntil);',
+    '    if (evidencePressureReasonCodes) writeNestedRecordValue(manifest, ["spec", "parameters"], "swarmEvidencePressureReasonCodes", evidencePressureReasonCodes);',
+    '    if (evidencePressureWatchBackoffState) writeNestedRecordValue(manifest, ["spec", "parameters"], "swarmEvidencePressureWatchBackoffState", evidencePressureWatchBackoffState);',
+    '    if (evidencePressureRequiredRepairReceipts) writeNestedRecordValue(manifest, ["spec", "parameters"], "swarmEvidencePressureRequiredRepairReceipts", evidencePressureRequiredRepairReceipts);',
     '  };',
     '  const targetByKind = {',
     "  AgentRun: { group: 'agents.proompteng.ai', version: 'v1alpha1', plural: 'agentruns' },",

--- a/services/jangar/src/server/supporting-primitives-stage-clearance.ts
+++ b/services/jangar/src/server/supporting-primitives-stage-clearance.ts
@@ -8,6 +8,14 @@ import type {
 import { asRecord, asString } from '~/server/primitives-http'
 import { resolveSupportingPrimitivesConfig } from '~/server/supporting-primitives-config'
 import {
+  applyEvidencePressureTrace,
+  evidencePressureEnforced,
+  evidencePressureTraceForAction,
+  readEvidencePressureStatusSnapshot,
+  type EvidencePressureStatusSnapshot,
+  type EvidencePressureTrace,
+} from '~/server/supporting-primitives-evidence-pressure'
+import {
   SWARM_STAGE_CLEARANCE_ANNOTATION_ACTION_CLASS,
   SWARM_STAGE_CLEARANCE_ANNOTATION_CLEARANCE_MARKET_LEDGER_ID,
   SWARM_STAGE_CLEARANCE_ANNOTATION_CLEARANCE_MARKET_SELECTED_REPAIR_LOT,
@@ -64,6 +72,7 @@ export type StageClearanceLaunchAdmission = {
   packet: StageClearancePacket | null
   clearanceMarket: StageClearanceMarketTrace | null
   stageCredit: StageCreditTrace | null
+  evidencePressure: EvidencePressureTrace | null
   reason:
     | 'StageClearanceDisabled'
     | 'StageClearanceAllowed'
@@ -73,6 +82,8 @@ export type StageClearanceLaunchAdmission = {
     | 'StageClearanceStale'
     | 'StageClearanceHeld'
     | 'StageClearanceLaunchBudgetExhausted'
+    | 'EvidencePressureHeld'
+    | 'EvidencePressureStale'
   message: string
   annotations: Record<string, string>
   parameters: Record<string, string>
@@ -83,6 +94,7 @@ export type StageClearanceStatusSnapshot = {
   clearanceMarketLedgerId: string | null
   stageAdmissions: ClearanceMarketStageAdmission[]
   stageCredit: StageCreditStatusSnapshot | null
+  evidencePressure: EvidencePressureStatusSnapshot | null
 }
 
 type StageCreditAccountSnapshot = {
@@ -113,7 +125,7 @@ type StageClearanceAdmissionSnapshot = Pick<
   StageClearanceStatusSnapshot,
   'clearanceMarketLedgerId' | 'stageAdmissions'
 > &
-  Partial<Pick<StageClearanceStatusSnapshot, 'stageCredit'>>
+  Partial<Pick<StageClearanceStatusSnapshot, 'stageCredit' | 'evidencePressure'>>
 
 const asArray = (value: unknown) => (Array.isArray(value) ? value : [])
 
@@ -275,6 +287,7 @@ const readStageClearanceStatusSnapshot = (status: Record<string, unknown>): Stag
       .map(readClearanceMarketStageAdmission)
       .filter(isPresent),
     stageCredit: readStageCreditStatusSnapshot(status.stage_credit_ledger),
+    evidencePressure: readEvidencePressureStatusSnapshot(status.evidence_pressure_ledger),
   }
 }
 
@@ -376,6 +389,7 @@ const buildStageClearanceTrace = (
   mode: StageClearanceMode,
   clearanceMarket: StageClearanceMarketTrace | null,
   stageCredit: StageCreditTrace | null,
+  evidencePressure: EvidencePressureTrace | null,
 ): Pick<StageClearanceLaunchAdmission, 'annotations' | 'parameters'> => {
   const reasonCodes = packet.reason_codes.join(',')
   const annotations: Record<string, string> = {
@@ -460,6 +474,7 @@ const buildStageClearanceTrace = (
     annotations[SWARM_STAGE_CREDIT_ANNOTATION_SELECTED_REPAIR_LOT] = stageCredit.selectedRepairLotRef
     parameters.swarmCreditSelectedRepairLotRef = stageCredit.selectedRepairLotRef
   }
+  applyEvidencePressureTrace(annotations, parameters, evidencePressure)
   return { annotations, parameters }
 }
 
@@ -495,6 +510,7 @@ export const resolveStageClearanceAdmissionFromPackets = (input: {
       packet: null,
       clearanceMarket: null,
       stageCredit: null,
+      evidencePressure: null,
       reason: 'StageClearanceDisabled',
       message: 'stage clearance enforcement disabled',
       annotations: {},
@@ -520,6 +536,7 @@ export const resolveStageClearanceAdmissionFromPackets = (input: {
       packet: null,
       clearanceMarket: null,
       stageCredit: null,
+      evidencePressure: null,
       reason: 'StageClearanceMissing',
       message: `missing stage clearance packet for ${input.swarmName}/${input.stage}/${actionClass}`,
       annotations: {},
@@ -530,7 +547,8 @@ export const resolveStageClearanceAdmissionFromPackets = (input: {
   const clearanceMarket = clearanceMarketTraceForPacket(input.clearanceMarket, packet)
   const nowMs = input.nowMs ?? Date.now()
   const stageCredit = stageCreditTraceForPacket(input.clearanceMarket, packet, nowMs)
-  const trace = buildStageClearanceTrace(packet, input.mode, clearanceMarket, stageCredit)
+  const evidencePressure = evidencePressureTraceForAction(input.clearanceMarket, actionClass)
+  const trace = buildStageClearanceTrace(packet, input.mode, clearanceMarket, stageCredit, evidencePressure)
   const freshUntilMs = Date.parse(packet.fresh_until)
   if (!Number.isFinite(freshUntilMs) || freshUntilMs <= nowMs) {
     return {
@@ -541,6 +559,7 @@ export const resolveStageClearanceAdmissionFromPackets = (input: {
       packet,
       clearanceMarket,
       stageCredit,
+      evidencePressure,
       reason: 'StageClearanceStale',
       message: `stage clearance packet ${packet.packet_id} is stale`,
       ...trace,
@@ -556,6 +575,7 @@ export const resolveStageClearanceAdmissionFromPackets = (input: {
       packet,
       clearanceMarket,
       stageCredit,
+      evidencePressure,
       reason: 'StageClearanceHeld',
       message: summarizeStageClearanceBlock(packet, clearanceMarket),
       ...trace,
@@ -570,6 +590,7 @@ export const resolveStageClearanceAdmissionFromPackets = (input: {
       packet,
       clearanceMarket,
       stageCredit,
+      evidencePressure,
       reason: 'StageClearanceHeld',
       message: `clearance market stage admission ${clearanceMarket.stageAdmissionId ?? clearanceMarket.ledgerId} is ${
         clearanceMarket.decision
@@ -588,9 +609,45 @@ export const resolveStageClearanceAdmissionFromPackets = (input: {
       packet,
       clearanceMarket,
       stageCredit,
+      evidencePressure,
       reason: 'StageClearanceLaunchBudgetExhausted',
       message: `stage clearance packet ${packet.packet_id} has no launch budget`,
       ...trace,
+    }
+  }
+  if (evidencePressure && evidencePressureEnforced(evidencePressure)) {
+    const pressureFreshUntilMs = Date.parse(evidencePressure.freshUntil ?? '')
+    if (!Number.isFinite(pressureFreshUntilMs) || pressureFreshUntilMs <= nowMs) {
+      return {
+        mode: input.mode,
+        admitted: false,
+        stage: input.stage,
+        actionClass,
+        packet,
+        clearanceMarket,
+        stageCredit,
+        evidencePressure,
+        reason: 'EvidencePressureStale',
+        message: `evidence pressure ledger ${evidencePressure.ledgerId} is stale`,
+        ...trace,
+      }
+    }
+    if (evidencePressure.decision !== 'allow') {
+      return {
+        mode: input.mode,
+        admitted: false,
+        stage: input.stage,
+        actionClass,
+        packet,
+        clearanceMarket,
+        stageCredit,
+        evidencePressure,
+        reason: 'EvidencePressureHeld',
+        message: `evidence pressure budget ${evidencePressure.ledgerId}/${actionClass} is ${
+          evidencePressure.decision ?? 'missing'
+        }${evidencePressure.reasonCodes.length > 0 ? `: ${evidencePressure.reasonCodes.join(', ')}` : ''}`,
+        ...trace,
+      }
     }
   }
 
@@ -602,6 +659,7 @@ export const resolveStageClearanceAdmissionFromPackets = (input: {
     packet,
     clearanceMarket,
     stageCredit,
+    evidencePressure,
     reason: input.mode === 'hold' ? 'StageClearanceAllowed' : 'StageClearanceShadow',
     message:
       input.mode === 'hold'
@@ -624,6 +682,7 @@ export const resolveStageClearanceUnavailable = (
   packet: null,
   clearanceMarket: null,
   stageCredit: null,
+  evidencePressure: null,
   reason: 'StageClearanceUnavailable',
   message: `stage clearance snapshot unavailable: ${errorMessage}`,
   annotations: {},
@@ -663,6 +722,7 @@ export const resolveStageClearanceForStage = async (input: {
           clearanceMarketLedgerId: input.clearanceMarket?.clearanceMarketLedgerId ?? null,
           stageAdmissions: input.clearanceMarket?.stageAdmissions ?? [],
           stageCredit: input.clearanceMarket?.stageCredit ?? null,
+          evidencePressure: input.clearanceMarket?.evidencePressure ?? null,
         }
       : await fetchStageClearanceStatusSnapshot(input.namespace, config)
     return resolveStageClearanceAdmissionFromPackets({
@@ -706,6 +766,13 @@ export const stageClearanceStatusForStage = (admission: StageClearanceLaunchAdmi
   runnerSlotFutureId: admission.stageCredit?.runnerSlotFutureId ?? null,
   runnerSlotFutureExpiresAt: admission.stageCredit?.runnerSlotFutureExpiresAt ?? null,
   stageCreditSelectedRepairLotRef: admission.stageCredit?.selectedRepairLotRef ?? null,
+  evidencePressureLedgerId: admission.evidencePressure?.ledgerId ?? null,
+  evidencePressureDecision: admission.evidencePressure?.decision ?? null,
+  evidencePressureMode: admission.evidencePressure?.mode ?? null,
+  evidencePressureFreshUntil: admission.evidencePressure?.freshUntil ?? null,
+  evidencePressureReasonCodes: admission.evidencePressure?.reasonCodes ?? [],
+  evidencePressureWatchBackoffState: admission.evidencePressure?.watchBackoffState ?? null,
+  evidencePressureRequiredRepairReceipts: admission.evidencePressure?.requiredRepairReceipts ?? [],
   reason: admission.reason,
   message: admission.message,
 })


### PR DESCRIPTION
## Summary

- Implements scheduler-side adoption for the evidence pressure ledger from `docs/agents/designs/188-jangar-evidence-pressure-ledger-and-watch-backoff-governor-2026-05-13.md`.
- Makes fire-time schedule runners read `evidence_pressure_ledger`, stamp `swarmEvidencePressure*` handoff fields, and fail closed for stale or held pressure only when `JANGAR_EVIDENCE_PRESSURE_LEDGER_MODE` or the ledger mode is `hold`/`enforce`.
- Shares the same evidence pressure trace through stage-clearance launch admission so shadow mode records pressure evidence and hold mode blocks `dispatch_normal` before launch.
- Documents the runtime behavior and rollback path.

## Related Issues

None. Runtime requirement provenance: swarm `jangar-control-plane`, value gates `failed_agentrun_rate`, `ready_status_truth`, and `handoff_evidence_quality`.

## Testing

- `bun install --frozen-lockfile --ignore-scripts` passed.
- `bun run --filter @proompteng/jangar pretest` passed.
- `bunx oxfmt --check services/jangar/README.md services/jangar/src/server/__tests__/supporting-primitives-controller.test.ts services/jangar/src/server/supporting-primitives-config.ts services/jangar/src/server/supporting-primitives-controller.ts services/jangar/src/server/supporting-primitives-evidence-pressure.ts services/jangar/src/server/supporting-primitives-schedule-runner.ts services/jangar/src/server/supporting-primitives-stage-clearance.ts` passed.
- `cd services/jangar && bunx vitest run --config vitest.config.ts src/server/__tests__/supporting-primitives-controller.test.ts` passed: 74 tests.
- `bun run --filter @proompteng/jangar tsc` passed.
- `bun run --cwd services/jangar lint:oxlint` passed with warnings and 0 errors.
- `bun run --cwd services/jangar lint:oxlint:type` passed with warnings and 0 errors.
- `git diff --check` passed.

## Screenshots (if applicable)

N/A. This is a backend/control-plane scheduler change.

## Breaking Changes

None by default. Rollback path: keep or set `JANGAR_EVIDENCE_PRESSURE_LEDGER_MODE=observe` to retain evidence stamps without refusing launches; if the ledger payload itself regresses status generation, set `JANGAR_EVIDENCE_PRESSURE_LEDGER_ENABLED=false`.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
