### PR TITLE
docs: document test pull request validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,3 +173,4 @@ Service deploy/build/reseal workflows use the typed scripts under `packages/scri
 - Use `mise` when a workflow requires a pinned tool major such as `helm@3`.
 - Generated artifacts and lockfiles are maintained through their owning generators and package managers.
 - For infra changes, default to GitOps under `argocd/` and let Argo CD apply the desired state.
+- Docs-only pull requests can be used to validate repository PR automation without changing runtime behavior.


### PR DESCRIPTION
## Summary

- Adds a README note that docs-only pull requests can validate repository PR automation.
- Keeps the change isolated to documentation with no runtime behavior changes.
- Uses this branch as a ready-to-merge test pull request.

## Related Issues

None

## Testing

- `bunx oxfmt --check README.md` - passed

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
