### PR TITLE
feat(torghut): add alpha repair dividend ledger

### DIFF
--- a/docs/torghut/design-system/README.md
+++ b/docs/torghut/design-system/README.md
@@ -35,6 +35,10 @@ The v1 documents are written to stay consistent with:
 If you are trying to decide which docs are current contract truth versus historical milestone records, start with:
 
 - `docs/torghut/design-system/current-source-of-truth-and-priority-guide-2026-03-09.md`
+- `docs/torghut/design-system/v6/205-torghut-alpha-readiness-settlement-conveyor-and-routeable-profit-runway-2026-05-14.md`
+- `docs/agents/designs/200-jangar-revenue-repair-settlement-conveyor-and-stage-health-custody-2026-05-14.md`
+- `docs/torghut/design-system/v6/204-torghut-alpha-repair-dividend-ledger-and-custody-flight-recorder-2026-05-14.md`
+- `docs/agents/designs/199-jangar-material-action-custody-flight-recorder-and-merge-reentry-slo-2026-05-14.md`
 - `docs/torghut/design-system/v6/197-torghut-alpha-readiness-strike-ledger-and-routeable-candidate-ladder-2026-05-13.md`
 - `docs/agents/designs/192-jangar-alpha-readiness-repair-escrow-and-runner-admission-2026-05-13.md`
 - `docs/torghut/design-system/v6/190-torghut-repair-bid-settlement-and-routeability-proof-compaction-2026-05-13.md`

--- a/docs/torghut/rollouts/2026-05-14-alpha-repair-dividend-ledger.md
+++ b/docs/torghut/rollouts/2026-05-14-alpha-repair-dividend-ledger.md
@@ -1,0 +1,88 @@
+# Torghut Alpha Repair Dividend Ledger Rollout
+
+This rollout note covers the observe-only Torghut alpha repair dividend ledger for the current
+`repair_alpha_readiness` revenue blocker.
+
+## Governing Design
+
+- `docs/torghut/design-system/v6/204-torghut-alpha-repair-dividend-ledger-and-custody-flight-recorder-2026-05-14.md`
+- Companion contract:
+  `docs/agents/designs/199-jangar-material-action-custody-flight-recorder-and-merge-reentry-slo-2026-05-14.md`
+- Upstream conveyor contract:
+  `docs/torghut/design-system/v6/205-torghut-alpha-readiness-settlement-conveyor-and-routeable-profit-runway-2026-05-14.md`
+
+## Revenue Evidence
+
+Read-only source: `GET http://torghut.torghut.svc.cluster.local/trading/revenue-repair`.
+
+Before implementation, 2026-05-14T11:05:48Z:
+
+- `business_state=repair_only`
+- `revenue_ready=false`
+- top queue item: `repair_alpha_readiness` / `alpha_readiness_not_promotion_eligible`
+- affected value gate: `routeable_candidate_count`
+- `routeable_candidate_count=0`
+- `zero_notional_or_stale_evidence_rate=1.0`
+- `max_notional=0`
+- active live source commit: `6f7f0fbd2f7746a62d899c2962662caba97020b2`
+- `alpha_readiness_settlement_conveyor` was not yet present in the live payload
+- `alpha_repair_dividend_ledger` was not yet present in the live payload
+
+After local implementation, live pre-deploy evidence is expected to remain repair-only until image promotion:
+
+- `business_state=repair_only`
+- `revenue_ready=false`
+- top queue item remains `repair_alpha_readiness` until alpha readiness is actually settled
+- `max_notional=0`
+- live submission remains disabled
+
+## What Shipped
+
+- Added `torghut.alpha-repair-dividend-ledger.v1` as a pure Torghut read-model under `/trading/revenue-repair`.
+- Added compact `torghut.alpha-repair-dividend-ledger-ref.v1` mirrors to `/readyz` and
+  `/trading/consumer-evidence`.
+- The ledger records selected hypothesis, value gate, before/after routeable candidate counts, measured delta,
+  preserved/retired blockers, no-delta release key, required receipts, validation command, and Jangar custody
+  launch decision.
+- Repeated no-delta alpha repair is `launch_decision=deny` until source ref, evidence window, blocker set, or required
+  receipt set changes.
+- Preserved `max_notional=0`, `capital_rule=zero_notional_repair_only`, and live submission disabled.
+
+## Validation
+
+- `cd services/torghut && /tmp/codex-uv-bootstrap/bin/uv sync --frozen --extra dev`
+- `cd services/torghut && /tmp/codex-uv-bootstrap/bin/uv run --frozen ruff format --check app/trading/alpha_repair_dividend_ledger.py app/trading/revenue_repair.py app/main.py tests/test_alpha_repair_dividend_ledger.py tests/test_build_revenue_repair_digest.py tests/test_trading_api.py`
+- `cd services/torghut && /tmp/codex-uv-bootstrap/bin/uv run --frozen ruff check app/trading/alpha_repair_dividend_ledger.py app/trading/revenue_repair.py app/main.py tests/test_alpha_repair_dividend_ledger.py tests/test_build_revenue_repair_digest.py tests/test_trading_api.py`
+- `cd services/torghut && /tmp/codex-uv-bootstrap/bin/uv run --frozen pytest tests/test_alpha_repair_dividend_ledger.py tests/test_build_revenue_repair_digest.py tests/test_trading_api.py -k "alpha_repair_dividend or revenue_repair or consumer_evidence"`:
+  pass, 27 selected tests
+- `cd services/torghut && /tmp/codex-uv-bootstrap/bin/uv run --frozen pytest tests/test_alpha_repair_dividend_ledger.py tests/test_alpha_readiness_settlement_conveyor.py tests/test_alpha_evidence_foundry.py tests/test_alpha_repair_closure_board.py tests/test_build_revenue_repair_digest.py tests/test_trading_api.py -k "alpha or revenue_repair or consumer_evidence or settlement_conveyor or dividend" --cov --cov-branch --cov-fail-under=0 --cov-report=xml --cov-report=`:
+  pass, 54 selected tests
+- `cd services/torghut && /tmp/codex-uv-bootstrap/bin/uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90`:
+  pass, changed-line coverage 202/216 (93.52%)
+- `cd services/torghut && /tmp/codex-uv-bootstrap/bin/uv run --frozen pytest tests/test_repair_bid_settlement.py -k promotion_custody`:
+  pass, 1 selected test
+- `cd services/torghut && /tmp/codex-uv-bootstrap/bin/uv run --frozen pytest tests/test_executable_alpha_repair_receipts.py -k evidence_window`:
+  pass, 1 selected test
+- `cd services/torghut && /tmp/codex-uv-bootstrap/bin/uv run --frozen python scripts/check_migration_graph.py`:
+  pass
+- `cd services/torghut && /tmp/codex-uv-bootstrap/bin/uv run --frozen pyright --project pyrightconfig.json`:
+  pass
+- `cd services/torghut && /tmp/codex-uv-bootstrap/bin/uv run --frozen pyright --project pyrightconfig.alpha.json`:
+  pass
+- `cd services/torghut && /tmp/codex-uv-bootstrap/bin/uv run --frozen pyright --project pyrightconfig.scripts.json`:
+  pass
+
+## Risk And Rollback
+
+Risk is limited to additive evidence payloads on Torghut revenue repair, health, and consumer evidence. The ledger is
+observe-only and does not execute trades, mutate broker state, change database rows, or alter submit gates.
+
+Rollback is to revert this PR or stop emitting `alpha_repair_dividend_ledger` and the compact dividend ledger ref.
+Existing revenue-repair, alpha evidence foundry, alpha readiness settlement conveyor, proof floor, and capital holds
+remain the fallback surfaces. Capital stays `max_notional=0`.
+
+## Owner Status
+
+The revenue metric targeted is `routeable_candidate_count`. The current smallest revenue blocker remains
+`alpha_readiness_not_promotion_eligible`; this PR adds compact dividend accounting so Torghut and Jangar can prove
+whether the selected alpha repair paid, no-deltaed, or must be held before another zero-notional repair launch.

