### PR TITLE
docs(torghut): define verification carry bridge

### DIFF
--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -19,6 +19,8 @@ clear entrypoints, clear “source of truth”, and a complete catalog of relate
 - Autonomous Jangar/Torghut production system design: `designs/autonomous-jangar-torghut-production-system.md`
 - Swarm agentic mission architecture notes: `designs/swarm-agentic-mission-architecture-2026-05-08.md`
 - Current Jangar/Torghut architecture contracts:
+  - `../torghut/design-system/v6/208-torghut-jangar-verification-carry-bridge-and-no-delta-reentry-market-2026-05-14.md`
+  - `designs/202-jangar-verification-carry-export-and-repair-slot-reconciliation-2026-05-14.md`
   - `../torghut/design-system/v6/207-torghut-quant-plan-closeout-and-alpha-repair-reentry-handoff-2026-05-14.md`
   - `designs/201-jangar-verify-trust-foreclosure-and-alpha-repair-reentry-2026-05-14.md`
   - `../torghut/design-system/v6/206-torghut-no-delta-repair-reentry-auction-and-verification-carry-2026-05-14.md`

--- a/docs/agents/designs/202-jangar-verification-carry-export-and-repair-slot-reconciliation-2026-05-14.md
+++ b/docs/agents/designs/202-jangar-verification-carry-export-and-repair-slot-reconciliation-2026-05-14.md
@@ -1,0 +1,376 @@
+# 202. Jangar Verification Carry Export And Repair Slot Reconciliation (2026-05-14)
+
+Status: Accepted for engineer and deployer handoff
+Date: 2026-05-14
+Owner: Gideon Park, Torghut Traders Architecture
+Scope: Jangar verify-trust foreclosure export, Torghut no-delta auction carry, repair-slot reconciliation, rollout,
+rollback, validation, and zero-notional capital safety.
+
+Companion Torghut contract:
+
+- `docs/torghut/design-system/v6/208-torghut-jangar-verification-carry-bridge-and-no-delta-reentry-market-2026-05-14.md`
+
+Extends:
+
+- `201-jangar-verify-trust-foreclosure-and-alpha-repair-reentry-2026-05-14.md`
+- `200-jangar-revenue-repair-settlement-conveyor-and-stage-health-custody-2026-05-14.md`
+- `194-jangar-receipt-settled-repair-slots-and-stage-custody-thaw-2026-05-14.md`
+- `docs/torghut/design-system/v6/206-torghut-no-delta-repair-reentry-auction-and-verification-carry-2026-05-14.md`
+- `docs/torghut/design-system/v6/199-torghut-executable-alpha-settlement-slots-and-no-delta-repair-custody-2026-05-14.md`
+
+## Decision
+
+I am selecting a **compact verification-carry export plus repair-slot reconciliation packet** for Jangar.
+
+Jangar already has the facts that Torghut needs. On 2026-05-14 around 16:11Z, the control-plane status route reported
+`execution_trust=degraded`, source rollout status `block`, a verify-trust foreclosure board in `observe` mode, and
+open tickets for execution trust, stage trust, plan trust, verify trust, source rollout split, controller witness,
+route stability, Torghut repair-only state, and revenue-repair settlement custody. It also denied the
+`torghut_no_delta_active` ticket, which is correct because Torghut's no-delta budget was already consumed.
+
+The problem is transport and reconciliation, not vocabulary. Torghut's live `/trading/revenue-repair` surface showed
+`reentry_decision=deny`, `selected_ticket=null`, and reason `jangar_verification_carry_unavailable`. Jangar's
+`repair_slot_escrow` also blocked because the selected receipt source revenue-repair ref mismatched and a material
+reentry receipt was missing for the selected executable alpha. Those are useful reason codes, but today they are
+visible only after a human compares Jangar status with Torghut revenue repair.
+
+The selected design adds `jangar.verify-trust-foreclosure-carry.v1`, a compact Jangar packet exported for Torghut's
+auction. It also refines repair-slot reconciliation so source-ref mismatch and missing material-reentry receipt become
+machine-readable release-condition inputs instead of generic slot blockers.
+
+The tradeoff is that Jangar has to curate a smaller contract instead of exposing its whole board. I accept that. A full
+board export would be faster, but it would make Torghut depend on Jangar's internal control-plane schema and would
+turn every future Jangar field change into a trading-surface compatibility risk.
+
+## Governing Runtime Requirements
+
+This contract implements the active swarm validation contract:
+
+- every run must cite the governing design or runtime requirement before changing code;
+- implement stages must produce production PRs that improve readiness, profit evidence, data freshness, execution
+  quality, or capital safety;
+- verify stages must merge only green PRs and prove image promotion, Argo sync, live service health, and trading or
+  evidence status after rollout;
+- final handoff must name the revenue metric improved or the smallest blocker preventing revenue impact.
+
+Jangar value-gate mapping:
+
+- `failed_agentrun_rate`: duplicate no-delta and stale carry packets deny new material launch slots.
+- `pr_to_rollout_latency`: deployers get one carry id and one repair-slot reconciliation packet instead of manually
+  gathering source, image, board, and Torghut evidence.
+- `ready_status_truth`: `/ready=ok` remains serving truth; the carry packet is material evidence, not serving health.
+- `manual_intervention_count`: source-ref mismatch and missing material-reentry receipts become explicit next actions.
+- `handoff_evidence_quality`: engineer and deployer handoffs cite carry id, selected ticket, active release key,
+  validation command, and rollback target.
+
+Torghut value-gate mapping:
+
+- `routeable_candidate_count`: carry export is only relevant to the alpha-readiness queue item and its prerequisites.
+- `zero_notional_or_stale_evidence_rate`: stale carry is denial evidence.
+- `fill_tca_or_slippage_quality`: execution proof may be selected only if the carry names it as the release
+  prerequisite.
+- `post_cost_daily_net_pnl`: carry cannot promote capital without current post-cost evidence.
+- `capital_gate_safety`: every Jangar carry packet used by Torghut must carry `max_notional=0`.
+
+## Current Evidence
+
+All evidence below was collected read-only on 2026-05-14. I did not mutate Kubernetes resources, database records,
+AgentRuns, GitOps resources, broker state, market data, or trading flags.
+
+### Cluster And Control Plane
+
+- Service-account identity was `system:serviceaccount:agents:agents-sa`.
+- Jangar deployment was available with `jangar=1/1`; Agents deployments were available with `agents=1/1` and
+  `agents-controllers=2/2`.
+- Argo reported `jangar=Synced/Healthy`; `agents` was `OutOfSync/Healthy` during rollout at revision
+  `2de0a9e7592b1aaedc8649035b83eb0a7e7e7720`.
+- Recent Jangar events showed a fresh rollout to `jangar-798f789cdd`, transient readiness probe refusal while the pod
+  started, and then the pod running with both containers ready.
+- Recent Agents events showed scheduled discover and verify jobs completing, current implement/verify jobs running,
+  and one readiness timeout on the `agents` pod.
+
+### Jangar Runtime Evidence
+
+- `GET /ready` returned `status=ok` and `business_state=repair_only`.
+- `GET /api/agents/control-plane/status?namespace=agents` generated at `2026-05-14T16:11:25.232Z`.
+- `execution_trust.status=degraded`.
+- Source rollout status was `block`.
+- The verify-trust foreclosure board was in `observe` mode.
+- The board reported `execution_trust_status=degraded` and source rollout truth state `converged`.
+- Debt classes included `execution_trust_degraded`, `stage_trust_degraded`, `plan_trust_degraded`,
+  `verify_trust_degraded`, `source_rollout_truth_split`, `controller_witness_stale`, `route_stability_hold`,
+  `torghut_business_repair_only`, `torghut_no_delta_active`, and `revenue_repair_settlement_custody_deny`.
+- Foreclosure tickets were open for all of those debt classes except `torghut_no_delta_active`, which was denied.
+- Material gate digest allowed `serve_readonly` and `torghut_observe`, denied `dispatch_repair`, held normal dispatch,
+  deploy widening, merge readiness, and paper canary, and blocked live capital actions.
+- `dispatch_repair` was denied by `alpha_closure_no_delta_budget_consumed` and
+  `alpha_closure_no_delta_debt_active`.
+- Repair-slot escrow had `status=block`, no selected slot, and reason codes
+  `selected_receipt_source_revenue_repair_ref_mismatch` and
+  `material_reentry_receipt_missing_for_selected_executable_alpha`.
+
+### Torghut Business Evidence
+
+- `GET /trading/health` returned HTTP `503` with `status=degraded` because live submission is disabled and the proof
+  floor is repair-only.
+- `GET /trading/revenue-repair` returned `business_state=repair_only`, `revenue_ready=false`, top queue item
+  `repair_alpha_readiness`, and value gate `routeable_candidate_count`.
+- Repair-bid settlement had `routeable_candidate_count=0`, `41` raw repair bids, and `3` dispatchable lots.
+- Alpha closure settlement market was `pending_no_delta`.
+- No-delta budget was `consumed` with zero remaining attempts.
+- Torghut no-delta reentry auction denied reentry with reason `jangar_verification_carry_unavailable`.
+- `GET /db-check` returned `ok=true`, `schema_current=true`, `account_scope_ready=true`, and
+  `schema_graph_lineage_ready=true`.
+
+### Source And Test Surface
+
+- Jangar's high-risk shared type surface is `services/jangar/src/data/agents-control-plane.ts`.
+- The verify board reducer lives in `services/jangar/src/server/control-plane-verify-trust-foreclosure.ts`.
+- The repair-slot reducer lives in `services/jangar/src/server/control-plane-repair-slot-escrow.ts`.
+- `/ready` and `/api/agents/control-plane/status` already emit the verify board and repair-slot escrow, but not a
+  compact carry packet dedicated to Torghut.
+- Existing tests cover verify-trust foreclosure, material gate digest, Torghut consumer evidence, repair slot escrow,
+  and ready route projection. Missing coverage is the compact carry export and the repair-slot reconciliation mapping
+  to Torghut auction release conditions.
+
+## Problem
+
+Jangar can see the right debt, but it does not yet publish the right contract.
+
+The concrete failure modes are:
+
+1. Torghut reports `jangar_verification_carry_unavailable` even while Jangar has an active verify-trust foreclosure
+   board.
+2. Jangar exposes a large board with many tickets, but Torghut only needs one selected carry witness.
+3. Repair-slot escrow blocks on source-ref mismatch and missing material reentry without turning those blockers into a
+   stable Torghut release-condition input.
+4. `/ready=ok` can be misread as material readiness when the material gate correctly denies `dispatch_repair`.
+5. A full-board export would couple Torghut to Jangar internals and make rollout compatibility brittle.
+6. A self-dispatching Jangar slot would bypass `/trading/revenue-repair`, the business evidence authority.
+
+The next design has to export a narrow, stable Jangar witness that Torghut can safely use.
+
+## Alternatives Considered
+
+### Option A: Export The Full Verify-Trust Foreclosure Board
+
+Jangar would document the whole existing board as Torghut's input.
+
+Advantages:
+
+- Minimal implementation effort.
+- No additional reducer.
+- Torghut can inspect every ticket and debt class.
+
+Disadvantages:
+
+- The board is an operator/debug object, not a trading contract.
+- It would carry more data than Torghut needs.
+- It would make Torghut sensitive to Jangar schema churn.
+- It would not reconcile repair-slot source-ref mismatches.
+
+Decision: reject.
+
+### Option B: Let Repair Slot Escrow Drive Launches Without Torghut Carry
+
+Jangar would keep the auction local and use repair-slot escrow to decide whether a zero-notional dispatch repair can
+launch.
+
+Advantages:
+
+- Keeps launch custody inside Jangar.
+- Avoids a new Torghut importer.
+- Can reuse current repair-slot escrow logic.
+
+Disadvantages:
+
+- Bypasses Torghut's top revenue-repair queue.
+- Can spend a repair slot that Torghut still denies as duplicate no-delta.
+- Does not reduce the `jangar_verification_carry_unavailable` blocker.
+- Splits business metric ownership between two surfaces.
+
+Decision: reject.
+
+### Option C: Compact Verification Carry Export With Repair-Slot Reconciliation
+
+Jangar builds a small export object from the verify board, material gate digest, repair-slot escrow, and Torghut
+consumer evidence. Torghut consumes that object as `jangar_verification_carry`.
+
+Advantages:
+
+- Clears the exact missing witness Torghut names today.
+- Keeps the full board available for operators without making it the trading API.
+- Converts source-ref mismatch and missing material-reentry receipts into release-condition reason codes.
+- Preserves serving readiness as separate from material readiness.
+- Keeps live and paper capital blocked.
+
+Disadvantages:
+
+- Adds one Jangar reducer and tests.
+- Requires careful freshness handling.
+- May still deny reentry when evidence is unchanged, which can look like no progress unless the handoff names it.
+
+Decision: select Option C.
+
+## Architecture
+
+Jangar emits `jangar.verify-trust-foreclosure-carry.v1`.
+
+Required shape:
+
+```text
+schema_version: jangar.verify-trust-foreclosure-carry.v1
+carry_id
+generated_at
+fresh_until
+mode
+status
+namespace
+board_ref:
+  board_id
+  execution_trust_status
+  source_rollout_truth_state
+  active_no_delta_release_key
+selected_ticket:
+  ticket_id
+  debt_class
+  state
+  expected_delta
+  required_output_receipt
+  validation_commands
+  dedupe_key
+  ttl_seconds
+torghut_reentry_context:
+  consumer_evidence_ref
+  alpha_repair_closure_board_ref
+  alpha_closure_settlement_market_ref
+  selected_hypothesis_id
+  selected_value_gate
+  routeable_candidate_count
+  max_notional
+repair_slot_reconciliation:
+  status
+  selected_slot_id
+  source_revenue_repair_ref_state
+  material_reentry_receipt_state
+  stage_credit_state
+  release_condition
+decision
+reason_codes
+rollback_target
+```
+
+Selection policy:
+
+1. Prefer a ticket whose `debt_class` directly blocks the current Torghut alpha no-delta release:
+   `revenue_repair_settlement_custody_deny`, `torghut_business_repair_only`, `route_stability_hold`, or
+   `verify_trust_degraded`.
+2. Do not select `torghut_no_delta_active` as an opening ticket when Torghut already consumed the no-delta budget.
+   Preserve it as denial evidence.
+3. If repair-slot escrow reports `selected_receipt_source_revenue_repair_ref_mismatch`, set release condition
+   `source_revenue_repair_ref_changed`.
+4. If material reentry receipt is missing, set release condition `required_receipt_set_changed`.
+5. If stage credit is stale or held, set release condition `jangar_verify_foreclosure_ticket_current` and require the
+   Jangar ticket receipt.
+6. If no selected ticket is safe, emit `status=blocked` with no selected ticket and keep `max_notional=0`.
+
+Freshness policy:
+
+- `fresh_until` must be the minimum valid freshness across the verify board, Torghut consumer evidence, material gate
+  digest, and repair-slot escrow.
+- If no upstream freshness is valid, default to 60 seconds.
+- Expired carry is still emitted for observability, but Torghut must treat it as stale denial evidence.
+
+## Implementation Scope
+
+Jangar engineer responsibilities:
+
+1. Add a pure reducer that builds `verification_carry` from verify-trust foreclosure, material gate digest,
+   repair-slot escrow, and Torghut consumer evidence.
+2. Add TypeScript types for the compact carry packet.
+3. Project the packet on `/ready` and `/api/agents/control-plane/status?namespace=agents`.
+4. Optionally expose a dedicated Torghut route for the same packet after the ready/status projections are stable.
+5. Add tests for current carry, stale carry, unavailable board, denied no-delta ticket, source-ref mismatch,
+   material-reentry missing, and max-notional zero enforcement.
+6. Keep the full verify board and repair-slot escrow unchanged for operator debugging.
+
+Torghut responsibilities are defined in the companion contract.
+
+## Validation Gates
+
+Local Jangar validation:
+
+- `env -u CODEX_STAGE bun run test services/jangar/src/server/__tests__/control-plane-verify-trust-foreclosure.test.ts`
+- `env -u CODEX_STAGE bun run test services/jangar/src/server/__tests__/control-plane-repair-slot-escrow.test.ts`
+- `env -u CODEX_STAGE bun run test services/jangar/src/routes/ready.test.ts`
+- `bunx tsc --noEmit --project services/jangar/tsconfig.paths.json`
+- `bun run --cwd services/jangar lint:oxlint`
+- `bun run --cwd services/jangar lint:oxlint:type`
+
+Post-rollout validation:
+
+- `kubectl get applications.argoproj.io -n argocd agents jangar torghut`
+- `kubectl get deploy -n jangar -o wide`
+- `kubectl get deploy -n agents -o wide`
+- `curl -fsS http://jangar.jangar.svc.cluster.local/ready | jq '.verification_carry'`
+- `curl -fsS 'http://jangar.jangar.svc.cluster.local/api/agents/control-plane/status?namespace=agents' | jq '.verification_carry'`
+- `curl -fsS http://torghut.torghut.svc.cluster.local/trading/revenue-repair | jq '.no_delta_repair_reentry_auction.jangar_verification_carry'`
+
+Acceptance gates:
+
+- Jangar emits `schema_version=jangar.verify-trust-foreclosure-carry.v1`.
+- Carry includes one selected ticket or an explicit blocked reason.
+- Carry includes `active_no_delta_release_key` when Torghut no-delta is active.
+- Carry includes source-ref and material-reentry reconciliation states.
+- Carry never opens nonzero notional.
+- Torghut stops reporting `jangar_verification_carry_unavailable` once it consumes a fresh packet.
+
+## Rollout
+
+1. Ship carry export in observe mode.
+2. Confirm `/ready` and control-plane status include the packet without changing existing verify-board fields.
+3. Ship Torghut ingestion after the Jangar packet is live.
+4. Keep material gate and repair-slot decisions conservative until Torghut proves the packet changes the auction
+   reason set.
+5. Promote only through CI and GitOps.
+6. Record carry id, selected ticket, active no-delta release key, Torghut auction id, routeable candidate count, and
+   max notional in the deployer handoff.
+
+## Rollback
+
+- Remove the dedicated carry route if it causes serving risk.
+- Keep `/ready` serving truth independent from carry export.
+- Keep verify-trust foreclosure board and repair-slot escrow as operator/debug surfaces.
+- Let Torghut fall back to `jangar_verification_carry_unavailable`.
+- Keep `dispatch_repair` denied, normal dispatch held, paper/live blocked, and Torghut `max_notional=0`.
+
+## Risks
+
+- **Schema sprawl:** the carry packet must stay compact. Do not export the full board by another name.
+- **False release:** source-ref mismatch and material-reentry-missing are release-condition hints, not permission to
+  launch unless Torghut's auction selects the ticket.
+- **Freshness confusion:** expired carry must be visible but denied.
+- **Double authority:** Jangar names the carry; Torghut decides whether it changes the revenue-repair auction.
+- **No immediate PnL:** the first successful rollout may only replace an unavailable-carry denial with a current-carry
+  denial. That still improves evidence quality and reduces duplicate no-delta work.
+
+## Handoff
+
+Engineer:
+
+- Build the compact carry reducer and projection first.
+- Keep it pure and deterministic so tests can assert selected ticket, reason codes, release condition, and freshness.
+- Do not widen material action or capital behavior in the same change.
+
+Deployer:
+
+- Validate Jangar carry export before enabling Torghut ingestion.
+- Treat `status=blocked` with clear reason codes as a valid rollout outcome if Torghut no-delta remains active.
+- Keep proof of image digest, Argo sync, workload readiness, Jangar carry id, Torghut auction decision, and
+  `max_notional=0`.
+
+Smallest blocker preventing revenue impact:
+
+- Jangar has verify-trust foreclosure evidence, but it is not exported as a compact carry packet that Torghut can
+  consume; Torghut therefore keeps `routeable_candidate_count=0` and denies no-delta reentry with
+  `jangar_verification_carry_unavailable`.

