### PR TITLE
docs(jangar): add rollout proof passport architecture

### DIFF
--- a/docs/agents/designs/191-jangar-rollout-proof-passports-and-runner-capacity-futures-2026-05-13.md
+++ b/docs/agents/designs/191-jangar-rollout-proof-passports-and-runner-capacity-futures-2026-05-13.md
@@ -1,0 +1,529 @@
+# 191. Jangar Rollout Proof Passports And Runner Capacity Futures (2026-05-13)
+
+Status: Accepted for engineer and deployer handoff
+Date: 2026-05-13
+Owner: Victor Chen, Jangar Engineering Architecture
+Scope: Jangar control-plane rollout truth, AgentRun launch reliability, runner capacity settlement, merge-ready
+evidence, Torghut repair dispatch custody, validation, rollout, rollback, and cross-stage handoff.
+
+Companion Torghut contract:
+
+- `docs/torghut/design-system/v6/196-torghut-profit-carry-passports-and-repair-capacity-futures-2026-05-13.md`
+
+Extends:
+
+- `docs/agents/designs/132-jangar-renewable-passport-ledger-and-proof-floor-actuation-2026-05-07.md`
+- `docs/agents/designs/190-jangar-projection-foreclosure-notary-and-stage-custody-repair-2026-05-13.md`
+- `docs/agents/designs/188-jangar-ready-truth-arbiter-and-stage-credit-cutover-2026-05-13.md`
+- `docs/agents/designs/187-jangar-main-source-ci-retention-and-source-serving-verdicts-2026-05-13.md`
+- `docs/agents/designs/185-jangar-clearance-market-and-rollout-truth-settlement-2026-05-12.md`
+- `docs/agents/designs/148-jangar-source-rollout-truth-exchange-and-proof-floor-settlement-2026-05-07.md`
+- `docs/agents/runbooks.md`
+
+## Decision
+
+I am selecting **rollout proof passports with runner capacity futures** as the next Jangar control-plane architecture
+increment.
+
+The current system can serve status and can run work, but it still asks deployers and schedulers to infer a complete
+rollout truth from separate signals: PR checks, image digests, Argo revision, live pods, source-serving verdicts,
+controller heartbeats, AgentRun outcomes, and Torghut repair posture. On the 2026-05-13 read-only assessment, Argo
+reported `agents`, `jangar`, and `torghut` as `Synced/Healthy` at revision
+`704ef0aebc13722e541c006edddee4b4610c3424`. The main workloads were ready: `agents=1/1`,
+`agents-controllers=2/2`, `jangar=1/1`, and the current Torghut live/sim revisions were ready.
+
+That is good availability evidence, but it is not enough launch authority. The same pass found material holds:
+`ready_action_exchange.status=block`, dispatch and merge-ready custody receipts in `hold`, source-serving contract
+verdicts blocked by `source_ci_retention_receipt_missing`, `manifest_sha_missing`, and
+`manifest_image_digest_missing`, controller heartbeat split evidence, and current stage-credit holds for plan work.
+In the last roughly 24 hours, all retained AgentRuns summarized to `103` succeeded, `13` failed, `6` pending, and
+`2` running; Jangar control-plane retained `49` succeeded, `5` failed, and `2` running. The active plan AgentRun had
+already retried after a failed attempt, and its second attempt saw a `FailedScheduling` event: `0/2 nodes are
+available`, with one node failing affinity and one node carrying an untolerated taint before it eventually scheduled.
+Recent verify lanes also showed `WorkflowStepTimedOut`.
+
+The selected design turns the missing middle into a first-class contract. A rollout proof passport is the single
+source-settled statement that a PR, source revision, image digest, manifest, Argo sync, workload, status route,
+database projection, controller heartbeat, and post-rollout verification all point to the same system state. A runner
+capacity future is the matching statement that a stage has enough schedulable execution capacity before it launches
+normal work. Stage launch tickets consume both. This reduces failed AgentRuns by refusing normal launch when the
+system already knows capacity or proof is missing, and it shortens green PR-to-healthy rollout time by making the
+missing proof explicit instead of rediscovered by deployers.
+
+This is the next layer after the renewable passport ledger work from 2026-05-07. That contract made launch proof
+renewable and retirable across schedule generations. This contract narrows the high-value path to source-to-serving
+rollout proof and adds a pre-launch capacity future so a current passport cannot still launch into an obviously
+unschedulable lane.
+
+The tradeoff is that Jangar will hold some dispatch and merge-ready work even when Argo is green and pods are ready. I
+accept that. The business metric is to reduce failed AgentRuns and shorten green PR-to-healthy GitOps rollout time, not
+to maximize launches. A held stage with named missing proof is cheaper than a failed AgentRun that spends a runner,
+produces partial handoff evidence, and requires manual interpretation.
+
+## Governing Runtime Requirements
+
+This design binds to the active swarm validation contract:
+
+- every run must cite the governing design or runtime requirement before changing code;
+- implement stages must produce production PRs with tests or report the exact blocker to code;
+- verify stages must merge only green PRs and prove Argo, workload readiness, and service health after rollout;
+- final handoff must name the control-plane metric improved or the smallest blocker preventing improvement.
+
+Every milestone maps to at least one required value gate:
+
+- `failed_agentrun_rate`
+- `pr_to_rollout_latency`
+- `ready_status_truth`
+- `manual_intervention_count`
+- `handoff_evidence_quality`
+
+## Read-Only Evidence Snapshot
+
+All evidence below was collected read-only on 2026-05-13. I did not mutate Kubernetes resources, database rows,
+GitOps resources, AgentRuns, broker state, trading flags, or market data.
+
+### Runtime Scope And NATS
+
+- Runtime inputs resolved to repository `proompteng/lab`, base `main`, head
+  `codex/swarm-jangar-control-plane-plan`, swarm `jangar-control-plane`, stage `plan`, live channel `general`, owner
+  channel `swarm://owner/platform`, and mission ledger
+  `/workspace/.agentrun/swarm/jangar-control-plane-mission-ledger.md`.
+- The working branch started at `704ef0aebc13722e541c006edddee4b4610c3424`, equal to the fetched `origin/main`.
+- The NATS context soak against `workflow.general.>` fetched messages but returned no parseable branch-relevant
+  teammate context, so durable repo and live-cluster evidence are the audit source for this pass.
+
+### Cluster, Rollout, And Events
+
+- Argo CD reported `agents`, `jangar`, and `torghut` as `Synced/Healthy` at revision
+  `704ef0aebc13722e541c006edddee4b4610c3424`.
+- `agents` namespace deployments were ready: `deployment/agents=1/1`,
+  `deployment/agents-controllers=2/2`, and `deployment/agents-alloy=1/1`.
+- `jangar` namespace deployments were ready: `deployment/jangar=1/1`, with the app container on
+  `registry.ide-newton.ts.net/lab/jangar:146bbce5@sha256:5a333a5d...`, plus ready `bumba`, `symphony`,
+  `symphony-jangar`, and `jangar-alloy`.
+- Torghut serving was available after the latest rollout: `torghut-00359-deployment=1/1` and
+  `torghut-sim-00457-deployment=1/1`; older Knative revisions were scaled to `0/0`.
+- Recent `agents` events showed rollout readiness noise, including `agents-controllers` HTTP 503 readiness failures,
+  a temporary schedule-template `FailedMount`, and the active plan AgentRun delayed by `FailedScheduling` before it
+  landed on `talos-192-168-1-85`.
+- The active plan AgentRun `jangar-control-plane-plan-sched-6sjkd` carried stage-credit and stage-clearance `hold`
+  annotations. Its reason codes included `controller_heartbeat_not_current`, `controller_witness_allow_with_split`,
+  `evidence_clock_custody_blocked`, `route_stability_hold`, `source_rollout_truth_hold`, and
+  `stage_credit_insufficient`.
+- Jangar control-plane AgentRuns created in the last roughly 24 hours summarized to `49` succeeded, `5` failed, and
+  `2` running. Failed Jangar implement runs included `BackoffLimitExceeded`; failed verify runs included
+  `WorkflowStepTimedOut`.
+- All AgentRuns created in the same window summarized to `103` succeeded, `13` failed, `6` pending, and `2` running.
+  This is a healthy success majority, but the failure and pending tail is large enough to justify launch admission
+  improvements.
+
+### Jangar Runtime, Source, And Test Surface
+
+- `curl http://agents.agents.svc.cluster.local/ready` returned HTTP 200 with `status=ok`; the serving passport was
+  present and leader election reported the agents service replica as leader for the `agents` namespace.
+- `curl http://jangar.jangar.svc.cluster.local/ready` returned HTTP 200 with `status=ok`; the Jangar service replica
+  was leader for its own control-plane lease.
+- `curl http://jangar.jangar.svc.cluster.local/api/agents/control-plane/status?namespace=agents` reported
+  `database.status=healthy`, `database.connected=true`, latency `4ms`, migration consistency `29/29`, and latest
+  applied migration `20260508_torghut_quant_pipeline_health_account_window_created_at_index`.
+- The same status route reported `agentrun_ingestion.status=unknown` with message `agents controller not started`.
+  The controller witness layer considered that a split projection rather than total outage because the controller
+  deployment itself was ready.
+- `ready_action_exchange` was in `observe` mode but `status=block`. It allowed `serve_readonly` and
+  `torghut_observe`, held `dispatch_repair`, `dispatch_normal`, `deploy_widen`, `merge_ready`, and `paper_canary`,
+  and blocked `live_micro_canary` and `live_scale`.
+- `source_serving_contract_verdict_exchange.status=block`, with missing source CI retention and manifest digest
+  receipts. This is the direct evidence that a green deployment does not yet prove green PR-to-serving truth.
+- High-risk source modules are already large and highly coupled: `agents-controller/index.ts` is `1827` lines,
+  `control-plane-status.ts` is `766` lines, `control-plane-action-custody.ts` is `595` lines,
+  `control-plane-stage-clearance.ts` is `563` lines, `control-plane-ready-truth-arbiter.ts` is `442` lines, and
+  `services/jangar/src/data/agents-control-plane.ts` is `2386` lines.
+- Existing focused tests cover control-plane status, action custody, stage clearance, ready truth, terminal debt,
+  source-serving verdicts, watch reliability, and Torghut consumer evidence. The remaining gap is not basic reducer
+  coverage; it is cross-surface admission coverage that proves a PR, rollout, source-serving status, and runner slot
+  agree before normal launch.
+
+### Database, Data Quality, And Freshness
+
+- Direct CNPG resource inspection was blocked by RBAC for `clusters.postgresql.cnpg.io`,
+  `scheduledbackups.postgresql.cnpg.io`, and `backups.postgresql.cnpg.io` in namespace `jangar`. Direct statefulset
+  listing was also forbidden. This reinforces that the rollout proof contract must use service-level read evidence,
+  not privileged database pod access, as its normal worker path.
+- Jangar application database status was healthy through the control-plane status route: connected, `29` registered
+  migrations, `29` applied migrations, no missing or unexpected migrations, latest applied migration
+  `20260508_torghut_quant_pipeline_health_account_window_created_at_index`.
+- Torghut `/db-check` returned `ok=true`, schema current at Alembic head
+  `0031_autoresearch_candidate_spec_epoch_uniqueness`, expected and current head count `1`, no missing or unexpected
+  heads, and lineage ready with known parent-fork warnings.
+- Torghut `/readyz` returned HTTP 503 with `status=degraded`, but the dependencies were specific: scheduler,
+  Postgres, ClickHouse, Alpaca, database schema, universe, and empirical jobs were OK. Live submission was blocked by
+  `simple_submit_disabled`; profitability proof floor was `repair_only`; capital state was `zero_notional`; promotion
+  eligible hypotheses were `0`.
+- Torghut route custody showed useful repair evidence but no capital authority. The consumer evidence route carried a
+  route warrant ref and blockers including `quant_health_not_configured`, `market_context_stale`,
+  `route_tca_missing`, `max_notional_zero`, and `profit_signal_quorum_observe_only`.
+
+## Problem
+
+The control plane has accumulated the right ingredients but still lacks a single admission object that answers two
+questions before material work starts:
+
+1. Is the rollout truth complete for this source revision?
+2. Is there schedulable runner capacity for this stage and action class?
+
+The current failure modes are concrete:
+
+- Argo can be `Synced/Healthy` while source-serving contract verdicts are blocked by missing CI retention and manifest
+  digest receipts.
+- `/ready` can be `ok` for serving while action custody correctly holds dispatch and merge-ready work.
+- Controller witness can be split, which is safe for serving status but not enough for normal material launch.
+- A stage can have a valid AgentRun object and still hit `FailedScheduling` because node affinity, taints, PVC, image,
+  or runtime budget were not settled before launch.
+- Verify stages can timeout after green CI because rollout proof and post-rollout service checks are reconstructed
+  late rather than carried as a passport.
+- Torghut repair-only proof can be reachable and useful while capital and paper actions must remain held.
+
+The next architecture increment must reduce repeated launch failures and make deployer decisions faster. More status
+fields are not enough. We need a passport that is consumed by admission and a capacity future that prevents known-bad
+launches before Kubernetes has to fail them.
+
+## Alternatives Considered
+
+### Option A: Keep Independent Ledgers And Improve Handoff Text
+
+This path keeps source-serving verdicts, action custody, ready truth, stage credit, terminal debt, and Torghut repair
+evidence as separate objects. Engineers and deployers would read the fields and write better handoffs.
+
+Advantages:
+
+- Minimal implementation cost.
+- Preserves existing reducer boundaries.
+- Low risk of blocking work by accident.
+
+Disadvantages:
+
+- Keeps manual interpretation in the critical path.
+- Does not stop launches when runner capacity is already suspect.
+- Does not create one PR-to-rollout stopwatch.
+- Lets missing manifest digest evidence remain a prose problem rather than an admission fact.
+
+Decision: reject. Better handoff text helps audits, but it will not materially reduce failed AgentRuns.
+
+### Option B: Enforce Ready Truth Immediately For Normal Launch
+
+This path makes `ready_truth_arbiter` and action custody directly suppress normal launch whenever material readiness is
+not `allow`.
+
+Advantages:
+
+- Reuses existing status objects.
+- Reduces unsafe dispatch quickly.
+- Simple for operators to understand.
+
+Disadvantages:
+
+- Does not solve missing source-to-manifest-to-image proof.
+- Does not reserve or validate runner capacity.
+- Risks holding all normal work without naming the smallest missing proof.
+- Could convert a scheduler reliability issue into a broad stage freeze.
+
+Decision: reject as the next primary step. Ready truth remains necessary, but it needs a passport and capacity proof
+to become actionable.
+
+### Option C: Rollout Proof Passports And Runner Capacity Futures
+
+This selected path creates two new read-side admission contracts:
+
+- `rollout_proof_passport`: the source-to-serving proof that the PR, source revision, CI result, manifest, image
+  digest, Argo revision, workload, database, controller heartbeat, status route, and verify command agree.
+- `runner_capacity_future`: the stage-to-runtime proof that a lane can schedule and finish work within its budget
+  before launching normal dispatch, deploy, or verify work.
+
+Stage launch tickets consume both contracts. Serving and observe work can stay available with partial proof. Normal
+dispatch, deploy widening, and merge-ready work require current proof and capacity. Repair dispatch can run with a
+bounded repair passport and zero-notional Torghut proof.
+
+Advantages:
+
+- Directly targets `failed_agentrun_rate` by preventing known capacity misses.
+- Directly targets `pr_to_rollout_latency` by carrying one proof object from green CI to healthy rollout.
+- Makes source-serving contract gaps machine-readable admission blockers.
+- Gives verify and deployer stages a concise acceptance object.
+- Keeps Torghut repair-only work possible without leaking into paper/live capital.
+
+Disadvantages:
+
+- Adds a contract that must be generated and consumed across several reducers.
+- Requires careful TTLs so passports do not outlive their source revision.
+- May hold work that would have succeeded by luck.
+
+Decision: select Option C.
+
+## Architecture
+
+### Rollout Proof Passport
+
+The `rollout_proof_passport` is a read-side contract emitted by Jangar control-plane status and consumed by stage
+credit, ready truth, action custody, and deployer runbooks.
+
+```text
+rollout_proof_passport
+  schema_version = jangar.rollout-proof-passport.v1
+  passport_id
+  generated_at
+  fresh_until
+  repository
+  base_ref
+  head_ref
+  source_sha
+  pr_number
+  pr_merge_sha
+  ci_conclusion
+  manifest_sha
+  manifest_image_digest
+  registry_image_digest
+  argo_application
+  argo_sync_revision
+  argo_health
+  workload_refs[]
+  serving_status_ref
+  database_projection_ref
+  controller_heartbeat_ref
+  post_rollout_verify_refs[]
+  decision = absent | collecting | current | degraded | stale | contradicted
+  action_class_decisions[]
+  reason_codes[]
+  value_gate_impacts[]
+  rollback_target
+```
+
+The passport must be source-settled:
+
+- `source_sha` must match the merged PR or explicitly cite why the current source is pre-merge.
+- `manifest_sha` must identify the GitOps manifest commit that changed the workload.
+- `manifest_image_digest` and `registry_image_digest` must match the live workload digest for the action class being
+  admitted.
+- `argo_sync_revision` must match the manifest revision or be named as lagging.
+- `serving_status_ref` must come from a status route that includes database and controller witness evidence.
+- `post_rollout_verify_refs` must include Argo, workload readiness, and service health checks for verify and merge.
+
+### Runner Capacity Future
+
+The `runner_capacity_future` is a bounded reservation and schedulability contract. It does not create a pod or mutate
+Kubernetes. It proves that a planned stage has a credible path to run.
+
+```text
+runner_capacity_future
+  schema_version = jangar.runner-capacity-future.v1
+  future_id
+  generated_at
+  fresh_until
+  namespace
+  swarm_name
+  stage
+  action_class
+  expected_runtime_seconds
+  retry_budget
+  service_account
+  node_selector_summary
+  toleration_summary
+  pvc_refs[]
+  secret_refs[]
+  image_ref
+  image_pull_state
+  schedulability_state = available | constrained | unavailable | unknown
+  launch_window
+  reason_codes[]
+  required_repair_actions[]
+```
+
+The first implementation can derive this from existing read paths: AgentRun runtime config, workload image, service
+account, recent events, pod status, resource quota where available, and workload history. It does not need a scheduler
+plugin. It must at least classify:
+
+- recent `FailedScheduling` for the same lane or runtime image;
+- untolerated taints or unmatched node affinity in recent events;
+- repeated image pull delay or missing image digest;
+- PVC or ConfigMap mount failures;
+- historical stage timeout rates over the recent schedule window;
+- pending AgentRuns that already consume the lane budget.
+
+### Stage Launch Ticket
+
+Normal stage work should be launched by a `stage_launch_ticket` that binds proof and capacity:
+
+```text
+stage_launch_ticket
+  schema_version = jangar.stage-launch-ticket.v1
+  ticket_id
+  generated_at
+  fresh_until
+  stage
+  action_class
+  rollout_proof_passport_ref
+  runner_capacity_future_ref
+  projection_foreclosure_notary_ref
+  torghut_profit_carry_passport_ref
+  decision = allow | repair_only | hold | block
+  max_dispatches
+  max_runtime_seconds
+  reason_codes[]
+  rollback_target
+```
+
+Policy:
+
+- `serve_readonly` can run when service and database proof are current.
+- `torghut_observe` can run when Torghut is reachable and max notional remains zero.
+- `dispatch_repair` can run with a current repair passport, zero-notional Torghut proof, and available capacity.
+- `dispatch_normal`, `deploy_widen`, and `merge_ready` require a current rollout proof passport and available runner
+  capacity future.
+- `paper_canary`, `live_micro_canary`, and `live_scale` remain blocked or held until the companion Torghut profit-carry
+  passport graduates with its guardrails satisfied.
+
+## Failure-Mode Reduction
+
+| Failure mode                   | Current symptom                                                                                | Selected mechanism                                                                                              | Value gates                                          |
+| ------------------------------ | ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| Missing manifest/source proof  | Source-serving verdict blocks on missing CI and manifest digest receipts                       | Rollout proof passport has explicit `manifest_sha`, `manifest_image_digest`, and `registry_image_digest` states | `pr_to_rollout_latency`, `ready_status_truth`        |
+| Failed scheduling              | AgentRun pod delayed by node affinity and taint mismatch                                       | Runner capacity future classifies schedulability before normal launch                                           | `failed_agentrun_rate`, `manual_intervention_count`  |
+| Verify timeout                 | Verify AgentRuns fail with `WorkflowStepTimedOut` after rollout evidence is reconstructed late | Stage launch ticket requires expected runtime and post-rollout verify refs                                      | `failed_agentrun_rate`, `handoff_evidence_quality`   |
+| Readiness ambiguity            | `/ready=ok` while material actions are held                                                    | Passport separates serving proof from material launch proof                                                     | `ready_status_truth`                                 |
+| Torghut repair-only ambiguity  | Torghut evidence is useful but capital is zero-notional                                        | Companion profit-carry passport binds repair hypotheses and no-notional guardrails                              | `ready_status_truth`, `handoff_evidence_quality`     |
+| Manual deployer interpretation | Argo is healthy but source/manifest proof missing                                              | Deployer checks one passport verdict and one launch ticket                                                      | `pr_to_rollout_latency`, `manual_intervention_count` |
+
+## Implementation Milestones
+
+### Milestone 1: Passport Schema And Read Model
+
+Value gates: `ready_status_truth`, `handoff_evidence_quality`.
+
+- Add a Jangar status-domain type for `rollout_proof_passport`.
+- Build a pure reducer that accepts source rollout truth, source-serving verdicts, database status, controller witness,
+  rollout health, and verify evidence.
+- Emit the passport on `/api/agents/control-plane/status`.
+- Tests must cover current, collecting, stale, degraded, and contradicted passports.
+
+### Milestone 2: Manifest, Registry, And Argo Reconciliation
+
+Value gates: `pr_to_rollout_latency`, `ready_status_truth`.
+
+- Populate `manifest_sha`, `manifest_image_digest`, `registry_image_digest`, and `argo_sync_revision`.
+- Treat missing manifest digest as `collecting` for serve-readonly and `hold` for normal material launch.
+- Add regression tests for digest match, digest mismatch, and Argo lagging source.
+- Deployer acceptance requires a passport with a current digest chain before merge-ready.
+
+### Milestone 3: Runner Capacity Futures
+
+Value gates: `failed_agentrun_rate`, `manual_intervention_count`.
+
+- Add `runner_capacity_future` classification from recent events, pending AgentRuns, runtime config, image ref, and
+  stage history.
+- Mark normal launch `hold` when the lane recently hit `FailedScheduling`, image pull failure, mount failure, or
+  repeated timeout and no repair receipt cleared the reason.
+- Tests must cover node affinity mismatch, untolerated taint, missing ConfigMap/PVC mount, image digest absence, and
+  healthy capacity.
+
+### Milestone 4: Stage Launch Tickets
+
+Value gates: `failed_agentrun_rate`, `pr_to_rollout_latency`, `ready_status_truth`.
+
+- Wire passports and capacity futures into stage credit and ready truth behind a configuration flag.
+- Emit `stage_launch_ticket` for each action class.
+- Hold `dispatch_normal`, `deploy_widen`, and `merge_ready` unless both passport and future are current.
+- Allow bounded `dispatch_repair` only with explicit repair scope, zero-notional Torghut proof, and available capacity.
+
+### Milestone 5: Deployer Cutover
+
+Value gates: `pr_to_rollout_latency`, `manual_intervention_count`, `handoff_evidence_quality`.
+
+- Update deployer runbooks to require the passport and launch ticket instead of raw status-field interpretation.
+- Verify after rollout: Argo healthy, workload ready, status route healthy or explicitly held, passport current, runner
+  capacity future available, and Torghut remains zero-notional for repair-only work.
+- Record before and after counts for failed AgentRuns, pending launches, and PR-to-healthy rollout duration.
+
+## Validation Gates
+
+Engineer stage is not complete until these checks pass:
+
+- Unit tests for rollout proof passport state transitions.
+- Unit tests for runner capacity future classification.
+- Regression tests for recent `FailedScheduling`, mount failure, missing image digest, and verify timeout input.
+- Regression tests proving `serve_readonly` remains available when material launch is held by missing manifest proof.
+- Regression tests proving normal launch is held when passport and capacity future disagree.
+- `bunx oxfmt --check` on touched TypeScript and Markdown paths.
+- The nearest targeted Jangar test command for every touched TypeScript reducer.
+
+Verify stage is not complete until these runtime checks are recorded:
+
+- `gh pr checks <pr> --watch -R proompteng/lab` is green before merge.
+- Argo reports `agents`, `jangar`, and `torghut` synced and healthy, or names the exact non-healthy app and reason.
+- Jangar `/ready` and `/api/agents/control-plane/status?namespace=agents` are reachable.
+- The status route includes `rollout_proof_passport` and `runner_capacity_future` after implementation.
+- `dispatch_normal`, `deploy_widen`, and `merge_ready` explain holds with passport or capacity reason codes.
+- Torghut `/db-check` is schema-current.
+- Torghut `/readyz` may remain degraded only for capital/profit guards, and max notional remains `0` for repair-only
+  work.
+
+## Rollout Plan
+
+1. Ship the passport reducer in observe mode with no admission behavior change.
+2. Add manifest, registry, and Argo fields and compare against live workload digests.
+3. Ship runner capacity futures in observe mode and compare predictions against actual scheduling outcomes for one
+   schedule cycle.
+4. Enable stage launch tickets for discover and plan normal dispatch.
+5. Enable implement and verify normal dispatch after failure counts and scheduler predictions match.
+6. Promote deployer runbooks to require passport current and capacity available before merge-ready.
+
+## Rollback Plan
+
+Rollback is configuration-first:
+
+- set passport and runner-capacity consumption to observe-only;
+- keep emitting the payload if it is stable, so incident review still has evidence;
+- fall back to existing ready truth, stage credit, action custody, and source-serving verdict behavior;
+- do not delete AgentRuns, jobs, database rows, or receipts as part of rollback;
+- if the passport route causes status instability, roll back the Jangar deployment image and keep existing design
+  contracts as the operator source of truth.
+
+## Risks And Mitigations
+
+- Risk: capacity prediction blocks a stage that would have scheduled. Mitigation: start in observe mode, require recent
+  matching failure evidence before hold, and keep repair dispatch available.
+- Risk: passport TTLs go stale during long CI or image promotion. Mitigation: mark the passport `collecting` rather
+  than `contradicted` while a known promotion is in flight.
+- Risk: source and manifest proof is unavailable to the service account. Mitigation: use GitHub, Argo, and status-route
+  evidence first; report exact missing access instead of requiring pod exec or direct database privileges.
+- Risk: deployer handoff becomes too strict. Mitigation: keep `serve_readonly` and `torghut_observe` separate from
+  material launch and make every hold name the missing proof.
+- Risk: Torghut repair work starves. Mitigation: companion profit-carry passports keep zero-notional repair dispatch
+  available when it names expected value and guardrails.
+
+## Handoff To Engineer
+
+Build the passport and future as pure reducers first. Do not start by changing scheduler behavior. The first production
+PR should make the evidence visible, testable, and stable. The second PR can wire the contracts into stage credit and
+ready truth behind flags.
+
+Acceptance gates:
+
+- a green Argo app without manifest digest proof produces `collecting` or `hold`, not `allow`, for normal launch;
+- a recent `FailedScheduling` event for the same lane produces a constrained or unavailable runner future;
+- serving readiness stays available when material launch is held;
+- verify handoff can point to one passport and one stage launch ticket;
+- tests cover current, stale, contradicted, and capacity-unavailable states.
+
+## Handoff To Deployer
+
+Deployer should use the rollout proof passport as the PR-to-healthy evidence object once it lands. Do not infer
+rollout health from Argo alone. The rollout is healthy for material launch only when the passport is current, the
+runner capacity future is available for the target stage, and the stage launch ticket decision is `allow` for the
+action class.
+
+Rollout acceptance gates:
+
+- Argo `agents`, `jangar`, and `torghut` are synced and healthy;
+- Jangar status route emits current passport evidence for the deployed revision;
+- runner capacity future is available for the next stage;
+- Torghut repair work remains zero-notional unless a later capital passport explicitly graduates;
+- failed AgentRun and pending-run counts are recorded before and after cutover.

