### PR TITLE
docs(torghut): define route adjacent proof reentry

### DIFF
--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -19,6 +19,8 @@ clear entrypoints, clear “source of truth”, and a complete catalog of relate
 - Autonomous Jangar/Torghut production system design: `designs/autonomous-jangar-torghut-production-system.md`
 - Swarm agentic mission architecture notes: `designs/swarm-agentic-mission-architecture-2026-05-08.md`
 - Current Jangar/Torghut architecture contracts:
+  - `designs/206-jangar-route-adjacent-proof-custody-and-torghut-reentry-admission-2026-05-14.md`
+  - `../torghut/design-system/v6/212-torghut-route-adjacent-proof-and-execution-freshness-reentry-2026-05-14.md`
   - `designs/205-jangar-controller-ingestion-settlement-and-verification-carry-cutover-2026-05-14.md`
   - `../torghut/design-system/v6/211-torghut-controller-ingestion-carry-and-alpha-no-delta-release-2026-05-14.md`
   - `designs/204-jangar-source-bound-verification-carry-exchange-and-repair-slot-reconciliation-2026-05-14.md`

--- a/docs/agents/designs/206-jangar-route-adjacent-proof-custody-and-torghut-reentry-admission-2026-05-14.md
+++ b/docs/agents/designs/206-jangar-route-adjacent-proof-custody-and-torghut-reentry-admission-2026-05-14.md
@@ -1,0 +1,358 @@
+# 206. Jangar Route-Adjacent Proof Custody And Torghut Reentry Admission (2026-05-14)
+
+Status: Accepted for engineer and deployer handoff
+Date: 2026-05-14
+Owner: Gideon Park, Torghut Traders Architecture
+Scope: Jangar control-plane custody for Torghut route-adjacent proof, execution freshness, no-delta reentry admission,
+zero-notional repair dispatch, rollout evidence, rollback, and cross-swarm handoff.
+
+Companion Torghut contract:
+
+- `docs/torghut/design-system/v6/212-torghut-route-adjacent-proof-and-execution-freshness-reentry-2026-05-14.md`
+
+Extends:
+
+- `205-jangar-controller-ingestion-settlement-and-verification-carry-cutover-2026-05-14.md`
+- `204-jangar-source-bound-verification-carry-exchange-and-repair-slot-reconciliation-2026-05-14.md`
+- `203-jangar-foreclosure-carry-rollout-witness-and-stage-debt-repair-2026-05-14.md`
+- `201-jangar-verify-trust-foreclosure-and-alpha-repair-reentry-2026-05-14.md`
+- `200-jangar-revenue-repair-settlement-conveyor-and-stage-health-custody-2026-05-14.md`
+- `188-jangar-ready-truth-arbiter-and-stage-credit-cutover-2026-05-13.md`
+
+## Decision
+
+I am selecting **route-adjacent proof custody with bounded Torghut reentry admission** as the next Jangar control-plane
+increment.
+
+The previous carry work did what we asked. Torghut now receives `torghut.jangar-controller-ingestion-carry.v1` from
+live revenue repair, and Jangar exposes `jangar.controller-ingestion-settlement.v1`. That changed the failure mode from
+opaque missing carry to a precise `lagging` carry state. It did not make revenue routeable. Live Torghut still reports
+`business_state=repair_only`, `revenue_ready=false`, `routeable_candidate_count=0`, and `max_notional=0`. The new
+blocking shape is route-adjacent proof and execution freshness: live revenue repair names
+`route_adjacent_workload_proof_missing`, `active_session_execution_samples_stale`,
+`execution_tca_expected_shortfall_samples_missing_non_promoting`, `empirical_jobs_degraded`, and
+`alpha_readiness_not_promotion_eligible`.
+
+The system should not respond by launching broader repair traffic. Jangar should produce one compact custody object
+that joins Torghut live revision, source commit, serving digest, route-adjacent workload readiness, execution TCA
+refresh recency, empirical job state, and the active no-delta release key. Only then should stage clearance admit a
+zero-notional repair ticket. Normal dispatch, paper canary, live micro canary, and live scale remain blocked until the
+same custody object proves that route-adjacent proof and execution freshness are current.
+
+The tradeoff is stricter admission. Some repairs that look useful in isolation will stay held because they do not
+retire the top revenue queue item. I accept that. The business metric is routeable post-cost profit evidence with
+capital safety intact, not repair volume.
+
+## Governing Runtime Requirements
+
+This contract implements the current swarm validation contract:
+
+- every run must cite the governing design or runtime requirement before changing code;
+- implementation stages must ship production PRs that improve readiness, profit evidence, data freshness, execution
+  quality, or capital safety;
+- verification stages must merge only green PRs and prove image promotion, Argo sync, live service health, and trading
+  or evidence status after rollout;
+- the final handoff must name the revenue metric improved or the smallest blocker preventing revenue impact.
+
+Jangar value-gate mapping:
+
+- `failed_agentrun_rate`: hold broad dispatch while route-adjacent proof is missing and no-delta release debt is
+  active.
+- `pr_to_rollout_latency`: one custody object carries source commit, serving digest, Argo revision, and Torghut active
+  revision.
+- `ready_status_truth`: `/ready.status=ok` remains serving truth; route-adjacent custody is material action truth.
+- `manual_intervention_count`: operators no longer have to compare Argo, Knative revisions, Torghut revenue repair,
+  and TCA refresh jobs by hand.
+- `handoff_evidence_quality`: handoffs cite custody id, selected repair ticket, value gate, validation commands, and
+  rollback target.
+
+Torghut value-gate mapping:
+
+- `routeable_candidate_count`: the selected repair must plausibly move H-MICRO-01 or a successor lane from zero to at
+  least one routeable candidate.
+- `zero_notional_or_stale_evidence_rate`: stale execution samples, missing route-adjacent proof, or stale empirical
+  jobs keep the zero-notional stale-evidence rate high and capital locked.
+- `fill_tca_or_slippage_quality`: execution freshness must be measured with current active-session samples, not only a
+  recent cron run timestamp.
+- `post_cost_daily_net_pnl`: no paper or live widening follows from custody alone.
+- `capital_gate_safety`: all admitted repair tickets remain `max_notional=0`.
+
+## Current Evidence
+
+Evidence was collected read-only on 2026-05-14 between 20:24Z and 20:27Z. I did not mutate Kubernetes resources,
+database records, AgentRuns, GitOps state, broker state, market data, or trading flags.
+
+### Cluster, Rollout, And Events
+
+- Argo reported `agents`, `jangar`, and `torghut` as `Synced/Healthy` at revision
+  `57095de61842f69a8dce99b09afec438c46a5945`.
+- Torghut served active revision `torghut-00417` on image digest
+  `sha256:60dfc10974c03aa8909f2f8ddd42dc34fea56c7a44bea1a3be2dc29608d6a837`.
+- Torghut live, sim, options catalog, options enricher, TA, websocket, guardrail exporters, and ClickHouse pods were
+  running. Several old profit feedback and whitepaper autoresearch pods were failed, with exit codes including `2`,
+  `127`, `143`, `255`, and wait-container artifact errors. Those failed pods are not serving-blocking, but they are
+  evidence that profit-feedback and autoresearch runners should not be treated as healthy proof sources.
+- Recent Torghut events showed execution TCA refresh jobs completing every five minutes. Revenue repair still reported
+  `latest_execution_created_at=2026-04-02T19:00:29.586040+00:00`, so a recent refresh job alone does not prove active
+  execution samples are current.
+
+### Jangar Control-Plane Evidence
+
+- Jangar `/ready` returned `status=ok`, leader election healthy, and `execution_trust.status=healthy`.
+- Jangar control-plane status reported `dependency_quorum.decision=block`.
+- `verify_trust_foreclosure_board` was present and fresh, but material actions still blocked dispatch repair with
+  reasons including `source_rollout_truth_split`, `controller_witness_stale`, `torghut_no_delta_active`,
+  `jangar_verification_carry_unavailable`, `jangar_controller_ingestion_settlement_missing`, and
+  `revenue_repair_settlement_custody_deny`.
+- `controller_ingestion_settlement` was present with `decision=hold`, `agentrun_ingestion_current=false`,
+  `source_serving_status=block`, `torghut_verification_carry_status=unavailable`, and selected repair reason codes
+  `source_serving_block` and `torghut_verification_carry_unavailable`.
+
+### Torghut Business Evidence
+
+- `/trading/revenue-repair` returned `business_state=repair_only`, `revenue_ready=false`, `route_state=repair_only`,
+  `capital_state=zero_notional`, and `max_notional=0`.
+- The active source commit in revenue repair was `03213d0bd7f1be055cafc3031c1b792ade249dd4`.
+- The top repair queue item remained `repair_alpha_readiness` with reason
+  `alpha_readiness_not_promotion_eligible`, value gate `routeable_candidate_count`, required output
+  `torghut.executable-alpha-receipts.v1`, and `max_notional=0`.
+- Torghut emitted `jangar_controller_ingestion_carry.carry_state=lagging` with source settlement ref
+  `controller-ingestion-settlement:*`, verification board ref `verify-trust-foreclosure-board:*`, repair-slot escrow
+  ref `repair-slot-escrow:*`, and reason codes including `empirical_jobs_degraded`, `source_serving_block`,
+  `torghut_verification_carry_unavailable`, `jangar_controller_ingestion_hold`, and
+  `jangar_controller_ingestion_lagging`.
+- Route evidence books reported source freshness current, execution freshness held, rollout image held because
+  `route_adjacent_workload_proof_missing`, profit-window custody held, and capital held.
+- The execution book had `order_count=5388`, `filled_execution_count=5353`, a fresh computation timestamp, but the
+  newest execution sample remained more than 3.6 million seconds old.
+- `/trading/consumer-evidence` exposed a compact controller-ingestion carry ref, but the active no-delta auction still
+  denied reentry and selected no ticket.
+
+### Database And Data Evidence
+
+- `/db-check` returned `ok=true`, `schema_current=true`, and `schema_graph_lineage_ready=true`.
+- CNPG cluster reads were blocked by RBAC:
+  `clusters.postgresql.cnpg.io is forbidden` for the `agents-sa` service account in namespace `torghut`.
+- Direct Postgres exec was blocked by RBAC:
+  `pods/exec` forbidden on `torghut-db-1`.
+- I am treating that access boundary as correct for swarm workers. Jangar should depend on typed service evidence and
+  database health endpoints, not privileged direct database reads.
+
+### Source And Test Surface
+
+- Recent merged source history includes:
+  - `feat(torghut): import controller ingestion carry`;
+  - `fix(torghut): import jangar controller carry evidence`;
+  - `fix(torghut): restrict jangar carry repair tickets`.
+- Relevant Torghut tests now cover controller-ingestion carry classification, no-delta reentry selection and denial,
+  revenue repair digest assembly, and consumer evidence exposure.
+- High-risk modules for the next slice are Torghut `revenue_repair.py`, `evidence_clock_arbiter.py`,
+  `no_delta_repair_reentry_auction.py`, `jangar_controller_ingestion_carry.py`, and Jangar control-plane status,
+  stage-clearance, revenue-repair settlement custody, and Torghut evidence normalizers.
+
+## Problem
+
+The system can now say that Jangar carry exists and is lagging. It cannot yet say which route-adjacent proof must be
+current before alpha reentry can make a routeable candidate. That leaves three failure modes:
+
+1. Argo and Knative can look healthy while route-adjacent workload proof is missing.
+2. TCA refresh jobs can complete while active execution samples remain stale.
+3. No-delta alpha reentry can stay denied without a bounded repair ticket that names the route-adjacent proof gap.
+
+The next architecture has to connect those surfaces without weakening the capital gate.
+
+## Alternatives Considered
+
+### Option A: Treat Argo Healthy And Revision Match As Route Proof
+
+Jangar would accept Synced/Healthy Argo apps and live Torghut revision as enough proof to clear route-adjacent workload
+debt.
+
+Advantages:
+
+- Minimal implementation cost.
+- Fast deployer handoff.
+- Easy for operators to understand.
+
+Disadvantages:
+
+- Live evidence disproves it. Argo is healthy while revenue repair still emits `route_adjacent_workload_proof_missing`.
+- It ignores options catalog/enricher, sim, TCA refresh, and old failed profit-feedback pods.
+- It could clear a capital safety hold from deployment health alone.
+
+Decision: reject.
+
+### Option B: Dispatch Execution TCA Refresh First
+
+Jangar would select execution freshness repair whenever active-session samples are stale.
+
+Advantages:
+
+- Directly maps to `fill_tca_or_slippage_quality`.
+- There is already a TCA refresh cron surface.
+- It is bounded and zero-notional.
+
+Disadvantages:
+
+- It does not retire route-adjacent workload proof.
+- Recent refresh jobs are already completing without making active execution samples current.
+- It can burn repair slots while the top queue item remains alpha readiness.
+
+Decision: reject as the sole architecture. Keep it as one input to custody.
+
+### Option C: Route-Adjacent Proof Custody With Bounded Reentry Admission
+
+Jangar emits a route-adjacent custody object and admits a zero-notional Torghut repair only when that object names a
+specific missing proof.
+
+Advantages:
+
+- Targets the live blocker without broad dispatch.
+- Separates serving health from material route proof.
+- Gives deployers one acceptance object after image promotion.
+- Keeps no-delta alpha repair denied until the release condition changes.
+- Maintains `max_notional=0`.
+
+Disadvantages:
+
+- Adds a new reducer and companion Torghut import.
+- Requires tests across Argo, Torghut evidence, and execution freshness.
+- It may hold otherwise useful empirical or market-context repairs until route-adjacent proof is settled.
+
+Decision: select Option C.
+
+## Architecture
+
+Jangar adds `jangar.route-adjacent-proof-custody.v1` to control-plane status and later to `/ready` after the payload is
+small enough for the hot path.
+
+Proposed schema:
+
+```yaml
+schema_version: jangar.route-adjacent-proof-custody.v1
+custody_id: route-adjacent-proof-custody:<namespace>:<digest>
+mode: observe|shadow|enforce
+generated_at: <iso8601>
+fresh_until: <iso8601>
+namespace: agents
+decision: allow|repair_only|hold|block
+source_commit: <torghut source commit>
+argo_revision: <gitops revision>
+serving_revision: <torghut active revision>
+serving_image_digest: <digest>
+route_adjacent_workloads:
+  torghut_live: current|missing|stale|split
+  torghut_sim: current|missing|stale|split
+  options_catalog: current|missing|stale|split
+  options_enricher: current|missing|stale|split
+  execution_tca_refresh: current|missing|stale|split
+execution_freshness:
+  state: current|stale|missing|non_promoting
+  latest_execution_created_at: <iso8601|null>
+  computed_at: <iso8601|null>
+  avg_abs_slippage_bps: <number|null>
+torghut_revenue_repair_ref: <route evidence clearinghouse id>
+controller_ingestion_carry_ref: <carry id>
+selected_repair_ticket:
+  ticket_class: route_adjacent_proof|execution_freshness|none
+  target_value_gate: routeable_candidate_count|fill_tca_or_slippage_quality|capital_gate_safety
+  required_output_receipt: <receipt schema>
+  validation_commands: []
+  max_notional: '0'
+reason_codes: []
+rollback_target: <string>
+```
+
+Decision rules:
+
+- `allow`: all route-adjacent workloads are current, execution freshness is current, controller-ingestion carry is
+  current or repairable, and Torghut remains zero-notional until separate capital gates pass.
+- `repair_only`: exactly one missing proof can be repaired with a bounded zero-notional ticket.
+- `hold`: proof is stale, broad, or ambiguous, or Torghut no-delta debt is active without a changed release condition.
+- `block`: proof is contradictory, source/serving digests split in a way that cannot be reconciled, or any nonzero
+  notional path is requested.
+
+Jangar stage clearance consumes the object this way:
+
+- `serve_readonly`: allow when Jangar serving health is ok.
+- `torghut_observe`: allow when Torghut revenue repair is reachable.
+- `dispatch_repair`: allow only for the selected zero-notional ticket when `decision=repair_only`.
+- `dispatch_normal`, `paper_canary`, `live_micro_canary`, `live_scale`, `deploy_widen`: hold or block until
+  `decision=allow` and Torghut capital gates independently pass.
+- `merge_ready`: remains governed by PR checks, but deployer handoffs must cite the custody object before claiming
+  revenue-readiness movement.
+
+## Implementation Scope
+
+Engineer stage should implement the smallest production slice:
+
+1. Add the Jangar route-adjacent custody reducer and tests for current, repair-only, hold, and contradiction states.
+2. Add a compact ref to control-plane status; defer `/ready` until payload size and latency are proven.
+3. Add Torghut import support for the custody ref in revenue repair and consumer evidence.
+4. Convert `route_adjacent_workload_proof_missing` into a selected zero-notional ticket only when custody says the
+   ticket is repairable.
+5. Keep `max_notional=0`, live submit disabled, and no paper widening throughout the slice.
+
+Do not implement broker submission, capital widening, or a generic empirical runner in this milestone.
+
+## Validation Gates
+
+Required local checks for the next implementation PR:
+
+- Jangar targeted tests for route-adjacent custody and stage clearance admission.
+- Torghut targeted tests for revenue repair digest, consumer evidence import, and no-delta reentry denial/selection.
+- Format and lint checks for touched TypeScript and Python files.
+- For `services/torghut`, all three Pyright profiles must pass when Python source changes:
+  `pyrightconfig.json`, `pyrightconfig.alpha.json`, and `pyrightconfig.scripts.json`.
+
+Required live verification after promotion:
+
+- Argo `agents`, `jangar`, and `torghut` are `Synced/Healthy`.
+- Jangar status emits `route_adjacent_proof_custody` with a fresh `custody_id`.
+- Torghut `/trading/revenue-repair` emits the custody ref and no longer reports
+  `route_adjacent_workload_proof_missing` if the selected proof is current.
+- `routeable_candidate_count` is still `0` or improved with an explicit reason; no silent promotion is allowed.
+- `capital_state=zero_notional`, `max_notional=0`, and live submit remains disabled until capital gates pass.
+
+## Rollout
+
+Roll out in observe mode first:
+
+1. Merge the Jangar/Torghut implementation PR with green CI.
+2. Let CI build and promote images through the existing GitOps pipeline.
+3. Verify Argo sync and workload readiness.
+4. Verify Jangar status and Torghut revenue repair surfaces.
+5. Move from observe to shadow only after the custody object is stable across at least two refresh windows.
+6. Consider enforce only after a repair-only ticket retires a named blocker without increasing notional.
+
+## Rollback
+
+Rollback is fail-closed:
+
+- Stop emitting `route_adjacent_proof_custody`.
+- Torghut treats missing custody as `hold`, preserves existing controller-ingestion carry behavior, and keeps
+  no-delta reentry denied.
+- Jangar stage clearance falls back to existing controller-ingestion settlement, verification foreclosure board, and
+  revenue-repair settlement custody.
+- Capital remains zero-notional.
+
+## Risks
+
+- A reducer that overtrusts Argo health could clear a proof hold without fresh execution samples. Tests must include
+  healthy Argo with stale executions.
+- A reducer that overtrusts TCA cron completion could clear a stale execution sample hold. Tests must include a fresh
+  computation timestamp with old `latest_execution_created_at`.
+- Old failed profit-feedback pods can create noisy evidence. The reducer should ignore terminal historical pods unless
+  they are selected proof sources for the active ticket.
+- Direct database access is intentionally unavailable to normal swarm workers. The architecture must keep using typed
+  service evidence, not privileged SQL.
+
+## Handoff
+
+Engineer: implement the route-adjacent custody reducer and Torghut import as a zero-notional production slice. Cite
+this doc and the companion Torghut doc before changing code. The first revenue metric to move is
+`zero_notional_or_stale_evidence_rate`; the next route metric is `routeable_candidate_count`.
+
+Deployer: after merge and promotion, verify the custody object is fresh, Argo is healthy, Torghut revenue repair still
+holds capital at zero notional, and either `route_adjacent_workload_proof_missing` is retired or the exact remaining
+reason is named.

