### PR TITLE
docs(jangar): define verify trust foreclosure

### DIFF
--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -19,6 +19,8 @@ clear entrypoints, clear “source of truth”, and a complete catalog of relate
 - Autonomous Jangar/Torghut production system design: `designs/autonomous-jangar-torghut-production-system.md`
 - Swarm agentic mission architecture notes: `designs/swarm-agentic-mission-architecture-2026-05-08.md`
 - Current Jangar/Torghut architecture contracts:
+  - `designs/201-jangar-verify-trust-foreclosure-and-alpha-repair-reentry-2026-05-14.md`
+  - `../torghut/design-system/v6/206-torghut-no-delta-repair-reentry-auction-and-verification-carry-2026-05-14.md`
   - `designs/200-jangar-revenue-repair-settlement-conveyor-and-stage-health-custody-2026-05-14.md`
   - `../torghut/design-system/v6/205-torghut-alpha-readiness-settlement-conveyor-and-routeable-profit-runway-2026-05-14.md`
   - `designs/199-jangar-material-action-custody-flight-recorder-and-merge-reentry-slo-2026-05-14.md`

--- a/docs/agents/designs/201-jangar-verify-trust-foreclosure-and-alpha-repair-reentry-2026-05-14.md
+++ b/docs/agents/designs/201-jangar-verify-trust-foreclosure-and-alpha-repair-reentry-2026-05-14.md
@@ -1,0 +1,456 @@
+# 201. Jangar Verify-Trust Foreclosure And Alpha-Repair Reentry (2026-05-14)
+
+Status: Accepted for engineer and deployer handoff
+Date: 2026-05-14
+Owner: Victor Chen, Jangar Engineering
+Scope: Jangar control-plane verify trust, source-rollout truth, material-action admission, Torghut alpha-repair reentry,
+no-delta suppression, validation, rollout, rollback, and cross-swarm handoff.
+
+Companion Torghut contract:
+
+- `docs/torghut/design-system/v6/206-torghut-no-delta-repair-reentry-auction-and-verification-carry-2026-05-14.md`
+
+Extends:
+
+- `200-jangar-revenue-repair-settlement-conveyor-and-stage-health-custody-2026-05-14.md`
+- `199-jangar-material-action-custody-flight-recorder-and-merge-reentry-slo-2026-05-14.md`
+- `188-jangar-ready-truth-arbiter-and-stage-credit-cutover-2026-05-13.md`
+- `180-jangar-execution-trust-debt-retirement-and-profit-repair-settlement-2026-05-08.md`
+- `175-jangar-failure-debt-clearance-and-action-reentry-frontier-2026-05-08.md`
+
+## Decision
+
+I am selecting a **verify-trust foreclosure board with alpha-repair reentry admission** as the next Jangar
+control-plane contract.
+
+The current system is healthy in the places that used to be the obvious blockers, and degraded in the place that now
+matters. On 2026-05-14 around 12:11Z, Jangar's control-plane status reported healthy agents, supporting, and
+orchestration controllers; healthy watch reliability with `548` events, `0` errors, and `1` restart in a 15 minute
+window; and a healthy database with `29` registered Kysely migrations and `29` applied migrations. `/ready` returned
+`status=ok`. Those are good signs.
+
+They are not enough to admit material work. The same evidence reported `execution_trust.status=degraded` because
+`jangar-control-plane:verify` had consecutive failures. Source rollout truth was in
+`heartbeat_projection_split`, with `dispatch_repair`, `dispatch_normal`, `deploy_widen`, `merge_ready`,
+`paper_canary`, `live_micro_canary`, and `live_scale` held. Recent `AgentRun` inventory showed `124` failed runs,
+`667` succeeded runs, `6` running runs, `11` pending runs, and `12` templates in the `agents` namespace. That is not a
+serving outage, but it is an admission problem.
+
+Torghut confirms the same shape from the business side. `/trading/revenue-repair` remained
+`business_state=repair_only`, `revenue_ready=false`, with top queue item `repair_alpha_readiness`, value gate
+`routeable_candidate_count`, and `max_notional=0`. The current alpha-readiness settlement conveyor was already in
+`no_delta`, selected `H-MICRO-01`, measured `routeable_candidate_count` as `0 -> 0`, and carried an active no-delta
+release key. Jangar should not spend another verify or repair launch on the same unchanged proof package.
+
+The selected design adds a Jangar `verify_trust_foreclosure_board` and a narrower `alpha_repair_reentry_admission`
+decision. The board converts verify-stage failure debt, source-rollout truth, controller witness state, Torghut
+consumer evidence, and Torghut no-delta release keys into one machine-readable answer: allow observe-only work, hold
+material action, deny duplicate no-delta repair, or open one bounded reentry slot with an explicit validation receipt.
+
+The tradeoff is that Jangar becomes stricter about proof reuse. Some repair work that looks safe at the Kubernetes
+level will be denied until it proves either a changed Torghut release condition or a current verify-trust retirement
+receipt. I accept that. The business metric is fewer failed AgentRuns and shorter green PR-to-healthy GitOps rollout
+time. Re-running unchanged no-delta repairs increases both failure rate and operator ambiguity.
+
+## Governing Runtime Requirements
+
+This contract implements the active swarm validation contract:
+
+- every run must cite the governing design or runtime requirement before changing code;
+- implement stages must produce production PRs with tests or report the exact blocker to code;
+- verify stages must merge only green PRs and prove Argo, workload readiness, and service health after rollout;
+- final handoff must name the control-plane metric improved or the smallest blocker preventing improvement.
+
+Value-gate mapping:
+
+- `failed_agentrun_rate`: deny duplicate no-delta launches and require verify-debt foreclosure before new material
+  dispatch.
+- `pr_to_rollout_latency`: require the reentry board to carry source SHA, image digest, Argo/workload evidence, and
+  service health in one packet.
+- `ready_status_truth`: preserve `/ready` serving truth while separating material-action authority.
+- `manual_intervention_count`: replace manual synthesis of verify failures, no-delta keys, and rollout split with one
+  compact decision.
+- `handoff_evidence_quality`: every handoff cites the foreclosure board id, Torghut release key, decision, validation
+  command, and rollback target.
+
+Torghut value-gate mapping:
+
+- `routeable_candidate_count`: no alpha repair reentry is allowed unless the launch can move this gate or record a new
+  no-delta result under a changed release condition.
+- `zero_notional_or_stale_evidence_rate`: unchanged evidence and stale release keys are denial evidence.
+- `fill_tca_or_slippage_quality`: TCA work is admitted only as a named prerequisite to release the alpha-readiness
+  blocker, not as a competing generic lane.
+- `post_cost_daily_net_pnl`: post-cost evidence remains required before paper or live capital.
+- `capital_gate_safety`: every reentry action is `max_notional=0`; paper and live action classes stay held or blocked.
+
+## Current Evidence
+
+All evidence was collected read-only on 2026-05-14. I did not mutate Kubernetes resources, database records, trading
+flags, AgentRuns, GitOps resources, broker state, or market data.
+
+### Cluster And Rollout Evidence
+
+- The active identity was `system:serviceaccount:agents:agents-sa`.
+- Agents deployments were available: `agents` `1/1`, `agents-controllers` `2/2`, and `agents-alloy` `1/1`.
+- Jangar serving image was `registry.ide-newton.ts.net/lab/jangar-control-plane:af7de0d0` at digest
+  `sha256:f668fea1bf077292bd788b29aff026ae75cb7430f192c9e003944359fc84f5aa`.
+- Agents controller image was `registry.ide-newton.ts.net/lab/jangar:af7de0d0` at digest
+  `sha256:5f883f91b8b02671d9ff6b3cff82c35a25d16ee3d80dffd8039126fbc03413bb`.
+- Recent agents events were mostly successful scheduled jobs and completions, but still included verify
+  `BackoffLimitExceeded` and readiness-probe timeouts on Jangar and controller pods.
+- Torghut live and sim revisions rolled to `torghut-00389` and `torghut-sim-00487` on image digest
+  `sha256:f451b35a66392e9d769ebab8b6c7708f617b5449d6473aed8b349ea34f60187b`.
+- Torghut events showed normal revision replacement and completed migration/bootstrap jobs, plus transient probe
+  failures during startup, profit-feedback workflows failing with exit code `127`, and a Flink options-TA checkpoint
+  restart.
+
+### Jangar Control-Plane Evidence
+
+- `/api/agents/control-plane/status?namespace=agents` generated at `2026-05-14T12:11:21.595Z`.
+- Controllers were healthy with fresh heartbeat authority.
+- Watch reliability was healthy with `548` total events, `0` errors, and `1` restart.
+- Database was connected and healthy with `latency_ms=3`.
+- Migration consistency was healthy: `registered_count=29`, `applied_count=29`, `unapplied_count=0`,
+  `unexpected_count=0`, latest migration
+  `20260508_torghut_quant_pipeline_health_account_window_created_at_index`.
+- Execution trust was degraded by `stages:agents:jangar-control-plane:verify:verify consecutive failures`.
+- Route-stability window was stable for serving, but only `serve_readonly` and `torghut_observe` were allowed.
+- `dispatch_repair`, `dispatch_normal`, `deploy_widen`, `merge_ready`, and `paper_canary` were held; live capital
+  classes were blocked.
+- The deployer summary reported `heartbeat_projection_split` and rollback target
+  `hold material dispatch until controller heartbeat authority settles`.
+
+### Torghut Business Evidence
+
+- Jangar `/ready` returned `business_state=repair_only`, `revenue_ready=false`, and top queue item
+  `repair_alpha_readiness`.
+- The top value gate was `routeable_candidate_count`; required output was `torghut.executable-alpha-receipts.v1`;
+  capital rule was `zero_notional_repair_only`; `max_notional=0`.
+- Torghut consumer evidence was current at the time of assessment, but accepted routeable candidate count was `0`.
+- Torghut `/readyz` returned HTTP `503`, correctly degraded by `live_submission_gate=simple_submit_disabled` and
+  `profitability_proof_floor=repair_only`.
+- Torghut `/db-check` returned HTTP `200`, `ok=true`, `schema_current=true`, current and expected Alembic head
+  `0031_autoresearch_candidate_spec_epoch_uniqueness`, no missing heads, no unexpected heads, and
+  `schema_graph_lineage_ready=true`.
+- The schema witness still reported historical parent-fork warnings, so DB head alone is not a sufficient launch
+  authority.
+- The alpha-readiness settlement conveyor reported `status=no_delta`, selected lane `H-MICRO-01`,
+  `repeat_launch_decision=deny`, measured routeable candidate delta `0`, and validation command
+  `uv run --frozen pytest services/torghut/tests/test_alpha_readiness_settlement_conveyor.py`.
+- The alpha repair dividend ledger reported `status=no_delta`, `launch_decision=deny`,
+  `launch_decision_reason=no_delta_release_key_active`, and denied `paper_canary`, `live_micro_canary`, and
+  `live_scale`.
+
+### Source And Test Surface
+
+- Jangar's high-risk integration file is `services/jangar/src/data/agents-control-plane.ts` at `2974` lines.
+- Jangar control-plane reducers in scope include `control-plane-status.ts` (`766` lines),
+  `control-plane-route-stability-escrow.ts` (`490` lines), and `control-plane-material-action-verdict.ts`
+  (`680` lines).
+- There are `40` Jangar server tests matching `*control-plane*test.ts`, including ready truth, material gate digest,
+  material reentry, material action verdict, source rollout truth, and authority provenance.
+- Torghut's high-risk producer file is `services/torghut/app/main.py` at `6990` lines.
+- Torghut revenue and alpha producer files in scope include `revenue_repair.py` (`1161` lines),
+  `alpha_readiness_settlement_conveyor.py` (`848` lines), `alpha_evidence_foundry.py` (`608` lines), and
+  `alpha_repair_dividend_ledger.py` (`637` lines).
+- Torghut already has focused tests for revenue repair, repair bid settlement, repair outcome dividend,
+  executable alpha receipts, alpha readiness settlement conveyor, alpha evidence foundry, alpha repair closure, route
+  reacquisition, routeability repair acceptance, and consumer evidence.
+- The remaining gap is the cross-plane foreclosure contract: verify-trust debt must be bound to a Torghut no-delta
+  release key and a specific reentry receipt before Jangar spends another material launch.
+
+## Problem
+
+Jangar currently exposes the relevant facts, but it does not reduce them into one admission object that prevents the
+wrong next launch.
+
+The concrete failure modes are:
+
+1. `/ready` can be serving `ok` while verify-stage trust is degraded.
+2. Source-rollout truth can be split while Kubernetes deployments are available.
+3. Torghut can report a fresh alpha settlement, but the settlement can be no-delta with an active release key.
+4. Workers can keep launching broad implement or verify runs that do not retire the active debt class.
+5. Deployer handoff can cite service health without proving source SHA, image digest, workload readiness, and Torghut
+   business state in one place.
+6. Direct database inspection is correctly unavailable to the worker identity, so admission has to rely on application
+   DB witnesses rather than ad hoc psql.
+
+The control plane needs a foreclosure board that turns failure debt into either a closed receipt or a denied launch.
+
+## Alternatives Considered
+
+### Option A: Keep Retrying Verify Until It Turns Green
+
+This option leaves current schedules and status surfaces alone. Verify-stage debt is treated as an operational retry
+problem.
+
+Advantages:
+
+- No new reducer.
+- It may clear transient flakes without code changes.
+- It preserves existing stage behavior.
+
+Disadvantages:
+
+- It already failed the live evidence test: verify has consecutive failures.
+- It does not suppress repeated no-delta repair attempts.
+- It spends runner capacity without naming the debt class being retired.
+- It does not shorten PR-to-rollout latency because deployer proof remains scattered.
+
+Decision: reject.
+
+### Option B: Freeze All Material Work Until Verify Is Healthy
+
+This option blocks every material action whenever execution trust is degraded.
+
+Advantages:
+
+- Strong reliability posture.
+- Easy to reason about under incident conditions.
+- Prevents risky capital or merge widening.
+
+Disadvantages:
+
+- It blocks the zero-notional evidence repair that may be required to make verify green.
+- It conflates safe observe-only Torghut evidence with material dispatch.
+- It still does not explain which verify failure must be retired.
+- It increases manual intervention when the right action is a bounded proof repair.
+
+Decision: keep as an emergency brake, reject as the normal architecture.
+
+### Option C: Verify-Trust Foreclosure Board With Alpha-Repair Reentry Admission
+
+This option emits a foreclosure board that joins verify trust, source-rollout truth, route-stability escrow, Torghut
+consumer evidence, Torghut no-delta release keys, and deployer proof into one compact decision.
+
+Advantages:
+
+- Targets the current failure mode directly.
+- Reduces duplicate AgentRuns by denying unchanged no-delta launches.
+- Preserves serve-readonly and Torghut observe paths while holding material action.
+- Gives deployers one packet for source, image, workload, service, and business evidence.
+- Keeps least-privilege database boundaries intact.
+
+Disadvantages:
+
+- Adds one Jangar reducer and tests.
+- Requires Torghut to expose stable no-delta release-key and reentry-auction fields.
+- Can delay useful repairs until the release condition changes or the verify-debt ticket is current.
+
+Decision: select Option C.
+
+## Architecture
+
+Jangar emits two additive, shadow-first payloads:
+
+```text
+jangar.verify-trust-foreclosure-board.v1
+  board_id
+  generated_at
+  fresh_until
+  namespace
+  execution_trust_ref
+  execution_trust_status
+  source_rollout_truth_ref
+  source_rollout_truth_state
+  controller_witness_ref
+  database_projection_ref
+  route_stability_ref
+  torghut_consumer_evidence_ref
+  torghut_alpha_repair_dividend_ref
+  active_no_delta_release_key
+  debt_classes[]
+  foreclosure_tickets[]
+  action_decisions[]
+  deployer_packet
+  rollback_target
+
+jangar.alpha-repair-reentry-admission.v1
+  admission_id
+  generated_at
+  fresh_until
+  selected_value_gate
+  selected_hypothesis_id
+  release_key_state: clear | active | changed | missing
+  material_action_class
+  decision: allow | hold | deny
+  reason_codes[]
+  required_output_receipt
+  validation_command
+  rollback_target
+```
+
+The board is not a replacement for `/ready`. `/ready` remains a serving-health surface. The board is a material-action
+surface.
+
+### Debt Classification
+
+Each board build classifies current debt into these stable categories:
+
+- `verify_trust_degraded`: execution trust reports degraded or blocked verify windows.
+- `source_rollout_truth_split`: source SHA, desired image, live image, or GitOps revision disagree.
+- `controller_witness_stale`: heartbeat authority is stale or split.
+- `torghut_no_delta_active`: Torghut reports an active no-delta release key for the selected alpha lane.
+- `torghut_business_repair_only`: Torghut remains `revenue_ready=false` or `business_state=repair_only`.
+- `capital_gate_hold`: Torghut proof floor, paper canary, or live action classes are held or blocked.
+
+### Admission Rules
+
+Jangar allows `serve_readonly` when serving route health is current.
+
+Jangar allows `torghut_observe` when Torghut consumer evidence or revenue-repair evidence is current, even if material
+work is held.
+
+Jangar denies `dispatch_repair` when:
+
+- the selected Torghut alpha lane has `repeat_launch_decision=deny`;
+- a no-delta release key is active and no release condition changed;
+- `max_notional` is not `0`;
+- required output receipt or validation command is missing;
+- the launch does not cite the governing Jangar and Torghut design ids.
+
+Jangar holds `dispatch_repair` when:
+
+- execution trust is degraded and no current foreclosure ticket names the debt class;
+- source-rollout truth is split and the repair does not target that split;
+- controller witness is stale;
+- Torghut consumer evidence is unavailable or stale;
+- Torghut `/readyz` is degraded for a reason other than the expected capital-safety holds;
+- database application witness is missing or schema currentness is unknown.
+
+Jangar allows one bounded `dispatch_repair` only when:
+
+- the repair targets the top Torghut queue item or a named prerequisite to release it;
+- the Torghut no-delta release key is clear, changed, or tied to a new release condition;
+- the board has a current foreclosure ticket;
+- `max_notional=0`;
+- the validation command is specific and fast;
+- the rollback target preserves zero notional and disables repeated launch for the same release key.
+
+Jangar holds `merge_ready`, `deploy_widen`, and all capital action classes until verify trust is healthy and source
+rollout truth converges.
+
+### Foreclosure Tickets
+
+A foreclosure ticket is the smallest unit of accepted debt retirement:
+
+```text
+foreclosure_ticket
+  ticket_id
+  debt_class
+  source_ref
+  expected_delta
+  required_output_receipt
+  validation_commands[]
+  max_runtime_seconds
+  max_parallelism
+  ttl_seconds
+  dedupe_key
+  state: open | closed | denied | expired
+```
+
+Tickets do not create work by themselves. They are admission receipts. A worker still needs a production PR, tests, and
+CI.
+
+## Implementation Scope
+
+Engineer milestone 1:
+
+- Add `verify_trust_foreclosure_board` and `alpha_repair_reentry_admission` types to the Jangar control-plane data
+  model.
+- Build the board from existing execution-trust, source-rollout truth, route-stability escrow, database, watch,
+  controller witness, Torghut consumer evidence, and revenue-repair settlement custody inputs.
+- Expose compact board refs on `/ready` and `/api/agents/control-plane/status`.
+- Keep enforcement in observe mode for one deploy.
+
+Engineer milestone 2:
+
+- Wire the board into material-action verdicts for `dispatch_repair`, `merge_ready`, `deploy_widen`, `paper_canary`,
+  `live_micro_canary`, and `live_scale`.
+- Deny duplicate no-delta reentry when Torghut reports `launch_decision=deny` for the same release key.
+- Add regression tests for serving `ok` with material hold, verify-debt foreclosure, source-rollout split,
+  no-delta denial, changed release-key allow, and application DB witness fallback.
+
+Deployer milestone:
+
+- Verify the board in live status before enforcement.
+- Promote only after Argo sync, workload readiness, `/ready`, control-plane status, Torghut `/readyz`,
+  `/trading/revenue-repair`, and `/trading/consumer-evidence` all report the expected states.
+
+## Validation Gates
+
+Local validation for the Jangar implementation:
+
+- `bun run --filter jangar test -- services/jangar/src/server/__tests__/control-plane-ready-truth-arbiter.test.ts`
+- `bun run --filter jangar test -- services/jangar/src/server/__tests__/control-plane-material-action-verdict.test.ts`
+- `bun run --filter jangar test -- services/jangar/src/server/__tests__/control-plane-material-reentry-clearinghouse.test.ts`
+- `bunx oxfmt --check services/jangar/src/server services/jangar/src/data docs/agents/designs/201-jangar-verify-trust-foreclosure-and-alpha-repair-reentry-2026-05-14.md`
+
+Live validation for deployer:
+
+- `curl -fsS http://agents.agents.svc.cluster.local/ready | jq '.execution_trust, .business_state, .top_repair_queue_item'`
+- `curl -fsS http://agents.agents.svc.cluster.local/api/agents/control-plane/status?namespace=agents | jq '.verify_trust_foreclosure_board, .route_stability_escrow.route_stability_window'`
+- `curl -fsS http://torghut.torghut.svc.cluster.local/trading/revenue-repair | jq '.alpha_readiness_settlement_conveyor, .alpha_repair_dividend_ledger'`
+- `curl -sS -w '\nHTTP_STATUS:%{http_code}\n' http://torghut.torghut.svc.cluster.local/readyz`
+
+Acceptance:
+
+- Serving can be `ok` while material action is held, and the board explains the split.
+- Duplicate no-delta repair is denied with the active release key.
+- A changed release condition opens at most one bounded zero-notional reentry ticket.
+- Merge and deploy widening stay held while verify trust is degraded.
+- Handoff names the metric: failed AgentRuns reduced by suppressing duplicate no-delta and verify-debt launches.
+
+## Rollout
+
+Phase 0 is documentation and tests.
+
+Phase 1 emits the board in observe mode on control-plane status and `/ready`.
+
+Phase 2 adds material-action verdict integration but keeps `dispatch_repair` in hold-on-unknown.
+
+Phase 3 enables denial for duplicate no-delta release keys and changed-release-key allow for one bounded dispatch
+repair.
+
+Phase 4 makes the board required for `merge_ready` and `deploy_widen` evidence.
+
+## Rollback
+
+Rollback is to stop emitting the foreclosure board and leave existing route-stability escrow, material-action verdicts,
+source-rollout truth, and revenue-repair settlement custody as the authorities.
+
+If enforcement causes false holds:
+
+- disable the board as an input to material-action verdicts;
+- keep the payload visible in observe mode for debugging;
+- preserve Torghut `max_notional=0`;
+- keep paper and live classes held until proof-floor contracts recover.
+
+If the board allows a duplicate no-delta launch:
+
+- immediately set the no-delta rule to deny-on-active-key;
+- require a human deployer note before re-enabling allow-on-changed-release-condition;
+- inspect the Torghut release-key fields and Jangar digest inputs before another launch.
+
+## Risks
+
+- Risk: a stale Torghut no-delta key denies useful work. Mitigation: release conditions are explicit and include source
+  ref, evidence window, blocker set, and required receipt set changes.
+- Risk: verify trust stays degraded for unrelated flakes. Mitigation: tickets name the debt class and can allow
+  observe-only work while holding material action.
+- Risk: the board duplicates material-action verdict logic. Mitigation: the board summarizes debt and release keys;
+  material-action verdict remains the enforcement point.
+- Risk: application DB witnesses hide row-level data issues. Mitigation: DB witnesses are required but not sufficient;
+  Torghut must also carry schema-lineage and evidence receipts.
+
+## Handoff
+
+Engineer next action: implement `jangar.verify-trust-foreclosure-board.v1` in observe mode and add tests that prove
+verify trust degraded plus active Torghut no-delta denies duplicate `dispatch_repair`.
+
+Deployer next action: after rollout, prove Jangar `/ready`, control-plane status, workload readiness, and Torghut
+revenue-repair agree on the board decision before calling the PR-to-rollout path healthy.
+
+The smallest blocker preventing improvement is current and specific: `jangar-control-plane:verify` has consecutive
+failures, and Torghut's selected alpha repair has an active no-delta release key with routeable candidate count still
+at zero.

