### PR TITLE
feat(torghut): bind alpha repair evidence to revenue digest

### DIFF
--- a/services/torghut/README.md
+++ b/services/torghut/README.md
@@ -194,6 +194,11 @@ Testing rules for the trading core:
   `torghut.executable-alpha-receipts.v1` candidate receipts. The initial board is observation-only, seeds AAPL route
   rehab, NVDA scoped proof refill, and missing megacap breadth probes from proof-floor/route evidence, and keeps every
   replay and receipt at `max_notional=0` until Jangar contract graduation and fresh scoped proof close.
+- `GET /trading/revenue-repair` uses that executable-alpha projection when `repair_alpha_readiness` is the top queue
+  item. The digest binds the queue row to `value_gate=routeable_candidate_count`,
+  `required_output_receipt=torghut.executable-alpha-receipts.v1`, `max_notional=0`, the current capital replay board,
+  and candidate executable-alpha receipts so the alpha-readiness repair is dispatchable as zero-notional evidence
+  instead of a generic capital-unblock instruction.
 - `GET /trading/status` and `GET /readyz` now include the May 8 doc 181
   `quality_adjusted_profit_frontier` shadow projection. The reducer ranks zero-notional repair packets from quant
   quality, market-context risk flags, route/TCA state, simulation-cache freshness, and Jangar evidence-quality refs

--- a/services/torghut/app/trading/revenue_repair.py
+++ b/services/torghut/app/trading/revenue_repair.py
@@ -101,6 +101,103 @@ _REPAIR_CATALOG: dict[str, tuple[str, str, str, int, int]] = {
     ),
 }
 
+_REPAIR_METADATA: dict[str, dict[str, object]] = {
+    "alpha_readiness_not_promotion_eligible": {
+        "value_gate": "routeable_candidate_count",
+        "required_output_receipt": "torghut.executable-alpha-receipts.v1",
+        "required_receipts": [
+            "alpha_readiness_receipt",
+            "hypothesis_promotion_receipt",
+            "capital_replay_board",
+        ],
+    },
+    "execution_tca_stale": {
+        "value_gate": "fill_tca_or_slippage_quality",
+        "required_output_receipt": "torghut.execution-tca-current-receipt.v1",
+        "required_receipts": [
+            "execution_tca_receipt",
+            "slippage_guardrail_receipt",
+        ],
+    },
+    "execution_tca_missing": {
+        "value_gate": "fill_tca_or_slippage_quality",
+        "required_output_receipt": "torghut.execution-tca-current-receipt.v1",
+        "required_receipts": [
+            "execution_tca_receipt",
+            "route_universe_receipt",
+        ],
+    },
+    "execution_tca_slippage_guardrail_exceeded": {
+        "value_gate": "fill_tca_or_slippage_quality",
+        "required_output_receipt": "torghut.execution-tca-current-receipt.v1",
+        "required_receipts": [
+            "execution_tca_receipt",
+            "slippage_guardrail_receipt",
+        ],
+    },
+    "execution_tca_route_universe_empty": {
+        "value_gate": "routeable_candidate_count",
+        "required_output_receipt": "torghut.route-universe-repair-receipt.v1",
+        "required_receipts": [
+            "route_universe_receipt",
+            "execution_tca_receipt",
+        ],
+    },
+    "execution_tca_route_universe_incomplete": {
+        "value_gate": "routeable_candidate_count",
+        "required_output_receipt": "torghut.route-universe-repair-receipt.v1",
+        "required_receipts": [
+            "route_universe_receipt",
+            "execution_tca_receipt",
+        ],
+    },
+    "quant_pipeline_degraded": {
+        "value_gate": "zero_notional_or_stale_evidence_rate",
+        "required_output_receipt": "torghut.quant-pipeline-current-receipt.v1",
+        "required_receipts": [
+            "scoped_quant_health_receipt",
+            "quant_pipeline_stage_receipt",
+        ],
+    },
+    "quant_health_degraded": {
+        "value_gate": "zero_notional_or_stale_evidence_rate",
+        "required_output_receipt": "torghut.quant-pipeline-current-receipt.v1",
+        "required_receipts": [
+            "scoped_quant_health_receipt",
+            "quant_pipeline_stage_receipt",
+        ],
+    },
+    "quant_health_fetch_failed": {
+        "value_gate": "zero_notional_or_stale_evidence_rate",
+        "required_output_receipt": "torghut.quant-pipeline-current-receipt.v1",
+        "required_receipts": [
+            "scoped_quant_health_receipt",
+            "quant_pipeline_stage_receipt",
+        ],
+    },
+    "quant_latest_metrics_empty": {
+        "value_gate": "zero_notional_or_stale_evidence_rate",
+        "required_output_receipt": "torghut.quant-pipeline-current-receipt.v1",
+        "required_receipts": [
+            "scoped_quant_health_receipt",
+            "quant_pipeline_stage_receipt",
+        ],
+    },
+    "simple_submit_disabled": {
+        "value_gate": "capital_gate_safety",
+        "required_output_receipt": "torghut.capital-hold-repair-receipt.v1",
+        "required_receipts": [
+            "profitability_proof_floor_receipt",
+            "routeability_acceptance_receipt",
+        ],
+    },
+    "insufficient_buying_power": {
+        "value_gate": "capital_gate_safety",
+        "required_output_receipt": "torghut.capital-account-repair-receipt.v1",
+        "required_receipts": ["capital_account_receipt"],
+    },
+}
+
 _NON_ACTIONABLE_DEPENDENCY_DETAILS = {
     "candidate",
     "healthy",
@@ -123,6 +220,13 @@ def _catalog(reason: str) -> dict[str, object]:
         "priority": priority,
         "expected_unblock_value": expected_unblock_value,
     }
