### PR TITLE
feat(torghut): expose alpha repair targets

### DIFF
--- a/docs/torghut/rollouts/2026-05-13-alpha-readiness-repair-targets.md
+++ b/docs/torghut/rollouts/2026-05-13-alpha-readiness-repair-targets.md
@@ -1,0 +1,74 @@
+# 2026-05-13 Torghut Alpha Readiness Repair Targets
+
+## Scope
+
+This rollout note covers the zero-notional alpha-readiness repair target projection added for the Torghut quant repair
+loop.
+
+Governing design references:
+
+- `docs/torghut/design-system/current-source-of-truth-and-priority-guide-2026-03-09.md`
+- `docs/torghut/design-system/v6/168-torghut-executable-alpha-receipts-and-capital-replay-board-2026-05-07.md`
+- `docs/torghut/design-system/v6/192-torghut-repair-receipt-frontier-and-profit-cutover-2026-05-13.md`
+
+## Runtime Evidence Before Change
+
+Read-only source: `GET http://torghut.torghut.svc.cluster.local/trading/revenue-repair` on 2026-05-13.
+
+- `business_state=repair_only`
+- `revenue_ready=false`
+- top `repair_queue` item: `repair_alpha_readiness` / `alpha_readiness_not_promotion_eligible`
+- selected value gate: `routeable_candidate_count`
+- capital remained `zero_notional` with `max_notional=0`
+- routeable candidate count remained `0`
+
+The live routeability acceptance lot for `alpha_readiness_repair` showed empty `symbols` and `hypothesis_ids`, even
+though the route-evidence clearinghouse had hypothesis and candidate refs. That made the top repair action measurable
+only as a generic blocker, not as a scoped hypothesis repair.
+
+## Shipped Change
+
+- The profitability proof floor now projects alpha repair target provenance from hypothesis runtime items into the
+  `alpha_readiness` source ref: hypothesis ids, blocked ids, promotion-eligible ids, repair target counts, and compact
+  target metadata.
+- Route reacquisition records already consume proof-floor alpha `hypothesis_ids`; with the new source refs, zero-notional
+  route repair rows can name the hypothesis that must clear before routeability can count a candidate.
+- `/trading/revenue-repair` now preserves those alpha repair targets in `evidence.alpha_readiness`, so Jangar and
+  operators can dispatch `repair_alpha_readiness` against a concrete target while keeping capital closed.
+
+## Validation
+
+Local targeted validation:
+
+```bash
+cd services/torghut
+/root/.local/bin/uv run --frozen pytest tests/test_profitability_proof_floor.py tests/test_build_revenue_repair_digest.py tests/test_route_reacquisition.py tests/test_routeability_repair_acceptance.py
+```
+
+Result: `47 passed`.
+
+Broader local validation:
+
+- `/root/.local/bin/uv lock --check`: pass
+- `/root/.local/bin/uv run --frozen ruff format --check app/trading/proof_floor.py app/trading/revenue_repair.py tests/test_profitability_proof_floor.py tests/test_build_revenue_repair_digest.py`: pass
+- `/root/.local/bin/uv run --frozen ruff check app tests scripts migrations`: pass
+- `/root/.local/bin/uv run --frozen python -m compileall app`: pass
+- `/root/.local/bin/uv run --frozen python scripts/check_migration_graph.py`: pass
+- `/root/.local/bin/uv run --frozen pyright --project pyrightconfig.json`: pass
+- `/root/.local/bin/uv run --frozen pyright --project pyrightconfig.alpha.json`: pass
+- `/root/.local/bin/uv run --frozen pyright --project pyrightconfig.scripts.json`: pass
+- `/root/.local/bin/uv run --frozen pytest --cov --cov-branch --cov-report=term-missing --cov-report=xml`: pass,
+  `2256 passed`, total coverage `78.91%`
+
+## Risk And Rollback
+
+Risk is limited to additive evidence payload fields. The change does not alter submission gates, notional sizing,
+route-state decisions, or live submit configuration. If a downstream consumer rejects the added fields, roll back by
+reverting this PR; the prior behavior falls back to generic `alpha_readiness_not_promotion_eligible` repair evidence
+with capital still held at `max_notional=0`.
+
+## Owner-Facing Status
+
+This improves `routeable_candidate_count` readiness by making the current top alpha repair target concrete. It does
+not make Torghut revenue-ready by itself: live submission remains disabled until the repair queue clears and proof-floor
+capital gates leave `repair_only`.

