### PR TITLE
fix(torghut): remediate feedback-shaped replay candidates

### DIFF
--- a/.github/workflows/torghut-ci.yml
+++ b/.github/workflows/torghut-ci.yml
@@ -393,7 +393,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        slice: [0, 1, 2, 3, 4, 5, 6, 7]
+        slice: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -426,7 +426,7 @@ jobs:
         env:
           COVERAGE_FILE: .coverage.autoresearch-runner-${{ matrix.slice }}
           SLICE_INDEX: ${{ matrix.slice }}
-          SLICE_TOTAL: 8
+          SLICE_TOTAL: 16
         run: |
           set -euo pipefail
           mapfile -t TEST_IDS < <(
@@ -521,8 +521,8 @@ jobs:
           set -euo pipefail
           mapfile -t COVERAGE_FILES < <(find .coverage-shards -type f -name '.coverage*' -print | sort)
           printf 'Combining %s coverage data files\n' "${#COVERAGE_FILES[@]}"
-          if [ "${#COVERAGE_FILES[@]}" -lt 12 ]; then
-            echo "Expected coverage data from all 4 pytest shards and all 8 autoresearch runner slices"
+          if [ "${#COVERAGE_FILES[@]}" -lt 20 ]; then
+            echo "Expected coverage data from all 4 pytest shards and all 16 autoresearch runner slices"
             exit 1
           fi
           uv run --frozen coverage combine "${COVERAGE_FILES[@]}"

--- a/.github/workflows/torghut-ci.yml
+++ b/.github/workflows/torghut-ci.yml
@@ -431,7 +431,7 @@ jobs:
           set -euo pipefail
           mapfile -t TEST_IDS < <(
             uv run --frozen pytest --collect-only -q tests/test_run_whitepaper_autoresearch_profit_target.py |
-              awk '/^tests\// {print $1}' |
+              awk '/^tests\/.*::/ {print $1}' |
               awk -v slice="${SLICE_INDEX}" -v total="${SLICE_TOTAL}" '((NR - 1) % total) == slice'
           )
           printf 'Running %s autoresearch runner tests in slice %s/%s\n' "${#TEST_IDS[@]}" "${SLICE_INDEX}" "${SLICE_TOTAL}"

--- a/.github/workflows/torghut-ci.yml
+++ b/.github/workflows/torghut-ci.yml
@@ -432,7 +432,12 @@ jobs:
           mapfile -t TEST_IDS < <(
             uv run --frozen pytest --collect-only -q tests/test_run_whitepaper_autoresearch_profit_target.py |
               awk '/^tests\/.*::/ {print $1}' |
-              awk -v slice="${SLICE_INDEX}" -v total="${SLICE_TOTAL}" '((NR - 1) % total) == slice'
+              while IFS= read -r test_id; do
+                checksum="$(printf '%s' "${test_id}" | cksum | awk '{print $1}')"
+                if [ "$((checksum % SLICE_TOTAL))" -eq "${SLICE_INDEX}" ]; then
+                  printf '%s\n' "${test_id}"
+                fi
+              done
           )
           printf 'Running %s autoresearch runner tests in slice %s/%s\n' "${#TEST_IDS[@]}" "${SLICE_INDEX}" "${SLICE_TOTAL}"
           if [ "${#TEST_IDS[@]}" -eq 0 ]; then

--- a/services/torghut/app/trading/discovery/candidate_specs.py
+++ b/services/torghut/app/trading/discovery/candidate_specs.py
@@ -1951,6 +1951,188 @@ def _capital_limited_profile_values(profile: Mapping[str, Any]) -> tuple[str, st
     return _format_profile_budget(max_notional), _format_profile_budget(max_position)
 
 
+def _decimal_profile_param(
+    params: Mapping[str, Any],
+    key: str,
+    *,
+    default: Decimal,
+) -> Decimal:
+    try:
+        return Decimal(str(params.get(key) or default))
+    except Exception:
+        return default
+
+
+def _int_profile_param(params: Mapping[str, Any], key: str, *, default: int) -> int:
+    try:
+        return int(Decimal(str(params.get(key) or default)))
+    except Exception:
+        return default
+
+
+def _clamped_profile_decimal(
+    *,
+    params: Mapping[str, Any],
+    key: str,
+    default: Decimal,
+    delta: Decimal,
+    lower: Decimal,
+    upper: Decimal,
+    places: Decimal = Decimal("0.01"),
+) -> str:
+    value = _decimal_profile_param(params, key, default=default) + delta
+    return _format_profile_budget(min(upper, max(lower, value)).quantize(places))
+
+
+def _cash_constrain_profile(
+    profile: dict[str, Any],
+    *,
+    capital_profile: str,
+    label: str,
+) -> dict[str, Any]:
+    params = _mapping(profile.get("params"))
+    max_notional, max_position = _capital_limited_profile_values(profile)
+    profile["max_notional_per_trade"] = max_notional
+    profile["max_position_pct_equity"] = max_position
+    params["capital_profile"] = capital_profile
+    params["feedback_remediation_profile"] = label
+    params["max_gross_exposure_pct_equity"] = "1.0"
+    profile["params"] = params
+    return profile
+
+
+def _daily_coverage_feedback_escape_profile(
+    profile: Mapping[str, Any],
+) -> dict[str, Any]:
+    next_profile = json.loads(json.dumps(profile))
+    params = _mapping(next_profile.get("params"))
+    params["max_entries_per_session"] = str(
+        max(2, min(4, _int_profile_param(params, "max_entries_per_session", default=2)))
+    )
+    params["max_concurrent_positions"] = str(
+        max(1, min(3, _profile_rank_count_floor(next_profile)))
+    )
+    params["entry_cooldown_seconds"] = str(
+        max(300, _int_profile_param(params, "entry_cooldown_seconds", default=600))
+    )
+    params["long_stop_loss_bps"] = str(
+        min(8, max(4, _int_profile_param(params, "long_stop_loss_bps", default=6)))
+    )
+    params["short_stop_loss_bps"] = str(
+        min(8, max(4, _int_profile_param(params, "short_stop_loss_bps", default=6)))
+    )
+    params["max_session_negative_exit_bps"] = str(
+        min(
+            8,
+            max(
+                3,
+                _int_profile_param(params, "max_session_negative_exit_bps", default=4),
+            ),
+        )
+    )
+    next_profile["params"] = params
+    return _cash_constrain_profile(
+        next_profile,
+        capital_profile="feedback_daily_coverage_cash_constrained_1x",
+        label="daily_coverage_feedback_escape",
+    )
+
+
+def _consistency_guard_feedback_escape_profile(
+    profile: Mapping[str, Any],
+) -> dict[str, Any]:
+    next_profile = json.loads(json.dumps(profile))
+    params = _mapping(next_profile.get("params"))
+    params["entry_cooldown_seconds"] = str(
+        max(1200, _int_profile_param(params, "entry_cooldown_seconds", default=1200))
+    )
+    params["long_stop_loss_bps"] = str(
+        min(6, max(4, _int_profile_param(params, "long_stop_loss_bps", default=6)))
+    )
+    params["short_stop_loss_bps"] = str(
+        min(6, max(4, _int_profile_param(params, "short_stop_loss_bps", default=6)))
+    )
+    params["max_session_negative_exit_bps"] = str(
+        min(
+            5,
+            max(
+                2,
+                _int_profile_param(params, "max_session_negative_exit_bps", default=3),
+            ),
+        )
+    )
+    next_profile["max_position_pct_equity"] = _clamped_profile_decimal(
+        params=next_profile,
+        key="max_position_pct_equity",
+        default=Decimal("0.25"),
+        delta=Decimal("-0.05"),
+        lower=Decimal("0.05"),
+        upper=Decimal("0.35"),
+    )
+    next_profile["params"] = params
+    return _cash_constrain_profile(
+        next_profile,
+        capital_profile="feedback_consistency_guard_cash_constrained_1x",
+        label="consistency_guard_feedback_escape",
+    )
+
+
+def _turnover_coverage_feedback_escape_profile(
+    profile: Mapping[str, Any],
+) -> dict[str, Any]:
+    next_profile = json.loads(json.dumps(profile))
+    params = _mapping(next_profile.get("params"))
+    current_entries = _int_profile_param(params, "max_entries_per_session", default=3)
+    params["max_entries_per_session"] = str(max(2, min(5, current_entries + 1)))
+    params["max_concurrent_positions"] = str(
+        max(1, min(2, _profile_rank_count_floor(next_profile)))
+    )
+    current_cooldown = _int_profile_param(params, "entry_cooldown_seconds", default=480)
+    params["entry_cooldown_seconds"] = str(max(180, min(900, current_cooldown)))
+    current_hold_seconds = _int_profile_param(params, "max_hold_seconds", default=1800)
+    params["max_hold_seconds"] = str(max(300, min(2400, current_hold_seconds)))
+    params["long_stop_loss_bps"] = str(
+        min(6, max(3, _int_profile_param(params, "long_stop_loss_bps", default=5)))
+    )
+    params["short_stop_loss_bps"] = str(
+        min(6, max(3, _int_profile_param(params, "short_stop_loss_bps", default=5)))
+    )
+    params["max_session_negative_exit_bps"] = str(
+        min(
+            5,
+            max(
+                2,
+                _int_profile_param(params, "max_session_negative_exit_bps", default=3),
+            ),
+        )
+    )
+    next_profile["params"] = params
+    return _cash_constrain_profile(
+        next_profile,
+        capital_profile="feedback_turnover_coverage_cash_constrained_1x",
+        label="turnover_coverage_feedback_escape",
+    )
+
+
+def _portfolio_feedback_escape_execution_profiles(
+    profiles: Sequence[Mapping[str, Any]],
+) -> tuple[dict[str, Any], ...]:
+    expanded: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for profile in profiles:
+        for next_profile in (
+            _daily_coverage_feedback_escape_profile(profile),
+            _consistency_guard_feedback_escape_profile(profile),
+            _turnover_coverage_feedback_escape_profile(profile),
+        ):
+            key = _stable_hash(next_profile)
+            if key in seen:
+                continue
+            seen.add(key)
+            expanded.append(next_profile)
+    return tuple(expanded)
+
+
 def _capital_constrained_execution_profiles(
     profiles: Sequence[Mapping[str, Any]],
 ) -> tuple[dict[str, Any], ...]:
@@ -2297,9 +2479,16 @@ def _execution_profiles_for_target(
         family_template_id, ()
     )
     exploratory_profiles = (*base_profiles, *portfolio_profiles)
+    capital_constrained_profiles = _capital_constrained_execution_profiles(
+        exploratory_profiles
+    )
+    feedback_escape_profiles = _portfolio_feedback_escape_execution_profiles(
+        exploratory_profiles
+    )
     return (
         *exploratory_profiles,
-        *_capital_constrained_execution_profiles(exploratory_profiles),
+        *capital_constrained_profiles,
+        *feedback_escape_profiles,
     )
 
 

--- a/services/torghut/app/trading/discovery/evidence_bundles.py
+++ b/services/torghut/app/trading/discovery/evidence_bundles.py
@@ -128,6 +128,12 @@ def evidence_bundle_from_frontier_candidate(
         "runtime_family",
         "runtime_strategy_name",
         "execution_signature",
+        "execution_profile_id",
+        "execution_profile_index",
+        "feedback_risk_profile_key",
+        "feedback_shape_key",
+        "universe_key",
+        "signal_key",
     ):
         value = _string(candidate.get(key))
         if value and key not in scorecard:

--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -104,6 +104,28 @@ _RUNTIME_CLOSURE_PROOF_ORACLE_BLOCKERS = frozenset(
         "executable_replay_notional_within_buying_power_failed",
     }
 )
+_FAMILY_PRIOR_HARD_BLOCK_ORACLE_BLOCKERS = frozenset(
+    {
+        "active_day_ratio_below_oracle",
+        "positive_day_ratio_below_oracle",
+        "best_day_share_above_oracle",
+    }
+)
+_RISK_PROFILE_FEEDBACK_ORACLE_BLOCKERS = frozenset(
+    {
+        "active_day_ratio_below_oracle",
+        "positive_day_ratio_below_oracle",
+        "best_day_share_above_oracle",
+        "active_day_ratio_failed",
+        "positive_day_ratio_failed",
+        "min_daily_net_pnl_failed",
+        "daily_net_observed_day_count_failed",
+        "best_day_share_failed",
+        "max_single_day_contribution_share_failed",
+        "max_single_symbol_contribution_share_failed",
+        "max_cluster_contribution_share_failed",
+    }
+)
 
 
 def _default_strategy_config_path() -> Path:
@@ -231,6 +253,30 @@ def _parse_args() -> argparse.Namespace:
             "Maximum number of bounded real-replay shards to run concurrently. "
             "Defaults to 1 for the legacy sequential behavior."
         ),
