### PR TITLE
fix(torghut): backfill paper quotes from alpaca

### DIFF
--- a/argocd/applications/feature-flags/gitops/default/features.yaml
+++ b/argocd/applications/feature-flags/gitops/default/features.yaml
@@ -75,6 +75,11 @@ flags:
     description: Enables strict feature quality gate enforcement.
     type: BOOLEAN_FLAG_TYPE
     enabled: true
+  - key: torghut_trading_alpaca_quote_fallback_enabled
+    name: Torghut Trading Alpaca Quote Fallback Enabled
+    description: Enables paper-safe Alpaca latest-quote fallback when executable signal quotes are missing.
+    type: BOOLEAN_FLAG_TYPE
+    enabled: false
   - key: torghut_trading_autonomy_enabled
     name: Torghut Trading Autonomy Enabled
     description: Enables autonomous lane orchestration in Torghut.

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -154,6 +154,12 @@ spec:
               value: "300"
             - name: TRADING_EXECUTABLE_QUOTE_FORWARD_SECONDS
               value: "60"
+            - name: TRADING_ALPACA_QUOTE_FALLBACK_ENABLED
+              value: "true"
+            - name: TRADING_ALPACA_QUOTE_FEED
+              value: iex
+            - name: TRADING_ALPACA_QUOTE_MAX_AGE_SECONDS
+              value: "20"
             - name: TRADING_SESSION_CONTEXT_WARMUP_MAX_SECONDS
               value: "300"
             - name: TRADING_SESSION_CONTEXT_WARMUP_MAX_SIGNALS

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -136,6 +136,8 @@ spec:
               value: "60"
             - name: TRADING_EXECUTABLE_QUOTE_FORWARD_SECONDS
               value: "0"
+            - name: TRADING_ALPACA_QUOTE_FALLBACK_ENABLED
+              value: "false"
             - name: TRADING_SESSION_CONTEXT_WARMUP_MAX_SECONDS
               value: "300"
             - name: TRADING_SESSION_CONTEXT_WARMUP_MAX_SIGNALS

--- a/services/torghut/app/config.py
+++ b/services/torghut/app/config.py
@@ -49,6 +49,7 @@ FEATURE_FLAG_BOOLEAN_KEY_BY_FIELD: dict[str, str] = {
     "trading_drift_rollback_on_performance": "torghut_trading_drift_rollback_on_performance",
     "trading_execution_advisor_enabled": "torghut_trading_execution_advisor_enabled",
     "trading_execution_advisor_live_apply_enabled": "torghut_trading_execution_advisor_live_apply_enabled",
+    "trading_alpaca_quote_fallback_enabled": "torghut_trading_alpaca_quote_fallback_enabled",
     "trading_simulation_enabled": "torghut_trading_simulation_enabled",
     "trading_allow_shorts": "torghut_trading_allow_shorts",
     "trading_fractional_equities_enabled": "torghut_trading_fractional_equities_enabled",
@@ -434,6 +435,30 @@ class Settings(BaseSettings):
             "a signal timestamp but before decision evaluation. Keep this disabled for "
             "replay and live-submit lanes."
         ),
+    )
+    trading_alpaca_quote_fallback_enabled: bool = Field(
+        default=False,
+        alias="TRADING_ALPACA_QUOTE_FALLBACK_ENABLED",
+        description=(
+            "Allow runtime executable quote backfill from Alpaca latest stock quotes "
+            "when ClickHouse signal rows do not carry bid/ask. Keep disabled for "
+            "live-submit lanes unless explicitly promoted."
+        ),
+    )
+    trading_alpaca_quote_feed: str = Field(
+        default="iex",
+        alias="TRADING_ALPACA_QUOTE_FEED",
+        description="Alpaca stock-data feed used for latest-quote executable backfill.",
+    )
+    trading_alpaca_quote_timeout_seconds: float = Field(
+        default=2.0,
+        alias="TRADING_ALPACA_QUOTE_TIMEOUT_SECONDS",
+        description="HTTP timeout for Alpaca latest-quote executable backfill.",
+    )
+    trading_alpaca_quote_max_age_seconds: int = Field(
+        default=20,
+        alias="TRADING_ALPACA_QUOTE_MAX_AGE_SECONDS",
+        description="Reject Alpaca fallback quotes older than this many seconds.",
     )
     trading_poll_ms: int = Field(default=5000, alias="TRADING_POLL_MS")
     trading_reconcile_ms: int = Field(default=15000, alias="TRADING_RECONCILE_MS")

