### PR TITLE
test(sag): cover audit event export lifecycle

### DIFF
--- a/services/sag/src/server/gateway.test.ts
+++ b/services/sag/src/server/gateway.test.ts
@@ -7,6 +7,7 @@ import {
   createTaskFromText,
   evaluateAgentRun,
   exportAuditEvents,
+  type GatewayEvent,
 } from './gateway'
 
 describe('secure action gateway engine', () => {
@@ -80,6 +81,47 @@ describe('secure action gateway engine', () => {
     const approved = approveAction(state, { actorId: 'ops', approvalId: approval.id })
     expect(approved.ok).toBe(true)
     expect(buildSnapshot(state).tasks.find((item) => item.id === task.id)?.decision).toBe('approved')
+  })
+
+  test('exports replayable audit events in lifecycle order', () => {
+    const state = createGatewayState()
+    const task = createTaskFromText(state, {
+      actorId: 'greg',
+      text: 'Inspect AgentRuns and execute a guarded restart if policy allows it',
+    })
+    const approval = buildSnapshot(state).approvals[0]
+    expect(approval).toBeDefined()
+
+    approveAction(state, { actorId: 'ops', approvalId: approval.id })
+
+    const exportedEvents = exportAuditEvents(state)
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as GatewayEvent)
+      .filter((event) => event.taskId === task.id)
+
+    expect(exportedEvents.map((event) => event.operation)).toEqual([
+      'task:intake',
+      'task:plan',
+      'policy_context.read',
+      'agentruns.list',
+      'audit_graph.query',
+      'legacy_status.parse',
+      'approval:request',
+      'approval:approve',
+    ])
+    expect(exportedEvents.map((event) => event.status)).toEqual([
+      'received',
+      'planned',
+      'succeeded',
+      'succeeded',
+      'succeeded',
+      'succeeded',
+      'approval_required',
+      'approved',
+    ])
+    expect(exportedEvents.every((event) => event.requestHash.length > 0)).toBe(true)
+    expect(exportedEvents.every((event) => event.correlationId.startsWith(`${task.id}:`))).toBe(true)
   })
 
   test('blocks sensitive AgentRun secret requests and redacts secret names', () => {


### PR DESCRIPTION
## Summary

- Added a SAG gateway regression test for audit event JSONL export.
- Covers the mutating task lifecycle from intake and plan through connector execution, approval request, and approval.
- Verifies exported audit events remain replayable with stable request hashes and task-scoped correlation IDs.

## Related Issues

None

## Testing

- `bun install` failed because `tree-sitter-json` postinstall could not load `env-paths` from `node-gyp`.
- `bun install --ignore-scripts`
- `bun run --filter @proompteng/sag test -- src/server/gateway.test.ts`
- `bun run --filter @proompteng/sag format:check`
- `bun run --filter @proompteng/sag tsc`
- `bun run --filter @proompteng/sag lint:oxlint`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
