### PR TITLE
feat(torghut): emit executable alpha repair receipts

### DIFF
--- a/docs/torghut/rollouts/2026-05-13-executable-alpha-repair-receipts.md
+++ b/docs/torghut/rollouts/2026-05-13-executable-alpha-repair-receipts.md
@@ -1,0 +1,83 @@
+# 2026-05-13 Torghut Executable Alpha Repair Receipts
+
+## Scope
+
+This rollout note covers the compact zero-notional executable-alpha repair receipt projection for the Torghut quant
+repair loop.
+
+Governing design references:
+
+- `docs/torghut/design-system/current-source-of-truth-and-priority-guide-2026-03-09.md`
+- `docs/torghut/design-system/v6/197-torghut-executable-alpha-repair-receipts-and-zero-notional-reentry-2026-05-13.md`
+- `docs/torghut/design-system/v6/197-torghut-alpha-readiness-strike-ledger-and-routeable-candidate-ladder-2026-05-13.md`
+
+## Runtime Evidence Before Change
+
+Read-only source: `GET http://torghut.torghut.svc.cluster.local/trading/revenue-repair` on 2026-05-13.
+
+- `business_state=repair_only`
+- `revenue_ready=false`
+- top `repair_queue` item: `repair_alpha_readiness` / `alpha_readiness_not_promotion_eligible`
+- selected value gate: `routeable_candidate_count`
+- `routeable_candidate_count=0`
+- `zero_notional_or_stale_evidence_rate=1.0`
+- capital remained `zero_notional` with `max_notional=0`
+- live submission remained disabled by `simple_submit_disabled`
+
+The endpoint already selected the right business blocker, but the alpha-readiness work item was still spread across
+the queue row, capital replay board, executable-alpha candidate receipts, and nested alpha target evidence. Jangar
+needed a compact repair receipt that names the target, repair class, expected blocker delta, validation command, and
+no-delta settlement requirement without widening capital.
+
+## Shipped Change
+
+- `services/torghut/app/trading/executable_alpha_receipts.py` now builds
+  `torghut.executable-alpha-repair-receipts.v1` collections and selected
+  `torghut.executable-alpha-repair-receipt.v1` receipts when the top revenue-repair queue item is
+  `repair_alpha_readiness`.
+- The builder maps current alpha blockers to repair classes: strategy lineage repair, evidence-window refresh,
+  autoresearch portfolio repair, equity TA refill, rejection drag measurement, promotion decision receipt, and capital
+  replay board refresh.
+- Each receipt carries `max_notional=0`, `capital_rule=zero_notional_repair_only`, required input refs, required output
+  receipts, validation commands, Jangar material-reentry binding, and `no_delta_settlement_required=true`.
+- `/trading/revenue-repair` exposes the compact collection as `executable_alpha_repair_receipts`.
+- `/trading/consumer-evidence` mirrors the same compact collection for Jangar while keeping readiness and capital gates
+  unchanged.
+
+## Validation
+
+Initial targeted validation:
+
+```bash
+cd services/torghut
+uv sync --frozen --extra dev
+uv run --frozen pytest tests/test_executable_alpha_repair_receipts.py tests/test_build_revenue_repair_digest.py -k "executable_alpha or repair_only_payload"
+```
+
+Result: `5 passed`, `13 deselected`, with the existing event-loop deprecation warning from `tests/conftest.py`.
+
+Broader local validation:
+
+- `uv lock --check`: pass
+- `uv run --frozen ruff format --check app/trading/executable_alpha_receipts.py app/trading/revenue_repair.py app/main.py tests/test_executable_alpha_repair_receipts.py tests/test_build_revenue_repair_digest.py tests/test_trading_api.py`: pass
+- `uv run --frozen ruff check app tests scripts migrations`: pass
+- `uv run --frozen python scripts/check_migration_graph.py`: pass
+- `uv run --frozen python -m compileall app`: pass
+- `uv run --frozen pyright --project pyrightconfig.json`: pass
+- `uv run --frozen pyright --project pyrightconfig.alpha.json`: pass
+- `uv run --frozen pyright --project pyrightconfig.scripts.json`: pass
+- `uv run --frozen pytest --cov --cov-branch --cov-report=term-missing --cov-report=xml`: pass, `2275 passed`,
+  total coverage `79.02%`
+
+## Risk And Rollback
+
+Risk is limited to additive evidence payload fields on `/trading/revenue-repair` and `/trading/consumer-evidence`.
+The change does not alter submission gates, notional sizing, repair execution, database state, broker state, or
+GitOps manifests. Roll back by reverting the PR or suppressing the `executable_alpha_repair_receipts` projection;
+existing revenue-repair queue, strike ledger, repair-bid settlement, and capital holds remain intact.
+
+## Owner-Facing Status
+
+This improves `routeable_candidate_count` readiness by turning the current top alpha-readiness queue item into a
+compact zero-notional repair receipt with explicit no-delta accounting. It does not make Torghut revenue-ready by
+itself: live submission remains disabled until alpha readiness, proof-floor, routeability, TCA, and capital gates pass.

--- a/services/torghut/README.md
+++ b/services/torghut/README.md
@@ -199,6 +199,12 @@ Testing rules for the trading core:
   `required_output_receipt=torghut.executable-alpha-receipts.v1`, `max_notional=0`, the current capital replay board,
   and candidate executable-alpha receipts so the alpha-readiness repair is dispatchable as zero-notional evidence
   instead of a generic capital-unblock instruction.
