### PR TITLE
fix(jangar): expose revenue repair custody on ready

### DIFF
--- a/docs/agents/runbooks.md
+++ b/docs/agents/runbooks.md
@@ -183,6 +183,9 @@ Expected outcomes:
 - `repair_warrant_exchange.schedule_debt_window` nets a failed schedule attempt only when a later success has the same
   lane, source ref, image ref, and objective ref. Unmatched failures stay open; if open errors outnumber successes by
   more than two, new repair warrants move to `observe_only`.
+- `/ready.revenue_repair_settlement_custody` is the bounded hot-path custody object for design doc 200. It must cite
+  the current Torghut alpha-readiness conveyor when available, deny active no-delta or nonzero-notional repair repeats,
+  and conservatively report missing stage/source proof as hold reasons because `/ready` does not collect full status.
 - `ready_action_exchange.mode` is `observe`; it points to the current `action_custody_receipts` and summarizes which
   action classes are `allow`, `repair_only`, `hold`, or `block`.
 - `action_custody_receipts` cite design doc 183 and wrap material verdicts, controller witness, source rollout truth,

--- a/services/jangar/src/routes/ready.test.ts
+++ b/services/jangar/src/routes/ready.test.ts
@@ -391,6 +391,30 @@ describe('getReadyHandler', () => {
             max_notional: '0',
             reason_codes: [],
           },
+          alpha_readiness_settlement_conveyor: {
+            schema_version: 'torghut.alpha-readiness-settlement-conveyor-ref.v1',
+            conveyor_schema_version: 'torghut.alpha-readiness-settlement-conveyor.v1',
+            conveyor_id: 'alpha-readiness-settlement-conveyor:ready-test',
+            generated_at: '2026-05-14T00:23:00.000Z',
+            fresh_until: '2026-05-14T00:38:00.000Z',
+            status: 'no_delta',
+            settlement_state: 'no_delta',
+            reason_codes: ['active_no_delta_lease'],
+            selected_hypothesis_id: 'H-MICRO-01',
+            selected_value_gate: 'routeable_candidate_count',
+            routeable_candidate_count_before: 0,
+            routeable_candidate_count_after: 0,
+            measured_routeable_candidate_delta: 0,
+            active_no_delta_lease_count: 1,
+            required_receipt: 'torghut.alpha-readiness-settlement-receipt.v1',
+            validation_command:
+              'uv run --frozen pytest services/torghut/tests/test_alpha_readiness_settlement_conveyor.py',
+            no_delta_release_key: 'alpha-readiness-no-delta:ready-test',
+            repeat_launch_decision: 'deny',
+            max_notional: '0',
+            capital_rule: 'zero_notional_repair_only',
+            rollback_target: 'stop emitting alpha_readiness_settlement_conveyor and keep Torghut max_notional=0',
+          },
         }),
       )
       .mockResolvedValueOnce(
@@ -460,6 +484,39 @@ describe('getReadyHandler', () => {
     expect(body.torghut_consumer_evidence).toMatchObject({
       revenue_repair_business_state: 'repair_only',
       revenue_repair_ready: false,
+    })
+    expect(body.revenue_repair_settlement_custody).toMatchObject({
+      schema_version: 'jangar.revenue-repair-settlement-custody.v1',
+      mode: 'observe',
+      torghut_conveyor_ref: 'alpha-readiness-settlement-conveyor:ready-test',
+      selected_hypothesis_id: 'H-MICRO-01',
+      selected_value_gate: 'routeable_candidate_count',
+      action_class: 'dispatch_repair',
+      decision: 'deny',
+      reason_codes: expect.arrayContaining([
+        'active_no_delta_lease',
+        'stage_credit_ledger_missing',
+        'source_serving_dispatch_repair_verdict_missing',
+        'rollout_health_unknown',
+      ]),
+      no_delta_release_key: 'alpha-readiness-no-delta:ready-test',
+      no_delta_release_state: 'active',
+      stage_health: {
+        stage_credit_ledger_ref: null,
+        dispatch_repair_decision: null,
+        reason_codes: ['stage_credit_ledger_missing'],
+      },
+      rollout_proof: {
+        source_serving_verdict_ref: null,
+        source_serving_decision: null,
+        rollout_health: 'unknown',
+        reason_codes: expect.arrayContaining([
+          'rollout_health_unknown',
+          'source_serving_dispatch_repair_verdict_missing',
+        ]),
+      },
+      validation_command: 'uv run --frozen pytest services/torghut/tests/test_alpha_readiness_settlement_conveyor.py',
+      rollback_target: 'stop emitting alpha_readiness_settlement_conveyor and keep Torghut max_notional=0',
     })
     expect(body.material_gate_digest).toMatchObject({
       schema_version: 'jangar.material-gate-digest.v1',

--- a/services/jangar/src/routes/ready.tsx
+++ b/services/jangar/src/routes/ready.tsx
@@ -1,6 +1,10 @@
 import { createFileRoute } from '@tanstack/react-router'
 
-import type { ExecutionTrustStatus, TorghutRevenueRepairQueueItem } from '~/data/agents-control-plane'
+import type {
+  ExecutionTrustStatus,
+  SourceServingContractVerdictExchange,
+  TorghutRevenueRepairQueueItem,
+} from '~/data/agents-control-plane'
 import { assessAgentRunIngestion, getAgentsControllerHealth } from '~/server/agents-controller'
 import { buildRuntimeAdmissionSnapshot, findAdmissionPassport } from '~/server/control-plane-runtime-admission'
 import {
@@ -21,6 +25,8 @@ import {
   type TorghutConsumerEvidenceStatus,
 } from '~/server/control-plane-torghut-consumer-evidence'
 import { buildMaterialGateDigest } from '~/server/control-plane-material-gate-digest'
+import { buildRevenueRepairSettlementCustody } from '~/server/control-plane-revenue-repair-settlement-custody'
+import type { ControlPlaneRolloutHealth } from '~/server/control-plane-status-types'
 import { getWatchReliabilitySummary } from '~/server/control-plane-watch-reliability'
 
 const isControllerHealthReady = (health: ReturnType<typeof getAgentsControllerHealth>) =>
@@ -167,6 +173,44 @@ const buildBusinessEvidence = (
   }
 }
 
+const readyPathFreshUntil = (now: Date) => new Date(now.getTime() + 60_000).toISOString()
+
+const buildReadyPathRolloutHealth = (ready: boolean): ControlPlaneRolloutHealth => ({
+  status: ready ? 'unknown' : 'degraded',
+  observed_deployments: 0,
+  degraded_deployments: ready ? 0 : 1,
+  deployments: [],
+  message: ready
+    ? 'rollout proof unavailable on /ready hot path; use control-plane status for full proof'
+    : 'serving readiness degraded on /ready hot path',
+})
+
+const buildReadyPathSourceServingExchange = (now: Date, namespace: string): SourceServingContractVerdictExchange => ({
+  mode: 'observe',
+  design_artifact:
+    'docs/agents/designs/200-jangar-revenue-repair-settlement-conveyor-and-stage-health-custody-2026-05-14.md',
+  exchange_id: `source-serving-contract-verdict-exchange:${namespace}:ready-hot-path-unavailable`,
+  generated_at: now.toISOString(),
+  fresh_until: readyPathFreshUntil(now),
+  namespace,
+  status: 'hold',
+  source_sha: null,
+  serving_build_commit: null,
+  manifest_image_digest: null,
+  serving_image_digest: null,
+  required_contracts: [],
+  observed_contracts: [],
+  missing_contracts: [],
+  verdict_refs: [],
+  allowed_action_classes: [],
+  repair_only_action_classes: [],
+  held_action_classes: ['dispatch_repair'],
+  blocked_action_classes: [],
+  reason_codes: ['source_serving_contract_unavailable_on_ready_hot_path'],
+  verdicts: [],
+  rollback_target: 'use /api/agents/control-plane/status for full source-serving rollout proof',
+})
+
 const executionTrustStatus = async (namespaces: string[]) => {
   const now = new Date()
   const resolvedNamespaces = uniqueStrings(namespaces.length > 0 ? namespaces : ['agents'])
@@ -279,6 +323,18 @@ export const getReadyHandler = async () => {
   const memoryProviderReady = memoryProvider.status !== 'blocked'
   const ready = controllersOk && leaderElectionReady && memoryProviderReady
   const status = ready && agentsControllerHealthy && servingPassportReady ? 'ok' : 'degraded'
+  const readyPathRolloutHealth = buildReadyPathRolloutHealth(ready)
+  const revenueRepairSettlementCustody = buildRevenueRepairSettlementCustody(
+    {
+      now,
+      namespace: namespaces[0] ?? 'agents',
+      rolloutHealth: readyPathRolloutHealth,
+      sourceServingContractVerdictExchange: buildReadyPathSourceServingExchange(now, namespaces[0] ?? 'agents'),
+      stageCreditLedger: null,
+      torghutConsumerEvidence: torghutConsumerEvidence.status,
+    },
+    'observe',
+  )
   const materialGateDigest = buildMaterialGateDigest({
     now,
     namespace: namespaces[0] ?? 'agents',
@@ -304,6 +360,7 @@ export const getReadyHandler = async () => {
     ...businessEvidence,
     torghut_consumer_evidence: torghutConsumerEvidence.status,
     repair_bid_admission: repairBidAdmission,
+    revenue_repair_settlement_custody: revenueRepairSettlementCustody,
     material_gate_digest: materialGateDigest,
     evidence_pressure_ledger: evidencePressureLedger,
     memory_provider: memoryProvider,


### PR DESCRIPTION
## Summary

- Exposes `revenue_repair_settlement_custody` on the Jangar `/ready` hot path so deployer and runner evidence can cite the same design-doc-200 custody object without waiting for full control-plane status.
- Keeps the ready-path custody reducer conservative: full source-serving and stage-credit proof are reported as hold reasons when unavailable, while Torghut active no-delta leases and nonzero-notional evidence still produce deny decisions.
- Extends the ready-route regression to cover a live-shaped Torghut alpha-readiness conveyor ref and documents the new `/ready` field in `docs/agents/runbooks.md`.
- Governing design: `docs/agents/designs/200-jangar-revenue-repair-settlement-conveyor-and-stage-health-custody-2026-05-14.md`; companion Torghut design: `docs/torghut/design-system/v6/205-torghut-alpha-readiness-settlement-conveyor-and-routeable-profit-runway-2026-05-14.md`.
- Runtime signal before this PR: `GET http://agents.agents.svc.cluster.local/ready` returned `business_state=repair_only`, `revenue_ready=false`, top repair `repair_alpha_readiness`, affected value gate `routeable_candidate_count`, `material_gate_digest.dispatch_repair=deny`, and `revenue_repair_settlement_custody=null`. Post-PR CI live evidence is still pre-rollout with the same `repair_only` state and `revenue_repair_settlement_custody=null`; after this source change is deployed, the ready-route test proves the field is emitted with `decision=deny` for active alpha no-delta debt and conservative hold reasons for missing full status proof.
- Value gates improved: `ready_status_truth`, `manual_intervention_count`, `handoff_evidence_quality`, and `failed_agentrun_rate`.

## Related Issues

None

## Testing

- PASS: `bunx oxfmt --check services/jangar/src/routes/ready.tsx services/jangar/src/routes/ready.test.ts`
- PASS: `bun run --cwd services/jangar test -- src/routes/ready.test.ts`
- PASS: `bun run --cwd services/jangar tsc`
- PASS: `bun run --cwd services/jangar lint`
- PASS: `bun run --cwd services/jangar lint:oxlint` (existing warnings only, 0 errors)
- PASS: `bunx oxfmt --check services/jangar packages/scripts/src/jangar argocd/applications/jangar`
- PASS: `bun run --cwd services/jangar lint:oxlint:type` (existing warnings only, 0 errors)
- PASS: `bun run --cwd services/jangar test`
- PASS: `bunx tsc --noEmit --project services/jangar/tsconfig.paths.json`
- PASS: `bun run --cwd services/jangar docs:inventory:check`
- PASS: `bun run --cwd services/jangar check:module-sizes`
- PASS: `bun run --cwd services/jangar build`
- PASS after rebase: `bunx oxfmt --check services/jangar/src/routes/ready.tsx services/jangar/src/routes/ready.test.ts`
- PASS after rebase: `bun run --cwd services/jangar test -- src/routes/ready.test.ts`
- PASS CI: `gh pr checks 6617 -R proompteng/lab` (`lint-and-typecheck / run`, `agents-ci validate`, `agents-ci integration`, semantic commit, PR title, and changed-files checks all green)
- INSTALL NOTE: `bun install --frozen-lockfile` failed in the `tree-sitter-json` lifecycle script because `node-gyp` could not resolve `abbrev`; CI uses `--ignore-scripts` for Jangar, and `bun install --frozen-lockfile --ignore-scripts` passed locally.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
