### PR TITLE
chore(symphony): promote image e3d66461

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-05-14T04:16:35Z"
+        kubectl.kubernetes.io/restartedAt: "2026-05-14T08:19:06Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -23,5 +23,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "210250b2"
-    digest: sha256:274d58dda834bbacb0d5b05b311900b47747c02276d470716f1451a25e214aae
+    newTag: "e3d66461"
+    digest: sha256:a7eb60e70fbe8389623f44f3a5dc907a7ae06617833292fb25bf4fb003d270ea

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-05-14T04:16:35Z"
+        kubectl.kubernetes.io/restartedAt: "2026-05-14T08:19:06Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -25,5 +25,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "210250b2"
-    digest: sha256:274d58dda834bbacb0d5b05b311900b47747c02276d470716f1451a25e214aae
+    newTag: "e3d66461"
+    digest: sha256:a7eb60e70fbe8389623f44f3a5dc907a7ae06617833292fb25bf4fb003d270ea

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-05-14T04:16:35Z"
+        kubectl.kubernetes.io/restartedAt: "2026-05-14T08:19:06Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -18,5 +18,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "210250b2"
-    digest: sha256:274d58dda834bbacb0d5b05b311900b47747c02276d470716f1451a25e214aae
+    newTag: "e3d66461"
+    digest: sha256:a7eb60e70fbe8389623f44f3a5dc907a7ae06617833292fb25bf4fb003d270ea


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `e3d66461806eae5a95196722251b445647b31dee`
- Image tag: `e3d66461`
- Image digest: `sha256:a7eb60e70fbe8389623f44f3a5dc907a7ae06617833292fb25bf4fb003d270ea`