### PR TITLE
chore(jangar): promote image 210250b2

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 1a37a432
-  digest: sha256:ee9cc261c3c2c1a465af17739bbf9f4644aee4fa27e325db6eebd2549b40a44c
+  tag: 210250b2
+  digest: sha256:ba11dd62602f86f4e48bb8c94b5acfc840d01ef2089c0dfc64c42a7a7e81a905
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,8 +11,8 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 1a37a432
-    digest: sha256:f4eb1618d04facd500b97291f1537929902d1727efdc114f01e2fde380af03c7
+    tag: 210250b2
+    digest: sha256:379b1bd8d4cb11d7e27ab45b41ca5a162951d654aee98d53d591083f3cb32ae5
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
@@ -21,8 +21,8 @@ controlPlane:
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 1a37a432
-    digest: sha256:ee9cc261c3c2c1a465af17739bbf9f4644aee4fa27e325db6eebd2549b40a44c
+    tag: 210250b2
+    digest: sha256:ba11dd62602f86f4e48bb8c94b5acfc840d01ef2089c0dfc64c42a7a7e81a905
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-14T03:37:42Z
+    deploy.knative.dev/rollout: 2026-05-14T04:24:50Z
 spec:
   replicas: 1
   strategy:
@@ -57,11 +57,11 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_RUNTIME_IMAGE
-              value: registry.ide-newton.ts.net/lab/jangar:1a37a432@sha256:ee9cc261c3c2c1a465af17739bbf9f4644aee4fa27e325db6eebd2549b40a44c
+              value: registry.ide-newton.ts.net/lab/jangar:210250b2@sha256:ba11dd62602f86f4e48bb8c94b5acfc840d01ef2089c0dfc64c42a7a7e81a905
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: 1a37a432e7c2d06e0cfc2d90ffd9a09a6551ffc3
+              value: 210250b227e5ad8b58af64c06339ee5b6743fb02
             - name: JANGAR_GITOPS_REVISION
-              value: 1a37a432e7c2d06e0cfc2d90ffd9a09a6551ffc3
+              value: 210250b227e5ad8b58af64c06339ee5b6743fb02
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_BUMBA_TASK_QUEUE

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -59,5 +59,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: 1a37a432
-    digest: sha256:ee9cc261c3c2c1a465af17739bbf9f4644aee4fa27e325db6eebd2549b40a44c
+    newTag: 210250b2
+    digest: sha256:ba11dd62602f86f4e48bb8c94b5acfc840d01ef2089c0dfc64c42a7a7e81a905


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `210250b227e5ad8b58af64c06339ee5b6743fb02`
- Image tag: `210250b2`
- Image digest: `sha256:ba11dd62602f86f4e48bb8c94b5acfc840d01ef2089c0dfc64c42a7a7e81a905`
- Updated API rollout annotation
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`