+- `GET /trading/revenue-repair` also emits the May 13 doc 197
+  `torghut.executable-alpha-repair-receipts.v1` compact receipt collection. When the live queue is topped by
+  `repair_alpha_readiness`, it selects zero-notional `torghut.executable-alpha-repair-receipt.v1` work for the
+  concrete alpha repair target, maps target reason codes to a repair class, carries validation commands and
+  no-delta settlement requirements, and keeps `max_notional=0`. `/trading/consumer-evidence` mirrors the same compact
+  collection for Jangar without making `/readyz` green or enabling paper/live submission.
 - `GET /trading/status` and `GET /readyz` now include the May 8 doc 181
   `quality_adjusted_profit_frontier` shadow projection. The reducer ranks zero-notional repair packets from quant
   quality, market-context risk flags, route/TCA state, simulation-cache freshness, and Jangar evidence-quality refs

--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -3117,6 +3117,9 @@ def _build_trading_consumer_evidence_payload() -> dict[str, object]:
             "capital_replay_board": capital_replay_projection.get(
                 "capital_replay_board"
             ),
+            "executable_alpha_receipts": capital_replay_projection.get(
+                "executable_alpha_receipts"
+            ),
         },
         generated_at=datetime.now(timezone.utc),
     )
@@ -3261,6 +3264,9 @@ def _build_trading_consumer_evidence_payload() -> dict[str, object]:
         "repair_bid_settlement_ledger": repair_bid_settlement_ledger,
         "alpha_readiness_strike_ledger": revenue_repair_digest.get(
             "alpha_readiness_strike_ledger"
+        ),
+        "executable_alpha_repair_receipts": revenue_repair_digest.get(
+            "executable_alpha_repair_receipts"
         ),
         "route_warrant_exchange": route_warrant_exchange,
         "source_serving_repair_receipt_ledger": source_serving_repair_receipt_ledger,

--- a/services/torghut/app/trading/executable_alpha_receipts.py
+++ b/services/torghut/app/trading/executable_alpha_receipts.py
@@ -11,6 +11,20 @@ from typing import Any, Literal, cast
 
 CAPITAL_REPLAY_BOARD_SCHEMA_VERSION = "torghut.capital-replay-board.v1"
 EXECUTABLE_ALPHA_RECEIPTS_SCHEMA_VERSION = "torghut.executable-alpha-receipts.v1"