+
+
+def _repair_metadata(reason: str) -> dict[str, object]:
+    metadata = dict(_REPAIR_METADATA.get(reason, {}))
+    metadata.setdefault("max_notional", "0")
+    metadata.setdefault("capital_rule", "zero_notional_repair_only")
+    return metadata
 
 
 def _text(value: object, default: str = "") -> str:
@@ -308,6 +412,7 @@ def _repair_from_ladder_item(
         "priority": priority,
         "expected_unblock_value": max(1, expected_unblock_value),
         "source": "proof_floor.repair_ladder",
+        **_repair_metadata(reason),
     }
 
 
@@ -335,6 +440,7 @@ def _repair_from_reason(
         ),
         "source": "derived.blocking_reason",
         "observed_count": max(1, count),
+        **_repair_metadata(reason),
     }
 
 
@@ -387,6 +493,54 @@ def _build_repair_queue(
     )
 
 
+def _summarize_alpha_replay_items(
+    capital_replay_board: Mapping[str, Any],
+) -> list[dict[str, object]]:
+    replays: list[dict[str, object]] = []
+    for raw_replay in _sequence(capital_replay_board.get("replay_items"))[:3]:
+        replay = _mapping(raw_replay)
+        if not replay:
+            continue
+        replays.append(
+            {
+                "replay_id": replay.get("replay_id"),
+                "hypothesis_id": replay.get("hypothesis_id"),
+                "replay_class": replay.get("replay_class"),
+                "target_symbols": _string_items(replay.get("target_symbols")),
+                "remaining_blockers": _string_items(replay.get("remaining_blockers")),
+                "required_after_refs": _string_items(replay.get("required_after_refs")),
+                "max_notional": _text(replay.get("max_notional"), "0"),
+            }
+        )
+    return replays
+
+
+def _summarize_executable_alpha_receipts(
+    executable_alpha_receipts: Mapping[str, Any],
+) -> list[dict[str, object]]:
+    receipts: list[dict[str, object]] = []
+    for raw_receipt in _sequence(executable_alpha_receipts.get("receipts"))[:3]:
+        receipt = _mapping(raw_receipt)
+        if not receipt:
+            continue
+        guardrail = _mapping(receipt.get("guardrail_result"))
+        capital_effect = _mapping(receipt.get("capital_effect"))
+        receipts.append(
+            {
+                "receipt_id": receipt.get("receipt_id"),
+                "replay_id": receipt.get("replay_id"),
+                "hypothesis_id": receipt.get("hypothesis_id"),
+                "graduation_state": _text(receipt.get("graduation_state")),
+                "remaining_blockers": _string_items(receipt.get("remaining_blockers")),
+                "guardrail_state": _text(guardrail.get("state")),
+                "guardrail_passed": _bool(guardrail.get("passed")),
+                "capital_state": _text(capital_effect.get("capital_state")),
+                "max_notional": _text(capital_effect.get("max_notional"), "0"),
+            }
+        )
+    return receipts
+
+
 def _summarize_alpha(
     status_payload: Mapping[str, Any], proof_floor: Mapping[str, Any]
 ) -> dict[str, object]:
