### PR TITLE
chore(jangar): promote image 63ccaa95

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: fa06e2bb
-  digest: sha256:038c08ec00746b2fc90ed9b2a410a1f9f417baa9bf1a4b906aeb0b582871395f
+  tag: 63ccaa95
+  digest: sha256:24845b35437f8153fe11674fd48f87e149a8d5383a51a6913a3a74aa226ab2e0
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,8 +11,8 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: fa06e2bb
-    digest: sha256:80e31d9c0d15c4dc45a17d600403820fbb5aa2f355a6e3872652324e171c6599
+    tag: 63ccaa95
+    digest: sha256:0662fb870d032713396e0486d25fac26c73a3eea6dbee45f47459f10c44d92f9
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
@@ -21,8 +21,8 @@ controlPlane:
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: fa06e2bb
-    digest: sha256:038c08ec00746b2fc90ed9b2a410a1f9f417baa9bf1a4b906aeb0b582871395f
+    tag: 63ccaa95
+    digest: sha256:24845b35437f8153fe11674fd48f87e149a8d5383a51a6913a3a74aa226ab2e0
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-14T06:04:37Z
+    deploy.knative.dev/rollout: 2026-05-14T06:59:46Z
 spec:
   replicas: 1
   strategy:
@@ -57,11 +57,11 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_RUNTIME_IMAGE
-              value: registry.ide-newton.ts.net/lab/jangar:fa06e2bb@sha256:038c08ec00746b2fc90ed9b2a410a1f9f417baa9bf1a4b906aeb0b582871395f
+              value: registry.ide-newton.ts.net/lab/jangar:63ccaa95@sha256:24845b35437f8153fe11674fd48f87e149a8d5383a51a6913a3a74aa226ab2e0
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: fa06e2bb36fd3614b6bd6c1c96bb585b536fb2f9
+              value: 63ccaa95efc95cc1674a10d645d5f206f8ab3dd8
             - name: JANGAR_GITOPS_REVISION
-              value: fa06e2bb36fd3614b6bd6c1c96bb585b536fb2f9
+              value: 63ccaa95efc95cc1674a10d645d5f206f8ab3dd8
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_BUMBA_TASK_QUEUE

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -59,5 +59,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: fa06e2bb
-    digest: sha256:038c08ec00746b2fc90ed9b2a410a1f9f417baa9bf1a4b906aeb0b582871395f
+    newTag: 63ccaa95
+    digest: sha256:24845b35437f8153fe11674fd48f87e149a8d5383a51a6913a3a74aa226ab2e0


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `63ccaa95efc95cc1674a10d645d5f206f8ab3dd8`
- Image tag: `63ccaa95`
- Image digest: `sha256:24845b35437f8153fe11674fd48f87e149a8d5383a51a6913a3a74aa226ab2e0`
- Updated API rollout annotation
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`