### PR TITLE
chore(torghut): promote image 54e35769

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:5e58d7b896c5303985506854355889726a36c769223fc37a654e14ac197eae8a
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:d08ffe8fdebd27f471a9067934fa02cff5e212f076c5f7eca5df36a2e14c37cf
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.569.1-415-g007833f18
+              value: v0.569.1-418-g54e35769c
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 007833f18232fa61e3de095203a59d84f6fa1e0a
+              value: 54e35769c00dff5fe856d077b7754d63afb10636
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:5e58d7b896c5303985506854355889726a36c769223fc37a654e14ac197eae8a
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:d08ffe8fdebd27f471a9067934fa02cff5e212f076c5f7eca5df36a2e14c37cf
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.569.1-415-g007833f18
+              value: v0.569.1-418-g54e35769c
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 007833f18232fa61e3de095203a59d84f6fa1e0a
+              value: 54e35769c00dff5fe856d077b7754d63afb10636
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:5e58d7b896c5303985506854355889726a36c769223fc37a654e14ac197eae8a
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:d08ffe8fdebd27f471a9067934fa02cff5e212f076c5f7eca5df36a2e14c37cf
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:5e58d7b896c5303985506854355889726a36c769223fc37a654e14ac197eae8a
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:d08ffe8fdebd27f471a9067934fa02cff5e212f076c5f7eca5df36a2e14c37cf
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:5e58d7b896c5303985506854355889726a36c769223fc37a654e14ac197eae8a
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:d08ffe8fdebd27f471a9067934fa02cff5e212f076c5f7eca5df36a2e14c37cf
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:5e58d7b896c5303985506854355889726a36c769223fc37a654e14ac197eae8a
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:d08ffe8fdebd27f471a9067934fa02cff5e212f076c5f7eca5df36a2e14c37cf
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:5e58d7b896c5303985506854355889726a36c769223fc37a654e14ac197eae8a
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:d08ffe8fdebd27f471a9067934fa02cff5e212f076c5f7eca5df36a2e14c37cf
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -15,7 +15,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:5e58d7b896c5303985506854355889726a36c769223fc37a654e14ac197eae8a
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:d08ffe8fdebd27f471a9067934fa02cff5e212f076c5f7eca5df36a2e14c37cf
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -23,7 +23,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:5e58d7b896c5303985506854355889726a36c769223fc37a654e14ac197eae8a
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:d08ffe8fdebd27f471a9067934fa02cff5e212f076c5f7eca5df36a2e14c37cf
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:5e58d7b896c5303985506854355889726a36c769223fc37a654e14ac197eae8a
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:d08ffe8fdebd27f471a9067934fa02cff5e212f076c5f7eca5df36a2e14c37cf
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-14T15:06:18Z"
+        client.knative.dev/updateTimestamp: "2026-05-14T15:31:30Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -27,7 +27,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:5e58d7b896c5303985506854355889726a36c769223fc37a654e14ac197eae8a
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:d08ffe8fdebd27f471a9067934fa02cff5e212f076c5f7eca5df36a2e14c37cf
           ports:
             - name: http1
               containerPort: 8181
@@ -482,11 +482,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.569.1-415-g007833f18
+              value: v0.569.1-418-g54e35769c
             - name: TORGHUT_COMMIT
-              value: 007833f18232fa61e3de095203a59d84f6fa1e0a
+              value: 54e35769c00dff5fe856d077b7754d63afb10636
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:5e58d7b896c5303985506854355889726a36c769223fc37a654e14ac197eae8a
+              value: sha256:d08ffe8fdebd27f471a9067934fa02cff5e212f076c5f7eca5df36a2e14c37cf
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-14T15:06:18Z"
+        client.knative.dev/updateTimestamp: "2026-05-14T15:31:30Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:5e58d7b896c5303985506854355889726a36c769223fc37a654e14ac197eae8a
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:d08ffe8fdebd27f471a9067934fa02cff5e212f076c5f7eca5df36a2e14c37cf
           ports:
             - name: http1
               containerPort: 8181
@@ -306,11 +306,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.569.1-415-g007833f18
+              value: v0.569.1-418-g54e35769c
             - name: TORGHUT_COMMIT
-              value: 007833f18232fa61e3de095203a59d84f6fa1e0a
+              value: 54e35769c00dff5fe856d077b7754d63afb10636
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:5e58d7b896c5303985506854355889726a36c769223fc37a654e14ac197eae8a
+              value: sha256:d08ffe8fdebd27f471a9067934fa02cff5e212f076c5f7eca5df36a2e14c37cf
           livenessProbe:
             httpGet:
               path: /healthz

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -98,7 +98,7 @@ spec:
           - name: allowStaleTape
           - name: persistResults
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:5e58d7b896c5303985506854355889726a36c769223fc37a654e14ac197eae8a
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:d08ffe8fdebd27f471a9067934fa02cff5e212f076c5f7eca5df36a2e14c37cf
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
+++ b/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:5e58d7b896c5303985506854355889726a36c769223fc37a654e14ac197eae8a
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:d08ffe8fdebd27f471a9067934fa02cff5e212f076c5f7eca5df36a2e14c37cf
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `54e35769c00dff5fe856d077b7754d63afb10636`
- Image tag: `54e35769`
- Image digest: `sha256:d08ffe8fdebd27f471a9067934fa02cff5e212f076c5f7eca5df36a2e14c37cf`