--- a/services/torghut/app/trading/proof_floor.py
+++ b/services/torghut/app/trading/proof_floor.py
@@ -108,6 +108,82 @@ def _hypothesis_items(hypothesis_payload: Mapping[str, Any]) -> list[Mapping[str
     ]
 
 
+def _strings(value: object) -> list[str]:
+    return sorted({_text(item) for item in _sequence(value) if _text(item)})
+
+
+def _truthy(value: object) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on", "pass", "ready"}
+    return bool(value)
+
+
+def _hypothesis_repair_target_summary(
+    hypothesis_payload: Mapping[str, Any],
+) -> dict[str, object]:
+    hypothesis_ids: set[str] = set()
+    promotion_eligible_ids: set[str] = set()
+    blocked_ids: set[str] = set()
+    repair_targets: list[dict[str, object]] = []
+
+    for item in _hypothesis_items(hypothesis_payload):
+        lineage_ref = _mapping(item.get("lineage_ref"))
+        hypothesis_id = _text(
+            item.get("hypothesis_id"), _text(lineage_ref.get("hypothesis_id"))
+        )
+        if not hypothesis_id:
+            continue
+        if hypothesis_id in hypothesis_ids:
+            continue
+
+        hypothesis_ids.add(hypothesis_id)
+        promotion_eligible = _truthy(item.get("promotion_eligible"))
+        if promotion_eligible:
+            promotion_eligible_ids.add(hypothesis_id)
+        else:
+            blocked_ids.add(hypothesis_id)
+
+        candidate_id = _text(
+            item.get("candidate_id"), _text(lineage_ref.get("candidate_id"))
+        )
+        strategy_id = _text(
+            item.get("strategy_id"), _text(lineage_ref.get("strategy_id"))
+        )
+        lane_id = _text(item.get("lane_id"), _text(lineage_ref.get("lane_id")))
+        strategy_family = _text(
+            item.get("strategy_family"), _text(lineage_ref.get("strategy_family"))
+        )
+        target: dict[str, object] = {
+            "hypothesis_id": hypothesis_id,
+            "state": _text(item.get("state"), "unknown"),
+            "promotion_eligible": promotion_eligible,
+            "reasons": _strings(item.get("reasons")),
+            "informational_reasons": _strings(item.get("informational_reasons")),
+        }
+        if candidate_id:
+            target["candidate_id"] = candidate_id
+        if strategy_id:
+            target["strategy_id"] = strategy_id
+        if lane_id:
+            target["lane_id"] = lane_id
+        if strategy_family:
+            target["strategy_family"] = strategy_family
+        if len(repair_targets) < 5:
+            repair_targets.append(target)
+
+    return {
+        "hypothesis_ids": sorted(hypothesis_ids),
+        "blocked_hypothesis_ids": sorted(blocked_ids),
+        "promotion_eligible_hypothesis_ids": sorted(promotion_eligible_ids),
+        "repair_target_count": len(hypothesis_ids),
+        "blocked_repair_target_count": len(blocked_ids),
+        "promotion_eligible_repair_target_count": len(promotion_eligible_ids),
+        "repair_targets": repair_targets,
+    }
+
+
 def _reason_counts(hypothesis_payload: Mapping[str, Any]) -> Counter[str]:
     counts: Counter[str] = Counter()
     for item in _hypothesis_items(hypothesis_payload):
@@ -311,6 +387,7 @@ def build_profitability_proof_floor_receipt(
 
     promotion_eligible_total = _int(summary.get("promotion_eligible_total"))
     rollback_required_total = _int(summary.get("rollback_required_total"))
+    alpha_repair_target_summary = _hypothesis_repair_target_summary(hypothesis_payload)
     if promotion_eligible_total <= 0:
         add_dimension(
             dimension="alpha_readiness",
@@ -326,6 +403,7 @@ def build_profitability_proof_floor_receipt(
                     "informational_reason_totals"
                 )
                 or {},
+                **alpha_repair_target_summary,
             },
         )
         _add_repair(
@@ -343,7 +421,10 @@ def build_profitability_proof_floor_receipt(
             state="pass",
             reason="promotion_eligible",
             capital_effect="none",
-            source_ref={"promotion_eligible_total": promotion_eligible_total},
+            source_ref={
+                "promotion_eligible_total": promotion_eligible_total,
+                **alpha_repair_target_summary,
+            },
         )
 
     empirical_ready = _bool(empirical_jobs_status.get("ready"))

--- a/services/torghut/app/trading/revenue_repair.py
+++ b/services/torghut/app/trading/revenue_repair.py
@@ -541,6 +541,29 @@ def _summarize_executable_alpha_receipts(
     return receipts
 
 
+def _summarize_alpha_repair_targets(
+    alpha_source: Mapping[str, Any],
+) -> list[dict[str, object]]:
+    targets: list[dict[str, object]] = []
+    for raw_target in _sequence(alpha_source.get("repair_targets"))[:5]:
+        target = _mapping(raw_target)
+        if not target:
+            continue
+        payload: dict[str, object] = {
+            "hypothesis_id": _text(target.get("hypothesis_id")),
+            "state": _text(target.get("state"), "unknown"),
+            "promotion_eligible": _bool(target.get("promotion_eligible")),
+            "reasons": _string_items(target.get("reasons")),
+            "informational_reasons": _string_items(target.get("informational_reasons")),
+        }
+        for key in ("candidate_id", "strategy_id", "lane_id", "strategy_family"):
+            value = _text(target.get(key))
+            if value:
+                payload[key] = value
+        targets.append(payload)
+    return targets
+
+
 def _summarize_alpha(
     status_payload: Mapping[str, Any], proof_floor: Mapping[str, Any]
 ) -> dict[str, object]:
@@ -552,16 +575,23 @@ def _summarize_alpha(
             if _text(dimension.get("dimension")) != "alpha_readiness":
                 continue
             source_ref = _mapping(dimension.get("source_ref"))
-            summary = {
-                "promotion_eligible_total": source_ref.get("promotion_eligible_total"),
-                "rollback_required_total": source_ref.get("rollback_required_total"),
-                "state_totals": source_ref.get("state_totals"),
-            }
+            summary = dict(source_ref)
             break
     alpha_summary: dict[str, object] = {
         "promotion_eligible_total": _int(summary.get("promotion_eligible_total")),
         "rollback_required_total": _int(summary.get("rollback_required_total")),
         "state_totals": _mapping(summary.get("state_totals")),
+        "hypothesis_ids": _string_items(summary.get("hypothesis_ids")),
+        "blocked_hypothesis_ids": _string_items(summary.get("blocked_hypothesis_ids")),
+        "promotion_eligible_hypothesis_ids": _string_items(
+            summary.get("promotion_eligible_hypothesis_ids")
+        ),
+        "repair_target_count": _int(summary.get("repair_target_count")),
+        "blocked_repair_target_count": _int(summary.get("blocked_repair_target_count")),
+        "promotion_eligible_repair_target_count": _int(
+            summary.get("promotion_eligible_repair_target_count")
+        ),
+        "repair_targets": _summarize_alpha_repair_targets(summary),
     }
     capital_replay_board = _mapping(status_payload.get("capital_replay_board"))
     if capital_replay_board:

--- a/services/torghut/tests/test_build_revenue_repair_digest.py
+++ b/services/torghut/tests/test_build_revenue_repair_digest.py
@@ -111,6 +111,30 @@ def _repair_only_status() -> dict[str, object]:
                         "promotion_eligible_total": 0,
                         "rollback_required_total": 3,
                         "state_totals": {"blocked": 1, "shadow": 2},
+                        "hypothesis_ids": ["H-AAPL-ROUTE-REHAB"],
+                        "blocked_hypothesis_ids": ["H-AAPL-ROUTE-REHAB"],
+                        "promotion_eligible_hypothesis_ids": [],
+                        "repair_target_count": 1,
+                        "blocked_repair_target_count": 1,
+                        "promotion_eligible_repair_target_count": 0,
+                        "repair_targets": [
+                            {
+                                "hypothesis_id": "H-AAPL-ROUTE-REHAB",
+                                "state": "shadow",
+                                "promotion_eligible": False,
+                                "reasons": [
+                                    "alpha_readiness_not_promotion_eligible",
+                                    "post_cost_expectancy_non_positive",
+                                ],
+                                "informational_reasons": [
+                                    "closed_session_market_context_hold"
+                                ],
+                                "candidate_id": "chip-paper-microbar-composite@execution-proof",
+                                "strategy_id": "intraday_tsmom_v1@paper",
+                                "lane_id": "continuation",
+                                "strategy_family": "intraday_continuation",
+                            }
+                        ],
                     },
                 },
                 {
@@ -327,6 +351,23 @@ class TestBuildRevenueRepairDigest(TestCase):
         self.assertIsInstance(evidence, dict)
         alpha_readiness = evidence["alpha_readiness"]
         self.assertIsInstance(alpha_readiness, dict)
+        self.assertEqual(
+            alpha_readiness["hypothesis_ids"],
+            ["H-AAPL-ROUTE-REHAB"],
+        )
+        self.assertEqual(
+            alpha_readiness["blocked_hypothesis_ids"],
+            ["H-AAPL-ROUTE-REHAB"],
+        )
+        self.assertEqual(alpha_readiness["repair_target_count"], 1)
+        repair_targets = alpha_readiness["repair_targets"]
+        self.assertIsInstance(repair_targets, list)
+        self.assertEqual(repair_targets[0]["hypothesis_id"], "H-AAPL-ROUTE-REHAB")
+        self.assertEqual(
+            repair_targets[0]["candidate_id"],
+            "chip-paper-microbar-composite@execution-proof",
+        )
+        self.assertEqual(repair_targets[0]["strategy_id"], "intraday_tsmom_v1@paper")
         capital_replay_board = alpha_readiness["capital_replay_board"]
         self.assertIsInstance(capital_replay_board, dict)
         self.assertEqual(

--- a/services/torghut/tests/test_profitability_proof_floor.py
+++ b/services/torghut/tests/test_profitability_proof_floor.py
@@ -100,13 +100,22 @@ def test_live_degraded_evidence_routes_to_repair_only() -> None:
             },
             "items": [
                 {
-                    "hypothesis_id": "chip-paper-microbar-composite",
+                    "hypothesis_id": "H-CONT-01",
+                    "state": "shadow",
+                    "promotion_eligible": False,
                     "reasons": [
                         "tca_evidence_stale",
                         "signal_lag_exceeded",
                         "feature_rows_missing",
                     ],
+                    "informational_reasons": ["closed_session_signal_hold"],
                     "promotion_contract": {"max_avg_abs_slippage_bps": "20"},
+                    "lineage_ref": {
+                        "candidate_id": "chip-paper-microbar-composite@execution-proof",
+                        "strategy_id": "intraday_tsmom_v1@paper",
+                        "lane_id": "continuation",
+                        "strategy_family": "intraday_continuation",
+                    },
                 }
             ],
         },
@@ -156,6 +165,98 @@ def test_live_degraded_evidence_routes_to_repair_only() -> None:
     assert alpha_dimension["source_ref"]["informational_reason_totals"] == {
         "closed_session_signal_hold": 2
     }
+    assert alpha_dimension["source_ref"]["hypothesis_ids"] == ["H-CONT-01"]
+    assert alpha_dimension["source_ref"]["blocked_hypothesis_ids"] == ["H-CONT-01"]
+    assert alpha_dimension["source_ref"]["repair_target_count"] == 1
+    assert alpha_dimension["source_ref"]["blocked_repair_target_count"] == 1
+    repair_targets = cast(
+        list[Mapping[str, Any]], alpha_dimension["source_ref"]["repair_targets"]
+    )
+    assert repair_targets == [
+        {
+            "hypothesis_id": "H-CONT-01",
+            "state": "shadow",
+            "promotion_eligible": False,
+            "reasons": [
+                "feature_rows_missing",
+                "signal_lag_exceeded",
+                "tca_evidence_stale",
+            ],
+            "informational_reasons": ["closed_session_signal_hold"],
+            "candidate_id": "chip-paper-microbar-composite@execution-proof",
+            "strategy_id": "intraday_tsmom_v1@paper",
+            "lane_id": "continuation",
+            "strategy_family": "intraday_continuation",
+        }
+    ]
+
+
+def test_alpha_repair_targets_flow_to_route_reacquisition_records() -> None:
+    receipt = build_profitability_proof_floor_receipt(
+        account_label="PA3SX7FYNUTF",
+        torghut_revision="torghut-00364",
+        trading_mode="live",
+        market_session_open=True,
+        live_submission_gate={
+            "allowed": False,
+            "reason": "simple_submit_disabled",
+            "blocked_reasons": ["simple_submit_disabled"],
+            "capital_stage": "shadow",
+        },
+        hypothesis_payload={
+            "summary": {
+                "hypotheses_total": 1,
+                "promotion_eligible_total": 0,
+                "rollback_required_total": 0,
+                "state_totals": {"shadow": 1},
+                "reason_totals": {"post_cost_expectancy_non_positive": 1},
+            },
+            "items": [
+                {
+                    "hypothesis_id": "H-CONT-01",
+                    "state": "shadow",
+                    "promotion_eligible": False,
+                    "reasons": ["post_cost_expectancy_non_positive"],
+                    "promotion_contract": {"max_avg_abs_slippage_bps": "12"},
+                    "lineage_ref": {
+                        "candidate_id": "chip-paper-microbar-composite@execution-proof",
+                        "strategy_id": "intraday_tsmom_v1@paper",
+                    },
+                }
+            ],
+        },
+        empirical_jobs_status=_healthy_empirical_jobs(),
+        quant_evidence=_healthy_quant_evidence(),
+        market_context_status=_healthy_market_context(),
+        tca_summary={
+            "order_count": 2033,
+            "filled_execution_count": 2033,
+            "unsettled_execution_count": 0,
+            "last_computed_at": NOW.isoformat(),
+            "latest_execution_created_at": NOW.isoformat(),
+            "avg_abs_slippage_bps": "9.25",
+            "scope_symbols": ["AAPL"],
+            "scope_symbol_count": 1,
+            "symbol_breakdown": [
+                {
+                    "symbol": "AAPL",
+                    "order_count": 2033,
+                    "avg_abs_slippage_bps": "9.25",
+                    "max_abs_slippage_bps": "112.77",
+                    "last_computed_at": NOW.isoformat(),
+                }
+            ],
+        },
+        simple_lane_status=_simple_lane_status(),
+        now=NOW,
+    )
+
+    route_book = cast(dict[str, Any], receipt["route_reacquisition_book"])
+    records = cast(list[Mapping[str, Any]], route_book["records"])
+    assert len(records) == 1
+    assert records[0]["symbol"] == "AAPL"
+    assert records[0]["state"] == "probing"
+    assert records[0]["hypothesis_ids"] == ["H-CONT-01"]
 
 
 def test_live_all_clear_routes_to_micro_candidate_with_configured_notional() -> None:


### PR DESCRIPTION
## Summary

- Adds scoped alpha repair target provenance to the profitability proof floor so `alpha_readiness` source refs name the hypothesis ids, blocked ids, promotion-eligible ids, and compact target metadata behind `repair_alpha_readiness`.
- Preserves those alpha repair targets in `/trading/revenue-repair` under `evidence.alpha_readiness`, making the live top blocker actionable for `routeable_candidate_count` while keeping `max_notional=0`.
- Adds regression coverage for proof-floor target projection, route-reacquisition target carry-through, and revenue-repair digest summaries.
- Adds a Torghut rollout note with governing design refs, live before evidence, validation, risk, and rollback.

## Related Issues

None

## Testing

- `cd services/torghut && /root/.local/bin/uv sync --frozen --extra dev` - pass
- `cd services/torghut && /root/.local/bin/uv lock --check` - pass
- `cd services/torghut && /root/.local/bin/uv run --frozen ruff format --check app/trading/proof_floor.py app/trading/revenue_repair.py tests/test_profitability_proof_floor.py tests/test_build_revenue_repair_digest.py` - pass
- `cd services/torghut && /root/.local/bin/uv run --frozen ruff check app tests scripts migrations` - pass
- `cd services/torghut && /root/.local/bin/uv run --frozen python -m compileall app` - pass
- `cd services/torghut && /root/.local/bin/uv run --frozen python scripts/check_migration_graph.py` - pass
- `cd services/torghut && /root/.local/bin/uv run --frozen pyright --project pyrightconfig.json` - pass, `0 errors`
- `cd services/torghut && /root/.local/bin/uv run --frozen pyright --project pyrightconfig.alpha.json` - pass, `0 errors`
- `cd services/torghut && /root/.local/bin/uv run --frozen pyright --project pyrightconfig.scripts.json` - pass, `0 errors`
- `cd services/torghut && /root/.local/bin/uv run --frozen pytest tests/test_profitability_proof_floor.py tests/test_build_revenue_repair_digest.py tests/test_route_reacquisition.py tests/test_routeability_repair_acceptance.py` - pass, `47 passed`
- `cd services/torghut && /root/.local/bin/uv run --frozen pytest --cov --cov-branch --cov-report=term-missing --cov-report=xml` - pass, `2256 passed`, total coverage `78.91%`
- Hosted PR CI on 2026-05-13 - pass: Torghut Pyright, bytecode/lint/migration guard, pytest shards 0-3, aggregate bytecode/pytest/coverage, quality signals, changed-file plan, semantic commits, semantic PR title, and changed-files.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Release Notes

Governing design provenance:

- `docs/torghut/design-system/current-source-of-truth-and-priority-guide-2026-03-09.md`
- `docs/torghut/design-system/v6/168-torghut-executable-alpha-receipts-and-capital-replay-board-2026-05-07.md`
- `docs/torghut/design-system/v6/192-torghut-repair-receipt-frontier-and-profit-cutover-2026-05-13.md`

Runtime requirement provenance:

- Read-only `/trading/revenue-repair` evidence on 2026-05-13 showed `business_state=repair_only`, `revenue_ready=false`, top queue item `repair_alpha_readiness` / `alpha_readiness_not_promotion_eligible`, value gate `routeable_candidate_count`, and routeable candidate count `0`.
- Live capital remains zero-notional; this PR does not alter submit gates, notional sizing, route-state decisions, or order execution behavior.

Risk and rollback:

- Risk is limited to additive evidence payload fields under proof-floor alpha source refs and revenue-repair alpha summaries.
- Roll back by reverting this PR; Torghut falls back to generic `alpha_readiness_not_promotion_eligible` repair evidence with capital still held at `max_notional=0`.

Owner-facing status:

- This improves `routeable_candidate_count` readiness by making the current top alpha repair target concrete.
- It does not make Torghut revenue-ready by itself; live submission remains disabled until the repair queue clears and proof-floor capital gates leave `repair_only`.
- PR #6489 is open, mergeable, not a draft, and green on hosted CI at commit `8d74f76c20892f903984da20ca9f58664e498465`.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
