### PR TITLE
chore(jangar): promote image 4947b00e

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: e888717c
-  digest: sha256:246bc5280e8097f2d909f50c43b6bb968ccf616b929ddec3834c3f02e6a6d016
+  tag: 4947b00e
+  digest: sha256:03bcb2e644758aa745117dd70e94293c4c11ff64b64febc098a87727a2aad44b
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,25 +11,25 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: e888717c
-    digest: sha256:a5dc4b90e1df9543acf7c75b1b461bbb20f2816a74e281964841e9e906898a0d
+    tag: 4947b00e
+    digest: sha256:59ceafa05c1b4d1051b26a87f5fc73a4fe468009776b1aeb6af69bbdf096d348
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
       JANGAR_TORGHUT_STATUS_URL: http://torghut.torghut.svc.cluster.local/trading/consumer-evidence
       JANGAR_TORGHUT_STATUS_TIMEOUT_MS: "3000"
-      JANGAR_SOURCE_HEAD_SHA: e888717c6add1c3d9ed5c54e0d65f54543974aa4
-      JANGAR_GITOPS_REVISION: e888717c6add1c3d9ed5c54e0d65f54543974aa4
-      JANGAR_SOURCE_CI_RUN_ID: "25890004689"
+      JANGAR_SOURCE_HEAD_SHA: 4947b00e52c41dc0822db45bc45ed44dc696dad7
+      JANGAR_GITOPS_REVISION: 4947b00e52c41dc0822db45bc45ed44dc696dad7
+      JANGAR_SOURCE_CI_RUN_ID: "25891490939"
       JANGAR_SOURCE_CI_CONCLUSION: success
-      JANGAR_MANIFEST_IMAGE_DIGEST: sha256:a5dc4b90e1df9543acf7c75b1b461bbb20f2816a74e281964841e9e906898a0d
-      JANGAR_SERVING_BUILD_COMMIT: e888717c6add1c3d9ed5c54e0d65f54543974aa4
-      JANGAR_SERVING_IMAGE_DIGEST: sha256:a5dc4b90e1df9543acf7c75b1b461bbb20f2816a74e281964841e9e906898a0d
+      JANGAR_MANIFEST_IMAGE_DIGEST: sha256:59ceafa05c1b4d1051b26a87f5fc73a4fe468009776b1aeb6af69bbdf096d348
+      JANGAR_SERVING_BUILD_COMMIT: 4947b00e52c41dc0822db45bc45ed44dc696dad7
+      JANGAR_SERVING_IMAGE_DIGEST: sha256:59ceafa05c1b4d1051b26a87f5fc73a4fe468009776b1aeb6af69bbdf096d348
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: e888717c
-    digest: sha256:246bc5280e8097f2d909f50c43b6bb968ccf616b929ddec3834c3f02e6a6d016
+    tag: 4947b00e
+    digest: sha256:03bcb2e644758aa745117dd70e94293c4c11ff64b64febc098a87727a2aad44b
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-14T22:50:26Z
+    deploy.knative.dev/rollout: 2026-05-14T23:27:55Z
 spec:
   replicas: 1
   strategy:
@@ -57,11 +57,11 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_RUNTIME_IMAGE
-              value: registry.ide-newton.ts.net/lab/jangar:e888717c@sha256:246bc5280e8097f2d909f50c43b6bb968ccf616b929ddec3834c3f02e6a6d016
+              value: registry.ide-newton.ts.net/lab/jangar:4947b00e@sha256:03bcb2e644758aa745117dd70e94293c4c11ff64b64febc098a87727a2aad44b
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: e888717c6add1c3d9ed5c54e0d65f54543974aa4
+              value: 4947b00e52c41dc0822db45bc45ed44dc696dad7
             - name: JANGAR_GITOPS_REVISION
-              value: e888717c6add1c3d9ed5c54e0d65f54543974aa4
+              value: 4947b00e52c41dc0822db45bc45ed44dc696dad7
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_CONTROL_PLANE_STATUS_CACHE_TTL_MS
@@ -405,15 +405,15 @@ spec:
             - name: OPENAI_EMBEDDING_TIMEOUT_MS
               value: "60000"
             - name: JANGAR_SOURCE_CI_RUN_ID
-              value: "25890004689"
+              value: "25891490939"
             - name: JANGAR_SOURCE_CI_CONCLUSION
               value: success
             - name: JANGAR_MANIFEST_IMAGE_DIGEST
-              value: sha256:a5dc4b90e1df9543acf7c75b1b461bbb20f2816a74e281964841e9e906898a0d
+              value: sha256:59ceafa05c1b4d1051b26a87f5fc73a4fe468009776b1aeb6af69bbdf096d348
             - name: JANGAR_SERVING_BUILD_COMMIT
-              value: e888717c6add1c3d9ed5c54e0d65f54543974aa4
+              value: 4947b00e52c41dc0822db45bc45ed44dc696dad7
             - name: JANGAR_SERVING_IMAGE_DIGEST
-              value: sha256:a5dc4b90e1df9543acf7c75b1b461bbb20f2816a74e281964841e9e906898a0d
+              value: sha256:59ceafa05c1b4d1051b26a87f5fc73a4fe468009776b1aeb6af69bbdf096d348
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -59,5 +59,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: e888717c
-    digest: sha256:246bc5280e8097f2d909f50c43b6bb968ccf616b929ddec3834c3f02e6a6d016
+    newTag: 4947b00e
+    digest: sha256:03bcb2e644758aa745117dd70e94293c4c11ff64b64febc098a87727a2aad44b


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `4947b00e52c41dc0822db45bc45ed44dc696dad7`
- Image tag: `4947b00e`
- Image digest: `sha256:03bcb2e644758aa745117dd70e94293c4c11ff64b64febc098a87727a2aad44b`
- Source CI run: `25891490939`
- Control-plane serving digest: `sha256:59ceafa05c1b4d1051b26a87f5fc73a4fe468009776b1aeb6af69bbdf096d348`
- Updated API rollout annotation
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`
- Published source-serving proof env for revenue repair custody gates