### PR TITLE
chore(jangar): promote image 7a05e24d

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 2ee617e3
-  digest: sha256:5f4a8f428f3092a004b3bb5d34f85874933f1add8a2485af8fbb52da183d257b
+  tag: 7a05e24d
+  digest: sha256:b89653f68e0bf2489a08805ff0d928fb92d35b908da7d6b06cd7daced22e7ea1
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,8 +11,8 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 2ee617e3
-    digest: sha256:0266821f0c51035760f2f0eaa3c75d8ffb2c6072db04ac7297c410957932cef6
+    tag: 7a05e24d
+    digest: sha256:6202805b417de1982ad362f1ee99c1b6fa464125048dec2afb4bda0fe4f49cbe
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
@@ -21,8 +21,8 @@ controlPlane:
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 2ee617e3
-    digest: sha256:5f4a8f428f3092a004b3bb5d34f85874933f1add8a2485af8fbb52da183d257b
+    tag: 7a05e24d
+    digest: sha256:b89653f68e0bf2489a08805ff0d928fb92d35b908da7d6b06cd7daced22e7ea1
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-14T08:35:25Z
+    deploy.knative.dev/rollout: 2026-05-14T09:24:00Z
 spec:
   replicas: 1
   strategy:
@@ -57,11 +57,11 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_RUNTIME_IMAGE
-              value: registry.ide-newton.ts.net/lab/jangar:2ee617e3@sha256:5f4a8f428f3092a004b3bb5d34f85874933f1add8a2485af8fbb52da183d257b
+              value: registry.ide-newton.ts.net/lab/jangar:7a05e24d@sha256:b89653f68e0bf2489a08805ff0d928fb92d35b908da7d6b06cd7daced22e7ea1
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: 2ee617e354af746549731b54e037f90af5d3fd6f
+              value: 7a05e24d523d4310c00b6ae4577cc0834610bb12
             - name: JANGAR_GITOPS_REVISION
-              value: 2ee617e354af746549731b54e037f90af5d3fd6f
+              value: 7a05e24d523d4310c00b6ae4577cc0834610bb12
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_BUMBA_TASK_QUEUE

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -59,5 +59,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: 2ee617e3
-    digest: sha256:5f4a8f428f3092a004b3bb5d34f85874933f1add8a2485af8fbb52da183d257b
+    newTag: 7a05e24d
+    digest: sha256:b89653f68e0bf2489a08805ff0d928fb92d35b908da7d6b06cd7daced22e7ea1


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `7a05e24d523d4310c00b6ae4577cc0834610bb12`
- Image tag: `7a05e24d`
- Image digest: `sha256:b89653f68e0bf2489a08805ff0d928fb92d35b908da7d6b06cd7daced22e7ea1`
- Updated API rollout annotation
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`