### PR TITLE
chore(jangar): promote image ff98e821

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: daa3db54
-  digest: sha256:d1041f92455a0790ae0198d9ab007da6b7f85e535b5dc00cb61ff78726116773
+  tag: ff98e821
+  digest: sha256:64459686b1f0c5e7a956f239dfa6e00adcee3f215c48a93896dda670d0e36416
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,25 +11,25 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: daa3db54
-    digest: sha256:605e2bc949a9ffac1232fac516c10dcfdef2437ef3b221d157cbc487e66a052b
+    tag: ff98e821
+    digest: sha256:bf0169290cf1c31a5fe2d35c04b43e8c00f8320caf3e0884b2f19cfd546da2b5
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
       JANGAR_TORGHUT_STATUS_URL: http://torghut.torghut.svc.cluster.local/trading/consumer-evidence
       JANGAR_TORGHUT_STATUS_TIMEOUT_MS: "3000"
-      JANGAR_SOURCE_HEAD_SHA: daa3db545ebb27234bedb1e081186c0fcd59ef8a
-      JANGAR_GITOPS_REVISION: daa3db545ebb27234bedb1e081186c0fcd59ef8a
-      JANGAR_SOURCE_CI_RUN_ID: "25893037050"
+      JANGAR_SOURCE_HEAD_SHA: ff98e82146135c9a592eee4c3676da47c2e83477
+      JANGAR_GITOPS_REVISION: ff98e82146135c9a592eee4c3676da47c2e83477
+      JANGAR_SOURCE_CI_RUN_ID: "25893609619"
       JANGAR_SOURCE_CI_CONCLUSION: success
-      JANGAR_MANIFEST_IMAGE_DIGEST: sha256:605e2bc949a9ffac1232fac516c10dcfdef2437ef3b221d157cbc487e66a052b
-      JANGAR_SERVING_BUILD_COMMIT: daa3db545ebb27234bedb1e081186c0fcd59ef8a
-      JANGAR_SERVING_IMAGE_DIGEST: sha256:605e2bc949a9ffac1232fac516c10dcfdef2437ef3b221d157cbc487e66a052b
+      JANGAR_MANIFEST_IMAGE_DIGEST: sha256:bf0169290cf1c31a5fe2d35c04b43e8c00f8320caf3e0884b2f19cfd546da2b5
+      JANGAR_SERVING_BUILD_COMMIT: ff98e82146135c9a592eee4c3676da47c2e83477
+      JANGAR_SERVING_IMAGE_DIGEST: sha256:bf0169290cf1c31a5fe2d35c04b43e8c00f8320caf3e0884b2f19cfd546da2b5
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: daa3db54
-    digest: sha256:d1041f92455a0790ae0198d9ab007da6b7f85e535b5dc00cb61ff78726116773
+    tag: ff98e821
+    digest: sha256:64459686b1f0c5e7a956f239dfa6e00adcee3f215c48a93896dda670d0e36416
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-15T00:14:15Z
+    deploy.knative.dev/rollout: 2026-05-15T00:35:05Z
 spec:
   replicas: 1
   strategy:
@@ -57,11 +57,11 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_RUNTIME_IMAGE
-              value: registry.ide-newton.ts.net/lab/jangar:daa3db54@sha256:d1041f92455a0790ae0198d9ab007da6b7f85e535b5dc00cb61ff78726116773
+              value: registry.ide-newton.ts.net/lab/jangar:ff98e821@sha256:64459686b1f0c5e7a956f239dfa6e00adcee3f215c48a93896dda670d0e36416
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: daa3db545ebb27234bedb1e081186c0fcd59ef8a
+              value: ff98e82146135c9a592eee4c3676da47c2e83477
             - name: JANGAR_GITOPS_REVISION
-              value: daa3db545ebb27234bedb1e081186c0fcd59ef8a
+              value: ff98e82146135c9a592eee4c3676da47c2e83477
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_CONTROL_PLANE_STATUS_CACHE_TTL_MS
@@ -405,15 +405,15 @@ spec:
             - name: OPENAI_EMBEDDING_TIMEOUT_MS
               value: "60000"
             - name: JANGAR_SOURCE_CI_RUN_ID
-              value: "25893037050"
+              value: "25893609619"
             - name: JANGAR_SOURCE_CI_CONCLUSION
               value: success
             - name: JANGAR_MANIFEST_IMAGE_DIGEST
-              value: sha256:605e2bc949a9ffac1232fac516c10dcfdef2437ef3b221d157cbc487e66a052b
+              value: sha256:bf0169290cf1c31a5fe2d35c04b43e8c00f8320caf3e0884b2f19cfd546da2b5
             - name: JANGAR_SERVING_BUILD_COMMIT
-              value: daa3db545ebb27234bedb1e081186c0fcd59ef8a
+              value: ff98e82146135c9a592eee4c3676da47c2e83477
             - name: JANGAR_SERVING_IMAGE_DIGEST
-              value: sha256:605e2bc949a9ffac1232fac516c10dcfdef2437ef3b221d157cbc487e66a052b
+              value: sha256:bf0169290cf1c31a5fe2d35c04b43e8c00f8320caf3e0884b2f19cfd546da2b5
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -59,5 +59,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: daa3db54
-    digest: sha256:d1041f92455a0790ae0198d9ab007da6b7f85e535b5dc00cb61ff78726116773
+    newTag: ff98e821
+    digest: sha256:64459686b1f0c5e7a956f239dfa6e00adcee3f215c48a93896dda670d0e36416


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `ff98e82146135c9a592eee4c3676da47c2e83477`
- Image tag: `ff98e821`
- Image digest: `sha256:64459686b1f0c5e7a956f239dfa6e00adcee3f215c48a93896dda670d0e36416`
- Source CI run: `25893609619`
- Control-plane serving digest: `sha256:bf0169290cf1c31a5fe2d35c04b43e8c00f8320caf3e0884b2f19cfd546da2b5`
- Updated API rollout annotation
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`
- Published source-serving proof env for revenue repair custody gates