### PR TITLE
fix(jangar): parse full Torghut conveyor evidence

### DIFF
--- a/services/jangar/src/server/__tests__/control-plane-torghut-consumer-evidence.test.ts
+++ b/services/jangar/src/server/__tests__/control-plane-torghut-consumer-evidence.test.ts
@@ -1106,6 +1106,92 @@ describe('control-plane Torghut consumer evidence', () => {
     })
   })
 
+  it('normalizes full alpha-readiness settlement conveyors from the revenue-repair fallback', async () => {
+    process.env = {
+      ...originalEnv,
+      JANGAR_TORGHUT_STATUS_URL: 'http://torghut.torghut.svc.cluster.local/trading/consumer-evidence',
+    }
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        buildJsonResponse({
+          schema_version: 'torghut.consumer-evidence-status.v1',
+          route_proven_profit_receipt: {
+            schema_version: 'torghut.route-proven-profit-receipt.v1',
+            receipt_id: 'torghut-route-proven-profit:settlement-conveyor-fallback',
+            generated_at: '2026-05-14T09:15:00.000Z',
+            fresh_until: '2026-05-14T09:16:00.000Z',
+            paper_readiness_state: 'blocked',
+            live_readiness_state: 'blocked',
+            max_notional: '0',
+            reason_codes: [],
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        buildJsonResponse({
+          business_state: 'repair_only',
+          revenue_ready: false,
+          repair_queue: [
+            {
+              code: 'repair_alpha_readiness',
+              reason: 'alpha_readiness_not_promotion_eligible',
+              value_gate: 'routeable_candidate_count',
+            },
+          ],
+          alpha_readiness_settlement_conveyor: {
+            schema_version: 'torghut.alpha-readiness-settlement-conveyor.v1',
+            conveyor_id: 'alpha-readiness-settlement-conveyor:full',
+            generated_at: '2026-05-14T09:15:00.000Z',
+            fresh_until: '2026-05-14T09:30:00.000Z',
+            status: 'no_delta',
+            settlement_state: 'no_delta',
+            reason_codes: ['active_no_delta_lease'],
+            selected_lane: {
+              hypothesis_id: 'H-MICRO-01',
+              no_delta_release_key: 'alpha-readiness-no-delta:H-MICRO-01:window-a',
+              repeat_launch_decision: 'deny',
+            },
+            selected_value_gate: 'routeable_candidate_count',
+            routeable_candidate_count_before: 0,
+            routeable_candidate_count_after: 0,
+            measured_routeable_candidate_delta: 0,
+            active_no_delta_leases: [{ lease_id: 'alpha-readiness-no-delta-lease:test' }],
+            required_output_receipt: 'torghut.alpha-readiness-settlement-receipt.v1',
+            validation_commands: [
+              'uv run --frozen pytest services/torghut/tests/test_alpha_readiness_settlement_conveyor.py',
+            ],
+            max_notional: '0',
+            capital_rule: 'zero_notional_repair_only',
+            rollback_target: 'stop emitting alpha_readiness_settlement_conveyor and keep Torghut max_notional=0',
+          },
+        }),
+      )
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch
+
+    const result = await resolveTorghutConsumerEvidence(new Date('2026-05-14T09:15:10.000Z'))
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(String(fetchMock.mock.calls[0]?.[0])).toBe(
+      'http://torghut.torghut.svc.cluster.local/trading/consumer-evidence?view=summary',
+    )
+    expect(String(fetchMock.mock.calls[1]?.[0])).toBe('http://torghut.torghut.svc.cluster.local/trading/revenue-repair')
+    expect(result.status.observed_contracts).toEqual(expect.arrayContaining(['alpha_readiness_settlement_conveyor']))
+    expect(result.status.contract_schema_mismatches).not.toEqual(
+      expect.arrayContaining(['alpha_readiness_settlement_conveyor:torghut.alpha-readiness-settlement-conveyor.v1']),
+    )
+    expect(result.status.alpha_readiness_settlement_conveyor).toMatchObject({
+      conveyor_schema_version: 'torghut.alpha-readiness-settlement-conveyor.v1',
+      conveyor_id: 'alpha-readiness-settlement-conveyor:full',
+      selected_hypothesis_id: 'H-MICRO-01',
+      selected_value_gate: 'routeable_candidate_count',
+      active_no_delta_lease_count: 1,
+      required_receipt: 'torghut.alpha-readiness-settlement-receipt.v1',
+      repeat_launch_decision: 'deny',
+      max_notional: '0',
+    })
+  })
+
   it('maps compact alpha repair dividend ledger refs from consumer evidence', async () => {
     process.env = {
       ...originalEnv,

--- a/services/jangar/src/server/control-plane-torghut-alpha-readiness-settlement-conveyor.ts
+++ b/services/jangar/src/server/control-plane-torghut-alpha-readiness-settlement-conveyor.ts
@@ -9,6 +9,10 @@ import { asRecord } from '~/server/primitives-http'
 
 export const ALPHA_READINESS_SETTLEMENT_CONVEYOR_REF_SCHEMA_VERSION =
   'torghut.alpha-readiness-settlement-conveyor-ref.v1'
+const ALPHA_READINESS_SETTLEMENT_CONVEYOR_SCHEMA_VERSION = 'torghut.alpha-readiness-settlement-conveyor.v1'
+
+const countItems = (value: unknown) => (Array.isArray(value) ? value.length : null)
+const firstString = (value: unknown) => stringList(value)[0] ?? null
 
 export const readAlphaReadinessSettlementConveyorRef = (
   payload: Record<string, unknown> | null,
@@ -16,27 +20,47 @@ export const readAlphaReadinessSettlementConveyorRef = (
   const conveyor = asRecord(payload?.alpha_readiness_settlement_conveyor)
   if (!conveyor) return null
   const schema = normalizeNonEmpty(conveyor.schema_version)
-  if (schema !== ALPHA_READINESS_SETTLEMENT_CONVEYOR_REF_SCHEMA_VERSION) return null
+  if (
+    schema !== ALPHA_READINESS_SETTLEMENT_CONVEYOR_REF_SCHEMA_VERSION &&
+    schema !== ALPHA_READINESS_SETTLEMENT_CONVEYOR_SCHEMA_VERSION
+  ) {
+    return null
+  }
+
+  const selectedLane = asRecord(conveyor.selected_lane)
+  const settlementReceipt = asRecord(conveyor.settlement_receipt)
+  const activeNoDeltaLeaseCount =
+    normalizeNumber(conveyor.active_no_delta_lease_count) ?? countItems(conveyor.active_no_delta_leases)
 
   return {
     schema_version: ALPHA_READINESS_SETTLEMENT_CONVEYOR_REF_SCHEMA_VERSION,
-    conveyor_schema_version: normalizeNonEmpty(conveyor.conveyor_schema_version),
+    conveyor_schema_version:
+      normalizeNonEmpty(conveyor.conveyor_schema_version) ??
+      (schema === ALPHA_READINESS_SETTLEMENT_CONVEYOR_SCHEMA_VERSION ? schema : null),
     conveyor_id: normalizeNonEmpty(conveyor.conveyor_id),
     generated_at: normalizeNonEmpty(conveyor.generated_at),
     fresh_until: normalizeNonEmpty(conveyor.fresh_until),
     status: normalizeReason(conveyor.status),
     settlement_state: normalizeReason(conveyor.settlement_state),
     reason_codes: stringList(conveyor.reason_codes),
-    selected_hypothesis_id: normalizeNonEmpty(conveyor.selected_hypothesis_id),
+    selected_hypothesis_id:
+      normalizeNonEmpty(conveyor.selected_hypothesis_id) ?? normalizeNonEmpty(selectedLane?.hypothesis_id),
     selected_value_gate: normalizeReason(conveyor.selected_value_gate),
     routeable_candidate_count_before: normalizeNumber(conveyor.routeable_candidate_count_before),
     routeable_candidate_count_after: normalizeNumber(conveyor.routeable_candidate_count_after),
     measured_routeable_candidate_delta: normalizeNumber(conveyor.measured_routeable_candidate_delta),
-    active_no_delta_lease_count: normalizeNumber(conveyor.active_no_delta_lease_count),
-    required_receipt: normalizeNonEmpty(conveyor.required_receipt),
-    validation_command: normalizeNonEmpty(conveyor.validation_command),
-    no_delta_release_key: normalizeNonEmpty(conveyor.no_delta_release_key),
-    repeat_launch_decision: normalizeReason(conveyor.repeat_launch_decision),
+    active_no_delta_lease_count: activeNoDeltaLeaseCount,
+    required_receipt:
+      normalizeNonEmpty(conveyor.required_receipt) ?? normalizeNonEmpty(conveyor.required_output_receipt),
+    validation_command: normalizeNonEmpty(conveyor.validation_command) ?? firstString(conveyor.validation_commands),
+    no_delta_release_key:
+      normalizeNonEmpty(conveyor.no_delta_release_key) ??
+      normalizeNonEmpty(selectedLane?.no_delta_release_key) ??
+      normalizeNonEmpty(settlementReceipt?.no_delta_release_key),
+    repeat_launch_decision:
+      normalizeReason(conveyor.repeat_launch_decision) ??
+      normalizeReason(selectedLane?.repeat_launch_decision) ??
+      normalizeReason(settlementReceipt?.repeat_launch_decision),
     max_notional: normalizeNonEmpty(conveyor.max_notional),
     capital_rule: normalizeReason(conveyor.capital_rule),
     rollback_target: normalizeNonEmpty(conveyor.rollback_target),
@@ -49,6 +73,12 @@ export const alphaReadinessSettlementConveyorRefSchemaMismatch = (
   const conveyor = asRecord(payload?.alpha_readiness_settlement_conveyor)
   if (!conveyor) return null
   const schema = normalizeNonEmpty(conveyor.schema_version)
-  if (!schema || schema === ALPHA_READINESS_SETTLEMENT_CONVEYOR_REF_SCHEMA_VERSION) return null
+  if (
+    !schema ||
+    schema === ALPHA_READINESS_SETTLEMENT_CONVEYOR_REF_SCHEMA_VERSION ||
+    schema === ALPHA_READINESS_SETTLEMENT_CONVEYOR_SCHEMA_VERSION
+  ) {
+    return null
+  }
   return `alpha_readiness_settlement_conveyor:${schema}`
 }


### PR DESCRIPTION
## Summary

- Normalize Torghut full `alpha_readiness_settlement_conveyor` payloads into the compact Jangar ref shape.
- Preserve existing compact-ref behavior while allowing the revenue-repair fallback to carry conveyor evidence.
- Add regression coverage for the two-call consumer-evidence summary plus revenue-repair fallback path.

## Related Issues

None

## Testing

- `bunx vitest run src/server/__tests__/control-plane-torghut-consumer-evidence.test.ts` from `services/jangar`
- `bunx oxfmt --check services/jangar/src/server/control-plane-torghut-alpha-readiness-settlement-conveyor.ts services/jangar/src/server/__tests__/control-plane-torghut-consumer-evidence.test.ts`
- `bun run --filter @proompteng/jangar tsc`
- `bun run --filter @proompteng/jangar lint`
- `git diff --check`
- `bun run --filter @proompteng/jangar test -- src/server/__tests__/control-plane-torghut-consumer-evidence.test.ts` reached `16 passed` for the target file, but the wrapper exited nonzero because the existing `@proompteng/temporal-bun-sdk build` pretest invokes TypeScript with `TS5042: Option 'project' cannot be mixed with source files on a command line`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
