### PR TITLE
fix(torghut): block nonpositive family feedback replays

### DIFF
--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -37,19 +37,19 @@ spec:
       - name: targetNetPnlPerDay
         value: '500'
       - name: maxCandidates
-        value: '64'
+        value: '96'
       - name: topK
-        value: '16'
+        value: '24'
       - name: explorationSlots
-        value: '8'
+        value: '16'
       - name: portfolioSizeMin
-        value: '2'
+        value: '3'
       - name: portfolioSizeMax
         value: '8'
       - name: maxFrontierCandidatesPerSpec
         value: '2'
       - name: maxTotalFrontierCandidates
-        value: '24'
+        value: '48'
       - name: realReplayTimeoutSeconds
         value: '7200'
       - name: realReplayShardSize
@@ -57,7 +57,7 @@ spec:
       - name: realReplayShardTimeoutSeconds
         value: '900'
       - name: realReplayShardWorkers
-        value: '3'
+        value: '6'
       - name: prefetchFullWindowRows
         value: 'true'
       - name: allowStaleTape

--- a/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
+++ b/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
@@ -119,6 +119,10 @@ describe('Torghut manifest scheduling', () => {
     expect(JSON.stringify(template)).toContain('--real-replay-shard-size')
     expect(JSON.stringify(template)).toContain('--real-replay-shard-timeout-seconds')
     expect(JSON.stringify(template)).toContain('--real-replay-shard-workers')
+    expect(parameterValue(manifest, 'maxCandidates')).toBe('96')
+    expect(parameterValue(manifest, 'topK')).toBe('24')
+    expect(parameterValue(manifest, 'explorationSlots')).toBe('16')
+    expect(parameterValue(manifest, 'portfolioSizeMin')).toBe('3')
   })
 
   it('bounds whitepaper autoresearch real replay so profit runs emit evidence before timeout', () => {
@@ -126,10 +130,10 @@ describe('Torghut manifest scheduling', () => {
     const template = getAtPath(manifest, ['spec', 'templates', 0])
 
     expect(parameterValue(manifest, 'maxFrontierCandidatesPerSpec')).toBe('2')
-    expect(parameterValue(manifest, 'maxTotalFrontierCandidates')).toBe('24')
+    expect(parameterValue(manifest, 'maxTotalFrontierCandidates')).toBe('48')
     expect(parameterValue(manifest, 'realReplayTimeoutSeconds')).toBe('7200')
     expect(parameterValue(manifest, 'realReplayShardSize')).toBe('1')
-    expect(parameterValue(manifest, 'realReplayShardWorkers')).toBe('3')
+    expect(parameterValue(manifest, 'realReplayShardWorkers')).toBe('6')
     expect(template.activeDeadlineSeconds).toBe(10800)
   })
 })

--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -2389,6 +2389,10 @@ def _feedback_is_blocked(scorecard: Mapping[str, Any]) -> bool:
     )
 
 
+def _feedback_has_nonpositive_expected_value(scorecard: Mapping[str, Any]) -> bool:
+    return _decimal(scorecard.get("net_pnl_per_day")) <= Decimal("0")
+
+
 def _feedback_bundle_sort_value(
     bundle: CandidateEvidenceBundle,
 ) -> tuple[int, Decimal, str]:
@@ -2578,6 +2582,12 @@ def _pre_replay_proposal_model_and_rows(
             return "pre_replay_mlx_feedback_blocked"
         if source == "feedback_execution_signature_replay" and is_blocked:
             return "pre_replay_mlx_signature_feedback_blocked"
+        if (
+            source == "feedback_family_replay"
+            and bundle is not None
+            and _feedback_has_nonpositive_expected_value(bundle.objective_scorecard)
+        ):
+            return "pre_replay_mlx_family_feedback_blocked"
         if source == "feedback_family_replay" and is_blocked:
             return "pre_replay_mlx_family_feedback_penalized"
         return "pre_replay_mlx_rank"
@@ -2589,6 +2599,12 @@ def _pre_replay_proposal_model_and_rows(
             source in {"feedback_real_replay", "feedback_execution_signature_replay"}
             and bundle is not None
             and _feedback_is_blocked(bundle.objective_scorecard)
+        ):
+            return min(-1_000_000.0, target_by_spec.get(candidate_spec_id, raw_score))
+        if (
+            source == "feedback_family_replay"
+            and bundle is not None
+            and _feedback_has_nonpositive_expected_value(bundle.objective_scorecard)
         ):
             return min(-1_000_000.0, target_by_spec.get(candidate_spec_id, raw_score))
         return raw_score
@@ -2718,6 +2734,7 @@ def _select_candidate_specs_for_replay(
     feedback_block_reasons = {
         "pre_replay_mlx_feedback_blocked",
         "pre_replay_mlx_signature_feedback_blocked",
+        "pre_replay_mlx_family_feedback_blocked",
     }
 
     def proposal_score(candidate_spec_id: str) -> Decimal:

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -991,6 +991,67 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             "synthetic_prior",
         )
 
+    def test_candidate_selection_blocks_nonpositive_family_feedback(self) -> None:
+        source_spec = self._candidate_spec("spec-family-negative-source")
+        mutated_family_spec = self._candidate_spec(
+            "spec-family-negative-mutated",
+            entry_minute_after_open="60",
+        )
+        family_feedback_bundle = runner.evidence_bundle_from_frontier_candidate(
+            candidate_spec_id=source_spec.candidate_spec_id,
+            candidate={
+                "candidate_id": "cand-family-negative-source",
+                "family_template_id": source_spec.family_template_id,
+                "runtime_family": source_spec.runtime_family,
+                "runtime_strategy_name": source_spec.runtime_strategy_name,
+                "objective_scorecard": {
+                    "net_pnl_per_day": "-250",
+                    "active_day_ratio": "1",
+                    "positive_day_ratio": "0",
+                    "negative_day_count": 4,
+                    "daily_net": {
+                        "2026-05-01": "-150",
+                        "2026-05-04": "-350",
+                    },
+                },
+            },
+            dataset_snapshot_id="snap-family-negative-feedback",
+            result_path="feedback://family-negative",
+        )
+
+        _model, rows = runner._pre_replay_proposal_model_and_rows(
+            specs=(mutated_family_spec,),
+            feedback_evidence_bundles=(family_feedback_bundle,),
+        )
+
+        self.assertEqual(rows[0]["training_source"], "feedback_family_replay")
+        self.assertEqual(
+            rows[0]["selection_reason"], "pre_replay_mlx_family_feedback_blocked"
+        )
+        self.assertLessEqual(
+            Decimal(str(rows[0]["proposal_score"])), Decimal("-999999")
+        )
+
+        selected, selection = runner._select_candidate_specs_for_replay(
+            specs=(mutated_family_spec,),
+            proposal_rows=rows,
+            top_k=1,
+            exploration_slots=0,
+            max_candidates=1,
+            portfolio_size_min=1,
+        )
+
+        self.assertEqual(selected, [])
+        self.assertEqual(selection["budget"]["selected_count"], 0)
+        self.assertEqual(selection["budget"]["eligible_candidate_count"], 0)
+        self.assertEqual(
+            selection["budget"]["pre_replay_feedback_blocked_candidate_count"], 1
+        )
+        self.assertEqual(
+            selection["rows"][0]["selection_reason"],
+            "pre_replay_mlx_family_feedback_blocked",
+        )
+
     def test_candidate_selection_blocks_synthetic_nonpositive_expected_value(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Hard-block pre-replay candidates when the best matched family-level feedback has nonpositive net PnL.
- Keep positive but inconsistent family feedback as a penalty, so mutated sleeves can still be explored.
- Add a regression test proving nonpositive family feedback prevents replay selection and increments feedback-block diagnostics.
- Raise the whitepaper-autoresearch WorkflowTemplate defaults to the failed run's evidence-backed next-epoch breadth: 96 max candidates, topK 24, 16 exploration slots, portfolio min 3, 48 total frontier candidates, and 6 replay shard workers.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py -q -k 'family_feedback or feedback_evidence or candidate_selection_blocks'`
- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py -q`
- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py --cov=scripts.run_whitepaper_autoresearch_profit_target --cov-report=xml -q && uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --base-ref origin/main`
- `uv run --frozen ruff format --check scripts/run_whitepaper_autoresearch_profit_target.py tests/test_run_whitepaper_autoresearch_profit_target.py && uv run --frozen ruff check scripts/run_whitepaper_autoresearch_profit_target.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `bun install --frozen-lockfile`
- `bun test packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts`
- `bunx oxfmt --check packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
