### PR TITLE
fix(sag): use shadcn sidebar block shell

### DIFF
--- a/services/sag/src/components/app-sidebar.tsx
+++ b/services/sag/src/components/app-sidebar.tsx
@@ -1,0 +1,46 @@
+import { Link } from '@tanstack/react-router'
+import { HugeiconsIcon } from '@hugeicons/react'
+import { AiSecurity02Icon } from '@hugeicons/core-free-icons'
+import type * as React from 'react'
+
+import { NavMain } from '~/components/nav-main'
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarHeader,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarRail,
+} from '~/components/ui/sidebar'
+
+export function AppSidebar({
+  active,
+  ...props
+}: React.ComponentProps<typeof Sidebar> & {
+  active: string
+}) {
+  return (
+    <Sidebar collapsible="icon" {...props}>
+      <SidebarHeader>
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <SidebarMenuButton render={<Link to="/agent-runs" />} size="lg" tooltip="Action Gateway">
+              <div className="flex aspect-square size-8 items-center justify-center rounded-lg bg-sidebar-accent text-sidebar-accent-foreground">
+                <HugeiconsIcon icon={AiSecurity02Icon} strokeWidth={2} />
+              </div>
+              <div className="grid flex-1 text-left text-sm leading-tight">
+                <span className="truncate font-medium">Action Gateway</span>
+                <span className="truncate text-xs">Agent authority</span>
+              </div>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+        </SidebarMenu>
+      </SidebarHeader>
+      <SidebarContent>
+        <NavMain active={active} />
+      </SidebarContent>
+      <SidebarRail />
+    </Sidebar>
+  )
+}

--- a/services/sag/src/components/gateway-shell.tsx
+++ b/services/sag/src/components/gateway-shell.tsx
@@ -1,30 +1,10 @@
-import { Link } from '@tanstack/react-router'
-import { Bot, GitBranch, SquareTerminal } from 'lucide-react'
 import type { ReactNode } from 'react'
-import {
-  Sidebar,
-  SidebarContent,
-  SidebarGroup,
-  SidebarGroupContent,
-  SidebarHeader,
-  SidebarInset,
-  SidebarMenu,
-  SidebarMenuButton,
-  SidebarMenuItem,
-  SidebarProvider,
-  SidebarRail,
-  SidebarTrigger,
-} from '~/components/ui/sidebar'
+import { Breadcrumb, BreadcrumbItem, BreadcrumbList, BreadcrumbPage } from '~/components/ui/breadcrumb'
+import { Separator } from '~/components/ui/separator'
+import { SidebarInset, SidebarProvider, SidebarTrigger } from '~/components/ui/sidebar'
+import { AppSidebar } from '~/components/app-sidebar'
 import { TooltipProvider } from '~/components/ui/tooltip'
 import type { GatewaySnapshot } from '~/server/gateway'
