### PR TITLE
chore(jangar): promote image 40d6ffb9

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 146bbce5
-  digest: sha256:5a333a5d3a631ec2e16a2681b443d3a9309e080bd2216c2756e67f83be0b6157
+  tag: 40d6ffb9
+  digest: sha256:f32b21ef4f8d1f223fa25ee151126b1540d189ed902c05c6d9a6a3b73b617be6
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,8 +11,8 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 146bbce5
-    digest: sha256:e2b2a6bc2c5cf7cae253e1dd17b080ff206b1e46fe75d71a3592a039aa9a2675
+    tag: 40d6ffb9
+    digest: sha256:11d24bc21ccff1c5227d9edddeb4c778fe44f0f47dd2e4b99b6f5c8919b79dc6
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
@@ -21,8 +21,8 @@ controlPlane:
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 146bbce5
-    digest: sha256:5a333a5d3a631ec2e16a2681b443d3a9309e080bd2216c2756e67f83be0b6157
+    tag: 40d6ffb9
+    digest: sha256:f32b21ef4f8d1f223fa25ee151126b1540d189ed902c05c6d9a6a3b73b617be6
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-13T16:13:00Z
+    deploy.knative.dev/rollout: 2026-05-13T17:03:02Z
 spec:
   replicas: 1
   strategy:
@@ -57,11 +57,11 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_RUNTIME_IMAGE
-              value: registry.ide-newton.ts.net/lab/jangar:146bbce5@sha256:5a333a5d3a631ec2e16a2681b443d3a9309e080bd2216c2756e67f83be0b6157
+              value: registry.ide-newton.ts.net/lab/jangar:40d6ffb9@sha256:f32b21ef4f8d1f223fa25ee151126b1540d189ed902c05c6d9a6a3b73b617be6
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: 146bbce57898673937a5e9a2fe684797b2dce33c
+              value: 40d6ffb900716cd9a6b5f1955ba753671f6e9d70
             - name: JANGAR_GITOPS_REVISION
-              value: 146bbce57898673937a5e9a2fe684797b2dce33c
+              value: 40d6ffb900716cd9a6b5f1955ba753671f6e9d70
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_BUMBA_TASK_QUEUE

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -59,5 +59,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: 146bbce5
-    digest: sha256:5a333a5d3a631ec2e16a2681b443d3a9309e080bd2216c2756e67f83be0b6157
+    newTag: 40d6ffb9
+    digest: sha256:f32b21ef4f8d1f223fa25ee151126b1540d189ed902c05c6d9a6a3b73b617be6


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `40d6ffb900716cd9a6b5f1955ba753671f6e9d70`
- Image tag: `40d6ffb9`
- Image digest: `sha256:f32b21ef4f8d1f223fa25ee151126b1540d189ed902c05c6d9a6a3b73b617be6`
- Updated API rollout annotation
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`