### PR TITLE
docs(torghut): define alpha evidence foreclosure

### DIFF
--- a/docs/agents/designs/197-jangar-alpha-evidence-foreclosure-governor-and-runner-custody-2026-05-14.md
+++ b/docs/agents/designs/197-jangar-alpha-evidence-foreclosure-governor-and-runner-custody-2026-05-14.md
@@ -1,0 +1,366 @@
+# 197. Jangar Alpha Evidence Foreclosure Governor And Runner Custody (2026-05-14)
+
+Status: Accepted for engineer and deployer handoff
+Date: 2026-05-14
+Owner: Gideon Park, Torghut Traders Architecture
+Scope: Jangar Torghut evidence admission, alpha evidence foreclosure, no-delta runner custody, repair dispatch safety,
+validation, rollout, rollback, and cross-stage handoff.
+
+Companion Torghut contract:
+
+- `docs/torghut/design-system/v6/202-torghut-alpha-evidence-foreclosure-and-routeable-candidate-reentry-2026-05-14.md`
+
+Extends:
+
+- `196-jangar-alpha-closure-slot-governor-and-no-delta-budget-2026-05-14.md`
+- `195-jangar-receipt-backed-alpha-foundry-and-rollout-safety-covenant-2026-05-14.md`
+- `194-jangar-receipt-settled-repair-slots-and-stage-custody-thaw-2026-05-14.md`
+- `193-jangar-cross-plane-closure-board-and-revenue-repair-admission-2026-05-14.md`
+- `188-jangar-typed-torghut-evidence-admission-and-repair-dispatch-2026-05-13.md`
+
+## Decision
+
+I am selecting a **Jangar alpha evidence foreclosure governor** for the next control-plane reliability increment.
+
+Torghut now publishes enough typed evidence for Jangar to avoid broad repair dispatch. On 2026-05-14 at 04:10 UTC,
+the Torghut revenue surface reported `business_state=repair_only`, `revenue_ready=false`,
+`accepted_routeable_candidate_count=0`, `zero_notional_or_stale_evidence_rate=1.0`, and
+`max_notional=0`. The top queue item was still `repair_alpha_readiness`, and the current alpha evidence foundry carried
+no-delta receipts whose measured routeable candidate delta was `0`.
+
+Jangar's role is not to pick a trading strategy. Torghut owns that decision. Jangar's role is to protect runner
+capacity and material-action truth. The selected behavior is to consume Torghut's compact
+`alpha_evidence_foreclosure_ref`, deny duplicate zero-notional alpha repair runner launches for unchanged no-delta
+keys, and allow a new runner only when Torghut proves that source commit, evidence window, blocker digest, required
+receipt set, or terminal settlement changed.
+
+The tradeoff is lower runner throughput. That is intentional. The cluster already shows repeated failed, errored, and
+OOMKilled AgentRun pods across Jangar and Torghut lanes. More starts are not leverage unless each start is tied to the
+live revenue queue and a terminal after-receipt.
+
+## Governing Runtime Requirements
+
+This design follows the active swarm validation contract:
+
+- every run must cite the governing Torghut design or runtime requirement before changing code;
+- implement stages must produce production PRs that improve readiness, profit evidence, data freshness, execution
+  quality, or capital safety;
+- verify stages must merge only green PRs and prove image promotion, Argo sync, live service health, and trading or
+  evidence status after rollout;
+- final handoff must name the revenue metric improved or the smallest blocker preventing revenue impact.
+
+Jangar value gates:
+
+- `failed_agentrun_rate`: deny repeat no-delta launch keys before another runner is created.
+- `ready_status_truth`: keep Jangar `/ready` separate from permission to dispatch material Torghut work.
+- `manual_intervention_count`: convert a broad queue into one current, typed foreclosure decision.
+- `handoff_evidence_quality`: require book id, selected hypothesis, no-delta key, release condition, validation
+  command, and rollback target in the handoff.
+- `pr_to_rollout_latency`: shorten verification by giving deployers one compact Torghut ref to capture.
+
+Torghut value gates carried through Jangar:
+
+- `routeable_candidate_count`
+- `zero_notional_or_stale_evidence_rate`
+- `fill_tca_or_slippage_quality`
+- `post_cost_daily_net_pnl`
+- `capital_gate_safety`
+
+## Read-Only Evidence Snapshot
+
+Evidence was collected read-only on 2026-05-14. I did not mutate Kubernetes resources, database records, trading flags,
+GitOps resources, AgentRuns, or broker state.
+
+### Cluster And Control Plane
+
+- The current workspace branch was `codex/swarm-torghut-quant-discover`, based on `origin/main` at
+  `29f0d1c9fd417fc65666896b6b5433be668c78a5`.
+- Argo reported `agents`, `jangar`, and `torghut` as `Synced` and `Healthy` at the same revision.
+- Agents pods were available, with `agents`, `agents-controllers`, and `agents-alloy` running.
+- Jangar pods were running, including `jangar-7b97b57567-45294`, `bumba`, the Jangar database, Open WebUI Redis, and
+  Symphony services.
+- The agents namespace retained many completed, errored, and OOMKilled Jangar/Torghut AgentRun pods, including recent
+  Torghut quant discover, implement, and verify attempts. That tail is the control-plane failure mode this governor
+  reduces.
+- Torghut live and sim revisions were running on `torghut-00376` and `torghut-sim-00474`; options catalog and enricher
+  were running; Postgres, ClickHouse, Keeper, TA, TA sim, WebSocket services, and guardrail exporters were running.
+
+### Torghut Evidence Seen By Jangar
+
+- `/trading/revenue-repair` was the live business evidence surface.
+- Business state was `repair_only`; revenue was not ready.
+- Top queue item was `repair_alpha_readiness`, selected value gate `routeable_candidate_count`, required output
+  `torghut.executable-alpha-receipts.v1`, expected unblock value `4`, capital rule `zero_notional_repair_only`, and
+  `max_notional=0`.
+- Alpha readiness had 3 hypotheses, 0 promotion-eligible hypotheses, 2 rollback-required lanes, and H-MICRO-01 as the
+  only lineage-ready lane.
+- Alpha evidence-window receipts preserved blockers and reported `measured_routeable_candidate_delta=0`.
+- Routeability acceptance stayed blocked with accepted routeable candidate count `0`.
+- Repair-bid settlement exposed 33 raw bids, 6 compacted lots, 5 selected lots, and 3 dispatchable lots.
+- Runtime profitability over 72 hours had 68 decisions, 0 executions, 6250 TCA samples, and negative TCA-derived PnL
+  proxy. This is evidence for caution, not a reason to loosen capital.
+
+### Database And Source Witnesses
+
+- Direct CNPG reads and pod exec were forbidden to the service account, so Jangar should continue to rely on typed
+  Torghut HTTP evidence rather than direct DB reads.
+- Torghut `/db-check` was schema-current at `0031_autoresearch_candidate_spec_epoch_uniqueness`, with one schema graph
+  branch, no missing heads, no unexpected heads, and lineage ready.
+- Source modules already exist for alpha evidence foundry, alpha repair closure board, executable alpha receipts,
+  routeability repair acceptance, and repair-bid settlement. The missing Jangar behavior is not parsing more fields; it
+  is runner custody for unchanged no-delta foreclosure keys.
+
+## Problem
+
+Jangar can admit zero-notional repair work, but it does not yet have a foreclosure governor that prevents unchanged
+alpha evidence no-delta work from spending another runner slot.
+
+The concrete failure modes are:
+
+1. A current Torghut evidence packet can be treated as generally dispatchable even when it carries active no-delta debt.
+2. Jangar can launch a second runner for the same alpha evidence-window key before Torghut proves that the source or
+   blocker set changed.
+3. Failed or OOMKilled AgentRuns can repeat against stale work because the launch key is not tied to a terminal
+   settlement receipt.
+4. `/ready=ok` can be misread as permission to widen action classes, even though Torghut is still `repair_only` and
+   `max_notional=0`.
+5. Deployer handoffs can prove Argo health and still miss the business truth: routeable candidate count remains zero.
+6. Manual operators have to inspect large Torghut payloads instead of one compact foreclosure decision.
+
+Jangar needs to enforce runner custody from typed Torghut evidence while leaving strategy and capital authority inside
+Torghut.
+
+## Alternatives Considered
+
+### Option A: Admit Any Dispatchable Torghut Repair Lot
+
+Jangar continues to launch when repair-bid settlement reports dispatchable lots and capital remains zero.
+
+Advantages:
+
+- Simple implementation.
+- Uses existing Jangar parsing.
+- Keeps the repair system moving.
+
+Disadvantages:
+
+- Ignores active no-delta debt.
+- Does not reduce failed or duplicate runner launches.
+- Can spend runner capacity without moving routeable candidate count.
+- Leaves deployer handoff dependent on large payload inspection.
+
+Decision: reject. Dispatchable is necessary but not sufficient.
+
+### Option B: Freeze All Torghut Alpha Repair Until Routeability Improves
+
+Jangar denies every Torghut alpha repair until routeability acceptance reports a positive candidate count.
+
+Advantages:
+
+- Very conservative.
+- Eliminates duplicate alpha runner starts.
+- Keeps capital safe.
+
+Disadvantages:
+
+- Deadlocks the system: routeability cannot improve without zero-notional repair work.
+- Forces manual exceptions.
+- Does not distinguish stale no-delta work from fresh release-key work.
+
+Decision: reject. The governor needs selective denial, not a freeze.
+
+### Option C: Foreclosure Governor With Release-Key Admission
+
+Jangar consumes a compact Torghut foreclosure ref, denies unchanged no-delta launch keys, and allows a new runner only
+when Torghut reports a changed release key or a terminal settlement receipt.
+
+Advantages:
+
+- Directly reduces duplicate and failed runner work.
+- Keeps Torghut as the strategy and capital authority.
+- Gives deployers one compact ref to verify.
+- Preserves zero-notional safety while allowing fresh repair work.
+- Maps every runner decision to the live revenue queue.
+
+Disadvantages:
+
+- Requires a new Jangar reducer and tests.
+- Needs shadow-mode rollout before enforcement to avoid over-denial.
+- Depends on Torghut emitting stable foreclosure keys.
+
+Decision: select Option C.
+
+## Architecture
+
+Jangar consumes `torghut.alpha-evidence-foreclosure-ref.v1` from `/trading/consumer-evidence`.
+
+```text
+jangar.alpha-evidence-foreclosure-governor.v1
+  governor_id
+  generated_at
+  fresh_until
+  mode = observe | shadow | enforce
+  torghut_consumer_evidence_ref
+  torghut_alpha_evidence_foreclosure_ref
+  selected_hypothesis_id
+  selected_value_gate = routeable_candidate_count
+  no_delta_key
+  release_key
+  required_after_receipts[]
+  admission_decision = allow | hold | deny
+  denied_reason_codes[]
+  runner_slot_ref
+  launch_ticket
+  validation_commands[]
+  rollback_target
+```
+
+Admission allows only when:
+
+1. Torghut consumer evidence is current.
+2. Foreclosure ref is current and schema-valid.
+3. Selected value gate is `routeable_candidate_count`.
+4. Selected hypothesis is the Torghut-selected reentry hypothesis.
+5. The selected work has `max_notional=0`.
+6. Live submission is disabled and capital stage is shadow.
+7. The no-delta key is not active, or the release key changed.
+8. Required output receipt is approved for zero-notional repair.
+9. Action class is `dispatch_repair`; paper and live action classes remain held.
+
+Admission denies when:
+
+- `torghut_alpha_evidence_foreclosure_ref_missing`
+- `torghut_alpha_evidence_foreclosure_ref_stale`
+- `torghut_alpha_evidence_foreclosure_not_zero_notional`
+- `torghut_alpha_evidence_foreclosure_gate_not_routeable_candidate_count`
+- `alpha_evidence_no_delta_key_active`
+- `alpha_evidence_release_key_unchanged`
+- `live_submission_not_disabled`
+- `capital_stage_not_shadow`
+- `required_after_receipt_unapproved`
+
+The runner ticket is compact:
+
+```text
+alpha_foreclosure_runner_ticket
+  ticket_id
+  source = torghut.alpha-evidence-foreclosure-ref.v1
+  selected_hypothesis_id
+  selected_lane_id
+  no_delta_key
+  release_key
+  required_after_receipts[]
+  validation_command
+  expected_gate_delta
+  max_notional = 0
+```
+
+Jangar stores enough local state to deny repeats within an enforcement window, but Torghut remains the source of truth
+for the foreclosure key and terminal settlement.
+
+## Implementation Scope
+
+M1 consume and observe:
+
+- Add a Jangar parser for `torghut.alpha-evidence-foreclosure-ref.v1`.
+- Add a pure reducer that returns allow, hold, or deny in observe mode.
+- Add tests for missing ref, stale ref, nonzero notional, wrong gate, active no-delta key, changed release key, and
+  capital stage violations.
+
+M2 shadow custody:
+
+- Surface the governor decision in the existing Torghut revenue-repair/status control-plane response.
+- Publish deny reasons without blocking runner creation.
+- Capture decision counts for duplicate no-delta keys.
+
+M3 enforcement:
+
+- Deny repeat alpha evidence repair AgentRuns when the same no-delta key remains active and the release key is
+  unchanged.
+- Continue allowing unrelated zero-notional repairs that are not the selected alpha foreclosure key.
+- Keep `dispatch_normal`, `deploy_widen`, `paper_canary`, and `live_canary` held.
+
+M4 deployer verification:
+
+- Capture Jangar ready, Torghut consumer evidence, Torghut revenue repair, foreclosure governor decision, and runner
+  ticket state after rollout.
+
+## Validation Gates
+
+Local Jangar validation:
+
+- `bun run --filter @proompteng/jangar test -- services/jangar/src/server/__tests__/control-plane-torghut-consumer-evidence.test.ts`
+- Add a focused test file for the foreclosure governor and run it with the same workspace test command.
+- `bunx oxfmt --check services/jangar/src/server`
+
+Cross-plane validation:
+
+- Torghut `/trading/consumer-evidence` includes `alpha_evidence_foreclosure_ref`.
+- Jangar governor reports observe or shadow decision without mutating AgentRuns.
+- Active no-delta key produces `admission_decision=deny` in shadow mode.
+- Changed release key produces `admission_decision=allow` while `max_notional=0`.
+- Jangar `/ready` remains about control-plane availability, not material trading readiness.
+
+Business validation:
+
+- Primary metric: `routeable_candidate_count`.
+- Intermediate metric: duplicate no-delta runner starts for the same alpha evidence key should go to zero after
+  enforcement.
+- Safety metric: no paper or live action class opens while Torghut reports `max_notional=0`.
+
+## Rollout
+
+1. Ship parser and reducer in observe mode.
+2. Verify Jangar can parse the compact ref from Torghut without changing runner behavior.
+3. Enable shadow-mode denial metrics for active no-delta keys.
+4. Compare shadow denials against actual launches for at least one deploy cycle.
+5. Enable enforcement only for duplicate alpha evidence foreclosure keys.
+6. Keep capital and action-class widening controlled by existing Torghut gates.
+
+## Rollback
+
+Rollback is to disable consumption of `alpha_evidence_foreclosure_ref` and return to existing repair-bid settlement
+admission.
+
+Safe rollback rules:
+
+- Do not change Torghut capital flags.
+- Do not delete local launch history; ignore it while the reducer is disabled.
+- Keep Jangar typed consumer evidence admission intact.
+- Keep paper and live action classes held unless independent capital gates clear.
+
+Emergency rollback triggers:
+
+- Governor denies changed release keys.
+- Governor allows nonzero notional.
+- Governor allows a wrong value gate.
+- Jangar ready status becomes coupled to Torghut revenue readiness.
+- Enforcement blocks unrelated zero-notional repair work outside the selected alpha foreclosure key.
+
+## Risks
+
+- If Torghut emits unstable no-delta keys, Jangar can under-deny duplicate work.
+- If Torghut omits a legitimate release condition, Jangar can over-deny fresh work.
+- Shadow-mode metrics can be noisy while older Torghut revisions do not publish the compact ref.
+- Enforcement has to stay scoped to the selected alpha foreclosure key; broad repair denial would slow recovery.
+- The cluster's AgentRun failure tail means the first enforcement should be narrow and easy to disable.
+
+## Handoff
+
+Engineer:
+
+- Implement the parser and reducer as pure TypeScript server code with focused tests.
+- Treat Torghut as the authority for selected hypothesis, value gate, no-delta key, release key, and notional.
+- Keep enforcement behind a config flag until deployer evidence proves the ref is stable.
+
+Deployer:
+
+- Verify Argo sync, Jangar pod readiness, Torghut consumer-evidence ref presence, governor decision, and unchanged
+  Torghut `max_notional=0`.
+- In shadow mode, capture at least one active no-delta key and prove Jangar would deny a duplicate launch.
+- Do not enable paper, live, or deploy-widen action classes from this rollout.
+
+Next bounded milestone:
+
+- Consume `torghut.alpha-evidence-foreclosure-ref.v1` in observe mode, publish the governor decision, and prepare the
+  enforcement flag for duplicate no-delta alpha repair keys.

