### PR TITLE
fix(jangar): dedupe material reentry signals

### DIFF
--- a/services/jangar/src/server/__tests__/supporting-primitives-controller.test.ts
+++ b/services/jangar/src/server/__tests__/supporting-primitives-controller.test.ts
@@ -2618,6 +2618,31 @@ describe('supporting primitives controller', () => {
               },
             },
           },
+          {
+            receipt_id: 'material-reentry-receipt:alpha-duplicate',
+            implementer_dispatch: {
+              schema_version: 'jangar.material-reentry-implementer-dispatch.v1',
+              dispatch_kind: 'swarm_requirement_signal',
+              source_swarm: 'jangar-control-plane',
+              target_swarm: 'torghut-quant',
+              target_stage: 'implement',
+              target_role: 'engineer',
+              signal_name: 'material-reentry-torghut-alpha-rotated',
+              channel: 'workflow.general.requirement',
+              description: 'Implement Torghut zero-notional executable-alpha repair for routeable_candidate_count',
+              priority: 'critical',
+              dedupe_key: 'material-reentry:alpha:routeable_candidate_count',
+              payload: {
+                type: 'material_reentry_requirement',
+                business_metric: 'routeable_candidate_count',
+                target_value_gate: 'routeable_candidate_count',
+                required_output_receipt: 'torghut.executable-alpha-receipts.v1',
+                max_notional: 0,
+                no_codex_review: true,
+                review_policy: 'no_automatic_codex_review',
+              },
+            },
+          },
         ],
       },
     )
