### PR TITLE
chore(jangar): promote image 42e2cafa

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 0c02842f
-  digest: sha256:e231f93a30145dd7c12397255a190f7b9c6ac2dbbca186c1e76f0a406e2577cc
+  tag: 42e2cafa
+  digest: sha256:b02a53a8f8f1869bfdd234db9a06f49cc75acfe5e4e95cacacfd6c993ce2f2ce
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,8 +11,8 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 0c02842f
-    digest: sha256:ea078c92e01d4cf9ee815067df87815537559763238c6711ab6b0a130cef0afe
+    tag: 42e2cafa
+    digest: sha256:d629b5892d0ece0f20b47cb06ff275f22feb6486bda00a9f025d1da1a31cf710
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
@@ -21,8 +21,8 @@ controlPlane:
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 0c02842f
-    digest: sha256:e231f93a30145dd7c12397255a190f7b9c6ac2dbbca186c1e76f0a406e2577cc
+    tag: 42e2cafa
+    digest: sha256:b02a53a8f8f1869bfdd234db9a06f49cc75acfe5e4e95cacacfd6c993ce2f2ce
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-13T18:35:50Z
+    deploy.knative.dev/rollout: 2026-05-13T19:14:44Z
 spec:
   replicas: 1
   strategy:
@@ -57,11 +57,11 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_RUNTIME_IMAGE
-              value: registry.ide-newton.ts.net/lab/jangar:0c02842f@sha256:e231f93a30145dd7c12397255a190f7b9c6ac2dbbca186c1e76f0a406e2577cc
+              value: registry.ide-newton.ts.net/lab/jangar:42e2cafa@sha256:b02a53a8f8f1869bfdd234db9a06f49cc75acfe5e4e95cacacfd6c993ce2f2ce
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: 0c02842f964184debf04d75bde1742ef313f4b83
+              value: 42e2cafad008511f5f4fb58270d9cf7aa43215be
             - name: JANGAR_GITOPS_REVISION
-              value: 0c02842f964184debf04d75bde1742ef313f4b83
+              value: 42e2cafad008511f5f4fb58270d9cf7aa43215be
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_BUMBA_TASK_QUEUE

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -59,5 +59,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: 0c02842f
-    digest: sha256:e231f93a30145dd7c12397255a190f7b9c6ac2dbbca186c1e76f0a406e2577cc
+    newTag: 42e2cafa
+    digest: sha256:b02a53a8f8f1869bfdd234db9a06f49cc75acfe5e4e95cacacfd6c993ce2f2ce


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `42e2cafad008511f5f4fb58270d9cf7aa43215be`
- Image tag: `42e2cafa`
- Image digest: `sha256:b02a53a8f8f1869bfdd234db9a06f49cc75acfe5e4e95cacacfd6c993ce2f2ce`
- Updated API rollout annotation
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`