### PR TITLE
feat(torghut): search portfolio sleeves against oracle

### DIFF
--- a/services/torghut/app/trading/discovery/candidate_specs.py
+++ b/services/torghut/app/trading/discovery/candidate_specs.py
@@ -98,6 +98,16 @@ _LIQUID_TECH_PLATFORM_UNIVERSE_PROFILE: tuple[str, ...] = (
 _BROAD_SEMICONDUCTOR_UNIVERSE_PROFILE: tuple[str, ...] = (
     _RESEARCHED_SEMICONDUCTOR_TECH_UNIVERSE
 )
+_PORTFOLIO_COVERAGE_UNIVERSE_PROFILE: tuple[str, ...] = (
+    "NVDA",
+    "AAPL",
+    "AMD",
+    "AVGO",
+    "INTC",
+    "ORCL",
+    "AMZN",
+    "GOOGL",
+)
 
 _LARGE_CAP_UNIVERSE_PROFILES: tuple[tuple[str, ...], ...] = (
     _AI_ACCELERATOR_UNIVERSE_PROFILE,
@@ -939,6 +949,240 @@ _FAMILY_EXECUTION_PROFILES: dict[str, tuple[dict[str, Any], ...]] = {
     ),
 }
 
+_BASE_FAMILY_EXECUTION_PROFILES = _FAMILY_EXECUTION_PROFILES
+
+# These profiles broaden the portfolio-oracle research surface. They keep
+# notional and stop/session-loss controls tight while lowering entry thresholds
+# enough to test whether diversified sleeves can cover more trading days.
+_PORTFOLIO_ORACLE_COVERAGE_EXECUTION_PROFILES: dict[str, tuple[dict[str, Any], ...]] = {
+    "microbar_cross_sectional_pairs_v1": (
+        {
+            "universe_symbols": list(_PORTFOLIO_COVERAGE_UNIVERSE_PROFILE),
+            "normalization_regime": "market_neutral_gross_scaled",
+            "max_position_pct_equity": "3.0",
+            "max_notional_per_trade": "94770",
+            "params": {
+                "entry_minute_after_open": "45",
+                "exit_minute_after_open": "close",
+                "signal_motif": "open_window_continuation",
+                "rank_feature": "cross_section_session_open_rank",
+                "selection_mode": "continuation",
+                "top_n": "3",
+                "min_cross_section_continuation_rank": "0.50",
+                "max_pair_legs": "4",
+                "max_entries_per_session": "4",
+                "entry_cooldown_seconds": "300",
+                "long_stop_loss_bps": "4",
+                "long_trailing_stop_activation_profit_bps": "4",
+                "long_trailing_stop_drawdown_bps": "2",
+                "max_hold_seconds": "5400",
+                "max_session_negative_exit_bps": "3",
+                "max_stop_loss_exits_per_session": "1",
+                "stop_loss_lockout_seconds": "1200",
+            },
+        },
+    ),
+    "microstructure_continuation_matched_filter_v1": (
+        {
+            "universe_symbols": list(_PORTFOLIO_COVERAGE_UNIVERSE_PROFILE),
+            "max_position_pct_equity": "3.0",
+            "max_notional_per_trade": "94770",
+            "params": {
+                "min_cross_section_continuation_rank": "0.48",
+                "min_cross_section_opening_window_return_rank": "0.40",
+                "max_gross_exposure_pct_equity": "5.0",
+                "entry_notional_max_multiplier": "0.70",
+                "max_entries_per_session": "4",
+                "entry_cooldown_seconds": "300",
+                "leader_reclaim_start_minutes_since_open": "20",
+                "leader_reclaim_min_recent_imbalance_pressure": "0.04",
+                "leader_reclaim_min_recent_microprice_bias_bps": "0.08",
+                "leader_reclaim_min_recent_above_opening_window_close_ratio": "0.50",
+                "leader_reclaim_min_recent_above_vwap_w5m_ratio": "0.50",
+                "max_session_negative_exit_bps": "4",
+                "long_stop_loss_bps": "6",
+                "long_trailing_stop_activation_profit_bps": "5",
+                "long_trailing_stop_drawdown_bps": "2",
+            },
+        },
+    ),
+    "intraday_tsmom_v2": (
+        {
+            "universe_symbols": list(_PORTFOLIO_COVERAGE_UNIVERSE_PROFILE),
+            "max_notional_per_trade": "94770",
+            "max_position_pct_equity": "3.0",
+            "params": {
+                "long_stop_loss_bps": "6",
+                "long_trailing_stop_activation_profit_bps": "5",
+                "long_trailing_stop_drawdown_bps": "2",
+                "max_session_negative_exit_bps": "4",
+                "min_cross_section_continuation_rank": "0.50",
+                "max_entries_per_session": "4",
+                "entry_cooldown_seconds": "300",
+            },
+        },
+    ),
+    "mean_reversion_rebound_v1": (
+        {
+            "universe_symbols": list(_PORTFOLIO_COVERAGE_UNIVERSE_PROFILE),
+            "max_position_pct_equity": "3.0",
+            "max_notional_per_trade": "94770",
+            "params": {
+                "min_bull_rsi": "36",
+                "max_bull_rsi": "52",
+                "min_price_below_vwap_bps": "6",
+                "max_price_below_vwap_bps": "65",
+                "max_price_vs_session_open_bps": "-12",
+                "max_opening_window_return_bps": "0",
+                "max_cross_section_continuation_rank": "0.58",
+                "min_cross_section_reversal_rank": "0.58",
+                "min_recent_imbalance_pressure": "0.00",
+                "entry_start_minute_utc": "810",
+                "entry_end_minute_utc": "1140",
+                "max_gross_exposure_pct_equity": "4.0",
+                "entry_cooldown_seconds": "450",
+                "long_stop_loss_bps": "8",
+                "long_trailing_stop_activation_profit_bps": "6",
+                "long_trailing_stop_drawdown_bps": "3",
+                "max_session_negative_exit_bps": "5",
+                "max_hold_seconds": "3600",
+            },
+        },
+    ),
+    "breakout_reclaim_v2": (
+        {
+            "universe_symbols": list(_PORTFOLIO_COVERAGE_UNIVERSE_PROFILE),
+            "max_position_pct_equity": "4.0",
+            "max_notional_per_trade": "126360",
+            "params": {
+                "min_cross_section_continuation_rank": "0.50",
+                "min_cross_section_opening_window_return_rank": "0.45",
+                "max_gross_exposure_pct_equity": "6.0",
+                "entry_notional_max_multiplier": "0.80",
+                "max_entries_per_session": "4",
+                "entry_cooldown_seconds": "300",
+                "max_session_negative_exit_bps": "5",
+                "leader_reclaim_start_minutes_since_open": "25",
+                "leader_reclaim_min_recent_imbalance_pressure": "0.05",
+                "leader_reclaim_min_recent_microprice_bias_bps": "0.12",
+                "leader_reclaim_min_recent_above_opening_window_close_ratio": "0.54",
+                "leader_reclaim_min_recent_above_vwap_w5m_ratio": "0.52",
+                "long_stop_loss_bps": "6",
+                "long_trailing_stop_activation_profit_bps": "6",
+                "long_trailing_stop_drawdown_bps": "2",
+            },
+        },
+    ),
+    "washout_rebound_v2": (
+        {
+            "universe_symbols": list(_PORTFOLIO_COVERAGE_UNIVERSE_PROFILE),
+            "max_notional_per_trade": "94770",
+            "max_position_pct_equity": "3.0",
+            "params": {
+                "min_session_open_selloff_bps": "12",
+                "max_price_vs_session_low_bps": "48",
+                "min_recent_microprice_bias_bps": "0.00",
+                "min_cross_section_reversal_rank": "0.55",
+            },
+        },
+    ),
+    "momentum_pullback_v1": (
+        {
+            "universe_symbols": list(_PORTFOLIO_COVERAGE_UNIVERSE_PROFILE),
+            "max_position_pct_equity": "3.0",
+            "max_notional_per_trade": "94770",
+            "params": {
+                "bullish_hist_min": "0.002",
+                "min_bull_rsi": "46",
+                "max_bull_rsi": "70",
+                "min_price_below_ema12_bps": "-2",
+                "max_price_below_ema12_bps": "16",
+                "max_spread_bps": "8",
+                "min_imbalance_pressure": "-0.08",
+                "min_recent_microprice_bias_bps": "-0.10",
+                "min_cross_section_continuation_rank": "0.30",
+                "entry_start_minute_utc": "840",
+                "entry_end_minute_utc": "1110",
+                "exit_macd_hist_max": "-0.002",
+                "exit_rsi_max": "52",
+                "max_hold_seconds": "1200",
+                "long_stop_loss_bps": "8",
+                "long_trailing_stop_activation_profit_bps": "6",
+                "long_trailing_stop_drawdown_bps": "3",
+                "max_session_negative_exit_bps": "5",
+            },
+        },
+    ),
+    "late_day_continuation_v1": (
+        {
+            "universe_symbols": list(_PORTFOLIO_COVERAGE_UNIVERSE_PROFILE),
+            "max_position_pct_equity": "3.0",
+            "max_notional_per_trade": "94770",
+            "params": {
+                "bullish_hist_min": "0.002",
+                "bullish_hist_cap": "0.075",
+                "min_bull_rsi": "50",
+                "max_bull_rsi": "78",
+                "vol_floor": "0.00003",
+                "vol_ceil": "0.00045",
+                "min_price_above_ema12_bps": "-10",
+                "max_price_above_ema12_bps": "24",
+                "min_price_vs_vwap_w5m_bps": "-8",
+                "max_price_vs_vwap_w5m_bps": "24",
+                "min_session_open_drive_bps": "16",
+                "min_opening_window_return_bps": "6",
+                "min_session_range_position": "0.52",
+                "min_cross_section_continuation_breadth": "0.28",
+                "min_cross_section_opening_window_return_rank": "0.48",
+                "min_cross_section_continuation_rank": "0.52",
+                "min_imbalance_pressure": "-0.06",
+                "min_recent_imbalance_pressure": "-0.04",
+                "min_recent_microprice_bias_bps": "-0.25",
+                "max_spread_bps": "12",
+                "max_recent_spread_bps": "12",
+                "max_recent_quote_invalid_ratio": "0.25",
+                "max_recent_quote_jump_bps": "80",
+                "min_recent_above_opening_window_close_ratio": "0.42",
+                "min_recent_above_vwap_w5m_ratio": "0.42",
+                "entry_start_minute_utc": "1020",
+                "entry_end_minute_utc": "1170",
+                "session_flatten_start_minute_utc": "1170",
+                "min_entry_minutes_before_flatten": "8",
+                "long_stop_loss_bps": "12",
+                "long_trailing_stop_activation_profit_bps": "8",
+                "long_trailing_stop_drawdown_bps": "4",
+                "entry_cooldown_seconds": "450",
+                "max_entries_per_session": "4",
+                "max_concurrent_positions": "4",
+                "require_positive_price_for_signal_exit": "true",
+            },
+        },
+    ),
+    "end_of_day_reversal_v1": (
+        {
+            "universe_symbols": list(_PORTFOLIO_COVERAGE_UNIVERSE_PROFILE),
+            "max_position_pct_equity": "3.0",
+            "max_notional_per_trade": "94770",
+            "params": {
+                "min_bull_rsi": "32",
+                "max_bull_rsi": "52",
+                "min_macd_hist": "-0.014",
+                "max_macd_hist": "0.014",
+                "max_price_vs_session_open_bps": "-18",
+                "max_opening_window_return_bps": "0",
+                "max_cross_section_continuation_rank": "0.55",
+                "min_cross_section_reversal_rank": "0.55",
+                "entry_start_minute_utc": "1120",
+                "entry_end_minute_utc": "1188",
+                "max_gross_exposure_pct_equity": "4.0",
+                "entry_cooldown_seconds": "1800",
+                "min_hold_seconds": "60",
+                "max_hold_seconds": "600",
+            },
+        },
+    ),
+}
+
 
 def _stable_hash(payload: Mapping[str, Any]) -> str:
     encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
@@ -1197,8 +1441,12 @@ def _execution_profile_index(
     card: HypothesisCard,
     family_template_id: str,
     family_rank: int,
+    target_net_pnl_per_day: Decimal = Decimal("300"),
 ) -> int:
-    profiles = _FAMILY_EXECUTION_PROFILES.get(family_template_id)
+    profiles = _execution_profiles_for_target(
+        family_template_id=family_template_id,
+        target_net_pnl_per_day=target_net_pnl_per_day,
+    )
     profile_count = len(profiles) if profiles else _DEFAULT_PROFILE_COUNT
     explicit_profile = card.implementation_constraints.get("execution_profile_index")
     if explicit_profile is not None:
@@ -1224,8 +1472,12 @@ def _execution_profile_indexes(
     card: HypothesisCard,
     family_template_id: str,
     family_rank: int,
+    target_net_pnl_per_day: Decimal = Decimal("300"),
 ) -> tuple[int, ...]:
-    profiles = _FAMILY_EXECUTION_PROFILES.get(family_template_id)
+    profiles = _execution_profiles_for_target(
+        family_template_id=family_template_id,
+        target_net_pnl_per_day=target_net_pnl_per_day,
+    )
     profile_count = len(profiles) if profiles else _DEFAULT_PROFILE_COUNT
     explicit_profile = card.implementation_constraints.get("execution_profile_index")
     if explicit_profile is not None:
@@ -1234,6 +1486,7 @@ def _execution_profile_indexes(
                 card=card,
                 family_template_id=family_template_id,
                 family_rank=family_rank,
+                target_net_pnl_per_day=target_net_pnl_per_day,
             ),
         )
     return tuple(range(profile_count))
