### PR TITLE
fix(jangar): publish ready carry settlement

### DIFF
--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -92,7 +92,7 @@ spec:
             - name: TRADING_MARKET_CONTEXT_URL
               value: http://jangar.jangar.svc.cluster.local/api/torghut/market-context
             - name: TRADING_JANGAR_CONTROL_PLANE_STATUS_URL
-              value: "http://agents.agents.svc.cluster.local/api/agents/control-plane/status?namespace=agents"
+              value: "http://agents.agents.svc.cluster.local/ready"
             - name: TRADING_JANGAR_CONTROL_PLANE_TIMEOUT_SECONDS
               value: "30"
             - name: TRADING_MARKET_CONTEXT_TIMEOUT_SECONDS

--- a/docs/torghut/rollouts/2026-05-14-jangar-controller-carry-url-and-repair-slot-import.md
+++ b/docs/torghut/rollouts/2026-05-14-jangar-controller-carry-url-and-repair-slot-import.md
@@ -35,6 +35,10 @@ reported `carry_state=unavailable` with `jangar_control_plane_status_url_missing
 - `repair_slot_escrow.status=block`
 - controller carry still zero-notional; no live or paper widening was authorized
 
+Follow-up evidence showed the full Jangar status route could exceed Torghut's 2 second import timeout on a cold
+request, which turned current Jangar carry into `jangar_status_fetch_failed`. The low-latency Jangar `/ready` route
+already carried verify-foreclosure and repair-slot evidence, but not `controller_ingestion_settlement`.
+
 After local changes, pre-deploy live Torghut business evidence is intentionally unchanged until GitOps rolls the new
 manifest and image:
 
@@ -49,9 +53,14 @@ manifest and image:
 ## Change
 
 - The live Torghut Knative service now sets `TRADING_JANGAR_CONTROL_PLANE_STATUS_URL` to the cluster-local Jangar
-  control-plane status route.
+  `/ready` route instead of the slower full control-plane status route.
+- Jangar `/ready` now emits `controller_ingestion_settlement` alongside `verify_trust_foreclosure_board` and
+  `repair_slot_escrow`, using hot-path proof fields that explicitly say full source-serving and database proof remain
+  available from `/api/agents/control-plane/status`.
 - `JangarDependencyQuorumStatus` now preserves `repair_slot_escrow`, `stage_debt_repair_admission`, and
   `foreclosure_carry_rollout_witness`.
+- `JangarDependencyQuorumStatus` also preserves top-level `controller_ingestion_settlement` from legacy or `/ready`
+  payloads that do not include a nested `dependency_quorum`.
 - Revenue repair, health, and consumer evidence pass those carry fields into
   `torghut.jangar-controller-ingestion-carry.v1`.
 - Held or blocked Jangar controller-ingestion settlements with current board or repair-slot evidence classify as
@@ -72,7 +81,7 @@ manifest and image:
 
 ## Risk And Rollback
 
-Risk is limited to Torghut observing Jangar control-plane status for revenue-repair carry. This does not enable live
+Risk is limited to Torghut observing Jangar `/ready` for revenue-repair carry. This does not enable live
 submission, paper widening, or nonzero notional. The rollback is to remove `TRADING_JANGAR_CONTROL_PLANE_STATUS_URL`
 from `argocd/applications/torghut/knative-service.yaml` and stop emitting the additional repair-slot carry fields;
 Torghut will return to the existing unavailable-carry denial while keeping `max_notional=0`.

--- a/services/jangar/src/routes/ready.test.ts
+++ b/services/jangar/src/routes/ready.test.ts
@@ -576,6 +576,24 @@ describe('getReadyHandler', () => {
       validation_command: 'uv run --frozen pytest services/torghut/tests/test_alpha_readiness_settlement_conveyor.py',
       rollback_target: 'stop emitting alpha_readiness_settlement_conveyor and keep Torghut max_notional=0',
     })
+    expect(body.controller_ingestion_settlement).toMatchObject({
+      schema_version: 'jangar.controller-ingestion-settlement.v1',
+      mode: 'observe',
+      namespace: 'agents',
+      serving_readiness: 'ok',
+      controller_witness_ref: 'controller-witness:agents:ready-hot-path',
+      database_status: 'disabled',
+      source_serving_status: 'hold',
+      verify_trust_foreclosure_board_ref: expect.any(String),
+      selected_repair_ticket: {
+        max_notional: '0',
+      },
+      reason_codes: expect.arrayContaining([
+        'database_disabled',
+        'source_serving_hold',
+        'source_serving_contract_unavailable_on_ready_hot_path',
+      ]),
+    })
     expect(body.verify_trust_foreclosure_board).toMatchObject({
       schema_version: 'jangar.verify-trust-foreclosure-board.v1',
       mode: 'observe',

--- a/services/jangar/src/routes/ready.tsx
+++ b/services/jangar/src/routes/ready.tsx
@@ -1,11 +1,13 @@
 import { createFileRoute } from '@tanstack/react-router'
 
 import type {
+  ControlPlaneControllerWitnessQuorum,
   ExecutionTrustStatus,
   SourceServingContractVerdictExchange,
   TorghutRevenueRepairQueueItem,
 } from '~/data/agents-control-plane'
 import { assessAgentRunIngestion, getAgentsControllerHealth } from '~/server/agents-controller'
+import { buildControllerIngestionSettlement } from '~/server/control-plane-controller-ingestion-settlement'
 import { buildRuntimeAdmissionSnapshot, findAdmissionPassport } from '~/server/control-plane-runtime-admission'
 import {
   buildEvidencePressureLedger,
@@ -31,8 +33,13 @@ import {
   resolveRepairSlotEscrowMode,
 } from '~/server/control-plane-repair-slot-escrow'
 import { buildRevenueRepairSettlementCustody } from '~/server/control-plane-revenue-repair-settlement-custody'
+import { buildAgentRunIngestionStatus } from '~/server/control-plane-serving-process-status'
 import { buildVerifyTrustForeclosureBoard } from '~/server/control-plane-verify-trust-foreclosure'
-import type { ControlPlaneRolloutHealth } from '~/server/control-plane-status-types'
+import type {
+  AgentRunIngestionStatus,
+  ControlPlaneRolloutHealth,
+  DatabaseStatus,
+} from '~/server/control-plane-status-types'
 import { getWatchReliabilitySummary } from '~/server/control-plane-watch-reliability'
 
 const isControllerHealthReady = (health: ReturnType<typeof getAgentsControllerHealth>) =>
@@ -217,6 +224,147 @@ const buildReadyPathSourceServingExchange = (now: Date, namespace: string): Sour
   rollback_target: 'use /api/agents/control-plane/status for full source-serving rollout proof',
 })
 
+const buildReadyPathDatabaseStatus = (): DatabaseStatus => ({
+  configured: false,
+  connected: false,
+  status: 'disabled',
+  message: 'database proof unavailable on /ready hot path; use control-plane status for full proof',
+  latency_ms: 0,
+  migration_consistency: {
+    status: 'unknown',
+    migration_table: null,
+    registered_count: 0,
+    applied_count: 0,
+    unapplied_count: 0,
+    unexpected_count: 0,
+    latest_registered: null,
+    latest_applied: null,
+    missing_migrations: [],
+    unexpected_migrations: [],
+    message: 'database migration proof unavailable on /ready hot path',
+  },
+})
+
+const readyPathWitnessId = (namespace: string, surface: string) => `witness:${surface}:${namespace}:ready-hot-path`
+
+const buildReadyPathControllerWitness = (input: {
+  now: Date
+  namespace: string
+  agentsController: ReturnType<typeof getAgentsControllerHealth>
+  agentRunIngestion: AgentRunIngestionStatus
+  watchReliability: ReturnType<typeof getWatchReliabilitySummary>
+}): ControlPlaneControllerWitnessQuorum => {
+  const expiresAt = readyPathFreshUntil(input.now)
+  const deploymentAvailable = input.agentsController.enabled && input.agentsController.started
+  const watchEpochCurrent = input.watchReliability.status === 'healthy'
+  const controllerSelfReportCurrent = deploymentAvailable && input.agentRunIngestion.status === 'healthy'
+  const decision =
+    input.agentRunIngestion.status === 'degraded'
+      ? 'hold_material'
+      : controllerSelfReportCurrent
+        ? 'allow'
+        : deploymentAvailable && watchEpochCurrent
+          ? 'repair_only'
+          : 'hold_material'
+  const reasonCodes = uniqueStrings([
+    ...(deploymentAvailable ? [] : ['controller_deployment_unavailable_on_ready_hot_path']),
+    ...(watchEpochCurrent ? [] : ['watch_epoch_not_current_on_ready_hot_path']),
+    ...(controllerSelfReportCurrent ? [] : ['controller_self_report_unavailable_on_ready_hot_path']),
+    ...(input.agentRunIngestion.status === 'healthy' ? [] : [`agentrun_ingestion_${input.agentRunIngestion.status}`]),
+  ])
+  const witnessRefs = [
+    readyPathWitnessId(input.namespace, 'serving_process'),
+    readyPathWitnessId(input.namespace, 'watch_epoch'),
+    readyPathWitnessId(input.namespace, 'agentrun_ingestion'),
+  ]
+
+  return {
+    mode: 'shadow',
+    design_artifact:
+      'docs/agents/designs/116-jangar-controller-witness-quorum-and-capital-activation-receipts-2026-05-06.md',
+    quorum_id: `controller-witness:${input.namespace}:ready-hot-path`,
+    generated_at: input.now.toISOString(),
+    expires_at: expiresAt,
+    namespace: input.namespace,
+    decision,
+    reason_codes: reasonCodes,
+    message: controllerSelfReportCurrent
+      ? 'ready hot path sees controller ingestion as current'
+      : 'ready hot path cannot prove full controller ingestion; use control-plane status for full proof',
+    witness_refs: witnessRefs,
+    deployment_available: deploymentAvailable,
+    watch_epoch_current: watchEpochCurrent,
+    controller_self_report_current: controllerSelfReportCurrent,
+    witnesses: [
+      {
+        witness_id: witnessRefs[0],
+        generated_at: input.now.toISOString(),
+        expires_at: expiresAt,
+        namespace: input.namespace,
+        controller_surface: 'serving_process',
+        deployment_ref: null,
+        pod_uid: null,
+        image_ref: null,
+        leader_identity: null,
+        controller_started: input.agentsController.started,
+        deployment_available: deploymentAvailable,
+        watch_epoch_id: null,
+        ingestion_epoch_id: null,
+        last_watch_event_at: null,
+        last_resync_at: null,
+        observed_run_count: null,
+        untouched_run_count: null,
+        decision: deploymentAvailable ? 'allow' : 'repair_only',
+        reason_codes: deploymentAvailable ? [] : ['controller_deployment_unavailable_on_ready_hot_path'],
+      },
+      {
+        witness_id: witnessRefs[1],
+        generated_at: input.now.toISOString(),
+        expires_at: expiresAt,
+        namespace: input.namespace,
+        controller_surface: 'watch_epoch',
+        deployment_ref: null,
+        pod_uid: null,
+        image_ref: null,
+        leader_identity: null,
+        controller_started: null,
+        deployment_available: null,
+        watch_epoch_id: `watch:${input.namespace}:ready-hot-path`,
+        ingestion_epoch_id: null,
+        last_watch_event_at: input.watchReliability.streams[0]?.last_seen_at ?? null,
+        last_resync_at: null,
+        observed_run_count: input.watchReliability.total_events,
+        untouched_run_count: null,
+        decision: watchEpochCurrent ? 'allow' : 'hold_material',
+        reason_codes: watchEpochCurrent ? [] : ['watch_epoch_not_current_on_ready_hot_path'],
+      },
+      {
+        witness_id: witnessRefs[2],
+        generated_at: input.now.toISOString(),
+        expires_at: expiresAt,
+        namespace: input.namespace,
+        controller_surface: 'agentrun_ingestion',
+        deployment_ref: null,
+        pod_uid: null,
+        image_ref: null,
+        leader_identity: null,
+        controller_started: null,
+        deployment_available: null,
+        watch_epoch_id: null,
+        ingestion_epoch_id: `ingestion:${input.namespace}:ready-hot-path`,
+        last_watch_event_at: input.agentRunIngestion.last_watch_event_at,
+        last_resync_at: input.agentRunIngestion.last_resync_at,
+        observed_run_count: null,
+        untouched_run_count: input.agentRunIngestion.untouched_run_count,
+        decision: input.agentRunIngestion.status === 'healthy' ? 'allow' : 'hold_material',
+        reason_codes:
+          input.agentRunIngestion.status === 'healthy' ? [] : [`agentrun_ingestion_${input.agentRunIngestion.status}`],
+      },
+    ],
+    rollback_target: 'use /api/agents/control-plane/status for full controller witness proof',
+  }
+}
+
 const executionTrustStatus = async (namespaces: string[]) => {
   const now = new Date()
   const resolvedNamespaces = uniqueStrings(namespaces.length > 0 ? namespaces : ['agents'])
@@ -296,6 +444,7 @@ export const getReadyHandler = async () => {
         torghutConsumerEvidence: torghutConsumerEvidence.status,
       })
     : null
+  const watchReliability = getWatchReliabilitySummary()
   const servingPassport = findAdmissionPassport({
     admissionPassports: runtimeAdmission.admissionPassports,
     consumerClass: 'serving',
@@ -331,6 +480,15 @@ export const getReadyHandler = async () => {
   const status = ready && agentsControllerHealthy && servingPassportReady ? 'ok' : 'degraded'
   const readyPathRolloutHealth = buildReadyPathRolloutHealth(ready)
   const readyPathSourceServingExchange = buildReadyPathSourceServingExchange(now, namespaces[0] ?? 'agents')
+  const readyPathAgentRunIngestion = buildAgentRunIngestionStatus(namespaces[0] ?? 'agents', agentsController)
+  const readyPathControllerWitness = buildReadyPathControllerWitness({
+    now,
+    namespace: namespaces[0] ?? 'agents',
+    agentsController,
+    agentRunIngestion: readyPathAgentRunIngestion,
+    watchReliability,
+  })
+  const readyPathDatabase = buildReadyPathDatabaseStatus()
   const revenueRepairSettlementCustody = buildRevenueRepairSettlementCustody(
     {
       now,
@@ -379,6 +537,20 @@ export const getReadyHandler = async () => {
         mode: resolveRepairSlotEscrowMode(),
       })
     : null
+  const controllerIngestionSettlement = buildControllerIngestionSettlement({
+    now,
+    namespace: namespaces[0] ?? 'agents',
+    servingReadiness: ready ? status : 'down',
+    controllerWitness: readyPathControllerWitness,
+    agentRunIngestion: readyPathAgentRunIngestion,
+    executionTrust: trust,
+    database: readyPathDatabase,
+    rolloutHealth: readyPathRolloutHealth,
+    sourceServingContractVerdictExchange: readyPathSourceServingExchange,
+    verifyTrustForeclosureBoard,
+    repairSlotEscrow,
+    torghutConsumerEvidence: torghutConsumerEvidence.status,
+  })
 
   const body = JSON.stringify({
     status,
@@ -392,6 +564,7 @@ export const getReadyHandler = async () => {
     torghut_consumer_evidence: torghutConsumerEvidence.status,
     repair_bid_admission: repairBidAdmission,
     revenue_repair_settlement_custody: revenueRepairSettlementCustody,
+    controller_ingestion_settlement: controllerIngestionSettlement,
     verify_trust_foreclosure_board: verifyTrustForeclosureBoard,
     material_gate_digest: materialGateDigest,
     repair_slot_escrow: repairSlotEscrow,

--- a/services/torghut/README.md
+++ b/services/torghut/README.md
@@ -165,13 +165,13 @@ Testing rules for the trading core:
   - `torghut_trading_alpha_readiness_hypotheses_total`
   - `torghut_trading_alpha_readiness_promotion_eligible_total`
   - `torghut_trading_alpha_readiness_rollback_required_total`
-- The live trading-loop manifest sets `TRADING_JANGAR_CONTROL_PLANE_STATUS_URL` to the cluster-local Jangar
-  control-plane status route so revenue-repair can import controller-ingestion carry, verify-foreclosure boards, and
+- The live trading-loop manifest sets `TRADING_JANGAR_CONTROL_PLANE_STATUS_URL` to the cluster-local Jangar `/ready`
+  route so revenue-repair can import low-latency controller-ingestion carry, verify-foreclosure boards, and
   repair-slot escrow for zero-notional no-delta decisions. Live also pins
-  `TRADING_JANGAR_CONTROL_PLANE_TIMEOUT_SECONDS=30` because the status route can take longer than the config default
-  under controller/database load. Paper/sim still leaves that URL unset. The executable universe remains declared
-  inside Torghut, and live submission remains gated by Torghut-owned signal, empirical-job, proof-floor, routeability,
-  and execution evidence rather than by Jangar serving health alone.
+  `TRADING_JANGAR_CONTROL_PLANE_TIMEOUT_SECONDS=30` as a defensive upper bound, but routine carry import no longer
+  depends on the slower full status route. Paper/sim still leaves that URL unset. The executable universe remains
+  declared inside Torghut, and live submission remains gated by Torghut-owned signal, empirical-job, proof-floor,
+  routeability, and execution evidence rather than by Jangar serving health alone.
 - Optional cross-service dependency quorum checks remain available for off-path experiments by setting
   `TRADING_JANGAR_CONTROL_PLANE_STATUS_URL` on non-production surfaces that need the same bounded carry import.
 - Optional external quant-health checks remain available by setting `TRADING_JANGAR_QUANT_HEALTH_URL`. Torghut rejects

--- a/services/torghut/app/trading/hypotheses.py
+++ b/services/torghut/app/trading/hypotheses.py
@@ -707,6 +707,10 @@ def _fallback_quorum_from_legacy_status(
                 decision="block",
                 reasons=["workflows_data_unknown"],
                 message="Torghut workflow reliability is unavailable.",
+                controller_ingestion_settlement=_extract_controller_ingestion_settlement(
+                    payload,
+                    {},
+                ),
                 verify_trust_foreclosure_board=_extract_verify_trust_foreclosure_board(
                     payload,
                     {},
@@ -726,6 +730,10 @@ def _fallback_quorum_from_legacy_status(
                 decision="delay",
                 reasons=["workflows_degraded"],
                 message="Torghut workflow reliability is degraded.",
+                controller_ingestion_settlement=_extract_controller_ingestion_settlement(
+                    payload,
+                    {},
+                ),
                 verify_trust_foreclosure_board=_extract_verify_trust_foreclosure_board(
                     payload,
                     {},
@@ -753,6 +761,10 @@ def _fallback_quorum_from_legacy_status(
                     decision="delay",
                     reasons=["jangar_namespace_degraded"],
                     message="Torghut namespace health is degraded.",
+                    controller_ingestion_settlement=_extract_controller_ingestion_settlement(
+                        payload,
+                        {},
+                    ),
                     verify_trust_foreclosure_board=_extract_verify_trust_foreclosure_board(
                         payload,
                         {},
@@ -771,6 +783,10 @@ def _fallback_quorum_from_legacy_status(
         decision="unknown",
         reasons=["jangar_dependency_quorum_missing"],
         message="Torghut control-plane status did not include dependency_quorum.",
+        controller_ingestion_settlement=_extract_controller_ingestion_settlement(
+            payload,
+            {},
+        ),
         verify_trust_foreclosure_board=_extract_verify_trust_foreclosure_board(
             payload,
             {},

--- a/services/torghut/tests/test_hypotheses.py
+++ b/services/torghut/tests/test_hypotheses.py
@@ -1053,6 +1053,42 @@ class TestHypothesisReadiness(TestCase):
         self.assertEqual(status.decision, "block")
         self.assertEqual(status.reasons, ["workflows_data_unknown"])
 
+    def test_load_jangar_dependency_quorum_preserves_ready_controller_ingestion_settlement(
+        self,
+    ) -> None:
+        settings.trading_jangar_control_plane_status_url = (
+            "https://jangar.example/ready"
+        )
+        settings.trading_jangar_control_plane_cache_ttl_seconds = 0
+        settlement = {
+            "schema_version": "jangar.controller-ingestion-settlement.v1",
+            "settlement_id": "controller-ingestion-settlement:ready-test",
+            "decision": "hold",
+            "agentrun_ingestion_current": False,
+            "reason_codes": ["source_serving_hold"],
+        }
+        board = {
+            "schema_version": "jangar.verify-trust-foreclosure-board.v1",
+            "board_id": "verify-trust-foreclosure-board:ready-test",
+        }
+        with patch(
+            "app.trading.hypotheses.urlopen",
+            return_value=_FakeHttpResponse(
+                {
+                    "status": "ok",
+                    "controller_ingestion_settlement": settlement,
+                    "verify_trust_foreclosure_board": board,
+                }
+            ),
+        ):
+            status = load_jangar_dependency_quorum()
+
+        self.assertEqual(status.decision, "unknown")
+        self.assertEqual(status.reasons, ["jangar_dependency_quorum_missing"])
+        payload = status.as_payload()
+        self.assertEqual(payload["controller_ingestion_settlement"], settlement)
+        self.assertEqual(payload["verify_trust_foreclosure_board"], board)
+
     def test_load_jangar_dependency_quorum_handles_malformed_url(self) -> None:
         settings.trading_jangar_control_plane_status_url = "jangar.example/status"
         settings.trading_jangar_control_plane_cache_ttl_seconds = 0

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -262,7 +262,7 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertIsNone(settings.trading_jangar_symbols_url)
         self.assertEqual(
             settings.trading_jangar_control_plane_status_url,
-            "http://agents.agents.svc.cluster.local/api/agents/control-plane/status?namespace=agents",
+            "http://agents.agents.svc.cluster.local/ready",
         )
         self.assertIsNone(settings.trading_jangar_quant_health_url)
         self.assertEqual(
@@ -312,7 +312,7 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertTrue(blocked_env.isdisjoint(env))
         self.assertEqual(
             env.get("TRADING_JANGAR_CONTROL_PLANE_STATUS_URL"),
-            "http://agents.agents.svc.cluster.local/api/agents/control-plane/status?namespace=agents",
+            "http://agents.agents.svc.cluster.local/ready",
         )
         self.assertEqual(env.get("TRADING_JANGAR_CONTROL_PLANE_TIMEOUT_SECONDS"), "30")
         self.assertEqual(


### PR DESCRIPTION
## Summary

- Publish `controller_ingestion_settlement` from Jangar `/ready` with hot-path proof fields so Torghut can import typed controller carry without waiting on the full status route.
- Point the live Torghut manifest at `http://agents.agents.svc.cluster.local/ready` for `TRADING_JANGAR_CONTROL_PLANE_STATUS_URL`.
- Preserve top-level ready-path controller settlement payloads in Torghut fallback parsing when the response has no nested `dependency_quorum`.
- Update Torghut docs and the rollout note with design provenance, runtime evidence, risk, and rollback.

