### PR TITLE
docs(torghut): define alpha closure settlement market

### DIFF
--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -19,6 +19,10 @@ clear entrypoints, clear “source of truth”, and a complete catalog of relate
 - Autonomous Jangar/Torghut production system design: `designs/autonomous-jangar-torghut-production-system.md`
 - Swarm agentic mission architecture notes: `designs/swarm-agentic-mission-architecture-2026-05-08.md`
 - Current Jangar/Torghut architecture contracts:
+  - `designs/196-jangar-alpha-closure-slot-governor-and-no-delta-budget-2026-05-14.md`
+  - `../torghut/design-system/v6/201-torghut-alpha-closure-settlement-and-feature-replay-market-2026-05-14.md`
+  - `designs/195-jangar-receipt-backed-alpha-foundry-and-rollout-safety-covenant-2026-05-14.md`
+  - `../torghut/design-system/v6/200-torghut-routeable-alpha-evidence-foundry-and-capital-safe-profit-ladder-2026-05-14.md`
   - `designs/194-jangar-receipt-settled-repair-slots-and-stage-custody-thaw-2026-05-14.md`
   - `../torghut/design-system/v6/199-torghut-executable-alpha-settlement-slots-and-no-delta-repair-custody-2026-05-14.md`
   - `designs/193-jangar-cross-plane-closure-board-and-revenue-repair-admission-2026-05-14.md`

