### PR TITLE
docs(jangar): define foreclosure carry witness

### DIFF
--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -19,6 +19,8 @@ clear entrypoints, clear “source of truth”, and a complete catalog of relate
 - Autonomous Jangar/Torghut production system design: `designs/autonomous-jangar-torghut-production-system.md`
 - Swarm agentic mission architecture notes: `designs/swarm-agentic-mission-architecture-2026-05-08.md`
 - Current Jangar/Torghut architecture contracts:
+  - `designs/203-jangar-foreclosure-carry-rollout-witness-and-stage-debt-repair-2026-05-14.md`
+  - `../torghut/design-system/v6/209-torghut-verification-carry-import-and-alpha-repair-release-2026-05-14.md`
   - `../torghut/design-system/v6/208-torghut-jangar-verification-carry-bridge-and-no-delta-reentry-market-2026-05-14.md`
   - `designs/202-jangar-verification-carry-export-and-repair-slot-reconciliation-2026-05-14.md`
   - `../torghut/design-system/v6/207-torghut-quant-plan-closeout-and-alpha-repair-reentry-handoff-2026-05-14.md`

--- a/docs/agents/designs/203-jangar-foreclosure-carry-rollout-witness-and-stage-debt-repair-2026-05-14.md
+++ b/docs/agents/designs/203-jangar-foreclosure-carry-rollout-witness-and-stage-debt-repair-2026-05-14.md
@@ -1,0 +1,465 @@
+# 203. Jangar Foreclosure-Carry Rollout Witness And Stage-Debt Repair (2026-05-14)
+
+Status: Accepted for engineer and deployer handoff
+Date: 2026-05-14
+Owner: Victor Chen, Jangar Engineering
+Scope: Jangar control-plane source-to-live foreclosure carry, stage-debt repair admission, Torghut verification
+carry, rollout truth, validation, rollback, and cross-swarm handoff.
+
+Companion Torghut contract:
+
+- `docs/torghut/design-system/v6/209-torghut-verification-carry-import-and-alpha-repair-release-2026-05-14.md`
+
+Extends:
+
+- `202-jangar-verification-carry-export-and-repair-slot-reconciliation-2026-05-14.md`
+- `docs/torghut/design-system/v6/208-torghut-jangar-verification-carry-bridge-and-no-delta-reentry-market-2026-05-14.md`
+- `201-jangar-verify-trust-foreclosure-and-alpha-repair-reentry-2026-05-14.md`
+- `200-jangar-revenue-repair-settlement-conveyor-and-stage-health-custody-2026-05-14.md`
+- `199-jangar-material-action-custody-flight-recorder-and-merge-reentry-slo-2026-05-14.md`
+- `188-jangar-ready-truth-arbiter-and-stage-credit-cutover-2026-05-13.md`
+- `180-jangar-execution-trust-debt-retirement-and-profit-repair-settlement-2026-05-08.md`
+
+## Decision
+
+I am selecting a **foreclosure-carry rollout witness with stage-debt repair admission** as the next Jangar
+control-plane contract.
+
+The current failure is not that the repository lacks the foreclosure-board implementation. Source already contains
+`services/jangar/src/server/control-plane-verify-trust-foreclosure.ts`, `/ready` wiring, status wiring, and tests.
+The failure is that the live system cannot spend that source fact. On 2026-05-14 at about 16:10Z, the `agents`
+deployment was still running image `registry.ide-newton.ts.net/lab/jangar-control-plane:0f963a1d`, while the current
+GitOps desired state in `argocd/applications/agents/values.yaml` pointed at `77e207de` and digest
+`sha256:0eaafd56bf7292502b142fb9ca0dff9f082a8c497539be62e7145f4411f4b41a`. Argo CD reported the `agents`
+application `OutOfSync` but `Healthy`.
+
+That is exactly the kind of split that makes a control plane look healthy while its material-action authority is
+missing. Jangar `/ready` returned `status=ok`, controller heartbeats were healthy, database migrations were current,
+and watch reliability saw `1327` events with `0` errors and `0` restarts in the last 15 minutes. But
+`execution_trust.status=degraded` because `jangar-control-plane:plan` and `jangar-control-plane:verify` had
+consecutive failures, and both `/ready` and `/api/agents/control-plane/status` returned
+`verify_trust_foreclosure_board=null`.
+
+Torghut has already moved to the next contract. `/trading/revenue-repair` emits
+`no_delta_repair_reentry_auction` in observe mode, denies duplicate alpha repair because the active no-delta release
+key is unchanged, keeps `max_notional=0`, and reports `jangar_verification_carry_unavailable`. Torghut is waiting for
+a Jangar carry that source promises but live Jangar does not yet emit.
+
+The selected design adds a Jangar-owned rollout witness that treats the foreclosure board as usable only when source,
+GitOps desired image, live image, `/ready`, control-plane status, and Torghut auction carry all agree. It also adds a
+stage-debt repair admission object that can spend one bounded zero-notional repair slot on the specific reason the
+carry is unavailable: rollout lag, board emission absence, plan/verify failure debt, or Torghut import mismatch.
+
+The tradeoff is that this contract is stricter than the current source rollout path. A merged source PR and healthy
+Kubernetes deployment will no longer be enough to claim stage-debt recovery. I accept that. The business metric is
+fewer failed AgentRuns and shorter green PR-to-healthy GitOps rollout time. Counting a source-only foreclosure board
+as recovered would hide the exact lag that currently keeps Torghut from accepting Jangar verification carry.
+
+## Governing Runtime Requirements
+
+This contract implements the active swarm validation contract:
+
+- every run must cite the governing design or runtime requirement before changing code;
+- implement stages must produce production PRs with tests or report the exact blocker to code;
+- verify stages must merge only green PRs and prove Argo, workload readiness, and service health after rollout;
+- final handoff must name the control-plane metric improved or the smallest blocker preventing improvement.
+
+Value-gate mapping:
+
+- `failed_agentrun_rate`: deny broad retries while the same plan/verify debt and missing live board are still active.
+- `pr_to_rollout_latency`: turn source-to-live lag into an explicit witness with target revision, desired image,
+  observed image, service fields, and Torghut carry result.
+- `ready_status_truth`: keep `/ready.status=ok` as serving truth while refusing to treat serving health as material
+  action authority.
+- `manual_intervention_count`: replace manual comparison of Git, Argo, live images, status fields, and Torghut auction
+  output with one witness packet.
+- `handoff_evidence_quality`: every handoff cites witness id, carry state, rollout lag class, validation commands, and
+  rollback target.
+
+Torghut value-gate mapping:
+
+- `routeable_candidate_count`: alpha-repair reentry remains denied until Jangar verification carry is current or a
+  named zero-notional stage-debt repair ticket is selected.
+- `zero_notional_or_stale_evidence_rate`: stale or source-only Jangar carry remains denial evidence.
+- `fill_tca_or_slippage_quality`: execution repair can be admitted only if the witness says Jangar carry is current
+  enough to let Torghut evaluate the top alpha lane.
+- `post_cost_daily_net_pnl`: no live or paper capital follows from this contract.
+- `capital_gate_safety`: all stage-debt and alpha-repair work remains `max_notional=0`.
+
+## Current Evidence
+
+All evidence was collected read-only on 2026-05-14. I did not mutate Kubernetes resources, database records, GitOps
+resources, trading flags, AgentRuns, or market data.
+
+### Cluster And Rollout Evidence
+
+- Kubernetes identity was `system:serviceaccount:agents:agents-sa`.
+- `agents`, `agents-controllers`, and `agents-alloy` deployments were available in the `agents` namespace.
+- `agents` live image was `registry.ide-newton.ts.net/lab/jangar-control-plane:0f963a1d` with digest
+  `sha256:41c2cec100cf819712a64e39b504a965dd34a1519d90b14c23905e259a512e21`.
+- `agents-controllers` live image was `registry.ide-newton.ts.net/lab/jangar:0f963a1d` with digest
+  `sha256:3e0cc409faa2445769ad05266674ee0c370ef07be8b11d78a295974f20828e11`.
+- Current GitOps desired state pointed `agents` at image tag `77e207de`, digest
+  `sha256:0eaafd56bf7292502b142fb9ca0dff9f082a8c497539be62e7145f4411f4b41a`, and source SHA
+  `77e207ded12c0144af7f1196e7c1676d03aaeef4`.
+- Argo CD reported `agents` `OutOfSync` and `Healthy`; `jangar` was `Synced` and `Healthy`; `torghut` was
+  `OutOfSync` and `Healthy` while waiting on a migration hook; `symphony-torghut` was `Synced` and `Healthy`.
+- Recent agents events showed successful scheduled jobs, but plan pods had `OOMKilled` attempts and verify jobs had
+  `BackoffLimitExceeded` failures.
+- AgentRun inventory in `agents` contained `127` failed, `699` succeeded, `6` running, `11` pending, and `12`
+  template runs.
+- Recent Jangar stage inventory included failed `jangar-control-plane-plan-sched-w9w7f` with
+  `BackoffLimitExceeded`, failed `jangar-control-plane-verify-sched-jm4rd`, and a currently running verify run.
+- The `jangar-control-plane` and `torghut-quant` Swarms were both `Active`, `lights-out`, and `Ready=True`.
+
+### Jangar Control-Plane Evidence
+
+- `/ready` returned `status=ok`, `business_state=repair_only`, `revenue_ready=false`, and top repair
+  `repair_alpha_readiness`.
+- `/ready.execution_trust.status=degraded` with blocking windows
+  `jangar-control-plane:plan:plan consecutive failures` and
+  `jangar-control-plane:verify:verify consecutive failures`.
+- `/api/agents/control-plane/status?namespace=agents` generated at `2026-05-14T16:10:12.103Z`.
+- Controllers were healthy with fresh heartbeat authority.
+- Watch reliability was healthy with `1327` events, `0` errors, and `0` restarts in the 15 minute window.
+- Database was connected and healthy with `latency_ms=15`.
+- Kysely migration consistency was healthy: `registered_count=29`, `applied_count=29`, `unapplied_count=0`,
+  `unexpected_count=0`, latest migration
+  `20260508_torghut_quant_pipeline_health_account_window_created_at_index`.
+- Route-stability window allowed only `serve_readonly` and `torghut_observe`; it held `dispatch_repair`,
+  `dispatch_normal`, `deploy_widen`, `merge_ready`, and `paper_canary`; it blocked `live_micro_canary` and
+  `live_scale`.
+- `verify_trust_foreclosure_board` was `null` on both `/ready` and control-plane status.
+- `repair_slot_escrow` was also `null` on `/ready`, even though source head `77e207de` contains the repair slot
+  escrow implementation.
+
+### Torghut Business And Data Evidence
+
+- Torghut live revision was `torghut-00397`; sim revision was `torghut-sim-00494`; both pods were running.
+- Torghut `/readyz` returned `status=degraded`, with degradation aligned to capital safety rather than service
+  unavailability.
+- Torghut `/db-check` returned `ok=true`, `schema_current=true`, `schema_missing_heads=[]`,
+  `schema_unexpected_heads=[]`, `schema_head_delta_count=0`, and `schema_graph_lineage_ready=true`.
+- The database witness still reported historical parent-fork warnings under
+  `0010_execution_provenance_and_governance_trace` and `0015_whitepaper_workflow_tables`.
+- `/trading/revenue-repair` returned `business_state=repair_only`, `revenue_ready=false`, and
+  `alpha_readiness_settlement_conveyor.status=no_delta`.
+- The selected lane was `H-MICRO-01`, selected value gate was `routeable_candidate_count`, and accepted routeable
+  candidate count remained `0`.
+- `alpha_repair_dividend_ledger.status=no_delta`, `jangar_custody.launch_decision=deny`, and
+  `launch_decision_reason=no_delta_release_key_active`.
+- `no_delta_repair_reentry_auction.reentry_decision=deny`, with reason codes including
+  `active_no_delta_release_key`, `no_release_condition_changed`, `zero_notional_reentry_ticket_not_selected`,
+  `jangar_verification_carry_unavailable`, and `duplicate_no_delta_reentry_denied`.
+- `no_delta_repair_reentry_auction.jangar_verification_carry.status=unavailable` and required
+  `jangar.verify-trust-foreclosure-ticket.v1`.
+
+### Source And Test Surface
+
+- Source contains the Jangar foreclosure builder in
+  `services/jangar/src/server/control-plane-verify-trust-foreclosure.ts`.
+- Source contains `/ready` and status emission wiring in `services/jangar/src/routes/ready.tsx` and
+  `services/jangar/src/server/control-plane-status.ts`.
+- The implementation landed after the live `0f963a1d` image: source history from `0f963a1d..77e207de` includes
+  `13d640a02 feat(jangar): add verify trust foreclosure board`, `b9e2b92d5 fix(jangar): bind foreclosure admission to
+closure board`, and `77e207ded feat(jangar): add repair slot escrow`.
+- Jangar high-risk integration files remain large: `agents-control-plane.ts` is `3165` lines,
+  `control-plane-status.ts` is `798` lines, and `control-plane-material-action-verdict.ts` is `680` lines.
+- There are `42` Jangar server tests matching `*control-plane*test.ts`, including foreclosure, ready truth, material
+  action verdict, material reentry, source rollout truth, repair slot escrow, and authority provenance.
+- Torghut source contains `services/torghut/app/trading/no_delta_repair_reentry_auction.py` and
+  `services/torghut/tests/test_no_delta_repair_reentry_auction.py`.
+- The missing contract is not another local reducer. It is the live witness that proves the reducer has crossed the
+  source-to-serving boundary and that Torghut has consumed the resulting carry.
+
+## Problem
+
+Jangar currently has three separate truths for the same recovery:
+
+1. Source truth says the foreclosure board and repair slot escrow exist.
+2. GitOps desired truth says the `77e207de` image should be deployed.
+3. Live serving truth says the old `0f963a1d` image is still active and the board fields are absent.
+
+The system lets these truths remain separate. That creates concrete failure modes:
+
+1. `/ready.status=ok` can be mistaken for material-action readiness.
+2. Argo `Healthy` can hide `OutOfSync` application state.
+3. A current source SHA can be treated as recovered before its fields appear in live status.
+4. Torghut can correctly deny duplicate alpha repair but still lack the Jangar verification carry needed to price the
+   next release condition.
+5. Plan and verify failures can keep accumulating while implement runs continue to spend capacity.
+6. Deployer handoff can cite rollout or service health without proving the carry field has appeared and been consumed.
+
+The control plane needs a rollout witness that makes source-to-live carry availability a first-class admission gate.
+
+## Alternatives Considered
+
+### Option A: Wait For Argo To Converge And Recheck `/ready`
+
+This option treats the current split as a transient deployment lag.
+
+Advantages:
+
+- No new contract.
+- If Argo catches up quickly, the missing board may appear without more work.
+- Avoids more documentation and reducer surface.
+
+Disadvantages:
+
+- It does not explain why `agents` is `OutOfSync` while `Healthy`.
+- It does not prevent workers from spending more plan/verify capacity while the carry is missing.
+- It does not give Torghut a stable reason to keep `jangar_verification_carry_unavailable`.
+- It does not improve handoff evidence quality.
+
+Decision: reject as the architecture. It remains a deployer action inside the selected contract.
+
+### Option B: Treat Source Commit Presence As The Carry
+
+This option lets Torghut or Jangar accept `13d640a02`/`77e207de` source presence as proof that the foreclosure board is
+available.
+
+Advantages:
+
+- Easy to compute.
+- Unblocks downstream contracts quickly.
+- Reduces dependence on live status payload shape.
+
+Disadvantages:
+
+- It failed the live evidence test: source exists and live status still returns `null`.
+- It would make the business surface less truthful.
+- It can open alpha-repair reentry before the deployed service can explain material action decisions.
+- It weakens rollback because source cannot say which live image is answering traffic.
+
+Decision: reject.
+
+### Option C: Foreclosure-Carry Rollout Witness With Stage-Debt Repair Admission
+
+This option creates a Jangar witness that joins source commit, GitOps desired image, live image, Argo state, workload
+readiness, `/ready` field presence, control-plane status field presence, execution-trust debt, and Torghut auction
+carry. It then admits only one bounded repair ticket for the current missing link.
+
+Advantages:
+
+- Directly targets the current failure.
+- Separates serving health from material-action authority.
+- Gives Torghut a compact carry state that is either current, lagging, stale, unavailable, or denied.
+- Converts source-to-live lag into a measurable PR-to-rollout latency component.
+- Reduces duplicate plan/verify AgentRuns by requiring debt-specific repair tickets.
+
+Disadvantages:
+
+- Adds one more status payload.
+- Requires deployer discipline: green CI is not enough until live carry appears.
+- Can hold otherwise safe repairs while the witness is missing.
+
+Decision: select Option C.
+
+## Architecture
+
+Jangar emits two additive payloads in observe mode first:
+
+```text
+jangar.foreclosure-carry-rollout-witness.v1
+  witness_id
+  generated_at
+  fresh_until
+  source_head_sha
+  gitops_revision
+  desired_agents_image
+  desired_agents_digest
+  observed_agents_image
+  observed_agents_digest
+  argo_app_status
+  workload_readiness
+  ready_field_presence
+  control_plane_status_field_presence
+  execution_trust_status
+  execution_trust_blocking_windows[]
+  torghut_auction_ref
+  torghut_jangar_verification_carry_state
+  carry_state: current | rollout_lagging | field_absent | stale | unavailable | denied
+  reason_codes[]
+  validation_commands[]
+  rollback_target
+
+jangar.stage-debt-repair-admission.v1
+  admission_id
+  generated_at
+  fresh_until
+  selected_debt_class:
+    rollout_lag | board_field_absent | plan_failure_debt | verify_failure_debt | torghut_carry_import_mismatch
+  action_class
+  decision: allow | hold | deny
+  required_output_receipt
+  max_parallelism
+  max_runtime_seconds
+  max_notional: "0"
+  reason_codes[]
+  validation_commands[]
+  rollback_target
+```
+
+The witness is not a replacement for `/ready`. `/ready` remains a serving surface. The witness is an authority surface
+for material action, rollout widening, and Torghut carry import.
+
+### Carry States
+
+- `current`: desired source/image, observed image, `/ready` board, control-plane status board, and Torghut carry all
+  agree within freshness windows.
+- `rollout_lagging`: GitOps desired source/image is ahead of the observed workload image.
+- `field_absent`: observed image should contain the field, but `/ready` or status does not emit it.
+- `stale`: fields exist but are older than their freshness windows.
+- `unavailable`: Torghut reports missing Jangar carry or Jangar cannot compute the witness.
+- `denied`: carry exists but material action is denied by active debt or no-delta duplicate suppression.
+
+### Admission Rules
+
+Jangar allows `serve_readonly` when `/ready.status=ok` and route-stability allows it.
+
+Jangar allows `torghut_observe` when Torghut evidence is current, even if material action is held.
+
+Jangar holds `dispatch_repair`, `merge_ready`, and `deploy_widen` when:
+
+- `carry_state` is `rollout_lagging`, `field_absent`, `stale`, or `unavailable`;
+- Argo is `OutOfSync` for the serving app that owns the carry field;
+- execution trust has plan or verify consecutive failures and no current repair admission;
+- Torghut auction carry is unavailable or stale;
+- required output receipt is missing.
+
+Jangar denies duplicate repair when:
+
+- the selected debt class is unchanged from the previous admission;
+- the previous repair produced no carry-state delta;
+- Torghut active no-delta release key is unchanged;
+- the run does not cite the governing Jangar and Torghut design refs.
+
+Jangar allows one bounded repair only when:
+
+- the selected debt class is exactly one of the active missing links;
+- the repair has one required output receipt and one fast validation command;
+- `max_parallelism=1`;
+- `max_notional=0`;
+- rollback preserves existing material-action holds.
+
+### Stage-Debt Classes
+
+- `rollout_lag`: desired source/image is ahead of the observed workload image.
+- `board_field_absent`: live service is on an eligible image but does not emit the required board fields.
+- `plan_failure_debt`: plan stage has consecutive failures, OOMKilled attempts, or BackoffLimitExceeded debt.
+- `verify_failure_debt`: verify stage has consecutive failures or BackoffLimitExceeded debt.
+- `torghut_carry_import_mismatch`: Jangar emits a current board but Torghut still reports verification carry
+  unavailable or stale.
+
+## Implementation Scope
+
+Engineer milestone 1:
+
+- Add `foreclosure_carry_rollout_witness` and `stage_debt_repair_admission` to the Jangar status model.
+- Build the witness from existing source-serving proof, source rollout truth, workload image evidence,
+  route-stability escrow, execution trust, `verify_trust_foreclosure_board`, `repair_slot_escrow`, and Torghut
+  `no_delta_repair_reentry_auction` fields.
+- Expose compact witness refs on `/ready` and `/api/agents/control-plane/status`.
+- Keep enforcement in observe mode for one deploy.
+
+Engineer milestone 2:
+
+- Wire witness state into material-action verdicts for `dispatch_repair`, `merge_ready`, and `deploy_widen`.
+- Add debt-specific dedupe keys so repeated plan/verify repairs are denied when the carry-state delta is unchanged.
+- Add tests for source ahead of live image, field absent, Torghut carry unavailable, carry current, and duplicate
+  no-delta suppression.
+
+Deployer milestone:
+
+- Promote the current Jangar image and prove `agents` is `Synced` and `Healthy`.
+- Prove live `/ready.verify_trust_foreclosure_board` and status `.verify_trust_foreclosure_board` are non-null.
+- Prove Torghut auction moves from `jangar_verification_carry_unavailable` to a current, stale, or denied carry state
+  that cites the Jangar board.
+
+## Validation Gates
+
+Local validation for the Jangar implementation:
+
+- `bunx vitest run --config vitest.config.ts src/server/__tests__/control-plane-verify-trust-foreclosure.test.ts`
+- `bunx vitest run --config vitest.config.ts src/server/__tests__/control-plane-repair-slot-escrow.test.ts`
+- `bunx vitest run --config vitest.config.ts src/server/__tests__/control-plane-material-action-verdict.test.ts`
+- `bunx vitest run --config vitest.config.ts src/routes/ready.test.ts`
+- `bun run --filter @proompteng/jangar tsc`
+- `bun run --filter @proompteng/jangar lint`
+- `bun run --filter @proompteng/jangar lint:oxlint`
+
+Live validation for deployer:
+
+- `kubectl -n argocd get applications.argoproj.io agents -o json | jq '{sync: .status.sync.status, health: .status.health.status, revision: .status.sync.revision}'`
+- `kubectl -n agents get deploy agents -o jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'`
+- `curl -fsS http://agents.agents.svc.cluster.local/ready | jq '.verify_trust_foreclosure_board, .foreclosure_carry_rollout_witness, .stage_debt_repair_admission'`
+- `curl -fsS 'http://agents.agents.svc.cluster.local/api/agents/control-plane/status?namespace=agents' | jq '.verify_trust_foreclosure_board, .foreclosure_carry_rollout_witness'`
+- `curl -fsS http://torghut.torghut.svc.cluster.local/trading/revenue-repair | jq '.no_delta_repair_reentry_auction.jangar_verification_carry'`
+
+Acceptance:
+
+- Source and GitOps desired image cannot count as carry-current until live `/ready` and status emit the board.
+- `agents` `OutOfSync` forces `carry_state=rollout_lagging` or a more specific hold.
+- Torghut `jangar_verification_carry_unavailable` blocks alpha-repair reentry unless a Jangar stage-debt repair ticket
+  is selected.
+- Duplicate plan/verify repair launches are denied when the selected debt class and carry-state delta are unchanged.
+- Material `merge_ready`, `deploy_widen`, `paper_canary`, `live_micro_canary`, and `live_scale` remain held or blocked
+  while carry is unavailable.
+
+## Rollout
+
+Phase 0 is documentation and test fixtures.
+
+Phase 1 emits the witness in observe mode on `/ready` and control-plane status.
+
+Phase 2 makes deployer handoff require non-null witness fields before claiming PR-to-rollout recovery.
+
+Phase 3 feeds `carry_state` into material-action verdicts while keeping hold-on-unknown behavior.
+
+Phase 4 allows one bounded stage-debt repair ticket for the exact active missing link.
+
+Phase 5 makes `carry_state=current` required for `merge_ready` and `deploy_widen`.
+
+## Rollback
+
+Rollback is to stop consuming `foreclosure_carry_rollout_witness` in material-action verdicts and keep existing
+route-stability escrow, execution trust, verify-trust foreclosure board, repair slot escrow, and Torghut no-delta
+auction as separate observe-mode authorities.
+
+If the witness falsely holds rollout:
+
+- keep the witness visible;
+- remove it from material-action verdicts;
+- require the deployer to cite live `/ready` and status fields manually;
+- keep Torghut `max_notional=0`.
+
+If the witness falsely allows carry-current:
+
+- force `carry_state=denied` unless both `/ready` and status emit a fresh board;
+- deny `dispatch_repair`, `merge_ready`, and `deploy_widen`;
+- inspect source SHA, desired image, live image, and Torghut carry import before reopening.
+
+## Risks
+
+- Risk: Argo `OutOfSync` is transient and creates noisy holds. Mitigation: the witness has a freshness window and
+  records both desired and observed image facts.
+- Risk: status payload grows too large. Mitigation: expose compact refs on `/ready` and full detail only on
+  control-plane status.
+- Risk: plan and verify failures are caused by resource limits rather than source defects. Mitigation: stage-debt
+  repair tickets classify OOMKilled and BackoffLimitExceeded separately and require one bounded output receipt.
+- Risk: Torghut treats stale carry as capital permission. Mitigation: Torghut companion contract keeps every carry
+  state zero-notional and keeps no-delta duplicate suppression authoritative.
+
+## Handoff
+
+Engineer next action: implement `jangar.foreclosure-carry-rollout-witness.v1` in observe mode and add tests proving
+that source ahead of live image plus missing board fields produces `carry_state=rollout_lagging` or `field_absent`,
+not material readiness.
+
+Deployer next action: after promotion, prove `agents` is `Synced` and `Healthy`, live image matches desired
+`77e207de`, `/ready.verify_trust_foreclosure_board` is non-null, status emits the board, and Torghut no-delta auction
+imports a Jangar carry state.
+
+The smallest current blocker is specific: Jangar source contains the foreclosure board and repair slot escrow, but the
+live `agents` image is still `0f963a1d`; Torghut therefore reports `jangar_verification_carry_unavailable` while
+`routeable_candidate_count` remains `0`.

