### PR TITLE
feat(torghut): add no-delta reentry auction

### DIFF
--- a/docs/torghut/rollouts/2026-05-14-no-delta-reentry-auction.md
+++ b/docs/torghut/rollouts/2026-05-14-no-delta-reentry-auction.md
@@ -1,0 +1,95 @@
+# Torghut no-delta repair reentry auction rollout note
+
+Governing design:
+
+- `docs/torghut/design-system/v6/206-torghut-no-delta-repair-reentry-auction-and-verification-carry-2026-05-14.md`
+- `docs/torghut/design-system/v6/207-torghut-quant-plan-closeout-and-alpha-repair-reentry-handoff-2026-05-14.md`
+
+Runtime requirement:
+
+- Source of truth: `GET http://torghut.torghut.svc.cluster.local/trading/revenue-repair`
+- Business metric: increase routeable post-cost profit evidence and live trading readiness without weakening capital
+  safety.
+- Selected value gate: `routeable_candidate_count`.
+
+## Live evidence before implementation
+
+Read-only sample at `2026-05-14T14:34:43Z`:
+
+- `business_state=repair_only`
+- `revenue_ready=false`
+- active revision `torghut-00392`
+- source commit `637239a49a577d20596ded51244d6fb3b0cf3d72`
+- top queue item `repair_alpha_readiness`
+- top queue reason `alpha_readiness_not_promotion_eligible`
+- top queue value gate `routeable_candidate_count`
+- `accepted_routeable_candidate_count=0`
+- repair-bid settlement `routeable_candidate_count=0`
+- `max_notional=0`
+- `live_submission_allowed=false`
+- `/trading/consumer-evidence` did not expose `no_delta_repair_reentry_auction`
+
+Read-only sample after local implementation, before deploy, at `2026-05-14T14:49:40Z`:
+
+- `business_state=repair_only`
+- `revenue_ready=false`
+- active revision `torghut-00393`
+- source commit `637239a49a577d20596ded51244d6fb3b0cf3d72`
+- top queue item `repair_alpha_readiness`
+- top queue reason `alpha_readiness_not_promotion_eligible`
+- top queue value gate `routeable_candidate_count`
+- `accepted_routeable_candidate_count=0`
+- repair-bid settlement `routeable_candidate_count=0`
+- alpha repair dividend state `no_delta`
+- active no-delta release key present
+- `no_delta_repair_reentry_auction=null` on live service because this PR is not deployed yet
+- `/readyz` returned HTTP 503 with expected capital-safety holds: `simple_submit_disabled` and `repair_only`
+
+## What changed
+
+This implementation adds `torghut.no-delta-repair-reentry-auction.v1` in observe mode.
+
+- The auction denies duplicate alpha-readiness reentry when the active no-delta release key is unchanged.
+- It selects at most one zero-notional ticket when a release condition changes.
+- It can select Jangar verify-carry as a release condition when a current foreclosure ticket exists.
+- It exports the full auction on `/trading/revenue-repair`.
+- It mirrors compact `torghut.no-delta-repair-reentry-auction-ref.v1` through `/readyz` and
+  `/trading/consumer-evidence`.
+- It preserves `max_notional=0`, `capital_rule=zero_notional_repair_only`, and disabled paper/live submission.
+
+## Validation
+
+Local validation used `/tmp/codex-uv-bootstrap/bin/uv` because `uv` was not installed on PATH in this workspace.
+
+- `/tmp/codex-uv-bootstrap/bin/uv sync --frozen --extra dev`: pass
+- `/tmp/codex-uv-bootstrap/bin/uv run --frozen ruff format --check app/trading/no_delta_repair_reentry_auction.py app/trading/revenue_repair.py app/main.py tests/test_no_delta_repair_reentry_auction.py tests/test_build_revenue_repair_digest.py tests/test_trading_api.py`: pass
+- `/tmp/codex-uv-bootstrap/bin/uv run --frozen ruff check app/trading/no_delta_repair_reentry_auction.py app/trading/revenue_repair.py app/main.py tests/test_no_delta_repair_reentry_auction.py tests/test_build_revenue_repair_digest.py tests/test_trading_api.py`: pass
+- `/tmp/codex-uv-bootstrap/bin/uv run --frozen pytest tests/test_no_delta_repair_reentry_auction.py`: pass, 6 tests
+- `/tmp/codex-uv-bootstrap/bin/uv run --frozen pytest tests/test_alpha_readiness_settlement_conveyor.py`: pass, 7 tests
+- `/tmp/codex-uv-bootstrap/bin/uv run --frozen pytest tests/test_alpha_repair_dividend_ledger.py`: pass, 10 tests
+- `/tmp/codex-uv-bootstrap/bin/uv run --frozen pytest tests/test_build_revenue_repair_digest.py -k revenue_repair`: pass, 15 tests
+- `/tmp/codex-uv-bootstrap/bin/uv run --frozen pytest tests/test_trading_api.py -k "consumer_evidence or revenue_repair"`: pass, 2 tests
+- `/tmp/codex-uv-bootstrap/bin/uv run --frozen pytest tests/test_consumer_evidence.py`: pass, 2 tests
+- `/tmp/codex-uv-bootstrap/bin/uv run --frozen pytest tests/test_no_delta_repair_reentry_auction.py tests/test_alpha_readiness_settlement_conveyor.py tests/test_alpha_repair_dividend_ledger.py tests/test_build_revenue_repair_digest.py tests/test_trading_api.py tests/test_consumer_evidence.py -k "no_delta or alpha or revenue_repair or consumer_evidence" --cov --cov-branch --cov-fail-under=0 --cov-report=xml --cov-report=`: pass, 43 tests
+- `/tmp/codex-uv-bootstrap/bin/uv run --frozen pyright --project pyrightconfig.json`: pass
+- `/tmp/codex-uv-bootstrap/bin/uv run --frozen pyright --project pyrightconfig.alpha.json`: pass
+- `/tmp/codex-uv-bootstrap/bin/uv run --frozen pyright --project pyrightconfig.scripts.json`: pass
+
+Note: the design-doc command `pytest tests/test_consumer_evidence.py -k alpha` selected zero tests in this repo state,
+so the whole `tests/test_consumer_evidence.py` file was run instead.
+
+## Risk and rollback
+
+Risk is limited to an additive observe-mode payload and compact reference. The reducer does not mutate database state,
+broker state, Kubernetes resources, trading flags, or GitOps resources.
+
+Rollback is to revert the PR or stop emitting `no_delta_repair_reentry_auction`, leaving the existing alpha-readiness
+settlement conveyor, alpha repair dividend ledger, repair-bid settlement, and capital proof-floor contracts as the
+authorities. Paper and live action classes remain closed because `max_notional=0` and live submit stays disabled.
+
+## Revenue impact
+
+The metric targeted is `routeable_candidate_count`. Immediate live revenue impact is still blocked because
+`repair_alpha_readiness` remains the top queue item, selected `H-MICRO-01` has no routeable-candidate delta, and the
+live service has not yet deployed this PR. The implementation improves readiness by making duplicate no-delta reentry
+machine-deniable and by naming the single zero-notional release-condition ticket that can be admitted after rollout.

--- a/docs/torghut/rollouts/2026-05-14-no-delta-reentry-auction.md
+++ b/docs/torghut/rollouts/2026-05-14-no-delta-reentry-auction.md
@@ -64,14 +64,14 @@ Local validation used `/tmp/codex-uv-bootstrap/bin/uv` because `uv` was not inst
 - `/tmp/codex-uv-bootstrap/bin/uv sync --frozen --extra dev`: pass
 - `/tmp/codex-uv-bootstrap/bin/uv run --frozen ruff format --check app/trading/no_delta_repair_reentry_auction.py app/trading/revenue_repair.py app/main.py tests/test_no_delta_repair_reentry_auction.py tests/test_build_revenue_repair_digest.py tests/test_trading_api.py`: pass
 - `/tmp/codex-uv-bootstrap/bin/uv run --frozen ruff check app/trading/no_delta_repair_reentry_auction.py app/trading/revenue_repair.py app/main.py tests/test_no_delta_repair_reentry_auction.py tests/test_build_revenue_repair_digest.py tests/test_trading_api.py`: pass
-- `/tmp/codex-uv-bootstrap/bin/uv run --frozen pytest tests/test_no_delta_repair_reentry_auction.py`: pass, 9 tests
+- `/tmp/codex-uv-bootstrap/bin/uv run --frozen pytest tests/test_no_delta_repair_reentry_auction.py`: pass, 13 tests
 - `/tmp/codex-uv-bootstrap/bin/uv run --frozen pytest tests/test_alpha_readiness_settlement_conveyor.py`: pass, 7 tests
 - `/tmp/codex-uv-bootstrap/bin/uv run --frozen pytest tests/test_alpha_repair_dividend_ledger.py`: pass, 10 tests
 - `/tmp/codex-uv-bootstrap/bin/uv run --frozen pytest tests/test_build_revenue_repair_digest.py -k revenue_repair`: pass, 15 tests
 - `/tmp/codex-uv-bootstrap/bin/uv run --frozen pytest tests/test_trading_api.py -k "consumer_evidence or revenue_repair"`: pass, 2 tests
 - `/tmp/codex-uv-bootstrap/bin/uv run --frozen pytest tests/test_consumer_evidence.py`: pass, 2 tests
-- `/tmp/codex-uv-bootstrap/bin/uv run --frozen pytest tests/test_no_delta_repair_reentry_auction.py tests/test_alpha_readiness_settlement_conveyor.py tests/test_alpha_repair_dividend_ledger.py tests/test_build_revenue_repair_digest.py tests/test_trading_api.py tests/test_consumer_evidence.py -k "no_delta or alpha or revenue_repair or consumer_evidence" --cov --cov-branch --cov-fail-under=0 --cov-report=xml --cov-report=`: pass, 46 tests
-- `/tmp/codex-uv-bootstrap/bin/uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90`: pass, changed-line coverage 94.77%
+- `/tmp/codex-uv-bootstrap/bin/uv run --frozen pytest tests/test_no_delta_repair_reentry_auction.py tests/test_alpha_readiness_settlement_conveyor.py tests/test_alpha_repair_dividend_ledger.py tests/test_build_revenue_repair_digest.py tests/test_trading_api.py tests/test_consumer_evidence.py -k "no_delta or alpha or revenue_repair or consumer_evidence" --cov --cov-branch --cov-fail-under=0 --cov-report=xml --cov-report=`: pass, 50 tests
+- `/tmp/codex-uv-bootstrap/bin/uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90`: pass, changed-line coverage 99.65%
 - `/tmp/codex-uv-bootstrap/bin/uv run --frozen pyright --project pyrightconfig.json`: pass
 - `/tmp/codex-uv-bootstrap/bin/uv run --frozen pyright --project pyrightconfig.alpha.json`: pass
 - `/tmp/codex-uv-bootstrap/bin/uv run --frozen pyright --project pyrightconfig.scripts.json`: pass

