### PR TITLE
chore(jangar): promote image e08ceddf

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 7a05e24d
-  digest: sha256:b89653f68e0bf2489a08805ff0d928fb92d35b908da7d6b06cd7daced22e7ea1
+  tag: e08ceddf
+  digest: sha256:2a811980bb3a12b1193508053f4cbd76c9cfb99855dddce26c1881edc6b21ad4
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,8 +11,8 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 7a05e24d
-    digest: sha256:6202805b417de1982ad362f1ee99c1b6fa464125048dec2afb4bda0fe4f49cbe
+    tag: e08ceddf
+    digest: sha256:e6bc0c8622532353d209ee1a421ffdd259715f382e3904fbc79165c8a7d96314
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
@@ -21,8 +21,8 @@ controlPlane:
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 7a05e24d
-    digest: sha256:b89653f68e0bf2489a08805ff0d928fb92d35b908da7d6b06cd7daced22e7ea1
+    tag: e08ceddf
+    digest: sha256:2a811980bb3a12b1193508053f4cbd76c9cfb99855dddce26c1881edc6b21ad4
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-14T09:24:00Z
+    deploy.knative.dev/rollout: 2026-05-14T10:14:03Z
 spec:
   replicas: 1
   strategy:
@@ -57,11 +57,11 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_RUNTIME_IMAGE
-              value: registry.ide-newton.ts.net/lab/jangar:7a05e24d@sha256:b89653f68e0bf2489a08805ff0d928fb92d35b908da7d6b06cd7daced22e7ea1
+              value: registry.ide-newton.ts.net/lab/jangar:e08ceddf@sha256:2a811980bb3a12b1193508053f4cbd76c9cfb99855dddce26c1881edc6b21ad4
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: 7a05e24d523d4310c00b6ae4577cc0834610bb12
+              value: e08ceddf18b13a4a568de4396c603f98b03bd0fd
             - name: JANGAR_GITOPS_REVISION
-              value: 7a05e24d523d4310c00b6ae4577cc0834610bb12
+              value: e08ceddf18b13a4a568de4396c603f98b03bd0fd
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_BUMBA_TASK_QUEUE

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -59,5 +59,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: 7a05e24d
-    digest: sha256:b89653f68e0bf2489a08805ff0d928fb92d35b908da7d6b06cd7daced22e7ea1
+    newTag: e08ceddf
+    digest: sha256:2a811980bb3a12b1193508053f4cbd76c9cfb99855dddce26c1881edc6b21ad4


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `e08ceddf18b13a4a568de4396c603f98b03bd0fd`
- Image tag: `e08ceddf`
- Image digest: `sha256:2a811980bb3a12b1193508053f4cbd76c9cfb99855dddce26c1881edc6b21ad4`
- Updated API rollout annotation
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`