### PR TITLE
fix(sag): allow kubernetes pod log media type

### DIFF
--- a/argocd/sag/kustomization.yaml
+++ b/argocd/sag/kustomization.yaml
@@ -12,4 +12,4 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/sag
     newName: registry.ide-newton.ts.net/lab/sag
-    newTag: "sag-20260514082406"
+    newTag: "sag-20260514082919"

--- a/services/sag/src/server/kubernetes.ts
+++ b/services/sag/src/server/kubernetes.ts
@@ -907,7 +907,6 @@ const requestInClusterText = (client: InClusterKubernetesClient, path: string) =
         ca: client.ca,
         headers: {
           authorization: `Bearer ${client.token}`,
-          accept: 'application/json',
         },
       },
       (res) => {
@@ -945,7 +944,6 @@ const requestTextStream = (client: KubernetesClient, path: string): Response => 
           ca: client.ca,
           headers: {
             authorization: `Bearer ${client.token}`,
-            accept: 'text/plain',
           },
         },
         (res) => {


### PR DESCRIPTION
## Summary

- Removes explicit upstream `Accept` headers from SAG Kubernetes pod-log requests so the Kubernetes API does not reject log reads with 406.
- Promotes SAG to image `sag-20260514082919`, which includes the stylesheet asset fix and the pod-log media-type fix.
- Keeps SAG browser responses typed as text/plain while letting Kubernetes negotiate the pod-log subresource response.

## Related Issues

None

## Testing

- `bun run --filter @proompteng/sag tsc`
- `bun run --filter @proompteng/sag lint`
- `bun run --filter @proompteng/sag lint:oxlint`
- `docker buildx imagetools inspect registry.ide-newton.ts.net/lab/sag:sag-20260514082919`
- `kubectl kustomize argocd/sag | rg -n "image: registry.ide-newton.ts.net/lab/sag:sag-20260514082919"`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