## Related Issues

None

## Testing

- `bunx oxfmt --check services/jangar/src/routes/ready.tsx services/jangar/src/routes/ready.test.ts`
- `bun run --cwd services/jangar test -- src/routes/ready.test.ts`
- `bun run --cwd services/jangar test -- src/routes/ready.test.ts src/server/__tests__/control-plane-controller-ingestion-settlement.test.ts`
- `bun run --filter @proompteng/jangar tsc`
- `bun run --filter @proompteng/jangar lint`
- `bun run --filter @proompteng/jangar lint:oxlint` passed with 0 errors; it still reports pre-existing warnings outside this change.
- `cd services/torghut && /tmp/codex-uv-bootstrap/bin/uv sync --frozen --extra dev`
- `cd services/torghut && /tmp/codex-uv-bootstrap/bin/uv run --frozen ruff format --check app/trading/hypotheses.py tests/test_hypotheses.py tests/test_live_config_manifest_contract.py`
- `cd services/torghut && /tmp/codex-uv-bootstrap/bin/uv run --frozen ruff check app/trading/hypotheses.py tests/test_hypotheses.py tests/test_live_config_manifest_contract.py`
- `cd services/torghut && /tmp/codex-uv-bootstrap/bin/uv run --frozen pytest tests/test_hypotheses.py tests/test_live_config_manifest_contract.py -k 'jangar_dependency_quorum or live_manifest'`
- `cd services/torghut && /tmp/codex-uv-bootstrap/bin/uv run --frozen pytest tests/test_jangar_controller_ingestion_carry.py tests/test_hypotheses.py tests/test_live_config_manifest_contract.py -k 'controller_ingestion or jangar_dependency_quorum or live_manifest'`
- `cd services/torghut && /tmp/codex-uv-bootstrap/bin/uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && /tmp/codex-uv-bootstrap/bin/uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && /tmp/codex-uv-bootstrap/bin/uv run --frozen pyright --project pyrightconfig.scripts.json`
- `kubectl kustomize argocd/applications/torghut`
- `bun run lint:argocd`
- `git diff --check`