--- a/docs/torghut/design-system/v6/202-torghut-alpha-evidence-foreclosure-and-routeable-candidate-reentry-2026-05-14.md
+++ b/docs/torghut/design-system/v6/202-torghut-alpha-evidence-foreclosure-and-routeable-candidate-reentry-2026-05-14.md
@@ -1,0 +1,460 @@
+# 202. Torghut Alpha Evidence Foreclosure And Routeable Candidate Reentry (2026-05-14)
+
+Status: Accepted for engineer and deployer handoff
+Date: 2026-05-14
+Owner: Gideon Park, Torghut Traders Architecture
+Scope: Torghut quant revenue repair, alpha evidence-window foreclosure, no-delta debt settlement, routeable candidate
+reentry, zero-notional capital safety, validation, rollout, rollback, and Jangar handoff.
+
+Companion Jangar contract:
+
+- `docs/agents/designs/197-jangar-alpha-evidence-foreclosure-governor-and-runner-custody-2026-05-14.md`
+
+Extends:
+
+- `201-torghut-alpha-closure-settlement-and-feature-replay-market-2026-05-14.md`
+- `200-torghut-routeable-alpha-evidence-foundry-and-capital-safe-profit-ladder-2026-05-14.md`
+- `199-torghut-executable-alpha-settlement-slots-and-no-delta-repair-custody-2026-05-14.md`
+- `198-torghut-alpha-repair-closure-board-and-routeable-revenue-reentry-2026-05-14.md`
+- `197-torghut-executable-alpha-repair-receipts-and-zero-notional-reentry-2026-05-13.md`
+- `190-torghut-repair-bid-settlement-and-routeability-proof-compaction-2026-05-13.md`
+
+## Decision
+
+I am selecting an **alpha evidence foreclosure and routeable candidate reentry contract** as the next Torghut quant
+architecture increment.
+
+The live business surface has moved again, but the revenue blocker has not cleared. On 2026-05-14 at 04:10 UTC,
+`GET http://torghut.torghut.svc.cluster.local/trading/revenue-repair` returned
+`business_state=repair_only`, `revenue_ready=false`, active revision `torghut-00376`, accepted routeable candidate
+count `0`, `zero_notional_or_stale_evidence_rate=1.0`, `max_notional=0`, and top queue item
+`repair_alpha_readiness`. That queue item still targets `routeable_candidate_count`, still cites
+`alpha_readiness_not_promotion_eligible`, and still requires `torghut.executable-alpha-receipts.v1`.
+
+The difference is that Torghut now publishes the alpha evidence foundry, alpha repair closure board, closure settlement
+market, and executable alpha repair receipts. Those contracts make the work visible. They also expose a new failure
+mode: the foundry is producing no-delta evidence-window receipts for the same blocker set. Three
+`torghut.alpha-evidence-window-receipt.v1` receipts reported measured routeable candidate delta `0` and
+`no_delta_reason=routeable_candidate_count_unchanged`. `H-MICRO-01` remains the only lineage-ready lane, but it is
+still blocked by `drift_checks_missing`, `feature_rows_missing`, and `required_feature_set_unavailable`; `H-CONT-01`
+and `H-REV-01` remain shadow lanes with non-positive post-cost evidence or missing lineage.
+
+The next architecture should not create yet another alpha-readiness receipt type. It should foreclose unchanged
+evidence windows, reserve one reentry path for the lineage-ready H-MICRO-01 feature replay, and require a terminal
+settlement receipt before the same dedupe key can spend another zero-notional repair slot. The tradeoff is strict:
+some useful repair work will wait behind no-delta custody. That is the right trade while the business metric is
+routeable post-cost profit evidence and live trading readiness without weakening capital safety.
+
+## Governing Runtime Requirements
+
+This design follows the active Torghut quant validation contract:
+
+- every run must cite the governing Torghut design or runtime requirement before changing code;
+- implement stages must produce production PRs that improve readiness, profit evidence, data freshness, execution
+  quality, or capital safety;
+- verify stages must merge only green PRs and prove image promotion, Argo sync, live service health, and trading or
+  evidence status after rollout;
+- final handoff must name the revenue metric improved or the smallest blocker preventing revenue impact.
+
+The value-gate mapping is explicit:
+
+- `routeable_candidate_count`: primary gate. A foreclosure window may reopen only when H-MICRO-01 produces fresh
+  feature rows, drift checks, required feature-set evidence, or a promotion receipt that can change routeability.
+- `zero_notional_or_stale_evidence_rate`: each no-delta receipt must either retire stale evidence or be carried as
+  foreclosure debt until its source key changes.
+- `fill_tca_or_slippage_quality`: AAPL is the only probing symbol; AMD, AVGO, INTC, and NVDA remain blocked by route
+  TCA quality, and AMZN, GOOGL, and ORCL remain missing TCA. Reentry cannot count a routeable candidate while those
+  route constraints block the selected path.
+- `post_cost_daily_net_pnl`: H-CONT-01 and H-REV-01 remain behind non-positive post-cost expectancy; H-MICRO-01 must
+  settle a current post-cost or rejection-drag receipt before promotion custody can graduate.
+- `capital_gate_safety`: live submit remains disabled, capital stage remains shadow, and every foreclosure or reentry
+  object carries `max_notional=0`.
+
+## Read-Only Evidence Snapshot
+
+I collected this evidence read-only on 2026-05-14. I did not mutate Kubernetes resources, database rows, trading flags,
+broker state, GitOps resources, AgentRuns, or market data.
+
+### Cluster And Rollout
+
+- The working branch was `codex/swarm-torghut-quant-discover`, based on `origin/main` at
+  `29f0d1c9fd417fc65666896b6b5433be668c78a5`.
+- Argo reported `torghut`, `jangar`, and `agents` as `Synced` and `Healthy` at revision
+  `29f0d1c9fd417fc65666896b6b5433be668c78a5`.
+- Torghut live revision `torghut-00376` and sim revision `torghut-sim-00474` were running and available. The serving
+  image digest was `sha256:6077dc8dc64721d4772b0d10c8e1a0b567e2c7f2475686bf323f7d211941b750`, source commit
+  `9292518f9a313af097a24f7fd50f912676740a9e`.
+- Postgres `torghut-db-1`, ClickHouse, Keeper, TA, TA sim, options catalog, options enricher, WebSocket services, and
+  guardrail exporters were running.
+- Recent Torghut events showed normal Knative replacement behavior: image pulls, migrations completed, startup and
+  readiness probe warnings during revision replacement, then `RevisionReady` for `torghut-00376` and
+  `torghut-sim-00474`.
+- The cluster still has reliability noise outside the live capital path: many Torghut whitepaper autoresearch pods and
+  several Jangar/Torghut AgentRun pods were in `Error` or `OOMKilled` while current attempts were running or
+  completed. That tail is evidence for stricter no-delta runner custody.
+
+### Database And Data Quality
+
+- Direct CNPG cluster listing and `kubectl cnpg psql` were forbidden to this service account for `torghut` and
+  `jangar`. That least-privilege boundary means the architecture lane must use application-level database witnesses.
+- `GET /db-check` returned `ok=true`, `schema_current=true`, current and expected Alembic head
+  `0031_autoresearch_candidate_spec_epoch_uniqueness`, one schema graph branch, no missing heads, no unexpected
+  heads, lineage ready, and account-scope ready.
+- Known schema graph parent-fork warnings remain under `0010_execution_provenance_and_governance_trace` and
+  `0015_whitepaper_workflow_tables`; they did not block schema currentness.
+- `GET /readyz` returned HTTP 503 with `status=degraded`, while Postgres, ClickHouse, Alpaca, database schema,
+  universe, empirical jobs, DSPy runtime, and optional quant evidence were healthy or acceptable.
+- The readiness failures were capital-safe: `live_submission_gate=simple_submit_disabled` and
+  `profitability_proof_floor=repair_only`.
+- Runtime profitability over 72 hours reported 68 decisions, 0 executions, 6250 TCA samples, and
+  `realized_pnl_proxy_notional=-1726.06230727`. Every recent decision path remained blocked; this is evidence, not a
+  tradable profit certificate.
+- Promotion table counts showed 1242 autoresearch candidate specs, 1242 proposal scores, 5 portfolio candidates,
+  0 portfolio-ready rows, and 5 blocked portfolio candidates. H-MICRO-01 had ready strategy lineage; H-CONT-01 and
+  H-REV-01 did not.
+
+### Source And Test Surface
+
+- `services/torghut/app/main.py` is 6925 lines and remains the high-risk integration surface for `/readyz`,
+  `/trading/status`, `/trading/revenue-repair`, `/trading/consumer-evidence`, and zero-notional repair execution.
+- `services/torghut/app/trading/revenue_repair.py` is 1111 lines and builds the live revenue digest, queue, foundry,
+  closure board, and repair settlement projections.
+- `services/torghut/app/trading/alpha_evidence_foundry.py` is 608 lines and now emits the evidence-window receipt set
+  that exposes no-delta debt.
+- `services/torghut/app/trading/alpha_repair_closure_board.py` is 820 lines and implements the closure board and
+  market described by docs 198 and 201.
+- `services/torghut/app/trading/executable_alpha_receipts.py` is 1146 lines and remains the launch-candidate receipt
+  producer.
+- `services/torghut/app/trading/routeability_repair_acceptance.py` is 768 lines and is the routeable count authority
+  that must consume terminal closure receipts before increasing accepted candidate count.
+- `services/torghut/app/trading/repair_bid_settlement.py` is 716 lines and compacts raw repair bids into dispatchable
+  lots.
+- The test suite already has focused coverage for executable alpha repair receipts, alpha evidence foundry, alpha
+  repair closure board, routeability repair acceptance, repair-bid settlement, and revenue repair digest. The missing
+  coverage is foreclosure behavior: unchanged evidence-window receipts should deny repeat runner spend until source,
+  evidence window, blocker digest, or required receipt set changes.
+
+### Trading Evidence
+
+- `/trading/revenue-repair` reported `repair_only`, `revenue_ready=false`, and active revision `torghut-00376`.
+- Capital stayed closed: `live_submission_allowed=false`, `live_submission_reason=simple_submit_disabled`,
+  `capital_stage=shadow`, `proof_floor_state=repair_only`, `route_state=repair_only`,
+  `capital_state=zero_notional`, and `max_notional=0`.
+- Top repair queue item:
+  - `code=repair_alpha_readiness`
+  - `reason=alpha_readiness_not_promotion_eligible`
+  - `value_gate=routeable_candidate_count`
+  - `expected_unblock_value=4`
+  - `required_output_receipt=torghut.executable-alpha-receipts.v1`
+  - `required_receipts=alpha_readiness_receipt,hypothesis_promotion_receipt,capital_replay_board`
+  - `max_notional=0`
+- Routeability acceptance was blocked with `accepted_routeable_candidate_count=0` and
+  `zero_notional_or_stale_evidence_rate=1.0`.
+- Repair-bid settlement had 33 raw bids, 6 compacted lots, 5 selected lots, 3 dispatchable lots, and
+  `routeable_candidate_count=0`.
+- Alpha readiness had 3 hypotheses, 0 promotion-eligible hypotheses, 2 rollback-required shadow lanes, and 3 blocked
+  repair targets.
+- H-MICRO-01 was the only lineage-ready target. It remained blocked by drift checks, feature rows, required feature
+  set evidence, and closed-session signal hold.
+- Route reacquisition had `routeable_symbol_count=0`, `probing_symbol_count=1`, `blocked_symbol_count=4`,
+  `missing_symbol_count=3`, candidate symbol `AAPL`, and expected unblock value `14`.
+- Execution TCA held the route universe: 7334 orders, 7245 filled executions, latest execution created at
+  `2026-04-02T19:00:29.586040+00:00`, average absolute slippage `13.8203637593029676` bps against an 8 bps guardrail,
+  AAPL probing, AMD/AVGO/INTC/NVDA blocked, and AMZN/GOOGL/ORCL missing.
+
+## Problem
+
+Torghut has enough architecture to name the alpha repair, but not enough custody to prevent repeated no-delta work.
+That is now the system-level blocker.
+
+The concrete failure modes are:
+
+1. An unchanged alpha evidence-window receipt can be regenerated and relaunched even when it previously preserved every
+   blocker.
+2. Routeability remains zero while repair-bid settlement reports dispatchable work, so runner dispatch can look busy
+   while the business metric does not move.
+3. H-MICRO-01 is the only lineage-ready lane, but the current payload does not make its stale feature window the sole
+   foreclosure release key.
+4. H-CONT-01 and H-REV-01 can consume attention even though their immediate blockers are non-positive post-cost
+   expectancy or missing lineage.
+5. Jangar can see current Torghut evidence but needs a compact foreclosure decision to deny duplicate launch keys.
+6. Operators can misread `/readyz` degradation as a submit-gate problem; the correct next blocker is alpha evidence
+   foreclosure and feature-replay after-receipt settlement.
+
+The design must convert no-delta evidence into debt with release conditions, then define the only reentry path that can
+move routeable candidate count without opening capital.
+
+## Alternatives Considered
+
+### Option A: Keep Launching Existing Alpha Evidence Receipts
+
+Continue to let the alpha evidence foundry and closure board produce the same receipt set, with Jangar deciding whether
+to launch another repair run from dispatchable lots.
+
+Advantages:
+
+- No new Torghut schema.
+- Uses live reducers and tests already present.
+- Keeps all capital fields at zero.
+
+Disadvantages:
+
+- Repeats no-delta work against unchanged blocker sets.
+- Does not give routeability acceptance a terminal after-receipt.
+- Keeps failed AgentRun and OOM risk detached from business impact.
+- Leaves routeable candidate count at zero while work appears active.
+
+Decision: reject. Existing receipts remain inputs, not repeat authorization.
+
+### Option B: Switch Priority To TCA Route Repair
+
+Spend the next architecture and runner capacity on route TCA quality for AMD, AVGO, INTC, NVDA, and missing route
+coverage for AMZN, GOOGL, and ORCL.
+
+Advantages:
+
+- Directly improves `fill_tca_or_slippage_quality`.
+- Route quality is a real capital-safety guardrail.
+- The evidence is concrete and symbol-scoped.
+
+Disadvantages:
+
+- It is not the live top `/trading/revenue-repair` queue item.
+- It cannot increase routeable candidate count while alpha readiness remains not promotion eligible.
+- It can improve downstream execution quality without producing a promotion-ready hypothesis.
+
+Decision: reject as the lead lane. TCA remains a required reentry gate after alpha foreclosure releases H-MICRO-01.
+
+### Option C: Alpha Evidence Foreclosure With H-MICRO-01 Reentry
+
+Create a foreclosure read-model that marks unchanged alpha evidence-window receipts as active no-delta debt, reserves
+H-MICRO-01 as the only current reentry lane, and requires terminal feature-replay and promotion-custody receipts before
+routeability acceptance can change.
+
+Advantages:
+
+- Targets the live top queue item and primary business gate.
+- Prevents repeat runner spend on unchanged no-delta keys.
+- Uses H-MICRO-01 because it is the only lineage-ready lane.
+- Keeps H-CONT-01 and H-REV-01 behind post-cost and lineage blockers.
+- Preserves `max_notional=0` and live submit disabled.
+- Gives Jangar a compact admission and denial contract.
+
+Disadvantages:
+
+- Adds another reducer and test family.
+- Holds some useful repairs until the foreclosure key changes.
+- Requires careful source/evidence-window keying so legitimate fresh evidence is not blocked.
+
+Decision: select Option C.
+
+## Architecture
+
+Torghut publishes an `alpha_evidence_foreclosure_book` in `/trading/revenue-repair` and mirrors a compact
+`alpha_evidence_foreclosure_ref` in `/trading/consumer-evidence`.
+
+```text
+torghut.alpha-evidence-foreclosure-book.v1
+  book_id
+  generated_at
+  fresh_until
+  account_id
+  window
+  trading_mode
+  source_commit
+  active_revision
+  source_revenue_repair_ref
+  source_alpha_evidence_foundry_ref
+  source_alpha_closure_board_ref
+  routeability_acceptance_ref
+  capital_rule = zero_notional_repair_only
+  foreclosure_state = open | released | superseded
+  selected_reentry_hypothesis_id
+  selected_reentry_lane_id
+  selected_value_gate = routeable_candidate_count
+  active_no_delta_debts[]
+  release_conditions[]
+  required_after_receipts[]
+  denied_repeat_keys[]
+  validation_commands[]
+  rollback_target
+```
+
+The active no-delta debt key is:
+
+```text
+account_id + window + source_commit + hypothesis_id + repair_class + blocker_digest + required_receipt_digest
+```
+
+The book records one row per active no-delta receipt:
+
+```text
+alpha_evidence_foreclosure_debt
+  debt_id
+  source_receipt_id
+  hypothesis_id
+  candidate_id
+  strategy_id
+  lane_id
+  repair_class
+  value_gate
+  blocker_digest
+  preserved_reason_codes[]
+  retired_reason_codes[]
+  measured_routeable_candidate_delta
+  no_delta_reason
+  release_conditions[]
+  repeat_launch_decision = deny | allow_after_change
+  max_notional = 0
+```
+
+The first release policy is intentionally narrow:
+
+- H-MICRO-01 is the selected reentry hypothesis while it is the only lineage-ready lane.
+- H-MICRO-01 release requires a current feature replay receipt, drift check receipt, required feature set receipt,
+  alpha readiness receipt, and promotion custody receipt.
+- H-MICRO-01 may not count as routeable while route/TCA remains outside the selected symbol path guardrail.
+- H-CONT-01 and H-REV-01 stay foreclosed until post-cost expectancy or lineage status changes.
+- Any repeat launch with the same debt key is denied.
+- A repeat launch becomes eligible only when source commit, evidence window, blocker digest, required receipt set, or
+  selected top queue item changes.
+
+Routeability acceptance consumes only terminal foreclosure outcomes:
+
+```text
+routeability_repair_acceptance_input
+  alpha_evidence_foreclosure_book_ref
+  terminal_foreclosure_receipt_ref
+  selected_hypothesis_id
+  selected_route_symbol
+  measured_routeable_candidate_delta
+  release_state
+  capital_rule
+```
+
+If terminal settlement reports no movement, routeability remains at zero and the no-delta debt stays active. If
+terminal settlement retires the feature blockers but post-cost or TCA remains blocked, routeability remains zero and
+the book moves the lane to the next explicit blocker. If terminal settlement retires feature, promotion, post-cost, and
+route/TCA blockers, routeability acceptance may increase the routeable candidate count while still keeping
+`max_notional=0` until capital gate safety separately clears.
+
+## Implementation Scope
+
+M1 is a pure Torghut reducer and tests:
+
+- Add `services/torghut/app/trading/alpha_evidence_foreclosure.py`.
+- Consume the current `alpha_evidence_foundry`, `alpha_repair_closure_board`, routeability acceptance ledger, and
+  runtime build fields.
+- Emit `alpha_evidence_foreclosure_book` from `/trading/revenue-repair`.
+- Mirror compact `alpha_evidence_foreclosure_ref` from `/trading/consumer-evidence`.
+- Add tests proving unchanged no-delta debts deny repeat keys and H-MICRO-01 is the selected reentry lane.
+
+M2 is Jangar admission:
+
+- Consume `alpha_evidence_foreclosure_ref`.
+- Deny duplicate zero-notional repair AgentRuns when `repeat_launch_decision=deny`.
+- Allow a new alpha-repair runner only when the release key changed or a terminal settlement receipt exists.
+
+M3 is routeability reentry:
+
+- Add a routeability acceptance input that consumes terminal foreclosure outcomes.
+- Keep `accepted_routeable_candidate_count=0` until after-receipts retire the selected blockers.
+- Emit a clear next-blocker state when H-MICRO-01 releases feature evidence but remains blocked by post-cost or TCA.
+
+M4 is deployer verification:
+
+- Verify image promotion, Argo sync, workload readiness, `/readyz`, `/trading/revenue-repair`, and
+  `/trading/consumer-evidence`.
+- Capture routeable candidate count, no-delta debt count, H-MICRO-01 release state, and capital notional.
+
+## Validation Gates
+
+Local engineer validation:
+
+- `uv run --frozen pytest services/torghut/tests/test_alpha_evidence_foreclosure.py`
+- `uv run --frozen pytest services/torghut/tests/test_alpha_evidence_foundry.py services/torghut/tests/test_alpha_repair_closure_board.py`
+- `uv run --frozen pytest services/torghut/tests/test_build_revenue_repair_digest.py -k alpha`
+- `uv run --frozen pyright --project pyrightconfig.json`
+- `uv run --frozen pyright --project pyrightconfig.alpha.json`
+- `uv run --frozen pyright --project pyrightconfig.scripts.json`
+
+Runtime verification after deploy:
+
+- `/trading/revenue-repair` includes `alpha_evidence_foreclosure_book.schema_version=torghut.alpha-evidence-foreclosure-book.v1`.
+- `active_no_delta_debts.length >= 1` while current no-delta receipts preserve blockers.
+- `selected_reentry_hypothesis_id=H-MICRO-01`.
+- `repeat_launch_decision=deny` for unchanged H-MICRO-01 debt keys.
+- `accepted_routeable_candidate_count` remains `0` until terminal after-receipts retire blockers.
+- `max_notional=0`, `live_submission_allowed=false`, and `capital_stage=shadow`.
+
+Business validation:
+
+- Primary metric: `routeable_candidate_count`.
+- Intermediate metric: `zero_notional_or_stale_evidence_rate`.
+- Safety metric: `capital_gate_safety`.
+- Smallest blocker if revenue does not move: H-MICRO-01 feature replay and promotion custody did not produce terminal
+  after-receipts that retire `feature_rows_missing`, `required_feature_set_unavailable`, and the active no-delta debt
+  key.
+
+## Rollout
+
+1. Ship the Torghut reducer in observe mode. Do not change live submission, proof-floor, or capital flags.
+2. Verify the book appears in `/trading/revenue-repair` and compact ref appears in `/trading/consumer-evidence`.
+3. Deploy Jangar consume-only parsing for the compact ref.
+4. Enable Jangar shadow denial metrics for duplicate foreclosure keys.
+5. Enable Jangar enforcement for repeat no-delta alpha repair launches only after at least one deploy cycle proves the
+   ref is stable.
+6. Keep all paper and live action classes held until routeability acceptance and capital gate safety separately pass.
+
+## Rollback
+
+Rollback is to ignore `alpha_evidence_foreclosure_book` and `alpha_evidence_foreclosure_ref`.
+
+Safe rollback conditions:
+
+- Keep existing alpha evidence foundry, alpha repair closure board, executable alpha repair receipts, and repair-bid
+  settlement payloads intact.
+- Keep `max_notional=0`.
+- Keep `simple_submit_disabled`.
+- Keep routeability acceptance at its current authority state.
+- Do not delete or rewrite no-delta history; stop consuming the foreclosure book until the reducer is fixed.
+
+Emergency rollback triggers:
+
+- Foreclosure book emits nonzero notional.
+- Foreclosure book selects a hypothesis other than H-MICRO-01 while H-MICRO-01 is the only lineage-ready lane and the
+  live top queue remains alpha readiness.
+- Repeat keys are denied after source commit, evidence window, blocker digest, or required receipt set changes.
+- Routeability acceptance increases candidate count without terminal after-receipts.
+
+## Risks
+
+- Over-foreclosure can block useful repair work if the key omits a legitimate source or evidence-window change.
+- Under-foreclosure can repeat no-delta runner work and increase failed AgentRun rate.
+- H-MICRO-01 can retire feature blockers and still fail post-cost or TCA; the book must report the next blocker rather
+  than imply revenue readiness.
+- Direct DB introspection is unavailable to this worker; application-level witnesses must remain trustworthy and
+  schema-versioned.
+- The live AgentRun error tail means Jangar enforcement should start in shadow mode before denying real runner starts.
+
+## Handoff
+
+Engineer:
+
+- Implement M1 as a pure read-model with focused tests.
+- Do not mutate trading records, broker state, or Kubernetes resources from the reducer.
+- Keep every emitted object at `max_notional=0`.
+- Add regression tests for unchanged no-delta keys, changed release keys, H-MICRO-01 selection, and routeability count
+  preservation.
+
+Deployer:
+
+- Roll out only after Torghut pyright profiles and targeted tests pass.
+- Prove image promotion, Argo sync, active revision, `/readyz` degraded-for-capital-only state, revenue-repair book
+  presence, consumer-evidence ref presence, and unchanged `max_notional=0`.
+- Do not enable paper or live action classes from this rollout.
+
+Next bounded milestone:
+
+- Build `torghut.alpha-evidence-foreclosure-book.v1` and the compact consumer-evidence ref, then hand Jangar the
+  duplicate-denial key for shadow enforcement.

