### PR TITLE
chore(jangar): promote image 81291d7c

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 202dcaf1
-  digest: sha256:2e6967a5d54533a34a992aa3996ac65a040807cb4e75183340b2edd2cf739333
+  tag: 81291d7c
+  digest: sha256:5c092d3026b1b80cac2dd1ffd5e2009bbae5e5a2a63323635477e3962c5c608c
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,8 +11,8 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 202dcaf1
-    digest: sha256:85c879cf387c7f088be854b3909c5eab444ff23a637d81f6e4153890a3d92ff4
+    tag: 81291d7c
+    digest: sha256:bb88d74ce3da0dfe5f7227ac666c927104e2b6afbf7d24eaca6a6eaf5528abbd
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
@@ -21,8 +21,8 @@ controlPlane:
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 202dcaf1
-    digest: sha256:2e6967a5d54533a34a992aa3996ac65a040807cb4e75183340b2edd2cf739333
+    tag: 81291d7c
+    digest: sha256:5c092d3026b1b80cac2dd1ffd5e2009bbae5e5a2a63323635477e3962c5c608c
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-14T00:03:56Z
+    deploy.knative.dev/rollout: 2026-05-14T01:05:53Z
 spec:
   replicas: 1
   strategy:
@@ -57,11 +57,11 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_RUNTIME_IMAGE
-              value: registry.ide-newton.ts.net/lab/jangar:202dcaf1@sha256:2e6967a5d54533a34a992aa3996ac65a040807cb4e75183340b2edd2cf739333
+              value: registry.ide-newton.ts.net/lab/jangar:81291d7c@sha256:5c092d3026b1b80cac2dd1ffd5e2009bbae5e5a2a63323635477e3962c5c608c
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: 202dcaf121682eb87e1e7744b3ed14817a3e3f0e
+              value: 81291d7cb42eeab098575cfe61f0d85dfdd7398d
             - name: JANGAR_GITOPS_REVISION
-              value: 202dcaf121682eb87e1e7744b3ed14817a3e3f0e
+              value: 81291d7cb42eeab098575cfe61f0d85dfdd7398d
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_BUMBA_TASK_QUEUE

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -59,5 +59,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: 202dcaf1
-    digest: sha256:2e6967a5d54533a34a992aa3996ac65a040807cb4e75183340b2edd2cf739333
+    newTag: 81291d7c
+    digest: sha256:5c092d3026b1b80cac2dd1ffd5e2009bbae5e5a2a63323635477e3962c5c608c


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `81291d7cb42eeab098575cfe61f0d85dfdd7398d`
- Image tag: `81291d7c`
- Image digest: `sha256:5c092d3026b1b80cac2dd1ffd5e2009bbae5e5a2a63323635477e3962c5c608c`
- Updated API rollout annotation
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`