### PR TITLE
feat(torghut): expose revenue repair topline

### DIFF
--- a/services/torghut/README.md
+++ b/services/torghut/README.md
@@ -245,6 +245,12 @@ Testing rules for the trading core:
   source, evidence-window, blocker, receipt, selected-hypothesis, or Jangar verify-carry release condition changes, and
   mirrors a compact `torghut.no-delta-repair-reentry-auction-ref.v1` through `/readyz` and
   `/trading/consumer-evidence`. It does not enable paper or live submission.
+- `GET /trading/revenue-repair` now also exposes the May 14 doc 212 top-line business contract fields directly:
+  `top_repair_queue_item`, `selected_value_gate`, `required_output_receipt`, routeable-candidate before/after counts,
+  no-delta reentry decision, repair-bid lot summaries, typed unavailable reason codes, validation commands, and a
+  rollback target. `/trading/status` and `/trading/consumer-evidence` mirror the compact top-line fields so Jangar can
+  compare the direct revenue-repair source with the consumer-evidence action boundary without inferring
+  `repair_queue[0]`. These fields remain additive and keep `max_notional=0`.
 - `GET /trading/revenue-repair` also emits the May 14 doc 211
   `torghut.jangar-controller-ingestion-carry.v1` import reducer. It classifies Jangar controller-ingestion carry as
   `current`, `repairable`, `lagging`, `unavailable`, `stale`, or `contradicted`, feeds that state into the no-delta

