### PR TITLE
feat(torghut): add alpha repair closure board

### DIFF
--- a/services/torghut/README.md
+++ b/services/torghut/README.md
@@ -205,6 +205,12 @@ Testing rules for the trading core:
   concrete alpha repair target, maps target reason codes to a repair class, carries validation commands and
   no-delta settlement requirements, and keeps `max_notional=0`. `/trading/consumer-evidence` mirrors the same compact
   collection for Jangar without making `/readyz` green or enabling paper/live submission.
+- `GET /trading/revenue-repair` also emits the May 14 doc 198
+  `torghut.alpha-repair-closure-board.v1` board. The board binds the top `repair_alpha_readiness` queue item to the
+  selected executable-alpha repair receipt, names the routeable-candidate value gate, records zero-notional
+  no-delta debt when candidate count does not move, and keeps the rollback target at `max_notional=0`.
+  `/readyz` and `/trading/consumer-evidence` mirror only the compact
+  `torghut.alpha-repair-closure-board-ref.v1` fields for Jangar admission.
 - `GET /trading/status` and `GET /readyz` now include the May 8 doc 181
   `quality_adjusted_profit_frontier` shadow projection. The reducer ranks zero-notional repair packets from quant
   quality, market-context risk flags, route/TCA state, simulation-cache freshness, and Jangar evidence-quality refs

--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -49,6 +49,7 @@ from .models import (
 )
 from .observability import capture_posthog_event, shutdown_posthog_telemetry
 from .trading import TradingScheduler
