### PR TITLE
feat(torghut): harden profit autoresearch selection

### DIFF
--- a/services/torghut/app/trading/discovery/candidate_specs.py
+++ b/services/torghut/app/trading/discovery/candidate_specs.py
@@ -1909,11 +1909,42 @@ def _format_profile_budget(value: Decimal) -> str:
     return text or "0"
 
 
+def _profile_rank_count_floor(profile: Mapping[str, Any]) -> int:
+    params = _mapping(profile.get("params"))
+    for key in (
+        "max_entries_per_session",
+        "max_concurrent_positions",
+        "max_pair_legs",
+        "top_n",
+        "rank_count",
+    ):
+        try:
+            if Decimal(str(params.get(key) or "0")) > 0:
+                return 1
+        except Exception:
+            continue
+    universe = profile.get("universe_symbols")
+    if not isinstance(universe, Sequence) or isinstance(universe, (str, bytes)):
+        return 1
+    cleaned_count = 0
+    for item in cast(Sequence[Any], universe):
+        if _string(item):
+            cleaned_count += 1
+    return max(1, cleaned_count)
+
+
 def _capital_limited_profile_values(profile: Mapping[str, Any]) -> tuple[str, str]:
     params = _mapping(profile.get("params"))
     pressure = max(
         Decimal("1"),
-        Decimal(str(estimate_capital_pressure(params))),
+        Decimal(
+            str(
+                estimate_capital_pressure(
+                    params,
+                    rank_count_floor=_profile_rank_count_floor(profile),
+                )
+            )
+        ),
     )
     max_notional = (Decimal("30000") / pressure).quantize(Decimal("0.01"))
     max_position = (Decimal("1") / pressure).quantize(Decimal("0.000001"))
@@ -2283,9 +2314,16 @@ def _strategy_overrides_for_profile(
         target_net_pnl_per_day=target_net_pnl_per_day,
     )
     if not profiles:
-        return {"max_notional_per_trade": "50000"}
+        return {
+            "max_notional_per_trade": "50000",
+            "params": {"position_isolation_mode": "per_strategy"},
+        }
     selected = profiles[profile_index % len(profiles)]
-    return json.loads(json.dumps(selected))
+    overrides = json.loads(json.dumps(selected))
+    params = _mapping(overrides.get("params"))
+    params.setdefault("position_isolation_mode", "per_strategy")
+    overrides["params"] = params
+    return overrides
 
 
 @dataclass(frozen=True)

--- a/services/torghut/app/trading/discovery/mlx_features.py
+++ b/services/torghut/app/trading/discovery/mlx_features.py
@@ -13,7 +13,7 @@ from app.trading.discovery.family_templates import FamilyTemplate
 
 
 def _string(value: Any) -> str:
-    return str(value or '').strip()
+    return str(value or "").strip()
 
 
 def _float(value: Any) -> float:
@@ -24,7 +24,7 @@ def _float(value: Any) -> float:
 
 
 def _format_float(value: float) -> str:
-    return format(value, '.12g')
+    return format(value, ".12g")
 
 
 def _mapping(value: Any) -> dict[str, Any]:
@@ -42,36 +42,36 @@ def _first_value(raw: Any) -> Any:
 
 
 def _param_value(config: Mapping[str, Any], key: str) -> Any:
-    return _first_value(_mapping(config.get('parameters')).get(key))
+    return _first_value(_mapping(config.get("parameters")).get(key))
 
 
 def _override_value(config: Mapping[str, Any], key: str) -> Any:
-    return _first_value(_mapping(config.get('strategy_overrides')).get(key))
+    return _first_value(_mapping(config.get("strategy_overrides")).get(key))
 
 
 def _infer_side_policy(template: FamilyTemplate) -> str:
     runtime = _mapping(template.runtime_harness)