--- a/docs/torghut/README.md
+++ b/docs/torghut/README.md
@@ -4,6 +4,14 @@
 
 Start here:
 
+- `docs/torghut/design-system/v6/206-torghut-no-delta-repair-reentry-auction-and-verification-carry-2026-05-14.md`
+  (current no-delta repair reentry auction and verification carry contract)
+- `docs/agents/designs/201-jangar-verify-trust-foreclosure-and-alpha-repair-reentry-2026-05-14.md`
+  (current Jangar verify-trust foreclosure and alpha-repair reentry contract)
+- `docs/torghut/design-system/v6/205-torghut-alpha-readiness-settlement-conveyor-and-routeable-profit-runway-2026-05-14.md`
+  (current alpha-readiness settlement conveyor and routeable profit runway contract)
+- `docs/agents/designs/200-jangar-revenue-repair-settlement-conveyor-and-stage-health-custody-2026-05-14.md`
+  (current Jangar revenue-repair settlement conveyor and stage-health custody contract)
 - `docs/torghut/design-system/v6/193-torghut-repair-outcome-dividend-ledger-and-capital-reentry-frontier-2026-05-13.md`
   (current repair outcome dividend ledger and capital reentry frontier contract)
 - `docs/agents/designs/189-jangar-terminal-debt-compaction-and-repair-outcome-escrow-2026-05-13.md`

