### PR TITLE
feat(sag): enable image updater

### DIFF
--- a/argocd/applications/argocd/base/image-updater-product.yaml
+++ b/argocd/applications/argocd/base/image-updater-product.yaml
@@ -64,6 +64,24 @@ spec:
           manifestTargets:
             kustomize:
               name: registry.ide-newton.ts.net/lab/docs
+    - namePattern: sag
+      writeBackConfig:
+        method: git:secret:argocd/image-updater-git-ssh
+        gitConfig:
+          repository: git@github.com:proompteng/lab.git
+          branch: main:release/{{.SHA256}}
+          writeBackTarget: kustomization:/argocd/sag
+      images:
+        - alias: sag
+          imageName: registry.ide-newton.ts.net/lab/sag:latest
+          commonUpdateSettings:
+            updateStrategy: newest-build
+            allowTags: 'regexp:^(sag-[0-9]{14}|[0-9a-f]{7,40})$'
+            platforms:
+              - linux/amd64
+          manifestTargets:
+            kustomize:
+              name: registry.ide-newton.ts.net/lab/sag
     - namePattern: khoshut
       writeBackConfig:
         method: git:secret:argocd/image-updater-git-ssh


### PR DESCRIPTION
## Summary

- Adds SAG to the product Argo CD ImageUpdater configuration.
- Writes SAG image updates back to `argocd/sag` so the existing ApplicationSet deploys new images through GitOps.
- Uses `newest-build` for SAG timestamp/SHA image tags and pins updates to `linux/amd64`, matching the SAG workload node selector.

## Related Issues

None

## Testing

- `kubectl apply --dry-run=server -f argocd/applications/argocd/base/image-updater-product.yaml`
- `kubectl kustomize argocd/applications/argocd -o /tmp/sag-image-updater-render.yaml` and `rg -n "namePattern: sag|registry.ide-newton.ts.net/lab/sag|writeBackTarget: kustomization:/argocd/sag" /tmp/sag-image-updater-render.yaml`
- `bun run lint:argocd`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
