### PR TITLE
fix(torghut): hydrate verify carry in revenue repair

### DIFF
--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -104,6 +104,7 @@ from .trading.hypotheses import (
     JangarDependencyQuorumStatus,
     compile_hypothesis_runtime_statuses,
     hypothesis_registry_requires_dependency_capability,
+    load_jangar_dependency_quorum,
     load_hypothesis_registry,
     resolve_hypothesis_dependency_quorum,
     summarize_hypothesis_runtime_statuses,
@@ -1569,6 +1570,16 @@ def readyz() -> JSONResponse:
     )
 
 
+def _load_jangar_verify_trust_foreclosure_board() -> dict[str, object] | None:
+    """Fetch cached Jangar verify-trust carry for revenue-repair reentry only."""
+
+    dependency_quorum = load_jangar_dependency_quorum()
+    board = dependency_quorum.as_payload().get("verify_trust_foreclosure_board")
+    if not isinstance(board, Mapping):
+        return None
+    return dict(cast(Mapping[str, object], board))
+
+
 @app.get("/trading/revenue-repair")
 def trading_revenue_repair() -> dict[str, object]:
     """Return business-state and repair-priority evidence for revenue readiness."""
@@ -1578,6 +1589,12 @@ def trading_revenue_repair() -> dict[str, object]:
         allow_stale_dependency_cache=True,
     )
     status_payload = trading_status()