--- a/docs/agents/designs/196-jangar-alpha-closure-slot-governor-and-no-delta-budget-2026-05-14.md
+++ b/docs/agents/designs/196-jangar-alpha-closure-slot-governor-and-no-delta-budget-2026-05-14.md
@@ -1,0 +1,374 @@
+# 196. Jangar Alpha Closure Slot Governor And No-Delta Budget (2026-05-14)
+
+Status: Accepted for engineer and deployer handoff
+Date: 2026-05-14
+Owner: Gideon Park, Torghut Traders Architecture
+Scope: Jangar repair admission, Torghut alpha closure settlement, no-delta retry budget, runner slot custody, source
+and rollout proof, validation, rollback, and cross-stage handoff.
+
+Companion Torghut contract:
+
+- `docs/torghut/design-system/v6/201-torghut-alpha-closure-settlement-and-feature-replay-market-2026-05-14.md`
+
+Extends:
+
+- `193-jangar-cross-plane-closure-board-and-revenue-repair-admission-2026-05-14.md`
+- `192-jangar-alpha-readiness-repair-escrow-and-runner-admission-2026-05-13.md`
+- `192-jangar-material-readiness-reentry-clearinghouse-and-source-rollout-receipts-2026-05-13.md`
+- `188-jangar-typed-torghut-evidence-admission-and-repair-dispatch-2026-05-13.md`
+- `186-jangar-repair-bid-admission-and-settlement-custody-2026-05-13.md`
+
+## Decision
+
+I am selecting an **alpha closure slot governor with a no-delta budget** for Jangar's next Torghut repair admission
+contract.
+
+The live Jangar surface is healthy enough to govern, but not safe enough to launch material trading actions. On
+2026-05-14 at 00:27 UTC, `GET http://agents.agents.svc.cluster.local/ready` returned `status=ok`, leader election was
+active, and execution trust was healthy. Jangar observed Torghut consumer evidence as current, serving revision
+`torghut-00371`, build commit `8d84f9f5ce028214bfb5326e0791638bc35625f5`, decision `repair`, route repair value `14`,
+and accepted routeable candidate count `0`.
+
+That healthy control-plane posture should not become broad runner admission. The Torghut business surface still says
+`repair_only`; live submit is disabled; max notional is zero; and `/readyz` is degraded for the correct reasons.
+Jangar sees three dispatchable Torghut repair lots today: `quant_pipeline`, `promotion_custody`, and
+`feature_lineage`. The selected Jangar behavior is to reserve exactly one zero-notional alpha closure slot when
+Torghut's `alpha_repair_closure_board` is current, the selected market targets `routeable_candidate_count`, and no
+active no-delta debt blocks the dedupe key.
+
+The first closure target is the Torghut-selected `H-MICRO-01` feature replay market. Jangar should not decide the
+hypothesis by itself; it should verify the Torghut board, enforce slot and no-delta rules, and attach launch evidence
+to the resulting AgentRun or handoff. If the closure produces no movement, the no-delta budget denies repeats until the
+evidence key changes.
+
+The tradeoff is lower launch volume. I accept that. The current failure tail includes failed and timed-out AgentRuns
+across Jangar and Torghut lanes. More runner starts will not improve profitability if the starts are not tied to the
+top revenue repair item and a terminal outcome receipt.
+
+## Governing Runtime Requirements
+
+This contract implements the active validation requirements:
+
+- every run must cite the governing design or runtime requirement before changing code;
+- implement stages must produce production PRs with tests or report the exact blocker to code;
+- verify stages must merge only green PRs and prove Argo, workload readiness, and service health after rollout;
+- final handoff must name the control-plane metric improved or the smallest blocker preventing improvement.
+
+Jangar value gates:
+
+- `failed_agentrun_rate`: deny duplicate no-delta alpha closure launches and stale board launches.
+- `pr_to_rollout_latency`: require the deployer to cite source, image, Argo, workload, service, and Torghut board
+  evidence before calling a rollout complete.
+- `ready_status_truth`: keep `/ready=ok` separate from material-action readiness.
+- `manual_intervention_count`: turn the broad Torghut repair surface into one current closure slot.
+- `handoff_evidence_quality`: require board id, market id, selected hypothesis, required receipt, validation command,
+  and rollback target in every handoff.
+
+Torghut value gates carried through Jangar admission:
+
+- `routeable_candidate_count`
+- `zero_notional_or_stale_evidence_rate`
+- `fill_tca_or_slippage_quality`
+- `post_cost_daily_net_pnl`
+- `capital_gate_safety`
+
+## Current Evidence
+
+Evidence was collected read-only on 2026-05-14. I did not mutate Kubernetes resources, database rows, trading flags,
+GitOps resources, AgentRuns, or market data.
+
+### Cluster And Runtime
+
+- Agents deployments were available: `agents=1/1`, `agents-controllers=2/2`, and `agents-alloy=1/1`.
+- Jangar `/ready` returned `status=ok`, leader election enabled, current pod leader true, and execution trust healthy.
+- Torghut live and sim serving pods were running as `torghut-00371` and `torghut-sim-00469`.
+- Torghut core data plane pods were running: Postgres, ClickHouse, Keeper, TA, TA sim, options services, WebSocket
+  services, and guardrail exporters.
+- Recent cluster events still show workload noise: failed whitepaper autoresearch pods, failed market-context jobs, and
+  failed or timed-out Jangar/Torghut AgentRun pods. This is the failure class the no-delta budget is intended to
+  reduce.
+
+### Jangar Torghut Evidence
+
+- Torghut consumer evidence status was `current`.
+- Serving revision was `torghut-00371`; build commit was `8d84f9f5ce028214bfb5326e0791638bc35625f5`.
+- Decision was `repair`; route repair value was `14`; accepted routeable candidate count was `0`.
+- Observed Torghut contracts included route warrant exchange, repair-bid settlement, repair outcome dividend, source
+  serving repair receipt, freshness carry, routeability repair acceptance, profit repair settlement, routeable profit
+  candidate exchange, and alpha readiness strike ledger.
+- Repair-bid settlement exposed these compacted lots:
+  - `quant_pipeline`, priority `100`, dispatchable, required receipt `torghut.quant-pipeline-current-receipt.v1`;
+  - `promotion_custody`, priority `98`, dispatchable, required receipt `torghut.executable-alpha-receipts.v1`;
+  - `feature_lineage`, priority `95`, dispatchable, required receipt `torghut.feature-lineage-current-receipt.v1`;
+  - `execution_tca`, priority `90`, held by `dispatch_limit_exceeded`;
+  - `rollout_image`, priority `80`, held by `dispatch_limit_exceeded`;
+  - `empirical_replay`, priority `70`, held by `selection_limit_exceeded`.
+- Evidence clock state was `split`; blocking reasons included `alpha_readiness_not_promotion_eligible`,
+  `drift_checks_missing`, `feature_rows_missing`, `required_feature_set_unavailable`,
+  `execution_tca_slippage_guardrail_exceeded`, `execution_tca_symbol_missing`, `simple_submit_disabled`, and
+  `max_notional_zero`.
+
+### Torghut Business Evidence
+
+- `/trading/revenue-repair` returned `business_state=repair_only`, `revenue_ready=false`, and active revision
+  `torghut-00371`.
+- Capital stayed closed: `live_submission_allowed=false`, `capital_stage=shadow`, `capital_state=zero_notional`, and
+  `max_notional=0`.
+- The top queue item was `repair_alpha_readiness`, reason `alpha_readiness_not_promotion_eligible`, selected gate
+  `routeable_candidate_count`, expected unblock value `4`, required receipt `torghut.executable-alpha-receipts.v1`.
+- `/db-check` was schema-current at `0031_autoresearch_candidate_spec_epoch_uniqueness`.
+- `/readyz` was degraded because `simple_submit_disabled` and proof-floor `repair_only` were true. Postgres,
+  ClickHouse, Alpaca, database schema, universe, and empirical jobs were healthy.
+
+## Problem
+
+Jangar can now see too much, not too little. It has current Torghut evidence, dispatchable lots, source and rollout
+proof, execution trust, and ready truth. Without a specific slot governor, it can still spend capacity in the wrong
+order or repeat an unchanged alpha repair.
+
+The concrete failure modes are:
+
+1. `/ready=ok` can be misread as permission for broad material work.
+2. Three repair lots are dispatchable, but only one is tied to the top revenue queue item.
+3. Torghut's prior closure board design is not implemented, so Jangar cannot yet cite a compact board id.
+4. Failed or timed-out AgentRuns can repeat without proving the source or blocker set changed.
+5. A no-delta alpha repair can preserve every blocker and still consume a future slot.
+6. Deployer handoffs can pass with rollout health while the business lane remains `routeable_candidate_count=0`.
+
+Jangar needs to act as the slot governor, not the strategy chooser. Torghut selects the market. Jangar verifies that
+the market is current, zero-notional, and not duplicate debt.
+
+## Alternatives Considered
+
+### Option A: Admit Any Dispatchable Torghut Repair Lot
+
+Jangar launches work whenever repair-bid settlement reports a dispatchable lot and capital is zero.
+
+Advantages:
+
+- Simple and fast.
+- Uses existing fields already parsed by Jangar.
+- Keeps quant, promotion, and feature work moving.
+
+Disadvantages:
+
+- It ignores the top revenue queue item when multiple lots are dispatchable.
+- It does not enforce a no-delta cooldown.
+- It can raise failed AgentRun rate by launching stale or duplicate work.
+- It does not improve ready-status truth because `/ready=ok` remains too broad.
+
+Decision: reject. Dispatchable is necessary but not sufficient.
+
+### Option B: Freeze Torghut Repair Until The Full Cross-Plane Closure Board Exists
+
+Jangar denies Torghut repair slots until both `cross_plane_closure_board` and `alpha_repair_closure_board` are fully
+implemented and mirrored.
+
+Advantages:
+
+- Very conservative.
+- Reduces accidental launches against incomplete contracts.
+- Easy to explain during rollout.
+
+Disadvantages:
+
+- It blocks the zero-notional repair work needed to create those contracts.
+- It increases manual intervention.
+- It leaves the current routeable-candidate blocker unchanged.
+
+Decision: reject as the steady path. Use this only as an emergency stop if capital safety preconditions fail.
+
+### Option C: Alpha Closure Slot Governor
+
+Jangar admits one zero-notional Torghut alpha closure slot only when Torghut publishes a current closure board and the
+dedupe key is not under no-delta debt.
+
+Advantages:
+
+- Keeps Torghut strategy selection inside Torghut.
+- Ties runner capacity to the live revenue queue.
+- Denies stale boards, nonzero notional, and duplicate no-delta attempts.
+- Reduces failed and timed-out AgentRuns by requiring one closure target and one receipt.
+- Gives deployer handoff one board id and one market id to cite.
+
+Disadvantages:
+
+- Adds a new admission reducer and tests.
+- Holds some useful repairs until the selected closure settles.
+- Requires Torghut to publish the board before enforcement mode can be enabled.
+
+Decision: select Option C.
+
+## Architecture
+
+Jangar consumes a compact `alpha_repair_closure_board_ref` from Torghut consumer evidence. Until that field exists,
+Jangar remains in observe mode and continues to parse repair-bid settlement and alpha readiness strike ledger.
+
+```text
+jangar.alpha-closure-slot-governor.v1
+  governor_id
+  generated_at
+  fresh_until
+  mode = observe | shadow | enforce
+  torghut_consumer_evidence_ref
+  torghut_alpha_repair_closure_board_ref
+  selected_market_id
+  selected_hypothesis_id
+  selected_value_gate = routeable_candidate_count
+  required_output_receipt
+  no_delta_budget_ref
+  admission_decision = allow | hold | deny
+  denied_reason_codes[]
+  launch_ticket
+  stop_conditions[]
+  rollback_target
+```
+
+Admission allows only when all conditions pass:
+
+1. Torghut consumer evidence is current.
+2. The alpha closure board is current and schema-valid.
+3. Selected value gate is `routeable_candidate_count`.
+4. The selected market has `max_notional=0`.
+5. Live submission is disabled and capital stage is shadow.
+6. No active no-delta debt exists for the selected dedupe key.
+7. Required output receipt is one of the approved zero-notional receipts.
+8. The action class is `dispatch_repair`; paper and live action classes remain held.
+
+Admission denies when any of these reason codes appear:
+
+- `torghut_alpha_closure_board_missing`
+- `torghut_alpha_closure_board_stale`
+- `torghut_alpha_closure_not_zero_notional`
+- `torghut_alpha_closure_gate_not_routeable_candidate_count`
+- `alpha_closure_no_delta_budget_exhausted`
+- `live_submission_not_disabled`
+- `capital_stage_not_shadow`
+- `required_output_receipt_unapproved`
+
+No-delta budget:
+
+```text
+no_delta_budget
+  key = account_id + window + hypothesis_id + repair_class + source_commit + blocker_digest
+  max_attempts_per_key = 1
+  expires_when_any_changes = source_commit | evidence_window | blocker_digest | required_receipt_set
+  terminal_receipt_required = torghut.alpha-closure-settlement-receipt.v1
+```
+
+Launch ticket:
+
+```text
+launch_ticket
+  action_class = dispatch_repair
+  max_parallelism = 1
+  max_runtime_seconds = 1200
+  branch_prefix = codex/swarm-torghut-quant-implement
+  required_prompt_refs[]
+  required_validation_commands[]
+  required_handoff_fields[]
+```
+
+## Implementation Scope
+
+M1: Extend Jangar's Torghut consumer-evidence parser with optional alpha closure compact refs.
+
+- Accept missing fields in observe mode.
+- Validate schema, freshness, selected gate, notional, and required receipt when present.
+- Tests: parser accepts current board, denies stale board, denies nonzero notional.
+
+M2: Add the pure slot-governor reducer.
+
+- Inputs: Torghut consumer evidence, no-delta debt records, ready truth, execution trust, and current time.
+- Output: `jangar.alpha-closure-slot-governor.v1`.
+- Tests: allow one current zero-notional closure; deny duplicate no-delta; deny paper/live action classes.
+
+M3: Surface the governor in control-plane status.
+
+- Include governor id, selected market id, selected hypothesis id, required receipt, and denied reason codes.
+- Keep `/ready=ok` serving behavior unchanged.
+
+M4: Enforce for Torghut repair dispatch.
+
+- Start in observe, then shadow, then enforce.
+- Enforce only for alpha closure slots; do not change merge, deploy, or non-Torghut admission behavior in this PR.
+
+M5: Deployer proof.
+
+- Deployer must prove Jangar sees the board and governor, Torghut still has max notional zero, and the service remains
+  healthy or correctly degraded.
+
+## Validation Gates
+
+Architecture PR validation:
+
+- `bunx oxfmt --check docs/agents/designs/196-jangar-alpha-closure-slot-governor-and-no-delta-budget-2026-05-14.md docs/torghut/design-system/v6/201-torghut-alpha-closure-settlement-and-feature-replay-market-2026-05-14.md docs/agents/release-handoffs/torghut-alpha-closure-settlement-2026-05-14.md docs/agents/README.md docs/torghut/design-system/v6/index.md`
+- `git diff --check`
+
+Engineer validation:
+
+- `bun run --filter jangar test -- src/server/__tests__/control-plane-torghut-consumer-evidence.test.ts src/server/__tests__/control-plane-repair-bid-admission.test.ts`
+- `bun run --filter jangar test -- src/server/__tests__/control-plane-status.test.ts -t alpha`
+- `bunx oxfmt --check services/jangar/src/server services/jangar/src/server/__tests__`
+- Torghut companion checks from the companion doc must pass if the PR spans both services.
+
+Deployer validation:
+
+- `GET http://agents.agents.svc.cluster.local/ready` stays `status=ok`.
+- Jangar control-plane status includes the slot governor in observe or shadow mode before enforcement.
+- `GET http://torghut.torghut.svc.cluster.local/trading/revenue-repair` includes the Torghut closure board.
+- `GET http://torghut.torghut.svc.cluster.local/trading/consumer-evidence` includes compact board refs.
+- Torghut `/readyz` may remain HTTP 503 for `simple_submit_disabled` and proof-floor `repair_only`.
+- No deployer may claim routeable revenue readiness until `routeable_candidate_count > 0` or the smallest blocker is
+  named.
+
+## Rollout
+
+Phase 0 merges this design and the Torghut companion.
+
+Phase 1 adds parser support in observe mode.
+
+Phase 2 adds the pure slot-governor reducer and status output in shadow mode.
+
+Phase 3 connects dispatch admission for one alpha closure slot.
+
+Phase 4 enables enforcement only after Torghut emits closure board refs and no-delta debt is visible.
+
+Phase 5 evaluates the first closure. If the terminal receipt is no-delta, the same key is denied until source or
+evidence changes. If it improves routeable-candidate evidence, the next slot can move to TCA or post-cost replay.
+
+## Rollback
+
+Rollback is configuration-first:
+
+- set the slot governor mode to `observe`;
+- ignore alpha closure compact refs and use existing repair-bid admission;
+- preserve no-delta records for audit but do not enforce them;
+- keep ready truth, source-serving verdicts, repair-bid admission, and Torghut consumer evidence unchanged;
+- do not delete AgentRuns, database records, receipts, or trading evidence.
+
+## Risks
+
+- Enforcement before Torghut emits a board can freeze useful repair. Keep observe mode as the default until board
+  visibility is proven.
+- A no-delta denial can block a legitimate retry. The key must include source commit, evidence window, blocker digest,
+  and required receipt set.
+- The governor can become another broad status object. Keep it compact: one selected market, one decision, one denied
+  reason list.
+- The first feature replay may not improve post-cost PnL. That is acceptable only if the terminal receipt preserves
+  the post-cost blocker and keeps capital closed.
+- The failure tail in the agents namespace includes old retained pods. Use current service status and fresh receipts
+  for admission, not retained pod count alone.
+
+## Handoff
+
+Engineer: implement parser support and the pure governor before enforcement. Do not launch AgentRuns from the reducer
+itself. Do not open paper or live action classes. The first enforcement target is one zero-notional alpha closure slot
+selected by Torghut, not a generic repair queue item.
+
+Deployer: prove Jangar can see the governor and Torghut closure board after rollout. The rollout is successful if the
+governor is visible, Torghut remains capital-closed, and stale or duplicate alpha closures are denied in shadow or
+enforce mode.
+
+Control-plane metric improved: `failed_agentrun_rate` should fall by denying stale or duplicate no-delta alpha closure
+launches. If it does not move, the smallest blocker is missing Torghut `alpha_repair_closure_board` emission.

