### PR TITLE
ci(temporal-bun-sdk): avoid release cache stalls

### DIFF
--- a/.github/workflows/temporal-bun-sdk.yml
+++ b/.github/workflows/temporal-bun-sdk.yml
@@ -212,14 +212,6 @@ jobs:
         with:
           bun-version: 1.3.13
 
-      - name: Cache Bun install
-        uses: actions/cache@v4
-        with:
-          path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-1.3.13-${{ hashFiles('bun.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-bun-1.3.13-
-
       - name: Install dependencies
         run: bun install --frozen-lockfile --ignore-scripts --filter @proompteng/source --filter @proompteng/temporal-bun-sdk --filter temporal-bun-sdk-example
 
@@ -282,14 +274,6 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.13
-
-      - name: Cache Bun install
-        uses: actions/cache@v4
-        with:
-          path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-1.3.13-${{ hashFiles('bun.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-bun-1.3.13-
 
       - name: Install dependencies
         run: bun install --frozen-lockfile --ignore-scripts --filter @proompteng/source --filter @proompteng/temporal-bun-sdk --filter temporal-bun-sdk-example


### PR DESCRIPTION
## Summary

- Removes the remaining Bun cache restore steps from the Temporal Bun SDK release prepare and publish jobs.
- Keeps release jobs on deterministic `bun install --frozen-lockfile` so release automation does not block on nonessential cache restore.
- Completes the cache-stall hardening for the same workflow path used to publish `@proompteng/temporal-bun-sdk`.

## Related Issues

None

## Testing

- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/temporal-bun-sdk.yml')"`
- `rg -n "Cache Bun install|actions/cache" .github/workflows/temporal-bun-sdk.yml .github/workflows/temporal-bun-sdk-nightly.yml` returned no matches
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
