### PR TITLE
test(sag): cover api client requests

### DIFF
--- a/services/sag/src/lib/sag-client.test.ts
+++ b/services/sag/src/lib/sag-client.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { fetchJson, requestDatabaseAccess, submitTask } from './sag-client'
+
+const jsonResponse = (body: unknown, init: Pick<Response, 'ok' | 'status'> = { ok: true, status: 200 }) =>
+  ({
+    ok: init.ok,
+    status: init.status,
+    json: vi.fn().mockResolvedValue(body),
+  }) as unknown as Response
+
+describe('SAG API client', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn<typeof fetch>())
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  test('encodes AgentRun names when requesting database access approval', async () => {
+    const fetchMock = vi.mocked(fetch)
+    fetchMock.mockResolvedValue(jsonResponse({ ok: true, tables: [], snapshot: {} }))
+
+    await requestDatabaseAccess('agents/run with spaces')
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/agent-runs/agents%2Frun%20with%20spaces/database-access', {
+      method: 'POST',
+      body: JSON.stringify({}),
+      headers: {
+        'content-type': 'application/json',
+      },
+    })
+  })
+
+  test('sends natural-language tasks as JSON requests', async () => {
+    const fetchMock = vi.mocked(fetch)
+    fetchMock.mockResolvedValue(jsonResponse({ ok: true, task: { id: 'task-1' }, snapshot: {} }))
+
+    await submitTask('Inspect live protected workloads')
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/tasks', {
+      method: 'POST',
+      body: JSON.stringify({ text: 'Inspect live protected workloads' }),
+      headers: {
+        'content-type': 'application/json',
+      },
+    })
+  })
+
+  test('throws response errors from failed JSON responses', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      jsonResponse({ error: 'Request rejected by policy' }, { ok: false, status: 403 }),
+    )
+
+    await expect(fetchJson('/api/tasks')).rejects.toThrow('Request rejected by policy')
+  })
+})


### PR DESCRIPTION
## Summary

- Adds SAG API client coverage for AgentRun database-access request paths with URL encoding.
- Verifies natural-language task submissions are sent as JSON POST requests.
- Covers failed JSON response handling so server policy errors are surfaced to callers.

## Related Issues

None

## Testing

- PASS: `bun install --frozen-lockfile`
- PASS: `bun run --filter @proompteng/sag test -- src/lib/sag-client.test.ts`
- PASS: `bun run --filter @proompteng/sag test`
- PASS: `bun run --filter @proompteng/sag tsc`
- PASS: `bun run --filter @proompteng/sag lint`
- PASS: `bun run --filter @proompteng/sag lint:oxlint`
- PASS: `bun run --filter @proompteng/sag build`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
