### PR TITLE
fix(torghut): import jangar controller carry evidence

### DIFF
--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -91,6 +91,8 @@ spec:
               value: "false"
             - name: TRADING_MARKET_CONTEXT_URL
               value: http://jangar.jangar.svc.cluster.local/api/torghut/market-context
+            - name: TRADING_JANGAR_CONTROL_PLANE_STATUS_URL
+              value: "http://agents.agents.svc.cluster.local/api/agents/control-plane/status?namespace=agents"
             - name: TRADING_MARKET_CONTEXT_TIMEOUT_SECONDS
               value: "5"
             - name: TRADING_MARKET_CONTEXT_REQUIRED

--- a/docs/torghut/rollouts/2026-05-14-jangar-controller-carry-url-and-repair-slot-import.md
+++ b/docs/torghut/rollouts/2026-05-14-jangar-controller-carry-url-and-repair-slot-import.md
@@ -1,0 +1,84 @@
+# Torghut Jangar Controller Carry URL And Repair-Slot Import
+
+Date: 2026-05-14
+
+Governing design:
+
+- `docs/torghut/design-system/v6/211-torghut-controller-ingestion-carry-and-alpha-no-delta-release-2026-05-14.md`
+- Companion: `docs/agents/designs/205-jangar-controller-ingestion-settlement-and-verification-carry-cutover-2026-05-14.md`
+
+## Runtime Requirement
+
+`GET http://torghut.torghut.svc.cluster.local/trading/revenue-repair` is the revenue-blocker source of truth. The
+selected live queue item remains `repair_alpha_readiness`, reason `alpha_readiness_not_promotion_eligible`, value gate
+`routeable_candidate_count`, and capital rule `zero_notional_repair_only`.
+
+## Evidence
+
+Before change, live Torghut reported:
+
+- `business_state=repair_only`
+- `revenue_ready=false`
+- top `repair_queue` item `repair_alpha_readiness`
+- selected value gate `routeable_candidate_count`
+- `accepted_routeable_candidate_count=0`
+- `zero_notional_or_stale_evidence_rate=1.0`
+- `max_notional=0`
+- no-delta denial included `jangar_verification_carry_unavailable`
+
+During implementation, live Torghut had progressed to emitting `jangar_controller_ingestion_carry`, but it still
+reported `carry_state=unavailable` with `jangar_control_plane_status_url_missing`. Live Jangar control-plane status at
+`http://agents.agents.svc.cluster.local/api/agents/control-plane/status?namespace=agents` exposed:
+
+- `controller_ingestion_settlement.decision=hold`
+- `controller_ingestion_settlement.repair_slot_escrow_ref` present
+- `repair_slot_escrow.status=block`
+- controller carry still zero-notional; no live or paper widening was authorized
+
+After local changes, pre-deploy live Torghut business evidence is intentionally unchanged until GitOps rolls the new
+manifest and image:
+
+- `business_state=repair_only`
+- `revenue_ready=false`
+- top `repair_queue` item `repair_alpha_readiness`
+- selected value gate `routeable_candidate_count`
+- `accepted_routeable_candidate_count=0`
+- `zero_notional_or_stale_evidence_rate=1.0`
+- `max_notional=0`
+
+## Change
+
+- The live Torghut Knative service now sets `TRADING_JANGAR_CONTROL_PLANE_STATUS_URL` to the cluster-local Jangar
+  control-plane status route.
+- `JangarDependencyQuorumStatus` now preserves `repair_slot_escrow`, `stage_debt_repair_admission`, and
+  `foreclosure_carry_rollout_witness`.
+- Revenue repair, health, and consumer evidence pass those carry fields into
+  `torghut.jangar-controller-ingestion-carry.v1`.
+- Held or blocked Jangar controller-ingestion settlements with current board or repair-slot evidence classify as
+  `lagging`, not as generic missing carry.
+- No selected ticket can bypass `repairable` carry, and every selected or held ticket remains `max_notional=0`.
+
+## Validation
+
+- `uv sync --frozen --extra dev`
+- `uv run --frozen pytest tests/test_live_config_manifest_contract.py tests/test_jangar_controller_ingestion_carry.py tests/test_hypotheses.py tests/test_trading_api.py tests/test_no_delta_repair_reentry_auction.py tests/test_build_revenue_repair_digest.py`
+- `uv run --frozen ruff check app/main.py app/trading/hypotheses.py app/trading/jangar_controller_ingestion_carry.py tests/test_hypotheses.py tests/test_jangar_controller_ingestion_carry.py tests/test_live_config_manifest_contract.py tests/test_trading_api.py`
+- `uv run --frozen ruff format --check app/main.py app/trading/hypotheses.py app/trading/jangar_controller_ingestion_carry.py tests/test_hypotheses.py tests/test_jangar_controller_ingestion_carry.py tests/test_live_config_manifest_contract.py tests/test_trading_api.py`
+- `uv run --frozen pyright --project pyrightconfig.json`
+- `uv run --frozen pyright --project pyrightconfig.alpha.json`
+- `uv run --frozen pyright --project pyrightconfig.scripts.json`
+- `kubectl kustomize argocd/applications/torghut`
+- `bun run lint:argocd`
+
+## Risk And Rollback
+
+Risk is limited to Torghut observing Jangar control-plane status for revenue-repair carry. This does not enable live
+submission, paper widening, or nonzero notional. The rollback is to remove `TRADING_JANGAR_CONTROL_PLANE_STATUS_URL`
+from `argocd/applications/torghut/knative-service.yaml` and stop emitting the additional repair-slot carry fields;
+Torghut will return to the existing unavailable-carry denial while keeping `max_notional=0`.
+
+## Owner Status
+
+The revenue metric targeted is `routeable_candidate_count`. This PR does not claim a routeable-count increase before
+deployment; it removes the smallest observed blocker preventing the no-delta auction from consuming Jangar carry:
+`jangar_control_plane_status_url_missing`, then preserves the repair-slot evidence needed to name the next blocker.