@@ -1243,10 +1496,30 @@ def _execution_profile_id(*, family_template_id: str, profile_index: int) -> str
     return f"{family_template_id}:profile-{profile_index + 1}"
 
 
+def _execution_profiles_for_target(
+    *,
+    family_template_id: str,
+    target_net_pnl_per_day: Decimal = Decimal("300"),
+) -> tuple[dict[str, Any], ...]:
+    base_profiles = _BASE_FAMILY_EXECUTION_PROFILES.get(family_template_id, ())
+    if target_net_pnl_per_day < _PORTFOLIO_TARGET_NET_PNL_PER_DAY:
+        return base_profiles
+    return (
+        *base_profiles,
+        *_PORTFOLIO_ORACLE_COVERAGE_EXECUTION_PROFILES.get(family_template_id, ()),
+    )
+
+
 def _strategy_overrides_for_profile(
-    *, family_template_id: str, profile_index: int
+    *,
+    family_template_id: str,
+    profile_index: int,
+    target_net_pnl_per_day: Decimal = Decimal("300"),
 ) -> dict[str, Any]:
-    profiles = _FAMILY_EXECUTION_PROFILES.get(family_template_id)
+    profiles = _execution_profiles_for_target(
+        family_template_id=family_template_id,
+        target_net_pnl_per_day=target_net_pnl_per_day,
+    )
     if not profiles:
         return {"max_notional_per_trade": "50000"}
     selected = profiles[profile_index % len(profiles)]
