### PR TITLE
feat(torghut): add alpha readiness settlement conveyor

### DIFF
--- a/docs/torghut/rollouts/2026-05-14-alpha-readiness-settlement-conveyor.md
+++ b/docs/torghut/rollouts/2026-05-14-alpha-readiness-settlement-conveyor.md
@@ -1,0 +1,85 @@
+# Torghut Alpha-Readiness Settlement Conveyor Rollout
+
+This rollout note covers the observe-only Torghut alpha-readiness settlement conveyor for the current
+`repair_alpha_readiness` revenue blocker.
+
+## Governing Design
+
+- `docs/torghut/design-system/v6/205-torghut-alpha-readiness-settlement-conveyor-and-routeable-profit-runway-2026-05-14.md`
+- Companion contract:
+  `docs/agents/designs/200-jangar-revenue-repair-settlement-conveyor-and-stage-health-custody-2026-05-14.md`
+
+## Revenue Evidence
+
+Read-only source: `GET http://torghut.torghut.svc.cluster.local/trading/revenue-repair`.
+
+Before implementation, 2026-05-14T10:03:24Z:
+
+- `business_state=repair_only`
+- `revenue_ready=false`
+- top queue item: `repair_alpha_readiness` / `alpha_readiness_not_promotion_eligible`
+- affected value gate: `routeable_candidate_count`
+- `routeable_candidate_count=0`
+- `zero_notional_or_stale_evidence_rate=1.0`
+- `max_notional=0`
+- `alpha_evidence_foundry.next_implementation_milestone=settle alpha evidence-window receipts before any paper or live capital release`
+
+After local implementation, live pre-deploy evidence at 2026-05-14T10:16:25Z still correctly showed:
+
+- `business_state=repair_only`
+- `revenue_ready=false`
+- top queue item: `repair_alpha_readiness` / `alpha_readiness_not_promotion_eligible`
+- affected value gate: `routeable_candidate_count`
+- `routeable_candidate_count=0`
+- `zero_notional_or_stale_evidence_rate=1.0`
+- `max_notional=0`
+- `alpha_closure_settlement_market.status=pending_no_delta`
+- `alpha_closure_settlement_market.selected_hypothesis_id=H-MICRO-01`
+
+The runtime route remains zero-notional until the image containing this PR is promoted and the conveyor appears on
+`/trading/revenue-repair` and compact consumer evidence.
+
+## What Shipped
+
+- Added `torghut.alpha-readiness-settlement-conveyor.v1` as a pure Torghut read-model.
+- Added compact `torghut.alpha-readiness-settlement-conveyor-ref.v1` mirrors to health and consumer evidence payloads.
+- Selected `H-MICRO-01` first when the live alpha-readiness evidence matches the accepted design: it is the
+  lineage-ready feature/drift lane, while other lanes remain behind post-cost or lineage blockers.
+- Added no-delta lease accounting keyed by source ref, evidence window, blocker set, source commit, hypothesis, and
+  required receipt set.
+- Preserved `max_notional=0`, `capital_rule=zero_notional_repair_only`, and live submission disabled.
+
+## Validation
+
+- `cd services/torghut && /tmp/codex-uv/bin/uv sync --frozen --extra dev`
+- `cd services/torghut && /tmp/codex-uv/bin/uv run --frozen ruff format --check app/trading/alpha_readiness_settlement_conveyor.py app/trading/revenue_repair.py app/main.py tests/test_alpha_readiness_settlement_conveyor.py tests/test_build_revenue_repair_digest.py tests/test_trading_api.py`
+- `cd services/torghut && /tmp/codex-uv/bin/uv run --frozen ruff check app/trading/alpha_readiness_settlement_conveyor.py app/trading/revenue_repair.py app/main.py tests/test_alpha_readiness_settlement_conveyor.py tests/test_build_revenue_repair_digest.py tests/test_trading_api.py`
+- `cd services/torghut && /tmp/codex-uv/bin/uv run --frozen pytest tests/test_alpha_readiness_settlement_conveyor.py tests/test_alpha_evidence_foundry.py tests/test_alpha_repair_closure_board.py tests/test_build_revenue_repair_digest.py tests/test_trading_api.py -k "alpha or revenue_repair or consumer_evidence or settlement_conveyor"`: pass, 43 selected tests
+- `cd services/torghut && /tmp/codex-uv/bin/uv run --frozen pytest tests/test_alpha_readiness_settlement_conveyor.py tests/test_alpha_evidence_foundry.py tests/test_alpha_repair_closure_board.py tests/test_build_revenue_repair_digest.py tests/test_trading_api.py -k "alpha or revenue_repair or consumer_evidence or settlement_conveyor" --cov --cov-branch --cov-fail-under=0 --cov-report=xml --cov-report=`: pass, 43 selected tests
+- `cd services/torghut && /tmp/codex-uv/bin/uv run --frozen python scripts/check_migration_graph.py`
+- `cd services/torghut && /tmp/codex-uv/bin/uv run --frozen pyright --project pyrightconfig.json`
+- `cd services/torghut && /tmp/codex-uv/bin/uv run --frozen pyright --project pyrightconfig.alpha.json`
+- `cd services/torghut && /tmp/codex-uv/bin/uv run --frozen pyright --project pyrightconfig.scripts.json`
+- `cd services/torghut && /tmp/codex-uv/bin/uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90`: pass, changed-line coverage 273/287 (95.12%)
+
+Additional broad coverage evidence:
+
+- `cd services/torghut && /tmp/codex-uv/bin/uv run --frozen pytest --cov --cov-branch --cov-report=term-missing --cov-report=xml`
+  reached 1,403 passing tests with no failures before the local serial run was stopped in
+  `tests/test_run_whitepaper_autoresearch_profit_target.py::TestWhitepaperAutoresearchProfitTarget::test_seed_recent_whitepapers_runs_end_to_end_and_writes_artifacts`.
+  CI shards that file into separate runner slices and remains the full required coverage gate for the PR.
+
+## Risk And Rollback
+
+Risk is limited to additive evidence payloads on Torghut health, revenue repair, and consumer evidence. The conveyor is
+observe-only and does not execute trades, mutate broker state, change database rows, or alter submit gates.
+
+Rollback is to revert this PR or stop emitting `alpha_readiness_settlement_conveyor` and the compact conveyor ref.
+Existing revenue-repair, alpha evidence foundry, alpha repair closure board, proof floor, and capital holds remain
+the fallback surfaces. Capital stays `max_notional=0`.
+
+## Owner Status
+
+The revenue metric targeted is `routeable_candidate_count`. The current smallest revenue blocker remains
+`alpha_readiness_not_promotion_eligible`; this PR makes the H-MICRO-01 no-delta/reentry key explicit so repeated
+zero-notional repair work can be denied until source, blocker, evidence-window, or required-receipt inputs change.