--- a/docs/torghut/rollouts/2026-05-14-no-delta-reentry-auction.md
+++ b/docs/torghut/rollouts/2026-05-14-no-delta-reentry-auction.md
@@ -64,13 +64,14 @@ Local validation used `/tmp/codex-uv-bootstrap/bin/uv` because `uv` was not inst
 - `/tmp/codex-uv-bootstrap/bin/uv sync --frozen --extra dev`: pass
 - `/tmp/codex-uv-bootstrap/bin/uv run --frozen ruff format --check app/trading/no_delta_repair_reentry_auction.py app/trading/revenue_repair.py app/main.py tests/test_no_delta_repair_reentry_auction.py tests/test_build_revenue_repair_digest.py tests/test_trading_api.py`: pass
 - `/tmp/codex-uv-bootstrap/bin/uv run --frozen ruff check app/trading/no_delta_repair_reentry_auction.py app/trading/revenue_repair.py app/main.py tests/test_no_delta_repair_reentry_auction.py tests/test_build_revenue_repair_digest.py tests/test_trading_api.py`: pass
-- `/tmp/codex-uv-bootstrap/bin/uv run --frozen pytest tests/test_no_delta_repair_reentry_auction.py`: pass, 6 tests
+- `/tmp/codex-uv-bootstrap/bin/uv run --frozen pytest tests/test_no_delta_repair_reentry_auction.py`: pass, 9 tests
 - `/tmp/codex-uv-bootstrap/bin/uv run --frozen pytest tests/test_alpha_readiness_settlement_conveyor.py`: pass, 7 tests
 - `/tmp/codex-uv-bootstrap/bin/uv run --frozen pytest tests/test_alpha_repair_dividend_ledger.py`: pass, 10 tests
 - `/tmp/codex-uv-bootstrap/bin/uv run --frozen pytest tests/test_build_revenue_repair_digest.py -k revenue_repair`: pass, 15 tests
 - `/tmp/codex-uv-bootstrap/bin/uv run --frozen pytest tests/test_trading_api.py -k "consumer_evidence or revenue_repair"`: pass, 2 tests
 - `/tmp/codex-uv-bootstrap/bin/uv run --frozen pytest tests/test_consumer_evidence.py`: pass, 2 tests
-- `/tmp/codex-uv-bootstrap/bin/uv run --frozen pytest tests/test_no_delta_repair_reentry_auction.py tests/test_alpha_readiness_settlement_conveyor.py tests/test_alpha_repair_dividend_ledger.py tests/test_build_revenue_repair_digest.py tests/test_trading_api.py tests/test_consumer_evidence.py -k "no_delta or alpha or revenue_repair or consumer_evidence" --cov --cov-branch --cov-fail-under=0 --cov-report=xml --cov-report=`: pass, 43 tests
+- `/tmp/codex-uv-bootstrap/bin/uv run --frozen pytest tests/test_no_delta_repair_reentry_auction.py tests/test_alpha_readiness_settlement_conveyor.py tests/test_alpha_repair_dividend_ledger.py tests/test_build_revenue_repair_digest.py tests/test_trading_api.py tests/test_consumer_evidence.py -k "no_delta or alpha or revenue_repair or consumer_evidence" --cov --cov-branch --cov-fail-under=0 --cov-report=xml --cov-report=`: pass, 46 tests
+- `/tmp/codex-uv-bootstrap/bin/uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90`: pass, changed-line coverage 94.77%
 - `/tmp/codex-uv-bootstrap/bin/uv run --frozen pyright --project pyrightconfig.json`: pass
 - `/tmp/codex-uv-bootstrap/bin/uv run --frozen pyright --project pyrightconfig.alpha.json`: pass
 - `/tmp/codex-uv-bootstrap/bin/uv run --frozen pyright --project pyrightconfig.scripts.json`: pass

--- a/services/torghut/README.md
+++ b/services/torghut/README.md
@@ -237,6 +237,12 @@ Testing rules for the trading core:
   zero-notional alpha-readiness lane, and the dividend ledger records whether that lane paid
   `routeable_candidate_count`, produced no-delta debt, or must be blocked/stale before another material repair launch.
   `/readyz` and `/trading/consumer-evidence` mirror compact refs for Jangar custody while keeping `max_notional=0`.
+- `GET /trading/revenue-repair` also emits the May 14 doc 206
+  `torghut.no-delta-repair-reentry-auction.v1` observe-mode reducer. The auction denies repeat alpha-readiness
+  launches while the active no-delta release key is unchanged, selects at most one zero-notional reentry ticket when a
+  source, evidence-window, blocker, receipt, selected-hypothesis, or Jangar verify-carry release condition changes, and
+  mirrors a compact `torghut.no-delta-repair-reentry-auction-ref.v1` through `/readyz` and
+  `/trading/consumer-evidence`. It does not enable paper or live submission.
 - `GET /trading/status` and `GET /readyz` now include the May 8 doc 181
   `quality_adjusted_profit_frontier` shadow projection. The reducer ranks zero-notional repair packets from quant
   quality, market-context risk flags, route/TCA state, simulation-cache freshness, and Jangar evidence-quality refs

--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -113,6 +113,9 @@ from .trading.jangar_continuity import load_jangar_route_continuity_packet
 from .trading.lean_lanes import LeanLaneManager
 from .trading.lean_runtime import lean_authority_status
 from .trading.llm.evaluation import build_llm_evaluation_metrics
+from .trading.no_delta_repair_reentry_auction import (
+    compact_no_delta_repair_reentry_auction,
+)
 from .trading.profit_carry_passports import build_profit_carry_passport_ledger
 from .trading.profit_freshness_frontier import build_profit_freshness_frontier
 from .trading.profit_repair_settlement import build_profit_repair_settlement_ledger
@@ -1159,6 +1162,12 @@ def _evaluate_trading_health_payload(
                 cast(
                     Mapping[str, Any],
                     revenue_repair_digest.get("alpha_repair_dividend_ledger"),
+                )
+            ),
+            "no_delta_repair_reentry_auction": compact_no_delta_repair_reentry_auction(
+                cast(
+                    Mapping[str, Any],
+                    revenue_repair_digest.get("no_delta_repair_reentry_auction"),
                 )
             ),
             "route_reacquisition_book": proof_floor.get("route_reacquisition_book"),
@@ -3374,6 +3383,12 @@ def _build_trading_consumer_evidence_payload() -> dict[str, object]:
             cast(
                 Mapping[str, Any],
                 revenue_repair_digest.get("alpha_repair_dividend_ledger"),
+            )
+        ),
+        "no_delta_repair_reentry_auction": compact_no_delta_repair_reentry_auction(
+            cast(
+                Mapping[str, Any],
+                revenue_repair_digest.get("no_delta_repair_reentry_auction"),
             )
         ),
         "route_warrant_exchange": route_warrant_exchange,