CI evidence on head `3af959c519930e92a2fe7c9a7757daf614801e3f`:

- `jangar-ci / lint-and-typecheck / run`: pass.
- `torghut-ci`: pass for changed-file plan, Pyright, bytecode/lint/migration guard, bytecode/pytest/coverage, pytest shards 0-3, autoresearch runners 0-7, and quality signals.
- `agents-ci`: pass for validate and integration.
- `argo-lint`, `kubeconform`, semantic commit, semantic PR title, and changed-files checks: pass.
- Deploy-automerge enable checks and unrelated package matrix entries were skipped by workflow rules.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.

## Design And Requirement Provenance

Governing design:

- `docs/agents/designs/swarm-agentic-mission-architecture-2026-05-08.md`
- `docs/agents/designs/205-jangar-controller-ingestion-settlement-and-verification-carry-cutover-2026-05-14.md`
- `docs/torghut/design-system/v6/211-torghut-controller-ingestion-carry-and-alpha-no-delta-release-2026-05-14.md`

Runtime requirement:

- `/ready` and `/trading/revenue-repair` showed `business_state=repair_only`, `revenue_ready=false`, and top repair item `repair_alpha_readiness`.
- Torghut's Jangar carry was `unavailable` with `jangar_status_fetch_failed`, `jangar_controller_ingestion_settlement_missing`, and `jangar_verify_foreclosure_board_missing`.
- The full Jangar status route could exceed Torghut's 2 second import timeout on cold requests, while `/ready` was available and already carried the adjacent verify and repair-slot evidence.

