### PR TITLE
chore(torghut): promote image 3f57e064

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:f451b35a66392e9d769ebab8b6c7708f617b5449d6473aed8b349ea34f60187b
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:c1c83ddc5f33fb0d46c393b398eb885e62598a8878e915397d68fe91845c8f03
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.569.1-391-g6cf49aaba
+              value: v0.569.1-401-g3f57e0645
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 6cf49aaba69bc79f953d91e38547f77d87b1c036
+              value: 3f57e0645905087167f1b52e99cc7d62f1391c57
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:f451b35a66392e9d769ebab8b6c7708f617b5449d6473aed8b349ea34f60187b
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:c1c83ddc5f33fb0d46c393b398eb885e62598a8878e915397d68fe91845c8f03
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.569.1-391-g6cf49aaba
+              value: v0.569.1-401-g3f57e0645
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 6cf49aaba69bc79f953d91e38547f77d87b1c036
+              value: 3f57e0645905087167f1b52e99cc7d62f1391c57
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:f451b35a66392e9d769ebab8b6c7708f617b5449d6473aed8b349ea34f60187b
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:c1c83ddc5f33fb0d46c393b398eb885e62598a8878e915397d68fe91845c8f03
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:f451b35a66392e9d769ebab8b6c7708f617b5449d6473aed8b349ea34f60187b
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:c1c83ddc5f33fb0d46c393b398eb885e62598a8878e915397d68fe91845c8f03
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:f451b35a66392e9d769ebab8b6c7708f617b5449d6473aed8b349ea34f60187b
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:c1c83ddc5f33fb0d46c393b398eb885e62598a8878e915397d68fe91845c8f03
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:f451b35a66392e9d769ebab8b6c7708f617b5449d6473aed8b349ea34f60187b
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:c1c83ddc5f33fb0d46c393b398eb885e62598a8878e915397d68fe91845c8f03
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:f451b35a66392e9d769ebab8b6c7708f617b5449d6473aed8b349ea34f60187b
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:c1c83ddc5f33fb0d46c393b398eb885e62598a8878e915397d68fe91845c8f03
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -15,7 +15,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:f451b35a66392e9d769ebab8b6c7708f617b5449d6473aed8b349ea34f60187b
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:c1c83ddc5f33fb0d46c393b398eb885e62598a8878e915397d68fe91845c8f03
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -23,7 +23,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:f451b35a66392e9d769ebab8b6c7708f617b5449d6473aed8b349ea34f60187b
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:c1c83ddc5f33fb0d46c393b398eb885e62598a8878e915397d68fe91845c8f03
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:f451b35a66392e9d769ebab8b6c7708f617b5449d6473aed8b349ea34f60187b
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:c1c83ddc5f33fb0d46c393b398eb885e62598a8878e915397d68fe91845c8f03
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-14T11:58:02Z"
+        client.knative.dev/updateTimestamp: "2026-05-14T13:00:46Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -27,7 +27,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:f451b35a66392e9d769ebab8b6c7708f617b5449d6473aed8b349ea34f60187b
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:c1c83ddc5f33fb0d46c393b398eb885e62598a8878e915397d68fe91845c8f03
           ports:
             - name: http1
               containerPort: 8181
@@ -482,11 +482,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.569.1-391-g6cf49aaba
+              value: v0.569.1-401-g3f57e0645
             - name: TORGHUT_COMMIT
-              value: 6cf49aaba69bc79f953d91e38547f77d87b1c036
+              value: 3f57e0645905087167f1b52e99cc7d62f1391c57
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:f451b35a66392e9d769ebab8b6c7708f617b5449d6473aed8b349ea34f60187b
+              value: sha256:c1c83ddc5f33fb0d46c393b398eb885e62598a8878e915397d68fe91845c8f03
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-14T11:58:02Z"
+        client.knative.dev/updateTimestamp: "2026-05-14T13:00:46Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:f451b35a66392e9d769ebab8b6c7708f617b5449d6473aed8b349ea34f60187b
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:c1c83ddc5f33fb0d46c393b398eb885e62598a8878e915397d68fe91845c8f03
           ports:
             - name: http1
               containerPort: 8181
@@ -298,11 +298,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.569.1-391-g6cf49aaba
+              value: v0.569.1-401-g3f57e0645
             - name: TORGHUT_COMMIT
-              value: 6cf49aaba69bc79f953d91e38547f77d87b1c036
+              value: 3f57e0645905087167f1b52e99cc7d62f1391c57
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:f451b35a66392e9d769ebab8b6c7708f617b5449d6473aed8b349ea34f60187b
+              value: sha256:c1c83ddc5f33fb0d46c393b398eb885e62598a8878e915397d68fe91845c8f03
           livenessProbe:
             httpGet:
               path: /healthz

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -98,7 +98,7 @@ spec:
           - name: allowStaleTape
           - name: persistResults
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:f451b35a66392e9d769ebab8b6c7708f617b5449d6473aed8b349ea34f60187b
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:c1c83ddc5f33fb0d46c393b398eb885e62598a8878e915397d68fe91845c8f03
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
+++ b/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:f451b35a66392e9d769ebab8b6c7708f617b5449d6473aed8b349ea34f60187b
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:c1c83ddc5f33fb0d46c393b398eb885e62598a8878e915397d68fe91845c8f03
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `3f57e0645905087167f1b52e99cc7d62f1391c57`
- Image tag: `3f57e064`
- Image digest: `sha256:c1c83ddc5f33fb0d46c393b398eb885e62598a8878e915397d68fe91845c8f03`