### PR TITLE
fix(torghut): promote quote-covered paper sleeve

### DIFF
--- a/argocd/applications/torghut/strategy-configmap.yaml
+++ b/argocd/applications/torghut/strategy-configmap.yaml
@@ -14,11 +14,11 @@ data:
         strategy_id: microbar_volume_continuation_long_top2_chip_v1@paper
         strategy_type: microbar_cross_sectional_long_v1
         version: 1.0.0
-        description: Paper-only top-12 semiconductor volume continuation long top2 sleeve; live promotion blocked pending durable $300/day evidence, version=1.0.0
+        description: Paper-only quote-covered chip-core volume continuation long top2 sleeve; live promotion blocked pending durable $300/day evidence, version=1.0.0
         enabled: true
         base_timeframe: "1Sec"
         universe_type: microbar_cross_sectional_long_v1
-        universe_symbols: ["NVDA", "AAPL", "AMZN", "GOOGL", "AVGO", "AMD", "ORCL", "INTC"]
+        universe_symbols: ["AAPL", "AMZN", "INTC", "NVDA"]
         max_notional_per_trade: 50000
         max_position_pct_equity: 2.0
         params:
@@ -36,11 +36,11 @@ data:
         strategy_id: microbar_prev_day_open45_reversal_long_top1_chip_v1@paper
         strategy_type: microbar_cross_sectional_long_v1
         version: 1.0.0
-        description: Paper-only top-12 semiconductor prior-session opening-window reversal long sleeve; live promotion blocked pending durable $300/day evidence, version=1.0.0
+        description: Paper-only quote-covered chip-core prior-session opening-window reversal long sleeve; live promotion blocked pending durable $300/day evidence, version=1.0.0
         enabled: true
         base_timeframe: "1Sec"
         universe_type: microbar_cross_sectional_long_v1
-        universe_symbols: ["NVDA", "AAPL", "AMZN", "GOOGL", "AVGO", "AMD", "ORCL", "INTC"]
+        universe_symbols: ["AAPL", "AMZN", "INTC", "NVDA"]
         max_notional_per_trade: 50000
         max_position_pct_equity: 2.0
         params:
@@ -58,11 +58,11 @@ data:
         strategy_id: intraday_tsmom_v1@paper
         strategy_type: intraday_tsmom_v1
         version: 1.1.0
-        description: Paper-only intraday momentum sleeve on the live executable chip core; production approval blocked pending $300/day executable proof, version=1.1.0
+        description: Paper-only intraday momentum sleeve on the quote-covered executable chip core; production approval blocked pending $300/day executable proof, version=1.1.0
         enabled: true
         base_timeframe: "1Sec"
         universe_type: intraday_tsmom_v1
-        universe_symbols: ["NVDA", "AAPL", "AMZN", "GOOGL", "AVGO", "AMD", "ORCL", "INTC"]
+        universe_symbols: ["AAPL", "AMZN", "INTC", "NVDA"]
         max_notional_per_trade: 50000
         max_position_pct_equity: 3.0
         params:
@@ -138,11 +138,11 @@ data:
         strategy_id: breakout_continuation_long_v1@research
         strategy_type: breakout_continuation_long_v1
         version: 1.0.0
-        description: Paper-only breakout continuation sleeve on the live executable chip core; production approval blocked pending $300/day executable proof, version=1.0.0
+        description: Paper-only breakout continuation sleeve on the quote-covered executable chip core; production approval blocked pending $300/day executable proof, version=1.0.0
         enabled: true
         base_timeframe: "1Sec"
         universe_type: breakout_continuation_long_v1
-        universe_symbols: ["NVDA", "AAPL", "AMZN", "GOOGL", "AVGO", "AMD", "ORCL", "INTC"]
+        universe_symbols: ["AAPL", "AMZN", "INTC", "NVDA"]
         max_notional_per_trade: 50000
         max_position_pct_equity: 3.0
         params:
@@ -219,11 +219,11 @@ data:
         strategy_id: mean_reversion_rebound_long_v1@research
         strategy_type: mean_reversion_rebound_long_v1
         version: 1.0.0
