### PR TITLE
chore(torghut): promote image a5d8989d

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:eb9790555bc1682506dae5542d2e36a06c02dba907f767b12b0346839a8ce55d
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:f03725d12c575c582bd2bb929c422e87ee2e44e20963f63d86546be633f53a0a
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.569.1-464-g57095de61
+              value: v0.569.1-469-ga5d8989df
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 57095de61842f69a8dce99b09afec438c46a5945
+              value: a5d8989df11fb3abe97dcaa8648e113daa9a75cf
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:eb9790555bc1682506dae5542d2e36a06c02dba907f767b12b0346839a8ce55d
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:f03725d12c575c582bd2bb929c422e87ee2e44e20963f63d86546be633f53a0a
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.569.1-464-g57095de61
+              value: v0.569.1-469-ga5d8989df
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 57095de61842f69a8dce99b09afec438c46a5945
+              value: a5d8989df11fb3abe97dcaa8648e113daa9a75cf
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:eb9790555bc1682506dae5542d2e36a06c02dba907f767b12b0346839a8ce55d
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:f03725d12c575c582bd2bb929c422e87ee2e44e20963f63d86546be633f53a0a
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:eb9790555bc1682506dae5542d2e36a06c02dba907f767b12b0346839a8ce55d
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:f03725d12c575c582bd2bb929c422e87ee2e44e20963f63d86546be633f53a0a
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:eb9790555bc1682506dae5542d2e36a06c02dba907f767b12b0346839a8ce55d
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:f03725d12c575c582bd2bb929c422e87ee2e44e20963f63d86546be633f53a0a
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:eb9790555bc1682506dae5542d2e36a06c02dba907f767b12b0346839a8ce55d
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:f03725d12c575c582bd2bb929c422e87ee2e44e20963f63d86546be633f53a0a
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:eb9790555bc1682506dae5542d2e36a06c02dba907f767b12b0346839a8ce55d
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:f03725d12c575c582bd2bb929c422e87ee2e44e20963f63d86546be633f53a0a
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -15,7 +15,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:eb9790555bc1682506dae5542d2e36a06c02dba907f767b12b0346839a8ce55d
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:f03725d12c575c582bd2bb929c422e87ee2e44e20963f63d86546be633f53a0a
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -23,7 +23,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:eb9790555bc1682506dae5542d2e36a06c02dba907f767b12b0346839a8ce55d
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:f03725d12c575c582bd2bb929c422e87ee2e44e20963f63d86546be633f53a0a
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+++ b/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
@@ -23,7 +23,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: refresh-execution-tca
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:eb9790555bc1682506dae5542d2e36a06c02dba907f767b12b0346839a8ce55d
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:f03725d12c575c582bd2bb929c422e87ee2e44e20963f63d86546be633f53a0a
               imagePullPolicy: IfNotPresent
               env:
                 - name: DB_DSN

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:eb9790555bc1682506dae5542d2e36a06c02dba907f767b12b0346839a8ce55d
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:f03725d12c575c582bd2bb929c422e87ee2e44e20963f63d86546be633f53a0a
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-14T20:19:34Z"
+        client.knative.dev/updateTimestamp: "2026-05-14T21:00:00Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -27,7 +27,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:eb9790555bc1682506dae5542d2e36a06c02dba907f767b12b0346839a8ce55d
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:f03725d12c575c582bd2bb929c422e87ee2e44e20963f63d86546be633f53a0a
           ports:
             - name: http1
               containerPort: 8181
@@ -490,11 +490,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.569.1-464-g57095de61
+              value: v0.569.1-469-ga5d8989df
             - name: TORGHUT_COMMIT
-              value: 57095de61842f69a8dce99b09afec438c46a5945
+              value: a5d8989df11fb3abe97dcaa8648e113daa9a75cf
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:eb9790555bc1682506dae5542d2e36a06c02dba907f767b12b0346839a8ce55d
+              value: sha256:f03725d12c575c582bd2bb929c422e87ee2e44e20963f63d86546be633f53a0a
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-14T20:19:34Z"
+        client.knative.dev/updateTimestamp: "2026-05-14T21:00:00Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:eb9790555bc1682506dae5542d2e36a06c02dba907f767b12b0346839a8ce55d
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:f03725d12c575c582bd2bb929c422e87ee2e44e20963f63d86546be633f53a0a
           ports:
             - name: http1
               containerPort: 8181
@@ -314,11 +314,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.569.1-464-g57095de61
+              value: v0.569.1-469-ga5d8989df
             - name: TORGHUT_COMMIT
-              value: 57095de61842f69a8dce99b09afec438c46a5945
+              value: a5d8989df11fb3abe97dcaa8648e113daa9a75cf
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:eb9790555bc1682506dae5542d2e36a06c02dba907f767b12b0346839a8ce55d
+              value: sha256:f03725d12c575c582bd2bb929c422e87ee2e44e20963f63d86546be633f53a0a
           livenessProbe:
             httpGet:
               path: /healthz

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -98,7 +98,7 @@ spec:
           - name: allowStaleTape
           - name: persistResults
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:eb9790555bc1682506dae5542d2e36a06c02dba907f767b12b0346839a8ce55d
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:f03725d12c575c582bd2bb929c422e87ee2e44e20963f63d86546be633f53a0a
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
+++ b/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:eb9790555bc1682506dae5542d2e36a06c02dba907f767b12b0346839a8ce55d
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:f03725d12c575c582bd2bb929c422e87ee2e44e20963f63d86546be633f53a0a
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `a5d8989df11fb3abe97dcaa8648e113daa9a75cf`
- Image tag: `a5d8989d`
- Image digest: `sha256:f03725d12c575c582bd2bb929c422e87ee2e44e20963f63d86546be633f53a0a`