### PR TITLE
fix(jangar): align revenue repair custody evidence

### DIFF
--- a/docs/agents/designs/200-jangar-revenue-repair-settlement-conveyor-and-stage-health-custody-2026-05-14.md
+++ b/docs/agents/designs/200-jangar-revenue-repair-settlement-conveyor-and-stage-health-custody-2026-05-14.md
@@ -367,6 +367,18 @@ Implement this only after or alongside Torghut's compact conveyor ref. The first
 the compact ref, emit a custody decision, and keep it in shadow unless the Torghut producer is live. Acceptance is a
 testable status object that denies unchanged no-delta repair and nonzero notional while preserving observe access.
 
+2026-05-14 alpha-evidence compatibility follow-up:
+
+- Revenue-repair custody now accepts the later alpha closure-board and executable-alpha receipt surfaces as settlement
+  evidence when the older compact conveyor ref is absent.
+- Queue-head evidence from Torghut consumer evidence is enough to infer `business_state=repair_only` for custody; the
+  reducer should not emit `business_state_missing` or `revenue_repair_top_item_missing` when a current
+  `repair_alpha_readiness` queue item is already present.
+- Active closure-board no-delta evidence remains a denial, not an allow. The denial must cite the closure board,
+  active release key, no-delta budget state, validation command, and rollback target.
+- This keeps `ready_status_truth` aligned with `/ready.material_evidence_settlement_spine.business_truth` while still
+  reducing duplicate repair launches that would worsen `failed_agentrun_rate`.
+
 ## Deployer Handoff
 
 Do not call the Jangar side ready just because `/ready` is HTTP 200. The deployer must prove Argo, workloads, service

--- a/docs/agents/designs/206-jangar-material-evidence-settlement-spine-and-repair-dispatch-budget-2026-05-14.md
+++ b/docs/agents/designs/206-jangar-material-evidence-settlement-spine-and-repair-dispatch-budget-2026-05-14.md
@@ -423,6 +423,20 @@ Next implementation milestone:
 - Enforcement remains observe-mode and additive. If the settlement is missing or stale, existing runtime admission,
   stage clearance, stage credit, evidence pressure, and Torghut zero-notional gates remain authoritative.
 
+2026-05-14 revenue-repair custody alignment follow-up:
+
+- The revenue-repair custody reducer now treats three alpha evidence shapes as valid settlement evidence:
+  `alpha_readiness_settlement_conveyor`, `alpha_repair_closure_board`, and
+  `executable_alpha_repair_receipts.selected_receipt`.
+- When Torghut consumer evidence carries a current queue head, custody derives `repair_only` from that queue instead
+  of reporting `business_state_missing`; this removes a false transport-missing signal from ready truth while
+  preserving material holds.
+- If the current closure board has an active no-delta budget or pending no-delta settlement market, custody returns
+  `deny` with the active release key and closure-board reason codes. It does not convert no-delta evidence into a
+  repair budget.
+- The implementation remains additive to the material settlement spine and keeps Torghut `max_notional=0` as a hard
+  safety condition.
+
 ## Deployer Handoff
 
 After engineer PR merge and image promotion, deployer must prove:

