### PR TITLE
fix(torghut): feed replay evidence into autoresearch

### DIFF
--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -18,16 +18,18 @@ spec:
         value: /tmp/torghut-whitepaper-autoresearch
       - name: sourceJsonlB64
         value: ''
+      - name: feedbackEvidenceJsonlB64
+        value: ''
       - name: seedRecentWhitepapers
         value: 'true'
       - name: symbols
         value: NVDA,AAPL,AMZN,GOOGL,AVGO,AMD,ORCL,INTC
       - name: fullWindowStartDate
-        value: '2026-04-24'
+        value: ''
       - name: fullWindowEndDate
-        value: '2026-05-01'
+        value: ''
       - name: expectedLastTradingDay
-        value: '2026-05-01'
+        value: ''
       - name: targetNetPnlPerDay
         value: '500'
       - name: maxCandidates
@@ -55,7 +57,7 @@ spec:
       - name: prefetchFullWindowRows
         value: 'true'
       - name: allowStaleTape
-        value: 'true'
+        value: 'false'
       - name: persistResults
         value: 'true'
   templates:
@@ -68,6 +70,7 @@ spec:
           - name: runId
           - name: outputRoot
           - name: sourceJsonlB64
+          - name: feedbackEvidenceJsonlB64
           - name: seedRecentWhitepapers
           - name: symbols
           - name: fullWindowStartDate
@@ -136,6 +139,7 @@ spec:
             OUTPUT_DIR="${OUTPUT_ROOT%/}/${RUN_ID}"
             WORKDIR=/tmp/torghut-whitepaper-autoresearch-workflow
             SOURCE_JSONL="${WORKDIR}/sources.jsonl"
+            FEEDBACK_EVIDENCE_JSONL="${WORKDIR}/feedback-evidence.jsonl"
             mkdir -p "${WORKDIR}" "${OUTPUT_DIR}"
 
             SCRIPT_ARGS=(
@@ -164,9 +168,6 @@ spec:
               --real-replay-shard-workers "{{inputs.parameters.realReplayShardWorkers}}"
               --train-days 6
               --holdout-days 3
-              --full-window-start-date "{{inputs.parameters.fullWindowStartDate}}"
-              --full-window-end-date "{{inputs.parameters.fullWindowEndDate}}"
-              --expected-last-trading-day "{{inputs.parameters.expectedLastTradingDay}}"
               --min-active-day-ratio 1
               --min-positive-day-ratio 1
               --min-daily-net-pnl "{{inputs.parameters.targetNetPnlPerDay}}"
@@ -179,6 +180,19 @@ spec:
             if [ -n "{{inputs.parameters.sourceJsonlB64}}" ]; then
               printf '%s' "{{inputs.parameters.sourceJsonlB64}}" | base64 -d > "${SOURCE_JSONL}"
               SCRIPT_ARGS+=(--source-jsonl "${SOURCE_JSONL}")
+            fi
+            if [ -n "{{inputs.parameters.feedbackEvidenceJsonlB64}}" ]; then
+              printf '%s' "{{inputs.parameters.feedbackEvidenceJsonlB64}}" | base64 -d > "${FEEDBACK_EVIDENCE_JSONL}"
+              SCRIPT_ARGS+=(--feedback-evidence-jsonl "${FEEDBACK_EVIDENCE_JSONL}")
+            fi
+            if [ -n "{{inputs.parameters.fullWindowStartDate}}" ]; then
+              SCRIPT_ARGS+=(--full-window-start-date "{{inputs.parameters.fullWindowStartDate}}")
+            fi
+            if [ -n "{{inputs.parameters.fullWindowEndDate}}" ]; then
+              SCRIPT_ARGS+=(--full-window-end-date "{{inputs.parameters.fullWindowEndDate}}")
+            fi
+            if [ -n "{{inputs.parameters.expectedLastTradingDay}}" ]; then
+              SCRIPT_ARGS+=(--expected-last-trading-day "{{inputs.parameters.expectedLastTradingDay}}")
             fi
             if [ "{{inputs.parameters.prefetchFullWindowRows}}" = "true" ]; then
               SCRIPT_ARGS+=(--prefetch-full-window-rows)

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -215,6 +215,32 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         self.assertEqual(args.symbols.split(","), _CHIP_UNIVERSE)
         self.assertEqual(args.feedback_evidence_jsonl, [])
 
+    def test_workflow_template_surfaces_feedback_and_fails_closed_on_stale_tape(
+        self,
+    ) -> None:
+        template_path = (
+            Path(__file__).parents[3]
+            / "argocd"
+            / "applications"
+            / "torghut"
+            / "whitepaper-autoresearch-workflowtemplate.yaml"
+        )
+        template = template_path.read_text()
+
+        self.assertIn("name: feedbackEvidenceJsonlB64", template)
+        self.assertIn("--feedback-evidence-jsonl", template)
+        self.assertIn(
+            'if [ -n "{{inputs.parameters.fullWindowStartDate}}" ]; then',
+            template,
+        )
+        self.assertIn(
+            'if [ -n "{{inputs.parameters.expectedLastTradingDay}}" ]; then',
+            template,
+        )
+        self.assertIn("name: allowStaleTape\n        value: 'false'", template)
+        self.assertNotIn("value: '2026-04-24'", template)
+        self.assertNotIn("value: '2026-05-01'", template)
+
     def test_pre_replay_ranker_ingests_feedback_evidence_bundles(self) -> None:
         losing_spec = self._candidate_spec(
             "spec-losing",


### PR DESCRIPTION
## Summary

- Adds a `feedbackEvidenceJsonlB64` workflow parameter so follow-up Torghut autoresearch epochs can feed real replay evidence into the pre-replay ranker.
- Removes stale hardcoded default replay dates from the workflow template and defaults `allowStaleTape` to `false`.
- Passes explicit full-window and expected-last-trading-day args only when the workflow caller provides them.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py -k 'workflow_template_surfaces_feedback or parse_args_defaults_to_500_daily_profit_program'`
- `uv run --frozen ruff format --check tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv run --frozen ruff check tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/torghut >/tmp/torghut-kustomize-render.yaml`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
