### PR TITLE
chore(jangar): promote image 035cecf5

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 3bbf8ab3
-  digest: sha256:ba208c0c77b07f360a92541d5a414fda3133161c90d5a5ccb9a5e60dbcb249b1
+  tag: 035cecf5
+  digest: sha256:8e24693ed11800694e258815d28e479451f849f97c8abc38cc5d0df071addf9d
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,8 +11,8 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 3bbf8ab3
-    digest: sha256:067feaf2134f7c4e19ac2a39339c831e10d75ce4c60e7ef16d508789c2853f93
+    tag: 035cecf5
+    digest: sha256:2b208fc289168321cfc5eccf8ac6038102c05c6edd650ba3b4760177d8107ccd
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
@@ -21,8 +21,8 @@ controlPlane:
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 3bbf8ab3
-    digest: sha256:ba208c0c77b07f360a92541d5a414fda3133161c90d5a5ccb9a5e60dbcb249b1
+    tag: 035cecf5
+    digest: sha256:8e24693ed11800694e258815d28e479451f849f97c8abc38cc5d0df071addf9d
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-14T12:45:52Z
+    deploy.knative.dev/rollout: 2026-05-14T13:06:01Z
 spec:
   replicas: 1
   strategy:
@@ -57,11 +57,11 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_RUNTIME_IMAGE
-              value: registry.ide-newton.ts.net/lab/jangar:3bbf8ab3@sha256:ba208c0c77b07f360a92541d5a414fda3133161c90d5a5ccb9a5e60dbcb249b1
+              value: registry.ide-newton.ts.net/lab/jangar:035cecf5@sha256:8e24693ed11800694e258815d28e479451f849f97c8abc38cc5d0df071addf9d
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: 3bbf8ab37cc659168452fc47a209bc6b29272216
+              value: 035cecf56cf34fb28f464fddcd3a0d9c6c4fc8c9
             - name: JANGAR_GITOPS_REVISION
-              value: 3bbf8ab37cc659168452fc47a209bc6b29272216
+              value: 035cecf56cf34fb28f464fddcd3a0d9c6c4fc8c9
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_BUMBA_TASK_QUEUE

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -59,5 +59,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: 3bbf8ab3
-    digest: sha256:ba208c0c77b07f360a92541d5a414fda3133161c90d5a5ccb9a5e60dbcb249b1
+    newTag: 035cecf5
+    digest: sha256:8e24693ed11800694e258815d28e479451f849f97c8abc38cc5d0df071addf9d


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `035cecf56cf34fb28f464fddcd3a0d9c6c4fc8c9`
- Image tag: `035cecf5`
- Image digest: `sha256:8e24693ed11800694e258815d28e479451f849f97c8abc38cc5d0df071addf9d`
- Updated API rollout annotation
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`