--- a/docs/torghut/README.md
+++ b/docs/torghut/README.md
@@ -4,6 +4,10 @@
 
 Start here:
 
+- `docs/torghut/design-system/v6/208-torghut-jangar-verification-carry-bridge-and-no-delta-reentry-market-2026-05-14.md`
+  (current Jangar verification-carry bridge and no-delta reentry market contract)
+- `docs/agents/designs/202-jangar-verification-carry-export-and-repair-slot-reconciliation-2026-05-14.md`
+  (current Jangar verification carry export and repair-slot reconciliation contract)
 - `docs/torghut/design-system/v6/207-torghut-quant-plan-closeout-and-alpha-repair-reentry-handoff-2026-05-14.md`
   (current quant plan closeout and alpha-repair reentry handoff)
 - `docs/torghut/design-system/v6/206-torghut-no-delta-repair-reentry-auction-and-verification-carry-2026-05-14.md`

--- a/docs/torghut/design-system/README.md
+++ b/docs/torghut/design-system/README.md
@@ -35,6 +35,8 @@ The v1 documents are written to stay consistent with:
 If you are trying to decide which docs are current contract truth versus historical milestone records, start with:
 
 - `docs/torghut/design-system/current-source-of-truth-and-priority-guide-2026-03-09.md`
+- `docs/torghut/design-system/v6/208-torghut-jangar-verification-carry-bridge-and-no-delta-reentry-market-2026-05-14.md`
+- `docs/agents/designs/202-jangar-verification-carry-export-and-repair-slot-reconciliation-2026-05-14.md`
 - `docs/torghut/design-system/v6/207-torghut-quant-plan-closeout-and-alpha-repair-reentry-handoff-2026-05-14.md`
 - `docs/torghut/design-system/v6/206-torghut-no-delta-repair-reentry-auction-and-verification-carry-2026-05-14.md`
 - `docs/agents/designs/201-jangar-verify-trust-foreclosure-and-alpha-repair-reentry-2026-05-14.md`