--- a/docs/torghut/README.md
+++ b/docs/torghut/README.md
@@ -4,6 +4,10 @@
 
 Start here:
 
+- `docs/agents/designs/203-jangar-foreclosure-carry-rollout-witness-and-stage-debt-repair-2026-05-14.md`
+  (current Jangar foreclosure-carry rollout witness and stage-debt repair contract)
+- `docs/torghut/design-system/v6/209-torghut-verification-carry-import-and-alpha-repair-release-2026-05-14.md`
+  (current Torghut verification-carry import and alpha-repair release contract)
 - `docs/torghut/design-system/v6/208-torghut-jangar-verification-carry-bridge-and-no-delta-reentry-market-2026-05-14.md`
   (current Jangar verification-carry bridge and no-delta reentry market contract)
 - `docs/agents/designs/202-jangar-verification-carry-export-and-repair-slot-reconciliation-2026-05-14.md`

--- a/docs/torghut/design-system/README.md
+++ b/docs/torghut/design-system/README.md
@@ -35,6 +35,8 @@ The v1 documents are written to stay consistent with:
 If you are trying to decide which docs are current contract truth versus historical milestone records, start with:
 
 - `docs/torghut/design-system/current-source-of-truth-and-priority-guide-2026-03-09.md`
+- `docs/agents/designs/203-jangar-foreclosure-carry-rollout-witness-and-stage-debt-repair-2026-05-14.md`
+- `docs/torghut/design-system/v6/209-torghut-verification-carry-import-and-alpha-repair-release-2026-05-14.md`
 - `docs/torghut/design-system/v6/208-torghut-jangar-verification-carry-bridge-and-no-delta-reentry-market-2026-05-14.md`
 - `docs/agents/designs/202-jangar-verification-carry-export-and-repair-slot-reconciliation-2026-05-14.md`
 - `docs/torghut/design-system/v6/207-torghut-quant-plan-closeout-and-alpha-repair-reentry-handoff-2026-05-14.md`

