### PR TITLE
chore(jangar): promote image fbaacdf5

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: c29a84a8
-  digest: sha256:22fd76b172d80e463587e235fece7d5ec797460e34622a3517d8147814a4e7f8
+  tag: fbaacdf5
+  digest: sha256:8bf30b44d8110f6198b9689f83a297c88f155fac9c7865b25e75bbd26a6f5860
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,8 +11,8 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: c29a84a8
-    digest: sha256:d0c31b83235d747ffd47887a9f7c32ab34d6d752e947e5b437f2014cc82dfb52
+    tag: fbaacdf5
+    digest: sha256:360a16e6d61dfe06c97ea1694c02eec1272ccebec5f25ee741b3e9b27a4383d0
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
@@ -21,8 +21,8 @@ controlPlane:
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: c29a84a8
-    digest: sha256:22fd76b172d80e463587e235fece7d5ec797460e34622a3517d8147814a4e7f8
+    tag: fbaacdf5
+    digest: sha256:8bf30b44d8110f6198b9689f83a297c88f155fac9c7865b25e75bbd26a6f5860
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-14T01:36:27Z
+    deploy.knative.dev/rollout: 2026-05-14T02:03:36Z
 spec:
   replicas: 1
   strategy:
@@ -57,11 +57,11 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_RUNTIME_IMAGE
-              value: registry.ide-newton.ts.net/lab/jangar:c29a84a8@sha256:22fd76b172d80e463587e235fece7d5ec797460e34622a3517d8147814a4e7f8
+              value: registry.ide-newton.ts.net/lab/jangar:fbaacdf5@sha256:8bf30b44d8110f6198b9689f83a297c88f155fac9c7865b25e75bbd26a6f5860
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: c29a84a89ee4a8f12321b1f18c1464875dcc30cb
+              value: fbaacdf509514950f42420e8a4c23f1b248eae5a
             - name: JANGAR_GITOPS_REVISION
-              value: c29a84a89ee4a8f12321b1f18c1464875dcc30cb
+              value: fbaacdf509514950f42420e8a4c23f1b248eae5a
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_BUMBA_TASK_QUEUE

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -59,5 +59,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: c29a84a8
-    digest: sha256:22fd76b172d80e463587e235fece7d5ec797460e34622a3517d8147814a4e7f8
+    newTag: fbaacdf5
+    digest: sha256:8bf30b44d8110f6198b9689f83a297c88f155fac9c7865b25e75bbd26a6f5860


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `fbaacdf509514950f42420e8a4c23f1b248eae5a`
- Image tag: `fbaacdf5`
- Image digest: `sha256:8bf30b44d8110f6198b9689f83a297c88f155fac9c7865b25e75bbd26a6f5860`
- Updated API rollout annotation
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`