+from .trading.alpha_repair_closure_board import compact_alpha_repair_closure_board
 from .trading.autonomy import (
     assert_runtime_gate_policy_contract,
     evaluate_evidence_continuity,
@@ -1048,6 +1049,36 @@ def _evaluate_trading_health_payload(
         "required": bool(quant_evidence.get("required", False)),
         "window": quant_evidence.get("window"),
     }
+    revenue_repair_digest = build_revenue_repair_digest(
+        readyz_payload={
+            "status": (
+                "degraded" if live_submission_gate.get("allowed") is not True else "ok"
+            ),
+            "proof_floor": proof_floor,
+            "live_submission_gate": live_submission_gate,
+            "quant_evidence": quant_evidence,
+            "dependencies": dependencies,
+        },
+        status_payload={
+            "mode": settings.trading_mode,
+            "pipeline_mode": settings.trading_pipeline_mode,
+            "build": build_payload,
+            "live_submission_gate": live_submission_gate,
+            "proof_floor": proof_floor,
+            "quant_evidence": quant_evidence,
+            "routeability_repair_acceptance_ledger": routeability_repair_acceptance_ledger,
+            "route_evidence_clearinghouse_packet": route_evidence_clearinghouse_packet,
+            "repair_bid_settlement_ledger": repair_bid_settlement_ledger,
+            "capital_replay_board": capital_replay_projection.get(
+                "capital_replay_board"
+            ),
+            "executable_alpha_receipts": capital_replay_projection.get(
+                "executable_alpha_receipts"
+            ),
+            "source_serving_repair_receipt_ledger": source_serving_repair_receipt_ledger,
+        },
+        generated_at=now,
+    )
     dependency_statuses = [
         cast(dict[str, object], checks).get("ok", True)
         for name, checks in dependencies.items()
@@ -1090,6 +1121,12 @@ def _evaluate_trading_health_payload(
             "freshness_carry_ledger": freshness_carry_ledger,
             "repair_receipt_frontier": repair_receipt_frontier,
             "repair_outcome_dividend_ledger": repair_outcome_dividend_ledger,
+            "alpha_repair_closure_board": compact_alpha_repair_closure_board(
+                cast(
+                    Mapping[str, Any],
+                    revenue_repair_digest.get("alpha_repair_closure_board"),
+                )
+            ),
             "route_reacquisition_book": proof_floor.get("route_reacquisition_book"),
             "route_reacquisition_board": route_reacquisition_board,
             "quant_evidence": quant_evidence,
@@ -3267,6 +3304,12 @@ def _build_trading_consumer_evidence_payload() -> dict[str, object]:
         ),
         "executable_alpha_repair_receipts": revenue_repair_digest.get(
             "executable_alpha_repair_receipts"
+        ),
+        "alpha_repair_closure_board": compact_alpha_repair_closure_board(
+            cast(
+                Mapping[str, Any],
+                revenue_repair_digest.get("alpha_repair_closure_board"),
+            )
         ),
         "route_warrant_exchange": route_warrant_exchange,
         "source_serving_repair_receipt_ledger": source_serving_repair_receipt_ledger,

--- a/services/torghut/app/trading/alpha_repair_closure_board.py
+++ b/services/torghut/app/trading/alpha_repair_closure_board.py
@@ -1,0 +1,494 @@
+"""Alpha repair closure board for routeable revenue reentry."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from datetime import datetime, timedelta, timezone
+from typing import Any, cast
+
+ALPHA_REPAIR_CLOSURE_BOARD_SCHEMA_VERSION = (
+    "torghut.alpha-repair-closure-board.v1"
+)
+ALPHA_REPAIR_CLOSURE_BOARD_REF_SCHEMA_VERSION = (
+    "torghut.alpha-repair-closure-board-ref.v1"
+)
+
+_DESIGN_REF = (
+    "docs/torghut/design-system/v6/"
+    "198-torghut-alpha-repair-closure-board-and-routeable-revenue-reentry-2026-05-14.md"
+)
+_COMPANION_JANGAR_DESIGN_REF = (
+    "docs/agents/designs/"
+    "193-jangar-cross-plane-closure-board-and-revenue-repair-admission-2026-05-14.md"
+)
+_DEFAULT_FRESHNESS_SECONDS = 15 * 60
+_ROLLBACK_TARGET = (
+    "disable alpha_repair_closure_board emission and keep Torghut max_notional=0"
+)
+_NO_DELTA_RELEASE_CONDITIONS = [
+    "evidence_window_changes",
+    "blocker_set_changes",
+    "source_ref_changes",
+    "required_receipt_changes",
+]
+
+
+def _text(value: object, default: str = "") -> str:
+    if value is None:
+        return default
+    normalized = str(value).strip()
+    return normalized or default
+
+
+def _bool(value: object, default: bool = False) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on", "allow", "allowed", "ok"}:
+            return True
+        if normalized in {"0", "false", "no", "off", "deny", "blocked", "hold"}:
+            return False
+    return default
+
+
+def _int(value: object, default: int = 0) -> int:
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if isinstance(value, str) and value.strip():
+        try:
+            return int(float(value.strip()))
+        except ValueError:
+            return default
+    return default
+
+
+def _mapping(value: object) -> Mapping[str, Any]:
+    if isinstance(value, Mapping):
+        return cast(Mapping[str, Any], value)
+    return {}
+
+
+def _sequence(value: object) -> Sequence[object]:
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return cast(Sequence[object], value)
+    return []
+
+
+def _string_list(value: object) -> list[str]:
+    items: list[str] = []
+    seen: set[str] = set()
+    for item in _sequence(value):
+        normalized = _text(item)
+        if not normalized or normalized in seen:
+            continue
+        seen.add(normalized)
+        items.append(normalized)
+    return items
+
+
+def _stable_hash(prefix: str, payload: Mapping[str, object]) -> str:
+    encoded = json.dumps(
+        {"prefix": prefix, **dict(payload)},
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()[:24]
+
+
+def _top_queue_item(repair_queue: Sequence[Mapping[str, Any]]) -> Mapping[str, Any]:
+    for item in repair_queue:
+        payload = _mapping(item)
+        if payload:
+            return payload
+    return {}
+
+
+def _is_alpha_repair(item: Mapping[str, Any]) -> bool:
+    return (
+        _text(item.get("code")) == "repair_alpha_readiness"
+        or _text(item.get("reason")) == "alpha_readiness_not_promotion_eligible"
+    )
+
+
+def _routeable_candidate_count(evidence: Mapping[str, Any]) -> int:
+    repair_bid_settlement = _mapping(evidence.get("repair_bid_settlement"))
+    routeability_acceptance = _mapping(evidence.get("routeability_acceptance"))
+    route_clearinghouse = _mapping(evidence.get("route_evidence_clearinghouse"))
+    return max(
+        _int(repair_bid_settlement.get("routeable_candidate_count")),
+        _int(routeability_acceptance.get("accepted_routeable_candidate_count")),
+        _int(route_clearinghouse.get("accepted_routeable_candidate_count")),
+    )
+
+
+def _account_window(
+    *,
+    evidence: Mapping[str, Any],
+    executable_alpha_repair_receipts: Mapping[str, Any],
+) -> tuple[str, str, str]:
+    selected_receipt = _mapping(executable_alpha_repair_receipts.get("selected_receipt"))
+    repair_bid_settlement = _mapping(evidence.get("repair_bid_settlement"))
+    account = (
+        _text(selected_receipt.get("account_id"))
+        or _text(repair_bid_settlement.get("account_id"))
+        or "unknown"
+    )
+    window = (
+        _text(selected_receipt.get("window"))
+        or _text(repair_bid_settlement.get("session_id"))
+        or "unknown"
+    )
+    trading_mode = (
+        _text(selected_receipt.get("trading_mode"))
+        or _text(repair_bid_settlement.get("trading_mode"))
+        or "unknown"
+    )
+    return account, window, trading_mode
+
+
+def _source_serving_refs(source_serving_metadata: Mapping[str, Any]) -> dict[str, object]:
+    build = _mapping(source_serving_metadata.get("build"))
+    source_serving = _mapping(
+        source_serving_metadata.get("source_serving_repair_receipt_ledger")
+    )
+    route_packet = _mapping(source_serving_metadata.get("route_evidence_clearinghouse_packet"))
+    source_commit = (
+        _text(source_serving.get("source_commit"))
+        or _text(route_packet.get("source_commit"))
+        or _text(build.get("commit"))
+        or "unknown"
+    )
+    active_revision = (
+        _text(source_serving.get("active_revision"))
+        or _text(route_packet.get("torghut_revision"))
+        or _text(build.get("active_revision"))
+        or "unknown"
+    )
+    image_digest = _text(source_serving.get("image_digest")) or _text(
+        build.get("image_digest")
+    )
+    source_serving_ref = (
+        _text(source_serving.get("ledger_id"))
+        or _text(source_serving.get("receipt_id"))
+        or f"source-serving:{source_commit}:{active_revision}"
+    )
+    refs: dict[str, object] = {
+        "source_commit": source_commit,
+        "active_revision": active_revision,
+        "source_serving_ref": source_serving_ref,
+    }
+    if image_digest:
+        refs["image_digest"] = image_digest
+    source_state = _text(source_serving.get("source_serving_state"))
+    if source_state:
+        refs["source_serving_state"] = source_state
+    return refs
+
+
+def _selected_repair_receipt(
+    executable_alpha_repair_receipts: Mapping[str, Any],
+) -> Mapping[str, Any]:
+    selected = _mapping(executable_alpha_repair_receipts.get("selected_receipt"))
+    if selected:
+        return selected
+    for raw_receipt in _sequence(executable_alpha_repair_receipts.get("receipts")):
+        receipt = _mapping(raw_receipt)
+        if receipt:
+            return receipt
+    return {}
+
+
+def _build_repair_closure(
+    *,
+    generated: datetime,
+    top_queue_item: Mapping[str, Any],
+    selected_receipt: Mapping[str, Any],
+    executable_alpha_repair_receipts: Mapping[str, Any],
+    evidence: Mapping[str, Any],
+    capital: Mapping[str, Any],
+    source_refs: Mapping[str, object],
+    account: str,
+    window: str,
+) -> dict[str, object]:
+    source_revenue_repair_ref = (
+        _text(selected_receipt.get("source_revenue_repair_ref"))
+        or _text(executable_alpha_repair_receipts.get("source_revenue_repair_ref"))
+        or "torghut-revenue-repair-digest:unknown"
+    )
+    receipt_id = _text(selected_receipt.get("receipt_id"))
+    capital_replay_board = _mapping(_mapping(evidence.get("alpha_readiness")).get("capital_replay_board"))
+    repair_bid_settlement = _mapping(evidence.get("repair_bid_settlement"))
+    before_refs = [
+        source_revenue_repair_ref,
+        _text(capital_replay_board.get("board_id")),
+        _text(repair_bid_settlement.get("ledger_id")),
+        receipt_id,
+    ]
+    before_refs = [item for item in before_refs if item]
+    reason_codes = _string_list(selected_receipt.get("reason_codes")) or [
+        _text(top_queue_item.get("reason"), "alpha_readiness_not_promotion_eligible")
+    ]
+    routeable_before = _routeable_candidate_count(evidence)
+    measured_delta = _int(selected_receipt.get("measured_delta"))
+    if routeable_before <= 0:
+        measured_delta = min(measured_delta, 0)
+    dedupe_key = _stable_hash(
+        "alpha-repair-closure-dedupe",
+        {
+            "account": account,
+            "window": window,
+            "queue_code": _text(top_queue_item.get("code")),
+            "reason": _text(top_queue_item.get("reason")),
+            "hypothesis_id": _text(selected_receipt.get("hypothesis_id")),
+            "reason_codes": reason_codes,
+            "source_commit": _text(source_refs.get("source_commit")),
+        },
+    )
+    closure_id = "alpha-repair-closure:" + _stable_hash(
+        "alpha-repair-closure",
+        {
+            "dedupe_key": dedupe_key,
+            "receipt_id": receipt_id,
+            "generated_at": generated.isoformat(),
+        },
+    )
+    required_receipts = _string_list(top_queue_item.get("required_receipts"))
+    required_output = _text(
+        top_queue_item.get("required_output_receipt"),
+        "torghut.executable-alpha-receipts.v1",
+    )
+    if required_output not in required_receipts:
+        required_receipts.append(required_output)
+    validation_commands = _string_list(selected_receipt.get("validation_commands"))
+    no_delta_reason = (
+        "routeable_candidate_count_unchanged"
+        if measured_delta <= 0
+        else ""
+    )
+    return {
+        "closure_id": closure_id,
+        "queue_code": _text(top_queue_item.get("code"), "repair_alpha_readiness"),
+        "reason_code": _text(
+            top_queue_item.get("reason"), "alpha_readiness_not_promotion_eligible"
+        ),
+        "hypothesis_id": _text(selected_receipt.get("hypothesis_id")),
+        "value_gate": _text(top_queue_item.get("value_gate"), "routeable_candidate_count"),
+        "priority": _int(top_queue_item.get("priority"), 70),
+        "expected_unblock_value": _int(top_queue_item.get("expected_unblock_value"), 1),
+        "required_output_receipt": required_output,
+        "required_receipts": required_receipts,
+        "before_refs": before_refs,
+        "after_refs": [],
+        "routeable_candidate_count_before": routeable_before,
+        "measured_delta": measured_delta,
+        "no_delta_reason": no_delta_reason,
+        "validation_commands": validation_commands,
+        "dedupe_key": dedupe_key,
+        "max_notional": _text(capital.get("max_notional"), "0"),
+        "capital_rule": _text(
+            top_queue_item.get("capital_rule"), "zero_notional_repair_only"
+        ),
+        "rollback_target": _text(
+            selected_receipt.get("rollback_target"), _ROLLBACK_TARGET
+        ),
+    }
+
+
+def _no_delta_debt_from_closure(closure: Mapping[str, Any]) -> dict[str, object] | None:
+    if _int(closure.get("measured_delta")) > 0:
+        return None
+    return {
+        "debt_id": "alpha-repair-no-delta:" + _stable_hash(
+            "alpha-repair-no-delta",
+            {
+                "closure_id": _text(closure.get("closure_id")),
+                "dedupe_key": _text(closure.get("dedupe_key")),
+                "reason_code": _text(closure.get("reason_code")),
+            },
+        ),
+        "closure_id": closure.get("closure_id"),
+        "dedupe_key": closure.get("dedupe_key"),
+        "reason_code": closure.get("reason_code"),
+        "value_gate": closure.get("value_gate"),
+        "routeable_candidate_count_before": closure.get(
+            "routeable_candidate_count_before"
+        ),
+        "measured_delta": closure.get("measured_delta"),
+        "no_delta_reason": closure.get("no_delta_reason"),
+        "release_conditions": list(_NO_DELTA_RELEASE_CONDITIONS),
+    }
+
+
+def _db_schema_current(db_check: Mapping[str, Any]) -> tuple[bool, list[str]]:
+    if not db_check:
+        return True, ["db_check_not_provided"]
+    schema_current = _bool(db_check.get("schema_current"), default=False)
+    if schema_current:
+        return True, []
+    return False, ["db_check_schema_not_current"]
+
+
+def build_alpha_repair_closure_board(
+    *,
+    generated_at: datetime,
+    business_state: str,
+    revenue_ready: bool,
+    repair_queue: Sequence[Mapping[str, Any]],
+    capital: Mapping[str, Any],
+    evidence: Mapping[str, Any],
+    executable_alpha_repair_receipts: Mapping[str, Any],
+    source_serving_metadata: Mapping[str, Any] | None = None,
+    db_check: Mapping[str, Any] | None = None,
+) -> dict[str, object]:
+    """Build the compact closure board for the live alpha-readiness repair lane."""
+
+    if generated_at.tzinfo is None:
+        raise ValueError("generated_at_missing_timezone")
+    generated = generated_at.astimezone(timezone.utc)
+    fresh_until = generated + timedelta(seconds=_DEFAULT_FRESHNESS_SECONDS)
+    top_item = _top_queue_item(repair_queue)
+    selected_receipt = _selected_repair_receipt(executable_alpha_repair_receipts)
+    source_refs = _source_serving_refs(source_serving_metadata or {})
+    account, window, trading_mode = _account_window(
+        evidence=evidence,
+        executable_alpha_repair_receipts=executable_alpha_repair_receipts,
+    )
+    db_current, reason_codes = _db_schema_current(db_check or {})
+    max_notional = _text(capital.get("max_notional"), "0")
+    if max_notional not in {"0", "0.0", "0.00"}:
+        reason_codes.append("capital_notional_nonzero")
+    if not _is_alpha_repair(top_item):
+        reason_codes.append("revenue_repair_top_item_not_alpha_readiness")
+    if not selected_receipt:
+        reason_codes.append("alpha_repair_receipt_missing")
+
+    closure: dict[str, object] | None = None
+    if selected_receipt and _is_alpha_repair(top_item):
+        closure = _build_repair_closure(
+            generated=generated,
+            top_queue_item=top_item,
+            selected_receipt=selected_receipt,
+            executable_alpha_repair_receipts=executable_alpha_repair_receipts,
+            evidence=evidence,
+            capital=capital,
+            source_refs=source_refs,
+            account=account,
+            window=window,
+        )
+
+    no_delta_debt: list[dict[str, object]] = []
+    if closure is not None:
+        debt = _no_delta_debt_from_closure(closure)
+        if debt is not None:
+            no_delta_debt.append(debt)
+
+    status = "selected"
+    if "revenue_repair_top_item_not_alpha_readiness" in reason_codes:
+        status = "inactive"
+    elif (
+        "capital_notional_nonzero" in reason_codes
+        or "alpha_repair_receipt_missing" in reason_codes
+    ):
+        status = "blocked"
+    elif not db_current:
+        status = "held"
+
+    board_id = "alpha-repair-closure-board:" + _stable_hash(
+        "alpha-repair-closure-board",
+        {
+            "account": account,
+            "window": window,
+            "queue_code": _text(top_item.get("code")),
+            "reason": _text(top_item.get("reason")),
+            "source_commit": source_refs.get("source_commit"),
+            "closure": closure.get("closure_id") if closure else None,
+        },
+    )
+    return {
+        "schema_version": ALPHA_REPAIR_CLOSURE_BOARD_SCHEMA_VERSION,
+        "board_id": board_id,
+        "generated_at": generated.isoformat(),
+        "fresh_until": fresh_until.isoformat(),
+        "governing_design_ref": _DESIGN_REF,
+        "jangar_cross_plane_closure_board_ref": _COMPANION_JANGAR_DESIGN_REF,
+        "status": status,
+        "reason_codes": reason_codes,
+        "account_id": account,
+        "window": window,
+        "trading_mode": trading_mode,
+        "business_state": business_state,
+        "revenue_ready": revenue_ready,
+        "top_queue_item_ref": {
+            "code": _text(top_item.get("code")),
+            "reason": _text(top_item.get("reason")),
+            "value_gate": _text(top_item.get("value_gate")),
+            "required_output_receipt": _text(top_item.get("required_output_receipt")),
+        },
+        "selected_value_gate": _text(
+            top_item.get("value_gate"), "routeable_candidate_count"
+        ),
+        "routeable_candidate_count": _routeable_candidate_count(evidence),
+        "max_notional": max_notional,
+        "capital_rule": _text(
+            top_item.get("capital_rule"), "zero_notional_repair_only"
+        ),
+        "source_serving_closure_ref": source_refs.get("source_serving_ref"),
+        "source_serving": source_refs,
+        "db_schema_current": db_current,
+        "repair_closures": [closure] if closure is not None else [],
+        "no_delta_debt": no_delta_debt,
+        "rollback_target": _ROLLBACK_TARGET,
+    }
+
+
+def compact_alpha_repair_closure_board(
+    board: Mapping[str, Any] | None,
+) -> dict[str, object]:
+    """Return the Jangar-facing compact reference for status payloads."""
+
+    payload = _mapping(board)
+    if not payload:
+        return {
+            "schema_version": ALPHA_REPAIR_CLOSURE_BOARD_REF_SCHEMA_VERSION,
+            "status": "missing",
+            "reason_codes": ["alpha_repair_closure_board_missing"],
+        }
+    closures: list[Mapping[str, Any]] = [
+        _mapping(item) for item in _sequence(payload.get("repair_closures"))
+    ]
+    empty_closure: Mapping[str, Any] = {}
+    top_closure = closures[0] if closures else empty_closure
+    no_delta_debt = _sequence(payload.get("no_delta_debt"))
+    return {
+        "schema_version": ALPHA_REPAIR_CLOSURE_BOARD_REF_SCHEMA_VERSION,
+        "board_schema_version": payload.get("schema_version"),
+        "board_id": payload.get("board_id"),
+        "generated_at": payload.get("generated_at"),
+        "fresh_until": payload.get("fresh_until"),
+        "status": payload.get("status"),
+        "reason_codes": _string_list(payload.get("reason_codes")),
+        "top_closure_id": top_closure.get("closure_id"),
+        "selected_value_gate": payload.get("selected_value_gate"),
+        "required_output_receipt": top_closure.get("required_output_receipt")
+        or _mapping(payload.get("top_queue_item_ref")).get("required_output_receipt"),
+        "no_delta_debt_count": len(no_delta_debt),
+        "max_notional": payload.get("max_notional"),
+        "capital_rule": payload.get("capital_rule"),
+        "rollback_target": payload.get("rollback_target"),
+    }
+
+
+__all__ = [
+    "ALPHA_REPAIR_CLOSURE_BOARD_REF_SCHEMA_VERSION",
+    "ALPHA_REPAIR_CLOSURE_BOARD_SCHEMA_VERSION",
+    "build_alpha_repair_closure_board",
+    "compact_alpha_repair_closure_board",
+]

--- a/services/torghut/app/trading/revenue_repair.py
+++ b/services/torghut/app/trading/revenue_repair.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any, Mapping, Sequence, cast
 
 from .alpha_readiness_strike_ledger import build_alpha_readiness_strike_ledger
+from .alpha_repair_closure_board import build_alpha_repair_closure_board
 from .executable_alpha_receipts import build_executable_alpha_repair_receipts
 
 
@@ -851,6 +852,12 @@ def build_revenue_repair_digest(
         status_payload.get("repair_bid_settlement_ledger"),
         readyz_payload.get("repair_bid_settlement_ledger"),
     )
+    db_check = _choose_mapping(
+        status_payload.get("db_check"),
+        status_payload.get("database_contract"),
+        _mapping(_mapping(readyz_payload.get("dependencies")).get("database")),
+        _mapping(_mapping(readyz_payload.get("dependencies")).get("database_contract")),
+    )
     dependencies = _mapping(readyz_payload.get("dependencies"))
     blocking_reasons = _collect_blocking_reasons(readyz_payload, status_payload)
     repair_queue = _build_repair_queue(proof_floor, status_payload, blocking_reasons)
@@ -932,6 +939,23 @@ def build_revenue_repair_digest(
         capital=capital,
         repair_bid_settlement_ledger=repair_bid_settlement,
     )
+    alpha_repair_closure_board = build_alpha_repair_closure_board(
+        generated_at=generated,
+        business_state=business_state,
+        revenue_ready=revenue_ready,
+        repair_queue=cast(Sequence[Mapping[str, Any]], repair_queue),
+        capital=capital,
+        evidence=evidence,
+        executable_alpha_repair_receipts=executable_alpha_repair_receipts,
+        source_serving_metadata={
+            "build": build,
+            "source_serving_repair_receipt_ledger": status_payload.get(
+                "source_serving_repair_receipt_ledger"
+            ),
+            "route_evidence_clearinghouse_packet": route_evidence_clearinghouse,
+        },
+        db_check=db_check,
+    )
     return {
         "schema_version": SCHEMA_VERSION,
         "generated_at": generated.isoformat(),
@@ -942,6 +966,7 @@ def build_revenue_repair_digest(
         "repair_bid_settlement_ledger": dict(repair_bid_settlement),
         "alpha_readiness_strike_ledger": alpha_readiness_strike_ledger,
         "executable_alpha_repair_receipts": executable_alpha_repair_receipts,
+        "alpha_repair_closure_board": alpha_repair_closure_board,
         "business_state": business_state,
         "revenue_ready": revenue_ready,
         "health": {

--- a/services/torghut/scripts/build_revenue_repair_digest.py
+++ b/services/torghut/scripts/build_revenue_repair_digest.py
@@ -22,6 +22,7 @@ from app.trading.revenue_repair import (
     _load_json_object,
     _parse_generated_at,
     _sequence,
+    build_alpha_repair_closure_board,
     build_revenue_repair_digest,
     main,
 )
@@ -36,6 +37,7 @@ __all__ = [
     "_load_json_object",
     "_parse_generated_at",
     "_sequence",
+    "build_alpha_repair_closure_board",
     "build_revenue_repair_digest",
     "main",
 ]

--- a/services/torghut/tests/test_alpha_repair_closure_board.py
+++ b/services/torghut/tests/test_alpha_repair_closure_board.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import datetime, timezone
+from typing import Any, cast
+
+from app.trading.alpha_repair_closure_board import (
+    build_alpha_repair_closure_board,
+    compact_alpha_repair_closure_board,
+)
+
+NOW = datetime(2026, 5, 14, 0, 10, tzinfo=timezone.utc)
+
+
+def _repair_queue() -> list[dict[str, object]]:
+    return [
+        {
+            "code": "repair_alpha_readiness",
+            "reason": "alpha_readiness_not_promotion_eligible",
+            "priority": 70,
+            "expected_unblock_value": 4,
+            "value_gate": "routeable_candidate_count",
+            "required_output_receipt": "torghut.executable-alpha-receipts.v1",
+            "required_receipts": [
+                "alpha_readiness_receipt",
+                "hypothesis_promotion_receipt",
+                "capital_replay_board",
+            ],
+            "max_notional": "0",
+            "capital_rule": "zero_notional_repair_only",
+        }
+    ]
+
+
+def _evidence() -> dict[str, object]:
+    return {
+        "alpha_readiness": {
+            "capital_replay_board": {
+                "schema_version": "torghut.capital-replay-board.v1",
+                "board_id": "capital-replay:test",
+            }
+        },
+        "repair_bid_settlement": {
+            "ledger_id": "repair-bid-settlement-ledger:test",
+            "account_id": "PA3SX7FYNUTF",
+            "session_id": "15m",
+            "trading_mode": "live",
+            "routeable_candidate_count": 0,
+        },
+        "routeability_acceptance": {
+            "accepted_routeable_candidate_count": 0,
+        },
+    }
+
+
+def _repair_receipts() -> dict[str, object]:
+    return {
+        "schema_version": "torghut.executable-alpha-repair-receipts.v1",
+        "source_revenue_repair_ref": "torghut-revenue-repair-digest:test",
+        "status": "selected",
+        "selected_receipt_id": "executable-alpha-repair-receipt:test",
+        "selected_receipt": {
+            "receipt_id": "executable-alpha-repair-receipt:test",
+            "source_revenue_repair_ref": "torghut-revenue-repair-digest:test",
+            "hypothesis_id": "H-AAPL-ROUTE-REHAB",
+            "reason_codes": ["alpha_readiness_not_promotion_eligible"],
+            "validation_commands": [
+                "uv run --frozen pytest services/torghut/tests/test_executable_alpha_repair_receipts.py -k promotion"
+            ],
+            "max_notional": "0",
+            "capital_rule": "zero_notional_repair_only",
+            "rollback_target": (
+                "stop emitting executable_alpha_repair_receipts and keep Torghut max_notional=0"
+            ),
+        },
+    }
+
+
+def _build(
+    *,
+    repair_queue: list[dict[str, object]] | None = None,
+    capital: Mapping[str, Any] | None = None,
+    db_check: Mapping[str, Any] | None = None,
+) -> dict[str, object]:
+    return build_alpha_repair_closure_board(
+        generated_at=NOW,
+        business_state="repair_only",
+        revenue_ready=False,
+        repair_queue=repair_queue or _repair_queue(),
+        capital=capital or {"max_notional": "0"},
+        evidence=_evidence(),
+        executable_alpha_repair_receipts=_repair_receipts(),
+        source_serving_metadata={
+            "build": {
+                "commit": "source-sha",
+                "active_revision": "torghut-00371",
+                "image_digest": "sha256:test",
+            }
+        },
+        db_check=db_check or {"schema_current": True},
+    )
+
+
+def test_alpha_repair_closure_board_selects_zero_notional_top_alpha_repair() -> None:
+    board = _build()
+
+    assert board["schema_version"] == "torghut.alpha-repair-closure-board.v1"
+    assert board["status"] == "selected"
+    assert board["selected_value_gate"] == "routeable_candidate_count"
+    assert board["routeable_candidate_count"] == 0
+    assert board["max_notional"] == "0"
+    assert board["capital_rule"] == "zero_notional_repair_only"
+    assert board["db_schema_current"] is True
+    closure = cast(list[Mapping[str, Any]], board["repair_closures"])[0]
+    assert closure["queue_code"] == "repair_alpha_readiness"
+    assert closure["required_output_receipt"] == "torghut.executable-alpha-receipts.v1"
+    assert closure["routeable_candidate_count_before"] == 0
+    assert closure["measured_delta"] == 0
+    assert closure["no_delta_reason"] == "routeable_candidate_count_unchanged"
+    assert closure["max_notional"] == "0"
+    assert closure["validation_commands"]
+    no_delta_debt = cast(list[Mapping[str, Any]], board["no_delta_debt"])
+    assert no_delta_debt[0]["dedupe_key"] == closure["dedupe_key"]
+    assert "blocker_set_changes" in no_delta_debt[0]["release_conditions"]
+
+
+def test_alpha_repair_closure_board_holds_when_db_schema_is_not_current() -> None:
+    board = _build(db_check={"schema_current": False})
+
+    assert board["status"] == "held"
+    assert board["db_schema_current"] is False
+    assert "db_check_schema_not_current" in board["reason_codes"]
+    assert board["max_notional"] == "0"
+
+
+def test_alpha_repair_closure_board_blocks_nonzero_notional() -> None:
+    board = _build(capital={"max_notional": "25"})
+
+    assert board["status"] == "blocked"
+    assert "capital_notional_nonzero" in board["reason_codes"]
+    assert board["max_notional"] == "25"
+
+
+def test_alpha_repair_closure_board_inactive_when_top_queue_is_not_alpha() -> None:
+    board = _build(
+        repair_queue=[
+            {
+                "code": "repair_execution_tca",
+                "reason": "execution_tca_stale",
+                "value_gate": "fill_tca_or_slippage_quality",
+            }
+        ]
+    )
+
+    assert board["status"] == "inactive"
+    assert "revenue_repair_top_item_not_alpha_readiness" in board["reason_codes"]
+    assert board["repair_closures"] == []
+    assert board["no_delta_debt"] == []
+
+
+def test_compact_alpha_repair_closure_board_returns_jangar_facing_ref() -> None:
+    board = _build()
+    compact = compact_alpha_repair_closure_board(board)
+
+    assert compact["schema_version"] == "torghut.alpha-repair-closure-board-ref.v1"
+    assert compact["board_id"] == board["board_id"]
+    assert compact["status"] == "selected"
+    assert compact["selected_value_gate"] == "routeable_candidate_count"
+    assert compact["required_output_receipt"] == "torghut.executable-alpha-receipts.v1"
+    assert compact["no_delta_debt_count"] == 1
+    assert compact["max_notional"] == "0"

--- a/services/torghut/tests/test_alpha_repair_closure_board.py
+++ b/services/torghut/tests/test_alpha_repair_closure_board.py
@@ -4,6 +4,8 @@ from collections.abc import Mapping
 from datetime import datetime, timezone
 from typing import Any, cast
 
+import pytest
+
 from app.trading.alpha_repair_closure_board import (
     build_alpha_repair_closure_board,
     compact_alpha_repair_closure_board,
@@ -78,18 +80,21 @@ def _repair_receipts() -> dict[str, object]:
 
 def _build(
     *,
+    generated_at: datetime = NOW,
     repair_queue: list[dict[str, object]] | None = None,
     capital: Mapping[str, Any] | None = None,
+    evidence: Mapping[str, Any] | None = None,
+    repair_receipts: Mapping[str, Any] | None = None,
     db_check: Mapping[str, Any] | None = None,
 ) -> dict[str, object]:
     return build_alpha_repair_closure_board(
-        generated_at=NOW,
+        generated_at=generated_at,
         business_state="repair_only",
         revenue_ready=False,
         repair_queue=repair_queue or _repair_queue(),
         capital=capital or {"max_notional": "0"},
-        evidence=_evidence(),
-        executable_alpha_repair_receipts=_repair_receipts(),
+        evidence=evidence or _evidence(),
+        executable_alpha_repair_receipts=repair_receipts or _repair_receipts(),
         source_serving_metadata={
             "build": {
                 "commit": "source-sha",
@@ -122,6 +127,54 @@ def test_alpha_repair_closure_board_selects_zero_notional_top_alpha_repair() -> 
     no_delta_debt = cast(list[Mapping[str, Any]], board["no_delta_debt"])
     assert no_delta_debt[0]["dedupe_key"] == closure["dedupe_key"]
     assert "blocker_set_changes" in no_delta_debt[0]["release_conditions"]
+
+
+def test_alpha_repair_closure_board_accepts_string_db_schema_flags() -> None:
+    selected = _build(db_check={"schema_current": "allow"})
+    held = _build(db_check={"schema_current": "hold"})
+    default_held = _build(db_check={"schema_current": "unknown"})
+
+    assert selected["status"] == "selected"
+    assert selected["db_schema_current"] is True
+    assert held["status"] == "held"
+    assert held["db_schema_current"] is False
+    assert default_held["status"] == "held"
+    assert "db_check_schema_not_current" in default_held["reason_codes"]
+
+
+def test_alpha_repair_closure_board_uses_receipt_list_fallback_and_positive_delta() -> None:
+    repair_receipts = _repair_receipts()
+    selected_receipt = cast(dict[str, object], repair_receipts.pop("selected_receipt"))
+    selected_receipt["measured_delta"] = "2.0"
+    selected_receipt["reason_codes"] = [
+        "alpha_readiness_not_promotion_eligible",
+        "alpha_readiness_not_promotion_eligible",
+        "",
+    ]
+    repair_receipts["receipts"] = [selected_receipt]
+    evidence = _evidence()
+    repair_bid_settlement = cast(dict[str, object], evidence["repair_bid_settlement"])
+    routeability_acceptance = cast(dict[str, object], evidence["routeability_acceptance"])
+    repair_bid_settlement["routeable_candidate_count"] = True
+    routeability_acceptance["accepted_routeable_candidate_count"] = 4.7
+    evidence["route_evidence_clearinghouse"] = {
+        "accepted_routeable_candidate_count": "not-a-count",
+    }
+
+    board = _build(evidence=evidence, repair_receipts=repair_receipts)
+
+    closure = cast(list[Mapping[str, Any]], board["repair_closures"])[0]
+    assert board["routeable_candidate_count"] == 4
+    assert closure["measured_delta"] == 2
+    assert closure["no_delta_reason"] == ""
+    assert board["no_delta_debt"] == []
+    assert closure["before_refs"][-1] == "executable-alpha-repair-receipt:test"
+    assert closure["required_receipts"].count("torghut.executable-alpha-receipts.v1") == 1
+
+
+def test_alpha_repair_closure_board_rejects_naive_generated_at() -> None:
+    with pytest.raises(ValueError, match="generated_at_missing_timezone"):
+        _build(generated_at=datetime(2026, 5, 14, 0, 10))
 
 
 def test_alpha_repair_closure_board_holds_when_db_schema_is_not_current() -> None:
@@ -169,3 +222,33 @@ def test_compact_alpha_repair_closure_board_returns_jangar_facing_ref() -> None:
     assert compact["required_output_receipt"] == "torghut.executable-alpha-receipts.v1"
     assert compact["no_delta_debt_count"] == 1
     assert compact["max_notional"] == "0"
+
+
+def test_compact_alpha_repair_closure_board_reports_missing_payload() -> None:
+    compact = compact_alpha_repair_closure_board(None)
+
+    assert compact == {
+        "schema_version": "torghut.alpha-repair-closure-board-ref.v1",
+        "status": "missing",
+        "reason_codes": ["alpha_repair_closure_board_missing"],
+    }
+
+
+def test_compact_alpha_repair_closure_board_tolerates_non_sequence_closures() -> None:
+    compact = compact_alpha_repair_closure_board(
+        {
+            "schema_version": "torghut.alpha-repair-closure-board.v1",
+            "status": "held",
+            "reason_codes": "not-a-list",
+            "repair_closures": "not-a-list",
+            "no_delta_debt": "not-a-list",
+            "top_queue_item_ref": {
+                "required_output_receipt": "torghut.executable-alpha-receipts.v1",
+            },
+        }
+    )
+
+    assert compact["reason_codes"] == []
+    assert compact["top_closure_id"] is None
+    assert compact["required_output_receipt"] == "torghut.executable-alpha-receipts.v1"
+    assert compact["no_delta_debt_count"] == 0

--- a/services/torghut/tests/test_build_revenue_repair_digest.py
+++ b/services/torghut/tests/test_build_revenue_repair_digest.py
@@ -416,6 +416,29 @@ class TestBuildRevenueRepairDigest(TestCase):
         )
         self.assertEqual(selected_repair_receipt["max_notional"], "0")
         self.assertTrue(selected_repair_receipt["no_delta_settlement_required"])
+        closure_board = digest["alpha_repair_closure_board"]
+        self.assertIsInstance(closure_board, dict)
+        self.assertEqual(
+            closure_board["schema_version"],
+            "torghut.alpha-repair-closure-board.v1",
+        )
+        self.assertEqual(closure_board["status"], "selected")
+        self.assertEqual(
+            closure_board["selected_value_gate"], "routeable_candidate_count"
+        )
+        self.assertEqual(closure_board["max_notional"], "0")
+        repair_closures = closure_board["repair_closures"]
+        self.assertIsInstance(repair_closures, list)
+        self.assertEqual(repair_closures[0]["queue_code"], "repair_alpha_readiness")
+        self.assertEqual(
+            repair_closures[0]["required_output_receipt"],
+            "torghut.executable-alpha-receipts.v1",
+        )
+        self.assertEqual(
+            repair_closures[0]["no_delta_reason"],
+            "routeable_candidate_count_unchanged",
+        )
+        self.assertEqual(len(closure_board["no_delta_debt"]), 1)
         self.assertEqual(repair_queue[1]["code"], "repair_execution_tca")
         self.assertNotIn("repair_repair_only", [item["code"] for item in repair_queue])
         self.assertIn(

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -1172,6 +1172,13 @@ class TestTradingApi(TestCase):
         )
         self.assertEqual(executable_alpha_repair["status"], "inactive")
         self.assertEqual(executable_alpha_repair["max_notional"], "0")
+        alpha_repair_closure = payload["alpha_repair_closure_board"]
+        self.assertEqual(
+            alpha_repair_closure["schema_version"],
+            "torghut.alpha-repair-closure-board-ref.v1",
+        )
+        self.assertEqual(alpha_repair_closure["status"], "inactive")
+        self.assertEqual(alpha_repair_closure["max_notional"], "0")
         warrant = payload["route_warrant_exchange"]
         self.assertEqual(
             warrant["schema_version"],
@@ -2904,6 +2911,14 @@ class TestTradingApi(TestCase):
             self.assertIn("readiness_cache", payload["dependencies"])
             self.assertIn("cache_used", payload["dependencies"]["readiness_cache"])
             self.assertFalse(payload["dependencies"]["readiness_cache"]["cache_stale"])
+            self.assertEqual(
+                payload["alpha_repair_closure_board"]["schema_version"],
+                "torghut.alpha-repair-closure-board-ref.v1",
+            )
+            self.assertEqual(
+                payload["alpha_repair_closure_board"]["max_notional"],
+                "0",
+            )
         finally:
             settings.trading_enabled = original
             settings.trading_universe_source = original_source
@@ -4192,6 +4207,15 @@ class TestTradingApi(TestCase):
             "alpha_readiness_repair_targets_missing",
             payload["executable_alpha_repair_receipts"]["reason_codes"],
         )
+        closure_board = payload["alpha_repair_closure_board"]
+        self.assertEqual(
+            closure_board["schema_version"],
+            "torghut.alpha-repair-closure-board.v1",
+        )
+        self.assertEqual(closure_board["status"], "blocked")
+        self.assertEqual(closure_board["selected_value_gate"], "routeable_candidate_count")
+        self.assertEqual(closure_board["max_notional"], "0")
+        self.assertIn("alpha_repair_receipt_missing", closure_board["reason_codes"])
         self.assertEqual(
             payload["evidence"]["repair_bid_settlement"]["dispatchable_lot_count"],
             1,


### PR DESCRIPTION
## Summary

- Adds `torghut.alpha-repair-closure-board.v1` for the current top `/trading/revenue-repair` blocker, `repair_alpha_readiness`.
- Exposes the full board on `/trading/revenue-repair` and compact `torghut.alpha-repair-closure-board-ref.v1` refs on `/readyz` and `/trading/consumer-evidence`.
- Keeps the repair lane zero-notional, records no-delta debt when `routeable_candidate_count` does not move, and preserves live submit disablement.
- Updates Torghut runtime docs and regression coverage for the board, revenue digest, readiness ref, and consumer-evidence ref.
- Adds branch coverage for the closure board normalizers, receipt-list fallback, positive-delta/no-debt path, naive timestamp rejection, and compact missing-board output after CI caught a changed-line coverage gap.

## Related Issues

None.

Design provenance:

- `docs/torghut/design-system/v6/198-torghut-alpha-repair-closure-board-and-routeable-revenue-reentry-2026-05-14.md`
- `docs/agents/designs/193-jangar-cross-plane-closure-board-and-revenue-repair-admission-2026-05-14.md`

Runtime requirement provenance:

- `GET http://torghut.torghut.svc.cluster.local/trading/revenue-repair`
- Before evidence at `2026-05-14T00:31:54.613012+00:00`: `business_state=repair_only`, `revenue_ready=false`, top queue item `repair_alpha_readiness`, reason `alpha_readiness_not_promotion_eligible`, value gate `routeable_candidate_count`, expected unblock value `4`, required output `torghut.executable-alpha-receipts.v1`, `max_notional=0`.
- After evidence at `2026-05-14T00:44:40.747637+00:00`: live deployed service remains pre-PR and unchanged with `business_state=repair_only`, `revenue_ready=false`, top queue item `repair_alpha_readiness`, `routeable_candidate_count=0`, `accepted_routeable_candidate_count=0`, `zero_notional_or_stale_evidence_rate=1.0`, `live_submission_allowed=false`, `capital_stage=shadow`, `capital_state=zero_notional`, `max_notional=0`.

Risk and rollback:

- Risk: the board can surface no-delta debt before a real alpha repair increases routeable candidates. Mitigation: the contract is additive and zero-notional.
- Risk: Jangar may consume compact refs directly. Mitigation: compact refs carry board status, required output receipt, no-delta count, `max_notional`, capital rule, and rollback target.
- Rollback: revert this PR or disable `alpha_repair_closure_board` emission; existing revenue-repair, executable-alpha receipts, and submit/capital gates remain unchanged with `max_notional=0`.

## Testing

- PASS: `uv sync --frozen --extra dev`
- PASS: `uv run --frozen ruff check app/main.py app/trading/alpha_repair_closure_board.py app/trading/revenue_repair.py scripts/build_revenue_repair_digest.py tests/test_alpha_repair_closure_board.py tests/test_build_revenue_repair_digest.py tests/test_trading_api.py`
- PASS: `uv run --frozen pytest tests/test_alpha_repair_closure_board.py -q` (`10 passed`, one existing `tests/conftest.py` event-loop deprecation warning)
- PASS: `GITHUB_BASE_REF=main GITHUB_EVENT_NAME=pull_request uv run --frozen pytest --cov --cov-branch --cov-fail-under=0 --cov-report=xml tests/test_alpha_repair_closure_board.py tests/test_build_revenue_repair_digest.py tests/test_trading_api.py -q && GITHUB_BASE_REF=main GITHUB_EVENT_NAME=pull_request uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90` (`112 passed`; changed-line coverage `187/187`, `100.00%`)
- PASS: `uv run --frozen pyright --project pyrightconfig.json`
- PASS: `uv run --frozen pyright --project pyrightconfig.alpha.json`
- PASS: `uv run --frozen pyright --project pyrightconfig.scripts.json`
- PASS: `curl -fsS http://torghut.torghut.svc.cluster.local/trading/revenue-repair | jq '{generated_at, business_state, revenue_ready, top_repair_queue_item: .repair_queue[0], affected_value_gate: .repair_queue[0].value_gate, routeable_candidate_count: .route_evidence_clearinghouse_packet.routeable_candidate_count, accepted_routeable_candidate_count: .route_evidence_clearinghouse_packet.accepted_routeable_candidate_count, zero_notional_or_stale_evidence_rate: .route_evidence_clearinghouse_packet.zero_notional_or_stale_evidence_rate, capital: .capital}'`
- PASS: GitHub PR checks on head `8ab9fcd66`: `Bytecode + lint + migration guard`, `Bytecode + pytest + coverage`, `Changed-file plan`, `Lint commit messages`, `Pyright`, `Pytest shard 0`, `Pytest shard 1`, `Pytest shard 2`, `Pytest shard 3`, `Quality signals (complexity + security)`, `Validate PR title`, and `check_changed_files`.

## Screenshots (if applicable)

N/A.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