--- a/services/torghut/README.md
+++ b/services/torghut/README.md
@@ -165,13 +165,13 @@ Testing rules for the trading core:
   - `torghut_trading_alpha_readiness_hypotheses_total`
   - `torghut_trading_alpha_readiness_promotion_eligible_total`
   - `torghut_trading_alpha_readiness_rollback_required_total`
-- Live and paper trading-loop manifests intentionally do not configure Jangar control-plane, quant-health,
-  symbol-universe, or market-context URLs. The executable universe is declared inside Torghut, and readiness must be
-  proven from Torghut-owned signal, empirical-job, proof-floor, routeability, and execution evidence rather than an
-  external Jangar status service.
+- The live trading-loop manifest sets `TRADING_JANGAR_CONTROL_PLANE_STATUS_URL` to the cluster-local Jangar
+  control-plane status route so revenue-repair can import controller-ingestion carry, verify-foreclosure boards, and
+  repair-slot escrow for zero-notional no-delta decisions. Paper/sim still leaves that URL unset. The executable
+  universe remains declared inside Torghut, and live submission remains gated by Torghut-owned signal, empirical-job,
+  proof-floor, routeability, and execution evidence rather than by Jangar serving health alone.
 - Optional cross-service dependency quorum checks remain available for off-path experiments by setting
-  `TRADING_JANGAR_CONTROL_PLANE_STATUS_URL`. Do not add that variable to the production live or paper trading services
-  unless the trading loop is explicitly meant to fail closed on that external service.
+  `TRADING_JANGAR_CONTROL_PLANE_STATUS_URL` on non-production surfaces that need the same bounded carry import.
 - Optional external quant-health checks remain available by setting `TRADING_JANGAR_QUANT_HEALTH_URL`. Torghut rejects
   that URL when it does not target the typed `/api/torghut/trading/control-plane/quant/health` surface; use
   `TRADING_JANGAR_QUANT_WINDOW` to align the expected freshness window. The production live and paper trading manifests
@@ -247,8 +247,9 @@ Testing rules for the trading core:
   `torghut.jangar-controller-ingestion-carry.v1` import reducer. It classifies Jangar controller-ingestion carry as
   `current`, `repairable`, `lagging`, `unavailable`, `stale`, or `contradicted`, feeds that state into the no-delta
   auction, and mirrors a compact `torghut.jangar-controller-ingestion-carry-ref.v1` through `/readyz` and