--- a/docs/torghut/design-system/README.md
+++ b/docs/torghut/design-system/README.md
@@ -35,6 +35,8 @@ The v1 documents are written to stay consistent with:
 If you are trying to decide which docs are current contract truth versus historical milestone records, start with:
 
 - `docs/torghut/design-system/current-source-of-truth-and-priority-guide-2026-03-09.md`
+- `docs/torghut/design-system/v6/206-torghut-no-delta-repair-reentry-auction-and-verification-carry-2026-05-14.md`
+- `docs/agents/designs/201-jangar-verify-trust-foreclosure-and-alpha-repair-reentry-2026-05-14.md`
 - `docs/torghut/design-system/v6/205-torghut-alpha-readiness-settlement-conveyor-and-routeable-profit-runway-2026-05-14.md`
 - `docs/agents/designs/200-jangar-revenue-repair-settlement-conveyor-and-stage-health-custody-2026-05-14.md`
 - `docs/torghut/design-system/v6/204-torghut-alpha-repair-dividend-ledger-and-custody-flight-recorder-2026-05-14.md`

--- a/docs/torghut/design-system/v6/206-torghut-no-delta-repair-reentry-auction-and-verification-carry-2026-05-14.md
+++ b/docs/torghut/design-system/v6/206-torghut-no-delta-repair-reentry-auction-and-verification-carry-2026-05-14.md
@@ -1,0 +1,438 @@
+# 206. Torghut No-Delta Repair Reentry Auction And Verification Carry (2026-05-14)
+
+Status: Accepted for engineer and deployer handoff
+Date: 2026-05-14
+Owner: Victor Chen, Jangar Engineering
+Scope: Torghut revenue-repair priority, alpha-readiness no-delta suppression, routeable-candidate recovery, Jangar
+verification carry, zero-notional capital safety, validation, rollout, rollback, and cross-swarm handoff.
+
+Companion Jangar contract:
+
+- `docs/agents/designs/201-jangar-verify-trust-foreclosure-and-alpha-repair-reentry-2026-05-14.md`
+
+Extends:
+
+- `205-torghut-alpha-readiness-settlement-conveyor-and-routeable-profit-runway-2026-05-14.md`
+- `204-torghut-alpha-repair-dividend-ledger-and-custody-flight-recorder-2026-05-14.md`
+- `203-torghut-alpha-closure-dividend-slo-and-consumer-evidence-carry-2026-05-14.md`
+- `200-torghut-routeable-alpha-evidence-foundry-and-capital-safe-profit-ladder-2026-05-14.md`
+- `197-torghut-executable-alpha-repair-receipts-and-zero-notional-reentry-2026-05-13.md`
+
+## Decision
+
+I am selecting a **no-delta repair reentry auction with Jangar verification carry** as Torghut's next profitability
+contract.
+
+The live business surface is clear. On 2026-05-14 around 12:11Z, `GET /trading/revenue-repair` returned
+`business_state=repair_only`, `revenue_ready=false`, top queue item `repair_alpha_readiness`, top value gate
+`routeable_candidate_count`, capital rule `zero_notional_repair_only`, and `max_notional=0`. `/readyz` returned HTTP
+`503`, but for the right reasons: `live_submission_gate=simple_submit_disabled` and
+`profitability_proof_floor=repair_only`. Postgres, ClickHouse, Alpaca, database schema, static universe, and optional
+quant evidence were healthy.
+
+Torghut has already built the first layer of the repair machinery. The alpha-readiness settlement conveyor selected
+`H-MICRO-01`, measured `routeable_candidate_count` as `0 -> 0`, and returned `status=no_delta`. The alpha repair
+dividend ledger returned `launch_decision=deny`, `launch_decision_reason=no_delta_release_key_active`, and denied
+`paper_canary`, `live_micro_canary`, and `live_scale`. That is the correct safety posture. It is also the current
+profitability blocker: the system needs to know what must change before spending another repair slot.
+
+The selected design adds a Torghut-owned `no_delta_repair_reentry_auction`. The auction does not let workers rerun the
+same alpha repair after a timer. It prices the release conditions that can invalidate the active no-delta key:
+changed source revenue-repair digest, changed evidence window, changed blocker set, changed required receipt set, or a
+new Jangar verify-trust foreclosure ticket. If none of those changed, the auction denies reentry and keeps capital at
+zero. If one changed, it selects the smallest zero-notional repair that can clear the top alpha-readiness queue item or
+fund a named prerequisite to that queue item.
+
+The tradeoff is that Torghut will sometimes hold useful execution or empirical work behind the alpha no-delta release
+key. I accept that. The objective is not generic activity; it is routeable candidate recovery under capital safety. A
+second unchanged no-delta launch would raise failed AgentRun pressure and still leave `routeable_candidate_count=0`.
+
+## Governing Runtime Requirements
+
+This contract implements the active cross-swarm runtime requirements:
+
+- every run must cite the governing Torghut design or runtime requirement before changing code;
+- implement stages must produce production PRs that improve readiness, profit evidence, data freshness, execution
+  quality, or capital safety;
+- verify stages must merge only green PRs and prove Argo, workload readiness, service health, and trading evidence
+  after rollout;
+- final handoff must name the revenue metric improved or the smallest blocker preventing revenue impact.
+
+Torghut value-gate mapping:
+
+- `routeable_candidate_count`: primary value gate; reentry must increase accepted routeable candidates or record a new
+  no-delta debt with a changed release condition.
+- `zero_notional_or_stale_evidence_rate`: unchanged no-delta evidence keeps reentry denied.
+- `fill_tca_or_slippage_quality`: execution TCA repair can win only when it is a named prerequisite to unlock the
+  alpha-readiness lane.
+- `post_cost_daily_net_pnl`: no lane can promote to capital until post-cost evidence is positive and current.
+- `capital_gate_safety`: every auction ticket has `max_notional=0`; live submission remains disabled.
+
+Jangar value-gate mapping:
+
+- `failed_agentrun_rate`: no-delta release keys suppress duplicate repair AgentRuns.
+- `pr_to_rollout_latency`: verification carry gives deployers one packet that binds source, image, status, and Torghut
+  business evidence.
+- `ready_status_truth`: `/readyz` can stay degraded for capital safety while the auction remains observable.
+- `manual_intervention_count`: the top repair lane and denial reason are machine-readable.
+- `handoff_evidence_quality`: handoffs cite auction id, release key, selected ticket, validation command, and rollback.
+
+## Current Evidence
+
+All evidence was collected read-only on 2026-05-14. I did not mutate Kubernetes resources, database records, broker
+state, trading flags, GitOps resources, AgentRuns, or market data.
+
+### Cluster And Runtime
+
+- Torghut live revision was `torghut-00389`; sim revision was `torghut-sim-00487`.
+- Live and sim pods were running with two containers ready.
+- Current Torghut image digest was `sha256:f451b35a66392e9d769ebab8b6c7708f617b5449d6473aed8b349ea34f60187b`.
+- Torghut DB pod, ClickHouse shards, Keeper, options catalog, options enricher, TA, TA sim, WebSocket services, and
+  guardrail exporters were running.
+- Recent Torghut events showed successful database migrations and revision readiness, plus transient startup/readiness
+  probe failures during revision replacement.
+- Recent Torghut events also showed profit-feedback workflows failing with exit code `127` and a Flink options-TA
+  checkpoint restart. Those are not the current revenue-repair top queue item, but they are verification carry risk.
+
+### Database And Schema
+
+- `GET /db-check` returned HTTP `200` with `ok=true` and `schema_current=true`.
+- Current and expected Alembic head was `0031_autoresearch_candidate_spec_epoch_uniqueness`.
+- `schema_missing_heads=[]`, `schema_unexpected_heads=[]`, `schema_head_delta_count=0`.
+- `schema_graph_lineage_ready=true`, no duplicate revisions, and no orphan parents.
+- The schema witness still reported historical parent forks under
+  `0010_execution_provenance_and_governance_trace` and `0015_whitepaper_workflow_tables`.
+- `GET /readyz` returned HTTP `503`, but Postgres, ClickHouse, Alpaca, database schema, static universe, optional
+  empirical job dependency, DSPy runtime, and optional quant evidence were acceptable for observation.
+- The failing readiness dependencies were `live_submission_gate=simple_submit_disabled` and
+  `profitability_proof_floor=repair_only`, which are correct capital-safety holds.
+
+### Revenue Repair
+
+- `GET /trading/revenue-repair` generated at `2026-05-14T12:11:24.819445+00:00`.
+- `business_state=repair_only`, `revenue_ready=false`, `capital_stage=shadow`, `capital_state=zero_notional`,
+  `live_submission_allowed=false`, and `max_notional=0`.
+- Top queue item was `repair_alpha_readiness`, reason `alpha_readiness_not_promotion_eligible`, priority `70`, action
+  `clear_hypothesis_blockers_before_capital`, value gate `routeable_candidate_count`, and required output
+  `torghut.executable-alpha-receipts.v1`.
+- Blockers included `alpha_readiness_not_promotion_eligible`, `degraded`, `simple_submit_disabled`, and
+  `empirical_jobs_not_ready`.
+- Alpha readiness had `3` hypotheses, `0` promotion-eligible hypotheses, and all hypotheses blocked:
+  `H-CONT-01`, `H-MICRO-01`, and `H-REV-01`.
+- The alpha-readiness settlement conveyor reported `status=no_delta`, `settlement_state=no_delta`,
+  selected lane `H-MICRO-01`, selected value gate `routeable_candidate_count`, routeable candidate count `0 -> 0`,
+  measured delta `0`, and `repeat_launch_decision=deny`.
+- The alpha repair dividend ledger reported `status=no_delta`, `dividend_state=no_delta`,
+  `active_no_delta_release_key`, routeable candidate count `0 -> 0`, and
+  `next_allowed_attempt_after=2026-05-14T12:27:46.541488+00:00`.
+- Jangar custody in the dividend ledger denied `paper_canary`, `live_micro_canary`, and `live_scale`.
+
+### Source And Test Surface
+
+- `services/torghut/app/main.py` is `6990` lines and assembles `/readyz`, `/trading/status`,
+  `/trading/revenue-repair`, and `/trading/consumer-evidence`.
+- `services/torghut/app/trading/revenue_repair.py` is `1161` lines and owns the revenue-repair digest.
+- `services/torghut/app/trading/alpha_readiness_settlement_conveyor.py` is `848` lines and owns the active no-delta
+  release-key logic.
+- `services/torghut/app/trading/alpha_repair_dividend_ledger.py` is `637` lines and owns the Jangar-facing no-delta
+  custody summary.
+- Existing tests include `test_build_revenue_repair_digest.py`, `test_alpha_readiness_settlement_conveyor.py`,
+  `test_alpha_repair_dividend_ledger.py`, `test_executable_alpha_repair_receipts.py`,
+  `test_repair_bid_settlement.py`, `test_repair_outcome_dividend.py`, `test_route_evidence_clearinghouse.py`,
+  `test_routeability_repair_acceptance.py`, and `test_consumer_evidence.py`.
+- The missing test family is the auction itself: unchanged release key deny, changed evidence-window allow,
+  changed blocker-set allow, changed required-receipt-set allow, Jangar verify carry hold, zero-notional enforcement,
+  and compact consumer-evidence export.
+
+## Problem
+
+Torghut can now prove that an alpha repair produced no routeable-candidate delta. It does not yet have a first-class
+auction that decides what evidence must change before another alpha repair can launch.
+
+The concrete failure modes are:
+
+1. A worker can repeat the selected `H-MICRO-01` repair after waiting, even if the evidence window and blocker set did
+   not change.
+2. Execution TCA repair can compete with the top alpha-readiness queue item instead of acting as a named prerequisite.
+3. Jangar verify-stage debt can be ignored by Torghut's revenue-repair queue, even though failed verification raises
+   the cost of every repair PR.
+4. `/readyz` degradation can be misread as service breakage instead of correct capital-safety behavior.
+5. Schema head currentness can be mistaken for strategy-lineage readiness.
+6. Deployer handoff can cite revision readiness without proving that routeable candidate count changed or no-delta
+   debt was recorded.
+
+The system needs a reentry auction that turns no-delta evidence into a launch-deny key until a release condition
+changes.
+
+## Alternatives Considered
+
+### Option A: Rerun The Selected Alpha Lane After Cooldown
+
+This option lets the current `next_allowed_attempt_after` timestamp reopen `H-MICRO-01` without requiring a changed
+release condition.
+
+Advantages:
+
+- Simple.
+- Gives the top queue item another chance.
+- Fits the existing settlement conveyor shape.
+
+Disadvantages:
+
+- It repeats the exact failure mode: routeable candidate count stayed `0`.
+- It spends runner capacity without explaining what changed.
+- It can make verify-stage failure debt worse.
+- It does not reduce stale evidence rate or improve capital safety.
+
+Decision: reject.
+
+### Option B: Switch The Next Run To Execution TCA Repair
+
+This option treats `fill_tca_or_slippage_quality` as the immediate path because TCA evidence has blocked and missing
+symbols.
+
+Advantages:
+
+- TCA evidence is concrete and measurable.
+- It can improve downstream route quality.
+- It may unlock future paper candidates once alpha is eligible.
+
+Disadvantages:
+
+- It does not clear the top `/trading/revenue-repair` queue item.
+- It risks proving better execution for hypotheses that still cannot promote.
+- It does not explain the active alpha no-delta release key.
+- It can create a parallel repair stream that Jangar has to reconcile manually.
+
+Decision: reject as primary. Permit TCA only when the auction names it as a prerequisite to release the alpha lane.
+
+### Option C: No-Delta Repair Reentry Auction With Verification Carry
+
+This option makes Torghut price release conditions and choose one zero-notional ticket only when the active no-delta
+key is cleared or changed.
+
+Advantages:
+
+- Directly targets `repair_alpha_readiness`, the live top queue item.
+- Prevents duplicate no-delta repair AgentRuns.
+- Lets prerequisite TCA, empirical, market-context, or schema-lineage work compete only when tied to alpha release.
+- Gives Jangar a compact verification-carry input.
+- Keeps capital and live submission locked down.
+
+Disadvantages:
+
+- Adds a reducer and tests.
+- Requires stable release-key calculation.
+- Can hold useful work until enough evidence changes.
+
+Decision: select Option C.
+
+## Architecture
+
+Torghut emits two additive payloads:
+
+```text
+torghut.no-delta-repair-reentry-auction.v1
+  auction_id
+  generated_at
+  fresh_until
+  source_revenue_repair_ref
+  active_alpha_conveyor_ref
+  active_alpha_dividend_ref
+  active_no_delta_release_key
+  selected_queue_code: repair_alpha_readiness
+  selected_value_gate: routeable_candidate_count
+  routeable_candidate_count_before
+  routeable_candidate_count_after
+  release_conditions[]
+  candidate_tickets[]
+  selected_ticket
+  reentry_decision: allow | hold | deny
+  reason_codes[]
+  max_notional: "0"
+  rollback_target
+
+torghut.jangar-verification-carry.v1
+  carry_id
+  generated_at
+  fresh_until
+  jangar_execution_trust_status
+  jangar_source_rollout_truth_state
+  jangar_foreclosure_board_ref
+  held_action_classes[]
+  blocked_action_classes[]
+  required_jangar_receipt
+  reason_codes[]
+```
+
+### Release Conditions
+
+The active no-delta key can be released only by one or more of these changes:
+
+- `source_revenue_repair_ref_changed`
+- `evidence_window_changed`
+- `blocker_set_changed`
+- `required_receipt_set_changed`
+- `selected_hypothesis_changed`
+- `jangar_verify_foreclosure_ticket_current`
+- `schema_lineage_receipt_current`
+- `empirical_receipt_current`
+- `market_context_receipt_current`
+- `execution_tca_receipt_current`
+
+A timestamp alone is not a release condition. Time can expire a lease, but it cannot create evidence.
+
+### Auction Tickets
+
+Each candidate ticket has:
+
+```text
+candidate_ticket
+  ticket_id
+  ticket_class:
+    alpha_evidence_window | empirical_receipt | market_context_receipt |
+    execution_tca_receipt | schema_lineage_receipt | jangar_verify_carry
+  target_value_gate
+  expected_gate_delta
+  release_condition
+  required_output_receipt
+  validation_commands[]
+  max_runtime_seconds
+  max_parallelism
+  max_notional: "0"
+  state: selected | held | denied
+  hold_reason_codes[]
+```
+
+The auction selects at most one ticket for Jangar material dispatch. The first implementation should keep the selected
+ticket in observe mode and expose it in `/trading/revenue-repair` and `/trading/consumer-evidence`.
+
+### Reentry Rules
+
+Torghut denies reentry when:
+
+- no release condition changed;
+- active no-delta release key matches the selected lane;
+- `max_notional` is not `0`;
+- Jangar verification carry is degraded and no foreclosure ticket exists;
+- the selected ticket does not target the live top queue item or a named prerequisite.
+
+Torghut holds reentry when:
+
+- release condition state is unknown;
+- DB schema witness is unavailable;
+- Jangar verification carry is unavailable;
+- required validation command is missing;
+- consumer-evidence export has not carried the auction ref.
+
+Torghut allows reentry when:
+
+- at least one release condition changed;
+- the selected ticket is zero-notional and has one required output receipt;
+- Jangar verification carry is current or the selected ticket is explicitly scoped to retire that carry;
+- the ticket target is `routeable_candidate_count`, `zero_notional_or_stale_evidence_rate`, or a named prerequisite
+  that releases alpha readiness.
+
+No reentry decision authorizes paper or live capital.
+
+## Implementation Scope
+
+Engineer milestone 1:
+
+- Add `no_delta_repair_reentry_auction.py` as a pure reducer under `services/torghut/app/trading/`.
+- Build it from revenue-repair digest, alpha-readiness settlement conveyor, alpha repair dividend ledger, repair bid
+  settlement, and optional Jangar verification carry.
+- Expose compact auction refs on `/trading/revenue-repair` and `/trading/consumer-evidence`.
+- Keep enforcement in observe mode and preserve existing no-delta denial fields.
+
+Engineer milestone 2:
+
+- Feed the auction decision into revenue-repair queue ordering.
+- Deny unchanged no-delta reentry even after cooldown.
+- Allow one selected zero-notional prerequisite ticket when a release condition changed.
+- Add tests for unchanged deny, changed-release-condition allow, Jangar verify carry hold, and consumer-evidence parity.
+
+Deployer milestone:
+
+- After rollout, prove `/trading/revenue-repair` carries the auction ref, selected ticket, and zero-notional decision.
+- Prove Jangar consumes the compact ref before material dispatch is counted as accepted evidence.
+
+## Validation Gates
+
+Local validation:
+
+- `uv run --frozen pytest services/torghut/tests/test_alpha_readiness_settlement_conveyor.py`
+- `uv run --frozen pytest services/torghut/tests/test_alpha_repair_dividend_ledger.py`
+- `uv run --frozen pytest services/torghut/tests/test_build_revenue_repair_digest.py -k revenue_repair`
+- `uv run --frozen pytest services/torghut/tests/test_consumer_evidence.py -k alpha`
+- `ruff check services/torghut/app/trading services/torghut/tests`
+
+Live validation:
+
+- `curl -fsS http://torghut.torghut.svc.cluster.local/trading/revenue-repair | jq '.no_delta_repair_reentry_auction'`
+- `curl -fsS http://torghut.torghut.svc.cluster.local/trading/consumer-evidence | jq '.no_delta_repair_reentry_auction'`
+- `curl -sS -w '\nHTTP_STATUS:%{http_code}\n' http://torghut.torghut.svc.cluster.local/readyz`
+- `curl -fsS http://agents.agents.svc.cluster.local/api/agents/control-plane/status?namespace=agents | jq '.verify_trust_foreclosure_board'`
+
+Acceptance:
+
+- Current unchanged no-delta release key yields `reentry_decision=deny`.
+- Changed release condition yields at most one selected zero-notional ticket.
+- Auction selected ticket cites one required output receipt and at least one validation command.
+- Consumer evidence carries the compact auction ref for Jangar.
+- `/readyz` remains degraded while proof floor is repair-only; service degradation must not enable capital.
+
+## Rollout
+
+Phase 0 is documentation and test fixtures.
+
+Phase 1 emits the auction in observe mode on `/trading/revenue-repair`.
+
+Phase 2 mirrors compact refs to `/trading/consumer-evidence`.
+
+Phase 3 feeds the decision into Jangar material-action admission but denies only duplicate unchanged no-delta reentry.
+
+Phase 4 lets changed release conditions open one bounded zero-notional ticket.
+
+Phase 5 allows deployer handoff to treat routeable candidate delta or no-delta debt as the accepted revenue-repair
+settlement evidence.
+
+## Rollback
+
+Rollback is to stop emitting `no_delta_repair_reentry_auction` and keep existing alpha-readiness settlement conveyor,
+alpha repair dividend ledger, repair bid settlement, and capital proof-floor contracts.
+
+If the auction falsely denies useful work:
+
+- keep the existing conveyor and dividend fields;
+- remove the auction ref from queue ordering;
+- preserve `max_notional=0`;
+- keep live submission disabled.
+
+If the auction falsely allows duplicate no-delta work:
+
+- force `reentry_decision=deny` whenever `active_no_delta_release_key` is present;
+- require a new source revenue-repair ref before reentry;
+- leave paper and live action classes denied.
+
+## Risks
+
+- Risk: release-key calculation changes too often and hides duplicate work. Mitigation: base the key on source ref,
+  evidence window, blocker set, required receipt set, selected hypothesis, account, window, and trading mode.
+- Risk: Jangar verification carry blocks Torghut-local repair. Mitigation: carry is a hold unless the selected ticket
+  explicitly retires verify debt.
+- Risk: TCA work is starved. Mitigation: TCA can win as a prerequisite ticket when it releases alpha readiness.
+- Risk: operators treat no-delta as failure. Mitigation: no-delta is an accepted settlement outcome when it carries a
+  release key, validation command, and next action.
+
+## Handoff
+
+Engineer next action: implement `torghut.no-delta-repair-reentry-auction.v1` in observe mode and prove unchanged
+no-delta denies repeat launch while changed evidence conditions select one zero-notional ticket.
+
+Deployer next action: after rollout, prove the auction appears on `/trading/revenue-repair` and
+`/trading/consumer-evidence`, Jangar consumes the compact ref, and Torghut remains `max_notional=0`.
+
+The smallest blocker preventing revenue impact is current and measurable: `repair_alpha_readiness` is still the top
+queue item, selected `H-MICRO-01` produced no routeable-candidate delta, and the active no-delta release key denies
+another unchanged launch.