--- a/docs/torghut/design-system/v6/index.md
+++ b/docs/torghut/design-system/v6/index.md
@@ -12,6 +12,8 @@
 - Implementation status (strict, core 01-13 docs, source-state refresh `2026-03-09`): `Implemented=7`, `Partial=5`, `Completed=1`
 - Evidence (historical closure): `13-production-gap-closure-master-plan-2026-03-03.md` (Wave 0-6 closure + DoD)
 - Evidence (current next-work priority, refreshed `2026-05-14T00:35Z`):
+  - `202-torghut-alpha-evidence-foreclosure-and-routeable-candidate-reentry-2026-05-14.md`
+  - `docs/agents/designs/197-jangar-alpha-evidence-foreclosure-governor-and-runner-custody-2026-05-14.md`
   - `201-torghut-alpha-closure-settlement-and-feature-replay-market-2026-05-14.md`
   - `docs/agents/designs/196-jangar-alpha-closure-slot-governor-and-no-delta-budget-2026-05-14.md`
   - `200-torghut-routeable-alpha-evidence-foundry-and-capital-safe-profit-ladder-2026-05-14.md`


### PR DESCRIPTION
## Summary

- Added the Torghut alpha evidence foreclosure architecture contract for unchanged no-delta evidence-window keys.
- Added the companion Jangar foreclosure governor contract for duplicate runner-slot custody.
- Updated the Torghut design-system index so the new foreclosure design is the current next-work priority.

## Related Issues

None

## Testing

- `bunx oxfmt --check docs/torghut/design-system/v6/202-torghut-alpha-evidence-foreclosure-and-routeable-candidate-reentry-2026-05-14.md docs/agents/designs/197-jangar-alpha-evidence-foreclosure-governor-and-runner-custody-2026-05-14.md docs/torghut/design-system/v6/index.md`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
