### PR TITLE
fix(agents): raise swarm verify memory limit

### DIFF
--- a/argocd/applications/agents/swarm-agentrun-templates.yaml
+++ b/argocd/applications/agents/swarm-agentrun-templates.yaml
@@ -4,7 +4,7 @@ metadata:
   name: jangar-swarm-discover-template
   namespace: agents
   annotations:
-    agents.proompteng.ai/template: 'true'
+    agents.proompteng.ai/template: "true"
 spec:
   agentRef:
     name: codex-spark-agent
@@ -64,7 +64,7 @@ metadata:
   name: jangar-swarm-plan-template
   namespace: agents
   annotations:
-    agents.proompteng.ai/template: 'true'
+    agents.proompteng.ai/template: "true"
 spec:
   agentRef:
     name: codex-spark-agent
@@ -124,7 +124,7 @@ metadata:
   name: jangar-swarm-implement-template
   namespace: agents
   annotations:
-    agents.proompteng.ai/template: 'true'
+    agents.proompteng.ai/template: "true"
 spec:
   agentRef:
     name: codex-spark-agent
@@ -185,7 +185,7 @@ metadata:
   name: jangar-swarm-verify-template
   namespace: agents
   annotations:
-    agents.proompteng.ai/template: 'true'
+    agents.proompteng.ai/template: "true"
 spec:
   agentRef:
     name: codex-spark-agent
@@ -195,6 +195,15 @@ spec:
     type: workflow
     config:
       serviceAccountName: agents-sa
+  workload:
+    resources:
+      requests:
+        cpu: "1"
+        memory: 4Gi
+        ephemeral-storage: 8Gi
+      limits:
+        memory: 16Gi
+        ephemeral-storage: 16Gi
   ttlSecondsAfterFinished: 0
   workflow:
     steps:
@@ -249,7 +258,7 @@ metadata:
   name: torghut-swarm-discover-template
   namespace: agents
   annotations:
-    agents.proompteng.ai/template: 'true'
+    agents.proompteng.ai/template: "true"
 spec:
   agentRef:
     name: codex-spark-agent
@@ -309,7 +318,7 @@ metadata:
   name: torghut-swarm-plan-template
   namespace: agents
   annotations:
-    agents.proompteng.ai/template: 'true'
+    agents.proompteng.ai/template: "true"
 spec:
   agentRef:
     name: codex-spark-agent
@@ -369,7 +378,7 @@ metadata:
   name: torghut-swarm-implement-template
   namespace: agents
   annotations:
-    agents.proompteng.ai/template: 'true'
+    agents.proompteng.ai/template: "true"
 spec:
   agentRef:
     name: codex-spark-agent
@@ -430,7 +439,7 @@ metadata:
   name: torghut-swarm-verify-template
   namespace: agents
   annotations:
-    agents.proompteng.ai/template: 'true'
+    agents.proompteng.ai/template: "true"
 spec:
   agentRef:
     name: codex-spark-agent
@@ -440,6 +449,15 @@ spec:
     type: workflow
     config:
       serviceAccountName: agents-sa
+  workload:
+    resources:
+      requests:
+        cpu: "1"
+        memory: 4Gi
+        ephemeral-storage: 8Gi
+      limits:
+        memory: 16Gi
+        ephemeral-storage: 16Gi
   ttlSecondsAfterFinished: 0
   workflow:
     steps:


### PR DESCRIPTION
## Summary

- Raises the Jangar and Torghut swarm verify AgentRun memory limit from 8Gi to 16Gi.
- Keeps discover, plan, and implement stages on the existing default runner resources.
- Preserves the existing CPU and ephemeral-storage profile while increasing the verify memory request to 4Gi for more reliable scheduling.

## Related Issues

None

## Testing

- `git diff --check`
- `bunx prettier --check argocd/applications/agents/swarm-agentrun-templates.yaml`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents-render.yaml`
- `rg -n "name: (jangar|torghut)-swarm-verify-template|memory: 16Gi|memory: 4Gi" /tmp/agents-render.yaml`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
