### PR TITLE
feat(torghut): settle executable alpha no-delta receipts

### DIFF
--- a/services/torghut/README.md
+++ b/services/torghut/README.md
@@ -205,6 +205,12 @@ Testing rules for the trading core:
   concrete alpha repair target, maps target reason codes to a repair class, carries validation commands and
   no-delta settlement requirements, and keeps `max_notional=0`. `/trading/consumer-evidence` mirrors the same compact
   collection for Jangar without making `/readyz` green or enabling paper/live submission.
+- `GET /trading/revenue-repair` also emits the May 14 doc 199
+  `torghut.executable-alpha-settlement-slots.v1` read-model. It settles the selected executable-alpha repair receipt
+  against the current routeable-candidate count, emits no-delta debt when the selected blocker remains unchanged,
+  names the material reentry receipt reference, and stays additive with `max_notional=0`. `/readyz` and
+  `/trading/consumer-evidence` mirror only the compact
+  `torghut.executable-alpha-settlement-slots-ref.v1` fields for Jangar admission.
 - `GET /trading/revenue-repair` also emits the May 14 doc 198
   `torghut.alpha-repair-closure-board.v1` board. The board binds the top `repair_alpha_readiness` queue item to the
   selected executable-alpha repair receipt, names the routeable-candidate value gate, records zero-notional

--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -84,7 +84,10 @@ from .trading.evidence_receipts import (
     build_schema_receipt,
     build_service_health_receipt,
 )