@@ -404,11 +558,59 @@ def _summarize_alpha(
                 "state_totals": source_ref.get("state_totals"),
             }
             break
-    return {
+    alpha_summary: dict[str, object] = {
         "promotion_eligible_total": _int(summary.get("promotion_eligible_total")),
         "rollback_required_total": _int(summary.get("rollback_required_total")),
         "state_totals": _mapping(summary.get("state_totals")),
     }
+    capital_replay_board = _mapping(status_payload.get("capital_replay_board"))
+    if capital_replay_board:
+        board_summary = _mapping(capital_replay_board.get("summary"))
+        alpha_summary["capital_replay_board"] = {
+            "schema_version": capital_replay_board.get("schema_version"),
+            "board_id": capital_replay_board.get("board_id"),
+            "selected_replay_count": _int(
+                board_summary.get("selected_replay_count"),
+                len(_sequence(capital_replay_board.get("selected_replays"))),
+            ),
+            "zero_notional_replay_count": _int(
+                board_summary.get("zero_notional_replay_count")
+            ),
+            "paper_replay_candidate_count": _int(
+                board_summary.get("paper_replay_candidate_count")
+            ),
+            "capital_ready": _bool(board_summary.get("capital_ready")),
+            "selected_replays": _string_items(
+                capital_replay_board.get("selected_replays")
+            ),
+            "top_zero_notional_replays": _summarize_alpha_replay_items(
+                capital_replay_board
+            ),
+        }
+    executable_alpha_receipts = _mapping(
+        status_payload.get("executable_alpha_receipts")
+    )
+    if executable_alpha_receipts:
+        receipt_summary = _mapping(executable_alpha_receipts.get("summary"))
+        alpha_summary["executable_alpha_receipts"] = {
+            "schema_version": executable_alpha_receipts.get("schema_version"),
+            "generated_at": executable_alpha_receipts.get("generated_at"),
+            "receipts_total": _int(receipt_summary.get("receipts_total")),
+            "zero_notional_receipt_count": _int(
+                receipt_summary.get("zero_notional_receipt_count")
+            ),
+            "paper_replay_candidate_count": _int(
+                receipt_summary.get("paper_replay_candidate_count")
+            ),
+            "capital_ready": _bool(receipt_summary.get("capital_ready")),
+            "graduation_state_totals": _mapping(
+                receipt_summary.get("graduation_state_totals")
+            ),
+            "candidate_receipts": _summarize_executable_alpha_receipts(
+                executable_alpha_receipts
+            ),
+        }
+    return alpha_summary
 
 
 def _summarize_tca(proof_floor: Mapping[str, Any]) -> dict[str, object]:

--- a/services/torghut/tests/test_build_revenue_repair_digest.py
+++ b/services/torghut/tests/test_build_revenue_repair_digest.py
@@ -158,6 +158,61 @@ def _repair_only_status() -> dict[str, object]:
             "max_stage_lag_seconds": 56287,
             "blocking_reasons": ["quant_pipeline_degraded"],
         },
