### PR TITLE
chore(sag): promote log cleanup image

### DIFF
--- a/argocd/sag/kustomization.yaml
+++ b/argocd/sag/kustomization.yaml
@@ -12,4 +12,4 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/sag
     newName: registry.ide-newton.ts.net/lab/sag
-    newTag: "sag-20260513212944"
+    newTag: "c3e3ae5ca"


### PR DESCRIPTION
## Summary

- Promotes the SAG image built from the merged log cleanup revision.
- Pins `argocd/sag` to `registry.ide-newton.ts.net/lab/sag:c3e3ae5ca`.
- Keeps GitOps desired state aligned with the live rollout.

## Related Issues

None

## Testing

- `kubectl kustomize argocd/sag >/tmp/sag-render.yaml`
- `rg -n 'registry.ide-newton.ts.net/lab/sag:c3e3ae5ca' /tmp/sag-render.yaml`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