-import { cn } from '~/lib/utils'
-
-const navItems = [
-  { label: 'Agents', href: '/agents', icon: Bot },
-  { label: 'Agent Runs', href: '/agent-runs', icon: SquareTerminal },
-] as const
-
-type NavHref = (typeof navItems)[number]['href']
 
 export function GatewayFrame({
   active,
@@ -38,83 +18,43 @@ export function GatewayFrame({
   return (
     <TooltipProvider>
       <SidebarProvider
-        className="min-h-screen bg-zinc-950 text-zinc-100"
         style={
           {
-            '--sidebar-width': '14rem',
-            '--sidebar-width-icon': '3rem',
+            '--sidebar-width': 'calc(var(--spacing) * 56)',
+            '--header-height': 'calc(var(--spacing) * 14)',
           } as React.CSSProperties
         }
       >
-        <GatewaySidebar active={active} />
-        <SidebarInset id="main-content" className="min-w-0 bg-zinc-950">
-          <div className="flex h-screen min-h-[720px] min-w-0 flex-col">{children}</div>
+        <AppSidebar active={active} />
+        <SidebarInset id="main-content">
+          <div className="flex h-svh min-h-[720px] min-w-0 flex-col">{children}</div>
         </SidebarInset>
       </SidebarProvider>
     </TooltipProvider>
   )
 }
 
-function GatewaySidebar({ active }: { active: string }) {
+export function GatewayPageHeader({ title, detail, action }: { title: string; detail?: string; action?: ReactNode }) {
   return (
-    <Sidebar collapsible="icon" className="border-zinc-900 bg-zinc-950">
-      <SidebarHeader className="border-b border-zinc-900 p-2">
-        <SidebarMenu>
-          <SidebarMenuItem>
-            <SidebarMenuButton render={<Link to="/agent-runs" />} size="lg" tooltip="Action Gateway">
-              <div className="flex size-8 items-center justify-center rounded-md border border-zinc-800 bg-zinc-950">
-                <GitBranch aria-hidden="true" />
-              </div>
-              <div className="grid min-w-0 flex-1 text-left leading-tight">
-                <span className="truncate font-semibold text-zinc-50">Action Gateway</span>
-                <span className="truncate text-xs text-zinc-400">Agent authority</span>
-              </div>
-            </SidebarMenuButton>
-          </SidebarMenuItem>
-        </SidebarMenu>
-      </SidebarHeader>
-
-      <SidebarContent>
-        <SidebarGroup>
-          <SidebarGroupContent>
-            <SidebarMenu>
-              {navItems.map((item) => (
-                <SidebarNavItem key={item.href} active={active === item.href} href={item.href} icon={<item.icon />}>
-                  {item.label}
-                </SidebarNavItem>
-              ))}
-            </SidebarMenu>
-          </SidebarGroupContent>
-        </SidebarGroup>
-      </SidebarContent>
-      <SidebarRail />
-    </Sidebar>
-  )
-}
-
-export function SidebarNavItem({
-  active,
-  href,
-  icon,
-  children,
-}: {
-  active: boolean
-  href: NavHref
-  icon: ReactNode
-  children: ReactNode
-}) {
-  return (
-    <SidebarMenuItem>
-      <SidebarMenuButton
-        render={<Link to={href} />}
-        isActive={active}
-        tooltip={String(children)}
-        className={cn('text-zinc-400 hover:bg-zinc-900 hover:text-zinc-50', active && 'bg-zinc-900 text-zinc-50')}
-      >
-        {icon}
-        <span>{children}</span>
-      </SidebarMenuButton>
-    </SidebarMenuItem>
+    <header className="flex h-(--header-height) shrink-0 items-center justify-between gap-2 border-b transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-12">
+      <div className="flex min-w-0 items-center gap-2 px-4">
+        <SidebarTrigger className="-ml-1" />
+        <Separator orientation="vertical" className="mr-2 data-vertical:h-4 data-vertical:self-auto" />
+        <Breadcrumb>
+          <BreadcrumbList>
+            <BreadcrumbItem>
+              <BreadcrumbPage>
+                <span className="flex min-w-0 flex-col leading-tight">
+                  <span className="truncate text-sm font-medium">{title}</span>
+                  {detail ? <span className="truncate text-xs text-muted-foreground">{detail}</span> : null}
+                </span>
+              </BreadcrumbPage>
+            </BreadcrumbItem>
+          </BreadcrumbList>
+        </Breadcrumb>
+      </div>
+      {action ? <div className="flex shrink-0 items-center gap-2 px-4">{action}</div> : null}
+    </header>
   )
 }
 

--- a/services/sag/src/components/nav-main.tsx
+++ b/services/sag/src/components/nav-main.tsx
@@ -1,0 +1,49 @@
+import { Link } from '@tanstack/react-router'
+import { HugeiconsIcon } from '@hugeicons/react'
+import { BotIcon, ComputerTerminalIcon } from '@hugeicons/core-free-icons'
+import type * as React from 'react'
+
+import {
+  SidebarGroup,
+  SidebarGroupLabel,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+} from '~/components/ui/sidebar'
+
+type NavItem = {
+  title: string
+  url: '/agents' | '/agent-runs'
+  icon: React.ComponentProps<typeof HugeiconsIcon>['icon']
+}
+
+const items: NavItem[] = [
+  {
+    title: 'Agents',
+    url: '/agents',
+    icon: BotIcon,
+  },
+  {
+    title: 'Agent Runs',
+    url: '/agent-runs',
+    icon: ComputerTerminalIcon,
+  },
+]
+
+export function NavMain({ active }: { active: string }) {
+  return (
+    <SidebarGroup>
+      <SidebarGroupLabel>Control</SidebarGroupLabel>
+      <SidebarMenu>
+        {items.map((item) => (
+          <SidebarMenuItem key={item.url}>
+            <SidebarMenuButton render={<Link to={item.url} />} isActive={active === item.url} tooltip={item.title}>
+              <HugeiconsIcon icon={item.icon} strokeWidth={2} />
+              <span>{item.title}</span>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+        ))}
+      </SidebarMenu>
+    </SidebarGroup>
+  )
+}

--- a/services/sag/src/routes/agent-runs.tsx
+++ b/services/sag/src/routes/agent-runs.tsx
@@ -9,7 +9,7 @@ import { Card, CardAction, CardContent, CardHeader, CardTitle } from '~/componen
 import { Empty, EmptyDescription, EmptyHeader, EmptyTitle } from '~/components/ui/empty'
 import { Field, FieldGroup, FieldLabel } from '~/components/ui/field'
 import { Input } from '~/components/ui/input'
-import { SidebarTrigger, GatewayFrame } from '~/components/gateway-shell'
+import { GatewayFrame, GatewayPageHeader } from '~/components/gateway-shell'
 import { Spinner } from '~/components/ui/spinner'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '~/components/ui/table'
 import { Textarea } from '~/components/ui/textarea'
@@ -78,19 +78,16 @@ function AgentRunsRoute() {
 
   return (
     <GatewayFrame active="/agent-runs" snapshot={snapshot}>
-      <header className="flex h-14 shrink-0 items-center justify-between border-b px-4">
-        <div className="flex min-w-0 items-center gap-3">
-          <SidebarTrigger />
-          <div className="min-w-0">
-            <h1 className="truncate text-sm font-medium">Agent Runs</h1>
-            <p className="truncate text-xs text-muted-foreground">Create, inspect, follow logs.</p>
-          </div>
-        </div>
-        <Button variant="outline" size="sm" onClick={() => runsQuery.refetch()} disabled={runsQuery.isFetching}>
-          {runsQuery.isFetching ? <Spinner data-icon="inline-start" /> : <RefreshCw data-icon="inline-start" />}
-          Refresh
-        </Button>
-      </header>
+      <GatewayPageHeader
+        title="Agent Runs"
+        detail="Create, inspect, follow logs."
+        action={
+          <Button variant="outline" size="sm" onClick={() => runsQuery.refetch()} disabled={runsQuery.isFetching}>
+            {runsQuery.isFetching ? <Spinner data-icon="inline-start" /> : <RefreshCw data-icon="inline-start" />}
+            Refresh
+          </Button>
+        }
+      />
 
       <main className="grid min-h-0 flex-1 grid-cols-1 gap-4 overflow-hidden p-4 xl:grid-cols-[minmax(0,1fr)_minmax(420px,0.45fr)]">
         <section className="flex min-h-0 flex-col gap-4 overflow-hidden">

--- a/services/sag/src/routes/agents.tsx
+++ b/services/sag/src/routes/agents.tsx
@@ -5,7 +5,7 @@ import { Badge } from '~/components/ui/badge'
 import { Button } from '~/components/ui/button'
 import { Card, CardAction, CardContent, CardHeader, CardTitle } from '~/components/ui/card'
 import { Empty, EmptyDescription, EmptyHeader, EmptyTitle } from '~/components/ui/empty'
-import { SidebarTrigger, GatewayFrame } from '~/components/gateway-shell'
+import { GatewayFrame, GatewayPageHeader } from '~/components/gateway-shell'
 import { Spinner } from '~/components/ui/spinner'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '~/components/ui/table'
 import { fetchLiveAgents, fetchSnapshot } from '~/lib/sag-client'
@@ -32,19 +32,16 @@ function AgentsRoute() {
 
   return (
     <GatewayFrame active="/agents" snapshot={snapshotQuery.data ?? initialSnapshot}>
-      <header className="flex h-14 shrink-0 items-center justify-between border-b px-4">
-        <div className="flex min-w-0 items-center gap-3">
-          <SidebarTrigger />
-          <div className="min-w-0">
-            <h1 className="truncate text-sm font-medium">Agents</h1>
-            <p className="truncate text-xs text-muted-foreground">Cluster executors.</p>
-          </div>
-        </div>
-        <Button variant="outline" size="sm" onClick={() => agentsQuery.refetch()} disabled={agentsQuery.isFetching}>
-          {agentsQuery.isFetching ? <Spinner data-icon="inline-start" /> : <RefreshCw data-icon="inline-start" />}
-          Refresh
-        </Button>
-      </header>
+      <GatewayPageHeader
+        title="Agents"
+        detail="Cluster executors."
+        action={
+          <Button variant="outline" size="sm" onClick={() => agentsQuery.refetch()} disabled={agentsQuery.isFetching}>
+            {agentsQuery.isFetching ? <Spinner data-icon="inline-start" /> : <RefreshCw data-icon="inline-start" />}
+            Refresh
+          </Button>
+        }
+      />
 
       <main className="min-h-0 flex-1 overflow-hidden p-4">
         <Card className="h-full rounded-lg" size="sm">


### PR DESCRIPTION
## Summary

- Reworks the SAG shell around the official `sidebar-07` shadcn block structure.
- Adds local `AppSidebar` and `NavMain` block components with only real SAG navigation.
- Updates Agents and Agent Runs to use the block-style inset header with `SidebarTrigger`, `Separator`, and `Breadcrumb`.

## Related Issues

None

## Testing

- `./node_modules/.bin/shadcn info --json`
- `./node_modules/.bin/shadcn docs sidebar breadcrumb separator`
- `./node_modules/.bin/shadcn view sidebar-07`
- `bun run --filter @proompteng/sag tsc`
- `bun run --filter @proompteng/sag lint`
- `bun run --filter @proompteng/sag lint:oxlint`
- `bun run --filter @proompteng/sag test`
- `bun run --filter @proompteng/sag build`
- Local Playwright check against `http://localhost:3001/agent-runs` confirmed sidebar labels render and old footer terms are absent.

## Screenshots (if applicable)

Validated locally with `/tmp/sag-sidebar-block.png`.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
