### PR TITLE
fix(torghut): fund alpha settlement output receipt

### DIFF
--- a/docs/torghut/design-system/v6/205-torghut-alpha-readiness-settlement-conveyor-and-routeable-profit-runway-2026-05-14.md
+++ b/docs/torghut/design-system/v6/205-torghut-alpha-readiness-settlement-conveyor-and-routeable-profit-runway-2026-05-14.md
@@ -288,6 +288,11 @@ torghut.alpha-readiness-settlement-receipt.v1
   max_notional: "0"
 ```
 
+The emitted `torghut.alpha-readiness-settlement-receipt.v1` is its own output receipt. When the receipt is present, its
+schema is included in `funded_receipts[]` and must not appear in `missing_receipts[]`; otherwise the conveyor would
+create an impossible self-dependency while real upstream receipts such as drift checks, feature replay, hypothesis
+promotion, and capital replay remain unsettled.
+
 ### Conveyor State Machine
 
 - `observing`: revenue repair is available, but the top queue item is not alpha readiness.

--- a/docs/torghut/rollouts/2026-05-14-alpha-readiness-settlement-conveyor.md
+++ b/docs/torghut/rollouts/2026-05-14-alpha-readiness-settlement-conveyor.md
@@ -47,6 +47,9 @@ The runtime route remains zero-notional until the image containing this PR is pr
   lineage-ready feature/drift lane, while other lanes remain behind post-cost or lineage blockers.
 - Added no-delta lease accounting keyed by source ref, evidence window, blocker set, source commit, hypothesis, and
   required receipt set.
+- Marked the emitted `torghut.alpha-readiness-settlement-receipt.v1` as funded by the settlement itself so
+  `missing_receipts` only names real upstream repair receipts and no longer records the output schema as a
+  self-dependency.
 - Preserved `max_notional=0`, `capital_rule=zero_notional_repair_only`, and live submission disabled.
 
 ## Validation

--- a/services/torghut/app/trading/alpha_readiness_settlement_conveyor.py
+++ b/services/torghut/app/trading/alpha_readiness_settlement_conveyor.py
@@ -503,12 +503,13 @@ def _build_settlement_receipt(
         return None
     reason_codes = _reason_codes(selected_receipt)
     reason_set = set(reason_codes)
-    funded_receipts = _funded_receipts(
-        _string_list(selected_lane.get("required_receipts")),
-        selected_receipt,
+    required_receipts = _string_list(selected_lane.get("required_receipts"))
+    funded_receipts = _append_unique(
+        _funded_receipts(required_receipts, selected_receipt),
+        ALPHA_READINESS_SETTLEMENT_RECEIPT_SCHEMA_VERSION,
     )
     missing_receipts = _missing_receipts(
-        _string_list(selected_lane.get("required_receipts")),
+        required_receipts,
         funded_receipts,
     )
     measured_delta = _int(selected_lane.get("measured_routeable_candidate_delta"))

--- a/services/torghut/tests/test_alpha_readiness_settlement_conveyor.py
+++ b/services/torghut/tests/test_alpha_readiness_settlement_conveyor.py
@@ -207,6 +207,11 @@ def test_alpha_readiness_settlement_conveyor_selects_micro_no_delta_lane() -> No
     assert receipt["evidence_window_state"] == "no_delta"
     assert receipt["drift_state"] == "missing"
     assert receipt["schema_lineage_state"] == "missing"
+    assert "torghut.alpha-readiness-settlement-receipt.v1" in receipt["funded_receipts"]
+    assert (
+        "torghut.alpha-readiness-settlement-receipt.v1"
+        not in receipt["missing_receipts"]
+    )
     assert receipt["max_notional"] == "0"
 
 
@@ -241,6 +246,11 @@ def test_alpha_readiness_settlement_conveyor_marks_paid_when_selected_lane_moves
     receipt = cast(Mapping[str, Any], conveyor["settlement_receipt"])
     assert receipt["settlement_state"] == "paid"
     assert "feature_replay_receipt" in receipt["funded_receipts"]
+    assert "torghut.alpha-readiness-settlement-receipt.v1" in receipt["funded_receipts"]
+    assert (
+        "torghut.alpha-readiness-settlement-receipt.v1"
+        not in receipt["missing_receipts"]
+    )
 
 
 def test_alpha_readiness_settlement_conveyor_quarantines_nonzero_notional() -> None:


### PR DESCRIPTION
## Summary

- Governing design: `docs/torghut/design-system/v6/205-torghut-alpha-readiness-settlement-conveyor-and-routeable-profit-runway-2026-05-14.md`, supported by Torghut designs `168`, `184`, and `204`.
- Runtime requirement source: live `GET http://torghut.torghut.svc.cluster.local/trading/revenue-repair`; top repair is `repair_alpha_readiness`, value gate `routeable_candidate_count`, `business_state=repair_only`, `revenue_ready=false`, and `max_notional=0`.
- Fixed the alpha-readiness settlement receipt so emitted `torghut.alpha-readiness-settlement-receipt.v1` funds its own output schema before calculating `missing_receipts`; real upstream blockers remain missing until actually funded.
- Updated Torghut design and rollout docs with the self-dependency rule, risk notes, and rollback path.