--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -1151,6 +1151,7 @@ def _evaluate_trading_health_payload(
             "clock_settlement_receipt": clock_settlement_receipt,
             "route_evidence_clearinghouse_packet": route_evidence_clearinghouse_packet,
             "repair_bid_settlement_ledger": repair_bid_settlement_ledger,
+            **_revenue_repair_topline_fields(revenue_repair_digest),
             "route_warrant_exchange": route_warrant_exchange,
             "source_serving_repair_receipt_ledger": source_serving_repair_receipt_ledger,
             "freshness_carry_ledger": freshness_carry_ledger,
@@ -3099,6 +3100,37 @@ def _consumer_evidence_summary_view(view: str | None) -> bool:
     return (view or "").strip().lower() in {"compact", "summary", "jangar"}
 
 
+def _revenue_repair_topline_fields(
+    revenue_repair_digest: Mapping[str, Any],
+) -> dict[str, object]:
+    keys = (
+        "business_state",
+        "revenue_ready",
+        "capital_state",
+        "capital_stage",
+        "live_submission_allowed",
+        "max_notional",
+        "top_repair_queue_item",
+        "selected_value_gate",
+        "required_output_receipt",
+        "required_receipts",
+        "routeable_candidate_count_before",
+        "routeable_candidate_count_after",
+        "accepted_routeable_candidate_count",
+        "routeable_candidate_delta",
+        "alpha_no_delta_release_key",
+        "no_delta_reentry_decision",
+        "no_delta_reentry_reason_codes",
+        "field_unavailable_reason_codes",
+        "validation_commands",
+        "rollback_target",
+    )
+    return {
+        "revenue_repair_digest_ref": "/trading/revenue-repair",
+        **{key: revenue_repair_digest.get(key) for key in keys},
+    }
+
+
 def _build_trading_consumer_evidence_payload(
     *, summary: bool = False
 ) -> dict[str, object]:
@@ -3492,6 +3524,7 @@ def _build_trading_consumer_evidence_payload(
         "clock_settlement_receipt": clock_settlement_receipt,
         "route_evidence_clearinghouse_packet": route_evidence_clearinghouse_packet,
         "repair_bid_settlement_ledger": repair_bid_settlement_ledger,
+        **_revenue_repair_topline_fields(revenue_repair_digest),
         "alpha_readiness_strike_ledger": revenue_repair_digest.get(
             "alpha_readiness_strike_ledger"
         ),

--- a/services/torghut/app/trading/revenue_repair.py
+++ b/services/torghut/app/trading/revenue_repair.py
@@ -840,6 +840,296 @@ def _summarize_repair_outcome_dividend(
     }
 
 
+def _first_mapping_item(value: object) -> dict[str, Any]:
+    for raw_item in _sequence(value):
+        item = _mapping(raw_item)
+        if item:
+            return item
+    return {}
+
+
+def _first_text(*values: object) -> str | None:
+    for value in values:
+        text = _text(value)
+        if text:
+            return text
+    return None
+
+
+def _top_repair_queue_item(repair_queue: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    for raw_item in repair_queue:
+        item = _mapping(raw_item)
+        if item:
+            return dict(item)
+    return {}
+
+
+def _routeable_candidate_count_from_evidence(evidence: Mapping[str, Any]) -> int:
+    routeability_acceptance = _mapping(evidence.get("routeability_acceptance"))
+    route_evidence_clearinghouse = _mapping(
+        evidence.get("route_evidence_clearinghouse")
+    )
+    repair_bid_settlement = _mapping(evidence.get("repair_bid_settlement"))
+    return max(
+        _int(routeability_acceptance.get("accepted_routeable_candidate_count")),
+        _int(route_evidence_clearinghouse.get("accepted_routeable_candidate_count")),
+        _int(repair_bid_settlement.get("routeable_candidate_count")),
+    )
+
+
+def _repair_bid_settlement_held_lot_ids(
+    repair_bid_settlement: Mapping[str, Any],
+) -> list[str]:
+    held_lot_ids: list[str] = []
+    for raw_lot in _sequence(repair_bid_settlement.get("compacted_lots")):
+        lot = _mapping(raw_lot)
+        lot_id = _text(lot.get("lot_id"))
+        if not lot_id:
+            continue
+        lot_state = _text(lot.get("state")).lower()
+        if lot_state == "held" or lot.get("dispatchable") is False:
+            held_lot_ids.append(lot_id)
+    if held_lot_ids:
+        return _dedupe(held_lot_ids)
+
+    selected = set(_string_items(repair_bid_settlement.get("selected_lot_ids")))
+    dispatchable = set(_string_items(repair_bid_settlement.get("dispatchable_lot_ids")))
+    return sorted(selected - dispatchable)
+
+
+def _state_from_mapping(payload: Mapping[str, Any], *keys: str) -> str | None:
+    for key in keys:
+        text = _text(payload.get(key))
+        if text:
+            return text
+    return None
+
+
+def _jangar_material_evidence_settlement_ref(
+    status_payload: Mapping[str, Any],
+) -> object | None:
+    dependency_quorum = _mapping(status_payload.get("dependency_quorum"))
+    for source in (
+        status_payload,
+        dependency_quorum,
+        _mapping(dependency_quorum.get("control_plane_status")),
+    ):
+        settlement = _mapping(source.get("material_evidence_settlement_spine"))
+        if settlement:
+            return (
+                settlement.get("settlement_id")
+                or settlement.get("spine_id")
+                or settlement.get("id")
+                or dict(settlement)
+            )
+    return None
+
+
+def _validation_commands(
+    *,
+    top_item: Mapping[str, Any],
+    no_delta_repair_reentry_auction: Mapping[str, Any],
+) -> list[str]:
+    selected_ticket = _mapping(no_delta_repair_reentry_auction.get("selected_ticket"))
+    ticket_commands = _string_items(selected_ticket.get("validation_commands"))
+    if ticket_commands:
+        return ticket_commands
+    if _text(top_item.get("code")) == "repair_alpha_readiness":
+        return [
+            "uv run --frozen pytest tests/test_build_revenue_repair_digest.py -k revenue_repair",
+            "uv run --frozen pytest tests/test_no_delta_repair_reentry_auction.py",
+            "uv run --frozen pytest tests/test_consumer_evidence.py -k revenue",
+        ]
+    return [
+        "uv run --frozen pytest tests/test_build_revenue_repair_digest.py -k revenue_repair"
+    ]
+
+
+def _field_unavailable_reason_codes(fields: Mapping[str, object]) -> list[str]:
+    reasons: list[str] = []
+    for field_name, value in fields.items():
+        if value is None:
+            reasons.append(f"{field_name}_unavailable")
+        elif isinstance(value, list) and not value:
+            reasons.append(f"{field_name}_empty")
+    return reasons
+
+
+def _build_topline_contract(
+    *,
+    status_payload: Mapping[str, Any],
+    repair_queue: Sequence[Mapping[str, Any]],
+    capital: Mapping[str, Any],
+    evidence: Mapping[str, Any],
+    repair_bid_settlement: Mapping[str, Any],
+    alpha_evidence_foundry: Mapping[str, Any],
+    alpha_readiness_settlement_conveyor: Mapping[str, Any],
+    alpha_repair_dividend_ledger: Mapping[str, Any],
+    no_delta_repair_reentry_auction: Mapping[str, Any],
+) -> dict[str, object]:
+    top_item = _top_repair_queue_item(repair_queue)
+    first_foundry_receipt = _first_mapping_item(alpha_evidence_foundry.get("receipts"))
+    selected_lane = _mapping(alpha_readiness_settlement_conveyor.get("selected_lane"))
+    selected_target = _first_mapping_item(
+        _mapping(evidence.get("alpha_readiness")).get("repair_targets")
+    )
+    routeable_before = _int(
+        no_delta_repair_reentry_auction.get("routeable_candidate_count_before"),
+        _int(
+            alpha_evidence_foundry.get("routeable_candidate_count_before"),
+            _routeable_candidate_count_from_evidence(evidence),
+        ),
+    )
+    routeable_after = _int(
+        no_delta_repair_reentry_auction.get("routeable_candidate_count_after"),
+        _int(
+            alpha_readiness_settlement_conveyor.get("routeable_candidate_count_after"),
+            _int(
+                alpha_repair_dividend_ledger.get("routeable_candidate_count_after"),
+                routeable_before,
+            ),
+        ),
+    )
+    evidence_clock = _choose_mapping(
+        status_payload.get("evidence_clock_arbiter"),
+        status_payload.get("evidence_clock"),
+    )
+    required_custody = _mapping(evidence_clock.get("required_torghut_custody_ref"))
+    route_warrant = _choose_mapping(
+        status_payload.get("route_warrant_exchange"),
+        status_payload.get("route_warrant"),
+    )
+    jangar_material_ref = _jangar_material_evidence_settlement_ref(status_payload)
+    selected_hypothesis_id = _first_text(
+        no_delta_repair_reentry_auction.get("selected_hypothesis_id"),
+        alpha_repair_dividend_ledger.get("selected_hypothesis_id"),
+        selected_lane.get("hypothesis_id"),
+        first_foundry_receipt.get("hypothesis_id"),
+        selected_target.get("hypothesis_id"),
+    )
+    selected_candidate_id = _first_text(
+        first_foundry_receipt.get("candidate_id"),
+        selected_lane.get("candidate_id"),
+        selected_target.get("candidate_id"),
+    )
+    selected_strategy_id = _first_text(
+        first_foundry_receipt.get("strategy_id"),
+        selected_lane.get("strategy_id"),
+        selected_target.get("strategy_id"),
+    )
+    selected_dataset_snapshot_ref = _first_text(
+        first_foundry_receipt.get("dataset_snapshot_ref"),
+        first_foundry_receipt.get("dataset_snapshot_id"),
+        selected_lane.get("dataset_snapshot_ref"),
+        selected_lane.get("dataset_snapshot_id"),
+        alpha_repair_dividend_ledger.get("dataset_snapshot_ref"),
+    )
+    selected_value_gate = _first_text(
+        no_delta_repair_reentry_auction.get("selected_value_gate"),
+        alpha_evidence_foundry.get("selected_value_gate"),
+        top_item.get("value_gate"),
+    )
+    required_output_receipt = _first_text(
+        top_item.get("required_output_receipt"),
+        no_delta_repair_reentry_auction.get("required_output_receipt"),
+    )
+    top_line: dict[str, object] = {
+        "capital_state": _text(capital.get("capital_state"), "unknown"),
+        "capital_stage": _text(capital.get("capital_stage"), "unknown"),
+        "live_submission_allowed": _bool(capital.get("live_submission_allowed")),
+        "max_notional": _text(capital.get("max_notional"), "0"),
+        "top_repair_queue_item": top_item or None,
+        "selected_value_gate": selected_value_gate,
+        "required_output_receipt": required_output_receipt,
+        "required_receipts": _string_items(top_item.get("required_receipts")),
+        "selected_hypothesis_id": selected_hypothesis_id,
+        "selected_candidate_id": selected_candidate_id,
+        "selected_strategy_id": selected_strategy_id,
+        "selected_dataset_snapshot_ref": selected_dataset_snapshot_ref,
+        "routeable_candidate_count_before": routeable_before,
+        "routeable_candidate_count_after": routeable_after,
+        "accepted_routeable_candidate_count": _routeable_candidate_count_from_evidence(
+            evidence
+        ),
+        "routeable_candidate_delta": routeable_after - routeable_before,
+        "alpha_no_delta_release_key": no_delta_repair_reentry_auction.get(
+            "active_no_delta_release_key"
+        ),
+        "no_delta_reentry_decision": no_delta_repair_reentry_auction.get(
+            "reentry_decision"
+        ),
+        "no_delta_reentry_reason_codes": _string_items(
+            no_delta_repair_reentry_auction.get("reason_codes")
+        ),
+        "repair_bid_settlement_status": _first_text(
+            repair_bid_settlement.get("status"),
+            repair_bid_settlement.get("capital_decision"),
+        ),
+        "repair_bid_settlement_selected_lot_ids": _string_items(
+            repair_bid_settlement.get("selected_lot_ids")
+        ),
+        "repair_bid_settlement_dispatchable_lot_ids": _string_items(
+            repair_bid_settlement.get("dispatchable_lot_ids")
+        ),
+        "repair_bid_settlement_held_lot_ids": _repair_bid_settlement_held_lot_ids(
+            repair_bid_settlement
+        ),
+        "evidence_clock_state": _state_from_mapping(
+            evidence_clock, "capital_decision", "state", "status"
+        ),
+        "evidence_clock_custody_status": _state_from_mapping(
+            required_custody, "decision", "state", "status"
+        ),
+        "route_warrant_state": _state_from_mapping(
+            route_warrant, "warrant_state", "state", "status"
+        ),
+        "jangar_material_evidence_settlement_ref": jangar_material_ref,
+        "validation_commands": _validation_commands(
+            top_item=top_item,
+            no_delta_repair_reentry_auction=no_delta_repair_reentry_auction,
+        ),
+        "rollback_target": _first_text(
+            no_delta_repair_reentry_auction.get("rollback_target"),
+            alpha_evidence_foundry.get("rollback_target"),
+            "ignore revenue-repair top-line fields and keep Torghut max_notional=0",
+        ),
+    }
+    top_line["field_unavailable_reason_codes"] = _field_unavailable_reason_codes(
+        {
+            "top_repair_queue_item": top_line["top_repair_queue_item"],
+            "selected_value_gate": top_line["selected_value_gate"],
+            "required_output_receipt": top_line["required_output_receipt"],
+            "selected_hypothesis_id": top_line["selected_hypothesis_id"],
+            "selected_candidate_id": top_line["selected_candidate_id"],
+            "selected_strategy_id": top_line["selected_strategy_id"],
+            "selected_dataset_snapshot_ref": top_line["selected_dataset_snapshot_ref"],
+            "evidence_clock_state": top_line["evidence_clock_state"],
+            "evidence_clock_custody_status": top_line["evidence_clock_custody_status"],
+            "route_warrant_state": top_line["route_warrant_state"],
+            "jangar_material_evidence_settlement_ref": top_line[
+                "jangar_material_evidence_settlement_ref"
+            ],
+        }
+    )
+    top_line["transport_evidence_refs"] = {
+        "route_evidence_clearinghouse_packet": _mapping(
+            evidence.get("route_evidence_clearinghouse")
+        ).get("packet_id"),
+        "repair_bid_settlement_ledger": repair_bid_settlement.get("ledger_id"),
+        "alpha_evidence_foundry": alpha_evidence_foundry.get("foundry_id"),
+        "no_delta_repair_reentry_auction": no_delta_repair_reentry_auction.get(
+            "auction_id"
+        ),
+        "evidence_clock_arbiter": evidence_clock.get("arbiter_id"),
+        "route_warrant_exchange": route_warrant.get("warrant_id"),
+    }
+    top_line["producer_component"] = "services/torghut/app/trading/revenue_repair.py"
+    top_line["expected_repair_action"] = _text(
+        top_item.get("action"), "no_repair_queue_item_selected"
+    )
+    return top_line
+
+
 def _business_state(
     *,
     revenue_ready: bool,
@@ -1097,6 +1387,17 @@ def build_revenue_repair_digest(
         ),
         jangar_controller_ingestion_carry=jangar_controller_ingestion_carry,
     )
+    topline_contract = _build_topline_contract(
+        status_payload=status_payload,
+        repair_queue=cast(Sequence[Mapping[str, Any]], repair_queue),
+        capital=capital,
+        evidence=evidence,
+        repair_bid_settlement=repair_bid_settlement,
+        alpha_evidence_foundry=alpha_evidence_foundry,
+        alpha_readiness_settlement_conveyor=alpha_readiness_settlement_conveyor,
+        alpha_repair_dividend_ledger=alpha_repair_dividend_ledger,
+        no_delta_repair_reentry_auction=no_delta_repair_reentry_auction,
+    )
     return {
         "schema_version": SCHEMA_VERSION,
         "generated_at": generated.isoformat(),
@@ -1116,6 +1417,7 @@ def build_revenue_repair_digest(
         "no_delta_repair_reentry_auction": no_delta_repair_reentry_auction,
         "business_state": business_state,
         "revenue_ready": revenue_ready,
+        **topline_contract,
         "health": {
             "readyz_status": readyz_status,
             "readyz_ok": readiness_ok,

--- a/services/torghut/tests/test_build_revenue_repair_digest.py
+++ b/services/torghut/tests/test_build_revenue_repair_digest.py
@@ -365,6 +365,55 @@ class TestBuildRevenueRepairDigest(TestCase):
             repair_queue[0]["capital_rule"],
             "zero_notional_repair_only",
         )
+        self.assertEqual(digest["top_repair_queue_item"], repair_queue[0])
+        self.assertEqual(digest["selected_value_gate"], "routeable_candidate_count")
+        self.assertEqual(
+            digest["required_output_receipt"],
+            "torghut.executable-alpha-receipts.v1",
+        )
+        self.assertEqual(
+            digest["required_receipts"],
+            [
+                "alpha_readiness_receipt",
+                "hypothesis_promotion_receipt",
+                "capital_replay_board",
+            ],
+        )
+        self.assertEqual(digest["capital_state"], "zero_notional")
+        self.assertEqual(digest["capital_stage"], "shadow")
+        self.assertFalse(digest["live_submission_allowed"])
+        self.assertEqual(digest["max_notional"], "0")
+        self.assertEqual(
+            digest["selected_hypothesis_id"],
+            "H-AAPL-ROUTE-REHAB",
+        )
+        self.assertEqual(
+            digest["selected_candidate_id"],
+            "chip-paper-microbar-composite@execution-proof",
+        )
+        self.assertEqual(digest["selected_strategy_id"], "intraday_tsmom_v1@paper")
+        self.assertEqual(digest["routeable_candidate_count_before"], 0)
+        self.assertEqual(digest["routeable_candidate_count_after"], 0)
+        self.assertEqual(digest["accepted_routeable_candidate_count"], 0)
+        self.assertEqual(digest["routeable_candidate_delta"], 0)
+        self.assertEqual(digest["no_delta_reentry_decision"], "deny")
+        self.assertEqual(
+            digest["repair_bid_settlement_status"],
+            "repair_only",
+        )
+        self.assertEqual(
+            digest["repair_bid_settlement_held_lot_ids"],
+            ["compacted-repair-lot:promotion"],
+        )
+        self.assertIn(
+            "jangar_material_evidence_settlement_ref_unavailable",
+            digest["field_unavailable_reason_codes"],
+        )
+        self.assertIn(
+            "uv run --frozen pytest tests/test_build_revenue_repair_digest.py -k revenue_repair",
+            digest["validation_commands"],
+        )
+        self.assertIn("max_notional=0", str(digest["rollback_target"]))
         strike_ledger = digest["alpha_readiness_strike_ledger"]
         self.assertIsInstance(strike_ledger, dict)
         self.assertEqual(

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -1252,6 +1252,16 @@ class TestTradingApi(TestCase):
         self.assertEqual(payload["control_plane_dependency_mode"], "caller_evaluated")
         self.assertEqual(payload["dependency_quorum"]["decision"], "allow")
         self.assertEqual(payload["proof_floor"], proof_floor)
+        self.assertEqual(
+            payload["revenue_repair_digest_ref"], "/trading/revenue-repair"
+        )
+        self.assertEqual(
+            payload["top_repair_queue_item"]["code"], "live_submit_gate_closed"
+        )
+        self.assertEqual(payload["selected_value_gate"], "capital_gate_safety")
+        self.assertEqual(payload["max_notional"], "0")
+        self.assertEqual(payload["accepted_routeable_candidate_count"], 0)
+        self.assertEqual(payload["routeable_candidate_delta"], 0)
         self.assertNotIn("route_reacquisition_board", payload)
         summary_payload = summary_response.json()
         self.assertEqual(summary_payload["schema_version"], payload["schema_version"])
@@ -4547,6 +4557,39 @@ class TestTradingApi(TestCase):
             {item["reason"] for item in payload["blockers"]},
         )
         self.assertEqual(payload["repair_queue"][0]["code"], "repair_alpha_readiness")
+        self.assertEqual(payload["top_repair_queue_item"], payload["repair_queue"][0])
+        self.assertEqual(payload["selected_value_gate"], "routeable_candidate_count")
+        self.assertEqual(
+            payload["required_output_receipt"],
+            "torghut.executable-alpha-receipts.v1",
+        )
+        self.assertEqual(payload["capital_state"], "zero_notional")
+        self.assertEqual(payload["capital_stage"], "shadow")
+        self.assertFalse(payload["live_submission_allowed"])
+        self.assertEqual(payload["max_notional"], "0")
+        self.assertEqual(payload["accepted_routeable_candidate_count"], 0)
+        self.assertEqual(payload["routeable_candidate_delta"], 0)
+        self.assertEqual(payload["repair_bid_settlement_status"], "repair_only")
+        self.assertEqual(
+            payload["repair_bid_settlement_selected_lot_ids"],
+            ["compacted-repair-lot:test"],
+        )
+        self.assertEqual(
+            payload["repair_bid_settlement_dispatchable_lot_ids"],
+            ["compacted-repair-lot:test"],
+        )
+        self.assertEqual(
+            payload["repair_bid_settlement_held_lot_ids"],
+            ["compacted-repair-lot:promotion"],
+        )
+        self.assertIn(
+            "jangar_material_evidence_settlement_ref_unavailable",
+            payload["field_unavailable_reason_codes"],
+        )
+        self.assertEqual(
+            payload["expected_repair_action"],
+            "clear_hypothesis_blockers_before_capital",
+        )
         self.assertEqual(
             payload["evidence"]["execution_tca"]["last_computed_at"],
             "2026-04-02T20:59:45.136640+00:00",


### PR DESCRIPTION
## Summary

- Exposes the May 14 doc 212 `/trading/revenue-repair` top-line contract directly for the live `repair_alpha_readiness` queue item: top queue item, selected value gate, required output receipt, routeable candidate counts, no-delta reentry state, settlement lot summaries, validation commands, typed unavailable reasons, and rollback target.
- Mirrors the compact action-boundary fields through `/trading/status` and `/trading/consumer-evidence` so Jangar and owner handoff can compare the direct revenue-repair source without deriving `repair_queue[0]`.
- Keeps capital safety unchanged: `business_state=repair_only`, `revenue_ready=false`, `live_submission_allowed=false`, and `max_notional=0`; this does not enable live submission.
- Updates `services/torghut/README.md` and `/workspace/.agentrun/swarm/torghut-quant-mission-ledger.md` with design provenance, runtime evidence, validation, risk, and rollback notes.

Design provenance:

- `docs/torghut/design-system/v6/212-torghut-revenue-repair-topline-contract-and-alpha-evidence-budget-2026-05-14.md`
- `docs/torghut/design-system/v6/212-torghut-route-adjacent-proof-and-execution-freshness-reentry-2026-05-14.md`

Requirement provenance and business evidence:

- Runtime source of truth: `http://torghut.torghut.svc.cluster.local/trading/revenue-repair`
- Before coding: `business_state=repair_only`, `revenue_ready=false`, top `repair_queue` item `repair_alpha_readiness`, reason `alpha_readiness_not_promotion_eligible`, `selected_value_gate=routeable_candidate_count`, `required_output_receipt=torghut.executable-alpha-receipts.v1`, `capital_state=zero_notional`, `max_notional=0`, `accepted_routeable_candidate_count=0`.
- After implementation pre-deploy, live state remains the safe control: `business_state=repair_only`, `revenue_ready=false`, top `repair_queue` item `repair_alpha_readiness`, `capital_state=zero_notional`, `max_notional=0`, `accepted_routeable_candidate_count=0`; live has not yet deployed these new direct fields, so `top_repair_queue_item`, `routeable_candidate_delta`, `validation_commands`, and `field_unavailable_reason_codes` are still absent on the live endpoint.
- Affected value gate: `routeable_candidate_count`.

Risk and rollback:

- Risk is limited to additive response fields exposing evidence that was already nested in Torghut runtime payloads.
- Rollback is to revert this service commit or have consumers ignore the new top-line fields and continue deriving from nested `repair_queue`, alpha foundry, settlement, and consumer-evidence payloads.
- Capital safety remains unchanged and live submission stays disabled.

Release note:

- Torghut now emits the doc 212 revenue-repair top-line contract for alpha-readiness repair and mirrors the compact fields to consumer evidence/status. This improves routeable-candidate repair observability and Jangar handoff while preserving zero-notional repair-only operation.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`: pass
- `uv run --frozen ruff check app/main.py app/trading/revenue_repair.py tests/test_build_revenue_repair_digest.py tests/test_trading_api.py`: pass
- `uv run --frozen ruff format --check app/main.py app/trading/revenue_repair.py tests/test_build_revenue_repair_digest.py tests/test_trading_api.py`: pass
- `uv run --frozen ruff check app scripts tests`: pass
- `uv run --frozen pytest tests/test_build_revenue_repair_digest.py tests/test_trading_api.py -k "revenue_repair or consumer_evidence_avoids_recursive"`: pass, 20 passed
- `uv run --frozen pytest tests/test_build_revenue_repair_digest.py tests/test_no_delta_repair_reentry_auction.py tests/test_consumer_evidence.py -k "revenue"`: pass, 16 passed
- `uv run --frozen pyright --project pyrightconfig.json`: pass
- `uv run --frozen pyright --project pyrightconfig.alpha.json`: pass
- `uv run --frozen pyright --project pyrightconfig.scripts.json`: pass
- `uv run --frozen pytest`: pass, 2481 passed
- `uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90`: pass, 95.74% changed-line coverage
- Post-rebase on current `origin/main`: touched-file Ruff, touched-file format check, focused revenue-repair/API tests, and all three Pyright profiles passed.
- `uv run --frozen ruff format --check app scripts tests`: baseline mismatch only, 226 unrelated pre-existing files would be reformatted; touched-file format and service Ruff are green.
- GitHub checks on PR #6716: pass, including Torghut Pyright, bytecode/lint/migration, all four pytest shards, all 16 autoresearch shards, aggregate bytecode/pytest/coverage, semantic checks, and changed-file checks.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
