### PR TITLE
chore(jangar): promote image 13d640a0

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 0f963a1d
-  digest: sha256:3e0cc409faa2445769ad05266674ee0c370ef07be8b11d78a295974f20828e11
+  tag: 13d640a0
+  digest: sha256:68335f00b292252c64080a51f6b7f724fabc68be7f70f156ca3f44619e2590a8
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,25 +11,25 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 0f963a1d
-    digest: sha256:41c2cec100cf819712a64e39b504a965dd34a1519d90b14c23905e259a512e21
+    tag: 13d640a0
+    digest: sha256:5a3935288918a35399d60c667d823af93cad07fa01d2219b7b18ae77126b7016
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
       JANGAR_TORGHUT_STATUS_URL: http://torghut.torghut.svc.cluster.local/trading/consumer-evidence
       JANGAR_TORGHUT_STATUS_TIMEOUT_MS: "3000"
-      JANGAR_SOURCE_HEAD_SHA: 0f963a1deaa5bd5c18e1bfa7779791dfb767a297
-      JANGAR_GITOPS_REVISION: 0f963a1deaa5bd5c18e1bfa7779791dfb767a297
-      JANGAR_SOURCE_CI_RUN_ID: "25863790187"
+      JANGAR_SOURCE_HEAD_SHA: 13d640a02e107b453684078b13a223711444407b
+      JANGAR_GITOPS_REVISION: 13d640a02e107b453684078b13a223711444407b
+      JANGAR_SOURCE_CI_RUN_ID: "25864565594"
       JANGAR_SOURCE_CI_CONCLUSION: success
-      JANGAR_MANIFEST_IMAGE_DIGEST: sha256:41c2cec100cf819712a64e39b504a965dd34a1519d90b14c23905e259a512e21
-      JANGAR_SERVING_BUILD_COMMIT: 0f963a1deaa5bd5c18e1bfa7779791dfb767a297
-      JANGAR_SERVING_IMAGE_DIGEST: sha256:41c2cec100cf819712a64e39b504a965dd34a1519d90b14c23905e259a512e21
+      JANGAR_MANIFEST_IMAGE_DIGEST: sha256:5a3935288918a35399d60c667d823af93cad07fa01d2219b7b18ae77126b7016
+      JANGAR_SERVING_BUILD_COMMIT: 13d640a02e107b453684078b13a223711444407b
+      JANGAR_SERVING_IMAGE_DIGEST: sha256:5a3935288918a35399d60c667d823af93cad07fa01d2219b7b18ae77126b7016
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 0f963a1d
-    digest: sha256:3e0cc409faa2445769ad05266674ee0c370ef07be8b11d78a295974f20828e11
+    tag: 13d640a0
+    digest: sha256:68335f00b292252c64080a51f6b7f724fabc68be7f70f156ca3f44619e2590a8
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-14T13:51:07Z
+    deploy.knative.dev/rollout: 2026-05-14T14:06:05Z
 spec:
   replicas: 1
   strategy:
@@ -57,11 +57,11 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_RUNTIME_IMAGE
-              value: registry.ide-newton.ts.net/lab/jangar:0f963a1d@sha256:3e0cc409faa2445769ad05266674ee0c370ef07be8b11d78a295974f20828e11
+              value: registry.ide-newton.ts.net/lab/jangar:13d640a0@sha256:68335f00b292252c64080a51f6b7f724fabc68be7f70f156ca3f44619e2590a8
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: 0f963a1deaa5bd5c18e1bfa7779791dfb767a297
+              value: 13d640a02e107b453684078b13a223711444407b
             - name: JANGAR_GITOPS_REVISION
-              value: 0f963a1deaa5bd5c18e1bfa7779791dfb767a297
+              value: 13d640a02e107b453684078b13a223711444407b
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_BUMBA_TASK_QUEUE
@@ -401,15 +401,15 @@ spec:
             - name: OPENAI_EMBEDDING_TIMEOUT_MS
               value: "60000"
             - name: JANGAR_SOURCE_CI_RUN_ID
-              value: "25863790187"
+              value: "25864565594"
             - name: JANGAR_SOURCE_CI_CONCLUSION
               value: success
             - name: JANGAR_MANIFEST_IMAGE_DIGEST
-              value: sha256:41c2cec100cf819712a64e39b504a965dd34a1519d90b14c23905e259a512e21
+              value: sha256:5a3935288918a35399d60c667d823af93cad07fa01d2219b7b18ae77126b7016
             - name: JANGAR_SERVING_BUILD_COMMIT
-              value: 0f963a1deaa5bd5c18e1bfa7779791dfb767a297
+              value: 13d640a02e107b453684078b13a223711444407b
             - name: JANGAR_SERVING_IMAGE_DIGEST
-              value: sha256:41c2cec100cf819712a64e39b504a965dd34a1519d90b14c23905e259a512e21
+              value: sha256:5a3935288918a35399d60c667d823af93cad07fa01d2219b7b18ae77126b7016
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -59,5 +59,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: 0f963a1d
-    digest: sha256:3e0cc409faa2445769ad05266674ee0c370ef07be8b11d78a295974f20828e11
+    newTag: 13d640a0
+    digest: sha256:68335f00b292252c64080a51f6b7f724fabc68be7f70f156ca3f44619e2590a8


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `13d640a02e107b453684078b13a223711444407b`
- Image tag: `13d640a0`
- Image digest: `sha256:68335f00b292252c64080a51f6b7f724fabc68be7f70f156ca3f44619e2590a8`
- Source CI run: `25864565594`
- Control-plane serving digest: `sha256:5a3935288918a35399d60c667d823af93cad07fa01d2219b7b18ae77126b7016`
- Updated API rollout annotation
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`
- Published source-serving proof env for revenue repair custody gates