-from .trading.executable_alpha_receipts import build_capital_replay_projection
+from .trading.executable_alpha_receipts import (
+    build_capital_replay_projection,
+    compact_executable_alpha_settlement_slots,
+)
 from .trading.feature_quality import (
     FeatureQualityThresholds,
     evaluate_feature_batch_quality,
@@ -1122,6 +1125,12 @@ def _evaluate_trading_health_payload(
             "freshness_carry_ledger": freshness_carry_ledger,
             "repair_receipt_frontier": repair_receipt_frontier,
             "repair_outcome_dividend_ledger": repair_outcome_dividend_ledger,
+            "executable_alpha_settlement_slots": compact_executable_alpha_settlement_slots(
+                cast(
+                    Mapping[str, Any],
+                    revenue_repair_digest.get("executable_alpha_settlement_slots"),
+                )
+            ),
             "alpha_repair_closure_board": compact_alpha_repair_closure_board(
                 cast(
                     Mapping[str, Any],
@@ -3311,6 +3320,12 @@ def _build_trading_consumer_evidence_payload() -> dict[str, object]:
         ),
         "executable_alpha_repair_receipts": revenue_repair_digest.get(
             "executable_alpha_repair_receipts"
+        ),
+        "executable_alpha_settlement_slots": compact_executable_alpha_settlement_slots(
+            cast(
+                Mapping[str, Any],
+                revenue_repair_digest.get("executable_alpha_settlement_slots"),
+            )
         ),
         "alpha_repair_closure_board": compact_alpha_repair_closure_board(
             cast(

--- a/services/torghut/app/trading/executable_alpha_receipts.py
+++ b/services/torghut/app/trading/executable_alpha_receipts.py
@@ -17,14 +17,36 @@ EXECUTABLE_ALPHA_REPAIR_RECEIPT_SCHEMA_VERSION = (
 EXECUTABLE_ALPHA_REPAIR_RECEIPTS_SCHEMA_VERSION = (
     "torghut.executable-alpha-repair-receipts.v1"
 )
+EXECUTABLE_ALPHA_SETTLEMENT_SLOT_SCHEMA_VERSION = (
+    "torghut.executable-alpha-settlement-slot.v1"
+)
+EXECUTABLE_ALPHA_SETTLEMENT_SLOTS_SCHEMA_VERSION = (
+    "torghut.executable-alpha-settlement-slots.v1"
+)
+EXECUTABLE_ALPHA_SETTLEMENT_SLOTS_REF_SCHEMA_VERSION = (
+    "torghut.executable-alpha-settlement-slots-ref.v1"
+)
 
 _EXECUTABLE_ALPHA_REPAIR_DESIGN_REF = (
     "docs/torghut/design-system/v6/"
     "197-torghut-executable-alpha-repair-receipts-and-zero-notional-reentry-2026-05-13.md"
 )
+_EXECUTABLE_ALPHA_SETTLEMENT_DESIGN_REF = (
+    "docs/torghut/design-system/v6/"
+    "199-torghut-executable-alpha-settlement-slots-and-no-delta-repair-custody-2026-05-14.md"
+)
 _EXECUTABLE_ALPHA_REPAIR_ROLLBACK_TARGET = (
     "stop emitting executable_alpha_repair_receipts and keep Torghut max_notional=0"
 )
+_EXECUTABLE_ALPHA_SETTLEMENT_ROLLBACK_TARGET = (
+    "stop emitting executable_alpha_settlement_slots and keep Torghut max_notional=0"
+)
+_NO_DELTA_RELEASE_CONDITIONS = [
+    "source_ref_changes",
+    "evidence_window_changes",
+    "blocker_set_changes",
+    "required_receipt_changes",
+]
 
 GraduationState = Literal[
     "candidate",
@@ -577,6 +599,436 @@ def build_executable_alpha_repair_receipts(
         "capital_rule": "zero_notional_repair_only",
         "reason_codes": reason_codes,
         "rollback_target": _EXECUTABLE_ALPHA_REPAIR_ROLLBACK_TARGET,
+    }
+
+
+def _zero_notional(value: object) -> bool:
+    return _text(value, "0") in {"0", "0.0", "0.00", "0.0000"}
+
+
+def _top_queue_item(repair_queue: Sequence[Mapping[str, Any]]) -> Mapping[str, Any]:
+    for item in repair_queue:
+        payload = _mapping(item)
+        if payload:
+            return payload
+    return {}
+
+
+def _repair_receipt_reason_codes(receipt: Mapping[str, Any]) -> list[str]:
+    reason_codes = _string_list(receipt.get("reason_codes"))
+    settlement = _mapping(receipt.get("settlement"))
+    if not reason_codes:
+        reason_codes = _string_list(settlement.get("before_reason_codes"))
+    return reason_codes
+
+
+def _selected_repair_receipt(
+    executable_alpha_repair_receipts: Mapping[str, Any],
+) -> Mapping[str, Any]:
+    selected = _mapping(executable_alpha_repair_receipts.get("selected_receipt"))
+    if selected:
+        return selected
+    selected_receipt_id = _text(
+        executable_alpha_repair_receipts.get("selected_receipt_id")
+    )
+    receipts = [
+        _mapping(item)
+        for item in _sequence(executable_alpha_repair_receipts.get("receipts"))
+    ]
+    for receipt in receipts:
+        if (
+            selected_receipt_id
+            and _text(receipt.get("receipt_id")) == selected_receipt_id
+        ):
+            return receipt
+    return receipts[0] if receipts else {}
+
+
+def _parse_datetime(value: object) -> datetime | None:
+    text = _text(value)
+    if not text:
+        return None
+    if text.endswith("Z"):
+        text = f"{text[:-1]}+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _routeable_candidate_count_from_evidence(evidence: Mapping[str, Any]) -> int:
+    repair_bid_settlement = _mapping(evidence.get("repair_bid_settlement"))
+    routeability_acceptance = _mapping(evidence.get("routeability_acceptance"))
+    route_clearinghouse = _mapping(evidence.get("route_evidence_clearinghouse"))
+    return max(
+        _int(repair_bid_settlement.get("routeable_candidate_count")),
+        _int(routeability_acceptance.get("accepted_routeable_candidate_count")),
+        _int(route_clearinghouse.get("accepted_routeable_candidate_count")),
+    )
+
+
+def _alpha_target_reason_codes(
+    evidence: Mapping[str, Any], hypothesis_id: str
+) -> list[str]:
+    alpha_readiness = _mapping(evidence.get("alpha_readiness"))
+    for raw_target in _sequence(alpha_readiness.get("repair_targets")):
+        target = _mapping(raw_target)
+        if _text(target.get("hypothesis_id")) != hypothesis_id:
+            continue
+        return _reason_list_from_target(target)
+    return []
+
+
+def _required_after_receipts(
+    top_queue_item: Mapping[str, Any], selected_receipt: Mapping[str, Any]
+) -> list[str]:
+    receipts = _string_list(selected_receipt.get("required_output_receipts"))
+    for receipt in [
+        *_string_list(top_queue_item.get("required_receipts")),
+        _text(top_queue_item.get("required_output_receipt")),
+    ]:
+        if receipt and receipt not in receipts:
+            receipts.append(receipt)
+    return receipts
+
+
+def _before_routeable_candidate_count(selected_receipt: Mapping[str, Any]) -> int:
+    settlement = _mapping(selected_receipt.get("settlement"))
+    before_value_gate = _mapping(settlement.get("before_value_gate"))
+    return _int(before_value_gate.get("routeable_candidate_count"))
+
+
+def _settlement_state(
+    *,
+    before_reason_codes: Sequence[str],
+    after_reason_codes: Sequence[str],
+    routeable_before: int,
+    routeable_after: int,
+) -> str:
+    before_set = set(before_reason_codes)
+    after_set = set(after_reason_codes)
+    if routeable_after > routeable_before:
+        return "improved"
+    if before_set and not before_set.intersection(after_set):
+        return "retired"
+    if len(after_set) < len(before_set):
+        return "improved"
+    return "no_delta"
+
+
+def _build_executable_alpha_settlement_slot(
+    *,
+    generated: datetime,
+    fresh_until: datetime,
+    top_queue_item: Mapping[str, Any],
+    selected_receipt: Mapping[str, Any],
+    evidence: Mapping[str, Any],
+    capital: Mapping[str, Any],
+) -> dict[str, object]:
+    selected_receipt_id = _text(selected_receipt.get("receipt_id"))
+    hypothesis_id = _text(selected_receipt.get("hypothesis_id"), "unknown")
+    before_reason_codes = _repair_receipt_reason_codes(selected_receipt)
+    after_reason_codes = _alpha_target_reason_codes(evidence, hypothesis_id)
+    if not after_reason_codes:
+        after_reason_codes = before_reason_codes
+    routeable_before = _before_routeable_candidate_count(selected_receipt)
+    routeable_after = _routeable_candidate_count_from_evidence(evidence)
+    measured_delta = routeable_after - routeable_before
+    state = _settlement_state(
+        before_reason_codes=before_reason_codes,
+        after_reason_codes=after_reason_codes,
+        routeable_before=routeable_before,
+        routeable_after=routeable_after,
+    )
+    before_set = set(before_reason_codes)
+    after_set = set(after_reason_codes)
+    retired_reason_codes = sorted(before_set - after_set)
+    preserved_reason_codes = [
+        reason for reason in before_reason_codes if reason in after_set
+    ]
+    introduced_reason_codes = sorted(after_set - before_set)
+    no_delta_reason = (
+        "routeable_candidate_count_unchanged" if state == "no_delta" else ""
+    )
+    source_revenue_repair_ref = _text(
+        selected_receipt.get("source_revenue_repair_ref"),
+        "torghut-revenue-repair-digest:unknown",
+    )
+    dedupe_key = _stable_hash(
+        "executable-alpha-settlement-slot-dedupe",
+        {
+            "source_revenue_repair_ref": source_revenue_repair_ref,
+            "selected_receipt_id": selected_receipt_id,
+            "hypothesis_id": hypothesis_id,
+            "before_reason_codes": before_reason_codes,
+            "required_after_receipts": _required_after_receipts(
+                top_queue_item, selected_receipt
+            ),
+        },
+    )
+    slot_id = "executable-alpha-settlement-slot:" + _stable_hash(
+        "executable-alpha-settlement-slot",
+        {
+            "dedupe_key": dedupe_key,
+            "selected_receipt_id": selected_receipt_id,
+        },
+    )
+    material_reentry_receipt_id = "material-reentry-receipt:" + _stable_hash(
+        "material-reentry-receipt",
+        {
+            "slot_id": slot_id,
+            "dedupe_key": dedupe_key,
+            "selected_receipt_id": selected_receipt_id,
+        },
+    )
+    return {
+        "schema_version": EXECUTABLE_ALPHA_SETTLEMENT_SLOT_SCHEMA_VERSION,
+        "slot_id": slot_id,
+        "selected_receipt_id": selected_receipt_id,
+        "source_revenue_repair_ref": source_revenue_repair_ref,
+        "hypothesis_id": hypothesis_id,
+        "candidate_id": selected_receipt.get("candidate_id"),
+        "strategy_id": selected_receipt.get("strategy_id"),
+        "repair_class": _text(selected_receipt.get("repair_class")),
+        "target_value_gate": _text(
+            selected_receipt.get("target_value_gate"),
+            _text(top_queue_item.get("value_gate"), "routeable_candidate_count"),
+        ),
+        "expected_gate_delta": _text(selected_receipt.get("expected_gate_delta")),
+        "before_reason_codes": before_reason_codes,
+        "after_reason_codes": after_reason_codes,
+        "retired_reason_codes": retired_reason_codes,
+        "preserved_reason_codes": preserved_reason_codes,
+        "introduced_reason_codes": introduced_reason_codes,
+        "before_refs": _string_list(selected_receipt.get("required_input_refs")),
+        "after_refs": [],
+        "required_after_receipts": _required_after_receipts(
+            top_queue_item, selected_receipt
+        ),
+        "validation_commands": _string_list(
+            selected_receipt.get("validation_commands")
+        ),
+        "routeable_candidate_count_before": routeable_before,
+        "routeable_candidate_count_after": routeable_after,
+        "measured_delta": measured_delta,
+        "settlement_state": state,
+        "no_delta_reason": no_delta_reason,
+        "dedupe_key": dedupe_key,
+        "material_reentry_receipt_id": material_reentry_receipt_id,
+        "required_material_reentry_receipt": "jangar.material-reentry-receipt.v1",
+        "next_allowed_attempt_after": fresh_until.isoformat()
+        if no_delta_reason
+        else None,
+        "max_notional": _text(
+            selected_receipt.get("max_notional"),
+            _text(capital.get("max_notional"), "0"),
+        ),
+        "capital_rule": _text(
+            selected_receipt.get("capital_rule"), "zero_notional_repair_only"
+        ),
+        "generated_at": generated.isoformat(),
+        "fresh_until": fresh_until.isoformat(),
+        "rollback_target": _EXECUTABLE_ALPHA_SETTLEMENT_ROLLBACK_TARGET,
+    }
+
+
+def _no_delta_debt_from_settlement_slot(
+    slot: Mapping[str, Any],
+) -> dict[str, object] | None:
+    if _text(slot.get("settlement_state")) != "no_delta":
+        return None
+    preserved_reason_codes = _string_list(slot.get("preserved_reason_codes"))
+    return {
+        "debt_id": "executable-alpha-no-delta:"
+        + _stable_hash(
+            "executable-alpha-no-delta",
+            {
+                "slot_id": _text(slot.get("slot_id")),
+                "dedupe_key": _text(slot.get("dedupe_key")),
+                "selected_receipt_id": _text(slot.get("selected_receipt_id")),
+            },
+        ),
+        "slot_id": slot.get("slot_id"),
+        "selected_receipt_id": slot.get("selected_receipt_id"),
+        "material_reentry_receipt_id": slot.get("material_reentry_receipt_id"),
+        "dedupe_key": slot.get("dedupe_key"),
+        "hypothesis_id": slot.get("hypothesis_id"),
+        "value_gate": slot.get("target_value_gate"),
+        "preserved_reason_codes": preserved_reason_codes,
+        "routeable_candidate_count_before": slot.get(
+            "routeable_candidate_count_before"
+        ),
+        "routeable_candidate_count_after": slot.get("routeable_candidate_count_after"),
+        "measured_delta": slot.get("measured_delta"),
+        "no_delta_reason": slot.get("no_delta_reason"),
+        "remaining_blocker": _primary_remaining_blocker(preserved_reason_codes),
+        "release_conditions": list(_NO_DELTA_RELEASE_CONDITIONS),
+    }
+
+
+def _primary_remaining_blocker(reason_codes: Sequence[str]) -> str:
+    for reason in reason_codes:
+        if not reason.startswith("closed_session_"):
+            return reason
+    return reason_codes[0] if reason_codes else "unknown"
+
+
+def build_executable_alpha_settlement_slots(
+    *,
+    generated_at: datetime,
+    business_state: str,
+    revenue_ready: bool,
+    repair_queue: Sequence[Mapping[str, Any]],
+    capital: Mapping[str, Any],
+    evidence: Mapping[str, Any],
+    executable_alpha_repair_receipts: Mapping[str, Any],
+) -> dict[str, object]:
+    """Build no-delta settlement custody for the selected executable-alpha receipt."""
+
+    if generated_at.tzinfo is None:
+        raise ValueError("generated_at_missing_timezone")
+    generated = generated_at.astimezone(timezone.utc)
+    fresh_until = generated + timedelta(seconds=_DEFAULT_FRESHNESS_SECONDS)
+    top_item = _top_queue_item(repair_queue)
+    selected_receipt = _selected_repair_receipt(executable_alpha_repair_receipts)
+    max_notional = _text(capital.get("max_notional"), "0")
+
+    reason_codes: list[str] = []
+    if revenue_ready:
+        reason_codes.append("revenue_already_ready")
+    if business_state != "repair_only":
+        reason_codes.append(f"business_state_{business_state or 'unknown'}")
+    top_alpha_repair = _top_alpha_repair(top_item)
+    if not top_alpha_repair:
+        reason_codes.append("revenue_repair_top_item_not_alpha_readiness")
+    if top_alpha_repair and not selected_receipt:
+        reason_codes.append("selected_executable_alpha_repair_receipt_missing")
+    if not _zero_notional(max_notional):
+        reason_codes.append("capital_notional_nonzero")
+    if bool(capital.get("live_submission_allowed")):
+        reason_codes.append("live_submission_enabled")
+    if selected_receipt and not _zero_notional(selected_receipt.get("max_notional")):
+        reason_codes.append("selected_receipt_notional_nonzero")
+
+    selected_fresh_until = _parse_datetime(selected_receipt.get("fresh_until"))
+    if (
+        selected_receipt
+        and selected_fresh_until is not None
+        and selected_fresh_until < generated
+    ):
+        reason_codes.append("selected_executable_alpha_repair_receipt_stale")
+
+    slots: list[dict[str, object]] = []
+    if not reason_codes:
+        slots.append(
+            _build_executable_alpha_settlement_slot(
+                generated=generated,
+                fresh_until=fresh_until,
+                top_queue_item=top_item,
+                selected_receipt=selected_receipt,
+                evidence=evidence,
+                capital=capital,
+            )
+        )
+
+    selected_slot = slots[0] if slots else None
+    no_delta_debt = [
+        debt
+        for slot in slots
+        if (debt := _no_delta_debt_from_settlement_slot(slot)) is not None
+    ]
+
+    if any(
+        reason
+        in {
+            "capital_notional_nonzero",
+            "live_submission_enabled",
+            "selected_receipt_notional_nonzero",
+            "selected_executable_alpha_repair_receipt_stale",
+        }
+        for reason in reason_codes
+    ):
+        status = "blocked"
+    elif "revenue_repair_top_item_not_alpha_readiness" in reason_codes:
+        status = "inactive"
+    elif selected_slot and _text(selected_slot.get("settlement_state")) in {
+        "retired",
+        "improved",
+        "no_delta",
+        "invalidated",
+        "failed",
+        "superseded",
+    }:
+        status = "settled"
+    elif selected_slot:
+        status = "selected"
+    else:
+        status = "held"
+
+    return {
+        "schema_version": EXECUTABLE_ALPHA_SETTLEMENT_SLOTS_SCHEMA_VERSION,
+        "generated_at": generated.isoformat(),
+        "fresh_until": fresh_until.isoformat(),
+        "governing_design_ref": _EXECUTABLE_ALPHA_SETTLEMENT_DESIGN_REF,
+        "source_revenue_repair_ref": executable_alpha_repair_receipts.get(
+            "source_revenue_repair_ref"
+        ),
+        "selected_receipt_id": selected_receipt.get("receipt_id")
+        if selected_receipt
+        else None,
+        "selected_slot_id": selected_slot.get("slot_id") if selected_slot else None,
+        "status": status,
+        "reason_codes": reason_codes,
+        "slots": slots,
+        "selected_slot": selected_slot,
+        "no_delta_debt": no_delta_debt,
+        "max_notional": max_notional,
+        "capital_rule": _text(
+            top_item.get("capital_rule"), "zero_notional_repair_only"
+        ),
+        "rollback_target": _EXECUTABLE_ALPHA_SETTLEMENT_ROLLBACK_TARGET,
+    }
+
+
+def compact_executable_alpha_settlement_slots(
+    settlement_slots: Mapping[str, Any] | None,
+) -> dict[str, object]:
+    """Return the Jangar-facing compact settlement slot reference."""
+
+    payload = _mapping(settlement_slots)
+    if not payload:
+        return {
+            "schema_version": EXECUTABLE_ALPHA_SETTLEMENT_SLOTS_REF_SCHEMA_VERSION,
+            "status": "missing",
+            "reason_codes": ["executable_alpha_settlement_slots_missing"],
+        }
+    selected_slot = _mapping(payload.get("selected_slot"))
+    no_delta_debt = _sequence(payload.get("no_delta_debt"))
+    preserved_reason_codes = _string_list(selected_slot.get("preserved_reason_codes"))
+    return {
+        "schema_version": EXECUTABLE_ALPHA_SETTLEMENT_SLOTS_REF_SCHEMA_VERSION,
+        "slots_schema_version": payload.get("schema_version"),
+        "generated_at": payload.get("generated_at"),
+        "fresh_until": payload.get("fresh_until"),
+        "status": payload.get("status"),
+        "reason_codes": _string_list(payload.get("reason_codes")),
+        "selected_receipt_id": payload.get("selected_receipt_id"),
+        "selected_slot_id": payload.get("selected_slot_id"),
+        "selected_hypothesis_id": selected_slot.get("hypothesis_id"),
+        "settlement_state": selected_slot.get("settlement_state"),
+        "target_value_gate": selected_slot.get("target_value_gate"),
+        "active_dedupe_key": selected_slot.get("dedupe_key"),
+        "material_reentry_receipt_id": selected_slot.get("material_reentry_receipt_id"),
+        "no_delta_debt_count": len(no_delta_debt),
+        "remaining_blocker": _primary_remaining_blocker(preserved_reason_codes)
+        if preserved_reason_codes
+        else None,
+        "max_notional": payload.get("max_notional"),
+        "capital_rule": payload.get("capital_rule"),
+        "rollback_target": payload.get("rollback_target"),
     }
 
 
@@ -1141,6 +1593,11 @@ __all__ = [
     "EXECUTABLE_ALPHA_RECEIPTS_SCHEMA_VERSION",
     "EXECUTABLE_ALPHA_REPAIR_RECEIPT_SCHEMA_VERSION",
     "EXECUTABLE_ALPHA_REPAIR_RECEIPTS_SCHEMA_VERSION",
+    "EXECUTABLE_ALPHA_SETTLEMENT_SLOT_SCHEMA_VERSION",
+    "EXECUTABLE_ALPHA_SETTLEMENT_SLOTS_REF_SCHEMA_VERSION",
+    "EXECUTABLE_ALPHA_SETTLEMENT_SLOTS_SCHEMA_VERSION",
     "build_capital_replay_projection",
     "build_executable_alpha_repair_receipts",
+    "build_executable_alpha_settlement_slots",
+    "compact_executable_alpha_settlement_slots",
 ]

--- a/services/torghut/app/trading/revenue_repair.py
+++ b/services/torghut/app/trading/revenue_repair.py
@@ -13,7 +13,10 @@ from typing import Any, Mapping, Sequence, cast
 from .alpha_readiness_strike_ledger import build_alpha_readiness_strike_ledger
 from .alpha_evidence_foundry import build_alpha_evidence_foundry
 from .alpha_repair_closure_board import build_alpha_repair_closure_board
-from .executable_alpha_receipts import build_executable_alpha_repair_receipts
+from .executable_alpha_receipts import (
+    build_executable_alpha_repair_receipts,
+    build_executable_alpha_settlement_slots,
+)
 
 
 SCHEMA_VERSION = "torghut.revenue-repair-digest.v1"
@@ -989,6 +992,15 @@ def build_revenue_repair_digest(
         },
         db_check=db_check,
     )
+    executable_alpha_settlement_slots = build_executable_alpha_settlement_slots(
+        generated_at=generated,
+        business_state=business_state,
+        revenue_ready=revenue_ready,
+        repair_queue=cast(Sequence[Mapping[str, Any]], repair_queue),
+        capital=capital,
+        evidence=evidence,
+        executable_alpha_repair_receipts=executable_alpha_repair_receipts,
+    )
     alpha_evidence_foundry = build_alpha_evidence_foundry(
         generated_at=generated,
         business_state=business_state,
@@ -1015,6 +1027,7 @@ def build_revenue_repair_digest(
         "repair_bid_settlement_ledger": dict(repair_bid_settlement),
         "alpha_readiness_strike_ledger": alpha_readiness_strike_ledger,
         "executable_alpha_repair_receipts": executable_alpha_repair_receipts,
+        "executable_alpha_settlement_slots": executable_alpha_settlement_slots,
         "alpha_repair_closure_board": alpha_repair_closure_board,
         "alpha_evidence_foundry": alpha_evidence_foundry,
         "business_state": business_state,

--- a/services/torghut/scripts/build_revenue_repair_digest.py
+++ b/services/torghut/scripts/build_revenue_repair_digest.py
@@ -24,6 +24,7 @@ from app.trading.revenue_repair import (
     _sequence,
     build_alpha_evidence_foundry,
     build_alpha_repair_closure_board,
+    build_executable_alpha_settlement_slots,
     build_revenue_repair_digest,
     main,
 )
@@ -40,6 +41,7 @@ __all__ = [
     "_sequence",
     "build_alpha_evidence_foundry",
     "build_alpha_repair_closure_board",
+    "build_executable_alpha_settlement_slots",
     "build_revenue_repair_digest",
     "main",
 ]

--- a/services/torghut/tests/test_build_revenue_repair_digest.py
+++ b/services/torghut/tests/test_build_revenue_repair_digest.py
@@ -416,6 +416,30 @@ class TestBuildRevenueRepairDigest(TestCase):
         )
         self.assertEqual(selected_repair_receipt["max_notional"], "0")
         self.assertTrue(selected_repair_receipt["no_delta_settlement_required"])
+        settlement_slots = digest["executable_alpha_settlement_slots"]
+        self.assertIsInstance(settlement_slots, dict)
+        self.assertEqual(
+            settlement_slots["schema_version"],
+            "torghut.executable-alpha-settlement-slots.v1",
+        )
+        self.assertEqual(settlement_slots["status"], "settled")
+        self.assertEqual(settlement_slots["max_notional"], "0")
+        selected_slot = settlement_slots["selected_slot"]
+        self.assertIsInstance(selected_slot, dict)
+        self.assertEqual(
+            selected_slot["schema_version"],
+            "torghut.executable-alpha-settlement-slot.v1",
+        )
+        self.assertEqual(
+            selected_slot["selected_receipt_id"],
+            selected_repair_receipt["receipt_id"],
+        )
+        self.assertEqual(selected_slot["settlement_state"], "no_delta")
+        self.assertEqual(
+            selected_slot["no_delta_reason"],
+            "routeable_candidate_count_unchanged",
+        )
+        self.assertEqual(len(settlement_slots["no_delta_debt"]), 1)
         closure_board = digest["alpha_repair_closure_board"]
         self.assertIsInstance(closure_board, dict)
         self.assertEqual(

--- a/services/torghut/tests/test_executable_alpha_repair_receipts.py
+++ b/services/torghut/tests/test_executable_alpha_repair_receipts.py
@@ -6,6 +6,8 @@ from typing import Any, cast
 
 from app.trading.executable_alpha_receipts import (
     build_executable_alpha_repair_receipts,
+    build_executable_alpha_settlement_slots,
+    compact_executable_alpha_settlement_slots,
 )
 
 
@@ -106,6 +108,63 @@ def _alpha_readiness() -> dict[str, object]:
     }
 
 
+def _h_cont_alpha_readiness() -> dict[str, object]:
+    return {
+        "promotion_eligible_total": 0,
+        "repair_target_count": 1,
+        "capital_replay_board": {
+            "schema_version": "torghut.capital-replay-board.v1",
+            "board_id": "capital-replay:cont",
+        },
+        "executable_alpha_receipts": {
+            "schema_version": "torghut.executable-alpha-receipts.v1",
+            "candidate_receipts": [
+                {
+                    "receipt_id": "receipt:cont",
+                    "hypothesis_id": "H-CONT-01",
+                    "max_notional": "0",
+                }
+            ],
+        },
+        "repair_targets": [
+            {
+                "hypothesis_id": "H-CONT-01",
+                "candidate_id": "chip-paper-microbar-composite@execution-proof",
+                "strategy_id": "intraday_tsmom_v1@paper",
+                "state": "shadow",
+                "promotion_eligible": False,
+                "reasons": ["post_cost_expectancy_non_positive"],
+                "informational_reasons": [
+                    "closed_session_signal_hold",
+                    "closed_session_tca_evidence_hold",
+                ],
+            }
+        ],
+    }
+
+
+def _settlement_evidence(
+    alpha_readiness: Mapping[str, Any] | None = None,
+    *,
+    routeable_candidate_count: int = 0,
+) -> dict[str, object]:
+    return {
+        "alpha_readiness": alpha_readiness or _h_cont_alpha_readiness(),
+        "repair_bid_settlement": {
+            "ledger_id": "repair-bid-settlement-ledger:test",
+            "routeable_candidate_count": routeable_candidate_count,
+        },
+        "routeability_acceptance": {
+            "ledger_id": "routeability-acceptance-ledger:test",
+            "accepted_routeable_candidate_count": routeable_candidate_count,
+        },
+        "route_evidence_clearinghouse": {
+            "packet_id": "route-evidence-clearinghouse:test",
+            "accepted_routeable_candidate_count": routeable_candidate_count,
+        },
+    }
+
+
 def _build(
     *,
     alpha_readiness: Mapping[str, Any] | None = None,
@@ -120,6 +179,29 @@ def _build(
         alpha_readiness=alpha_readiness or _alpha_readiness(),
         capital=capital or {"max_notional": "0"},
         repair_bid_settlement_ledger=_settlement_ledger(),
+    )
+
+
+def _build_settlement_slots(
+    *,
+    alpha_readiness: Mapping[str, Any] | None = None,
+    repair_queue: list[dict[str, object]] | None = None,
+    capital: Mapping[str, Any] | None = None,
+    routeable_candidate_count: int = 0,
+    generated_at: datetime = NOW,
+) -> dict[str, object]:
+    alpha = alpha_readiness or _h_cont_alpha_readiness()
+    repair_receipts = _build(alpha_readiness=alpha, repair_queue=repair_queue)
+    return build_executable_alpha_settlement_slots(
+        generated_at=generated_at,
+        business_state="repair_only",
+        revenue_ready=False,
+        repair_queue=repair_queue or _top_alpha_queue(),
+        capital=capital or {"max_notional": "0", "live_submission_allowed": False},
+        evidence=_settlement_evidence(
+            alpha, routeable_candidate_count=routeable_candidate_count
+        ),
+        executable_alpha_repair_receipts=repair_receipts,
     )
 
 
@@ -199,3 +281,108 @@ def test_receipts_block_nonzero_notional() -> None:
     assert payload["selected_receipt"] is None
     assert payload["receipts"] == []
     assert payload["reason_codes"] == ["capital_notional_nonzero"]
+
+
+def test_evidence_window_selected_repair_receipt_settles_no_delta_for_unchanged_routeable_count() -> (
+    None
+):
+    payload = _build_settlement_slots()
+
+    assert payload["schema_version"] == "torghut.executable-alpha-settlement-slots.v1"
+    assert payload["status"] == "settled"
+    assert payload["max_notional"] == "0"
+    assert payload["capital_rule"] == "zero_notional_repair_only"
+    selected_slot = cast(Mapping[str, Any], payload["selected_slot"])
+    assert (
+        selected_slot["schema_version"] == "torghut.executable-alpha-settlement-slot.v1"
+    )
+    assert selected_slot["hypothesis_id"] == "H-CONT-01"
+    assert selected_slot["target_value_gate"] == "routeable_candidate_count"
+    assert selected_slot["settlement_state"] == "no_delta"
+    assert selected_slot["routeable_candidate_count_before"] == 0
+    assert selected_slot["routeable_candidate_count_after"] == 0
+    assert selected_slot["measured_delta"] == 0
+    assert selected_slot["no_delta_reason"] == "routeable_candidate_count_unchanged"
+    assert selected_slot["material_reentry_receipt_id"].startswith(
+        "material-reentry-receipt:"
+    )
+    assert selected_slot["required_material_reentry_receipt"] == (
+        "jangar.material-reentry-receipt.v1"
+    )
+    assert selected_slot["max_notional"] == "0"
+    no_delta_debt = cast(list[Mapping[str, Any]], payload["no_delta_debt"])
+    assert len(no_delta_debt) == 1
+    assert no_delta_debt[0]["selected_receipt_id"] == payload["selected_receipt_id"]
+    assert no_delta_debt[0]["remaining_blocker"] == (
+        "post_cost_expectancy_non_positive"
+    )
+    assert "blocker_set_changes" in no_delta_debt[0]["release_conditions"]
+
+
+def test_settlement_slots_inactive_when_alpha_readiness_is_not_top_queue_item() -> None:
+    payload = _build_settlement_slots(
+        repair_queue=[
+            {
+                "code": "repair_execution_tca",
+                "reason": "execution_tca_stale",
+                "value_gate": "fill_tca_or_slippage_quality",
+            }
+        ]
+    )
+
+    assert payload["status"] == "inactive"
+    assert payload["selected_slot"] is None
+    assert payload["slots"] == []
+    assert payload["no_delta_debt"] == []
+    assert payload["reason_codes"] == ["revenue_repair_top_item_not_alpha_readiness"]
+
+
+def test_settlement_slots_block_when_capital_safety_is_not_zero_notional() -> None:
+    payload = _build_settlement_slots(
+        capital={"max_notional": "25", "live_submission_allowed": True}
+    )
+
+    assert payload["status"] == "blocked"
+    assert payload["selected_slot"] is None
+    assert payload["slots"] == []
+    assert payload["reason_codes"] == [
+        "capital_notional_nonzero",
+        "live_submission_enabled",
+    ]
+
+
+def test_settlement_slots_block_stale_selected_repair_receipt() -> None:
+    alpha = _h_cont_alpha_readiness()
+    repair_receipts = _build(alpha_readiness=alpha)
+    selected = cast(dict[str, object], repair_receipts["selected_receipt"])
+    selected["fresh_until"] = "2026-05-13T22:54:00+00:00"
+
+    payload = build_executable_alpha_settlement_slots(
+        generated_at=NOW,
+        business_state="repair_only",
+        revenue_ready=False,
+        repair_queue=_top_alpha_queue(),
+        capital={"max_notional": "0", "live_submission_allowed": False},
+        evidence=_settlement_evidence(alpha),
+        executable_alpha_repair_receipts=repair_receipts,
+    )
+
+    assert payload["status"] == "blocked"
+    assert payload["selected_slot"] is None
+    assert payload["reason_codes"] == ["selected_executable_alpha_repair_receipt_stale"]
+
+
+def test_compact_settlement_slots_exposes_no_delta_receipt_ref() -> None:
+    payload = _build_settlement_slots()
+    compact = compact_executable_alpha_settlement_slots(payload)
+
+    assert compact["schema_version"] == (
+        "torghut.executable-alpha-settlement-slots-ref.v1"
+    )
+    assert compact["status"] == "settled"
+    assert compact["selected_hypothesis_id"] == "H-CONT-01"
+    assert compact["settlement_state"] == "no_delta"
+    assert compact["target_value_gate"] == "routeable_candidate_count"
+    assert compact["no_delta_debt_count"] == 1
+    assert compact["remaining_blocker"] == "post_cost_expectancy_non_positive"
+    assert compact["max_notional"] == "0"

--- a/services/torghut/tests/test_executable_alpha_repair_receipts.py
+++ b/services/torghut/tests/test_executable_alpha_repair_receipts.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any, cast
 
 from app.trading.executable_alpha_receipts import (
@@ -205,6 +205,14 @@ def _build_settlement_slots(
     )
 
 
+def _selected_repair_receipt_payload() -> dict[str, object]:
+    alpha = _h_cont_alpha_readiness()
+    repair_receipts = _build(alpha_readiness=alpha)
+    selected = cast(dict[str, object], repair_receipts["selected_receipt"])
+    assert selected["receipt_id"] == repair_receipts["selected_receipt_id"]
+    return repair_receipts
+
+
 def test_alpha_readiness_top_queue_selects_zero_notional_lineage_receipt() -> None:
     payload = _build()
 
@@ -370,6 +378,168 @@ def test_settlement_slots_block_stale_selected_repair_receipt() -> None:
     assert payload["status"] == "blocked"
     assert payload["selected_slot"] is None
     assert payload["reason_codes"] == ["selected_executable_alpha_repair_receipt_stale"]
+
+
+def test_settlement_slots_select_receipt_by_id_when_selected_payload_missing() -> None:
+    alpha = _h_cont_alpha_readiness()
+    repair_receipts = _selected_repair_receipt_payload()
+    repair_receipts["selected_receipt"] = None
+
+    payload = build_executable_alpha_settlement_slots(
+        generated_at=NOW,
+        business_state="repair_only",
+        revenue_ready=False,
+        repair_queue=_top_alpha_queue(),
+        capital={"max_notional": "0", "live_submission_allowed": False},
+        evidence=_settlement_evidence(alpha),
+        executable_alpha_repair_receipts=repair_receipts,
+    )
+
+    assert payload["status"] == "settled"
+    assert payload["selected_receipt_id"] == repair_receipts["selected_receipt_id"]
+    selected_slot = cast(Mapping[str, Any], payload["selected_slot"])
+    assert (
+        selected_slot["selected_receipt_id"] == repair_receipts["selected_receipt_id"]
+    )
+
+
+def test_settlement_slots_use_receipt_settlement_reasons_and_keep_unknown_blocker() -> (
+    None
+):
+    repair_receipts = _selected_repair_receipt_payload()
+    selected = cast(dict[str, object], repair_receipts["selected_receipt"])
+    selected["reason_codes"] = []
+    settlement = cast(dict[str, object], selected["settlement"])
+    settlement["before_reason_codes"] = ["closed_session_signal_hold"]
+
+    alpha = _h_cont_alpha_readiness()
+    target = cast(dict[str, object], cast(list[object], alpha["repair_targets"])[0])
+    target["hypothesis_id"] = "H-OTHER"
+
+    payload = build_executable_alpha_settlement_slots(
+        generated_at=NOW,
+        business_state="repair_only",
+        revenue_ready=False,
+        repair_queue=_top_alpha_queue(),
+        capital={"max_notional": "0", "live_submission_allowed": False},
+        evidence=_settlement_evidence(alpha),
+        executable_alpha_repair_receipts=repair_receipts,
+    )
+
+    selected_slot = cast(Mapping[str, Any], payload["selected_slot"])
+    assert selected_slot["preserved_reason_codes"] == ["closed_session_signal_hold"]
+    no_delta_debt = cast(list[Mapping[str, Any]], payload["no_delta_debt"])
+    assert no_delta_debt[0]["remaining_blocker"] == "closed_session_signal_hold"
+
+
+def test_settlement_slots_mark_retired_when_blocker_set_clears() -> None:
+    alpha = _h_cont_alpha_readiness()
+    repair_receipts = _build(alpha_readiness=alpha)
+    target = cast(dict[str, object], cast(list[object], alpha["repair_targets"])[0])
+    target["reasons"] = ["drift_checks_missing"]
+    target["informational_reasons"] = []
+
+    payload = build_executable_alpha_settlement_slots(
+        generated_at=NOW,
+        business_state="repair_only",
+        revenue_ready=False,
+        repair_queue=_top_alpha_queue(),
+        capital={"max_notional": "0", "live_submission_allowed": False},
+        evidence=_settlement_evidence(alpha),
+        executable_alpha_repair_receipts=repair_receipts,
+    )
+
+    assert payload["status"] == "settled"
+    selected_slot = cast(Mapping[str, Any], payload["selected_slot"])
+    assert selected_slot["settlement_state"] == "retired"
+    assert payload["no_delta_debt"] == []
+
+
+def test_settlement_slots_mark_improved_when_routeable_count_increases() -> None:
+    payload = _build_settlement_slots(routeable_candidate_count=1)
+
+    assert payload["status"] == "settled"
+    selected_slot = cast(Mapping[str, Any], payload["selected_slot"])
+    assert selected_slot["settlement_state"] == "improved"
+    assert selected_slot["measured_delta"] == 1
+    assert selected_slot["no_delta_reason"] == ""
+    assert payload["no_delta_debt"] == []
+
+
+def test_settlement_slots_block_invalid_and_naive_selected_receipt_timestamps() -> None:
+    alpha = _h_cont_alpha_readiness()
+    repair_receipts = _selected_repair_receipt_payload()
+    selected = cast(dict[str, object], repair_receipts["selected_receipt"])
+    selected["fresh_until"] = "not-a-date"
+
+    invalid_timestamp_payload = build_executable_alpha_settlement_slots(
+        generated_at=NOW,
+        business_state="repair_only",
+        revenue_ready=False,
+        repair_queue=_top_alpha_queue(),
+        capital={"max_notional": "0", "live_submission_allowed": False},
+        evidence=_settlement_evidence(alpha),
+        executable_alpha_repair_receipts=repair_receipts,
+    )
+    assert invalid_timestamp_payload["status"] == "settled"
+
+    selected["fresh_until"] = (
+        (NOW - timedelta(minutes=1)).replace(tzinfo=None).isoformat()
+    )
+    stale_naive_payload = build_executable_alpha_settlement_slots(
+        generated_at=NOW,
+        business_state="repair_only",
+        revenue_ready=False,
+        repair_queue=_top_alpha_queue(),
+        capital={"max_notional": "0", "live_submission_allowed": False},
+        evidence=_settlement_evidence(alpha),
+        executable_alpha_repair_receipts=repair_receipts,
+    )
+
+    assert stale_naive_payload["status"] == "blocked"
+    assert stale_naive_payload["reason_codes"] == [
+        "selected_executable_alpha_repair_receipt_stale"
+    ]
+
+
+def test_settlement_slots_block_selected_receipt_nonzero_notional() -> None:
+    alpha = _h_cont_alpha_readiness()
+    repair_receipts = _selected_repair_receipt_payload()
+    selected = cast(dict[str, object], repair_receipts["selected_receipt"])
+    selected["max_notional"] = "10"
+
+    payload = build_executable_alpha_settlement_slots(
+        generated_at=NOW,
+        business_state="repair_only",
+        revenue_ready=False,
+        repair_queue=_top_alpha_queue(),
+        capital={"max_notional": "0", "live_submission_allowed": False},
+        evidence=_settlement_evidence(alpha),
+        executable_alpha_repair_receipts=repair_receipts,
+    )
+
+    assert payload["status"] == "blocked"
+    assert payload["selected_slot"] is None
+    assert payload["reason_codes"] == ["selected_receipt_notional_nonzero"]
+
+
+def test_settlement_slots_require_timezone_aware_generation_time() -> None:
+    try:
+        _build_settlement_slots(generated_at=NOW.replace(tzinfo=None))
+    except ValueError as error:
+        assert str(error) == "generated_at_missing_timezone"
+    else:
+        raise AssertionError("expected generated_at_missing_timezone")
+
+
+def test_compact_settlement_slots_reports_missing_payload() -> None:
+    compact = compact_executable_alpha_settlement_slots(None)
+
+    assert compact == {
+        "schema_version": "torghut.executable-alpha-settlement-slots-ref.v1",
+        "status": "missing",
+        "reason_codes": ["executable_alpha_settlement_slots_missing"],
+    }
 
 
 def test_compact_settlement_slots_exposes_no_delta_receipt_ref() -> None:

--- a/services/torghut/tests/test_executable_alpha_repair_receipts.py
+++ b/services/torghut/tests/test_executable_alpha_repair_receipts.py
@@ -4,6 +4,8 @@ from collections.abc import Mapping
 from datetime import datetime, timedelta, timezone
 from typing import Any, cast
 
+import pytest
+
 from app.trading.executable_alpha_receipts import (
     build_executable_alpha_repair_receipts,
     build_executable_alpha_settlement_slots,
@@ -143,6 +145,11 @@ def _h_cont_alpha_readiness() -> dict[str, object]:
     }
 
 
+def _h_cont_repair_receipts() -> tuple[dict[str, object], dict[str, object]]:
+    alpha = _h_cont_alpha_readiness()
+    return alpha, _build(alpha_readiness=alpha)
+
+
 def _settlement_evidence(
     alpha_readiness: Mapping[str, Any] | None = None,
     *,
@@ -203,14 +210,6 @@ def _build_settlement_slots(
         ),
         executable_alpha_repair_receipts=repair_receipts,
     )
-
-
-def _selected_repair_receipt_payload() -> dict[str, object]:
-    alpha = _h_cont_alpha_readiness()
-    repair_receipts = _build(alpha_readiness=alpha)
-    selected = cast(dict[str, object], repair_receipts["selected_receipt"])
-    assert selected["receipt_id"] == repair_receipts["selected_receipt_id"]
-    return repair_receipts
 
 
 def test_alpha_readiness_top_queue_selects_zero_notional_lineage_receipt() -> None:
@@ -360,10 +359,9 @@ def test_settlement_slots_block_when_capital_safety_is_not_zero_notional() -> No
 
 
 def test_settlement_slots_block_stale_selected_repair_receipt() -> None:
-    alpha = _h_cont_alpha_readiness()
-    repair_receipts = _build(alpha_readiness=alpha)
+    alpha, repair_receipts = _h_cont_repair_receipts()
     selected = cast(dict[str, object], repair_receipts["selected_receipt"])
-    selected["fresh_until"] = "2026-05-13T22:54:00+00:00"
+    selected["fresh_until"] = "2026-05-13T22:54:00Z"
 
     payload = build_executable_alpha_settlement_slots(
         generated_at=NOW,
@@ -380,10 +378,144 @@ def test_settlement_slots_block_stale_selected_repair_receipt() -> None:
     assert payload["reason_codes"] == ["selected_executable_alpha_repair_receipt_stale"]
 
 
-def test_settlement_slots_select_receipt_by_id_when_selected_payload_missing() -> None:
-    alpha = _h_cont_alpha_readiness()
-    repair_receipts = _selected_repair_receipt_payload()
+def test_settlement_slots_select_receipt_by_id_and_records_routeable_improvement() -> (
+    None
+):
+    alpha, repair_receipts = _h_cont_repair_receipts()
+    selected = cast(dict[str, object], repair_receipts["selected_receipt"])
+    selected_receipt_id = selected["receipt_id"]
+    selected.pop("reason_codes")
+    selected.pop("required_output_receipts")
     repair_receipts["selected_receipt"] = None
+    repair_receipts["selected_receipt_id"] = selected_receipt_id
+
+    payload = build_executable_alpha_settlement_slots(
+        generated_at=NOW,
+        business_state="repair_only",
+        revenue_ready=False,
+        repair_queue=_top_alpha_queue(),
+        capital={"max_notional": "0", "live_submission_allowed": False},
+        evidence=_settlement_evidence(alpha, routeable_candidate_count=1),
+        executable_alpha_repair_receipts=repair_receipts,
+    )
+
+    selected_slot = cast(Mapping[str, Any], payload["selected_slot"])
+    assert payload["status"] == "settled"
+    assert payload["no_delta_debt"] == []
+    assert selected_slot["selected_receipt_id"] == selected_receipt_id
+    assert selected_slot["settlement_state"] == "improved"
+    assert selected_slot["measured_delta"] == 1
+    assert set(selected_slot["before_reason_codes"]) == {
+        "post_cost_expectancy_non_positive",
+        "closed_session_signal_hold",
+        "closed_session_tca_evidence_hold",
+    }
+    assert set(selected_slot["required_after_receipts"]) == {
+        "alpha_readiness_receipt",
+        "hypothesis_promotion_receipt",
+        "capital_replay_board",
+        "torghut.executable-alpha-receipts.v1",
+    }
+
+
+def test_settlement_slots_fall_back_to_before_reasons_when_after_target_missing() -> (
+    None
+):
+    alpha, repair_receipts = _h_cont_repair_receipts()
+    after_alpha = {
+        "repair_targets": [
+            {
+                "hypothesis_id": "H-OTHER",
+                "reasons": ["post_cost_expectancy_non_positive"],
+            }
+        ]
+    }
+
+    payload = build_executable_alpha_settlement_slots(
+        generated_at=NOW,
+        business_state="repair_only",
+        revenue_ready=False,
+        repair_queue=_top_alpha_queue(),
+        capital={"max_notional": "0", "live_submission_allowed": False},
+        evidence=_settlement_evidence(after_alpha),
+        executable_alpha_repair_receipts=repair_receipts,
+    )
+
+    selected_slot = cast(Mapping[str, Any], payload["selected_slot"])
+    selected_receipt = cast(Mapping[str, Any], repair_receipts["selected_receipt"])
+    assert alpha["repair_targets"]
+    assert set(selected_slot["after_reason_codes"]) == set(
+        selected_receipt["reason_codes"]
+    )
+    assert selected_slot["settlement_state"] == "no_delta"
+
+
+def test_settlement_slots_retire_when_before_blocker_clears() -> None:
+    _, repair_receipts = _h_cont_repair_receipts()
+    after_alpha = {
+        "repair_targets": [
+            {
+                "hypothesis_id": "H-OTHER",
+                "reasons": ["post_cost_expectancy_non_positive"],
+            },
+            {
+                "hypothesis_id": "H-CONT-01",
+                "reasons": ["fresh_after_receipt_missing"],
+            },
+        ]
+    }
+
+    payload = build_executable_alpha_settlement_slots(
+        generated_at=NOW,
+        business_state="repair_only",
+        revenue_ready=False,
+        repair_queue=_top_alpha_queue(),
+        capital={"max_notional": "0", "live_submission_allowed": False},
+        evidence=_settlement_evidence(after_alpha),
+        executable_alpha_repair_receipts=repair_receipts,
+    )
+
+    selected_slot = cast(Mapping[str, Any], payload["selected_slot"])
+    assert selected_slot["settlement_state"] == "retired"
+    assert selected_slot["retired_reason_codes"] == [
+        "closed_session_signal_hold",
+        "closed_session_tca_evidence_hold",
+        "post_cost_expectancy_non_positive",
+    ]
+
+
+def test_settlement_slots_improve_when_blocker_count_shrinks() -> None:
+    _, repair_receipts = _h_cont_repair_receipts()
+    after_alpha = {
+        "repair_targets": [
+            {
+                "hypothesis_id": "H-CONT-01",
+                "reasons": ["post_cost_expectancy_non_positive"],
+            }
+        ]
+    }
+
+    payload = build_executable_alpha_settlement_slots(
+        generated_at=NOW,
+        business_state="repair_only",
+        revenue_ready=False,
+        repair_queue=_top_alpha_queue(),
+        capital={"max_notional": "0", "live_submission_allowed": False},
+        evidence=_settlement_evidence(after_alpha),
+        executable_alpha_repair_receipts=repair_receipts,
+    )
+
+    selected_slot = cast(Mapping[str, Any], payload["selected_slot"])
+    assert selected_slot["settlement_state"] == "improved"
+    assert selected_slot["preserved_reason_codes"] == [
+        "post_cost_expectancy_non_positive"
+    ]
+
+
+def test_settlement_slots_block_selected_receipt_with_nonzero_notional() -> None:
+    alpha, repair_receipts = _h_cont_repair_receipts()
+    selected = cast(dict[str, object], repair_receipts["selected_receipt"])
+    selected["max_notional"] = "25"
 
     payload = build_executable_alpha_settlement_slots(
         generated_at=NOW,
@@ -395,24 +527,19 @@ def test_settlement_slots_select_receipt_by_id_when_selected_payload_missing() -
         executable_alpha_repair_receipts=repair_receipts,
     )
 
-    assert payload["status"] == "settled"
-    assert payload["selected_receipt_id"] == repair_receipts["selected_receipt_id"]
-    selected_slot = cast(Mapping[str, Any], payload["selected_slot"])
-    assert (
-        selected_slot["selected_receipt_id"] == repair_receipts["selected_receipt_id"]
-    )
+    assert payload["status"] == "blocked"
+    assert payload["selected_slot"] is None
+    assert payload["reason_codes"] == ["selected_receipt_notional_nonzero"]
 
 
 def test_settlement_slots_use_receipt_settlement_reasons_and_keep_unknown_blocker() -> (
     None
 ):
-    repair_receipts = _selected_repair_receipt_payload()
+    alpha, repair_receipts = _h_cont_repair_receipts()
     selected = cast(dict[str, object], repair_receipts["selected_receipt"])
     selected["reason_codes"] = []
     settlement = cast(dict[str, object], selected["settlement"])
     settlement["before_reason_codes"] = ["closed_session_signal_hold"]
-
-    alpha = _h_cont_alpha_readiness()
     target = cast(dict[str, object], cast(list[object], alpha["repair_targets"])[0])
     target["hypothesis_id"] = "H-OTHER"
 
@@ -432,12 +559,35 @@ def test_settlement_slots_use_receipt_settlement_reasons_and_keep_unknown_blocke
     assert no_delta_debt[0]["remaining_blocker"] == "closed_session_signal_hold"
 
 
-def test_settlement_slots_mark_retired_when_blocker_set_clears() -> None:
-    alpha = _h_cont_alpha_readiness()
-    repair_receipts = _build(alpha_readiness=alpha)
-    target = cast(dict[str, object], cast(list[object], alpha["repair_targets"])[0])
-    target["reasons"] = ["drift_checks_missing"]
-    target["informational_reasons"] = []
+def test_compact_settlement_slots_reports_missing_payload() -> None:
+    compact = compact_executable_alpha_settlement_slots(None)
+
+    assert compact == {
+        "schema_version": "torghut.executable-alpha-settlement-slots-ref.v1",
+        "status": "missing",
+        "reason_codes": ["executable_alpha_settlement_slots_missing"],
+    }
+
+
+def test_settlement_slots_reject_generated_at_without_timezone() -> None:
+    alpha, repair_receipts = _h_cont_repair_receipts()
+
+    with pytest.raises(ValueError, match="generated_at_missing_timezone"):
+        build_executable_alpha_settlement_slots(
+            generated_at=datetime(2026, 5, 13, 22, 55),
+            business_state="repair_only",
+            revenue_ready=False,
+            repair_queue=_top_alpha_queue(),
+            capital={"max_notional": "0", "live_submission_allowed": False},
+            evidence=_settlement_evidence(alpha),
+            executable_alpha_repair_receipts=repair_receipts,
+        )
+
+
+def test_settlement_slots_allow_invalid_fresh_until_as_untrusted_input() -> None:
+    alpha, repair_receipts = _h_cont_repair_receipts()
+    selected = cast(dict[str, object], repair_receipts["selected_receipt"])
+    selected["fresh_until"] = "invalid"
 
     payload = build_executable_alpha_settlement_slots(
         generated_at=NOW,
@@ -450,63 +600,14 @@ def test_settlement_slots_mark_retired_when_blocker_set_clears() -> None:
     )
 
     assert payload["status"] == "settled"
-    selected_slot = cast(Mapping[str, Any], payload["selected_slot"])
-    assert selected_slot["settlement_state"] == "retired"
-    assert payload["no_delta_debt"] == []
 
 
-def test_settlement_slots_mark_improved_when_routeable_count_increases() -> None:
-    payload = _build_settlement_slots(routeable_candidate_count=1)
-
-    assert payload["status"] == "settled"
-    selected_slot = cast(Mapping[str, Any], payload["selected_slot"])
-    assert selected_slot["settlement_state"] == "improved"
-    assert selected_slot["measured_delta"] == 1
-    assert selected_slot["no_delta_reason"] == ""
-    assert payload["no_delta_debt"] == []
-
-
-def test_settlement_slots_block_invalid_and_naive_selected_receipt_timestamps() -> None:
-    alpha = _h_cont_alpha_readiness()
-    repair_receipts = _selected_repair_receipt_payload()
+def test_settlement_slots_block_naive_stale_selected_receipt_timestamp() -> None:
+    alpha, repair_receipts = _h_cont_repair_receipts()
     selected = cast(dict[str, object], repair_receipts["selected_receipt"])
-    selected["fresh_until"] = "not-a-date"
-
-    invalid_timestamp_payload = build_executable_alpha_settlement_slots(
-        generated_at=NOW,
-        business_state="repair_only",
-        revenue_ready=False,
-        repair_queue=_top_alpha_queue(),
-        capital={"max_notional": "0", "live_submission_allowed": False},
-        evidence=_settlement_evidence(alpha),
-        executable_alpha_repair_receipts=repair_receipts,
-    )
-    assert invalid_timestamp_payload["status"] == "settled"
-
     selected["fresh_until"] = (
         (NOW - timedelta(minutes=1)).replace(tzinfo=None).isoformat()
     )
-    stale_naive_payload = build_executable_alpha_settlement_slots(
-        generated_at=NOW,
-        business_state="repair_only",
-        revenue_ready=False,
-        repair_queue=_top_alpha_queue(),
-        capital={"max_notional": "0", "live_submission_allowed": False},
-        evidence=_settlement_evidence(alpha),
-        executable_alpha_repair_receipts=repair_receipts,
-    )
-
-    assert stale_naive_payload["status"] == "blocked"
-    assert stale_naive_payload["reason_codes"] == [
-        "selected_executable_alpha_repair_receipt_stale"
-    ]
-
-
-def test_settlement_slots_block_selected_receipt_nonzero_notional() -> None:
-    alpha = _h_cont_alpha_readiness()
-    repair_receipts = _selected_repair_receipt_payload()
-    selected = cast(dict[str, object], repair_receipts["selected_receipt"])
-    selected["max_notional"] = "10"
 
     payload = build_executable_alpha_settlement_slots(
         generated_at=NOW,
@@ -519,27 +620,7 @@ def test_settlement_slots_block_selected_receipt_nonzero_notional() -> None:
     )
 
     assert payload["status"] == "blocked"
-    assert payload["selected_slot"] is None
-    assert payload["reason_codes"] == ["selected_receipt_notional_nonzero"]
-
-
-def test_settlement_slots_require_timezone_aware_generation_time() -> None:
-    try:
-        _build_settlement_slots(generated_at=NOW.replace(tzinfo=None))
-    except ValueError as error:
-        assert str(error) == "generated_at_missing_timezone"
-    else:
-        raise AssertionError("expected generated_at_missing_timezone")
-
-
-def test_compact_settlement_slots_reports_missing_payload() -> None:
-    compact = compact_executable_alpha_settlement_slots(None)
-
-    assert compact == {
-        "schema_version": "torghut.executable-alpha-settlement-slots-ref.v1",
-        "status": "missing",
-        "reason_codes": ["executable_alpha_settlement_slots_missing"],
-    }
+    assert payload["reason_codes"] == ["selected_executable_alpha_repair_receipt_stale"]
 
 
 def test_compact_settlement_slots_exposes_no_delta_receipt_ref() -> None:

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -1172,6 +1172,13 @@ class TestTradingApi(TestCase):
         )
         self.assertEqual(executable_alpha_repair["status"], "inactive")
         self.assertEqual(executable_alpha_repair["max_notional"], "0")
+        executable_alpha_settlement = payload["executable_alpha_settlement_slots"]
+        self.assertEqual(
+            executable_alpha_settlement["schema_version"],
+            "torghut.executable-alpha-settlement-slots-ref.v1",
+        )
+        self.assertEqual(executable_alpha_settlement["status"], "inactive")
+        self.assertEqual(executable_alpha_settlement["max_notional"], "0")
         alpha_repair_closure = payload["alpha_repair_closure_board"]
         self.assertEqual(
             alpha_repair_closure["schema_version"],
@@ -2927,6 +2934,14 @@ class TestTradingApi(TestCase):
                 "0",
             )
             self.assertEqual(
+                payload["executable_alpha_settlement_slots"]["schema_version"],
+                "torghut.executable-alpha-settlement-slots-ref.v1",
+            )
+            self.assertEqual(
+                payload["executable_alpha_settlement_slots"]["max_notional"],
+                "0",
+            )
+            self.assertEqual(
                 payload["alpha_evidence_foundry"]["schema_version"],
                 "torghut.alpha-evidence-foundry-ref.v1",
             )
@@ -4221,6 +4236,18 @@ class TestTradingApi(TestCase):
         self.assertIn(
             "alpha_readiness_repair_targets_missing",
             payload["executable_alpha_repair_receipts"]["reason_codes"],
+        )
+        settlement_slots = payload["executable_alpha_settlement_slots"]
+        self.assertEqual(
+            settlement_slots["schema_version"],
+            "torghut.executable-alpha-settlement-slots.v1",
+        )
+        self.assertEqual(settlement_slots["status"], "held")
+        self.assertEqual(settlement_slots["selected_slot"], None)
+        self.assertEqual(settlement_slots["max_notional"], "0")
+        self.assertIn(
+            "selected_executable_alpha_repair_receipt_missing",
+            settlement_slots["reason_codes"],
         )
         closure_board = payload["alpha_repair_closure_board"]
         self.assertEqual(


### PR DESCRIPTION
## Summary

- Add `torghut.executable-alpha-settlement-slots.v1` for the selected executable-alpha repair receipt so H-CONT zero-notional repair can settle as no-delta when `routeable_candidate_count` stays unchanged.
- Expose the compact `torghut.executable-alpha-settlement-slots-ref.v1` on `/readyz` and `/trading/consumer-evidence` while keeping `/trading/revenue-repair` as the full evidence surface.
- Preserve capital safety: every slot/ref carries `max_notional=0`, `zero_notional_repair_only`, no live-submit authority, no-delta release conditions, and rollback text.
- Cover selected, inactive, stale, nonzero-notional, fallback receipt, improved, retired, no-delta, and compact missing-payload paths.

## Related Issues

Requirement `00sjiz08`: material reentry signal `material-reentry-torghut-quant-006dzbml` for `routeable_candidate_count`.

## Testing

- PASS: `/tmp/codex-uv/bin/uv sync --frozen --extra dev`
- PASS: `/tmp/codex-uv/bin/uv run --frozen ruff format --check app/trading/executable_alpha_receipts.py app/trading/revenue_repair.py app/main.py scripts/build_revenue_repair_digest.py tests/test_executable_alpha_repair_receipts.py tests/test_build_revenue_repair_digest.py tests/test_trading_api.py`
- PASS: `/tmp/codex-uv/bin/uv run --frozen ruff check app/trading/executable_alpha_receipts.py app/trading/revenue_repair.py app/main.py scripts/build_revenue_repair_digest.py tests/test_executable_alpha_repair_receipts.py tests/test_build_revenue_repair_digest.py tests/test_trading_api.py`
- PASS: `/tmp/codex-uv/bin/uv run --frozen pytest tests/test_executable_alpha_repair_receipts.py -k evidence_window` (`1 passed, 18 deselected`)
- PASS: `curl -fsS http://torghut.torghut.svc.cluster.local/trading/revenue-repair | jq '.executable_alpha_repair_receipts.selected_receipt'`
- PASS: `/tmp/codex-uv/bin/uv run --frozen pytest tests/test_executable_alpha_repair_receipts.py` (`19 passed`)
- PASS: `/tmp/codex-uv/bin/uv run --frozen pyright --project pyrightconfig.json`
- PASS: `/tmp/codex-uv/bin/uv run --frozen pyright --project pyrightconfig.alpha.json`
- PASS: `/tmp/codex-uv/bin/uv run --frozen pyright --project pyrightconfig.scripts.json`
- PASS: `/tmp/codex-uv/bin/uv run --frozen pytest --cov --cov-branch --cov-fail-under=0 --cov-report=xml tests/test_executable_alpha_repair_receipts.py tests/test_build_revenue_repair_digest.py tests/test_trading_api.py` (`121 passed`)
- PASS: `/tmp/codex-uv/bin/uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90` (`160/161`, `99.38%`)
- PASS: current-branch reducer run from live `/readyz` and `/trading/status` inputs emitted `executable_alpha_settlement_slots.status=settled`, `settlement_state=no_delta`, `remaining_blocker=post_cost_expectancy_non_positive`, `routeable_candidate_count_before=0`, `routeable_candidate_count_after=0`, `max_notional=0`, and `live_submission_allowed=false`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.

## Design and Runtime Provenance

- Governing design: `docs/torghut/design-system/v6/199-torghut-executable-alpha-settlement-slots-and-no-delta-repair-custody-2026-05-14.md`.
- Extended designs: `docs/torghut/design-system/v6/197-torghut-executable-alpha-repair-receipts-and-zero-notional-reentry-2026-05-13.md` and `docs/torghut/design-system/v6/168-torghut-executable-alpha-receipts-and-capital-replay-board-2026-05-07.md`.
- Runtime requirement: `00sjiz08`, material reentry payload for `H-CONT-01`, candidate `chip-paper-microbar-composite@execution-proof`, strategy `intraday_tsmom_v1@paper`, `expected_gate_delta=retire_post_cost_expectancy_non_positive`, `expected_unblock_value=2`, `max_notional=0`, review policy `no_automatic_codex_review`.

## Business Evidence

Before live evidence from `GET /trading/revenue-repair` at `2026-05-14T09:41:33.604111+00:00`:

- `business_state=repair_only`
- `revenue_ready=false`
- top queue item `repair_alpha_readiness`, value gate `routeable_candidate_count`, required output `torghut.executable-alpha-receipts.v1`
- selected repair receipt `executable-alpha-repair-receipt:59cec3ee23dcfacfda971873`
- selected hypothesis `H-CONT-01`, repair class `evidence_window_refresh`, expected delta `retire_post_cost_expectancy_non_positive`
- `accepted_routeable_candidate_count=0`
- `repair_bid_settlement.routeable_candidate_count=0`
- `zero_notional_or_stale_evidence_rate=1.0`
- `executable_alpha_settlement_slots` absent from the deployed live digest
- `max_notional=0`
- `live_submission_allowed=false`

After current-branch reducer evidence from live `/readyz` and `/trading/status` inputs at `2026-05-14T09:42:10.229263+00:00`:

- `business_state=repair_only`
- `revenue_ready=false`
- top queue item remains `repair_alpha_readiness` for `routeable_candidate_count`
- selected H-CONT settlement slot `executable-alpha-settlement-slot:118c8eab67d32df8ef30b275`
- no-delta debt `executable-alpha-no-delta:9fd077e13f55818e33cffd89`
- `settlement_state=no_delta`
- `no_delta_reason=routeable_candidate_count_unchanged`
- `remaining_blocker=post_cost_expectancy_non_positive`
- `routeable_candidate_count_before=0`
- `routeable_candidate_count_after=0`
- `material_reentry_receipt_id=material-reentry-receipt:e9f5ad6b9cc2355d4c877236`
- `max_notional=0`
- `live_submission_allowed=false`

## Risk and Rollback

- Risk: operators or downstream automation could over-read settlement as trading authority. Mitigation: the full and compact payloads repeat `max_notional=0`, `zero_notional_repair_only`, and no live-submit authority.
- Risk: no-delta debt could suppress duplicate repair attempts until evidence changes. Mitigation: the debt lists release conditions: source ref, evidence window, blocker set, or required receipt changes.
- Rollback: revert this PR or stop emitting `executable_alpha_settlement_slots`; keep `executable_alpha_repair_receipts`, existing closure/foundry payloads, `max_notional=0`, and live submit disabled.