--- a/docs/agents/release-handoffs/torghut-alpha-closure-settlement-2026-05-14.md
+++ b/docs/agents/release-handoffs/torghut-alpha-closure-settlement-2026-05-14.md
@@ -1,0 +1,69 @@
+# Torghut Alpha Closure Settlement Handoff (2026-05-14)
+
+Status: Accepted for engineer and deployer handoff
+Owner: Gideon Park, Torghut Traders Architecture
+Related designs:
+
+- `docs/torghut/design-system/v6/201-torghut-alpha-closure-settlement-and-feature-replay-market-2026-05-14.md`
+- `docs/agents/designs/196-jangar-alpha-closure-slot-governor-and-no-delta-budget-2026-05-14.md`
+
+## Decision
+
+Build the Torghut alpha closure board around one zero-notional feature-replay market for `H-MICRO-01`, then let Jangar
+admit exactly one closure slot when the board is current and no no-delta debt blocks the dedupe key.
+
+## Evidence
+
+- `GET /trading/revenue-repair` on 2026-05-14 returned `business_state=repair_only`, `revenue_ready=false`,
+  `routeable_candidate_count=0`, and top queue item `repair_alpha_readiness`.
+- Capital stayed closed: `live_submission_allowed=false`, `capital_stage=shadow`, `capital_state=zero_notional`, and
+  `max_notional=0`.
+- `GET /db-check` was schema-current at `0031_autoresearch_candidate_spec_epoch_uniqueness`.
+- `GET /readyz` was degraded on `simple_submit_disabled` and proof-floor `repair_only`; Postgres, ClickHouse, Alpaca,
+  database schema, universe, and empirical jobs were healthy.
+- Jangar `/ready` was `status=ok`, execution trust was healthy, and Torghut consumer evidence was current for serving
+  revision `torghut-00371`.
+- Jangar saw three dispatchable Torghut repair lots: `quant_pipeline`, `promotion_custody`, and `feature_lineage`.
+
+## Engineer Acceptance Gates
+
+- Torghut implements a pure `build_alpha_repair_closure_board()` helper.
+- `/trading/revenue-repair` includes `alpha_repair_closure_board.alpha_closure_settlement_market`.
+- The selected market targets `routeable_candidate_count`, selects `H-MICRO-01` while the current blocker set
+  persists, and keeps `max_notional=0`.
+- The board records a no-delta key based on account, window, hypothesis, repair class, source commit, and blocker
+  digest.
+- Tests cover current board, stale board, nonzero notional denial, H-MICRO-01 priority, and no-delta cooldown.
+
+## Jangar Acceptance Gates
+
+- Jangar parser accepts optional compact alpha closure refs in observe mode.
+- The slot governor emits one decision with selected market id, selected hypothesis id, required receipt, and denied
+  reason codes.
+- Stale board, nonzero notional, missing board, paper/live action class, or active no-delta debt are denied.
+- Enforcement is off until Torghut board visibility is proven in a rollout.
+
+## Deployer Acceptance Gates
+
+- Argo `torghut`, `jangar`, and `agents` are `Synced/Healthy`.
+- Torghut live and sim revisions are ready.
+- `GET /db-check` stays schema-current.
+- `GET /trading/revenue-repair` includes the alpha closure board.
+- `GET /trading/consumer-evidence` includes compact closure refs.
+- Jangar status includes the alpha closure slot governor.
+- Torghut remains `max_notional=0`, `live_submission_allowed=false`, and `capital_stage=shadow`.
+- `/readyz` may remain HTTP 503 while the live submit gate and proof floor are intentionally closed.
+
+## Rollback
+
+- Disable board emission or ignore `alpha_repair_closure_board`.
+- Set Jangar slot-governor mode to `observe`.
+- Keep existing revenue repair, repair-bid settlement, alpha readiness strike, and repair outcome dividend payloads.
+- Preserve emitted receipts for audit.
+- Do not delete AgentRuns, database rows, jobs, or trading evidence.
+
+## Next Milestone
+
+Implement the Torghut board builder and additive `/trading/revenue-repair` exposure. The revenue metric is
+`routeable_candidate_count`; the smallest current blocker is `alpha_readiness_not_promotion_eligible` with feature
+rows, drift checks, and required feature set evidence missing for the lineage-ready `H-MICRO-01` lane.

