### PR TITLE
fix(torghut): consume live market context proof

### DIFF
--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -89,6 +89,14 @@ spec:
               value: "false"
             - name: TRADING_SIMPLE_ORDER_FEED_TELEMETRY_ENABLED
               value: "false"
+            - name: TRADING_MARKET_CONTEXT_URL
+              value: http://jangar.jangar.svc.cluster.local/api/torghut/market-context
+            - name: TRADING_MARKET_CONTEXT_TIMEOUT_SECONDS
+              value: "5"
+            - name: TRADING_MARKET_CONTEXT_REQUIRED
+              value: "false"
+            - name: TRADING_MARKET_CONTEXT_FAIL_MODE
+              value: shadow_only
             - name: TRADING_KILL_SWITCH_ENABLED
               value: "false"
             - name: TRADING_FEATURE_FLAGS_ENABLED

--- a/services/torghut/app/trading/scheduler/runtime.py
+++ b/services/torghut/app/trading/scheduler/runtime.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from datetime import datetime, timedelta, timezone
 from typing import Any, Optional, cast
 
@@ -21,7 +21,7 @@ from ..firewall import OrderFirewall
 from ..ingest import ClickHouseSignalIngestor
 from ..llm.dspy_programs.runtime import DSPyReviewRuntime, DSPyRuntimeUnsupportedStateError
 from ..llm.guardrails import evaluate_llm_guardrails
-from ..market_context import MarketContextClient
+from ..market_context import MarketContextClient, evaluate_market_context
 from ..order_feed import OrderFeedIngestor
 from ..prices import ClickHousePriceFetcher
 from ..reconcile import Reconciler
@@ -172,7 +172,11 @@ class TradingScheduler(TradingSchedulerGovernanceMixin):
             raw_status = None
             if isinstance(executor, OrderExecutor):
                 raw_status = executor.shorting_metadata_status()
-            account_ready = raw_status.get("account_ready") if isinstance(raw_status, Mapping) else None
+            account_ready = (
+                raw_status.get("account_ready")
+                if isinstance(raw_status, Mapping)
+                else None
+            )
             alert_active = account_ready is False
         if isinstance(executor, OrderExecutor):
             status = cast(dict[str, object], executor.shorting_metadata_status())
@@ -188,6 +192,7 @@ class TradingScheduler(TradingSchedulerGovernanceMixin):
     def market_context_status(self) -> dict[str, object]:
         health: dict[str, Any] | None = None
         health_error: str | None = None
