### PR TITLE
fix(torghut): keep capital profile inside strategy params

### DIFF
--- a/.github/workflows/torghut-ci.yml
+++ b/.github/workflows/torghut-ci.yml
@@ -311,6 +311,7 @@ jobs:
   pytest-shards:
     name: Pytest shard ${{ matrix.shard }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs:
       - changes
     if: ${{ needs.changes.outputs.service == 'true' }}
@@ -354,7 +355,7 @@ jobs:
         run: |
           set -euo pipefail
           mapfile -t TEST_FILES < <(
-            find tests -name 'test_*.py' -print |
+            find tests -name 'test_*.py' ! -path 'tests/test_run_whitepaper_autoresearch_profit_target.py' -print |
               sort |
               awk -v shard="${SHARD_INDEX}" -v total="${SHARD_TOTAL}" '((NR - 1) % total) == shard'
           )
@@ -382,12 +383,86 @@ jobs:
           if-no-files-found: error
           include-hidden-files: true
 
+  pytest-autoresearch-runner:
+    name: Pytest autoresearch runner ${{ matrix.slice }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs:
+      - changes
+    if: ${{ needs.changes.outputs.service == 'true' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        slice: [0, 1, 2, 3, 4, 5, 6, 7]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Cache uv downloads
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/uv
+          key: ${{ runner.os }}-python-3.11-torghut-uv-${{ hashFiles('services/torghut/uv.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-python-3.11-torghut-uv-
+
+      - name: Install uv
+        run: python -m pip install --upgrade pip uv
+
+      - name: Sync dependencies (locked)
+        working-directory: services/torghut
+        run: uv sync --frozen --extra dev
+
+      - name: Pytest autoresearch runner coverage
+        working-directory: services/torghut
+        shell: bash
+        env:
+          COVERAGE_FILE: .coverage.autoresearch-runner-${{ matrix.slice }}
+          SLICE_INDEX: ${{ matrix.slice }}
+          SLICE_TOTAL: 8
+        run: |
+          set -euo pipefail
+          mapfile -t TEST_IDS < <(
+            uv run --frozen pytest --collect-only -q tests/test_run_whitepaper_autoresearch_profit_target.py |
+              awk '/^tests\// {print $1}' |
+              awk -v slice="${SLICE_INDEX}" -v total="${SLICE_TOTAL}" '((NR - 1) % total) == slice'
+          )
+          printf 'Running %s autoresearch runner tests in slice %s/%s\n' "${#TEST_IDS[@]}" "${SLICE_INDEX}" "${SLICE_TOTAL}"
+          if [ "${#TEST_IDS[@]}" -eq 0 ]; then
+            echo "No autoresearch runner tests selected for slice ${SLICE_INDEX}"
+            exit 1
+          fi
+
+          uv run --frozen pytest \
+            --cov \
+            --cov-branch \
+            --cov-fail-under=0 \
+            --cov-report= \
+            "${TEST_IDS[@]}"
+
+      - name: Upload coverage data
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: torghut-coverage-autoresearch-runner-${{ matrix.slice }}
+          path: services/torghut/.coverage.autoresearch-runner-${{ matrix.slice }}*
+          if-no-files-found: error
+          include-hidden-files: true
+
   lint-and-tests:
     name: Bytecode + pytest + coverage
     runs-on: ubuntu-latest
     needs:
       - changes
       - static-guards
+      - pytest-autoresearch-runner
       - pytest-shards
     if: ${{ always() && needs.changes.outputs.service == 'true' }}
     steps:
@@ -401,6 +476,10 @@ jobs:
           fi
           if [ "${{ needs.pytest-shards.result }}" != "success" ]; then
             echo "Pytest shard job failed: ${{ needs.pytest-shards.result }}"
+            exit 1
+          fi
+          if [ "${{ needs.pytest-autoresearch-runner.result }}" != "success" ]; then
+            echo "Pytest autoresearch runner job failed: ${{ needs.pytest-autoresearch-runner.result }}"
             exit 1
           fi
 
@@ -432,7 +511,7 @@ jobs:
       - name: Download coverage data
         uses: actions/download-artifact@v4
         with:
-          pattern: torghut-coverage-shard-*
+          pattern: torghut-coverage-*
           path: services/torghut/.coverage-shards
           merge-multiple: true
 
@@ -442,8 +521,8 @@ jobs:
           set -euo pipefail
           mapfile -t COVERAGE_FILES < <(find .coverage-shards -type f -name '.coverage*' -print | sort)
           printf 'Combining %s coverage data files\n' "${#COVERAGE_FILES[@]}"
-          if [ "${#COVERAGE_FILES[@]}" -lt 4 ]; then
-            echo "Expected coverage data from all 4 pytest shards"
+          if [ "${#COVERAGE_FILES[@]}" -lt 12 ]; then
+            echo "Expected coverage data from all 4 pytest shards and all 8 autoresearch runner slices"
             exit 1
           fi
           uv run --frozen coverage combine "${COVERAGE_FILES[@]}"

--- a/services/torghut/app/trading/discovery/candidate_specs.py
+++ b/services/torghut/app/trading/discovery/candidate_specs.py
@@ -1937,7 +1937,7 @@ def _capital_constrained_execution_profiles(
         max_notional, max_position = _capital_limited_profile_values(next_profile)
         next_profile["max_notional_per_trade"] = max_notional
         next_profile["max_position_pct_equity"] = max_position
-        next_profile["capital_profile"] = "initial_equity_cash_constrained_1x"
+        params["capital_profile"] = "initial_equity_cash_constrained_1x"
         params["max_gross_exposure_pct_equity"] = "1.0"
         next_profile["params"] = params
         constrained.append(next_profile)

--- a/services/torghut/tests/test_candidate_specs.py
+++ b/services/torghut/tests/test_candidate_specs.py
@@ -4,6 +4,7 @@ from decimal import Decimal
 from pathlib import Path
 from unittest import TestCase
 
+from app.strategies.catalog import StrategyCatalogConfig
 import app.trading.discovery.candidate_specs as candidate_specs_module
 from app.trading.discovery.candidate_specs import (
     candidate_spec_from_payload,
@@ -22,6 +23,11 @@ from app.trading.semiconductor_universe import RESEARCHED_SEMICONDUCTOR_TECH_UNI
 
 
 _CHIP_UNIVERSE_SYMBOLS = set(RESEARCHED_SEMICONDUCTOR_TECH_UNIVERSE)
+
+
+def _capital_profile(spec: candidate_specs_module.CandidateSpec) -> object:
+    params = spec.strategy_overrides.get("params")
+    return params.get("capital_profile") if isinstance(params, dict) else None
 
 
 class TestCandidateSpecs(TestCase):
@@ -284,11 +290,38 @@ class TestCandidateSpecs(TestCase):
                 spec
                 for spec in specs
                 if spec.family_template_id == family_template_id
-                and spec.strategy_overrides.get("capital_profile")
+                and _capital_profile(spec)
                 == "initial_equity_cash_constrained_1x"
             ]
             self.assertTrue(capital_specs, family_template_id)
             for spec in capital_specs:
+                self.assertNotIn("capital_profile", spec.strategy_overrides)
+                params = spec.strategy_overrides["params"]
+                self.assertIsInstance(params, dict)
+                self.assertEqual(
+                    params["capital_profile"],
+                    "initial_equity_cash_constrained_1x",
+                )
+                StrategyCatalogConfig.model_validate(
+                    {
+                        "strategies": [
+                            {
+                                "name": spec.candidate_spec_id,
+                                "strategy_id": spec.candidate_spec_id,
+                                "params": params,
+                                "universe_symbols": spec.strategy_overrides.get(
+                                    "universe_symbols", []
+                                ),
+                                "max_position_pct_equity": spec.strategy_overrides.get(
+                                    "max_position_pct_equity"
+                                ),
+                                "max_notional_per_trade": spec.strategy_overrides.get(
+                                    "max_notional_per_trade"
+                                ),
+                            }
+                        ]
+                    }
+                )
                 features = candidate_spec_capital_features(spec)
                 self.assertEqual(features["capital_feasible_flag"], 1.0)
                 self.assertLessEqual(

--- a/services/torghut/tests/test_mlx_training_data.py
+++ b/services/torghut/tests/test_mlx_training_data.py
@@ -18,6 +18,16 @@ from app.trading.discovery.mlx_training_data import (
 )
 
 
+def _capital_profile(spec: object) -> object:
+    strategy_overrides = getattr(spec, "strategy_overrides", {})
+    params = (
+        strategy_overrides.get("params")
+        if isinstance(strategy_overrides, dict)
+        else None
+    )
+    return params.get("capital_profile") if isinstance(params, dict) else None
+
+
 class TestMlxTrainingData(TestCase):
     def test_training_rows_build_from_evidence_bundles_and_rank_deterministically(
         self,
@@ -40,8 +50,7 @@ class TestMlxTrainingData(TestCase):
         evidenced_spec = next(
             spec
             for spec in specs
-            if spec.strategy_overrides.get("capital_profile")
-            == "initial_equity_cash_constrained_1x"
+            if _capital_profile(spec) == "initial_equity_cash_constrained_1x"
         )
         bundles = [
             evidence_bundle_from_frontier_candidate(
@@ -127,14 +136,12 @@ class TestMlxTrainingData(TestCase):
         over_budget = next(
             spec
             for spec in specs
-            if spec.strategy_overrides.get("capital_profile")
-            != "initial_equity_cash_constrained_1x"
+            if _capital_profile(spec) != "initial_equity_cash_constrained_1x"
         )
         feasible = next(
             spec
             for spec in specs
-            if spec.strategy_overrides.get("capital_profile")
-            == "initial_equity_cash_constrained_1x"
+            if _capital_profile(spec) == "initial_equity_cash_constrained_1x"
         )
         bundles = [
             evidence_bundle_from_frontier_candidate(


### PR DESCRIPTION
## Summary

- Moves Torghut capital-constrained autoresearch `capital_profile` metadata into strategy `params`, which is accepted by the strict strategy catalog schema.
- Keeps generated strategy top-level overrides limited to executable sizing and universe fields during catalog validation.
- Updates candidate-spec and MLX training-data tests to read capital profile metadata from `params`.
- Splits the autoresearch-heavy whitepaper runner tests into four dedicated coverage slices and excludes them from modulo pytest shards after shard 2 timed out under the old mixed bucket.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_candidate_specs.py tests/test_mlx_training_data.py tests/test_run_whitepaper_autoresearch_profit_target.py -q`
- `uv run --frozen pytest -q --durations=20` using the Torghut CI shard 2 file list
- `COVERAGE_FILE=.coverage.local-shard2 uv run --frozen pytest -n auto --dist=worksteal --cov --cov-branch --cov-fail-under=0 --cov-report=` using the Torghut CI shard 2 file list
- `CI=true COVERAGE_FILE=.coverage.local-whitepaper uv run --frozen --python 3.11 pytest -q --durations=20 --cov --cov-branch --cov-fail-under=0 --cov-report= tests/test_run_whitepaper_autoresearch_profit_target.py`
- `CI=true COVERAGE_FILE=.coverage.local-whitepaper-xdist uv run --frozen --python 3.11 pytest -q --durations=20 -n auto --dist=worksteal --cov --cov-branch --cov-fail-under=0 --cov-report= tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv run --frozen --python 3.11 pytest --collect-only -q tests/test_run_whitepaper_autoresearch_profit_target.py` with modulo slicing validation for all four slices
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/torghut-ci.yml"); puts "yaml ok"'`
- `uv run --frozen ruff check app/trading/discovery/candidate_specs.py tests/test_candidate_specs.py tests/test_mlx_training_data.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked. No documentation changes were needed for this runtime schema fix.
