### PR TITLE
chore(torghut): promote image bbe57030

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:e178548a285e9a4f0ef6bdf0eac59673eb86ff67e7665cf66dbf364f53c40e98
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:6f664c6a1b23007de42d9fee0dced73bd1e739c79b465d3dba138e9ea7e88818
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.569.1-442-gcc371b357
+              value: v0.569.1-444-gbbe570305
             - name: TORGHUT_OPTIONS_COMMIT
-              value: cc371b3571f68ed8e218b032659605ab9cc01d68
+              value: bbe570305bc7696a4acde579cb0bd210d5b7c357
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:e178548a285e9a4f0ef6bdf0eac59673eb86ff67e7665cf66dbf364f53c40e98
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:6f664c6a1b23007de42d9fee0dced73bd1e739c79b465d3dba138e9ea7e88818
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.569.1-442-gcc371b357
+              value: v0.569.1-444-gbbe570305
             - name: TORGHUT_OPTIONS_COMMIT
-              value: cc371b3571f68ed8e218b032659605ab9cc01d68
+              value: bbe570305bc7696a4acde579cb0bd210d5b7c357
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:e178548a285e9a4f0ef6bdf0eac59673eb86ff67e7665cf66dbf364f53c40e98
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:6f664c6a1b23007de42d9fee0dced73bd1e739c79b465d3dba138e9ea7e88818
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:e178548a285e9a4f0ef6bdf0eac59673eb86ff67e7665cf66dbf364f53c40e98
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:6f664c6a1b23007de42d9fee0dced73bd1e739c79b465d3dba138e9ea7e88818
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:e178548a285e9a4f0ef6bdf0eac59673eb86ff67e7665cf66dbf364f53c40e98
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:6f664c6a1b23007de42d9fee0dced73bd1e739c79b465d3dba138e9ea7e88818
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:e178548a285e9a4f0ef6bdf0eac59673eb86ff67e7665cf66dbf364f53c40e98
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:6f664c6a1b23007de42d9fee0dced73bd1e739c79b465d3dba138e9ea7e88818
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:e178548a285e9a4f0ef6bdf0eac59673eb86ff67e7665cf66dbf364f53c40e98
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:6f664c6a1b23007de42d9fee0dced73bd1e739c79b465d3dba138e9ea7e88818
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -15,7 +15,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:e178548a285e9a4f0ef6bdf0eac59673eb86ff67e7665cf66dbf364f53c40e98
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:6f664c6a1b23007de42d9fee0dced73bd1e739c79b465d3dba138e9ea7e88818
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -23,7 +23,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:e178548a285e9a4f0ef6bdf0eac59673eb86ff67e7665cf66dbf364f53c40e98
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:6f664c6a1b23007de42d9fee0dced73bd1e739c79b465d3dba138e9ea7e88818
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+++ b/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
@@ -23,7 +23,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: refresh-execution-tca
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:e178548a285e9a4f0ef6bdf0eac59673eb86ff67e7665cf66dbf364f53c40e98
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:6f664c6a1b23007de42d9fee0dced73bd1e739c79b465d3dba138e9ea7e88818
               imagePullPolicy: IfNotPresent
               env:
                 - name: DB_DSN

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:e178548a285e9a4f0ef6bdf0eac59673eb86ff67e7665cf66dbf364f53c40e98
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:6f664c6a1b23007de42d9fee0dced73bd1e739c79b465d3dba138e9ea7e88818
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-14T17:33:49Z"
+        client.knative.dev/updateTimestamp: "2026-05-14T17:56:03Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -27,7 +27,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:e178548a285e9a4f0ef6bdf0eac59673eb86ff67e7665cf66dbf364f53c40e98
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:6f664c6a1b23007de42d9fee0dced73bd1e739c79b465d3dba138e9ea7e88818
           ports:
             - name: http1
               containerPort: 8181
@@ -482,11 +482,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.569.1-442-gcc371b357
+              value: v0.569.1-444-gbbe570305
             - name: TORGHUT_COMMIT
-              value: cc371b3571f68ed8e218b032659605ab9cc01d68
+              value: bbe570305bc7696a4acde579cb0bd210d5b7c357
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:e178548a285e9a4f0ef6bdf0eac59673eb86ff67e7665cf66dbf364f53c40e98
+              value: sha256:6f664c6a1b23007de42d9fee0dced73bd1e739c79b465d3dba138e9ea7e88818
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-14T17:33:49Z"
+        client.knative.dev/updateTimestamp: "2026-05-14T17:56:03Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:e178548a285e9a4f0ef6bdf0eac59673eb86ff67e7665cf66dbf364f53c40e98
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:6f664c6a1b23007de42d9fee0dced73bd1e739c79b465d3dba138e9ea7e88818
           ports:
             - name: http1
               containerPort: 8181
@@ -306,11 +306,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.569.1-442-gcc371b357
+              value: v0.569.1-444-gbbe570305
             - name: TORGHUT_COMMIT
-              value: cc371b3571f68ed8e218b032659605ab9cc01d68
+              value: bbe570305bc7696a4acde579cb0bd210d5b7c357
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:e178548a285e9a4f0ef6bdf0eac59673eb86ff67e7665cf66dbf364f53c40e98
+              value: sha256:6f664c6a1b23007de42d9fee0dced73bd1e739c79b465d3dba138e9ea7e88818
           livenessProbe:
             httpGet:
               path: /healthz

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -98,7 +98,7 @@ spec:
           - name: allowStaleTape
           - name: persistResults
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:e178548a285e9a4f0ef6bdf0eac59673eb86ff67e7665cf66dbf364f53c40e98
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:6f664c6a1b23007de42d9fee0dced73bd1e739c79b465d3dba138e9ea7e88818
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
+++ b/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:e178548a285e9a4f0ef6bdf0eac59673eb86ff67e7665cf66dbf364f53c40e98
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:6f664c6a1b23007de42d9fee0dced73bd1e739c79b465d3dba138e9ea7e88818
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `bbe570305bc7696a4acde579cb0bd210d5b7c357`
- Image tag: `bbe57030`
- Image digest: `sha256:6f664c6a1b23007de42d9fee0dced73bd1e739c79b465d3dba138e9ea7e88818`