-  `/trading/consumer-evidence`. A `jangar_verify_carry` ticket is selectable only for `repairable` carry and always
-  keeps `max_notional=0`.
+  `/trading/consumer-evidence`. The import carries Jangar repair-slot escrow and rollout-witness refs when available
+  so `hold` or `block` settlements can name the exact zero-notional blocker instead of collapsing to a generic missing
+  carry. A `jangar_verify_carry` ticket is selectable only for `repairable` carry and always keeps `max_notional=0`.
 - `GET /trading/status` and `GET /readyz` now include the May 8 doc 181
   `quality_adjusted_profit_frontier` shadow projection. The reducer ranks zero-notional repair packets from quant
   quality, market-context risk flags, route/TCA state, simulation-cache freshness, and Jangar evidence-quality refs

--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -1100,6 +1100,15 @@ def _evaluate_trading_health_payload(
             "verify_trust_foreclosure_board": _dependency_quorum.as_payload().get(
                 "verify_trust_foreclosure_board"
             ),
+            "repair_slot_escrow": _dependency_quorum.as_payload().get(
+                "repair_slot_escrow"
+            ),
+            "stage_debt_repair_admission": _dependency_quorum.as_payload().get(
+                "stage_debt_repair_admission"
+            ),
+            "foreclosure_carry_rollout_witness": _dependency_quorum.as_payload().get(
+                "foreclosure_carry_rollout_witness"
+            ),
             "source_serving_repair_receipt_ledger": source_serving_repair_receipt_ledger,
         },
         generated_at=now,
@@ -1628,6 +1637,13 @@ def trading_revenue_repair() -> dict[str, object]:
             ),
             "verify_trust_foreclosure_board": verify_trust_foreclosure_board
             or dependency_quorum_payload.get("verify_trust_foreclosure_board"),
+            "repair_slot_escrow": dependency_quorum_payload.get("repair_slot_escrow"),
+            "stage_debt_repair_admission": dependency_quorum_payload.get(
+                "stage_debt_repair_admission"
+            ),
+            "foreclosure_carry_rollout_witness": dependency_quorum_payload.get(
+                "foreclosure_carry_rollout_witness"
+            ),
         }
     elif verify_trust_foreclosure_board is not None:
         status_payload = {
@@ -3284,6 +3300,15 @@ def _build_trading_consumer_evidence_payload() -> dict[str, object]:
             ),
             "verify_trust_foreclosure_board": dependency_quorum.as_payload().get(
                 "verify_trust_foreclosure_board"
+            ),
+            "repair_slot_escrow": dependency_quorum.as_payload().get(
+                "repair_slot_escrow"
+            ),
+            "stage_debt_repair_admission": dependency_quorum.as_payload().get(
+                "stage_debt_repair_admission"
+            ),
+            "foreclosure_carry_rollout_witness": dependency_quorum.as_payload().get(
+                "foreclosure_carry_rollout_witness"
             ),
         },
         generated_at=datetime.now(timezone.utc),

--- a/services/torghut/app/trading/hypotheses.py
+++ b/services/torghut/app/trading/hypotheses.py
@@ -306,6 +306,13 @@ class JangarDependencyQuorumStatus:
     verify_trust_foreclosure_board: dict[str, object] = field(
         default_factory=_empty_payload_dict
     )
+    repair_slot_escrow: dict[str, object] = field(default_factory=_empty_payload_dict)
+    stage_debt_repair_admission: dict[str, object] = field(
+        default_factory=_empty_payload_dict
+    )
+    foreclosure_carry_rollout_witness: dict[str, object] = field(
+        default_factory=_empty_payload_dict
+    )
     generated_at: str | None = None
 
     def as_payload(self) -> dict[str, object]:
@@ -327,6 +334,16 @@ class JangarDependencyQuorumStatus:
         if self.verify_trust_foreclosure_board:
             payload["verify_trust_foreclosure_board"] = dict(
                 self.verify_trust_foreclosure_board
+            )
+        if self.repair_slot_escrow:
+            payload["repair_slot_escrow"] = dict(self.repair_slot_escrow)
+        if self.stage_debt_repair_admission:
+            payload["stage_debt_repair_admission"] = dict(
+                self.stage_debt_repair_admission
+            )
+        if self.foreclosure_carry_rollout_witness:
+            payload["foreclosure_carry_rollout_witness"] = dict(
+                self.foreclosure_carry_rollout_witness
             )
         if self.generated_at:
             payload["generated_at"] = self.generated_at
