### PR TITLE
feat(torghut): import controller ingestion carry

### DIFF
--- a/docs/torghut/rollouts/2026-05-14-controller-ingestion-carry-import.md
+++ b/docs/torghut/rollouts/2026-05-14-controller-ingestion-carry-import.md
@@ -1,0 +1,58 @@
+# Torghut Controller-Ingestion Carry Import
+
+Date: 2026-05-14
+
+Governing design:
+
+- `docs/torghut/design-system/v6/211-torghut-controller-ingestion-carry-and-alpha-no-delta-release-2026-05-14.md`
+- Companion Jangar design:
+  `docs/agents/designs/205-jangar-controller-ingestion-settlement-and-verification-carry-cutover-2026-05-14.md`
+
+## Runtime Evidence Before Change
+
+Source: `http://torghut.torghut.svc.cluster.local/trading/revenue-repair`
+
+- `business_state=repair_only`
+- `revenue_ready=false`
+- top queue item: `repair_alpha_readiness` / `alpha_readiness_not_promotion_eligible`
+- affected value gate: `routeable_candidate_count`
+- `accepted_routeable_candidate_count=0`
+- `max_notional=0`
+- no-delta auction reason included `jangar_verification_carry_unavailable`
+
+## Shipped Change
+
+- Added the additive `torghut.jangar-controller-ingestion-carry.v1` reducer.
+- The reducer classifies imported Jangar carry as `current`, `repairable`, `lagging`, `unavailable`, `stale`, or
+  `contradicted`.
+- `/trading/revenue-repair` now emits the full carry import and passes it into the no-delta reentry auction.
+- `/readyz` and `/trading/consumer-evidence` mirror the compact
+  `torghut.jangar-controller-ingestion-carry-ref.v1` payload.
+- The no-delta auction selects `jangar_verify_carry` only when controller-ingestion carry is `repairable`; current,
+  unavailable, stale, lagging, or contradicted carry does not open another alpha repair ticket by itself.
+- All carry import and selected-ticket paths keep `max_notional=0` and do not alter live submission.
+
+## Validation Plan
+
+- `cd services/torghut && uv run --frozen pytest tests/test_jangar_controller_ingestion_carry.py`
+- `cd services/torghut && uv run --frozen pytest tests/test_no_delta_repair_reentry_auction.py`
+- `cd services/torghut && uv run --frozen pytest tests/test_build_revenue_repair_digest.py -k revenue_repair`
+- `cd services/torghut && uv run --frozen pytest tests/test_trading_api.py -k consumer_evidence`
+- `cd services/torghut && uv run --frozen ruff check app/trading tests`
+- `cd services/torghut && uv run --frozen ruff format --check app/trading tests`
+
+## Risk And Rollback
+
+Risk is schema drift in the Jangar carry fields. The reducer fails closed: missing or contradictory fields become denial
+evidence and cannot enable paper or live capital.
+
+Rollback is to revert the PR or stop consuming `jangar_controller_ingestion_carry`; existing no-delta auction,
+alpha-readiness conveyor, dividend ledger, and proof-floor holds continue to keep Torghut at `max_notional=0`.
+
+## Revenue Impact
+
+Target metric is `routeable_candidate_count`. This change does not directly increase routeable candidates; it improves
+the top repair lane by replacing opaque `jangar_verification_carry_unavailable` evidence with a typed carry state and a
+bounded zero-notional Jangar carry ticket only when the runtime proves the gap is repairable. The smallest current
+blocker remains unchanged no-delta alpha-readiness evidence or missing Jangar controller-ingestion carry, depending on
+the live post-rollout state.

--- a/services/torghut/README.md
+++ b/services/torghut/README.md
@@ -243,6 +243,12 @@ Testing rules for the trading core:
   source, evidence-window, blocker, receipt, selected-hypothesis, or Jangar verify-carry release condition changes, and
   mirrors a compact `torghut.no-delta-repair-reentry-auction-ref.v1` through `/readyz` and
   `/trading/consumer-evidence`. It does not enable paper or live submission.
+- `GET /trading/revenue-repair` also emits the May 14 doc 211
+  `torghut.jangar-controller-ingestion-carry.v1` import reducer. It classifies Jangar controller-ingestion carry as
+  `current`, `repairable`, `lagging`, `unavailable`, `stale`, or `contradicted`, feeds that state into the no-delta
+  auction, and mirrors a compact `torghut.jangar-controller-ingestion-carry-ref.v1` through `/readyz` and
+  `/trading/consumer-evidence`. A `jangar_verify_carry` ticket is selectable only for `repairable` carry and always
+  keeps `max_notional=0`.
 - `GET /trading/status` and `GET /readyz` now include the May 8 doc 181
   `quality_adjusted_profit_frontier` shadow projection. The reducer ranks zero-notional repair packets from quant
   quality, market-context risk flags, route/TCA state, simulation-cache freshness, and Jangar evidence-quality refs

--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -111,6 +111,9 @@ from .trading.hypotheses import (
     validate_hypothesis_registry_from_settings,
 )
 from .trading.jangar_continuity import load_jangar_route_continuity_packet
+from .trading.jangar_controller_ingestion_carry import (
+    compact_jangar_controller_ingestion_carry,
+)
 from .trading.lean_lanes import LeanLaneManager
 from .trading.lean_runtime import lean_authority_status
 from .trading.llm.evaluation import build_llm_evaluation_metrics
@@ -1078,6 +1081,7 @@ def _evaluate_trading_health_payload(
             "mode": settings.trading_mode,
             "pipeline_mode": settings.trading_pipeline_mode,
             "build": build_payload,
+            "dependency_quorum": _dependency_quorum.as_payload(),
             "live_submission_gate": live_submission_gate,
             "proof_floor": proof_floor,
             "quant_evidence": quant_evidence,
@@ -1089,6 +1093,12 @@ def _evaluate_trading_health_payload(
             ),
             "executable_alpha_receipts": capital_replay_projection.get(
                 "executable_alpha_receipts"
+            ),
+            "controller_ingestion_settlement": _dependency_quorum.as_payload().get(
+                "controller_ingestion_settlement"
+            ),
+            "verify_trust_foreclosure_board": _dependency_quorum.as_payload().get(
+                "verify_trust_foreclosure_board"
             ),
             "source_serving_repair_receipt_ledger": source_serving_repair_receipt_ledger,
         },
@@ -1164,6 +1174,12 @@ def _evaluate_trading_health_payload(
                 cast(
                     Mapping[str, Any],
                     revenue_repair_digest.get("alpha_repair_dividend_ledger"),
+                )
+            ),
+            "jangar_controller_ingestion_carry": compact_jangar_controller_ingestion_carry(
+                cast(
+                    Mapping[str, Any],
+                    revenue_repair_digest.get("jangar_controller_ingestion_carry"),
                 )
             ),
             "no_delta_repair_reentry_auction": compact_no_delta_repair_reentry_auction(
@@ -1571,11 +1587,20 @@ def readyz() -> JSONResponse:
     )
 
 
-def _load_jangar_verify_trust_foreclosure_board() -> dict[str, object] | None:
-    """Fetch cached Jangar verify-trust carry for revenue-repair reentry only."""
+def _load_jangar_dependency_quorum_payload() -> dict[str, object]:
+    """Fetch cached Jangar dependency carry for revenue-repair reentry only."""
 
     dependency_quorum = load_jangar_dependency_quorum()
-    board = dependency_quorum.as_payload().get("verify_trust_foreclosure_board")
+    return dependency_quorum.as_payload()
+
+
+def _load_jangar_verify_trust_foreclosure_board(
+    dependency_quorum_payload: Mapping[str, object] | None = None,
+) -> dict[str, object] | None:
+    """Fetch cached Jangar verify-trust board for legacy revenue-repair callers."""
+
+    payload = dependency_quorum_payload or _load_jangar_dependency_quorum_payload()
+    board = payload.get("verify_trust_foreclosure_board")
     if not isinstance(board, Mapping):
         return None
     return dict(cast(Mapping[str, object], board))
@@ -1590,8 +1615,21 @@ def trading_revenue_repair() -> dict[str, object]:
         allow_stale_dependency_cache=True,
     )
     status_payload = trading_status()
