### PR TITLE
fix(torghut): mount autoresearch feedback evidence

### DIFF
--- a/argocd/applications/torghut/kustomization.yaml
+++ b/argocd/applications/torghut/kustomization.yaml
@@ -18,6 +18,7 @@ resources:
   - serviceaccount.yaml
   - role.yaml
   - rolebinding.yaml
+  - workflow-controller-configmap-rbac.yaml
   - rollouts-analysis-role.yaml
   - rollouts-analysis-rolebinding-codex-workflow.yaml
   - rollouts-analysis-rolebinding-runtime.yaml

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -20,6 +20,10 @@ spec:
         value: ''
       - name: feedbackEvidenceJsonlB64
         value: ''
+      - name: feedbackEvidenceConfigMapName
+        value: torghut-whitepaper-autoresearch-feedback-evidence
+      - name: feedbackEvidenceConfigMapKey
+        value: feedback-evidence.jsonl
       - name: seedRecentWhitepapers
         value: 'true'
       - name: symbols
@@ -64,13 +68,15 @@ spec:
     - name: run
       nodeSelector:
         kubernetes.io/arch: arm64
-      activeDeadlineSeconds: 10800
+      activeDeadlineSeconds: 21600
       inputs:
         parameters:
           - name: runId
           - name: outputRoot
           - name: sourceJsonlB64
           - name: feedbackEvidenceJsonlB64
+          - name: feedbackEvidenceConfigMapName
+          - name: feedbackEvidenceConfigMapKey
           - name: seedRecentWhitepapers
           - name: symbols
           - name: fullWindowStartDate
@@ -114,9 +120,18 @@ spec:
                 key: torghut_password
           - name: TRADING_STRATEGY_CONFIG_PATH
             value: /etc/torghut/strategies.yaml
+          - name: TORGHUT_WHITEPAPER_SOURCE_JSONL_B64
+            value: "{{inputs.parameters.sourceJsonlB64}}"
+          - name: TORGHUT_WHITEPAPER_FEEDBACK_EVIDENCE_JSONL_B64
+            value: "{{inputs.parameters.feedbackEvidenceJsonlB64}}"
+          - name: TORGHUT_WHITEPAPER_FEEDBACK_EVIDENCE_CONFIGMAP_PATH
+            value: /var/run/torghut-feedback/feedback-evidence.jsonl
         volumeMounts:
           - name: strategy-config
             mountPath: /etc/torghut
+            readOnly: true
+          - name: feedback-evidence
+            mountPath: /var/run/torghut-feedback
             readOnly: true
         resources:
           requests:
@@ -177,12 +192,15 @@ spec:
             if [ "{{inputs.parameters.seedRecentWhitepapers}}" = "true" ]; then
               SCRIPT_ARGS+=(--seed-recent-whitepapers)
             fi
-            if [ -n "{{inputs.parameters.sourceJsonlB64}}" ]; then
-              printf '%s' "{{inputs.parameters.sourceJsonlB64}}" | base64 -d > "${SOURCE_JSONL}"
+            if [ -n "${TORGHUT_WHITEPAPER_SOURCE_JSONL_B64}" ]; then
+              printf '%s' "${TORGHUT_WHITEPAPER_SOURCE_JSONL_B64}" | base64 -d > "${SOURCE_JSONL}"
               SCRIPT_ARGS+=(--source-jsonl "${SOURCE_JSONL}")
             fi
-            if [ -n "{{inputs.parameters.feedbackEvidenceJsonlB64}}" ]; then
-              printf '%s' "{{inputs.parameters.feedbackEvidenceJsonlB64}}" | base64 -d > "${FEEDBACK_EVIDENCE_JSONL}"
+            if [ -s "${TORGHUT_WHITEPAPER_FEEDBACK_EVIDENCE_CONFIGMAP_PATH:-}" ]; then
+              cp "${TORGHUT_WHITEPAPER_FEEDBACK_EVIDENCE_CONFIGMAP_PATH}" "${FEEDBACK_EVIDENCE_JSONL}"
+              SCRIPT_ARGS+=(--feedback-evidence-jsonl "${FEEDBACK_EVIDENCE_JSONL}")
+            elif [ -n "${TORGHUT_WHITEPAPER_FEEDBACK_EVIDENCE_JSONL_B64}" ]; then
+              printf '%s' "${TORGHUT_WHITEPAPER_FEEDBACK_EVIDENCE_JSONL_B64}" | base64 -d > "${FEEDBACK_EVIDENCE_JSONL}"
               SCRIPT_ARGS+=(--feedback-evidence-jsonl "${FEEDBACK_EVIDENCE_JSONL}")
             fi
             if [ -n "{{inputs.parameters.fullWindowStartDate}}" ]; then
