### PR TITLE
feat(torghut): add autoresearch gate diagnostics

### DIFF
--- a/services/torghut/app/trading/evaluation_trace.py
+++ b/services/torghut/app/trading/evaluation_trace.py
@@ -195,6 +195,9 @@ class ReplayFunnelBucket:
     quote_valid_rows: int
     strategy_evaluations: int
     gate_pass_counts: dict[str, int]
+    first_failed_gate_counts: dict[str, int]
+    failing_threshold_counts: dict[str, int]
+    passed_trace_count: int
     decision_count: int
     filled_count: int
     filled_notional: Decimal
@@ -212,6 +215,9 @@ class ReplayFunnelBucket:
             'quote_valid_rows': self.quote_valid_rows,
             'strategy_evaluations': self.strategy_evaluations,
             'gate_pass_counts': dict(sorted(self.gate_pass_counts.items())),
+            'first_failed_gate_counts': dict(sorted(self.first_failed_gate_counts.items())),
+            'failing_threshold_counts': dict(sorted(self.failing_threshold_counts.items())),
+            'passed_trace_count': self.passed_trace_count,
             'decision_count': self.decision_count,
             'filled_count': self.filled_count,
             'filled_notional': str(self.filled_notional),

--- a/services/torghut/scripts/local_intraday_tsmom_replay.py
+++ b/services/torghut/scripts/local_intraday_tsmom_replay.py
@@ -82,6 +82,7 @@ class ReplayConfig:
     symbols: tuple[str, ...] = ()
     progress_log_interval_seconds: int = DEFAULT_PROGRESS_LOG_INTERVAL_SECONDS
     capture_traces: bool = False
+    capture_trace_funnel: bool = False
     max_executable_spread_bps: Decimal = DEFAULT_MAX_EXECUTABLE_SPREAD_BPS
     max_quote_mid_jump_bps: Decimal = DEFAULT_MAX_QUOTE_MID_JUMP_BPS
     max_jump_with_wide_spread_bps: Decimal = DEFAULT_MAX_JUMP_WITH_WIDE_SPREAD_BPS
@@ -203,6 +204,11 @@ def _parse_args() -> argparse.Namespace:
         '--collect-traces',
         action='store_true',
         help='Capture per-strategy runtime traces and emit them in payload trace output.',
+    )
+    parser.add_argument(
+        '--collect-trace-funnel',
+        action='store_true',
+        help='Capture aggregate runtime gate funnel diagnostics without emitting per-row trace records.',
     )
     parser.add_argument('--no-flatten-eod', action='store_true')
     parser.add_argument('--json', action='store_true')
@@ -805,6 +811,9 @@ def _init_funnel_stats() -> dict[str, Any]:
         'quote_valid_rows': 0,
         'strategy_evaluations': 0,
         'gate_pass_counts': defaultdict(int),
+        'first_failed_gate_counts': defaultdict(int),
+        'failing_threshold_counts': defaultdict(int),
+        'passed_trace_count': 0,
         'decision_count': 0,
         'filled_count': 0,
         'filled_notional': Decimal('0'),
@@ -834,11 +843,23 @@ def _record_trace_for_funnel(
     trace: StrategyTrace,
 ) -> None:
     stats['strategy_evaluations'] += 1
+    if trace.passed:
+        stats['passed_trace_count'] += 1
     for gate in trace.gates:
         if not gate.passed:
             break
         gate_key = f'{trace.strategy_type}:{gate.gate}'
         stats['gate_pass_counts'][gate_key] += 1
+    if trace.first_failed_gate is None:
+        return
+    failed_gate_key = f'{trace.strategy_type}:{trace.first_failed_gate}'
+    stats['first_failed_gate_counts'][failed_gate_key] += 1
+    failed_gate = trace.failed_gate()
+    if failed_gate is None:
+        return
+    for threshold in failed_gate.failing_thresholds():
+        threshold_key = f'{trace.strategy_type}:{failed_gate.gate}:{threshold.metric}'
+        stats['failing_threshold_counts'][threshold_key] += 1
 
 
 def _build_near_miss(trace: StrategyTrace, *, trading_day: str) -> NearMissRecord | None:
