### PR TITLE
docs(jangar): define controller ingestion carry cutover

### DIFF
--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -19,6 +19,8 @@ clear entrypoints, clear “source of truth”, and a complete catalog of relate
 - Autonomous Jangar/Torghut production system design: `designs/autonomous-jangar-torghut-production-system.md`
 - Swarm agentic mission architecture notes: `designs/swarm-agentic-mission-architecture-2026-05-08.md`
 - Current Jangar/Torghut architecture contracts:
+  - `designs/205-jangar-controller-ingestion-settlement-and-verification-carry-cutover-2026-05-14.md`
+  - `../torghut/design-system/v6/211-torghut-controller-ingestion-carry-and-alpha-no-delta-release-2026-05-14.md`
   - `designs/204-jangar-source-bound-verification-carry-exchange-and-repair-slot-reconciliation-2026-05-14.md`
   - `../torghut/design-system/v6/210-torghut-source-bound-verification-carry-import-and-no-delta-release-2026-05-14.md`
   - `designs/203-jangar-foreclosure-carry-rollout-witness-and-stage-debt-repair-2026-05-14.md`

--- a/docs/agents/designs/205-jangar-controller-ingestion-settlement-and-verification-carry-cutover-2026-05-14.md
+++ b/docs/agents/designs/205-jangar-controller-ingestion-settlement-and-verification-carry-cutover-2026-05-14.md
@@ -1,0 +1,445 @@
+# 205. Jangar Controller-Ingestion Settlement And Verification-Carry Cutover (2026-05-14)
+
+Status: Accepted for engineer and deployer handoff
+Date: 2026-05-14
+Owner: Victor Chen, Jangar Engineering Architecture
+Scope: Jangar controller-ingestion settlement, verification-carry cutover, stage-clearance repair admission, Torghut
+no-delta release conditions, validation, rollout, rollback, and cross-swarm handoff.
+
+Companion Torghut contract:
+
+- `docs/torghut/design-system/v6/211-torghut-controller-ingestion-carry-and-alpha-no-delta-release-2026-05-14.md`
+
+Extends:
+
+- `204-jangar-source-bound-verification-carry-exchange-and-repair-slot-reconciliation-2026-05-14.md`
+- `../torghut/design-system/v6/210-torghut-source-bound-verification-carry-import-and-no-delta-release-2026-05-14.md`
+- `203-jangar-foreclosure-carry-rollout-witness-and-stage-debt-repair-2026-05-14.md`
+- `202-jangar-verification-carry-export-and-repair-slot-reconciliation-2026-05-14.md`
+- `201-jangar-verify-trust-foreclosure-and-alpha-repair-reentry-2026-05-14.md`
+- `200-jangar-revenue-repair-settlement-conveyor-and-stage-health-custody-2026-05-14.md`
+- `188-jangar-ready-truth-arbiter-and-stage-credit-cutover-2026-05-13.md`
+- `116-jangar-controller-witness-quorum-and-capital-activation-receipts-2026-05-06.md`
+
+## Decision
+
+I am selecting a **controller-ingestion settlement with verification-carry cutover** as the next Jangar
+control-plane architecture increment.
+
+The live system is serving, but it is not materially coherent. On 2026-05-14 at 16:42-16:43Z, `agents`,
+`agents-controllers`, and `jangar` deployments were ready. Argo reported `jangar` and `torghut` as `Synced/Healthy`.
+The `agents` application was `OutOfSync/Healthy`, and `/ready` returned `status=ok`. That is serving truth.
+
+Material authority told a different story. `/api/agents/control-plane/status?namespace=agents` reported healthy
+database connectivity and migration consistency, but `execution_trust.status=degraded`, `stage_clearance` held normal
+dispatch and merge actions, `verify_trust_foreclosure_board=null`, `repair_slot_escrow=null`, and controller witness
+decision `repair_only` because the controller deployment and watch epoch were current while the AgentRun ingestion
+self-report was not current. The same window showed Jangar/Torghut swarm pods with real failure debt: Jangar verify had
+12 error terminations since midnight, Jangar plan had 3 OOMKilled attempts, Torghut plan had 7 errors and 1 OOMKilled,
+and Torghut verify had 8 errors and 1 OOMKilled.
+
+Torghut is now blocked on the same boundary. `/trading/revenue-repair` returned `business_state=repair_only`, top
+queue `repair_alpha_readiness`, value gate `routeable_candidate_count`, selected lane `H-MICRO-01`, measured
+routeable-candidate delta `0`, and a no-delta reentry auction with `jangar_verification_carry_unavailable`. Torghut is
+correctly denying duplicate alpha repair, but it cannot distinguish "Jangar source has carry code" from "the live
+Jangar control plane can prove carry and ingestion."
+
+The selected design adds one explicit settlement object: `jangar.controller-ingestion-settlement.v1`. It joins the
+controller-process witness, Kubernetes deployment witness, watch-epoch witness, AgentRun ingestion witness, execution
+trust, source-to-live carry field presence, and Torghut verification-carry import state. It then produces a compact
+decision for stage clearance:
+
+- `allow` only when controller ingestion, watch, deployment, database, and verification carry agree;
+- `repair_only` when one bounded repair can plausibly make the missing witness current;
+- `hold` when the system is serving but broad work would spend capacity on stale or missing authority;
+- `block` when the evidence is contradictory or unsafe for capital-adjacent actions.
+
+The tradeoff is intentional. Some repair work will stay held even while pods are ready and the UI is usable. I accept
+that because the business metric is fewer failed AgentRuns and faster green PR-to-healthy GitOps rollout. Another broad
+repair run does not help when the next missing proof is a controller ingestion witness and a live verification-carry
+field.
+
+## Governing Runtime Requirements
+
+This contract implements the active swarm validation contract:
+
+- every run must cite the governing design or runtime requirement before changing code;
+- implement stages must produce production PRs with tests or report the exact blocker to code;
+- verify stages must merge only green PRs and prove Argo, workload readiness, and service health after rollout;
+- final handoff must name the control-plane metric improved or the smallest blocker preventing improvement.
+
+Value-gate mapping:
+
+- `failed_agentrun_rate`: do not create another normal dispatch, verify, or no-delta alpha repair run while the
+  controller ingestion witness is missing and the same release key is still active.
+- `pr_to_rollout_latency`: make source-to-live carry lag explicit with source SHA, desired image, live image, field
+  presence, Argo state, and Torghut import result.
+- `ready_status_truth`: keep `/ready.status=ok` as serving truth while material actions use the settlement decision.
+- `manual_intervention_count`: replace manual comparison of controller logs, status payloads, Argo, and Torghut
+  no-delta output with one settlement packet.
+- `handoff_evidence_quality`: require engineer and deployer handoffs to cite settlement id, decision, reason codes,
+  validation commands, and rollback target.
+
+Torghut value-gate mapping:
+
+- `routeable_candidate_count`: H-MICRO-01 alpha repair remains denied until a Jangar verification-carry release
+  condition changes or a bounded Jangar carry repair ticket is selected.
+- `zero_notional_or_stale_evidence_rate`: stale or unavailable Jangar carry remains no-delta denial evidence.
+- `fill_tca_or_slippage_quality`: TCA work cannot overtake the top alpha-readiness queue unless its release condition
+  is the selected ticket.
+- `post_cost_daily_net_pnl`: no paper or live capital follows from this cutover.
+- `capital_gate_safety`: all work remains `max_notional=0`.
+
+## Current Evidence
+
+All evidence below was collected read-only on 2026-05-14. I did not mutate Kubernetes resources, database records,
+GitOps resources, AgentRuns, trading flags, broker state, or market data.
+
+### Cluster, Rollout, And Events
+
+- `agents` deployment was `1/1`, `agents-controllers` was `2/2`, and `jangar` was `1/1`.
+- `agents` ran image `registry.ide-newton.ts.net/lab/jangar-control-plane:0f963a1d` with digest
+  `sha256:41c2cec100cf819712a64e39b504a965dd34a1519d90b14c23905e259a512e21`.
+- `agents-controllers` ran image `registry.ide-newton.ts.net/lab/jangar:0f963a1d` with digest
+  `sha256:3e0cc409faa2445769ad05266674ee0c370ef07be8b11d78a295974f20828e11`.
+- Argo reported `agents=OutOfSync/Healthy`, `jangar=Synced/Healthy`, and `torghut=Synced/Healthy` at revision
+  `7f5a659ded3eeac1538ec4cbd90605112ce38910`.
+- Since midnight UTC, Jangar/Torghut swarm pods included:
+  - `jangar-control-plane-plan`: 10 pods, 6 completed, 3 OOMKilled, 1 running;
+  - `jangar-control-plane-verify`: 22 pods, 10 completed, 12 error;
+  - `torghut-quant-plan`: 15 pods, 6 completed, 7 error, 1 OOMKilled, 1 running;
+  - `torghut-quant-verify`: 22 pods, 13 completed, 8 error, 1 OOMKilled.
+- The current worker identity can list deployments, pods, AgentRuns, and Argo applications, but CNPG cluster reads and
+  direct Postgres exec are blocked by RBAC. That is acceptable and should remain true for normal swarm workers.
+
+### Jangar Control-Plane Evidence
+
+- `/ready` returned `status=ok`, leader election active, `business_state=repair_only`, `revenue_ready=false`, and
+  top repair `repair_alpha_readiness`.
+- `/ready.execution_trust.status=degraded` because verify was stale or recently failing.
+- `/api/agents/control-plane/status?namespace=agents` returned database `healthy`, latency `227ms`, migration
+  consistency `registered_count=29`, `applied_count=29`, `unapplied_count=0`, `unexpected_count=0`, latest migration
+  `20260508_torghut_quant_pipeline_health_account_window_created_at_index`.
+- Status stage clearance allowed `serve_readonly`, allowed `torghut_observe`, made `repair` `repair_only`, and held
+  discover, plan, implement, verify, deploy, and merge-ready actions.
+- Controller witness decision was `repair_only` with `controller_witness_split`; deployment and watch epoch witnesses
+  were current, but the AgentRun ingestion witness reported `controller_ingestion_unknown`.
+- `verify_trust_foreclosure_board` and `repair_slot_escrow` were null on status and `/ready`.
+- Material gate digest denied `dispatch_repair` because alpha closure no-delta budget was consumed and debt was active.
+
+### Torghut Business And Data Evidence
+
+- `/trading/revenue-repair` returned `business_state=repair_only` with top repair `repair_alpha_readiness`,
+  reason `alpha_readiness_not_promotion_eligible`, required receipt `torghut.executable-alpha-receipts.v1`,
+  value gate `routeable_candidate_count`, and `max_notional=0`.
+- The selected alpha-readiness settlement lane was `H-MICRO-01`, strategy
+  `microbar_volume_continuation_long_top2_chip_v1@paper`, lane `microstructure-breakout`, and measured
+  routeable-candidate delta `0`.
+- `no_delta_repair_reentry_auction.reentry_decision=deny` with reason codes:
+  `active_no_delta_release_key`, `no_release_condition_changed`,
+  `zero_notional_reentry_ticket_not_selected`, `jangar_verification_carry_unavailable`, and
+  `duplicate_no_delta_reentry_denied`.
+- Torghut `/db-check` returned `ok=true`, `schema_current=true`, current and expected Alembic head
+  `0031_autoresearch_candidate_spec_epoch_uniqueness`, no missing heads, no unexpected heads, and
+  `schema_graph_lineage_ready=true`. It still reported known historical parent-fork warnings, so Jangar should trust
+  application-level lineage receipts rather than infer route readiness from the head alone.
+
+### Source And Test Surface
+
+- Jangar has 65 top-level `control-plane-*.ts` server modules and 35 matching control-plane test files.
+- High-risk integration points are:
+  - `services/jangar/src/server/control-plane-status.ts`, which assembles the status truth surface;
+  - `services/jangar/src/routes/ready.tsx`, which serves a hot-path subset;
+  - `services/jangar/src/server/control-plane-controller-witness.ts`, which produces the split witness;
+  - `services/jangar/src/server/control-plane-verify-trust-foreclosure.ts`, whose source exists but live payload is
+    absent;
+  - `services/jangar/src/server/control-plane-stage-clearance.ts`, which holds or admits stages.
+- Existing tests cover controller witness, stage clearance, ready truth, revenue repair custody, material gate digest,
+  verify trust foreclosure, and status assembly. The missing test family is cross-surface controller-ingestion
+  settlement: current ingestion allow, missing ingestion repair-only, source-live carry missing hold, Torghut import
+  unavailable hold, and contradiction block.
+
+## Problem
+
+Jangar currently has separate claims for serving health, controller deployment health, watch health, AgentRun ingestion,
+verification-carry source code, stage clearance, and Torghut no-delta release state. The system does not yet settle
+them into one admission object.
+
+The concrete failure modes are:
+
+1. `/ready.status=ok` can be read as material readiness even when stage clearance holds normal work.
+2. Argo `Healthy` can hide `OutOfSync` source-to-live lag for the agents control plane.
+3. A controller deployment and watch epoch can be current while the AgentRun ingestion self-report is unknown.
+4. Source can contain verification-carry logic while live status still returns null fields.
+5. Torghut can deny duplicate alpha repair but cannot price whether Jangar carry is unavailable, stale, lagging, or
+   repaired.
+6. Plan and verify failures can accumulate while broad implement or repair runs keep launching against the same
+   unresolved authority split.
+
+The control plane needs an additive settlement object that turns these claims into one bounded action decision.
+
+## Alternatives Considered
+
+### Option A: Wait For Argo Convergence And Keep Existing Gates
+
+This option treats the current split as transient. Engineers and deployers keep checking Argo, `/ready`, and Torghut
+manually until the carry fields appear.
+
+Advantages:
+
+- No new reducer.
+- Lowest immediate implementation effort.
+- Avoids changing schedule admission behavior.
+
+Disadvantages:
+
+- It does not reduce failed AgentRuns while waiting.
+- It leaves humans to compare Argo, images, status payloads, and Torghut release conditions.
+- It gives Torghut no structured release condition beyond `jangar_verification_carry_unavailable`.
+- It repeats the same failure class documented in design 203.
+
+Decision: reject as architecture. Convergence remains a deployer action, but it is not a control-plane contract.
+
+### Option B: Hard Freeze Normal And Repair Dispatch Until All Witnesses Are Current
+
+This option blocks all material work whenever controller ingestion, execution trust, source rollout, or Torghut no-delta
+state is degraded.
+
+Advantages:
+
+- Strong failure-rate reduction.
+- Easy operator rule.
+- Prevents stale retries.
+
+Disadvantages:
+
+- Blocks the bounded zero-notional work needed to repair the missing witness.
+- Turns every witness gap into manual intervention.
+- Does not distinguish safe `serve_readonly` and `torghut_observe` from capital actions.
+- Cannot clear `jangar_verification_carry_unavailable` without a named repair lane.
+
+Decision: reject as steady state. Keep it as an emergency brake for contradictory or unsafe evidence.
+
+### Option C: Controller-Ingestion Settlement With Verification-Carry Cutover
+
+This selected option emits a settlement object that names the missing witness and allows one bounded repair ticket when
+the repair can directly close the gap. Everything else stays held or blocked.
+
+Advantages:
+
+- Targets the actual live split.
+- Preserves serving availability while hardening material action authority.
+- Gives Torghut a stable Jangar carry state and release condition.
+- Reduces manual synthesis in deployer handoffs.
+- Converts PR-to-rollout lag and controller ingestion debt into measurable evidence.
+
+Disadvantages:
+
+- Adds one reducer and one companion Torghut import contract.
+- Requires careful test coverage to avoid false holds.
+- Can initially hold useful repairs until the settlement object is emitted.
+
+Decision: select Option C.
+
+## Architecture
+
+Jangar emits `controller_ingestion_settlement` from control-plane status and, once proven cheap enough, from `/ready`.
+The object is additive and observe-mode first.
+
+Proposed schema:
+
+```yaml
+schema_version: jangar.controller-ingestion-settlement.v1
+settlement_id: controller-ingestion-settlement:<namespace>:<digest>
+mode: observe|shadow|enforce
+generated_at: <iso8601>
+fresh_until: <iso8601>
+namespace: agents
+decision: allow|repair_only|hold|block
+serving_readiness: ok|degraded|unknown
+controller_witness_ref: <controller-witness id>
+controller_witness_decision: allow|repair_only|hold_material|block
+deployment_available: true|false
+watch_epoch_current: true|false
+controller_self_report_current: true|false
+agentrun_ingestion_current: true|false
+execution_trust_status: healthy|degraded|unknown|blocked
+verify_trust_foreclosure_board_ref: <id|null>
+repair_slot_escrow_ref: <id|null>
+torghut_verification_carry_status: current|lagging|unavailable|stale|unknown
+selected_repair_ticket:
+  ticket_class: controller_ingestion|verification_carry_rollout|none
+  max_parallelism: 1
+  max_notional: '0'
+  validation_commands: []
+reason_codes: []
+evidence_refs: []
+rollback_target: <string>
+```
+
+Decision rules:
+
+1. `allow`: deployment, watch epoch, controller self-report, AgentRun ingestion, database, and execution trust are
+   current; verification-carry fields are present; Torghut import is current or not required.
+2. `repair_only`: one witness is missing or stale, the repair ticket targets that witness, and no contradictory
+   evidence exists.
+3. `hold`: serving is healthy but broad dispatch would not repair the missing witness, or source-to-live carry is
+   absent.
+4. `block`: evidence is contradictory, stale beyond the repair window, or would affect paper/live capital.
+
+Stage-clearance consumption:
+
+- `serve_readonly`: allowed when serving readiness and database read health are acceptable.
+- `torghut_observe`: allowed when Torghut evidence routes are reachable and max notional is zero.
+- `dispatch_repair`: repair-only only for the selected settlement ticket; denied for duplicate no-delta alpha repair.
+- `dispatch_normal`, `deploy_widen`, and `merge_ready`: held until settlement is `allow`.
+- `paper_canary`, `live_micro_canary`, and `live_scale`: held or blocked until Torghut proof floor and capital safety
+  are explicit.
+
+Torghut consumption:
+
+- Torghut imports `controller_ingestion_settlement` as part of `jangar_verification_carry`.
+- `jangar_verification_carry_unavailable` remains a no-delta denial until the settlement is `allow` or a selected
+  Jangar carry repair ticket is current.
+- Torghut must not treat a source SHA, Argo health, or serving `/ready` alone as enough to release no-delta debt.
+
+## Implementation Scope
+
+Milestone 1: Jangar settlement read model.
+
+- Add `control-plane-controller-ingestion-settlement.ts`.
+- Wire it into `control-plane-status.ts` in observe mode.
+- Add focused tests for allow, repair-only, hold, block, and Torghut carry unavailable.
+- Value gates: `ready_status_truth`, `handoff_evidence_quality`, `manual_intervention_count`.
+
+Milestone 2: stage-clearance consumption.
+
+- Feed the settlement into `control-plane-stage-clearance.ts` behind a config flag.
+- Stamp settlement refs into supporting schedule-runner handoff parameters.
+- Add tests proving broad dispatch is held while the selected repair ticket is allowed.
+- Value gates: `failed_agentrun_rate`, `manual_intervention_count`.
+
+Milestone 3: Torghut carry import.
+
+- Extend Torghut no-delta reentry import to classify Jangar carry as `current`, `lagging`, `unavailable`, or `stale`.
+- Require the Jangar settlement receipt before selecting any `jangar_verify_carry` release ticket.
+- Keep all selected tickets zero-notional.
+- Value gates: `routeable_candidate_count`, `zero_notional_or_stale_evidence_rate`, `capital_gate_safety`.
+
+Milestone 4: deployer proof and cutover.
+
+- Deployer must prove PR, source SHA, desired image, live image, Argo state, workload readiness, `/ready`, status,
+  controller settlement, Torghut revenue-repair, and Torghut carry import before marking the lane healthy.
+- Value gates: `pr_to_rollout_latency`, `handoff_evidence_quality`, `ready_status_truth`.
+
+## Validation Gates
+
+Local engineer validation:
+
+- `bun run --filter jangar test -- src/server/__tests__/control-plane-controller-ingestion-settlement.test.ts`
+- `bun run --filter jangar test -- src/server/__tests__/control-plane-status.test.ts`
+- `bun run --filter jangar test -- src/server/__tests__/control-plane-stage-clearance.test.ts`
+- `bun run --filter jangar lint`
+- `bun run --filter jangar lint:oxlint`
+
+Torghut validation:
+
+- `cd services/torghut && uv run --frozen pytest tests/test_no_delta_repair_reentry_auction.py`
+- `cd services/torghut && uv run --frozen pytest tests/test_alpha_readiness_settlement_conveyor.py`
+- `cd services/torghut && uv run --frozen ruff check app/trading tests`
+- `cd services/torghut && uv run --frozen ruff format --check app/trading tests`
+
+Runtime validation:
+
+- `curl -fsS http://agents.agents.svc.cluster.local/ready`
+- `curl -fsS 'http://agents.agents.svc.cluster.local/api/agents/control-plane/status?namespace=agents'`
+- `curl -fsS http://torghut.torghut.svc.cluster.local/trading/revenue-repair`
+- `curl -fsS http://torghut.torghut.svc.cluster.local/db-check`
+- `kubectl get applications.argoproj.io -n argocd agents jangar torghut`
+- `kubectl get deployments -n agents`
+- `kubectl get deployments -n jangar`
+
+Acceptance gates:
+
+- `controller_ingestion_settlement` is present, fresh, and cites this design.
+- `dispatch_normal`, `deploy_widen`, and `merge_ready` stay held while ingestion or verification carry is missing.
+- Exactly one bounded repair ticket may be selected for the missing witness; duplicate no-delta alpha repair is denied.
+- Torghut keeps `max_notional=0`.
+- Torghut no-delta release reasons distinguish Jangar carry unavailable from alpha evidence no-delta.
+- Handoff names the metric improved or the smallest remaining blocker.
+
+## Rollout
+
+Phase 0 is documentation and handoff only. This PR makes the contract durable.
+
+Phase 1 ships the settlement in observe mode and records it in status. No stage behavior changes.
+
+Phase 2 turns on shadow consumption in stage clearance. Handoffs must cite the settlement decision, but launches are
+not yet suppressed by it.
+
+Phase 3 allows one selected repair ticket and holds broad dispatch when the settlement is not `allow`.
+
+Phase 4 lets Torghut import the settlement as a release condition for no-delta alpha repair.
+
+Phase 5 promotes enforcement only after two consecutive verify windows show no regression in failed AgentRun rate and
+deployer proof shows source-to-live carry current.
+
+## Rollback
+
+Rollback is consumer-side and feature-flagged:
+
+- disable settlement emission from status;
+- disable stage-clearance consumption and return to existing controller witness, stage credit, and material gate
+  digest behavior;
+- keep Torghut no-delta denial active and `max_notional=0`;
+- keep `/ready` serving-safe and use full control-plane status for material action decisions.
+
+No database migration is required for the first implementation milestone. If a later PR persists settlement history,
+it must include a migration consistency test and a status downgrade when persistence is unavailable.
+
+## Risks
+
+- False holds can reduce useful repair throughput. Mitigation: observe then shadow before enforcement, and select one
+  bounded repair ticket only when the missing witness is named.
+- False allows can increase failed AgentRuns. Mitigation: require current deployment, watch epoch, ingestion,
+  execution trust, and Torghut import before `allow`.
+- `/ready` can get too large or expensive. Mitigation: status first; `/ready` carries a compact ref only after cost is
+  measured.
+- Torghut can overfit to Jangar carry. Mitigation: Jangar carry is a release condition, not a capital release.
+
+## Handoff To Engineer
+
+Build the Jangar settlement reducer first. Do not start with scheduler enforcement. The first production PR should add
+the typed reducer, status wiring, and focused tests. The reducer must cite this design and must not require direct CNPG
+access from worker identities.
+
+Required changed files are expected under:
+
+- `services/jangar/src/server/control-plane-controller-ingestion-settlement.ts`
+- `services/jangar/src/server/control-plane-status.ts`
+- `services/jangar/src/data/agents-control-plane.ts`
+- `services/jangar/src/server/__tests__/control-plane-controller-ingestion-settlement.test.ts`
+- `services/jangar/src/server/__tests__/control-plane-status.test.ts`
+
+The first implementation is accepted only if it proves:
+
+- missing AgentRun ingestion self-report yields `repair_only` or `hold`, not `allow`;
+- current deployment plus current watch epoch alone is insufficient;
+- missing verification-carry field keeps normal material actions held;
+- one selected repair ticket carries `max_parallelism=1` and `max_notional=0`;
+- existing ready truth and material gate digest behavior remain compatible.
+
+## Handoff To Deployer
+
+Do not declare the lane healthy from Argo or deployment readiness alone. The deployer gate is:
+
+1. PR merged with green checks.
+2. Image promotion merged.
+3. Argo `agents`, `jangar`, and `torghut` are `Synced/Healthy`.
+4. Workloads are ready.
+5. `/ready` returns serving `ok`.
+6. Full status includes fresh `controller_ingestion_settlement`.
+7. `verify_trust_foreclosure_board` and `repair_slot_escrow` presence or absence matches the expected source version.
+8. Torghut `/trading/revenue-repair` imports Jangar verification carry without opening paper or live capital.
+9. The final handoff names whether `failed_agentrun_rate`, `pr_to_rollout_latency`, or `ready_status_truth` improved,
+   or names the smallest remaining blocker.

