### PR TITLE
docs(jangar): define consumer evidence parity settlement

### DIFF
--- a/docs/agents/designs/206-jangar-consumer-evidence-parity-settlement-and-alpha-release-custody-2026-05-14.md
+++ b/docs/agents/designs/206-jangar-consumer-evidence-parity-settlement-and-alpha-release-custody-2026-05-14.md
@@ -1,0 +1,471 @@
+# 206. Jangar Consumer-Evidence Parity Settlement And Alpha Release Custody (2026-05-14)
+
+Status: Accepted for engineer and deployer handoff
+Date: 2026-05-14
+Owner: Victor Chen, Jangar Engineering Architecture
+Scope: Jangar consumer-evidence parity settlement, Torghut alpha-release custody, AgentRun failure reduction,
+rollout gating, validation, rollback, and cross-swarm handoff.
+
+Companion Torghut contract:
+
+- `docs/torghut/design-system/v6/212-torghut-consumer-evidence-parity-and-alpha-release-freshness-2026-05-14.md`
+
+Extends:
+
+- `205-jangar-controller-ingestion-settlement-and-verification-carry-cutover-2026-05-14.md`
+- `docs/torghut/design-system/v6/211-torghut-controller-ingestion-carry-and-alpha-no-delta-release-2026-05-14.md`
+- `201-jangar-verify-trust-foreclosure-and-alpha-repair-reentry-2026-05-14.md`
+- `198-jangar-material-gate-digest-and-alpha-closure-carry-2026-05-14.md`
+- `188-jangar-typed-torghut-evidence-admission-and-repair-dispatch-2026-05-13.md`
+- `187-jangar-main-source-ci-retention-and-source-serving-verdicts-2026-05-13.md`
+
+## Decision
+
+I am selecting a **consumer-evidence parity settlement** as the next Jangar control-plane architecture increment.
+
+The prior controller-ingestion design is now live enough to expose the next failure mode. On 2026-05-14 between
+20:08Z and 20:11Z, `/ready` returned `status=ok`, leader election was active, rollout proof cells were fresh, and the
+serving process was healthy. The same payload reported `business_state=repair_only`, `revenue_ready=false`, top repair
+`repair_alpha_readiness`, value gate `routeable_candidate_count`, and accepted routeable candidates at `0`.
+
+Full Jangar status was more specific. It reported database health as `healthy`, migration consistency as
+`29/29 applied`, rollout health as `2 configured deployment(s) healthy`, and a current
+`controller_ingestion_settlement`. That settlement was `decision=hold`, with
+`agentrun_ingestion_current=false`, `source_serving_status=block`, and
+`torghut_verification_carry_status=unavailable`. It also had the right governing design refs and a bounded
+zero-notional rollback target.
+
+Torghut then showed why another broad repair launch would be waste. Direct `/trading/revenue-repair` reported
+`business_state=repair_only`, `readyz_status=degraded`, active revision `torghut-00415`, selected lane `H-MICRO-01`,
+`routeable_candidate_count_before=0`, `routeable_candidate_count_after=0`, and
+`jangar_controller_ingestion_carry.carry_state=lagging` with a non-null Jangar settlement ref. The Jangar-facing
+`/trading/consumer-evidence` compact path, sampled in the same window, could still surface
+`jangar_controller_ingestion_carry.carry_state=unavailable` with `source_jangar_settlement_ref=null`.
+
+That split is the control-plane problem. Jangar consumes Torghut through the consumer-evidence boundary, not through
+operator memory of the richer revenue-repair digest. If the compact boundary lags, drops refs, or normalizes a lagging
+state to unavailable, stage clearance and material gates can hold for the wrong reason, or worse, can admit a duplicate
+repair after the no-delta key has already proven no routeable-candidate movement.
+
+The selected design adds `jangar.consumer-evidence-parity-settlement.v1`. It compares the Jangar-facing
+consumer-evidence payload, the direct Torghut revenue-repair digest when reachable, and Jangar's local
+controller-ingestion settlement. It produces one material action decision:
+
+- `allow` only when the consumer-evidence compact refs agree with direct revenue repair and the Jangar settlement is
+  current;
+- `repair_only` when a bounded projection refresh or carry-sync repair can make parity current without paper or live
+  notional;
+- `hold` when serving is healthy but parity is lagging, stale, or missing enough refs to make the top repair unsafe;
+- `block` when the surfaces contradict each other, report nonzero notional, or would admit alpha repair against an
+  unchanged no-delta release key.
+
+The tradeoff is stricter admission while projections converge. I accept that because the business metric is fewer
+failed AgentRuns and shorter green PR-to-healthy GitOps rollout time. A repair runner that starts from stale compact
+evidence is not progress; it is failure debt with a new timestamp.
+
+## Governing Runtime Requirements
+
+This contract implements the active swarm validation contract:
+
+- every run must cite the governing design or runtime requirement before changing code;
+- implement stages must produce production PRs with tests or report the exact blocker to code;
+- verify stages must merge only green PRs and prove Argo, workload readiness, and service health after rollout;
+- final handoff must name the control-plane metric improved or the smallest blocker preventing improvement.
+
+Value-gate mapping:
+
+- `failed_agentrun_rate`: deny duplicate alpha repair and broad dispatch while consumer evidence and revenue repair
+  disagree about carry state, no-delta release key, selected lane, or routeable-candidate count.
+- `pr_to_rollout_latency`: make source-to-live and projection-to-consumer lag visible as one parity packet instead of
+  forcing deployers to compare `/ready`, full status, `/trading/revenue-repair`, and `/trading/consumer-evidence`.
+- `ready_status_truth`: preserve `/ready.status=ok` as serving truth while material actions cite parity truth.
+- `manual_intervention_count`: replace manual endpoint diffing with a reducer that names the stale or missing ref.
+- `handoff_evidence_quality`: require engineer and deployer handoffs to cite parity settlement id, compared refs,
+  selected value gate, decision, validation commands, and rollback target.
+
+Torghut value-gate mapping:
+
+- `routeable_candidate_count`: the top alpha-readiness lane remains the objective, but it can only relaunch after
+  parity proves the current no-delta key and selected H-MICRO evidence window are the same on both surfaces.
+- `zero_notional_or_stale_evidence_rate`: stale compact evidence becomes first-class repair debt.
+- `fill_tca_or_slippage_quality`: TCA repair remains lower priority unless parity proves the alpha lane released it.
+- `post_cost_daily_net_pnl`: no paper or live widening follows from parity alone.
+- `capital_gate_safety`: every selected repair remains `max_notional=0`.
+
+## Current Evidence
+
+All evidence below was collected read-only on 2026-05-14. I did not mutate Kubernetes resources, database rows,
+GitOps resources, AgentRuns, trading flags, broker state, or market data.
+
+### Cluster, Rollout, And Events
+
+- Argo reported `agents`, `jangar`, and `symphony-jangar` as `Synced/Healthy`. `torghut` was `OutOfSync/Healthy`
+  during the initial sweep while newer `torghut-00415` Knative revisions were rolling.
+- The agents namespace deployments were ready: `agents=1/1`, `agents-controllers=2/2`, both running images built from
+  commit `2fa5bf6d4ff92c1d11303c916d50e817e0008762`.
+- The Jangar namespace deployment `jangar=1/1` and `symphony-jangar=1/1` were ready.
+- The Torghut namespace had `torghut-00415-deployment=1/1` and `torghut-sim-00510-deployment=1/1` after revision
+  rollout; older revisions were scaled down.
+- The agents namespace still carried material failure debt: `132` failed AgentRuns, `723` succeeded AgentRuns,
+  `11` pending, `6` running, and one unknown in the current list. Current pod summaries showed Jangar/Torghut plan
+  and verify lanes with recent Error and OOMKilled pods.
+- Events in `agents` and `torghut` showed normal rollouts, but also transient readiness failures during rollout and
+  `BackoffLimitExceeded` for a Torghut market-context fundamentals job.
+
+### Jangar Control-Plane Evidence
+
+- `/ready` returned `status=ok`, `business_state=repair_only`, `revenue_ready=false`, top repair
+  `repair_alpha_readiness`, affected value gate `routeable_candidate_count`, and Torghut consumer evidence marked
+  `current`.
+- `/ready.torghut_consumer_evidence` still reported accepted routeable candidates as `0`, routeability state
+  `blocked`, evidence-clock state `split`, and evidence-clock custody `missing`.
+- Full status reported database `healthy`, `latency_ms=3`, migration consistency `registered_count=29`,
+  `applied_count=29`, `unapplied_count=0`, and `unexpected_count=0`.
+- Full status reported rollout health `healthy` for `agents` and `agents-controllers`.
+- `controller_ingestion_settlement` existed and was `decision=hold`. It had `deployment_available=true`,
+  `watch_epoch_current=true`, `controller_self_report_current=true`, `agentrun_ingestion_current=false`,
+  `execution_trust_status=healthy`, `database_status=healthy`, `source_serving_status=block`, and
+  `torghut_verification_carry_status=unavailable`.
+- `verify_trust_foreclosure_board.alpha_repair_reentry_admission.decision=deny`.
+- `repair_slot_escrow.status=block`, with a blocked slot caused by
+  `selected_receipt_source_revenue_repair_ref_mismatch`,
+  `material_reentry_receipt_missing_for_selected_executable_alpha`, and active no-delta debt.
+- `material_gate_digest.material_readiness=repair_only`, and `dispatch_repair` was denied because alpha closure
+  no-delta budget was consumed and no-delta debt was active.
+
+### Torghut Business And Data Evidence
+
+- Direct `/trading/revenue-repair` returned `business_state=repair_only`, `revenue_ready=false`,
+  `readyz_status=degraded`, active revision `torghut-00415`, and operating rule
+  `keep_live_submit_disabled_until_repair_queue_clears`.
+- The top repair was `repair_alpha_readiness`, reason `alpha_readiness_not_promotion_eligible`, value gate
+  `routeable_candidate_count`, required output `torghut.executable-alpha-receipts.v1`, and `max_notional=0`.
+- `routeability_acceptance.accepted_routeable_candidate_count=0` and
+  `route_evidence_clearinghouse.accepted_routeable_candidate_count=0`.
+- `alpha_readiness_settlement_conveyor.status=no_delta`, selected lane `H-MICRO-01`, strategy
+  `microbar_volume_continuation_long_top2_chip_v1@paper`, reason `drift_checks_missing`, measured routeable-candidate
+  delta `0`, and required receipts including `feature_replay_receipt`, `drift_check_receipt`, and
+  `required_feature_set_receipt`.
+- Direct revenue repair reported `jangar_controller_ingestion_carry.carry_state=lagging`, a non-null
+  `source_jangar_settlement_ref`, and reason codes including `agentrun_ingestion_unknown`,
+  `source_serving_block`, and `torghut_verification_carry_unavailable`.
+- The compact Jangar-facing consumer-evidence route could still report carry `unavailable` with
+  `source_jangar_settlement_ref=null` in the same evidence window. That is the parity gap this design addresses.
+- Torghut `/db-check` returned `ok=true`, `schema_current=true`, and `schema_graph_lineage_ready=true`.
+- Direct CNPG cluster reads are correctly blocked for this worker:
+  `clusters.postgresql.cnpg.io is forbidden` for both `jangar` and `torghut`. Database assessment therefore relies on
+  application-level health and schema endpoints plus pod readiness, not privileged database inspection.
+
+### Source And Test Surface
+
+- Jangar currently has `70` top-level `control-plane*.ts` server modules and `36` matching server test files under
+  `services/jangar/src/server/__tests__`.
+- The new implementation surface is tightly bounded:
+  - `services/jangar/src/server/control-plane-consumer-evidence-parity-settlement.ts` for the reducer;
+  - `services/jangar/src/server/control-plane-status.ts` for full status projection;
+  - `services/jangar/src/routes/ready.tsx` only for compact readback after full status proves stable;
+  - `services/jangar/src/data/agents-control-plane.ts` for typed status shape;
+  - `services/jangar/src/server/__tests__/control-plane-consumer-evidence-parity-settlement.test.ts` and
+    `control-plane-status.test.ts` for coverage.
+- Torghut already has implementation and tests for the adjacent contracts:
+  `test_jangar_controller_ingestion_carry.py`, `test_no_delta_repair_reentry_auction.py`,
+  `test_alpha_readiness_settlement_conveyor.py`, `test_alpha_repair_dividend_ledger.py`, and
+  `test_build_revenue_repair_digest.py`.
+- The missing test family is cross-surface parity: compact consumer evidence current, compact lagging behind direct
+  revenue repair, compact missing Jangar settlement ref, changed no-delta release key, stale compact TTL, and
+  contradiction between compact and direct selected lane.
+
+## Problem
+
+The system now has the right individual claims, but it does not have a single admission object for whether the
+Jangar-facing Torghut projection is the same truth as the direct Torghut business surface.
+
+Concrete failure modes:
+
+1. `/ready.status=ok` can be true while material actions are correctly held.
+2. Full Jangar status can hold on `torghut_verification_carry_unavailable` while direct Torghut revenue repair has
+   already classified the carry as `lagging` with a settlement ref.
+3. Torghut can deny no-delta reentry from direct revenue repair while consumer evidence still lacks the refs Jangar
+   needs to explain the denial.
+4. Repair-slot escrow can block on source-revenue-repair ref mismatch without a first-class parity packet that names
+   which endpoint or projection is stale.
+5. Engineers can rerun alpha repair against an unchanged H-MICRO no-delta release key because the compact boundary did
+   not carry the richer direct evidence.
+6. Deployer handoffs can claim a green rollout while the Jangar business evidence surface still contains stale compact
+   evidence.
+
+The control plane needs to settle projection parity before it admits another material alpha repair or deploy-widening
+action.
+
+## Alternatives Considered
+
+### Option A: Enforce Controller-Ingestion Settlement Immediately
+
+This option promotes `controller_ingestion_settlement` from observe mode to an admission gate and leaves Torghut
+consumer-evidence parity to later.
+
+Advantages:
+
+- Uses a reducer that already exists.
+- Directly addresses AgentRun ingestion and source-serving hold.
+- Gives a simple operator rule: no broad work unless the settlement allows it.
+
+Disadvantages:
+
+- It does not explain why direct revenue repair and consumer evidence disagree.
+- It can hold on `torghut_verification_carry_unavailable` after direct Torghut has already advanced to `lagging`.
+- It risks hardening a stale compact projection into a runtime gate.
+- It does not tell Torghut whether the next useful zero-notional action is projection refresh or H-MICRO feature
+  replay.
+
+Decision: reject as the next architecture increment. Controller-ingestion remains a dependency, not the final gate.
+
+### Option B: Launch H-MICRO Feature Replay As The Next Repair
+
+This option treats `drift_checks_missing` and missing feature-set evidence as the next revenue repair and asks
+engineers to fund `feature_replay_receipt`, `drift_check_receipt`, and `required_feature_set_receipt` for H-MICRO.
+
+Advantages:
+
+- It targets the top business value gate directly.
+- It is the path most likely to increase `routeable_candidate_count`.
+- It uses current Torghut lane scoring.
+
+Disadvantages:
+
+- The active no-delta release key says repeated launch is denied.
+- It does not reduce failed AgentRuns if the compact consumer projection remains stale.
+- It can spend repair capacity before Jangar and Torghut agree on the selected lane and release key.
+- It weakens the "every run cites governing design or runtime requirement" contract because the consumer boundary
+  would still be ambiguous.
+
+Decision: reject for immediate implementation. H-MICRO feature replay is the next bounded repair only after parity is
+current or the parity reducer selects it as a changed release condition.
+
+### Option C: Add Consumer-Evidence Parity Settlement
+
+This option adds a Jangar settlement that compares compact consumer evidence, direct revenue repair, and local
+controller-ingestion settlement before stage clearance or material gates admit another alpha repair.
+
+Advantages:
+
+- Targets the live split directly.
+- Preserves `/ready` as serving truth while giving material actions a stronger business-evidence truth source.
+- Reduces failed AgentRuns by preventing duplicate no-delta repair launches from stale compact evidence.
+- Gives deployers a single packet for projection lag and source-to-live lag.
+- Creates a clean Torghut handoff: either refresh consumer evidence, or fund the H-MICRO feature replay after parity.
+
+Disadvantages:
+
+- Adds another reducer and test surface.
+- Requires careful timeout and caching so `/ready` does not depend on a slow direct Torghut call.
+- Keeps repair actions held when the system is serving but parity is stale.
+
+Decision: select Option C.
+
+## Architecture
+
+### Contract Shape
+
+Jangar adds an observe-first status object:
+
+```yaml
+schema_version: jangar.consumer-evidence-parity-settlement.v1
+settlement_id: consumer-evidence-parity:<namespace>:<digest>
+generated_at: <iso8601>
+fresh_until: <iso8601>
+namespace: agents
+mode: observe|enforce
+decision: allow|repair_only|hold|block
+serving_readiness: ok|degraded|down
+business_state: repair_only|ready|blocked|unknown
+revenue_ready: true|false|null
+selected_value_gate: routeable_candidate_count
+selected_hypothesis_id: H-MICRO-01|null
+consumer_evidence_ref: <torghut consumer evidence receipt/ref|null>
+revenue_repair_ref: <torghut revenue repair digest ref|null>
+controller_ingestion_settlement_ref: <jangar settlement ref|null>
+consumer_carry_state: current|repairable|lagging|unavailable|stale|contradicted|unknown
+revenue_carry_state: current|repairable|lagging|unavailable|stale|contradicted|unknown
+consumer_no_delta_release_key: <key|null>
+revenue_no_delta_release_key: <key|null>
+consumer_routeable_candidate_count: <int|null>
+revenue_routeable_candidate_count: <int|null>
+parity_state: current|lagging|stale|missing|contradicted
+selected_repair_ticket_class: none|consumer_evidence_projection_refresh|controller_ingestion|alpha_feature_replay
+selected_repair_ticket_ref: <ref|null>
+max_notional: '0'
+reason_codes: []
+validation_commands: []
+rollback_target: <string>
+```
+
+The reducer must compare:
+
+- selected value gate;
+- selected hypothesis id;
+- routeable candidate count before and after;
+- no-delta release key;
+- no-delta reentry decision;
+- Jangar controller-ingestion settlement ref;
+- Jangar carry state;
+- verify-trust foreclosure board ref;
+- repair-slot escrow ref;
+- freshness and expiry windows;
+- max notional.
+
+### Decision Rules
+
+`allow` requires all of the following:
+
+- consumer evidence is fresh;
+- direct revenue repair is fresh or explicitly unavailable with a cached last-good digest that has not expired;
+- consumer and direct surfaces agree on selected value gate, selected hypothesis, no-delta release key, routeable
+  candidate count, carry state, and max notional;
+- Jangar controller-ingestion settlement is `allow` or `repair_only` with a selected zero-notional repair;
+- material gate is not `block`.
+
+`repair_only` is emitted when one bounded action can repair parity:
+
+- compact consumer evidence is stale or missing a ref that direct revenue repair has;
+- direct revenue repair and Jangar status agree that a projection refresh is enough;
+- controller ingestion is the only stale witness and the selected ticket stays zero-notional.
+
+`hold` is emitted when serving is healthy but the correct repair action is not attributable:
+
+- consumer evidence and direct revenue repair disagree on carry state;
+- consumer evidence lacks the Jangar settlement ref direct revenue repair has;
+- source-serving status is block or hold while the direct Torghut digest has advanced;
+- the no-delta release key is active and unchanged.
+
+`block` is emitted when:
+
+- any compared surface reports nonzero notional;
+- selected hypothesis or value gate contradicts across fresh surfaces;
+- direct revenue repair says no-delta deny while compact consumer evidence would select an alpha repair;
+- freshness windows are expired on all compared surfaces.
+
+### Runtime Placement
+
+The first implementation should attach the settlement to full control-plane status only. `/ready` can expose a compact
+parity ref after full status proves stable for one rollout. The full status route may call direct Torghut revenue repair
+with a short timeout and must preserve the last known compact consumer evidence if the direct call is unavailable.
+
+The hot `/ready` path must not become dependent on a slow direct Torghut fetch. The serving readiness contract remains
+Kubernetes, runtime kits, leader election, memory provider, and existing hot-path Torghut consumer evidence. Material
+actions use the parity settlement.
+
+## Implementation Scope
+
+Engineer milestone 1: Jangar parity reducer.
+
+- Add `services/jangar/src/server/control-plane-consumer-evidence-parity-settlement.ts`.
+- Add types in `services/jangar/src/data/agents-control-plane.ts`.
+- Unit-test allow, repair-only projection refresh, hold on compact/direct carry mismatch, hold on missing settlement
+  ref, block on nonzero notional, and block on selected-hypothesis contradiction.
+- Value gates: `failed_agentrun_rate`, `ready_status_truth`, `handoff_evidence_quality`.
+
+Engineer milestone 2: Status projection and action packet.
+
+- Attach the settlement to `services/jangar/src/server/control-plane-status.ts`.
+- Feed settlement decision into material gate digest and repair-slot escrow as observe-mode evidence only.
+- Add control-plane status tests proving the settlement cites design refs and validation commands.
+- Value gates: `pr_to_rollout_latency`, `manual_intervention_count`, `handoff_evidence_quality`.
+
+Engineer milestone 3: Torghut companion parity export.
+
+- Consume `torghut.consumer-evidence-parity-ledger.v1` compact refs once Torghut exports them.
+- Treat `consumer_evidence_projection_refresh` as the only selected repair when compact parity is stale.
+- Value gates: `routeable_candidate_count`, `zero_notional_or_stale_evidence_rate`, `capital_gate_safety`.
+
+## Validation Gates
+
+Required local checks for the Jangar implementation PR:
+
+```bash
+bun run --filter jangar test -- services/jangar/src/server/__tests__/control-plane-consumer-evidence-parity-settlement.test.ts
+bun run --filter jangar test -- services/jangar/src/server/__tests__/control-plane-status.test.ts
+bunx oxfmt --check services/jangar/src/server/control-plane-consumer-evidence-parity-settlement.ts services/jangar/src/server/__tests__/control-plane-consumer-evidence-parity-settlement.test.ts services/jangar/src/data/agents-control-plane.ts
+```
+
+Required rollout checks before deployer marks the implementation healthy:
+
+```bash
+kubectl get applications.argoproj.io -n argocd agents jangar torghut symphony-jangar
+kubectl get deployments -n agents agents agents-controllers
+curl -fsS 'http://agents.agents.svc.cluster.local/api/agents/control-plane/status?namespace=agents' | jq '.consumer_evidence_parity_settlement'
+curl -fsS http://agents.agents.svc.cluster.local/ready | jq '{status,business_state,revenue_ready,top_repair_queue_item}'
+curl -fsS http://torghut.torghut.svc.cluster.local/trading/revenue-repair | jq '{business_state,revenue_ready,jangar_controller_ingestion_carry,no_delta_repair_reentry_auction}'
+curl -fsS http://torghut.torghut.svc.cluster.local/trading/consumer-evidence | jq '.consumer_evidence_parity_ledger'
+```
+
+Acceptance requires:
+
+- parity settlement exists on full status;
+- settlement cites this design and the Torghut companion design;
+- `max_notional` remains `0`;
+- `dispatch_repair` is not admitted while parity is `lagging`, `stale`, `missing`, or `contradicted`;
+- if the selected ticket is `consumer_evidence_projection_refresh`, the handoff names the stale compact refs;
+- if the selected ticket is `alpha_feature_replay`, the handoff proves the no-delta release key changed or was retired.
+
+## Rollout Plan
+
+1. Ship in observe mode on full status.
+2. Verify status projection, unit tests, and Argo workload readiness.
+3. Add compact `/ready` ref only after full status is stable for one healthy rollout.
+4. Enable material-gate consumption in observe mode.
+5. Consider enforcement only after two consecutive rollout windows show parity current or attributable repair-only.
+
+## Rollback Plan
+
+Rollback is configuration and consumer-level:
+
+- ignore `consumer_evidence_parity_settlement` in material gate digest and repair-slot escrow;
+- keep `/ready` serving semantics unchanged;
+- keep controller-ingestion settlement, source-serving verdicts, repair-slot escrow, no-delta auction, and Torghut
+  `max_notional=0` as the active safety boundaries;
+- remove the direct revenue-repair comparison if it causes latency, while retaining compact consumer evidence.
+
+Rollback success is:
+
+- `/ready` still returns serving status;
+- full status still returns controller-ingestion settlement;
+- Torghut remains `repair_only`;
+- no paper or live notional is enabled by the rollback.
+
+## Risks And Mitigations
+
+- Risk: direct Torghut revenue-repair fetch makes status slow. Mitigation: short timeout, cached last-known digest, and
+  no dependency from `/ready`.
+- Risk: parity reducer becomes another opaque gate. Mitigation: every reason code must include compared refs and a
+  validation command.
+- Risk: compact and direct surfaces intentionally differ. Mitigation: the Torghut companion contract defines which
+  fields must be compact parity fields and which remain diagnostic only.
+- Risk: engineers treat parity current as capital readiness. Mitigation: parity only proves projection truth;
+  `routeable_candidate_count`, profit proof, capital gates, and `max_notional=0` remain separate.
+- Risk: repeated hold states increase manual intervention. Mitigation: `repair_only` must name
+  `consumer_evidence_projection_refresh` when a bounded projection repair is possible.
+
+## Handoff Contract
+
+Engineer handoff must include:
+
+- governing design refs: this document and the Torghut companion;
+- files changed and tests run;
+- sample full-status parity payload;
+- whether the selected ticket is projection refresh, controller ingestion, or alpha feature replay;
+- whether `routeable_candidate_count` moved above `0`; if not, the smallest blocker.
+
+Deployer handoff must include:
+
+- PR URL and merge commit;
+- Argo status for `agents`, `jangar`, `torghut`, and `symphony-jangar`;
+- workload readiness for `agents`, `agents-controllers`, Jangar, and Torghut active revision;
+- `/ready` serving result;
+- full status parity result;
+- Torghut revenue-repair result;
+- rollback target.
+
+The next bounded implementation milestone is Jangar milestone 1: add the parity reducer and full-status projection in
+observe mode. It directly maps to `failed_agentrun_rate`, `ready_status_truth`, `manual_intervention_count`, and
+`handoff_evidence_quality`.