@@ -1352,7 +1373,8 @@ def _apply_filled_decision(
 def run_replay(config: ReplayConfig) -> dict[str, Any]:
     strategies = _load_strategies(config.strategy_configmap_path)
     strategies_by_id = {str(strategy.id): strategy for strategy in strategies}
-    engine = DecisionEngine(price_fetcher=None, runtime_trace_enabled=config.capture_traces)
+    capture_runtime_traces = config.capture_traces or config.capture_trace_funnel
+    engine = DecisionEngine(price_fetcher=None, runtime_trace_enabled=capture_runtime_traces)
     quote_quality = SignalQuoteQualityTracker(
         policy=QuoteQualityPolicy(
             max_executable_spread_bps=config.max_executable_spread_bps,
@@ -1507,7 +1529,7 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
             )
             telemetry = engine.consume_runtime_telemetry()
             symbol_bucket['runtime_evaluable_rows'] += 1
-            telemetry_traces = telemetry.traces if config.capture_traces else ()
+            telemetry_traces = telemetry.traces if capture_runtime_traces else ()
             for trace in telemetry_traces:
                 _record_trace_for_funnel(symbol_bucket, trace)
                 near_miss = _build_near_miss(trace, trading_day=signal_day.isoformat())
@@ -1707,6 +1729,9 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
                 quote_valid_rows=int(bucket['quote_valid_rows']),
                 strategy_evaluations=int(bucket['strategy_evaluations']),
                 gate_pass_counts=dict(bucket['gate_pass_counts']),
+                first_failed_gate_counts=dict(bucket['first_failed_gate_counts']),
+                failing_threshold_counts=dict(bucket['failing_threshold_counts']),
+                passed_trace_count=int(bucket['passed_trace_count']),
                 decision_count=int(bucket['decision_count']),
                 filled_count=int(bucket['filled_count']),
                 filled_notional=bucket['filled_notional'],
@@ -1945,6 +1970,7 @@ def main() -> None:
             or args.funnel_output is not None
             or args.near_misses_output is not None
         ),
+        capture_trace_funnel=bool(getattr(args, "collect_trace_funnel", False)),
         max_executable_spread_bps=Decimal(str(args.max_executable_spread_bps)),
         max_quote_mid_jump_bps=Decimal(str(args.max_quote_mid_jump_bps)),
         max_jump_with_wide_spread_bps=Decimal(str(args.max_jump_with_wide_spread_bps)),

--- a/services/torghut/scripts/run_strategy_factory_v2.py
+++ b/services/torghut/scripts/run_strategy_factory_v2.py
@@ -87,6 +87,11 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--expected-last-trading-day", default="")
     parser.add_argument("--allow-stale-tape", action="store_true")
     parser.add_argument("--prefetch-full-window-rows", action="store_true")
+    parser.add_argument(
+        "--collect-train-gate-diagnostics",
+        action="store_true",
+        help="Persist aggregate train-window gate diagnostics for each frontier candidate.",
+    )
     parser.add_argument("--top-n", type=int, default=5)
     parser.add_argument("--max-candidates-to-evaluate", type=int, default=0)
     parser.add_argument(
@@ -408,6 +413,9 @@ def _frontier_args(
         allow_stale_tape=bool(args.allow_stale_tape),
         family_template_dir=args.family_template_dir,
         prefetch_full_window_rows=bool(args.prefetch_full_window_rows),
+        collect_train_gate_diagnostics=bool(
+            getattr(args, "collect_train_gate_diagnostics", False)
+        ),
         top_n=int(args.top_n),
         max_candidates_to_evaluate=(
             int(max_candidates_to_evaluate)

--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -224,6 +224,18 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--expected-last-trading-day", default="")
     parser.add_argument("--allow-stale-tape", action="store_true")
     parser.add_argument("--prefetch-full-window-rows", action="store_true")
+    parser.add_argument(
+        "--collect-train-gate-diagnostics",
+        dest="collect_train_gate_diagnostics",
+        action="store_true",
+        help="Persist aggregate train-window gate diagnostics for real replay candidates.",
+    )
+    parser.add_argument(
+        "--no-collect-train-gate-diagnostics",
+        dest="collect_train_gate_diagnostics",
+        action="store_false",
+        help="Disable aggregate train-window gate diagnostics.",
+    )
     parser.add_argument("--min-active-day-ratio", default="0.90")
     parser.add_argument("--min-positive-day-ratio", default="0.60")
     parser.add_argument("--min-daily-net-pnl", default="0")
@@ -245,7 +257,10 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--no-persist-results", dest="persist_results", action="store_false"
     )
-    parser.set_defaults(persist_results=True)
+    parser.set_defaults(
+        persist_results=True,
+        collect_train_gate_diagnostics=True,
+    )
     return parser.parse_args()
 
 
@@ -2428,6 +2443,9 @@ def _run_real_replay(
         expected_last_trading_day=args.expected_last_trading_day,
         allow_stale_tape=args.allow_stale_tape,
         prefetch_full_window_rows=args.prefetch_full_window_rows,
+        collect_train_gate_diagnostics=bool(
+            getattr(args, "collect_train_gate_diagnostics", True)
+        ),
         top_n=args.top_k,
         max_candidates_to_evaluate=getattr(
             args,

--- a/services/torghut/scripts/search_consistent_profitability_frontier.py
+++ b/services/torghut/scripts/search_consistent_profitability_frontier.py
@@ -10,7 +10,7 @@ import json
 import os
 import sys
 import tempfile
-from collections import deque
+from collections import Counter, deque
 from dataclasses import dataclass
 from datetime import date
 from decimal import Decimal
@@ -230,6 +230,11 @@ def _parse_args() -> argparse.Namespace:
         '--max-train-screen-worst-day-loss',
         default='',
         help='Optional max train worst-day loss before holdout/full-window replay. Defaults to the consistency max worst-day loss.',
+    )
+    parser.add_argument(
+        '--collect-train-gate-diagnostics',
+        action='store_true',
+        help='Capture aggregate train-window gate failure diagnostics in frontier candidates.',
     )
     return parser.parse_args()
 
@@ -909,6 +914,118 @@ def _symbol_contributions_from_replay_payload(
     )
 
 
+def _top_counter_payload(counter: Counter[str], *, limit: int = 10) -> list[dict[str, Any]]:
+    return [
+        {'key': key, 'count': count}
+        for key, count in counter.most_common(max(1, limit))
+    ]
+
+
+def _counter_from_payload(value: Any) -> Counter[str]:
+    counter: Counter[str] = Counter()
+    if not isinstance(value, Mapping):
+        return counter
+    for key, raw_count in value.items():
+        try:
+            count = int(raw_count)
+        except (TypeError, ValueError):
+            continue
+        if count > 0:
+            counter[str(key)] += count
+    return counter
+
+
+def _near_miss_digest(raw_near_miss: Mapping[str, Any]) -> dict[str, Any]:
+    thresholds = raw_near_miss.get('thresholds')
+    threshold_digest: list[dict[str, Any]] = []
+    if isinstance(thresholds, list):
+        for item in thresholds[:3]:
+            if not isinstance(item, Mapping):
+                continue
+            threshold_digest.append(
+                {
+                    'metric': str(item.get('metric') or ''),
+                    'value': item.get('value'),
+                    'threshold': item.get('threshold'),
+                    'distance_to_pass': item.get('distance_to_pass'),
+                }
+            )
+    return {
+        'trading_day': raw_near_miss.get('trading_day'),
+        'symbol': raw_near_miss.get('symbol'),
+        'strategy_type': raw_near_miss.get('strategy_type'),
+        'event_ts': raw_near_miss.get('event_ts'),
+        'first_failed_gate': raw_near_miss.get('first_failed_gate'),
+        'distance_score': raw_near_miss.get('distance_score'),
+        'thresholds': threshold_digest,
+    }
+
+
+def _train_gate_diagnostics_from_replay_payload(
+    payload: Mapping[str, Any],
+) -> dict[str, Any]:
+    funnel = payload.get('funnel')
+    buckets = (
+        cast(list[Any], funnel.get('buckets'))
+        if isinstance(funnel, Mapping) and isinstance(funnel.get('buckets'), list)
+        else []
+    )
+    aggregate = {
+        'retained_rows': 0,
+        'runtime_evaluable_rows': 0,
+        'quote_valid_rows': 0,
+        'strategy_evaluations': 0,
+        'passed_trace_count': 0,
+        'decision_count': int(payload.get('decision_count') or 0),
+        'filled_count': int(payload.get('filled_count') or 0),
+    }
+    first_failed_gate_counts: Counter[str] = Counter()
+    failing_threshold_counts: Counter[str] = Counter()
+    gate_pass_counts: Counter[str] = Counter()
+    for raw_bucket in buckets:
+        if not isinstance(raw_bucket, Mapping):
+            continue
+        for key in (
+            'retained_rows',
+            'runtime_evaluable_rows',
+            'quote_valid_rows',
+            'strategy_evaluations',
+            'passed_trace_count',
+        ):
+            try:
+                aggregate[key] += int(raw_bucket.get(key) or 0)
+            except (TypeError, ValueError):
+                continue
+        first_failed_gate_counts.update(
+            _counter_from_payload(raw_bucket.get('first_failed_gate_counts'))
+        )
+        failing_threshold_counts.update(
+            _counter_from_payload(raw_bucket.get('failing_threshold_counts'))
+        )
+        gate_pass_counts.update(_counter_from_payload(raw_bucket.get('gate_pass_counts')))
+
+    near_misses = payload.get('near_misses')
+    near_miss_digest = [
+        _near_miss_digest(item)
+        for item in (near_misses if isinstance(near_misses, list) else [])[:20]
+        if isinstance(item, Mapping)
+    ]
+    status = (
+        'available'
+        if aggregate['strategy_evaluations'] > 0
+        else 'no_runtime_trace_evaluations'
+    )
+    return {
+        'schema_version': 'torghut.frontier-train-gate-diagnostics.v1',
+        'status': status,
+        'aggregate': aggregate,
+        'top_first_failed_gates': _top_counter_payload(first_failed_gate_counts),
+        'top_failing_thresholds': _top_counter_payload(failing_threshold_counts),
+        'top_gate_pass_counts': _top_counter_payload(gate_pass_counts),
+        'near_misses': near_miss_digest,
+    }
+
+
 def _generate_symbol_prune_children(
     *,
     cli_symbols: tuple[str, ...],
@@ -1214,6 +1331,9 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
         template_defaults=family_template.default_hard_vetoes,
         trading_day_count=len(window.train_days) + len(window.holdout_days),
     )
+    collect_train_gate_diagnostics = bool(
+        getattr(args, 'collect_train_gate_diagnostics', False)
+    )
 
     symbols = tuple(
         symbol.strip().upper()
@@ -1311,6 +1431,7 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
                         chunk_minutes=max(1, int(args.chunk_minutes)),
                         symbols=candidate_symbols,
                         progress_log_interval_seconds=max(1, int(args.progress_log_seconds)),
+                        capture_trace_funnel=collect_train_gate_diagnostics,
                     )
                 )
                 train_screen_failures = (
@@ -1480,6 +1601,10 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
                 candidate_payload['normalization_regime'] = normalization_regime
                 candidate_payload['objective_scorecard'] = objective_scorecard.to_payload()
                 candidate_payload['hard_vetoes'] = sorted(dict.fromkeys(hard_vetoes))
+                if collect_train_gate_diagnostics:
+                    candidate_payload['train_gate_diagnostics'] = (
+                        _train_gate_diagnostics_from_replay_payload(train_payload)
+                    )
                 if cached_rows is not None:
                     candidate_payload['prefetched_row_count'] = len(cached_rows)
                     candidate_payload['prefetched_symbols'] = list(prefetch_symbols)

--- a/services/torghut/scripts/search_profitability_frontier.py
+++ b/services/torghut/scripts/search_profitability_frontier.py
@@ -247,6 +247,7 @@ def _build_replay_config(
     chunk_minutes: int,
     symbols: tuple[str, ...],
     progress_log_interval_seconds: int,
+    capture_trace_funnel: bool = False,
 ) -> ReplayConfig:
     return ReplayConfig(
         strategy_configmap_path=strategy_configmap_path,
@@ -260,6 +261,7 @@ def _build_replay_config(
         start_equity=start_equity,
         symbols=symbols,
         progress_log_interval_seconds=progress_log_interval_seconds,
+        capture_trace_funnel=capture_trace_funnel,
     )
 
 

--- a/services/torghut/tests/test_evaluation_trace.py
+++ b/services/torghut/tests/test_evaluation_trace.py
@@ -131,6 +131,9 @@ class TestEvaluationTrace(TestCase):
             quote_valid_rows=9,
             strategy_evaluations=5,
             gate_pass_counts={'b:confirmation': 2, 'a:eligibility': 4},
+            first_failed_gate_counts={'b:feed_quality': 3},
+            failing_threshold_counts={'b:feed_quality:spread_bps': 3},
+            passed_trace_count=2,
             decision_count=2,
             filled_count=1,
             filled_notional=Decimal('451.25'),
@@ -150,6 +153,11 @@ class TestEvaluationTrace(TestCase):
             report_payload['buckets'][0]['gate_pass_counts'],
             {'a:eligibility': 4, 'b:confirmation': 2},
         )
+        self.assertEqual(
+            report_payload['buckets'][0]['first_failed_gate_counts'],
+            {'b:feed_quality': 3},
+        )
+        self.assertEqual(report_payload['buckets'][0]['passed_trace_count'], 2)
 
         near_miss = NearMissRecord(
             trading_day='2026-03-27',

--- a/services/torghut/tests/test_local_intraday_tsmom_replay.py
+++ b/services/torghut/tests/test_local_intraday_tsmom_replay.py
@@ -909,8 +909,51 @@ class TestLocalIntradayTsmomReplay(TestCase):
 
         self.assertEqual(funnel["strategy_evaluations"], 1)
         self.assertEqual(
+            dict(funnel["first_failed_gate_counts"]),
+            {"breakout_continuation_long:feed_quality": 1},
+        )
+        self.assertEqual(
+            dict(funnel["failing_threshold_counts"]),
+            {"breakout_continuation_long:feed_quality:recent_quote_invalid_ratio": 1},
+        )
+        self.assertEqual(funnel["passed_trace_count"], 0)
+        self.assertEqual(
             dict(funnel["gate_pass_counts"]),
             {"breakout_continuation_long:structure": 1},
+        )
+
+    def test_record_trace_for_funnel_handles_missing_failed_gate(self) -> None:
+        funnel = _init_funnel_stats()
+        trace = StrategyTrace(
+            strategy_id="short@prod",
+            strategy_type="mean_reversion_short",
+            symbol="META",
+            event_ts="2026-03-27T17:30:24+00:00",
+            timeframe="1Sec",
+            passed=False,
+            action=None,
+            first_failed_gate="confirmation",
+            gates=(
+                GateTrace(
+                    gate="structure",
+                    category="structure",
+                    passed=True,
+                    thresholds=(),
+                ),
+            ),
+        )
+
+        _record_trace_for_funnel(funnel, trace)
+
+        self.assertEqual(funnel["strategy_evaluations"], 1)
+        self.assertEqual(
+            dict(funnel["first_failed_gate_counts"]),
+            {"mean_reversion_short:confirmation": 1},
+        )
+        self.assertEqual(dict(funnel["failing_threshold_counts"]), {})
+        self.assertEqual(
+            dict(funnel["gate_pass_counts"]),
+            {"mean_reversion_short:structure": 1},
         )
 
     def test_build_near_miss_uses_failed_gate_thresholds(self) -> None:

--- a/services/torghut/tests/test_search_consistent_profitability_frontier.py
+++ b/services/torghut/tests/test_search_consistent_profitability_frontier.py
@@ -53,6 +53,7 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
                     '0.25',
                     '--max-train-screen-worst-day-loss',
                     '125',
+                    '--collect-train-gate-diagnostics',
                 ],
             ):
                 args = frontier._parse_args()
@@ -66,6 +67,7 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
         self.assertEqual(args.min_train_screen_net_per_day, '-50')
         self.assertEqual(args.min_train_screen_active_ratio, '0.25')
         self.assertEqual(args.max_train_screen_worst_day_loss, '125')
+        self.assertTrue(args.collect_train_gate_diagnostics)
 
     def test_clickhouse_password_env_resolution_keeps_secret_out_of_argv(self) -> None:
         with patch.dict('os.environ', {'TORGHUT_CLICKHOUSE_PASSWORD': 'from-env'}):
@@ -481,6 +483,134 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
         self.assertEqual(contributions['AVGO']['downside_pnl'], '120')
         self.assertEqual(contributions['MSFT']['contribution_score'], '220')
 
+    def test_train_gate_diagnostics_from_replay_payload_summarizes_funnel(self) -> None:
+        payload = {
+            'decision_count': 0,
+            'filled_count': 0,
+            'funnel': {
+                'buckets': [
+                    {
+                        'retained_rows': 10,
+                        'runtime_evaluable_rows': 8,
+                        'quote_valid_rows': 9,
+                        'strategy_evaluations': 8,
+                        'passed_trace_count': 1,
+                        'gate_pass_counts': {'short:eligibility': 8},
+                        'first_failed_gate_counts': {'short:confirmation': 5},
+                        'failing_threshold_counts': {
+                            'short:confirmation:imbalance_pressure': 5,
+                        },
+                    },
+                    {
+                        'retained_rows': 4,
+                        'runtime_evaluable_rows': 3,
+                        'quote_valid_rows': 3,
+                        'strategy_evaluations': 3,
+                        'passed_trace_count': 0,
+                        'first_failed_gate_counts': {'short:structure': 3},
+                        'failing_threshold_counts': {'short:structure:rsi14': 3},
+                    },
+                ]
+            },
+            'near_misses': [
+                {
+                    'trading_day': '2026-05-01',
+                    'symbol': 'AAPL',
+                    'strategy_type': 'short',
+                    'event_ts': '2026-05-01T15:00:00+00:00',
+                    'first_failed_gate': 'confirmation',
+                    'distance_score': '0.02',
+                    'thresholds': [
+                        {
+                            'metric': 'imbalance_pressure',
+                            'value': '0.01',
+                            'threshold': '0.00',
+                            'distance_to_pass': '0.01',
+                        }
+                    ],
+                }
+            ],
+        }
+
+        diagnostics = frontier._train_gate_diagnostics_from_replay_payload(payload)
+
+        self.assertEqual(diagnostics['status'], 'available')
+        self.assertEqual(diagnostics['aggregate']['strategy_evaluations'], 11)
+        self.assertEqual(
+            diagnostics['top_first_failed_gates'][0],
+            {'key': 'short:confirmation', 'count': 5},
+        )
+        self.assertEqual(
+            diagnostics['top_failing_thresholds'][0],
+            {'key': 'short:confirmation:imbalance_pressure', 'count': 5},
+        )
+        self.assertEqual(
+            diagnostics['near_misses'][0]['thresholds'][0]['metric'],
+            'imbalance_pressure',
+        )
+
+    def test_train_gate_diagnostics_from_replay_payload_ignores_malformed_items(self) -> None:
+        payload = {
+            'decision_count': 1,
+            'filled_count': 0,
+            'funnel': {
+                'buckets': [
+                    'not-a-bucket',
+                    {
+                        'retained_rows': 'bad-count',
+                        'runtime_evaluable_rows': '2',
+                        'quote_valid_rows': '2',
+                        'strategy_evaluations': '2',
+                        'passed_trace_count': '0',
+                        'gate_pass_counts': {'short:structure': '2'},
+                        'first_failed_gate_counts': {
+                            'short:confirmation': 'bad-count',
+                            'short:structure': '1',
+                        },
+                    },
+                ]
+            },
+            'near_misses': [
+                {
+                    'trading_day': '2026-05-01',
+                    'symbol': 'AAPL',
+                    'strategy_type': 'short',
+                    'event_ts': '2026-05-01T15:00:00+00:00',
+                    'first_failed_gate': 'confirmation',
+                    'distance_score': '0.02',
+                    'thresholds': [
+                        'not-a-threshold',
+                        {
+                            'metric': 'rsi14',
+                            'value': '72',
+                            'threshold': '70',
+                            'distance_to_pass': '2',
+                        },
+                    ],
+                }
+            ],
+        }
+
+        diagnostics = frontier._train_gate_diagnostics_from_replay_payload(payload)
+
+        self.assertEqual(diagnostics['aggregate']['retained_rows'], 0)
+        self.assertEqual(diagnostics['aggregate']['runtime_evaluable_rows'], 2)
+        self.assertEqual(
+            diagnostics['top_first_failed_gates'],
+            [{'key': 'short:structure', 'count': 1}],
+        )
+        self.assertEqual(
+            diagnostics['near_misses'][0]['thresholds'],
+            [
+                {
+                    'metric': 'rsi14',
+                    'value': '72',
+                    'threshold': '70',
+                    'distance_to_pass': '2',
+                }
+            ],
+        )
+
     def test_generate_symbol_prune_children_removes_worst_symbols_from_universe(self) -> None:
         children = frontier._generate_symbol_prune_children(
             cli_symbols=(),
@@ -736,6 +866,7 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
                 json_output=json_output,
             )
             args.min_train_screen_net_per_day = '1'
+            args.collect_train_gate_diagnostics = True
             recent_days = tuple(date(2026, 3, 18) + timedelta(days=index) for index in range(6))
             snapshot_receipt = SimpleNamespace(
                 snapshot_id='snap-partial',
@@ -809,7 +940,7 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
                             '2026-03-23': '110',
                         }
                     )
-                return self._payload(
+                replay_payload = self._payload(
                     start_date=start_date,
                     end_date=end_date,
                     daily_net=daily_net,
@@ -818,6 +949,17 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
                     wins=3,
                     losses=0,
                 )
+                if getattr(config, 'capture_trace_funnel', False):
+                    replay_payload['funnel'] = {
+                        'buckets': [
+                            {
+                                'strategy_evaluations': 2,
+                                'passed_trace_count': 0,
+                                'first_failed_gate_counts': {'breakout:confirmation': 2},
+                            }
+                        ]
+                    }
+                return replay_payload
 
             with (
                 patch('scripts.search_consistent_profitability_frontier._resolve_recent_trading_days', return_value=recent_days),
@@ -829,6 +971,7 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
 
             self.assertEqual(payload['status'], 'completed')
             self.assertEqual(payload['candidate_count'], 2)
+            self.assertEqual(payload['top'][0]['train_gate_diagnostics']['status'], 'available')
             persisted = json.loads(json_output.read_text(encoding='utf-8'))
             self.assertEqual(persisted['status'], 'completed')
             self.assertEqual(persisted['candidate_count'], 2)


### PR DESCRIPTION
## Summary

- Adds lightweight replay trace-funnel diagnostics for first-failed gates and failing thresholds without storing per-row trace records.
- Persists train-window gate diagnostics on strict consistent-profit frontier candidates when enabled.
- Wires whitepaper autoresearch and strategy-factory real replay to collect these diagnostics by default for the strict profit loop.

## Related Issues

None

## Testing

- `uv run --frozen ruff check app/trading/evaluation_trace.py scripts/local_intraday_tsmom_replay.py scripts/search_profitability_frontier.py scripts/search_consistent_profitability_frontier.py scripts/run_strategy_factory_v2.py scripts/run_whitepaper_autoresearch_profit_target.py tests/test_evaluation_trace.py tests/test_local_intraday_tsmom_replay.py tests/test_search_consistent_profitability_frontier.py`
- `uv run --frozen pytest tests/test_evaluation_trace.py tests/test_search_consistent_profitability_frontier.py tests/test_search_profitability_frontier.py tests/test_run_strategy_factory_v2.py tests/test_local_intraday_tsmom_replay.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
