### PR TITLE
fix(jangar): extend material reentry status timeout

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -83,6 +83,7 @@ controllers:
       JANGAR_WHITEPAPER_FINALIZE_BASE_URL: http://torghut.torghut.svc.cluster.local
       JANGAR_WHITEPAPER_FINALIZE_USE_SERVICE_ACCOUNT_TOKEN: "true"
       JANGAR_MATERIAL_REENTRY_REQUIREMENT_SIGNALS: "true"
+      JANGAR_SCHEDULE_RUNNER_ADMISSION_STATUS_TIMEOUT_MS: "15000"
 resources:
   requests:
     cpu: 200m

--- a/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
+++ b/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
@@ -230,6 +230,16 @@ describe('scheduled AgentRun templates', () => {
     expect(objectAt(limits, 'ephemeral-storage')).toBe('16Gi')
   })
 
+  it('keeps material reentry status reads within the live controller budget', () => {
+    const values = readYamlObjects('argocd/applications/agents/values.yaml')[0]
+    const controllers = objectAt(values, 'controllers')
+    const env = objectAt(objectAt(controllers, 'env'), 'vars')
+    const timeoutMs = Number(objectAt(env, 'JANGAR_SCHEDULE_RUNNER_ADMISSION_STATUS_TIMEOUT_MS'))
+
+    expect(objectAt(env, 'JANGAR_MATERIAL_REENTRY_REQUIREMENT_SIGNALS')).toBe('true')
+    expect(timeoutMs).toBeGreaterThanOrEqual(10_000)
+  })
+
   it('disable retention so schedules can always resolve their template targets', () => {
     const manifestPaths = [
       'argocd/applications/agents/swarm-agentrun-templates.yaml',


### PR DESCRIPTION
## Summary

- Extends the agents-controller material-reentry stage-clearance status read timeout to 15 seconds so live status calls that take about 9 seconds can complete instead of aborting before Signal publication.
- Keeps material-reentry requirement signal publishing enabled for the controllers and adds a regression guard in the agents smoke tests.
- Leaves Codex review automation untouched; this change only affects the controller status-read budget.

## Related Issues

None

## Testing

- `bunx oxfmt --check argocd/applications/agents/values.yaml packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts -t "material reentry"`
- `bun run lint:argocd`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