## Related Issues

None

## Testing

- PASS: `python3 -m venv /tmp/codex-uv`
- PASS: `/tmp/codex-uv/bin/python -m pip install uv`
- PASS: `/tmp/codex-uv/bin/uv sync --frozen --extra dev`
- PASS: `/tmp/codex-uv/bin/uv run --frozen ruff format --check app/trading/alpha_readiness_settlement_conveyor.py tests/test_alpha_readiness_settlement_conveyor.py`
- PASS: `/tmp/codex-uv/bin/uv run --frozen ruff check app/trading/alpha_readiness_settlement_conveyor.py tests/test_alpha_readiness_settlement_conveyor.py`
- PASS: `/tmp/codex-uv/bin/uv run --frozen pytest tests/test_alpha_readiness_settlement_conveyor.py`
- PASS: `/tmp/codex-uv/bin/uv run --frozen pytest tests/test_alpha_readiness_settlement_conveyor.py tests/test_alpha_repair_dividend_ledger.py tests/test_build_revenue_repair_digest.py -k "settlement or dividend or repair_only_payload_prioritizes_evidence_before_live_submit"`
- PASS: `/tmp/codex-uv/bin/uv run --frozen pyright --project pyrightconfig.json`
- PASS: `/tmp/codex-uv/bin/uv run --frozen pyright --project pyrightconfig.alpha.json`
- PASS: `/tmp/codex-uv/bin/uv run --frozen pyright --project pyrightconfig.scripts.json`
- PASS: `/tmp/codex-uv/bin/uv run --frozen python -m compileall -q app scripts tests`
- PASS: `/tmp/codex-uv/bin/uv run --frozen python scripts/check_migration_graph.py`
- PASS: `git diff --check`
- PASS: `gh pr checks 6616 --repo proompteng/lab --watch --interval 30` on head `d33ef3301aee15232ab1b94164f3c4c87588467a`.

Business evidence:

- Before run, `2026-05-14T12:33:44Z`: `business_state=repair_only`, `revenue_ready=false`, top queue `repair_alpha_readiness`, value gate `routeable_candidate_count`, `promotion_eligible_total=0`, `blocked_repair_target_count=3`, `live_submission_allowed=false`, `max_notional=0`.
- After local implementation and rebase, live pre-deploy read at `2026-05-14T12:38:02Z`: `business_state=repair_only`, `revenue_ready=false`, top queue `repair_alpha_readiness`, selected lane `H-MICRO-01`, settlement state `no_delta`, `accepted_routeable_candidate_count=0`, `zero_notional_or_stale_evidence_rate=1.0`, `live_submission_allowed=false`, `max_notional=0`. The deployed service still shows the pre-PR self-dependency until this branch is promoted.

Hosted CI evidence:

- PASS: Torghut `Changed-file plan`, `Pyright`, `Bytecode + lint + migration guard`, `Bytecode + pytest + coverage`, `Pytest shard 0-3`, `Pytest autoresearch runner 0-7`, and `Quality signals (complexity + security)`.
- PASS: root `check_changed_files`, semantic commit lint, and semantic PR title validation.
- SKIPPED as expected: unrelated app/docs/service deploy toggles and release-manifest checks.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

Risk and rollback:

- Risk is limited to derived `/trading/revenue-repair` settlement accounting. No broker calls, database rows, Kubernetes manifests, trading flags, or submit gates are changed.
- Capital safety is unchanged: live submission remains disabled while `business_state=repair_only`, `revenue_ready=false`, and `max_notional=0`.
- Rollback is to revert this PR or stop emitting `alpha_readiness_settlement_conveyor`; existing zero-notional capital holds and revenue-repair diagnostics remain available.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
