### PR TITLE
feat(torghut): rank autoresearch by capital feasibility

### DIFF
--- a/services/torghut/app/trading/discovery/candidate_specs.py
+++ b/services/torghut/app/trading/discovery/candidate_specs.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 from dataclasses import dataclass
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 from typing import Any, Literal, Mapping, Sequence, cast
 
 from app.trading.discovery.hypothesis_cards import HypothesisCard
@@ -1901,6 +1901,49 @@ def _mapping(value: Any) -> dict[str, Any]:
     return {str(key): item for key, item in cast(Mapping[Any, Any], value).items()}
 
 
+def _profile_decimal(value: Any, *, default: str = "0") -> Decimal:
+    try:
+        return Decimal(str(value if value is not None else default))
+    except (InvalidOperation, TypeError, ValueError):
+        return Decimal(default)
+
+
+def _profile_slot_count(profile: Mapping[str, Any]) -> int:
+    params = _mapping(profile.get("params"))
+    slot_values = [
+        _profile_decimal(params.get("max_entries_per_session"), default="1"),
+        _profile_decimal(params.get("max_pair_legs"), default="1"),
+        _profile_decimal(params.get("top_n"), default="1"),
+    ]
+    return max(1, int(max(slot_values)))
+
+
+def _capital_limited_profile_values(profile: Mapping[str, Any]) -> tuple[str, str]:
+    slot_count = _profile_slot_count(profile)
+    if slot_count <= 1:
+        return "30000", "1.0"
+    if slot_count == 2:
+        return "15000", "0.50"
+    return "7500", "0.25"
+
+
+def _capital_constrained_execution_profiles(
+    profiles: Sequence[Mapping[str, Any]],
+) -> tuple[dict[str, Any], ...]:
+    constrained: list[dict[str, Any]] = []
+    for profile in profiles:
+        next_profile = json.loads(json.dumps(profile))
+        params = _mapping(next_profile.get("params"))
+        max_notional, max_position = _capital_limited_profile_values(next_profile)
+        next_profile["max_notional_per_trade"] = max_notional
+        next_profile["max_position_pct_equity"] = max_position
+        next_profile["capital_profile"] = "initial_equity_cash_constrained_1x"
+        params["max_gross_exposure_pct_equity"] = "1.0"
+        next_profile["params"] = params
+        constrained.append(next_profile)
+    return tuple(constrained)
+
+
 def _universe_symbol_override(symbols: Sequence[str]) -> tuple[str, ...]:
     cleaned: list[str] = []
     seen: set[str] = set()