--- a/docs/torghut/README.md
+++ b/docs/torghut/README.md
@@ -4,6 +4,10 @@
 
 Start here:
 
+- `docs/agents/designs/206-jangar-route-adjacent-proof-custody-and-torghut-reentry-admission-2026-05-14.md`
+  (current Jangar route-adjacent proof custody and Torghut reentry admission contract)
+- `docs/torghut/design-system/v6/212-torghut-route-adjacent-proof-and-execution-freshness-reentry-2026-05-14.md`
+  (current Torghut route-adjacent proof and execution-freshness reentry contract)
 - `docs/agents/designs/204-jangar-source-bound-verification-carry-exchange-and-repair-slot-reconciliation-2026-05-14.md`
   (current Jangar source-bound verification carry exchange and repair-slot reconciliation contract)
 - `docs/torghut/design-system/v6/210-torghut-source-bound-verification-carry-import-and-no-delta-release-2026-05-14.md`

--- a/docs/torghut/design-system/v6/212-torghut-route-adjacent-proof-and-execution-freshness-reentry-2026-05-14.md
+++ b/docs/torghut/design-system/v6/212-torghut-route-adjacent-proof-and-execution-freshness-reentry-2026-05-14.md
@@ -1,0 +1,370 @@
+# 212. Torghut Route-Adjacent Proof And Execution-Freshness Reentry (2026-05-14)
+
+Status: Accepted for engineer and deployer handoff
+Date: 2026-05-14
+Owner: Gideon Park, Torghut Traders Architecture
+Scope: Torghut route-adjacent workload proof, execution freshness, alpha-readiness no-delta reentry, zero-notional
+repair lots, validation gates, rollout, rollback, and cross-swarm handoff.
+
+Companion Jangar contract:
+
+- `docs/agents/designs/206-jangar-route-adjacent-proof-custody-and-torghut-reentry-admission-2026-05-14.md`
+
+Extends:
+
+- `211-torghut-controller-ingestion-carry-and-alpha-no-delta-release-2026-05-14.md`
+- `210-torghut-source-bound-verification-carry-import-and-no-delta-release-2026-05-14.md`
+- `209-torghut-verification-carry-import-and-alpha-repair-release-2026-05-14.md`
+- `208-torghut-jangar-verification-carry-bridge-and-no-delta-reentry-market-2026-05-14.md`
+- `206-torghut-no-delta-repair-reentry-auction-and-verification-carry-2026-05-14.md`
+- `205-torghut-alpha-readiness-settlement-conveyor-and-routeable-profit-runway-2026-05-14.md`
+- `188-torghut-evidence-clock-arbiter-and-routeable-profit-candidate-exchange-2026-05-12.md`
+- `186-torghut-routeability-acceptance-cutover-and-fill-quality-loop-2026-05-08.md`
+
+## Decision
+
+I am selecting **route-adjacent proof plus execution-freshness reentry** as Torghut's next architecture slice.
+
+The current live system is safer than it was earlier today, but it is still not revenue-ready. Controller-ingestion
+carry is no longer absent; `/trading/revenue-repair` now emits it and classifies it as `lagging`. That is progress.
+The profit blocker has moved to the next boundary: Torghut cannot prove that the active route-adjacent workloads and
+active-session execution samples are fresh enough to let alpha-readiness repair produce a routeable candidate.
+
+The evidence is concrete. `/trading/revenue-repair` is `repair_only`, `revenue_ready=false`, `capital_state=zero_notional`,
+and `max_notional=0`. The top queue item is still `repair_alpha_readiness`, reason
+`alpha_readiness_not_promotion_eligible`, value gate `routeable_candidate_count`, and required output
+`torghut.executable-alpha-receipts.v1`. The route evidence clearinghouse says source freshness is current, but execution
+freshness is held for stale active-session execution samples, rollout image proof is held for
+`route_adjacent_workload_proof_missing`, profit-window custody is held, and capital is held. The execution book has
+fresh computation, but its newest execution sample is from 2026-04-02.
+
+The selected design adds a Torghut-side proof import and repair ticket model. Torghut should consume Jangar's
+route-adjacent custody object, convert it into `torghut.route-adjacent-workload-proof.v1`, and let no-delta reentry
+select exactly one zero-notional ticket when the missing proof is repairable. The first implementation should target
+`zero_notional_or_stale_evidence_rate` and `fill_tca_or_slippage_quality`; only after those move should we expect
+`routeable_candidate_count` to improve.
+
+The tradeoff is that H-MICRO-01 remains denied while proof is lagging. I accept that. A repeat alpha launch against an
+unchanged no-delta key is not innovation; it is churn. The leverage is to make the next repair receipt attributable
+enough that routeability can move without touching live capital.
+
+## Governing Runtime Requirements
+
+This design is the governing Torghut requirement for the next implementation stage:
+
+- every code-changing run must cite this doc or the companion Jangar doc;
+- implementation PRs must improve data freshness, execution quality, routeability evidence, or capital safety;
+- verification must prove image promotion, Argo sync, live service health, and revenue-repair status after rollout;
+- final handoff must name the revenue metric improved or the smallest blocker preventing revenue impact.
+
+Value-gate mapping:
+
+- `post_cost_daily_net_pnl`: no direct movement in this slice; it remains blocked until routeable candidates exist and
+  capital gates pass.
+- `routeable_candidate_count`: the selected alpha-readiness repair remains H-MICRO-01 or its successor, and it must
+  show a changed release condition before another zero-delta alpha launch is allowed.
+- `zero_notional_or_stale_evidence_rate`: route-adjacent workload proof and execution freshness must become current
+  before stale-evidence debt can fall.
+- `fill_tca_or_slippage_quality`: active-session execution sample age, missing expected-shortfall samples, and slippage
+  guardrail state are first-class gates.
+- `capital_gate_safety`: every repair stays `max_notional=0`; live submit and paper widening remain disabled.
+
+## Current Assessment
+
+All evidence was collected read-only on 2026-05-14 between 20:24Z and 20:27Z.
+
+### Cluster Assessment
+
+- Argo reported `agents`, `jangar`, and `torghut` as `Synced/Healthy` at
+  `57095de61842f69a8dce99b09afec438c46a5945`.
+- Torghut live revision `torghut-00417` was running with `2/2` containers ready. Torghut sim revision
+  `torghut-sim-00512`, options catalog, options enricher, TA, websocket, ClickHouse, and guardrail exporter pods were
+  running.
+- Recent events showed execution TCA refresh jobs starting and completing every five minutes.
+- Several old profit-feedback and whitepaper autoresearch pods were failed. Those failures explain why empirical and
+  profit-feedback evidence should be treated as debt until selected receipts prove otherwise.
+
+### Source Assessment
+
+- The current branch is based on main `57095de61842f69a8dce99b09afec438c46a5945`.
+- The relevant merged Torghut history includes controller-ingestion carry import, Jangar carry evidence import,
+  no-delta repair reentry auction, and carry ticket restriction fixes.
+- High-risk modules for the next implementation are:
+  - `services/torghut/app/trading/revenue_repair.py`;
+  - `services/torghut/app/trading/evidence_clock_arbiter.py`;
+  - `services/torghut/app/trading/no_delta_repair_reentry_auction.py`;
+  - `services/torghut/app/trading/jangar_controller_ingestion_carry.py`;
+  - `services/torghut/tests/test_build_revenue_repair_digest.py`;
+  - `services/torghut/tests/test_no_delta_repair_reentry_auction.py`.
+- Existing tests already protect digest assembly, no-delta selection, controller-ingestion carry classification, and
+  consumer evidence exposure. The missing regression family is route-adjacent proof custody: healthy Argo with missing
+  route proof, fresh TCA computation with stale execution samples, repairable route proof selected, contradictory proof
+  denied, and capital held throughout.
+
+### Database And Data Assessment
+
+- `/db-check` returned `ok=true`, `schema_current=true`, and `schema_graph_lineage_ready=true`.
+- Direct CNPG cluster reads and Postgres exec are blocked for the swarm worker by RBAC. That is acceptable for this
+  role and should not be bypassed for normal planning or verification.
+- Revenue repair is the live business evidence surface. It reports:
+  - `business_state=repair_only`;
+  - `revenue_ready=false`;
+  - `route_state=repair_only`;
+  - `capital_state=zero_notional`;
+  - `max_notional=0`;
+  - source freshness `current`;
+  - execution freshness `hold`;
+  - rollout image proof `hold`;
+  - profit-window custody `hold`;
+  - capital hold `hold`.
+- Execution freshness details are internally inconsistent in a useful way: `last_computed_at` is fresh, but
+  `latest_execution_created_at=2026-04-02T19:00:29.586040+00:00`. The next repair must prove fresh samples, not only a
+  successful refresh job.
+
+### Business Evidence
+
+- The active top queue item is `repair_alpha_readiness`, reason `alpha_readiness_not_promotion_eligible`, value gate
+  `routeable_candidate_count`, required output `torghut.executable-alpha-receipts.v1`, `max_notional=0`.
+- Controller-ingestion carry is present with `carry_state=lagging`, settlement decision `hold`, and reasons including
+  `source_serving_block`, `torghut_verification_carry_unavailable`, and `empirical_jobs_degraded`.
+- No-delta reentry remains denied. The selected ticket is `none`.
+- The repair bid book names top zero-notional debts across forecast registry, autoresearch candidates, hypothesis
+  promotion eligibility, empirical jobs, simple submit, alpha readiness, execution TCA, and route-adjacent workload
+  proof.
+
+## Problem
+
+Torghut has enough source and controller evidence to know that the previous blocker evolved, but it cannot yet retire
+the route-adjacent and execution freshness blockers. The current model still allows four bad interpretations:
+
+1. A healthy Argo application can be mistaken for fresh route proof.
+2. A completed TCA cron job can be mistaken for current active-session execution samples.
+3. A lagging Jangar carry state can be mistaken for a changed no-delta release condition.
+4. A broad empirical repair can consume capacity while the top alpha-readiness routeability queue stays unchanged.
+
+The architecture must make those interpretations impossible.
+
+## Alternatives Considered
+
+### Option A: Prioritize Empirical Jobs
+
+Torghut would route the next engineer stage to repair empirical job readiness and autoresearch candidates.
+
+Advantages:
+
+- Empirical jobs are visible in the repair queue.
+- Failed profit and whitepaper pods show real debt.
+- It could improve future post-cost PnL evidence.
+
+Disadvantages:
+
+- It does not clear `route_adjacent_workload_proof_missing`.
+- It does not address stale active-session execution samples.
+- It can leave H-MICRO-01 with zero routeable candidates.
+
+Decision: reject as the next architecture slice, but keep as a later repair once route-adjacent proof is settled.
+
+### Option B: Run Another Alpha-Readiness Repair
+
+Torghut would re-run H-MICRO-01 alpha readiness after the controller-ingestion carry changes.
+
+Advantages:
+
+- It directly targets the top queue item.
+- It keeps the value gate focused on `routeable_candidate_count`.
+- It is easy to explain to the business owner.
+
+Disadvantages:
+
+- Live no-delta reentry says the release key is still active and selected ticket is none.
+- Carry is `lagging`, not current or repairable.
+- It risks another zero-delta launch without retiring the proof gap.
+
+Decision: reject until route-adjacent proof or execution freshness changes.
+
+### Option C: Route-Adjacent Proof Plus Execution-Freshness Reentry
+
+Torghut imports route-adjacent proof custody, models active-session execution freshness explicitly, and only selects a
+zero-notional no-delta reentry ticket when a missing proof can be repaired.
+
+Advantages:
+
+- It targets the live proof blockers.
+- It preserves capital safety.
+- It gives Jangar and deployer stages a single acceptance surface.
+- It creates measurable movement before asking routeable candidates to change.
+- It is robust to healthy Argo with stale execution data.
+
+Disadvantages:
+
+- It adds another import and compact receipt path.
+- It requires careful tests around stale samples and source/serving split.
+- It can hold alpha repair longer than operators may want.
+
+Decision: select Option C.
+
+## Architecture
+
+Torghut adds three additive evidence contracts.
+
+### Route-Adjacent Workload Proof
+
+`torghut.route-adjacent-workload-proof.v1` is a compact import from Jangar custody plus local runtime facts.
+
+```yaml
+schema_version: torghut.route-adjacent-workload-proof.v1
+proof_id: route-adjacent-workload-proof:<digest>
+generated_at: <iso8601>
+fresh_until: <iso8601>
+source_jangar_custody_ref: <id|null>
+source_commit: <sha>
+serving_revision: <revision>
+serving_image_digest: <digest>
+workloads:
+  torghut_live: current|missing|stale|split
+  torghut_sim: current|missing|stale|split
+  options_catalog: current|missing|stale|split
+  options_enricher: current|missing|stale|split
+  execution_tca_refresh: current|missing|stale|split
+state: current|repairable|hold|block
+reason_codes: []
+max_notional: '0'
+rollback_target: <string>
+```
+
+### Execution Freshness Sweep
+
+`torghut.execution-freshness-sweep-receipt.v1` proves that active-session execution samples, expected-shortfall inputs,
+and slippage quality are current.
+
+```yaml
+schema_version: torghut.execution-freshness-sweep-receipt.v1
+receipt_id: execution-freshness-sweep:<digest>
+generated_at: <iso8601>
+account_id: <account>
+window: <window>
+latest_execution_created_at: <iso8601|null>
+last_computed_at: <iso8601|null>
+max_age_seconds: <number>
+avg_abs_slippage_bps: <number|null>
+expected_shortfall_sample_count: <number>
+state: current|stale|missing|non_promoting
+value_gate: fill_tca_or_slippage_quality
+max_notional: '0'
+reason_codes: []
+```
+
+### Reentry Ticket
+
+`torghut.route-adjacent-reentry-ticket.v1` is the only ticket no-delta reentry can select from this design.
+
+```yaml
+schema_version: torghut.route-adjacent-reentry-ticket.v1
+ticket_id: route-adjacent-reentry-ticket:<digest>
+selected_queue_code: repair_alpha_readiness
+selected_value_gate: routeable_candidate_count
+repair_class: route_adjacent_proof|execution_freshness
+required_output_receipt: torghut.route-adjacent-workload-proof.v1|torghut.execution-freshness-sweep-receipt.v1
+release_condition: route_adjacent_proof_current|active_execution_samples_current
+max_notional: '0'
+validation_commands: []
+```
+
+No-delta reentry rules:
+
+1. Deny repeat alpha repair while `carry_state=lagging`, route-adjacent proof is missing, and active execution samples
+   are stale.
+2. Select one route-adjacent or execution freshness ticket only when the imported proof says the ticket is repairable.
+3. Do not select empirical, market-context, or submit-gate repair ahead of the top alpha-readiness queue unless the
+   live top queue changes.
+4. Keep all selected tickets zero-notional.
+5. Treat missing Jangar custody as hold, not allow.
+
+## Implementation Milestones
+
+Milestone 1: custody import and digest exposure.
+
+- Value gates: `zero_notional_or_stale_evidence_rate`, `capital_gate_safety`.
+- Add Torghut import and compact ref for Jangar route-adjacent custody.
+- Expose it in `/trading/revenue-repair` and `/trading/consumer-evidence`.
+- Add tests for missing, stale, repairable, current, and contradictory custody.
+
+Milestone 2: execution freshness sweep.
+
+- Value gates: `fill_tca_or_slippage_quality`, `zero_notional_or_stale_evidence_rate`.
+- Prove active-session sample age and expected-shortfall sample count separately from cron job recency.
+- Add tests for fresh computation with stale executions.
+
+Milestone 3: no-delta reentry selection.
+
+- Value gates: `routeable_candidate_count`, `capital_gate_safety`.
+- Permit exactly one zero-notional route-adjacent or execution freshness ticket when a release condition changes.
+- Deny alpha re-run until the selected receipt is current.
+
+Milestone 4: deployer verification.
+
+- Value gates: all five, with no direct `post_cost_daily_net_pnl` claim unless routeable candidates and capital gates
+  move.
+- Verify Argo sync, service health, image promotion, revenue repair, consumer evidence, and zero-notional capital.
+
+## Validation Gates
+
+Local validation for implementation PRs:
+
+- `uv sync --frozen --extra dev` in `services/torghut`.
+- Targeted pytest for revenue repair digest, consumer evidence, no-delta reentry, and the new proof models.
+- Ruff check and format check for touched Python.
+- Pyright with all three Torghut profiles if Python source changes.
+- Jangar targeted TypeScript tests if the companion custody reducer changes Jangar code.
+
+Runtime validation after promotion:
+
+- Argo `agents`, `jangar`, and `torghut` are `Synced/Healthy`.
+- Torghut active revision and image digest match the promoted source.
+- `/db-check` remains `ok=true`, `schema_current=true`, and `schema_graph_lineage_ready=true`.
+- `/trading/revenue-repair` emits route-adjacent proof and execution freshness receipts.
+- `route_adjacent_workload_proof_missing` and active execution sample staleness either retire or are preserved with a
+  named blocker.
+- `capital_state=zero_notional`, `max_notional=0`, and live submission remains disabled.
+
+## Rollout
+
+Roll out observe-mode evidence first:
+
+1. Merge Jangar custody and Torghut import code with green CI.
+2. Promote through the existing CI/CD and GitOps pipeline.
+3. Verify Argo and workload readiness.
+4. Verify revenue repair, consumer evidence, and db-check.
+5. Hold no-delta selection until at least one fresh custody window agrees across Jangar and Torghut.
+6. Enable no-delta ticket selection only for zero-notional route-adjacent or execution freshness repair.
+
+## Rollback
+
+Rollback is a deletion or feature flag rollback of the additive evidence:
+
+- Stop emitting route-adjacent custody from Jangar.
+- Torghut treats missing custody as hold and keeps controller-ingestion carry plus no-delta auction behavior.
+- Remove route-adjacent ticket selection from no-delta reentry.
+- Keep existing alpha-readiness settlement, dividend ledger, and capital hold intact.
+- Capital remains zero-notional.
+
+## Risks
+
+- Healthy workload status can hide stale data. Validation must compare active execution sample age, not just pod
+  readiness.
+- Failed historical profit jobs can pollute the proof surface. Only active selected proof sources should affect the
+  custody decision.
+- A route proof receipt can reduce stale-evidence debt without moving routeable candidates. That is acceptable for the
+  first slice, but the handoff must avoid claiming PnL impact until routeable candidates and capital gates move.
+- Direct database access is unavailable by design. If db-check and typed evidence disagree, typed evidence wins for
+  capital safety and the database mismatch is a blocker.
+
+## Handoff
+
+Engineer: implement milestones 1 and 2 as one bounded production PR only if the diff stays small. Otherwise implement
+milestone 1 first. Cite this design before changing Torghut code. The smallest acceptable revenue movement is retiring
+`route_adjacent_workload_proof_missing` or reducing stale-evidence debt while capital remains zero-notional.
+
+Deployer: after promotion, verify Argo sync, active revision, `/db-check`, `/trading/revenue-repair`, and
+`/trading/consumer-evidence`. Do not claim live trading readiness until routeable candidates are nonzero, TCA quality is
+current, and capital gates independently authorize notional.

