### PR TITLE
fix(torghut): align alpha feature replay priority

### DIFF
--- a/docs/torghut/rollouts/2026-05-14-alpha-feature-replay-priority.md
+++ b/docs/torghut/rollouts/2026-05-14-alpha-feature-replay-priority.md
@@ -1,0 +1,58 @@
+# Torghut Alpha Feature Replay Priority
+
+Date: 2026-05-14
+
+Governing design:
+
+- `docs/torghut/design-system/v6/201-torghut-alpha-closure-settlement-and-feature-replay-market-2026-05-14.md`
+- `docs/torghut/design-system/v6/200-torghut-routeable-alpha-evidence-foundry-and-capital-safe-profit-ladder-2026-05-14.md`
+
+Runtime requirement source:
+
+- `GET http://torghut.torghut.svc.cluster.local/trading/revenue-repair`
+
+Before evidence at `2026-05-14T04:07:00Z`:
+
+- `business_state=repair_only`
+- `revenue_ready=false`
+- top `repair_queue` item: `repair_alpha_readiness` / `alpha_readiness_not_promotion_eligible`
+- affected value gate: `routeable_candidate_count`
+- `accepted_routeable_candidate_count=0`
+- `zero_notional_or_stale_evidence_rate=1.0`
+- `max_notional=0`
+- live closure market selected `H-MICRO-01` / `feature_replay_closure`
+- live profit-freshness frontier selected `rerun_drift_checks_for_blocked_hypotheses`
+
+## Change
+
+The profit-freshness frontier now applies a bounded `alpha_feature_replay_closure` priority adjustment to
+`feature_coverage` repair lots when `feature_rows_missing` or `required_feature_set_unavailable` are present. That
+aligns the default zero-notional repair action with the alpha closure settlement market, which reserves the active
+H-MICRO-01 slot for feature replay while `repair_alpha_readiness` remains the top revenue blocker.
+
+This is an additive ranking change only. It does not make `/readyz` green, does not change repair queue order, does
+not submit orders, and does not open paper or live notional.
+
+## Validation
+
+Run before release handoff:
+
+- `cd services/torghut && uv run --frozen pytest tests/test_profit_freshness_frontier.py -k feature_replay_closure`
+- `cd services/torghut && uv run --frozen pytest tests/test_trading_api.py -k zero_notional_repair`
+- `cd services/torghut && uv run --frozen ruff format --check app/trading/profit_freshness_frontier.py tests/test_profit_freshness_frontier.py`
+- `cd services/torghut && uv run --frozen ruff check app/trading/profit_freshness_frontier.py tests/test_profit_freshness_frontier.py`
+- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
+- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
+- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
+
+## Risk And Rollback
+
+Risk is limited to ranking between existing zero-notional repair lots. Feature replay can still fail closed through the
+existing repair endpoint if no signals, feature runner, or quality pass is available. Rollback is to revert the priority
+adjustment; Torghut remains `max_notional=0` with live submission disabled either way.
+
+## Revenue Status
+
+This targets `routeable_candidate_count` by making the selected H-MICRO-01 closure run feature evidence repair before
+lower-value drift-only repair. Immediate revenue impact remains blocked until feature rows, required feature-set
+availability, drift checks, post-cost proof, route TCA, and capital gates settle with routeable candidates above zero.

--- a/services/torghut/README.md
+++ b/services/torghut/README.md
@@ -215,7 +215,9 @@ Testing rules for the trading core:
   `repair_alpha_readiness` is the live top queue item, the market reserves the first zero-notional closure slot for
   lineage-ready `H-MICRO-01` feature replay when drift checks, feature rows, or required feature-set evidence remain
   missing. The compact board ref exposes the market id, selected hypothesis, settlement receipt requirement, active