--- a/services/torghut/app/trading/prices.py
+++ b/services/torghut/app/trading/prices.py
@@ -105,6 +105,13 @@ class ClickHousePriceFetcher(PriceFetcher):
         lookback_minutes: Optional[int] = None,
         quote_lookback_seconds: Optional[int] = None,
         quote_forward_seconds: Optional[int] = None,
+        alpaca_quote_fallback_enabled: Optional[bool] = None,
+        alpaca_data_api_base_url: Optional[str] = None,
+        alpaca_api_key_id: Optional[str] = None,
+        alpaca_api_secret_key: Optional[str] = None,
+        alpaca_quote_feed: Optional[str] = None,
+        alpaca_quote_timeout_seconds: Optional[float] = None,
+        alpaca_quote_max_age_seconds: Optional[int] = None,
     ) -> None:
         self.url = (url or settings.trading_clickhouse_url or "").rstrip("/")
         self.username = username or settings.trading_clickhouse_username
@@ -127,6 +134,36 @@ class ClickHousePriceFetcher(PriceFetcher):
             else quote_forward_seconds
         )
         self.quote_forward_seconds = max(0, configured_forward_seconds)
+        self.alpaca_quote_fallback_enabled = (
+            settings.trading_alpaca_quote_fallback_enabled
+            if alpaca_quote_fallback_enabled is None
+            else alpaca_quote_fallback_enabled
+        )
+        self.alpaca_data_api_base_url = (
+            alpaca_data_api_base_url
+            or settings.apca_data_api_base_url
+            or "https://data.alpaca.markets"
+        ).rstrip("/")
+        self.alpaca_api_key_id = alpaca_api_key_id or settings.apca_api_key_id
+        self.alpaca_api_secret_key = (
+            alpaca_api_secret_key or settings.apca_api_secret_key
+        )
+        self.alpaca_quote_feed = (
+            alpaca_quote_feed
+            if alpaca_quote_feed is not None
+            else settings.trading_alpaca_quote_feed
+        ).strip()
+        self.alpaca_quote_timeout_seconds = (
+            alpaca_quote_timeout_seconds
+            if alpaca_quote_timeout_seconds is not None
+            else settings.trading_alpaca_quote_timeout_seconds
+        )
+        self.alpaca_quote_max_age_seconds = max(
+            1,
+            alpaca_quote_max_age_seconds
+            if alpaca_quote_max_age_seconds is not None
+            else settings.trading_alpaca_quote_max_age_seconds,
+        )
         self._columns: Optional[set[str]] = None
 
     def fetch_price(self, signal: SignalEnvelope) -> Optional[Decimal]:
@@ -199,6 +236,10 @@ class ClickHousePriceFetcher(PriceFetcher):
             symbol=symbol,
             target_ts=target_ts,
         )
+        quote_source = "ta_signals_quote"
+        if quote_row is None:
+            quote_row = self._fetch_alpaca_latest_quote_row(symbol=symbol)
+            quote_source = "alpaca_latest_quote"
         as_of = _snapshot_as_of(row, signal.event_ts)
         price = _select_price(row)
         spread = _optional_decimal(row.get("spread"))
@@ -213,7 +254,7 @@ class ClickHousePriceFetcher(PriceFetcher):
             price = price or _select_price(quote_row) or _midpoint(bid=bid, ask=ask)
             spread = spread or quote_spread
             as_of = quote_as_of if not row else as_of
