### PR TITLE
docs(jangar): define receipt-settled repair slots

### DIFF
--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -19,6 +19,8 @@ clear entrypoints, clear “source of truth”, and a complete catalog of relate
 - Autonomous Jangar/Torghut production system design: `designs/autonomous-jangar-torghut-production-system.md`
 - Swarm agentic mission architecture notes: `designs/swarm-agentic-mission-architecture-2026-05-08.md`
 - Current Jangar/Torghut architecture contracts:
+  - `designs/194-jangar-receipt-settled-repair-slots-and-stage-custody-thaw-2026-05-14.md`
+  - `../torghut/design-system/v6/199-torghut-executable-alpha-settlement-slots-and-no-delta-repair-custody-2026-05-14.md`
   - `designs/193-jangar-cross-plane-closure-board-and-revenue-repair-admission-2026-05-14.md`
   - `../torghut/design-system/v6/198-torghut-alpha-repair-closure-board-and-routeable-revenue-reentry-2026-05-14.md`
   - `designs/192-jangar-material-readiness-reentry-clearinghouse-and-source-rollout-receipts-2026-05-13.md`

--- a/docs/agents/designs/194-jangar-receipt-settled-repair-slots-and-stage-custody-thaw-2026-05-14.md
+++ b/docs/agents/designs/194-jangar-receipt-settled-repair-slots-and-stage-custody-thaw-2026-05-14.md
@@ -1,0 +1,435 @@
+# 194. Jangar Receipt-Settled Repair Slots And Stage-Custody Thaw (2026-05-14)
+
+Status: Accepted for engineer and deployer handoff
+Date: 2026-05-14
+Owner: Victor Chen, Jangar Engineering Architecture
+Scope: Jangar stage credit, material reentry, Torghut executable-alpha repair admission, no-delta debt, rollout
+verification, rollback, and implementation handoff.
+
+Companion Torghut contract:
+
+- `docs/torghut/design-system/v6/199-torghut-executable-alpha-settlement-slots-and-no-delta-repair-custody-2026-05-14.md`
+
+Extends:
+
+- `docs/agents/designs/193-jangar-cross-plane-closure-board-and-revenue-repair-admission-2026-05-14.md`
+- `docs/agents/designs/192-jangar-material-readiness-reentry-clearinghouse-and-source-rollout-receipts-2026-05-13.md`
+- `docs/agents/designs/187-jangar-stage-credit-ledger-and-runner-slot-futures-2026-05-13.md`
+- `docs/agents/designs/188-jangar-evidence-pressure-ledger-and-watch-backoff-governor-2026-05-13.md`
+- `docs/torghut/design-system/v6/197-torghut-executable-alpha-repair-receipts-and-zero-notional-reentry-2026-05-13.md`
+
+## Decision
+
+I am selecting **receipt-settled repair slots** as the next Jangar architecture increment.
+
+The control plane is serving, but the material path is still held. On 2026-05-14, the `agents`, `jangar`, and
+`torghut` Argo applications were `Synced/Healthy` at revision `567e9ca3831d028fd2e978ad6dd27b76c87b59f4`.
+Deployments were ready: `agents=1/1`, `agents-controllers=2/2`, `jangar=1/1`, and Torghut active revision
+`torghut-00371=1/1`. `GET http://agents.agents.svc.cluster.local/ready` returned `status=ok`, leader election
+enabled, execution trust healthy, and Torghut consumer evidence current.
+
+That is not enough to open normal dispatch. The richer control-plane status route reported
+`ready_action_exchange.status=block`, stage credit decisions for `discover`, `plan`, `implement`, `verify`,
+`deploy_widen`, and `merge_ready` were held by `stage_credit_insufficient`, `controller_heartbeat_not_current`,
+`source_rollout_truth_hold`, and `evidence_clock_custody_blocked`, and the evidence-pressure ledger was `pressured`.
+The retained AgentRun surface shows why that matters: the cluster currently has 775 AgentRuns, including 119 failed
+runs, and recent Jangar/Torghut schedule pods include 43 `Error`, 3 `OOMKilled`, and 1 `ContainerStatusUnknown` in the
+filtered control-plane set. More broad dispatch is not the safe response.
+
+At the same time, Torghut now exposes a concrete zero-notional repair receipt. `GET /trading/revenue-repair` returns
+`business_state=repair_only`, top queue item `repair_alpha_readiness`, value gate `routeable_candidate_count`,
+required output `torghut.executable-alpha-receipts.v1`, and an executable alpha repair receipt selected for
+`H-CONT-01` with `max_notional=0`, `capital_rule=zero_notional_repair_only`, and validation command
+`uv run --frozen pytest services/torghut/tests/test_executable_alpha_repair_receipts.py -k evidence_window`.
+
+The selected design lets Jangar thaw exactly one bounded `dispatch_repair` slot when a current Torghut executable
+alpha repair receipt, current Jangar material reentry receipt, and current stage credit ledger agree on the same
+repair objective. It does not thaw `dispatch_normal`, `deploy_widen`, `merge_ready`, paper canary, or live canary. It
+does not change capital safety. It turns the current design stack from "held with useful proof nearby" into a
+specific runner slot with settlement requirements.
+
+The tradeoff is stricter launch accounting. Some useful repair attempts remain held if they cannot bind to the
+selected receipt, a fresh source/serving snapshot, and a no-delta settlement key. I accept that tradeoff because the
+business metric is fewer failed AgentRuns and shorter green PR-to-healthy GitOps rollout time, not higher raw launch
+volume.
+
+## Governing Runtime Requirements
+
+This contract implements the active swarm validation requirements:
+
+- every run must cite the governing design or runtime requirement before changing code;
+- implement stages must produce production PRs with tests or report the exact blocker to code;
+- verify stages must merge only green PRs and prove Argo, workload readiness, and service health after rollout;
+- final handoff must name the control-plane metric improved or the smallest blocker preventing improvement.
+
+Value-gate mapping:
+
+- `failed_agentrun_rate`: a repair slot is allocated only for one fresh receipt and one dedupe key. A terminal
+  no-delta or failed run burns the slot until the receipt, source ref, blocker set, or evidence window changes.
+- `pr_to_rollout_latency`: deployer stages may cite the slot as bounded repair evidence, but cannot treat it as
+  rollout health until the PR, CI, Argo revision, workload images, `/ready`, and Torghut repair receipt settle.
+- `ready_status_truth`: `/ready=ok` remains serving truth. Material readiness stays held except for the named
+  zero-notional repair slot.
+- `manual_intervention_count`: the operator does not choose from long reason-code lists; the slot names one receipt,
+  one command, one max runtime, one rollback target, and one next engineer action.
+- `handoff_evidence_quality`: engineer and deployer handoffs must cite the slot id, source revenue-repair digest,
+  selected executable alpha repair receipt, material reentry receipt, validation command, and settlement outcome.
+
+## Current Evidence
+
+All runtime evidence below was collected read-only on 2026-05-14. I did not mutate Kubernetes resources, database rows,
+trading flags, broker state, GitOps applications, AgentRuns, or market data.
+
+### Cluster, Rollout, And AgentRuns
+
+- Local branch: `codex/swarm-jangar-control-plane-plan`, based on `origin/main`.
+- Kubernetes context was bootstrapped locally as `in-cluster` because the workspace had no current context. The
+  service account is `system:serviceaccount:agents:agents-sa`.
+- Argo: `agents`, `jangar`, and `torghut` were `Synced/Healthy/Succeeded` at
+  `567e9ca3831d028fd2e978ad6dd27b76c87b59f4`.
+- Deployments: `agents=1/1`, `agents-controllers=2/2`, `jangar=1/1`, `torghut-00371=1/1`, and
+  `torghut-sim-00469=1/1`.
+- Recent events show rollout churn that settled: transient readiness probe failures on replacing `agents`,
+  `agents-controllers`, `jangar`, and Torghut Knative revisions, followed by successful pod starts and completed jobs.
+- AgentRun objects in `agents`: 775 total, with 628 `Succeeded`, 119 `Failed`, 11 `Pending`, 5 `Running`, and
+  12 `Template`.
+- Filtered Jangar/Torghut control-plane pods: 173 total, with 121 `Completed`, 43 `Error`, 3 `OOMKilled`,
+  5 `Running`, and 1 `ContainerStatusUnknown`.
+- Recent failures included a Jangar plan schedule pod, Torghut quant plan schedule pod, Torghut quant discover OOM,
+  and verify/implement cron failures. That failure tail argues for receipt dedupe before any new broad dispatch.
+
+### Ready And Control-Plane Truth
+
+- `GET http://agents.agents.svc.cluster.local/ready` returned `status=ok`, leader election active, execution trust
+  healthy, and Torghut consumer evidence `current`.
+- The same `/ready` payload showed the serving process did not run the agents, orchestration, or supporting
+  controllers (`enabled=false`, `started=false`). Material authority should therefore come from
+  `/api/agents/control-plane/status`, not the serving-process controller fields.
+- `GET http://jangar.jangar.svc.cluster.local/api/agents/control-plane/status?namespace=agents` returned a
+  `ready_action_exchange` in `observe` mode with `status=block`. It allowed `serve_readonly` and `torghut_observe`,
+  held `dispatch_repair`, `dispatch_normal`, `deploy_widen`, `merge_ready`, and `paper_canary`, and blocked live
+  capital actions.
+- Stage credit ledger `0545bac701902318` had `dispatch_repair` held and required a fresh execution TCA receipt inside
+  the active observation epoch. Normal stages were held by controller heartbeat, source rollout truth, and stage credit
+  insufficiency.
+- Evidence pressure ledger `535d7abcfe9a70df` was `pressured`, with pressure sources for controller replica split and
+  Torghut freshness. It gave `dispatch_repair` a repair-only budget but kept `dispatch_normal`, `deploy_widen`, and
+  `merge_ready` held.
+
+### Torghut Business And Data State
+
+- `GET http://torghut.torghut.svc.cluster.local/readyz` returned HTTP 503 with `status=degraded`.
+- Torghut dependencies were not the blocker: Postgres, ClickHouse, Alpaca, universe, empirical jobs, DSPy runtime,
+  and optional quant evidence were healthy or acceptable.
+- Torghut database schema was current: current and expected Alembic head
+  `0031_autoresearch_candidate_spec_epoch_uniqueness`, no missing heads, no unexpected heads, schema graph lineage
+  ready. Known parent-fork warnings remain under `0010_execution_provenance_and_governance_trace` and
+  `0015_whitepaper_workflow_tables`.
+- Direct database reads were blocked for this AgentRun by RBAC and missing local `psql`; that is acceptable for this
+  architecture lane because the application database witness is current and read-only.
+- `/trading/revenue-repair` returned `business_state=repair_only`, `revenue_ready=false`, active revision
+  `torghut-00371`, source commit `8d84f9f5ce028214bfb5326e0791638bc35625f5`, live submission disabled, capital stage
+  `shadow`, proof floor `repair_only`, and max notional `0`.
+- The top repair queue item was `repair_alpha_readiness` with reason `alpha_readiness_not_promotion_eligible`,
+  value gate `routeable_candidate_count`, expected unblock value `4`, required output
+  `torghut.executable-alpha-receipts.v1`, and max notional `0`.
+- The selected executable alpha repair receipt was
+  `executable-alpha-repair-receipt:a0e37a7c9b96f322d6f6bbac` for `H-CONT-01`, repair class
+  `evidence_window_refresh`, expected delta `retire_post_cost_expectancy_non_positive`, and no-delta settlement
+  required.
+- Execution TCA data is populated but still problematic: 7,334 orders, 7,245 filled executions, last TCA computed
+  2026-05-13T15:29:49Z, latest execution created 2026-04-02T19:00:29Z, average absolute slippage 13.82 bps, one
+  routeable symbol (`AAPL`), four blocked symbols, and three missing symbols.
+- Alpha readiness has three repair targets and zero promotion-eligible hypotheses. `H-CONT-01` and `H-REV-01` are
+  blocked by non-positive post-cost expectancy; `H-MICRO-01` is blocked by missing drift checks, feature rows, and
+  required feature set.
+
+### Source Architecture And Test Gaps
+
+- High-risk Jangar reducer modules are already broad:
+  `control-plane-stage-credit-ledger.ts` is 594 lines,
+  `control-plane-evidence-pressure-ledger.ts` is 679 lines,
+  `control-plane-action-custody.ts` is 595 lines, and
+  `control-plane-torghut-consumer-evidence.ts` is 758 lines.
+- High-risk Torghut proof modules are also broad:
+  `revenue_repair.py` is 1,036 lines,
+  `executable_alpha_receipts.py` is 1,146 lines,
+  `route_evidence_clearinghouse.py` is 716 lines, and
+  `zero_notional_repair_executor.py` is 576 lines.
+- Existing tests cover stage credit, evidence pressure, ready truth, action custody, Torghut consumer evidence, and
+  executable alpha repair receipts. The missing test family is cross-plane slot settlement: given a current selected
+  executable alpha repair receipt and held stage credit, Jangar should allocate exactly one repair slot, stamp the
+  governing refs, and block another slot until an after receipt or no-delta settlement appears.
+
+## Problem
+
+The architecture has reached a useful but incomplete point. Jangar can see the Torghut repair receipt, and Torghut can
+name the business blocker. Jangar still cannot safely spend the slot.
+
+The current failure modes are concrete:
+
+1. `/ready=ok` can coexist with held material readiness. Operators need a repair exception that is explicit, not
+   inferred from serving health.
+2. Stage credit sees broad debt and withholds all dispatch credit, even when a current zero-notional receipt names a
+   bounded repair.
+3. Torghut emits a selected executable alpha repair receipt, but Jangar does not yet convert it into a runner-slot
+   future with no-delta settlement.
+4. The failure tail includes schedule errors, OOMs, and old AgentRun failures. A repair attempt without a dedupe key
+   can become another repeated failed run.
+5. Torghut capital is correctly zero-notional. A repair slot must not be confused with paper or live capital release.
+
+The system needs one new boundary: a receipt-settled repair slot that can thaw exactly the selected repair and then
+settle as retired, improved, no-delta, invalidated, failed, or superseded.
+
+## Alternatives Considered
+
+### Option A: Keep Stage Credit Fully Held Until All Inputs Are Green
+
+This option leaves stage credit as-is. No dispatch repair runs until controller heartbeat, source rollout truth,
+evidence clock, execution TCA, market context, and alpha readiness are all green.
+
+Advantages:
+
+- Maximum safety.
+- No new reducer or status object.
+- Easy to reason about during incidents.
+
+Disadvantages:
+
+- Deadlocks the selected alpha repair because the repair itself is needed to make Torghut greener.
+- Increases manual intervention for a repair with current zero-notional proof.
+- Does not reduce failed schedule churn; it only suppresses all work.
+
+Decision: reject as the steady-state architecture. Keep it as emergency rollback.
+
+### Option B: Let Torghut Self-Dispatch Alpha Repair Outside Jangar Stage Credit
+
+Torghut would run the selected executable alpha repair without asking Jangar stage credit for a slot.
+
+Advantages:
+
+- Fastest path to trying the repair.
+- Keeps Jangar dispatch logic simpler.
+- Avoids waiting on controller heartbeat and source rollout reconciliation.
+
+Disadvantages:
+
+- Splits audit custody from Jangar, the system accountable for AgentRun reliability.
+- Weakens the swarm validation requirement that every run cite the governing design or runtime requirement.
+- Makes no-delta debt invisible to Jangar stage admission.
+- Risks parallel repair launches when the revenue-repair digest refreshes frequently.
+
+Decision: reject. Torghut owns the business evidence; Jangar owns launch custody.
+
+### Option C: Receipt-Settled Repair Slots
+
+Jangar builds a pure read model that consumes stage credit, evidence pressure, material reentry, Torghut consumer
+evidence, and Torghut executable alpha repair receipts. It emits one repair slot only when all selected refs agree.
+
+Advantages:
+
+- Lets the top zero-notional repair proceed without reopening normal dispatch.
+- Keeps source, readiness, and no-delta evidence in one audit object.
+- Reduces failed AgentRun risk by deduping on selected receipt, source ref, blocker set, and evidence window.
+- Gives engineer and deployer stages a testable acceptance gate.
+- Preserves capital safety by keeping max notional `0` and live submission disabled.
+
+Disadvantages:
+
+- Adds another reducer and status object.
+- Requires Jangar to understand the Torghut selected executable-alpha receipt shape.
+- The first rollout must run in observe mode before enforcement.
+
+Decision: select Option C.
+
+## Architecture
+
+The new read model is `repair_slot_escrow`.
+
+```text
+repair_slot_escrow
+  schema_version = jangar.repair-slot-escrow.v1
+  escrow_id
+  generated_at
+  fresh_until
+  namespace
+  mode = observe | shadow | hold | enforce
+  governing_design_refs[]
+  selected_slot_id
+  slots[]
+  blocked_slots[]
+  no_delta_debt[]
+  scheduler_handoff
+  deployer_handoff
+  rollback_target
+```
+
+Each slot is intentionally small:
+
+```text
+repair_slot
+  slot_id
+  action_class = dispatch_repair
+  state = observe_only | open | held | blocked | settled | superseded
+  source_revenue_repair_ref
+  torghut_selected_receipt_id
+  torghut_selected_receipt_schema
+  material_reentry_receipt_id
+  stage_credit_ledger_id
+  stage_credit_account_id
+  evidence_pressure_ledger_id
+  target_value_gate
+  expected_gate_delta
+  required_output_receipts[]
+  validation_commands[]
+  max_parallelism = 1
+  max_runtime_seconds
+  max_notional = 0
+  dedupe_key
+  before_refs[]
+  after_refs[]
+  settlement_state = pending | retired | improved | no_delta | invalidated | failed
+  rollback_target
+```
+
+Admission rules:
+
+1. A slot can open only for `dispatch_repair`.
+2. The Torghut revenue-repair top queue item must be `repair_alpha_readiness`.
+3. The selected executable alpha repair receipt must be current, zero-notional, and tied to the same source
+   revenue-repair digest.
+4. The Jangar material reentry receipt must cite the same Torghut selected receipt and `dispatch_repair`.
+5. Stage credit must be in `observe`, `shadow`, or `hold` mode; `enforce` can open the slot only after shadow evidence
+   proves no false positives.
+6. Evidence pressure can tax the slot but cannot open more than one concurrent dispatch.
+7. The dedupe key is a hash of the source revenue-repair ref, selected receipt id, hypothesis id, target value gate,
+   before reason codes, source commit, serving revision, and validation command set.
+8. A terminal no-delta, failed, or invalidated settlement blocks another slot with the same dedupe key until one input
+   changes.
+9. Paper and live capital remain blocked until a separate capital reentry receipt exists and ready truth no longer
+   blocks those action classes.
+
+## Implementation Scope
+
+M1: Add the Jangar read model and tests.
+
+- Add `services/jangar/src/server/control-plane-repair-slot-escrow.ts`.
+- Add data types in `services/jangar/src/data/agents-control-plane.ts`.
+- Wire the object into `/api/agents/control-plane/status` and `/ready` in observe mode.
+- Tests:
+  - current executable alpha repair receipt opens one observe-only `dispatch_repair` slot;
+  - stale receipt blocks the slot;
+  - nonzero notional blocks the slot;
+  - no-delta debt blocks repeated launch for the same dedupe key;
+  - changed receipt, source ref, blocker set, or evidence window reopens the lane.
+
+M2: Stamp repair-slot refs on admitted schedule-runner launches in observe mode.
+
+- Stamp `swarmRepairSlotEscrowId`, `swarmRepairSlotId`, `swarmRepairSlotDedupeKey`,
+  `swarmTorghutExecutableAlphaRepairReceiptId`, and governing design refs.
+- Do not enforce at first; log and surface the would-have-opened slot.
+- Tests: schedule runner carries the fields when the slot is open and omits them when stale or blocked.
+
+M3: Add settlement ingestion.
+
+- Consume terminal AgentRun outcome plus Torghut after receipt.
+- Mark the slot as `retired`, `improved`, `no_delta`, `invalidated`, or `failed`.
+- Convert no-delta and failed settlements into retained debt for stage credit.
+- Tests: no-delta blocks relaunch; improved/retired clears the dedupe key.
+
+M4: Move `dispatch_repair` to hold/enforce only after observe evidence is clean.
+
+- Gate on at least one day with zero false-open slots and no repeated no-delta launches.
+- Keep `dispatch_normal`, `deploy_widen`, `merge_ready`, paper, and live blocked by their current gates.
+
+## Validation
+
+Local validation for the first implementation PR:
+
+- `bunx oxfmt --check services/jangar/src/server/control-plane-repair-slot-escrow.ts services/jangar/src/data/agents-control-plane.ts`
+- `bun run --filter @proompteng/jangar test -- services/jangar/src/server/__tests__/control-plane-repair-slot-escrow.test.ts`
+- `bun run --filter @proompteng/jangar test -- services/jangar/src/routes/ready.test.ts`
+- `uv run --frozen pytest services/torghut/tests/test_executable_alpha_repair_receipts.py -k evidence_window`
+
+Runtime validation after merge and promotion:
+
+- `kubectl -n argocd get applications.argoproj.io agents jangar torghut`
+- `kubectl -n agents rollout status deploy/agents`
+- `kubectl -n agents rollout status deploy/agents-controllers`
+- `kubectl -n jangar rollout status deploy/jangar`
+- `curl -fsS http://agents.agents.svc.cluster.local/ready | jq '.repair_slot_escrow'`
+- `curl -fsS 'http://jangar.jangar.svc.cluster.local/api/agents/control-plane/status?namespace=agents' | jq '.repair_slot_escrow'`
+- `curl -fsS http://torghut.torghut.svc.cluster.local/trading/revenue-repair | jq '.executable_alpha_repair_receipts.selected_receipt'`
+
+Acceptance gates:
+
+- Exactly one selected repair slot for `dispatch_repair` when Torghut selected receipt is current.
+- No slot for nonzero notional, stale receipt, missing material reentry receipt, or mismatched source revenue-repair
+  digest.
+- No broad `dispatch_normal`, `deploy_widen`, `merge_ready`, paper, or live capital thaw.
+- A no-delta terminal run blocks relaunch for the same dedupe key.
+- Handoff includes slot id, selected Torghut receipt id, validation command, settlement state, and rollback target.
+
+## Rollout
+
+Phase 0 is documentation and test contract.
+
+Phase 1 emits `repair_slot_escrow` in observe mode on status routes only. This is safe because it does not change
+launch behavior.
+
+Phase 2 stamps schedule-runner launches with repair-slot refs in observe mode. It still does not block launches.
+
+Phase 3 changes `dispatch_repair` to hold mode for repeated no-delta keys only. A missing slot records a warning in
+observe/shadow, then holds in hold/enforce.
+
+Phase 4 enforces one-slot repair admission for Torghut alpha repair. `dispatch_normal`, deployer, paper, and live
+capital remain governed by the existing material-readiness and ready-truth gates.
+
+## Rollback
+
+Rollback is staged:
+
+1. Set `JANGAR_REPAIR_SLOT_ESCROW_MODE=observe`.
+2. If status payload generation breaks, set `JANGAR_REPAIR_SLOT_ESCROW_ENABLED=false`.
+3. Keep ready truth, stage credit, evidence pressure, material reentry, and Torghut revenue repair active.
+4. Do not delete slot, receipt, AgentRun, job, or database evidence. Mark stale or superseded objects in status.
+5. Keep Torghut max notional `0` and live submission disabled.
+
+## Risks
+
+- Receipt schema drift: Jangar may parse a Torghut receipt that changes shape. Mitigation: strict schema version checks
+  and tests for missing selected receipt fields.
+- False-open slot: a slot may open while source rollout truth is still split. Mitigation: observe mode first, require
+  material reentry receipt and source revenue-repair digest agreement.
+- Repair churn: the selected receipt can refresh every minute. Mitigation: dedupe key includes stable receipt inputs,
+  not generated timestamp alone.
+- No-delta overblocking: useful groundwork may not move the value gate immediately. Mitigation: allow an engineer to
+  attach a new evidence window, changed blocker set, or explicit invalidation receipt to reopen.
+- Capital confusion: zero-notional repair could be mistaken for paper approval. Mitigation: slot action class is only
+  `dispatch_repair`, max notional is always `0`, and capital actions remain blocked by ready truth.
+
+## Handoff
+
+Engineer handoff:
+
+- Implement M1 first as a pure read model.
+- Use the current selected Torghut receipt
+  `executable-alpha-repair-receipt:a0e37a7c9b96f322d6f6bbac` as the fixture shape, but keep tests deterministic.
+- Do not change scheduler enforcement until the observe payload and tests are green.
+- The exact next production PR should add the reducer, types, status exposure, and tests.
+
+Deployer handoff:
+
+- Do not widen based on `repair_slot_escrow` alone.
+- Treat a slot as permission for one zero-notional repair attempt only after it is emitted by the promoted image and
+  stamped onto a launch.
+- Verify Argo, deployment readiness, `/ready`, control-plane status, and Torghut `/trading/revenue-repair` after
+  rollout.
+- Roll back by disabling the repair slot escrow, not by deleting receipts or AgentRuns.
+
+Final metric target:
+
+- Improve `failed_agentrun_rate` by preventing repeated no-delta repair launches.
+- Improve `manual_intervention_count` and `handoff_evidence_quality` by giving engineer and deployer stages one slot
+  id and one selected receipt to cite.
+- Preserve `ready_status_truth` by keeping serving readiness distinct from material repair-slot admission.

