### PR TITLE
fix(torghut): allow bounded paper route probes

### DIFF
--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -105,6 +105,10 @@ spec:
               value: "true"
             - name: TRADING_SIMPLE_ORDER_FEED_TELEMETRY_ENABLED
               value: "false"
+            - name: TRADING_SIMPLE_PAPER_ROUTE_PROBE_ENABLED
+              value: "true"
+            - name: TRADING_SIMPLE_PAPER_ROUTE_PROBE_MAX_NOTIONAL
+              value: "25"
             - name: TRADING_KILL_SWITCH_ENABLED
               value: "false"
             - name: TRADING_FEATURE_FLAGS_ENABLED

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -89,6 +89,8 @@ spec:
               value: "false"
             - name: TRADING_SIMPLE_ORDER_FEED_TELEMETRY_ENABLED
               value: "false"
+            - name: TRADING_SIMPLE_PAPER_ROUTE_PROBE_ENABLED
+              value: "false"
             - name: TRADING_MARKET_CONTEXT_URL
               value: http://jangar.jangar.svc.cluster.local/api/torghut/market-context
             - name: TRADING_JANGAR_CONTROL_PLANE_STATUS_URL

--- a/services/torghut/app/config.py
+++ b/services/torghut/app/config.py
@@ -1391,6 +1391,19 @@ class Settings(BaseSettings):
         alias="TRADING_SIMPLE_ORDER_FEED_TELEMETRY_ENABLED",
         description="In simple mode, keep Kafka order-feed ingestion only as optional telemetry.",
     )