--- a/docs/torghut/design-system/v6/201-torghut-alpha-closure-settlement-and-feature-replay-market-2026-05-14.md
+++ b/docs/torghut/design-system/v6/201-torghut-alpha-closure-settlement-and-feature-replay-market-2026-05-14.md
@@ -1,0 +1,447 @@
+# 201. Torghut Alpha Closure Settlement And Feature Replay Market (2026-05-14)
+
+Status: Accepted for engineer and deployer handoff
+Date: 2026-05-14
+Owner: Gideon Park, Torghut Traders Architecture
+Scope: Torghut quant revenue repair, alpha-closure settlement, feature replay, zero-notional capital safety, Jangar
+runner admission, validation, rollout, rollback, and next implementation gates.
+
+Companion Jangar contract:
+
+- `docs/agents/designs/196-jangar-alpha-closure-slot-governor-and-no-delta-budget-2026-05-14.md`
+
+Extends:
+
+- `198-torghut-alpha-repair-closure-board-and-routeable-revenue-reentry-2026-05-14.md`
+- `197-torghut-executable-alpha-repair-receipts-and-zero-notional-reentry-2026-05-13.md`
+- `197-torghut-alpha-readiness-strike-ledger-and-routeable-candidate-ladder-2026-05-13.md`
+- `193-torghut-repair-outcome-dividend-ledger-and-capital-reentry-frontier-2026-05-13.md`
+- `190-torghut-repair-bid-settlement-and-routeability-proof-compaction-2026-05-13.md`
+- `docs/agents/designs/193-jangar-cross-plane-closure-board-and-revenue-repair-admission-2026-05-14.md`
+
+## Decision
+
+I am selecting an **alpha closure settlement and feature replay market** as the next Torghut quant architecture
+increment.
+
+The live business surface is explicit and still capital-safe. On 2026-05-14 at 00:27 UTC,
+`GET /trading/revenue-repair` returned `business_state=repair_only`, `revenue_ready=false`,
+`routeable_candidate_count=0`, `max_notional=0`, and `capital_rule=zero_notional_repair_only`. The top queue item
+remained `repair_alpha_readiness` for `alpha_readiness_not_promotion_eligible`, value gate
+`routeable_candidate_count`, expected unblock value `4`, and required output receipt
+`torghut.executable-alpha-receipts.v1`.
+
+The prior design correctly chose an `alpha_repair_closure_board`, but the current source tree does not implement
+`alpha_repair_closure_board` yet. It does implement `alpha_readiness_strike_ledger`,
+`executable_alpha_repair_receipts`, `repair_bid_settlement_ledger`, and `repair_outcome_dividend_ledger`. Jangar also
+sees Torghut consumer evidence as current and sees three dispatchable compacted repair lots:
+`quant_pipeline`, `promotion_custody`, and `feature_lineage`. The open problem is no longer "can we rank promotion
+custody ahead of static repair lots"; that is now true. The open problem is "which concrete alpha closure should get
+the next zero-notional runner and what proves it changed the blocker set."
+
+I am choosing the feature-replay lane for `H-MICRO-01` as the first closure market product. It is the only active
+hypothesis with strategy lineage ready. It is blocked by `drift_checks_missing`, `feature_rows_missing`, and
+`required_feature_set_unavailable`; those map to a bounded feature replay and evidence-window refresh. `H-CONT-01` and
+`H-REV-01` remain shadow lanes with non-positive post-cost expectancy and missing strategy lineage, so they should not
+consume the first closure slot unless the feature-replay closure produces no-delta debt or the live queue changes.
+
+The tradeoff is that we do not try to clear every reason code in one implementation. We leave execution TCA, rollout
+image proof, and live submit gate work behind the alpha closure lane. That is deliberate. Moving
+`routeable_candidate_count` from zero requires one hypothesis to become a paper replay candidate with fresh feature
+evidence and a settled promotion receipt; clearing lower-priority evidence while that count stays zero does not improve
+the business metric.
+
+## Governing Runtime Requirements
+
+This contract follows the active Torghut quant validation contract:
+
+- every run must cite the governing Torghut design or runtime requirement before changing code;
+- implement stages must produce production PRs that improve readiness, profit evidence, data freshness, execution
+  quality, or capital safety;
+- verify stages must merge only green PRs and prove image promotion, Argo sync, live service health, and trading or
+  evidence status after rollout;
+- final handoff must name the revenue metric improved or the smallest blocker preventing revenue impact.
+
+The value-gate mapping is direct:
+
+- `routeable_candidate_count`: primary gate. The first closure must try to move `H-MICRO-01` from blocked
+  feature-evidence state toward paper replay candidate evidence.
+- `zero_notional_or_stale_evidence_rate`: feature replay must retire stale or missing feature evidence, or record
+  no-delta debt with the exact preserved blockers.
+- `fill_tca_or_slippage_quality`: the closure cannot graduate if route TCA remains outside the guardrail for the
+  selected symbol path.
+- `post_cost_daily_net_pnl`: the closure must bind to post-cost evidence or deny promotion with the measured
+  expectancy blocker.
+- `capital_gate_safety`: live submit remains disabled, capital stage remains shadow, and every repair object keeps
+  `max_notional=0`.
+
+## Current Evidence
+
+Evidence was collected read-only on 2026-05-14. I did not mutate Kubernetes resources, database rows, trading flags,
+broker state, GitOps resources, AgentRuns, or market data.
+
+### Cluster And Rollout
+
+- Working branch: `codex/swarm-torghut-quant-plan`, based on `main` at
+  `c7f5dbf3284448e930addb5e7682eb105b250046`.
+- Torghut live revision `torghut-00371` and sim revision `torghut-sim-00469` were both `2/2 Running`.
+- Serving build commit was `8d84f9f5ce028214bfb5326e0791638bc35625f5`; serving image digest was
+  `sha256:8d3a43bed9c6da942827c5e25f40fc88d1b0712a99a172831da222eebc820c4d`.
+- Postgres `torghut-db-1`, ClickHouse, Keeper, TA, TA sim, options catalog, options enricher, WebSocket services,
+  and guardrail exporters were running.
+- Recent rollout events showed expected Knative startup/readiness probe noise for new revisions, followed by
+  `RevisionReady` for `torghut-00371` and `torghut-sim-00469`.
+- The cluster still has operational noise: many `torghut-whitepaper-autoresearch-profit-target-*` pods are failed
+  while one current instance is running. That is not the current revenue blocker, but it reinforces why repair launches
+  need no-delta accounting and bounded retry slots.
+- Jangar was serving `/ready` with `status=ok`; leader election was active; execution trust was healthy; agents and
+  agents-controllers deployments were available.
+
+### Database And Data
+
+- `GET /db-check` returned `ok=true`, `schema_current=true`, current and expected head
+  `0031_autoresearch_candidate_spec_epoch_uniqueness`, one schema graph branch, lineage ready, no missing heads, and no
+  unexpected heads.
+- The known historical parent-fork warnings remain under `0010_execution_provenance_and_governance_trace` and
+  `0015_whitepaper_workflow_tables`.
+- Direct database introspection is intentionally unavailable to this worker: CNPG cluster listing, secret listing, and
+  pod exec into `torghut-db-1` were denied by RBAC. The accepted read path for this lane is Torghut's application
+  database witness plus trading evidence endpoints.
+- `/readyz` returned HTTP 503 with `status=degraded`, while Postgres, ClickHouse, Alpaca, database schema, universe,
+  empirical jobs, DSPy runtime, and optional quant evidence were healthy or acceptable.
+- The readiness failures were exactly the expected capital blockers: `live_submission_gate=simple_submit_disabled` and
+  `profitability_proof_floor=repair_only`.
+- Alpha readiness had three hypotheses, zero promotion-eligible hypotheses, and two rollback-required shadow lanes.
+
+### Source And Test Surface
+
+- `services/torghut/app/trading/revenue_repair.py` is 1036 lines and builds the business digest, queue, summaries,
+  strike ledger, and executable alpha repair receipts.
+- `services/torghut/app/trading/executable_alpha_receipts.py` is 1146 lines and already maps feature, drift, lineage,
+  autoresearch, equity TA, rejection-drag, and promotion blockers into repair receipt classes.
+- `services/torghut/app/trading/repair_bid_settlement.py` is 716 lines and now reserves alpha readiness strike capacity
+  by ranking `promotion_custody` at priority `98`.
+- `services/torghut/app/trading/repair_outcome_dividend.py` is 524 lines and already tracks open escrows, preserved
+  reason codes, and no-delta outcomes for selected repair lots.
+- `services/torghut/app/main.py` is 6869 lines and is the high-risk integration surface for `/readyz`,
+  `/trading/revenue-repair`, `/trading/consumer-evidence`, and the zero-notional repair endpoint.
+- Jangar consumer evidence and repair admission are covered by focused tests, but there is no implemented reducer named
+  `alpha_repair_closure_board` and no test that selects `H-MICRO-01` as the first feature-replay closure when the live
+  revenue queue is topped by alpha readiness.
+
+### Trading Evidence
+
+- `/trading/revenue-repair` had `business_state=repair_only`, `revenue_ready=false`, `readyz_status=degraded`, and
+  active revision `torghut-00371`.
+- Capital stayed closed: `live_submission_allowed=false`, `live_submission_reason=simple_submit_disabled`,
+  `capital_stage=shadow`, `proof_floor_state=repair_only`, `capital_state=zero_notional`, and `max_notional=0`.
+- Top queue item:
+  - `code=repair_alpha_readiness`
+  - `reason=alpha_readiness_not_promotion_eligible`
+  - `value_gate=routeable_candidate_count`
+  - `expected_unblock_value=4`
+  - `required_output_receipt=torghut.executable-alpha-receipts.v1`
+  - `required_receipts=alpha_readiness_receipt,hypothesis_promotion_receipt,capital_replay_board`
+- Second queue item:
+  - `code=live_submit_gate_closed`
+  - `reason=simple_submit_disabled`
+  - `value_gate=capital_gate_safety`
+  - `required_output_receipt=torghut.capital-hold-repair-receipt.v1`
+- Routeability acceptance was blocked with `accepted_routeable_candidate_count=0` and
+  `zero_notional_or_stale_evidence_rate=1.0`.
+- Repair-bid settlement had `33` raw bids, `6` compacted lots, `5` selected lots, `3` dispatchable lots, and
+  `routeable_candidate_count=0`.
+- Jangar saw dispatchable lots for `quant_pipeline`, `promotion_custody`, and `feature_lineage`. The selected but held
+  lots were execution TCA and rollout image proof; empirical replay was held by selection limit.
+- Execution TCA had `7334` orders and `7245` filled executions. It was fresh enough for the one-day threshold but the
+  latest execution sample was from 2026-04-02. Average absolute slippage was `13.82` bps against an `8` bps guardrail.
+  AAPL had route evidence, AMD/AVGO/INTC/NVDA were blocked, and AMZN/GOOGL/ORCL were missing symbol TCA.
+- Route reacquisition had `routeable_symbol_count=0`, `probing_symbol_count=1`, `blocked_symbol_count=4`,
+  `missing_symbol_count=3`, candidate symbol `AAPL`, and expected unblock value `14`.
+
+## Problem
+
+Torghut has moved past broad advisory evidence. It can now name the revenue blocker and expose dispatchable zero-notion
+repair lots. The missing system property is closure settlement: a repair attempt must either move a named alpha lane
+toward routeable-candidate admission or create no-delta debt that prevents repeated launches against the same evidence
+window.
+
+The concrete failure modes are:
+
+1. `promotion_custody` can be dispatchable, but no closure object says which hypothesis is first and why.
+2. The live queue says alpha readiness, but `quant_pipeline`, `promotion_custody`, and `feature_lineage` are all
+   dispatchable, so worker selection can still drift without a market-clearing rule.
+3. `H-MICRO-01` is lineage-ready and blocked by feature evidence, while `H-CONT-01` and `H-REV-01` carry missing
+   lineage and non-positive expectancy; the payload does not yet make that priority explicit.
+4. A zero-notional repair can finish without increasing `routeable_candidate_count`, and the system has no required
+   no-delta cooldown keyed by hypothesis, evidence window, blocker set, and source revision.
+5. `/readyz` is correctly degraded; operators may be tempted to treat that as a submit-gate task instead of an alpha
+   closure task.
+6. The alpha closure board described in doc 198 is not implemented, so deployer validation cannot yet prove the board
+   is live.
+
+The next architecture must turn the current top queue item into a small market: one selected hypothesis, one selected
+repair class, one required after receipt, one no-delta budget, and one zero-notional rollback path.
+
+## Alternatives Considered
+
+### Option A: Build The Full Alpha Repair Closure Board First
+
+This option implements doc 198 exactly before choosing any hypothesis-specific closure policy.
+
+Advantages:
+
+- It follows the current accepted design.
+- It gives Jangar the compact board it already expects.
+- It avoids adding another contract before implementation.
+
+Disadvantages:
+
+- It does not answer which closure receives the first runner slot when several lots are dispatchable.
+- It can become a board-shaped summary of existing ambiguity.
+- It does not force a no-delta cooldown keyed to a specific hypothesis and repair class.
+
+Decision: reject as the complete next step. Keep it as M1, but add the settlement market rules now so the board has a
+deterministic first product.
+
+### Option B: Clear Execution TCA And Route Coverage Before Alpha Closure
+
+This option spends the next zero-notional slots on execution TCA, missing symbols, and route evidence because those
+gates are real and measurable.
+
+Advantages:
+
+- It improves `fill_tca_or_slippage_quality`.
+- It has clear symbol-level work: AAPL probing, four blocked symbols, and three missing symbols.
+- It reduces risk before any paper candidate is admitted.
+
+Disadvantages:
+
+- It is not the current top `/trading/revenue-repair` queue item.
+- It can leave `promotion_eligible_total=0` and `routeable_candidate_count=0`.
+- It spends repair capacity on downstream guardrails before a hypothesis can consume the repaired route evidence.
+
+Decision: reject as the first closure product. TCA remains a required graduation gate, not the lead item.
+
+### Option C: Feature Replay Closure Market For H-MICRO-01
+
+This option implements the closure board with a first market product that selects `H-MICRO-01`, the lineage-ready
+microstructure lane, and funds a zero-notional feature replay plus evidence-window refresh.
+
+Advantages:
+
+- It targets the top revenue queue item and the primary value gate.
+- It uses the only active lane with ready strategy lineage.
+- It has concrete blockers: drift checks missing, feature rows missing, and required feature set unavailable.
+- It can settle as improved, retired, or no-delta without enabling capital.
+- It lets Jangar deny duplicate launches until evidence window, blocker set, source ref, or required receipt changes.
+
+Disadvantages:
+
+- It may not improve post-cost expectancy in the same PR.
+- It intentionally delays execution TCA and route-coverage work unless the closure produces after-receipts.
+- It requires a new reducer and tests around selection, no-delta debt, and board freshness.
+
+Decision: select Option C.
+
+## Architecture
+
+Torghut publishes `alpha_closure_settlement_market` as part of the new `alpha_repair_closure_board`. The market is a
+read-model first. It does not submit orders, does not change capital flags, and does not mutate repair records.
+
+```text
+alpha_closure_settlement_market
+  schema_version = torghut.alpha-closure-settlement-market.v1
+  market_id
+  generated_at
+  fresh_until
+  source_revenue_repair_ref
+  source_repair_bid_settlement_ref
+  source_repair_outcome_dividend_ref
+  account_id
+  window
+  selected_value_gate = routeable_candidate_count
+  selected_hypothesis_id = H-MICRO-01
+  selected_repair_class = feature_replay_closure
+  selected_lot_class = promotion_custody | feature_lineage
+  required_output_receipt = torghut.alpha-closure-settlement-receipt.v1
+  required_after_receipts[]
+  before_blocker_codes[]
+  no_delta_budget
+  active_dedupe_key
+  max_notional = 0
+  capital_rule = zero_notional_repair_only
+  rollback_target
+```
+
+The selected closure receipt:
+
+```text
+alpha_closure_settlement_receipt
+  schema_version = torghut.alpha-closure-settlement-receipt.v1
+  receipt_id
+  market_id
+  hypothesis_id
+  candidate_id
+  strategy_id
+  repair_class
+  before_refs[]
+  after_refs[]
+  retired_reason_codes[]
+  preserved_reason_codes[]
+  introduced_reason_codes[]
+  measured_delta
+  routeable_candidate_count_before
+  routeable_candidate_count_after
+  promotion_eligible_before
+  promotion_eligible_after
+  no_delta_reason
+  next_allowed_attempt_after
+  validation_commands[]
+  max_notional = 0
+```
+
+Selection rules:
+
+1. The live revenue-repair top item must be `repair_alpha_readiness`.
+2. `/db-check` must be schema-current.
+3. `capital.max_notional` and all selected lots must be zero.
+4. Live submission must remain disabled.
+5. A hypothesis with ready lineage and feature evidence blockers outranks lanes with missing lineage or non-positive
+   expectancy when the selected value gate is `routeable_candidate_count`.
+6. The first selected lane is `H-MICRO-01` while its blockers remain `drift_checks_missing`,
+   `feature_rows_missing`, or `required_feature_set_unavailable`.
+7. `promotion_custody` and `feature_lineage` can both feed the closure, but only one market slot is admitted until the
+   receipt settles.
+8. A no-delta outcome consumes the active dedupe key until source revision, evidence window, blocker set, or required
+   receipt changes.
+
+Graduation rules:
+
+- `improved`: at least one selected blocker retires, or `promotion_eligible_total` increases, while
+  `max_notional=0`.
+- `retired`: `repair_alpha_readiness` is no longer the top queue item or `routeable_candidate_count` increases above
+  zero.
+- `no_delta`: validation ran, but the same selected blockers remain.
+- `invalidated`: schema, source, or capital safety precondition changed before settlement.
+- `blocked`: any object requests nonzero notional or live submission.
+
+## Implementation Scope
+
+M1: Implement `build_alpha_repair_closure_board()`.
+
+- Inputs: revenue repair digest fields, repair-bid settlement, repair-outcome dividend ledger, executable alpha repair
+  receipts, `/db-check` summary, serving build metadata, and current time.
+- Outputs: `alpha_repair_closure_board` with nested `alpha_closure_settlement_market`.
+- Tests: top queue selection, schema-current requirement, zero-notional rule, H-MICRO-01 priority, stale board, and
+  no-delta cooldown.
+- Value gates: `routeable_candidate_count`, `zero_notional_or_stale_evidence_rate`, `capital_gate_safety`.
+
+M2: Expose the board on `/trading/revenue-repair`.
+
+- Keep it additive.
+- Do not change `/readyz` status.
+- Do not change live submission or notional.
+- Tests: `/trading/revenue-repair` contains board id, selected hypothesis, selected value gate, and no-delta budget.
+
+M3: Mirror compact board refs on `/trading/consumer-evidence`.
+
+- Jangar needs `board_id`, `market_id`, selected hypothesis, selected repair class, required receipt, dedupe key, and
+  no-delta state.
+- Tests: Jangar consumer evidence parser accepts the compact refs and denies nonzero notional.
+
+M4: Add the zero-notional feature replay receipt.
+
+- Run only from the repair endpoint or a worker path that writes a receipt, not from readiness generation.
+- Required validations:
+  - feature rows were regenerated or explicitly still missing;
+  - drift checks were executed or explicitly still missing;
+  - required feature set availability changed or stayed missing;
+  - routeable candidate and promotion-eligible counts are captured before and after;
+  - capital remains zero.
+
+M5: Add Jangar slot-governor enforcement.
+
+- Jangar admits one alpha closure slot only when the compact board is current and dedupe is clear.
+- Jangar denies duplicate no-delta launches until the board's evidence key changes.
+
+## Validation Gates
+
+Architecture PR validation:
+
+- `bunx oxfmt --check docs/agents/designs/196-jangar-alpha-closure-slot-governor-and-no-delta-budget-2026-05-14.md docs/torghut/design-system/v6/201-torghut-alpha-closure-settlement-and-feature-replay-market-2026-05-14.md docs/agents/release-handoffs/torghut-alpha-closure-settlement-2026-05-14.md docs/agents/README.md docs/torghut/design-system/v6/index.md`
+- `git diff --check`
+
+Engineer validation:
+
+- `cd services/torghut && uv run --frozen pytest tests/test_build_revenue_repair_digest.py -k alpha_repair_closure`
+- `cd services/torghut && uv run --frozen pytest tests/test_executable_alpha_repair_receipts.py -k feature`
+- `cd services/torghut && uv run --frozen pytest tests/test_trading_api.py -k revenue_repair`
+- `cd services/torghut && uv run --frozen ruff check app/trading tests/test_build_revenue_repair_digest.py tests/test_trading_api.py`
+- If Jangar parser changes are included:
+  `bun run --filter jangar test -- src/server/__tests__/control-plane-torghut-consumer-evidence.test.ts src/server/__tests__/control-plane-repair-bid-admission.test.ts`
+
+Deployer validation:
+
+- Argo `torghut`, `jangar`, and `agents` are `Synced/Healthy`.
+- Torghut live and sim revisions are ready.
+- `GET /db-check` remains schema-current.
+- `GET /trading/revenue-repair` includes `alpha_repair_closure_board.alpha_closure_settlement_market`.
+- `GET /trading/consumer-evidence` includes compact alpha closure refs.
+- `GET /readyz` may remain HTTP 503 while `simple_submit_disabled` and proof-floor repair-only remain active.
+- `max_notional=0`, `live_submission_allowed=false`, and `capital_stage=shadow` remain true after rollout.
+
+## Rollout
+
+Phase 0 merges this design and the Jangar companion.
+
+Phase 1 implements the pure builder and tests. The builder is not exposed outside test fixtures yet.
+
+Phase 2 exposes the board on `/trading/revenue-repair`.
+
+Phase 3 mirrors compact refs to `/trading/consumer-evidence`.
+
+Phase 4 lets Jangar reserve one zero-notional closure slot for `H-MICRO-01` feature replay.
+
+Phase 5 evaluates the receipt. If improved or retired, the next market can select route TCA or post-cost replay. If
+no-delta, the dedupe key blocks a repeat until source or evidence changes.
+
+No phase enables paper or live notional. Paper/live canary gates remain independent and must prove profit, route TCA,
+source-serving convergence, and capital safety before they open.
+
+## Rollback
+
+Rollback is additive and safe:
+
+- disable board emission or omit `alpha_repair_closure_board` from `/trading/revenue-repair`;
+- keep existing revenue repair, repair-bid settlement, executable alpha receipts, and repair outcome dividend payloads;
+- keep live submission disabled and max notional `0`;
+- keep Jangar fallback on repair-bid settlement and alpha readiness strike ledger;
+- preserve emitted closure receipts for audit, but ignore them for admission;
+- do not delete database rows, AgentRuns, jobs, or trading evidence.
+
+## Risks
+
+- The first closure may retire feature blockers but leave post-cost expectancy negative. That is acceptable only if the
+  receipt records the preserved expectancy blocker.
+- The closure board may duplicate fields already carried by executable alpha repair receipts. Keep the board compact
+  and use refs instead of copying full payloads into Jangar status.
+- A no-delta cooldown can block a legitimate retry after fresh data arrives. The dedupe key must include source
+  revision, evidence window, blocker set, and required receipt ids.
+- Route TCA can remain above guardrail after feature replay. Graduation to paper candidate must still require TCA
+  evidence.
+- Direct DB introspection is not available to workers under current RBAC. Implementation must continue to cite
+  `/db-check` and application-level data witnesses.
+
+## Handoff
+
+Engineer: implement M1 and M2 first. The smallest production PR is a pure `alpha_repair_closure_board` builder,
+tests, and additive `/trading/revenue-repair` exposure. It must select `H-MICRO-01` while the current blocker set
+persists, carry `max_notional=0`, and produce no-delta debt keys without enabling live submit.
+
+Deployer: validate that the board is visible and capital remains closed. A successful rollout does not mean Torghut is
+revenue-ready; it means the next zero-notional repair can be admitted and audited.
+
+Revenue metric: this targets `routeable_candidate_count`. The smallest blocker preventing immediate revenue impact is
+`alpha_readiness_not_promotion_eligible` with feature rows, drift checks, and required feature set evidence missing on
+the lineage-ready `H-MICRO-01` lane.