--- a/services/torghut/app/trading/no_delta_repair_reentry_auction.py
+++ b/services/torghut/app/trading/no_delta_repair_reentry_auction.py
@@ -1,0 +1,857 @@
+"""No-delta alpha repair reentry auction for routeable-candidate recovery."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from datetime import datetime, timedelta, timezone
+from typing import Any, cast
+
+NO_DELTA_REPAIR_REENTRY_AUCTION_SCHEMA_VERSION = (
+    "torghut.no-delta-repair-reentry-auction.v1"
+)
+NO_DELTA_REPAIR_REENTRY_AUCTION_REF_SCHEMA_VERSION = (
+    "torghut.no-delta-repair-reentry-auction-ref.v1"
+)
+JANGAR_VERIFICATION_CARRY_SCHEMA_VERSION = "torghut.jangar-verification-carry.v1"
+
+_DESIGN_REF = (
+    "docs/torghut/design-system/v6/"
+    "206-torghut-no-delta-repair-reentry-auction-and-verification-carry-2026-05-14.md"
+)
+_COMPANION_JANGAR_DESIGN_REF = (
+    "docs/agents/designs/"
+    "201-jangar-verify-trust-foreclosure-and-alpha-repair-reentry-2026-05-14.md"
+)
+_DEFAULT_FRESHNESS_SECONDS = 15 * 60
+_ZERO_NOTIONAL_VALUES = {"0", "0.0", "0.00", "0.0000"}
+_ROLLBACK_TARGET = (
+    "stop emitting no_delta_repair_reentry_auction, keep alpha settlement and "
+    "dividend evidence, and keep Torghut max_notional=0"
+)
+_RELEASE_CONDITION_CODES = [
+    "source_revenue_repair_ref_changed",
+    "evidence_window_changed",
+    "blocker_set_changed",
+    "required_receipt_set_changed",
+    "selected_hypothesis_changed",
+    "jangar_verify_foreclosure_ticket_current",
+    "schema_lineage_receipt_current",
+    "empirical_receipt_current",
+    "market_context_receipt_current",
+    "execution_tca_receipt_current",
+]
+_SOURCE_CHANGE_CONDITIONS = {
+    "source_revenue_repair_ref_changed",
+    "source_ref_changed",
+    "source_ref_changes",
+}
+_EVIDENCE_WINDOW_CONDITIONS = {
+    "evidence_window_changed",
+    "evidence_window_changes",
+}
+_BLOCKER_SET_CONDITIONS = {
+    "blocker_set_changed",
+    "blocker_set_changes",
+}
+_REQUIRED_RECEIPT_CONDITIONS = {
+    "required_receipt_set_changed",
+    "required_receipt_changes",
+}
+_SELECTED_HYPOTHESIS_CONDITIONS = {
+    "selected_hypothesis_changed",
+}
+_EMPIRICAL_BLOCKERS = {
+    "empirical_jobs_degraded",
+    "empirical_jobs_not_ready",
+    "job_ineligible:benchmark_parity",
+    "job_ineligible:foundation_router_parity",
+    "job_ineligible:janus_event_car",
+    "job_ineligible:janus_hgrm_reward",
+    "job_stale:benchmark_parity",
+    "job_stale:foundation_router_parity",
+    "job_stale:janus_event_car",
+    "job_stale:janus_hgrm_reward",
+}
+_MARKET_CONTEXT_BLOCKERS = {
+    "market_context_evidence_missing",
+    "market_context_stale",
+    "market_context_state_unknown",
+}
+_SCHEMA_LINEAGE_BLOCKERS = {
+    "schema_lineage_missing",
+    "strategy_hypothesis_lineage_missing",
+    "required_feature_set_unavailable",
+}
+_TCA_BLOCKERS = {
+    "execution_tca_above_guardrail",
+    "execution_tca_expected_shortfall_samples_missing_non_promoting",
+    "execution_tca_missing",
+    "execution_tca_route_universe_exclusions_applied",
+    "execution_tca_stale",
+    "execution_tca_symbol_missing",
+    "tca_evidence_stale",
+}
+
+
+def _mapping(value: object) -> Mapping[str, Any]:
+    if isinstance(value, Mapping):
+        return cast(Mapping[str, Any], value)
+    return {}
+
+
+def _sequence(value: object) -> Sequence[object]:
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return cast(Sequence[object], value)
+    return ()
+
+
+def _text(value: object, default: str = "") -> str:
+    if value is None:
+        return default
+    normalized = str(value).strip()
+    return normalized or default
+
+
+def _int(value: object, default: int = 0) -> int:
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if isinstance(value, str) and value.strip():
+        try:
+            return int(float(value.strip()))
+        except ValueError:
+            return default
+    return default
+
+
+def _string_list(value: object) -> list[str]:
+    result: list[str] = []
+    seen: set[str] = set()
+    for item in _sequence(value):
+        normalized = _text(item)
+        if not normalized or normalized in seen:
+            continue
+        seen.add(normalized)
+        result.append(normalized)
+    return result
+
+
+def _append_unique(items: list[str], *values: object) -> list[str]:
+    seen = set(items)
+    for value in values:
+        if isinstance(value, Sequence) and not isinstance(
+            value, (str, bytes, bytearray)
+        ):
+            candidates = _string_list(cast(Sequence[object], value))
+        else:
+            candidates = [_text(value)]
+        for candidate in candidates:
+            if not candidate or candidate in seen:
+                continue
+            seen.add(candidate)
+            items.append(candidate)
+    return items
+
+
+def _stable_hash(prefix: str, payload: Mapping[str, object]) -> str:
+    encoded = json.dumps(
+        {"prefix": prefix, **dict(payload)},
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()[:24]
+
+
+def _parse_datetime(value: object) -> datetime | None:
+    raw = _text(value)
+    if not raw:
+        return None
+    normalized = raw[:-1] + "+00:00" if raw.endswith("Z") else raw
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return None
+    return parsed.astimezone(timezone.utc)
+
+
+def _top_queue_item(repair_queue: Sequence[Mapping[str, Any]]) -> Mapping[str, Any]:
+    for item in repair_queue:
+        payload = _mapping(item)
+        if payload:
+            return payload
+    return {}
+
+
+def _is_alpha_repair(item: Mapping[str, Any]) -> bool:
+    return (
+        _text(item.get("code")) == "repair_alpha_readiness"
+        or _text(item.get("reason")) == "alpha_readiness_not_promotion_eligible"
+    )
+
+
+def _zero_notional(value: object) -> bool:
+    raw = _text(value)
+    if raw in _ZERO_NOTIONAL_VALUES:
+        return True
+    try:
+        return float(raw) == 0
+    except ValueError:
+        return False
+
+
+def _release_condition_changes(
+    alpha_repair_dividend_ledger: Mapping[str, Any],
+    alpha_readiness_settlement_conveyor: Mapping[str, Any],
+) -> set[str]:
+    raw_changes = _string_list(
+        alpha_repair_dividend_ledger.get("changed_release_conditions")
+    )
+    raw_changes = _append_unique(
+        raw_changes,
+        alpha_readiness_settlement_conveyor.get("changed_release_conditions"),
+    )
+    changes: set[str] = set()
+    for condition in raw_changes:
+        if condition in _SOURCE_CHANGE_CONDITIONS:
+            changes.add("source_revenue_repair_ref_changed")
+        elif condition in _EVIDENCE_WINDOW_CONDITIONS:
+            changes.add("evidence_window_changed")
+        elif condition in _BLOCKER_SET_CONDITIONS:
+            changes.add("blocker_set_changed")
+        elif condition in _REQUIRED_RECEIPT_CONDITIONS:
+            changes.add("required_receipt_set_changed")
+        elif condition in _SELECTED_HYPOTHESIS_CONDITIONS:
+            changes.add("selected_hypothesis_changed")
+        elif condition in _RELEASE_CONDITION_CODES:
+            changes.add(condition)
+    return changes
+
+
+def _preserved_reason_codes(
+    alpha_repair_dividend_ledger: Mapping[str, Any],
+    alpha_readiness_settlement_conveyor: Mapping[str, Any],
+) -> list[str]:
+    selected_lane = _mapping(alpha_readiness_settlement_conveyor.get("selected_lane"))
+    settlement_receipt = _mapping(
+        alpha_readiness_settlement_conveyor.get("settlement_receipt")
+    )
+    return (
+        _string_list(alpha_repair_dividend_ledger.get("preserved_reason_codes"))
+        or _string_list(settlement_receipt.get("preserved_reason_codes"))
+        or _string_list(selected_lane.get("before_reason_codes"))
+    )
+
+
+def _source_revenue_repair_ref(
+    alpha_repair_dividend_ledger: Mapping[str, Any],
+    alpha_readiness_settlement_conveyor: Mapping[str, Any],
+) -> str:
+    return (
+        _text(alpha_repair_dividend_ledger.get("source_revenue_repair_ref"))
+        or _text(alpha_readiness_settlement_conveyor.get("source_revenue_repair_ref"))
+        or "torghut-revenue-repair-digest:unknown"
+    )
+
+
+def _selected_hypothesis_id(
+    alpha_repair_dividend_ledger: Mapping[str, Any],
+    alpha_readiness_settlement_conveyor: Mapping[str, Any],
+) -> str:
+    selected_lane = _mapping(alpha_readiness_settlement_conveyor.get("selected_lane"))
+    return (
+        _text(alpha_repair_dividend_ledger.get("selected_hypothesis_id"))
+        or _text(selected_lane.get("hypothesis_id"))
+        or "unknown"
+    )
+
+
+def _selected_value_gate(
+    top_item: Mapping[str, Any],
+    alpha_repair_dividend_ledger: Mapping[str, Any],
+    alpha_readiness_settlement_conveyor: Mapping[str, Any],
+) -> str:
+    return (
+        _text(alpha_repair_dividend_ledger.get("selected_value_gate"))
+        or _text(alpha_readiness_settlement_conveyor.get("selected_value_gate"))
+        or _text(top_item.get("value_gate"))
+        or "routeable_candidate_count"
+    )
+
+
+def _active_no_delta_release_key(
+    alpha_repair_dividend_ledger: Mapping[str, Any],
+    alpha_readiness_settlement_conveyor: Mapping[str, Any],
+) -> str:
+    dividend_state = _text(alpha_repair_dividend_ledger.get("dividend_state"))
+    dividend_launch = _mapping(alpha_repair_dividend_ledger.get("jangar_custody")).get(
+        "launch_decision"
+    )
+    dividend_launch = _text(
+        dividend_launch, _text(alpha_repair_dividend_ledger.get("launch_decision"))
+    )
+    conveyor_repeat = _text(
+        _mapping(alpha_readiness_settlement_conveyor.get("selected_lane")).get(
+            "repeat_launch_decision"
+        ),
+        _text(alpha_readiness_settlement_conveyor.get("repeat_launch_decision")),
+    )
+    active = (
+        dividend_state == "no_delta"
+        or dividend_launch == "deny"
+        or conveyor_repeat == "deny"
+        or _int(alpha_readiness_settlement_conveyor.get("active_no_delta_lease_count"))
+        > 0
+    )
+    if not active:
+        return ""
+    return (
+        _text(alpha_repair_dividend_ledger.get("no_delta_release_key"))
+        or _text(alpha_readiness_settlement_conveyor.get("no_delta_release_key"))
+        or _text(
+            _mapping(alpha_readiness_settlement_conveyor.get("selected_lane")).get(
+                "no_delta_release_key"
+            )
+        )
+    )
+
+
+def _build_jangar_verification_carry(
+    *,
+    generated: datetime,
+    jangar_verification_carry: Mapping[str, Any] | None,
+) -> dict[str, object]:
+    fresh_until = generated + timedelta(seconds=_DEFAULT_FRESHNESS_SECONDS)
+    payload = _mapping(jangar_verification_carry)
+    if not payload:
+        return {
+            "schema_version": JANGAR_VERIFICATION_CARRY_SCHEMA_VERSION,
+            "carry_id": "jangar-verification-carry:unavailable",
+            "generated_at": generated.isoformat(),
+            "fresh_until": fresh_until.isoformat(),
+            "status": "unavailable",
+            "jangar_execution_trust_status": "unavailable",
+            "jangar_source_rollout_truth_state": "unknown",
+            "jangar_foreclosure_board_ref": None,
+            "held_action_classes": ["dispatch_repair"],
+            "blocked_action_classes": [],
+            "required_jangar_receipt": "jangar.verify-trust-foreclosure-ticket.v1",
+            "reason_codes": ["jangar_verification_carry_unavailable"],
+        }
+
+    board_id = _text(payload.get("board_id")) or _text(payload.get("carry_id"))
+    fresh = _parse_datetime(payload.get("fresh_until"))
+    status = _text(payload.get("status"), "current")
+    execution_trust = _text(payload.get("execution_trust_status"), status)
+    source_truth = _text(payload.get("source_rollout_truth_state"), "unknown")
+    tickets: list[Mapping[str, Any]] = [
+        _mapping(ticket)
+        for ticket in _sequence(payload.get("foreclosure_tickets"))
+        if _mapping(ticket)
+    ]
+    current_ticket: Mapping[str, Any] = {}
+    for ticket in tickets:
+        if _text(ticket.get("state")) in {"open", "closed", "current"}:
+            current_ticket = ticket
+            break
+    reason_codes = _string_list(payload.get("reason_codes"))
+    if fresh is not None and fresh <= generated:
+        reason_codes = _append_unique(reason_codes, "jangar_verification_carry_stale")
+        status = "stale"
+    if not current_ticket:
+        reason_codes = _append_unique(reason_codes, "jangar_foreclosure_ticket_missing")
+    carry_id = "jangar-verification-carry:" + _stable_hash(
+        "jangar-verification-carry",
+        {
+            "board_id": board_id,
+            "status": status,
+            "execution_trust": execution_trust,
+            "source_truth": source_truth,
+            "ticket": _text(current_ticket.get("ticket_id")),
+        },
+    )
+    return {
+        "schema_version": JANGAR_VERIFICATION_CARRY_SCHEMA_VERSION,
+        "carry_id": carry_id,
+        "generated_at": generated.isoformat(),
+        "fresh_until": (fresh or fresh_until).isoformat(),
+        "status": status,
+        "jangar_execution_trust_status": execution_trust,
+        "jangar_source_rollout_truth_state": source_truth,
+        "jangar_foreclosure_board_ref": board_id or None,
+        "held_action_classes": _string_list(payload.get("held_action_classes")),
+        "blocked_action_classes": _string_list(payload.get("blocked_action_classes")),
+        "required_jangar_receipt": _text(
+            current_ticket.get("required_output_receipt"),
+            "jangar.verify-trust-foreclosure-ticket.v1",
+        ),
+        "current_foreclosure_ticket_id": current_ticket.get("ticket_id"),
+        "reason_codes": reason_codes,
+    }
+
+
+def _condition_state(
+    *,
+    code: str,
+    changed_conditions: set[str],
+    preserved_reasons: set[str],
+    jangar_carry: Mapping[str, Any],
+) -> tuple[str, list[str]]:
+    if code in changed_conditions:
+        return "changed", ["release_condition_changed"]
+    if code == "jangar_verify_foreclosure_ticket_current":
+        if _text(jangar_carry.get("status")) == "current" and _text(
+            jangar_carry.get("current_foreclosure_ticket_id")
+        ):
+            return "current", ["jangar_foreclosure_ticket_current"]
+        return "unavailable", _string_list(jangar_carry.get("reason_codes"))
+    blocker_sets = {
+        "schema_lineage_receipt_current": _SCHEMA_LINEAGE_BLOCKERS,
+        "empirical_receipt_current": _EMPIRICAL_BLOCKERS,
+        "market_context_receipt_current": _MARKET_CONTEXT_BLOCKERS,
+        "execution_tca_receipt_current": _TCA_BLOCKERS,
+    }
+    blockers = blocker_sets.get(code)
+    if blockers is None:
+        return "unchanged", ["release_condition_not_changed"]
+    if preserved_reasons.intersection(blockers):
+        return "missing", [
+            f"{code.removesuffix('_current')}_missing",
+            "release_condition_not_changed",
+        ]
+    return "not_required", ["prerequisite_not_required_for_selected_lane"]
+
+
+def _build_release_conditions(
+    *,
+    changed_conditions: set[str],
+    preserved_reason_codes: Sequence[str],
+    jangar_carry: Mapping[str, Any],
+) -> list[dict[str, object]]:
+    preserved = set(preserved_reason_codes)
+    return [
+        {
+            "code": code,
+            "state": state,
+            "reason_codes": reason_codes,
+        }
+        for code in _RELEASE_CONDITION_CODES
+        for state, reason_codes in [
+            _condition_state(
+                code=code,
+                changed_conditions=changed_conditions,
+                preserved_reasons=preserved,
+                jangar_carry=jangar_carry,
+            )
+        ]
+    ]
+
+
+def _condition_unblocks(condition: Mapping[str, Any]) -> bool:
+    state = _text(condition.get("state"))
+    return state in {"changed", "current"}
+
+
+def _ticket_specs() -> list[dict[str, object]]:
+    return [
+        {
+            "ticket_class": "alpha_evidence_window",
+            "release_conditions": [
+                "source_revenue_repair_ref_changed",
+                "evidence_window_changed",
+                "blocker_set_changed",
+                "required_receipt_set_changed",
+                "selected_hypothesis_changed",
+            ],
+            "required_output_receipt": "torghut.alpha-evidence-window-receipt.v1",
+            "validation_commands": [
+                "uv run --frozen pytest services/torghut/tests/test_alpha_evidence_foundry.py"
+            ],
+            "priority": 100,
+        },
+        {
+            "ticket_class": "schema_lineage_receipt",
+            "release_conditions": ["schema_lineage_receipt_current"],
+            "required_output_receipt": "torghut.schema-lineage-receipt.v1",
+            "validation_commands": [
+                "uv run --frozen pytest services/torghut/tests/test_alpha_readiness_settlement_conveyor.py"
+            ],
+            "priority": 90,
+        },
+        {
+            "ticket_class": "empirical_receipt",
+            "release_conditions": ["empirical_receipt_current"],
+            "required_output_receipt": "torghut.empirical-job-receipt.v1",
+            "validation_commands": [
+                "uv run --frozen pytest services/torghut/tests/test_build_revenue_repair_digest.py -k revenue_repair"
+            ],
+            "priority": 80,
+        },
+        {
+            "ticket_class": "market_context_receipt",
+            "release_conditions": ["market_context_receipt_current"],
+            "required_output_receipt": "torghut.market-context-receipt.v1",
+            "validation_commands": [
+                "uv run --frozen pytest services/torghut/tests/test_consumer_evidence.py"
+            ],
+            "priority": 70,
+        },
+        {
+            "ticket_class": "execution_tca_receipt",
+            "release_conditions": ["execution_tca_receipt_current"],
+            "required_output_receipt": "torghut.execution-tca-repair-receipt.v1",
+            "validation_commands": [
+                "uv run --frozen pytest services/torghut/tests/test_build_revenue_repair_digest.py -k revenue_repair"
+            ],
+            "priority": 60,
+        },
+        {
+            "ticket_class": "jangar_verify_carry",
+            "release_conditions": ["jangar_verify_foreclosure_ticket_current"],
+            "required_output_receipt": "jangar.verify-trust-foreclosure-ticket.v1",
+            "validation_commands": [
+                "bun run --filter jangar test -- services/jangar/src/server/__tests__/control-plane-verify-trust-foreclosure.test.ts"
+            ],
+            "priority": 50,
+        },
+    ]
+
+
+def _build_candidate_tickets(
+    *,
+    source_revenue_repair_ref: str,
+    active_no_delta_release_key: str,
+    selected_hypothesis_id: str,
+    selected_value_gate: str,
+    release_conditions: Sequence[Mapping[str, Any]],
+    max_notional: str,
+    top_item_is_alpha: bool,
+) -> list[dict[str, object]]:
+    conditions_by_code = {
+        _text(condition.get("code")): condition for condition in release_conditions
+    }
+    tickets: list[dict[str, object]] = []
+    for spec in _ticket_specs():
+        spec_conditions = _string_list(spec.get("release_conditions"))
+        matched_condition: Mapping[str, Any] = {}
+        for condition in spec_conditions:
+            candidate_condition = conditions_by_code.get(condition)
+            if candidate_condition and _condition_unblocks(candidate_condition):
+                matched_condition = candidate_condition
+                break
+        release_condition = _text(
+            matched_condition.get("code"),
+            spec_conditions[0] if spec_conditions else "unknown",
+        )
+        hold_reason_codes: list[str] = []
+        if not top_item_is_alpha:
+            hold_reason_codes.append("top_repair_queue_item_not_alpha_readiness")
+        if selected_value_gate != "routeable_candidate_count":
+            hold_reason_codes.append(
+                "selected_value_gate_not_routeable_candidate_count"
+            )
+        if not _zero_notional(max_notional):
+            hold_reason_codes.append("capital_notional_nonzero")
+        if not matched_condition:
+            hold_reason_codes.append("release_condition_not_changed")
+        if active_no_delta_release_key and not matched_condition:
+            hold_reason_codes.append("active_no_delta_release_key_unchanged")
+
+        state = "held"
+        if hold_reason_codes and active_no_delta_release_key:
+            state = "denied"
+        elif hold_reason_codes:
+            state = "held"
+        else:
+            state = "eligible"
+
+        ticket_id = "no-delta-reentry-ticket:" + _stable_hash(
+            "no-delta-reentry-ticket",
+            {
+                "source_revenue_repair_ref": source_revenue_repair_ref,
+                "release_key": active_no_delta_release_key,
+                "selected_hypothesis_id": selected_hypothesis_id,
+                "ticket_class": _text(spec.get("ticket_class")),
+                "release_condition": release_condition,
+                "state": state,
+            },
+        )
+        tickets.append(
+            {
+                "ticket_id": ticket_id,
+                "ticket_class": spec.get("ticket_class"),
+                "target_value_gate": selected_value_gate,
+                "expected_gate_delta": "retire_alpha_readiness_not_promotion_eligible",
+                "release_condition": release_condition,
+                "required_output_receipt": spec.get("required_output_receipt"),
+                "validation_commands": _string_list(spec.get("validation_commands")),
+                "max_runtime_seconds": 20 * 60,
+                "max_parallelism": 1,
+                "max_notional": "0",
+                "state": state,
+                "hold_reason_codes": hold_reason_codes,
+                "priority": spec.get("priority"),
+            }
+        )
+    return tickets
+
+
+def _select_ticket(tickets: Sequence[Mapping[str, Any]]) -> dict[str, object] | None:
+    eligible = [
+        ticket
+        for ticket in tickets
+        if _text(ticket.get("state")) == "eligible"
+        and _zero_notional(ticket.get("max_notional"))
+        and _text(ticket.get("required_output_receipt"))
+        and _string_list(ticket.get("validation_commands"))
+    ]
+    if not eligible:
+        return None
+    selected = sorted(
+        eligible,
+        key=lambda ticket: (
+            -_int(ticket.get("priority")),
+            _text(ticket.get("ticket_id")),
+        ),
+    )[0]
+    result = dict(selected)
+    result["state"] = "selected"
+    return result
+
+
+def build_no_delta_repair_reentry_auction(
+    *,
+    generated_at: datetime,
+    business_state: str,
+    revenue_ready: bool,
+    repair_queue: Sequence[Mapping[str, Any]],
+    capital: Mapping[str, Any],
+    alpha_readiness_settlement_conveyor: Mapping[str, Any],
+    alpha_repair_dividend_ledger: Mapping[str, Any],
+    repair_bid_settlement_ledger: Mapping[str, Any],
+    jangar_verification_carry: Mapping[str, Any] | None = None,
+) -> dict[str, object]:
+    """Build the observe-mode no-delta reentry auction for alpha repair."""
+
+    if generated_at.tzinfo is None:
+        raise ValueError("generated_at_missing_timezone")
+    generated = generated_at.astimezone(timezone.utc)
+    fresh_until = generated + timedelta(seconds=_DEFAULT_FRESHNESS_SECONDS)
+    top_item = _top_queue_item(repair_queue)
+    selected_value_gate = _selected_value_gate(
+        top_item,
+        alpha_repair_dividend_ledger,
+        alpha_readiness_settlement_conveyor,
+    )
+    selected_hypothesis_id = _selected_hypothesis_id(
+        alpha_repair_dividend_ledger,
+        alpha_readiness_settlement_conveyor,
+    )
+    source_revenue_repair_ref = _source_revenue_repair_ref(
+        alpha_repair_dividend_ledger,
+        alpha_readiness_settlement_conveyor,
+    )
+    active_release_key = _active_no_delta_release_key(
+        alpha_repair_dividend_ledger,
+        alpha_readiness_settlement_conveyor,
+    )
+    max_notional = (
+        _text(capital.get("max_notional"))
+        or _text(alpha_repair_dividend_ledger.get("max_notional"))
+        or _text(top_item.get("max_notional"))
+        or "0"
+    )
+    routeable_before = _int(
+        alpha_repair_dividend_ledger.get("routeable_candidate_count_before"),
+        _int(
+            alpha_readiness_settlement_conveyor.get("routeable_candidate_count_before")
+        ),
+    )
+    routeable_after = _int(
+        alpha_repair_dividend_ledger.get("routeable_candidate_count_after"),
+        _int(
+            alpha_readiness_settlement_conveyor.get("routeable_candidate_count_after"),
+            routeable_before,
+        ),
+    )
+    changed_conditions = _release_condition_changes(
+        alpha_repair_dividend_ledger,
+        alpha_readiness_settlement_conveyor,
+    )
+    jangar_carry = _build_jangar_verification_carry(
+        generated=generated,
+        jangar_verification_carry=jangar_verification_carry,
+    )
+    preserved_codes = _preserved_reason_codes(
+        alpha_repair_dividend_ledger,
+        alpha_readiness_settlement_conveyor,
+    )
+    release_conditions = _build_release_conditions(
+        changed_conditions=changed_conditions,
+        preserved_reason_codes=preserved_codes,
+        jangar_carry=jangar_carry,
+    )
+    top_item_is_alpha = _is_alpha_repair(top_item)
+    candidate_tickets = _build_candidate_tickets(
+        source_revenue_repair_ref=source_revenue_repair_ref,
+        active_no_delta_release_key=active_release_key,
+        selected_hypothesis_id=selected_hypothesis_id,
+        selected_value_gate=selected_value_gate,
+        release_conditions=release_conditions,
+        max_notional=max_notional,
+        top_item_is_alpha=top_item_is_alpha,
+    )
+    selected_ticket = _select_ticket(candidate_tickets)
+
+    reason_codes: list[str] = []
+    if revenue_ready:
+        reason_codes.append("revenue_already_ready")
+    if business_state != "repair_only":
+        reason_codes.append(f"business_state_{business_state or 'unknown'}")
+    if not top_item_is_alpha:
+        reason_codes.append("top_repair_queue_item_not_alpha_readiness")
+    if selected_value_gate != "routeable_candidate_count":
+        reason_codes.append("selected_value_gate_not_routeable_candidate_count")
+    if not _zero_notional(max_notional):
+        reason_codes.append("capital_notional_nonzero")
+    if active_release_key:
+        reason_codes.append("active_no_delta_release_key")
+    if not any(_condition_unblocks(condition) for condition in release_conditions):
+        reason_codes.append("no_release_condition_changed")
+    if not selected_ticket:
+        reason_codes.append("zero_notional_reentry_ticket_not_selected")
+    else:
+        reason_codes.append("zero_notional_reentry_ticket_selected")
+    reason_codes = _append_unique(
+        reason_codes,
+        jangar_carry.get("reason_codes"),
+    )
+
+    if not _zero_notional(max_notional):
+        reentry_decision = "deny"
+    elif selected_ticket:
+        reentry_decision = "allow"
+    elif active_release_key:
+        reentry_decision = "deny"
+        reason_codes = _append_unique(reason_codes, "duplicate_no_delta_reentry_denied")
+    else:
+        reentry_decision = "hold"
+
+    auction_id = "no-delta-repair-reentry-auction:" + _stable_hash(
+        "no-delta-repair-reentry-auction",
+        {
+            "source_revenue_repair_ref": source_revenue_repair_ref,
+            "alpha_conveyor_ref": alpha_readiness_settlement_conveyor.get(
+                "conveyor_id"
+            ),
+            "alpha_dividend_ref": alpha_repair_dividend_ledger.get("ledger_id"),
+            "active_no_delta_release_key": active_release_key,
+            "selected_ticket_id": selected_ticket.get("ticket_id")
+            if selected_ticket
+            else None,
+            "decision": reentry_decision,
+        },
+    )
+
+    return {
+        "schema_version": NO_DELTA_REPAIR_REENTRY_AUCTION_SCHEMA_VERSION,
+        "auction_id": auction_id,
+        "generated_at": generated.isoformat(),
+        "fresh_until": fresh_until.isoformat(),
+        "governing_design_ref": _DESIGN_REF,
+        "companion_jangar_design_ref": _COMPANION_JANGAR_DESIGN_REF,
+        "enforcement_mode": "observe",
+        "source_revenue_repair_ref": source_revenue_repair_ref,
+        "active_alpha_conveyor_ref": alpha_readiness_settlement_conveyor.get(
+            "conveyor_id"
+        ),
+        "active_alpha_dividend_ref": alpha_repair_dividend_ledger.get("ledger_id"),
+        "active_no_delta_release_key": active_release_key or None,
+        "selected_queue_code": _text(top_item.get("code")),
+        "selected_value_gate": selected_value_gate,
+        "selected_hypothesis_id": selected_hypothesis_id,
+        "account_id": alpha_repair_dividend_ledger.get("account_id")
+        or alpha_readiness_settlement_conveyor.get("account_id")
+        or repair_bid_settlement_ledger.get("account_id"),
+        "window": alpha_repair_dividend_ledger.get("window")
+        or alpha_readiness_settlement_conveyor.get("window")
+        or repair_bid_settlement_ledger.get("session_id"),
+        "trading_mode": alpha_repair_dividend_ledger.get("trading_mode")
+        or alpha_readiness_settlement_conveyor.get("trading_mode")
+        or repair_bid_settlement_ledger.get("trading_mode"),
+        "business_state": business_state,
+        "revenue_ready": revenue_ready,
+        "routeable_candidate_count_before": routeable_before,
+        "routeable_candidate_count_after": routeable_after,
+        "measured_delta": routeable_after - routeable_before,
+        "release_conditions": release_conditions,
+        "candidate_tickets": candidate_tickets,
+        "selected_ticket": selected_ticket,
+        "reentry_decision": reentry_decision,
+        "reason_codes": reason_codes,
+        "jangar_verification_carry": jangar_carry,
+        "max_notional": max_notional,
+        "capital_rule": _text(
+            top_item.get("capital_rule"), "zero_notional_repair_only"
+        ),
+        "rollback_target": _ROLLBACK_TARGET,
+    }
+
+
+def compact_no_delta_repair_reentry_auction(
+    auction: Mapping[str, Any] | None,
+) -> dict[str, object]:
+    """Return the compact Jangar-facing no-delta reentry auction ref."""
+
+    payload = _mapping(auction)
+    if not payload:
+        return {
+            "schema_version": NO_DELTA_REPAIR_REENTRY_AUCTION_REF_SCHEMA_VERSION,
+            "status": "missing",
+            "reason_codes": ["no_delta_repair_reentry_auction_missing"],
+        }
+    selected_ticket = _mapping(payload.get("selected_ticket"))
+    validation_commands = _string_list(selected_ticket.get("validation_commands"))
+    return {
+        "schema_version": NO_DELTA_REPAIR_REENTRY_AUCTION_REF_SCHEMA_VERSION,
+        "auction_schema_version": payload.get("schema_version"),
+        "auction_id": payload.get("auction_id"),
+        "generated_at": payload.get("generated_at"),
+        "fresh_until": payload.get("fresh_until"),
+        "reentry_decision": payload.get("reentry_decision"),
+        "reason_codes": _string_list(payload.get("reason_codes")),
+        "active_no_delta_release_key": payload.get("active_no_delta_release_key"),
+        "selected_hypothesis_id": payload.get("selected_hypothesis_id"),
+        "selected_value_gate": payload.get("selected_value_gate"),
+        "routeable_candidate_count_before": payload.get(
+            "routeable_candidate_count_before"
+        ),
+        "routeable_candidate_count_after": payload.get(
+            "routeable_candidate_count_after"
+        ),
+        "selected_ticket_id": selected_ticket.get("ticket_id"),
+        "selected_ticket_class": selected_ticket.get("ticket_class"),
+        "selected_release_condition": selected_ticket.get("release_condition"),
+        "required_output_receipt": selected_ticket.get("required_output_receipt"),
+        "validation_command": validation_commands[0] if validation_commands else None,
+        "enforcement_mode": payload.get("enforcement_mode"),
+        "max_notional": payload.get("max_notional"),
+        "capital_rule": payload.get("capital_rule"),
+        "rollback_target": payload.get("rollback_target"),
+    }
+
+
+__all__ = [
+    "JANGAR_VERIFICATION_CARRY_SCHEMA_VERSION",
+    "NO_DELTA_REPAIR_REENTRY_AUCTION_REF_SCHEMA_VERSION",
+    "NO_DELTA_REPAIR_REENTRY_AUCTION_SCHEMA_VERSION",
+    "build_no_delta_repair_reentry_auction",
+    "compact_no_delta_repair_reentry_auction",
+]

--- a/services/torghut/app/trading/revenue_repair.py
+++ b/services/torghut/app/trading/revenue_repair.py
@@ -21,6 +21,9 @@ from .executable_alpha_receipts import (
     build_executable_alpha_repair_receipts,
     build_executable_alpha_settlement_slots,
 )
+from .no_delta_repair_reentry_auction import (
+    build_no_delta_repair_reentry_auction,
+)
 
 
 SCHEMA_VERSION = "torghut.revenue-repair-digest.v1"
@@ -1052,6 +1055,21 @@ def build_revenue_repair_digest(
         alpha_repair_closure_board=alpha_repair_closure_board,
         alpha_readiness_settlement_conveyor=alpha_readiness_settlement_conveyor,
     )
+    no_delta_repair_reentry_auction = build_no_delta_repair_reentry_auction(
+        generated_at=generated,
+        business_state=business_state,
+        revenue_ready=revenue_ready,
+        repair_queue=cast(Sequence[Mapping[str, Any]], repair_queue),
+        capital=capital,
+        alpha_readiness_settlement_conveyor=alpha_readiness_settlement_conveyor,
+        alpha_repair_dividend_ledger=alpha_repair_dividend_ledger,
+        repair_bid_settlement_ledger=repair_bid_settlement,
+        jangar_verification_carry=cast(
+            Mapping[str, Any] | None,
+            status_payload.get("verify_trust_foreclosure_board")
+            or status_payload.get("jangar_verification_carry"),
+        ),
+    )
     return {
         "schema_version": SCHEMA_VERSION,
         "generated_at": generated.isoformat(),
@@ -1067,6 +1085,7 @@ def build_revenue_repair_digest(
         "alpha_evidence_foundry": alpha_evidence_foundry,
         "alpha_readiness_settlement_conveyor": alpha_readiness_settlement_conveyor,
         "alpha_repair_dividend_ledger": alpha_repair_dividend_ledger,
+        "no_delta_repair_reentry_auction": no_delta_repair_reentry_auction,
         "business_state": business_state,
         "revenue_ready": revenue_ready,
         "health": {

--- a/services/torghut/tests/test_build_revenue_repair_digest.py
+++ b/services/torghut/tests/test_build_revenue_repair_digest.py
@@ -533,6 +533,23 @@ class TestBuildRevenueRepairDigest(TestCase):
             alpha_dividend_ledger["jangar_custody"]["launch_decision"],
             "deny",
         )
+        no_delta_auction = digest["no_delta_repair_reentry_auction"]
+        self.assertIsInstance(no_delta_auction, dict)
+        self.assertEqual(
+            no_delta_auction["schema_version"],
+            "torghut.no-delta-repair-reentry-auction.v1",
+        )
+        self.assertEqual(no_delta_auction["reentry_decision"], "deny")
+        self.assertEqual(
+            no_delta_auction["selected_value_gate"],
+            "routeable_candidate_count",
+        )
+        self.assertEqual(no_delta_auction["selected_ticket"], None)
+        self.assertEqual(no_delta_auction["max_notional"], "0")
+        self.assertIn(
+            "duplicate_no_delta_reentry_denied",
+            no_delta_auction["reason_codes"],
+        )
         self.assertEqual(repair_queue[1]["code"], "repair_execution_tca")
         self.assertNotIn("repair_repair_only", [item["code"] for item in repair_queue])
         self.assertIn(

--- a/services/torghut/tests/test_no_delta_repair_reentry_auction.py
+++ b/services/torghut/tests/test_no_delta_repair_reentry_auction.py
@@ -254,6 +254,81 @@ def test_no_delta_reentry_auction_denies_nonzero_notional() -> None:
     assert "capital_notional_nonzero" in auction["reason_codes"]
 
 
+def test_no_delta_reentry_auction_holds_without_active_key_or_release_change() -> None:
+    conveyor = deepcopy(_conveyor())
+    conveyor["status"] = "settled"
+    conveyor["settlement_state"] = "settled"
+    conveyor["active_no_delta_lease_count"] = 0
+    conveyor["selected_lane"] = {
+        **cast(dict[str, object], conveyor["selected_lane"]),
+        "repeat_launch_decision": "allow",
+        "no_delta_release_key": "",
+    }
+
+    dividend = deepcopy(_dividend_ledger())
+    dividend["status"] = "settled"
+    dividend["dividend_state"] = "settled"
+    dividend["no_delta_release_key"] = ""
+    dividend["jangar_custody"] = {
+        "launch_decision": "allow",
+        "launch_decision_reason": "repaired",
+    }
+
+    auction = _build(conveyor=conveyor, dividend=dividend)
+
+    assert auction["reentry_decision"] == "hold"
+    assert auction["active_no_delta_release_key"] is None
+    assert "no_release_condition_changed" in auction["reason_codes"]
+    tickets = cast(list[Mapping[str, Any]], auction["candidate_tickets"])
+    assert {ticket["state"] for ticket in tickets} == {"held"}
+
+
+def test_no_delta_reentry_auction_maps_stale_jangar_release_conditions() -> None:
+    dividend = deepcopy(_dividend_ledger())
+    dividend["changed_release_conditions"] = [
+        "source_ref_changes",
+        "blocker_set_changes",
+        "required_receipt_changes",
+        "selected_hypothesis_changes",
+        "jangar_verify_foreclosure_ticket_current",
+    ]
+
+    auction = _build(
+        dividend=dividend,
+        jangar_verification_carry={
+            "schema_version": "jangar.verify-trust-foreclosure-board.v1",
+            "board_id": "verify-trust-foreclosure-board:agents:test",
+            "status": "current",
+            "execution_trust_status": "degraded",
+            "fresh_until": "2026-05-14T14:39:00+00:00",
+            "foreclosure_tickets": [],
+        },
+    )
+
+    condition_codes = {
+        condition["code"]
+        for condition in cast(list[Mapping[str, str]], auction["release_conditions"])
+    }
+    assert {
+        "source_revenue_repair_ref_changed",
+        "blocker_set_changed",
+        "required_receipt_set_changed",
+        "selected_hypothesis_changed",
+        "jangar_verify_foreclosure_ticket_current",
+    } <= condition_codes
+    assert "jangar_verification_carry_stale" in auction["reason_codes"]
+    assert "jangar_foreclosure_ticket_missing" in auction["reason_codes"]
+
+
+def test_no_delta_reentry_auction_denies_malformed_notional() -> None:
+    auction = _build(
+        capital={"capital_state": "shadow", "max_notional": "not-a-number"}
+    )
+
+    assert auction["reentry_decision"] == "deny"
+    assert "capital_notional_nonzero" in auction["reason_codes"]
+
+
 def test_compact_no_delta_reentry_auction_ref() -> None:
     auction = _build()
     compact = compact_no_delta_repair_reentry_auction(auction)

--- a/services/torghut/tests/test_no_delta_repair_reentry_auction.py
+++ b/services/torghut/tests/test_no_delta_repair_reentry_auction.py
@@ -197,14 +197,31 @@ def test_no_delta_reentry_auction_denies_unchanged_active_release_key() -> None:
 
 def test_no_delta_reentry_auction_selects_one_changed_evidence_ticket() -> None:
     dividend = deepcopy(_dividend_ledger())
-    dividend["changed_release_conditions"] = ["evidence_window_changed"]
+    dividend["changed_release_conditions"] = [
+        "source_ref_changes",
+        "evidence_window_changes",
+        "blocker_set_changes",
+        "required_receipt_changes",
+        "selected_hypothesis_changed",
+        "schema_lineage_receipt_current",
+    ]
 
     auction = _build(dividend=dividend)
 
     assert auction["reentry_decision"] == "allow"
+    release_states = {
+        condition["code"]: condition["state"]
+        for condition in cast(list[Mapping[str, Any]], auction["release_conditions"])
+    }
+    assert release_states["source_revenue_repair_ref_changed"] == "changed"
+    assert release_states["evidence_window_changed"] == "changed"
+    assert release_states["blocker_set_changed"] == "changed"
+    assert release_states["required_receipt_set_changed"] == "changed"
+    assert release_states["selected_hypothesis_changed"] == "changed"
+    assert release_states["schema_lineage_receipt_current"] == "changed"
     selected = cast(Mapping[str, Any], auction["selected_ticket"])
     assert selected["ticket_class"] == "alpha_evidence_window"
-    assert selected["release_condition"] == "evidence_window_changed"
+    assert selected["release_condition"] == "source_revenue_repair_ref_changed"
     assert selected["state"] == "selected"
     assert selected["max_notional"] == "0"
     assert (
@@ -217,7 +234,9 @@ def test_no_delta_reentry_auction_selects_one_changed_evidence_ticket() -> None:
         for ticket in cast(list[Mapping[str, Any]], auction["candidate_tickets"])
         if ticket["state"] == "eligible"
     ]
-    assert len(selected_tickets) == 1
+    assert any(
+        ticket["ticket_class"] == "alpha_evidence_window" for ticket in selected_tickets
+    )
 
 
 def test_no_delta_reentry_auction_selects_jangar_foreclosure_ticket() -> None:
@@ -254,31 +273,38 @@ def test_no_delta_reentry_auction_denies_nonzero_notional() -> None:
     assert "capital_notional_nonzero" in auction["reason_codes"]
 
 
-def test_no_delta_reentry_auction_holds_without_active_key_or_release_change() -> None:
-    conveyor = deepcopy(_conveyor())
-    conveyor["status"] = "settled"
-    conveyor["settlement_state"] = "settled"
-    conveyor["active_no_delta_lease_count"] = 0
-    conveyor["selected_lane"] = {
-        **cast(dict[str, object], conveyor["selected_lane"]),
-        "repeat_launch_decision": "allow",
-        "no_delta_release_key": "",
-    }
+def test_no_delta_reentry_auction_denies_invalid_notional_string() -> None:
+    auction = _build(
+        capital={"capital_state": "shadow", "max_notional": "not-a-number"}
+    )
 
+    assert auction["reentry_decision"] == "deny"
+    assert auction["max_notional"] == "not-a-number"
+    assert "capital_notional_nonzero" in auction["reason_codes"]
+
+
+def test_no_delta_reentry_auction_holds_without_active_key_or_release_change() -> None:
     dividend = deepcopy(_dividend_ledger())
-    dividend["status"] = "settled"
-    dividend["dividend_state"] = "settled"
-    dividend["no_delta_release_key"] = ""
-    dividend["jangar_custody"] = {
-        "launch_decision": "allow",
-        "launch_decision_reason": "repaired",
-    }
+    dividend["dividend_state"] = "positive_delta"
+    dividend["routeable_candidate_count_before"] = True
+    dividend["routeable_candidate_count_after"] = 2.0
+    dividend["jangar_custody"] = {"launch_decision": "allow"}
+
+    conveyor = deepcopy(_conveyor())
+    conveyor["active_no_delta_lease_count"] = "not-a-number"
+    conveyor["repeat_launch_decision"] = "allow"
+    selected_lane = cast(dict[str, object], conveyor["selected_lane"])
+    selected_lane["repeat_launch_decision"] = "allow"
 
     auction = _build(conveyor=conveyor, dividend=dividend)
 
-    assert auction["reentry_decision"] == "hold"
     assert auction["active_no_delta_release_key"] is None
+    assert auction["reentry_decision"] == "hold"
+    assert auction["routeable_candidate_count_before"] == 1
+    assert auction["routeable_candidate_count_after"] == 2
     assert "no_release_condition_changed" in auction["reason_codes"]
+    assert "duplicate_no_delta_reentry_denied" not in auction["reason_codes"]
+
     tickets = cast(list[Mapping[str, Any]], auction["candidate_tickets"])
     assert {ticket["state"] for ticket in tickets} == {"held"}
 
@@ -320,13 +346,37 @@ def test_no_delta_reentry_auction_maps_stale_jangar_release_conditions() -> None
     assert "jangar_foreclosure_ticket_missing" in auction["reason_codes"]
 
 
-def test_no_delta_reentry_auction_denies_malformed_notional() -> None:
+@pytest.mark.parametrize(
+    ("fresh_until", "expected_extra_reason"),
+    [
+        ("", None),
+        ("not-a-date", None),
+        ("2026-05-14T14:00:00", None),
+        ("2026-05-14T14:00:00Z", "jangar_verification_carry_stale"),
+    ],
+)
+def test_no_delta_reentry_auction_handles_unusable_jangar_carry_times(
+    fresh_until: str,
+    expected_extra_reason: str | None,
+) -> None:
     auction = _build(
-        capital={"capital_state": "shadow", "max_notional": "not-a-number"}
+        jangar_verification_carry={
+            "schema_version": "jangar.verify-trust-foreclosure-board.v1",
+            "board_id": "verify-trust-foreclosure-board:agents:test",
+            "status": "current",
+            "execution_trust_status": "degraded",
+            "fresh_until": fresh_until,
+            "reason_codes": ["existing_reason", " ", "existing_reason"],
+            "foreclosure_tickets": [],
+        }
     )
 
-    assert auction["reentry_decision"] == "deny"
-    assert "capital_notional_nonzero" in auction["reason_codes"]
+    carry = cast(Mapping[str, Any], auction["jangar_verification_carry"])
+    reason_codes = cast(list[str], carry["reason_codes"])
+    assert reason_codes.count("existing_reason") == 1
+    assert "jangar_foreclosure_ticket_missing" in reason_codes
+    if expected_extra_reason is not None:
+        assert expected_extra_reason in reason_codes
 
 
 def test_compact_no_delta_reentry_auction_ref() -> None:

--- a/services/torghut/tests/test_no_delta_repair_reentry_auction.py
+++ b/services/torghut/tests/test_no_delta_repair_reentry_auction.py
@@ -1,0 +1,286 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from copy import deepcopy
+from datetime import datetime, timezone
+from typing import Any, cast
+
+import pytest
+
+from app.trading.no_delta_repair_reentry_auction import (
+    build_no_delta_repair_reentry_auction,
+    compact_no_delta_repair_reentry_auction,
+)
+
+NOW = datetime(2026, 5, 14, 14, 40, tzinfo=timezone.utc)
+
+
+def _repair_queue() -> list[dict[str, object]]:
+    return [
+        {
+            "code": "repair_alpha_readiness",
+            "reason": "alpha_readiness_not_promotion_eligible",
+            "dimension": "alpha_readiness",
+            "action": "clear_hypothesis_blockers_before_capital",
+            "priority": 70,
+            "expected_unblock_value": 3,
+            "value_gate": "routeable_candidate_count",
+            "required_output_receipt": "torghut.executable-alpha-receipts.v1",
+            "required_receipts": [
+                "alpha_readiness_receipt",
+                "hypothesis_promotion_receipt",
+                "capital_replay_board",
+            ],
+            "max_notional": "0",
+            "capital_rule": "zero_notional_repair_only",
+        }
+    ]
+
+
+def _repair_bid_settlement() -> dict[str, object]:
+    return {
+        "ledger_id": "repair-bid-settlement-ledger:test",
+        "account_id": "PA3SX7FYNUTF",
+        "session_id": "15m",
+        "trading_mode": "live",
+        "routeable_candidate_count": 0,
+    }
+
+
+def _conveyor() -> dict[str, object]:
+    return {
+        "schema_version": "torghut.alpha-readiness-settlement-conveyor.v1",
+        "conveyor_id": "alpha-readiness-settlement-conveyor:test",
+        "generated_at": NOW.isoformat(),
+        "fresh_until": "2026-05-14T14:55:00+00:00",
+        "status": "no_delta",
+        "settlement_state": "no_delta",
+        "source_revenue_repair_ref": "torghut-revenue-repair-digest:test",
+        "account_id": "PA3SX7FYNUTF",
+        "window": "15m",
+        "trading_mode": "live",
+        "selected_value_gate": "routeable_candidate_count",
+        "routeable_candidate_count_before": 0,
+        "routeable_candidate_count_after": 0,
+        "measured_routeable_candidate_delta": 0,
+        "active_no_delta_lease_count": 1,
+        "selected_lane": {
+            "hypothesis_id": "H-MICRO-01",
+            "strategy_id": "microbar_volume_continuation_long_top2_chip_v1@paper",
+            "lane_id": "microstructure-breakout",
+            "before_reason_codes": [
+                "drift_checks_missing",
+                "feature_rows_missing",
+                "required_feature_set_unavailable",
+            ],
+            "required_receipts": [
+                "alpha_readiness_receipt",
+                "capital_replay_board",
+                "feature_replay_receipt",
+            ],
+            "no_delta_release_key": "release-key:micro",
+            "repeat_launch_decision": "deny",
+            "measured_routeable_candidate_delta": 0,
+            "max_notional": "0",
+        },
+        "settlement_receipt": {
+            "schema_version": "torghut.alpha-readiness-settlement-receipt.v1",
+            "receipt_id": "alpha-readiness-settlement-receipt:micro",
+            "hypothesis_id": "H-MICRO-01",
+            "settlement_state": "no_delta",
+            "routeable_candidate_count_before": 0,
+            "routeable_candidate_count_after": 0,
+            "measured_routeable_candidate_delta": 0,
+            "preserved_reason_codes": [
+                "drift_checks_missing",
+                "feature_rows_missing",
+                "required_feature_set_unavailable",
+            ],
+            "no_delta_release_key": "release-key:micro",
+            "repeat_launch_decision": "deny",
+            "missing_receipts": ["feature_replay_receipt"],
+        },
+    }
+
+
+def _dividend_ledger() -> dict[str, object]:
+    return {
+        "schema_version": "torghut.alpha-repair-dividend-ledger.v1",
+        "ledger_id": "alpha-repair-dividend-ledger:test",
+        "generated_at": NOW.isoformat(),
+        "fresh_until": "2026-05-14T14:55:00+00:00",
+        "source_revenue_repair_ref": "torghut-revenue-repair-digest:test",
+        "source_alpha_readiness_settlement_conveyor_ref": (
+            "alpha-readiness-settlement-conveyor:test"
+        ),
+        "account_id": "PA3SX7FYNUTF",
+        "window": "15m",
+        "trading_mode": "live",
+        "status": "no_delta",
+        "dividend_state": "no_delta",
+        "reason_codes": ["active_no_delta_release_key"],
+        "selected_queue_code": "repair_alpha_readiness",
+        "selected_value_gate": "routeable_candidate_count",
+        "routeable_candidate_count_before": 0,
+        "routeable_candidate_count_after": 0,
+        "measured_delta": 0,
+        "selected_hypothesis_id": "H-MICRO-01",
+        "preserved_reason_codes": [
+            "drift_checks_missing",
+            "feature_rows_missing",
+            "required_feature_set_unavailable",
+        ],
+        "required_output_receipt": "torghut.executable-alpha-receipts.v1",
+        "required_receipts": [
+            "alpha_readiness_receipt",
+            "feature_replay_receipt",
+        ],
+        "no_delta_release_key": "release-key:micro",
+        "no_delta_release_conditions": [
+            "source_ref_changes",
+            "evidence_window_changes",
+            "blocker_set_changes",
+            "required_receipt_changes",
+        ],
+        "jangar_custody": {
+            "required_recorder_schema": (
+                "jangar.material-action-custody-flight-recorder.v1"
+            ),
+            "launch_decision": "deny",
+            "launch_decision_reason": "no_delta_release_key_active",
+        },
+        "max_notional": "0",
+        "capital_rule": "zero_notional_repair_only",
+    }
+
+
+def _build(
+    *,
+    conveyor: Mapping[str, Any] | None = None,
+    dividend: Mapping[str, Any] | None = None,
+    capital: Mapping[str, Any] | None = None,
+    jangar_verification_carry: Mapping[str, Any] | None = None,
+) -> dict[str, object]:
+    return build_no_delta_repair_reentry_auction(
+        generated_at=NOW,
+        business_state="repair_only",
+        revenue_ready=False,
+        repair_queue=_repair_queue(),
+        capital=capital or {"capital_state": "zero_notional", "max_notional": "0"},
+        alpha_readiness_settlement_conveyor=_conveyor()
+        if conveyor is None
+        else conveyor,
+        alpha_repair_dividend_ledger=_dividend_ledger()
+        if dividend is None
+        else dividend,
+        repair_bid_settlement_ledger=_repair_bid_settlement(),
+        jangar_verification_carry=jangar_verification_carry,
+    )
+
+
+def test_no_delta_reentry_auction_denies_unchanged_active_release_key() -> None:
+    auction = _build()
+
+    assert auction["schema_version"] == "torghut.no-delta-repair-reentry-auction.v1"
+    assert auction["reentry_decision"] == "deny"
+    assert auction["active_no_delta_release_key"] == "release-key:micro"
+    assert auction["selected_ticket"] is None
+    assert auction["selected_value_gate"] == "routeable_candidate_count"
+    assert auction["max_notional"] == "0"
+    assert "no_release_condition_changed" in auction["reason_codes"]
+    assert "duplicate_no_delta_reentry_denied" in auction["reason_codes"]
+
+    tickets = cast(list[Mapping[str, Any]], auction["candidate_tickets"])
+    assert tickets
+    assert {ticket["state"] for ticket in tickets} == {"denied"}
+
+
+def test_no_delta_reentry_auction_selects_one_changed_evidence_ticket() -> None:
+    dividend = deepcopy(_dividend_ledger())
+    dividend["changed_release_conditions"] = ["evidence_window_changed"]
+
+    auction = _build(dividend=dividend)
+
+    assert auction["reentry_decision"] == "allow"
+    selected = cast(Mapping[str, Any], auction["selected_ticket"])
+    assert selected["ticket_class"] == "alpha_evidence_window"
+    assert selected["release_condition"] == "evidence_window_changed"
+    assert selected["state"] == "selected"
+    assert selected["max_notional"] == "0"
+    assert (
+        selected["required_output_receipt"]
+        == "torghut.alpha-evidence-window-receipt.v1"
+    )
+
+    selected_tickets = [
+        ticket
+        for ticket in cast(list[Mapping[str, Any]], auction["candidate_tickets"])
+        if ticket["state"] == "eligible"
+    ]
+    assert len(selected_tickets) == 1
+
+
+def test_no_delta_reentry_auction_selects_jangar_foreclosure_ticket() -> None:
+    auction = _build(
+        jangar_verification_carry={
+            "schema_version": "jangar.verify-trust-foreclosure-board.v1",
+            "board_id": "verify-trust-foreclosure-board:agents:test",
+            "status": "current",
+            "execution_trust_status": "degraded",
+            "fresh_until": "2026-05-14T14:55:00+00:00",
+            "foreclosure_tickets": [
+                {
+                    "ticket_id": "verify-trust-foreclosure-ticket:test",
+                    "state": "open",
+                    "required_output_receipt": (
+                        "jangar.verify-trust-foreclosure-ticket.v1"
+                    ),
+                }
+            ],
+        }
+    )
+
+    assert auction["reentry_decision"] == "allow"
+    selected = cast(Mapping[str, Any], auction["selected_ticket"])
+    assert selected["ticket_class"] == "jangar_verify_carry"
+    assert selected["release_condition"] == "jangar_verify_foreclosure_ticket_current"
+
+
+def test_no_delta_reentry_auction_denies_nonzero_notional() -> None:
+    auction = _build(capital={"capital_state": "shadow", "max_notional": "25"})
+
+    assert auction["reentry_decision"] == "deny"
+    assert auction["max_notional"] == "25"
+    assert "capital_notional_nonzero" in auction["reason_codes"]
+
+
+def test_compact_no_delta_reentry_auction_ref() -> None:
+    auction = _build()
+    compact = compact_no_delta_repair_reentry_auction(auction)
+
+    assert compact["schema_version"] == "torghut.no-delta-repair-reentry-auction-ref.v1"
+    assert compact["auction_id"] == auction["auction_id"]
+    assert compact["reentry_decision"] == "deny"
+    assert compact["active_no_delta_release_key"] == "release-key:micro"
+    assert compact["selected_ticket_id"] is None
+    assert compact["max_notional"] == "0"
+
+    assert compact_no_delta_repair_reentry_auction(None) == {
+        "schema_version": "torghut.no-delta-repair-reentry-auction-ref.v1",
+        "status": "missing",
+        "reason_codes": ["no_delta_repair_reentry_auction_missing"],
+    }
+
+
+def test_no_delta_reentry_auction_rejects_naive_generated_at() -> None:
+    with pytest.raises(ValueError, match="generated_at_missing_timezone"):
+        build_no_delta_repair_reentry_auction(
+            generated_at=datetime(2026, 5, 14, 14, 40),
+            business_state="repair_only",
+            revenue_ready=False,
+            repair_queue=_repair_queue(),
+            capital={"capital_state": "zero_notional", "max_notional": "0"},
+            alpha_readiness_settlement_conveyor=_conveyor(),
+            alpha_repair_dividend_ledger=_dividend_ledger(),
+            repair_bid_settlement_ledger=_repair_bid_settlement(),
+        )

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -1231,6 +1231,16 @@ class TestTradingApi(TestCase):
             alpha_dividend["required_recorder_schema"],
             "jangar.material-action-custody-flight-recorder.v1",
         )
+        no_delta_auction = payload["no_delta_repair_reentry_auction"]
+        self.assertEqual(
+            no_delta_auction["schema_version"],
+            "torghut.no-delta-repair-reentry-auction-ref.v1",
+        )
+        self.assertIn(
+            no_delta_auction["reentry_decision"],
+            {"deny", "hold"},
+        )
+        self.assertEqual(no_delta_auction["max_notional"], "0")
         warrant = payload["route_warrant_exchange"]
         self.assertEqual(
             warrant["schema_version"],


### PR DESCRIPTION
## Summary

- Implements the Torghut doc 206 observe-mode `torghut.no-delta-repair-reentry-auction.v1` reducer for the live `repair_alpha_readiness` blocker.
- Exposes the full auction on `/trading/revenue-repair` and compact `torghut.no-delta-repair-reentry-auction-ref.v1` on `/readyz` and `/trading/consumer-evidence`.
- Denies duplicate no-delta alpha-readiness reentry when the active release key is unchanged, and selects at most one zero-notional ticket when a source, evidence-window, blocker, receipt, selected-hypothesis, or Jangar verify-carry release condition changes.
- Keeps capital safety unchanged: observe mode only, `max_notional=0`, `capital_rule=zero_notional_repair_only`, and no paper/live submission enablement.
- Adds Torghut regression coverage plus rollout documentation with live before/after evidence. Before and after live reads both remain `business_state=repair_only`, `revenue_ready=false`, top queue `repair_alpha_readiness`, `routeable_candidate_count=0`, and `no_delta_repair_reentry_auction=null` because this PR is not deployed yet.

Design and requirement provenance:

- Governing design: `docs/torghut/design-system/v6/206-torghut-no-delta-repair-reentry-auction-and-verification-carry-2026-05-14.md`
- Handoff design: `docs/torghut/design-system/v6/207-torghut-quant-plan-closeout-and-alpha-repair-reentry-handoff-2026-05-14.md`
- Runtime source: `GET http://torghut.torghut.svc.cluster.local/trading/revenue-repair`
- Value gate: `routeable_candidate_count`

Risk and rollback:

- Risk is limited to additive observe-mode evidence fields.
- Rollback is to revert this PR or stop emitting `no_delta_repair_reentry_auction`; existing alpha-readiness settlement conveyor, alpha repair dividend ledger, repair-bid settlement, and capital proof-floor remain authoritative.
- Paper and live action classes remain closed because live submit stays disabled and `max_notional=0`.

## Related Issues

None

## Testing

- `/tmp/codex-uv-bootstrap/bin/uv sync --frozen --extra dev`: pass
- `/tmp/codex-uv-bootstrap/bin/uv run --frozen ruff format --check app/trading/no_delta_repair_reentry_auction.py app/trading/revenue_repair.py app/main.py tests/test_no_delta_repair_reentry_auction.py tests/test_build_revenue_repair_digest.py tests/test_trading_api.py`: pass
- `/tmp/codex-uv-bootstrap/bin/uv run --frozen ruff check app/trading/no_delta_repair_reentry_auction.py app/trading/revenue_repair.py app/main.py tests/test_no_delta_repair_reentry_auction.py tests/test_build_revenue_repair_digest.py tests/test_trading_api.py`: pass
- `/tmp/codex-uv-bootstrap/bin/uv run --frozen pytest tests/test_no_delta_repair_reentry_auction.py`: pass, 13 tests
- `/tmp/codex-uv-bootstrap/bin/uv run --frozen pytest tests/test_alpha_readiness_settlement_conveyor.py`: pass, 7 tests
- `/tmp/codex-uv-bootstrap/bin/uv run --frozen pytest tests/test_alpha_repair_dividend_ledger.py`: pass, 10 tests
- `/tmp/codex-uv-bootstrap/bin/uv run --frozen pytest tests/test_build_revenue_repair_digest.py -k revenue_repair`: pass, 15 tests
- `/tmp/codex-uv-bootstrap/bin/uv run --frozen pytest tests/test_trading_api.py -k "consumer_evidence or revenue_repair"`: pass, 2 tests
- `/tmp/codex-uv-bootstrap/bin/uv run --frozen pytest tests/test_consumer_evidence.py`: pass, 2 tests
- `/tmp/codex-uv-bootstrap/bin/uv run --frozen pytest tests/test_no_delta_repair_reentry_auction.py tests/test_alpha_readiness_settlement_conveyor.py tests/test_alpha_repair_dividend_ledger.py tests/test_build_revenue_repair_digest.py tests/test_trading_api.py tests/test_consumer_evidence.py -k "no_delta or alpha or revenue_repair or consumer_evidence" --cov --cov-branch --cov-fail-under=0 --cov-report=xml --cov-report=`: pass, 50 tests
- `/tmp/codex-uv-bootstrap/bin/uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90`: pass, changed-line coverage 99.65%
- `/tmp/codex-uv-bootstrap/bin/uv run --frozen pyright --project pyrightconfig.json`: pass
- `/tmp/codex-uv-bootstrap/bin/uv run --frozen pyright --project pyrightconfig.alpha.json`: pass
- `/tmp/codex-uv-bootstrap/bin/uv run --frozen pyright --project pyrightconfig.scripts.json`: pass
- `curl -fsS --max-time 10 http://torghut.torghut.svc.cluster.local/trading/revenue-repair | jq '{generated_at,business_state,revenue_ready,top_repair_queue:.repair_queue[0],capital:.capital,routeability:.evidence.routeability_acceptance,no_delta_repair_reentry_auction:.no_delta_repair_reentry_auction}'`: live service still repair-only before deploy
- `curl -fsS --max-time 10 http://torghut.torghut.svc.cluster.local/trading/consumer-evidence | jq '{alpha_readiness_settlement_conveyor,alpha_repair_dividend_ledger,no_delta_repair_reentry_auction}'`: live service still has no compact auction before deploy
- `curl -sS --max-time 10 -w '\nHTTP_STATUS:%{http_code}\n' http://torghut.torghut.svc.cluster.local/readyz`: HTTP 503 with expected capital-safety holds

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