-        description: Paper-only intraday rebound sleeve after controlled downside dislocation; production approval blocked pending $300/day executable proof, version=1.0.0
+        description: Paper-only intraday rebound sleeve after controlled downside dislocation on the quote-covered chip core; production approval blocked pending $300/day executable proof, version=1.0.0
         enabled: true
         base_timeframe: "1Sec"
         universe_type: mean_reversion_rebound_long_v1
-        universe_symbols: ["NVDA", "AAPL", "AMZN", "GOOGL", "AVGO", "AMD", "ORCL", "INTC"]
+        universe_symbols: ["AAPL", "AMZN", "INTC", "NVDA"]
         max_notional_per_trade: 31590
         max_position_pct_equity: 1.0
         params:
@@ -273,11 +273,11 @@ data:
         strategy_id: mean_reversion_exhaustion_short_v1@research
         strategy_type: mean_reversion_exhaustion_short_v1
         version: 1.0.0
-        description: Paper-only intraday short fade after controlled upside exhaustion; production approval blocked pending $300/day executable proof, version=1.0.0
+        description: Paper-only intraday short fade after controlled upside exhaustion on the quote-covered chip core; production approval blocked pending $300/day executable proof, version=1.0.0
         enabled: true
         base_timeframe: "1Sec"
         universe_type: mean_reversion_exhaustion_short_v1
-        universe_symbols: ["NVDA", "AAPL", "AMZN", "GOOGL", "AVGO", "AMD", "ORCL", "INTC"]
+        universe_symbols: ["AAPL", "AMZN", "INTC", "NVDA"]
         max_notional_per_trade: 30000
         max_position_pct_equity: 1.0
         params:
@@ -341,11 +341,11 @@ data:
         strategy_id: washout_rebound_long_v1@research
         strategy_type: washout_rebound_long_v1
         version: 1.0.0
-        description: Promoted washout rebound sleeve paired with the March 24, 2026 through April 2, 2026 replay composite winner, version=1.0.0
-        enabled: false
+        description: Paper-only washout rebound sleeve paired with the March 24, 2026 through April 2, 2026 replay composite winner on the quote-covered chip core; production approval blocked pending $300/day executable proof, version=1.0.0
+        enabled: true
         base_timeframe: "1Sec"
         universe_type: washout_rebound_long_v1
-        universe_symbols: ["NVDA", "AAPL", "AMZN", "GOOGL", "AVGO", "AMD", "ORCL", "INTC"]
+        universe_symbols: ["AAPL", "AMZN", "INTC", "NVDA"]
         max_notional_per_trade: 63180
         max_position_pct_equity: 2.0
         params:
@@ -504,11 +504,11 @@ data:
         strategy_id: late_day_continuation_long_v1@research
         strategy_type: late_day_continuation_long_v1
         version: 1.0.0
-        description: Paper-only late-day continuation sleeve on the live executable chip core; production approval blocked pending $300/day executable proof, version=1.0.0
+        description: Paper-only late-day continuation sleeve on the quote-covered executable chip core; production approval blocked pending $300/day executable proof, version=1.0.0
         enabled: true
         base_timeframe: "1Sec"
         universe_type: late_day_continuation_long_v1
-        universe_symbols: ["NVDA", "AAPL", "AMZN", "GOOGL", "AVGO", "AMD", "ORCL", "INTC"]
+        universe_symbols: ["AAPL", "AMZN", "INTC", "NVDA"]
         max_notional_per_trade: 94770
         max_position_pct_equity: 3.0
         params:

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -24,6 +24,7 @@ _RESEARCHED_CHIP_TECH_UNIVERSE = (
     "INTC",
 )
 _LIVE_EXECUTION_CHIP_TECH_UNIVERSE = _RESEARCHED_CHIP_TECH_UNIVERSE
