### PR TITLE
fix(torghut): refresh execution tca evidence

### DIFF
--- a/.github/workflows/torghut-deploy-automerge.yml
+++ b/.github/workflows/torghut-deploy-automerge.yml
@@ -57,6 +57,7 @@ jobs:
             'argocd/applications/torghut/analysis-template-teardown-clean.yaml'
             'argocd/applications/torghut/analysis-template-artifact-bundle.yaml'
             'argocd/applications/torghut/empirical-jobs-backfill-job.yaml'
+            'argocd/applications/torghut/execution-tca-refresh-cronjob.yaml'
             'argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml'
             'argocd/applications/torghut-options/catalog/deployment.yaml'
             'argocd/applications/torghut-options/enricher/deployment.yaml'

--- a/.github/workflows/torghut-release.yml
+++ b/.github/workflows/torghut-release.yml
@@ -254,6 +254,7 @@ jobs:
             argocd/applications/torghut/analysis-template-teardown-clean.yaml \
             argocd/applications/torghut/analysis-template-artifact-bundle.yaml \
             argocd/applications/torghut/empirical-jobs-backfill-job.yaml \
+            argocd/applications/torghut/execution-tca-refresh-cronjob.yaml \
             argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml \
             argocd/applications/torghut-options/catalog/deployment.yaml \
             argocd/applications/torghut-options/enricher/deployment.yaml; then
@@ -291,6 +292,7 @@ jobs:
             argocd/applications/torghut/analysis-template-teardown-clean.yaml
             argocd/applications/torghut/analysis-template-artifact-bundle.yaml
             argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+            argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
             argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
             argocd/applications/torghut-options/catalog/deployment.yaml
             argocd/applications/torghut-options/enricher/deployment.yaml
@@ -331,6 +333,7 @@ jobs:
             argocd/applications/torghut/analysis-template-teardown-clean.yaml
             argocd/applications/torghut/analysis-template-artifact-bundle.yaml
             argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+            argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
             argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
             argocd/applications/torghut-options/catalog/deployment.yaml
             argocd/applications/torghut-options/enricher/deployment.yaml

--- a/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+++ b/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
@@ -1,0 +1,46 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: torghut-execution-tca-refresh
+  namespace: torghut
+  labels:
+    app.kubernetes.io/name: torghut
+    app.kubernetes.io/component: execution-tca-refresh
+spec:
+  schedule: "*/10 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 600
+      template:
+        spec:
+          restartPolicy: OnFailure
+          serviceAccountName: torghut-runtime
+          nodeSelector:
+            kubernetes.io/arch: arm64
+          containers:
+            - name: refresh-execution-tca
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:a1df69ef37fd947b19e0fe1e1be0d9c1d3677c6cd23572d79ee88df546c36eef
+              imagePullPolicy: IfNotPresent
+              env:
+                - name: DB_DSN
+                  valueFrom:
+                    secretKeyRef:
+                      name: torghut-db-app
+                      key: uri
+              command:
+                - /bin/bash
+                - -lc
+              args:
+                - |
+                  set -euo pipefail
+                  cd /app
+                  /opt/venv/bin/python scripts/refresh_execution_tca_metrics.py \
+                    --older-than-seconds 900 \
+                    --batch-size 5000 \
+                    --max-batches 3 \
+                    --apply \
+                    --json

--- a/argocd/applications/torghut/kustomization.yaml
+++ b/argocd/applications/torghut/kustomization.yaml
@@ -33,6 +33,7 @@ resources:
   - empirical-artifacts-objectbucketclaim.yaml
   - empirical-jobs-backfill-job.yaml
   - empirical-artifacts-retention-cronjob.yaml
+  - execution-tca-refresh-cronjob.yaml
   - whitepaper-autoresearch-workflowtemplate.yaml
   - empirical-promotion-workflowtemplate.yaml
   - historical-simulation-workflowtemplate.yaml