## Business Evidence

Before this change:

- Jangar `/ready`: `status=ok`, `business_state=repair_only`, `revenue_ready=false`, top `repair_queue` item `repair_alpha_readiness`, reason `alpha_readiness_not_promotion_eligible`, affected gate `routeable_candidate_count`.
- Torghut `/trading/revenue-repair`: `business_state=repair_only`, `revenue_ready=false`, top `repair_queue` item `repair_alpha_readiness`, `jangar_controller_ingestion_carry.carry_state=unavailable`.

After source validation:

- Jangar `/ready` test proves `controller_ingestion_settlement` is emitted with schema `jangar.controller-ingestion-settlement.v1`, observe mode, `database_status=disabled`, `source_serving_status=hold`, and `max_notional=0`.
- Torghut fallback test proves `/ready` payloads preserve top-level `controller_ingestion_settlement` and `verify_trust_foreclosure_board`.
- Rendered Argo manifest proves Torghut now imports Jangar carry from `http://agents.agents.svc.cluster.local/ready`.
- Live revenue remains intentionally repair-only until GitOps rolls the new image and manifest; this does not enable live submission while `revenue_ready=false` or the repair queue is non-empty.

Affected value gates:

- `ready_status_truth`
- `pr_to_rollout_latency`
- `failed_agentrun_rate`
- `handoff_evidence_quality`

## Risk And Rollback

Risk is limited to Torghut observing typed Jangar controller carry from `/ready` instead of the slower full status route. The ready-path settlement remains observe-mode, keeps `max_notional=0`, and explicitly marks full database/source-serving proof as unavailable on the hot path.

Rollback is to revert `TRADING_JANGAR_CONTROL_PLANE_STATUS_URL` in `argocd/applications/torghut/knative-service.yaml` to the previous full status route or remove it, and revert the Jangar `/ready` settlement projection. Torghut then returns to the prior unavailable-carry denial path with `max_notional=0`.

## Release Note

Jangar `/ready` now includes controller-ingestion settlement carry for Torghut, and the live Torghut manifest consumes that faster readiness contract. This is a no-delta repair-only change: it improves carry truth and rollout latency, but it does not authorize live submission or nonzero notional while `repair_queue` remains populated.