--- a/docs/torghut/design-system/v6/199-torghut-executable-alpha-settlement-slots-and-no-delta-repair-custody-2026-05-14.md
+++ b/docs/torghut/design-system/v6/199-torghut-executable-alpha-settlement-slots-and-no-delta-repair-custody-2026-05-14.md
@@ -1,0 +1,392 @@
+# 199. Torghut Executable Alpha Settlement Slots And No-Delta Repair Custody (2026-05-14)
+
+Status: Accepted for Jangar engineer and deployer handoff
+Date: 2026-05-14
+Owner: Victor Chen, Jangar Engineering Architecture
+Scope: Torghut executable-alpha repair receipt settlement, routeable candidate movement, no-delta debt, zero-notional
+capital safety, validation, rollout, rollback, and Jangar slot handoff.
+
+Companion Jangar contract:
+
+- `docs/agents/designs/194-jangar-receipt-settled-repair-slots-and-stage-custody-thaw-2026-05-14.md`
+
+Extends:
+
+- `198-torghut-alpha-repair-closure-board-and-routeable-revenue-reentry-2026-05-14.md`
+- `197-torghut-executable-alpha-repair-receipts-and-zero-notional-reentry-2026-05-13.md`
+- `197-torghut-alpha-readiness-strike-ledger-and-routeable-candidate-ladder-2026-05-13.md`
+- `192-torghut-repair-receipt-frontier-and-profit-cutover-2026-05-13.md`
+- `190-torghut-repair-bid-settlement-and-routeability-proof-compaction-2026-05-13.md`
+
+## Decision
+
+I am selecting **executable alpha settlement slots** as Torghut's companion contract for Jangar receipt-settled repair
+slots.
+
+Torghut now exposes the right business target, but it still needs a compact before/after settlement object that Jangar
+can use to decide whether one zero-notional repair slot retired debt, improved the blocker set, produced no delta, or
+invalidated the hypothesis. On 2026-05-14, `GET /trading/revenue-repair` returned
+`business_state=repair_only`, `revenue_ready=false`, top repair item `repair_alpha_readiness`, value gate
+`routeable_candidate_count`, required output `torghut.executable-alpha-receipts.v1`, and selected repair receipt
+`executable-alpha-repair-receipt:a0e37a7c9b96f322d6f6bbac`.
+
+The selected receipt is useful but incomplete as settlement proof. It states the before position for `H-CONT-01`:
+repair class `evidence_window_refresh`, expected delta `retire_post_cost_expectancy_non_positive`, max notional `0`,
+and no-delta settlement required. It does not, by itself, tell Jangar whether the after run produced an
+`alpha_readiness_receipt`, changed `routeable_candidate_count`, left a no-delta result, or superseded the slot because
+the top queue changed.
+
+The selected design adds a small `executable_alpha_settlement_slots` object to Torghut's revenue-repair and consumer
+evidence surfaces. It keeps `/trading/revenue-repair` as the live business evidence surface, keeps max notional at
+`0`, and gives Jangar one settlement contract per selected repair. It turns "I have a receipt to try" into "this
+receipt can spend one Jangar slot and must settle with one of these outcomes."
+
+The tradeoff is stricter repair accounting. A repair PR can be technically useful and still settle as no-delta if the
+routeable candidate count, blocker set, or required after receipts do not move. I accept that because Torghut's active
+business blocker is routeable revenue reentry, not generic proof accumulation.
+
+## Governing Runtime Requirements
+
+This contract follows the active Jangar validation requirements:
+
+- every run must cite the governing design or runtime requirement before changing code;
+- implement stages must produce production PRs with tests or report the exact blocker to code;
+- verify stages must merge only green PRs and prove Argo, workload readiness, and service health after rollout;
+- final handoff must name the control-plane metric improved or the smallest blocker preventing improvement.
+
+Torghut value gates:
+
+- `routeable_candidate_count`
+- `zero_notional_or_stale_evidence_rate`
+- `fill_tca_or_slippage_quality`
+- `post_cost_daily_net_pnl`
+- `capital_gate_safety`
+
+Jangar value gates affected:
+
+- `failed_agentrun_rate`
+- `ready_status_truth`
+- `manual_intervention_count`
+- `handoff_evidence_quality`
+
+## Current Evidence
+
+All evidence was collected read-only on 2026-05-14.
+
+### Business Surface
+
+- `GET http://torghut.torghut.svc.cluster.local/trading/revenue-repair` returned
+  `schema_version=torghut.revenue-repair-digest.v1`, `business_state=repair_only`, and `revenue_ready=false`.
+- Top repair queue item:
+  - `code=repair_alpha_readiness`
+  - `reason=alpha_readiness_not_promotion_eligible`
+  - `dimension=alpha_readiness`
+  - `action=clear_hypothesis_blockers_before_capital`
+  - `priority=70`
+  - `expected_unblock_value=4`
+  - `value_gate=routeable_candidate_count`
+  - `required_output_receipt=torghut.executable-alpha-receipts.v1`
+  - `required_receipts=alpha_readiness_receipt,hypothesis_promotion_receipt,capital_replay_board`
+  - `max_notional=0`
+  - `capital_rule=zero_notional_repair_only`
+- Second repair queue item was `live_submit_gate_closed` with `simple_submit_disabled`, which must remain downstream
+  until alpha readiness and proof-floor evidence improve.
+- `executable_alpha_repair_receipts.status=selected`, with three receipts and selected receipt
+  `executable-alpha-repair-receipt:a0e37a7c9b96f322d6f6bbac`.
+- Selected receipt:
+  - hypothesis `H-CONT-01`
+  - candidate `chip-paper-microbar-composite@execution-proof`
+  - strategy `intraday_tsmom_v1@paper`
+  - repair class `evidence_window_refresh`
+  - expected delta `retire_post_cost_expectancy_non_positive`
+  - before routeable candidate count `0`
+  - required outputs `alpha_readiness_receipt`, `capital_replay_board`, `hypothesis_promotion_receipt`, and
+    `torghut.executable-alpha-receipts.v1`
+  - validation command
+    `uv run --frozen pytest services/torghut/tests/test_executable_alpha_repair_receipts.py -k evidence_window`
+  - max notional `0`
+  - capital rule `zero_notional_repair_only`
+  - no-delta settlement required
+
+### Runtime And Cluster
+
+- Argo: `torghut=Synced/Healthy/Succeeded` at `567e9ca3831d028fd2e978ad6dd27b76c87b59f4`.
+- Active Torghut serving revision: `torghut-00371`, image digest
+  `sha256:8d3a43bed9c6da942827c5e25f40fc88d1b0712a99a172831da222eebc820c4d`, source commit
+  `8d84f9f5ce028214bfb5326e0791638bc35625f5`.
+- Active Torghut live and sim deployments were ready (`torghut-00371=1/1`, `torghut-sim-00469=1/1`).
+- Torghut DB, ClickHouse, Keeper, options catalog, options enricher, TA, TA sim, WebSocket, and guardrail exporters
+  were running.
+- Recent Torghut whitepaper autoresearch pods had a long error tail while a current pod was running. That is not the
+  current revenue-repair blocker, but it reinforces the need for no-delta repair custody and dedupe.
+
+### Database And Data Quality
+
+- `GET http://torghut.torghut.svc.cluster.local/readyz` returned HTTP 503 with `status=degraded`.
+- Dependencies were healthy or acceptable: Postgres, ClickHouse, Alpaca, universe, empirical jobs, DSPy runtime, and
+  optional quant evidence.
+- Database schema was current at Alembic head `0031_autoresearch_candidate_spec_epoch_uniqueness`, with no missing or
+  unexpected heads and lineage ready.
+- Known schema graph parent-fork warnings remain under `0010_execution_provenance_and_governance_trace` and
+  `0015_whitepaper_workflow_tables`.
+- Live submission was blocked by `simple_submit_disabled`.
+- Profitability proof floor was `repair_only`.
+- Capital stage was `shadow`, capital state was `zero_notional`, and max notional was `0`.
+- Execution TCA data exists but routeability is not ready: 7,334 orders, 7,245 filled executions, average absolute
+  slippage 13.82 bps, one routeable symbol, four blocked symbols, and three missing symbols.
+- Alpha readiness had three repair targets and zero promotion-eligible hypotheses.
+
+## Problem
+
+Torghut can now nominate a repair receipt, but Jangar needs settlement custody before it can trust one runner slot.
+
+The current failure modes are:
+
+1. A selected executable alpha repair receipt can be retried without proving any routeable-candidate movement.
+2. The after evidence is not compact. Jangar would need to compare revenue repair, alpha readiness, TCA, market
+   context, and proof-floor payloads manually.
+3. A no-delta repair can be useful context but should not keep consuming slots with the same dedupe key.
+4. If the top queue item changes while a slot is running, the old receipt must settle as superseded, not as a fresh
+   launch candidate.
+5. Capital must remain zero-notional while the repair is running and after it settles.
+
+The architecture needs an object that binds selected repair, before state, after state, outcome, and Jangar slot ref.
+
+## Alternatives Considered
+
+### Option A: Treat `executable_alpha_repair_receipts.selected_receipt` As The Settlement Object
+
+Torghut would leave the existing selected receipt unchanged and Jangar would infer settlement by polling the full
+revenue-repair digest later.
+
+Advantages:
+
+- No new payload shape.
+- Minimal implementation work.
+- Keeps one obvious repair object.
+
+Disadvantages:
+
+- The selected receipt is a before contract, not an after receipt.
+- No-delta and superseded outcomes remain implicit.
+- Jangar has to diff large payloads and reason-code lists.
+- Repeated no-delta launch blocking would be fragile.
+
+Decision: reject. The selected receipt remains the launch candidate, but settlement needs its own compact object.
+
+### Option B: Write Settlement Only To Database Tables
+
+Torghut records repair settlement rows in Postgres and exposes them later through analytics.
+
+Advantages:
+
+- Durable persistence.
+- Natural fit for longer repair history.
+- Good for offline profitability review.
+
+Disadvantages:
+
+- Jangar's current read path is HTTP control-plane evidence, not direct DB access.
+- This AgentRun's service account cannot read Torghut DB directly, and that least-privilege boundary is intentional.
+- It does not give schedule-runner admission a fresh compact object.
+
+Decision: reject as the primary action boundary. Persist later if needed, but publish the compact status object first.
+
+### Option C: Executable Alpha Settlement Slots
+
+Torghut emits `executable_alpha_settlement_slots` next to the selected repair receipt. Each slot carries before refs,
+after refs, Jangar slot ref, settlement state, measured delta, no-delta debt, and rollback target.
+
+Advantages:
+
+- Gives Jangar a compact after-proof contract.
+- Keeps `/trading/revenue-repair` as the live business evidence surface.
+- Makes no-delta repeats visible and deniable.
+- Preserves zero-notional capital safety.
+- Lets the engineer stage test a pure builder before changing runtime admission.
+
+Disadvantages:
+
+- Adds a new payload and tests.
+- Requires stable linking between Jangar slot id and Torghut settlement slot.
+- Needs careful handling when the selected receipt changes mid-run.
+
+Decision: select Option C.
+
+## Architecture
+
+Torghut adds `executable_alpha_settlement_slots`.
+
+```text
+executable_alpha_settlement_slots
+  schema_version = torghut.executable-alpha-settlement-slots.v1
+  generated_at
+  fresh_until
+  source_revenue_repair_ref
+  selected_receipt_id
+  selected_slot_id
+  status = inactive | selected | running | settled | blocked
+  slots[]
+  no_delta_debt[]
+  rollback_target
+```
+
+Each slot:
+
+```text
+executable_alpha_settlement_slot
+  schema_version = torghut.executable-alpha-settlement-slot.v1
+  slot_id
+  jangar_repair_slot_id
+  selected_receipt_id
+  source_revenue_repair_ref
+  hypothesis_id
+  candidate_id
+  strategy_id
+  repair_class
+  target_value_gate
+  expected_gate_delta
+  before_reason_codes[]
+  before_value_gate
+  before_refs[]
+  required_output_receipts[]
+  validation_commands[]
+  after_reason_codes[]
+  after_value_gate
+  after_refs[]
+  measured_delta
+  settlement_state = pending | retired | improved | no_delta | invalidated | failed | superseded
+  no_delta_reason
+  dedupe_key
+  max_notional = 0
+  capital_rule = zero_notional_repair_only
+  rollback_target
+```
+
+Settlement rules:
+
+1. A slot can be `selected` only when the revenue-repair top queue item is `repair_alpha_readiness`.
+2. A slot can be `running` only when Jangar returns a matching `jangar.repair-slot-escrow.v1` slot id.
+3. The slot settles `retired` when the selected blocker is absent from the next current alpha-readiness evidence.
+4. The slot settles `improved` when routeable candidate count, blocker count, or required receipt coverage improves
+   but the top queue is not fully retired.
+5. The slot settles `no_delta` when after evidence is current but the blocker set and value gate do not improve.
+6. The slot settles `superseded` when the top queue item changes before the repair completes.
+7. The slot settles `failed` when the linked AgentRun fails for a repair-owned reason.
+8. Any nonzero notional, enabled live submission, or missing zero-notional capital rule blocks the slot.
+
+## Implementation Scope
+
+M1: Build settlement slots as a pure projection.
+
+- Implement near `services/torghut/app/trading/executable_alpha_receipts.py`.
+- Consume the selected executable alpha repair receipt and optional Jangar repair slot ref.
+- Emit a selected settlement slot with before value gate and no after refs.
+- Tests:
+  - selected receipt creates one selected settlement slot;
+  - non-alpha top queue produces inactive status;
+  - nonzero notional blocks;
+  - stale selected receipt blocks.
+
+M2: Add after-state settlement.
+
+- Compare after alpha readiness, routeable candidate count, and required output receipts.
+- Classify `retired`, `improved`, `no_delta`, `invalidated`, `failed`, or `superseded`.
+- Tests:
+  - blocker removed settles retired;
+  - routeable candidate count increases settles improved;
+  - unchanged blocker set settles no-delta;
+  - top queue changed settles superseded.
+
+M3: Expose the compact object.
+
+- Add `executable_alpha_settlement_slots` to `/trading/revenue-repair`, `/trading/consumer-evidence`, and `/readyz`.
+- Keep existing revenue repair, executable alpha repair receipts, capital replay board, and proof-floor payloads intact.
+- Tests for endpoint payload shape should assert schema version, selected slot id, dedupe key, capital rule, and
+  rollback target.
+
+M4: Optional persistence.
+
+- If repeated no-delta history is needed beyond status TTL, add a Postgres table in a later PR.
+- The runtime gate must not depend on direct DB access from Jangar.
+
+## Validation
+
+Local validation for the first implementation PR:
+
+- `uv run --frozen pytest services/torghut/tests/test_executable_alpha_repair_receipts.py`
+- `uv run --frozen pytest services/torghut/tests/test_revenue_repair.py -k executable_alpha`
+- `uv run --frozen pyright --project pyrightconfig.json`
+- `uv run --frozen pyright --project pyrightconfig.alpha.json`
+- `uv run --frozen pyright --project pyrightconfig.scripts.json`
+
+Runtime validation after merge and promotion:
+
+- `curl -fsS http://torghut.torghut.svc.cluster.local/trading/revenue-repair | jq '.executable_alpha_settlement_slots'`
+- `curl -fsS http://torghut.torghut.svc.cluster.local/trading/consumer-evidence | jq '.executable_alpha_settlement_slots'`
+- `curl -sS -w '\nHTTP_STATUS:%{http_code}\n' http://torghut.torghut.svc.cluster.local/readyz`
+- `curl -fsS 'http://jangar.jangar.svc.cluster.local/api/agents/control-plane/status?namespace=agents' | jq '.repair_slot_escrow'`
+
+Acceptance gates:
+
+- Top queue `repair_alpha_readiness` produces one selected settlement slot and no paper/live capital permission.
+- Settlement slot names the selected executable alpha repair receipt and Jangar repair slot when present.
+- No-delta outcome produces debt with the same dedupe key.
+- A changed receipt, changed blocker set, changed source revenue-repair ref, or improved value gate can supersede or
+  clear the debt.
+- Torghut remains `max_notional=0` and live submission remains disabled.
+
+## Rollout
+
+Phase 0 is this contract.
+
+Phase 1 adds the pure builder and tests, with no endpoint exposure.
+
+Phase 2 exposes the object on `/trading/revenue-repair` and `/trading/consumer-evidence` in observe mode.
+
+Phase 3 lets Jangar attach `jangar_repair_slot_id` and records running/settled status.
+
+Phase 4 persists no-delta history only if status TTL proves insufficient.
+
+## Rollback
+
+Rollback is safe because the object is additive:
+
+1. Stop emitting `executable_alpha_settlement_slots`.
+2. Keep `executable_alpha_repair_receipts`, revenue repair digest, repair-bid settlement, and capital replay board.
+3. Keep live submission disabled and max notional `0`.
+4. Do not delete repair receipts, AgentRuns, jobs, or database rows.
+5. Jangar should fall back to holding the repair slot when settlement slots are missing.
+
+## Risks
+
+- Payload churn: the settlement slot could duplicate too much of revenue repair. Mitigation: include only selected
+  refs, before/after value gates, outcome, and dedupe key.
+- Source mismatch: Torghut source commit and Jangar source rollout truth can disagree. Mitigation: settlement remains
+  selected but Jangar holds the slot until material reentry and source refs agree.
+- No-delta false negatives: an implementation may improve diagnostics without moving routeable candidates. Mitigation:
+  settle as no-delta but allow a changed blocker set or after receipt to reopen.
+- Capital leak: a repair slot could be misread as capital approval. Mitigation: every slot carries max notional `0`,
+  `zero_notional_repair_only`, and no paper/live action class.
+
+## Handoff
+
+Engineer handoff:
+
+- Implement M1 and M2 in Torghut with deterministic tests before wiring Jangar admission.
+- Use the current selected receipt shape from `/trading/revenue-repair` as the fixture.
+- Do not enable paper or live submission.
+- Emit settlement slots as additive status data only.
+
+Deployer handoff:
+
+- After promotion, verify `/trading/revenue-repair`, `/trading/consumer-evidence`, `/readyz`, Jangar `/ready`, and
+  Jangar control-plane status.
+- A successful deployment is not a capital release. It only proves Torghut can publish the settlement slot.
+- Roll back by removing the additive object from payloads or disabling its builder; leave existing receipts intact.
+
+Final metric target:
+
+- Increase `routeable_candidate_count` through measured alpha repair attempts.
+- Lower zero-notional stale-evidence churn by blocking repeated no-delta repairs.
+- Improve Jangar `failed_agentrun_rate` by giving schedule-runner admission a concrete settlement object.