--- a/docs/torghut/design-system/v6/212-torghut-consumer-evidence-parity-and-alpha-release-freshness-2026-05-14.md
+++ b/docs/torghut/design-system/v6/212-torghut-consumer-evidence-parity-and-alpha-release-freshness-2026-05-14.md
@@ -1,0 +1,441 @@
+# 212. Torghut Consumer-Evidence Parity And Alpha Release Freshness (2026-05-14)
+
+Status: Accepted for engineer and deployer handoff
+Date: 2026-05-14
+Owner: Victor Chen, Jangar Engineering Architecture
+Scope: Torghut consumer-evidence parity, alpha-release freshness, zero-notional repair selection, Jangar admission
+handoff, validation, rollout, and rollback.
+
+Companion Jangar contract:
+
+- `docs/agents/designs/206-jangar-consumer-evidence-parity-settlement-and-alpha-release-custody-2026-05-14.md`
+
+Extends:
+
+- `211-torghut-controller-ingestion-carry-and-alpha-no-delta-release-2026-05-14.md`
+- `210-torghut-source-bound-verification-carry-import-and-no-delta-release-2026-05-14.md`
+- `206-torghut-no-delta-repair-reentry-auction-and-verification-carry-2026-05-14.md`
+- `205-torghut-alpha-readiness-settlement-conveyor-and-routeable-profit-runway-2026-05-14.md`
+- `204-torghut-alpha-repair-dividend-ledger-and-custody-flight-recorder-2026-05-14.md`
+- `200-torghut-routeable-alpha-evidence-foundry-and-capital-safe-profit-ladder-2026-05-14.md`
+- `192-torghut-typed-consumer-evidence-route-and-capital-safe-repair-dispatch-2026-05-13.md`
+
+## Decision
+
+I am selecting **consumer-evidence parity as the release precondition for the next alpha-readiness repair**.
+
+The live business evidence is clear. `/trading/revenue-repair` on 2026-05-14 at 20:10Z returned
+`business_state=repair_only`, `revenue_ready=false`, `readyz_status=degraded`, active revision `torghut-00415`, and
+top repair `repair_alpha_readiness`. The selected value gate remained `routeable_candidate_count`; accepted routeable
+candidates were still `0`; and capital stayed `max_notional=0`.
+
+The selected lane was not random. The alpha-readiness settlement conveyor selected `H-MICRO-01` with strategy
+`microbar_volume_continuation_long_top2_chip_v1@paper`, lane `microstructure-breakout`, reason
+`drift_checks_missing`, and lane score `105`. It carried the required receipts that can plausibly move the value gate:
+`feature_replay_receipt`, `drift_check_receipt`, `required_feature_set_receipt`, and
+`torghut.alpha-readiness-settlement-receipt.v1`. It also reported no routeable-candidate delta and denied repeat
+launch under the active no-delta release key.
+
+The control-plane dependency is now the narrow risk. Direct revenue repair classified Jangar controller-ingestion carry
+as `lagging` and named a Jangar settlement ref. The Jangar-facing consumer-evidence compact path could still show the
+same carry family as `unavailable` with a missing settlement ref. Jangar is supposed to consume the compact boundary.
+If the compact boundary is stale or lossy, Jangar cannot safely distinguish "run H-MICRO feature replay" from
+"refresh the evidence projection first."
+
+The selected design adds `torghut.consumer-evidence-parity-ledger.v1`. It is a Torghut-side ledger that compares the
+direct revenue-repair digest to the compact consumer-evidence payload before Jangar acts on it. The ledger must be
+mirrored through `/trading/consumer-evidence` and included in `/trading/revenue-repair`. It produces a parity state and
+a selected zero-notional release action:
+
+- `current`: consumer evidence and revenue repair agree on the carry state, selected lane, no-delta release key,
+  routeable-candidate count, and max notional;
+- `lagging`: direct revenue repair has newer refs than compact consumer evidence;
+- `stale`: either surface expired;
+- `missing`: required compact refs are absent;
+- `contradicted`: fresh surfaces disagree on selected lane, value gate, release key, or notional.
+
+The tradeoff is that Torghut will sometimes select projection refresh ahead of H-MICRO feature replay. I accept that.
+Profitability improves when the next repair is the one that can actually change `routeable_candidate_count`, not when
+we create more zero-notional work against an unchanged release key.
+
+## Governing Runtime Requirements
+
+This contract implements the active cross-swarm requirements:
+
+- every implementation run must cite this design or its companion Jangar design before changing code;
+- implement stages must ship production PRs with tests or report the exact blocker to code;
+- verify stages must merge only green PRs and prove Argo, workload readiness, service health, and business evidence;
+- final handoff must name the control-plane or revenue metric improved or the smallest blocker preventing improvement.
+
+Jangar value-gate mapping:
+
+- `failed_agentrun_rate`: Jangar does not launch duplicate repair work from stale consumer evidence.
+- `pr_to_rollout_latency`: deployers can see whether the rollout is blocked by source, serving, or projection parity.
+- `ready_status_truth`: Torghut keeps revenue truth and consumer truth separate until parity is proven.
+- `manual_intervention_count`: the ledger replaces manual endpoint diffing.
+- `handoff_evidence_quality`: handoffs cite parity ledger id, selected release action, no-delta release key, and
+  validation commands.
+
+Torghut value-gate mapping:
+
+- `routeable_candidate_count`: H-MICRO feature replay is selected only when parity is current or the release key has
+  changed.
+- `zero_notional_or_stale_evidence_rate`: stale compact projection becomes explicit repair debt.
+- `fill_tca_or_slippage_quality`: TCA remains a separate lane and cannot bypass alpha-readiness parity.
+- `post_cost_daily_net_pnl`: no paper or live widening is authorized.
+- `capital_gate_safety`: all actions remain `max_notional=0`.
+
+## Current Evidence
+
+All evidence below was collected read-only on 2026-05-14. I did not mutate database rows, Kubernetes resources,
+trading flags, broker state, market data, or AgentRuns.
+
+### Revenue-Repair Surface
+
+- `/trading/revenue-repair` returned `business_state=repair_only`, `revenue_ready=false`, active revision
+  `torghut-00415`, and `readyz_status=degraded`.
+- The repair queue had five items. The top item was `repair_alpha_readiness`, reason
+  `alpha_readiness_not_promotion_eligible`, priority `70`, value gate `routeable_candidate_count`, required output
+  `torghut.executable-alpha-receipts.v1`, and `max_notional=0`.
+- Lower-priority items were live submit disabled, empirical jobs degraded, generic degraded state, and empirical jobs
+  not ready.
+- Routeability acceptance reported aggregate state `blocked` and accepted routeable candidates `0`.
+- Route evidence clearinghouse reported accepted routeable candidates `0`, held route claims `3`, and selected repair
+  bids across `post_cost_daily_net_pnl`, `routeable_candidate_count`, `zero_notional_or_stale_evidence_rate`,
+  `fill_tca_or_slippage_quality`, and `capital_gate_safety`.
+
+### Alpha-Readiness Surface
+
+- All three primary hypotheses were still `shadow` and not promotion eligible.
+- `H-MICRO-01` was selected because it is the best current routeable-candidate repair lane.
+- The preserved blocker for H-MICRO was `drift_checks_missing`.
+- The conveyor reported `routeable_candidate_count_before=0`, `routeable_candidate_count_after=0`, and measured delta
+  `0`.
+- The settlement receipt funded only `torghut.alpha-readiness-settlement-receipt.v1`; it still missed
+  `alpha_readiness_receipt`, `capital_replay_board`, `hypothesis_promotion_receipt`,
+  `torghut.executable-alpha-receipts.v1`, `feature_replay_receipt`, `drift_check_receipt`, and
+  `required_feature_set_receipt`.
+- Active no-delta leases existed for H-MICRO, H-REV, and H-CONT. Repeat launch was denied.
+
+### Jangar Carry And Consumer Evidence Surface
+
+- Direct revenue repair reported `jangar_controller_ingestion_carry.carry_state=lagging`.
+- The same direct payload carried a non-null `source_jangar_settlement_ref`, Jangar settlement decision `hold`,
+  `jangar_controller_ingestion_current=false`, and a non-null repair-slot escrow ref.
+- The compact consumer-evidence payload sampled in the same window reported carry `unavailable`,
+  `source_jangar_settlement_ref=null`, and reason codes `jangar_controller_ingestion_settlement_missing` and
+  `jangar_verify_foreclosure_board_missing`.
+- The compact no-delta auction ref still denied reentry with active no-delta release key and
+  `jangar_verification_carry_unavailable`.
+
+### Data And Schema Surface
+
+- `/db-check` returned `ok=true`, `schema_current=true`, and `schema_graph_lineage_ready=true`.
+- The Torghut database pod `torghut-db-1` was `1/1 Running`, with two restarts 37 hours earlier.
+- Direct CNPG cluster reads are blocked for the swarm worker by Kubernetes RBAC. That is the right operational
+  posture. Torghut should expose business and schema truth through typed endpoints, not privileged database access.
+- No evidence authorizes live submission. Capital remains `zero_notional`.
+
+### Source And Test Surface
+
+- The implementation ownership is narrow:
+  - `services/torghut/app/trading/consumer_evidence_parity_ledger.py`;
+  - `services/torghut/app/main.py` for revenue-repair and consumer-evidence projection;
+  - `services/torghut/app/trading/no_delta_repair_reentry_auction.py` for selected release condition consumption;
+  - `services/torghut/tests/test_consumer_evidence_parity_ledger.py`;
+  - targeted updates to `test_build_revenue_repair_digest.py`, `test_trading_api.py`, and
+    `test_no_delta_repair_reentry_auction.py`.
+- Existing adjacent coverage already includes Jangar carry import, no-delta auction, alpha readiness conveyor, alpha
+  repair dividend ledger, and revenue-repair digest construction.
+- The missing coverage is compact/direct parity: current, lagging, stale, missing, contradicted, and projection-refresh
+  ticket selection.
+
+## Problem
+
+Torghut currently publishes enough direct revenue-repair evidence to make a good decision, but the compact
+consumer-evidence boundary can lag or drop the exact refs Jangar needs. That creates four bad outcomes:
+
+1. Jangar holds on an unavailable carry state after Torghut has already classified it as lagging.
+2. Jangar launches or denies work from a compact payload that does not match the direct business digest.
+3. H-MICRO feature replay competes with projection refresh even when the no-delta release key is unchanged.
+4. Deployer handoffs have to summarize two large endpoints by hand.
+
+The fix is not a bigger endpoint dump. The fix is a compact parity ledger with explicit release actions.
+
+## Alternatives Considered
+
+### Option A: Make `/trading/revenue-repair` The Only Authority
+
+Jangar would stop consuming compact consumer evidence and call direct revenue repair for all material decisions.
+
+Advantages:
+
+- Uses the richest payload.
+- Avoids compact projection loss.
+- Fastest way to reason about H-MICRO release conditions.
+
+Disadvantages:
+
+- It makes Jangar more tightly coupled to a large endpoint.
+- It risks putting direct Torghut fetch latency on Jangar status paths.
+- It removes the purpose of the Jangar-facing consumer-evidence contract.
+- It does not solve projection truth for other consumers.
+
+Decision: reject.
+
+### Option B: Keep Consumer Evidence As Best Effort
+
+Torghut keeps mirroring compact refs and relies on Jangar to tolerate nulls, stale refs, and missing settlement ids.
+
+Advantages:
+
+- No new Torghut reducer.
+- No compatibility change.
+- Existing no-delta denial remains safe.
+
+Disadvantages:
+
+- It keeps the current failure mode.
+- It increases manual endpoint diffing.
+- It cannot select projection refresh as a repair action.
+- It can keep `routeable_candidate_count` stuck while the system argues about carry state.
+
+Decision: reject.
+
+### Option C: Publish Consumer-Evidence Parity Ledger
+
+Torghut compares direct revenue repair to compact consumer evidence and publishes a compact parity ledger through both
+surfaces.
+
+Advantages:
+
+- Names the exact projection drift.
+- Lets Jangar hold or repair for the right reason.
+- Preserves compact consumer evidence as the Jangar boundary.
+- Protects no-delta releases from duplicate alpha repair.
+- Gives H-MICRO feature replay a clean precondition.
+
+Disadvantages:
+
+- Adds a reducer, tests, and one compact schema.
+- Requires care to avoid comparing diagnostic-only fields that may legitimately differ.
+- Can delay H-MICRO repair until projection truth catches up.
+
+Decision: select Option C.
+
+## Architecture
+
+### Contract Shape
+
+Torghut adds:
+
+```yaml
+schema_version: torghut.consumer-evidence-parity-ledger.v1
+ledger_id: consumer-evidence-parity-ledger:<digest>
+generated_at: <iso8601>
+fresh_until: <iso8601>
+source_revenue_repair_ref: <digest-ref>
+source_consumer_evidence_ref: <receipt/ref|null>
+business_state: repair_only|ready|blocked
+revenue_ready: true|false
+selected_value_gate: routeable_candidate_count
+selected_hypothesis_id: H-MICRO-01|null
+revenue_no_delta_release_key: <key|null>
+consumer_no_delta_release_key: <key|null>
+revenue_carry_state: current|repairable|lagging|unavailable|stale|contradicted|unknown
+consumer_carry_state: current|repairable|lagging|unavailable|stale|contradicted|unknown
+revenue_routeable_candidate_count: <int|null>
+consumer_routeable_candidate_count: <int|null>
+parity_state: current|lagging|stale|missing|contradicted
+selected_release_action: none|consumer_evidence_projection_refresh|alpha_feature_replay|controller_ingestion_repair
+selected_ticket_id: <id|null>
+required_output_receipt: <schema|null>
+max_notional: '0'
+reason_codes: []
+validation_commands: []
+rollback_target: <string>
+```
+
+The compact ref mirrored through `/trading/consumer-evidence` must include:
+
+```yaml
+schema_version: torghut.consumer-evidence-parity-ledger-ref.v1
+ledger_schema_version: torghut.consumer-evidence-parity-ledger.v1
+ledger_id: <id>
+generated_at: <iso8601>
+fresh_until: <iso8601>
+parity_state: current|lagging|stale|missing|contradicted
+selected_release_action: <action>
+selected_value_gate: routeable_candidate_count
+selected_hypothesis_id: H-MICRO-01|null
+revenue_carry_state: <state>
+consumer_carry_state: <state>
+reason_codes: []
+max_notional: '0'
+```
+
+### Compared Fields
+
+The parity ledger compares only fields that must agree for material action:
+
+- selected value gate;
+- selected hypothesis id;
+- no-delta release key;
+- no-delta reentry decision;
+- routeable-candidate count before and after;
+- Jangar controller-ingestion carry state;
+- Jangar settlement ref presence;
+- repair-slot escrow ref presence;
+- max notional;
+- freshness windows;
+- required output receipt for the selected repair.
+
+It must not compare diagnostic-only fields such as full repair queue ordering, full evidence window arrays, raw route
+claims, or descriptive text. Those can differ without invalidating the compact action boundary.
+
+### Release Action Rules
+
+`consumer_evidence_projection_refresh` is selected when:
+
+- direct revenue repair has a fresh Jangar settlement ref that compact consumer evidence lacks;
+- direct revenue repair has a newer carry state than compact consumer evidence;
+- direct revenue repair and compact consumer evidence disagree on no-delta release key or selected lane;
+- compact consumer evidence is stale while direct revenue repair is fresh.
+
+`alpha_feature_replay` is selected only when:
+
+- parity state is `current`;
+- selected lane is H-MICRO or another lane explicitly chosen by the alpha-readiness conveyor;
+- no-delta release key changed, expired, or was retired by a receipt;
+- required feature replay, drift check, and feature-set receipts are still missing;
+- max notional is `0`.
+
+`controller_ingestion_repair` is selected when:
+
+- Jangar settlement says controller ingestion is repairable;
+- direct and compact surfaces agree on that selected Jangar repair;
+- the selected ticket is zero-notional.
+
+`none` is selected when:
+
+- parity state is current but no release condition changed;
+- parity state is contradicted and the safe answer is block;
+- live or paper notional would be required.
+
+## Implementation Scope
+
+Engineer milestone 1: Torghut parity reducer.
+
+- Add `services/torghut/app/trading/consumer_evidence_parity_ledger.py`.
+- Unit-test current, lagging, stale, missing, contradicted, and projection-refresh action selection.
+- Value gates: `zero_notional_or_stale_evidence_rate`, `handoff_evidence_quality`.
+
+Engineer milestone 2: Revenue-repair and consumer-evidence projection.
+
+- Attach full parity ledger to `/trading/revenue-repair`.
+- Mirror compact parity ref through `/trading/consumer-evidence`.
+- Ensure generated refs are stable for the same compared field set.
+- Value gates: `ready_status_truth`, `manual_intervention_count`.
+
+Engineer milestone 3: No-delta auction release action.
+
+- Let the no-delta auction prefer `consumer_evidence_projection_refresh` while parity is lagging or missing.
+- Permit `alpha_feature_replay` only after parity is current and release conditions changed.
+- Value gates: `routeable_candidate_count`, `failed_agentrun_rate`, `capital_gate_safety`.
+
+## Validation Gates
+
+Required local checks for the Torghut implementation PR:
+
+```bash
+cd services/torghut && uv run --frozen pytest tests/test_consumer_evidence_parity_ledger.py
+cd services/torghut && uv run --frozen pytest tests/test_build_revenue_repair_digest.py -k consumer_evidence_parity
+cd services/torghut && uv run --frozen pytest tests/test_trading_api.py -k consumer_evidence_parity
+cd services/torghut && uv run --frozen pytest tests/test_no_delta_repair_reentry_auction.py -k consumer_evidence_projection
+cd services/torghut && uv run --frozen pyright --project pyrightconfig.json
+cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json
+cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json
+```
+
+Required rollout checks before deployer marks it healthy:
+
+```bash
+kubectl get applications.argoproj.io -n argocd torghut agents jangar symphony-torghut
+kubectl get deployments -n torghut
+curl -fsS http://torghut.torghut.svc.cluster.local/trading/revenue-repair | jq '.consumer_evidence_parity_ledger'
+curl -fsS http://torghut.torghut.svc.cluster.local/trading/consumer-evidence | jq '.consumer_evidence_parity_ledger'
+curl -fsS 'http://agents.agents.svc.cluster.local/api/agents/control-plane/status?namespace=agents' | jq '.consumer_evidence_parity_settlement'
+curl -fsS http://agents.agents.svc.cluster.local/ready | jq '{status,business_state,revenue_ready,top_repair_queue_item}'
+```
+
+Acceptance requires:
+
+- full and compact parity refs are present;
+- parity state is not `missing` for fields required by Jangar;
+- selected release action is projection refresh while compact evidence lags;
+- selected release action is alpha feature replay only after parity is current and release conditions changed;
+- routeable candidate count is reported on both surfaces;
+- `max_notional` remains `0`;
+- no live submission is enabled.
+
+## Rollout Plan
+
+1. Ship the parity ledger in observe mode.
+2. Mirror compact refs to `/trading/consumer-evidence`.
+3. Validate direct revenue-repair and compact consumer-evidence parity over at least one healthy Torghut rollout.
+4. Let Jangar consume parity in observe mode.
+5. Permit no-delta auction selection of projection refresh.
+6. Permit H-MICRO alpha feature replay only after parity current and release conditions changed.
+
+## Rollback Plan
+
+Rollback is additive:
+
+- stop emitting `consumer_evidence_parity_ledger`;
+- keep existing no-delta auction, alpha-readiness conveyor, alpha repair dividend ledger, and Jangar carry import;
+- keep `/trading/consumer-evidence` on its prior compact fields;
+- keep `max_notional=0`;
+- keep live submit disabled until repair queue clears.
+
+Rollback success is:
+
+- `/trading/revenue-repair` still returns `repair_only`;
+- `/trading/consumer-evidence` still returns existing compact refs;
+- Jangar continues to hold material actions through existing controller-ingestion, no-delta, and repair-slot gates;
+- no paper or live capital is enabled.
+
+## Risks And Mitigations
+
+- Risk: parity compares too much and creates false lag. Mitigation: compare only material action fields listed above.
+- Risk: parity current is mistaken for routeability. Mitigation: routeable-candidate count and capital gates remain
+  separate acceptance criteria.
+- Risk: projection refresh becomes a sink for repeated zero-delta work. Mitigation: selection requires a stale or
+  missing compact ref and must carry its own dedupe key.
+- Risk: H-MICRO feature replay is delayed. Mitigation: this is acceptable until the consumer boundary proves the same
+  selected lane and no-delta release key as direct revenue repair.
+- Risk: Jangar and Torghut name different states. Mitigation: companion designs define the shared state vocabulary.
+
+## Handoff Contract
+
+Engineer handoff must include:
+
+- governing design refs: this document and the Jangar companion;
+- files changed and tests run;
+- direct revenue-repair parity sample;
+- compact consumer-evidence parity sample;
+- selected release action;
+- whether `routeable_candidate_count` moved above `0`; if not, the smallest blocker.
+
+Deployer handoff must include:
+
+- PR URL and merge commit;
+- Argo status for `torghut`, `agents`, `jangar`, and `symphony-torghut`;
+- workload readiness for the active Torghut revision and dependent services;
+- `/trading/revenue-repair` parity state;
+- `/trading/consumer-evidence` parity ref;
+- Jangar full-status parity result after consumption;
+- rollback target.
+
+The next bounded implementation milestone is Torghut milestone 1: add the parity reducer and mirror the compact
+parity ref. It maps to `zero_notional_or_stale_evidence_rate`, `failed_agentrun_rate`, `ready_status_truth`, and
+`handoff_evidence_quality`, and it is the smallest safe blocker before another H-MICRO feature replay attempt.