--- a/packages/scripts/src/torghut/__tests__/update-manifests.test.ts
+++ b/packages/scripts/src/torghut/__tests__/update-manifests.test.ts
@@ -19,6 +19,7 @@ const createFixture = () => {
   const analysisTeardownManifestPath = join(dir, 'analysis-template-teardown-clean.yaml')
   const analysisArtifactManifestPath = join(dir, 'analysis-template-artifact-bundle.yaml')
   const empiricalBackfillManifestPath = join(dir, 'empirical-jobs-backfill-job.yaml')
+  const executionTcaRefreshManifestPath = join(dir, 'execution-tca-refresh-cronjob.yaml')
   const whitepaperSemanticBackfillManifestPath = join(dir, 'whitepaper-semantic-backfill-job.yaml')
   const optionsCatalogManifestPath = join(dir, 'options-catalog-deployment.yaml')
   const optionsEnricherManifestPath = join(dir, 'options-enricher-deployment.yaml')
@@ -93,6 +94,7 @@ spec:
     analysisTeardownManifestPath,
     analysisArtifactManifestPath,
     empiricalBackfillManifestPath,
+    executionTcaRefreshManifestPath,
     whitepaperSemanticBackfillManifestPath,
   ]) {
     writeFileSync(
@@ -142,6 +144,7 @@ spec:
     analysisTeardownManifestPath,
     analysisArtifactManifestPath,
     empiricalBackfillManifestPath,
+    executionTcaRefreshManifestPath,
     whitepaperSemanticBackfillManifestPath,
     optionsCatalogManifestPath,
     optionsEnricherManifestPath,
@@ -210,6 +213,7 @@ describe('update-manifests', () => {
       analysisTeardownManifestPath: relative(repoRoot, fixture.analysisTeardownManifestPath),
       analysisArtifactManifestPath: relative(repoRoot, fixture.analysisArtifactManifestPath),
       empiricalBackfillManifestPath: relative(repoRoot, fixture.empiricalBackfillManifestPath),
+      executionTcaRefreshManifestPath: relative(repoRoot, fixture.executionTcaRefreshManifestPath),
       whitepaperSemanticBackfillManifestPath: relative(repoRoot, fixture.whitepaperSemanticBackfillManifestPath),
       optionsCatalogManifestPath: relative(repoRoot, fixture.optionsCatalogManifestPath),
       optionsEnricherManifestPath: relative(repoRoot, fixture.optionsEnricherManifestPath),
@@ -229,6 +233,7 @@ describe('update-manifests', () => {
     const analysisTeardownManifest = readFileSync(fixture.analysisTeardownManifestPath, 'utf8')
     const analysisArtifactManifest = readFileSync(fixture.analysisArtifactManifestPath, 'utf8')
     const empiricalBackfillManifest = readFileSync(fixture.empiricalBackfillManifestPath, 'utf8')
+    const executionTcaRefreshManifest = readFileSync(fixture.executionTcaRefreshManifestPath, 'utf8')
     const whitepaperSemanticBackfillManifest = readFileSync(fixture.whitepaperSemanticBackfillManifestPath, 'utf8')
     const optionsCatalogManifest = readFileSync(fixture.optionsCatalogManifestPath, 'utf8')
     const optionsEnricherManifest = readFileSync(fixture.optionsEnricherManifestPath, 'utf8')
@@ -261,6 +266,7 @@ describe('update-manifests', () => {
       analysisTeardownManifest,
       analysisArtifactManifest,
       empiricalBackfillManifest,
+      executionTcaRefreshManifest,
       whitepaperSemanticBackfillManifest,
     ]) {
       expect(manifest).toContain(
@@ -278,7 +284,7 @@ describe('update-manifests', () => {
     expect(result.imageRef).toBe(
       'registry.ide-newton.ts.net/lab/torghut@sha256:430763ebeeda8734e1da3ae8c6b665bcc1b380fb815317fffc98371cccea219e',
     )
-    expect(result.changedPaths.length).toBe(14)
+    expect(result.changedPaths.length).toBe(15)
 
     rmSync(fixture.dir, { recursive: true, force: true })
   })
@@ -305,6 +311,7 @@ describe('update-manifests', () => {
       analysisTeardownManifestPath: relative(repoRoot, fixture.analysisTeardownManifestPath),
       analysisArtifactManifestPath: relative(repoRoot, fixture.analysisArtifactManifestPath),
       empiricalBackfillManifestPath: relative(repoRoot, fixture.empiricalBackfillManifestPath),
+      executionTcaRefreshManifestPath: relative(repoRoot, fixture.executionTcaRefreshManifestPath),
       whitepaperSemanticBackfillManifestPath: relative(repoRoot, fixture.whitepaperSemanticBackfillManifestPath),
       optionsCatalogManifestPath: relative(repoRoot, fixture.optionsCatalogManifestPath),
       optionsEnricherManifestPath: relative(repoRoot, fixture.optionsEnricherManifestPath),

--- a/packages/scripts/src/torghut/update-manifests.ts
+++ b/packages/scripts/src/torghut/update-manifests.ts
@@ -24,6 +24,7 @@ const defaultAnalysisActivityManifestPath = 'argocd/applications/torghut/analysi
 const defaultAnalysisTeardownManifestPath = 'argocd/applications/torghut/analysis-template-teardown-clean.yaml'
 const defaultAnalysisArtifactManifestPath = 'argocd/applications/torghut/analysis-template-artifact-bundle.yaml'
 const defaultEmpiricalBackfillManifestPath = 'argocd/applications/torghut/empirical-jobs-backfill-job.yaml'
+const defaultExecutionTcaRefreshManifestPath = 'argocd/applications/torghut/execution-tca-refresh-cronjob.yaml'
 const defaultWhitepaperSemanticBackfillManifestPath =
   'argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml'
 const defaultOptionsCatalogManifestPath = 'argocd/applications/torghut-options/catalog/deployment.yaml'
@@ -48,6 +49,7 @@ type UpdateManifestsOptions = {
   analysisTeardownManifestPath?: string
   analysisArtifactManifestPath?: string
   empiricalBackfillManifestPath?: string
+  executionTcaRefreshManifestPath?: string
   whitepaperSemanticBackfillManifestPath?: string
   optionsCatalogManifestPath?: string
   optionsEnricherManifestPath?: string
@@ -72,6 +74,7 @@ type CliOptions = {
   analysisTeardownManifestPath?: string
   analysisArtifactManifestPath?: string
   empiricalBackfillManifestPath?: string
+  executionTcaRefreshManifestPath?: string
   whitepaperSemanticBackfillManifestPath?: string
   optionsCatalogManifestPath?: string
   optionsEnricherManifestPath?: string
@@ -293,6 +296,11 @@ const updateTorghutManifests = (options: UpdateManifestsOptions) => {
     options.empiricalBackfillManifestPath ?? defaultEmpiricalBackfillManifestPath,
     'torghut-empirical-jobs-backfill image reference',
   )
+  const executionTcaRefresh = updateImageOnlyManifest(
+    options,
+    options.executionTcaRefreshManifestPath ?? defaultExecutionTcaRefreshManifestPath,
+    'torghut-execution-tca-refresh image reference',
+  )
   const whitepaperSemanticBackfill = updateImageOnlyManifest(
     options,
     options.whitepaperSemanticBackfillManifestPath ?? defaultWhitepaperSemanticBackfillManifestPath,
@@ -326,6 +334,7 @@ const updateTorghutManifests = (options: UpdateManifestsOptions) => {
     analysisTeardown,
     analysisArtifact,
     empiricalBackfill,
+    executionTcaRefresh,
     whitepaperSemanticBackfill,
     optionsCatalog,
     optionsEnricher,
@@ -366,6 +375,7 @@ Options:
   --analysis-teardown-manifest-path <path>
   --analysis-artifact-manifest-path <path>
   --empirical-backfill-manifest-path <path>
+  --execution-tca-refresh-manifest-path <path>
   --whitepaper-semantic-backfill-manifest-path <path>
   --options-catalog-manifest-path <path>
   --options-enricher-manifest-path <path>`)
@@ -440,6 +450,9 @@ Options:
       case '--empirical-backfill-manifest-path':
         options.empiricalBackfillManifestPath = value
         break
+      case '--execution-tca-refresh-manifest-path':
+        options.executionTcaRefreshManifestPath = value
+        break
       case '--whitepaper-semantic-backfill-manifest-path':
         options.whitepaperSemanticBackfillManifestPath = value
         break
@@ -500,6 +513,8 @@ const main = (cliOptions?: CliOptions) => {
       parsed.analysisArtifactManifestPath ?? process.env.TORGHUT_ANALYSIS_ARTIFACT_MANIFEST_PATH,
     empiricalBackfillManifestPath:
       parsed.empiricalBackfillManifestPath ?? process.env.TORGHUT_EMPIRICAL_BACKFILL_MANIFEST_PATH,
+    executionTcaRefreshManifestPath:
+      parsed.executionTcaRefreshManifestPath ?? process.env.TORGHUT_EXECUTION_TCA_REFRESH_MANIFEST_PATH,
     whitepaperSemanticBackfillManifestPath:
       parsed.whitepaperSemanticBackfillManifestPath ?? process.env.TORGHUT_WHITEPAPER_SEMANTIC_BACKFILL_MANIFEST_PATH,
     optionsCatalogManifestPath: parsed.optionsCatalogManifestPath ?? process.env.TORGHUT_OPTIONS_CATALOG_MANIFEST_PATH,

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -558,6 +558,52 @@ class TestLiveConfigManifestContract(TestCase):
             {"kubernetes.io/arch": "arm64"},
         )
 
+    def test_execution_tca_refresh_cronjob_keeps_readiness_evidence_fresh(
+        self,
+    ) -> None:
+        manifest = _load_yaml_mapping(
+            "argocd/applications/torghut/execution-tca-refresh-cronjob.yaml"
+        )
+        spec = cast(Mapping[str, object], manifest.get("spec", {}))
+        job_template = cast(Mapping[str, object], spec.get("jobTemplate", {}))
+        job_spec = cast(Mapping[str, object], job_template.get("spec", {}))
+        template = cast(Mapping[str, object], job_spec.get("template", {}))
+        pod_spec = cast(Mapping[str, object], template.get("spec", {}))
+        containers = cast(list[Mapping[str, object]], pod_spec.get("containers", []))
+
+        self.assertEqual(spec.get("schedule"), "*/10 * * * *")
+        self.assertEqual(spec.get("concurrencyPolicy"), "Forbid")
+        self.assertEqual(job_spec.get("activeDeadlineSeconds"), 600)
+        self.assertEqual(pod_spec.get("serviceAccountName"), "torghut-runtime")
+        self.assertEqual(
+            pod_spec.get("nodeSelector"),
+            {"kubernetes.io/arch": "arm64"},
+        )
+        self.assertTrue(containers)
+
+        container = containers[0]
+        self.assertIn(
+            "registry.ide-newton.ts.net/lab/torghut@sha256:",
+            str(container.get("image")),
+        )
+        env = {
+            item.get("name"): item
+            for item in cast(list[Mapping[str, object]], container.get("env", []))
+        }
+        db_dsn = cast(Mapping[str, object], env["DB_DSN"])
+        value_from = cast(Mapping[str, object], db_dsn.get("valueFrom", {}))
+        self.assertEqual(
+            value_from.get("secretKeyRef"),
+            {"name": "torghut-db-app", "key": "uri"},
+        )
+
+        args = "\n".join(str(item) for item in container.get("args", []))
+        self.assertIn("scripts/refresh_execution_tca_metrics.py", args)
+        self.assertIn("--older-than-seconds 900", args)
+        self.assertIn("--batch-size 5000", args)
+        self.assertIn("--max-batches 3", args)
+        self.assertIn("--apply", args)
+
     def test_migration_job_prepares_sim_database_before_sim_upgrade(self) -> None:
         manifest = _load_yaml_mapping(
             "argocd/applications/torghut/db-migrations-job.yaml"


### PR DESCRIPTION
## Summary

- Adds a GitOps CronJob that refreshes materialized `execution_tca_metrics` every 10 minutes before the 30-minute live-readiness stale-evidence gate trips.
- Wires the Torghut release manifest updater and deploy automerge allowlist so future promoted images keep the refresh CronJob on the same digest as the live service.
- Adds manifest contract coverage for the CronJob schedule, runtime service account, arm64 placement, database secret, bounded refresh command, and release updater image propagation.

## Related Issues

None

## Testing

- `git diff --check`
- `bun test packages/scripts/src/torghut/__tests__/update-manifests.test.ts`
- `uv run --frozen pytest tests/test_live_config_manifest_contract.py -k 'execution_tca_refresh or whitepaper_semantic_backfill or migration_job'`
- `uv run --frozen pytest tests/test_live_config_manifest_contract.py`
- `uv run --frozen ruff check tests/test_live_config_manifest_contract.py`
- `uv run --frozen ruff format --check tests/test_live_config_manifest_contract.py`
- `bun run lint:argocd`
- `bun run --filter @proompteng/scripts lint`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
