### PR TITLE
feat(torghut): add alpha closure settlement market

### DIFF
--- a/docs/torghut/rollouts/2026-05-14-alpha-closure-settlement-market.md
+++ b/docs/torghut/rollouts/2026-05-14-alpha-closure-settlement-market.md
@@ -1,0 +1,69 @@
+# Torghut Alpha Closure Settlement Market
+
+Date: 2026-05-14
+
+Governing design:
+
+- `docs/torghut/design-system/v6/201-torghut-alpha-closure-settlement-and-feature-replay-market-2026-05-14.md`
+- `docs/torghut/design-system/v6/198-torghut-alpha-repair-closure-board-and-routeable-revenue-reentry-2026-05-14.md`
+
+Runtime requirement source:
+
+- `GET http://torghut.torghut.svc.cluster.local/trading/revenue-repair`
+
+Before evidence at `2026-05-14T02:17:19Z`:
+
+- `business_state=repair_only`
+- `revenue_ready=false`
+- top `repair_queue` item: `repair_alpha_readiness` / `alpha_readiness_not_promotion_eligible`
+- affected value gate: `routeable_candidate_count`
+- `routeable_candidate_count=0`
+- `zero_notional_or_stale_evidence_rate=1.0`
+- `max_notional=0`
+- `live_submission_allowed=false`
+- live alpha repair closure selected `H-CONT-01`
+
+## Change
+
+`alpha_repair_closure_board` now includes a nested
+`torghut.alpha-closure-settlement-market.v1` object. The market follows doc 201 by selecting `H-MICRO-01` as the first
+feature-replay closure while the live alpha-readiness queue remains topped by
+`alpha_readiness_not_promotion_eligible` and the hypothesis carries feature, drift, or required feature-set blockers.
+
+The market carries:
+
+- selected hypothesis, repair class, and lot class;
+- required `torghut.alpha-closure-settlement-receipt.v1`;
+- required after-receipts for alpha readiness, promotion custody, capital replay, feature replay, drift checks, and
+  required feature-set proof;
+- active dedupe key and no-delta budget;
+- pending settlement receipt template with before blockers and routeable-candidate before/after counts;
+- `max_notional=0` and `capital_rule=zero_notional_repair_only`.
+
+`/readyz` and `/trading/consumer-evidence` continue to expose only compact board refs, now including the market id,
+selected hypothesis, selected repair class, settlement receipt requirement, active dedupe key, and no-delta state.
+
+## Validation
+
+Run before release handoff:
+
+- `cd services/torghut && uv run --frozen pytest tests/test_alpha_repair_closure_board.py tests/test_build_revenue_repair_digest.py -k "alpha_repair_closure or revenue_repair"`
+- `cd services/torghut && uv run --frozen pytest tests/test_trading_api.py -k "revenue_repair or alpha_repair_closure"`
+- `cd services/torghut && uv run --frozen ruff format --check app/trading/alpha_repair_closure_board.py app/trading/revenue_repair.py tests/test_alpha_repair_closure_board.py`
+- `cd services/torghut && uv run --frozen ruff check app/trading/alpha_repair_closure_board.py app/trading/revenue_repair.py tests/test_alpha_repair_closure_board.py`
+
+## Risk And Rollback
+
+Risk is limited to additive read-model output. The change does not submit orders, write trading records, enable paper or
+live notional, or change `/readyz` admission status.
+
+Rollback is to revert the PR or stop emitting `alpha_closure_settlement_market` from `alpha_repair_closure_board`.
+Keep existing revenue-repair, executable-alpha, repair-bid settlement, and repair-outcome dividend payloads. Capital
+must remain `max_notional=0` with live submission disabled.
+
+## Revenue Status
+
+This targets `routeable_candidate_count`. It improves the next repair admission step by selecting the lineage-ready
+`H-MICRO-01` feature replay lane and blocking duplicate no-delta launches until the evidence key changes. Immediate
+revenue impact remains blocked until a settlement receipt retires feature, drift, or required feature-set blockers and
+routeable candidates rise above zero.

--- a/services/torghut/README.md
+++ b/services/torghut/README.md
@@ -211,6 +211,11 @@ Testing rules for the trading core:
   no-delta debt when candidate count does not move, and keeps the rollback target at `max_notional=0`.
   `/readyz` and `/trading/consumer-evidence` mirror only the compact
   `torghut.alpha-repair-closure-board-ref.v1` fields for Jangar admission.
+- The same board now carries the May 14 doc 201 `torghut.alpha-closure-settlement-market.v1` read-model. While
+  `repair_alpha_readiness` is the live top queue item, the market reserves the first zero-notional closure slot for
+  lineage-ready `H-MICRO-01` feature replay when drift checks, feature rows, or required feature-set evidence remain
+  missing. The compact board ref exposes the market id, selected hypothesis, settlement receipt requirement, active
+  dedupe key, and no-delta budget state without enabling paper or live notional.
 - `GET /trading/status` and `GET /readyz` now include the May 8 doc 181
   `quality_adjusted_profit_frontier` shadow projection. The reducer ranks zero-notional repair packets from quant
   quality, market-context risk flags, route/TCA state, simulation-cache freshness, and Jangar evidence-quality refs

--- a/services/torghut/app/trading/alpha_repair_closure_board.py
+++ b/services/torghut/app/trading/alpha_repair_closure_board.py
@@ -8,11 +8,15 @@ from collections.abc import Mapping, Sequence
 from datetime import datetime, timedelta, timezone
 from typing import Any, cast
 