--- a/docs/torghut/design-system/v6/index.md
+++ b/docs/torghut/design-system/v6/index.md
@@ -8,10 +8,12 @@
 - Scope: intraday strategy architecture upgrade beyond static TSMOM, with regime-adaptive routing, DSPy-governed LLM
   reasoning, contamination-safe evaluation, and production rollout controls
 - Implementation status: `Mixed` (historical program closure recorded on `2026-03-03`; source-state refreshed on
-  `2026-03-09`; active proof/capital authority evidence refreshed on `2026-05-14T00:12Z`)
+  `2026-03-09`; active proof/capital authority evidence refreshed on `2026-05-14T00:27Z`)
 - Implementation status (strict, core 01-13 docs, source-state refresh `2026-03-09`): `Implemented=7`, `Partial=5`, `Completed=1`
 - Evidence (historical closure): `13-production-gap-closure-master-plan-2026-03-03.md` (Wave 0-6 closure + DoD)
 - Evidence (current next-work priority, refreshed `2026-05-14T00:35Z`):
+  - `201-torghut-alpha-closure-settlement-and-feature-replay-market-2026-05-14.md`
+  - `docs/agents/designs/196-jangar-alpha-closure-slot-governor-and-no-delta-budget-2026-05-14.md`
   - `200-torghut-routeable-alpha-evidence-foundry-and-capital-safe-profit-ladder-2026-05-14.md`
   - `docs/agents/designs/195-jangar-receipt-backed-alpha-foundry-and-rollout-safety-covenant-2026-05-14.md`
   - `199-torghut-executable-alpha-settlement-slots-and-no-delta-repair-custody-2026-05-14.md`


