### PR TITLE
docs(sag): add panel presentation evidence

### DIFF
--- a/docs/secure-action-gateway/README.md
+++ b/docs/secure-action-gateway/README.md
@@ -12,4 +12,5 @@ Documents:
 - [Submission PRD](./prd-submission.md)
 - [Submission TDD](./tdd-submission.md)
 - [Submission Evidence](./submission-evidence.md)
+- [Panel Presentation](./panel-presentation.md)
 - [Product Requirements Document](./prd.md)

--- a/docs/secure-action-gateway/panel-presentation.md
+++ b/docs/secure-action-gateway/panel-presentation.md
@@ -1,0 +1,67 @@
+# SAG Panel Presentation
+
+## 1. Problem
+
+Enterprises want agents to replace brittle internal dashboards, scripts, and runbooks, but they cannot hand agents production authority without control over identity, policy, approvals, connectors, and audit evidence.
+
+## 2. Product
+
+SAG is a behind-the-firewall action gateway. An operator submits a natural-language task. SAG creates a plan, evaluates policy before each connector call, executes safe read steps, holds risky mutations for approval, and writes every decision to an audit trail.
+
+## 3. Live Workflow
+
+Open `https://sag.proompteng.ai`.
+
+Run:
+
+```text
+Final panel smoke: inspect live agent runs, read SQL policy state, query audit graph, and parse the legacy feed
+```
+
+Show:
+
+- Task succeeds.
+- SQL, REST, GraphQL, and legacy connector steps are recorded.
+- AgentRun secrets are redacted as `secret:<hash>`.
+- Audit export includes task intake, plan, connector calls, and policy decisions.
+
+## 4. Guarded Mutation
+
+Run:
+
+```text
+Final panel smoke: inspect AgentRuns and execute a guarded restart if policy allows it
+```
+
+Show:
+
+- The task enters `waiting_approval`.
+- The approval row shows `guarded_action.execute`.
+- Approving as `greg` moves the task to `succeeded` with decision `approved`.
+
+## 5. Codex Rule Creation
+
+Run:
+
+```text
+Require approval before agents change billing database records
+```
+
+Show:
+
+- The rule is created with translator `codex-app-server`.
+- The rule targets mutating operations and participates in later approval decisions.
+
+## 6. Evidence
+
+- Live URL: `https://sag.proompteng.ai`
+- Argo app: `sag`, `Synced Healthy`
+- Final image: `registry.ide-newton.ts.net/lab/sag:sag-20260513095640`
+- Database counts after smoke: `tasks=5`, `calls=20`, `events=39`, `approvals=2`, `rules=5`
+- Source PRs: `#6452`, `#6453`, `#6454`, `#6455`, `#6456`
+
+## 7. Close
+
+This is not an AgentRun viewer and not a mock dashboard. The implemented primitive is: `identity -> task -> plan step -> connector call -> policy decision -> approval -> audit event`.
+
+The wedge is safe internal action execution. The platform path is connector breadth, policy primitives, approval workflows, and compliance evidence across every enterprise system an agent touches.

--- a/docs/secure-action-gateway/submission-evidence.md
+++ b/docs/secure-action-gateway/submission-evidence.md
@@ -85,22 +85,24 @@ curl -fsS -X POST https://sag.proompteng.ai/api/rules \
 curl -fsS https://sag.proompteng.ai/api/events/export
 ```
 
-Expected live result:
+Verified live result on 2026-05-13:
 
-- The read task succeeds and records SQL, REST, GraphQL, and legacy connector calls.
-- The guarded mutation task enters `waiting_approval` before executing the risky step.
-- Approving the generated approval records an `approval:approved` event and completes the held decision.
-- The JSONL export contains task, plan, connector, policy, approval, and audit events without raw secret values.
+- Read task `task-00066` succeeded and recorded SQL, REST, GraphQL, and legacy connector calls.
+- Guarded mutation task `task-00081` entered `waiting_approval` before executing `guarded_action.execute`.
+- Approval `appr-00097` moved to `approved` and task `task-00081` completed with decision `approved`.
+- Natural-language rule `rule-00062` was created by translator `codex-app-server`.
+- JSONL export contained task, plan, connector, policy, approval, and audit events without raw secret values.
+- CNPG row counts after smoke: `tasks=5`, `calls=20`, `events=39`, `approvals=2`, `rules=5`.
 
 ## Deliverable Map
 
 | Requirement                              | Evidence                                                 |
 | ---------------------------------------- | -------------------------------------------------------- |
 | Working product URL or runnable artifact | `https://sag.proompteng.ai`; `services/sag`              |
-| Source code                              | `services/sag`, `argocd/sag`, `packages/scripts/src/sag`; PRs `#6452`, `#6453`, `#6454`, `#6455` |
+| Source code                              | `services/sag`, `argocd/sag`, `packages/scripts/src/sag`; PRs `#6452`, `#6453`, `#6454`, `#6455`, `#6456` |
 | PRD, 1-2 pages                           | `docs/secure-action-gateway/prd-submission.md`           |
 | TDD, 1-2 pages                           | `docs/secure-action-gateway/tdd-submission.md`           |
-| 2-5 minute walkthrough                   | Record the workflow above against the live URL           |
+| 2-5 minute walkthrough                   | `docs/secure-action-gateway/panel-presentation.md`       |
 | Authorship/build note                    | See below                                                |
 
 ## Authorship / Build Note


### PR DESCRIPTION
## Summary

- Add a concise SAG panel presentation script that walks through problem, product, live workflow, guarded mutation, Codex rule creation, and close.
- Update the submission evidence with final live smoke results, database counts, and PR `#6456`.
- Link the presentation from the Secure Action Gateway documentation index.

## Related Issues

None

## Testing

- `git diff --check`
- `git diff --check origin/main..HEAD`
- Live validation performed before this docs update:
  - `kubectl get application sag -n argocd`
  - `kubectl get deploy sag -n sag -o jsonpath='{.spec.template.spec.containers[0].image}{"\\n"}{.status.readyReplicas}{"/"}{.status.replicas}{" ready\\n"}'`
  - `curl -fsS https://sag.proompteng.ai/api/health`
  - `curl -fsS -X POST https://sag.proompteng.ai/api/tasks` for read and guarded-mutation tasks.
  - `curl -fsS -X POST https://sag.proompteng.ai/api/rules` for Codex-backed rule creation.
  - `kubectl cnpg psql -n sag sag-db -- -d sag -tAc` for persisted row counts.

## Screenshots (if applicable)

Not applicable. This PR adds the panel presentation and final evidence notes.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
