### PR TITLE
chore(jangar): promote image dfb81249

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 603daaaf
-  digest: sha256:07a35a93749c76e4eb84f2c680efbafb3927593f4bcef6a942a19d46be9b262f
+  tag: dfb81249
+  digest: sha256:7bcda033ab74a9dbd43f04e8da3b5cf0ff62eed65d2d6cb4ce1854c4a171f29b
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,25 +11,25 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 603daaaf
-    digest: sha256:d9147138ea17445c4ea6245f531c670c21170a050c0dd258498afc5a106d34a6
+    tag: dfb81249
+    digest: sha256:efec3a2ecc829b69b929d97b09ee72cf4f0fd433fcaa2106a41553d04a8ec197
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
       JANGAR_TORGHUT_STATUS_URL: http://torghut.torghut.svc.cluster.local/trading/consumer-evidence
       JANGAR_TORGHUT_STATUS_TIMEOUT_MS: "3000"
-      JANGAR_SOURCE_HEAD_SHA: 603daaaf9e549013b4c88063281b56d74b5955d7
-      JANGAR_GITOPS_REVISION: 603daaaf9e549013b4c88063281b56d74b5955d7
-      JANGAR_SOURCE_CI_RUN_ID: "25873761958"
+      JANGAR_SOURCE_HEAD_SHA: dfb81249c28e6576a68f758e4c6667522419ef49
+      JANGAR_GITOPS_REVISION: dfb81249c28e6576a68f758e4c6667522419ef49
+      JANGAR_SOURCE_CI_RUN_ID: "25877169269"
       JANGAR_SOURCE_CI_CONCLUSION: success
-      JANGAR_MANIFEST_IMAGE_DIGEST: sha256:d9147138ea17445c4ea6245f531c670c21170a050c0dd258498afc5a106d34a6
-      JANGAR_SERVING_BUILD_COMMIT: 603daaaf9e549013b4c88063281b56d74b5955d7
-      JANGAR_SERVING_IMAGE_DIGEST: sha256:d9147138ea17445c4ea6245f531c670c21170a050c0dd258498afc5a106d34a6
+      JANGAR_MANIFEST_IMAGE_DIGEST: sha256:efec3a2ecc829b69b929d97b09ee72cf4f0fd433fcaa2106a41553d04a8ec197
+      JANGAR_SERVING_BUILD_COMMIT: dfb81249c28e6576a68f758e4c6667522419ef49
+      JANGAR_SERVING_IMAGE_DIGEST: sha256:efec3a2ecc829b69b929d97b09ee72cf4f0fd433fcaa2106a41553d04a8ec197
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 603daaaf
-    digest: sha256:07a35a93749c76e4eb84f2c680efbafb3927593f4bcef6a942a19d46be9b262f
+    tag: dfb81249
+    digest: sha256:7bcda033ab74a9dbd43f04e8da3b5cf0ff62eed65d2d6cb4ce1854c4a171f29b
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-14T17:05:48Z
+    deploy.knative.dev/rollout: 2026-05-14T18:14:33Z
 spec:
   replicas: 1
   strategy:
@@ -57,11 +57,11 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_RUNTIME_IMAGE
-              value: registry.ide-newton.ts.net/lab/jangar:603daaaf@sha256:07a35a93749c76e4eb84f2c680efbafb3927593f4bcef6a942a19d46be9b262f
+              value: registry.ide-newton.ts.net/lab/jangar:dfb81249@sha256:7bcda033ab74a9dbd43f04e8da3b5cf0ff62eed65d2d6cb4ce1854c4a171f29b
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: 603daaaf9e549013b4c88063281b56d74b5955d7
+              value: dfb81249c28e6576a68f758e4c6667522419ef49
             - name: JANGAR_GITOPS_REVISION
-              value: 603daaaf9e549013b4c88063281b56d74b5955d7
+              value: dfb81249c28e6576a68f758e4c6667522419ef49
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_BUMBA_TASK_QUEUE
@@ -401,15 +401,15 @@ spec:
             - name: OPENAI_EMBEDDING_TIMEOUT_MS
               value: "60000"
             - name: JANGAR_SOURCE_CI_RUN_ID
-              value: "25873761958"
+              value: "25877169269"
             - name: JANGAR_SOURCE_CI_CONCLUSION
               value: success
             - name: JANGAR_MANIFEST_IMAGE_DIGEST
-              value: sha256:d9147138ea17445c4ea6245f531c670c21170a050c0dd258498afc5a106d34a6
+              value: sha256:efec3a2ecc829b69b929d97b09ee72cf4f0fd433fcaa2106a41553d04a8ec197
             - name: JANGAR_SERVING_BUILD_COMMIT
-              value: 603daaaf9e549013b4c88063281b56d74b5955d7
+              value: dfb81249c28e6576a68f758e4c6667522419ef49
             - name: JANGAR_SERVING_IMAGE_DIGEST
-              value: sha256:d9147138ea17445c4ea6245f531c670c21170a050c0dd258498afc5a106d34a6
+              value: sha256:efec3a2ecc829b69b929d97b09ee72cf4f0fd433fcaa2106a41553d04a8ec197
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -59,5 +59,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: 603daaaf
-    digest: sha256:07a35a93749c76e4eb84f2c680efbafb3927593f4bcef6a942a19d46be9b262f
+    newTag: dfb81249
+    digest: sha256:7bcda033ab74a9dbd43f04e8da3b5cf0ff62eed65d2d6cb4ce1854c4a171f29b


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `dfb81249c28e6576a68f758e4c6667522419ef49`
- Image tag: `dfb81249`
- Image digest: `sha256:7bcda033ab74a9dbd43f04e8da3b5cf0ff62eed65d2d6cb4ce1854c4a171f29b`
- Source CI run: `25877169269`
- Control-plane serving digest: `sha256:efec3a2ecc829b69b929d97b09ee72cf4f0fd433fcaa2106a41553d04a8ec197`
- Updated API rollout annotation
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`
- Published source-serving proof env for revenue repair custody gates