### PR TITLE
fix(jangar): publish source serving proof env

### DIFF
--- a/.github/workflows/jangar-release.yml
+++ b/.github/workflows/jangar-release.yml
@@ -163,6 +163,11 @@ jobs:
           JANGAR_CONTROL_PLANE_IMAGE_DIGEST: ${{ steps.control_plane_digest.outputs.digest }}
           JANGAR_SOURCE_HEAD_SHA: ${{ steps.meta.outputs.source_sha }}
           JANGAR_GITOPS_REVISION: ${{ steps.meta.outputs.source_sha }}
+          JANGAR_SOURCE_CI_RUN_ID: ${{ github.run_id }}
+          JANGAR_SOURCE_CI_CONCLUSION: success
+          JANGAR_MANIFEST_IMAGE_DIGEST: ${{ steps.control_plane_digest.outputs.digest }}
+          JANGAR_SERVING_BUILD_COMMIT: ${{ steps.meta.outputs.source_sha }}
+          JANGAR_SERVING_IMAGE_DIGEST: ${{ steps.control_plane_digest.outputs.digest }}
         run: |
           TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           bun run packages/scripts/src/jangar/update-manifests.ts \
@@ -172,6 +177,11 @@ jobs:
             --control-plane-digest "${JANGAR_CONTROL_PLANE_IMAGE_DIGEST}" \
             --source-head-sha "${JANGAR_SOURCE_HEAD_SHA}" \
             --gitops-revision "${JANGAR_GITOPS_REVISION}" \
+            --source-ci-run-id "${JANGAR_SOURCE_CI_RUN_ID}" \
+            --source-ci-conclusion "${JANGAR_SOURCE_CI_CONCLUSION}" \
+            --manifest-image-digest "${JANGAR_MANIFEST_IMAGE_DIGEST}" \
+            --serving-build-commit "${JANGAR_SERVING_BUILD_COMMIT}" \
+            --serving-image-digest "${JANGAR_SERVING_IMAGE_DIGEST}" \
             --rollout-timestamp "${TIMESTAMP}" \
             --agents-values-path "argocd/applications/agents/values.yaml"
 
@@ -211,8 +221,11 @@ jobs:
             - Source commit: `${{ steps.meta.outputs.source_sha }}`
             - Image tag: `${{ steps.meta.outputs.tag }}`
             - Image digest: `${{ steps.digest.outputs.digest }}`
