### PR TITLE
fix(keycloak): restore headlamp audience mapper bootstrap

### DIFF
--- a/argocd/applications/keycloak/headlamp-client-bootstrap-job.yaml
+++ b/argocd/applications/keycloak/headlamp-client-bootstrap-job.yaml
@@ -23,170 +23,180 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: bootstrap
-          image: quay.io/keycloak/keycloak:26.5.1
+          image: python:3.12-alpine
           command:
             - /bin/sh
             - -ec
             - |
-              set -eu
+              python - <<'PY'
+              import json
+              import os
+              import time
+              import urllib.error
+              import urllib.parse
+              import urllib.request
 
-              KCADM_CONFIG="$(mktemp /tmp/kcadm-config.XXXXXX)"
-              export KCADM_CONFIG
 
-              login() {
-                /opt/keycloak/bin/kcadm.sh config credentials \
-                  --config "$KCADM_CONFIG" \
-                  --server "$KEYCLOAK_ADMIN_URL" \
-                  --realm master \
-                  --user "$KEYCLOAK_ADMIN_USERNAME" \
-                  --password "$KEYCLOAK_ADMIN_PASSWORD" \
-                  >/dev/null
-              }
+              def require_env(name):
+                value = os.environ.get(name, '').strip()
+                if not value:
+                  raise RuntimeError(f'Missing required environment variable {name}')
+                return value
 
-              for i in $(seq 1 120); do
-                if login 2>/dev/null; then
+
+              base_url = require_env('KEYCLOAK_ADMIN_URL').rstrip('/')
+              realm = require_env('KEYCLOAK_REALM')
+              realm_path = urllib.parse.quote(realm, safe='')
+              admin_username = require_env('KEYCLOAK_ADMIN_USERNAME')
+              admin_password = require_env('KEYCLOAK_ADMIN_PASSWORD')
+              headlamp_client_id = require_env('HEADLAMP_OIDC_CLIENT_ID')
+              headlamp_client_secret = require_env('HEADLAMP_OIDC_CLIENT_SECRET')
+
+
+              def request(method, path, token=None, data=None, expected=(200,)):
+                body = None
+                headers = {}
+                if data is not None:
+                  body = json.dumps(data).encode('utf-8')
+                  headers['Content-Type'] = 'application/json'
+                if token:
+                  headers['Authorization'] = f'Bearer {token}'
+
+                req = urllib.request.Request(f'{base_url}{path}', data=body, headers=headers, method=method)
+                try:
+                  with urllib.request.urlopen(req, timeout=30) as response:
+                    payload = response.read()
+                    status = response.status
+                except urllib.error.HTTPError as error:
+                  payload = error.read()
+                  raise RuntimeError(
+                    f'{method} {path} failed with HTTP {error.code}: {payload.decode("utf-8", "replace")}',
+                  ) from error
+
+                if status not in expected:
+                  raise RuntimeError(
+                    f'{method} {path} returned HTTP {status}, expected {expected}: '
+                    f'{payload.decode("utf-8", "replace")}',
+                  )
+                if not payload:
+                  return None
+                return json.loads(payload.decode('utf-8'))
+
+
+              def request_token():
+                form = urllib.parse.urlencode(
+                  {
+                    'grant_type': 'password',
+                    'client_id': 'admin-cli',
+                    'username': admin_username,
+                    'password': admin_password,
+                  },
+                ).encode('utf-8')
+                req = urllib.request.Request(
+                  f'{base_url}/realms/master/protocol/openid-connect/token',
+                  data=form,
+                  headers={'Content-Type': 'application/x-www-form-urlencoded'},
+                  method='POST',
+                )
+                with urllib.request.urlopen(req, timeout=30) as response:
+                  return json.loads(response.read().decode('utf-8'))['access_token']
+
+
+              token = None
+              for attempt in range(120):
+                try:
+                  token = request_token()
                   break
-                fi
+                except Exception:
+                  if attempt == 119:
+                    raise
+                  time.sleep(5)
 