--- a/services/torghut/README.md
+++ b/services/torghut/README.md
@@ -229,6 +229,12 @@ Testing rules for the trading core:
   `torghut.alpha-evidence-window-receipt.v1` receipts with feature, drift, post-cost, market-context, TCA,
   route-universe, no-delta, and zero-notional fields. `/readyz` and `/trading/consumer-evidence` mirror only the
   compact `torghut.alpha-evidence-foundry-ref.v1` fields for Jangar admission.
+- `GET /trading/revenue-repair` also emits the May 14 doc 205
+  `torghut.alpha-readiness-settlement-conveyor.v1` read-model and the May 14 doc 204
+  `torghut.alpha-repair-dividend-ledger.v1` accounting surface. The conveyor selects the current
+  zero-notional alpha-readiness lane, and the dividend ledger records whether that lane paid
+  `routeable_candidate_count`, produced no-delta debt, or must be blocked/stale before another material repair launch.
+  `/readyz` and `/trading/consumer-evidence` mirror compact refs for Jangar custody while keeping `max_notional=0`.
 - `GET /trading/status` and `GET /readyz` now include the May 8 doc 181
   `quality_adjusted_profit_frontier` shadow projection. The reducer ranks zero-notional repair packets from quant
   quality, market-context risk flags, route/TCA state, simulation-cache freshness, and Jangar evidence-quality refs

--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -53,6 +53,9 @@ from .trading.alpha_evidence_foundry import compact_alpha_evidence_foundry
 from .trading.alpha_readiness_settlement_conveyor import (
     compact_alpha_readiness_settlement_conveyor,
 )
+from .trading.alpha_repair_dividend_ledger import (
+    compact_alpha_repair_dividend_ledger,
+)
 from .trading.alpha_repair_closure_board import compact_alpha_repair_closure_board
 from .trading.autonomy import (
     assert_runtime_gate_policy_contract,
@@ -1150,6 +1153,12 @@ def _evaluate_trading_health_payload(
                 cast(
                     Mapping[str, Any],
                     revenue_repair_digest.get("alpha_readiness_settlement_conveyor"),
+                )
+            ),
+            "alpha_repair_dividend_ledger": compact_alpha_repair_dividend_ledger(
+                cast(
+                    Mapping[str, Any],
+                    revenue_repair_digest.get("alpha_repair_dividend_ledger"),
                 )
             ),
             "route_reacquisition_book": proof_floor.get("route_reacquisition_book"),
@@ -3359,6 +3368,12 @@ def _build_trading_consumer_evidence_payload() -> dict[str, object]:
             cast(
                 Mapping[str, Any],
                 revenue_repair_digest.get("alpha_readiness_settlement_conveyor"),
+            )
+        ),
+        "alpha_repair_dividend_ledger": compact_alpha_repair_dividend_ledger(
+            cast(
+                Mapping[str, Any],
+                revenue_repair_digest.get("alpha_repair_dividend_ledger"),
             )
         ),
         "route_warrant_exchange": route_warrant_exchange,