+            - Source CI run: `${{ github.run_id }}`
+            - Control-plane serving digest: `${{ steps.control_plane_digest.outputs.digest }}`
             - Updated API rollout annotation
             - Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`
+            - Published source-serving proof env for revenue repair custody gates
 
       - name: No manifest changes detected
         if: steps.meta.outputs.promote == 'true' && steps.changes.outputs.changed != 'true'

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -68,7 +68,7 @@ spec:
     - name: run
       nodeSelector:
         kubernetes.io/arch: arm64
-      activeDeadlineSeconds: 21600
+      activeDeadlineSeconds: 10800
       inputs:
         parameters:
           - name: runId

--- a/packages/scripts/src/jangar/__tests__/update-manifests.test.ts
+++ b/packages/scripts/src/jangar/__tests__/update-manifests.test.ts
@@ -109,6 +109,11 @@ describe('updateJangarManifests', () => {
       runtimeImageEnv: true,
       sourceHeadShaEnv: false,
       gitopsRevisionEnv: false,
+      sourceCiRunIdEnv: false,
+      sourceCiConclusionEnv: false,
+      manifestImageDigestEnv: false,
+      servingBuildCommitEnv: false,
+      servingImageDigestEnv: false,
       worker: false,
       agentsValues: false,
     })
@@ -271,6 +276,63 @@ describe('updateJangarManifests', () => {
       digest: 'sha256:controlplanedigest',
     })
     expect(result.changed.agentsValues).toBe(true)
+
+    rmSync(fixture.dir, { recursive: true, force: true })
+  })
+
+  it('publishes source-serving proof env to service and agents control-plane values', () => {
+    const fixture = createFixture()
+    const sourceHeadSha = '9e7b87d813d9732d44586e213d9f47ec178f705a'
+    const gitopsRevision = '9e7b87d8'
+    const controlPlaneDigest = 'sha256:controlplanedigest'
+
+    const result = updateJangarManifests({
+      imageName,
+      tag: 'agents-tag',
+      digest: 'sha256:agentsdigest',
+      controlPlaneImageName: 'registry.ide-newton.ts.net/lab/jangar-control-plane',
+      controlPlaneDigest,
+      sourceHeadSha,
+      gitopsRevision,
+      sourceCiRunId: '123456',
+      sourceCiConclusion: 'success',
+      rolloutTimestamp: '2026-02-20T08:45:00.000Z',
+      kustomizationPath: relative(repoRoot, fixture.kustomizationPath),
+      serviceManifestPath: relative(repoRoot, fixture.serviceManifestPath),
+      agentsValuesPath: relative(repoRoot, fixture.agentsValuesPath),
+    })
+
+    const serviceManifest = YAML.parse(readFileSync(fixture.serviceManifestPath, 'utf8')) as {
+      spec?: { template?: { spec?: { containers?: Array<{ env?: Array<{ name?: string; value?: string }> }> } } }
+    }
+    const values = YAML.parse(readFileSync(fixture.agentsValuesPath, 'utf8')) as {
+      controlPlane?: { env?: { vars?: Record<string, string> } }
+    }
+    const serviceEnv = serviceManifest.spec?.template?.spec?.containers?.[0]?.env
+    const expectedProofEnv = {
+      JANGAR_SOURCE_HEAD_SHA: sourceHeadSha,
+      JANGAR_GITOPS_REVISION: gitopsRevision,
+      JANGAR_SOURCE_CI_RUN_ID: '123456',
+      JANGAR_SOURCE_CI_CONCLUSION: 'success',
+      JANGAR_MANIFEST_IMAGE_DIGEST: controlPlaneDigest,
+      JANGAR_SERVING_BUILD_COMMIT: sourceHeadSha,
+      JANGAR_SERVING_IMAGE_DIGEST: controlPlaneDigest,
+    }
+
+    for (const [name, value] of Object.entries(expectedProofEnv)) {
+      expect(serviceEnv).toContainEqual({ name, value })
+      expect(values.controlPlane?.env?.vars?.[name]).toBe(value)
+    }
+    expect(result.changed).toMatchObject({
+      sourceHeadShaEnv: true,
+      gitopsRevisionEnv: true,
+      sourceCiRunIdEnv: true,
+      sourceCiConclusionEnv: true,
+      manifestImageDigestEnv: true,
+      servingBuildCommitEnv: true,
+      servingImageDigestEnv: true,
+      agentsValues: true,
+    })
 
     rmSync(fixture.dir, { recursive: true, force: true })
   })

--- a/packages/scripts/src/jangar/update-manifests.ts
+++ b/packages/scripts/src/jangar/update-manifests.ts
@@ -27,6 +27,11 @@ export type UpdateManifestsOptions = {
   controlPlaneDigest?: string
   sourceHeadSha?: string
   gitopsRevision?: string
+  sourceCiRunId?: string
+  sourceCiConclusion?: string
+  manifestImageDigest?: string
+  servingBuildCommit?: string
+  servingImageDigest?: string
   rolloutTimestamp: string
   kustomizationPath?: string
   serviceManifestPath?: string
@@ -43,6 +48,11 @@ type CliOptions = {
   controlPlaneDigest?: string
   sourceHeadSha?: string
   gitopsRevision?: string
+  sourceCiRunId?: string
+  sourceCiConclusion?: string
+  manifestImageDigest?: string
+  servingBuildCommit?: string
+  servingImageDigest?: string
   rolloutTimestamp?: string
   kustomizationPath?: string
   serviceManifestPath?: string
@@ -69,6 +79,53 @@ const asRecord = (value: unknown): Record<string, unknown> | null => {
   return null
 }
 
+type SourceServingProofEnv = {
+  sourceHeadSha?: string
+  gitopsRevision?: string
+  sourceCiRunId?: string
+  sourceCiConclusion?: string
+  manifestImageDigest?: string
+  servingBuildCommit?: string
+  servingImageDigest?: string
+}
+
+const buildSourceServingProofEnv = (proof: SourceServingProofEnv) =>
+  Object.fromEntries(
+    Object.entries({
+      JANGAR_SOURCE_HEAD_SHA: normalizeOptional(proof.sourceHeadSha),
+      JANGAR_GITOPS_REVISION: normalizeOptional(proof.gitopsRevision),
+      JANGAR_SOURCE_CI_RUN_ID: normalizeOptional(proof.sourceCiRunId),
+      JANGAR_SOURCE_CI_CONCLUSION: normalizeOptional(proof.sourceCiConclusion),
+      JANGAR_MANIFEST_IMAGE_DIGEST: normalizeOptional(proof.manifestImageDigest),
+      JANGAR_SERVING_BUILD_COMMIT: normalizeOptional(proof.servingBuildCommit),
+      JANGAR_SERVING_IMAGE_DIGEST: normalizeOptional(proof.servingImageDigest),
+    }).filter((entry): entry is [string, string] => typeof entry[1] === 'string'),
+  )
+
+const upsertDeploymentEnvValues = (manifestPath: string, containerName: string, values: Record<string, string>) => {
+  const changed: Record<string, boolean> = {}
+  for (const [name, value] of Object.entries(values)) {
+    changed[name] = upsertDeploymentContainerEnvValue(manifestPath, containerName, name, value)
+    if (changed[name]) {
+      console.log(`Updated ${manifestPath} env ${name} to ${value}`)
+    } else {
+      console.warn(`Warning: ${manifestPath} env ${name} was not updated; manifest may already match.`)
+    }
+  }
+  return changed
+}
+
+const upsertRecordValues = (record: Record<string, unknown>, values: Record<string, string>) => {
+  let changed = false
+  for (const [key, value] of Object.entries(values)) {
+    if (record[key] !== value) {
+      record[key] = value
+      changed = true
+    }
+  }
+  return changed
+}
+
 const updateAgentsValuesManifest = (
   valuesPath: string,
   imageName: string,
@@ -76,6 +133,7 @@ const updateAgentsValuesManifest = (
   digest: string,
   controlPlaneImageName?: string,
   controlPlaneDigest?: string,
+  sourceServingProofEnv: Record<string, string> = {},
 ): boolean => {
   const source = readFileSync(valuesPath, 'utf8')
   const parsed = YAML.parse(source)
@@ -111,6 +169,16 @@ const updateAgentsValuesManifest = (
     doc.controlPlane = controlPlane
   }
 
+  if (Object.keys(sourceServingProofEnv).length > 0) {
+    const controlPlane = asRecord(doc.controlPlane) ?? {}
+    const controlPlaneEnv = asRecord(controlPlane.env) ?? {}
+    const controlPlaneEnvVars = asRecord(controlPlaneEnv.vars) ?? {}
+    upsertRecordValues(controlPlaneEnvVars, sourceServingProofEnv)
+    controlPlaneEnv.vars = controlPlaneEnvVars
+    controlPlane.env = controlPlaneEnv
+    doc.controlPlane = controlPlane
+  }
+
   const updated = YAML.stringify(doc, { lineWidth: 120 })
   if (source === updated) {
     console.warn('Warning: agents values were not updated; values already match requested image.')
@@ -129,6 +197,9 @@ export const updateJangarManifests = (options: UpdateManifestsOptions) => {
   const digest = normalizeDigest(options.digest ?? inspectImageDigest(`${options.imageName}:${options.tag}`))
   const controlPlaneDigest = options.controlPlaneDigest ? normalizeDigest(options.controlPlaneDigest) : undefined
   const agentsValuesPath = options.agentsValuesPath ? resolvePath(options.agentsValuesPath) : null
+  const manifestImageDigest = normalizeOptional(options.manifestImageDigest) ?? controlPlaneDigest
+  const servingBuildCommit = normalizeOptional(options.servingBuildCommit) ?? normalizeOptional(options.sourceHeadSha)
+  const servingImageDigest = normalizeOptional(options.servingImageDigest) ?? controlPlaneDigest
 
   const kustomizationChanged = updateKustomizationImage(kustomizationPath, options.imageName, options.tag, digest)
   if (!kustomizationChanged) {
@@ -162,28 +233,17 @@ export const updateJangarManifests = (options: UpdateManifestsOptions) => {
   }
 
   const sourceHeadSha = normalizeOptional(options.sourceHeadSha)
-  const sourceHeadShaEnvChanged = sourceHeadSha
-    ? upsertDeploymentContainerEnvValue(serviceManifestPath, 'app', 'JANGAR_SOURCE_HEAD_SHA', sourceHeadSha)
-    : false
-  if (sourceHeadSha) {
-    if (!sourceHeadShaEnvChanged) {
-      console.warn('Warning: jangar source head env was not updated; manifest may already match.')
-    } else {
-      console.log(`Updated ${serviceManifestPath} env JANGAR_SOURCE_HEAD_SHA to ${sourceHeadSha}`)
-    }
-  }
-
   const gitopsRevision = normalizeOptional(options.gitopsRevision)
-  const gitopsRevisionEnvChanged = gitopsRevision
-    ? upsertDeploymentContainerEnvValue(serviceManifestPath, 'app', 'JANGAR_GITOPS_REVISION', gitopsRevision)
-    : false
-  if (gitopsRevision) {
-    if (!gitopsRevisionEnvChanged) {
-      console.warn('Warning: jangar GitOps revision env was not updated; manifest may already match.')
-    } else {
-      console.log(`Updated ${serviceManifestPath} env JANGAR_GITOPS_REVISION to ${gitopsRevision}`)
-    }
-  }
+  const sourceServingProofEnv = buildSourceServingProofEnv({
+    sourceHeadSha,
+    gitopsRevision,
+    sourceCiRunId: options.sourceCiRunId,
+    sourceCiConclusion: options.sourceCiConclusion,
+    manifestImageDigest,
+    servingBuildCommit,
+    servingImageDigest,
+  })
+  const sourceServingProofEnvChanged = upsertDeploymentEnvValues(serviceManifestPath, 'app', sourceServingProofEnv)
 
   const workerChanged = workerManifestPath
     ? updateManifestAnnotation(workerManifestPath, 'kubectl.kubernetes.io/restartedAt', options.rolloutTimestamp)
@@ -205,6 +265,7 @@ export const updateJangarManifests = (options: UpdateManifestsOptions) => {
         digest,
         options.controlPlaneImageName,
         controlPlaneDigest,
+        sourceServingProofEnv,
       )
     : false
 
@@ -217,8 +278,13 @@ export const updateJangarManifests = (options: UpdateManifestsOptions) => {
       kustomization: kustomizationChanged,
       service: serviceChanged,
       runtimeImageEnv: runtimeImageEnvChanged,
-      sourceHeadShaEnv: sourceHeadShaEnvChanged,
-      gitopsRevisionEnv: gitopsRevisionEnvChanged,
+      sourceHeadShaEnv: sourceServingProofEnvChanged.JANGAR_SOURCE_HEAD_SHA ?? false,
+      gitopsRevisionEnv: sourceServingProofEnvChanged.JANGAR_GITOPS_REVISION ?? false,
+      sourceCiRunIdEnv: sourceServingProofEnvChanged.JANGAR_SOURCE_CI_RUN_ID ?? false,
+      sourceCiConclusionEnv: sourceServingProofEnvChanged.JANGAR_SOURCE_CI_CONCLUSION ?? false,
+      manifestImageDigestEnv: sourceServingProofEnvChanged.JANGAR_MANIFEST_IMAGE_DIGEST ?? false,
+      servingBuildCommitEnv: sourceServingProofEnvChanged.JANGAR_SERVING_BUILD_COMMIT ?? false,
+      servingImageDigestEnv: sourceServingProofEnvChanged.JANGAR_SERVING_IMAGE_DIGEST ?? false,
       worker: workerChanged,
       agentsValues: agentsValuesChanged,
     },
@@ -241,6 +307,11 @@ Options:
   --control-plane-digest <value>
   --source-head-sha <sha>
   --gitops-revision <sha>
+  --source-ci-run-id <id>
+  --source-ci-conclusion <conclusion>
+  --manifest-image-digest <digest>
+  --serving-build-commit <sha>
+  --serving-image-digest <digest>
   --rollout-timestamp <ISO8601>
   --kustomization-path <path>
   --service-manifest-path <path>
@@ -287,6 +358,21 @@ Options:
       case '--gitops-revision':
         options.gitopsRevision = value
         break
+      case '--source-ci-run-id':
+        options.sourceCiRunId = value
+        break
+      case '--source-ci-conclusion':
+        options.sourceCiConclusion = value
+        break
+      case '--manifest-image-digest':
+        options.manifestImageDigest = value
+        break
+      case '--serving-build-commit':
+        options.servingBuildCommit = value
+        break
+      case '--serving-image-digest':
+        options.servingImageDigest = value
+        break
       case '--rollout-timestamp':
         options.rolloutTimestamp = value
         break
@@ -331,6 +417,21 @@ export const main = (cliOptions?: CliOptions) => {
       process.env.JANGAR_GITOPS_REVISION ??
       process.env.ARGOCD_APP_REVISION ??
       process.env.ARGOCD_REVISION,
+    sourceCiRunId: parsed.sourceCiRunId ?? process.env.JANGAR_SOURCE_CI_RUN_ID ?? process.env.GITHUB_RUN_ID,
+    sourceCiConclusion: parsed.sourceCiConclusion ?? process.env.JANGAR_SOURCE_CI_CONCLUSION,
+    manifestImageDigest:
+      parsed.manifestImageDigest ??
+      process.env.JANGAR_MANIFEST_IMAGE_DIGEST ??
+      process.env.JANGAR_CONTROL_PLANE_IMAGE_DIGEST,
+    servingBuildCommit:
+      parsed.servingBuildCommit ??
+      process.env.JANGAR_SERVING_BUILD_COMMIT ??
+      process.env.JANGAR_SOURCE_HEAD_SHA ??
+      process.env.JANGAR_COMMIT,
+    servingImageDigest:
+      parsed.servingImageDigest ??
+      process.env.JANGAR_SERVING_IMAGE_DIGEST ??
+      process.env.JANGAR_CONTROL_PLANE_IMAGE_DIGEST,
     rolloutTimestamp,
     kustomizationPath: parsed.kustomizationPath ?? process.env.JANGAR_KUSTOMIZATION_PATH,
     serviceManifestPath: parsed.serviceManifestPath ?? process.env.JANGAR_SERVICE_MANIFEST,

--- a/services/jangar/src/server/__tests__/control-plane-source-serving-contract-verdict.test.ts
+++ b/services/jangar/src/server/__tests__/control-plane-source-serving-contract-verdict.test.ts
@@ -148,4 +148,33 @@ describe('control-plane source-serving contract verdict', () => {
       max_notional: 250,
     })
   })
+
+  it('uses Jangar serving proof env instead of Torghut build metadata for source convergence', () => {
+    const digest = 'sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc'
+    const exchange = build({
+      torghutConsumerEvidence: torghutEvidence({
+        build_commit: 'torghut-build-commit',
+        image_digest: 'sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd',
+        max_notional: '250',
+      }),
+      evidence: {
+        sourceCiRunId: '9003',
+        sourceCiConclusion: 'success',
+        manifestImageDigest: digest,
+        servingBuildCommit: '4dfa7c70771f3f8d6f3884c52a77c41e5e851638',
+        servingImageDigest: digest,
+      },
+    })
+
+    expect(exchange.status).toBe('allow')
+    expect(exchange.serving_build_commit).toBe('4dfa7c70771f3f8d6f3884c52a77c41e5e851638')
+    expect(exchange.serving_image_digest).toBe(digest)
+    expect(exchange.reason_codes).not.toContain('source_serving_build_mismatch')
+    expect(exchange.reason_codes).not.toContain('manifest_serving_image_digest_mismatch')
+    expect(verdict(exchange, 'live_support')).toMatchObject({
+      decision: 'allow',
+      source_serving_state: 'converged',
+      max_notional: 250,
+    })
+  })
 })

--- a/services/jangar/src/server/control-plane-source-serving-contract-verdict.ts
+++ b/services/jangar/src/server/control-plane-source-serving-contract-verdict.ts
@@ -41,6 +41,8 @@ export type SourceServingContractEvidence = {
   sourceCiRunId?: string | null
   sourceCiConclusion?: string | null
   manifestImageDigest?: string | null
+  servingBuildCommit?: string | null
+  servingImageDigest?: string | null
   requiredContracts?: string[]
 }
 
@@ -116,6 +118,12 @@ export const resolveSourceServingContractEnvironment = (
   sourceCiRunId: normalizeNonEmpty(env.JANGAR_SOURCE_CI_RUN_ID ?? env.SOURCE_CI_RUN_ID),
   sourceCiConclusion: normalizeNonEmpty(env.JANGAR_SOURCE_CI_CONCLUSION ?? env.SOURCE_CI_CONCLUSION),
   manifestImageDigest: normalizeNonEmpty(env.JANGAR_MANIFEST_IMAGE_DIGEST ?? env.MANIFEST_IMAGE_DIGEST),
+  servingBuildCommit: normalizeNonEmpty(
+    env.JANGAR_SERVING_BUILD_COMMIT ?? env.SOURCE_SERVING_BUILD_COMMIT ?? env.JANGAR_SOURCE_HEAD_SHA,
+  ),
+  servingImageDigest: normalizeNonEmpty(
+    env.JANGAR_SERVING_IMAGE_DIGEST ?? env.SOURCE_SERVING_IMAGE_DIGEST ?? env.JANGAR_MANIFEST_IMAGE_DIGEST,
+  ),
   requiredContracts: parseContractList(
     env.JANGAR_SOURCE_SERVING_REQUIRED_CONTRACTS ?? env.SOURCE_SERVING_REQUIRED_CONTRACTS,
   ),
@@ -167,8 +175,11 @@ const resolveSourceServingSummary = (input: SourceServingContractVerdictInput): 
   const missingContracts = requiredContracts.filter((contract) => !observedContracts.includes(contract))
   const contractSchemaMismatches = compactStrings(torghut.contract_schema_mismatches ?? [])
   const manifestImageDigest = normalizeNonEmpty(evidence.manifestImageDigest)
-  const servingImageDigest = normalizeNonEmpty(torghut.serving_image_digest) ?? normalizeNonEmpty(torghut.image_digest)
-  const servingBuildCommit = normalizeNonEmpty(torghut.build_commit)
+  const servingImageDigest =
+    normalizeNonEmpty(evidence.servingImageDigest) ??
+    normalizeNonEmpty(torghut.serving_image_digest) ??
+    normalizeNonEmpty(torghut.image_digest)
+  const servingBuildCommit = normalizeNonEmpty(evidence.servingBuildCommit) ?? normalizeNonEmpty(torghut.build_commit)
   const sourceRevisionMissing = !sourceSha || !manifestSha
   const sourceGitopsMismatch = Boolean(sourceSha && manifestSha && !commitsMatch(sourceSha, manifestSha))
   const servingBuildMissing = !servingBuildCommit || servingBuildCommit === 'unknown'


### PR DESCRIPTION
## Summary

- Publishes Jangar source CI and serving-image proof env through the Jangar release workflow.
- Writes the same proof env into both `argocd/applications/jangar/deployment.yaml` and `argocd/applications/agents/values.yaml` during image promotion.
- Makes the source-serving verdict prefer Jangar serving proof before falling back to Torghut consumer build metadata, preventing false cross-plane build or image mismatches.
- Bounds the Torghut whitepaper autoresearch workflow deadline to the tested 10,800 second budget so stale profit runs cannot hold the lane for six hours.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/jangar/__tests__/update-manifests.test.ts`
- `bunx vitest run --config vitest.config.ts src/server/__tests__/control-plane-source-serving-contract-verdict.test.ts` from `services/jangar`
- `bunx oxfmt --check .github/workflows/jangar-release.yml packages/scripts/src/jangar/update-manifests.ts packages/scripts/src/jangar/__tests__/update-manifests.test.ts services/jangar/src/server/control-plane-source-serving-contract-verdict.ts services/jangar/src/server/__tests__/control-plane-source-serving-contract-verdict.test.ts`
- `bun run --cwd packages/scripts lint:oxlint:type`
- `bun run --cwd services/jangar lint:oxlint:type`
- `bun run --cwd services/jangar tsc`
- `bun test packages/scripts/src`
- `bun run lint:argocd`
- `git diff --check HEAD~1..HEAD`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
