### PR TITLE
docs(jangar): define material gate digest

### DIFF
--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -19,6 +19,8 @@ clear entrypoints, clear “source of truth”, and a complete catalog of relate
 - Autonomous Jangar/Torghut production system design: `designs/autonomous-jangar-torghut-production-system.md`
 - Swarm agentic mission architecture notes: `designs/swarm-agentic-mission-architecture-2026-05-08.md`
 - Current Jangar/Torghut architecture contracts:
+  - `designs/198-jangar-material-gate-digest-and-alpha-closure-carry-2026-05-14.md`
+  - `../torghut/design-system/v6/203-torghut-alpha-closure-dividend-slo-and-consumer-evidence-carry-2026-05-14.md`
   - `designs/197-jangar-compact-alpha-closure-ingestion-and-stage-credit-repair-gate-2026-05-14.md`
   - `../torghut/design-system/v6/202-torghut-compact-alpha-closure-export-and-no-delta-lease-2026-05-14.md`
   - `designs/196-jangar-alpha-closure-slot-governor-and-no-delta-budget-2026-05-14.md`

--- a/docs/agents/designs/198-jangar-material-gate-digest-and-alpha-closure-carry-2026-05-14.md
+++ b/docs/agents/designs/198-jangar-material-gate-digest-and-alpha-closure-carry-2026-05-14.md
@@ -1,0 +1,382 @@
+# 198. Jangar Material Gate Digest And Alpha Closure Carry (2026-05-14)
+
+Status: Accepted for engineer and deployer handoff
+Date: 2026-05-14
+Owner: Victor Chen, Jangar Engineering Architecture
+Scope: Jangar material-readiness proof, Torghut compact closure evidence carry, AgentRun launch admission, status-route
+latency, zero-notional no-delta custody, validation, rollout, rollback, and implementation handoff.
+
+Companion Torghut contract:
+
+- `docs/torghut/design-system/v6/203-torghut-alpha-closure-dividend-slo-and-consumer-evidence-carry-2026-05-14.md`
+
+Extends:
+
+- `docs/agents/designs/197-jangar-compact-alpha-closure-ingestion-and-stage-credit-repair-gate-2026-05-14.md`
+- `docs/agents/designs/197-jangar-alpha-evidence-foreclosure-governor-and-runner-custody-2026-05-14.md`
+- `docs/torghut/design-system/v6/202-torghut-compact-alpha-closure-export-and-no-delta-lease-2026-05-14.md`
+- `docs/torghut/design-system/v6/202-torghut-alpha-evidence-foreclosure-and-routeable-candidate-reentry-2026-05-14.md`
+- `docs/agents/designs/188-jangar-ready-truth-arbiter-and-stage-credit-cutover-2026-05-13.md`
+
+## Decision
+
+I am selecting a **material gate digest with alpha closure carry** as the next Jangar control-plane architecture
+increment.
+
+The evidence points to a projection problem, not a lack of proof. On 2026-05-14, Argo reported `agents`, `jangar`,
+and `torghut` `Synced/Healthy` at `60ea7ce8935a77676696b415bcd16fddbedd0575`. The service pods were available:
+`agents=1/1`, `agents-controllers=2/2`, `jangar=1/1`, Torghut live revision `torghut-00377=2/2`, and Torghut sim
+revision `torghut-sim-00475=2/2`. `GET http://agents.agents.svc.cluster.local/ready` returned `status=ok`,
+leader-election active, execution trust healthy, and Torghut consumer evidence current.
+
+That is serving truth. It is not material launch truth. The same `/ready` payload exposed `business_state=repair_only`,
+`revenue_ready=false`, top repair queue item `repair_alpha_readiness`, value gate `routeable_candidate_count`, and
+`max_notional=0`. Jangar's repair-bid admission stayed in `observe` mode with `status=block`, but it still emitted a
+launch-allowed dispatch ticket for `compacted-repair-lot:f7db48978857ae33628f`, lot class `promotion_custody`, and
+dedupe key `PA3SX7FYNUTF:15m:promotion_custody`.
+
+Torghut now has the missing negative evidence. `GET /trading/consumer-evidence` includes compact
+`torghut.alpha-repair-closure-board-ref.v1` with selected hypothesis `H-MICRO-01`, selected value gate
+`routeable_candidate_count`, settlement market `alpha-closure-settlement-market:89e028004ab04284dd5c7cac`,
+required settlement receipt `torghut.alpha-closure-settlement-receipt.v1`, active dedupe key
+`26ad0e6f5062ffa349b21e8a`, `no_delta_budget_state=consumed`, `no_delta_debt_count=1`, and `max_notional=0`.
+Jangar `/ready` does not carry that board ref yet; its observed contract list still stops at
+`executable_alpha_repair_receipts`. That is why a generic repair dispatch ticket can look allowed even while the
+current closure market says the same evidence window consumed its no-delta budget.
+
+The material status route is also too expensive for the hot path. Two read-only attempts to call
+`/api/agents/control-plane/status?namespace=agents` with a 10 second client timeout returned no bytes. That route is
+still valuable for diagnostics, but launch admission and deployer proof cannot depend on a full reducer pass that may
+time out while `/ready` stays green.
+
+The selected design introduces a small `jangar.material-gate-digest.v1` projection. It is built from already typed
+inputs: serving readiness, repair-bid admission, source/rollout truth when available, database witness status,
+Torghut consumer evidence, and the compact alpha closure board ref. It is small enough to serve from `/ready` and
+stable enough for schedule runners, implement stages, verify stages, and deployers to cite. The digest carries the
+decision for each material action class plus the alpha closure carry that explains whether a zero-notional repair
+slot is allowed, held, or denied.
+
+The tradeoff is strict pre-launch denial when the digest is stale or missing. I accept that tradeoff. The business
+metric is fewer failed AgentRuns and shorter green PR-to-healthy GitOps rollout time, not higher runner start volume.
+A fast serving endpoint that says "hold because no-delta debt is active" is more useful than a slow full status route
+plus another failed repair pod.
+
+## Governing Runtime Requirements
+
+This contract implements the active swarm validation requirements:
+
+- every run must cite the governing design or runtime requirement before changing code;
+- implement stages must produce production PRs with tests or report the exact blocker to code;
+- verify stages must merge only green PRs and prove Argo, workload readiness, and service health after rollout;
+- final handoff must name the control-plane metric improved or the smallest blocker preventing improvement.
+
+Value-gate mapping:
+
+- `failed_agentrun_rate`: unchanged or consumed alpha closure keys deny launch before creating another runner pod.
+- `pr_to_rollout_latency`: deployer verification can read one bounded digest from `/ready` instead of waiting on the
+  full material status route.
+- `ready_status_truth`: `/ready=ok` stays serving truth, while `material_gate_digest.decision` is material truth.
+- `manual_intervention_count`: operators get one selected closure carry, one no-delta state, one release condition set,
+  and one next implementation action.
+- `handoff_evidence_quality`: engineer and deployer handoffs cite the digest id, source revision, Argo revision,
+  Torghut board id, settlement market id, no-delta state, validation command, and rollback target.
+
+## Current Evidence
+
+All evidence was collected read-only on 2026-05-14. I did not mutate Kubernetes resources, database rows, trading
+flags, broker state, GitOps resources, AgentRuns, or market data.
+
+### Cluster, Rollout, And Runner Debt
+
+- Work branch: `codex/swarm-jangar-control-plane-plan`, based on `origin/main`.
+- Kubernetes identity: `system:serviceaccount:agents:agents-sa`. The local kube context was bootstrapped as
+  `in-cluster` from the service-account token because no current context was configured.
+- Argo applications `agents`, `jangar`, and `torghut` were `Synced/Healthy` at
+  `60ea7ce8935a77676696b415bcd16fddbedd0575`.
+- Workloads were available: `agents=1/1`, `agents-controllers=2/2`, `jangar=1/1`, `bumba=1/1`, Torghut live
+  `torghut-00377=2/2`, and Torghut sim `torghut-sim-00475=2/2`.
+- AgentRuns created since `2026-05-14T00:00:00Z` showed 22 total, with 18 `Succeeded`, 2 `Failed`, and 2 `Running`.
+  Jangar control-plane had 11 total with 10 `Succeeded`, 1 `Running`, and 0 failed. Torghut quant had 11 total with
+  8 `Succeeded`, 2 `Failed`, and 1 `Running`; the failures were implement and verify `BackoffLimitExceeded`.
+- Pods in the agents namespace created since `2026-05-14T00:00:00Z` showed 114 total, with 37 `Succeeded`,
+  72 `Failed`, and 5 `Running`; terminated container reasons included 68 `Error` and 4 `OOMKilled`. That is the
+  launch-pressure tail this digest should reduce.
+- Recent events showed normal rollout churn and readiness probe noise while images were replaced, then successful
+  starts for the current agents, Jangar, and Torghut revisions.
+
+### Ready, Business, And Material Truth
+
+- `GET http://agents.agents.svc.cluster.local/ready` returned `status=ok`, leader election active, and execution trust
+  healthy.
+- The same payload reported `business_state=repair_only`, `revenue_ready=false`, and top repair queue item
+  `repair_alpha_readiness` for `alpha_readiness_not_promotion_eligible`.
+- The affected value gate was `routeable_candidate_count`; the required output receipt was
+  `torghut.executable-alpha-receipts.v1`; capital remained `zero_notional_repair_only`.
+- Jangar repair-bid admission was `mode=observe` and `status=block`, but still produced a launch-allowed
+  `promotion_custody` dispatch ticket for dedupe key `PA3SX7FYNUTF:15m:promotion_custody`.
+- Two calls to `GET /api/agents/control-plane/status?namespace=agents` with a 10 second timeout returned no bytes.
+  The full status route should remain diagnostic, not a launch hot path.
+- Jangar did not project Torghut's compact alpha closure board into `/ready`; its observed contracts still omitted
+  `alpha_repair_closure_board` and `alpha_evidence_foundry`.
+
+### Torghut Business And Data State
+
+- `GET http://torghut.torghut.svc.cluster.local/db-check` returned a current schema witness: current head
+  `0031_autoresearch_candidate_spec_epoch_uniqueness`, one schema graph branch, no lineage errors, and only known
+  parent-fork warnings under historical migration roots.
+- `GET /readyz` returned HTTP 503 with `status=degraded`, which is the correct capital-safe state while live submit is
+  disabled and no hypothesis is promotion eligible.
+- `GET /trading/revenue-repair` returned `business_state=repair_only`, `revenue_ready=false`, queue count 5, and top
+  queue item `repair_alpha_readiness`.
+- The full alpha closure board was selected, with selected value gate `routeable_candidate_count`, settlement market
+  `alpha-closure-settlement-market:89e028004ab04284dd5c7cac`, selected hypothesis `H-MICRO-01`, repair class
+  `feature_replay_closure`, required settlement receipt `torghut.alpha-closure-settlement-receipt.v1`, and
+  no-delta budget `consumed`.
+- The pending settlement receipt preserved `drift_checks_missing`, `feature_rows_missing`,
+  `required_feature_set_unavailable`, and `closed_session_signal_hold`; routeable candidate count stayed `0`;
+  `next_allowed_attempt_after` was `2026-05-14T04:53:40.994334+00:00`.
+- `GET /trading/consumer-evidence` already emitted compact `torghut.alpha-repair-closure-board-ref.v1` with
+  `no_delta_budget_state=consumed`, `no_delta_debt_count=1`, and `max_notional=0`.
+
+### Source Architecture And Test Gaps
+
+- Jangar high-risk modules remain broad: `supporting-primitives-controller.ts` is 3312 lines,
+  `control-plane-torghut-consumer-evidence.ts` is 784 lines, `control-plane-status.ts` is 757 lines,
+  `control-plane-stage-credit-ledger.ts` is 594 lines, and `control-plane-repair-bid-admission.ts` is 440 lines.
+- Torghut high-risk modules are also broad: `app/main.py` is 6925 lines, `revenue_repair.py` is 1111 lines,
+  `alpha_repair_closure_board.py` is 820 lines, `repair_bid_settlement.py` is 716 lines, and
+  `alpha_evidence_foundry.py` is 608 lines.
+- Existing tests cover many individual reducers, including ready truth, stage credit, repair-bid admission, Torghut
+  consumer evidence, alpha closure boards, and revenue repair. The missing cross-plane test family is material gate
+  digest behavior: current board ref, missing board ref, stale board ref, consumed no-delta budget, nonzero notional,
+  full status timeout fallback, and source/rollout mismatch.
+
+## Problem
+
+Jangar has reached a split-brain point between serving health and material launch proof.
+
+The concrete failure modes are:
+
+1. `/ready=ok` can coexist with `repair_only`, zero-notional capital, and active Torghut no-delta debt.
+2. The full material status route can exceed a 10 second client timeout, which makes it poor as a scheduler or deployer
+   hot path.
+3. Torghut now exposes compact alpha closure refs, but Jangar's `/ready` projection does not carry them.
+4. Jangar can emit a launch-allowed repair ticket from repair-bid settlement while Torghut's closure market says the
+   current evidence window consumed its no-delta budget.
+5. AgentRun objects look mostly healthy in the current window, while pod-level runner debt shows 72 failed pods since
+   midnight. The launch gate must see both material truth and runner debt before starting more work.
+6. Deployer handoff has to stitch together Argo, workload readiness, `/ready`, full status, `/db-check`,
+   `/trading/revenue-repair`, and `/trading/consumer-evidence` manually.
+
+The system needs a small material gate digest that is fast enough for launch admission and rich enough to prevent the
+wrong zero-notional repair from launching.
+
+## Alternatives Considered
+
+### Option A: Keep The Full Status Route As The Material Gate
+
+Jangar would continue to require `/api/agents/control-plane/status?namespace=agents` for launch and deployer proof.
+
+Advantages:
+
+- No new status object.
+- Preserves the richest diagnostic view.
+- Keeps existing reducer ownership.
+
+Disadvantages:
+
+- The route timed out at 10 seconds in this evidence window.
+- Schedule runners need a bounded proof surface, not a full diagnostic reducer pass.
+- Deployer proof remains slow and manual.
+- The route still needs Torghut compact closure carry before it can deny no-delta repeats.
+
+Decision: reject as the hot path. Keep it for diagnostics and backfill.
+
+### Option B: Broaden Stage Clearance Until All Proof Surfaces Are Green
+
+This option keeps every material action held until status, source, rollout, Torghut, and database witnesses are green.
+
+Advantages:
+
+- Simple and conservative.
+- Avoids accidental capital or rollout widening.
+- Keeps the current safety posture intact.
+
+Disadvantages:
+
+- Deadlocks zero-notional repairs that are required to clear the top revenue blocker.
+- Does not explain why a specific repair is denied.
+- Increases manual exceptions.
+- Does not improve deployer latency.
+
+Decision: reject as the default. It remains the emergency rollback posture.
+
+### Option C: Add A Material Gate Digest With Alpha Closure Carry
+
+Jangar builds a small digest from existing typed inputs and serves it through `/ready` and the status route. Schedule
+runners and deployers use the digest, while full status remains diagnostic.
+
+Advantages:
+
+- Converts no-delta debt into pre-launch denial.
+- Gives deployers one bounded proof object.
+- Keeps serving readiness separate from material readiness.
+- Lets Jangar use Torghut compact evidence without polling full revenue repair on every decision.
+- Reduces repeated runner starts when proof cannot change the value gate.
+
+Disadvantages:
+
+- Adds a compatibility surface that needs tests.
+- Requires shadow comparison before enforcement.
+- Can over-hold repair work if the digest is stale or the compact board ref is missing.
+
+Decision: select Option C.
+
+## Architecture
+
+Jangar emits `jangar.material-gate-digest.v1`.
+
+```text
+jangar.material-gate-digest.v1
+  digest_id
+  generated_at
+  fresh_until
+  producer_revision
+  serving_readiness
+  material_readiness
+  action_class_decisions[]
+    action_class
+    decision: allow | hold | deny | block
+    reason_codes[]
+    source_refs[]
+    validation_refs[]
+    rollback_target
+  alpha_closure_carry
+    schema_version: jangar.alpha-closure-carry.v1
+    source: torghut.consumer-evidence
+    board_id
+    settlement_market_id
+    selected_hypothesis_id
+    selected_value_gate
+    required_settlement_receipt
+    active_dedupe_key
+    no_delta_budget_state
+    no_delta_debt_count
+    next_allowed_attempt_after
+    max_notional
+    capital_rule
+    decision
+    release_conditions[]
+  rollout_truth_ref
+  database_witness_ref
+  runner_debt_summary
+```
+
+The digest is intentionally smaller than full control-plane status.
+
+Inputs:
+
+- Jangar serving readiness from `/ready`.
+- Jangar repair-bid admission state.
+- Torghut consumer evidence compact `alpha_repair_closure_board` and `alpha_evidence_foundry` refs.
+- Torghut `/db-check` status through the existing application witness path.
+- Argo revision and workload readiness when cached or already available.
+- Runner debt summary from AgentRun and pod status caches.
+- Full control-plane status only as a background enrichment source, never as a synchronous requirement for serving the
+  digest.
+
+Decision rules:
+
+- `serve_readonly` can allow when serving readiness is ok and the digest is fresh.
+- `torghut_observe` can allow when Torghut consumer evidence is current, even while capital remains zero.
+- `dispatch_repair` holds when the compact closure ref is missing, stale, nonzero-notional, wrong value gate, or has
+  consumed no-delta budget.
+- `dispatch_repair` can allow exactly one zero-notional repair only when the compact closure ref is fresh, no-delta
+  budget is available, the dedupe key is inactive, and the validation command is present.
+- `dispatch_normal`, `deploy_widen`, `merge_ready`, `paper_canary`, `live_micro_canary`, and `live_scale` remain held
+  or blocked while `business_state=repair_only`, `revenue_ready=false`, or source/rollout proof is unsettled.
+- If the full status route times out, the digest records `full_status_unavailable` but does not make serving readiness
+  fail. Material actions fail closed.
+
+## Validation Plan
+
+Engineer stage must add focused tests before enforcement:
+
+- Jangar parses `torghut.alpha-repair-closure-board-ref.v1` from consumer evidence.
+- Missing, stale, wrong-gate, nonzero-notional, and consumed no-delta refs hold `dispatch_repair`.
+- A fresh available no-delta budget allows exactly one zero-notional repair ticket and stamps the selected board id.
+- Full status timeout does not fail `/ready`, but it marks material action classes held.
+- Source/rollout mismatch keeps `deploy_widen` and `merge_ready` held even when repair observe is allowed.
+- Runner debt is surfaced in the digest but does not override capital safety.
+
+Targeted commands for the implementation PR:
+
+- `bun --cwd services/jangar run test -- src/server/__tests__/control-plane-torghut-consumer-evidence.test.ts`
+- `bun --cwd services/jangar run test -- src/server/__tests__/control-plane-repair-bid-admission.test.ts`
+- `bun --cwd services/jangar run test -- src/routes/ready.test.ts`
+- `bun --cwd services/jangar run tsc`
+
+Deployer validation:
+
+- `kubectl get application -n argocd agents jangar torghut -o wide`
+- `kubectl rollout status -n agents deployment/agents`
+- `kubectl rollout status -n agents deployment/agents-controllers`
+- `kubectl rollout status -n jangar deployment/jangar`
+- `curl -fsS http://agents.agents.svc.cluster.local/ready | jq .material_gate_digest`
+- `curl -fsS http://torghut.torghut.svc.cluster.local/trading/consumer-evidence | jq .alpha_repair_closure_board`
+- `curl -sS -w '\n%{http_code}\n' http://torghut.torghut.svc.cluster.local/readyz`
+
+## Rollout
+
+Phase 0 is observe-only. Emit the digest on `/ready` and the full status route, compare it against existing ready
+truth and repair-bid admission, and record mismatches as diagnostics.
+
+Phase 1 holds duplicate `dispatch_repair` when the compact alpha closure ref is missing, stale, or no-delta consumed.
+No CronJob or AgentRun launch behavior changes for normal, deploy, merge, paper, or live classes.
+
+Phase 2 lets exactly one fresh zero-notional repair slot launch when the closure carry is current and no-delta budget
+is available. The launch must stamp the digest id, board id, settlement market id, active dedupe key, and required
+receipt.
+
+Phase 3 allows deployer stages to treat the digest as the primary material readiness proof for green PR-to-healthy
+rollout handoff. Full status remains required for debugging when the digest reports stale or unavailable inputs.
+
+## Rollback
+
+- Set `JANGAR_MATERIAL_GATE_DIGEST_MODE=disabled` or equivalent config.
+- Keep `/ready` serving readiness unchanged.
+- Keep existing ready truth, stage credit, repair-bid admission, and Torghut consumer evidence reducers active.
+- Keep Torghut max notional at `0` and live submit disabled.
+- Do not delete AgentRuns, jobs, database rows, no-delta receipts, or closure boards.
+- Revert to emergency posture: hold `dispatch_repair`, `dispatch_normal`, `deploy_widen`, `merge_ready`,
+  `paper_canary`, and live action classes until full status and Torghut evidence are manually verified.
+
+## Risks
+
+- A stale digest could over-hold useful zero-notional repairs. Mitigation: short freshness window and explicit
+  `digest_stale` reason.
+- A compact board schema mismatch could hide Torghut evidence. Mitigation: observe-mode comparison against
+  `/trading/consumer-evidence` and full `/trading/revenue-repair`.
+- A fast digest could be mistaken for capital authority. Mitigation: every action decision carries `max_notional=0`
+  and paper/live action classes stay held or blocked while Torghut is repair-only.
+- Full status route slowness could mask a deeper reducer regression. Mitigation: keep a separate diagnostic SLO for
+  the full route and alert when it exceeds the deployer budget.
+
+## Engineer And Deployer Handoff
+
+Next engineer milestone: implement the additive material gate digest in observe mode, parse Torghut compact alpha
+closure refs into Jangar consumer evidence, and make consumed no-delta budget visible on `/ready`.
+
+Acceptance gates:
+
+- `/ready` includes `material_gate_digest`.
+- The digest carries the Torghut board id, settlement market id, selected hypothesis, active dedupe key,
+  no-delta state, max notional, and capital rule.
+- Current live evidence produces `dispatch_repair=hold` or `deny` because no-delta budget is consumed.
+- The existing repair-bid dispatch ticket is no longer the only visible launch proof.
+- Tests cover current, missing, stale, wrong-gate, nonzero-notional, consumed no-delta, and full-status-timeout cases.
+
+Next deployer milestone: after the implementation PR merges, prove Argo, workload readiness, `/ready` digest presence,
+Torghut consumer evidence board ref, Torghut `/db-check`, and Torghut repair-only capital safety. The metric improved
+first is `failed_agentrun_rate`; the smallest blocker for revenue impact remains `routeable_candidate_count=0` until
+Torghut settles a feature replay receipt that retires H-MICRO-01 feature evidence blockers.

