### PR TITLE
fix(sag): remove agent runs subtitle

### DIFF
--- a/services/sag/src/routes/agent-runs.tsx
+++ b/services/sag/src/routes/agent-runs.tsx
@@ -78,7 +78,7 @@ function AgentRunsRoute() {
 
   return (
     <GatewayFrame active="/agent-runs" snapshot={snapshot}>
-      <GatewayPageHeader title="Agent Runs" detail="Create, inspect, follow logs." />
+      <GatewayPageHeader title="Agent Runs" />
 
       <main className="grid min-h-0 flex-1 grid-cols-1 gap-4 overflow-hidden p-4 xl:grid-cols-[minmax(0,1fr)_minmax(420px,0.45fr)]">
         <section className="flex min-h-0 flex-col gap-4 overflow-hidden">


### PR DESCRIPTION
## Summary

- Removed the `Agent Runs` page header subtitle.
- Left the route title and existing shadcn sidebar shell unchanged.
- Kept automatic run polling and log behavior unchanged.

## Related Issues

None

## Testing

- `bun run --filter @proompteng/sag tsc`
- `bun run --filter @proompteng/sag lint`
- `bun run --filter @proompteng/sag lint:oxlint`
- `bun run --filter @proompteng/sag test`
- `bun run --filter @proompteng/sag build`
- Local SSR check confirmed `Create, inspect, follow logs.` is absent from `/agent-runs`.
- Local Playwright screenshot: `/tmp/sag-remove-agent-runs-subtitle.png`.

## Screenshots (if applicable)

Validated locally: `/tmp/sag-remove-agent-runs-subtitle.png` shows the `Agent Runs` header without subtitle text.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
