### PR TITLE
fix(sag): release first paint guard

### DIFF
--- a/argocd/sag/kustomization.yaml
+++ b/argocd/sag/kustomization.yaml
@@ -12,4 +12,4 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/sag
     newName: registry.ide-newton.ts.net/lab/sag
-    newTag: "sag-20260513212251"
+    newTag: "sag-20260513212944"

--- a/services/sag/src/app/styles/app.css
+++ b/services/sag/src/app/styles/app.css
@@ -124,6 +124,9 @@
   body {
     @apply visible bg-zinc-950 text-zinc-100;
   }
+  html[data-sag-paint='guard'] body {
+    visibility: visible;
+  }
   html {
     @apply bg-zinc-950 font-sans text-zinc-100;
   }

--- a/services/sag/src/client.tsx
+++ b/services/sag/src/client.tsx
@@ -1,6 +1,7 @@
 import { StartClient } from '@tanstack/react-start/client'
 import { StrictMode, startTransition } from 'react'
 import { hydrateRoot } from 'react-dom/client'
+import './app/styles/app.css'
 
 startTransition(() => {
   hydrateRoot(

--- a/services/sag/src/routes/__root.tsx
+++ b/services/sag/src/routes/__root.tsx
@@ -1,7 +1,4 @@
-/// <reference types="vite/client" />
 import { createRootRoute, HeadContent, Outlet, Scripts } from '@tanstack/react-router'
-
-import appCss from '../app/styles/app.css?url'
 
 export const Route = createRootRoute({
   head: () => ({
@@ -12,10 +9,7 @@ export const Route = createRootRoute({
       { name: 'color-scheme', content: 'dark' },
       { title: 'Secure Action Gateway' },
     ],
-    links: [
-      { rel: 'stylesheet', href: appCss },
-      { rel: 'icon', href: 'data:,' },
-    ],
+    links: [{ rel: 'icon', href: 'data:,' }],
   }),
   component: RootDocument,
 })
@@ -24,11 +18,22 @@ function RootDocument() {
   return (
     <html
       lang="en"
+      data-sag-paint="guard"
       className="dark h-full bg-zinc-950 text-zinc-100 [color-scheme:dark]"
       style={{ backgroundColor: '#09090b', color: '#f4f4f5', colorScheme: 'dark' }}
     >
       <head>
-        <style>{'html,body{background:#09090b;color:#f4f4f5;color-scheme:dark}body{visibility:hidden}'}</style>
+        <style>
+          {
+            'html,body{background:#09090b;color:#f4f4f5;color-scheme:dark}html[data-sag-paint=guard] body{visibility:hidden}'
+          }
+        </style>
+        <script
+          dangerouslySetInnerHTML={{
+            __html:
+              'window.addEventListener("load",function(){document.documentElement.dataset.sagPaint="ready"},{once:true});setTimeout(function(){document.documentElement.dataset.sagPaint="ready"},2500);',
+          }}
+        />
         <HeadContent />
       </head>
       <body


### PR DESCRIPTION
## Summary

- Restores the SAG app CSS import path that produces the public client stylesheet instead of the SSR-only stylesheet path.
- Keeps the dark first-paint guard, but releases it from loaded app CSS and from a load-time fallback so the page cannot stay blank.
- Promotes SAG to image `sag-20260513212944`, built from the releasable guard fix.

## Related Issues

None

## Testing

- `bun run --filter @proompteng/sag lint`
- `bun run --filter @proompteng/sag lint:oxlint`
- `bun run --filter @proompteng/sag tsc`
- `bun run --filter @proompteng/sag test`
- `bun run --filter @proompteng/sag build`
- `SAG_IMAGE_TAG=sag-20260513212944 bun run sag:deploy`

## Screenshots (if applicable)

N/A - this change is validated through emitted HTML, browser console, computed styles, and live rollout checks after merge.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