--- a/docs/torghut/design-system/v6/208-torghut-jangar-verification-carry-bridge-and-no-delta-reentry-market-2026-05-14.md
+++ b/docs/torghut/design-system/v6/208-torghut-jangar-verification-carry-bridge-and-no-delta-reentry-market-2026-05-14.md
@@ -1,0 +1,432 @@
+# 208. Torghut Jangar Verification Carry Bridge And No-Delta Reentry Market (2026-05-14)
+
+Status: Accepted for engineer and deployer handoff
+Date: 2026-05-14
+Owner: Gideon Park, Torghut Traders Architecture
+Scope: Torghut no-delta repair reentry, Jangar verification carry ingestion, routeable-candidate recovery, zero-notional
+capital safety, rollout, rollback, validation, and cross-stage handoff.
+
+Companion Jangar contract:
+
+- `docs/agents/designs/202-jangar-verification-carry-export-and-repair-slot-reconciliation-2026-05-14.md`
+
+Extends:
+
+- `206-torghut-no-delta-repair-reentry-auction-and-verification-carry-2026-05-14.md`
+- `207-torghut-quant-plan-closeout-and-alpha-repair-reentry-handoff-2026-05-14.md`
+- `docs/agents/designs/201-jangar-verify-trust-foreclosure-and-alpha-repair-reentry-2026-05-14.md`
+- `199-torghut-executable-alpha-settlement-slots-and-no-delta-repair-custody-2026-05-14.md`
+- `docs/agents/designs/194-jangar-receipt-settled-repair-slots-and-stage-custody-thaw-2026-05-14.md`
+
+## Decision
+
+I am selecting a **Jangar verification-carry bridge feeding Torghut's no-delta reentry market** as the next
+architecture increment.
+
+The live state has changed since the no-delta auction was designed. The auction now exists and is doing its safety
+job. On 2026-05-14 around 16:11Z, `GET /trading/revenue-repair` returned `business_state=repair_only`,
+`revenue_ready=false`, top queue item `repair_alpha_readiness`, value gate `routeable_candidate_count`, required
+output `torghut.executable-alpha-receipts.v1`, and `max_notional=0`. The alpha closure settlement market was
+`pending_no_delta`, the no-delta budget was `consumed`, `routeable_candidate_count` remained `0`, and the no-delta
+reentry auction returned `reentry_decision=deny` with `selected_ticket=null`.
+
+That denial is correct, but it exposes the new smallest blocker: Torghut reported
+`jangar_verification_carry_unavailable`. At the same time, Jangar already had useful evidence. Its control-plane status
+reported `execution_trust=degraded`, source rollout status `block`, open verify-trust foreclosure tickets, a denied
+`torghut_no_delta_active` ticket, and repair-slot escrow blocked by
+`selected_receipt_source_revenue_repair_ref_mismatch` plus
+`material_reentry_receipt_missing_for_selected_executable_alpha`. In plain terms, Jangar can name the failure debt,
+but Torghut cannot consume it as a stable release-condition witness.
+
+The selected design makes Jangar export a compact `jangar.verify-trust-foreclosure-carry.v1` packet and makes Torghut
+ingest that packet into `status_payload.jangar_verification_carry` before building
+`torghut.no-delta-repair-reentry-auction.v1`. The packet is not a permission slip to trade. It is a zero-notional
+proof-carry witness that lets the auction distinguish three cases:
+
+1. Jangar carry unavailable or stale: keep denying reentry.
+2. Jangar carry current but no release condition changed: keep denying duplicate no-delta repair.
+3. Jangar carry current and a named release condition changed: select exactly one zero-notional ticket bound to the
+   active alpha-readiness queue item or a named prerequisite to it.
+
+The tradeoff is extra cross-plane plumbing. Torghut will depend on a bounded Jangar evidence packet for one branch of
+its repair market. I accept that because the alternative is worse: repeating no-delta repairs or asking operators to
+manually reconcile a Jangar foreclosure board with a Torghut auction. The business metric is not raw repair activity.
+It is increased routeable post-cost profit evidence and live trading readiness without weakening capital safety.
+
+## Governing Runtime Requirements
+
+This contract implements the active swarm validation contract:
+
+- every run must cite the governing Torghut design or runtime requirement before changing code;
+- implement stages must produce production PRs that improve readiness, profit evidence, data freshness, execution
+  quality, or capital safety;
+- verify stages must merge only green PRs and prove image promotion, Argo sync, live service health, and trading or
+  evidence status after rollout;
+- final handoff must name the revenue metric improved or the smallest blocker preventing revenue impact.
+
+Value-gate mapping:
+
+- `routeable_candidate_count`: primary gate. The bridge only matters when the top queue remains
+  `repair_alpha_readiness`; selected tickets must target this gate or a named prerequisite that releases it.
+- `zero_notional_or_stale_evidence_rate`: stale or unavailable Jangar carry remains denial evidence.
+- `fill_tca_or_slippage_quality`: TCA work can win only when the carry and auction name it as a prerequisite to
+  alpha-readiness release.
+- `post_cost_daily_net_pnl`: no carry packet can promote paper or live capital without positive, current post-cost
+  evidence.
+- `capital_gate_safety`: every selected ticket carries `max_notional=0`, live submission remains disabled, and
+  `simple_submit_disabled` stays a correct degraded readiness reason.
+
+## Current Evidence
+
+All evidence below was collected read-only on 2026-05-14. I did not mutate Kubernetes resources, database records,
+trading flags, AgentRuns, broker state, market data, or GitOps resources.
+
+### Cluster And Rollout
+
+- Workspace identity was `system:serviceaccount:agents:agents-sa`.
+- Argo reported `jangar=Synced/Healthy`, `torghut-options=Synced/Healthy`, `agents=OutOfSync/Healthy`, and
+  `torghut=OutOfSync/Healthy`. The out-of-sync apps were in active rollout, not unavailable.
+- Torghut active serving deployment was `torghut-00397-deployment=1/1`, with sim
+  `torghut-sim-00494-deployment=1/1`.
+- Torghut active image digest was `sha256:f90bf4663eb0e7dabaaf30aeec222238beef81028c7ab4781217515a49a24af3`.
+- Jangar deployment was `1/1` on image `registry.ide-newton.ts.net/lab/jangar:77e207de` with digest
+  `sha256:0eaafd56bf7292502b142fb9ca0dff9f082a8c497539be62e7145f4411f4b41a`.
+- Agents deployments were available: `agents=1/1`, `agents-controllers=2/2`, and `agents-alloy=1/1`.
+- Recent Torghut events showed rollout replacement, database migration startup, transient options-catalog and
+  options-enricher readiness probe failures during rollout, one `torghut-ws-options` readiness 503, and a
+  `torghut-profit-summary-feedback` workflow failure with exit code `2`.
+- Recent Agents events showed discover and verify cron jobs completing, current implementation/verify jobs running,
+  and an `agents` readiness probe timeout. The failure tail is still a launch-custody risk.
+- The service account cannot create `pods/exec` in namespace `torghut`; privileged database inspection is not part of
+  the acceptance path.
+
+### Torghut Business Evidence
+
+- `GET /trading/health` returned HTTP `503` with `status=degraded`.
+- Healthy dependencies included Postgres, ClickHouse, Alpaca live broker status, static universe, readiness cache,
+  optional empirical jobs, DSPy runtime, and optional quant evidence.
+- The failing dependencies were `live_submission_gate=simple_submit_disabled` and
+  `profitability_proof_floor=repair_only`; both are correct capital-safety holds.
+- `GET /trading/revenue-repair` returned `business_state=repair_only`, `revenue_ready=false`, top queue item
+  `repair_alpha_readiness`, reason `alpha_readiness_not_promotion_eligible`, and value gate
+  `routeable_candidate_count`.
+- The top queue item required `torghut.executable-alpha-receipts.v1`, had `expected_unblock_value=2`, and carried
+  `max_notional=0` with capital rule `zero_notional_repair_only`.
+- Repair-bid settlement summarized `41` raw repair bids, `6` compacted lots, `5` selected lots, `3` dispatchable lots,
+  `3` held lots, and `routeable_candidate_count=0`.
+- Alpha closure settlement market status was `pending_no_delta`.
+- No-delta budget state was `consumed`, with `used_attempts=1`, `remaining_attempts=0`, and release conditions
+  `evidence_window_changes`, `blocker_set_changes`, `source_ref_changes`, and `required_receipt_changes`.
+- The no-delta reentry auction returned `reentry_decision=deny`, `selected_ticket=null`, and reason codes
+  `active_no_delta_release_key`, `no_release_condition_changed`, `zero_notional_reentry_ticket_not_selected`,
+  `jangar_verification_carry_unavailable`, and `duplicate_no_delta_reentry_denied`.
+
+### Jangar Evidence
+
+- `GET /ready` returned `status=ok`, while preserving `business_state=repair_only`.
+- `GET /api/agents/control-plane/status?namespace=agents` generated at `2026-05-14T16:11:25.232Z`.
+- Jangar execution trust was `degraded`.
+- Source rollout status was `block`, while the verify board's source rollout truth state was `converged`.
+- The verify-trust foreclosure board was in `observe` mode and carried debt classes
+  `execution_trust_degraded`, `stage_trust_degraded`, `plan_trust_degraded`, `verify_trust_degraded`,
+  `source_rollout_truth_split`, `controller_witness_stale`, `route_stability_hold`, `torghut_business_repair_only`,
+  `torghut_no_delta_active`, and `revenue_repair_settlement_custody_deny`.
+- Foreclosure tickets were open for execution trust, stage trust, plan trust, verify trust, source rollout split,
+  controller witness, route stability, Torghut repair-only state, and revenue-repair settlement custody. The
+  `torghut_no_delta_active` ticket was denied, which is the correct duplicate-repair posture.
+- Material gate digest allowed `serve_readonly` and `torghut_observe`, denied `dispatch_repair` because
+  `alpha_closure_no_delta_budget_consumed` and `alpha_closure_no_delta_debt_active`, held normal dispatch and paper
+  canary, and blocked live capital actions.
+- Repair-slot escrow was blocked with no selected slot because the selected receipt source revenue-repair ref did not
+  match and the material reentry receipt was missing for the selected executable alpha.
+
+### Database And Data
+
+- `GET /db-check` returned `ok=true`, `schema_current=true`, `account_scope_ready=true`,
+  `schema_graph_lineage_ready=true`, `schema_missing_heads=[]`, `schema_unexpected_heads=[]`, and
+  `schema_head_delta_count=0`.
+- The DB surface is therefore not the top blocker. Schema currentness is necessary but insufficient.
+- Data quality remains below capital grade because `routeable_candidate_count=0`, no-delta debt is active,
+  release conditions are unchanged, and Jangar verification carry is unavailable to Torghut.
+
+### Source And Test Surface
+
+- Torghut's high-risk integration file is `services/torghut/app/main.py`, which assembles readiness, trading status,
+  revenue repair, and consumer evidence.
+- `services/torghut/app/trading/revenue_repair.py` already passes
+  `status_payload.get("verify_trust_foreclosure_board") or status_payload.get("jangar_verification_carry")` into
+  `build_no_delta_repair_reentry_auction`.
+- `services/torghut/app/trading/no_delta_repair_reentry_auction.py` already degrades to
+  `jangar-verification-carry:unavailable` when that payload is absent.
+- The missing Torghut implementation surface is an evidence ingress that fetches or receives Jangar's compact carry,
+  normalizes it into the trading status payload, and keeps stale or failed fetches as explicit denial evidence.
+- Existing Torghut tests cover the no-delta auction, revenue-repair digest, consumer evidence, executable alpha
+  receipts, alpha evidence foundry, alpha repair closure, and repair-bid settlement. The missing tests are the
+  transport and freshness cases around imported Jangar carry.
+
+## Problem
+
+Torghut can now say "do not run the same alpha repair again." It cannot yet say "Jangar has a current foreclosure
+ticket that makes a different zero-notional repair worth trying."
+
+The concrete failure modes are:
+
+1. Jangar exposes a verify-trust foreclosure board, but Torghut sees `jangar_verification_carry_unavailable`.
+2. Torghut's no-delta auction has a release condition for `jangar_verify_foreclosure_ticket_current`, but no durable
+   cross-plane packet satisfies it.
+3. Jangar repair-slot escrow can block on source-ref and material-reentry mismatches without that mismatch becoming a
+   Torghut auction prerequisite.
+4. Operators can see `/ready=ok` and `/trading/health=503` at the same time, then manually stitch together whether
+   this is serving health, material readiness, or capital safety.
+5. A future implementation could solve this by polling a large Jangar status object on Torghut's hot path, creating a
+   new reliability dependency instead of a bounded witness.
+6. Direct database access is unavailable, so the bridge must rely on typed application witnesses and not on ad hoc SQL.
+
+The next architecture has to turn Jangar failure debt into a compact, fresh, zero-notional auction input.
+
+## Alternatives Considered
+
+### Option A: Have Torghut Poll Jangar Control-Plane Status Directly
+
+Torghut would call `/api/agents/control-plane/status?namespace=agents`, extract
+`verify_trust_foreclosure_board`, and pass the whole board into the no-delta auction.
+
+Advantages:
+
+- Fast to implement.
+- Reuses the board shape already emitted by Jangar.
+- Gives Torghut access to all current failure debt.
+
+Disadvantages:
+
+- Couples Torghut's revenue-repair hot path to a large control-plane status route.
+- Makes transient Jangar slowness look like Torghut evidence failure.
+- Expands the cross-plane contract every time Jangar adds fields.
+- Does not solve repair-slot source-ref reconciliation; it only moves the raw board.
+
+Decision: reject as the primary contract. It is acceptable as a temporary implementation source only if Torghut
+normalizes the response into the compact carry packet and caches it with a short TTL.
+
+### Option B: Let Jangar Self-Launch The Next Repair Slot
+
+Jangar would ignore Torghut's auction denial and allocate a repair slot from its own foreclosure board when it sees a
+current ticket.
+
+Advantages:
+
+- Avoids a Torghut importer.
+- Keeps launch custody in the control plane.
+- Could retire Jangar-specific trust debt faster.
+
+Disadvantages:
+
+- Splits business evidence from launch custody.
+- Risks launching work that Torghut still considers duplicate no-delta.
+- Weakens the rule that `/trading/revenue-repair` is the live business evidence surface.
+- Does not move `routeable_candidate_count` unless Torghut accepts the repair as a release-conditioned ticket.
+
+Decision: reject.
+
+### Option C: Compact Verification-Carry Bridge And Auction Ingress
+
+Jangar emits a compact carry packet with one selected debt ticket, active no-delta key, source refs, freshness, action
+class, validation command, and rollback target. Torghut imports only that packet into the no-delta auction.
+
+Advantages:
+
+- Directly clears the current `jangar_verification_carry_unavailable` blocker.
+- Keeps `/trading/revenue-repair` as the business evidence authority.
+- Avoids coupling Torghut to the full Jangar control-plane status schema.
+- Gives deployer and verifier stages a single object to cite.
+- Preserves zero-notional capital safety and duplicate no-delta denial.
+
+Disadvantages:
+
+- Adds one cross-plane transport and cache.
+- Requires strict freshness and source-ref checks.
+- Can keep denying useful repairs until Jangar exports a current packet.
+
+Decision: select Option C.
+
+## Architecture
+
+The bridge has two additive contracts.
+
+### Jangar Export
+
+Jangar emits `jangar.verify-trust-foreclosure-carry.v1` on `/ready` and
+`/api/agents/control-plane/status?namespace=agents`. A later implementation may expose a dedicated
+`/api/agents/control-plane/torghut/verification-carry` route, but the payload shape must stay the same.
+
+Required fields:
+
+```text
+schema_version: jangar.verify-trust-foreclosure-carry.v1
+carry_id
+board_id
+generated_at
+fresh_until
+mode
+status: current | stale | unavailable | blocked
+namespace
+selected_ticket:
+  ticket_id
+  debt_class
+  state
+  required_output_receipt
+  dedupe_key
+  validation_commands
+torghut_context:
+  consumer_evidence_ref
+  alpha_repair_closure_board_ref
+  active_no_delta_release_key
+  selected_value_gate
+  selected_hypothesis_id
+action_class
+decision
+reason_codes
+release_condition
+max_notional
+rollback_target
+```
+
+The packet is compact by design. It should not carry the full foreclosure ticket list, full material gate digest, full
+repair-slot escrow, or full AgentRun inventory.
+
+### Torghut Ingress
+
+Torghut imports the packet into trading status as `jangar_verification_carry`.
+
+Ingress rules:
+
+1. Fetch the carry from a configured URL such as `TRADING_JANGAR_VERIFY_CARRY_URL`.
+2. Enforce a short timeout and bounded stale cache. A failed fetch becomes `status=unavailable`, not an exception that
+   breaks `/trading/revenue-repair`.
+3. Reject packets with `fresh_until <= now` as `jangar_verification_carry_stale`.
+4. Require `max_notional=0` before the packet can open a zero-notional auction ticket.
+5. Require the packet's active no-delta key to match the Torghut active no-delta release key unless the packet states
+   a source-ref, blocker-set, evidence-window, or required-receipt release condition.
+6. Pass the normalized packet into `build_no_delta_repair_reentry_auction`.
+7. Export the compact result on `/trading/revenue-repair` and `/trading/consumer-evidence`.
+
+### Auction Behavior
+
+The no-delta auction keeps the current default:
+
+- unavailable carry denies reentry;
+- stale carry denies reentry;
+- current carry without a changed release condition denies duplicate no-delta reentry;
+- current carry with a changed release condition may select one zero-notional ticket;
+- nonzero notional blocks the ticket, even if every evidence condition is current.
+
+The selected ticket must name one of:
+
+- `jangar_verify_carry` for verification-debt foreclosure;
+- `execution_tca_receipt` when Jangar carry names execution proof as the release prerequisite;
+- `market_context_receipt` when the blocker set changed around market context;
+- `empirical_receipt` when post-cost evidence is the active prerequisite;
+- `schema_lineage_receipt` when lineage is the active prerequisite.
+
+## Implementation Scope
+
+Engineer stage should implement this as two PRs if ownership boundaries are split, or one PR if the same engineer owns
+both surfaces.
+
+Torghut responsibilities:
+
+1. Add a small Jangar verification-carry client with timeout, TTL, stale-cache handling, and schema validation.
+2. Wire the client into the trading status payload before `build_revenue_repair_digest`.
+3. Keep fetch failures observable as `jangar_verification_carry_unavailable`.
+4. Add tests proving current carry can satisfy `jangar_verify_foreclosure_ticket_current`, stale carry is denied,
+   unavailable carry is denied, mismatched no-delta keys are denied unless a release condition changed, and all selected
+   tickets keep `max_notional=0`.
+5. Add consumer-evidence coverage for the compact auction ref after carry import.
+
+Jangar responsibilities are defined in the companion document.
+
+## Validation Gates
+
+Local validation for Torghut implementation:
+
+- `uv sync --frozen --extra dev`
+- `uv run --frozen pytest services/torghut/tests/test_no_delta_repair_reentry_auction.py`
+- `uv run --frozen pytest services/torghut/tests/test_build_revenue_repair_digest.py -k no_delta`
+- `uv run --frozen pytest services/torghut/tests/test_trading_api.py -k no_delta`
+- `uv run --frozen pyright --project pyrightconfig.json`
+- `uv run --frozen pyright --project pyrightconfig.alpha.json`
+- `uv run --frozen pyright --project pyrightconfig.scripts.json`
+
+Post-rollout validation:
+
+- `kubectl get applications.argoproj.io -n argocd torghut jangar agents`
+- `kubectl get deploy -n torghut -o wide`
+- `kubectl get deploy -n jangar -o wide`
+- `curl -fsS http://jangar.jangar.svc.cluster.local/ready | jq '.verification_carry'`
+- `curl -fsS http://torghut.torghut.svc.cluster.local/trading/revenue-repair | jq '.no_delta_repair_reentry_auction'`
+- `curl -fsS http://torghut.torghut.svc.cluster.local/trading/consumer-evidence | jq '.no_delta_repair_reentry_auction'`
+- `curl -sS -o /tmp/torghut-health.json -w '%{http_code}' http://torghut.torghut.svc.cluster.local/trading/health`
+
+Acceptance gates:
+
+- Jangar emits a fresh carry packet with a non-null `carry_id`.
+- Torghut no longer reports `jangar_verification_carry_unavailable` when Jangar carry is fresh.
+- If release conditions are unchanged, Torghut still denies duplicate no-delta reentry.
+- If a release condition changed, Torghut selects at most one zero-notional ticket.
+- `routeable_candidate_count` either increases above `0` or a new no-delta debt records the changed release condition.
+- `max_notional=0` and `simple_submit_disabled` remain true until post-cost and routeability evidence clear capital
+  gates.
+
+## Rollout
+
+1. Ship Jangar carry export first in observe mode.
+2. Prove `/ready` and control-plane status include the compact carry and that the full foreclosure board remains
+   available for operator debugging.
+3. Ship Torghut carry ingress with a configured URL and fail-closed behavior.
+4. Keep the no-delta auction in observe mode until it has at least one fresh carry sample and one denial sample.
+5. Promote images through normal CI and GitOps only.
+6. Confirm Argo health, workload readiness, Jangar carry freshness, Torghut revenue repair, consumer evidence, and
+   `/trading/health` capital holds after rollout.
+
+## Rollback
+
+Rollback is straightforward and must not require database mutation:
+
+- unset or disable `TRADING_JANGAR_VERIFY_CARRY_URL`;
+- keep Torghut treating missing carry as `jangar_verification_carry_unavailable`;
+- keep `max_notional=0`;
+- keep live submission disabled;
+- leave the Jangar carry export in observe mode, or remove the route if it causes serving risk;
+- fall back to existing no-delta auction duplicate-denial behavior.
+
+## Risks
+
+- **Hot-path coupling:** Torghut must cache and fail closed rather than block revenue repair on a slow Jangar route.
+- **False release:** mismatched no-delta keys can open a ticket accidentally unless the implementation checks active
+  key, source ref, blocker set, and receipt set together.
+- **Overbroad payload:** exporting the full foreclosure board would make the contract brittle.
+- **Operator confusion:** `/ready=ok` and `/trading/health=503` remain valid together. Docs and handoffs must name
+  serving readiness separately from material and capital readiness.
+- **No revenue delta:** the bridge may only replace `jangar_verification_carry_unavailable` with a stricter denial if
+  release conditions remain unchanged. That is acceptable because it improves evidence truth and prevents duplicate
+  no-delta work.
+
+## Handoff
+
+Engineer:
+
+- Implement Jangar carry export from the companion contract and Torghut carry ingress here.
+- Start with observe-mode payloads and focused unit tests before changing scheduling behavior.
+- Do not select a repair ticket unless `max_notional=0`, the carry is fresh, and the auction release condition is
+  explicit.
+
+Deployer:
+
+- Promote only through CI and GitOps.
+- After rollout, capture Argo status, image digest, Jangar carry id, Torghut auction id, reentry decision, selected
+  ticket, `routeable_candidate_count`, and `max_notional`.
+- Treat a denied duplicate no-delta ticket as a valid safety outcome if the release condition did not change.
+
+Smallest blocker preventing revenue impact:
+
+- Torghut cannot consume Jangar's verify-trust foreclosure evidence as a fresh carry packet, so
+  `routeable_candidate_count` remains `0` and no zero-notional reentry ticket can be selected.

