### PR TITLE
chore(jangar): promote image fa06e2bb

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 210250b2
-  digest: sha256:ba11dd62602f86f4e48bb8c94b5acfc840d01ef2089c0dfc64c42a7a7e81a905
+  tag: fa06e2bb
+  digest: sha256:038c08ec00746b2fc90ed9b2a410a1f9f417baa9bf1a4b906aeb0b582871395f
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,8 +11,8 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 210250b2
-    digest: sha256:379b1bd8d4cb11d7e27ab45b41ca5a162951d654aee98d53d591083f3cb32ae5
+    tag: fa06e2bb
+    digest: sha256:80e31d9c0d15c4dc45a17d600403820fbb5aa2f355a6e3872652324e171c6599
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
@@ -21,8 +21,8 @@ controlPlane:
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 210250b2
-    digest: sha256:ba11dd62602f86f4e48bb8c94b5acfc840d01ef2089c0dfc64c42a7a7e81a905
+    tag: fa06e2bb
+    digest: sha256:038c08ec00746b2fc90ed9b2a410a1f9f417baa9bf1a4b906aeb0b582871395f
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-14T04:24:50Z
+    deploy.knative.dev/rollout: 2026-05-14T06:04:37Z
 spec:
   replicas: 1
   strategy:
@@ -57,11 +57,11 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_RUNTIME_IMAGE
-              value: registry.ide-newton.ts.net/lab/jangar:210250b2@sha256:ba11dd62602f86f4e48bb8c94b5acfc840d01ef2089c0dfc64c42a7a7e81a905
+              value: registry.ide-newton.ts.net/lab/jangar:fa06e2bb@sha256:038c08ec00746b2fc90ed9b2a410a1f9f417baa9bf1a4b906aeb0b582871395f
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: 210250b227e5ad8b58af64c06339ee5b6743fb02
+              value: fa06e2bb36fd3614b6bd6c1c96bb585b536fb2f9
             - name: JANGAR_GITOPS_REVISION
-              value: 210250b227e5ad8b58af64c06339ee5b6743fb02
+              value: fa06e2bb36fd3614b6bd6c1c96bb585b536fb2f9
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_BUMBA_TASK_QUEUE

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -59,5 +59,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: 210250b2
-    digest: sha256:ba11dd62602f86f4e48bb8c94b5acfc840d01ef2089c0dfc64c42a7a7e81a905
+    newTag: fa06e2bb
+    digest: sha256:038c08ec00746b2fc90ed9b2a410a1f9f417baa9bf1a4b906aeb0b582871395f


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `fa06e2bb36fd3614b6bd6c1c96bb585b536fb2f9`
- Image tag: `fa06e2bb`
- Image digest: `sha256:038c08ec00746b2fc90ed9b2a410a1f9f417baa9bf1a4b906aeb0b582871395f`
- Updated API rollout annotation
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`