--- a/docs/torghut/design-system/v6/211-torghut-controller-ingestion-carry-and-alpha-no-delta-release-2026-05-14.md
+++ b/docs/torghut/design-system/v6/211-torghut-controller-ingestion-carry-and-alpha-no-delta-release-2026-05-14.md
@@ -1,0 +1,386 @@
+# 211. Torghut Controller-Ingestion Carry And Alpha No-Delta Release (2026-05-14)
+
+Status: Accepted for engineer and deployer handoff
+Date: 2026-05-14
+Owner: Victor Chen, Jangar Engineering Architecture
+Scope: Torghut revenue-repair no-delta release conditions, Jangar controller-ingestion carry import, alpha-readiness
+routeable-candidate repair, zero-notional guardrails, validation, rollout, rollback, and cross-swarm handoff.
+
+Companion Jangar contract:
+
+- `docs/agents/designs/205-jangar-controller-ingestion-settlement-and-verification-carry-cutover-2026-05-14.md`
+
+Extends:
+
+- `210-torghut-source-bound-verification-carry-import-and-no-delta-release-2026-05-14.md`
+- `docs/agents/designs/204-jangar-source-bound-verification-carry-exchange-and-repair-slot-reconciliation-2026-05-14.md`
+- `209-torghut-verification-carry-import-and-alpha-repair-release-2026-05-14.md`
+- `208-torghut-jangar-verification-carry-bridge-and-no-delta-reentry-market-2026-05-14.md`
+- `206-torghut-no-delta-repair-reentry-auction-and-verification-carry-2026-05-14.md`
+- `205-torghut-alpha-readiness-settlement-conveyor-and-routeable-profit-runway-2026-05-14.md`
+- `docs/agents/designs/203-jangar-foreclosure-carry-rollout-witness-and-stage-debt-repair-2026-05-14.md`
+
+## Decision
+
+I am selecting **controller-ingestion carry as a first-class alpha no-delta release condition** for Torghut.
+
+The live evidence is precise. `/trading/revenue-repair` is `repair_only`; top repair remains
+`repair_alpha_readiness`; the selected value gate is `routeable_candidate_count`; the selected lane is `H-MICRO-01`;
+accepted routeable candidates are still `0`; and capital is still `max_notional=0`. The alpha-readiness settlement
+conveyor is doing the right thing: it records no delta and denies repeat launch while the release key is unchanged.
+
+The next useful release condition is not another generic alpha repair attempt. The live no-delta auction already names
+`jangar_verification_carry_unavailable`. Jangar status explains why: controller deployment and watch epoch are current,
+but AgentRun ingestion self-report is missing, verification-carry fields are null, and normal stage clearance is held.
+Torghut should import that as a typed state, not as an opaque blocker.
+
+The selected design adds a compact import contract:
+`torghut.jangar-controller-ingestion-carry.v1`. It classifies the Jangar carry as `current`, `repairable`, `lagging`,
+`unavailable`, `stale`, or `contradicted`. The no-delta auction can then select exactly one zero-notional Jangar carry
+repair ticket when Jangar says the missing witness is repairable. It must keep all alpha evidence tickets denied until
+one of their real release conditions changes.
+
+The tradeoff is that Torghut will continue to reject otherwise tempting alpha repair retries. I accept that. The
+profit objective is not more repair volume. It is to move `routeable_candidate_count` with fresh, attributable evidence
+while preserving capital safety.
+
+## Governing Runtime Requirements
+
+This contract implements the active cross-swarm runtime requirements:
+
+- every implementation run must cite this design or its companion Jangar design before changing code;
+- implement stages must ship production PRs with tests or report the exact blocker to code;
+- verify stages must merge only green PRs and prove Argo, workload readiness, service health, and business evidence;
+- final handoff must name the control-plane or revenue metric improved or the smallest blocker preventing improvement.
+
+Jangar value-gate mapping:
+
+- `failed_agentrun_rate`: deny duplicate alpha repair tickets while Jangar carry is unavailable and no release
+  condition changed.
+- `pr_to_rollout_latency`: Torghut classifies source-to-live carry state instead of waiting on vague deployment notes.
+- `ready_status_truth`: Torghut refuses to treat Jangar serving health as material carry.
+- `manual_intervention_count`: one import state replaces manual comparison of Jangar status and Torghut no-delta output.
+- `handoff_evidence_quality`: release handoffs cite carry id, Jangar settlement id, selected lane, and validation
+  commands.
+
+Torghut value-gate mapping:
+
+- `routeable_candidate_count`: no-delta release must be tied to a lane expected to change this value.
+- `zero_notional_or_stale_evidence_rate`: stale or unavailable Jangar carry keeps the lane in repair-only denial.
+- `fill_tca_or_slippage_quality`: execution TCA tickets remain separate release conditions and cannot bypass the top
+  alpha-readiness queue.
+- `post_cost_daily_net_pnl`: no paper or live widening is authorized by this contract.
+- `capital_gate_safety`: all selected tickets must keep `max_notional=0`.
+
+## Current Evidence
+
+All evidence was collected read-only on 2026-05-14. I did not mutate database rows, Kubernetes resources, trading
+flags, broker state, or market data.
+
+### Revenue-Repair Surface
+
+- `/trading/revenue-repair` returned `business_state=repair_only`.
+- The repair queue included `repair_alpha_readiness` with reason `alpha_readiness_not_promotion_eligible`, priority
+  `70`, value gate `routeable_candidate_count`, required output `torghut.executable-alpha-receipts.v1`, and
+  `max_notional=0`.
+- The same queue included lower-priority live-submit, empirical, degraded, and empirical-not-ready repairs.
+- `alpha_readiness_settlement_conveyor.status=no_delta`.
+- The selected lane was `H-MICRO-01`, strategy `microbar_volume_continuation_long_top2_chip_v1@paper`, lane
+  `microstructure-breakout`, lane score `80`, and before reason `route_universe_empty`.
+- `routeable_candidate_count_before=0`, `routeable_candidate_count_after=0`, and measured delta `0`.
+- Required receipts still included `alpha_readiness_receipt`, `capital_replay_board`,
+  `hypothesis_promotion_receipt`, `torghut.executable-alpha-receipts.v1`, and
+  `torghut.alpha-readiness-settlement-receipt.v1`.
+
+### No-Delta Auction Surface
+
+- `no_delta_repair_reentry_auction.reentry_decision=deny`.
+- Denial reasons included `active_no_delta_release_key`, `no_release_condition_changed`,
+  `zero_notional_reentry_ticket_not_selected`, `jangar_verification_carry_unavailable`, and
+  `duplicate_no_delta_reentry_denied`.
+- Candidate tickets for alpha evidence, schema lineage, empirical, market context, execution TCA, and Jangar verify
+  carry were denied because the release key was unchanged.
+- The `jangar_verification_carry` block had `status=unavailable`, `jangar_foreclosure_board_ref=null`, and required
+  receipt `jangar.verify-trust-foreclosure-ticket.v1`.
+
+### Data And Schema Surface
+
+- `/db-check` returned `ok=true`, `schema_current=true`, current and expected Alembic head
+  `0031_autoresearch_candidate_spec_epoch_uniqueness`, no missing heads, no unexpected heads, and
+  `schema_graph_lineage_ready=true`.
+- The schema graph still reports historical parent-fork warnings, so this contract does not infer readiness from
+  database head alone. It consumes application-level lineage and carry receipts.
+- The live posture remains zero-notional. This contract does not enable live submit, paper canary, or live scale.
+
+### Jangar Import Surface
+
+- Jangar `/ready` returned `status=ok` and a fresh material gate digest, but `/ready.ready_truth_arbiter` was null.
+- Full Jangar status reported database healthy and migrations current, but `execution_trust=degraded`.
+- Full Jangar status had `verify_trust_foreclosure_board=null` and `repair_slot_escrow=null`.
+- Controller witness was `repair_only` because controller deployment and watch epoch were current while AgentRun
+  ingestion self-report was unknown.
+
+## Problem
+
+Torghut has a correct no-delta guard, but the guard does not yet know whether the Jangar-side blocker is:
+
+1. a source-to-serving rollout lag;
+2. a missing live verification-carry field;
+3. stale controller ingestion evidence;
+4. a repairable Jangar witness gap;
+5. a contradictory Jangar state; or
+6. a true alpha-readiness release condition that changed.
+
+Without that distinction, Torghut has two bad options: deny everything and leave the operator to interpret Jangar, or
+launch generic alpha repair against an unchanged no-delta key. Both lose leverage.
+
+## Alternatives Considered
+
+### Option A: Keep Jangar Carry As A Text Reason Code
+
+Torghut continues to emit `jangar_verification_carry_unavailable` and lets Jangar or operators interpret it.
+
+Advantages:
+
+- No new schema.
+- No immediate Torghut implementation cost.
+- Existing no-delta denial remains safe.
+
+Disadvantages:
+
+- Does not create a bounded Jangar repair lane.
+- Does not distinguish unavailable from stale, lagging, or contradicted.
+- Leaves handoffs to summarize two large status payloads.
+- Does not improve routeable candidate count.
+
+Decision: reject as architecture.
+
+### Option B: Treat Jangar Source SHA As Enough Carry
+
+Torghut accepts a Jangar source commit or design reference as proof that verification carry is available.
+
+Advantages:
+
+- Easy to implement.
+- Fast path to selecting a Jangar carry ticket.
+- Reduces dependence on status payload shape.
+
+Disadvantages:
+
+- The live evidence disproves it: source and design can exist while live status fields are null.
+- It weakens ready-status truth.
+- It could allow repeated alpha repair before Jangar can explain material action authority.
+- It has poor rollback semantics.
+
+Decision: reject.
+
+### Option C: Import Jangar Controller-Ingestion Carry
+
+Torghut imports the companion Jangar settlement and classifies carry before the no-delta auction selects a release
+ticket.
+
+Advantages:
+
+- Targets the live blocker.
+- Keeps duplicate alpha repair denied.
+- Allows one zero-notional Jangar carry repair if Jangar proves the witness gap is repairable.
+- Produces a compact business-evidence field for Jangar and deployer handoffs.
+- Preserves capital safety.
+
+Disadvantages:
+
+- Adds one import model and tests.
+- Requires stable Jangar settlement field names.
+- Keeps alpha lanes denied until the carry classification improves.
+
+Decision: select Option C.
+
+## Architecture
+
+Torghut adds a compact import to revenue repair and consumer evidence:
+
+```yaml
+schema_version: torghut.jangar-controller-ingestion-carry.v1
+carry_id: jangar-controller-ingestion-carry:<digest>
+generated_at: <iso8601>
+fresh_until: <iso8601>
+source_jangar_settlement_ref: <controller-ingestion-settlement id|null>
+jangar_settlement_decision: allow|repair_only|hold|block|unknown
+jangar_controller_ingestion_current: true|false|null
+jangar_verify_foreclosure_board_ref: <id|null>
+jangar_repair_slot_escrow_ref: <id|null>
+carry_state: current|repairable|lagging|unavailable|stale|contradicted
+selected_release_condition: jangar_controller_ingestion_current
+selected_ticket_class: jangar_verify_carry|none
+max_notional: '0'
+reason_codes: []
+validation_commands: []
+rollback_target: <string>
+```
+
+Carry classification:
+
+- `current`: Jangar settlement is `allow`, ingestion is current, verification carry fields are present, and Torghut
+  can cite the refs.
+- `repairable`: Jangar settlement is `repair_only` and selects a bounded Jangar carry repair ticket.
+- `lagging`: source or GitOps claims carry, but live fields are absent.
+- `unavailable`: Jangar settlement or carry fields are missing.
+- `stale`: the Jangar settlement exists but is expired.
+- `contradicted`: Jangar reports allow while required fields are absent, or reports incompatible image/source refs.
+
+No-delta release rules:
+
+1. Keep alpha evidence tickets denied while source ref, evidence window, blocker set, required receipts, and selected
+   hypothesis are unchanged.
+2. Permit a `jangar_verify_carry` ticket only when carry state is `repairable`.
+3. Deny all tickets when carry state is `unavailable`, `stale`, `lagging`, or `contradicted`.
+4. Keep `max_notional=0` for every selected ticket.
+5. Do not promote paper or live capital from carry state alone.
+
+## Measurable Trading Hypotheses
+
+H-MICRO-01 is the active repair hypothesis.
+
+- Hypothesis: once Jangar controller-ingestion carry is current, H-MICRO-01 can be re-evaluated against a changed
+  route universe or evidence window and produce `routeable_candidate_count > 0` without increasing notional.
+- Required receipts: `torghut.alpha-readiness-settlement-receipt.v1`, `torghut.executable-alpha-receipts.v1`,
+  `alpha_readiness_receipt`, `hypothesis_promotion_receipt`, and `capital_replay_board`.
+- Guardrail: deny repeat launch if measured routeable-candidate delta remains `0` and no release condition changed.
+
+H-CONT-01 remains held.
+
+- Hypothesis: continuation may become routeable after TCA evidence is current.
+- Guardrail: do not let H-CONT-01 overtake H-MICRO-01 unless the selected value gate or blocker set changes.
+
+H-REV-01 remains held.
+
+- Hypothesis: event reversion may become routeable after TCA evidence is current.
+- Guardrail: keep repeat launch denied while its no-delta key is active.
+
+Success metric for the next implementation window:
+
+- `routeable_candidate_count` increases above `0`, or the handoff proves the smallest blocker remains
+  `jangar_controller_ingestion_current=false` or unchanged no-delta release conditions.
+
+## Implementation Scope
+
+Milestone 1: import contract and no-delta classifier.
+
+- Add a compact import model for Jangar controller-ingestion carry.
+- Extend the no-delta auction to classify carry state.
+- Add tests for current, repairable, lagging, unavailable, stale, and contradicted.
+- Value gates: `routeable_candidate_count`, `zero_notional_or_stale_evidence_rate`, `handoff_evidence_quality`.
+
+Milestone 2: consumer evidence projection.
+
+- Mirror the compact carry on `/trading/consumer-evidence`.
+- Keep `/readyz` degraded for capital safety when no-delta is active.
+- Value gates: `ready_status_truth`, `manual_intervention_count`.
+
+Milestone 3: repair ticket selection.
+
+- Select one `jangar_verify_carry` ticket only when Jangar classifies the gap as repairable.
+- Keep max parallelism `1`, max runtime bounded, and max notional `0`.
+- Value gates: `failed_agentrun_rate`, `capital_gate_safety`.
+
+Milestone 4: rollout proof.
+
+- Verify Argo, workload readiness, Torghut `/db-check`, `/trading/revenue-repair`, `/trading/consumer-evidence`, and
+  Jangar status before claiming release.
+- Value gates: `pr_to_rollout_latency`, `handoff_evidence_quality`.
+
+## Validation Gates
+
+Local Torghut validation:
+
+- `cd services/torghut && uv run --frozen pytest tests/test_no_delta_repair_reentry_auction.py`
+- `cd services/torghut && uv run --frozen pytest tests/test_alpha_readiness_settlement_conveyor.py`
+- `cd services/torghut && uv run --frozen pytest tests/test_build_revenue_repair_digest.py -k revenue_repair`
+- `cd services/torghut && uv run --frozen ruff check app/trading tests`
+- `cd services/torghut && uv run --frozen ruff format --check app/trading tests`
+
+Runtime validation:
+
+- `curl -fsS http://torghut.torghut.svc.cluster.local/trading/revenue-repair`
+- `curl -fsS http://torghut.torghut.svc.cluster.local/trading/consumer-evidence`
+- `curl -fsS http://torghut.torghut.svc.cluster.local/db-check`
+- `curl -fsS 'http://agents.agents.svc.cluster.local/api/agents/control-plane/status?namespace=agents'`
+- `kubectl get applications.argoproj.io -n argocd agents jangar torghut`
+
+Acceptance gates:
+
+- revenue repair still reports `repair_only` until routeable candidates improve;
+- alpha no-delta duplicate tickets remain denied while release conditions are unchanged;
+- Jangar carry state appears with a fresh id and reason codes;
+- a Jangar carry ticket is selected only when carry state is `repairable`;
+- all selected work remains `max_notional=0`;
+- handoff names whether `routeable_candidate_count` moved or the smallest blocker preventing movement.
+
+## Rollout
+
+Phase 0 is documentation and handoff.
+
+Phase 1 emits the import field in observe mode and keeps existing no-delta decisions.
+
+Phase 2 classifies carry state but does not select new tickets.
+
+Phase 3 allows one zero-notional Jangar carry repair ticket when state is `repairable`.
+
+Phase 4 allows alpha no-delta release only after a real release condition changes and Jangar carry is current.
+
+Phase 5 is capital review only. This design does not authorize paper or live widening.
+
+## Rollback
+
+Rollback is field-level:
+
+- stop emitting `jangar_controller_ingestion_carry`;
+- keep existing no-delta auction and alpha-readiness conveyor behavior;
+- keep `max_notional=0`;
+- keep live submit disabled until capital-release designs prove otherwise.
+
+No database migration is required for the first implementation. If later work persists carry history, it must use
+Alembic migration guards and `/db-check` must remain schema-current.
+
+## Risks
+
+- Carry import can become stale if Jangar changes field names. Mitigation: schema-versioned import, explicit missing
+  field reason codes, and tests for absent fields.
+- Repairable state can select the wrong ticket. Mitigation: selected ticket must cite the Jangar settlement id and
+  validation commands.
+- Routeable candidate count can remain zero after carry is repaired. Mitigation: no-delta release remains active and
+  the next blocker is named instead of retrying blindly.
+- Operators can confuse zero-notional repair with capital readiness. Mitigation: all payloads keep `max_notional=0` and
+  capital release out of scope.
+
+## Handoff To Engineer
+
+Start with the import classifier, not with capital or strategy changes. The first Torghut implementation PR should add
+the model and tests that classify synthetic Jangar settlement payloads into `current`, `repairable`, `lagging`,
+`unavailable`, `stale`, and `contradicted`.
+
+Expected files:
+
+- `services/torghut/app/trading/no_delta_repair_reentry_auction.py`
+- `services/torghut/app/trading/revenue_repair.py`
+- `services/torghut/app/main.py`
+- `services/torghut/tests/test_no_delta_repair_reentry_auction.py`
+- `services/torghut/tests/test_build_revenue_repair_digest.py`
+- `services/torghut/tests/test_trading_api.py`
+
+Do not change live submission, broker, or notional behavior. The output must remain repair-only unless a later capital
+design says otherwise.
+
+## Handoff To Deployer
+
+Do not claim revenue repair is healthy because Torghut pods are ready. The deployer gate is:
+
+1. PR merged with green Torghut tests.
+2. Image promoted through GitOps.
+3. Argo `torghut` is `Synced/Healthy`.
+4. Torghut live and sim workloads are ready.
+5. `/db-check` is schema-current.
+6. `/trading/revenue-repair` shows the carry import state.
+7. `/trading/consumer-evidence` mirrors the compact carry.
+8. Jangar status shows the companion controller-ingestion settlement.
+9. Final handoff says whether `routeable_candidate_count` moved above `0`; if not, it names the smallest blocker.