-                if [ "$i" -eq 120 ]; then
-                  echo "Keycloak admin API did not become ready in time" >&2
-                  exit 1
-                fi
+              realm_doc = request('GET', f'/admin/realms/{realm_path}', token=token)
+              realm_doc.update(
+                {
+                  'accessTokenLifespan': int(require_env('KEYCLOAK_REALM_ACCESS_TOKEN_LIFESPAN_SECONDS')),
+                  'ssoSessionIdleTimeout': int(require_env('KEYCLOAK_REALM_SSO_SESSION_IDLE_SECONDS')),
+                  'ssoSessionMaxLifespan': int(require_env('KEYCLOAK_REALM_SSO_SESSION_MAX_SECONDS')),
+                  'clientSessionIdleTimeout': int(require_env('KEYCLOAK_REALM_CLIENT_SESSION_IDLE_SECONDS')),
+                  'clientSessionMaxLifespan': int(require_env('KEYCLOAK_REALM_CLIENT_SESSION_MAX_SECONDS')),
+                },
+              )
+              request('PUT', f'/admin/realms/{realm_path}', token=token, data=realm_doc, expected=(204,))
 
-                sleep 5
-              done
-
-              /opt/keycloak/bin/kcadm.sh update "realms/$KEYCLOAK_REALM" \
-                --config "$KCADM_CONFIG" \
-                -s "accessTokenLifespan=${KEYCLOAK_REALM_ACCESS_TOKEN_LIFESPAN_SECONDS}" \
-                -s "ssoSessionIdleTimeout=${KEYCLOAK_REALM_SSO_SESSION_IDLE_SECONDS}" \
-                -s "ssoSessionMaxLifespan=${KEYCLOAK_REALM_SSO_SESSION_MAX_SECONDS}" \
-                -s "clientSessionIdleTimeout=${KEYCLOAK_REALM_CLIENT_SESSION_IDLE_SECONDS}" \
-                -s "clientSessionMaxLifespan=${KEYCLOAK_REALM_CLIENT_SESSION_MAX_SECONDS}"
-
-              cat > /tmp/headlamp-client.json <<EOF
-              {
-                "clientId": "${HEADLAMP_OIDC_CLIENT_ID}",
-                "name": "Headlamp Kubernetes UI",
-                "description": "OIDC client for Headlamp and kube-apiserver",
-                "enabled": true,
-                "protocol": "openid-connect",
-                "publicClient": false,
-                "standardFlowEnabled": true,
-                "directAccessGrantsEnabled": false,
-                "implicitFlowEnabled": false,
-                "serviceAccountsEnabled": false,
-                "redirectUris": [
-                  "${HEADLAMP_TAILSCALE_CALLBACK_URL}",
-                  "${HEADLAMP_PRIVATE_CALLBACK_URL}"
+              client_doc = {
+                'clientId': headlamp_client_id,
+                'name': 'Headlamp Kubernetes UI',
+                'description': 'OIDC client for Headlamp and kube-apiserver',
+                'enabled': True,
+                'protocol': 'openid-connect',
+                'publicClient': False,
+                'standardFlowEnabled': True,
+                'directAccessGrantsEnabled': False,
+                'implicitFlowEnabled': False,
+                'serviceAccountsEnabled': False,
+                'redirectUris': [
+                  require_env('HEADLAMP_TAILSCALE_CALLBACK_URL'),
+                  require_env('HEADLAMP_PRIVATE_CALLBACK_URL'),
                 ],
-                "webOrigins": [
-                  "${HEADLAMP_TAILSCALE_BASE_URL}",
-                  "${HEADLAMP_PRIVATE_BASE_URL}"
+                'webOrigins': [
+                  require_env('HEADLAMP_TAILSCALE_BASE_URL'),
+                  require_env('HEADLAMP_PRIVATE_BASE_URL'),
                 ],
-                "attributes": {
-                  "pkce.code.challenge.required": "false",
-                  "pkce.code.challenge.method": ""
-                }
+                'secret': headlamp_client_secret,
+                'attributes': {
+                  'pkce.code.challenge.required': 'false',
+                  'pkce.code.challenge.method': '',
+                },
               }
-              EOF
 
-              cat > /tmp/kubernetes-audience-mapper.json <<EOF
-              {
-                "name": "kubernetes-audience",
-                "protocol": "openid-connect",
-                "protocolMapper": "oidc-audience-mapper",
-                "consentRequired": false,
-                "config": {
-                  "included.client.audience": "${HEADLAMP_OIDC_CLIENT_ID}",
-                  "access.token.claim": "true",
-                  "id.token.claim": "false",
-                  "userinfo.token.claim": "false",
-                  "introspection.token.claim": "true",
-                  "lightweight.claim": "false"
-                }
+              query_client_id = urllib.parse.quote(headlamp_client_id, safe='')
+              clients_path = f'/admin/realms/{realm_path}/clients'
+              clients = request('GET', f'{clients_path}?clientId={query_client_id}', token=token)
+              if clients:
+                client_resource_id = clients[0]['id']
+                existing_client = request('GET', f'{clients_path}/{client_resource_id}', token=token)
+                existing_client.update(client_doc)
+                request('PUT', f'{clients_path}/{client_resource_id}', token=token, data=existing_client, expected=(204,))
+              else:
+                request('POST', clients_path, token=token, data=client_doc, expected=(201, 204))
+                clients = request('GET', f'{clients_path}?clientId={query_client_id}', token=token)
+                if not clients:
+                  raise RuntimeError(f'Failed to resolve Keycloak client resource ID for {headlamp_client_id}')
+                client_resource_id = clients[0]['id']
+
+              mapper_path = f'{clients_path}/{client_resource_id}/protocol-mappers/models'
+              for mapper in request('GET', mapper_path, token=token):
+                if mapper.get('name') == 'kubernetes-audience':
+                  mapper_id = urllib.parse.quote(mapper['id'], safe='')
+                  request('DELETE', f'{mapper_path}/{mapper_id}', token=token, expected=(204,))
+
+              mapper_doc = {
+                'name': 'kubernetes-audience',
+                'protocol': 'openid-connect',
+                'protocolMapper': 'oidc-audience-mapper',
+                'consentRequired': False,
+                'config': {
+                  'included.client.audience': headlamp_client_id,
+                  'access.token.claim': 'true',
+                  'id.token.claim': 'false',
+                  'userinfo.token.claim': 'false',
+                  'introspection.token.claim': 'true',
+                  'lightweight.claim': 'false',
+                },
               }
-              EOF
+              request('POST', mapper_path, token=token, data=mapper_doc, expected=(201, 204))
 
-              client_resource_id="$(
-                /opt/keycloak/bin/kcadm.sh get clients \
-                  --config "$KCADM_CONFIG" \
-                  -r "$KEYCLOAK_REALM" \
-                  -q clientId="$HEADLAMP_OIDC_CLIENT_ID" \
-                  --fields id \
-                  --format csv \
-                  --noquotes \
-                  | tr -d '\r' \
-                  | head -n 1
-              )"
+              configured = [
+                mapper
+                for mapper in request('GET', mapper_path, token=token)
+                if mapper.get('name') == 'kubernetes-audience'
+              ]
+              if len(configured) != 1 or configured[0].get('config', {}) != mapper_doc['config']:
+                raise RuntimeError(f'Failed to configure kubernetes-audience mapper: {configured!r}')
 
-              if [ -n "$client_resource_id" ]; then
-                /opt/keycloak/bin/kcadm.sh update "clients/$client_resource_id" \
-                  --config "$KCADM_CONFIG" \
-                  -r "$KEYCLOAK_REALM" \
-                  --merge \
-                  -f /tmp/headlamp-client.json
-              else
-                /opt/keycloak/bin/kcadm.sh create clients \
-                  --config "$KCADM_CONFIG" \
-                  -r "$KEYCLOAK_REALM" \
-                  -f /tmp/headlamp-client.json \
-                  >/dev/null
-
-                client_resource_id="$(
-                  /opt/keycloak/bin/kcadm.sh get clients \
-                    --config "$KCADM_CONFIG" \
-                    -r "$KEYCLOAK_REALM" \
-                    -q clientId="$HEADLAMP_OIDC_CLIENT_ID" \
-                    --fields id \
-                    --format csv \
-                    --noquotes \
-                    | tr -d '\r' \
-                    | head -n 1
-                )"
-              fi
-
-              if [ -z "$client_resource_id" ]; then
-                echo "Failed to resolve Keycloak client resource ID for ${HEADLAMP_OIDC_CLIENT_ID}" >&2
-                exit 1
-              fi
-
-              /opt/keycloak/bin/kcadm.sh update "clients/$client_resource_id" \
-                --config "$KCADM_CONFIG" \
-                -r "$KEYCLOAK_REALM" \
-                -s "secret=${HEADLAMP_OIDC_CLIENT_SECRET}"
-
-              mapper_resource_id="$(
-                /opt/keycloak/bin/kcadm.sh get "clients/$client_resource_id/protocol-mappers/models" \
-                  --config "$KCADM_CONFIG" \
-                  -r "$KEYCLOAK_REALM" \
-                  --fields id,name \
-                  --format csv \
-                  --noquotes \
-                  | tr -d '\r' \
-                  | while IFS=, read -r mapper_id mapper_name; do
-                      if [ "$mapper_name" = "kubernetes-audience" ]; then
-                        printf '%s\n' "$mapper_id"
-                        break
-                      fi
-                    done
-              )"
-
-              if [ -n "$mapper_resource_id" ]; then
-                /opt/keycloak/bin/kcadm.sh update "clients/$client_resource_id/protocol-mappers/models/$mapper_resource_id" \
-                  --config "$KCADM_CONFIG" \
-                  -r "$KEYCLOAK_REALM" \
-                  --merge \
-                  -f /tmp/kubernetes-audience-mapper.json
-              else
-                /opt/keycloak/bin/kcadm.sh create "clients/$client_resource_id/protocol-mappers/models" \
-                  --config "$KCADM_CONFIG" \
-                  -r "$KEYCLOAK_REALM" \
-                  -f /tmp/kubernetes-audience-mapper.json \
-                  >/dev/null
-              fi
-
-              echo "Configured Keycloak client ${HEADLAMP_OIDC_CLIENT_ID} in realm ${KEYCLOAK_REALM}"
+              print(f'Configured Keycloak client {headlamp_client_id} in realm {realm}')
+              PY
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:


### PR DESCRIPTION
## Summary

- Replace the Headlamp Keycloak bootstrap job's `kcadm` mapper writes with Admin REST calls from a small Python bootstrap script.
- Keep the existing Headlamp/Kubernetes OIDC client settings, client secret, callback URLs, realm lifetimes, and PKCE-disabled attributes managed by the job.
- Delete and recreate the `kubernetes-audience` mapper, then assert the exact mapper config so failed writes cannot be reported as success.

## Related Issues

None

## Testing

- `kubectl kustomize argocd/applications/keycloak >/tmp/keycloak-render.yaml`
- `kubectl apply --dry-run=server -f argocd/applications/keycloak/headlamp-client-bootstrap-job.yaml`
- `git diff --check HEAD~1..HEAD`
- Applied the corrected job live and verified it completed.
- Verified live Keycloak `kubernetes-audience` mapper config includes `included.client.audience=kubernetes` and `access.token.claim=true`.
- Verified `https://headlamp.ide-newton.ts.net/` returns HTTP 200.
- Verified Keycloak accepts the `kubernetes` client auth request for `https://headlamp.ide-newton.ts.net/oidc-callback`.
- Verified unauthenticated Headlamp cluster API returns expected HTTP 401.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
