### PR TITLE
fix(torghut): allow bounded paper quote catchup

### DIFF
--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -152,6 +152,8 @@ spec:
               value: torghut.ta_microbars
             - name: TRADING_EXECUTABLE_QUOTE_LOOKBACK_SECONDS
               value: "300"
+            - name: TRADING_EXECUTABLE_QUOTE_FORWARD_SECONDS
+              value: "60"
             - name: TRADING_SESSION_CONTEXT_WARMUP_MAX_SECONDS
               value: "300"
             - name: TRADING_SESSION_CONTEXT_WARMUP_MAX_SIGNALS

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -134,6 +134,8 @@ spec:
               value: torghut.ta_microbars
             - name: TRADING_EXECUTABLE_QUOTE_LOOKBACK_SECONDS
               value: "60"
+            - name: TRADING_EXECUTABLE_QUOTE_FORWARD_SECONDS
+              value: "0"
             - name: TRADING_SESSION_CONTEXT_WARMUP_MAX_SECONDS
               value: "300"
             - name: TRADING_SESSION_CONTEXT_WARMUP_MAX_SIGNALS

--- a/services/torghut/app/config.py
+++ b/services/torghut/app/config.py
@@ -426,6 +426,15 @@ class Settings(BaseSettings):
         alias="TRADING_EXECUTABLE_QUOTE_LOOKBACK_SECONDS",
         description="Maximum age for a last-good executable quote used to backfill bid/ask before quote-quality checks.",
     )
+    trading_executable_quote_forward_seconds: int = Field(
+        default=0,
+        alias="TRADING_EXECUTABLE_QUOTE_FORWARD_SECONDS",
+        description=(
+            "Runtime-only grace window for using an executable quote that arrives after "
+            "a signal timestamp but before decision evaluation. Keep this disabled for "
+            "replay and live-submit lanes."
+        ),
+    )
     trading_poll_ms: int = Field(default=5000, alias="TRADING_POLL_MS")
     trading_reconcile_ms: int = Field(default=15000, alias="TRADING_RECONCILE_MS")
     trading_order_feed_enabled: bool = Field(

--- a/services/torghut/app/trading/prices.py
+++ b/services/torghut/app/trading/prices.py
@@ -104,6 +104,7 @@ class ClickHousePriceFetcher(PriceFetcher):
         quote_table: Optional[str] = None,
         lookback_minutes: Optional[int] = None,
         quote_lookback_seconds: Optional[int] = None,
+        quote_forward_seconds: Optional[int] = None,
     ) -> None:
         self.url = (url or settings.trading_clickhouse_url or "").rstrip("/")
         self.username = username or settings.trading_clickhouse_username
@@ -120,6 +121,12 @@ class ClickHousePriceFetcher(PriceFetcher):
             quote_lookback_seconds
             or settings.trading_executable_quote_lookback_seconds,
         )
+        configured_forward_seconds = (
+            settings.trading_executable_quote_forward_seconds
+            if quote_forward_seconds is None
+            else quote_forward_seconds
+        )
+        self.quote_forward_seconds = max(0, configured_forward_seconds)
         self._columns: Optional[set[str]] = None
 
     def fetch_price(self, signal: SignalEnvelope) -> Optional[Decimal]:
@@ -226,6 +233,13 @@ class ClickHousePriceFetcher(PriceFetcher):
         target_ts: datetime,
     ) -> dict[str, Any] | None:
         lookback = target_ts - timedelta(seconds=self.quote_lookback_seconds)