+        "capital_replay_board": {
+            "schema_version": "torghut.capital-replay-board.v1",
+            "board_id": "capital-replay:test",
+            "selected_replays": ["replay:aapl-route-rehab"],
+            "summary": {
+                "selected_replay_count": 1,
+                "zero_notional_replay_count": 1,
+                "paper_replay_candidate_count": 0,
+                "capital_ready": False,
+            },
+            "replay_items": [
+                {
+                    "replay_id": "replay:aapl-route-rehab",
+                    "hypothesis_id": "H-AAPL-ROUTE-REHAB",
+                    "replay_class": "route_rehab",
+                    "target_symbols": ["AAPL"],
+                    "remaining_blockers": [
+                        "alpha_readiness_not_promotion_eligible",
+                        "market_context_stale",
+                    ],
+                    "required_after_refs": [
+                        "alpha_readiness_receipt",
+                        "hypothesis_promotion_receipt",
+                    ],
+                    "max_notional": "0",
+                }
+            ],
+        },
+        "executable_alpha_receipts": {
+            "schema_version": "torghut.executable-alpha-receipts.v1",
+            "generated_at": "2026-05-07T16:00:00+00:00",
+            "summary": {
+                "receipts_total": 1,
+                "zero_notional_receipt_count": 1,
+                "paper_replay_candidate_count": 0,
+                "capital_ready": False,
+                "graduation_state_totals": {"candidate": 1},
+            },
+            "receipts": [
+                {
+                    "receipt_id": "receipt:aapl-route-rehab",
+                    "replay_id": "replay:aapl-route-rehab",
+                    "hypothesis_id": "H-AAPL-ROUTE-REHAB",
+                    "graduation_state": "candidate",
+                    "remaining_blockers": [
+                        "alpha_readiness_not_promotion_eligible",
+                    ],
+                    "guardrail_result": {"state": "blocked", "passed": False},
+                    "capital_effect": {
+                        "capital_state": "zero_notional",
+                        "max_notional": "0",
+                    },
+                }
+            ],
+        },
         "simple_lane_reject_reason_totals": {
             "insufficient_buying_power": 8,
         },
@@ -246,6 +301,16 @@ class TestBuildRevenueRepairDigest(TestCase):
         repair_queue = digest["repair_queue"]
         self.assertIsInstance(repair_queue, list)
         self.assertEqual(repair_queue[0]["code"], "repair_alpha_readiness")
+        self.assertEqual(repair_queue[0]["value_gate"], "routeable_candidate_count")
+        self.assertEqual(
+            repair_queue[0]["required_output_receipt"],
+            "torghut.executable-alpha-receipts.v1",
+        )
+        self.assertEqual(repair_queue[0]["max_notional"], "0")
+        self.assertEqual(
+            repair_queue[0]["capital_rule"],
+            "zero_notional_repair_only",
+        )
         self.assertEqual(repair_queue[1]["code"], "repair_execution_tca")
         self.assertNotIn("repair_repair_only", [item["code"] for item in repair_queue])
         self.assertIn(
@@ -260,6 +325,29 @@ class TestBuildRevenueRepairDigest(TestCase):
         )
         evidence = cast(dict[str, object], digest["evidence"])
         self.assertIsInstance(evidence, dict)
+        alpha_readiness = evidence["alpha_readiness"]
+        self.assertIsInstance(alpha_readiness, dict)
+        capital_replay_board = alpha_readiness["capital_replay_board"]
+        self.assertIsInstance(capital_replay_board, dict)
+        self.assertEqual(
+            capital_replay_board["board_id"],
+            "capital-replay:test",
+        )
+        self.assertEqual(capital_replay_board["zero_notional_replay_count"], 1)
+        self.assertFalse(capital_replay_board["capital_ready"])
+        top_replays = capital_replay_board["top_zero_notional_replays"]
+        self.assertIsInstance(top_replays, list)
+        self.assertEqual(top_replays[0]["hypothesis_id"], "H-AAPL-ROUTE-REHAB")
+        self.assertEqual(top_replays[0]["max_notional"], "0")
+        executable_receipts = alpha_readiness["executable_alpha_receipts"]
+        self.assertIsInstance(executable_receipts, dict)
+        self.assertEqual(executable_receipts["zero_notional_receipt_count"], 1)
+        self.assertFalse(executable_receipts["capital_ready"])
+        candidate_receipts = executable_receipts["candidate_receipts"]
+        self.assertIsInstance(candidate_receipts, list)
+        self.assertEqual(candidate_receipts[0]["guardrail_state"], "blocked")
+        self.assertFalse(candidate_receipts[0]["guardrail_passed"])
+        self.assertEqual(candidate_receipts[0]["max_notional"], "0")
         route_reacquisition = evidence["route_reacquisition"]
         self.assertIsInstance(route_reacquisition, dict)
         self.assertEqual(route_reacquisition["state"], "repair_only")


