### PR TITLE
fix(torghut): source TA readiness from ClickHouse

### DIFF
--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -4890,16 +4890,21 @@ def _build_hypothesis_runtime_payload(
     tca_summary: Mapping[str, Any],
     market_context_status: Mapping[str, Any],
     dependency_quorum: JangarDependencyQuorumStatus | None = None,
+    feature_readiness: Mapping[str, Any] | None = None,
 ) -> tuple[dict[str, object], dict[str, object], JangarDependencyQuorumStatus]:
     registry = load_hypothesis_registry()
     if dependency_quorum is None:
         dependency_quorum = resolve_hypothesis_dependency_quorum(registry)
+    resolved_feature_readiness = feature_readiness or _load_clickhouse_ta_status(
+        scheduler
+    )
     items = compile_hypothesis_runtime_statuses(
         registry=registry,
         state=scheduler.state,
         tca_summary=tca_summary,
         market_context_status=market_context_status,
         jangar_dependency_quorum=dependency_quorum,
+        feature_readiness=resolved_feature_readiness,
         market_session_open=cast(
             bool | None,
             getattr(scheduler.state, "market_session_open", None),
@@ -4933,7 +4938,13 @@ def _build_live_submission_gate_payload(
     empirical_jobs_status: Mapping[str, Any] | None = None,
     dspy_runtime_status: Mapping[str, Any] | None = None,
     quant_health_status: Mapping[str, Any] | None = None,
+    clickhouse_ta_status: Mapping[str, Any] | None = None,
 ) -> dict[str, object]:
+    resolved_clickhouse_ta_status = clickhouse_ta_status
+    if resolved_clickhouse_ta_status is None:
+        resolved_clickhouse_ta_status = _load_clickhouse_ta_status(
+            cast(TradingScheduler | None, getattr(app.state, "trading_scheduler", None))
+        )
     if settings.trading_pipeline_mode == "simple":
         if settings.trading_mode != "live":
             return {
@@ -4972,6 +4983,7 @@ def _build_live_submission_gate_payload(
             empirical_jobs_status=empirical_jobs_status,
             dspy_runtime_status=dspy_runtime_status,
             quant_health_status=quant_health_status,
+            clickhouse_ta_status=resolved_clickhouse_ta_status,
         )
         merged_blocked_reasons = list(
             dict.fromkeys(
@@ -5008,6 +5020,7 @@ def _build_live_submission_gate_payload(
         empirical_jobs_status=empirical_jobs_status,
         dspy_runtime_status=dspy_runtime_status,
         quant_health_status=quant_health_status,
+        clickhouse_ta_status=resolved_clickhouse_ta_status,
     )
 
 

--- a/services/torghut/app/trading/hypotheses.py
+++ b/services/torghut/app/trading/hypotheses.py
@@ -759,6 +759,7 @@ def compile_hypothesis_runtime_statuses(
     tca_summary: Mapping[str, Any],
     market_context_status: Mapping[str, Any],
     jangar_dependency_quorum: JangarDependencyQuorumStatus,
+    feature_readiness: Mapping[str, Any] | None = None,
     now: datetime | None = None,
     market_session_open: bool | None = None,
     route_symbol_filter_enabled: bool = False,
@@ -772,6 +773,21 @@ def compile_hypothesis_runtime_statuses(
         0,
         _optional_int(getattr(metrics, "feature_batch_rows_total", 0)) or 0,
     )
+    readiness = (
+        dict(feature_readiness) if isinstance(feature_readiness, Mapping) else {}
+    )
+    persisted_feature_rows = max(
+        0,
+        _optional_int(
+            readiness.get("equity_ta_rows")
+            or readiness.get("signal_rows")
+            or readiness.get("row_count")
+            or readiness.get("rows")
+            or 0
+        )
+        or 0,
+    )
+    feature_batch_rows_total = max(feature_batch_rows_total, persisted_feature_rows)
     drift_detection_checks_total = max(
         0,
         _optional_int(getattr(metrics, "drift_detection_checks_total", 0)) or 0,

--- a/services/torghut/app/trading/ingest.py
+++ b/services/torghut/app/trading/ingest.py
@@ -35,6 +35,21 @@ LATEST_SIGNAL_TS_ERROR_LOG_COOLDOWN = timedelta(minutes=5)
 SIMULATION_CURSOR_BASELINE = datetime(1970, 1, 1, tzinfo=timezone.utc)
 
 
+def _coerce_count(value: object) -> int:
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if isinstance(value, str) and value.strip():
+        try:
+            return int(value.strip())
+        except ValueError:
+            return 0
+    return 0
+
+
 def _simulation_fetch_window() -> timedelta:
     return timedelta(seconds=max(1, settings.trading_simulation_fetch_window_seconds))
 
@@ -806,11 +821,59 @@ class ClickHouseSignalIngestor:
                 "source_ref": self.table,
                 "time_column": time_column,
             }
-        return {
+        status: dict[str, Any] = {
             "state": "current",
             "latest_signal_at": latest_signal_at,
             "source_ref": self.table,
             "time_column": time_column,
+        }
+        try:
+            status.update(
+                self._latest_signal_readiness_counts(
+                    time_column=time_column,
+                    latest_signal_at=latest_signal_at,
+                )
+            )
+        except Exception as exc:
+            logger.warning("Failed to load ClickHouse TA readiness counts: %s", exc)
+            status["readiness_reason_codes"] = ["clickhouse_ta_readiness_query_failed"]
+            status["readiness_detail"] = str(exc)[:200]
+        return status
+
+    def _latest_signal_readiness_counts(
+        self,
+        *,
+        time_column: str,
+        latest_signal_at: datetime,
+    ) -> dict[str, Any]:
+        safe_time_column = _safe_identifier(time_column, kind="column")
+        lookback_minutes = max(int(self.initial_lookback_minutes or 1), 1)
+        window_start = latest_signal_at - timedelta(minutes=lookback_minutes)
+        where_parts = [
+            f"{safe_time_column} >= {to_datetime64(window_start)}",
+            f"{safe_time_column} <= {to_datetime64(latest_signal_at)}",
+        ]
+        source_clause = self._source_where_clause()
+        if source_clause is not None:
+            where_parts.append(source_clause)
+        query = " ".join(
+            [
+                "SELECT",
+                "count() AS signal_rows, uniqExact(symbol) AS symbol_count",
+                "FROM",
+                self.table,
+                "WHERE",
+                " AND ".join(where_parts),
+                "FORMAT JSONEachRow",
+            ]
+        )
+        rows = self._query_clickhouse(query)
+        row = rows[0] if rows else {}
+        return {
+            "signal_rows": _coerce_count(row.get("signal_rows")),
+            "symbol_count": _coerce_count(row.get("symbol_count")),
+            "readiness_window_start": window_start,
+            "readiness_window_end": latest_signal_at,
         }
 
     def _latest_signal_timestamp_queries(self, time_column: str) -> list[str]:

--- a/services/torghut/app/trading/submission_council.py
+++ b/services/torghut/app/trading/submission_council.py
@@ -984,16 +984,76 @@ def _load_profit_promotion_table_counts(session: Session) -> dict[str, int]:
     }
 
 
-def _build_profit_data_readiness_summary(state: object) -> dict[str, object]:
+def _coerce_aware_datetime(value: object) -> datetime | None:
+    if isinstance(value, datetime):
+        parsed = value
+    elif isinstance(value, str) and value.strip():
+        normalized = value.strip()
+        if normalized.endswith("Z"):
+            normalized = f"{normalized[:-1]}+00:00"
+        try:
+            parsed = datetime.fromisoformat(normalized)
+        except ValueError:
+            return None
+    else:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _build_profit_data_readiness_summary(
+    state: object,
+    *,
+    clickhouse_ta_status: Mapping[str, Any] | None = None,
+) -> dict[str, object]:
     metrics = getattr(state, "metrics", None)
     rows = _safe_int(getattr(metrics, "feature_batch_rows_total", 0))
+    symbols = 0
+    source_ref = "scheduler.metrics.feature_batch_rows_total"
+    observed_at = None
+    fresh_until = None
+    clickhouse_status = (
+        dict(clickhouse_ta_status) if isinstance(clickhouse_ta_status, Mapping) else {}
+    )
+    clickhouse_rows = _safe_int(
+        clickhouse_status.get("signal_rows")
+        or clickhouse_status.get("equity_ta_rows")
+        or clickhouse_status.get("row_count")
+        or clickhouse_status.get("rows")
+        or 0
+    )
+    clickhouse_symbols = _safe_int(
+        clickhouse_status.get("symbol_count")
+        or clickhouse_status.get("equity_ta_symbols")
+        or clickhouse_status.get("symbols")
+        or 0
+    )
+    if rows <= 0 and clickhouse_rows > 0:
+        rows = clickhouse_rows
+        symbols = clickhouse_symbols
+        source_ref = (
+            _safe_text(clickhouse_status.get("source_ref")) or "clickhouse:ta_signals"
+        )
+        observed_at = _coerce_aware_datetime(
+            clickhouse_status.get("latest_signal_at")
+            or clickhouse_status.get("readiness_window_end")
+            or clickhouse_status.get("as_of")
+        )
+        fresh_until = _coerce_aware_datetime(clickhouse_status.get("fresh_until"))
+        if fresh_until is None and observed_at is not None:
+            fresh_until = observed_at + timedelta(
+                milliseconds=max(1, settings.trading_feature_max_staleness_ms)
+            )
     null_rate = getattr(metrics, "feature_null_rate", {}) if metrics else {}
     staleness_ms_p95 = _safe_int(getattr(metrics, "feature_staleness_ms_p95", 0))
     duplicate_ratio = getattr(metrics, "feature_duplicate_ratio", None)
     return {
         "equity_ta_rows": rows,
-        "equity_ta_symbols": 0,
-        "equity_ta_source_ref": "scheduler.metrics.feature_batch_rows_total",
+        "equity_ta_symbols": symbols,
+        "equity_ta_source_ref": source_ref,
+        "observed_at": observed_at,
+        "fresh_until": fresh_until,
         "feature_null_rate": dict(cast(Mapping[str, float], null_rate))
         if isinstance(null_rate, Mapping)
         else {},
@@ -1109,6 +1169,7 @@ def build_live_submission_gate_payload(
     quant_account_label: str | None = None,
     session: Session | None = None,
     promotion_certificate_evidence: Sequence[Mapping[str, object]] | None = None,
+    clickhouse_ta_status: Mapping[str, Any] | None = None,
 ) -> dict[str, object]:
     summary: Mapping[str, Any] = hypothesis_summary or {}
     summary, runtime_items = _extract_runtime_summary(hypothesis_summary)
@@ -1198,7 +1259,10 @@ def build_live_submission_gate_payload(
             now=now,
         ),
         promotion_table_counts=promotion_table_counts,
-        data_readiness=_build_profit_data_readiness_summary(state),
+        data_readiness=_build_profit_data_readiness_summary(
+            state,
+            clickhouse_ta_status=clickhouse_ta_status,
+        ),
         live_controls=_build_profit_live_controls(state),
         account=_safe_text(quant_evidence.get("account")),
         window=_safe_text(quant_evidence.get("window")),

--- a/services/torghut/tests/test_hypotheses.py
+++ b/services/torghut/tests/test_hypotheses.py
@@ -219,6 +219,32 @@ class TestHypothesisReadiness(TestCase):
         self.assertEqual(micro["state"], "blocked")
         self.assertIn("required_feature_set_unavailable", micro["reasons"])
 
+    def test_compile_hypothesis_runtime_statuses_uses_persisted_feature_readiness(
+        self,
+    ) -> None:
+        registry = load_hypothesis_registry()
+        statuses = compile_hypothesis_runtime_statuses(
+            registry=registry,
+            state=_state(feature_rows=0),
+            tca_summary={
+                "order_count": 0,
+                "avg_abs_slippage_bps": 0,
+                "avg_realized_shortfall_bps": 0,
+            },
+            market_context_status={"last_freshness_seconds": None},
+            jangar_dependency_quorum=JangarDependencyQuorumStatus(
+                decision="allow",
+                reasons=[],
+                message="ok",
+            ),
+            feature_readiness={"equity_ta_rows": 12, "equity_ta_symbols": 6},
+            now=datetime(2026, 3, 6, 16, 0, tzinfo=timezone.utc),
+        )
+
+        micro = next(item for item in statuses if item["hypothesis_id"] == "H-MICRO-01")
+        self.assertNotIn("feature_rows_missing", micro["reasons"])
+        self.assertNotIn("required_feature_set_unavailable", micro["reasons"])
+
     def test_compile_hypothesis_runtime_statuses_promotes_canary_when_thresholds_are_met(
         self,
     ) -> None:

--- a/services/torghut/tests/test_signal_readiness_status.py
+++ b/services/torghut/tests/test_signal_readiness_status.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from app.trading.ingest import ClickHouseSignalIngestor, _coerce_count
+
+
+class ReadinessCountingIngestor(ClickHouseSignalIngestor):
+    def __init__(
+        self,
+        *args: object,
+        latest_signal_ts: datetime,
+        signal_rows: int,
+        symbol_count: int,
+        **kwargs: object,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.latest_signal_ts = latest_signal_ts
+        self.signal_rows = signal_rows
+        self.symbol_count = symbol_count
+        self.queries: list[str] = []
+
+    def _query_clickhouse(self, query: str) -> list[dict[str, object]]:
+        self.queries.append(query)
+        if "latest_signal_ts" in query:
+            return [{"latest_signal_ts": self.latest_signal_ts.isoformat()}]
+        if "count() AS signal_rows" in query:
+            return [
+                {
+                    "signal_rows": str(self.signal_rows),
+                    "symbol_count": str(self.symbol_count),
+                }
+            ]
+        return []
+
+
+class SourceFilteredReadinessIngestor(ReadinessCountingIngestor):
+    def _source_where_clause(self) -> str | None:
+        return "lower(source) IN ('ta')"
+
+
+class FailingReadinessIngestor(ReadinessCountingIngestor):
+    def _latest_signal_readiness_counts(
+        self,
+        *,
+        time_column: str,
+        latest_signal_at: datetime,
+    ) -> dict[str, object]:
+        raise RuntimeError("count query unavailable")
+
+
+def test_coerce_count_handles_clickhouse_json_values() -> None:
+    assert _coerce_count(True) == 1
+    assert _coerce_count(12) == 12
+    assert _coerce_count(6.9) == 6
+    assert _coerce_count(" 8 ") == 8
+    assert _coerce_count("bad") == 0
+    assert _coerce_count("") == 0
+
+
+def test_latest_signal_status_includes_readiness_counts() -> None:
+    latest = datetime(2026, 5, 13, 20, 56, 16, tzinfo=timezone.utc)
+    ingestor = ReadinessCountingIngestor(
+        schema="envelope",
+        table="torghut.ta_signals",
+        url="http://example",
+        latest_signal_ts=latest,
+        signal_rows=12,
+        symbol_count=6,
+    )
+
+    status = ingestor.latest_signal_status()
+
+    assert status["state"] == "current"
+    assert status["signal_rows"] == 12
+    assert status["symbol_count"] == 6
+    assert status["readiness_window_end"] == latest
+    assert any("count() AS signal_rows" in query for query in ingestor.queries)
+
+
+def test_latest_signal_status_keeps_current_state_when_readiness_count_fails() -> None:
+    latest = datetime(2026, 5, 13, 20, 56, 16, tzinfo=timezone.utc)
+    ingestor = FailingReadinessIngestor(
+        schema="envelope",
+        table="torghut.ta_signals",
+        url="http://example",
+        latest_signal_ts=latest,
+        signal_rows=12,
+        symbol_count=6,
+    )
+
+    status = ingestor.latest_signal_status()
+
+    assert status["state"] == "current"
+    assert status["readiness_reason_codes"] == ["clickhouse_ta_readiness_query_failed"]
+    assert "count query unavailable" in status["readiness_detail"]
+
+
+def test_latest_signal_readiness_counts_include_source_filter() -> None:
+    latest = datetime(2026, 5, 13, 20, 56, 16, tzinfo=timezone.utc)
+    ingestor = SourceFilteredReadinessIngestor(
+        schema="envelope",
+        table="torghut.ta_signals",
+        url="http://example",
+        latest_signal_ts=latest,
+        signal_rows=12,
+        symbol_count=6,
+    )
+
+    status = ingestor.latest_signal_status()
+
+    assert status["signal_rows"] == 12
+    readiness_queries = [
+        query for query in ingestor.queries if "count() AS signal_rows" in query
+    ]
+    assert readiness_queries
+    assert "lower(source) IN ('ta')" in readiness_queries[0]

--- a/services/torghut/tests/test_submission_council.py
+++ b/services/torghut/tests/test_submission_council.py
@@ -23,6 +23,7 @@ from app.models import (
 )
 from app.trading.submission_council import (
     _QUANT_HEALTH_CACHE,
+    _coerce_aware_datetime,
     _load_profit_promotion_table_counts,
     build_live_submission_gate_payload,
     load_quant_evidence_status,
@@ -132,6 +133,18 @@ class TestSubmissionCouncil(TestCase):
             "status": "healthy",
             "source_url": "http://jangar.test/api/torghut/trading/control-plane/quant/health?account=paper&window=15m",
         }
+
+    def test_coerce_aware_datetime_normalizes_runtime_status_values(self) -> None:
+        self.assertEqual(
+            _coerce_aware_datetime(datetime(2026, 5, 13, 20, 56, 16)),
+            datetime(2026, 5, 13, 20, 56, 16, tzinfo=timezone.utc),
+        )
+        self.assertEqual(
+            _coerce_aware_datetime("2026-05-13T20:56:16Z"),
+            datetime(2026, 5, 13, 20, 56, 16, tzinfo=timezone.utc),
+        )
+        self.assertIsNone(_coerce_aware_datetime("not-a-timestamp"))
+        self.assertIsNone(_coerce_aware_datetime(None))
 
     def test_load_profit_promotion_counts_includes_autoresearch_ledgers(self) -> None:
         engine = create_engine(
@@ -317,6 +330,67 @@ class TestSubmissionCouncil(TestCase):
         self.assertEqual(equity_source["rows"], 9)
         self.assertEqual(rejection_source["rows"], 2)
         self.assertEqual(rejection_source["source_ref"], "postgres:trade_decisions:7d")
+
+    def test_profit_lease_projection_uses_clickhouse_ta_readiness_after_restart(
+        self,
+    ) -> None:
+        result = build_live_submission_gate_payload(
+            SimpleNamespace(
+                last_autonomy_promotion_eligible=True,
+                last_autonomy_promotion_action="promote",
+                drift_live_promotion_eligible=False,
+                last_market_context_freshness_seconds=45,
+                metrics=SimpleNamespace(
+                    feature_batch_rows_total=0,
+                    feature_null_rate={},
+                    feature_staleness_ms_p95=0,
+                    feature_duplicate_ratio=None,
+                    decision_state_total={},
+                ),
+            ),
+            hypothesis_summary={
+                "summary": {
+                    "promotion_eligible_total": 1,
+                    "capital_stage_totals": {"shadow": 1},
+                    "dependency_quorum": {
+                        "decision": "allow",
+                        "reasons": [],
+                        "message": "ready",
+                    },
+                },
+                "items": [
+                    {
+                        "hypothesis_id": "H-CONT-01",
+                        "lane_id": "continuation",
+                        "strategy_family": "intraday_continuation",
+                        "promotion_eligible": True,
+                        "capital_stage": "shadow",
+                        "reasons": [],
+                    }
+                ],
+            },
+            empirical_jobs_status={"ready": True, "status": "healthy"},
+            quant_health_status=self._healthy_quant_status(),
+            clickhouse_ta_status={
+                "state": "current",
+                "source_ref": "torghut.ta_signals",
+                "latest_signal_at": "2026-05-13T20:56:16+00:00",
+                "signal_rows": 12,
+                "symbol_count": 6,
+            },
+        )
+
+        projection = result["profit_lease_projection"]
+        reasons = projection["torghut_capital"]["blocking_reason_codes"]
+        self.assertNotIn("equity_ta_rows_missing", reasons)
+        equity_source = next(
+            source
+            for source in projection["source_provenance"]
+            if source["source_class"] == "equity_ta"
+        )
+        self.assertEqual(equity_source["rows"], 12)
+        self.assertEqual(equity_source["symbols"], 6)
+        self.assertEqual(equity_source["source_ref"], "torghut.ta_signals")
 
     def test_build_live_submission_gate_payload_fails_closed_on_empty_quant_evidence(
         self,


### PR DESCRIPTION
## Summary

- Adds ClickHouse TA readiness counts to Torghut signal freshness status.
- Feeds persisted ClickHouse TA row/symbol evidence into hypothesis runtime and profit lease readiness when scheduler counters are zero after restart.
- Keeps live submission fail-closed; this only removes the false `equity_ta_rows_missing` blocker when persisted TA evidence exists.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_submission_council.py tests/test_hypotheses.py tests/test_signal_ingest.py tests/test_signal_readiness_status.py -q`
- `cd services/torghut && uv run --frozen ruff check app/trading/ingest.py app/trading/hypotheses.py app/trading/submission_council.py tests/test_signal_ingest.py tests/test_signal_readiness_status.py tests/test_hypotheses.py tests/test_submission_council.py`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/ingest.py app/trading/hypotheses.py app/trading/submission_council.py tests/test_signal_readiness_status.py tests/test_hypotheses.py tests/test_submission_council.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
