### PR TITLE
chore(jangar): promote image 7faccace

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 4bb49794
-  digest: sha256:fd072169144f17ce47a20664f2cf2fc522d8b92c3b10ef50c6acd4c2845802f9
+  tag: 7faccace
+  digest: sha256:fa7bf7b62516e3384f5a39015a05c94d48bdf959343601b20f3c946c19adbbdb
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,8 +11,8 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 4bb49794
-    digest: sha256:8a75d6a3cca9d2be0c75939f3772bab3c4ca52ed02dc19113dec124d9397738d
+    tag: 7faccace
+    digest: sha256:799ced3e91261bd87f03953eb0314793a4f69bdd4cac2d03e45d9243dec1c177
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
@@ -21,8 +21,8 @@ controlPlane:
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 4bb49794
-    digest: sha256:fd072169144f17ce47a20664f2cf2fc522d8b92c3b10ef50c6acd4c2845802f9
+    tag: 7faccace
+    digest: sha256:fa7bf7b62516e3384f5a39015a05c94d48bdf959343601b20f3c946c19adbbdb
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-13T21:04:23Z
+    deploy.knative.dev/rollout: 2026-05-13T22:03:41Z
 spec:
   replicas: 1
   strategy:
@@ -57,11 +57,11 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_RUNTIME_IMAGE
-              value: registry.ide-newton.ts.net/lab/jangar:4bb49794@sha256:fd072169144f17ce47a20664f2cf2fc522d8b92c3b10ef50c6acd4c2845802f9
+              value: registry.ide-newton.ts.net/lab/jangar:7faccace@sha256:fa7bf7b62516e3384f5a39015a05c94d48bdf959343601b20f3c946c19adbbdb
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: 4bb497943e2b9249eac57d82e64b491bd58631ae
+              value: 7faccaceda2fa7af21849678b6688baf5e4c30fe
             - name: JANGAR_GITOPS_REVISION
-              value: 4bb497943e2b9249eac57d82e64b491bd58631ae
+              value: 7faccaceda2fa7af21849678b6688baf5e4c30fe
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_BUMBA_TASK_QUEUE

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -59,5 +59,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: 4bb49794
-    digest: sha256:fd072169144f17ce47a20664f2cf2fc522d8b92c3b10ef50c6acd4c2845802f9
+    newTag: 7faccace
+    digest: sha256:fa7bf7b62516e3384f5a39015a05c94d48bdf959343601b20f3c946c19adbbdb


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `7faccaceda2fa7af21849678b6688baf5e4c30fe`
- Image tag: `7faccace`
- Image digest: `sha256:fa7bf7b62516e3384f5a39015a05c94d48bdf959343601b20f3c946c19adbbdb`
- Updated API rollout annotation
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`