### PR TITLE
fix(torghut): bound jangar carry status timeout

### DIFF
--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -93,6 +93,8 @@ spec:
               value: http://jangar.jangar.svc.cluster.local/api/torghut/market-context
             - name: TRADING_JANGAR_CONTROL_PLANE_STATUS_URL
               value: "http://agents.agents.svc.cluster.local/api/agents/control-plane/status?namespace=agents"
+            - name: TRADING_JANGAR_CONTROL_PLANE_TIMEOUT_SECONDS
+              value: "30"
             - name: TRADING_MARKET_CONTEXT_TIMEOUT_SECONDS
               value: "5"
             - name: TRADING_MARKET_CONTEXT_REQUIRED

--- a/services/torghut/README.md
+++ b/services/torghut/README.md
@@ -167,9 +167,11 @@ Testing rules for the trading core:
   - `torghut_trading_alpha_readiness_rollback_required_total`
 - The live trading-loop manifest sets `TRADING_JANGAR_CONTROL_PLANE_STATUS_URL` to the cluster-local Jangar
   control-plane status route so revenue-repair can import controller-ingestion carry, verify-foreclosure boards, and
-  repair-slot escrow for zero-notional no-delta decisions. Paper/sim still leaves that URL unset. The executable
-  universe remains declared inside Torghut, and live submission remains gated by Torghut-owned signal, empirical-job,
-  proof-floor, routeability, and execution evidence rather than by Jangar serving health alone.
+  repair-slot escrow for zero-notional no-delta decisions. Live also pins
+  `TRADING_JANGAR_CONTROL_PLANE_TIMEOUT_SECONDS=30` because the status route can take longer than the config default
+  under controller/database load. Paper/sim still leaves that URL unset. The executable universe remains declared
+  inside Torghut, and live submission remains gated by Torghut-owned signal, empirical-job, proof-floor, routeability,
+  and execution evidence rather than by Jangar serving health alone.
 - Optional cross-service dependency quorum checks remain available for off-path experiments by setting
   `TRADING_JANGAR_CONTROL_PLANE_STATUS_URL` on non-production surfaces that need the same bounded carry import.
 - Optional external quant-health checks remain available by setting `TRADING_JANGAR_QUANT_HEALTH_URL`. Torghut rejects

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -288,7 +288,8 @@ class TestLiveConfigManifestContract(TestCase):
             settings.trading_jangar_control_plane_status_url,
         )
         self.assertNotIn("TRADING_JANGAR_CONTROL_PLANE_CACHE_TTL_SECONDS", env)
-        self.assertNotIn("TRADING_JANGAR_CONTROL_PLANE_TIMEOUT_SECONDS", env)
+        self.assertEqual(env.get("TRADING_JANGAR_CONTROL_PLANE_TIMEOUT_SECONDS"), "30")
+        self.assertEqual(settings.trading_jangar_control_plane_timeout_seconds, 30)
         self.assertNotIn("TRADING_JANGAR_QUANT_HEALTH_REQUIRED", env)
         self.assertNotIn("TRADING_JANGAR_QUANT_HEALTH_URL", env)
         self.assertEqual(
@@ -305,7 +306,6 @@ class TestLiveConfigManifestContract(TestCase):
         blocked_env = {
             "JANGAR_SYMBOLS_URL",
             "TRADING_JANGAR_CONTROL_PLANE_CACHE_TTL_SECONDS",
-            "TRADING_JANGAR_CONTROL_PLANE_TIMEOUT_SECONDS",
             "TRADING_JANGAR_QUANT_HEALTH_REQUIRED",
             "TRADING_JANGAR_QUANT_HEALTH_URL",
         }
@@ -314,6 +314,7 @@ class TestLiveConfigManifestContract(TestCase):
             env.get("TRADING_JANGAR_CONTROL_PLANE_STATUS_URL"),
             "http://agents.agents.svc.cluster.local/api/agents/control-plane/status?namespace=agents",
         )
+        self.assertEqual(env.get("TRADING_JANGAR_CONTROL_PLANE_TIMEOUT_SECONDS"), "30")
         self.assertEqual(
             env.get("TRADING_MARKET_CONTEXT_URL"),
             "http://jangar.jangar.svc.cluster.local/api/torghut/market-context",


### PR DESCRIPTION
## Summary
- set live Torghut `TRADING_JANGAR_CONTROL_PLANE_TIMEOUT_SECONDS=30` so controller-ingestion carry can fetch the Jangar status route under observed controller/database load
- keep sim/paper isolated from Jangar control-plane URL wiring
- update the manifest contract test and Torghut README to document the bounded live timeout

## Testing
- `uv run --frozen pytest tests/test_live_config_manifest_contract.py -q`
- `uv run --frozen ruff check tests/test_live_config_manifest_contract.py`
- `uv run --frozen ruff format --check tests/test_live_config_manifest_contract.py`
- `bunx oxfmt --check services/torghut/README.md`
- `bun run lint:argocd`
- `git diff --check`

## Risk
- Low. This changes only the live Torghut Jangar status fetch timeout and its contract/docs. It does not enable live submissions or change capital gates.

## Rollback
- Revert this PR to return the live Jangar status fetch timeout to the default 2 seconds.