+        context_error: str | None = None
         pipeline = self._pipeline
         market_context_client = (
             getattr(pipeline, "market_context_client", None)
@@ -197,14 +202,72 @@ class TradingScheduler(TradingSchedulerGovernanceMixin):
         if not isinstance(market_context_client, MarketContextClient):
             market_context_client = MarketContextClient()
         as_of = resolve_market_context_as_of()
-        if self.state.last_market_context_symbol:
+        last_symbol = self.state.last_market_context_symbol
+        last_checked_at = self.state.last_market_context_checked_at
+        last_as_of = self.state.last_market_context_as_of
+        last_freshness_seconds = self.state.last_market_context_freshness_seconds
+        last_quality_score = self.state.last_market_context_quality_score
+        last_domain_states = dict(self.state.last_market_context_domain_states)
+        last_risk_flags = list(self.state.last_market_context_risk_flags)
+        last_allow_llm = self.state.last_market_context_allow_llm
+        last_reason = self.state.last_market_context_reason
+        alert_active = self.state.market_context_alert_active
+        alert_reason = self.state.market_context_alert_reason
+        probe_symbol = self._market_context_probe_symbol()
+        fetch_symbol = last_symbol or probe_symbol
+        if fetch_symbol:
             try:
                 health = market_context_client.fetch_health(
-                    self.state.last_market_context_symbol,
+                    fetch_symbol,
                     as_of=as_of,
                 )
             except Exception as exc:
                 health_error = str(exc)
+        if (
+            settings.trading_market_context_url
+            and (last_freshness_seconds is None or last_symbol is None)
+            and probe_symbol
+        ):
+            try:
+                bundle = market_context_client.fetch(probe_symbol, as_of=as_of)
+            except Exception as exc:
+                context_error = str(exc)
+                self.state.last_market_context_fetch_error = context_error
+            else:
+                if bundle is not None:
+                    verdict = evaluate_market_context(bundle)
+                    last_symbol = bundle.symbol
+                    last_checked_at = datetime.now(timezone.utc)
+                    last_as_of = bundle.as_of_utc
+                    last_freshness_seconds = int(bundle.freshness_seconds)
+                    last_quality_score = float(bundle.quality_score)
+                    last_domain_states = {
+                        "technicals": bundle.domains.technicals.state,
+                        "fundamentals": bundle.domains.fundamentals.state,
+                        "news": bundle.domains.news.state,
+                        "regime": bundle.domains.regime.state,
+                    }
+                    last_risk_flags = list(bundle.risk_flags)
+                    last_allow_llm = verdict.allow_llm
+                    last_reason = verdict.reason
+                    alert_active = not verdict.allow_llm
+                    alert_reason = verdict.reason
+                    self.state.last_market_context_symbol = last_symbol
+                    self.state.last_market_context_checked_at = last_checked_at
+                    self.state.last_market_context_as_of = last_as_of
+                    self.state.last_market_context_freshness_seconds = (
+                        last_freshness_seconds
+                    )
+                    self.state.last_market_context_quality_score = last_quality_score
+                    self.state.last_market_context_domain_states = dict(
+                        last_domain_states
+                    )
+                    self.state.last_market_context_risk_flags = list(last_risk_flags)
+                    self.state.last_market_context_allow_llm = last_allow_llm
+                    self.state.last_market_context_reason = last_reason
+                    self.state.last_market_context_fetch_error = None
+                    self.state.market_context_alert_active = alert_active
+                    self.state.market_context_alert_reason = alert_reason
         return {
             "required": settings.trading_market_context_required,
             "fail_mode": settings.trading_market_context_fail_mode,
@@ -213,24 +276,55 @@ class TradingScheduler(TradingSchedulerGovernanceMixin):
             "max_staleness_seconds": settings.trading_market_context_max_staleness_seconds,
             "fundamentals_degraded_max_staleness_seconds": settings.trading_market_context_fundamentals_degraded_max_staleness_seconds,
             "news_degraded_max_staleness_seconds": settings.trading_market_context_news_degraded_max_staleness_seconds,
-            "last_symbol": self.state.last_market_context_symbol,
-            "last_checked_at": self.state.last_market_context_checked_at,
-            "last_as_of": self.state.last_market_context_as_of,
-            "last_freshness_seconds": self.state.last_market_context_freshness_seconds,
-            "last_quality_score": self.state.last_market_context_quality_score,
-            "last_domain_states": dict(self.state.last_market_context_domain_states),
-            "last_risk_flags": list(self.state.last_market_context_risk_flags),
-            "last_allow_llm": self.state.last_market_context_allow_llm,
-            "last_reason": self.state.last_market_context_reason,
-            "last_fetch_error": self.state.last_market_context_fetch_error,
+            "last_symbol": last_symbol,
+            "last_checked_at": last_checked_at,
+            "last_as_of": last_as_of,
+            "last_freshness_seconds": last_freshness_seconds,
+            "last_quality_score": last_quality_score,
+            "last_domain_states": last_domain_states,
+            "last_risk_flags": last_risk_flags,
+            "last_allow_llm": last_allow_llm,
+            "last_reason": last_reason,
+            "last_fetch_error": self.state.last_market_context_fetch_error
+            or context_error,
             "reason_total": dict(self.state.metrics.llm_market_context_reason_total),
             "shadow_total": dict(self.state.metrics.llm_market_context_shadow_total),
-            "alert_active": self.state.market_context_alert_active,
-            "alert_reason": self.state.market_context_alert_reason,
+            "alert_active": alert_active,
+            "alert_reason": alert_reason,
             "health": health,
             "health_error": health_error,
-            "time_source": trading_time_status(account_label=settings.trading_account_label),
+            "time_source": trading_time_status(
+                account_label=settings.trading_account_label
+            ),
         }
+
+    def _market_context_probe_symbol(self) -> str | None:
+        existing_symbol = (
+            str(self.state.last_market_context_symbol or "").strip().upper()
+        )
+        if existing_symbol:
+            return existing_symbol
+        pipeline = self._pipeline
+        resolver = (
+            getattr(pipeline, "universe_resolver", None)
+            if pipeline is not None
+            else None
+        )
+        if resolver is not None:
+            try:
+                symbols = cast(
+                    Iterable[object], getattr(resolver.get_resolution(), "symbols", ())
+                )
+                for symbol in sorted(str(raw).strip().upper() for raw in symbols):
+                    if symbol:
+                        return symbol
+            except Exception:
+                logger.exception("Market-context status probe universe unavailable")
+        for symbol in settings.trading_static_symbols:
+            normalized = str(symbol).strip().upper()
+            if normalized:
+                return normalized
+        return None
 
     def rejection_alert_status(self) -> dict[str, object]:
         llm_requests_total = max(0, int(self.state.metrics.llm_requests_total))

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -247,7 +247,10 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertIsNone(settings.trading_jangar_symbols_url)
         self.assertIsNone(settings.trading_jangar_control_plane_status_url)
         self.assertIsNone(settings.trading_jangar_quant_health_url)
-        self.assertIsNone(settings.trading_market_context_url)
+        self.assertEqual(
+            settings.trading_market_context_url,
+            "http://jangar.jangar.svc.cluster.local/api/torghut/market-context",
+        )
         self.assertEqual(
             set(settings.trading_static_symbols),
             _LIVE_EXECUTION_CHIP_UNIVERSE_SYMBOLS,
@@ -267,11 +270,12 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertNotIn("TRADING_JANGAR_CONTROL_PLANE_TIMEOUT_SECONDS", env)
         self.assertNotIn("TRADING_JANGAR_QUANT_HEALTH_REQUIRED", env)
         self.assertNotIn("TRADING_JANGAR_QUANT_HEALTH_URL", env)
-        self.assertNotIn("TRADING_MARKET_CONTEXT_URL", env)
-        self.assertFalse(
-            any(key.startswith("TRADING_MARKET_CONTEXT_") for key in env),
-            "live trading service must not import external market-context wiring",
+        self.assertEqual(
+            env.get("TRADING_MARKET_CONTEXT_URL"), settings.trading_market_context_url
         )
+        self.assertEqual(env.get("TRADING_MARKET_CONTEXT_TIMEOUT_SECONDS"), "5")
+        self.assertEqual(env.get("TRADING_MARKET_CONTEXT_REQUIRED"), "false")
+        self.assertEqual(env.get("TRADING_MARKET_CONTEXT_FAIL_MODE"), "shadow_only")
         self.assertNotIn("JANGAR_BASE_URL", env)
 
     def test_live_manifest_has_no_jangar_trading_loop_urls(self) -> None:
@@ -284,9 +288,12 @@ class TestLiveConfigManifestContract(TestCase):
             "TRADING_JANGAR_CONTROL_PLANE_TIMEOUT_SECONDS",
             "TRADING_JANGAR_QUANT_HEALTH_REQUIRED",
             "TRADING_JANGAR_QUANT_HEALTH_URL",
-            "TRADING_MARKET_CONTEXT_URL",
         }
         self.assertTrue(blocked_env.isdisjoint(env))
+        self.assertEqual(
+            env.get("TRADING_MARKET_CONTEXT_URL"),
+            "http://jangar.jangar.svc.cluster.local/api/torghut/market-context",
+        )
 
     def test_strategy_catalog_universes_are_chip_only(self) -> None:
         for strategy in _load_torghut_strategy_catalog():

--- a/services/torghut/tests/test_scheduler_market_context_status.py
+++ b/services/torghut/tests/test_scheduler_market_context_status.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import json
+from typing import Any, cast
+from unittest import TestCase
+from unittest.mock import patch
+
+from app import config
+from app.trading.llm.schema import MarketContextBundle
+from app.trading.scheduler.runtime import TradingScheduler
+
+
+class _FakeResponse:
+    status = 200
+
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self._payload = json.dumps(payload).encode("utf-8")
+
+    def read(self) -> bytes:
+        return self._payload
+
+    def __enter__(self) -> "_FakeResponse":
+        return self
+
+    def __exit__(self, _exc_type: object, _exc: object, _tb: object) -> bool:
+        return False
+
+
+class _BrokenUniverseResolver:
+    def get_resolution(self) -> object:
+        raise RuntimeError("universe unavailable")
+
+
+class _PipelineWithBrokenUniverse:
+    universe_resolver = _BrokenUniverseResolver()
+
+
+class TestTradingSchedulerMarketContextStatus(TestCase):
+    def setUp(self) -> None:
+        self._original_url = config.settings.trading_market_context_url
+        self._original_timeout = config.settings.trading_market_context_timeout_seconds
+        self._original_static_symbols = config.settings.trading_static_symbols_raw
+        self._original_min_quality = config.settings.trading_market_context_min_quality
+        self._original_max_staleness = (
+            config.settings.trading_market_context_max_staleness_seconds
+        )
+
+    def tearDown(self) -> None:
+        config.settings.trading_market_context_url = self._original_url
+        config.settings.trading_market_context_timeout_seconds = self._original_timeout
+        config.settings.trading_static_symbols_raw = self._original_static_symbols
+        config.settings.trading_market_context_min_quality = self._original_min_quality
+        config.settings.trading_market_context_max_staleness_seconds = (
+            self._original_max_staleness
+        )
+
+    def test_status_fetches_jangar_context_when_runtime_state_is_empty(self) -> None:
+        config.settings.trading_market_context_url = (
+            "http://jangar.test/api/torghut/market-context"
+        )
+        config.settings.trading_market_context_timeout_seconds = 2
+        config.settings.trading_static_symbols_raw = "AAPL,NVDA"
+        config.settings.trading_market_context_min_quality = 0.4
+        config.settings.trading_market_context_max_staleness_seconds = 300
+
+        bundle = MarketContextBundle.model_validate(
+            {
+                "contextVersion": "torghut.market-context.v1",
+                "symbol": "AAPL",
+                "asOfUtc": "2026-05-14T13:35:00Z",
+                "freshnessSeconds": 20,
+                "qualityScore": 0.82,
+                "sourceCount": 4,
+                "riskFlags": [],
+                "domains": {
+                    "technicals": {
+                        "domain": "technicals",
+                        "state": "ok",
+                        "asOf": "2026-05-14T13:35:00Z",
+                        "freshnessSeconds": 20,
+                        "maxFreshnessSeconds": 60,
+                        "sourceCount": 1,
+                        "qualityScore": 1,
+                        "payload": {},
+                        "citations": [],
+                        "riskFlags": [],
+                    },
+                    "fundamentals": {
+                        "domain": "fundamentals",
+                        "state": "ok",
+                        "asOf": "2026-05-14T13:20:00Z",
+                        "freshnessSeconds": 920,
+                        "maxFreshnessSeconds": 86400,
+                        "sourceCount": 3,
+                        "qualityScore": 0.95,
+                        "payload": {},
+                        "citations": [],
+                        "riskFlags": [],
+                    },
+                    "news": {
+                        "domain": "news",
+                        "state": "ok",
+                        "asOf": "2026-05-14T13:34:00Z",
+                        "freshnessSeconds": 80,
+                        "maxFreshnessSeconds": 600,
+                        "sourceCount": 3,
+                        "qualityScore": 0.9,
+                        "payload": {},
+                        "citations": [],
+                        "riskFlags": [],
+                    },
+                    "regime": {
+                        "domain": "regime",
+                        "state": "ok",
+                        "asOf": "2026-05-14T13:35:00Z",
+                        "freshnessSeconds": 20,
+                        "maxFreshnessSeconds": 120,
+                        "sourceCount": 1,
+                        "qualityScore": 1,
+                        "payload": {},
+                        "citations": [],
+                        "riskFlags": [],
+                    },
+                },
+            }
+        )
+        responses = iter(
+            [
+                _FakeResponse({"ok": True, "health": {"ok": True}}),
+                _FakeResponse(
+                    {
+                        "ok": True,
+                        "context": bundle.model_dump(mode="json", by_alias=True),
+                    }
+                ),
+            ]
+        )
+        request_urls: list[str] = []
+
+        def fake_urlopen(request: Any, _timeout: int) -> _FakeResponse:
+            request_urls.append(str(request.full_url))
+            return next(responses)
+
+        scheduler = TradingScheduler()
+        with patch("app.trading.market_context.urlopen", side_effect=fake_urlopen):
+            status = scheduler.market_context_status()
+
+        self.assertIn("/api/torghut/market-context/health?symbol=AAPL", request_urls[0])
+        self.assertIn("/api/torghut/market-context?symbol=AAPL", request_urls[1])
+        self.assertEqual(status["last_symbol"], "AAPL")
+        self.assertEqual(scheduler.state.last_market_context_symbol, "AAPL")
+        self.assertEqual(status["last_freshness_seconds"], 20)
+        self.assertEqual(scheduler.state.last_market_context_freshness_seconds, 20)
+        self.assertEqual(status["last_quality_score"], 0.82)
+        self.assertEqual(
+            status["last_domain_states"],
+            {
+                "technicals": "ok",
+                "fundamentals": "ok",
+                "news": "ok",
+                "regime": "ok",
+            },
+        )
+        self.assertFalse(status["alert_active"])
+        self.assertFalse(scheduler.state.market_context_alert_active)
+
+    def test_status_records_context_fetch_error(self) -> None:
+        config.settings.trading_market_context_url = (
+            "http://jangar.test/api/torghut/market-context"
+        )
+        config.settings.trading_market_context_timeout_seconds = 2
+        config.settings.trading_static_symbols_raw = "AAPL"
+
+        request_urls: list[str] = []
+
+        def fake_urlopen(request: Any, _timeout: int) -> _FakeResponse:
+            request_urls.append(str(request.full_url))
+            if len(request_urls) == 1:
+                return _FakeResponse({"ok": True, "health": {"ok": True}})
+            raise RuntimeError("context unavailable")
+
+        scheduler = TradingScheduler()
+        with patch("app.trading.market_context.urlopen", side_effect=fake_urlopen):
+            status = scheduler.market_context_status()
+
+        self.assertIn("/api/torghut/market-context/health?symbol=AAPL", request_urls[0])
+        self.assertIn("/api/torghut/market-context?symbol=AAPL", request_urls[1])
+        self.assertEqual(status["last_fetch_error"], "context unavailable")
+        self.assertEqual(
+            scheduler.state.last_market_context_fetch_error,
+            "context unavailable",
+        )
+
+    def test_probe_symbol_falls_back_when_universe_resolution_fails(self) -> None:
+        config.settings.trading_static_symbols_raw = "MSFT,AAPL"
+
+        scheduler = TradingScheduler()
+        cast(Any, scheduler)._pipeline = _PipelineWithBrokenUniverse()
+
+        self.assertEqual(
+            cast(Any, scheduler)._market_context_probe_symbol(),
+            "MSFT",
+        )


### PR DESCRIPTION
## Summary

- Wire live Torghut to the Jangar market-context proof endpoint in shadow-only mode; live order submission remains disabled.
- Teach `TradingScheduler.market_context_status()` to fetch and persist Jangar context for a configured probe symbol when runtime state has not observed market context yet.
- Add regression coverage for empty runtime-state context consumption, fetch-error handling, probe fallback, and the live manifest contract around the allowed market-context wiring.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_market_context.py tests/test_scheduler_market_context_status.py tests/test_live_config_manifest_contract.py -q`
- `uv run --frozen ruff check app/trading/scheduler/runtime.py tests/test_scheduler_market_context_status.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `bun run lint:argocd`
- `git diff --check origin/main...HEAD`
- `uv run --frozen coverage erase && uv run --frozen coverage run -m pytest tests/test_scheduler_market_context_status.py tests/test_live_config_manifest_contract.py -q && uv run --frozen coverage xml -o coverage.xml --fail-under=0 && uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