--- a/docs/torghut/design-system/v6/index.md
+++ b/docs/torghut/design-system/v6/index.md
@@ -8,11 +8,13 @@
 - Scope: intraday strategy architecture upgrade beyond static TSMOM, with regime-adaptive routing, DSPy-governed LLM
   reasoning, contamination-safe evaluation, and production rollout controls
 - Implementation status: `Mixed` (historical program closure recorded on `2026-03-03`; source-state refreshed on
-  `2026-03-09`; active proof/capital authority evidence refreshed on `2026-05-14T16:44Z`)
+  `2026-03-09`; active proof/capital authority evidence refreshed on `2026-05-14T20:12Z`)
 - Implementation status (strict, core 01-13 docs, source-state refresh `2026-03-09`): `Implemented=7`, `Partial=5`,
   `Completed=1`
 - Evidence (historical closure): `13-production-gap-closure-master-plan-2026-03-03.md` (Wave 0-6 closure + DoD)
-- Evidence (current next-work priority, refreshed `2026-05-14T16:44Z`):
+- Evidence (current next-work priority, refreshed `2026-05-14T20:12Z`):
+  - `docs/agents/designs/206-jangar-consumer-evidence-parity-settlement-and-alpha-release-custody-2026-05-14.md`
+  - `212-torghut-consumer-evidence-parity-and-alpha-release-freshness-2026-05-14.md`
   - `docs/agents/designs/205-jangar-controller-ingestion-settlement-and-verification-carry-cutover-2026-05-14.md`
   - `211-torghut-controller-ingestion-carry-and-alpha-no-delta-release-2026-05-14.md`
   - `docs/agents/designs/204-jangar-source-bound-verification-carry-exchange-and-repair-slot-reconciliation-2026-05-14.md`


