### PR TITLE
chore(jangar): promote image c9b7d3e9

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 917631f7
-  digest: sha256:381a9adc4fbf67c72c40c7230e6819f17b74385bee241b4e61b44491e8661fff
+  tag: c9b7d3e9
+  digest: sha256:aba0ec3d61213c97376513d427cee3095d7165593ac9c792e791fa74f3c26304
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,8 +11,8 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 917631f7
-    digest: sha256:b870655aca9cc6fb857e10afcc3e829fdf3e3ab2abefd7797bc81abf5f5ed433
+    tag: c9b7d3e9
+    digest: sha256:4d7280a0d2851a552135754e717fa5640d51fe75bcabe776c3bf811cba1fefe6
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
@@ -21,8 +21,8 @@ controlPlane:
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 917631f7
-    digest: sha256:381a9adc4fbf67c72c40c7230e6819f17b74385bee241b4e61b44491e8661fff
+    tag: c9b7d3e9
+    digest: sha256:aba0ec3d61213c97376513d427cee3095d7165593ac9c792e791fa74f3c26304
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-13T17:22:19Z
+    deploy.knative.dev/rollout: 2026-05-13T18:15:26Z
 spec:
   replicas: 1
   strategy:
@@ -57,11 +57,11 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_RUNTIME_IMAGE
-              value: registry.ide-newton.ts.net/lab/jangar:917631f7@sha256:381a9adc4fbf67c72c40c7230e6819f17b74385bee241b4e61b44491e8661fff
+              value: registry.ide-newton.ts.net/lab/jangar:c9b7d3e9@sha256:aba0ec3d61213c97376513d427cee3095d7165593ac9c792e791fa74f3c26304
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: 917631f79cc29bfb3f24d89eedb481a3e61da584
+              value: c9b7d3e90f7396bc0717617cc18291830ba38215
             - name: JANGAR_GITOPS_REVISION
-              value: 917631f79cc29bfb3f24d89eedb481a3e61da584
+              value: c9b7d3e90f7396bc0717617cc18291830ba38215
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_BUMBA_TASK_QUEUE

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -59,5 +59,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: 917631f7
-    digest: sha256:381a9adc4fbf67c72c40c7230e6819f17b74385bee241b4e61b44491e8661fff
+    newTag: c9b7d3e9
+    digest: sha256:aba0ec3d61213c97376513d427cee3095d7165593ac9c792e791fa74f3c26304


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `c9b7d3e90f7396bc0717617cc18291830ba38215`
- Image tag: `c9b7d3e9`
- Image digest: `sha256:aba0ec3d61213c97376513d427cee3095d7165593ac9c792e791fa74f3c26304`
- Updated API rollout annotation
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`