### PR TITLE
fix(torghut): hydrate consumer evidence carry

### DIFF
--- a/services/jangar/README.md
+++ b/services/jangar/README.md
@@ -696,6 +696,9 @@ boundary. No database migration or scheduler enforcement is introduced by this p
 
 Design doc `docs/agents/designs/188-jangar-typed-torghut-evidence-admission-and-repair-dispatch-2026-05-13.md`
 requires Jangar to expose typed Torghut custody evidence from the non-recursive `/trading/consumer-evidence` route.
+When Torghut imports Jangar carry for that route, it calls `/api/agents/control-plane/status` with
+`x-torghut-consumer-evidence-mode: omit`; Jangar then computes the local control-plane status without fetching Torghut
+consumer evidence, which prevents a Torghut -> Jangar -> Torghut status loop.
 When Torghut reports an evidence-clock arbiter but does not publish a `required_jangar_custody_ref`, control-plane
 status attaches Jangar's current local `stage_clearance_packets[]` entry for the Torghut paper-capital lane to
 `torghut_consumer_evidence.evidence_clock_custody_*`. A fresh held packet is reported as blocked custody with the

--- a/services/jangar/src/routes/api/agents/control-plane/status.test.ts
+++ b/services/jangar/src/routes/api/agents/control-plane/status.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveTorghutConsumerEvidenceForStatusRequest } from './status'
+
+describe('control-plane status route', () => {
+  it('omits Torghut consumer evidence for non-recursive carry imports', async () => {
+    const resolver = resolveTorghutConsumerEvidenceForStatusRequest(
+      new Request('http://jangar.test/api/agents/control-plane/status', {
+        headers: {
+          'x-torghut-consumer-evidence-mode': 'omit',
+        },
+      }),
+    )
+
+    expect(resolver).toBeDefined()
+    const resolution = await resolver!()
+    expect(resolution.status.status).toBe('disabled')
+    expect(resolution.status.reason_codes).toContain('torghut_consumer_evidence_omitted_for_non_recursive_status')
+  })
+
+  it('keeps normal status requests on the full Torghut consumer-evidence path', () => {
+    expect(
+      resolveTorghutConsumerEvidenceForStatusRequest(new Request('http://jangar.test/api/agents/control-plane/status')),
+    ).toBeUndefined()
+  })
+})

--- a/services/jangar/src/routes/api/agents/control-plane/status.ts
+++ b/services/jangar/src/routes/api/agents/control-plane/status.ts
@@ -1,7 +1,9 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { resolveGrpcStatus } from '~/server/control-plane-grpc'
+import { buildControlPlaneStatus } from '~/server/control-plane-status'
 import { buildCachedControlPlaneStatus } from '~/server/control-plane-status-cache'
 import { projectControlPlaneStatus } from '~/server/control-plane-status-projection'