-ALPHA_REPAIR_CLOSURE_BOARD_SCHEMA_VERSION = (
-    "torghut.alpha-repair-closure-board.v1"
-)
+ALPHA_REPAIR_CLOSURE_BOARD_SCHEMA_VERSION = "torghut.alpha-repair-closure-board.v1"
 ALPHA_REPAIR_CLOSURE_BOARD_REF_SCHEMA_VERSION = (
     "torghut.alpha-repair-closure-board-ref.v1"
+)
+ALPHA_CLOSURE_SETTLEMENT_MARKET_SCHEMA_VERSION = (
+    "torghut.alpha-closure-settlement-market.v1"
+)
+ALPHA_CLOSURE_SETTLEMENT_RECEIPT_SCHEMA_VERSION = (
+    "torghut.alpha-closure-settlement-receipt.v1"
 )
 
 _DESIGN_REF = (
@@ -23,10 +27,23 @@ _COMPANION_JANGAR_DESIGN_REF = (
     "docs/agents/designs/"
     "193-jangar-cross-plane-closure-board-and-revenue-repair-admission-2026-05-14.md"
 )
+_SETTLEMENT_MARKET_DESIGN_REF = (
+    "docs/torghut/design-system/v6/"
+    "201-torghut-alpha-closure-settlement-and-feature-replay-market-2026-05-14.md"
+)
 _DEFAULT_FRESHNESS_SECONDS = 15 * 60
 _ROLLBACK_TARGET = (
     "disable alpha_repair_closure_board emission and keep Torghut max_notional=0"
 )
+_SETTLEMENT_ROLLBACK_TARGET = (
+    "disable alpha_closure_settlement_market and keep Torghut max_notional=0"
+)
+_FEATURE_REPLAY_HYPOTHESIS_ID = "H-MICRO-01"
+_FEATURE_REPLAY_BLOCKERS = {
+    "drift_checks_missing",
+    "feature_rows_missing",
+    "required_feature_set_unavailable",
+}
 _NO_DELTA_RELEASE_CONDITIONS = [
     "evidence_window_changes",
     "blocker_set_changes",
@@ -93,6 +110,17 @@ def _string_list(value: object) -> list[str]:
     return items
 
 
+def _append_unique(items: list[str], *values: object) -> list[str]:
+    seen = set(items)
+    for value in values:
+        for candidate in _string_list(value) if _sequence(value) else [_text(value)]:
+            if not candidate or candidate in seen:
+                continue
+            seen.add(candidate)
+            items.append(candidate)
+    return items
+
+
 def _stable_hash(prefix: str, payload: Mapping[str, object]) -> str:
     encoded = json.dumps(
         {"prefix": prefix, **dict(payload)},
@@ -134,7 +162,9 @@ def _account_window(
     evidence: Mapping[str, Any],
     executable_alpha_repair_receipts: Mapping[str, Any],
 ) -> tuple[str, str, str]:
-    selected_receipt = _mapping(executable_alpha_repair_receipts.get("selected_receipt"))
+    selected_receipt = _mapping(
+        executable_alpha_repair_receipts.get("selected_receipt")
+    )
     repair_bid_settlement = _mapping(evidence.get("repair_bid_settlement"))
     account = (
         _text(selected_receipt.get("account_id"))
@@ -154,12 +184,16 @@ def _account_window(
     return account, window, trading_mode
 
 
-def _source_serving_refs(source_serving_metadata: Mapping[str, Any]) -> dict[str, object]:
+def _source_serving_refs(
+    source_serving_metadata: Mapping[str, Any],
+) -> dict[str, object]:
     build = _mapping(source_serving_metadata.get("build"))
     source_serving = _mapping(
         source_serving_metadata.get("source_serving_repair_receipt_ledger")
     )
-    route_packet = _mapping(source_serving_metadata.get("route_evidence_clearinghouse_packet"))
+    route_packet = _mapping(
+        source_serving_metadata.get("route_evidence_clearinghouse_packet")
+    )
     source_commit = (
         _text(source_serving.get("source_commit"))
         or _text(route_packet.get("source_commit"))
@@ -193,17 +227,81 @@ def _source_serving_refs(source_serving_metadata: Mapping[str, Any]) -> dict[str
     return refs
 
 
-def _selected_repair_receipt(
+def _all_repair_receipts(
+    executable_alpha_repair_receipts: Mapping[str, Any],
+) -> list[Mapping[str, Any]]:
+    receipts: list[Mapping[str, Any]] = []
+    seen: set[str] = set()
+    for raw_receipt in [
+        executable_alpha_repair_receipts.get("selected_receipt"),
+        *_sequence(executable_alpha_repair_receipts.get("receipts")),
+    ]:
+        receipt = _mapping(raw_receipt)
+        if not receipt:
+            continue
+        receipt_key = _text(receipt.get("receipt_id")) or _text(
+            receipt.get("hypothesis_id")
+        )
+        if receipt_key and receipt_key in seen:
+            continue
+        if receipt_key:
+            seen.add(receipt_key)
+        receipts.append(receipt)
+    return receipts
+
+
+def _receipt_reason_codes(receipt: Mapping[str, Any]) -> list[str]:
+    reason_codes = _string_list(receipt.get("reason_codes"))
+    settlement = _mapping(receipt.get("settlement"))
+    if not reason_codes:
+        reason_codes = _string_list(settlement.get("before_reason_codes"))
+    return reason_codes
+
+
+def _is_zero_notional_receipt(receipt: Mapping[str, Any]) -> bool:
+    return _text(receipt.get("max_notional"), "0") in {"0", "0.0", "0.00"}
+
+
+def _is_feature_replay_receipt(receipt: Mapping[str, Any]) -> bool:
+    return bool(
+        set(_receipt_reason_codes(receipt)).intersection(_FEATURE_REPLAY_BLOCKERS)
+    )
+
+
+def _closure_receipt_rank(
+    receipt: Mapping[str, Any], selected_receipt_id: str
+) -> tuple[int, str]:
+    hypothesis_id = _text(receipt.get("hypothesis_id"))
+    reason_codes = set(_receipt_reason_codes(receipt))
+    lineage_ready = _text(receipt.get("lineage_status"), "ready") == "ready"
+    feature_replay = bool(reason_codes.intersection(_FEATURE_REPLAY_BLOCKERS))
+    if (
+        hypothesis_id == _FEATURE_REPLAY_HYPOTHESIS_ID
+        and lineage_ready
+        and feature_replay
+        and _is_zero_notional_receipt(receipt)
+    ):
+        return (0, hypothesis_id)
+    if lineage_ready and feature_replay and _is_zero_notional_receipt(receipt):
+        return (10, hypothesis_id)
+    if _text(receipt.get("receipt_id")) == selected_receipt_id:
+        return (20, hypothesis_id)
+    return (50, hypothesis_id)
+
+
+def _select_closure_receipt(
     executable_alpha_repair_receipts: Mapping[str, Any],
 ) -> Mapping[str, Any]:
-    selected = _mapping(executable_alpha_repair_receipts.get("selected_receipt"))
-    if selected:
-        return selected
-    for raw_receipt in _sequence(executable_alpha_repair_receipts.get("receipts")):
-        receipt = _mapping(raw_receipt)
-        if receipt:
-            return receipt
-    return {}
+    receipts = _all_repair_receipts(executable_alpha_repair_receipts)
+    if not receipts:
+        return {}
+    selected_receipt_id = _text(
+        executable_alpha_repair_receipts.get("selected_receipt_id")
+    )
+    return sorted(
+        receipts,
+        key=lambda receipt: _closure_receipt_rank(receipt, selected_receipt_id),
+    )[0]
 
 
 def _build_repair_closure(
@@ -224,7 +322,9 @@ def _build_repair_closure(
         or "torghut-revenue-repair-digest:unknown"
     )
     receipt_id = _text(selected_receipt.get("receipt_id"))
-    capital_replay_board = _mapping(_mapping(evidence.get("alpha_readiness")).get("capital_replay_board"))
+    capital_replay_board = _mapping(
+        _mapping(evidence.get("alpha_readiness")).get("capital_replay_board")
+    )
     repair_bid_settlement = _mapping(evidence.get("repair_bid_settlement"))
     before_refs = [
         source_revenue_repair_ref,
@@ -269,9 +369,7 @@ def _build_repair_closure(
         required_receipts.append(required_output)
     validation_commands = _string_list(selected_receipt.get("validation_commands"))
     no_delta_reason = (
-        "routeable_candidate_count_unchanged"
-        if measured_delta <= 0
-        else ""
+        "routeable_candidate_count_unchanged" if measured_delta <= 0 else ""
     )
     return {
         "closure_id": closure_id,
@@ -280,7 +378,9 @@ def _build_repair_closure(
             top_queue_item.get("reason"), "alpha_readiness_not_promotion_eligible"
         ),
         "hypothesis_id": _text(selected_receipt.get("hypothesis_id")),
-        "value_gate": _text(top_queue_item.get("value_gate"), "routeable_candidate_count"),
+        "value_gate": _text(
+            top_queue_item.get("value_gate"), "routeable_candidate_count"
+        ),
         "priority": _int(top_queue_item.get("priority"), 70),
         "expected_unblock_value": _int(top_queue_item.get("expected_unblock_value"), 1),
         "required_output_receipt": required_output,
@@ -306,7 +406,8 @@ def _no_delta_debt_from_closure(closure: Mapping[str, Any]) -> dict[str, object]
     if _int(closure.get("measured_delta")) > 0:
         return None
     return {
-        "debt_id": "alpha-repair-no-delta:" + _stable_hash(
+        "debt_id": "alpha-repair-no-delta:"
+        + _stable_hash(
             "alpha-repair-no-delta",
             {
                 "closure_id": _text(closure.get("closure_id")),
@@ -324,6 +425,201 @@ def _no_delta_debt_from_closure(closure: Mapping[str, Any]) -> dict[str, object]
         "measured_delta": closure.get("measured_delta"),
         "no_delta_reason": closure.get("no_delta_reason"),
         "release_conditions": list(_NO_DELTA_RELEASE_CONDITIONS),
+    }
+
+
+def _selected_lot_class(selected_receipt: Mapping[str, Any]) -> str:
+    if _is_feature_replay_receipt(selected_receipt):
+        return "feature_lineage"
+    return "promotion_custody"
+
+
+def _required_after_receipts(
+    top_queue_item: Mapping[str, Any], selected_receipt: Mapping[str, Any]
+) -> list[str]:
+    receipts = _string_list(selected_receipt.get("required_output_receipts"))
+    receipts = _append_unique(
+        receipts,
+        top_queue_item.get("required_receipts"),
+        top_queue_item.get("required_output_receipt"),
+    )
+    if _is_feature_replay_receipt(selected_receipt):
+        receipts = _append_unique(
+            receipts,
+            "feature_replay_receipt",
+            "drift_check_receipt",
+            "required_feature_set_receipt",
+        )
+    return receipts
+
+
+def _promotion_eligible_count(evidence: Mapping[str, Any]) -> int:
+    return _int(
+        _mapping(evidence.get("alpha_readiness")).get("promotion_eligible_total")
+    )
+
+
+def _settlement_status(
+    *,
+    board_status: str,
+    selected_receipt: Mapping[str, Any],
+    no_delta_used: int,
+) -> str:
+    if board_status in {"blocked", "held", "inactive"}:
+        return board_status
+    if not selected_receipt:
+        return "blocked"
+    if no_delta_used > 0:
+        return "pending_no_delta"
+    return "pending"
+
+
+def _build_pending_settlement_receipt(
+    *,
+    market_id: str,
+    closure: Mapping[str, Any],
+    selected_receipt: Mapping[str, Any],
+    evidence: Mapping[str, Any],
+    fresh_until: datetime,
+) -> dict[str, object]:
+    reason_codes = _receipt_reason_codes(selected_receipt)
+    routeable_before = _int(closure.get("routeable_candidate_count_before"))
+    measured_delta = _int(closure.get("measured_delta"))
+    routeable_after = max(0, routeable_before + measured_delta)
+    no_delta_reason = _text(closure.get("no_delta_reason"))
+    receipt_id = "alpha-closure-settlement-receipt:" + _stable_hash(
+        "alpha-closure-settlement-receipt",
+        {
+            "market_id": market_id,
+            "hypothesis_id": _text(selected_receipt.get("hypothesis_id")),
+            "dedupe_key": _text(closure.get("dedupe_key")),
+            "reason_codes": reason_codes,
+        },
+    )
+    return {
+        "schema_version": ALPHA_CLOSURE_SETTLEMENT_RECEIPT_SCHEMA_VERSION,
+        "receipt_id": receipt_id,
+        "market_id": market_id,
+        "hypothesis_id": _text(selected_receipt.get("hypothesis_id")),
+        "candidate_id": _text(selected_receipt.get("candidate_id")) or None,
+        "strategy_id": _text(selected_receipt.get("strategy_id")) or None,
+        "repair_class": "feature_replay_closure"
+        if _is_feature_replay_receipt(selected_receipt)
+        else _text(selected_receipt.get("repair_class"), "alpha_repair_closure"),
+        "before_refs": _string_list(closure.get("before_refs")),
+        "after_refs": [],
+        "retired_reason_codes": [],
+        "preserved_reason_codes": reason_codes,
+        "introduced_reason_codes": [],
+        "measured_delta": measured_delta,
+        "routeable_candidate_count_before": routeable_before,
+        "routeable_candidate_count_after": routeable_after,
+        "promotion_eligible_before": _promotion_eligible_count(evidence),
+        "promotion_eligible_after": _promotion_eligible_count(evidence),
+        "no_delta_reason": no_delta_reason,
+        "next_allowed_attempt_after": fresh_until.isoformat()
+        if no_delta_reason
+        else None,
+        "validation_commands": _string_list(closure.get("validation_commands")),
+        "max_notional": _text(closure.get("max_notional"), "0"),
+        "capital_rule": _text(closure.get("capital_rule"), "zero_notional_repair_only"),
+    }
+
+
+def _build_settlement_market(
+    *,
+    generated: datetime,
+    fresh_until: datetime,
+    status: str,
+    reason_codes: Sequence[str],
+    top_queue_item: Mapping[str, Any],
+    selected_receipt: Mapping[str, Any],
+    executable_alpha_repair_receipts: Mapping[str, Any],
+    evidence: Mapping[str, Any],
+    capital: Mapping[str, Any],
+    source_refs: Mapping[str, object],
+    closure: Mapping[str, Any] | None,
+    account: str,
+    window: str,
+) -> dict[str, object]:
+    source_revenue_repair_ref = (
+        _text(selected_receipt.get("source_revenue_repair_ref"))
+        or _text(executable_alpha_repair_receipts.get("source_revenue_repair_ref"))
+        or "torghut-revenue-repair-digest:unknown"
+    )
+    repair_bid_settlement = _mapping(evidence.get("repair_bid_settlement"))
+    repair_outcome_dividend = _mapping(evidence.get("repair_outcome_dividend"))
+    hypothesis_id = _text(selected_receipt.get("hypothesis_id"))
+    active_dedupe_key = _text(_mapping(closure).get("dedupe_key"))
+    market_id = "alpha-closure-settlement-market:" + _stable_hash(
+        "alpha-closure-settlement-market",
+        {
+            "account": account,
+            "window": window,
+            "queue_code": _text(top_queue_item.get("code")),
+            "hypothesis_id": hypothesis_id,
+            "reason_codes": _receipt_reason_codes(selected_receipt),
+            "source_commit": _text(source_refs.get("source_commit")),
+        },
+    )
+    pending_receipt = (
+        _build_pending_settlement_receipt(
+            market_id=market_id,
+            closure=closure,
+            selected_receipt=selected_receipt,
+            evidence=evidence,
+            fresh_until=fresh_until,
+        )
+        if closure is not None and selected_receipt
+        else None
+    )
+    no_delta_used = (
+        1 if pending_receipt and pending_receipt.get("no_delta_reason") else 0
+    )
+    return {
+        "schema_version": ALPHA_CLOSURE_SETTLEMENT_MARKET_SCHEMA_VERSION,
+        "market_id": market_id,
+        "generated_at": generated.isoformat(),
+        "fresh_until": fresh_until.isoformat(),
+        "governing_design_ref": _SETTLEMENT_MARKET_DESIGN_REF,
+        "status": _settlement_status(
+            board_status=status,
+            selected_receipt=selected_receipt,
+            no_delta_used=no_delta_used,
+        ),
+        "reason_codes": list(reason_codes),
+        "source_revenue_repair_ref": source_revenue_repair_ref,
+        "source_repair_bid_settlement_ref": repair_bid_settlement.get("ledger_id"),
+        "source_repair_outcome_dividend_ref": repair_outcome_dividend.get("ledger_id"),
+        "account_id": account,
+        "window": window,
+        "selected_value_gate": _text(
+            top_queue_item.get("value_gate"), "routeable_candidate_count"
+        ),
+        "selected_hypothesis_id": hypothesis_id,
+        "selected_repair_class": "feature_replay_closure"
+        if _is_feature_replay_receipt(selected_receipt)
+        else _text(selected_receipt.get("repair_class"), "alpha_repair_closure"),
+        "selected_lot_class": _selected_lot_class(selected_receipt),
+        "required_output_receipt": ALPHA_CLOSURE_SETTLEMENT_RECEIPT_SCHEMA_VERSION,
+        "required_after_receipts": _required_after_receipts(
+            top_queue_item, selected_receipt
+        ),
+        "before_blocker_codes": _receipt_reason_codes(selected_receipt),
+        "no_delta_budget": {
+            "max_attempts_per_dedupe_key": 1,
+            "used_attempts": no_delta_used,
+            "remaining_attempts": max(0, 1 - no_delta_used),
+            "state": "consumed" if no_delta_used else "available",
+            "release_conditions": list(_NO_DELTA_RELEASE_CONDITIONS),
+        },
+        "active_dedupe_key": active_dedupe_key,
+        "pending_settlement_receipt": pending_receipt,
+        "max_notional": _text(capital.get("max_notional"), "0"),
+        "capital_rule": _text(
+            top_queue_item.get("capital_rule"), "zero_notional_repair_only"
+        ),
+        "rollback_target": _SETTLEMENT_ROLLBACK_TARGET,
     }
 
 
@@ -355,7 +651,7 @@ def build_alpha_repair_closure_board(
     generated = generated_at.astimezone(timezone.utc)
     fresh_until = generated + timedelta(seconds=_DEFAULT_FRESHNESS_SECONDS)
     top_item = _top_queue_item(repair_queue)
-    selected_receipt = _selected_repair_receipt(executable_alpha_repair_receipts)
+    selected_receipt = _select_closure_receipt(executable_alpha_repair_receipts)
     source_refs = _source_serving_refs(source_serving_metadata or {})
     account, window, trading_mode = _account_window(
         evidence=evidence,
@@ -401,6 +697,22 @@ def build_alpha_repair_closure_board(
     elif not db_current:
         status = "held"
 
+    alpha_closure_settlement_market = _build_settlement_market(
+        generated=generated,
+        fresh_until=fresh_until,
+        status=status,
+        reason_codes=reason_codes,
+        top_queue_item=top_item,
+        selected_receipt=selected_receipt,
+        executable_alpha_repair_receipts=executable_alpha_repair_receipts,
+        evidence=evidence,
+        capital=capital,
+        source_refs=source_refs,
+        closure=closure,
+        account=account,
+        window=window,
+    )
+
     board_id = "alpha-repair-closure-board:" + _stable_hash(
         "alpha-repair-closure-board",
         {
@@ -445,6 +757,7 @@ def build_alpha_repair_closure_board(
         "db_schema_current": db_current,
         "repair_closures": [closure] if closure is not None else [],
         "no_delta_debt": no_delta_debt,
+        "alpha_closure_settlement_market": alpha_closure_settlement_market,
         "rollback_target": _ROLLBACK_TARGET,
     }
 
@@ -467,6 +780,8 @@ def compact_alpha_repair_closure_board(
     empty_closure: Mapping[str, Any] = {}
     top_closure = closures[0] if closures else empty_closure
     no_delta_debt = _sequence(payload.get("no_delta_debt"))
+    settlement_market = _mapping(payload.get("alpha_closure_settlement_market"))
+    no_delta_budget = _mapping(settlement_market.get("no_delta_budget"))
     return {
         "schema_version": ALPHA_REPAIR_CLOSURE_BOARD_REF_SCHEMA_VERSION,
         "board_schema_version": payload.get("schema_version"),
@@ -479,6 +794,15 @@ def compact_alpha_repair_closure_board(
         "selected_value_gate": payload.get("selected_value_gate"),
         "required_output_receipt": top_closure.get("required_output_receipt")
         or _mapping(payload.get("top_queue_item_ref")).get("required_output_receipt"),
+        "settlement_market_id": settlement_market.get("market_id"),
+        "settlement_market_status": settlement_market.get("status"),
+        "selected_hypothesis_id": settlement_market.get("selected_hypothesis_id")
+        or top_closure.get("hypothesis_id"),
+        "selected_repair_class": settlement_market.get("selected_repair_class"),
+        "required_settlement_receipt": settlement_market.get("required_output_receipt"),
+        "active_dedupe_key": settlement_market.get("active_dedupe_key")
+        or top_closure.get("dedupe_key"),
+        "no_delta_budget_state": no_delta_budget.get("state"),
         "no_delta_debt_count": len(no_delta_debt),
         "max_notional": payload.get("max_notional"),
         "capital_rule": payload.get("capital_rule"),
@@ -487,6 +811,8 @@ def compact_alpha_repair_closure_board(
 
 
 __all__ = [
+    "ALPHA_CLOSURE_SETTLEMENT_MARKET_SCHEMA_VERSION",
+    "ALPHA_CLOSURE_SETTLEMENT_RECEIPT_SCHEMA_VERSION",
     "ALPHA_REPAIR_CLOSURE_BOARD_REF_SCHEMA_VERSION",
     "ALPHA_REPAIR_CLOSURE_BOARD_SCHEMA_VERSION",
     "build_alpha_repair_closure_board",

--- a/services/torghut/app/trading/revenue_repair.py
+++ b/services/torghut/app/trading/revenue_repair.py
@@ -801,6 +801,31 @@ def _summarize_repair_bid_settlement(
     }
 
 
+def _summarize_repair_outcome_dividend(
+    repair_outcome_dividend_ledger: Mapping[str, Any],
+) -> dict[str, object]:
+    if not repair_outcome_dividend_ledger:
+        return {
+            "ledger_id": None,
+            "schema_version": None,
+            "open_escrow_count": 0,
+            "no_delta_lot_count": 0,
+            "routeable_candidate_count": 0,
+            "max_notional": "0",
+        }
+    summary = _mapping(repair_outcome_dividend_ledger.get("summary"))
+    return {
+        "ledger_id": repair_outcome_dividend_ledger.get("ledger_id"),
+        "schema_version": repair_outcome_dividend_ledger.get("schema_version"),
+        "open_escrow_count": _int(summary.get("open_escrow_count")),
+        "no_delta_lot_count": _int(summary.get("no_delta_lot_count")),
+        "positive_dividend_count": _int(summary.get("positive_dividend_count")),
+        "negative_dividend_count": _int(summary.get("negative_dividend_count")),
+        "routeable_candidate_count": _int(summary.get("routeable_candidate_count")),
+        "max_notional": _text(summary.get("max_notional"), "0"),
+    }
+
+
 def _business_state(
     *,
     revenue_ready: bool,
@@ -851,6 +876,10 @@ def build_revenue_repair_digest(
     repair_bid_settlement = _choose_mapping(
         status_payload.get("repair_bid_settlement_ledger"),
         readyz_payload.get("repair_bid_settlement_ledger"),
+    )
+    repair_outcome_dividend = _choose_mapping(
+        status_payload.get("repair_outcome_dividend_ledger"),
+        readyz_payload.get("repair_outcome_dividend_ledger"),
     )
     db_check = _choose_mapping(
         status_payload.get("db_check"),
@@ -913,6 +942,9 @@ def build_revenue_repair_digest(
         ),
         "repair_bid_settlement": _summarize_repair_bid_settlement(
             repair_bid_settlement
+        ),
+        "repair_outcome_dividend": _summarize_repair_outcome_dividend(
+            repair_outcome_dividend
         ),
         "simple_lane_reject_reason_totals": _collect_reason_counts(status_payload),
     }

--- a/services/torghut/tests/test_alpha_repair_closure_board.py
+++ b/services/torghut/tests/test_alpha_repair_closure_board.py
@@ -78,6 +78,61 @@ def _repair_receipts() -> dict[str, object]:
     }
 
 
+def _feature_repair_receipts() -> dict[str, object]:
+    payload = _repair_receipts()
+    payload["selected_receipt_id"] = "executable-alpha-repair-receipt:cont"
+    payload["selected_receipt"] = {
+        "receipt_id": "executable-alpha-repair-receipt:cont",
+        "source_revenue_repair_ref": "torghut-revenue-repair-digest:test",
+        "hypothesis_id": "H-CONT-01",
+        "candidate_id": "candidate-cont",
+        "strategy_id": "strategy-cont",
+        "lineage_status": "ready",
+        "repair_class": "evidence_window_refresh",
+        "reason_codes": ["post_cost_expectancy_non_positive"],
+        "validation_commands": [
+            "uv run --frozen pytest services/torghut/tests/test_executable_alpha_repair_receipts.py -k evidence_window"
+        ],
+        "required_output_receipts": [
+            "alpha_readiness_receipt",
+            "hypothesis_promotion_receipt",
+            "capital_replay_board",
+            "torghut.executable-alpha-receipts.v1",
+        ],
+        "max_notional": "0",
+        "capital_rule": "zero_notional_repair_only",
+    }
+    payload["receipts"] = [
+        payload["selected_receipt"],
+        {
+            "receipt_id": "executable-alpha-repair-receipt:micro",
+            "source_revenue_repair_ref": "torghut-revenue-repair-digest:test",
+            "hypothesis_id": "H-MICRO-01",
+            "candidate_id": "chip-paper-microbar-composite@execution-proof",
+            "strategy_id": "microbar_volume_continuation_long_top2_chip_v1@paper",
+            "lineage_status": "ready",
+            "repair_class": "evidence_window_refresh",
+            "reason_codes": [
+                "drift_checks_missing",
+                "feature_rows_missing",
+                "required_feature_set_unavailable",
+            ],
+            "validation_commands": [
+                "uv run --frozen pytest services/torghut/tests/test_executable_alpha_repair_receipts.py -k evidence_window"
+            ],
+            "required_output_receipts": [
+                "alpha_readiness_receipt",
+                "hypothesis_promotion_receipt",
+                "capital_replay_board",
+                "torghut.executable-alpha-receipts.v1",
+            ],
+            "max_notional": "0",
+            "capital_rule": "zero_notional_repair_only",
+        },
+    ]
+    return payload
+
+
 def _build(
     *,
     generated_at: datetime = NOW,
@@ -124,9 +179,55 @@ def test_alpha_repair_closure_board_selects_zero_notional_top_alpha_repair() -> 
     assert closure["no_delta_reason"] == "routeable_candidate_count_unchanged"
     assert closure["max_notional"] == "0"
     assert closure["validation_commands"]
+    market = cast(Mapping[str, Any], board["alpha_closure_settlement_market"])
+    assert market["schema_version"] == "torghut.alpha-closure-settlement-market.v1"
+    assert (
+        market["required_output_receipt"]
+        == "torghut.alpha-closure-settlement-receipt.v1"
+    )
+    assert market["active_dedupe_key"] == closure["dedupe_key"]
+    assert market["no_delta_budget"]["state"] == "consumed"
     no_delta_debt = cast(list[Mapping[str, Any]], board["no_delta_debt"])
     assert no_delta_debt[0]["dedupe_key"] == closure["dedupe_key"]
     assert "blocker_set_changes" in no_delta_debt[0]["release_conditions"]
+
+
+def test_alpha_repair_closure_board_selects_micro_feature_replay_market_first() -> None:
+    board = _build(repair_receipts=_feature_repair_receipts())
+
+    closure = cast(list[Mapping[str, Any]], board["repair_closures"])[0]
+    assert closure["hypothesis_id"] == "H-MICRO-01"
+    assert closure["reason_code"] == "alpha_readiness_not_promotion_eligible"
+    assert closure["max_notional"] == "0"
+    market = cast(Mapping[str, Any], board["alpha_closure_settlement_market"])
+    assert market["selected_hypothesis_id"] == "H-MICRO-01"
+    assert market["selected_repair_class"] == "feature_replay_closure"
+    assert market["selected_lot_class"] == "feature_lineage"
+    assert market["selected_value_gate"] == "routeable_candidate_count"
+    assert (
+        market["required_output_receipt"]
+        == "torghut.alpha-closure-settlement-receipt.v1"
+    )
+    assert market["required_after_receipts"][-3:] == [
+        "feature_replay_receipt",
+        "drift_check_receipt",
+        "required_feature_set_receipt",
+    ]
+    assert market["before_blocker_codes"] == [
+        "drift_checks_missing",
+        "feature_rows_missing",
+        "required_feature_set_unavailable",
+    ]
+    pending_receipt = cast(Mapping[str, Any], market["pending_settlement_receipt"])
+    assert (
+        pending_receipt["schema_version"]
+        == "torghut.alpha-closure-settlement-receipt.v1"
+    )
+    assert pending_receipt["hypothesis_id"] == "H-MICRO-01"
+    assert pending_receipt["repair_class"] == "feature_replay_closure"
+    assert pending_receipt["routeable_candidate_count_before"] == 0
+    assert pending_receipt["routeable_candidate_count_after"] == 0
+    assert pending_receipt["max_notional"] == "0"
 
 
 def test_alpha_repair_closure_board_accepts_string_db_schema_flags() -> None:
@@ -142,7 +243,7 @@ def test_alpha_repair_closure_board_accepts_string_db_schema_flags() -> None:
     assert "db_check_schema_not_current" in default_held["reason_codes"]
 
 
-def test_alpha_repair_closure_board_uses_receipt_list_fallback_and_positive_delta() -> None:
+def test_alpha_repair_closure_board_uses_receipt_fallback_and_positive_delta() -> None:
     repair_receipts = _repair_receipts()
     selected_receipt = cast(dict[str, object], repair_receipts.pop("selected_receipt"))
     selected_receipt["measured_delta"] = "2.0"
@@ -154,7 +255,9 @@ def test_alpha_repair_closure_board_uses_receipt_list_fallback_and_positive_delt
     repair_receipts["receipts"] = [selected_receipt]
     evidence = _evidence()
     repair_bid_settlement = cast(dict[str, object], evidence["repair_bid_settlement"])
-    routeability_acceptance = cast(dict[str, object], evidence["routeability_acceptance"])
+    routeability_acceptance = cast(
+        dict[str, object], evidence["routeability_acceptance"]
+    )
     repair_bid_settlement["routeable_candidate_count"] = True
     routeability_acceptance["accepted_routeable_candidate_count"] = 4.7
     evidence["route_evidence_clearinghouse"] = {
@@ -169,7 +272,9 @@ def test_alpha_repair_closure_board_uses_receipt_list_fallback_and_positive_delt
     assert closure["no_delta_reason"] == ""
     assert board["no_delta_debt"] == []
     assert closure["before_refs"][-1] == "executable-alpha-repair-receipt:test"
-    assert closure["required_receipts"].count("torghut.executable-alpha-receipts.v1") == 1
+    assert (
+        closure["required_receipts"].count("torghut.executable-alpha-receipts.v1") == 1
+    )
 
 
 def test_alpha_repair_closure_board_rejects_naive_generated_at() -> None:
@@ -220,6 +325,13 @@ def test_compact_alpha_repair_closure_board_returns_jangar_facing_ref() -> None:
     assert compact["status"] == "selected"
     assert compact["selected_value_gate"] == "routeable_candidate_count"
     assert compact["required_output_receipt"] == "torghut.executable-alpha-receipts.v1"
+    assert (
+        compact["required_settlement_receipt"]
+        == "torghut.alpha-closure-settlement-receipt.v1"
+    )
+    assert compact["selected_hypothesis_id"] == "H-AAPL-ROUTE-REHAB"
+    assert compact["active_dedupe_key"]
+    assert compact["no_delta_budget_state"] == "consumed"
     assert compact["no_delta_debt_count"] == 1
     assert compact["max_notional"] == "0"
 


### PR DESCRIPTION
## Summary

- Implements the doc 201 Torghut alpha closure settlement market inside the existing
  `alpha_repair_closure_board`, with governing references to doc 201 and doc 198.
- Ranks executable alpha repair receipts so lineage-ready `H-MICRO-01` feature replay receives the first
  zero-notional closure slot while `drift_checks_missing`, `feature_rows_missing`, or
  `required_feature_set_unavailable` remain active.
- Adds the pending `torghut.alpha-closure-settlement-receipt.v1` template, active dedupe key, no-delta budget,
  compact Jangar-facing refs, and repair outcome dividend source refs without enabling paper or live notional.
- Updates Torghut README and rollout notes with validation, risk, rollback, and revenue status.

## Related Issues

None.

Design and runtime provenance:

- Governing design: `docs/torghut/design-system/v6/201-torghut-alpha-closure-settlement-and-feature-replay-market-2026-05-14.md`
- Base board design: `docs/torghut/design-system/v6/198-torghut-alpha-repair-closure-board-and-routeable-revenue-reentry-2026-05-14.md`
- Runtime source of truth: `GET http://torghut.torghut.svc.cluster.local/trading/revenue-repair`

Business evidence:

- Before live evidence at `2026-05-14T02:17:19Z`: `business_state=repair_only`, `revenue_ready=false`, top queue
  `repair_alpha_readiness` / `alpha_readiness_not_promotion_eligible`, value gate `routeable_candidate_count`,
  `routeable_candidate_count=0`, `zero_notional_or_stale_evidence_rate=1.0`, `live_submission_allowed=false`,
  `capital_stage=shadow`, `capital_state=zero_notional`, `max_notional=0`, existing closure selected `H-CONT-01`.
- Branch-local after evidence from live `/readyz` and `/trading/status` rebuilt at `2026-05-14T02:25:00Z`:
  `business_state=repair_only`, `revenue_ready=false`, same top queue and capital posture, closure market selected
  `H-MICRO-01`, `selected_repair_class=feature_replay_closure`, `selected_lot_class=feature_lineage`,
  `required_output_receipt=torghut.alpha-closure-settlement-receipt.v1`, `no_delta_budget.state=consumed`,
  `max_notional=0`.

Risk and rollback:

- Risk is limited to additive read-model output on revenue-repair and compact evidence refs. The change does not
  submit orders, write trading records, change `/readyz` status, or open paper/live capital.
- Rollback is to revert this PR or stop emitting `alpha_closure_settlement_market`; existing revenue-repair,
  executable-alpha, repair-bid settlement, and repair-outcome dividend payloads remain valid.

## Testing

- `cd services/torghut && /tmp/codex-uv/bin/uv sync --frozen --extra dev` - pass
- `cd services/torghut && /tmp/codex-uv/bin/uv run --frozen --extra dev pytest tests/test_alpha_repair_closure_board.py tests/test_build_revenue_repair_digest.py -k "alpha_repair_closure or revenue_repair"` - pass, 25 passed
- `cd services/torghut && /tmp/codex-uv/bin/uv run --frozen --extra dev pytest tests/test_trading_api.py -k "revenue_repair or alpha_repair_closure"` - pass, 1 passed
- `cd services/torghut && /tmp/codex-uv/bin/uv run --frozen --extra dev ruff format --check app/trading/alpha_repair_closure_board.py app/trading/revenue_repair.py tests/test_alpha_repair_closure_board.py` - pass
- `cd services/torghut && /tmp/codex-uv/bin/uv run --frozen --extra dev ruff check app/trading/alpha_repair_closure_board.py app/trading/revenue_repair.py tests/test_alpha_repair_closure_board.py` - pass
- `cd services/torghut && /tmp/codex-uv/bin/uv run --frozen --extra dev pyright --project pyrightconfig.json` - pass, 0 errors
- `cd services/torghut && /tmp/codex-uv/bin/uv run --frozen --extra dev pyright --project pyrightconfig.alpha.json` - pass, 0 errors
- `cd services/torghut && /tmp/codex-uv/bin/uv run --frozen --extra dev pyright --project pyrightconfig.scripts.json` - pass, 0 errors
- `bunx oxfmt --check services/torghut/README.md docs/torghut/rollouts/2026-05-14-alpha-closure-settlement-market.md` - pass
- `git diff --check` - pass
- Local digest rebuild from live `/readyz` and `/trading/status` with this branch selected `H-MICRO-01` and kept
  `max_notional=0`.

## Screenshots (if applicable)

N/A.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