-            source = "ta_microbars+ta_signals_quote" if row else "ta_signals_quote"
+            source = f"ta_microbars+{quote_source}" if row else quote_source
         if price is None and bid is None and ask is None:
             return None
         return MarketSnapshot(
@@ -277,6 +318,135 @@ class ClickHousePriceFetcher(PriceFetcher):
         if not rows:
             return None
         return rows[0]
+
+    def _fetch_alpaca_latest_quote_row(self, *, symbol: str) -> dict[str, Any] | None:
+        if not self.alpaca_quote_fallback_enabled:
+            return None
+        if not self.alpaca_api_key_id or not self.alpaca_api_secret_key:
+            logger.warning(
+                "Alpaca latest quote fallback disabled by missing credentials symbol=%s",
+                symbol,
+            )
+            return None
+        quote = self._fetch_alpaca_latest_quote(symbol=symbol)
+        if quote is None:
+            return None
+        bid = _optional_decimal(quote.get("bp") or quote.get("bid_price"))
+        ask = _optional_decimal(quote.get("ap") or quote.get("ask_price"))
+        if bid is None or ask is None or bid <= 0 or ask < bid:
+            logger.info(
+                "Alpaca latest quote fallback rejected invalid quote symbol=%s", symbol
+            )
+            return None
+        spread_bps = _quote_spread_bps(bid=bid, ask=ask)
+        if spread_bps is None:
+            return None
+        if spread_bps > settings.trading_signal_max_executable_spread_bps:
+            logger.info(
+                "Alpaca latest quote fallback rejected wide quote symbol=%s spread_bps=%s",
+                symbol,
+                spread_bps,
+            )
+            return None
+        quote_ts = _parse_ts(quote.get("t") or quote.get("timestamp"))
+        if quote_ts is None:
+            logger.info(
+                "Alpaca latest quote fallback rejected missing timestamp symbol=%s",
+                symbol,
+            )
+            return None
+        if quote_ts.tzinfo is None:
+            quote_ts = quote_ts.replace(tzinfo=timezone.utc)
+        quote_age = max(
+            0.0,
+            (
+                datetime.now(timezone.utc) - quote_ts.astimezone(timezone.utc)
+            ).total_seconds(),
+        )
+        if quote_age > self.alpaca_quote_max_age_seconds:
+            logger.info(
+                "Alpaca latest quote fallback rejected stale quote symbol=%s age_seconds=%.3f",
+                symbol,
+                quote_age,
+            )
+            return None
+        return {
+            "event_ts": quote_ts.isoformat(),
+            "imbalance_bid_px": bid,
+            "imbalance_ask_px": ask,
+            "imbalance_spread": ask - bid,
+        }
+
+    def _fetch_alpaca_latest_quote(self, *, symbol: str) -> Mapping[str, Any] | None:
+        params: dict[str, str] = {}
+        if self.alpaca_quote_feed:
+            params["feed"] = self.alpaca_quote_feed
+        query = urlencode(params)
+        request_url = (
+            f"{self.alpaca_data_api_base_url}/v2/stocks/{symbol}/quotes/latest"
+        )
+        if query:
+            request_url = f"{request_url}?{query}"
+        parsed = urlsplit(request_url)
+        scheme = parsed.scheme.lower()
+        if scheme not in {"http", "https"}:
+            logger.warning(
+                "Unsupported Alpaca data API URL scheme: %s", scheme or "missing"
+            )
+            return None
+        if not parsed.hostname:
+            logger.warning("Invalid Alpaca data API URL host")
+            return None
+
+        headers = {
+            "Accept": "application/json",
+            "APCA-API-KEY-ID": self.alpaca_api_key_id or "",
+            "APCA-API-SECRET-KEY": self.alpaca_api_secret_key or "",
+        }
+        path = parsed.path or "/"
+        if parsed.query:
+            path = f"{path}?{parsed.query}"
+        connection_class = HTTPSConnection if scheme == "https" else HTTPConnection
+        connection = connection_class(
+            parsed.hostname,
+            parsed.port,
+            timeout=self.alpaca_quote_timeout_seconds,
+        )
+        try:
+            connection.request("GET", path, headers=headers)
+            response = connection.getresponse()
+            body = response.read().decode("utf-8", errors="replace")
+        except Exception as exc:
+            logger.warning(
+                "Alpaca latest quote fallback request failed symbol=%s error=%s",
+                symbol,
+                exc,
+            )
+            return None
+        finally:
+            connection.close()
+        if response.status < 200 or response.status >= 300:
+            logger.warning(
+                "Alpaca latest quote fallback HTTP failure symbol=%s status=%s body=%s",
+                symbol,
+                response.status,
+                body[:200],
+            )
+            return None
+        try:
+            payload = json.loads(body)
+        except json.JSONDecodeError:
+            logger.warning(
+                "Alpaca latest quote fallback returned invalid JSON symbol=%s", symbol
+            )
+            return None
+        if not isinstance(payload, Mapping):
+            return None
+        payload_mapping = cast(Mapping[str, Any], payload)
+        quote = payload_mapping.get("quote")
+        if not isinstance(quote, Mapping):
+            return None
+        return cast(Mapping[str, Any], quote)
 
     def _query_clickhouse(self, query: str) -> list[dict[str, Any]]:
         params = {"query": query}
@@ -423,6 +593,13 @@ def _midpoint(*, bid: Decimal | None, ask: Decimal | None) -> Optional[Decimal]:
     if bid is None or ask is None:
         return None
     return (bid + ask) / Decimal("2")
+
+
+def _quote_spread_bps(*, bid: Decimal, ask: Decimal) -> Optional[Decimal]:
+    midpoint = _midpoint(bid=bid, ask=ask)
+    if midpoint is None or midpoint <= 0:
+        return None
+    return ((ask - bid) / midpoint) * Decimal("10000")
 
 
 def _quote_spread_bps_sql() -> str:

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -537,6 +537,18 @@ class TestLiveConfigManifestContract(TestCase):
             "60",
         )
         self.assertEqual(
+            sim_env.get("TRADING_ALPACA_QUOTE_FALLBACK_ENABLED"),
+            "true",
+        )
+        self.assertEqual(
+            sim_env.get("TRADING_ALPACA_QUOTE_FEED"),
+            "iex",
+        )
+        self.assertEqual(
+            sim_env.get("TRADING_ALPACA_QUOTE_MAX_AGE_SECONDS"),
+            "20",
+        )
+        self.assertEqual(
             _load_torghut_knative_env().get(
                 "TRADING_EXECUTABLE_QUOTE_LOOKBACK_SECONDS"
             ),
@@ -545,6 +557,10 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertEqual(
             _load_torghut_knative_env().get("TRADING_EXECUTABLE_QUOTE_FORWARD_SECONDS"),
             "0",
+        )
+        self.assertEqual(
+            _load_torghut_knative_env().get("TRADING_ALPACA_QUOTE_FALLBACK_ENABLED"),
+            "false",
         )
         self.assertEqual(
             sim_env.get("TRADING_UNIVERSE_STATIC_FALLBACK_SYMBOLS"),
@@ -825,6 +841,7 @@ class TestLiveConfigManifestContract(TestCase):
             context="live static universe",
         )
         self.assertFalse(_manifest_bool(env, "TRADING_SIMPLE_SUBMIT_ENABLED"))
+        self.assertFalse(_manifest_bool(env, "TRADING_ALPACA_QUOTE_FALLBACK_ENABLED"))
         self.assertFalse(_manifest_bool(env, "TRADING_AUTONOMY_ENABLED"))
         self.assertFalse(_manifest_bool(env, "TRADING_AUTONOMY_ALLOW_LIVE_PROMOTION"))
         self.assertFalse(_manifest_bool(env, "TRADING_KILL_SWITCH_ENABLED"))

--- a/services/torghut/tests/test_prices.py
+++ b/services/torghut/tests/test_prices.py
@@ -6,7 +6,7 @@ from unittest import TestCase
 from unittest.mock import patch
 
 from app.trading.models import SignalEnvelope
-from app.trading.prices import ClickHousePriceFetcher, _midpoint
+from app.trading.prices import ClickHousePriceFetcher, _midpoint, _quote_spread_bps
 
 
 class FakeClickHousePriceFetcher(ClickHousePriceFetcher):
@@ -39,6 +39,8 @@ class RoutingClickHousePriceFetcher(ClickHousePriceFetcher):
         quote_rows: list[dict[str, object]],
         fail_quote_query: bool = False,
         quote_forward_seconds: int = 0,
+        alpaca_quote: dict[str, object] | None = None,
+        alpaca_quote_fallback_enabled: bool | None = None,
     ) -> None:
         super().__init__(
             url="http://example",
@@ -46,10 +48,20 @@ class RoutingClickHousePriceFetcher(ClickHousePriceFetcher):
             quote_table="torghut.ta_signals",
             quote_lookback_seconds=60,
             quote_forward_seconds=quote_forward_seconds,
+            alpaca_quote_fallback_enabled=(
+                alpaca_quote is not None
+                if alpaca_quote_fallback_enabled is None
+                else alpaca_quote_fallback_enabled
+            ),
+            alpaca_data_api_base_url="https://data.example",
+            alpaca_api_key_id="key" if alpaca_quote is not None else None,
+            alpaca_api_secret_key="secret" if alpaca_quote is not None else None,
+            alpaca_quote_max_age_seconds=120,
         )
         self.price_rows = price_rows
         self.quote_rows = quote_rows
         self.fail_quote_query = fail_quote_query
