### PR TITLE
fix(torghut): restrict jangar carry repair tickets

### DIFF
--- a/services/torghut/app/trading/jangar_controller_ingestion_carry.py
+++ b/services/torghut/app/trading/jangar_controller_ingestion_carry.py
@@ -327,7 +327,6 @@ def _repairable_ticket_present(
     repair_slot: Mapping[str, Any],
 ) -> bool:
     ticket_class = _selected_ticket_class(settlement, repair_slot)
-    ticket_id = _selected_ticket_id(settlement, repair_slot)
     release_condition = _first_text(
         repair_slot.get("release_condition"),
         repair_slot.get("releaseCondition"),
@@ -344,7 +343,6 @@ def _repairable_ticket_present(
         ticket_class == "jangar_verify_carry"
         or release_condition == "jangar_controller_ingestion_current"
         or receipt == "jangar.verify-trust-foreclosure-ticket.v1"
-        or bool(ticket_id and repair_slot)
     )
 
 

--- a/services/torghut/tests/test_jangar_controller_ingestion_carry.py
+++ b/services/torghut/tests/test_jangar_controller_ingestion_carry.py
@@ -87,6 +87,35 @@ def test_controller_ingestion_carry_classifies_repairable_ticket() -> None:
     assert carry["validation_commands"]
 
 
+def test_controller_ingestion_carry_rejects_unrelated_repair_ticket() -> None:
+    carry = build_jangar_controller_ingestion_carry(
+        generated_at=NOW,
+        dependency_quorum={
+            "controller_ingestion_settlement": {
+                "settlement_id": "controller-ingestion-settlement:unrelated",
+                "decision": "repair_only",
+                "controller_ingestion_current": False,
+                "selected_repair_ticket": {
+                    "ticket_id": "alpha-evidence-window-ticket:repair",
+                    "ticket_class": "alpha_evidence_window",
+                    "required_output_receipt": (
+                        "torghut.alpha-evidence-window-receipt.v1"
+                    ),
+                    "validation_commands": [
+                        "uv run --frozen pytest services/torghut/tests/test_alpha_evidence_foundry.py"
+                    ],
+                },
+            },
+        },
+    )
+
+    assert carry["carry_state"] == "unavailable"
+    assert carry["selected_ticket_class"] == "alpha_evidence_window"
+    assert carry["selected_ticket_id"] == "alpha-evidence-window-ticket:repair"
+    assert "jangar_controller_ingestion_repairable" not in carry["reason_codes"]
+    assert "jangar_verify_foreclosure_board_missing" in carry["reason_codes"]
+
+
 def test_controller_ingestion_carry_classifies_lagging_source_claim() -> None:
     carry = build_jangar_controller_ingestion_carry(
         generated_at=NOW,


### PR DESCRIPTION
## Summary

- Rebases #6676 onto current `main` after #6665 merged the broader controller-ingestion carry import.
- Tightens `torghut.jangar-controller-ingestion-carry.v1` so an unrelated repair ticket id no longer classifies a Jangar controller-ingestion settlement as `repairable`.
- Adds a regression for a `repair_only` settlement carrying an `alpha_evidence_window` ticket, preserving no-delta denial, `max_notional=0`, and the Jangar verify-carry ticket boundary.

## Related Issues

None

Design provenance:

- `docs/torghut/design-system/v6/211-torghut-controller-ingestion-carry-and-alpha-no-delta-release-2026-05-14.md`
- `docs/agents/designs/205-jangar-controller-ingestion-settlement-and-verification-carry-cutover-2026-05-14.md`

Runtime evidence:

- Before: `GET http://agents.agents.svc.cluster.local/ready` at 2026-05-14T18:32Z reported `business_state=repair_only`, `revenue_ready=false`, top repair `repair_alpha_readiness`, affected gate `routeable_candidate_count`, and `execution_trust=degraded` due `verify stage is stale`.
- After local implementation: live `/ready` at 2026-05-14T19:02Z reported `business_state=repair_only`, `revenue_ready=false`, top repair `repair_alpha_readiness`, affected gate `routeable_candidate_count`, and `execution_trust=healthy`.
- Live Torghut `/trading/revenue-repair` at 2026-05-14T19:02Z still serves revision `torghut-00408` from build commit `37e22937d5074b1bdbc1b0bed427478d65acd3dc`, denies no-delta reentry with selected ticket `null`, `max_notional=0`, and `jangar_verification_carry_unavailable`; it does not yet expose `jangar_controller_ingestion_carry` because #6665/#6676 have not been built and deployed.
- PR state after CI: head `82e82dd1ae44af993b16099ae812695dbb27587d`, open, not draft, `mergeStateStatus=CLEAN`, and review threads empty.

Risk and rollback:

- Risk: the carry classifier can select a Jangar repair path too broadly if unrelated Torghut repair slots are accepted as Jangar verify-carry evidence. Mitigation: this PR narrows the repairable predicate to Jangar ticket class, release condition, or receipt provenance and adds a regression test.
- Rollback: revert this PR. The #6665 import remains in observe mode, the no-delta auction still denies unchanged retries, live submission stays disabled while repair-only, and `max_notional=0` remains authoritative.

## Testing

- Hosted GitHub checks on `82e82dd1`: pass for `Bytecode + lint + migration guard`, `Bytecode + pytest + coverage`, `Changed-file plan`, `Pyright`, `Pytest shard 0` through `Pytest shard 3`, `Pytest autoresearch runner 0` through `Pytest autoresearch runner 7`, `Quality signals (complexity + security)`, `Lint commit messages`, `Validate PR title`, and `check_changed_files`.
- `/tmp/codex-uv/uv run --frozen pytest tests/test_jangar_controller_ingestion_carry.py -q` - pass, 9 tests, 1 existing event-loop deprecation warning
- `/tmp/codex-uv/uv run --frozen pytest tests/test_jangar_controller_ingestion_carry.py tests/test_no_delta_repair_reentry_auction.py tests/test_build_revenue_repair_digest.py -q` - pass, 43 tests, 1 existing event-loop deprecation warning
- `/tmp/codex-uv/uv run --frozen ruff check app/trading/jangar_controller_ingestion_carry.py tests/test_jangar_controller_ingestion_carry.py` - pass
- `/tmp/codex-uv/uv run --frozen ruff format --check app/trading/jangar_controller_ingestion_carry.py tests/test_jangar_controller_ingestion_carry.py` - pass
- `/tmp/codex-uv/uv run --frozen pyright --project pyrightconfig.json` - pass, 0 errors
- `/tmp/codex-uv/uv run --frozen pyright --project pyrightconfig.alpha.json` - pass, 0 errors
- `/tmp/codex-uv/uv run --frozen pyright --project pyrightconfig.scripts.json` - pass, 0 errors
- `git diff --check` - pass

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