### PR DESCRIPTION
## Summary

- Enriches `/trading/revenue-repair` queue rows with zero-notional action metadata: `value_gate`, `required_output_receipt`, `required_receipts`, `max_notional=0`, and `capital_rule=zero_notional_repair_only`.
- Binds the top `repair_alpha_readiness` work item to the existing `capital_replay_board` and `executable_alpha_receipts` summaries so alpha-readiness repair points at concrete zero-notional replay evidence.
- Updates Torghut service docs and regression coverage for the alpha-readiness digest evidence.

## Related Issues

None

## Design & Requirement Provenance

- Governing Torghut source-of-truth: `docs/torghut/design-system/current-source-of-truth-and-priority-guide-2026-03-09.md`.
- Governing alpha-repair design: `docs/torghut/design-system/v6/168-torghut-executable-alpha-receipts-and-capital-replay-board-2026-05-07.md`.
- Governing repair-outcome design: `docs/torghut/design-system/v6/193-torghut-repair-outcome-dividend-ledger-and-capital-reentry-frontier-2026-05-13.md`.
- Runtime requirement signal: `GET http://torghut.torghut.svc.cluster.local/trading/revenue-repair`.

## Business Evidence

- Before implementation, `/trading/revenue-repair` at `2026-05-13T19:33:25.042966+00:00` reported `business_state=repair_only`, `revenue_ready=false`, top repair queue item `repair_alpha_readiness`, reason `alpha_readiness_not_promotion_eligible`, priority `70`, expected unblock value `3`, live submit disabled, `capital_state=zero_notional`, and `max_notional=0`.
- After local implementation, the live read at `2026-05-13T19:40:44.473728+00:00` remained capital-safe with `business_state=repair_only`, `revenue_ready=false`, top repair queue item `repair_alpha_readiness`, live submit disabled, `capital_state=zero_notional`, and `max_notional=0`.
- Affected value gate: `routeable_candidate_count`.

## Testing

- `uv sync --frozen --extra dev` - pass
- `uv run --frozen pytest tests/test_build_revenue_repair_digest.py tests/test_trading_api.py -k "revenue_repair or alpha_replay_projection"` - pass, `16 passed`
- `uv run --frozen pytest tests/test_build_revenue_repair_digest.py tests/test_executable_alpha_receipts.py tests/test_trading_api.py -k "revenue_repair or alpha_replay_projection or capital_replay_board"` - pass, `17 passed`
- `uv run --frozen ruff check app/trading/revenue_repair.py tests/test_build_revenue_repair_digest.py` - pass
- `uv run --frozen ruff format --check app/trading/revenue_repair.py tests/test_build_revenue_repair_digest.py` - pass
- `uv run --frozen pyright --project pyrightconfig.json` - pass
- `uv run --frozen pyright --project pyrightconfig.alpha.json` - pass
- `uv run --frozen pyright --project pyrightconfig.scripts.json` - pass

## Breaking Changes

None

## Risk And Rollback

- Risk: downstream consumers may start displaying the richer queue metadata before deployed services are promoted. The new fields are additive and existing fields are unchanged.
- Rollback: revert this PR to remove the extra revenue-repair metadata and alpha replay summaries. Capital remains held by existing proof-floor, routeability, and live-submission gates.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