--- a/docs/torghut/design-system/v6/209-torghut-verification-carry-import-and-alpha-repair-release-2026-05-14.md
+++ b/docs/torghut/design-system/v6/209-torghut-verification-carry-import-and-alpha-repair-release-2026-05-14.md
@@ -1,0 +1,429 @@
+# 209. Torghut Verification Carry Import And Alpha Repair Release (2026-05-14)
+
+Status: Accepted for engineer and deployer handoff
+Date: 2026-05-14
+Owner: Victor Chen, Jangar Engineering
+Scope: Torghut verification-carry import, alpha-repair no-delta release, Jangar foreclosure witness consumption,
+zero-notional routeable-candidate recovery, validation, rollout, rollback, and cross-swarm handoff.
+
+Companion Jangar contract:
+
+- `docs/agents/designs/203-jangar-foreclosure-carry-rollout-witness-and-stage-debt-repair-2026-05-14.md`
+
+Extends:
+
+- `208-torghut-jangar-verification-carry-bridge-and-no-delta-reentry-market-2026-05-14.md`
+- `docs/agents/designs/202-jangar-verification-carry-export-and-repair-slot-reconciliation-2026-05-14.md`
+- `207-torghut-quant-plan-closeout-and-alpha-repair-reentry-handoff-2026-05-14.md`
+- `206-torghut-no-delta-repair-reentry-auction-and-verification-carry-2026-05-14.md`
+- `205-torghut-alpha-readiness-settlement-conveyor-and-routeable-profit-runway-2026-05-14.md`
+- `204-torghut-alpha-repair-dividend-ledger-and-custody-flight-recorder-2026-05-14.md`
+- `197-torghut-executable-alpha-repair-receipts-and-zero-notional-reentry-2026-05-13.md`
+
+## Decision
+
+I am selecting a **verification-carry import board with alpha-repair release accounting** as Torghut's next
+profitability contract.
+
+Torghut has made the right local move. On 2026-05-14 at about 16:10Z, `/trading/revenue-repair` emitted
+`no_delta_repair_reentry_auction`, selected `H-MICRO-01`, kept the selected value gate
+`routeable_candidate_count`, measured routeable candidate count as `0 -> 0`, and denied reentry because the active
+no-delta release key had not changed. That is correct. Repeating the same alpha repair would burn capacity and still
+leave `routeable_candidate_count=0`.
+
+The current blocker is the cross-plane import. The same auction reported
+`jangar_verification_carry.status=unavailable`, required `jangar.verify-trust-foreclosure-ticket.v1`, and included
+`jangar_verification_carry_unavailable` in the denial reasons. That is also correct: Jangar live `/ready` and
+control-plane status still returned `verify_trust_foreclosure_board=null`, even though source has the board
+implementation and GitOps desired state points at a newer Jangar image.
+
+This means Torghut should not open the alpha-repair release just because time passes or because Jangar source contains
+the board. It should import a Jangar foreclosure-carry rollout witness and classify the carry state as current,
+rollout-lagging, field-absent, stale, unavailable, or denied. That imported state then becomes one of the auction
+release conditions. If the carry is current, Torghut can price the next zero-notional alpha prerequisite. If the carry
+is lagging or absent, Torghut keeps the top repair item closed and records a Jangar-stage blocker rather than launching
+another no-delta alpha run.
+
+The tradeoff is that Torghut becomes more dependent on Jangar deployer proof before it can spend its next repair slot.
+I accept that. The live business metric is not generic job throughput; it is routeable candidate recovery under
+capital safety. A Jangar carry that exists only in source cannot reduce trading risk or failed AgentRuns.
+
+## Governing Runtime Requirements
+
+This contract implements the active cross-swarm runtime requirements:
+
+- every run must cite the governing Torghut or Jangar design before changing code;
+- implement stages must produce production PRs that improve readiness, profit evidence, data freshness, execution
+  quality, or capital safety;
+- verify stages must merge only green PRs and prove Argo, workload readiness, service health, and trading evidence
+  after rollout;
+- final handoff must name the revenue metric improved or the smallest blocker preventing revenue impact.
+
+Torghut value-gate mapping:
+
+- `routeable_candidate_count`: primary value gate; reentry can open only when carry is current or the selected ticket
+  explicitly repairs carry import.
+- `zero_notional_or_stale_evidence_rate`: source-only or stale Jangar carry is denial evidence.
+- `fill_tca_or_slippage_quality`: TCA repair can win only after verification carry is current or explicitly not
+  required for the selected alpha release.
+- `post_cost_daily_net_pnl`: no paper or live capital follows from this contract.
+- `capital_gate_safety`: all tickets remain `max_notional=0`; live submission stays disabled.
+
+Jangar value-gate mapping:
+
+- `failed_agentrun_rate`: duplicate no-delta alpha repair stays denied while Jangar carry is unavailable.
+- `pr_to_rollout_latency`: Torghut records the Jangar carry state and rollout lag as an imported release condition.
+- `ready_status_truth`: Torghut distinguishes service degradation for capital safety from missing cross-plane carry.
+- `manual_intervention_count`: no human has to manually compare source, live Jangar status, and auction denial reason.
+- `handoff_evidence_quality`: handoffs cite auction id, imported carry state, active no-delta key, required receipt,
+  validation commands, and rollback target.
+
+## Current Evidence
+
+All evidence was collected read-only on 2026-05-14. I did not mutate Kubernetes resources, database records, trading
+flags, GitOps resources, AgentRuns, or market data.
+
+### Torghut Runtime Evidence
+
+- Torghut live revision was `torghut-00397`; simulation revision was `torghut-sim-00494`; both pods were running.
+- Torghut `/readyz` returned `status=degraded`. The observed degradation was aligned with capital holds rather than
+  serving unavailability.
+- Torghut `/db-check` returned `ok=true`, `schema_current=true`, `schema_missing_heads=[]`,
+  `schema_unexpected_heads=[]`, `schema_head_delta_count=0`, and `schema_graph_lineage_ready=true`.
+- The DB witness still carried historical parent-fork warnings for
+  `0010_execution_provenance_and_governance_trace` and `0015_whitepaper_workflow_tables`; schema currentness is
+  required but not sufficient for repair release.
+- Recent Torghut namespace events showed revision replacement, successful migration/bootstrap jobs, and running data
+  services. They also showed startup/readiness probe noise during rollout and a recent
+  `torghut-profit-summary-feedback` workflow failure with exit code `2`.
+
+### Revenue Repair Evidence
+
+- `/trading/revenue-repair` generated at `2026-05-14T16:10:21.721419+00:00`.
+- `business_state=repair_only` and `revenue_ready=false`.
+- `alpha_readiness_settlement_conveyor.status=no_delta` and `settlement_state=no_delta`.
+- Selected queue code was `repair_alpha_readiness`; selected value gate was `routeable_candidate_count`.
+- Selected lane was `H-MICRO-01`, candidate `chip-paper-microbar-composite@execution-proof`, strategy
+  `microbar_volume_continuation_long_top2_chip_v1@paper`.
+- Routeable candidate count remained `0 -> 0`; `accepted_routeable_candidate_count=0`;
+  `measured_routeable_candidate_delta=0`.
+- `alpha_repair_dividend_ledger.status=no_delta`, `selected_hypothesis_id=H-MICRO-01`, and
+  `jangar_custody.launch_decision=deny`.
+- Dividend ledger reason was `no_delta_release_key_active`; capital state remained `zero_notional` with
+  `max_notional=0`.
+- `no_delta_repair_reentry_auction.reentry_decision=deny`.
+- Auction reason codes were `active_no_delta_release_key`, `no_release_condition_changed`,
+  `zero_notional_reentry_ticket_not_selected`, `jangar_verification_carry_unavailable`, and
+  `duplicate_no_delta_reentry_denied`.
+- Auction `jangar_verification_carry.status=unavailable`, `jangar_execution_trust_status=unavailable`,
+  `jangar_source_rollout_truth_state=unknown`, and `required_jangar_receipt=jangar.verify-trust-foreclosure-ticket.v1`.
+
+### Jangar Evidence Imported By Torghut
+
+- Jangar `/ready` returned `status=ok`, `business_state=repair_only`, `revenue_ready=false`, and top repair
+  `repair_alpha_readiness`.
+- Jangar `/ready.execution_trust.status=degraded` because `jangar-control-plane:plan` and
+  `jangar-control-plane:verify` had consecutive failures.
+- Jangar `/ready.verify_trust_foreclosure_board=null`.
+- Jangar control-plane status also returned `verify_trust_foreclosure_board=null`.
+- Jangar database witness was healthy with `29` registered migrations, `29` applied migrations, and no unapplied or
+  unexpected migrations.
+- Jangar watch reliability was healthy with `1327` events, `0` errors, and `0` restarts in the 15 minute window.
+- `agents` workload was healthy but running old image `0f963a1d`; GitOps desired state pointed at `77e207de`.
+- Argo CD reported `agents` `OutOfSync` and `Healthy`.
+
+### Source And Test Surface
+
+- Torghut no-delta auction source is `services/torghut/app/trading/no_delta_repair_reentry_auction.py`.
+- Revenue repair digest construction is in `services/torghut/app/trading/revenue_repair.py`.
+- API export wiring is in `services/torghut/app/main.py`.
+- Existing tests include `test_no_delta_repair_reentry_auction.py`, `test_build_revenue_repair_digest.py`,
+  `test_alpha_readiness_settlement_conveyor.py`, `test_alpha_repair_dividend_ledger.py`,
+  `test_consumer_evidence.py`, `test_routeability_repair_acceptance.py`, and `test_trading_api.py`.
+- The missing test family is the import board: source-only Jangar carry deny, rollout-lagging carry hold,
+  current carry allow-pricing, stale carry deny, and carry-import mismatch escalation.
+
+## Problem
+
+Torghut now knows how to deny repeated alpha repair when the no-delta release key is active. It does not yet have a
+capital-safe way to distinguish these Jangar states:
+
+1. Jangar source contains the foreclosure board but live status does not emit it.
+2. Jangar live status emits a fresh foreclosure board but Torghut has not imported it.
+3. Jangar emits stale carry.
+4. Jangar emits current carry but still denies material action because plan/verify debt is active.
+5. Jangar emits current carry and explicitly selects one stage-debt repair ticket.
+
+Without that classification, every missing carry becomes the same `jangar_verification_carry_unavailable` reason. That
+is safe, but it is not precise enough to shorten the next PR-to-rollout loop or to decide whether the top alpha repair
+queue item can move.
+
+The current business blocker is specific: `routeable_candidate_count=0`, active no-delta release key unchanged, and
+Jangar verification carry unavailable.
+
+## Alternatives Considered
+
+### Option A: Keep Denying Until Jangar Carry Appears
+
+This option leaves the current auction as-is. Missing Jangar carry remains a simple denial reason.
+
+Advantages:
+
+- Safe.
+- No new source work.
+- Keeps duplicate no-delta repair closed.
+
+Disadvantages:
+
+- It does not distinguish rollout lag from source absence or import bugs.
+- It gives deployers no Torghut-side proof that the Jangar promotion fixed the carry path.
+- It keeps the top queue item blocked without selecting the smallest cross-plane repair.
+- It does not improve handoff evidence beyond the current denial reason.
+
+Decision: reject as the target state. Keep it as the fallback behavior.
+
+### Option B: Ignore Jangar Carry For Zero-Notional Alpha Repair
+
+This option lets Torghut reopen the alpha repair lane because all work is zero-notional.
+
+Advantages:
+
+- Fastest path to another alpha run.
+- Keeps Torghut locally autonomous.
+- Could find a routeable candidate if the previous no-delta was incidental.
+
+Disadvantages:
+
+- It repeats the exact failed pattern while the no-delta key is unchanged.
+- It ignores Jangar plan/verify debt and increases failed AgentRun pressure.
+- It does not clear the cross-plane release condition that the auction already identified.
+- It weakens capital safety discipline by treating zero-notional as reason to bypass control-plane truth.
+
+Decision: reject.
+
+### Option C: Verification-Carry Import Board With Alpha-Repair Release Accounting
+
+This option imports Jangar's foreclosure-carry rollout witness, classifies the carry state, and feeds that state into
+the no-delta auction as a release condition and repair-ticket selector.
+
+Advantages:
+
+- Targets the live blocker directly.
+- Keeps duplicate no-delta repair denied.
+- Gives deployers a Torghut-side receipt after Jangar rollout.
+- Lets the auction select a Jangar-stage repair ticket only when it can retire the missing carry condition.
+- Preserves `max_notional=0`.
+
+Disadvantages:
+
+- Adds an import reducer and tests.
+- Requires Jangar and Torghut payload schemas to stay aligned.
+- Can hold Torghut-local work until Jangar carry is fixed.
+
+Decision: select Option C.
+
+## Architecture
+
+Torghut emits two additive payloads:
+
+```text
+torghut.verification-carry-import-board.v1
+  import_board_id
+  generated_at
+  fresh_until
+  source_revenue_repair_ref
+  active_no_delta_auction_ref
+  active_no_delta_release_key
+  imported_jangar_witness_ref
+  imported_jangar_board_ref
+  imported_jangar_stage_debt_admission_ref
+  jangar_carry_state:
+    current | rollout_lagging | field_absent | stale | unavailable | denied | import_mismatch
+  jangar_execution_trust_status
+  jangar_blocking_windows[]
+  jangar_desired_image_ref
+  jangar_observed_image_ref
+  release_condition_state
+  reason_codes[]
+  validation_commands[]
+  rollback_target
+
+torghut.alpha-repair-release-accounting.v1
+  release_accounting_id
+  generated_at
+  fresh_until
+  selected_queue_code: repair_alpha_readiness
+  selected_value_gate: routeable_candidate_count
+  selected_hypothesis_id
+  active_no_delta_release_key
+  routeable_candidate_count_before
+  routeable_candidate_count_after
+  release_conditions[]
+  selected_repair_ticket
+  reentry_decision: allow | hold | deny
+  max_notional: "0"
+  reason_codes[]
+```
+
+The import board does not authorize capital. It is an evidence bridge between Jangar's material-action authority and
+Torghut's no-delta auction.
+
+### Carry States
+
+- `current`: Jangar witness and board are fresh, source/live image facts agree, and Torghut imported matching refs.
+- `rollout_lagging`: Jangar desired image is ahead of live workload image.
+- `field_absent`: Jangar live status does not emit the required board or witness field.
+- `stale`: imported Jangar fields exist but are expired.
+- `unavailable`: Jangar carry is missing and no more specific state is known.
+- `denied`: Jangar carry is present and explicitly denies material action.
+- `import_mismatch`: Jangar reports a current witness but Torghut imported a different board id, source ref, or stage
+  debt admission ref.
+
+### Release Accounting Rules
+
+Torghut denies alpha repair reentry when:
+
+- active no-delta release key is unchanged;
+- no release condition changed;
+- imported Jangar carry state is `rollout_lagging`, `field_absent`, `stale`, `unavailable`, or `import_mismatch`;
+- selected ticket is missing a required output receipt or validation command;
+- `max_notional` is not `0`.
+
+Torghut holds reentry when:
+
+- Jangar carry state is `denied` but includes a current stage-debt repair admission;
+- Jangar plan or verify debt is active and the selected ticket is Jangar-owned;
+- Torghut can observe a changed release condition but not enough evidence to choose the next zero-notional ticket.
+
+Torghut allows one bounded zero-notional reentry ticket when:
+
+- Jangar carry state is `current`, or the ticket explicitly repairs Jangar carry import;
+- exactly one release condition changed;
+- the selected ticket targets `routeable_candidate_count` or a named prerequisite to the alpha-readiness lane;
+- the ticket cites a required output receipt and validation command;
+- paper and live capital remain denied.
+
+### Release Conditions
+
+The active no-delta key can be released only by one or more of these changes:
+
+- source revenue-repair ref changed;
+- evidence window changed;
+- blocker set changed;
+- required receipt set changed;
+- selected hypothesis changed;
+- Jangar foreclosure-carry rollout witness became current;
+- Jangar stage-debt repair admission selected the carry blocker;
+- schema-lineage receipt became current;
+- empirical receipt became current;
+- market-context receipt became current;
+- execution-TCA receipt became current.
+
+A timer is still not a release condition. Time can expire a lease; it cannot create evidence.
+
+## Implementation Scope
+
+Engineer milestone 1:
+
+- Add `verification_carry_import_board.py` as a pure reducer under `services/torghut/app/trading/`.
+- Feed it from optional Jangar `foreclosure_carry_rollout_witness`, `verify_trust_foreclosure_board`, and
+  `stage_debt_repair_admission` payloads when present in Jangar status or consumer evidence.
+- Expose compact import-board refs on `/trading/revenue-repair`, `/trading/consumer-evidence`, and `/readyz`.
+- Keep enforcement in observe mode and preserve current no-delta denial behavior.
+
+Engineer milestone 2:
+
+- Feed import-board carry state into `no_delta_repair_reentry_auction`.
+- Add release-accounting output that records whether `routeable_candidate_count` changed, stayed no-delta, or was
+  blocked by Jangar carry.
+- Add tests for source-only carry denial, rollout-lagging hold, current carry allow-pricing, stale carry denial,
+  import mismatch, and zero-notional enforcement.
+
+Deployer milestone:
+
+- After Jangar rollout, prove Torghut imports a non-unavailable carry state.
+- Prove duplicate no-delta alpha repair remains denied unless the imported carry or another release condition changes.
+- Prove `/readyz` remains degraded while proof floor is repair-only.
+
+## Validation Gates
+
+Local validation for Torghut implementation:
+
+- `uv run --frozen pytest services/torghut/tests/test_no_delta_repair_reentry_auction.py`
+- `uv run --frozen pytest services/torghut/tests/test_build_revenue_repair_digest.py -k revenue_repair`
+- `uv run --frozen pytest services/torghut/tests/test_consumer_evidence.py -k alpha`
+- `uv run --frozen pytest services/torghut/tests/test_trading_api.py -k no_delta`
+- `ruff check services/torghut/app/trading services/torghut/tests`
+
+Live validation:
+
+- `curl -fsS http://torghut.torghut.svc.cluster.local/trading/revenue-repair | jq '.verification_carry_import_board, .no_delta_repair_reentry_auction.jangar_verification_carry'`
+- `curl -fsS http://torghut.torghut.svc.cluster.local/trading/consumer-evidence | jq '.verification_carry_import_board'`
+- `curl -sS -w '\nHTTP_STATUS:%{http_code}\n' http://torghut.torghut.svc.cluster.local/readyz`
+- `curl -fsS http://agents.agents.svc.cluster.local/ready | jq '.foreclosure_carry_rollout_witness, .verify_trust_foreclosure_board'`
+- `kubectl -n argocd get applications.argoproj.io agents -o json | jq '{sync: .status.sync.status, health: .status.health.status, revision: .status.sync.revision}'`
+
+Acceptance:
+
+- Missing Jangar witness yields `jangar_carry_state=unavailable` or a more specific rollout/field state.
+- Jangar source-only carry does not release alpha repair.
+- Current Jangar carry updates the auction release-condition state.
+- Duplicate no-delta repair remains denied when release conditions are unchanged.
+- Every selected ticket remains `max_notional=0`.
+
+## Rollout
+
+Phase 0 is documentation and tests.
+
+Phase 1 emits `verification_carry_import_board` in observe mode on revenue repair and consumer evidence.
+
+Phase 2 mirrors the compact import state to `/readyz`.
+
+Phase 3 feeds carry state into the existing no-delta auction while preserving deny-on-unknown.
+
+Phase 4 permits one zero-notional ticket only when Jangar carry is current or the selected ticket repairs the carry
+condition.
+
+Phase 5 lets deployer handoff count a Jangar carry fix only when both Jangar status and Torghut import board agree.
+
+## Rollback
+
+Rollback is to stop emitting `verification_carry_import_board` and keep the existing no-delta auction,
+alpha-readiness settlement conveyor, alpha repair dividend ledger, and proof-floor holds.
+
+If the import board falsely denies useful work:
+
+- remove it from auction release-condition scoring;
+- preserve the compact output for debugging;
+- keep duplicate no-delta suppression active;
+- keep `max_notional=0`.
+
+If the import board falsely allows reentry:
+
+- force `jangar_carry_state=denied` unless Jangar witness and board refs are fresh and matching;
+- deny selected tickets until source/live/import refs are reconciled;
+- keep paper and live capital denied.
+
+## Risks
+
+- Risk: Torghut blocks on Jangar for too long. Mitigation: the selected ticket can be a Jangar-stage repair when it
+  directly retires the missing carry condition.
+- Risk: carry schema drift creates false `import_mismatch`. Mitigation: version every payload and keep compact refs
+  backward compatible.
+- Risk: no-delta evidence hides progress on a prerequisite. Mitigation: release accounting records changed
+  prerequisite receipts separately from routeable candidate delta.
+- Risk: operators misread `/readyz` degradation as outage. Mitigation: readiness remains degraded for capital safety,
+  while import-board status explains the actionable blocker.
+
+## Handoff
+
+Engineer next action: implement `torghut.verification-carry-import-board.v1` in observe mode and add tests proving
+that Jangar source-only carry does not release alpha repair, while current imported carry changes the auction
+release-condition state without opening capital.
+
+Deployer next action: after Jangar promotion, prove Torghut imports a non-unavailable Jangar carry state and that
+duplicate no-delta alpha repair remains denied unless a release condition changed.
+
+The smallest blocker preventing revenue impact is current and measurable: `repair_alpha_readiness` remains the top
+queue item, `routeable_candidate_count=0`, the active no-delta key is unchanged, and Jangar verification carry is
+unavailable because live Jangar has not emitted the foreclosure board.