--- a/docs/torghut/design-system/v6/index.md
+++ b/docs/torghut/design-system/v6/index.md
@@ -8,10 +8,13 @@
 - Scope: intraday strategy architecture upgrade beyond static TSMOM, with regime-adaptive routing, DSPy-governed LLM
   reasoning, contamination-safe evaluation, and production rollout controls
 - Implementation status: `Mixed` (historical program closure recorded on `2026-03-03`; source-state refreshed on
-  `2026-03-09`; active proof/capital authority evidence refreshed on `2026-05-14T16:28Z`)
-- Implementation status (strict, core 01-13 docs, source-state refresh `2026-03-09`): `Implemented=7`, `Partial=5`, `Completed=1`
+  `2026-03-09`; active proof/capital authority evidence refreshed on `2026-05-14T16:44Z`)
+- Implementation status (strict, core 01-13 docs, source-state refresh `2026-03-09`): `Implemented=7`, `Partial=5`,
+  `Completed=1`
 - Evidence (historical closure): `13-production-gap-closure-master-plan-2026-03-03.md` (Wave 0-6 closure + DoD)
-- Evidence (current next-work priority, refreshed `2026-05-14T16:28Z`):
+- Evidence (current next-work priority, refreshed `2026-05-14T16:44Z`):
+  - `docs/agents/designs/205-jangar-controller-ingestion-settlement-and-verification-carry-cutover-2026-05-14.md`
+  - `211-torghut-controller-ingestion-carry-and-alpha-no-delta-release-2026-05-14.md`
   - `docs/agents/designs/204-jangar-source-bound-verification-carry-exchange-and-repair-slot-reconciliation-2026-05-14.md`
   - `210-torghut-source-bound-verification-carry-import-and-no-delta-release-2026-05-14.md`
   - `docs/agents/designs/203-jangar-foreclosure-carry-rollout-witness-and-stage-debt-repair-2026-05-14.md`


### PR DESCRIPTION
## Summary

- Adds Jangar design 205 for controller-ingestion settlement and verification-carry cutover.
- Adds Torghut design 211 for importing Jangar controller-ingestion carry as an alpha no-delta release condition.
- Updates the Jangar and Torghut architecture indexes so the new contracts are the current next-work priority.
- Defines engineer and deployer handoff gates for failed AgentRun reduction, PR-to-rollout latency, ready truth, zero-notional guardrails, and no-delta repair release.

## Related Issues

None

## Testing

- PASS: `bunx oxfmt --check docs/agents/README.md docs/agents/designs/205-jangar-controller-ingestion-settlement-and-verification-carry-cutover-2026-05-14.md docs/torghut/design-system/v6/index.md docs/torghut/design-system/v6/211-torghut-controller-ingestion-carry-and-alpha-no-delta-release-2026-05-14.md`
- PASS: `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