### PR DESCRIPTION
## Summary

- Defines the Torghut alpha closure settlement and feature replay market architecture for the current
  `repair_alpha_readiness` business blocker.
- Adds the Jangar alpha closure slot governor and no-delta budget companion design so control-plane admission stays
  bounded to one zero-notional routeability repair lane.
- Adds an engineer/deployer handoff with explicit acceptance gates, rollout proof, rollback behavior, and revenue metric
  mapping for `routeable_candidate_count`.
- Updates the Torghut v6 and Agents indexes so the new architecture contracts are discoverable with the current
  evidence catalog as docs `201` and `196`, preserving the main branch docs `200` and `195`.

## Related Issues

None provided. Swarm context: `torghut-quant` plan lane.

## Testing

- PASS `bunx oxfmt --check docs/agents/designs/196-jangar-alpha-closure-slot-governor-and-no-delta-budget-2026-05-14.md docs/torghut/design-system/v6/201-torghut-alpha-closure-settlement-and-feature-replay-market-2026-05-14.md docs/agents/release-handoffs/torghut-alpha-closure-settlement-2026-05-14.md docs/agents/README.md docs/torghut/design-system/v6/index.md`
- PASS `git diff --check`
- PASS placeholder/conflict scan over changed docs and swarm artifacts
- PASS ASCII scan over new docs and swarm artifacts
- PASS `/workspace/.agentrun/swarm/torghut-quant-plan.md` size check: 118 lines, 6221 bytes

## Screenshots (if applicable)

N/A - documentation and architecture artifacts only.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