+    trading_simple_paper_route_probe_enabled: bool = Field(
+        default=False,
+        alias="TRADING_SIMPLE_PAPER_ROUTE_PROBE_ENABLED",
+        description=(
+            "Permit bounded paper-only route-acquisition probes when the proof floor "
+            "is zero-notional because route/TCA evidence must be rebuilt."
+        ),
+    )
+    trading_simple_paper_route_probe_max_notional: float = Field(
+        default=25.0,
+        alias="TRADING_SIMPLE_PAPER_ROUTE_PROBE_MAX_NOTIONAL",
+        description="Maximum notional per paper route-acquisition probe order.",
+    )
     trading_emergency_stop_enabled: bool = Field(
         default=False,
         alias="TRADING_EMERGENCY_STOP_ENABLED",
@@ -2286,6 +2299,10 @@ class Settings(BaseSettings):
             (
                 self.trading_simple_buying_power_reserve_bps,
                 "TRADING_SIMPLE_BUYING_POWER_RESERVE_BPS must be >= 0",
+            ),
+            (
+                self.trading_simple_paper_route_probe_max_notional,
+                "TRADING_SIMPLE_PAPER_ROUTE_PROBE_MAX_NOTIONAL must be >= 0",
             ),
             (
                 self.trading_readiness_dependency_cache_stale_tolerance_seconds,

--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Mapping
 from datetime import datetime, timedelta, timezone
-from decimal import Decimal
+from decimal import Decimal, ROUND_DOWN
 from typing import Any, Optional, cast
 
 from sqlalchemy.orm import Session
@@ -49,8 +49,14 @@ _SIMPLE_ALLOWED_REJECT_REASONS = {
     "broker_precheck_failed",
     "broker_submit_failed",
 }
+_PAPER_ROUTE_PROBE_REASONS = {
+    "execution_tca_route_universe_empty",
+    "execution_tca_symbol_missing",
+    "tca_evidence_stale",
+}
 _PROFITABILITY_PROOF_FLOOR_TCA_MAX_AGE_SECONDS = 86_400
 _SIMPLE_MARKET_CONTEXT_RETRY_INTERVAL = timedelta(seconds=30)
+_PAPER_ROUTE_PROBE_QTY_STEP = Decimal("0.0001")
 
 
 class SimpleTradingPipeline(TradingPipeline):
@@ -506,6 +512,13 @@ class SimpleTradingPipeline(TradingPipeline):
         return None
 
     @staticmethod
+    def _proof_floor_market_session_open(proof_floor: Mapping[str, object]) -> bool:
+        market_window = proof_floor.get("market_window")
+        if not isinstance(market_window, Mapping):
+            return False
+        return bool(cast(Mapping[str, object], market_window).get("session_open"))
+
+    @staticmethod
     def _proof_floor_route_candidate_symbols(
         proof_floor: Mapping[str, object],
     ) -> set[str]:
@@ -526,6 +539,143 @@ class SimpleTradingPipeline(TradingPipeline):
             if symbol:
                 candidate_symbols.add(symbol)
         return candidate_symbols
+
+    @staticmethod
+    def _proof_floor_route_repair_symbols(
+        proof_floor: Mapping[str, object],
+    ) -> set[str]:
+        route_book = proof_floor.get("route_reacquisition_book")
+        if not isinstance(route_book, Mapping):
+            return set()
+        summary = cast(Mapping[str, Any], route_book).get("summary")
+        if not isinstance(summary, Mapping):
+            return set()
+        repair_symbols: set[str] = set()
+        for key in ("repair_candidate_symbols", "candidate_symbols"):
+            raw_symbols = cast(Mapping[str, Any], summary).get(key)
+            if not isinstance(raw_symbols, list):
+                continue
+            for raw_symbol in cast(list[object], raw_symbols):
+                symbol = str(raw_symbol).strip().upper()
+                if symbol:
+                    repair_symbols.add(symbol)
+        return repair_symbols
+
+    @staticmethod
+    def _paper_route_probe_reference_price(
+        decision: StrategyDecision,
+    ) -> Decimal | None:
+        for value in (
+            decision.limit_price,
+            decision.params.get("price"),
+            cast(Mapping[str, Any], decision.params.get("simple_lane") or {}).get(
+                "price"
+            )
+            if isinstance(decision.params.get("simple_lane"), Mapping)
+            else None,
+            cast(Mapping[str, Any], decision.params.get("price_snapshot") or {}).get(
+                "price"
+            )
+            if isinstance(decision.params.get("price_snapshot"), Mapping)
+            else None,
+        ):
+            price = _optional_decimal(value)
+            if price is not None and price > 0:
+                return price
+        return None
+
+    def _paper_route_probe_context(
+        self,
+        *,
+        proof_floor: Mapping[str, object],
+        decision: StrategyDecision,
+    ) -> dict[str, object] | None:
+        if settings.trading_mode != "paper":
+            return None
+        if not settings.trading_simple_paper_route_probe_enabled:
+            return None
+        if not settings.trading_simple_submit_enabled:
+            return None
+        if decision.action != "buy":
+            return None
+        cap = _optional_decimal(settings.trading_simple_paper_route_probe_max_notional)
+        if cap is None or cap <= 0:
+            return None
+        if not self._proof_floor_market_session_open(proof_floor):
+            return None
+
+        blocking_reasons = {
+            str(item).strip()
+            for item in cast(list[object], proof_floor.get("blocking_reasons") or [])
+            if str(item).strip()
+        }
+        if not (blocking_reasons & _PAPER_ROUTE_PROBE_REASONS):
+            return None
+
+        repair_symbols = self._proof_floor_route_repair_symbols(proof_floor)
+        symbol = decision.symbol.strip().upper()
+        if repair_symbols and symbol not in repair_symbols:
+            return None
+
+        return {
+            "enabled": True,
+            "mode": "paper_route_acquisition",
+            "max_notional": str(cap),
+            "symbol": symbol,
+            "blocking_reasons": sorted(blocking_reasons),
+            "route_repair_symbols": sorted(repair_symbols),
+        }
+
+    def _apply_paper_route_probe_cap(
+        self,
+        *,
+        session: Session,
+        decision: StrategyDecision,
+        decision_row: TradeDecision,
+        proof_floor: Mapping[str, object],
+        context: Mapping[str, object],
+    ) -> bool:
+        cap = _optional_decimal(context.get("max_notional"))
+        price = self._paper_route_probe_reference_price(decision)
+        if cap is None or cap <= 0 or price is None or price <= 0:
+            return False
+
+        capped_qty = (cap / price).quantize(
+            _PAPER_ROUTE_PROBE_QTY_STEP,
+            rounding=ROUND_DOWN,
+        )
+        if capped_qty <= 0:
+            return False
+        if decision.qty > 0:
+            capped_qty = min(decision.qty, capped_qty)
+
+        capped_notional = capped_qty * price
+        params = dict(decision.params)
+        simple_lane = dict(cast(Mapping[str, Any], params.get("simple_lane") or {}))
+        simple_lane["final_qty"] = str(capped_qty)
+        simple_lane["notional"] = str(capped_notional)
+        simple_lane["paper_route_probe_cap_applied"] = True
+        params["simple_lane"] = simple_lane
+        params["paper_route_probe"] = {
+            **dict(context),
+            "reference_price": str(price),
+            "capped_qty": str(capped_qty),
+            "capped_notional": str(capped_notional),
+            "capital_stage": str(proof_floor.get("capital_state") or "zero_notional"),
+        }
+        decision.qty = capped_qty
+        decision.params = params
+        self.executor.sync_decision_state(session, decision_row, decision)
+        self.executor.update_decision_params(session, decision_row, params)
+        logger.warning(
+            "Allowing bounded paper route-acquisition probe strategy_id=%s symbol=%s qty=%s notional=%s reasons=%s",
+            decision.strategy_id,
+            decision.symbol,
+            capped_qty,
+            capped_notional,
+            ",".join(cast(list[str], context.get("blocking_reasons") or [])),
+        )
+        return True
 
     @staticmethod
     def _proof_floor_symbol_block_reason(
@@ -588,16 +738,29 @@ class SimpleTradingPipeline(TradingPipeline):
             proof_floor
         )
         if proof_floor_block_reason is not None:
-            self._block_decision_submission(
+            probe_context = self._paper_route_probe_context(
+                proof_floor=proof_floor,
+                decision=decision,
+            )
+            if probe_context is None or not self._apply_paper_route_probe_cap(
                 session=session,
                 decision=decision,
                 decision_row=decision_row,
-                reason=proof_floor_block_reason,
-                submission_stage="blocked_profitability_proof_floor",
-                capital_stage=str(proof_floor.get("capital_state") or "zero_notional"),
-                extra_metadata={"profitability_proof_floor": dict(proof_floor)},
-            )
-            return False
+                proof_floor=proof_floor,
+                context=probe_context,
+            ):
+                self._block_decision_submission(
+                    session=session,
+                    decision=decision,
+                    decision_row=decision_row,
+                    reason=proof_floor_block_reason,
+                    submission_stage="blocked_profitability_proof_floor",
+                    capital_stage=str(
+                        proof_floor.get("capital_state") or "zero_notional"
+                    ),
+                    extra_metadata={"profitability_proof_floor": dict(proof_floor)},
+                )
+                return False
         proof_floor_symbol_block_reason = self._proof_floor_symbol_block_reason(
             proof_floor,
             decision.symbol,

--- a/services/torghut/tests/test_config.py
+++ b/services/torghut/tests/test_config.py
@@ -757,6 +757,8 @@ class TestConfig(TestCase):
             TRADING_SIMPLE_BUYING_POWER_RESERVE_BPS=50.0,
             TRADING_SIMPLE_SUBMIT_ENABLED=True,
             TRADING_SIMPLE_ORDER_FEED_TELEMETRY_ENABLED=True,
+            TRADING_SIMPLE_PAPER_ROUTE_PROBE_ENABLED=True,
+            TRADING_SIMPLE_PAPER_ROUTE_PROBE_MAX_NOTIONAL=15.0,
             DB_DSN="postgresql+psycopg://torghut:torghut@localhost:15438/torghut",
         )
 
@@ -766,6 +768,8 @@ class TestConfig(TestCase):
         self.assertEqual(settings.trading_simple_buying_power_reserve_bps, 50.0)
         self.assertTrue(settings.trading_simple_submit_enabled)
         self.assertTrue(settings.trading_simple_order_feed_telemetry_enabled)
+        self.assertTrue(settings.trading_simple_paper_route_probe_enabled)
+        self.assertEqual(settings.trading_simple_paper_route_probe_max_notional, 15.0)
 
     def test_parses_signal_staleness_critical_reasons(self) -> None:
         settings = Settings(
@@ -1026,6 +1030,7 @@ class TestConfig(TestCase):
             "trading_lean_live_canary_hard_rollback_enabled",
             "trading_simple_submit_enabled",
             "trading_simple_order_feed_telemetry_enabled",
+            "trading_simple_paper_route_probe_enabled",
             "trading_empirical_jobs_health_required",
             "trading_jangar_quant_health_required",
         }

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -523,6 +523,13 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertEqual(sim_env.get("TRADING_MODE"), "paper")
         self.assertEqual(sim_env.get("TRADING_PIPELINE_MODE"), "simple")
         self.assertTrue(_manifest_bool(sim_env, "TRADING_SIMPLE_SUBMIT_ENABLED"))
+        self.assertTrue(
+            _manifest_bool(sim_env, "TRADING_SIMPLE_PAPER_ROUTE_PROBE_ENABLED")
+        )
+        self.assertEqual(
+            sim_env.get("TRADING_SIMPLE_PAPER_ROUTE_PROBE_MAX_NOTIONAL"),
+            "25",
+        )
         self.assertFalse(_manifest_bool(sim_env, "TRADING_SIMULATION_ENABLED"))
         self.assertEqual(sim_env.get("TRADING_UNIVERSE_SOURCE"), "static")
         self.assertEqual(
@@ -851,6 +858,9 @@ class TestLiveConfigManifestContract(TestCase):
             context="live static universe",
         )
         self.assertFalse(_manifest_bool(env, "TRADING_SIMPLE_SUBMIT_ENABLED"))
+        self.assertFalse(
+            _manifest_bool(env, "TRADING_SIMPLE_PAPER_ROUTE_PROBE_ENABLED")
+        )
         self.assertFalse(_manifest_bool(env, "TRADING_ALPACA_QUOTE_FALLBACK_ENABLED"))
         self.assertFalse(_manifest_bool(env, "TRADING_AUTONOMY_ENABLED"))
         self.assertFalse(_manifest_bool(env, "TRADING_AUTONOMY_ALLOW_LIVE_PROMOTION"))

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -759,6 +759,8 @@ class TestTradingPipeline(TestCase):
                 "trading_simple_max_notional_per_order",
                 "trading_simple_max_notional_per_symbol",
                 "trading_simple_order_feed_telemetry_enabled",
+                "trading_simple_paper_route_probe_enabled",
+                "trading_simple_paper_route_probe_max_notional",
                 "trading_universe_static_fallback_enabled",
                 "trading_universe_static_fallback_symbols_raw",
                 "trading_market_context_url",
@@ -2264,6 +2266,302 @@ class TestTradingPipeline(TestCase):
             )
             self.assertEqual(proof_floor.get("capital_state"), "zero_notional")
             self.assertEqual(control_plane.get("execution_lane"), "simple")
+
+    def test_simple_pipeline_allows_bounded_paper_route_probe_for_tca_repair(
+        self,
+    ) -> None:
+        from app import config
+
+        config.settings.trading_enabled = True
+        config.settings.trading_mode = "paper"
+        config.settings.trading_live_enabled = False
+        config.settings.trading_pipeline_mode = "simple"
+        config.settings.trading_simple_submit_enabled = True
+        config.settings.trading_fractional_equities_enabled = True
+        config.settings.trading_simple_paper_route_probe_enabled = True
+        config.settings.trading_simple_paper_route_probe_max_notional = 25.0
+        config.settings.trading_universe_source = "jangar"
+        config.settings.trading_universe_static_fallback_enabled = True
+        config.settings.trading_universe_static_fallback_symbols_raw = "NVDA"
+
+        with self.session_local() as session:
+            strategy = Strategy(
+                name="simple-paper-route-probe",
+                description="simple paper lane route probe",
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="static",
+                universe_symbols=["NVDA"],
+                max_notional_per_trade=Decimal("1000"),
+            )
+            session.add(strategy)
+            session.commit()
+
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 26, 13, 30, tzinfo=timezone.utc),
+            ingest_ts=datetime(2026, 3, 26, 13, 30, 5, tzinfo=timezone.utc),
+            symbol="NVDA",
+            timeframe="1Min",
+            seq=1,
+            payload={
+                "feature_schema_version": "3.0.0",
+                "macd": {"macd": 1.2, "signal": 0.5},
+                "rsi14": 25,
+                "price": 100,
+            },
+        )
+
+        alpaca_client = FakeAlpacaClient()
+        pipeline = SimpleTradingPipeline(
+            alpaca_client=alpaca_client,
+            order_firewall=OrderFirewall(alpaca_client),
+            ingestor=FakeIngestor([signal]),
+            decision_engine=DecisionEngine(),
+            risk_engine=RiskEngine(),
+            executor=OrderExecutor(),
+            execution_adapter=alpaca_client,
+            reconciler=Reconciler(),
+            universe_resolver=UniverseResolver(),
+            state=TradingState(),
+            account_label="paper",
+            session_factory=self.session_local,
+        )
+        pipeline._is_market_session_open = lambda _now=None: True  # type: ignore[method-assign]
+
+        proof_floor = {
+            "route_state": "repair_only",
+            "capital_state": "zero_notional",
+            "max_notional": "0",
+            "market_window": {"session_open": True},
+            "blocking_reasons": [
+                "alpha_readiness_not_promotion_eligible",
+                "execution_tca_route_universe_empty",
+            ],
+            "route_reacquisition_book": {
+                "summary": {
+                    "candidate_symbols": [],
+                    "repair_candidate_symbols": ["NVDA"],
+                }
+            },
+        }
+        with patch.object(
+            SimpleTradingPipeline,
+            "_profitability_proof_floor",
+            return_value=proof_floor,
+        ):
+            pipeline.run_once()
+
+        self.assertEqual(len(alpaca_client.submitted), 1)
+        self.assertEqual(alpaca_client.submitted[0]["qty"], "0.25")
+        with self.session_local() as session:
+            decision = session.execute(select(TradeDecision)).scalar_one()
+            execution = session.execute(select(Execution)).scalar_one()
+            decision_json = cast(dict[str, Any], decision.decision_json)
+            params = cast(dict[str, Any], decision_json.get("params"))
+            paper_route_probe = cast(dict[str, Any], params.get("paper_route_probe"))
+            simple_lane = cast(dict[str, Any], params.get("simple_lane"))
+
+            self.assertEqual(decision.status, "submitted")
+            self.assertEqual(execution.submitted_qty, Decimal("0.25000000"))
+            self.assertEqual(paper_route_probe.get("mode"), "paper_route_acquisition")
+            self.assertEqual(paper_route_probe.get("max_notional"), "25.0")
+            self.assertEqual(paper_route_probe.get("capped_qty"), "0.2500")
+            self.assertEqual(simple_lane.get("paper_route_probe_cap_applied"), True)
+
+    def test_paper_route_probe_helpers_handle_missing_repair_metadata(self) -> None:
+        self.assertFalse(SimpleTradingPipeline._proof_floor_market_session_open({}))
+        self.assertEqual(
+            SimpleTradingPipeline._proof_floor_route_repair_symbols({}), set()
+        )
+        self.assertEqual(
+            SimpleTradingPipeline._proof_floor_route_repair_symbols(
+                {"route_reacquisition_book": {}}
+            ),
+            set(),
+        )
+        self.assertEqual(
+            SimpleTradingPipeline._proof_floor_route_repair_symbols(
+                {
+                    "route_reacquisition_book": {
+                        "summary": {
+                            "repair_candidate_symbols": "NVDA",
+                            "candidate_symbols": [" nvda ", "", "MU"],
+                        }
+                    }
+                }
+            ),
+            {"NVDA", "MU"},
+        )
+
+        decision = StrategyDecision(
+            strategy_id="strategy-1",
+            symbol="NVDA",
+            event_ts=datetime(2026, 3, 26, 13, 30, tzinfo=timezone.utc),
+            timeframe="1Min",
+            action="buy",
+            qty=Decimal("1"),
+            rationale="missing-reference-price",
+            params={},
+        )
+
+        self.assertIsNone(
+            SimpleTradingPipeline._paper_route_probe_reference_price(decision)
+        )
+
+    def test_paper_route_probe_context_rejects_unsafe_profiles(self) -> None:
+        from app import config
+
+        pipeline = SimpleTradingPipeline(
+            alpaca_client=FakeAlpacaClient(),
+            order_firewall=OrderFirewall(FakeAlpacaClient()),
+            ingestor=FakeIngestor([]),
+            decision_engine=DecisionEngine(),
+            risk_engine=RiskEngine(),
+            executor=OrderExecutor(),
+            execution_adapter=FakeAlpacaClient(),
+            reconciler=Reconciler(),
+            universe_resolver=UniverseResolver(),
+            state=TradingState(),
+            account_label="paper",
+            session_factory=self.session_local,
+        )
+        decision = StrategyDecision(
+            strategy_id="strategy-1",
+            symbol="NVDA",
+            event_ts=datetime(2026, 3, 26, 13, 30, tzinfo=timezone.utc),
+            timeframe="1Min",
+            action="buy",
+            qty=Decimal("1"),
+            rationale="route-probe-context",
+            params={"price": "100"},
+        )
+        proof_floor = {
+            "market_window": {"session_open": True},
+            "blocking_reasons": ["execution_tca_route_universe_empty"],
+            "route_reacquisition_book": {
+                "summary": {"repair_candidate_symbols": ["NVDA"]}
+            },
+        }
+
+        config.settings.trading_mode = "live"
+        config.settings.trading_simple_paper_route_probe_enabled = True
+        config.settings.trading_simple_submit_enabled = True
+        config.settings.trading_simple_paper_route_probe_max_notional = 25.0
+        self.assertIsNone(
+            pipeline._paper_route_probe_context(
+                proof_floor=proof_floor,
+                decision=decision,
+            )
+        )
+
+        config.settings.trading_mode = "paper"
+        config.settings.trading_simple_submit_enabled = False
+        self.assertIsNone(
+            pipeline._paper_route_probe_context(
+                proof_floor=proof_floor,
+                decision=decision,
+            )
+        )
+
+        config.settings.trading_simple_submit_enabled = True
+        sell_decision = decision.model_copy(update={"action": "sell"})
+        self.assertIsNone(
+            pipeline._paper_route_probe_context(
+                proof_floor=proof_floor,
+                decision=sell_decision,
+            )
+        )
+
+        config.settings.trading_simple_paper_route_probe_max_notional = 0.0
+        self.assertIsNone(
+            pipeline._paper_route_probe_context(
+                proof_floor=proof_floor,
+                decision=decision,
+            )
+        )
+
+        config.settings.trading_simple_paper_route_probe_max_notional = 25.0
+        closed_floor = {**proof_floor, "market_window": {"session_open": False}}
+        self.assertIsNone(
+            pipeline._paper_route_probe_context(
+                proof_floor=closed_floor,
+                decision=decision,
+            )
+        )
+
+        no_route_reason_floor = {
+            **proof_floor,
+            "blocking_reasons": ["alpha_readiness_not_promotion_eligible"],
+        }
+        self.assertIsNone(
+            pipeline._paper_route_probe_context(
+                proof_floor=no_route_reason_floor,
+                decision=decision,
+            )
+        )
+
+        wrong_symbol_floor = {
+            **proof_floor,
+            "route_reacquisition_book": {
+                "summary": {"repair_candidate_symbols": ["MU"]}
+            },
+        }
+        self.assertIsNone(
+            pipeline._paper_route_probe_context(
+                proof_floor=wrong_symbol_floor,
+                decision=decision,
+            )
+        )
+
+    def test_paper_route_probe_cap_rejects_missing_or_tiny_quantity(
+        self,
+    ) -> None:
+        pipeline = SimpleTradingPipeline(
+            alpaca_client=FakeAlpacaClient(),
+            order_firewall=OrderFirewall(FakeAlpacaClient()),
+            ingestor=FakeIngestor([]),
+            decision_engine=DecisionEngine(),
+            risk_engine=RiskEngine(),
+            executor=OrderExecutor(),
+            execution_adapter=FakeAlpacaClient(),
+            reconciler=Reconciler(),
+            universe_resolver=UniverseResolver(),
+            state=TradingState(),
+            account_label="paper",
+            session_factory=self.session_local,
+        )
+        missing_price_decision = StrategyDecision(
+            strategy_id="strategy-1",
+            symbol="NVDA",
+            event_ts=datetime(2026, 3, 26, 13, 30, tzinfo=timezone.utc),
+            timeframe="1Min",
+            action="buy",
+            qty=Decimal("1"),
+            rationale="missing-price",
+            params={},
+        )
+        priced_decision = missing_price_decision.model_copy(
+            update={"params": {"price": "100"}}
+        )
+
+        self.assertFalse(
+            pipeline._apply_paper_route_probe_cap(
+                session=cast(Session, None),
+                decision=missing_price_decision,
+                decision_row=cast(TradeDecision, object()),
+                proof_floor={},
+                context={"max_notional": "25"},
+            )
+        )
+        self.assertFalse(
+            pipeline._apply_paper_route_probe_cap(
+                session=cast(Session, None),
+                decision=priced_decision,
+                decision_row=cast(TradeDecision, object()),
+                proof_floor={},
+                context={"max_notional": "0.00001"},
+            )
+        )
 
     def test_simple_pipeline_blocks_symbol_excluded_from_route_candidates(
         self,


### PR DESCRIPTION
## Summary

- Add a paper-only simple-lane route-acquisition probe for proof-floor repair mode when route/TCA evidence blocks normal submissions.
- Cap each probe order by `TRADING_SIMPLE_PAPER_ROUTE_PROBE_MAX_NOTIONAL` and persist probe metadata on the trade decision.
- Enable the probe only in `torghut-sim`; keep the live Torghut service explicitly disabled.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest -q tests/test_trading_pipeline.py::TestTradingPipeline::test_simple_pipeline_blocks_paper_order_when_profitability_floor_zero_notional tests/test_trading_pipeline.py::TestTradingPipeline::test_simple_pipeline_allows_bounded_paper_route_probe_for_tca_repair tests/test_trading_pipeline.py::TestTradingPipeline::test_paper_route_probe_helpers_handle_missing_repair_metadata tests/test_trading_pipeline.py::TestTradingPipeline::test_paper_route_probe_context_rejects_unsafe_profiles tests/test_trading_pipeline.py::TestTradingPipeline::test_paper_route_probe_cap_rejects_missing_or_tiny_quantity tests/test_live_config_manifest_contract.py::TestLiveConfigManifestContract::test_sim_manifest_runs_paper_live_signal_profile tests/test_live_config_manifest_contract.py::TestLiveConfigManifestContract::test_manifest_simple_lane_profile_is_enforced tests/test_config.py::TestConfig::test_simple_pipeline_settings_are_supported tests/test_config.py::TestConfig::test_feature_flag_map_covers_all_boolean_runtime_gates`
- `uv run --frozen ruff format --check app/config.py app/trading/scheduler/simple_pipeline.py tests/test_config.py tests/test_trading_pipeline.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen ruff check app/config.py app/trading/scheduler/simple_pipeline.py tests/test_config.py tests/test_trading_pipeline.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`
- `bun run lint:argocd`
- `GITHUB_BASE_REF=main uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