@@ -2226,9 +2269,13 @@ def _execution_profiles_for_target(
     base_profiles = _BASE_FAMILY_EXECUTION_PROFILES.get(family_template_id, ())
     if target_net_pnl_per_day < _PORTFOLIO_TARGET_NET_PNL_PER_DAY:
         return base_profiles
+    portfolio_profiles = _PORTFOLIO_ORACLE_COVERAGE_EXECUTION_PROFILES.get(
+        family_template_id, ()
+    )
+    exploratory_profiles = (*base_profiles, *portfolio_profiles)
     return (
-        *base_profiles,
-        *_PORTFOLIO_ORACLE_COVERAGE_EXECUTION_PROFILES.get(family_template_id, ()),
+        *exploratory_profiles,
+        *_capital_constrained_execution_profiles(exploratory_profiles),
     )
 
 

--- a/services/torghut/app/trading/discovery/mlx_features.py
+++ b/services/torghut/app/trading/discovery/mlx_features.py
@@ -10,9 +10,22 @@ from typing import Any, Mapping, cast
 from app.trading.discovery.autoresearch import FamilyAutoresearchPlan
 from app.trading.discovery.family_templates import FamilyTemplate
 
+DEFAULT_CAPITAL_START_EQUITY = 31590.02
+
 
 def _string(value: Any) -> str:
     return str(value or '').strip()
+
+
+def _float(value: Any) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _format_float(value: float) -> str:
+    return format(value, '.12g')
 
 
 def _mapping(value: Any) -> dict[str, Any]:
@@ -129,6 +142,31 @@ def _infer_budget(value: Any, default: str = '0') -> str:
     return normalized or default
 
 
+def _capital_budget_payload(config: Mapping[str, Any], *, rank_count: int) -> dict[str, Any]:
+    max_notional = _float(_override_value(config, 'max_notional_per_trade'))
+    max_notional_pct_start_equity = (
+        max_notional / DEFAULT_CAPITAL_START_EQUITY if DEFAULT_CAPITAL_START_EQUITY > 0 else 0.0
+    )
+    max_position_pct = _float(_override_value(config, 'max_position_pct_equity'))
+    max_trade_pct_equity = max(max_notional_pct_start_equity, max_position_pct)
+    configured_max_gross_pct = _float(_param_value(config, 'max_gross_exposure_pct_equity'))
+    estimated_max_gross_pct = max(
+        configured_max_gross_pct,
+        max_trade_pct_equity * max(1, rank_count),
+    )
+    capital_budget_overage_ratio = max(0.0, estimated_max_gross_pct - 1.0) + max(
+        0.0, max_trade_pct_equity - 1.0
+    )
+    capital_feasible = estimated_max_gross_pct <= 1.0 and max_trade_pct_equity <= 1.0
+    return {
+        'max_position_pct_equity': _format_float(max_position_pct),
+        'configured_max_gross_exposure_pct_equity': _format_float(configured_max_gross_pct),
+        'estimated_max_gross_exposure_pct_equity': _format_float(estimated_max_gross_pct),
+        'capital_budget_overage_ratio': _format_float(capital_budget_overage_ratio),
+        'capital_feasible': capital_feasible,
+    }
+
+
 def _descriptor_id(payload: Mapping[str, Any]) -> str:
     digest = hashlib.sha256(
         json.dumps(payload, sort_keys=True, separators=(',', ':')).encode('utf-8')
@@ -160,6 +198,11 @@ class MlxCandidateDescriptor:
     requires_quote_quality_gate: bool
     expected_fill_mode: str
     approval_path: str
+    max_position_pct_equity: str = '0'
+    configured_max_gross_exposure_pct_equity: str = '0'
+    estimated_max_gross_exposure_pct_equity: str = '0'
+    capital_budget_overage_ratio: str = '0'
+    capital_feasible: bool = True
 
     def to_payload(self) -> dict[str, Any]:
         return {
@@ -185,6 +228,11 @@ class MlxCandidateDescriptor:
             'requires_quote_quality_gate': self.requires_quote_quality_gate,
             'expected_fill_mode': self.expected_fill_mode,
             'approval_path': self.approval_path,
+            'max_position_pct_equity': self.max_position_pct_equity,
+            'configured_max_gross_exposure_pct_equity': self.configured_max_gross_exposure_pct_equity,
+            'estimated_max_gross_exposure_pct_equity': self.estimated_max_gross_exposure_pct_equity,
+            'capital_budget_overage_ratio': self.capital_budget_overage_ratio,
+            'capital_feasible': self.capital_feasible,
         }
 
 
@@ -208,6 +256,7 @@ def descriptor_from_sweep_config(
     rank_count = _infer_rank_count(sweep_config)
     gross_budget_usd = _infer_budget(_override_value(sweep_config, 'max_notional_per_trade'))
     per_leg_budget_usd = _infer_budget(_override_value(sweep_config, 'max_notional_per_trade'))
+    capital_budget = _capital_budget_payload(sweep_config, rank_count=rank_count)
     normalization_regime = _string(_override_value(sweep_config, 'normalization_regime')) or 'runtime_default'
     regime_gate_id = (
         _string(template.regime_activation_rules[0].get('rule_id')) if template.regime_activation_rules else 'none'
@@ -241,6 +290,7 @@ def descriptor_from_sweep_config(
         'requires_quote_quality_gate': requires_quote_quality_gate,
         'expected_fill_mode': expected_fill_mode,
         'approval_path': approval_path,
+        **capital_budget,
     }
     return MlxCandidateDescriptor(
         descriptor_id=_descriptor_id(descriptor_payload),
@@ -265,6 +315,11 @@ def descriptor_from_sweep_config(
         requires_quote_quality_gate=requires_quote_quality_gate,
         expected_fill_mode=expected_fill_mode,
         approval_path=approval_path,
+        max_position_pct_equity=str(capital_budget['max_position_pct_equity']),
+        configured_max_gross_exposure_pct_equity=str(capital_budget['configured_max_gross_exposure_pct_equity']),
+        estimated_max_gross_exposure_pct_equity=str(capital_budget['estimated_max_gross_exposure_pct_equity']),
+        capital_budget_overage_ratio=str(capital_budget['capital_budget_overage_ratio']),
+        capital_feasible=bool(capital_budget['capital_feasible']),
     )
 
 
@@ -291,6 +346,11 @@ def descriptor_numeric_vector(descriptor: MlxCandidateDescriptor) -> list[float]
         float(descriptor.entry_window_end_minute),
         float(descriptor.max_hold_minutes),
         float(descriptor.rank_count),
+        _float(descriptor.max_position_pct_equity),
+        _float(descriptor.configured_max_gross_exposure_pct_equity),
+        _float(descriptor.estimated_max_gross_exposure_pct_equity),
+        _float(descriptor.capital_budget_overage_ratio),
+        float(descriptor.capital_feasible),
         float(descriptor.requires_prev_day_features),
         float(descriptor.requires_cross_sectional_features),
         float(descriptor.requires_quote_quality_gate),

--- a/services/torghut/app/trading/discovery/mlx_proposal_models.py
+++ b/services/torghut/app/trading/discovery/mlx_proposal_models.py
@@ -25,11 +25,19 @@ def _candidate_target(row: Mapping[str, Any]) -> float:
     activity = _float(row.get("active_day_ratio"))
     concentration_penalty = _float(row.get("best_day_share"))
     veto_penalty = 1.0 if row.get("hard_vetoes") else 0.0
+    gross_overage_penalty = max(
+        0.0, _float(row.get("max_gross_exposure_pct_equity")) - 1.0
+    )
+    cash_deficit_penalty = max(0.0, -_float(row.get("min_cash"))) / 100.0
+    negative_cash_penalty = _float(row.get("negative_cash_observation_count")) * 20.0
     return (
         net
         + (activity * 100.0)
         - (concentration_penalty * 100.0)
         - (veto_penalty * 250.0)
+        - (gross_overage_penalty * 500.0)
+        - cash_deficit_penalty
+        - negative_cash_penalty
     )
 
 
@@ -96,6 +104,8 @@ class ProposalSelectionEntry:
     rank: int
     family_template_id: str
     side_policy: str
+    capital_feasible: bool = True
+    capital_budget_overage_ratio: float = 0.0
 
     def to_payload(self) -> dict[str, Any]:
         return {
@@ -106,6 +116,8 @@ class ProposalSelectionEntry:
             "rank": self.rank,
             "family_template_id": self.family_template_id,
             "side_policy": self.side_policy,
+            "capital_feasible": self.capital_feasible,
+            "capital_budget_overage_ratio": self.capital_budget_overage_ratio,
         }
 
 
@@ -288,9 +300,40 @@ def select_proposal_batch(
     if limit <= 0 or not descriptors or not proposal_scores:
         return []
     descriptor_by_candidate = _descriptor_by_candidate(descriptors)
-    ordered_scores = sorted(
-        proposal_scores, key=lambda item: (item.rank, -item.score, item.candidate_id)
-    )
+
+    def proposal_sort_key(item: ProposalScore) -> tuple[int, float, int, float, str]:
+        descriptor = descriptor_by_candidate.get(item.candidate_id)
+        if descriptor is None:
+            return (1, math.inf, item.rank, -item.score, item.candidate_id)
+        return (
+            0 if descriptor.capital_feasible else 1,
+            _float(descriptor.capital_budget_overage_ratio),
+            item.rank,
+            -item.score,
+            item.candidate_id,
+        )
+
+    def selection_entry(
+        *,
+        score: ProposalScore,
+        descriptor: MlxCandidateDescriptor,
+        selection_reason: str,
+    ) -> ProposalSelectionEntry:
+        return ProposalSelectionEntry(
+            candidate_id=score.candidate_id,
+            descriptor_id=score.descriptor_id,
+            selection_reason=selection_reason,
+            score=score.score,
+            rank=score.rank,
+            family_template_id=descriptor.family_template_id,
+            side_policy=descriptor.side_policy,
+            capital_feasible=descriptor.capital_feasible,
+            capital_budget_overage_ratio=_float(
+                descriptor.capital_budget_overage_ratio
+            ),
+        )
+
+    ordered_scores = sorted(proposal_scores, key=proposal_sort_key)
     selected: list[ProposalSelectionEntry] = []
     selected_ids: set[str] = set()
     selected_families: set[str] = set()
@@ -302,14 +345,8 @@ def select_proposal_batch(
         if descriptor is None or item.candidate_id in selected_ids:
             continue
         selected.append(
-            ProposalSelectionEntry(
-                candidate_id=item.candidate_id,
-                descriptor_id=item.descriptor_id,
-                selection_reason="exploitation",
-                score=item.score,
-                rank=item.rank,
-                family_template_id=descriptor.family_template_id,
-                side_policy=descriptor.side_policy,
+            selection_entry(
+                score=item, descriptor=descriptor, selection_reason="exploitation"
             )
         )
         selected_ids.add(item.candidate_id)
@@ -358,8 +395,12 @@ def select_proposal_batch(
                 diversity_bonus = _mean(distances)
             else:
                 diversity_bonus = 0.0
+            capital_penalty = _float(descriptor.capital_budget_overage_ratio) * 1000.0
+            if not descriptor.capital_feasible:
+                capital_penalty += 10000.0
             combined = (
                 family_bonus + side_bonus + diversity_bonus + (score.score * 0.001)
+                - capital_penalty
             )
             candidate = (combined, score, descriptor)
             if (
@@ -376,14 +417,10 @@ def select_proposal_batch(
             break
         _, score, descriptor = best_item
         selected.append(
-            ProposalSelectionEntry(
-                candidate_id=score.candidate_id,
-                descriptor_id=score.descriptor_id,
+            selection_entry(
+                score=score,
+                descriptor=descriptor,
                 selection_reason="exploration",
-                score=score.score,
-                rank=score.rank,
-                family_template_id=descriptor.family_template_id,
-                side_policy=descriptor.side_policy,
             )
         )
         selected_ids.add(score.candidate_id)
@@ -554,11 +591,21 @@ def rank_candidate_descriptors(
     history_vectors: list[list[float]] = []
     history_targets: list[float] = []
     for row in history_rows:
+        history_capital_feasible = (
+            bool(row.get("capital_feasible"))
+            if row.get("capital_feasible") is not None
+            else True
+        )
         history_descriptor = [
             float(row.get("entry_window_start_minute") or 0),
             float(row.get("entry_window_end_minute") or 0),
             float(row.get("max_hold_minutes") or 0),
             float(row.get("rank_count") or 0),
+            float(row.get("max_position_pct_equity") or 0),
+            float(row.get("configured_max_gross_exposure_pct_equity") or 0),
+            float(row.get("estimated_max_gross_exposure_pct_equity") or 0),
+            float(row.get("capital_budget_overage_ratio") or 0),
+            float(history_capital_feasible),
             float(bool(row.get("requires_prev_day_features"))),
             float(bool(row.get("requires_cross_sectional_features"))),
             float(bool(row.get("requires_quote_quality_gate"))),

--- a/services/torghut/app/trading/discovery/mlx_training_data.py
+++ b/services/torghut/app/trading/discovery/mlx_training_data.py
@@ -12,6 +12,7 @@ from app.trading.discovery.candidate_specs import CandidateSpec
 from app.trading.discovery.evidence_bundles import CandidateEvidenceBundle
 
 MLX_RANKER_SCHEMA_VERSION = "torghut.mlx-ranker.v1"
+DEFAULT_CAPITAL_START_EQUITY = 31590.02
 
 
 def _stable_hash(payload: Mapping[str, Any]) -> str:
@@ -147,6 +148,72 @@ def _float(value: Any) -> float:
         return 0.0
 
 
+def _mapping(value: Any) -> Mapping[str, Any]:
+    if isinstance(value, Mapping):
+        return cast(Mapping[str, Any], value)
+    return {}
+
+
+def _positive_or_default(value: float, default: float) -> float:
+    return value if value > 0.0 else default
+
+
+def candidate_spec_capital_features(spec: CandidateSpec) -> Mapping[str, float]:
+    overrides = _mapping(spec.strategy_overrides)
+    params = _mapping(overrides.get("params"))
+    max_notional = _float(overrides.get("max_notional_per_trade"))
+    max_position_pct = _float(overrides.get("max_position_pct_equity"))
+    configured_max_gross_pct = _float(params.get("max_gross_exposure_pct_equity"))
+    max_entries = _positive_or_default(_float(params.get("max_entries_per_session")), 1.0)
+    max_notional_pct_start_equity = (
+        max_notional / DEFAULT_CAPITAL_START_EQUITY
+        if DEFAULT_CAPITAL_START_EQUITY > 0.0
+        else 0.0
+    )
+    max_trade_pct_equity = max(
+        max_notional_pct_start_equity,
+        _positive_or_default(max_position_pct, 0.0),
+    )
+    inferred_max_gross_pct = max_trade_pct_equity * max_entries
+    estimated_max_gross_pct = max(configured_max_gross_pct, inferred_max_gross_pct)
+    capital_budget_overage_ratio = max(0.0, estimated_max_gross_pct - 1.0) + max(
+        0.0, max_trade_pct_equity - 1.0
+    )
+    capital_feasible = (
+        1.0
+        if estimated_max_gross_pct <= 1.0 and max_trade_pct_equity <= 1.0
+        else 0.0
+    )
+    return {
+        "max_notional_per_trade": max_notional,
+        "max_notional_pct_start_equity": max_notional_pct_start_equity,
+        "max_position_pct_equity": max_position_pct,
+        "configured_max_gross_exposure_pct_equity": configured_max_gross_pct,
+        "estimated_max_gross_exposure_pct_equity": estimated_max_gross_pct,
+        "max_entries_per_session": max_entries,
+        "capital_budget_overage_ratio": capital_budget_overage_ratio,
+        "capital_feasible_flag": capital_feasible,
+    }
+
+
+def capital_budget_penalty(features: Mapping[str, float]) -> float:
+    return (
+        _float(features.get("capital_budget_overage_ratio")) * 125.0
+        + max(0.0, _float(features.get("max_position_pct_equity")) - 1.0) * 35.0
+        + max(0.0, _float(features.get("max_notional_pct_start_equity")) - 1.0)
+        * 35.0
+    )
+
+
+def observed_capital_penalty(scorecard: Mapping[str, Any]) -> float:
+    return (
+        max(0.0, _float(scorecard.get("max_gross_exposure_pct_equity")) - 1.0)
+        * 500.0
+        + max(0.0, -_float(scorecard.get("min_cash"))) / 100.0
+        + _float(scorecard.get("negative_cash_observation_count")) * 20.0
+    )
+
+
 def _format_float(value: float) -> str:
     return format(value, ".12g")
 
@@ -206,23 +273,48 @@ def build_mlx_training_rows(
             "required_feature_count",
             "failure_mode_count",
             "target_net_pnl_per_day",
+            "max_notional_per_trade",
+            "max_notional_pct_start_equity",
+            "max_position_pct_equity",
+            "configured_max_gross_exposure_pct_equity",
+            "estimated_max_gross_exposure_pct_equity",
+            "max_entries_per_session",
+            "capital_budget_overage_ratio",
+            "capital_feasible_flag",
             "history_net_pnl_per_day",
             "history_active_day_ratio",
             "history_positive_day_ratio",
+            "history_max_gross_exposure_pct_equity",
+            "history_min_cash",
+            "history_negative_cash_observation_count",
         )
+        capital_features = candidate_spec_capital_features(spec)
         feature_values = (
             _family_code(spec.family_template_id),
             float(len(spec.feature_contract.get("required_features") or [])),
             float(len(spec.expected_failure_modes)),
             _float(spec.objective.get("target_net_pnl_per_day")),
+            _float(capital_features.get("max_notional_per_trade")),
+            _float(capital_features.get("max_notional_pct_start_equity")),
+            _float(capital_features.get("max_position_pct_equity")),
+            _float(capital_features.get("configured_max_gross_exposure_pct_equity")),
+            _float(capital_features.get("estimated_max_gross_exposure_pct_equity")),
+            _float(capital_features.get("max_entries_per_session")),
+            _float(capital_features.get("capital_budget_overage_ratio")),
+            _float(capital_features.get("capital_feasible_flag")),
             _float(scorecard.get("net_pnl_per_day")),
             _float(scorecard.get("active_day_ratio")),
             _float(scorecard.get("positive_day_ratio")),
+            _float(scorecard.get("max_gross_exposure_pct_equity")),
+            _float(scorecard.get("min_cash")),
+            _float(scorecard.get("negative_cash_observation_count")),
         )
         target = (
             _float(scorecard.get("net_pnl_per_day"))
             + (_float(scorecard.get("active_day_ratio")) * 100.0)
             + (_float(scorecard.get("positive_day_ratio")) * 50.0)
+            - capital_budget_penalty(capital_features)
+            - observed_capital_penalty(scorecard)
         )
         rows.append(
             MlxTrainingRow(

--- a/services/torghut/config/trading/research-programs/strict-daily-profit-autoresearch-500-v1.yaml
+++ b/services/torghut/config/trading/research-programs/strict-daily-profit-autoresearch-500-v1.yaml
@@ -171,12 +171,15 @@ families:
         deltas: ['-300', '0', '300']
         minimum: '300'
         maximum: '1500'
+      max_gross_exposure_pct_equity:
+        mode: explicit_values
+        values: ['0.50', '0.75', '1.0']
     strategy_override_mutations:
       normalization_regime:
         mode: allowed_normalizations
       max_notional_per_trade:
         mode: explicit_values
-        values: ['157950.10', '236925.15', '315900.20']
+        values: ['7500', '15000', '22500', '30000']
   - family_template_id: microbar_cross_sectional_pairs_v1
     seed_sweep_config: ../profitability-frontier-consistent-microbar-cross-sectional-pairs.yaml
     max_iterations: 2
@@ -197,12 +200,15 @@ families:
         deltas: ['-1', '0', '1']
         minimum: '1'
         maximum: '3'
+      max_gross_exposure_pct_equity:
+        mode: explicit_values
+        values: ['0.50', '0.75', '1.0']
     strategy_override_mutations:
       normalization_regime:
         mode: allowed_normalizations
       max_notional_per_trade:
         mode: explicit_values
-        values: ['157950.10', '236925.15', '315900.20']
+        values: ['7500', '15000', '22500', '30000']
   - family_template_id: intraday_tsmom_v2
     seed_sweep_config: ../profitability-frontier-strict-daily-tsmom.yaml
     max_iterations: 2
@@ -223,12 +229,15 @@ families:
         deltas: ['-0.05', '0', '0.05']
         minimum: '0.45'
         maximum: '0.75'
+      max_gross_exposure_pct_equity:
+        mode: explicit_values
+        values: ['0.50', '0.75', '1.0']
     strategy_override_mutations:
       normalization_regime:
         mode: allowed_normalizations
       max_notional_per_trade:
         mode: explicit_values
-        values: ['63180', '126360', '189540']
+        values: ['7500', '15000', '22500', '30000']
   - family_template_id: momentum_pullback_v1
     seed_sweep_config: ../profitability-frontier-strict-daily-momentum-pullback.yaml
     max_iterations: 2
@@ -249,13 +258,16 @@ families:
         deltas: ['-120', '0', '120']
         minimum: '300'
         maximum: '1200'
+      max_gross_exposure_pct_equity:
+        mode: explicit_values
+        values: ['0.50', '0.75', '1.0']
     strategy_override_mutations:
       max_notional_per_trade:
         mode: explicit_values
-        values: ['63180', '126360', '189540']
+        values: ['7500', '15000', '22500', '30000']
       max_position_pct_equity:
         mode: explicit_values
-        values: ['2.0', '4.0']
+        values: ['0.25', '0.50', '0.75', '1.0']
   - family_template_id: late_day_continuation_v1
     seed_sweep_config: ../profitability-frontier-strict-daily-late-day-continuation.yaml
     max_iterations: 2
@@ -281,13 +293,16 @@ families:
         deltas: ['-3', '0', '3']
         minimum: '8'
         maximum: '18'
+      max_gross_exposure_pct_equity:
+        mode: explicit_values
+        values: ['0.50', '0.75', '1.0']
     strategy_override_mutations:
       max_notional_per_trade:
         mode: explicit_values
-        values: ['94770', '126360', '189540']
+        values: ['7500', '15000', '22500', '30000']
       max_position_pct_equity:
         mode: explicit_values
-        values: ['3.0', '4.0']
+        values: ['0.25', '0.50', '0.75', '1.0']
   - family_template_id: end_of_day_reversal_v1
     seed_sweep_config: ../profitability-frontier-strict-daily-end-of-day-reversal.yaml
     max_iterations: 2
@@ -313,13 +328,16 @@ families:
         deltas: ['-10', '0', '10']
         minimum: '-60'
         maximum: '-20'
+      max_gross_exposure_pct_equity:
+        mode: explicit_values
+        values: ['0.50', '0.75', '1.0']
     strategy_override_mutations:
       max_notional_per_trade:
         mode: explicit_values
-        values: ['63180', '126360']
+        values: ['7500', '15000', '22500', '30000']
       max_position_pct_equity:
         mode: explicit_values
-        values: ['2.0', '4.0']
+        values: ['0.25', '0.50', '0.75', '1.0']
   - family_template_id: breakout_reclaim_v2
     seed_sweep_config: ../profitability-frontier-strict-daily-breakout-reclaim.yaml
     max_iterations: 2
@@ -340,9 +358,18 @@ families:
         deltas: ['-2', '0', '2']
         minimum: '8'
         maximum: '16'
+      max_gross_exposure_pct_equity:
+        mode: explicit_values
+        values: ['0.50', '0.75', '1.0']
     strategy_override_mutations:
       normalization_regime:
         mode: allowed_normalizations
+      max_notional_per_trade:
+        mode: explicit_values
+        values: ['7500', '15000', '22500', '30000']
+      max_position_pct_equity:
+        mode: explicit_values
+        values: ['0.25', '0.50', '0.75', '1.0']
   - family_template_id: mean_reversion_rebound_v1
     seed_sweep_config: ../profitability-frontier-strict-daily-mean-reversion.yaml
     max_iterations: 2
@@ -363,13 +390,16 @@ families:
         deltas: ['-0.05', '0', '0.05']
         minimum: '0.60'
         maximum: '0.90'
+      max_gross_exposure_pct_equity:
+        mode: explicit_values
+        values: ['0.50', '0.75', '1.0']
     strategy_override_mutations:
       max_notional_per_trade:
         mode: explicit_values
-        values: ['63180', '126360', '189540']
+        values: ['7500', '15000', '22500', '30000']
       max_position_pct_equity:
         mode: explicit_values
-        values: ['2.0', '4.0']
+        values: ['0.25', '0.50', '0.75', '1.0']
   - family_template_id: mean_reversion_exhaustion_short_v1
     seed_sweep_config: ../profitability-frontier-strict-daily-exhaustion-short.yaml
     max_iterations: 2
@@ -400,10 +430,13 @@ families:
         deltas: ['-0.05', '0', '0.05']
         minimum: '0.55'
         maximum: '0.75'
+      max_gross_exposure_pct_equity:
+        mode: explicit_values
+        values: ['0.50', '0.75', '1.0']
     strategy_override_mutations:
       max_notional_per_trade:
         mode: explicit_values
-        values: ['20000', '30000', '50000']
+        values: ['7500', '15000', '22500', '30000']
       max_position_pct_equity:
         mode: explicit_values
-        values: ['0.75', '1.0']
+        values: ['0.25', '0.50', '0.75', '1.0']

--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -48,6 +48,8 @@ from app.trading.discovery.mlx_snapshot import MlxSnapshotManifest
 from app.trading.discovery.mlx_snapshot import write_mlx_snapshot_manifest
 from app.trading.discovery.mlx_training_data import build_mlx_training_rows
 from app.trading.discovery.mlx_training_data import (
+    capital_budget_penalty,
+    candidate_spec_capital_features,
     rank_training_rows,
     rank_training_rows_with_lift_policy,
     train_mlx_ranker,
@@ -1937,7 +1939,10 @@ def _pre_replay_candidate_score(spec: CandidateSpec) -> Decimal:
         else 0
     )
     failure_penalty = Decimal(len(spec.expected_failure_modes)) * Decimal("0.25")
-    return family_score + Decimal(feature_count) - failure_penalty
+    capital_penalty = Decimal(
+        str(capital_budget_penalty(candidate_spec_capital_features(spec)))
+    )
+    return family_score + Decimal(feature_count) - failure_penalty - capital_penalty
 
 
 def _pre_replay_prior_bundle(spec: CandidateSpec) -> CandidateEvidenceBundle:
@@ -2066,6 +2071,17 @@ def _select_candidate_specs_for_replay(
         spec.candidate_spec_id: _candidate_spec_execution_signature(spec)
         for spec in specs
     }
+    capital_features_by_spec = {
+        spec.candidate_spec_id: dict(candidate_spec_capital_features(spec))
+        for spec in specs
+    }
+
+    def capital_sort_key(candidate_spec_id: str) -> tuple[int, Decimal, str]:
+        features = capital_features_by_spec.get(candidate_spec_id, {})
+        feasible = Decimal(str(features.get("capital_feasible_flag", 0)))
+        overage = Decimal(str(features.get("capital_budget_overage_ratio", 0)))
+        return (0 if feasible >= Decimal("1") else 1, overage, candidate_spec_id)
+
     max_budget = max(1, int(max_candidates))
     model_confidence = _proposal_score_confidence(proposal_rows)
     requested_exploration_slots = max(0, int(exploration_slots))
@@ -2083,6 +2099,7 @@ def _select_candidate_specs_for_replay(
         for row in sorted(
             _list_of_mappings(list(proposal_rows)),
             key=lambda row: (
+                *capital_sort_key(str(row.get("candidate_spec_id") or ""))[:2],
                 int(row.get("rank") or 10**9),
                 -float(row.get("proposal_score") or 0.0),
                 str(row.get("candidate_spec_id") or ""),
@@ -2092,7 +2109,12 @@ def _select_candidate_specs_for_replay(
     ]
     ranked_ids.extend(
         spec.candidate_spec_id
-        for spec in sorted(specs, key=lambda item: item.candidate_spec_id)
+        for spec in sorted(
+            specs,
+            key=lambda item: (
+                *capital_sort_key(item.candidate_spec_id),
+            ),
+        )
         if spec.candidate_spec_id not in set(ranked_ids)
     )
     ordered = [spec_by_id[candidate_spec_id] for candidate_spec_id in ranked_ids]
@@ -2219,6 +2241,38 @@ def _select_candidate_specs_for_replay(
             != spec.candidate_spec_id
             else None,
             "pre_replay_score": str(_pre_replay_candidate_score(spec)),
+            "capital_budget": {
+                "max_notional_per_trade": str(
+                    capital_features_by_spec[spec.candidate_spec_id][
+                        "max_notional_per_trade"
+                    ]
+                ),
+                "max_notional_pct_start_equity": str(
+                    capital_features_by_spec[spec.candidate_spec_id][
+                        "max_notional_pct_start_equity"
+                    ]
+                ),
+                "max_position_pct_equity": str(
+                    capital_features_by_spec[spec.candidate_spec_id][
+                        "max_position_pct_equity"
+                    ]
+                ),
+                "estimated_max_gross_exposure_pct_equity": str(
+                    capital_features_by_spec[spec.candidate_spec_id][
+                        "estimated_max_gross_exposure_pct_equity"
+                    ]
+                ),
+                "capital_budget_overage_ratio": str(
+                    capital_features_by_spec[spec.candidate_spec_id][
+                        "capital_budget_overage_ratio"
+                    ]
+                ),
+                "capital_feasible": bool(
+                    capital_features_by_spec[spec.candidate_spec_id][
+                        "capital_feasible_flag"
+                    ]
+                ),
+            },
             "rank": index,
             "selected_for_replay": spec.candidate_spec_id in selected_ids,
             "selection_reason": row_selection_reason(spec),
@@ -2247,6 +2301,12 @@ def _select_candidate_specs_for_replay(
             "compiled_candidate_count": len(specs),
             "unique_execution_signature_count": len(ordered_unique),
             "replay_order_policy": "diversity_pick_order",
+            "capital_feasible_candidate_count": sum(
+                1
+                for features in capital_features_by_spec.values()
+                if Decimal(str(features.get("capital_feasible_flag", 0)))
+                >= Decimal("1")
+            ),
         },
         "proposal_score_confidence": model_confidence,
         "selected_candidate_spec_ids": [item.candidate_spec_id for item in selected],

--- a/services/torghut/tests/test_candidate_specs.py
+++ b/services/torghut/tests/test_candidate_specs.py
@@ -14,6 +14,7 @@ from app.trading.discovery.hypothesis_cards import (
     HypothesisCard,
     build_hypothesis_cards,
 )
+from app.trading.discovery.mlx_training_data import candidate_spec_capital_features
 from app.trading.discovery.whitepaper_candidate_compiler import (
     compile_whitepaper_candidate_specs,
 )
@@ -108,10 +109,13 @@ class TestCandidateSpecs(TestCase):
         )
 
         continuation_profiles = sorted(
-            spec.feature_contract["execution_profile"]["profile_id"]
-            for spec in specs
-            if spec.family_template_id
-            == "microstructure_continuation_matched_filter_v1"
+            (
+                spec.feature_contract["execution_profile"]["profile_id"]
+                for spec in specs
+                if spec.family_template_id
+                == "microstructure_continuation_matched_filter_v1"
+            ),
+            key=lambda profile_id: int(str(profile_id).rsplit("-", 1)[1]),
         )
         expected_continuation_profiles = [
             f"microstructure_continuation_matched_filter_v1:profile-{index + 1}"
@@ -256,6 +260,47 @@ class TestCandidateSpecs(TestCase):
                     Decimal(str(profile["max_notional_per_trade"])),
                     Decimal("126360"),
                     family_template_id,
+                )
+
+    def test_portfolio_profit_target_adds_capital_constrained_profiles(self) -> None:
+        cards = build_hypothesis_cards(
+            source_run_id="paper-capital-realistic",
+            claims=[
+                {
+                    "claim_id": "claim-flow-capital",
+                    "claim_type": "signal_mechanism",
+                    "claim_text": "Order-flow clustering can predict short-horizon continuation.",
+                    "confidence": "0.82",
+                }
+            ],
+        )
+
+        specs = compile_candidate_specs(
+            hypothesis_cards=cards, target_net_pnl_per_day=Decimal("500")
+        )
+
+        for family_template_id in candidate_specs_module._FAMILY_RUNTIME:
+            capital_specs = [
+                spec
+                for spec in specs
+                if spec.family_template_id == family_template_id
+                and spec.strategy_overrides.get("capital_profile")
+                == "initial_equity_cash_constrained_1x"
+            ]
+            self.assertTrue(capital_specs, family_template_id)
+            for spec in capital_specs:
+                features = candidate_spec_capital_features(spec)
+                self.assertEqual(features["capital_feasible_flag"], 1.0)
+                self.assertLessEqual(
+                    Decimal(str(features["estimated_max_gross_exposure_pct_equity"])),
+                    Decimal("1.0"),
+                    spec.candidate_spec_id,
+                )
+                self.assertEqual(
+                    spec.strategy_overrides["params"][
+                        "max_gross_exposure_pct_equity"
+                    ],
+                    "1.0",
                 )
 
     def test_short_exhaustion_claim_compiles_short_sleeve_profiles(self) -> None:

--- a/services/torghut/tests/test_mlx_autoresearch.py
+++ b/services/torghut/tests/test_mlx_autoresearch.py
@@ -156,6 +156,7 @@ class TestMlxAutoresearch(TestCase):
                 },
                 "strategy_overrides": {
                     "max_notional_per_trade": ["315900.20"],
+                    "max_position_pct_equity": ["10.0"],
                     "normalization_regime": ["price_scaled"],
                 },
             },
@@ -167,7 +168,9 @@ class TestMlxAutoresearch(TestCase):
         self.assertEqual(descriptor.rank_count, 2)
         self.assertTrue(descriptor.requires_prev_day_features)
         self.assertTrue(descriptor.requires_cross_sectional_features)
-        self.assertEqual(len(descriptor_numeric_vector(descriptor)), 7)
+        self.assertFalse(descriptor.capital_feasible)
+        self.assertGreater(float(descriptor.capital_budget_overage_ratio), 0.0)
+        self.assertEqual(len(descriptor_numeric_vector(descriptor)), 12)
 
     def test_write_mlx_signal_bundle_persists_signal_rows(self) -> None:
         rows = [
@@ -458,6 +461,92 @@ class TestMlxAutoresearch(TestCase):
         )
         self.assertEqual(selected[0].selection_reason, "exploitation")
         self.assertEqual(selected[1].selection_reason, "exploration")
+
+    def test_select_proposal_batch_prefers_capital_feasible_candidates(self) -> None:
+        infeasible_descriptor = MlxCandidateDescriptor(
+            descriptor_id="desc-infeasible",
+            candidate_id="infeasible",
+            family_template_id="breakout_reclaim_v2",
+            runtime_family="breakout_continuation_consistent",
+            strategy_name="breakout-continuation-long-v1",
+            side_policy="long",
+            entry_window_start_minute=45,
+            entry_window_end_minute=75,
+            max_hold_minutes=30,
+            entry_type="breakout_reclaim",
+            exit_type="time_exit",
+            rank_policy="rank",
+            rank_count=1,
+            gross_budget_usd="315900.20",
+            per_leg_budget_usd="315900.20",
+            normalization_regime="runtime_default",
+            regime_gate_id="regime-bull",
+            requires_prev_day_features=True,
+            requires_cross_sectional_features=True,
+            requires_quote_quality_gate=True,
+            expected_fill_mode="market",
+            approval_path="scheduler_v3",
+            max_position_pct_equity="10.0",
+            estimated_max_gross_exposure_pct_equity="10.0",
+            capital_budget_overage_ratio="18.0",
+            capital_feasible=False,
+        )
+        feasible_descriptor = MlxCandidateDescriptor(
+            descriptor_id="desc-feasible",
+            candidate_id="feasible",
+            family_template_id="intraday_tsmom_v2",
+            runtime_family="intraday_tsmom_consistent",
+            strategy_name="intraday-tsmom-profit-v3",
+            side_policy="long",
+            entry_window_start_minute=45,
+            entry_window_end_minute=75,
+            max_hold_minutes=30,
+            entry_type="momentum",
+            exit_type="time_exit",
+            rank_policy="rank",
+            rank_count=1,
+            gross_budget_usd="30000",
+            per_leg_budget_usd="30000",
+            normalization_regime="runtime_default",
+            regime_gate_id="regime-bull",
+            requires_prev_day_features=True,
+            requires_cross_sectional_features=True,
+            requires_quote_quality_gate=True,
+            expected_fill_mode="market",
+            approval_path="scheduler_v3",
+            max_position_pct_equity="1.0",
+            estimated_max_gross_exposure_pct_equity="1.0",
+            capital_budget_overage_ratio="0",
+            capital_feasible=True,
+        )
+
+        selected = select_proposal_batch(
+            descriptors=[infeasible_descriptor, feasible_descriptor],
+            proposal_scores=[
+                ProposalScore(
+                    "infeasible",
+                    "desc-infeasible",
+                    1000.0,
+                    1,
+                    "numpy-fallback",
+                    "ranking_only",
+                ),
+                ProposalScore(
+                    "feasible",
+                    "desc-feasible",
+                    10.0,
+                    2,
+                    "numpy-fallback",
+                    "ranking_only",
+                ),
+            ],
+            limit=1,
+            top_k=1,
+            exploration_slots=0,
+        )
+
+        self.assertEqual(selected[0].candidate_id, "feasible")
+        self.assertTrue(selected[0].capital_feasible)
 
     def test_build_proposal_diagnostics_reports_lift_and_failure_tables(self) -> None:
         descriptors = [

--- a/services/torghut/tests/test_mlx_training_data.py
+++ b/services/torghut/tests/test_mlx_training_data.py
@@ -37,9 +37,15 @@ class TestMlxTrainingData(TestCase):
             hypothesis_cards=cards,
             target_net_pnl_per_day=Decimal("500"),
         )
+        evidenced_spec = next(
+            spec
+            for spec in specs
+            if spec.strategy_overrides.get("capital_profile")
+            == "initial_equity_cash_constrained_1x"
+        )
         bundles = [
             evidence_bundle_from_frontier_candidate(
-                candidate_spec_id=specs[0].candidate_spec_id,
+                candidate_spec_id=evidenced_spec.candidate_spec_id,
                 candidate={
                     "candidate_id": "cand-1",
                     "objective_scorecard": {
@@ -60,7 +66,7 @@ class TestMlxTrainingData(TestCase):
         self.assertEqual(len(rows), len(specs))
         self.assertEqual(model.backend, "numpy-fallback")
         self.assertEqual(ranked[0].rank, 1)
-        self.assertEqual(ranked[0].candidate_spec_id, specs[0].candidate_spec_id)
+        self.assertEqual(ranked[0].candidate_spec_id, evidenced_spec.candidate_spec_id)
 
     def test_negative_rank_bucket_lift_demotes_to_heuristic_order(self) -> None:
         rows = [
@@ -102,3 +108,65 @@ class TestMlxTrainingData(TestCase):
         self.assertLess(result.rank_bucket_lift.lift, 0)
         self.assertEqual(result.ranked_rows[0].candidate_spec_id, "aaa-strong")
         self.assertEqual(result.ranked_rows[0].score, 500.0)
+
+    def test_training_rows_penalize_capital_infeasible_specs(self) -> None:
+        cards = build_hypothesis_cards(
+            source_run_id="paper-capital-features",
+            claims=[
+                {
+                    "claim_id": "claim-capital-features",
+                    "claim_type": "signal_mechanism",
+                    "claim_text": "Order-flow clustering improves intraday continuation.",
+                    "confidence": "0.82",
+                }
+            ],
+        )
+        specs = compile_candidate_specs(
+            hypothesis_cards=cards, target_net_pnl_per_day=Decimal("500")
+        )
+        over_budget = next(
+            spec
+            for spec in specs
+            if spec.strategy_overrides.get("capital_profile")
+            != "initial_equity_cash_constrained_1x"
+        )
+        feasible = next(
+            spec
+            for spec in specs
+            if spec.strategy_overrides.get("capital_profile")
+            == "initial_equity_cash_constrained_1x"
+        )
+        bundles = [
+            evidence_bundle_from_frontier_candidate(
+                candidate_spec_id=spec.candidate_spec_id,
+                candidate={
+                    "candidate_id": f"cand-{index}",
+                    "objective_scorecard": {
+                        "net_pnl_per_day": "500",
+                        "active_day_ratio": "1.0",
+                        "positive_day_ratio": "1.0",
+                    },
+                },
+                dataset_snapshot_id="snapshot-capital",
+                result_path=f"/tmp/cand-{index}.json",
+            )
+            for index, spec in enumerate((over_budget, feasible), start=1)
+        ]
+
+        rows = build_mlx_training_rows(
+            candidate_specs=[over_budget, feasible],
+            evidence_bundles=bundles,
+        )
+        row_by_spec = {row.candidate_spec_id: row for row in rows}
+        over_payload = row_by_spec[over_budget.candidate_spec_id].to_payload()
+        feasible_payload = row_by_spec[feasible.candidate_spec_id].to_payload()
+
+        self.assertGreater(
+            over_payload["features"]["capital_budget_overage_ratio"], 0.0
+        )
+        self.assertEqual(over_payload["features"]["capital_feasible_flag"], 0.0)
+        self.assertEqual(feasible_payload["features"]["capital_feasible_flag"], 1.0)
+        self.assertLess(
+            row_by_spec[over_budget.candidate_spec_id].target,
+            row_by_spec[feasible.candidate_spec_id].target,
+        )

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -839,6 +839,10 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         )
         self.assertFalse(payload["best_false_negative_table"][0]["selected_for_replay"])
         selected_rows = [row for row in selection["rows"] if row["selected_for_replay"]]
+        self.assertGreater(selection["budget"]["capital_feasible_candidate_count"], 0)
+        self.assertTrue(
+            all(row["capital_budget"]["capital_feasible"] for row in selected_rows)
+        )
         self.assertEqual(
             {row["selection_reason"] for row in selected_rows},
             {"exploitation", "exploration", "budget_backfill"},


### PR DESCRIPTION
## Summary

- Adds capital-budget features and penalties to the Torghut MLX autoresearch ranker so over-budget, negative-cash candidates are deprioritized before replay.
- Adds capital-constrained `$500/day` candidate profiles and updates the strict `$500` research program to sweep realistic per-trade notional, position, and gross-exposure budgets.
- Records capital feasibility in candidate-selection manifests and proposal selections, with regression coverage for capital-aware ranking and replay selection.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_mlx_training_data.py tests/test_mlx_autoresearch.py tests/test_candidate_specs.py tests/test_run_whitepaper_autoresearch_profit_target.py -q`
- `cd services/torghut && uv run --frozen pytest tests/test_mlx_training_data.py tests/test_mlx_autoresearch.py tests/test_candidate_specs.py -q`
- `cd services/torghut && uv run --frozen ruff check app/trading/discovery/mlx_training_data.py app/trading/discovery/mlx_features.py app/trading/discovery/mlx_proposal_models.py app/trading/discovery/candidate_specs.py scripts/run_whitepaper_autoresearch_profit_target.py tests/test_mlx_training_data.py tests/test_mlx_autoresearch.py tests/test_candidate_specs.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
