### PR TITLE
chore(torghut): promote image 961b514e

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:4ad5b52b6c8f008eb41b2b5c55c66523617f72ccbfcb9310a82e7053225e4149
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8cf039af420c8e57959081511c81a8e3ec7eca881d31d62b8e93094b1c70267f
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.569.1-243-g9b9c57340
+              value: v0.569.1-249-g961b514ea
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 9b9c57340a34aef9146e0be528c2a4fb5ade5e63
+              value: 961b514eadaa89f2dade143f5e9c155ce1481896
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:4ad5b52b6c8f008eb41b2b5c55c66523617f72ccbfcb9310a82e7053225e4149
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8cf039af420c8e57959081511c81a8e3ec7eca881d31d62b8e93094b1c70267f
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.569.1-243-g9b9c57340
+              value: v0.569.1-249-g961b514ea
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 9b9c57340a34aef9146e0be528c2a4fb5ade5e63
+              value: 961b514eadaa89f2dade143f5e9c155ce1481896
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:4ad5b52b6c8f008eb41b2b5c55c66523617f72ccbfcb9310a82e7053225e4149
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:8cf039af420c8e57959081511c81a8e3ec7eca881d31d62b8e93094b1c70267f
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:4ad5b52b6c8f008eb41b2b5c55c66523617f72ccbfcb9310a82e7053225e4149
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:8cf039af420c8e57959081511c81a8e3ec7eca881d31d62b8e93094b1c70267f
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:4ad5b52b6c8f008eb41b2b5c55c66523617f72ccbfcb9310a82e7053225e4149
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:8cf039af420c8e57959081511c81a8e3ec7eca881d31d62b8e93094b1c70267f
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:4ad5b52b6c8f008eb41b2b5c55c66523617f72ccbfcb9310a82e7053225e4149
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:8cf039af420c8e57959081511c81a8e3ec7eca881d31d62b8e93094b1c70267f
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:4ad5b52b6c8f008eb41b2b5c55c66523617f72ccbfcb9310a82e7053225e4149
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8cf039af420c8e57959081511c81a8e3ec7eca881d31d62b8e93094b1c70267f
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -15,7 +15,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:4ad5b52b6c8f008eb41b2b5c55c66523617f72ccbfcb9310a82e7053225e4149
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8cf039af420c8e57959081511c81a8e3ec7eca881d31d62b8e93094b1c70267f
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -23,7 +23,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:4ad5b52b6c8f008eb41b2b5c55c66523617f72ccbfcb9310a82e7053225e4149
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:8cf039af420c8e57959081511c81a8e3ec7eca881d31d62b8e93094b1c70267f
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:4ad5b52b6c8f008eb41b2b5c55c66523617f72ccbfcb9310a82e7053225e4149
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:8cf039af420c8e57959081511c81a8e3ec7eca881d31d62b8e93094b1c70267f
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-13T17:11:14Z"
+        client.knative.dev/updateTimestamp: "2026-05-13T18:14:51Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -27,7 +27,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:4ad5b52b6c8f008eb41b2b5c55c66523617f72ccbfcb9310a82e7053225e4149
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8cf039af420c8e57959081511c81a8e3ec7eca881d31d62b8e93094b1c70267f
           ports:
             - name: http1
               containerPort: 8181
@@ -482,11 +482,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.569.1-243-g9b9c57340
+              value: v0.569.1-249-g961b514ea
             - name: TORGHUT_COMMIT
-              value: 9b9c57340a34aef9146e0be528c2a4fb5ade5e63
+              value: 961b514eadaa89f2dade143f5e9c155ce1481896
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:4ad5b52b6c8f008eb41b2b5c55c66523617f72ccbfcb9310a82e7053225e4149
+              value: sha256:8cf039af420c8e57959081511c81a8e3ec7eca881d31d62b8e93094b1c70267f
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-13T17:11:14Z"
+        client.knative.dev/updateTimestamp: "2026-05-13T18:14:51Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:4ad5b52b6c8f008eb41b2b5c55c66523617f72ccbfcb9310a82e7053225e4149
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8cf039af420c8e57959081511c81a8e3ec7eca881d31d62b8e93094b1c70267f
           ports:
             - name: http1
               containerPort: 8181
@@ -298,11 +298,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.569.1-243-g9b9c57340
+              value: v0.569.1-249-g961b514ea
             - name: TORGHUT_COMMIT
-              value: 9b9c57340a34aef9146e0be528c2a4fb5ade5e63
+              value: 961b514eadaa89f2dade143f5e9c155ce1481896
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:4ad5b52b6c8f008eb41b2b5c55c66523617f72ccbfcb9310a82e7053225e4149
+              value: sha256:8cf039af420c8e57959081511c81a8e3ec7eca881d31d62b8e93094b1c70267f
           livenessProbe:
             httpGet:
               path: /healthz

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -89,7 +89,7 @@ spec:
           - name: allowStaleTape
           - name: persistResults
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:4ad5b52b6c8f008eb41b2b5c55c66523617f72ccbfcb9310a82e7053225e4149
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:8cf039af420c8e57959081511c81a8e3ec7eca881d31d62b8e93094b1c70267f
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
+++ b/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:4ad5b52b6c8f008eb41b2b5c55c66523617f72ccbfcb9310a82e7053225e4149
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8cf039af420c8e57959081511c81a8e3ec7eca881d31d62b8e93094b1c70267f
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `961b514eadaa89f2dade143f5e9c155ce1481896`
- Image tag: `961b514e`
- Image digest: `sha256:8cf039af420c8e57959081511c81a8e3ec7eca881d31d62b8e93094b1c70267f`