### PR TITLE
chore(torghut): promote image 5cc85729

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:5ad787eaa465bf65dd9260851944d3cb1759a17fa20103ad8f7ebd8aa2b46a57
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:7bafc4217bca433ce32edb62ce7de9ab2fc717c041b5f9a706648a5aeee0e1d8
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.569.1-335-g813573fbb
+              value: v0.569.1-340-g5cc857291
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 813573fbb010422b53a4d7afc2c51df726da4233
+              value: 5cc85729153df11956a5aa1745dace53b90fb34a
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:5ad787eaa465bf65dd9260851944d3cb1759a17fa20103ad8f7ebd8aa2b46a57
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:7bafc4217bca433ce32edb62ce7de9ab2fc717c041b5f9a706648a5aeee0e1d8
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.569.1-335-g813573fbb
+              value: v0.569.1-340-g5cc857291
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 813573fbb010422b53a4d7afc2c51df726da4233
+              value: 5cc85729153df11956a5aa1745dace53b90fb34a
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:5ad787eaa465bf65dd9260851944d3cb1759a17fa20103ad8f7ebd8aa2b46a57
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:7bafc4217bca433ce32edb62ce7de9ab2fc717c041b5f9a706648a5aeee0e1d8
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:5ad787eaa465bf65dd9260851944d3cb1759a17fa20103ad8f7ebd8aa2b46a57
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:7bafc4217bca433ce32edb62ce7de9ab2fc717c041b5f9a706648a5aeee0e1d8
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:5ad787eaa465bf65dd9260851944d3cb1759a17fa20103ad8f7ebd8aa2b46a57
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:7bafc4217bca433ce32edb62ce7de9ab2fc717c041b5f9a706648a5aeee0e1d8
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:5ad787eaa465bf65dd9260851944d3cb1759a17fa20103ad8f7ebd8aa2b46a57
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:7bafc4217bca433ce32edb62ce7de9ab2fc717c041b5f9a706648a5aeee0e1d8
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:5ad787eaa465bf65dd9260851944d3cb1759a17fa20103ad8f7ebd8aa2b46a57
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:7bafc4217bca433ce32edb62ce7de9ab2fc717c041b5f9a706648a5aeee0e1d8
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -15,7 +15,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:5ad787eaa465bf65dd9260851944d3cb1759a17fa20103ad8f7ebd8aa2b46a57
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:7bafc4217bca433ce32edb62ce7de9ab2fc717c041b5f9a706648a5aeee0e1d8
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -23,7 +23,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:5ad787eaa465bf65dd9260851944d3cb1759a17fa20103ad8f7ebd8aa2b46a57
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:7bafc4217bca433ce32edb62ce7de9ab2fc717c041b5f9a706648a5aeee0e1d8
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:5ad787eaa465bf65dd9260851944d3cb1759a17fa20103ad8f7ebd8aa2b46a57
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:7bafc4217bca433ce32edb62ce7de9ab2fc717c041b5f9a706648a5aeee0e1d8
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-14T05:02:24Z"
+        client.knative.dev/updateTimestamp: "2026-05-14T05:26:42Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -27,7 +27,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:5ad787eaa465bf65dd9260851944d3cb1759a17fa20103ad8f7ebd8aa2b46a57
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:7bafc4217bca433ce32edb62ce7de9ab2fc717c041b5f9a706648a5aeee0e1d8
           ports:
             - name: http1
               containerPort: 8181
@@ -482,11 +482,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.569.1-335-g813573fbb
+              value: v0.569.1-340-g5cc857291
             - name: TORGHUT_COMMIT
-              value: 813573fbb010422b53a4d7afc2c51df726da4233
+              value: 5cc85729153df11956a5aa1745dace53b90fb34a
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:5ad787eaa465bf65dd9260851944d3cb1759a17fa20103ad8f7ebd8aa2b46a57
+              value: sha256:7bafc4217bca433ce32edb62ce7de9ab2fc717c041b5f9a706648a5aeee0e1d8
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-14T05:02:24Z"
+        client.knative.dev/updateTimestamp: "2026-05-14T05:26:42Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:5ad787eaa465bf65dd9260851944d3cb1759a17fa20103ad8f7ebd8aa2b46a57
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:7bafc4217bca433ce32edb62ce7de9ab2fc717c041b5f9a706648a5aeee0e1d8
           ports:
             - name: http1
               containerPort: 8181
@@ -298,11 +298,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.569.1-335-g813573fbb
+              value: v0.569.1-340-g5cc857291
             - name: TORGHUT_COMMIT
-              value: 813573fbb010422b53a4d7afc2c51df726da4233
+              value: 5cc85729153df11956a5aa1745dace53b90fb34a
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:5ad787eaa465bf65dd9260851944d3cb1759a17fa20103ad8f7ebd8aa2b46a57
+              value: sha256:7bafc4217bca433ce32edb62ce7de9ab2fc717c041b5f9a706648a5aeee0e1d8
           livenessProbe:
             httpGet:
               path: /healthz

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -89,7 +89,7 @@ spec:
           - name: allowStaleTape
           - name: persistResults
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:5ad787eaa465bf65dd9260851944d3cb1759a17fa20103ad8f7ebd8aa2b46a57
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:7bafc4217bca433ce32edb62ce7de9ab2fc717c041b5f9a706648a5aeee0e1d8
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
+++ b/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:5ad787eaa465bf65dd9260851944d3cb1759a17fa20103ad8f7ebd8aa2b46a57
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:7bafc4217bca433ce32edb62ce7de9ab2fc717c041b5f9a706648a5aeee0e1d8
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `5cc85729153df11956a5aa1745dace53b90fb34a`
- Image tag: `5cc85729`
- Image digest: `sha256:7bafc4217bca433ce32edb62ce7de9ab2fc717c041b5f9a706648a5aeee0e1d8`