--- a/docs/torghut/design-system/v6/index.md
+++ b/docs/torghut/design-system/v6/index.md
@@ -12,6 +12,8 @@
 - Implementation status (strict, core 01-13 docs, source-state refresh `2026-03-09`): `Implemented=7`, `Partial=5`, `Completed=1`
 - Evidence (historical closure): `13-production-gap-closure-master-plan-2026-03-03.md` (Wave 0-6 closure + DoD)
 - Evidence (current next-work priority, refreshed `2026-05-14T00:12Z`):
+  - `199-torghut-executable-alpha-settlement-slots-and-no-delta-repair-custody-2026-05-14.md`
+  - `docs/agents/designs/194-jangar-receipt-settled-repair-slots-and-stage-custody-thaw-2026-05-14.md`
   - `198-torghut-alpha-repair-closure-board-and-routeable-revenue-reentry-2026-05-14.md`
   - `docs/agents/designs/193-jangar-cross-plane-closure-board-and-revenue-repair-admission-2026-05-14.md`
   - `197-torghut-executable-alpha-repair-receipts-and-zero-notional-reentry-2026-05-13.md`


### PR DESCRIPTION
## Summary

- Adds Jangar architecture contract 194 for receipt-settled repair slots that thaw exactly one zero-notional
  `dispatch_repair` slot when stage credit, material reentry, and the selected Torghut executable alpha receipt agree.
- Adds Torghut companion contract 199 for executable alpha settlement slots and no-delta repair custody.
- Updates the Agents and Torghut documentation indexes so the new contracts are the current next-work priority.

## Related Issues

Runtime mission: `swarm-jangar-control-plane-plan`

## Testing

- `bunx oxfmt --check docs/agents/README.md docs/agents/designs/194-jangar-receipt-settled-repair-slots-and-stage-custody-thaw-2026-05-14.md docs/torghut/design-system/v6/index.md docs/torghut/design-system/v6/199-torghut-executable-alpha-settlement-slots-and-no-delta-repair-custody-2026-05-14.md`
- `git diff --check -- docs/agents/README.md docs/torghut/design-system/v6/index.md docs/agents/designs/194-jangar-receipt-settled-repair-slots-and-stage-custody-thaw-2026-05-14.md docs/torghut/design-system/v6/199-torghut-executable-alpha-settlement-slots-and-no-delta-repair-custody-2026-05-14.md`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
