### PR TITLE
chore(symphony): promote image 210250b2

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-05-13T08:36:13Z"
+        kubectl.kubernetes.io/restartedAt: "2026-05-14T04:16:35Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -23,5 +23,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "57bfbc7f"
-    digest: sha256:902d8fea1a97d97d55c8ceb41c3008d564f72d471314cdf528ef487c98aa197b
+    newTag: "210250b2"
+    digest: sha256:274d58dda834bbacb0d5b05b311900b47747c02276d470716f1451a25e214aae

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-05-13T08:36:13Z"
+        kubectl.kubernetes.io/restartedAt: "2026-05-14T04:16:35Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -25,5 +25,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "57bfbc7f"
-    digest: sha256:902d8fea1a97d97d55c8ceb41c3008d564f72d471314cdf528ef487c98aa197b
+    newTag: "210250b2"
+    digest: sha256:274d58dda834bbacb0d5b05b311900b47747c02276d470716f1451a25e214aae

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-05-13T08:36:13Z"
+        kubectl.kubernetes.io/restartedAt: "2026-05-14T04:16:35Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -18,5 +18,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "57bfbc7f"
-    digest: sha256:902d8fea1a97d97d55c8ceb41c3008d564f72d471314cdf528ef487c98aa197b
+    newTag: "210250b2"
+    digest: sha256:274d58dda834bbacb0d5b05b311900b47747c02276d470716f1451a25e214aae


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `210250b227e5ad8b58af64c06339ee5b6743fb02`
- Image tag: `210250b2`
- Image digest: `sha256:274d58dda834bbacb0d5b05b311900b47747c02276d470716f1451a25e214aae`