### PR TITLE
chore(torghut): promote image b6f2fb1a

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:67c3aa4bd42c67e59b3dc96d6cf03cab151ebdcdf941be6a8e58938e20cccad2
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:5b849bf86349a459e52f5776b23e8dc0eabf3702f1c190bbccd64529d1481263
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.569.1-467-gf4fd8f35b
+              value: v0.569.1-472-gb6f2fb1ac
             - name: TORGHUT_OPTIONS_COMMIT
-              value: f4fd8f35bb7d24a9e50766700327556656896918
+              value: b6f2fb1acfd94c48ad9ca267e41017474cc7481d
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:67c3aa4bd42c67e59b3dc96d6cf03cab151ebdcdf941be6a8e58938e20cccad2
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:5b849bf86349a459e52f5776b23e8dc0eabf3702f1c190bbccd64529d1481263
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.569.1-467-gf4fd8f35b
+              value: v0.569.1-472-gb6f2fb1ac
             - name: TORGHUT_OPTIONS_COMMIT
-              value: f4fd8f35bb7d24a9e50766700327556656896918
+              value: b6f2fb1acfd94c48ad9ca267e41017474cc7481d
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:67c3aa4bd42c67e59b3dc96d6cf03cab151ebdcdf941be6a8e58938e20cccad2
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:5b849bf86349a459e52f5776b23e8dc0eabf3702f1c190bbccd64529d1481263
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:67c3aa4bd42c67e59b3dc96d6cf03cab151ebdcdf941be6a8e58938e20cccad2
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:5b849bf86349a459e52f5776b23e8dc0eabf3702f1c190bbccd64529d1481263
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:67c3aa4bd42c67e59b3dc96d6cf03cab151ebdcdf941be6a8e58938e20cccad2
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:5b849bf86349a459e52f5776b23e8dc0eabf3702f1c190bbccd64529d1481263
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:67c3aa4bd42c67e59b3dc96d6cf03cab151ebdcdf941be6a8e58938e20cccad2
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:5b849bf86349a459e52f5776b23e8dc0eabf3702f1c190bbccd64529d1481263
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:67c3aa4bd42c67e59b3dc96d6cf03cab151ebdcdf941be6a8e58938e20cccad2
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:5b849bf86349a459e52f5776b23e8dc0eabf3702f1c190bbccd64529d1481263
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -15,7 +15,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:67c3aa4bd42c67e59b3dc96d6cf03cab151ebdcdf941be6a8e58938e20cccad2
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:5b849bf86349a459e52f5776b23e8dc0eabf3702f1c190bbccd64529d1481263
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -23,7 +23,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:67c3aa4bd42c67e59b3dc96d6cf03cab151ebdcdf941be6a8e58938e20cccad2
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:5b849bf86349a459e52f5776b23e8dc0eabf3702f1c190bbccd64529d1481263
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+++ b/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
@@ -23,7 +23,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: refresh-execution-tca
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:67c3aa4bd42c67e59b3dc96d6cf03cab151ebdcdf941be6a8e58938e20cccad2
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:5b849bf86349a459e52f5776b23e8dc0eabf3702f1c190bbccd64529d1481263
               imagePullPolicy: IfNotPresent
               env:
                 - name: DB_DSN

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:67c3aa4bd42c67e59b3dc96d6cf03cab151ebdcdf941be6a8e58938e20cccad2
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:5b849bf86349a459e52f5776b23e8dc0eabf3702f1c190bbccd64529d1481263
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-14T20:42:47Z"
+        client.knative.dev/updateTimestamp: "2026-05-14T21:14:32Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -27,7 +27,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:67c3aa4bd42c67e59b3dc96d6cf03cab151ebdcdf941be6a8e58938e20cccad2
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:5b849bf86349a459e52f5776b23e8dc0eabf3702f1c190bbccd64529d1481263
           ports:
             - name: http1
               containerPort: 8181
@@ -490,11 +490,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.569.1-467-gf4fd8f35b
+              value: v0.569.1-472-gb6f2fb1ac
             - name: TORGHUT_COMMIT
-              value: f4fd8f35bb7d24a9e50766700327556656896918
+              value: b6f2fb1acfd94c48ad9ca267e41017474cc7481d
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:67c3aa4bd42c67e59b3dc96d6cf03cab151ebdcdf941be6a8e58938e20cccad2
+              value: sha256:5b849bf86349a459e52f5776b23e8dc0eabf3702f1c190bbccd64529d1481263
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-14T20:42:47Z"
+        client.knative.dev/updateTimestamp: "2026-05-14T21:14:32Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:67c3aa4bd42c67e59b3dc96d6cf03cab151ebdcdf941be6a8e58938e20cccad2
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:5b849bf86349a459e52f5776b23e8dc0eabf3702f1c190bbccd64529d1481263
           ports:
             - name: http1
               containerPort: 8181
@@ -314,11 +314,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.569.1-467-gf4fd8f35b
+              value: v0.569.1-472-gb6f2fb1ac
             - name: TORGHUT_COMMIT
-              value: f4fd8f35bb7d24a9e50766700327556656896918
+              value: b6f2fb1acfd94c48ad9ca267e41017474cc7481d
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:67c3aa4bd42c67e59b3dc96d6cf03cab151ebdcdf941be6a8e58938e20cccad2
+              value: sha256:5b849bf86349a459e52f5776b23e8dc0eabf3702f1c190bbccd64529d1481263
           livenessProbe:
             httpGet:
               path: /healthz

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -98,7 +98,7 @@ spec:
           - name: allowStaleTape
           - name: persistResults
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:67c3aa4bd42c67e59b3dc96d6cf03cab151ebdcdf941be6a8e58938e20cccad2
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:5b849bf86349a459e52f5776b23e8dc0eabf3702f1c190bbccd64529d1481263
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
+++ b/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:67c3aa4bd42c67e59b3dc96d6cf03cab151ebdcdf941be6a8e58938e20cccad2
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:5b849bf86349a459e52f5776b23e8dc0eabf3702f1c190bbccd64529d1481263
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `b6f2fb1acfd94c48ad9ca267e41017474cc7481d`
- Image tag: `b6f2fb1a`
- Image digest: `sha256:5b849bf86349a459e52f5776b23e8dc0eabf3702f1c190bbccd64529d1481263`