+import type { TorghutConsumerEvidenceResolution } from '~/server/control-plane-torghut-consumer-evidence'
 import { errorResponse, normalizeNamespace, okResponse } from '~/server/primitives-http'
 
 export const Route = createFileRoute('/api/agents/control-plane/status')({
@@ -16,15 +18,41 @@ export const getControlPlaneStatus = async (request: Request) => {
   const url = new URL(request.url)
   const namespace = normalizeNamespace(url.searchParams.get('namespace'), 'agents')
   const view = url.searchParams.get('view') ?? url.searchParams.get('projection')
+  const resolveTorghutConsumerEvidence = resolveTorghutConsumerEvidenceForStatusRequest(request)
 
   try {
-    const status = await buildCachedControlPlaneStatus({
+    const options = {
       namespace,
       grpc: await resolveGrpcStatus(),
-    })
+    }
+    const status = resolveTorghutConsumerEvidence
+      ? await buildControlPlaneStatus(options, { resolveTorghutConsumerEvidence })
+      : await buildCachedControlPlaneStatus(options)
     return okResponse(projectControlPlaneStatus(status, view))
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
     return errorResponse(message, 500, { namespace })
   }
+}
+
+export const resolveTorghutConsumerEvidenceForStatusRequest = (
+  request: Request,
+): (() => Promise<TorghutConsumerEvidenceResolution>) | undefined => {
+  const mode = request.headers.get('x-torghut-consumer-evidence-mode')?.trim().toLowerCase()
+  if (mode !== 'omit') return undefined
+
+  return async () => ({
+    status: {
+      status: 'disabled',
+      endpoint: '',
+      receipt_id: null,
+      generated_at: null,
+      fresh_until: null,
+      candidate_id: null,
+      dataset_snapshot_ref: null,
+      max_notional: null,
+      reason_codes: ['torghut_consumer_evidence_omitted_for_non_recursive_status'],
+      message: 'torghut consumer evidence omitted for non-recursive Torghut carry import',
+    },
+  })
 }

--- a/services/torghut/README.md
+++ b/services/torghut/README.md
@@ -251,7 +251,9 @@ Testing rules for the trading core:
   auction, and mirrors a compact `torghut.jangar-controller-ingestion-carry-ref.v1` through `/readyz` and
   `/trading/consumer-evidence`. The import carries Jangar repair-slot escrow and rollout-witness refs when available
   so `hold` or `block` settlements can name the exact zero-notional blocker instead of collapsing to a generic missing
-  carry. A `jangar_verify_carry` ticket is selectable only for `repairable` carry and always keeps `max_notional=0`.
+  carry. `/trading/consumer-evidence` fetches the Jangar status payload with Torghut consumer-evidence expansion
+  explicitly omitted, so the route can mirror current Jangar carry without recursively calling itself through Jangar.
+  A `jangar_verify_carry` ticket is selectable only for `repairable` carry and always keeps `max_notional=0`.
 - `GET /trading/status` and `GET /readyz` now include the May 8 doc 181
   `quality_adjusted_profit_frontier` shadow projection. The reducer ranks zero-notional repair packets from quant
   quality, market-context risk flags, route/TCA state, simulation-cache freshness, and Jangar evidence-quality refs

--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -3046,6 +3046,12 @@ def trading_status() -> dict[str, object]:
 
 
 def _consumer_evidence_dependency_quorum() -> JangarDependencyQuorumStatus:
+    dependency_quorum = load_jangar_dependency_quorum(
+        omit_torghut_consumer_evidence=True,
+    )
+    if dependency_quorum.reasons != ["jangar_control_plane_status_url_missing"]:
+        return dependency_quorum
+
     return JangarDependencyQuorumStatus(
         decision="allow",
         reasons=[],
@@ -3416,7 +3422,12 @@ def _build_trading_consumer_evidence_payload() -> dict[str, object]:
         "mode": settings.trading_mode,
         "running": state.running,
         "build": build_payload,
-        "control_plane_dependency_mode": "caller_evaluated",
+        "control_plane_dependency_mode": (
+            "caller_evaluated"
+            if dependency_quorum.message
+            == CONSUMER_EVIDENCE_CONTROL_PLANE_DEPENDENCY_MESSAGE
+            else "jangar_status_non_recursive"
+        ),
         "dependency_quorum": dependency_quorum.as_payload(),
         "forecast_service": forecast_service_status,
         "lean_authority": lean_authority_status,

--- a/services/torghut/app/trading/hypotheses.py
+++ b/services/torghut/app/trading/hypotheses.py
@@ -784,7 +784,10 @@ def _fallback_quorum_from_legacy_status(
     )
 
 
-def load_jangar_dependency_quorum() -> JangarDependencyQuorumStatus:
+def load_jangar_dependency_quorum(
+    *,
+    omit_torghut_consumer_evidence: bool = False,
+) -> JangarDependencyQuorumStatus:
     status_url = (settings.trading_jangar_control_plane_status_url or "").strip()
     if not status_url:
         return JangarDependencyQuorumStatus(
@@ -792,12 +795,16 @@ def load_jangar_dependency_quorum() -> JangarDependencyQuorumStatus:
             reasons=["jangar_control_plane_status_url_missing"],
             message="TRADING_JANGAR_CONTROL_PLANE_STATUS_URL is not configured.",
         )
+    cache_key = (
+        f"{status_url}#omit_torghut_consumer_evidence="
+        f"{str(omit_torghut_consumer_evidence).lower()}"
+    )
 
     ttl_seconds = max(0, int(settings.trading_jangar_control_plane_cache_ttl_seconds))
     if ttl_seconds > 0:
         now = datetime.now(timezone.utc)
         with _JANGAR_QUORUM_CACHE_LOCK:
-            cached = cast(dict[str, Any] | None, _JANGAR_QUORUM_CACHE.get(status_url))
+            cached = cast(dict[str, Any] | None, _JANGAR_QUORUM_CACHE.get(cache_key))
             if cached is not None:
                 checked_at = cast(datetime | None, cached.get("checked_at"))
                 if checked_at is not None and now - checked_at <= timedelta(
@@ -807,9 +814,10 @@ def load_jangar_dependency_quorum() -> JangarDependencyQuorumStatus:
 
     decoded: Any = None
     try:
-        request = Request(
-            status_url, method="GET", headers={"accept": "application/json"}
-        )
+        headers = {"accept": "application/json"}
+        if omit_torghut_consumer_evidence:
+            headers["x-torghut-consumer-evidence-mode"] = "omit"
+        request = Request(status_url, method="GET", headers=headers)
         with urlopen(
             request, timeout=settings.trading_jangar_control_plane_timeout_seconds
         ) as response:
@@ -883,7 +891,7 @@ def load_jangar_dependency_quorum() -> JangarDependencyQuorumStatus:
 
     if ttl_seconds > 0:
         with _JANGAR_QUORUM_CACHE_LOCK:
-            _JANGAR_QUORUM_CACHE[status_url] = {
+            _JANGAR_QUORUM_CACHE[cache_key] = {
                 "checked_at": datetime.now(timezone.utc),
                 "status": status,
             }

--- a/services/torghut/tests/test_hypotheses.py
+++ b/services/torghut/tests/test_hypotheses.py
@@ -1030,6 +1030,66 @@ class TestHypothesisReadiness(TestCase):
             rollout_witness,
         )
 
+    def test_load_jangar_dependency_quorum_can_omit_torghut_consumer_evidence(
+        self,
+    ) -> None:
+        settings.trading_jangar_control_plane_status_url = (
+            "https://jangar.example/status"
+        )
+        settings.trading_jangar_control_plane_cache_ttl_seconds = 0
+        with patch(
+            "app.trading.hypotheses.urlopen",
+            return_value=_FakeHttpResponse(
+                {
+                    "dependency_quorum": {
+                        "decision": "allow",
+                        "reasons": [],
+                        "message": "ok",
+                    }
+                }
+            ),
+        ) as urlopen_mock:
+            status = load_jangar_dependency_quorum(
+                omit_torghut_consumer_evidence=True,
+            )
+
+        self.assertEqual(status.decision, "allow")
+        request = urlopen_mock.call_args.args[0]
+        self.assertEqual(
+            request.get_header("X-torghut-consumer-evidence-mode"),
+            "omit",
+        )
+
+    def test_load_jangar_dependency_quorum_caches_by_consumer_evidence_mode(
+        self,
+    ) -> None:
+        settings.trading_jangar_control_plane_status_url = (
+            "https://jangar.example/status"
+        )
+        settings.trading_jangar_control_plane_cache_ttl_seconds = 30
+        with patch(
+            "app.trading.hypotheses.urlopen",
+            return_value=_FakeHttpResponse(
+                {
+                    "dependency_quorum": {
+                        "decision": "delay",
+                        "reasons": ["workflow_backoff_warning"],
+                        "message": "degraded",
+                    }
+                }
+            ),
+        ) as urlopen_mock:
+            first = load_jangar_dependency_quorum(
+                omit_torghut_consumer_evidence=True,
+            )
+            second = load_jangar_dependency_quorum(
+                omit_torghut_consumer_evidence=True,
+            )
+
+        self.assertEqual(first.decision, "delay")
+        self.assertIs(first, second)
+        urlopen_mock.assert_called_once()
+
     def test_load_jangar_dependency_quorum_falls_back_to_legacy_status_when_needed(
         self,
     ) -> None:

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -46,6 +46,7 @@ from app.trading.completion import (
 )
 from app.trading.execution import OrderExecutor
 from app.config import settings
+from app.trading.hypotheses import JangarDependencyQuorumStatus
 from app.models import (
     AutoresearchCandidateSpec,
     AutoresearchEpoch,
@@ -1544,6 +1545,136 @@ class TestTradingApi(TestCase):
         )
         dependency_fetch.assert_not_called()
         continuity_fetch.assert_not_called()
+
+    def test_trading_consumer_evidence_hydrates_jangar_carry_non_recursively(
+        self,
+    ) -> None:
+        settlement = {
+            "settlement_id": "controller-ingestion-settlement:current",
+            "decision": "allow",
+            "controller_ingestion_current": True,
+            "fresh_until": "2099-05-14T15:45:00+00:00",
+        }
+        board = {
+            "board_id": "verify-trust-foreclosure-board:current",
+            "fresh_until": "2099-05-14T15:45:00+00:00",
+        }
+        proof_floor = {
+            "schema_version": "torghut.profitability-proof-floor.v1",
+            "generated_at": "2026-05-08T03:54:41.769374+00:00",
+            "account_label": "PA3SX7FYNUTF",
+            "route_state": "repair_only",
+            "capital_state": "zero_notional",
+            "max_notional": "0",
+            "blocking_reasons": ["simple_submit_disabled"],
+            "proof_dimensions": [],
+            "repair_ladder": [],
+        }
+        live_submission_gate = {
+            "allowed": False,
+            "reason": "simple_submit_disabled",
+            "blocked_reasons": ["simple_submit_disabled"],
+            "capital_stage": "shadow",
+            "dependency_quorum_decision": "allow",
+        }
+
+        with (
+            patch("app.main.resolve_hypothesis_dependency_quorum") as dependency_fetch,
+            patch("app.main.load_jangar_route_continuity_packet") as continuity_fetch,
+            patch(
+                "app.main.load_jangar_dependency_quorum",
+                return_value=JangarDependencyQuorumStatus(
+                    decision="allow",
+                    reasons=[],
+                    message="ok",
+                    controller_ingestion_settlement=settlement,
+                    verify_trust_foreclosure_board=board,
+                ),
+            ) as jangar_fetch,
+            patch(
+                "app.main._forecast_service_status",
+                return_value={
+                    "status": "healthy",
+                    "authority": "empirical",
+                    "promotion_authority_eligible_models": ["candidate-a"],
+                },
+            ),
+            patch(
+                "app.main._lean_authority_status",
+                return_value={"status": "healthy", "authority": "empirical"},
+            ),
+            patch(
+                "app.main._empirical_jobs_status",
+                return_value={
+                    "status": "healthy",
+                    "ready": True,
+                    "candidate_ids": ["candidate-a"],
+                    "dataset_snapshot_refs": ["dataset-a"],
+                },
+            ),
+            patch(
+                "app.main.load_quant_evidence_status",
+                return_value={"ok": True, "required": False},
+            ),
+            patch("app.main._load_tca_summary", return_value={}),
+            patch(
+                "app.main._build_live_submission_gate_payload",
+                return_value=live_submission_gate,
+            ),
+            patch(
+                "app.main.build_profitability_proof_floor_receipt",
+                return_value=proof_floor,
+            ),
+            patch(
+                "app.main._readiness_dependency_snapshot",
+                return_value=(
+                    {
+                        "database": {
+                            "ok": True,
+                            "schema_current": True,
+                            "schema_current_heads": ["0029_live_submission_gate"],
+                        }
+                    },
+                    datetime(2026, 5, 8, 3, 54, 41, tzinfo=timezone.utc),
+                    True,
+                ),
+            ),
+            patch("app.main.SessionLocal", self.session_local),
+        ):
+            response = self.client.get("/trading/consumer-evidence")
+
+        self.assertEqual(response.status_code, 200)
+        jangar_fetch.assert_called_once_with(omit_torghut_consumer_evidence=True)
+        dependency_fetch.assert_not_called()
+        continuity_fetch.assert_not_called()
+        payload = response.json()
+        self.assertEqual(
+            payload["control_plane_dependency_mode"],
+            "jangar_status_non_recursive",
+        )
+        self.assertEqual(
+            payload["dependency_quorum"]["controller_ingestion_settlement"],
+            settlement,
+        )
+        self.assertEqual(
+            payload["dependency_quorum"]["verify_trust_foreclosure_board"],
+            board,
+        )
+        controller_carry = payload["jangar_controller_ingestion_carry"]
+        self.assertEqual(controller_carry["carry_state"], "current")
+        self.assertEqual(
+            controller_carry["source_jangar_settlement_ref"],
+            "controller-ingestion-settlement:current",
+        )
+        self.assertNotIn(
+            "jangar_controller_ingestion_settlement_missing",
+            controller_carry["reason_codes"],
+        )
+        self.assertNotIn(
+            "jangar_verify_foreclosure_board_missing",
+            controller_carry["reason_codes"],
+        )
+        self.assertEqual(controller_carry["max_notional"], "0")
 
     def test_route_continuity_delegates_to_jangar_when_registry_requires_it(
         self,


### PR DESCRIPTION
## Summary

- Hydrates Torghut `/trading/consumer-evidence` with Jangar controller-ingestion settlement and verify-foreclosure board data when the Jangar status URL is configured.
- Adds a non-recursive Jangar status mode for Torghut carry imports so Torghut can fetch Jangar carry without creating a Torghut -> Jangar -> Torghut loop.
- Preserves zero-notional repair-only safety and documents the non-recursive carry path in Torghut and Jangar docs.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_hypotheses.py -k 'jangar_dependency_quorum' -q`
- `cd services/torghut && uv run --frozen pytest tests/test_trading_api.py -k 'consumer_evidence' -q`
- `cd services/torghut && uv run --frozen pytest tests/test_jangar_controller_ingestion_carry.py tests/test_build_revenue_repair_digest.py -k 'jangar_controller_ingestion or revenue_repair' -q`
- `cd services/torghut && uv run --frozen ruff check app/main.py app/trading/hypotheses.py tests/test_hypotheses.py tests/test_trading_api.py && uv run --frozen ruff format --check app/main.py app/trading/hypotheses.py tests/test_hypotheses.py tests/test_trading_api.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json && uv run --frozen pyright --project pyrightconfig.alpha.json && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `bun run --cwd services/jangar test -- src/routes/api/agents/control-plane/status.test.ts src/server/__tests__/control-plane-status.test.ts`
- `bun run --filter @proompteng/jangar lint && bun run --filter @proompteng/jangar tsc`
- `bunx oxfmt --check services/torghut/README.md services/jangar/README.md services/jangar/src/routes/api/agents/control-plane/status.ts services/jangar/src/routes/api/agents/control-plane/status.test.ts`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
