### PR TITLE
chore(jangar): promote image 0c02842f

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: c9b7d3e9
-  digest: sha256:aba0ec3d61213c97376513d427cee3095d7165593ac9c792e791fa74f3c26304
+  tag: 0c02842f
+  digest: sha256:e231f93a30145dd7c12397255a190f7b9c6ac2dbbca186c1e76f0a406e2577cc
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,8 +11,8 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: c9b7d3e9
-    digest: sha256:4d7280a0d2851a552135754e717fa5640d51fe75bcabe776c3bf811cba1fefe6
+    tag: 0c02842f
+    digest: sha256:ea078c92e01d4cf9ee815067df87815537559763238c6711ab6b0a130cef0afe
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
@@ -21,8 +21,8 @@ controlPlane:
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: c9b7d3e9
-    digest: sha256:aba0ec3d61213c97376513d427cee3095d7165593ac9c792e791fa74f3c26304
+    tag: 0c02842f
+    digest: sha256:e231f93a30145dd7c12397255a190f7b9c6ac2dbbca186c1e76f0a406e2577cc
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-13T18:15:26Z
+    deploy.knative.dev/rollout: 2026-05-13T18:35:50Z
 spec:
   replicas: 1
   strategy:
@@ -57,11 +57,11 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_RUNTIME_IMAGE
-              value: registry.ide-newton.ts.net/lab/jangar:c9b7d3e9@sha256:aba0ec3d61213c97376513d427cee3095d7165593ac9c792e791fa74f3c26304
+              value: registry.ide-newton.ts.net/lab/jangar:0c02842f@sha256:e231f93a30145dd7c12397255a190f7b9c6ac2dbbca186c1e76f0a406e2577cc
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: c9b7d3e90f7396bc0717617cc18291830ba38215
+              value: 0c02842f964184debf04d75bde1742ef313f4b83
             - name: JANGAR_GITOPS_REVISION
-              value: c9b7d3e90f7396bc0717617cc18291830ba38215
+              value: 0c02842f964184debf04d75bde1742ef313f4b83
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_BUMBA_TASK_QUEUE

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -59,5 +59,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: c9b7d3e9
-    digest: sha256:aba0ec3d61213c97376513d427cee3095d7165593ac9c792e791fa74f3c26304
+    newTag: 0c02842f
+    digest: sha256:e231f93a30145dd7c12397255a190f7b9c6ac2dbbca186c1e76f0a406e2577cc


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `0c02842f964184debf04d75bde1742ef313f4b83`
- Image tag: `0c02842f`
- Image digest: `sha256:e231f93a30145dd7c12397255a190f7b9c6ac2dbbca186c1e76f0a406e2577cc`
- Updated API rollout annotation
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`