### PR TITLE
fix(torghut): feed runtime proof into profit leases

### DIFF
--- a/services/torghut/app/trading/profit_leases.py
+++ b/services/torghut/app/trading/profit_leases.py
@@ -514,7 +514,8 @@ def _rejection_source(
             account=account,
             window=window,
             source_class="rejection_drag",
-            source_ref="scheduler:decision_state_total",
+            source_ref=rejection_summary.get("source_ref")
+            or "scheduler:decision_state_total",
             freshness_state="missing",
             rows=total,
             rejection_drag_bps=drag_bps,
@@ -531,7 +532,8 @@ def _rejection_source(
         account=account,
         window=window,
         source_class="rejection_drag",
-        source_ref="scheduler:decision_state_total",
+        source_ref=rejection_summary.get("source_ref")
+        or "scheduler:decision_state_total",
         freshness_state="current",
         rows=total,
         rejection_drag_bps=drag_bps,

--- a/services/torghut/app/trading/submission_council.py
+++ b/services/torghut/app/trading/submission_council.py
@@ -25,6 +25,7 @@ from ..models import (
     StrategyHypothesis,
     StrategyHypothesisMetricWindow,
     StrategyPromotionDecision,
+    TradeDecision,
     VNextDatasetSnapshot,
     VNextPromotionDecision,
 )
@@ -983,7 +984,70 @@ def _load_profit_promotion_table_counts(session: Session) -> dict[str, int]:
     }
 
 
-def _build_profit_rejection_summary(state: object) -> dict[str, object]:
+def _build_profit_data_readiness_summary(state: object) -> dict[str, object]:
+    metrics = getattr(state, "metrics", None)
+    rows = _safe_int(getattr(metrics, "feature_batch_rows_total", 0))
+    null_rate = getattr(metrics, "feature_null_rate", {}) if metrics else {}
+    staleness_ms_p95 = _safe_int(getattr(metrics, "feature_staleness_ms_p95", 0))
+    duplicate_ratio = getattr(metrics, "feature_duplicate_ratio", None)
+    return {
+        "equity_ta_rows": rows,
+        "equity_ta_symbols": 0,
+        "equity_ta_source_ref": "scheduler.metrics.feature_batch_rows_total",
+        "feature_null_rate": dict(cast(Mapping[str, float], null_rate))
+        if isinstance(null_rate, Mapping)
+        else {},
+        "feature_staleness_ms_p95": staleness_ms_p95,
+        "feature_duplicate_ratio": duplicate_ratio,
+    }
+
+
+def _load_persisted_profit_rejection_summary(
+    session: Session,
+    *,
+    account_label: str | None,
+    now: datetime,
+) -> dict[str, object]:
+    lookback_start = now - timedelta(days=7)
+    filters = [TradeDecision.created_at >= lookback_start]
+    if account_label:
+        filters.append(TradeDecision.alpaca_account_label == account_label)
+    rows = session.execute(
+        select(TradeDecision.status, func.count())
+        .where(*filters)
+        .group_by(TradeDecision.status)
+    ).all()
+    status_totals: dict[str, int] = {}
+    for status, count in rows:
+        normalized = str(status or "unknown").strip().lower() or "unknown"
+        status_totals[normalized] = status_totals.get(normalized, 0) + _safe_int(count)
+    rejected = status_totals.get("rejected", 0)
+    blocked = status_totals.get("blocked", 0)
+    filled = status_totals.get("filled", 0)
+    planned = status_totals.get("planned", 0) + status_totals.get("submitted", 0)
+    total = sum(status_totals.values())
+    rejection_drag_ratio = (
+        float(rejected + blocked) / float(total) if total > 0 else None
+    )
+    return {
+        "rejected": rejected,
+        "blocked": blocked,
+        "filled": filled,
+        "planned": planned,
+        "total": total,
+        "rejection_drag_ratio": rejection_drag_ratio,
+        "status_totals": status_totals,
+        "source_ref": "postgres:trade_decisions:7d",
+    }
+
+
+def _build_profit_rejection_summary(
+    state: object,
+    *,
+    session: Session | None = None,
+    account_label: str | None = None,
+    now: datetime | None = None,
+) -> dict[str, object]:
     metrics = getattr(state, "metrics", None)
     state_totals = getattr(metrics, "decision_state_total", {}) if metrics else {}
     decision_state_total = (
@@ -998,6 +1062,12 @@ def _build_profit_rejection_summary(state: object) -> dict[str, object]:
     total = sum(_safe_int(value) for value in decision_state_total.values())
     if total == 0:
         total = rejected + blocked + filled + planned
+    if total <= 0 and session is not None:
+        return _load_persisted_profit_rejection_summary(
+            session,
+            account_label=account_label,
+            now=now or datetime.now(timezone.utc),
+        )
     rejection_drag_ratio = (
         float(rejected + blocked) / float(total) if total > 0 else None
     )
@@ -1120,8 +1190,15 @@ def build_live_submission_gate_payload(
         quant_evidence=quant_evidence,
         empirical_jobs_status=empirical_jobs_status,
         dependency_quorum=dependency_quorum_payload,
-        rejection_summary=_build_profit_rejection_summary(state),
+        rejection_summary=_build_profit_rejection_summary(
+            state,
+            session=session,
+            account_label=_safe_text(quant_evidence.get("account"))
+            or quant_account_label,
+            now=now,
+        ),
         promotion_table_counts=promotion_table_counts,
+        data_readiness=_build_profit_data_readiness_summary(state),
         live_controls=_build_profit_live_controls(state),
         account=_safe_text(quant_evidence.get("account")),
         window=_safe_text(quant_evidence.get("window")),

--- a/services/torghut/tests/test_submission_council.py
+++ b/services/torghut/tests/test_submission_council.py
@@ -18,6 +18,8 @@ from app.models import (
     AutoresearchPortfolioCandidate,
     AutoresearchProposalScore,
     Base,
+    Strategy,
+    TradeDecision,
 )
 from app.trading.submission_council import (
     _QUANT_HEALTH_CACHE,
@@ -203,6 +205,118 @@ class TestSubmissionCouncil(TestCase):
         self.assertEqual(counts["autoresearch_portfolio_candidates"], 1)
         self.assertEqual(counts["autoresearch_portfolio_blocked"], 1)
         self.assertEqual(counts["autoresearch_portfolio_ready"], 0)
+
+    def test_profit_lease_projection_uses_runtime_feature_and_persisted_decision_evidence(
+        self,
+    ) -> None:
+        engine = create_engine(
+            "sqlite+pysqlite:///:memory:",
+            future=True,
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        Base.metadata.create_all(engine)
+        session_local = sessionmaker(bind=engine, expire_on_commit=False, future=True)
+        now = datetime.now(timezone.utc)
+        with session_local() as session:
+            strategy = Strategy(
+                name="demo",
+                description="demo",
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="static",
+                universe_symbols=["AAPL"],
+            )
+            session.add(strategy)
+            session.commit()
+            session.add_all(
+                [
+                    TradeDecision(
+                        strategy_id=strategy.id,
+                        alpaca_account_label="paper",
+                        symbol="AAPL",
+                        timeframe="1Min",
+                        decision_json={"action": "buy"},
+                        status="planned",
+                        created_at=now,
+                    ),
+                    TradeDecision(
+                        strategy_id=strategy.id,
+                        alpaca_account_label="paper",
+                        symbol="AAPL",
+                        timeframe="1Min",
+                        decision_json={"action": "sell"},
+                        status="blocked",
+                        created_at=now,
+                    ),
+                ]
+            )
+            session.commit()
+
+            result = build_live_submission_gate_payload(
+                SimpleNamespace(
+                    last_autonomy_promotion_eligible=True,
+                    last_autonomy_promotion_action="promote",
+                    drift_live_promotion_eligible=False,
+                    last_market_context_freshness_seconds=45,
+                    metrics=SimpleNamespace(
+                        feature_batch_rows_total=9,
+                        feature_null_rate={"price": 0.0},
+                        feature_staleness_ms_p95=250,
+                        feature_duplicate_ratio=0.0,
+                        decision_state_total={},
+                    ),
+                ),
+                hypothesis_summary={
+                    "summary": {
+                        "promotion_eligible_total": 1,
+                        "capital_stage_totals": {"shadow": 1},
+                        "dependency_quorum": {
+                            "decision": "allow",
+                            "reasons": [],
+                            "message": "ready",
+                        },
+                    },
+                    "items": [
+                        {
+                            "hypothesis_id": "H-CONT-01",
+                            "lane_id": "continuation",
+                            "strategy_family": "intraday_continuation",
+                            "promotion_eligible": True,
+                            "capital_stage": "shadow",
+                            "reasons": [],
+                        }
+                    ],
+                },
+                empirical_jobs_status={"ready": True, "status": "healthy"},
+                quant_health_status=self._healthy_quant_status(),
+                promotion_certificate_evidence=[
+                    {
+                        "hypothesis_id": "H-CONT-01",
+                        "metric_window": self._metric_window(),
+                        "promotion_decision": self._promotion_decision(),
+                    }
+                ],
+                session=session,
+            )
+
+        projection = result["profit_lease_projection"]
+        reasons = projection["torghut_capital"]["blocking_reason_codes"]
+        self.assertNotIn("equity_ta_rows_missing", reasons)
+        self.assertNotIn("rejection_drag_unmeasured", reasons)
+        equity_source = next(
+            source
+            for source in projection["source_provenance"]
+            if source["source_class"] == "equity_ta"
+        )
+        rejection_source = next(
+            source
+            for source in projection["source_provenance"]
+            if source["source_class"] == "rejection_drag"
+        )
+        self.assertEqual(equity_source["rows"], 9)
+        self.assertEqual(rejection_source["rows"], 2)
+        self.assertEqual(rejection_source["source_ref"], "postgres:trade_decisions:7d")
 
     def test_build_live_submission_gate_payload_fails_closed_on_empty_quant_evidence(
         self,


### PR DESCRIPTION
## Summary

- Feeds runtime feature batch readiness into the Torghut profit-lease projection so live gates can see observed equity TA rows.
- Falls back to recent persisted `trade_decisions` when scheduler decision-state counters are empty after restart, preserving rejection-drag evidence.
- Adds regression coverage proving the live submission payload no longer reports missing TA rows or unmeasured rejection drag when persisted/runtime evidence exists.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_submission_council.py tests/test_profit_leases.py -q`
- `cd services/torghut && uv run --frozen ruff check app/trading/submission_council.py app/trading/profit_leases.py tests/test_submission_council.py tests/test_profit_leases.py`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/submission_council.py app/trading/profit_leases.py tests/test_submission_council.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
