### PR TITLE
fix(torghut): refresh stale market context status

### DIFF
--- a/services/torghut/app/trading/scheduler/runtime.py
+++ b/services/torghut/app/trading/scheduler/runtime.py
@@ -19,7 +19,10 @@ from ..execution import OrderExecutor
 from ..execution_adapters import build_execution_adapter
 from ..firewall import OrderFirewall
 from ..ingest import ClickHouseSignalIngestor
-from ..llm.dspy_programs.runtime import DSPyReviewRuntime, DSPyRuntimeUnsupportedStateError
+from ..llm.dspy_programs.runtime import (
+    DSPyReviewRuntime,
+    DSPyRuntimeUnsupportedStateError,
+)
 from ..llm.guardrails import evaluate_llm_guardrails
 from ..market_context import MarketContextClient, evaluate_market_context
 from ..order_feed import OrderFeedIngestor
@@ -37,6 +40,7 @@ from .pipeline_helpers import _build_llm_policy_resolution
 from .state import TradingState
 
 logger = logging.getLogger(__name__)
+
 
 class TradingScheduler(TradingSchedulerGovernanceMixin):
     def __init__(self) -> None:
@@ -95,12 +99,12 @@ class TradingScheduler(TradingSchedulerGovernanceMixin):
         circuit_snapshot = None
         pipeline = self._pipeline
         llm_review_engine = (
-            getattr(pipeline, "llm_review_engine", None) if pipeline is not None else None
+            getattr(pipeline, "llm_review_engine", None)
+            if pipeline is not None
+            else None
         )
         if llm_review_engine:
-            circuit_snapshot = (
-                llm_review_engine.circuit_breaker.snapshot()
-            )
+            circuit_snapshot = llm_review_engine.circuit_breaker.snapshot()
         guardrails = evaluate_llm_guardrails()
         policy_resolution = _build_llm_policy_resolution(
             rollout_stage=guardrails.rollout_stage,
@@ -223,9 +227,24 @@ class TradingScheduler(TradingSchedulerGovernanceMixin):
                 )
             except Exception as exc:
                 health_error = str(exc)
+        domain_refresh_states = {"stale", "error"}
+        refreshable_domain_state = any(
+            str(state).strip().lower() in domain_refresh_states
+            for state in last_domain_states.values()
+        )
+        local_snapshot_stale = (
+            last_freshness_seconds is not None
+            and int(last_freshness_seconds)
+            > settings.trading_market_context_max_staleness_seconds
+        )
         if (
             settings.trading_market_context_url
-            and (last_freshness_seconds is None or last_symbol is None)
+            and (
+                last_freshness_seconds is None
+                or last_symbol is None
+                or local_snapshot_stale
+                or refreshable_domain_state
+            )
             and probe_symbol
         ):
             try:
@@ -338,8 +357,7 @@ class TradingScheduler(TradingSchedulerGovernanceMixin):
         )
         runtime_fallback_alert_active = (
             llm_requests_total > 0
-            and runtime_fallback_ratio
-            > settings.llm_dspy_runtime_fallback_alert_ratio
+            and runtime_fallback_ratio > settings.llm_dspy_runtime_fallback_alert_ratio
         )
         shorting_status = self.shorting_metadata_status()
         return {
@@ -437,7 +455,9 @@ class TradingScheduler(TradingSchedulerGovernanceMixin):
             lanes = settings.trading_accounts
             self._pipelines = [self._build_pipeline_for_account(lane) for lane in lanes]
             self._pipeline = self._pipelines[0] if self._pipelines else None
-        account_labels = ",".join(pipeline.account_label for pipeline in self._pipelines)
+        account_labels = ",".join(
+            pipeline.account_label for pipeline in self._pipelines
+        )
         logger.info(
             "Trading scheduler starting accounts=%s poll_interval_seconds=%s reconcile_interval_seconds=%s autonomy_enabled=%s autonomy_interval_seconds=%s evidence_enabled=%s evidence_interval_seconds=%s",
             account_labels or "none",
@@ -460,7 +480,9 @@ class TradingScheduler(TradingSchedulerGovernanceMixin):
             return
         account_labels = ",".join(
             pipeline.account_label
-            for pipeline in (self._pipelines or ([self._pipeline] if self._pipeline else []))
+            for pipeline in (
+                self._pipelines or ([self._pipeline] if self._pipeline else [])
+            )
         )
         logger.info("Trading scheduler stopping accounts=%s", account_labels or "none")
         self._stop_event.set()
@@ -516,8 +538,11 @@ class TradingScheduler(TradingSchedulerGovernanceMixin):
                     await self._run_autonomy_iteration()
                     last_autonomy = now
 
-                if settings.trading_evidence_continuity_enabled and self._interval_elapsed(
-                    last_evidence_check, evidence_interval, now=now
+                if (
+                    settings.trading_evidence_continuity_enabled
+                    and self._interval_elapsed(
+                        last_evidence_check, evidence_interval, now=now
+                    )
                 ):
                     await self._run_evidence_iteration()
                     last_evidence_check = now

--- a/services/torghut/tests/test_scheduler_market_context_status.py
+++ b/services/torghut/tests/test_scheduler_market_context_status.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import asyncio
 import json
+from datetime import datetime, timezone
+from types import SimpleNamespace
 from typing import Any, cast
 from unittest import TestCase
 from unittest.mock import patch
@@ -35,6 +38,23 @@ class _PipelineWithBrokenUniverse:
     universe_resolver = _BrokenUniverseResolver()
 
 
+class _CircuitBreakerStub:
+    def snapshot(self) -> dict[str, str]:
+        return {"state": "closed"}
+
+
+class _LlmReviewEngineStub:
+    circuit_breaker = _CircuitBreakerStub()
+
+
+class _PipelineWithLlmReview:
+    llm_review_engine = _LlmReviewEngineStub()
+
+
+class _PipelineLabelStub:
+    account_label = "live"
+
+
 class TestTradingSchedulerMarketContextStatus(TestCase):
     def setUp(self) -> None:
         self._original_url = config.settings.trading_market_context_url
@@ -44,6 +64,10 @@ class TestTradingSchedulerMarketContextStatus(TestCase):
         self._original_max_staleness = (
             config.settings.trading_market_context_max_staleness_seconds
         )
+        self._original_autonomy_enabled = config.settings.trading_autonomy_enabled
+        self._original_evidence_enabled = (
+            config.settings.trading_evidence_continuity_enabled
+        )
 
     def tearDown(self) -> None:
         config.settings.trading_market_context_url = self._original_url
@@ -52,6 +76,10 @@ class TestTradingSchedulerMarketContextStatus(TestCase):
         config.settings.trading_market_context_min_quality = self._original_min_quality
         config.settings.trading_market_context_max_staleness_seconds = (
             self._original_max_staleness
+        )
+        config.settings.trading_autonomy_enabled = self._original_autonomy_enabled
+        config.settings.trading_evidence_continuity_enabled = (
+            self._original_evidence_enabled
         )
 
     def test_status_fetches_jangar_context_when_runtime_state_is_empty(self) -> None:
@@ -164,6 +192,133 @@ class TestTradingSchedulerMarketContextStatus(TestCase):
         self.assertFalse(status["alert_active"])
         self.assertFalse(scheduler.state.market_context_alert_active)
 
+    def test_status_refetches_when_cached_domain_state_is_stale(self) -> None:
+        config.settings.trading_market_context_url = (
+            "http://jangar.test/api/torghut/market-context"
+        )
+        config.settings.trading_market_context_timeout_seconds = 2
+        config.settings.trading_static_symbols_raw = "AAPL,AVGO,NVDA"
+        config.settings.trading_market_context_min_quality = 0.4
+        config.settings.trading_market_context_max_staleness_seconds = 300
+
+        bundle = MarketContextBundle.model_validate(
+            {
+                "contextVersion": "torghut.market-context.v1",
+                "symbol": "AVGO",
+                "asOfUtc": "2026-05-14T15:01:12Z",
+                "freshnessSeconds": 20,
+                "qualityScore": 0.93,
+                "sourceCount": 10,
+                "riskFlags": [],
+                "domains": {
+                    "technicals": {
+                        "domain": "technicals",
+                        "state": "ok",
+                        "asOf": "2026-05-14T15:01:12Z",
+                        "freshnessSeconds": 20,
+                        "maxFreshnessSeconds": 60,
+                        "sourceCount": 1,
+                        "qualityScore": 1,
+                        "payload": {},
+                        "citations": [],
+                        "riskFlags": [],
+                    },
+                    "fundamentals": {
+                        "domain": "fundamentals",
+                        "state": "ok",
+                        "asOf": "2026-05-13T15:45:29Z",
+                        "freshnessSeconds": 83750,
+                        "maxFreshnessSeconds": 86400,
+                        "sourceCount": 3,
+                        "qualityScore": 0.91,
+                        "payload": {},
+                        "citations": [],
+                        "riskFlags": [],
+                    },
+                    "news": {
+                        "domain": "news",
+                        "state": "ok",
+                        "asOf": "2026-05-14T14:57:44Z",
+                        "freshnessSeconds": 215,
+                        "maxFreshnessSeconds": 600,
+                        "sourceCount": 5,
+                        "qualityScore": 0.8,
+                        "payload": {},
+                        "citations": [],
+                        "riskFlags": [],
+                    },
+                    "regime": {
+                        "domain": "regime",
+                        "state": "ok",
+                        "asOf": "2026-05-14T15:01:12Z",
+                        "freshnessSeconds": 20,
+                        "maxFreshnessSeconds": 120,
+                        "sourceCount": 1,
+                        "qualityScore": 1,
+                        "payload": {},
+                        "citations": [],
+                        "riskFlags": [],
+                    },
+                },
+            }
+        )
+        responses = iter(
+            [
+                _FakeResponse({"ok": True, "health": {"overallState": "ok"}}),
+                _FakeResponse(
+                    {
+                        "ok": True,
+                        "context": bundle.model_dump(mode="json", by_alias=True),
+                    }
+                ),
+            ]
+        )
+        request_urls: list[str] = []
+
+        def fake_urlopen(request: Any, _timeout: int) -> _FakeResponse:
+            request_urls.append(str(request.full_url))
+            return next(responses)
+
+        scheduler = TradingScheduler()
+        scheduler.state.last_market_context_symbol = "AVGO"
+        scheduler.state.last_market_context_checked_at = datetime(
+            2026, 5, 14, 14, 57, 53, tzinfo=timezone.utc
+        )
+        scheduler.state.last_market_context_as_of = datetime(
+            2026, 5, 14, 14, 57, 12, tzinfo=timezone.utc
+        )
+        scheduler.state.last_market_context_freshness_seconds = 239
+        scheduler.state.last_market_context_quality_score = 0.93
+        scheduler.state.last_market_context_domain_states = {
+            "technicals": "ok",
+            "fundamentals": "ok",
+            "news": "stale",
+            "regime": "ok",
+        }
+        scheduler.state.last_market_context_risk_flags = ["news_stale"]
+        scheduler.state.market_context_alert_active = True
+        scheduler.state.market_context_alert_reason = "market_context_domain_news_stale"
+
+        with patch("app.trading.market_context.urlopen", side_effect=fake_urlopen):
+            status = scheduler.market_context_status()
+
+        self.assertIn("/api/torghut/market-context/health?symbol=AVGO", request_urls[0])
+        self.assertIn("/api/torghut/market-context?symbol=AVGO", request_urls[1])
+        self.assertEqual(status["last_symbol"], "AVGO")
+        self.assertEqual(status["last_freshness_seconds"], 20)
+        self.assertEqual(
+            status["last_domain_states"],
+            {
+                "technicals": "ok",
+                "fundamentals": "ok",
+                "news": "ok",
+                "regime": "ok",
+            },
+        )
+        self.assertFalse(status["alert_active"])
+        self.assertFalse(scheduler.state.market_context_alert_active)
+        self.assertIsNone(scheduler.state.market_context_alert_reason)
+
     def test_status_records_context_fetch_error(self) -> None:
         config.settings.trading_market_context_url = (
             "http://jangar.test/api/torghut/market-context"
@@ -201,3 +356,85 @@ class TestTradingSchedulerMarketContextStatus(TestCase):
             cast(Any, scheduler)._market_context_probe_symbol(),
             "MSFT",
         )
+
+    def test_llm_status_includes_review_engine_circuit_snapshot(self) -> None:
+        scheduler = TradingScheduler()
+        cast(Any, scheduler)._pipeline = _PipelineWithLlmReview()
+        guardrails = SimpleNamespace(
+            rollout_stage="shadow",
+            effective_fail_mode="shadow",
+            reasons=[],
+            shadow_mode=True,
+            allow_requests=True,
+            governance_evidence_complete=True,
+            adjustment_allowed=False,
+            committee_enabled=False,
+        )
+
+        with (
+            patch(
+                "app.trading.scheduler.runtime.evaluate_llm_guardrails",
+                return_value=guardrails,
+            ),
+            patch(
+                "app.trading.scheduler.runtime._build_llm_policy_resolution",
+                return_value={"mode": "shadow"},
+            ),
+        ):
+            status = scheduler.llm_status()
+
+        self.assertEqual(status["circuit"], {"state": "closed"})
+
+    def test_start_reports_existing_pipeline_labels(self) -> None:
+        async def run_once() -> None:
+            scheduler = TradingScheduler()
+            pipeline = _PipelineLabelStub()
+            cast(Any, scheduler)._pipelines = [pipeline]
+            cast(Any, scheduler)._pipeline = pipeline
+
+            async def fake_run_loop() -> None:
+                return None
+
+            with (
+                patch.object(scheduler, "_assert_trading_shorts_startup_policy"),
+                patch.object(scheduler, "_run_loop", side_effect=fake_run_loop),
+            ):
+                await scheduler.start()
+                task = scheduler._task
+                self.assertIsNotNone(task)
+                await cast(asyncio.Task[None], task)
+
+        asyncio.run(run_once())
+
+    def test_run_loop_executes_enabled_evidence_continuity_check(self) -> None:
+        config.settings.trading_autonomy_enabled = False
+        config.settings.trading_evidence_continuity_enabled = True
+        scheduler = TradingScheduler()
+        calls = {"trading": 0, "reconcile": 0, "evidence": 0}
+
+        async def fake_trading_iteration() -> None:
+            calls["trading"] += 1
+            scheduler._stop_event.set()
+
+        async def fake_reconcile_iteration() -> None:
+            calls["reconcile"] += 1
+
+        async def fake_evidence_iteration() -> None:
+            calls["evidence"] += 1
+
+        async def fake_sleep(_delay: float) -> None:
+            return None
+
+        cast(Any, scheduler)._run_trading_iteration = fake_trading_iteration
+        cast(Any, scheduler)._run_reconcile_iteration = fake_reconcile_iteration
+        cast(Any, scheduler)._run_evidence_iteration = fake_evidence_iteration
+        cast(Any, scheduler)._sync_simulation_run_context = lambda: None
+        cast(Any, scheduler)._interval_elapsed = lambda *_args, **_kwargs: True
+
+        with patch(
+            "app.trading.scheduler.runtime.asyncio.sleep", side_effect=fake_sleep
+        ):
+            asyncio.run(scheduler._run_loop())
+
+        self.assertEqual(calls, {"trading": 1, "reconcile": 1, "evidence": 1})
+        self.assertFalse(scheduler.state.running)


### PR DESCRIPTION
## Summary

- Refreshes Torghut market-context status when the cached domain state is stale or errored, so repaired Jangar proofs can clear the live revenue gate.
- Keeps existing cached behavior for healthy market-context snapshots and still records health/context fetch errors through the existing status path.
- Adds a scheduler regression covering the live AVGO shape: stale cached news is re-fetched from Jangar and clears the alert.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_scheduler_market_context_status.py`
- `uv run --frozen pytest tests/test_market_context.py tests/test_scheduler_market_context_status.py`
- `uv run --frozen ruff check app/trading/scheduler/runtime.py tests/test_scheduler_market_context_status.py`
- `uv run --frozen ruff format --check app/trading/scheduler/runtime.py tests/test_scheduler_market_context_status.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