@@ -392,6 +409,46 @@ def _extract_verify_trust_foreclosure_board(
         or payload.get("verifyTrustForeclosureBoard")
         or quorum.get("verify_trust_foreclosure_board")
         or quorum.get("verifyTrustForeclosureBoard")
+    )
+
+
+def _extract_repair_slot_escrow(
+    payload: Mapping[str, Any],
+    quorum: Mapping[str, Any],
+) -> dict[str, object]:
+    return _as_payload_dict(
+        payload.get("repair_slot_escrow")
+        or payload.get("repairSlotEscrow")
+        or quorum.get("repair_slot_escrow")
+        or quorum.get("repairSlotEscrow")
+    )
+
+
+def _extract_stage_debt_repair_admission(
+    payload: Mapping[str, Any],
+    quorum: Mapping[str, Any],
+) -> dict[str, object]:
+    return _as_payload_dict(
+        payload.get("stage_debt_repair_admission")
+        or payload.get("stageDebtRepairAdmission")
+        or quorum.get("stage_debt_repair_admission")
+        or quorum.get("stageDebtRepairAdmission")
+    )
+
+
+def _extract_foreclosure_carry_rollout_witness(
+    payload: Mapping[str, Any],
+    quorum: Mapping[str, Any],
+) -> dict[str, object]:
+    return _as_payload_dict(
+        payload.get("foreclosure_carry_rollout_witness")
+        or payload.get("foreclosureCarryRolloutWitness")
+        or payload.get("controller_ingestion_witness")
+        or payload.get("controllerIngestionWitness")
+        or quorum.get("foreclosure_carry_rollout_witness")
+        or quorum.get("foreclosureCarryRolloutWitness")
+        or quorum.get("controller_ingestion_witness")
+        or quorum.get("controllerIngestionWitness")
     )
 
 
@@ -654,6 +711,15 @@ def _fallback_quorum_from_legacy_status(
                     payload,
                     {},
                 ),
