### PR TITLE
fix(sag): lower memory request

### DIFF
--- a/argocd/sag/deployment.yaml
+++ b/argocd/sag/deployment.yaml
@@ -88,7 +88,7 @@ spec:
           resources:
             requests:
               cpu: 100m
-              memory: 384Mi
+              memory: 192Mi
             limits:
               cpu: 500m
               memory: 1Gi


### PR DESCRIPTION
## Summary

- Lowers the SAG memory request back to `192Mi` so the pod can schedule on the current amd64 node.
- Keeps the higher `1Gi` memory limit from the prior fix so SAG is not OOMKilled at `512Mi`.
- Restores the live footer-free SAG surface by making the GitOps deployment schedulable and stable.

## Related Issues

None

## Testing

- `kubectl apply --dry-run=server -k argocd/sag`
- `kubectl apply -k argocd/sag`
- `kubectl -n sag get deploy sag -o jsonpath='{.spec.template.spec.containers[0].resources.requests.memory} {.spec.template.spec.containers[0].resources.limits.memory}{"\n"}'`

## Screenshots (if applicable)

N/A - infrastructure scheduling fix, validated through Kubernetes deployment resources.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