-    verify_trust_foreclosure_board = _load_jangar_verify_trust_foreclosure_board()
-    if verify_trust_foreclosure_board is not None:
+    dependency_quorum_payload = _load_jangar_dependency_quorum_payload()
+    verify_trust_foreclosure_board = _load_jangar_verify_trust_foreclosure_board(
+        dependency_quorum_payload
+    )
+    if dependency_quorum_payload:
+        status_payload = {
+            **status_payload,
+            "dependency_quorum": dependency_quorum_payload,
+            "controller_ingestion_settlement": dependency_quorum_payload.get(
+                "controller_ingestion_settlement"
+            ),
+            "verify_trust_foreclosure_board": verify_trust_foreclosure_board
+            or dependency_quorum_payload.get("verify_trust_foreclosure_board"),
+        }
+    elif verify_trust_foreclosure_board is not None:
         status_payload = {
             **status_payload,
             "verify_trust_foreclosure_board": verify_trust_foreclosure_board,
@@ -3228,6 +3266,7 @@ def _build_trading_consumer_evidence_payload() -> dict[str, object]:
             "mode": settings.trading_mode,
             "pipeline_mode": "simple",
             "build": build_payload,
+            "dependency_quorum": dependency_quorum.as_payload(),
             "live_submission_gate": live_submission_gate,
             "proof_floor": proof_floor,
             "quant_evidence": quant_evidence,
@@ -3239,6 +3278,12 @@ def _build_trading_consumer_evidence_payload() -> dict[str, object]:
             ),
             "executable_alpha_receipts": capital_replay_projection.get(
                 "executable_alpha_receipts"
+            ),
+            "controller_ingestion_settlement": dependency_quorum.as_payload().get(
+                "controller_ingestion_settlement"
+            ),
+            "verify_trust_foreclosure_board": dependency_quorum.as_payload().get(
+                "verify_trust_foreclosure_board"
             ),
         },
         generated_at=datetime.now(timezone.utc),
