### PR TITLE
chore(torghut): promote image 37e22937

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:92e33ea851a7b6841f9738b4149e827a84e0899e49a11ebb84f4400ef1620303
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:b1fdd985683dcaf5abad141eb56e05fe000286e3419d72c9f88ef3029e20ab2b
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.569.1-447-g5cfd9ffcf
+              value: v0.569.1-450-g37e22937d
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 5cfd9ffcf21b1307fc54d0999be3a9d95fb93e38
+              value: 37e22937d5074b1bdbc1b0bed427478d65acd3dc
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:92e33ea851a7b6841f9738b4149e827a84e0899e49a11ebb84f4400ef1620303
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:b1fdd985683dcaf5abad141eb56e05fe000286e3419d72c9f88ef3029e20ab2b
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.569.1-447-g5cfd9ffcf
+              value: v0.569.1-450-g37e22937d
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 5cfd9ffcf21b1307fc54d0999be3a9d95fb93e38
+              value: 37e22937d5074b1bdbc1b0bed427478d65acd3dc
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:92e33ea851a7b6841f9738b4149e827a84e0899e49a11ebb84f4400ef1620303
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:b1fdd985683dcaf5abad141eb56e05fe000286e3419d72c9f88ef3029e20ab2b
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:92e33ea851a7b6841f9738b4149e827a84e0899e49a11ebb84f4400ef1620303
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:b1fdd985683dcaf5abad141eb56e05fe000286e3419d72c9f88ef3029e20ab2b
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:92e33ea851a7b6841f9738b4149e827a84e0899e49a11ebb84f4400ef1620303
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:b1fdd985683dcaf5abad141eb56e05fe000286e3419d72c9f88ef3029e20ab2b
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:92e33ea851a7b6841f9738b4149e827a84e0899e49a11ebb84f4400ef1620303
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:b1fdd985683dcaf5abad141eb56e05fe000286e3419d72c9f88ef3029e20ab2b
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:92e33ea851a7b6841f9738b4149e827a84e0899e49a11ebb84f4400ef1620303
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:b1fdd985683dcaf5abad141eb56e05fe000286e3419d72c9f88ef3029e20ab2b
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -15,7 +15,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:92e33ea851a7b6841f9738b4149e827a84e0899e49a11ebb84f4400ef1620303
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:b1fdd985683dcaf5abad141eb56e05fe000286e3419d72c9f88ef3029e20ab2b
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -23,7 +23,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:92e33ea851a7b6841f9738b4149e827a84e0899e49a11ebb84f4400ef1620303
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:b1fdd985683dcaf5abad141eb56e05fe000286e3419d72c9f88ef3029e20ab2b
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+++ b/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
@@ -23,7 +23,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: refresh-execution-tca
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:92e33ea851a7b6841f9738b4149e827a84e0899e49a11ebb84f4400ef1620303
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:b1fdd985683dcaf5abad141eb56e05fe000286e3419d72c9f88ef3029e20ab2b
               imagePullPolicy: IfNotPresent
               env:
                 - name: DB_DSN

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:92e33ea851a7b6841f9738b4149e827a84e0899e49a11ebb84f4400ef1620303
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:b1fdd985683dcaf5abad141eb56e05fe000286e3419d72c9f88ef3029e20ab2b
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-14T18:07:43Z"
+        client.knative.dev/updateTimestamp: "2026-05-14T18:26:58Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -27,7 +27,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:92e33ea851a7b6841f9738b4149e827a84e0899e49a11ebb84f4400ef1620303
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:b1fdd985683dcaf5abad141eb56e05fe000286e3419d72c9f88ef3029e20ab2b
           ports:
             - name: http1
               containerPort: 8181
@@ -482,11 +482,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.569.1-447-g5cfd9ffcf
+              value: v0.569.1-450-g37e22937d
             - name: TORGHUT_COMMIT
-              value: 5cfd9ffcf21b1307fc54d0999be3a9d95fb93e38
+              value: 37e22937d5074b1bdbc1b0bed427478d65acd3dc
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:92e33ea851a7b6841f9738b4149e827a84e0899e49a11ebb84f4400ef1620303
+              value: sha256:b1fdd985683dcaf5abad141eb56e05fe000286e3419d72c9f88ef3029e20ab2b
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-14T18:07:43Z"
+        client.knative.dev/updateTimestamp: "2026-05-14T18:26:58Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:92e33ea851a7b6841f9738b4149e827a84e0899e49a11ebb84f4400ef1620303
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:b1fdd985683dcaf5abad141eb56e05fe000286e3419d72c9f88ef3029e20ab2b
           ports:
             - name: http1
               containerPort: 8181
@@ -306,11 +306,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.569.1-447-g5cfd9ffcf
+              value: v0.569.1-450-g37e22937d
             - name: TORGHUT_COMMIT
-              value: 5cfd9ffcf21b1307fc54d0999be3a9d95fb93e38
+              value: 37e22937d5074b1bdbc1b0bed427478d65acd3dc
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:92e33ea851a7b6841f9738b4149e827a84e0899e49a11ebb84f4400ef1620303
+              value: sha256:b1fdd985683dcaf5abad141eb56e05fe000286e3419d72c9f88ef3029e20ab2b
           livenessProbe:
             httpGet:
               path: /healthz

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -98,7 +98,7 @@ spec:
           - name: allowStaleTape
           - name: persistResults
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:92e33ea851a7b6841f9738b4149e827a84e0899e49a11ebb84f4400ef1620303
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:b1fdd985683dcaf5abad141eb56e05fe000286e3419d72c9f88ef3029e20ab2b
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
+++ b/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:92e33ea851a7b6841f9738b4149e827a84e0899e49a11ebb84f4400ef1620303
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:b1fdd985683dcaf5abad141eb56e05fe000286e3419d72c9f88ef3029e20ab2b
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `37e22937d5074b1bdbc1b0bed427478d65acd3dc`
- Image tag: `37e22937`
- Image digest: `sha256:b1fdd985683dcaf5abad141eb56e05fe000286e3419d72c9f88ef3029e20ab2b`