### PR TITLE
fix(torghut): isolate standalone profit replays

### DIFF
--- a/services/torghut/app/trading/discovery/mlx_proposal_models.py
+++ b/services/torghut/app/trading/discovery/mlx_proposal_models.py
@@ -23,6 +23,13 @@ def _float(value: Any) -> float:
 def _candidate_target(row: Mapping[str, Any]) -> float:
     net = _float(row.get("net_pnl_per_day"))
     activity = _float(row.get("active_day_ratio"))
+    positive_day_ratio = _float(row.get("positive_day_ratio"))
+    has_filled_notional = "avg_filled_notional_per_day" in row
+    avg_filled_notional_per_day = _float(row.get("avg_filled_notional_per_day"))
+    required_min_daily_notional = _float(
+        row.get("required_min_daily_notional")
+        or row.get("min_avg_filled_notional_per_day")
+    )
     concentration_penalty = _float(row.get("best_day_share"))
     veto_penalty = 1.0 if row.get("hard_vetoes") else 0.0
     gross_overage_penalty = max(
@@ -30,11 +37,32 @@ def _candidate_target(row: Mapping[str, Any]) -> float:
     )
     cash_deficit_penalty = max(0.0, -_float(row.get("min_cash"))) / 100.0
     negative_cash_penalty = _float(row.get("negative_cash_observation_count")) * 20.0
+    notional_shortfall_penalty = 0.0
+    if required_min_daily_notional > 0.0 and has_filled_notional:
+        notional_shortfall_penalty = (
+            max(
+                0.0,
+                required_min_daily_notional - avg_filled_notional_per_day,
+            )
+            / required_min_daily_notional
+        )
+    no_activity_penalty = (
+        1.0
+        if activity <= 0.0
+        and has_filled_notional
+        and avg_filled_notional_per_day <= 0.0
+        else 0.0
+    )
     return (
         net
         + (activity * 100.0)
+        + (positive_day_ratio * 100.0)
         - (concentration_penalty * 100.0)
         - (veto_penalty * 250.0)
+        - (max(0.0, 1.0 - activity) * 400.0)
+        - (max(0.0, 1.0 - positive_day_ratio) * 300.0)
+        - (notional_shortfall_penalty * 350.0)
+        - (no_activity_penalty * 500.0)
         - (gross_overage_penalty * 500.0)
         - cash_deficit_penalty
         - negative_cash_penalty

--- a/services/torghut/app/trading/discovery/mlx_training_data.py
+++ b/services/torghut/app/trading/discovery/mlx_training_data.py
@@ -259,6 +259,51 @@ def observed_capital_penalty(scorecard: Mapping[str, Any]) -> float:
     )
 
 
+def _observed_replay_viability_penalty(
+    scorecard: Mapping[str, Any],
+    *,
+    required_min_daily_notional: float,
+    target_net_pnl_per_day: float,
+) -> float:
+    if not scorecard:
+        return 0.0
+
+    active_day_ratio = _float(scorecard.get("active_day_ratio"))
+    positive_day_ratio = _float(scorecard.get("positive_day_ratio"))
+    has_filled_notional = "avg_filled_notional_per_day" in scorecard
+    avg_filled_notional_per_day = _float(scorecard.get("avg_filled_notional_per_day"))
+    net_pnl_per_day = _float(scorecard.get("net_pnl_per_day"))
+    no_activity_penalty = (
+        500.0
+        if active_day_ratio <= 0.0
+        and has_filled_notional
+        and avg_filled_notional_per_day <= 0.0
+        else 0.0
+    )
+    notional_shortfall_ratio = 0.0
+    if required_min_daily_notional > 0.0 and has_filled_notional:
+        notional_shortfall_ratio = max(
+            0.0,
+            (required_min_daily_notional - avg_filled_notional_per_day)
+            / required_min_daily_notional,
+        )
+    elif (
+        active_day_ratio <= 0.0
+        and has_filled_notional
+        and avg_filled_notional_per_day <= 0.0
+    ):
+        notional_shortfall_ratio = 1.0
+
+    return (
+        no_activity_penalty
+        + max(0.0, 1.0 - active_day_ratio) * 600.0
+        + max(0.0, 1.0 - positive_day_ratio) * 450.0
+        + notional_shortfall_ratio * 500.0
+        + _float(scorecard.get("negative_day_count")) * 125.0
+        + max(0.0, target_net_pnl_per_day - net_pnl_per_day) * 0.20
+    )
+
+
 def _format_float(value: float) -> str:
     return format(value, ".12g")
 
@@ -318,6 +363,7 @@ def build_mlx_training_rows(
             "required_feature_count",
             "failure_mode_count",
             "target_net_pnl_per_day",
+            "required_min_daily_notional",
             "entry_minute_after_open",
             "exit_minute_after_open",
             "max_hold_seconds",
@@ -354,12 +400,31 @@ def build_mlx_training_rows(
             "history_worst_day_loss",
             "history_max_drawdown",
             "history_avg_filled_notional_per_day",
+            "history_avg_filled_notional_required_ratio",
             "history_hard_veto_count",
             "history_daily_target_shortfall",
+            "history_observed_replay_viability_penalty",
         )
         capital_features = candidate_spec_capital_features(spec)
         params = _params(spec)
         target_net_pnl_per_day = _float(spec.objective.get("target_net_pnl_per_day"))
+        required_min_daily_notional = _float(
+            spec.hard_vetoes.get("required_min_daily_notional")
+            or spec.objective.get("min_avg_filled_notional_per_day")
+        )
+        avg_filled_notional_per_day = _float(
+            scorecard.get("avg_filled_notional_per_day")
+        )
+        avg_filled_notional_required_ratio = (
+            avg_filled_notional_per_day / required_min_daily_notional
+            if required_min_daily_notional > 0.0
+            else 0.0
+        )
+        observed_replay_penalty = _observed_replay_viability_penalty(
+            scorecard,
+            required_min_daily_notional=required_min_daily_notional,
+            target_net_pnl_per_day=target_net_pnl_per_day,
+        )
         selection_mode = params.get("selection_mode")
         signal_motif = params.get("signal_motif")
         stop_loss_bps = _float(
@@ -372,6 +437,7 @@ def build_mlx_training_rows(
             float(len(spec.feature_contract.get("required_features") or [])),
             float(len(spec.expected_failure_modes)),
             target_net_pnl_per_day,
+            required_min_daily_notional,
             _float(params.get("entry_minute_after_open")),
             _float(params.get("exit_minute_after_open")),
             _float(params.get("max_hold_seconds")),
@@ -416,11 +482,13 @@ def build_mlx_training_rows(
             _float(scorecard.get("best_day_share")),
             _float(scorecard.get("worst_day_loss")),
             _float(scorecard.get("max_drawdown")),
-            _float(scorecard.get("avg_filled_notional_per_day")),
+            avg_filled_notional_per_day,
+            avg_filled_notional_required_ratio,
             _hard_veto_count(scorecard),
             _daily_target_shortfall(
                 scorecard, target_net_pnl_per_day=target_net_pnl_per_day
             ),
+            observed_replay_penalty,
         )
         target = (
             _float(scorecard.get("net_pnl_per_day"))
@@ -437,6 +505,7 @@ def build_mlx_training_rows(
                 )
                 * 0.10
             )
+            - observed_replay_penalty
             - capital_budget_penalty(capital_features)
             - observed_capital_penalty(scorecard)
         )

--- a/services/torghut/scripts/local_intraday_tsmom_replay.py
+++ b/services/torghut/scripts/local_intraday_tsmom_replay.py
@@ -51,17 +51,17 @@ from app.trading.quote_quality import (
 )
 from app.trading.session_context import SessionContextTracker
 
-logging.getLogger('alembic').setLevel(logging.WARNING)
+logging.getLogger("alembic").setLevel(logging.WARNING)
 
-logging.getLogger('alembic').setLevel(logging.WARNING)
+logging.getLogger("alembic").setLevel(logging.WARNING)
 
 REGULAR_OPEN_UTC = time(hour=13, minute=30)
 REGULAR_CLOSE_UTC = time(hour=20, minute=0)
 DEFAULT_CHUNK_MINUTES = 10
-DEFAULT_START_EQUITY = Decimal('31590.02')
+DEFAULT_START_EQUITY = Decimal("31590.02")
 DEFAULT_PROGRESS_LOG_INTERVAL_SECONDS = 15
 logger = logging.getLogger(__name__)
-_SHARED_POSITION_OWNER = '__shared__'
+_SHARED_POSITION_OWNER = "__shared__"
 
 
 def _position_key(symbol: str, strategy_id: str) -> tuple[str, str]:
@@ -83,6 +83,7 @@ class ReplayConfig:
     progress_log_interval_seconds: int = DEFAULT_PROGRESS_LOG_INTERVAL_SECONDS
     capture_traces: bool = False
     capture_trace_funnel: bool = False
+    force_position_isolation: bool = False
     max_executable_spread_bps: Decimal = DEFAULT_MAX_EXECUTABLE_SPREAD_BPS
     max_quote_mid_jump_bps: Decimal = DEFAULT_MAX_QUOTE_MID_JUMP_BPS
     max_jump_with_wide_spread_bps: Decimal = DEFAULT_MAX_JUMP_WITH_WIDE_SPREAD_BPS
@@ -123,108 +124,113 @@ class ClosedTrade:
 
 def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description='Replay intraday TSMOM over a week of ClickHouse `ta_signals`.',
+        description="Replay intraday TSMOM over a week of ClickHouse `ta_signals`.",
     )
     parser.add_argument(
-        '--strategy-configmap',
-        default='argocd/applications/torghut/strategy-configmap.yaml',
+        "--strategy-configmap",
+        default="argocd/applications/torghut/strategy-configmap.yaml",
     )
     parser.add_argument(
-        '--clickhouse-http-url',
+        "--clickhouse-http-url",
         default=os.environ.get(
-            'TA_CLICKHOUSE_URL',
-            'http://torghut-clickhouse.torghut.svc.cluster.local:8123',
+            "TA_CLICKHOUSE_URL",
+            "http://torghut-clickhouse.torghut.svc.cluster.local:8123",
         ),
     )
     parser.add_argument(
-        '--clickhouse-username',
+        "--clickhouse-username",
         default=os.environ.get(
-            'TA_CLICKHOUSE_USERNAME',
-            os.environ.get('CLICKHOUSE_USERNAME', 'torghut'),
+            "TA_CLICKHOUSE_USERNAME",
+            os.environ.get("CLICKHOUSE_USERNAME", "torghut"),
         ),
     )
     parser.add_argument(
-        '--clickhouse-password',
+        "--clickhouse-password",
         default=os.environ.get(
-            'TA_CLICKHOUSE_PASSWORD',
-            os.environ.get('CLICKHOUSE_PASSWORD', ''),
+            "TA_CLICKHOUSE_PASSWORD",
+            os.environ.get("CLICKHOUSE_PASSWORD", ""),
         ),
     )
-    parser.add_argument('--start-date', default='2026-03-23')
-    parser.add_argument('--end-date', default='2026-03-27')
-    parser.add_argument('--chunk-minutes', type=int, default=DEFAULT_CHUNK_MINUTES)
-    parser.add_argument('--start-equity', default=str(DEFAULT_START_EQUITY))
+    parser.add_argument("--start-date", default="2026-03-23")
+    parser.add_argument("--end-date", default="2026-03-27")
+    parser.add_argument("--chunk-minutes", type=int, default=DEFAULT_CHUNK_MINUTES)
+    parser.add_argument("--start-equity", default=str(DEFAULT_START_EQUITY))
     parser.add_argument(
-        '--symbols',
-        default='',
-        help='Optional comma-separated symbol filter applied in the ClickHouse query.',
+        "--symbols",
+        default="",
+        help="Optional comma-separated symbol filter applied in the ClickHouse query.",
     )
     parser.add_argument(
-        '--progress-log-seconds',
+        "--progress-log-seconds",
         type=int,
         default=DEFAULT_PROGRESS_LOG_INTERVAL_SECONDS,
-        help='Emit replay heartbeat logs at most once per this many seconds.',
+        help="Emit replay heartbeat logs at most once per this many seconds.",
     )
     parser.add_argument(
-        '--max-executable-spread-bps',
+        "--max-executable-spread-bps",
         default=str(DEFAULT_MAX_EXECUTABLE_SPREAD_BPS),
-        help='Reject quotes wider than this when evaluating, filling, or flattening.',
+        help="Reject quotes wider than this when evaluating, filling, or flattening.",
     )
     parser.add_argument(
-        '--max-quote-mid-jump-bps',
+        "--max-quote-mid-jump-bps",
         default=str(DEFAULT_MAX_QUOTE_MID_JUMP_BPS),
-        help='Reject wide-spread quotes whose midpoint jumps beyond this many bps from the last sane price.',
+        help="Reject wide-spread quotes whose midpoint jumps beyond this many bps from the last sane price.",
     )
     parser.add_argument(
-        '--max-jump-with-wide-spread-bps',
+        "--max-jump-with-wide-spread-bps",
         default=str(DEFAULT_MAX_JUMP_WITH_WIDE_SPREAD_BPS),
-        help='Minimum spread width required before the jump filter blocks a quote.',
+        help="Minimum spread width required before the jump filter blocks a quote.",
     )
     parser.add_argument(
-        '--log-level',
-        default=os.environ.get('TORGHUT_REPLAY_LOG_LEVEL', 'INFO'),
-        help='Python logging level for replay progress logs.',
+        "--log-level",
+        default=os.environ.get("TORGHUT_REPLAY_LOG_LEVEL", "INFO"),
+        help="Python logging level for replay progress logs.",
     )
     parser.add_argument(
-        '--trace-output',
+        "--trace-output",
         type=Path,
-        help='Optional path to write replay trace JSONL.',
+        help="Optional path to write replay trace JSONL.",
     )
     parser.add_argument(
-        '--funnel-output',
+        "--funnel-output",
         type=Path,
-        help='Optional path to write replay funnel JSON.',
+        help="Optional path to write replay funnel JSON.",
     )
     parser.add_argument(
-        '--near-misses-output',
+        "--near-misses-output",
         type=Path,
-        help='Optional path to write replay near-miss JSON.',
+        help="Optional path to write replay near-miss JSON.",
     )
     parser.add_argument(
-        '--collect-traces',
-        action='store_true',
-        help='Capture per-strategy runtime traces and emit them in payload trace output.',
+        "--collect-traces",
+        action="store_true",
+        help="Capture per-strategy runtime traces and emit them in payload trace output.",
     )
     parser.add_argument(
-        '--collect-trace-funnel',
-        action='store_true',
-        help='Capture aggregate runtime gate funnel diagnostics without emitting per-row trace records.',
+        "--collect-trace-funnel",
+        action="store_true",
+        help="Capture aggregate runtime gate funnel diagnostics without emitting per-row trace records.",
     )
-    parser.add_argument('--no-flatten-eod', action='store_true')
-    parser.add_argument('--json', action='store_true')
+    parser.add_argument("--no-flatten-eod", action="store_true")
+    parser.add_argument(
+        "--force-position-isolation",
+        action="store_true",
+        help="Own replay positions by strategy id even when runtime metadata omits isolation.",
+    )
+    parser.add_argument("--json", action="store_true")
     return parser.parse_args()
 
 
 def _load_strategies(path: Path) -> list[Strategy]:
-    root_payload = yaml.safe_load(path.read_text(encoding='utf-8'))
+    root_payload = yaml.safe_load(path.read_text(encoding="utf-8"))
     if not isinstance(root_payload, dict):
-        raise RuntimeError('strategy_configmap_not_mapping')
-    data = root_payload.get('data')
+        raise RuntimeError("strategy_configmap_not_mapping")
+    data = root_payload.get("data")
     if not isinstance(data, dict):
-        raise RuntimeError('strategy_configmap_missing_data')
-    strategies_yaml = data.get('strategies.yaml')
+        raise RuntimeError("strategy_configmap_missing_data")
+    strategies_yaml = data.get("strategies.yaml")
     if not isinstance(strategies_yaml, str):
-        raise RuntimeError('strategy_configmap_missing_strategies_yaml')
+        raise RuntimeError("strategy_configmap_missing_strategies_yaml")
     catalog = StrategyCatalogConfig.model_validate(yaml.safe_load(strategies_yaml))
     strategies: list[Strategy] = []
     for item in catalog.strategies:
@@ -253,35 +259,35 @@ def _http_query(
     password: str | None,
     query: str,
 ) -> str:
-    body = query.encode('utf-8')
+    body = query.encode("utf-8")
     last_error: Exception | None = None
     for attempt in range(3):
-        req = request.Request(url=url.rstrip('/') + '/', data=body, method='POST')
+        req = request.Request(url=url.rstrip("/") + "/", data=body, method="POST")
         if username:
-            credentials = f'{username}:{password or ""}'.encode('utf-8')
-            req.add_header('Authorization', 'Basic ' + _b64(credentials))
+            credentials = f"{username}:{password or ''}".encode("utf-8")
+            req.add_header("Authorization", "Basic " + _b64(credentials))
         try:
             with request.urlopen(req, timeout=120) as resp:
-                return resp.read().decode('utf-8')
+                return resp.read().decode("utf-8")
         except error.HTTPError as exc:
-            payload = exc.read().decode('utf-8', errors='replace')
-            raise RuntimeError(f'clickhouse_http_error: {exc.code}: {payload}') from exc
+            payload = exc.read().decode("utf-8", errors="replace")
+            raise RuntimeError(f"clickhouse_http_error: {exc.code}: {payload}") from exc
         except http.client.IncompleteRead as exc:
             if exc.partial:
-                return exc.partial.decode('utf-8', errors='replace')
+                return exc.partial.decode("utf-8", errors="replace")
             last_error = exc
         except Exception as exc:  # pragma: no cover - retry path for flaky transport
             last_error = exc
         time_mod.sleep(0.5 * (attempt + 1))
     if last_error is None:
-        raise RuntimeError('clickhouse_http_query_failed')
-    raise RuntimeError(f'clickhouse_http_query_failed: {last_error}') from last_error
+        raise RuntimeError("clickhouse_http_query_failed")
+    raise RuntimeError(f"clickhouse_http_query_failed: {last_error}") from last_error
 
 
 def _b64(raw: bytes) -> str:
     import base64
 
-    return base64.b64encode(raw).decode('ascii')
+    return base64.b64encode(raw).decode("ascii")
 
 
 def _iter_signal_rows(config: ReplayConfig) -> Iterable[SignalEnvelope]:
@@ -289,13 +295,19 @@ def _iter_signal_rows(config: ReplayConfig) -> Iterable[SignalEnvelope]:
     current_day = config.start_date
     while current_day <= config.end_date:
         if current_day.weekday() >= 5:
-            logger.info('replay_day_skip day=%s reason=weekend', current_day.isoformat())
+            logger.info(
+                "replay_day_skip day=%s reason=weekend", current_day.isoformat()
+            )
             current_day += timedelta(days=1)
             continue
-        session_start = datetime.combine(current_day, REGULAR_OPEN_UTC, tzinfo=timezone.utc)
-        session_end = datetime.combine(current_day, REGULAR_CLOSE_UTC, tzinfo=timezone.utc)
+        session_start = datetime.combine(
+            current_day, REGULAR_OPEN_UTC, tzinfo=timezone.utc
+        )
+        session_end = datetime.combine(
+            current_day, REGULAR_CLOSE_UTC, tzinfo=timezone.utc
+        )
         logger.info(
-            'replay_day_fetch_start day=%s session_start=%s session_end=%s',
+            "replay_day_fetch_start day=%s session_start=%s session_end=%s",
             current_day.isoformat(),
             session_start.isoformat(),
             session_end.isoformat(),
@@ -305,7 +317,7 @@ def _iter_signal_rows(config: ReplayConfig) -> Iterable[SignalEnvelope]:
             chunk_end = min(chunk_start + chunk_delta, session_end)
             fetch_started_at = time_mod.monotonic()
             logger.debug(
-                'replay_chunk_fetch_start day=%s chunk_start=%s chunk_end=%s symbol_count=%s',
+                "replay_chunk_fetch_start day=%s chunk_start=%s chunk_end=%s symbol_count=%s",
                 current_day.isoformat(),
                 chunk_start.isoformat(),
                 chunk_end.isoformat(),
@@ -320,7 +332,7 @@ def _iter_signal_rows(config: ReplayConfig) -> Iterable[SignalEnvelope]:
                 symbols=config.symbols,
             )
             logger.debug(
-                'replay_chunk_fetch_done day=%s chunk_start=%s chunk_end=%s rows=%s elapsed_s=%.3f',
+                "replay_chunk_fetch_done day=%s chunk_start=%s chunk_end=%s rows=%s elapsed_s=%.3f",
                 current_day.isoformat(),
                 chunk_start.isoformat(),
                 chunk_end.isoformat(),
@@ -343,10 +355,10 @@ def _fetch_chunk(
     chunk_end: datetime,
     symbols: tuple[str, ...] = (),
 ) -> list[SignalEnvelope]:
-    symbol_filter = ''
+    symbol_filter = ""
     if symbols:
-        rendered_symbols = ', '.join(f"'{symbol}'" for symbol in symbols)
-        symbol_filter = f'\n  AND s.symbol IN ({rendered_symbols})'
+        rendered_symbols = ", ".join(f"'{symbol}'" for symbol in symbols)
+        symbol_filter = f"\n  AND s.symbol IN ({rendered_symbols})"
     query = f"""
 SELECT
   s.symbol,
@@ -376,8 +388,8 @@ ANY LEFT JOIN torghut.ta_microbars AS m
   AND s.window_size = m.window_size
 WHERE s.source = 'ta'
   AND s.window_size = 'PT1S'
-  AND s.event_ts >= toDateTime64('{chunk_start.strftime('%Y-%m-%d %H:%M:%S')}', 3, 'UTC')
-  AND s.event_ts < toDateTime64('{chunk_end.strftime('%Y-%m-%d %H:%M:%S')}', 3, 'UTC')
+  AND s.event_ts >= toDateTime64('{chunk_start.strftime("%Y-%m-%d %H:%M:%S")}', 3, 'UTC')
+  AND s.event_ts < toDateTime64('{chunk_end.strftime("%Y-%m-%d %H:%M:%S")}', 3, 'UTC')
   {symbol_filter}
   AND isNotNull(s.imbalance_bid_px)
   AND isNotNull(s.imbalance_ask_px)
@@ -389,7 +401,7 @@ FORMAT TSVRaw
         password=password,
         query=query,
     )
-    reader = csv.reader(raw.splitlines(), delimiter='\t')
+    reader = csv.reader(raw.splitlines(), delimiter="\t")
     rows: list[SignalEnvelope] = []
     for parts in reader:
         parsed = _parse_signal_row(parts)
@@ -430,50 +442,52 @@ def _parse_signal_row(parts: list[str]) -> SignalEnvelope | None:
     ask_sz_value = _to_decimal(ask_sz)
     imbalance_spread_value = _to_decimal(imbalance_spread)
     payload = {
-        'macd': _to_decimal(macd),
-        'macd_signal': _to_decimal(macd_signal),
-        'ema12': _to_decimal(ema12),
-        'ema26': _to_decimal(ema26),
-        'rsi14': _to_decimal(rsi14),
-        'rsi': _to_decimal(rsi14),
-        'price': price_value,
-        'vwap_session': _to_decimal(vwap_session),
-        'vwap_w5m': _to_decimal(vwap_w5m),
-        'vol_realized_w60s': _to_decimal(vol),
-        'microbar_volume': _to_decimal(microbar_volume),
-        'imbalance_bid_px': bid_px_value,
-        'imbalance_ask_px': ask_px_value,
-        'imbalance_bid_sz': bid_sz_value,
-        'imbalance_ask_sz': ask_sz_value,
-        'imbalance_spread': imbalance_spread_value,
-        'imbalance': {
-            'bid_px': bid_px_value,
-            'ask_px': ask_px_value,
-            'bid_sz': bid_sz_value,
-            'ask_sz': ask_sz_value,
-            'spread': imbalance_spread_value if imbalance_spread_value is not None else spread_value,
+        "macd": _to_decimal(macd),
+        "macd_signal": _to_decimal(macd_signal),
+        "ema12": _to_decimal(ema12),
+        "ema26": _to_decimal(ema26),
+        "rsi14": _to_decimal(rsi14),
+        "rsi": _to_decimal(rsi14),
+        "price": price_value,
+        "vwap_session": _to_decimal(vwap_session),
+        "vwap_w5m": _to_decimal(vwap_w5m),
+        "vol_realized_w60s": _to_decimal(vol),
+        "microbar_volume": _to_decimal(microbar_volume),
+        "imbalance_bid_px": bid_px_value,
+        "imbalance_ask_px": ask_px_value,
+        "imbalance_bid_sz": bid_sz_value,
+        "imbalance_ask_sz": ask_sz_value,
+        "imbalance_spread": imbalance_spread_value,
+        "imbalance": {
+            "bid_px": bid_px_value,
+            "ask_px": ask_px_value,
+            "bid_sz": bid_sz_value,
+            "ask_sz": ask_sz_value,
+            "spread": imbalance_spread_value
+            if imbalance_spread_value is not None
+            else spread_value,
         },
-        'spread': spread_value,
-        'spread_bps': (
-            (spread_value / price_value) * Decimal('10000')
+        "spread": spread_value,
+        "spread_bps": (
+            (spread_value / price_value) * Decimal("10000")
             if spread_value is not None and price_value is not None and price_value > 0
             else None
         ),
-        'window_size': 'PT1S',
-        'window_step': 'PT1S',
+        "window_size": "PT1S",
+        "window_step": "PT1S",
     }
     return SignalEnvelope(
         event_ts=_parse_clickhouse_ts(event_ts),
         symbol=symbol,
-        timeframe='1Sec',
+        timeframe="1Sec",
         seq=int(seq),
-        source='ta',
+        source="ta",
         payload=payload,
     )
 
 
 def _parse_clickhouse_ts(value: str) -> datetime:
-    normalized = value.replace(' ', 'T')
+    normalized = value.replace(" ", "T")
     parsed = datetime.fromisoformat(normalized)
     if parsed.tzinfo is None:
         return parsed.replace(tzinfo=timezone.utc)
@@ -482,7 +496,7 @@ def _parse_clickhouse_ts(value: str) -> datetime:
 
 def _to_decimal(value: str) -> Decimal | None:
     stripped = value.strip()
-    if not stripped or stripped == '\\N':
+    if not stripped or stripped == "\\N":
         return None
     return Decimal(stripped)
 
@@ -491,6 +505,8 @@ def _positions_payload(
     positions: dict[tuple[str, str], PositionState],
     last_prices: dict[str, Decimal],
     pending_orders: dict[tuple[str, str], PendingOrder] | None = None,
+    *,
+    force_position_isolation: bool = False,
 ) -> list[dict[str, Any]]:
     projected_positions: dict[tuple[str, str], PositionState] = {
         key: PositionState(
@@ -509,7 +525,10 @@ def _positions_payload(
     for pending in (pending_orders or {}).values():
         decision = pending.decision
         symbol = decision.symbol
-        owner_strategy_id = _decision_position_owner(decision)
+        owner_strategy_id = _decision_position_owner(
+            decision,
+            force_position_isolation=force_position_isolation,
+        )
         position_key = _position_key(symbol, owner_strategy_id)
         reference_price = (
             decision.limit_price
@@ -518,20 +537,22 @@ def _positions_payload(
         )
         projected_prices[symbol] = reference_price
         existing = projected_positions.get(position_key)
-        if decision.action == 'buy':
+        if decision.action == "buy":
             if existing is None:
                 projected_positions[position_key] = PositionState(
                     strategy_id=owner_strategy_id,
                     qty=decision.qty,
                     avg_entry_price=reference_price,
                     opened_at=pending.signal.event_ts,
-                    entry_cost_total=Decimal('0'),
+                    entry_cost_total=Decimal("0"),
                     decision_at=pending.created_at,
                     pending_entry=True,
                 )
                 continue
             if existing.qty < 0:
-                remaining_abs_qty = abs(existing.qty) - min(decision.qty, abs(existing.qty))
+                remaining_abs_qty = abs(existing.qty) - min(
+                    decision.qty, abs(existing.qty)
+                )
                 if remaining_abs_qty <= 0:
                     projected_positions.pop(position_key, None)
                     continue
@@ -556,9 +577,9 @@ def _positions_payload(
                 avg_entry_price=avg_entry,
                 opened_at=existing.opened_at,
                 entry_cost_total=existing.entry_cost_total,
-                    decision_at=existing.decision_at,
-                    pending_entry=existing.pending_entry,
-                )
+                decision_at=existing.decision_at,
+                pending_entry=existing.pending_entry,
+            )
             continue
         if existing is None:
             projected_positions[position_key] = PositionState(
@@ -566,7 +587,7 @@ def _positions_payload(
                 qty=-decision.qty,
                 avg_entry_price=reference_price,
                 opened_at=pending.signal.event_ts,
-                entry_cost_total=Decimal('0'),
+                entry_cost_total=Decimal("0"),
                 decision_at=pending.created_at,
                 pending_entry=True,
             )
@@ -607,15 +628,15 @@ def _positions_payload(
         signed_qty = position.qty
         payload.append(
             {
-                'symbol': symbol,
-                'strategy_id': position.strategy_id,
-                'qty': str(abs(signed_qty)),
-                'side': 'short' if signed_qty < 0 else 'long',
-                'market_value': str(signed_qty * market_price),
-                'avg_entry_price': str(position.avg_entry_price),
-                'opened_at': position.opened_at.isoformat(),
-                'decision_at': position.decision_at.isoformat(),
-                'pending_entry': position.pending_entry,
+                "symbol": symbol,
+                "strategy_id": position.strategy_id,
+                "qty": str(abs(signed_qty)),
+                "side": "short" if signed_qty < 0 else "long",
+                "market_value": str(signed_qty * market_price),
+                "avg_entry_price": str(position.avg_entry_price),
+                "opened_at": position.opened_at.isoformat(),
+                "decision_at": position.decision_at.isoformat(),
+                "pending_entry": position.pending_entry,
             }
         )
     return payload
@@ -638,8 +659,8 @@ def _position_exposure(
     positions: dict[tuple[str, str], PositionState],
     last_prices: dict[str, Decimal],
 ) -> tuple[Decimal, Decimal]:
-    gross_exposure = Decimal('0')
-    net_exposure = Decimal('0')
+    gross_exposure = Decimal("0")
+    net_exposure = Decimal("0")
     for (symbol, _owner_strategy_id), position in positions.items():
         market_value = position.qty * last_prices.get(symbol, position.avg_entry_price)
         gross_exposure += abs(market_value)
@@ -648,7 +669,7 @@ def _position_exposure(
 
 
 def _extract_spread(signal: SignalEnvelope) -> Decimal | None:
-    raw = signal.payload.get('spread')
+    raw = signal.payload.get("spread")
     if isinstance(raw, Decimal):
         return raw
     if raw is None:
@@ -657,7 +678,7 @@ def _extract_spread(signal: SignalEnvelope) -> Decimal | None:
 
 
 def _extract_bid(signal: SignalEnvelope) -> Decimal | None:
-    raw = signal.payload.get('imbalance_bid_px')
+    raw = signal.payload.get("imbalance_bid_px")
     if isinstance(raw, Decimal):
         return raw
     if raw is None:
@@ -666,7 +687,7 @@ def _extract_bid(signal: SignalEnvelope) -> Decimal | None:
 
 
 def _extract_ask(signal: SignalEnvelope) -> Decimal | None:
-    raw = signal.payload.get('imbalance_ask_px')
+    raw = signal.payload.get("imbalance_ask_px")
     if isinstance(raw, Decimal):
         return raw
     if raw is None:
@@ -675,14 +696,14 @@ def _extract_ask(signal: SignalEnvelope) -> Decimal | None:
 
 
 def _extract_price(signal: SignalEnvelope) -> Decimal:
-    raw = signal.payload.get('price')
+    raw = signal.payload.get("price")
     if isinstance(raw, Decimal):
         return raw
     return Decimal(str(raw))
 
 
 def _extract_volatility(signal: SignalEnvelope) -> Decimal | None:
-    raw = signal.payload.get('vol_realized_w60s')
+    raw = signal.payload.get("vol_realized_w60s")
     if raw is None:
         return None
     if isinstance(raw, Decimal):
@@ -690,20 +711,24 @@ def _extract_volatility(signal: SignalEnvelope) -> Decimal | None:
     return Decimal(str(raw))
 
 
-def _signal_spread_bps(*, signal: SignalEnvelope, price: Decimal | None = None) -> Decimal | None:
+def _signal_spread_bps(
+    *, signal: SignalEnvelope, price: Decimal | None = None
+) -> Decimal | None:
     resolved_price = _extract_price(signal) if price is None else price
     if resolved_price <= 0:
         return None
     spread = _extract_spread(signal)
     if spread is None:
         return None
-    return (abs(spread) / resolved_price) * Decimal('10000')
+    return (abs(spread) / resolved_price) * Decimal("10000")
 
 
-def _signal_mid_jump_bps(*, price: Decimal, reference_price: Decimal | None) -> Decimal | None:
+def _signal_mid_jump_bps(
+    *, price: Decimal, reference_price: Decimal | None
+) -> Decimal | None:
     if reference_price is None or reference_price <= 0:
         return None
-    return (abs(price - reference_price) / reference_price) * Decimal('10000')
+    return (abs(price - reference_price) / reference_price) * Decimal("10000")
 
 
 def _quote_quality_status(
@@ -731,12 +756,12 @@ def _log_quote_skipped(
     has_pending_order: bool,
 ) -> None:
     logger.debug(
-        'replay_quote_skipped ts=%s symbol=%s reason=%s spread_bps=%s jump_bps=%s open_position=%s pending_order=%s',
+        "replay_quote_skipped ts=%s symbol=%s reason=%s spread_bps=%s jump_bps=%s open_position=%s pending_order=%s",
         signal.event_ts.isoformat(),
         signal.symbol,
-        status.reason or 'unknown',
-        _decimal_text(status.spread_bps) if status.spread_bps is not None else 'None',
-        _decimal_text(status.jump_bps) if status.jump_bps is not None else 'None',
+        status.reason or "unknown",
+        _decimal_text(status.spread_bps) if status.spread_bps is not None else "None",
+        _decimal_text(status.jump_bps) if status.jump_bps is not None else "None",
         has_open_position,
         has_pending_order,
     )
@@ -770,8 +795,8 @@ def _estimate_trade_cost(
 
 
 def _record_decision(stats: dict[str, Any], decision: StrategyDecision) -> None:
-    stats['decision_count'] += 1
-    symbol_counts = stats.setdefault('decision_symbols', defaultdict(int))
+    stats["decision_count"] += 1
+    symbol_counts = stats.setdefault("decision_symbols", defaultdict(int))
     symbol_counts[decision.symbol] += 1
 
 
@@ -779,14 +804,14 @@ def _apply_order_preferences(
     decision: StrategyDecision,
     signal: SignalEnvelope,
 ) -> StrategyDecision:
-    position_exit = decision.params.get('position_exit')
+    position_exit = decision.params.get("position_exit")
     if isinstance(position_exit, dict):
-        exit_type = str(position_exit.get('type') or '').strip()
-        if exit_type == 'session_flatten_minute_utc':
+        exit_type = str(position_exit.get("type") or "").strip()
+        if exit_type == "session_flatten_minute_utc":
             return decision
     if not settings.trading_execution_prefer_limit:
         return decision
-    if decision.order_type != 'market':
+    if decision.order_type != "market":
         return decision
     price = _extract_price(signal)
     spread = _extract_spread(signal)
@@ -798,71 +823,71 @@ def _apply_order_preferences(
         return decision
     return decision.model_copy(
         update={
-            'order_type': 'limit',
-            'limit_price': _near_touch_limit_price(price, spread, decision.action),
+            "order_type": "limit",
+            "limit_price": _near_touch_limit_price(price, spread, decision.action),
         }
     )
 
 
 def _init_day_stats() -> dict[str, Any]:
     return {
-        'decision_count': 0,
-        'filled_count': 0,
-        'filled_notional': Decimal('0'),
-        'gross_pnl': Decimal('0'),
-        'net_pnl': Decimal('0'),
-        'cost_total': Decimal('0'),
-        'wins': 0,
-        'losses': 0,
-        'closed_trades': [],
-        'capital_snapshot_count': 0,
-        'min_cash': None,
-        'min_equity': None,
-        'max_gross_exposure': Decimal('0'),
-        'max_net_exposure_abs': Decimal('0'),
-        'max_gross_exposure_pct_equity': Decimal('0'),
-        'negative_cash_observation_count': 0,
+        "decision_count": 0,
+        "filled_count": 0,
+        "filled_notional": Decimal("0"),
+        "gross_pnl": Decimal("0"),
+        "net_pnl": Decimal("0"),
+        "cost_total": Decimal("0"),
+        "wins": 0,
+        "losses": 0,
+        "closed_trades": [],
+        "capital_snapshot_count": 0,
+        "min_cash": None,
+        "min_equity": None,
+        "max_gross_exposure": Decimal("0"),
+        "max_net_exposure_abs": Decimal("0"),
+        "max_gross_exposure_pct_equity": Decimal("0"),
+        "negative_cash_observation_count": 0,
     }
 
 
 def _init_funnel_stats() -> dict[str, Any]:
     return {
-        'retained_rows': 0,
-        'runtime_evaluable_rows': 0,
-        'quote_valid_rows': 0,
-        'strategy_evaluations': 0,
-        'gate_pass_counts': defaultdict(int),
-        'first_failed_gate_counts': defaultdict(int),
-        'failing_threshold_counts': defaultdict(int),
-        'passed_trace_count': 0,
-        'decision_count': 0,
-        'filled_count': 0,
-        'filled_notional': Decimal('0'),
-        'closed_trade_count': 0,
-        'gross_pnl': Decimal('0'),
-        'net_pnl': Decimal('0'),
-        'cost_total': Decimal('0'),
+        "retained_rows": 0,
+        "runtime_evaluable_rows": 0,
+        "quote_valid_rows": 0,
+        "strategy_evaluations": 0,
+        "gate_pass_counts": defaultdict(int),
+        "first_failed_gate_counts": defaultdict(int),
+        "failing_threshold_counts": defaultdict(int),
+        "passed_trace_count": 0,
+        "decision_count": 0,
+        "filled_count": 0,
+        "filled_notional": Decimal("0"),
+        "closed_trade_count": 0,
+        "gross_pnl": Decimal("0"),
+        "net_pnl": Decimal("0"),
+        "cost_total": Decimal("0"),
     }
 
 
 def _ensure_replay_stats_bucket(bucket: dict[str, Any]) -> dict[str, Any]:
-    bucket.setdefault('decision_count', 0)
-    bucket.setdefault('filled_count', 0)
-    bucket.setdefault('filled_notional', Decimal('0'))
-    bucket.setdefault('gross_pnl', Decimal('0'))
-    bucket.setdefault('net_pnl', Decimal('0'))
-    bucket.setdefault('cost_total', Decimal('0'))
-    bucket.setdefault('wins', 0)
-    bucket.setdefault('losses', 0)
-    bucket.setdefault('closed_trades', [])
-    bucket.setdefault('closed_trade_count', 0)
-    bucket.setdefault('capital_snapshot_count', 0)
-    bucket.setdefault('min_cash', None)
-    bucket.setdefault('min_equity', None)
-    bucket.setdefault('max_gross_exposure', Decimal('0'))
-    bucket.setdefault('max_net_exposure_abs', Decimal('0'))
-    bucket.setdefault('max_gross_exposure_pct_equity', Decimal('0'))
-    bucket.setdefault('negative_cash_observation_count', 0)
+    bucket.setdefault("decision_count", 0)
+    bucket.setdefault("filled_count", 0)
+    bucket.setdefault("filled_notional", Decimal("0"))
+    bucket.setdefault("gross_pnl", Decimal("0"))
+    bucket.setdefault("net_pnl", Decimal("0"))
+    bucket.setdefault("cost_total", Decimal("0"))
+    bucket.setdefault("wins", 0)
+    bucket.setdefault("losses", 0)
+    bucket.setdefault("closed_trades", [])
+    bucket.setdefault("closed_trade_count", 0)
+    bucket.setdefault("capital_snapshot_count", 0)
+    bucket.setdefault("min_cash", None)
+    bucket.setdefault("min_equity", None)
+    bucket.setdefault("max_gross_exposure", Decimal("0"))
+    bucket.setdefault("max_net_exposure_abs", Decimal("0"))
+    bucket.setdefault("max_gross_exposure_pct_equity", Decimal("0"))
+    bucket.setdefault("negative_cash_observation_count", 0)
     return bucket
 
 
@@ -882,24 +907,26 @@ def _record_capital_snapshot(
     gross_exposure_pct_equity = (
         gross_exposure / equity
         if equity > 0
-        else Decimal('999999999') if gross_exposure > 0 else Decimal('0')
+        else Decimal("999999999")
+        if gross_exposure > 0
+        else Decimal("0")
     )
-    min_cash = bucket.get('min_cash')
+    min_cash = bucket.get("min_cash")
     if not isinstance(min_cash, Decimal) or cash < min_cash:
-        bucket['min_cash'] = cash
-    min_equity = bucket.get('min_equity')
+        bucket["min_cash"] = cash
+    min_equity = bucket.get("min_equity")
     if not isinstance(min_equity, Decimal) or equity < min_equity:
-        bucket['min_equity'] = equity
-    if gross_exposure > bucket['max_gross_exposure']:
-        bucket['max_gross_exposure'] = gross_exposure
+        bucket["min_equity"] = equity
+    if gross_exposure > bucket["max_gross_exposure"]:
+        bucket["max_gross_exposure"] = gross_exposure
     net_exposure_abs = abs(net_exposure)
-    if net_exposure_abs > bucket['max_net_exposure_abs']:
-        bucket['max_net_exposure_abs'] = net_exposure_abs
-    if gross_exposure_pct_equity > bucket['max_gross_exposure_pct_equity']:
-        bucket['max_gross_exposure_pct_equity'] = gross_exposure_pct_equity
-    bucket['capital_snapshot_count'] += 1
+    if net_exposure_abs > bucket["max_net_exposure_abs"]:
+        bucket["max_net_exposure_abs"] = net_exposure_abs
+    if gross_exposure_pct_equity > bucket["max_gross_exposure_pct_equity"]:
+        bucket["max_gross_exposure_pct_equity"] = gross_exposure_pct_equity
+    bucket["capital_snapshot_count"] += 1
     if cash < 0:
-        bucket['negative_cash_observation_count'] += 1
+        bucket["negative_cash_observation_count"] += 1
     return equity
 
 
@@ -907,27 +934,29 @@ def _record_trace_for_funnel(
     stats: dict[str, Any],
     trace: StrategyTrace,
 ) -> None:
-    stats['strategy_evaluations'] += 1
+    stats["strategy_evaluations"] += 1
     if trace.passed:
-        stats['passed_trace_count'] += 1
+        stats["passed_trace_count"] += 1
     for gate in trace.gates:
         if not gate.passed:
             break
-        gate_key = f'{trace.strategy_type}:{gate.gate}'
-        stats['gate_pass_counts'][gate_key] += 1
+        gate_key = f"{trace.strategy_type}:{gate.gate}"
+        stats["gate_pass_counts"][gate_key] += 1
     if trace.first_failed_gate is None:
         return
-    failed_gate_key = f'{trace.strategy_type}:{trace.first_failed_gate}'
-    stats['first_failed_gate_counts'][failed_gate_key] += 1
+    failed_gate_key = f"{trace.strategy_type}:{trace.first_failed_gate}"
+    stats["first_failed_gate_counts"][failed_gate_key] += 1
     failed_gate = trace.failed_gate()
     if failed_gate is None:
         return
     for threshold in failed_gate.failing_thresholds():
-        threshold_key = f'{trace.strategy_type}:{failed_gate.gate}:{threshold.metric}'
-        stats['failing_threshold_counts'][threshold_key] += 1
+        threshold_key = f"{trace.strategy_type}:{failed_gate.gate}:{threshold.metric}"
+        stats["failing_threshold_counts"][threshold_key] += 1
 
 
-def _build_near_miss(trace: StrategyTrace, *, trading_day: str) -> NearMissRecord | None:
+def _build_near_miss(
+    trace: StrategyTrace, *, trading_day: str
+) -> NearMissRecord | None:
     if trace.passed or trace.first_failed_gate is None:
         return None
     failed_gate = trace.failed_gate()
@@ -969,26 +998,28 @@ def _insert_near_miss(
 
 
 def _decimal_text(value: Decimal) -> str:
-    return format(value, 'f')
+    return format(value, "f")
 
 
 def _log_decision_queued(decision: StrategyDecision, created_at: datetime) -> None:
     logger.info(
-        'replay_decision_queued ts=%s strategy_id=%s symbol=%s action=%s qty=%s order_type=%s limit_price=%s rationale=%s',
+        "replay_decision_queued ts=%s strategy_id=%s symbol=%s action=%s qty=%s order_type=%s limit_price=%s rationale=%s",
         created_at.isoformat(),
         decision.strategy_id,
         decision.symbol,
         decision.action,
         _decimal_text(decision.qty),
         decision.order_type,
-        _decimal_text(decision.limit_price) if decision.limit_price is not None else 'None',
-        decision.rationale or '',
+        _decimal_text(decision.limit_price)
+        if decision.limit_price is not None
+        else "None",
+        decision.rationale or "",
     )
 
 
 def _log_trade_closed(trade: ClosedTrade) -> None:
     logger.info(
-        'replay_trade_closed symbol=%s strategy_id=%s opened_at=%s closed_at=%s qty=%s entry=%s exit=%s gross_pnl=%s net_pnl=%s exit_reason=%s',
+        "replay_trade_closed symbol=%s strategy_id=%s opened_at=%s closed_at=%s qty=%s entry=%s exit=%s gross_pnl=%s net_pnl=%s exit_reason=%s",
         trade.symbol,
         trade.strategy_id,
         trade.opened_at.isoformat(),
@@ -1011,8 +1042,8 @@ def _resolve_pending_fill_price(
     ask = _extract_ask(signal)
     normalized_action = decision.action.strip().lower()
 
-    if decision.order_type == 'limit' and decision.limit_price is not None:
-        if normalized_action == 'buy':
+    if decision.order_type == "limit" and decision.limit_price is not None:
+        if normalized_action == "buy":
             executable_price = ask if ask is not None else price
             if executable_price > decision.limit_price:
                 return None
@@ -1022,28 +1053,36 @@ def _resolve_pending_fill_price(
             return None
         return executable_price
 
-    if normalized_action == 'buy':
+    if normalized_action == "buy":
         return ask if ask is not None else price
     return bid if bid is not None else price
 
 
 def _decision_exit_reason(decision: StrategyDecision) -> str:
-    position_exit = decision.params.get('position_exit')
+    position_exit = decision.params.get("position_exit")
     if isinstance(position_exit, dict):
-        exit_type = str(position_exit.get('type') or '').strip()
+        exit_type = str(position_exit.get("type") or "").strip()
         if exit_type:
             return exit_type
-    rationale = str(decision.rationale or '').strip()
+    rationale = str(decision.rationale or "").strip()
     if rationale:
-        return rationale.split(',')[0]
-    return 'signal_exit'
+        return rationale.split(",")[0]
+    return "signal_exit"
 
 
-def _decision_position_owner(decision: StrategyDecision) -> str:
-    runtime_payload = decision.params.get('strategy_runtime')
+def _decision_position_owner(
+    decision: StrategyDecision,
+    *,
+    force_position_isolation: bool = False,
+) -> str:
+    if force_position_isolation:
+        return decision.strategy_id
+    runtime_payload = decision.params.get("strategy_runtime")
     if isinstance(runtime_payload, dict):
-        isolation_mode = str(runtime_payload.get('position_isolation_mode') or '').strip().lower()
-        if isolation_mode == 'per_strategy':
+        isolation_mode = (
+            str(runtime_payload.get("position_isolation_mode") or "").strip().lower()
+        )
+        if isolation_mode == "per_strategy":
             return decision.strategy_id
     return _SHARED_POSITION_OWNER
 
@@ -1069,28 +1108,28 @@ def _resolve_passed_trace_block_reason(
     emitted_strategy_ids: set[str],
 ) -> str | None:
     if strategy_id not in raw_decision_strategy_ids:
-        return 'engine_runtime_filter_rejected'
+        return "engine_runtime_filter_rejected"
     if strategy_id in allocation_reject_reason_by_strategy_id:
         return allocation_reject_reason_by_strategy_id[strategy_id]
     if strategy_id in sizing_reject_reason_by_strategy_id:
         return sizing_reject_reason_by_strategy_id[strategy_id]
     if strategy_id not in emitted_strategy_ids:
-        return 'post_runtime_filter_rejected'
+        return "post_runtime_filter_rejected"
     return None
 
 
 def _pending_order_priority(decision: StrategyDecision) -> int:
-    if decision.action.strip().lower() != 'sell':
+    if decision.action.strip().lower() != "sell":
         return 0
-    position_exit = decision.params.get('position_exit')
-    exit_type = ''
+    position_exit = decision.params.get("position_exit")
+    exit_type = ""
     if isinstance(position_exit, dict):
-        exit_type = str(position_exit.get('type') or '').strip()
-    if exit_type == 'session_flatten_minute_utc':
+        exit_type = str(position_exit.get("type") or "").strip()
+    if exit_type == "session_flatten_minute_utc":
         return 5
-    if exit_type in {'long_stop_loss_bps', 'long_trailing_stop_bps'}:
+    if exit_type in {"long_stop_loss_bps", "long_trailing_stop_bps"}:
         return 4
-    if decision.order_type == 'market':
+    if decision.order_type == "market":
         return 3
     if exit_type:
         return 2
@@ -1113,9 +1152,9 @@ def _should_replace_pending_order(
         return False
 
     if existing.order_type != replacement.order_type:
-        return existing.order_type == 'limit' and replacement.order_type == 'market'
+        return existing.order_type == "limit" and replacement.order_type == "market"
 
-    if existing.order_type != 'limit':
+    if existing.order_type != "limit":
         return False
 
     existing_limit = existing.limit_price
@@ -1123,9 +1162,9 @@ def _should_replace_pending_order(
     if existing_limit is None or replacement_limit is None:
         return False
 
-    if replacement_action == 'sell':
+    if replacement_action == "sell":
         return replacement_limit < existing_limit
-    if replacement_action == 'buy':
+    if replacement_action == "buy":
         return replacement_limit > existing_limit
     return False
 
@@ -1135,16 +1174,20 @@ def _reconcile_pending_order_before_immediate_fill(
     decision: StrategyDecision,
     pending_orders: dict[tuple[str, str], PendingOrder],
     created_at: datetime,
+    force_position_isolation: bool = False,
 ) -> None:
     pending_key = _position_key(
         decision.symbol,
-        _decision_position_owner(decision),
+        _decision_position_owner(
+            decision,
+            force_position_isolation=force_position_isolation,
+        ),
     )
     existing_pending = pending_orders.pop(pending_key, None)
     if existing_pending is None:
         return
     logger.info(
-        'replay_pending_order_cleared_for_immediate_fill ts=%s symbol=%s existing_order_type=%s existing_limit=%s existing_exit=%s immediate_order_type=%s immediate_limit=%s immediate_exit=%s',
+        "replay_pending_order_cleared_for_immediate_fill ts=%s symbol=%s existing_order_type=%s existing_limit=%s existing_exit=%s immediate_order_type=%s immediate_limit=%s immediate_exit=%s",
         created_at.isoformat(),
         decision.symbol,
         existing_pending.decision.order_type,
@@ -1163,14 +1206,18 @@ def _log_pending_order_replaced(
     replacement: StrategyDecision,
 ) -> None:
     logger.info(
-        'replay_pending_order_replaced ts=%s symbol=%s existing_order_type=%s existing_limit=%s existing_exit=%s replacement_order_type=%s replacement_limit=%s replacement_exit=%s',
+        "replay_pending_order_replaced ts=%s symbol=%s existing_order_type=%s existing_limit=%s existing_exit=%s replacement_order_type=%s replacement_limit=%s replacement_exit=%s",
         created_at.isoformat(),
         replacement.symbol,
         existing.order_type,
-        _decimal_text(existing.limit_price) if existing.limit_price is not None else 'None',
+        _decimal_text(existing.limit_price)
+        if existing.limit_price is not None
+        else "None",
         _decision_exit_reason(existing),
         replacement.order_type,
-        _decimal_text(replacement.limit_price) if replacement.limit_price is not None else 'None',
+        _decimal_text(replacement.limit_price)
+        if replacement.limit_price is not None
+        else "None",
         _decision_exit_reason(replacement),
     )
 
@@ -1184,15 +1231,15 @@ def _log_day_summary(
     open_positions: int,
 ) -> None:
     logger.info(
-        'replay_day_complete day=%s decisions=%s fills=%s wins=%s losses=%s gross_pnl=%s net_pnl=%s cost_total=%s cash=%s equity=%s open_positions=%s',
+        "replay_day_complete day=%s decisions=%s fills=%s wins=%s losses=%s gross_pnl=%s net_pnl=%s cost_total=%s cash=%s equity=%s open_positions=%s",
         day.isoformat(),
-        stats['decision_count'],
-        stats['filled_count'],
-        stats['wins'],
-        stats['losses'],
-        _decimal_text(stats['gross_pnl']),
-        _decimal_text(stats['net_pnl']),
-        _decimal_text(stats['cost_total']),
+        stats["decision_count"],
+        stats["filled_count"],
+        stats["wins"],
+        stats["losses"],
+        _decimal_text(stats["gross_pnl"]),
+        _decimal_text(stats["net_pnl"]),
+        _decimal_text(stats["cost_total"]),
         _decimal_text(cash),
         _decimal_text(equity),
         open_positions,
@@ -1211,14 +1258,14 @@ def _log_progress(
     equity: Decimal,
 ) -> None:
     logger.info(
-        'replay_progress day=%s ts=%s signals=%s decisions=%s fills=%s wins=%s losses=%s pending_orders=%s open_positions=%s cash=%s equity=%s',
+        "replay_progress day=%s ts=%s signals=%s decisions=%s fills=%s wins=%s losses=%s pending_orders=%s open_positions=%s cash=%s equity=%s",
         signal_day.isoformat(),
         signal_ts.isoformat(),
         signals_seen,
-        day_bucket['decision_count'],
-        day_bucket['filled_count'],
-        day_bucket['wins'],
-        day_bucket['losses'],
+        day_bucket["decision_count"],
+        day_bucket["filled_count"],
+        day_bucket["wins"],
+        day_bucket["losses"],
         len(pending_orders),
         len(positions),
         _decimal_text(cash),
@@ -1283,31 +1330,37 @@ def _apply_filled_decision(
     cost_model: TransactionCostModel,
     cash: Decimal,
     all_closed_trades: list[ClosedTrade],
+    force_position_isolation: bool = False,
 ) -> Decimal:
     day_bucket = _ensure_replay_stats_bucket(day_bucket)
     if symbol_bucket is not None:
         symbol_bucket = _ensure_replay_stats_bucket(symbol_bucket)
 
     def _record_fill(fill_notional: Decimal, fill_cost: Decimal) -> None:
-        day_bucket['cost_total'] += fill_cost
-        day_bucket['filled_count'] += 1
-        day_bucket['filled_notional'] += fill_notional
+        day_bucket["cost_total"] += fill_cost
+        day_bucket["filled_count"] += 1
+        day_bucket["filled_notional"] += fill_notional
         if symbol_bucket is not None:
-            symbol_bucket['cost_total'] += fill_cost
-            symbol_bucket['filled_count'] += 1
-            symbol_bucket['filled_notional'] += fill_notional
+            symbol_bucket["cost_total"] += fill_cost
+            symbol_bucket["filled_count"] += 1
+            symbol_bucket["filled_notional"] += fill_notional
 
-    owner_strategy_id = _decision_position_owner(decision)
+    owner_strategy_id = _decision_position_owner(
+        decision,
+        force_position_isolation=force_position_isolation,
+    )
     position_key = _position_key(decision.symbol, owner_strategy_id)
     existing = positions.get(position_key)
     fill_cost = _estimate_trade_cost(model=cost_model, decision=decision, signal=signal)
-    if decision.action == 'buy':
+    if decision.action == "buy":
         if existing is not None and existing.qty < 0:
             cover_qty = min(decision.qty, abs(existing.qty))
             fill_notional = fill_price * cover_qty
             _record_fill(fill_notional, fill_cost)
             cash -= fill_notional + fill_cost
-            entry_cost_allocated = existing.entry_cost_total * (cover_qty / abs(existing.qty))
+            entry_cost_allocated = existing.entry_cost_total * (
+                cover_qty / abs(existing.qty)
+            )
             remaining, trade = _close_position(
                 symbol=decision.symbol,
                 position=existing,
@@ -1322,17 +1375,17 @@ def _apply_filled_decision(
                 positions.pop(position_key, None)
             else:
                 positions[position_key] = remaining
-            day_bucket['gross_pnl'] += trade.gross_pnl
-            day_bucket['net_pnl'] += trade.net_pnl
+            day_bucket["gross_pnl"] += trade.gross_pnl
+            day_bucket["net_pnl"] += trade.net_pnl
             if symbol_bucket is not None:
-                symbol_bucket['gross_pnl'] += trade.gross_pnl
-                symbol_bucket['net_pnl'] += trade.net_pnl
-                symbol_bucket['closed_trade_count'] += 1
+                symbol_bucket["gross_pnl"] += trade.gross_pnl
+                symbol_bucket["net_pnl"] += trade.net_pnl
+                symbol_bucket["closed_trade_count"] += 1
             if trade.net_pnl > 0:
-                day_bucket['wins'] += 1
+                day_bucket["wins"] += 1
             elif trade.net_pnl < 0:
-                day_bucket['losses'] += 1
-            day_bucket['closed_trades'].append(trade)
+                day_bucket["losses"] += 1
+            day_bucket["closed_trades"].append(trade)
             all_closed_trades.append(trade)
             _log_trade_closed(trade)
             return cash
@@ -1419,17 +1472,17 @@ def _apply_filled_decision(
         positions.pop(position_key, None)
     else:
         positions[position_key] = remaining
-    day_bucket['gross_pnl'] += trade.gross_pnl
-    day_bucket['net_pnl'] += trade.net_pnl
+    day_bucket["gross_pnl"] += trade.gross_pnl
+    day_bucket["net_pnl"] += trade.net_pnl
     if symbol_bucket is not None:
-        symbol_bucket['gross_pnl'] += trade.gross_pnl
-        symbol_bucket['net_pnl'] += trade.net_pnl
-        symbol_bucket['closed_trade_count'] += 1
+        symbol_bucket["gross_pnl"] += trade.gross_pnl
+        symbol_bucket["net_pnl"] += trade.net_pnl
+        symbol_bucket["closed_trade_count"] += 1
     if trade.net_pnl > 0:
-        day_bucket['wins'] += 1
+        day_bucket["wins"] += 1
     elif trade.net_pnl < 0:
-        day_bucket['losses'] += 1
-    day_bucket['closed_trades'].append(trade)
+        day_bucket["losses"] += 1
+    day_bucket["closed_trades"].append(trade)
     all_closed_trades.append(trade)
     _log_trade_closed(trade)
     return cash
@@ -1439,7 +1492,9 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
     strategies = _load_strategies(config.strategy_configmap_path)
     strategies_by_id = {str(strategy.id): strategy for strategy in strategies}
     capture_runtime_traces = config.capture_traces or config.capture_trace_funnel
-    engine = DecisionEngine(price_fetcher=None, runtime_trace_enabled=capture_runtime_traces)
+    engine = DecisionEngine(
+        price_fetcher=None, runtime_trace_enabled=capture_runtime_traces
+    )
     quote_quality = SignalQuoteQualityTracker(
         policy=QuoteQualityPolicy(
             max_executable_spread_bps=config.max_executable_spread_bps,
@@ -1467,27 +1522,29 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
     last_progress_at = replay_started_at
 
     logger.info(
-        'replay_start start_date=%s end_date=%s chunk_minutes=%s flatten_eod=%s start_equity=%s symbol_count=%s symbols=%s',
+        "replay_start start_date=%s end_date=%s chunk_minutes=%s flatten_eod=%s start_equity=%s symbol_count=%s symbols=%s",
         config.start_date.isoformat(),
         config.end_date.isoformat(),
         config.chunk_minutes,
         config.flatten_eod,
         _decimal_text(config.start_equity),
         len(config.symbols),
-        ','.join(config.symbols) if config.symbols else '*',
+        ",".join(config.symbols) if config.symbols else "*",
     )
 
     def _active_day_stats(target_day: date) -> dict[str, Any]:
         return day_stats.setdefault(target_day.isoformat(), _init_day_stats())
 
     def _active_symbol_funnel(target_day: date, symbol: str) -> dict[str, Any]:
-        return funnel_stats.setdefault((target_day.isoformat(), symbol), _init_funnel_stats())
+        return funnel_stats.setdefault(
+            (target_day.isoformat(), symbol), _init_funnel_stats()
+        )
 
     with (
-        patch.object(settings, 'trading_strategy_runtime_mode', 'scheduler_v3'),
-        patch.object(settings, 'trading_strategy_scheduler_enabled', True),
-        patch.object(settings, 'trading_allow_shorts', True),
-        patch.object(settings, 'trading_fractional_equities_enabled', True),
+        patch.object(settings, "trading_strategy_runtime_mode", "scheduler_v3"),
+        patch.object(settings, "trading_strategy_scheduler_enabled", True),
+        patch.object(settings, "trading_allow_shorts", True),
+        patch.object(settings, "trading_fractional_equities_enabled", True),
     ):
         for signal in _iter_signal_rows(config):
             signal = signal.model_copy(
@@ -1496,7 +1553,7 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
             signal_day = signal.event_ts.date()
             if current_day is None:
                 current_day = signal_day
-                logger.info('replay_day_start day=%s', current_day.isoformat())
+                logger.info("replay_day_start day=%s", current_day.isoformat())
                 _record_capital_snapshot(
                     bucket=_active_day_stats(current_day),
                     cash=cash,
@@ -1534,7 +1591,7 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
                     open_positions=len(positions),
                 )
                 current_day = signal_day
-                logger.info('replay_day_start day=%s', current_day.isoformat())
+                logger.info("replay_day_start day=%s", current_day.isoformat())
                 _record_capital_snapshot(
                     bucket=_active_day_stats(current_day),
                     cash=cash,
@@ -1545,12 +1602,16 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
             signals_seen += 1
             day_bucket = _active_day_stats(signal_day)
             symbol_bucket = _active_symbol_funnel(signal_day, signal.symbol)
-            symbol_bucket['retained_rows'] += 1
+            symbol_bucket["retained_rows"] += 1
             quote_status = quote_quality.assess(signal)
             if not quote_status.valid:
                 engine.observe_signal(signal)
-                has_open_position = any(symbol == signal.symbol for symbol, _ in positions)
-                has_pending_order = any(symbol == signal.symbol for symbol, _ in pending_orders)
+                has_open_position = any(
+                    symbol == signal.symbol for symbol, _ in positions
+                )
+                has_pending_order = any(
+                    symbol == signal.symbol for symbol, _ in pending_orders
+                )
                 if has_open_position or has_pending_order:
                     _log_quote_skipped(
                         signal=signal,
@@ -1561,7 +1622,7 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
                 continue
 
             price = _extract_price(signal)
-            symbol_bucket['quote_valid_rows'] += 1
+            symbol_bucket["quote_valid_rows"] += 1
             last_prices[signal.symbol] = price
             last_signals[signal.symbol] = signal
             equity = _record_capital_snapshot(
@@ -1597,6 +1658,7 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
                     cost_model=cost_model,
                     cash=cash,
                     all_closed_trades=all_closed_trades,
+                    force_position_isolation=config.force_position_isolation,
                 )
                 equity = _record_capital_snapshot(
                     bucket=day_bucket,
@@ -1615,6 +1677,7 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
                 positions,
                 last_prices,
                 pending_orders,
+                force_position_isolation=config.force_position_isolation,
             )
             raw_decisions = engine.evaluate(
                 signal,
@@ -1623,7 +1686,7 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
                 positions=live_positions,
             )
             telemetry = engine.consume_runtime_telemetry()
-            symbol_bucket['runtime_evaluable_rows'] += 1
+            symbol_bucket["runtime_evaluable_rows"] += 1
             telemetry_traces = telemetry.traces if capture_runtime_traces else ()
             for trace in telemetry_traces:
                 _record_trace_for_funnel(symbol_bucket, trace)
@@ -1632,9 +1695,11 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
                     _insert_near_miss(near_misses, near_miss)
             regime_label = _signal_regime_label(signal)
             allocator = allocator_from_settings(equity)
-            account = {'equity': str(equity)}
+            account = {"equity": str(equity)}
             executable_decisions: list[StrategyDecision] = []
-            raw_decision_strategy_ids = {decision.strategy_id for decision in raw_decisions}
+            raw_decision_strategy_ids = {
+                decision.strategy_id for decision in raw_decisions
+            }
             allocation_reject_reason_by_strategy_id: dict[str, str] = {}
             sizing_reject_reason_by_strategy_id: dict[str, str] = {}
             for allocation_result in allocator.allocate(
@@ -1649,7 +1714,7 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
                         decision.strategy_id,
                         _first_reject_reason(
                             reason_codes=allocation_result.reason_codes,
-                            default_reason='allocator_rejected',
+                            default_reason="allocator_rejected",
                         ),
                     )
                     continue
@@ -1667,13 +1732,15 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
                         decision.strategy_id,
                         _first_reject_reason(
                             reason_codes=sizing_result.reasons,
-                            default_reason='sizer_rejected',
+                            default_reason="sizer_rejected",
                         ),
                     )
                     continue
                 executable_decisions.append(sizing_result.decision)
 
-            emitted_strategy_ids = {decision.strategy_id for decision in executable_decisions}
+            emitted_strategy_ids = {
+                decision.strategy_id for decision in executable_decisions
+            }
             fill_status_by_strategy_id: dict[str, str] = {}
             block_reason_by_strategy_id: dict[str, str] = {}
             if config.capture_traces:
@@ -1687,15 +1754,21 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
                             emitted_strategy_ids=emitted_strategy_ids,
                         )
                         if block_reason is not None:
-                            block_reason_by_strategy_id[trace.strategy_id] = block_reason
+                            block_reason_by_strategy_id[trace.strategy_id] = (
+                                block_reason
+                            )
                     elif not trace.passed and trace.first_failed_gate is not None:
-                        block_reason_by_strategy_id[trace.strategy_id] = trace.first_failed_gate
+                        block_reason_by_strategy_id[trace.strategy_id] = (
+                            trace.first_failed_gate
+                        )
 
             for decision in executable_decisions:
                 decision = _apply_order_preferences(decision, signal)
                 _record_decision(day_bucket, decision)
-                decision_symbol_bucket = _active_symbol_funnel(signal_day, decision.symbol)
-                decision_symbol_bucket['decision_count'] += 1
+                decision_symbol_bucket = _active_symbol_funnel(
+                    signal_day, decision.symbol
+                )
+                decision_symbol_bucket["decision_count"] += 1
                 if decision.qty <= 0:
                     continue
                 immediate_fill_price = _resolve_pending_fill_price(decision, signal)
@@ -1704,6 +1777,7 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
                         decision=decision,
                         pending_orders=pending_orders,
                         created_at=signal.event_ts,
+                        force_position_isolation=config.force_position_isolation,
                     )
                     cash = _apply_filled_decision(
                         decision=decision,
@@ -1717,6 +1791,7 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
                         cost_model=cost_model,
                         cash=cash,
                         all_closed_trades=all_closed_trades,
+                        force_position_isolation=config.force_position_isolation,
                     )
                     equity = _record_capital_snapshot(
                         bucket=day_bucket,
@@ -1724,11 +1799,14 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
                         positions=positions,
                         last_prices=last_prices,
                     )
-                    fill_status_by_strategy_id[decision.strategy_id] = 'filled'
+                    fill_status_by_strategy_id[decision.strategy_id] = "filled"
                     continue
                 pending_key = _position_key(
                     decision.symbol,
-                    _decision_position_owner(decision),
+                    _decision_position_owner(
+                        decision,
+                        force_position_isolation=config.force_position_isolation,
+                    ),
                 )
                 existing_pending = pending_orders.get(pending_key)
                 if existing_pending is not None:
@@ -1747,7 +1825,7 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
                             replacement=decision,
                         )
                         _log_decision_queued(decision, signal.event_ts)
-                        fill_status_by_strategy_id[decision.strategy_id] = 'pending'
+                        fill_status_by_strategy_id[decision.strategy_id] = "pending"
                     continue
                 pending_orders[pending_key] = PendingOrder(
                     decision=decision,
@@ -1755,7 +1833,7 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
                     signal=signal,
                 )
                 _log_decision_queued(decision, signal.event_ts)
-                fill_status_by_strategy_id[decision.strategy_id] = 'pending'
+                fill_status_by_strategy_id[decision.strategy_id] = "pending"
 
             if config.capture_traces:
                 for trace in telemetry_traces:
@@ -1764,9 +1842,15 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
                             trading_day=signal_day.isoformat(),
                             strategy_trace=trace,
                             decision_emitted=trace.strategy_id in emitted_strategy_ids,
-                            fill_status=fill_status_by_strategy_id.get(trace.strategy_id, 'none'),
-                            decision_strategy_id=trace.strategy_id if trace.strategy_id in emitted_strategy_ids else None,
-                            block_reason=block_reason_by_strategy_id.get(trace.strategy_id),
+                            fill_status=fill_status_by_strategy_id.get(
+                                trace.strategy_id, "none"
+                            ),
+                            decision_strategy_id=trace.strategy_id
+                            if trace.strategy_id in emitted_strategy_ids
+                            else None,
+                            block_reason=block_reason_by_strategy_id.get(
+                                trace.strategy_id
+                            ),
                         )
                     )
 
@@ -1820,20 +1904,24 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
                 open_positions=len(positions),
             )
 
-    final_equity = _position_equity(cash=cash, positions=positions, last_prices=last_prices)
-    total_decisions = sum(item['decision_count'] for item in day_stats.values())
-    total_filled = sum(item['filled_count'] for item in day_stats.values())
-    total_filled_notional = sum((item['filled_notional'] for item in day_stats.values()), Decimal('0'))
-    total_gross = sum((item['gross_pnl'] for item in day_stats.values()), Decimal('0'))
+    final_equity = _position_equity(
+        cash=cash, positions=positions, last_prices=last_prices
+    )
+    total_decisions = sum(item["decision_count"] for item in day_stats.values())
+    total_filled = sum(item["filled_count"] for item in day_stats.values())
+    total_filled_notional = sum(
+        (item["filled_notional"] for item in day_stats.values()), Decimal("0")
+    )
+    total_gross = sum((item["gross_pnl"] for item in day_stats.values()), Decimal("0"))
     total_net = final_equity - config.start_equity
-    total_cost = sum((item['cost_total'] for item in day_stats.values()), Decimal('0'))
-    wins = sum(item['wins'] for item in day_stats.values())
-    losses = sum(item['losses'] for item in day_stats.values())
+    total_cost = sum((item["cost_total"] for item in day_stats.values()), Decimal("0"))
+    wins = sum(item["wins"] for item in day_stats.values())
+    losses = sum(item["losses"] for item in day_stats.values())
     min_cash = min(
         (
             value
             for item in day_stats.values()
-            for value in (item.get('min_cash'),)
+            for value in (item.get("min_cash"),)
             if isinstance(value, Decimal)
         ),
         default=cash,
@@ -1842,7 +1930,7 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
         (
             value
             for item in day_stats.values()
-            for value in (item.get('min_equity'),)
+            for value in (item.get("min_equity"),)
             if isinstance(value, Decimal)
         ),
         default=final_equity,
@@ -1851,32 +1939,34 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
         (
             value
             for item in day_stats.values()
-            for value in (item.get('max_gross_exposure'),)
+            for value in (item.get("max_gross_exposure"),)
             if isinstance(value, Decimal)
         ),
-        default=Decimal('0'),
+        default=Decimal("0"),
     )
     max_net_exposure_abs = max(
         (
             value
             for item in day_stats.values()
-            for value in (item.get('max_net_exposure_abs'),)
+            for value in (item.get("max_net_exposure_abs"),)
             if isinstance(value, Decimal)
         ),
-        default=Decimal('0'),
+        default=Decimal("0"),
     )
     max_gross_exposure_pct_equity = max(
         (
             value
             for item in day_stats.values()
-            for value in (item.get('max_gross_exposure_pct_equity'),)
+            for value in (item.get("max_gross_exposure_pct_equity"),)
             if isinstance(value, Decimal)
         ),
-        default=Decimal('0'),
+        default=Decimal("0"),
     )
-    capital_snapshot_count = sum(int(item.get('capital_snapshot_count') or 0) for item in day_stats.values())
+    capital_snapshot_count = sum(
+        int(item.get("capital_snapshot_count") or 0) for item in day_stats.values()
+    )
     negative_cash_observation_count = sum(
-        int(item.get('negative_cash_observation_count') or 0)
+        int(item.get("negative_cash_observation_count") or 0)
         for item in day_stats.values()
     )
     funnel_report = ReplayFunnelReport(
@@ -1886,21 +1976,21 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
             ReplayFunnelBucket(
                 trading_day=trading_day,
                 symbol=symbol,
-                retained_rows=int(bucket['retained_rows']),
-                runtime_evaluable_rows=int(bucket['runtime_evaluable_rows']),
-                quote_valid_rows=int(bucket['quote_valid_rows']),
-                strategy_evaluations=int(bucket['strategy_evaluations']),
-                gate_pass_counts=dict(bucket['gate_pass_counts']),
-                first_failed_gate_counts=dict(bucket['first_failed_gate_counts']),
-                failing_threshold_counts=dict(bucket['failing_threshold_counts']),
-                passed_trace_count=int(bucket['passed_trace_count']),
-                decision_count=int(bucket['decision_count']),
-                filled_count=int(bucket['filled_count']),
-                filled_notional=bucket['filled_notional'],
-                closed_trade_count=int(bucket['closed_trade_count']),
-                gross_pnl=bucket['gross_pnl'],
-                net_pnl=bucket['net_pnl'],
-                cost_total=bucket['cost_total'],
+                retained_rows=int(bucket["retained_rows"]),
+                runtime_evaluable_rows=int(bucket["runtime_evaluable_rows"]),
+                quote_valid_rows=int(bucket["quote_valid_rows"]),
+                strategy_evaluations=int(bucket["strategy_evaluations"]),
+                gate_pass_counts=dict(bucket["gate_pass_counts"]),
+                first_failed_gate_counts=dict(bucket["first_failed_gate_counts"]),
+                failing_threshold_counts=dict(bucket["failing_threshold_counts"]),
+                passed_trace_count=int(bucket["passed_trace_count"]),
+                decision_count=int(bucket["decision_count"]),
+                filled_count=int(bucket["filled_count"]),
+                filled_notional=bucket["filled_notional"],
+                closed_trade_count=int(bucket["closed_trade_count"]),
+                gross_pnl=bucket["gross_pnl"],
+                net_pnl=bucket["net_pnl"],
+                cost_total=bucket["cost_total"],
             )
             for (trading_day, symbol), bucket in sorted(funnel_stats.items())
         ),
@@ -1915,7 +2005,7 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
         key=lambda item: item.net_pnl,
     )
     logger.info(
-        'replay_complete elapsed_s=%.3f signals=%s decisions=%s fills=%s wins=%s losses=%s gross_pnl=%s net_pnl=%s total_cost=%s final_equity=%s',
+        "replay_complete elapsed_s=%.3f signals=%s decisions=%s fills=%s wins=%s losses=%s gross_pnl=%s net_pnl=%s total_cost=%s final_equity=%s",
         time_mod.monotonic() - replay_started_at,
         signals_seen,
         total_decisions,
@@ -1928,98 +2018,106 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
         _decimal_text(final_equity),
     )
     return {
-        'start_date': config.start_date.isoformat(),
-        'end_date': config.end_date.isoformat(),
-        'start_equity': str(config.start_equity),
-        'final_cash': str(cash),
-        'final_equity': str(final_equity),
-        'net_pnl': str(total_net),
-        'gross_pnl': str(total_gross),
-        'total_cost': str(total_cost),
-        'decision_count': total_decisions,
-        'filled_count': total_filled,
-        'filled_notional': str(total_filled_notional),
-        'wins': wins,
-        'losses': losses,
-        'capital_snapshot_count': capital_snapshot_count,
-        'min_cash': str(min_cash),
-        'min_equity': str(min_equity),
-        'max_gross_exposure': str(max_gross_exposure),
-        'max_net_exposure_abs': str(max_net_exposure_abs),
-        'max_gross_exposure_pct_equity': str(max_gross_exposure_pct_equity),
-        'negative_cash_observation_count': negative_cash_observation_count,
-        'open_positions': {
-            f'{symbol}|{owner_strategy_id}': {
-                'strategy_id': position.strategy_id,
-                'qty': str(position.qty),
-                'avg_entry_price': str(position.avg_entry_price),
-                'last_price': str(last_prices.get(symbol, position.avg_entry_price)),
+        "start_date": config.start_date.isoformat(),
+        "end_date": config.end_date.isoformat(),
+        "start_equity": str(config.start_equity),
+        "final_cash": str(cash),
+        "final_equity": str(final_equity),
+        "net_pnl": str(total_net),
+        "gross_pnl": str(total_gross),
+        "total_cost": str(total_cost),
+        "decision_count": total_decisions,
+        "filled_count": total_filled,
+        "filled_notional": str(total_filled_notional),
+        "wins": wins,
+        "losses": losses,
+        "capital_snapshot_count": capital_snapshot_count,
+        "min_cash": str(min_cash),
+        "min_equity": str(min_equity),
+        "max_gross_exposure": str(max_gross_exposure),
+        "max_net_exposure_abs": str(max_net_exposure_abs),
+        "max_gross_exposure_pct_equity": str(max_gross_exposure_pct_equity),
+        "negative_cash_observation_count": negative_cash_observation_count,
+        "open_positions": {
+            f"{symbol}|{owner_strategy_id}": {
+                "strategy_id": position.strategy_id,
+                "qty": str(position.qty),
+                "avg_entry_price": str(position.avg_entry_price),
+                "last_price": str(last_prices.get(symbol, position.avg_entry_price)),
             }
             for (symbol, owner_strategy_id), position in positions.items()
         },
-        'daily': {
+        "daily": {
             key: {
-                'decision_count': value['decision_count'],
-                'filled_count': value['filled_count'],
-                'filled_notional': str(value['filled_notional']),
-                'gross_pnl': str(value['gross_pnl']),
-                'net_pnl': str(value['net_pnl']),
-                'cost_total': str(value['cost_total']),
-                'wins': value['wins'],
-                'losses': value['losses'],
-                'capital_snapshot_count': int(value.get('capital_snapshot_count') or 0),
-                'min_cash': str(value['min_cash']) if isinstance(value.get('min_cash'), Decimal) else None,
-                'min_equity': str(value['min_equity']) if isinstance(value.get('min_equity'), Decimal) else None,
-                'max_gross_exposure': str(value.get('max_gross_exposure', Decimal('0'))),
-                'max_net_exposure_abs': str(value.get('max_net_exposure_abs', Decimal('0'))),
-                'max_gross_exposure_pct_equity': str(
-                    value.get('max_gross_exposure_pct_equity', Decimal('0'))
+                "decision_count": value["decision_count"],
+                "filled_count": value["filled_count"],
+                "filled_notional": str(value["filled_notional"]),
+                "gross_pnl": str(value["gross_pnl"]),
+                "net_pnl": str(value["net_pnl"]),
+                "cost_total": str(value["cost_total"]),
+                "wins": value["wins"],
+                "losses": value["losses"],
+                "capital_snapshot_count": int(value.get("capital_snapshot_count") or 0),
+                "min_cash": str(value["min_cash"])
+                if isinstance(value.get("min_cash"), Decimal)
+                else None,
+                "min_equity": str(value["min_equity"])
+                if isinstance(value.get("min_equity"), Decimal)
+                else None,
+                "max_gross_exposure": str(
+                    value.get("max_gross_exposure", Decimal("0"))
                 ),
-                'negative_cash_observation_count': int(
-                    value.get('negative_cash_observation_count') or 0
+                "max_net_exposure_abs": str(
+                    value.get("max_net_exposure_abs", Decimal("0"))
+                ),
+                "max_gross_exposure_pct_equity": str(
+                    value.get("max_gross_exposure_pct_equity", Decimal("0"))
+                ),
+                "negative_cash_observation_count": int(
+                    value.get("negative_cash_observation_count") or 0
                 ),
             }
             for key, value in sorted(day_stats.items())
         },
-        'largest_losses': [
+        "largest_losses": [
             {
-                'symbol': item.symbol,
-                'strategy_id': item.strategy_id,
-                'decision_at': item.decision_at.isoformat(),
-                'opened_at': item.opened_at.isoformat(),
-                'closed_at': item.closed_at.isoformat(),
-                'qty': str(item.qty),
-                'entry_price': str(item.entry_price),
-                'exit_price': str(item.exit_price),
-                'net_pnl': str(item.net_pnl),
-                'exit_reason': item.exit_reason,
+                "symbol": item.symbol,
+                "strategy_id": item.strategy_id,
+                "decision_at": item.decision_at.isoformat(),
+                "opened_at": item.opened_at.isoformat(),
+                "closed_at": item.closed_at.isoformat(),
+                "qty": str(item.qty),
+                "entry_price": str(item.entry_price),
+                "exit_price": str(item.exit_price),
+                "net_pnl": str(item.net_pnl),
+                "exit_reason": item.exit_reason,
             }
             for item in closed_trade_payload[:10]
         ],
-        'largest_wins': [
+        "largest_wins": [
             {
-                'symbol': item.symbol,
-                'strategy_id': item.strategy_id,
-                'decision_at': item.decision_at.isoformat(),
-                'opened_at': item.opened_at.isoformat(),
-                'closed_at': item.closed_at.isoformat(),
-                'qty': str(item.qty),
-                'entry_price': str(item.entry_price),
-                'exit_price': str(item.exit_price),
-                'net_pnl': str(item.net_pnl),
-                'exit_reason': item.exit_reason,
+                "symbol": item.symbol,
+                "strategy_id": item.strategy_id,
+                "decision_at": item.decision_at.isoformat(),
+                "opened_at": item.opened_at.isoformat(),
+                "closed_at": item.closed_at.isoformat(),
+                "qty": str(item.qty),
+                "entry_price": str(item.entry_price),
+                "exit_price": str(item.exit_price),
+                "net_pnl": str(item.net_pnl),
+                "exit_reason": item.exit_reason,
             }
             for item in list(reversed(closed_trade_payload[-10:]))
         ],
-        'trace': [item.to_payload() for item in trace_records],
-        'funnel': funnel_report.to_payload(),
-        'near_misses': near_miss_payload,
+        "trace": [item.to_payload() for item in trace_records],
+        "funnel": funnel_report.to_payload(),
+        "near_misses": near_miss_payload,
     }
 
 
 def _signal_regime_label(signal: SignalEnvelope) -> str | None:
     payload = signal.payload or {}
-    for key in ('route_regime_label', 'regime_label'):
+    for key in ("route_regime_label", "regime_label"):
         raw = payload.get(key)
         if raw is None:
             continue
@@ -2052,17 +2150,19 @@ def _flatten_positions(
         if last_signal is None:
             continue
         fill_price = last_prices.get(symbol, position.avg_entry_price)
-        exit_action = 'buy' if position.qty < 0 else 'sell'
+        exit_action = "buy" if position.qty < 0 else "sell"
         exit_qty = abs(position.qty)
         synthetic_decision = StrategyDecision(
-            strategy_id=owner_strategy_id if owner_strategy_id != _SHARED_POSITION_OWNER else 'flatten',
+            strategy_id=owner_strategy_id
+            if owner_strategy_id != _SHARED_POSITION_OWNER
+            else "flatten",
             symbol=symbol,
             event_ts=last_signal.event_ts,
-            timeframe='1Sec',
+            timeframe="1Sec",
             action=exit_action,
             qty=exit_qty,
-            order_type='market',
-            time_in_force='day',
+            order_type="market",
+            time_in_force="day",
             params={},
         )
         exit_cost = _estimate_trade_cost(
@@ -2098,25 +2198,27 @@ def _flatten_positions(
                 - position.entry_cost_total
                 - exit_cost
             ),
-            exit_reason='eod_flatten',
+            exit_reason="eod_flatten",
         )
-        stats['gross_pnl'] += trade.gross_pnl
-        stats['net_pnl'] += trade.net_pnl
-        stats['cost_total'] += exit_cost
-        stats['filled_count'] += 1
-        stats['filled_notional'] += exit_notional
-        symbol_bucket = funnel_stats.setdefault((day.isoformat(), symbol), _init_funnel_stats())
-        symbol_bucket['gross_pnl'] += trade.gross_pnl
-        symbol_bucket['net_pnl'] += trade.net_pnl
-        symbol_bucket['cost_total'] += exit_cost
-        symbol_bucket['filled_count'] += 1
-        symbol_bucket['filled_notional'] += exit_notional
-        symbol_bucket['closed_trade_count'] += 1
+        stats["gross_pnl"] += trade.gross_pnl
+        stats["net_pnl"] += trade.net_pnl
+        stats["cost_total"] += exit_cost
+        stats["filled_count"] += 1
+        stats["filled_notional"] += exit_notional
+        symbol_bucket = funnel_stats.setdefault(
+            (day.isoformat(), symbol), _init_funnel_stats()
+        )
+        symbol_bucket["gross_pnl"] += trade.gross_pnl
+        symbol_bucket["net_pnl"] += trade.net_pnl
+        symbol_bucket["cost_total"] += exit_cost
+        symbol_bucket["filled_count"] += 1
+        symbol_bucket["filled_notional"] += exit_notional
+        symbol_bucket["closed_trade_count"] += 1
         if trade.net_pnl > 0:
-            stats['wins'] += 1
+            stats["wins"] += 1
         elif trade.net_pnl < 0:
-            stats['losses'] += 1
-        stats['closed_trades'].append(trade)
+            stats["losses"] += 1
+        stats["closed_trades"].append(trade)
         all_closed_trades.append(trade)
         _log_trade_closed(trade)
     cash_ref[0] = current_cash
@@ -2126,9 +2228,9 @@ def main() -> None:
     args = _parse_args()
     logging.basicConfig(
         level=getattr(logging, str(args.log_level).upper(), logging.INFO),
-        format='%(asctime)s %(levelname)s %(message)s',
+        format="%(asctime)s %(levelname)s %(message)s",
     )
-    logging.getLogger('alembic').setLevel(logging.WARNING)
+    logging.getLogger("alembic").setLevel(logging.WARNING)
     config = ReplayConfig(
         strategy_configmap_path=Path(args.strategy_configmap).resolve(),
         clickhouse_http_url=str(args.clickhouse_http_url),
@@ -2141,7 +2243,7 @@ def main() -> None:
         start_equity=Decimal(str(args.start_equity)),
         symbols=tuple(
             symbol.strip().upper()
-            for symbol in str(args.symbols or '').split(',')
+            for symbol in str(args.symbols or "").split(",")
             if symbol.strip()
         ),
         progress_log_interval_seconds=max(1, int(args.progress_log_seconds)),
@@ -2152,6 +2254,7 @@ def main() -> None:
             or args.near_misses_output is not None
         ),
         capture_trace_funnel=bool(getattr(args, "collect_trace_funnel", False)),
+        force_position_isolation=bool(getattr(args, "force_position_isolation", False)),
         max_executable_spread_bps=Decimal(str(args.max_executable_spread_bps)),
         max_quote_mid_jump_bps=Decimal(str(args.max_quote_mid_jump_bps)),
         max_jump_with_wide_spread_bps=Decimal(str(args.max_jump_with_wide_spread_bps)),
@@ -2159,24 +2262,26 @@ def main() -> None:
     payload = run_replay(config)
     if args.trace_output:
         args.trace_output.write_text(
-            ''.join(json.dumps(item, sort_keys=True) + '\n' for item in payload['trace']),
-            encoding='utf-8',
+            "".join(
+                json.dumps(item, sort_keys=True) + "\n" for item in payload["trace"]
+            ),
+            encoding="utf-8",
         )
     if args.funnel_output:
         args.funnel_output.write_text(
-            json.dumps(payload['funnel'], indent=2, sort_keys=True),
-            encoding='utf-8',
+            json.dumps(payload["funnel"], indent=2, sort_keys=True),
+            encoding="utf-8",
         )
     if args.near_misses_output:
         args.near_misses_output.write_text(
-            json.dumps(payload['near_misses'], indent=2, sort_keys=True),
-            encoding='utf-8',
+            json.dumps(payload["near_misses"], indent=2, sort_keys=True),
+            encoding="utf-8",
         )
     if args.json:
-        print(json.dumps(payload, sort_keys=True, separators=(',', ':')))
+        print(json.dumps(payload, sort_keys=True, separators=(",", ":")))
         return
     print(json.dumps(payload, indent=2, sort_keys=True))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/services/torghut/scripts/run_strategy_factory_v2.py
+++ b/services/torghut/scripts/run_strategy_factory_v2.py
@@ -180,6 +180,14 @@ def _coerce_ratio_days(*, ratio: Decimal, total_days: int) -> int:
     return max(1, int(scaled))
 
 
+def _force_standalone_research_replay(experiment_payload: Mapping[str, Any]) -> bool:
+    promotion_contract = _mapping(experiment_payload.get("promotion_contract"))
+    return (
+        str(promotion_contract.get("source") or "").strip()
+        == "whitepaper_autoresearch_profit_target"
+    )
+
+
 def _singleton_grid(value: Any) -> list[Any]:
     return [json.loads(json.dumps(value))]
 
@@ -297,6 +305,7 @@ def _compile_sweep_config(
     parameters = _mapping(seed_config.get("parameters"))
     for key, value in param_overrides.items():
         parameters[str(key)] = _singleton_grid(value)
+    parameters.setdefault("position_isolation_mode", ["per_strategy"])
 
     family = str(
         seed_config.get("family") or runtime_harness.get("family") or ""
@@ -359,7 +368,9 @@ def _compile_sweep_config(
         "family": family,
         "family_template_id": family_template.family_id,
         "strategy_name": strategy_name,
-        "disable_other_strategies": bool(
+        "disable_other_strategies": True
+        if _force_standalone_research_replay(experiment_payload)
+        else bool(
             seed_config.get(
                 "disable_other_strategies",
                 runtime_harness.get("disable_other_strategies", True),

--- a/services/torghut/scripts/search_consistent_profitability_frontier.py
+++ b/services/torghut/scripts/search_consistent_profitability_frontier.py
@@ -57,7 +57,7 @@ from scripts.search_profitability_frontier import (
     resolve_sweep_window,
 )
 
-_LOCAL_ONLY_OVERRIDE_KEYS = frozenset({'normalization_regime'})
+_LOCAL_ONLY_OVERRIDE_KEYS = frozenset({"normalization_regime"})
 
 
 @dataclass(frozen=True)
@@ -74,31 +74,39 @@ class FullWindowConsistencyPolicy:
     min_avg_filled_notional_per_day: Decimal
     min_avg_filled_notional_per_active_day: Decimal
     require_every_day_active: bool
-    min_regime_slice_pass_rate: Decimal = Decimal('0')
-    max_symbol_concentration_share: Decimal = Decimal('1')
-    max_entry_family_contribution_share: Decimal = Decimal('1')
-    max_gross_exposure_pct_equity: Decimal = Decimal('999999999')
-    min_cash: Decimal = Decimal('-999999999')
+    min_regime_slice_pass_rate: Decimal = Decimal("0")
+    max_symbol_concentration_share: Decimal = Decimal("1")
+    max_entry_family_contribution_share: Decimal = Decimal("1")
+    max_gross_exposure_pct_equity: Decimal = Decimal("999999999")
+    min_cash: Decimal = Decimal("-999999999")
 
     def to_payload(self) -> dict[str, Any]:
         return {
-            'target_net_per_day': str(self.target_net_per_day),
-            'min_daily_net_pnl': str(self.min_daily_net_pnl),
-            'min_active_days': self.min_active_days,
-            'min_active_ratio': str(self.min_active_ratio),
-            'min_positive_days': self.min_positive_days,
-            'max_worst_day_loss': str(self.max_worst_day_loss),
-            'max_negative_days': self.max_negative_days,
-            'max_drawdown': str(self.max_drawdown),
-            'max_best_day_share_of_total_pnl': str(self.max_best_day_share_of_total_pnl),
-            'min_avg_filled_notional_per_day': str(self.min_avg_filled_notional_per_day),
-            'min_avg_filled_notional_per_active_day': str(self.min_avg_filled_notional_per_active_day),
-            'require_every_day_active': self.require_every_day_active,
-            'min_regime_slice_pass_rate': str(self.min_regime_slice_pass_rate),
-            'max_symbol_concentration_share': str(self.max_symbol_concentration_share),
-            'max_entry_family_contribution_share': str(self.max_entry_family_contribution_share),
-            'max_gross_exposure_pct_equity': str(self.max_gross_exposure_pct_equity),
-            'min_cash': str(self.min_cash),
+            "target_net_per_day": str(self.target_net_per_day),
+            "min_daily_net_pnl": str(self.min_daily_net_pnl),
+            "min_active_days": self.min_active_days,
+            "min_active_ratio": str(self.min_active_ratio),
+            "min_positive_days": self.min_positive_days,
+            "max_worst_day_loss": str(self.max_worst_day_loss),
+            "max_negative_days": self.max_negative_days,
+            "max_drawdown": str(self.max_drawdown),
+            "max_best_day_share_of_total_pnl": str(
+                self.max_best_day_share_of_total_pnl
+            ),
+            "min_avg_filled_notional_per_day": str(
+                self.min_avg_filled_notional_per_day
+            ),
+            "min_avg_filled_notional_per_active_day": str(
+                self.min_avg_filled_notional_per_active_day
+            ),
+            "require_every_day_active": self.require_every_day_active,
+            "min_regime_slice_pass_rate": str(self.min_regime_slice_pass_rate),
+            "max_symbol_concentration_share": str(self.max_symbol_concentration_share),
+            "max_entry_family_contribution_share": str(
+                self.max_entry_family_contribution_share
+            ),
+            "max_gross_exposure_pct_equity": str(self.max_gross_exposure_pct_equity),
+            "min_cash": str(self.min_cash),
         }
 
 
@@ -110,135 +118,135 @@ def _optional_int(value: Any, *, default: int) -> int:
 
 def _write_json_output(path: Path, payload: Mapping[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding='utf-8')
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
 
 
 def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description='Search replay configs using holdout profitability plus full-window consistency.',
+        description="Search replay configs using holdout profitability plus full-window consistency.",
     )
     parser.add_argument(
-        '--strategy-configmap',
+        "--strategy-configmap",
         type=Path,
-        default=Path('argocd/applications/torghut/strategy-configmap.yaml'),
+        default=Path("argocd/applications/torghut/strategy-configmap.yaml"),
     )
     parser.add_argument(
-        '--sweep-config',
+        "--sweep-config",
         type=Path,
-        default=Path('config/trading/profitability-frontier-consistent-tsmom.yaml'),
+        default=Path("config/trading/profitability-frontier-consistent-tsmom.yaml"),
     )
     parser.add_argument(
-        '--clickhouse-http-url',
+        "--clickhouse-http-url",
         default=os.environ.get(
-            'TA_CLICKHOUSE_URL',
-            'http://torghut-clickhouse.torghut.svc.cluster.local:8123',
+            "TA_CLICKHOUSE_URL",
+            "http://torghut-clickhouse.torghut.svc.cluster.local:8123",
         ),
     )
     parser.add_argument(
-        '--clickhouse-username',
+        "--clickhouse-username",
         default=os.environ.get(
-            'TA_CLICKHOUSE_USERNAME',
-            os.environ.get('CLICKHOUSE_USERNAME', 'torghut'),
+            "TA_CLICKHOUSE_USERNAME",
+            os.environ.get("CLICKHOUSE_USERNAME", "torghut"),
         ),
     )
     parser.add_argument(
-        '--clickhouse-password',
+        "--clickhouse-password",
         default=os.environ.get(
-            'TA_CLICKHOUSE_PASSWORD',
-            os.environ.get('CLICKHOUSE_PASSWORD', ''),
+            "TA_CLICKHOUSE_PASSWORD",
+            os.environ.get("CLICKHOUSE_PASSWORD", ""),
         ),
     )
     parser.add_argument(
-        '--clickhouse-password-env',
-        default='',
-        help='Environment variable that contains the ClickHouse password; ignored when --clickhouse-password is set.',
+        "--clickhouse-password-env",
+        default="",
+        help="Environment variable that contains the ClickHouse password; ignored when --clickhouse-password is set.",
     )
-    parser.add_argument('--start-equity', default='31590.02')
-    parser.add_argument('--chunk-minutes', type=int, default=10)
-    parser.add_argument('--symbols', default='')
-    parser.add_argument('--progress-log-seconds', type=int, default=30)
-    parser.add_argument('--train-days', type=int, default=6)
-    parser.add_argument('--holdout-days', type=int, default=3)
-    parser.add_argument('--full-window-start-date', default='')
-    parser.add_argument('--full-window-end-date', default='')
+    parser.add_argument("--start-equity", default="31590.02")
+    parser.add_argument("--chunk-minutes", type=int, default=10)
+    parser.add_argument("--symbols", default="")
+    parser.add_argument("--progress-log-seconds", type=int, default=30)
+    parser.add_argument("--train-days", type=int, default=6)
+    parser.add_argument("--holdout-days", type=int, default=3)
+    parser.add_argument("--full-window-start-date", default="")
+    parser.add_argument("--full-window-end-date", default="")
     parser.add_argument(
-        '--expected-last-trading-day',
-        default='',
-        help='Optional ISO date freshness witness. If omitted, recent sweeps expect the latest completed trading day.',
-    )
-    parser.add_argument(
-        '--allow-stale-tape',
-        action='store_true',
-        help='Persist and continue even when the latest expected trading day is missing from PT1S tape.',
+        "--expected-last-trading-day",
+        default="",
+        help="Optional ISO date freshness witness. If omitted, recent sweeps expect the latest completed trading day.",
     )
     parser.add_argument(
-        '--family-template-dir',
+        "--allow-stale-tape",
+        action="store_true",
+        help="Persist and continue even when the latest expected trading day is missing from PT1S tape.",
+    )
+    parser.add_argument(
+        "--family-template-dir",
         type=Path,
         default=family_template_dir(),
     )
     parser.add_argument(
-        '--prefetch-full-window-rows',
-        action='store_true',
-        help='Fetch full-window replay rows once and reuse them for every candidate replay.',
+        "--prefetch-full-window-rows",
+        action="store_true",
+        help="Fetch full-window replay rows once and reuse them for every candidate replay.",
     )
-    parser.add_argument('--top-n', type=int, default=10)
+    parser.add_argument("--top-n", type=int, default=10)
     parser.add_argument(
-        '--max-candidates-to-evaluate',
+        "--max-candidates-to-evaluate",
         type=int,
         default=0,
-        help='Optional cap on evaluated candidates inside one frontier run. 0 means unbounded.',
+        help="Optional cap on evaluated candidates inside one frontier run. 0 means unbounded.",
     )
-    parser.add_argument('--json-output', type=Path)
+    parser.add_argument("--json-output", type=Path)
     parser.add_argument(
-        '--symbol-prune-iterations',
+        "--symbol-prune-iterations",
         type=int,
         default=0,
-        help='Greedily generate child candidates by removing downside-contributing symbols from replay attribution.',
+        help="Greedily generate child candidates by removing downside-contributing symbols from replay attribution.",
     )
     parser.add_argument(
-        '--symbol-prune-candidates',
+        "--symbol-prune-candidates",
         type=int,
         default=1,
-        help='How many worst-contributing symbols to branch on per pruning step.',
+        help="How many worst-contributing symbols to branch on per pruning step.",
     )
     parser.add_argument(
-        '--symbol-prune-min-universe-size',
+        "--symbol-prune-min-universe-size",
         type=int,
         default=2,
-        help='Do not prune below this many symbols in the candidate universe.',
+        help="Do not prune below this many symbols in the candidate universe.",
     )
     parser.add_argument(
-        '--train-screening',
-        dest='train_screening',
-        action='store_true',
-        help='Skip holdout/full-window replay for candidates that fail the cheap train screen.',
+        "--train-screening",
+        dest="train_screening",
+        action="store_true",
+        help="Skip holdout/full-window replay for candidates that fail the cheap train screen.",
     )
     parser.add_argument(
-        '--no-train-screening',
-        dest='train_screening',
-        action='store_false',
-        help='Disable cheap train-screen early rejection and always run all replay windows.',
+        "--no-train-screening",
+        dest="train_screening",
+        action="store_false",
+        help="Disable cheap train-screen early rejection and always run all replay windows.",
     )
     parser.set_defaults(train_screening=True)
     parser.add_argument(
-        '--min-train-screen-net-per-day',
-        default='0',
-        help='Minimum train net PnL/day required before holdout/full-window replay.',
+        "--min-train-screen-net-per-day",
+        default="0",
+        help="Minimum train net PnL/day required before holdout/full-window replay.",
     )
     parser.add_argument(
-        '--min-train-screen-active-ratio',
-        default='0.50',
-        help='Minimum active train-day ratio required before holdout/full-window replay.',
+        "--min-train-screen-active-ratio",
+        default="0.50",
+        help="Minimum active train-day ratio required before holdout/full-window replay.",
     )
     parser.add_argument(
-        '--max-train-screen-worst-day-loss',
-        default='',
-        help='Optional max train worst-day loss before holdout/full-window replay. Defaults to the consistency max worst-day loss.',
+        "--max-train-screen-worst-day-loss",
+        default="",
+        help="Optional max train worst-day loss before holdout/full-window replay. Defaults to the consistency max worst-day loss.",
     )
     parser.add_argument(
-        '--collect-train-gate-diagnostics',
-        action='store_true',
-        help='Capture aggregate train-window gate failure diagnostics in frontier candidates.',
+        "--collect-train-gate-diagnostics",
+        action="store_true",
+        help="Capture aggregate train-window gate failure diagnostics in frontier candidates.",
     )
     return parser.parse_args()
 
@@ -246,14 +254,14 @@ def _parse_args() -> argparse.Namespace:
 def _rolling_lower_bound(daily_net: Mapping[str, Decimal], *, window: int) -> Decimal:
     ordered = [daily_net[key] for key in sorted(daily_net)]
     if not ordered:
-        return Decimal('0')
+        return Decimal("0")
     if len(ordered) < window:
-        return sum(ordered, Decimal('0')) / Decimal(len(ordered))
+        return sum(ordered, Decimal("0")) / Decimal(len(ordered))
     values: list[Decimal] = []
     for index in range(len(ordered) - window + 1):
         sample = ordered[index : index + window]
-        values.append(sum(sample, Decimal('0')) / Decimal(window))
-    return min(values) if values else Decimal('0')
+        values.append(sum(sample, Decimal("0")) / Decimal(window))
+    return min(values) if values else Decimal("0")
 
 
 def _objective_veto_policy(
@@ -263,39 +271,60 @@ def _objective_veto_policy(
     trading_day_count: int,
 ) -> ObjectiveVetoPolicy:
     required_min_active_day_ratio = consistency_policy.min_active_ratio
-    if required_min_active_day_ratio <= 0 and trading_day_count > 0 and consistency_policy.min_active_days > 0:
-        required_min_active_day_ratio = Decimal(consistency_policy.min_active_days) / Decimal(trading_day_count)
+    if (
+        required_min_active_day_ratio <= 0
+        and trading_day_count > 0
+        and consistency_policy.min_active_days > 0
+    ):
+        required_min_active_day_ratio = Decimal(
+            consistency_policy.min_active_days
+        ) / Decimal(trading_day_count)
     return ObjectiveVetoPolicy(
         required_min_active_day_ratio=max(
             required_min_active_day_ratio,
-            Decimal(str(template_defaults.get('required_min_active_day_ratio', '0'))),
+            Decimal(str(template_defaults.get("required_min_active_day_ratio", "0"))),
         ),
         required_min_daily_notional=max(
             consistency_policy.min_avg_filled_notional_per_day,
-            Decimal(str(template_defaults.get('required_min_daily_notional', '0'))),
+            Decimal(str(template_defaults.get("required_min_daily_notional", "0"))),
         ),
         required_max_best_day_share=min(
             consistency_policy.max_best_day_share_of_total_pnl,
-            Decimal(str(template_defaults.get('required_max_best_day_share', '1'))),
+            Decimal(str(template_defaults.get("required_max_best_day_share", "1"))),
         ),
         required_max_worst_day_loss=min(
             consistency_policy.max_worst_day_loss,
-            Decimal(str(template_defaults.get('required_max_worst_day_loss', str(consistency_policy.max_worst_day_loss)))),
+            Decimal(
+                str(
+                    template_defaults.get(
+                        "required_max_worst_day_loss",
+                        str(consistency_policy.max_worst_day_loss),
+                    )
+                )
+            ),
         ),
         required_max_drawdown=min(
             consistency_policy.max_drawdown,
-            Decimal(str(template_defaults.get('required_max_drawdown', str(consistency_policy.max_drawdown)))),
+            Decimal(
+                str(
+                    template_defaults.get(
+                        "required_max_drawdown", str(consistency_policy.max_drawdown)
+                    )
+                )
+            ),
         ),
         required_min_regime_slice_pass_rate=max(
             consistency_policy.min_regime_slice_pass_rate,
-            Decimal(str(template_defaults.get('required_min_regime_slice_pass_rate', '0'))),
+            Decimal(
+                str(template_defaults.get("required_min_regime_slice_pass_rate", "0"))
+            ),
         ),
         required_max_gross_exposure_pct_equity=min(
             consistency_policy.max_gross_exposure_pct_equity,
             Decimal(
                 str(
                     template_defaults.get(
-                        'required_max_gross_exposure_pct_equity',
+                        "required_max_gross_exposure_pct_equity",
                         str(consistency_policy.max_gross_exposure_pct_equity),
                     )
                 )
@@ -303,7 +332,13 @@ def _objective_veto_policy(
         ),
         required_min_cash=max(
             consistency_policy.min_cash,
-            Decimal(str(template_defaults.get('required_min_cash', str(consistency_policy.min_cash)))),
+            Decimal(
+                str(
+                    template_defaults.get(
+                        "required_min_cash", str(consistency_policy.min_cash)
+                    )
+                )
+            ),
         ),
     )
 
@@ -322,39 +357,58 @@ def _parameter_grid_items(
     items: list[tuple[str, list[Any]]] = []
     for key, values in parameter_grid.items():
         if isinstance(values, (str, bytes)):
-            raise ValueError(f'parameter_values_not_sequence:{key}')
+            raise ValueError(f"parameter_values_not_sequence:{key}")
         if isinstance(values, Mapping):
-            raise ValueError(f'parameter_values_not_sequence:{key}')
+            raise ValueError(f"parameter_values_not_sequence:{key}")
         if not isinstance(values, Iterable):
-            raise ValueError(f'parameter_values_not_iterable:{key}')
+            raise ValueError(f"parameter_values_not_iterable:{key}")
         items.append((str(key), list(values)))
     return items
 
 
 def _parameter_exploration_priority(name: str) -> int:
     lowered = name.lower()
-    if any(token in lowered for token in ('imbalance', 'microprice', 'recent_above', 'spread', 'quote')):
+    if any(
+        token in lowered
+        for token in ("imbalance", "microprice", "recent_above", "spread", "quote")
+    ):
         return 0
     if any(
         token in lowered
         for token in (
-            'cross_section',
-            'session_open',
-            'opening_window',
-            'range_position',
-            'price_vs_vwap',
-            'price_vs_opening',
-            'price_above_ema',
-            'entry_start',
-            'entry_end',
+            "cross_section",
+            "session_open",
+            "opening_window",
+            "range_position",
+            "price_vs_vwap",
+            "price_vs_opening",
+            "price_above_ema",
+            "entry_start",
+            "entry_end",
         )
     ):
         return 1
-    if any(token in lowered for token in ('bullish_hist', 'bull_rsi', 'vol_floor', 'vol_ceil')):
+    if any(
+        token in lowered
+        for token in ("bullish_hist", "bull_rsi", "vol_floor", "vol_ceil")
+    ):
         return 2
-    if any(token in lowered for token in ('universe_symbols', 'max_notional', 'position_pct')):
+    if any(
+        token in lowered
+        for token in ("universe_symbols", "max_notional", "position_pct")
+    ):
         return 3
-    if any(token in lowered for token in ('stop', 'trailing', 'flatten', 'cooldown', 'max_entries', 'max_concurrent')):
+    if any(
+        token in lowered
+        for token in (
+            "stop",
+            "trailing",
+            "flatten",
+            "cooldown",
+            "max_entries",
+            "max_concurrent",
+        )
+    ):
         return 4
     return 5
 
@@ -399,7 +453,9 @@ def _iter_parameter_candidates(
     names = [name for name, _ in items]
     value_sets = [values for _, values in items]
     for combination in itertools.product(*value_sets):
-        candidate = {name: value for name, value in zip(names, combination, strict=True)}
+        candidate = {
+            name: value for name, value in zip(names, combination, strict=True)
+        }
         emitted = emit(candidate)
         if emitted is not None:
             yield emitted
@@ -422,13 +478,11 @@ def _candidate_symbols(
 ) -> tuple[str, ...]:
     if cli_symbols:
         return cli_symbols
-    override_symbols = strategy_overrides.get('universe_symbols')
+    override_symbols = strategy_overrides.get("universe_symbols")
     if not isinstance(override_symbols, (list, tuple)):
         return ()
     values = tuple(
-        str(item).strip().upper()
-        for item in override_symbols
-        if str(item).strip()
+        str(item).strip().upper() for item in override_symbols if str(item).strip()
     )
     return values
 
@@ -438,30 +492,28 @@ def _strategy_universe_symbols(
     configmap_payload: Mapping[str, Any],
     strategy_name: str,
 ) -> tuple[str, ...]:
-    data = configmap_payload.get('data')
+    data = configmap_payload.get("data")
     if not isinstance(data, Mapping):
         return ()
-    strategies_yaml = data.get('strategies.yaml')
+    strategies_yaml = data.get("strategies.yaml")
     if not isinstance(strategies_yaml, str):
         return ()
     catalog = yaml.safe_load(strategies_yaml)
     if not isinstance(catalog, Mapping):
         return ()
-    strategies = catalog.get('strategies')
+    strategies = catalog.get("strategies")
     if not isinstance(strategies, list):
         return ()
     for item in strategies:
         if not isinstance(item, Mapping):
             continue
-        if str(item.get('name') or '').strip() != strategy_name:
+        if str(item.get("name") or "").strip() != strategy_name:
             continue
-        raw_symbols = item.get('universe_symbols')
+        raw_symbols = item.get("universe_symbols")
         if not isinstance(raw_symbols, (list, tuple)):
             return ()
         return tuple(
-            str(symbol).strip().upper()
-            for symbol in raw_symbols
-            if str(symbol).strip()
+            str(symbol).strip().upper() for symbol in raw_symbols if str(symbol).strip()
         )
     return ()
 
@@ -494,7 +546,10 @@ def _candidate_search_key(
 ) -> str:
     def _normalize(value: Any) -> Any:
         if isinstance(value, Mapping):
-            return {str(key): _normalize(val) for key, val in sorted(value.items(), key=lambda item: str(item[0]))}
+            return {
+                str(key): _normalize(val)
+                for key, val in sorted(value.items(), key=lambda item: str(item[0]))
+            }
         if isinstance(value, tuple):
             return [_normalize(item) for item in value]
         if isinstance(value, list):
@@ -503,8 +558,8 @@ def _candidate_search_key(
 
     return json.dumps(
         {
-            'params': _normalize(params_candidate),
-            'strategy_overrides': _normalize(
+            "params": _normalize(params_candidate),
+            "strategy_overrides": _normalize(
                 {
                     str(key): value
                     for key, value in strategy_overrides.items()
@@ -513,7 +568,7 @@ def _candidate_search_key(
             ),
         },
         sort_keys=True,
-        separators=(',', ':'),
+        separators=(",", ":"),
     )
 
 
@@ -577,12 +632,17 @@ def _cached_iter_signal_rows_factory(
     rows: list[Any],
 ) -> Callable[[replay_mod.ReplayConfig], Iterator[Any]]:
     def _iter_signal_rows(config: replay_mod.ReplayConfig) -> Iterator[Any]:
-        selected_symbols = {symbol.upper() for symbol in config.symbols} if config.symbols else None
+        selected_symbols = (
+            {symbol.upper() for symbol in config.symbols} if config.symbols else None
+        )
         for row in rows:
             signal_day = row.event_ts.date()
             if signal_day < config.start_date or signal_day > config.end_date:
                 continue
-            if selected_symbols is not None and row.symbol.upper() not in selected_symbols:
+            if (
+                selected_symbols is not None
+                and row.symbol.upper() not in selected_symbols
+            ):
                 continue
             yield row
 
@@ -593,7 +653,7 @@ def _cached_iter_signal_rows_factory(
 def _cached_signal_rows_patch(rows: list[Any]) -> Iterator[None]:
     with patch.object(
         replay_mod,
-        '_iter_signal_rows',
+        "_iter_signal_rows",
         _cached_iter_signal_rows_factory(rows),
     ):
         yield
@@ -607,6 +667,9 @@ def apply_candidate_to_configmap_with_overrides(
     strategy_overrides: Mapping[str, Any],
     disable_other_strategies: bool,
 ) -> dict[str, Any]:
+    candidate_params = dict(candidate_params)
+    if disable_other_strategies:
+        candidate_params.setdefault("position_isolation_mode", "per_strategy")
     root = apply_candidate_to_configmap(
         configmap_payload=configmap_payload,
         strategy_name=strategy_name,
@@ -616,38 +679,38 @@ def apply_candidate_to_configmap_with_overrides(
     if not strategy_overrides:
         return root
 
-    data = root.get('data')
+    data = root.get("data")
     if not isinstance(data, dict):
-        raise ValueError('strategy_configmap_missing_data')
-    strategies_yaml = data.get('strategies.yaml')
+        raise ValueError("strategy_configmap_missing_data")
+    strategies_yaml = data.get("strategies.yaml")
     if not isinstance(strategies_yaml, str):
-        raise ValueError('strategy_configmap_missing_strategies_yaml')
+        raise ValueError("strategy_configmap_missing_strategies_yaml")
     catalog = yaml.safe_load(strategies_yaml)
     if not isinstance(catalog, dict):
-        raise ValueError('strategy_catalog_not_mapping')
-    strategies = catalog.get('strategies')
+        raise ValueError("strategy_catalog_not_mapping")
+    strategies = catalog.get("strategies")
     if not isinstance(strategies, list):
-        raise ValueError('strategy_catalog_missing_strategies')
+        raise ValueError("strategy_catalog_missing_strategies")
 
     matched = False
     for item in strategies:
         if not isinstance(item, dict):
             continue
-        item_name = str(item.get('name') or '').strip()
+        item_name = str(item.get("name") or "").strip()
         if item_name != strategy_name:
             continue
         matched = True
         for key, value in strategy_overrides.items():
-            if key == 'params':
-                raise ValueError('strategy_override_key_reserved:params')
+            if key == "params":
+                raise ValueError("strategy_override_key_reserved:params")
             if key in _LOCAL_ONLY_OVERRIDE_KEYS:
                 continue
             item[key] = value
         break
     if not matched:
-        raise ValueError(f'strategy_not_found:{strategy_name}')
+        raise ValueError(f"strategy_not_found:{strategy_name}")
 
-    data['strategies.yaml'] = yaml.safe_dump(catalog, sort_keys=False)
+    data["strategies.yaml"] = yaml.safe_dump(catalog, sort_keys=False)
     return root
 
 
@@ -657,23 +720,23 @@ def _resolve_full_window(
     train_days: tuple[date, ...],
     holdout_days: tuple[date, ...],
 ) -> tuple[date, date]:
-    if str(args.full_window_start_date or '').strip():
+    if str(args.full_window_start_date or "").strip():
         start = date.fromisoformat(str(args.full_window_start_date))
     else:
         start = train_days[0]
-    if str(args.full_window_end_date or '').strip():
+    if str(args.full_window_end_date or "").strip():
         end = date.fromisoformat(str(args.full_window_end_date))
     else:
         end = holdout_days[-1]
     if start > end:
-        raise ValueError('full_window_invalid_range')
+        raise ValueError("full_window_invalid_range")
     return (start, end)
 
 
 def _max_drawdown_from_daily_net(daily_net: Mapping[str, Decimal]) -> Decimal:
-    equity = Decimal('0')
-    peak = Decimal('0')
-    max_drawdown = Decimal('0')
+    equity = Decimal("0")
+    peak = Decimal("0")
+    max_drawdown = Decimal("0")
     for trading_day in sorted(daily_net):
         equity += daily_net[trading_day]
         if equity > peak:
@@ -685,18 +748,20 @@ def _max_drawdown_from_daily_net(daily_net: Mapping[str, Decimal]) -> Decimal:
 
 
 def _daily_filled_notional(payload: Mapping[str, Any]) -> dict[str, Decimal]:
-    daily_payload = cast(Mapping[str, Any], payload.get('daily') or {})
+    daily_payload = cast(Mapping[str, Any], payload.get("daily") or {})
     filled_notional: dict[str, Decimal] = {}
     for day, value in daily_payload.items():
         if not isinstance(value, Mapping):
             continue
         value_mapping = cast(Mapping[str, Any], value)
-        filled_notional[str(day)] = Decimal(str(value_mapping.get('filled_notional', '0')))
+        filled_notional[str(day)] = Decimal(
+            str(value_mapping.get("filled_notional", "0"))
+        )
     return filled_notional
 
 
 def _daily_decimal_metric(payload: Mapping[str, Any], key: str) -> dict[str, Decimal]:
-    daily_payload = cast(Mapping[str, Any], payload.get('daily') or {})
+    daily_payload = cast(Mapping[str, Any], payload.get("daily") or {})
     values: dict[str, Decimal] = {}
     for day, value in daily_payload.items():
         if not isinstance(value, Mapping):
@@ -709,7 +774,7 @@ def _daily_decimal_metric(payload: Mapping[str, Any], key: str) -> dict[str, Dec
 
 
 def _daily_int_metric(payload: Mapping[str, Any], key: str) -> dict[str, int]:
-    daily_payload = cast(Mapping[str, Any], payload.get('daily') or {})
+    daily_payload = cast(Mapping[str, Any], payload.get("daily") or {})
     values: dict[str, int] = {}
     for day, value in daily_payload.items():
         if not isinstance(value, Mapping):
@@ -739,10 +804,12 @@ def _max_best_day_share_of_total_pnl(
     total_net_pnl: Decimal,
 ) -> Decimal:
     if total_net_pnl <= 0:
-        return Decimal('1')
-    best_positive_day = max((value for value in daily_net.values() if value > 0), default=Decimal('0'))
+        return Decimal("1")
+    best_positive_day = max(
+        (value for value in daily_net.values() if value > 0), default=Decimal("0")
+    )
     if best_positive_day <= 0:
-        return Decimal('0')
+        return Decimal("0")
     return best_positive_day / total_net_pnl
 
 
@@ -755,12 +822,12 @@ def _consistency_penalty(
     daily_filled_notional = _daily_filled_notional(full_window_payload)
     daily_gross_exposure_pct_equity = _daily_decimal_metric(
         full_window_payload,
-        'max_gross_exposure_pct_equity',
+        "max_gross_exposure_pct_equity",
     )
-    daily_min_cash = _daily_decimal_metric(full_window_payload, 'min_cash')
+    daily_min_cash = _daily_decimal_metric(full_window_payload, "min_cash")
     daily_negative_cash_observations = _daily_int_metric(
         full_window_payload,
-        'negative_cash_observation_count',
+        "negative_cash_observation_count",
     )
     negative_days = sum(1 for value in summary.daily_net.values() if value < 0)
     positive_days = sum(1 for value in summary.daily_net.values() if value > 0)
@@ -768,73 +835,88 @@ def _consistency_penalty(
     active_ratio = (
         Decimal(summary.active_days) / Decimal(summary.trading_day_count)
         if summary.trading_day_count > 0
-        else Decimal('0')
+        else Decimal("0")
     )
-    total_filled_notional = sum(daily_filled_notional.values(), Decimal('0'))
+    total_filled_notional = sum(daily_filled_notional.values(), Decimal("0"))
     avg_filled_notional_per_day = (
         total_filled_notional / Decimal(summary.trading_day_count)
         if summary.trading_day_count > 0
-        else Decimal('0')
+        else Decimal("0")
     )
     avg_filled_notional_per_active_day = (
         total_filled_notional / Decimal(summary.active_days)
         if summary.active_days > 0
-        else Decimal('0')
+        else Decimal("0")
     )
     best_day_share_of_total_pnl = _max_best_day_share_of_total_pnl(
         daily_net=summary.daily_net,
         total_net_pnl=summary.net_pnl,
     )
-    min_daily_net_pnl = min(summary.daily_net.values(), default=Decimal('0'))
+    min_daily_net_pnl = min(summary.daily_net.values(), default=Decimal("0"))
     daily_net_below_min_count = sum(
         1 for value in summary.daily_net.values() if value < policy.min_daily_net_pnl
     )
-    if policy.min_daily_net_pnl > 0 and len(summary.daily_net) < summary.trading_day_count:
+    if (
+        policy.min_daily_net_pnl > 0
+        and len(summary.daily_net) < summary.trading_day_count
+    ):
         daily_net_below_min_count += summary.trading_day_count - len(summary.daily_net)
     max_gross_exposure_pct_equity = max(
         (
             _decimal_payload_metric(
                 full_window_payload,
-                'max_gross_exposure_pct_equity',
-                default=Decimal('0'),
+                "max_gross_exposure_pct_equity",
+                default=Decimal("0"),
             ),
             *daily_gross_exposure_pct_equity.values(),
         ),
-        default=Decimal('0'),
+        default=Decimal("0"),
     )
     min_cash = min(
         (
-            _decimal_payload_metric(full_window_payload, 'min_cash', default=Decimal('0')),
+            _decimal_payload_metric(
+                full_window_payload, "min_cash", default=Decimal("0")
+            ),
             *daily_min_cash.values(),
         ),
-        default=Decimal('0'),
+        default=Decimal("0"),
     )
     negative_cash_observation_count = max(
-        int(full_window_payload.get('negative_cash_observation_count') or 0),
+        int(full_window_payload.get("negative_cash_observation_count") or 0),
         sum(daily_negative_cash_observations.values()),
     )
-    penalties = Decimal('0')
+    penalties = Decimal("0")
 
     if summary.net_per_day < policy.target_net_per_day:
         penalties += policy.target_net_per_day - summary.net_per_day
     if policy.min_daily_net_pnl > 0 and daily_net_below_min_count > 0:
         penalties += sum(
-            max(Decimal('0'), policy.min_daily_net_pnl - value)
+            max(Decimal("0"), policy.min_daily_net_pnl - value)
             for value in summary.daily_net.values()
         )
-        penalties += Decimal(max(0, summary.trading_day_count - len(summary.daily_net))) * policy.min_daily_net_pnl
+        penalties += (
+            Decimal(max(0, summary.trading_day_count - len(summary.daily_net)))
+            * policy.min_daily_net_pnl
+        )
     if summary.active_days < policy.min_active_days:
-        penalties += Decimal(policy.min_active_days - summary.active_days) * Decimal('250')
+        penalties += Decimal(policy.min_active_days - summary.active_days) * Decimal(
+            "250"
+        )
     if active_ratio < policy.min_active_ratio:
-        penalties += (policy.min_active_ratio - active_ratio) * Decimal('2000')
+        penalties += (policy.min_active_ratio - active_ratio) * Decimal("2000")
     if positive_days < policy.min_positive_days:
-        penalties += Decimal(policy.min_positive_days - positive_days) * Decimal('350')
-    if policy.require_every_day_active and summary.active_days < summary.trading_day_count:
-        penalties += Decimal(summary.trading_day_count - summary.active_days) * Decimal('400')
+        penalties += Decimal(policy.min_positive_days - positive_days) * Decimal("350")
+    if (
+        policy.require_every_day_active
+        and summary.active_days < summary.trading_day_count
+    ):
+        penalties += Decimal(summary.trading_day_count - summary.active_days) * Decimal(
+            "400"
+        )
     if summary.worst_day_net < -policy.max_worst_day_loss:
         penalties += abs(summary.worst_day_net + policy.max_worst_day_loss)
     if negative_days > policy.max_negative_days:
-        penalties += Decimal(negative_days - policy.max_negative_days) * Decimal('300')
+        penalties += Decimal(negative_days - policy.max_negative_days) * Decimal("300")
     if drawdown > policy.max_drawdown:
         penalties += drawdown - policy.max_drawdown
     if best_day_share_of_total_pnl > policy.max_best_day_share_of_total_pnl:
@@ -844,69 +926,81 @@ def _consistency_penalty(
     if avg_filled_notional_per_day < policy.min_avg_filled_notional_per_day:
         penalties += (
             policy.min_avg_filled_notional_per_day - avg_filled_notional_per_day
-        ) / Decimal('1000')
-    if avg_filled_notional_per_active_day < policy.min_avg_filled_notional_per_active_day:
+        ) / Decimal("1000")
+    if (
+        avg_filled_notional_per_active_day
+        < policy.min_avg_filled_notional_per_active_day
+    ):
         penalties += (
-            policy.min_avg_filled_notional_per_active_day - avg_filled_notional_per_active_day
-        ) / Decimal('1000')
+            policy.min_avg_filled_notional_per_active_day
+            - avg_filled_notional_per_active_day
+        ) / Decimal("1000")
     if max_gross_exposure_pct_equity > policy.max_gross_exposure_pct_equity:
         penalties += (
             max_gross_exposure_pct_equity - policy.max_gross_exposure_pct_equity
-        ) * Decimal('1000')
+        ) * Decimal("1000")
     if min_cash < policy.min_cash:
         penalties += policy.min_cash - min_cash
 
     return (
         penalties,
         {
-            'start_date': summary.start_date,
-            'end_date': summary.end_date,
-            'trading_day_count': summary.trading_day_count,
-            'net_pnl': str(summary.net_pnl),
-            'net_per_day': str(summary.net_per_day),
-            'min_daily_net_pnl': str(min_daily_net_pnl),
-            'min_daily_net_pnl_required': str(policy.min_daily_net_pnl),
-            'daily_net_below_min_count': daily_net_below_min_count,
-            'active_days': summary.active_days,
-            'active_ratio': str(active_ratio),
-            'positive_days': positive_days,
-            'worst_day_net': str(summary.worst_day_net),
-            'negative_days': negative_days,
-            'max_drawdown': str(drawdown),
-            'total_filled_notional': str(total_filled_notional),
-            'avg_filled_notional_per_day': str(avg_filled_notional_per_day),
-            'avg_filled_notional_per_active_day': str(avg_filled_notional_per_active_day),
-            'best_day_share_of_total_pnl': str(best_day_share_of_total_pnl),
-            'max_gross_exposure_pct_equity': str(max_gross_exposure_pct_equity),
-            'max_gross_exposure_pct_equity_required': str(policy.max_gross_exposure_pct_equity),
-            'min_cash': str(min_cash),
-            'min_cash_required': str(policy.min_cash),
-            'negative_cash_observation_count': negative_cash_observation_count,
-            'daily_net': {day: str(value) for day, value in summary.daily_net.items()},
-            'daily_filled_notional': {day: str(value) for day, value in daily_filled_notional.items()},
-            'daily_max_gross_exposure_pct_equity': {
+            "start_date": summary.start_date,
+            "end_date": summary.end_date,
+            "trading_day_count": summary.trading_day_count,
+            "net_pnl": str(summary.net_pnl),
+            "net_per_day": str(summary.net_per_day),
+            "min_daily_net_pnl": str(min_daily_net_pnl),
+            "min_daily_net_pnl_required": str(policy.min_daily_net_pnl),
+            "daily_net_below_min_count": daily_net_below_min_count,
+            "active_days": summary.active_days,
+            "active_ratio": str(active_ratio),
+            "positive_days": positive_days,
+            "worst_day_net": str(summary.worst_day_net),
+            "negative_days": negative_days,
+            "max_drawdown": str(drawdown),
+            "total_filled_notional": str(total_filled_notional),
+            "avg_filled_notional_per_day": str(avg_filled_notional_per_day),
+            "avg_filled_notional_per_active_day": str(
+                avg_filled_notional_per_active_day
+            ),
+            "best_day_share_of_total_pnl": str(best_day_share_of_total_pnl),
+            "max_gross_exposure_pct_equity": str(max_gross_exposure_pct_equity),
+            "max_gross_exposure_pct_equity_required": str(
+                policy.max_gross_exposure_pct_equity
+            ),
+            "min_cash": str(min_cash),
+            "min_cash_required": str(policy.min_cash),
+            "negative_cash_observation_count": negative_cash_observation_count,
+            "daily_net": {day: str(value) for day, value in summary.daily_net.items()},
+            "daily_filled_notional": {
+                day: str(value) for day, value in daily_filled_notional.items()
+            },
+            "daily_max_gross_exposure_pct_equity": {
                 day: str(value)
                 for day, value in daily_gross_exposure_pct_equity.items()
             },
-            'daily_min_cash': {day: str(value) for day, value in daily_min_cash.items()},
-            'daily_negative_cash_observation_count': daily_negative_cash_observations,
+            "daily_min_cash": {
+                day: str(value) for day, value in daily_min_cash.items()
+            },
+            "daily_negative_cash_observation_count": daily_negative_cash_observations,
         },
     )
 
 
 def _empty_replay_payload(*, start_date: date, end_date: date) -> dict[str, Any]:
     return {
-        'start_date': start_date.isoformat(),
-        'end_date': end_date.isoformat(),
-        'net_pnl': '0',
-        'gross_pnl': '0',
-        'total_cost': '0',
-        'decision_count': 0,
-        'filled_count': 0,
-        'wins': 0,
-        'losses': 0,
-        'daily': {},
-        'funnel': {'buckets': []},
+        "start_date": start_date.isoformat(),
+        "end_date": end_date.isoformat(),
+        "net_pnl": "0",
+        "gross_pnl": "0",
+        "total_cost": "0",
+        "decision_count": 0,
+        "filled_count": 0,
+        "wins": 0,
+        "losses": 0,
+        "daily": {},
+        "funnel": {"buckets": []},
     }
 
 
@@ -924,34 +1018,34 @@ def _train_screen_failures(
     active_ratio = (
         Decimal(summary.active_days) / Decimal(summary.trading_day_count)
         if summary.trading_day_count > 0
-        else Decimal('0')
+        else Decimal("0")
     )
     if holdout_policy.require_training_decisions and summary.decision_count <= 0:
-        failures.append('train_no_decisions')
+        failures.append("train_no_decisions")
     if summary.active_days <= 0:
-        failures.append('train_no_active_days')
+        failures.append("train_no_active_days")
     if active_ratio < min_train_active_ratio:
-        failures.append('train_active_ratio_below_screen')
+        failures.append("train_active_ratio_below_screen")
     if summary.net_per_day < min_train_net_per_day:
-        failures.append('train_net_per_day_below_screen')
+        failures.append("train_net_per_day_below_screen")
     if summary.worst_day_net < -max_train_worst_day_loss:
-        failures.append('train_worst_day_loss_above_screen')
+        failures.append("train_worst_day_loss_above_screen")
     if (
         consistency_policy.require_every_day_active
         and summary.trading_day_count > 0
         and summary.active_days == 0
     ):
-        failures.append('train_every_day_active_impossible')
+        failures.append("train_every_day_active_impossible")
     return list(dict.fromkeys(failures))
 
 
 def _symbol_contributions_from_replay_payload(
     payload: Mapping[str, Any],
 ) -> dict[str, dict[str, Any]]:
-    funnel = payload.get('funnel')
+    funnel = payload.get("funnel")
     if not isinstance(funnel, Mapping):
         return {}
-    buckets = funnel.get('buckets')
+    buckets = funnel.get("buckets")
     if not isinstance(buckets, list):
         return {}
 
@@ -959,69 +1053,71 @@ def _symbol_contributions_from_replay_payload(
     for raw_bucket in buckets:
         if not isinstance(raw_bucket, Mapping):
             continue
-        symbol = str(raw_bucket.get('symbol') or '').strip().upper()
+        symbol = str(raw_bucket.get("symbol") or "").strip().upper()
         if not symbol:
             continue
-        bucket_net = Decimal(str(raw_bucket.get('net_pnl', '0')))
-        bucket_cost = Decimal(str(raw_bucket.get('cost_total', '0')))
-        bucket_filled = int(raw_bucket.get('filled_count', 0) or 0)
-        bucket_day = str(raw_bucket.get('trading_day') or '').strip()
+        bucket_net = Decimal(str(raw_bucket.get("net_pnl", "0")))
+        bucket_cost = Decimal(str(raw_bucket.get("cost_total", "0")))
+        bucket_filled = int(raw_bucket.get("filled_count", 0) or 0)
+        bucket_day = str(raw_bucket.get("trading_day") or "").strip()
         aggregate = contributions.setdefault(
             symbol,
             {
-                'net_pnl': Decimal('0'),
-                'cost_total': Decimal('0'),
-                'downside_pnl': Decimal('0'),
-                'worst_day_net': Decimal('0'),
-                'active_days': set(),
-                'negative_days': set(),
-                'filled_count': 0,
+                "net_pnl": Decimal("0"),
+                "cost_total": Decimal("0"),
+                "downside_pnl": Decimal("0"),
+                "worst_day_net": Decimal("0"),
+                "active_days": set(),
+                "negative_days": set(),
+                "filled_count": 0,
             },
         )
-        aggregate['net_pnl'] += bucket_net
-        aggregate['cost_total'] += bucket_cost
-        aggregate['filled_count'] += bucket_filled
+        aggregate["net_pnl"] += bucket_net
+        aggregate["cost_total"] += bucket_cost
+        aggregate["filled_count"] += bucket_filled
         if bucket_filled > 0 and bucket_day:
-            aggregate['active_days'].add(bucket_day)
+            aggregate["active_days"].add(bucket_day)
         if bucket_net < 0:
-            aggregate['downside_pnl'] += -bucket_net
+            aggregate["downside_pnl"] += -bucket_net
             if bucket_day:
-                aggregate['negative_days'].add(bucket_day)
-            if bucket_net < aggregate['worst_day_net']:
-                aggregate['worst_day_net'] = bucket_net
+                aggregate["negative_days"].add(bucket_day)
+            if bucket_net < aggregate["worst_day_net"]:
+                aggregate["worst_day_net"] = bucket_net
 
     result: dict[str, dict[str, Any]] = {}
     for symbol, aggregate in contributions.items():
-        net_pnl = aggregate['net_pnl']
-        downside_pnl = aggregate['downside_pnl']
-        worst_day_net = aggregate['worst_day_net']
+        net_pnl = aggregate["net_pnl"]
+        downside_pnl = aggregate["downside_pnl"]
+        worst_day_net = aggregate["worst_day_net"]
         # Risk-sensitive marginal contribution: reward positive contribution, penalize
         # downside and especially severe one-day losses.
         contribution_score = net_pnl - downside_pnl - abs(worst_day_net)
         result[symbol] = {
-            'net_pnl': str(net_pnl),
-            'cost_total': str(aggregate['cost_total']),
-            'downside_pnl': str(downside_pnl),
-            'worst_day_net': str(worst_day_net),
-            'active_days': len(aggregate['active_days']),
-            'negative_days': len(aggregate['negative_days']),
-            'filled_count': aggregate['filled_count'],
-            'contribution_score': str(contribution_score),
+            "net_pnl": str(net_pnl),
+            "cost_total": str(aggregate["cost_total"]),
+            "downside_pnl": str(downside_pnl),
+            "worst_day_net": str(worst_day_net),
+            "active_days": len(aggregate["active_days"]),
+            "negative_days": len(aggregate["negative_days"]),
+            "filled_count": aggregate["filled_count"],
+            "contribution_score": str(contribution_score),
         }
     return dict(
         sorted(
             result.items(),
             key=lambda item: (
-                Decimal(str(item[1]['contribution_score'])),
-                Decimal(str(item[1]['net_pnl'])),
+                Decimal(str(item[1]["contribution_score"])),
+                Decimal(str(item[1]["net_pnl"])),
             ),
         )
     )
 
 
-def _top_counter_payload(counter: Counter[str], *, limit: int = 10) -> list[dict[str, Any]]:
+def _top_counter_payload(
+    counter: Counter[str], *, limit: int = 10
+) -> list[dict[str, Any]]:
     return [
-        {'key': key, 'count': count}
+        {"key": key, "count": count}
         for key, count in counter.most_common(max(1, limit))
     ]
 
@@ -1041,7 +1137,7 @@ def _counter_from_payload(value: Any) -> Counter[str]:
 
 
 def _near_miss_digest(raw_near_miss: Mapping[str, Any]) -> dict[str, Any]:
-    thresholds = raw_near_miss.get('thresholds')
+    thresholds = raw_near_miss.get("thresholds")
     threshold_digest: list[dict[str, Any]] = []
     if isinstance(thresholds, list):
         for item in thresholds[:3]:
@@ -1049,40 +1145,40 @@ def _near_miss_digest(raw_near_miss: Mapping[str, Any]) -> dict[str, Any]:
                 continue
             threshold_digest.append(
                 {
-                    'metric': str(item.get('metric') or ''),
-                    'value': item.get('value'),
-                    'threshold': item.get('threshold'),
-                    'distance_to_pass': item.get('distance_to_pass'),
+                    "metric": str(item.get("metric") or ""),
+                    "value": item.get("value"),
+                    "threshold": item.get("threshold"),
+                    "distance_to_pass": item.get("distance_to_pass"),
                 }
             )
     return {
-        'trading_day': raw_near_miss.get('trading_day'),
-        'symbol': raw_near_miss.get('symbol'),
-        'strategy_type': raw_near_miss.get('strategy_type'),
-        'event_ts': raw_near_miss.get('event_ts'),
-        'first_failed_gate': raw_near_miss.get('first_failed_gate'),
-        'distance_score': raw_near_miss.get('distance_score'),
-        'thresholds': threshold_digest,
+        "trading_day": raw_near_miss.get("trading_day"),
+        "symbol": raw_near_miss.get("symbol"),
+        "strategy_type": raw_near_miss.get("strategy_type"),
+        "event_ts": raw_near_miss.get("event_ts"),
+        "first_failed_gate": raw_near_miss.get("first_failed_gate"),
+        "distance_score": raw_near_miss.get("distance_score"),
+        "thresholds": threshold_digest,
     }
 
 
 def _train_gate_diagnostics_from_replay_payload(
     payload: Mapping[str, Any],
 ) -> dict[str, Any]:
-    funnel = payload.get('funnel')
+    funnel = payload.get("funnel")
     buckets = (
-        cast(list[Any], funnel.get('buckets'))
-        if isinstance(funnel, Mapping) and isinstance(funnel.get('buckets'), list)
+        cast(list[Any], funnel.get("buckets"))
+        if isinstance(funnel, Mapping) and isinstance(funnel.get("buckets"), list)
         else []
     )
     aggregate = {
-        'retained_rows': 0,
-        'runtime_evaluable_rows': 0,
-        'quote_valid_rows': 0,
-        'strategy_evaluations': 0,
-        'passed_trace_count': 0,
-        'decision_count': int(payload.get('decision_count') or 0),
-        'filled_count': int(payload.get('filled_count') or 0),
+        "retained_rows": 0,
+        "runtime_evaluable_rows": 0,
+        "quote_valid_rows": 0,
+        "strategy_evaluations": 0,
+        "passed_trace_count": 0,
+        "decision_count": int(payload.get("decision_count") or 0),
+        "filled_count": int(payload.get("filled_count") or 0),
     }
     first_failed_gate_counts: Counter[str] = Counter()
     failing_threshold_counts: Counter[str] = Counter()
@@ -1091,43 +1187,45 @@ def _train_gate_diagnostics_from_replay_payload(
         if not isinstance(raw_bucket, Mapping):
             continue
         for key in (
-            'retained_rows',
-            'runtime_evaluable_rows',
-            'quote_valid_rows',
-            'strategy_evaluations',
-            'passed_trace_count',
+            "retained_rows",
+            "runtime_evaluable_rows",
+            "quote_valid_rows",
+            "strategy_evaluations",
+            "passed_trace_count",
         ):
             try:
                 aggregate[key] += int(raw_bucket.get(key) or 0)
             except (TypeError, ValueError):
                 continue
         first_failed_gate_counts.update(
-            _counter_from_payload(raw_bucket.get('first_failed_gate_counts'))
+            _counter_from_payload(raw_bucket.get("first_failed_gate_counts"))
         )
         failing_threshold_counts.update(
-            _counter_from_payload(raw_bucket.get('failing_threshold_counts'))
+            _counter_from_payload(raw_bucket.get("failing_threshold_counts"))
         )
-        gate_pass_counts.update(_counter_from_payload(raw_bucket.get('gate_pass_counts')))
+        gate_pass_counts.update(
+            _counter_from_payload(raw_bucket.get("gate_pass_counts"))
+        )
 
-    near_misses = payload.get('near_misses')
+    near_misses = payload.get("near_misses")
     near_miss_digest = [
         _near_miss_digest(item)
         for item in (near_misses if isinstance(near_misses, list) else [])[:20]
         if isinstance(item, Mapping)
     ]
     status = (
-        'available'
-        if aggregate['strategy_evaluations'] > 0
-        else 'no_runtime_trace_evaluations'
+        "available"
+        if aggregate["strategy_evaluations"] > 0
+        else "no_runtime_trace_evaluations"
     )
     return {
-        'schema_version': 'torghut.frontier-train-gate-diagnostics.v1',
-        'status': status,
-        'aggregate': aggregate,
-        'top_first_failed_gates': _top_counter_payload(first_failed_gate_counts),
-        'top_failing_thresholds': _top_counter_payload(failing_threshold_counts),
-        'top_gate_pass_counts': _top_counter_payload(gate_pass_counts),
-        'near_misses': near_miss_digest,
+        "schema_version": "torghut.frontier-train-gate-diagnostics.v1",
+        "status": status,
+        "aggregate": aggregate,
+        "top_first_failed_gates": _top_counter_payload(first_failed_gate_counts),
+        "top_failing_thresholds": _top_counter_payload(failing_threshold_counts),
+        "top_gate_pass_counts": _top_counter_payload(gate_pass_counts),
+        "near_misses": near_miss_digest,
     }
 
 
@@ -1154,18 +1252,14 @@ def _generate_symbol_prune_children(
     if len(universe) <= max(1, min_universe_size):
         return []
 
-    ranked_symbols = [
-        symbol
-        for symbol in symbol_contributions
-        if symbol in universe
-    ]
+    ranked_symbols = [symbol for symbol in symbol_contributions if symbol in universe]
     children: list[tuple[str, dict[str, Any]]] = []
     for symbol in ranked_symbols[: max(1, branch_count)]:
         pruned_universe = [item for item in universe if item != symbol]
         if len(pruned_universe) < max(1, min_universe_size):
             continue
         next_override = dict(strategy_overrides)
-        next_override['universe_symbols'] = pruned_universe
+        next_override["universe_symbols"] = pruned_universe
         children.append((symbol, next_override))
     return children
 
@@ -1174,39 +1268,55 @@ def _rank_scored_candidates(scored: list[dict[str, Any]]) -> list[dict[str, Any]
     if not scored:
         return []
     scorecards = {
-        str(item['candidate_id']): build_scorecard(
-            candidate_id=str(item['candidate_id']),
-            trading_day_count=int(item['full_window']['trading_day_count']),
-            net_pnl_per_day=Decimal(str(item['objective_scorecard']['net_pnl_per_day'])),
+        str(item["candidate_id"]): build_scorecard(
+            candidate_id=str(item["candidate_id"]),
+            trading_day_count=int(item["full_window"]["trading_day_count"]),
+            net_pnl_per_day=Decimal(
+                str(item["objective_scorecard"]["net_pnl_per_day"])
+            ),
             active_days=int(
-                Decimal(str(item['objective_scorecard']['active_day_ratio']))
-                * Decimal(str(item['full_window']['trading_day_count']))
+                Decimal(str(item["objective_scorecard"]["active_day_ratio"]))
+                * Decimal(str(item["full_window"]["trading_day_count"]))
             ),
             positive_days=int(
-                Decimal(str(item['objective_scorecard']['positive_day_ratio']))
-                * Decimal(str(item['full_window']['trading_day_count']))
+                Decimal(str(item["objective_scorecard"]["positive_day_ratio"]))
+                * Decimal(str(item["full_window"]["trading_day_count"]))
             ),
-            avg_filled_notional_per_day=Decimal(str(item['objective_scorecard']['avg_filled_notional_per_day'])),
+            avg_filled_notional_per_day=Decimal(
+                str(item["objective_scorecard"]["avg_filled_notional_per_day"])
+            ),
             avg_filled_notional_per_active_day=Decimal(
-                str(item['objective_scorecard']['avg_filled_notional_per_active_day'])
+                str(item["objective_scorecard"]["avg_filled_notional_per_active_day"])
             ),
-            worst_day_loss=Decimal(str(item['objective_scorecard']['worst_day_loss'])),
-            max_drawdown=Decimal(str(item['objective_scorecard']['max_drawdown'])),
-            best_day_share=Decimal(str(item['objective_scorecard']['best_day_share'])),
-            negative_day_count=int(item['objective_scorecard']['negative_day_count']),
-            rolling_3d_lower_bound=Decimal(str(item['objective_scorecard']['rolling_3d_lower_bound'])),
-            rolling_5d_lower_bound=Decimal(str(item['objective_scorecard']['rolling_5d_lower_bound'])),
-            regime_slice_pass_rate=Decimal(str(item['objective_scorecard']['regime_slice_pass_rate'])),
-            symbol_concentration_share=Decimal(str(item['objective_scorecard']['symbol_concentration_share'])),
+            worst_day_loss=Decimal(str(item["objective_scorecard"]["worst_day_loss"])),
+            max_drawdown=Decimal(str(item["objective_scorecard"]["max_drawdown"])),
+            best_day_share=Decimal(str(item["objective_scorecard"]["best_day_share"])),
+            negative_day_count=int(item["objective_scorecard"]["negative_day_count"]),
+            rolling_3d_lower_bound=Decimal(
+                str(item["objective_scorecard"]["rolling_3d_lower_bound"])
+            ),
+            rolling_5d_lower_bound=Decimal(
+                str(item["objective_scorecard"]["rolling_5d_lower_bound"])
+            ),
+            regime_slice_pass_rate=Decimal(
+                str(item["objective_scorecard"]["regime_slice_pass_rate"])
+            ),
+            symbol_concentration_share=Decimal(
+                str(item["objective_scorecard"]["symbol_concentration_share"])
+            ),
             entry_family_contribution_share=Decimal(
-                str(item['objective_scorecard']['entry_family_contribution_share'])
+                str(item["objective_scorecard"]["entry_family_contribution_share"])
             ),
             max_gross_exposure_pct_equity=Decimal(
-                str(item['objective_scorecard'].get('max_gross_exposure_pct_equity', '0'))
+                str(
+                    item["objective_scorecard"].get(
+                        "max_gross_exposure_pct_equity", "0"
+                    )
+                )
             ),
-            min_cash=Decimal(str(item['objective_scorecard'].get('min_cash', '0'))),
+            min_cash=Decimal(str(item["objective_scorecard"].get("min_cash", "0"))),
             negative_cash_observation_count=int(
-                item['objective_scorecard'].get('negative_cash_observation_count') or 0
+                item["objective_scorecard"].get("negative_cash_observation_count") or 0
             ),
         )
         for item in scored
@@ -1214,30 +1324,29 @@ def _rank_scored_candidates(scored: list[dict[str, Any]]) -> list[dict[str, Any]
     ranked_scorecards = rank_scorecards(
         scorecards.values(),
         veto_lookup={
-            str(item['candidate_id']): tuple(cast(list[str], item.get('hard_vetoes') or []))
+            str(item["candidate_id"]): tuple(
+                cast(list[str], item.get("hard_vetoes") or [])
+            )
             for item in scored
         },
     )
-    ranked_lookup = {
-        item.candidate_id: item
-        for item in ranked_scorecards
-    }
+    ranked_lookup = {item.candidate_id: item for item in ranked_scorecards}
     ranked_items = [dict(item) for item in scored]
     for item in ranked_items:
-        ranked = ranked_lookup[str(item['candidate_id'])]
-        item['objective_scorecard'] = ranked.to_payload()
-        item['ranking'] = {
-            'method': 'pareto_frontier_v2',
-            'pareto_tier': ranked.pareto_tier,
-            'tie_breaker_score': str(ranked.tie_breaker_score),
-            'vetoed': bool(ranked.veto_reasons),
+        ranked = ranked_lookup[str(item["candidate_id"])]
+        item["objective_scorecard"] = ranked.to_payload()
+        item["ranking"] = {
+            "method": "pareto_frontier_v2",
+            "pareto_tier": ranked.pareto_tier,
+            "tie_breaker_score": str(ranked.tie_breaker_score),
+            "vetoed": bool(ranked.veto_reasons),
         }
     ranked_items.sort(
         key=lambda item: (
-            bool(item['ranking']['vetoed']),
-            int(item['ranking']['pareto_tier']),
-            -Decimal(str(item['ranking']['tie_breaker_score'])),
-            -Decimal(str(item['full_window']['net_per_day'])),
+            bool(item["ranking"]["vetoed"]),
+            int(item["ranking"]["pareto_tier"]),
+            -Decimal(str(item["ranking"]["tie_breaker_score"])),
+            -Decimal(str(item["full_window"]["net_per_day"])),
         )
     )
     return ranked_items
@@ -1262,40 +1371,44 @@ def _build_frontier_payload(
 ) -> dict[str, Any]:
     ranked_items = _rank_scored_candidates(scored)
     return {
-        'schema_version': _SWEEP_SCHEMA_VERSION,
-        'status': status,
-        'family': family,
-        'strategy_name': strategy_name,
-        'family_template': family_template.to_payload(),
-        'dataset_snapshot_receipt': dataset_snapshot_receipt.to_payload(),
-        'window': {
-            'train_days': [item.isoformat() for item in window.train_days],
-            'holdout_days': [item.isoformat() for item in window.holdout_days],
-            'full_window_start_date': full_window_start.isoformat(),
-            'full_window_end_date': full_window_end.isoformat(),
+        "schema_version": _SWEEP_SCHEMA_VERSION,
+        "status": status,
+        "family": family,
+        "strategy_name": strategy_name,
+        "family_template": family_template.to_payload(),
+        "dataset_snapshot_receipt": dataset_snapshot_receipt.to_payload(),
+        "window": {
+            "train_days": [item.isoformat() for item in window.train_days],
+            "holdout_days": [item.isoformat() for item in window.holdout_days],
+            "full_window_start_date": full_window_start.isoformat(),
+            "full_window_end_date": full_window_end.isoformat(),
         },
-        'constraints': {
-            'holdout': {
-                'holdout_target_net_per_day': str(holdout_policy.holdout_target_net_per_day),
-                'min_active_holdout_days': holdout_policy.min_active_holdout_days,
-                'max_worst_holdout_day_loss': str(holdout_policy.max_worst_holdout_day_loss),
-                'min_profit_factor': str(holdout_policy.min_profit_factor),
-                'require_training_decisions': holdout_policy.require_training_decisions,
-                'require_holdout_decisions': holdout_policy.require_holdout_decisions,
+        "constraints": {
+            "holdout": {
+                "holdout_target_net_per_day": str(
+                    holdout_policy.holdout_target_net_per_day
+                ),
+                "min_active_holdout_days": holdout_policy.min_active_holdout_days,
+                "max_worst_holdout_day_loss": str(
+                    holdout_policy.max_worst_holdout_day_loss
+                ),
+                "min_profit_factor": str(holdout_policy.min_profit_factor),
+                "require_training_decisions": holdout_policy.require_training_decisions,
+                "require_holdout_decisions": holdout_policy.require_holdout_decisions,
             },
-            'consistency': consistency_policy.to_payload(),
-            'hard_vetoes': objective_veto_policy.to_payload(),
+            "consistency": consistency_policy.to_payload(),
+            "hard_vetoes": objective_veto_policy.to_payload(),
         },
-        'ranking': {
-            'method': 'pareto_frontier_v2',
-            'stale_override_used': dataset_snapshot_receipt.stale_override_used,
+        "ranking": {
+            "method": "pareto_frontier_v2",
+            "stale_override_used": dataset_snapshot_receipt.stale_override_used,
         },
-        'progress': {
-            'evaluated_candidates': len(scored),
-            'pending_candidates': pending_candidates,
+        "progress": {
+            "evaluated_candidates": len(scored),
+            "pending_candidates": pending_candidates,
         },
-        'candidate_count': len(scored),
-        'top': ranked_items[: max(1, int(top_n))],
+        "candidate_count": len(scored),
+        "top": ranked_items[: max(1, int(top_n))],
     }
 
 
@@ -1304,17 +1417,19 @@ def _selected_normalization_regime(
     strategy_overrides: Mapping[str, Any],
     template_allowed_normalizations: tuple[str, ...],
 ) -> str | None:
-    override = str(strategy_overrides.get('normalization_regime') or '').strip()
+    override = str(strategy_overrides.get("normalization_regime") or "").strip()
     if override:
         return override
-    return template_allowed_normalizations[0] if template_allowed_normalizations else None
+    return (
+        template_allowed_normalizations[0] if template_allowed_normalizations else None
+    )
 
 
 def _resolved_clickhouse_password(args: argparse.Namespace) -> str | None:
-    direct_password = str(getattr(args, 'clickhouse_password', '') or '').strip()
+    direct_password = str(getattr(args, "clickhouse_password", "") or "").strip()
     if direct_password:
         return direct_password
-    password_env = str(getattr(args, 'clickhouse_password_env', '') or '').strip()
+    password_env = str(getattr(args, "clickhouse_password_env", "") or "").strip()
     if not password_env:
         return None
     return os.environ.get(password_env) or None
@@ -1340,93 +1455,138 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
         holdout_days=window.holdout_days,
     )
 
-    base_configmap = yaml.safe_load(args.strategy_configmap.resolve().read_text(encoding='utf-8'))
+    base_configmap = yaml.safe_load(
+        args.strategy_configmap.resolve().read_text(encoding="utf-8")
+    )
     if not isinstance(base_configmap, dict):
-        raise ValueError('base_strategy_configmap_not_mapping')
+        raise ValueError("base_strategy_configmap_not_mapping")
 
-    family = str(sweep_config.get('family') or '').strip()
-    strategy_name = str(sweep_config.get('strategy_name') or '').strip()
+    family = str(sweep_config.get("family") or "").strip()
+    strategy_name = str(sweep_config.get("strategy_name") or "").strip()
     if not family or not strategy_name:
-        raise ValueError('sweep_config_missing_family_or_strategy_name')
+        raise ValueError("sweep_config_missing_family_or_strategy_name")
     family_template = load_family_template(
         derive_family_template_id(
-            explicit_id=str(sweep_config.get('family_template_id') or '').strip() or None,
+            explicit_id=str(sweep_config.get("family_template_id") or "").strip()
+            or None,
             family=family,
         ),
         directory=args.family_template_dir,
     )
-    disable_other_strategies = bool(sweep_config.get('disable_other_strategies', True))
+    disable_other_strategies = bool(sweep_config.get("disable_other_strategies", True))
 
-    parameter_grid = sweep_config.get('parameters')
+    parameter_grid = sweep_config.get("parameters")
     if not isinstance(parameter_grid, Mapping):
-        raise ValueError('sweep_config_parameters_not_mapping')
-    strategy_override_grid = sweep_config.get('strategy_overrides')
-    if strategy_override_grid is not None and not isinstance(strategy_override_grid, Mapping):
-        raise ValueError('sweep_config_strategy_overrides_not_mapping')
+        raise ValueError("sweep_config_parameters_not_mapping")
+    strategy_override_grid = sweep_config.get("strategy_overrides")
+    if strategy_override_grid is not None and not isinstance(
+        strategy_override_grid, Mapping
+    ):
+        raise ValueError("sweep_config_strategy_overrides_not_mapping")
 
-    constraints_value = sweep_config.get('constraints')
+    constraints_value = sweep_config.get("constraints")
     if constraints_value is None:
         constraints: Mapping[str, Any] = {}
     elif isinstance(constraints_value, Mapping):
         constraints = cast(Mapping[str, Any], constraints_value)
     else:
-        raise ValueError('sweep_config_constraints_not_mapping')
+        raise ValueError("sweep_config_constraints_not_mapping")
 
-    consistency_value = sweep_config.get('consistency_constraints')
+    consistency_value = sweep_config.get("consistency_constraints")
     if consistency_value is None:
         consistency_constraints: Mapping[str, Any] = {}
     elif isinstance(consistency_value, Mapping):
         consistency_constraints = cast(Mapping[str, Any], consistency_value)
     else:
-        raise ValueError('sweep_config_consistency_constraints_not_mapping')
+        raise ValueError("sweep_config_consistency_constraints_not_mapping")
 
     holdout_policy = ProfitabilityConstraintPolicy(
-        holdout_target_net_per_day=Decimal(str(constraints.get('holdout_target_net_per_day', '200'))),
-        min_active_holdout_days=int(constraints.get('min_active_holdout_days', 2)),
-        max_worst_holdout_day_loss=Decimal(str(constraints.get('max_worst_holdout_day_loss', '200'))),
-        min_profit_factor=Decimal(str(constraints.get('min_profit_factor', '1.2'))),
-        require_training_decisions=bool(constraints.get('require_training_decisions', True)),
-        require_holdout_decisions=bool(constraints.get('require_holdout_decisions', True)),
+        holdout_target_net_per_day=Decimal(
+            str(constraints.get("holdout_target_net_per_day", "200"))
+        ),
+        min_active_holdout_days=int(constraints.get("min_active_holdout_days", 2)),
+        max_worst_holdout_day_loss=Decimal(
+            str(constraints.get("max_worst_holdout_day_loss", "200"))
+        ),
+        min_profit_factor=Decimal(str(constraints.get("min_profit_factor", "1.2"))),
+        require_training_decisions=bool(
+            constraints.get("require_training_decisions", True)
+        ),
+        require_holdout_decisions=bool(
+            constraints.get("require_holdout_decisions", True)
+        ),
     )
     consistency_policy = FullWindowConsistencyPolicy(
-        target_net_per_day=Decimal(str(consistency_constraints.get('target_net_per_day', '200'))),
-        min_daily_net_pnl=Decimal(str(consistency_constraints.get('min_daily_net_pnl', '0'))),
+        target_net_per_day=Decimal(
+            str(consistency_constraints.get("target_net_per_day", "200"))
+        ),
+        min_daily_net_pnl=Decimal(
+            str(consistency_constraints.get("min_daily_net_pnl", "0"))
+        ),
         # Widened full-window evaluations intentionally omit count-based activity thresholds
         # because train+holdout counts are not authoritative for the larger window.
-        min_active_days=_optional_int(consistency_constraints.get('min_active_days'), default=0),
-        min_active_ratio=Decimal(str(consistency_constraints.get('min_active_ratio', '0'))),
-        min_positive_days=int(consistency_constraints.get('min_positive_days', 0)),
-        max_worst_day_loss=Decimal(str(consistency_constraints.get('max_worst_day_loss', '250'))),
-        max_negative_days=int(consistency_constraints.get('max_negative_days', 2)),
-        max_drawdown=Decimal(str(consistency_constraints.get('max_drawdown', '600'))),
-        max_best_day_share_of_total_pnl=Decimal(str(consistency_constraints.get('max_best_day_share_of_total_pnl', '1'))),
-        min_avg_filled_notional_per_day=Decimal(str(consistency_constraints.get('min_avg_filled_notional_per_day', '0'))),
-        min_avg_filled_notional_per_active_day=Decimal(str(consistency_constraints.get('min_avg_filled_notional_per_active_day', '0'))),
-        require_every_day_active=bool(consistency_constraints.get('require_every_day_active', True)),
-        min_regime_slice_pass_rate=Decimal(str(consistency_constraints.get('min_regime_slice_pass_rate', '0'))),
-        max_symbol_concentration_share=Decimal(str(consistency_constraints.get('max_symbol_concentration_share', '1'))),
-        max_entry_family_contribution_share=Decimal(str(consistency_constraints.get('max_entry_family_contribution_share', '1'))),
-        max_gross_exposure_pct_equity=Decimal(
-            str(consistency_constraints.get('max_gross_exposure_pct_equity', '999999999'))
+        min_active_days=_optional_int(
+            consistency_constraints.get("min_active_days"), default=0
         ),
-        min_cash=Decimal(str(consistency_constraints.get('min_cash', '-999999999'))),
+        min_active_ratio=Decimal(
+            str(consistency_constraints.get("min_active_ratio", "0"))
+        ),
+        min_positive_days=int(consistency_constraints.get("min_positive_days", 0)),
+        max_worst_day_loss=Decimal(
+            str(consistency_constraints.get("max_worst_day_loss", "250"))
+        ),
+        max_negative_days=int(consistency_constraints.get("max_negative_days", 2)),
+        max_drawdown=Decimal(str(consistency_constraints.get("max_drawdown", "600"))),
+        max_best_day_share_of_total_pnl=Decimal(
+            str(consistency_constraints.get("max_best_day_share_of_total_pnl", "1"))
+        ),
+        min_avg_filled_notional_per_day=Decimal(
+            str(consistency_constraints.get("min_avg_filled_notional_per_day", "0"))
+        ),
+        min_avg_filled_notional_per_active_day=Decimal(
+            str(
+                consistency_constraints.get(
+                    "min_avg_filled_notional_per_active_day", "0"
+                )
+            )
+        ),
+        require_every_day_active=bool(
+            consistency_constraints.get("require_every_day_active", True)
+        ),
+        min_regime_slice_pass_rate=Decimal(
+            str(consistency_constraints.get("min_regime_slice_pass_rate", "0"))
+        ),
+        max_symbol_concentration_share=Decimal(
+            str(consistency_constraints.get("max_symbol_concentration_share", "1"))
+        ),
+        max_entry_family_contribution_share=Decimal(
+            str(consistency_constraints.get("max_entry_family_contribution_share", "1"))
+        ),
+        max_gross_exposure_pct_equity=Decimal(
+            str(
+                consistency_constraints.get(
+                    "max_gross_exposure_pct_equity", "999999999"
+                )
+            )
+        ),
+        min_cash=Decimal(str(consistency_constraints.get("min_cash", "-999999999"))),
     )
     max_train_screen_worst_day_loss = Decimal(
         str(
-            getattr(args, 'max_train_screen_worst_day_loss', '')
+            getattr(args, "max_train_screen_worst_day_loss", "")
             or consistency_policy.max_worst_day_loss
         )
     )
     min_train_screen_net_per_day = Decimal(
-        str(getattr(args, 'min_train_screen_net_per_day', '0') or '0')
+        str(getattr(args, "min_train_screen_net_per_day", "0") or "0")
     )
     min_train_screen_active_ratio = Decimal(
-        str(getattr(args, 'min_train_screen_active_ratio', '0.50') or '0.50')
+        str(getattr(args, "min_train_screen_active_ratio", "0.50") or "0.50")
     )
     expected_last_trading_day = (
         date.fromisoformat(str(args.expected_last_trading_day))
-        if str(args.expected_last_trading_day or '').strip()
-        else (full_window_end if str(args.full_window_end_date or '').strip() else None)
+        if str(args.expected_last_trading_day or "").strip()
+        else (full_window_end if str(args.full_window_end_date or "").strip() else None)
     )
     dataset_snapshot_receipt = build_dataset_snapshot_receipt(
         clickhouse_http_url=str(args.clickhouse_http_url),
@@ -1448,12 +1608,12 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
         trading_day_count=len(window.train_days) + len(window.holdout_days),
     )
     collect_train_gate_diagnostics = bool(
-        getattr(args, 'collect_train_gate_diagnostics', False)
+        getattr(args, "collect_train_gate_diagnostics", False)
     )
 
     symbols = tuple(
         symbol.strip().upper()
-        for symbol in str(args.symbols or '').split(',')
+        for symbol in str(args.symbols or "").split(",")
         if symbol.strip()
     )
     override_candidates = _iter_strategy_override_candidates(
@@ -1467,7 +1627,9 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
     )
     scored: list[dict[str, Any]] = []
 
-    with tempfile.TemporaryDirectory(prefix='torghut-consistent-profitability-frontier-') as tmpdir:
+    with tempfile.TemporaryDirectory(
+        prefix="torghut-consistent-profitability-frontier-"
+    ) as tmpdir:
         root = Path(tmpdir)
         cached_rows: list[Any] | None = None
         if args.prefetch_full_window_rows:
@@ -1495,7 +1657,11 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
         ] = deque()
         seen_candidate_keys: set[str] = set()
         cache_context: contextlib.AbstractContextManager[None]
-        cache_context = _cached_signal_rows_patch(cached_rows) if cached_rows is not None else contextlib.nullcontext()
+        cache_context = (
+            _cached_signal_rows_patch(cached_rows)
+            if cached_rows is not None
+            else contextlib.nullcontext()
+        )
         with cache_context:
             budget_exhausted = False
             while True:
@@ -1509,7 +1675,13 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
                 if candidate_budget > 0 and len(scored) >= candidate_budget:
                     budget_exhausted = True
                     break
-                params_candidate, override_candidate, prune_iteration, pruned_symbol, parent_candidate_id = worklist.popleft()
+                (
+                    params_candidate,
+                    override_candidate,
+                    prune_iteration,
+                    pruned_symbol,
+                    parent_candidate_id,
+                ) = worklist.popleft()
                 candidate_key = _candidate_search_key(
                     params_candidate=params_candidate,
                     strategy_overrides=override_candidate,
@@ -1529,24 +1701,30 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
                     strategy_overrides=override_candidate,
                     disable_other_strategies=disable_other_strategies,
                 )
-                candidate_configmap_path = root / f'candidate-{candidate_index:04d}.yaml'
+                candidate_configmap_path = (
+                    root / f"candidate-{candidate_index:04d}.yaml"
+                )
                 candidate_configmap_path.write_text(
                     yaml.safe_dump(candidate_configmap, sort_keys=False),
-                    encoding='utf-8',
+                    encoding="utf-8",
                 )
 
                 train_payload = run_replay(
                     _build_replay_config(
                         strategy_configmap_path=candidate_configmap_path,
                         clickhouse_http_url=str(args.clickhouse_http_url),
-                        clickhouse_username=(str(args.clickhouse_username).strip() or None),
+                        clickhouse_username=(
+                            str(args.clickhouse_username).strip() or None
+                        ),
                         clickhouse_password=clickhouse_password,
                         start_date=window.train_start,
                         end_date=window.train_end,
                         start_equity=Decimal(str(args.start_equity)),
                         chunk_minutes=max(1, int(args.chunk_minutes)),
                         symbols=candidate_symbols,
-                        progress_log_interval_seconds=max(1, int(args.progress_log_seconds)),
+                        progress_log_interval_seconds=max(
+                            1, int(args.progress_log_seconds)
+                        ),
                         capture_trace_funnel=collect_train_gate_diagnostics,
                     )
                 )
@@ -1559,7 +1737,7 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
                         min_train_active_ratio=min_train_screen_active_ratio,
                         max_train_worst_day_loss=max_train_screen_worst_day_loss,
                     )
-                    if bool(getattr(args, 'train_screening', True))
+                    if bool(getattr(args, "train_screening", True))
                     else []
                 )
                 holdout_replay_skipped = bool(train_screen_failures)
@@ -1575,28 +1753,36 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
                         _build_replay_config(
                             strategy_configmap_path=candidate_configmap_path,
                             clickhouse_http_url=str(args.clickhouse_http_url),
-                            clickhouse_username=(str(args.clickhouse_username).strip() or None),
+                            clickhouse_username=(
+                                str(args.clickhouse_username).strip() or None
+                            ),
                             clickhouse_password=clickhouse_password,
                             start_date=window.holdout_start,
                             end_date=window.holdout_end,
                             start_equity=Decimal(str(args.start_equity)),
                             chunk_minutes=max(1, int(args.chunk_minutes)),
                             symbols=candidate_symbols,
-                            progress_log_interval_seconds=max(1, int(args.progress_log_seconds)),
+                            progress_log_interval_seconds=max(
+                                1, int(args.progress_log_seconds)
+                            ),
                         )
                     )
                     full_window_payload = run_replay(
                         _build_replay_config(
                             strategy_configmap_path=candidate_configmap_path,
                             clickhouse_http_url=str(args.clickhouse_http_url),
-                            clickhouse_username=(str(args.clickhouse_username).strip() or None),
+                            clickhouse_username=(
+                                str(args.clickhouse_username).strip() or None
+                            ),
                             clickhouse_password=clickhouse_password,
                             start_date=full_window_start,
                             end_date=full_window_end,
                             start_equity=Decimal(str(args.start_equity)),
                             chunk_minutes=max(1, int(args.chunk_minutes)),
                             symbols=candidate_symbols,
-                            progress_log_interval_seconds=max(1, int(args.progress_log_seconds)),
+                            progress_log_interval_seconds=max(
+                                1, int(args.progress_log_seconds)
+                            ),
                         )
                     )
 
@@ -1604,15 +1790,15 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
                     family=family,
                     strategy_name=strategy_name,
                     replay_config={
-                        'candidate_index': candidate_index,
-                        'params': params_candidate,
-                        'strategy_overrides': override_candidate,
-                        'train_start_date': window.train_start.isoformat(),
-                        'train_end_date': window.train_end.isoformat(),
-                        'holdout_start_date': window.holdout_start.isoformat(),
-                        'holdout_end_date': window.holdout_end.isoformat(),
-                        'full_window_start_date': full_window_start.isoformat(),
-                        'full_window_end_date': full_window_end.isoformat(),
+                        "candidate_index": candidate_index,
+                        "params": params_candidate,
+                        "strategy_overrides": override_candidate,
+                        "train_start_date": window.train_start.isoformat(),
+                        "train_end_date": window.train_end.isoformat(),
+                        "holdout_start_date": window.holdout_start.isoformat(),
+                        "holdout_end_date": window.holdout_end.isoformat(),
+                        "full_window_start_date": full_window_start.isoformat(),
+                        "full_window_end_date": full_window_end.isoformat(),
                     },
                     train_payload=train_payload,
                     holdout_payload=holdout_payload,
@@ -1622,35 +1808,41 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
                     full_window_payload=full_window_payload,
                     policy=consistency_policy,
                 )
-                adjusted_score = base_result.score + Decimal(full_window_summary['net_per_day']) - consistency_penalty
+                adjusted_score = (
+                    base_result.score
+                    + Decimal(full_window_summary["net_per_day"])
+                    - consistency_penalty
+                )
                 candidate_payload = base_result.to_payload()
-                candidate_payload['full_window'] = full_window_summary
-                candidate_payload['consistency_penalty'] = str(consistency_penalty)
-                candidate_payload['adjusted_score'] = str(adjusted_score)
-                candidate_payload['search_iteration'] = prune_iteration
-                candidate_payload['family_template_id'] = family_template.family_id
-                candidate_payload['dataset_snapshot_id'] = dataset_snapshot_receipt.snapshot_id
-                candidate_payload['screening'] = {
-                    'schema_version': 'torghut.frontier-train-screen.v1',
-                    'enabled': bool(getattr(args, 'train_screening', True)),
-                    'status': 'rejected'
-                    if train_screen_failures
-                    else 'passed',
-                    'stage': 'train',
-                    'reasons': train_screen_failures,
-                    'min_train_net_per_day': str(min_train_screen_net_per_day),
-                    'min_train_active_ratio': str(min_train_screen_active_ratio),
-                    'max_train_worst_day_loss': str(max_train_screen_worst_day_loss),
-                    'holdout_replay_skipped': holdout_replay_skipped,
-                    'full_window_replay_skipped': full_window_replay_skipped,
+                candidate_payload["full_window"] = full_window_summary
+                candidate_payload["consistency_penalty"] = str(consistency_penalty)
+                candidate_payload["adjusted_score"] = str(adjusted_score)
+                candidate_payload["search_iteration"] = prune_iteration
+                candidate_payload["family_template_id"] = family_template.family_id
+                candidate_payload["dataset_snapshot_id"] = (
+                    dataset_snapshot_receipt.snapshot_id
+                )
+                candidate_payload["screening"] = {
+                    "schema_version": "torghut.frontier-train-screen.v1",
+                    "enabled": bool(getattr(args, "train_screening", True)),
+                    "status": "rejected" if train_screen_failures else "passed",
+                    "stage": "train",
+                    "reasons": train_screen_failures,
+                    "min_train_net_per_day": str(min_train_screen_net_per_day),
+                    "min_train_active_ratio": str(min_train_screen_active_ratio),
+                    "max_train_worst_day_loss": str(max_train_screen_worst_day_loss),
+                    "holdout_replay_skipped": holdout_replay_skipped,
+                    "full_window_replay_skipped": full_window_replay_skipped,
                 }
                 if pruned_symbol is not None:
-                    candidate_payload['pruned_symbol'] = pruned_symbol
+                    candidate_payload["pruned_symbol"] = pruned_symbol
                 if parent_candidate_id is not None:
-                    candidate_payload['parent_candidate_id'] = parent_candidate_id
-                symbol_contributions = _symbol_contributions_from_replay_payload(full_window_payload)
+                    candidate_payload["parent_candidate_id"] = parent_candidate_id
+                symbol_contributions = _symbol_contributions_from_replay_payload(
+                    full_window_payload
+                )
                 if symbol_contributions:
-                    candidate_payload['symbol_contributions'] = symbol_contributions
+                    candidate_payload["symbol_contributions"] = symbol_contributions
                 normalization_regime = _selected_normalization_regime(
                     strategy_overrides=override_candidate,
                     template_allowed_normalizations=family_template.allowed_normalizations,
@@ -1663,12 +1855,16 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
                 summary = summarize_replay_profitability(full_window_payload)
                 total_filled_notional = sum(
                     _daily_filled_notional(full_window_payload).values(),
-                    Decimal('0'),
+                    Decimal("0"),
                 )
-                positive_days = sum(1 for value in summary.daily_net.values() if value > 0)
-                negative_days = sum(1 for value in summary.daily_net.values() if value < 0)
+                positive_days = sum(
+                    1 for value in summary.daily_net.values() if value > 0
+                )
+                negative_days = sum(
+                    1 for value in summary.daily_net.values() if value < 0
+                )
                 objective_scorecard = build_scorecard(
-                    candidate_id=str(candidate_payload['candidate_id']),
+                    candidate_id=str(candidate_payload["candidate_id"]),
                     trading_day_count=summary.trading_day_count,
                     net_pnl_per_day=summary.net_per_day,
                     active_days=summary.active_days,
@@ -1676,71 +1872,102 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
                     avg_filled_notional_per_day=(
                         total_filled_notional / Decimal(summary.trading_day_count)
                         if summary.trading_day_count > 0
-                        else Decimal('0')
+                        else Decimal("0")
                     ),
                     avg_filled_notional_per_active_day=(
                         total_filled_notional / Decimal(summary.active_days)
                         if summary.active_days > 0
-                        else Decimal('0')
+                        else Decimal("0")
                     ),
-                    worst_day_loss=abs(summary.worst_day_net) if summary.worst_day_net < 0 else Decimal('0'),
+                    worst_day_loss=abs(summary.worst_day_net)
+                    if summary.worst_day_net < 0
+                    else Decimal("0"),
                     max_drawdown=_max_drawdown_from_daily_net(summary.daily_net),
                     best_day_share=_max_best_day_share_of_total_pnl(
                         daily_net=summary.daily_net,
                         total_net_pnl=summary.net_pnl,
                     ),
                     negative_day_count=negative_days,
-                    rolling_3d_lower_bound=_rolling_lower_bound(summary.daily_net, window=3),
-                    rolling_5d_lower_bound=_rolling_lower_bound(summary.daily_net, window=5),
-                    regime_slice_pass_rate=regime_slice_pass_rate(decomposition),
-                    symbol_concentration_share=max_symbol_concentration_share(decomposition),
-                    entry_family_contribution_share=max_family_contribution_share(decomposition),
-                    max_gross_exposure_pct_equity=Decimal(
-                        str(full_window_summary.get('max_gross_exposure_pct_equity', '0'))
+                    rolling_3d_lower_bound=_rolling_lower_bound(
+                        summary.daily_net, window=3
                     ),
-                    min_cash=Decimal(str(full_window_summary.get('min_cash', '0'))),
+                    rolling_5d_lower_bound=_rolling_lower_bound(
+                        summary.daily_net, window=5
+                    ),
+                    regime_slice_pass_rate=regime_slice_pass_rate(decomposition),
+                    symbol_concentration_share=max_symbol_concentration_share(
+                        decomposition
+                    ),
+                    entry_family_contribution_share=max_family_contribution_share(
+                        decomposition
+                    ),
+                    max_gross_exposure_pct_equity=Decimal(
+                        str(
+                            full_window_summary.get(
+                                "max_gross_exposure_pct_equity", "0"
+                            )
+                        )
+                    ),
+                    min_cash=Decimal(str(full_window_summary.get("min_cash", "0"))),
                     negative_cash_observation_count=int(
-                        full_window_summary.get('negative_cash_observation_count') or 0
+                        full_window_summary.get("negative_cash_observation_count") or 0
                     ),
                 )
                 hard_vetoes = list(
                     evaluate_vetoes(
                         objective_scorecard,
                         policy=objective_veto_policy,
-                        is_fresh=(dataset_snapshot_receipt.is_fresh or bool(args.allow_stale_tape)),
+                        is_fresh=(
+                            dataset_snapshot_receipt.is_fresh
+                            or bool(args.allow_stale_tape)
+                        ),
                     )
                 )
                 hard_vetoes.extend(train_screen_failures)
                 if (
                     consistency_policy.min_daily_net_pnl > 0
-                    and int(full_window_summary.get('daily_net_below_min_count') or 0) > 0
+                    and int(full_window_summary.get("daily_net_below_min_count") or 0)
+                    > 0
                 ):
-                    hard_vetoes.append('daily_net_below_min')
-                if objective_scorecard.symbol_concentration_share > consistency_policy.max_symbol_concentration_share:
-                    hard_vetoes.append('symbol_concentration_above_max')
-                if objective_scorecard.entry_family_contribution_share > consistency_policy.max_entry_family_contribution_share:
-                    hard_vetoes.append('entry_family_contribution_above_max')
-                candidate_payload['decomposition'] = decomposition.to_payload()
-                candidate_payload['normalization_regime'] = normalization_regime
-                candidate_payload['objective_scorecard'] = objective_scorecard.to_payload()
-                candidate_payload['hard_vetoes'] = sorted(dict.fromkeys(hard_vetoes))
+                    hard_vetoes.append("daily_net_below_min")
+                if (
+                    objective_scorecard.symbol_concentration_share
+                    > consistency_policy.max_symbol_concentration_share
+                ):
+                    hard_vetoes.append("symbol_concentration_above_max")
+                if (
+                    objective_scorecard.entry_family_contribution_share
+                    > consistency_policy.max_entry_family_contribution_share
+                ):
+                    hard_vetoes.append("entry_family_contribution_above_max")
+                candidate_payload["decomposition"] = decomposition.to_payload()
+                candidate_payload["normalization_regime"] = normalization_regime
+                candidate_payload["objective_scorecard"] = (
+                    objective_scorecard.to_payload()
+                )
+                candidate_payload["hard_vetoes"] = sorted(dict.fromkeys(hard_vetoes))
                 if collect_train_gate_diagnostics:
-                    candidate_payload['train_gate_diagnostics'] = (
+                    candidate_payload["train_gate_diagnostics"] = (
                         _train_gate_diagnostics_from_replay_payload(train_payload)
                     )
                 if cached_rows is not None:
-                    candidate_payload['prefetched_row_count'] = len(cached_rows)
-                    candidate_payload['prefetched_symbols'] = list(prefetch_symbols)
+                    candidate_payload["prefetched_row_count"] = len(cached_rows)
+                    candidate_payload["prefetched_symbols"] = list(prefetch_symbols)
                 scored.append(candidate_payload)
                 if prune_iteration < max(0, int(args.symbol_prune_iterations)):
-                    for removed_symbol, next_override in _generate_symbol_prune_children(
+                    for (
+                        removed_symbol,
+                        next_override,
+                    ) in _generate_symbol_prune_children(
                         cli_symbols=symbols,
                         strategy_overrides=override_candidate,
                         configmap_payload=base_configmap,
                         strategy_name=strategy_name,
                         symbol_contributions=symbol_contributions,
                         branch_count=max(1, int(args.symbol_prune_candidates)),
-                        min_universe_size=max(1, int(args.symbol_prune_min_universe_size)),
+                        min_universe_size=max(
+                            1, int(args.symbol_prune_min_universe_size)
+                        ),
                     ):
                         worklist.append(
                             (
@@ -1748,7 +1975,7 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
                                 next_override,
                                 prune_iteration + 1,
                                 removed_symbol,
-                                str(candidate_payload['candidate_id']),
+                                str(candidate_payload["candidate_id"]),
                             )
                         )
                 if args.json_output is not None:
@@ -1765,7 +1992,7 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
                         consistency_policy=consistency_policy,
                         objective_veto_policy=objective_veto_policy,
                         top_n=max(1, int(args.top_n)),
-                        status='running',
+                        status="running",
                         pending_candidates=len(worklist)
                         + (0 if initial_candidates_exhausted else 1),
                     )
@@ -1784,9 +2011,9 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
         consistency_policy=consistency_policy,
         objective_veto_policy=objective_veto_policy,
         top_n=max(1, int(args.top_n)),
-        status='candidate_budget_exhausted'
+        status="candidate_budget_exhausted"
         if budget_exhausted and (worklist or not initial_candidates_exhausted)
-        else 'completed',
+        else "completed",
         pending_candidates=len(worklist) + (0 if initial_candidates_exhausted else 1),
     )
     if args.json_output is not None:
@@ -1811,5 +2038,5 @@ def cli_main() -> int:
         return 1
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     raise SystemExit(cli_main())

--- a/services/torghut/scripts/search_profitability_frontier.py
+++ b/services/torghut/scripts/search_profitability_frontier.py
@@ -23,8 +23,9 @@ from app.trading.reporting import (
 )
 from scripts.local_intraday_tsmom_replay import ReplayConfig, _http_query, run_replay
 
-_SWEEP_SCHEMA_VERSION = 'torghut.replay-frontier-sweep.v1'
-_REPLAY_SIGNAL_TABLE = 'torghut.ta_signals'
+_SWEEP_SCHEMA_VERSION = "torghut.replay-frontier-sweep.v1"
+_REPLAY_SIGNAL_TABLE = "torghut.ta_signals"
+_LOCAL_ONLY_STRATEGY_OVERRIDE_KEYS = frozenset({"normalization_regime"})
 
 
 @dataclass(frozen=True)
@@ -51,47 +52,47 @@ class SweepWindow:
 
 def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description='Search profitability frontier candidates using the local Torghut replay.',
+        description="Search profitability frontier candidates using the local Torghut replay.",
     )
     parser.add_argument(
-        '--strategy-configmap',
+        "--strategy-configmap",
         type=Path,
-        default=Path('argocd/applications/torghut/strategy-configmap.yaml'),
+        default=Path("argocd/applications/torghut/strategy-configmap.yaml"),
     )
     parser.add_argument(
-        '--sweep-config',
+        "--sweep-config",
         type=Path,
-        default=Path('config/trading/profitability-frontier-breakout.yaml'),
+        default=Path("config/trading/profitability-frontier-breakout.yaml"),
     )
     parser.add_argument(
-        '--clickhouse-http-url',
+        "--clickhouse-http-url",
         default=os.environ.get(
-            'TA_CLICKHOUSE_URL',
-            'http://torghut-clickhouse.torghut.svc.cluster.local:8123',
+            "TA_CLICKHOUSE_URL",
+            "http://torghut-clickhouse.torghut.svc.cluster.local:8123",
         ),
     )
     parser.add_argument(
-        '--clickhouse-username',
+        "--clickhouse-username",
         default=os.environ.get(
-            'TA_CLICKHOUSE_USERNAME',
-            os.environ.get('CLICKHOUSE_USERNAME', 'torghut'),
+            "TA_CLICKHOUSE_USERNAME",
+            os.environ.get("CLICKHOUSE_USERNAME", "torghut"),
         ),
     )
     parser.add_argument(
-        '--clickhouse-password',
+        "--clickhouse-password",
         default=os.environ.get(
-            'TA_CLICKHOUSE_PASSWORD',
-            os.environ.get('CLICKHOUSE_PASSWORD', ''),
+            "TA_CLICKHOUSE_PASSWORD",
+            os.environ.get("CLICKHOUSE_PASSWORD", ""),
         ),
     )
-    parser.add_argument('--start-equity', default='31590.02')
-    parser.add_argument('--chunk-minutes', type=int, default=10)
-    parser.add_argument('--symbols', default='')
-    parser.add_argument('--progress-log-seconds', type=int, default=30)
-    parser.add_argument('--train-days', type=int, default=10)
-    parser.add_argument('--holdout-days', type=int, default=5)
-    parser.add_argument('--top-n', type=int, default=10)
-    parser.add_argument('--json-output', type=Path)
+    parser.add_argument("--start-equity", default="31590.02")
+    parser.add_argument("--chunk-minutes", type=int, default=10)
+    parser.add_argument("--symbols", default="")
+    parser.add_argument("--progress-log-seconds", type=int, default=30)
+    parser.add_argument("--train-days", type=int, default=10)
+    parser.add_argument("--holdout-days", type=int, default=5)
+    parser.add_argument("--top-n", type=int, default=10)
+    parser.add_argument("--json-output", type=Path)
     return parser.parse_args()
 
 
@@ -107,19 +108,17 @@ def _resolve_recent_trading_days(
         username=clickhouse_username,
         password=clickhouse_password,
         query=(
-            'SELECT DISTINCT toDate(event_ts) AS trading_day '
-            f'FROM {_REPLAY_SIGNAL_TABLE} '
+            "SELECT DISTINCT toDate(event_ts) AS trading_day "
+            f"FROM {_REPLAY_SIGNAL_TABLE} "
             "WHERE source = 'ta' "
             "  AND window_size = 'PT1S' "
-            'ORDER BY trading_day DESC '
-            f'LIMIT {max(1, int(limit))} '
-            'FORMAT TSVRaw'
+            "ORDER BY trading_day DESC "
+            f"LIMIT {max(1, int(limit))} "
+            "FORMAT TSVRaw"
         ),
     )
     values = [
-        date.fromisoformat(line.strip())
-        for line in raw.splitlines()
-        if line.strip()
+        date.fromisoformat(line.strip()) for line in raw.splitlines() if line.strip()
     ]
     values.sort()
     return tuple(values)
@@ -134,7 +133,7 @@ def resolve_sweep_window(
     ordered = sorted(dict.fromkeys(recent_days))
     required = max(1, train_days) + max(1, holdout_days)
     if len(ordered) < required:
-        raise ValueError(f'insufficient_recent_trading_days:{len(ordered)}<{required}')
+        raise ValueError(f"insufficient_recent_trading_days:{len(ordered)}<{required}")
     selected = ordered[-required:]
     return SweepWindow(
         train_days=tuple(selected[:train_days]),
@@ -143,12 +142,12 @@ def resolve_sweep_window(
 
 
 def _load_sweep_config(path: Path) -> dict[str, Any]:
-    payload = yaml.safe_load(path.read_text(encoding='utf-8'))
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
     if not isinstance(payload, dict):
-        raise ValueError('sweep_config_not_mapping')
-    schema_version = str(payload.get('schema_version') or '').strip()
+        raise ValueError("sweep_config_not_mapping")
+    schema_version = str(payload.get("schema_version") or "").strip()
     if schema_version != _SWEEP_SCHEMA_VERSION:
-        raise ValueError(f'sweep_config_schema_version_invalid:{schema_version}')
+        raise ValueError(f"sweep_config_schema_version_invalid:{schema_version}")
     return payload
 
 
@@ -158,11 +157,11 @@ def iter_parameter_candidates(
     items = []
     for key, values in parameter_grid.items():
         if isinstance(values, (str, bytes)):
-            raise ValueError(f'parameter_values_not_sequence:{key}')
+            raise ValueError(f"parameter_values_not_sequence:{key}")
         if isinstance(values, Mapping):
-            raise ValueError(f'parameter_values_not_sequence:{key}')
+            raise ValueError(f"parameter_values_not_sequence:{key}")
         if not isinstance(values, Iterable):
-            raise ValueError(f'parameter_values_not_iterable:{key}')
+            raise ValueError(f"parameter_values_not_iterable:{key}")
         value_list = list(values)
         items.append((str(key), value_list))
     if not items:
@@ -171,25 +170,29 @@ def iter_parameter_candidates(
     value_sets = [values for _, values in items]
     candidates: list[dict[str, Any]] = []
     for combination in itertools.product(*value_sets):
-        candidates.append({name: value for name, value in zip(names, combination, strict=True)})
+        candidates.append(
+            {name: value for name, value in zip(names, combination, strict=True)}
+        )
     return candidates
 
 
-def _coerce_strategy_configmap_payload(configmap_payload: Mapping[str, Any]) -> dict[str, Any]:
+def _coerce_strategy_configmap_payload(
+    configmap_payload: Mapping[str, Any],
+) -> dict[str, Any]:
     root = json.loads(json.dumps(configmap_payload))
     if not isinstance(root, dict):
-        raise ValueError('strategy_configmap_not_mapping')
-    data = root.get('data')
+        raise ValueError("strategy_configmap_not_mapping")
+    data = root.get("data")
     if isinstance(data, dict):
         return root
-    if isinstance(root.get('strategies'), list):
+    if isinstance(root.get("strategies"), list):
         return {
-            'apiVersion': 'v1',
-            'kind': 'ConfigMap',
-            'metadata': {'name': 'mounted-strategy-catalog'},
-            'data': {'strategies.yaml': yaml.safe_dump(root, sort_keys=False)},
+            "apiVersion": "v1",
+            "kind": "ConfigMap",
+            "metadata": {"name": "mounted-strategy-catalog"},
+            "data": {"strategies.yaml": yaml.safe_dump(root, sort_keys=False)},
         }
-    raise ValueError('strategy_configmap_missing_data')
+    raise ValueError("strategy_configmap_missing_data")
 
 
 def apply_candidate_to_configmap(
@@ -198,40 +201,51 @@ def apply_candidate_to_configmap(
     strategy_name: str,
     candidate_params: Mapping[str, Any],
     disable_other_strategies: bool,
+    strategy_overrides: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
+    candidate_params = dict(candidate_params)
+    strategy_overrides = dict(strategy_overrides or {})
+    if disable_other_strategies:
+        candidate_params.setdefault("position_isolation_mode", "per_strategy")
     root = _coerce_strategy_configmap_payload(configmap_payload)
-    data = root.get('data')
+    data = root.get("data")
     if not isinstance(data, dict):
-        raise ValueError('strategy_configmap_missing_data')
-    strategies_yaml = data.get('strategies.yaml')
+        raise ValueError("strategy_configmap_missing_data")
+    strategies_yaml = data.get("strategies.yaml")
     if not isinstance(strategies_yaml, str):
-        raise ValueError('strategy_configmap_missing_strategies_yaml')
+        raise ValueError("strategy_configmap_missing_strategies_yaml")
     catalog = yaml.safe_load(strategies_yaml)
     if not isinstance(catalog, dict):
-        raise ValueError('strategy_catalog_not_mapping')
-    strategies = catalog.get('strategies')
+        raise ValueError("strategy_catalog_not_mapping")
+    strategies = catalog.get("strategies")
     if not isinstance(strategies, list):
-        raise ValueError('strategy_catalog_missing_strategies')
+        raise ValueError("strategy_catalog_missing_strategies")
 
     matched = False
     for item in strategies:
         if not isinstance(item, dict):
             continue
-        item_name = str(item.get('name') or '').strip()
+        item_name = str(item.get("name") or "").strip()
         if item_name == strategy_name:
-            params = item.setdefault('params', {})
+            params = item.setdefault("params", {})
             if not isinstance(params, dict):
                 params = {}
-                item['params'] = params
+                item["params"] = params
             params.update(dict(candidate_params))
-            item['enabled'] = True
+            for key, value in strategy_overrides.items():
+                if key == "params":
+                    raise ValueError("strategy_override_key_reserved:params")
+                if key in _LOCAL_ONLY_STRATEGY_OVERRIDE_KEYS:
+                    continue
+                item[key] = value
+            item["enabled"] = True
             matched = True
         elif disable_other_strategies:
-            item['enabled'] = False
+            item["enabled"] = False
     if not matched:
-        raise ValueError(f'strategy_not_found:{strategy_name}')
+        raise ValueError(f"strategy_not_found:{strategy_name}")
 
-    data['strategies.yaml'] = yaml.safe_dump(catalog, sort_keys=False)
+    data["strategies.yaml"] = yaml.safe_dump(catalog, sort_keys=False)
     return root
 
 
@@ -262,6 +276,7 @@ def _build_replay_config(
         symbols=symbols,
         progress_log_interval_seconds=progress_log_interval_seconds,
         capture_trace_funnel=capture_trace_funnel,
+        force_position_isolation=True,
     )
 
 
@@ -280,126 +295,171 @@ def main() -> int:
         holdout_days=max(1, int(args.holdout_days)),
     )
 
-    base_configmap = yaml.safe_load(args.strategy_configmap.resolve().read_text(encoding='utf-8'))
+    base_configmap = yaml.safe_load(
+        args.strategy_configmap.resolve().read_text(encoding="utf-8")
+    )
     if not isinstance(base_configmap, dict):
-        raise ValueError('base_strategy_configmap_not_mapping')
+        raise ValueError("base_strategy_configmap_not_mapping")
 
-    family = str(sweep_config.get('family') or '').strip()
-    strategy_name = str(sweep_config.get('strategy_name') or '').strip()
+    family = str(sweep_config.get("family") or "").strip()
+    strategy_name = str(sweep_config.get("strategy_name") or "").strip()
     if not family or not strategy_name:
-        raise ValueError('sweep_config_missing_family_or_strategy_name')
-    disable_other_strategies = bool(sweep_config.get('disable_other_strategies', True))
-    parameter_grid = sweep_config.get('parameters')
+        raise ValueError("sweep_config_missing_family_or_strategy_name")
+    disable_other_strategies = bool(sweep_config.get("disable_other_strategies", True))
+    parameter_grid = sweep_config.get("parameters")
     if not isinstance(parameter_grid, Mapping):
-        raise ValueError('sweep_config_parameters_not_mapping')
+        raise ValueError("sweep_config_parameters_not_mapping")
+    strategy_override_grid = sweep_config.get("strategy_overrides") or {}
+    if not isinstance(strategy_override_grid, Mapping):
+        raise ValueError("sweep_config_strategy_overrides_not_mapping")
+    strategy_override_candidates = (
+        tuple(iter_parameter_candidates(strategy_override_grid))
+        if strategy_override_grid
+        else ({},)
+    )
 
-    constraints_value = sweep_config.get('constraints')
+    constraints_value = sweep_config.get("constraints")
     if constraints_value is None:
         constraints: Mapping[str, Any] = {}
     elif isinstance(constraints_value, Mapping):
         constraints = cast(Mapping[str, Any], constraints_value)
     else:
-        raise ValueError('sweep_config_constraints_not_mapping')
+        raise ValueError("sweep_config_constraints_not_mapping")
     policy = ProfitabilityConstraintPolicy(
-        holdout_target_net_per_day=Decimal(str(constraints.get('holdout_target_net_per_day', '250'))),
-        min_active_holdout_days=int(constraints.get('min_active_holdout_days', 3)),
-        max_worst_holdout_day_loss=Decimal(str(constraints.get('max_worst_holdout_day_loss', '150'))),
-        min_profit_factor=Decimal(str(constraints.get('min_profit_factor', '1.5'))),
-        require_training_decisions=bool(constraints.get('require_training_decisions', True)),
-        require_holdout_decisions=bool(constraints.get('require_holdout_decisions', True)),
+        holdout_target_net_per_day=Decimal(
+            str(constraints.get("holdout_target_net_per_day", "250"))
+        ),
+        min_active_holdout_days=int(constraints.get("min_active_holdout_days", 3)),
+        max_worst_holdout_day_loss=Decimal(
+            str(constraints.get("max_worst_holdout_day_loss", "150"))
+        ),
+        min_profit_factor=Decimal(str(constraints.get("min_profit_factor", "1.5"))),
+        require_training_decisions=bool(
+            constraints.get("require_training_decisions", True)
+        ),
+        require_holdout_decisions=bool(
+            constraints.get("require_holdout_decisions", True)
+        ),
     )
     symbols = tuple(
         symbol.strip().upper()
-        for symbol in str(args.symbols or '').split(',')
+        for symbol in str(args.symbols or "").split(",")
         if symbol.strip()
     )
-    candidates = iter_parameter_candidates(parameter_grid)
     scored = []
 
-    with tempfile.TemporaryDirectory(prefix='torghut-profitability-frontier-') as tmpdir:
+    with tempfile.TemporaryDirectory(
+        prefix="torghut-profitability-frontier-"
+    ) as tmpdir:
         root = Path(tmpdir)
-        for index, candidate in enumerate(candidates, start=1):
-            candidate_configmap = apply_candidate_to_configmap(
-                configmap_payload=base_configmap,
-                strategy_name=strategy_name,
-                candidate_params=candidate,
-                disable_other_strategies=disable_other_strategies,
-            )
-            candidate_configmap_path = root / f'candidate-{index:04d}.yaml'
-            candidate_configmap_path.write_text(
-                yaml.safe_dump(candidate_configmap, sort_keys=False),
-                encoding='utf-8',
-            )
-
-            train_payload = run_replay(
-                _build_replay_config(
-                    strategy_configmap_path=candidate_configmap_path,
-                    clickhouse_http_url=str(args.clickhouse_http_url),
-                    clickhouse_username=(str(args.clickhouse_username).strip() or None),
-                    clickhouse_password=(str(args.clickhouse_password).strip() or None),
-                    start_date=window.train_start,
-                    end_date=window.train_end,
-                    start_equity=Decimal(str(args.start_equity)),
-                    chunk_minutes=max(1, int(args.chunk_minutes)),
-                    symbols=symbols,
-                    progress_log_interval_seconds=max(1, int(args.progress_log_seconds)),
-                )
-            )
-            holdout_payload = run_replay(
-                _build_replay_config(
-                    strategy_configmap_path=candidate_configmap_path,
-                    clickhouse_http_url=str(args.clickhouse_http_url),
-                    clickhouse_username=(str(args.clickhouse_username).strip() or None),
-                    clickhouse_password=(str(args.clickhouse_password).strip() or None),
-                    start_date=window.holdout_start,
-                    end_date=window.holdout_end,
-                    start_equity=Decimal(str(args.start_equity)),
-                    chunk_minutes=max(1, int(args.chunk_minutes)),
-                    symbols=symbols,
-                    progress_log_interval_seconds=max(1, int(args.progress_log_seconds)),
-                )
-            )
-            scored.append(
-                score_replay_profitability_candidate(
-                    family=family,
+        index = 0
+        for candidate in iter_parameter_candidates(parameter_grid):
+            for strategy_overrides in strategy_override_candidates:
+                index += 1
+                candidate_configmap = apply_candidate_to_configmap(
+                    configmap_payload=base_configmap,
                     strategy_name=strategy_name,
-                    replay_config={
-                        'candidate_index': index,
-                        'params': candidate,
-                        'train_start_date': window.train_start.isoformat(),
-                        'train_end_date': window.train_end.isoformat(),
-                        'holdout_start_date': window.holdout_start.isoformat(),
-                        'holdout_end_date': window.holdout_end.isoformat(),
-                    },
-                    train_payload=train_payload,
-                    holdout_payload=holdout_payload,
-                    policy=policy,
+                    candidate_params=candidate,
+                    disable_other_strategies=disable_other_strategies,
+                    strategy_overrides=strategy_overrides,
                 )
-            )
+                candidate_configmap_path = root / f"candidate-{index:04d}.yaml"
+                candidate_configmap_path.write_text(
+                    yaml.safe_dump(candidate_configmap, sort_keys=False),
+                    encoding="utf-8",
+                )
 
-    scored.sort(key=lambda item: (item.score, item.holdout_net_per_day, item.profit_factor or Decimal('-1')), reverse=True)
+                train_payload = run_replay(
+                    _build_replay_config(
+                        strategy_configmap_path=candidate_configmap_path,
+                        clickhouse_http_url=str(args.clickhouse_http_url),
+                        clickhouse_username=(
+                            str(args.clickhouse_username).strip() or None
+                        ),
+                        clickhouse_password=(
+                            str(args.clickhouse_password).strip() or None
+                        ),
+                        start_date=window.train_start,
+                        end_date=window.train_end,
+                        start_equity=Decimal(str(args.start_equity)),
+                        chunk_minutes=max(1, int(args.chunk_minutes)),
+                        symbols=symbols,
+                        progress_log_interval_seconds=max(
+                            1, int(args.progress_log_seconds)
+                        ),
+                    )
+                )
+                holdout_payload = run_replay(
+                    _build_replay_config(
+                        strategy_configmap_path=candidate_configmap_path,
+                        clickhouse_http_url=str(args.clickhouse_http_url),
+                        clickhouse_username=(
+                            str(args.clickhouse_username).strip() or None
+                        ),
+                        clickhouse_password=(
+                            str(args.clickhouse_password).strip() or None
+                        ),
+                        start_date=window.holdout_start,
+                        end_date=window.holdout_end,
+                        start_equity=Decimal(str(args.start_equity)),
+                        chunk_minutes=max(1, int(args.chunk_minutes)),
+                        symbols=symbols,
+                        progress_log_interval_seconds=max(
+                            1, int(args.progress_log_seconds)
+                        ),
+                    )
+                )
+                scored.append(
+                    score_replay_profitability_candidate(
+                        family=family,
+                        strategy_name=strategy_name,
+                        replay_config={
+                            "candidate_index": index,
+                            "params": candidate,
+                            "strategy_overrides": dict(strategy_overrides),
+                            "train_start_date": window.train_start.isoformat(),
+                            "train_end_date": window.train_end.isoformat(),
+                            "holdout_start_date": window.holdout_start.isoformat(),
+                            "holdout_end_date": window.holdout_end.isoformat(),
+                        },
+                        train_payload=train_payload,
+                        holdout_payload=holdout_payload,
+                        policy=policy,
+                    )
+                )
+
+    scored.sort(
+        key=lambda item: (
+            item.score,
+            item.holdout_net_per_day,
+            item.profit_factor or Decimal("-1"),
+        ),
+        reverse=True,
+    )
     payload = {
-        'schema_version': _SWEEP_SCHEMA_VERSION,
-        'family': family,
-        'strategy_name': strategy_name,
-        'window': {
-            'train_days': [item.isoformat() for item in window.train_days],
-            'holdout_days': [item.isoformat() for item in window.holdout_days],
+        "schema_version": _SWEEP_SCHEMA_VERSION,
+        "family": family,
+        "strategy_name": strategy_name,
+        "window": {
+            "train_days": [item.isoformat() for item in window.train_days],
+            "holdout_days": [item.isoformat() for item in window.holdout_days],
         },
-        'constraints': {
-            'holdout_target_net_per_day': str(policy.holdout_target_net_per_day),
-            'min_active_holdout_days': policy.min_active_holdout_days,
-            'max_worst_holdout_day_loss': str(policy.max_worst_holdout_day_loss),
-            'min_profit_factor': str(policy.min_profit_factor),
-            'require_training_decisions': policy.require_training_decisions,
-            'require_holdout_decisions': policy.require_holdout_decisions,
+        "constraints": {
+            "holdout_target_net_per_day": str(policy.holdout_target_net_per_day),
+            "min_active_holdout_days": policy.min_active_holdout_days,
+            "max_worst_holdout_day_loss": str(policy.max_worst_holdout_day_loss),
+            "min_profit_factor": str(policy.min_profit_factor),
+            "require_training_decisions": policy.require_training_decisions,
+            "require_holdout_decisions": policy.require_holdout_decisions,
         },
-        'candidate_count': len(scored),
-        'top': [item.to_payload() for item in scored[: max(1, int(args.top_n))]],
+        "candidate_count": len(scored),
+        "top": [item.to_payload() for item in scored[: max(1, int(args.top_n))]],
     }
 
     if args.json_output:
-        args.json_output.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding='utf-8')
+        args.json_output.write_text(
+            json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8"
+        )
     print(json.dumps(payload, indent=2, sort_keys=True))
     return 0
 
@@ -412,5 +472,5 @@ def cli_main() -> int:
         return 1
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     raise SystemExit(cli_main())

--- a/services/torghut/tests/test_candidate_specs.py
+++ b/services/torghut/tests/test_candidate_specs.py
@@ -124,6 +124,10 @@ class TestCandidateSpecs(TestCase):
             self.assertIn("long_stop_loss_bps", params)
             self.assertIn("long_trailing_stop_drawdown_bps", params)
             self.assertIn("max_session_negative_exit_bps", params)
+        self.assertEqual(
+            first[0].strategy_overrides["params"]["position_isolation_mode"],
+            "per_strategy",
+        )
         self.assertNotIn("live_runtime_config_path", first[0].to_payload())
         reloaded = candidate_spec_from_payload(first[0].to_payload())
         self.assertEqual(reloaded.candidate_spec_id, first[0].candidate_spec_id)
@@ -219,6 +223,13 @@ class TestCandidateSpecs(TestCase):
             ),
         )
         self.assertGreater(len(portfolio_specs), 36)
+        self.assertTrue(
+            all(
+                spec.strategy_overrides["params"]["position_isolation_mode"]
+                == "per_strategy"
+                for spec in portfolio_specs
+            )
+        )
         self.assertGreater(len(portfolio_specs), len(baseline_specs))
         complementary_spec = next(
             spec

--- a/services/torghut/tests/test_local_intraday_tsmom_replay.py
+++ b/services/torghut/tests/test_local_intraday_tsmom_replay.py
@@ -28,17 +28,24 @@ from scripts.local_intraday_tsmom_replay import (
     _apply_filled_decision,
     _apply_order_preferences,
     _build_near_miss,
+    _decision_exit_reason,
+    _decision_position_owner,
+    _fetch_chunk,
     _flatten_positions,
     _init_funnel_stats,
     _insert_near_miss,
+    _load_strategies,
     _parse_signal_row,
     _positions_payload,
     _quote_quality_status,
     _record_capital_snapshot,
     _record_trace_for_funnel,
     _reconcile_pending_order_before_immediate_fill,
+    _resolve_passed_trace_block_reason,
     _resolve_pending_fill_price,
     _should_replace_pending_order,
+    _signal_mid_jump_bps,
+    _signal_spread_bps,
     main as replay_main,
     run_replay,
 )
@@ -58,6 +65,102 @@ class TestLocalIntradayTsmomReplay(TestCase):
                 "spread": Decimal(ask) - Decimal(bid),
             },
         )
+
+    def test_force_position_isolation_owns_decision_by_strategy_id(self) -> None:
+        decision = StrategyDecision(
+            strategy_id="candidate-strategy-1",
+            symbol="META",
+            event_ts=datetime(2026, 3, 27, 17, 30, 3, tzinfo=timezone.utc),
+            timeframe="1Sec",
+            action="buy",
+            qty=Decimal("1"),
+            order_type="market",
+            time_in_force="day",
+            params={},
+        )
+
+        self.assertEqual(_decision_position_owner(decision), _SHARED_POSITION_OWNER)
+        self.assertEqual(
+            _decision_position_owner(decision, force_position_isolation=True),
+            "candidate-strategy-1",
+        )
+
+    def test_load_strategies_rejects_invalid_configmap_shapes(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            not_mapping = root / "not-mapping.yaml"
+            missing_data = root / "missing-data.yaml"
+            missing_strategies = root / "missing-strategies.yaml"
+            not_mapping.write_text("- bad\n", encoding="utf-8")
+            missing_data.write_text("apiVersion: v1\n", encoding="utf-8")
+            missing_strategies.write_text(
+                "data:\n  other.yaml: '{}'\n", encoding="utf-8"
+            )
+
+            with self.assertRaisesRegex(RuntimeError, "strategy_configmap_not_mapping"):
+                _load_strategies(not_mapping)
+            with self.assertRaisesRegex(
+                RuntimeError, "strategy_configmap_missing_data"
+            ):
+                _load_strategies(missing_data)
+            with self.assertRaisesRegex(
+                RuntimeError, "strategy_configmap_missing_strategies_yaml"
+            ):
+                _load_strategies(missing_strategies)
+
+    def test_fetch_chunk_filters_symbols_and_parses_rows(self) -> None:
+        captured_queries: list[str] = []
+
+        def fake_http_query(
+            *,
+            url: str,
+            username: str | None,
+            password: str | None,
+            query: str,
+        ) -> str:
+            self.assertEqual(url, "http://clickhouse")
+            self.assertEqual(username, "reader")
+            self.assertEqual(password, "secret")
+            captured_queries.append(query)
+            return "\t".join(
+                [
+                    "META",
+                    "2026-03-27 17:30:24.000",
+                    "12",
+                    "0.031",
+                    "0.019",
+                    "523.10",
+                    "522.80",
+                    "57",
+                    "523.25",
+                    "523.22",
+                    "523.28",
+                    "0.06",
+                    "1200",
+                    "800",
+                    "0.06",
+                    "522.95",
+                    "523.05",
+                    "0.00018",
+                    "18200",
+                ]
+            )
+
+        with patch(
+            "scripts.local_intraday_tsmom_replay._http_query",
+            side_effect=fake_http_query,
+        ):
+            rows = _fetch_chunk(
+                http_url="http://clickhouse",
+                username="reader",
+                password="secret",
+                chunk_start=datetime(2026, 3, 27, 17, 0, tzinfo=timezone.utc),
+                chunk_end=datetime(2026, 3, 27, 18, 0, tzinfo=timezone.utc),
+                symbols=("META", "NVDA"),
+            )
+
+        self.assertEqual([row.symbol for row in rows], ["META"])
+        self.assertIn("s.symbol IN ('META', 'NVDA')", captured_queries[0])
 
     def _decision(
         self,
@@ -109,6 +212,83 @@ class TestLocalIntradayTsmomReplay(TestCase):
         fill_price = _resolve_pending_fill_price(decision, signal)
 
         self.assertEqual(fill_price, Decimal("593.80"))
+
+    def test_market_buy_uses_ask_without_limit_price(self) -> None:
+        decision = self._decision(action="buy", order_type="market")
+        signal = self._signal(bid="593.70", ask="593.80", price="593.75")
+
+        fill_price = _resolve_pending_fill_price(decision, signal)
+
+        self.assertEqual(fill_price, Decimal("593.80"))
+
+    def test_quote_metric_helpers_return_positive_bps(self) -> None:
+        signal = self._signal(bid="593.70", ask="593.80", price="593.75")
+
+        self.assertEqual(
+            _signal_spread_bps(signal=signal, price=Decimal("593.75")),
+            Decimal("1.684210526315789473684210526"),
+        )
+        self.assertEqual(
+            _signal_mid_jump_bps(
+                price=Decimal("593.75"),
+                reference_price=Decimal("590.00"),
+            ),
+            Decimal("63.55932203389830508474576271"),
+        )
+
+    def test_decision_exit_reason_prefers_runtime_exit_then_rationale(self) -> None:
+        stop_loss = StrategyDecision(
+            strategy_id="intraday_tsmom_v1@prod",
+            symbol="META",
+            event_ts=datetime(2026, 3, 27, 19, 11, 0, tzinfo=timezone.utc),
+            timeframe="1Sec",
+            action="sell",
+            qty=Decimal("10"),
+            order_type="market",
+            time_in_force="day",
+            rationale="signal_exit",
+            params={"position_exit": {"type": "long_stop_loss_bps"}},
+        )
+        rationale_exit = StrategyDecision(
+            strategy_id="intraday_tsmom_v1@prod",
+            symbol="META",
+            event_ts=datetime(2026, 3, 27, 19, 12, 0, tzinfo=timezone.utc),
+            timeframe="1Sec",
+            action="sell",
+            qty=Decimal("10"),
+            order_type="market",
+            time_in_force="day",
+            rationale="microbar_exit,score=0.2",
+            params={},
+        )
+        fallback_exit = StrategyDecision(
+            strategy_id="intraday_tsmom_v1@prod",
+            symbol="META",
+            event_ts=datetime(2026, 3, 27, 19, 13, 0, tzinfo=timezone.utc),
+            timeframe="1Sec",
+            action="sell",
+            qty=Decimal("10"),
+            order_type="market",
+            time_in_force="day",
+            params={},
+        )
+
+        self.assertEqual(_decision_exit_reason(stop_loss), "long_stop_loss_bps")
+        self.assertEqual(_decision_exit_reason(rationale_exit), "microbar_exit")
+        self.assertEqual(_decision_exit_reason(fallback_exit), "signal_exit")
+
+    def test_resolve_passed_trace_block_reason_reports_post_runtime_filter(
+        self,
+    ) -> None:
+        reason = _resolve_passed_trace_block_reason(
+            strategy_id="candidate-a",
+            raw_decision_strategy_ids={"candidate-a"},
+            allocation_reject_reason_by_strategy_id={},
+            sizing_reject_reason_by_strategy_id={},
+            emitted_strategy_ids=set(),
+        )
+
+        self.assertEqual(reason, "post_runtime_filter_rejected")
 
     def test_apply_filled_decision_opens_position_on_same_signal(self) -> None:
         signal = self._signal(bid="523.22", ask="523.28", price="523.25")
@@ -182,7 +362,9 @@ class TestLocalIntradayTsmomReplay(TestCase):
         self.assertEqual(bucket["min_equity"], Decimal("215"))
         self.assertEqual(bucket["max_gross_exposure"], Decimal("420"))
         self.assertEqual(bucket["max_net_exposure_abs"], Decimal("240"))
-        self.assertEqual(bucket["max_gross_exposure_pct_equity"], Decimal("420") / Decimal("215"))
+        self.assertEqual(
+            bucket["max_gross_exposure_pct_equity"], Decimal("420") / Decimal("215")
+        )
         self.assertEqual(bucket["negative_cash_observation_count"], 1)
         self.assertEqual(bucket["capital_snapshot_count"], 1)
 
@@ -502,6 +684,40 @@ class TestLocalIntradayTsmomReplay(TestCase):
 
         self.assertTrue(should_replace)
 
+    def test_buy_market_replaces_same_priority_resting_buy_limit(self) -> None:
+        existing = StrategyDecision(
+            strategy_id="intraday_tsmom_v1@prod",
+            symbol="META",
+            event_ts=datetime(2026, 3, 27, 19, 11, 0, tzinfo=timezone.utc),
+            timeframe="1Sec",
+            action="buy",
+            qty=Decimal("10"),
+            order_type="limit",
+            time_in_force="day",
+            limit_price=Decimal("523.80"),
+            rationale="entry",
+            params={},
+        )
+        replacement = StrategyDecision(
+            strategy_id="intraday_tsmom_v1@prod",
+            symbol="META",
+            event_ts=datetime(2026, 3, 27, 19, 12, 0, tzinfo=timezone.utc),
+            timeframe="1Sec",
+            action="buy",
+            qty=Decimal("10"),
+            order_type="market",
+            time_in_force="day",
+            rationale="entry",
+            params={},
+        )
+
+        should_replace = _should_replace_pending_order(
+            existing=existing,
+            replacement=replacement,
+        )
+
+        self.assertTrue(should_replace)
+
     def test_immediate_fill_clears_existing_pending_order_for_same_position_owner(
         self,
     ) -> None:
@@ -708,7 +924,9 @@ class TestLocalIntradayTsmomReplay(TestCase):
             ],
         )
 
-    def test_positions_payload_projects_pending_sell_against_existing_short(self) -> None:
+    def test_positions_payload_projects_pending_sell_against_existing_short(
+        self,
+    ) -> None:
         positions = {
             ("META", _SHARED_POSITION_OWNER): PositionState(
                 strategy_id=_SHARED_POSITION_OWNER,
@@ -1277,7 +1495,9 @@ class TestLocalIntradayTsmomReplay(TestCase):
             all_closed_trades=[],
         )
 
-        self.assertEqual(positions[("META", _SHARED_POSITION_OWNER)].qty, Decimal("-15"))
+        self.assertEqual(
+            positions[("META", _SHARED_POSITION_OWNER)].qty, Decimal("-15")
+        )
         self.assertEqual(
             positions[("META", _SHARED_POSITION_OWNER)].avg_entry_price,
             Decimal("523.4466666666666666666666667"),
@@ -2072,7 +2292,9 @@ class TestLocalIntradayTsmomReplay(TestCase):
             payload["trace"][0]["block_reason"], "allocator_reject_symbol_capacity"
         )
 
-    def test_run_replay_marks_passed_trace_with_engine_runtime_filter_reason(self) -> None:
+    def test_run_replay_marks_passed_trace_with_engine_runtime_filter_reason(
+        self,
+    ) -> None:
         strategy = Strategy(
             name="breakout-continuation-long-v1",
             description=None,

--- a/services/torghut/tests/test_mlx_autoresearch.py
+++ b/services/torghut/tests/test_mlx_autoresearch.py
@@ -25,6 +25,7 @@ from app.trading.discovery.mlx_features import (
 )
 from app.trading.discovery.mlx_proposal_models import (
     ProposalScore,
+    _candidate_target,
     build_proposal_diagnostics,
     rank_candidate_descriptors,
     select_proposal_batch,
@@ -121,6 +122,19 @@ def _program() -> StrategyAutoresearchProgram:
 
 
 class TestMlxAutoresearch(TestCase):
+    def test_candidate_target_penalizes_observed_notional_shortfall(self) -> None:
+        target = _candidate_target(
+            {
+                "net_pnl_per_day": "500",
+                "active_day_ratio": "1",
+                "positive_day_ratio": "1",
+                "avg_filled_notional_per_day": "250000",
+                "required_min_daily_notional": "500000",
+            }
+        )
+
+        self.assertEqual(target, 525.0)
+
     def test_descriptor_inference_covers_side_rank_and_universe_fallbacks(
         self,
     ) -> None:

--- a/services/torghut/tests/test_mlx_training_data.py
+++ b/services/torghut/tests/test_mlx_training_data.py
@@ -114,6 +114,22 @@ class TestMlxTrainingData(TestCase):
         self.assertGreater(features["estimated_max_gross_exposure_pct_equity"], 1.0)
         self.assertEqual(features["capital_feasible_flag"], 0.0)
 
+    def test_observed_replay_viability_penalty_marks_zero_activity_notional_gap(
+        self,
+    ) -> None:
+        penalty = mlx_training_data_module._observed_replay_viability_penalty(
+            {
+                "active_day_ratio": "0",
+                "positive_day_ratio": "0",
+                "avg_filled_notional_per_day": "0",
+                "net_pnl_per_day": "0",
+            },
+            required_min_daily_notional=0.0,
+            target_net_pnl_per_day=500.0,
+        )
+
+        self.assertEqual(penalty, 2150.0)
+
     def test_training_rows_build_from_evidence_bundles_and_rank_deterministically(
         self,
     ) -> None:
@@ -259,4 +275,86 @@ class TestMlxTrainingData(TestCase):
         self.assertLess(
             row_by_spec[over_budget.candidate_spec_id].target,
             row_by_spec[feasible.candidate_spec_id].target,
+        )
+
+    def test_training_rows_penalize_flat_real_replay_evidence(self) -> None:
+        base_kwargs = {
+            "schema_version": "torghut.candidate-spec.v1",
+            "hypothesis_id": "H-FLAT",
+            "family_template_id": "momentum_pullback_v1",
+            "candidate_kind": "configuration",
+            "runtime_family": "momentum_pullback_consistent",
+            "runtime_strategy_name": "momentum-pullback-long-v1",
+            "feature_contract": {},
+            "parameter_space": {},
+            "strategy_overrides": {
+                "max_notional_per_trade": "7500",
+                "max_position_pct_equity": "0.25",
+                "params": {
+                    "capital_profile": "initial_equity_cash_constrained_1x",
+                    "max_entries_per_session": "1",
+                    "max_gross_exposure_pct_equity": "1.0",
+                },
+            },
+            "objective": {"target_net_pnl_per_day": "500"},
+            "hard_vetoes": {"required_min_daily_notional": "300000"},
+            "expected_failure_modes": (),
+            "promotion_contract": {},
+        }
+        flat = CandidateSpec(candidate_spec_id="spec-flat", **base_kwargs)
+        active = CandidateSpec(
+            candidate_spec_id="spec-active",
+            **{**base_kwargs, "hypothesis_id": "H-ACTIVE"},
+        )
+        bundles = [
+            evidence_bundle_from_frontier_candidate(
+                candidate_spec_id=flat.candidate_spec_id,
+                candidate={
+                    "candidate_id": "cand-flat",
+                    "objective_scorecard": {
+                        "net_pnl_per_day": "0",
+                        "active_day_ratio": "0",
+                        "positive_day_ratio": "0",
+                        "avg_filled_notional_per_day": "0",
+                        "hard_vetoes": [
+                            "active_day_ratio_below_oracle",
+                            "avg_filled_notional_per_day_below_oracle",
+                        ],
+                    },
+                },
+                dataset_snapshot_id="snapshot-flat",
+                result_path="/tmp/cand-flat.json",
+            ),
+            evidence_bundle_from_frontier_candidate(
+                candidate_spec_id=active.candidate_spec_id,
+                candidate={
+                    "candidate_id": "cand-active",
+                    "objective_scorecard": {
+                        "net_pnl_per_day": "25",
+                        "active_day_ratio": "1",
+                        "positive_day_ratio": "0.8",
+                        "avg_filled_notional_per_day": "350000",
+                        "hard_vetoes": [],
+                    },
+                },
+                dataset_snapshot_id="snapshot-active",
+                result_path="/tmp/cand-active.json",
+            ),
+        ]
+
+        rows = build_mlx_training_rows(
+            candidate_specs=[flat, active],
+            evidence_bundles=bundles,
+        )
+        row_by_spec = {row.candidate_spec_id: row for row in rows}
+
+        self.assertGreater(
+            row_by_spec[flat.candidate_spec_id].to_payload()["features"][
+                "history_observed_replay_viability_penalty"
+            ],
+            0.0,
+        )
+        self.assertLess(
+            row_by_spec[flat.candidate_spec_id].target,
+            row_by_spec[active.candidate_spec_id].target - 1000.0,
         )

--- a/services/torghut/tests/test_run_strategy_factory_v2.py
+++ b/services/torghut/tests/test_run_strategy_factory_v2.py
@@ -339,6 +339,45 @@ class TestRunStrategyFactoryV2(TestCase):
                     holdout_days=3,
                 )
 
+    def test_whitepaper_profit_target_experiments_force_standalone_replay(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            family_template_dir = self._write_family_template(root)
+            seed_sweep_dir = self._write_seed_sweep(root)
+            seed_path = (
+                seed_sweep_dir / "profitability-frontier-consistent-breakout.yaml"
+            )
+            seed_payload = yaml.safe_load(seed_path.read_text(encoding="utf-8"))
+            seed_payload["disable_other_strategies"] = False
+            seed_path.write_text(
+                yaml.safe_dump(seed_payload, sort_keys=False),
+                encoding="utf-8",
+            )
+            experiment_row = VNextExperimentSpec(
+                run_id="paper-run-standalone",
+                candidate_id=None,
+                experiment_id="exp-standalone",
+                payload_json={
+                    "family_template_id": "breakout_reclaim_v2",
+                    "selection_objectives": {"target_net_pnl_per_day": "500"},
+                    "promotion_contract": {
+                        "source": "whitepaper_autoresearch_profit_target",
+                    },
+                },
+            )
+
+            compiled = runner._compile_sweep_config(
+                experiment_row=experiment_row,
+                family_dir=family_template_dir,
+                seed_dir=seed_sweep_dir,
+                train_days=6,
+                holdout_days=3,
+            )
+
+            self.assertTrue(compiled.sweep_config["disable_other_strategies"])
+
     def test_run_strategy_factory_v2_compiles_executes_and_persists(self) -> None:
         with TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
@@ -452,6 +491,9 @@ class TestRunStrategyFactoryV2(TestCase):
                 compiled["strategy_overrides"]["max_notional_per_trade"], ["50000"]
             )
             self.assertEqual(compiled["parameters"]["long_stop_loss_bps"], ["12"])
+            self.assertEqual(
+                compiled["parameters"]["position_isolation_mode"], ["per_strategy"]
+            )
             self.assertEqual(
                 compiled["experiment_spec"]["paper_claim_links"], ["claim-1"]
             )

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -488,7 +488,13 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         self.assertEqual(model["feedback_matched_spec_count"], 3)
         self.assertEqual(
             row_by_spec[string_veto_spec.candidate_spec_id]["feedback_replay_target"],
-            135.0,
+            85.0,
+        )
+        self.assertEqual(
+            row_by_spec[string_veto_spec.candidate_spec_id]["features"][
+                "history_observed_replay_viability_penalty"
+            ],
+            50.0,
         )
         self.assertEqual(
             row_by_spec[string_veto_spec.candidate_spec_id]["selection_reason"],

--- a/services/torghut/tests/test_search_consistent_profitability_frontier.py
+++ b/services/torghut/tests/test_search_consistent_profitability_frontier.py
@@ -23,116 +23,135 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
     def test_parse_args_supports_harness_v2_flags(self) -> None:
         with TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
-            strategy_configmap = root / 'strategies.yaml'
-            sweep_config = root / 'sweep.yaml'
-            family_dir = root / 'families'
-            strategy_configmap.write_text('apiVersion: v1\nkind: ConfigMap\n', encoding='utf-8')
-            sweep_config.write_text('family: breakout_reclaim\nstrategy_name: intraday-tsmom-profit-v3\n', encoding='utf-8')
+            strategy_configmap = root / "strategies.yaml"
+            sweep_config = root / "sweep.yaml"
+            family_dir = root / "families"
+            strategy_configmap.write_text(
+                "apiVersion: v1\nkind: ConfigMap\n", encoding="utf-8"
+            )
+            sweep_config.write_text(
+                "family: breakout_reclaim\nstrategy_name: intraday-tsmom-profit-v3\n",
+                encoding="utf-8",
+            )
             family_dir.mkdir()
             with patch.object(
                 sys,
-                'argv',
+                "argv",
                 [
-                    'prog',
-                    '--strategy-configmap',
+                    "prog",
+                    "--strategy-configmap",
                     str(strategy_configmap),
-                    '--sweep-config',
+                    "--sweep-config",
                     str(sweep_config),
-                    '--expected-last-trading-day',
-                    '2026-04-07',
-                    '--clickhouse-password-env',
-                    'TORGHUT_CLICKHOUSE_PASSWORD',
-                    '--allow-stale-tape',
-                    '--family-template-dir',
+                    "--expected-last-trading-day",
+                    "2026-04-07",
+                    "--clickhouse-password-env",
+                    "TORGHUT_CLICKHOUSE_PASSWORD",
+                    "--allow-stale-tape",
+                    "--family-template-dir",
                     str(family_dir),
-                    '--max-candidates-to-evaluate',
-                    '12',
-                    '--no-train-screening',
-                    '--min-train-screen-net-per-day',
-                    '-50',
-                    '--min-train-screen-active-ratio',
-                    '0.25',
-                    '--max-train-screen-worst-day-loss',
-                    '125',
-                    '--collect-train-gate-diagnostics',
+                    "--max-candidates-to-evaluate",
+                    "12",
+                    "--no-train-screening",
+                    "--min-train-screen-net-per-day",
+                    "-50",
+                    "--min-train-screen-active-ratio",
+                    "0.25",
+                    "--max-train-screen-worst-day-loss",
+                    "125",
+                    "--collect-train-gate-diagnostics",
                 ],
             ):
                 args = frontier._parse_args()
 
-        self.assertEqual(args.expected_last_trading_day, '2026-04-07')
-        self.assertEqual(args.clickhouse_password_env, 'TORGHUT_CLICKHOUSE_PASSWORD')
+        self.assertEqual(args.expected_last_trading_day, "2026-04-07")
+        self.assertEqual(args.clickhouse_password_env, "TORGHUT_CLICKHOUSE_PASSWORD")
         self.assertTrue(args.allow_stale_tape)
         self.assertEqual(args.family_template_dir, family_dir)
         self.assertEqual(args.max_candidates_to_evaluate, 12)
         self.assertFalse(args.train_screening)
-        self.assertEqual(args.min_train_screen_net_per_day, '-50')
-        self.assertEqual(args.min_train_screen_active_ratio, '0.25')
-        self.assertEqual(args.max_train_screen_worst_day_loss, '125')
+        self.assertEqual(args.min_train_screen_net_per_day, "-50")
+        self.assertEqual(args.min_train_screen_active_ratio, "0.25")
+        self.assertEqual(args.max_train_screen_worst_day_loss, "125")
         self.assertTrue(args.collect_train_gate_diagnostics)
 
     def test_clickhouse_password_env_resolution_keeps_secret_out_of_argv(self) -> None:
-        with patch.dict('os.environ', {'TORGHUT_CLICKHOUSE_PASSWORD': 'from-env'}):
+        with patch.dict("os.environ", {"TORGHUT_CLICKHOUSE_PASSWORD": "from-env"}):
             resolved = frontier._resolved_clickhouse_password(
-                Namespace(clickhouse_password='', clickhouse_password_env='TORGHUT_CLICKHOUSE_PASSWORD')
+                Namespace(
+                    clickhouse_password="",
+                    clickhouse_password_env="TORGHUT_CLICKHOUSE_PASSWORD",
+                )
             )
             direct = frontier._resolved_clickhouse_password(
-                Namespace(clickhouse_password='direct', clickhouse_password_env='TORGHUT_CLICKHOUSE_PASSWORD')
+                Namespace(
+                    clickhouse_password="direct",
+                    clickhouse_password_env="TORGHUT_CLICKHOUSE_PASSWORD",
+                )
             )
 
-        self.assertEqual(resolved, 'from-env')
-        self.assertEqual(direct, 'direct')
+        self.assertEqual(resolved, "from-env")
+        self.assertEqual(direct, "direct")
 
     def test_rolling_lower_bound_handles_empty_and_short_windows(self) -> None:
-        self.assertEqual(frontier._rolling_lower_bound({}, window=3), Decimal('0'))
+        self.assertEqual(frontier._rolling_lower_bound({}, window=3), Decimal("0"))
         self.assertEqual(
             frontier._rolling_lower_bound(
-                {'2026-04-03': Decimal('30'), '2026-04-04': Decimal('60')},
+                {"2026-04-03": Decimal("30"), "2026-04-04": Decimal("60")},
                 window=5,
             ),
-            Decimal('45'),
+            Decimal("45"),
         )
 
     def test_selected_normalization_regime_prefers_override(self) -> None:
         self.assertEqual(
             frontier._selected_normalization_regime(
-                strategy_overrides={'normalization_regime': 'matched_filter'},
-                template_allowed_normalizations=('trading_value_scaled',),
+                strategy_overrides={"normalization_regime": "matched_filter"},
+                template_allowed_normalizations=("trading_value_scaled",),
             ),
-            'matched_filter',
+            "matched_filter",
         )
 
     def test_candidate_search_key_ignores_local_only_overrides(self) -> None:
         left = frontier._candidate_search_key(
-            params_candidate={'long_stop_loss_bps': '12'},
+            params_candidate={"long_stop_loss_bps": "12"},
             strategy_overrides={
-                'universe_symbols': ['NVDA', 'AMAT'],
-                'normalization_regime': 'price_scaled',
+                "universe_symbols": ["NVDA", "AMAT"],
+                "normalization_regime": "price_scaled",
             },
         )
         right = frontier._candidate_search_key(
-            params_candidate={'long_stop_loss_bps': '12'},
+            params_candidate={"long_stop_loss_bps": "12"},
             strategy_overrides={
-                'universe_symbols': ['NVDA', 'AMAT'],
-                'normalization_regime': 'matched_filter',
+                "universe_symbols": ["NVDA", "AMAT"],
+                "normalization_regime": "matched_filter",
             },
         )
 
         self.assertEqual(left, right)
 
+    def test_parameter_grid_items_rejects_non_iterable_shapes(self) -> None:
+        with self.assertRaisesRegex(ValueError, "parameter_values_not_sequence:alpha"):
+            frontier._parameter_grid_items({"alpha": "1"})
+        with self.assertRaisesRegex(ValueError, "parameter_values_not_sequence:alpha"):
+            frontier._parameter_grid_items({"alpha": {"nested": "1"}})
+        with self.assertRaisesRegex(ValueError, "parameter_values_not_iterable:alpha"):
+            frontier._parameter_grid_items({"alpha": 1})
+
     def test_candidate_symbols_prefers_cli_filter_then_universe_override(self) -> None:
         self.assertEqual(
             frontier._candidate_symbols(
-                cli_symbols=('META',),
-                strategy_overrides={'universe_symbols': ['NVDA', 'AMAT']},
+                cli_symbols=("META",),
+                strategy_overrides={"universe_symbols": ["NVDA", "AMAT"]},
             ),
-            ('META',),
+            ("META",),
         )
         self.assertEqual(
             frontier._candidate_symbols(
                 cli_symbols=(),
-                strategy_overrides={'universe_symbols': ['nvda', ' amat ']},
+                strategy_overrides={"universe_symbols": ["nvda", " amat "]},
             ),
-            ('NVDA', 'AMAT'),
+            ("NVDA", "AMAT"),
         )
 
     @staticmethod
@@ -148,53 +167,152 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
         losses: int,
     ) -> dict[str, object]:
         return {
-            'start_date': start_date,
-            'end_date': end_date,
-            'net_pnl': str(sum(float(value) for value in daily_net.values())),
-            'decision_count': decision_count,
-            'filled_count': filled_count,
-            'wins': wins,
-            'losses': losses,
-            'daily': {
+            "start_date": start_date,
+            "end_date": end_date,
+            "net_pnl": str(sum(float(value) for value in daily_net.values())),
+            "decision_count": decision_count,
+            "filled_count": filled_count,
+            "wins": wins,
+            "losses": losses,
+            "daily": {
                 day: {
-                    'net_pnl': value,
-                    'filled_count': 1 if float(value) != 0 else 0,
-                    'filled_notional': (
+                    "net_pnl": value,
+                    "filled_count": 1 if float(value) != 0 else 0,
+                    "filled_notional": (
                         daily_filled_notional[day]
-                        if daily_filled_notional is not None and day in daily_filled_notional
-                        else ('1000' if float(value) != 0 else '0')
+                        if daily_filled_notional is not None
+                        and day in daily_filled_notional
+                        else ("1000" if float(value) != 0 else "0")
                     ),
                 }
                 for day, value in daily_net.items()
             },
         }
 
+    def test_resolve_full_window_rejects_inverted_explicit_dates(self) -> None:
+        with self.assertRaisesRegex(ValueError, "full_window_invalid_range"):
+            frontier._resolve_full_window(
+                args=Namespace(
+                    full_window_start_date="2026-04-03",
+                    full_window_end_date="2026-04-02",
+                ),
+                train_days=(date(2026, 4, 1),),
+                holdout_days=(date(2026, 4, 2),),
+            )
+
+    def test_max_best_day_share_returns_zero_when_positive_total_has_no_positive_day(
+        self,
+    ) -> None:
+        self.assertEqual(
+            frontier._max_best_day_share_of_total_pnl(
+                daily_net={"2026-04-01": Decimal("-10")},
+                total_net_pnl=Decimal("100"),
+            ),
+            Decimal("0"),
+        )
+
+    def test_consistency_penalty_penalizes_excess_negative_days(self) -> None:
+        penalties, summary = frontier._consistency_penalty(
+            full_window_payload=self._payload(
+                start_date="2026-04-01",
+                end_date="2026-04-03",
+                daily_net={
+                    "2026-04-01": "-20",
+                    "2026-04-02": "-30",
+                    "2026-04-03": "200",
+                },
+                decision_count=3,
+                filled_count=3,
+                wins=1,
+                losses=2,
+            ),
+            policy=frontier.FullWindowConsistencyPolicy(
+                target_net_per_day=Decimal("10"),
+                min_daily_net_pnl=Decimal("-1000"),
+                min_active_days=1,
+                min_active_ratio=Decimal("0"),
+                min_positive_days=1,
+                max_worst_day_loss=Decimal("1000"),
+                max_negative_days=0,
+                max_drawdown=Decimal("1000"),
+                max_best_day_share_of_total_pnl=Decimal("1"),
+                min_avg_filled_notional_per_day=Decimal("0"),
+                min_avg_filled_notional_per_active_day=Decimal("0"),
+                require_every_day_active=False,
+            ),
+        )
+
+        self.assertGreaterEqual(penalties, Decimal("600"))
+        self.assertEqual(summary["negative_days"], 2)
+
+    def test_train_screen_failures_reports_worst_day_loss(self) -> None:
+        failures = frontier._train_screen_failures(
+            train_payload=self._payload(
+                start_date="2026-04-01",
+                end_date="2026-04-02",
+                daily_net={"2026-04-01": "-125", "2026-04-02": "200"},
+                decision_count=2,
+                filled_count=2,
+                wins=1,
+                losses=1,
+            ),
+            holdout_policy=frontier.ProfitabilityConstraintPolicy(
+                holdout_target_net_per_day=Decimal("0"),
+                min_active_holdout_days=0,
+                max_worst_holdout_day_loss=Decimal("1000"),
+                min_profit_factor=Decimal("0"),
+                require_training_decisions=True,
+                require_holdout_decisions=False,
+            ),
+            consistency_policy=frontier.FullWindowConsistencyPolicy(
+                target_net_per_day=Decimal("0"),
+                min_daily_net_pnl=Decimal("-1000"),
+                min_active_days=1,
+                min_active_ratio=Decimal("0"),
+                min_positive_days=1,
+                max_worst_day_loss=Decimal("1000"),
+                max_negative_days=1,
+                max_drawdown=Decimal("1000"),
+                max_best_day_share_of_total_pnl=Decimal("1"),
+                min_avg_filled_notional_per_day=Decimal("0"),
+                min_avg_filled_notional_per_active_day=Decimal("0"),
+                require_every_day_active=False,
+            ),
+            min_train_net_per_day=Decimal("-1000"),
+            min_train_active_ratio=Decimal("0"),
+            max_train_worst_day_loss=Decimal("100"),
+        )
+
+        self.assertIn("train_worst_day_loss_above_screen", failures)
+
     def _write_strategy_configmap(self, root: Path) -> Path:
-        path = root / 'strategy-configmap.yaml'
+        path = root / "strategy-configmap.yaml"
         path.write_text(
             yaml.safe_dump(
                 {
-                    'apiVersion': 'v1',
-                    'kind': 'ConfigMap',
-                    'data': {
-                        'strategies.yaml': yaml.safe_dump(
+                    "apiVersion": "v1",
+                    "kind": "ConfigMap",
+                    "data": {
+                        "strategies.yaml": yaml.safe_dump(
                             {
-                                'strategies': [
+                                "strategies": [
                                     {
-                                        'name': 'intraday-tsmom-profit-v3',
-                                        'enabled': True,
-                                        'max_notional_per_trade': '25000',
-                                        'max_position_pct_equity': '2.0',
-                                        'universe_symbols': ['NVDA', 'AMAT', 'AMD'],
-                                        'params': {
-                                            'min_cross_section_continuation_rank': '0.60',
-                                            'long_stop_loss_bps': '18',
+                                        "name": "intraday-tsmom-profit-v3",
+                                        "enabled": True,
+                                        "max_notional_per_trade": "25000",
+                                        "max_position_pct_equity": "2.0",
+                                        "universe_symbols": ["NVDA", "AMAT", "AMD"],
+                                        "params": {
+                                            "min_cross_section_continuation_rank": "0.60",
+                                            "long_stop_loss_bps": "18",
                                         },
                                     },
                                     {
-                                        'name': 'late-day-continuation-long-v1',
-                                        'enabled': True,
-                                        'params': {'min_recent_microprice_bias_bps': '0.20'},
+                                        "name": "late-day-continuation-long-v1",
+                                        "enabled": True,
+                                        "params": {
+                                            "min_recent_microprice_bias_bps": "0.20"
+                                        },
                                     },
                                 ]
                             },
@@ -204,65 +322,70 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
                 },
                 sort_keys=False,
             ),
-            encoding='utf-8',
+            encoding="utf-8",
         )
         return path
 
     def _write_sweep_config(self, root: Path) -> Path:
-        path = root / 'sweep.yaml'
+        path = root / "sweep.yaml"
         path.write_text(
             yaml.safe_dump(
                 {
-                    'schema_version': 'torghut.replay-frontier-sweep.v1',
-                    'family': 'intraday_tsmom_consistent',
-                    'strategy_name': 'intraday-tsmom-profit-v3',
-                    'disable_other_strategies': True,
-                    'constraints': {
-                        'holdout_target_net_per_day': '200',
-                        'min_active_holdout_days': 2,
-                        'max_worst_holdout_day_loss': '200',
-                        'min_profit_factor': '1.1',
+                    "schema_version": "torghut.replay-frontier-sweep.v1",
+                    "family": "intraday_tsmom_consistent",
+                    "strategy_name": "intraday-tsmom-profit-v3",
+                    "disable_other_strategies": True,
+                    "constraints": {
+                        "holdout_target_net_per_day": "200",
+                        "min_active_holdout_days": 2,
+                        "max_worst_holdout_day_loss": "200",
+                        "min_profit_factor": "1.1",
                     },
-                    'consistency_constraints': {
-                        'target_net_per_day': '200',
-                        'min_active_days': 6,
-                        'max_worst_day_loss': '250',
-                        'max_negative_days': 1,
-                        'max_drawdown': '300',
-                        'require_every_day_active': True,
+                    "consistency_constraints": {
+                        "target_net_per_day": "200",
+                        "min_active_days": 6,
+                        "max_worst_day_loss": "250",
+                        "max_negative_days": 1,
+                        "max_drawdown": "300",
+                        "require_every_day_active": True,
                     },
-                    'strategy_overrides': {
-                        'universe_symbols': [['NVDA'], ['NVDA', 'AMAT']],
-                        'max_notional_per_trade': ['15000'],
+                    "strategy_overrides": {
+                        "universe_symbols": [["NVDA"], ["NVDA", "AMAT"]],
+                        "max_notional_per_trade": ["15000"],
                     },
-                    'parameters': {
-                        'long_stop_loss_bps': ['12', '18'],
+                    "parameters": {
+                        "long_stop_loss_bps": ["12", "18"],
                     },
                 },
                 sort_keys=False,
             ),
-            encoding='utf-8',
+            encoding="utf-8",
         )
         return path
 
-    def _make_args(self, *, strategy_configmap: Path, sweep_config: Path, json_output: Path) -> Namespace:
+    def _make_args(
+        self, *, strategy_configmap: Path, sweep_config: Path, json_output: Path
+    ) -> Namespace:
         return Namespace(
             strategy_configmap=strategy_configmap,
             sweep_config=sweep_config,
-            clickhouse_http_url='http://example.invalid:8123',
-            clickhouse_username='torghut',
-            clickhouse_password='secret',
-            start_equity='31590.02',
+            clickhouse_http_url="http://example.invalid:8123",
+            clickhouse_username="torghut",
+            clickhouse_password="secret",
+            start_equity="31590.02",
             chunk_minutes=10,
-            symbols='',
+            symbols="",
             progress_log_seconds=30,
             train_days=3,
             holdout_days=3,
-            full_window_start_date='',
-            full_window_end_date='',
-            expected_last_trading_day='',
+            full_window_start_date="",
+            full_window_end_date="",
+            expected_last_trading_day="",
             allow_stale_tape=False,
-            family_template_dir=Path(__file__).resolve().parents[1] / 'config' / 'trading' / 'families',
+            family_template_dir=Path(__file__).resolve().parents[1]
+            / "config"
+            / "trading"
+            / "families",
             prefetch_full_window_rows=False,
             top_n=10,
             max_candidates_to_evaluate=0,
@@ -271,24 +394,24 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
             symbol_prune_candidates=1,
             symbol_prune_min_universe_size=2,
             train_screening=True,
-            min_train_screen_net_per_day='0',
-            min_train_screen_active_ratio='0.50',
-            max_train_screen_worst_day_loss='',
+            min_train_screen_net_per_day="0",
+            min_train_screen_active_ratio="0.50",
+            max_train_screen_worst_day_loss="",
         )
 
     def test_strategy_universe_symbols_reads_target_strategy_universe(self) -> None:
         configmap_payload = {
-            'data': {
-                'strategies.yaml': yaml.safe_dump(
+            "data": {
+                "strategies.yaml": yaml.safe_dump(
                     {
-                        'strategies': [
+                        "strategies": [
                             {
-                                'name': 'intraday-tsmom-profit-v3',
-                                'universe_symbols': ['nvda', ' AMAT '],
+                                "name": "intraday-tsmom-profit-v3",
+                                "universe_symbols": ["nvda", " AMAT "],
                             },
                             {
-                                'name': 'other',
-                                'universe_symbols': ['META'],
+                                "name": "other",
+                                "universe_symbols": ["META"],
                             },
                         ]
                     },
@@ -299,20 +422,22 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
         self.assertEqual(
             frontier._strategy_universe_symbols(
                 configmap_payload=configmap_payload,
-                strategy_name='intraday-tsmom-profit-v3',
+                strategy_name="intraday-tsmom-profit-v3",
             ),
-            ('NVDA', 'AMAT'),
+            ("NVDA", "AMAT"),
         )
 
-    def test_resolve_prefetch_symbols_uses_override_union_before_base_universe(self) -> None:
+    def test_resolve_prefetch_symbols_uses_override_union_before_base_universe(
+        self,
+    ) -> None:
         configmap_payload = {
-            'data': {
-                'strategies.yaml': yaml.safe_dump(
+            "data": {
+                "strategies.yaml": yaml.safe_dump(
                     {
-                        'strategies': [
+                        "strategies": [
                             {
-                                'name': 'intraday-tsmom-profit-v3',
-                                'universe_symbols': ['META'],
+                                "name": "intraday-tsmom-profit-v3",
+                                "universe_symbols": ["META"],
                             },
                         ]
                     },
@@ -324,58 +449,62 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
             frontier._resolve_prefetch_symbols(
                 cli_symbols=(),
                 override_candidates=[
-                    {'universe_symbols': ['nvda', 'amat']},
-                    {'universe_symbols': ['AMAT', 'amd']},
+                    {"universe_symbols": ["nvda", "amat"]},
+                    {"universe_symbols": ["AMAT", "amd"]},
                 ],
                 configmap_payload=configmap_payload,
-                strategy_name='intraday-tsmom-profit-v3',
+                strategy_name="intraday-tsmom-profit-v3",
             ),
-            ('NVDA', 'AMAT', 'AMD'),
+            ("NVDA", "AMAT", "AMD"),
         )
 
-    def test_cached_iter_signal_rows_factory_filters_by_date_and_symbol_preserving_order(self) -> None:
+    def test_cached_iter_signal_rows_factory_filters_by_date_and_symbol_preserving_order(
+        self,
+    ) -> None:
         rows = [
             SimpleNamespace(
-                symbol='NVDA',
+                symbol="NVDA",
                 event_ts=datetime(2026, 3, 23, 14, 0, tzinfo=timezone.utc),
                 seq=2,
             ),
             SimpleNamespace(
-                symbol='AMAT',
+                symbol="AMAT",
                 event_ts=datetime(2026, 3, 23, 14, 0, 1, tzinfo=timezone.utc),
                 seq=1,
             ),
             SimpleNamespace(
-                symbol='NVDA',
+                symbol="NVDA",
                 event_ts=datetime(2026, 3, 24, 14, 0, tzinfo=timezone.utc),
                 seq=3,
             ),
         ]
         iterator = frontier._cached_iter_signal_rows_factory(rows)
         config = SimpleNamespace(
-            symbols=('NVDA',),
+            symbols=("NVDA",),
             start_date=date(2026, 3, 23),
             end_date=date(2026, 3, 23),
         )
         filtered = list(iterator(config))
-        self.assertEqual([item.symbol for item in filtered], ['NVDA'])
+        self.assertEqual([item.symbol for item in filtered], ["NVDA"])
         self.assertEqual(filtered[0].seq, 2)
 
-    def test_apply_candidate_to_configmap_with_overrides_updates_top_level_fields(self) -> None:
+    def test_apply_candidate_to_configmap_with_overrides_updates_top_level_fields(
+        self,
+    ) -> None:
         configmap_payload = {
-            'apiVersion': 'v1',
-            'kind': 'ConfigMap',
-            'data': {
-                'strategies.yaml': yaml.safe_dump(
+            "apiVersion": "v1",
+            "kind": "ConfigMap",
+            "data": {
+                "strategies.yaml": yaml.safe_dump(
                     {
-                        'strategies': [
+                        "strategies": [
                             {
-                                'name': 'intraday-tsmom-profit-v3',
-                                'enabled': False,
-                                'max_notional_per_trade': '25000',
-                                'params': {'long_stop_loss_bps': '18'},
+                                "name": "intraday-tsmom-profit-v3",
+                                "enabled": False,
+                                "max_notional_per_trade": "25000",
+                                "params": {"long_stop_loss_bps": "18"},
                             },
-                            {'name': 'late-day', 'enabled': True, 'params': {}},
+                            {"name": "late-day", "enabled": True, "params": {}},
                         ]
                     },
                     sort_keys=False,
@@ -385,44 +514,50 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
 
         updated = frontier.apply_candidate_to_configmap_with_overrides(
             configmap_payload=configmap_payload,
-            strategy_name='intraday-tsmom-profit-v3',
-            candidate_params={'long_stop_loss_bps': '12'},
+            strategy_name="intraday-tsmom-profit-v3",
+            candidate_params={"long_stop_loss_bps": "12"},
             strategy_overrides={
-                'universe_symbols': ['NVDA', 'AMAT'],
-                'max_notional_per_trade': '15000',
+                "universe_symbols": ["NVDA", "AMAT"],
+                "max_notional_per_trade": "15000",
             },
             disable_other_strategies=True,
         )
 
-        catalog = yaml.safe_load(updated['data']['strategies.yaml'])
-        strategies = {item['name']: item for item in catalog['strategies']}
+        catalog = yaml.safe_load(updated["data"]["strategies.yaml"])
+        strategies = {item["name"]: item for item in catalog["strategies"]}
         self.assertEqual(
-            strategies['intraday-tsmom-profit-v3']['params']['long_stop_loss_bps'],
-            '12',
+            strategies["intraday-tsmom-profit-v3"]["params"]["long_stop_loss_bps"],
+            "12",
         )
         self.assertEqual(
-            strategies['intraday-tsmom-profit-v3']['universe_symbols'],
-            ['NVDA', 'AMAT'],
+            strategies["intraday-tsmom-profit-v3"]["params"]["position_isolation_mode"],
+            "per_strategy",
         )
         self.assertEqual(
-            strategies['intraday-tsmom-profit-v3']['max_notional_per_trade'],
-            '15000',
+            strategies["intraday-tsmom-profit-v3"]["universe_symbols"],
+            ["NVDA", "AMAT"],
         )
-        self.assertFalse(strategies['late-day']['enabled'])
+        self.assertEqual(
+            strategies["intraday-tsmom-profit-v3"]["max_notional_per_trade"],
+            "15000",
+        )
+        self.assertFalse(strategies["late-day"]["enabled"])
 
-    def test_apply_candidate_to_configmap_with_overrides_skips_search_only_normalization_override(self) -> None:
+    def test_apply_candidate_to_configmap_with_overrides_skips_search_only_normalization_override(
+        self,
+    ) -> None:
         configmap_payload = {
-            'apiVersion': 'v1',
-            'kind': 'ConfigMap',
-            'data': {
-                'strategies.yaml': yaml.safe_dump(
+            "apiVersion": "v1",
+            "kind": "ConfigMap",
+            "data": {
+                "strategies.yaml": yaml.safe_dump(
                     {
-                        'strategies': [
+                        "strategies": [
                             {
-                                'name': 'intraday-tsmom-profit-v3',
-                                'enabled': True,
-                                'max_notional_per_trade': '25000',
-                                'params': {'long_stop_loss_bps': '18'},
+                                "name": "intraday-tsmom-profit-v3",
+                                "enabled": True,
+                                "max_notional_per_trade": "25000",
+                                "params": {"long_stop_loss_bps": "18"},
                             },
                         ]
                     },
@@ -433,100 +568,171 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
 
         updated = frontier.apply_candidate_to_configmap_with_overrides(
             configmap_payload=configmap_payload,
-            strategy_name='intraday-tsmom-profit-v3',
-            candidate_params={'long_stop_loss_bps': '12'},
+            strategy_name="intraday-tsmom-profit-v3",
+            candidate_params={"long_stop_loss_bps": "12"},
             strategy_overrides={
-                'normalization_regime': 'opening_window_scaled',
-                'universe_symbols': ['NVDA', 'AMAT'],
+                "normalization_regime": "opening_window_scaled",
+                "universe_symbols": ["NVDA", "AMAT"],
             },
             disable_other_strategies=True,
         )
 
-        catalog = yaml.safe_load(updated['data']['strategies.yaml'])
-        strategy = catalog['strategies'][0]
-        self.assertEqual(strategy['params']['long_stop_loss_bps'], '12')
-        self.assertEqual(strategy['universe_symbols'], ['NVDA', 'AMAT'])
-        self.assertNotIn('normalization_regime', strategy)
+        catalog = yaml.safe_load(updated["data"]["strategies.yaml"])
+        strategy = catalog["strategies"][0]
+        self.assertEqual(strategy["params"]["long_stop_loss_bps"], "12")
+        self.assertEqual(strategy["universe_symbols"], ["NVDA", "AMAT"])
+        self.assertNotIn("normalization_regime", strategy)
 
-    def test_symbol_contributions_from_replay_payload_aggregates_downside_and_activity(self) -> None:
+    def test_apply_candidate_to_configmap_with_overrides_validates_returned_catalog(
+        self,
+    ) -> None:
+        base_payload = {
+            "apiVersion": "v1",
+            "kind": "ConfigMap",
+            "data": {
+                "strategies.yaml": yaml.safe_dump(
+                    {"strategies": [{"name": "target", "enabled": True, "params": {}}]},
+                    sort_keys=False,
+                )
+            },
+        }
+
+        invalid_returns = [
+            ({"data": []}, "strategy_configmap_missing_data"),
+            ({"data": {}}, "strategy_configmap_missing_strategies_yaml"),
+            ({"data": {"strategies.yaml": "- bad\n"}}, "strategy_catalog_not_mapping"),
+            (
+                {"data": {"strategies.yaml": "strategies: {}\n"}},
+                "strategy_catalog_missing_strategies",
+            ),
+        ]
+        for returned, reason in invalid_returns:
+            with self.subTest(reason=reason):
+                with patch.object(
+                    frontier, "apply_candidate_to_configmap", return_value=returned
+                ):
+                    with self.assertRaisesRegex(ValueError, reason):
+                        frontier.apply_candidate_to_configmap_with_overrides(
+                            configmap_payload=base_payload,
+                            strategy_name="target",
+                            candidate_params={},
+                            strategy_overrides={"universe_symbols": ["NVDA"]},
+                            disable_other_strategies=True,
+                        )
+
+        with self.assertRaisesRegex(
+            ValueError, "strategy_override_key_reserved:params"
+        ):
+            frontier.apply_candidate_to_configmap_with_overrides(
+                configmap_payload=base_payload,
+                strategy_name="target",
+                candidate_params={},
+                strategy_overrides={"params": {"long_stop_loss_bps": "10"}},
+                disable_other_strategies=True,
+            )
+        returned_other_strategy = {
+            "data": {
+                "strategies.yaml": yaml.safe_dump(
+                    {"strategies": [{"name": "other", "params": {}}]},
+                    sort_keys=False,
+                )
+            }
+        }
+        with patch.object(
+            frontier,
+            "apply_candidate_to_configmap",
+            return_value=returned_other_strategy,
+        ):
+            with self.assertRaisesRegex(ValueError, "strategy_not_found:missing"):
+                frontier.apply_candidate_to_configmap_with_overrides(
+                    configmap_payload=base_payload,
+                    strategy_name="missing",
+                    candidate_params={},
+                    strategy_overrides={"universe_symbols": ["NVDA"]},
+                    disable_other_strategies=False,
+                )
+
+    def test_symbol_contributions_from_replay_payload_aggregates_downside_and_activity(
+        self,
+    ) -> None:
         payload = {
-            'funnel': {
-                'buckets': [
+            "funnel": {
+                "buckets": [
                     {
-                        'trading_day': '2026-03-31',
-                        'symbol': 'AVGO',
-                        'filled_count': 1,
-                        'net_pnl': '-120',
-                        'cost_total': '10',
+                        "trading_day": "2026-03-31",
+                        "symbol": "AVGO",
+                        "filled_count": 1,
+                        "net_pnl": "-120",
+                        "cost_total": "10",
                     },
                     {
-                        'trading_day': '2026-04-01',
-                        'symbol': 'AVGO',
-                        'filled_count': 1,
-                        'net_pnl': '30',
-                        'cost_total': '5',
+                        "trading_day": "2026-04-01",
+                        "symbol": "AVGO",
+                        "filled_count": 1,
+                        "net_pnl": "30",
+                        "cost_total": "5",
                     },
                     {
-                        'trading_day': '2026-04-01',
-                        'symbol': 'MSFT',
-                        'filled_count': 1,
-                        'net_pnl': '220',
-                        'cost_total': '7',
+                        "trading_day": "2026-04-01",
+                        "symbol": "MSFT",
+                        "filled_count": 1,
+                        "net_pnl": "220",
+                        "cost_total": "7",
                     },
                 ]
             }
         }
         contributions = frontier._symbol_contributions_from_replay_payload(payload)
-        self.assertEqual(list(contributions), ['AVGO', 'MSFT'])
-        self.assertEqual(contributions['AVGO']['active_days'], 2)
-        self.assertEqual(contributions['AVGO']['negative_days'], 1)
-        self.assertEqual(contributions['AVGO']['net_pnl'], '-90')
-        self.assertEqual(contributions['AVGO']['downside_pnl'], '120')
-        self.assertEqual(contributions['MSFT']['contribution_score'], '220')
+        self.assertEqual(list(contributions), ["AVGO", "MSFT"])
+        self.assertEqual(contributions["AVGO"]["active_days"], 2)
+        self.assertEqual(contributions["AVGO"]["negative_days"], 1)
+        self.assertEqual(contributions["AVGO"]["net_pnl"], "-90")
+        self.assertEqual(contributions["AVGO"]["downside_pnl"], "120")
+        self.assertEqual(contributions["MSFT"]["contribution_score"], "220")
 
     def test_train_gate_diagnostics_from_replay_payload_summarizes_funnel(self) -> None:
         payload = {
-            'decision_count': 0,
-            'filled_count': 0,
-            'funnel': {
-                'buckets': [
+            "decision_count": 0,
+            "filled_count": 0,
+            "funnel": {
+                "buckets": [
                     {
-                        'retained_rows': 10,
-                        'runtime_evaluable_rows': 8,
-                        'quote_valid_rows': 9,
-                        'strategy_evaluations': 8,
-                        'passed_trace_count': 1,
-                        'gate_pass_counts': {'short:eligibility': 8},
-                        'first_failed_gate_counts': {'short:confirmation': 5},
-                        'failing_threshold_counts': {
-                            'short:confirmation:imbalance_pressure': 5,
+                        "retained_rows": 10,
+                        "runtime_evaluable_rows": 8,
+                        "quote_valid_rows": 9,
+                        "strategy_evaluations": 8,
+                        "passed_trace_count": 1,
+                        "gate_pass_counts": {"short:eligibility": 8},
+                        "first_failed_gate_counts": {"short:confirmation": 5},
+                        "failing_threshold_counts": {
+                            "short:confirmation:imbalance_pressure": 5,
                         },
                     },
                     {
-                        'retained_rows': 4,
-                        'runtime_evaluable_rows': 3,
-                        'quote_valid_rows': 3,
-                        'strategy_evaluations': 3,
-                        'passed_trace_count': 0,
-                        'first_failed_gate_counts': {'short:structure': 3},
-                        'failing_threshold_counts': {'short:structure:rsi14': 3},
+                        "retained_rows": 4,
+                        "runtime_evaluable_rows": 3,
+                        "quote_valid_rows": 3,
+                        "strategy_evaluations": 3,
+                        "passed_trace_count": 0,
+                        "first_failed_gate_counts": {"short:structure": 3},
+                        "failing_threshold_counts": {"short:structure:rsi14": 3},
                     },
                 ]
             },
-            'near_misses': [
+            "near_misses": [
                 {
-                    'trading_day': '2026-05-01',
-                    'symbol': 'AAPL',
-                    'strategy_type': 'short',
-                    'event_ts': '2026-05-01T15:00:00+00:00',
-                    'first_failed_gate': 'confirmation',
-                    'distance_score': '0.02',
-                    'thresholds': [
+                    "trading_day": "2026-05-01",
+                    "symbol": "AAPL",
+                    "strategy_type": "short",
+                    "event_ts": "2026-05-01T15:00:00+00:00",
+                    "first_failed_gate": "confirmation",
+                    "distance_score": "0.02",
+                    "thresholds": [
                         {
-                            'metric': 'imbalance_pressure',
-                            'value': '0.01',
-                            'threshold': '0.00',
-                            'distance_to_pass': '0.01',
+                            "metric": "imbalance_pressure",
+                            "value": "0.01",
+                            "threshold": "0.00",
+                            "distance_to_pass": "0.01",
                         }
                     ],
                 }
@@ -535,57 +741,59 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
 
         diagnostics = frontier._train_gate_diagnostics_from_replay_payload(payload)
 
-        self.assertEqual(diagnostics['status'], 'available')
-        self.assertEqual(diagnostics['aggregate']['strategy_evaluations'], 11)
+        self.assertEqual(diagnostics["status"], "available")
+        self.assertEqual(diagnostics["aggregate"]["strategy_evaluations"], 11)
         self.assertEqual(
-            diagnostics['top_first_failed_gates'][0],
-            {'key': 'short:confirmation', 'count': 5},
+            diagnostics["top_first_failed_gates"][0],
+            {"key": "short:confirmation", "count": 5},
         )
         self.assertEqual(
-            diagnostics['top_failing_thresholds'][0],
-            {'key': 'short:confirmation:imbalance_pressure', 'count': 5},
+            diagnostics["top_failing_thresholds"][0],
+            {"key": "short:confirmation:imbalance_pressure", "count": 5},
         )
         self.assertEqual(
-            diagnostics['near_misses'][0]['thresholds'][0]['metric'],
-            'imbalance_pressure',
+            diagnostics["near_misses"][0]["thresholds"][0]["metric"],
+            "imbalance_pressure",
         )
 
-    def test_train_gate_diagnostics_from_replay_payload_ignores_malformed_items(self) -> None:
+    def test_train_gate_diagnostics_from_replay_payload_ignores_malformed_items(
+        self,
+    ) -> None:
         payload = {
-            'decision_count': 1,
-            'filled_count': 0,
-            'funnel': {
-                'buckets': [
-                    'not-a-bucket',
+            "decision_count": 1,
+            "filled_count": 0,
+            "funnel": {
+                "buckets": [
+                    "not-a-bucket",
                     {
-                        'retained_rows': 'bad-count',
-                        'runtime_evaluable_rows': '2',
-                        'quote_valid_rows': '2',
-                        'strategy_evaluations': '2',
-                        'passed_trace_count': '0',
-                        'gate_pass_counts': {'short:structure': '2'},
-                        'first_failed_gate_counts': {
-                            'short:confirmation': 'bad-count',
-                            'short:structure': '1',
+                        "retained_rows": "bad-count",
+                        "runtime_evaluable_rows": "2",
+                        "quote_valid_rows": "2",
+                        "strategy_evaluations": "2",
+                        "passed_trace_count": "0",
+                        "gate_pass_counts": {"short:structure": "2"},
+                        "first_failed_gate_counts": {
+                            "short:confirmation": "bad-count",
+                            "short:structure": "1",
                         },
                     },
                 ]
             },
-            'near_misses': [
+            "near_misses": [
                 {
-                    'trading_day': '2026-05-01',
-                    'symbol': 'AAPL',
-                    'strategy_type': 'short',
-                    'event_ts': '2026-05-01T15:00:00+00:00',
-                    'first_failed_gate': 'confirmation',
-                    'distance_score': '0.02',
-                    'thresholds': [
-                        'not-a-threshold',
+                    "trading_day": "2026-05-01",
+                    "symbol": "AAPL",
+                    "strategy_type": "short",
+                    "event_ts": "2026-05-01T15:00:00+00:00",
+                    "first_failed_gate": "confirmation",
+                    "distance_score": "0.02",
+                    "thresholds": [
+                        "not-a-threshold",
                         {
-                            'metric': 'rsi14',
-                            'value': '72',
-                            'threshold': '70',
-                            'distance_to_pass': '2',
+                            "metric": "rsi14",
+                            "value": "72",
+                            "threshold": "70",
+                            "distance_to_pass": "2",
                         },
                     ],
                 }
@@ -594,67 +802,71 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
 
         diagnostics = frontier._train_gate_diagnostics_from_replay_payload(payload)
 
-        self.assertEqual(diagnostics['aggregate']['retained_rows'], 0)
-        self.assertEqual(diagnostics['aggregate']['runtime_evaluable_rows'], 2)
+        self.assertEqual(diagnostics["aggregate"]["retained_rows"], 0)
+        self.assertEqual(diagnostics["aggregate"]["runtime_evaluable_rows"], 2)
         self.assertEqual(
-            diagnostics['top_first_failed_gates'],
-            [{'key': 'short:structure', 'count': 1}],
+            diagnostics["top_first_failed_gates"],
+            [{"key": "short:structure", "count": 1}],
         )
         self.assertEqual(
-            diagnostics['near_misses'][0]['thresholds'],
+            diagnostics["near_misses"][0]["thresholds"],
             [
                 {
-                    'metric': 'rsi14',
-                    'value': '72',
-                    'threshold': '70',
-                    'distance_to_pass': '2',
+                    "metric": "rsi14",
+                    "value": "72",
+                    "threshold": "70",
+                    "distance_to_pass": "2",
                 }
             ],
         )
 
-    def test_generate_symbol_prune_children_removes_worst_symbols_from_universe(self) -> None:
+    def test_generate_symbol_prune_children_removes_worst_symbols_from_universe(
+        self,
+    ) -> None:
         children = frontier._generate_symbol_prune_children(
             cli_symbols=(),
-            strategy_overrides={'universe_symbols': ['NVDA', 'AVGO', 'MSFT']},
+            strategy_overrides={"universe_symbols": ["NVDA", "AVGO", "MSFT"]},
             configmap_payload={},
-            strategy_name='intraday-tsmom-profit-v3',
+            strategy_name="intraday-tsmom-profit-v3",
             symbol_contributions={
-                'AVGO': {'contribution_score': '-200', 'net_pnl': '-100'},
-                'NVDA': {'contribution_score': '-50', 'net_pnl': '10'},
-                'MSFT': {'contribution_score': '100', 'net_pnl': '120'},
+                "AVGO": {"contribution_score": "-200", "net_pnl": "-100"},
+                "NVDA": {"contribution_score": "-50", "net_pnl": "10"},
+                "MSFT": {"contribution_score": "100", "net_pnl": "120"},
             },
             branch_count=2,
             min_universe_size=2,
         )
-        self.assertEqual(children[0][0], 'AVGO')
-        self.assertEqual(children[0][1]['universe_symbols'], ['NVDA', 'MSFT'])
-        self.assertEqual(children[1][0], 'NVDA')
-        self.assertEqual(children[1][1]['universe_symbols'], ['AVGO', 'MSFT'])
+        self.assertEqual(children[0][0], "AVGO")
+        self.assertEqual(children[0][1]["universe_symbols"], ["NVDA", "MSFT"])
+        self.assertEqual(children[1][0], "NVDA")
+        self.assertEqual(children[1][1]["universe_symbols"], ["AVGO", "MSFT"])
 
-    def test_consistency_penalty_rejects_lucky_strike_and_low_notional_profile(self) -> None:
+    def test_consistency_penalty_rejects_lucky_strike_and_low_notional_profile(
+        self,
+    ) -> None:
         penalties, summary = frontier._consistency_penalty(
             full_window_payload=self._payload(
-                start_date='2026-03-24',
-                end_date='2026-04-02',
+                start_date="2026-03-24",
+                end_date="2026-04-02",
                 daily_net={
-                    '2026-03-24': '0',
-                    '2026-03-25': '0',
-                    '2026-03-26': '0',
-                    '2026-03-27': '0',
-                    '2026-03-30': '0',
-                    '2026-03-31': '-150',
-                    '2026-04-01': '-100',
-                    '2026-04-02': '2650',
+                    "2026-03-24": "0",
+                    "2026-03-25": "0",
+                    "2026-03-26": "0",
+                    "2026-03-27": "0",
+                    "2026-03-30": "0",
+                    "2026-03-31": "-150",
+                    "2026-04-01": "-100",
+                    "2026-04-02": "2650",
                 },
                 daily_filled_notional={
-                    '2026-03-24': '0',
-                    '2026-03-25': '0',
-                    '2026-03-26': '0',
-                    '2026-03-27': '0',
-                    '2026-03-30': '0',
-                    '2026-03-31': '40000',
-                    '2026-04-01': '50000',
-                    '2026-04-02': '60000',
+                    "2026-03-24": "0",
+                    "2026-03-25": "0",
+                    "2026-03-26": "0",
+                    "2026-03-27": "0",
+                    "2026-03-30": "0",
+                    "2026-03-31": "40000",
+                    "2026-04-01": "50000",
+                    "2026-04-02": "60000",
                 },
                 decision_count=3,
                 filled_count=3,
@@ -662,130 +874,136 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
                 losses=2,
             ),
             policy=frontier.FullWindowConsistencyPolicy(
-                target_net_per_day=frontier.Decimal('300'),
-                min_daily_net_pnl=frontier.Decimal('0'),
+                target_net_per_day=frontier.Decimal("300"),
+                min_daily_net_pnl=frontier.Decimal("0"),
                 min_active_days=6,
-                min_active_ratio=frontier.Decimal('0.75'),
+                min_active_ratio=frontier.Decimal("0.75"),
                 min_positive_days=4,
-                max_worst_day_loss=frontier.Decimal('250'),
+                max_worst_day_loss=frontier.Decimal("250"),
                 max_negative_days=2,
-                max_drawdown=frontier.Decimal('500'),
-                max_best_day_share_of_total_pnl=frontier.Decimal('0.55'),
-                min_avg_filled_notional_per_day=frontier.Decimal('150000'),
-                min_avg_filled_notional_per_active_day=frontier.Decimal('200000'),
+                max_drawdown=frontier.Decimal("500"),
+                max_best_day_share_of_total_pnl=frontier.Decimal("0.55"),
+                min_avg_filled_notional_per_day=frontier.Decimal("150000"),
+                min_avg_filled_notional_per_active_day=frontier.Decimal("200000"),
                 require_every_day_active=False,
             ),
         )
 
-        self.assertGreater(penalties, frontier.Decimal('0'))
-        self.assertEqual(summary['active_days'], 3)
-        self.assertEqual(summary['positive_days'], 1)
-        self.assertEqual(summary['best_day_share_of_total_pnl'], '1.104166666666666666666666667')
-        self.assertEqual(summary['avg_filled_notional_per_day'], '18750')
+        self.assertGreater(penalties, frontier.Decimal("0"))
+        self.assertEqual(summary["active_days"], 3)
+        self.assertEqual(summary["positive_days"], 1)
+        self.assertEqual(
+            summary["best_day_share_of_total_pnl"], "1.104166666666666666666666667"
+        )
+        self.assertEqual(summary["avg_filled_notional_per_day"], "18750")
 
     def test_consistency_penalty_reports_and_penalizes_capital_realism(self) -> None:
         payload = self._payload(
-            start_date='2026-03-24',
-            end_date='2026-03-26',
+            start_date="2026-03-24",
+            end_date="2026-03-26",
             daily_net={
-                '2026-03-24': '600',
-                '2026-03-25': '550',
-                '2026-03-26': '650',
+                "2026-03-24": "600",
+                "2026-03-25": "550",
+                "2026-03-26": "650",
             },
             daily_filled_notional={
-                '2026-03-24': '250000',
-                '2026-03-25': '260000',
-                '2026-03-26': '270000',
+                "2026-03-24": "250000",
+                "2026-03-25": "260000",
+                "2026-03-26": "270000",
             },
             decision_count=12,
             filled_count=12,
             wins=9,
             losses=3,
         )
-        daily = cast(dict[str, dict[str, object]], payload['daily'])
-        daily['2026-03-24']['min_cash'] = '12000'
-        daily['2026-03-24']['max_gross_exposure_pct_equity'] = '0.80'
-        daily['2026-03-24']['negative_cash_observation_count'] = 0
-        daily['2026-03-25']['min_cash'] = '-2500'
-        daily['2026-03-25']['max_gross_exposure_pct_equity'] = '2.40'
-        daily['2026-03-25']['negative_cash_observation_count'] = 3
-        daily['2026-03-26']['min_cash'] = '8000'
-        daily['2026-03-26']['max_gross_exposure_pct_equity'] = '1.10'
-        daily['2026-03-26']['negative_cash_observation_count'] = 0
+        daily = cast(dict[str, dict[str, object]], payload["daily"])
+        daily["2026-03-24"]["min_cash"] = "12000"
+        daily["2026-03-24"]["max_gross_exposure_pct_equity"] = "0.80"
+        daily["2026-03-24"]["negative_cash_observation_count"] = 0
+        daily["2026-03-25"]["min_cash"] = "-2500"
+        daily["2026-03-25"]["max_gross_exposure_pct_equity"] = "2.40"
+        daily["2026-03-25"]["negative_cash_observation_count"] = 3
+        daily["2026-03-26"]["min_cash"] = "8000"
+        daily["2026-03-26"]["max_gross_exposure_pct_equity"] = "1.10"
+        daily["2026-03-26"]["negative_cash_observation_count"] = 0
 
         penalties, summary = frontier._consistency_penalty(
             full_window_payload=payload,
             policy=frontier.FullWindowConsistencyPolicy(
-                target_net_per_day=frontier.Decimal('500'),
-                min_daily_net_pnl=frontier.Decimal('0'),
+                target_net_per_day=frontier.Decimal("500"),
+                min_daily_net_pnl=frontier.Decimal("0"),
                 min_active_days=3,
-                min_active_ratio=frontier.Decimal('1.0'),
+                min_active_ratio=frontier.Decimal("1.0"),
                 min_positive_days=3,
-                max_worst_day_loss=frontier.Decimal('0'),
+                max_worst_day_loss=frontier.Decimal("0"),
                 max_negative_days=0,
-                max_drawdown=frontier.Decimal('0'),
-                max_best_day_share_of_total_pnl=frontier.Decimal('0.60'),
-                min_avg_filled_notional_per_day=frontier.Decimal('200000'),
-                min_avg_filled_notional_per_active_day=frontier.Decimal('200000'),
+                max_drawdown=frontier.Decimal("0"),
+                max_best_day_share_of_total_pnl=frontier.Decimal("0.60"),
+                min_avg_filled_notional_per_day=frontier.Decimal("200000"),
+                min_avg_filled_notional_per_active_day=frontier.Decimal("200000"),
                 require_every_day_active=True,
-                max_gross_exposure_pct_equity=frontier.Decimal('1.50'),
-                min_cash=frontier.Decimal('0'),
+                max_gross_exposure_pct_equity=frontier.Decimal("1.50"),
+                min_cash=frontier.Decimal("0"),
             ),
         )
 
-        self.assertGreater(penalties, frontier.Decimal('0'))
-        self.assertEqual(summary['max_gross_exposure_pct_equity'], '2.40')
-        self.assertEqual(summary['min_cash'], '-2500')
-        self.assertEqual(summary['negative_cash_observation_count'], 3)
-        self.assertEqual(summary['daily_min_cash']['2026-03-25'], '-2500')
+        self.assertGreater(penalties, frontier.Decimal("0"))
+        self.assertEqual(summary["max_gross_exposure_pct_equity"], "2.40")
+        self.assertEqual(summary["min_cash"], "-2500")
+        self.assertEqual(summary["negative_cash_observation_count"], 3)
+        self.assertEqual(summary["daily_min_cash"]["2026-03-25"], "-2500")
 
     def test_main_prefers_consistent_candidate_over_prettier_holdout(self) -> None:
         with TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
             strategy_configmap = self._write_strategy_configmap(root)
             sweep_config = self._write_sweep_config(root)
-            json_output = root / 'frontier.json'
+            json_output = root / "frontier.json"
             args = self._make_args(
                 strategy_configmap=strategy_configmap,
                 sweep_config=sweep_config,
                 json_output=json_output,
             )
-            recent_days = tuple(date(2026, 3, 18) + timedelta(days=index) for index in range(6))
+            recent_days = tuple(
+                date(2026, 3, 18) + timedelta(days=index) for index in range(6)
+            )
 
             def fake_run_replay(config: object) -> dict[str, object]:
-                configmap_path = Path(getattr(config, 'strategy_configmap_path'))
-                payload = yaml.safe_load(configmap_path.read_text(encoding='utf-8'))
+                configmap_path = Path(getattr(config, "strategy_configmap_path"))
+                payload = yaml.safe_load(configmap_path.read_text(encoding="utf-8"))
                 strategy = next(
                     item
-                    for item in yaml.safe_load(payload['data']['strategies.yaml'])['strategies']
-                    if item['name'] == 'intraday-tsmom-profit-v3'
+                    for item in yaml.safe_load(payload["data"]["strategies.yaml"])[
+                        "strategies"
+                    ]
+                    if item["name"] == "intraday-tsmom-profit-v3"
                 )
-                stop = str(strategy['params']['long_stop_loss_bps'])
-                start_date = str(getattr(config, 'start_date'))
-                end_date = str(getattr(config, 'end_date'))
-                if start_date == '2026-03-18' and end_date == '2026-03-20':
+                stop = str(strategy["params"]["long_stop_loss_bps"])
+                start_date = str(getattr(config, "start_date"))
+                end_date = str(getattr(config, "end_date"))
+                if start_date == "2026-03-18" and end_date == "2026-03-20":
                     return self._payload(
-                        start_date='2026-03-18',
-                        end_date='2026-03-20',
+                        start_date="2026-03-18",
+                        end_date="2026-03-20",
                         daily_net={
-                            '2026-03-18': '80',
-                            '2026-03-19': '90',
-                            '2026-03-20': '85',
+                            "2026-03-18": "80",
+                            "2026-03-19": "90",
+                            "2026-03-20": "85",
                         },
                         decision_count=3,
                         filled_count=3,
                         wins=3,
                         losses=0,
                     )
-                if start_date == '2026-03-21' and end_date == '2026-03-23':
-                    if stop == '12':
+                if start_date == "2026-03-21" and end_date == "2026-03-23":
+                    if stop == "12":
                         return self._payload(
-                            start_date='2026-03-21',
-                            end_date='2026-03-23',
+                            start_date="2026-03-21",
+                            end_date="2026-03-23",
                             daily_net={
-                                '2026-03-21': '450',
-                                '2026-03-22': '0',
-                                '2026-03-23': '0',
+                                "2026-03-21": "450",
+                                "2026-03-22": "0",
+                                "2026-03-23": "0",
                             },
                             decision_count=1,
                             filled_count=1,
@@ -793,29 +1011,29 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
                             losses=0,
                         )
                     return self._payload(
-                        start_date='2026-03-21',
-                        end_date='2026-03-23',
+                        start_date="2026-03-21",
+                        end_date="2026-03-23",
                         daily_net={
-                            '2026-03-21': '220',
-                            '2026-03-22': '210',
-                            '2026-03-23': '205',
+                            "2026-03-21": "220",
+                            "2026-03-22": "210",
+                            "2026-03-23": "205",
                         },
                         decision_count=3,
                         filled_count=3,
                         wins=3,
                         losses=0,
                     )
-                if stop == '12':
+                if stop == "12":
                     return self._payload(
-                        start_date='2026-03-18',
-                        end_date='2026-03-23',
+                        start_date="2026-03-18",
+                        end_date="2026-03-23",
                         daily_net={
-                            '2026-03-18': '80',
-                            '2026-03-19': '90',
-                            '2026-03-20': '85',
-                            '2026-03-21': '450',
-                            '2026-03-22': '0',
-                            '2026-03-23': '0',
+                            "2026-03-18": "80",
+                            "2026-03-19": "90",
+                            "2026-03-20": "85",
+                            "2026-03-21": "450",
+                            "2026-03-22": "0",
+                            "2026-03-23": "0",
                         },
                         decision_count=4,
                         filled_count=4,
@@ -823,15 +1041,15 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
                         losses=0,
                     )
                 return self._payload(
-                    start_date='2026-03-18',
-                    end_date='2026-03-23',
+                    start_date="2026-03-18",
+                    end_date="2026-03-23",
                     daily_net={
-                        '2026-03-18': '80',
-                        '2026-03-19': '90',
-                        '2026-03-20': '85',
-                        '2026-03-21': '220',
-                        '2026-03-22': '210',
-                        '2026-03-23': '205',
+                        "2026-03-18": "80",
+                        "2026-03-19": "90",
+                        "2026-03-20": "85",
+                        "2026-03-21": "220",
+                        "2026-03-22": "210",
+                        "2026-03-23": "205",
                     },
                     decision_count=6,
                     filled_count=6,
@@ -841,160 +1059,194 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
 
             stdout = io.StringIO()
             snapshot_receipt = SimpleNamespace(
-                snapshot_id='snap-test',
+                snapshot_id="snap-test",
                 is_fresh=True,
                 stale_override_used=False,
                 to_payload=lambda: {
-                    'snapshot_id': 'snap-test',
-                    'source': 'ta',
-                    'window_size': 'PT1S',
-                    'start_day': '2026-03-18',
-                    'end_day': '2026-03-23',
-                    'expected_last_trading_day': '2026-03-23',
-                    'is_fresh': True,
-                    'missing_days': [],
-                    'row_count': 123,
-                    'stale_override_used': False,
-                    'witnesses': [],
+                    "snapshot_id": "snap-test",
+                    "source": "ta",
+                    "window_size": "PT1S",
+                    "start_day": "2026-03-18",
+                    "end_day": "2026-03-23",
+                    "expected_last_trading_day": "2026-03-23",
+                    "is_fresh": True,
+                    "missing_days": [],
+                    "row_count": 123,
+                    "stale_override_used": False,
+                    "witnesses": [],
                 },
             )
             with (
-                patch('scripts.search_consistent_profitability_frontier._parse_args', return_value=args),
-                patch('scripts.search_consistent_profitability_frontier._resolve_recent_trading_days', return_value=recent_days),
-                patch('scripts.search_consistent_profitability_frontier.build_dataset_snapshot_receipt', return_value=snapshot_receipt),
-                patch('scripts.search_consistent_profitability_frontier.ensure_fresh_snapshot'),
-                patch('scripts.search_consistent_profitability_frontier.run_replay', side_effect=fake_run_replay),
+                patch(
+                    "scripts.search_consistent_profitability_frontier._parse_args",
+                    return_value=args,
+                ),
+                patch(
+                    "scripts.search_consistent_profitability_frontier._resolve_recent_trading_days",
+                    return_value=recent_days,
+                ),
+                patch(
+                    "scripts.search_consistent_profitability_frontier.build_dataset_snapshot_receipt",
+                    return_value=snapshot_receipt,
+                ),
+                patch(
+                    "scripts.search_consistent_profitability_frontier.ensure_fresh_snapshot"
+                ),
+                patch(
+                    "scripts.search_consistent_profitability_frontier.run_replay",
+                    side_effect=fake_run_replay,
+                ),
                 redirect_stdout(stdout),
             ):
                 exit_code = frontier.main()
 
             self.assertEqual(exit_code, 0)
-            payload = json.loads(json_output.read_text(encoding='utf-8'))
+            payload = json.loads(json_output.read_text(encoding="utf-8"))
             stdout_payload = json.loads(stdout.getvalue())
             self.assertEqual(payload, stdout_payload)
-            top = payload['top'][0]
-            self.assertEqual(top['replay_config']['params']['long_stop_loss_bps'], '18')
-            self.assertEqual(top['full_window']['active_days'], 6)
-            self.assertEqual(payload['dataset_snapshot_receipt']['snapshot_id'], 'snap-test')
-            self.assertEqual(top['ranking']['method'], 'pareto_frontier_v2')
-            self.assertEqual(top['family_template_id'], 'intraday_tsmom_v2')
+            top = payload["top"][0]
+            self.assertEqual(top["replay_config"]["params"]["long_stop_loss_bps"], "18")
+            self.assertEqual(top["full_window"]["active_days"], 6)
+            self.assertEqual(
+                payload["dataset_snapshot_receipt"]["snapshot_id"], "snap-test"
+            )
+            self.assertEqual(top["ranking"]["method"], "pareto_frontier_v2")
+            self.assertEqual(top["family_template_id"], "intraday_tsmom_v2")
 
     def test_run_frontier_writes_partial_json_output_between_candidates(self) -> None:
         with TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
             strategy_configmap = self._write_strategy_configmap(root)
-            sweep_config = root / 'sweep.yaml'
+            sweep_config = root / "sweep.yaml"
             sweep_config.write_text(
                 yaml.safe_dump(
                     {
-                        'schema_version': 'torghut.replay-frontier-sweep.v1',
-                        'family': 'intraday_tsmom_consistent',
-                        'strategy_name': 'intraday-tsmom-profit-v3',
-                        'disable_other_strategies': True,
-                        'constraints': {
-                            'holdout_target_net_per_day': '200',
-                            'min_active_holdout_days': 2,
-                            'max_worst_holdout_day_loss': '200',
-                            'min_profit_factor': '1.0',
+                        "schema_version": "torghut.replay-frontier-sweep.v1",
+                        "family": "intraday_tsmom_consistent",
+                        "strategy_name": "intraday-tsmom-profit-v3",
+                        "disable_other_strategies": True,
+                        "constraints": {
+                            "holdout_target_net_per_day": "200",
+                            "min_active_holdout_days": 2,
+                            "max_worst_holdout_day_loss": "200",
+                            "min_profit_factor": "1.0",
                         },
-                        'consistency_constraints': {
-                            'target_net_per_day': '200',
-                            'min_active_days': 2,
-                            'max_worst_day_loss': '300',
-                            'max_negative_days': 1,
-                            'max_drawdown': '400',
-                            'require_every_day_active': False,
+                        "consistency_constraints": {
+                            "target_net_per_day": "200",
+                            "min_active_days": 2,
+                            "max_worst_day_loss": "300",
+                            "max_negative_days": 1,
+                            "max_drawdown": "400",
+                            "require_every_day_active": False,
                         },
-                        'strategy_overrides': {
-                            'universe_symbols': [['NVDA']],
+                        "strategy_overrides": {
+                            "universe_symbols": [["NVDA"]],
                         },
-                        'parameters': {
-                            'long_stop_loss_bps': ['12', '18'],
+                        "parameters": {
+                            "long_stop_loss_bps": ["12", "18"],
                         },
                     },
                     sort_keys=False,
                 ),
-                encoding='utf-8',
+                encoding="utf-8",
             )
-            json_output = root / 'frontier.json'
+            json_output = root / "frontier.json"
             args = self._make_args(
                 strategy_configmap=strategy_configmap,
                 sweep_config=sweep_config,
                 json_output=json_output,
             )
-            args.min_train_screen_net_per_day = '1'
+            args.min_train_screen_net_per_day = "1"
             args.collect_train_gate_diagnostics = True
-            recent_days = tuple(date(2026, 3, 18) + timedelta(days=index) for index in range(6))
+            recent_days = tuple(
+                date(2026, 3, 18) + timedelta(days=index) for index in range(6)
+            )
             snapshot_receipt = SimpleNamespace(
-                snapshot_id='snap-partial',
+                snapshot_id="snap-partial",
                 is_fresh=True,
                 stale_override_used=False,
                 to_payload=lambda: {
-                    'snapshot_id': 'snap-partial',
-                    'source': 'ta',
-                    'window_size': 'PT1S',
-                    'start_day': '2026-03-18',
-                    'end_day': '2026-03-23',
-                    'expected_last_trading_day': '2026-03-23',
-                    'is_fresh': True,
-                    'missing_days': [],
-                    'row_count': 123,
-                    'stale_override_used': False,
-                    'witnesses': [],
+                    "snapshot_id": "snap-partial",
+                    "source": "ta",
+                    "window_size": "PT1S",
+                    "start_day": "2026-03-18",
+                    "end_day": "2026-03-23",
+                    "expected_last_trading_day": "2026-03-23",
+                    "is_fresh": True,
+                    "missing_days": [],
+                    "row_count": 123,
+                    "stale_override_used": False,
+                    "witnesses": [],
                 },
             )
-            replay_call_count = {'count': 0}
+            replay_call_count = {"count": 0}
 
             def fake_run_replay(config: object) -> dict[str, object]:
-                replay_call_count['count'] += 1
-                if replay_call_count['count'] == 4:
-                    partial_payload = json.loads(json_output.read_text(encoding='utf-8'))
-                    self.assertEqual(partial_payload['status'], 'running')
-                    self.assertEqual(partial_payload['candidate_count'], 1)
-                    self.assertEqual(partial_payload['progress']['evaluated_candidates'], 1)
-                    self.assertGreaterEqual(partial_payload['progress']['pending_candidates'], 0)
-                    self.assertEqual(len(partial_payload['top']), 1)
+                replay_call_count["count"] += 1
+                if replay_call_count["count"] == 4:
+                    partial_payload = json.loads(
+                        json_output.read_text(encoding="utf-8")
+                    )
+                    self.assertEqual(partial_payload["status"], "running")
+                    self.assertEqual(partial_payload["candidate_count"], 1)
+                    self.assertEqual(
+                        partial_payload["progress"]["evaluated_candidates"], 1
+                    )
+                    self.assertGreaterEqual(
+                        partial_payload["progress"]["pending_candidates"], 0
+                    )
+                    self.assertEqual(len(partial_payload["top"]), 1)
 
-                configmap_path = Path(getattr(config, 'strategy_configmap_path'))
-                payload = yaml.safe_load(configmap_path.read_text(encoding='utf-8'))
+                configmap_path = Path(getattr(config, "strategy_configmap_path"))
+                payload = yaml.safe_load(configmap_path.read_text(encoding="utf-8"))
                 strategy = next(
                     item
-                    for item in yaml.safe_load(payload['data']['strategies.yaml'])['strategies']
-                    if item['name'] == 'intraday-tsmom-profit-v3'
+                    for item in yaml.safe_load(payload["data"]["strategies.yaml"])[
+                        "strategies"
+                    ]
+                    if item["name"] == "intraday-tsmom-profit-v3"
                 )
-                stop = str(strategy['params']['long_stop_loss_bps'])
-                start_date = str(getattr(config, 'start_date'))
-                end_date = str(getattr(config, 'end_date'))
-                if start_date == '2026-03-18' and end_date == '2026-03-20':
+                stop = str(strategy["params"]["long_stop_loss_bps"])
+                start_date = str(getattr(config, "start_date"))
+                end_date = str(getattr(config, "end_date"))
+                if start_date == "2026-03-18" and end_date == "2026-03-20":
                     daily_net = (
-                        {'2026-03-18': '90', '2026-03-19': '95', '2026-03-20': '100'}
-                        if stop == '18'
-                        else {'2026-03-18': '60', '2026-03-19': '55', '2026-03-20': '50'}
+                        {"2026-03-18": "90", "2026-03-19": "95", "2026-03-20": "100"}
+                        if stop == "18"
+                        else {
+                            "2026-03-18": "60",
+                            "2026-03-19": "55",
+                            "2026-03-20": "50",
+                        }
                     )
-                elif start_date == '2026-03-21' and end_date == '2026-03-23':
+                elif start_date == "2026-03-21" and end_date == "2026-03-23":
                     daily_net = (
-                        {'2026-03-21': '220', '2026-03-22': '210', '2026-03-23': '205'}
-                        if stop == '18'
-                        else {'2026-03-21': '120', '2026-03-22': '115', '2026-03-23': '110'}
+                        {"2026-03-21": "220", "2026-03-22": "210", "2026-03-23": "205"}
+                        if stop == "18"
+                        else {
+                            "2026-03-21": "120",
+                            "2026-03-22": "115",
+                            "2026-03-23": "110",
+                        }
                     )
                 else:
                     daily_net = (
                         {
-                            '2026-03-18': '90',
-                            '2026-03-19': '95',
-                            '2026-03-20': '100',
-                            '2026-03-21': '220',
-                            '2026-03-22': '210',
-                            '2026-03-23': '205',
+                            "2026-03-18": "90",
+                            "2026-03-19": "95",
+                            "2026-03-20": "100",
+                            "2026-03-21": "220",
+                            "2026-03-22": "210",
+                            "2026-03-23": "205",
                         }
-                        if stop == '18'
+                        if stop == "18"
                         else {
-                            '2026-03-18': '60',
-                            '2026-03-19': '55',
-                            '2026-03-20': '50',
-                            '2026-03-21': '120',
-                            '2026-03-22': '115',
-                            '2026-03-23': '110',
+                            "2026-03-18": "60",
+                            "2026-03-19": "55",
+                            "2026-03-20": "50",
+                            "2026-03-21": "120",
+                            "2026-03-22": "115",
+                            "2026-03-23": "110",
                         }
                     )
                 replay_payload = self._payload(
@@ -1006,107 +1258,131 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
                     wins=3,
                     losses=0,
                 )
-                if getattr(config, 'capture_trace_funnel', False):
-                    replay_payload['funnel'] = {
-                        'buckets': [
+                if getattr(config, "capture_trace_funnel", False):
+                    replay_payload["funnel"] = {
+                        "buckets": [
                             {
-                                'strategy_evaluations': 2,
-                                'passed_trace_count': 0,
-                                'first_failed_gate_counts': {'breakout:confirmation': 2},
+                                "strategy_evaluations": 2,
+                                "passed_trace_count": 0,
+                                "first_failed_gate_counts": {
+                                    "breakout:confirmation": 2
+                                },
                             }
                         ]
                     }
                 return replay_payload
 
             with (
-                patch('scripts.search_consistent_profitability_frontier._resolve_recent_trading_days', return_value=recent_days),
-                patch('scripts.search_consistent_profitability_frontier.build_dataset_snapshot_receipt', return_value=snapshot_receipt),
-                patch('scripts.search_consistent_profitability_frontier.ensure_fresh_snapshot'),
-                patch('scripts.search_consistent_profitability_frontier.run_replay', side_effect=fake_run_replay),
+                patch(
+                    "scripts.search_consistent_profitability_frontier._resolve_recent_trading_days",
+                    return_value=recent_days,
+                ),
+                patch(
+                    "scripts.search_consistent_profitability_frontier.build_dataset_snapshot_receipt",
+                    return_value=snapshot_receipt,
+                ),
+                patch(
+                    "scripts.search_consistent_profitability_frontier.ensure_fresh_snapshot"
+                ),
+                patch(
+                    "scripts.search_consistent_profitability_frontier.run_replay",
+                    side_effect=fake_run_replay,
+                ),
             ):
                 payload = frontier.run_consistent_profitability_frontier(args)
 
-            self.assertEqual(payload['status'], 'completed')
-            self.assertEqual(payload['candidate_count'], 2)
-            self.assertEqual(payload['top'][0]['train_gate_diagnostics']['status'], 'available')
-            persisted = json.loads(json_output.read_text(encoding='utf-8'))
-            self.assertEqual(persisted['status'], 'completed')
-            self.assertEqual(persisted['candidate_count'], 2)
+            self.assertEqual(payload["status"], "completed")
+            self.assertEqual(payload["candidate_count"], 2)
+            self.assertEqual(
+                payload["top"][0]["train_gate_diagnostics"]["status"], "available"
+            )
+            persisted = json.loads(json_output.read_text(encoding="utf-8"))
+            self.assertEqual(persisted["status"], "completed")
+            self.assertEqual(persisted["candidate_count"], 2)
 
-    def test_run_frontier_train_screen_skips_dead_candidate_expensive_replays(self) -> None:
+    def test_run_frontier_train_screen_skips_dead_candidate_expensive_replays(
+        self,
+    ) -> None:
         with TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
             strategy_configmap = self._write_strategy_configmap(root)
-            sweep_config = root / 'sweep.yaml'
+            sweep_config = root / "sweep.yaml"
             sweep_config.write_text(
                 yaml.safe_dump(
                     {
-                        'schema_version': 'torghut.replay-frontier-sweep.v1',
-                        'family': 'intraday_tsmom_consistent',
-                        'strategy_name': 'intraday-tsmom-profit-v3',
-                        'disable_other_strategies': True,
-                        'constraints': {
-                            'holdout_target_net_per_day': '200',
-                            'min_active_holdout_days': 2,
-                            'max_worst_holdout_day_loss': '200',
-                            'min_profit_factor': '1.0',
+                        "schema_version": "torghut.replay-frontier-sweep.v1",
+                        "family": "intraday_tsmom_consistent",
+                        "strategy_name": "intraday-tsmom-profit-v3",
+                        "disable_other_strategies": True,
+                        "constraints": {
+                            "holdout_target_net_per_day": "200",
+                            "min_active_holdout_days": 2,
+                            "max_worst_holdout_day_loss": "200",
+                            "min_profit_factor": "1.0",
                         },
-                        'consistency_constraints': {
-                            'target_net_per_day': '200',
-                            'min_active_days': 2,
-                            'max_worst_day_loss': '300',
-                            'max_negative_days': 1,
-                            'max_drawdown': '400',
-                            'require_every_day_active': True,
+                        "consistency_constraints": {
+                            "target_net_per_day": "200",
+                            "min_active_days": 2,
+                            "max_worst_day_loss": "300",
+                            "max_negative_days": 1,
+                            "max_drawdown": "400",
+                            "require_every_day_active": True,
                         },
-                        'strategy_overrides': {
-                            'universe_symbols': [['NVDA']],
+                        "strategy_overrides": {
+                            "universe_symbols": [["NVDA"]],
                         },
-                        'parameters': {
-                            'long_stop_loss_bps': ['12'],
+                        "parameters": {
+                            "long_stop_loss_bps": ["12"],
                         },
                     },
                     sort_keys=False,
                 ),
-                encoding='utf-8',
+                encoding="utf-8",
             )
-            json_output = root / 'frontier.json'
+            json_output = root / "frontier.json"
             args = self._make_args(
                 strategy_configmap=strategy_configmap,
                 sweep_config=sweep_config,
                 json_output=json_output,
             )
-            args.min_train_screen_net_per_day = '1'
-            recent_days = tuple(date(2026, 3, 18) + timedelta(days=index) for index in range(6))
+            args.min_train_screen_net_per_day = "1"
+            recent_days = tuple(
+                date(2026, 3, 18) + timedelta(days=index) for index in range(6)
+            )
             snapshot_receipt = SimpleNamespace(
-                snapshot_id='snap-screen',
+                snapshot_id="snap-screen",
                 is_fresh=True,
                 stale_override_used=False,
                 to_payload=lambda: {
-                    'snapshot_id': 'snap-screen',
-                    'source': 'ta',
-                    'window_size': 'PT1S',
-                    'start_day': '2026-03-18',
-                    'end_day': '2026-03-23',
-                    'expected_last_trading_day': '2026-03-23',
-                    'is_fresh': True,
-                    'missing_days': [],
-                    'row_count': 123,
-                    'stale_override_used': False,
-                    'witnesses': [],
+                    "snapshot_id": "snap-screen",
+                    "source": "ta",
+                    "window_size": "PT1S",
+                    "start_day": "2026-03-18",
+                    "end_day": "2026-03-23",
+                    "expected_last_trading_day": "2026-03-23",
+                    "is_fresh": True,
+                    "missing_days": [],
+                    "row_count": 123,
+                    "stale_override_used": False,
+                    "witnesses": [],
                 },
             )
             replay_calls: list[tuple[str, str]] = []
 
             def fake_run_replay(config: object) -> dict[str, object]:
-                replay_calls.append((str(getattr(config, 'start_date')), str(getattr(config, 'end_date'))))
+                replay_calls.append(
+                    (
+                        str(getattr(config, "start_date")),
+                        str(getattr(config, "end_date")),
+                    )
+                )
                 return self._payload(
-                    start_date='2026-03-18',
-                    end_date='2026-03-20',
+                    start_date="2026-03-18",
+                    end_date="2026-03-20",
                     daily_net={
-                        '2026-03-18': '0',
-                        '2026-03-19': '0',
-                        '2026-03-20': '0',
+                        "2026-03-18": "0",
+                        "2026-03-19": "0",
+                        "2026-03-20": "0",
                     },
                     decision_count=0,
                     filled_count=0,
@@ -1115,59 +1391,76 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
                 )
 
             with (
-                patch('scripts.search_consistent_profitability_frontier._resolve_recent_trading_days', return_value=recent_days),
-                patch('scripts.search_consistent_profitability_frontier.build_dataset_snapshot_receipt', return_value=snapshot_receipt),
-                patch('scripts.search_consistent_profitability_frontier.ensure_fresh_snapshot'),
-                patch('scripts.search_consistent_profitability_frontier.run_replay', side_effect=fake_run_replay),
+                patch(
+                    "scripts.search_consistent_profitability_frontier._resolve_recent_trading_days",
+                    return_value=recent_days,
+                ),
+                patch(
+                    "scripts.search_consistent_profitability_frontier.build_dataset_snapshot_receipt",
+                    return_value=snapshot_receipt,
+                ),
+                patch(
+                    "scripts.search_consistent_profitability_frontier.ensure_fresh_snapshot"
+                ),
+                patch(
+                    "scripts.search_consistent_profitability_frontier.run_replay",
+                    side_effect=fake_run_replay,
+                ),
             ):
                 payload = frontier.run_consistent_profitability_frontier(args)
 
-            self.assertEqual(replay_calls, [('2026-03-18', '2026-03-20')])
-            self.assertEqual(payload['candidate_count'], 1)
-            top = payload['top'][0]
-            self.assertEqual(top['screening']['status'], 'rejected')
-            self.assertTrue(top['screening']['holdout_replay_skipped'])
-            self.assertTrue(top['screening']['full_window_replay_skipped'])
-            self.assertIn('train_no_decisions', top['hard_vetoes'])
-            self.assertIn('train_net_per_day_below_screen', top['hard_vetoes'])
+            self.assertEqual(replay_calls, [("2026-03-18", "2026-03-20")])
+            self.assertEqual(payload["candidate_count"], 1)
+            top = payload["top"][0]
+            self.assertEqual(top["screening"]["status"], "rejected")
+            self.assertTrue(top["screening"]["holdout_replay_skipped"])
+            self.assertTrue(top["screening"]["full_window_replay_skipped"])
+            self.assertIn("train_no_decisions", top["hard_vetoes"])
+            self.assertIn("train_net_per_day_below_screen", top["hard_vetoes"])
 
     def test_run_frontier_respects_candidate_budget(self) -> None:
         with TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
             strategy_configmap = self._write_strategy_configmap(root)
             sweep_config = self._write_sweep_config(root)
-            json_output = root / 'nested' / 'frontier.json'
+            json_output = root / "nested" / "frontier.json"
             args = self._make_args(
                 strategy_configmap=strategy_configmap,
                 sweep_config=sweep_config,
                 json_output=json_output,
             )
             args.max_candidates_to_evaluate = 1
-            recent_days = tuple(date(2026, 3, 18) + timedelta(days=index) for index in range(6))
+            recent_days = tuple(
+                date(2026, 3, 18) + timedelta(days=index) for index in range(6)
+            )
             snapshot_receipt = SimpleNamespace(
-                snapshot_id='snap-budget',
+                snapshot_id="snap-budget",
                 is_fresh=True,
                 stale_override_used=False,
                 to_payload=lambda: {
-                    'snapshot_id': 'snap-budget',
-                    'source': 'ta',
-                    'window_size': 'PT1S',
-                    'start_day': '2026-03-18',
-                    'end_day': '2026-03-23',
-                    'expected_last_trading_day': '2026-03-23',
-                    'is_fresh': True,
-                    'missing_days': [],
-                    'row_count': 123,
-                    'stale_override_used': False,
-                    'witnesses': [],
+                    "snapshot_id": "snap-budget",
+                    "source": "ta",
+                    "window_size": "PT1S",
+                    "start_day": "2026-03-18",
+                    "end_day": "2026-03-23",
+                    "expected_last_trading_day": "2026-03-23",
+                    "is_fresh": True,
+                    "missing_days": [],
+                    "row_count": 123,
+                    "stale_override_used": False,
+                    "witnesses": [],
                 },
             )
 
             def fake_run_replay(config: object) -> dict[str, object]:
                 return self._payload(
-                    start_date=str(getattr(config, 'start_date')),
-                    end_date=str(getattr(config, 'end_date')),
-                    daily_net={'2026-03-18': '100', '2026-03-19': '110', '2026-03-20': '120'},
+                    start_date=str(getattr(config, "start_date")),
+                    end_date=str(getattr(config, "end_date")),
+                    daily_net={
+                        "2026-03-18": "100",
+                        "2026-03-19": "110",
+                        "2026-03-20": "120",
+                    },
                     decision_count=3,
                     filled_count=3,
                     wins=3,
@@ -1175,35 +1468,64 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
                 )
 
             with (
-                patch('scripts.search_consistent_profitability_frontier._resolve_recent_trading_days', return_value=recent_days),
-                patch('scripts.search_consistent_profitability_frontier.build_dataset_snapshot_receipt', return_value=snapshot_receipt),
-                patch('scripts.search_consistent_profitability_frontier.ensure_fresh_snapshot'),
-                patch('scripts.search_consistent_profitability_frontier.run_replay', side_effect=fake_run_replay),
+                patch(
+                    "scripts.search_consistent_profitability_frontier._resolve_recent_trading_days",
+                    return_value=recent_days,
+                ),
+                patch(
+                    "scripts.search_consistent_profitability_frontier.build_dataset_snapshot_receipt",
+                    return_value=snapshot_receipt,
+                ),
+                patch(
+                    "scripts.search_consistent_profitability_frontier.ensure_fresh_snapshot"
+                ),
+                patch(
+                    "scripts.search_consistent_profitability_frontier.run_replay",
+                    side_effect=fake_run_replay,
+                ),
             ):
                 payload = frontier.run_consistent_profitability_frontier(args)
 
-            self.assertEqual(payload['status'], 'candidate_budget_exhausted')
-            self.assertEqual(payload['candidate_count'], 1)
-            self.assertGreater(payload['progress']['pending_candidates'], 0)
-            persisted = json.loads(json_output.read_text(encoding='utf-8'))
-            self.assertEqual(persisted['status'], 'candidate_budget_exhausted')
+            self.assertEqual(payload["status"], "candidate_budget_exhausted")
+            self.assertEqual(payload["candidate_count"], 1)
+            self.assertGreater(payload["progress"]["pending_candidates"], 0)
+            persisted = json.loads(json_output.read_text(encoding="utf-8"))
+            self.assertEqual(persisted["status"], "candidate_budget_exhausted")
 
     def test_initial_worklist_streams_large_parameter_product(self) -> None:
         candidates = frontier._iter_initial_worklist_candidates(
             parameter_grid={
-                'min_recent_microprice_bias_bps': list(range(10_000)),
-                'min_late_day_continuation_bps': list(range(10_000)),
+                "min_recent_microprice_bias_bps": list(range(10_000)),
+                "min_late_day_continuation_bps": list(range(10_000)),
             },
-            override_candidates=[{'universe_symbols': ['NVDA']}],
+            override_candidates=[{"universe_symbols": ["NVDA"]}],
         )
 
-        first_params, first_overrides, first_iteration, first_pruned_symbol, first_parent_id = next(candidates)
-        second_params, second_overrides, second_iteration, second_pruned_symbol, second_parent_id = next(candidates)
+        (
+            first_params,
+            first_overrides,
+            first_iteration,
+            first_pruned_symbol,
+            first_parent_id,
+        ) = next(candidates)
+        (
+            second_params,
+            second_overrides,
+            second_iteration,
+            second_pruned_symbol,
+            second_parent_id,
+        ) = next(candidates)
 
-        self.assertEqual(first_params, {'min_recent_microprice_bias_bps': 0, 'min_late_day_continuation_bps': 0})
-        self.assertEqual(second_params, {'min_recent_microprice_bias_bps': 1, 'min_late_day_continuation_bps': 0})
-        self.assertEqual(first_overrides, {'universe_symbols': ['NVDA']})
-        self.assertEqual(second_overrides, {'universe_symbols': ['NVDA']})
+        self.assertEqual(
+            first_params,
+            {"min_recent_microprice_bias_bps": 0, "min_late_day_continuation_bps": 0},
+        )
+        self.assertEqual(
+            second_params,
+            {"min_recent_microprice_bias_bps": 1, "min_late_day_continuation_bps": 0},
+        )
+        self.assertEqual(first_overrides, {"universe_symbols": ["NVDA"]})
+        self.assertEqual(second_overrides, {"universe_symbols": ["NVDA"]})
         self.assertEqual(first_iteration, 0)
         self.assertEqual(second_iteration, 0)
         self.assertIsNone(first_pruned_symbol)
@@ -1214,9 +1536,9 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
     def test_parameter_stream_prioritizes_entry_gates_for_small_budgets(self) -> None:
         candidates = frontier._iter_parameter_candidates(
             {
-                'long_stop_loss_bps': ['20', '24'],
-                'min_cross_section_continuation_rank': ['0.60', '0.70'],
-                'entry_cooldown_seconds': ['3600', '7200'],
+                "long_stop_loss_bps": ["20", "24"],
+                "min_cross_section_continuation_rank": ["0.60", "0.70"],
+                "entry_cooldown_seconds": ["3600", "7200"],
             }
         )
 
@@ -1224,49 +1546,49 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
         second = next(candidates)
         third = next(candidates)
 
-        self.assertEqual(first['min_cross_section_continuation_rank'], '0.60')
-        self.assertEqual(second['min_cross_section_continuation_rank'], '0.70')
-        self.assertEqual(second['long_stop_loss_bps'], '20')
-        self.assertEqual(third['long_stop_loss_bps'], '24')
+        self.assertEqual(first["min_cross_section_continuation_rank"], "0.60")
+        self.assertEqual(second["min_cross_section_continuation_rank"], "0.70")
+        self.assertEqual(second["long_stop_loss_bps"], "20")
+        self.assertEqual(third["long_stop_loss_bps"], "24")
 
     def test_main_symbol_pruning_promotes_pruned_universe(self) -> None:
         with TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
             strategy_configmap = self._write_strategy_configmap(root)
-            sweep_config = root / 'sweep.yaml'
+            sweep_config = root / "sweep.yaml"
             sweep_config.write_text(
                 yaml.safe_dump(
                     {
-                        'schema_version': 'torghut.replay-frontier-sweep.v1',
-                        'family': 'breakout_reclaim',
-                        'strategy_name': 'intraday-tsmom-profit-v3',
-                        'disable_other_strategies': True,
-                        'constraints': {
-                            'holdout_target_net_per_day': '200',
-                            'min_active_holdout_days': 2,
-                            'max_worst_holdout_day_loss': '200',
-                            'min_profit_factor': '1.0',
+                        "schema_version": "torghut.replay-frontier-sweep.v1",
+                        "family": "breakout_reclaim",
+                        "strategy_name": "intraday-tsmom-profit-v3",
+                        "disable_other_strategies": True,
+                        "constraints": {
+                            "holdout_target_net_per_day": "200",
+                            "min_active_holdout_days": 2,
+                            "max_worst_holdout_day_loss": "200",
+                            "min_profit_factor": "1.0",
                         },
-                        'consistency_constraints': {
-                            'target_net_per_day': '200',
-                            'min_active_days': 2,
-                            'max_worst_day_loss': '300',
-                            'max_negative_days': 1,
-                            'max_drawdown': '400',
-                            'require_every_day_active': False,
+                        "consistency_constraints": {
+                            "target_net_per_day": "200",
+                            "min_active_days": 2,
+                            "max_worst_day_loss": "300",
+                            "max_negative_days": 1,
+                            "max_drawdown": "400",
+                            "require_every_day_active": False,
                         },
-                        'strategy_overrides': {
-                            'universe_symbols': [['NVDA', 'AVGO']],
+                        "strategy_overrides": {
+                            "universe_symbols": [["NVDA", "AVGO"]],
                         },
-                        'parameters': {
-                            'long_stop_loss_bps': ['12'],
+                        "parameters": {
+                            "long_stop_loss_bps": ["12"],
                         },
                     },
                     sort_keys=False,
                 ),
-                encoding='utf-8',
+                encoding="utf-8",
             )
-            json_output = root / 'frontier.json'
+            json_output = root / "frontier.json"
             args = self._make_args(
                 strategy_configmap=strategy_configmap,
                 sweep_config=sweep_config,
@@ -1275,98 +1597,108 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
             args.symbol_prune_iterations = 1
             args.symbol_prune_candidates = 1
             args.symbol_prune_min_universe_size = 1
-            recent_days = tuple(date(2026, 3, 18) + timedelta(days=index) for index in range(6))
+            recent_days = tuple(
+                date(2026, 3, 18) + timedelta(days=index) for index in range(6)
+            )
             snapshot_receipt = SimpleNamespace(
-                snapshot_id='snap-prune',
+                snapshot_id="snap-prune",
                 is_fresh=True,
                 stale_override_used=False,
                 to_payload=lambda: {
-                    'snapshot_id': 'snap-prune',
-                    'source': 'ta',
-                    'window_size': 'PT1S',
-                    'start_day': '2026-03-18',
-                    'end_day': '2026-03-23',
-                    'expected_last_trading_day': '2026-03-23',
-                    'is_fresh': True,
-                    'missing_days': [],
-                    'row_count': 123,
-                    'stale_override_used': False,
-                    'witnesses': [],
+                    "snapshot_id": "snap-prune",
+                    "source": "ta",
+                    "window_size": "PT1S",
+                    "start_day": "2026-03-18",
+                    "end_day": "2026-03-23",
+                    "expected_last_trading_day": "2026-03-23",
+                    "is_fresh": True,
+                    "missing_days": [],
+                    "row_count": 123,
+                    "stale_override_used": False,
+                    "witnesses": [],
                 },
             )
 
             def fake_run_replay(config: object) -> dict[str, object]:
-                configmap_path = Path(getattr(config, 'strategy_configmap_path'))
-                payload = yaml.safe_load(configmap_path.read_text(encoding='utf-8'))
+                configmap_path = Path(getattr(config, "strategy_configmap_path"))
+                payload = yaml.safe_load(configmap_path.read_text(encoding="utf-8"))
                 strategy = next(
                     item
-                    for item in yaml.safe_load(payload['data']['strategies.yaml'])['strategies']
-                    if item['name'] == 'intraday-tsmom-profit-v3'
+                    for item in yaml.safe_load(payload["data"]["strategies.yaml"])[
+                        "strategies"
+                    ]
+                    if item["name"] == "intraday-tsmom-profit-v3"
                 )
-                universe = tuple(strategy.get('universe_symbols') or [])
-                start_date = str(getattr(config, 'start_date'))
-                end_date = str(getattr(config, 'end_date'))
+                universe = tuple(strategy.get("universe_symbols") or [])
+                start_date = str(getattr(config, "start_date"))
+                end_date = str(getattr(config, "end_date"))
 
-                if universe == ('NVDA',):
+                if universe == ("NVDA",):
                     daily_net = {
-                        '2026-03-18': '240',
-                        '2026-03-19': '260',
-                        '2026-03-20': '250',
-                        '2026-03-21': '280',
-                        '2026-03-22': '270',
-                        '2026-03-23': '275',
+                        "2026-03-18": "240",
+                        "2026-03-19": "260",
+                        "2026-03-20": "250",
+                        "2026-03-21": "280",
+                        "2026-03-22": "270",
+                        "2026-03-23": "275",
                     }
                     funnel = {
-                        'buckets': [
+                        "buckets": [
                             {
-                                'trading_day': day,
-                                'symbol': 'NVDA',
-                                'filled_count': 1,
-                                'net_pnl': value,
-                                'cost_total': '5',
+                                "trading_day": day,
+                                "symbol": "NVDA",
+                                "filled_count": 1,
+                                "net_pnl": value,
+                                "cost_total": "5",
                             }
                             for day, value in daily_net.items()
                         ]
                     }
                 else:
                     daily_net = {
-                        '2026-03-18': '240',
-                        '2026-03-19': '260',
-                        '2026-03-20': '250',
-                        '2026-03-21': '60',
-                        '2026-03-22': '-220',
-                        '2026-03-23': '290',
+                        "2026-03-18": "240",
+                        "2026-03-19": "260",
+                        "2026-03-20": "250",
+                        "2026-03-21": "60",
+                        "2026-03-22": "-220",
+                        "2026-03-23": "290",
                     }
                     funnel = {
-                        'buckets': [
+                        "buckets": [
                             {
-                                'trading_day': '2026-03-22',
-                                'symbol': 'AVGO',
-                                'filled_count': 1,
-                                'net_pnl': '-260',
-                                'cost_total': '10',
+                                "trading_day": "2026-03-22",
+                                "symbol": "AVGO",
+                                "filled_count": 1,
+                                "net_pnl": "-260",
+                                "cost_total": "10",
                             },
                             {
-                                'trading_day': '2026-03-21',
-                                'symbol': 'AVGO',
-                                'filled_count': 1,
-                                'net_pnl': '20',
-                                'cost_total': '5',
+                                "trading_day": "2026-03-21",
+                                "symbol": "AVGO",
+                                "filled_count": 1,
+                                "net_pnl": "20",
+                                "cost_total": "5",
                             },
                             {
-                                'trading_day': '2026-03-18',
-                                'symbol': 'NVDA',
-                                'filled_count': 1,
-                                'net_pnl': '240',
-                                'cost_total': '5',
+                                "trading_day": "2026-03-18",
+                                "symbol": "NVDA",
+                                "filled_count": 1,
+                                "net_pnl": "240",
+                                "cost_total": "5",
                             },
                         ]
                     }
 
-                if start_date == '2026-03-18' and end_date == '2026-03-20':
-                    subset = {day: daily_net[day] for day in ('2026-03-18', '2026-03-19', '2026-03-20')}
-                elif start_date == '2026-03-21' and end_date == '2026-03-23':
-                    subset = {day: daily_net[day] for day in ('2026-03-21', '2026-03-22', '2026-03-23')}
+                if start_date == "2026-03-18" and end_date == "2026-03-20":
+                    subset = {
+                        day: daily_net[day]
+                        for day in ("2026-03-18", "2026-03-19", "2026-03-20")
+                    }
+                elif start_date == "2026-03-21" and end_date == "2026-03-23":
+                    subset = {
+                        day: daily_net[day]
+                        for day in ("2026-03-21", "2026-03-22", "2026-03-23")
+                    }
                 else:
                     subset = daily_net
                 payload = self._payload(
@@ -1378,106 +1710,124 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
                     wins=2,
                     losses=1,
                 )
-                payload['funnel'] = funnel
+                payload["funnel"] = funnel
                 return payload
 
             stdout = io.StringIO()
             with (
-                patch('scripts.search_consistent_profitability_frontier._parse_args', return_value=args),
-                patch('scripts.search_consistent_profitability_frontier._resolve_recent_trading_days', return_value=recent_days),
-                patch('scripts.search_consistent_profitability_frontier.build_dataset_snapshot_receipt', return_value=snapshot_receipt),
-                patch('scripts.search_consistent_profitability_frontier.ensure_fresh_snapshot'),
-                patch('scripts.search_consistent_profitability_frontier.run_replay', side_effect=fake_run_replay),
+                patch(
+                    "scripts.search_consistent_profitability_frontier._parse_args",
+                    return_value=args,
+                ),
+                patch(
+                    "scripts.search_consistent_profitability_frontier._resolve_recent_trading_days",
+                    return_value=recent_days,
+                ),
+                patch(
+                    "scripts.search_consistent_profitability_frontier.build_dataset_snapshot_receipt",
+                    return_value=snapshot_receipt,
+                ),
+                patch(
+                    "scripts.search_consistent_profitability_frontier.ensure_fresh_snapshot"
+                ),
+                patch(
+                    "scripts.search_consistent_profitability_frontier.run_replay",
+                    side_effect=fake_run_replay,
+                ),
                 redirect_stdout(stdout),
             ):
                 exit_code = frontier.main()
 
             self.assertEqual(exit_code, 0)
-            payload = json.loads(json_output.read_text(encoding='utf-8'))
-            top = payload['top'][0]
-            self.assertEqual(top['replay_config']['strategy_overrides']['universe_symbols'], ['NVDA'])
-            self.assertEqual(top['search_iteration'], 1)
-            self.assertEqual(top['pruned_symbol'], 'AVGO')
+            payload = json.loads(json_output.read_text(encoding="utf-8"))
+            top = payload["top"][0]
+            self.assertEqual(
+                top["replay_config"]["strategy_overrides"]["universe_symbols"], ["NVDA"]
+            )
+            self.assertEqual(top["search_iteration"], 1)
+            self.assertEqual(top["pruned_symbol"], "AVGO")
 
     def test_main_adds_concentration_hard_vetoes(self) -> None:
         with TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
             strategy_configmap = self._write_strategy_configmap(root)
-            sweep_config = root / 'sweep.yaml'
+            sweep_config = root / "sweep.yaml"
             sweep_config.write_text(
                 yaml.safe_dump(
                     {
-                        'schema_version': 'torghut.replay-frontier-sweep.v1',
-                        'family': 'breakout_reclaim',
-                        'strategy_name': 'intraday-tsmom-profit-v3',
-                        'disable_other_strategies': True,
-                        'constraints': {
-                            'holdout_target_net_per_day': '100',
-                            'min_active_holdout_days': 1,
-                            'max_worst_holdout_day_loss': '500',
-                            'min_profit_factor': '1.0',
+                        "schema_version": "torghut.replay-frontier-sweep.v1",
+                        "family": "breakout_reclaim",
+                        "strategy_name": "intraday-tsmom-profit-v3",
+                        "disable_other_strategies": True,
+                        "constraints": {
+                            "holdout_target_net_per_day": "100",
+                            "min_active_holdout_days": 1,
+                            "max_worst_holdout_day_loss": "500",
+                            "min_profit_factor": "1.0",
                         },
-                        'consistency_constraints': {
-                            'target_net_per_day': '100',
-                            'min_active_days': 1,
-                            'max_worst_day_loss': '500',
-                            'max_negative_days': 3,
-                            'max_drawdown': '800',
-                            'require_every_day_active': False,
-                            'max_symbol_concentration_share': '0.50',
-                            'max_entry_family_contribution_share': '0.50',
+                        "consistency_constraints": {
+                            "target_net_per_day": "100",
+                            "min_active_days": 1,
+                            "max_worst_day_loss": "500",
+                            "max_negative_days": 3,
+                            "max_drawdown": "800",
+                            "require_every_day_active": False,
+                            "max_symbol_concentration_share": "0.50",
+                            "max_entry_family_contribution_share": "0.50",
                         },
-                        'strategy_overrides': {
-                            'universe_symbols': [['NVDA', 'AMAT']],
+                        "strategy_overrides": {
+                            "universe_symbols": [["NVDA", "AMAT"]],
                         },
-                        'parameters': {
-                            'long_stop_loss_bps': ['12'],
+                        "parameters": {
+                            "long_stop_loss_bps": ["12"],
                         },
                     },
                     sort_keys=False,
                 ),
-                encoding='utf-8',
+                encoding="utf-8",
             )
-            json_output = root / 'frontier.json'
+            json_output = root / "frontier.json"
             args = self._make_args(
                 strategy_configmap=strategy_configmap,
                 sweep_config=sweep_config,
                 json_output=json_output,
             )
-            recent_days = tuple(date(2026, 3, 18) + timedelta(days=index) for index in range(6))
+            recent_days = tuple(
+                date(2026, 3, 18) + timedelta(days=index) for index in range(6)
+            )
             snapshot_receipt = SimpleNamespace(
-                snapshot_id='snap-veto',
+                snapshot_id="snap-veto",
                 is_fresh=True,
                 stale_override_used=False,
                 to_payload=lambda: {
-                    'snapshot_id': 'snap-veto',
-                    'source': 'ta',
-                    'window_size': 'PT1S',
-                    'start_day': '2026-03-18',
-                    'end_day': '2026-03-23',
-                    'expected_last_trading_day': '2026-03-23',
-                    'is_fresh': True,
-                    'missing_days': [],
-                    'row_count': 123,
-                    'stale_override_used': False,
-                    'witnesses': [],
+                    "snapshot_id": "snap-veto",
+                    "source": "ta",
+                    "window_size": "PT1S",
+                    "start_day": "2026-03-18",
+                    "end_day": "2026-03-23",
+                    "expected_last_trading_day": "2026-03-23",
+                    "is_fresh": True,
+                    "missing_days": [],
+                    "row_count": 123,
+                    "stale_override_used": False,
+                    "witnesses": [],
                 },
             )
 
             def fake_run_replay(config: object) -> dict[str, object]:
-                start_date = str(getattr(config, 'start_date'))
-                end_date = str(getattr(config, 'end_date'))
-                if start_date == '2026-03-18' and end_date == '2026-03-20':
+                start_date = str(getattr(config, "start_date"))
+                end_date = str(getattr(config, "end_date"))
+                if start_date == "2026-03-18" and end_date == "2026-03-20":
                     daily_net = {
-                        '2026-03-18': '200',
-                        '2026-03-19': '180',
-                        '2026-03-20': '160',
+                        "2026-03-18": "200",
+                        "2026-03-19": "180",
+                        "2026-03-20": "160",
                     }
                 else:
                     daily_net = {
-                        '2026-03-21': '220',
-                        '2026-03-22': '210',
-                        '2026-03-23': '205',
+                        "2026-03-21": "220",
+                        "2026-03-22": "210",
+                        "2026-03-23": "205",
                     }
                 payload = self._payload(
                     start_date=start_date,
@@ -1488,110 +1838,142 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
                     wins=3,
                     losses=0,
                 )
-                payload['trace'] = []
+                payload["trace"] = []
                 return payload
 
             fake_decomposition = SimpleNamespace(
-                to_payload=lambda: {'families': {}, 'symbols': {}},
+                to_payload=lambda: {"families": {}, "symbols": {}},
             )
             stdout = io.StringIO()
             with (
-                patch('scripts.search_consistent_profitability_frontier._parse_args', return_value=args),
-                patch('scripts.search_consistent_profitability_frontier._resolve_recent_trading_days', return_value=recent_days),
-                patch('scripts.search_consistent_profitability_frontier.build_dataset_snapshot_receipt', return_value=snapshot_receipt),
-                patch('scripts.search_consistent_profitability_frontier.ensure_fresh_snapshot'),
-                patch('scripts.search_consistent_profitability_frontier.run_replay', side_effect=fake_run_replay),
-                patch('scripts.search_consistent_profitability_frontier.build_replay_decomposition', return_value=fake_decomposition),
-                patch('scripts.search_consistent_profitability_frontier.regime_slice_pass_rate', return_value=Decimal('1')),
-                patch('scripts.search_consistent_profitability_frontier.max_symbol_concentration_share', return_value=Decimal('0.90')),
-                patch('scripts.search_consistent_profitability_frontier.max_family_contribution_share', return_value=Decimal('0.90')),
+                patch(
+                    "scripts.search_consistent_profitability_frontier._parse_args",
+                    return_value=args,
+                ),
+                patch(
+                    "scripts.search_consistent_profitability_frontier._resolve_recent_trading_days",
+                    return_value=recent_days,
+                ),
+                patch(
+                    "scripts.search_consistent_profitability_frontier.build_dataset_snapshot_receipt",
+                    return_value=snapshot_receipt,
+                ),
+                patch(
+                    "scripts.search_consistent_profitability_frontier.ensure_fresh_snapshot"
+                ),
+                patch(
+                    "scripts.search_consistent_profitability_frontier.run_replay",
+                    side_effect=fake_run_replay,
+                ),
+                patch(
+                    "scripts.search_consistent_profitability_frontier.build_replay_decomposition",
+                    return_value=fake_decomposition,
+                ),
+                patch(
+                    "scripts.search_consistent_profitability_frontier.regime_slice_pass_rate",
+                    return_value=Decimal("1"),
+                ),
+                patch(
+                    "scripts.search_consistent_profitability_frontier.max_symbol_concentration_share",
+                    return_value=Decimal("0.90"),
+                ),
+                patch(
+                    "scripts.search_consistent_profitability_frontier.max_family_contribution_share",
+                    return_value=Decimal("0.90"),
+                ),
                 redirect_stdout(stdout),
             ):
                 exit_code = frontier.main()
 
             self.assertEqual(exit_code, 0)
-            payload = json.loads(json_output.read_text(encoding='utf-8'))
-            self.assertIn('symbol_concentration_above_max', payload['top'][0]['hard_vetoes'])
-            self.assertIn('entry_family_contribution_above_max', payload['top'][0]['hard_vetoes'])
+            payload = json.loads(json_output.read_text(encoding="utf-8"))
+            self.assertIn(
+                "symbol_concentration_above_max", payload["top"][0]["hard_vetoes"]
+            )
+            self.assertIn(
+                "entry_family_contribution_above_max", payload["top"][0]["hard_vetoes"]
+            )
 
     def test_main_keeps_min_active_days_disabled_for_widened_full_window(self) -> None:
         with TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
             strategy_configmap = self._write_strategy_configmap(root)
-            sweep_config = root / 'widened-sweep.yaml'
+            sweep_config = root / "widened-sweep.yaml"
             sweep_config.write_text(
                 yaml.safe_dump(
                     {
-                        'schema_version': 'torghut.replay-frontier-sweep.v1',
-                        'family': 'intraday_tsmom_consistent',
-                        'strategy_name': 'intraday-tsmom-profit-v3',
-                        'disable_other_strategies': True,
-                        'constraints': {
-                            'holdout_target_net_per_day': '100',
-                            'min_active_holdout_days': 1,
-                            'max_worst_holdout_day_loss': '500',
-                            'min_profit_factor': '1.0',
+                        "schema_version": "torghut.replay-frontier-sweep.v1",
+                        "family": "intraday_tsmom_consistent",
+                        "strategy_name": "intraday-tsmom-profit-v3",
+                        "disable_other_strategies": True,
+                        "constraints": {
+                            "holdout_target_net_per_day": "100",
+                            "min_active_holdout_days": 1,
+                            "max_worst_holdout_day_loss": "500",
+                            "min_profit_factor": "1.0",
                         },
-                        'consistency_constraints': {
-                            'target_net_per_day': '100',
-                            'min_active_ratio': '0',
-                            'max_worst_day_loss': '500',
-                            'max_negative_days': 7,
-                            'max_drawdown': '900',
-                            'require_every_day_active': False,
+                        "consistency_constraints": {
+                            "target_net_per_day": "100",
+                            "min_active_ratio": "0",
+                            "max_worst_day_loss": "500",
+                            "max_negative_days": 7,
+                            "max_drawdown": "900",
+                            "require_every_day_active": False,
                         },
-                        'strategy_overrides': {
-                            'universe_symbols': [['NVDA']],
+                        "strategy_overrides": {
+                            "universe_symbols": [["NVDA"]],
                         },
-                        'parameters': {
-                            'long_stop_loss_bps': ['12'],
+                        "parameters": {
+                            "long_stop_loss_bps": ["12"],
                         },
                     },
                     sort_keys=False,
                 ),
-                encoding='utf-8',
+                encoding="utf-8",
             )
-            json_output = root / 'frontier.json'
+            json_output = root / "frontier.json"
             args = self._make_args(
                 strategy_configmap=strategy_configmap,
                 sweep_config=sweep_config,
                 json_output=json_output,
             )
-            args.full_window_start_date = '2026-03-17'
-            args.full_window_end_date = '2026-03-23'
-            recent_days = tuple(date(2026, 3, 18) + timedelta(days=index) for index in range(6))
+            args.full_window_start_date = "2026-03-17"
+            args.full_window_end_date = "2026-03-23"
+            recent_days = tuple(
+                date(2026, 3, 18) + timedelta(days=index) for index in range(6)
+            )
             snapshot_receipt = SimpleNamespace(
-                snapshot_id='snap-wide',
+                snapshot_id="snap-wide",
                 is_fresh=True,
                 stale_override_used=False,
                 to_payload=lambda: {
-                    'snapshot_id': 'snap-wide',
-                    'source': 'ta',
-                    'window_size': 'PT1S',
-                    'start_day': '2026-03-17',
-                    'end_day': '2026-03-23',
-                    'expected_last_trading_day': '2026-03-23',
-                    'is_fresh': True,
-                    'missing_days': [],
-                    'row_count': 321,
-                    'stale_override_used': False,
-                    'witnesses': [],
+                    "snapshot_id": "snap-wide",
+                    "source": "ta",
+                    "window_size": "PT1S",
+                    "start_day": "2026-03-17",
+                    "end_day": "2026-03-23",
+                    "expected_last_trading_day": "2026-03-23",
+                    "is_fresh": True,
+                    "missing_days": [],
+                    "row_count": 321,
+                    "stale_override_used": False,
+                    "witnesses": [],
                 },
             )
 
             daily_net = {
-                '2026-03-17': '90',
-                '2026-03-18': '110',
-                '2026-03-19': '95',
-                '2026-03-20': '120',
-                '2026-03-21': '130',
-                '2026-03-22': '115',
-                '2026-03-23': '125',
+                "2026-03-17": "90",
+                "2026-03-18": "110",
+                "2026-03-19": "95",
+                "2026-03-20": "120",
+                "2026-03-21": "130",
+                "2026-03-22": "115",
+                "2026-03-23": "125",
             }
 
             def fake_run_replay(config: object) -> dict[str, object]:
-                start_date = str(getattr(config, 'start_date'))
-                end_date = str(getattr(config, 'end_date'))
+                start_date = str(getattr(config, "start_date"))
+                end_date = str(getattr(config, "end_date"))
                 subset = {
                     day: value
                     for day, value in daily_net.items()
@@ -1609,15 +1991,31 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
 
             stdout = io.StringIO()
             with (
-                patch('scripts.search_consistent_profitability_frontier._parse_args', return_value=args),
-                patch('scripts.search_consistent_profitability_frontier._resolve_recent_trading_days', return_value=recent_days),
-                patch('scripts.search_consistent_profitability_frontier.build_dataset_snapshot_receipt', return_value=snapshot_receipt),
-                patch('scripts.search_consistent_profitability_frontier.ensure_fresh_snapshot'),
-                patch('scripts.search_consistent_profitability_frontier.run_replay', side_effect=fake_run_replay),
+                patch(
+                    "scripts.search_consistent_profitability_frontier._parse_args",
+                    return_value=args,
+                ),
+                patch(
+                    "scripts.search_consistent_profitability_frontier._resolve_recent_trading_days",
+                    return_value=recent_days,
+                ),
+                patch(
+                    "scripts.search_consistent_profitability_frontier.build_dataset_snapshot_receipt",
+                    return_value=snapshot_receipt,
+                ),
+                patch(
+                    "scripts.search_consistent_profitability_frontier.ensure_fresh_snapshot"
+                ),
+                patch(
+                    "scripts.search_consistent_profitability_frontier.run_replay",
+                    side_effect=fake_run_replay,
+                ),
                 redirect_stdout(stdout),
             ):
                 exit_code = frontier.main()
 
             self.assertEqual(exit_code, 0)
-            payload = json.loads(json_output.read_text(encoding='utf-8'))
-            self.assertEqual(payload['constraints']['consistency']['min_active_days'], 0)
+            payload = json.loads(json_output.read_text(encoding="utf-8"))
+            self.assertEqual(
+                payload["constraints"]["consistency"]["min_active_days"], 0
+            )

--- a/services/torghut/tests/test_search_profitability_frontier.py
+++ b/services/torghut/tests/test_search_profitability_frontier.py
@@ -274,6 +274,11 @@ class TestSearchProfitabilityFrontier(TestCase):
                 "min_cross_section_continuation_rank": "0.65",
                 "min_recent_above_opening_window_close_ratio": "0.75",
             },
+            strategy_overrides={
+                "universe_symbols": ["NVDA", "AVGO"],
+                "max_notional_per_trade": "6000",
+                "normalization_regime": "local_only_research_feature",
+            },
             disable_other_strategies=True,
         )
 
@@ -292,7 +297,58 @@ class TestSearchProfitabilityFrontier(TestCase):
             ],
             "0.75",
         )
+        self.assertEqual(
+            strategies["breakout-continuation-long-v1"]["params"][
+                "position_isolation_mode"
+            ],
+            "per_strategy",
+        )
+        self.assertEqual(
+            strategies["breakout-continuation-long-v1"]["universe_symbols"],
+            ["NVDA", "AVGO"],
+        )
+        self.assertEqual(
+            strategies["breakout-continuation-long-v1"]["max_notional_per_trade"],
+            "6000",
+        )
+        self.assertNotIn(
+            "normalization_regime",
+            strategies["breakout-continuation-long-v1"],
+        )
         self.assertFalse(strategies["late-day-continuation-long-v1"]["enabled"])
+
+    def test_apply_candidate_to_configmap_rejects_reserved_params_override(
+        self,
+    ) -> None:
+        configmap_payload = {
+            "apiVersion": "v1",
+            "kind": "ConfigMap",
+            "data": {
+                "strategies.yaml": yaml.safe_dump(
+                    {
+                        "strategies": [
+                            {
+                                "name": "breakout-continuation-long-v1",
+                                "enabled": False,
+                                "params": {},
+                            }
+                        ]
+                    },
+                    sort_keys=False,
+                )
+            },
+        }
+
+        with self.assertRaisesRegex(
+            ValueError, "strategy_override_key_reserved:params"
+        ):
+            apply_candidate_to_configmap(
+                configmap_payload=configmap_payload,
+                strategy_name="breakout-continuation-long-v1",
+                candidate_params={},
+                strategy_overrides={"params": {"long_stop_loss_bps": "12"}},
+                disable_other_strategies=False,
+            )
 
     def test_apply_candidate_to_configmap_accepts_mounted_strategy_catalog(
         self,


### PR DESCRIPTION
## Summary

- Forces standalone whitepaper/autoresearch replays to isolate positions per strategy so candidate sleeves cannot share or mask exposure through the runtime portfolio state.
- Adds observed replay viability and capital-pressure features to MLX proposal ranking so zero-activity, low-notional, negative-cash, or over-budget candidates are penalized before expensive replay.
- Threads per-strategy isolation through local and frontier replay paths, including configmap candidate application and strategy-factory sweep compilation.
- Adds focused regression coverage for the coverage-gated replay/frontier/ranker branches that protect the standalone proof path.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen ruff check app/trading/discovery/mlx_proposal_models.py app/trading/discovery/mlx_training_data.py scripts/local_intraday_tsmom_replay.py scripts/run_strategy_factory_v2.py scripts/search_consistent_profitability_frontier.py scripts/search_profitability_frontier.py tests/test_candidate_specs.py tests/test_local_intraday_tsmom_replay.py tests/test_mlx_autoresearch.py tests/test_mlx_training_data.py tests/test_run_strategy_factory_v2.py tests/test_search_consistent_profitability_frontier.py tests/test_search_profitability_frontier.py`
- `uv run --frozen ruff format --check app/trading/discovery/mlx_proposal_models.py app/trading/discovery/mlx_training_data.py scripts/local_intraday_tsmom_replay.py scripts/run_strategy_factory_v2.py scripts/search_consistent_profitability_frontier.py scripts/search_profitability_frontier.py tests/test_candidate_specs.py tests/test_local_intraday_tsmom_replay.py tests/test_mlx_autoresearch.py tests/test_mlx_training_data.py tests/test_run_strategy_factory_v2.py tests/test_search_consistent_profitability_frontier.py tests/test_search_profitability_frontier.py`
- `uv run --frozen pytest tests/test_mlx_autoresearch.py tests/test_mlx_training_data.py tests/test_local_intraday_tsmom_replay.py tests/test_search_consistent_profitability_frontier.py tests/test_search_profitability_frontier.py`
- `uv run --frozen pytest tests/test_mlx_training_data.py tests/test_run_strategy_factory_v2.py tests/test_search_profitability_frontier.py tests/test_search_consistent_profitability_frontier.py tests/test_local_intraday_tsmom_replay.py tests/test_candidate_specs.py`
- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py -k 'pre_replay_ranker_keeps_best_duplicate_feedback_and_blocks_rejections or pre_replay_ranker_ingests_feedback_evidence_bundles'`
- `uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90` (targeted coverage XML produced 93.43% changed-line coverage)
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
