### PR TITLE
chore(jangar): promote image 02afb5d3

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 7faccace
-  digest: sha256:fa7bf7b62516e3384f5a39015a05c94d48bdf959343601b20f3c946c19adbbdb
+  tag: 02afb5d3
+  digest: sha256:1cc415c97666ff3c09b0a22e5912cc4411eeb30d3f6a85ce5dea17cbd5dc84d2
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,8 +11,8 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 7faccace
-    digest: sha256:799ced3e91261bd87f03953eb0314793a4f69bdd4cac2d03e45d9243dec1c177
+    tag: 02afb5d3
+    digest: sha256:f0b664445cbc00ea0de6fa27a0faddfb1a6f35447f26ce007f560872b3648afa
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
@@ -21,8 +21,8 @@ controlPlane:
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 7faccace
-    digest: sha256:fa7bf7b62516e3384f5a39015a05c94d48bdf959343601b20f3c946c19adbbdb
+    tag: 02afb5d3
+    digest: sha256:1cc415c97666ff3c09b0a22e5912cc4411eeb30d3f6a85ce5dea17cbd5dc84d2
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-13T22:03:41Z
+    deploy.knative.dev/rollout: 2026-05-13T22:46:35Z
 spec:
   replicas: 1
   strategy:
@@ -57,11 +57,11 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_RUNTIME_IMAGE
-              value: registry.ide-newton.ts.net/lab/jangar:7faccace@sha256:fa7bf7b62516e3384f5a39015a05c94d48bdf959343601b20f3c946c19adbbdb
+              value: registry.ide-newton.ts.net/lab/jangar:02afb5d3@sha256:1cc415c97666ff3c09b0a22e5912cc4411eeb30d3f6a85ce5dea17cbd5dc84d2
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: 7faccaceda2fa7af21849678b6688baf5e4c30fe
+              value: 02afb5d395fdc5e3dd795e9a79a1f26a89a2827e
             - name: JANGAR_GITOPS_REVISION
-              value: 7faccaceda2fa7af21849678b6688baf5e4c30fe
+              value: 02afb5d395fdc5e3dd795e9a79a1f26a89a2827e
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_BUMBA_TASK_QUEUE

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -59,5 +59,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: 7faccace
-    digest: sha256:fa7bf7b62516e3384f5a39015a05c94d48bdf959343601b20f3c946c19adbbdb
+    newTag: 02afb5d3
+    digest: sha256:1cc415c97666ff3c09b0a22e5912cc4411eeb30d3f6a85ce5dea17cbd5dc84d2


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `02afb5d395fdc5e3dd795e9a79a1f26a89a2827e`
- Image tag: `02afb5d3`
- Image digest: `sha256:1cc415c97666ff3c09b0a22e5912cc4411eeb30d3f6a85ce5dea17cbd5dc84d2`
- Updated API rollout annotation
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`