+        quote_window_end = target_ts
+        if self.quote_forward_seconds > 0:
+            forward_end = target_ts + timedelta(seconds=self.quote_forward_seconds)
+            now = datetime.now(timezone.utc)
+            if target_ts.tzinfo is None:
+                now = now.replace(tzinfo=None)
+            quote_window_end = min(forward_end, now)
         order_clause = "event_ts DESC"
         query = " ".join(
             [
@@ -237,7 +251,7 @@ class ClickHousePriceFetcher(PriceFetcher):
                 "AND",
                 f"event_ts >= {to_datetime64(lookback)}",
                 "AND",
-                f"event_ts <= {to_datetime64(target_ts)}",
+                f"event_ts <= {to_datetime64(quote_window_end)}",
                 "AND",
                 "imbalance_bid_px IS NOT NULL",
                 "AND",

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -533,10 +533,18 @@ class TestLiveConfigManifestContract(TestCase):
             "300",
         )
         self.assertEqual(
+            sim_env.get("TRADING_EXECUTABLE_QUOTE_FORWARD_SECONDS"),
+            "60",
+        )
+        self.assertEqual(
             _load_torghut_knative_env().get(
                 "TRADING_EXECUTABLE_QUOTE_LOOKBACK_SECONDS"
             ),
             "60",
+        )
+        self.assertEqual(
+            _load_torghut_knative_env().get("TRADING_EXECUTABLE_QUOTE_FORWARD_SECONDS"),
+            "0",
         )
         self.assertEqual(
             sim_env.get("TRADING_UNIVERSE_STATIC_FALLBACK_SYMBOLS"),

--- a/services/torghut/tests/test_prices.py
+++ b/services/torghut/tests/test_prices.py
@@ -38,12 +38,14 @@ class RoutingClickHousePriceFetcher(ClickHousePriceFetcher):
         price_rows: list[dict[str, object]],
         quote_rows: list[dict[str, object]],
         fail_quote_query: bool = False,
+        quote_forward_seconds: int = 0,
     ) -> None:
         super().__init__(
             url="http://example",
             table="torghut.ta_microbars",
             quote_table="torghut.ta_signals",
             quote_lookback_seconds=60,
+            quote_forward_seconds=quote_forward_seconds,
         )
         self.price_rows = price_rows
         self.quote_rows = quote_rows
@@ -192,6 +194,41 @@ class TestClickHousePriceFetcher(TestCase):
         self.assertEqual(snapshot.spread, Decimal("0.20"))
         self.assertEqual(snapshot.source, "ta_signals_quote")
 
+    def test_fetch_market_snapshot_can_use_runtime_forward_quote_window(
+        self,
+    ) -> None:
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 1, 1, 12, 0, 30, tzinfo=timezone.utc),
+            symbol="NVDA",
+            payload={},
+        )
+        fetcher = RoutingClickHousePriceFetcher(
+            price_rows=[],
+            quote_rows=[
+                {
+                    "event_ts": "2026-01-01T12:00:45Z",
+                    "imbalance_bid_px": "200.10",
+                    "imbalance_ask_px": "200.30",
+                }
+            ],
+            quote_forward_seconds=30,
+        )
+
+        snapshot = fetcher.fetch_market_snapshot(signal)
+
+        self.assertIsNotNone(snapshot)
+        assert snapshot is not None
+        self.assertEqual(snapshot.price, Decimal("200.20"))
+        self.assertEqual(snapshot.bid, Decimal("200.10"))
+        self.assertEqual(snapshot.ask, Decimal("200.30"))
+        self.assertEqual(
+            snapshot.as_of, datetime(2026, 1, 1, 12, 0, 45, tzinfo=timezone.utc)
+        )
+        self.assertEqual(snapshot.source, "ta_signals_quote")
+        self.assertIn(
+            "event_ts <= toDateTime64('2026-01-01 12:01:00", fetcher.queries[1]
+        )
+
     def test_fetch_market_snapshot_returns_none_without_price_or_quote(
         self,
     ) -> None:
@@ -238,9 +275,7 @@ class TestClickHousePriceFetcher(TestCase):
             payload={},
         )
         fetcher = RoutingClickHousePriceFetcher(
-            price_rows=[
-                {"event_ts": "2026-01-01T12:00:29Z", "c": "200.25"}
-            ],
+            price_rows=[{"event_ts": "2026-01-01T12:00:29Z", "c": "200.25"}],
             quote_rows=[],
             fail_quote_query=True,
         )


### PR DESCRIPTION
## Summary

- Added a disabled-by-default runtime quote forward window to `ClickHousePriceFetcher`.
- Enabled a 60 second forward executable-quote catchup only for the Torghut paper sim lane.
- Kept the live-submit lane explicit at `TRADING_EXECUTABLE_QUOTE_FORWARD_SECONDS=0`.
- Added price-fetcher and manifest-contract coverage for the new quote window.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest -q tests/test_prices.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen ruff check app/config.py app/trading/prices.py tests/test_prices.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen ruff format --check app/config.py app/trading/prices.py tests/test_prices.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
