### PR TITLE
fix(sag): remove header refresh controls

### DIFF
--- a/services/sag/src/app/styles/app.css
+++ b/services/sag/src/app/styles/app.css
@@ -124,9 +124,6 @@
   body {
     @apply visible bg-zinc-950 text-zinc-100;
   }
-  html[data-sag-paint='guard'] body {
-    visibility: visible;
-  }
   html {
     @apply bg-zinc-950 font-sans text-zinc-100;
   }

--- a/services/sag/src/routes/__root.tsx
+++ b/services/sag/src/routes/__root.tsx
@@ -18,22 +18,10 @@ function RootDocument() {
   return (
     <html
       lang="en"
-      data-sag-paint="guard"
       className="dark h-full bg-zinc-950 text-zinc-100 [color-scheme:dark]"
       style={{ backgroundColor: '#09090b', color: '#f4f4f5', colorScheme: 'dark' }}
     >
       <head>
-        <style>
-          {
-            'html,body{background:#09090b;color:#f4f4f5;color-scheme:dark}html[data-sag-paint=guard] body{visibility:hidden}'
-          }
-        </style>
-        <script
-          dangerouslySetInnerHTML={{
-            __html:
-              'window.addEventListener("load",function(){document.documentElement.dataset.sagPaint="ready"},{once:true});setTimeout(function(){document.documentElement.dataset.sagPaint="ready"},2500);',
-          }}
-        />
         <HeadContent />
       </head>
       <body

--- a/services/sag/src/routes/agent-runs.tsx
+++ b/services/sag/src/routes/agent-runs.tsx
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { createFileRoute } from '@tanstack/react-router'
-import { RefreshCw, Send } from 'lucide-react'
+import { Send } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
 import { Alert, AlertDescription, AlertTitle } from '~/components/ui/alert'
 import { Badge } from '~/components/ui/badge'
@@ -78,16 +78,7 @@ function AgentRunsRoute() {
 
   return (
     <GatewayFrame active="/agent-runs" snapshot={snapshot}>
-      <GatewayPageHeader
-        title="Agent Runs"
-        detail="Create, inspect, follow logs."
-        action={
-          <Button variant="outline" size="sm" onClick={() => runsQuery.refetch()} disabled={runsQuery.isFetching}>
-            {runsQuery.isFetching ? <Spinner data-icon="inline-start" /> : <RefreshCw data-icon="inline-start" />}
-            Refresh
-          </Button>
-        }
-      />
+      <GatewayPageHeader title="Agent Runs" detail="Create, inspect, follow logs." />
 
       <main className="grid min-h-0 flex-1 grid-cols-1 gap-4 overflow-hidden p-4 xl:grid-cols-[minmax(0,1fr)_minmax(420px,0.45fr)]">
         <section className="flex min-h-0 flex-col gap-4 overflow-hidden">

--- a/services/sag/src/routes/agents.tsx
+++ b/services/sag/src/routes/agents.tsx
@@ -1,12 +1,9 @@
 import { useQuery } from '@tanstack/react-query'
 import { createFileRoute } from '@tanstack/react-router'
-import { RefreshCw } from 'lucide-react'
 import { Badge } from '~/components/ui/badge'
-import { Button } from '~/components/ui/button'
 import { Card, CardAction, CardContent, CardHeader, CardTitle } from '~/components/ui/card'
 import { Empty, EmptyDescription, EmptyHeader, EmptyTitle } from '~/components/ui/empty'
 import { GatewayFrame, GatewayPageHeader } from '~/components/gateway-shell'
-import { Spinner } from '~/components/ui/spinner'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '~/components/ui/table'
 import { fetchLiveAgents, fetchSnapshot } from '~/lib/sag-client'
 import { loadInitialSnapshot } from '~/lib/load-snapshot'
@@ -32,16 +29,7 @@ function AgentsRoute() {
 
   return (
     <GatewayFrame active="/agents" snapshot={snapshotQuery.data ?? initialSnapshot}>
-      <GatewayPageHeader
-        title="Agents"
-        detail="Cluster executors."
-        action={
-          <Button variant="outline" size="sm" onClick={() => agentsQuery.refetch()} disabled={agentsQuery.isFetching}>
-            {agentsQuery.isFetching ? <Spinner data-icon="inline-start" /> : <RefreshCw data-icon="inline-start" />}
-            Refresh
-          </Button>
-        }
-      />
+      <GatewayPageHeader title="Agents" detail="Cluster executors." />
 
       <main className="min-h-0 flex-1 overflow-hidden p-4">
         <Card className="h-full rounded-lg" size="sm">


### PR DESCRIPTION
## Summary

- Removed header refresh controls from the `Agents` and `Agent Runs` SAG routes.
- Removed the root paint guard script and `data-sag-paint` attribute that mutated before hydration.
- Kept the shadcn sidebar shell and automatic query polling intact.

## Related Issues

None

## Testing

- `bun run --filter @proompteng/sag tsc`
- `bun run --filter @proompteng/sag lint`
- `bun run --filter @proompteng/sag lint:oxlint`
- `bun run --filter @proompteng/sag test`
- `bun run --filter @proompteng/sag build`
- Local dev screenshot check with Playwright CLI: `/agent-runs` and `/agents` render without the `Refresh` header button.
- Local SSR checks confirmed no paint guard attribute, refresh icon import, or rendered `Refresh` button label remains in `/agent-runs` or `/agents` HTML.

## Screenshots (if applicable)

Validated locally: `/tmp/sag-remove-refresh-agent-runs-after-root.png` shows no header refresh button.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