+    verify_trust_foreclosure_board = _load_jangar_verify_trust_foreclosure_board()
+    if verify_trust_foreclosure_board is not None:
+        status_payload = {
+            **status_payload,
+            "verify_trust_foreclosure_board": verify_trust_foreclosure_board,
+        }
     return cast(
         dict[str, object],
         jsonable_encoder(

--- a/services/torghut/app/trading/hypotheses.py
+++ b/services/torghut/app/trading/hypotheses.py
@@ -303,6 +303,9 @@ class JangarDependencyQuorumStatus:
     controller_ingestion_settlement: dict[str, object] = field(
         default_factory=_empty_payload_dict
     )
+    verify_trust_foreclosure_board: dict[str, object] = field(
+        default_factory=_empty_payload_dict
+    )
     generated_at: str | None = None
 
     def as_payload(self) -> dict[str, object]:
@@ -320,6 +323,10 @@ class JangarDependencyQuorumStatus:
         if self.controller_ingestion_settlement:
             payload["controller_ingestion_settlement"] = dict(
                 self.controller_ingestion_settlement
+            )
+        if self.verify_trust_foreclosure_board:
+            payload["verify_trust_foreclosure_board"] = dict(
+                self.verify_trust_foreclosure_board
             )
         if self.generated_at:
             payload["generated_at"] = self.generated_at
@@ -373,6 +380,18 @@ def _extract_controller_ingestion_settlement(
         or payload.get("controllerIngestionSettlement")
         or quorum.get("controller_ingestion_settlement")
         or quorum.get("controllerIngestionSettlement")
+    )
+
+
+def _extract_verify_trust_foreclosure_board(
+    payload: Mapping[str, Any],
+    quorum: Mapping[str, Any],
+) -> dict[str, object]:
+    return _as_payload_dict(
+        payload.get("verify_trust_foreclosure_board")
+        or payload.get("verifyTrustForeclosureBoard")
+        or quorum.get("verify_trust_foreclosure_board")
+        or quorum.get("verifyTrustForeclosureBoard")
     )
 
 
@@ -631,12 +650,20 @@ def _fallback_quorum_from_legacy_status(
                 decision="block",
                 reasons=["workflows_data_unknown"],
                 message="Torghut workflow reliability is unavailable.",
+                verify_trust_foreclosure_board=_extract_verify_trust_foreclosure_board(
+                    payload,
+                    {},
+                ),
             )
         if backoff_jobs > 0 or confidence == "degraded":
             return JangarDependencyQuorumStatus(
                 decision="delay",
                 reasons=["workflows_degraded"],
                 message="Torghut workflow reliability is degraded.",
+                verify_trust_foreclosure_board=_extract_verify_trust_foreclosure_board(
+                    payload,
+                    {},
+                ),
             )
     namespaces = payload.get("namespaces")
     if isinstance(namespaces, Sequence) and not isinstance(
@@ -651,11 +678,19 @@ def _fallback_quorum_from_legacy_status(
                     decision="delay",
                     reasons=["jangar_namespace_degraded"],
                     message="Torghut namespace health is degraded.",
+                    verify_trust_foreclosure_board=_extract_verify_trust_foreclosure_board(
+                        payload,
+                        {},
+                    ),
                 )
     return JangarDependencyQuorumStatus(
         decision="unknown",
         reasons=["jangar_dependency_quorum_missing"],
         message="Torghut control-plane status did not include dependency_quorum.",
+        verify_trust_foreclosure_board=_extract_verify_trust_foreclosure_board(
+            payload,
+            {},
+        ),
     )
 
 
@@ -726,6 +761,10 @@ def load_jangar_dependency_quorum() -> JangarDependencyQuorumStatus:
                 stage_trust=_extract_stage_trust(payload, quorum),
                 stage_renewal_bonds=_extract_stage_renewal_bonds(payload, quorum),
                 controller_ingestion_settlement=_extract_controller_ingestion_settlement(
+                    payload,
+                    quorum,
+                ),
+                verify_trust_foreclosure_board=_extract_verify_trust_foreclosure_board(
                     payload,
                     quorum,
                 ),

--- a/services/torghut/tests/test_hypotheses.py
+++ b/services/torghut/tests/test_hypotheses.py
@@ -941,6 +941,51 @@ class TestHypothesisReadiness(TestCase):
         self.assertEqual(status.controller_ingestion_settlement["decision"], "current")
         self.assertEqual(status.as_payload()["generated_at"], "2026-05-07T12:00:00Z")
 
+    def test_load_jangar_dependency_quorum_preserves_verify_foreclosure_board(
+        self,
+    ) -> None:
+        settings.trading_jangar_control_plane_status_url = (
+            "https://jangar.example/status"
+        )
+        settings.trading_jangar_control_plane_cache_ttl_seconds = 0
+        settings.trading_jangar_control_plane_timeout_seconds = 1.0
+        board = {
+            "schema_version": "jangar.verify-trust-foreclosure-board.v1",
+            "board_id": "verify-trust-foreclosure-board:agents:test",
+            "fresh_until": "2026-05-14T16:30:00Z",
+            "execution_trust_status": "degraded",
+            "source_rollout_truth_state": "converged",
+            "foreclosure_tickets": [
+                {
+                    "ticket_id": "verify-trust-foreclosure-ticket:test",
+                    "state": "open",
+                    "required_output_receipt": (
+                        "jangar.verify-trust-foreclosure-ticket.v1"
+                    ),
+                }
+            ],
+        }
+        with patch(
+            "app.trading.hypotheses.urlopen",
+            return_value=_FakeHttpResponse(
+                {
+                    "generated_at": "2026-05-14T16:10:00Z",
+                    "dependency_quorum": {
+                        "decision": "allow",
+                        "reasons": [],
+                        "message": "ok",
+                    },
+                    "verify_trust_foreclosure_board": board,
+                }
+            ),
+        ):
+            status = load_jangar_dependency_quorum()
+
+        self.assertEqual(status.decision, "allow")
+        self.assertEqual(status.message, "ok")
+        payload = status.as_payload()
+        self.assertEqual(payload["verify_trust_foreclosure_board"], board)
+
     def test_load_jangar_dependency_quorum_falls_back_to_legacy_status_when_needed(
         self,
     ) -> None:

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -1022,6 +1022,62 @@ class TestTradingApi(TestCase):
         self.assertIn("tca", call_order)
         jangar_status_fetch.assert_not_called()
 
+    def test_revenue_repair_hydrates_jangar_verify_foreclosure_board(self) -> None:
+        board = {
+            "schema_version": "jangar.verify-trust-foreclosure-board.v1",
+            "board_id": "verify-trust-foreclosure-board:agents:test",
+            "fresh_until": "2026-05-14T16:30:00Z",
+            "execution_trust_status": "degraded",
+            "source_rollout_truth_state": "converged",
+            "foreclosure_tickets": [
+                {
+                    "ticket_id": "verify-trust-foreclosure-ticket:test",
+                    "state": "open",
+                    "required_output_receipt": (
+                        "jangar.verify-trust-foreclosure-ticket.v1"
+                    ),
+                }
+            ],
+        }
+
+        def _build_digest(
+            *,
+            readyz_payload: dict[str, object],
+            status_payload: dict[str, object],
+        ) -> dict[str, object]:
+            self.assertEqual(readyz_payload["status"], "degraded")
+            return {
+                "schema_version": "torghut.revenue-repair-digest.v1",
+                "verify_trust_foreclosure_board": status_payload.get(
+                    "verify_trust_foreclosure_board"
+                ),
+            }
+
+        with (
+            patch(
+                "app.main._evaluate_trading_health_payload",
+                return_value=({"status": "degraded"}, 503),
+            ),
+            patch(
+                "app.main.trading_status",
+                return_value={
+                    "mode": "live",
+                    "pipeline_mode": "simple",
+                    "build": {"commit": "source-sha"},
+                },
+            ),
+            patch(
+                "app.main._load_jangar_verify_trust_foreclosure_board",
+                return_value=board,
+            ),
+            patch("app.main.build_revenue_repair_digest", side_effect=_build_digest),
+        ):
+            response = self.client.get("/trading/revenue-repair")
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["verify_trust_foreclosure_board"], board)
+
     def test_trading_consumer_evidence_avoids_recursive_jangar_status_fetch(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Preserved Jangar `verify_trust_foreclosure_board` in Torghut's dependency-quorum adapter so the current verify-trust board is not dropped before repair evidence generation.
- Hydrated the cached Jangar verify-trust foreclosure board only inside `/trading/revenue-repair`, then passed it into the no-delta repair reentry auction digest.
- Kept `/trading/status` fetch-free for the self-governed hypothesis registry and kept consumer evidence protected from recursive Jangar status fetches.
- Capital safety is unchanged: live submission stays disabled in `repair_only`, no-delta tickets remain `max_notional=0`, and unavailable Jangar carry still fails closed.

## Related Issues

None. Runtime requirement source is live `/trading/revenue-repair`, where the top repair item is `repair_alpha_readiness` for value gate `routeable_candidate_count`.

## Testing

- PASS: `/tmp/codex-uv-venv/bin/uv sync --frozen --extra dev`
- PASS: `/tmp/codex-uv-venv/bin/uv run --frozen ruff check app/main.py app/trading/hypotheses.py tests/test_hypotheses.py tests/test_trading_api.py`
- PASS: `/tmp/codex-uv-venv/bin/uv run --frozen ruff format --check app/main.py app/trading/hypotheses.py tests/test_hypotheses.py tests/test_trading_api.py`
- PASS: `/tmp/codex-uv-venv/bin/uv run --frozen pytest tests/test_hypotheses.py tests/test_no_delta_repair_reentry_auction.py tests/test_build_revenue_repair_digest.py tests/test_trading_api.py`
- PASS: `/tmp/codex-uv-venv/bin/uv run --frozen pyright --project pyrightconfig.json`
- PASS: `/tmp/codex-uv-venv/bin/uv run --frozen pyright --project pyrightconfig.alpha.json`
- PASS: `/tmp/codex-uv-venv/bin/uv run --frozen pyright --project pyrightconfig.scripts.json`
- PASS: `git diff --check`

## Screenshots (if applicable)

N/A - backend runtime evidence route change.

## Breaking Changes

None.

## Release Note

Design provenance: `docs/torghut/design-system/v6/206-torghut-no-delta-repair-reentry-auction-and-verification-carry-2026-05-14.md` and `docs/agents/designs/201-jangar-verify-trust-foreclosure-and-alpha-repair-reentry-2026-05-14.md`.

Before business evidence from `http://torghut.torghut.svc.cluster.local/trading/revenue-repair`: `business_state=repair_only`, `revenue_ready=false`, top repair `repair_alpha_readiness`, reason `alpha_readiness_not_promotion_eligible`, value gate `routeable_candidate_count`, `max_notional=0`, and Jangar carry `unavailable` because `jangar_verify_foreclosure_ticket_current` was not hydrated into the auction input.

Jangar control-plane evidence at the same time exposed `verify_trust_foreclosure_board` with schema `jangar.verify-trust-foreclosure-board.v1`, `source_rollout_truth_state=converged`, `execution_trust_status=degraded`, and open foreclosure tickets. This PR connects that existing board to `/trading/revenue-repair` without enabling live submission.

After URL evidence is unchanged until this PR is merged and deployed because live Torghut is still serving the previous image. The smallest remaining blocker to revenue impact is rollout of this PR; after deploy, the repair digest can price the existing zero-notional `jangar_verify_carry` ticket instead of reporting the carry as unavailable.

Risk: `/trading/revenue-repair` now performs the cached Jangar dependency-quorum fetch. If Jangar is unavailable or malformed, Torghut keeps the existing fail-closed unavailable-carry path and route capital remains zero notional.

Rollback: revert this PR. Torghut returns to the previous revenue-repair evidence path, no-delta verify carry remains unavailable, and capital safety stays unchanged.

Owner-facing status: local Torghut validation and GitHub CI are green. PR #6649 is open, non-draft, and mergeable with clean merge state.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