-  dedupe key, and no-delta budget state without enabling paper or live notional.
+  dedupe key, and no-delta budget state without enabling paper or live notional. The profit-freshness frontier applies
+  the same alpha feature-replay priority when required feature rows or feature-set evidence are missing, so the default
+  zero-notional repair action aligns with the closure market before lower-value drift-only repair.
 - `GET /trading/revenue-repair` also emits the May 14 doc 200 `torghut.alpha-evidence-foundry.v1` read-model. The
   foundry turns the current `repair_alpha_readiness` queue item into hypothesis-scoped
   `torghut.alpha-evidence-window-receipt.v1` receipts with feature, drift, post-cost, market-context, TCA,

--- a/services/torghut/app/trading/profit_freshness_frontier.py
+++ b/services/torghut/app/trading/profit_freshness_frontier.py
@@ -103,6 +103,11 @@ _ROUTEABILITY_TCA_REPAIR_LOT_TYPES = {"route_universe_tca_repair"}
 _ROUTEABILITY_TCA_REPAIR_ACTION = "recompute_route_tca_and_fill_quality"
 _ROUTEABILITY_TCA_REPAIR_REASON_PREFIXES = ("execution_tca_", "route_tca_")
 _ROUTEABILITY_TCA_REPAIR_REASON_FRAGMENTS = ("slippage", "route_universe")
+_ALPHA_FEATURE_REPLAY_REASON_CODES = {
+    "feature_rows_missing",
+    "required_feature_set_unavailable",
+}
+_ALPHA_FEATURE_REPLAY_PRIORITY_BONUS = Decimal("3")
 
 
 def _mapping(value: object) -> Mapping[str, Any]:
