### PR TITLE
fix(jangar): publish runtime image proof env

### DIFF
--- a/charts/agents/templates/deployment-controllers.yaml
+++ b/charts/agents/templates/deployment-controllers.yaml
@@ -208,6 +208,14 @@ spec:
             {{- end }}
             - name: JANGAR_IMAGE
               value: "{{ $imageRepo }}:{{ $imageTag }}{{- if $imageDigest }}@{{ $imageDigest }}{{ end }}"
+            {{- if not (hasKey $envVars "JANGAR_RUNTIME_IMAGE") }}
+            - name: JANGAR_RUNTIME_IMAGE
+              value: "{{ $imageRepo }}:{{ $imageTag }}{{- if $imageDigest }}@{{ $imageDigest }}{{ end }}"
+            {{- end }}
+            {{- if and $imageTag (not (hasKey $envVars "JANGAR_GITOPS_REVISION")) }}
+            - name: JANGAR_GITOPS_REVISION
+              value: {{ $imageTag | quote }}
+            {{- end }}
             {{- if hasKey .Values.controller "jobTtlSecondsAfterFinished" }}
             - name: JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS
               value: {{ .Values.controller.jobTtlSecondsAfterFinished | quote }}

--- a/charts/agents/templates/deployment.yaml
+++ b/charts/agents/templates/deployment.yaml
@@ -185,6 +185,14 @@ spec:
             {{- end }}
             - name: JANGAR_IMAGE
               value: "{{ $imageRepo }}:{{ $imageTag }}{{- if $imageDigest }}@{{ $imageDigest }}{{ end }}"
+            {{- if not (hasKey $envVars "JANGAR_RUNTIME_IMAGE") }}
+            - name: JANGAR_RUNTIME_IMAGE
+              value: "{{ $imageRepo }}:{{ $imageTag }}{{- if $imageDigest }}@{{ $imageDigest }}{{ end }}"
+            {{- end }}
+            {{- if and $imageTag (not (hasKey $envVars "JANGAR_GITOPS_REVISION")) }}
+            - name: JANGAR_GITOPS_REVISION
+              value: {{ $imageTag | quote }}
+            {{- end }}
             {{- $jobTtl := .Values.controller.jobTtlSecondsAfterFinished }}
             {{- if hasKey .Values.controller "jobTtlSeconds" }}
             {{- $jobTtl = .Values.controller.jobTtlSeconds }}

--- a/services/jangar/src/server/__tests__/control-plane-runtime-admission.test.ts
+++ b/services/jangar/src/server/__tests__/control-plane-runtime-admission.test.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'node:url'
 import { afterEach, describe, expect, it } from 'vitest'
 
 import { buildRuntimeAdmissionSnapshot } from '~/server/control-plane-runtime-admission'
+import { resolveRuntimeAdmissionConfig } from '~/server/runtime-tooling-config'
 
 const REPO_ROOT = fileURLToPath(new URL('../../../../../', import.meta.url))
 
@@ -33,6 +34,14 @@ describe('buildRuntimeAdmissionSnapshot', () => {
       tempDir = undefined
     }
     resetEnv()
+  })
+
+  it('uses the deployed Jangar image as the runtime image fallback', () => {
+    delete process.env.JANGAR_RUNTIME_IMAGE
+    delete process.env.IMAGE_REF
+    process.env.JANGAR_IMAGE = 'registry.example.com/lab/jangar-control-plane:abc123@sha256:'.concat('a'.repeat(64))
+
+    expect(resolveRuntimeAdmissionConfig().runtimeImage).toBe(process.env.JANGAR_IMAGE)
   })
 
   it('accepts NATS_URL and NATS helper runtime components for collaboration admission', async () => {

--- a/services/jangar/src/server/runtime-tooling-config.ts
+++ b/services/jangar/src/server/runtime-tooling-config.ts
@@ -107,7 +107,11 @@ export const resolveRuntimeAdmissionConfig = (env: EnvSource = process.env): Run
   worktree: normalizeNonEmpty(env.WORKTREE) ?? (process.cwd().trim() || DEFAULT_WORKTREE),
   natsUrl: normalizeNonEmpty(env.NATS_URL) ?? normalizeNonEmpty(env.natsUrl) ?? '',
   pythonBin: normalizeNonEmpty(env.PYTHON_BIN) ?? normalizeNonEmpty(env.PYTHON) ?? DEFAULT_PYTHON_BIN,
-  runtimeImage: normalizeNonEmpty(env.JANGAR_RUNTIME_IMAGE) ?? normalizeNonEmpty(env.IMAGE_REF) ?? 'runtime:local',
+  runtimeImage:
+    normalizeNonEmpty(env.JANGAR_RUNTIME_IMAGE) ??
+    normalizeNonEmpty(env.JANGAR_IMAGE) ??
+    normalizeNonEmpty(env.IMAGE_REF) ??
+    'runtime:local',
   pathEntries: (env.PATH ?? '').split(':').filter((entry) => entry.length > 0),
 })
 


### PR DESCRIPTION
## Summary

- Publishes `JANGAR_RUNTIME_IMAGE` from the rendered agents image so runtime-kit proof uses the promoted image instead of `runtime:local`.
- Publishes `JANGAR_GITOPS_REVISION` from the image tag when no explicit override is configured, letting source-rollout truth compare source and deployed revision evidence.
- Adds a runtime-admission regression test for the deployed image fallback.

## Related Issues

None

## Testing

- `bunx oxfmt --check services/jangar/src/server/runtime-tooling-config.ts services/jangar/src/server/__tests__/control-plane-runtime-admission.test.ts`
- `bun test services/jangar/src/server/__tests__/control-plane-runtime-admission.test.ts`
- `git diff --check`
- `mise exec helm@3 -- helm template agents charts/agents -n agents -f argocd/applications/agents/values.yaml | rg -A8 -B4 'name: JANGAR_RUNTIME_IMAGE|name: JANGAR_GITOPS_REVISION'`
- `bun run --cwd services/jangar test`
- `bunx tsc --noEmit --project services/jangar/tsconfig.paths.json`
- `bun run --cwd services/jangar check:module-sizes`
- `mise exec helm@3 -- helm lint charts/agents -f argocd/applications/agents/values.yaml`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