--- a/docs/agents/release-handoffs/jangar-material-gate-digest-2026-05-14.md
+++ b/docs/agents/release-handoffs/jangar-material-gate-digest-2026-05-14.md
@@ -1,0 +1,67 @@
+# Jangar Material Gate Digest Handoff (2026-05-14)
+
+Status: Accepted for engineer and deployer handoff
+Owner: Victor Chen, Jangar Engineering Architecture
+Related designs:
+
+- `docs/agents/designs/198-jangar-material-gate-digest-and-alpha-closure-carry-2026-05-14.md`
+- `docs/torghut/design-system/v6/203-torghut-alpha-closure-dividend-slo-and-consumer-evidence-carry-2026-05-14.md`
+
+## Decision
+
+Build a small Jangar material gate digest that carries Torghut alpha closure no-delta custody from consumer evidence
+into `/ready`, then use it to hold duplicate zero-notional repair launch keys before another runner pod starts.
+
+## Evidence
+
+- Argo `agents`, `jangar`, and `torghut` were `Synced/Healthy` at
+  `60ea7ce8935a77676696b415bcd16fddbedd0575`.
+- Workloads were available: `agents=1/1`, `agents-controllers=2/2`, `jangar=1/1`, `torghut-00377=2/2`, and
+  `torghut-sim-00475=2/2`.
+- `GET http://agents.agents.svc.cluster.local/ready` returned `status=ok`, but business state remained
+  `repair_only`, revenue was not ready, and the top queue item was `repair_alpha_readiness`.
+- Jangar repair-bid admission was `observe` and `block`, yet it still emitted a launch-allowed promotion-custody ticket
+  for dedupe key `PA3SX7FYNUTF:15m:promotion_custody`.
+- `GET /api/agents/control-plane/status?namespace=agents` timed out at 10 seconds in this run, so full status should
+  not be the synchronous launch hot path.
+- Torghut `/db-check` was schema-current at `0031_autoresearch_candidate_spec_epoch_uniqueness`.
+- Torghut `/readyz` was HTTP 503 for correct capital-safety reasons: live submit disabled and zero promotion-eligible
+  hypotheses.
+- Torghut `/trading/consumer-evidence` included compact `torghut.alpha-repair-closure-board-ref.v1` with selected
+  hypothesis `H-MICRO-01`, no-delta budget `consumed`, no-delta debt count `1`, and `max_notional=0`.
+- Jangar `/ready` did not yet carry that compact board ref in its Torghut projection.
+
+## Engineer Acceptance Gates
+
+- Jangar emits additive `material_gate_digest` on `/ready`.
+- The digest carries Torghut board id, settlement market id, selected hypothesis, selected value gate, active dedupe
+  key, no-delta state, no-delta debt count, max notional, and capital rule.
+- Current live evidence produces `dispatch_repair=hold` or `deny` because no-delta budget is consumed.
+- Full status route timeout records `full_status_unavailable` without failing serving readiness.
+- Tests cover current, missing, stale, wrong-gate, nonzero-notional, consumed no-delta, and full-status-timeout cases.
+
+## Deployer Acceptance Gates
+
+- Argo `agents`, `jangar`, and `torghut` are `Synced/Healthy`.
+- `kubectl rollout status -n agents deployment/agents` passes.
+- `kubectl rollout status -n agents deployment/agents-controllers` passes.
+- `kubectl rollout status -n jangar deployment/jangar` passes.
+- `GET http://agents.agents.svc.cluster.local/ready` includes `material_gate_digest`.
+- `GET http://torghut.torghut.svc.cluster.local/trading/consumer-evidence` includes the compact closure board ref and
+  dividend SLO.
+- Torghut remains `max_notional=0`; live submission remains disabled.
+- `/readyz` may remain HTTP 503 while proof floor and live submit stay intentionally closed.
+
+## Rollback
+
+- Disable the material gate digest or mark it observe-only.
+- Keep existing ready truth, stage credit, repair-bid admission, and Torghut consumer evidence reducers active.
+- Hold material repair dispatch when the digest is absent.
+- Keep Torghut capital zero-notional and live submission disabled.
+- Do not delete AgentRuns, jobs, database rows, closure boards, or no-delta receipts.
+
+## Next Milestone
+
+Implement the digest and dividend SLO in observe mode first. The control-plane metric improved is
+`failed_agentrun_rate`; the smallest revenue blocker remains `routeable_candidate_count=0` until H-MICRO-01 feature
+replay produces a terminal settlement receipt that retires the current feature evidence blockers.

