### PR TITLE
chore(jangar): promote image 374c2c1c

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 63ccaa95
-  digest: sha256:24845b35437f8153fe11674fd48f87e149a8d5383a51a6913a3a74aa226ab2e0
+  tag: 374c2c1c
+  digest: sha256:50ce53d5862c779ab21d24ea6e035a3d404c9e21d4be0ba9a11cb33febef8246
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,8 +11,8 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 63ccaa95
-    digest: sha256:0662fb870d032713396e0486d25fac26c73a3eea6dbee45f47459f10c44d92f9
+    tag: 374c2c1c
+    digest: sha256:6f338ba2eb17f1efd67676704da9951f7dd0bc67a69508d6def5572e7865c1b3
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
@@ -21,8 +21,8 @@ controlPlane:
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 63ccaa95
-    digest: sha256:24845b35437f8153fe11674fd48f87e149a8d5383a51a6913a3a74aa226ab2e0
+    tag: 374c2c1c
+    digest: sha256:50ce53d5862c779ab21d24ea6e035a3d404c9e21d4be0ba9a11cb33febef8246
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-14T06:59:46Z
+    deploy.knative.dev/rollout: 2026-05-14T07:42:55Z
 spec:
   replicas: 1
   strategy:
@@ -57,11 +57,11 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_RUNTIME_IMAGE
-              value: registry.ide-newton.ts.net/lab/jangar:63ccaa95@sha256:24845b35437f8153fe11674fd48f87e149a8d5383a51a6913a3a74aa226ab2e0
+              value: registry.ide-newton.ts.net/lab/jangar:374c2c1c@sha256:50ce53d5862c779ab21d24ea6e035a3d404c9e21d4be0ba9a11cb33febef8246
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: 63ccaa95efc95cc1674a10d645d5f206f8ab3dd8
+              value: 374c2c1cf1ac9593906ff9283274652b753a792f
             - name: JANGAR_GITOPS_REVISION
-              value: 63ccaa95efc95cc1674a10d645d5f206f8ab3dd8
+              value: 374c2c1cf1ac9593906ff9283274652b753a792f
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_BUMBA_TASK_QUEUE

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -59,5 +59,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: 63ccaa95
-    digest: sha256:24845b35437f8153fe11674fd48f87e149a8d5383a51a6913a3a74aa226ab2e0
+    newTag: 374c2c1c
+    digest: sha256:50ce53d5862c779ab21d24ea6e035a3d404c9e21d4be0ba9a11cb33febef8246


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `374c2c1cf1ac9593906ff9283274652b753a792f`
- Image tag: `374c2c1c`
- Image digest: `sha256:50ce53d5862c779ab21d24ea6e035a3d404c9e21d4be0ba9a11cb33febef8246`
- Updated API rollout annotation
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`