### PR TITLE
chore(jangar): promote image 202dcaf1

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 02afb5d3
-  digest: sha256:1cc415c97666ff3c09b0a22e5912cc4411eeb30d3f6a85ce5dea17cbd5dc84d2
+  tag: 202dcaf1
+  digest: sha256:2e6967a5d54533a34a992aa3996ac65a040807cb4e75183340b2edd2cf739333
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,8 +11,8 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 02afb5d3
-    digest: sha256:f0b664445cbc00ea0de6fa27a0faddfb1a6f35447f26ce007f560872b3648afa
+    tag: 202dcaf1
+    digest: sha256:85c879cf387c7f088be854b3909c5eab444ff23a637d81f6e4153890a3d92ff4
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
@@ -21,8 +21,8 @@ controlPlane:
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 02afb5d3
-    digest: sha256:1cc415c97666ff3c09b0a22e5912cc4411eeb30d3f6a85ce5dea17cbd5dc84d2
+    tag: 202dcaf1
+    digest: sha256:2e6967a5d54533a34a992aa3996ac65a040807cb4e75183340b2edd2cf739333
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-13T22:46:35Z
+    deploy.knative.dev/rollout: 2026-05-14T00:05:35Z
 spec:
   replicas: 1
   strategy:
@@ -57,11 +57,11 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_RUNTIME_IMAGE
-              value: registry.ide-newton.ts.net/lab/jangar:02afb5d3@sha256:1cc415c97666ff3c09b0a22e5912cc4411eeb30d3f6a85ce5dea17cbd5dc84d2
+              value: registry.ide-newton.ts.net/lab/jangar:202dcaf1@sha256:2e6967a5d54533a34a992aa3996ac65a040807cb4e75183340b2edd2cf739333
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: 02afb5d395fdc5e3dd795e9a79a1f26a89a2827e
+              value: 202dcaf121682eb87e1e7744b3ed14817a3e3f0e
             - name: JANGAR_GITOPS_REVISION
-              value: 02afb5d395fdc5e3dd795e9a79a1f26a89a2827e
+              value: 202dcaf121682eb87e1e7744b3ed14817a3e3f0e
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_BUMBA_TASK_QUEUE

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -59,5 +59,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: 02afb5d3
-    digest: sha256:1cc415c97666ff3c09b0a22e5912cc4411eeb30d3f6a85ce5dea17cbd5dc84d2
+    newTag: 202dcaf1
+    digest: sha256:2e6967a5d54533a34a992aa3996ac65a040807cb4e75183340b2edd2cf739333


### PR DESCRIPTION
## Summary

- Promotes the Jangar #6503 release contract into GitOps manifests after the automated `jangar-release` workflow skipped the workflow_run as stale.
- Updates `argocd/applications/jangar` to image tag `202dcaf1`, Jangar digest `sha256:2e6967a5d54533a34a992aa3996ac65a040807cb4e75183340b2edd2cf739333`, and source revision `202dcaf121682eb87e1e7744b3ed14817a3e3f0e`.
- Updates `argocd/applications/agents/values.yaml` to the same Jangar runtime image and control-plane digest `sha256:85c879cf387c7f088be854b3909c5eab444ff23a637d81f6e4153890a3d92ff4`.

## Related Issues

None

## Testing

- `git diff --check`
- `PATH=/root/go/bin:$PATH bun run lint:argocd`
- `gh run watch 25833198785 -R proompteng/lab --exit-status --interval 15`
- `gh run watch 25833198800 -R proompteng/lab --exit-status --interval 15`
- `kubectl kustomize --enable-helm argocd/applications/jangar` could not run locally because `helm` is not installed in this pod; PR CI `argo-lint` and `kubeconform` are expected to cover the rendered path.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
