### PR TITLE
fix(agents): extend swarm verify timeout

### DIFF
--- a/argocd/applications/agents/swarm-agentrun-templates.yaml
+++ b/argocd/applications/agents/swarm-agentrun-templates.yaml
@@ -201,7 +201,7 @@ spec:
       - name: verify
         retries: 0
         retryBackoffSeconds: 30
-        timeoutSeconds: 2700
+        timeoutSeconds: 7200
         parameters:
           stage: verify
   parameters:
@@ -446,7 +446,7 @@ spec:
       - name: verify
         retries: 0
         retryBackoffSeconds: 30
-        timeoutSeconds: 2700
+        timeoutSeconds: 7200
         parameters:
           stage: verify
   parameters:

--- a/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
+++ b/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
@@ -287,7 +287,7 @@ describe('scheduled AgentRun templates', () => {
       const verifyStep = steps?.find((step) => objectAt(step, 'name') === 'verify')
 
       expect(objectAt(verifyStep, 'retries')).toBe(0)
-      expect(objectAt(verifyStep, 'timeoutSeconds')).toBe(2700)
+      expect(objectAt(verifyStep, 'timeoutSeconds')).toBe(7200)
     }
   })
 


### PR DESCRIPTION
## Summary

- Raises scheduled Jangar and Torghut swarm verify AgentRun timeouts from 2700s to 7200s.
- Keeps verify cadence bounded to one release slice while allowing real GitOps promotion and post-deploy verification to finish.
- Updates the scheduled AgentRun smoke test so future template changes preserve the longer verify budget.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts -t "keeps scheduled verify runs bounded"`
- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `bunx oxfmt --check packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `git diff --check`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