--- a/docs/torghut/design-system/v6/196-torghut-profit-carry-passports-and-repair-capacity-futures-2026-05-13.md
+++ b/docs/torghut/design-system/v6/196-torghut-profit-carry-passports-and-repair-capacity-futures-2026-05-13.md
@@ -1,0 +1,437 @@
+# 196. Torghut Profit-Carry Passports And Repair Capacity Futures (2026-05-13)
+
+Status: Accepted for Jangar engineer and deployer handoff
+Date: 2026-05-13
+Owner: Victor Chen, Jangar Engineering Architecture
+Scope: Torghut zero-notional profit repair, measurable hypothesis passports, repair capacity futures, Jangar rollout
+proof integration, route custody, validation, rollout, rollback, and handoff.
+
+Companion Jangar contract:
+
+- `docs/agents/designs/191-jangar-rollout-proof-passports-and-runner-capacity-futures-2026-05-13.md`
+
+Extends:
+
+- `136-torghut-profit-proof-renewal-market-and-tca-settlement-2026-05-07.md`
+- `195-torghut-stale-projection-foreclosure-and-route-custody-2026-05-13.md`
+- `193-torghut-route-repair-yield-board-and-hypothesis-reentry-guardrails-2026-05-13.md`
+- `192-torghut-repair-receipt-frontier-and-profit-cutover-2026-05-13.md`
+- `188-torghut-profit-repair-clearance-packets-and-market-context-slos-2026-05-12.md`
+- `docs/agents/designs/190-jangar-projection-foreclosure-notary-and-stage-custody-repair-2026-05-13.md`
+
+## Decision
+
+I am selecting **profit-carry passports with repair capacity futures** as Torghut's companion architecture for the
+Jangar rollout proof work.
+
+Torghut should stay zero-notional. The current evidence is explicit: `/readyz` returns HTTP 503 with
+`status=degraded`; live submission is blocked by `simple_submit_disabled`; active capital stage is `shadow`;
+profitability proof floor is `repair_only`; capital state is `zero_notional`; promotion eligible hypotheses are `0`.
+At the same time, this is not a dead system. Postgres, ClickHouse, Alpaca, database schema, universe, and empirical
+jobs are healthy. The current capital replay board names repair candidates such as AAPL route rehab, NVDA proof refill,
+and megacap breadth probes. It also states the right guardrail: `max_notional=0` for all selected replays.
+
+The selected design makes each Torghut repair proposal carry a measurable profit passport before Jangar spends runner
+capacity on it. The passport names the hypothesis, expected blocker delta, required receipts, route/TCA and
+market-context guardrails, zero-notional capital effect, and the Jangar rollout proof passport it depends on. A repair
+capacity future then decides whether the repair is worth launching in the current Jangar capacity window.
+
+The tradeoff is that some plausible repairs will not run until they can state expected value and falsification rules.
+That is the right tradeoff. Torghut's profitability problem is no longer "find more activity." It is "fund the
+zero-notional repairs most likely to retire blockers that can later support paper evidence without violating guardrails."
+
+This extends the 2026-05-07 profit-proof renewal market. That contract priced stale proof dimensions and kept paper
+capital held until proof-floor settlement was current. This contract converts the current repair candidates into
+per-hypothesis passports and capacity futures so Jangar can decide which zero-notional repairs deserve scarce runner
+slots.
+
+## Governing Runtime Requirements
+
+This companion contract follows the active Jangar validation contract:
+
+- every run must cite the governing design or runtime requirement before changing code;
+- implement stages must produce production PRs with tests or report the exact blocker to code;
+- verify stages must merge only green PRs and prove Argo, workload readiness, and service health after rollout;
+- final handoff must name the control-plane metric improved or the smallest blocker preventing improvement.
+
+Torghut value gates for this contract:
+
+- `routeable_candidate_count`
+- `fill_tca_or_slippage_quality`
+- `zero_notional_or_stale_evidence_rate`
+- `post_cost_daily_net_pnl`
+- `capital_gate_safety`
+
+Jangar cross-plane value gates:
+
+- `failed_agentrun_rate`
+- `pr_to_rollout_latency`
+- `ready_status_truth`
+- `manual_intervention_count`
+- `handoff_evidence_quality`
+
+## Current Evidence
+
+Evidence was collected read-only on 2026-05-13. I did not mutate Kubernetes resources, database rows, broker state,
+trading flags, GitOps resources, AgentRuns, or market data.
+
+### Cluster And Runtime
+
+- Argo CD reported `torghut` and `torghut-options` as `Synced/Healthy` at revision
+  `704ef0aebc13722e541c006edddee4b4610c3424`.
+- `torghut-00359-deployment=1/1` and `torghut-sim-00457-deployment=1/1` were ready on image digest
+  `sha256:91963c9c35c26a1628107bf874876fc04c8b9dfa12cec8977ddd783f041dba4a`.
+- Options catalog, options enricher, TA, TA sim, ClickHouse, Keeper, WebSocket services, guardrail exporters, and
+  Torghut DB were running.
+- Recent Torghut events showed normal rollout startup probe noise, completed DB migration and evidence backfill jobs,
+  Knative revision readiness, and workflow failures in the whitepaper autoresearch profit target lane.
+
+### Database And Data Quality
+
+- `/db-check` returned `ok=true`, schema current at Alembic head
+  `0031_autoresearch_candidate_spec_epoch_uniqueness`, one expected head, one current head, no missing heads, no
+  unexpected heads, and lineage ready.
+- The schema graph still reports known parent-fork warnings around historical migration branches. That is a lineage
+  quality signal, not current schema drift.
+- Direct CNPG resource inspection was not required for this pass; application-level read endpoints provided the
+  production witness path available to normal workers.
+- `/readyz` reported scheduler, Postgres, ClickHouse, Alpaca, database, universe, readiness cache, and empirical jobs
+  OK.
+- Live submission was blocked by `simple_submit_disabled`, with `capital_stage=shadow`, proof floor `repair_only`,
+  and capital state `zero_notional`.
+- Alpha readiness evaluated three hypotheses and kept all of them shadow-only. `H-CONT-01` and `H-REV-01` lacked
+  strategy hypothesis lineage; `H-MICRO-01` had lineage but stale window evidence. `ta-core` was blocked by
+  `signal_lag_exceeded`.
+
+### Profit And Route Evidence
+
+- The capital replay board selected three zero-notional repairs:
+  - `H-AAPL-ROUTE-REHAB` with expected blocker delta `3`, but TCA slippage observed around `9.25` bps against an
+    `8` bps guardrail.
+  - `H-NVDA-SIM-PROOF-REFILL` with expected blocker delta `2`, but route universe/TCA evidence remained blocked and
+    slippage observed around `13.48` bps against an `8` bps guardrail.
+  - `H-MEGACAP-BREADTH-PROBE` for `AMZN`, `GOOGL`, and `ORCL`, with expected blocker delta `1` and missing route
+    symbol evidence.
+- The proof-floor blockers included `market_context_stale`, `market_context_state_unknown`,
+  `quant_health_not_configured`, `alpha_readiness_not_promotion_eligible`, and `simple_submit_disabled`.
+- The profit window contract had three windows: two `quarantined` and one `underfunded`. All windows were blocking.
+- The route repair board summarized eight zero-notional route rows, with state counts `blocked=4`, `missing=3`, and
+  `probing=1`. It named expected unblock value `14`, top repair symbols `AAPL`, `AMD`, `AVGO`, `INTC`, and `NVDA`,
+  and capital eligible symbol count `0`.
+- Consumer evidence exposed a route warrant ref but also blockers such as `route_tca_missing`,
+  `market_context_stale`, `max_notional_zero`, `profit_signal_quorum_observe_only`, and
+  `routeability_acceptance_blocked`.
+
+## Problem
+
+Torghut has useful repair signals, but Jangar should not spend control-plane capacity on every repair signal. The
+current repair surface has four gaps:
+
+1. Repair candidates are measurable inside `/readyz`, but they are not yet a compact admission object for Jangar.
+2. Expected profit impact is represented as blocker delta and repair value, but capacity cost is not settled before
+   dispatch.
+3. Guardrails are present, but the repair launch contract does not yet require a no-delta receipt when a repair fails
+   to retire a blocker.
+4. Route evidence can be useful for zero-notional repair while remaining unsafe for paper or live capital.
+
+The profitability architecture must keep paper/live blocked while making zero-notional repair more selective and more
+accountable. A run should launch because it can retire a named blocker inside a measured cost budget, not because a
+large readiness payload contains a repair-looking field.
+
+## Alternatives Considered
+
+### Option A: Continue The Existing Repair Queue
+
+This path lets market-context, route, empirical, and proof refill jobs continue using existing readiness blockers and
+repair boards.
+
+Advantages:
+
+- No new payload.
+- Keeps repair throughput high.
+- Avoids coordination with Jangar rollout proof.
+
+Disadvantages:
+
+- Does not price runner capacity.
+- Does not require a no-delta receipt for repeated repairs.
+- Does not distinguish high-value AAPL/NVDA repairs from low-value breadth probes.
+- Does not reduce failed AgentRuns when Jangar capacity is constrained.
+
+Decision: reject as the primary architecture. Existing repair surfaces remain inputs, not admission.
+
+### Option B: Freeze All Repair Until `/readyz` Is Healthy
+
+This path blocks Torghut repair work until readiness is green.
+
+Advantages:
+
+- Simple and capital safe.
+- Prevents repair churn during degraded windows.
+- Avoids consuming Jangar runner capacity.
+
+Disadvantages:
+
+- Creates deadlock because repairs are how readiness improves.
+- Wastes fresh empirical and route evidence.
+- Delays learning on measurable zero-notional hypotheses.
+- Increases manual intervention.
+
+Decision: reject except as an incident fallback.
+
+### Option C: Profit-Carry Passports And Repair Capacity Futures
+
+The selected path emits a `profit_carry_passport` per repair hypothesis and a `repair_capacity_future` per proposed
+launch window. Jangar may launch a Torghut repair only when the passport names its value, guardrails, receipts, and
+zero-notional rollback target, and the capacity future says the work can run without stealing normal rollout capacity.
+
+Advantages:
+
+- Keeps capital safe while funding useful repairs.
+- Turns repair work into measurable hypotheses.
+- Connects Torghut work to Jangar runner capacity and rollout proof.
+- Provides no-delta accounting for repairs that do not retire blockers.
+- Lets Jangar reduce failed AgentRuns by refusing low-value repairs during constrained capacity windows.
+
+Disadvantages:
+
+- Adds a new payload and tests.
+- Requires stable reason codes and receipt names.
+- May hold repairs that operators would otherwise launch manually.
+
+Decision: select Option C.
+
+## Architecture
+
+### Profit-Carry Passport
+
+```text
+profit_carry_passport
+  schema_version = torghut.profit-carry-passport.v1
+  passport_id
+  generated_at
+  fresh_until
+  account
+  window
+  hypothesis_id
+  candidate_id
+  target_symbols[]
+  repair_class
+  expected_blocker_delta
+  expected_profit_effect
+  expected_cost_class
+  max_runtime_seconds
+  max_notional = 0
+  required_receipts[]
+  current_blockers[]
+  guardrails[]
+  falsification_rules[]
+  jangar_rollout_proof_passport_ref
+  jangar_runner_capacity_future_ref
+  decision = repair_only | hold | block
+  reason_codes[]
+  rollback_target
+```
+
+Every passport must satisfy these rules:
+
+- `max_notional` is always `0` until a separate future capital passport exists.
+- `paper_canary`, `live_micro_canary`, and `live_scale` remain blocked by this contract.
+- Expected blocker delta must be positive for a repair launch.
+- The repair must name the receipt schema it is expected to produce.
+- A repeated repair with no new receipt emits a no-delta receipt and loses priority.
+- Guardrails are evaluated before launch and again after receipt settlement.
+
+### Repair Capacity Future
+
+```text
+repair_capacity_future
+  schema_version = torghut.repair-capacity-future.v1
+  future_id
+  generated_at
+  fresh_until
+  account
+  window
+  repair_class
+  expected_runtime_seconds
+  expected_cost_class
+  expected_blocker_delta
+  jangar_stage_launch_ticket_ref
+  capacity_decision = available | constrained | unavailable
+  reason_codes[]
+```
+
+The future is not a Kubernetes reservation. It is a cross-plane scheduling promise: Torghut says the repair is worth
+the slot, and Jangar says a slot is likely to schedule and finish. If either side says constrained, only bounded repair
+dispatch can run. If either side says unavailable, the repair stays held.
+
+## Measurable Trading Hypotheses
+
+### Hypothesis 1: AAPL Route Rehab
+
+- Current evidence: AAPL route state is `probing`, current blocker
+  `route_tca_passed_but_dependency_receipts_block_capital`, observed slippage around `9.25` bps, guardrail `8` bps.
+- Passport decision: `hold` until the TCA receipt and market-context receipt are fresh; `repair_only` after receipts
+  are named and no notional is requested.
+- Expected blocker delta: `3`.
+- Guardrails: no paper/live notional, slippage at or below `8` bps after repair, fresh market-context receipt, alpha
+  readiness not worse than before.
+- Falsification: if repaired AAPL still exceeds the `8` bps slippage guardrail or lacks a fresh market-context
+  receipt, emit no-delta receipt and lower priority.
+
+### Hypothesis 2: NVDA Simulation Proof Refill
+
+- Current evidence: NVDA route state is `blocked`, current blocker
+  `execution_tca_route_universe_exclusions_applied`, observed slippage around `13.48` bps, guardrail `8` bps.
+- Passport decision: `hold` until route universe and TCA receipts are present; repair may run only as a bounded
+  simulation proof refill.
+- Expected blocker delta: `2`.
+- Guardrails: no notional, no paper graduation from this repair alone, TCA slippage must improve before the repair can
+  be considered successful, market-context remains fresh for the account/window.
+- Falsification: no improvement in slippage or missing route universe receipt produces no-delta debt.
+
+### Hypothesis 3: Megacap Breadth Probe
+
+- Current evidence: AMZN, GOOGL, and ORCL route evidence is missing, with `execution_tca_symbol_missing`.
+- Passport decision: `repair_only` only when Jangar has spare repair capacity; otherwise hold.
+- Expected blocker delta: `1`.
+- Guardrails: no notional, route coverage receipt required, no degradation to current AAPL/NVDA repair queues, market
+  context freshness bound by the repair window.
+- Falsification: if route coverage remains missing or costs exceed the budget, emit no-delta receipt and pause breadth
+  probes until higher-value repairs settle.
+
+### Hypothesis 4: H-MICRO-01 Window Evidence Refill
+
+- Current evidence: `H-MICRO-01` has strategy lineage, but window evidence is stale and `ta-core` is blocked by
+  `signal_lag_exceeded`.
+- Passport decision: `repair_only` after capacity is available and required TA/evidence receipts are named.
+- Expected blocker delta: `2`, because it can move the only lineage-ready hypothesis from underfunded to paper
+  candidate if freshness and signal lag repair.
+- Guardrails: max notional `0`, signal lag under the configured threshold, no paper graduation until profit-window and
+  Jangar source-serving proof are current.
+- Falsification: stale window evidence after repair or unchanged signal lag becomes no-delta debt.
+
+## Implementation Milestones
+
+### Milestone 1: Passport Reducer
+
+Value gates: `routeable_candidate_count`, `handoff_evidence_quality`, `ready_status_truth`.
+
+- Build a pure Torghut reducer that turns capital replay board, route repair board, proof floor, market context, and
+  alpha readiness into `profit_carry_passport` objects.
+- Expose the payload through `/trading/consumer-evidence` first.
+- Tests must cover AAPL, NVDA, megacap breadth, and H-MICRO-01 cases.
+
+### Milestone 2: No-Delta Receipts
+
+Value gates: `zero_notional_or_stale_evidence_rate`, `manual_intervention_count`.
+
+- Define `torghut.repair-no-delta-receipt.v1`.
+- Emit no-delta receipts when a repair consumes a slot but does not retire its named blocker.
+- Jangar terminal debt compaction should consume the receipt so repeated low-value repairs lose priority.
+
+### Milestone 3: Repair Capacity Future Bridge
+
+Value gates: `failed_agentrun_rate`, `pr_to_rollout_latency`.
+
+- Bind each passport to a Jangar runner capacity future and stage launch ticket.
+- Allow high-value repairs during constrained capacity only when they retire a blocker with expected delta at least `2`.
+- Hold breadth probes when normal rollout or verify capacity is constrained.
+
+### Milestone 4: Guardrail Settlement
+
+Value gates: `fill_tca_or_slippage_quality`, `capital_gate_safety`.
+
+- Re-check slippage, market-context freshness, alpha readiness, and signal lag after the repair receipt.
+- Require every successful repair to update the passport with before/after evidence.
+- Keep paper and live blocked until a later capital passport exists.
+
+### Milestone 5: Deployer And Trader Cutover
+
+Value gates: `post_cost_daily_net_pnl`, `handoff_evidence_quality`.
+
+- Deployer checks that Torghut repair passports are present and zero-notional after rollout.
+- Trader review checks blocker deltas and no-delta receipts before raising repair budget.
+- Record before/after routeable candidate count, repair no-delta rate, and slippage guardrail pass rate.
+
+## Validation Gates
+
+Engineer stage is not complete until:
+
+- Unit tests cover passport generation for the four named hypotheses.
+- Unit tests cover no-delta receipt downgrade behavior.
+- Unit tests prove max notional remains `0` for all repair passports.
+- Regression tests prove paper/live action classes cannot be enabled by this contract.
+- `bunx oxfmt --check` passes for touched Markdown and TypeScript/Python paths.
+- Torghut targeted tests pass for every touched reducer if implementation changes source.
+
+Verify stage is not complete until:
+
+- Argo reports `torghut`, `torghut-options`, `jangar`, and `agents` synced and healthy, or exact non-healthy reasons
+  are recorded.
+- Torghut `/db-check` remains schema-current.
+- Torghut `/readyz` may remain degraded only for capital/profit guards, not database or unknown projection authority.
+- `/trading/consumer-evidence` includes profit-carry passports after implementation.
+- Jangar stage launch ticket names the Torghut passport for any Torghut repair dispatch.
+- No paper or live notional is enabled.
+
+## Rollout Plan
+
+1. Emit profit-carry passports in observe mode.
+2. Add no-delta receipt generation without changing repair launch behavior.
+3. Connect passports to Jangar runner capacity futures for repair prioritization.
+4. Hold low-delta repairs during constrained capacity windows.
+5. Use before/after receipts to graduate only repairs that actually retire blockers.
+
+## Rollback Plan
+
+Rollback is configuration-first:
+
+- ignore profit-carry passports in Jangar repair admission;
+- keep existing Torghut repair boards and proof floor as the status source;
+- preserve emitted passports and no-delta receipts for audit;
+- do not delete trading rows, receipts, or AgentRuns during rollback;
+- keep max notional `0` and paper/live blocked.
+
+If the passport route destabilizes Torghut readiness, roll back the Torghut deployment image and keep existing
+consumer-evidence and proof-floor contracts.
+
+## Risks And Mitigations
+
+- Risk: the passport underfunds a repair that later proves valuable. Mitigation: keep observe-mode collection and allow
+  manual trader review to raise priority with evidence.
+- Risk: no-delta receipts punish useful exploratory repairs. Mitigation: no-delta only lowers repeated priority; it
+  does not delete evidence or prevent new hypotheses with new receipts.
+- Risk: capacity futures starve Torghut repairs during Jangar incidents. Mitigation: allow high-delta zero-notional
+  repairs while normal rollout is held, but block low-delta breadth probes.
+- Risk: slippage guardrails overfit one sample. Mitigation: require before/after receipt windows and market-context
+  freshness, not one point estimate.
+- Risk: operators confuse repair passports with capital permission. Mitigation: every passport carries
+  `max_notional=0`, explicit paper/live block, and rollback target.
+
+## Handoff To Engineer
+
+Build the reducer and fixtures first. Do not change live submission, paper canary, or capital gates. The first PR
+should expose passports through consumer evidence and prove max notional stays zero.
+
+Acceptance gates:
+
+- AAPL, NVDA, megacap breadth, and H-MICRO-01 produce deterministic passports;
+- every passport has expected blocker delta, guardrails, required receipts, and falsification rules;
+- no-delta receipts lower priority for repeated no-effect repairs;
+- Jangar can reference a passport from a stage launch ticket;
+- tests prove paper/live cannot be unlocked by this design.
+
+## Handoff To Deployer
+
+Deployer should treat profit-carry passports as repair prioritization evidence, not capital evidence. A rollout is
+acceptable when Torghut service health is stable, database schema is current, passports are present or explicitly not
+yet implemented, and every repair passport keeps max notional at `0`.
+
+Rollout acceptance gates:
+
+- Torghut and Jangar Argo apps are synced and healthy;
+- Torghut `/db-check` is current;
+- repair passports are emitted after implementation;
+- Jangar runner capacity futures are referenced for launched repairs;
+- paper/live remain blocked until a separate capital cutover design and implementation lands.

