### PR TITLE
fix(sag): clean agent run log output

### DIFF
--- a/services/sag/src/server/kubernetes.ts
+++ b/services/sag/src/server/kubernetes.ts
@@ -273,7 +273,7 @@ export const readAgentRunLogs = async (
   const logs = await requestText(
     client,
     `/api/v1/namespaces/${safeNamespace}/pods/${podName}/log?tailLines=${Math.max(20, Math.min(1000, tailLines))}&timestamps=true`,
-  ).catch((error) => `Logs unavailable: ${error instanceof Error ? error.message : String(error)}`)
+  ).catch(() => 'Logs unavailable.')
 
   return { logs: logs || 'No log lines yet.', jobName, podName, phase }
 }
@@ -539,7 +539,7 @@ const requestText = (client: KubernetesClient, path: string) =>
         ca: client.ca,
         headers: {
           authorization: `Bearer ${client.token}`,
-          accept: 'text/plain',
+          accept: 'application/json',
         },
       },
       (res) => {


### PR DESCRIPTION
## Summary

- Removes raw Kubernetes error bodies from the Agent Runs logs panel.
- Requests pod logs with the Kubernetes API server's accepted media type.
- Keeps log failures as concise product copy instead of backend JSON.

## Related Issues

None

## Testing

- `bun run --filter @proompteng/sag tsc`
- `bun run --filter @proompteng/sag test`
- `bun run --filter @proompteng/sag lint`
- `bun run --filter @proompteng/sag lint:oxlint`
- `bun run --filter @proompteng/sag build`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
