### PR TITLE
fix(torghut): preserve executable quote snapshots

### DIFF
--- a/argocd/applications/torghut/strategy-configmap.yaml
+++ b/argocd/applications/torghut/strategy-configmap.yaml
@@ -505,7 +505,7 @@ data:
         strategy_type: late_day_continuation_long_v1
         version: 1.0.0
         description: Paper-only late-day continuation sleeve on the live executable chip core; production approval blocked pending $300/day executable proof, version=1.0.0
-        enabled: false
+        enabled: true
         base_timeframe: "1Sec"
         universe_type: late_day_continuation_long_v1
         universe_symbols: ["NVDA", "AAPL", "AMZN", "GOOGL", "AVGO", "AMD", "ORCL", "INTC"]

--- a/services/torghut/app/trading/scheduler/pipeline.py
+++ b/services/torghut/app/trading/scheduler/pipeline.py
@@ -821,7 +821,12 @@ class TradingPipeline:
         if snapshot is None:
             return signal
         payload = dict(signal.payload)
-        if price is None and snapshot.price is not None:
+        snapshot_has_executable_quote = (
+            snapshot.bid is not None and snapshot.ask is not None
+        )
+        if snapshot.price is not None and (
+            price is None or snapshot_has_executable_quote
+        ):
             payload["price"] = snapshot.price
         if payload.get("spread") is None and snapshot.spread is not None:
             payload["spread"] = snapshot.spread

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -325,6 +325,7 @@ class TestLiveConfigManifestContract(TestCase):
                 "breakout-continuation-long-v1",
                 "mean-reversion-rebound-long-v1",
                 "mean-reversion-exhaustion-short-v1",
+                "late-day-continuation-long-v1",
             },
         )
 
@@ -398,6 +399,22 @@ class TestLiveConfigManifestContract(TestCase):
                 self.assertLessEqual(
                     Decimal(str(params.get("max_spread_bps") or "0")),
                     Decimal("20"),
+                )
+            elif str(strategy.get("strategy_type")) == "late_day_continuation_long_v1":
+                self.assertEqual(name, "late-day-continuation-long-v1")
+                self.assertLessEqual(
+                    _strategy_decimal(strategy, "max_notional_per_trade")
+                    or Decimal("0"),
+                    Decimal("94770"),
+                )
+                self.assertEqual(
+                    _strategy_decimal(strategy, "max_position_pct_equity"),
+                    Decimal("3.0"),
+                )
+                self.assertEqual(params.get("position_isolation_mode"), "per_strategy")
+                self.assertLessEqual(
+                    Decimal(str(params.get("max_spread_bps") or "0")),
+                    Decimal("22"),
                 )
             else:
                 self.fail(

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -844,6 +844,60 @@ class TestTradingPipeline(TestCase):
         self.assertEqual(enriched.payload.get("spread"), Decimal("0.02"))
         self.assertTrue(pipeline._signal_quote_quality.assess(enriched).valid)
 
+    def test_ensure_signal_executable_price_replaces_feature_price_when_quote_is_backfilled(
+        self,
+    ) -> None:
+        alpaca_client = FakeAlpacaClient()
+        pipeline = TradingPipeline(
+            alpaca_client=alpaca_client,
+            order_firewall=OrderFirewall(alpaca_client),
+            ingestor=FakeIngestor([]),
+            decision_engine=DecisionEngine(),
+            risk_engine=RiskEngine(),
+            executor=OrderExecutor(),
+            execution_adapter=alpaca_client,
+            reconciler=Reconciler(),
+            universe_resolver=UniverseResolver(),
+            state=TradingState(),
+            account_label="paper",
+            session_factory=self.session_local,
+            price_fetcher=FakePriceFetcher(
+                Decimal("117.36"),
+                spread=Decimal("0.40"),
+                bid=Decimal("117.10"),
+                ask=Decimal("117.50"),
+            ),
+        )
+        pipeline._signal_quote_quality.assess(
+            SignalEnvelope(
+                event_ts=datetime(2026, 1, 1, 14, 30, tzinfo=timezone.utc),
+                symbol="INTC",
+                payload={
+                    "price": Decimal("117.20"),
+                    "spread": Decimal("0.10"),
+                    "imbalance_bid_px": Decimal("117.15"),
+                    "imbalance_ask_px": Decimal("117.25"),
+                },
+                timeframe="1Sec",
+            )
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 1, 1, 14, 31, tzinfo=timezone.utc),
+            symbol="INTC",
+            payload={
+                "price": Decimal("83.00"),
+                "macd": {"macd": Decimal("1.1"), "signal": Decimal("0.4")},
+            },
+            timeframe="1Sec",
+        )
+
+        enriched = pipeline._ensure_signal_executable_price(signal)
+
+        self.assertEqual(enriched.payload.get("price"), Decimal("117.36"))
+        self.assertEqual(enriched.payload.get("imbalance_bid_px"), Decimal("117.10"))
+        self.assertEqual(enriched.payload.get("imbalance_ask_px"), Decimal("117.50"))
+        self.assertTrue(pipeline._signal_quote_quality.assess(enriched).valid)
+
     def test_ensure_signal_executable_price_backfills_missing_price_from_snapshot(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Preserve executable market-snapshot prices when bid/ask quotes are backfilled into scheduler signals.
- Enable the late-day continuation paper sleeve in the Torghut strategy ConfigMap.
- Add regression coverage for feature-price replacement and manifest contract coverage for the enabled sleeve.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen ruff format app/trading/scheduler/pipeline.py tests/test_trading_pipeline.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen ruff check app/trading/scheduler/pipeline.py tests/test_trading_pipeline.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen pytest -q tests/test_trading_pipeline.py::TestTradingPipeline::test_ensure_signal_executable_price_replaces_feature_price_when_quote_is_backfilled tests/test_trading_pipeline.py::TestTradingPipeline::test_ensure_signal_executable_price_backfills_missing_quote_from_snapshot tests/test_live_config_manifest_contract.py::TestLiveConfigManifestContract::test_enabled_paper_sleeves_are_chip_universe_with_safe_profiles`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