--- a/docs/torghut/design-system/v6/203-torghut-alpha-closure-dividend-slo-and-consumer-evidence-carry-2026-05-14.md
+++ b/docs/torghut/design-system/v6/203-torghut-alpha-closure-dividend-slo-and-consumer-evidence-carry-2026-05-14.md
@@ -1,0 +1,361 @@
+# 203. Torghut Alpha Closure Dividend SLO And Consumer Evidence Carry (2026-05-14)
+
+Status: Accepted for engineer and deployer handoff
+Date: 2026-05-14
+Owner: Victor Chen, Jangar Engineering Architecture
+Scope: Torghut revenue repair, alpha closure dividend settlement, compact consumer evidence, no-delta repair SLO,
+routeable candidate reentry, zero-notional capital safety, validation, rollout, rollback, and Jangar handoff.
+
+Companion Jangar contract:
+
+- `docs/agents/designs/198-jangar-material-gate-digest-and-alpha-closure-carry-2026-05-14.md`
+
+Extends:
+
+- `202-torghut-compact-alpha-closure-export-and-no-delta-lease-2026-05-14.md`
+- `202-torghut-alpha-evidence-foreclosure-and-routeable-candidate-reentry-2026-05-14.md`
+- `201-torghut-alpha-closure-settlement-and-feature-replay-market-2026-05-14.md`
+- `200-torghut-routeable-alpha-evidence-foundry-and-capital-safe-profit-ladder-2026-05-14.md`
+- `198-torghut-alpha-repair-closure-board-and-routeable-revenue-reentry-2026-05-14.md`
+
+## Decision
+
+I am selecting an **alpha closure dividend SLO with consumer-evidence carry** as the next Torghut architecture
+increment.
+
+The current business evidence is specific. On 2026-05-14, `/trading/revenue-repair` returned
+`business_state=repair_only`, `revenue_ready=false`, queue count 5, top queue item `repair_alpha_readiness`, value
+gate `routeable_candidate_count`, required output `torghut.executable-alpha-receipts.v1`, and `max_notional=0`.
+Torghut also emitted a selected alpha closure board and settlement market for `H-MICRO-01`, with repair class
+`feature_replay_closure`, required settlement receipt `torghut.alpha-closure-settlement-receipt.v1`, and a consumed
+no-delta budget.
+
+That is the right strategic priority. The blocker is no longer "find any repair." The blocker is "settle whether the
+current alpha closure moved the value gate, and carry that result to Jangar before another runner starts." The pending
+settlement receipt preserved `drift_checks_missing`, `feature_rows_missing`, `required_feature_set_unavailable`, and
+`closed_session_signal_hold`; measured routeable candidate delta stayed `0`; the next allowed attempt was
+`2026-05-14T04:53:40.994334+00:00`.
+
+Torghut already exports a compact `torghut.alpha-repair-closure-board-ref.v1` through `/trading/consumer-evidence`.
+That is useful, but it is still a board ref, not a dividend SLO. Jangar needs to know whether the last closure attempt
+paid a value-gate dividend, produced no-delta debt, or is eligible for a new zero-notional repair slot. Torghut should
+own that answer because it owns the trading hypothesis, the routeable candidate count, and the capital safety rules.
+
+The selected design adds a compact `torghut.alpha-closure-dividend-slo.v1` carry object to consumer evidence. It
+summarizes the current closure board, settlement market, before/after value-gate counts, preserved and retired blocker
+codes, no-delta release conditions, next allowed attempt, validation commands, and zero-notional capital rule. Jangar
+uses it as launch custody; Torghut keeps full strategy details on `/trading/revenue-repair`.
+
+The tradeoff is one more compatibility object. I accept it because the alternative is repeated no-delta work. A
+dividend SLO forces every alpha closure run to answer whether it improved `routeable_candidate_count`, and it gives
+Jangar a compact reason to hold when the answer is no.
+
+## Governing Runtime Requirements
+
+This contract follows the active validation requirements:
+
+- every run must cite the governing Torghut design or runtime requirement before changing code;
+- implement stages must produce production PRs that improve readiness, profit evidence, data freshness, execution
+  quality, or capital safety;
+- verify stages must merge only green PRs and prove image promotion, Argo sync, live service health, and trading or
+  evidence status after rollout;
+- final handoff must name the revenue metric improved or the smallest blocker preventing revenue impact.
+
+Torghut value-gate mapping:
+
+- `routeable_candidate_count`: primary dividend. A closure succeeds only when at least one selected hypothesis becomes
+  routeable or the receipt records why the count stayed zero.
+- `zero_notional_or_stale_evidence_rate`: no-delta receipts become active debt until the release key changes.
+- `fill_tca_or_slippage_quality`: route TCA remains a graduation guardrail; no closure can promote a route with
+  stale or failing slippage evidence.
+- `post_cost_daily_net_pnl`: post-cost expectancy remains a blocker for H-CONT-01 and H-REV-01, not a reason to spend
+  the H-MICRO-01 feature replay slot.
+- `capital_gate_safety`: live submit remains disabled, capital stage remains shadow, and every dividend object carries
+  `max_notional=0`.
+
+Jangar value-gate mapping:
+
+- `failed_agentrun_rate`: consumed no-delta debt gives Jangar a pre-launch denial reason.
+- `pr_to_rollout_latency`: deployers can validate the same compact dividend SLO Jangar consumes.
+- `ready_status_truth`: repair-only business state remains distinct from material launch authority.
+- `manual_intervention_count`: operators do not compare full payloads by hand to know whether the closure paid.
+- `handoff_evidence_quality`: every handoff cites the SLO id, board id, market id, selected hypothesis, measured
+  delta, no-delta state, and rollback target.
+
+## Current Evidence
+
+All evidence was collected read-only on 2026-05-14. I did not mutate Kubernetes resources, database rows, trading
+flags, broker state, GitOps resources, AgentRuns, or market data.
+
+### Cluster And Serving Evidence
+
+- Argo applications `agents`, `jangar`, and `torghut` were `Synced/Healthy` at
+  `60ea7ce8935a77676696b415bcd16fddbedd0575`.
+- Torghut live revision `torghut-00377` and sim revision `torghut-sim-00475` were running with `2/2` containers ready.
+- Postgres `torghut-db-1`, ClickHouse, Keeper, TA, TA sim, options services, WebSocket services, and guardrail
+  exporters were running.
+- Jangar `/ready` returned `status=ok`, but kept the business state `repair_only` and revenue not ready.
+- Agents namespace runner debt remained material: since `2026-05-14T00:00:00Z`, pod-level evidence showed 72 failed
+  pods and 4 OOMKilled terminations, while Torghut quant AgentRuns had implement and verify `BackoffLimitExceeded`
+  failures.
+
+### Database And Data Quality
+
+- Direct CNPG cluster reads and pod exec were forbidden to the service account. The accepted read path for this lane is
+  application-level database witnesses.
+- `GET /db-check` returned current head `0031_autoresearch_candidate_spec_epoch_uniqueness`, one schema graph branch,
+  no missing heads, no unexpected heads, and no lineage errors.
+- Known parent-fork warnings remain under `0010_execution_provenance_and_governance_trace` and
+  `0015_whitepaper_workflow_tables`; they do not block the current schema head.
+- `GET /readyz` returned HTTP 503 with `status=degraded`, which is correct while the live submission gate is closed
+  and alpha readiness has zero promotion-eligible hypotheses.
+- The readiness summary reported three alpha hypotheses, one blocked lane, two shadow lanes, zero promotion-eligible
+  lanes, and two rollback-required lanes.
+
+### Revenue Repair And Closure Evidence
+
+- `/trading/revenue-repair` returned `business_state=repair_only`, `revenue_ready=false`, and top queue item
+  `repair_alpha_readiness`.
+- The top item cited reason `alpha_readiness_not_promotion_eligible`, value gate `routeable_candidate_count`, expected
+  unblock value `4`, required output `torghut.executable-alpha-receipts.v1`, and `max_notional=0`.
+- The full alpha repair closure board was selected with board id
+  `alpha-repair-closure-board:a99bea7acfa184abcd5d297c` and value gate `routeable_candidate_count`.
+- The settlement market was `alpha-closure-settlement-market:89e028004ab04284dd5c7cac`, status `pending_no_delta`,
+  selected hypothesis `H-MICRO-01`, selected repair class `feature_replay_closure`, and required output
+  `torghut.alpha-closure-settlement-receipt.v1`.
+- The no-delta budget had `used_attempts=1`, `remaining_attempts=0`, and state `consumed`.
+- The pending settlement receipt preserved `drift_checks_missing`, `feature_rows_missing`,
+  `required_feature_set_unavailable`, and `closed_session_signal_hold`; measured delta was `0`;
+  routeable candidate count stayed `0`.
+- `/trading/consumer-evidence` exposed compact `torghut.alpha-repair-closure-board-ref.v1` with selected hypothesis
+  `H-MICRO-01`, active dedupe key `26ad0e6f5062ffa349b21e8a`, no-delta state `consumed`, no-delta debt count `1`,
+  and `max_notional=0`.
+- Jangar `/ready` did not yet carry that compact board ref through its Torghut projection.
+
+### Source And Test Surface
+
+- `services/torghut/app/main.py` is 6925 lines and remains the high-risk integration surface for `/readyz`,
+  `/trading/status`, `/trading/revenue-repair`, `/trading/consumer-evidence`, and repair execution.
+- `services/torghut/app/trading/revenue_repair.py` is 1111 lines and builds the live repair digest.
+- `services/torghut/app/trading/alpha_repair_closure_board.py` is 820 lines and owns the selected closure board and
+  settlement market.
+- `services/torghut/app/trading/alpha_evidence_foundry.py` is 608 lines and owns evidence-window receipts.
+- `services/torghut/app/trading/repair_bid_settlement.py` is 716 lines and compacts repair lots.
+- Existing tests cover revenue repair, alpha closure board, alpha evidence foundry, repair-bid settlement, and
+  executable alpha receipts. The missing test family is dividend SLO carry: paid dividend, no-delta dividend,
+  changed release key, stale SLO, nonzero notional, and consumer-evidence projection parity.
+
+## Problem
+
+Torghut can now identify the right closure, but it does not yet expose the closure outcome as a compact SLO that
+Jangar can enforce.
+
+The concrete failure modes are:
+
+1. A selected board ref can be current while the actual closure has produced no-delta debt.
+2. Jangar can see a dispatchable promotion-custody lot without seeing the settlement receipt that preserved the same
+   blockers and left routeable candidate count at zero.
+3. Operators have to inspect full `/trading/revenue-repair` to learn whether the closure attempt paid a dividend.
+4. A no-delta repair can restart when the source, evidence window, blocker set, and required receipt set have not
+   changed.
+5. H-MICRO-01 is the only lineage-ready path, but the live status still needs to preserve H-CONT-01 and H-REV-01
+   blockers without allowing them to steal the first feature replay slot.
+6. `/readyz` degradation can be misread as a live-submit problem. The actual next revenue action is alpha closure
+   settlement under zero notional.
+
+Torghut needs to convert closure outcomes into a compact dividend SLO and carry it through consumer evidence.
+
+## Alternatives Considered
+
+### Option A: Keep Only The Current Board Ref
+
+Torghut would leave `/trading/consumer-evidence` as-is, carrying the compact alpha repair closure board ref but no
+separate dividend SLO.
+
+Advantages:
+
+- No new schema.
+- Jangar can still see board id, market id, selected hypothesis, and no-delta state.
+- Full details remain on `/trading/revenue-repair`.
+
+Disadvantages:
+
+- The board ref does not explicitly answer whether the closure paid a value-gate dividend.
+- Release conditions and next allowed attempt can remain buried in the full endpoint.
+- Jangar still has to infer no-delta denial from fields that are not framed as launch custody.
+- Deployer proof remains less direct than it should be.
+
+Decision: reject.
+
+### Option B: Copy The Full Settlement Receipt Into Consumer Evidence
+
+Torghut would mirror the pending or terminal settlement receipt into `/trading/consumer-evidence`.
+
+Advantages:
+
+- Jangar has all details.
+- No separate summary logic is needed.
+- Debugging is straightforward.
+
+Disadvantages:
+
+- Payload size and volatility increase.
+- Strategy details leak across the launch boundary.
+- Schema changes in the full settlement receipt can break Jangar admission.
+- The main signal, value-gate dividend or no-delta debt, is not isolated.
+
+Decision: reject.
+
+### Option C: Add A Compact Alpha Closure Dividend SLO
+
+Torghut keeps the full board and receipt on `/trading/revenue-repair`, then exports a compact dividend SLO on
+consumer evidence.
+
+Advantages:
+
+- Makes routeable candidate delta first-class.
+- Carries no-delta release conditions to Jangar.
+- Keeps capital safety explicit.
+- Gives deployers a small proof object.
+- Lets Torghut evolve full strategy details without destabilizing Jangar launch custody.
+
+Disadvantages:
+
+- Adds compatibility tests.
+- Requires parity checks between full revenue repair and consumer evidence.
+- Can hold launches when the SLO is stale even if the full endpoint is healthy.
+
+Decision: select Option C.
+
+## Architecture
+
+Torghut emits `torghut.alpha-closure-dividend-slo.v1` inside `/trading/consumer-evidence`.
+
+```text
+torghut.alpha-closure-dividend-slo.v1
+  slo_id
+  generated_at
+  fresh_until
+  source_revenue_repair_ref
+  source_board_ref
+  source_settlement_market_ref
+  selected_hypothesis_id
+  selected_value_gate
+  selected_repair_class
+  required_settlement_receipt
+  active_dedupe_key
+  routeable_candidate_count_before
+  routeable_candidate_count_after
+  measured_delta
+  dividend_state: paid | no_delta | pending | stale | invalid
+  retired_reason_codes[]
+  preserved_reason_codes[]
+  introduced_reason_codes[]
+  no_delta_budget_state
+  no_delta_debt_count
+  release_conditions[]
+  next_allowed_attempt_after
+  validation_commands[]
+  max_notional
+  capital_rule
+  rollback_target
+```
+
+Rules:
+
+- `paid` requires a positive `routeable_candidate_count` delta or a terminal receipt that retires the selected
+  promotion blocker.
+- `no_delta` requires a terminal or pending settlement receipt with measured delta `0` and preserved blockers.
+- `pending` is allowed only before the first settlement attempt in the current release key.
+- `stale` applies when the SLO is past `fresh_until` or source refs disagree with the current revenue repair digest.
+- `invalid` applies when notional is nonzero, capital rule is not zero-notional repair only, or required refs are
+  missing.
+- The SLO never enables paper or live submission. It only governs Jangar zero-notional runner custody.
+
+The release key is:
+
+```text
+account_id + window + selected_hypothesis_id + selected_value_gate
+  + active_dedupe_key + blocker_digest + source_revenue_repair_ref
+  + required_settlement_receipt
+```
+
+A new zero-notional runner is eligible only when one of the release conditions changes: evidence window, blocker set,
+source ref, required receipt set, or terminal settlement outcome.
+
+## Validation Plan
+
+Engineer stage must add focused tests:
+
+- Revenue repair builds a dividend SLO when the closure market has a pending no-delta settlement.
+- Consumer evidence carries the same SLO id, board id, market id, selected hypothesis, value gate, and notional as the
+  full revenue-repair endpoint.
+- No-delta SLO preserves blocker codes and exposes `next_allowed_attempt_after`.
+- Paid SLO records a positive routeable candidate delta or a retired promotion blocker.
+- Stale or invalid SLOs do not claim launch eligibility.
+- Nonzero notional or nonzero capital rule makes the SLO invalid.
+
+Targeted commands for the implementation PR:
+
+- `uv run --frozen pytest services/torghut/tests/test_trading_api.py -k consumer_evidence`
+- `uv run --frozen pytest services/torghut/tests/test_build_revenue_repair_digest.py -k alpha`
+- `uv run --frozen pytest services/torghut/tests/test_alpha_repair_closure_board.py`
+- `uv run --frozen pyright --project pyrightconfig.json`
+
+Deployer validation:
+
+- `GET /trading/revenue-repair` includes the full board, settlement market, and pending or terminal receipt.
+- `GET /trading/consumer-evidence` includes `alpha_closure_dividend_slo`.
+- `GET /db-check` remains schema-current.
+- `/readyz` may remain HTTP 503 while live submission and proof floor stay intentionally closed.
+- `max_notional=0` and live submission disabled remain true.
+- Jangar `/ready` material gate digest carries the SLO and holds duplicate repair launch while no-delta is active.
+
+## Rollout
+
+Phase 0 emits the SLO in shadow on `/trading/consumer-evidence` and compares it with the full revenue-repair board.
+
+Phase 1 marks stale or invalid SLOs as launch-ineligible while leaving existing repair endpoints unchanged.
+
+Phase 2 lets Jangar use the SLO to hold duplicate no-delta launch keys. Torghut remains the source of truth for
+selected hypothesis, routeable candidate delta, and capital rule.
+
+Phase 3 records paid dividend receipts as routeable candidate reentry evidence. This phase does not open paper or live
+capital; it only allows the next promotion and proof gates to evaluate with fresher evidence.
+
+## Rollback
+
+- Disable `alpha_closure_dividend_slo` emission or mark it `stale`.
+- Keep the full alpha closure board, evidence foundry, repair-bid settlement, and revenue-repair digest active.
+- Keep live submission disabled and `max_notional=0`.
+- Preserve no-delta and settlement receipts for audit.
+- Jangar falls back to holding `dispatch_repair` when the SLO is missing.
+- Do not delete database rows, market evidence, AgentRuns, jobs, or no-delta receipts.
+
+## Risks
+
+- The SLO could disagree with the full board. Mitigation: shadow parity tests and source ref equality.
+- The SLO could over-hold fresh repair if `fresh_until` is too short. Mitigation: align freshness with the closure
+  market and emit explicit `slo_stale`.
+- Operators could treat a paid zero-notional dividend as capital authority. Mitigation: repeat `max_notional=0`,
+  `capital_rule=zero_notional_repair_only`, and live-submit disabled on every SLO.
+- A dividend SLO does not itself fix H-MICRO-01 feature evidence. Mitigation: acceptance requires routeable candidate
+  delta or a terminal no-delta reason, not just SLO presence.
+
+## Engineer And Deployer Handoff
+
+Next engineer milestone: add `alpha_closure_dividend_slo` to Torghut consumer evidence and teach Jangar's material
+gate digest to carry it. The first implementation should be observe-only and must keep capital at zero.
+
+Acceptance gates:
+
+- `/trading/consumer-evidence` includes the dividend SLO.
+- The SLO reports current live evidence as `no_delta` or `pending` with the selected H-MICRO-01 closure.
+- Jangar `/ready` carries the SLO through `material_gate_digest`.
+- Current consumed no-delta state holds duplicate `dispatch_repair`.
+- Tests cover paid, no-delta, stale, invalid, nonzero notional, and parity cases.
+
+Next deployer milestone: after implementation, verify Argo health, Torghut `/db-check`, Torghut consumer-evidence SLO,
+Jangar `/ready` material digest, and zero-notional capital safety. The revenue metric targeted is
+`routeable_candidate_count`; the smallest blocker remains H-MICRO-01 feature replay settlement until a terminal receipt
+retires `feature_rows_missing`, `required_feature_set_unavailable`, and `drift_checks_missing`.

