### PR TITLE
fix(sag): make codex cli executable in runtime

### DIFF
--- a/argocd/sag/deployment.yaml
+++ b/argocd/sag/deployment.yaml
@@ -54,7 +54,7 @@ spec:
             - name: CODEX_AUTH
               value: /home/bun/.codex/auth.json
             - name: SAG_CODEX_BINARY
-              value: codex
+              value: /usr/local/bin/codex
             - name: SAG_CODEX_CWD
               value: /tmp
             - name: DATABASE_URL

--- a/argocd/sag/kustomization.yaml
+++ b/argocd/sag/kustomization.yaml
@@ -12,4 +12,4 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/sag
     newName: registry.ide-newton.ts.net/lab/sag
-    newTag: "sag-20260513093939"
+    newTag: "sag-20260513095012"

--- a/docs/secure-action-gateway/submission-evidence.md
+++ b/docs/secure-action-gateway/submission-evidence.md
@@ -7,7 +7,7 @@ Owner: Greg Konush
 
 - Live URL: https://sag.proompteng.ai
 - Kubernetes namespace: `sag`
-- Deployed image: `registry.ide-newton.ts.net/lab/sag:sag-20260513093939`
+- Deployed image: `registry.ide-newton.ts.net/lab/sag:sag-20260513095012`
 - Database: CNPG cluster `sag-db` in namespace `sag`
 - Source paths: `services/sag`, `argocd/sag`, `packages/scripts/src/sag`
 
@@ -97,7 +97,7 @@ Expected live result:
 | Requirement                              | Evidence                                                 |
 | ---------------------------------------- | -------------------------------------------------------- |
 | Working product URL or runnable artifact | `https://sag.proompteng.ai`; `services/sag`              |
-| Source code                              | `services/sag`, `argocd/sag`, `packages/scripts/src/sag`; PRs `#6452`, `#6453` |
+| Source code                              | `services/sag`, `argocd/sag`, `packages/scripts/src/sag`; PRs `#6452`, `#6453`, `#6454` |
 | PRD, 1-2 pages                           | `docs/secure-action-gateway/prd-submission.md`           |
 | TDD, 1-2 pages                           | `docs/secure-action-gateway/tdd-submission.md`           |
 | 2-5 minute walkthrough                   | Record the workflow above against the live URL           |
@@ -131,3 +131,4 @@ What broke and how it was debugged:
 - The first loader pulled Postgres code into the browser bundle. Build output showed browser externalization warnings, so the loader was moved to a TanStack Start server function.
 - The first persistence version wrote normalized state beside legacy JSON. Live logs exposed undefined values from older persisted rows, so state normalization and JSON parameter sanitization were added before rollout.
 - Argo reverted direct cluster applies until the image tag was committed and merged through GitOps, so rollout evidence now tracks both the direct deploy and the GitOps image promotion.
+- The Codex CLI was initially installed without Node available in the runtime image. The runner now carries Node 24 and points `SAG_CODEX_BINARY` at the installed Codex executable.

--- a/services/sag/Dockerfile
+++ b/services/sag/Dockerfile
@@ -14,16 +14,23 @@ COPY scripts ./scripts
 RUN bun install --frozen-lockfile --ignore-scripts
 RUN bun run build:sag
 
+FROM node:24.11.1-bookworm-slim AS node-runtime
+
 FROM oven/bun:${BUN_VERSION}-slim AS runner
 WORKDIR /app
 ENV NODE_ENV=production
 ENV PORT=3000
 ENV CODEX_HOME=/home/bun/.codex
 ENV CODEX_AUTH=/home/bun/.codex/auth.json
+ENV BUN_INSTALL=/home/bun/.bun
+ENV PATH=/home/bun/.bun/bin:/usr/local/bin:/usr/bin:/bin:/usr/local/games:/usr/games
 
 COPY --from=builder /workspace/services/sag/.output ./.output
+COPY --from=node-runtime /usr/local/bin/node /usr/local/bin/node
 
-RUN mkdir -p /home/bun/.codex && chown -R bun:bun /home/bun/.codex && bun add -g @openai/codex@latest
+RUN mkdir -p /home/bun/.bun /home/bun/.codex \
+  && bun add -g @openai/codex@latest \
+  && chown -R bun:bun /home/bun/.bun /home/bun/.codex
 
 USER bun
 EXPOSE 3000


### PR DESCRIPTION
## Summary

- Add Node 24 to the SAG runtime image so the npm Codex CLI executable can run inside the pod.
- Install Codex under the Bun global package location and point `SAG_CODEX_BINARY` at `/usr/local/bin/codex`.
- Promote image `registry.ide-newton.ts.net/lab/sag:sag-20260513095012` and update submission evidence with the runtime fix.

## Related Issues

None

## Testing

- `SAG_IMAGE_TAG=sag-20260513095012 bun run sag:deploy`
- `docker run --rm --entrypoint sh registry.ide-newton.ts.net/lab/sag:sag-20260513095012 -c 'whoami; echo PATH=$PATH; command -v node; node --version; command -v codex; codex --version'`
- `bun run --filter @proompteng/sag test`
- `bun run --filter @proompteng/sag tsc`
- `bun run --filter @proompteng/sag lint`
- `bun run --filter @proompteng/sag lint:oxlint`
- `bun run lint:argocd`
- `git diff --check`
- `git diff --check origin/main..HEAD`

## Screenshots (if applicable)

Not applicable. This PR fixes the runtime image and GitOps deployment configuration for Codex-backed rule translation.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
