### PR TITLE
fix(sag): repair agent run creation

### DIFF
--- a/services/sag/src/routes/agent-runs.tsx
+++ b/services/sag/src/routes/agent-runs.tsx
@@ -10,6 +10,7 @@ import { Empty, EmptyDescription, EmptyHeader, EmptyTitle } from '~/components/u
 import { Field, FieldGroup, FieldLabel } from '~/components/ui/field'
 import { Input } from '~/components/ui/input'
 import { GatewayFrame, GatewayPageHeader } from '~/components/gateway-shell'
+import { ScrollArea } from '~/components/ui/scroll-area'
 import { Spinner } from '~/components/ui/spinner'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '~/components/ui/table'
 import { Textarea } from '~/components/ui/textarea'
@@ -80,7 +81,7 @@ function AgentRunsRoute() {
     <GatewayFrame active="/agent-runs" snapshot={snapshot}>
       <GatewayPageHeader title="Agent Runs" />
 
-      <main className="grid min-h-0 flex-1 grid-cols-1 gap-4 overflow-hidden p-4 xl:grid-cols-[minmax(0,1fr)_minmax(420px,0.45fr)]">
+      <main className="grid min-h-0 flex-1 grid-cols-1 gap-4 overflow-hidden p-4 xl:grid-cols-[minmax(0,1fr)_minmax(320px,420px)]">
         <section className="flex min-h-0 flex-col gap-4 overflow-hidden">
           <Card className="shrink-0 rounded-lg" size="sm">
             <CardHeader>
@@ -139,46 +140,50 @@ function AgentRunsRoute() {
                 <Badge variant="outline">{runs.length}</Badge>
               </CardAction>
             </CardHeader>
-            <CardContent className="min-h-0 overflow-auto">
+            <CardContent className="min-h-0 flex-1 overflow-hidden px-0">
               {runs.length === 0 ? (
-                <Empty className="min-h-[260px] rounded-lg border">
+                <Empty className="mx-4 min-h-[260px] rounded-lg border">
                   <EmptyHeader>
                     <EmptyTitle>No runs</EmptyTitle>
                     <EmptyDescription>Create one above.</EmptyDescription>
                   </EmptyHeader>
                 </Empty>
               ) : (
-                <Table>
-                  <TableHeader>
-                    <TableRow>
-                      <TableHead>Run</TableHead>
-                      <TableHead>Agent</TableHead>
-                      <TableHead>Phase</TableHead>
-                      <TableHead>Created</TableHead>
-                      <TableHead>Pod</TableHead>
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {runs.map((run) => (
-                      <TableRow
-                        key={runKey(run)}
-                        data-state={selectedRun && runKey(run) === runKey(selectedRun) ? 'selected' : undefined}
-                        className="cursor-pointer"
-                        onClick={() => setSelectedRunKey(runKey(run))}
-                      >
-                        <TableCell className="max-w-[280px] truncate font-medium">{run.name}</TableCell>
-                        <TableCell>{run.agent}</TableCell>
-                        <TableCell>
-                          <Badge variant={phaseVariant(run.phase)}>{run.phase}</Badge>
-                        </TableCell>
-                        <TableCell>{formatDate(run.createdAt)}</TableCell>
-                        <TableCell className="max-w-[240px] truncate text-muted-foreground">
-                          {run.podName ?? '-'}
-                        </TableCell>
+                <ScrollArea className="h-full min-h-0">
+                  <Table className="table-fixed">
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead className="w-[38%] pl-4">Run</TableHead>
+                        <TableHead className="w-[24%]">Agent</TableHead>
+                        <TableHead className="w-[16%]">Phase</TableHead>
+                        <TableHead className="w-[22%] pr-4">Created</TableHead>
                       </TableRow>
-                    ))}
-                  </TableBody>
-                </Table>
+                    </TableHeader>
+                    <TableBody>
+                      {runs.map((run) => (
+                        <TableRow
+                          key={runKey(run)}
+                          data-state={selectedRun && runKey(run) === runKey(selectedRun) ? 'selected' : undefined}
+                          className="cursor-pointer"
+                          onClick={() => setSelectedRunKey(runKey(run))}
+                        >
+                          <TableCell className="pl-4 font-medium">
+                            <span className="block truncate">{run.name}</span>
+                          </TableCell>
+                          <TableCell>
+                            <span className="block truncate">{run.agent}</span>
+                          </TableCell>
+                          <TableCell>
+                            <Badge variant={phaseVariant(run.phase)}>{run.phase}</Badge>
+                          </TableCell>
+                          <TableCell className="pr-4">
+                            <span className="block truncate">{formatDate(run.createdAt)}</span>
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </ScrollArea>
               )}
             </CardContent>
           </Card>
@@ -203,14 +208,13 @@ function AgentRunsRoute() {
                     {logsQuery.data?.podName ?? selectedRun.podName ?? 'pod pending'}
                   </div>
                 </div>
-                <pre
-                  className={cn(
-                    'min-h-0 flex-1 overflow-auto rounded-lg border bg-muted/30 p-3 font-mono text-xs leading-5 text-foreground',
-                    logsQuery.isFetching && 'opacity-80',
-                  )}
+                <ScrollArea
+                  className={cn('min-h-0 flex-1 rounded-lg border bg-muted/30', logsQuery.isFetching && 'opacity-80')}
                 >
-                  {logsQuery.data?.logs ?? 'Waiting for logs.'}
-                </pre>
+                  <pre className="min-h-full whitespace-pre-wrap break-words p-3 font-mono text-xs leading-5 text-foreground">
+                    {logsQuery.data?.logs ?? 'Waiting for logs.'}
+                  </pre>
+                </ScrollArea>
               </>
             ) : (
               <Empty className="min-h-[360px] rounded-lg border">

--- a/services/sag/src/routes/api/agent-runs.ts
+++ b/services/sag/src/routes/api/agent-runs.ts
@@ -21,6 +21,9 @@ export const Route = createFileRoute('/api/agent-runs')({
           repository: payload?.repository,
           base: payload?.base,
           head: payload?.head,
+          issueNumber: payload?.issueNumber,
+          issueTitle: payload?.issueTitle,
+          issueUrl: payload?.issueUrl,
         })
 
         const state = await loadGatewayState()

--- a/services/sag/src/server/kubernetes.test.ts
+++ b/services/sag/src/server/kubernetes.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from 'vitest'
+import { buildAgentRunManifest } from './kubernetes'
+
+describe('SAG AgentRun manifests', () => {
+  test('include issue metadata required by the in-cluster runner', () => {
+    const manifest = buildAgentRunManifest({
+      name: 'sag-test',
+      namespace: 'agents',
+      agent: 'codex-agent',
+      task: 'Inspect repository health without changing files.',
+      repository: 'proompteng/lab',
+      base: 'main',
+      head: 'codex/sag-test',
+      issueNumber: '0',
+      issueTitle: 'SAG AgentRun',
+      issueUrl: 'https://sag.proompteng.ai',
+    })
+
+    expect(manifest.spec.parameters).toMatchObject({
+      repository: 'proompteng/lab',
+      base: 'main',
+      head: 'codex/sag-test',
+      issueNumber: '0',
+      issueTitle: 'SAG AgentRun',
+      issueUrl: 'https://sag.proompteng.ai',
+      stage: 'implementation',
+    })
+    expect(manifest.spec.workflow.steps[0]?.parameters).toMatchObject({
+      repository: 'proompteng/lab',
+      base: 'main',
+      head: 'codex/sag-test',
+      issueNumber: '0',
+      issueTitle: 'SAG AgentRun',
+      issueUrl: 'https://sag.proompteng.ai',
+      stage: 'implementation',
+    })
+  })
+})

--- a/services/sag/src/server/kubernetes.ts
+++ b/services/sag/src/server/kubernetes.ts
@@ -126,6 +126,9 @@ export type CreateLiveAgentRunInput = {
   repository?: string
   base?: string
   head?: string
+  issueNumber?: string
+  issueTitle?: string
+  issueUrl?: string
 }
 
 export type AgentRunLogResult = {
@@ -141,6 +144,9 @@ const defaultNamespace = process.env.SAG_AGENTRUN_NAMESPACE ?? 'agents'
 const defaultAgent = process.env.SAG_AGENTRUN_AGENT ?? 'codex-agent'
 const defaultRepository = process.env.SAG_AGENTRUN_REPOSITORY ?? 'proompteng/lab'
 const defaultBase = process.env.SAG_AGENTRUN_BASE ?? 'main'
+const defaultIssueNumber = normalizeIssueNumber(process.env.SAG_AGENTRUN_ISSUE_NUMBER) || '0'
+const defaultIssueTitle = process.env.SAG_AGENTRUN_ISSUE_TITLE ?? 'SAG AgentRun'
+const defaultIssueUrl = process.env.SAG_AGENTRUN_ISSUE_URL ?? 'https://sag.proompteng.ai'
 
 export const listLiveAgentRuns = async (limit = 25): Promise<AgentRunEvaluationInput[]> => {
   const client = kubernetesClient()
@@ -227,6 +233,10 @@ export const createLiveAgentRun = async (input: CreateLiveAgentRunInput): Promis
   const task = input.task.trim()
   if (!task) throw new Error('Task is required')
 
+  const issueNumber = normalizeIssueNumber(input.issueNumber) || defaultIssueNumber
+  const issueTitle = input.issueTitle?.trim() || defaultIssueTitle
+  const issueUrl = input.issueUrl?.trim() || defaultIssueUrl
+
   const manifest = buildAgentRunManifest({
     name,
     namespace,
@@ -235,6 +245,9 @@ export const createLiveAgentRun = async (input: CreateLiveAgentRunInput): Promis
     repository: input.repository?.trim() || defaultRepository,
     base: input.base?.trim() || defaultBase,
     head: input.head?.trim() || `codex/sag-${Date.now().toString(36)}`,
+    issueNumber,
+    issueTitle,
+    issueUrl,
   })
 
   const created = await requestJson<KubernetesAgentRun>(client, `${agentApiPrefix}/namespaces/${namespace}/agentruns`, {
@@ -404,7 +417,7 @@ const firstPodForJob = async (client: KubernetesClient, namespace: string, jobNa
   )[0]
 }
 
-const buildAgentRunManifest = ({
+export const buildAgentRunManifest = ({
   name,
   namespace,
   agent,
@@ -412,6 +425,9 @@ const buildAgentRunManifest = ({
   repository,
   base,
   head,
+  issueNumber,
+  issueTitle,
+  issueUrl,
 }: {
   name: string
   namespace: string
@@ -420,6 +436,9 @@ const buildAgentRunManifest = ({
   repository: string
   base: string
   head: string
+  issueNumber: string
+  issueTitle: string
+  issueUrl: string
 }) => ({
   apiVersion: 'agents.proompteng.ai/v1alpha1',
   kind: 'AgentRun',
@@ -443,9 +462,10 @@ const buildAgentRunManifest = ({
       repository,
       base,
       head,
+      issueNumber,
       stage: 'implementation',
-      issueTitle: 'SAG AgentRun',
-      issueUrl: 'https://sag.proompteng.ai',
+      issueTitle,
+      issueUrl,
     },
     runtime: {
       type: 'workflow',
@@ -455,7 +475,13 @@ const buildAgentRunManifest = ({
         {
           name: 'run',
           parameters: {
+            repository,
+            base,
+            head,
+            issueNumber,
             stage: 'implementation',
+            issueTitle,
+            issueUrl,
           },
           timeoutSeconds: 7200,
         },
@@ -564,5 +590,10 @@ const sanitizeDnsName = (value: string) =>
     .toLowerCase()
     .replace(/[^a-z0-9-]+/g, '-')
     .replace(/^-+|-+$/g, '')
+
+function normalizeIssueNumber(value: string | undefined) {
+  const normalized = value?.trim().replace(/^#/, '') ?? ''
+  return /^[0-9]+$/.test(normalized) ? normalized : ''
+}
 
 const titleCase = (value: string) => value.slice(0, 1).toUpperCase() + value.slice(1).toLowerCase()


### PR DESCRIPTION
## Summary

- Fix SAG-created AgentRun manifests by including runner-required issue metadata in spec and workflow parameters.
- Add a regression test that locks the issue metadata into the generated AgentRun manifest.
- Replace raw runs/log overflow with the existing shadcn ScrollArea composition and tighten the Agent Runs table so it does not expose browser scrollbars.

## Related Issues

None

## Testing

- `bun run --filter @proompteng/sag tsc`
- `bun run --filter @proompteng/sag lint`
- `bun run --filter @proompteng/sag lint:oxlint`
- `bun run --filter @proompteng/sag test`
- `bun run --filter @proompteng/sag build`
- Local browser render check at `http://localhost:3001/agent-runs`

## Screenshots (if applicable)

Local render check confirmed the Agent Runs page uses the updated two-panel layout without raw horizontal browser scrollbars.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