+                repair_slot_escrow=_extract_repair_slot_escrow(payload, {}),
+                stage_debt_repair_admission=_extract_stage_debt_repair_admission(
+                    payload,
+                    {},
+                ),
+                foreclosure_carry_rollout_witness=_extract_foreclosure_carry_rollout_witness(
+                    payload,
+                    {},
+                ),
             )
         if backoff_jobs > 0 or confidence == "degraded":
             return JangarDependencyQuorumStatus(
@@ -661,6 +727,15 @@ def _fallback_quorum_from_legacy_status(
                 reasons=["workflows_degraded"],
                 message="Torghut workflow reliability is degraded.",
                 verify_trust_foreclosure_board=_extract_verify_trust_foreclosure_board(
+                    payload,
+                    {},
+                ),
+                repair_slot_escrow=_extract_repair_slot_escrow(payload, {}),
+                stage_debt_repair_admission=_extract_stage_debt_repair_admission(
+                    payload,
+                    {},
+                ),
+                foreclosure_carry_rollout_witness=_extract_foreclosure_carry_rollout_witness(
                     payload,
                     {},
                 ),
@@ -682,12 +757,27 @@ def _fallback_quorum_from_legacy_status(
                         payload,
                         {},
                     ),
+                    repair_slot_escrow=_extract_repair_slot_escrow(payload, {}),
+                    stage_debt_repair_admission=_extract_stage_debt_repair_admission(
+                        payload,
+                        {},
+                    ),
+                    foreclosure_carry_rollout_witness=_extract_foreclosure_carry_rollout_witness(
+                        payload,
+                        {},
+                    ),
                 )
     return JangarDependencyQuorumStatus(
         decision="unknown",
         reasons=["jangar_dependency_quorum_missing"],
         message="Torghut control-plane status did not include dependency_quorum.",
         verify_trust_foreclosure_board=_extract_verify_trust_foreclosure_board(
+            payload,
+            {},
+        ),
+        repair_slot_escrow=_extract_repair_slot_escrow(payload, {}),
+        stage_debt_repair_admission=_extract_stage_debt_repair_admission(payload, {}),
+        foreclosure_carry_rollout_witness=_extract_foreclosure_carry_rollout_witness(
             payload,
             {},
         ),
@@ -765,6 +855,15 @@ def load_jangar_dependency_quorum() -> JangarDependencyQuorumStatus:
                     quorum,
                 ),
                 verify_trust_foreclosure_board=_extract_verify_trust_foreclosure_board(
+                    payload,
+                    quorum,
+                ),
+                repair_slot_escrow=_extract_repair_slot_escrow(payload, quorum),
+                stage_debt_repair_admission=_extract_stage_debt_repair_admission(
+                    payload,
+                    quorum,
+                ),
+                foreclosure_carry_rollout_witness=_extract_foreclosure_carry_rollout_witness(
                     payload,
                     quorum,
                 ),

--- a/services/torghut/app/trading/jangar_controller_ingestion_carry.py
+++ b/services/torghut/app/trading/jangar_controller_ingestion_carry.py
@@ -257,11 +257,17 @@ def _controller_ingestion_current(settlement: Mapping[str, Any]) -> bool | None:
     if direct is not None:
         return direct
     for key in (
+        "agentrun_ingestion_current",
+        "agentrunIngestionCurrent",
         "ingestion_current",
         "ingestionCurrent",
+        "controller_self_report_current",
+        "controllerSelfReportCurrent",
         "current",
         "watch_current",
         "watchCurrent",
+        "watch_epoch_current",
+        "watchEpochCurrent",
         "self_report_current",
         "selfReportCurrent",
     ):
@@ -463,6 +469,17 @@ def build_jangar_controller_ingestion_carry(
         )
         if not selected_ticket_class:
             selected_ticket_class = "jangar_verify_carry"
+    elif (
+        decision in {"hold", "block"}
+        and settlement
+        and (board_ref or source_claim or ingestion_current is False)
+    ):
+        carry_state = "lagging"
+        reason_codes = _append_unique(
+            reason_codes,
+            f"jangar_controller_ingestion_{decision}",
+            "jangar_controller_ingestion_lagging",
+        )
     elif source_claim and (not board_ref or ingestion_current is not True):
         carry_state = "lagging"
         reason_codes = _append_unique(

--- a/services/torghut/tests/test_hypotheses.py
+++ b/services/torghut/tests/test_hypotheses.py
@@ -986,6 +986,50 @@ class TestHypothesisReadiness(TestCase):
         payload = status.as_payload()
         self.assertEqual(payload["verify_trust_foreclosure_board"], board)
 
+    def test_load_jangar_dependency_quorum_preserves_repair_slot_carry(
+        self,
+    ) -> None:
+        settings.trading_jangar_control_plane_status_url = (
+            "https://jangar.example/status"
+        )
+        settings.trading_jangar_control_plane_cache_ttl_seconds = 0
+        settings.trading_jangar_control_plane_timeout_seconds = 1.0
+        repair_slot_escrow = {
+            "schema_version": "jangar.repair-slot-escrow.v1",
+            "escrow_id": "repair-slot-escrow:test",
+            "status": "block",
+            "reason_codes": ["selected_receipt_source_revenue_repair_ref_mismatch"],
+        }
+        rollout_witness = {
+            "schema_version": "jangar.foreclosure-carry-rollout-witness.v1",
+            "witness_id": "foreclosure-carry-rollout-witness:test",
+            "fresh_until": "2026-05-14T16:30:00Z",
+        }
+        with patch(
+            "app.trading.hypotheses.urlopen",
+            return_value=_FakeHttpResponse(
+                {
+                    "generated_at": "2026-05-14T16:10:00Z",
+                    "dependency_quorum": {
+                        "decision": "block",
+                        "reasons": ["empirical_jobs_degraded"],
+                        "message": "blocked",
+                    },
+                    "repair_slot_escrow": repair_slot_escrow,
+                    "foreclosure_carry_rollout_witness": rollout_witness,
+                }
+            ),
+        ):
+            status = load_jangar_dependency_quorum()
+
+        payload = status.as_payload()
+        self.assertEqual(status.decision, "block")
+        self.assertEqual(payload["repair_slot_escrow"], repair_slot_escrow)
+        self.assertEqual(
+            payload["foreclosure_carry_rollout_witness"],
+            rollout_witness,
+        )
+
     def test_load_jangar_dependency_quorum_falls_back_to_legacy_status_when_needed(
         self,
     ) -> None:

--- a/services/torghut/tests/test_jangar_controller_ingestion_carry.py
+++ b/services/torghut/tests/test_jangar_controller_ingestion_carry.py
@@ -102,6 +102,39 @@ def test_controller_ingestion_carry_classifies_lagging_source_claim() -> None:
     assert "jangar_controller_ingestion_lagging" in carry["reason_codes"]
 
 
+def test_controller_ingestion_carry_classifies_held_jangar_settlement_as_lagging() -> (
+    None
+):
+    carry = build_jangar_controller_ingestion_carry(
+        generated_at=NOW,
+        dependency_quorum={
+            "controller_ingestion_settlement": {
+                "settlement_id": "controller-ingestion-settlement:hold",
+                "decision": "hold",
+                "agentrun_ingestion_current": False,
+                "fresh_until": "2026-05-14T15:45:00+00:00",
+                "reason_codes": ["agentrun_ingestion_unknown"],
+            },
+            "verify_trust_foreclosure_board": {
+                "board_id": "verify-trust-foreclosure-board:hold",
+                "fresh_until": "2026-05-14T15:45:00+00:00",
+            },
+            "repair_slot_escrow": {
+                "escrow_id": "repair-slot-escrow:hold",
+                "status": "block",
+                "reason_codes": ["selected_receipt_source_revenue_repair_ref_mismatch"],
+            },
+        },
+    )
+
+    assert carry["carry_state"] == "lagging"
+    assert carry["jangar_settlement_decision"] == "hold"
+    assert carry["jangar_controller_ingestion_current"] is False
+    assert carry["jangar_repair_slot_escrow_ref"] == "repair-slot-escrow:hold"
+    assert "jangar_controller_ingestion_hold" in carry["reason_codes"]
+    assert "jangar_controller_ingestion_lagging" in carry["reason_codes"]
+
+
 def test_controller_ingestion_carry_classifies_stale_settlement() -> None:
     carry = build_jangar_controller_ingestion_carry(
         generated_at=NOW,

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -260,7 +260,10 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertFalse(settings.trading_universe_static_fallback_enabled)
         self.assertEqual(settings.trading_universe_max_stale_seconds, 900)
         self.assertIsNone(settings.trading_jangar_symbols_url)
-        self.assertIsNone(settings.trading_jangar_control_plane_status_url)
+        self.assertEqual(
+            settings.trading_jangar_control_plane_status_url,
+            "http://agents.agents.svc.cluster.local/api/agents/control-plane/status?namespace=agents",
+        )
         self.assertIsNone(settings.trading_jangar_quant_health_url)
         self.assertEqual(
             settings.trading_market_context_url,
@@ -280,7 +283,10 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertNotIn("TRADING_FORECAST_SERVICE_URL", env)
         self.assertNotIn("TRADING_LEAN_RUNNER_URL", env)
         self.assertNotIn("JANGAR_SYMBOLS_URL", env)
-        self.assertNotIn("TRADING_JANGAR_CONTROL_PLANE_STATUS_URL", env)
+        self.assertEqual(
+            env.get("TRADING_JANGAR_CONTROL_PLANE_STATUS_URL"),
+            settings.trading_jangar_control_plane_status_url,
+        )
         self.assertNotIn("TRADING_JANGAR_CONTROL_PLANE_CACHE_TTL_SECONDS", env)
         self.assertNotIn("TRADING_JANGAR_CONTROL_PLANE_TIMEOUT_SECONDS", env)
         self.assertNotIn("TRADING_JANGAR_QUANT_HEALTH_REQUIRED", env)
@@ -293,18 +299,21 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertEqual(env.get("TRADING_MARKET_CONTEXT_FAIL_MODE"), "shadow_only")
         self.assertNotIn("JANGAR_BASE_URL", env)
 
-    def test_live_manifest_has_no_jangar_trading_loop_urls(self) -> None:
+    def test_live_manifest_limits_jangar_trading_loop_urls(self) -> None:
         env = _load_torghut_knative_env()
 
         blocked_env = {
             "JANGAR_SYMBOLS_URL",
-            "TRADING_JANGAR_CONTROL_PLANE_STATUS_URL",
             "TRADING_JANGAR_CONTROL_PLANE_CACHE_TTL_SECONDS",
             "TRADING_JANGAR_CONTROL_PLANE_TIMEOUT_SECONDS",
             "TRADING_JANGAR_QUANT_HEALTH_REQUIRED",
             "TRADING_JANGAR_QUANT_HEALTH_URL",
         }
         self.assertTrue(blocked_env.isdisjoint(env))
+        self.assertEqual(
+            env.get("TRADING_JANGAR_CONTROL_PLANE_STATUS_URL"),
+            "http://agents.agents.svc.cluster.local/api/agents/control-plane/status?namespace=agents",
+        )
         self.assertEqual(
             env.get("TRADING_MARKET_CONTEXT_URL"),
             "http://jangar.jangar.svc.cluster.local/api/torghut/market-context",

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -1078,6 +1078,84 @@ class TestTradingApi(TestCase):
         payload = response.json()
         self.assertEqual(payload["verify_trust_foreclosure_board"], board)
 
+    def test_revenue_repair_hydrates_jangar_repair_slot_carry(self) -> None:
+        board = {
+            "schema_version": "jangar.verify-trust-foreclosure-board.v1",
+            "board_id": "verify-trust-foreclosure-board:agents:test",
+            "fresh_until": "2026-05-14T16:30:00Z",
+        }
+        settlement = {
+            "schema_version": "jangar.controller-ingestion-settlement.v1",
+            "settlement_id": "controller-ingestion-settlement:agents:test",
+            "decision": "hold",
+            "agentrun_ingestion_current": False,
+        }
+        repair_slot_escrow = {
+            "schema_version": "jangar.repair-slot-escrow.v1",
+            "escrow_id": "repair-slot-escrow:test",
+            "status": "block",
+            "reason_codes": ["selected_receipt_source_revenue_repair_ref_mismatch"],
+        }
+        rollout_witness = {
+            "schema_version": "jangar.foreclosure-carry-rollout-witness.v1",
+            "witness_id": "foreclosure-carry-rollout-witness:test",
+        }
+        dependency_quorum = {
+            "decision": "block",
+            "reasons": ["empirical_jobs_degraded"],
+            "message": "blocked",
+            "controller_ingestion_settlement": settlement,
+            "verify_trust_foreclosure_board": board,
+            "repair_slot_escrow": repair_slot_escrow,
+            "foreclosure_carry_rollout_witness": rollout_witness,
+        }
+
+        def _build_digest(
+            *,
+            readyz_payload: dict[str, object],
+            status_payload: dict[str, object],
+        ) -> dict[str, object]:
+            self.assertEqual(readyz_payload["status"], "degraded")
+            self.assertEqual(status_payload["dependency_quorum"], dependency_quorum)
+            self.assertEqual(
+                status_payload["controller_ingestion_settlement"],
+                settlement,
+            )
+            self.assertEqual(status_payload["repair_slot_escrow"], repair_slot_escrow)
+            self.assertEqual(
+                status_payload["foreclosure_carry_rollout_witness"],
+                rollout_witness,
+            )
+            return {
+                "schema_version": "torghut.revenue-repair-digest.v1",
+                "repair_slot_escrow": status_payload.get("repair_slot_escrow"),
+            }
+
+        with (
+            patch(
+                "app.main._evaluate_trading_health_payload",
+                return_value=({"status": "degraded"}, 503),
+            ),
+            patch(
+                "app.main.trading_status",
+                return_value={
+                    "mode": "live",
+                    "pipeline_mode": "simple",
+                    "build": {"commit": "source-sha"},
+                },
+            ),
+            patch(
+                "app.main._load_jangar_dependency_quorum_payload",
+                return_value=dependency_quorum,
+            ),
+            patch("app.main.build_revenue_repair_digest", side_effect=_build_digest),
+        ):
+            response = self.client.get("/trading/revenue-repair")
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["repair_slot_escrow"], repair_slot_escrow)
+
     def test_trading_consumer_evidence_avoids_recursive_jangar_status_fetch(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Wires live Torghut to the cluster-local Jangar control-plane status route so revenue repair can import controller-ingestion carry instead of reporting `jangar_control_plane_status_url_missing`.
- Preserves Jangar `repair_slot_escrow`, `stage_debt_repair_admission`, and `foreclosure_carry_rollout_witness` through Torghut dependency quorum, health, revenue-repair, and consumer-evidence payloads.
- Classifies held or blocked Jangar controller-ingestion settlements with board or repair-slot evidence as `lagging`, while keeping `jangar_verify_carry` ticket selection gated on `carry_state=repairable` and `max_notional=0`.
- Updates Torghut docs and rollout evidence for design `docs/torghut/design-system/v6/211-torghut-controller-ingestion-carry-and-alpha-no-delta-release-2026-05-14.md`.

## Related Issues

None

## Testing

- PASS: `/root/.local/bin/uv sync --frozen --extra dev`
- PASS: `/root/.local/bin/uv run --frozen pytest tests/test_live_config_manifest_contract.py tests/test_jangar_controller_ingestion_carry.py tests/test_hypotheses.py tests/test_trading_api.py tests/test_no_delta_repair_reentry_auction.py tests/test_build_revenue_repair_digest.py`
- PASS: `/root/.local/bin/uv run --frozen ruff check app/main.py app/trading/hypotheses.py app/trading/jangar_controller_ingestion_carry.py tests/test_hypotheses.py tests/test_jangar_controller_ingestion_carry.py tests/test_live_config_manifest_contract.py tests/test_trading_api.py`
- PASS: `/root/.local/bin/uv run --frozen ruff format --check app/main.py app/trading/hypotheses.py app/trading/jangar_controller_ingestion_carry.py tests/test_hypotheses.py tests/test_jangar_controller_ingestion_carry.py tests/test_live_config_manifest_contract.py tests/test_trading_api.py`
- PASS: `/root/.local/bin/uv run --frozen pyright --project pyrightconfig.json`
- PASS: `/root/.local/bin/uv run --frozen pyright --project pyrightconfig.alpha.json`
- PASS: `/root/.local/bin/uv run --frozen pyright --project pyrightconfig.scripts.json`
- PASS: `kubectl kustomize argocd/applications/torghut`
- PASS: `bun run lint:argocd` with 816 resources, 0 invalid, 0 errors
- PASS: GitHub PR CI on PR #6680: `Pyright`, `Bytecode + lint + migration guard`, `Bytecode + pytest + coverage`, `Pytest shard 0/1/2/3`, `Pytest autoresearch runner 0/1/2/3/4/5/6/7`, `Quality signals`, and PR metadata checks

## Screenshots (if applicable)

N/A

## Breaking Changes

None. This adds an observe-mode evidence import and live manifest URL for revenue-repair carry; it does not enable live submission, paper widening, or nonzero notional.

## Design And Requirement Provenance

- Governing Torghut design: `docs/torghut/design-system/v6/211-torghut-controller-ingestion-carry-and-alpha-no-delta-release-2026-05-14.md`
- Companion Jangar design: `docs/agents/designs/205-jangar-controller-ingestion-settlement-and-verification-carry-cutover-2026-05-14.md`
- Runtime source of truth: `GET http://torghut.torghut.svc.cluster.local/trading/revenue-repair`
- Selected live work item: `repair_alpha_readiness`, reason `alpha_readiness_not_promotion_eligible`
- Affected value gate: `routeable_candidate_count`
- Capital rule preserved: `zero_notional_repair_only`, `max_notional=0`

## Business Evidence

Before implementation, live Torghut reported:

- `business_state=repair_only`
- `revenue_ready=false`
- top `repair_queue` item `repair_alpha_readiness`
- `accepted_routeable_candidate_count=0`
- `zero_notional_or_stale_evidence_rate=1.0`
- no-delta denial included `jangar_verification_carry_unavailable`

During implementation, live Torghut exposed `jangar_controller_ingestion_carry.carry_state=unavailable` with `jangar_control_plane_status_url_missing`. Live Jangar status at `http://agents.agents.svc.cluster.local/api/agents/control-plane/status?namespace=agents` exposed `controller_ingestion_settlement.decision=hold`, a `repair_slot_escrow_ref`, and `repair_slot_escrow.status=block`.

After local changes and before deployment, live business evidence is intentionally unchanged until GitOps rolls the manifest and image:

- `business_state=repair_only`
- `revenue_ready=false`
- top `repair_queue` item `repair_alpha_readiness`
- top reason `alpha_readiness_not_promotion_eligible`
- affected value gate `routeable_candidate_count`
- `accepted_routeable_candidate_count=0`
- `zero_notional_or_stale_evidence_rate=1.0`
- `max_notional=0`
- current live carry blocker before this PR is deployed: `jangar_control_plane_status_url_missing`

Final PR state:

- Mergeability: `CLEAN`, `MERGEABLE`
- Review threads: none

## Risk And Rollback

Risk is limited to Torghut fetching the bounded Jangar control-plane status route for revenue-repair carry. Fetch failure remains a denial reason, and `jangar_verify_carry` ticket selection still requires `carry_state=repairable`.

Rollback is to remove `TRADING_JANGAR_CONTROL_PLANE_STATUS_URL` from `argocd/applications/torghut/knative-service.yaml` and revert the carry field propagation; Torghut returns to unavailable-carry denial while keeping `max_notional=0`.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
