### PR TITLE
fix(torghut): admit profit freshness repair tickets

### DIFF
--- a/services/jangar/src/server/__tests__/control-plane-repair-bid-admission.test.ts
+++ b/services/jangar/src/server/__tests__/control-plane-repair-bid-admission.test.ts
@@ -243,6 +243,64 @@ describe('control-plane repair bid admission', () => {
     ])
   })
 
+  it('keeps selected profit-freshness repair tickets available during alpha-readiness strike admission', () => {
+    const profitFreshnessLot = {
+      ...baseConsumerEvidence().repair_bid_settlement_compacted_lots![0]!,
+      lot_id: 'profit-freshness-repair-lot:market-context',
+      lot_class: 'market_context_refresh',
+      target_value_gate: 'zero_notional_or_stale_evidence_rate',
+      priority: 99,
+      expected_gate_delta: 'retire_market_context_stale',
+      required_output_receipt: 'torghut.market-context-freshness-receipt.v1',
+      validation_commands: ['pytest services/torghut/tests/test_zero_notional_repair_executor.py -k dispatch_ticket'],
+      dedupe_key: 'PA3SX7FYNUTF:15m:profit_freshness:refresh_stale_market_context_domains:market_context',
+      state: 'selected',
+      dispatchable: true,
+      hold_reason_codes: [],
+    }
+    const admission = buildAdmission({
+      alpha_readiness_strike_ledger: alphaStrikeLedger(),
+      repair_bid_settlement_selected_lot_ids: [
+        'compacted-repair-lot:quant',
+        'profit-freshness-repair-lot:market-context',
+      ],
+      repair_bid_settlement_dispatchable_lot_ids: [
+        'compacted-repair-lot:quant',
+        'profit-freshness-repair-lot:market-context',
+      ],
+      repair_bid_settlement_compacted_lots: [
+        baseConsumerEvidence().repair_bid_settlement_compacted_lots![0]!,
+        profitFreshnessLot,
+      ],
+    })
+
+    const repairReceipt = admission.receipts.find((receipt) => receipt.action_class === 'dispatch_repair')
+
+    expect(repairReceipt).toMatchObject({
+      decision: 'allow',
+      admitted_lot_ids: ['compacted-repair-lot:promotion', 'profit-freshness-repair-lot:market-context'],
+      max_parallelism: 2,
+      max_notional: 0,
+    })
+    expect(admission.dispatch_tickets).toEqual([
+      expect.objectContaining({
+        torghut_lot_id: 'compacted-repair-lot:promotion',
+        lot_class: 'promotion_custody',
+        target_value_gate: 'routeable_candidate_count',
+        launch_allowed: true,
+      }),
+      expect.objectContaining({
+        torghut_lot_id: 'profit-freshness-repair-lot:market-context',
+        lot_class: 'market_context_refresh',
+        target_value_gate: 'zero_notional_or_stale_evidence_rate',
+        dedupe_key: 'PA3SX7FYNUTF:15m:profit_freshness:refresh_stale_market_context_domains:market_context',
+        required_output_receipt: 'torghut.market-context-freshness-receipt.v1',
+        launch_allowed: true,
+        max_notional: 0,
+      }),
+    ])
+  })
+
   it('holds alpha-readiness strike admission when the revenue ledger is stale', () => {
     const admission = buildAdmission({
       alpha_readiness_strike_ledger: {

--- a/services/jangar/src/server/control-plane-repair-bid-admission.ts
+++ b/services/jangar/src/server/control-plane-repair-bid-admission.ts
@@ -112,6 +112,21 @@ const isLotSelected = (lot: TorghutRepairBidSettlementLot, selectedLotIds: Set<s
 const isLotDispatchable = (lot: TorghutRepairBidSettlementLot, dispatchableLotIds: Set<string>) =>
   dispatchableLotIds.has(lot.lot_id) || lot.dispatchable === true
 
+const isProfitFreshnessRepairLot = (lot: TorghutRepairBidSettlementLot) =>
+  lot.lot_id.startsWith('profit-freshness-repair-lot:') &&
+  lot.target_value_gate === 'zero_notional_or_stale_evidence_rate'
+
+const uniqueLots = (lots: TorghutRepairBidSettlementLot[]) => {
+  const result: TorghutRepairBidSettlementLot[] = []
+  const seen = new Set<string>()
+  for (const lot of lots) {
+    if (seen.has(lot.lot_id)) continue
+    seen.add(lot.lot_id)
+    result.push(lot)
+  }
+  return result
+}
+
 const alphaStrikeFresh = (ledger: TorghutAlphaReadinessStrikeLedger, now: Date) => {
   const parsed = parseTimestampMs(ledger.fresh_until)
   return Boolean(parsed && parsed > now.getTime())
@@ -305,6 +320,8 @@ export const buildRepairBidAdmissionState = (input: RepairBidAdmissionInput): Re
   const dispatchableLotIds = new Set(torghut.repair_bid_settlement_dispatchable_lot_ids ?? [])
   const compactedLots = torghut.repair_bid_settlement_compacted_lots ?? []
   const selectedLots = compactedLots.filter((lot) => isLotSelected(lot, selectedLotIds))
+  const dispatchableSelectedLots = selectedLots.filter((lot) => isLotDispatchable(lot, dispatchableLotIds))
+  const profitFreshnessTicketLots = dispatchableSelectedLots.filter(isProfitFreshnessRepairLot)
   const strikeSlot = alphaStrikeSlot(torghut.alpha_readiness_strike_ledger, input.now)
   const strikeLot =
     strikeSlot && torghut.alpha_readiness_strike_ledger
@@ -313,10 +330,14 @@ export const buildRepairBidAdmissionState = (input: RepairBidAdmissionInput): Re
   const alphaStrikeRequired =
     torghut.alpha_readiness_strike_ledger?.selected_business_blocker?.value_gate === 'routeable_candidate_count'
   const ticketLots = strikeLot
-    ? [strikeLot]
+    ? uniqueLots([strikeLot, ...profitFreshnessTicketLots])
     : alphaStrikeRequired
-      ? []
-      : selectedLots.filter((lot) => isLotDispatchable(lot, dispatchableLotIds))
+      ? profitFreshnessTicketLots
+      : dispatchableSelectedLots
+  const receiptLotRefs = uniqueStrings([
+    ...(strikeLot ? [strikeLot.lot_id] : []),
+    ...selectedLots.map((lot) => lot.lot_id),
+  ])
   const ledgerMaxNotional = torghut.repair_bid_settlement_max_notional
   const baseReasons = uniqueStrings([
     ...(ledgerCurrent ? [] : [`torghut_repair_bid_settlement_${ledgerStatus}`]),
@@ -398,7 +419,7 @@ export const buildRepairBidAdmissionState = (input: RepairBidAdmissionInput): Re
       action_class: actionClass,
       decision: actionDecision.decision,
       torghut_settlement_ledger_ref: torghut.repair_bid_settlement_ledger_id ?? null,
-      torghut_compacted_lot_refs: strikeLot ? [strikeLot.lot_id] : selectedLots.map((lot) => lot.lot_id),
+      torghut_compacted_lot_refs: receiptLotRefs,
       active_dedupe_keys: [...activeDedupeKeys].sort(),
       admitted_lot_ids: actionClass === 'dispatch_repair' ? admittedLotIds : [],
       held_lot_ids: heldLotIds,

--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -948,6 +948,7 @@ def _evaluate_trading_health_payload(
         route_evidence_clearinghouse_packet=route_evidence_clearinghouse_packet,
         routeability_repair_acceptance_ledger=routeability_repair_acceptance_ledger,
         quant_evidence=quant_evidence,
+        profit_freshness_frontier=profit_freshness_frontier,
     )
     route_warrant_exchange = _build_route_warrant_exchange_payload(
         torghut_revision=BUILD_COMMIT,
@@ -2761,6 +2762,7 @@ def trading_status() -> dict[str, object]:
         route_evidence_clearinghouse_packet=route_evidence_clearinghouse_packet,
         routeability_repair_acceptance_ledger=routeability_repair_acceptance_ledger,
         quant_evidence=quant_evidence,
+        profit_freshness_frontier=profit_freshness_frontier,
     )
     route_warrant_exchange = _build_route_warrant_exchange_payload(
         torghut_revision=cast(str | None, shadow_first_runtime["active_revision"]),
@@ -3189,6 +3191,19 @@ def _build_trading_consumer_evidence_payload() -> dict[str, object]:
         tca_summary=tca_summary,
         options_catalog_freshness=options_catalog_freshness,
     )
+    profit_freshness_frontier = _build_profit_freshness_frontier_payload(
+        torghut_revision=cast(str | None, shadow_first_runtime["active_revision"]),
+        dependency_quorum=dependency_quorum.as_payload(),
+        proof_floor=proof_floor,
+        routeability_repair_acceptance_ledger=routeability_repair_acceptance_ledger,
+        quality_adjusted_profit_frontier=quality_adjusted_profit_frontier,
+        route_reacquisition_board=route_reacquisition_board,
+        live_submission_gate=live_submission_gate,
+        quant_evidence=quant_evidence,
+        market_context_status=market_context_status,
+        empirical_jobs_status=empirical_jobs,
+        hypothesis_payload=hypothesis_payload,
+    )
     repair_bid_settlement_ledger = _build_repair_bid_settlement_payload(
         torghut_revision=cast(str | None, shadow_first_runtime["active_revision"]),
         source_commit=BUILD_COMMIT,
@@ -3197,6 +3212,7 @@ def _build_trading_consumer_evidence_payload() -> dict[str, object]:
         route_evidence_clearinghouse_packet=route_evidence_clearinghouse_packet,
         routeability_repair_acceptance_ledger=routeability_repair_acceptance_ledger,
         quant_evidence=quant_evidence,
+        profit_freshness_frontier=profit_freshness_frontier,
     )
     revenue_repair_digest = build_revenue_repair_digest(
         readyz_payload={
@@ -3226,19 +3242,6 @@ def _build_trading_consumer_evidence_payload() -> dict[str, object]:
             ),
         },
         generated_at=datetime.now(timezone.utc),
-    )
-    profit_freshness_frontier = _build_profit_freshness_frontier_payload(
-        torghut_revision=cast(str | None, shadow_first_runtime["active_revision"]),
-        dependency_quorum=dependency_quorum.as_payload(),
-        proof_floor=proof_floor,
-        routeability_repair_acceptance_ledger=routeability_repair_acceptance_ledger,
-        quality_adjusted_profit_frontier=quality_adjusted_profit_frontier,
-        route_reacquisition_board=route_reacquisition_board,
-        live_submission_gate=live_submission_gate,
-        quant_evidence=quant_evidence,
-        market_context_status=market_context_status,
-        empirical_jobs_status=empirical_jobs,
-        hypothesis_payload=hypothesis_payload,
     )
     evidence_clock_arbiter, routeable_profit_candidate_exchange = (
         _build_evidence_clock_payloads(
@@ -5632,7 +5635,7 @@ def _build_route_evidence_clearinghouse_payload(*, torghut_revision: str | None,
 
 
 # fmt: off
-def _build_repair_bid_settlement_payload(*, torghut_revision: str | None, source_commit: str | None, dependency_quorum: Mapping[str, Any], build: Mapping[str, Any], route_evidence_clearinghouse_packet: Mapping[str, Any], routeability_repair_acceptance_ledger: Mapping[str, Any], quant_evidence: Mapping[str, Any]) -> dict[str, object]:
+def _build_repair_bid_settlement_payload(*, torghut_revision: str | None, source_commit: str | None, dependency_quorum: Mapping[str, Any], build: Mapping[str, Any], route_evidence_clearinghouse_packet: Mapping[str, Any], routeability_repair_acceptance_ledger: Mapping[str, Any], quant_evidence: Mapping[str, Any], profit_freshness_frontier: Mapping[str, Any] | None = None) -> dict[str, object]:
 # fmt: on
     return build_repair_bid_settlement_ledger(
         account_label=settings.trading_account_label,
@@ -5644,6 +5647,7 @@ def _build_repair_bid_settlement_payload(*, torghut_revision: str | None, source
         routeability_acceptance_ledger=routeability_repair_acceptance_ledger,
         active_run_dedupe_state={},
         jangar_scoped_quant_status=quant_evidence,
+        profit_freshness_frontier=profit_freshness_frontier,
         rollout_image_summary=_build_route_image_proof_summary(
             build=build,
             dependency_quorum=dependency_quorum,

--- a/services/torghut/app/trading/repair_bid_settlement.py
+++ b/services/torghut/app/trading/repair_bid_settlement.py
@@ -91,6 +91,28 @@ _ALPHA_READINESS_STRIKE_REASONS = {
     "alpha_readiness_not_promotion_eligible",
     "hypothesis_not_promotion_eligible",
 }
+_PROFIT_FRESHNESS_REPAIR_PRIORITY = 99
+_ZERO_NOTIONAL_TEXT = {"", "0", "0.0", "0.00", "0.0000"}
+_PROFIT_FRESHNESS_ACTION_CONTRACTS: Mapping[str, Mapping[str, object]] = {
+    "refresh_stale_market_context_domains": {
+        "lot_class": "market_context_refresh",
+        "target_value_gate": "zero_notional_or_stale_evidence_rate",
+        "required_output_receipt": "torghut.market-context-freshness-receipt.v1",
+        "validation_command": (
+            "pytest services/torghut/tests/test_zero_notional_repair_executor.py "
+            "-k dispatch_ticket"
+        ),
+    },
+    "renew_empirical_proof_jobs": {
+        "lot_class": "empirical_replay",
+        "target_value_gate": "zero_notional_or_stale_evidence_rate",
+        "required_output_receipt": "torghut.empirical-proof-refresh-receipt.v1",
+        "validation_command": (
+            "pytest services/torghut/tests/test_zero_notional_repair_executor.py "
+            "-k dispatch_ticket"
+        ),
+    },
+}
 
 
 def _mapping(value: object) -> Mapping[str, Any]:
@@ -144,6 +166,16 @@ def _unique(values: Sequence[str]) -> list[str]:
 
 def _strings(value: object) -> list[str]:
     return _unique([_text(item) for item in _sequence(value)])
+
+
+def _is_zero_notional(value: object, default: str = _ZERO_NOTIONAL) -> bool:
+    text = _text(value, default)
+    if text in _ZERO_NOTIONAL_TEXT:
+        return True
+    try:
+        return float(text) == 0
+    except ValueError:
+        return False
 
 
 def _timestamp(value: object) -> datetime | None:
@@ -507,6 +539,119 @@ def _build_lot(
     }
 
 
+def _profit_freshness_repairs(
+    profit_freshness_frontier: Mapping[str, Any],
+) -> list[Mapping[str, Any]]:
+    repairs: list[Mapping[str, Any]] = []
+    seen: set[str] = set()
+    raw_repairs: list[tuple[object, bool]] = [
+        (raw_repair, True)
+        for raw_repair in _sequence(
+            profit_freshness_frontier.get("selected_zero_notional_repairs")
+        )
+    ]
+    raw_repairs.extend(
+        (raw_repair, False)
+        for raw_repair in _sequence(profit_freshness_frontier.get("repair_lots"))
+    )
+    for raw_repair, explicitly_selected in raw_repairs:
+        repair = _mapping(raw_repair)
+        if not repair:
+            continue
+        repair_id = _text(repair.get("lot_id")) or _ref(
+            "profit-freshness-repair-lot", repair
+        )
+        key = f"{repair_id}:{_text(repair.get('zero_notional_action'))}"
+        if key in seen:
+            continue
+        seen.add(key)
+        if (
+            _text(repair.get("state")) != "selected_zero_notional_repair"
+            and not explicitly_selected
+        ):
+            continue
+        repairs.append(repair)
+    return repairs
+
+
+def _build_profit_freshness_lot(
+    *,
+    account_id: str,
+    session_id: str,
+    repair: Mapping[str, Any],
+    frontier: Mapping[str, Any],
+    active_keys: Sequence[str],
+) -> dict[str, object] | None:
+    action = _text(repair.get("zero_notional_action"))
+    contract = _mapping(_PROFIT_FRESHNESS_ACTION_CONTRACTS.get(action))
+    if not contract:
+        return None
+    if not (
+        _is_zero_notional(repair.get("paper_notional_limit"))
+        and _is_zero_notional(repair.get("live_notional_limit"))
+    ):
+        return None
+
+    lot_id = _text(repair.get("lot_id")) or _ref(
+        "profit-freshness-repair-lot",
+        {
+            "frontier_id": frontier.get("frontier_id"),
+            "action": action,
+            "candidate_id": repair.get("candidate_id"),
+            "hypothesis_id": repair.get("hypothesis_id"),
+            "blocked_dimension": repair.get("blocked_dimension"),
+        },
+    )
+    blocked_dimension = _text(repair.get("blocked_dimension"), "profit_freshness")
+    dedupe_key = (
+        f"{account_id}:{session_id}:profit_freshness:{action}:{blocked_dimension}"
+    )
+    hold_reasons = ["dedupe_key_active"] if dedupe_key in active_keys else []
+    state = "active" if hold_reasons else "candidate"
+    reason_codes = _unique(
+        [
+            f"profit_freshness_{blocked_dimension}_repair_selected",
+            *_strings(repair.get("guardrail_failures")),
+        ]
+    )
+    return {
+        "lot_id": lot_id,
+        "lot_class": _text(contract.get("lot_class"), "profit_freshness"),
+        "target_value_gate": _text(
+            contract.get("target_value_gate"),
+            _text(repair.get("value_gate"), "zero_notional_or_stale_evidence_rate"),
+        ),
+        "priority": _PROFIT_FRESHNESS_REPAIR_PRIORITY,
+        "expected_gate_delta": f"retire_{blocked_dimension}_stale",
+        "raw_reason_codes": reason_codes,
+        "root_cause_hypothesis": (
+            "profit freshness frontier selected a zero-notional runner repair "
+            f"for {blocked_dimension}"
+        ),
+        "required_input_refs": _unique(
+            [
+                _text(frontier.get("frontier_id")),
+                lot_id,
+                _text(repair.get("candidate_id")),
+                _text(repair.get("hypothesis_id")),
+                *_strings(repair.get("before_refs")),
+            ]
+        ),
+        "required_output_receipt": _text(contract.get("required_output_receipt")),
+        "required_output_receipt_count": 1,
+        "validation_commands": [_text(contract.get("validation_command"))],
+        "dedupe_key": dedupe_key,
+        "ttl_seconds": _DEFAULT_TTL_SECONDS,
+        "max_runtime_seconds": _DEFAULT_MAX_RUNTIME_SECONDS,
+        "max_parallelism": 1,
+        "max_notional": _ZERO_NOTIONAL,
+        "state": state,
+        "dispatchable": False,
+        "hold_reason_codes": hold_reasons,
+        "source_bid_ids": _unique([_text(frontier.get("frontier_id")), lot_id, action]),
+    }
+
+
 def _classed_reasons(
     *,
     clearinghouse_packet: Mapping[str, Any],
@@ -594,6 +739,7 @@ def build_repair_bid_settlement_ledger(
     active_run_dedupe_state: Mapping[str, Any] | None = None,
     jangar_scoped_quant_status: Mapping[str, Any] | None = None,
     rollout_image_summary: Mapping[str, Any] | None = None,
+    profit_freshness_frontier: Mapping[str, Any] | None = None,
     now: datetime | None = None,
 ) -> dict[str, object]:
     """Compact raw route-evidence bids into bounded zero-notional repair lots."""
@@ -603,6 +749,7 @@ def build_repair_bid_settlement_ledger(
     routeability_ledger = _mapping(routeability_acceptance_ledger)
     quant_status = _mapping(jangar_scoped_quant_status)
     rollout_summary = _mapping(rollout_image_summary)
+    freshness_frontier = _mapping(profit_freshness_frontier)
     active_keys = _active_dedupe_keys(_mapping(active_run_dedupe_state))
     packet_is_stale = _packet_stale(clearinghouse_packet, generated_at)
     classed_reasons = _classed_reasons(
@@ -626,6 +773,16 @@ def build_repair_bid_settlement_ledger(
         )
         for lot_class, payload in classed_reasons.items()
     ]
+    for repair in _profit_freshness_repairs(freshness_frontier):
+        profit_lot = _build_profit_freshness_lot(
+            account_id=account_label,
+            session_id=session_id,
+            repair=repair,
+            frontier=freshness_frontier,
+            active_keys=active_keys,
+        )
+        if profit_lot:
+            lots.append(profit_lot)
     compacted_lots = _select_lots(lots)
     selected_lot_ids = [
         str(lot["lot_id"]) for lot in compacted_lots if lot["state"] == "selected"

--- a/services/torghut/tests/test_repair_bid_settlement.py
+++ b/services/torghut/tests/test_repair_bid_settlement.py
@@ -67,6 +67,7 @@ def _build(
     active_dedupe_keys: list[str] | None = None,
     jangar_status: dict[str, object] | None = None,
     rollout_status: dict[str, object] | None = None,
+    profit_freshness_frontier: dict[str, object] | None = None,
 ) -> dict[str, object]:
     return build_repair_bid_settlement_ledger(
         account_label="PA3SX7FYNUTF",
@@ -81,6 +82,7 @@ def _build(
         },
         active_run_dedupe_state={"active_dedupe_keys": active_dedupe_keys or []},
         jangar_scoped_quant_status=jangar_status or {"ok": True, "status": "healthy"},
+        profit_freshness_frontier=profit_freshness_frontier,
         rollout_image_summary=rollout_status
         or {
             "state": "current",
@@ -261,6 +263,72 @@ def test_alpha_readiness_strike_reserves_promotion_custody_dispatch_capacity() -
     assert (
         "dispatch_limit_exceeded" in lots_by_class["execution_tca"]["hold_reason_codes"]
     )
+
+
+def test_profit_freshness_selected_repair_becomes_ticketable_zero_notional_lot() -> (
+    None
+):
+    ledger = _build(
+        reason_codes=[
+            "quant_health_not_configured",
+            "alpha_readiness_not_promotion_eligible",
+            "execution_tca_stale",
+        ],
+        profit_freshness_frontier={
+            "frontier_id": "profit-freshness-frontier:test",
+            "selected_zero_notional_repairs": [
+                {
+                    "lot_id": "profit-freshness-repair-lot:market-context",
+                    "candidate_id": "chip-paper-microbar-composite@execution-proof",
+                    "blocked_dimension": "market_context",
+                    "zero_notional_action": "refresh_stale_market_context_domains",
+                    "before_refs": ["market_context:INTC"],
+                    "paper_notional_limit": "0",
+                    "live_notional_limit": "0",
+                    "state": "selected_zero_notional_repair",
+                }
+            ],
+        },
+    )
+    lots_by_id = {lot["lot_id"]: lot for lot in ledger["compacted_lots"]}
+    profit_lot = lots_by_id["profit-freshness-repair-lot:market-context"]
+
+    assert profit_lot["lot_class"] == "market_context_refresh"
+    assert profit_lot["target_value_gate"] == "zero_notional_or_stale_evidence_rate"
+    assert (
+        profit_lot["required_output_receipt"]
+        == "torghut.market-context-freshness-receipt.v1"
+    )
+    assert profit_lot["state"] == "selected"
+    assert profit_lot["dispatchable"] is True
+    assert profit_lot["max_notional"] == "0"
+    assert "profit-freshness-repair-lot:market-context" in ledger["selected_lot_ids"]
+    assert (
+        "profit-freshness-repair-lot:market-context" in ledger["dispatchable_lot_ids"]
+    )
+    assert ledger["max_notional"] == "0"
+
+
+def test_profit_freshness_nonzero_repair_is_not_compacted_for_dispatch() -> None:
+    ledger = _build(
+        profit_freshness_frontier={
+            "frontier_id": "profit-freshness-frontier:test",
+            "selected_zero_notional_repairs": [
+                {
+                    "lot_id": "profit-freshness-repair-lot:nonzero",
+                    "blocked_dimension": "market_context",
+                    "zero_notional_action": "refresh_stale_market_context_domains",
+                    "paper_notional_limit": "10",
+                    "live_notional_limit": "0",
+                    "state": "selected_zero_notional_repair",
+                }
+            ],
+        },
+    )
+
+    assert "profit-freshness-repair-lot:nonzero" not in {
+        lot["lot_id"] for lot in ledger["compacted_lots"]
+    }
 
 
 def test_string_booleans_and_rollout_workload_gaps_create_typed_lots() -> None:


### PR DESCRIPTION
## Summary

- Publish Torghut selected profit-freshness zero-notional repairs as settlement-ledger lots with stable lot IDs, value gates, output receipts, dedupe keys, and zero-notional limits.
- Pass the profit-freshness frontier into Torghut status and consumer-evidence settlement projection so Jangar can issue matching dispatch tickets for the selected repair.
- Keep Jangar alpha-readiness strike tickets while also admitting selected profit-freshness repair tickets, instead of starving the runner-backed zero-notional repair path.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_repair_bid_settlement.py tests/test_zero_notional_repair_executor.py -q`
- `uv run --frozen ruff check app/trading/repair_bid_settlement.py tests/test_repair_bid_settlement.py app/main.py`
- `uv run --frozen ruff format --check app/trading/repair_bid_settlement.py tests/test_repair_bid_settlement.py app/main.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `bun run --filter @proompteng/otel build`
- `bun run --filter @proompteng/temporal-bun-sdk build`
- `bunx vitest run src/server/__tests__/control-plane-repair-bid-admission.test.ts`
- `bun run --filter @proompteng/jangar tsc`
- `bun run --filter @proompteng/jangar lint`
- `git diff --check`
- `git diff --cached --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
