### PR TITLE
chore(jangar): promote image 1a37a432

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 36f3b393
-  digest: sha256:94a0c46d1618518a3863fda7a7e8e0062767fb8b840163b63d8f3f092d78b996
+  tag: 1a37a432
+  digest: sha256:ee9cc261c3c2c1a465af17739bbf9f4644aee4fa27e325db6eebd2549b40a44c
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,8 +11,8 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 36f3b393
-    digest: sha256:0f82efe34f94bce2f528fd7177ceba007f0250a34ed566c064b6a037edbad16b
+    tag: 1a37a432
+    digest: sha256:f4eb1618d04facd500b97291f1537929902d1727efdc114f01e2fde380af03c7
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
@@ -21,8 +21,8 @@ controlPlane:
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 36f3b393
-    digest: sha256:94a0c46d1618518a3863fda7a7e8e0062767fb8b840163b63d8f3f092d78b996
+    tag: 1a37a432
+    digest: sha256:ee9cc261c3c2c1a465af17739bbf9f4644aee4fa27e325db6eebd2549b40a44c
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-14T03:03:11Z
+    deploy.knative.dev/rollout: 2026-05-14T03:37:42Z
 spec:
   replicas: 1
   strategy:
@@ -57,11 +57,11 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_RUNTIME_IMAGE
-              value: registry.ide-newton.ts.net/lab/jangar:36f3b393@sha256:94a0c46d1618518a3863fda7a7e8e0062767fb8b840163b63d8f3f092d78b996
+              value: registry.ide-newton.ts.net/lab/jangar:1a37a432@sha256:ee9cc261c3c2c1a465af17739bbf9f4644aee4fa27e325db6eebd2549b40a44c
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: 36f3b3936514af7f95d751670b64238eb0df7876
+              value: 1a37a432e7c2d06e0cfc2d90ffd9a09a6551ffc3
             - name: JANGAR_GITOPS_REVISION
-              value: 36f3b3936514af7f95d751670b64238eb0df7876
+              value: 1a37a432e7c2d06e0cfc2d90ffd9a09a6551ffc3
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_BUMBA_TASK_QUEUE

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -59,5 +59,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: 36f3b393
-    digest: sha256:94a0c46d1618518a3863fda7a7e8e0062767fb8b840163b63d8f3f092d78b996
+    newTag: 1a37a432
+    digest: sha256:ee9cc261c3c2c1a465af17739bbf9f4644aee4fa27e325db6eebd2549b40a44c


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `1a37a432e7c2d06e0cfc2d90ffd9a09a6551ffc3`
- Image tag: `1a37a432`
- Image digest: `sha256:ee9cc261c3c2c1a465af17739bbf9f4644aee4fa27e325db6eebd2549b40a44c`
- Updated API rollout annotation
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`