--- a/docs/torghut/design-system/v6/index.md
+++ b/docs/torghut/design-system/v6/index.md
@@ -12,7 +12,9 @@
 - Implementation status (strict, core 01-13 docs, source-state refresh `2026-03-09`): `Implemented=7`, `Partial=5`,
   `Completed=1`
 - Evidence (historical closure): `13-production-gap-closure-master-plan-2026-03-03.md` (Wave 0-6 closure + DoD)
-- Evidence (current next-work priority, refreshed `2026-05-14T20:12Z`):
+- Evidence (current next-work priority, refreshed `2026-05-14T20:27Z`):
+  - `docs/agents/designs/206-jangar-route-adjacent-proof-custody-and-torghut-reentry-admission-2026-05-14.md`
+  - `212-torghut-route-adjacent-proof-and-execution-freshness-reentry-2026-05-14.md`
   - `docs/agents/designs/206-jangar-consumer-evidence-parity-settlement-and-alpha-release-custody-2026-05-14.md`
   - `212-torghut-consumer-evidence-parity-and-alpha-release-freshness-2026-05-14.md`
   - `docs/agents/designs/205-jangar-controller-ingestion-settlement-and-verification-carry-cutover-2026-05-14.md`


### PR DESCRIPTION
## Summary

- Adds Jangar design 206 for route-adjacent proof custody and bounded Torghut reentry admission.
- Adds Torghut design 212 for route-adjacent workload proof, execution freshness receipts, and zero-notional no-delta
  reentry tickets.
