### PR TITLE
fix(torghut): align alpha repair receipt selection

### DIFF
--- a/services/torghut/README.md
+++ b/services/torghut/README.md
@@ -203,7 +203,9 @@ Testing rules for the trading core:
   `torghut.executable-alpha-repair-receipts.v1` compact receipt collection. When the live queue is topped by
   `repair_alpha_readiness`, it selects zero-notional `torghut.executable-alpha-repair-receipt.v1` work for the
   concrete alpha repair target, maps target reason codes to a repair class, carries validation commands and
-  no-delta settlement requirements, and keeps `max_notional=0`. `/trading/consumer-evidence` mirrors the same compact
+  no-delta settlement requirements, and keeps `max_notional=0`. Same-class alpha-window receipts prefer feature/drift
+  repair ahead of post-cost and closed-session holds so the selected launch candidate stays aligned with the
+  alpha-readiness settlement conveyor and dividend ledger. `/trading/consumer-evidence` mirrors the same compact
   collection for Jangar without making `/readyz` green or enabling paper/live submission.
 - `GET /trading/revenue-repair` also emits the May 14 doc 199
   `torghut.executable-alpha-settlement-slots.v1` read-model. It settles the selected executable-alpha repair receipt

--- a/services/torghut/app/trading/executable_alpha_receipts.py
+++ b/services/torghut/app/trading/executable_alpha_receipts.py
@@ -136,6 +136,22 @@ _VALIDATION_COMMANDS_BY_CLASS = {
         "uv run --frozen pytest services/torghut/tests/test_executable_alpha_repair_receipts.py",
     ],
 }
+_FEATURE_OR_DRIFT_REPAIR_REASONS = {
+    "drift_checks_missing",
+    "feature_rows_missing",
+    "required_feature_set_unavailable",
+    "hypothesis_window_evidence_missing",
+    "hypothesis_window_evidence_stale",
+}
+_POST_COST_REPAIR_REASONS = {
+    "post_cost_expectancy_non_positive",
+    "post_cost_expectancy_missing",
+}
+_CLOSED_SESSION_REPAIR_REASONS = {
+    "closed_session_market_context_hold",
+    "closed_session_signal_hold",
+    "closed_session_tca_evidence_hold",
+}
 
 
 def _text(value: object, default: str = "") -> str:
@@ -390,9 +406,21 @@ def _required_input_refs(
     return _string_list(refs)
 
 
-def _receipt_target_key(receipt: Mapping[str, Any]) -> tuple[int, str]:
+def _receipt_revenue_lane_rank(receipt: Mapping[str, Any]) -> int:
+    reason_set = set(_string_list(receipt.get("reason_codes")))
+    if reason_set.intersection(_FEATURE_OR_DRIFT_REPAIR_REASONS):
+        return 0
+    if reason_set.intersection(_POST_COST_REPAIR_REASONS):
+        return 2
+    if reason_set.intersection(_CLOSED_SESSION_REPAIR_REASONS):
+        return 3
+    return 1
+
+
+def _receipt_target_key(receipt: Mapping[str, Any]) -> tuple[int, int, str]:
     return (
         _REPAIR_CLASS_RANK.get(_text(receipt.get("repair_class")), 100),
+        _receipt_revenue_lane_rank(receipt),
         _text(receipt.get("hypothesis_id")),
     )
 

--- a/services/torghut/tests/test_executable_alpha_repair_receipts.py
+++ b/services/torghut/tests/test_executable_alpha_repair_receipts.py
@@ -145,6 +145,70 @@ def _h_cont_alpha_readiness() -> dict[str, object]:
     }
 
 
+def _alpha_readiness_with_micro_drift_lane() -> dict[str, object]:
+    return {
+        "promotion_eligible_total": 0,
+        "repair_target_count": 3,
+        "capital_replay_board": {
+            "schema_version": "torghut.capital-replay-board.v1",
+            "board_id": "capital-replay:micro",
+        },
+        "executable_alpha_receipts": {
+            "schema_version": "torghut.executable-alpha-receipts.v1",
+            "candidate_receipts": [
+                {
+                    "receipt_id": "receipt:cont",
+                    "hypothesis_id": "H-CONT-01",
+                    "max_notional": "0",
+                },
+                {
+                    "receipt_id": "receipt:micro",
+                    "hypothesis_id": "H-MICRO-01",
+                    "max_notional": "0",
+                },
+                {
+                    "receipt_id": "receipt:rev",
+                    "hypothesis_id": "H-REV-01",
+                    "max_notional": "0",
+                },
+            ],
+        },
+        "repair_targets": [
+            {
+                "hypothesis_id": "H-CONT-01",
+                "candidate_id": "chip-paper-microbar-composite@execution-proof",
+                "strategy_id": "intraday_tsmom_v1@paper",
+                "state": "shadow",
+                "promotion_eligible": False,
+                "reasons": ["post_cost_expectancy_non_positive"],
+                "informational_reasons": ["closed_session_tca_evidence_hold"],
+            },
+            {
+                "hypothesis_id": "H-MICRO-01",
+                "candidate_id": "chip-paper-microbar-composite@execution-proof",
+                "strategy_id": ("microbar_volume_continuation_long_top2_chip_v1@paper"),
+                "state": "shadow",
+                "promotion_eligible": False,
+                "reasons": ["drift_checks_missing"],
+            },
+            {
+                "hypothesis_id": "H-REV-01",
+                "candidate_id": "chip-paper-microbar-composite@execution-proof",
+                "strategy_id": (
+                    "microbar_prev_day_open45_reversal_long_top1_chip_v1@paper"
+                ),
+                "state": "shadow",
+                "promotion_eligible": False,
+                "reasons": ["post_cost_expectancy_non_positive"],
+                "informational_reasons": [
+                    "closed_session_market_context_hold",
+                    "closed_session_tca_evidence_hold",
+                ],
+            },
+        ],
+    }
+
+
 def _h_cont_repair_receipts() -> tuple[dict[str, object], dict[str, object]]:
     alpha = _h_cont_alpha_readiness()
     return alpha, _build(alpha_readiness=alpha)
