### PR TITLE
chore(jangar): promote image 3bbf8ab3

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: ae2f6851
-  digest: sha256:87933d2e3b1a8d14e31d93c107be7b7e261d390a6dca09456ada56aff9d4266c
+  tag: 3bbf8ab3
+  digest: sha256:ba208c0c77b07f360a92541d5a414fda3133161c90d5a5ccb9a5e60dbcb249b1
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,8 +11,8 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: ae2f6851
-    digest: sha256:e1b659e74e781757b6e1eba1479389921594e38ce5a4fa05f1a6af58aab8cf7f
+    tag: 3bbf8ab3
+    digest: sha256:067feaf2134f7c4e19ac2a39339c831e10d75ce4c60e7ef16d508789c2853f93
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
@@ -21,8 +21,8 @@ controlPlane:
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: ae2f6851
-    digest: sha256:87933d2e3b1a8d14e31d93c107be7b7e261d390a6dca09456ada56aff9d4266c
+    tag: 3bbf8ab3
+    digest: sha256:ba208c0c77b07f360a92541d5a414fda3133161c90d5a5ccb9a5e60dbcb249b1
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-14T12:07:30Z
+    deploy.knative.dev/rollout: 2026-05-14T12:45:52Z
 spec:
   replicas: 1
   strategy:
@@ -57,11 +57,11 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_RUNTIME_IMAGE
-              value: registry.ide-newton.ts.net/lab/jangar:ae2f6851@sha256:87933d2e3b1a8d14e31d93c107be7b7e261d390a6dca09456ada56aff9d4266c
+              value: registry.ide-newton.ts.net/lab/jangar:3bbf8ab3@sha256:ba208c0c77b07f360a92541d5a414fda3133161c90d5a5ccb9a5e60dbcb249b1
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: ae2f685113994c3372b6d10e691a14db707508f9
+              value: 3bbf8ab37cc659168452fc47a209bc6b29272216
             - name: JANGAR_GITOPS_REVISION
-              value: ae2f685113994c3372b6d10e691a14db707508f9
+              value: 3bbf8ab37cc659168452fc47a209bc6b29272216
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_BUMBA_TASK_QUEUE

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -59,5 +59,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: ae2f6851
-    digest: sha256:87933d2e3b1a8d14e31d93c107be7b7e261d390a6dca09456ada56aff9d4266c
+    newTag: 3bbf8ab3
+    digest: sha256:ba208c0c77b07f360a92541d5a414fda3133161c90d5a5ccb9a5e60dbcb249b1


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `3bbf8ab37cc659168452fc47a209bc6b29272216`
- Image tag: `3bbf8ab3`
- Image digest: `sha256:ba208c0c77b07f360a92541d5a414fda3133161c90d5a5ccb9a5e60dbcb249b1`
- Updated API rollout annotation
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`