### PR TITLE
chore(jangar): promote image 4bb49794

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: a29d185c
-  digest: sha256:8f0ddab95dfdbe0d26605f3ba613cc5fef96675a317ef2b4d4a3a2f7ea1745c2
+  tag: 4bb49794
+  digest: sha256:fd072169144f17ce47a20664f2cf2fc522d8b92c3b10ef50c6acd4c2845802f9
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,8 +11,8 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: a29d185c
-    digest: sha256:173d7c2e547862e562d778bf282054cd78c88ca2851be443b73ce3cd753e3a71
+    tag: 4bb49794
+    digest: sha256:8a75d6a3cca9d2be0c75939f3772bab3c4ca52ed02dc19113dec124d9397738d
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
@@ -21,8 +21,8 @@ controlPlane:
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: a29d185c
-    digest: sha256:8f0ddab95dfdbe0d26605f3ba613cc5fef96675a317ef2b4d4a3a2f7ea1745c2
+    tag: 4bb49794
+    digest: sha256:fd072169144f17ce47a20664f2cf2fc522d8b92c3b10ef50c6acd4c2845802f9
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-13T20:12:18Z
+    deploy.knative.dev/rollout: 2026-05-13T21:04:23Z
 spec:
   replicas: 1
   strategy:
@@ -57,11 +57,11 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_RUNTIME_IMAGE
-              value: registry.ide-newton.ts.net/lab/jangar:a29d185c@sha256:8f0ddab95dfdbe0d26605f3ba613cc5fef96675a317ef2b4d4a3a2f7ea1745c2
+              value: registry.ide-newton.ts.net/lab/jangar:4bb49794@sha256:fd072169144f17ce47a20664f2cf2fc522d8b92c3b10ef50c6acd4c2845802f9
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: a29d185c6653b0b02360be785bb71f36f2253d15
+              value: 4bb497943e2b9249eac57d82e64b491bd58631ae
             - name: JANGAR_GITOPS_REVISION
-              value: a29d185c6653b0b02360be785bb71f36f2253d15
+              value: 4bb497943e2b9249eac57d82e64b491bd58631ae
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_BUMBA_TASK_QUEUE

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -59,5 +59,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: a29d185c
-    digest: sha256:8f0ddab95dfdbe0d26605f3ba613cc5fef96675a317ef2b4d4a3a2f7ea1745c2
+    newTag: 4bb49794
+    digest: sha256:fd072169144f17ce47a20664f2cf2fc522d8b92c3b10ef50c6acd4c2845802f9


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `4bb497943e2b9249eac57d82e64b491bd58631ae`
- Image tag: `4bb49794`
- Image digest: `sha256:fd072169144f17ce47a20664f2cf2fc522d8b92c3b10ef50c6acd4c2845802f9`
- Updated API rollout annotation
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`