- Refreshes the Agents and Torghut design indexes so the new contracts are the current entrypoints.

## Related Issues

None. Swarm mission: `torghut-quant`.

## Testing

- `bunx oxfmt --check docs/agents/README.md docs/agents/designs/206-jangar-route-adjacent-proof-custody-and-torghut-reentry-admission-2026-05-14.md docs/torghut/README.md docs/torghut/design-system/v6/index.md docs/torghut/design-system/v6/212-torghut-route-adjacent-proof-and-execution-freshness-reentry-2026-05-14.md`: pass.
- `git diff --check`: pass.
- Rebase validation after main moved to `f4fd8f35bb7d24a9e50766700327556656896918`: pass; resolved the Torghut v6
  index by keeping both the new consumer-evidence parity entries from main and this PR's route-adjacent proof entries.
- `kubectl get applications.argoproj.io -n argocd agents jangar torghut -o json | jq '[.items[] | {name:.metadata.name, sync:.status.sync.status, health:.status.health.status, revision:.status.sync.revision, reconciledAt:.status.reconciledAt}]'`: pass; all three apps were `Synced/Healthy` at `57095de61842f69a8dce99b09afec438c46a5945`.
- `curl -fsS http://torghut.torghut.svc.cluster.local/db-check | jq '{ok, schema_current, schema_graph_lineage_ready}'`: pass; all values were `true`.
- `curl -fsS http://torghut.torghut.svc.cluster.local/trading/revenue-repair | jq '{business_state,revenue_ready,repair_queue:(.repair_queue[0:5]),jangar_controller_ingestion_carry,no_delta_repair_reentry_auction:{decision:.no_delta_repair_reentry_auction.reentry_decision, reason_codes:.no_delta_repair_reentry_auction.reason_codes}}'`: pass; live state was `repair_only`, `revenue_ready=false`, controller-ingestion carry was `lagging`, and capital remained zero-notional.
- Direct CNPG and Postgres checks were attempted read-only and blocked by RBAC for `agents-sa`; the docs record the exact access boundary and use typed service evidence instead.

## Screenshots (if applicable)

N/A.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
