### PR TITLE
fix(torghut): compact consumer evidence hot path

### DIFF
--- a/services/jangar/README.md
+++ b/services/jangar/README.md
@@ -718,6 +718,9 @@ controller-ingestion settlement, terminal debt compaction, and Torghut max_notio
 
 Design doc `docs/agents/designs/188-jangar-typed-torghut-evidence-admission-and-repair-dispatch-2026-05-13.md`
 requires Jangar to expose typed Torghut custody evidence from the non-recursive `/trading/consumer-evidence` route.
+Jangar requests `/trading/consumer-evidence?view=summary` when the configured Torghut status URL points at the
+consumer-evidence route, so readiness gets the compact status, receipt, route-profit, and canary fields without
+pulling the full operator ledger payload through the control-plane hot path.
 When Torghut imports Jangar carry for that route, it calls `/api/agents/control-plane/status` with
 `x-torghut-consumer-evidence-mode: omit`; Jangar then computes the local control-plane status without fetching Torghut
 consumer evidence, which prevents a Torghut -> Jangar -> Torghut status loop.

--- a/services/jangar/src/server/__tests__/control-plane-torghut-consumer-evidence.test.ts
+++ b/services/jangar/src/server/__tests__/control-plane-torghut-consumer-evidence.test.ts
@@ -285,6 +285,13 @@ describe('control-plane Torghut consumer evidence', () => {
 
     const result = await resolveTorghutConsumerEvidence(new Date('2026-05-08T02:30:10.000Z'))
 
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      'http://torghut.torghut.svc.cluster.local/trading/consumer-evidence?view=summary',
+      expect.objectContaining({
+        method: 'GET',
+        headers: { accept: 'application/json' },
+      }),
+    )
     expect(result.status).toMatchObject({
       status: 'current',
       receipt_id: 'torghut-route-proven-profit:test',

--- a/services/jangar/src/server/control-plane-torghut-consumer-evidence.ts
+++ b/services/jangar/src/server/control-plane-torghut-consumer-evidence.ts
@@ -93,6 +93,20 @@ const requestJson = async (url: string, timeoutMs: number): Promise<JsonRouteRes
   }
 }
 
+const compactConsumerEvidenceEndpoint = (endpoint: string): string => {
+  try {
+    const url = new URL(endpoint)
+    const path = url.pathname.replace(/\/+$/, '')
+    if (path.endsWith('/trading/consumer-evidence') && !url.searchParams.has('view')) {
+      url.searchParams.set('view', 'summary')
+      return url.toString()
+    }
+  } catch {
+    return endpoint
+  }
+  return endpoint
+}
+
 const readMarketContext = (
   payload: Record<string, unknown>,
 ): Pick<TorghutNegativeEvidenceInput, 'market_context_status' | 'market_context_stale_domains'> => {
@@ -142,7 +156,7 @@ export const resolveTorghutConsumerEvidence = async (now = new Date()): Promise<
     }
   }
 
-  const routeResult = await requestJson(endpoint, config.torghutStatusTimeoutMs)
+  const routeResult = await requestJson(compactConsumerEvidenceEndpoint(endpoint), config.torghutStatusTimeoutMs)
   if (!routeResult.ok) {
     const routeMissing = routeResult.statusCode === 404
     const status = routeMissing ? 'route_missing' : 'unavailable'

--- a/services/torghut/README.md
+++ b/services/torghut/README.md
@@ -251,8 +251,11 @@ Testing rules for the trading core:
   auction, and mirrors a compact `torghut.jangar-controller-ingestion-carry-ref.v1` through `/readyz` and
   `/trading/consumer-evidence`. The import carries Jangar repair-slot escrow and rollout-witness refs when available
   so `hold` or `block` settlements can name the exact zero-notional blocker instead of collapsing to a generic missing
-  carry. `/trading/consumer-evidence` fetches the Jangar status payload with Torghut consumer-evidence expansion
-  explicitly omitted, so the route can mirror current Jangar carry without recursively calling itself through Jangar.
+  carry. `/trading/consumer-evidence?view=summary` returns the same action-boundary schema with only the compact
+  status, receipt, route-profit, and canary fields Jangar needs for readiness. The default route keeps the full
+  operator evidence payload. `/trading/consumer-evidence` fetches the Jangar status payload with Torghut
+  consumer-evidence expansion explicitly omitted, so the route can mirror current Jangar carry without recursively
+  calling itself through Jangar.
   A `jangar_verify_carry` ticket is selectable only for `repairable` carry and always keeps `max_notional=0`.
 - `GET /trading/status` and `GET /readyz` now include the May 8 doc 181
   `quality_adjusted_profit_frontier` shadow projection. The reducer ranks zero-notional repair packets from quant

--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -3083,7 +3083,13 @@ def _build_consumer_evidence_receipt_projection(
     return consumer_evidence_receipt, route_proven_profit_receipt
 
 
-def _build_trading_consumer_evidence_payload() -> dict[str, object]:
+def _consumer_evidence_summary_view(view: str | None) -> bool:
+    return (view or "").strip().lower() in {"compact", "summary", "jangar"}
+
+
+def _build_trading_consumer_evidence_payload(
+    *, summary: bool = False
+) -> dict[str, object]:
     scheduler: TradingScheduler | None = getattr(app.state, "trading_scheduler", None)
     if scheduler is None:
         scheduler = TradingScheduler()
@@ -3157,6 +3163,35 @@ def _build_trading_consumer_evidence_payload() -> dict[str, object]:
             serving_revision=cast(str | None, shadow_first_runtime["active_revision"]),
         )
     )
