### PR TITLE
chore(jangar): promote image 36f3b393

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: fbaacdf5
-  digest: sha256:8bf30b44d8110f6198b9689f83a297c88f155fac9c7865b25e75bbd26a6f5860
+  tag: 36f3b393
+  digest: sha256:94a0c46d1618518a3863fda7a7e8e0062767fb8b840163b63d8f3f092d78b996
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,8 +11,8 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: fbaacdf5
-    digest: sha256:360a16e6d61dfe06c97ea1694c02eec1272ccebec5f25ee741b3e9b27a4383d0
+    tag: 36f3b393
+    digest: sha256:0f82efe34f94bce2f528fd7177ceba007f0250a34ed566c064b6a037edbad16b
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
@@ -21,8 +21,8 @@ controlPlane:
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: fbaacdf5
-    digest: sha256:8bf30b44d8110f6198b9689f83a297c88f155fac9c7865b25e75bbd26a6f5860
+    tag: 36f3b393
+    digest: sha256:94a0c46d1618518a3863fda7a7e8e0062767fb8b840163b63d8f3f092d78b996
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-14T02:03:36Z
+    deploy.knative.dev/rollout: 2026-05-14T03:03:11Z
 spec:
   replicas: 1
   strategy:
@@ -57,11 +57,11 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_RUNTIME_IMAGE
-              value: registry.ide-newton.ts.net/lab/jangar:fbaacdf5@sha256:8bf30b44d8110f6198b9689f83a297c88f155fac9c7865b25e75bbd26a6f5860
+              value: registry.ide-newton.ts.net/lab/jangar:36f3b393@sha256:94a0c46d1618518a3863fda7a7e8e0062767fb8b840163b63d8f3f092d78b996
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: fbaacdf509514950f42420e8a4c23f1b248eae5a
+              value: 36f3b3936514af7f95d751670b64238eb0df7876
             - name: JANGAR_GITOPS_REVISION
-              value: fbaacdf509514950f42420e8a4c23f1b248eae5a
+              value: 36f3b3936514af7f95d751670b64238eb0df7876
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_BUMBA_TASK_QUEUE

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -59,5 +59,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: fbaacdf5
-    digest: sha256:8bf30b44d8110f6198b9689f83a297c88f155fac9c7865b25e75bbd26a6f5860
+    newTag: 36f3b393
+    digest: sha256:94a0c46d1618518a3863fda7a7e8e0062767fb8b840163b63d8f3f092d78b996


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `36f3b3936514af7f95d751670b64238eb0df7876`
- Image tag: `36f3b393`
- Image digest: `sha256:94a0c46d1618518a3863fda7a7e8e0062767fb8b840163b63d8f3f092d78b996`
- Updated API rollout annotation
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`