### PR TITLE
fix(jangar): require verify warrant in deploy checks

### DIFF
--- a/docs/agents/designs/65-jangar-recovery-warrants-and-runtime-proof-cells-contract-2026-03-21.md
+++ b/docs/agents/designs/65-jangar-recovery-warrants-and-runtime-proof-cells-contract-2026-03-21.md
@@ -379,7 +379,8 @@ Implementation note: deploy-verification proof gate (2026-05-07).
 - `packages/scripts/src/jangar/verify-deployment.ts` now validates the recovery-warrant proof surface after rollout
   image and admission passport parity pass.
 - the verifier maps configured passport consumers to the deploy-relevant warrant classes: `serving`, `plan`,
-  `implement`, and `verify`.
+  `implement`, and `verify`; the default configured consumer set includes `swarm_verify` so verify-stage parity is not
+  an opt-in rollout check.
 - each required warrant must be `sealed`, cite the same admission passport and runtime-kit digest, and report an
   admitted image digest matching the promoted rollout digest.
 - each required proof cell must be present, required, `healthy`, and fresh.

--- a/packages/scripts/src/jangar/__tests__/verify-deployment.test.ts
+++ b/packages/scripts/src/jangar/__tests__/verify-deployment.test.ts
@@ -51,6 +51,22 @@ describe('verify-deployment', () => {
         required_runtime_kits: ['runtime-kit:collaboration:1'],
         fresh_until: futureFreshUntil,
       },
+      {
+        admission_passport_id: 'passport:swarm_implement:1',
+        consumer_class: 'swarm_implement',
+        decision: 'allow',
+        runtime_kit_set_digest: 'runtime-implement',
+        required_runtime_kits: ['runtime-kit:collaboration:1'],
+        fresh_until: futureFreshUntil,
+      },
+      {
+        admission_passport_id: 'passport:swarm_verify:1',
+        consumer_class: 'swarm_verify',
+        decision: 'allow',
+        runtime_kit_set_digest: 'runtime-verify',
+        required_runtime_kits: ['runtime-kit:collaboration:1'],
+        fresh_until: futureFreshUntil,
+      },
     ],
     recovery_warrants: [
       {
@@ -77,6 +93,30 @@ describe('verify-deployment', () => {
         active_backlog_seat_count: 0,
         reason_codes: [],
       },
+      {
+        recovery_warrant_id: 'recovery-warrant:implement:1',
+        execution_class: 'implement',
+        admission_passport_id: 'passport:swarm_implement:1',
+        runtime_kit_digest: 'runtime-implement',
+        admitted_image_digest: expectedDigest,
+        required_proof_cell_ids: ['runtime-proof-cell:implement:image'],
+        projection_watermark_ids: ['projection-watermark:implement:deploy'],
+        status: 'sealed',
+        active_backlog_seat_count: 0,
+        reason_codes: [],
+      },
+      {
+        recovery_warrant_id: 'recovery-warrant:verify:1',
+        execution_class: 'verify',
+        admission_passport_id: 'passport:swarm_verify:1',
+        runtime_kit_digest: 'runtime-verify',
+        admitted_image_digest: expectedDigest,
+        required_proof_cell_ids: ['runtime-proof-cell:verify:image'],
+        projection_watermark_ids: ['projection-watermark:verify:deploy'],
+        status: 'sealed',
+        active_backlog_seat_count: 0,
+        reason_codes: [],
+      },
     ],
     runtime_proof_cells: [
       {
@@ -89,6 +129,20 @@ describe('verify-deployment', () => {
       {
         runtime_proof_cell_id: 'runtime-proof-cell:plan:image',
         recovery_warrant_id: 'recovery-warrant:plan:1',
+        status: 'healthy',
+        required: true,
+        expires_at: futureFreshUntil,
+      },
+      {
+        runtime_proof_cell_id: 'runtime-proof-cell:implement:image',
+        recovery_warrant_id: 'recovery-warrant:implement:1',
+        status: 'healthy',
+        required: true,
+        expires_at: futureFreshUntil,
+      },
+      {
+        runtime_proof_cell_id: 'runtime-proof-cell:verify:image',
+        recovery_warrant_id: 'recovery-warrant:verify:1',
         status: 'healthy',
         required: true,
         expires_at: futureFreshUntil,
@@ -112,6 +166,24 @@ describe('verify-deployment', () => {
         status: 'fresh',
         expires_at: futureFreshUntil,
         projection_digest: 'projection-plan',
+      },
+      {
+        projection_watermark_id: 'projection-watermark:implement:deploy',
+        consumer_key: 'deploy_verification',
+        recovery_warrant_id: 'recovery-warrant:implement:1',
+        source_ref: 'admission-passport:passport:swarm_implement:1',
+        status: 'fresh',
+        expires_at: futureFreshUntil,
+        projection_digest: 'projection-implement',
+      },
+      {
+        projection_watermark_id: 'projection-watermark:verify:deploy',
+        consumer_key: 'deploy_verification',
+        recovery_warrant_id: 'recovery-warrant:verify:1',
+        source_ref: 'admission-passport:passport:swarm_verify:1',
+        status: 'fresh',
+        expires_at: futureFreshUntil,
+        projection_digest: 'projection-verify',
       },
     ],
     ...overrides,
@@ -344,6 +416,45 @@ describe('verify-deployment', () => {
       'projection-watermark:serving:deploy',
       'projection-watermark:plan:deploy',
     ])
+  })
+
+  it('includes verify warrants in the default deploy proof gate', () => {
+    const evidence = __private.verifyRuntimeProofSurfaceParity({
+      status: buildRuntimeProofStatus(),
+      expectedDigest,
+      consumers: __private.defaultAdmissionPassportConsumers,
+      now: new Date('2026-05-07T00:00:00.000Z'),
+    })
+
+    expect(__private.defaultAdmissionPassportConsumers).toEqual([
+      'serving',
+      'swarm_plan',
+      'swarm_implement',
+      'swarm_verify',
+    ])
+    expect(evidence.warrantIds).toEqual([
+      'recovery-warrant:serving:1',
+      'recovery-warrant:plan:1',
+      'recovery-warrant:implement:1',
+      'recovery-warrant:verify:1',
+    ])
+    expect(evidence.projectionWatermarkIds).toContain('projection-watermark:verify:deploy')
+  })
+
+  it('fails the default deploy proof gate when verify warrant parity is missing', () => {
+    const status = buildRuntimeProofStatus()
+    const recoveryWarrants = (status.recovery_warrants as Record<string, unknown>[]).filter(
+      (warrant) => warrant.recovery_warrant_id !== 'recovery-warrant:verify:1',
+    )
+
+    expect(() =>
+      __private.verifyRuntimeProofSurfaceParity({
+        status: { ...status, recovery_warrants: recoveryWarrants },
+        expectedDigest,
+        consumers: __private.defaultAdmissionPassportConsumers,
+        now: new Date('2026-05-07T00:00:00.000Z'),
+      }),
+    ).toThrow('Missing verify recovery warrant for admission passport passport:swarm_verify:1')
   })
 
   it('fails runtime proof verification when the deploy watermark is missing', () => {

--- a/packages/scripts/src/jangar/verify-deployment.ts
+++ b/packages/scripts/src/jangar/verify-deployment.ts
@@ -88,7 +88,12 @@ const supportedRevisionModes = ['exact', 'ancestor'] as const
 type ExpectedRevisionMode = (typeof supportedRevisionModes)[number]
 const supportedAdmissionPassportConsumers = ['serving', 'swarm_plan', 'swarm_implement', 'swarm_verify'] as const
 type AdmissionPassportConsumer = (typeof supportedAdmissionPassportConsumers)[number]
-const defaultAdmissionPassportConsumers: AdmissionPassportConsumer[] = ['serving', 'swarm_plan', 'swarm_implement']
+const defaultAdmissionPassportConsumers: AdmissionPassportConsumer[] = [
+  'serving',
+  'swarm_plan',
+  'swarm_implement',
+  'swarm_verify',
+]
 const supportedAuthorityProvenanceSettlementStates = [
   'settled',
   'settled_with_split',
@@ -435,7 +440,7 @@ Options:
   --control-plane-status-namespace <name>
                                       Namespace passed to /api/agents/control-plane/status (default: agents)
   --admission-passport-consumers <csv>
-                                      Required passport consumers (default: serving,swarm_plan,swarm_implement)
+                                      Required passport consumers (default: ${defaultAdmissionPassportConsumers.join(',')})
   --skip-admission-passport-verification
                                       Skip runtime admission passport parity verification
   --skip-runtime-proof-verification
@@ -1314,6 +1319,7 @@ export const __private = {
   isExpectedRevisionSatisfied,
   parseArgs,
   parseAdmissionPassportConsumers,
+  defaultAdmissionPassportConsumers,
   verifyAuthorityProvenanceSettlement,
   verifyAdmissionPassportParity,
   verifyRuntimeProofSurfaceParity,

--- a/services/jangar/README.md
+++ b/services/jangar/README.md
@@ -307,9 +307,9 @@ not change scheduler behavior; rollback is to ignore these status fields or keep
 Deploy verification also consumes the runtime-admission projection. After Argo, rollout, and image digest checks pass,
 `packages/scripts/src/jangar/verify-deployment.ts` reads
 `/api/agents/control-plane/status?namespace=agents` through the Kubernetes service proxy and requires the configured
-passport consumers (`serving`, `swarm_plan`, and `swarm_implement` by default) to be `allow`, fresh, backed by present
-runtime kits, and running on the same image digest as the promoted deployment. The deployment manifest sets
-`JANGAR_RUNTIME_IMAGE` to the promoted tag and digest so runtime-kit `image_ref` can be compared directly. Emergency
+passport consumers (`serving`, `swarm_plan`, `swarm_implement`, and `swarm_verify` by default) to be `allow`, fresh,
+backed by present runtime kits, and running on the same image digest as the promoted deployment. The deployment manifest
+sets `JANGAR_RUNTIME_IMAGE` to the promoted tag and digest so runtime-kit `image_ref` can be compared directly. Emergency
 rollback for the verifier gate is `--skip-admission-passport-verification` or
 `JANGAR_VERIFY_ADMISSION_PASSPORTS=false`; keep the status projection enabled for forensics.
 


### PR DESCRIPTION
## Summary

- Requires `swarm_verify` in the default Jangar deploy-verification runtime admission and proof-surface gate, so serving,
  plan, implement, and verify warrants are all checked before promotion-safe claims.
- Adds regression coverage proving the default deploy proof gate includes the verify warrant and fails when verify warrant
  parity is missing.
- Updates `services/jangar/README.md` and design 65 with the new default consumer set, design provenance, risk, and
  rollback path.
- Live `/ready` evidence before and after local implementation stayed `business_state=repair_only`,
  `revenue_ready=false`, top repair item `repair_alpha_readiness`, affected gate `routeable_candidate_count`; the shipped
  impact is tighter handoff evidence and rollout verification once deployed.

## Related Issues

None

## Testing

- PASS: `bun install --frozen-lockfile`
- PASS: `bun test packages/scripts/src/jangar/__tests__/verify-deployment.test.ts`
- PASS: `bun run --filter @proompteng/scripts lint`
- PASS: `bun run --filter @proompteng/scripts lint:oxlint:type`
- PASS: `bun test packages/scripts/src`
- PASS: `bunx oxfmt --check services/jangar packages/scripts/src/jangar argocd/applications/jangar`
- PASS: `bun run --cwd services/jangar lint:oxlint`
- PASS: `bun run --cwd services/jangar lint:oxlint:type`
- PASS: `bun run --cwd services/jangar test`
- PASS: `cd services/jangar && bunx tsc --noEmit --project tsconfig.paths.json`
- PASS: `bun run --cwd services/jangar docs:inventory:check`
- PASS: `bun run --cwd services/jangar check:module-sizes`
- PASS: `bun run --cwd services/jangar build`
- PASS: `git diff --check`
- NON-GATE OBSERVATION: `bunx tsc --noEmit -p packages/scripts/tsconfig.json` still fails on existing package-wide
  strictness errors outside this change; the required package scripts type-aware gate is `lint:oxlint:type`, which
  passed.

## Screenshots (if applicable)

N/A

## Breaking Changes

None. Operational risk is intentional fail-closed deploy verification: a promotion can now fail if the verify-stage
passport, recovery warrant, required proof cells, or `deploy_verification` watermark are missing or stale. Emergency
rollback is `--admission-passport-consumers serving,swarm_plan,swarm_implement`, or the existing
`--skip-runtime-proof-verification` / `JANGAR_VERIFY_RUNTIME_PROOF_SURFACE=false` escape hatch.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
