### PR TITLE
fix(sag): serve emitted stylesheet asset

### DIFF
--- a/argocd/sag/kustomization.yaml
+++ b/argocd/sag/kustomization.yaml
@@ -12,4 +12,4 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/sag
     newName: registry.ide-newton.ts.net/lab/sag
-    newTag: "sag-20260514075617"
+    newTag: "sag-20260514082406"

--- a/services/sag/src/routes/__root.tsx
+++ b/services/sag/src/routes/__root.tsx
@@ -1,5 +1,5 @@
 import { createRootRoute, HeadContent, Outlet, Scripts } from '@tanstack/react-router'
-import appCss from '../styles.css?url'
+import '../styles.css'
 
 export const Route = createRootRoute({
   head: () => ({
@@ -10,10 +10,7 @@ export const Route = createRootRoute({
       { name: 'color-scheme', content: 'dark' },
       { title: 'Secure Action Gateway' },
     ],
-    links: [
-      { rel: 'stylesheet', href: appCss },
-      { rel: 'icon', href: 'data:,' },
-    ],
+    links: [{ rel: 'icon', href: 'data:,' }],
   }),
   component: RootDocument,
 })


### PR DESCRIPTION
## Summary

- Changes the SAG root route to import global CSS as a route asset instead of emitting a manual SSR-derived stylesheet URL.
- Promotes the SAG GitOps image tag to `sag-20260514082406`, built from this fix.
- Fixes production pages referencing a stylesheet asset that is not present in `.output/public/assets`.

## Related Issues

None

## Testing

- `bun run --filter @proompteng/sag build`
- `rg -n "styles-BqQeCqvk|/assets/index-CRL-t7AT.css" services/sag/.output/server services/sag/.output/public`
- Local smoke: `curl http://localhost:3000/agents` emitted `/assets/index-CRL-t7AT.css`, and `curl http://localhost:3000/assets/index-CRL-t7AT.css` returned `200 text/css`.
- `bun run --filter @proompteng/sag tsc`
- `bun run --filter @proompteng/sag lint`
- `bun run --filter @proompteng/sag lint:oxlint`
- `docker buildx imagetools inspect registry.ide-newton.ts.net/lab/sag:sag-20260514082406`
- `kubectl kustomize argocd/sag | rg -n "image: registry.ide-newton.ts.net/lab/sag:sag-20260514082406"`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