--- a/docs/agents/release-handoffs/jangar-revenue-repair-custody-alpha-evidence-2026-05-14.md
+++ b/docs/agents/release-handoffs/jangar-revenue-repair-custody-alpha-evidence-2026-05-14.md
@@ -1,0 +1,98 @@
+# Jangar revenue-repair custody alpha evidence handoff - 2026-05-14
+
+Swarm: `jangar-control-plane`
+Branch: `codex/swarm-jangar-control-plane`
+Governing designs:
+
+- `docs/agents/designs/200-jangar-revenue-repair-settlement-conveyor-and-stage-health-custody-2026-05-14.md`
+- `docs/agents/designs/206-jangar-material-evidence-settlement-spine-and-repair-dispatch-budget-2026-05-14.md`
+
+## Owner update message
+
+I shipped a Jangar ready-truth cleanup in source: revenue-repair custody now understands the current Torghut alpha
+evidence shapes instead of treating newer closure-board and executable-alpha receipt evidence as missing. The runtime
+decision stays conservative: active no-delta closure-board evidence still denies duplicate `dispatch_repair`, and
+Torghut remains zero-notional.
+
+The selected value gates are `ready_status_truth`, `failed_agentrun_rate`, and `handoff_evidence_quality`. The change
+reduces false missing-evidence reasons in Jangar status and keeps duplicate no-delta repair launches blocked with the
+specific release key and rollback target.
+
+## Runtime evidence
+
+Before local implementation, `GET http://agents.agents.svc.cluster.local/ready` returned:
+
+- `status=ok`
+- `business_state=repair_only`
+- `revenue_ready=false`
+- top queue item `repair_alpha_readiness`
+- top queue reason `alpha_readiness_not_promotion_eligible`
+- affected value gate `routeable_candidate_count`
+- `execution_trust.status=degraded`
+- blocker `jangar-control-plane:verify` consecutive failures
+- `material_evidence_settlement_spine.business_truth.selected_value_gate=routeable_candidate_count`
+- `material_evidence_settlement_spine.business_truth.max_notional=0`
+
+Full status in the same window still reported revenue-repair custody reasons such as `business_state_missing`,
+`revenue_repair_top_item_missing`, and `alpha_readiness_settlement_conveyor_missing` on paths where newer alpha
+closure-board or executable-alpha evidence was available. This PR fixes that reducer-level mismatch.
+
+After local implementation, the live deployed service is unchanged until image promotion. A later read still returned
+`status=ok`, `business_state=repair_only`, `revenue_ready=false`, top repair `repair_alpha_readiness`, affected value
+gate `routeable_candidate_count`, material settlement `decision=hold`, and `max_notional=0`. Execution trust remained
+degraded, with current evidence naming stale Jangar verify and Torghut verify consecutive failures. Source-level tests
+prove the reducer now classifies executable-alpha receipts as current alpha evidence and closure-board no-delta
+evidence as a denial instead of missing evidence.
+
+## What changed
+
+- `buildRevenueRepairSettlementCustody` now resolves alpha settlement evidence from the legacy conveyor, the alpha
+  repair closure board, or the selected executable-alpha repair receipt.
+- Custody derives `repair_only` from the live queue head when top-level Torghut business fields are absent but the
+  queue carries `repair_alpha_readiness`.
+- Active closure-board no-delta state now produces a denial with `active_no_delta_lease` and closure-board reason
+  codes, not a missing-conveyor hold.
+- Regression tests cover queue-only executable-alpha evidence and active no-delta closure-board evidence.
+
+## Validation
+
+- `bun install --frozen-lockfile --ignore-scripts`: pass
+- `bun run --cwd services/jangar test -- src/server/__tests__/control-plane-revenue-repair-settlement-custody.test.ts`:
+  pass, 9 tests
+- `bun run --cwd services/jangar test -- src/server/__tests__/control-plane-revenue-repair-settlement-custody.test.ts src/server/__tests__/control-plane-status.test.ts src/routes/ready.test.ts`:
+  pass, 57 tests
+- `bun run --cwd services/jangar test`: pass, 199 files, 1254 tests
+- `bun run --cwd services/jangar check:module-sizes`: pass
+- `bun run --cwd services/jangar lint`: pass
+- `bunx oxlint --config .oxlintrc.json services/jangar/src/server/control-plane-revenue-repair-settlement-custody.ts services/jangar/src/server/__tests__/control-plane-revenue-repair-settlement-custody.test.ts`:
+  pass, 0 warnings and 0 errors
+- `bun run --cwd services/jangar lint:oxlint`: pass with existing repository warning-only baseline and 0 errors
+- `bun run --cwd services/jangar lint:oxlint:type`: pass with existing repository warning-only baseline and 0 errors
+- `bun run --cwd services/jangar tsc`: pass
+- `bun run --cwd services/jangar build`: pass
+- `bunx oxfmt --check services/jangar/src/server/control-plane-revenue-repair-settlement-custody.ts services/jangar/src/server/__tests__/control-plane-revenue-repair-settlement-custody.test.ts`:
+  pass
+- `bunx oxfmt --check services/jangar/src/server/control-plane-revenue-repair-settlement-custody.ts services/jangar/src/server/__tests__/control-plane-revenue-repair-settlement-custody.test.ts docs/agents/designs/200-jangar-revenue-repair-settlement-conveyor-and-stage-health-custody-2026-05-14.md docs/agents/designs/206-jangar-material-evidence-settlement-spine-and-repair-dispatch-budget-2026-05-14.md docs/agents/release-handoffs/jangar-revenue-repair-custody-alpha-evidence-2026-05-14.md`:
+  pass
+- `git diff --check`: pass
+
+## Risks and rollback
+
+- Risk: `torghut_conveyor_ref` can now hold a closure-board id or executable-alpha receipt id for compatibility with
+  existing custody consumers. Mitigation: governing design refs and reason codes identify the source evidence.
+- Risk: treating executable-alpha receipts as settlement evidence could look like dispatch approval. Mitigation:
+  stage credit, source-serving proof, material gate digest, no-delta state, and zero-notional checks still participate
+  in the custody decision.
+- Rollback: revert this PR or ignore `revenue_repair_settlement_custody` for alpha closure-board/executable-alpha
+  evidence; ready truth, material evidence settlement spine, repair-slot escrow, and Torghut `max_notional=0` remain
+  authoritative.
+
+## Deployer proof after rollout
+
+- Confirm Argo `agents` and `jangar` are `Synced/Healthy`.
+- Confirm `agents` and `agents-controllers` deployments are ready.
+- Confirm `/ready.status=ok`, `business_state=repair_only`, and `revenue_ready=false`.
+- Confirm full status no longer reports `business_state_missing` or `alpha_readiness_settlement_conveyor_missing`
+  when current alpha closure-board or selected executable-alpha evidence is present.
+- Confirm active no-delta closure-board evidence still denies duplicate `dispatch_repair` and keeps capital at
+  `max_notional=0`.