--- a/docs/torghut/design-system/v6/index.md
+++ b/docs/torghut/design-system/v6/index.md
@@ -8,10 +8,12 @@
 - Scope: intraday strategy architecture upgrade beyond static TSMOM, with regime-adaptive routing, DSPy-governed LLM
   reasoning, contamination-safe evaluation, and production rollout controls
 - Implementation status: `Mixed` (historical program closure recorded on `2026-03-03`; source-state refreshed on
-  `2026-03-09`; active proof/capital authority evidence refreshed on `2026-05-14T12:30Z`)
+  `2026-03-09`; active proof/capital authority evidence refreshed on `2026-05-14T16:12Z`)
 - Implementation status (strict, core 01-13 docs, source-state refresh `2026-03-09`): `Implemented=7`, `Partial=5`, `Completed=1`
 - Evidence (historical closure): `13-production-gap-closure-master-plan-2026-03-03.md` (Wave 0-6 closure + DoD)
-- Evidence (current next-work priority, refreshed `2026-05-14T12:30Z`):
+- Evidence (current next-work priority, refreshed `2026-05-14T16:12Z`):
+  - `208-torghut-jangar-verification-carry-bridge-and-no-delta-reentry-market-2026-05-14.md`
+  - `docs/agents/designs/202-jangar-verification-carry-export-and-repair-slot-reconciliation-2026-05-14.md`
   - `207-torghut-quant-plan-closeout-and-alpha-repair-reentry-handoff-2026-05-14.md`
   - `206-torghut-no-delta-repair-reentry-auction-and-verification-carry-2026-05-14.md`
   - `docs/agents/designs/201-jangar-verify-trust-foreclosure-and-alpha-repair-reentry-2026-05-14.md`