+    )
+    parser.add_argument(
+        "--real-replay-failed-spec-retries",
+        type=int,
+        default=1,
+        help=(
+            "Retry candidate specs from timed-out real-replay shards individually "
+            "before marking the epoch replay incomplete."
+        ),
+    )
+    parser.add_argument(
+        "--real-replay-retry-timeout-seconds",
+        type=int,
+        default=0,
+        help=(
+            "Timeout for missing-spec retry replays. Defaults to twice the shard "
+            "timeout when omitted."
+        ),
+    )
+    parser.add_argument(
+        "--real-replay-retry-max-frontier-candidates-per-spec",
+        type=int,
+        default=1,
+        help="Frontier candidate budget for each missing-spec retry replay.",
     )
     parser.add_argument("--train-days", type=int, default=6)
     parser.add_argument("--holdout-days", type=int, default=3)
@@ -2085,6 +2131,27 @@ def _profitability_next_epoch_plan(
     real_replay_shard_workers = _int_arg(args, "real_replay_shard_workers", 1)
     if real_replay_shard_workers > 1:
         flags["--real-replay-shard-workers"] = str(real_replay_shard_workers)
+    real_replay_failed_spec_retries = _int_arg(
+        args, "real_replay_failed_spec_retries", 1
+    )
+    if real_replay_failed_spec_retries > 0:
+        flags["--real-replay-failed-spec-retries"] = str(
+            real_replay_failed_spec_retries
+        )
+    real_replay_retry_timeout_seconds = _int_arg(
+        args, "real_replay_retry_timeout_seconds", 0
+    )
+    if real_replay_retry_timeout_seconds > 0:
+        flags["--real-replay-retry-timeout-seconds"] = str(
+            real_replay_retry_timeout_seconds
+        )
+    real_replay_retry_frontier_candidates = _int_arg(
+        args, "real_replay_retry_max_frontier_candidates_per_spec", 1
+    )
+    if real_replay_retry_frontier_candidates > 1:
+        flags["--real-replay-retry-max-frontier-candidates-per-spec"] = str(
+            real_replay_retry_frontier_candidates
+        )
     shadow_validation_artifact = getattr(args, "shadow_validation_artifact", None)
     if shadow_validation_artifact is not None:
         flags["--shadow-validation-artifact"] = str(shadow_validation_artifact)
@@ -2329,37 +2396,153 @@ def _pre_replay_candidate_score(spec: CandidateSpec) -> Decimal:
     return family_score + Decimal(feature_count) - failure_penalty - capital_penalty
 
 
+def _candidate_spec_universe_key(spec: CandidateSpec) -> str:
+    universe = spec.strategy_overrides.get("universe_symbols")
+    if not isinstance(universe, Sequence) or isinstance(universe, str):
+        return ""
+    return ",".join(sorted(_string(item).upper() for item in universe if _string(item)))
+
+
+def _candidate_spec_signal_key(spec: CandidateSpec) -> str:
+    params = _mapping(spec.strategy_overrides.get("params"))
+    return "|".join(
+        part
+        for part in (
+            _string(params.get("signal_motif")),
+            _string(params.get("selection_mode")),
+            _string(params.get("rank_feature")),
+        )
+        if part
+    )
+
+
+def _candidate_spec_execution_profile(spec: CandidateSpec) -> Mapping[str, Any]:
+    return _mapping(spec.feature_contract.get("execution_profile"))
+
+
+def _feedback_risk_profile_key_payload(
+    *,
+    family_template_id: str,
+    runtime_strategy_name: str,
+    execution_profile_id: str,
+    universe_key: str,
+    signal_key: str,
+) -> Mapping[str, Any]:
+    return {
+        "family_template_id": family_template_id,
+        "runtime_strategy_name": runtime_strategy_name,
+        "execution_profile_id": execution_profile_id,
+        "universe_key": universe_key,
+        "signal_key": signal_key,
+    }
+
+
+def _candidate_spec_feedback_risk_profile_key(spec: CandidateSpec) -> str:
+    execution_profile = _candidate_spec_execution_profile(spec)
+    return _stable_hash(
+        _feedback_risk_profile_key_payload(
+            family_template_id=spec.family_template_id,
+            runtime_strategy_name=spec.runtime_strategy_name,
+            execution_profile_id=_string(execution_profile.get("profile_id")),
+            universe_key=_candidate_spec_universe_key(spec),
+            signal_key=_candidate_spec_signal_key(spec),
+        )
+    )
+
+
+def _candidate_spec_feedback_shape_key(spec: CandidateSpec) -> str:
+    params = _mapping(spec.strategy_overrides.get("params"))
+    execution_profile = _candidate_spec_execution_profile(spec)
+    return _stable_hash(
+        {
+            "family_template_id": spec.family_template_id,
+            "runtime_family": spec.runtime_family,
+            "runtime_strategy_name": spec.runtime_strategy_name,
+            "execution_profile_id": _string(execution_profile.get("profile_id")),
+            "universe_key": _candidate_spec_universe_key(spec),
+            "signal_key": _candidate_spec_signal_key(spec),
+            "capital_profile": _string(params.get("capital_profile")),
+            "entry_minute_after_open": _string(params.get("entry_minute_after_open")),
+            "exit_minute_after_open": _string(params.get("exit_minute_after_open")),
+            "entry_start_minute_utc": _string(params.get("entry_start_minute_utc")),
+            "entry_end_minute_utc": _string(params.get("entry_end_minute_utc")),
+            "max_entries_per_session": _string(params.get("max_entries_per_session")),
+            "max_concurrent_positions": _string(params.get("max_concurrent_positions")),
+            "top_n": _string(params.get("top_n")),
+            "max_pair_legs": _string(params.get("max_pair_legs")),
+            "long_stop_loss_bps": _string(params.get("long_stop_loss_bps")),
+            "short_stop_loss_bps": _string(params.get("short_stop_loss_bps")),
+            "max_session_negative_exit_bps": _string(
+                params.get("max_session_negative_exit_bps")
+            ),
+        }
+    )
+
+
+def _candidate_spec_feedback_metadata(spec: CandidateSpec) -> dict[str, Any]:
+    execution_profile = _candidate_spec_execution_profile(spec)
+    return {
+        "family_template_id": spec.family_template_id,
+        "runtime_family": spec.runtime_family,
+        "runtime_strategy_name": spec.runtime_strategy_name,
+        "execution_signature": _candidate_spec_execution_signature(spec),
+        "execution_profile_id": _string(execution_profile.get("profile_id")),
+        "execution_profile_index": execution_profile.get("profile_index"),
+        "feedback_risk_profile_key": _candidate_spec_feedback_risk_profile_key(spec),
+        "feedback_shape_key": _candidate_spec_feedback_shape_key(spec),
+        "universe_key": _candidate_spec_universe_key(spec),
+        "signal_key": _candidate_spec_signal_key(spec),
+    }
+
+
+def _candidate_payload_with_feedback_metadata(
+    *, candidate: Mapping[str, Any], spec: CandidateSpec
+) -> dict[str, Any]:
+    metadata = _candidate_spec_feedback_metadata(spec)
+    next_candidate = {**dict(candidate), **metadata}
+    scorecard = _mapping(next_candidate.get("objective_scorecard"))
+    next_candidate["objective_scorecard"] = {
+        **metadata,
+        **scorecard,
+    }
+    return next_candidate
+
+
 def _pre_replay_prior_bundle(spec: CandidateSpec) -> CandidateEvidenceBundle:
     prior_score = _pre_replay_candidate_score(spec)
     return evidence_bundle_from_frontier_candidate(
         candidate_spec_id=spec.candidate_spec_id,
-        candidate={
-            "candidate_id": f"pre-replay-prior-{spec.candidate_spec_id}",
-            "family_template_id": spec.family_template_id,
-            "runtime_family": spec.runtime_family,
-            "runtime_strategy_name": spec.runtime_strategy_name,
-            "execution_signature": _candidate_spec_execution_signature(spec),
-            "objective_scorecard": {
-                "net_pnl_per_day": str(prior_score),
-                "active_day_ratio": "0.50",
-                "positive_day_ratio": "0.50",
-                "regime_slice_pass_rate": "0.45",
-                "posterior_edge_lower": "0.001",
-                "shadow_parity_status": "pending",
+        candidate=_candidate_payload_with_feedback_metadata(
+            spec=spec,
+            candidate={
+                "candidate_id": f"pre-replay-prior-{spec.candidate_spec_id}",
+                "objective_scorecard": {
+                    "net_pnl_per_day": str(prior_score),
+                    "active_day_ratio": "0.50",
+                    "positive_day_ratio": "0.50",
+                    "regime_slice_pass_rate": "0.45",
+                    "posterior_edge_lower": "0.001",
+                    "shadow_parity_status": "pending",
+                },
+                "promotion_readiness": {
+                    "stage": "research_candidate",
+                    "status": "pre_replay_prior",
+                    "promotable": False,
+                    "blockers": ["runtime_replay_required"],
+                },
             },
-            "promotion_readiness": {
-                "stage": "research_candidate",
-                "status": "pre_replay_prior",
-                "promotable": False,
-                "blockers": ["runtime_replay_required"],
-            },
-        },
+        ),
         dataset_snapshot_id="pre-replay-proposal-priors",
         result_path=f"pre-replay-proposal-priors://{spec.candidate_spec_id}",
     )
 
 
 def _feedback_scorecard_has_hard_veto(scorecard: Mapping[str, Any]) -> bool:
+    if _oracle_blockers(scorecard):
+        return True
+    oracle_passed = scorecard.get("oracle_passed")
+    if oracle_passed is not None and not _boolish(oracle_passed):
+        return True
     hard_vetoes = scorecard.get("hard_vetoes") or scorecard.get("veto_reasons")
     if isinstance(hard_vetoes, str):
         return bool(hard_vetoes.strip())
@@ -2369,8 +2552,47 @@ def _feedback_scorecard_has_hard_veto(scorecard: Mapping[str, Any]) -> bool:
 
 
 def _feedback_daily_net_has_loss(scorecard: Mapping[str, Any]) -> bool:
-    daily_net = _mapping(scorecard.get("daily_net"))
-    return any(_decimal(value) < Decimal("0") for value in daily_net.values())
+    daily_net = scorecard.get("daily_net")
+    if not isinstance(daily_net, Mapping):
+        return False
+    return any(
+        _decimal(value, default="0") <= Decimal("0")
+        for value in cast(Mapping[Any, Any], daily_net).values()
+    )
+
+
+def _feedback_family_prior_has_hard_block(scorecard: Mapping[str, Any]) -> bool:
+    oracle_blockers = _oracle_blockers(scorecard)
+    if oracle_blockers & _FAMILY_PRIOR_HARD_BLOCK_ORACLE_BLOCKERS:
+        return True
+    if _decimal(scorecard.get("active_day_ratio"), default="1") < Decimal("1"):
+        return True
+    if _decimal(scorecard.get("positive_day_ratio"), default="1") < Decimal("1"):
+        return True
+    if _decimal(scorecard.get("best_day_share")) > Decimal("0.50"):
+        return True
+    return _feedback_daily_net_has_loss(scorecard)
+
+
+def _feedback_risk_profile_has_penalty(scorecard: Mapping[str, Any]) -> bool:
+    oracle_blockers = _oracle_blockers(scorecard)
+    if oracle_blockers & _RISK_PROFILE_FEEDBACK_ORACLE_BLOCKERS:
+        return True
+    if _decimal(scorecard.get("active_day_ratio"), default="1") < Decimal("1"):
+        return True
+    if _decimal(scorecard.get("positive_day_ratio"), default="1") < Decimal("0.60"):
+        return True
+    if _decimal(scorecard.get("best_day_share")) > Decimal("0.35"):
+        return True
+    if _decimal(scorecard.get("max_single_day_contribution_share")) > Decimal("0.35"):
+        return True
+    if _decimal(scorecard.get("max_single_symbol_contribution_share")) > Decimal(
+        "0.35"
+    ):
+        return True
+    if _decimal(scorecard.get("max_cluster_contribution_share")) > Decimal("0.40"):
+        return True
+    return False
 
 
 def _feedback_is_blocked(scorecard: Mapping[str, Any]) -> bool:
@@ -2412,6 +2634,30 @@ def _feedback_execution_signature(bundle: CandidateEvidenceBundle) -> str:
     return _string(bundle.objective_scorecard.get("execution_signature"))
 
 
+def _feedback_shape_key(bundle: CandidateEvidenceBundle) -> str:
+    return _string(bundle.objective_scorecard.get("feedback_shape_key"))
+
+
+def _feedback_risk_profile_key_from_scorecard(scorecard: Mapping[str, Any]) -> str:
+    direct_key = _string(scorecard.get("feedback_risk_profile_key"))
+    if direct_key:
+        return direct_key
+    payload = _feedback_risk_profile_key_payload(
+        family_template_id=_string(scorecard.get("family_template_id")),
+        runtime_strategy_name=_string(scorecard.get("runtime_strategy_name")),
+        execution_profile_id=_string(scorecard.get("execution_profile_id")),
+        universe_key=_string(scorecard.get("universe_key")),
+        signal_key=_string(scorecard.get("signal_key")),
+    )
+    if not any(_string(value) for value in payload.values()):
+        return ""
+    return _stable_hash(payload)
+
+
+def _feedback_risk_profile_key(bundle: CandidateEvidenceBundle) -> str:
+    return _feedback_risk_profile_key_from_scorecard(bundle.objective_scorecard)
+
+
 def _execution_signature_feedback_bundle_for_spec(
     *,
     spec: CandidateSpec,
@@ -2419,16 +2665,52 @@ def _execution_signature_feedback_bundle_for_spec(
 ) -> CandidateEvidenceBundle:
     scorecard = {
         **dict(bundle.objective_scorecard),
+        **_candidate_spec_feedback_metadata(spec),
         "feedback_match_scope": "execution_signature",
         "feedback_source_candidate_spec_id": bundle.candidate_spec_id,
-        "family_template_id": spec.family_template_id,
-        "runtime_family": spec.runtime_family,
-        "runtime_strategy_name": spec.runtime_strategy_name,
-        "execution_signature": _candidate_spec_execution_signature(spec),
     }
     return replace(
         bundle,
         candidate_spec_id=spec.candidate_spec_id,
+        candidate_id=f"signature-feedback-{bundle.candidate_id}",
+        objective_scorecard=scorecard,
+    )
+
+
+def _shape_feedback_bundle_for_spec(
+    *,
+    spec: CandidateSpec,
+    bundle: CandidateEvidenceBundle,
+) -> CandidateEvidenceBundle:
+    scorecard = {
+        **dict(bundle.objective_scorecard),
+        **_candidate_spec_feedback_metadata(spec),
+        "feedback_match_scope": "feedback_shape_key",
+        "feedback_source_candidate_spec_id": bundle.candidate_spec_id,
+    }
+    return replace(
+        bundle,
+        candidate_spec_id=spec.candidate_spec_id,
+        candidate_id=f"shape-feedback-{bundle.candidate_id}",
+        objective_scorecard=scorecard,
+    )
+
+
+def _risk_profile_feedback_bundle_for_spec(
+    *,
+    spec: CandidateSpec,
+    bundle: CandidateEvidenceBundle,
+) -> CandidateEvidenceBundle:
+    scorecard = {
+        **dict(bundle.objective_scorecard),
+        **_candidate_spec_feedback_metadata(spec),
+        "feedback_match_scope": "feedback_risk_profile_key",
+        "feedback_source_candidate_spec_id": bundle.candidate_spec_id,
+    }
+    return replace(
+        bundle,
+        candidate_spec_id=spec.candidate_spec_id,
+        candidate_id=f"risk-profile-feedback-{bundle.candidate_id}",
         objective_scorecard=scorecard,
     )
 
@@ -2440,16 +2722,14 @@ def _family_feedback_bundle_for_spec(
 ) -> CandidateEvidenceBundle:
     scorecard = {
         **dict(bundle.objective_scorecard),
+        **_candidate_spec_feedback_metadata(spec),
         "feedback_match_scope": "family_template_id",
         "feedback_source_candidate_spec_id": bundle.candidate_spec_id,
-        "family_template_id": spec.family_template_id,
-        "runtime_family": spec.runtime_family,
-        "runtime_strategy_name": spec.runtime_strategy_name,
-        "execution_signature": _candidate_spec_execution_signature(spec),
     }
     return replace(
         bundle,
         candidate_spec_id=spec.candidate_spec_id,
+        candidate_id=f"family-feedback-{bundle.candidate_id}",
         objective_scorecard=scorecard,
     )
 
@@ -2460,6 +2740,18 @@ def _pre_replay_proposal_model_and_rows(
     feedback_evidence_bundles: Sequence[CandidateEvidenceBundle] = (),
 ) -> tuple[Mapping[str, Any], list[dict[str, Any]]]:
     spec_ids = {spec.candidate_spec_id for spec in specs}
+    execution_signature_by_spec = {
+        spec.candidate_spec_id: _candidate_spec_execution_signature(spec)
+        for spec in specs
+    }
+    feedback_shape_key_by_spec = {
+        spec.candidate_spec_id: _candidate_spec_feedback_shape_key(spec)
+        for spec in specs
+    }
+    feedback_risk_profile_key_by_spec = {
+        spec.candidate_spec_id: _candidate_spec_feedback_risk_profile_key(spec)
+        for spec in specs
+    }
     feedback_by_spec: dict[str, CandidateEvidenceBundle] = {}
     for bundle in feedback_evidence_bundles:
         if bundle.candidate_spec_id not in spec_ids:
@@ -2470,10 +2762,6 @@ def _pre_replay_proposal_model_and_rows(
         ) > _feedback_bundle_sort_value(current):
             feedback_by_spec[bundle.candidate_spec_id] = bundle
 
-    execution_signature_by_spec = {
-        spec.candidate_spec_id: _candidate_spec_execution_signature(spec)
-        for spec in specs
-    }
     feedback_by_execution_signature: dict[str, CandidateEvidenceBundle] = {}
     for bundle in feedback_evidence_bundles:
         execution_signature = _feedback_execution_signature(bundle)
@@ -2495,6 +2783,59 @@ def _pre_replay_proposal_model_and_rows(
                 _execution_signature_feedback_bundle_for_spec(spec=spec, bundle=bundle)
             )
 
+    feedback_by_shape: dict[str, CandidateEvidenceBundle] = {}
+    for bundle in feedback_evidence_bundles:
+        feedback_shape_key = _feedback_shape_key(bundle)
+        if not feedback_shape_key:
+            continue
+        current = feedback_by_shape.get(feedback_shape_key)
+        if current is None or _feedback_bundle_sort_value(
+            bundle
+        ) > _feedback_bundle_sort_value(current):
+            feedback_by_shape[feedback_shape_key] = bundle
+    shape_feedback_by_spec: dict[str, CandidateEvidenceBundle] = {}
+    for spec in specs:
+        if (
+            spec.candidate_spec_id in feedback_by_spec
+            or spec.candidate_spec_id in signature_feedback_by_spec
+        ):
+            continue
+        bundle = feedback_by_shape.get(
+            feedback_shape_key_by_spec[spec.candidate_spec_id]
+        )
+        if bundle is not None:
+            shape_feedback_by_spec[spec.candidate_spec_id] = (
+                _shape_feedback_bundle_for_spec(spec=spec, bundle=bundle)
+            )
+
+    feedback_by_risk_profile: dict[str, CandidateEvidenceBundle] = {}
+    for bundle in feedback_evidence_bundles:
+        if not _feedback_risk_profile_has_penalty(bundle.objective_scorecard):
+            continue
+        risk_profile_key = _feedback_risk_profile_key(bundle)
+        if not risk_profile_key:
+            continue
+        current = feedback_by_risk_profile.get(risk_profile_key)
+        if current is None or _feedback_bundle_sort_value(
+            bundle
+        ) > _feedback_bundle_sort_value(current):
+            feedback_by_risk_profile[risk_profile_key] = bundle
+    risk_profile_feedback_by_spec: dict[str, CandidateEvidenceBundle] = {}
+    for spec in specs:
+        if (
+            spec.candidate_spec_id in feedback_by_spec
+            or spec.candidate_spec_id in signature_feedback_by_spec
+            or spec.candidate_spec_id in shape_feedback_by_spec
+        ):
+            continue
+        bundle = feedback_by_risk_profile.get(
+            feedback_risk_profile_key_by_spec[spec.candidate_spec_id]
+        )
+        if bundle is not None:
+            risk_profile_feedback_by_spec[spec.candidate_spec_id] = (
+                _risk_profile_feedback_bundle_for_spec(spec=spec, bundle=bundle)
+            )
+
     feedback_by_family: dict[str, CandidateEvidenceBundle] = {}
     for bundle in feedback_evidence_bundles:
         family_template_id = _feedback_family_template_id(bundle)
@@ -2510,6 +2851,8 @@ def _pre_replay_proposal_model_and_rows(
         if (
             spec.candidate_spec_id in feedback_by_spec
             or spec.candidate_spec_id in signature_feedback_by_spec
+            or spec.candidate_spec_id in shape_feedback_by_spec
+            or spec.candidate_spec_id in risk_profile_feedback_by_spec
         ):
             continue
         bundle = feedback_by_family.get(spec.family_template_id)
@@ -2534,6 +2877,20 @@ def _pre_replay_proposal_model_and_rows(
             bundle = signature_feedback_by_spec[candidate_spec_id]
             training_source = "feedback_execution_signature_replay"
             match_scope = "execution_signature"
+            source_spec_id = _string(
+                bundle.objective_scorecard.get("feedback_source_candidate_spec_id")
+            )
+        elif candidate_spec_id in shape_feedback_by_spec:
+            bundle = shape_feedback_by_spec[candidate_spec_id]
+            training_source = "feedback_shape_prior"
+            match_scope = "feedback_shape_key"
+            source_spec_id = _string(
+                bundle.objective_scorecard.get("feedback_source_candidate_spec_id")
+            )
+        elif candidate_spec_id in risk_profile_feedback_by_spec:
+            bundle = risk_profile_feedback_by_spec[candidate_spec_id]
+            training_source = "feedback_risk_profile_prior"
+            match_scope = "feedback_risk_profile_key"
             source_spec_id = _string(
                 bundle.objective_scorecard.get("feedback_source_candidate_spec_id")
             )
@@ -2565,6 +2922,8 @@ def _pre_replay_proposal_model_and_rows(
     feedback_bundle_by_spec = {
         **feedback_by_spec,
         **signature_feedback_by_spec,
+        **shape_feedback_by_spec,
+        **risk_profile_feedback_by_spec,
         **family_feedback_by_spec,
     }
 
@@ -2590,6 +2949,17 @@ def _pre_replay_proposal_model_and_rows(
             ):
                 return "pre_replay_mlx_signature_feedback_blocked"
             return "pre_replay_mlx_signature_feedback_penalized"
+        if source == "feedback_shape_prior" and bundle is not None:
+            if _feedback_family_prior_has_hard_block(bundle.objective_scorecard):
+                return "pre_replay_mlx_shape_feedback_blocked"
+            if is_blocked:
+                return "pre_replay_mlx_family_feedback_penalized"
+        if (
+            source == "feedback_risk_profile_prior"
+            and bundle is not None
+            and _feedback_risk_profile_has_penalty(bundle.objective_scorecard)
+        ):
+            return "pre_replay_mlx_risk_profile_feedback_penalized"
         if (
             source == "feedback_family_replay"
             and bundle is not None
@@ -2615,6 +2985,24 @@ def _pre_replay_proposal_model_and_rows(
             and _feedback_has_nonpositive_expected_value(bundle.objective_scorecard)
         ):
             return min(-1_000_000.0, target_by_spec.get(candidate_spec_id, raw_score))
+        if (
+            source == "feedback_shape_prior"
+            and bundle is not None
+            and _feedback_family_prior_has_hard_block(bundle.objective_scorecard)
+        ):
+            return min(-1_000_000.0, target_by_spec.get(candidate_spec_id, raw_score))
+        if (
+            source == "feedback_risk_profile_prior"
+            and bundle is not None
+            and _feedback_risk_profile_has_penalty(bundle.objective_scorecard)
+        ):
+            return min(-500_000.0, target_by_spec.get(candidate_spec_id, raw_score))
+        if (
+            source == "feedback_family_replay"
+            and bundle is not None
+            and _feedback_is_blocked(bundle.objective_scorecard)
+        ):
+            return min(-100_000.0, target_by_spec.get(candidate_spec_id, raw_score))
         return raw_score
 
     rows_unranked = [
@@ -2662,6 +3050,8 @@ def _pre_replay_proposal_model_and_rows(
         "feedback_execution_signature_matched_spec_count": len(
             signature_feedback_by_spec
         ),
+        "feedback_shape_matched_spec_count": len(shape_feedback_by_spec),
+        "feedback_risk_profile_matched_spec_count": len(risk_profile_feedback_by_spec),
         "feedback_family_matched_spec_count": len(family_feedback_by_spec),
         "training_source_counts": training_source_counts,
     }, rows
@@ -2742,6 +3132,7 @@ def _select_candidate_specs_for_replay(
     feedback_block_reasons = {
         "pre_replay_mlx_feedback_blocked",
         "pre_replay_mlx_signature_feedback_blocked",
+        "pre_replay_mlx_shape_feedback_blocked",
         "pre_replay_mlx_family_feedback_blocked",
     }
 
@@ -2877,6 +3268,10 @@ def _select_candidate_specs_for_replay(
             if part
         )
 
+    def spec_param_text(spec: CandidateSpec, key: str) -> str:
+        params = _mapping(spec.strategy_overrides.get("params"))
+        return _string(params.get(key))
+
     def diversity_key(
         spec: CandidateSpec, selected_so_far: Sequence[CandidateSpec]
     ) -> tuple[bool, bool, bool, bool, bool, int, int, str]:
@@ -2987,6 +3382,11 @@ def _select_candidate_specs_for_replay(
             "family_template_id": spec.family_template_id,
             "runtime_family": spec.runtime_family,
             "runtime_strategy_name": spec.runtime_strategy_name,
+            "capital_profile": spec_param_text(spec, "capital_profile") or None,
+            "feedback_remediation_profile": spec_param_text(
+                spec, "feedback_remediation_profile"
+            )
+            or None,
             "universe_key": spec_universe_key(spec),
             "signal_key": spec_signal_key(spec),
             "execution_signature": execution_signature_by_spec[spec.candidate_spec_id],
@@ -3357,13 +3757,9 @@ def _real_replay_result_from_factory_payload(
                 candidate["candidate_spec_id"] = candidate_spec_id
             spec = specs_by_id.get(candidate_spec_id)
             if spec is not None:
-                candidate.setdefault("family_template_id", spec.family_template_id)
-                candidate.setdefault("runtime_family", spec.runtime_family)
-                candidate.setdefault(
-                    "runtime_strategy_name", spec.runtime_strategy_name
-                )
-                candidate.setdefault(
-                    "execution_signature", _candidate_spec_execution_signature(spec)
+                candidate = _candidate_payload_with_feedback_metadata(
+                    candidate=candidate,
+                    spec=spec,
                 )
             if (
                 not candidate.get("promotion_readiness")
@@ -3619,6 +4015,174 @@ def _execute_real_replay_shard(plan: _ReplayShardPlan) -> _ReplayShardOutcome:
     )
 
 
+def _failed_shard_spec_ids(
+    shard_failures: Sequence[Mapping[str, Any]],
+) -> tuple[str, ...]:
+    spec_ids: list[str] = []
+    seen: set[str] = set()
+    for failure in shard_failures:
+        raw_ids = failure.get("candidate_spec_ids")
+        if not isinstance(raw_ids, Sequence) or isinstance(raw_ids, str):
+            continue
+        for raw_id in raw_ids:
+            candidate_spec_id = _string(raw_id)
+            if not candidate_spec_id or candidate_spec_id in seen:
+                continue
+            seen.add(candidate_spec_id)
+            spec_ids.append(candidate_spec_id)
+    return tuple(spec_ids)
+
+
+def _evidenced_spec_ids(
+    evidence_bundles: Sequence[CandidateEvidenceBundle],
+) -> frozenset[str]:
+    return frozenset(
+        candidate_spec_id
+        for candidate_spec_id in (
+            _string(bundle.candidate_spec_id) for bundle in evidence_bundles
+        )
+        if candidate_spec_id
+    )
+
+
+def _retry_real_replay_failed_shard_specs(
+    *,
+    args: argparse.Namespace,
+    output_dir: Path,
+    specs: Sequence[CandidateSpec],
+    shard_failures: Sequence[Mapping[str, Any]],
+    shard_timeout_seconds: int,
+    starting_shard_index: int,
+) -> tuple[
+    tuple[CandidateEvidenceBundle, ...],
+    tuple[Mapping[str, Any], ...],
+    tuple[Mapping[str, Any], ...],
+    Mapping[str, Any] | None,
+]:
+    retry_limit = max(0, int(getattr(args, "real_replay_failed_spec_retries", 1) or 0))
+    failed_spec_ids = _failed_shard_spec_ids(shard_failures)
+    if retry_limit <= 0 or not failed_spec_ids:
+        return (), (), tuple(shard_failures), None
+
+    spec_by_id = {spec.candidate_spec_id: spec for spec in specs}
+    retry_specs = tuple(
+        spec_by_id[candidate_spec_id]
+        for candidate_spec_id in failed_spec_ids
+        if candidate_spec_id in spec_by_id
+    )
+    if not retry_specs:
+        return (), (), tuple(shard_failures), None
+
+    configured_timeout = max(
+        0, int(getattr(args, "real_replay_retry_timeout_seconds", 0) or 0)
+    )
+    retry_timeout_seconds = configured_timeout
+    if retry_timeout_seconds <= 0 and shard_timeout_seconds > 0:
+        retry_timeout_seconds = max(shard_timeout_seconds * 2, 900)
+    retry_frontier_budget = max(
+        1,
+        int(
+            getattr(args, "real_replay_retry_max_frontier_candidates_per_spec", 1) or 1
+        ),
+    )
+
+    evidence_bundles: list[CandidateEvidenceBundle] = []
+    replay_results: list[Mapping[str, Any]] = []
+    completed_spec_ids: set[str] = set()
+    last_failure_by_spec: dict[str, Mapping[str, Any]] = {}
+    attempt_summaries: list[dict[str, Any]] = []
+    next_shard_index = starting_shard_index
+
+    for attempt in range(1, retry_limit + 1):
+        pending_specs = tuple(
+            spec
+            for spec in retry_specs
+            if spec.candidate_spec_id not in completed_spec_ids
+        )
+        if not pending_specs:
+            break
+        attempt_failures: list[dict[str, Any]] = []
+        attempt_completed: list[str] = []
+        attempt_evidence_before = len(evidence_bundles)
+        for retry_index, spec in enumerate(pending_specs, start=1):
+            next_shard_index += 1
+            retry_args = argparse.Namespace(
+                **{
+                    **vars(args),
+                    "max_candidates": 1,
+                    "top_k": 1,
+                    "max_frontier_candidates_per_spec": retry_frontier_budget,
+                    "max_total_frontier_candidates": retry_frontier_budget,
+                }
+            )
+            outcome = _execute_real_replay_shard(
+                _ReplayShardPlan(
+                    shard_index=next_shard_index,
+                    args=retry_args,
+                    output_dir=output_dir
+                    / "strategy-factory-failed-spec-retries"
+                    / f"attempt-{attempt:02d}"
+                    / f"retry-{retry_index:03d}-{spec.candidate_spec_id}",
+                    specs=(spec,),
+                    timeout_seconds=retry_timeout_seconds,
+                )
+            )
+            evidence_bundles.extend(outcome.result.evidence_bundles)
+            replay_results.extend(outcome.result.replay_results)
+            if outcome.failure is not None:
+                failure = {
+                    **dict(outcome.failure),
+                    "retry_attempt": attempt,
+                    "retry_candidate_spec_id": spec.candidate_spec_id,
+                    "retry_timeout_seconds": retry_timeout_seconds,
+                    "retry_max_frontier_candidates_per_spec": retry_frontier_budget,
+                }
+                attempt_failures.append(failure)
+                last_failure_by_spec[spec.candidate_spec_id] = failure
+                continue
+            completed_spec_ids.add(spec.candidate_spec_id)
+            last_failure_by_spec.pop(spec.candidate_spec_id, None)
+            attempt_completed.append(spec.candidate_spec_id)
+        attempt_summaries.append(
+            {
+                "attempt": attempt,
+                "requested_candidate_spec_ids": [
+                    spec.candidate_spec_id for spec in pending_specs
+                ],
+                "completed_candidate_spec_ids": attempt_completed,
+                "failure_count": len(attempt_failures),
+                "failures": attempt_failures,
+                "new_evidence_bundle_count": len(evidence_bundles)
+                - attempt_evidence_before,
+            }
+        )
+
+    deduped_retry_evidence = _dedupe_replay_evidence(evidence_bundles)
+    remaining_failures = tuple(last_failure_by_spec.values())
+    summary = {
+        "status": "failed_shard_specs_retried",
+        "schema_version": "torghut.whitepaper-autoresearch-shard-retry.v1",
+        "retry_limit": retry_limit,
+        "retry_timeout_seconds": retry_timeout_seconds,
+        "retry_max_frontier_candidates_per_spec": retry_frontier_budget,
+        "original_failure_count": len(shard_failures),
+        "requested_candidate_spec_ids": [
+            spec.candidate_spec_id for spec in retry_specs
+        ],
+        "completed_candidate_spec_ids": sorted(completed_spec_ids),
+        "evidence_candidate_spec_ids": sorted(
+            _evidenced_spec_ids(deduped_retry_evidence)
+        ),
+        "remaining_failed_candidate_spec_ids": [
+            _string(failure.get("retry_candidate_spec_id"))
+            for failure in remaining_failures
+            if _string(failure.get("retry_candidate_spec_id"))
+        ],
+        "attempts": attempt_summaries,
+    }
+    return deduped_retry_evidence, tuple(replay_results), remaining_failures, summary
+
+
 def _run_real_replay_shards(
     *,
     args: argparse.Namespace,
@@ -3664,6 +4228,27 @@ def _run_real_replay_shards(
             shard_failures.append(dict(outcome.failure))
 
     deduped_evidence = _dedupe_replay_evidence(evidence_bundles)
+    if shard_failures:
+        (
+            retry_evidence,
+            retry_replay_results,
+            remaining_failures,
+            retry_summary,
+        ) = _retry_real_replay_failed_shard_specs(
+            args=args,
+            output_dir=output_dir,
+            specs=specs,
+            shard_failures=shard_failures,
+            shard_timeout_seconds=shard_timeout_seconds,
+            starting_shard_index=len(plans),
+        )
+        if retry_evidence:
+            evidence_bundles.extend(retry_evidence)
+            deduped_evidence = _dedupe_replay_evidence(evidence_bundles)
+        replay_results.extend(retry_replay_results)
+        if retry_summary is not None:
+            replay_results.append(dict(retry_summary))
+        shard_failures = [dict(item) for item in remaining_failures]
     if shard_failures and not deduped_evidence:
         raise TimeoutError(f"real_replay_shards_failed:{len(shard_failures)}")
     if shard_failures:
@@ -4684,6 +5269,16 @@ def run_whitepaper_autoresearch_profit_target(
             ),
             "real_replay_shard_workers": int(
                 getattr(args, "real_replay_shard_workers", 1) or 1
+            ),
+            "real_replay_failed_spec_retries": int(
+                getattr(args, "real_replay_failed_spec_retries", 1) or 0
+            ),
+            "real_replay_retry_timeout_seconds": int(
+                getattr(args, "real_replay_retry_timeout_seconds", 0) or 0
+            ),
+            "real_replay_retry_max_frontier_candidates_per_spec": int(
+                getattr(args, "real_replay_retry_max_frontier_candidates_per_spec", 1)
+                or 1
             ),
             "source_jsonl": [str(path) for path in getattr(args, "source_jsonl", [])],
         }

--- a/services/torghut/tests/test_candidate_specs.py
+++ b/services/torghut/tests/test_candidate_specs.py
@@ -375,6 +375,61 @@ class TestCandidateSpecs(TestCase):
                     "1.0",
                 )
 
+    def test_portfolio_profit_target_adds_feedback_escape_profiles(self) -> None:
+        cards = build_hypothesis_cards(
+            source_run_id="paper-feedback-escape",
+            claims=[
+                {
+                    "claim_id": "claim-feedback-escape",
+                    "claim_type": "signal_mechanism",
+                    "claim_text": "Order-flow clustering can predict short-horizon continuation.",
+                    "confidence": "0.82",
+                }
+            ],
+        )
+
+        specs = compile_candidate_specs(
+            hypothesis_cards=cards, target_net_pnl_per_day=Decimal("500")
+        )
+
+        expected_profiles = {
+            "daily_coverage_feedback_escape",
+            "consistency_guard_feedback_escape",
+            "turnover_coverage_feedback_escape",
+        }
+        for family_template_id in candidate_specs_module._FAMILY_RUNTIME:
+            family_specs = [
+                spec for spec in specs if spec.family_template_id == family_template_id
+            ]
+            remediation_profiles = {
+                str(
+                    spec.strategy_overrides["params"].get(
+                        "feedback_remediation_profile"
+                    )
+                )
+                for spec in family_specs
+                if isinstance(spec.strategy_overrides.get("params"), dict)
+                and spec.strategy_overrides["params"].get(
+                    "feedback_remediation_profile"
+                )
+            }
+            self.assertGreaterEqual(
+                remediation_profiles,
+                expected_profiles,
+                family_template_id,
+            )
+            for spec in family_specs:
+                params = spec.strategy_overrides.get("params")
+                if not isinstance(params, dict) or not params.get(
+                    "feedback_remediation_profile"
+                ):
+                    continue
+                self.assertEqual(params["max_gross_exposure_pct_equity"], "1.0")
+                self.assertTrue(str(params["capital_profile"]).startswith("feedback_"))
+                self.assertEqual(
+                    candidate_spec_capital_features(spec)["capital_feasible_flag"], 1.0
+                )
+
     def test_short_exhaustion_claim_compiles_short_sleeve_profiles(self) -> None:
         cards = build_hypothesis_cards(
             source_run_id="paper-short-exhaustion",

--- a/services/torghut/tests/test_candidate_specs.py
+++ b/services/torghut/tests/test_candidate_specs.py
@@ -430,6 +430,50 @@ class TestCandidateSpecs(TestCase):
                     candidate_spec_capital_features(spec)["capital_feasible_flag"], 1.0
                 )
 
+    def test_feedback_escape_profiles_dedupe_and_fallback_invalid_params(self) -> None:
+        profile = {
+            "params": {
+                "entry_minute_after_open": "not-a-decimal",
+                "exit_minute_after_open": "invalid",
+                "top_n": "2",
+            },
+            "universe_symbols": ["NVDA", "AAPL"],
+            "max_notional_per_trade": "90000",
+            "max_position_pct_equity": "2.0",
+        }
+
+        expanded = candidate_specs_module._portfolio_feedback_escape_execution_profiles(
+            (profile, profile)
+        )
+
+        self.assertEqual(
+            [
+                next_profile["params"]["feedback_remediation_profile"]
+                for next_profile in expanded
+            ],
+            [
+                "daily_coverage_feedback_escape",
+                "consistency_guard_feedback_escape",
+                "turnover_coverage_feedback_escape",
+            ],
+        )
+        self.assertEqual(
+            candidate_specs_module._decimal_profile_param(
+                profile["params"],
+                "entry_minute_after_open",
+                default=Decimal("45"),
+            ),
+            Decimal("45"),
+        )
+        self.assertEqual(
+            candidate_specs_module._int_profile_param(
+                profile["params"],
+                "exit_minute_after_open",
+                default=150,
+            ),
+            150,
+        )
+
     def test_short_exhaustion_claim_compiles_short_sleeve_profiles(self) -> None:
         cards = build_hypothesis_cards(
             source_run_id="paper-short-exhaustion",

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -1287,6 +1287,126 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             "synthetic_prior",
         )
 
+    def test_feedback_shape_prior_penalizes_cash_blocks_without_family_veto(
+        self,
+    ) -> None:
+        failed_spec = self._candidate_spec("spec-shape-cash-source")
+        same_shape_probe = replace(
+            failed_spec,
+            candidate_spec_id="spec-shape-cash-probe",
+            hypothesis_id="hyp-spec-shape-cash-probe",
+            hard_vetoes={"required_min_daily_notional": "400000"},
+        )
+        feedback_bundle = runner.evidence_bundle_from_frontier_candidate(
+            candidate_spec_id=failed_spec.candidate_spec_id,
+            candidate=runner._candidate_payload_with_feedback_metadata(
+                spec=failed_spec,
+                candidate={
+                    "candidate_id": "cand-shape-cash-source",
+                    "objective_scorecard": {
+                        "net_pnl_per_day": "250",
+                        "active_day_ratio": "1",
+                        "positive_day_ratio": "1",
+                        "best_day_share": "0.25",
+                        "min_cash": "-1",
+                    },
+                },
+            ),
+            dataset_snapshot_id="snap-shape-cash-feedback",
+            result_path="feedback://shape-cash",
+        )
+
+        model, rows = runner._pre_replay_proposal_model_and_rows(
+            specs=(same_shape_probe,),
+            feedback_evidence_bundles=(feedback_bundle,),
+        )
+
+        self.assertEqual(model["feedback_shape_matched_spec_count"], 1)
+        self.assertEqual(rows[0]["training_source"], "feedback_shape_prior")
+        self.assertEqual(
+            rows[0]["selection_reason"],
+            "pre_replay_mlx_family_feedback_penalized",
+        )
+
+    def test_feedback_scorecard_helpers_cover_veto_and_penalty_edges(self) -> None:
+        invalid_universe_spec = replace(
+            self._candidate_spec("spec-invalid-universe"),
+            strategy_overrides={
+                **self._candidate_spec("spec-invalid-universe").strategy_overrides,
+                "universe_symbols": "NVDA",
+            },
+        )
+        self.assertEqual(runner._candidate_spec_universe_key(invalid_universe_spec), "")
+        self.assertTrue(
+            runner._feedback_scorecard_has_hard_veto(
+                {
+                    "profit_target_oracle": {
+                        "blockers": ["positive_day_ratio_below_oracle"]
+                    }
+                }
+            )
+        )
+        self.assertTrue(
+            runner._feedback_scorecard_has_hard_veto({"oracle_passed": False})
+        )
+        self.assertFalse(runner._feedback_daily_net_has_loss({"daily_net": "bad"}))
+        self.assertTrue(
+            runner._feedback_family_prior_has_hard_block(
+                {
+                    "profit_target_oracle": {
+                        "blockers": ["active_day_ratio_below_oracle"]
+                    }
+                }
+            )
+        )
+        self.assertTrue(
+            runner._feedback_family_prior_has_hard_block({"positive_day_ratio": "0.5"})
+        )
+        self.assertTrue(
+            runner._feedback_family_prior_has_hard_block({"best_day_share": "0.51"})
+        )
+        self.assertTrue(
+            runner._feedback_family_prior_has_hard_block(
+                {
+                    "active_day_ratio": "1",
+                    "positive_day_ratio": "1",
+                    "best_day_share": "0.25",
+                    "daily_net": {"2026-05-01": "0"},
+                }
+            )
+        )
+        for scorecard in (
+            {
+                "profit_target_oracle": {
+                    "blockers": ["max_single_day_contribution_share_failed"]
+                }
+            },
+            {"best_day_share": "0.36"},
+            {"max_single_day_contribution_share": "0.36"},
+            {"max_single_symbol_contribution_share": "0.36"},
+            {"max_cluster_contribution_share": "0.41"},
+        ):
+            self.assertTrue(runner._feedback_risk_profile_has_penalty(scorecard))
+        self.assertEqual(runner._feedback_risk_profile_key_from_scorecard({}), "")
+
+        spec = self._candidate_spec("spec-empty-risk-key")
+        orphan_bundle = runner.evidence_bundle_from_frontier_candidate(
+            candidate_spec_id="spec-unmatched-risk-feedback",
+            candidate={
+                "candidate_id": "cand-unmatched-risk-feedback",
+                "objective_scorecard": {"positive_day_ratio": "0.5"},
+            },
+            dataset_snapshot_id="snap-empty-risk-key",
+            result_path="feedback://empty-risk-key",
+        )
+        model, rows = runner._pre_replay_proposal_model_and_rows(
+            specs=(spec,),
+            feedback_evidence_bundles=(orphan_bundle,),
+        )
+
+        self.assertEqual(model["feedback_risk_profile_matched_spec_count"], 0)
+        self.assertEqual(rows[0]["training_source"], "synthetic_prior")
+
     def test_real_replay_evidence_carries_feedback_shape_metadata(self) -> None:
         spec = self._candidate_spec("spec-real-replay-shape-metadata")
         with TemporaryDirectory() as tmpdir:
@@ -2970,6 +3090,9 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             args.real_replay_shard_size = 2
             args.real_replay_shard_timeout_seconds = 900
             args.real_replay_shard_workers = 3
+            args.real_replay_failed_spec_retries = 2
+            args.real_replay_retry_timeout_seconds = 1800
+            args.real_replay_retry_max_frontier_candidates_per_spec = 3
             args.shadow_validation_artifact = Path("/tmp/shadow-validation.json")
             remediation = {
                 "next_actions": [
@@ -2998,6 +3121,12 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         self.assertEqual(plan["flags"]["--real-replay-shard-size"], "2")
         self.assertEqual(plan["flags"]["--real-replay-shard-timeout-seconds"], "900")
         self.assertEqual(plan["flags"]["--real-replay-shard-workers"], "3")
+        self.assertEqual(plan["flags"]["--real-replay-failed-spec-retries"], "2")
+        self.assertEqual(plan["flags"]["--real-replay-retry-timeout-seconds"], "1800")
+        self.assertEqual(
+            plan["flags"]["--real-replay-retry-max-frontier-candidates-per-spec"],
+            "3",
+        )
         self.assertEqual(
             plan["flags"]["--shadow-validation-artifact"],
             "/tmp/shadow-validation.json",
@@ -3870,6 +3999,159 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             [calls[1][0][0]],
         )
         self.assertEqual(result.failure_reasons, ())
+
+    def test_failed_shard_retry_skips_malformed_and_unknown_spec_ids(self) -> None:
+        self.assertEqual(
+            runner._failed_shard_spec_ids(
+                (
+                    {"candidate_spec_ids": "spec-not-a-list"},
+                    {"candidate_spec_ids": ["spec-a", "", "spec-a", "spec-b"]},
+                )
+            ),
+            ("spec-a", "spec-b"),
+        )
+
+        with TemporaryDirectory() as tmpdir:
+            args = self._args(Path(tmpdir) / "epoch")
+            evidence, replay_results, failures, summary = (
+                runner._retry_real_replay_failed_shard_specs(
+                    args=args,
+                    output_dir=Path(tmpdir) / "epoch",
+                    specs=(self._candidate_spec("spec-known"),),
+                    shard_failures=({"candidate_spec_ids": ["spec-missing"]},),
+                    shard_timeout_seconds=7,
+                    starting_shard_index=1,
+                )
+            )
+
+        self.assertEqual(evidence, ())
+        self.assertEqual(replay_results, ())
+        self.assertEqual(failures, ({"candidate_spec_ids": ["spec-missing"]},))
+        self.assertIsNone(summary)
+
+    def test_failed_shard_retry_defaults_timeout_and_reports_retry_failures(
+        self,
+    ) -> None:
+        spec = self._candidate_spec("spec-retry-fails")
+        calls: list[tuple[int, int, int]] = []
+
+        def fake_execute(
+            plan: runner._ReplayShardPlan,
+        ) -> runner._ReplayShardOutcome:
+            calls.append(
+                (
+                    plan.shard_index,
+                    plan.timeout_seconds,
+                    int(plan.args.max_total_frontier_candidates),
+                )
+            )
+            return runner._ReplayShardOutcome(
+                shard_index=plan.shard_index,
+                candidate_spec_ids=(spec.candidate_spec_id,),
+                result=runner.EpochReplayResult(
+                    evidence_bundles=(),
+                    replay_results=(),
+                ),
+                failure={
+                    "shard_index": plan.shard_index,
+                    "candidate_spec_ids": [spec.candidate_spec_id],
+                    "reason": "nested_shard_incomplete",
+                },
+            )
+
+        with TemporaryDirectory() as tmpdir:
+            args = self._args(Path(tmpdir) / "epoch")
+            args.real_replay_failed_spec_retries = 2
+            args.real_replay_retry_timeout_seconds = 0
+            args.real_replay_retry_max_frontier_candidates_per_spec = 2
+            with patch.object(
+                runner, "_execute_real_replay_shard", side_effect=fake_execute
+            ):
+                evidence, replay_results, failures, summary = (
+                    runner._retry_real_replay_failed_shard_specs(
+                        args=args,
+                        output_dir=Path(tmpdir) / "epoch",
+                        specs=(spec,),
+                        shard_failures=(
+                            {"candidate_spec_ids": [spec.candidate_spec_id]},
+                        ),
+                        shard_timeout_seconds=7,
+                        starting_shard_index=3,
+                    )
+                )
+
+        self.assertEqual(evidence, ())
+        self.assertEqual(replay_results, ())
+        self.assertEqual(calls, [(4, 900, 2), (5, 900, 2)])
+        self.assertEqual(len(failures), 1)
+        self.assertEqual(failures[0]["retry_attempt"], 2)
+        self.assertEqual(failures[0]["retry_candidate_spec_id"], spec.candidate_spec_id)
+        self.assertEqual(failures[0]["retry_timeout_seconds"], 900)
+        self.assertEqual(failures[0]["retry_max_frontier_candidates_per_spec"], 2)
+        assert summary is not None
+        self.assertEqual(len(summary["attempts"]), 2)
+        self.assertEqual(
+            summary["remaining_failed_candidate_spec_ids"], [spec.candidate_spec_id]
+        )
+
+    def test_failed_shard_retry_stops_after_all_specs_complete(self) -> None:
+        spec = self._candidate_spec("spec-retry-completes")
+        calls: list[int] = []
+
+        def fake_execute(
+            plan: runner._ReplayShardPlan,
+        ) -> runner._ReplayShardOutcome:
+            calls.append(plan.shard_index)
+            bundle = runner.evidence_bundle_from_frontier_candidate(
+                candidate_spec_id=spec.candidate_spec_id,
+                candidate={
+                    "candidate_id": "cand-retry-completes",
+                    "objective_scorecard": {
+                        "net_pnl_per_day": "10",
+                        "active_day_ratio": "1",
+                        "positive_day_ratio": "1",
+                    },
+                },
+                dataset_snapshot_id="snap-retry-completes",
+                result_path="feedback://retry-completes",
+            )
+            return runner._ReplayShardOutcome(
+                shard_index=plan.shard_index,
+                candidate_spec_ids=(spec.candidate_spec_id,),
+                result=runner.EpochReplayResult(
+                    evidence_bundles=(bundle,),
+                    replay_results=({"status": "ok"},),
+                ),
+            )
+
+        with TemporaryDirectory() as tmpdir:
+            args = self._args(Path(tmpdir) / "epoch")
+            args.real_replay_failed_spec_retries = 2
+            with patch.object(
+                runner, "_execute_real_replay_shard", side_effect=fake_execute
+            ):
+                evidence, replay_results, failures, summary = (
+                    runner._retry_real_replay_failed_shard_specs(
+                        args=args,
+                        output_dir=Path(tmpdir) / "epoch",
+                        specs=(spec,),
+                        shard_failures=(
+                            {"candidate_spec_ids": [spec.candidate_spec_id]},
+                        ),
+                        shard_timeout_seconds=7,
+                        starting_shard_index=3,
+                    )
+                )
+
+        self.assertEqual(calls, [4])
+        self.assertEqual(evidence[0].candidate_spec_id, spec.candidate_spec_id)
+        self.assertEqual(replay_results, ({"status": "ok"},))
+        self.assertEqual(failures, ())
+        assert summary is not None
+        self.assertEqual(len(summary["attempts"]), 1)
+        self.assertEqual(
+            summary["completed_candidate_spec_ids"], [spec.candidate_spec_id]
+        )
 
     def test_real_replay_shards_use_isolated_output_dirs_and_bounded_budget(
         self,

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -117,6 +117,9 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             real_replay_shard_size=0,
             real_replay_shard_timeout_seconds=0,
             real_replay_shard_workers=1,
+            real_replay_failed_spec_retries=1,
+            real_replay_retry_timeout_seconds=0,
+            real_replay_retry_max_frontier_candidates_per_spec=1,
             train_days=6,
             holdout_days=3,
             full_window_start_date="2026-02-23",
@@ -1164,6 +1167,175 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         self.assertEqual(selected, [matching_spec])
         self.assertEqual(selection["budget"]["selected_count"], 1)
         self.assertEqual(selection["budget"]["eligible_candidate_count"], 1)
+
+    def test_pre_replay_ranker_blocks_shape_and_penalizes_risk_profile_feedback(
+        self,
+    ) -> None:
+        failed_spec = self._candidate_spec("spec-daily-coverage-source")
+        same_shape_probe = replace(
+            failed_spec,
+            candidate_spec_id="spec-same-shape-probe",
+            hypothesis_id="hyp-spec-same-shape-probe",
+            hard_vetoes={"required_min_daily_notional": "400000"},
+        )
+        different_shape_same_risk_probe = replace(
+            failed_spec,
+            candidate_spec_id="spec-risk-profile-probe",
+            hypothesis_id="hyp-spec-risk-profile-probe",
+            hard_vetoes={"required_min_daily_notional": "450000"},
+            strategy_overrides={
+                **failed_spec.strategy_overrides,
+                "params": {
+                    **cast(dict[str, Any], failed_spec.strategy_overrides["params"]),
+                    "entry_minute_after_open": "90",
+                },
+            },
+        )
+        clean_probe = self._candidate_spec(
+            "spec-clean-probe",
+            family_template_id="breakout_reclaim_v2",
+            entry_minute_after_open="120",
+            selection_mode="continuation",
+        )
+        self.assertNotEqual(
+            runner._candidate_spec_execution_signature(failed_spec),
+            runner._candidate_spec_execution_signature(same_shape_probe),
+        )
+        self.assertEqual(
+            runner._candidate_spec_feedback_shape_key(failed_spec),
+            runner._candidate_spec_feedback_shape_key(same_shape_probe),
+        )
+        self.assertNotEqual(
+            runner._candidate_spec_feedback_shape_key(failed_spec),
+            runner._candidate_spec_feedback_shape_key(different_shape_same_risk_probe),
+        )
+        self.assertEqual(
+            runner._candidate_spec_feedback_risk_profile_key(failed_spec),
+            runner._candidate_spec_feedback_risk_profile_key(
+                different_shape_same_risk_probe
+            ),
+        )
+        feedback_bundle = runner.evidence_bundle_from_frontier_candidate(
+            candidate_spec_id=failed_spec.candidate_spec_id,
+            candidate=runner._candidate_payload_with_feedback_metadata(
+                spec=failed_spec,
+                candidate={
+                    "candidate_id": "cand-daily-coverage-source",
+                    "objective_scorecard": {
+                        "net_pnl_per_day": "959.07",
+                        "active_day_ratio": "0.2",
+                        "positive_day_ratio": "0.2",
+                        "negative_day_count": 0,
+                        "best_day_share": "0.92",
+                        "daily_net": {
+                            "2026-05-01": "4795.37",
+                            "2026-05-04": "0",
+                        },
+                    },
+                },
+            ),
+            dataset_snapshot_id="snap-daily-coverage-feedback",
+            result_path="feedback://daily-coverage",
+        )
+
+        model, rows = runner._pre_replay_proposal_model_and_rows(
+            specs=(same_shape_probe, different_shape_same_risk_probe, clean_probe),
+            feedback_evidence_bundles=(feedback_bundle,),
+        )
+
+        row_by_spec = {row["candidate_spec_id"]: row for row in rows}
+        self.assertEqual(model["feedback_shape_matched_spec_count"], 1)
+        self.assertEqual(model["feedback_risk_profile_matched_spec_count"], 1)
+        self.assertEqual(
+            row_by_spec[same_shape_probe.candidate_spec_id]["training_source"],
+            "feedback_shape_prior",
+        )
+        self.assertEqual(
+            row_by_spec[same_shape_probe.candidate_spec_id]["selection_reason"],
+            "pre_replay_mlx_shape_feedback_blocked",
+        )
+        self.assertLessEqual(
+            Decimal(
+                str(row_by_spec[same_shape_probe.candidate_spec_id]["proposal_score"])
+            ),
+            Decimal("-999999"),
+        )
+        self.assertEqual(
+            row_by_spec[different_shape_same_risk_probe.candidate_spec_id][
+                "training_source"
+            ],
+            "feedback_risk_profile_prior",
+        )
+        self.assertEqual(
+            row_by_spec[different_shape_same_risk_probe.candidate_spec_id][
+                "selection_reason"
+            ],
+            "pre_replay_mlx_risk_profile_feedback_penalized",
+        )
+        self.assertLessEqual(
+            Decimal(
+                str(
+                    row_by_spec[different_shape_same_risk_probe.candidate_spec_id][
+                        "proposal_score"
+                    ]
+                )
+            ),
+            Decimal("-500000"),
+        )
+        self.assertEqual(
+            row_by_spec[clean_probe.candidate_spec_id]["training_source"],
+            "synthetic_prior",
+        )
+
+    def test_real_replay_evidence_carries_feedback_shape_metadata(self) -> None:
+        spec = self._candidate_spec("spec-real-replay-shape-metadata")
+        with TemporaryDirectory() as tmpdir:
+            result_path = Path(tmpdir) / "result.json"
+            result_path.write_text(
+                json.dumps(
+                    {
+                        "top": [
+                            {
+                                "candidate_id": "cand-real-replay-shape",
+                                "objective_scorecard": {
+                                    "net_pnl_per_day": "650",
+                                    "active_day_ratio": "1",
+                                    "positive_day_ratio": "1",
+                                },
+                            }
+                        ]
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            replay = runner._real_replay_result_from_factory_payload(
+                {
+                    "experiments": [
+                        {
+                            "candidate_spec_id": spec.candidate_spec_id,
+                            "result_path": str(result_path),
+                            "dataset_snapshot_id": "snap-real-replay-shape",
+                        }
+                    ]
+                },
+                specs_by_id={spec.candidate_spec_id: spec},
+            )
+
+        self.assertEqual(len(replay.evidence_bundles), 1)
+        scorecard = replay.evidence_bundles[0].objective_scorecard
+        self.assertEqual(
+            scorecard["feedback_shape_key"],
+            runner._candidate_spec_feedback_shape_key(spec),
+        )
+        self.assertEqual(
+            scorecard["feedback_risk_profile_key"],
+            runner._candidate_spec_feedback_risk_profile_key(spec),
+        )
+        self.assertEqual(
+            scorecard["execution_signature"],
+            runner._candidate_spec_execution_signature(spec),
+        )
 
     def test_candidate_selection_blocks_synthetic_nonpositive_expected_value(
         self,
@@ -3593,6 +3765,7 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             args.replay_mode = "real"
             args.real_replay_shard_size = 1
             args.real_replay_shard_timeout_seconds = 7
+            args.real_replay_failed_spec_retries = 0
             with patch.object(runner, "_run_real_replay", side_effect=fake_replay):
                 result = runner._run_replay_with_optional_timeout(
                     args=args,
@@ -3618,6 +3791,85 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         self.assertIn(
             "TimeoutError:real_replay_timeout_seconds:7", result.failure_reasons
         )
+
+    def test_sharded_real_replay_retries_failed_specs_individually(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir) / "epoch"
+            cards = claim_compiler_script.compile_sources_to_hypothesis_cards(
+                [runner.RECENT_WHITEPAPER_SEEDS[0]]
+            )
+            compilation = runner.compile_whitepaper_candidate_specs(
+                hypothesis_cards=cards,
+                family_template_dir=Path("config/trading/families"),
+                seed_sweep_dir=Path("config/trading"),
+            )
+            specs = compilation.executable_specs[:3]
+            calls: list[tuple[list[str], int, int, int]] = []
+
+            def fake_replay(
+                args: Namespace,
+                *,
+                output_dir: Path,
+                specs: Sequence[runner.CandidateSpec],
+            ) -> runner.EpochReplayResult:
+                spec_ids = [spec.candidate_spec_id for spec in specs]
+                calls.append(
+                    (
+                        spec_ids,
+                        int(args.max_candidates),
+                        int(args.top_k),
+                        int(args.max_total_frontier_candidates),
+                    )
+                )
+                if len(calls) == 2:
+                    raise TimeoutError("real_replay_timeout_seconds:7")
+                bundle = runner.evidence_bundle_from_frontier_candidate(
+                    candidate_spec_id=spec_ids[0],
+                    candidate={
+                        "candidate_id": f"cand-{spec_ids[0]}",
+                        "objective_scorecard": {
+                            "net_pnl_per_day": "10",
+                            "active_day_ratio": "1",
+                            "positive_day_ratio": "1",
+                        },
+                    },
+                    dataset_snapshot_id="snap-shard",
+                    result_path=str(output_dir / f"{spec_ids[0]}.json"),
+                )
+                return runner.EpochReplayResult(
+                    evidence_bundles=(bundle,),
+                    replay_results=({"status": "ok", "spec_ids": spec_ids},),
+                )
+
+            args = self._args(output_dir)
+            args.replay_mode = "real"
+            args.real_replay_shard_size = 1
+            args.real_replay_shard_timeout_seconds = 7
+            args.real_replay_failed_spec_retries = 1
+            args.real_replay_retry_timeout_seconds = 11
+            args.real_replay_retry_max_frontier_candidates_per_spec = 1
+            with patch.object(runner, "_run_real_replay", side_effect=fake_replay):
+                result = runner._run_replay_with_optional_timeout(
+                    args=args,
+                    output_dir=output_dir,
+                    specs=specs,
+                )
+
+        self.assertEqual(len(calls), 4)
+        self.assertFalse(result.incomplete)
+        self.assertEqual(len(result.evidence_bundles), 3)
+        self.assertEqual(calls[-1][1:], (1, 1, 1))
+        retry_summary = next(
+            item
+            for item in result.replay_results
+            if item.get("status") == "failed_shard_specs_retried"
+        )
+        self.assertEqual(retry_summary["retry_timeout_seconds"], 11)
+        self.assertEqual(
+            retry_summary["completed_candidate_spec_ids"],
+            [calls[1][0][0]],
+        )
+        self.assertEqual(result.failure_reasons, ())
 
     def test_real_replay_shards_use_isolated_output_dirs_and_bounded_budget(
         self,


### PR DESCRIPTION
## Summary

- Adds feedback escape execution profiles for Torghut profit-target candidate generation so the next autoresearch pass explores cash-constrained coverage, consistency, and turnover repairs.
- Carries feedback shape, risk-profile, universe, signal, and execution-profile metadata into replay evidence and pre-replay ranking.
- Blocks repeated failed feedback shapes, penalizes failed risk profiles, preserves positive exact/signature candidates for replay, and retries timed-out real-replay shards per spec before marking replay incomplete.
- Splits the Torghut autoresearch runner CI coverage lane from 8 to 16 deterministic hash-balanced slices to keep the slow replay-focused test file inside the CI timeout budget.

## Related Issues

None

## Testing

- `uv run --frozen ruff format app/trading/discovery/candidate_specs.py app/trading/discovery/evidence_bundles.py scripts/run_whitepaper_autoresearch_profit_target.py tests/test_candidate_specs.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py -k 'sharded_real_replay or feedback_shape or positive_blocked_feedback or positive_signature_feedback or family_feedback or real_replay_evidence_carries_feedback_shape_metadata' -q`
- `uv run --frozen pytest tests/test_candidate_specs.py -k 'feedback_escape or capital_constrained_profiles or unpinned_hypotheses_expand_all_family_execution_profiles or portfolio_profit_target_adds_diversified' -q`
- `uv run --frozen ruff check app/trading/discovery/candidate_specs.py app/trading/discovery/evidence_bundles.py scripts/run_whitepaper_autoresearch_profit_target.py tests/test_candidate_specs.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py tests/test_candidate_specs.py -q`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`
- `actionlint .github/workflows/torghut-ci.yml`
- Hash-balanced 16-slice local collect validation for `tests/test_run_whitepaper_autoresearch_profit_target.py` confirmed all slices are non-empty across 73 pytest node IDs.
- Local duration profile for the slow autoresearch runner slices: 23 selected tests passed in 361.53s, identifying seven roughly 50s tests that the hash-balanced slicer spreads across separate CI slices.
- `uv run --frozen pytest tests/test_candidate_specs.py -k 'feedback_escape_helpers or feedback_escape_profiles' -q`
- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py -k 'feedback_prior_helper_edges or shape_feedback_prior_penalizes or next_epoch_plan_preserves_runtime_flags or failed_shard_retry_helpers' -q`
- `uv run --frozen pytest --cov --cov-branch --cov-fail-under=0 --cov-report=xml:coverage.xml tests/test_run_whitepaper_autoresearch_profit_target.py tests/test_candidate_specs.py -q`
- `uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
