### PR TITLE
chore(jangar): promote image c29a84a8

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 81291d7c
-  digest: sha256:5c092d3026b1b80cac2dd1ffd5e2009bbae5e5a2a63323635477e3962c5c608c
+  tag: c29a84a8
+  digest: sha256:22fd76b172d80e463587e235fece7d5ec797460e34622a3517d8147814a4e7f8
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,8 +11,8 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 81291d7c
-    digest: sha256:bb88d74ce3da0dfe5f7227ac666c927104e2b6afbf7d24eaca6a6eaf5528abbd
+    tag: c29a84a8
+    digest: sha256:d0c31b83235d747ffd47887a9f7c32ab34d6d752e947e5b437f2014cc82dfb52
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
@@ -21,8 +21,8 @@ controlPlane:
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 81291d7c
-    digest: sha256:5c092d3026b1b80cac2dd1ffd5e2009bbae5e5a2a63323635477e3962c5c608c
+    tag: c29a84a8
+    digest: sha256:22fd76b172d80e463587e235fece7d5ec797460e34622a3517d8147814a4e7f8
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-14T01:05:53Z
+    deploy.knative.dev/rollout: 2026-05-14T01:36:27Z
 spec:
   replicas: 1
   strategy:
@@ -57,11 +57,11 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_RUNTIME_IMAGE
-              value: registry.ide-newton.ts.net/lab/jangar:81291d7c@sha256:5c092d3026b1b80cac2dd1ffd5e2009bbae5e5a2a63323635477e3962c5c608c
+              value: registry.ide-newton.ts.net/lab/jangar:c29a84a8@sha256:22fd76b172d80e463587e235fece7d5ec797460e34622a3517d8147814a4e7f8
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: 81291d7cb42eeab098575cfe61f0d85dfdd7398d
+              value: c29a84a89ee4a8f12321b1f18c1464875dcc30cb
             - name: JANGAR_GITOPS_REVISION
-              value: 81291d7cb42eeab098575cfe61f0d85dfdd7398d
+              value: c29a84a89ee4a8f12321b1f18c1464875dcc30cb
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_BUMBA_TASK_QUEUE

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -59,5 +59,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: 81291d7c
-    digest: sha256:5c092d3026b1b80cac2dd1ffd5e2009bbae5e5a2a63323635477e3962c5c608c
+    newTag: c29a84a8
+    digest: sha256:22fd76b172d80e463587e235fece7d5ec797460e34622a3517d8147814a4e7f8


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `c29a84a89ee4a8f12321b1f18c1464875dcc30cb`
- Image tag: `c29a84a8`
- Image digest: `sha256:22fd76b172d80e463587e235fece7d5ec797460e34622a3517d8147814a4e7f8`
- Updated API rollout annotation
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`