@@ -1348,6 +1621,7 @@ def compile_candidate_specs(
                 card=card,
                 family_template_id=family_template_id,
                 family_rank=family_rank,
+                target_net_pnl_per_day=target_net_pnl_per_day,
             ):
                 execution_profile_id = _execution_profile_id(
                     family_template_id=family_template_id,
@@ -1356,6 +1630,7 @@ def compile_candidate_specs(
                 strategy_overrides = _strategy_overrides_for_profile(
                     family_template_id=family_template_id,
                     profile_index=execution_profile_index,
+                    target_net_pnl_per_day=target_net_pnl_per_day,
                 )
                 if explicit_universe_symbols:
                     strategy_overrides = {

--- a/services/torghut/app/trading/discovery/portfolio_optimizer.py
+++ b/services/torghut/app/trading/discovery/portfolio_optimizer.py
@@ -21,6 +21,7 @@ from app.trading.discovery.profit_target_oracle import ProfitTargetOraclePolicy
 MAX_CLUSTER_CONTRIBUTION_SHARE = Decimal("0.40")
 MAX_SINGLE_SYMBOL_CONTRIBUTION_SHARE = Decimal("0.35")
 MAX_ALLOWED_PAIRWISE_CORRELATION = Decimal("0.85")
+PORTFOLIO_SEARCH_BEAM_WIDTH = 256
 
 
 def _decimal(value: Any, *, default: str = "0") -> Decimal:
@@ -428,6 +429,200 @@ def _sleeve_score(bundle: CandidateEvidenceBundle) -> Decimal:
     )
 
 
+def _scorecard_decimal(scorecard: Mapping[str, Any], field: str) -> Decimal:
+    return _decimal(scorecard.get(field))
+
+
+def _portfolio_selection_key(
+    *,
+    selected: Sequence[CandidateEvidenceBundle],
+    scorecard: Mapping[str, Any],
+) -> tuple[Decimal, ...]:
+    return (
+        Decimal(1 if bool(scorecard.get("oracle_passed")) else 0),
+        Decimal(1 if bool(scorecard.get("target_met")) else 0),
+        _scorecard_decimal(scorecard, "net_pnl_per_day"),
+        _scorecard_decimal(scorecard, "active_day_ratio"),
+        _scorecard_decimal(scorecard, "positive_day_ratio"),
+        -_scorecard_decimal(scorecard, "best_day_share"),
+        -_scorecard_decimal(scorecard, "max_single_symbol_contribution_share"),
+        -_scorecard_decimal(scorecard, "max_cluster_contribution_share"),
+        -_scorecard_decimal(scorecard, "worst_day_loss"),
+        -_scorecard_decimal(scorecard, "max_drawdown"),
+        Decimal(len(selected)),
+        sum((_sleeve_score(bundle) for bundle in selected), Decimal("0")),
+    )
+
+
+def _partial_selection_key(
+    selected: Sequence[CandidateEvidenceBundle],
+) -> tuple[Decimal, ...]:
+    if not selected:
+        return (
+            Decimal("0"),
+            Decimal("0"),
+            Decimal("0"),
+            Decimal("0"),
+            Decimal("0"),
+            Decimal("0"),
+            Decimal("0"),
+            Decimal("0"),
+            Decimal("0"),
+            Decimal("0"),
+            Decimal("0"),
+            Decimal("0"),
+        )
+    return (
+        Decimal("0"),
+        Decimal("0"),
+        sum((_net_per_day(bundle) for bundle in selected), Decimal("0")),
+        _mean([_active_ratio(bundle) for bundle in selected]),
+        _mean([_positive_ratio(bundle) for bundle in selected]),
+        -max((_best_day_share(bundle) for bundle in selected), default=Decimal("0")),
+        -_max_share(_symbol_contribution_shares(selected)),
+        -_max_share(_cluster_contribution_shares(selected)),
+        -max((_worst_day_loss(bundle) for bundle in selected), default=Decimal("0")),
+        -max((_max_drawdown(bundle) for bundle in selected), default=Decimal("0")),
+        Decimal(len(selected)),
+        sum((_sleeve_score(bundle) for bundle in selected), Decimal("0")),
+    )
+
+
+def _portfolio_addition_rejection(
+    *,
+    bundle: CandidateEvidenceBundle,
+    selected: Sequence[CandidateEvidenceBundle],
+    requested_portfolio_size_min: int,
+    max_allowed_correlation: Decimal,
+) -> dict[str, Any] | None:
+    cluster = _cluster_id(bundle)
+    selected_clusters = {_cluster_id(item) for item in selected}
+    if cluster in selected_clusters and len(selected) >= requested_portfolio_size_min:
+        return {
+            "candidate_id": bundle.candidate_id,
+            "reason": "cluster_cap",
+            "cluster": cluster,
+        }
+    max_correlation = _max_pairwise_correlation(bundle, selected)
+    if (
+        max_correlation > max_allowed_correlation
+        and len(selected) >= requested_portfolio_size_min
+    ):
+        return {
+            "candidate_id": bundle.candidate_id,
+            "reason": "correlation_cap",
+            "max_pairwise_correlation": str(max_correlation),
+        }
+    return None
+
+
+def _record_unique_rejection(
+    rejected: list[dict[str, Any]],
+    seen_rejections: set[tuple[str, str]],
+    rejection: Mapping[str, Any],
+) -> None:
+    key = (_string(rejection.get("candidate_id")), _string(rejection.get("reason")))
+    if key in seen_rejections:
+        return
+    seen_rejections.add(key)
+    rejected.append(dict(rejection))
+
+
+def _selected_from_state(
+    ordered: Sequence[CandidateEvidenceBundle],
+    state: tuple[int, ...],
+) -> tuple[CandidateEvidenceBundle, ...]:
+    return tuple(ordered[index] for index in state)
+
+
+def _select_portfolio_bundles(
+    *,
+    ordered: Sequence[CandidateEvidenceBundle],
+    rejected: list[dict[str, Any]],
+    target_net_pnl_per_day: Decimal,
+    oracle_policy: ProfitTargetOraclePolicy,
+    requested_portfolio_size_min: int,
+    requested_portfolio_size_max: int,
+    max_allowed_correlation: Decimal,
+) -> tuple[list[CandidateEvidenceBundle], dict[str, Any]] | None:
+    if len(ordered) < requested_portfolio_size_min:
+        return None
+
+    seen_rejections = {
+        (_string(item.get("candidate_id")), _string(item.get("reason")))
+        for item in rejected
+    }
+    scorecard_cache: dict[tuple[int, ...], dict[str, Any]] = {}
+
+    def state_scorecard(state: tuple[int, ...]) -> dict[str, Any]:
+        cached = scorecard_cache.get(state)
+        if cached is not None:
+            return cached
+        scorecard = _portfolio_scorecard(
+            selected=_selected_from_state(ordered, state),
+            target_net_pnl_per_day=target_net_pnl_per_day,
+            oracle_policy=oracle_policy,
+        )
+        scorecard_cache[state] = scorecard
+        return scorecard
+
+    def state_sort_key(state: tuple[int, ...]) -> tuple[tuple[Decimal, ...], str]:
+        selected = _selected_from_state(ordered, state)
+        if len(state) >= requested_portfolio_size_min:
+            quality_key = _portfolio_selection_key(
+                selected=selected,
+                scorecard=state_scorecard(state),
+            )
+        else:
+            quality_key = _partial_selection_key(selected)
+        return (quality_key, "|".join(bundle.candidate_id for bundle in selected))
+
+    beam: list[tuple[int, ...]] = [()]
+    candidate_state_count = 0
+    pruned_state_count = 0
+    for bundle_index, bundle in enumerate(ordered):
+        next_states = list(beam)
+        for state in beam:
+            if len(state) >= requested_portfolio_size_max:
+                continue
+            selected = _selected_from_state(ordered, state)
+            rejection = _portfolio_addition_rejection(
+                bundle=bundle,
+                selected=selected,
+                requested_portfolio_size_min=requested_portfolio_size_min,
+                max_allowed_correlation=max_allowed_correlation,
+            )
+            if rejection is not None:
+                _record_unique_rejection(rejected, seen_rejections, rejection)
+                continue
+            next_states.append((*state, bundle_index))
+            candidate_state_count += 1
+        unique_next_states = list(dict.fromkeys(next_states))
+        unique_next_states.sort(key=state_sort_key, reverse=True)
+        if len(unique_next_states) > PORTFOLIO_SEARCH_BEAM_WIDTH:
+            pruned_state_count += len(unique_next_states) - PORTFOLIO_SEARCH_BEAM_WIDTH
+        beam = unique_next_states[:PORTFOLIO_SEARCH_BEAM_WIDTH]
+
+    finalists: list[tuple[tuple[tuple[Decimal, ...], str], tuple[int, ...]]] = []
+    for state in beam:
+        if len(state) < requested_portfolio_size_min:
+            continue
+        finalists.append((state_sort_key(state), state))
+    if not finalists:
+        return None
+    finalists.sort(key=lambda item: item[0], reverse=True)
+    selected_state = finalists[0][1]
+    selected = list(_selected_from_state(ordered, selected_state))
+    return selected, {
+        "beam_width": PORTFOLIO_SEARCH_BEAM_WIDTH,
+        "candidate_state_count": candidate_state_count,
+        "portfolio_state_count": len(scorecard_cache),
+        "pruned_state_count": pruned_state_count,
+        "finalist_state_count": len(finalists),
+        "search_input_count": len(ordered),
+    }
+
+
 def _portfolio_candidate_id(
     source_candidate_ids: Sequence[str], target: Decimal
 ) -> str:
@@ -464,51 +659,21 @@ def optimize_portfolio_candidate(
         key=lambda item: (_sleeve_score(item), _net_per_day(item), item.candidate_id),
         reverse=True,
     )
-    selected: list[CandidateEvidenceBundle] = []
-    selected_clusters: set[str] = set()
     rejected: list[dict[str, Any]] = list(invalid_evidence_rejections)
     max_allowed_correlation = MAX_ALLOWED_PAIRWISE_CORRELATION
-    for bundle in ordered:
-        cluster = _cluster_id(bundle)
-        if (
-            cluster in selected_clusters
-            and len(selected) >= requested_portfolio_size_min
-        ):
-            rejected.append(
-                {
-                    "candidate_id": bundle.candidate_id,
-                    "reason": "cluster_cap",
-                    "cluster": cluster,
-                }
-            )
-            continue
-        max_correlation = _max_pairwise_correlation(bundle, selected)
-        if (
-            max_correlation > max_allowed_correlation
-            and len(selected) >= requested_portfolio_size_min
-        ):
-            rejected.append(
-                {
-                    "candidate_id": bundle.candidate_id,
-                    "reason": "correlation_cap",
-                    "max_pairwise_correlation": str(max_correlation),
-                }
-            )
-            continue
-        selected.append(bundle)
-        selected_clusters.add(cluster)
-        if len(selected) >= requested_portfolio_size_max:
-            break
-        if len(selected) >= requested_portfolio_size_min:
-            candidate_scorecard = _portfolio_scorecard(
-                selected=selected,
-                target_net_pnl_per_day=target_net_pnl_per_day,
-                oracle_policy=oracle_policy,
-            )
-            if bool(candidate_scorecard.get("oracle_passed")):
-                break
-    if not selected or len(selected) < requested_portfolio_size_min:
+    selection_result = _select_portfolio_bundles(
+        ordered=ordered,
+        rejected=rejected,
+        target_net_pnl_per_day=target_net_pnl_per_day,
+        oracle_policy=oracle_policy,
+        requested_portfolio_size_min=requested_portfolio_size_min,
+        requested_portfolio_size_max=requested_portfolio_size_max,
+        max_allowed_correlation=max_allowed_correlation,
+    )
+    if selection_result is None:
         return None
+    selected, search_report = selection_result
+    selected_clusters = {_cluster_id(bundle) for bundle in selected}
 
     source_candidate_ids = tuple(item.candidate_id for item in selected)
     objective_scorecard = _portfolio_scorecard(
@@ -576,7 +741,8 @@ def optimize_portfolio_candidate(
         "max_single_symbol_contribution_share": objective_scorecard.get(
             "max_single_symbol_contribution_share"
         ),
-        "method": "deterministic_greedy_pareto_v1",
+        "method": "deterministic_beam_oracle_search_v1",
+        **search_report,
         "target_met": bool(objective_scorecard["target_met"]),
         "oracle_passed": bool(objective_scorecard["oracle_passed"]),
     }

--- a/services/torghut/tests/test_candidate_specs.py
+++ b/services/torghut/tests/test_candidate_specs.py
@@ -117,9 +117,10 @@ class TestCandidateSpecs(TestCase):
             f"microstructure_continuation_matched_filter_v1:profile-{index + 1}"
             for index in range(
                 len(
-                    candidate_specs_module._FAMILY_EXECUTION_PROFILES[
-                        "microstructure_continuation_matched_filter_v1"
-                    ]
+                    candidate_specs_module._execution_profiles_for_target(
+                        family_template_id="microstructure_continuation_matched_filter_v1",
+                        target_net_pnl_per_day=Decimal("500"),
+                    )
                 )
             )
         ]
@@ -164,6 +165,19 @@ class TestCandidateSpecs(TestCase):
             {spec.family_template_id for spec in portfolio_specs},
             set(candidate_specs_module._FAMILY_EXECUTION_PROFILES),
         )
+        self.assertEqual(
+            len(portfolio_specs),
+            sum(
+                len(
+                    candidate_specs_module._execution_profiles_for_target(
+                        family_template_id=family_template_id,
+                        target_net_pnl_per_day=Decimal("500"),
+                    )
+                )
+                for family_template_id in candidate_specs_module._FAMILY_EXECUTION_PROFILES
+            ),
+        )
+        self.assertGreater(len(portfolio_specs), 36)
         self.assertGreater(len(portfolio_specs), len(baseline_specs))
         complementary_spec = next(
             spec
@@ -174,6 +188,29 @@ class TestCandidateSpecs(TestCase):
             complementary_spec.feature_contract["family_selection"]["reasons"],
             ["portfolio_sleeve_diversification"],
         )
+
+    def test_portfolio_profit_target_profiles_include_oracle_coverage_sleeves(
+        self,
+    ) -> None:
+        coverage_profiles = (
+            candidate_specs_module._PORTFOLIO_ORACLE_COVERAGE_EXECUTION_PROFILES
+        )
+
+        self.assertEqual(
+            set(coverage_profiles), set(candidate_specs_module._FAMILY_RUNTIME)
+        )
+        for family_template_id, profiles in coverage_profiles.items():
+            self.assertEqual(len(profiles), 1)
+            profile = profiles[0]
+            self.assertLessEqual(
+                Decimal(str(profile["max_position_pct_equity"])),
+                Decimal("4.0"),
+                family_template_id,
+            )
+            self.assertEqual(
+                list(profile["universe_symbols"]),
+                list(candidate_specs_module._PORTFOLIO_COVERAGE_UNIVERSE_PROFILE),
+            )
 
     def test_same_family_whitepaper_hypotheses_get_distinct_execution_profiles(
         self,

--- a/services/torghut/tests/test_portfolio_optimizer.py
+++ b/services/torghut/tests/test_portfolio_optimizer.py
@@ -4,6 +4,7 @@ from decimal import Decimal
 from unittest import TestCase
 
 from app.trading.discovery.evidence_bundles import (
+    CandidateEvidenceBundle,
     evidence_bundle_blockers,
     evidence_bundle_from_frontier_candidate,
     evidence_bundle_from_payload,
@@ -524,3 +525,107 @@ class TestPortfolioOptimizer(TestCase):
             "executable_replay_passed_failed",
             portfolio.objective_scorecard["profit_target_oracle"]["blockers"],
         )
+
+    def test_optimizer_searches_past_concentrated_greedy_sleeve(self) -> None:
+        def bundle(
+            *,
+            candidate_id: str,
+            net_pnl_per_day: str,
+            symbol: str,
+            cluster: str,
+        ) -> CandidateEvidenceBundle:
+            return evidence_bundle_from_frontier_candidate(
+                candidate_spec_id=f"spec-{candidate_id}",
+                candidate={
+                    "candidate_id": candidate_id,
+                    "runtime_family": "microbar_cross_sectional_pairs",
+                    "runtime_strategy_name": "microbar-cross-sectional-pairs-v1",
+                    "family_template_id": "microbar_cross_sectional_pairs_v1",
+                    "objective_scorecard": {
+                        "net_pnl_per_day": net_pnl_per_day,
+                        "active_day_ratio": "1.0",
+                        "positive_day_ratio": "1.0",
+                        "worst_day_loss": "0",
+                        "max_drawdown": "0",
+                        "best_day_share": "0.2",
+                        "avg_filled_notional_per_day": "350000",
+                        "regime_slice_pass_rate": "0.55",
+                        "posterior_edge_lower": "0.01",
+                        "shadow_parity_status": "within_budget",
+                        "correlation_cluster": cluster,
+                        "symbol_contribution_shares": {symbol: "1.0"},
+                        **_executable_scorecard_fields(candidate_id),
+                    },
+                    "full_window": {
+                        "daily_net": {
+                            "2026-02-23": net_pnl_per_day,
+                            "2026-02-24": net_pnl_per_day,
+                            "2026-02-25": net_pnl_per_day,
+                            "2026-02-26": net_pnl_per_day,
+                            "2026-02-27": net_pnl_per_day,
+                        },
+                        "daily_filled_notional": {
+                            "2026-02-23": "350000",
+                            "2026-02-24": "350000",
+                            "2026-02-25": "350000",
+                            "2026-02-26": "350000",
+                            "2026-02-27": "350000",
+                        },
+                    },
+                },
+                dataset_snapshot_id="snapshot-beam-search",
+                result_path=f"/tmp/{candidate_id}.json",
+            )
+
+        portfolio = optimize_portfolio_candidate(
+            evidence_bundles=[
+                bundle(
+                    candidate_id="cand-concentrated",
+                    net_pnl_per_day="800",
+                    symbol="NVDA",
+                    cluster="concentrated-alpha",
+                ),
+                bundle(
+                    candidate_id="cand-diverse-a",
+                    net_pnl_per_day="200",
+                    symbol="AAPL",
+                    cluster="diverse-a",
+                ),
+                bundle(
+                    candidate_id="cand-diverse-b",
+                    net_pnl_per_day="200",
+                    symbol="AMZN",
+                    cluster="diverse-b",
+                ),
+                bundle(
+                    candidate_id="cand-diverse-c",
+                    net_pnl_per_day="200",
+                    symbol="GOOGL",
+                    cluster="diverse-c",
+                ),
+            ],
+            target_net_pnl_per_day=Decimal("500"),
+            portfolio_size_min=3,
+            portfolio_size_max=3,
+        )
+
+        self.assertIsNotNone(portfolio)
+        assert portfolio is not None
+        self.assertNotIn("cand-concentrated", portfolio.source_candidate_ids)
+        self.assertCountEqual(
+            portfolio.source_candidate_ids,
+            ("cand-diverse-a", "cand-diverse-b", "cand-diverse-c"),
+        )
+        self.assertTrue(portfolio.objective_scorecard["target_met"])
+        self.assertTrue(portfolio.objective_scorecard["oracle_passed"])
+        self.assertLessEqual(
+            Decimal(
+                portfolio.objective_scorecard["max_single_symbol_contribution_share"]
+            ),
+            Decimal("0.35"),
+        )
+        self.assertEqual(
+            portfolio.optimizer_report["method"],
+            "deterministic_beam_oracle_search_v1",
+        )
+        self.assertGreater(portfolio.optimizer_report["finalist_state_count"], 1)

--- a/services/torghut/tests/test_whitepaper_autoresearch_artifacts.py
+++ b/services/torghut/tests/test_whitepaper_autoresearch_artifacts.py
@@ -33,7 +33,12 @@ def _profile_ids_for_family(family_template_id: str) -> list[str]:
     return [
         f"{family_template_id}:profile-{index + 1}"
         for index in range(
-            len(candidate_specs_module._FAMILY_EXECUTION_PROFILES[family_template_id])
+            len(
+                candidate_specs_module._execution_profiles_for_target(
+                    family_template_id=family_template_id,
+                    target_net_pnl_per_day=Decimal("500"),
+                )
+            )
         )
     ]
 

--- a/services/torghut/tests/test_whitepaper_candidate_compiler.py
+++ b/services/torghut/tests/test_whitepaper_candidate_compiler.py
@@ -16,16 +16,38 @@ from app.trading.discovery.whitepaper_candidate_compiler import (
 _PORTFOLIO_TARGET_FAMILIES = set(candidate_specs_module._FAMILY_EXECUTION_PROFILES)
 
 
-def _profile_count_for_family(family_template_id: str) -> int:
-    return len(candidate_specs_module._FAMILY_EXECUTION_PROFILES[family_template_id])
+def _profile_count_for_family(
+    family_template_id: str,
+    *,
+    target_net_pnl_per_day: Decimal = Decimal("300"),
+) -> int:
+    return len(
+        candidate_specs_module._execution_profiles_for_target(
+            family_template_id=family_template_id,
+            target_net_pnl_per_day=target_net_pnl_per_day,
+        )
+    )
 
 
-def _expected_candidate_count(family_ids: set[str]) -> int:
-    return sum(_profile_count_for_family(family_id) for family_id in family_ids)
+def _expected_candidate_count(
+    family_ids: set[str],
+    *,
+    target_net_pnl_per_day: Decimal = Decimal("300"),
+) -> int:
+    return sum(
+        _profile_count_for_family(
+            family_id,
+            target_net_pnl_per_day=target_net_pnl_per_day,
+        )
+        for family_id in family_ids
+    )
 
 
 def _expected_portfolio_target_candidate_count() -> int:
-    return _expected_candidate_count(_PORTFOLIO_TARGET_FAMILIES)
+    return _expected_candidate_count(
+        _PORTFOLIO_TARGET_FAMILIES,
+        target_net_pnl_per_day=Decimal("500"),
+    )
 
 
 class TestWhitepaperCandidateCompiler(TestCase):
@@ -66,7 +88,10 @@ class TestWhitepaperCandidateCompiler(TestCase):
                 for family_id in family_ids
             },
             {
-                family_id: _profile_count_for_family(family_id)
+                family_id: _profile_count_for_family(
+                    family_id,
+                    target_net_pnl_per_day=Decimal("500"),
+                )
                 for family_id in _PORTFOLIO_TARGET_FAMILIES
             },
         )

--- a/services/torghut/tests/test_whitepaper_workflow.py
+++ b/services/torghut/tests/test_whitepaper_workflow.py
@@ -4,6 +4,7 @@ import json
 import os
 import tempfile
 from dataclasses import dataclass
+from decimal import Decimal
 from typing import Any, cast
 from unittest import TestCase
 from unittest.mock import patch
@@ -47,7 +48,12 @@ def _profile_ids_for_family(family_template_id: str) -> list[str]:
     return [
         f"{family_template_id}:profile-{index + 1}"
         for index in range(
-            len(candidate_specs_module._FAMILY_EXECUTION_PROFILES[family_template_id])
+            len(
+                candidate_specs_module._execution_profiles_for_target(
+                    family_template_id=family_template_id,
+                    target_net_pnl_per_day=Decimal("500"),
+                )
+            )
         )
     ]
 


### PR DESCRIPTION
## Summary

- Replaces the Torghut portfolio optimizer's single greedy sleeve selection with a bounded deterministic beam search.
- Keeps the same profit-target oracle, executable replay, concentration, correlation, and proof gates; the search only changes which combinations are evaluated.
- Adds optimizer report diagnostics for beam width, state counts, pruning, finalists, and search input size.
- Adds `$500/day` target-only coverage execution profiles so autoresearch can test more active, lower-notional diversified sleeves across the full portfolio family set.
- Adds a regression proving the optimizer skips a higher-PnL concentrated sleeve when a diversified lower-PnL combination is the oracle-passing portfolio.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_portfolio_optimizer.py -q`
- `uv run --frozen ruff format --check app/trading/discovery/portfolio_optimizer.py tests/test_portfolio_optimizer.py`
- `uv run --frozen ruff check app/trading/discovery/portfolio_optimizer.py tests/test_portfolio_optimizer.py`
- `uv run --frozen pytest tests/test_whitepaper_autoresearch_artifacts.py::TestWhitepaperAutoresearchArtifacts::test_portfolio_optimizer_uses_daily_vectors_and_correlation_cap tests/test_runtime_closure.py -q`
- `uv run --frozen pytest tests/test_candidate_specs.py tests/test_whitepaper_candidate_compiler.py -q`
- `uv run --frozen pytest tests/test_portfolio_optimizer.py tests/test_candidate_specs.py tests/test_whitepaper_autoresearch_artifacts.py::TestWhitepaperAutoresearchArtifacts::test_portfolio_optimizer_uses_daily_vectors_and_correlation_cap tests/test_runtime_closure.py -q`
- `uv run --frozen pytest tests/test_whitepaper_autoresearch_artifacts.py -q`
- `uv run --frozen pytest tests/test_whitepaper_autoresearch_artifacts.py::TestWhitepaperAutoresearchArtifacts::test_hypothesis_and_candidate_specs_round_trip tests/test_candidate_specs.py tests/test_whitepaper_candidate_compiler.py tests/test_whitepaper_workflow.py::TestWhitepaperWorkflow::test_structured_outputs_compile_claims_when_experiment_specs_are_absent -q`
- `uv run --frozen ruff format --check app/trading/discovery/candidate_specs.py app/trading/discovery/portfolio_optimizer.py tests/test_candidate_specs.py tests/test_portfolio_optimizer.py tests/test_whitepaper_autoresearch_artifacts.py tests/test_whitepaper_candidate_compiler.py tests/test_whitepaper_workflow.py`
- `uv run --frozen ruff check app/trading/discovery/candidate_specs.py app/trading/discovery/portfolio_optimizer.py tests/test_candidate_specs.py tests/test_portfolio_optimizer.py tests/test_whitepaper_autoresearch_artifacts.py tests/test_whitepaper_candidate_compiler.py tests/test_whitepaper_workflow.py`
- `uv run --frozen ruff check tests/test_whitepaper_autoresearch_artifacts.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py tests/test_whitepaper_candidate_compiler.py tests/test_whitepaper_workflow.py -q`
- Python compiler smoke confirming `$300` remains 15 specs across 3 families and `$500` expands to 45 specs across 9 families.
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