+        self.alpaca_quote = alpaca_quote
         self.queries: list[str] = []
 
     def _resolve_columns(self) -> set[str] | None:
@@ -62,6 +74,10 @@ class RoutingClickHousePriceFetcher(ClickHousePriceFetcher):
                 raise RuntimeError("quote query failed")
             return self.quote_rows
         return self.price_rows
+
+    def _fetch_alpaca_latest_quote(self, *, symbol: str) -> dict[str, object] | None:
+        _ = symbol
+        return self.alpaca_quote
 
 
 class SeqAwarePriceFetcher(CapturingPriceFetcher):
@@ -243,6 +259,182 @@ class TestClickHousePriceFetcher(TestCase):
 
         self.assertIsNone(snapshot)
 
+    def test_fetch_market_snapshot_uses_alpaca_latest_quote_when_signal_quote_missing(
+        self,
+    ) -> None:
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 1, 1, 12, 0, 30, tzinfo=timezone.utc),
+            symbol="AMZN",
+            payload={},
+        )
+        quote_ts = datetime.now(timezone.utc)
+        fetcher = RoutingClickHousePriceFetcher(
+            price_rows=[],
+            quote_rows=[],
+            alpaca_quote={
+                "t": quote_ts.isoformat(),
+                "bp": "185.10",
+                "ap": "185.14",
+            },
+        )
+
+        snapshot = fetcher.fetch_market_snapshot(signal)
+
+        self.assertIsNotNone(snapshot)
+        assert snapshot is not None
+        self.assertEqual(snapshot.price, Decimal("185.12"))
+        self.assertEqual(snapshot.bid, Decimal("185.10"))
+        self.assertEqual(snapshot.ask, Decimal("185.14"))
+        self.assertEqual(snapshot.spread, Decimal("0.04"))
+        self.assertEqual(snapshot.as_of, quote_ts)
+        self.assertEqual(snapshot.source, "alpaca_latest_quote")
+
+    def test_fetch_market_snapshot_rejects_wide_alpaca_latest_quote(
+        self,
+    ) -> None:
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 1, 1, 12, 0, 30, tzinfo=timezone.utc),
+            symbol="AMZN",
+            payload={},
+        )
+        fetcher = RoutingClickHousePriceFetcher(
+            price_rows=[],
+            quote_rows=[],
+            alpaca_quote={
+                "t": datetime.now(timezone.utc).isoformat(),
+                "bp": "100.00",
+                "ap": "101.00",
+            },
+        )
+
+        snapshot = fetcher.fetch_market_snapshot(signal)
+
+        self.assertIsNone(snapshot)
+
+    def test_fetch_market_snapshot_disables_alpaca_latest_quote_without_credentials(
+        self,
+    ) -> None:
+        fetcher = ClickHousePriceFetcher(
+            url="http://example",
+            table="torghut.ta_microbars",
+            alpaca_quote_fallback_enabled=True,
+        )
+        fetcher.alpaca_api_key_id = None
+        fetcher.alpaca_api_secret_key = None
+
+        quote = fetcher._fetch_alpaca_latest_quote_row(symbol="AMZN")
+
+        self.assertIsNone(quote)
+
+    def test_fetch_market_snapshot_ignores_empty_alpaca_latest_quote(
+        self,
+    ) -> None:
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 1, 1, 12, 0, 30, tzinfo=timezone.utc),
+            symbol="AMZN",
+            payload={},
+        )
+        fetcher = RoutingClickHousePriceFetcher(
+            price_rows=[],
+            quote_rows=[],
+            alpaca_quote=None,
+            alpaca_quote_fallback_enabled=True,
+        )
+
+        snapshot = fetcher.fetch_market_snapshot(signal)
+
+        self.assertIsNone(snapshot)
+
+    def test_fetch_market_snapshot_rejects_invalid_alpaca_latest_quote(
+        self,
+    ) -> None:
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 1, 1, 12, 0, 30, tzinfo=timezone.utc),
+            symbol="AMZN",
+            payload={},
+        )
+        fetcher = RoutingClickHousePriceFetcher(
+            price_rows=[],
+            quote_rows=[],
+            alpaca_quote={
+                "t": datetime.now(timezone.utc).isoformat(),
+                "bp": "185.14",
+                "ap": "185.10",
+            },
+        )
+
+        snapshot = fetcher.fetch_market_snapshot(signal)
+
+        self.assertIsNone(snapshot)
+
+    def test_fetch_market_snapshot_rejects_alpaca_latest_quote_without_timestamp(
+        self,
+    ) -> None:
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 1, 1, 12, 0, 30, tzinfo=timezone.utc),
+            symbol="AMZN",
+            payload={},
+        )
+        fetcher = RoutingClickHousePriceFetcher(
+            price_rows=[],
+            quote_rows=[],
+            alpaca_quote={
+                "bp": "185.10",
+                "ap": "185.14",
+            },
+        )
+
+        snapshot = fetcher.fetch_market_snapshot(signal)
+
+        self.assertIsNone(snapshot)
+
+    def test_fetch_market_snapshot_accepts_naive_alpaca_latest_quote_timestamp(
+        self,
+    ) -> None:
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 1, 1, 12, 0, 30, tzinfo=timezone.utc),
+            symbol="AMZN",
+            payload={},
+        )
+        quote_ts = datetime.now(timezone.utc).replace(tzinfo=None)
+        fetcher = RoutingClickHousePriceFetcher(
+            price_rows=[],
+            quote_rows=[],
+            alpaca_quote={
+                "timestamp": quote_ts.isoformat(),
+                "bid_price": "185.10",
+                "ask_price": "185.14",
+            },
+        )
+
+        snapshot = fetcher.fetch_market_snapshot(signal)
+
+        self.assertIsNotNone(snapshot)
+        assert snapshot is not None
+        self.assertEqual(snapshot.as_of, quote_ts.replace(tzinfo=timezone.utc))
+
+    def test_fetch_market_snapshot_rejects_stale_alpaca_latest_quote(
+        self,
+    ) -> None:
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 1, 1, 12, 0, 30, tzinfo=timezone.utc),
+            symbol="AMZN",
+            payload={},
+        )
+        fetcher = RoutingClickHousePriceFetcher(
+            price_rows=[],
+            quote_rows=[],
+            alpaca_quote={
+                "t": "2020-01-01T00:00:00Z",
+                "bp": "185.10",
+                "ap": "185.14",
+            },
+        )
+
+        snapshot = fetcher.fetch_market_snapshot(signal)
+
+        self.assertIsNone(snapshot)
+
     def test_fetch_market_snapshot_keeps_price_when_quote_lookup_empty(
         self,
     ) -> None:
@@ -316,6 +508,143 @@ class TestClickHousePriceFetcher(TestCase):
 
     def test_quote_midpoint_requires_complete_quote(self) -> None:
         self.assertIsNone(_midpoint(bid=None, ask=Decimal("100.20")))
+
+    def test_quote_spread_bps_rejects_zero_midpoint(self) -> None:
+        self.assertIsNone(_quote_spread_bps(bid=Decimal("0"), ask=Decimal("0")))
+
+    def test_fetch_alpaca_latest_quote_sends_data_api_request(self) -> None:
+        fetcher = ClickHousePriceFetcher(
+            url="http://clickhouse.example",
+            table="torghut.ta_microbars",
+            alpaca_quote_fallback_enabled=True,
+            alpaca_data_api_base_url="https://data.example:8443",
+            alpaca_api_key_id="key",
+            alpaca_api_secret_key="secret",
+            alpaca_quote_feed="iex",
+            alpaca_quote_timeout_seconds=1.5,
+        )
+        CapturingHTTPConnection.response = FakeHTTPResponse(
+            200,
+            '{"quote": {"t": "2026-01-01T00:00:00Z", "bp": "100.10", "ap": "100.20"}}',
+        )
+
+        with patch("app.trading.prices.HTTPSConnection", CapturingHTTPConnection):
+            quote = fetcher._fetch_alpaca_latest_quote(symbol="AAPL")
+
+        self.assertEqual(
+            quote,
+            {"t": "2026-01-01T00:00:00Z", "bp": "100.10", "ap": "100.20"},
+        )
+        self.assertEqual(len(CapturingHTTPConnection.instances), 1)
+        connection = CapturingHTTPConnection.instances[0]
+        self.assertEqual(connection.host, "data.example")
+        self.assertEqual(connection.port, 8443)
+        self.assertEqual(connection.timeout, 1.5)
+        self.assertTrue(connection.closed)
+        self.assertEqual(len(connection.requests), 1)
+        method, path, headers = connection.requests[0]
+        self.assertEqual(method, "GET")
+        self.assertEqual(path, "/v2/stocks/AAPL/quotes/latest?feed=iex")
+        self.assertEqual(headers["APCA-API-KEY-ID"], "key")
+        self.assertEqual(headers["APCA-API-SECRET-KEY"], "secret")
+
+    def test_fetch_alpaca_latest_quote_rejects_bad_url(self) -> None:
+        fetcher = ClickHousePriceFetcher(
+            url="http://clickhouse.example",
+            table="torghut.ta_microbars",
+            alpaca_quote_fallback_enabled=True,
+            alpaca_data_api_base_url="ftp://data.example",
+            alpaca_api_key_id="key",
+            alpaca_api_secret_key="secret",
+        )
+
+        self.assertIsNone(fetcher._fetch_alpaca_latest_quote(symbol="AAPL"))
+
+    def test_fetch_alpaca_latest_quote_rejects_missing_host(self) -> None:
+        fetcher = ClickHousePriceFetcher(
+            url="http://clickhouse.example",
+            table="torghut.ta_microbars",
+            alpaca_quote_fallback_enabled=True,
+            alpaca_data_api_base_url="https://",
+            alpaca_api_key_id="key",
+            alpaca_api_secret_key="secret",
+        )
+
+        self.assertIsNone(fetcher._fetch_alpaca_latest_quote(symbol="AAPL"))
+
+    def test_fetch_alpaca_latest_quote_returns_none_on_request_failure(
+        self,
+    ) -> None:
+        class FailingHTTPConnection(CapturingHTTPConnection):
+            def request(
+                self, method: str, path: str, *, headers: dict[str, str]
+            ) -> None:
+                super().request(method, path, headers=headers)
+                raise TimeoutError("timeout")
+
+        fetcher = ClickHousePriceFetcher(
+            url="http://clickhouse.example",
+            table="torghut.ta_microbars",
+            alpaca_quote_fallback_enabled=True,
+            alpaca_data_api_base_url="https://data.example",
+            alpaca_api_key_id="key",
+            alpaca_api_secret_key="secret",
+        )
+
+        with patch("app.trading.prices.HTTPSConnection", FailingHTTPConnection):
+            quote = fetcher._fetch_alpaca_latest_quote(symbol="AAPL")
+
+        self.assertIsNone(quote)
+        self.assertTrue(FailingHTTPConnection.instances[0].closed)
+
+    def test_fetch_alpaca_latest_quote_returns_none_on_http_failure(self) -> None:
+        fetcher = ClickHousePriceFetcher(
+            url="http://clickhouse.example",
+            table="torghut.ta_microbars",
+            alpaca_quote_fallback_enabled=True,
+            alpaca_data_api_base_url="https://data.example",
+            alpaca_api_key_id="key",
+            alpaca_api_secret_key="secret",
+        )
+        CapturingHTTPConnection.response = FakeHTTPResponse(403, "forbidden")
+
+        with patch("app.trading.prices.HTTPSConnection", CapturingHTTPConnection):
+            quote = fetcher._fetch_alpaca_latest_quote(symbol="AAPL")
+
+        self.assertIsNone(quote)
+        self.assertTrue(CapturingHTTPConnection.instances[0].closed)
+
+    def test_fetch_alpaca_latest_quote_returns_none_on_invalid_json(self) -> None:
+        fetcher = ClickHousePriceFetcher(
+            url="http://clickhouse.example",
+            table="torghut.ta_microbars",
+            alpaca_quote_fallback_enabled=True,
+            alpaca_data_api_base_url="https://data.example",
+            alpaca_api_key_id="key",
+            alpaca_api_secret_key="secret",
+        )
+        CapturingHTTPConnection.response = FakeHTTPResponse(200, "not-json")
+
+        with patch("app.trading.prices.HTTPSConnection", CapturingHTTPConnection):
+            quote = fetcher._fetch_alpaca_latest_quote(symbol="AAPL")
+
+        self.assertIsNone(quote)
+
+    def test_fetch_alpaca_latest_quote_returns_none_without_quote_object(self) -> None:
+        fetcher = ClickHousePriceFetcher(
+            url="http://clickhouse.example",
+            table="torghut.ta_microbars",
+            alpaca_quote_fallback_enabled=True,
+            alpaca_data_api_base_url="https://data.example",
+            alpaca_api_key_id="key",
+            alpaca_api_secret_key="secret",
+        )
+        CapturingHTTPConnection.response = FakeHTTPResponse(200, '{"quote": null}')
+
+        with patch("app.trading.prices.HTTPSConnection", CapturingHTTPConnection):
+            quote = fetcher._fetch_alpaca_latest_quote(symbol="AAPL")
+
+        self.assertIsNone(quote)
 
     def test_fetch_price_query_uses_schema_columns(self) -> None:
         signal = SignalEnvelope(


### PR DESCRIPTION
## Summary

- Added a configurable Alpaca latest-quote fallback for Torghut executable price snapshots when ClickHouse signal rows lack bid/ask.
- Enforced quote freshness, credentials, timestamp, and spread checks before using fallback quotes.
- Enabled the fallback only for the paper `torghut-sim` Knative service and kept live Torghut explicitly disabled.
- Registered the fallback gate in the feature-flag manifest and added unit/config/manifest-contract coverage for fallback behavior and live-vs-paper safety wiring.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest -q tests/test_prices.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen pytest -q tests/test_config.py::TestConfig::test_feature_flag_map_covers_all_boolean_runtime_gates tests/test_prices.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen pytest -q tests/test_config.py::TestConfig::test_torghut_feature_flag_manifest_matches_config_mapping tests/test_config.py::TestConfig::test_feature_flag_map_covers_all_boolean_runtime_gates tests/test_prices.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen pytest -q --cov --cov-branch --cov-fail-under=0 --cov-report=xml tests/test_prices.py tests/test_config.py::TestConfig::test_torghut_feature_flag_manifest_matches_config_mapping tests/test_config.py::TestConfig::test_feature_flag_map_covers_all_boolean_runtime_gates tests/test_live_config_manifest_contract.py`
- `uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90`
- `uv run --frozen ruff check app/trading/prices.py tests/test_prices.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen ruff format --check app/trading/prices.py tests/test_prices.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