-    joined = ' '.join(
+    joined = " ".join(
         [
             template.family_id,
-            _string(runtime.get('family')),
-            _string(runtime.get('strategy_name')),
+            _string(runtime.get("family")),
+            _string(runtime.get("strategy_name")),
             template.economic_mechanism,
         ]
     ).lower()
-    if 'short' in joined:
-        return 'short'
-    if 'long' in joined:
-        return 'long'
-    return 'long_short'
+    if "short" in joined:
+        return "short"
+    if "long" in joined:
+        return "long"
+    return "long_short"
 
 
 def _infer_entry_window_start(config: Mapping[str, Any]) -> int:
     for key in (
-        'entry_start_minutes_since_open',
-        'leader_reclaim_start_minutes_since_open',
-        'open_window_start_minutes_since_open',
-        'start_minutes_since_open',
+        "entry_start_minutes_since_open",
+        "leader_reclaim_start_minutes_since_open",
+        "open_window_start_minutes_since_open",
+        "start_minutes_since_open",
     ):
         value = _param_value(config, key)
         if value is not None:
@@ -84,9 +84,9 @@ def _infer_entry_window_start(config: Mapping[str, Any]) -> int:
 
 def _infer_entry_window_end(config: Mapping[str, Any], start_minute: int) -> int:
     for key in (
-        'entry_end_minutes_since_open',
-        'open_window_end_minutes_since_open',
-        'end_minutes_since_open',
+        "entry_end_minutes_since_open",
+        "open_window_end_minutes_since_open",
+        "end_minutes_since_open",
     ):
         value = _param_value(config, key)
         if value is not None:
@@ -94,7 +94,7 @@ def _infer_entry_window_end(config: Mapping[str, Any], start_minute: int) -> int
                 return int(float(str(value)))
             except ValueError:
                 continue
-    hold_seconds = _param_value(config, 'max_hold_seconds')
+    hold_seconds = _param_value(config, "max_hold_seconds")
     if hold_seconds is not None:
         try:
             return start_minute + max(1, int(float(str(hold_seconds)) // 60))
@@ -103,8 +103,10 @@ def _infer_entry_window_end(config: Mapping[str, Any], start_minute: int) -> int
     return start_minute + 30
 
 
-def _infer_max_hold_minutes(config: Mapping[str, Any], start_minute: int, end_minute: int) -> int:
-    hold_seconds = _param_value(config, 'max_hold_seconds')
+def _infer_max_hold_minutes(
+    config: Mapping[str, Any], start_minute: int, end_minute: int
+) -> int:
+    hold_seconds = _param_value(config, "max_hold_seconds")
     if hold_seconds is not None:
         try:
             return max(1, int(float(str(hold_seconds)) // 60))
@@ -114,59 +116,71 @@ def _infer_max_hold_minutes(config: Mapping[str, Any], start_minute: int, end_mi
 
 
 def _infer_rank_policy(config: Mapping[str, Any], template: FamilyTemplate) -> str:
-    params = _mapping(config.get('parameters'))
+    params = _mapping(config.get("parameters"))
     for key in params:
-        if 'cross_section' in key:
-            return 'cross_sectional_rank'
-        if 'rank' in key:
-            return 'rank'
+        if "cross_section" in key:
+            return "cross_sectional_rank"
+        if "rank" in key:
+            return "rank"
     if template.entry_motifs:
         return template.entry_motifs[0]
-    return 'none'
+    return "none"
 
 
 def _infer_rank_count(config: Mapping[str, Any]) -> int:
-    for key in ('max_entries_per_session', 'rank_count'):
+    for key in (
+        "max_entries_per_session",
+        "max_concurrent_positions",
+        "max_pair_legs",
+        "top_n",
+        "rank_count",
+    ):
         value = _param_value(config, key)
         if value is not None:
             try:
                 return max(1, int(float(str(value))))
             except ValueError:
                 continue
+    universe = _override_value(config, "universe_symbols")
+    if isinstance(universe, list):
+        universe_values = cast(list[Any], universe)
+        return max(1, len([item for item in universe_values if _string(item)]))
     return 1
 
 
-def _infer_budget(value: Any, default: str = '0') -> str:
+def _infer_budget(value: Any, default: str = "0") -> str:
     normalized = _string(value)
     return normalized or default
 
 
-def _capital_budget_payload(config: Mapping[str, Any], *, rank_count: int) -> dict[str, Any]:
+def _capital_budget_payload(
+    config: Mapping[str, Any], *, rank_count: int
+) -> dict[str, Any]:
     estimate = estimate_capital_budget(
-        strategy_overrides=_mapping(config.get('strategy_overrides')),
-        params=_mapping(config.get('parameters')),
+        strategy_overrides=_mapping(config.get("strategy_overrides")),
+        params=_mapping(config.get("parameters")),
         rank_count_floor=rank_count,
     )
     return {
-        'max_position_pct_equity': _format_float(estimate.max_position_pct_equity),
-        'configured_max_gross_exposure_pct_equity': _format_float(
+        "max_position_pct_equity": _format_float(estimate.max_position_pct_equity),
+        "configured_max_gross_exposure_pct_equity": _format_float(
             estimate.configured_max_gross_exposure_pct_equity
         ),
-        'estimated_max_gross_exposure_pct_equity': _format_float(
+        "estimated_max_gross_exposure_pct_equity": _format_float(
             estimate.estimated_max_gross_exposure_pct_equity
         ),
-        'capital_budget_overage_ratio': _format_float(
+        "capital_budget_overage_ratio": _format_float(
             estimate.capital_budget_overage_ratio
         ),
-        'capital_feasible': bool(estimate.capital_feasible_flag),
+        "capital_feasible": bool(estimate.capital_feasible_flag),
     }
 
 
 def _descriptor_id(payload: Mapping[str, Any]) -> str:
     digest = hashlib.sha256(
-        json.dumps(payload, sort_keys=True, separators=(',', ':')).encode('utf-8')
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
     ).hexdigest()
-    return f'desc-{digest[:24]}'
+    return f"desc-{digest[:24]}"
 
 
 @dataclass(frozen=True)
@@ -193,41 +207,41 @@ class MlxCandidateDescriptor:
     requires_quote_quality_gate: bool
     expected_fill_mode: str
     approval_path: str
-    max_position_pct_equity: str = '0'
-    configured_max_gross_exposure_pct_equity: str = '0'
-    estimated_max_gross_exposure_pct_equity: str = '0'
-    capital_budget_overage_ratio: str = '0'
+    max_position_pct_equity: str = "0"
+    configured_max_gross_exposure_pct_equity: str = "0"
+    estimated_max_gross_exposure_pct_equity: str = "0"
+    capital_budget_overage_ratio: str = "0"
     capital_feasible: bool = True
 
     def to_payload(self) -> dict[str, Any]:
         return {
-            'descriptor_id': self.descriptor_id,
-            'candidate_id': self.candidate_id,
-            'family_template_id': self.family_template_id,
-            'runtime_family': self.runtime_family,
-            'strategy_name': self.strategy_name,
-            'side_policy': self.side_policy,
-            'entry_window_start_minute': self.entry_window_start_minute,
-            'entry_window_end_minute': self.entry_window_end_minute,
-            'max_hold_minutes': self.max_hold_minutes,
-            'entry_type': self.entry_type,
-            'exit_type': self.exit_type,
-            'rank_policy': self.rank_policy,
-            'rank_count': self.rank_count,
-            'gross_budget_usd': self.gross_budget_usd,
-            'per_leg_budget_usd': self.per_leg_budget_usd,
-            'normalization_regime': self.normalization_regime,
-            'regime_gate_id': self.regime_gate_id,
-            'requires_prev_day_features': self.requires_prev_day_features,
-            'requires_cross_sectional_features': self.requires_cross_sectional_features,
-            'requires_quote_quality_gate': self.requires_quote_quality_gate,
-            'expected_fill_mode': self.expected_fill_mode,
-            'approval_path': self.approval_path,
-            'max_position_pct_equity': self.max_position_pct_equity,
-            'configured_max_gross_exposure_pct_equity': self.configured_max_gross_exposure_pct_equity,
-            'estimated_max_gross_exposure_pct_equity': self.estimated_max_gross_exposure_pct_equity,
-            'capital_budget_overage_ratio': self.capital_budget_overage_ratio,
-            'capital_feasible': self.capital_feasible,
+            "descriptor_id": self.descriptor_id,
+            "candidate_id": self.candidate_id,
+            "family_template_id": self.family_template_id,
+            "runtime_family": self.runtime_family,
+            "strategy_name": self.strategy_name,
+            "side_policy": self.side_policy,
+            "entry_window_start_minute": self.entry_window_start_minute,
+            "entry_window_end_minute": self.entry_window_end_minute,
+            "max_hold_minutes": self.max_hold_minutes,
+            "entry_type": self.entry_type,
+            "exit_type": self.exit_type,
+            "rank_policy": self.rank_policy,
+            "rank_count": self.rank_count,
+            "gross_budget_usd": self.gross_budget_usd,
+            "per_leg_budget_usd": self.per_leg_budget_usd,
+            "normalization_regime": self.normalization_regime,
+            "regime_gate_id": self.regime_gate_id,
+            "requires_prev_day_features": self.requires_prev_day_features,
+            "requires_cross_sectional_features": self.requires_cross_sectional_features,
+            "requires_quote_quality_gate": self.requires_quote_quality_gate,
+            "expected_fill_mode": self.expected_fill_mode,
+            "approval_path": self.approval_path,
+            "max_position_pct_equity": self.max_position_pct_equity,
+            "configured_max_gross_exposure_pct_equity": self.configured_max_gross_exposure_pct_equity,
+            "estimated_max_gross_exposure_pct_equity": self.estimated_max_gross_exposure_pct_equity,
+            "capital_budget_overage_ratio": self.capital_budget_overage_ratio,
+            "capital_feasible": self.capital_feasible,
         }
 
 
@@ -241,50 +255,65 @@ def descriptor_from_sweep_config(
     runtime = _mapping(template.runtime_harness)
     start_minute = _infer_entry_window_start(sweep_config)
     end_minute = _infer_entry_window_end(sweep_config, start_minute)
-    runtime_family = _string(runtime.get('family'))
-    strategy_name = _string(runtime.get('strategy_name'))
+    runtime_family = _string(runtime.get("family"))
+    strategy_name = _string(runtime.get("strategy_name"))
     side_policy = _infer_side_policy(template)
     max_hold_minutes = _infer_max_hold_minutes(sweep_config, start_minute, end_minute)
-    entry_type = template.entry_motifs[0] if template.entry_motifs else 'unknown'
-    exit_type = template.exit_motifs[0] if template.exit_motifs else 'unknown'
+    entry_type = template.entry_motifs[0] if template.entry_motifs else "unknown"
+    exit_type = template.exit_motifs[0] if template.exit_motifs else "unknown"
     rank_policy = _infer_rank_policy(sweep_config, template)
     rank_count = _infer_rank_count(sweep_config)
-    gross_budget_usd = _infer_budget(_override_value(sweep_config, 'max_notional_per_trade'))
-    per_leg_budget_usd = _infer_budget(_override_value(sweep_config, 'max_notional_per_trade'))
+    gross_budget_usd = _infer_budget(
+        _override_value(sweep_config, "max_notional_per_trade")
+    )
+    per_leg_budget_usd = _infer_budget(
+        _override_value(sweep_config, "max_notional_per_trade")
+    )
     capital_budget = _capital_budget_payload(sweep_config, rank_count=rank_count)
-    normalization_regime = _string(_override_value(sweep_config, 'normalization_regime')) or 'runtime_default'
+    normalization_regime = (
+        _string(_override_value(sweep_config, "normalization_regime"))
+        or "runtime_default"
+    )
     regime_gate_id = (
-        _string(template.regime_activation_rules[0].get('rule_id')) if template.regime_activation_rules else 'none'
+        _string(template.regime_activation_rules[0].get("rule_id"))
+        if template.regime_activation_rules
+        else "none"
     )
     requires_prev_day_features = any(
-        term in feature for feature in template.required_features for term in ('prev_day', 'prior_day')
+        term in feature
+        for feature in template.required_features
+        for term in ("prev_day", "prior_day")
     )
-    requires_cross_sectional_features = any('cross_section' in feature for feature in template.required_features)
+    requires_cross_sectional_features = any(
+        "cross_section" in feature for feature in template.required_features
+    )
     requires_quote_quality_gate = bool(template.liquidity_assumptions)
-    expected_fill_mode = _string(_override_value(sweep_config, 'entry_order_type')) or 'runtime_default'
-    approval_path = 'scheduler_v3'
+    expected_fill_mode = (
+        _string(_override_value(sweep_config, "entry_order_type")) or "runtime_default"
+    )
+    approval_path = "scheduler_v3"
     descriptor_payload: dict[str, Any] = {
-        'candidate_id': candidate_id,
-        'family_template_id': template.family_id,
-        'runtime_family': runtime_family,
-        'strategy_name': strategy_name,
-        'side_policy': side_policy,
-        'entry_window_start_minute': start_minute,
-        'entry_window_end_minute': end_minute,
-        'max_hold_minutes': max_hold_minutes,
-        'entry_type': entry_type,
-        'exit_type': exit_type,
-        'rank_policy': rank_policy,
-        'rank_count': rank_count,
-        'gross_budget_usd': gross_budget_usd,
-        'per_leg_budget_usd': per_leg_budget_usd,
-        'normalization_regime': normalization_regime,
-        'regime_gate_id': regime_gate_id,
-        'requires_prev_day_features': requires_prev_day_features,
-        'requires_cross_sectional_features': requires_cross_sectional_features,
-        'requires_quote_quality_gate': requires_quote_quality_gate,
-        'expected_fill_mode': expected_fill_mode,
-        'approval_path': approval_path,
+        "candidate_id": candidate_id,
+        "family_template_id": template.family_id,
+        "runtime_family": runtime_family,
+        "strategy_name": strategy_name,
+        "side_policy": side_policy,
+        "entry_window_start_minute": start_minute,
+        "entry_window_end_minute": end_minute,
+        "max_hold_minutes": max_hold_minutes,
+        "entry_type": entry_type,
+        "exit_type": exit_type,
+        "rank_policy": rank_policy,
+        "rank_count": rank_count,
+        "gross_budget_usd": gross_budget_usd,
+        "per_leg_budget_usd": per_leg_budget_usd,
+        "normalization_regime": normalization_regime,
+        "regime_gate_id": regime_gate_id,
+        "requires_prev_day_features": requires_prev_day_features,
+        "requires_cross_sectional_features": requires_cross_sectional_features,
+        "requires_quote_quality_gate": requires_quote_quality_gate,
+        "expected_fill_mode": expected_fill_mode,
+        "approval_path": approval_path,
         **capital_budget,
     }
     return MlxCandidateDescriptor(
@@ -310,11 +339,17 @@ def descriptor_from_sweep_config(
         requires_quote_quality_gate=requires_quote_quality_gate,
         expected_fill_mode=expected_fill_mode,
         approval_path=approval_path,
-        max_position_pct_equity=str(capital_budget['max_position_pct_equity']),
-        configured_max_gross_exposure_pct_equity=str(capital_budget['configured_max_gross_exposure_pct_equity']),
-        estimated_max_gross_exposure_pct_equity=str(capital_budget['estimated_max_gross_exposure_pct_equity']),
-        capital_budget_overage_ratio=str(capital_budget['capital_budget_overage_ratio']),
-        capital_feasible=bool(capital_budget['capital_feasible']),
+        max_position_pct_equity=str(capital_budget["max_position_pct_equity"]),
+        configured_max_gross_exposure_pct_equity=str(
+            capital_budget["configured_max_gross_exposure_pct_equity"]
+        ),
+        estimated_max_gross_exposure_pct_equity=str(
+            capital_budget["estimated_max_gross_exposure_pct_equity"]
+        ),
+        capital_budget_overage_ratio=str(
+            capital_budget["capital_budget_overage_ratio"]
+        ),
+        capital_feasible=bool(capital_budget["capital_feasible"]),
     )
 
 
@@ -323,13 +358,13 @@ def descriptor_from_candidate_payload(
     candidate_payload: Mapping[str, Any],
     family_plan: FamilyAutoresearchPlan,
 ) -> MlxCandidateDescriptor:
-    replay_config = _mapping(candidate_payload.get('replay_config'))
+    replay_config = _mapping(candidate_payload.get("replay_config"))
     compiled_config = {
-        'parameters': _mapping(replay_config.get('params')),
-        'strategy_overrides': _mapping(replay_config.get('strategy_overrides')),
+        "parameters": _mapping(replay_config.get("params")),
+        "strategy_overrides": _mapping(replay_config.get("strategy_overrides")),
     }
     return descriptor_from_sweep_config(
-        candidate_id=_string(candidate_payload.get('candidate_id')) or 'candidate',
+        candidate_id=_string(candidate_payload.get("candidate_id")) or "candidate",
         family_plan=family_plan,
         sweep_config=compiled_config,
     )

--- a/services/torghut/app/trading/discovery/mlx_proposal_models.py
+++ b/services/torghut/app/trading/discovery/mlx_proposal_models.py
@@ -219,6 +219,37 @@ def _heuristic_scores_from_history(
     ]
 
 
+def _cold_start_capital_prior_scores(
+    *,
+    descriptors: Sequence[MlxCandidateDescriptor],
+    backend: str,
+) -> list[ProposalScore]:
+    scored: list[tuple[MlxCandidateDescriptor, float]] = []
+    for descriptor in descriptors:
+        capital_overage = _float(descriptor.capital_budget_overage_ratio)
+        estimated_gross = _float(descriptor.estimated_max_gross_exposure_pct_equity)
+        configured_gross = _float(descriptor.configured_max_gross_exposure_pct_equity)
+        score = (
+            (100.0 if descriptor.capital_feasible else -100.0)
+            - (capital_overage * 1000.0)
+            - (max(0.0, estimated_gross - 1.0) * 100.0)
+            - (max(0.0, configured_gross - 1.0) * 100.0)
+        )
+        scored.append((descriptor, score))
+    ordered = sorted(scored, key=lambda item: (-item[1], item[0].candidate_id))
+    return [
+        ProposalScore(
+            candidate_id=descriptor.candidate_id,
+            descriptor_id=descriptor.descriptor_id,
+            score=score,
+            rank=index,
+            backend=backend,
+            mode="ranking_only_cold_start_capital_prior",
+        )
+        for index, (descriptor, score) in enumerate(ordered, start=1)
+    ]
+
+
 def _descriptor_by_candidate(
     descriptors: Sequence[MlxCandidateDescriptor],
 ) -> dict[str, MlxCandidateDescriptor]:
@@ -399,7 +430,10 @@ def select_proposal_batch(
             if not descriptor.capital_feasible:
                 capital_penalty += 10000.0
             combined = (
-                family_bonus + side_bonus + diversity_bonus + (score.score * 0.001)
+                family_bonus
+                + side_bonus
+                + diversity_bonus
+                + (score.score * 0.001)
                 - capital_penalty
             )
             candidate = (combined, score, descriptor)
@@ -576,17 +610,10 @@ def rank_candidate_descriptors(
         xp, [descriptor_numeric_vector(item) for item in descriptors]
     )
     if len(history_rows) < policy.minimum_history_rows:
-        return [
-            ProposalScore(
-                candidate_id=descriptor.candidate_id,
-                descriptor_id=descriptor.descriptor_id,
-                score=0.0,
-                rank=index + 1,
-                backend=backend_name,
-                mode=policy.mode,
-            )
-            for index, descriptor in enumerate(descriptors)
-        ]
+        return _cold_start_capital_prior_scores(
+            descriptors=descriptors,
+            backend=backend_name,
+        )
 
     history_vectors: list[list[float]] = []
     history_targets: list[float] = []

--- a/services/torghut/app/trading/discovery/mlx_training_data.py
+++ b/services/torghut/app/trading/discovery/mlx_training_data.py
@@ -158,17 +158,88 @@ def _positive_or_default(value: float, default: float) -> float:
     return value if value > 0.0 else default
 
 
+def _sequence_length(value: Any) -> float:
+    if isinstance(value, Sequence) and not isinstance(value, str):
+        return float(len(cast(Sequence[Any], value)))
+    return 0.0
+
+
+def _params(spec: CandidateSpec) -> Mapping[str, Any]:
+    overrides = _mapping(spec.strategy_overrides)
+    return _mapping(overrides.get("params"))
+
+
+def _strategy_universe_size(spec: CandidateSpec) -> float:
+    overrides = _mapping(spec.strategy_overrides)
+    return _sequence_length(overrides.get("universe_symbols"))
+
+
+def _bool_feature(value: Any, expected: str) -> float:
+    return 1.0 if str(value or "").strip().lower() == expected else 0.0
+
+
+def _hard_veto_count(scorecard: Mapping[str, Any]) -> float:
+    raw_vetoes = scorecard.get("hard_vetoes") or scorecard.get("veto_reasons")
+    if isinstance(raw_vetoes, str):
+        return 1.0 if raw_vetoes.strip() else 0.0
+    return _sequence_length(raw_vetoes)
+
+
+def _daily_target_shortfall(
+    scorecard: Mapping[str, Any], *, target_net_pnl_per_day: float
+) -> float:
+    raw_daily = scorecard.get("daily_net")
+    if not isinstance(raw_daily, Mapping):
+        return max(
+            0.0, target_net_pnl_per_day - _float(scorecard.get("net_pnl_per_day"))
+        )
+    shortfalls = [
+        max(0.0, target_net_pnl_per_day - _float(value))
+        for value in cast(Mapping[Any, Any], raw_daily).values()
+    ]
+    return _mean(shortfalls)
+
+
+def _sequence_strings(value: Any) -> tuple[str, ...]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        return ()
+    return tuple(
+        str(item).strip() for item in cast(Sequence[Any], value) if str(item).strip()
+    )
+
+
+def _capital_rank_count_floor(
+    *, strategy_overrides: Mapping[str, Any], params: Mapping[str, Any]
+) -> int:
+    for key in (
+        "max_entries_per_session",
+        "max_concurrent_positions",
+        "max_pair_legs",
+        "top_n",
+        "rank_count",
+    ):
+        if _float(params.get(key)) > 0:
+            return 1
+    return max(1, len(_sequence_strings(strategy_overrides.get("universe_symbols"))))
+
+
 def candidate_spec_capital_features(spec: CandidateSpec) -> Mapping[str, float]:
     overrides = _mapping(spec.strategy_overrides)
     params = _mapping(overrides.get("params"))
+    rank_count_floor = _capital_rank_count_floor(
+        strategy_overrides=overrides,
+        params=params,
+    )
     features = estimate_capital_budget(
         strategy_overrides=overrides,
         params=params,
+        rank_count_floor=rank_count_floor,
     ).to_feature_payload()
     features["max_entries_per_session"] = _positive_or_default(
         _float(params.get("max_entries_per_session")),
         1.0,
     )
+    features["inferred_universe_slot_floor"] = float(rank_count_floor)
     return features
 
 
@@ -176,15 +247,13 @@ def capital_budget_penalty(features: Mapping[str, float]) -> float:
     return (
         _float(features.get("capital_budget_overage_ratio")) * 125.0
         + max(0.0, _float(features.get("max_position_pct_equity")) - 1.0) * 35.0
-        + max(0.0, _float(features.get("max_notional_pct_start_equity")) - 1.0)
-        * 35.0
+        + max(0.0, _float(features.get("max_notional_pct_start_equity")) - 1.0) * 35.0
     )
 
 
 def observed_capital_penalty(scorecard: Mapping[str, Any]) -> float:
     return (
-        max(0.0, _float(scorecard.get("max_gross_exposure_pct_equity")) - 1.0)
-        * 500.0
+        max(0.0, _float(scorecard.get("max_gross_exposure_pct_equity")) - 1.0) * 500.0
         + max(0.0, -_float(scorecard.get("min_cash"))) / 100.0
         + _float(scorecard.get("negative_cash_observation_count")) * 20.0
     )
@@ -249,6 +318,23 @@ def build_mlx_training_rows(
             "required_feature_count",
             "failure_mode_count",
             "target_net_pnl_per_day",
+            "entry_minute_after_open",
+            "exit_minute_after_open",
+            "max_hold_seconds",
+            "entry_cooldown_seconds",
+            "stop_loss_bps",
+            "trailing_activation_profit_bps",
+            "trailing_drawdown_bps",
+            "rank_count",
+            "universe_size",
+            "selection_mode_reversal",
+            "selection_mode_continuation",
+            "selection_mode_momentum",
+            "selection_mode_pullback",
+            "signal_motif_open_window_reversal",
+            "signal_motif_open_window_continuation",
+            "signal_motif_late_day",
+            "signal_motif_washout",
             "max_notional_per_trade",
             "max_notional_pct_start_equity",
             "max_position_pct_equity",
@@ -263,13 +349,55 @@ def build_mlx_training_rows(
             "history_max_gross_exposure_pct_equity",
             "history_min_cash",
             "history_negative_cash_observation_count",
+            "history_negative_day_count",
+            "history_best_day_share",
+            "history_worst_day_loss",
+            "history_max_drawdown",
+            "history_avg_filled_notional_per_day",
+            "history_hard_veto_count",
+            "history_daily_target_shortfall",
         )
         capital_features = candidate_spec_capital_features(spec)
+        params = _params(spec)
+        target_net_pnl_per_day = _float(spec.objective.get("target_net_pnl_per_day"))
+        selection_mode = params.get("selection_mode")
+        signal_motif = params.get("signal_motif")
+        stop_loss_bps = _float(
+            params.get("long_stop_loss_bps")
+            or params.get("short_stop_loss_bps")
+            or params.get("stop_loss_bps")
+        )
         feature_values = (
             _family_code(spec.family_template_id),
             float(len(spec.feature_contract.get("required_features") or [])),
             float(len(spec.expected_failure_modes)),
-            _float(spec.objective.get("target_net_pnl_per_day")),
+            target_net_pnl_per_day,
+            _float(params.get("entry_minute_after_open")),
+            _float(params.get("exit_minute_after_open")),
+            _float(params.get("max_hold_seconds")),
+            _float(params.get("entry_cooldown_seconds")),
+            stop_loss_bps,
+            _float(
+                params.get("long_trailing_stop_activation_profit_bps")
+                or params.get("short_trailing_stop_activation_profit_bps")
+            ),
+            _float(
+                params.get("long_trailing_stop_drawdown_bps")
+                or params.get("short_trailing_stop_drawdown_bps")
+            ),
+            _positive_or_default(
+                _float(params.get("top_n") or params.get("rank_count")),
+                _positive_or_default(_float(params.get("max_pair_legs")), 1.0),
+            ),
+            _strategy_universe_size(spec),
+            _bool_feature(selection_mode, "reversal"),
+            _bool_feature(selection_mode, "continuation"),
+            _bool_feature(selection_mode, "momentum"),
+            _bool_feature(selection_mode, "pullback"),
+            _bool_feature(signal_motif, "open_window_reversal"),
+            _bool_feature(signal_motif, "open_window_continuation"),
+            _bool_feature(signal_motif, "late_day_continuation"),
+            _bool_feature(signal_motif, "washout_rebound"),
             _float(capital_features.get("max_notional_per_trade")),
             _float(capital_features.get("max_notional_pct_start_equity")),
             _float(capital_features.get("max_position_pct_equity")),
@@ -284,11 +412,31 @@ def build_mlx_training_rows(
             _float(scorecard.get("max_gross_exposure_pct_equity")),
             _float(scorecard.get("min_cash")),
             _float(scorecard.get("negative_cash_observation_count")),
+            _float(scorecard.get("negative_day_count")),
+            _float(scorecard.get("best_day_share")),
+            _float(scorecard.get("worst_day_loss")),
+            _float(scorecard.get("max_drawdown")),
+            _float(scorecard.get("avg_filled_notional_per_day")),
+            _hard_veto_count(scorecard),
+            _daily_target_shortfall(
+                scorecard, target_net_pnl_per_day=target_net_pnl_per_day
+            ),
         )
         target = (
             _float(scorecard.get("net_pnl_per_day"))
             + (_float(scorecard.get("active_day_ratio")) * 100.0)
-            + (_float(scorecard.get("positive_day_ratio")) * 50.0)
+            + (_float(scorecard.get("positive_day_ratio")) * 100.0)
+            - (_float(scorecard.get("negative_day_count")) * 100.0)
+            - (_float(scorecard.get("best_day_share")) * 200.0)
+            - (_float(scorecard.get("worst_day_loss")) * 0.50)
+            - (_float(scorecard.get("max_drawdown")) * 0.10)
+            - (_hard_veto_count(scorecard) * 250.0)
+            - (
+                _daily_target_shortfall(
+                    scorecard, target_net_pnl_per_day=target_net_pnl_per_day
+                )
+                * 0.10
+            )
             - capital_budget_penalty(capital_features)
             - observed_capital_penalty(scorecard)
         )

--- a/services/torghut/app/trading/discovery/portfolio_optimizer.py
+++ b/services/torghut/app/trading/discovery/portfolio_optimizer.py
@@ -21,7 +21,27 @@ from app.trading.discovery.profit_target_oracle import ProfitTargetOraclePolicy
 MAX_CLUSTER_CONTRIBUTION_SHARE = Decimal("0.40")
 MAX_SINGLE_SYMBOL_CONTRIBUTION_SHARE = Decimal("0.35")
 MAX_ALLOWED_PAIRWISE_CORRELATION = Decimal("0.85")
+MAX_PORTFOLIO_GROSS_EXPOSURE_PCT_EQUITY = Decimal("1.0")
 PORTFOLIO_SEARCH_BEAM_WIDTH = 256
+PORTFOLIO_COMPOSABLE_SINGLE_SLEEVE_VETOES = frozenset(
+    {
+        "active_day_ratio_below_min",
+        "active_day_ratio_below_oracle",
+        "avg_daily_notional_below_min",
+        "avg_filled_notional_per_day_below_oracle",
+        "best_day_share_above_max",
+        "best_day_share_above_oracle",
+        "daily_net_below_min",
+        "max_drawdown_above_max",
+        "max_drawdown_above_oracle",
+        "positive_day_ratio_below_oracle",
+        "train_active_ratio_below_screen",
+        "train_net_per_day_below_screen",
+        "train_worst_day_loss_above_screen",
+        "worst_day_loss_above_max",
+        "worst_day_loss_above_oracle",
+    }
+)
 
 
 def _decimal(value: Any, *, default: str = "0") -> Decimal:
@@ -69,6 +89,24 @@ def _worst_day_loss(bundle: CandidateEvidenceBundle) -> Decimal:
     return _decimal(_scorecard(bundle).get("worst_day_loss"))
 
 
+def _max_gross_exposure_pct_equity(bundle: CandidateEvidenceBundle) -> Decimal:
+    return _decimal(_scorecard(bundle).get("max_gross_exposure_pct_equity"))
+
+
+def _min_cash(bundle: CandidateEvidenceBundle) -> Decimal:
+    return _decimal(_scorecard(bundle).get("min_cash"))
+
+
+def _negative_cash_observation_count(bundle: CandidateEvidenceBundle) -> int:
+    try:
+        return max(
+            0,
+            int(_decimal(_scorecard(bundle).get("negative_cash_observation_count"))),
+        )
+    except Exception:
+        return 0
+
+
 def _hard_vetoes(bundle: CandidateEvidenceBundle) -> tuple[str, ...]:
     raw_hard_vetoes = _scorecard(bundle).get("hard_vetoes")
     if isinstance(raw_hard_vetoes, str):
@@ -83,10 +121,52 @@ def _hard_vetoes(bundle: CandidateEvidenceBundle) -> tuple[str, ...]:
     return tuple(vetoes)
 
 
+def _non_composable_hard_vetoes(bundle: CandidateEvidenceBundle) -> tuple[str, ...]:
+    return tuple(
+        veto
+        for veto in _hard_vetoes(bundle)
+        if veto not in PORTFOLIO_COMPOSABLE_SINGLE_SLEEVE_VETOES
+    )
+
+
+def _capital_safety_rejection(
+    bundle: CandidateEvidenceBundle,
+) -> dict[str, Any] | None:
+    max_gross = _max_gross_exposure_pct_equity(bundle)
+    min_cash = _min_cash(bundle)
+    negative_cash_observations = _negative_cash_observation_count(bundle)
+    if max_gross > MAX_PORTFOLIO_GROSS_EXPOSURE_PCT_EQUITY:
+        return {
+            "candidate_id": bundle.candidate_id,
+            "reason": "frontier_capital_violation",
+            "max_gross_exposure_pct_equity": str(max_gross),
+            "limit": str(MAX_PORTFOLIO_GROSS_EXPOSURE_PCT_EQUITY),
+        }
+    if min_cash < 0:
+        return {
+            "candidate_id": bundle.candidate_id,
+            "reason": "frontier_negative_cash",
+            "min_cash": str(min_cash),
+        }
+    if negative_cash_observations > 0:
+        return {
+            "candidate_id": bundle.candidate_id,
+            "reason": "frontier_negative_cash_observed",
+            "negative_cash_observation_count": negative_cash_observations,
+        }
+    return None
+
+
 def _candidate_passes_minimums(bundle: CandidateEvidenceBundle) -> bool:
     if not evidence_bundle_is_valid(bundle):
         return False
-    if _hard_vetoes(bundle):
+    if _non_composable_hard_vetoes(bundle):
+        return False
+    if _capital_safety_rejection(bundle) is not None:
+        return False
+    if _net_per_day(bundle) <= 0:
+        return False
+    if _active_ratio(bundle) <= 0 or _positive_ratio(bundle) <= 0:
         return False
     if bool(bundle.promotion_readiness.get("promotable")):
         return True
@@ -99,7 +179,7 @@ def _candidate_passes_minimums(bundle: CandidateEvidenceBundle) -> bool:
     }
     if blocking - allowed_blockers:
         return False
-    return _net_per_day(bundle) > 0 and _active_ratio(bundle) >= Decimal("0.50")
+    return True
 
 
 def _daily_net(bundle: CandidateEvidenceBundle) -> dict[str, Decimal]:
@@ -309,6 +389,25 @@ def _max_drawdown_from_daily(daily_net: Mapping[str, Decimal]) -> Decimal:
     return drawdown
 
 
+def _portfolio_max_gross_exposure_pct_equity(
+    selected: Sequence[CandidateEvidenceBundle],
+) -> Decimal:
+    return sum(
+        (_max_gross_exposure_pct_equity(bundle) for bundle in selected),
+        Decimal("0"),
+    )
+
+
+def _portfolio_min_cash(selected: Sequence[CandidateEvidenceBundle]) -> Decimal:
+    return min((_min_cash(bundle) for bundle in selected), default=Decimal("0"))
+
+
+def _portfolio_negative_cash_observation_count(
+    selected: Sequence[CandidateEvidenceBundle],
+) -> int:
+    return sum(_negative_cash_observation_count(bundle) for bundle in selected)
+
+
 def _portfolio_trading_day_count(
     selected: Sequence[CandidateEvidenceBundle],
     daily_net: Mapping[str, Decimal],
@@ -388,6 +487,13 @@ def _portfolio_scorecard(
         "positive_day_ratio": str(positive_day_ratio),
         "worst_day_loss": str(worst_day_loss),
         "max_drawdown": str(_max_drawdown_from_daily(daily_net)),
+        "max_gross_exposure_pct_equity": str(
+            _portfolio_max_gross_exposure_pct_equity(selected)
+        ),
+        "min_cash": str(_portfolio_min_cash(selected)),
+        "negative_cash_observation_count": _portfolio_negative_cash_observation_count(
+            selected
+        ),
         "best_day_share": str(best_day_share),
         "max_single_day_contribution_share": str(best_day_share),
         "cluster_contribution_shares": {
@@ -463,6 +569,9 @@ def _portfolio_selection_key(
         -_scorecard_decimal(scorecard, "best_day_share"),
         -_scorecard_decimal(scorecard, "max_single_symbol_contribution_share"),
         -_scorecard_decimal(scorecard, "max_cluster_contribution_share"),
+        -_scorecard_decimal(scorecard, "max_gross_exposure_pct_equity"),
+        _scorecard_decimal(scorecard, "min_cash"),
+        -_scorecard_decimal(scorecard, "negative_cash_observation_count"),
         -_scorecard_decimal(scorecard, "worst_day_loss"),
         -_scorecard_decimal(scorecard, "max_drawdown"),
         Decimal(len(selected)),
@@ -487,6 +596,9 @@ def _partial_selection_key(
             Decimal("0"),
             Decimal("0"),
             Decimal("0"),
+            Decimal("0"),
+            Decimal("0"),
+            Decimal("0"),
         )
     return (
         Decimal("0"),
@@ -497,6 +609,9 @@ def _partial_selection_key(
         -max((_best_day_share(bundle) for bundle in selected), default=Decimal("0")),
         -_max_share(_symbol_contribution_shares(selected)),
         -_max_share(_cluster_contribution_shares(selected)),
+        -_portfolio_max_gross_exposure_pct_equity(selected),
+        _portfolio_min_cash(selected),
+        Decimal(-_portfolio_negative_cash_observation_count(selected)),
         -max((_worst_day_loss(bundle) for bundle in selected), default=Decimal("0")),
         -max((_max_drawdown(bundle) for bundle in selected), default=Decimal("0")),
         Decimal(len(selected)),
@@ -670,11 +785,20 @@ def optimize_portfolio_candidate(
     hard_veto_rejections = [
         {
             "candidate_id": bundle.candidate_id,
-            "reason": "frontier_hard_veto",
-            "hard_vetoes": list(_hard_vetoes(bundle)),
+            "reason": "frontier_non_composable_hard_veto",
+            "hard_vetoes": list(_non_composable_hard_vetoes(bundle)),
         }
         for bundle in evidence_bundles
-        if evidence_bundle_is_valid(bundle) and _hard_vetoes(bundle)
+        if evidence_bundle_is_valid(bundle) and _non_composable_hard_vetoes(bundle)
+    ]
+    capital_safety_rejections = [
+        rejection
+        for rejection in (
+            _capital_safety_rejection(bundle)
+            for bundle in evidence_bundles
+            if evidence_bundle_is_valid(bundle)
+        )
+        if rejection is not None
     ]
     eligible = [
         bundle for bundle in evidence_bundles if _candidate_passes_minimums(bundle)
@@ -687,6 +811,7 @@ def optimize_portfolio_candidate(
     rejected: list[dict[str, Any]] = [
         *invalid_evidence_rejections,
         *hard_veto_rejections,
+        *capital_safety_rejections,
     ]
     max_allowed_correlation = MAX_ALLOWED_PAIRWISE_CORRELATION
     selection_result = _select_portfolio_bundles(

--- a/services/torghut/app/trading/discovery/profit_target_oracle.py
+++ b/services/torghut/app/trading/discovery/profit_target_oracle.py
@@ -20,6 +20,9 @@ class ProfitTargetOraclePolicy:
     max_single_symbol_contribution_share: Decimal = Decimal("0.35")
     max_worst_day_loss: Decimal = Decimal("350")
     max_drawdown: Decimal = Decimal("900")
+    max_gross_exposure_pct_equity: Decimal = Decimal("1.0")
+    min_cash: Decimal = Decimal("0")
+    max_negative_cash_observation_count: int = 0
     min_avg_filled_notional_per_day: Decimal = Decimal("300000")
     min_regime_slice_pass_rate: Decimal = Decimal("0.45")
     min_posterior_edge_lower: Decimal = Decimal("0")
@@ -40,6 +43,9 @@ class ProfitTargetOraclePolicy:
             ),
             "max_worst_day_loss": str(self.max_worst_day_loss),
             "max_drawdown": str(self.max_drawdown),
+            "max_gross_exposure_pct_equity": str(self.max_gross_exposure_pct_equity),
+            "min_cash": str(self.min_cash),
+            "max_negative_cash_observation_count": self.max_negative_cash_observation_count,
             "min_avg_filled_notional_per_day": str(
                 self.min_avg_filled_notional_per_day
             ),
@@ -129,7 +135,10 @@ def evaluate_profit_target_oracle(
     )
     if trading_day_count < daily_net_observed_day_count:
         trading_day_count = daily_net_observed_day_count
-    if policy.min_daily_net_pnl > 0 and daily_net_observed_day_count < trading_day_count:
+    if (
+        policy.min_daily_net_pnl > 0
+        and daily_net_observed_day_count < trading_day_count
+    ):
         min_daily_net_pnl = min(min_daily_net_pnl, Decimal("0"))
     checks = [
         _numeric_check(
@@ -206,6 +215,26 @@ def evaluate_profit_target_oracle(
             threshold=policy.max_drawdown,
         ),
         _numeric_check(
+            metric="max_gross_exposure_pct_equity",
+            observed=_decimal(scorecard.get("max_gross_exposure_pct_equity")),
+            operator="lte",
+            threshold=policy.max_gross_exposure_pct_equity,
+        ),
+        _numeric_check(
+            metric="min_cash",
+            observed=_decimal(scorecard.get("min_cash"), default=str(policy.min_cash)),
+            operator="gte",
+            threshold=policy.min_cash,
+        ),
+        _numeric_check(
+            metric="negative_cash_observation_count",
+            observed=Decimal(
+                _nonnegative_int(scorecard.get("negative_cash_observation_count"))
+            ),
+            operator="lte",
+            threshold=Decimal(max(0, policy.max_negative_cash_observation_count)),
+        ),
+        _numeric_check(
             metric="avg_filled_notional_per_day",
             observed=_decimal(scorecard.get("avg_filled_notional_per_day")),
             operator="gte",
@@ -246,7 +275,9 @@ def evaluate_profit_target_oracle(
     executable_artifact_ref = str(
         scorecard.get("executable_replay_artifact_ref") or ""
     ).strip()
-    executable_artifact_present = bool(executable_artifact_ref or executable_artifact_refs)
+    executable_artifact_present = bool(
+        executable_artifact_ref or executable_artifact_refs
+    )
     executable_passed = _boolish(scorecard.get("executable_replay_passed"))
     executable_order_count = _nonnegative_int(
         scorecard.get("executable_replay_order_count")

--- a/services/torghut/config/trading/research-programs/strict-daily-profit-autoresearch-500-v1.yaml
+++ b/services/torghut/config/trading/research-programs/strict-daily-profit-autoresearch-500-v1.yaml
@@ -156,7 +156,7 @@ families:
     max_iterations: 2
     keep_top_candidates: 2
     frontier_top_n: 5
-    force_keep_top_candidate_if_all_vetoed: true
+    force_keep_top_candidate_if_all_vetoed: false
     symbol_prune_iterations: 1
     symbol_prune_candidates: 2
     symbol_prune_min_universe_size: 4
@@ -185,7 +185,7 @@ families:
     max_iterations: 2
     keep_top_candidates: 2
     frontier_top_n: 5
-    force_keep_top_candidate_if_all_vetoed: true
+    force_keep_top_candidate_if_all_vetoed: false
     symbol_prune_iterations: 1
     symbol_prune_candidates: 2
     symbol_prune_min_universe_size: 4
@@ -214,7 +214,7 @@ families:
     max_iterations: 2
     keep_top_candidates: 2
     frontier_top_n: 5
-    force_keep_top_candidate_if_all_vetoed: true
+    force_keep_top_candidate_if_all_vetoed: false
     symbol_prune_iterations: 1
     symbol_prune_candidates: 2
     symbol_prune_min_universe_size: 3
@@ -243,7 +243,7 @@ families:
     max_iterations: 2
     keep_top_candidates: 2
     frontier_top_n: 5
-    force_keep_top_candidate_if_all_vetoed: true
+    force_keep_top_candidate_if_all_vetoed: false
     symbol_prune_iterations: 1
     symbol_prune_candidates: 2
     symbol_prune_min_universe_size: 5
@@ -273,7 +273,7 @@ families:
     max_iterations: 2
     keep_top_candidates: 2
     frontier_top_n: 5
-    force_keep_top_candidate_if_all_vetoed: true
+    force_keep_top_candidate_if_all_vetoed: false
     symbol_prune_iterations: 1
     symbol_prune_candidates: 2
     symbol_prune_min_universe_size: 5
@@ -308,7 +308,7 @@ families:
     max_iterations: 2
     keep_top_candidates: 2
     frontier_top_n: 5
-    force_keep_top_candidate_if_all_vetoed: true
+    force_keep_top_candidate_if_all_vetoed: false
     symbol_prune_iterations: 1
     symbol_prune_candidates: 2
     symbol_prune_min_universe_size: 5
@@ -343,7 +343,7 @@ families:
     max_iterations: 2
     keep_top_candidates: 1
     frontier_top_n: 4
-    force_keep_top_candidate_if_all_vetoed: true
+    force_keep_top_candidate_if_all_vetoed: false
     symbol_prune_iterations: 1
     symbol_prune_candidates: 1
     symbol_prune_min_universe_size: 5
@@ -375,7 +375,7 @@ families:
     max_iterations: 2
     keep_top_candidates: 2
     frontier_top_n: 5
-    force_keep_top_candidate_if_all_vetoed: true
+    force_keep_top_candidate_if_all_vetoed: false
     symbol_prune_iterations: 1
     symbol_prune_candidates: 2
     symbol_prune_min_universe_size: 5
@@ -405,7 +405,7 @@ families:
     max_iterations: 2
     keep_top_candidates: 2
     frontier_top_n: 5
-    force_keep_top_candidate_if_all_vetoed: true
+    force_keep_top_candidate_if_all_vetoed: false
     symbol_prune_iterations: 1
     symbol_prune_candidates: 2
     symbol_prune_min_universe_size: 3

--- a/services/torghut/scripts/run_strategy_autoresearch_loop.py
+++ b/services/torghut/scripts/run_strategy_autoresearch_loop.py
@@ -7,7 +7,7 @@ import argparse
 import json
 from dataclasses import dataclass
 from datetime import date
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation, ROUND_DOWN
 from pathlib import Path
 from typing import Any, Mapping, cast
 
@@ -25,6 +25,10 @@ from app.trading.discovery.autoresearch import (
     stable_payload_hash,
 )
 from app.trading.discovery.autoresearch_notebooks import write_autoresearch_notebooks
+from app.trading.discovery.evidence_bundles import (
+    CandidateEvidenceBundle,
+    evidence_bundle_from_frontier_candidate,
+)
 from app.trading.discovery.family_templates import family_template_dir
 from app.trading.discovery.mlx_features import (
     MlxCandidateDescriptor,
@@ -51,70 +55,85 @@ from app.trading.discovery.promotion_contract import (
     blocked_research_candidate_promotion_readiness,
     summary_promotion_readiness,
 )
+from app.trading.discovery.portfolio_candidates import PortfolioCandidateSpec
+from app.trading.discovery.portfolio_optimizer import optimize_portfolio_candidate
+from app.trading.discovery.profit_target_oracle import ProfitTargetOraclePolicy
 from app.trading.discovery.runtime_closure import write_runtime_closure_bundle
 from app.trading.discovery.runtime_closure import RuntimeClosureExecutionContext
 import scripts.local_intraday_tsmom_replay as replay_mod
-from scripts.search_consistent_profitability_frontier import run_consistent_profitability_frontier
+from scripts.search_consistent_profitability_frontier import (
+    run_consistent_profitability_frontier,
+)
 
 _REPO_ROOT = Path(__file__).resolve().parents[3]
+_CAPITAL_LIMIT_SAFETY_MULTIPLIER = Decimal("0.98")
 
 
 def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description='Run an autoresearch-style strategy discovery loop and emit notebooks.',
+        description="Run an autoresearch-style strategy discovery loop and emit notebooks.",
     )
     parser.add_argument(
-        '--program',
+        "--program",
         type=Path,
         required=True,
-        help='Path to the strategy autoresearch program YAML.',
+        help="Path to the strategy autoresearch program YAML.",
     )
     parser.add_argument(
-        '--output-dir',
+        "--output-dir",
         type=Path,
         required=True,
-        help='Directory that will receive a timestamped run folder.',
+        help="Directory that will receive a timestamped run folder.",
     )
     parser.add_argument(
-        '--strategy-configmap',
+        "--strategy-configmap",
         type=Path,
-        default=_REPO_ROOT / 'argocd/applications/torghut/strategy-configmap.yaml',
+        default=_REPO_ROOT / "argocd/applications/torghut/strategy-configmap.yaml",
     )
     parser.add_argument(
-        '--family-template-dir',
+        "--family-template-dir",
         type=Path,
         default=family_template_dir(),
     )
     parser.add_argument(
-        '--clickhouse-http-url',
-        default='http://torghut-clickhouse.torghut.svc.cluster.local:8123',
+        "--clickhouse-http-url",
+        default="http://torghut-clickhouse.torghut.svc.cluster.local:8123",
     )
-    parser.add_argument('--clickhouse-username', default='torghut')
-    parser.add_argument('--clickhouse-password', default='')
-    parser.add_argument('--start-equity', default='31590.02')
-    parser.add_argument('--chunk-minutes', type=int, default=10)
-    parser.add_argument('--symbols', default='')
-    parser.add_argument('--progress-log-seconds', type=int, default=30)
+    parser.add_argument("--clickhouse-username", default="torghut")
+    parser.add_argument("--clickhouse-password", default="")
+    parser.add_argument("--start-equity", default="31590.02")
+    parser.add_argument("--chunk-minutes", type=int, default=10)
+    parser.add_argument("--symbols", default="")
+    parser.add_argument("--progress-log-seconds", type=int, default=30)
     parser.add_argument(
-        '--shadow-validation-artifact',
+        "--shadow-validation-artifact",
         type=Path,
         default=None,
-        help='Optional path to an existing shadow-live-deviation-report-v1 artifact.',
+        help="Optional path to an existing shadow-live-deviation-report-v1 artifact.",
     )
-    parser.add_argument('--train-days', type=int, default=6)
-    parser.add_argument('--holdout-days', type=int, default=3)
-    parser.add_argument('--full-window-start-date', default='')
-    parser.add_argument('--full-window-end-date', default='')
-    parser.add_argument('--expected-last-trading-day', default='')
-    parser.add_argument('--allow-stale-tape', action='store_true')
-    parser.add_argument('--prefetch-full-window-rows', action='store_true')
+    parser.add_argument("--train-days", type=int, default=6)
+    parser.add_argument("--holdout-days", type=int, default=3)
+    parser.add_argument("--full-window-start-date", default="")
+    parser.add_argument("--full-window-end-date", default="")
+    parser.add_argument("--expected-last-trading-day", default="")
+    parser.add_argument("--allow-stale-tape", action="store_true")
+    parser.add_argument("--prefetch-full-window-rows", action="store_true")
     parser.add_argument(
-        '--max-frontier-runs',
+        "--max-frontier-runs",
         type=int,
         default=0,
-        help='Optional overall cap on frontier executions. 0 means use the family budgets only.',
+        help="Optional overall cap on frontier executions. 0 means use the family budgets only.",
     )
-    parser.add_argument('--json-output', type=Path)
+    parser.add_argument(
+        "--max-candidates-per-frontier-run",
+        type=int,
+        default=0,
+        help=(
+            "Optional local research cap for candidates evaluated inside each frontier "
+            "execution. 0 uses the program replay budget."
+        ),
+    )
+    parser.add_argument("--json-output", type=Path)
     return parser.parse_args()
 
 
@@ -128,16 +147,139 @@ class WorkItem:
 
 
 def _mapping(value: Any) -> dict[str, Any]:
-    return {str(key): item for key, item in value.items()} if isinstance(value, Mapping) else {}
+    return (
+        {str(key): item for key, item in value.items()}
+        if isinstance(value, Mapping)
+        else {}
+    )
 
 
 def _string(value: Any) -> str:
-    return str(value or '').strip()
+    return str(value or "").strip()
+
+
+def _float(value: Any) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _decimal(value: Any, *, default: Decimal = Decimal("0")) -> Decimal:
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError):
+        return default
+
+
+def _json_clone(payload: Mapping[str, Any]) -> dict[str, Any]:
+    return cast(dict[str, Any], json.loads(json.dumps(payload, default=str)))
+
+
+def _as_grid_values(value: Any) -> list[Any]:
+    if isinstance(value, list):
+        return list(value)
+    if value is None:
+        return []
+    return [value]
+
+
+def _format_decimal(value: Decimal) -> str:
+    if value == 0:
+        return "0"
+    formatted = format(value.normalize(), "f")
+    if "." in formatted:
+        return formatted.rstrip("0").rstrip(".") or "0"
+    return formatted
+
+
+def _positive_decimal_grid_values(value: Any) -> list[Decimal]:
+    decimals: list[Decimal] = []
+    for item in _as_grid_values(value):
+        parsed = _decimal(item)
+        if parsed > 0:
+            decimals.append(parsed)
+    return decimals
+
+
+def _max_entry_count(parameters: Mapping[str, Any]) -> int:
+    for key in ("max_entries_per_session", "rank_count"):
+        values = _positive_decimal_grid_values(parameters.get(key))
+        if values:
+            return max(1, int(max(values)))
+    return 1
+
+
+def _capped_numeric_grid(
+    *,
+    existing: Any,
+    maximum: Decimal,
+    fallback: Decimal,
+) -> list[str]:
+    kept = [
+        value for value in _positive_decimal_grid_values(existing) if value <= maximum
+    ]
+    if not kept:
+        kept = [fallback]
+    return [_format_decimal(value) for value in kept]
+
+
+def _apply_objective_capital_limits(
+    *,
+    sweep_config: Mapping[str, Any],
+    max_gross_exposure_pct_equity: Decimal,
+    start_equity: Decimal,
+) -> dict[str, Any]:
+    payload = _json_clone(sweep_config)
+    parameters = _mapping(payload.get("parameters"))
+    strategy_overrides = _mapping(payload.get("strategy_overrides"))
+    max_gross = max(Decimal("0"), max_gross_exposure_pct_equity)
+    effective_max_gross = (max_gross * _CAPITAL_LIMIT_SAFETY_MULTIPLIER).quantize(
+        Decimal("0.000001"),
+        rounding=ROUND_DOWN,
+    )
+    max_entries = _max_entry_count(parameters)
+    per_entry_pct_cap = (
+        (effective_max_gross / Decimal(max_entries)).quantize(
+            Decimal("0.000001"),
+            rounding=ROUND_DOWN,
+        )
+        if effective_max_gross > 0
+        else Decimal("0")
+    )
+    per_trade_notional_cap = (
+        (start_equity * effective_max_gross / Decimal(max_entries)).quantize(
+            Decimal("0.01"),
+            rounding=ROUND_DOWN,
+        )
+        if start_equity > 0 and effective_max_gross > 0
+        else Decimal("0")
+    )
+    if effective_max_gross > 0:
+        parameters["max_gross_exposure_pct_equity"] = _capped_numeric_grid(
+            existing=parameters.get("max_gross_exposure_pct_equity"),
+            maximum=effective_max_gross,
+            fallback=effective_max_gross,
+        )
+        strategy_overrides["max_position_pct_equity"] = _capped_numeric_grid(
+            existing=strategy_overrides.get("max_position_pct_equity"),
+            maximum=per_entry_pct_cap,
+            fallback=per_entry_pct_cap,
+        )
+    if per_trade_notional_cap > 0:
+        strategy_overrides["max_notional_per_trade"] = _capped_numeric_grid(
+            existing=strategy_overrides.get("max_notional_per_trade"),
+            maximum=per_trade_notional_cap,
+            fallback=per_trade_notional_cap,
+        )
+    payload["parameters"] = parameters
+    payload["strategy_overrides"] = strategy_overrides
+    return payload
 
 
 def _slug(value: str) -> str:
-    normalized = ''.join(char if char.isalnum() else '-' for char in value.lower())
-    return '-'.join(part for part in normalized.split('-') if part)
+    normalized = "".join(char if char.isalnum() else "-" for char in value.lower())
+    return "-".join(part for part in normalized.split("-") if part)
 
 
 def _iter_symbols(value: Any) -> list[str]:
@@ -152,10 +294,12 @@ def _iter_symbols(value: Any) -> list[str]:
     return []
 
 
-def _snapshot_symbols(*, args: argparse.Namespace, worklist: list[WorkItem]) -> tuple[str, ...]:
+def _snapshot_symbols(
+    *, args: argparse.Namespace, worklist: list[WorkItem]
+) -> tuple[str, ...]:
     cli_symbols = tuple(
         symbol.strip().upper()
-        for symbol in str(args.symbols or '').split(',')
+        for symbol in str(args.symbols or "").split(",")
         if symbol.strip()
     )
     if cli_symbols:
@@ -163,8 +307,8 @@ def _snapshot_symbols(*, args: argparse.Namespace, worklist: list[WorkItem]) -> 
     ordered: list[str] = []
     seen: set[str] = set()
     for item in worklist:
-        strategy_overrides = _mapping(item.sweep_config.get('strategy_overrides'))
-        for symbol in _iter_symbols(strategy_overrides.get('universe_symbols')):
+        strategy_overrides = _mapping(item.sweep_config.get("strategy_overrides"))
+        for symbol in _iter_symbols(strategy_overrides.get("universe_symbols")):
             if symbol in seen:
                 continue
             seen.add(symbol)
@@ -174,18 +318,22 @@ def _snapshot_symbols(*, args: argparse.Namespace, worklist: list[WorkItem]) -> 
 
 def _mlx_bundle_paths(run_root: Path) -> dict[str, str]:
     return {
-        'signal_rows_jsonl': str(run_root / 'mlx-snapshot-signals.jsonl'),
-        'descriptors_jsonl': str(run_root / 'mlx-candidate-descriptors.jsonl'),
-        'proposal_scores_jsonl': str(run_root / 'mlx-proposal-scores.jsonl'),
-        'history_jsonl': str(run_root / 'history.jsonl'),
-        'results_tsv': str(run_root / 'results.tsv'),
+        "signal_rows_jsonl": str(run_root / "mlx-snapshot-signals.jsonl"),
+        "descriptors_jsonl": str(run_root / "mlx-candidate-descriptors.jsonl"),
+        "proposal_scores_jsonl": str(run_root / "mlx-proposal-scores.jsonl"),
+        "history_jsonl": str(run_root / "history.jsonl"),
+        "results_tsv": str(run_root / "results.tsv"),
     }
 
 
-def _keep_candidate_limit(*, family_plan: FamilyAutoresearchPlan, replay_budget_max_candidates_per_round: int) -> int:
+def _keep_candidate_limit(
+    *, family_plan: FamilyAutoresearchPlan, replay_budget_max_candidates_per_round: int
+) -> int:
     if replay_budget_max_candidates_per_round <= 0:
         return max(1, family_plan.keep_top_candidates)
-    return max(1, min(family_plan.keep_top_candidates, replay_budget_max_candidates_per_round))
+    return max(
+        1, min(family_plan.keep_top_candidates, replay_budget_max_candidates_per_round)
+    )
 
 
 def _frontier_candidate_budget(
@@ -205,7 +353,7 @@ def _frontier_candidate_budget(
 
 def _work_item_candidate_id(work_item: WorkItem) -> str:
     return _slug(
-        f'{work_item.family_plan.family_template.family_id}-iter-{work_item.iteration}-{work_item.mutation_label}'
+        f"{work_item.family_plan.family_template.family_id}-iter-{work_item.iteration}-{work_item.mutation_label}"
     )
 
 
@@ -218,43 +366,43 @@ def _runtime_missing_candidate_payload(
 ) -> dict[str, Any]:
     runtime_harness = _mapping(family_plan.family_template.runtime_harness)
     return {
-        'candidate_id': candidate_id,
-        'family_template_id': family_plan.family_template.family_id,
-        'hard_vetoes': ['runtime_strategy_missing'],
-        'ranking': {
-            'method': 'runtime_availability_preflight',
-            'pareto_tier': 999,
-            'tie_breaker_score': '0',
-            'vetoed': True,
+        "candidate_id": candidate_id,
+        "family_template_id": family_plan.family_template.family_id,
+        "hard_vetoes": ["runtime_strategy_missing"],
+        "ranking": {
+            "method": "runtime_availability_preflight",
+            "pareto_tier": 999,
+            "tie_breaker_score": "0",
+            "vetoed": True,
         },
-        'objective_scorecard': {
-            'net_pnl_per_day': '0',
-            'active_day_ratio': '0',
-            'positive_day_ratio': '0',
-            'avg_filled_notional_per_day': '0',
-            'avg_filled_notional_per_active_day': '0',
-            'best_day_share': '1',
-            'worst_day_loss': '0',
-            'max_drawdown': '0',
-            'regime_slice_pass_rate': '0',
+        "objective_scorecard": {
+            "net_pnl_per_day": "0",
+            "active_day_ratio": "0",
+            "positive_day_ratio": "0",
+            "avg_filled_notional_per_day": "0",
+            "avg_filled_notional_per_active_day": "0",
+            "best_day_share": "1",
+            "worst_day_loss": "0",
+            "max_drawdown": "0",
+            "regime_slice_pass_rate": "0",
         },
-        'full_window': {
-            'net_per_day': '0',
-            'trading_day_count': 0,
-            'active_days': 0,
-            'daily_net': {},
-            'daily_filled_notional': {},
+        "full_window": {
+            "net_per_day": "0",
+            "trading_day_count": 0,
+            "active_days": 0,
+            "daily_net": {},
+            "daily_filled_notional": {},
         },
-        'replay_config': {
-            'params': _mapping(sweep_config.get('parameters')),
-            'strategy_overrides': _mapping(sweep_config.get('strategy_overrides')),
+        "replay_config": {
+            "params": _mapping(sweep_config.get("parameters")),
+            "strategy_overrides": _mapping(sweep_config.get("strategy_overrides")),
         },
-        'runtime_availability': {
-            'schema_version': 'torghut.runtime-availability.v1',
-            'status': 'missing',
-            'reason': reason,
-            'runtime_family': _string(runtime_harness.get('family')),
-            'runtime_strategy_name': _string(runtime_harness.get('strategy_name')),
+        "runtime_availability": {
+            "schema_version": "torghut.runtime-availability.v1",
+            "status": "missing",
+            "reason": reason,
+            "runtime_family": _string(runtime_harness.get("family")),
+            "runtime_strategy_name": _string(runtime_harness.get("strategy_name")),
         },
     }
 
@@ -266,21 +414,25 @@ def _runtime_missing_frontier_payload(
     status_reason: str,
 ) -> dict[str, Any]:
     return {
-        'schema_version': 'torghut.replay-frontier-sweep.v1',
-        'status': 'skipped_runtime_strategy_missing',
-        'status_reason': status_reason,
-        'family': _string(family_plan.family_template.runtime_harness.get('family')),
-        'strategy_name': _string(family_plan.family_template.runtime_harness.get('strategy_name')),
-        'family_template': family_plan.family_template.to_payload(),
-        'candidate_count': 1,
-        'progress': {'evaluated_candidates': 0, 'pending_candidates': 0},
-        'top': [dict(candidate_payload)],
+        "schema_version": "torghut.replay-frontier-sweep.v1",
+        "status": "skipped_runtime_strategy_missing",
+        "status_reason": status_reason,
+        "family": _string(family_plan.family_template.runtime_harness.get("family")),
+        "strategy_name": _string(
+            family_plan.family_template.runtime_harness.get("strategy_name")
+        ),
+        "family_template": family_plan.family_template.to_payload(),
+        "candidate_count": 1,
+        "progress": {"evaluated_candidates": 0, "pending_candidates": 0},
+        "top": [dict(candidate_payload)],
     }
 
 
-def _promotion_readiness_payload(*, family_plan: FamilyAutoresearchPlan) -> dict[str, Any]:
+def _promotion_readiness_payload(
+    *, family_plan: FamilyAutoresearchPlan
+) -> dict[str, Any]:
     return blocked_research_candidate_promotion_readiness(
-        candidate_id='',
+        candidate_id="",
         family_template_id=family_plan.family_template.family_id,
         runtime_harness=family_plan.family_template.runtime_harness,
     )
@@ -295,9 +447,18 @@ def _frontier_args(
     json_output_path: Path,
 ) -> argparse.Namespace:
     top_n = max(family_plan.frontier_top_n, family_plan.keep_top_candidates)
-    max_candidates_to_evaluate = _frontier_candidate_budget(
-        family_plan=family_plan,
-        replay_budget_max_candidates_per_frontier_run=int(program.replay_budget.max_candidates_per_frontier_run),
+    replay_budget_max_candidates_per_frontier_run = (
+        int(args.max_candidates_per_frontier_run)
+        if int(getattr(args, "max_candidates_per_frontier_run", 0)) > 0
+        else int(program.replay_budget.max_candidates_per_frontier_run)
+    )
+    max_candidates_to_evaluate = (
+        max(1, int(args.max_candidates_per_frontier_run))
+        if int(getattr(args, "max_candidates_per_frontier_run", 0)) > 0
+        else _frontier_candidate_budget(
+            family_plan=family_plan,
+            replay_budget_max_candidates_per_frontier_run=replay_budget_max_candidates_per_frontier_run,
+        )
     )
     return argparse.Namespace(
         strategy_configmap=args.strategy_configmap.resolve(),
@@ -327,9 +488,9 @@ def _frontier_args(
 
 
 def _load_yaml(path: Path) -> dict[str, Any]:
-    payload = yaml.safe_load(path.read_text(encoding='utf-8'))
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
     if not isinstance(payload, Mapping):
-        raise ValueError(f'sweep_config_not_mapping:{path}')
+        raise ValueError(f"sweep_config_not_mapping:{path}")
     return json.loads(json.dumps(payload))
 
 
@@ -373,7 +534,7 @@ def _maybe_write_signal_bundle(
         progress_log_interval_seconds=max(1, int(args.progress_log_seconds)),
     )
     return write_mlx_signal_bundle(
-        Path(bundle_paths['signal_rows_jsonl']),
+        Path(bundle_paths["signal_rows_jsonl"]),
         replay_mod._iter_signal_rows(signal_bundle_config),
     )
 
@@ -396,122 +557,189 @@ def _history_record(
     descriptor: MlxCandidateDescriptor | None = None,
     proposal_score: ProposalScore | None = None,
     proposal_selected: bool = False,
-    proposal_selection_reason: str = '',
+    proposal_selection_reason: str = "",
     disable_other_strategies: bool = True,
 ) -> dict[str, Any]:
-    full_window = _mapping(candidate_payload.get('full_window'))
-    scorecard = _mapping(candidate_payload.get('objective_scorecard'))
-    ranking = _mapping(candidate_payload.get('ranking'))
-    replay_config = _mapping(candidate_payload.get('replay_config'))
+    full_window = _mapping(candidate_payload.get("full_window"))
+    scorecard = _mapping(candidate_payload.get("objective_scorecard"))
+    ranking = _mapping(candidate_payload.get("ranking"))
+    replay_config = _mapping(candidate_payload.get("replay_config"))
     promotion_readiness = _promotion_readiness_payload(family_plan=family_plan)
     return {
-        'runner_run_id': runner_run_id,
-        'experiment_index': experiment_index,
-        'iteration': iteration,
-        'rank': rank,
-        'family_template_id': family_plan.family_template.family_id,
-        'candidate_id': _string(candidate_payload.get('candidate_id')),
-        'parent_candidate_id': parent_candidate_id,
-        'status': status,
-        'objective_met': objective_met,
-        'mutation_label': mutation_label,
-        'dataset_snapshot_id': dataset_snapshot_id,
-        'sweep_config_path': str(sweep_config_path),
-        'result_path': str(result_path),
-        'candidate_params': _mapping(replay_config.get('params')),
-        'candidate_strategy_overrides': _mapping(replay_config.get('strategy_overrides')),
-        'disable_other_strategies': disable_other_strategies,
-        'train_start_date': _string(replay_config.get('train_start_date')),
-        'train_end_date': _string(replay_config.get('train_end_date')),
-        'holdout_start_date': _string(replay_config.get('holdout_start_date')),
-        'holdout_end_date': _string(replay_config.get('holdout_end_date')),
-        'full_window_start_date': _string(replay_config.get('full_window_start_date')),
-        'full_window_end_date': _string(replay_config.get('full_window_end_date')),
-        'normalization_regime': _string(candidate_payload.get('normalization_regime')),
-        'net_pnl_per_day': _string(scorecard.get('net_pnl_per_day') or full_window.get('net_per_day')),
-        'active_day_ratio': _string(scorecard.get('active_day_ratio')),
-        'positive_day_ratio': _string(scorecard.get('positive_day_ratio')),
-        'avg_filled_notional_per_day': _string(scorecard.get('avg_filled_notional_per_day')),
-        'avg_filled_notional_per_active_day': _string(scorecard.get('avg_filled_notional_per_active_day')),
-        'worst_day_loss': _string(scorecard.get('worst_day_loss')),
-        'max_drawdown': _string(scorecard.get('max_drawdown')),
-        'best_day_share': _string(scorecard.get('best_day_share')),
-        'regime_slice_pass_rate': _string(scorecard.get('regime_slice_pass_rate')),
-        'pareto_tier': int(ranking.get('pareto_tier') or 999),
-        'tie_breaker_score': _string(ranking.get('tie_breaker_score')),
-        'hard_vetoes': list(cast(list[str], candidate_payload.get('hard_vetoes') or [])),
-        'daily_net': _mapping(full_window.get('daily_net')),
-        'daily_filled_notional': _mapping(full_window.get('daily_filled_notional')),
-        'pruned_symbol': _string(candidate_payload.get('pruned_symbol')),
-        'objective_scope': 'research_only',
-        'promotion_stage': promotion_readiness['stage'],
-        'promotion_status': promotion_readiness['status'],
-        'promotable': promotion_readiness['promotable'],
-        'promotion_reason': promotion_readiness['reason'],
-        'promotion_blockers': list(cast(list[str], promotion_readiness['blockers'])),
-        'promotion_required_evidence': list(cast(list[str], promotion_readiness['required_evidence'])),
-        'runtime_family': _string(_mapping(promotion_readiness['runtime_harness']).get('family')),
-        'runtime_strategy_name': _string(_mapping(promotion_readiness['runtime_harness']).get('strategy_name')),
-        'descriptor_id': _string(descriptor.descriptor_id) if descriptor is not None else '',
-        'entry_window_start_minute': descriptor.entry_window_start_minute if descriptor is not None else 0,
-        'entry_window_end_minute': descriptor.entry_window_end_minute if descriptor is not None else 0,
-        'max_hold_minutes': descriptor.max_hold_minutes if descriptor is not None else 0,
-        'rank_count': descriptor.rank_count if descriptor is not None else 0,
-        'requires_prev_day_features': descriptor.requires_prev_day_features if descriptor is not None else False,
-        'requires_cross_sectional_features': (
-            descriptor.requires_cross_sectional_features if descriptor is not None else False
+        "runner_run_id": runner_run_id,
+        "experiment_index": experiment_index,
+        "iteration": iteration,
+        "rank": rank,
+        "family_template_id": family_plan.family_template.family_id,
+        "candidate_id": _string(candidate_payload.get("candidate_id")),
+        "parent_candidate_id": parent_candidate_id,
+        "status": status,
+        "objective_met": objective_met,
+        "mutation_label": mutation_label,
+        "dataset_snapshot_id": dataset_snapshot_id,
+        "sweep_config_path": str(sweep_config_path),
+        "result_path": str(result_path),
+        "candidate_params": _mapping(replay_config.get("params")),
+        "candidate_strategy_overrides": _mapping(
+            replay_config.get("strategy_overrides")
         ),
-        'requires_quote_quality_gate': descriptor.requires_quote_quality_gate if descriptor is not None else False,
-        'proposal_score': proposal_score.score if proposal_score is not None else 0.0,
-        'proposal_rank': proposal_score.rank if proposal_score is not None else 0,
-        'proposal_backend': _string(proposal_score.backend) if proposal_score is not None else '',
-        'proposal_mode': _string(proposal_score.mode) if proposal_score is not None else '',
-        'proposal_selected': proposal_selected,
-        'proposal_selection_reason': proposal_selection_reason,
+        "disable_other_strategies": disable_other_strategies,
+        "train_start_date": _string(replay_config.get("train_start_date")),
+        "train_end_date": _string(replay_config.get("train_end_date")),
+        "holdout_start_date": _string(replay_config.get("holdout_start_date")),
+        "holdout_end_date": _string(replay_config.get("holdout_end_date")),
+        "full_window_start_date": _string(replay_config.get("full_window_start_date")),
+        "full_window_end_date": _string(replay_config.get("full_window_end_date")),
+        "normalization_regime": _string(candidate_payload.get("normalization_regime")),
+        "net_pnl_per_day": _string(
+            scorecard.get("net_pnl_per_day") or full_window.get("net_per_day")
+        ),
+        "active_day_ratio": _string(scorecard.get("active_day_ratio")),
+        "positive_day_ratio": _string(scorecard.get("positive_day_ratio")),
+        "avg_filled_notional_per_day": _string(
+            scorecard.get("avg_filled_notional_per_day")
+        ),
+        "avg_filled_notional_per_active_day": _string(
+            scorecard.get("avg_filled_notional_per_active_day")
+        ),
+        "worst_day_loss": _string(scorecard.get("worst_day_loss")),
+        "max_drawdown": _string(scorecard.get("max_drawdown")),
+        "best_day_share": _string(scorecard.get("best_day_share")),
+        "regime_slice_pass_rate": _string(scorecard.get("regime_slice_pass_rate")),
+        "pareto_tier": int(ranking.get("pareto_tier") or 999),
+        "tie_breaker_score": _string(ranking.get("tie_breaker_score")),
+        "hard_vetoes": list(
+            cast(list[str], candidate_payload.get("hard_vetoes") or [])
+        ),
+        "daily_net": _mapping(full_window.get("daily_net")),
+        "daily_filled_notional": _mapping(full_window.get("daily_filled_notional")),
+        "pruned_symbol": _string(candidate_payload.get("pruned_symbol")),
+        "objective_scope": "research_only",
+        "promotion_stage": promotion_readiness["stage"],
+        "promotion_status": promotion_readiness["status"],
+        "promotable": promotion_readiness["promotable"],
+        "promotion_reason": promotion_readiness["reason"],
+        "promotion_blockers": list(cast(list[str], promotion_readiness["blockers"])),
+        "promotion_required_evidence": list(
+            cast(list[str], promotion_readiness["required_evidence"])
+        ),
+        "runtime_family": _string(
+            _mapping(promotion_readiness["runtime_harness"]).get("family")
+        ),
+        "runtime_strategy_name": _string(
+            _mapping(promotion_readiness["runtime_harness"]).get("strategy_name")
+        ),
+        "descriptor_id": _string(descriptor.descriptor_id)
+        if descriptor is not None
+        else "",
+        "entry_window_start_minute": descriptor.entry_window_start_minute
+        if descriptor is not None
+        else 0,
+        "entry_window_end_minute": descriptor.entry_window_end_minute
+        if descriptor is not None
+        else 0,
+        "max_hold_minutes": descriptor.max_hold_minutes
+        if descriptor is not None
+        else 0,
+        "rank_count": descriptor.rank_count if descriptor is not None else 0,
+        "requires_prev_day_features": descriptor.requires_prev_day_features
+        if descriptor is not None
+        else False,
+        "requires_cross_sectional_features": (
+            descriptor.requires_cross_sectional_features
+            if descriptor is not None
+            else False
+        ),
+        "requires_quote_quality_gate": descriptor.requires_quote_quality_gate
+        if descriptor is not None
+        else False,
+        "max_position_pct_equity": (
+            _string(descriptor.max_position_pct_equity)
+            if descriptor is not None
+            else ""
+        ),
+        "configured_max_gross_exposure_pct_equity": (
+            _string(descriptor.configured_max_gross_exposure_pct_equity)
+            if descriptor is not None
+            else ""
+        ),
+        "estimated_max_gross_exposure_pct_equity": (
+            _string(descriptor.estimated_max_gross_exposure_pct_equity)
+            if descriptor is not None
+            else ""
+        ),
+        "capital_budget_overage_ratio": (
+            _string(descriptor.capital_budget_overage_ratio)
+            if descriptor is not None
+            else ""
+        ),
+        "capital_feasible": descriptor.capital_feasible
+        if descriptor is not None
+        else True,
+        "max_gross_exposure_pct_equity": _string(
+            scorecard.get("max_gross_exposure_pct_equity")
+            or full_window.get("max_gross_exposure_pct_equity")
+        ),
+        "min_cash": _string(scorecard.get("min_cash") or full_window.get("min_cash")),
+        "negative_cash_observation_count": int(
+            scorecard.get("negative_cash_observation_count")
+            or full_window.get("negative_cash_observation_count")
+            or 0
+        ),
+        "proposal_score": proposal_score.score if proposal_score is not None else 0.0,
+        "proposal_rank": proposal_score.rank if proposal_score is not None else 0,
+        "proposal_backend": _string(proposal_score.backend)
+        if proposal_score is not None
+        else "",
+        "proposal_mode": _string(proposal_score.mode)
+        if proposal_score is not None
+        else "",
+        "proposal_selected": proposal_selected,
+        "proposal_selection_reason": proposal_selection_reason,
     }
 
 
 def _write_history_jsonl(path: Path, history: list[dict[str, Any]]) -> None:
     lines = [json.dumps(item, sort_keys=True) for item in history]
-    path.write_text('\n'.join(lines) + ('\n' if lines else ''), encoding='utf-8')
+    path.write_text("\n".join(lines) + ("\n" if lines else ""), encoding="utf-8")
 
 
 def _sanitize_tsv_field(value: Any) -> str:
-    return str(value).replace('\t', ' ').replace('\n', ' ').strip()
+    return str(value).replace("\t", " ").replace("\n", " ").strip()
 
 
 def _write_results_tsv(path: Path, history: list[dict[str, Any]]) -> None:
     header = [
-        'experiment',
-        'iteration',
-        'family_template_id',
-        'candidate_id',
-        'net_pnl_per_day',
-        'active_day_ratio',
-        'best_day_share',
-        'max_drawdown',
-        'status',
-        'description',
+        "experiment",
+        "iteration",
+        "family_template_id",
+        "candidate_id",
+        "net_pnl_per_day",
+        "active_day_ratio",
+        "best_day_share",
+        "max_drawdown",
+        "status",
+        "description",
     ]
-    rows = ['\t'.join(header)]
+    rows = ["\t".join(header)]
     for item in history:
         rows.append(
-            '\t'.join(
+            "\t".join(
                 [
-                    _sanitize_tsv_field(item['experiment_index']),
-                    _sanitize_tsv_field(item['iteration']),
-                    _sanitize_tsv_field(item['family_template_id']),
-                    _sanitize_tsv_field(item['candidate_id']),
-                    _sanitize_tsv_field(item['net_pnl_per_day']),
-                    _sanitize_tsv_field(item['active_day_ratio']),
-                    _sanitize_tsv_field(item['best_day_share']),
-                    _sanitize_tsv_field(item['max_drawdown']),
-                    _sanitize_tsv_field(item['status']),
-                    _sanitize_tsv_field(item['mutation_label']),
+                    _sanitize_tsv_field(item["experiment_index"]),
+                    _sanitize_tsv_field(item["iteration"]),
+                    _sanitize_tsv_field(item["family_template_id"]),
+                    _sanitize_tsv_field(item["candidate_id"]),
+                    _sanitize_tsv_field(item["net_pnl_per_day"]),
+                    _sanitize_tsv_field(item["active_day_ratio"]),
+                    _sanitize_tsv_field(item["best_day_share"]),
+                    _sanitize_tsv_field(item["max_drawdown"]),
+                    _sanitize_tsv_field(item["status"]),
+                    _sanitize_tsv_field(item["mutation_label"]),
                 ]
             )
         )
-    path.write_text('\n'.join(rows) + '\n', encoding='utf-8')
+    path.write_text("\n".join(rows) + "\n", encoding="utf-8")
 
 
 def _best_history_record(history: list[dict[str, Any]]) -> dict[str, Any] | None:
@@ -520,14 +748,145 @@ def _best_history_record(history: list[dict[str, Any]]) -> dict[str, Any] | None
     sorted_history = sorted(
         history,
         key=lambda item: (
-            item['status'] != 'keep',
-            bool(item['hard_vetoes']),
-            int(item['pareto_tier']),
-            -float(item['net_pnl_per_day'] or '0'),
-            -float(item['active_day_ratio'] or '0'),
+            item["status"] != "keep",
+            bool(item["hard_vetoes"]),
+            int(item["pareto_tier"]),
+            -float(item["net_pnl_per_day"] or "0"),
+            -float(item["active_day_ratio"] or "0"),
         ),
     )
     return sorted_history[0]
+
+
+def _runtime_closure_candidate(
+    best_candidate: Mapping[str, Any] | None,
+) -> Mapping[str, Any] | None:
+    if best_candidate is None:
+        return None
+    if not bool(best_candidate.get("objective_met")):
+        return None
+    if cast(list[Any], best_candidate.get("hard_vetoes") or []):
+        return None
+    return best_candidate
+
+
+def _portfolio_oracle_policy(
+    program: StrategyAutoresearchProgram,
+) -> ProfitTargetOraclePolicy:
+    objective = program.objective
+    return ProfitTargetOraclePolicy(
+        min_active_day_ratio=objective.min_active_day_ratio,
+        min_positive_day_ratio=objective.min_positive_day_ratio,
+        min_daily_net_pnl=objective.min_daily_net_pnl,
+        max_best_day_share=objective.max_best_day_share,
+        max_cluster_contribution_share=Decimal("0.40"),
+        max_single_symbol_contribution_share=Decimal("0.35"),
+        max_worst_day_loss=objective.max_worst_day_loss,
+        max_drawdown=objective.max_drawdown,
+        min_avg_filled_notional_per_day=objective.min_daily_notional,
+        min_regime_slice_pass_rate=objective.min_regime_slice_pass_rate,
+        require_shadow_parity_within_budget=True,
+        require_executable_replay=True,
+    )
+
+
+def _candidate_spec_id_for_portfolio_payload(
+    *,
+    candidate: Mapping[str, Any],
+    result_path: Path,
+) -> str:
+    return (
+        _string(candidate.get("candidate_spec_id"))
+        or _string(candidate.get("descriptor_id"))
+        or _string(candidate.get("candidate_id"))
+        or result_path.parent.name
+    )
+
+
+def _portfolio_evidence_bundles_from_results(
+    run_root: Path,
+) -> tuple[CandidateEvidenceBundle, ...]:
+    bundles: list[CandidateEvidenceBundle] = []
+    seen_bundle_ids: set[str] = set()
+    for result_path in sorted((run_root / "experiments").glob("*/result.json")):
+        try:
+            payload = json.loads(result_path.read_text(encoding="utf-8"))
+        except (FileNotFoundError, json.JSONDecodeError):
+            continue
+        if not isinstance(payload, Mapping):
+            continue
+        dataset_snapshot_id = _string(
+            _mapping(payload.get("dataset_snapshot_receipt")).get("snapshot_id")
+        )
+        for candidate in cast(list[Mapping[str, Any]], payload.get("top") or []):
+            if not isinstance(candidate, Mapping):
+                continue
+            bundle = evidence_bundle_from_frontier_candidate(
+                candidate_spec_id=_candidate_spec_id_for_portfolio_payload(
+                    candidate=candidate,
+                    result_path=result_path,
+                ),
+                candidate=candidate,
+                dataset_snapshot_id=dataset_snapshot_id,
+                result_path=str(result_path),
+            )
+            if bundle.evidence_bundle_id in seen_bundle_ids:
+                continue
+            seen_bundle_ids.add(bundle.evidence_bundle_id)
+            bundles.append(bundle)
+    return tuple(bundles)
+
+
+def _write_portfolio_outputs(
+    *,
+    run_root: Path,
+    program: StrategyAutoresearchProgram,
+) -> tuple[PortfolioCandidateSpec | None, dict[str, Any]]:
+    evidence_bundles = _portfolio_evidence_bundles_from_results(run_root)
+    portfolio = optimize_portfolio_candidate(
+        evidence_bundles=evidence_bundles,
+        target_net_pnl_per_day=program.objective.target_net_pnl_per_day,
+        oracle_policy=_portfolio_oracle_policy(program),
+        portfolio_size_min=2,
+        portfolio_size_max=8,
+    )
+    portfolio_rows = [portfolio.to_payload()] if portfolio is not None else []
+    portfolio_path = run_root / "portfolio-candidates.jsonl"
+    portfolio_path.write_text(
+        "\n".join(json.dumps(item, sort_keys=True) for item in portfolio_rows)
+        + ("\n" if portfolio_rows else ""),
+        encoding="utf-8",
+    )
+    evidence_path = run_root / "candidate-evidence-bundles.jsonl"
+    evidence_path.write_text(
+        "\n".join(
+            json.dumps(bundle.to_payload(), sort_keys=True)
+            for bundle in evidence_bundles
+        )
+        + ("\n" if evidence_bundles else ""),
+        encoding="utf-8",
+    )
+    optimizer_report = (
+        dict(portfolio.optimizer_report)
+        if portfolio is not None
+        else {
+            "status": "no_portfolio_candidate",
+            "evidence_bundle_count": len(evidence_bundles),
+        }
+    )
+    optimizer_report_path = run_root / "portfolio-optimizer-report.json"
+    optimizer_report_path.write_text(
+        json.dumps(optimizer_report, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+    return portfolio, {
+        "portfolio_candidates_path": str(portfolio_path),
+        "candidate_evidence_bundles_path": str(evidence_path),
+        "portfolio_optimizer_report_path": str(optimizer_report_path),
+        "portfolio_candidate_count": len(portfolio_rows),
+        "candidate_evidence_bundle_count": len(evidence_bundles),
+        "portfolio_optimizer_report": optimizer_report,
+    }
 
 
 def _proposal_diagnostics(
@@ -538,24 +897,25 @@ def _proposal_diagnostics(
 ) -> ProposalDiagnostics:
     selected_entries = [
         {
-            'candidate_id': _string(item.get('candidate_id')),
-            'descriptor_id': _string(item.get('descriptor_id')),
-            'selection_reason': _string(item.get('proposal_selection_reason')) or 'exploitation',
-            'score': float(item.get('proposal_score') or 0.0),
-            'rank': int(item.get('proposal_rank') or 0),
-            'family_template_id': _string(item.get('family_template_id')),
-            'side_policy': 'unknown',
+            "candidate_id": _string(item.get("candidate_id")),
+            "descriptor_id": _string(item.get("descriptor_id")),
+            "selection_reason": _string(item.get("proposal_selection_reason"))
+            or "exploitation",
+            "score": float(item.get("proposal_score") or 0.0),
+            "rank": int(item.get("proposal_rank") or 0),
+            "family_template_id": _string(item.get("family_template_id")),
+            "side_policy": "unknown",
         }
         for item in history
-        if bool(item.get('proposal_selected'))
+        if bool(item.get("proposal_selected"))
     ]
     selected_by_candidate: dict[str, dict[str, Any]] = {}
     descriptor_by_candidate = {item.candidate_id: item for item in descriptors}
     for item in selected_entries:
-        candidate_id = item['candidate_id']
+        candidate_id = item["candidate_id"]
         descriptor = descriptor_by_candidate.get(candidate_id)
         if descriptor is not None:
-            item['side_policy'] = descriptor.side_policy
+            item["side_policy"] = descriptor.side_policy
         selected_by_candidate[candidate_id] = item
     return build_proposal_diagnostics(
         descriptors=descriptors,
@@ -563,13 +923,35 @@ def _proposal_diagnostics(
         history_rows=history,
         selected_candidates=[
             ProposalSelectionEntry(
-                candidate_id=item['candidate_id'],
-                descriptor_id=item['descriptor_id'],
-                selection_reason=item['selection_reason'],
-                score=float(item['score']),
-                rank=int(item['rank']),
-                family_template_id=item['family_template_id'],
-                side_policy=item['side_policy'],
+                candidate_id=item["candidate_id"],
+                descriptor_id=item["descriptor_id"],
+                selection_reason=item["selection_reason"],
+                score=float(item["score"]),
+                rank=int(item["rank"]),
+                family_template_id=item["family_template_id"],
+                side_policy=item["side_policy"],
+                capital_feasible=bool(
+                    next(
+                        (
+                            history_item.get("capital_feasible")
+                            for history_item in history
+                            if _string(history_item.get("candidate_id"))
+                            == item["candidate_id"]
+                        ),
+                        True,
+                    )
+                ),
+                capital_budget_overage_ratio=_float(
+                    next(
+                        (
+                            history_item.get("capital_budget_overage_ratio")
+                            for history_item in history
+                            if _string(history_item.get("candidate_id"))
+                            == item["candidate_id"]
+                        ),
+                        0,
+                    )
+                ),
             )
             for item in selected_by_candidate.values()
         ],
@@ -582,32 +964,32 @@ def _experiment_snapshot_from_payload(
     experiment: str,
     result_path: Path,
 ) -> dict[str, Any] | None:
-    top_candidates = cast(list[dict[str, Any]], payload.get('top') or [])
+    top_candidates = cast(list[dict[str, Any]], payload.get("top") or [])
     if not top_candidates:
         return None
     top_row = _mapping(top_candidates[0])
-    scorecard = _mapping(top_row.get('objective_scorecard'))
-    progress = _mapping(payload.get('progress'))
+    scorecard = _mapping(top_row.get("objective_scorecard"))
+    progress = _mapping(payload.get("progress"))
     return {
-        'experiment': experiment,
-        'path': str(result_path),
-        'status': _string(payload.get('status')),
-        'candidate_count': int(payload.get('candidate_count') or 0),
-        'evaluated_candidates': int(progress.get('evaluated_candidates') or 0),
-        'pending_candidates': int(progress.get('pending_candidates') or 0),
-        'top_candidate_id': _string(top_row.get('candidate_id')),
-        'top_net_pnl_per_day': _string(scorecard.get('net_pnl_per_day')),
-        'top_active_day_ratio': _string(scorecard.get('active_day_ratio')),
-        'top_best_day_share': _string(scorecard.get('best_day_share')),
-        'top_hard_vetoes': list(cast(list[str], top_row.get('hard_vetoes') or [])),
+        "experiment": experiment,
+        "path": str(result_path),
+        "status": _string(payload.get("status")),
+        "candidate_count": int(payload.get("candidate_count") or 0),
+        "evaluated_candidates": int(progress.get("evaluated_candidates") or 0),
+        "pending_candidates": int(progress.get("pending_candidates") or 0),
+        "top_candidate_id": _string(top_row.get("candidate_id")),
+        "top_net_pnl_per_day": _string(scorecard.get("net_pnl_per_day")),
+        "top_active_day_ratio": _string(scorecard.get("active_day_ratio")),
+        "top_best_day_share": _string(scorecard.get("best_day_share")),
+        "top_hard_vetoes": list(cast(list[str], top_row.get("hard_vetoes") or [])),
     }
 
 
 def _load_experiment_snapshots(run_root: Path) -> list[dict[str, Any]]:
     snapshots: list[dict[str, Any]] = []
-    for result_path in sorted((run_root / 'experiments').glob('*/result.json')):
+    for result_path in sorted((run_root / "experiments").glob("*/result.json")):
         try:
-            payload = json.loads(result_path.read_text(encoding='utf-8'))
+            payload = json.loads(result_path.read_text(encoding="utf-8"))
         except (FileNotFoundError, json.JSONDecodeError):
             continue
         if not isinstance(payload, Mapping):
@@ -628,10 +1010,10 @@ def _best_experiment_snapshot(snapshots: list[dict[str, Any]]) -> dict[str, Any]
     return max(
         snapshots,
         key=lambda item: (
-            Decimal(_string(item.get('top_net_pnl_per_day')) or '0'),
-            Decimal(_string(item.get('top_active_day_ratio')) or '0'),
-            -Decimal(_string(item.get('top_best_day_share')) or '0'),
-            -int(item.get('pending_candidates') or 0),
+            Decimal(_string(item.get("top_net_pnl_per_day")) or "0"),
+            Decimal(_string(item.get("top_active_day_ratio")) or "0"),
+            -Decimal(_string(item.get("top_best_day_share")) or "0"),
+            -int(item.get("pending_candidates") or 0),
         ),
     )
 
@@ -649,29 +1031,33 @@ def _live_progress_payload(
 ) -> dict[str, Any]:
     snapshots = _load_experiment_snapshots(run_root)
     payload: dict[str, Any] = {
-        'frontier_runs_started': frontier_runs,
-        'pending_work_items': len(worklist),
-        'history_row_count': len(history),
-        'descriptor_count': len(descriptors),
-        'proposal_score_count': len(proposal_scores),
-        'experiment_result_count': len(snapshots),
-        'latest_experiment': snapshots[-1] if snapshots else None,
-        'best_experiment_candidate': _best_experiment_snapshot(snapshots),
+        "frontier_runs_started": frontier_runs,
+        "pending_work_items": len(worklist),
+        "history_row_count": len(history),
+        "descriptor_count": len(descriptors),
+        "proposal_score_count": len(proposal_scores),
+        "experiment_result_count": len(snapshots),
+        "latest_experiment": snapshots[-1] if snapshots else None,
+        "best_experiment_candidate": _best_experiment_snapshot(snapshots),
     }
     if selected_for_replay is not None:
-        payload['selected_for_replay'] = {
-            'candidate_id': selected_for_replay.candidate_id,
-            'descriptor_id': selected_for_replay.descriptor_id,
-            'selection_reason': selected_for_replay.selection_reason,
-            'score': selected_for_replay.score,
-            'rank': selected_for_replay.rank,
-            'family_template_id': selected_for_replay.family_template_id,
-            'side_policy': selected_for_replay.side_policy,
-            'entry_window_start_minute': (
-                selected_descriptor.entry_window_start_minute if selected_descriptor is not None else 0
+        payload["selected_for_replay"] = {
+            "candidate_id": selected_for_replay.candidate_id,
+            "descriptor_id": selected_for_replay.descriptor_id,
+            "selection_reason": selected_for_replay.selection_reason,
+            "score": selected_for_replay.score,
+            "rank": selected_for_replay.rank,
+            "family_template_id": selected_for_replay.family_template_id,
+            "side_policy": selected_for_replay.side_policy,
+            "entry_window_start_minute": (
+                selected_descriptor.entry_window_start_minute
+                if selected_descriptor is not None
+                else 0
             ),
-            'entry_window_end_minute': (
-                selected_descriptor.entry_window_end_minute if selected_descriptor is not None else 0
+            "entry_window_end_minute": (
+                selected_descriptor.entry_window_end_minute
+                if selected_descriptor is not None
+                else 0
             ),
         }
     return payload
@@ -697,17 +1083,17 @@ def _persist_run_outputs(
     closure_execution_context: RuntimeClosureExecutionContext | None = None,
     error: Mapping[str, str] | None = None,
 ) -> dict[str, Any]:
-    history_path = run_root / 'history.jsonl'
-    results_tsv_path = run_root / 'results.tsv'
-    research_dossier_path = run_root / 'research_dossier.json'
-    summary_path = run_root / 'summary.json'
-    promotion_readiness_path = run_root / 'promotion_readiness.json'
-    snapshot_manifest_path = run_root / 'mlx-snapshot-manifest.json'
+    history_path = run_root / "history.jsonl"
+    results_tsv_path = run_root / "results.tsv"
+    research_dossier_path = run_root / "research_dossier.json"
+    summary_path = run_root / "summary.json"
+    promotion_readiness_path = run_root / "promotion_readiness.json"
+    snapshot_manifest_path = run_root / "mlx-snapshot-manifest.json"
     _write_history_jsonl(history_path, history)
     _write_results_tsv(results_tsv_path, history)
     research_dossier_path.write_text(
         json.dumps(program_payload, indent=2, sort_keys=True),
-        encoding='utf-8',
+        encoding="utf-8",
     )
     write_mlx_snapshot_manifest(snapshot_manifest_path, manifest)
     proposal_diagnostics = _proposal_diagnostics(
@@ -724,22 +1110,22 @@ def _persist_run_outputs(
     )
     notebook_paths = write_autoresearch_notebooks(run_root)
     summary: dict[str, Any] = {
-        'status': status,
-        'runner_run_id': runner_run_id,
-        'program_id': program_id,
-        'run_root': str(run_root),
-        'frontier_run_count': frontier_runs,
-        'objective_met': objective_met,
-        'objective_scope': 'research_only',
-        'history_path': str(history_path),
-        'results_tsv_path': str(results_tsv_path),
-        'research_dossier_path': str(research_dossier_path),
-        'promotion_readiness_path': str(promotion_readiness_path),
-        'snapshot_manifest_path': str(snapshot_manifest_path),
-        'mlx_exports': dict(mlx_exports),
-        'notebooks': [str(path) for path in notebook_paths],
-        'best_candidate': _best_history_record(history),
-        'live_progress': _live_progress_payload(
+        "status": status,
+        "runner_run_id": runner_run_id,
+        "program_id": program_id,
+        "run_root": str(run_root),
+        "frontier_run_count": frontier_runs,
+        "objective_met": objective_met,
+        "objective_scope": "research_only",
+        "history_path": str(history_path),
+        "results_tsv_path": str(results_tsv_path),
+        "research_dossier_path": str(research_dossier_path),
+        "promotion_readiness_path": str(promotion_readiness_path),
+        "snapshot_manifest_path": str(snapshot_manifest_path),
+        "mlx_exports": dict(mlx_exports),
+        "notebooks": [str(path) for path in notebook_paths],
+        "best_candidate": _best_history_record(history),
+        "live_progress": _live_progress_payload(
             run_root=run_root,
             frontier_runs=frontier_runs,
             worklist=worklist,
@@ -750,26 +1136,34 @@ def _persist_run_outputs(
             selected_descriptor=selected_descriptor,
         ),
     }
-    best_candidate = cast(dict[str, Any] | None, summary['best_candidate'])
-    summary['promotion_readiness'] = summary_promotion_readiness(best_candidate)
+    best_candidate = cast(dict[str, Any] | None, summary["best_candidate"])
+    portfolio, portfolio_outputs = _write_portfolio_outputs(
+        run_root=run_root,
+        program=program,
+    )
+    summary.update(portfolio_outputs)
+    summary["best_portfolio_candidate"] = (
+        portfolio.to_payload() if portfolio is not None else None
+    )
+    summary["promotion_readiness"] = summary_promotion_readiness(best_candidate)
     runtime_closure = write_runtime_closure_bundle(
         run_root=run_root,
         runner_run_id=runner_run_id,
         program=program,
-        best_candidate=best_candidate,
+        best_candidate=_runtime_closure_candidate(best_candidate),
         manifest=manifest,
         execution_context=closure_execution_context,
     )
-    summary['runtime_closure'] = runtime_closure.to_payload()
+    summary["runtime_closure"] = runtime_closure.to_payload()
     if error is not None:
-        summary['error'] = dict(error)
+        summary["error"] = dict(error)
     promotion_readiness_path.write_text(
-        json.dumps(summary['promotion_readiness'], indent=2, sort_keys=True),
-        encoding='utf-8',
+        json.dumps(summary["promotion_readiness"], indent=2, sort_keys=True),
+        encoding="utf-8",
     )
     summary_path.write_text(
         json.dumps(summary, indent=2, sort_keys=True),
-        encoding='utf-8',
+        encoding="utf-8",
     )
     return summary
 
@@ -779,10 +1173,10 @@ def run_strategy_autoresearch_loop(args: argparse.Namespace) -> dict[str, Any]:
         args.program.resolve(),
         family_dir=args.family_template_dir.resolve(),
     )
-    runner_run_id = run_id('strategy-autoresearch')
-    run_root = (args.output_dir.resolve() / runner_run_id)
+    runner_run_id = run_id("strategy-autoresearch")
+    run_root = args.output_dir.resolve() / runner_run_id
     run_root.mkdir(parents=True, exist_ok=True)
-    (run_root / 'experiments').mkdir(parents=True, exist_ok=True)
+    (run_root / "experiments").mkdir(parents=True, exist_ok=True)
 
     worklist: list[WorkItem] = []
     seen_sweeps: set[str] = set()
@@ -794,12 +1188,17 @@ def run_strategy_autoresearch_loop(args: argparse.Namespace) -> dict[str, Any]:
             holdout_day_count=max(1, int(args.holdout_days)),
             full_window_day_count=_default_full_window_day_count(args),
         )
+        seed_sweep = _apply_objective_capital_limits(
+            sweep_config=seed_sweep,
+            max_gross_exposure_pct_equity=program.objective.max_gross_exposure_pct_equity,
+            start_equity=Decimal(str(args.start_equity)),
+        )
         worklist.append(
             WorkItem(
                 family_plan=family_plan,
                 iteration=1,
                 sweep_config=seed_sweep,
-                mutation_label='seed',
+                mutation_label="seed",
                 parent_candidate_id=None,
             )
         )
@@ -834,18 +1233,22 @@ def run_strategy_autoresearch_loop(args: argparse.Namespace) -> dict[str, Any]:
         return build_mlx_snapshot_manifest(
             runner_run_id=runner_run_id,
             program=program,
-            symbols=','.join(snapshot_symbols),
+            symbols=",".join(snapshot_symbols),
             train_days=int(args.train_days),
             holdout_days=int(args.holdout_days),
             full_window_start_date=resolved_full_window_start_date,
             full_window_end_date=resolved_full_window_end_date,
             tape_freshness_receipts=tuple(tape_freshness_receipts),
             row_counts={
-                'receipt_count': len(tape_freshness_receipts),
-                'latest_receipt_row_count': int(latest_receipt.get('row_count') or 0),
-                'signal_row_count': signal_bundle_stats.row_count if signal_bundle_stats is not None else 0,
-                'signal_symbol_count': (
-                    signal_bundle_stats.symbol_count if signal_bundle_stats is not None else len(snapshot_symbols)
+                "receipt_count": len(tape_freshness_receipts),
+                "latest_receipt_row_count": int(latest_receipt.get("row_count") or 0),
+                "signal_row_count": signal_bundle_stats.row_count
+                if signal_bundle_stats is not None
+                else 0,
+                "signal_symbol_count": (
+                    signal_bundle_stats.symbol_count
+                    if signal_bundle_stats is not None
+                    else len(snapshot_symbols)
                 ),
             },
             tensor_bundle_paths=bundle_paths,
@@ -867,7 +1270,7 @@ def run_strategy_autoresearch_loop(args: argparse.Namespace) -> dict[str, Any]:
         descriptors=descriptors,
         proposal_scores=proposal_scores,
         worklist=worklist,
-        status='running',
+        status="running",
         closure_execution_context=closure_execution_context,
     )
     signal_bundle_stats = _maybe_write_signal_bundle(
@@ -892,12 +1295,14 @@ def run_strategy_autoresearch_loop(args: argparse.Namespace) -> dict[str, Any]:
         descriptors=descriptors,
         proposal_scores=proposal_scores,
         worklist=worklist,
-        status='running',
+        status="running",
         closure_execution_context=closure_execution_context,
     )
     try:
         while worklist:
-            if int(args.max_frontier_runs) > 0 and frontier_runs >= int(args.max_frontier_runs):
+            if int(args.max_frontier_runs) > 0 and frontier_runs >= int(
+                args.max_frontier_runs
+            ):
                 break
             pending_descriptors = [
                 descriptor_from_sweep_config(
@@ -917,7 +1322,10 @@ def run_strategy_autoresearch_loop(args: argparse.Namespace) -> dict[str, Any]:
             ordered_pending = sorted(
                 zip(worklist, pending_descriptors, strict=False),
                 key=lambda item: (
+                    not item[1].capital_feasible,
+                    _float(item[1].capital_budget_overage_ratio),
                     score_by_candidate[item[1].candidate_id].rank,
+                    -score_by_candidate[item[1].candidate_id].score,
                     item[0].family_plan.family_template.family_id,
                 ),
             )
@@ -931,26 +1339,30 @@ def run_strategy_autoresearch_loop(args: argparse.Namespace) -> dict[str, Any]:
             frontier_runs += 1
             experiment_index = frontier_runs
             experiment_slug = _slug(
-                f'{experiment_index:03d}-{current.family_plan.family_template.family_id}-iter-{current.iteration}'
+                f"{experiment_index:03d}-{current.family_plan.family_template.family_id}-iter-{current.iteration}"
             )
-            experiment_root = run_root / 'experiments' / experiment_slug
+            experiment_root = run_root / "experiments" / experiment_slug
             experiment_root.mkdir(parents=True, exist_ok=True)
-            sweep_config_path = experiment_root / 'sweep.yaml'
+            sweep_config_path = experiment_root / "sweep.yaml"
             sweep_config_path.write_text(
                 yaml.safe_dump(current.sweep_config, sort_keys=False),
-                encoding='utf-8',
+                encoding="utf-8",
             )
-            result_path = experiment_root / 'result.json'
+            result_path = experiment_root / "result.json"
             selected_score = score_by_candidate.get(current_descriptor.candidate_id)
             selected_for_replay = (
                 ProposalSelectionEntry(
                     candidate_id=current_descriptor.candidate_id,
                     descriptor_id=current_descriptor.descriptor_id,
-                    selection_reason='frontier_seed',
+                    selection_reason="frontier_seed",
                     score=selected_score.score,
                     rank=selected_score.rank,
                     family_template_id=current_descriptor.family_template_id,
                     side_policy=current_descriptor.side_policy,
+                    capital_feasible=current_descriptor.capital_feasible,
+                    capital_budget_overage_ratio=_float(
+                        current_descriptor.capital_budget_overage_ratio
+                    ),
                 )
                 if selected_score is not None
                 else None
@@ -968,7 +1380,7 @@ def run_strategy_autoresearch_loop(args: argparse.Namespace) -> dict[str, Any]:
                 descriptors=descriptors,
                 proposal_scores=proposal_scores,
                 worklist=worklist,
-                status='running',
+                status="running",
                 selected_for_replay=selected_for_replay,
                 selected_descriptor=current_descriptor,
                 closure_execution_context=closure_execution_context,
@@ -985,7 +1397,7 @@ def run_strategy_autoresearch_loop(args: argparse.Namespace) -> dict[str, Any]:
                 )
             except ValueError as exc:
                 status_reason = str(exc)
-                if not status_reason.startswith('strategy_not_found:'):
+                if not status_reason.startswith("strategy_not_found:"):
                     raise
                 candidate_payload = _runtime_missing_candidate_payload(
                     candidate_id=current_descriptor.candidate_id,
@@ -1010,19 +1422,21 @@ def run_strategy_autoresearch_loop(args: argparse.Namespace) -> dict[str, Any]:
                         result_path=result_path,
                         candidate_payload=candidate_payload,
                         rank=1,
-                        status='skip',
+                        status="skip",
                         objective_met=False,
-                        dataset_snapshot_id='',
+                        dataset_snapshot_id="",
                         descriptor=current_descriptor,
                         proposal_score=selected_score,
                         proposal_selected=False,
-                        proposal_selection_reason='runtime_strategy_missing',
-                        disable_other_strategies=bool(current.sweep_config.get('disable_other_strategies', True)),
+                        proposal_selection_reason="runtime_strategy_missing",
+                        disable_other_strategies=bool(
+                            current.sweep_config.get("disable_other_strategies", True)
+                        ),
                     )
                 )
                 result_path.write_text(
                     json.dumps(frontier_payload, indent=2, sort_keys=True),
-                    encoding='utf-8',
+                    encoding="utf-8",
                 )
                 _persist_run_outputs(
                     run_root=run_root,
@@ -1037,26 +1451,30 @@ def run_strategy_autoresearch_loop(args: argparse.Namespace) -> dict[str, Any]:
                     descriptors=descriptors,
                     proposal_scores=proposal_scores,
                     worklist=worklist,
-                    status='running',
+                    status="running",
                     closure_execution_context=closure_execution_context,
                 )
                 continue
             result_path.write_text(
                 json.dumps(frontier_payload, indent=2, sort_keys=True),
-                encoding='utf-8',
+                encoding="utf-8",
             )
             dataset_snapshot_id = _string(
-                _mapping(frontier_payload.get('dataset_snapshot_receipt')).get('snapshot_id')
+                _mapping(frontier_payload.get("dataset_snapshot_receipt")).get(
+                    "snapshot_id"
+                )
             )
-            receipt_payload = _mapping(frontier_payload.get('dataset_snapshot_receipt'))
+            receipt_payload = _mapping(frontier_payload.get("dataset_snapshot_receipt"))
             if receipt_payload:
                 tape_freshness_receipts.append(receipt_payload)
-            frontier_window = _mapping(frontier_payload.get('window'))
+            frontier_window = _mapping(frontier_payload.get("window"))
             resolved_full_window_start_date = (
-                _string(frontier_window.get('full_window_start_date')) or resolved_full_window_start_date
+                _string(frontier_window.get("full_window_start_date"))
+                or resolved_full_window_start_date
             )
             resolved_full_window_end_date = (
-                _string(frontier_window.get('full_window_end_date')) or resolved_full_window_end_date
+                _string(frontier_window.get("full_window_end_date"))
+                or resolved_full_window_end_date
             )
             signal_bundle_stats = _maybe_write_signal_bundle(
                 args=args,
@@ -1067,11 +1485,13 @@ def run_strategy_autoresearch_loop(args: argparse.Namespace) -> dict[str, Any]:
                 existing=signal_bundle_stats,
             )
             manifest = _refresh_manifest()
-            top_candidates = cast(list[dict[str, Any]], frontier_payload.get('top') or [])
+            top_candidates = cast(
+                list[dict[str, Any]], frontier_payload.get("top") or []
+            )
             keep_candidates = [
                 candidate
                 for candidate in top_candidates
-                if not bool(_mapping(candidate.get('ranking')).get('vetoed'))
+                if not bool(_mapping(candidate.get("ranking")).get("vetoed"))
             ]
             frontier_descriptors = [
                 descriptor_from_candidate_payload(
@@ -1087,21 +1507,28 @@ def run_strategy_autoresearch_loop(args: argparse.Namespace) -> dict[str, Any]:
                 policy=cast(ProposalModelPolicy, program.proposal_model_policy),
             )
             proposal_scores.extend(frontier_candidate_scores)
-            frontier_descriptor_by_candidate = {item.candidate_id: item for item in frontier_descriptors}
-            frontier_score_by_candidate = {item.candidate_id: item for item in frontier_candidate_scores}
+            frontier_descriptor_by_candidate = {
+                item.candidate_id: item for item in frontier_descriptors
+            }
+            frontier_score_by_candidate = {
+                item.candidate_id: item for item in frontier_candidate_scores
+            }
             keep_limit = _keep_candidate_limit(
                 family_plan=current.family_plan,
-                replay_budget_max_candidates_per_round=int(program.replay_budget.max_candidates_per_round),
+                replay_budget_max_candidates_per_round=int(
+                    program.replay_budget.max_candidates_per_round
+                ),
             )
             non_vetoed_descriptors = [
-                frontier_descriptor_by_candidate[_string(candidate.get('candidate_id'))]
+                frontier_descriptor_by_candidate[_string(candidate.get("candidate_id"))]
                 for candidate in keep_candidates
-                if _string(candidate.get('candidate_id')) in frontier_descriptor_by_candidate
+                if _string(candidate.get("candidate_id"))
+                in frontier_descriptor_by_candidate
             ]
             non_vetoed_scores = [
-                frontier_score_by_candidate[_string(candidate.get('candidate_id'))]
+                frontier_score_by_candidate[_string(candidate.get("candidate_id"))]
                 for candidate in keep_candidates
-                if _string(candidate.get('candidate_id')) in frontier_score_by_candidate
+                if _string(candidate.get("candidate_id")) in frontier_score_by_candidate
             ]
             exploration_slots = min(
                 max(0, int(program.proposal_model_policy.exploration_slots)),
@@ -1114,9 +1541,13 @@ def run_strategy_autoresearch_loop(args: argparse.Namespace) -> dict[str, Any]:
                 top_k=max(1, int(program.proposal_model_policy.top_k)),
                 exploration_slots=exploration_slots,
             )
-            if not selected_keep_entries and current.family_plan.force_keep_top_candidate_if_all_vetoed and top_candidates:
+            if (
+                not selected_keep_entries
+                and current.family_plan.force_keep_top_candidate_if_all_vetoed
+                and top_candidates
+            ):
                 first_candidate = top_candidates[0]
-                first_candidate_id = _string(first_candidate.get('candidate_id'))
+                first_candidate_id = _string(first_candidate.get("candidate_id"))
                 descriptor = frontier_descriptor_by_candidate.get(first_candidate_id)
                 score = frontier_score_by_candidate.get(first_candidate_id)
                 if descriptor is not None and score is not None:
@@ -1124,7 +1555,7 @@ def run_strategy_autoresearch_loop(args: argparse.Namespace) -> dict[str, Any]:
                         ProposalSelectionEntry(
                             candidate_id=first_candidate_id,
                             descriptor_id=descriptor.descriptor_id,
-                            selection_reason='fallback_force_keep',
+                            selection_reason="fallback_force_keep",
                             score=score.score,
                             rank=score.rank,
                             family_template_id=descriptor.family_template_id,
@@ -1132,11 +1563,16 @@ def run_strategy_autoresearch_loop(args: argparse.Namespace) -> dict[str, Any]:
                         )
                     ]
             keep_ids = {item.candidate_id for item in selected_keep_entries}
-            keep_reason_by_candidate = {item.candidate_id: item.selection_reason for item in selected_keep_entries}
+            keep_reason_by_candidate = {
+                item.candidate_id: item.selection_reason
+                for item in selected_keep_entries
+            }
             for rank, candidate in enumerate(top_candidates, start=1):
-                candidate_id = _string(candidate.get('candidate_id'))
-                candidate_status = 'keep' if candidate_id in keep_ids else 'discard'
-                candidate_objective_met = candidate_meets_objective(candidate, objective=program.objective)
+                candidate_id = _string(candidate.get("candidate_id"))
+                candidate_status = "keep" if candidate_id in keep_ids else "discard"
+                candidate_objective_met = candidate_meets_objective(
+                    candidate, objective=program.objective
+                )
                 candidate_descriptor = frontier_descriptor_by_candidate[candidate_id]
                 history.append(
                     _history_record(
@@ -1156,13 +1592,17 @@ def run_strategy_autoresearch_loop(args: argparse.Namespace) -> dict[str, Any]:
                         descriptor=candidate_descriptor,
                         proposal_score=frontier_score_by_candidate.get(candidate_id),
                         proposal_selected=candidate_id in keep_ids,
-                        proposal_selection_reason=keep_reason_by_candidate.get(candidate_id, ''),
-                        disable_other_strategies=bool(current.sweep_config.get('disable_other_strategies', True)),
+                        proposal_selection_reason=keep_reason_by_candidate.get(
+                            candidate_id, ""
+                        ),
+                        disable_other_strategies=bool(
+                            current.sweep_config.get("disable_other_strategies", True)
+                        ),
                     )
                 )
                 if candidate_objective_met:
                     objective_met = True
-                if candidate_status != 'keep':
+                if candidate_status != "keep":
                     continue
                 if current.iteration >= current.family_plan.max_iterations:
                     continue
@@ -1176,6 +1616,11 @@ def run_strategy_autoresearch_loop(args: argparse.Namespace) -> dict[str, Any]:
                     objective=program.objective,
                     holdout_day_count=max(1, int(args.holdout_days)),
                     full_window_day_count=_default_full_window_day_count(args),
+                )
+                next_sweep_config = _apply_objective_capital_limits(
+                    sweep_config=next_sweep_config,
+                    max_gross_exposure_pct_equity=program.objective.max_gross_exposure_pct_equity,
+                    start_equity=Decimal(str(args.start_equity)),
                 )
                 worklist.append(
                     WorkItem(
@@ -1199,7 +1644,7 @@ def run_strategy_autoresearch_loop(args: argparse.Namespace) -> dict[str, Any]:
                 descriptors=descriptors,
                 proposal_scores=proposal_scores,
                 worklist=worklist,
-                status='running',
+                status="running",
                 closure_execution_context=closure_execution_context,
             )
             if objective_met and program.objective.stop_when_objective_met:
@@ -1218,11 +1663,11 @@ def run_strategy_autoresearch_loop(args: argparse.Namespace) -> dict[str, Any]:
             descriptors=descriptors,
             proposal_scores=proposal_scores,
             worklist=worklist,
-            status='error',
+            status="error",
             closure_execution_context=closure_execution_context,
             error={
-                'type': exc.__class__.__name__,
-                'message': str(exc),
+                "type": exc.__class__.__name__,
+                "message": str(exc),
             },
         )
 
@@ -1239,7 +1684,7 @@ def run_strategy_autoresearch_loop(args: argparse.Namespace) -> dict[str, Any]:
         descriptors=descriptors,
         proposal_scores=proposal_scores,
         worklist=worklist,
-        status='ok',
+        status="ok",
         closure_execution_context=closure_execution_context,
     )
 
@@ -1250,11 +1695,11 @@ def main() -> int:
     if args.json_output is not None:
         args.json_output.write_text(
             json.dumps(payload, indent=2, sort_keys=True),
-            encoding='utf-8',
+            encoding="utf-8",
         )
     print(json.dumps(payload, indent=2, sort_keys=True))
-    return 0 if payload.get('status') == 'ok' else 1
+    return 0 if payload.get("status") == "ok" else 1
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     raise SystemExit(main())

--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -41,6 +41,7 @@ from app.trading.discovery.candidate_specs import candidate_spec_id_for_payload
 from app.trading.discovery.evidence_bundles import (
     CandidateEvidenceBundle,
     evidence_bundle_from_frontier_candidate,
+    evidence_bundle_from_payload,
 )
 from app.trading.discovery.hypothesis_cards import HypothesisCard
 from app.trading.discovery.mlx_snapshot import build_mlx_snapshot_manifest
@@ -123,6 +124,16 @@ def _parse_args() -> argparse.Namespace:
         default=[],
         type=Path,
         help="JSONL file of normalized WhitepaperResearchSource payloads.",
+    )
+    parser.add_argument(
+        "--feedback-evidence-jsonl",
+        action="append",
+        default=[],
+        type=Path,
+        help=(
+            "Prior real-replay candidate evidence bundles to feed back into the "
+            "pre-replay MLX ranker for the next autoresearch epoch."
+        ),
     )
     parser.add_argument(
         "--target-net-pnl-per-day", default=_DEFAULT_DAILY_PROFIT_TARGET
@@ -305,6 +316,32 @@ def _write_jsonl(path: Path, rows: Sequence[Mapping[str, Any]]) -> Path:
         encoding="utf-8",
     )
     return path
+
+
+def _load_feedback_evidence_bundles(
+    paths: Sequence[Path],
+) -> tuple[CandidateEvidenceBundle, ...]:
+    bundles: list[CandidateEvidenceBundle] = []
+    for raw_path in paths:
+        path = _resolve_existing_path(raw_path)
+        if not path.exists():
+            raise ValueError(f"feedback_evidence_jsonl_missing:{raw_path}")
+        for line_number, line in enumerate(
+            path.read_text(encoding="utf-8").splitlines(), start=1
+        ):
+            text = line.strip()
+            if not text:
+                continue
+            try:
+                payload = json.loads(text)
+                if not isinstance(payload, Mapping):
+                    raise ValueError("payload_not_object")
+                bundles.append(evidence_bundle_from_payload(payload))
+            except Exception as exc:
+                raise ValueError(
+                    f"feedback_evidence_jsonl_invalid:{raw_path}:{line_number}:{exc}"
+                ) from exc
+    return tuple(bundles)
 
 
 def _program_claim_type(claim: ResearchClaim) -> str:
@@ -906,6 +943,18 @@ def _candidate_quality_gate_failures(
         > oracle_policy.max_drawdown
     ):
         failures.append("max_drawdown_above_oracle")
+    if (
+        _decimal(scorecard.get("max_gross_exposure_pct_equity"))
+        > oracle_policy.max_gross_exposure_pct_equity
+    ):
+        failures.append("max_gross_exposure_above_oracle")
+    if _decimal(scorecard.get("min_cash")) < oracle_policy.min_cash:
+        failures.append("min_cash_below_oracle")
+    if (
+        int(_decimal(scorecard.get("negative_cash_observation_count")))
+        > oracle_policy.max_negative_cash_observation_count
+    ):
+        failures.append("negative_cash_observed")
     if (
         _decimal(scorecard.get("avg_filled_notional_per_day"))
         < oracle_policy.min_avg_filled_notional_per_day
@@ -1977,34 +2026,105 @@ def _pre_replay_prior_bundle(spec: CandidateSpec) -> CandidateEvidenceBundle:
 def _pre_replay_proposal_model_and_rows(
     *,
     specs: Sequence[CandidateSpec],
+    feedback_evidence_bundles: Sequence[CandidateEvidenceBundle] = (),
 ) -> tuple[Mapping[str, Any], list[dict[str, Any]]]:
+    spec_ids = {spec.candidate_spec_id for spec in specs}
+    matched_feedback = [
+        bundle
+        for bundle in feedback_evidence_bundles
+        if bundle.candidate_spec_id in spec_ids
+    ]
+    feedback_by_spec: dict[str, CandidateEvidenceBundle] = {}
+    for bundle in matched_feedback:
+        current = feedback_by_spec.get(bundle.candidate_spec_id)
+        if current is None:
+            feedback_by_spec[bundle.candidate_spec_id] = bundle
+            continue
+        current_score = _decimal(current.objective_scorecard.get("net_pnl_per_day"))
+        bundle_score = _decimal(bundle.objective_scorecard.get("net_pnl_per_day"))
+        if bundle_score > current_score:
+            feedback_by_spec[bundle.candidate_spec_id] = bundle
     prior_bundles = [_pre_replay_prior_bundle(spec) for spec in specs]
+    training_bundles = [
+        feedback_by_spec.get(spec.candidate_spec_id) or prior_bundle
+        for spec, prior_bundle in zip(specs, prior_bundles, strict=True)
+    ]
     training_rows = build_mlx_training_rows(
-        candidate_specs=specs, evidence_bundles=prior_bundles
+        candidate_specs=specs, evidence_bundles=training_bundles
     )
     model = train_mlx_ranker(training_rows, backend_preference="mlx")
     ranked_rows = rank_training_rows(model=model, rows=training_rows)
     feature_by_spec = {
         row.candidate_spec_id: row.to_payload()["features"] for row in training_rows
     }
-    rows = [
+    target_by_spec = {row.candidate_spec_id: row.target for row in training_rows}
+    feedback_spec_ids = set(feedback_by_spec)
+
+    def feedback_is_blocked(bundle: CandidateEvidenceBundle) -> bool:
+        scorecard = bundle.objective_scorecard
+        hard_vetoes = scorecard.get("hard_vetoes") or scorecard.get("veto_reasons")
+        if isinstance(hard_vetoes, str) and hard_vetoes.strip():
+            return True
+        if isinstance(hard_vetoes, Sequence) and not isinstance(hard_vetoes, str):
+            if any(_string(item) for item in hard_vetoes):
+                return True
+        if _decimal(scorecard.get("max_gross_exposure_pct_equity")) > Decimal("1.0"):
+            return True
+        if _decimal(scorecard.get("min_cash")) < Decimal("0"):
+            return True
+        if _decimal(scorecard.get("negative_cash_observation_count")) > Decimal("0"):
+            return True
+        return _decimal(scorecard.get("net_pnl_per_day")) <= Decimal("0") or _decimal(
+            scorecard.get("negative_day_count")
+        ) > Decimal("0")
+
+    rows_unranked = [
         {
             "candidate_spec_id": item.candidate_spec_id,
-            "proposal_score": item.score,
-            "rank": item.rank,
+            "proposal_score": (
+                min(
+                    -1_000_000.0, target_by_spec.get(item.candidate_spec_id, item.score)
+                )
+                if item.candidate_spec_id in feedback_spec_ids
+                and feedback_is_blocked(feedback_by_spec[item.candidate_spec_id])
+                else item.score
+            ),
+            "raw_mlx_proposal_score": item.score,
+            "feedback_replay_target": target_by_spec.get(item.candidate_spec_id)
+            if item.candidate_spec_id in feedback_spec_ids
+            else None,
             "backend": item.backend,
             "model_id": item.model_id,
-            "selection_reason": "pre_replay_mlx_rank",
+            "selection_reason": "pre_replay_mlx_feedback_blocked"
+            if item.candidate_spec_id in feedback_spec_ids
+            and feedback_is_blocked(feedback_by_spec[item.candidate_spec_id])
+            else "pre_replay_mlx_rank",
+            "training_source": "feedback_real_replay"
+            if item.candidate_spec_id in feedback_spec_ids
+            else "synthetic_prior",
             "feature_hash": item.feature_hash,
             "features": feature_by_spec.get(item.candidate_spec_id, {}),
         }
         for item in ranked_rows
     ]
+    rows_unranked.sort(
+        key=lambda row: (
+            -float(row.get("proposal_score") or 0.0),
+            _string(row.get("candidate_spec_id")),
+        )
+    )
+    rows = [{**row, "rank": index} for index, row in enumerate(rows_unranked, start=1)]
     return {
         **model.to_payload(),
         "proposal_stage": "pre_replay",
         "model_status": "active",
         "rank_bucket_lift": {"status": "pending_replay_evidence"},
+        "feedback_evidence_bundle_count": len(feedback_evidence_bundles),
+        "feedback_matched_spec_count": len(feedback_by_spec),
+        "training_source_counts": {
+            "feedback_real_replay": len(feedback_by_spec),
+            "synthetic_prior": max(0, len(specs) - len(feedback_by_spec)),
+        },
     }, rows
 
 
@@ -2075,6 +2195,11 @@ def _select_candidate_specs_for_replay(
         spec.candidate_spec_id: dict(candidate_spec_capital_features(spec))
         for spec in specs
     }
+    proposal_by_spec = {
+        _string(row.get("candidate_spec_id")): row
+        for row in _list_of_mappings(list(proposal_rows))
+        if _string(row.get("candidate_spec_id"))
+    }
 
     def capital_sort_key(candidate_spec_id: str) -> tuple[int, Decimal, str]:
         features = capital_features_by_spec.get(candidate_spec_id, {})
@@ -2111,9 +2236,7 @@ def _select_candidate_specs_for_replay(
         spec.candidate_spec_id
         for spec in sorted(
             specs,
-            key=lambda item: (
-                *capital_sort_key(item.candidate_spec_id),
-            ),
+            key=lambda item: (*capital_sort_key(item.candidate_spec_id),),
         )
         if spec.candidate_spec_id not in set(ranked_ids)
     )
@@ -2135,14 +2258,43 @@ def _select_candidate_specs_for_replay(
     def spec_source_run_id(spec: CandidateSpec) -> str:
         return _string(spec.feature_contract.get("source_run_id")) or spec.hypothesis_id
 
+    def spec_universe_key(spec: CandidateSpec) -> str:
+        universe = spec.strategy_overrides.get("universe_symbols")
+        if not isinstance(universe, Sequence) or isinstance(universe, str):
+            return ""
+        return ",".join(
+            sorted(_string(item).upper() for item in universe if _string(item))
+        )
+
+    def spec_signal_key(spec: CandidateSpec) -> str:
+        params = _mapping(spec.strategy_overrides.get("params"))
+        return "|".join(
+            part
+            for part in (
+                _string(params.get("signal_motif")),
+                _string(params.get("selection_mode")),
+                _string(params.get("rank_feature")),
+            )
+            if part
+        )
+
     def diversity_key(
         spec: CandidateSpec, selected_so_far: Sequence[CandidateSpec]
-    ) -> tuple[bool, bool, int, str]:
+    ) -> tuple[bool, bool, bool, bool, bool, int, int, str]:
         selected_families = {item.family_template_id for item in selected_so_far}
+        selected_runtime_strategies = {
+            item.runtime_strategy_name for item in selected_so_far
+        }
+        selected_universes = {spec_universe_key(item) for item in selected_so_far}
+        selected_signals = {spec_signal_key(item) for item in selected_so_far}
         selected_sources = {spec_source_run_id(item) for item in selected_so_far}
         family_selection = _mapping(spec.feature_contract.get("family_selection"))
         return (
             spec.family_template_id in selected_families,
+            spec.runtime_strategy_name in selected_runtime_strategies,
+            bool(spec_universe_key(spec))
+            and spec_universe_key(spec) in selected_universes,
+            bool(spec_signal_key(spec)) and spec_signal_key(spec) in selected_signals,
             spec_source_run_id(spec) in selected_sources,
             rank_position_by_spec.get(spec.candidate_spec_id, 10**6),
             int(family_selection.get("rank") or 10**6),
@@ -2231,6 +2383,10 @@ def _select_candidate_specs_for_replay(
         {
             "candidate_spec_id": spec.candidate_spec_id,
             "family_template_id": spec.family_template_id,
+            "runtime_family": spec.runtime_family,
+            "runtime_strategy_name": spec.runtime_strategy_name,
+            "universe_key": spec_universe_key(spec),
+            "signal_key": spec_signal_key(spec),
             "execution_signature": execution_signature_by_spec[spec.candidate_spec_id],
             "duplicate_of_candidate_spec_id": representative_by_signature[
                 execution_signature_by_spec[spec.candidate_spec_id]
@@ -2241,6 +2397,13 @@ def _select_candidate_specs_for_replay(
             != spec.candidate_spec_id
             else None,
             "pre_replay_score": str(_pre_replay_candidate_score(spec)),
+            "proposal_score": proposal_by_spec.get(spec.candidate_spec_id, {}).get(
+                "proposal_score"
+            ),
+            "proposal_training_source": _string(
+                proposal_by_spec.get(spec.candidate_spec_id, {}).get("training_source")
+            )
+            or "unknown",
             "capital_budget": {
                 "max_notional_per_trade": str(
                     capital_features_by_spec[spec.candidate_spec_id][
@@ -3395,8 +3558,21 @@ def run_whitepaper_autoresearch_profit_target(
             reason="candidate_compiler_produced_no_executable_specs",
             started_at=started_at,
         )
+    try:
+        feedback_evidence_bundles = _load_feedback_evidence_bundles(
+            cast(Sequence[Path], getattr(args, "feedback_evidence_jsonl", ()) or ())
+        )
+    except ValueError as exc:
+        return _write_failure_summary(
+            output_dir=output_dir,
+            epoch_id=epoch_id,
+            status="invalid_feedback_evidence",
+            reason=str(exc),
+            started_at=started_at,
+        )
     pre_replay_model, pre_replay_proposal_rows = _pre_replay_proposal_model_and_rows(
-        specs=candidate_specs
+        specs=candidate_specs,
+        feedback_evidence_bundles=feedback_evidence_bundles,
     )
     _write_json(output_dir / "pre-replay-mlx-ranker-model.json", pre_replay_model)
     _write_jsonl(

--- a/services/torghut/tests/test_candidate_specs.py
+++ b/services/torghut/tests/test_candidate_specs.py
@@ -31,6 +31,37 @@ def _capital_profile(spec: candidate_specs_module.CandidateSpec) -> object:
 
 
 class TestCandidateSpecs(TestCase):
+    def test_profile_rank_floor_handles_invalid_params_and_universe_fallbacks(
+        self,
+    ) -> None:
+        self.assertEqual(
+            candidate_specs_module._profile_rank_count_floor(
+                {
+                    "params": {"rank_count": "not-a-decimal"},
+                    "universe_symbols": "NVDA",
+                }
+            ),
+            1,
+        )
+        self.assertEqual(
+            candidate_specs_module._profile_rank_count_floor(
+                {"params": {}, "universe_symbols": ["NVDA", "", "AMD"]}
+            ),
+            2,
+        )
+
+        fallback = candidate_specs_module._strategy_overrides_for_profile(
+            family_template_id="unknown-family",
+            profile_index=0,
+            target_net_pnl_per_day=Decimal("500"),
+        )
+
+        self.assertEqual(fallback["max_notional_per_trade"], "50000")
+        self.assertEqual(
+            fallback["params"],
+            {"position_isolation_mode": "per_strategy"},
+        )
+
     def test_default_execution_profiles_use_chip_only_universes(self) -> None:
         seen_profiles = 0
         execution_profiles = candidate_specs_module._FAMILY_EXECUTION_PROFILES
@@ -290,8 +321,7 @@ class TestCandidateSpecs(TestCase):
                 spec
                 for spec in specs
                 if spec.family_template_id == family_template_id
-                and _capital_profile(spec)
-                == "initial_equity_cash_constrained_1x"
+                and _capital_profile(spec) == "initial_equity_cash_constrained_1x"
             ]
             self.assertTrue(capital_specs, family_template_id)
             for spec in capital_specs:
@@ -330,9 +360,7 @@ class TestCandidateSpecs(TestCase):
                     spec.candidate_spec_id,
                 )
                 self.assertEqual(
-                    spec.strategy_overrides["params"][
-                        "max_gross_exposure_pct_equity"
-                    ],
+                    spec.strategy_overrides["params"]["max_gross_exposure_pct_equity"],
                     "1.0",
                 )
 

--- a/services/torghut/tests/test_mlx_autoresearch.py
+++ b/services/torghut/tests/test_mlx_autoresearch.py
@@ -8,6 +8,7 @@ from tempfile import TemporaryDirectory
 from unittest import TestCase
 from unittest.mock import patch
 
+import app.trading.discovery.mlx_features as mlx_features_module
 from app.trading.discovery.autoresearch import (
     ProposalModelPolicy,
     ReplayBudget,
@@ -120,6 +121,84 @@ def _program() -> StrategyAutoresearchProgram:
 
 
 class TestMlxAutoresearch(TestCase):
+    def test_descriptor_inference_covers_side_rank_and_universe_fallbacks(
+        self,
+    ) -> None:
+        short_template = FamilyTemplate(
+            family_id="mean_reversion_exhaustion_short_v1",
+            economic_mechanism="Exhaustion reversal.",
+            supported_markets=("us_equities_intraday",),
+            required_features=(),
+            allowed_normalizations=(),
+            entry_motifs=(),
+            exit_motifs=(),
+            risk_controls=(),
+            activity_model={},
+            liquidity_assumptions={},
+            regime_activation_rules=(),
+            day_veto_rules=(),
+            default_hard_vetoes={},
+            default_selection_objectives={},
+            runtime_harness={
+                "family": "mean_reversion_exhaustion_short",
+                "strategy_name": "mean-reversion-short-v1",
+            },
+        )
+        neutral_template = FamilyTemplate(
+            family_id="stat_arb_pairs_v1",
+            economic_mechanism="Paired statistical arbitrage.",
+            supported_markets=("us_equities_intraday",),
+            required_features=(),
+            allowed_normalizations=(),
+            entry_motifs=(),
+            exit_motifs=(),
+            risk_controls=(),
+            activity_model={},
+            liquidity_assumptions={},
+            regime_activation_rules=(),
+            day_veto_rules=(),
+            default_hard_vetoes={},
+            default_selection_objectives={},
+            runtime_harness={"family": "paired_stat_arb", "strategy_name": "pairs-v1"},
+        )
+
+        self.assertEqual(
+            mlx_features_module._infer_side_policy(short_template), "short"
+        )
+        self.assertEqual(
+            mlx_features_module._infer_side_policy(neutral_template),
+            "long_short",
+        )
+        self.assertEqual(
+            mlx_features_module._infer_rank_policy(
+                {"parameters": {"cross_section_signal": ["spread_z"]}},
+                neutral_template,
+            ),
+            "cross_sectional_rank",
+        )
+        self.assertEqual(
+            mlx_features_module._infer_rank_policy(
+                {"parameters": {"rank_feature": ["momentum_z"]}},
+                neutral_template,
+            ),
+            "rank",
+        )
+        self.assertEqual(
+            mlx_features_module._infer_rank_policy(
+                {"parameters": {}}, neutral_template
+            ),
+            "none",
+        )
+        self.assertEqual(
+            mlx_features_module._infer_rank_count(
+                {
+                    "parameters": {},
+                    "strategy_overrides": {"universe_symbols": [["NVDA", "", "AMD"]]},
+                }
+            ),
+            2,
+        )
+
     def test_build_snapshot_manifest_uses_program_snapshot_policy(self) -> None:
         manifest = build_mlx_snapshot_manifest(
             runner_run_id="run-1",
@@ -299,6 +378,49 @@ class TestMlxAutoresearch(TestCase):
             )
 
         self.assertEqual(ranked[0].backend, "numpy-fallback")
+
+    def test_rank_candidate_descriptors_uses_capital_prior_during_cold_start(
+        self,
+    ) -> None:
+        family_plan = Namespace(family_template=_template())
+        over_budget = descriptor_from_sweep_config(
+            candidate_id="aaa-over-budget",
+            family_plan=family_plan,  # type: ignore[arg-type]
+            sweep_config={
+                "parameters": {"max_gross_exposure_pct_equity": ["10.0"]},
+                "strategy_overrides": {
+                    "max_position_pct_equity": ["10.0"],
+                    "max_notional_per_trade": ["315900.20"],
+                },
+            },
+        )
+        feasible = descriptor_from_sweep_config(
+            candidate_id="zzz-feasible",
+            family_plan=family_plan,  # type: ignore[arg-type]
+            sweep_config={
+                "parameters": {"max_gross_exposure_pct_equity": ["1.0"]},
+                "strategy_overrides": {
+                    "max_position_pct_equity": ["0.50"],
+                    "max_notional_per_trade": ["7500"],
+                },
+            },
+        )
+
+        ranked = rank_candidate_descriptors(
+            descriptors=[over_budget, feasible],
+            history_rows=[],
+            policy=ProposalModelPolicy(
+                enabled=True,
+                mode="ranking_only",
+                backend_preference="numpy-fallback",
+                top_k=4,
+                exploration_slots=1,
+                minimum_history_rows=2,
+            ),
+        )
+
+        self.assertEqual(ranked[0].candidate_id, "zzz-feasible")
+        self.assertEqual(ranked[0].mode, "ranking_only_cold_start_capital_prior")
 
     def test_rank_candidate_descriptors_demotes_negative_lift_model(self) -> None:
         family_plan = Namespace(family_template=_template())

--- a/services/torghut/tests/test_mlx_training_data.py
+++ b/services/torghut/tests/test_mlx_training_data.py
@@ -8,6 +8,7 @@ from app.trading.discovery.evidence_bundles import (
     evidence_bundle_from_frontier_candidate,
 )
 from app.trading.discovery.hypothesis_cards import build_hypothesis_cards
+import app.trading.discovery.mlx_training_data as mlx_training_data_module
 from app.trading.discovery.mlx_training_data import (
     MlxRankerModel,
     MlxTrainingRow,
@@ -30,6 +31,25 @@ def _capital_profile(spec: object) -> object:
 
 
 class TestMlxTrainingData(TestCase):
+    def test_training_feedback_helpers_handle_string_vetoes_and_scalar_sequences(
+        self,
+    ) -> None:
+        self.assertEqual(
+            mlx_training_data_module._hard_veto_count(
+                {"hard_vetoes": "positive_day_ratio_below_oracle"}
+            ),
+            1.0,
+        )
+        self.assertEqual(
+            mlx_training_data_module._hard_veto_count({"hard_vetoes": "  "}),
+            0.0,
+        )
+        self.assertEqual(mlx_training_data_module._sequence_strings("NVDA"), ())
+        self.assertEqual(
+            mlx_training_data_module._sequence_strings(["NVDA", "", "AMD"]),
+            ("NVDA", "AMD"),
+        )
+
     def test_candidate_capital_features_include_runtime_slot_pressure(self) -> None:
         spec = CandidateSpec(
             schema_version="torghut.candidate-spec.v1",
@@ -61,6 +81,36 @@ class TestMlxTrainingData(TestCase):
 
         self.assertEqual(features["estimated_capital_slot_count"], 4.0)
         self.assertEqual(features["entry_notional_max_multiplier"], 1.5)
+        self.assertGreater(features["estimated_max_gross_exposure_pct_equity"], 1.0)
+        self.assertEqual(features["capital_feasible_flag"], 0.0)
+
+    def test_candidate_capital_features_infer_uncapped_universe_slots(self) -> None:
+        spec = CandidateSpec(
+            schema_version="torghut.candidate-spec.v1",
+            candidate_spec_id="spec-uncapped-universe",
+            hypothesis_id="H-UNCAPPED",
+            family_template_id="momentum_pullback_v1",
+            candidate_kind="configuration",
+            runtime_family="momentum_pullback_consistent",
+            runtime_strategy_name="momentum-pullback-long-v1",
+            feature_contract={},
+            parameter_space={},
+            strategy_overrides={
+                "max_notional_per_trade": "30000",
+                "max_position_pct_equity": "1",
+                "params": {"max_gross_exposure_pct_equity": "1.0"},
+                "universe_symbols": ["NVDA", "AVGO", "AMD"],
+            },
+            objective={},
+            hard_vetoes={},
+            expected_failure_modes=(),
+            promotion_contract={},
+        )
+
+        features = candidate_spec_capital_features(spec)
+
+        self.assertEqual(features["inferred_universe_slot_floor"], 3.0)
+        self.assertEqual(features["estimated_capital_slot_count"], 3.0)
         self.assertGreater(features["estimated_max_gross_exposure_pct_equity"], 1.0)
         self.assertEqual(features["capital_feasible_flag"], 0.0)
 
@@ -146,9 +196,7 @@ class TestMlxTrainingData(TestCase):
         result = rank_training_rows_with_lift_policy(model=tie_model, rows=rows)
 
         self.assertEqual(result.model_status, "demoted_to_heuristic")
-        self.assertEqual(
-            result.selection_reason, "heuristic_negative_lift_fallback"
-        )
+        self.assertEqual(result.selection_reason, "heuristic_negative_lift_fallback")
         self.assertLess(result.rank_bucket_lift.lift, 0)
         self.assertEqual(result.ranked_rows[0].candidate_spec_id, "aaa-strong")
         self.assertEqual(result.ranked_rows[0].score, 500.0)

--- a/services/torghut/tests/test_portfolio_optimizer.py
+++ b/services/torghut/tests/test_portfolio_optimizer.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from decimal import Decimal
 from unittest import TestCase
 
+import app.trading.discovery.portfolio_optimizer as portfolio_optimizer_module
 from app.trading.discovery.evidence_bundles import (
     CandidateEvidenceBundle,
     evidence_bundle_blockers,
@@ -13,6 +14,7 @@ from app.trading.discovery.portfolio_candidates import (
     portfolio_candidate_from_payload,
 )
 from app.trading.discovery.portfolio_optimizer import optimize_portfolio_candidate
+from app.trading.discovery.profit_target_oracle import ProfitTargetOraclePolicy
 
 
 def _executable_scorecard_fields(index: int | str = 0) -> dict[str, object]:
@@ -26,6 +28,71 @@ def _executable_scorecard_fields(index: int | str = 0) -> dict[str, object]:
 
 
 class TestPortfolioOptimizer(TestCase):
+    def test_capital_safety_rejection_reasons_block_minimums(self) -> None:
+        def bundle(
+            candidate_id: str,
+            scorecard_updates: dict[str, object],
+        ) -> CandidateEvidenceBundle:
+            return evidence_bundle_from_frontier_candidate(
+                candidate_spec_id=f"spec-{candidate_id}",
+                candidate={
+                    "candidate_id": candidate_id,
+                    "objective_scorecard": {
+                        "net_pnl_per_day": "250",
+                        "active_day_ratio": "1.0",
+                        "positive_day_ratio": "1.0",
+                        "max_gross_exposure_pct_equity": "0.5",
+                        "min_cash": "0",
+                        "negative_cash_observation_count": 0,
+                        **scorecard_updates,
+                    },
+                },
+                dataset_snapshot_id="snapshot-capital-safety",
+                result_path=f"/tmp/{candidate_id}.json",
+            )
+
+        malformed_count = bundle(
+            "bad-negative-cash-count",
+            {"negative_cash_observation_count": "NaN"},
+        )
+        max_gross = bundle(
+            "max-gross",
+            {"max_gross_exposure_pct_equity": "1.1"},
+        )
+        min_cash = bundle("min-cash", {"min_cash": "-1"})
+        observed_negative_cash = bundle(
+            "observed-negative-cash",
+            {"negative_cash_observation_count": 2},
+        )
+        zero_pnl = bundle("zero-pnl", {"net_pnl_per_day": "0"})
+
+        self.assertEqual(
+            portfolio_optimizer_module._negative_cash_observation_count(
+                malformed_count
+            ),
+            0,
+        )
+        self.assertEqual(
+            portfolio_optimizer_module._capital_safety_rejection(max_gross)["reason"],
+            "frontier_capital_violation",
+        )
+        self.assertEqual(
+            portfolio_optimizer_module._capital_safety_rejection(min_cash)["reason"],
+            "frontier_negative_cash",
+        )
+        self.assertEqual(
+            portfolio_optimizer_module._capital_safety_rejection(
+                observed_negative_cash
+            )["reason"],
+            "frontier_negative_cash_observed",
+        )
+        self.assertFalse(
+            portfolio_optimizer_module._candidate_passes_minimums(max_gross)
+        )
+        self.assertFalse(
+            portfolio_optimizer_module._candidate_passes_minimums(zero_pnl)
+        )
+
     def test_portfolio_candidate_round_trips_from_optimizer_payload(self) -> None:
         daily_profiles = [
             ("210", "220", "230", "240", "250"),
@@ -461,7 +528,9 @@ class TestPortfolioOptimizer(TestCase):
         ]
         self.assertEqual(len(invalid_rejections), 2)
 
-    def test_frontier_hard_vetoes_are_not_admitted_to_portfolios(self) -> None:
+    def test_non_composable_frontier_hard_vetoes_are_not_admitted_to_portfolios(
+        self,
+    ) -> None:
         def bundle(
             *,
             candidate_id: str,
@@ -519,7 +588,7 @@ class TestPortfolioOptimizer(TestCase):
             net_pnl_per_day="1200",
             symbol="NVDA",
             cluster="vetoed-shock",
-            hard_vetoes=["max_drawdown_above_max", "best_day_share_above_max"],
+            hard_vetoes=["strategy_contract_missing"],
         )
         portfolio = optimize_portfolio_candidate(
             evidence_bundles=[
@@ -544,13 +613,14 @@ class TestPortfolioOptimizer(TestCase):
                 ),
             ],
             target_net_pnl_per_day=Decimal("500"),
+            oracle_policy=ProfitTargetOraclePolicy(max_best_day_share=Decimal("0.40")),
             portfolio_size_min=3,
             portfolio_size_max=3,
         )
 
         self.assertEqual(
             vetoed.objective_scorecard["hard_vetoes"],
-            ["max_drawdown_above_max", "best_day_share_above_max"],
+            ["strategy_contract_missing"],
         )
         self.assertIsNotNone(portfolio)
         assert portfolio is not None
@@ -563,14 +633,105 @@ class TestPortfolioOptimizer(TestCase):
         self.assertIn(
             {
                 "candidate_id": "cand-vetoed-shock",
-                "reason": "frontier_hard_veto",
-                "hard_vetoes": [
-                    "max_drawdown_above_max",
-                    "best_day_share_above_max",
-                ],
+                "reason": "frontier_non_composable_hard_veto",
+                "hard_vetoes": ["strategy_contract_missing"],
             },
             portfolio.optimizer_report["rejections"],
         )
+
+    def test_optimizer_can_compose_capital_safe_single_sleeve_vetoes(self) -> None:
+        def bundle(
+            *,
+            candidate_id: str,
+            symbol: str,
+            cluster: str,
+            daily_net: tuple[str, str, str],
+        ) -> CandidateEvidenceBundle:
+            return evidence_bundle_from_frontier_candidate(
+                candidate_spec_id=f"spec-{candidate_id}",
+                candidate={
+                    "candidate_id": candidate_id,
+                    "runtime_family": "microbar_cross_sectional_pairs",
+                    "runtime_strategy_name": "microbar-cross-sectional-pairs-v1",
+                    "family_template_id": "microbar_cross_sectional_pairs_v1",
+                    "hard_vetoes": [
+                        "avg_daily_notional_below_min",
+                        "best_day_share_above_max",
+                        "positive_day_ratio_below_oracle",
+                    ],
+                    "objective_scorecard": {
+                        "net_pnl_per_day": "190",
+                        "active_day_ratio": "1.0",
+                        "positive_day_ratio": "0.67",
+                        "worst_day_loss": "40",
+                        "max_drawdown": "40",
+                        "max_gross_exposure_pct_equity": "0.25",
+                        "min_cash": "12000",
+                        "negative_cash_observation_count": 0,
+                        "best_day_share": "0.80",
+                        "avg_filled_notional_per_day": "120000",
+                        "regime_slice_pass_rate": "0.55",
+                        "posterior_edge_lower": "0.01",
+                        "shadow_parity_status": "within_budget",
+                        "correlation_cluster": cluster,
+                        "symbol_contribution_shares": {symbol: "1.0"},
+                        **_executable_scorecard_fields(candidate_id),
+                    },
+                    "full_window": {
+                        "daily_net": {
+                            "2026-02-23": daily_net[0],
+                            "2026-02-24": daily_net[1],
+                            "2026-02-25": daily_net[2],
+                        },
+                        "daily_filled_notional": {
+                            "2026-02-23": "120000",
+                            "2026-02-24": "120000",
+                            "2026-02-25": "120000",
+                        },
+                    },
+                },
+                dataset_snapshot_id="snapshot-composable-vetoes",
+                result_path=f"/tmp/{candidate_id}.json",
+            )
+
+        portfolio = optimize_portfolio_candidate(
+            evidence_bundles=[
+                bundle(
+                    candidate_id="cand-offset-a",
+                    symbol="AAPL",
+                    cluster="offset-a",
+                    daily_net=("300", "-40", "310"),
+                ),
+                bundle(
+                    candidate_id="cand-offset-b",
+                    symbol="AMZN",
+                    cluster="offset-b",
+                    daily_net=("-40", "310", "300"),
+                ),
+                bundle(
+                    candidate_id="cand-offset-c",
+                    symbol="GOOGL",
+                    cluster="offset-c",
+                    daily_net=("310", "300", "-40"),
+                ),
+            ],
+            target_net_pnl_per_day=Decimal("500"),
+            oracle_policy=ProfitTargetOraclePolicy(max_best_day_share=Decimal("0.40")),
+            portfolio_size_min=3,
+            portfolio_size_max=3,
+        )
+
+        self.assertIsNotNone(portfolio)
+        assert portfolio is not None
+        self.assertCountEqual(
+            portfolio.source_candidate_ids,
+            ("cand-offset-a", "cand-offset-b", "cand-offset-c"),
+        )
+        self.assertEqual(
+            portfolio.objective_scorecard["max_gross_exposure_pct_equity"],
+            "0.75",
+        )
+        self.assertTrue(portfolio.objective_scorecard["oracle_passed"])
 
     def test_portfolio_candidate_rejects_pnl_only_replay_without_executable_proof(
         self,

--- a/services/torghut/tests/test_profit_target_oracle.py
+++ b/services/torghut/tests/test_profit_target_oracle.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 from decimal import Decimal
 from unittest import TestCase
 
-from app.trading.discovery.profit_target_oracle import ProfitTargetOraclePolicy, evaluate_profit_target_oracle
+from app.trading.discovery.profit_target_oracle import (
+    ProfitTargetOraclePolicy,
+    evaluate_profit_target_oracle,
+)
 
 
 def _executable_scorecard_fields() -> dict[str, object]:
@@ -173,3 +176,32 @@ class TestProfitTargetOracle(TestCase):
         self.assertIn("executable_replay_passed_failed", result["blockers"])
         self.assertIn("executable_replay_artifact_present_failed", result["blockers"])
         self.assertIn("executable_replay_order_count_failed", result["blockers"])
+
+    def test_profit_target_oracle_rejects_capital_unsafe_replay(self) -> None:
+        result = evaluate_profit_target_oracle(
+            {
+                "net_pnl_per_day": "900",
+                "active_day_ratio": "1",
+                "positive_day_ratio": "1",
+                "best_day_share": "0.20",
+                "max_single_day_contribution_share": "0.20",
+                "max_cluster_contribution_share": "0.34",
+                "max_single_symbol_contribution_share": "0.25",
+                "worst_day_loss": "0",
+                "max_drawdown": "0",
+                "max_gross_exposure_pct_equity": "1.25",
+                "min_cash": "-1",
+                "negative_cash_observation_count": 2,
+                "avg_filled_notional_per_day": "700000",
+                "regime_slice_pass_rate": "0.55",
+                "posterior_edge_lower": "0.01",
+                "shadow_parity_status": "within_budget",
+                **_executable_scorecard_fields(),
+            },
+            target_net_pnl_per_day=Decimal("500"),
+        )
+
+        self.assertFalse(result["passed"])
+        self.assertIn("max_gross_exposure_pct_equity_failed", result["blockers"])
+        self.assertIn("min_cash_failed", result["blockers"])
+        self.assertIn("negative_cash_observation_count_failed", result["blockers"])

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import replace
 import json
 import sys
 from argparse import Namespace
@@ -86,6 +87,7 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             output_dir=output_dir,
             paper_run_id=[],
             source_jsonl=[],
+            feedback_evidence_jsonl=[],
             seed_recent_whitepapers=True,
             target_net_pnl_per_day="500",
             max_candidates=8,
@@ -125,6 +127,71 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             persist_results=False,
         )
 
+    def _source_jsonl_args(
+        self,
+        output_dir: Path,
+        *,
+        source_count: int = 1,
+    ) -> Namespace:
+        source_path = output_dir.parent / "source.jsonl"
+        rows: list[str] = []
+        for index in range(source_count):
+            source_payload = _source_jsonl_payload()
+            source_payload["run_id"] = f"paper-jsonl-{index}"
+            rows.append(json.dumps(source_payload))
+        source_path.write_text("\n".join(rows) + "\n", encoding="utf-8")
+        args = self._args(output_dir)
+        args.seed_recent_whitepapers = False
+        args.source_jsonl = [source_path]
+        return args
+
+    def _candidate_spec(
+        self,
+        candidate_spec_id: str,
+        *,
+        family_template_id: str = "microbar_cross_sectional_pairs_v1",
+        entry_minute_after_open: str = "45",
+        selection_mode: str = "reversal",
+    ) -> runner.CandidateSpec:
+        return runner.CandidateSpec(
+            schema_version="torghut.candidate-spec.v1",
+            candidate_spec_id=candidate_spec_id,
+            hypothesis_id=f"hyp-{candidate_spec_id}",
+            family_template_id=family_template_id,
+            candidate_kind="sleeve",
+            runtime_family=family_template_id.replace("_v1", ""),
+            runtime_strategy_name=f"{family_template_id}-runtime",
+            feature_contract={
+                "mechanism": "deterministic test spec",
+                "required_features": ("spread_bps", "depth_proxy"),
+                "source_run_id": f"source-{candidate_spec_id}",
+                "family_selection": {"rank": 1},
+            },
+            parameter_space={},
+            strategy_overrides={
+                "max_notional_per_trade": "7500",
+                "max_position_pct_equity": "0.25",
+                "params": {
+                    "entry_minute_after_open": entry_minute_after_open,
+                    "exit_minute_after_open": "150",
+                    "max_hold_seconds": "5400",
+                    "entry_cooldown_seconds": "1200",
+                    "long_stop_loss_bps": "8",
+                    "long_trailing_stop_activation_profit_bps": "6",
+                    "long_trailing_stop_drawdown_bps": "3",
+                    "selection_mode": selection_mode,
+                    "signal_motif": "open_window_reversal",
+                    "rank_feature": "cross_section_session_open_rank",
+                    "top_n": "2",
+                },
+                "universe_symbols": ["NVDA", "AAPL", "INTC"],
+            },
+            objective={"target_net_pnl_per_day": "500"},
+            hard_vetoes={},
+            expected_failure_modes=(),
+            promotion_contract={},
+        )
+
     def test_parse_args_defaults_to_500_daily_profit_program(self) -> None:
         with TemporaryDirectory() as tmpdir:
             with patch.object(
@@ -146,6 +213,329 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             ),
         )
         self.assertEqual(args.symbols.split(","), _CHIP_UNIVERSE)
+        self.assertEqual(args.feedback_evidence_jsonl, [])
+
+    def test_pre_replay_ranker_ingests_feedback_evidence_bundles(self) -> None:
+        losing_spec = self._candidate_spec(
+            "spec-losing",
+            entry_minute_after_open="45",
+            selection_mode="reversal",
+        )
+        unexplored_spec = self._candidate_spec(
+            "spec-unexplored",
+            family_template_id="breakout_reclaim_v2",
+            entry_minute_after_open="90",
+            selection_mode="continuation",
+        )
+        capital_unsafe_spec = self._candidate_spec(
+            "spec-capital-unsafe",
+            family_template_id="momentum_pullback_v1",
+            entry_minute_after_open="75",
+            selection_mode="continuation",
+        )
+        losing_bundle = runner.evidence_bundle_from_frontier_candidate(
+            candidate_spec_id=losing_spec.candidate_spec_id,
+            candidate={
+                "candidate_id": "cand-losing",
+                "family_template_id": losing_spec.family_template_id,
+                "runtime_family": losing_spec.runtime_family,
+                "runtime_strategy_name": losing_spec.runtime_strategy_name,
+                "objective_scorecard": {
+                    "net_pnl_per_day": "-120",
+                    "active_day_ratio": "1",
+                    "positive_day_ratio": "0",
+                    "negative_day_count": 6,
+                    "best_day_share": "1",
+                    "worst_day_loss": "430",
+                    "max_drawdown": "997",
+                    "avg_filled_notional_per_day": "50000",
+                    "hard_vetoes": ["positive_day_ratio_below_oracle"],
+                    "daily_net": {
+                        "2026-05-01": "-100",
+                        "2026-05-04": "-140",
+                    },
+                },
+            },
+            dataset_snapshot_id="snap-feedback",
+            result_path="feedback://losing",
+        )
+        capital_unsafe_bundle = runner.evidence_bundle_from_frontier_candidate(
+            candidate_spec_id=capital_unsafe_spec.candidate_spec_id,
+            candidate={
+                "candidate_id": "cand-capital-unsafe",
+                "family_template_id": capital_unsafe_spec.family_template_id,
+                "runtime_family": capital_unsafe_spec.runtime_family,
+                "runtime_strategy_name": capital_unsafe_spec.runtime_strategy_name,
+                "objective_scorecard": {
+                    "net_pnl_per_day": "750",
+                    "active_day_ratio": "1",
+                    "positive_day_ratio": "1",
+                    "negative_day_count": 0,
+                    "best_day_share": "0.25",
+                    "worst_day_loss": "0",
+                    "max_drawdown": "0",
+                    "max_gross_exposure_pct_equity": "2.5",
+                    "min_cash": "-500",
+                    "negative_cash_observation_count": 8,
+                    "avg_filled_notional_per_day": "500000",
+                },
+            },
+            dataset_snapshot_id="snap-feedback",
+            result_path="feedback://capital-unsafe",
+        )
+
+        model, rows = runner._pre_replay_proposal_model_and_rows(
+            specs=(losing_spec, unexplored_spec, capital_unsafe_spec),
+            feedback_evidence_bundles=(losing_bundle, capital_unsafe_bundle),
+        )
+
+        row_by_spec = {row["candidate_spec_id"]: row for row in rows}
+        self.assertEqual(model["feedback_evidence_bundle_count"], 2)
+        self.assertEqual(model["feedback_matched_spec_count"], 2)
+        self.assertEqual(
+            model["training_source_counts"],
+            {"feedback_real_replay": 2, "synthetic_prior": 1},
+        )
+        self.assertEqual(
+            row_by_spec[losing_spec.candidate_spec_id]["training_source"],
+            "feedback_real_replay",
+        )
+        self.assertEqual(
+            row_by_spec[losing_spec.candidate_spec_id]["selection_reason"],
+            "pre_replay_mlx_feedback_blocked",
+        )
+        self.assertEqual(
+            row_by_spec[capital_unsafe_spec.candidate_spec_id]["selection_reason"],
+            "pre_replay_mlx_feedback_blocked",
+        )
+        self.assertGreater(
+            row_by_spec[losing_spec.candidate_spec_id]["rank"],
+            row_by_spec[unexplored_spec.candidate_spec_id]["rank"],
+        )
+        self.assertGreater(
+            row_by_spec[capital_unsafe_spec.candidate_spec_id]["rank"],
+            row_by_spec[unexplored_spec.candidate_spec_id]["rank"],
+        )
+        self.assertEqual(
+            row_by_spec[unexplored_spec.candidate_spec_id]["training_source"],
+            "synthetic_prior",
+        )
+        self.assertIn(
+            "history_daily_target_shortfall",
+            row_by_spec[losing_spec.candidate_spec_id]["features"],
+        )
+
+    def test_feedback_evidence_jsonl_round_trips(self) -> None:
+        spec = self._candidate_spec("spec-feedback-jsonl")
+        bundle = runner.evidence_bundle_from_frontier_candidate(
+            candidate_spec_id=spec.candidate_spec_id,
+            candidate={
+                "candidate_id": "cand-feedback-jsonl",
+                "objective_scorecard": {
+                    "net_pnl_per_day": "42",
+                    "active_day_ratio": "1",
+                },
+            },
+            dataset_snapshot_id="snap-feedback",
+            result_path="feedback://jsonl",
+        )
+
+        with TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "feedback.jsonl"
+            path.write_text(
+                json.dumps(bundle.to_payload(), sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+            loaded = runner._load_feedback_evidence_bundles((path,))
+
+        self.assertEqual(len(loaded), 1)
+        self.assertEqual(loaded[0].candidate_spec_id, spec.candidate_spec_id)
+
+    def test_feedback_evidence_jsonl_reports_missing_and_invalid_lines(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            missing_path = Path(tmpdir) / "missing.jsonl"
+            with self.assertRaisesRegex(
+                ValueError,
+                "feedback_evidence_jsonl_missing",
+            ):
+                runner._load_feedback_evidence_bundles((missing_path,))
+
+            invalid_path = Path(tmpdir) / "invalid.jsonl"
+            invalid_path.write_text("\n[]\n", encoding="utf-8")
+            with self.assertRaisesRegex(
+                ValueError,
+                "feedback_evidence_jsonl_invalid",
+            ):
+                runner._load_feedback_evidence_bundles((invalid_path,))
+
+    def test_candidate_quality_gate_flags_capital_safety_failures(self) -> None:
+        policy = runner.ProfitTargetOraclePolicy()
+
+        failures = runner._candidate_quality_gate_failures(
+            {
+                "net_pnl_per_day": "750",
+                "active_day_ratio": "1",
+                "positive_day_ratio": "1",
+                "best_day_share": "0.1",
+                "worst_day_loss": "0",
+                "max_drawdown": "0",
+                "max_gross_exposure_pct_equity": "1.2",
+                "min_cash": "-10",
+                "negative_cash_observation_count": "1",
+                "avg_filled_notional_per_day": "500000",
+                "regime_slice_pass_rate": "1",
+                "posterior_edge_lower": "0.01",
+                "shadow_parity_status": "within_budget",
+                "executable_replay_passed": True,
+                "executable_replay_artifact_ref": "/tmp/replay.json",
+                "executable_replay_order_count": "5",
+                "executable_replay_account_buying_power": "10000",
+                "executable_replay_max_notional_per_trade": "9000",
+            },
+            oracle_policy=policy,
+        )
+
+        self.assertIn("max_gross_exposure_above_oracle", failures)
+        self.assertIn("min_cash_below_oracle", failures)
+        self.assertIn("negative_cash_observed", failures)
+
+    def test_pre_replay_ranker_keeps_best_duplicate_feedback_and_blocks_rejections(
+        self,
+    ) -> None:
+        string_veto_spec = self._candidate_spec("spec-string-veto")
+        min_cash_spec = self._candidate_spec("spec-min-cash")
+        negative_cash_spec = self._candidate_spec("spec-negative-cash")
+        unexplored_spec = self._candidate_spec(
+            "spec-unexplored-feedback",
+            family_template_id="breakout_reclaim_v2",
+            entry_minute_after_open="90",
+            selection_mode="continuation",
+        )
+
+        def feedback(
+            spec: runner.CandidateSpec,
+            *,
+            candidate_id: str,
+            scorecard: dict[str, object],
+        ) -> runner.CandidateEvidenceBundle:
+            return runner.evidence_bundle_from_frontier_candidate(
+                candidate_spec_id=spec.candidate_spec_id,
+                candidate={
+                    "candidate_id": candidate_id,
+                    "family_template_id": spec.family_template_id,
+                    "runtime_family": spec.runtime_family,
+                    "runtime_strategy_name": spec.runtime_strategy_name,
+                    "objective_scorecard": {
+                        "net_pnl_per_day": "100",
+                        "active_day_ratio": "1",
+                        "positive_day_ratio": "1",
+                        "negative_day_count": 0,
+                        "best_day_share": "0.2",
+                        "worst_day_loss": "0",
+                        "max_drawdown": "0",
+                        "max_gross_exposure_pct_equity": "0.5",
+                        "min_cash": "0",
+                        "negative_cash_observation_count": 0,
+                        "avg_filled_notional_per_day": "500000",
+                        **scorecard,
+                    },
+                },
+                dataset_snapshot_id="snap-feedback-blockers",
+                result_path=f"feedback://{candidate_id}",
+            )
+
+        lower_duplicate = feedback(
+            string_veto_spec,
+            candidate_id="cand-string-veto-low",
+            scorecard={"net_pnl_per_day": "-500"},
+        )
+        higher_blocked_duplicate = feedback(
+            string_veto_spec,
+            candidate_id="cand-string-veto-high",
+            scorecard={
+                "net_pnl_per_day": "250",
+                "hard_vetoes": "positive_day_ratio_below_oracle",
+            },
+        )
+        min_cash_blocked = feedback(
+            min_cash_spec,
+            candidate_id="cand-min-cash",
+            scorecard={"min_cash": "-1"},
+        )
+        negative_cash_blocked = feedback(
+            negative_cash_spec,
+            candidate_id="cand-negative-cash",
+            scorecard={"negative_cash_observation_count": "1"},
+        )
+
+        model, rows = runner._pre_replay_proposal_model_and_rows(
+            specs=(
+                string_veto_spec,
+                min_cash_spec,
+                negative_cash_spec,
+                unexplored_spec,
+            ),
+            feedback_evidence_bundles=(
+                lower_duplicate,
+                higher_blocked_duplicate,
+                min_cash_blocked,
+                negative_cash_blocked,
+            ),
+        )
+
+        row_by_spec = {row["candidate_spec_id"]: row for row in rows}
+        self.assertEqual(model["feedback_evidence_bundle_count"], 4)
+        self.assertEqual(model["feedback_matched_spec_count"], 3)
+        self.assertEqual(
+            row_by_spec[string_veto_spec.candidate_spec_id]["feedback_replay_target"],
+            135.0,
+        )
+        self.assertEqual(
+            row_by_spec[string_veto_spec.candidate_spec_id]["selection_reason"],
+            "pre_replay_mlx_feedback_blocked",
+        )
+        self.assertEqual(
+            row_by_spec[min_cash_spec.candidate_spec_id]["selection_reason"],
+            "pre_replay_mlx_feedback_blocked",
+        )
+        self.assertEqual(
+            row_by_spec[negative_cash_spec.candidate_spec_id]["selection_reason"],
+            "pre_replay_mlx_feedback_blocked",
+        )
+        self.assertEqual(
+            row_by_spec[unexplored_spec.candidate_spec_id]["training_source"],
+            "synthetic_prior",
+        )
+
+    def test_candidate_selection_handles_scalar_universe_overrides(self) -> None:
+        scalar_universe_spec = replace(
+            self._candidate_spec("spec-scalar-universe"),
+            strategy_overrides={
+                "max_notional_per_trade": "7500",
+                "max_position_pct_equity": "0.25",
+                "params": {"entry_minute_after_open": "45"},
+                "universe_symbols": "NVDA",
+            },
+        )
+
+        selected, selection = runner._select_candidate_specs_for_replay(
+            specs=(scalar_universe_spec,),
+            proposal_rows=[
+                {
+                    "candidate_spec_id": scalar_universe_spec.candidate_spec_id,
+                    "rank": 1,
+                    "proposal_score": 10.0,
+                    "training_source": "synthetic_prior",
+                }
+            ],
+            top_k=1,
+            exploration_slots=0,
+            max_candidates=1,
+            portfolio_size_min=1,
+        )
+
+        self.assertEqual(selected, [scalar_universe_spec])
+        self.assertEqual(selection["rows"][0]["universe_key"], "")
 
     def test_parse_args_defaults_strategy_configmap_to_runtime_env_path(self) -> None:
         with TemporaryDirectory() as tmpdir:
@@ -901,7 +1291,7 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
     def test_seed_recent_whitepapers_dedupes_execution_signatures(self) -> None:
         with TemporaryDirectory() as tmpdir:
             output_dir = Path(tmpdir) / "epoch"
-            args = self._args(output_dir)
+            args = self._source_jsonl_args(output_dir, source_count=2)
             args.top_k = 6
             args.exploration_slots = 4
             payload = runner.run_whitepaper_autoresearch_profit_target(args)
@@ -1141,7 +1531,7 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         with TemporaryDirectory() as tmpdir:
             output_dir = Path(tmpdir) / "epoch"
             payload = runner.run_whitepaper_autoresearch_profit_target(
-                self._args(output_dir)
+                self._source_jsonl_args(output_dir)
             )
 
             model_payload, scores = ranker_trainer.train_from_artifacts(
@@ -1169,7 +1559,7 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                 "_parse_args",
                 return_value=Namespace(
                     **{
-                        **vars(self._args(Path(tmpdir) / "epoch")),
+                        **vars(self._source_jsonl_args(Path(tmpdir) / "epoch")),
                         "replay_mode": "real",
                     }
                 ),
@@ -1644,7 +2034,7 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         with TemporaryDirectory() as tmpdir:
             output_dir = Path(tmpdir) / "epoch"
             payload = runner.run_whitepaper_autoresearch_profit_target(
-                self._args(output_dir)
+                self._source_jsonl_args(output_dir)
             )
             model_output = Path(tmpdir) / "ranker" / "model.json"
             scores_output = Path(tmpdir) / "ranker" / "scores.jsonl"
@@ -2541,7 +2931,7 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                     failure_reasons=("TimeoutError:real_replay_timeout_seconds:7",),
                 )
 
-            args = self._args(output_dir)
+            args = self._source_jsonl_args(output_dir)
             args.replay_mode = "real"
             args.portfolio_size_min = 1
             with patch.object(

--- a/services/torghut/tests/test_strategy_autoresearch.py
+++ b/services/torghut/tests/test_strategy_autoresearch.py
@@ -36,73 +36,135 @@ import scripts.run_strategy_autoresearch_loop as runner
 
 def _family_template() -> FamilyTemplate:
     return FamilyTemplate(
-        family_id='breakout_reclaim_v2',
-        economic_mechanism='Breakout reclaim.',
-        supported_markets=('us_equities_intraday',),
-        required_features=('quote_quality',),
-        allowed_normalizations=('price_scaled', 'opening_window_scaled'),
-        entry_motifs=('breakout_reclaim',),
-        exit_motifs=('trailing_stop',),
-        risk_controls=('stop_loss',),
-        activity_model={'min_active_day_ratio': '0.50', 'min_daily_notional': '200000'},
-        liquidity_assumptions={'max_spread_bps': '30'},
+        family_id="breakout_reclaim_v2",
+        economic_mechanism="Breakout reclaim.",
+        supported_markets=("us_equities_intraday",),
+        required_features=("quote_quality",),
+        allowed_normalizations=("price_scaled", "opening_window_scaled"),
+        entry_motifs=("breakout_reclaim",),
+        exit_motifs=("trailing_stop",),
+        risk_controls=("stop_loss",),
+        activity_model={"min_active_day_ratio": "0.50", "min_daily_notional": "200000"},
+        liquidity_assumptions={"max_spread_bps": "30"},
         regime_activation_rules=(),
         day_veto_rules=(),
-        default_hard_vetoes={'required_max_best_day_share': '0.45'},
-        default_selection_objectives={'target_net_pnl_per_day': '300'},
+        default_hard_vetoes={"required_max_best_day_share": "0.45"},
+        default_selection_objectives={"target_net_pnl_per_day": "300"},
         runtime_harness={
-            'family': 'breakout_continuation_consistent',
-            'strategy_name': 'breakout-continuation-long-v1',
-            'disable_other_strategies': True,
+            "family": "breakout_continuation_consistent",
+            "strategy_name": "breakout-continuation-long-v1",
+            "disable_other_strategies": True,
         },
     )
 
 
 class TestStrategyAutoresearch(TestCase):
     def test_autoresearch_helper_branches_cover_edge_cases(self) -> None:
-        self.assertEqual(autoresearch._string_list('not-a-list'), ())
-        self.assertEqual(autoresearch._string_list(['', ' NVDA ', None]), ('NVDA',))
+        self.assertEqual(autoresearch._string_list("not-a-list"), ())
+        self.assertEqual(autoresearch._string_list(["", " NVDA ", None]), ("NVDA",))
         self.assertEqual(
-            autoresearch._stable_value_key({'b': 2, 'a': 1}),
+            autoresearch._stable_value_key({"b": 2, "a": 1}),
             '{"a":1,"b":2}',
         )
         self.assertIsNone(autoresearch._decimal_from_candidate(None))
-        self.assertIsNone(autoresearch._decimal_from_candidate('not-a-number'))
+        self.assertIsNone(autoresearch._decimal_from_candidate("not-a-number"))
         self.assertEqual(
-            autoresearch._format_numeric_like(Decimal('3'), current_value='2'),
-            '3',
+            autoresearch._format_numeric_like(Decimal("3"), current_value="2"),
+            "3",
         )
         self.assertEqual(
-            autoresearch._format_numeric_like(Decimal('3.125'), current_value='2.00'),
-            '3.12',
+            autoresearch._format_numeric_like(Decimal("3.125"), current_value="2.00"),
+            "3.12",
         )
         self.assertEqual(
-            autoresearch._format_numeric_like(Decimal('3.1400'), current_value=''),
-            '3.14',
+            autoresearch._format_numeric_like(Decimal("3.1400"), current_value=""),
+            "3.14",
         )
 
+    def test_apply_objective_capital_limits_clamps_legacy_seed_leverage(self) -> None:
+        limited = runner._apply_objective_capital_limits(
+            sweep_config={
+                "parameters": {
+                    "max_entries_per_session": ["2", "3"],
+                    "max_gross_exposure_pct_equity": ["10.0"],
+                },
+                "strategy_overrides": {
+                    "max_position_pct_equity": ["10.0"],
+                    "max_notional_per_trade": ["315900.20"],
+                },
+            },
+            max_gross_exposure_pct_equity=Decimal("1.0"),
+            start_equity=Decimal("31590.02"),
+        )
+
+        self.assertEqual(
+            limited["parameters"]["max_gross_exposure_pct_equity"], ["0.98"]
+        )
+        self.assertEqual(
+            limited["strategy_overrides"]["max_position_pct_equity"], ["0.326666"]
+        )
+        self.assertEqual(
+            limited["strategy_overrides"]["max_notional_per_trade"], ["10319.4"]
+        )
+
+    def test_runtime_closure_candidate_rejects_failed_or_vetoed_candidates(
+        self,
+    ) -> None:
+        self.assertIsNone(runner._runtime_closure_candidate(None))
+        self.assertIsNone(
+            runner._runtime_closure_candidate(
+                {"candidate_id": "failed", "objective_met": False, "hard_vetoes": []}
+            )
+        )
+        self.assertIsNone(
+            runner._runtime_closure_candidate(
+                {
+                    "candidate_id": "vetoed",
+                    "objective_met": True,
+                    "hard_vetoes": ["daily_net_below_min"],
+                }
+            )
+        )
+        eligible = {
+            "candidate_id": "eligible",
+            "objective_met": True,
+            "hard_vetoes": [],
+        }
+
+        self.assertIs(runner._runtime_closure_candidate(eligible), eligible)
+
     def test_load_mutation_space_rejects_invalid_mode(self) -> None:
-        with self.assertRaisesRegex(ValueError, 'autoresearch_mutation_mode_invalid'):
-            autoresearch._load_mutation_space({'mode': 'bad-mode'})
+        with self.assertRaisesRegex(ValueError, "autoresearch_mutation_mode_invalid"):
+            autoresearch._load_mutation_space({"mode": "bad-mode"})
 
     def test_resolve_seed_sweep_path_keeps_absolute_path(self) -> None:
         with TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
-            absolute = root / 'seed.yaml'
+            absolute = root / "seed.yaml"
             resolved = autoresearch._resolve_seed_sweep_path(
-                program_path=root / 'program.yaml',
+                program_path=root / "program.yaml",
                 raw_path=str(absolute),
             )
 
         self.assertEqual(resolved, absolute)
 
     def test_parse_args_defaults_strategy_configmap_to_repo_root(self) -> None:
-        with patch.object(sys, 'argv', ['run_strategy_autoresearch_loop.py', '--program', 'program.yaml', '--output-dir', '/tmp/out']):
+        with patch.object(
+            sys,
+            "argv",
+            [
+                "run_strategy_autoresearch_loop.py",
+                "--program",
+                "program.yaml",
+                "--output-dir",
+                "/tmp/out",
+            ],
+        ):
             args = runner._parse_args()
 
         self.assertEqual(
             args.strategy_configmap,
-            runner._REPO_ROOT / 'argocd/applications/torghut/strategy-configmap.yaml',
+            runner._REPO_ROOT / "argocd/applications/torghut/strategy-configmap.yaml",
         )
         self.assertIsNone(args.shadow_validation_artifact)
 
@@ -111,144 +173,153 @@ class TestStrategyAutoresearch(TestCase):
             root = Path(tmpdir)
             program_path, family_dir = self._write_program_fixture(root)
 
-            program = load_strategy_autoresearch_program(program_path, family_dir=family_dir)
+            program = load_strategy_autoresearch_program(
+                program_path, family_dir=family_dir
+            )
 
-        self.assertEqual(program.snapshot_policy.feature_set_id, 'torghut.mlx-autoresearch.v1')
+        self.assertEqual(
+            program.snapshot_policy.feature_set_id, "torghut.mlx-autoresearch.v1"
+        )
         self.assertTrue(program.proposal_model_policy.enabled)
-        self.assertEqual(program.proposal_model_policy.mode, 'ranking_only')
-        self.assertEqual(program.promotion_policy, 'research_only')
-        self.assertIn('scheduler_v3_parity_replay', program.parity_requirements)
+        self.assertEqual(program.proposal_model_policy.mode, "ranking_only")
+        self.assertEqual(program.promotion_policy, "research_only")
+        self.assertIn("scheduler_v3_parity_replay", program.parity_requirements)
         self.assertFalse(program.runtime_closure_policy.enabled)
-        self.assertEqual(program.runtime_closure_policy.parity_window, 'full_window')
-        self.assertEqual(program.runtime_closure_policy.approval_window, 'holdout')
+        self.assertEqual(program.runtime_closure_policy.parity_window, "full_window")
+        self.assertEqual(program.runtime_closure_policy.approval_window, "holdout")
         self.assertEqual(program.replay_budget.max_candidates_per_frontier_run, 96)
-        self.assertTrue(program.ledger_policy['append_only'])
+        self.assertTrue(program.ledger_policy["append_only"])
 
     def _write_program_fixture(self, root: Path) -> tuple[Path, Path]:
-        family_dir = root / 'families'
+        family_dir = root / "families"
         family_dir.mkdir()
-        (family_dir / 'breakout_reclaim_v2.yaml').write_text(
+        (family_dir / "breakout_reclaim_v2.yaml").write_text(
             yaml.safe_dump(
                 {
-                    'schema_version': 'torghut.family-template.v1',
-                    'family_id': 'breakout_reclaim_v2',
-                    'economic_mechanism': 'Breakout reclaim.',
-                    'supported_markets': ['us_equities_intraday'],
-                    'required_features': ['quote_quality'],
-                    'allowed_normalizations': ['price_scaled', 'opening_window_scaled'],
-                    'entry_motifs': ['breakout_reclaim'],
-                    'exit_motifs': ['trailing_stop'],
-                    'risk_controls': ['stop_loss'],
-                    'activity_model': {'min_active_day_ratio': '0.50', 'min_daily_notional': '200000'},
-                    'liquidity_assumptions': {'max_spread_bps': '30'},
-                    'regime_activation_rules': [],
-                    'day_veto_rules': [],
-                    'default_hard_vetoes': {'required_max_best_day_share': '0.45'},
-                    'default_selection_objectives': {'target_net_pnl_per_day': '300'},
-                    'runtime_harness': {
-                        'family': 'breakout_continuation_consistent',
-                        'strategy_name': 'breakout-continuation-long-v1',
-                        'disable_other_strategies': True,
+                    "schema_version": "torghut.family-template.v1",
+                    "family_id": "breakout_reclaim_v2",
+                    "economic_mechanism": "Breakout reclaim.",
+                    "supported_markets": ["us_equities_intraday"],
+                    "required_features": ["quote_quality"],
+                    "allowed_normalizations": ["price_scaled", "opening_window_scaled"],
+                    "entry_motifs": ["breakout_reclaim"],
+                    "exit_motifs": ["trailing_stop"],
+                    "risk_controls": ["stop_loss"],
+                    "activity_model": {
+                        "min_active_day_ratio": "0.50",
+                        "min_daily_notional": "200000",
+                    },
+                    "liquidity_assumptions": {"max_spread_bps": "30"},
+                    "regime_activation_rules": [],
+                    "day_veto_rules": [],
+                    "default_hard_vetoes": {"required_max_best_day_share": "0.45"},
+                    "default_selection_objectives": {"target_net_pnl_per_day": "300"},
+                    "runtime_harness": {
+                        "family": "breakout_continuation_consistent",
+                        "strategy_name": "breakout-continuation-long-v1",
+                        "disable_other_strategies": True,
                     },
                 },
                 sort_keys=False,
             ),
-            encoding='utf-8',
+            encoding="utf-8",
         )
-        sweep_path = root / 'profitability-frontier-consistent-breakout.yaml'
+        sweep_path = root / "profitability-frontier-consistent-breakout.yaml"
         sweep_path.write_text(
             yaml.safe_dump(
                 {
-                    'schema_version': 'torghut.replay-frontier-sweep.v1',
-                    'family': 'breakout_continuation_consistent',
-                    'family_template_id': 'breakout_reclaim_v2',
-                    'strategy_name': 'breakout-continuation-long-v1',
-                    'disable_other_strategies': True,
-                    'constraints': {'holdout_target_net_per_day': '300'},
-                    'consistency_constraints': {'target_net_per_day': '300'},
-                    'strategy_overrides': {
-                        'universe_symbols': [['AMAT', 'NVDA']],
-                        'max_position_pct_equity': ['10.0'],
+                    "schema_version": "torghut.replay-frontier-sweep.v1",
+                    "family": "breakout_continuation_consistent",
+                    "family_template_id": "breakout_reclaim_v2",
+                    "strategy_name": "breakout-continuation-long-v1",
+                    "disable_other_strategies": True,
+                    "constraints": {"holdout_target_net_per_day": "300"},
+                    "consistency_constraints": {"target_net_per_day": "300"},
+                    "strategy_overrides": {
+                        "universe_symbols": [["AMAT", "NVDA"]],
+                        "max_position_pct_equity": ["10.0"],
                     },
-                    'parameters': {
-                        'max_entries_per_session': ['2'],
-                        'entry_cooldown_seconds': ['600'],
+                    "parameters": {
+                        "max_entries_per_session": ["2"],
+                        "entry_cooldown_seconds": ["600"],
                     },
                 },
                 sort_keys=False,
             ),
-            encoding='utf-8',
+            encoding="utf-8",
         )
-        program_path = root / 'program.yaml'
+        program_path = root / "program.yaml"
         program_path.write_text(
             yaml.safe_dump(
                 {
-                    'schema_version': 'torghut.strategy-autoresearch.v1',
-                    'program_id': 'daily-profit',
-                    'description': 'Program fixture.',
-                    'objective': {
-                        'target_net_pnl_per_day': '500',
-                        'min_active_day_ratio': '0.80',
-                        'min_positive_day_ratio': '0.55',
-                        'min_daily_notional': '300000',
-                        'max_best_day_share': '0.35',
-                        'max_worst_day_loss': '450',
-                        'max_drawdown': '1000',
-                        'min_regime_slice_pass_rate': '0.40',
-                        'max_gross_exposure_pct_equity': '1.25',
-                        'min_cash': '0',
+                    "schema_version": "torghut.strategy-autoresearch.v1",
+                    "program_id": "daily-profit",
+                    "description": "Program fixture.",
+                    "objective": {
+                        "target_net_pnl_per_day": "500",
+                        "min_active_day_ratio": "0.80",
+                        "min_positive_day_ratio": "0.55",
+                        "min_daily_notional": "300000",
+                        "max_best_day_share": "0.35",
+                        "max_worst_day_loss": "450",
+                        "max_drawdown": "1000",
+                        "min_regime_slice_pass_rate": "0.40",
+                        "max_gross_exposure_pct_equity": "1.25",
+                        "min_cash": "0",
                     },
-                    'runtime_closure_policy': {
-                        'enabled': False,
-                        'execute_parity_replay': True,
-                        'execute_approval_replay': True,
-                        'parity_window': 'full_window',
-                        'approval_window': 'holdout',
-                        'shadow_validation_mode': 'require_live_evidence',
-                        'promotion_target': 'shadow',
+                    "runtime_closure_policy": {
+                        "enabled": False,
+                        "execute_parity_replay": True,
+                        "execute_approval_replay": True,
+                        "parity_window": "full_window",
+                        "approval_window": "holdout",
+                        "shadow_validation_mode": "require_live_evidence",
+                        "promotion_target": "shadow",
                     },
-                    'research_sources': [
+                    "research_sources": [
                         {
-                            'source_id': 'paper-1',
-                            'title': 'Paper 1',
-                            'url': 'https://example.com/paper-1',
-                            'published_at': '2026-01-01',
-                            'claims': [
+                            "source_id": "paper-1",
+                            "title": "Paper 1",
+                            "url": "https://example.com/paper-1",
+                            "published_at": "2026-01-01",
+                            "claims": [
                                 {
-                                    'claim_id': 'claim-1',
-                                    'summary': 'Use realistic replay.',
-                                    'implication': 'Prefer day-level diagnostics.',
+                                    "claim_id": "claim-1",
+                                    "summary": "Use realistic replay.",
+                                    "implication": "Prefer day-level diagnostics.",
                                 }
                             ],
                         }
                     ],
-                    'families': [
+                    "families": [
                         {
-                            'family_template_id': 'breakout_reclaim_v2',
-                            'seed_sweep_config': './profitability-frontier-consistent-breakout.yaml',
-                            'max_iterations': 2,
-                            'keep_top_candidates': 1,
-                            'frontier_top_n': 2,
-                            'symbol_prune_iterations': 1,
-                            'symbol_prune_candidates': 1,
-                            'symbol_prune_min_universe_size': 2,
-                            'parameter_mutations': {
-                                'max_entries_per_session': {
-                                    'mode': 'numeric_step',
-                                    'deltas': ['-1', '0', '1'],
-                                    'minimum': '1',
-                                    'maximum': '4',
+                            "family_template_id": "breakout_reclaim_v2",
+                            "seed_sweep_config": "./profitability-frontier-consistent-breakout.yaml",
+                            "max_iterations": 2,
+                            "keep_top_candidates": 1,
+                            "frontier_top_n": 2,
+                            "symbol_prune_iterations": 1,
+                            "symbol_prune_candidates": 1,
+                            "symbol_prune_min_universe_size": 2,
+                            "parameter_mutations": {
+                                "max_entries_per_session": {
+                                    "mode": "numeric_step",
+                                    "deltas": ["-1", "0", "1"],
+                                    "minimum": "1",
+                                    "maximum": "4",
                                 }
                             },
-                            'strategy_override_mutations': {
-                                'normalization_regime': {'mode': 'allowed_normalizations'}
+                            "strategy_override_mutations": {
+                                "normalization_regime": {
+                                    "mode": "allowed_normalizations"
+                                }
                             },
                         }
                     ],
                 },
                 sort_keys=False,
             ),
-            encoding='utf-8',
+            encoding="utf-8",
         )
         return program_path, family_dir
 
@@ -257,109 +328,153 @@ class TestStrategyAutoresearch(TestCase):
             root = Path(tmpdir)
             program_path, family_dir = self._write_program_fixture(root)
 
-            program = load_strategy_autoresearch_program(program_path, family_dir=family_dir)
-            self.assertEqual(program.program_id, 'daily-profit')
-            self.assertEqual(program.objective.target_net_pnl_per_day, Decimal('500'))
-            self.assertEqual(program.objective.max_gross_exposure_pct_equity, Decimal('1.25'))
-            self.assertEqual(program.objective.min_cash, Decimal('0'))
-            self.assertEqual(program.families[0].family_template.family_id, 'breakout_reclaim_v2')
-            self.assertEqual(program.families[0].strategy_override_mutations['normalization_regime'].mode, 'allowed_normalizations')
+            program = load_strategy_autoresearch_program(
+                program_path, family_dir=family_dir
+            )
+            self.assertEqual(program.program_id, "daily-profit")
+            self.assertEqual(program.objective.target_net_pnl_per_day, Decimal("500"))
+            self.assertEqual(
+                program.objective.max_gross_exposure_pct_equity, Decimal("1.25")
+            )
+            self.assertEqual(program.objective.min_cash, Decimal("0"))
+            self.assertEqual(
+                program.families[0].family_template.family_id, "breakout_reclaim_v2"
+            )
+            self.assertEqual(
+                program.families[0]
+                .strategy_override_mutations["normalization_regime"]
+                .mode,
+                "allowed_normalizations",
+            )
 
-            sweep_payload = yaml.safe_load((root / 'profitability-frontier-consistent-breakout.yaml').read_text(encoding='utf-8'))
+            sweep_payload = yaml.safe_load(
+                (root / "profitability-frontier-consistent-breakout.yaml").read_text(
+                    encoding="utf-8"
+                )
+            )
             updated = apply_program_objective(
                 sweep_config=sweep_payload,
                 objective=program.objective,
                 holdout_day_count=3,
                 full_window_day_count=9,
             )
-            self.assertEqual(updated['constraints']['holdout_target_net_per_day'], '500')
-            self.assertEqual(updated['consistency_constraints']['min_daily_net_pnl'], '0')
-            self.assertEqual(updated['consistency_constraints']['max_best_day_share_of_total_pnl'], '0.35')
-            self.assertEqual(updated['consistency_constraints']['max_gross_exposure_pct_equity'], '1.25')
-            self.assertEqual(updated['consistency_constraints']['min_cash'], '0')
-            self.assertEqual(updated['consistency_constraints']['min_active_days'], 8)
+            self.assertEqual(
+                updated["constraints"]["holdout_target_net_per_day"], "500"
+            )
+            self.assertEqual(
+                updated["consistency_constraints"]["min_daily_net_pnl"], "0"
+            )
+            self.assertEqual(
+                updated["consistency_constraints"]["max_best_day_share_of_total_pnl"],
+                "0.35",
+            )
+            self.assertEqual(
+                updated["consistency_constraints"]["max_gross_exposure_pct_equity"],
+                "1.25",
+            )
+            self.assertEqual(updated["consistency_constraints"]["min_cash"], "0")
+            self.assertEqual(updated["consistency_constraints"]["min_active_days"], 8)
 
     def test_checked_in_300_daily_profit_program_targets_daily_net(self) -> None:
         program_path = Path(
-            'config/trading/research-programs/strict-daily-profit-autoresearch-300-v1.yaml'
+            "config/trading/research-programs/strict-daily-profit-autoresearch-300-v1.yaml"
         )
 
         program = load_strategy_autoresearch_program(
             program_path,
-            family_dir=Path('config/trading/families'),
+            family_dir=Path("config/trading/families"),
         )
 
-        self.assertEqual(program.program_id, 'strict_daily_profit_autoresearch_300_v1')
-        self.assertEqual(program.objective.target_net_pnl_per_day, Decimal('300'))
-        self.assertEqual(program.objective.min_daily_net_pnl, Decimal('300'))
-        self.assertEqual(program.objective.min_positive_day_ratio, Decimal('1.0'))
-        self.assertEqual(program.objective.max_worst_day_loss, Decimal('0'))
+        self.assertEqual(program.program_id, "strict_daily_profit_autoresearch_300_v1")
+        self.assertEqual(program.objective.target_net_pnl_per_day, Decimal("300"))
+        self.assertEqual(program.objective.min_daily_net_pnl, Decimal("300"))
+        self.assertEqual(program.objective.min_positive_day_ratio, Decimal("1.0"))
+        self.assertEqual(program.objective.max_worst_day_loss, Decimal("0"))
         self.assertTrue(program.objective.require_every_day_active)
-        self.assertEqual(program.runtime_closure_policy.promotion_target, 'shadow')
-        self.assertIn('scheduler_v3_parity_replay', program.parity_requirements)
+        self.assertEqual(program.runtime_closure_policy.promotion_target, "shadow")
+        self.assertIn("scheduler_v3_parity_replay", program.parity_requirements)
         self.assertGreaterEqual(len(program.research_sources), 4)
         self.assertTrue(
             all(
-                source.published_at.startswith(('2025', '2026'))
+                source.published_at.startswith(("2025", "2026"))
                 for source in program.research_sources
             )
         )
 
-    def test_checked_in_500_daily_profit_program_enforces_cash_capital_realism(self) -> None:
+    def test_checked_in_500_daily_profit_program_enforces_cash_capital_realism(
+        self,
+    ) -> None:
         program_path = Path(
-            'config/trading/research-programs/strict-daily-profit-autoresearch-500-v1.yaml'
+            "config/trading/research-programs/strict-daily-profit-autoresearch-500-v1.yaml"
         )
 
         program = load_strategy_autoresearch_program(
             program_path,
-            family_dir=Path('config/trading/families'),
+            family_dir=Path("config/trading/families"),
         )
 
-        self.assertEqual(program.objective.target_net_pnl_per_day, Decimal('500'))
-        self.assertEqual(program.objective.max_gross_exposure_pct_equity, Decimal('1.0'))
-        self.assertEqual(program.objective.min_cash, Decimal('0'))
+        self.assertEqual(program.objective.target_net_pnl_per_day, Decimal("500"))
+        self.assertEqual(
+            program.objective.max_gross_exposure_pct_equity, Decimal("1.0")
+        )
+        self.assertEqual(program.objective.min_cash, Decimal("0"))
 
     def test_load_program_rejects_non_mapping_schema_and_missing_families(self) -> None:
         with TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
-            program_path = root / 'program.yaml'
+            program_path = root / "program.yaml"
 
-            program_path.write_text('- item\n', encoding='utf-8')
-            with self.assertRaisesRegex(ValueError, 'autoresearch_program_not_mapping'):
+            program_path.write_text("- item\n", encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "autoresearch_program_not_mapping"):
                 load_strategy_autoresearch_program(program_path, family_dir=root)
 
             program_path.write_text(
-                yaml.safe_dump({'schema_version': 'wrong', 'families': []}, sort_keys=False),
-                encoding='utf-8',
+                yaml.safe_dump(
+                    {"schema_version": "wrong", "families": []}, sort_keys=False
+                ),
+                encoding="utf-8",
             )
-            with self.assertRaisesRegex(ValueError, 'autoresearch_program_schema_invalid'):
+            with self.assertRaisesRegex(
+                ValueError, "autoresearch_program_schema_invalid"
+            ):
                 load_strategy_autoresearch_program(program_path, family_dir=root)
 
             program_path.write_text(
                 yaml.safe_dump(
                     {
-                        'schema_version': 'torghut.strategy-autoresearch.v1',
-                        'program_id': 'empty',
-                        'description': 'missing families',
-                        'objective': {},
-                        'families': [],
+                        "schema_version": "torghut.strategy-autoresearch.v1",
+                        "program_id": "empty",
+                        "description": "missing families",
+                        "objective": {},
+                        "families": [],
                     },
                     sort_keys=False,
                 ),
-                encoding='utf-8',
+                encoding="utf-8",
             )
-            with self.assertRaisesRegex(ValueError, 'autoresearch_program_missing_families'):
+            with self.assertRaisesRegex(
+                ValueError, "autoresearch_program_missing_families"
+            ):
                 load_strategy_autoresearch_program(program_path, family_dir=root)
 
     def test_load_program_rejects_invalid_runtime_closure_policy_values(self) -> None:
         invalid_cases = [
-            ({'parity_window': 'bad'}, 'autoresearch_runtime_closure_parity_window_invalid'),
-            ({'approval_window': 'bad'}, 'autoresearch_runtime_closure_approval_window_invalid'),
             (
-                {'shadow_validation_mode': 'bad'},
-                'autoresearch_runtime_closure_shadow_validation_mode_invalid',
+                {"parity_window": "bad"},
+                "autoresearch_runtime_closure_parity_window_invalid",
             ),
-            ({'promotion_target': 'bad'}, 'autoresearch_runtime_closure_promotion_target_invalid'),
+            (
+                {"approval_window": "bad"},
+                "autoresearch_runtime_closure_approval_window_invalid",
+            ),
+            (
+                {"shadow_validation_mode": "bad"},
+                "autoresearch_runtime_closure_shadow_validation_mode_invalid",
+            ),
+            (
+                {"promotion_target": "bad"},
+                "autoresearch_runtime_closure_promotion_target_invalid",
+            ),
         ]
 
         for overrides, expected_error in invalid_cases:
@@ -367,125 +482,147 @@ class TestStrategyAutoresearch(TestCase):
                 with TemporaryDirectory() as tmpdir:
                     root = Path(tmpdir)
                     program_path, family_dir = self._write_program_fixture(root)
-                    payload = yaml.safe_load(program_path.read_text(encoding='utf-8'))
-                    payload['runtime_closure_policy'] = {
-                        'enabled': False,
-                        'execute_parity_replay': True,
-                        'execute_approval_replay': True,
-                        'parity_window': 'full_window',
-                        'approval_window': 'holdout',
-                        'shadow_validation_mode': 'require_live_evidence',
-                        'promotion_target': 'shadow',
+                    payload = yaml.safe_load(program_path.read_text(encoding="utf-8"))
+                    payload["runtime_closure_policy"] = {
+                        "enabled": False,
+                        "execute_parity_replay": True,
+                        "execute_approval_replay": True,
+                        "parity_window": "full_window",
+                        "approval_window": "holdout",
+                        "shadow_validation_mode": "require_live_evidence",
+                        "promotion_target": "shadow",
                     }
-                    payload['runtime_closure_policy'].update(overrides)
-                    program_path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding='utf-8')
+                    payload["runtime_closure_policy"].update(overrides)
+                    program_path.write_text(
+                        yaml.safe_dump(payload, sort_keys=False), encoding="utf-8"
+                    )
 
                     with self.assertRaisesRegex(ValueError, expected_error):
-                        load_strategy_autoresearch_program(program_path, family_dir=family_dir)
+                        load_strategy_autoresearch_program(
+                            program_path, family_dir=family_dir
+                        )
 
     def test_load_program_skips_invalid_source_and_claim_entries(self) -> None:
         with TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
-            family_dir = root / 'families'
+            family_dir = root / "families"
             family_dir.mkdir()
-            (family_dir / 'breakout_reclaim_v2.yaml').write_text(
+            (family_dir / "breakout_reclaim_v2.yaml").write_text(
                 yaml.safe_dump(
                     {
-                        'schema_version': 'torghut.family-template.v1',
-                        'family_id': 'breakout_reclaim_v2',
-                        'economic_mechanism': 'Breakout reclaim.',
-                        'supported_markets': ['us_equities_intraday'],
-                        'required_features': ['quote_quality'],
-                        'allowed_normalizations': ['price_scaled'],
-                        'entry_motifs': ['breakout_reclaim'],
-                        'exit_motifs': ['trailing_stop'],
-                        'risk_controls': ['stop_loss'],
-                        'activity_model': {'min_active_day_ratio': '0.50', 'min_daily_notional': '200000'},
-                        'liquidity_assumptions': {'max_spread_bps': '30'},
-                        'regime_activation_rules': [],
-                        'day_veto_rules': [],
-                        'default_hard_vetoes': {},
-                        'default_selection_objectives': {},
-                        'runtime_harness': {'family': 'breakout', 'strategy_name': 'breakout-v1'},
+                        "schema_version": "torghut.family-template.v1",
+                        "family_id": "breakout_reclaim_v2",
+                        "economic_mechanism": "Breakout reclaim.",
+                        "supported_markets": ["us_equities_intraday"],
+                        "required_features": ["quote_quality"],
+                        "allowed_normalizations": ["price_scaled"],
+                        "entry_motifs": ["breakout_reclaim"],
+                        "exit_motifs": ["trailing_stop"],
+                        "risk_controls": ["stop_loss"],
+                        "activity_model": {
+                            "min_active_day_ratio": "0.50",
+                            "min_daily_notional": "200000",
+                        },
+                        "liquidity_assumptions": {"max_spread_bps": "30"},
+                        "regime_activation_rules": [],
+                        "day_veto_rules": [],
+                        "default_hard_vetoes": {},
+                        "default_selection_objectives": {},
+                        "runtime_harness": {
+                            "family": "breakout",
+                            "strategy_name": "breakout-v1",
+                        },
                     },
                     sort_keys=False,
                 ),
-                encoding='utf-8',
+                encoding="utf-8",
             )
-            sweep_path = root / 'seed.yaml'
-            sweep_path.write_text('schema_version: torghut.replay-frontier-sweep.v1\n', encoding='utf-8')
-            program_path = root / 'program.yaml'
+            sweep_path = root / "seed.yaml"
+            sweep_path.write_text(
+                "schema_version: torghut.replay-frontier-sweep.v1\n", encoding="utf-8"
+            )
+            program_path = root / "program.yaml"
             program_path.write_text(
                 yaml.safe_dump(
                     {
-                        'schema_version': 'torghut.strategy-autoresearch.v1',
-                        'program_id': 'valid-ish',
-                        'description': 'fixture',
-                        'objective': {},
-                        'research_sources': [
-                            'skip-me',
+                        "schema_version": "torghut.strategy-autoresearch.v1",
+                        "program_id": "valid-ish",
+                        "description": "fixture",
+                        "objective": {},
+                        "research_sources": [
+                            "skip-me",
                             {
-                                'source_id': '',
-                                'title': 'missing id',
-                                'claims': [{'claim_id': 'claim-ignored'}],
+                                "source_id": "",
+                                "title": "missing id",
+                                "claims": [{"claim_id": "claim-ignored"}],
                             },
                             {
-                                'source_id': 'paper-1',
-                                'title': 'Paper 1',
-                                'url': 'https://example.com',
-                                'published_at': '2026-01-01',
-                                'claims': [
-                                    'skip-claim',
-                                    {'claim_id': '', 'summary': 'missing id'},
-                                    {'claim_id': 'claim-1', 'summary': 'ok', 'implication': 'use it'},
+                                "source_id": "paper-1",
+                                "title": "Paper 1",
+                                "url": "https://example.com",
+                                "published_at": "2026-01-01",
+                                "claims": [
+                                    "skip-claim",
+                                    {"claim_id": "", "summary": "missing id"},
+                                    {
+                                        "claim_id": "claim-1",
+                                        "summary": "ok",
+                                        "implication": "use it",
+                                    },
                                 ],
                             },
                         ],
-                        'families': [
-                            'skip-family',
+                        "families": [
+                            "skip-family",
                             {
-                                'family_template_id': 'breakout_reclaim_v2',
-                                'seed_sweep_config': str(sweep_path),
+                                "family_template_id": "breakout_reclaim_v2",
+                                "seed_sweep_config": str(sweep_path),
                             },
                         ],
                     },
                     sort_keys=False,
                 ),
-                encoding='utf-8',
+                encoding="utf-8",
             )
 
-            program = load_strategy_autoresearch_program(program_path, family_dir=family_dir)
+            program = load_strategy_autoresearch_program(
+                program_path, family_dir=family_dir
+            )
 
         self.assertEqual(len(program.research_sources), 1)
-        self.assertEqual(program.research_sources[0].source_id, 'paper-1')
+        self.assertEqual(program.research_sources[0].source_id, "paper-1")
         self.assertEqual(len(program.research_sources[0].claims), 1)
-        self.assertEqual(program.research_sources[0].claims[0].claim_id, 'claim-1')
+        self.assertEqual(program.research_sources[0].claims[0].claim_id, "claim-1")
 
-    def test_apply_program_objective_skips_full_window_counts_when_unknown(self) -> None:
+    def test_apply_program_objective_skips_full_window_counts_when_unknown(
+        self,
+    ) -> None:
         updated = apply_program_objective(
-            sweep_config={'constraints': {}, 'consistency_constraints': {}},
+            sweep_config={"constraints": {}, "consistency_constraints": {}},
             objective=StrategyObjective(
-                target_net_pnl_per_day=Decimal('500'),
-                min_active_day_ratio=Decimal('0.80'),
-                min_positive_day_ratio=Decimal('0.55'),
-                min_daily_notional=Decimal('300000'),
-                max_best_day_share=Decimal('0.35'),
-                max_worst_day_loss=Decimal('450'),
-                max_drawdown=Decimal('1000'),
+                target_net_pnl_per_day=Decimal("500"),
+                min_active_day_ratio=Decimal("0.80"),
+                min_positive_day_ratio=Decimal("0.55"),
+                min_daily_notional=Decimal("300000"),
+                max_best_day_share=Decimal("0.35"),
+                max_worst_day_loss=Decimal("450"),
+                max_drawdown=Decimal("1000"),
                 require_every_day_active=False,
-                min_regime_slice_pass_rate=Decimal('0.40'),
+                min_regime_slice_pass_rate=Decimal("0.40"),
                 stop_when_objective_met=False,
             ),
             holdout_day_count=3,
             full_window_day_count=None,
         )
-        self.assertNotIn('min_active_days', updated['consistency_constraints'])
-        self.assertNotIn('min_positive_days', updated['consistency_constraints'])
+        self.assertNotIn("min_active_days", updated["consistency_constraints"])
+        self.assertNotIn("min_positive_days", updated["consistency_constraints"])
 
-    def test_build_mutated_sweep_config_keeps_current_values_and_mutates_neighbors(self) -> None:
+    def test_build_mutated_sweep_config_keeps_current_values_and_mutates_neighbors(
+        self,
+    ) -> None:
         family_plan = FamilyAutoresearchPlan(
             family_template=_family_template(),
-            seed_sweep_config=Path('/tmp/example.yaml'),
+            seed_sweep_config=Path("/tmp/example.yaml"),
             max_iterations=2,
             keep_top_candidates=1,
             frontier_top_n=2,
@@ -494,37 +631,37 @@ class TestStrategyAutoresearch(TestCase):
             symbol_prune_candidates=1,
             symbol_prune_min_universe_size=2,
             parameter_mutations={
-                'max_entries_per_session': MutationSpace(
-                    mode='numeric_step',
-                    deltas=(Decimal('-1'), Decimal('0'), Decimal('1')),
-                    minimum=Decimal('1'),
-                    maximum=Decimal('4'),
+                "max_entries_per_session": MutationSpace(
+                    mode="numeric_step",
+                    deltas=(Decimal("-1"), Decimal("0"), Decimal("1")),
+                    minimum=Decimal("1"),
+                    maximum=Decimal("4"),
                 )
             },
             strategy_override_mutations={
-                'normalization_regime': MutationSpace(mode='allowed_normalizations')
+                "normalization_regime": MutationSpace(mode="allowed_normalizations")
             },
         )
         base_sweep = {
-            'parameters': {
-                'max_entries_per_session': ['2'],
-                'entry_cooldown_seconds': ['600'],
+            "parameters": {
+                "max_entries_per_session": ["2"],
+                "entry_cooldown_seconds": ["600"],
             },
-            'strategy_overrides': {
-                'universe_symbols': [['AMAT', 'NVDA']],
-                'max_position_pct_equity': ['10.0'],
+            "strategy_overrides": {
+                "universe_symbols": [["AMAT", "NVDA"]],
+                "max_position_pct_equity": ["10.0"],
             },
         }
         candidate = {
-            'candidate_id': 'candidate-1',
-            'replay_config': {
-                'params': {
-                    'max_entries_per_session': '2',
-                    'entry_cooldown_seconds': '600',
+            "candidate_id": "candidate-1",
+            "replay_config": {
+                "params": {
+                    "max_entries_per_session": "2",
+                    "entry_cooldown_seconds": "600",
                 },
-                'strategy_overrides': {
-                    'universe_symbols': ['AMAT', 'NVDA'],
-                    'max_position_pct_equity': '10.0',
+                "strategy_overrides": {
+                    "universe_symbols": ["AMAT", "NVDA"],
+                    "max_position_pct_equity": "10.0",
                 },
             },
         }
@@ -535,16 +672,25 @@ class TestStrategyAutoresearch(TestCase):
             family_plan=family_plan,
         )
 
-        self.assertEqual(mutated['parameters']['entry_cooldown_seconds'], ['600'])
-        self.assertEqual(mutated['parameters']['max_entries_per_session'], ['2', '1', '3'])
-        self.assertEqual(mutated['strategy_overrides']['universe_symbols'], [['AMAT', 'NVDA']])
-        self.assertEqual(mutated['strategy_overrides']['normalization_regime'], ['price_scaled', 'opening_window_scaled'])
-        self.assertIn('max_entries_per_session', description)
+        self.assertEqual(mutated["parameters"]["entry_cooldown_seconds"], ["600"])
+        self.assertEqual(
+            mutated["parameters"]["max_entries_per_session"], ["2", "1", "3"]
+        )
+        self.assertEqual(
+            mutated["strategy_overrides"]["universe_symbols"], [["AMAT", "NVDA"]]
+        )
+        self.assertEqual(
+            mutated["strategy_overrides"]["normalization_regime"],
+            ["price_scaled", "opening_window_scaled"],
+        )
+        self.assertIn("max_entries_per_session", description)
 
-    def test_build_mutated_sweep_config_falls_back_when_mutation_values_are_filtered_out(self) -> None:
+    def test_build_mutated_sweep_config_falls_back_when_mutation_values_are_filtered_out(
+        self,
+    ) -> None:
         family_plan = FamilyAutoresearchPlan(
             family_template=_family_template(),
-            seed_sweep_config=Path('/tmp/example.yaml'),
+            seed_sweep_config=Path("/tmp/example.yaml"),
             max_iterations=2,
             keep_top_candidates=1,
             frontier_top_n=2,
@@ -553,42 +699,42 @@ class TestStrategyAutoresearch(TestCase):
             symbol_prune_candidates=1,
             symbol_prune_min_universe_size=2,
             parameter_mutations={
-                'entry_cooldown_seconds': MutationSpace(
-                    mode='numeric_step',
-                    deltas=(Decimal('-1000'),),
-                    minimum=Decimal('1'),
-                    maximum=Decimal('1200'),
+                "entry_cooldown_seconds": MutationSpace(
+                    mode="numeric_step",
+                    deltas=(Decimal("-1000"),),
+                    minimum=Decimal("1"),
+                    maximum=Decimal("1200"),
                 ),
-                'normalization_regime': MutationSpace(
-                    mode='explicit_values',
-                    values=('matched_filter',),
+                "normalization_regime": MutationSpace(
+                    mode="explicit_values",
+                    values=("matched_filter",),
                 ),
             },
             strategy_override_mutations={
-                'max_position_pct_equity': MutationSpace(
-                    mode='numeric_step',
-                    deltas=(Decimal('100'),),
-                    minimum=Decimal('0'),
-                    maximum=Decimal('20'),
+                "max_position_pct_equity": MutationSpace(
+                    mode="numeric_step",
+                    deltas=(Decimal("100"),),
+                    minimum=Decimal("0"),
+                    maximum=Decimal("20"),
                 )
             },
         )
         base_sweep = {
-            'parameters': {
-                'entry_cooldown_seconds': ['600'],
+            "parameters": {
+                "entry_cooldown_seconds": ["600"],
             },
-            'strategy_overrides': {
-                'max_position_pct_equity': ['10.0'],
+            "strategy_overrides": {
+                "max_position_pct_equity": ["10.0"],
             },
         }
         candidate = {
-            'candidate_id': 'candidate-2',
-            'replay_config': {
-                'params': {
-                    'entry_cooldown_seconds': '600',
+            "candidate_id": "candidate-2",
+            "replay_config": {
+                "params": {
+                    "entry_cooldown_seconds": "600",
                 },
-                'strategy_overrides': {
-                    'max_position_pct_equity': '10.0',
+                "strategy_overrides": {
+                    "max_position_pct_equity": "10.0",
                 },
             },
         }
@@ -599,467 +745,549 @@ class TestStrategyAutoresearch(TestCase):
             family_plan=family_plan,
         )
 
-        self.assertEqual(mutated['parameters']['entry_cooldown_seconds'], ['600'])
-        self.assertEqual(mutated['parameters']['normalization_regime'], ['matched_filter'])
-        self.assertEqual(mutated['strategy_overrides']['max_position_pct_equity'], ['10.0'])
-        self.assertIn('candidate-2', description)
+        self.assertEqual(mutated["parameters"]["entry_cooldown_seconds"], ["600"])
+        self.assertEqual(
+            mutated["parameters"]["normalization_regime"], ["matched_filter"]
+        )
+        self.assertEqual(
+            mutated["strategy_overrides"]["max_position_pct_equity"], ["10.0"]
+        )
+        self.assertIn("candidate-2", description)
 
     def test_candidate_meets_objective_respects_vetoes(self) -> None:
         objective = StrategyObjective(
-            target_net_pnl_per_day=Decimal('500'),
-            min_active_day_ratio=Decimal('0.80'),
-            min_positive_day_ratio=Decimal('0.55'),
-            min_daily_notional=Decimal('300000'),
-            max_best_day_share=Decimal('0.35'),
-            max_worst_day_loss=Decimal('450'),
-            max_drawdown=Decimal('1000'),
+            target_net_pnl_per_day=Decimal("500"),
+            min_active_day_ratio=Decimal("0.80"),
+            min_positive_day_ratio=Decimal("0.55"),
+            min_daily_notional=Decimal("300000"),
+            max_best_day_share=Decimal("0.35"),
+            max_worst_day_loss=Decimal("450"),
+            max_drawdown=Decimal("1000"),
             require_every_day_active=False,
-            min_regime_slice_pass_rate=Decimal('0.40'),
+            min_regime_slice_pass_rate=Decimal("0.40"),
             stop_when_objective_met=False,
-            max_gross_exposure_pct_equity=Decimal('1.50'),
-            min_cash=Decimal('0'),
+            max_gross_exposure_pct_equity=Decimal("1.50"),
+            min_cash=Decimal("0"),
         )
         candidate = {
-            'hard_vetoes': [],
-            'objective_scorecard': {
-                'net_pnl_per_day': '600',
-                'active_day_ratio': '0.80',
-                'positive_day_ratio': '0.60',
-                'avg_filled_notional_per_day': '350000',
-                'best_day_share': '0.30',
-                'worst_day_loss': '300',
-                'max_drawdown': '900',
-                'regime_slice_pass_rate': '0.45',
-                'max_gross_exposure_pct_equity': '1.25',
-                'min_cash': '2500',
+            "hard_vetoes": [],
+            "objective_scorecard": {
+                "net_pnl_per_day": "600",
+                "active_day_ratio": "0.80",
+                "positive_day_ratio": "0.60",
+                "avg_filled_notional_per_day": "350000",
+                "best_day_share": "0.30",
+                "worst_day_loss": "300",
+                "max_drawdown": "900",
+                "regime_slice_pass_rate": "0.45",
+                "max_gross_exposure_pct_equity": "1.25",
+                "min_cash": "2500",
             },
-            'full_window': {'trading_day_count': 9, 'active_days': 7},
+            "full_window": {"trading_day_count": 9, "active_days": 7},
         }
         self.assertTrue(candidate_meets_objective(candidate, objective=objective))
         over_levered = copy.deepcopy(candidate)
-        over_levered['objective_scorecard']['max_gross_exposure_pct_equity'] = '1.51'
+        over_levered["objective_scorecard"]["max_gross_exposure_pct_equity"] = "1.51"
         self.assertFalse(candidate_meets_objective(over_levered, objective=objective))
         negative_cash = copy.deepcopy(candidate)
-        negative_cash['objective_scorecard']['min_cash'] = '-0.01'
+        negative_cash["objective_scorecard"]["min_cash"] = "-0.01"
         self.assertFalse(candidate_meets_objective(negative_cash, objective=objective))
         vetoed = dict(candidate)
-        vetoed['hard_vetoes'] = ['best_day_share_above_max']
+        vetoed["hard_vetoes"] = ["best_day_share_above_max"]
         self.assertFalse(candidate_meets_objective(vetoed, objective=objective))
 
-    def test_candidate_meets_objective_requires_daily_minimum_when_configured(self) -> None:
+    def test_candidate_meets_objective_requires_daily_minimum_when_configured(
+        self,
+    ) -> None:
         objective = StrategyObjective(
-            target_net_pnl_per_day=Decimal('300'),
-            min_daily_net_pnl=Decimal('300'),
-            min_active_day_ratio=Decimal('1.0'),
-            min_positive_day_ratio=Decimal('1.0'),
-            min_daily_notional=Decimal('300000'),
-            max_best_day_share=Decimal('0.60'),
-            max_worst_day_loss=Decimal('0'),
-            max_drawdown=Decimal('0'),
+            target_net_pnl_per_day=Decimal("300"),
+            min_daily_net_pnl=Decimal("300"),
+            min_active_day_ratio=Decimal("1.0"),
+            min_positive_day_ratio=Decimal("1.0"),
+            min_daily_notional=Decimal("300000"),
+            max_best_day_share=Decimal("0.60"),
+            max_worst_day_loss=Decimal("0"),
+            max_drawdown=Decimal("0"),
             require_every_day_active=True,
-            min_regime_slice_pass_rate=Decimal('0.40'),
+            min_regime_slice_pass_rate=Decimal("0.40"),
             stop_when_objective_met=False,
         )
         candidate = {
-            'hard_vetoes': [],
-            'objective_scorecard': {
-                'net_pnl_per_day': '500',
-                'active_day_ratio': '1',
-                'positive_day_ratio': '1',
-                'avg_filled_notional_per_day': '350000',
-                'best_day_share': '0.40',
-                'worst_day_loss': '0',
-                'max_drawdown': '0',
-                'regime_slice_pass_rate': '0.45',
+            "hard_vetoes": [],
+            "objective_scorecard": {
+                "net_pnl_per_day": "500",
+                "active_day_ratio": "1",
+                "positive_day_ratio": "1",
+                "avg_filled_notional_per_day": "350000",
+                "best_day_share": "0.40",
+                "worst_day_loss": "0",
+                "max_drawdown": "0",
+                "regime_slice_pass_rate": "0.45",
             },
-            'full_window': {
-                'trading_day_count': 3,
-                'active_days': 3,
-                'daily_net': {
-                    '2026-04-01': '900',
-                    '2026-04-02': '300',
-                    '2026-04-03': '300',
+            "full_window": {
+                "trading_day_count": 3,
+                "active_days": 3,
+                "daily_net": {
+                    "2026-04-01": "900",
+                    "2026-04-02": "300",
+                    "2026-04-03": "300",
                 },
             },
         }
         self.assertTrue(candidate_meets_objective(candidate, objective=objective))
 
         weak_day = copy.deepcopy(candidate)
-        weak_day['full_window']['daily_net']['2026-04-02'] = '299.99'
+        weak_day["full_window"]["daily_net"]["2026-04-02"] = "299.99"
         self.assertFalse(candidate_meets_objective(weak_day, objective=objective))
 
     def test_write_autoresearch_notebooks_outputs_ipynb_files(self) -> None:
         with TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
-            (root / 'summary.json').write_text(
+            (root / "summary.json").write_text(
                 json.dumps(
                     {
-                        'best_candidate': {'candidate_id': 'c-1'},
-                        'program_id': 'program-1',
-                        'promotion_readiness': {
-                            'candidate_id': 'c-1',
-                            'status': 'blocked_pending_runtime_parity',
-                            'stage': 'research_candidate',
-                            'promotable': False,
-                            'runtime_family': 'breakout_continuation_consistent',
-                            'runtime_strategy_name': 'breakout-continuation-long-v1',
-                            'reason': 'research only',
-                            'blockers': ['scheduler_v3_parity_missing'],
+                        "best_candidate": {"candidate_id": "c-1"},
+                        "program_id": "program-1",
+                        "promotion_readiness": {
+                            "candidate_id": "c-1",
+                            "status": "blocked_pending_runtime_parity",
+                            "stage": "research_candidate",
+                            "promotable": False,
+                            "runtime_family": "breakout_continuation_consistent",
+                            "runtime_strategy_name": "breakout-continuation-long-v1",
+                            "reason": "research only",
+                            "blockers": ["scheduler_v3_parity_missing"],
                         },
                     }
                 ),
-                encoding='utf-8',
+                encoding="utf-8",
             )
-            (root / 'research_dossier.json').write_text(
+            (root / "research_dossier.json").write_text(
                 json.dumps(
                     {
-                        'program_id': 'program-1',
-                        'objective': {'target_net_pnl_per_day': '500'},
-                        'research_sources': [],
-                        'families': [],
+                        "program_id": "program-1",
+                        "objective": {"target_net_pnl_per_day": "500"},
+                        "research_sources": [],
+                        "families": [],
                     }
                 ),
-                encoding='utf-8',
+                encoding="utf-8",
             )
-            (root / 'history.jsonl').write_text(
+            (root / "history.jsonl").write_text(
                 json.dumps(
                     {
-                        'experiment_index': 1,
-                        'iteration': 1,
-                        'family_template_id': 'breakout_reclaim_v2',
-                        'candidate_id': 'c-1',
-                        'status': 'keep',
-                        'net_pnl_per_day': '600',
-                        'active_day_ratio': '0.80',
-                        'positive_day_ratio': '0.60',
-                        'avg_filled_notional_per_day': '300000',
-                        'best_day_share': '0.30',
-                        'max_drawdown': '900',
-                        'pareto_tier': 1,
-                        'mutation_label': 'seed',
-                        'hard_vetoes': [],
-                        'daily_net': {'2026-04-01': '600'},
+                        "experiment_index": 1,
+                        "iteration": 1,
+                        "family_template_id": "breakout_reclaim_v2",
+                        "candidate_id": "c-1",
+                        "status": "keep",
+                        "net_pnl_per_day": "600",
+                        "active_day_ratio": "0.80",
+                        "positive_day_ratio": "0.60",
+                        "avg_filled_notional_per_day": "300000",
+                        "best_day_share": "0.30",
+                        "max_drawdown": "900",
+                        "pareto_tier": 1,
+                        "mutation_label": "seed",
+                        "hard_vetoes": [],
+                        "daily_net": {"2026-04-01": "600"},
                     }
                 )
-                + '\n',
-                encoding='utf-8',
+                + "\n",
+                encoding="utf-8",
             )
-            (root / 'results.tsv').write_text('header\n', encoding='utf-8')
+            (root / "results.tsv").write_text("header\n", encoding="utf-8")
 
             history_nb, dossier_nb, mlx_nb = write_autoresearch_notebooks(root)
             self.assertTrue(history_nb.exists())
             self.assertTrue(dossier_nb.exists())
             self.assertTrue(mlx_nb.exists())
-            payload = json.loads(history_nb.read_text(encoding='utf-8'))
-            self.assertEqual(payload['nbformat'], 4)
-            joined_source = ''.join(payload['cells'][1]['source'])
+            payload = json.loads(history_nb.read_text(encoding="utf-8"))
+            self.assertEqual(payload["nbformat"], 4)
+            joined_source = "".join(payload["cells"][1]["source"])
             self.assertIn(str(root), joined_source)
-            self.assertIn('except ModuleNotFoundError', joined_source)
-            all_sources = '\n'.join(''.join(cell.get('source', [])) for cell in payload['cells'])
-            self.assertIn('Live Experiment Snapshots', all_sources)
-            self.assertIn('Promotion Guardrail', all_sources)
-            self.assertIn('research candidates only', all_sources)
-            mlx_payload = json.loads(mlx_nb.read_text(encoding='utf-8'))
-            mlx_sources = '\n'.join(''.join(cell.get('source', [])) for cell in mlx_payload['cells'])
-            self.assertIn('MLX Autoresearch Diagnostics', mlx_sources)
-            self.assertIn('Scheduler-v3 replay remains the authority', mlx_sources)
+            self.assertIn("except ModuleNotFoundError", joined_source)
+            all_sources = "\n".join(
+                "".join(cell.get("source", [])) for cell in payload["cells"]
+            )
+            self.assertIn("Live Experiment Snapshots", all_sources)
+            self.assertIn("Promotion Guardrail", all_sources)
+            self.assertIn("research candidates only", all_sources)
+            mlx_payload = json.loads(mlx_nb.read_text(encoding="utf-8"))
+            mlx_sources = "\n".join(
+                "".join(cell.get("source", [])) for cell in mlx_payload["cells"]
+            )
+            self.assertIn("MLX Autoresearch Diagnostics", mlx_sources)
+            self.assertIn("Scheduler-v3 replay remains the authority", mlx_sources)
 
     def test_generated_history_notebook_avoids_hard_pandas_dependency(self) -> None:
-        payload = build_strategy_discovery_history_notebook(Path('/tmp/example-run'))
-        joined_source = '\n'.join(
-            ''.join(cell.get('source', []))
-            for cell in payload['cells']
-            if cell.get('cell_type') == 'code'
+        payload = build_strategy_discovery_history_notebook(Path("/tmp/example-run"))
+        joined_source = "\n".join(
+            "".join(cell.get("source", []))
+            for cell in payload["cells"]
+            if cell.get("cell_type") == "code"
         )
-        self.assertIn('except ModuleNotFoundError', joined_source)
-        self.assertNotIn('sources_df = pd.DataFrame', joined_source)
+        self.assertIn("except ModuleNotFoundError", joined_source)
+        self.assertNotIn("sources_df = pd.DataFrame", joined_source)
 
     def test_write_strategy_factory_notebooks_outputs_ipynb_files(self) -> None:
         with TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
-            (root / 'summary.json').write_text(
-                json.dumps({'runner_run_id': 'factory-1', 'status': 'ok', 'best_candidate': {'candidate_id': 'cand-1'}}),
-                encoding='utf-8',
-            )
-            (root / 'research_dossier.json').write_text(
+            (root / "summary.json").write_text(
                 json.dumps(
                     {
-                        'runner_run_id': 'factory-1',
-                        'objective': {'mode': 'strategy_factory_v2'},
-                        'source_experiments': [],
-                        'families': [],
-                        'dataset_snapshots': [],
+                        "runner_run_id": "factory-1",
+                        "status": "ok",
+                        "best_candidate": {"candidate_id": "cand-1"},
                     }
                 ),
-                encoding='utf-8',
+                encoding="utf-8",
             )
-            (root / 'history.jsonl').write_text(
+            (root / "research_dossier.json").write_text(
                 json.dumps(
                     {
-                        'experiment_id': 'exp-1',
-                        'source_run_id': 'paper-1',
-                        'family_template_id': 'breakout_reclaim_v2',
-                        'candidate_id': 'cand-1',
-                        'status': 'keep',
-                        'net_pnl_per_day': '600',
-                        'active_day_ratio': '0.80',
-                        'best_day_share': '0.30',
-                        'max_drawdown': '900',
-                        'pareto_tier': 1,
-                        'hard_vetoes': [],
-                        'decomposition': {'symbols': {'NVDA': {'net_pnl': '600'}}},
+                        "runner_run_id": "factory-1",
+                        "objective": {"mode": "strategy_factory_v2"},
+                        "source_experiments": [],
+                        "families": [],
+                        "dataset_snapshots": [],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            (root / "history.jsonl").write_text(
+                json.dumps(
+                    {
+                        "experiment_id": "exp-1",
+                        "source_run_id": "paper-1",
+                        "family_template_id": "breakout_reclaim_v2",
+                        "candidate_id": "cand-1",
+                        "status": "keep",
+                        "net_pnl_per_day": "600",
+                        "active_day_ratio": "0.80",
+                        "best_day_share": "0.30",
+                        "max_drawdown": "900",
+                        "pareto_tier": 1,
+                        "hard_vetoes": [],
+                        "decomposition": {"symbols": {"NVDA": {"net_pnl": "600"}}},
                     }
                 )
-                + '\n',
-                encoding='utf-8',
+                + "\n",
+                encoding="utf-8",
             )
-            (root / 'results.tsv').write_text('header\n', encoding='utf-8')
+            (root / "results.tsv").write_text("header\n", encoding="utf-8")
 
             history_nb, dossier_nb = write_strategy_factory_notebooks(root)
             self.assertTrue(history_nb.exists())
             self.assertTrue(dossier_nb.exists())
-            payload = json.loads(history_nb.read_text(encoding='utf-8'))
-            self.assertEqual(payload['nbformat'], 4)
-            joined_source = '\n'.join(
-                ''.join(cell.get('source', []))
-                for cell in payload['cells']
-                if cell.get('cell_type') == 'code'
+            payload = json.loads(history_nb.read_text(encoding="utf-8"))
+            self.assertEqual(payload["nbformat"], 4)
+            joined_source = "\n".join(
+                "".join(cell.get("source", []))
+                for cell in payload["cells"]
+                if cell.get("cell_type") == "code"
             )
-            self.assertIn('Best Candidate Decomposition', joined_source)
+            self.assertIn("Best Candidate Decomposition", joined_source)
 
-    def test_generated_strategy_factory_history_notebook_avoids_hard_pandas_dependency(self) -> None:
-        payload = build_strategy_factory_history_notebook(Path('/tmp/factory-run'))
-        joined_source = '\n'.join(
-            ''.join(cell.get('source', []))
-            for cell in payload['cells']
-            if cell.get('cell_type') == 'code'
+    def test_generated_strategy_factory_history_notebook_avoids_hard_pandas_dependency(
+        self,
+    ) -> None:
+        payload = build_strategy_factory_history_notebook(Path("/tmp/factory-run"))
+        joined_source = "\n".join(
+            "".join(cell.get("source", []))
+            for cell in payload["cells"]
+            if cell.get("cell_type") == "code"
         )
-        self.assertIn('except ModuleNotFoundError', joined_source)
+        self.assertIn("except ModuleNotFoundError", joined_source)
 
-    def test_run_strategy_autoresearch_loop_writes_history_results_and_notebooks(self) -> None:
+    def test_run_strategy_autoresearch_loop_writes_history_results_and_notebooks(
+        self,
+    ) -> None:
         with TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
             program_path, family_dir = self._write_program_fixture(root)
-            configmap_path = root / 'strategy-configmap.yaml'
-            configmap_path.write_text(
-                yaml.safe_dump({'apiVersion': 'v1', 'kind': 'ConfigMap', 'data': {'strategies.yaml': 'strategies: []\n'}}, sort_keys=False),
-                encoding='utf-8',
-            )
-            output_dir = root / 'out'
-
-            responses = [
-                {
-                    'dataset_snapshot_receipt': {'snapshot_id': 'snap-1'},
-                    'window': {
-                        'full_window_start_date': '2026-03-20',
-                        'full_window_end_date': '2026-04-09',
-                    },
-                    'top': [
-                        {
-                            'candidate_id': 'seed-1',
-                            'hard_vetoes': [],
-                            'ranking': {'pareto_tier': 1, 'tie_breaker_score': '10', 'vetoed': False},
-                            'objective_scorecard': {
-                                'net_pnl_per_day': '450',
-                                'active_day_ratio': '0.70',
-                                'positive_day_ratio': '0.55',
-                                'avg_filled_notional_per_day': '290000',
-                                'avg_filled_notional_per_active_day': '360000',
-                                'best_day_share': '0.40',
-                                'worst_day_loss': '350',
-                                'max_drawdown': '900',
-                                'regime_slice_pass_rate': '0.45',
-                            },
-                            'full_window': {
-                                'net_per_day': '450',
-                                'trading_day_count': 9,
-                                'active_days': 6,
-                                'daily_net': {'2026-04-01': '450'},
-                                'daily_filled_notional': {'2026-04-01': '290000'},
-                            },
-                            'replay_config': {
-                                'params': {'max_entries_per_session': '2', 'entry_cooldown_seconds': '600'},
-                                'strategy_overrides': {'universe_symbols': ['AMAT', 'NVDA']},
-                            },
-                        }
-                    ],
-                },
-                {
-                    'dataset_snapshot_receipt': {'snapshot_id': 'snap-2'},
-                    'window': {
-                        'full_window_start_date': '2026-03-20',
-                        'full_window_end_date': '2026-04-09',
-                    },
-                    'top': [
-                        {
-                            'candidate_id': 'mutated-1',
-                            'hard_vetoes': [],
-                            'ranking': {'pareto_tier': 1, 'tie_breaker_score': '11', 'vetoed': False},
-                            'objective_scorecard': {
-                                'net_pnl_per_day': '620',
-                                'active_day_ratio': '0.85',
-                                'positive_day_ratio': '0.60',
-                                'avg_filled_notional_per_day': '340000',
-                                'avg_filled_notional_per_active_day': '400000',
-                                'best_day_share': '0.30',
-                                'worst_day_loss': '300',
-                                'max_drawdown': '850',
-                                'regime_slice_pass_rate': '0.50',
-                            },
-                            'full_window': {
-                                'net_per_day': '620',
-                                'trading_day_count': 9,
-                                'active_days': 8,
-                                'daily_net': {'2026-04-02': '620'},
-                                'daily_filled_notional': {'2026-04-02': '340000'},
-                            },
-                            'replay_config': {
-                                'params': {'max_entries_per_session': '1', 'entry_cooldown_seconds': '600'},
-                                'strategy_overrides': {'universe_symbols': ['AMAT', 'NVDA']},
-                            },
-                        }
-                    ],
-                },
-            ]
-            signal_rows = [
-                SignalEnvelope(
-                    event_ts=datetime(2026, 3, 20, 13, 30, tzinfo=UTC),
-                    symbol='AMAT',
-                    seq=1,
-                    source='ta',
-                    timeframe='1Sec',
-                    payload={'price': '180.10'},
-                )
-            ]
-
-            args = Namespace(
-                program=program_path,
-                output_dir=output_dir,
-                strategy_configmap=configmap_path,
-                family_template_dir=family_dir,
-                clickhouse_http_url='http://example.invalid:8123',
-                clickhouse_username='torghut',
-                clickhouse_password='secret',
-                start_equity='31590.02',
-                chunk_minutes=10,
-                symbols='',
-                progress_log_seconds=30,
-                shadow_validation_artifact=None,
-                train_days=6,
-                holdout_days=3,
-                full_window_start_date='',
-                full_window_end_date='',
-                expected_last_trading_day='',
-                allow_stale_tape=False,
-                prefetch_full_window_rows=False,
-                max_frontier_runs=0,
-                json_output=None,
-            )
-
-            with patch(
-                'scripts.run_strategy_autoresearch_loop.run_consistent_profitability_frontier',
-                side_effect=responses,
-            ), patch(
-                'scripts.run_strategy_autoresearch_loop.replay_mod._iter_signal_rows',
-                return_value=iter(signal_rows),
-            ):
-                payload = runner.run_strategy_autoresearch_loop(args)
-
-            self.assertEqual(payload['status'], 'ok')
-            self.assertEqual(payload['frontier_run_count'], 2)
-            self.assertTrue(payload['objective_met'])
-            run_root = Path(payload['run_root'])
-            self.assertTrue((run_root / 'history.jsonl').exists())
-            self.assertTrue((run_root / 'results.tsv').exists())
-            self.assertTrue((run_root / 'strategy-discovery-history.ipynb').exists())
-            self.assertTrue((run_root / 'mlx-autoresearch-diagnostics.ipynb').exists())
-            self.assertTrue((run_root / 'promotion_readiness.json').exists())
-            self.assertTrue((run_root / 'mlx-snapshot-manifest.json').exists())
-            self.assertTrue((run_root / 'mlx-snapshot-signals.jsonl').exists())
-            self.assertTrue((run_root / 'mlx-candidate-descriptors.jsonl').exists())
-            self.assertTrue((run_root / 'mlx-proposal-scores.jsonl').exists())
-            summary = json.loads((run_root / 'summary.json').read_text(encoding='utf-8'))
-            self.assertEqual(summary['best_candidate']['candidate_id'], 'mutated-1')
-            self.assertEqual(summary['objective_scope'], 'research_only')
-            self.assertFalse(summary['promotion_readiness']['promotable'])
-            self.assertEqual(summary['promotion_readiness']['stage'], 'research_candidate')
-            self.assertIn('scheduler_v3_parity_missing', summary['promotion_readiness']['blockers'])
-            self.assertEqual(summary['best_candidate']['promotion_status'], 'blocked_pending_runtime_parity')
-            self.assertEqual(summary['best_candidate']['runtime_strategy_name'], 'breakout-continuation-long-v1')
-            self.assertIn('mlx_exports', summary)
-            self.assertIn('snapshot_manifest_path', summary)
-            self.assertIn('runtime_closure', summary)
-            self.assertIn('live_progress', summary)
-            self.assertEqual(summary['live_progress']['frontier_runs_started'], 2)
-            self.assertGreaterEqual(summary['live_progress']['proposal_score_count'], 2)
-            self.assertEqual(
-                summary['live_progress']['best_experiment_candidate']['top_candidate_id'],
-                'mutated-1',
-            )
-            self.assertIn('descriptor_id', summary['best_candidate'])
-            self.assertIn('proposal_score', summary['best_candidate'])
-            self.assertEqual(
-                summary['best_candidate']['candidate_params'],
-                {'max_entries_per_session': '1', 'entry_cooldown_seconds': '600'},
-            )
-            self.assertEqual(
-                summary['best_candidate']['candidate_strategy_overrides'],
-                {'universe_symbols': ['AMAT', 'NVDA']},
-            )
-            self.assertEqual(summary['runtime_closure']['status'], 'pending_runtime_parity')
-            self.assertFalse(summary['runtime_closure']['promotion_prerequisites']['allowed'])
-            self.assertFalse(summary['runtime_closure']['rollback_readiness']['ready'])
-            mlx_notebook = (run_root / 'mlx-autoresearch-diagnostics.ipynb').read_text(encoding='utf-8')
-            self.assertIn('Runtime closure evidence', mlx_notebook)
-            self.assertIn('RUNTIME_SHADOW_VALIDATION', mlx_notebook)
-            self.assertTrue((run_root / 'runtime-closure' / 'summary.json').exists())
-            self.assertTrue((run_root / 'runtime-closure' / 'promotion' / 'promotion-prerequisites.json').exists())
-            manifest = json.loads((run_root / 'mlx-snapshot-manifest.json').read_text(encoding='utf-8'))
-            self.assertEqual(manifest['symbols'], ['AMAT', 'NVDA'])
-            self.assertEqual(manifest['row_counts']['signal_row_count'], 1)
-            self.assertEqual(
-                manifest['tensor_bundle_paths']['signal_rows_jsonl'],
-                str(run_root / 'mlx-snapshot-signals.jsonl'),
-            )
-            promotion_readiness = json.loads((run_root / 'promotion_readiness.json').read_text(encoding='utf-8'))
-            self.assertEqual(promotion_readiness['candidate_id'], 'mutated-1')
-            self.assertFalse(promotion_readiness['promotable'])
-
-    def test_run_strategy_autoresearch_loop_records_missing_runtime_strategy_as_skip(self) -> None:
-        with TemporaryDirectory() as tmpdir:
-            root = Path(tmpdir)
-            program_path, family_dir = self._write_program_fixture(root)
-            configmap_path = root / 'strategy-configmap.yaml'
+            configmap_path = root / "strategy-configmap.yaml"
             configmap_path.write_text(
                 yaml.safe_dump(
                     {
-                        'apiVersion': 'v1',
-                        'kind': 'ConfigMap',
-                        'data': {'strategies.yaml': 'strategies: []\n'},
+                        "apiVersion": "v1",
+                        "kind": "ConfigMap",
+                        "data": {"strategies.yaml": "strategies: []\n"},
                     },
                     sort_keys=False,
                 ),
-                encoding='utf-8',
+                encoding="utf-8",
             )
-            output_dir = root / 'out'
+            output_dir = root / "out"
+
+            responses = [
+                {
+                    "dataset_snapshot_receipt": {"snapshot_id": "snap-1"},
+                    "window": {
+                        "full_window_start_date": "2026-03-20",
+                        "full_window_end_date": "2026-04-09",
+                    },
+                    "top": [
+                        {
+                            "candidate_id": "seed-1",
+                            "hard_vetoes": [],
+                            "ranking": {
+                                "pareto_tier": 1,
+                                "tie_breaker_score": "10",
+                                "vetoed": False,
+                            },
+                            "objective_scorecard": {
+                                "net_pnl_per_day": "450",
+                                "active_day_ratio": "0.70",
+                                "positive_day_ratio": "0.55",
+                                "avg_filled_notional_per_day": "290000",
+                                "avg_filled_notional_per_active_day": "360000",
+                                "best_day_share": "0.40",
+                                "worst_day_loss": "350",
+                                "max_drawdown": "900",
+                                "regime_slice_pass_rate": "0.45",
+                            },
+                            "full_window": {
+                                "net_per_day": "450",
+                                "trading_day_count": 9,
+                                "active_days": 6,
+                                "daily_net": {"2026-04-01": "450"},
+                                "daily_filled_notional": {"2026-04-01": "290000"},
+                            },
+                            "replay_config": {
+                                "params": {
+                                    "max_entries_per_session": "2",
+                                    "entry_cooldown_seconds": "600",
+                                },
+                                "strategy_overrides": {
+                                    "universe_symbols": ["AMAT", "NVDA"]
+                                },
+                            },
+                        }
+                    ],
+                },
+                {
+                    "dataset_snapshot_receipt": {"snapshot_id": "snap-2"},
+                    "window": {
+                        "full_window_start_date": "2026-03-20",
+                        "full_window_end_date": "2026-04-09",
+                    },
+                    "top": [
+                        {
+                            "candidate_id": "mutated-1",
+                            "hard_vetoes": [],
+                            "ranking": {
+                                "pareto_tier": 1,
+                                "tie_breaker_score": "11",
+                                "vetoed": False,
+                            },
+                            "objective_scorecard": {
+                                "net_pnl_per_day": "620",
+                                "active_day_ratio": "0.85",
+                                "positive_day_ratio": "0.60",
+                                "avg_filled_notional_per_day": "340000",
+                                "avg_filled_notional_per_active_day": "400000",
+                                "best_day_share": "0.30",
+                                "worst_day_loss": "300",
+                                "max_drawdown": "850",
+                                "regime_slice_pass_rate": "0.50",
+                            },
+                            "full_window": {
+                                "net_per_day": "620",
+                                "trading_day_count": 9,
+                                "active_days": 8,
+                                "daily_net": {"2026-04-02": "620"},
+                                "daily_filled_notional": {"2026-04-02": "340000"},
+                            },
+                            "replay_config": {
+                                "params": {
+                                    "max_entries_per_session": "1",
+                                    "entry_cooldown_seconds": "600",
+                                },
+                                "strategy_overrides": {
+                                    "universe_symbols": ["AMAT", "NVDA"]
+                                },
+                            },
+                        }
+                    ],
+                },
+            ]
+            signal_rows = [
+                SignalEnvelope(
+                    event_ts=datetime(2026, 3, 20, 13, 30, tzinfo=UTC),
+                    symbol="AMAT",
+                    seq=1,
+                    source="ta",
+                    timeframe="1Sec",
+                    payload={"price": "180.10"},
+                )
+            ]
+
             args = Namespace(
                 program=program_path,
                 output_dir=output_dir,
                 strategy_configmap=configmap_path,
                 family_template_dir=family_dir,
-                clickhouse_http_url='http://example.invalid:8123',
-                clickhouse_username='torghut',
-                clickhouse_password='secret',
-                start_equity='31590.02',
+                clickhouse_http_url="http://example.invalid:8123",
+                clickhouse_username="torghut",
+                clickhouse_password="secret",
+                start_equity="31590.02",
                 chunk_minutes=10,
-                symbols='',
+                symbols="",
                 progress_log_seconds=30,
                 shadow_validation_artifact=None,
                 train_days=6,
                 holdout_days=3,
-                full_window_start_date='',
-                full_window_end_date='',
-                expected_last_trading_day='',
+                full_window_start_date="",
+                full_window_end_date="",
+                expected_last_trading_day="",
+                allow_stale_tape=False,
+                prefetch_full_window_rows=False,
+                max_frontier_runs=0,
+                json_output=None,
+            )
+
+            with (
+                patch(
+                    "scripts.run_strategy_autoresearch_loop.run_consistent_profitability_frontier",
+                    side_effect=responses,
+                ),
+                patch(
+                    "scripts.run_strategy_autoresearch_loop.replay_mod._iter_signal_rows",
+                    return_value=iter(signal_rows),
+                ),
+            ):
+                payload = runner.run_strategy_autoresearch_loop(args)
+
+            self.assertEqual(payload["status"], "ok")
+            self.assertEqual(payload["frontier_run_count"], 2)
+            self.assertTrue(payload["objective_met"])
+            run_root = Path(payload["run_root"])
+            self.assertTrue((run_root / "history.jsonl").exists())
+            self.assertTrue((run_root / "results.tsv").exists())
+            self.assertTrue((run_root / "strategy-discovery-history.ipynb").exists())
+            self.assertTrue((run_root / "mlx-autoresearch-diagnostics.ipynb").exists())
+            self.assertTrue((run_root / "promotion_readiness.json").exists())
+            self.assertTrue((run_root / "mlx-snapshot-manifest.json").exists())
+            self.assertTrue((run_root / "mlx-snapshot-signals.jsonl").exists())
+            self.assertTrue((run_root / "mlx-candidate-descriptors.jsonl").exists())
+            self.assertTrue((run_root / "mlx-proposal-scores.jsonl").exists())
+            summary = json.loads(
+                (run_root / "summary.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(summary["best_candidate"]["candidate_id"], "mutated-1")
+            self.assertEqual(summary["objective_scope"], "research_only")
+            self.assertFalse(summary["promotion_readiness"]["promotable"])
+            self.assertEqual(
+                summary["promotion_readiness"]["stage"], "research_candidate"
+            )
+            self.assertIn(
+                "scheduler_v3_parity_missing",
+                summary["promotion_readiness"]["blockers"],
+            )
+            self.assertEqual(
+                summary["best_candidate"]["promotion_status"],
+                "blocked_pending_runtime_parity",
+            )
+            self.assertEqual(
+                summary["best_candidate"]["runtime_strategy_name"],
+                "breakout-continuation-long-v1",
+            )
+            self.assertIn("mlx_exports", summary)
+            self.assertIn("snapshot_manifest_path", summary)
+            self.assertIn("runtime_closure", summary)
+            self.assertIn("live_progress", summary)
+            self.assertEqual(summary["live_progress"]["frontier_runs_started"], 2)
+            self.assertGreaterEqual(summary["live_progress"]["proposal_score_count"], 2)
+            self.assertEqual(
+                summary["live_progress"]["best_experiment_candidate"][
+                    "top_candidate_id"
+                ],
+                "mutated-1",
+            )
+            self.assertIn("descriptor_id", summary["best_candidate"])
+            self.assertIn("proposal_score", summary["best_candidate"])
+            self.assertEqual(
+                summary["best_candidate"]["candidate_params"],
+                {"max_entries_per_session": "1", "entry_cooldown_seconds": "600"},
+            )
+            self.assertEqual(
+                summary["best_candidate"]["candidate_strategy_overrides"],
+                {"universe_symbols": ["AMAT", "NVDA"]},
+            )
+            self.assertEqual(
+                summary["runtime_closure"]["status"], "pending_runtime_parity"
+            )
+            self.assertFalse(
+                summary["runtime_closure"]["promotion_prerequisites"]["allowed"]
+            )
+            self.assertFalse(summary["runtime_closure"]["rollback_readiness"]["ready"])
+            mlx_notebook = (run_root / "mlx-autoresearch-diagnostics.ipynb").read_text(
+                encoding="utf-8"
+            )
+            self.assertIn("Runtime closure evidence", mlx_notebook)
+            self.assertIn("RUNTIME_SHADOW_VALIDATION", mlx_notebook)
+            self.assertTrue((run_root / "runtime-closure" / "summary.json").exists())
+            self.assertTrue(
+                (
+                    run_root
+                    / "runtime-closure"
+                    / "promotion"
+                    / "promotion-prerequisites.json"
+                ).exists()
+            )
+            manifest = json.loads(
+                (run_root / "mlx-snapshot-manifest.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(manifest["symbols"], ["AMAT", "NVDA"])
+            self.assertEqual(manifest["row_counts"]["signal_row_count"], 1)
+            self.assertEqual(
+                manifest["tensor_bundle_paths"]["signal_rows_jsonl"],
+                str(run_root / "mlx-snapshot-signals.jsonl"),
+            )
+            promotion_readiness = json.loads(
+                (run_root / "promotion_readiness.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(promotion_readiness["candidate_id"], "mutated-1")
+            self.assertFalse(promotion_readiness["promotable"])
+
+    def test_run_strategy_autoresearch_loop_records_missing_runtime_strategy_as_skip(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            program_path, family_dir = self._write_program_fixture(root)
+            configmap_path = root / "strategy-configmap.yaml"
+            configmap_path.write_text(
+                yaml.safe_dump(
+                    {
+                        "apiVersion": "v1",
+                        "kind": "ConfigMap",
+                        "data": {"strategies.yaml": "strategies: []\n"},
+                    },
+                    sort_keys=False,
+                ),
+                encoding="utf-8",
+            )
+            output_dir = root / "out"
+            args = Namespace(
+                program=program_path,
+                output_dir=output_dir,
+                strategy_configmap=configmap_path,
+                family_template_dir=family_dir,
+                clickhouse_http_url="http://example.invalid:8123",
+                clickhouse_username="torghut",
+                clickhouse_password="secret",
+                start_equity="31590.02",
+                chunk_minutes=10,
+                symbols="",
+                progress_log_seconds=30,
+                shadow_validation_artifact=None,
+                train_days=6,
+                holdout_days=3,
+                full_window_start_date="",
+                full_window_end_date="",
+                expected_last_trading_day="",
                 allow_stale_tape=False,
                 prefetch_full_window_rows=False,
                 max_frontier_runs=0,
@@ -1067,163 +1295,211 @@ class TestStrategyAutoresearch(TestCase):
             )
 
             with patch(
-                'scripts.run_strategy_autoresearch_loop.run_consistent_profitability_frontier',
-                side_effect=ValueError('strategy_not_found:breakout-continuation-long-v1'),
+                "scripts.run_strategy_autoresearch_loop.run_consistent_profitability_frontier",
+                side_effect=ValueError(
+                    "strategy_not_found:breakout-continuation-long-v1"
+                ),
             ):
                 payload = runner.run_strategy_autoresearch_loop(args)
 
-            self.assertEqual(payload['status'], 'ok')
-            self.assertEqual(payload['frontier_run_count'], 1)
-            self.assertFalse(payload['objective_met'])
-            run_root = Path(payload['run_root'])
+            self.assertEqual(payload["status"], "ok")
+            self.assertEqual(payload["frontier_run_count"], 1)
+            self.assertFalse(payload["objective_met"])
+            run_root = Path(payload["run_root"])
             history_rows = [
                 json.loads(line)
-                for line in (run_root / 'history.jsonl').read_text(encoding='utf-8').splitlines()
+                for line in (run_root / "history.jsonl")
+                .read_text(encoding="utf-8")
+                .splitlines()
             ]
             self.assertEqual(len(history_rows), 1)
-            self.assertEqual(history_rows[0]['status'], 'skip')
-            self.assertIn('runtime_strategy_missing', history_rows[0]['hard_vetoes'])
-            self.assertEqual(history_rows[0]['proposal_selection_reason'], 'runtime_strategy_missing')
-            result_payload = json.loads(
-                next((run_root / 'experiments').glob('*/result.json')).read_text(encoding='utf-8')
-            )
-            self.assertEqual(result_payload['status'], 'skipped_runtime_strategy_missing')
+            self.assertEqual(history_rows[0]["status"], "skip")
+            self.assertIn("runtime_strategy_missing", history_rows[0]["hard_vetoes"])
             self.assertEqual(
-                result_payload['top'][0]['runtime_availability']['reason'],
-                'strategy_not_found:breakout-continuation-long-v1',
+                history_rows[0]["proposal_selection_reason"], "runtime_strategy_missing"
+            )
+            result_payload = json.loads(
+                next((run_root / "experiments").glob("*/result.json")).read_text(
+                    encoding="utf-8"
+                )
+            )
+            self.assertEqual(
+                result_payload["status"], "skipped_runtime_strategy_missing"
+            )
+            self.assertEqual(
+                result_payload["top"][0]["runtime_availability"]["reason"],
+                "strategy_not_found:breakout-continuation-long-v1",
             )
 
-    def test_run_strategy_autoresearch_loop_applies_replay_budget_and_candidate_specific_scores(self) -> None:
+    def test_run_strategy_autoresearch_loop_applies_replay_budget_and_candidate_specific_scores(
+        self,
+    ) -> None:
         with TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
             program_path, family_dir = self._write_program_fixture(root)
-            program_payload = yaml.safe_load(program_path.read_text(encoding='utf-8'))
-            program_payload['families'][0]['keep_top_candidates'] = 2
-            program_payload['replay_budget'] = {
-                'max_candidates_per_round': 1,
-                'exploration_slots': 1,
+            program_payload = yaml.safe_load(program_path.read_text(encoding="utf-8"))
+            program_payload["families"][0]["keep_top_candidates"] = 2
+            program_payload["replay_budget"] = {
+                "max_candidates_per_round": 1,
+                "exploration_slots": 1,
             }
-            program_payload['proposal_model_policy'] = {
-                'enabled': True,
-                'mode': 'ranking_only',
-                'backend_preference': 'numpy-fallback',
-                'top_k': 4,
-                'exploration_slots': 1,
-                'minimum_history_rows': 1,
+            program_payload["proposal_model_policy"] = {
+                "enabled": True,
+                "mode": "ranking_only",
+                "backend_preference": "numpy-fallback",
+                "top_k": 4,
+                "exploration_slots": 1,
+                "minimum_history_rows": 1,
             }
-            program_path.write_text(yaml.safe_dump(program_payload, sort_keys=False), encoding='utf-8')
-            configmap_path = root / 'strategy-configmap.yaml'
-            configmap_path.write_text(
-                yaml.safe_dump({'apiVersion': 'v1', 'kind': 'ConfigMap', 'data': {'strategies.yaml': 'strategies: []\n'}}, sort_keys=False),
-                encoding='utf-8',
+            program_path.write_text(
+                yaml.safe_dump(program_payload, sort_keys=False), encoding="utf-8"
             )
-            output_dir = root / 'out'
+            configmap_path = root / "strategy-configmap.yaml"
+            configmap_path.write_text(
+                yaml.safe_dump(
+                    {
+                        "apiVersion": "v1",
+                        "kind": "ConfigMap",
+                        "data": {"strategies.yaml": "strategies: []\n"},
+                    },
+                    sort_keys=False,
+                ),
+                encoding="utf-8",
+            )
+            output_dir = root / "out"
             signal_rows = [
                 SignalEnvelope(
                     event_ts=datetime(2026, 3, 20, 13, 30, tzinfo=UTC),
-                    symbol='AMAT',
+                    symbol="AMAT",
                     seq=1,
-                    source='ta',
-                    timeframe='1Sec',
-                    payload={'price': '180.10'},
+                    source="ta",
+                    timeframe="1Sec",
+                    payload={"price": "180.10"},
                 )
             ]
             responses = [
                 {
-                    'dataset_snapshot_receipt': {'snapshot_id': 'snap-1'},
-                    'window': {
-                        'full_window_start_date': '2026-03-20',
-                        'full_window_end_date': '2026-04-09',
+                    "dataset_snapshot_receipt": {"snapshot_id": "snap-1"},
+                    "window": {
+                        "full_window_start_date": "2026-03-20",
+                        "full_window_end_date": "2026-04-09",
                     },
-                    'top': [
+                    "top": [
                         {
-                            'candidate_id': 'seed-1',
-                            'hard_vetoes': [],
-                            'ranking': {'pareto_tier': 1, 'tie_breaker_score': '10', 'vetoed': False},
-                            'objective_scorecard': {
-                                'net_pnl_per_day': '450',
-                                'active_day_ratio': '0.70',
-                                'positive_day_ratio': '0.55',
-                                'avg_filled_notional_per_day': '290000',
-                                'avg_filled_notional_per_active_day': '360000',
-                                'best_day_share': '0.40',
-                                'worst_day_loss': '350',
-                                'max_drawdown': '900',
-                                'regime_slice_pass_rate': '0.45',
+                            "candidate_id": "seed-1",
+                            "hard_vetoes": [],
+                            "ranking": {
+                                "pareto_tier": 1,
+                                "tie_breaker_score": "10",
+                                "vetoed": False,
                             },
-                            'full_window': {
-                                'net_per_day': '450',
-                                'trading_day_count': 9,
-                                'active_days': 6,
-                                'daily_net': {'2026-04-01': '450'},
-                                'daily_filled_notional': {'2026-04-01': '290000'},
+                            "objective_scorecard": {
+                                "net_pnl_per_day": "450",
+                                "active_day_ratio": "0.70",
+                                "positive_day_ratio": "0.55",
+                                "avg_filled_notional_per_day": "290000",
+                                "avg_filled_notional_per_active_day": "360000",
+                                "best_day_share": "0.40",
+                                "worst_day_loss": "350",
+                                "max_drawdown": "900",
+                                "regime_slice_pass_rate": "0.45",
                             },
-                            'replay_config': {
-                                'params': {'max_entries_per_session': '2', 'entry_cooldown_seconds': '600'},
-                                'strategy_overrides': {'universe_symbols': ['AMAT', 'NVDA']},
+                            "full_window": {
+                                "net_per_day": "450",
+                                "trading_day_count": 9,
+                                "active_days": 6,
+                                "daily_net": {"2026-04-01": "450"},
+                                "daily_filled_notional": {"2026-04-01": "290000"},
+                            },
+                            "replay_config": {
+                                "params": {
+                                    "max_entries_per_session": "2",
+                                    "entry_cooldown_seconds": "600",
+                                },
+                                "strategy_overrides": {
+                                    "universe_symbols": ["AMAT", "NVDA"]
+                                },
                             },
                         }
                     ],
                 },
                 {
-                    'dataset_snapshot_receipt': {'snapshot_id': 'snap-2'},
-                    'window': {
-                        'full_window_start_date': '2026-03-20',
-                        'full_window_end_date': '2026-04-09',
+                    "dataset_snapshot_receipt": {"snapshot_id": "snap-2"},
+                    "window": {
+                        "full_window_start_date": "2026-03-20",
+                        "full_window_end_date": "2026-04-09",
                     },
-                    'top': [
+                    "top": [
                         {
-                            'candidate_id': 'mutated-1',
-                            'hard_vetoes': [],
-                            'ranking': {'pareto_tier': 1, 'tie_breaker_score': '11', 'vetoed': False},
-                            'objective_scorecard': {
-                                'net_pnl_per_day': '620',
-                                'active_day_ratio': '0.85',
-                                'positive_day_ratio': '0.60',
-                                'avg_filled_notional_per_day': '340000',
-                                'avg_filled_notional_per_active_day': '400000',
-                                'best_day_share': '0.30',
-                                'worst_day_loss': '300',
-                                'max_drawdown': '850',
-                                'regime_slice_pass_rate': '0.50',
+                            "candidate_id": "mutated-1",
+                            "hard_vetoes": [],
+                            "ranking": {
+                                "pareto_tier": 1,
+                                "tie_breaker_score": "11",
+                                "vetoed": False,
                             },
-                            'full_window': {
-                                'net_per_day': '620',
-                                'trading_day_count': 9,
-                                'active_days': 8,
-                                'daily_net': {'2026-04-02': '620'},
-                                'daily_filled_notional': {'2026-04-02': '340000'},
+                            "objective_scorecard": {
+                                "net_pnl_per_day": "620",
+                                "active_day_ratio": "0.85",
+                                "positive_day_ratio": "0.60",
+                                "avg_filled_notional_per_day": "340000",
+                                "avg_filled_notional_per_active_day": "400000",
+                                "best_day_share": "0.30",
+                                "worst_day_loss": "300",
+                                "max_drawdown": "850",
+                                "regime_slice_pass_rate": "0.50",
                             },
-                            'replay_config': {
-                                'params': {'max_entries_per_session': '1', 'entry_cooldown_seconds': '600'},
-                                'strategy_overrides': {'universe_symbols': ['AMAT', 'NVDA']},
+                            "full_window": {
+                                "net_per_day": "620",
+                                "trading_day_count": 9,
+                                "active_days": 8,
+                                "daily_net": {"2026-04-02": "620"},
+                                "daily_filled_notional": {"2026-04-02": "340000"},
+                            },
+                            "replay_config": {
+                                "params": {
+                                    "max_entries_per_session": "1",
+                                    "entry_cooldown_seconds": "600",
+                                },
+                                "strategy_overrides": {
+                                    "universe_symbols": ["AMAT", "NVDA"]
+                                },
                             },
                         },
                         {
-                            'candidate_id': 'mutated-2',
-                            'hard_vetoes': [],
-                            'ranking': {'pareto_tier': 1, 'tie_breaker_score': '10.5', 'vetoed': False},
-                            'objective_scorecard': {
-                                'net_pnl_per_day': '600',
-                                'active_day_ratio': '0.82',
-                                'positive_day_ratio': '0.58',
-                                'avg_filled_notional_per_day': '330000',
-                                'avg_filled_notional_per_active_day': '395000',
-                                'best_day_share': '0.31',
-                                'worst_day_loss': '305',
-                                'max_drawdown': '845',
-                                'regime_slice_pass_rate': '0.49',
+                            "candidate_id": "mutated-2",
+                            "hard_vetoes": [],
+                            "ranking": {
+                                "pareto_tier": 1,
+                                "tie_breaker_score": "10.5",
+                                "vetoed": False,
                             },
-                            'full_window': {
-                                'net_per_day': '600',
-                                'trading_day_count': 9,
-                                'active_days': 8,
-                                'daily_net': {'2026-04-02': '600'},
-                                'daily_filled_notional': {'2026-04-02': '330000'},
+                            "objective_scorecard": {
+                                "net_pnl_per_day": "600",
+                                "active_day_ratio": "0.82",
+                                "positive_day_ratio": "0.58",
+                                "avg_filled_notional_per_day": "330000",
+                                "avg_filled_notional_per_active_day": "395000",
+                                "best_day_share": "0.31",
+                                "worst_day_loss": "305",
+                                "max_drawdown": "845",
+                                "regime_slice_pass_rate": "0.49",
                             },
-                            'replay_config': {
-                                'params': {'max_entries_per_session': '3', 'entry_cooldown_seconds': '600'},
-                                'strategy_overrides': {'universe_symbols': ['AMAT', 'NVDA']},
+                            "full_window": {
+                                "net_per_day": "600",
+                                "trading_day_count": 9,
+                                "active_days": 8,
+                                "daily_net": {"2026-04-02": "600"},
+                                "daily_filled_notional": {"2026-04-02": "330000"},
+                            },
+                            "replay_config": {
+                                "params": {
+                                    "max_entries_per_session": "3",
+                                    "entry_cooldown_seconds": "600",
+                                },
+                                "strategy_overrides": {
+                                    "universe_symbols": ["AMAT", "NVDA"]
+                                },
                             },
                         },
                     ],
@@ -1235,131 +1511,168 @@ class TestStrategyAutoresearch(TestCase):
                 output_dir=output_dir,
                 strategy_configmap=configmap_path,
                 family_template_dir=family_dir,
-                clickhouse_http_url='http://example.invalid:8123',
-                clickhouse_username='torghut',
-                clickhouse_password='secret',
-                start_equity='31590.02',
+                clickhouse_http_url="http://example.invalid:8123",
+                clickhouse_username="torghut",
+                clickhouse_password="secret",
+                start_equity="31590.02",
                 chunk_minutes=10,
-                symbols='',
+                symbols="",
                 progress_log_seconds=30,
                 shadow_validation_artifact=None,
                 train_days=6,
                 holdout_days=3,
-                full_window_start_date='',
-                full_window_end_date='',
-                expected_last_trading_day='',
+                full_window_start_date="",
+                full_window_end_date="",
+                expected_last_trading_day="",
                 allow_stale_tape=False,
                 prefetch_full_window_rows=False,
                 max_frontier_runs=0,
                 json_output=None,
             )
 
-            with patch(
-                'scripts.run_strategy_autoresearch_loop.run_consistent_profitability_frontier',
-                side_effect=responses,
-            ), patch(
-                'scripts.run_strategy_autoresearch_loop.replay_mod._iter_signal_rows',
-                return_value=iter(signal_rows),
+            with (
+                patch(
+                    "scripts.run_strategy_autoresearch_loop.run_consistent_profitability_frontier",
+                    side_effect=responses,
+                ),
+                patch(
+                    "scripts.run_strategy_autoresearch_loop.replay_mod._iter_signal_rows",
+                    return_value=iter(signal_rows),
+                ),
             ):
                 payload = runner.run_strategy_autoresearch_loop(args)
 
             history_rows = [
                 json.loads(line)
-                for line in (Path(payload['run_root']) / 'history.jsonl').read_text(encoding='utf-8').splitlines()
+                for line in (Path(payload["run_root"]) / "history.jsonl")
+                .read_text(encoding="utf-8")
+                .splitlines()
                 if line.strip()
             ]
             diagnostics = json.loads(
-                (Path(payload['run_root']) / 'mlx-proposal-diagnostics.json').read_text(encoding='utf-8')
+                (Path(payload["run_root"]) / "mlx-proposal-diagnostics.json").read_text(
+                    encoding="utf-8"
+                )
             )
-            round_two_rows = [row for row in history_rows if row['experiment_index'] == 2]
+            round_two_rows = [
+                row for row in history_rows if row["experiment_index"] == 2
+            ]
             self.assertEqual(len(round_two_rows), 2)
-            keep_rows = [row for row in round_two_rows if row['status'] == 'keep']
+            keep_rows = [row for row in round_two_rows if row["status"] == "keep"]
             self.assertEqual(len(keep_rows), 1)
-            self.assertTrue(keep_rows[0]['proposal_selected'])
-            self.assertEqual(keep_rows[0]['proposal_selection_reason'], 'exploitation')
-            score_by_candidate = {row['candidate_id']: row['proposal_score'] for row in round_two_rows}
-            self.assertNotEqual(score_by_candidate['mutated-1'], score_by_candidate['mutated-2'])
-            self.assertEqual(diagnostics['parity_matrix']['replayed_count'], 3)
+            self.assertTrue(keep_rows[0]["proposal_selected"])
+            self.assertEqual(keep_rows[0]["proposal_selection_reason"], "exploitation")
+            score_by_candidate = {
+                row["candidate_id"]: row["proposal_score"] for row in round_two_rows
+            }
+            self.assertNotEqual(
+                score_by_candidate["mutated-1"], score_by_candidate["mutated-2"]
+            )
+            self.assertEqual(diagnostics["parity_matrix"]["replayed_count"], 3)
             self.assertIn(
-                keep_rows[0]['candidate_id'],
-                [row['candidate_id'] for row in diagnostics['selected_candidates']],
+                keep_rows[0]["candidate_id"],
+                [row["candidate_id"] for row in diagnostics["selected_candidates"]],
             )
 
-    def test_run_strategy_autoresearch_loop_flushes_visible_progress_between_experiments(self) -> None:
+    def test_run_strategy_autoresearch_loop_flushes_visible_progress_between_experiments(
+        self,
+    ) -> None:
         with TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
             program_path, family_dir = self._write_program_fixture(root)
-            configmap_path = root / 'strategy-configmap.yaml'
+            configmap_path = root / "strategy-configmap.yaml"
             configmap_path.write_text(
                 yaml.safe_dump(
-                    {'apiVersion': 'v1', 'kind': 'ConfigMap', 'data': {'strategies.yaml': 'strategies: []\n'}},
+                    {
+                        "apiVersion": "v1",
+                        "kind": "ConfigMap",
+                        "data": {"strategies.yaml": "strategies: []\n"},
+                    },
                     sort_keys=False,
                 ),
-                encoding='utf-8',
+                encoding="utf-8",
             )
-            output_dir = root / 'out'
+            output_dir = root / "out"
 
             responses = [
                 {
-                    'dataset_snapshot_receipt': {'snapshot_id': 'snap-1'},
-                    'top': [
+                    "dataset_snapshot_receipt": {"snapshot_id": "snap-1"},
+                    "top": [
                         {
-                            'candidate_id': 'seed-1',
-                            'hard_vetoes': [],
-                            'ranking': {'pareto_tier': 1, 'tie_breaker_score': '10', 'vetoed': False},
-                            'objective_scorecard': {
-                                'net_pnl_per_day': '450',
-                                'active_day_ratio': '0.70',
-                                'positive_day_ratio': '0.55',
-                                'avg_filled_notional_per_day': '290000',
-                                'avg_filled_notional_per_active_day': '360000',
-                                'best_day_share': '0.40',
-                                'worst_day_loss': '350',
-                                'max_drawdown': '900',
-                                'regime_slice_pass_rate': '0.45',
+                            "candidate_id": "seed-1",
+                            "hard_vetoes": [],
+                            "ranking": {
+                                "pareto_tier": 1,
+                                "tie_breaker_score": "10",
+                                "vetoed": False,
                             },
-                            'full_window': {
-                                'net_per_day': '450',
-                                'trading_day_count': 9,
-                                'active_days': 6,
-                                'daily_net': {'2026-04-01': '450'},
-                                'daily_filled_notional': {'2026-04-01': '290000'},
+                            "objective_scorecard": {
+                                "net_pnl_per_day": "450",
+                                "active_day_ratio": "0.70",
+                                "positive_day_ratio": "0.55",
+                                "avg_filled_notional_per_day": "290000",
+                                "avg_filled_notional_per_active_day": "360000",
+                                "best_day_share": "0.40",
+                                "worst_day_loss": "350",
+                                "max_drawdown": "900",
+                                "regime_slice_pass_rate": "0.45",
                             },
-                            'replay_config': {
-                                'params': {'max_entries_per_session': '2', 'entry_cooldown_seconds': '600'},
-                                'strategy_overrides': {'universe_symbols': ['AMAT', 'NVDA']},
+                            "full_window": {
+                                "net_per_day": "450",
+                                "trading_day_count": 9,
+                                "active_days": 6,
+                                "daily_net": {"2026-04-01": "450"},
+                                "daily_filled_notional": {"2026-04-01": "290000"},
+                            },
+                            "replay_config": {
+                                "params": {
+                                    "max_entries_per_session": "2",
+                                    "entry_cooldown_seconds": "600",
+                                },
+                                "strategy_overrides": {
+                                    "universe_symbols": ["AMAT", "NVDA"]
+                                },
                             },
                         }
                     ],
                 },
                 {
-                    'dataset_snapshot_receipt': {'snapshot_id': 'snap-2'},
-                    'top': [
+                    "dataset_snapshot_receipt": {"snapshot_id": "snap-2"},
+                    "top": [
                         {
-                            'candidate_id': 'mutated-1',
-                            'hard_vetoes': [],
-                            'ranking': {'pareto_tier': 1, 'tie_breaker_score': '11', 'vetoed': False},
-                            'objective_scorecard': {
-                                'net_pnl_per_day': '620',
-                                'active_day_ratio': '0.85',
-                                'positive_day_ratio': '0.60',
-                                'avg_filled_notional_per_day': '340000',
-                                'avg_filled_notional_per_active_day': '400000',
-                                'best_day_share': '0.30',
-                                'worst_day_loss': '300',
-                                'max_drawdown': '850',
-                                'regime_slice_pass_rate': '0.50',
+                            "candidate_id": "mutated-1",
+                            "hard_vetoes": [],
+                            "ranking": {
+                                "pareto_tier": 1,
+                                "tie_breaker_score": "11",
+                                "vetoed": False,
                             },
-                            'full_window': {
-                                'net_per_day': '620',
-                                'trading_day_count': 9,
-                                'active_days': 8,
-                                'daily_net': {'2026-04-02': '620'},
-                                'daily_filled_notional': {'2026-04-02': '340000'},
+                            "objective_scorecard": {
+                                "net_pnl_per_day": "620",
+                                "active_day_ratio": "0.85",
+                                "positive_day_ratio": "0.60",
+                                "avg_filled_notional_per_day": "340000",
+                                "avg_filled_notional_per_active_day": "400000",
+                                "best_day_share": "0.30",
+                                "worst_day_loss": "300",
+                                "max_drawdown": "850",
+                                "regime_slice_pass_rate": "0.50",
                             },
-                            'replay_config': {
-                                'params': {'max_entries_per_session': '1', 'entry_cooldown_seconds': '600'},
-                                'strategy_overrides': {'universe_symbols': ['AMAT', 'NVDA']},
+                            "full_window": {
+                                "net_per_day": "620",
+                                "trading_day_count": 9,
+                                "active_days": 8,
+                                "daily_net": {"2026-04-02": "620"},
+                                "daily_filled_notional": {"2026-04-02": "340000"},
+                            },
+                            "replay_config": {
+                                "params": {
+                                    "max_entries_per_session": "1",
+                                    "entry_cooldown_seconds": "600",
+                                },
+                                "strategy_overrides": {
+                                    "universe_symbols": ["AMAT", "NVDA"]
+                                },
                             },
                         }
                     ],
@@ -1371,96 +1684,120 @@ class TestStrategyAutoresearch(TestCase):
                 output_dir=output_dir,
                 strategy_configmap=configmap_path,
                 family_template_dir=family_dir,
-                clickhouse_http_url='http://example.invalid:8123',
-                clickhouse_username='torghut',
-                clickhouse_password='secret',
-                start_equity='31590.02',
+                clickhouse_http_url="http://example.invalid:8123",
+                clickhouse_username="torghut",
+                clickhouse_password="secret",
+                start_equity="31590.02",
                 chunk_minutes=10,
-                symbols='',
+                symbols="",
                 progress_log_seconds=30,
                 shadow_validation_artifact=None,
                 train_days=6,
                 holdout_days=3,
-                full_window_start_date='',
-                full_window_end_date='',
-                expected_last_trading_day='',
+                full_window_start_date="",
+                full_window_end_date="",
+                expected_last_trading_day="",
                 allow_stale_tape=False,
                 prefetch_full_window_rows=False,
                 max_frontier_runs=0,
                 json_output=None,
             )
 
-            frontier_call_count = {'count': 0}
+            frontier_call_count = {"count": 0}
 
             def _frontier_side_effect(_: Namespace) -> dict[str, object]:
-                if frontier_call_count['count'] == 1:
+                if frontier_call_count["count"] == 1:
                     run_roots = [path for path in output_dir.iterdir() if path.is_dir()]
                     self.assertEqual(len(run_roots), 1)
                     run_root = run_roots[0]
-                    summary = json.loads((run_root / 'summary.json').read_text(encoding='utf-8'))
-                    self.assertEqual(summary['status'], 'running')
-                    self.assertEqual(summary['frontier_run_count'], 2)
-                    self.assertEqual(summary['live_progress']['frontier_runs_started'], 2)
-                    self.assertTrue(summary['live_progress']['selected_for_replay']['candidate_id'])
+                    summary = json.loads(
+                        (run_root / "summary.json").read_text(encoding="utf-8")
+                    )
+                    self.assertEqual(summary["status"], "running")
+                    self.assertEqual(summary["frontier_run_count"], 2)
                     self.assertEqual(
-                        summary['live_progress']['selected_for_replay']['family_template_id'],
-                        'breakout_reclaim_v2',
+                        summary["live_progress"]["frontier_runs_started"], 2
+                    )
+                    self.assertTrue(
+                        summary["live_progress"]["selected_for_replay"]["candidate_id"]
                     )
                     self.assertEqual(
-                        summary['live_progress']['latest_experiment']['top_candidate_id'],
-                        'seed-1',
+                        summary["live_progress"]["selected_for_replay"][
+                            "family_template_id"
+                        ],
+                        "breakout_reclaim_v2",
                     )
-                    history_lines = (run_root / 'history.jsonl').read_text(encoding='utf-8').splitlines()
+                    self.assertEqual(
+                        summary["live_progress"]["latest_experiment"][
+                            "top_candidate_id"
+                        ],
+                        "seed-1",
+                    )
+                    history_lines = (
+                        (run_root / "history.jsonl")
+                        .read_text(encoding="utf-8")
+                        .splitlines()
+                    )
                     self.assertEqual(len(history_lines), 1)
-                    self.assertTrue((run_root / 'strategy-discovery-history.ipynb').exists())
-                response = responses[frontier_call_count['count']]
-                frontier_call_count['count'] += 1
+                    self.assertTrue(
+                        (run_root / "strategy-discovery-history.ipynb").exists()
+                    )
+                response = responses[frontier_call_count["count"]]
+                frontier_call_count["count"] += 1
                 return response
 
             with patch(
-                'scripts.run_strategy_autoresearch_loop.run_consistent_profitability_frontier',
+                "scripts.run_strategy_autoresearch_loop.run_consistent_profitability_frontier",
                 side_effect=_frontier_side_effect,
             ):
                 payload = runner.run_strategy_autoresearch_loop(args)
 
-            self.assertEqual(payload['status'], 'ok')
-            self.assertEqual(frontier_call_count['count'], 2)
+            self.assertEqual(payload["status"], "ok")
+            self.assertEqual(frontier_call_count["count"], 2)
 
-    def test_run_strategy_autoresearch_loop_stops_when_discarded_candidate_meets_objective(self) -> None:
+    def test_run_strategy_autoresearch_loop_stops_when_discarded_candidate_meets_objective(
+        self,
+    ) -> None:
         with TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
             program_path, family_dir = self._write_program_fixture(root)
-            program_payload = yaml.safe_load(program_path.read_text(encoding='utf-8'))
-            program_payload['objective']['stop_when_objective_met'] = True
-            program_path.write_text(yaml.safe_dump(program_payload, sort_keys=False), encoding='utf-8')
-            configmap_path = root / 'strategy-configmap.yaml'
+            program_payload = yaml.safe_load(program_path.read_text(encoding="utf-8"))
+            program_payload["objective"]["stop_when_objective_met"] = True
+            program_path.write_text(
+                yaml.safe_dump(program_payload, sort_keys=False), encoding="utf-8"
+            )
+            configmap_path = root / "strategy-configmap.yaml"
             configmap_path.write_text(
                 yaml.safe_dump(
-                    {'apiVersion': 'v1', 'kind': 'ConfigMap', 'data': {'strategies.yaml': 'strategies: []\n'}},
+                    {
+                        "apiVersion": "v1",
+                        "kind": "ConfigMap",
+                        "data": {"strategies.yaml": "strategies: []\n"},
+                    },
                     sort_keys=False,
                 ),
-                encoding='utf-8',
+                encoding="utf-8",
             )
-            output_dir = root / 'out'
+            output_dir = root / "out"
 
             args = Namespace(
                 program=program_path,
                 output_dir=output_dir,
                 strategy_configmap=configmap_path,
                 family_template_dir=family_dir,
-                clickhouse_http_url='http://example.invalid:8123',
-                clickhouse_username='torghut',
-                clickhouse_password='secret',
-                start_equity='31590.02',
+                clickhouse_http_url="http://example.invalid:8123",
+                clickhouse_username="torghut",
+                clickhouse_password="secret",
+                start_equity="31590.02",
                 chunk_minutes=10,
-                symbols='',
+                symbols="",
                 progress_log_seconds=30,
                 shadow_validation_artifact=None,
                 train_days=6,
                 holdout_days=3,
-                full_window_start_date='',
-                full_window_end_date='',
-                expected_last_trading_day='',
+                full_window_start_date="",
+                full_window_end_date="",
+                expected_last_trading_day="",
                 allow_stale_tape=False,
                 prefetch_full_window_rows=False,
                 max_frontier_runs=0,
@@ -1468,109 +1805,136 @@ class TestStrategyAutoresearch(TestCase):
             )
 
             frontier_payload = {
-                'dataset_snapshot_receipt': {'snapshot_id': 'snap-1'},
-                'top': [
+                "dataset_snapshot_receipt": {"snapshot_id": "snap-1"},
+                "top": [
                     {
-                        'candidate_id': 'keep-1',
-                        'hard_vetoes': [],
-                        'ranking': {'pareto_tier': 1, 'tie_breaker_score': '10', 'vetoed': False},
-                        'objective_scorecard': {
-                            'net_pnl_per_day': '420',
-                            'active_day_ratio': '0.70',
-                            'positive_day_ratio': '0.55',
-                            'avg_filled_notional_per_day': '290000',
-                            'avg_filled_notional_per_active_day': '360000',
-                            'best_day_share': '0.40',
-                            'worst_day_loss': '350',
-                            'max_drawdown': '900',
-                            'regime_slice_pass_rate': '0.45',
+                        "candidate_id": "keep-1",
+                        "hard_vetoes": [],
+                        "ranking": {
+                            "pareto_tier": 1,
+                            "tie_breaker_score": "10",
+                            "vetoed": False,
                         },
-                        'full_window': {
-                            'net_per_day': '420',
-                            'trading_day_count': 9,
-                            'active_days': 6,
-                            'daily_net': {'2026-04-01': '420'},
-                            'daily_filled_notional': {'2026-04-01': '290000'},
+                        "objective_scorecard": {
+                            "net_pnl_per_day": "420",
+                            "active_day_ratio": "0.70",
+                            "positive_day_ratio": "0.55",
+                            "avg_filled_notional_per_day": "290000",
+                            "avg_filled_notional_per_active_day": "360000",
+                            "best_day_share": "0.40",
+                            "worst_day_loss": "350",
+                            "max_drawdown": "900",
+                            "regime_slice_pass_rate": "0.45",
                         },
-                        'replay_config': {
-                            'params': {'max_entries_per_session': '2', 'entry_cooldown_seconds': '600'},
-                            'strategy_overrides': {'universe_symbols': ['AMAT', 'NVDA']},
+                        "full_window": {
+                            "net_per_day": "420",
+                            "trading_day_count": 9,
+                            "active_days": 6,
+                            "daily_net": {"2026-04-01": "420"},
+                            "daily_filled_notional": {"2026-04-01": "290000"},
+                        },
+                        "replay_config": {
+                            "params": {
+                                "max_entries_per_session": "2",
+                                "entry_cooldown_seconds": "600",
+                            },
+                            "strategy_overrides": {
+                                "universe_symbols": ["AMAT", "NVDA"]
+                            },
                         },
                     },
                     {
-                        'candidate_id': 'discarded-objective-hit',
-                        'hard_vetoes': [],
-                        'ranking': {'pareto_tier': 2, 'tie_breaker_score': '9', 'vetoed': False},
-                        'objective_scorecard': {
-                            'net_pnl_per_day': '620',
-                            'active_day_ratio': '0.85',
-                            'positive_day_ratio': '0.65',
-                            'avg_filled_notional_per_day': '340000',
-                            'avg_filled_notional_per_active_day': '400000',
-                            'best_day_share': '0.30',
-                            'worst_day_loss': '300',
-                            'max_drawdown': '850',
-                            'regime_slice_pass_rate': '0.50',
+                        "candidate_id": "discarded-objective-hit",
+                        "hard_vetoes": [],
+                        "ranking": {
+                            "pareto_tier": 2,
+                            "tie_breaker_score": "9",
+                            "vetoed": False,
                         },
-                        'full_window': {
-                            'net_per_day': '620',
-                            'trading_day_count': 9,
-                            'active_days': 8,
-                            'daily_net': {'2026-04-02': '620'},
-                            'daily_filled_notional': {'2026-04-02': '340000'},
+                        "objective_scorecard": {
+                            "net_pnl_per_day": "620",
+                            "active_day_ratio": "0.85",
+                            "positive_day_ratio": "0.65",
+                            "avg_filled_notional_per_day": "340000",
+                            "avg_filled_notional_per_active_day": "400000",
+                            "best_day_share": "0.30",
+                            "worst_day_loss": "300",
+                            "max_drawdown": "850",
+                            "regime_slice_pass_rate": "0.50",
                         },
-                        'replay_config': {
-                            'params': {'max_entries_per_session': '1', 'entry_cooldown_seconds': '600'},
-                            'strategy_overrides': {'universe_symbols': ['AMAT', 'NVDA']},
+                        "full_window": {
+                            "net_per_day": "620",
+                            "trading_day_count": 9,
+                            "active_days": 8,
+                            "daily_net": {"2026-04-02": "620"},
+                            "daily_filled_notional": {"2026-04-02": "340000"},
+                        },
+                        "replay_config": {
+                            "params": {
+                                "max_entries_per_session": "1",
+                                "entry_cooldown_seconds": "600",
+                            },
+                            "strategy_overrides": {
+                                "universe_symbols": ["AMAT", "NVDA"]
+                            },
                         },
                     },
                 ],
             }
 
             with patch(
-                'scripts.run_strategy_autoresearch_loop.run_consistent_profitability_frontier',
-                side_effect=[frontier_payload, AssertionError('loop should stop after discarded objective hit')],
+                "scripts.run_strategy_autoresearch_loop.run_consistent_profitability_frontier",
+                side_effect=[
+                    frontier_payload,
+                    AssertionError("loop should stop after discarded objective hit"),
+                ],
             ):
                 payload = runner.run_strategy_autoresearch_loop(args)
 
-            self.assertEqual(payload['status'], 'ok')
-            self.assertTrue(payload['objective_met'])
-            self.assertEqual(payload['frontier_run_count'], 1)
-            summary = json.loads((Path(payload['run_root']) / 'summary.json').read_text(encoding='utf-8'))
-            self.assertTrue(summary['objective_met'])
+            self.assertEqual(payload["status"], "ok")
+            self.assertTrue(payload["objective_met"])
+            self.assertEqual(payload["frontier_run_count"], 1)
+            summary = json.loads(
+                (Path(payload["run_root"]) / "summary.json").read_text(encoding="utf-8")
+            )
+            self.assertTrue(summary["objective_met"])
 
     def test_run_strategy_autoresearch_loop_persists_error_artifacts(self) -> None:
         with TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
             program_path, family_dir = self._write_program_fixture(root)
-            configmap_path = root / 'strategy-configmap.yaml'
+            configmap_path = root / "strategy-configmap.yaml"
             configmap_path.write_text(
                 yaml.safe_dump(
-                    {'apiVersion': 'v1', 'kind': 'ConfigMap', 'data': {'strategies.yaml': 'strategies: []\n'}},
+                    {
+                        "apiVersion": "v1",
+                        "kind": "ConfigMap",
+                        "data": {"strategies.yaml": "strategies: []\n"},
+                    },
                     sort_keys=False,
                 ),
-                encoding='utf-8',
+                encoding="utf-8",
             )
-            output_dir = root / 'out'
+            output_dir = root / "out"
 
             args = Namespace(
                 program=program_path,
                 output_dir=output_dir,
                 strategy_configmap=configmap_path,
                 family_template_dir=family_dir,
-                clickhouse_http_url='http://example.invalid:8123',
-                clickhouse_username='torghut',
-                clickhouse_password='secret',
-                start_equity='31590.02',
+                clickhouse_http_url="http://example.invalid:8123",
+                clickhouse_username="torghut",
+                clickhouse_password="secret",
+                start_equity="31590.02",
                 chunk_minutes=10,
-                symbols='',
+                symbols="",
                 progress_log_seconds=30,
                 shadow_validation_artifact=None,
                 train_days=6,
                 holdout_days=3,
-                full_window_start_date='',
-                full_window_end_date='',
-                expected_last_trading_day='',
+                full_window_start_date="",
+                full_window_end_date="",
+                expected_last_trading_day="",
                 allow_stale_tape=False,
                 prefetch_full_window_rows=False,
                 max_frontier_runs=0,
@@ -1578,108 +1942,124 @@ class TestStrategyAutoresearch(TestCase):
             )
 
             with patch(
-                'scripts.run_strategy_autoresearch_loop.run_consistent_profitability_frontier',
-                side_effect=RuntimeError('frontier blew up'),
+                "scripts.run_strategy_autoresearch_loop.run_consistent_profitability_frontier",
+                side_effect=RuntimeError("frontier blew up"),
             ):
                 payload = runner.run_strategy_autoresearch_loop(args)
 
-            self.assertEqual(payload['status'], 'error')
-            self.assertEqual(payload['error']['type'], 'RuntimeError')
-            self.assertIn('frontier blew up', payload['error']['message'])
-            run_root = Path(payload['run_root'])
-            self.assertTrue((run_root / 'summary.json').exists())
-            self.assertTrue((run_root / 'history.jsonl').exists())
-            self.assertTrue((run_root / 'results.tsv').exists())
-            self.assertTrue((run_root / 'research_dossier.json').exists())
-            self.assertTrue((run_root / 'strategy-discovery-history.ipynb').exists())
-            self.assertTrue((run_root / 'promotion_readiness.json').exists())
-            promotion_readiness = json.loads((run_root / 'promotion_readiness.json').read_text(encoding='utf-8'))
-            self.assertEqual(promotion_readiness['status'], 'blocked_no_candidate')
-            self.assertIn('best_candidate_missing', promotion_readiness['blockers'])
+            self.assertEqual(payload["status"], "error")
+            self.assertEqual(payload["error"]["type"], "RuntimeError")
+            self.assertIn("frontier blew up", payload["error"]["message"])
+            run_root = Path(payload["run_root"])
+            self.assertTrue((run_root / "summary.json").exists())
+            self.assertTrue((run_root / "history.jsonl").exists())
+            self.assertTrue((run_root / "results.tsv").exists())
+            self.assertTrue((run_root / "research_dossier.json").exists())
+            self.assertTrue((run_root / "strategy-discovery-history.ipynb").exists())
+            self.assertTrue((run_root / "promotion_readiness.json").exists())
+            promotion_readiness = json.loads(
+                (run_root / "promotion_readiness.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(promotion_readiness["status"], "blocked_no_candidate")
+            self.assertIn("best_candidate_missing", promotion_readiness["blockers"])
 
-    def test_run_strategy_autoresearch_loop_honors_max_frontier_runs_and_dedupes_seen_sweeps(self) -> None:
+    def test_run_strategy_autoresearch_loop_honors_max_frontier_runs_and_dedupes_seen_sweeps(
+        self,
+    ) -> None:
         with TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
             program_path, family_dir = self._write_program_fixture(root)
-            program_payload = yaml.safe_load(program_path.read_text(encoding='utf-8'))
-            program_payload['families'].append(dict(program_payload['families'][0]))
-            program_path.write_text(yaml.safe_dump(program_payload, sort_keys=False), encoding='utf-8')
-            configmap_path = root / 'strategy-configmap.yaml'
+            program_payload = yaml.safe_load(program_path.read_text(encoding="utf-8"))
+            program_payload["families"].append(dict(program_payload["families"][0]))
+            program_path.write_text(
+                yaml.safe_dump(program_payload, sort_keys=False), encoding="utf-8"
+            )
+            configmap_path = root / "strategy-configmap.yaml"
             configmap_path.write_text(
                 yaml.safe_dump(
-                    {'apiVersion': 'v1', 'kind': 'ConfigMap', 'data': {'strategies.yaml': 'strategies: []\n'}},
+                    {
+                        "apiVersion": "v1",
+                        "kind": "ConfigMap",
+                        "data": {"strategies.yaml": "strategies: []\n"},
+                    },
                     sort_keys=False,
                 ),
-                encoding='utf-8',
+                encoding="utf-8",
             )
             args = Namespace(
                 program=program_path,
-                output_dir=root / 'out',
+                output_dir=root / "out",
                 strategy_configmap=configmap_path,
                 family_template_dir=family_dir,
-                clickhouse_http_url='http://example.invalid:8123',
-                clickhouse_username='torghut',
-                clickhouse_password='secret',
-                start_equity='31590.02',
+                clickhouse_http_url="http://example.invalid:8123",
+                clickhouse_username="torghut",
+                clickhouse_password="secret",
+                start_equity="31590.02",
                 chunk_minutes=10,
-                symbols='',
+                symbols="",
                 progress_log_seconds=30,
                 shadow_validation_artifact=None,
                 train_days=6,
                 holdout_days=3,
-                full_window_start_date='2026-03-20',
-                full_window_end_date='',
-                expected_last_trading_day='',
+                full_window_start_date="2026-03-20",
+                full_window_end_date="",
+                expected_last_trading_day="",
                 allow_stale_tape=False,
                 prefetch_full_window_rows=False,
                 max_frontier_runs=1,
                 json_output=None,
             )
             frontier_payload = {
-                'dataset_snapshot_receipt': {'snapshot_id': 'snap-1'},
-                'top': [],
+                "dataset_snapshot_receipt": {"snapshot_id": "snap-1"},
+                "top": [],
             }
 
             with patch(
-                'scripts.run_strategy_autoresearch_loop.run_consistent_profitability_frontier',
+                "scripts.run_strategy_autoresearch_loop.run_consistent_profitability_frontier",
                 return_value=frontier_payload,
             ) as mock_frontier:
                 payload = runner.run_strategy_autoresearch_loop(args)
 
-        self.assertEqual(payload['status'], 'ok')
-        self.assertEqual(payload['frontier_run_count'], 1)
+        self.assertEqual(payload["status"], "ok")
+        self.assertEqual(payload["frontier_run_count"], 1)
         mock_frontier.assert_called_once()
 
-    def test_run_strategy_autoresearch_loop_force_keeps_top_candidate_when_all_vetoed(self) -> None:
+    def test_run_strategy_autoresearch_loop_force_keeps_top_candidate_when_all_vetoed(
+        self,
+    ) -> None:
         with TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
             program_path, family_dir = self._write_program_fixture(root)
-            configmap_path = root / 'strategy-configmap.yaml'
+            configmap_path = root / "strategy-configmap.yaml"
             configmap_path.write_text(
                 yaml.safe_dump(
-                    {'apiVersion': 'v1', 'kind': 'ConfigMap', 'data': {'strategies.yaml': 'strategies: []\n'}},
+                    {
+                        "apiVersion": "v1",
+                        "kind": "ConfigMap",
+                        "data": {"strategies.yaml": "strategies: []\n"},
+                    },
                     sort_keys=False,
                 ),
-                encoding='utf-8',
+                encoding="utf-8",
             )
             args = Namespace(
                 program=program_path,
-                output_dir=root / 'out',
+                output_dir=root / "out",
                 strategy_configmap=configmap_path,
                 family_template_dir=family_dir,
-                clickhouse_http_url='http://example.invalid:8123',
-                clickhouse_username='torghut',
-                clickhouse_password='secret',
-                start_equity='31590.02',
+                clickhouse_http_url="http://example.invalid:8123",
+                clickhouse_username="torghut",
+                clickhouse_password="secret",
+                start_equity="31590.02",
                 chunk_minutes=10,
-                symbols='',
+                symbols="",
                 progress_log_seconds=30,
                 shadow_validation_artifact=None,
                 train_days=6,
                 holdout_days=3,
-                full_window_start_date='',
-                full_window_end_date='',
-                expected_last_trading_day='',
+                full_window_start_date="",
+                full_window_end_date="",
+                expected_last_trading_day="",
                 allow_stale_tape=False,
                 prefetch_full_window_rows=False,
                 max_frontier_runs=2,
@@ -1687,76 +2067,99 @@ class TestStrategyAutoresearch(TestCase):
             )
             frontier_responses = [
                 {
-                    'dataset_snapshot_receipt': {'snapshot_id': 'snap-1'},
-                    'top': [
+                    "dataset_snapshot_receipt": {"snapshot_id": "snap-1"},
+                    "top": [
                         {
-                            'candidate_id': 'vetoed-seed',
-                            'hard_vetoes': ['bad'],
-                            'ranking': {'pareto_tier': 1, 'tie_breaker_score': '1', 'vetoed': True},
-                            'objective_scorecard': {
-                                'net_pnl_per_day': '0',
-                                'active_day_ratio': '0',
-                                'positive_day_ratio': '0',
-                                'avg_filled_notional_per_day': '0',
-                                'avg_filled_notional_per_active_day': '0',
-                                'best_day_share': '1',
-                                'worst_day_loss': '999',
-                                'max_drawdown': '999',
-                                'regime_slice_pass_rate': '0',
+                            "candidate_id": "vetoed-seed",
+                            "hard_vetoes": ["bad"],
+                            "ranking": {
+                                "pareto_tier": 1,
+                                "tie_breaker_score": "1",
+                                "vetoed": True,
                             },
-                            'full_window': {'trading_day_count': 9, 'active_days': 0, 'daily_net': {}, 'daily_filled_notional': {}},
-                            'replay_config': {
-                                'params': {'max_entries_per_session': '2', 'entry_cooldown_seconds': '600'},
-                                'strategy_overrides': {'universe_symbols': ['AMAT', 'NVDA']},
+                            "objective_scorecard": {
+                                "net_pnl_per_day": "0",
+                                "active_day_ratio": "0",
+                                "positive_day_ratio": "0",
+                                "avg_filled_notional_per_day": "0",
+                                "avg_filled_notional_per_active_day": "0",
+                                "best_day_share": "1",
+                                "worst_day_loss": "999",
+                                "max_drawdown": "999",
+                                "regime_slice_pass_rate": "0",
+                            },
+                            "full_window": {
+                                "trading_day_count": 9,
+                                "active_days": 0,
+                                "daily_net": {},
+                                "daily_filled_notional": {},
+                            },
+                            "replay_config": {
+                                "params": {
+                                    "max_entries_per_session": "2",
+                                    "entry_cooldown_seconds": "600",
+                                },
+                                "strategy_overrides": {
+                                    "universe_symbols": ["AMAT", "NVDA"]
+                                },
                             },
                         }
                     ],
                 },
                 {
-                    'dataset_snapshot_receipt': {'snapshot_id': 'snap-2'},
-                    'top': [],
+                    "dataset_snapshot_receipt": {"snapshot_id": "snap-2"},
+                    "top": [],
                 },
             ]
 
             with patch(
-                'scripts.run_strategy_autoresearch_loop.run_consistent_profitability_frontier',
+                "scripts.run_strategy_autoresearch_loop.run_consistent_profitability_frontier",
                 side_effect=frontier_responses,
             ):
                 payload = runner.run_strategy_autoresearch_loop(args)
 
-            self.assertEqual(payload['frontier_run_count'], 2)
-            history = (Path(payload['run_root']) / 'history.jsonl').read_text(encoding='utf-8')
+            self.assertEqual(payload["frontier_run_count"], 2)
+            history = (Path(payload["run_root"]) / "history.jsonl").read_text(
+                encoding="utf-8"
+            )
             self.assertIn('"candidate_id": "vetoed-seed"', history)
 
-    def test_main_writes_json_output_and_returns_nonzero_for_error_payload(self) -> None:
+    def test_main_writes_json_output_and_returns_nonzero_for_error_payload(
+        self,
+    ) -> None:
         with TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
-            program_path = root / 'program.yaml'
-            program_path.write_text('schema_version: torghut.strategy-autoresearch.v1\nfamilies: []\n', encoding='utf-8')
-            output_dir = root / 'out'
-            json_output = root / 'summary.json'
+            program_path = root / "program.yaml"
+            program_path.write_text(
+                "schema_version: torghut.strategy-autoresearch.v1\nfamilies: []\n",
+                encoding="utf-8",
+            )
+            output_dir = root / "out"
+            json_output = root / "summary.json"
 
             with (
                 patch.object(
                     sys,
-                    'argv',
+                    "argv",
                     [
-                        'run_strategy_autoresearch_loop.py',
-                        '--program',
+                        "run_strategy_autoresearch_loop.py",
+                        "--program",
                         str(program_path),
-                        '--output-dir',
+                        "--output-dir",
                         str(output_dir),
-                        '--json-output',
+                        "--json-output",
                         str(json_output),
                     ],
                 ),
                 patch.object(
                     runner,
-                    'run_strategy_autoresearch_loop',
-                    return_value={'status': 'error', 'run_root': str(output_dir)},
+                    "run_strategy_autoresearch_loop",
+                    return_value={"status": "error", "run_root": str(output_dir)},
                 ),
             ):
                 exit_code = runner.main()
 
             self.assertEqual(exit_code, 1)
-            self.assertEqual(json.loads(json_output.read_text(encoding='utf-8'))['status'], 'error')
+            self.assertEqual(
+                json.loads(json_output.read_text(encoding="utf-8"))["status"], "error"
+            )


### PR DESCRIPTION
## Summary

- Hardens the `$500/day` autoresearch loop to prefer capital-feasible, diversified, replay-worthy strategy sleeves instead of average-PnL false positives.
- Adds richer MLX/candidate features and real replay feedback so blocked candidates are deprioritized in later epochs without relaxing oracle gates.
- Tightens portfolio assembly and strict research-program defaults so blocked/vetoed sleeves are not force-kept as promotion candidates.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen ruff check app/trading/discovery/candidate_specs.py app/trading/discovery/mlx_features.py app/trading/discovery/mlx_proposal_models.py app/trading/discovery/mlx_training_data.py app/trading/discovery/portfolio_optimizer.py app/trading/discovery/profit_target_oracle.py scripts/run_strategy_autoresearch_loop.py scripts/run_whitepaper_autoresearch_profit_target.py tests/test_mlx_autoresearch.py tests/test_mlx_training_data.py tests/test_portfolio_optimizer.py tests/test_profit_target_oracle.py tests/test_run_whitepaper_autoresearch_profit_target.py tests/test_strategy_autoresearch.py`
- `uv run --frozen ruff format --check app/trading/discovery/candidate_specs.py app/trading/discovery/mlx_features.py app/trading/discovery/mlx_proposal_models.py app/trading/discovery/mlx_training_data.py app/trading/discovery/portfolio_optimizer.py app/trading/discovery/profit_target_oracle.py scripts/run_strategy_autoresearch_loop.py scripts/run_whitepaper_autoresearch_profit_target.py tests/test_mlx_autoresearch.py tests/test_mlx_training_data.py tests/test_portfolio_optimizer.py tests/test_profit_target_oracle.py tests/test_run_whitepaper_autoresearch_profit_target.py tests/test_strategy_autoresearch.py`
- `uv run --frozen pytest tests/test_mlx_training_data.py tests/test_portfolio_optimizer.py tests/test_profit_target_oracle.py tests/test_run_whitepaper_autoresearch_profit_target.py -q`
- `uv run --frozen pytest tests/test_strategy_autoresearch.py tests/test_mlx_autoresearch.py -q`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
