### PR TITLE
fix(torghut): bound tca refresh cron

### DIFF
--- a/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+++ b/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
@@ -7,14 +7,14 @@ metadata:
     app.kubernetes.io/name: torghut
     app.kubernetes.io/component: execution-tca-refresh
 spec:
-  schedule: "*/10 * * * *"
+  schedule: "*/5 * * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 2
   failedJobsHistoryLimit: 3
   jobTemplate:
     spec:
       backoffLimit: 1
-      activeDeadlineSeconds: 600
+      activeDeadlineSeconds: 240
       template:
         spec:
           restartPolicy: OnFailure
@@ -40,7 +40,7 @@ spec:
                   cd /app
                   /opt/venv/bin/python scripts/refresh_execution_tca_metrics.py \
                     --older-than-seconds 900 \
-                    --batch-size 5000 \
-                    --max-batches 3 \
+                    --batch-size 250 \
+                    --max-batches 1 \
                     --apply \
                     --json

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -571,9 +571,9 @@ class TestLiveConfigManifestContract(TestCase):
         pod_spec = cast(Mapping[str, object], template.get("spec", {}))
         containers = cast(list[Mapping[str, object]], pod_spec.get("containers", []))
 
-        self.assertEqual(spec.get("schedule"), "*/10 * * * *")
+        self.assertEqual(spec.get("schedule"), "*/5 * * * *")
         self.assertEqual(spec.get("concurrencyPolicy"), "Forbid")
-        self.assertEqual(job_spec.get("activeDeadlineSeconds"), 600)
+        self.assertEqual(job_spec.get("activeDeadlineSeconds"), 240)
         self.assertEqual(pod_spec.get("serviceAccountName"), "torghut-runtime")
         self.assertEqual(
             pod_spec.get("nodeSelector"),
@@ -600,8 +600,8 @@ class TestLiveConfigManifestContract(TestCase):
         args = "\n".join(str(item) for item in container.get("args", []))
         self.assertIn("scripts/refresh_execution_tca_metrics.py", args)
         self.assertIn("--older-than-seconds 900", args)
-        self.assertIn("--batch-size 5000", args)
-        self.assertIn("--max-batches 3", args)
+        self.assertIn("--batch-size 250", args)
+        self.assertIn("--max-batches 1", args)
         self.assertIn("--apply", args)
 
     def test_migration_job_prepares_sim_database_before_sim_upgrade(self) -> None:


### PR DESCRIPTION
## Summary

- Tightens the execution TCA refresh CronJob after the first natural run exceeded its 600-second deadline in-cluster.
- Changes the refresh to a 5-minute cadence with one 250-row slice and a 240-second job deadline, keeping freshness moving without monopolizing the Torghut database.
- Updates the manifest contract test so the bounded schedule, deadline, batch size, and max-batch count stay enforced.

## Related Issues

None

## Testing

- `git diff --check`
- `uv run --frozen pytest tests/test_live_config_manifest_contract.py -k execution_tca_refresh`
- `uv run --frozen pytest tests/test_live_config_manifest_contract.py`
- `uv run --frozen ruff check tests/test_live_config_manifest_contract.py`
- `uv run --frozen ruff format --check tests/test_live_config_manifest_contract.py`
- `bun run lint:argocd`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