--- a/docs/torghut/design-system/v6/index.md
+++ b/docs/torghut/design-system/v6/index.md
@@ -12,6 +12,8 @@
 - Implementation status (strict, core 01-13 docs, source-state refresh `2026-03-09`): `Implemented=7`, `Partial=5`, `Completed=1`
 - Evidence (historical closure): `13-production-gap-closure-master-plan-2026-03-03.md` (Wave 0-6 closure + DoD)
 - Evidence (current next-work priority, refreshed `2026-05-14T04:12Z`):
+  - `203-torghut-alpha-closure-dividend-slo-and-consumer-evidence-carry-2026-05-14.md`
+  - `docs/agents/designs/198-jangar-material-gate-digest-and-alpha-closure-carry-2026-05-14.md`
   - `202-torghut-compact-alpha-closure-export-and-no-delta-lease-2026-05-14.md`
   - `docs/agents/designs/197-jangar-compact-alpha-closure-ingestion-and-stage-credit-repair-gate-2026-05-14.md`
   - `202-torghut-alpha-evidence-foreclosure-and-routeable-candidate-reentry-2026-05-14.md`


### PR DESCRIPTION
## Summary

- Add the Jangar material gate digest architecture for carrying Torghut alpha closure no-delta evidence into `/ready`.
- Add the Torghut alpha closure dividend SLO companion contract for consumer-evidence launch custody.
- Add a release handoff plus update the Agents and Torghut design indexes.

## Related Issues

None

## Testing

- PASS: `git diff --check`
- PASS: `bunx oxfmt --check docs/agents/README.md docs/agents/designs/198-jangar-material-gate-digest-and-alpha-closure-carry-2026-05-14.md docs/agents/release-handoffs/jangar-material-gate-digest-2026-05-14.md docs/torghut/design-system/v6/index.md docs/torghut/design-system/v6/203-torghut-alpha-closure-dividend-slo-and-consumer-evidence-carry-2026-05-14.md`
- PASS: Node placeholder scan over the changed docs and PR body.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
