### PR TITLE
fix(jangar): ignore stale swarm release branches

### DIFF
--- a/argocd/applications/agents/swarm-implspecs.yaml
+++ b/argocd/applications/agents/swarm-implspecs.yaml
@@ -183,6 +183,9 @@ spec:
 
     Requirements:
     - Work only on `${head}` based on `${base}` in `${repository}`.
+    - Start from current `${base}` and the configured `${head}` branch. If the remote `${head}` branch is absent or only
+      has merged/closed historical PRs, create a fresh local `${head}` from `${base}` and open one new PR; do not spend
+      the run auditing old all-state PR history for that branch.
     - Identify and cite the governing design document and runtime requirement signal (path/PR/issue doc/payload) before coding.
     - If `${swarmBusinessEvidenceUrl}` is available but cannot be read, fail with the exact command/error and the smallest unblocker instead of choosing speculative work.
     - For Torghut, `/trading/revenue-repair` is the source of truth for revenue blocker priority. Pick the top actionable `repair_queue` item that maps to `${swarmValueGates}`; do not enable live submission while `business_state=repair_only`, `revenue_ready=false`, or `repair_queue` is non-empty.
@@ -382,6 +385,8 @@ spec:
     Requirements:
     - Work only on `${head}` based on `${base}` in `${repository}`.
     - Enumerate open PRs only enough to select one release slice; do not audit the full backlog in a verify run.
+    - Ignore or close superseded release/promotion PRs when their source commit, image digest, or base is older than the
+      live rollout already reported by `${swarmBusinessEvidenceUrl}` or Argo; do not repair stale promotion branches.
     - Prioritize unblock-first/high-impact, and move at most one selected PR to mergeable state per run.
     - Own selected PRs end-to-end: resolve blocking comments/conflicts and fix code/tests/CI until all required checks are green.
     - Treat `${swarmValidationContract}` as the release acceptance contract; do not count a PR as useful unless it advances `${swarmBusinessMetric}` or records the exact blocker.

--- a/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
+++ b/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
@@ -327,6 +327,7 @@ describe('scheduled AgentRun templates', () => {
     const text = String(objectAt(objectAt(deployerSpec, 'spec'), 'text') ?? '')
 
     expect(text).toContain('Select at most one unblock-first/high-impact PR')
+    expect(text).toContain('Ignore or close superseded release/promotion PRs')
     expect(text).toContain('Do not use GitHub comments for routine status')
     expect(text).toContain('Never request Codex review automatically')
     expect(text).toContain('/trading/revenue-repair')
@@ -343,6 +344,7 @@ describe('scheduled AgentRun templates', () => {
     const text = String(objectAt(objectAt(implementerSpec, 'spec'), 'text') ?? '')
 
     expect(text).toContain('Read `${swarmBusinessEvidenceUrl}` when provided')
+    expect(text).toContain('If the remote `${head}` branch is absent')
     expect(text).toContain('top actionable `repair_queue` item')
     expect(text).toContain('do not enable live submission while `business_state=repair_only`')
   })


### PR DESCRIPTION
## Summary

- Tightens the swarm implementer contract so absent/stale fixed head branches start fresh from current base instead of auditing old all-state PR history.
- Tightens the swarm deployer contract so superseded release/promotion PRs are ignored or closed when live rollout evidence is newer.
- Adds smoke-test assertions so future template edits keep those anti-theater gates in place.

## Related Issues

None

## Testing

- `bunx oxfmt --check argocd/applications/agents/swarm-implspecs.yaml packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `scripts/agents/validate-agents.sh`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