+EXECUTABLE_ALPHA_REPAIR_RECEIPT_SCHEMA_VERSION = (
+    "torghut.executable-alpha-repair-receipt.v1"
+)
+EXECUTABLE_ALPHA_REPAIR_RECEIPTS_SCHEMA_VERSION = (
+    "torghut.executable-alpha-repair-receipts.v1"
+)
+
+_EXECUTABLE_ALPHA_REPAIR_DESIGN_REF = (
+    "docs/torghut/design-system/v6/"
+    "197-torghut-executable-alpha-repair-receipts-and-zero-notional-reentry-2026-05-13.md"
+)
+_EXECUTABLE_ALPHA_REPAIR_ROLLBACK_TARGET = (
+    "stop emitting executable_alpha_repair_receipts and keep Torghut max_notional=0"
+)
 
 GraduationState = Literal[
     "candidate",
@@ -26,6 +40,80 @@ _DEFAULT_FRESHNESS_SECONDS = 15 * 60
 _LIVE_AAPL_HYPOTHESIS = "H-AAPL-ROUTE-REHAB"
 _SIM_NVDA_HYPOTHESIS = "H-NVDA-SIM-PROOF-REFILL"
 _BREADTH_HYPOTHESIS = "H-MEGACAP-BREADTH-PROBE"
+_REPAIR_REASON_CLASSES = (
+    (
+        "strategy_lineage_repair",
+        {
+            "strategy_hypothesis_missing",
+            "strategy_lineage_missing",
+            "schema_lineage_missing",
+        },
+    ),
+    (
+        "evidence_window_refresh",
+        {
+            "hypothesis_window_evidence_missing",
+            "hypothesis_window_evidence_stale",
+            "drift_checks_missing",
+            "feature_rows_missing",
+            "required_feature_set_unavailable",
+            "closed_session_market_context_hold",
+            "closed_session_signal_hold",
+            "closed_session_tca_evidence_hold",
+        },
+    ),
+    (
+        "autoresearch_portfolio_repair",
+        {
+            "autoresearch_portfolio_candidates_blocked",
+            "autoresearch_portfolio_ready_empty",
+        },
+    ),
+    ("equity_ta_refill", {"equity_ta_rows_missing"}),
+    ("rejection_drag_measurement", {"rejection_drag_unmeasured"}),
+    (
+        "promotion_decision_receipt",
+        {
+            "alpha_readiness_not_promotion_eligible",
+            "hypothesis_not_promotion_eligible",
+            "promotion_decision_missing",
+            "post_cost_expectancy_non_positive",
+        },
+    ),
+)
+_REPAIR_CLASS_RANK = {
+    "strategy_lineage_repair": 0,
+    "evidence_window_refresh": 1,
+    "autoresearch_portfolio_repair": 2,
+    "equity_ta_refill": 3,
+    "rejection_drag_measurement": 4,
+    "promotion_decision_receipt": 5,
+    "capital_replay_board_refresh": 6,
+}
+_VALIDATION_COMMANDS_BY_CLASS = {
+    "strategy_lineage_repair": [
+        "uv run --frozen pytest services/torghut/tests/test_profitability_proof_floor.py -k alpha",
+        "uv run --frozen pytest services/torghut/tests/test_executable_alpha_repair_receipts.py -k lineage",
+    ],
+    "evidence_window_refresh": [
+        "uv run --frozen pytest services/torghut/tests/test_executable_alpha_repair_receipts.py -k evidence_window",
+    ],
+    "autoresearch_portfolio_repair": [
+        "uv run --frozen pytest services/torghut/tests/test_executable_alpha_repair_receipts.py -k autoresearch",
+    ],
+    "equity_ta_refill": [
+        "uv run --frozen pytest services/torghut/tests/test_executable_alpha_repair_receipts.py -k equity_ta",
+    ],
+    "rejection_drag_measurement": [
+        "uv run --frozen pytest services/torghut/tests/test_executable_alpha_repair_receipts.py -k rejection_drag",
+    ],
+    "promotion_decision_receipt": [
+        "uv run --frozen pytest services/torghut/tests/test_executable_alpha_repair_receipts.py -k promotion",
+    ],
+    "capital_replay_board_refresh": [
+        "uv run --frozen pytest services/torghut/tests/test_executable_alpha_repair_receipts.py",
+    ],
+}
 
 
 def _text(value: object, default: str = "") -> str:
@@ -139,6 +227,356 @@ def _proof_window(
         "fresh_until": fresh_until,
         "route_state": _text(proof_floor_receipt.get("route_state"), "unknown"),
         "capital_state": _text(proof_floor_receipt.get("capital_state"), "unknown"),
+    }
+
+
+def _reason_list_from_target(target: Mapping[str, Any]) -> list[str]:
+    return _string_list(target.get("reasons")) + _string_list(
+        target.get("informational_reasons")
+    )
+
+
+def _repair_class_for_target(
+    target: Mapping[str, Any],
+) -> tuple[str, list[str], str, str, str]:
+    reason_codes = _reason_list_from_target(target)
+    reason_set = set(reason_codes)
+    candidate_id = _text(target.get("candidate_id"))
+    strategy_id = _text(target.get("strategy_id"))
+
+    if not candidate_id or not strategy_id:
+        repair_class = "strategy_lineage_repair"
+    else:
+        repair_class = "capital_replay_board_refresh"
+        for candidate_class, reasons in _REPAIR_REASON_CLASSES:
+            if reason_set.intersection(reasons):
+                repair_class = candidate_class
+                break
+
+    lineage_status = "missing" if repair_class == "strategy_lineage_repair" else "ready"
+    if {"lineage_contradictory", "strategy_lineage_contradictory"}.intersection(
+        reason_set
+    ):
+        lineage_status = "contradictory"
+    elif "schema_lineage_missing" in reason_set:
+        lineage_status = "missing"
+
+    if {
+        "hypothesis_window_evidence_missing",
+        "feature_rows_missing",
+        "required_feature_set_unavailable",
+    }.intersection(reason_set):
+        evidence_window_status = "missing"
+    elif {
+        "hypothesis_window_evidence_stale",
+        "drift_checks_missing",
+        "closed_session_market_context_hold",
+        "closed_session_signal_hold",
+        "closed_session_tca_evidence_hold",
+    }.intersection(reason_set):
+        evidence_window_status = "stale"
+    else:
+        evidence_window_status = "current"
+
+    state = _text(target.get("state"), "repair_only")
+    alpha_readiness_state = (
+        "promotion_candidate"
+        if bool(target.get("promotion_eligible"))
+        else state or "repair_only"
+    )
+    if alpha_readiness_state == "shadow" and reason_codes:
+        alpha_readiness_state = "blocked"
+
+    return (
+        repair_class,
+        reason_codes,
+        lineage_status,
+        evidence_window_status,
+        alpha_readiness_state,
+    )
+
+
+def _top_alpha_repair(top_blocker: Mapping[str, Any]) -> bool:
+    return (
+        _text(top_blocker.get("code")) == "repair_alpha_readiness"
+        or _text(top_blocker.get("reason")) == "alpha_readiness_not_promotion_eligible"
+    )
+
+
+def _receipt_by_hypothesis(
+    executable_alpha_receipts: Mapping[str, Any],
+) -> dict[str, Mapping[str, Any]]:
+    by_hypothesis: dict[str, Mapping[str, Any]] = {}
+    for raw_receipt in [
+        *_sequence(executable_alpha_receipts.get("receipts")),
+        *_sequence(executable_alpha_receipts.get("candidate_receipts")),
+    ]:
+        receipt = _mapping(raw_receipt)
+        hypothesis_id = _text(receipt.get("hypothesis_id"))
+        if hypothesis_id and hypothesis_id not in by_hypothesis:
+            by_hypothesis[hypothesis_id] = receipt
+    return by_hypothesis
+
+
+def _targets_from_alpha_readiness(
+    alpha_readiness: Mapping[str, Any],
+) -> list[Mapping[str, Any]]:
+    targets: list[Mapping[str, Any]] = [
+        _mapping(item) for item in _sequence(alpha_readiness.get("repair_targets"))
+    ]
+    targets = [target for target in targets if target]
+    if targets:
+        return targets
+    targets = []
+    for raw_hypothesis_id in _sequence(alpha_readiness.get("blocked_hypothesis_ids")):
+        hypothesis_id = _text(raw_hypothesis_id)
+        if hypothesis_id:
+            targets.append(
+                {
+                    "hypothesis_id": hypothesis_id,
+                    "state": "blocked",
+                    "promotion_eligible": False,
+                    "reasons": ["alpha_readiness_not_promotion_eligible"],
+                }
+            )
+    return targets
+
+
+def _expected_gate_delta(reason_codes: Sequence[str]) -> str:
+    for reason in reason_codes:
+        if reason:
+            return f"retire_{reason}"
+    return "retire_alpha_readiness_not_promotion_eligible"
+
+
+def _required_input_refs(
+    *,
+    source_revenue_repair_ref: str,
+    repair_bid_settlement_ledger: Mapping[str, Any],
+    capital_replay_board: Mapping[str, Any],
+    executable_alpha_receipt: Mapping[str, Any],
+) -> list[str]:
+    refs = [source_revenue_repair_ref]
+    for value in (
+        repair_bid_settlement_ledger.get("ledger_id"),
+        capital_replay_board.get("board_id"),
+        executable_alpha_receipt.get("receipt_id"),
+    ):
+        text = _text(value)
+        if text:
+            refs.append(text)
+    return _string_list(refs)
+
+
+def _receipt_target_key(receipt: Mapping[str, Any]) -> tuple[int, str]:
+    return (
+        _REPAIR_CLASS_RANK.get(_text(receipt.get("repair_class")), 100),
+        _text(receipt.get("hypothesis_id")),
+    )
+
+
+def _executable_alpha_repair_receipt(
+    *,
+    generated_at: datetime,
+    fresh_until: datetime,
+    source_revenue_repair_ref: str,
+    top_blocker: Mapping[str, Any],
+    target: Mapping[str, Any],
+    repair_bid_settlement_ledger: Mapping[str, Any],
+    capital_replay_board: Mapping[str, Any],
+    executable_alpha_receipt: Mapping[str, Any],
+    routeable_candidate_count_before: int,
+) -> dict[str, object]:
+    (
+        repair_class,
+        reason_codes,
+        lineage_status,
+        evidence_window_status,
+        alpha_readiness_state,
+    ) = _repair_class_for_target(target)
+    hypothesis_id = _text(target.get("hypothesis_id"), "unknown")
+    candidate_id = _text(target.get("candidate_id")) or None
+    strategy_id = _text(target.get("strategy_id")) or None
+    target_value_gate = _text(
+        top_blocker.get("value_gate"), "routeable_candidate_count"
+    )
+    expected_unblock_value = _int(top_blocker.get("expected_unblock_value"), 1)
+    payload_for_id = {
+        "schema_version": EXECUTABLE_ALPHA_REPAIR_RECEIPT_SCHEMA_VERSION,
+        "source_revenue_repair_ref": source_revenue_repair_ref,
+        "hypothesis_id": hypothesis_id,
+        "repair_class": repair_class,
+        "target_value_gate": target_value_gate,
+        "reason_codes": reason_codes,
+    }
+    validation_commands = _VALIDATION_COMMANDS_BY_CLASS.get(
+        repair_class, _VALIDATION_COMMANDS_BY_CLASS["capital_replay_board_refresh"]
+    )
+    required_output_receipts = _string_list(
+        [
+            _text(
+                top_blocker.get("required_output_receipt"),
+                EXECUTABLE_ALPHA_RECEIPTS_SCHEMA_VERSION,
+            ),
+            *_string_list(top_blocker.get("required_receipts")),
+        ]
+    )
+    return {
+        **payload_for_id,
+        "receipt_id": "executable-alpha-repair-receipt:"
+        + _stable_hash("executable-alpha-repair-receipt", payload_for_id),
+        "generated_at": generated_at.isoformat(),
+        "fresh_until": fresh_until.isoformat(),
+        "account_id": _text(repair_bid_settlement_ledger.get("account_id"), "unknown"),
+        "window": _text(repair_bid_settlement_ledger.get("session_id"), "unknown"),
+        "trading_mode": _text(
+            repair_bid_settlement_ledger.get("trading_mode"), "unknown"
+        ),
+        "candidate_id": candidate_id,
+        "strategy_id": strategy_id,
+        "lineage_status": lineage_status,
+        "evidence_window_status": evidence_window_status,
+        "alpha_readiness_state": alpha_readiness_state,
+        "repair_class": repair_class,
+        "target_value_gate": target_value_gate,
+        "expected_unblock_value": expected_unblock_value,
+        "expected_gate_delta": _expected_gate_delta(reason_codes),
+        "required_input_refs": _required_input_refs(
+            source_revenue_repair_ref=source_revenue_repair_ref,
+            repair_bid_settlement_ledger=repair_bid_settlement_ledger,
+            capital_replay_board=capital_replay_board,
+            executable_alpha_receipt=executable_alpha_receipt,
+        ),
+        "required_output_receipts": required_output_receipts,
+        "validation_commands": validation_commands,
+        "max_notional": "0",
+        "capital_rule": "zero_notional_repair_only",
+        "no_delta_settlement_required": True,
+        "settlement": {
+            "state": "pending",
+            "allowed_outcomes": ["retired", "improved", "no_delta", "invalidated"],
+            "before_reason_codes": reason_codes,
+            "before_value_gate": {
+                "routeable_candidate_count": routeable_candidate_count_before
+            },
+        },
+        "jangar_reentry": {
+            "governing_design_ref": _EXECUTABLE_ALPHA_REPAIR_DESIGN_REF,
+            "required_material_reentry_receipt": "jangar.material-reentry-receipt.v1",
+            "action_class": "dispatch_repair",
+            "max_parallelism": 1,
+            "max_runtime_seconds": 1200,
+            "value_gates": [target_value_gate],
+            "rollback_target": "keep max_notional=0 and live submit disabled",
+        },
+        "rollback_target": _EXECUTABLE_ALPHA_REPAIR_ROLLBACK_TARGET,
+    }
+
+
+def build_executable_alpha_repair_receipts(
+    *,
+    generated_at: datetime,
+    business_state: str,
+    revenue_ready: bool,
+    repair_queue: Sequence[Mapping[str, Any]],
+    alpha_readiness: Mapping[str, Any],
+    capital: Mapping[str, Any],
+    repair_bid_settlement_ledger: Mapping[str, Any],
+) -> dict[str, object]:
+    """Build compact zero-notional receipts for the active alpha-readiness repair."""
+
+    generated = generated_at.astimezone(timezone.utc)
+    fresh_until = generated + timedelta(seconds=_DEFAULT_FRESHNESS_SECONDS)
+    top_blocker: Mapping[str, Any] = repair_queue[0] if repair_queue else {}
+    source_revenue_repair_ref = "torghut-revenue-repair-digest:" + _stable_hash(
+        "torghut-revenue-repair-digest",
+        {
+            "generated_at": generated.isoformat(),
+            "top_blocker": dict(top_blocker),
+            "business_state": business_state,
+            "repair_bid_settlement_ledger_id": repair_bid_settlement_ledger.get(
+                "ledger_id"
+            ),
+        },
+    )
+
+    reason_codes: list[str] = []
+    if revenue_ready:
+        reason_codes.append("revenue_already_ready")
+    if business_state != "repair_only":
+        reason_codes.append(f"business_state_{business_state or 'unknown'}")
+    if not _top_alpha_repair(top_blocker):
+        reason_codes.append("revenue_repair_top_item_not_alpha_readiness")
+    if _text(capital.get("max_notional"), "0") not in {"0", "0.0", "0.00"}:
+        reason_codes.append("capital_notional_nonzero")
+    if _text(repair_bid_settlement_ledger.get("max_notional"), "0") not in {
+        "0",
+        "0.0",
+        "0.00",
+    }:
+        reason_codes.append("repair_bid_settlement_notional_nonzero")
+
+    capital_replay_board = _mapping(alpha_readiness.get("capital_replay_board"))
+    executable_alpha_receipts = _mapping(
+        alpha_readiness.get("executable_alpha_receipts")
+    )
+    receipts_by_hypothesis = _receipt_by_hypothesis(executable_alpha_receipts)
+    routeable_candidate_count_before = _int(
+        repair_bid_settlement_ledger.get("routeable_candidate_count")
+    )
+
+    receipts: list[dict[str, object]] = []
+    if not reason_codes:
+        for target in _targets_from_alpha_readiness(alpha_readiness)[:5]:
+            hypothesis_id = _text(target.get("hypothesis_id"))
+            receipts.append(
+                _executable_alpha_repair_receipt(
+                    generated_at=generated,
+                    fresh_until=fresh_until,
+                    source_revenue_repair_ref=source_revenue_repair_ref,
+                    top_blocker=top_blocker,
+                    target=target,
+                    repair_bid_settlement_ledger=repair_bid_settlement_ledger,
+                    capital_replay_board=capital_replay_board,
+                    executable_alpha_receipt=receipts_by_hypothesis.get(
+                        hypothesis_id, {}
+                    ),
+                    routeable_candidate_count_before=routeable_candidate_count_before,
+                )
+            )
+        receipts.sort(key=_receipt_target_key)
+        if not receipts:
+            reason_codes.append("alpha_readiness_repair_targets_missing")
+
+    selected_receipt = receipts[0] if receipts and not reason_codes else None
+    if any(reason.endswith("_nonzero") for reason in reason_codes):
+        status = "blocked"
+    elif selected_receipt:
+        status = "selected"
+    elif _top_alpha_repair(top_blocker):
+        status = "held"
+    else:
+        status = "inactive"
+
+    return {
+        "schema_version": EXECUTABLE_ALPHA_REPAIR_RECEIPTS_SCHEMA_VERSION,
+        "generated_at": generated.isoformat(),
+        "fresh_until": fresh_until.isoformat(),
+        "source_revenue_repair_ref": source_revenue_repair_ref,
+        "status": status,
+        "governing_design_ref": _EXECUTABLE_ALPHA_REPAIR_DESIGN_REF,
+        "selected_receipt_id": selected_receipt.get("receipt_id")
+        if selected_receipt
+        else None,
+        "selected_receipt": selected_receipt,
+        "receipt_count": len(receipts),
+        "receipts": receipts,
+        "target_value_gate": _text(top_blocker.get("value_gate")),
+        "routeable_candidate_count_before": routeable_candidate_count_before,
+        "max_notional": "0",
+        "capital_rule": "zero_notional_repair_only",
+        "reason_codes": reason_codes,
+        "rollback_target": _EXECUTABLE_ALPHA_REPAIR_ROLLBACK_TARGET,
     }
 
 
@@ -701,5 +1139,8 @@ def build_capital_replay_projection(
 __all__ = [
     "CAPITAL_REPLAY_BOARD_SCHEMA_VERSION",
     "EXECUTABLE_ALPHA_RECEIPTS_SCHEMA_VERSION",
+    "EXECUTABLE_ALPHA_REPAIR_RECEIPT_SCHEMA_VERSION",
+    "EXECUTABLE_ALPHA_REPAIR_RECEIPTS_SCHEMA_VERSION",
     "build_capital_replay_projection",
+    "build_executable_alpha_repair_receipts",
 ]

--- a/services/torghut/app/trading/revenue_repair.py
+++ b/services/torghut/app/trading/revenue_repair.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any, Mapping, Sequence, cast
 
 from .alpha_readiness_strike_ledger import build_alpha_readiness_strike_ledger
+from .executable_alpha_receipts import build_executable_alpha_repair_receipts
 
 
 SCHEMA_VERSION = "torghut.revenue-repair-digest.v1"
@@ -922,6 +923,15 @@ def build_revenue_repair_digest(
         capital=capital,
         evidence=evidence,
     )
+    executable_alpha_repair_receipts = build_executable_alpha_repair_receipts(
+        generated_at=generated,
+        business_state=business_state,
+        revenue_ready=revenue_ready,
+        repair_queue=cast(Sequence[Mapping[str, Any]], repair_queue),
+        alpha_readiness=alpha,
+        capital=capital,
+        repair_bid_settlement_ledger=repair_bid_settlement,
+    )
     return {
         "schema_version": SCHEMA_VERSION,
         "generated_at": generated.isoformat(),
@@ -931,6 +941,7 @@ def build_revenue_repair_digest(
         "route_evidence_clearinghouse_packet": dict(route_evidence_clearinghouse),
         "repair_bid_settlement_ledger": dict(repair_bid_settlement),
         "alpha_readiness_strike_ledger": alpha_readiness_strike_ledger,
+        "executable_alpha_repair_receipts": executable_alpha_repair_receipts,
         "business_state": business_state,
         "revenue_ready": revenue_ready,
         "health": {

--- a/services/torghut/tests/test_build_revenue_repair_digest.py
+++ b/services/torghut/tests/test_build_revenue_repair_digest.py
@@ -389,6 +389,33 @@ class TestBuildRevenueRepairDigest(TestCase):
             {"paper_canary", "live_micro_canary", "live_scale"},
         )
         self.assertIn("max_notional=0", strike_ledger["rollback_target"])
+        repair_receipts = digest["executable_alpha_repair_receipts"]
+        self.assertIsInstance(repair_receipts, dict)
+        self.assertEqual(
+            repair_receipts["schema_version"],
+            "torghut.executable-alpha-repair-receipts.v1",
+        )
+        self.assertEqual(repair_receipts["status"], "selected")
+        self.assertEqual(
+            repair_receipts["target_value_gate"], "routeable_candidate_count"
+        )
+        self.assertEqual(repair_receipts["max_notional"], "0")
+        selected_repair_receipt = repair_receipts["selected_receipt"]
+        self.assertIsInstance(selected_repair_receipt, dict)
+        self.assertEqual(
+            selected_repair_receipt["schema_version"],
+            "torghut.executable-alpha-repair-receipt.v1",
+        )
+        self.assertEqual(
+            selected_repair_receipt["hypothesis_id"],
+            "H-AAPL-ROUTE-REHAB",
+        )
+        self.assertEqual(
+            selected_repair_receipt["target_value_gate"],
+            "routeable_candidate_count",
+        )
+        self.assertEqual(selected_repair_receipt["max_notional"], "0")
+        self.assertTrue(selected_repair_receipt["no_delta_settlement_required"])
         self.assertEqual(repair_queue[1]["code"], "repair_execution_tca")
         self.assertNotIn("repair_repair_only", [item["code"] for item in repair_queue])
         self.assertIn(

--- a/services/torghut/tests/test_executable_alpha_repair_receipts.py
+++ b/services/torghut/tests/test_executable_alpha_repair_receipts.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import datetime, timezone
+from typing import Any, cast
+
+from app.trading.executable_alpha_receipts import (
+    build_executable_alpha_repair_receipts,
+)
+
+
+NOW = datetime(2026, 5, 13, 22, 55, tzinfo=timezone.utc)
+
+
+def _top_alpha_queue() -> list[dict[str, object]]:
+    return [
+        {
+            "code": "repair_alpha_readiness",
+            "reason": "alpha_readiness_not_promotion_eligible",
+            "dimension": "alpha_readiness",
+            "priority": 70,
+            "expected_unblock_value": 4,
+            "value_gate": "routeable_candidate_count",
+            "required_output_receipt": "torghut.executable-alpha-receipts.v1",
+            "required_receipts": [
+                "alpha_readiness_receipt",
+                "hypothesis_promotion_receipt",
+                "capital_replay_board",
+            ],
+            "max_notional": "0",
+            "capital_rule": "zero_notional_repair_only",
+        }
+    ]
+
+
+def _settlement_ledger() -> dict[str, object]:
+    return {
+        "schema_version": "torghut.repair-bid-settlement-ledger.v1",
+        "ledger_id": "repair-bid-settlement-ledger:test",
+        "account_id": "PA3SX7FYNUTF",
+        "session_id": "15m",
+        "trading_mode": "live",
+        "max_notional": "0",
+        "routeable_candidate_count": 0,
+    }
+
+
+def _alpha_readiness() -> dict[str, object]:
+    return {
+        "promotion_eligible_total": 0,
+        "repair_target_count": 5,
+        "capital_replay_board": {
+            "schema_version": "torghut.capital-replay-board.v1",
+            "board_id": "capital-replay:test",
+        },
+        "executable_alpha_receipts": {
+            "schema_version": "torghut.executable-alpha-receipts.v1",
+            "candidate_receipts": [
+                {
+                    "receipt_id": "receipt:stale",
+                    "hypothesis_id": "H-STALE",
+                    "max_notional": "0",
+                }
+            ],
+        },
+        "repair_targets": [
+            {
+                "hypothesis_id": "H-STALE",
+                "candidate_id": "candidate-stale",
+                "strategy_id": "strategy-stale",
+                "state": "shadow",
+                "promotion_eligible": False,
+                "reasons": ["hypothesis_window_evidence_stale"],
+            },
+            {
+                "hypothesis_id": "H-LINEAGE",
+                "state": "shadow",
+                "promotion_eligible": False,
+                "reasons": ["alpha_readiness_not_promotion_eligible"],
+            },
+            {
+                "hypothesis_id": "H-PORTFOLIO",
+                "candidate_id": "candidate-portfolio",
+                "strategy_id": "strategy-portfolio",
+                "state": "blocked",
+                "promotion_eligible": False,
+                "reasons": ["autoresearch_portfolio_candidates_blocked"],
+            },
+            {
+                "hypothesis_id": "H-TA",
+                "candidate_id": "candidate-ta",
+                "strategy_id": "strategy-ta",
+                "state": "blocked",
+                "promotion_eligible": False,
+                "reasons": ["equity_ta_rows_missing"],
+            },
+            {
+                "hypothesis_id": "H-DRAG",
+                "candidate_id": "candidate-drag",
+                "strategy_id": "strategy-drag",
+                "state": "blocked",
+                "promotion_eligible": False,
+                "reasons": ["rejection_drag_unmeasured"],
+            },
+        ],
+    }
+
+
+def _build(
+    *,
+    alpha_readiness: Mapping[str, Any] | None = None,
+    repair_queue: list[dict[str, object]] | None = None,
+    capital: Mapping[str, Any] | None = None,
+) -> dict[str, object]:
+    return build_executable_alpha_repair_receipts(
+        generated_at=NOW,
+        business_state="repair_only",
+        revenue_ready=False,
+        repair_queue=repair_queue or _top_alpha_queue(),
+        alpha_readiness=alpha_readiness or _alpha_readiness(),
+        capital=capital or {"max_notional": "0"},
+        repair_bid_settlement_ledger=_settlement_ledger(),
+    )
+
+
+def test_alpha_readiness_top_queue_selects_zero_notional_lineage_receipt() -> None:
+    payload = _build()
+
+    assert payload["schema_version"] == "torghut.executable-alpha-repair-receipts.v1"
+    assert payload["status"] == "selected"
+    assert payload["target_value_gate"] == "routeable_candidate_count"
+    assert payload["max_notional"] == "0"
+    assert payload["capital_rule"] == "zero_notional_repair_only"
+    assert payload["reason_codes"] == []
+    selected = cast(Mapping[str, Any], payload["selected_receipt"])
+    assert selected["schema_version"] == "torghut.executable-alpha-repair-receipt.v1"
+    assert selected["hypothesis_id"] == "H-LINEAGE"
+    assert selected["repair_class"] == "strategy_lineage_repair"
+    assert selected["lineage_status"] == "missing"
+    assert selected["target_value_gate"] == "routeable_candidate_count"
+    assert selected["max_notional"] == "0"
+    assert selected["capital_rule"] == "zero_notional_repair_only"
+    assert selected["no_delta_settlement_required"] is True
+    assert selected["validation_commands"]
+    assert selected["jangar_reentry"]["max_parallelism"] == 1
+    receipts = cast(list[Mapping[str, Any]], payload["receipts"])
+    assert "receipt:stale" in cast(list[str], receipts[1]["required_input_refs"])
+
+
+def test_reason_codes_map_to_executable_alpha_repair_classes() -> None:
+    payload = _build()
+    receipts = cast(list[Mapping[str, Any]], payload["receipts"])
+
+    classes_by_hypothesis = {
+        str(receipt["hypothesis_id"]): receipt["repair_class"] for receipt in receipts
+    }
+
+    assert classes_by_hypothesis == {
+        "H-LINEAGE": "strategy_lineage_repair",
+        "H-STALE": "evidence_window_refresh",
+        "H-PORTFOLIO": "autoresearch_portfolio_repair",
+        "H-TA": "equity_ta_refill",
+        "H-DRAG": "rejection_drag_measurement",
+    }
+    stale = next(
+        receipt for receipt in receipts if receipt["hypothesis_id"] == "H-STALE"
+    )
+    assert stale["evidence_window_status"] == "stale"
+    assert stale["expected_gate_delta"] == "retire_hypothesis_window_evidence_stale"
+    assert stale["settlement"]["allowed_outcomes"] == [
+        "retired",
+        "improved",
+        "no_delta",
+        "invalidated",
+    ]
+
+
+def test_receipts_hold_when_alpha_readiness_is_not_top_queue_item() -> None:
+    payload = _build(
+        repair_queue=[
+            {
+                "code": "repair_execution_tca",
+                "reason": "execution_tca_stale",
+                "value_gate": "fill_tca_or_slippage_quality",
+            }
+        ]
+    )
+
+    assert payload["status"] == "inactive"
+    assert payload["selected_receipt"] is None
+    assert payload["receipts"] == []
+    assert payload["reason_codes"] == ["revenue_repair_top_item_not_alpha_readiness"]
+
+
+def test_receipts_block_nonzero_notional() -> None:
+    payload = _build(capital={"max_notional": "25"})
+
+    assert payload["status"] == "blocked"
+    assert payload["selected_receipt"] is None
+    assert payload["receipts"] == []
+    assert payload["reason_codes"] == ["capital_notional_nonzero"]

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -1165,6 +1165,13 @@ class TestTradingApi(TestCase):
             len(repair_bid_settlement["selected_lot_ids"]),
             repair_bid_settlement["summary"]["max_selected_lots"],
         )
+        executable_alpha_repair = payload["executable_alpha_repair_receipts"]
+        self.assertEqual(
+            executable_alpha_repair["schema_version"],
+            "torghut.executable-alpha-repair-receipts.v1",
+        )
+        self.assertEqual(executable_alpha_repair["status"], "inactive")
+        self.assertEqual(executable_alpha_repair["max_notional"], "0")
         warrant = payload["route_warrant_exchange"]
         self.assertEqual(
             warrant["schema_version"],
@@ -4175,6 +4182,15 @@ class TestTradingApi(TestCase):
         self.assertEqual(
             payload["alpha_readiness_strike_ledger"]["strike_slots"][0]["lot_class"],
             "promotion_custody",
+        )
+        self.assertEqual(
+            payload["executable_alpha_repair_receipts"]["schema_version"],
+            "torghut.executable-alpha-repair-receipts.v1",
+        )
+        self.assertEqual(payload["executable_alpha_repair_receipts"]["status"], "held")
+        self.assertIn(
+            "alpha_readiness_repair_targets_missing",
+            payload["executable_alpha_repair_receipts"]["reason_codes"],
         )
         self.assertEqual(
             payload["evidence"]["repair_bid_settlement"]["dispatchable_lot_count"],


### PR DESCRIPTION
## Summary

- Implements Torghut doc 197 executable-alpha repair receipts for the top `repair_alpha_readiness` queue item while preserving zero-notional repair-only safety.
- Adds `torghut.executable-alpha-repair-receipts.v1` and selected `torghut.executable-alpha-repair-receipt.v1` projections to `/trading/revenue-repair`.
- Mirrors the compact receipt collection on `/trading/consumer-evidence` so Jangar can route repair work from the evidence surface without enabling live submission.
- Updates Torghut README and rollout notes with design provenance, runtime evidence, risk, rollback, and validation results.

## Related Issues

None.

Runtime requirement signal: `GET http://torghut.torghut.svc.cluster.local/trading/revenue-repair`.

Governing design: `docs/torghut/design-system/v6/197-torghut-executable-alpha-repair-receipts-and-zero-notional-reentry-2026-05-13.md`.

Companion design: `docs/torghut/design-system/v6/197-torghut-alpha-readiness-strike-ledger-and-routeable-candidate-ladder-2026-05-13.md`.

Value gate: `routeable_candidate_count`.

Before evidence collected from live revenue-repair at `2026-05-13T22:53:49.787764+00:00`: `business_state=repair_only`, `revenue_ready=false`, top queue `repair_alpha_readiness` / `alpha_readiness_not_promotion_eligible`, `routeable_candidate_count=0`, `zero_notional_or_stale_evidence_rate=1.0`, `max_notional=0`, live submission disabled.

After local implementation, before deploy, live evidence at `2026-05-13T23:42:24.983372+00:00` still shows deployed source commit `645366cfdf00598b15f5a7b4caa220e223af2251`, `business_state=repair_only`, `revenue_ready=false`, top queue `repair_alpha_readiness` / `alpha_readiness_not_promotion_eligible`, `routeable_candidate_count=0`, `zero_notional_or_stale_evidence_rate=1.0`, `max_notional=0`, live submission disabled. This PR improves routeable repair evidence readiness but does not claim live revenue impact before rollout.

## Testing

- `cd services/torghut && /tmp/uv-venv/bin/uv sync --frozen --extra dev`: pass.
- `cd services/torghut && /tmp/uv-venv/bin/uv lock --check`: pass.
- `cd services/torghut && /tmp/uv-venv/bin/uv run --frozen ruff format --check app/trading/executable_alpha_receipts.py app/trading/revenue_repair.py app/main.py tests/test_executable_alpha_repair_receipts.py tests/test_build_revenue_repair_digest.py tests/test_trading_api.py`: pass.
- `cd services/torghut && /tmp/uv-venv/bin/uv run --frozen ruff check app tests scripts migrations`: pass.
- `cd services/torghut && /tmp/uv-venv/bin/uv run --frozen python scripts/check_migration_graph.py`: pass.
- `cd services/torghut && /tmp/uv-venv/bin/uv run --frozen python -m compileall app`: pass.
- `cd services/torghut && /tmp/uv-venv/bin/uv run --frozen pyright --project pyrightconfig.json`: pass.
- `cd services/torghut && /tmp/uv-venv/bin/uv run --frozen pyright --project pyrightconfig.alpha.json`: pass.
- `cd services/torghut && /tmp/uv-venv/bin/uv run --frozen pyright --project pyrightconfig.scripts.json`: pass.
- `cd services/torghut && /tmp/uv-venv/bin/uv run --frozen pytest tests/test_executable_alpha_repair_receipts.py tests/test_build_revenue_repair_digest.py tests/test_trading_api.py -k "executable_alpha or repair_only_payload or revenue_repair or consumer_evidence_avoids"`: pass, `20 passed, 86 deselected`.
- `cd services/torghut && /tmp/uv-venv/bin/uv run --frozen pytest --cov --cov-branch --cov-report=term-missing --cov-report=xml`: pass, `2275 passed`, total coverage `79.02%`.

## Screenshots

N/A.

## Breaking Changes

None. The API change is additive. Rollback is reverting this PR or suppressing the `executable_alpha_repair_receipts` field; no broker submission, notional sizing, database state, GitOps manifest, or live-trading flag changes are included.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
