### PR TITLE
fix(torghut): account for runtime capital pressure

### DIFF
--- a/services/torghut/app/trading/discovery/candidate_specs.py
+++ b/services/torghut/app/trading/discovery/candidate_specs.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 import hashlib
 import json
 from dataclasses import dataclass
-from decimal import Decimal, InvalidOperation
+from decimal import Decimal
 from typing import Any, Literal, Mapping, Sequence, cast
 
+from app.trading.discovery.capital_budget import estimate_capital_pressure
 from app.trading.discovery.hypothesis_cards import HypothesisCard
 from app.trading.semiconductor_universe import (
     LIVE_SIGNAL_COVERED_SEMICONDUCTOR_UNIVERSE as LIVE_SIGNAL_COVERED_SEMICONDUCTOR_UNIVERSE,
@@ -1901,30 +1902,22 @@ def _mapping(value: Any) -> dict[str, Any]:
     return {str(key): item for key, item in cast(Mapping[Any, Any], value).items()}
 
 
-def _profile_decimal(value: Any, *, default: str = "0") -> Decimal:
-    try:
-        return Decimal(str(value if value is not None else default))
-    except (InvalidOperation, TypeError, ValueError):
-        return Decimal(default)
-
-
-def _profile_slot_count(profile: Mapping[str, Any]) -> int:
-    params = _mapping(profile.get("params"))
-    slot_values = [
-        _profile_decimal(params.get("max_entries_per_session"), default="1"),
-        _profile_decimal(params.get("max_pair_legs"), default="1"),
-        _profile_decimal(params.get("top_n"), default="1"),
-    ]
-    return max(1, int(max(slot_values)))
+def _format_profile_budget(value: Decimal) -> str:
+    text = format(value.normalize(), "f")
+    if "." in text:
+        text = text.rstrip("0").rstrip(".")
+    return text or "0"
 
 
 def _capital_limited_profile_values(profile: Mapping[str, Any]) -> tuple[str, str]:
-    slot_count = _profile_slot_count(profile)
-    if slot_count <= 1:
-        return "30000", "1.0"
-    if slot_count == 2:
-        return "15000", "0.50"
-    return "7500", "0.25"
+    params = _mapping(profile.get("params"))
+    pressure = max(
+        Decimal("1"),
+        Decimal(str(estimate_capital_pressure(params))),
+    )
+    max_notional = (Decimal("30000") / pressure).quantize(Decimal("0.01"))
+    max_position = (Decimal("1") / pressure).quantize(Decimal("0.000001"))
+    return _format_profile_budget(max_notional), _format_profile_budget(max_position)
 
 
 def _capital_constrained_execution_profiles(

--- a/services/torghut/app/trading/discovery/capital_budget.py
+++ b/services/torghut/app/trading/discovery/capital_budget.py
@@ -1,0 +1,126 @@
+"""Capital-budget estimates shared by autoresearch proposal and replay selection."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Sequence, cast
+
+DEFAULT_CAPITAL_START_EQUITY = 31590.02
+
+
+def _float(value: Any) -> float:
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        values = cast(Sequence[Any], value)
+        value = values[0] if values else 0.0
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _positive_or_default(value: float, default: float) -> float:
+    return value if value > 0.0 else default
+
+
+def _param_slot(params: Mapping[str, Any], key: str) -> float:
+    return _positive_or_default(_float(params.get(key)), 1.0)
+
+
+def estimate_capital_slot_count(
+    params: Mapping[str, Any], *, rank_count_floor: int = 1
+) -> float:
+    """Estimate simultaneous entry slots implied by runtime sleeve controls."""
+
+    return max(
+        1.0,
+        float(max(1, int(rank_count_floor))),
+        _param_slot(params, "max_entries_per_session"),
+        _param_slot(params, "max_concurrent_positions"),
+        _param_slot(params, "max_pair_legs"),
+        _param_slot(params, "top_n"),
+    )
+
+
+def estimate_entry_notional_multiplier(params: Mapping[str, Any]) -> float:
+    return _positive_or_default(
+        _float(params.get("entry_notional_max_multiplier")), 1.0
+    )
+
+
+def estimate_capital_pressure(
+    params: Mapping[str, Any], *, rank_count_floor: int = 1
+) -> float:
+    return estimate_capital_slot_count(
+        params,
+        rank_count_floor=rank_count_floor,
+    ) * max(1.0, estimate_entry_notional_multiplier(params))
+
+
+@dataclass(frozen=True)
+class CapitalBudgetEstimate:
+    max_notional_per_trade: float
+    max_notional_pct_start_equity: float
+    max_position_pct_equity: float
+    configured_max_gross_exposure_pct_equity: float
+    estimated_max_gross_exposure_pct_equity: float
+    estimated_capital_slot_count: float
+    entry_notional_max_multiplier: float
+    max_trade_pct_equity: float
+    capital_budget_overage_ratio: float
+    capital_feasible_flag: float
+
+    def to_feature_payload(self) -> dict[str, float]:
+        return {
+            "max_notional_per_trade": self.max_notional_per_trade,
+            "max_notional_pct_start_equity": self.max_notional_pct_start_equity,
+            "max_position_pct_equity": self.max_position_pct_equity,
+            "configured_max_gross_exposure_pct_equity": self.configured_max_gross_exposure_pct_equity,
+            "estimated_max_gross_exposure_pct_equity": self.estimated_max_gross_exposure_pct_equity,
+            "estimated_capital_slot_count": self.estimated_capital_slot_count,
+            "entry_notional_max_multiplier": self.entry_notional_max_multiplier,
+            "max_trade_pct_equity": self.max_trade_pct_equity,
+            "capital_budget_overage_ratio": self.capital_budget_overage_ratio,
+            "capital_feasible_flag": self.capital_feasible_flag,
+        }
+
+
+def estimate_capital_budget(
+    *,
+    strategy_overrides: Mapping[str, Any],
+    params: Mapping[str, Any],
+    rank_count_floor: int = 1,
+    start_equity: float = DEFAULT_CAPITAL_START_EQUITY,
+) -> CapitalBudgetEstimate:
+    max_notional = _float(strategy_overrides.get("max_notional_per_trade"))
+    max_notional_pct_start_equity = (
+        max_notional / start_equity if start_equity > 0.0 else 0.0
+    )
+    max_position_pct = _float(strategy_overrides.get("max_position_pct_equity"))
+    configured_max_gross_pct = _float(params.get("max_gross_exposure_pct_equity"))
+    entry_notional_multiplier = estimate_entry_notional_multiplier(params)
+    max_trade_pct_equity = max(
+        max_notional_pct_start_equity * max(1.0, entry_notional_multiplier),
+        _positive_or_default(max_position_pct, 0.0),
+    )
+    slot_count = estimate_capital_slot_count(params, rank_count_floor=rank_count_floor)
+    inferred_max_gross_pct = max_trade_pct_equity * slot_count
+    estimated_max_gross_pct = max(configured_max_gross_pct, inferred_max_gross_pct)
+    capital_budget_overage_ratio = max(0.0, estimated_max_gross_pct - 1.0) + max(
+        0.0,
+        max_trade_pct_equity - 1.0,
+    )
+    capital_feasible = (
+        1.0 if estimated_max_gross_pct <= 1.0 and max_trade_pct_equity <= 1.0 else 0.0
+    )
+    return CapitalBudgetEstimate(
+        max_notional_per_trade=max_notional,
+        max_notional_pct_start_equity=max_notional_pct_start_equity,
+        max_position_pct_equity=max_position_pct,
+        configured_max_gross_exposure_pct_equity=configured_max_gross_pct,
+        estimated_max_gross_exposure_pct_equity=estimated_max_gross_pct,
+        estimated_capital_slot_count=slot_count,
+        entry_notional_max_multiplier=entry_notional_multiplier,
+        max_trade_pct_equity=max_trade_pct_equity,
+        capital_budget_overage_ratio=capital_budget_overage_ratio,
+        capital_feasible_flag=capital_feasible,
+    )

--- a/services/torghut/app/trading/discovery/mlx_features.py
+++ b/services/torghut/app/trading/discovery/mlx_features.py
@@ -8,9 +8,8 @@ from dataclasses import dataclass
 from typing import Any, Mapping, cast
 
 from app.trading.discovery.autoresearch import FamilyAutoresearchPlan
+from app.trading.discovery.capital_budget import estimate_capital_budget
 from app.trading.discovery.family_templates import FamilyTemplate
-
-DEFAULT_CAPITAL_START_EQUITY = 31590.02
 
 
 def _string(value: Any) -> str:
@@ -143,27 +142,23 @@ def _infer_budget(value: Any, default: str = '0') -> str:
 
 
 def _capital_budget_payload(config: Mapping[str, Any], *, rank_count: int) -> dict[str, Any]:
-    max_notional = _float(_override_value(config, 'max_notional_per_trade'))
-    max_notional_pct_start_equity = (
-        max_notional / DEFAULT_CAPITAL_START_EQUITY if DEFAULT_CAPITAL_START_EQUITY > 0 else 0.0
+    estimate = estimate_capital_budget(
+        strategy_overrides=_mapping(config.get('strategy_overrides')),
+        params=_mapping(config.get('parameters')),
+        rank_count_floor=rank_count,
     )
-    max_position_pct = _float(_override_value(config, 'max_position_pct_equity'))
-    max_trade_pct_equity = max(max_notional_pct_start_equity, max_position_pct)
-    configured_max_gross_pct = _float(_param_value(config, 'max_gross_exposure_pct_equity'))
-    estimated_max_gross_pct = max(
-        configured_max_gross_pct,
-        max_trade_pct_equity * max(1, rank_count),
-    )
-    capital_budget_overage_ratio = max(0.0, estimated_max_gross_pct - 1.0) + max(
-        0.0, max_trade_pct_equity - 1.0
-    )
-    capital_feasible = estimated_max_gross_pct <= 1.0 and max_trade_pct_equity <= 1.0
     return {
-        'max_position_pct_equity': _format_float(max_position_pct),
-        'configured_max_gross_exposure_pct_equity': _format_float(configured_max_gross_pct),
-        'estimated_max_gross_exposure_pct_equity': _format_float(estimated_max_gross_pct),
-        'capital_budget_overage_ratio': _format_float(capital_budget_overage_ratio),
-        'capital_feasible': capital_feasible,
+        'max_position_pct_equity': _format_float(estimate.max_position_pct_equity),
+        'configured_max_gross_exposure_pct_equity': _format_float(
+            estimate.configured_max_gross_exposure_pct_equity
+        ),
+        'estimated_max_gross_exposure_pct_equity': _format_float(
+            estimate.estimated_max_gross_exposure_pct_equity
+        ),
+        'capital_budget_overage_ratio': _format_float(
+            estimate.capital_budget_overage_ratio
+        ),
+        'capital_feasible': bool(estimate.capital_feasible_flag),
     }
 
 

--- a/services/torghut/app/trading/discovery/mlx_training_data.py
+++ b/services/torghut/app/trading/discovery/mlx_training_data.py
@@ -9,10 +9,10 @@ from datetime import UTC, datetime
 from typing import Any, Mapping, Sequence, cast
 
 from app.trading.discovery.candidate_specs import CandidateSpec
+from app.trading.discovery.capital_budget import estimate_capital_budget
 from app.trading.discovery.evidence_bundles import CandidateEvidenceBundle
 
 MLX_RANKER_SCHEMA_VERSION = "torghut.mlx-ranker.v1"
-DEFAULT_CAPITAL_START_EQUITY = 31590.02
 
 
 def _stable_hash(payload: Mapping[str, Any]) -> str:
@@ -161,39 +161,15 @@ def _positive_or_default(value: float, default: float) -> float:
 def candidate_spec_capital_features(spec: CandidateSpec) -> Mapping[str, float]:
     overrides = _mapping(spec.strategy_overrides)
     params = _mapping(overrides.get("params"))
-    max_notional = _float(overrides.get("max_notional_per_trade"))
-    max_position_pct = _float(overrides.get("max_position_pct_equity"))
-    configured_max_gross_pct = _float(params.get("max_gross_exposure_pct_equity"))
-    max_entries = _positive_or_default(_float(params.get("max_entries_per_session")), 1.0)
-    max_notional_pct_start_equity = (
-        max_notional / DEFAULT_CAPITAL_START_EQUITY
-        if DEFAULT_CAPITAL_START_EQUITY > 0.0
-        else 0.0
+    features = estimate_capital_budget(
+        strategy_overrides=overrides,
+        params=params,
+    ).to_feature_payload()
+    features["max_entries_per_session"] = _positive_or_default(
+        _float(params.get("max_entries_per_session")),
+        1.0,
     )
-    max_trade_pct_equity = max(
-        max_notional_pct_start_equity,
-        _positive_or_default(max_position_pct, 0.0),
-    )
-    inferred_max_gross_pct = max_trade_pct_equity * max_entries
-    estimated_max_gross_pct = max(configured_max_gross_pct, inferred_max_gross_pct)
-    capital_budget_overage_ratio = max(0.0, estimated_max_gross_pct - 1.0) + max(
-        0.0, max_trade_pct_equity - 1.0
-    )
-    capital_feasible = (
-        1.0
-        if estimated_max_gross_pct <= 1.0 and max_trade_pct_equity <= 1.0
-        else 0.0
-    )
-    return {
-        "max_notional_per_trade": max_notional,
-        "max_notional_pct_start_equity": max_notional_pct_start_equity,
-        "max_position_pct_equity": max_position_pct,
-        "configured_max_gross_exposure_pct_equity": configured_max_gross_pct,
-        "estimated_max_gross_exposure_pct_equity": estimated_max_gross_pct,
-        "max_entries_per_session": max_entries,
-        "capital_budget_overage_ratio": capital_budget_overage_ratio,
-        "capital_feasible_flag": capital_feasible,
-    }
+    return features
 
 
 def capital_budget_penalty(features: Mapping[str, float]) -> float:

--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -2257,9 +2257,24 @@ def _select_candidate_specs_for_replay(
                         "max_position_pct_equity"
                     ]
                 ),
+                "max_trade_pct_equity": str(
+                    capital_features_by_spec[spec.candidate_spec_id][
+                        "max_trade_pct_equity"
+                    ]
+                ),
                 "estimated_max_gross_exposure_pct_equity": str(
                     capital_features_by_spec[spec.candidate_spec_id][
                         "estimated_max_gross_exposure_pct_equity"
+                    ]
+                ),
+                "estimated_capital_slot_count": str(
+                    capital_features_by_spec[spec.candidate_spec_id][
+                        "estimated_capital_slot_count"
+                    ]
+                ),
+                "entry_notional_max_multiplier": str(
+                    capital_features_by_spec[spec.candidate_spec_id][
+                        "entry_notional_max_multiplier"
                     ]
                 ),
                 "capital_budget_overage_ratio": str(

--- a/services/torghut/tests/test_mlx_training_data.py
+++ b/services/torghut/tests/test_mlx_training_data.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from decimal import Decimal
 from unittest import TestCase
 
-from app.trading.discovery.candidate_specs import compile_candidate_specs
+from app.trading.discovery.candidate_specs import CandidateSpec, compile_candidate_specs
 from app.trading.discovery.evidence_bundles import (
     evidence_bundle_from_frontier_candidate,
 )
@@ -12,6 +12,7 @@ from app.trading.discovery.mlx_training_data import (
     MlxRankerModel,
     MlxTrainingRow,
     build_mlx_training_rows,
+    candidate_spec_capital_features,
     rank_training_rows,
     rank_training_rows_with_lift_policy,
     train_mlx_ranker,
@@ -29,6 +30,40 @@ def _capital_profile(spec: object) -> object:
 
 
 class TestMlxTrainingData(TestCase):
+    def test_candidate_capital_features_include_runtime_slot_pressure(self) -> None:
+        spec = CandidateSpec(
+            schema_version="torghut.candidate-spec.v1",
+            candidate_spec_id="spec-slot-pressure",
+            hypothesis_id="H-SLOT",
+            family_template_id="breakout_reclaim_v2",
+            candidate_kind="configuration",
+            runtime_family="breakout_continuation_consistent",
+            runtime_strategy_name="breakout-continuation-long-v1",
+            feature_contract={},
+            parameter_space={},
+            strategy_overrides={
+                "max_notional_per_trade": "10000",
+                "max_position_pct_equity": "0.25",
+                "params": {
+                    "max_gross_exposure_pct_equity": "1.0",
+                    "max_entries_per_session": "2",
+                    "max_concurrent_positions": "4",
+                    "entry_notional_max_multiplier": "1.5",
+                },
+            },
+            objective={},
+            hard_vetoes={},
+            expected_failure_modes=(),
+            promotion_contract={},
+        )
+
+        features = candidate_spec_capital_features(spec)
+
+        self.assertEqual(features["estimated_capital_slot_count"], 4.0)
+        self.assertEqual(features["entry_notional_max_multiplier"], 1.5)
+        self.assertGreater(features["estimated_max_gross_exposure_pct_equity"], 1.0)
+        self.assertEqual(features["capital_feasible_flag"], 0.0)
+
     def test_training_rows_build_from_evidence_bundles_and_rank_deterministically(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Adds a shared Torghut autoresearch capital-budget estimator for candidate specs and MLX descriptors.
- Accounts for runtime exposure pressure from max entries, concurrent positions, pair legs, top-N breadth, and entry notional multipliers.
- Tightens replay-selection diagnostics with slot count, max trade percent, and entry multiplier fields so false feasible candidates are visible before replay.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_candidate_specs.py tests/test_mlx_training_data.py tests/test_run_whitepaper_autoresearch_profit_target.py -q`
- `uv run --frozen ruff check app/trading/discovery/capital_budget.py app/trading/discovery/candidate_specs.py app/trading/discovery/mlx_training_data.py app/trading/discovery/mlx_features.py scripts/run_whitepaper_autoresearch_profit_target.py tests/test_candidate_specs.py tests/test_mlx_training_data.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen pytest tests/test_candidate_specs.py tests/test_mlx_training_data.py -q`
- Live triage: queried deployed Torghut `/trading/status`, `/trading/decisions?limit=5`, and `/trading/executions?limit=5` from pod `torghut-00374-deployment-6649b8fd8c-9tkgh`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