+    control_plane_dependency_mode = (
+        "caller_evaluated"
+        if dependency_quorum.message
+        == CONSUMER_EVIDENCE_CONTROL_PLANE_DEPENDENCY_MESSAGE
+        else "jangar_status_non_recursive"
+    )
+    if summary:
+        return {
+            "schema_version": "torghut.consumer-evidence-status.v1",
+            "view": "summary",
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "enabled": settings.trading_enabled,
+            "mode": settings.trading_mode,
+            "running": state.running,
+            "build": build_payload,
+            "control_plane_dependency_mode": control_plane_dependency_mode,
+            "dependency_quorum": dependency_quorum.as_payload(),
+            "forecast_service": forecast_service_status,
+            "lean_authority": lean_authority_status,
+            "empirical_jobs": empirical_jobs,
+            "market_context": market_context_status,
+            "quant_evidence": quant_evidence,
+            "live_submission_gate": live_submission_gate,
+            "proof_floor": proof_floor,
+            "simple_lane_status": simple_lane_status,
+            "torghut_consumer_evidence_receipt": consumer_evidence_receipt,
+            "route_proven_profit_receipt": route_proven_profit_receipt,
+            "consumer_evidence_canary": route_proven_profit_receipt.get("route_canary"),
+        }
     route_reacquisition_board = build_route_reacquisition_board(
         proof_floor_receipt=proof_floor,
         route_reacquisition_book=cast(
@@ -3422,12 +3457,7 @@ def _build_trading_consumer_evidence_payload() -> dict[str, object]:
         "mode": settings.trading_mode,
         "running": state.running,
         "build": build_payload,
-        "control_plane_dependency_mode": (
-            "caller_evaluated"
-            if dependency_quorum.message
-            == CONSUMER_EVIDENCE_CONTROL_PLANE_DEPENDENCY_MESSAGE
-            else "jangar_status_non_recursive"
-        ),
+        "control_plane_dependency_mode": control_plane_dependency_mode,
         "dependency_quorum": dependency_quorum.as_payload(),
         "forecast_service": forecast_service_status,
         "lean_authority": lean_authority_status,
@@ -3508,10 +3538,14 @@ def _build_trading_consumer_evidence_payload() -> dict[str, object]:
 
 
 @app.get("/trading/consumer-evidence")
-def trading_consumer_evidence() -> dict[str, object]:
+def trading_consumer_evidence(
+    view: str | None = Query(default=None),
+) -> dict[str, object]:
     """Return Jangar-facing Torghut evidence without recursive Jangar status fetches."""
 
-    return _build_trading_consumer_evidence_payload()
+    return _build_trading_consumer_evidence_payload(
+        summary=_consumer_evidence_summary_view(view)
+    )
 
 
 @app.get("/trading/metrics")

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -1233,8 +1233,12 @@ class TestTradingApi(TestCase):
             patch("app.main.SessionLocal", self.session_local),
         ):
             response = self.client.get("/trading/consumer-evidence")
+            summary_response = self.client.get(
+                "/trading/consumer-evidence?view=summary"
+            )
 
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(summary_response.status_code, 200)
         self.assertTrue(
             readiness_snapshot.call_args.kwargs["include_database_contract"]
         )
@@ -1249,6 +1253,19 @@ class TestTradingApi(TestCase):
         self.assertEqual(payload["dependency_quorum"]["decision"], "allow")
         self.assertEqual(payload["proof_floor"], proof_floor)
         self.assertNotIn("route_reacquisition_board", payload)
+        summary_payload = summary_response.json()
+        self.assertEqual(summary_payload["schema_version"], payload["schema_version"])
+        self.assertEqual(summary_payload["view"], "summary")
+        self.assertEqual(
+            summary_payload["control_plane_dependency_mode"], "caller_evaluated"
+        )
+        self.assertEqual(summary_payload["dependency_quorum"]["decision"], "allow")
+        self.assertEqual(summary_payload["proof_floor"], proof_floor)
+        self.assertIn("torghut_consumer_evidence_receipt", summary_payload)
+        self.assertIn("route_proven_profit_receipt", summary_payload)
+        self.assertNotIn("route_reacquisition_board", summary_payload)
+        self.assertNotIn("capital_reentry_cohort_ledger", summary_payload)
+        self.assertNotIn("profit_carry_passport_ledger", summary_payload)
         receipt = payload["torghut_consumer_evidence_receipt"]
         self.assertEqual(
             receipt["schema_version"],


### PR DESCRIPTION
## Summary

- Add `view=summary` support to Torghut `/trading/consumer-evidence` so Jangar can read the compact action-boundary receipt without pulling the full operator ledger payload.
- Make Jangar automatically request `?view=summary` when its configured Torghut status URL points at `/trading/consumer-evidence`.
- Document the compact non-recursive consumer-evidence path and cover both sides with focused regression tests.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_trading_api.py -k consumer_evidence -q`
- `bun run --cwd services/jangar test src/server/__tests__/control-plane-torghut-consumer-evidence.test.ts`
- `uv run --frozen ruff format --check app/main.py tests/test_trading_api.py`
- `uv run --frozen ruff check app/main.py tests/test_trading_api.py`
- `bunx oxfmt --check services/jangar/src/server/control-plane-torghut-consumer-evidence.ts services/jangar/src/server/__tests__/control-plane-torghut-consumer-evidence.test.ts services/jangar/README.md services/torghut/README.md`
- `uv sync --frozen --extra dev`
- `bun run --cwd services/jangar lint`
- `bun run --cwd services/jangar tsc`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