### PR DESCRIPTION
## Summary

- Adds a Jangar architecture decision for `jangar.consumer-evidence-parity-settlement.v1`, focused on preventing material actions from using stale Torghut compact consumer evidence.
- Adds the companion Torghut design for `torghut.consumer-evidence-parity-ledger.v1`, including release-action rules for projection refresh versus H-MICRO alpha feature replay.
- Updates the Torghut v6 index so the current next-work priority reflects the new parity-settlement architecture pair.

## Related Issues

None. Swarm runtime issue ref: `swarm-jangar-control-plane-discover`.

## Testing

- PASS: `bunx oxfmt --check docs/agents/designs/206-jangar-consumer-evidence-parity-settlement-and-alpha-release-custody-2026-05-14.md docs/torghut/design-system/v6/212-torghut-consumer-evidence-parity-and-alpha-release-freshness-2026-05-14.md docs/torghut/design-system/v6/index.md`
- PASS: `bun run --filter @proompteng/jangar docs:inventory:check`
- PASS: `cd services/jangar && bunx vitest run --config vitest.config.ts src/server/__tests__/control-plane-controller-ingestion-settlement.test.ts src/server/__tests__/control-plane-status.test.ts`
- NOTE: `bun run --filter @proompteng/jangar test -- src/server/__tests__/control-plane-controller-ingestion-settlement.test.ts src/server/__tests__/control-plane-status.test.ts` ran the same 39 Vitest tests successfully, but exited nonzero because the package `pretest` hook failed in `@proompteng/temporal-bun-sdk build` with `TS5042`.
- NOTE: Torghut Python checks were not run locally because this workspace does not have `uv` or `mise`; this PR changes docs only.

## Screenshots (if applicable)

N/A. Documentation-only architecture change.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
