### PR TITLE
chore(jangar): promote image a29d185c

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 42e2cafa
-  digest: sha256:b02a53a8f8f1869bfdd234db9a06f49cc75acfe5e4e95cacacfd6c993ce2f2ce
+  tag: a29d185c
+  digest: sha256:8f0ddab95dfdbe0d26605f3ba613cc5fef96675a317ef2b4d4a3a2f7ea1745c2
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,8 +11,8 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 42e2cafa
-    digest: sha256:d629b5892d0ece0f20b47cb06ff275f22feb6486bda00a9f025d1da1a31cf710
+    tag: a29d185c
+    digest: sha256:173d7c2e547862e562d778bf282054cd78c88ca2851be443b73ce3cd753e3a71
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
@@ -21,8 +21,8 @@ controlPlane:
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 42e2cafa
-    digest: sha256:b02a53a8f8f1869bfdd234db9a06f49cc75acfe5e4e95cacacfd6c993ce2f2ce
+    tag: a29d185c
+    digest: sha256:8f0ddab95dfdbe0d26605f3ba613cc5fef96675a317ef2b4d4a3a2f7ea1745c2
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-13T19:14:44Z
+    deploy.knative.dev/rollout: 2026-05-13T20:12:18Z
 spec:
   replicas: 1
   strategy:
@@ -57,11 +57,11 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_RUNTIME_IMAGE
-              value: registry.ide-newton.ts.net/lab/jangar:42e2cafa@sha256:b02a53a8f8f1869bfdd234db9a06f49cc75acfe5e4e95cacacfd6c993ce2f2ce
+              value: registry.ide-newton.ts.net/lab/jangar:a29d185c@sha256:8f0ddab95dfdbe0d26605f3ba613cc5fef96675a317ef2b4d4a3a2f7ea1745c2
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: 42e2cafad008511f5f4fb58270d9cf7aa43215be
+              value: a29d185c6653b0b02360be785bb71f36f2253d15
             - name: JANGAR_GITOPS_REVISION
-              value: 42e2cafad008511f5f4fb58270d9cf7aa43215be
+              value: a29d185c6653b0b02360be785bb71f36f2253d15
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_BUMBA_TASK_QUEUE

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -59,5 +59,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: 42e2cafa
-    digest: sha256:b02a53a8f8f1869bfdd234db9a06f49cc75acfe5e4e95cacacfd6c993ce2f2ce
+    newTag: a29d185c
+    digest: sha256:8f0ddab95dfdbe0d26605f3ba613cc5fef96675a317ef2b4d4a3a2f7ea1745c2


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `a29d185c6653b0b02360be785bb71f36f2253d15`
- Image tag: `a29d185c`
- Image digest: `sha256:8f0ddab95dfdbe0d26605f3ba613cc5fef96675a317ef2b4d4a3a2f7ea1745c2`
- Updated API rollout annotation
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`