+_QUOTE_COVERED_PAPER_STRATEGY_UNIVERSE = ("AAPL", "AMZN", "INTC", "NVDA")
 _CHIP_UNIVERSE_SYMBOLS = set(_RESEARCHED_CHIP_TECH_UNIVERSE)
 _LIVE_EXECUTION_CHIP_UNIVERSE_SYMBOLS = set(_LIVE_EXECUTION_CHIP_TECH_UNIVERSE)
 
@@ -219,6 +220,20 @@ def _assert_exact_live_execution_chip_universe(
     )
 
 
+def _assert_exact_quote_covered_paper_strategy_universe(
+    test_case: TestCase, symbols: Iterable[object], *, context: str
+) -> None:
+    normalized = [
+        str(symbol).strip().upper() for symbol in symbols if str(symbol).strip()
+    ]
+    _assert_chip_universe(test_case, normalized, context=context)
+    test_case.assertEqual(
+        tuple(normalized),
+        _QUOTE_COVERED_PAPER_STRATEGY_UNIVERSE,
+        f"{context} does not match the quote-covered paper strategy core",
+    )
+
+
 class TestLiveConfigManifestContract(TestCase):
     def test_knative_env_wiring_is_safe_live_defaults(self) -> None:
         env = _load_torghut_knative_env()
@@ -303,7 +318,7 @@ class TestLiveConfigManifestContract(TestCase):
                 list,
                 f"{strategy.get('name')} missing explicit universe_symbols",
             )
-            _assert_exact_live_execution_chip_universe(
+            _assert_chip_universe(
                 self,
                 cast(list[object], raw_symbols),
                 context=f"strategy {strategy.get('name')}",
@@ -325,6 +340,7 @@ class TestLiveConfigManifestContract(TestCase):
                 "breakout-continuation-long-v1",
                 "mean-reversion-rebound-long-v1",
                 "mean-reversion-exhaustion-short-v1",
+                "washout-rebound-long-v1",
                 "late-day-continuation-long-v1",
             },
         )
@@ -337,7 +353,7 @@ class TestLiveConfigManifestContract(TestCase):
             self.assertIn("paper-only", description)
             self.assertIn("$300/day", description)
             self.assertIsInstance(raw_symbols, list)
-            _assert_exact_live_execution_chip_universe(
+            _assert_exact_quote_covered_paper_strategy_universe(
                 self,
                 cast(list[object], raw_symbols),
                 context=f"{name} universe",
@@ -394,6 +410,22 @@ class TestLiveConfigManifestContract(TestCase):
                 self.assertEqual(
                     _strategy_decimal(strategy, "max_position_pct_equity"),
                     Decimal("1.0"),
+                )
+                self.assertEqual(params.get("position_isolation_mode"), "per_strategy")
+                self.assertLessEqual(
+                    Decimal(str(params.get("max_spread_bps") or "0")),
+                    Decimal("20"),
+                )
+            elif str(strategy.get("strategy_type")) == "washout_rebound_long_v1":
+                self.assertEqual(name, "washout-rebound-long-v1")
+                self.assertLessEqual(
+                    _strategy_decimal(strategy, "max_notional_per_trade")
+                    or Decimal("0"),
+                    Decimal("63180"),
+                )
+                self.assertEqual(
+                    _strategy_decimal(strategy, "max_position_pct_equity"),
+                    Decimal("2.0"),
                 )
                 self.assertEqual(params.get("position_isolation_mode"), "per_strategy")
                 self.assertLessEqual(


### PR DESCRIPTION
## Summary

- Constrains enabled Torghut paper strategies to the quote-covered chip core: `AAPL`, `AMZN`, `INTC`, and `NVDA`.
- Enables the existing `washout-rebound-long-v1` sleeve as paper-only with live promotion still blocked pending durable executable proof.
- Updates manifest contract coverage so enabled paper sleeves must use the quote-covered core while broader research configs remain chip-only.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen ruff format --check tests/test_live_config_manifest_contract.py`
- `uv run --frozen ruff check tests/test_live_config_manifest_contract.py`
- `uv run --frozen pytest -q tests/test_live_config_manifest_contract.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