--- a/services/torghut/app/trading/alpha_repair_dividend_ledger.py
+++ b/services/torghut/app/trading/alpha_repair_dividend_ledger.py
@@ -1,0 +1,637 @@
+"""Alpha repair dividend accounting for routeable-candidate evidence."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from datetime import datetime, timedelta, timezone
+from typing import Any, cast
+
+ALPHA_REPAIR_DIVIDEND_LEDGER_SCHEMA_VERSION = "torghut.alpha-repair-dividend-ledger.v1"
+ALPHA_REPAIR_DIVIDEND_LEDGER_REF_SCHEMA_VERSION = (
+    "torghut.alpha-repair-dividend-ledger-ref.v1"
+)
+
+_DESIGN_REF = (
+    "docs/torghut/design-system/v6/"
+    "204-torghut-alpha-repair-dividend-ledger-and-custody-flight-recorder-2026-05-14.md"
+)
+_COMPANION_JANGAR_DESIGN_REF = (
+    "docs/agents/designs/"
+    "199-jangar-material-action-custody-flight-recorder-and-merge-reentry-slo-2026-05-14.md"
+)
+_JANGAR_RECORDER_SCHEMA = "jangar.material-action-custody-flight-recorder.v1"
+_DEFAULT_FRESHNESS_SECONDS = 15 * 60
+_ZERO_NOTIONAL_VALUES = {"0", "0.0", "0.00", "0.0000"}
+_ROLLBACK_TARGET = (
+    "stop emitting alpha_repair_dividend_ledger, keep revenue-repair diagnostics, "
+    "and keep Torghut max_notional=0"
+)
+_NO_DELTA_RELEASE_CONDITIONS = [
+    "source_ref_changes",
+    "evidence_window_changes",
+    "blocker_set_changes",
+    "required_receipt_changes",
+]
+
+
+def _mapping(value: object) -> Mapping[str, Any]:
+    if isinstance(value, Mapping):
+        return cast(Mapping[str, Any], value)
+    return {}
+
+
+def _sequence(value: object) -> Sequence[object]:
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return cast(Sequence[object], value)
+    return ()
+
+
+def _text(value: object, default: str = "") -> str:
+    if value is None:
+        return default
+    normalized = str(value).strip()
+    return normalized or default
+
+
+def _int(value: object, default: int = 0) -> int:
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if isinstance(value, str) and value.strip():
+        try:
+            return int(float(value.strip()))
+        except ValueError:
+            return default
+    return default
+
+
+def _string_list(value: object) -> list[str]:
+    result: list[str] = []
+    seen: set[str] = set()
+    for item in _sequence(value):
+        normalized = _text(item)
+        if not normalized or normalized in seen:
+            continue
+        seen.add(normalized)
+        result.append(normalized)
+    return result
+
+
+def _append_unique(items: list[str], *values: object) -> list[str]:
+    seen = set(items)
+    for value in values:
+        if isinstance(value, Sequence) and not isinstance(
+            value, (str, bytes, bytearray)
+        ):
+            candidates = _string_list(cast(Sequence[object], value))
+        else:
+            candidates = [_text(value)]
+        for candidate in candidates:
+            if not candidate or candidate in seen:
+                continue
+            seen.add(candidate)
+            items.append(candidate)
+    return items
+
+
+def _stable_hash(prefix: str, payload: Mapping[str, object]) -> str:
+    encoded = json.dumps(
+        {"prefix": prefix, **dict(payload)},
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()[:24]
+
+
+def _parse_datetime(value: object) -> datetime | None:
+    raw = _text(value)
+    if not raw:
+        return None
+    normalized = raw[:-1] + "+00:00" if raw.endswith("Z") else raw
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return None
+    return parsed.astimezone(timezone.utc)
+
+
+def _top_queue_item(repair_queue: Sequence[Mapping[str, Any]]) -> Mapping[str, Any]:
+    for item in repair_queue:
+        payload = _mapping(item)
+        if payload:
+            return payload
+    return {}
+
+
+def _is_alpha_repair(item: Mapping[str, Any]) -> bool:
+    return (
+        _text(item.get("code")) == "repair_alpha_readiness"
+        or _text(item.get("reason")) == "alpha_readiness_not_promotion_eligible"
+    )
+
+
+def _routeable_candidate_count(evidence: Mapping[str, Any]) -> int:
+    repair_bid_settlement = _mapping(evidence.get("repair_bid_settlement"))
+    routeability_acceptance = _mapping(evidence.get("routeability_acceptance"))
+    route_clearinghouse = _mapping(evidence.get("route_evidence_clearinghouse"))
+    return max(
+        _int(repair_bid_settlement.get("routeable_candidate_count")),
+        _int(routeability_acceptance.get("accepted_routeable_candidate_count")),
+        _int(route_clearinghouse.get("accepted_routeable_candidate_count")),
+    )
+
+
+def _source_revenue_repair_ref(
+    alpha_readiness_settlement_conveyor: Mapping[str, Any],
+    alpha_evidence_foundry: Mapping[str, Any],
+    executable_alpha_repair_receipts: Mapping[str, Any],
+) -> str:
+    return (
+        _text(alpha_readiness_settlement_conveyor.get("source_revenue_repair_ref"))
+        or _text(alpha_evidence_foundry.get("source_revenue_repair_ref"))
+        or _text(executable_alpha_repair_receipts.get("source_revenue_repair_ref"))
+        or "torghut-revenue-repair-digest:unknown"
+    )
+
+
+def _receipt_ids(payload: Mapping[str, Any], field_name: str) -> list[str]:
+    ids: list[str] = []
+    for raw_receipt in _sequence(payload.get(field_name)):
+        receipt = _mapping(raw_receipt)
+        receipt_id = _text(receipt.get("receipt_id"))
+        if receipt_id:
+            ids.append(receipt_id)
+    return ids
+
+
+def _selected_executable_receipt(
+    executable_alpha_repair_receipts: Mapping[str, Any],
+) -> Mapping[str, Any]:
+    selected = _mapping(executable_alpha_repair_receipts.get("selected_receipt"))
+    if selected:
+        return selected
+    for raw_receipt in _sequence(executable_alpha_repair_receipts.get("receipts")):
+        receipt = _mapping(raw_receipt)
+        if receipt:
+            return receipt
+    return {}
+
+
+def _closure_market(
+    alpha_repair_closure_board: Mapping[str, Any],
+) -> Mapping[str, Any]:
+    return _mapping(alpha_repair_closure_board.get("alpha_closure_settlement_market"))
+
+
+def _pending_closure_receipt(
+    alpha_repair_closure_board: Mapping[str, Any],
+) -> Mapping[str, Any]:
+    return _mapping(
+        _closure_market(alpha_repair_closure_board).get("pending_settlement_receipt")
+    )
+
+
+def _release_key(
+    *,
+    alpha_readiness_settlement_conveyor: Mapping[str, Any],
+    selected_lane: Mapping[str, Any],
+    settlement_receipt: Mapping[str, Any],
+    source_revenue_repair_ref: str,
+    selected_hypothesis_id: str,
+    preserved_reason_codes: Sequence[str],
+    required_receipts: Sequence[str],
+) -> str:
+    explicit = _text(selected_lane.get("no_delta_release_key")) or _text(
+        settlement_receipt.get("no_delta_release_key")
+    )
+    if explicit:
+        return explicit
+    return _stable_hash(
+        "alpha-repair-dividend-release-key",
+        {
+            "source_revenue_repair_ref": source_revenue_repair_ref,
+            "source_commit": _text(
+                alpha_readiness_settlement_conveyor.get("source_commit")
+            ),
+            "hypothesis_id": selected_hypothesis_id,
+            "preserved_reason_codes": list(preserved_reason_codes),
+            "required_receipts": list(required_receipts),
+        },
+    )
+
+
+def _dividend_state(
+    *,
+    reason_codes: Sequence[str],
+    settlement_state: str,
+    measured_delta: int,
+    repeat_launch_decision: str,
+) -> str:
+    reason_set = set(reason_codes)
+    if "alpha_readiness_settlement_conveyor_stale" in reason_set:
+        return "stale"
+    blocked_reasons = {
+        "alpha_readiness_settlement_conveyor_missing",
+        "alpha_repair_settlement_receipt_missing",
+        "capital_notional_nonzero",
+        "revenue_repair_top_item_not_alpha_readiness",
+        "selected_value_gate_not_routeable_candidate_count",
+    }
+    if reason_set.intersection(blocked_reasons):
+        return "blocked"
+    if measured_delta > 0 or settlement_state == "paid":
+        return "paid"
+    if repeat_launch_decision == "deny" or settlement_state == "no_delta":
+        return "no_delta"
+    return "pending"
+
+
+def _launch_decision(dividend_state: str) -> str:
+    if dividend_state == "paid":
+        return "allow"
+    if dividend_state == "pending":
+        return "hold"
+    return "deny"
+
+
+def _hypothesis_dividends(
+    *,
+    lanes: Sequence[object],
+    selected_hypothesis_id: str,
+    source_revenue_repair_ref: str,
+) -> list[dict[str, object]]:
+    dividends: list[dict[str, object]] = []
+    for raw_lane in lanes:
+        lane = _mapping(raw_lane)
+        if not lane:
+            continue
+        measured_delta = _int(lane.get("measured_routeable_candidate_delta"))
+        repeat_launch_decision = _text(lane.get("repeat_launch_decision"), "hold")
+        state = "paid" if measured_delta > 0 else "no_delta"
+        if repeat_launch_decision not in {"allow", "deny"}:
+            state = "pending"
+        hypothesis_id = _text(lane.get("hypothesis_id"))
+        dividends.append(
+            {
+                "hypothesis_id": hypothesis_id,
+                "candidate_id": lane.get("candidate_id"),
+                "strategy_id": lane.get("strategy_id"),
+                "lane_id": lane.get("lane_id"),
+                "dividend_state": state,
+                "selected": hypothesis_id == selected_hypothesis_id,
+                "selected_value_gate": "routeable_candidate_count",
+                "measured_delta": measured_delta,
+                "preserved_reason_codes": _string_list(lane.get("before_reason_codes")),
+                "no_delta_release_key": lane.get("no_delta_release_key")
+                or _stable_hash(
+                    "alpha-repair-lane-release-key",
+                    {
+                        "source_revenue_repair_ref": source_revenue_repair_ref,
+                        "hypothesis_id": hypothesis_id,
+                        "reason_codes": _string_list(lane.get("before_reason_codes")),
+                    },
+                ),
+                "repeat_launch_decision": repeat_launch_decision,
+                "max_notional": _text(lane.get("max_notional"), "0"),
+            }
+        )
+    return dividends
+
+
+def build_alpha_repair_dividend_ledger(
+    *,
+    generated_at: datetime,
+    business_state: str,
+    revenue_ready: bool,
+    repair_queue: Sequence[Mapping[str, Any]],
+    capital: Mapping[str, Any],
+    evidence: Mapping[str, Any],
+    repair_bid_settlement_ledger: Mapping[str, Any],
+    executable_alpha_repair_receipts: Mapping[str, Any],
+    executable_alpha_settlement_slots: Mapping[str, Any],
+    alpha_evidence_foundry: Mapping[str, Any],
+    alpha_repair_closure_board: Mapping[str, Any],
+    alpha_readiness_settlement_conveyor: Mapping[str, Any],
+) -> dict[str, object]:
+    """Build observe-mode alpha repair dividend accounting for Jangar custody."""
+
+    if generated_at.tzinfo is None:
+        raise ValueError("generated_at_missing_timezone")
+    generated = generated_at.astimezone(timezone.utc)
+    fresh_until = generated + timedelta(seconds=_DEFAULT_FRESHNESS_SECONDS)
+    top_item = _top_queue_item(repair_queue)
+    selected_lane = _mapping(alpha_readiness_settlement_conveyor.get("selected_lane"))
+    settlement_receipt = _mapping(
+        alpha_readiness_settlement_conveyor.get("settlement_receipt")
+    )
+    selected_executable_receipt = _selected_executable_receipt(
+        executable_alpha_repair_receipts
+    )
+    closure_market = _closure_market(alpha_repair_closure_board)
+    pending_closure_receipt = _pending_closure_receipt(alpha_repair_closure_board)
+
+    source_revenue_repair_ref = _source_revenue_repair_ref(
+        alpha_readiness_settlement_conveyor,
+        alpha_evidence_foundry,
+        executable_alpha_repair_receipts,
+    )
+    selected_hypothesis_id = (
+        _text(selected_lane.get("hypothesis_id"))
+        or _text(settlement_receipt.get("hypothesis_id"))
+        or _text(selected_executable_receipt.get("hypothesis_id"))
+        or _text(closure_market.get("selected_hypothesis_id"))
+    )
+    selected_value_gate = (
+        _text(alpha_readiness_settlement_conveyor.get("selected_value_gate"))
+        or _text(top_item.get("value_gate"))
+        or "routeable_candidate_count"
+    )
+    routeable_before = _int(
+        alpha_readiness_settlement_conveyor.get("routeable_candidate_count_before"),
+        _routeable_candidate_count(evidence),
+    )
+    routeable_after = _int(
+        alpha_readiness_settlement_conveyor.get("routeable_candidate_count_after"),
+        routeable_before,
+    )
+    measured_delta = _int(
+        alpha_readiness_settlement_conveyor.get("measured_routeable_candidate_delta"),
+        routeable_after - routeable_before,
+    )
+    max_notional = (
+        _text(capital.get("max_notional"))
+        or _text(alpha_readiness_settlement_conveyor.get("max_notional"))
+        or _text(top_item.get("max_notional"))
+        or "0"
+    )
+    preserved_reason_codes = (
+        _string_list(settlement_receipt.get("preserved_reason_codes"))
+        or _string_list(pending_closure_receipt.get("preserved_reason_codes"))
+        or _string_list(selected_lane.get("before_reason_codes"))
+    )
+    retired_reason_codes = _string_list(settlement_receipt.get("retired_reason_codes"))
+    introduced_reason_codes = _string_list(settlement_receipt.get("new_reason_codes"))
+    required_receipts = _append_unique(
+        _string_list(alpha_readiness_settlement_conveyor.get("required_receipts")),
+        settlement_receipt.get("missing_receipts"),
+        selected_lane.get("required_receipts"),
+        top_item.get("required_receipts"),
+        top_item.get("required_output_receipt"),
+    )
+    validation_commands = _append_unique(
+        _string_list(alpha_readiness_settlement_conveyor.get("validation_commands")),
+        settlement_receipt.get("validation_commands"),
+        pending_closure_receipt.get("validation_commands"),
+        "uv run --frozen pytest services/torghut/tests/test_alpha_repair_dividend_ledger.py",
+    )
+    no_delta_release_key = _release_key(
+        alpha_readiness_settlement_conveyor=alpha_readiness_settlement_conveyor,
+        selected_lane=selected_lane,
+        settlement_receipt=settlement_receipt,
+        source_revenue_repair_ref=source_revenue_repair_ref,
+        selected_hypothesis_id=selected_hypothesis_id,
+        preserved_reason_codes=preserved_reason_codes,
+        required_receipts=required_receipts,
+    )
+
+    reason_codes: list[str] = []
+    if revenue_ready:
+        reason_codes.append("revenue_already_ready")
+    if business_state != "repair_only":
+        reason_codes.append(f"business_state_{business_state or 'unknown'}")
+    if not _is_alpha_repair(top_item):
+        reason_codes.append("revenue_repair_top_item_not_alpha_readiness")
+    if selected_value_gate != "routeable_candidate_count":
+        reason_codes.append("selected_value_gate_not_routeable_candidate_count")
+    if max_notional not in _ZERO_NOTIONAL_VALUES:
+        reason_codes.append("capital_notional_nonzero")
+    if not alpha_readiness_settlement_conveyor:
+        reason_codes.append("alpha_readiness_settlement_conveyor_missing")
+    if alpha_readiness_settlement_conveyor and not settlement_receipt:
+        reason_codes.append("alpha_repair_settlement_receipt_missing")
+    conveyor_fresh_until = _parse_datetime(
+        alpha_readiness_settlement_conveyor.get("fresh_until")
+    )
+    if conveyor_fresh_until is not None and conveyor_fresh_until <= generated:
+        reason_codes.append("alpha_readiness_settlement_conveyor_stale")
+    if (
+        alpha_readiness_settlement_conveyor
+        and _text(alpha_readiness_settlement_conveyor.get("status")) == "no_delta"
+    ):
+        reason_codes.append("active_no_delta_release_key")
+
+    settlement_state = _text(
+        alpha_readiness_settlement_conveyor.get("settlement_state"),
+        _text(settlement_receipt.get("settlement_state"), "pending"),
+    )
+    repeat_launch_decision = (
+        _text(selected_lane.get("repeat_launch_decision"))
+        or _text(settlement_receipt.get("repeat_launch_decision"))
+        or "hold"
+    )
+    dividend_state = _dividend_state(
+        reason_codes=reason_codes,
+        settlement_state=settlement_state,
+        measured_delta=measured_delta,
+        repeat_launch_decision=repeat_launch_decision,
+    )
+    launch_decision = _launch_decision(dividend_state)
+    ledger_id = "alpha-repair-dividend-ledger:" + _stable_hash(
+        "alpha-repair-dividend-ledger",
+        {
+            "source_revenue_repair_ref": source_revenue_repair_ref,
+            "selected_hypothesis_id": selected_hypothesis_id,
+            "no_delta_release_key": no_delta_release_key,
+            "dividend_state": dividend_state,
+            "routeable_before": routeable_before,
+            "routeable_after": routeable_after,
+        },
+    )
+    hypothesis_dividends = _hypothesis_dividends(
+        lanes=_sequence(alpha_readiness_settlement_conveyor.get("lane_scores")),
+        selected_hypothesis_id=selected_hypothesis_id,
+        source_revenue_repair_ref=source_revenue_repair_ref,
+    )
+    if not hypothesis_dividends and selected_hypothesis_id:
+        hypothesis_dividends.append(
+            {
+                "hypothesis_id": selected_hypothesis_id,
+                "candidate_id": selected_lane.get("candidate_id")
+                or settlement_receipt.get("candidate_id"),
+                "strategy_id": selected_lane.get("strategy_id")
+                or settlement_receipt.get("strategy_id"),
+                "lane_id": selected_lane.get("lane_id")
+                or settlement_receipt.get("lane_id"),
+                "dividend_state": dividend_state,
+                "selected": True,
+                "selected_value_gate": selected_value_gate,
+                "measured_delta": measured_delta,
+                "preserved_reason_codes": preserved_reason_codes,
+                "no_delta_release_key": no_delta_release_key,
+                "repeat_launch_decision": repeat_launch_decision,
+                "max_notional": max_notional,
+            }
+        )
+
+    return {
+        "schema_version": ALPHA_REPAIR_DIVIDEND_LEDGER_SCHEMA_VERSION,
+        "ledger_id": ledger_id,
+        "generated_at": generated.isoformat(),
+        "fresh_until": fresh_until.isoformat(),
+        "governing_design_ref": _DESIGN_REF,
+        "companion_jangar_design_ref": _COMPANION_JANGAR_DESIGN_REF,
+        "enforcement_mode": "observe",
+        "source_revenue_repair_ref": source_revenue_repair_ref,
+        "source_repair_bid_refs": _string_list(
+            repair_bid_settlement_ledger.get("selected_lot_ids")
+        ),
+        "source_repair_bid_settlement_ref": repair_bid_settlement_ledger.get(
+            "ledger_id"
+        ),
+        "source_executable_alpha_repair_receipts_ref": executable_alpha_repair_receipts.get(
+            "selected_receipt_id"
+        )
+        or executable_alpha_repair_receipts.get("source_revenue_repair_ref"),
+        "source_executable_alpha_settlement_slots_ref": executable_alpha_settlement_slots.get(
+            "selected_slot_id"
+        )
+        or executable_alpha_settlement_slots.get("source_revenue_repair_ref"),
+        "source_alpha_evidence_foundry_ref": alpha_evidence_foundry.get("foundry_id"),
+        "source_alpha_repair_closure_board_ref": alpha_repair_closure_board.get(
+            "board_id"
+        ),
+        "source_alpha_readiness_settlement_conveyor_ref": alpha_readiness_settlement_conveyor.get(
+            "conveyor_id"
+        ),
+        "account_id": alpha_readiness_settlement_conveyor.get("account_id")
+        or closure_market.get("account_id")
+        or repair_bid_settlement_ledger.get("account_id"),
+        "window": alpha_readiness_settlement_conveyor.get("window")
+        or closure_market.get("window")
+        or repair_bid_settlement_ledger.get("session_id"),
+        "trading_mode": alpha_readiness_settlement_conveyor.get("trading_mode")
+        or closure_market.get("trading_mode")
+        or repair_bid_settlement_ledger.get("trading_mode"),
+        "business_state": business_state,
+        "revenue_ready": revenue_ready,
+        "status": dividend_state,
+        "dividend_state": dividend_state,
+        "reason_codes": reason_codes,
+        "selected_queue_code": _text(top_item.get("code")),
+        "selected_value_gate": selected_value_gate,
+        "routeable_candidate_count_before": routeable_before,
+        "routeable_candidate_count_after": routeable_after,
+        "accepted_routeable_candidate_count": _int(
+            _mapping(evidence.get("routeability_acceptance")).get(
+                "accepted_routeable_candidate_count"
+            )
+        ),
+        "measured_delta": measured_delta,
+        "selected_hypothesis_id": selected_hypothesis_id,
+        "selected_strategy_id": selected_lane.get("strategy_id")
+        or settlement_receipt.get("strategy_id")
+        or selected_executable_receipt.get("strategy_id"),
+        "selected_repair_class": closure_market.get("selected_repair_class")
+        or selected_executable_receipt.get("repair_class")
+        or "alpha_readiness",
+        "required_output_receipt": top_item.get("required_output_receipt")
+        or executable_alpha_repair_receipts.get("required_output_receipt"),
+        "required_receipts": required_receipts,
+        "executable_alpha_receipt_refs": _append_unique(
+            _receipt_ids(executable_alpha_repair_receipts, "receipts"),
+            selected_executable_receipt.get("receipt_id"),
+            settlement_receipt.get("evidence_window_id"),
+        ),
+        "preserved_reason_codes": preserved_reason_codes,
+        "retired_reason_codes": retired_reason_codes,
+        "introduced_reason_codes": introduced_reason_codes,
+        "no_delta_release_key": no_delta_release_key,
+        "no_delta_release_conditions": list(_NO_DELTA_RELEASE_CONDITIONS),
+        "next_allowed_attempt_after": pending_closure_receipt.get(
+            "next_allowed_attempt_after"
+        )
+        or alpha_readiness_settlement_conveyor.get("fresh_until"),
+        "hypothesis_dividends": hypothesis_dividends,
+        "jangar_custody": {
+            "required_recorder_schema": _JANGAR_RECORDER_SCHEMA,
+            "enforcement_mode": "observe",
+            "allowed_action_class": "dispatch_repair"
+            if launch_decision == "allow"
+            else None,
+            "launch_decision": launch_decision,
+            "launch_decision_reason": "no_delta_release_key_active"
+            if dividend_state == "no_delta"
+            else dividend_state,
+            "denied_action_classes": [
+                "paper_canary",
+                "live_micro_canary",
+                "live_scale",
+            ],
+        },
+        "validation_commands": validation_commands,
+        "capital_state": _text(capital.get("capital_state"), "zero_notional"),
+        "capital_rule": _text(
+            top_item.get("capital_rule"), "zero_notional_repair_only"
+        ),
+        "max_notional": max_notional,
+        "rollback_target": _ROLLBACK_TARGET,
+    }
+
+
+def compact_alpha_repair_dividend_ledger(
+    ledger: Mapping[str, Any] | None,
+) -> dict[str, object]:
+    """Return the compact Jangar-facing alpha repair dividend ledger ref."""
+
+    payload = _mapping(ledger)
+    if not payload:
+        return {
+            "schema_version": ALPHA_REPAIR_DIVIDEND_LEDGER_REF_SCHEMA_VERSION,
+            "status": "missing",
+            "reason_codes": ["alpha_repair_dividend_ledger_missing"],
+        }
+    validation_commands = _string_list(payload.get("validation_commands"))
+    jangar_custody = _mapping(payload.get("jangar_custody"))
+    return {
+        "schema_version": ALPHA_REPAIR_DIVIDEND_LEDGER_REF_SCHEMA_VERSION,
+        "ledger_schema_version": payload.get("schema_version"),
+        "ledger_id": payload.get("ledger_id"),
+        "generated_at": payload.get("generated_at"),
+        "fresh_until": payload.get("fresh_until"),
+        "status": payload.get("status"),
+        "dividend_state": payload.get("dividend_state"),
+        "reason_codes": _string_list(payload.get("reason_codes")),
+        "selected_hypothesis_id": payload.get("selected_hypothesis_id"),
+        "selected_value_gate": payload.get("selected_value_gate"),
+        "routeable_candidate_count_before": payload.get(
+            "routeable_candidate_count_before"
+        ),
+        "routeable_candidate_count_after": payload.get(
+            "routeable_candidate_count_after"
+        ),
+        "measured_delta": payload.get("measured_delta"),
+        "no_delta_release_key": payload.get("no_delta_release_key"),
+        "launch_decision": jangar_custody.get("launch_decision"),
+        "required_recorder_schema": jangar_custody.get("required_recorder_schema"),
+        "validation_command": validation_commands[0] if validation_commands else None,
+        "enforcement_mode": payload.get("enforcement_mode"),
+        "max_notional": payload.get("max_notional"),
+        "capital_rule": payload.get("capital_rule"),
+        "rollback_target": payload.get("rollback_target"),
+    }
+
+
+__all__ = [
+    "ALPHA_REPAIR_DIVIDEND_LEDGER_REF_SCHEMA_VERSION",
+    "ALPHA_REPAIR_DIVIDEND_LEDGER_SCHEMA_VERSION",
+    "build_alpha_repair_dividend_ledger",
+    "compact_alpha_repair_dividend_ledger",
+]

--- a/services/torghut/app/trading/revenue_repair.py
+++ b/services/torghut/app/trading/revenue_repair.py
@@ -15,6 +15,7 @@ from .alpha_evidence_foundry import build_alpha_evidence_foundry
 from .alpha_readiness_settlement_conveyor import (
     build_alpha_readiness_settlement_conveyor,
 )
+from .alpha_repair_dividend_ledger import build_alpha_repair_dividend_ledger
 from .alpha_repair_closure_board import build_alpha_repair_closure_board
 from .executable_alpha_receipts import (
     build_executable_alpha_repair_receipts,
@@ -1037,6 +1038,20 @@ def build_revenue_repair_digest(
             "route_evidence_clearinghouse_packet": route_evidence_clearinghouse,
         },
     )
+    alpha_repair_dividend_ledger = build_alpha_repair_dividend_ledger(
+        generated_at=generated,
+        business_state=business_state,
+        revenue_ready=revenue_ready,
+        repair_queue=cast(Sequence[Mapping[str, Any]], repair_queue),
+        capital=capital,
+        evidence=evidence,
+        repair_bid_settlement_ledger=repair_bid_settlement,
+        executable_alpha_repair_receipts=executable_alpha_repair_receipts,
+        executable_alpha_settlement_slots=executable_alpha_settlement_slots,
+        alpha_evidence_foundry=alpha_evidence_foundry,
+        alpha_repair_closure_board=alpha_repair_closure_board,
+        alpha_readiness_settlement_conveyor=alpha_readiness_settlement_conveyor,
+    )
     return {
         "schema_version": SCHEMA_VERSION,
         "generated_at": generated.isoformat(),
@@ -1051,6 +1066,7 @@ def build_revenue_repair_digest(
         "alpha_repair_closure_board": alpha_repair_closure_board,
         "alpha_evidence_foundry": alpha_evidence_foundry,
         "alpha_readiness_settlement_conveyor": alpha_readiness_settlement_conveyor,
+        "alpha_repair_dividend_ledger": alpha_repair_dividend_ledger,
         "business_state": business_state,
         "revenue_ready": revenue_ready,
         "health": {

--- a/services/torghut/tests/test_alpha_repair_dividend_ledger.py
+++ b/services/torghut/tests/test_alpha_repair_dividend_ledger.py
@@ -1,0 +1,380 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from copy import deepcopy
+from datetime import datetime, timedelta, timezone
+from typing import Any, cast
+
+import pytest
+
+from app.trading.alpha_repair_dividend_ledger import (
+    build_alpha_repair_dividend_ledger,
+    compact_alpha_repair_dividend_ledger,
+)
+
+NOW = datetime(2026, 5, 14, 11, 20, tzinfo=timezone.utc)
+
+
+def _repair_queue() -> list[dict[str, object]]:
+    return [
+        {
+            "code": "repair_alpha_readiness",
+            "reason": "alpha_readiness_not_promotion_eligible",
+            "value_gate": "routeable_candidate_count",
+            "required_output_receipt": "torghut.executable-alpha-receipts.v1",
+            "required_receipts": [
+                "alpha_readiness_receipt",
+                "hypothesis_promotion_receipt",
+                "capital_replay_board",
+            ],
+            "max_notional": "0",
+            "capital_rule": "zero_notional_repair_only",
+        }
+    ]
+
+
+def _evidence() -> dict[str, object]:
+    return {
+        "routeability_acceptance": {
+            "ledger_id": "routeability-acceptance-ledger:test",
+            "accepted_routeable_candidate_count": 0,
+        },
+        "repair_bid_settlement": {
+            "ledger_id": "repair-bid-settlement-ledger:test",
+            "routeable_candidate_count": 0,
+        },
+        "route_evidence_clearinghouse": {
+            "accepted_routeable_candidate_count": 0,
+        },
+    }
+
+
+def _repair_bid_settlement() -> dict[str, object]:
+    return {
+        "ledger_id": "repair-bid-settlement-ledger:test",
+        "account_id": "PA3SX7FYNUTF",
+        "session_id": "15m",
+        "trading_mode": "live",
+        "selected_lot_ids": ["compacted-repair-lot:alpha"],
+        "routeable_candidate_count": 0,
+    }
+
+
+def _executable_alpha_repair_receipts() -> dict[str, object]:
+    return {
+        "schema_version": "torghut.executable-alpha-repair-receipts.v1",
+        "receipt_set_id": "executable-alpha-repair-receipts:test",
+        "required_output_receipt": "torghut.executable-alpha-receipts.v1",
+        "selected_receipt": {
+            "receipt_id": "executable-alpha-repair-receipt:micro",
+            "hypothesis_id": "H-MICRO-01",
+            "strategy_id": "microbar_volume_continuation_long_top2_chip_v1@paper",
+            "repair_class": "evidence_window_refresh",
+            "max_notional": "0",
+        },
+        "receipts": [
+            {
+                "receipt_id": "executable-alpha-repair-receipt:micro",
+                "hypothesis_id": "H-MICRO-01",
+                "max_notional": "0",
+            }
+        ],
+    }
+
+
+def _settlement_slots() -> dict[str, object]:
+    return {
+        "schema_version": "torghut.executable-alpha-settlement-slots.v1",
+        "slot_set_id": "executable-alpha-settlement-slots:test",
+        "max_notional": "0",
+    }
+
+
+def _alpha_foundry() -> dict[str, object]:
+    return {
+        "schema_version": "torghut.alpha-evidence-foundry.v1",
+        "foundry_id": "alpha-evidence-foundry:test",
+        "source_revenue_repair_ref": "torghut-revenue-repair-digest:test",
+        "status": "selected",
+    }
+
+
+def _closure_board() -> dict[str, object]:
+    return {
+        "schema_version": "torghut.alpha-repair-closure-board.v1",
+        "board_id": "alpha-repair-closure-board:test",
+        "alpha_closure_settlement_market": {
+            "market_id": "alpha-closure-settlement-market:test",
+            "account_id": "PA3SX7FYNUTF",
+            "window": "15m",
+            "trading_mode": "live",
+            "selected_hypothesis_id": "H-MICRO-01",
+            "selected_repair_class": "feature_replay_closure",
+            "pending_settlement_receipt": {
+                "receipt_id": "alpha-closure-settlement-receipt:test",
+                "preserved_reason_codes": [
+                    "drift_checks_missing",
+                    "feature_rows_missing",
+                ],
+                "next_allowed_attempt_after": (NOW + timedelta(minutes=15)).isoformat(),
+                "validation_commands": [
+                    "uv run --frozen pytest services/torghut/tests/test_alpha_repair_closure_board.py"
+                ],
+            },
+        },
+    }
+
+
+def _conveyor(
+    *,
+    measured_delta: int = 0,
+    repeat_launch_decision: str = "deny",
+    release_key: str | None = "release-key:micro",
+    reason_codes: list[str] | None = None,
+    fresh_until: datetime | None = None,
+) -> dict[str, object]:
+    blockers = reason_codes or [
+        "drift_checks_missing",
+        "feature_rows_missing",
+        "required_feature_set_unavailable",
+    ]
+    selected_lane: dict[str, object] = {
+        "hypothesis_id": "H-MICRO-01",
+        "candidate_id": "chip-paper-microbar-composite@execution-proof",
+        "strategy_id": "microbar_volume_continuation_long_top2_chip_v1@paper",
+        "lane_id": "microstructure-breakout",
+        "before_reason_codes": blockers,
+        "required_receipts": [
+            "alpha_readiness_receipt",
+            "capital_replay_board",
+            "hypothesis_promotion_receipt",
+            "feature_replay_receipt",
+        ],
+        "repeat_launch_decision": repeat_launch_decision,
+        "measured_routeable_candidate_delta": measured_delta,
+        "max_notional": "0",
+    }
+    if release_key is not None:
+        selected_lane["no_delta_release_key"] = release_key
+    settlement_state = "paid" if measured_delta > 0 else "no_delta"
+    return {
+        "schema_version": "torghut.alpha-readiness-settlement-conveyor.v1",
+        "conveyor_id": "alpha-readiness-settlement-conveyor:test",
+        "generated_at": NOW.isoformat(),
+        "fresh_until": (fresh_until or NOW + timedelta(minutes=15)).isoformat(),
+        "source_revenue_repair_ref": "torghut-revenue-repair-digest:test",
+        "source_commit": "source-sha",
+        "account_id": "PA3SX7FYNUTF",
+        "window": "15m",
+        "trading_mode": "live",
+        "status": "settling" if measured_delta > 0 else "no_delta",
+        "settlement_state": settlement_state,
+        "selected_value_gate": "routeable_candidate_count",
+        "routeable_candidate_count_before": 0,
+        "routeable_candidate_count_after": measured_delta,
+        "measured_routeable_candidate_delta": measured_delta,
+        "max_notional": "0",
+        "selected_lane": selected_lane,
+        "lane_scores": [selected_lane],
+        "required_receipts": selected_lane["required_receipts"],
+        "settlement_receipt": {
+            "schema_version": "torghut.alpha-readiness-settlement-receipt.v1",
+            "receipt_id": "alpha-readiness-settlement-receipt:micro",
+            "hypothesis_id": "H-MICRO-01",
+            "strategy_id": "microbar_volume_continuation_long_top2_chip_v1@paper",
+            "lane_id": "microstructure-breakout",
+            "settlement_state": settlement_state,
+            "routeable_candidate_count_before": 0,
+            "routeable_candidate_count_after": measured_delta,
+            "measured_routeable_candidate_delta": measured_delta,
+            "preserved_reason_codes": blockers if measured_delta <= 0 else [],
+            "retired_reason_codes": ["drift_checks_missing"]
+            if measured_delta > 0
+            else [],
+            "new_reason_codes": [],
+            "evidence_window_id": "alpha-evidence-window-receipt:micro",
+            "no_delta_release_key": release_key or "",
+            "repeat_launch_decision": repeat_launch_decision,
+            "missing_receipts": ["feature_replay_receipt"]
+            if measured_delta <= 0
+            else [],
+            "funded_receipts": ["feature_replay_receipt"] if measured_delta > 0 else [],
+        },
+        "validation_commands": [
+            "uv run --frozen pytest services/torghut/tests/test_alpha_readiness_settlement_conveyor.py"
+        ],
+    }
+
+
+def _build(
+    *,
+    conveyor: Mapping[str, Any] | None = None,
+    capital: Mapping[str, Any] | None = None,
+    repair_queue: list[dict[str, object]] | None = None,
+) -> dict[str, object]:
+    return build_alpha_repair_dividend_ledger(
+        generated_at=NOW,
+        business_state="repair_only",
+        revenue_ready=False,
+        repair_queue=repair_queue or _repair_queue(),
+        capital=capital or {"capital_state": "zero_notional", "max_notional": "0"},
+        evidence=_evidence(),
+        repair_bid_settlement_ledger=_repair_bid_settlement(),
+        executable_alpha_repair_receipts=_executable_alpha_repair_receipts(),
+        executable_alpha_settlement_slots=_settlement_slots(),
+        alpha_evidence_foundry=_alpha_foundry(),
+        alpha_repair_closure_board=_closure_board(),
+        alpha_readiness_settlement_conveyor=_conveyor()
+        if conveyor is None
+        else conveyor,
+    )
+
+
+def test_alpha_repair_dividend_ledger_records_no_delta_launch_denial() -> None:
+    ledger = _build()
+
+    assert ledger["schema_version"] == "torghut.alpha-repair-dividend-ledger.v1"
+    assert ledger["dividend_state"] == "no_delta"
+    assert ledger["selected_value_gate"] == "routeable_candidate_count"
+    assert ledger["routeable_candidate_count_before"] == 0
+    assert ledger["routeable_candidate_count_after"] == 0
+    assert ledger["measured_delta"] == 0
+    assert ledger["selected_hypothesis_id"] == "H-MICRO-01"
+    assert ledger["no_delta_release_key"] == "release-key:micro"
+    assert ledger["max_notional"] == "0"
+    assert "active_no_delta_release_key" in ledger["reason_codes"]
+    custody = cast(Mapping[str, Any], ledger["jangar_custody"])
+    assert custody["required_recorder_schema"] == (
+        "jangar.material-action-custody-flight-recorder.v1"
+    )
+    assert custody["launch_decision"] == "deny"
+
+
+def test_alpha_repair_dividend_ledger_marks_paid_when_routeable_count_moves() -> None:
+    ledger = _build(
+        conveyor=_conveyor(
+            measured_delta=1,
+            repeat_launch_decision="allow",
+            release_key="release-key:micro-paid",
+        )
+    )
+
+    assert ledger["dividend_state"] == "paid"
+    assert ledger["routeable_candidate_count_after"] == 1
+    assert ledger["measured_delta"] == 1
+    custody = cast(Mapping[str, Any], ledger["jangar_custody"])
+    assert custody["launch_decision"] == "allow"
+    assert custody["allowed_action_class"] == "dispatch_repair"
+
+
+def test_alpha_repair_dividend_ledger_holds_pending_attempt() -> None:
+    conveyor = deepcopy(_conveyor(repeat_launch_decision="hold"))
+    conveyor["status"] = "settling"
+    conveyor["settlement_state"] = "pending"
+    selected_lane = cast(dict[str, object], conveyor["selected_lane"])
+    selected_lane["repeat_launch_decision"] = "hold"
+    settlement_receipt = cast(dict[str, object], conveyor["settlement_receipt"])
+    settlement_receipt["settlement_state"] = "pending"
+    settlement_receipt["repeat_launch_decision"] = "hold"
+
+    ledger = _build(conveyor=conveyor)
+
+    assert ledger["dividend_state"] == "pending"
+    custody = cast(Mapping[str, Any], ledger["jangar_custody"])
+    assert custody["launch_decision"] == "hold"
+    hypothesis_dividend = cast(list[Mapping[str, Any]], ledger["hypothesis_dividends"])[
+        0
+    ]
+    assert hypothesis_dividend["dividend_state"] == "pending"
+
+
+def test_alpha_repair_dividend_release_key_changes_with_blocker_set() -> None:
+    first = _build(conveyor=_conveyor(release_key=None))
+    second = _build(
+        conveyor=_conveyor(
+            release_key=None,
+            reason_codes=[
+                "drift_checks_missing",
+                "feature_rows_missing",
+                "schema_lineage_missing",
+            ],
+        )
+    )
+
+    assert first["no_delta_release_key"] != second["no_delta_release_key"]
+
+
+def test_alpha_repair_dividend_ledger_blocks_missing_conveyor() -> None:
+    ledger = _build(conveyor={})
+
+    assert ledger["dividend_state"] == "blocked"
+    assert "alpha_readiness_settlement_conveyor_missing" in ledger["reason_codes"]
+    custody = cast(Mapping[str, Any], ledger["jangar_custody"])
+    assert custody["launch_decision"] == "deny"
+
+
+def test_alpha_repair_dividend_ledger_keeps_selected_dividend_without_lane_scores() -> (
+    None
+):
+    conveyor = deepcopy(_conveyor())
+    conveyor["lane_scores"] = []
+
+    ledger = _build(conveyor=conveyor)
+
+    dividends = cast(list[Mapping[str, Any]], ledger["hypothesis_dividends"])
+    assert len(dividends) == 1
+    assert dividends[0]["selected"] is True
+    assert dividends[0]["hypothesis_id"] == "H-MICRO-01"
+
+
+def test_alpha_repair_dividend_ledger_blocks_stale_conveyor() -> None:
+    ledger = _build(conveyor=_conveyor(fresh_until=NOW - timedelta(seconds=1)))
+
+    assert ledger["dividend_state"] == "stale"
+    assert "alpha_readiness_settlement_conveyor_stale" in ledger["reason_codes"]
+    custody = cast(Mapping[str, Any], ledger["jangar_custody"])
+    assert custody["launch_decision"] == "deny"
+
+
+def test_alpha_repair_dividend_ledger_blocks_nonzero_notional() -> None:
+    ledger = _build(capital={"capital_state": "shadow", "max_notional": "25"})
+
+    assert ledger["dividend_state"] == "blocked"
+    assert ledger["max_notional"] == "25"
+    assert "capital_notional_nonzero" in ledger["reason_codes"]
+
+
+def test_compact_alpha_repair_dividend_ledger_ref() -> None:
+    ledger = _build()
+    compact = compact_alpha_repair_dividend_ledger(ledger)
+
+    assert compact["schema_version"] == "torghut.alpha-repair-dividend-ledger-ref.v1"
+    assert compact["ledger_id"] == ledger["ledger_id"]
+    assert compact["dividend_state"] == "no_delta"
+    assert compact["launch_decision"] == "deny"
+    assert compact["selected_value_gate"] == "routeable_candidate_count"
+    assert compact["max_notional"] == "0"
+
+    assert compact_alpha_repair_dividend_ledger(None) == {
+        "schema_version": "torghut.alpha-repair-dividend-ledger-ref.v1",
+        "status": "missing",
+        "reason_codes": ["alpha_repair_dividend_ledger_missing"],
+    }
+
+
+def test_alpha_repair_dividend_ledger_rejects_naive_generated_at() -> None:
+    with pytest.raises(ValueError, match="generated_at_missing_timezone"):
+        build_alpha_repair_dividend_ledger(
+            generated_at=datetime(2026, 5, 14, 11, 20),
+            business_state="repair_only",
+            revenue_ready=False,
+            repair_queue=_repair_queue(),
+            capital={"max_notional": "0"},
+            evidence=_evidence(),
+            repair_bid_settlement_ledger=_repair_bid_settlement(),
+            executable_alpha_repair_receipts=_executable_alpha_repair_receipts(),
+            executable_alpha_settlement_slots=_settlement_slots(),
+            alpha_evidence_foundry=_alpha_foundry(),
+            alpha_repair_closure_board=_closure_board(),
+            alpha_readiness_settlement_conveyor=_conveyor(),
+        )

--- a/services/torghut/tests/test_build_revenue_repair_digest.py
+++ b/services/torghut/tests/test_build_revenue_repair_digest.py
@@ -513,6 +513,26 @@ class TestBuildRevenueRepairDigest(TestCase):
             selected_lane["repeat_launch_decision"],
             "deny",
         )
+        alpha_dividend_ledger = digest["alpha_repair_dividend_ledger"]
+        self.assertIsInstance(alpha_dividend_ledger, dict)
+        self.assertEqual(
+            alpha_dividend_ledger["schema_version"],
+            "torghut.alpha-repair-dividend-ledger.v1",
+        )
+        self.assertEqual(alpha_dividend_ledger["dividend_state"], "no_delta")
+        self.assertEqual(
+            alpha_dividend_ledger["selected_value_gate"],
+            "routeable_candidate_count",
+        )
+        self.assertEqual(alpha_dividend_ledger["max_notional"], "0")
+        self.assertEqual(
+            alpha_dividend_ledger["jangar_custody"]["required_recorder_schema"],
+            "jangar.material-action-custody-flight-recorder.v1",
+        )
+        self.assertEqual(
+            alpha_dividend_ledger["jangar_custody"]["launch_decision"],
+            "deny",
+        )
         self.assertEqual(repair_queue[1]["code"], "repair_execution_tca")
         self.assertNotIn("repair_repair_only", [item["code"] for item in repair_queue])
         self.assertIn(

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -1221,6 +1221,16 @@ class TestTradingApi(TestCase):
         )
         self.assertEqual(settlement_conveyor["status"], "observing")
         self.assertEqual(settlement_conveyor["max_notional"], "0")
+        alpha_dividend = payload["alpha_repair_dividend_ledger"]
+        self.assertEqual(
+            alpha_dividend["schema_version"],
+            "torghut.alpha-repair-dividend-ledger-ref.v1",
+        )
+        self.assertEqual(alpha_dividend["max_notional"], "0")
+        self.assertEqual(
+            alpha_dividend["required_recorder_schema"],
+            "jangar.material-action-custody-flight-recorder.v1",
+        )
         warrant = payload["route_warrant_exchange"]
         self.assertEqual(
             warrant["schema_version"],
@@ -4317,6 +4327,17 @@ class TestTradingApi(TestCase):
         self.assertIn(
             "alpha_readiness_settlement_receipts_missing",
             settlement_conveyor["reason_codes"],
+        )
+        alpha_dividend = payload["alpha_repair_dividend_ledger"]
+        self.assertEqual(
+            alpha_dividend["schema_version"],
+            "torghut.alpha-repair-dividend-ledger.v1",
+        )
+        self.assertEqual(alpha_dividend["dividend_state"], "blocked")
+        self.assertEqual(alpha_dividend["max_notional"], "0")
+        self.assertIn(
+            "alpha_repair_settlement_receipt_missing",
+            alpha_dividend["reason_codes"],
         )
         self.assertEqual(
             payload["evidence"]["repair_bid_settlement"]["dispatchable_lot_count"],


### PR DESCRIPTION
## Summary

- Implemented `torghut.alpha-repair-dividend-ledger.v1` for the live `repair_alpha_readiness` blocker, governed by `docs/torghut/design-system/v6/204-torghut-alpha-repair-dividend-ledger-and-custody-flight-recorder-2026-05-14.md` and companion Jangar design `docs/agents/designs/199-jangar-material-action-custody-flight-recorder-and-merge-reentry-slo-2026-05-14.md`.
- Wired the full ledger into `/trading/revenue-repair` and compact `torghut.alpha-repair-dividend-ledger-ref.v1` mirrors into `/readyz` and `/trading/consumer-evidence` for Jangar custody.
- Preserved capital safety: no submit-gate changes, no broker mutation, `max_notional=0`, and no paper/live enablement.
- Updated Torghut service docs, design index, rollout notes, revenue-repair assertions, API assertions, and new dividend-ledger coverage.
- Live evidence before and after local implementation remains repair-only until deploy: `business_state=repair_only`, `revenue_ready=false`, top queue `repair_alpha_readiness`, value gate `routeable_candidate_count`, accepted routeable candidates `0`, `zero_notional_or_stale_evidence_rate=1.0`, `max_notional=0`, and live dividend ledger absent until image promotion.

## Related Issues

None

## Testing

- PASS `cd services/torghut && /tmp/codex-uv-bootstrap/bin/uv sync --frozen --extra dev`
- PASS `cd services/torghut && /tmp/codex-uv-bootstrap/bin/uv run --frozen ruff format --check app/trading/alpha_repair_dividend_ledger.py app/trading/revenue_repair.py app/main.py tests/test_alpha_repair_dividend_ledger.py tests/test_build_revenue_repair_digest.py tests/test_trading_api.py`
- PASS `cd services/torghut && /tmp/codex-uv-bootstrap/bin/uv run --frozen ruff check app/trading/alpha_repair_dividend_ledger.py app/trading/revenue_repair.py app/main.py tests/test_alpha_repair_dividend_ledger.py tests/test_build_revenue_repair_digest.py tests/test_trading_api.py`
- PASS `cd services/torghut && /tmp/codex-uv-bootstrap/bin/uv run --frozen pytest tests/test_alpha_repair_dividend_ledger.py tests/test_build_revenue_repair_digest.py tests/test_trading_api.py -k "alpha_repair_dividend or revenue_repair or consumer_evidence"`: 27 selected tests
- PASS `cd services/torghut && /tmp/codex-uv-bootstrap/bin/uv run --frozen pytest tests/test_alpha_repair_dividend_ledger.py tests/test_alpha_readiness_settlement_conveyor.py tests/test_alpha_evidence_foundry.py tests/test_alpha_repair_closure_board.py tests/test_build_revenue_repair_digest.py tests/test_trading_api.py -k "alpha or revenue_repair or consumer_evidence or settlement_conveyor or dividend" --cov --cov-branch --cov-fail-under=0 --cov-report=xml --cov-report=`: 54 selected tests
- PASS `cd services/torghut && /tmp/codex-uv-bootstrap/bin/uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90`: changed-line coverage 202/216, 93.52%
- PASS `cd services/torghut && /tmp/codex-uv-bootstrap/bin/uv run --frozen pytest tests/test_repair_bid_settlement.py -k promotion_custody`: 1 selected test
- PASS `cd services/torghut && /tmp/codex-uv-bootstrap/bin/uv run --frozen pytest tests/test_executable_alpha_repair_receipts.py -k evidence_window`: 1 selected test
- PASS `cd services/torghut && /tmp/codex-uv-bootstrap/bin/uv run --frozen python scripts/check_migration_graph.py`
- PASS `cd services/torghut && /tmp/codex-uv-bootstrap/bin/uv run --frozen pyright --project pyrightconfig.json`
- PASS `cd services/torghut && /tmp/codex-uv-bootstrap/bin/uv run --frozen pyright --project pyrightconfig.alpha.json`
- PASS `cd services/torghut && /tmp/codex-uv-bootstrap/bin/uv run --frozen pyright --project pyrightconfig.scripts.json`
- PASS `git diff --check`
- PASS GitHub PR checks for https://github.com/proompteng/lab/pull/6612: `Changed-file plan`, `Pyright`, `Bytecode + lint + migration guard`, `Pytest shard 0-3`, `Pytest autoresearch runner 0-7`, `Quality signals (complexity + security)`, `Bytecode + pytest + coverage`, `Lint commit messages`, `Validate PR title`, and `check_changed_files`.
- Live pre-deploy check: `curl -fsS http://torghut.torghut.svc.cluster.local/trading/revenue-repair` confirmed repair-only, revenue not ready, top `repair_alpha_readiness`, accepted routeable candidate count `0`, max notional `0`, and no live dividend ledger before promotion.

## Screenshots (if applicable)

N/A

## Breaking Changes

None. Risk is additive payload/schema drift on Torghut evidence surfaces. Rollback is to revert this PR or stop emitting `alpha_repair_dividend_ledger` plus its compact ref. Existing revenue-repair, alpha evidence foundry, alpha readiness settlement conveyor, proof floor, and capital holds remain fallback surfaces.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