@@ -3403,6 +3448,12 @@ def _build_trading_consumer_evidence_payload() -> dict[str, object]:
             cast(
                 Mapping[str, Any],
                 revenue_repair_digest.get("alpha_repair_dividend_ledger"),
+            )
+        ),
+        "jangar_controller_ingestion_carry": compact_jangar_controller_ingestion_carry(
+            cast(
+                Mapping[str, Any],
+                revenue_repair_digest.get("jangar_controller_ingestion_carry"),
             )
         ),
         "no_delta_repair_reentry_auction": compact_no_delta_repair_reentry_auction(

--- a/services/torghut/app/trading/jangar_controller_ingestion_carry.py
+++ b/services/torghut/app/trading/jangar_controller_ingestion_carry.py
@@ -1,0 +1,580 @@
+"""Jangar controller-ingestion carry import for Torghut no-delta repair."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from datetime import datetime, timedelta, timezone
+from typing import Any, cast
+
+JANGAR_CONTROLLER_INGESTION_CARRY_SCHEMA_VERSION = (
+    "torghut.jangar-controller-ingestion-carry.v1"
+)
+JANGAR_CONTROLLER_INGESTION_CARRY_REF_SCHEMA_VERSION = (
+    "torghut.jangar-controller-ingestion-carry-ref.v1"
+)
+
+_DESIGN_REF = (
+    "docs/torghut/design-system/v6/"
+    "211-torghut-controller-ingestion-carry-and-alpha-no-delta-release-2026-05-14.md"
+)
+_COMPANION_JANGAR_DESIGN_REF = (
+    "docs/agents/designs/"
+    "205-jangar-controller-ingestion-settlement-and-verification-carry-cutover-2026-05-14.md"
+)
+_DEFAULT_FRESHNESS_SECONDS = 15 * 60
+_ROLLBACK_TARGET = (
+    "stop emitting jangar_controller_ingestion_carry, keep the existing "
+    "no-delta auction and alpha-readiness conveyor behavior, and keep "
+    "Torghut max_notional=0"
+)
+_VALIDATION_COMMANDS = [
+    "uv run --frozen pytest services/torghut/tests/test_no_delta_repair_reentry_auction.py",
+    "uv run --frozen pytest services/torghut/tests/test_build_revenue_repair_digest.py -k revenue_repair",
+]
+
+
+def _mapping(value: object) -> Mapping[str, Any]:
+    if isinstance(value, Mapping):
+        return cast(Mapping[str, Any], value)
+    return {}
+
+
+def _sequence(value: object) -> Sequence[object]:
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return cast(Sequence[object], value)
+    return ()
+
+
+def _text(value: object, default: str = "") -> str:
+    if value is None:
+        return default
+    normalized = str(value).strip()
+    return normalized or default
+
+
+def _string_list(value: object) -> list[str]:
+    result: list[str] = []
+    seen: set[str] = set()
+    for item in _sequence(value):
+        normalized = _text(item)
+        if not normalized or normalized in seen:
+            continue
+        seen.add(normalized)
+        result.append(normalized)
+    return result
+
+
+def _append_unique(items: list[str], *values: object) -> list[str]:
+    seen = set(items)
+    for value in values:
+        if isinstance(value, Sequence) and not isinstance(
+            value, (str, bytes, bytearray)
+        ):
+            candidates = _string_list(cast(Sequence[object], value))
+        else:
+            candidates = [_text(value)]
+        for candidate in candidates:
+            if not candidate or candidate in seen:
+                continue
+            seen.add(candidate)
+            items.append(candidate)
+    return items
+
+
+def _stable_hash(prefix: str, payload: Mapping[str, object]) -> str:
+    encoded = json.dumps(
+        {"prefix": prefix, **dict(payload)},
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()[:24]
+
+
+def _parse_datetime(value: object) -> datetime | None:
+    raw = _text(value)
+    if not raw:
+        return None
+    normalized = raw[:-1] + "+00:00" if raw.endswith("Z") else raw
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return None
+    return parsed.astimezone(timezone.utc)
+
+
+def _first_text(*values: object) -> str:
+    for value in values:
+        normalized = _text(value)
+        if normalized:
+            return normalized
+    return ""
+
+
+def _bool_or_none(value: object) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"true", "1", "yes", "y", "current", "ok", "allow"}:
+            return True
+        if normalized in {"false", "0", "no", "n", "stale", "missing", "unknown"}:
+            return False
+    return None
+
+
+def _normalize_decision(value: object) -> str:
+    raw = _text(value, "unknown").lower()
+    if raw in {"allow", "allowed", "current", "ok", "pass", "ready"}:
+        return "allow"
+    if raw in {"repair_only", "repair", "repairable"}:
+        return "repair_only"
+    if raw in {"hold", "held", "delay", "delayed"}:
+        return "hold"
+    if raw in {"block", "blocked", "deny", "denied", "fail"}:
+        return "block"
+    return "unknown"
+
+
+def _extract_dependency_payload(
+    dependency_quorum: Mapping[str, Any] | None,
+) -> Mapping[str, Any]:
+    payload = _mapping(dependency_quorum)
+    nested = _mapping(payload.get("dependency_quorum"))
+    if nested:
+        return nested
+    return payload
+
+
+def _extract_controller_settlement(
+    *,
+    dependency_payload: Mapping[str, Any],
+    controller_ingestion_settlement: Mapping[str, Any] | None,
+) -> Mapping[str, Any]:
+    return (
+        _mapping(controller_ingestion_settlement)
+        or _mapping(dependency_payload.get("controller_ingestion_settlement"))
+        or _mapping(dependency_payload.get("controllerIngestionSettlement"))
+    )
+
+
+def _extract_foreclosure_board(
+    *,
+    dependency_payload: Mapping[str, Any],
+    verify_trust_foreclosure_board: Mapping[str, Any] | None,
+) -> Mapping[str, Any]:
+    return (
+        _mapping(verify_trust_foreclosure_board)
+        or _mapping(dependency_payload.get("verify_trust_foreclosure_board"))
+        or _mapping(dependency_payload.get("verifyTrustForeclosureBoard"))
+        or _mapping(dependency_payload.get("jangar_verification_carry"))
+    )
+
+
+def _extract_repair_slot(
+    *,
+    dependency_payload: Mapping[str, Any],
+    repair_slot_escrow: Mapping[str, Any] | None,
+    settlement: Mapping[str, Any],
+) -> Mapping[str, Any]:
+    return (
+        _mapping(repair_slot_escrow)
+        or _mapping(dependency_payload.get("repair_slot_escrow"))
+        or _mapping(dependency_payload.get("repairSlotEscrow"))
+        or _mapping(dependency_payload.get("stage_debt_repair_admission"))
+        or _mapping(dependency_payload.get("stageDebtRepairAdmission"))
+        or _mapping(settlement.get("selected_repair_ticket"))
+        or _mapping(settlement.get("selectedRepairTicket"))
+    )
+
+
+def _extract_witness(
+    *,
+    dependency_payload: Mapping[str, Any],
+    foreclosure_carry_rollout_witness: Mapping[str, Any] | None,
+) -> Mapping[str, Any]:
+    return (
+        _mapping(foreclosure_carry_rollout_witness)
+        or _mapping(dependency_payload.get("foreclosure_carry_rollout_witness"))
+        or _mapping(dependency_payload.get("foreclosureCarryRolloutWitness"))
+        or _mapping(dependency_payload.get("controller_ingestion_witness"))
+        or _mapping(dependency_payload.get("controllerIngestionWitness"))
+    )
+
+
+def _ref(payload: Mapping[str, Any], *keys: str) -> str:
+    for key in keys:
+        normalized = _text(payload.get(key))
+        if normalized:
+            return normalized
+    return ""
+
+
+def _selected_ticket_class(
+    settlement: Mapping[str, Any],
+    repair_slot: Mapping[str, Any],
+) -> str:
+    return _first_text(
+        repair_slot.get("ticket_class"),
+        repair_slot.get("ticketClass"),
+        repair_slot.get("repair_class"),
+        repair_slot.get("repairClass"),
+        settlement.get("selected_ticket_class"),
+        settlement.get("selectedTicketClass"),
+    )
+
+
+def _selected_ticket_id(
+    settlement: Mapping[str, Any],
+    repair_slot: Mapping[str, Any],
+) -> str:
+    return _first_text(
+        repair_slot.get("ticket_id"),
+        repair_slot.get("ticketId"),
+        repair_slot.get("admission_id"),
+        repair_slot.get("admissionId"),
+        repair_slot.get("escrow_id"),
+        repair_slot.get("escrowId"),
+        settlement.get("selected_ticket_id"),
+        settlement.get("selectedTicketId"),
+        settlement.get("selected_repair_ticket_id"),
+        settlement.get("selectedRepairTicketId"),
+    )
+
+
+def _controller_ingestion_current(settlement: Mapping[str, Any]) -> bool | None:
+    direct = _bool_or_none(
+        settlement.get("controller_ingestion_current")
+        if "controller_ingestion_current" in settlement
+        else settlement.get("controllerIngestionCurrent")
+    )
+    if direct is not None:
+        return direct
+    for key in (
+        "ingestion_current",
+        "ingestionCurrent",
+        "current",
+        "watch_current",
+        "watchCurrent",
+        "self_report_current",
+        "selfReportCurrent",
+    ):
+        parsed = _bool_or_none(settlement.get(key))
+        if parsed is not None:
+            return parsed
+    state = _text(settlement.get("state") or settlement.get("status")).lower()
+    if state in {"current", "ready", "ok"}:
+        return True
+    if state in {"missing", "unknown", "stale", "blocked", "degraded"}:
+        return False
+    return None
+
+
+def _has_source_claim(
+    *,
+    dependency_payload: Mapping[str, Any],
+    settlement: Mapping[str, Any],
+    witness: Mapping[str, Any],
+) -> bool:
+    if witness:
+        return True
+    source_state = _text(
+        dependency_payload.get("source_rollout_truth_state")
+        or dependency_payload.get("sourceRolloutTruthState")
+        or settlement.get("source_rollout_truth_state")
+        or settlement.get("sourceRolloutTruthState")
+    ).lower()
+    if source_state in {"source_ahead", "desired_ahead", "rollout_lagging", "lagging"}:
+        return True
+    desired = _first_text(
+        dependency_payload.get("desired_image_ref"),
+        dependency_payload.get("desiredImageRef"),
+        settlement.get("desired_image_ref"),
+        settlement.get("desiredImageRef"),
+    )
+    observed = _first_text(
+        dependency_payload.get("observed_image_ref"),
+        dependency_payload.get("observedImageRef"),
+        settlement.get("observed_image_ref"),
+        settlement.get("observedImageRef"),
+    )
+    return bool(desired and (not observed or desired != observed))
+
+
+def _is_stale(
+    *,
+    generated: datetime,
+    settlement: Mapping[str, Any],
+    board: Mapping[str, Any],
+    witness: Mapping[str, Any],
+) -> bool:
+    for payload in (settlement, board, witness):
+        fresh_until = _parse_datetime(payload.get("fresh_until"))
+        if fresh_until is not None and fresh_until <= generated:
+            return True
+    return False
+
+
+def _repairable_ticket_present(
+    *,
+    settlement: Mapping[str, Any],
+    repair_slot: Mapping[str, Any],
+) -> bool:
+    ticket_class = _selected_ticket_class(settlement, repair_slot)
+    ticket_id = _selected_ticket_id(settlement, repair_slot)
+    release_condition = _first_text(
+        repair_slot.get("release_condition"),
+        repair_slot.get("releaseCondition"),
+        settlement.get("selected_release_condition"),
+        settlement.get("selectedReleaseCondition"),
+    )
+    receipt = _first_text(
+        repair_slot.get("required_output_receipt"),
+        repair_slot.get("requiredOutputReceipt"),
+        settlement.get("required_output_receipt"),
+        settlement.get("requiredOutputReceipt"),
+    )
+    return (
+        ticket_class == "jangar_verify_carry"
+        or release_condition == "jangar_controller_ingestion_current"
+        or receipt == "jangar.verify-trust-foreclosure-ticket.v1"
+        or bool(ticket_id and repair_slot)
+    )
+
+
+def build_jangar_controller_ingestion_carry(
+    *,
+    generated_at: datetime,
+    dependency_quorum: Mapping[str, Any] | None = None,
+    controller_ingestion_settlement: Mapping[str, Any] | None = None,
+    verify_trust_foreclosure_board: Mapping[str, Any] | None = None,
+    repair_slot_escrow: Mapping[str, Any] | None = None,
+    foreclosure_carry_rollout_witness: Mapping[str, Any] | None = None,
+) -> dict[str, object]:
+    """Classify Jangar carry imported into Torghut's no-delta repair auction."""
+
+    if generated_at.tzinfo is None:
+        raise ValueError("generated_at_missing_timezone")
+    generated = generated_at.astimezone(timezone.utc)
+    default_fresh_until = generated + timedelta(seconds=_DEFAULT_FRESHNESS_SECONDS)
+    dependency_payload = _extract_dependency_payload(dependency_quorum)
+    settlement = _extract_controller_settlement(
+        dependency_payload=dependency_payload,
+        controller_ingestion_settlement=controller_ingestion_settlement,
+    )
+    board = _extract_foreclosure_board(
+        dependency_payload=dependency_payload,
+        verify_trust_foreclosure_board=verify_trust_foreclosure_board,
+    )
+    repair_slot = _extract_repair_slot(
+        dependency_payload=dependency_payload,
+        repair_slot_escrow=repair_slot_escrow,
+        settlement=settlement,
+    )
+    witness = _extract_witness(
+        dependency_payload=dependency_payload,
+        foreclosure_carry_rollout_witness=foreclosure_carry_rollout_witness,
+    )
+
+    settlement_ref = _ref(
+        settlement,
+        "settlement_id",
+        "settlementId",
+        "ledger_id",
+        "ledgerId",
+        "receipt_id",
+        "receiptId",
+        "id",
+        "ref",
+    )
+    board_ref = _ref(board, "board_id", "boardId", "carry_id", "carryId", "id", "ref")
+    repair_slot_ref = _ref(
+        repair_slot,
+        "escrow_id",
+        "escrowId",
+        "admission_id",
+        "admissionId",
+        "ticket_id",
+        "ticketId",
+        "id",
+        "ref",
+    )
+    raw_settlement_decision = (
+        settlement.get("decision")
+        or settlement.get("settlement_decision")
+        or settlement.get("settlementDecision")
+    )
+    decision = _normalize_decision(
+        raw_settlement_decision
+        if raw_settlement_decision is not None
+        else dependency_payload.get("decision")
+        if settlement
+        else None
+    )
+    ingestion_current = _controller_ingestion_current(settlement)
+    selected_ticket_class = _selected_ticket_class(settlement, repair_slot)
+    selected_ticket_id = _selected_ticket_id(settlement, repair_slot)
+    stale = bool(settlement) and _is_stale(
+        generated=generated,
+        settlement=settlement,
+        board=board,
+        witness=witness,
+    )
+    source_claim = _has_source_claim(
+        dependency_payload=dependency_payload,
+        settlement=settlement,
+        witness=witness,
+    )
+    reason_codes = _append_unique(
+        _string_list(dependency_payload.get("reasons")),
+        settlement.get("reason_codes"),
+        settlement.get("reasonCodes"),
+        board.get("reason_codes"),
+        board.get("reasonCodes"),
+        repair_slot.get("reason_codes"),
+        repair_slot.get("reasonCodes"),
+    )
+
+    if stale:
+        carry_state = "stale"
+        reason_codes = _append_unique(
+            reason_codes, "jangar_controller_ingestion_settlement_stale"
+        )
+    elif decision == "allow" and (ingestion_current is not True or not board_ref):
+        carry_state = "contradicted"
+        reason_codes = _append_unique(
+            reason_codes, "jangar_allow_without_required_carry_fields"
+        )
+    elif decision == "allow" and ingestion_current is True and board_ref:
+        carry_state = "current"
+    elif decision == "repair_only" and _repairable_ticket_present(
+        settlement=settlement,
+        repair_slot=repair_slot,
+    ):
+        carry_state = "repairable"
+        reason_codes = _append_unique(
+            reason_codes, "jangar_controller_ingestion_repairable"
+        )
+        if not selected_ticket_class:
+            selected_ticket_class = "jangar_verify_carry"
+    elif source_claim and (not board_ref or ingestion_current is not True):
+        carry_state = "lagging"
+        reason_codes = _append_unique(
+            reason_codes, "jangar_controller_ingestion_lagging"
+        )
+    else:
+        carry_state = "unavailable"
+        if not settlement:
+            reason_codes = _append_unique(
+                reason_codes, "jangar_controller_ingestion_settlement_missing"
+            )
+        if not board_ref:
+            reason_codes = _append_unique(
+                reason_codes, "jangar_verify_foreclosure_board_missing"
+            )
+
+    if carry_state not in {"current", "repairable"} and not reason_codes:
+        reason_codes = ["jangar_controller_ingestion_carry_unavailable"]
+
+    validation_commands = _string_list(
+        repair_slot.get("validation_commands")
+        or repair_slot.get("validationCommands")
+        or settlement.get("validation_commands")
+        or settlement.get("validationCommands")
+    )
+    if carry_state == "repairable" and not validation_commands:
+        validation_commands = list(_VALIDATION_COMMANDS)
+
+    fresh_until = (
+        _parse_datetime(settlement.get("fresh_until"))
+        or _parse_datetime(board.get("fresh_until"))
+        or _parse_datetime(witness.get("fresh_until"))
+        or default_fresh_until
+    )
+    carry_id = "jangar-controller-ingestion-carry:" + _stable_hash(
+        "jangar-controller-ingestion-carry",
+        {
+            "settlement_ref": settlement_ref,
+            "board_ref": board_ref,
+            "repair_slot_ref": repair_slot_ref,
+            "decision": decision,
+            "ingestion_current": ingestion_current,
+            "carry_state": carry_state,
+            "selected_ticket_id": selected_ticket_id,
+        },
+    )
+
+    return {
+        "schema_version": JANGAR_CONTROLLER_INGESTION_CARRY_SCHEMA_VERSION,
+        "carry_id": carry_id,
+        "generated_at": generated.isoformat(),
+        "fresh_until": fresh_until.isoformat(),
+        "governing_design_ref": _DESIGN_REF,
+        "companion_jangar_design_ref": _COMPANION_JANGAR_DESIGN_REF,
+        "source_jangar_settlement_ref": settlement_ref or None,
+        "jangar_settlement_decision": decision,
+        "jangar_controller_ingestion_current": ingestion_current,
+        "jangar_verify_foreclosure_board_ref": board_ref or None,
+        "jangar_repair_slot_escrow_ref": repair_slot_ref or None,
+        "carry_state": carry_state,
+        "selected_release_condition": "jangar_controller_ingestion_current",
+        "selected_ticket_class": selected_ticket_class or "none",
+        "selected_ticket_id": selected_ticket_id or None,
+        "max_notional": "0",
+        "reason_codes": reason_codes,
+        "validation_commands": validation_commands,
+        "rollback_target": _ROLLBACK_TARGET,
+    }
+
+
+def compact_jangar_controller_ingestion_carry(
+    carry: Mapping[str, Any] | None,
+) -> dict[str, object]:
+    """Return a compact Jangar-facing controller-ingestion carry ref."""
+
+    payload = _mapping(carry)
+    if not payload:
+        return {
+            "schema_version": JANGAR_CONTROLLER_INGESTION_CARRY_REF_SCHEMA_VERSION,
+            "status": "missing",
+            "reason_codes": ["jangar_controller_ingestion_carry_missing"],
+        }
+    validation_commands = _string_list(payload.get("validation_commands"))
+    return {
+        "schema_version": JANGAR_CONTROLLER_INGESTION_CARRY_REF_SCHEMA_VERSION,
+        "carry_schema_version": payload.get("schema_version"),
+        "carry_id": payload.get("carry_id"),
+        "generated_at": payload.get("generated_at"),
+        "fresh_until": payload.get("fresh_until"),
+        "carry_state": payload.get("carry_state"),
+        "source_jangar_settlement_ref": payload.get("source_jangar_settlement_ref"),
+        "jangar_settlement_decision": payload.get("jangar_settlement_decision"),
+        "jangar_controller_ingestion_current": payload.get(
+            "jangar_controller_ingestion_current"
+        ),
+        "jangar_verify_foreclosure_board_ref": payload.get(
+            "jangar_verify_foreclosure_board_ref"
+        ),
+        "jangar_repair_slot_escrow_ref": payload.get("jangar_repair_slot_escrow_ref"),
+        "selected_release_condition": payload.get("selected_release_condition"),
+        "selected_ticket_class": payload.get("selected_ticket_class"),
+        "selected_ticket_id": payload.get("selected_ticket_id"),
+        "max_notional": payload.get("max_notional"),
+        "reason_codes": _string_list(payload.get("reason_codes")),
+        "validation_command": validation_commands[0] if validation_commands else None,
+        "rollback_target": payload.get("rollback_target"),
+    }
+
+
+__all__ = [
+    "JANGAR_CONTROLLER_INGESTION_CARRY_REF_SCHEMA_VERSION",
+    "JANGAR_CONTROLLER_INGESTION_CARRY_SCHEMA_VERSION",
+    "build_jangar_controller_ingestion_carry",
+    "compact_jangar_controller_ingestion_carry",
+]

--- a/services/torghut/app/trading/no_delta_repair_reentry_auction.py
+++ b/services/torghut/app/trading/no_delta_repair_reentry_auction.py
@@ -36,6 +36,7 @@ _RELEASE_CONDITION_CODES = [
     "blocker_set_changed",
     "required_receipt_set_changed",
     "selected_hypothesis_changed",
+    "jangar_controller_ingestion_current",
     "jangar_verify_foreclosure_ticket_current",
     "schema_lineage_receipt_current",
     "empirical_receipt_current",
@@ -403,9 +404,21 @@ def _condition_state(
     changed_conditions: set[str],
     preserved_reasons: set[str],
     jangar_carry: Mapping[str, Any],
+    jangar_controller_ingestion_carry: Mapping[str, Any],
 ) -> tuple[str, list[str]]:
     if code in changed_conditions:
         return "changed", ["release_condition_changed"]
+    if code == "jangar_controller_ingestion_current":
+        carry_state = _text(jangar_controller_ingestion_carry.get("carry_state"))
+        if carry_state == "current":
+            return "current", ["jangar_controller_ingestion_carry_current"]
+        if carry_state == "repairable":
+            return "repairable", ["jangar_controller_ingestion_carry_repairable"]
+        if carry_state:
+            return carry_state, _string_list(
+                jangar_controller_ingestion_carry.get("reason_codes")
+            )
+        return "unavailable", ["jangar_controller_ingestion_carry_unavailable"]
     if code == "jangar_verify_foreclosure_ticket_current":
         if _text(jangar_carry.get("status")) == "current" and _text(
             jangar_carry.get("current_foreclosure_ticket_id")
@@ -434,6 +447,7 @@ def _build_release_conditions(
     changed_conditions: set[str],
     preserved_reason_codes: Sequence[str],
     jangar_carry: Mapping[str, Any],
+    jangar_controller_ingestion_carry: Mapping[str, Any],
 ) -> list[dict[str, object]]:
     preserved = set(preserved_reason_codes)
     return [
@@ -449,6 +463,7 @@ def _build_release_conditions(
                 changed_conditions=changed_conditions,
                 preserved_reasons=preserved,
                 jangar_carry=jangar_carry,
+                jangar_controller_ingestion_carry=jangar_controller_ingestion_carry,
             )
         ]
     ]
@@ -456,7 +471,7 @@ def _build_release_conditions(
 
 def _condition_unblocks(condition: Mapping[str, Any]) -> bool:
     state = _text(condition.get("state"))
-    return state in {"changed", "current"}
+    return state in {"changed", "current", "repairable"}
 
 
 def _ticket_specs() -> list[dict[str, object]]:
@@ -514,7 +529,10 @@ def _ticket_specs() -> list[dict[str, object]]:
         },
         {
             "ticket_class": "jangar_verify_carry",
-            "release_conditions": ["jangar_verify_foreclosure_ticket_current"],
+            "release_conditions": [
+                "jangar_controller_ingestion_current",
+                "jangar_verify_foreclosure_ticket_current",
+            ],
             "required_output_receipt": "jangar.verify-trust-foreclosure-ticket.v1",
             "validation_commands": [
                 "bun run --filter jangar test -- services/jangar/src/server/__tests__/control-plane-verify-trust-foreclosure.test.ts"
@@ -533,6 +551,7 @@ def _build_candidate_tickets(
     release_conditions: Sequence[Mapping[str, Any]],
     max_notional: str,
     top_item_is_alpha: bool,
+    jangar_controller_ingestion_carry: Mapping[str, Any],
 ) -> list[dict[str, object]]:
     conditions_by_code = {
         _text(condition.get("code")): condition for condition in release_conditions
@@ -563,6 +582,12 @@ def _build_candidate_tickets(
             hold_reason_codes.append("release_condition_not_changed")
         if active_no_delta_release_key and not matched_condition:
             hold_reason_codes.append("active_no_delta_release_key_unchanged")
+        if (
+            _text(spec.get("ticket_class")) == "jangar_verify_carry"
+            and _text(jangar_controller_ingestion_carry.get("carry_state"))
+            != "repairable"
+        ):
+            hold_reason_codes.append("jangar_controller_ingestion_carry_not_repairable")
 
         state = "held"
         if hold_reason_codes and active_no_delta_release_key:
@@ -637,6 +662,7 @@ def build_no_delta_repair_reentry_auction(
     alpha_repair_dividend_ledger: Mapping[str, Any],
     repair_bid_settlement_ledger: Mapping[str, Any],
     jangar_verification_carry: Mapping[str, Any] | None = None,
+    jangar_controller_ingestion_carry: Mapping[str, Any] | None = None,
 ) -> dict[str, object]:
     """Build the observe-mode no-delta reentry auction for alpha repair."""
 
@@ -689,6 +715,7 @@ def build_no_delta_repair_reentry_auction(
         generated=generated,
         jangar_verification_carry=jangar_verification_carry,
     )
+    controller_carry = _mapping(jangar_controller_ingestion_carry)
     preserved_codes = _preserved_reason_codes(
         alpha_repair_dividend_ledger,
         alpha_readiness_settlement_conveyor,
@@ -697,6 +724,7 @@ def build_no_delta_repair_reentry_auction(
         changed_conditions=changed_conditions,
         preserved_reason_codes=preserved_codes,
         jangar_carry=jangar_carry,
+        jangar_controller_ingestion_carry=controller_carry,
     )
     top_item_is_alpha = _is_alpha_repair(top_item)
     candidate_tickets = _build_candidate_tickets(
@@ -707,6 +735,7 @@ def build_no_delta_repair_reentry_auction(
         release_conditions=release_conditions,
         max_notional=max_notional,
         top_item_is_alpha=top_item_is_alpha,
+        jangar_controller_ingestion_carry=controller_carry,
     )
     selected_ticket = _select_ticket(candidate_tickets)
 
@@ -732,6 +761,7 @@ def build_no_delta_repair_reentry_auction(
     reason_codes = _append_unique(
         reason_codes,
         jangar_carry.get("reason_codes"),
+        controller_carry.get("reason_codes"),
     )
 
     if not _zero_notional(max_notional):
@@ -797,6 +827,7 @@ def build_no_delta_repair_reentry_auction(
         "reentry_decision": reentry_decision,
         "reason_codes": reason_codes,
         "jangar_verification_carry": jangar_carry,
+        "jangar_controller_ingestion_carry": controller_carry or None,
         "max_notional": max_notional,
         "capital_rule": _text(
             top_item.get("capital_rule"), "zero_notional_repair_only"
@@ -841,6 +872,9 @@ def compact_no_delta_repair_reentry_auction(
         "selected_release_condition": selected_ticket.get("release_condition"),
         "required_output_receipt": selected_ticket.get("required_output_receipt"),
         "validation_command": validation_commands[0] if validation_commands else None,
+        "jangar_controller_ingestion_carry_state": _mapping(
+            payload.get("jangar_controller_ingestion_carry")
+        ).get("carry_state"),
         "enforcement_mode": payload.get("enforcement_mode"),
         "max_notional": payload.get("max_notional"),
         "capital_rule": payload.get("capital_rule"),

--- a/services/torghut/app/trading/revenue_repair.py
+++ b/services/torghut/app/trading/revenue_repair.py
@@ -21,6 +21,9 @@ from .executable_alpha_receipts import (
     build_executable_alpha_repair_receipts,
     build_executable_alpha_settlement_slots,
 )
+from .jangar_controller_ingestion_carry import (
+    build_jangar_controller_ingestion_carry,
+)
 from .no_delta_repair_reentry_auction import (
     build_no_delta_repair_reentry_auction,
 )
@@ -1055,6 +1058,29 @@ def build_revenue_repair_digest(
         alpha_repair_closure_board=alpha_repair_closure_board,
         alpha_readiness_settlement_conveyor=alpha_readiness_settlement_conveyor,
     )
+    dependency_quorum = _mapping(status_payload.get("dependency_quorum"))
+    jangar_controller_ingestion_carry = build_jangar_controller_ingestion_carry(
+        generated_at=generated,
+        dependency_quorum=dependency_quorum,
+        controller_ingestion_settlement=cast(
+            Mapping[str, Any] | None,
+            status_payload.get("controller_ingestion_settlement"),
+        ),
+        verify_trust_foreclosure_board=cast(
+            Mapping[str, Any] | None,
+            status_payload.get("verify_trust_foreclosure_board")
+            or status_payload.get("jangar_verification_carry"),
+        ),
+        repair_slot_escrow=cast(
+            Mapping[str, Any] | None,
+            status_payload.get("repair_slot_escrow")
+            or status_payload.get("stage_debt_repair_admission"),
+        ),
+        foreclosure_carry_rollout_witness=cast(
+            Mapping[str, Any] | None,
+            status_payload.get("foreclosure_carry_rollout_witness"),
+        ),
+    )
     no_delta_repair_reentry_auction = build_no_delta_repair_reentry_auction(
         generated_at=generated,
         business_state=business_state,
@@ -1069,6 +1095,7 @@ def build_revenue_repair_digest(
             status_payload.get("verify_trust_foreclosure_board")
             or status_payload.get("jangar_verification_carry"),
         ),
+        jangar_controller_ingestion_carry=jangar_controller_ingestion_carry,
     )
     return {
         "schema_version": SCHEMA_VERSION,
@@ -1085,6 +1112,7 @@ def build_revenue_repair_digest(
         "alpha_evidence_foundry": alpha_evidence_foundry,
         "alpha_readiness_settlement_conveyor": alpha_readiness_settlement_conveyor,
         "alpha_repair_dividend_ledger": alpha_repair_dividend_ledger,
+        "jangar_controller_ingestion_carry": jangar_controller_ingestion_carry,
         "no_delta_repair_reentry_auction": no_delta_repair_reentry_auction,
         "business_state": business_state,
         "revenue_ready": revenue_ready,

--- a/services/torghut/tests/test_build_revenue_repair_digest.py
+++ b/services/torghut/tests/test_build_revenue_repair_digest.py
@@ -533,6 +533,19 @@ class TestBuildRevenueRepairDigest(TestCase):
             alpha_dividend_ledger["jangar_custody"]["launch_decision"],
             "deny",
         )
+        controller_carry = digest["jangar_controller_ingestion_carry"]
+        self.assertIsInstance(controller_carry, dict)
+        self.assertEqual(
+            controller_carry["schema_version"],
+            "torghut.jangar-controller-ingestion-carry.v1",
+        )
+        self.assertEqual(controller_carry["carry_state"], "unavailable")
+        self.assertEqual(controller_carry["selected_ticket_class"], "none")
+        self.assertEqual(controller_carry["max_notional"], "0")
+        self.assertIn(
+            "jangar_controller_ingestion_settlement_missing",
+            controller_carry["reason_codes"],
+        )
         no_delta_auction = digest["no_delta_repair_reentry_auction"]
         self.assertIsInstance(no_delta_auction, dict)
         self.assertEqual(
@@ -546,6 +559,10 @@ class TestBuildRevenueRepairDigest(TestCase):
         )
         self.assertEqual(no_delta_auction["selected_ticket"], None)
         self.assertEqual(no_delta_auction["max_notional"], "0")
+        self.assertEqual(
+            no_delta_auction["jangar_controller_ingestion_carry"]["carry_state"],
+            "unavailable",
+        )
         self.assertIn(
             "duplicate_no_delta_reentry_denied",
             no_delta_auction["reason_codes"],
@@ -627,6 +644,51 @@ class TestBuildRevenueRepairDigest(TestCase):
             ],
         )
         self.assertEqual(route_reacquisition["expected_unblock_value"], 13)
+
+    def test_repair_only_payload_selects_repairable_jangar_carry_ticket(self) -> None:
+        status_payload = _repair_only_status()
+        status_payload["dependency_quorum"] = {
+            "controller_ingestion_settlement": {
+                "settlement_id": "controller-ingestion-settlement:repairable",
+                "decision": "repair_only",
+                "controller_ingestion_current": False,
+                "selected_repair_ticket": {
+                    "ticket_id": "verify-trust-foreclosure-ticket:repairable",
+                    "ticket_class": "jangar_verify_carry",
+                    "required_output_receipt": (
+                        "jangar.verify-trust-foreclosure-ticket.v1"
+                    ),
+                    "validation_commands": [
+                        "bun run --filter jangar test -- services/jangar/src/server/__tests__/control-plane-verify-trust-foreclosure.test.ts"
+                    ],
+                },
+            }
+        }
+
+        digest = build_revenue_repair_digest(
+            readyz_payload=_repair_only_readyz(),
+            status_payload=status_payload,
+            generated_at=NOW,
+        )
+
+        controller_carry = cast(
+            dict[str, object], digest["jangar_controller_ingestion_carry"]
+        )
+        self.assertEqual(controller_carry["carry_state"], "repairable")
+        self.assertEqual(
+            controller_carry["selected_ticket_class"], "jangar_verify_carry"
+        )
+        no_delta_auction = cast(
+            dict[str, object], digest["no_delta_repair_reentry_auction"]
+        )
+        self.assertEqual(no_delta_auction["reentry_decision"], "allow")
+        selected_ticket = cast(dict[str, object], no_delta_auction["selected_ticket"])
+        self.assertEqual(selected_ticket["ticket_class"], "jangar_verify_carry")
+        self.assertEqual(
+            selected_ticket["release_condition"],
+            "jangar_controller_ingestion_current",
+        )
+        self.assertEqual(selected_ticket["max_notional"], "0")
 
     def test_repair_only_payload_carries_readyz_database_contract(self) -> None:
         readyz_payload = _repair_only_readyz()

--- a/services/torghut/tests/test_jangar_controller_ingestion_carry.py
+++ b/services/torghut/tests/test_jangar_controller_ingestion_carry.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from app.trading.jangar_controller_ingestion_carry import (
+    build_jangar_controller_ingestion_carry,
+    compact_jangar_controller_ingestion_carry,
+)
+
+NOW = datetime(2026, 5, 14, 15, 30, tzinfo=timezone.utc)
+
+
+def test_controller_ingestion_carry_classifies_unavailable_when_missing() -> None:
+    carry = build_jangar_controller_ingestion_carry(generated_at=NOW)
+
+    assert carry["schema_version"] == "torghut.jangar-controller-ingestion-carry.v1"
+    assert carry["carry_state"] == "unavailable"
+    assert carry["jangar_settlement_decision"] == "unknown"
+    assert carry["jangar_controller_ingestion_current"] is None
+    assert carry["selected_ticket_class"] == "none"
+    assert carry["max_notional"] == "0"
+    assert "jangar_controller_ingestion_settlement_missing" in carry["reason_codes"]
+    assert "jangar_verify_foreclosure_board_missing" in carry["reason_codes"]
+
+
+def test_controller_ingestion_carry_classifies_current_when_settlement_and_board_match() -> (
+    None
+):
+    carry = build_jangar_controller_ingestion_carry(
+        generated_at=NOW,
+        dependency_quorum={
+            "controller_ingestion_settlement": {
+                "settlement_id": "controller-ingestion-settlement:current",
+                "decision": "allow",
+                "controller_ingestion_current": True,
+                "fresh_until": "2026-05-14T15:45:00+00:00",
+            },
+            "verify_trust_foreclosure_board": {
+                "board_id": "verify-trust-foreclosure-board:current",
+                "fresh_until": "2026-05-14T15:45:00+00:00",
+            },
+        },
+    )
+
+    assert carry["carry_state"] == "current"
+    assert carry["source_jangar_settlement_ref"] == (
+        "controller-ingestion-settlement:current"
+    )
+    assert carry["jangar_controller_ingestion_current"] is True
+    assert (
+        carry["jangar_verify_foreclosure_board_ref"]
+        == "verify-trust-foreclosure-board:current"
+    )
+    assert carry["selected_ticket_class"] == "none"
+    assert carry["reason_codes"] == []
+
+
+def test_controller_ingestion_carry_classifies_repairable_ticket() -> None:
+    carry = build_jangar_controller_ingestion_carry(
+        generated_at=NOW,
+        dependency_quorum={
+            "controller_ingestion_settlement": {
+                "settlement_id": "controller-ingestion-settlement:repair",
+                "decision": "repair_only",
+                "controller_ingestion_current": False,
+                "selected_repair_ticket": {
+                    "ticket_id": "verify-trust-foreclosure-ticket:repair",
+                    "ticket_class": "jangar_verify_carry",
+                    "required_output_receipt": (
+                        "jangar.verify-trust-foreclosure-ticket.v1"
+                    ),
+                    "validation_commands": [
+                        "bun run --filter jangar test -- services/jangar/src/server/__tests__/control-plane-verify-trust-foreclosure.test.ts"
+                    ],
+                },
+            },
+        },
+    )
+
+    assert carry["carry_state"] == "repairable"
+    assert carry["selected_release_condition"] == "jangar_controller_ingestion_current"
+    assert carry["selected_ticket_class"] == "jangar_verify_carry"
+    assert carry["selected_ticket_id"] == "verify-trust-foreclosure-ticket:repair"
+    assert "jangar_controller_ingestion_repairable" in carry["reason_codes"]
+    assert carry["validation_commands"]
+
+
+def test_controller_ingestion_carry_classifies_lagging_source_claim() -> None:
+    carry = build_jangar_controller_ingestion_carry(
+        generated_at=NOW,
+        dependency_quorum={
+            "foreclosure_carry_rollout_witness": {
+                "witness_id": "foreclosure-carry-rollout-witness:source",
+                "fresh_until": "2026-05-14T15:45:00+00:00",
+            }
+        },
+    )
+
+    assert carry["carry_state"] == "lagging"
+    assert "jangar_controller_ingestion_lagging" in carry["reason_codes"]
+
+
+def test_controller_ingestion_carry_classifies_stale_settlement() -> None:
+    carry = build_jangar_controller_ingestion_carry(
+        generated_at=NOW,
+        dependency_quorum={
+            "controller_ingestion_settlement": {
+                "settlement_id": "controller-ingestion-settlement:stale",
+                "decision": "repair_only",
+                "fresh_until": "2026-05-14T15:00:00+00:00",
+            }
+        },
+    )
+
+    assert carry["carry_state"] == "stale"
+    assert "jangar_controller_ingestion_settlement_stale" in carry["reason_codes"]
+
+
+def test_controller_ingestion_carry_classifies_contradicted_allow_without_board() -> (
+    None
+):
+    carry = build_jangar_controller_ingestion_carry(
+        generated_at=NOW,
+        dependency_quorum={
+            "controller_ingestion_settlement": {
+                "settlement_id": "controller-ingestion-settlement:bad",
+                "decision": "allow",
+                "controller_ingestion_current": True,
+                "fresh_until": "2026-05-14T15:45:00+00:00",
+            }
+        },
+    )
+
+    assert carry["carry_state"] == "contradicted"
+    assert "jangar_allow_without_required_carry_fields" in carry["reason_codes"]
+
+
+def test_controller_ingestion_carry_rejects_naive_generated_at() -> None:
+    with pytest.raises(ValueError, match="generated_at_missing_timezone"):
+        build_jangar_controller_ingestion_carry(
+            generated_at=datetime(2026, 5, 14, 15, 30)
+        )
+
+
+def test_compact_controller_ingestion_carry_ref() -> None:
+    carry = build_jangar_controller_ingestion_carry(generated_at=NOW)
+    compact = compact_jangar_controller_ingestion_carry(carry)
+
+    assert (
+        compact["schema_version"] == "torghut.jangar-controller-ingestion-carry-ref.v1"
+    )
+    assert compact["carry_id"] == carry["carry_id"]
+    assert compact["carry_state"] == "unavailable"
+    assert compact["max_notional"] == "0"
+
+    assert compact_jangar_controller_ingestion_carry(None) == {
+        "schema_version": "torghut.jangar-controller-ingestion-carry-ref.v1",
+        "status": "missing",
+        "reason_codes": ["jangar_controller_ingestion_carry_missing"],
+    }

--- a/services/torghut/tests/test_no_delta_repair_reentry_auction.py
+++ b/services/torghut/tests/test_no_delta_repair_reentry_auction.py
@@ -160,6 +160,7 @@ def _build(
     dividend: Mapping[str, Any] | None = None,
     capital: Mapping[str, Any] | None = None,
     jangar_verification_carry: Mapping[str, Any] | None = None,
+    jangar_controller_ingestion_carry: Mapping[str, Any] | None = None,
 ) -> dict[str, object]:
     return build_no_delta_repair_reentry_auction(
         generated_at=NOW,
@@ -175,6 +176,7 @@ def _build(
         else dividend,
         repair_bid_settlement_ledger=_repair_bid_settlement(),
         jangar_verification_carry=jangar_verification_carry,
+        jangar_controller_ingestion_carry=jangar_controller_ingestion_carry,
     )
 
 
@@ -256,13 +258,79 @@ def test_no_delta_reentry_auction_selects_jangar_foreclosure_ticket() -> None:
                     ),
                 }
             ],
-        }
+        },
+        jangar_controller_ingestion_carry={
+            "schema_version": "torghut.jangar-controller-ingestion-carry.v1",
+            "carry_id": "jangar-controller-ingestion-carry:repairable",
+            "carry_state": "repairable",
+            "selected_release_condition": "jangar_controller_ingestion_current",
+            "selected_ticket_class": "jangar_verify_carry",
+            "selected_ticket_id": "verify-trust-foreclosure-ticket:test",
+            "max_notional": "0",
+            "reason_codes": ["jangar_controller_ingestion_repairable"],
+        },
     )
 
     assert auction["reentry_decision"] == "allow"
     selected = cast(Mapping[str, Any], auction["selected_ticket"])
     assert selected["ticket_class"] == "jangar_verify_carry"
-    assert selected["release_condition"] == "jangar_verify_foreclosure_ticket_current"
+    assert selected["release_condition"] == "jangar_controller_ingestion_current"
+
+
+def test_no_delta_reentry_auction_does_not_select_jangar_ticket_for_current_carry() -> (
+    None
+):
+    auction = _build(
+        jangar_controller_ingestion_carry={
+            "schema_version": "torghut.jangar-controller-ingestion-carry.v1",
+            "carry_id": "jangar-controller-ingestion-carry:current",
+            "carry_state": "current",
+            "selected_release_condition": "jangar_controller_ingestion_current",
+            "selected_ticket_class": "none",
+            "max_notional": "0",
+            "reason_codes": [],
+        },
+    )
+
+    assert auction["reentry_decision"] == "deny"
+    assert auction["selected_ticket"] is None
+    release_states = {
+        condition["code"]: condition["state"]
+        for condition in cast(list[Mapping[str, Any]], auction["release_conditions"])
+    }
+    assert release_states["jangar_controller_ingestion_current"] == "current"
+    tickets = cast(list[Mapping[str, Any]], auction["candidate_tickets"])
+    jangar_ticket = next(
+        ticket for ticket in tickets if ticket["ticket_class"] == "jangar_verify_carry"
+    )
+    assert (
+        "jangar_controller_ingestion_carry_not_repairable"
+        in jangar_ticket["hold_reason_codes"]
+    )
+
+
+@pytest.mark.parametrize(
+    "carry_state",
+    ["unavailable", "stale", "lagging", "contradicted"],
+)
+def test_no_delta_reentry_auction_denies_unusable_controller_carry(
+    carry_state: str,
+) -> None:
+    auction = _build(
+        jangar_controller_ingestion_carry={
+            "schema_version": "torghut.jangar-controller-ingestion-carry.v1",
+            "carry_id": f"jangar-controller-ingestion-carry:{carry_state}",
+            "carry_state": carry_state,
+            "selected_release_condition": "jangar_controller_ingestion_current",
+            "selected_ticket_class": "none",
+            "max_notional": "0",
+            "reason_codes": [f"jangar_controller_ingestion_{carry_state}"],
+        },
+    )
+
+    assert auction["reentry_decision"] == "deny"
+    assert auction["selected_ticket"] is None
+    assert f"jangar_controller_ingestion_{carry_state}" in auction["reason_codes"]
 
 
 def test_no_delta_reentry_auction_denies_nonzero_notional() -> None:

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -1287,10 +1287,21 @@ class TestTradingApi(TestCase):
             alpha_dividend["required_recorder_schema"],
             "jangar.material-action-custody-flight-recorder.v1",
         )
+        controller_carry = payload["jangar_controller_ingestion_carry"]
+        self.assertEqual(
+            controller_carry["schema_version"],
+            "torghut.jangar-controller-ingestion-carry-ref.v1",
+        )
+        self.assertEqual(controller_carry["carry_state"], "unavailable")
+        self.assertEqual(controller_carry["max_notional"], "0")
         no_delta_auction = payload["no_delta_repair_reentry_auction"]
         self.assertEqual(
             no_delta_auction["schema_version"],
             "torghut.no-delta-repair-reentry-auction-ref.v1",
+        )
+        self.assertEqual(
+            no_delta_auction["jangar_controller_ingestion_carry_state"],
+            "unavailable",
         )
         self.assertIn(
             no_delta_auction["reentry_decision"],


### PR DESCRIPTION
## Summary

- Implements the Torghut doc 211 controller-ingestion carry import for the active `repair_alpha_readiness` revenue-repair lane: `docs/torghut/design-system/v6/211-torghut-controller-ingestion-carry-and-alpha-no-delta-release-2026-05-14.md`.
- Adds `torghut.jangar-controller-ingestion-carry.v1` and compact refs so revenue repair, `/readyz`, and `/trading/consumer-evidence` classify Jangar carry as `current`, `repairable`, `lagging`, `unavailable`, `stale`, or `contradicted`.
- Tightens the no-delta reentry auction so `jangar_verify_carry` is selectable only when controller-ingestion carry is `repairable`; all selected work remains `max_notional=0`.
- Updates Torghut documentation and rollout notes with runtime evidence, risk, rollback, and deployer handoff.

## Related Issues

None. Swarm mission: `torghut-quant`.

## Testing

Design provenance:

- Governing Torghut design: `docs/torghut/design-system/v6/211-torghut-controller-ingestion-carry-and-alpha-no-delta-release-2026-05-14.md`.
- Companion Jangar design: `docs/agents/designs/205-jangar-controller-ingestion-settlement-and-verification-carry-cutover-2026-05-14.md`.
- Runtime requirement source: `http://torghut.torghut.svc.cluster.local/trading/revenue-repair` selected top queue item `repair_alpha_readiness`, reason `alpha_readiness_not_promotion_eligible`, value gate `routeable_candidate_count`, required output receipt `torghut.executable-alpha-receipts.v1`, capital rule `zero_notional_repair_only`.

Local validation on rebased head `af46d912dda100f69bde834056f4ffa594173245`:

- `cd services/torghut && ~/.local/bin/uv sync --frozen --extra dev`: pass.
- `cd services/torghut && ~/.local/bin/uv run --frozen pytest tests/test_jangar_controller_ingestion_carry.py tests/test_no_delta_repair_reentry_auction.py tests/test_build_revenue_repair_digest.py tests/test_trading_api.py -k 'revenue_repair or consumer_evidence or no_delta or controller_ingestion_carry'`: pass, 45 passed / 86 deselected.
- `cd services/torghut && ~/.local/bin/uv run --frozen ruff check app/main.py app/trading/jangar_controller_ingestion_carry.py app/trading/no_delta_repair_reentry_auction.py app/trading/revenue_repair.py tests/test_jangar_controller_ingestion_carry.py tests/test_no_delta_repair_reentry_auction.py tests/test_build_revenue_repair_digest.py tests/test_trading_api.py`: pass.
- `cd services/torghut && ~/.local/bin/uv run --frozen ruff format --check app/main.py app/trading/jangar_controller_ingestion_carry.py app/trading/no_delta_repair_reentry_auction.py app/trading/revenue_repair.py tests/test_jangar_controller_ingestion_carry.py tests/test_no_delta_repair_reentry_auction.py tests/test_build_revenue_repair_digest.py tests/test_trading_api.py`: pass.
- `cd services/torghut && ~/.local/bin/uv run --frozen pyright --project pyrightconfig.json`: pass, 0 errors.
- `cd services/torghut && ~/.local/bin/uv run --frozen pyright --project pyrightconfig.alpha.json`: pass, 0 errors.
- `cd services/torghut && ~/.local/bin/uv run --frozen pyright --project pyrightconfig.scripts.json`: pass, 0 errors.
- `curl -fsS http://torghut.torghut.svc.cluster.local/db-check | jq '{ok, schema_current, schema_graph_lineage_ready, current_revision, expected_revision}'`: pass, `ok=true`, `schema_current=true`, `schema_graph_lineage_ready=true`.
- `curl -fsS http://torghut.torghut.svc.cluster.local/trading/revenue-repair | jq '{generated_at,business_state,revenue_ready, top_repair_queue:.repair_queue[0], routeability:.evidence.routeability_acceptance, capital, no_delta_reentry:{decision:.no_delta_repair_reentry_auction.reentry_decision, reason_codes:.no_delta_repair_reentry_auction.reason_codes, jangar_controller_ingestion_carry:.jangar_controller_ingestion_carry}}'`: pass.
- `curl -fsS http://torghut.torghut.svc.cluster.local/trading/consumer-evidence | jq '{schema_version,business_state,revenue_ready,jangar_controller_ingestion_carry,no_delta_repair_reentry_auction}'`: pass; live pre-deploy still has `jangar_controller_ingestion_carry=null`.
- `curl -fsS 'http://agents.agents.svc.cluster.local/api/agents/control-plane/status?namespace=agents' | jq '{execution_trust:.execution_trust.status, stage_clearance_decision:.stage_clearance.decision, verify_trust_foreclosure_board:.verify_trust_foreclosure_board, controller_ingestion_settlement:.controller_ingestion_settlement, dependency_quorum_decision:.dependency_quorum.decision}'`: pass; `execution_trust=degraded`, `controller_ingestion_settlement=null`, `dependency_quorum_decision=block`.
- `kubectl get applications.argoproj.io -n argocd agents jangar torghut -o json | jq '[.items[] | {name:.metadata.name, sync:.status.sync.status, health:.status.health.status, revision:.status.sync.revision}]'`: pass; `agents`, `jangar`, and `torghut` are `Synced/Healthy` at revision `015798c4cf4626c8b2d68182c745b9806dbf6bf2`.

GitHub CI on head `af46d912dda100f69bde834056f4ffa594173245`:

- `gh pr checks 6665 --repo proompteng/lab --watch`: pass; all non-skipped checks are green.
- Green checks include `check_changed_files`, semantic commit lint, semantic PR title, `Changed-file plan`, `Pyright`, `Bytecode + lint + migration guard`, pytest shards 0-3, autoresearch runners 0-7, `Quality signals (complexity + security)`, and `Bytecode + pytest + coverage`.
- `gh pr view 6665 --repo proompteng/lab --json number,url,state,isDraft,mergeable,mergeStateStatus,headRefOid,statusCheckRollup`: pass; `state=OPEN`, `isDraft=false`, `mergeable=MERGEABLE`, `mergeStateStatus=CLEAN`, `headRefOid=af46d912dda100f69bde834056f4ffa594173245`.

Runtime evidence:

- Before this run, `/trading/revenue-repair` at `2026-05-14T18:32:28Z` reported `business_state=repair_only`, `revenue_ready=false`, top queue item `repair_alpha_readiness`, value gate `routeable_candidate_count`, `accepted_routeable_candidate_count=0`, `zero_notional_or_stale_evidence_rate=1.0`, `capital_state=zero_notional`, and `max_notional=0`.
- After local implementation, rebase, and green CI, live pre-deploy `/trading/revenue-repair` at `2026-05-14T18:48:48Z` still reports `business_state=repair_only`, `revenue_ready=false`, top queue item `repair_alpha_readiness`, value gate `routeable_candidate_count`, `accepted_routeable_candidate_count=0`, `zero_notional_or_stale_evidence_rate=1.0`, `capital_state=zero_notional`, and `max_notional=0`.
- Live pre-deploy no-delta evidence still denies reentry with `jangar_verification_carry_unavailable`; this PR converts that blocker into typed controller-ingestion carry evidence after rollout.

Risk and rollback:

- Risk: Jangar carry payload fields drift. The reducer fails closed by marking missing, stale, lagging, or contradicted carry as denial evidence.
- Risk: the live revenue metric will not move until this Torghut image is promoted and the Jangar settlement surface emits controller-ingestion carry.
- Rollback: revert this PR or stop emitting `jangar_controller_ingestion_carry`; existing no-delta auction, alpha-readiness conveyor, dividend ledger, proof-floor holds, and `max_notional=0` remain intact.

Release note:

- Ships doc 211 controller-ingestion carry import for Torghut revenue repair. It improves the `routeable_candidate_count` runway by making the active `repair_alpha_readiness` blocker attributable to a typed Jangar carry state without enabling live submission. Deployer handoff after merge: promote through normal CI/CD and verify `/trading/revenue-repair` emits `jangar_controller_ingestion_carry` while capital remains zero-notional until the repair queue clears.

## Screenshots (if applicable)

N/A.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
