### PR TITLE
chore(sag): promote sidebar block image

### DIFF
--- a/argocd/sag/kustomization.yaml
+++ b/argocd/sag/kustomization.yaml
@@ -12,4 +12,4 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/sag
     newName: registry.ide-newton.ts.net/lab/sag
-    newTag: "c3e3ae5ca"
+    newTag: "309f4b3da"


### PR DESCRIPTION
## Summary

- Promotes the SAG image built from the merged shadcn sidebar block shell revision.
- Pins `argocd/sag` to `registry.ide-newton.ts.net/lab/sag:309f4b3da`.
- Aligns GitOps desired state with the live sidebar-block rollout.

## Related Issues

None

## Testing

- `bun run sag:deploy`
- `kubectl kustomize argocd/sag >/tmp/sag-render-sidebar.yaml`
- `rg -n 'registry.ide-newton.ts.net/lab/sag:309f4b3da' /tmp/sag-render-sidebar.yaml`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
