### PR TITLE
fix(torghut): bridge autoresearch evidence into profit gate

### DIFF
--- a/services/torghut/app/trading/profit_leases.py
+++ b/services/torghut/app/trading/profit_leases.py
@@ -53,11 +53,23 @@ _QUANT_METRICS_REASONS = frozenset(
         "quant_pipeline_stages_missing",
     }
 )
-_PROMOTION_TABLE_NAMES = (
+_LEGACY_PROMOTION_TABLE_NAMES = (
     "research_candidates",
     "research_promotions",
     "strategy_promotion_decisions",
     "vnext_promotion_decisions",
+)
+_AUTORESEARCH_PROMOTION_TABLE_NAMES = (
+    "autoresearch_epochs",
+    "autoresearch_candidate_specs",
+    "autoresearch_proposal_scores",
+    "autoresearch_portfolio_candidates",
+    "autoresearch_portfolio_ready",
+    "autoresearch_portfolio_blocked",
+)
+_PROMOTION_TABLE_NAMES = (
+    *_LEGACY_PROMOTION_TABLE_NAMES,
+    *_AUTORESEARCH_PROMOTION_TABLE_NAMES,
 )
 
 
@@ -401,8 +413,9 @@ def _promotion_source(
         name: _safe_int(promotion_table_counts.get(name))
         for name in _PROMOTION_TABLE_NAMES
     }
-    missing = [name for name, count in counts.items() if count <= 0]
-    if missing:
+    legacy_counts = {name: counts[name] for name in _LEGACY_PROMOTION_TABLE_NAMES}
+    legacy_missing = [name for name, count in legacy_counts.items() if count <= 0]
+    if not legacy_missing:
         return _source_record(
             proof_id=proof_id,
             hypothesis_id=hypothesis_id,
@@ -410,11 +423,60 @@ def _promotion_source(
             window=window,
             source_class="research_candidate",
             source_ref="postgres:promotion_tables",
-            freshness_state="missing",
-            rows=sum(counts.values()),
-            decision="repair_only",
-            blocking_reason_codes=[f"{name}_empty" for name in missing],
+            freshness_state="current",
+            rows=sum(legacy_counts.values()),
+            decision="paper_candidate",
         )
+
+    autoresearch_candidates = counts["autoresearch_candidate_specs"]
+    autoresearch_proposals = counts["autoresearch_proposal_scores"]
+    autoresearch_portfolios = counts["autoresearch_portfolio_candidates"]
+    autoresearch_ready = counts["autoresearch_portfolio_ready"]
+    autoresearch_blocked = counts["autoresearch_portfolio_blocked"]
+    autoresearch_rows = (
+        autoresearch_candidates + autoresearch_proposals + autoresearch_portfolios
+    )
+    if autoresearch_rows > 0:
+        autoresearch_missing: list[str] = []
+        if autoresearch_candidates <= 0:
+            autoresearch_missing.append("autoresearch_candidate_specs_empty")
+        if autoresearch_proposals <= 0:
+            autoresearch_missing.append("autoresearch_proposal_scores_empty")
+        if autoresearch_portfolios <= 0:
+            autoresearch_missing.append("autoresearch_portfolio_candidates_empty")
+        if autoresearch_ready > 0 and not autoresearch_missing:
+            return _source_record(
+                proof_id=proof_id,
+                hypothesis_id=hypothesis_id,
+                account=account,
+                window=window,
+                source_class="research_candidate",
+                source_ref="postgres:autoresearch_ledgers",
+                freshness_state="current",
+                rows=autoresearch_rows,
+                decision="paper_candidate",
+            )
+
+        blockers = list(autoresearch_missing)
+        if autoresearch_ready <= 0:
+            blockers.append("autoresearch_portfolio_ready_empty")
+        if autoresearch_blocked > 0:
+            blockers.append("autoresearch_portfolio_candidates_blocked")
+        return _source_record(
+            proof_id=proof_id,
+            hypothesis_id=hypothesis_id,
+            account=account,
+            window=window,
+            source_class="research_candidate",
+            source_ref="postgres:autoresearch_ledgers",
+            freshness_state="blocked"
+            if autoresearch_portfolios > 0 or autoresearch_blocked > 0
+            else "missing",
+            rows=autoresearch_rows,
+            decision="repair_only",
+            blocking_reason_codes=blockers,
+        )
+
     return _source_record(
         proof_id=proof_id,
         hypothesis_id=hypothesis_id,
@@ -422,9 +484,10 @@ def _promotion_source(
         window=window,
         source_class="research_candidate",
         source_ref="postgres:promotion_tables",
-        freshness_state="current",
-        rows=sum(counts.values()),
-        decision="paper_candidate",
+        freshness_state="missing",
+        rows=sum(legacy_counts.values()),
+        decision="repair_only",
+        blocking_reason_codes=[f"{name}_empty" for name in legacy_missing],
     )
 
 
@@ -564,6 +627,8 @@ def _rehydration_lane(reason_codes: Sequence[str]) -> str:
         return "quant_metrics_rebuild"
     if "rejection_drag_high" in reasons or "rejection_drag_unmeasured" in reasons:
         return "rejection_drag_repair"
+    if any(reason.startswith("autoresearch_") for reason in reasons):
+        return "autoresearch_promotion_repair"
     if any(reason.endswith("_empty") for reason in reasons):
         return "promotion_table_repair"
     if any(

--- a/services/torghut/app/trading/submission_council.py
+++ b/services/torghut/app/trading/submission_council.py
@@ -16,6 +16,10 @@ from sqlalchemy.orm import Session
 
 from ..config import settings
 from ..models import (
+    AutoresearchCandidateSpec,
+    AutoresearchEpoch,
+    AutoresearchPortfolioCandidate,
+    AutoresearchProposalScore,
     ResearchCandidate,
     ResearchPromotion,
     StrategyHypothesis,
@@ -60,6 +64,15 @@ _TA_CORE_REASON_CODES = frozenset(
         "signal_continuity_alert_active",
         "signal_lag_exceeded",
     }
+)
+_AUTORESEARCH_PORTFOLIO_READY_STATUSES = (
+    "target_met",
+    "paper_candidate",
+    "promotion_ready",
+    "ready_for_promotion",
+    "ready_for_promotion_review",
+    "accepted",
+    "promoted",
 )
 
 
@@ -932,6 +945,40 @@ def _load_profit_promotion_table_counts(session: Session) -> dict[str, int]:
         ),
         "vnext_promotion_decisions": int(
             session.execute(select(func.count(VNextPromotionDecision.id))).scalar_one()
+        ),
+        "autoresearch_epochs": int(
+            session.execute(select(func.count(AutoresearchEpoch.id))).scalar_one()
+        ),
+        "autoresearch_candidate_specs": int(
+            session.execute(
+                select(func.count(AutoresearchCandidateSpec.id))
+            ).scalar_one()
+        ),
+        "autoresearch_proposal_scores": int(
+            session.execute(
+                select(func.count(AutoresearchProposalScore.id))
+            ).scalar_one()
+        ),
+        "autoresearch_portfolio_candidates": int(
+            session.execute(
+                select(func.count(AutoresearchPortfolioCandidate.id))
+            ).scalar_one()
+        ),
+        "autoresearch_portfolio_ready": int(
+            session.execute(
+                select(func.count(AutoresearchPortfolioCandidate.id)).where(
+                    AutoresearchPortfolioCandidate.status.in_(
+                        _AUTORESEARCH_PORTFOLIO_READY_STATUSES
+                    )
+                )
+            ).scalar_one()
+        ),
+        "autoresearch_portfolio_blocked": int(
+            session.execute(
+                select(func.count(AutoresearchPortfolioCandidate.id)).where(
+                    AutoresearchPortfolioCandidate.status == "blocked"
+                )
+            ).scalar_one()
         ),
     }
 

--- a/services/torghut/tests/test_profit_leases.py
+++ b/services/torghut/tests/test_profit_leases.py
@@ -228,6 +228,222 @@ class TestProfitLeaseProjection(TestCase):
         )
         self.assertEqual(lease["rehydration_lane"], "promotion_table_repair")
 
+    def test_autoresearch_ledgers_replace_false_empty_legacy_research_blockers(
+        self,
+    ) -> None:
+        counts = _promotion_counts(0)
+        counts.update(
+            {
+                "autoresearch_candidate_specs": 558,
+                "autoresearch_proposal_scores": 558,
+                "autoresearch_portfolio_candidates": 5,
+                "autoresearch_portfolio_ready": 0,
+                "autoresearch_portfolio_blocked": 5,
+            }
+        )
+
+        projection = build_profit_lease_projection(
+            runtime_items=[_runtime_item()],
+            quant_evidence=_healthy_quant(),
+            empirical_jobs_status=_current_empirical(),
+            dependency_quorum={"decision": "allow", "reasons": []},
+            rejection_summary={
+                "rejected": 1,
+                "blocked": 1,
+                "filled": 10,
+                "total": 12,
+            },
+            promotion_table_counts=counts,
+            data_readiness={"equity_ta_rows": 100, "equity_ta_symbols": 20},
+            now=datetime(2026, 5, 13, 12, 0, tzinfo=timezone.utc),
+        )
+
+        lease = projection["leases"][0]
+        promotion_source = next(
+            source
+            for source in projection["source_provenance"]
+            if source["source_class"] == "research_candidate"
+        )
+
+        self.assertEqual(lease["capital_decision"], "repair_only")
+        self.assertEqual(lease["proof_state"], "blocked")
+        self.assertEqual(lease["rehydration_lane"], "autoresearch_promotion_repair")
+        self.assertFalse(projection["torghut_capital"]["allowed"])
+        self.assertEqual(
+            promotion_source["source_ref"], "postgres:autoresearch_ledgers"
+        )
+        self.assertEqual(promotion_source["freshness_state"], "blocked")
+        self.assertEqual(promotion_source["rows"], 1121)
+        self.assertNotIn("research_candidates_empty", lease["blocking_reason_codes"])
+        self.assertNotIn("research_promotions_empty", lease["blocking_reason_codes"])
+        self.assertNotIn(
+            "vnext_promotion_decisions_empty", lease["blocking_reason_codes"]
+        )
+        self.assertIn(
+            "autoresearch_portfolio_ready_empty", lease["blocking_reason_codes"]
+        )
+        self.assertIn(
+            "autoresearch_portfolio_candidates_blocked",
+            lease["blocking_reason_codes"],
+        )
+
+    def test_autoresearch_ledgers_block_on_missing_candidate_specs(self) -> None:
+        counts = _promotion_counts(0)
+        counts.update(
+            {
+                "autoresearch_candidate_specs": 0,
+                "autoresearch_proposal_scores": 2,
+                "autoresearch_portfolio_candidates": 1,
+                "autoresearch_portfolio_ready": 0,
+                "autoresearch_portfolio_blocked": 1,
+            }
+        )
+
+        projection = build_profit_lease_projection(
+            runtime_items=[_runtime_item()],
+            quant_evidence=_healthy_quant(),
+            empirical_jobs_status=_current_empirical(),
+            dependency_quorum={"decision": "allow", "reasons": []},
+            rejection_summary={
+                "rejected": 1,
+                "blocked": 1,
+                "filled": 10,
+                "total": 12,
+            },
+            promotion_table_counts=counts,
+            data_readiness={"equity_ta_rows": 100, "equity_ta_symbols": 20},
+            now=datetime(2026, 5, 13, 12, 0, tzinfo=timezone.utc),
+        )
+
+        lease = projection["leases"][0]
+        self.assertEqual(lease["capital_decision"], "repair_only")
+        self.assertEqual(lease["proof_state"], "blocked")
+        self.assertIn(
+            "autoresearch_candidate_specs_empty", lease["blocking_reason_codes"]
+        )
+
+    def test_autoresearch_ledgers_block_on_missing_proposal_scores(self) -> None:
+        counts = _promotion_counts(0)
+        counts.update(
+            {
+                "autoresearch_candidate_specs": 2,
+                "autoresearch_proposal_scores": 0,
+                "autoresearch_portfolio_candidates": 1,
+                "autoresearch_portfolio_ready": 0,
+                "autoresearch_portfolio_blocked": 1,
+            }
+        )
+
+        projection = build_profit_lease_projection(
+            runtime_items=[_runtime_item()],
+            quant_evidence=_healthy_quant(),
+            empirical_jobs_status=_current_empirical(),
+            dependency_quorum={"decision": "allow", "reasons": []},
+            rejection_summary={
+                "rejected": 1,
+                "blocked": 1,
+                "filled": 10,
+                "total": 12,
+            },
+            promotion_table_counts=counts,
+            data_readiness={"equity_ta_rows": 100, "equity_ta_symbols": 20},
+            now=datetime(2026, 5, 13, 12, 0, tzinfo=timezone.utc),
+        )
+
+        lease = projection["leases"][0]
+        self.assertEqual(lease["capital_decision"], "repair_only")
+        self.assertEqual(lease["proof_state"], "blocked")
+        self.assertIn(
+            "autoresearch_proposal_scores_empty", lease["blocking_reason_codes"]
+        )
+
+    def test_autoresearch_ledgers_block_on_missing_portfolios(self) -> None:
+        counts = _promotion_counts(0)
+        counts.update(
+            {
+                "autoresearch_candidate_specs": 2,
+                "autoresearch_proposal_scores": 2,
+                "autoresearch_portfolio_candidates": 0,
+                "autoresearch_portfolio_ready": 0,
+                "autoresearch_portfolio_blocked": 0,
+            }
+        )
+
+        projection = build_profit_lease_projection(
+            runtime_items=[_runtime_item()],
+            quant_evidence=_healthy_quant(),
+            empirical_jobs_status=_current_empirical(),
+            dependency_quorum={"decision": "allow", "reasons": []},
+            rejection_summary={
+                "rejected": 1,
+                "blocked": 1,
+                "filled": 10,
+                "total": 12,
+            },
+            promotion_table_counts=counts,
+            data_readiness={"equity_ta_rows": 100, "equity_ta_symbols": 20},
+            now=datetime(2026, 5, 13, 12, 0, tzinfo=timezone.utc),
+        )
+
+        lease = projection["leases"][0]
+        promotion_source = next(
+            source
+            for source in projection["source_provenance"]
+            if source["source_class"] == "research_candidate"
+        )
+
+        self.assertEqual(lease["capital_decision"], "repair_only")
+        self.assertEqual(lease["proof_state"], "missing")
+        self.assertEqual(promotion_source["freshness_state"], "missing")
+        self.assertIn(
+            "autoresearch_portfolio_candidates_empty",
+            lease["blocking_reason_codes"],
+        )
+
+    def test_autoresearch_ready_portfolio_allows_paper_candidate(self) -> None:
+        counts = _promotion_counts(0)
+        counts.update(
+            {
+                "autoresearch_candidate_specs": 3,
+                "autoresearch_proposal_scores": 3,
+                "autoresearch_portfolio_candidates": 1,
+                "autoresearch_portfolio_ready": 1,
+                "autoresearch_portfolio_blocked": 0,
+            }
+        )
+
+        projection = build_profit_lease_projection(
+            runtime_items=[_runtime_item()],
+            quant_evidence=_healthy_quant(),
+            empirical_jobs_status=_current_empirical(),
+            dependency_quorum={"decision": "allow", "reasons": []},
+            rejection_summary={
+                "rejected": 1,
+                "blocked": 1,
+                "filled": 10,
+                "total": 12,
+            },
+            promotion_table_counts=counts,
+            data_readiness={"equity_ta_rows": 100, "equity_ta_symbols": 20},
+            now=datetime(2026, 5, 13, 12, 0, tzinfo=timezone.utc),
+        )
+
+        lease = projection["leases"][0]
+        promotion_source = next(
+            source
+            for source in projection["source_provenance"]
+            if source["source_class"] == "research_candidate"
+        )
+
+        self.assertEqual(lease["capital_decision"], "paper_candidate")
+        self.assertEqual(lease["proof_state"], "current")
+        self.assertTrue(projection["torghut_capital"]["allowed"])
+        self.assertEqual(
+            promotion_source["source_ref"], "postgres:autoresearch_ledgers"
+        )
+        self.assertEqual(promotion_source["freshness_state"], "current")
+        self.assertEqual(promotion_source["rows"], 7)
+
     def test_optional_quant_evidence_does_not_force_repair_lane(self) -> None:
         quant = _healthy_quant()
         quant.update(

--- a/services/torghut/tests/test_submission_council.py
+++ b/services/torghut/tests/test_submission_council.py
@@ -2,13 +2,26 @@ from __future__ import annotations
 
 import json
 from datetime import datetime, timezone
+from decimal import Decimal
 from types import SimpleNamespace
 from unittest import TestCase
 from unittest.mock import patch
 
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
 from app.config import settings
+from app.models import (
+    AutoresearchCandidateSpec,
+    AutoresearchEpoch,
+    AutoresearchPortfolioCandidate,
+    AutoresearchProposalScore,
+    Base,
+)
 from app.trading.submission_council import (
     _QUANT_HEALTH_CACHE,
+    _load_profit_promotion_table_counts,
     build_live_submission_gate_payload,
     load_quant_evidence_status,
     resolve_quant_health_url,
@@ -117,6 +130,79 @@ class TestSubmissionCouncil(TestCase):
             "status": "healthy",
             "source_url": "http://jangar.test/api/torghut/trading/control-plane/quant/health?account=paper&window=15m",
         }
+
+    def test_load_profit_promotion_counts_includes_autoresearch_ledgers(self) -> None:
+        engine = create_engine(
+            "sqlite+pysqlite:///:memory:",
+            future=True,
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        Base.metadata.create_all(engine)
+        session_local = sessionmaker(bind=engine, expire_on_commit=False, future=True)
+        with session_local() as session:
+            session.add(
+                AutoresearchEpoch(
+                    epoch_id="epoch-1",
+                    status="no_profit_target_candidate",
+                    target_net_pnl_per_day=Decimal("500"),
+                    paper_run_ids_json=[],
+                    snapshot_manifest_json={},
+                    runner_config_json={},
+                    summary_json={},
+                    started_at=datetime.now(timezone.utc),
+                    completed_at=datetime.now(timezone.utc),
+                )
+            )
+            session.add(
+                AutoresearchCandidateSpec(
+                    candidate_spec_id="spec-1",
+                    epoch_id="epoch-1",
+                    hypothesis_id="H-CONT-01",
+                    candidate_kind="sleeve",
+                    family_template_id="microbar_cross_sectional_pairs_v1",
+                    payload_json={"candidate_spec_id": "spec-1"},
+                    payload_hash="hash",
+                    status="eligible",
+                    blockers_json=[],
+                )
+            )
+            session.add(
+                AutoresearchProposalScore(
+                    epoch_id="epoch-1",
+                    candidate_spec_id="spec-1",
+                    model_id="model-1",
+                    backend="numpy-fallback",
+                    proposal_score=Decimal("12.5"),
+                    rank=1,
+                    selection_reason="exploitation",
+                    feature_hash="feature-hash",
+                    payload_json={},
+                )
+            )
+            session.add(
+                AutoresearchPortfolioCandidate(
+                    portfolio_candidate_id="portfolio-1",
+                    epoch_id="epoch-1",
+                    source_candidate_ids_json=["spec-1"],
+                    target_net_pnl_per_day=Decimal("500"),
+                    objective_scorecard_json={"oracle_passed": False},
+                    optimizer_report_json={"selected_count": 1},
+                    payload_json={"portfolio_candidate_id": "portfolio-1"},
+                    status="blocked",
+                )
+            )
+            session.commit()
+
+            counts = _load_profit_promotion_table_counts(session)
+
+        self.assertEqual(counts["research_candidates"], 0)
+        self.assertEqual(counts["autoresearch_epochs"], 1)
+        self.assertEqual(counts["autoresearch_candidate_specs"], 1)
+        self.assertEqual(counts["autoresearch_proposal_scores"], 1)
+        self.assertEqual(counts["autoresearch_portfolio_candidates"], 1)
+        self.assertEqual(counts["autoresearch_portfolio_blocked"], 1)
+        self.assertEqual(counts["autoresearch_portfolio_ready"], 0)
 
     def test_build_live_submission_gate_payload_fails_closed_on_empty_quant_evidence(
         self,


### PR DESCRIPTION
## Summary

- Adds autoresearch epoch/spec/proposal/portfolio ledger counts to Torghut's live profit-promotion evidence loader.
- Teaches profit leases to treat non-empty autoresearch ledgers as real research evidence while keeping blocked portfolios in `repair_only`.
- Adds regressions proving blocked autoresearch portfolios replace false legacy `research_candidates_empty` blockers without enabling capital.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_profit_leases.py::TestProfitLeaseProjection::test_autoresearch_ledgers_replace_false_empty_legacy_research_blockers tests/test_submission_council.py::TestSubmissionCouncil::test_load_profit_promotion_counts_includes_autoresearch_ledgers -q`
- `uv run --frozen pytest tests/test_profit_leases.py tests/test_submission_council.py -q`
- `uv run --frozen pytest tests/test_trading_api.py::TestTradingApi::test_trading_status_includes_llm_evaluation -q`
- `uv run --frozen ruff check app/trading/profit_leases.py app/trading/submission_council.py tests/test_profit_leases.py tests/test_submission_council.py`
- `uv run --frozen ruff format --check app/trading/profit_leases.py app/trading/submission_council.py tests/test_profit_leases.py tests/test_submission_council.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A - backend evidence-gate change with API/test validation.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
