### PR TITLE
fix(torghut): carry database proof into consumer evidence

### DIFF
--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -2992,6 +2992,13 @@ def _build_trading_consumer_evidence_payload() -> dict[str, object]:
     lean_authority_status = _lean_authority_status()
     with SessionLocal() as session:
         tca_summary = _load_tca_summary(session, scheduler=scheduler)
+        readiness_dependencies, _readiness_checked_at, _readiness_cache_used = (
+            _readiness_dependency_snapshot(
+                session,
+                include_database_contract=True,
+                allow_stale_dependency_cache=True,
+            )
+        )
     market_context_status = scheduler.market_context_status()
     hypothesis_payload, hypothesis_summary, _dependency_quorum = (
         _build_hypothesis_runtime_payload(
@@ -3155,7 +3162,7 @@ def _build_trading_consumer_evidence_payload() -> dict[str, object]:
             "proof_floor": proof_floor,
             "live_submission_gate": live_submission_gate,
             "quant_evidence": quant_evidence,
-            "dependencies": {},
+            "dependencies": readiness_dependencies,
         },
         status_payload={
             "mode": settings.trading_mode,

--- a/services/torghut/tests/test_build_revenue_repair_digest.py
+++ b/services/torghut/tests/test_build_revenue_repair_digest.py
@@ -569,6 +569,27 @@ class TestBuildRevenueRepairDigest(TestCase):
         )
         self.assertEqual(route_reacquisition["expected_unblock_value"], 13)
 
+    def test_repair_only_payload_carries_readyz_database_contract(self) -> None:
+        readyz_payload = _repair_only_readyz()
+        dependencies = readyz_payload["dependencies"]
+        self.assertIsInstance(dependencies, dict)
+        dependencies["database"] = {
+            "ok": True,
+            "schema_current": True,
+            "schema_current_heads": ["0029_live_submission_gate"],
+        }
+
+        digest = build_revenue_repair_digest(
+            readyz_payload=readyz_payload,
+            status_payload=_repair_only_status(),
+            generated_at=NOW,
+        )
+
+        closure_board = digest["alpha_repair_closure_board"]
+        self.assertIsInstance(closure_board, dict)
+        self.assertTrue(closure_board["db_schema_current"])
+        self.assertNotIn("db_check_not_provided", closure_board["reason_codes"])
+
     def test_digest_defaults_generated_at_and_handles_missing_tca_dimension(
         self,
     ) -> None:

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -1081,11 +1081,31 @@ class TestTradingApi(TestCase):
                 "app.main.build_profitability_proof_floor_receipt",
                 return_value=proof_floor,
             ),
+            patch(
+                "app.main._readiness_dependency_snapshot",
+                return_value=(
+                    {
+                        "database": {
+                            "ok": True,
+                            "schema_current": True,
+                            "schema_current_heads": ["0029_live_submission_gate"],
+                        }
+                    },
+                    datetime(2026, 5, 8, 3, 54, 41, tzinfo=timezone.utc),
+                    True,
+                ),
+            ) as readiness_snapshot,
             patch("app.main.SessionLocal", self.session_local),
         ):
             response = self.client.get("/trading/consumer-evidence")
 
         self.assertEqual(response.status_code, 200)
+        self.assertTrue(
+            readiness_snapshot.call_args.kwargs["include_database_contract"]
+        )
+        self.assertTrue(
+            readiness_snapshot.call_args.kwargs["allow_stale_dependency_cache"]
+        )
         payload = response.json()
         self.assertEqual(
             payload["schema_version"], "torghut.consumer-evidence-status.v1"
@@ -1186,6 +1206,7 @@ class TestTradingApi(TestCase):
         )
         self.assertEqual(alpha_repair_closure["status"], "inactive")
         self.assertEqual(alpha_repair_closure["max_notional"], "0")
+        self.assertNotIn("db_check_not_provided", alpha_repair_closure["reason_codes"])
         alpha_foundry = payload["alpha_evidence_foundry"]
         self.assertEqual(
             alpha_foundry["schema_version"],


### PR DESCRIPTION
## Summary

- Carries Torghut readiness dependency evidence, including the database contract, into `/trading/consumer-evidence` revenue-repair digest construction.
- Prevents Jangar-facing alpha repair closure evidence from reporting `db_check_not_provided` when Torghut already has current schema proof.
- Adds regression coverage for the direct digest path and the API path that builds consumer evidence without recursive Jangar status fetches.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_build_revenue_repair_digest.py -k 'readyz_database_contract or repair_only_payload_prioritizes'`
- `uv run --frozen pytest tests/test_trading_api.py -k 'consumer_evidence_avoids_recursive_jangar_status_fetch'`
- `uv run --frozen ruff format --check app/main.py tests/test_build_revenue_repair_digest.py tests/test_trading_api.py`
- `uv run --frozen ruff check app/main.py tests/test_build_revenue_repair_digest.py tests/test_trading_api.py`
- `git diff --check`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen pytest tests/test_build_revenue_repair_digest.py`
- `uv run --frozen pytest tests/test_trading_api.py`

## Screenshots (if applicable)

N/A, API evidence-path change only.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.

No `@codex` review was requested for this PR.