@@ -2681,11 +2706,21 @@ describe('supporting primitives controller', () => {
       | { metadata: Record<string, unknown>; spec: Record<string, unknown> }
       | undefined
     expect(signalPayload).toBeDefined()
-    expect(signalPayload?.metadata.name).toBe('material-reentry-torghut-alpha-test')
-    const signalLabels = (signalPayload?.metadata.labels ?? {}) as Record<string, string>
+    if (!signalPayload) throw new Error('expected material reentry Signal to be applied')
+    expect(signalPayload.metadata.name).toMatch(/^material-reentry-torghut-quant-[a-z0-9]+$/)
+    expect(
+      (signalPayload.metadata.annotations as Record<string, string>)['swarm.proompteng.ai/material-reentry-dispatch'],
+    ).toBe('material-reentry:alpha:routeable_candidate_count')
+    expect(
+      (signalPayload.metadata.annotations as Record<string, string>)[
+        'swarm.proompteng.ai/material-reentry-source-signal'
+      ],
+    ).toBe('material-reentry-torghut-alpha-rotated')
+    const signalLabels = (signalPayload.metadata.labels ?? {}) as Record<string, string>
     expect(signalLabels['swarm.proompteng.ai/from']).toBe('jangar-control-plane')
     expect(signalLabels['swarm.proompteng.ai/to']).toBe('torghut-quant')
-    expect(signalPayload?.spec.channel).toBe('workflow.general.requirement')
+    expect(signalPayload.spec.channel).toBe('workflow.general.requirement')
+    expect(apply.mock.calls.filter((call) => (call[0] as Record<string, unknown>).kind === 'Signal')).toHaveLength(1)
 
     const requirementRun = apply.mock.calls
       .map((call) => call[0] as Record<string, unknown>)
@@ -2695,7 +2730,7 @@ describe('supporting primitives controller', () => {
       }) as { metadata: Record<string, unknown>; spec: Record<string, unknown> } | undefined
     expect(requirementRun).toBeDefined()
     const parameters = (requirementRun?.spec.parameters ?? {}) as Record<string, string>
-    expect(parameters.swarmRequirementSignal).toBe('material-reentry-torghut-alpha-test')
+    expect(parameters.swarmRequirementSignal).toBe(signalPayload.metadata.name)
     expect(parameters.swarmRequirementSource).toBe('jangar-control-plane')
     expect(parameters.swarmRequirementTarget).toBe('torghut-quant')
     expect(parameters.swarmBusinessMetric).toBe('routeable_candidate_count')

--- a/services/jangar/src/server/supporting-primitives-material-reentry-requirements.ts
+++ b/services/jangar/src/server/supporting-primitives-material-reentry-requirements.ts
@@ -1,4 +1,5 @@
 import { asRecord, asString } from '~/server/primitives-http'
+import { hashNameSuffix, makeHashedName } from '~/server/supporting-primitives-naming'
 import {
   normalizeLabelValue,
   SWARM_REQUIREMENT_LABEL_CHANNEL,
@@ -72,43 +73,50 @@ export const readMaterialReentryRequirementSignals = (status: Record<string, unk
   const receiptDispatches = asArray(clearinghouse.action_receipts)
     .map(asRecord)
     .map((receipt) => readMaterialReentryRequirementSignal(receipt?.implementer_dispatch))
-  const byName = new Map<string, MaterialReentryRequirementSignal>()
+  const byDedupeKey = new Map<string, MaterialReentryRequirementSignal>()
   for (const signal of [...directDispatches, ...receiptDispatches]) {
-    if (signal) byName.set(signal.signalName, signal)
+    if (signal) byDedupeKey.set(signal.dedupeKey, signal)
   }
-  return [...byName.values()]
+  return [...byDedupeKey.values()]
 }
+
+const materialReentrySignalName = (dispatch: MaterialReentryRequirementSignal) =>
+  makeHashedName(`material-reentry-${dispatch.targetSwarm}`, hashNameSuffix(dispatch.dedupeKey))
 
 const materialReentrySignalResource = (
   dispatch: MaterialReentryRequirementSignal,
   namespace: string,
-): Record<string, unknown> => ({
-  apiVersion: 'signals.proompteng.ai/v1alpha1',
-  kind: 'Signal',
-  metadata: {
-    name: dispatch.signalName,
-    namespace,
-    labels: {
-      [SWARM_REQUIREMENT_LABEL_TYPE]: 'requirement',
-      [SWARM_REQUIREMENT_LABEL_FROM]: normalizeLabelValue(dispatch.sourceSwarm),
-      [SWARM_REQUIREMENT_LABEL_TO]: normalizeLabelValue(dispatch.targetSwarm),
-      [SWARM_REQUIREMENT_LABEL_CHANNEL]: 'nats',
-      priority: normalizeLabelValue(dispatch.priority),
+): Record<string, unknown> => {
+  const name = materialReentrySignalName(dispatch)
+  return {
+    apiVersion: 'signals.proompteng.ai/v1alpha1',
+    kind: 'Signal',
+    metadata: {
+      name,
+      namespace,
+      labels: {
+        [SWARM_REQUIREMENT_LABEL_TYPE]: 'requirement',
+        [SWARM_REQUIREMENT_LABEL_FROM]: normalizeLabelValue(dispatch.sourceSwarm),
+        [SWARM_REQUIREMENT_LABEL_TO]: normalizeLabelValue(dispatch.targetSwarm),
+        [SWARM_REQUIREMENT_LABEL_CHANNEL]: 'nats',
+        priority: normalizeLabelValue(dispatch.priority),
+      },
+      annotations: {
+        'swarm.proompteng.ai/material-reentry-dispatch': dispatch.dedupeKey,
+        'swarm.proompteng.ai/material-reentry-source-signal': dispatch.signalName,
+      },
     },
-    annotations: {
-      'swarm.proompteng.ai/material-reentry-dispatch': dispatch.dedupeKey,
+    spec: {
+      channel: dispatch.channel,
+      description: dispatch.description,
+      priority: dispatch.priority,
+      payload: {
+        ...dispatch.payload,
+        material_reentry_dispatch_dedupe_key: dispatch.dedupeKey,
+      },
     },
-  },
-  spec: {
-    channel: dispatch.channel,
-    description: dispatch.description,
-    priority: dispatch.priority,
-    payload: {
-      ...dispatch.payload,
-      material_reentry_dispatch_dedupe_key: dispatch.dedupeKey,
-    },
-  },
-})
+  }
+}
 
 const summarizePublishError = (error: unknown) => {
   if (error instanceof Error && error.message.trim().length > 0) return error.message
@@ -122,18 +130,19 @@ export const publishMaterialReentryRequirementSignals = async (
   let publishErrors = 0
   for (const dispatch of input.materialReentryRequirementSignals) {
     if (dispatch.targetSwarm !== input.swarmName || dispatch.targetStage !== 'implement') continue
-    if (input.existingSignalNames.has(dispatch.signalName)) continue
+    const signalName = materialReentrySignalName(dispatch)
+    if (input.existingSignalNames.has(signalName)) continue
     const signal = materialReentrySignalResource(dispatch, input.namespace)
     try {
       await input.kube.apply(signal)
       publishedSignals.push(signal)
-      input.existingSignalNames.add(dispatch.signalName)
+      input.existingSignalNames.add(signalName)
     } catch (error) {
       publishErrors += 1
       console.warn('[jangar] failed to publish material reentry requirement signal', {
         swarm: input.swarmName,
         namespace: input.namespace,
-        signal: dispatch.signalName,
+        signal: signalName,
         error: summarizePublishError(error),
       })
     }


### PR DESCRIPTION
## Summary

- Make material-reentry requirement Signals use a stable hashed name derived from the dispatch dedupe key instead of the rotating status signal name.
- Dedupe direct and receipt-backed material-reentry dispatches by dedupe key before publishing.
- Preserve the rotating source signal as an annotation while keeping the RequirementBridge parameter pointed at the stable Signal name.

## Related Issues

None

## Testing

- `bunx oxfmt --check services/jangar/src/server/supporting-primitives-material-reentry-requirements.ts services/jangar/src/server/__tests__/supporting-primitives-controller.test.ts`
- `bunx vitest run --config vitest.config.ts src/server/__tests__/supporting-primitives-controller.test.ts -t "material reentry"` from `services/jangar`
- `bun run --filter @proompteng/jangar tsc`
- `bun run --filter @proompteng/jangar lint:oxlint -- services/jangar/src/server/supporting-primitives-material-reentry-requirements.ts services/jangar/src/server/__tests__/supporting-primitives-controller.test.ts`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