--- a/services/jangar/src/server/__tests__/control-plane-revenue-repair-settlement-custody.test.ts
+++ b/services/jangar/src/server/__tests__/control-plane-revenue-repair-settlement-custody.test.ts
@@ -7,8 +7,10 @@ import type {
   SourceServingContractVerdictExchange,
   StageCreditAccount,
   StageCreditLedger,
+  TorghutAlphaRepairClosureBoardRef,
   TorghutAlphaReadinessSettlementConveyorRef,
   TorghutConsumerEvidenceStatus,
+  TorghutExecutableAlphaRepairReceiptSet,
 } from '~/data/agents-control-plane'
 import {
   buildRevenueRepairSettlementCustody,
@@ -184,6 +186,93 @@ const settlementConveyor = (
   ...overrides,
 })
 
+const closureBoard = (
+  overrides: Partial<TorghutAlphaRepairClosureBoardRef> = {},
+): TorghutAlphaRepairClosureBoardRef => ({
+  schema_version: 'torghut.alpha-repair-closure-board-ref.v1',
+  board_id: 'alpha-repair-closure-board:current',
+  generated_at: now.toISOString(),
+  fresh_until: '2026-05-14T09:30:00.000Z',
+  status: 'selected',
+  reason_codes: [],
+  top_closure_id: 'alpha-repair-closure:current',
+  selected_value_gate: 'routeable_candidate_count',
+  required_output_receipt: 'torghut.executable-alpha-receipts.v1',
+  settlement_market_id: 'alpha-closure-settlement-market:current',
+  settlement_market_status: 'pending_no_delta',
+  selected_hypothesis_id: 'H-MICRO-01',
+  selected_repair_class: 'evidence_window_refresh',
+  required_settlement_receipt: 'torghut.alpha-closure-settlement-receipt.v1',
+  active_dedupe_key: 'alpha-closure-dedupe:H-MICRO-01:window-a',
+  no_delta_budget_state: 'consumed',
+  no_delta_debt_count: 1,
+  next_allowed_attempt_after: null,
+  max_notional: '0',
+  capital_rule: 'zero_notional_repair_only',
+  release_conditions: ['evidence_window_changes', 'blocker_set_changes'],
+  validation_commands: ['uv run --frozen pytest services/torghut/tests/test_executable_alpha_repair_receipts.py'],
+  rollback_target: 'disable alpha_repair_closure_board emission and keep Torghut max_notional=0',
+  ...overrides,
+})
+
+const executableAlphaReceipts = (
+  overrides: Partial<TorghutExecutableAlphaRepairReceiptSet> = {},
+): TorghutExecutableAlphaRepairReceiptSet => ({
+  schema_version: 'torghut.executable-alpha-repair-receipts.v1',
+  generated_at: now.toISOString(),
+  fresh_until: '2026-05-14T09:30:00.000Z',
+  source_revenue_repair_ref: 'torghut-revenue-repair-digest:current',
+  status: 'selected',
+  governing_design_ref:
+    'docs/torghut/design-system/v6/197-torghut-executable-alpha-repair-receipts-and-zero-notional-reentry-2026-05-13.md',
+  selected_receipt_id: 'executable-alpha-repair-receipt:current',
+  selected_receipt: {
+    schema_version: 'torghut.executable-alpha-repair-receipt.v1',
+    receipt_id: 'executable-alpha-repair-receipt:current',
+    generated_at: now.toISOString(),
+    fresh_until: '2026-05-14T09:30:00.000Z',
+    source_revenue_repair_ref: 'torghut-revenue-repair-digest:current',
+    hypothesis_id: 'H-MICRO-01',
+    repair_class: 'evidence_window_refresh',
+    target_value_gate: 'routeable_candidate_count',
+    reason_codes: ['alpha_readiness_not_promotion_eligible'],
+    account_id: 'PA3SX7FYNUTF',
+    window: '15m',
+    trading_mode: 'paper',
+    candidate_id: 'chip-paper-microbar-composite@execution-proof',
+    strategy_id: 'microbar_volume_continuation_long_top2_chip_v1@paper',
+    lineage_status: 'ready',
+    evidence_window_status: 'stale',
+    alpha_readiness_state: 'blocked',
+    expected_unblock_value: 2,
+    expected_gate_delta: 'retire_alpha_readiness_not_promotion_eligible',
+    required_input_refs: ['capital-replay:current'],
+    required_output_receipts: ['alpha_readiness_receipt', 'hypothesis_promotion_receipt'],
+    validation_commands: ['uv run --frozen pytest services/torghut/tests/test_executable_alpha_repair_receipts.py'],
+    max_notional: '0',
+    capital_rule: 'zero_notional_repair_only',
+    no_delta_settlement_required: true,
+    jangar_reentry: {
+      required_material_reentry_receipt: 'jangar.material-reentry-receipt.v1',
+      action_class: 'dispatch_repair',
+      max_parallelism: 1,
+      max_runtime_seconds: 1200,
+      value_gates: ['routeable_candidate_count'],
+      rollback_target: 'keep max_notional=0 and live submit disabled',
+    },
+    rollback_target: 'stop emitting executable_alpha_repair_receipts and keep Torghut max_notional=0',
+  },
+  receipt_count: 1,
+  receipts: [],
+  target_value_gate: 'routeable_candidate_count',
+  routeable_candidate_count_before: 0,
+  max_notional: '0',
+  capital_rule: 'zero_notional_repair_only',
+  reason_codes: [],
+  rollback_target: 'stop emitting executable_alpha_repair_receipts and keep Torghut max_notional=0',
+  ...overrides,
+})
+
 const torghutEvidence = (overrides: Partial<TorghutConsumerEvidenceStatus> = {}): TorghutConsumerEvidenceStatus => ({
   status: 'current',
   endpoint: 'http://torghut.torghut.svc.cluster.local/trading/consumer-evidence',
@@ -258,6 +347,56 @@ describe('buildRevenueRepairSettlementCustody', () => {
     expect(custody.decision).toBe('hold')
     expect(custody.reason_codes).toContain('alpha_readiness_settlement_conveyor_missing')
     expect(custody.no_delta_release_state).toBe('missing')
+  })
+
+  it('uses executable alpha receipts when revenue repair topline is queue-only', () => {
+    const custody = build({
+      torghut: {
+        revenue_repair_business_state: null,
+        revenue_repair_ready: null,
+        alpha_readiness_settlement_conveyor: null,
+        executable_alpha_repair_receipts: executableAlphaReceipts(),
+      },
+    })
+
+    expect(custody.decision).toBe('allow')
+    expect(custody.torghut_conveyor_ref).toBe('executable-alpha-repair-receipt:current')
+    expect(custody.selected_hypothesis_id).toBe('H-MICRO-01')
+    expect(custody.selected_value_gate).toBe('routeable_candidate_count')
+    expect(custody.validation_command).toBe(
+      'uv run --frozen pytest services/torghut/tests/test_executable_alpha_repair_receipts.py',
+    )
+    expect(custody.reason_codes).not.toContain('business_state_missing')
+    expect(custody.reason_codes).not.toContain('alpha_readiness_settlement_conveyor_missing')
+    expect(custody.governing_design_refs).toContain(
+      'docs/agents/designs/206-jangar-material-evidence-settlement-spine-and-repair-dispatch-budget-2026-05-14.md',
+    )
+  })
+
+  it('denies active no-delta closure boards without reporting the alpha evidence missing', () => {
+    const custody = build({
+      torghut: {
+        revenue_repair_business_state: null,
+        revenue_repair_ready: null,
+        alpha_readiness_settlement_conveyor: null,
+        alpha_repair_closure_board: closureBoard(),
+      },
+    })
+
+    expect(custody.decision).toBe('deny')
+    expect(custody.torghut_conveyor_ref).toBe('alpha-repair-closure-board:current')
+    expect(custody.no_delta_release_key).toBe('alpha-closure-dedupe:H-MICRO-01:window-a')
+    expect(custody.no_delta_release_state).toBe('active')
+    expect(custody.reason_codes).toEqual(
+      expect.arrayContaining([
+        'active_no_delta_lease',
+        'alpha_closure_no_delta_budget_consumed',
+        'alpha_closure_settlement_market_pending_no_delta',
+        'alpha_closure_no_delta_debt_active',
+      ]),
+    )
+    expect(custody.reason_codes).not.toContain('business_state_missing')
+    expect(custody.reason_codes).not.toContain('alpha_readiness_settlement_conveyor_missing')
   })
 
   it('denies stale conveyor refs', () => {

--- a/services/jangar/src/server/control-plane-revenue-repair-settlement-custody.ts
+++ b/services/jangar/src/server/control-plane-revenue-repair-settlement-custody.ts
@@ -86,6 +86,108 @@ export const deriveRevenueRepairReadiness = (status: TorghutConsumerEvidenceStat
 const isTopAlphaRepair = (item: TorghutRevenueRepairQueueItem | null) =>
   item?.code === 'repair_alpha_readiness' || item?.reason === 'alpha_readiness_not_promotion_eligible'
 
+type AlphaSettlementEvidence = {
+  source: 'alpha_readiness_settlement_conveyor' | 'alpha_repair_closure_board' | 'executable_alpha_repair_receipt'
+  ref: string | null
+  freshUntil: string | null
+  status: string | null
+  selectedHypothesisId: string | null
+  selectedValueGate: string | null
+  validationCommand: string | null
+  noDeltaReleaseKey: string | null
+  noDeltaReleaseState: RevenueRepairSettlementCustody['no_delta_release_state']
+  maxNotional: string | null
+  capitalRule: string | null
+  reasonCodes: string[]
+  rollbackTarget: string | null
+}
+
+const closureBoardNoDeltaActive = (board: NonNullable<TorghutConsumerEvidenceStatus['alpha_repair_closure_board']>) => {
+  const noDeltaState = normalizeReason(board.no_delta_budget_state)
+  const marketStatus = normalizeReason(board.settlement_market_status)
+  return (
+    noDeltaState === 'consumed' ||
+    marketStatus === 'pending_no_delta' ||
+    marketStatus === 'no_delta' ||
+    (board.no_delta_debt_count ?? 0) > 0
+  )
+}
+
+const alphaSettlementEvidence = (status: TorghutConsumerEvidenceStatus): AlphaSettlementEvidence | null => {
+  const conveyor = status.alpha_readiness_settlement_conveyor ?? null
+  if (conveyor) {
+    const noDeltaActive = (conveyor.active_no_delta_lease_count ?? 0) > 0 || conveyor.repeat_launch_decision === 'deny'
+    return {
+      source: 'alpha_readiness_settlement_conveyor',
+      ref: conveyor.conveyor_id,
+      freshUntil: conveyor.fresh_until,
+      status: conveyor.status,
+      selectedHypothesisId: conveyor.selected_hypothesis_id,
+      selectedValueGate: conveyor.selected_value_gate,
+      validationCommand: conveyor.validation_command,
+      noDeltaReleaseKey: conveyor.no_delta_release_key,
+      noDeltaReleaseState: noDeltaActive ? 'active' : conveyor.no_delta_release_key ? 'clear' : 'missing',
+      maxNotional: conveyor.max_notional,
+      capitalRule: conveyor.capital_rule,
+      reasonCodes: conveyor.reason_codes,
+      rollbackTarget: conveyor.rollback_target,
+    }
+  }
+
+  const closureBoard = status.alpha_repair_closure_board ?? null
+  if (closureBoard) {
+    const noDeltaActive = closureBoardNoDeltaActive(closureBoard)
+    const noDeltaState = normalizeReason(closureBoard.no_delta_budget_state)
+    const marketStatus = normalizeReason(closureBoard.settlement_market_status)
+    const releaseKey = closureBoard.active_dedupe_key ?? closureBoard.settlement_market_id ?? closureBoard.board_id
+    return {
+      source: 'alpha_repair_closure_board',
+      ref: closureBoard.board_id,
+      freshUntil: closureBoard.fresh_until,
+      status: closureBoard.status,
+      selectedHypothesisId: closureBoard.selected_hypothesis_id,
+      selectedValueGate: closureBoard.selected_value_gate,
+      validationCommand:
+        closureBoard.validation_commands[0] ?? `curl -fsS ${status.endpoint} | jq '.alpha_repair_closure_board'`,
+      noDeltaReleaseKey: noDeltaActive ? releaseKey : closureBoard.active_dedupe_key,
+      noDeltaReleaseState: noDeltaActive ? 'active' : closureBoard.active_dedupe_key ? 'clear' : 'missing',
+      maxNotional: closureBoard.max_notional,
+      capitalRule: closureBoard.capital_rule,
+      reasonCodes: uniqueStrings([
+        ...closureBoard.reason_codes,
+        noDeltaActive ? 'active_no_delta_lease' : null,
+        noDeltaState === 'consumed' ? 'alpha_closure_no_delta_budget_consumed' : null,
+        marketStatus === 'pending_no_delta' || marketStatus === 'no_delta'
+          ? `alpha_closure_settlement_market_${marketStatus}`
+          : null,
+        (closureBoard.no_delta_debt_count ?? 0) > 0 ? 'alpha_closure_no_delta_debt_active' : null,
+      ]),
+      rollbackTarget: closureBoard.rollback_target,
+    }
+  }
+
+  const executableReceipts = status.executable_alpha_repair_receipts ?? null
+  const selectedReceipt = executableReceipts?.selected_receipt ?? null
+  if (!executableReceipts && !selectedReceipt) return null
+  return {
+    source: 'executable_alpha_repair_receipt',
+    ref: selectedReceipt?.receipt_id ?? executableReceipts?.selected_receipt_id ?? null,
+    freshUntil: selectedReceipt?.fresh_until ?? executableReceipts?.fresh_until ?? null,
+    status: executableReceipts?.status ?? null,
+    selectedHypothesisId: selectedReceipt?.hypothesis_id ?? null,
+    selectedValueGate: selectedReceipt?.target_value_gate ?? executableReceipts?.target_value_gate ?? null,
+    validationCommand:
+      selectedReceipt?.validation_commands[0] ??
+      `curl -fsS ${status.endpoint} | jq '.executable_alpha_repair_receipts.selected_receipt'`,
+    noDeltaReleaseKey: null,
+    noDeltaReleaseState: 'missing',
+    maxNotional: selectedReceipt?.max_notional ?? executableReceipts?.max_notional ?? null,
+    capitalRule: selectedReceipt?.capital_rule ?? executableReceipts?.capital_rule ?? null,
+    reasonCodes: [],
+    rollbackTarget: selectedReceipt?.rollback_target ?? executableReceipts?.rollback_target ?? null,
+  }
+}
+
 const stageAccountFor = (
   stageCreditLedger: StageCreditLedger | null,
   actionClass: ActionSloBudgetActionClass,
@@ -107,9 +209,10 @@ const normalizeDecision = (value: string | null | undefined): ReadyTruthActionDe
 }
 
 const freshUntilFor = (input: BuildRevenueRepairSettlementCustodyInput) => {
+  const settlementEvidence = alphaSettlementEvidence(input.torghutConsumerEvidence)
   const times = [
     input.torghutConsumerEvidence.fresh_until,
-    input.torghutConsumerEvidence.alpha_readiness_settlement_conveyor?.fresh_until,
+    settlementEvidence?.freshUntil,
     input.stageCreditLedger?.fresh_until,
     input.sourceServingContractVerdictExchange.fresh_until,
   ]
@@ -165,44 +268,51 @@ const rolloutProof = (input: BuildRevenueRepairSettlementCustodyInput) => {
 
 const conveyorReasons = (input: BuildRevenueRepairSettlementCustodyInput) => {
   const torghut = input.torghutConsumerEvidence
-  const conveyor = torghut.alpha_readiness_settlement_conveyor ?? null
+  const settlementEvidence = alphaSettlementEvidence(torghut)
   const topItem = topRepairQueueItem(torghut)
+  const { businessState } = deriveRevenueRepairReadiness(torghut)
   const reasons: string[] = []
 
   if (torghut.status !== 'current') reasons.push(`torghut_consumer_evidence_${torghut.status}`)
-  if (torghut.revenue_repair_business_state !== 'repair_only') {
-    reasons.push(`business_state_${torghut.revenue_repair_business_state ?? 'missing'}`)
+  if (businessState !== 'repair_only') {
+    reasons.push(`business_state_${businessState ?? 'missing'}`)
   }
   if (!topItem) {
     reasons.push('revenue_repair_top_item_missing')
   } else if (!isTopAlphaRepair(topItem)) {
     reasons.push('revenue_repair_top_item_not_alpha_readiness')
   }
-  if (!conveyor) {
+  if (!settlementEvidence) {
     reasons.push('alpha_readiness_settlement_conveyor_missing')
     return uniqueStrings(reasons)
   }
-  if (!conveyor.conveyor_id) reasons.push('alpha_readiness_settlement_conveyor_ref_missing')
-  if (!isFresh(conveyor.fresh_until, input.now)) reasons.push('alpha_readiness_settlement_conveyor_stale')
-  if (conveyor.selected_value_gate !== 'routeable_candidate_count') {
-    reasons.push(`selected_value_gate_${conveyor.selected_value_gate ?? 'missing'}`)
+  if (!settlementEvidence.ref) reasons.push(`${settlementEvidence.source}_ref_missing`)
+  if (!isFresh(settlementEvidence.freshUntil, input.now)) reasons.push(`${settlementEvidence.source}_stale`)
+  if (settlementEvidence.selectedValueGate !== 'routeable_candidate_count') {
+    reasons.push(`selected_value_gate_${settlementEvidence.selectedValueGate ?? 'missing'}`)
   }
-  if (!isZeroNotional(conveyor.max_notional)) reasons.push('capital_notional_nonzero')
-  if (conveyor.capital_rule && conveyor.capital_rule !== 'zero_notional_repair_only') {
+  if (!isZeroNotional(settlementEvidence.maxNotional)) reasons.push('capital_notional_nonzero')
+  if (settlementEvidence.capitalRule && settlementEvidence.capitalRule !== 'zero_notional_repair_only') {
     reasons.push('capital_rule_not_zero_notional_repair_only')
   }
-  if ((conveyor.active_no_delta_lease_count ?? 0) > 0 || conveyor.repeat_launch_decision === 'deny') {
+  if (settlementEvidence.noDeltaReleaseState === 'active') {
     reasons.push('active_no_delta_lease')
   }
 
-  const conveyorStatus = conveyor.status ?? 'missing'
-  if (CONVEYOR_HOLD_STATUSES.has(conveyorStatus)) {
+  const conveyorStatus = settlementEvidence.status ?? 'missing'
+  if (
+    settlementEvidence.source === 'alpha_readiness_settlement_conveyor' &&
+    CONVEYOR_HOLD_STATUSES.has(conveyorStatus)
+  ) {
     reasons.push(`alpha_readiness_settlement_conveyor_${conveyorStatus}`)
-  } else if (!CONVEYOR_ALLOW_STATUSES.has(conveyorStatus)) {
+  } else if (
+    settlementEvidence.source === 'alpha_readiness_settlement_conveyor' &&
+    !CONVEYOR_ALLOW_STATUSES.has(conveyorStatus)
+  ) {
     reasons.push(`alpha_readiness_settlement_conveyor_${conveyorStatus}`)
   }
 
-  return uniqueStrings([...reasons, ...conveyor.reason_codes])
+  return uniqueStrings([...reasons, ...settlementEvidence.reasonCodes])
 }
 
 const decisionFor = (reasons: string[]): RevenueRepairSettlementCustodyDecision => {
@@ -236,29 +346,24 @@ export const buildRevenueRepairSettlementCustody = (
   input: BuildRevenueRepairSettlementCustodyInput,
   mode: ReadyTruthArbiterMode = 'shadow',
 ): RevenueRepairSettlementCustody => {
-  const conveyor = input.torghutConsumerEvidence.alpha_readiness_settlement_conveyor ?? null
+  const settlementEvidence = alphaSettlementEvidence(input.torghutConsumerEvidence)
   const stage = stageHealth(input)
   const rollout = rolloutProof(input)
   const reasonCodes = uniqueStrings([...conveyorReasons(input), ...stage.reasonCodes, ...rollout.reasonCodes]).map(
     (reason) => normalizeReason(reason) ?? reason,
   )
   const decision = decisionFor(reasonCodes)
-  const noDeltaReleaseState =
-    conveyor && ((conveyor.active_no_delta_lease_count ?? 0) > 0 || conveyor.repeat_launch_decision === 'deny')
-      ? 'active'
-      : conveyor?.no_delta_release_key
-        ? 'clear'
-        : 'missing'
+  const noDeltaReleaseState = settlementEvidence?.noDeltaReleaseState ?? 'missing'
   const evidenceRefs = uniqueStrings([
     input.torghutConsumerEvidence.receipt_id,
-    conveyor?.conveyor_id,
+    settlementEvidence?.ref,
     ...stage.evidenceRefs,
     ...rollout.evidenceRefs,
   ])
   const custodyId = `revenue-repair-settlement-custody:${input.namespace}:${hashJson({
     consumer_ref: input.torghutConsumerEvidence.receipt_id,
-    conveyor_ref: conveyor?.conveyor_id ?? null,
-    selected_value_gate: conveyor?.selected_value_gate ?? null,
+    alpha_settlement_ref: settlementEvidence?.ref ?? null,
+    selected_value_gate: settlementEvidence?.selectedValueGate ?? null,
     decision,
     reasonCodes,
   })}`
@@ -273,13 +378,14 @@ export const buildRevenueRepairSettlementCustody = (
     governing_design_refs: [
       REVENUE_REPAIR_SETTLEMENT_CUSTODY_DESIGN_ARTIFACT,
       'docs/torghut/design-system/v6/205-torghut-alpha-readiness-settlement-conveyor-and-routeable-profit-runway-2026-05-14.md',
+      'docs/agents/designs/206-jangar-material-evidence-settlement-spine-and-repair-dispatch-budget-2026-05-14.md',
       'swarm-validation-contract:every-run-cites-governing-requirement',
     ],
     torghut_consumer_evidence_ref: input.torghutConsumerEvidence.receipt_id,
-    torghut_conveyor_ref: conveyor?.conveyor_id ?? null,
-    selected_hypothesis_id: conveyor?.selected_hypothesis_id ?? null,
+    torghut_conveyor_ref: settlementEvidence?.ref ?? null,
+    selected_hypothesis_id: settlementEvidence?.selectedHypothesisId ?? null,
     selected_value_gate:
-      conveyor?.selected_value_gate ?? topRepairQueueItem(input.torghutConsumerEvidence)?.value_gate ?? null,
+      settlementEvidence?.selectedValueGate ?? topRepairQueueItem(input.torghutConsumerEvidence)?.value_gate ?? null,
     action_class: 'dispatch_repair',
     decision,
     reason_codes: reasonCodes,
@@ -290,7 +396,7 @@ export const buildRevenueRepairSettlementCustody = (
       retained_failure_debt_refs: input.stageCreditLedger?.retained_failure_debt_refs ?? [],
       reason_codes: stage.reasonCodes,
     },
-    no_delta_release_key: conveyor?.no_delta_release_key ?? null,
+    no_delta_release_key: settlementEvidence?.noDeltaReleaseKey ?? null,
     no_delta_release_state: noDeltaReleaseState,
     rollout_proof: {
       source_serving_verdict_ref: rollout.sourceServingVerdictRef,
@@ -299,8 +405,8 @@ export const buildRevenueRepairSettlementCustody = (
       reason_codes: rollout.reasonCodes,
     },
     validation_command:
-      conveyor?.validation_command ??
+      settlementEvidence?.validationCommand ??
       `curl -fsS ${input.torghutConsumerEvidence.endpoint} | jq '.alpha_readiness_settlement_conveyor'`,
-    rollback_target: conveyor?.rollback_target ?? ROLLBACK_TARGET,
+    rollback_target: settlementEvidence?.rollbackTarget ?? ROLLBACK_TARGET,
   }
 }


### PR DESCRIPTION
## Summary

- Updates Jangar revenue-repair custody to accept the current Torghut alpha evidence surfaces:
  `alpha_readiness_settlement_conveyor`, `alpha_repair_closure_board`, and selected executable-alpha repair receipts.
- Fixes a ready-truth mismatch where queue-head alpha repair evidence could still be reported as
  `business_state_missing`, `revenue_repair_top_item_missing`, or `alpha_readiness_settlement_conveyor_missing`.
- Keeps the runtime decision conservative: active closure-board no-delta evidence denies duplicate `dispatch_repair`
  with the release key, validation command, and rollback target; Torghut remains `max_notional=0`.
- Updates design and release handoff docs with provenance, before/after readiness evidence, risk, rollback, and
  validation.
- Governing designs:
  `docs/agents/designs/200-jangar-revenue-repair-settlement-conveyor-and-stage-health-custody-2026-05-14.md` and
  `docs/agents/designs/206-jangar-material-evidence-settlement-spine-and-repair-dispatch-budget-2026-05-14.md`.

## Related Issues

None

## Testing

- PASS: `bun install --frozen-lockfile --ignore-scripts`
- PASS: `bun run --cwd services/jangar test -- src/server/__tests__/control-plane-revenue-repair-settlement-custody.test.ts`
- PASS: `bun run --cwd services/jangar test -- src/server/__tests__/control-plane-revenue-repair-settlement-custody.test.ts src/server/__tests__/control-plane-status.test.ts src/routes/ready.test.ts`
- PASS: `bun run --cwd services/jangar test`
- PASS: `bun run --cwd services/jangar check:module-sizes`
- PASS: `bun run --cwd services/jangar lint`
- PASS: `bunx oxlint --config .oxlintrc.json services/jangar/src/server/control-plane-revenue-repair-settlement-custody.ts services/jangar/src/server/__tests__/control-plane-revenue-repair-settlement-custody.test.ts`
- PASS: `bun run --cwd services/jangar lint:oxlint` with existing repository warning-only baseline and 0 errors
- PASS: `bun run --cwd services/jangar lint:oxlint:type` with existing repository warning-only baseline and 0 errors
- PASS: `bun run --cwd services/jangar tsc`
- PASS: `bun run --cwd services/jangar build`
- PASS: `bunx oxfmt --check services/jangar/src/server/control-plane-revenue-repair-settlement-custody.ts services/jangar/src/server/__tests__/control-plane-revenue-repair-settlement-custody.test.ts docs/agents/designs/200-jangar-revenue-repair-settlement-conveyor-and-stage-health-custody-2026-05-14.md docs/agents/designs/206-jangar-material-evidence-settlement-spine-and-repair-dispatch-budget-2026-05-14.md docs/agents/release-handoffs/jangar-revenue-repair-custody-alpha-evidence-2026-05-14.md`
- PASS: `git diff --check`
- PASS: hosted `agents-ci / validate`
- PASS: hosted `agents-ci / integration`
- PASS: hosted `jangar-ci / lint-and-typecheck / run`
- PASS: hosted `check_changed_files`
- PASS: hosted `Lint commit messages`
- PASS: hosted `Validate PR title`

Live evidence before local implementation:

- `/ready.status=ok`
- `business_state=repair_only`
- `revenue_ready=false`
- top repair queue item `repair_alpha_readiness`
- top repair reason `alpha_readiness_not_promotion_eligible`
- affected value gate `routeable_candidate_count`
- `execution_trust.status=degraded`
- material settlement selected value gate `routeable_candidate_count`
- material settlement max notional `0`

Live evidence after local implementation, before deployment:

- `/ready.status=ok`
- `business_state=repair_only`
- `revenue_ready=false`
- top repair queue item `repair_alpha_readiness`
- affected value gate `routeable_candidate_count`
- material settlement decision `hold`
- material settlement max notional `0`
- `execution_trust.status=degraded`; latest read named stale Jangar verify evidence and Torghut verify consecutive
  failures

Final closeout sample after hosted CI, still before deployment:

- `/ready.status=ok`
- `/ready.business_state=repair_only`
- `/ready.revenue_ready=false`
- `/ready.repair_queue[0]` not present in the sampled response
- `/ready.execution_trust.status=healthy`
- Torghut `/trading/revenue-repair` still reports top repair `repair_alpha_readiness` with reason
  `alpha_readiness_not_promotion_eligible`, value gate `routeable_candidate_count`, and `max_notional=0`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.

## Risk Notes

- `torghut_conveyor_ref` can now carry a closure-board id or executable-alpha receipt id for compatibility with
  existing custody consumers; governing design refs and reason codes identify the source evidence.
- The executable-alpha receipt path does not bypass material gates. Stage credit, source-serving proof, material gate
  digest, no-delta state, and zero-notional checks still participate in the custody decision.
- Live business impact requires image promotion and rollout. Until then, deployed `/ready` is external to this local PR
  and may change independently as runtime evidence refreshes.

## Rollback

Revert this PR, or ignore `revenue_repair_settlement_custody` fields derived from closure-board/executable-alpha
evidence. Existing ready truth, material evidence settlement spine, repair-slot escrow, and Torghut `max_notional=0`
remain authoritative.
