### PR TITLE
fix(sag): raise memory limit

### DIFF
--- a/argocd/sag/deployment.yaml
+++ b/argocd/sag/deployment.yaml
@@ -88,10 +88,10 @@ spec:
           resources:
             requests:
               cpu: 100m
-              memory: 192Mi
+              memory: 384Mi
             limits:
               cpu: 500m
-              memory: 512Mi
+              memory: 1Gi
       volumes:
         - name: codex-auth
           secret:


### PR DESCRIPTION
## Summary

- Raises the SAG memory request from `192Mi` to `384Mi`.
- Raises the SAG memory limit from `512Mi` to `1Gi` to stop the live pod OOMCrashLoop.
- Keeps the deployed footer-free Agent Runs UI stable behind the GitOps-managed Deployment.

## Related Issues

None

## Testing

- `kubectl apply --dry-run=server -k argocd/sag`
- `kubectl apply -k argocd/sag`
- `kubectl -n sag rollout status deployment/sag --timeout=240s`
- `curl -fsS https://sag.proompteng.ai/api/health`

## Screenshots (if applicable)

N/A - verified through live HTML, browser accessibility tree, Deployment rollout, and health endpoint.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
