### PR TITLE
fix(sag): prevent first paint flash

### DIFF
--- a/argocd/sag/kustomization.yaml
+++ b/argocd/sag/kustomization.yaml
@@ -12,4 +12,4 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/sag
     newName: registry.ide-newton.ts.net/lab/sag
-    newTag: "sag-20260513211441"
+    newTag: "sag-20260513212251"

--- a/argocd/sag/kustomization.yaml
+++ b/argocd/sag/kustomization.yaml
@@ -12,4 +12,4 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/sag
     newName: registry.ide-newton.ts.net/lab/sag
-    newTag: "sag-20260513203124"
+    newTag: "sag-20260513211441"

--- a/services/sag/src/app/styles/app.css
+++ b/services/sag/src/app/styles/app.css
@@ -122,7 +122,7 @@
     @apply border-border outline-ring/50;
   }
   body {
-    @apply bg-zinc-950 text-zinc-100;
+    @apply visible bg-zinc-950 text-zinc-100;
   }
   html {
     @apply bg-zinc-950 font-sans text-zinc-100;

--- a/services/sag/src/client.tsx
+++ b/services/sag/src/client.tsx
@@ -1,7 +1,6 @@
 import { StartClient } from '@tanstack/react-start/client'
 import { StrictMode, startTransition } from 'react'
 import { hydrateRoot } from 'react-dom/client'
-import './app/styles/app.css'
 
 startTransition(() => {
   hydrateRoot(

--- a/services/sag/src/routes/__root.tsx
+++ b/services/sag/src/routes/__root.tsx
@@ -1,4 +1,7 @@
+/// <reference types="vite/client" />
 import { createRootRoute, HeadContent, Outlet, Scripts } from '@tanstack/react-router'
+
+import appCss from '../app/styles/app.css?url'
 
 export const Route = createRootRoute({
   head: () => ({
@@ -6,20 +9,32 @@ export const Route = createRootRoute({
       { charSet: 'utf-8' },
       { name: 'viewport', content: 'width=device-width, initial-scale=1, viewport-fit=cover' },
       { name: 'theme-color', content: '#09090b' },
+      { name: 'color-scheme', content: 'dark' },
       { title: 'Secure Action Gateway' },
     ],
-    links: [{ rel: 'icon', href: 'data:,' }],
+    links: [
+      { rel: 'stylesheet', href: appCss },
+      { rel: 'icon', href: 'data:,' },
+    ],
   }),
   component: RootDocument,
 })
 
 function RootDocument() {
   return (
-    <html lang="en" className="dark h-full bg-zinc-950 text-zinc-100 [color-scheme:dark]">
+    <html
+      lang="en"
+      className="dark h-full bg-zinc-950 text-zinc-100 [color-scheme:dark]"
+      style={{ backgroundColor: '#09090b', color: '#f4f4f5', colorScheme: 'dark' }}
+    >
       <head>
+        <style>{'html,body{background:#09090b;color:#f4f4f5;color-scheme:dark}body{visibility:hidden}'}</style>
         <HeadContent />
       </head>
-      <body className="min-h-screen bg-zinc-950 text-zinc-100 antialiased">
+      <body
+        className="min-h-screen bg-zinc-950 text-zinc-100 antialiased"
+        style={{ backgroundColor: '#09090b', color: '#f4f4f5' }}
+      >
         <a
           href="#main-content"
           className="sr-only focus:not-sr-only focus:absolute focus:left-3 focus:top-3 focus:z-50 focus:rounded-md focus:bg-zinc-900 focus:px-3 focus:py-2 focus:text-sm focus:text-zinc-50 focus:outline-none focus:ring-2 focus:ring-zinc-400"


### PR DESCRIPTION
## Summary

- Moves SAG Tailwind CSS into the TanStack Start root route head using the documented `?url` stylesheet pattern.
- Adds a dark first-paint guard so SSR content cannot show as unstyled white while CSS is loading.
- Promotes the SAG image built from this fix to GitOps so Argo keeps the corrected deployment.

## Related Issues

None

## Testing

- `bun run --filter @proompteng/sag lint`
- `bun run --filter @proompteng/sag lint:oxlint`
- `bun run --filter @proompteng/sag tsc`
- `bun run --filter @proompteng/sag test`
- `bun run --filter @proompteng/sag build`
- `SAG_IMAGE_TAG=sag-20260513212251 bun run sag:deploy`

## Screenshots (if applicable)

N/A - first-paint behavior is verified from the emitted stylesheet link and live browser checks after rollout.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
