### PR TITLE
chore(jangar): promote image 2ee617e3

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 374c2c1c
-  digest: sha256:50ce53d5862c779ab21d24ea6e035a3d404c9e21d4be0ba9a11cb33febef8246
+  tag: 2ee617e3
+  digest: sha256:5f4a8f428f3092a004b3bb5d34f85874933f1add8a2485af8fbb52da183d257b
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,8 +11,8 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 374c2c1c
-    digest: sha256:6f338ba2eb17f1efd67676704da9951f7dd0bc67a69508d6def5572e7865c1b3
+    tag: 2ee617e3
+    digest: sha256:0266821f0c51035760f2f0eaa3c75d8ffb2c6072db04ac7297c410957932cef6
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
@@ -21,8 +21,8 @@ controlPlane:
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 374c2c1c
-    digest: sha256:50ce53d5862c779ab21d24ea6e035a3d404c9e21d4be0ba9a11cb33febef8246
+    tag: 2ee617e3
+    digest: sha256:5f4a8f428f3092a004b3bb5d34f85874933f1add8a2485af8fbb52da183d257b
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-14T07:42:55Z
+    deploy.knative.dev/rollout: 2026-05-14T08:35:25Z
 spec:
   replicas: 1
   strategy:
@@ -57,11 +57,11 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_RUNTIME_IMAGE
-              value: registry.ide-newton.ts.net/lab/jangar:374c2c1c@sha256:50ce53d5862c779ab21d24ea6e035a3d404c9e21d4be0ba9a11cb33febef8246
+              value: registry.ide-newton.ts.net/lab/jangar:2ee617e3@sha256:5f4a8f428f3092a004b3bb5d34f85874933f1add8a2485af8fbb52da183d257b
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: 374c2c1cf1ac9593906ff9283274652b753a792f
+              value: 2ee617e354af746549731b54e037f90af5d3fd6f
             - name: JANGAR_GITOPS_REVISION
-              value: 374c2c1cf1ac9593906ff9283274652b753a792f
+              value: 2ee617e354af746549731b54e037f90af5d3fd6f
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_BUMBA_TASK_QUEUE

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -59,5 +59,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: 374c2c1c
-    digest: sha256:50ce53d5862c779ab21d24ea6e035a3d404c9e21d4be0ba9a11cb33febef8246
+    newTag: 2ee617e3
+    digest: sha256:5f4a8f428f3092a004b3bb5d34f85874933f1add8a2485af8fbb52da183d257b


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `2ee617e354af746549731b54e037f90af5d3fd6f`
- Image tag: `2ee617e3`
- Image digest: `sha256:5f4a8f428f3092a004b3bb5d34f85874933f1add8a2485af8fbb52da183d257b`
- Updated API rollout annotation
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`