### PR TITLE
chore(torghut): promote image 11fc39b0

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:ae88bacb3a3e05be7da1f55690476e4e35d059ab6f749370184d1fa333091794
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:0ce192ddc9ab5386f4d39f7cac8cb20a937f1fa6891d129b1964a15116d383ae
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.569.1-426-gdf84e7417
+              value: v0.569.1-430-g11fc39b07
             - name: TORGHUT_OPTIONS_COMMIT
-              value: df84e741720c98447b4548906040bcdf6a829b6e
+              value: 11fc39b072a01528a0d4234146095113db5aa23e
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:ae88bacb3a3e05be7da1f55690476e4e35d059ab6f749370184d1fa333091794
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:0ce192ddc9ab5386f4d39f7cac8cb20a937f1fa6891d129b1964a15116d383ae
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.569.1-426-gdf84e7417
+              value: v0.569.1-430-g11fc39b07
             - name: TORGHUT_OPTIONS_COMMIT
-              value: df84e741720c98447b4548906040bcdf6a829b6e
+              value: 11fc39b072a01528a0d4234146095113db5aa23e
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:ae88bacb3a3e05be7da1f55690476e4e35d059ab6f749370184d1fa333091794
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:0ce192ddc9ab5386f4d39f7cac8cb20a937f1fa6891d129b1964a15116d383ae
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:ae88bacb3a3e05be7da1f55690476e4e35d059ab6f749370184d1fa333091794
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:0ce192ddc9ab5386f4d39f7cac8cb20a937f1fa6891d129b1964a15116d383ae
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:ae88bacb3a3e05be7da1f55690476e4e35d059ab6f749370184d1fa333091794
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:0ce192ddc9ab5386f4d39f7cac8cb20a937f1fa6891d129b1964a15116d383ae
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:ae88bacb3a3e05be7da1f55690476e4e35d059ab6f749370184d1fa333091794
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:0ce192ddc9ab5386f4d39f7cac8cb20a937f1fa6891d129b1964a15116d383ae
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:ae88bacb3a3e05be7da1f55690476e4e35d059ab6f749370184d1fa333091794
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:0ce192ddc9ab5386f4d39f7cac8cb20a937f1fa6891d129b1964a15116d383ae
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -15,7 +15,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:ae88bacb3a3e05be7da1f55690476e4e35d059ab6f749370184d1fa333091794
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:0ce192ddc9ab5386f4d39f7cac8cb20a937f1fa6891d129b1964a15116d383ae
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -23,7 +23,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:ae88bacb3a3e05be7da1f55690476e4e35d059ab6f749370184d1fa333091794
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:0ce192ddc9ab5386f4d39f7cac8cb20a937f1fa6891d129b1964a15116d383ae
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+++ b/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
@@ -23,7 +23,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: refresh-execution-tca
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:a1df69ef37fd947b19e0fe1e1be0d9c1d3677c6cd23572d79ee88df546c36eef
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:0ce192ddc9ab5386f4d39f7cac8cb20a937f1fa6891d129b1964a15116d383ae
               imagePullPolicy: IfNotPresent
               env:
                 - name: DB_DSN

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:ae88bacb3a3e05be7da1f55690476e4e35d059ab6f749370184d1fa333091794
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:0ce192ddc9ab5386f4d39f7cac8cb20a937f1fa6891d129b1964a15116d383ae
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-14T16:19:22Z"
+        client.knative.dev/updateTimestamp: "2026-05-14T16:33:17Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -27,7 +27,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:ae88bacb3a3e05be7da1f55690476e4e35d059ab6f749370184d1fa333091794
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:0ce192ddc9ab5386f4d39f7cac8cb20a937f1fa6891d129b1964a15116d383ae
           ports:
             - name: http1
               containerPort: 8181
@@ -482,11 +482,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.569.1-426-gdf84e7417
+              value: v0.569.1-430-g11fc39b07
             - name: TORGHUT_COMMIT
-              value: df84e741720c98447b4548906040bcdf6a829b6e
+              value: 11fc39b072a01528a0d4234146095113db5aa23e
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:ae88bacb3a3e05be7da1f55690476e4e35d059ab6f749370184d1fa333091794
+              value: sha256:0ce192ddc9ab5386f4d39f7cac8cb20a937f1fa6891d129b1964a15116d383ae
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-14T16:19:22Z"
+        client.knative.dev/updateTimestamp: "2026-05-14T16:33:17Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:ae88bacb3a3e05be7da1f55690476e4e35d059ab6f749370184d1fa333091794
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:0ce192ddc9ab5386f4d39f7cac8cb20a937f1fa6891d129b1964a15116d383ae
           ports:
             - name: http1
               containerPort: 8181
@@ -306,11 +306,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.569.1-426-gdf84e7417
+              value: v0.569.1-430-g11fc39b07
             - name: TORGHUT_COMMIT
-              value: df84e741720c98447b4548906040bcdf6a829b6e
+              value: 11fc39b072a01528a0d4234146095113db5aa23e
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:ae88bacb3a3e05be7da1f55690476e4e35d059ab6f749370184d1fa333091794
+              value: sha256:0ce192ddc9ab5386f4d39f7cac8cb20a937f1fa6891d129b1964a15116d383ae
           livenessProbe:
             httpGet:
               path: /healthz

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -98,7 +98,7 @@ spec:
           - name: allowStaleTape
           - name: persistResults
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:ae88bacb3a3e05be7da1f55690476e4e35d059ab6f749370184d1fa333091794
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:0ce192ddc9ab5386f4d39f7cac8cb20a937f1fa6891d129b1964a15116d383ae
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
+++ b/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:ae88bacb3a3e05be7da1f55690476e4e35d059ab6f749370184d1fa333091794
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:0ce192ddc9ab5386f4d39f7cac8cb20a937f1fa6891d129b1964a15116d383ae
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `11fc39b072a01528a0d4234146095113db5aa23e`
- Image tag: `11fc39b0`
- Image digest: `sha256:0ce192ddc9ab5386f4d39f7cac8cb20a937f1fa6891d129b1964a15116d383ae`