### PR TITLE
chore(jangar): promote image 917631f7

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 40d6ffb9
-  digest: sha256:f32b21ef4f8d1f223fa25ee151126b1540d189ed902c05c6d9a6a3b73b617be6
+  tag: 917631f7
+  digest: sha256:381a9adc4fbf67c72c40c7230e6819f17b74385bee241b4e61b44491e8661fff
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,8 +11,8 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 40d6ffb9
-    digest: sha256:11d24bc21ccff1c5227d9edddeb4c778fe44f0f47dd2e4b99b6f5c8919b79dc6
+    tag: 917631f7
+    digest: sha256:b870655aca9cc6fb857e10afcc3e829fdf3e3ab2abefd7797bc81abf5f5ed433
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
@@ -21,8 +21,8 @@ controlPlane:
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 40d6ffb9
-    digest: sha256:f32b21ef4f8d1f223fa25ee151126b1540d189ed902c05c6d9a6a3b73b617be6
+    tag: 917631f7
+    digest: sha256:381a9adc4fbf67c72c40c7230e6819f17b74385bee241b4e61b44491e8661fff
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-13T17:03:02Z
+    deploy.knative.dev/rollout: 2026-05-13T17:22:19Z
 spec:
   replicas: 1
   strategy:
@@ -57,11 +57,11 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_RUNTIME_IMAGE
-              value: registry.ide-newton.ts.net/lab/jangar:40d6ffb9@sha256:f32b21ef4f8d1f223fa25ee151126b1540d189ed902c05c6d9a6a3b73b617be6
+              value: registry.ide-newton.ts.net/lab/jangar:917631f7@sha256:381a9adc4fbf67c72c40c7230e6819f17b74385bee241b4e61b44491e8661fff
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: 40d6ffb900716cd9a6b5f1955ba753671f6e9d70
+              value: 917631f79cc29bfb3f24d89eedb481a3e61da584
             - name: JANGAR_GITOPS_REVISION
-              value: 40d6ffb900716cd9a6b5f1955ba753671f6e9d70
+              value: 917631f79cc29bfb3f24d89eedb481a3e61da584
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_BUMBA_TASK_QUEUE

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -59,5 +59,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: 40d6ffb9
-    digest: sha256:f32b21ef4f8d1f223fa25ee151126b1540d189ed902c05c6d9a6a3b73b617be6
+    newTag: 917631f7
+    digest: sha256:381a9adc4fbf67c72c40c7230e6819f17b74385bee241b4e61b44491e8661fff


### PR DESCRIPTION
## Summary

- Promotes Jangar image `917631f7` for source commit `917631f79cc29bfb3f24d89eedb481a3e61da584` into GitOps manifests.
- Pins image digest `sha256:381a9adc4fbf67c72c40c7230e6819f17b74385bee241b4e61b44491e8661fff` for the Jangar deployment.
- Updates the Jangar API rollout annotation and `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`.

## Related Issues

None. This promotes merged Jangar PR #6450.

## Testing

- `argo-lint` passed.
- `kubeconform` passed.
- `jangar-ci / lint-and-typecheck` passed.
- `jangar-post-deploy-verify` passed on merge commit `41ac3e048caf28e2befd4fec73d0ee9dca1d13d1`, including deployment health/digest verification and Temporal routing sync.

## Screenshots (if applicable)

N/A. This is a GitOps promotion change.

## Breaking Changes

None. Rollback path is a revert or rollback PR restoring the previous Jangar image `40d6ffb9` and its digest in the GitOps manifests.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
