### PR TITLE
fix(torghut): keep frontier vetoes out of portfolios

### DIFF
--- a/services/torghut/app/trading/discovery/evidence_bundles.py
+++ b/services/torghut/app/trading/discovery/evidence_bundles.py
@@ -109,6 +109,16 @@ def evidence_bundle_from_frontier_candidate(
         scorecard = {**scorecard, "daily_filled_notional": daily_filled_notional}
     if "trading_day_count" in full_window and "trading_day_count" not in scorecard:
         scorecard = {**scorecard, "trading_day_count": full_window["trading_day_count"]}
+    raw_candidate_hard_vetoes = candidate.get("hard_vetoes")
+    if isinstance(raw_candidate_hard_vetoes, str):
+        raw_hard_vetoes: Sequence[Any] = (raw_candidate_hard_vetoes,)
+    else:
+        raw_hard_vetoes = cast(Sequence[Any], raw_candidate_hard_vetoes or ())
+    hard_vetoes = tuple(
+        item for item in (_string(value) for value in raw_hard_vetoes) if item
+    )
+    if hard_vetoes and "hard_vetoes" not in scorecard:
+        scorecard = {**scorecard, "hard_vetoes": list(hard_vetoes)}
     if "symbol_contribution_shares" not in scorecard and "symbol" not in scorecard:
         symbol_shares = _decomposition_symbol_contribution_shares(candidate)
         if symbol_shares:

--- a/services/torghut/app/trading/discovery/portfolio_optimizer.py
+++ b/services/torghut/app/trading/discovery/portfolio_optimizer.py
@@ -69,8 +69,24 @@ def _worst_day_loss(bundle: CandidateEvidenceBundle) -> Decimal:
     return _decimal(_scorecard(bundle).get("worst_day_loss"))
 
 
+def _hard_vetoes(bundle: CandidateEvidenceBundle) -> tuple[str, ...]:
+    raw_hard_vetoes = _scorecard(bundle).get("hard_vetoes")
+    if isinstance(raw_hard_vetoes, str):
+        return (raw_hard_vetoes,) if raw_hard_vetoes.strip() else ()
+    if not isinstance(raw_hard_vetoes, Sequence):
+        return ()
+    vetoes: list[str] = []
+    for raw_value in cast(Sequence[object], raw_hard_vetoes):
+        veto = _string(raw_value)
+        if veto:
+            vetoes.append(veto)
+    return tuple(vetoes)
+
+
 def _candidate_passes_minimums(bundle: CandidateEvidenceBundle) -> bool:
     if not evidence_bundle_is_valid(bundle):
+        return False
+    if _hard_vetoes(bundle):
         return False
     if bool(bundle.promotion_readiness.get("promotable")):
         return True
@@ -651,6 +667,15 @@ def optimize_portfolio_candidate(
         for bundle in evidence_bundles
         if not evidence_bundle_is_valid(bundle)
     ]
+    hard_veto_rejections = [
+        {
+            "candidate_id": bundle.candidate_id,
+            "reason": "frontier_hard_veto",
+            "hard_vetoes": list(_hard_vetoes(bundle)),
+        }
+        for bundle in evidence_bundles
+        if evidence_bundle_is_valid(bundle) and _hard_vetoes(bundle)
+    ]
     eligible = [
         bundle for bundle in evidence_bundles if _candidate_passes_minimums(bundle)
     ]
@@ -659,7 +684,10 @@ def optimize_portfolio_candidate(
         key=lambda item: (_sleeve_score(item), _net_per_day(item), item.candidate_id),
         reverse=True,
     )
-    rejected: list[dict[str, Any]] = list(invalid_evidence_rejections)
+    rejected: list[dict[str, Any]] = [
+        *invalid_evidence_rejections,
+        *hard_veto_rejections,
+    ]
     max_allowed_correlation = MAX_ALLOWED_PAIRWISE_CORRELATION
     selection_result = _select_portfolio_bundles(
         ordered=ordered,

--- a/services/torghut/tests/test_portfolio_optimizer.py
+++ b/services/torghut/tests/test_portfolio_optimizer.py
@@ -461,6 +461,117 @@ class TestPortfolioOptimizer(TestCase):
         ]
         self.assertEqual(len(invalid_rejections), 2)
 
+    def test_frontier_hard_vetoes_are_not_admitted_to_portfolios(self) -> None:
+        def bundle(
+            *,
+            candidate_id: str,
+            net_pnl_per_day: str,
+            symbol: str,
+            cluster: str,
+            hard_vetoes: list[str] | None = None,
+        ) -> CandidateEvidenceBundle:
+            return evidence_bundle_from_frontier_candidate(
+                candidate_spec_id=f"spec-{candidate_id}",
+                candidate={
+                    "candidate_id": candidate_id,
+                    "runtime_family": "microbar_cross_sectional_pairs",
+                    "runtime_strategy_name": "microbar-cross-sectional-pairs-v1",
+                    "family_template_id": "microbar_cross_sectional_pairs_v1",
+                    "hard_vetoes": hard_vetoes or [],
+                    "objective_scorecard": {
+                        "net_pnl_per_day": net_pnl_per_day,
+                        "active_day_ratio": "1.0",
+                        "positive_day_ratio": "1.0",
+                        "worst_day_loss": "0",
+                        "max_drawdown": "0",
+                        "best_day_share": "0.2",
+                        "avg_filled_notional_per_day": "350000",
+                        "regime_slice_pass_rate": "0.55",
+                        "posterior_edge_lower": "0.01",
+                        "shadow_parity_status": "within_budget",
+                        "correlation_cluster": cluster,
+                        "symbol_contribution_shares": {symbol: "1.0"},
+                        **_executable_scorecard_fields(candidate_id),
+                    },
+                    "full_window": {
+                        "daily_net": {
+                            "2026-02-23": net_pnl_per_day,
+                            "2026-02-24": net_pnl_per_day,
+                            "2026-02-25": net_pnl_per_day,
+                            "2026-02-26": net_pnl_per_day,
+                            "2026-02-27": net_pnl_per_day,
+                        },
+                        "daily_filled_notional": {
+                            "2026-02-23": "350000",
+                            "2026-02-24": "350000",
+                            "2026-02-25": "350000",
+                            "2026-02-26": "350000",
+                            "2026-02-27": "350000",
+                        },
+                    },
+                },
+                dataset_snapshot_id="snapshot-hard-veto",
+                result_path=f"/tmp/{candidate_id}.json",
+            )
+
+        vetoed = bundle(
+            candidate_id="cand-vetoed-shock",
+            net_pnl_per_day="1200",
+            symbol="NVDA",
+            cluster="vetoed-shock",
+            hard_vetoes=["max_drawdown_above_max", "best_day_share_above_max"],
+        )
+        portfolio = optimize_portfolio_candidate(
+            evidence_bundles=[
+                vetoed,
+                bundle(
+                    candidate_id="cand-clean-a",
+                    net_pnl_per_day="200",
+                    symbol="AAPL",
+                    cluster="clean-a",
+                ),
+                bundle(
+                    candidate_id="cand-clean-b",
+                    net_pnl_per_day="200",
+                    symbol="AMZN",
+                    cluster="clean-b",
+                ),
+                bundle(
+                    candidate_id="cand-clean-c",
+                    net_pnl_per_day="200",
+                    symbol="GOOGL",
+                    cluster="clean-c",
+                ),
+            ],
+            target_net_pnl_per_day=Decimal("500"),
+            portfolio_size_min=3,
+            portfolio_size_max=3,
+        )
+
+        self.assertEqual(
+            vetoed.objective_scorecard["hard_vetoes"],
+            ["max_drawdown_above_max", "best_day_share_above_max"],
+        )
+        self.assertIsNotNone(portfolio)
+        assert portfolio is not None
+        self.assertNotIn("cand-vetoed-shock", portfolio.source_candidate_ids)
+        self.assertCountEqual(
+            portfolio.source_candidate_ids,
+            ("cand-clean-a", "cand-clean-b", "cand-clean-c"),
+        )
+        self.assertTrue(portfolio.objective_scorecard["oracle_passed"])
+        self.assertIn(
+            {
+                "candidate_id": "cand-vetoed-shock",
+                "reason": "frontier_hard_veto",
+                "hard_vetoes": [
+                    "max_drawdown_above_max",
+                    "best_day_share_above_max",
+                ],
+            },
+            portfolio.optimizer_report["rejections"],
+        )
+
     def test_portfolio_candidate_rejects_pnl_only_replay_without_executable_proof(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Preserves frontier `hard_vetoes` when converting replay candidates into Torghut evidence bundles.
- Rejects hard-vetoed replay candidates before portfolio sleeve optimization, with an explicit `frontier_hard_veto` optimizer rejection reason.
- Adds a regression proving a high-PnL vetoed shock candidate cannot displace lower-PnL clean sleeves in a valid portfolio.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_portfolio_optimizer.py -q`
- `uv run --frozen ruff format --check app/trading/discovery/evidence_bundles.py app/trading/discovery/portfolio_optimizer.py tests/test_portfolio_optimizer.py`
- `uv run --frozen ruff check app/trading/discovery/evidence_bundles.py app/trading/discovery/portfolio_optimizer.py tests/test_portfolio_optimizer.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