--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -50,6 +50,9 @@ from .models import (
 from .observability import capture_posthog_event, shutdown_posthog_telemetry
 from .trading import TradingScheduler
 from .trading.alpha_evidence_foundry import compact_alpha_evidence_foundry
+from .trading.alpha_readiness_settlement_conveyor import (
+    compact_alpha_readiness_settlement_conveyor,
+)
 from .trading.alpha_repair_closure_board import compact_alpha_repair_closure_board
 from .trading.autonomy import (
     assert_runtime_gate_policy_contract,
@@ -1141,6 +1144,12 @@ def _evaluate_trading_health_payload(
                 cast(
                     Mapping[str, Any],
                     revenue_repair_digest.get("alpha_evidence_foundry"),
+                )
+            ),
+            "alpha_readiness_settlement_conveyor": compact_alpha_readiness_settlement_conveyor(
+                cast(
+                    Mapping[str, Any],
+                    revenue_repair_digest.get("alpha_readiness_settlement_conveyor"),
                 )
             ),
             "route_reacquisition_book": proof_floor.get("route_reacquisition_book"),
@@ -3337,6 +3346,12 @@ def _build_trading_consumer_evidence_payload() -> dict[str, object]:
             cast(
                 Mapping[str, Any],
                 revenue_repair_digest.get("alpha_evidence_foundry"),
+            )
+        ),
+        "alpha_readiness_settlement_conveyor": compact_alpha_readiness_settlement_conveyor(
+            cast(
+                Mapping[str, Any],
+                revenue_repair_digest.get("alpha_readiness_settlement_conveyor"),
             )
         ),
         "route_warrant_exchange": route_warrant_exchange,

--- a/services/torghut/app/trading/alpha_readiness_settlement_conveyor.py
+++ b/services/torghut/app/trading/alpha_readiness_settlement_conveyor.py
@@ -1,0 +1,848 @@
+"""Alpha-readiness settlement conveyor for zero-notional routeable reentry."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from datetime import datetime, timedelta, timezone
+from typing import Any, cast
+
+ALPHA_READINESS_SETTLEMENT_CONVEYOR_SCHEMA_VERSION = (
+    "torghut.alpha-readiness-settlement-conveyor.v1"
+)
+ALPHA_READINESS_SETTLEMENT_CONVEYOR_REF_SCHEMA_VERSION = (
+    "torghut.alpha-readiness-settlement-conveyor-ref.v1"
+)
+ALPHA_READINESS_SETTLEMENT_RECEIPT_SCHEMA_VERSION = (
+    "torghut.alpha-readiness-settlement-receipt.v1"
+)
+
+_DESIGN_REF = (
+    "docs/torghut/design-system/v6/"
+    "205-torghut-alpha-readiness-settlement-conveyor-and-routeable-profit-runway-2026-05-14.md"
+)
+_DEFAULT_FRESHNESS_SECONDS = 15 * 60
+_ROLLBACK_TARGET = (
+    "stop emitting alpha_readiness_settlement_conveyor and keep Torghut max_notional=0"
+)
+_ZERO_NOTIONAL_VALUES = {"0", "0.0", "0.00", "0.0000"}
+_H_MICRO = "H-MICRO-01"
+_NO_DELTA_RELEASE_CONDITIONS = [
+    "source_ref_changes",
+    "evidence_window_changes",
+    "blocker_set_changes",
+    "required_receipt_changes",
+]
+_FEATURE_OR_DRIFT_BLOCKERS = {
+    "drift_checks_missing",
+    "feature_rows_missing",
+    "required_feature_set_unavailable",
+    "forecast_registry_degraded",
+}
+_POST_COST_BLOCKERS = {
+    "post_cost_expectancy_non_positive",
+    "post_cost_expectancy_missing",
+}
+_EMPIRICAL_BLOCKERS = {
+    "empirical_jobs_degraded",
+    "empirical_jobs_not_ready",
+    "job_ineligible:benchmark_parity",
+    "job_ineligible:foundation_router_parity",
+    "job_ineligible:janus_event_car",
+    "job_ineligible:janus_hgrm_reward",
+    "job_stale:benchmark_parity",
+    "job_stale:foundation_router_parity",
+    "job_stale:janus_event_car",
+    "job_stale:janus_hgrm_reward",
+}
+_SCHEMA_LINEAGE_BLOCKERS = {
+    "schema_lineage_missing",
+    "strategy_hypothesis_lineage_missing",
+    "required_feature_set_unavailable",
+}
+_REJECTION_DRAG_BLOCKERS = {"rejection_drag_high", "rejection_drag_unmeasured"}
+
+
+def _text(value: object, default: str = "") -> str:
+    if value is None:
+        return default
+    normalized = str(value).strip()
+    return normalized or default
+
+
+def _int(value: object, default: int = 0) -> int:
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if isinstance(value, str) and value.strip():
+        try:
+            return int(float(value.strip()))
+        except ValueError:
+            return default
+    return default
+
+
+def _mapping(value: object) -> Mapping[str, Any]:
+    if isinstance(value, Mapping):
+        return cast(Mapping[str, Any], value)
+    return {}
+
+
+def _sequence(value: object) -> Sequence[object]:
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return cast(Sequence[object], value)
+    return ()
+
+
+def _string_list(value: object) -> list[str]:
+    items: list[str] = []
+    seen: set[str] = set()
+    for item in _sequence(value):
+        normalized = _text(item)
+        if not normalized or normalized in seen:
+            continue
+        seen.add(normalized)
+        items.append(normalized)
+    return items
+
+
+def _append_unique(items: list[str], *values: object) -> list[str]:
+    seen = set(items)
+    for value in values:
+        if isinstance(value, Sequence) and not isinstance(
+            value, (str, bytes, bytearray)
+        ):
+            candidates = _string_list(cast(Sequence[object], value))
+        else:
+            candidates = [_text(value)]
+        for candidate in candidates:
+            if not candidate or candidate in seen:
+                continue
+            seen.add(candidate)
+            items.append(candidate)
+    return items
+
+
+def _stable_hash(prefix: str, payload: Mapping[str, object]) -> str:
+    encoded = json.dumps(
+        {"prefix": prefix, **dict(payload)},
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()[:24]
+
+
+def _top_queue_item(repair_queue: Sequence[Mapping[str, Any]]) -> Mapping[str, Any]:
+    for item in repair_queue:
+        payload = _mapping(item)
+        if payload:
+            return payload
+    return {}
+
+
+def _is_alpha_repair(item: Mapping[str, Any]) -> bool:
+    return (
+        _text(item.get("code")) == "repair_alpha_readiness"
+        or _text(item.get("reason")) == "alpha_readiness_not_promotion_eligible"
+    )
+
+
+def _routeable_candidate_count(evidence: Mapping[str, Any]) -> int:
+    repair_bid_settlement = _mapping(evidence.get("repair_bid_settlement"))
+    routeability_acceptance = _mapping(evidence.get("routeability_acceptance"))
+    route_clearinghouse = _mapping(evidence.get("route_evidence_clearinghouse"))
+    return max(
+        _int(repair_bid_settlement.get("routeable_candidate_count")),
+        _int(routeability_acceptance.get("accepted_routeable_candidate_count")),
+        _int(route_clearinghouse.get("accepted_routeable_candidate_count")),
+    )
+
+
+def _zero_notional_or_stale_evidence_rate(evidence: Mapping[str, Any]) -> object:
+    routeability_acceptance = _mapping(evidence.get("routeability_acceptance"))
+    route_clearinghouse = _mapping(evidence.get("route_evidence_clearinghouse"))
+    return routeability_acceptance.get(
+        "zero_notional_or_stale_evidence_rate",
+        route_clearinghouse.get("zero_notional_or_stale_evidence_rate", 1),
+    )
+
+
+def _source_commit(
+    source_serving_metadata: Mapping[str, Any],
+    alpha_evidence_foundry: Mapping[str, Any],
+) -> str:
+    build = _mapping(source_serving_metadata.get("build"))
+    source_serving = _mapping(
+        source_serving_metadata.get("source_serving_repair_receipt_ledger")
+    )
+    route_packet = _mapping(
+        source_serving_metadata.get("route_evidence_clearinghouse_packet")
+    )
+    return (
+        _text(alpha_evidence_foundry.get("source_commit"))
+        or _text(source_serving.get("source_commit"))
+        or _text(route_packet.get("source_commit"))
+        or _text(build.get("commit"))
+        or "unknown"
+    )
+
+
+def _active_revision(
+    source_serving_metadata: Mapping[str, Any],
+    alpha_evidence_foundry: Mapping[str, Any],
+) -> str:
+    build = _mapping(source_serving_metadata.get("build"))
+    source_serving = _mapping(
+        source_serving_metadata.get("source_serving_repair_receipt_ledger")
+    )
+    route_packet = _mapping(
+        source_serving_metadata.get("route_evidence_clearinghouse_packet")
+    )
+    return (
+        _text(alpha_evidence_foundry.get("active_revision"))
+        or _text(source_serving.get("active_revision"))
+        or _text(route_packet.get("torghut_revision"))
+        or _text(build.get("active_revision"))
+        or "unknown"
+    )
+
+
+def _alpha_evidence_receipts(
+    alpha_evidence_foundry: Mapping[str, Any],
+) -> list[Mapping[str, Any]]:
+    receipts: list[Mapping[str, Any]] = []
+    seen: set[str] = set()
+    for raw_receipt in _sequence(alpha_evidence_foundry.get("receipts")):
+        receipt = _mapping(raw_receipt)
+        if not receipt:
+            continue
+        receipt_key = _text(receipt.get("receipt_id")) or _text(
+            receipt.get("hypothesis_id")
+        )
+        if receipt_key and receipt_key in seen:
+            continue
+        if receipt_key:
+            seen.add(receipt_key)
+        receipts.append(receipt)
+    return receipts
+
+
+def _reason_codes(receipt: Mapping[str, Any]) -> list[str]:
+    return (
+        _string_list(receipt.get("preserved_reason_codes"))
+        or _string_list(receipt.get("before_reason_codes"))
+        or _string_list(receipt.get("reason_codes"))
+    )
+
+
+def _required_receipts(
+    top_item: Mapping[str, Any],
+    receipt: Mapping[str, Any],
+    closure_board: Mapping[str, Any],
+) -> list[str]:
+    required = _string_list(receipt.get("required_after_receipts"))
+    market = _mapping(closure_board.get("alpha_closure_settlement_market"))
+    required = _append_unique(
+        required,
+        market.get("required_after_receipts"),
+        top_item.get("required_receipts"),
+        top_item.get("required_output_receipt"),
+        ALPHA_READINESS_SETTLEMENT_RECEIPT_SCHEMA_VERSION,
+    )
+    return required
+
+
+def _funded_receipts(
+    required_receipts: Sequence[str],
+    receipt: Mapping[str, Any],
+) -> list[str]:
+    after_refs = _string_list(receipt.get("after_refs"))
+    funded: list[str] = []
+    for required in required_receipts:
+        required_prefix = required.split(":", 1)[0]
+        if any(required == ref or required_prefix in ref for ref in after_refs):
+            funded.append(required)
+    return funded
+
+
+def _missing_receipts(
+    required_receipts: Sequence[str],
+    funded_receipts: Sequence[str],
+) -> list[str]:
+    funded = set(funded_receipts)
+    return [receipt for receipt in required_receipts if receipt not in funded]
+
+
+def _blocker_digest(reason_codes: Sequence[str]) -> str:
+    return _stable_hash(
+        "alpha-readiness-blocker-digest", {"reason_codes": list(reason_codes)}
+    )
+
+
+def _required_receipt_digest(required_receipts: Sequence[str]) -> str:
+    return _stable_hash(
+        "alpha-readiness-required-receipt-digest",
+        {"required_receipts": list(required_receipts)},
+    )
+
+
+def _no_delta_release_key(
+    *,
+    account_id: str,
+    window: str,
+    source_commit: str,
+    source_revenue_repair_ref: str,
+    receipt: Mapping[str, Any],
+    reason_codes: Sequence[str],
+    required_receipts: Sequence[str],
+) -> str:
+    return _stable_hash(
+        "alpha-readiness-no-delta-release-key",
+        {
+            "account_id": account_id,
+            "window": window,
+            "source_commit": source_commit,
+            "source_revenue_repair_ref": source_revenue_repair_ref,
+            "hypothesis_id": _text(receipt.get("hypothesis_id")),
+            "repair_class": _text(receipt.get("repair_class"), "alpha_readiness"),
+            "blocker_digest": _blocker_digest(reason_codes),
+            "required_receipt_digest": _required_receipt_digest(required_receipts),
+        },
+    )
+
+
+def _score_lane(
+    receipt: Mapping[str, Any],
+    *,
+    reason_codes: Sequence[str],
+    no_delta_active: bool,
+) -> int:
+    reason_set = set(reason_codes)
+    score = 10
+    if _text(receipt.get("hypothesis_id")) == _H_MICRO:
+        score += 80
+    if reason_set.intersection(_FEATURE_OR_DRIFT_BLOCKERS):
+        score += 25
+    if reason_set.intersection(_POST_COST_BLOCKERS):
+        score -= 30
+    if reason_set.intersection(_SCHEMA_LINEAGE_BLOCKERS):
+        score -= 5
+    if no_delta_active:
+        score -= 10
+    if _text(receipt.get("max_notional"), "0") not in _ZERO_NOTIONAL_VALUES:
+        score -= 100
+    return score
+
+
+def _state_from_reasons(
+    reason_codes: set[str], blockers: set[str], missing: str
+) -> str:
+    if reason_codes.intersection(blockers):
+        return missing
+    return "current"
+
+
+def _evidence_window_state(receipt: Mapping[str, Any]) -> str:
+    if _text(receipt.get("no_delta_reason")):
+        return "no_delta"
+    if _text(receipt.get("ladder_state")):
+        return _text(receipt.get("ladder_state"))
+    return _text(receipt.get("evidence_window_status"), "current")
+
+
+def _lane_scores(
+    *,
+    receipts: Sequence[Mapping[str, Any]],
+    top_item: Mapping[str, Any],
+    closure_board: Mapping[str, Any],
+    source_commit: str,
+    source_revenue_repair_ref: str,
+    account_id: str,
+    window: str,
+) -> list[dict[str, object]]:
+    lanes: list[dict[str, object]] = []
+    for receipt in receipts:
+        reason_codes = _reason_codes(receipt)
+        required_receipts = _required_receipts(top_item, receipt, closure_board)
+        measured_delta = _int(receipt.get("measured_routeable_candidate_delta"))
+        no_delta_active = measured_delta <= 0
+        release_key = _no_delta_release_key(
+            account_id=account_id,
+            window=window,
+            source_commit=source_commit,
+            source_revenue_repair_ref=source_revenue_repair_ref,
+            receipt=receipt,
+            reason_codes=reason_codes,
+            required_receipts=required_receipts,
+        )
+        score = _score_lane(
+            receipt,
+            reason_codes=reason_codes,
+            no_delta_active=no_delta_active,
+        )
+        lanes.append(
+            {
+                "hypothesis_id": _text(receipt.get("hypothesis_id")),
+                "candidate_id": _text(receipt.get("candidate_id")) or None,
+                "strategy_id": _text(receipt.get("strategy_id")) or None,
+                "lane_id": _text(receipt.get("lane_id")) or None,
+                "strategy_family": _text(receipt.get("strategy_family")) or None,
+                "lane_score": score,
+                "score_reason_codes": [
+                    "lineage_ready_feature_replay"
+                    if _text(receipt.get("hypothesis_id")) == _H_MICRO
+                    else "alpha_readiness_candidate",
+                    "active_no_delta_lease" if no_delta_active else "positive_delta",
+                ],
+                "before_reason_codes": reason_codes,
+                "required_receipts": required_receipts,
+                "no_delta_release_key": release_key,
+                "repeat_launch_decision": "deny" if no_delta_active else "allow",
+                "measured_routeable_candidate_delta": measured_delta,
+                "max_notional": _text(receipt.get("max_notional"), "0"),
+            }
+        )
+    return sorted(
+        lanes,
+        key=lambda lane: (
+            -_int(lane.get("lane_score")),
+            _text(lane.get("hypothesis_id")),
+        ),
+    )
+
+
+def _build_no_delta_leases(
+    *,
+    receipts: Sequence[Mapping[str, Any]],
+    lane_scores: Sequence[Mapping[str, Any]],
+) -> list[dict[str, object]]:
+    scores_by_hypothesis = {
+        _text(score.get("hypothesis_id")): score for score in lane_scores
+    }
+    leases: list[dict[str, object]] = []
+    for receipt in receipts:
+        if _int(receipt.get("measured_routeable_candidate_delta")) > 0:
+            continue
+        hypothesis_id = _text(receipt.get("hypothesis_id"))
+        lane_score = _mapping(scores_by_hypothesis.get(hypothesis_id))
+        release_key = _text(lane_score.get("no_delta_release_key"))
+        lease_id = "alpha-readiness-no-delta-lease:" + _stable_hash(
+            "alpha-readiness-no-delta-lease",
+            {
+                "receipt_id": _text(receipt.get("receipt_id")),
+                "hypothesis_id": hypothesis_id,
+                "release_key": release_key,
+            },
+        )
+        leases.append(
+            {
+                "lease_id": lease_id,
+                "source_receipt_id": receipt.get("receipt_id"),
+                "hypothesis_id": hypothesis_id,
+                "candidate_id": receipt.get("candidate_id"),
+                "strategy_id": receipt.get("strategy_id"),
+                "lane_id": receipt.get("lane_id"),
+                "value_gate": receipt.get("target_value_gate"),
+                "preserved_reason_codes": _reason_codes(receipt),
+                "measured_routeable_candidate_delta": receipt.get(
+                    "measured_routeable_candidate_delta"
+                ),
+                "no_delta_reason": receipt.get("no_delta_reason"),
+                "no_delta_release_key": release_key,
+                "release_conditions": list(_NO_DELTA_RELEASE_CONDITIONS),
+                "repeat_launch_decision": "deny",
+                "max_notional": _text(receipt.get("max_notional"), "0"),
+            }
+        )
+    return leases
+
+
+def _receipt_for_selected_lane(
+    receipts: Sequence[Mapping[str, Any]],
+    selected_lane: Mapping[str, Any],
+) -> Mapping[str, Any]:
+    selected_hypothesis = _text(selected_lane.get("hypothesis_id"))
+    for receipt in receipts:
+        if _text(receipt.get("hypothesis_id")) == selected_hypothesis:
+            return receipt
+    return {}
+
+
+def _settlement_state(
+    *,
+    status: str,
+    selected_receipt: Mapping[str, Any],
+    measured_delta: int,
+    routeable_before: int,
+) -> str:
+    if status in {"observing", "blocked", "quarantined"}:
+        return status
+    if not selected_receipt:
+        return "blocked"
+    if measured_delta > 0:
+        return "paid"
+    if routeable_before > 0 and measured_delta == 0:
+        return "blocked"
+    return "no_delta"
+
+
+def _build_settlement_receipt(
+    *,
+    conveyor_id: str,
+    selected_lane: Mapping[str, Any],
+    selected_receipt: Mapping[str, Any],
+    status: str,
+    routeable_before: int,
+) -> dict[str, object] | None:
+    if not selected_lane or not selected_receipt:
+        return None
+    reason_codes = _reason_codes(selected_receipt)
+    reason_set = set(reason_codes)
+    funded_receipts = _funded_receipts(
+        _string_list(selected_lane.get("required_receipts")),
+        selected_receipt,
+    )
+    missing_receipts = _missing_receipts(
+        _string_list(selected_lane.get("required_receipts")),
+        funded_receipts,
+    )
+    measured_delta = _int(selected_lane.get("measured_routeable_candidate_delta"))
+    routeable_after = max(0, routeable_before + measured_delta)
+    settlement_state = _settlement_state(
+        status=status,
+        selected_receipt=selected_receipt,
+        measured_delta=measured_delta,
+        routeable_before=routeable_before,
+    )
+    receipt_id = "alpha-readiness-settlement-receipt:" + _stable_hash(
+        "alpha-readiness-settlement-receipt",
+        {
+            "conveyor_id": conveyor_id,
+            "hypothesis_id": _text(selected_lane.get("hypothesis_id")),
+            "release_key": _text(selected_lane.get("no_delta_release_key")),
+            "settlement_state": settlement_state,
+        },
+    )
+    return {
+        "schema_version": ALPHA_READINESS_SETTLEMENT_RECEIPT_SCHEMA_VERSION,
+        "receipt_id": receipt_id,
+        "conveyor_id": conveyor_id,
+        "hypothesis_id": selected_lane.get("hypothesis_id"),
+        "candidate_id": selected_lane.get("candidate_id"),
+        "strategy_id": selected_lane.get("strategy_id"),
+        "lane_id": selected_lane.get("lane_id"),
+        "strategy_family": selected_lane.get("strategy_family"),
+        "settlement_state": settlement_state,
+        "routeable_candidate_count_before": routeable_before,
+        "routeable_candidate_count_after": routeable_after,
+        "measured_routeable_candidate_delta": measured_delta,
+        "retired_reason_codes": _string_list(
+            selected_receipt.get("retired_reason_codes")
+        ),
+        "preserved_reason_codes": reason_codes,
+        "new_reason_codes": _string_list(selected_receipt.get("new_reason_codes")),
+        "funded_receipts": funded_receipts,
+        "missing_receipts": missing_receipts,
+        "evidence_window_id": selected_receipt.get("receipt_id"),
+        "evidence_window_state": _evidence_window_state(selected_receipt),
+        "schema_lineage_state": _state_from_reasons(
+            reason_set,
+            _SCHEMA_LINEAGE_BLOCKERS,
+            "missing",
+        ),
+        "empirical_jobs_state": _state_from_reasons(
+            reason_set,
+            _EMPIRICAL_BLOCKERS,
+            "stale",
+        ),
+        "post_cost_expectancy_state": _state_from_reasons(
+            reason_set,
+            _POST_COST_BLOCKERS,
+            "blocked",
+        ),
+        "drift_state": _state_from_reasons(
+            reason_set,
+            _FEATURE_OR_DRIFT_BLOCKERS,
+            "missing",
+        ),
+        "rejection_drag_state": _state_from_reasons(
+            reason_set,
+            _REJECTION_DRAG_BLOCKERS,
+            "measured_high",
+        ),
+        "no_delta_release_key": selected_lane.get("no_delta_release_key"),
+        "no_delta_release_conditions": list(_NO_DELTA_RELEASE_CONDITIONS),
+        "repeat_launch_decision": selected_lane.get("repeat_launch_decision"),
+        "max_notional": selected_lane.get("max_notional"),
+    }
+
+
+def _account_window_mode(
+    *,
+    selected_receipt: Mapping[str, Any],
+    alpha_evidence_foundry: Mapping[str, Any],
+    closure_board: Mapping[str, Any],
+    evidence: Mapping[str, Any],
+) -> tuple[str, str, str]:
+    repair_bid_settlement = _mapping(evidence.get("repair_bid_settlement"))
+    account = (
+        _text(selected_receipt.get("account_id"))
+        or _text(closure_board.get("account_id"))
+        or _text(repair_bid_settlement.get("account_id"))
+        or "unknown"
+    )
+    window = (
+        _text(selected_receipt.get("window"))
+        or _text(closure_board.get("window"))
+        or _text(repair_bid_settlement.get("session_id"))
+        or "unknown"
+    )
+    trading_mode = (
+        _text(selected_receipt.get("trading_mode"))
+        or _text(closure_board.get("trading_mode"))
+        or _text(repair_bid_settlement.get("trading_mode"))
+        or _text(alpha_evidence_foundry.get("trading_mode"))
+        or "unknown"
+    )
+    return account, window, trading_mode
+
+
+def build_alpha_readiness_settlement_conveyor(
+    *,
+    generated_at: datetime,
+    business_state: str,
+    revenue_ready: bool,
+    repair_queue: Sequence[Mapping[str, Any]],
+    capital: Mapping[str, Any],
+    evidence: Mapping[str, Any],
+    alpha_evidence_foundry: Mapping[str, Any],
+    alpha_repair_closure_board: Mapping[str, Any],
+    source_serving_metadata: Mapping[str, Any] | None = None,
+) -> dict[str, object]:
+    """Build the bounded alpha-readiness settlement lane from current evidence."""
+
+    if generated_at.tzinfo is None:
+        raise ValueError("generated_at_missing_timezone")
+    generated = generated_at.astimezone(timezone.utc)
+    fresh_until = generated + timedelta(seconds=_DEFAULT_FRESHNESS_SECONDS)
+    source_metadata = source_serving_metadata or {}
+    top_item = _top_queue_item(repair_queue)
+    routeable_before = _routeable_candidate_count(evidence)
+    max_notional = _text(capital.get("max_notional"), "0")
+    source_commit = _source_commit(source_metadata, alpha_evidence_foundry)
+    active_revision = _active_revision(source_metadata, alpha_evidence_foundry)
+    source_revenue_repair_ref = _text(
+        alpha_evidence_foundry.get("source_revenue_repair_ref"),
+        "torghut-revenue-repair-digest:unknown",
+    )
+    receipts = _alpha_evidence_receipts(alpha_evidence_foundry)
+    empty_receipt: Mapping[str, Any] = {}
+    selected_for_account: Mapping[str, Any] = receipts[0] if receipts else empty_receipt
+    account_id, window, trading_mode = _account_window_mode(
+        selected_receipt=selected_for_account,
+        alpha_evidence_foundry=alpha_evidence_foundry,
+        closure_board=alpha_repair_closure_board,
+        evidence=evidence,
+    )
+
+    reason_codes: list[str] = []
+    if revenue_ready:
+        reason_codes.append("revenue_already_ready")
+    if business_state != "repair_only":
+        reason_codes.append(f"business_state_{business_state or 'unknown'}")
+    if not _is_alpha_repair(top_item):
+        reason_codes.append("revenue_repair_top_item_not_alpha_readiness")
+    if max_notional not in _ZERO_NOTIONAL_VALUES:
+        reason_codes.append("capital_notional_nonzero")
+    if not alpha_evidence_foundry:
+        reason_codes.append("alpha_evidence_foundry_missing")
+    if alpha_evidence_foundry and _text(alpha_evidence_foundry.get("status")) not in {
+        "selected",
+        "held",
+    }:
+        reason_codes.append(
+            "alpha_evidence_foundry_"
+            + _text(alpha_evidence_foundry.get("status"), "unknown")
+        )
+    if _is_alpha_repair(top_item) and not receipts:
+        reason_codes.append("alpha_readiness_settlement_receipts_missing")
+
+    lanes = _lane_scores(
+        receipts=receipts,
+        top_item=top_item,
+        closure_board=alpha_repair_closure_board,
+        source_commit=source_commit,
+        source_revenue_repair_ref=source_revenue_repair_ref,
+        account_id=account_id,
+        window=window,
+    )
+    selected_lane = lanes[0] if lanes else {}
+    selected_receipt = _receipt_for_selected_lane(receipts, selected_lane)
+    active_no_delta_leases = _build_no_delta_leases(
+        receipts=receipts,
+        lane_scores=lanes,
+    )
+    if selected_lane and _text(selected_lane.get("repeat_launch_decision")) == "deny":
+        reason_codes.append("active_no_delta_lease")
+
+    status = "selecting"
+    if "revenue_repair_top_item_not_alpha_readiness" in reason_codes:
+        status = "observing"
+    elif "capital_notional_nonzero" in reason_codes:
+        status = "quarantined"
+    elif not selected_lane:
+        status = "blocked"
+    elif _text(selected_lane.get("repeat_launch_decision")) == "deny":
+        status = "no_delta"
+    else:
+        status = "settling"
+
+    conveyor_id = "alpha-readiness-settlement-conveyor:" + _stable_hash(
+        "alpha-readiness-settlement-conveyor",
+        {
+            "source_revenue_repair_ref": source_revenue_repair_ref,
+            "source_commit": source_commit,
+            "selected_hypothesis_id": _text(selected_lane.get("hypothesis_id")),
+            "release_key": _text(selected_lane.get("no_delta_release_key")),
+        },
+    )
+    settlement_receipt = _build_settlement_receipt(
+        conveyor_id=conveyor_id,
+        selected_lane=selected_lane,
+        selected_receipt=selected_receipt,
+        status=status,
+        routeable_before=routeable_before,
+    )
+    settlement = _mapping(settlement_receipt)
+    routeable_after = _int(
+        settlement.get("routeable_candidate_count_after"),
+        routeable_before,
+    )
+    measured_delta = _int(
+        settlement.get("measured_routeable_candidate_delta"),
+        0,
+    )
+    required_receipts = _string_list(selected_lane.get("required_receipts"))
+    validation_commands = _string_list(selected_receipt.get("validation_commands"))
+    validation_commands = _append_unique(
+        validation_commands,
+        "uv run --frozen pytest services/torghut/tests/test_alpha_readiness_settlement_conveyor.py",
+    )
+
+    return {
+        "schema_version": ALPHA_READINESS_SETTLEMENT_CONVEYOR_SCHEMA_VERSION,
+        "conveyor_id": conveyor_id,
+        "generated_at": generated.isoformat(),
+        "fresh_until": fresh_until.isoformat(),
+        "governing_design_ref": _DESIGN_REF,
+        "status": status,
+        "settlement_state": settlement.get("settlement_state", status),
+        "reason_codes": reason_codes,
+        "source_revenue_repair_ref": source_revenue_repair_ref,
+        "source_alpha_evidence_foundry_ref": alpha_evidence_foundry.get("foundry_id"),
+        "source_alpha_repair_closure_board_ref": alpha_repair_closure_board.get(
+            "board_id"
+        ),
+        "source_commit": source_commit,
+        "active_revision": active_revision,
+        "account_id": account_id,
+        "window": window,
+        "trading_mode": trading_mode,
+        "business_state": business_state,
+        "revenue_ready": revenue_ready,
+        "selected_queue_code": _text(top_item.get("code")),
+        "selected_value_gate": _text(
+            top_item.get("value_gate"), "routeable_candidate_count"
+        ),
+        "routeable_candidate_count_before": routeable_before,
+        "routeable_candidate_count_after": routeable_after,
+        "accepted_routeable_candidate_count": _int(
+            _mapping(evidence.get("routeability_acceptance")).get(
+                "accepted_routeable_candidate_count"
+            )
+        ),
+        "measured_routeable_candidate_delta": measured_delta,
+        "zero_notional_or_stale_evidence_rate": _zero_notional_or_stale_evidence_rate(
+            evidence
+        ),
+        "routeability_acceptance_ref": _mapping(
+            evidence.get("routeability_acceptance")
+        ).get("ledger_id"),
+        "capital_state": _text(capital.get("capital_state"), "zero_notional"),
+        "capital_rule": _text(
+            top_item.get("capital_rule"), "zero_notional_repair_only"
+        ),
+        "max_notional": max_notional,
+        "selected_lane": selected_lane,
+        "lane_scores": lanes,
+        "active_no_delta_leases": active_no_delta_leases,
+        "required_receipts": required_receipts,
+        "required_output_receipt": ALPHA_READINESS_SETTLEMENT_RECEIPT_SCHEMA_VERSION,
+        "settlement_receipt": settlement_receipt,
+        "validation_commands": validation_commands,
+        "rollback_target": _ROLLBACK_TARGET,
+    }
+
+
+def compact_alpha_readiness_settlement_conveyor(
+    conveyor: Mapping[str, Any] | None,
+) -> dict[str, object]:
+    """Return the compact Jangar-facing alpha-readiness settlement ref."""
+
+    payload = _mapping(conveyor)
+    if not payload:
+        return {
+            "schema_version": ALPHA_READINESS_SETTLEMENT_CONVEYOR_REF_SCHEMA_VERSION,
+            "status": "missing",
+            "reason_codes": ["alpha_readiness_settlement_conveyor_missing"],
+        }
+    selected_lane = _mapping(payload.get("selected_lane"))
+    settlement_receipt = _mapping(payload.get("settlement_receipt"))
+    validation_commands = _string_list(payload.get("validation_commands"))
+    return {
+        "schema_version": ALPHA_READINESS_SETTLEMENT_CONVEYOR_REF_SCHEMA_VERSION,
+        "conveyor_schema_version": payload.get("schema_version"),
+        "conveyor_id": payload.get("conveyor_id"),
+        "generated_at": payload.get("generated_at"),
+        "fresh_until": payload.get("fresh_until"),
+        "status": payload.get("status"),
+        "settlement_state": payload.get("settlement_state"),
+        "reason_codes": _string_list(payload.get("reason_codes")),
+        "selected_hypothesis_id": selected_lane.get("hypothesis_id"),
+        "selected_value_gate": payload.get("selected_value_gate"),
+        "routeable_candidate_count_before": payload.get(
+            "routeable_candidate_count_before"
+        ),
+        "routeable_candidate_count_after": payload.get(
+            "routeable_candidate_count_after"
+        ),
+        "measured_routeable_candidate_delta": payload.get(
+            "measured_routeable_candidate_delta"
+        ),
+        "active_no_delta_lease_count": len(
+            _sequence(payload.get("active_no_delta_leases"))
+        ),
+        "required_receipt": payload.get("required_output_receipt"),
+        "validation_command": validation_commands[0] if validation_commands else None,
+        "no_delta_release_key": selected_lane.get("no_delta_release_key")
+        or settlement_receipt.get("no_delta_release_key"),
+        "repeat_launch_decision": selected_lane.get("repeat_launch_decision")
+        or settlement_receipt.get("repeat_launch_decision"),
+        "max_notional": payload.get("max_notional"),
+        "capital_rule": payload.get("capital_rule"),
+        "rollback_target": payload.get("rollback_target"),
+    }
+
+
+__all__ = [
+    "ALPHA_READINESS_SETTLEMENT_CONVEYOR_REF_SCHEMA_VERSION",
+    "ALPHA_READINESS_SETTLEMENT_CONVEYOR_SCHEMA_VERSION",
+    "ALPHA_READINESS_SETTLEMENT_RECEIPT_SCHEMA_VERSION",
+    "build_alpha_readiness_settlement_conveyor",
+    "compact_alpha_readiness_settlement_conveyor",
+]

--- a/services/torghut/app/trading/revenue_repair.py
+++ b/services/torghut/app/trading/revenue_repair.py
@@ -12,6 +12,9 @@ from typing import Any, Mapping, Sequence, cast
 
 from .alpha_readiness_strike_ledger import build_alpha_readiness_strike_ledger
 from .alpha_evidence_foundry import build_alpha_evidence_foundry
+from .alpha_readiness_settlement_conveyor import (
+    build_alpha_readiness_settlement_conveyor,
+)
 from .alpha_repair_closure_board import build_alpha_repair_closure_board
 from .executable_alpha_receipts import (
     build_executable_alpha_repair_receipts,
@@ -1017,6 +1020,23 @@ def build_revenue_repair_digest(
             "route_evidence_clearinghouse_packet": route_evidence_clearinghouse,
         },
     )
+    alpha_readiness_settlement_conveyor = build_alpha_readiness_settlement_conveyor(
+        generated_at=generated,
+        business_state=business_state,
+        revenue_ready=revenue_ready,
+        repair_queue=cast(Sequence[Mapping[str, Any]], repair_queue),
+        capital=capital,
+        evidence=evidence,
+        alpha_evidence_foundry=alpha_evidence_foundry,
+        alpha_repair_closure_board=alpha_repair_closure_board,
+        source_serving_metadata={
+            "build": build,
+            "source_serving_repair_receipt_ledger": status_payload.get(
+                "source_serving_repair_receipt_ledger"
+            ),
+            "route_evidence_clearinghouse_packet": route_evidence_clearinghouse,
+        },
+    )
     return {
         "schema_version": SCHEMA_VERSION,
         "generated_at": generated.isoformat(),
@@ -1030,6 +1050,7 @@ def build_revenue_repair_digest(
         "executable_alpha_settlement_slots": executable_alpha_settlement_slots,
         "alpha_repair_closure_board": alpha_repair_closure_board,
         "alpha_evidence_foundry": alpha_evidence_foundry,
+        "alpha_readiness_settlement_conveyor": alpha_readiness_settlement_conveyor,
         "business_state": business_state,
         "revenue_ready": revenue_ready,
         "health": {

--- a/services/torghut/tests/test_alpha_readiness_settlement_conveyor.py
+++ b/services/torghut/tests/test_alpha_readiness_settlement_conveyor.py
@@ -1,0 +1,322 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from copy import deepcopy
+from datetime import datetime, timezone
+from typing import Any, cast
+
+import pytest
+
+from app.trading.alpha_readiness_settlement_conveyor import (
+    build_alpha_readiness_settlement_conveyor,
+    compact_alpha_readiness_settlement_conveyor,
+)
+
+NOW = datetime(2026, 5, 14, 9, 5, tzinfo=timezone.utc)
+
+
+def _repair_queue() -> list[dict[str, object]]:
+    return [
+        {
+            "code": "repair_alpha_readiness",
+            "reason": "alpha_readiness_not_promotion_eligible",
+            "priority": 70,
+            "expected_unblock_value": 2,
+            "value_gate": "routeable_candidate_count",
+            "required_output_receipt": "torghut.executable-alpha-receipts.v1",
+            "required_receipts": [
+                "alpha_readiness_receipt",
+                "hypothesis_promotion_receipt",
+                "capital_replay_board",
+            ],
+            "max_notional": "0",
+            "capital_rule": "zero_notional_repair_only",
+        }
+    ]
+
+
+def _evidence() -> dict[str, object]:
+    return {
+        "routeability_acceptance": {
+            "ledger_id": "routeability-acceptance-ledger:test",
+            "accepted_routeable_candidate_count": 0,
+            "zero_notional_or_stale_evidence_rate": 1,
+        },
+        "repair_bid_settlement": {
+            "ledger_id": "repair-bid-settlement-ledger:test",
+            "account_id": "PA3SX7FYNUTF",
+            "session_id": "15m",
+            "trading_mode": "live",
+            "routeable_candidate_count": 0,
+        },
+        "route_evidence_clearinghouse": {
+            "accepted_routeable_candidate_count": 0,
+        },
+    }
+
+
+def _window_receipt(
+    *,
+    receipt_id: str,
+    hypothesis_id: str,
+    reason_codes: list[str],
+    measured_delta: int = 0,
+    after_refs: list[str] | None = None,
+) -> dict[str, object]:
+    return {
+        "schema_version": "torghut.alpha-evidence-window-receipt.v1",
+        "receipt_id": receipt_id,
+        "source_revenue_repair_ref": "torghut-revenue-repair-digest:test",
+        "hypothesis_id": hypothesis_id,
+        "candidate_id": "chip-paper-microbar-composite@execution-proof",
+        "strategy_id": f"strategy:{hypothesis_id}",
+        "lane_id": "microstructure-breakout"
+        if hypothesis_id == "H-MICRO-01"
+        else "continuation",
+        "strategy_family": "microstructure_breakout"
+        if hypothesis_id == "H-MICRO-01"
+        else "intraday_continuation",
+        "target_value_gate": "routeable_candidate_count",
+        "preserved_reason_codes": reason_codes,
+        "retired_reason_codes": [],
+        "new_reason_codes": [],
+        "after_refs": after_refs or [],
+        "required_after_receipts": [
+            "alpha_readiness_receipt",
+            "capital_replay_board",
+            "hypothesis_promotion_receipt",
+            "torghut.executable-alpha-receipts.v1",
+            "feature_replay_receipt",
+            "drift_check_receipt",
+            "required_feature_set_receipt",
+        ],
+        "measured_routeable_candidate_delta": measured_delta,
+        "no_delta_reason": "routeable_candidate_count_unchanged"
+        if measured_delta <= 0
+        else "",
+        "dedupe_key": f"dedupe:{hypothesis_id}",
+        "max_notional": "0",
+        "capital_rule": "zero_notional_repair_only",
+        "validation_commands": [
+            "uv run --frozen pytest services/torghut/tests/test_executable_alpha_repair_receipts.py -k evidence_window"
+        ],
+    }
+
+
+def _foundry() -> dict[str, object]:
+    return {
+        "schema_version": "torghut.alpha-evidence-foundry.v1",
+        "foundry_id": "alpha-evidence-foundry:test",
+        "status": "selected",
+        "source_revenue_repair_ref": "torghut-revenue-repair-digest:test",
+        "source_commit": "source-sha",
+        "active_revision": "torghut-00384",
+        "selected_queue_code": "repair_alpha_readiness",
+        "selected_value_gate": "routeable_candidate_count",
+        "receipts": [
+            _window_receipt(
+                receipt_id="alpha-evidence-window-receipt:cont",
+                hypothesis_id="H-CONT-01",
+                reason_codes=["post_cost_expectancy_non_positive"],
+            ),
+            _window_receipt(
+                receipt_id="alpha-evidence-window-receipt:micro",
+                hypothesis_id="H-MICRO-01",
+                reason_codes=[
+                    "drift_checks_missing",
+                    "feature_rows_missing",
+                    "required_feature_set_unavailable",
+                ],
+            ),
+            _window_receipt(
+                receipt_id="alpha-evidence-window-receipt:rev",
+                hypothesis_id="H-REV-01",
+                reason_codes=["post_cost_expectancy_non_positive"],
+            ),
+        ],
+    }
+
+
+def _closure_board() -> dict[str, object]:
+    return {
+        "schema_version": "torghut.alpha-repair-closure-board.v1",
+        "board_id": "alpha-repair-closure-board:test",
+        "account_id": "PA3SX7FYNUTF",
+        "window": "15m",
+        "trading_mode": "live",
+        "status": "selected",
+        "alpha_closure_settlement_market": {
+            "market_id": "alpha-closure-settlement-market:test",
+            "selected_hypothesis_id": "H-MICRO-01",
+            "required_after_receipts": [
+                "feature_replay_receipt",
+                "drift_check_receipt",
+                "required_feature_set_receipt",
+            ],
+        },
+    }
+
+
+def _build(
+    *,
+    repair_queue: list[dict[str, object]] | None = None,
+    capital: Mapping[str, Any] | None = None,
+    foundry: Mapping[str, Any] | None = None,
+) -> dict[str, object]:
+    return build_alpha_readiness_settlement_conveyor(
+        generated_at=NOW,
+        business_state="repair_only",
+        revenue_ready=False,
+        repair_queue=repair_queue or _repair_queue(),
+        capital=capital or {"capital_state": "zero_notional", "max_notional": "0"},
+        evidence=_evidence(),
+        alpha_evidence_foundry=foundry or _foundry(),
+        alpha_repair_closure_board=_closure_board(),
+        source_serving_metadata={
+            "build": {
+                "commit": "source-sha",
+                "active_revision": "torghut-00384",
+            }
+        },
+    )
+
+
+def test_alpha_readiness_settlement_conveyor_selects_micro_no_delta_lane() -> None:
+    conveyor = _build()
+
+    assert (
+        conveyor["schema_version"] == "torghut.alpha-readiness-settlement-conveyor.v1"
+    )
+    assert conveyor["status"] == "no_delta"
+    assert conveyor["settlement_state"] == "no_delta"
+    assert conveyor["selected_value_gate"] == "routeable_candidate_count"
+    assert conveyor["routeable_candidate_count_before"] == 0
+    assert conveyor["routeable_candidate_count_after"] == 0
+    assert conveyor["max_notional"] == "0"
+    selected_lane = cast(Mapping[str, Any], conveyor["selected_lane"])
+    assert selected_lane["hypothesis_id"] == "H-MICRO-01"
+    assert selected_lane["repeat_launch_decision"] == "deny"
+    assert selected_lane["no_delta_release_key"]
+    assert "active_no_delta_lease" in conveyor["reason_codes"]
+    leases = cast(list[Mapping[str, Any]], conveyor["active_no_delta_leases"])
+    assert len(leases) == 3
+    assert any(lease["hypothesis_id"] == "H-MICRO-01" for lease in leases)
+    receipt = cast(Mapping[str, Any], conveyor["settlement_receipt"])
+    assert receipt["schema_version"] == "torghut.alpha-readiness-settlement-receipt.v1"
+    assert receipt["hypothesis_id"] == "H-MICRO-01"
+    assert receipt["evidence_window_state"] == "no_delta"
+    assert receipt["drift_state"] == "missing"
+    assert receipt["schema_lineage_state"] == "missing"
+    assert receipt["max_notional"] == "0"
+
+
+def test_alpha_readiness_settlement_conveyor_marks_paid_when_selected_lane_moves() -> (
+    None
+):
+    foundry = deepcopy(_foundry())
+    receipts = cast(list[dict[str, object]], foundry["receipts"])
+    receipts[1] = _window_receipt(
+        receipt_id="alpha-evidence-window-receipt:micro-paid",
+        hypothesis_id="H-MICRO-01",
+        reason_codes=["closed_session_signal_hold"],
+        measured_delta=1,
+        after_refs=[
+            "alpha_readiness_receipt:current",
+            "capital_replay_board:current",
+            "hypothesis_promotion_receipt:current",
+            "feature_replay_receipt:current",
+            "drift_check_receipt:current",
+            "required_feature_set_receipt:current",
+        ],
+    )
+
+    conveyor = _build(foundry=foundry)
+
+    assert conveyor["status"] == "settling"
+    assert conveyor["settlement_state"] == "paid"
+    assert conveyor["routeable_candidate_count_after"] == 1
+    assert conveyor["measured_routeable_candidate_delta"] == 1
+    selected_lane = cast(Mapping[str, Any], conveyor["selected_lane"])
+    assert selected_lane["repeat_launch_decision"] == "allow"
+    receipt = cast(Mapping[str, Any], conveyor["settlement_receipt"])
+    assert receipt["settlement_state"] == "paid"
+    assert "feature_replay_receipt" in receipt["funded_receipts"]
+
+
+def test_alpha_readiness_settlement_conveyor_quarantines_nonzero_notional() -> None:
+    conveyor = _build(capital={"capital_state": "shadow", "max_notional": "25"})
+
+    assert conveyor["status"] == "quarantined"
+    assert conveyor["settlement_state"] == "quarantined"
+    assert "capital_notional_nonzero" in conveyor["reason_codes"]
+    assert conveyor["max_notional"] == "25"
+
+
+def test_alpha_readiness_settlement_conveyor_observes_non_alpha_queue() -> None:
+    conveyor = _build(
+        repair_queue=[
+            {
+                "code": "repair_execution_tca",
+                "reason": "execution_tca_stale",
+                "value_gate": "fill_tca_or_slippage_quality",
+            }
+        ]
+    )
+
+    assert conveyor["status"] == "observing"
+    assert "revenue_repair_top_item_not_alpha_readiness" in conveyor["reason_codes"]
+
+
+def test_alpha_readiness_settlement_release_key_changes_with_blocker_set() -> None:
+    first = _build()
+    changed_foundry = deepcopy(_foundry())
+    receipts = cast(list[dict[str, object]], changed_foundry["receipts"])
+    micro = cast(dict[str, object], receipts[1])
+    micro["preserved_reason_codes"] = [
+        "drift_checks_missing",
+        "feature_rows_missing",
+        "required_feature_set_unavailable",
+        "schema_lineage_missing",
+    ]
+
+    second = _build(foundry=changed_foundry)
+
+    first_lane = cast(Mapping[str, Any], first["selected_lane"])
+    second_lane = cast(Mapping[str, Any], second["selected_lane"])
+    assert first_lane["no_delta_release_key"] != second_lane["no_delta_release_key"]
+
+
+def test_alpha_readiness_settlement_compact_ref_and_missing_payload() -> None:
+    conveyor = _build()
+    compact = compact_alpha_readiness_settlement_conveyor(conveyor)
+
+    assert (
+        compact["schema_version"]
+        == "torghut.alpha-readiness-settlement-conveyor-ref.v1"
+    )
+    assert compact["conveyor_id"] == conveyor["conveyor_id"]
+    assert compact["selected_hypothesis_id"] == "H-MICRO-01"
+    assert compact["settlement_state"] == "no_delta"
+    assert compact["active_no_delta_lease_count"] == 3
+    assert compact["repeat_launch_decision"] == "deny"
+    assert compact["max_notional"] == "0"
+
+    assert compact_alpha_readiness_settlement_conveyor(None) == {
+        "schema_version": "torghut.alpha-readiness-settlement-conveyor-ref.v1",
+        "status": "missing",
+        "reason_codes": ["alpha_readiness_settlement_conveyor_missing"],
+    }
+
+
+def test_alpha_readiness_settlement_conveyor_rejects_naive_generated_at() -> None:
+    with pytest.raises(ValueError, match="generated_at_missing_timezone"):
+        build_alpha_readiness_settlement_conveyor(
+            generated_at=datetime(2026, 5, 14, 9, 5),
+            business_state="repair_only",
+            revenue_ready=False,
+            repair_queue=_repair_queue(),
+            capital={"max_notional": "0"},
+            evidence=_evidence(),
+            alpha_evidence_foundry=_foundry(),
+            alpha_repair_closure_board=_closure_board(),
+        )

--- a/services/torghut/tests/test_build_revenue_repair_digest.py
+++ b/services/torghut/tests/test_build_revenue_repair_digest.py
@@ -491,6 +491,28 @@ class TestBuildRevenueRepairDigest(TestCase):
             "blocked",
         )
         self.assertEqual(len(alpha_foundry["no_delta_debt"]), 1)
+        settlement_conveyor = digest["alpha_readiness_settlement_conveyor"]
+        self.assertIsInstance(settlement_conveyor, dict)
+        self.assertEqual(
+            settlement_conveyor["schema_version"],
+            "torghut.alpha-readiness-settlement-conveyor.v1",
+        )
+        self.assertEqual(settlement_conveyor["status"], "no_delta")
+        self.assertEqual(
+            settlement_conveyor["selected_value_gate"],
+            "routeable_candidate_count",
+        )
+        self.assertEqual(
+            settlement_conveyor["required_output_receipt"],
+            "torghut.alpha-readiness-settlement-receipt.v1",
+        )
+        self.assertEqual(settlement_conveyor["max_notional"], "0")
+        selected_lane = settlement_conveyor["selected_lane"]
+        self.assertIsInstance(selected_lane, dict)
+        self.assertEqual(
+            selected_lane["repeat_launch_decision"],
+            "deny",
+        )
         self.assertEqual(repair_queue[1]["code"], "repair_execution_tca")
         self.assertNotIn("repair_repair_only", [item["code"] for item in repair_queue])
         self.assertIn(

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -1193,6 +1193,13 @@ class TestTradingApi(TestCase):
         )
         self.assertEqual(alpha_foundry["status"], "inactive")
         self.assertEqual(alpha_foundry["max_notional"], "0")
+        settlement_conveyor = payload["alpha_readiness_settlement_conveyor"]
+        self.assertEqual(
+            settlement_conveyor["schema_version"],
+            "torghut.alpha-readiness-settlement-conveyor-ref.v1",
+        )
+        self.assertEqual(settlement_conveyor["status"], "observing")
+        self.assertEqual(settlement_conveyor["max_notional"], "0")
         warrant = payload["route_warrant_exchange"]
         self.assertEqual(
             warrant["schema_version"],
@@ -4278,6 +4285,17 @@ class TestTradingApi(TestCase):
         self.assertIn(
             "alpha_evidence_window_receipts_missing",
             alpha_foundry["reason_codes"],
+        )
+        settlement_conveyor = payload["alpha_readiness_settlement_conveyor"]
+        self.assertEqual(
+            settlement_conveyor["schema_version"],
+            "torghut.alpha-readiness-settlement-conveyor.v1",
+        )
+        self.assertEqual(settlement_conveyor["status"], "blocked")
+        self.assertEqual(settlement_conveyor["max_notional"], "0")
+        self.assertIn(
+            "alpha_readiness_settlement_receipts_missing",
+            settlement_conveyor["reason_codes"],
         )
         self.assertEqual(
             payload["evidence"]["repair_bid_settlement"]["dispatchable_lot_count"],


### PR DESCRIPTION
## Summary

- Added `alpha_readiness_settlement_conveyor` to settle the top `/trading/revenue-repair` blocker, `repair_alpha_readiness`, through deterministic no-delta leases before any paper or live capital release.
- Exported the compact conveyor reference in `/healthz`, `/readyz`, and `/trading/consumer-evidence`, while keeping `repair_only`, `revenue_ready=false`, and zero notional unchanged until deployed evidence proves settlement.
- Updated Torghut rollout notes with design provenance, live revenue-repair evidence, validation, risk, and rollback.
- Governing design: `docs/torghut/design-system/v6/205-torghut-alpha-readiness-settlement-conveyor-and-routeable-profit-runway-2026-05-14.md`; companion requirement signal: `docs/agents/designs/200-jangar-revenue-repair-settlement-conveyor-and-stage-health-custody-2026-05-14.md`.

## Related Issues

None.

## Business Evidence

- Before local change, `2026-05-14T10:03:24Z`: `business_state=repair_only`, `revenue_ready=false`, top queue item `repair_alpha_readiness` / `alpha_readiness_not_promotion_eligible`, `routeable_candidate_count=0`, `zero_notional_or_stale_evidence_rate=1.0`, `max_notional=0`.
- After local implementation, pre-deploy live check at `2026-05-14T10:16:25Z`: source state remains `repair_only`, `revenue_ready=false`, top queue item remains `repair_alpha_readiness`, `accepted_routeable_candidate_count=0`, `zero_notional_or_stale_evidence_rate=1.0`, `max_notional=0`, and `live_submission_allowed=false`.
- Final pre-handoff live check at `2026-05-14T10:55:50Z`: source state remains `repair_only`, `revenue_ready=false`, top queue item remains `repair_alpha_readiness` / `alpha_readiness_not_promotion_eligible`, `alpha_evidence_foundry.status=selected`, and the top queue item keeps `max_notional=0`.
- Selected value gate: `routeable_candidate_count`. The PR improves the path to routeable candidates by converting alpha-readiness drift/feature replay evidence into lease-keyed settlement receipts without weakening capital safety.

## Risk And Rollback

- Risk: this changes revenue-repair and health payload shape by adding one new keyed object. Existing fields are left intact and tests cover missing payloads, compact export, top-queue selection, no-delta leases, paid deltas, and zero-notional quarantine.
- Rollback: revert commit `88e3a63e7` and redeploy the prior Torghut image. No database migration, generated artifact, or live-submission enablement is included.

## Testing

- PASS: `cd services/torghut && /tmp/codex-uv/bin/uv sync --frozen --extra dev`
- PASS: `cd services/torghut && /tmp/codex-uv/bin/uv run --frozen ruff format --check app/trading/alpha_readiness_settlement_conveyor.py app/trading/revenue_repair.py app/main.py tests/test_alpha_readiness_settlement_conveyor.py tests/test_build_revenue_repair_digest.py tests/test_trading_api.py`
- PASS: `cd services/torghut && /tmp/codex-uv/bin/uv run --frozen ruff check app/trading/alpha_readiness_settlement_conveyor.py app/trading/revenue_repair.py app/main.py tests/test_alpha_readiness_settlement_conveyor.py tests/test_build_revenue_repair_digest.py tests/test_trading_api.py`
- PASS: `cd services/torghut && /tmp/codex-uv/bin/uv run --frozen pytest tests/test_alpha_readiness_settlement_conveyor.py`
- PASS: `cd services/torghut && /tmp/codex-uv/bin/uv run --frozen pytest tests/test_alpha_readiness_settlement_conveyor.py tests/test_alpha_evidence_foundry.py tests/test_alpha_repair_closure_board.py tests/test_build_revenue_repair_digest.py tests/test_trading_api.py -k "alpha or revenue_repair or consumer_evidence or settlement_conveyor"`
- PASS: `cd services/torghut && /tmp/codex-uv/bin/uv run --frozen pytest tests/test_alpha_readiness_settlement_conveyor.py tests/test_alpha_evidence_foundry.py tests/test_alpha_repair_closure_board.py tests/test_build_revenue_repair_digest.py tests/test_trading_api.py -k "alpha or revenue_repair or consumer_evidence or settlement_conveyor" --cov --cov-branch --cov-fail-under=0 --cov-report=xml --cov-report=`
- PASS: `cd services/torghut && /tmp/codex-uv/bin/uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90` (`273/287`, `95.12%`)
- PASS: `cd services/torghut && /tmp/codex-uv/bin/uv run --frozen python scripts/check_migration_graph.py`
- PASS: `cd services/torghut && /tmp/codex-uv/bin/uv run --frozen pyright --project pyrightconfig.json`
- PASS: `cd services/torghut && /tmp/codex-uv/bin/uv run --frozen pyright --project pyrightconfig.alpha.json`
- PASS: `cd services/torghut && /tmp/codex-uv/bin/uv run --frozen pyright --project pyrightconfig.scripts.json`
- PARTIAL: `cd services/torghut && /tmp/codex-uv/bin/uv run --frozen pytest --cov --cov-branch --cov-report=term-missing --cov-report=xml` was stopped after 25 minutes at `1403 passed`, no failures observed; CI runs the slow whitepaper coverage path separately.
- PASS: GitHub checks are green for PR 6605: changed-file check, semantic commit, PR title, Torghut changed-file plan, Pyright, bytecode/lint/migration guard, pytest shards 0-3, autoresearch runners 0-7, quality signals, and aggregate `Bytecode + pytest + coverage`.
- PASS: PR 6605 is cleanly mergeable (`mergeStateStatus=CLEAN`, draft=false).

## Screenshots (if applicable)

N/A; backend/runtime payload change only.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
