### PR TITLE
fix(torghut): clear false signal lag holds

### DIFF
--- a/services/torghut/app/trading/hypotheses.py
+++ b/services/torghut/app/trading/hypotheses.py
@@ -876,14 +876,20 @@ def compile_hypothesis_runtime_statuses(
                 and evidence_age_minutes > requirements.max_evidence_age_minutes
             ):
                 reasons.append("evidence_continuity_stale")
-        if requirements.max_signal_lag_seconds is not None and (
-            signal_lag_seconds is None
-            or signal_lag_seconds > requirements.max_signal_lag_seconds
-        ):
-            if market_session_open is False:
-                informational_reasons.append("closed_session_signal_hold")
-            else:
-                reasons.append("signal_lag_exceeded")
+        max_signal_lag_seconds = requirements.max_signal_lag_seconds
+        if max_signal_lag_seconds is not None:
+            signal_lag_unmeasured_without_features = (
+                signal_lag_seconds is None and feature_batch_rows_total <= 0
+            )
+            signal_lag_exceeds_budget = (
+                signal_lag_seconds is not None
+                and signal_lag_seconds > max_signal_lag_seconds
+            )
+            if signal_lag_unmeasured_without_features or signal_lag_exceeds_budget:
+                if market_session_open is False:
+                    informational_reasons.append("closed_session_signal_hold")
+                else:
+                    reasons.append("signal_lag_exceeded")
         if (
             requirements.max_no_signal_streak is not None
             and no_signal_streak > requirements.max_no_signal_streak

--- a/services/torghut/tests/test_hypotheses.py
+++ b/services/torghut/tests/test_hypotheses.py
@@ -242,8 +242,15 @@ class TestHypothesisReadiness(TestCase):
         )
 
         micro = next(item for item in statuses if item["hypothesis_id"] == "H-MICRO-01")
+        cont = next(item for item in statuses if item["hypothesis_id"] == "H-CONT-01")
+        rev = next(item for item in statuses if item["hypothesis_id"] == "H-REV-01")
+        self.assertNotIn("signal_lag_exceeded", cont["reasons"])
         self.assertNotIn("feature_rows_missing", micro["reasons"])
         self.assertNotIn("required_feature_set_unavailable", micro["reasons"])
+        self.assertNotIn("signal_lag_exceeded", micro["reasons"])
+        self.assertNotIn("signal_lag_exceeded", rev["reasons"])
+        self.assertEqual(cont["observed"]["signal_lag_seconds"], None)
+        self.assertEqual(cont["observed"]["feature_batch_rows_total"], 12)
 
     def test_compile_hypothesis_runtime_statuses_promotes_canary_when_thresholds_are_met(
         self,


### PR DESCRIPTION
## Summary

- Stop treating null signal-lag telemetry as `signal_lag_exceeded` when feature rows prove the signal feed is present.
- Preserve the fail-closed behavior when signal lag is unmeasured and no feature rows are available.
- Add a regression assertion for persisted feature-readiness rows so Torghut does not keep false TA-core holds after a healthy signal cycle.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_hypotheses.py -k 'persisted_feature_readiness or stays_shadow_without_feature'`
- `uv run --frozen pytest tests/test_hypotheses.py`
- `uv run --frozen pytest tests/test_submission_council.py tests/test_hypotheses.py`
- `uv run --frozen ruff check app/trading/hypotheses.py tests/test_hypotheses.py`
- `uv run --frozen ruff format --check app/trading/hypotheses.py tests/test_hypotheses.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked; no docs change required for this narrow reducer fix.
