### PR TITLE
fix(sag): add ca certificates for codex runtime

### DIFF
--- a/argocd/sag/kustomization.yaml
+++ b/argocd/sag/kustomization.yaml
@@ -12,4 +12,4 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/sag
     newName: registry.ide-newton.ts.net/lab/sag
-    newTag: "sag-20260513095012"
+    newTag: "sag-20260513095640"

--- a/docs/secure-action-gateway/submission-evidence.md
+++ b/docs/secure-action-gateway/submission-evidence.md
@@ -7,7 +7,7 @@ Owner: Greg Konush
 
 - Live URL: https://sag.proompteng.ai
 - Kubernetes namespace: `sag`
-- Deployed image: `registry.ide-newton.ts.net/lab/sag:sag-20260513095012`
+- Deployed image: `registry.ide-newton.ts.net/lab/sag:sag-20260513095640`
 - Database: CNPG cluster `sag-db` in namespace `sag`
 - Source paths: `services/sag`, `argocd/sag`, `packages/scripts/src/sag`
 
@@ -97,7 +97,7 @@ Expected live result:
 | Requirement                              | Evidence                                                 |
 | ---------------------------------------- | -------------------------------------------------------- |
 | Working product URL or runnable artifact | `https://sag.proompteng.ai`; `services/sag`              |
-| Source code                              | `services/sag`, `argocd/sag`, `packages/scripts/src/sag`; PRs `#6452`, `#6453`, `#6454` |
+| Source code                              | `services/sag`, `argocd/sag`, `packages/scripts/src/sag`; PRs `#6452`, `#6453`, `#6454`, `#6455` |
 | PRD, 1-2 pages                           | `docs/secure-action-gateway/prd-submission.md`           |
 | TDD, 1-2 pages                           | `docs/secure-action-gateway/tdd-submission.md`           |
 | 2-5 minute walkthrough                   | Record the workflow above against the live URL           |
@@ -131,4 +131,4 @@ What broke and how it was debugged:
 - The first loader pulled Postgres code into the browser bundle. Build output showed browser externalization warnings, so the loader was moved to a TanStack Start server function.
 - The first persistence version wrote normalized state beside legacy JSON. Live logs exposed undefined values from older persisted rows, so state normalization and JSON parameter sanitization were added before rollout.
 - Argo reverted direct cluster applies until the image tag was committed and merged through GitOps, so rollout evidence now tracks both the direct deploy and the GitOps image promotion.
-- The Codex CLI was initially installed without Node available in the runtime image. The runner now carries Node 24 and points `SAG_CODEX_BINARY` at the installed Codex executable.
+- The Codex CLI was initially installed without Node or a native CA bundle available in the runtime image. The runner now carries Node 24, native CA certificates, and points `SAG_CODEX_BINARY` at the installed Codex executable.

--- a/services/sag/Dockerfile
+++ b/services/sag/Dockerfile
@@ -24,6 +24,11 @@ ENV CODEX_HOME=/home/bun/.codex
 ENV CODEX_AUTH=/home/bun/.codex/auth.json
 ENV BUN_INSTALL=/home/bun/.bun
 ENV PATH=/home/bun/.bun/bin:/usr/local/bin:/usr/bin:/bin:/usr/local/games:/usr/games
+ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /workspace/services/sag/.output ./.output
 COPY --from=node-runtime /usr/local/bin/node /usr/local/bin/node


### PR DESCRIPTION
## Summary

- Install native CA certificates in the SAG runtime image so Codex app-server streams can validate outbound TLS.
- Set `SSL_CERT_FILE` for the runtime and promote image `registry.ide-newton.ts.net/lab/sag:sag-20260513095640`.
- Update submission evidence with the final Codex runtime requirements: Node 24, Codex CLI, and CA bundle.

## Related Issues

None

## Testing

- `SAG_IMAGE_TAG=sag-20260513095640 bun run sag:deploy`
- `docker run --rm --entrypoint sh registry.ide-newton.ts.net/lab/sag:sag-20260513095640 -c '/usr/local/bin/node --version && /usr/local/bin/codex --version && test -s /etc/ssl/certs/ca-certificates.crt && echo certs-present && echo SSL_CERT_FILE=$SSL_CERT_FILE'`
- `bun run --filter @proompteng/sag test`
- `bun run --filter @proompteng/sag tsc`
- `bun run --filter @proompteng/sag lint`
- `bun run --filter @proompteng/sag lint:oxlint`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

Not applicable. This PR fixes runtime TLS support for the Codex-backed rule translator.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
