### PR TITLE
fix(torghut): retry market-context syntax failures

### DIFF
--- a/argocd/applications/agents/torghut-market-context-agentprovider.yaml
+++ b/argocd/applications/agents/torghut-market-context-agentprovider.yaml
@@ -498,10 +498,20 @@ spec:
             for token in ('unauthorized', 'forbidden', 'token', 'auth', 'api key', 'bootstrap', 'transport', 'connection refused')
           ):
             return 'provider_bootstrap_failure'
+          if any(
+            token in normalized
+            for token in (
+              'syntaxerror',
+              'indentationerror',
+              'traceback',
+              'command exited with status 1',
+            )
+          ):
+            return 'payload_validation_failure'
           return 'provider_turn_failed'
 
         def _can_retry_with_next_provider(failure_category: str) -> bool:
-          return failure_category in {'provider_attempt_timeout', 'provider_fallback_eligible'}
+          return failure_category in {'provider_attempt_timeout', 'provider_fallback_eligible', 'payload_validation_failure'}
 
         def _write_process_output(stream, output) -> None:
           if not output:
@@ -533,7 +543,7 @@ spec:
               _write_process_output(sys.stderr, result.stderr)
             message = (result.stderr or result.stdout or '').strip()
             last_line = message.splitlines()[-1] if message else ''
-            return result.returncode, _classify_attempt_failure(result.returncode, last_line), last_line
+            return result.returncode, _classify_attempt_failure(result.returncode, message), last_line
           except subprocess.TimeoutExpired as error:
             if error.stdout:
               _write_process_output(sys.stdout, error.stdout)

--- a/services/jangar/src/server/__tests__/torghut-market-context-agentprovider-manifest.test.ts
+++ b/services/jangar/src/server/__tests__/torghut-market-context-agentprovider-manifest.test.ts
@@ -243,4 +243,50 @@ assert message == 'provider_attempt_timeout', message
     expect(stdout).toContain('out')
     expect(stderr).toContain('err')
   })
+
+  it('classifies generated script syntax failures as provider-fallback eligible payload failures', async () => {
+    const manifest = await readFile(
+      resolve(process.cwd(), '..', '..', 'argocd/applications/agents/torghut-market-context-agentprovider.yaml'),
+      'utf8',
+    )
+    const runner = extractInputFileContent(manifest, '/root/.codex/market-context-provider-runner.py')
+    const tempDir = await mkdtemp(resolve(tmpdir(), 'market-context-runner-'))
+    const runnerPath = resolve(tempDir, 'market-context-provider-runner.py')
+    const probePath = resolve(tempDir, 'probe.py')
+    await writeFile(runnerPath, runner)
+    await writeFile(
+      probePath,
+      `
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+runner_path = Path(sys.argv[1])
+spec = importlib.util.spec_from_file_location('runner', runner_path)
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(module)
+
+def fake_run(*args, **kwargs):
+  return subprocess.CompletedProcess(
+    args=args[0],
+    returncode=1,
+    stdout='',
+    stderr='  File "<stdin>", line 689\\nSyntaxError: ( was never closed\\nCommand exited with status 1\\n',
+  )
+
+module.subprocess.run = fake_run
+exit_code, failure_category, message = module._run_attempt(Path('/tmp/event.json'), 'codex', 'gpt-5.5', 1)
+assert exit_code == 1, exit_code
+assert failure_category == 'payload_validation_failure', failure_category
+assert module._can_retry_with_next_provider(failure_category) is True
+assert message == 'Command exited with status 1', message
+`,
+    )
+
+    const { stderr } = await execFileAsync('python3', [probePath, runnerPath], { timeout: 10_000 })
+
+    expect(stderr).toContain('SyntaxError')
+  })
 })


### PR DESCRIPTION
## Summary

- Retry market-context provider fallback when generated scripts fail with syntax or traceback output.
- Classify these failures as payload validation failures so the next configured provider can attempt the batch instead of failing the revenue-data refresh immediately.
- Add a runner regression test for the exact SyntaxError shape seen in the failed fundamentals batch job.

## Related Issues

None

## Testing

- `cd services/jangar && bun test src/server/__tests__/torghut-market-context-agentprovider-manifest.test.ts`
- `bunx oxfmt --check argocd/applications/agents/torghut-market-context-agentprovider.yaml services/jangar/src/server/__tests__/torghut-market-context-agentprovider-manifest.test.ts`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