### PR DESCRIPTION
## Summary

- Added a long-form Torghut design for a Jangar verification-carry bridge feeding the no-delta reentry auction.
- Added the companion Jangar design for compact verification-carry export and repair-slot reconciliation.
- Updated Torghut and Agents documentation indexes so the new bridge contract is the current top architecture entry.
- Captured live evidence that Torghut remains `repair_only` with `routeable_candidate_count=0` because Jangar
  verification carry is unavailable to the auction while Jangar already exposes foreclosure tickets.

## Related Issues

None

## Testing

- `bunx oxfmt docs/torghut/design-system/v6/208-torghut-jangar-verification-carry-bridge-and-no-delta-reentry-market-2026-05-14.md docs/agents/designs/202-jangar-verification-carry-export-and-repair-slot-reconciliation-2026-05-14.md docs/torghut/design-system/v6/index.md docs/agents/README.md docs/torghut/README.md docs/torghut/design-system/README.md`
- `bunx oxfmt --check docs/torghut/design-system/v6/208-torghut-jangar-verification-carry-bridge-and-no-delta-reentry-market-2026-05-14.md docs/agents/designs/202-jangar-verification-carry-export-and-repair-slot-reconciliation-2026-05-14.md docs/torghut/design-system/v6/index.md docs/agents/README.md docs/torghut/README.md docs/torghut/design-system/README.md`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
