### PR TITLE
test(sag): cover database access audit gate

### DIFF
--- a/services/sag/src/server/gateway.test.ts
+++ b/services/sag/src/server/gateway.test.ts
@@ -7,6 +7,7 @@ import {
   createTaskFromText,
   evaluateAgentRun,
   exportAuditEvents,
+  requestDatabaseAccessApproval,
 } from './gateway'
 
 describe('secure action gateway engine', () => {
@@ -99,5 +100,49 @@ describe('secure action gateway engine', () => {
     expect(buildSnapshot(state).agentRuns[0]?.manifest).not.toContain(sensitiveSecret)
     expect(buildSnapshot(state).agentRuns[0]?.requestedSecrets[0]).toMatch(/^secret:/)
     expect(exportAuditEvents(state)).not.toContain(sensitiveSecret)
+  })
+
+  test('records database inspection requests as approval-gated audit events', () => {
+    const state = createGatewayState()
+    const agentRun = evaluateAgentRun(state, {
+      actorId: 'greg',
+      name: 'sag-mp582cjf',
+      namespace: 'agents',
+      requestedConnectors: ['kubernetes'],
+      requestedTools: ['create AgentRun', 'follow logs'],
+    })
+
+    const approval = requestDatabaseAccessApproval(state, {
+      actorId: 'greg',
+      namespace: agentRun.namespace,
+      runName: agentRun.name,
+    })
+    const duplicate = requestDatabaseAccessApproval(state, {
+      actorId: 'greg',
+      namespace: agentRun.namespace,
+      runName: agentRun.name,
+    })
+    const snapshot = buildSnapshot(state)
+    const event = snapshot.events.find((item) => item.operation === 'database:list_tables')
+
+    expect(duplicate.id).toBe(approval.id)
+    expect(approval).toMatchObject({
+      action: 'database.list_tables',
+      status: 'pending',
+      target: 'agents/sag-mp582cjf:sag.database.tables',
+      runId: agentRun.id,
+    })
+    expect(snapshot.approvals.filter((item) => item.action === 'database.list_tables')).toHaveLength(1)
+    expect(event).toMatchObject({
+      connector: 'sql',
+      status: 'approval_required',
+      policy: 'database-access-approval',
+    })
+    expect(event?.evidence).toMatchObject({
+      database: 'sag',
+      namespace: 'agents',
+      operation: 'list_tables',
+      runName: 'sag-mp582cjf',
+    })
   })
 })


### PR DESCRIPTION
## Summary

- Adds a SAG gateway regression test for AgentRun database inspection requests.
- Verifies database table inspection stays approval-gated and emits a `database:list_tables` SQL audit event.
- Confirms duplicate database inspection requests reuse the existing pending approval for the same AgentRun target.

## Related Issues

None

## Testing

- PASS: `bun run --filter @proompteng/sag test -- src/server/gateway.test.ts`
- PASS: `bun run --filter @proompteng/sag tsc`
- PASS: `bun run --filter @proompteng/sag lint`
- PASS: `bun run --filter @proompteng/sag lint:oxlint`
- PASS: `bun run --filter @proompteng/sag build`
- PASS: `git diff --check`
- PASS: `curl -fsS --max-time 10 https://sag.proompteng.ai/api/health` returned `persistence=postgres`, `totalTasks=5`, `totalEvents=44`, `awaitingApproval=1`, and `blockedAgentRuns=2`.
- PASS: `curl -fsS --max-time 10 https://sag.proompteng.ai/api/agent-runs/sag-mp582cjf/database-access` returned a pending `database.list_tables` approval for `agents/sag-mp582cjf:sag.database.tables` with `tableCount=0` while approval is pending.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
