### PR TITLE
chore(torghut): promote image 8a8a3747

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:bdc6463153c8ede2b46648596cc3c3f83dfdb5d572a1cd86dfbb93c51fbb5236
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:463dd5a5efaa58106aa1aa997a9b3d060984019fc26b9d4d219e48060de3a94a
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.569.1-357-ge3d664618
+              value: v0.569.1-369-g8a8a37471
             - name: TORGHUT_OPTIONS_COMMIT
-              value: e3d66461806eae5a95196722251b445647b31dee
+              value: 8a8a374713db2ceed78b2a45d25983d0f377e522
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:bdc6463153c8ede2b46648596cc3c3f83dfdb5d572a1cd86dfbb93c51fbb5236
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:463dd5a5efaa58106aa1aa997a9b3d060984019fc26b9d4d219e48060de3a94a
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.569.1-357-ge3d664618
+              value: v0.569.1-369-g8a8a37471
             - name: TORGHUT_OPTIONS_COMMIT
-              value: e3d66461806eae5a95196722251b445647b31dee
+              value: 8a8a374713db2ceed78b2a45d25983d0f377e522
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:bdc6463153c8ede2b46648596cc3c3f83dfdb5d572a1cd86dfbb93c51fbb5236
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:463dd5a5efaa58106aa1aa997a9b3d060984019fc26b9d4d219e48060de3a94a
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:bdc6463153c8ede2b46648596cc3c3f83dfdb5d572a1cd86dfbb93c51fbb5236
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:463dd5a5efaa58106aa1aa997a9b3d060984019fc26b9d4d219e48060de3a94a
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:bdc6463153c8ede2b46648596cc3c3f83dfdb5d572a1cd86dfbb93c51fbb5236
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:463dd5a5efaa58106aa1aa997a9b3d060984019fc26b9d4d219e48060de3a94a
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:bdc6463153c8ede2b46648596cc3c3f83dfdb5d572a1cd86dfbb93c51fbb5236
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:463dd5a5efaa58106aa1aa997a9b3d060984019fc26b9d4d219e48060de3a94a
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:bdc6463153c8ede2b46648596cc3c3f83dfdb5d572a1cd86dfbb93c51fbb5236
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:463dd5a5efaa58106aa1aa997a9b3d060984019fc26b9d4d219e48060de3a94a
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -15,7 +15,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:bdc6463153c8ede2b46648596cc3c3f83dfdb5d572a1cd86dfbb93c51fbb5236
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:463dd5a5efaa58106aa1aa997a9b3d060984019fc26b9d4d219e48060de3a94a
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -23,7 +23,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:bdc6463153c8ede2b46648596cc3c3f83dfdb5d572a1cd86dfbb93c51fbb5236
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:463dd5a5efaa58106aa1aa997a9b3d060984019fc26b9d4d219e48060de3a94a
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:bdc6463153c8ede2b46648596cc3c3f83dfdb5d572a1cd86dfbb93c51fbb5236
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:463dd5a5efaa58106aa1aa997a9b3d060984019fc26b9d4d219e48060de3a94a
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-14T08:18:04Z"
+        client.knative.dev/updateTimestamp: "2026-05-14T08:57:57Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -27,7 +27,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:bdc6463153c8ede2b46648596cc3c3f83dfdb5d572a1cd86dfbb93c51fbb5236
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:463dd5a5efaa58106aa1aa997a9b3d060984019fc26b9d4d219e48060de3a94a
           ports:
             - name: http1
               containerPort: 8181
@@ -482,11 +482,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.569.1-357-ge3d664618
+              value: v0.569.1-369-g8a8a37471
             - name: TORGHUT_COMMIT
-              value: e3d66461806eae5a95196722251b445647b31dee
+              value: 8a8a374713db2ceed78b2a45d25983d0f377e522
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:bdc6463153c8ede2b46648596cc3c3f83dfdb5d572a1cd86dfbb93c51fbb5236
+              value: sha256:463dd5a5efaa58106aa1aa997a9b3d060984019fc26b9d4d219e48060de3a94a
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-14T08:18:04Z"
+        client.knative.dev/updateTimestamp: "2026-05-14T08:57:57Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:bdc6463153c8ede2b46648596cc3c3f83dfdb5d572a1cd86dfbb93c51fbb5236
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:463dd5a5efaa58106aa1aa997a9b3d060984019fc26b9d4d219e48060de3a94a
           ports:
             - name: http1
               containerPort: 8181
@@ -298,11 +298,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.569.1-357-ge3d664618
+              value: v0.569.1-369-g8a8a37471
             - name: TORGHUT_COMMIT
-              value: e3d66461806eae5a95196722251b445647b31dee
+              value: 8a8a374713db2ceed78b2a45d25983d0f377e522
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:bdc6463153c8ede2b46648596cc3c3f83dfdb5d572a1cd86dfbb93c51fbb5236
+              value: sha256:463dd5a5efaa58106aa1aa997a9b3d060984019fc26b9d4d219e48060de3a94a
           livenessProbe:
             httpGet:
               path: /healthz

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -89,7 +89,7 @@ spec:
           - name: allowStaleTape
           - name: persistResults
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:bdc6463153c8ede2b46648596cc3c3f83dfdb5d572a1cd86dfbb93c51fbb5236
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:463dd5a5efaa58106aa1aa997a9b3d060984019fc26b9d4d219e48060de3a94a
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
+++ b/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:bdc6463153c8ede2b46648596cc3c3f83dfdb5d572a1cd86dfbb93c51fbb5236
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:463dd5a5efaa58106aa1aa997a9b3d060984019fc26b9d4d219e48060de3a94a
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `8a8a374713db2ceed78b2a45d25983d0f377e522`
- Image tag: `8a8a3747`
- Image digest: `sha256:463dd5a5efaa58106aa1aa997a9b3d060984019fc26b9d4d219e48060de3a94a`