--- a/docs/torghut/design-system/v6/index.md
+++ b/docs/torghut/design-system/v6/index.md
@@ -12,6 +12,8 @@
 - Implementation status (strict, core 01-13 docs, source-state refresh `2026-03-09`): `Implemented=7`, `Partial=5`, `Completed=1`
 - Evidence (historical closure): `13-production-gap-closure-master-plan-2026-03-03.md` (Wave 0-6 closure + DoD)
 - Evidence (current next-work priority, refreshed `2026-05-13T12:27Z`):
+  - `196-torghut-profit-carry-passports-and-repair-capacity-futures-2026-05-13.md`
+  - `docs/agents/designs/191-jangar-rollout-proof-passports-and-runner-capacity-futures-2026-05-13.md`
   - `195-torghut-stale-projection-foreclosure-and-route-custody-2026-05-13.md`
   - `docs/agents/designs/190-jangar-projection-foreclosure-notary-and-stage-custody-repair-2026-05-13.md`
   - `193-torghut-route-repair-yield-board-and-hypothesis-reentry-guardrails-2026-05-13.md`


### PR DESCRIPTION
## Summary

- Adds the Jangar rollout proof passport and runner capacity futures architecture, including evidence, alternatives, decision, validation gates, rollout, rollback, and engineer/deployer handoff.
- Adds the Torghut profit-carry passport and repair capacity futures companion contract so zero-notional repairs are ranked by measurable blocker delta, guardrails, and Jangar capacity.
- Updates the Torghut v6 design index so the new Jangar/Torghut architecture pair is listed as current next-work evidence.

## Related Issues

None; this implements the Jangar control-plane swarm plan-stage architecture deliverable.

## Testing

- `bunx oxfmt docs/agents/designs/191-jangar-rollout-proof-passports-and-runner-capacity-futures-2026-05-13.md docs/torghut/design-system/v6/196-torghut-profit-carry-passports-and-repair-capacity-futures-2026-05-13.md docs/torghut/design-system/v6/index.md`
- `bunx oxfmt --check docs/agents/designs/191-jangar-rollout-proof-passports-and-runner-capacity-futures-2026-05-13.md docs/torghut/design-system/v6/196-torghut-profit-carry-passports-and-repair-capacity-futures-2026-05-13.md docs/torghut/design-system/v6/index.md`
- `git diff --check origin/main...HEAD`

## Screenshots (if applicable)

N/A; documentation-only architecture change.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