--- a/docs/torghut/design-system/v6/index.md
+++ b/docs/torghut/design-system/v6/index.md
@@ -8,10 +8,12 @@
 - Scope: intraday strategy architecture upgrade beyond static TSMOM, with regime-adaptive routing, DSPy-governed LLM
   reasoning, contamination-safe evaluation, and production rollout controls
 - Implementation status: `Mixed` (historical program closure recorded on `2026-03-03`; source-state refreshed on
-  `2026-03-09`; active proof/capital authority evidence refreshed on `2026-05-14T16:12Z`)
+  `2026-03-09`; active proof/capital authority evidence refreshed on `2026-05-14T16:22Z`)
 - Implementation status (strict, core 01-13 docs, source-state refresh `2026-03-09`): `Implemented=7`, `Partial=5`, `Completed=1`
 - Evidence (historical closure): `13-production-gap-closure-master-plan-2026-03-03.md` (Wave 0-6 closure + DoD)
-- Evidence (current next-work priority, refreshed `2026-05-14T16:12Z`):
+- Evidence (current next-work priority, refreshed `2026-05-14T16:22Z`):
+  - `docs/agents/designs/203-jangar-foreclosure-carry-rollout-witness-and-stage-debt-repair-2026-05-14.md`
+  - `209-torghut-verification-carry-import-and-alpha-repair-release-2026-05-14.md`
   - `208-torghut-jangar-verification-carry-bridge-and-no-delta-reentry-market-2026-05-14.md`
   - `docs/agents/designs/202-jangar-verification-carry-export-and-repair-slot-reconciliation-2026-05-14.md`
   - `207-torghut-quant-plan-closeout-and-alpha-repair-reentry-handoff-2026-05-14.md`


