### PR TITLE
chore(sag): promote agent run fix

### DIFF
--- a/argocd/sag/kustomization.yaml
+++ b/argocd/sag/kustomization.yaml
@@ -12,4 +12,4 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/sag
     newName: registry.ide-newton.ts.net/lab/sag
-    newTag: "f5564f8f4"
+    newTag: "e73a8149d"


### PR DESCRIPTION
## Summary

- Promote the SAG service image built from `e73a8149d`.
- Move `argocd/sag` from `f5564f8f4` to the image containing the AgentRun creation and scroll-area fixes.
- Keep the rollout declarative through the existing Argo CD kustomization tag.

## Related Issues

None

## Testing

- `bun run lint:argocd`
- Built and pushed `registry.ide-newton.ts.net/lab/sag:e73a8149d`
- Kubernetes rollout was attempted by the deploy helper and will be finalized by Argo after this GitOps promotion merges.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
