### PR TITLE
chore(sag): promote subtitle removal image

### DIFF
--- a/argocd/sag/kustomization.yaml
+++ b/argocd/sag/kustomization.yaml
@@ -12,4 +12,4 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/sag
     newName: registry.ide-newton.ts.net/lab/sag
-    newTag: "7b84d47a2"
+    newTag: "f5564f8f4"


### PR DESCRIPTION
## Summary

- Promoted the SAG image built from `f5564f8f4`.
- Updated the SAG Argo CD kustomization to deploy `registry.ide-newton.ts.net/lab/sag:f5564f8f4`.
- Keeps GitOps state aligned with the rollout already applied by the deploy helper.

## Related Issues

None

## Testing

- `bun run sag:deploy`
- `kubectl rollout status deployment/sag -n sag --timeout=180s`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
