### PR TITLE
fix(jangar): stabilize material reentry dispatch keys

### DIFF
--- a/services/jangar/src/server/__tests__/control-plane-material-reentry-clearinghouse.test.ts
+++ b/services/jangar/src/server/__tests__/control-plane-material-reentry-clearinghouse.test.ts
@@ -9,6 +9,7 @@ import type {
   SourceServingContractVerdictExchange,
   StageCreditLedger,
   TorghutConsumerEvidenceStatus,
+  TorghutExecutableAlphaRepairReceipt,
 } from '~/data/agents-control-plane'
 import {
   buildMaterialReentryClearinghouse,
@@ -384,8 +385,10 @@ const torghutEvidence = (overrides: Partial<TorghutConsumerEvidenceStatus> = {})
   ...overrides,
 })
 
-const torghutEvidenceWithExecutableAlphaRepair = (): TorghutConsumerEvidenceStatus => {
-  const selectedReceipt = {
+const torghutEvidenceWithExecutableAlphaRepair = (
+  selectedReceiptOverrides: Partial<TorghutExecutableAlphaRepairReceipt> = {},
+): TorghutConsumerEvidenceStatus => {
+  const selectedReceipt: TorghutExecutableAlphaRepairReceipt = {
     schema_version: 'torghut.executable-alpha-repair-receipt.v1' as const,
     receipt_id: 'executable-alpha-repair-receipt:current',
     generated_at: now.toISOString(),
@@ -420,6 +423,7 @@ const torghutEvidenceWithExecutableAlphaRepair = (): TorghutConsumerEvidenceStat
       rollback_target: 'keep max_notional=0 and live submit disabled',
     },
     rollback_target: 'stop emitting executable alpha repair receipts',
+    ...selectedReceiptOverrides,
   }
 
   return torghutEvidence({
@@ -611,5 +615,48 @@ describe('control-plane material reentry clearinghouse', () => {
     expect(paperCanary.reason_codes).toContain('torghut_alpha_repair_blocks_capital_reentry')
     expect(clearinghouse.top_implementer_dispatch?.signal_name).toBe(observe.implementer_dispatch?.signal_name)
     expect(clearinghouse.implementer_dispatches).toHaveLength(1)
+  })
+
+  it('keeps Torghut material reentry dispatch identity stable across rotated receipts', () => {
+    const buildClearinghouse = (selectedReceiptOverrides: Partial<TorghutExecutableAlphaRepairReceipt>) =>
+      buildMaterialReentryClearinghouse({
+        now,
+        namespace: 'agents',
+        database: healthyDatabase(),
+        watchReliability: watchReliability(),
+        readyTruthArbiter: readyTruth({
+          material_readiness: 'hold',
+          allowed_action_classes: ['serve_readonly', 'torghut_observe'],
+          held_action_classes: [],
+          blocked_action_classes: ['paper_canary'],
+        }),
+        sourceServingContractVerdictExchange: sourceExchange([sourceVerdict('paper_support')]),
+        stageCreditLedger: null,
+        repairBidAdmission: repairAdmission({ receipts: [], dispatch_tickets: [] }),
+        torghutConsumerEvidence: torghutEvidenceWithExecutableAlphaRepair(selectedReceiptOverrides),
+      })
+
+    const first = buildClearinghouse({
+      receipt_id: 'executable-alpha-repair-receipt:first',
+      generated_at: '2026-05-14T00:09:30.000Z',
+      fresh_until: '2026-05-14T00:11:30.000Z',
+    })
+    const second = buildClearinghouse({
+      receipt_id: 'executable-alpha-repair-receipt:second',
+      generated_at: '2026-05-14T00:09:45.000Z',
+      fresh_until: '2026-05-14T00:11:45.000Z',
+    })
+
+    const firstDispatch = receiptFor(first.action_receipts, 'torghut_observe').implementer_dispatch
+    const secondDispatch = receiptFor(second.action_receipts, 'torghut_observe').implementer_dispatch
+
+    expect(firstDispatch).toBeDefined()
+    expect(secondDispatch).toBeDefined()
+    expect(firstDispatch?.dedupe_key).toBe(secondDispatch?.dedupe_key)
+    expect(firstDispatch?.dedupe_key).toContain('material-reentry:torghut-executable-alpha:')
+    expect(firstDispatch?.dedupe_key).not.toContain('executable-alpha-repair-receipt')
+    expect(firstDispatch?.signal_name).toBe(secondDispatch?.signal_name)
+    expect(firstDispatch?.payload.source_receipt_id).toBe('executable-alpha-repair-receipt:first')
+    expect(secondDispatch?.payload.source_receipt_id).toBe('executable-alpha-repair-receipt:second')
   })
 })

--- a/services/jangar/src/server/control-plane-material-reentry-clearinghouse.ts
+++ b/services/jangar/src/server/control-plane-material-reentry-clearinghouse.ts
@@ -38,6 +38,11 @@ const uniqueStrings = (values: Array<string | null | undefined>) => [
 
 const uniqueActionClasses = (values: ActionSloBudgetActionClass[]) => [...new Set(values)]
 
+const stableKeyPart = (value: string | null | undefined, fallback = 'unknown') => {
+  const trimmed = value?.trim()
+  return trimmed && trimmed.length > 0 ? trimmed : fallback
+}
+
 const parseFutureTime = (value: string | null | undefined, nowMs: number) => {
   if (!value) return null
   const parsed = Date.parse(value)
@@ -182,6 +187,23 @@ const basePlan = (input: {
   implementerDispatch: input.implementerDispatch ?? null,
 })
 
+const torghutExecutableAlphaRepairLane = (input: {
+  actionClass: ActionSloBudgetActionClass
+  selectedReceipt: TorghutExecutableAlphaRepairReceipt
+  requiredOutputReceipt: string | null
+  valueGate: string
+}) => ({
+  source: 'torghut.executable-alpha-repair',
+  actionClass: input.actionClass,
+  repairClass: stableKeyPart(input.selectedReceipt.repair_class),
+  hypothesisId: stableKeyPart(input.selectedReceipt.hypothesis_id),
+  accountId: stableKeyPart(input.selectedReceipt.account_id),
+  window: stableKeyPart(input.selectedReceipt.window),
+  tradingMode: stableKeyPart(input.selectedReceipt.trading_mode),
+  valueGate: stableKeyPart(input.valueGate),
+  requiredOutputReceipt: stableKeyPart(input.requiredOutputReceipt),
+})
+
 const buildTorghutExecutableAlphaImplementerDispatch = (input: {
   actionClass: ActionSloBudgetActionClass
   selectedReceipt: TorghutExecutableAlphaRepairReceipt
@@ -195,15 +217,17 @@ const buildTorghutExecutableAlphaImplementerDispatch = (input: {
   if (!isTorghutRepairAction(input.actionClass)) return null
 
   const valueGate = input.selectedReceipt.target_value_gate || input.valueGates[0] || 'routeable_candidate_count'
-  const signalName = `material-reentry-torghut-alpha-${hashJson(
-    {
+  const laneHash = hashJson(
+    torghutExecutableAlphaRepairLane({
       actionClass: input.actionClass,
-      selectedReceipt: input.selectedReceipt.receipt_id,
-      valueGate,
+      selectedReceipt: input.selectedReceipt,
       requiredOutputReceipt: input.requiredOutputReceipt,
-    },
+      valueGate,
+    }),
     12,
-  )}`
+  )
+  const signalName = `material-reentry-torghut-alpha-${laneHash}`
+  const dedupeKey = `material-reentry:torghut-executable-alpha:${laneHash}:${valueGate}`
   const description =
     `Implement Torghut zero-notional executable-alpha repair for ${valueGate}; ` +
     'produce the required receipt and keep live capital disabled.'
@@ -219,7 +243,7 @@ const buildTorghutExecutableAlphaImplementerDispatch = (input: {
     channel: 'workflow.general.requirement',
     description,
     priority: 'critical',
-    dedupe_key: `material-reentry:${input.selectedReceipt.receipt_id}:${valueGate}`,
+    dedupe_key: dedupeKey,
     payload: {
       type: 'material_reentry_requirement',
       source: 'jangar.material_reentry_clearinghouse',


### PR DESCRIPTION
## Summary

- Stabilizes Torghut material-reentry implementer dispatch identity by hashing the business repair lane instead of the rotating executable-alpha receipt id.
- Keeps the current source receipt id in the requirement payload for traceability while preventing repeated launches for the same zero-notional repair lane.
- Adds a regression proving rotated executable-alpha repair receipts keep the same `dedupe_key` and Signal name.

## Related Issues

None

## Testing

- `bunx oxfmt --check services/jangar/src/server/control-plane-material-reentry-clearinghouse.ts services/jangar/src/server/__tests__/control-plane-material-reentry-clearinghouse.test.ts`
- `bunx vitest run --config vitest.config.ts src/server/__tests__/control-plane-material-reentry-clearinghouse.test.ts -t "material reentry|executable-alpha|rotated receipts"` from `/Users/gregkonush/github.com/lab/services/jangar`
- `bun run --filter @proompteng/jangar tsc`
- `git diff --check`
- `bunx oxlint services/jangar/src/server/control-plane-material-reentry-clearinghouse.ts services/jangar/src/server/__tests__/control-plane-material-reentry-clearinghouse.test.ts`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