--- a/docs/torghut/design-system/v6/index.md
+++ b/docs/torghut/design-system/v6/index.md
@@ -8,10 +8,12 @@
 - Scope: intraday strategy architecture upgrade beyond static TSMOM, with regime-adaptive routing, DSPy-governed LLM
   reasoning, contamination-safe evaluation, and production rollout controls
 - Implementation status: `Mixed` (historical program closure recorded on `2026-03-03`; source-state refreshed on
-  `2026-03-09`; active proof/capital authority evidence refreshed on `2026-05-14T08:42Z`)
+  `2026-03-09`; active proof/capital authority evidence refreshed on `2026-05-14T12:11Z`)
 - Implementation status (strict, core 01-13 docs, source-state refresh `2026-03-09`): `Implemented=7`, `Partial=5`, `Completed=1`
 - Evidence (historical closure): `13-production-gap-closure-master-plan-2026-03-03.md` (Wave 0-6 closure + DoD)
-- Evidence (current next-work priority, refreshed `2026-05-14T08:42Z`):
+- Evidence (current next-work priority, refreshed `2026-05-14T12:11Z`):
+  - `206-torghut-no-delta-repair-reentry-auction-and-verification-carry-2026-05-14.md`
+  - `docs/agents/designs/201-jangar-verify-trust-foreclosure-and-alpha-repair-reentry-2026-05-14.md`
   - `205-torghut-alpha-readiness-settlement-conveyor-and-routeable-profit-runway-2026-05-14.md`
   - `docs/agents/designs/200-jangar-revenue-repair-settlement-conveyor-and-stage-health-custody-2026-05-14.md`
   - `204-torghut-alpha-repair-dividend-ledger-and-custody-flight-recorder-2026-05-14.md`


### PR DESCRIPTION
## Summary

- Adds the Jangar verify-trust foreclosure and alpha-repair reentry architecture contract.
- Adds the Torghut no-delta repair reentry auction and verification-carry architecture contract.
- Updates Agents and Torghut docs indexes so the new contracts are the current entry points.

## Related Issues

None. Runtime requirement: `jangar-control-plane` discover architecture pass on
`codex/swarm-jangar-control-plane-discover`.

## Testing

- PASS: `bunx oxfmt --check docs/agents/designs/201-jangar-verify-trust-foreclosure-and-alpha-repair-reentry-2026-05-14.md docs/torghut/design-system/v6/206-torghut-no-delta-repair-reentry-auction-and-verification-carry-2026-05-14.md docs/agents/README.md docs/torghut/README.md docs/torghut/design-system/README.md docs/torghut/design-system/v6/index.md`
- PASS: `bun run --cwd services/jangar docs:inventory:check`
- PASS: `git diff --check`
- PASS: read-only cluster/status evidence captured from Jangar `/ready`, Jangar control-plane status, Torghut
  `/readyz`, Torghut `/db-check`, Torghut `/trading/revenue-repair`, and Kubernetes workload/events views.

## Screenshots (if applicable)

N/A.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