@@ -261,6 +325,22 @@ def test_reason_codes_map_to_executable_alpha_repair_classes() -> None:
         "improved",
         "no_delta",
         "invalidated",
+    ]
+
+
+def test_feature_drift_lane_is_selected_before_post_cost_window_receipts() -> None:
+    payload = _build(alpha_readiness=_alpha_readiness_with_micro_drift_lane())
+
+    selected = cast(Mapping[str, Any], payload["selected_receipt"])
+    assert selected["hypothesis_id"] == "H-MICRO-01"
+    assert selected["repair_class"] == "evidence_window_refresh"
+    assert selected["expected_gate_delta"] == "retire_drift_checks_missing"
+    assert selected["max_notional"] == "0"
+    receipts = cast(list[Mapping[str, Any]], payload["receipts"])
+    assert [receipt["hypothesis_id"] for receipt in receipts] == [
+        "H-MICRO-01",
+        "H-CONT-01",
+        "H-REV-01",
     ]
 
 


### PR DESCRIPTION
## Summary

- Aligns `torghut.executable-alpha-repair-receipts.v1` selection with the accepted alpha-readiness conveyor so same-class alpha-window receipts prefer feature/drift repair before post-cost or closed-session holds.
- Adds a regression test proving the live-shaped `H-MICRO-01` drift lane is selected ahead of `H-CONT-01` and `H-REV-01` while keeping `max_notional=0`.
- Updates Torghut README docs for the launch-candidate ordering and Jangar handoff behavior.
- Governing design/runtime requirement: `docs/torghut/design-system/v6/205-torghut-alpha-readiness-settlement-conveyor-and-routeable-profit-runway-2026-05-14.md`, `docs/torghut/design-system/v6/200-torghut-routeable-alpha-evidence-foundry-and-capital-safe-profit-ladder-2026-05-14.md`, and live `/trading/revenue-repair` top queue item `repair_alpha_readiness`.

## Related Issues

None

## Business Evidence

- Before live evidence at `2026-05-14T13:12:48.422260+00:00`: `business_state=repair_only`, `revenue_ready=false`, top repair `repair_alpha_readiness`, value gate `routeable_candidate_count`, `accepted_routeable_candidate_count=0`, `zero_notional_or_stale_evidence_rate=1.0`, executable selected `H-CONT-01`, conveyor/dividend selected `H-MICRO-01`.
- After live pre-deploy evidence at `2026-05-14T13:41:35.379030+00:00`: `business_state=repair_only`, `revenue_ready=false`, top repair `repair_alpha_readiness`, value gate `routeable_candidate_count`, `accepted_routeable_candidate_count=0`, `zero_notional_or_stale_evidence_rate=1.0`, deployed source `3f57e0645905087167f1b52e99cc7d62f1391c57`, executable selected `H-CONT-01`, conveyor/dividend selected `H-MICRO-01`.
- Expected rollout impact: executable-alpha launch selection moves to `H-MICRO-01` for the current feature/drift lane, improving routeable candidate repair evidence consistency without enabling paper/live submission or changing `max_notional=0`.

## Risk And Rollback

- Risk: low; the change only adjusts ordering among already-built zero-notional executable alpha repair receipts and preserves missing-lineage priority plus capital guardrails.
- Rollback: revert this commit or stop emitting `executable_alpha_repair_receipts`; Torghut remains `repair_only` with live submit disabled and `max_notional=0`.

## Testing

- `/tmp/codex-uv/bin/uv sync --frozen --extra dev` - pass.
- `/tmp/codex-uv/bin/uv run --frozen pytest tests/test_executable_alpha_repair_receipts.py tests/test_alpha_readiness_settlement_conveyor.py tests/test_alpha_repair_dividend_ledger.py` - pass, `37 passed`.
- `/tmp/codex-uv/bin/uv run --frozen pytest tests/test_build_revenue_repair_digest.py tests/test_trading_api.py -k 'revenue_repair or executable_alpha or alpha_readiness_settlement or alpha_repair_dividend'` - pass, `16 passed, 87 deselected`.
- `/tmp/codex-uv/bin/uv run --frozen pytest` - pass, `2385 passed in 1385.16s`.
- `/tmp/codex-uv/bin/uv run --frozen ruff format --check app/trading/executable_alpha_receipts.py tests/test_executable_alpha_repair_receipts.py` - pass.
- `/tmp/codex-uv/bin/uv run --frozen ruff check app/trading/executable_alpha_receipts.py tests/test_executable_alpha_repair_receipts.py` - pass.
- `/tmp/codex-uv/bin/uv run --frozen ruff check app tests scripts` - pass.
- `/tmp/codex-uv/bin/uv run --frozen pyright --project pyrightconfig.json` - pass, `0 errors`.
- `/tmp/codex-uv/bin/uv run --frozen pyright --project pyrightconfig.alpha.json` - pass, `0 errors`.
- `/tmp/codex-uv/bin/uv run --frozen pyright --project pyrightconfig.scripts.json` - pass, `0 errors`.
- `/tmp/codex-uv/bin/uv run --frozen ruff format --check app tests scripts` - not used as a merge gate because current Ruff reports 228 pre-existing unrelated files that would be reformatted; touched-file format check is green and no unrelated formatting was applied.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