### PR DESCRIPTION
## Summary

- Adds the Jangar foreclosure-carry rollout witness and stage-debt repair architecture contract.
- Adds the Torghut verification-carry import and alpha-repair release companion contract.
- Preserves the concurrent Jangar 202 / Torghut 208 verification-carry bridge docs and layers this PR as 203 / 209.
- Updates Agents and Torghut docs indexes so the new contracts are the current entry points.

## Related Issues

None. Runtime requirement: `jangar-control-plane` discover architecture pass on
`codex/swarm-jangar-control-plane-discover`.

## Testing

- PASS: `bunx oxfmt --check docs/agents/designs/203-jangar-foreclosure-carry-rollout-witness-and-stage-debt-repair-2026-05-14.md docs/torghut/design-system/v6/209-torghut-verification-carry-import-and-alpha-repair-release-2026-05-14.md docs/agents/README.md docs/torghut/README.md docs/torghut/design-system/README.md docs/torghut/design-system/v6/index.md`
- PASS: `bun run --cwd services/jangar docs:inventory:check`
- PASS: `git diff --check origin/main..HEAD`
- PASS: read-only evidence captured from Jangar `/ready`, Jangar control-plane status, Torghut `/readyz`, Torghut
  `/db-check`, Torghut `/trading/revenue-repair`, Kubernetes workload/events, AgentRun inventory, and Argo CD
  Application status.

## Screenshots (if applicable)

N/A.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