@@ -215,6 +233,13 @@ spec:
             items:
               - key: strategies.yaml
                 path: strategies.yaml
+        - name: feedback-evidence
+          configMap:
+            name: "{{inputs.parameters.feedbackEvidenceConfigMapName}}"
+            optional: true
+            items:
+              - key: "{{inputs.parameters.feedbackEvidenceConfigMapKey}}"
+                path: feedback-evidence.jsonl
       outputs:
         artifacts:
           - name: whitepaper-autoresearch-output

--- a/argocd/applications/torghut/workflow-controller-configmap-rbac.yaml
+++ b/argocd/applications/torghut/workflow-controller-configmap-rbac.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: torghut-workflow-controller-configmaps
+  namespace: torghut
+rules:
+  - apiGroups: ['']
+    resources: ['configmaps']
+    verbs: ['get', 'list', 'watch', 'create', 'update', 'patch', 'delete']
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: torghut-workflow-controller-configmaps
+  namespace: torghut
+subjects:
+  - kind: ServiceAccount
+    name: argo-workflows-workflow-controller
+    namespace: argo-workflows
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: torghut-workflow-controller-configmaps

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -228,7 +228,21 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         template = template_path.read_text()
 
         self.assertIn("name: feedbackEvidenceJsonlB64", template)
+        self.assertIn("name: feedbackEvidenceConfigMapName", template)
+        self.assertIn("name: feedbackEvidenceConfigMapKey", template)
         self.assertIn("--feedback-evidence-jsonl", template)
+        self.assertIn("TORGHUT_WHITEPAPER_FEEDBACK_EVIDENCE_JSONL_B64", template)
+        self.assertIn("TORGHUT_WHITEPAPER_FEEDBACK_EVIDENCE_CONFIGMAP_PATH", template)
+        self.assertIn("TORGHUT_WHITEPAPER_SOURCE_JSONL_B64", template)
+        self.assertIn("name: feedback-evidence", template)
+        self.assertNotIn(
+            "printf '%s' \"{{inputs.parameters.feedbackEvidenceJsonlB64}}\"",
+            template,
+        )
+        self.assertNotIn(
+            "printf '%s' \"{{inputs.parameters.sourceJsonlB64}}\"",
+            template,
+        )
         self.assertIn(
             'if [ -n "{{inputs.parameters.fullWindowStartDate}}" ]; then',
             template,


### PR DESCRIPTION
## Summary

- Adds torghut-scoped RBAC so the Argo workflow-controller can create and update ConfigMaps needed for large autoresearch workflow payloads.
- Adds ConfigMap-backed feedback evidence inputs to the Torghut whitepaper autoresearch WorkflowTemplate, with the Base64 parameter fallback kept for small payloads.
- Extends the strict autoresearch workflow deadline to six hours so feedback-fed replays are not killed by the old three-hour cap.
- Adds regression coverage that the template exposes ConfigMap feedback inputs and avoids inlining large Base64 payloads into the bash script.

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/torghut >/tmp/torghut-feedback-template-render.yaml`
- `uv run --frozen ruff format --check tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv run --frozen ruff check tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py -k 'workflow_template_surfaces_feedback or feedback_evidence_jsonl_round_trips'`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `bun run lint:argocd`
- Manual: submitted `torghut-profit-feedback-cm-111732` with evidence mounted from ConfigMap `torghut-feedback-strict-95sqq`; pod reached `2/2 Running` and logs show real replay activity.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