@@ -971,6 +976,14 @@ def _repair_lot(
     state = _text(dimension.get("state"), "unknown")
     repair_cost_class = _DIMENSION_REPAIR_COST.get(dimension_name, "medium")
     expected_bps = _DIMENSION_EXPECTED_BPS.get(dimension_name, Decimal("5"))
+    reason_codes = _strings(dimension.get("reason_codes"))
+    priority_adjustments: list[str] = []
+    priority_bonus = Decimal("0")
+    if dimension_name == "feature_coverage" and set(reason_codes).intersection(
+        _ALPHA_FEATURE_REPLAY_REASON_CODES
+    ):
+        priority_adjustments.append("alpha_feature_replay_closure")
+        priority_bonus += _ALPHA_FEATURE_REPLAY_PRIORITY_BONUS
     blocking_hypotheses = _strings(dimension.get("blocking_hypotheses"))
     candidate_ids = _strings(empirical_jobs_status.get("candidate_ids"))
     symbol_set = _route_symbols(route_reacquisition_board)
@@ -982,12 +995,14 @@ def _repair_lot(
         symbol_set=symbol_set,
     )
     expected_profit = expected_daily_net_pnl_unlock or expected_bps
-    repair_priority = expected_profit * _confidence_for_state(
-        state
-    ) * _routeability_confidence(routeability_ledger) * _jangar_confidence(
-        jangar_reliability_settlement_ref
-    ) - _REPAIR_COST_PENALTY.get(repair_cost_class, Decimal("5"))
-    reason_codes = _strings(dimension.get("reason_codes"))
+    repair_priority = (
+        expected_profit
+        * _confidence_for_state(state)
+        * _routeability_confidence(routeability_ledger)
+        * _jangar_confidence(jangar_reliability_settlement_ref)
+        - _REPAIR_COST_PENALTY.get(repair_cost_class, Decimal("5"))
+        + priority_bonus
+    )
     lot_id = _stable_ref(
         "profit-freshness-repair-lot",
         {
@@ -1013,6 +1028,7 @@ def _repair_lot(
         "expected_daily_net_pnl_unlock": _decimal_text(expected_daily_net_pnl_unlock),
         "profit_unlock_refs": profit_unlock_refs,
         "repair_priority": round(float(repair_priority), 4),
+        "priority_adjustments": priority_adjustments,
         "repair_priority_basis": (
             "expected_daily_net_pnl_unlock"
             if expected_daily_net_pnl_unlock is not None

--- a/services/torghut/tests/test_profit_freshness_frontier.py
+++ b/services/torghut/tests/test_profit_freshness_frontier.py
@@ -210,6 +210,103 @@ def test_daily_net_pnl_unlock_outranks_bps_proxy_when_profit_packets_are_availab
     assert frontier["capital_posture"]["capital_state"] == "zero_notional"
 
 
+def test_feature_replay_closure_outranks_drift_for_micro_alpha_blocker() -> None:
+    frontier = _frontier(
+        proof_floor_receipt={
+            "schema_version": "torghut.profitability-proof-floor.v1",
+            "account_label": "PA3SX7FYNUTF",
+            "route_state": "repair_only",
+            "capital_state": "zero_notional",
+            "max_notional": "0",
+            "blocking_reasons": ["alpha_readiness_not_promotion_eligible"],
+            "proof_dimensions": [
+                {
+                    "dimension": "execution_tca",
+                    "state": "pass",
+                    "reason": "route_tca_passed",
+                    "freshness_seconds": 71,
+                    "source_ref": {
+                        "last_computed_at": "2026-05-12T15:08:49+00:00",
+                    },
+                }
+            ],
+        },
+        routeability_repair_acceptance_ledger={
+            "schema_version": "torghut.routeability-repair-acceptance-ledger.v1",
+            "ledger_id": "routeability-acceptance-ledger:alpha-feature",
+            "aggregate_state": "accepted",
+            "accepted_routeable_candidate_count": 1,
+            "aggregate_blocking_reason_codes": [],
+            "lots": [],
+        },
+        route_reacquisition_board={
+            "summary": {"capital_eligible_symbol_count": 1},
+            "rows": [
+                {
+                    "symbol": "AAPL",
+                    "state": "routeable",
+                    "current_blocker": "",
+                    "hypothesis_ids": ["H-MICRO-01"],
+                }
+            ],
+        },
+        quant_evidence={
+            "ok": True,
+            "status": "healthy",
+            "latest_metrics_count": 144,
+            "stage_count": 4,
+        },
+        market_context_status={"status": "healthy", "last_domain_states": {}},
+        empirical_jobs_status={
+            "ready": True,
+            "status": "healthy",
+            "eligible_jobs": [
+                "benchmark_parity",
+                "foundation_router_parity",
+                "janus_event_car",
+                "janus_hgrm_reward",
+            ],
+            "candidate_ids": ["chip-paper-microbar-composite@execution-proof"],
+            "dataset_snapshot_refs": ["dataset-micro"],
+        },
+        hypothesis_payload={
+            "summary": {
+                "promotion_eligible_total": 0,
+                "reason_totals": {
+                    "feature_rows_missing": 1,
+                    "required_feature_set_unavailable": 1,
+                    "drift_checks_missing": 1,
+                },
+            },
+            "items": [
+                {
+                    "hypothesis_id": "H-MICRO-01",
+                    "reasons": [
+                        "feature_rows_missing",
+                        "required_feature_set_unavailable",
+                        "drift_checks_missing",
+                    ],
+                }
+            ],
+        },
+        jangar_reliability_settlement_ref={
+            "settlement_ref": "jangar-reliability-settlement:ready",
+            "decision": "allow",
+            "state": "current",
+            "reason_codes": [],
+        },
+    )
+
+    selected = cast(list[Mapping[str, Any]], frontier["selected_zero_notional_repairs"])
+
+    assert frontier["next_zero_notional_action"] == "rebuild_required_feature_rows"
+    assert selected[0]["blocked_dimension"] == "feature_coverage"
+    assert selected[0]["hypothesis_id"] == "H-MICRO-01"
+    assert selected[0]["priority_adjustments"] == ["alpha_feature_replay_closure"]
+    assert selected[0]["paper_notional_limit"] == "0"
+    assert selected[0]["live_notional_limit"] == "0"
+
+
 def test_stale_market_context_and_empirical_jobs_are_explicit_dimensions() -> None:
     frontier = _frontier()
     market = _dimension(frontier, "market_context")


### PR DESCRIPTION
## Summary

- Aligns Torghut's profit-freshness frontier with governing design `docs/torghut/design-system/v6/201-torghut-alpha-closure-settlement-and-feature-replay-market-2026-05-14.md` by prioritizing H-MICRO feature replay when feature rows or required feature-set evidence are missing.
- Adds a bounded `alpha_feature_replay_closure` priority adjustment to feature-coverage repair lots while preserving `paper_notional_limit=0`, `live_notional_limit=0`, and unchanged submit gates.
- Adds a regression test proving feature replay outranks drift-only repair for the active H-MICRO alpha blocker, plus rollout documentation and README notes.
- Runtime requirement source: `GET http://torghut.torghut.svc.cluster.local/trading/revenue-repair` reported `business_state=repair_only`, `revenue_ready=false`, top item `repair_alpha_readiness`, value gate `routeable_candidate_count`, selected closure `H-MICRO-01` / `feature_replay_closure`, `accepted_routeable_candidate_count=0`, `zero_notional_or_stale_evidence_rate=1.0`, `max_notional=0`.
- Post-PR live evidence refresh at `2026-05-14T04:28:24Z` still reports `business_state=repair_only`, `revenue_ready=false`, top item `repair_alpha_readiness`, `accepted_routeable_candidate_count=0`, `zero_notional_or_stale_evidence_rate=1.0`, `max_notional=0`, and `live_submission_allowed=false` on deployed source commit `210250b227e5ad8b58af64c06339ee5b6743fb02`; revenue impact is blocked on image promotion and rollout validation.

## Related Issues

None

## Testing

- PASS: `cd services/torghut && uv sync --frozen --extra dev`
- PASS: `cd services/torghut && uv run --frozen pytest tests/test_profit_freshness_frontier.py -k feature_replay_closure`
- PASS: `cd services/torghut && uv run --frozen pytest tests/test_profit_freshness_frontier.py tests/test_zero_notional_repair_executor.py tests/test_trading_api.py -k 'zero_notional_repair or profit_freshness_frontier'`
- PASS: `cd services/torghut && uv run --frozen ruff format --check app/trading/profit_freshness_frontier.py tests/test_profit_freshness_frontier.py`
- PASS: `cd services/torghut && uv run --frozen ruff check app/trading/profit_freshness_frontier.py tests/test_profit_freshness_frontier.py`
- PASS: `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- PASS: `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- PASS: `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- PASS: `bunx oxfmt --check docs/torghut/rollouts/2026-05-14-alpha-feature-replay-priority.md services/torghut/README.md`
- PASS: `git diff --check`
- PASS: GitHub PR checks for #6538: `Changed-file plan`, `Bytecode + lint + migration guard`, `Pyright`, `Pytest shard 0-3`, `Pytest autoresearch runner 0-7`, `Bytecode + pytest + coverage`, `Quality signals (complexity + security)`, `Lint commit messages`, `Validate PR title`, and `check_changed_files`.
- PASS: `gh pr view 6538 --repo proompteng/lab --json mergeable,mergeStateStatus,isDraft` returned `mergeable=MERGEABLE`, `mergeStateStatus=CLEAN`, `isDraft=false`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None. This is a zero-notional repair ranking change only. Rollback is to revert this PR, which restores prior drift-first frontier selection while Torghut remains `max_notional=0` with live submission disabled.

## Risk Notes

- Risk is limited to ordering among existing zero-notional repair lots; no paper/live order path is enabled.
- Feature replay can still fail closed through the existing repair endpoint if no signals, feature runner, or feature quality pass is available.
- Live business evidence remains repair-only until this source change is built, promoted, and verified after rollout.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
