### PR TITLE
feat(torghut): gate autoresearch replay capital realism

### DIFF
--- a/services/torghut/app/trading/discovery/autoresearch.py
+++ b/services/torghut/app/trading/discovery/autoresearch.py
@@ -120,6 +120,8 @@ class StrategyObjective:
     min_regime_slice_pass_rate: Decimal
     stop_when_objective_met: bool
     min_daily_net_pnl: Decimal = Decimal('0')
+    max_gross_exposure_pct_equity: Decimal = Decimal('999999999')
+    min_cash: Decimal = Decimal('-999999999')
 
     def to_payload(self) -> dict[str, Any]:
         return {
@@ -134,6 +136,8 @@ class StrategyObjective:
             'require_every_day_active': self.require_every_day_active,
             'min_regime_slice_pass_rate': str(self.min_regime_slice_pass_rate),
             'stop_when_objective_met': self.stop_when_objective_met,
+            'max_gross_exposure_pct_equity': str(self.max_gross_exposure_pct_equity),
+            'min_cash': str(self.min_cash),
         }
 
 
@@ -459,6 +463,14 @@ def load_strategy_autoresearch_program(
             default='0.35',
         ),
         stop_when_objective_met=bool(objective_payload.get('stop_when_objective_met', False)),
+        max_gross_exposure_pct_equity=_coerce_decimal(
+            objective_payload.get('max_gross_exposure_pct_equity'),
+            default='999999999',
+        ),
+        min_cash=_coerce_decimal(
+            objective_payload.get('min_cash'),
+            default='-999999999',
+        ),
     )
     snapshot_policy_payload = _mapping(payload.get('snapshot_policy'))
     snapshot_policy = SnapshotPolicy(
@@ -648,6 +660,8 @@ def apply_program_objective(
         )
     consistency['require_every_day_active'] = bool(objective.require_every_day_active)
     consistency['min_regime_slice_pass_rate'] = str(objective.min_regime_slice_pass_rate)
+    consistency['max_gross_exposure_pct_equity'] = str(objective.max_gross_exposure_pct_equity)
+    consistency['min_cash'] = str(objective.min_cash)
     payload['constraints'] = constraints
     payload['consistency_constraints'] = consistency
     return payload
@@ -801,6 +815,11 @@ def candidate_meets_objective(
     worst_day_loss = _coerce_decimal(scorecard.get('worst_day_loss'), default='999999999')
     max_drawdown = _coerce_decimal(scorecard.get('max_drawdown'), default='999999999')
     regime_slice_pass_rate = _coerce_decimal(scorecard.get('regime_slice_pass_rate'), default='0')
+    max_gross_exposure_pct_equity = _coerce_decimal(
+        scorecard.get('max_gross_exposure_pct_equity') or full_window.get('max_gross_exposure_pct_equity'),
+        default='0',
+    )
+    min_cash = _coerce_decimal(scorecard.get('min_cash') or full_window.get('min_cash'), default='0')
     trading_day_count = int(full_window.get('trading_day_count') or 0)
     active_days = int(full_window.get('active_days') or 0)
     if objective.require_every_day_active and trading_day_count > 0 and active_days != trading_day_count:
@@ -826,6 +845,8 @@ def candidate_meets_objective(
             worst_day_loss <= objective.max_worst_day_loss,
             max_drawdown <= objective.max_drawdown,
             regime_slice_pass_rate >= objective.min_regime_slice_pass_rate,
+            max_gross_exposure_pct_equity <= objective.max_gross_exposure_pct_equity,
+            min_cash >= objective.min_cash,
         )
     )
 

--- a/services/torghut/app/trading/discovery/objectives.py
+++ b/services/torghut/app/trading/discovery/objectives.py
@@ -15,6 +15,8 @@ class ObjectiveVetoPolicy:
     required_max_worst_day_loss: Decimal = Decimal('999999999')
     required_max_drawdown: Decimal = Decimal('999999999')
     required_min_regime_slice_pass_rate: Decimal = Decimal('0')
+    required_max_gross_exposure_pct_equity: Decimal = Decimal('999999999')
+    required_min_cash: Decimal = Decimal('-999999999')
 
     def to_payload(self) -> dict[str, str]:
         return {
@@ -24,6 +26,8 @@ class ObjectiveVetoPolicy:
             'required_max_worst_day_loss': str(self.required_max_worst_day_loss),
             'required_max_drawdown': str(self.required_max_drawdown),
             'required_min_regime_slice_pass_rate': str(self.required_min_regime_slice_pass_rate),
+            'required_max_gross_exposure_pct_equity': str(self.required_max_gross_exposure_pct_equity),
+            'required_min_cash': str(self.required_min_cash),
         }
 
 
@@ -44,6 +48,9 @@ class CandidateObjectiveScorecard:
     regime_slice_pass_rate: Decimal
     symbol_concentration_share: Decimal
     entry_family_contribution_share: Decimal
+    max_gross_exposure_pct_equity: Decimal = Decimal('0')
+    min_cash: Decimal = Decimal('0')
+    negative_cash_observation_count: int = 0
     veto_reasons: tuple[str, ...] = ()
     pareto_tier: int | None = None
     tie_breaker_score: Decimal | None = None
@@ -79,6 +86,9 @@ class CandidateObjectiveScorecard:
             'regime_slice_pass_rate': str(self.regime_slice_pass_rate),
             'symbol_concentration_share': str(self.symbol_concentration_share),
             'entry_family_contribution_share': str(self.entry_family_contribution_share),
+            'max_gross_exposure_pct_equity': str(self.max_gross_exposure_pct_equity),
+            'min_cash': str(self.min_cash),
+            'negative_cash_observation_count': self.negative_cash_observation_count,
             'veto_reasons': list(self.veto_reasons),
             'pareto_tier': self.pareto_tier,
             'tie_breaker_score': str(self.tie_breaker_score) if self.tie_breaker_score is not None else None,
@@ -103,6 +113,9 @@ def build_scorecard(
     regime_slice_pass_rate: Decimal,
     symbol_concentration_share: Decimal,
     entry_family_contribution_share: Decimal,
+    max_gross_exposure_pct_equity: Decimal = Decimal('0'),
+    min_cash: Decimal = Decimal('0'),
+    negative_cash_observation_count: int = 0,
 ) -> CandidateObjectiveScorecard:
     day_count = max(trading_day_count, 1)
     return CandidateObjectiveScorecard(
@@ -121,6 +134,9 @@ def build_scorecard(
         regime_slice_pass_rate=regime_slice_pass_rate,
         symbol_concentration_share=symbol_concentration_share,
         entry_family_contribution_share=entry_family_contribution_share,
+        max_gross_exposure_pct_equity=max_gross_exposure_pct_equity,
+        min_cash=min_cash,
+        negative_cash_observation_count=negative_cash_observation_count,
     )
 
 
@@ -143,6 +159,10 @@ def evaluate_vetoes(
         reasons.append('max_drawdown_above_max')
     if scorecard.regime_slice_pass_rate < policy.required_min_regime_slice_pass_rate:
         reasons.append('regime_slice_pass_rate_below_min')
+    if scorecard.max_gross_exposure_pct_equity > policy.required_max_gross_exposure_pct_equity:
+        reasons.append('gross_exposure_pct_equity_above_max')
+    if scorecard.min_cash < policy.required_min_cash:
+        reasons.append('min_cash_below_min')
     if not is_fresh:
         reasons.append('stale_tape')
     return tuple(reasons)
@@ -158,6 +178,7 @@ def _maximize_metrics(scorecard: CandidateObjectiveScorecard) -> tuple[Decimal, 
         scorecard.rolling_3d_lower_bound,
         scorecard.rolling_5d_lower_bound,
         scorecard.regime_slice_pass_rate,
+        scorecard.min_cash,
     )
 
 
@@ -169,6 +190,8 @@ def _minimize_metrics(scorecard: CandidateObjectiveScorecard) -> tuple[Decimal, 
         Decimal(scorecard.negative_day_count),
         scorecard.symbol_concentration_share,
         scorecard.entry_family_contribution_share,
+        scorecard.max_gross_exposure_pct_equity,
+        Decimal(scorecard.negative_cash_observation_count),
     )
 
 
@@ -199,12 +222,15 @@ def tie_breaker(scorecard: CandidateObjectiveScorecard) -> Decimal:
         + (scorecard.regime_slice_pass_rate * Decimal('100'))
         + scorecard.rolling_3d_lower_bound
         + scorecard.rolling_5d_lower_bound
+        + (scorecard.min_cash / Decimal('10000'))
         - (scorecard.worst_day_loss * Decimal('0.5'))
         - (scorecard.max_drawdown * Decimal('0.1'))
         - (scorecard.best_day_share * Decimal('500'))
         - (scorecard.symbol_concentration_share * Decimal('100'))
         - (scorecard.entry_family_contribution_share * Decimal('25'))
+        - (scorecard.max_gross_exposure_pct_equity * Decimal('50'))
         - (Decimal(scorecard.negative_day_count) * Decimal('20'))
+        - (Decimal(scorecard.negative_cash_observation_count) * Decimal('5'))
     )
 
 

--- a/services/torghut/config/trading/research-programs/strict-daily-profit-autoresearch-500-v1.yaml
+++ b/services/torghut/config/trading/research-programs/strict-daily-profit-autoresearch-500-v1.yaml
@@ -53,6 +53,8 @@ objective:
   max_drawdown: '900'
   require_every_day_active: true
   min_regime_slice_pass_rate: '0.45'
+  max_gross_exposure_pct_equity: '1.0'
+  min_cash: '0'
   stop_when_objective_met: true
 research_sources:
   - source_id: tradefm_market_microstructure_2026

--- a/services/torghut/scripts/local_intraday_tsmom_replay.py
+++ b/services/torghut/scripts/local_intraday_tsmom_replay.py
@@ -633,6 +633,20 @@ def _position_equity(
     return equity
 
 
+def _position_exposure(
+    *,
+    positions: dict[tuple[str, str], PositionState],
+    last_prices: dict[str, Decimal],
+) -> tuple[Decimal, Decimal]:
+    gross_exposure = Decimal('0')
+    net_exposure = Decimal('0')
+    for (symbol, _owner_strategy_id), position in positions.items():
+        market_value = position.qty * last_prices.get(symbol, position.avg_entry_price)
+        gross_exposure += abs(market_value)
+        net_exposure += market_value
+    return gross_exposure, net_exposure
+
+
 def _extract_spread(signal: SignalEnvelope) -> Decimal | None:
     raw = signal.payload.get('spread')
     if isinstance(raw, Decimal):
@@ -801,6 +815,13 @@ def _init_day_stats() -> dict[str, Any]:
         'wins': 0,
         'losses': 0,
         'closed_trades': [],
+        'capital_snapshot_count': 0,
+        'min_cash': None,
+        'min_equity': None,
+        'max_gross_exposure': Decimal('0'),
+        'max_net_exposure_abs': Decimal('0'),
+        'max_gross_exposure_pct_equity': Decimal('0'),
+        'negative_cash_observation_count': 0,
     }
 
 
@@ -835,7 +856,51 @@ def _ensure_replay_stats_bucket(bucket: dict[str, Any]) -> dict[str, Any]:
     bucket.setdefault('losses', 0)
     bucket.setdefault('closed_trades', [])
     bucket.setdefault('closed_trade_count', 0)
+    bucket.setdefault('capital_snapshot_count', 0)
+    bucket.setdefault('min_cash', None)
+    bucket.setdefault('min_equity', None)
+    bucket.setdefault('max_gross_exposure', Decimal('0'))
+    bucket.setdefault('max_net_exposure_abs', Decimal('0'))
+    bucket.setdefault('max_gross_exposure_pct_equity', Decimal('0'))
+    bucket.setdefault('negative_cash_observation_count', 0)
     return bucket
+
+
+def _record_capital_snapshot(
+    *,
+    bucket: dict[str, Any],
+    cash: Decimal,
+    positions: dict[tuple[str, str], PositionState],
+    last_prices: dict[str, Decimal],
+) -> Decimal:
+    bucket = _ensure_replay_stats_bucket(bucket)
+    equity = _position_equity(cash=cash, positions=positions, last_prices=last_prices)
+    gross_exposure, net_exposure = _position_exposure(
+        positions=positions,
+        last_prices=last_prices,
+    )
+    gross_exposure_pct_equity = (
+        gross_exposure / equity
+        if equity > 0
+        else Decimal('999999999') if gross_exposure > 0 else Decimal('0')
+    )
+    min_cash = bucket.get('min_cash')
+    if not isinstance(min_cash, Decimal) or cash < min_cash:
+        bucket['min_cash'] = cash
+    min_equity = bucket.get('min_equity')
+    if not isinstance(min_equity, Decimal) or equity < min_equity:
+        bucket['min_equity'] = equity
+    if gross_exposure > bucket['max_gross_exposure']:
+        bucket['max_gross_exposure'] = gross_exposure
+    net_exposure_abs = abs(net_exposure)
+    if net_exposure_abs > bucket['max_net_exposure_abs']:
+        bucket['max_net_exposure_abs'] = net_exposure_abs
+    if gross_exposure_pct_equity > bucket['max_gross_exposure_pct_equity']:
+        bucket['max_gross_exposure_pct_equity'] = gross_exposure_pct_equity
+    bucket['capital_snapshot_count'] += 1
+    if cash < 0:
+        bucket['negative_cash_observation_count'] += 1
+    return equity
 
 
 def _record_trace_for_funnel(
@@ -1432,6 +1497,12 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
             if current_day is None:
                 current_day = signal_day
                 logger.info('replay_day_start day=%s', current_day.isoformat())
+                _record_capital_snapshot(
+                    bucket=_active_day_stats(current_day),
+                    cash=cash,
+                    positions=positions,
+                    last_prices=last_prices,
+                )
             if current_day != signal_day:
                 if config.flatten_eod:
                     cash_ref = [cash]
@@ -1449,7 +1520,8 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
                     cash = cash_ref[0]
                 pending_orders.clear()
                 completed_day_stats = _active_day_stats(current_day)
-                completed_day_equity = _position_equity(
+                completed_day_equity = _record_capital_snapshot(
+                    bucket=completed_day_stats,
                     cash=cash,
                     positions=positions,
                     last_prices=last_prices,
@@ -1463,6 +1535,12 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
                 )
                 current_day = signal_day
                 logger.info('replay_day_start day=%s', current_day.isoformat())
+                _record_capital_snapshot(
+                    bucket=_active_day_stats(current_day),
+                    cash=cash,
+                    positions=positions,
+                    last_prices=last_prices,
+                )
 
             signals_seen += 1
             day_bucket = _active_day_stats(signal_day)
@@ -1486,6 +1564,12 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
             symbol_bucket['quote_valid_rows'] += 1
             last_prices[signal.symbol] = price
             last_signals[signal.symbol] = signal
+            equity = _record_capital_snapshot(
+                bucket=day_bucket,
+                cash=cash,
+                positions=positions,
+                last_prices=last_prices,
+            )
 
             matching_pending_keys = [
                 pending_key
@@ -1514,8 +1598,19 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
                     cash=cash,
                     all_closed_trades=all_closed_trades,
                 )
+                equity = _record_capital_snapshot(
+                    bucket=day_bucket,
+                    cash=cash,
+                    positions=positions,
+                    last_prices=last_prices,
+                )
 
-            equity = _position_equity(cash=cash, positions=positions, last_prices=last_prices)
+            equity = _record_capital_snapshot(
+                bucket=day_bucket,
+                cash=cash,
+                positions=positions,
+                last_prices=last_prices,
+            )
             live_positions = _positions_payload(
                 positions,
                 last_prices,
@@ -1623,6 +1718,12 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
                         cash=cash,
                         all_closed_trades=all_closed_trades,
                     )
+                    equity = _record_capital_snapshot(
+                        bucket=day_bucket,
+                        cash=cash,
+                        positions=positions,
+                        last_prices=last_prices,
+                    )
                     fill_status_by_strategy_id[decision.strategy_id] = 'filled'
                     continue
                 pending_key = _position_key(
@@ -1669,6 +1770,12 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
                         )
                     )
 
+            equity = _record_capital_snapshot(
+                bucket=day_bucket,
+                cash=cash,
+                positions=positions,
+                last_prices=last_prices,
+            )
             now = time_mod.monotonic()
             if now - last_progress_at >= config.progress_log_interval_seconds:
                 _log_progress(
@@ -1699,7 +1806,12 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
             cash = cash_ref[0]
         if current_day is not None:
             final_day_stats = _active_day_stats(current_day)
-            final_day_equity = _position_equity(cash=cash, positions=positions, last_prices=last_prices)
+            final_day_equity = _record_capital_snapshot(
+                bucket=final_day_stats,
+                cash=cash,
+                positions=positions,
+                last_prices=last_prices,
+            )
             _log_day_summary(
                 day=current_day,
                 stats=final_day_stats,
@@ -1717,6 +1829,56 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
     total_cost = sum((item['cost_total'] for item in day_stats.values()), Decimal('0'))
     wins = sum(item['wins'] for item in day_stats.values())
     losses = sum(item['losses'] for item in day_stats.values())
+    min_cash = min(
+        (
+            value
+            for item in day_stats.values()
+            for value in (item.get('min_cash'),)
+            if isinstance(value, Decimal)
+        ),
+        default=cash,
+    )
+    min_equity = min(
+        (
+            value
+            for item in day_stats.values()
+            for value in (item.get('min_equity'),)
+            if isinstance(value, Decimal)
+        ),
+        default=final_equity,
+    )
+    max_gross_exposure = max(
+        (
+            value
+            for item in day_stats.values()
+            for value in (item.get('max_gross_exposure'),)
+            if isinstance(value, Decimal)
+        ),
+        default=Decimal('0'),
+    )
+    max_net_exposure_abs = max(
+        (
+            value
+            for item in day_stats.values()
+            for value in (item.get('max_net_exposure_abs'),)
+            if isinstance(value, Decimal)
+        ),
+        default=Decimal('0'),
+    )
+    max_gross_exposure_pct_equity = max(
+        (
+            value
+            for item in day_stats.values()
+            for value in (item.get('max_gross_exposure_pct_equity'),)
+            if isinstance(value, Decimal)
+        ),
+        default=Decimal('0'),
+    )
+    capital_snapshot_count = sum(int(item.get('capital_snapshot_count') or 0) for item in day_stats.values())
+    negative_cash_observation_count = sum(
+        int(item.get('negative_cash_observation_count') or 0)
+        for item in day_stats.values()
+    )
     funnel_report = ReplayFunnelReport(
         start_date=config.start_date.isoformat(),
         end_date=config.end_date.isoformat(),
@@ -1769,6 +1931,7 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
         'start_date': config.start_date.isoformat(),
         'end_date': config.end_date.isoformat(),
         'start_equity': str(config.start_equity),
+        'final_cash': str(cash),
         'final_equity': str(final_equity),
         'net_pnl': str(total_net),
         'gross_pnl': str(total_gross),
@@ -1778,6 +1941,13 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
         'filled_notional': str(total_filled_notional),
         'wins': wins,
         'losses': losses,
+        'capital_snapshot_count': capital_snapshot_count,
+        'min_cash': str(min_cash),
+        'min_equity': str(min_equity),
+        'max_gross_exposure': str(max_gross_exposure),
+        'max_net_exposure_abs': str(max_net_exposure_abs),
+        'max_gross_exposure_pct_equity': str(max_gross_exposure_pct_equity),
+        'negative_cash_observation_count': negative_cash_observation_count,
         'open_positions': {
             f'{symbol}|{owner_strategy_id}': {
                 'strategy_id': position.strategy_id,
@@ -1797,6 +1967,17 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
                 'cost_total': str(value['cost_total']),
                 'wins': value['wins'],
                 'losses': value['losses'],
+                'capital_snapshot_count': int(value.get('capital_snapshot_count') or 0),
+                'min_cash': str(value['min_cash']) if isinstance(value.get('min_cash'), Decimal) else None,
+                'min_equity': str(value['min_equity']) if isinstance(value.get('min_equity'), Decimal) else None,
+                'max_gross_exposure': str(value.get('max_gross_exposure', Decimal('0'))),
+                'max_net_exposure_abs': str(value.get('max_net_exposure_abs', Decimal('0'))),
+                'max_gross_exposure_pct_equity': str(
+                    value.get('max_gross_exposure_pct_equity', Decimal('0'))
+                ),
+                'negative_cash_observation_count': int(
+                    value.get('negative_cash_observation_count') or 0
+                ),
             }
             for key, value in sorted(day_stats.items())
         },

--- a/services/torghut/scripts/search_consistent_profitability_frontier.py
+++ b/services/torghut/scripts/search_consistent_profitability_frontier.py
@@ -77,6 +77,8 @@ class FullWindowConsistencyPolicy:
     min_regime_slice_pass_rate: Decimal = Decimal('0')
     max_symbol_concentration_share: Decimal = Decimal('1')
     max_entry_family_contribution_share: Decimal = Decimal('1')
+    max_gross_exposure_pct_equity: Decimal = Decimal('999999999')
+    min_cash: Decimal = Decimal('-999999999')
 
     def to_payload(self) -> dict[str, Any]:
         return {
@@ -95,6 +97,8 @@ class FullWindowConsistencyPolicy:
             'min_regime_slice_pass_rate': str(self.min_regime_slice_pass_rate),
             'max_symbol_concentration_share': str(self.max_symbol_concentration_share),
             'max_entry_family_contribution_share': str(self.max_entry_family_contribution_share),
+            'max_gross_exposure_pct_equity': str(self.max_gross_exposure_pct_equity),
+            'min_cash': str(self.min_cash),
         }
 
 
@@ -285,6 +289,21 @@ def _objective_veto_policy(
         required_min_regime_slice_pass_rate=max(
             consistency_policy.min_regime_slice_pass_rate,
             Decimal(str(template_defaults.get('required_min_regime_slice_pass_rate', '0'))),
+        ),
+        required_max_gross_exposure_pct_equity=min(
+            consistency_policy.max_gross_exposure_pct_equity,
+            Decimal(
+                str(
+                    template_defaults.get(
+                        'required_max_gross_exposure_pct_equity',
+                        str(consistency_policy.max_gross_exposure_pct_equity),
+                    )
+                )
+            ),
+        ),
+        required_min_cash=max(
+            consistency_policy.min_cash,
+            Decimal(str(template_defaults.get('required_min_cash', str(consistency_policy.min_cash)))),
         ),
     )
 
@@ -676,6 +695,44 @@ def _daily_filled_notional(payload: Mapping[str, Any]) -> dict[str, Decimal]:
     return filled_notional
 
 
+def _daily_decimal_metric(payload: Mapping[str, Any], key: str) -> dict[str, Decimal]:
+    daily_payload = cast(Mapping[str, Any], payload.get('daily') or {})
+    values: dict[str, Decimal] = {}
+    for day, value in daily_payload.items():
+        if not isinstance(value, Mapping):
+            continue
+        raw_value = cast(Mapping[str, Any], value).get(key)
+        if raw_value is None:
+            continue
+        values[str(day)] = Decimal(str(raw_value))
+    return values
+
+
+def _daily_int_metric(payload: Mapping[str, Any], key: str) -> dict[str, int]:
+    daily_payload = cast(Mapping[str, Any], payload.get('daily') or {})
+    values: dict[str, int] = {}
+    for day, value in daily_payload.items():
+        if not isinstance(value, Mapping):
+            continue
+        raw_value = cast(Mapping[str, Any], value).get(key)
+        if raw_value is None:
+            continue
+        values[str(day)] = int(raw_value)
+    return values
+
+
+def _decimal_payload_metric(
+    payload: Mapping[str, Any],
+    key: str,
+    *,
+    default: Decimal,
+) -> Decimal:
+    raw_value = payload.get(key)
+    if raw_value is None:
+        return default
+    return Decimal(str(raw_value))
+
+
 def _max_best_day_share_of_total_pnl(
     *,
     daily_net: Mapping[str, Decimal],
@@ -696,6 +753,15 @@ def _consistency_penalty(
 ) -> tuple[Decimal, dict[str, Any]]:
     summary = summarize_replay_profitability(full_window_payload)
     daily_filled_notional = _daily_filled_notional(full_window_payload)
+    daily_gross_exposure_pct_equity = _daily_decimal_metric(
+        full_window_payload,
+        'max_gross_exposure_pct_equity',
+    )
+    daily_min_cash = _daily_decimal_metric(full_window_payload, 'min_cash')
+    daily_negative_cash_observations = _daily_int_metric(
+        full_window_payload,
+        'negative_cash_observation_count',
+    )
     negative_days = sum(1 for value in summary.daily_net.values() if value < 0)
     positive_days = sum(1 for value in summary.daily_net.values() if value > 0)
     drawdown = _max_drawdown_from_daily_net(summary.daily_net)
@@ -725,6 +791,28 @@ def _consistency_penalty(
     )
     if policy.min_daily_net_pnl > 0 and len(summary.daily_net) < summary.trading_day_count:
         daily_net_below_min_count += summary.trading_day_count - len(summary.daily_net)
+    max_gross_exposure_pct_equity = max(
+        (
+            _decimal_payload_metric(
+                full_window_payload,
+                'max_gross_exposure_pct_equity',
+                default=Decimal('0'),
+            ),
+            *daily_gross_exposure_pct_equity.values(),
+        ),
+        default=Decimal('0'),
+    )
+    min_cash = min(
+        (
+            _decimal_payload_metric(full_window_payload, 'min_cash', default=Decimal('0')),
+            *daily_min_cash.values(),
+        ),
+        default=Decimal('0'),
+    )
+    negative_cash_observation_count = max(
+        int(full_window_payload.get('negative_cash_observation_count') or 0),
+        sum(daily_negative_cash_observations.values()),
+    )
     penalties = Decimal('0')
 
     if summary.net_per_day < policy.target_net_per_day:
@@ -761,6 +849,12 @@ def _consistency_penalty(
         penalties += (
             policy.min_avg_filled_notional_per_active_day - avg_filled_notional_per_active_day
         ) / Decimal('1000')
+    if max_gross_exposure_pct_equity > policy.max_gross_exposure_pct_equity:
+        penalties += (
+            max_gross_exposure_pct_equity - policy.max_gross_exposure_pct_equity
+        ) * Decimal('1000')
+    if min_cash < policy.min_cash:
+        penalties += policy.min_cash - min_cash
 
     return (
         penalties,
@@ -783,8 +877,19 @@ def _consistency_penalty(
             'avg_filled_notional_per_day': str(avg_filled_notional_per_day),
             'avg_filled_notional_per_active_day': str(avg_filled_notional_per_active_day),
             'best_day_share_of_total_pnl': str(best_day_share_of_total_pnl),
+            'max_gross_exposure_pct_equity': str(max_gross_exposure_pct_equity),
+            'max_gross_exposure_pct_equity_required': str(policy.max_gross_exposure_pct_equity),
+            'min_cash': str(min_cash),
+            'min_cash_required': str(policy.min_cash),
+            'negative_cash_observation_count': negative_cash_observation_count,
             'daily_net': {day: str(value) for day, value in summary.daily_net.items()},
             'daily_filled_notional': {day: str(value) for day, value in daily_filled_notional.items()},
+            'daily_max_gross_exposure_pct_equity': {
+                day: str(value)
+                for day, value in daily_gross_exposure_pct_equity.items()
+            },
+            'daily_min_cash': {day: str(value) for day, value in daily_min_cash.items()},
+            'daily_negative_cash_observation_count': daily_negative_cash_observations,
         },
     )
 
@@ -1096,6 +1201,13 @@ def _rank_scored_candidates(scored: list[dict[str, Any]]) -> list[dict[str, Any]
             entry_family_contribution_share=Decimal(
                 str(item['objective_scorecard']['entry_family_contribution_share'])
             ),
+            max_gross_exposure_pct_equity=Decimal(
+                str(item['objective_scorecard'].get('max_gross_exposure_pct_equity', '0'))
+            ),
+            min_cash=Decimal(str(item['objective_scorecard'].get('min_cash', '0'))),
+            negative_cash_observation_count=int(
+                item['objective_scorecard'].get('negative_cash_observation_count') or 0
+            ),
         )
         for item in scored
     }
@@ -1294,6 +1406,10 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
         min_regime_slice_pass_rate=Decimal(str(consistency_constraints.get('min_regime_slice_pass_rate', '0'))),
         max_symbol_concentration_share=Decimal(str(consistency_constraints.get('max_symbol_concentration_share', '1'))),
         max_entry_family_contribution_share=Decimal(str(consistency_constraints.get('max_entry_family_contribution_share', '1'))),
+        max_gross_exposure_pct_equity=Decimal(
+            str(consistency_constraints.get('max_gross_exposure_pct_equity', '999999999'))
+        ),
+        min_cash=Decimal(str(consistency_constraints.get('min_cash', '-999999999'))),
     )
     max_train_screen_worst_day_loss = Decimal(
         str(
@@ -1579,6 +1695,13 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
                     regime_slice_pass_rate=regime_slice_pass_rate(decomposition),
                     symbol_concentration_share=max_symbol_concentration_share(decomposition),
                     entry_family_contribution_share=max_family_contribution_share(decomposition),
+                    max_gross_exposure_pct_equity=Decimal(
+                        str(full_window_summary.get('max_gross_exposure_pct_equity', '0'))
+                    ),
+                    min_cash=Decimal(str(full_window_summary.get('min_cash', '0'))),
+                    negative_cash_observation_count=int(
+                        full_window_summary.get('negative_cash_observation_count') or 0
+                    ),
                 )
                 hard_vetoes = list(
                     evaluate_vetoes(

--- a/services/torghut/tests/test_discovery_harness_v2.py
+++ b/services/torghut/tests/test_discovery_harness_v2.py
@@ -428,6 +428,9 @@ class TestDiscoveryHarnessV2(TestCase):
             regime_slice_pass_rate=Decimal('0.10'),
             symbol_concentration_share=Decimal('0.80'),
             entry_family_contribution_share=Decimal('0.90'),
+            max_gross_exposure_pct_equity=Decimal('2.20'),
+            min_cash=Decimal('-2500'),
+            negative_cash_observation_count=4,
         )
         self.assertTrue(dominates(dominant, dominated))
         self.assertFalse(dominates(dominated, dominant))
@@ -442,11 +445,15 @@ class TestDiscoveryHarnessV2(TestCase):
                 required_max_worst_day_loss=Decimal('200'),
                 required_max_drawdown=Decimal('400'),
                 required_min_regime_slice_pass_rate=Decimal('0.40'),
+                required_max_gross_exposure_pct_equity=Decimal('1.50'),
+                required_min_cash=Decimal('0'),
             ),
             is_fresh=False,
         )
         self.assertIn('worst_day_loss_above_max', vetoes)
         self.assertIn('regime_slice_pass_rate_below_min', vetoes)
+        self.assertIn('gross_exposure_pct_equity_above_max', vetoes)
+        self.assertIn('min_cash_below_min', vetoes)
         self.assertIn('stale_tape', vetoes)
 
         ranked = rank_scorecards(

--- a/services/torghut/tests/test_local_intraday_tsmom_replay.py
+++ b/services/torghut/tests/test_local_intraday_tsmom_replay.py
@@ -34,6 +34,7 @@ from scripts.local_intraday_tsmom_replay import (
     _parse_signal_row,
     _positions_payload,
     _quote_quality_status,
+    _record_capital_snapshot,
     _record_trace_for_funnel,
     _reconcile_pending_order_before_immediate_fill,
     _resolve_pending_fill_price,
@@ -147,6 +148,43 @@ class TestLocalIntradayTsmomReplay(TestCase):
         self.assertEqual(day_bucket["filled_count"], 1)
         self.assertEqual(day_bucket["filled_notional"], Decimal("5232.80"))
         self.assertLess(cash, Decimal("10000"))
+
+    def test_record_capital_snapshot_tracks_cash_and_exposure(self) -> None:
+        positions = {
+            ("META", _SHARED_POSITION_OWNER): PositionState(
+                strategy_id=_SHARED_POSITION_OWNER,
+                qty=Decimal("3"),
+                avg_entry_price=Decimal("100"),
+                opened_at=datetime(2026, 3, 27, 17, 0, 0, tzinfo=timezone.utc),
+                entry_cost_total=Decimal("1.00"),
+                decision_at=datetime(2026, 3, 27, 17, 0, 0, tzinfo=timezone.utc),
+            ),
+            ("NVDA", _SHARED_POSITION_OWNER): PositionState(
+                strategy_id=_SHARED_POSITION_OWNER,
+                qty=Decimal("-2"),
+                avg_entry_price=Decimal("50"),
+                opened_at=datetime(2026, 3, 27, 17, 0, 0, tzinfo=timezone.utc),
+                entry_cost_total=Decimal("1.00"),
+                decision_at=datetime(2026, 3, 27, 17, 0, 0, tzinfo=timezone.utc),
+            ),
+        }
+        bucket: dict[str, object] = {}
+
+        equity = _record_capital_snapshot(
+            bucket=bucket,
+            cash=Decimal("-25"),
+            positions=positions,
+            last_prices={"META": Decimal("110"), "NVDA": Decimal("45")},
+        )
+
+        self.assertEqual(equity, Decimal("215"))
+        self.assertEqual(bucket["min_cash"], Decimal("-25"))
+        self.assertEqual(bucket["min_equity"], Decimal("215"))
+        self.assertEqual(bucket["max_gross_exposure"], Decimal("420"))
+        self.assertEqual(bucket["max_net_exposure_abs"], Decimal("240"))
+        self.assertEqual(bucket["max_gross_exposure_pct_equity"], Decimal("420") / Decimal("215"))
+        self.assertEqual(bucket["negative_cash_observation_count"], 1)
+        self.assertEqual(bucket["capital_snapshot_count"], 1)
 
     def test_apply_filled_decision_backfills_missing_stats_bucket_fields(self) -> None:
         signal = self._signal(bid="523.22", ask="523.28", price="523.25")

--- a/services/torghut/tests/test_search_consistent_profitability_frontier.py
+++ b/services/torghut/tests/test_search_consistent_profitability_frontier.py
@@ -9,6 +9,7 @@ from datetime import date, datetime, timedelta, timezone
 from decimal import Decimal
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from typing import cast
 from unittest import TestCase
 from unittest.mock import patch
 from types import SimpleNamespace
@@ -681,6 +682,62 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
         self.assertEqual(summary['positive_days'], 1)
         self.assertEqual(summary['best_day_share_of_total_pnl'], '1.104166666666666666666666667')
         self.assertEqual(summary['avg_filled_notional_per_day'], '18750')
+
+    def test_consistency_penalty_reports_and_penalizes_capital_realism(self) -> None:
+        payload = self._payload(
+            start_date='2026-03-24',
+            end_date='2026-03-26',
+            daily_net={
+                '2026-03-24': '600',
+                '2026-03-25': '550',
+                '2026-03-26': '650',
+            },
+            daily_filled_notional={
+                '2026-03-24': '250000',
+                '2026-03-25': '260000',
+                '2026-03-26': '270000',
+            },
+            decision_count=12,
+            filled_count=12,
+            wins=9,
+            losses=3,
+        )
+        daily = cast(dict[str, dict[str, object]], payload['daily'])
+        daily['2026-03-24']['min_cash'] = '12000'
+        daily['2026-03-24']['max_gross_exposure_pct_equity'] = '0.80'
+        daily['2026-03-24']['negative_cash_observation_count'] = 0
+        daily['2026-03-25']['min_cash'] = '-2500'
+        daily['2026-03-25']['max_gross_exposure_pct_equity'] = '2.40'
+        daily['2026-03-25']['negative_cash_observation_count'] = 3
+        daily['2026-03-26']['min_cash'] = '8000'
+        daily['2026-03-26']['max_gross_exposure_pct_equity'] = '1.10'
+        daily['2026-03-26']['negative_cash_observation_count'] = 0
+
+        penalties, summary = frontier._consistency_penalty(
+            full_window_payload=payload,
+            policy=frontier.FullWindowConsistencyPolicy(
+                target_net_per_day=frontier.Decimal('500'),
+                min_daily_net_pnl=frontier.Decimal('0'),
+                min_active_days=3,
+                min_active_ratio=frontier.Decimal('1.0'),
+                min_positive_days=3,
+                max_worst_day_loss=frontier.Decimal('0'),
+                max_negative_days=0,
+                max_drawdown=frontier.Decimal('0'),
+                max_best_day_share_of_total_pnl=frontier.Decimal('0.60'),
+                min_avg_filled_notional_per_day=frontier.Decimal('200000'),
+                min_avg_filled_notional_per_active_day=frontier.Decimal('200000'),
+                require_every_day_active=True,
+                max_gross_exposure_pct_equity=frontier.Decimal('1.50'),
+                min_cash=frontier.Decimal('0'),
+            ),
+        )
+
+        self.assertGreater(penalties, frontier.Decimal('0'))
+        self.assertEqual(summary['max_gross_exposure_pct_equity'], '2.40')
+        self.assertEqual(summary['min_cash'], '-2500')
+        self.assertEqual(summary['negative_cash_observation_count'], 3)
+        self.assertEqual(summary['daily_min_cash']['2026-03-25'], '-2500')
 
     def test_main_prefers_consistent_candidate_over_prettier_holdout(self) -> None:
         with TemporaryDirectory() as tmpdir:

--- a/services/torghut/tests/test_strategy_autoresearch.py
+++ b/services/torghut/tests/test_strategy_autoresearch.py
@@ -195,6 +195,8 @@ class TestStrategyAutoresearch(TestCase):
                         'max_worst_day_loss': '450',
                         'max_drawdown': '1000',
                         'min_regime_slice_pass_rate': '0.40',
+                        'max_gross_exposure_pct_equity': '1.25',
+                        'min_cash': '0',
                     },
                     'runtime_closure_policy': {
                         'enabled': False,
@@ -258,6 +260,8 @@ class TestStrategyAutoresearch(TestCase):
             program = load_strategy_autoresearch_program(program_path, family_dir=family_dir)
             self.assertEqual(program.program_id, 'daily-profit')
             self.assertEqual(program.objective.target_net_pnl_per_day, Decimal('500'))
+            self.assertEqual(program.objective.max_gross_exposure_pct_equity, Decimal('1.25'))
+            self.assertEqual(program.objective.min_cash, Decimal('0'))
             self.assertEqual(program.families[0].family_template.family_id, 'breakout_reclaim_v2')
             self.assertEqual(program.families[0].strategy_override_mutations['normalization_regime'].mode, 'allowed_normalizations')
 
@@ -271,6 +275,8 @@ class TestStrategyAutoresearch(TestCase):
             self.assertEqual(updated['constraints']['holdout_target_net_per_day'], '500')
             self.assertEqual(updated['consistency_constraints']['min_daily_net_pnl'], '0')
             self.assertEqual(updated['consistency_constraints']['max_best_day_share_of_total_pnl'], '0.35')
+            self.assertEqual(updated['consistency_constraints']['max_gross_exposure_pct_equity'], '1.25')
+            self.assertEqual(updated['consistency_constraints']['min_cash'], '0')
             self.assertEqual(updated['consistency_constraints']['min_active_days'], 8)
 
     def test_checked_in_300_daily_profit_program_targets_daily_net(self) -> None:
@@ -298,6 +304,20 @@ class TestStrategyAutoresearch(TestCase):
                 for source in program.research_sources
             )
         )
+
+    def test_checked_in_500_daily_profit_program_enforces_cash_capital_realism(self) -> None:
+        program_path = Path(
+            'config/trading/research-programs/strict-daily-profit-autoresearch-500-v1.yaml'
+        )
+
+        program = load_strategy_autoresearch_program(
+            program_path,
+            family_dir=Path('config/trading/families'),
+        )
+
+        self.assertEqual(program.objective.target_net_pnl_per_day, Decimal('500'))
+        self.assertEqual(program.objective.max_gross_exposure_pct_equity, Decimal('1.0'))
+        self.assertEqual(program.objective.min_cash, Decimal('0'))
 
     def test_load_program_rejects_non_mapping_schema_and_missing_families(self) -> None:
         with TemporaryDirectory() as tmpdir:
@@ -596,6 +616,8 @@ class TestStrategyAutoresearch(TestCase):
             require_every_day_active=False,
             min_regime_slice_pass_rate=Decimal('0.40'),
             stop_when_objective_met=False,
+            max_gross_exposure_pct_equity=Decimal('1.50'),
+            min_cash=Decimal('0'),
         )
         candidate = {
             'hard_vetoes': [],
@@ -608,10 +630,18 @@ class TestStrategyAutoresearch(TestCase):
                 'worst_day_loss': '300',
                 'max_drawdown': '900',
                 'regime_slice_pass_rate': '0.45',
+                'max_gross_exposure_pct_equity': '1.25',
+                'min_cash': '2500',
             },
             'full_window': {'trading_day_count': 9, 'active_days': 7},
         }
         self.assertTrue(candidate_meets_objective(candidate, objective=objective))
+        over_levered = copy.deepcopy(candidate)
+        over_levered['objective_scorecard']['max_gross_exposure_pct_equity'] = '1.51'
+        self.assertFalse(candidate_meets_objective(over_levered, objective=objective))
+        negative_cash = copy.deepcopy(candidate)
+        negative_cash['objective_scorecard']['min_cash'] = '-0.01'
+        self.assertFalse(candidate_meets_objective(negative_cash, objective=objective))
         vetoed = dict(candidate)
         vetoed['hard_vetoes'] = ['best_day_share_above_max']
         self.assertFalse(candidate_meets_objective(vetoed, objective=objective))


### PR DESCRIPTION
## Summary

- Adds replay capital telemetry for min cash, min equity, realized gross/net exposure, gross exposure per equity, and negative-cash observations.
- Propagates capital realism metrics into full-window frontier summaries, objective scorecards, ranking, and hard veto policy.
- Configures the checked-in `$500/day` autoresearch program to require cash-funded replay evidence with `max_gross_exposure_pct_equity: 1.0` and `min_cash: 0`.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen ruff check app/trading/discovery/autoresearch.py app/trading/discovery/objectives.py scripts/local_intraday_tsmom_replay.py scripts/search_consistent_profitability_frontier.py tests/test_local_intraday_tsmom_replay.py tests/test_search_consistent_profitability_frontier.py tests/test_discovery_harness_v2.py tests/test_strategy_autoresearch.py`
- `uv run --frozen pytest tests/test_strategy_autoresearch.py tests/test_local_intraday_tsmom_replay.py tests/test_search_consistent_profitability_frontier.py tests/test_discovery_harness_v2.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
