### PR TITLE
chore(jangar): promote image e888717c

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 79223ebb
-  digest: sha256:8f92e3854bb4dc6523ee96226464483e874948954740439386f695242d2da9e5
+  tag: e888717c
+  digest: sha256:246bc5280e8097f2d909f50c43b6bb968ccf616b929ddec3834c3f02e6a6d016
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,25 +11,25 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 79223ebb
-    digest: sha256:c500402561d7750345e00bb2c146ca66bca418d9f313edc8bfc3bcf4e1dc7b45
+    tag: e888717c
+    digest: sha256:a5dc4b90e1df9543acf7c75b1b461bbb20f2816a74e281964841e9e906898a0d
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
       JANGAR_TORGHUT_STATUS_URL: http://torghut.torghut.svc.cluster.local/trading/consumer-evidence
       JANGAR_TORGHUT_STATUS_TIMEOUT_MS: "3000"
-      JANGAR_SOURCE_HEAD_SHA: 79223ebb3e2d32a67e8cb34e990157986f92618f
-      JANGAR_GITOPS_REVISION: 79223ebb3e2d32a67e8cb34e990157986f92618f
-      JANGAR_SOURCE_CI_RUN_ID: "25888470203"
+      JANGAR_SOURCE_HEAD_SHA: e888717c6add1c3d9ed5c54e0d65f54543974aa4
+      JANGAR_GITOPS_REVISION: e888717c6add1c3d9ed5c54e0d65f54543974aa4
+      JANGAR_SOURCE_CI_RUN_ID: "25890004689"
       JANGAR_SOURCE_CI_CONCLUSION: success
-      JANGAR_MANIFEST_IMAGE_DIGEST: sha256:c500402561d7750345e00bb2c146ca66bca418d9f313edc8bfc3bcf4e1dc7b45
-      JANGAR_SERVING_BUILD_COMMIT: 79223ebb3e2d32a67e8cb34e990157986f92618f
-      JANGAR_SERVING_IMAGE_DIGEST: sha256:c500402561d7750345e00bb2c146ca66bca418d9f313edc8bfc3bcf4e1dc7b45
+      JANGAR_MANIFEST_IMAGE_DIGEST: sha256:a5dc4b90e1df9543acf7c75b1b461bbb20f2816a74e281964841e9e906898a0d
+      JANGAR_SERVING_BUILD_COMMIT: e888717c6add1c3d9ed5c54e0d65f54543974aa4
+      JANGAR_SERVING_IMAGE_DIGEST: sha256:a5dc4b90e1df9543acf7c75b1b461bbb20f2816a74e281964841e9e906898a0d
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 79223ebb
-    digest: sha256:8f92e3854bb4dc6523ee96226464483e874948954740439386f695242d2da9e5
+    tag: e888717c
+    digest: sha256:246bc5280e8097f2d909f50c43b6bb968ccf616b929ddec3834c3f02e6a6d016
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-14T22:09:15Z
+    deploy.knative.dev/rollout: 2026-05-14T22:50:26Z
 spec:
   replicas: 1
   strategy:
@@ -57,11 +57,11 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_RUNTIME_IMAGE
-              value: registry.ide-newton.ts.net/lab/jangar:79223ebb@sha256:8f92e3854bb4dc6523ee96226464483e874948954740439386f695242d2da9e5
+              value: registry.ide-newton.ts.net/lab/jangar:e888717c@sha256:246bc5280e8097f2d909f50c43b6bb968ccf616b929ddec3834c3f02e6a6d016
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: 79223ebb3e2d32a67e8cb34e990157986f92618f
+              value: e888717c6add1c3d9ed5c54e0d65f54543974aa4
             - name: JANGAR_GITOPS_REVISION
-              value: 79223ebb3e2d32a67e8cb34e990157986f92618f
+              value: e888717c6add1c3d9ed5c54e0d65f54543974aa4
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_CONTROL_PLANE_STATUS_CACHE_TTL_MS
@@ -405,15 +405,15 @@ spec:
             - name: OPENAI_EMBEDDING_TIMEOUT_MS
               value: "60000"
             - name: JANGAR_SOURCE_CI_RUN_ID
-              value: "25888470203"
+              value: "25890004689"
             - name: JANGAR_SOURCE_CI_CONCLUSION
               value: success
             - name: JANGAR_MANIFEST_IMAGE_DIGEST
-              value: sha256:c500402561d7750345e00bb2c146ca66bca418d9f313edc8bfc3bcf4e1dc7b45
+              value: sha256:a5dc4b90e1df9543acf7c75b1b461bbb20f2816a74e281964841e9e906898a0d
             - name: JANGAR_SERVING_BUILD_COMMIT
-              value: 79223ebb3e2d32a67e8cb34e990157986f92618f
+              value: e888717c6add1c3d9ed5c54e0d65f54543974aa4
             - name: JANGAR_SERVING_IMAGE_DIGEST
-              value: sha256:c500402561d7750345e00bb2c146ca66bca418d9f313edc8bfc3bcf4e1dc7b45
+              value: sha256:a5dc4b90e1df9543acf7c75b1b461bbb20f2816a74e281964841e9e906898a0d
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -59,5 +59,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: 79223ebb
-    digest: sha256:8f92e3854bb4dc6523ee96226464483e874948954740439386f695242d2da9e5
+    newTag: e888717c
+    digest: sha256:246bc5280e8097f2d909f50c43b6bb968ccf616b929ddec3834c3f02e6a6d016


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `e888717c6add1c3d9ed5c54e0d65f54543974aa4`
- Image tag: `e888717c`
- Image digest: `sha256:246bc5280e8097f2d909f50c43b6bb968ccf616b929ddec3834c3f02e6a6d016`
- Source CI run: `25890004689`
- Control-plane serving digest: `sha256:a5dc4b90e1df9543acf7c75b1b461bbb20f2816a74e281964841e9e906898a0d`
- Updated API rollout annotation
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`
- Published source-serving proof env for revenue repair custody gates