### PR TITLE
chore(torghut): promote image 9efeb550

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:2aac50cfbef35b1ce58acd781b0ca3f5d03f72d81f7741341b9846697cc6f725
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:cf7934bd65b7e1d58733b8174be6521a7f143e4ac277beabbe741f44703f9824
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.569.1-453-g146f6fa36
+              value: v0.569.1-458-g9efeb5508
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 146f6fa3637cf59a375075dc68bdd6847827b164
+              value: 9efeb55084417b79a62b3fd45bb4515a009e2dbb
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:2aac50cfbef35b1ce58acd781b0ca3f5d03f72d81f7741341b9846697cc6f725
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:cf7934bd65b7e1d58733b8174be6521a7f143e4ac277beabbe741f44703f9824
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.569.1-453-g146f6fa36
+              value: v0.569.1-458-g9efeb5508
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 146f6fa3637cf59a375075dc68bdd6847827b164
+              value: 9efeb55084417b79a62b3fd45bb4515a009e2dbb
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:2aac50cfbef35b1ce58acd781b0ca3f5d03f72d81f7741341b9846697cc6f725
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:cf7934bd65b7e1d58733b8174be6521a7f143e4ac277beabbe741f44703f9824
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:2aac50cfbef35b1ce58acd781b0ca3f5d03f72d81f7741341b9846697cc6f725
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:cf7934bd65b7e1d58733b8174be6521a7f143e4ac277beabbe741f44703f9824
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:2aac50cfbef35b1ce58acd781b0ca3f5d03f72d81f7741341b9846697cc6f725
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:cf7934bd65b7e1d58733b8174be6521a7f143e4ac277beabbe741f44703f9824
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:2aac50cfbef35b1ce58acd781b0ca3f5d03f72d81f7741341b9846697cc6f725
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:cf7934bd65b7e1d58733b8174be6521a7f143e4ac277beabbe741f44703f9824
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:2aac50cfbef35b1ce58acd781b0ca3f5d03f72d81f7741341b9846697cc6f725
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:cf7934bd65b7e1d58733b8174be6521a7f143e4ac277beabbe741f44703f9824
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -15,7 +15,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:2aac50cfbef35b1ce58acd781b0ca3f5d03f72d81f7741341b9846697cc6f725
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:cf7934bd65b7e1d58733b8174be6521a7f143e4ac277beabbe741f44703f9824
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -23,7 +23,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:2aac50cfbef35b1ce58acd781b0ca3f5d03f72d81f7741341b9846697cc6f725
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:cf7934bd65b7e1d58733b8174be6521a7f143e4ac277beabbe741f44703f9824
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+++ b/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
@@ -23,7 +23,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: refresh-execution-tca
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:2aac50cfbef35b1ce58acd781b0ca3f5d03f72d81f7741341b9846697cc6f725
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:cf7934bd65b7e1d58733b8174be6521a7f143e4ac277beabbe741f44703f9824
               imagePullPolicy: IfNotPresent
               env:
                 - name: DB_DSN

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:2aac50cfbef35b1ce58acd781b0ca3f5d03f72d81f7741341b9846697cc6f725
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:cf7934bd65b7e1d58733b8174be6521a7f143e4ac277beabbe741f44703f9824
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-14T19:03:18Z"
+        client.knative.dev/updateTimestamp: "2026-05-14T19:37:16Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -27,7 +27,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:2aac50cfbef35b1ce58acd781b0ca3f5d03f72d81f7741341b9846697cc6f725
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:cf7934bd65b7e1d58733b8174be6521a7f143e4ac277beabbe741f44703f9824
           ports:
             - name: http1
               containerPort: 8181
@@ -484,11 +484,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.569.1-453-g146f6fa36
+              value: v0.569.1-458-g9efeb5508
             - name: TORGHUT_COMMIT
-              value: 146f6fa3637cf59a375075dc68bdd6847827b164
+              value: 9efeb55084417b79a62b3fd45bb4515a009e2dbb
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:2aac50cfbef35b1ce58acd781b0ca3f5d03f72d81f7741341b9846697cc6f725
+              value: sha256:cf7934bd65b7e1d58733b8174be6521a7f143e4ac277beabbe741f44703f9824
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-14T19:03:18Z"
+        client.knative.dev/updateTimestamp: "2026-05-14T19:37:16Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:2aac50cfbef35b1ce58acd781b0ca3f5d03f72d81f7741341b9846697cc6f725
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:cf7934bd65b7e1d58733b8174be6521a7f143e4ac277beabbe741f44703f9824
           ports:
             - name: http1
               containerPort: 8181
@@ -310,11 +310,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.569.1-453-g146f6fa36
+              value: v0.569.1-458-g9efeb5508
             - name: TORGHUT_COMMIT
-              value: 146f6fa3637cf59a375075dc68bdd6847827b164
+              value: 9efeb55084417b79a62b3fd45bb4515a009e2dbb
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:2aac50cfbef35b1ce58acd781b0ca3f5d03f72d81f7741341b9846697cc6f725
+              value: sha256:cf7934bd65b7e1d58733b8174be6521a7f143e4ac277beabbe741f44703f9824
           livenessProbe:
             httpGet:
               path: /healthz

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -98,7 +98,7 @@ spec:
           - name: allowStaleTape
           - name: persistResults
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:2aac50cfbef35b1ce58acd781b0ca3f5d03f72d81f7741341b9846697cc6f725
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:cf7934bd65b7e1d58733b8174be6521a7f143e4ac277beabbe741f44703f9824
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
+++ b/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:2aac50cfbef35b1ce58acd781b0ca3f5d03f72d81f7741341b9846697cc6f725
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:cf7934bd65b7e1d58733b8174be6521a7f143e4ac277beabbe741f44703f9824
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `9efeb55084417b79a62b3fd45bb4515a009e2dbb`
- Image tag: `9efeb550`
- Image digest: `sha256:cf7934bd65b7e1d58733b8174be6521a7f143e4ac277beabbe741f44703f9824`