### PR TITLE
chore(jangar): promote image af7de0d0

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: e08ceddf
-  digest: sha256:2a811980bb3a12b1193508053f4cbd76c9cfb99855dddce26c1881edc6b21ad4
+  tag: af7de0d0
+  digest: sha256:5f883f91b8b02671d9ff6b3cff82c35a25d16ee3d80dffd8039126fbc03413bb
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,8 +11,8 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: e08ceddf
-    digest: sha256:e6bc0c8622532353d209ee1a421ffdd259715f382e3904fbc79165c8a7d96314
+    tag: af7de0d0
+    digest: sha256:f668fea1bf077292bd788b29aff026ae75cb7430f192c9e003944359fc84f5aa
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
@@ -21,8 +21,8 @@ controlPlane:
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: e08ceddf
-    digest: sha256:2a811980bb3a12b1193508053f4cbd76c9cfb99855dddce26c1881edc6b21ad4
+    tag: af7de0d0
+    digest: sha256:5f883f91b8b02671d9ff6b3cff82c35a25d16ee3d80dffd8039126fbc03413bb
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-14T10:14:03Z
+    deploy.knative.dev/rollout: 2026-05-14T10:37:00Z
 spec:
   replicas: 1
   strategy:
@@ -57,11 +57,11 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_RUNTIME_IMAGE
-              value: registry.ide-newton.ts.net/lab/jangar:e08ceddf@sha256:2a811980bb3a12b1193508053f4cbd76c9cfb99855dddce26c1881edc6b21ad4
+              value: registry.ide-newton.ts.net/lab/jangar:af7de0d0@sha256:5f883f91b8b02671d9ff6b3cff82c35a25d16ee3d80dffd8039126fbc03413bb
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: e08ceddf18b13a4a568de4396c603f98b03bd0fd
+              value: af7de0d0158a81802137014f1ef56ed5939375fc
             - name: JANGAR_GITOPS_REVISION
-              value: e08ceddf18b13a4a568de4396c603f98b03bd0fd
+              value: af7de0d0158a81802137014f1ef56ed5939375fc
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_BUMBA_TASK_QUEUE

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -59,5 +59,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: e08ceddf
-    digest: sha256:2a811980bb3a12b1193508053f4cbd76c9cfb99855dddce26c1881edc6b21ad4
+    newTag: af7de0d0
+    digest: sha256:5f883f91b8b02671d9ff6b3cff82c35a25d16ee3d80dffd8039126fbc03413bb


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `af7de0d0158a81802137014f1ef56ed5939375fc`
- Image tag: `af7de0d0`
- Image digest: `sha256:5f883f91b8b02671d9ff6b3cff82c35a25d16ee3d80dffd8039126fbc03413bb`
- Updated API rollout annotation
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`