### PR TITLE
fix(torghut): persist autoresearch feedback evidence

### DIFF
--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -90,6 +90,8 @@ _DEFAULT_STRICT_DAILY_PROFIT_PROGRAM = Path(
     "config/trading/research-programs/strict-daily-profit-autoresearch-500-v1.yaml"
 )
 _DEFAULT_MAX_FRONTIER_CANDIDATES_PER_SPEC = 8
+_MAX_PERSISTED_FEEDBACK_EVIDENCE_BUNDLES = 512
+_MAX_PERSISTED_FEEDBACK_EVIDENCE_EPOCHS = 12
 _PROGRAM_SOURCE_DEFAULT_CONFIDENCE = "0.70"
 _RUNTIME_CLOSURE_PROOF_ORACLE_BLOCKERS = frozenset(
     {
@@ -342,6 +344,114 @@ def _load_feedback_evidence_bundles(
                     f"feedback_evidence_jsonl_invalid:{raw_path}:{line_number}:{exc}"
                 ) from exc
     return tuple(bundles)
+
+
+def _dedupe_feedback_evidence_bundles(
+    bundles: Sequence[CandidateEvidenceBundle],
+) -> tuple[CandidateEvidenceBundle, ...]:
+    seen: set[str] = set()
+    deduped: list[CandidateEvidenceBundle] = []
+    for bundle in bundles:
+        key = bundle.evidence_bundle_id or _stable_hash(bundle.to_payload())
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(bundle)
+    return tuple(deduped)
+
+
+def _evidence_bundle_payloads_for_epoch_summary(
+    evidence_bundles: Sequence[CandidateEvidenceBundle],
+) -> list[dict[str, Any]]:
+    return [
+        bundle.to_payload()
+        for bundle in evidence_bundles[:_MAX_PERSISTED_FEEDBACK_EVIDENCE_BUNDLES]
+    ]
+
+
+def _load_recent_persisted_feedback_evidence_bundles(
+    *,
+    limit: int = _MAX_PERSISTED_FEEDBACK_EVIDENCE_BUNDLES,
+    epoch_limit: int = _MAX_PERSISTED_FEEDBACK_EVIDENCE_EPOCHS,
+) -> tuple[tuple[CandidateEvidenceBundle, ...], dict[str, Any]]:
+    manifest: dict[str, Any] = {
+        "source": "autoresearch_epochs.summary_json.candidate_evidence_bundle_payloads",
+        "epoch_scan_limit": epoch_limit,
+        "bundle_limit": limit,
+        "scanned_epoch_count": 0,
+        "loaded_bundle_count": 0,
+        "invalid_payload_count": 0,
+    }
+    try:
+        with SessionLocal() as session:
+            epochs = (
+                session.execute(
+                    select(AutoresearchEpoch)
+                    .order_by(
+                        AutoresearchEpoch.completed_at.desc(),
+                        AutoresearchEpoch.created_at.desc(),
+                    )
+                    .limit(epoch_limit)
+                )
+                .scalars()
+                .all()
+            )
+    except Exception as exc:
+        manifest["status"] = "unavailable"
+        manifest["error"] = str(exc)
+        return (), manifest
+
+    manifest["scanned_epoch_count"] = len(epochs)
+    bundles: list[CandidateEvidenceBundle] = []
+    invalid_payload_count = 0
+    source_epoch_ids: list[str] = []
+    for epoch in epochs:
+        if len(bundles) >= limit:
+            break
+        summary = _mapping(epoch.summary_json)
+        payloads = _list_of_mappings(summary.get("candidate_evidence_bundle_payloads"))
+        if not payloads:
+            continue
+        source_epoch_ids.append(epoch.epoch_id)
+        for payload in payloads:
+            if len(bundles) >= limit:
+                break
+            try:
+                bundles.append(evidence_bundle_from_payload(payload))
+            except Exception:
+                invalid_payload_count += 1
+
+    deduped = _dedupe_feedback_evidence_bundles(bundles)
+    manifest["status"] = "loaded" if deduped else "empty"
+    manifest["source_epoch_ids"] = source_epoch_ids
+    manifest["loaded_bundle_count"] = len(deduped)
+    manifest["invalid_payload_count"] = invalid_payload_count
+    return deduped, manifest
+
+
+def _load_autoresearch_feedback_evidence_bundles(
+    paths: Sequence[Path],
+    *,
+    include_persisted: bool,
+) -> tuple[tuple[CandidateEvidenceBundle, ...], dict[str, Any]]:
+    explicit_bundles = _load_feedback_evidence_bundles(paths)
+    persisted_bundles: tuple[CandidateEvidenceBundle, ...] = ()
+    persisted_manifest: dict[str, Any] = {"status": "disabled"}
+    if include_persisted:
+        (
+            persisted_bundles,
+            persisted_manifest,
+        ) = _load_recent_persisted_feedback_evidence_bundles()
+    combined = _dedupe_feedback_evidence_bundles(
+        (*explicit_bundles, *persisted_bundles)
+    )
+    return combined, {
+        "schema_version": "torghut.feedback-evidence-source-manifest.v1",
+        "explicit_jsonl_path_count": len(paths),
+        "explicit_jsonl_bundle_count": len(explicit_bundles),
+        "persisted": persisted_manifest,
+        "combined_bundle_count": len(combined),
+    }
 
 
 def _program_claim_type(claim: ResearchClaim) -> str:
@@ -3895,8 +4005,12 @@ def run_whitepaper_autoresearch_profit_target(
             started_at=started_at,
         )
     try:
-        feedback_evidence_bundles = _load_feedback_evidence_bundles(
-            cast(Sequence[Path], getattr(args, "feedback_evidence_jsonl", ()) or ())
+        (
+            feedback_evidence_bundles,
+            feedback_evidence_source_manifest,
+        ) = _load_autoresearch_feedback_evidence_bundles(
+            cast(Sequence[Path], getattr(args, "feedback_evidence_jsonl", ()) or ()),
+            include_persisted=bool(getattr(args, "persist_results", False)),
         )
     except ValueError as exc:
         return _write_failure_summary(
@@ -3906,6 +4020,10 @@ def run_whitepaper_autoresearch_profit_target(
             reason=str(exc),
             started_at=started_at,
         )
+    _write_json(
+        output_dir / "feedback-evidence-source-manifest.json",
+        feedback_evidence_source_manifest,
+    )
     pre_replay_model, pre_replay_proposal_rows = _pre_replay_proposal_model_and_rows(
         specs=candidate_specs,
         feedback_evidence_bundles=feedback_evidence_bundles,
@@ -4064,6 +4182,9 @@ def run_whitepaper_autoresearch_profit_target(
                     "profitability_search_goal": str(profitability_goal_path),
                     "candidate_selection_manifest": str(
                         output_dir / "candidate-selection-manifest.json"
+                    ),
+                    "feedback_evidence_source_manifest": str(
+                        output_dir / "feedback-evidence-source-manifest.json"
                     ),
                     "partial_candidate_evidence_bundles": str(partial_artifact_path)
                     if partial_replay_result.evidence_bundles
@@ -4284,6 +4405,13 @@ def run_whitepaper_autoresearch_profit_target(
         "candidate_spec_count": len(candidate_specs),
         "candidate_compiler_blocker_count": len(compilation.blockers),
         "evidence_bundle_count": len(replay_result.evidence_bundles),
+        "candidate_evidence_bundle_payloads": _evidence_bundle_payloads_for_epoch_summary(
+            replay_result.evidence_bundles
+        ),
+        "candidate_evidence_bundle_payload_count": min(
+            len(replay_result.evidence_bundles),
+            _MAX_PERSISTED_FEEDBACK_EVIDENCE_BUNDLES,
+        ),
         "replay_candidate_spec_count": len(replay_candidate_specs),
         "replay_incomplete": replay_result.incomplete,
         "replay_failure_reasons": replay_failure_reasons,
@@ -4320,6 +4448,9 @@ def run_whitepaper_autoresearch_profit_target(
             ),
             "pre_replay_proposal_model": str(
                 output_dir / "pre-replay-mlx-ranker-model.json"
+            ),
+            "feedback_evidence_source_manifest": str(
+                output_dir / "feedback-evidence-source-manifest.json"
             ),
             "mlx_snapshot_manifest": str(output_dir / "mlx-snapshot-manifest.json"),
             "candidate_compiler_report": str(

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -391,6 +391,72 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         self.assertEqual(len(loaded), 1)
         self.assertEqual(loaded[0].candidate_spec_id, spec.candidate_spec_id)
 
+    def test_feedback_evidence_loads_recent_persisted_epoch_bundles(self) -> None:
+        spec = self._candidate_spec("spec-feedback-persisted")
+        bundle = runner.evidence_bundle_from_frontier_candidate(
+            candidate_spec_id=spec.candidate_spec_id,
+            candidate={
+                "candidate_id": "cand-feedback-persisted",
+                "family_template_id": spec.family_template_id,
+                "runtime_family": spec.runtime_family,
+                "runtime_strategy_name": spec.runtime_strategy_name,
+                "objective_scorecard": {
+                    "net_pnl_per_day": "-210",
+                    "active_day_ratio": "1",
+                    "positive_day_ratio": "0",
+                    "negative_day_count": 5,
+                    "daily_net": {
+                        "2026-05-01": "-120",
+                        "2026-05-04": "-300",
+                    },
+                },
+            },
+            dataset_snapshot_id="snap-feedback-persisted",
+            result_path="db://autoresearch/prior-epoch/candidate-evidence-bundles.jsonl",
+        )
+        with (
+            Session(self.engine) as session,
+            patch(
+                "scripts.run_whitepaper_autoresearch_profit_target.SessionLocal",
+                side_effect=lambda: Session(self.engine),
+            ),
+        ):
+            session.add(
+                AutoresearchEpoch(
+                    epoch_id="prior-feedback-epoch",
+                    status="no_profit_target_candidate",
+                    target_net_pnl_per_day=Decimal("500"),
+                    paper_run_ids_json=[],
+                    snapshot_manifest_json={},
+                    runner_config_json={},
+                    summary_json={
+                        "candidate_evidence_bundle_payloads": [bundle.to_payload()]
+                    },
+                    started_at=datetime(2026, 5, 12, 14, 0, 0),
+                    completed_at=datetime(2026, 5, 12, 14, 5, 0),
+                    failure_reason=None,
+                )
+            )
+            session.commit()
+
+            loaded, manifest = runner._load_autoresearch_feedback_evidence_bundles(
+                (), include_persisted=True
+            )
+
+        model, rows = runner._pre_replay_proposal_model_and_rows(
+            specs=(spec,), feedback_evidence_bundles=loaded
+        )
+
+        self.assertEqual(manifest["combined_bundle_count"], 1)
+        self.assertEqual(manifest["persisted"]["status"], "loaded")
+        self.assertEqual(
+            manifest["persisted"]["source_epoch_ids"], ["prior-feedback-epoch"]
+        )
+        self.assertEqual(model["feedback_evidence_bundle_count"], 1)
+        self.assertEqual(model["feedback_matched_spec_count"], 1)
+        self.assertEqual(rows[0]["training_source"], "feedback_real_replay")
+        self.assertEqual(rows[0]["feedback_match_scope"], "candidate_spec_id")
+
     def test_feedback_evidence_jsonl_reports_missing_and_invalid_lines(self) -> None:
         with TemporaryDirectory() as tmpdir:
             missing_path = Path(tmpdir) / "missing.jsonl"
@@ -1670,6 +1736,10 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         self.assertEqual(len(proposals), payload["proposal_score_count"])
         self.assertEqual(len(portfolios), 1)
         self.assertEqual(portfolios[0].status, "blocked")
+        self.assertEqual(
+            epoch.summary_json["candidate_evidence_bundle_payload_count"],
+            len(epoch.summary_json["candidate_evidence_bundle_payloads"]),
+        )
 
     def test_epoch_ledgers_allow_repeated_candidate_specs_across_epochs(
         self,

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -457,6 +457,133 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         self.assertEqual(rows[0]["training_source"], "feedback_real_replay")
         self.assertEqual(rows[0]["feedback_match_scope"], "candidate_spec_id")
 
+    def test_feedback_evidence_dedupe_handles_missing_bundle_ids(self) -> None:
+        spec = self._candidate_spec("spec-feedback-dedupe")
+        bundle = runner.evidence_bundle_from_frontier_candidate(
+            candidate_spec_id=spec.candidate_spec_id,
+            candidate={
+                "candidate_id": "cand-feedback-dedupe",
+                "objective_scorecard": {"net_pnl_per_day": "10"},
+            },
+            dataset_snapshot_id="snap-feedback-dedupe",
+            result_path="feedback://dedupe",
+        )
+        no_id_bundle = replace(bundle, evidence_bundle_id="")
+
+        deduped = runner._dedupe_feedback_evidence_bundles((no_id_bundle, no_id_bundle))
+
+        self.assertEqual(len(deduped), 1)
+        self.assertEqual(deduped[0].candidate_spec_id, spec.candidate_spec_id)
+
+    def test_feedback_evidence_persisted_loader_reports_unavailable_store(self) -> None:
+        with patch(
+            "scripts.run_whitepaper_autoresearch_profit_target.SessionLocal",
+            side_effect=RuntimeError("db unavailable"),
+        ):
+            loaded, manifest = runner._load_autoresearch_feedback_evidence_bundles(
+                (), include_persisted=True
+            )
+
+        self.assertEqual(loaded, ())
+        self.assertEqual(manifest["combined_bundle_count"], 0)
+        self.assertEqual(manifest["persisted"]["status"], "unavailable")
+        self.assertIn("db unavailable", manifest["persisted"]["error"])
+
+    def test_feedback_evidence_persisted_loader_skips_empty_invalid_and_limited_payloads(
+        self,
+    ) -> None:
+        valid_spec = self._candidate_spec("spec-feedback-limit")
+        valid_bundle = runner.evidence_bundle_from_frontier_candidate(
+            candidate_spec_id=valid_spec.candidate_spec_id,
+            candidate={
+                "candidate_id": "cand-feedback-limit",
+                "objective_scorecard": {"net_pnl_per_day": "25"},
+            },
+            dataset_snapshot_id="snap-feedback-limit",
+            result_path="feedback://limit",
+        )
+        extra_bundle = runner.evidence_bundle_from_frontier_candidate(
+            candidate_spec_id="spec-feedback-extra",
+            candidate={
+                "candidate_id": "cand-feedback-extra",
+                "objective_scorecard": {"net_pnl_per_day": "30"},
+            },
+            dataset_snapshot_id="snap-feedback-limit",
+            result_path="feedback://limit-extra",
+        )
+        invalid_payload = {"schema_version": "torghut.invalid-feedback.v1"}
+
+        with (
+            Session(self.engine) as session,
+            patch(
+                "scripts.run_whitepaper_autoresearch_profit_target.SessionLocal",
+                side_effect=lambda: Session(self.engine),
+            ),
+        ):
+            session.add_all(
+                [
+                    AutoresearchEpoch(
+                        epoch_id="feedback-empty-epoch",
+                        status="no_profit_target_candidate",
+                        target_net_pnl_per_day=Decimal("500"),
+                        paper_run_ids_json=[],
+                        snapshot_manifest_json={},
+                        runner_config_json={},
+                        summary_json={},
+                        started_at=datetime(2026, 5, 13, 14, 0, 0),
+                        completed_at=datetime(2026, 5, 13, 14, 5, 0),
+                        failure_reason=None,
+                    ),
+                    AutoresearchEpoch(
+                        epoch_id="feedback-invalid-and-limited-epoch",
+                        status="no_profit_target_candidate",
+                        target_net_pnl_per_day=Decimal("500"),
+                        paper_run_ids_json=[],
+                        snapshot_manifest_json={},
+                        runner_config_json={},
+                        summary_json={
+                            "candidate_evidence_bundle_payloads": [
+                                invalid_payload,
+                                valid_bundle.to_payload(),
+                                extra_bundle.to_payload(),
+                            ]
+                        },
+                        started_at=datetime(2026, 5, 12, 14, 0, 0),
+                        completed_at=datetime(2026, 5, 12, 14, 5, 0),
+                        failure_reason=None,
+                    ),
+                    AutoresearchEpoch(
+                        epoch_id="feedback-unscanned-after-limit-epoch",
+                        status="no_profit_target_candidate",
+                        target_net_pnl_per_day=Decimal("500"),
+                        paper_run_ids_json=[],
+                        snapshot_manifest_json={},
+                        runner_config_json={},
+                        summary_json={
+                            "candidate_evidence_bundle_payloads": [
+                                extra_bundle.to_payload()
+                            ]
+                        },
+                        started_at=datetime(2026, 5, 11, 14, 0, 0),
+                        completed_at=datetime(2026, 5, 11, 14, 5, 0),
+                        failure_reason=None,
+                    ),
+                ]
+            )
+            session.commit()
+
+            loaded, manifest = runner._load_recent_persisted_feedback_evidence_bundles(
+                limit=1
+            )
+
+        self.assertEqual(len(loaded), 1)
+        self.assertEqual(loaded[0].candidate_spec_id, valid_spec.candidate_spec_id)
+        self.assertEqual(manifest["status"], "loaded")
+        self.assertEqual(manifest["invalid_payload_count"], 1)
+        self.assertEqual(
+            manifest["source_epoch_ids"], ["feedback-invalid-and-limited-epoch"]
+        )
+
     def test_feedback_evidence_jsonl_reports_missing_and_invalid_lines(self) -> None:
         with TemporaryDirectory() as tmpdir:
             missing_path = Path(tmpdir) / "missing.jsonl"


### PR DESCRIPTION
## Summary

- Persist bounded candidate evidence bundle payloads in autoresearch epoch summaries so completed runs can seed future epochs.
- Load recent persisted autoresearch evidence when explicit feedback JSONL paths are absent, while preserving strict failure behavior for invalid explicit files.
- Write a feedback evidence source manifest and cover persisted-feedback loading with regression tests.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py -q -k 'feedback_evidence or persists_epoch_ledgers'`
- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py -q`
- `uv run --frozen ruff format --check scripts/run_whitepaper_autoresearch_profit_target.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv run --frozen ruff check scripts/run_whitepaper_autoresearch_profit_target.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
