### PR TITLE
fix(torghut): align runtime universe with promoted sleeve

### DIFF
--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -259,11 +259,11 @@ spec:
             - name: TRADING_UNIVERSE_STATIC_FALLBACK_ENABLED
               value: "false"
             - name: TRADING_STATIC_SYMBOLS
-              value: NVDA,AAPL,AMZN,GOOGL,AVGO,AMD,ORCL,INTC
+              value: AAPL,AMZN,INTC,NVDA
             - name: TRADING_UNIVERSE_STATIC_FALLBACK_SYMBOLS
-              value: NVDA,AAPL,AMZN,GOOGL,AVGO,AMD,ORCL,INTC
+              value: AAPL,AMZN,INTC,NVDA
             - name: TRADING_UNIVERSE_SYMBOL_ALLOWLIST
-              value: NVDA,AAPL,AMZN,GOOGL,AVGO,AMD,ORCL,INTC
+              value: AAPL,AMZN,INTC,NVDA
             - name: TRADING_UNIVERSE_MAX_STALE_SECONDS
               value: "900"
             - name: POSTHOG_ENABLED

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -173,11 +173,11 @@ spec:
             - name: TRADING_UNIVERSE_STATIC_FALLBACK_ENABLED
               value: "false"
             - name: TRADING_STATIC_SYMBOLS
-              value: NVDA,AAPL,AMZN,GOOGL,AVGO,AMD,ORCL,INTC
+              value: AAPL,AMZN,INTC,NVDA
             - name: TRADING_UNIVERSE_STATIC_FALLBACK_SYMBOLS
-              value: NVDA,AAPL,AMZN,GOOGL,AVGO,AMD,ORCL,INTC
+              value: AAPL,AMZN,INTC,NVDA
             - name: TRADING_UNIVERSE_SYMBOL_ALLOWLIST
-              value: NVDA,AAPL,AMZN,GOOGL,AVGO,AMD,ORCL,INTC
+              value: AAPL,AMZN,INTC,NVDA
             - name: TRADING_UNIVERSE_MAX_STALE_SECONDS
               value: "900"
             - name: POSTHOG_ENABLED

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -268,13 +268,13 @@ class TestLiveConfigManifestContract(TestCase):
         )
         self.assertEqual(
             set(settings.trading_static_symbols),
-            _LIVE_EXECUTION_CHIP_UNIVERSE_SYMBOLS,
+            set(_QUOTE_COVERED_PAPER_STRATEGY_UNIVERSE),
         )
         self.assertFalse(settings.trading_market_context_required)
         self.assertEqual(settings.trading_market_context_fail_mode, "shadow_only")
         self.assertEqual(
             set(settings.trading_universe_static_fallback_symbols),
-            _LIVE_EXECUTION_CHIP_UNIVERSE_SYMBOLS,
+            set(_QUOTE_COVERED_PAPER_STRATEGY_UNIVERSE),
         )
         self.assertNotIn("TRADING_FEATURE_FLAGS_URL", env)
         self.assertNotIn("TRADING_FORECAST_SERVICE_URL", env)
@@ -466,22 +466,22 @@ class TestLiveConfigManifestContract(TestCase):
         ws_annotations = cast(Mapping[str, object], ws_metadata).get("annotations")
         self.assertIsInstance(ws_annotations, Mapping)
 
-        _assert_exact_live_execution_chip_universe(
+        _assert_exact_quote_covered_paper_strategy_universe(
             self,
             _csv_symbols(live_env.get("TRADING_UNIVERSE_STATIC_FALLBACK_SYMBOLS")),
             context="live static fallback symbols",
         )
-        _assert_exact_live_execution_chip_universe(
+        _assert_exact_quote_covered_paper_strategy_universe(
             self,
             _csv_symbols(live_env.get("TRADING_UNIVERSE_SYMBOL_ALLOWLIST")),
             context="live runtime universe allowlist",
         )
-        _assert_exact_live_execution_chip_universe(
+        _assert_exact_quote_covered_paper_strategy_universe(
             self,
             _csv_symbols(sim_env.get("TRADING_UNIVERSE_STATIC_FALLBACK_SYMBOLS")),
             context="sim static fallback symbols",
         )
-        _assert_exact_live_execution_chip_universe(
+        _assert_exact_quote_covered_paper_strategy_universe(
             self,
             _csv_symbols(sim_env.get("TRADING_UNIVERSE_SYMBOL_ALLOWLIST")),
             context="sim runtime universe allowlist",
@@ -523,7 +523,7 @@ class TestLiveConfigManifestContract(TestCase):
         )
         self.assertEqual(
             sim_env.get("TRADING_STATIC_SYMBOLS"),
-            "NVDA,AAPL,AMZN,GOOGL,AVGO,AMD,ORCL,INTC",
+            "AAPL,AMZN,INTC,NVDA",
         )
         self.assertEqual(sim_env.get("CLICKHOUSE_DATABASE"), "torghut")
         self.assertEqual(sim_env.get("TRADING_SIGNAL_TABLE"), "torghut.ta_signals")
@@ -540,7 +540,7 @@ class TestLiveConfigManifestContract(TestCase):
         )
         self.assertEqual(
             sim_env.get("TRADING_UNIVERSE_STATIC_FALLBACK_SYMBOLS"),
-            "NVDA,AAPL,AMZN,GOOGL,AVGO,AMD,ORCL,INTC",
+            "AAPL,AMZN,INTC,NVDA",
         )
         self.assertNotIn("JANGAR_SYMBOLS_URL", sim_env)
         self.assertNotIn("TRADING_JANGAR_CONTROL_PLANE_STATUS_URL", sim_env)
@@ -811,7 +811,7 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertEqual(env.get("TRADING_UNIVERSE_SOURCE"), "static")
         self.assertEqual(env.get("TRADING_UNIVERSE_REQUIRE_NON_EMPTY_JANGAR"), "false")
         self.assertEqual(env.get("TRADING_UNIVERSE_STATIC_FALLBACK_ENABLED"), "false")
-        _assert_exact_live_execution_chip_universe(
+        _assert_exact_quote_covered_paper_strategy_universe(
             self,
             str(env.get("TRADING_STATIC_SYMBOLS", "")).split(","),
             context="live static universe",


### PR DESCRIPTION
## Summary

- Align live Torghut runtime static symbols with the quote-covered promoted core: `AAPL,AMZN,INTC,NVDA`.
- Align `torghut-sim` runtime static symbols, fallback symbols, and allowlist with the same core.
- Update the Torghut manifest contract so future deploys cannot reintroduce the broad bad-quote runtime universe.

## Related Issues

None

## Testing

- `uv run --frozen pytest -q tests/test_live_config_manifest_contract.py`
- `uv run --frozen ruff check tests/test_live_config_manifest_contract.py`
- `uv run --frozen ruff format --check tests/test_live_config_manifest_contract.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
