### PR TITLE
chore(torghut): promote image c9d34c00

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:ecaf3a3e8353ed0260298132d8cf9d119f651313ffb243d3df95fcaa8ab39dd3
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:9abced565f41edf729b9a0309d573f106d511c1e6c36c5dca31b326d4f37fa9e
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.569.1-410-g637239a49
+              value: v0.569.1-412-gc9d34c004
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 637239a49a577d20596ded51244d6fb3b0cf3d72
+              value: c9d34c004373e65aca89dfc6cf5608170fb91bee
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:ecaf3a3e8353ed0260298132d8cf9d119f651313ffb243d3df95fcaa8ab39dd3
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:9abced565f41edf729b9a0309d573f106d511c1e6c36c5dca31b326d4f37fa9e
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.569.1-410-g637239a49
+              value: v0.569.1-412-gc9d34c004
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 637239a49a577d20596ded51244d6fb3b0cf3d72
+              value: c9d34c004373e65aca89dfc6cf5608170fb91bee
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:ecaf3a3e8353ed0260298132d8cf9d119f651313ffb243d3df95fcaa8ab39dd3
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:9abced565f41edf729b9a0309d573f106d511c1e6c36c5dca31b326d4f37fa9e
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:ecaf3a3e8353ed0260298132d8cf9d119f651313ffb243d3df95fcaa8ab39dd3
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:9abced565f41edf729b9a0309d573f106d511c1e6c36c5dca31b326d4f37fa9e
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:ecaf3a3e8353ed0260298132d8cf9d119f651313ffb243d3df95fcaa8ab39dd3
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:9abced565f41edf729b9a0309d573f106d511c1e6c36c5dca31b326d4f37fa9e
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:ecaf3a3e8353ed0260298132d8cf9d119f651313ffb243d3df95fcaa8ab39dd3
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:9abced565f41edf729b9a0309d573f106d511c1e6c36c5dca31b326d4f37fa9e
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:ecaf3a3e8353ed0260298132d8cf9d119f651313ffb243d3df95fcaa8ab39dd3
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:9abced565f41edf729b9a0309d573f106d511c1e6c36c5dca31b326d4f37fa9e
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -15,7 +15,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:ecaf3a3e8353ed0260298132d8cf9d119f651313ffb243d3df95fcaa8ab39dd3
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:9abced565f41edf729b9a0309d573f106d511c1e6c36c5dca31b326d4f37fa9e
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -23,7 +23,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:ecaf3a3e8353ed0260298132d8cf9d119f651313ffb243d3df95fcaa8ab39dd3
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:9abced565f41edf729b9a0309d573f106d511c1e6c36c5dca31b326d4f37fa9e
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:ecaf3a3e8353ed0260298132d8cf9d119f651313ffb243d3df95fcaa8ab39dd3
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:9abced565f41edf729b9a0309d573f106d511c1e6c36c5dca31b326d4f37fa9e
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-14T14:21:03Z"
+        client.knative.dev/updateTimestamp: "2026-05-14T14:45:11Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -27,7 +27,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:ecaf3a3e8353ed0260298132d8cf9d119f651313ffb243d3df95fcaa8ab39dd3
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:9abced565f41edf729b9a0309d573f106d511c1e6c36c5dca31b326d4f37fa9e
           ports:
             - name: http1
               containerPort: 8181
@@ -482,11 +482,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.569.1-410-g637239a49
+              value: v0.569.1-412-gc9d34c004
             - name: TORGHUT_COMMIT
-              value: 637239a49a577d20596ded51244d6fb3b0cf3d72
+              value: c9d34c004373e65aca89dfc6cf5608170fb91bee
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:ecaf3a3e8353ed0260298132d8cf9d119f651313ffb243d3df95fcaa8ab39dd3
+              value: sha256:9abced565f41edf729b9a0309d573f106d511c1e6c36c5dca31b326d4f37fa9e
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-14T14:21:03Z"
+        client.knative.dev/updateTimestamp: "2026-05-14T14:45:11Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:ecaf3a3e8353ed0260298132d8cf9d119f651313ffb243d3df95fcaa8ab39dd3
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:9abced565f41edf729b9a0309d573f106d511c1e6c36c5dca31b326d4f37fa9e
           ports:
             - name: http1
               containerPort: 8181
@@ -306,11 +306,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.569.1-410-g637239a49
+              value: v0.569.1-412-gc9d34c004
             - name: TORGHUT_COMMIT
-              value: 637239a49a577d20596ded51244d6fb3b0cf3d72
+              value: c9d34c004373e65aca89dfc6cf5608170fb91bee
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:ecaf3a3e8353ed0260298132d8cf9d119f651313ffb243d3df95fcaa8ab39dd3
+              value: sha256:9abced565f41edf729b9a0309d573f106d511c1e6c36c5dca31b326d4f37fa9e
           livenessProbe:
             httpGet:
               path: /healthz

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -98,7 +98,7 @@ spec:
           - name: allowStaleTape
           - name: persistResults
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:ecaf3a3e8353ed0260298132d8cf9d119f651313ffb243d3df95fcaa8ab39dd3
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:9abced565f41edf729b9a0309d573f106d511c1e6c36c5dca31b326d4f37fa9e
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
+++ b/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:ecaf3a3e8353ed0260298132d8cf9d119f651313ffb243d3df95fcaa8ab39dd3
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:9abced565f41edf729b9a0309d573f106d511c1e6c36c5dca31b326d4f37fa9e
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `c9d34c004373e65aca89dfc6cf5608170fb91bee`
- Image tag: `c9d34c00`
- Image digest: `sha256:9abced565f41edf729b9a0309d573f106d511c1e6c36c5dca31b326d4f37fa9e`