### PR TITLE
docs(torghut): define consumer evidence contract canaries

### DIFF
--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -19,6 +19,8 @@ clear entrypoints, clear “source of truth”, and a complete catalog of relate
 - Autonomous Jangar/Torghut production system design: `designs/autonomous-jangar-torghut-production-system.md`
 - Swarm agentic mission architecture notes: `designs/swarm-agentic-mission-architecture-2026-05-08.md`
 - Current Jangar/Torghut architecture contracts:
+  - `designs/207-jangar-consumer-evidence-transport-split-and-source-serving-contract-canary-2026-05-15.md`
+  - `../torghut/design-system/v6/213-torghut-consumer-evidence-contract-canary-and-alpha-reentry-transport-2026-05-15.md`
   - `designs/206-jangar-route-adjacent-proof-custody-and-torghut-reentry-admission-2026-05-14.md`
   - `../torghut/design-system/v6/212-torghut-route-adjacent-proof-and-execution-freshness-reentry-2026-05-14.md`
   - `designs/205-jangar-controller-ingestion-settlement-and-verification-carry-cutover-2026-05-14.md`

--- a/docs/agents/designs/207-jangar-consumer-evidence-transport-split-and-source-serving-contract-canary-2026-05-15.md
+++ b/docs/agents/designs/207-jangar-consumer-evidence-transport-split-and-source-serving-contract-canary-2026-05-15.md
@@ -1,0 +1,365 @@
+# 207. Jangar Consumer-Evidence Transport Split And Source-Serving Contract Canary (2026-05-15)
+
+Status: Accepted for engineer and deployer handoff
+Date: 2026-05-15
+Owner: Gideon Park, Torghut Traders Architecture
+Scope: Jangar control-plane evidence transport, source-serving contract canaries, controller-ingestion settlement,
+Torghut no-delta alpha reentry, rollout evidence, rollback, and cross-swarm handoff.
+
+Companion Torghut contract:
+
+- `docs/torghut/design-system/v6/213-torghut-consumer-evidence-contract-canary-and-alpha-reentry-transport-2026-05-15.md`
+
+Extends:
+
+- `206-jangar-route-adjacent-proof-custody-and-torghut-reentry-admission-2026-05-14.md`
+- `206-jangar-consumer-evidence-parity-settlement-and-alpha-release-custody-2026-05-14.md`
+- `205-jangar-controller-ingestion-settlement-and-verification-carry-cutover-2026-05-14.md`
+- `187-jangar-main-source-ci-retention-and-source-serving-verdicts-2026-05-13.md`
+- `183-jangar-attested-action-custody-and-profit-window-admission-2026-05-08.md`
+
+## Decision
+
+I am selecting **a split consumer-evidence transport with source-serving contract canaries** as the next Jangar
+control-plane architecture slice.
+
+The live blocker is no longer simply "route proof missing." The evidence is sharper. Torghut's full
+`/trading/consumer-evidence` payload contains `route_warrant_exchange` and `repair_bid_settlement_ledger`, but the
+compact `?view=summary` payload intentionally omits both. Jangar currently rewrites the configured
+`JANGAR_TORGHUT_STATUS_URL` from `/trading/consumer-evidence` to `/trading/consumer-evidence?view=summary` before it
+normalizes Torghut evidence. That keeps the hot payload small, but it makes the source-serving contract verifier see
+`source_serving_contract_missing:route_warrant_exchange` and
+`source_serving_contract_missing:repair_bid_settlement_ledger` even while the full Torghut payload has those contracts.
+
+Jangar should not solve this by making every hot-path readiness read pull the full Torghut evidence document. The full
+payload is the correct authority for contract shape, but the summary route is the correct authority for cheap service
+health and consumer-evidence freshness. The new contract splits those roles. Jangar keeps the summary fetch for hot
+readiness, adds a bounded contract-canary fetch for full evidence only where source-serving and controller-ingestion
+settlement need it, and records the transport decision as a first-class custody object. Torghut, in the companion
+contract, publishes compact contract refs in the summary route so Jangar can stay correct even when the full fetch is
+slow or rate-limited.
+
+The tradeoff is another evidence layer. I accept that because the current alternative is worse: Jangar can mark a
+healthy, source-bound Torghut payload as contract-missing and keep no-delta alpha reentry denied for a transport
+artifact rather than a trading blocker. This design reduces a control-plane false negative without weakening capital
+safety. Paper and live support remain held until routeable candidates, source-serving proof, and capital gates all
+pass.
+
+## Governing Runtime Requirements
+
+This contract is a governing Jangar requirement for the next implementation stage:
+
+- every code-changing run must cite this doc or the companion Torghut doc before changing Jangar or Torghut evidence
+  transport;
+- implementation PRs must improve readiness, profit evidence, data freshness, execution quality, or capital safety;
+- verification must merge only green PRs and prove image promotion, Argo sync, live service health, and Torghut revenue
+  or evidence status after rollout;
+- final handoff must name the revenue metric improved or the smallest blocker preventing revenue impact.
+
+Value-gate mapping:
+
+- `ready_status_truth`: summary evidence remains the hot readiness input; contract evidence becomes a separate
+  bounded lane.
+- `pr_to_rollout_latency`: source, manifest, serving image, contract refs, and Argo sync are joined in one source-serving
+  verdict.
+- `handoff_evidence_quality`: handoffs cite whether a hold comes from transport, missing contract, stale contract, or
+  real Torghut proof.
+- `manual_intervention_count`: operators stop comparing summary payloads, full payloads, revenue-repair, and Jangar
+  status by hand.
+- `routeable_candidate_count`: Torghut no-delta H-MICRO-01 reentry can only proceed after contract canaries remove the
+  false source-serving hold.
+- `zero_notional_or_stale_evidence_rate`: stale or missing contract canaries keep zero-notional repair debt explicit.
+- `capital_gate_safety`: all selected repairs remain `max_notional=0`; live support is still blocked unless capital
+  gates release independently.
+
+## Current Evidence
+
+Evidence was collected read-only on 2026-05-15 between 00:26Z and 00:30Z. I did not mutate Kubernetes resources,
+database records, AgentRuns, GitOps state, broker state, market data, or trading flags.
+
+### Cluster And Rollout
+
+- The working branch is `codex/swarm-torghut-quant-plan` based on `main` at
+  `ff98e82146135c9a592eee4c3676da47c2e83477`.
+- Argo reported `jangar` and `torghut` as `Synced/Healthy` at
+  `ff98e82146135c9a592eee4c3676da47c2e83477`. `agents` was `Healthy/OutOfSync`; the out-of-sync resources were the
+  `agents` and `agents-controllers` Deployments.
+- The live `agents-controllers` Deployment itself had `2/2` available replicas, observed generation `339`, and image
+  `registry.ide-newton.ts.net/lab/jangar:4947b00e@sha256:03bcb2e644758aa745117dd70e94293c4c11ff64b64febc098a87727a2aad44b`.
+- Torghut live revision `torghut-00433` and sim revision `torghut-sim-00518` were running with `2/2` containers ready.
+  Options catalog, options enricher, TA, websocket, ClickHouse, and guardrail exporters were running.
+- Recent Torghut events showed a successful rollout followed by execution TCA refresh jobs every five minutes. One
+  refresh job exceeded its active deadline, then later refresh jobs completed. This is a reliability signal, not a
+  capital-release signal.
+- Recent agents namespace AgentRuns included successful implement and discover runs, failed verify runs, and current
+  running plan/verify runs. This supports bounded repair dispatch, not broad normal dispatch.
+
+### Jangar Control-Plane Evidence
+
+- Jangar `/ready` returned `status=ok`, leader election healthy, and `execution_trust.status=healthy`, but its hot-path
+  `controller_ingestion_settlement.decision=hold` cited controller deployment, self-report, source-serving, rollout,
+  and database projection reasons.
+- Jangar full control-plane status at `2026-05-15T00:28:34.090Z` reported a clearer picture:
+  - `database.status=healthy`, `registered_count=29`, `applied_count=29`, latest applied migration
+    `20260508_torghut_quant_pipeline_health_account_window_created_at_index`;
+  - `rollout_health.status=healthy`, two configured deployments healthy;
+  - `control_plane_controller_witness.decision=allow_with_split`, with controller heartbeat authoritative while the
+    serving process is not the controller;
+  - `agentrun_ingestion.status=unknown`, message `agents controller not started`;
+  - `source_serving_contract_verdict_exchange.status=block`, missing `route_warrant_exchange` and
+    `repair_bid_settlement_ledger`;
+  - `controller_ingestion_settlement.decision=hold`, reasons including `source_serving_block`,
+    `torghut_route_warrant_missing`, `repair_bid_settlement_ledger_missing`, and `torghut_verification_carry_stale`;
+  - `material_evidence_settlement_spine.decision=hold`, with Torghut evidence and transport unavailable reasons.
+- The difference between `/ready` and full status is itself a design signal. Jangar needs separate hot summary,
+  contract-canary, and full-status authorities instead of collapsing every failure into controller-ingestion lag.
+
+### Torghut Business Evidence
+
+- `/trading/revenue-repair` returned `schema_version=torghut.revenue-repair-digest.v1`, `business_state=repair_only`,
+  and `revenue_ready=false`.
+- The top repair queue item was `repair_alpha_readiness`, reason `alpha_readiness_not_promotion_eligible`, value gate
+  `routeable_candidate_count`, required output `torghut.executable-alpha-receipts.v1`, and `max_notional=0`.
+- Torghut `jangar_controller_ingestion_carry.carry_state=lagging` with reasons including
+  `source_serving_contract_unavailable_on_ready_hot_path`, `rollout_health_unknown`, and
+  `jangar_controller_ingestion_lagging` on the hot read; later full Jangar status narrowed the cause to source-serving
+  contract transport.
+- Torghut `no_delta_repair_reentry_auction.reentry_decision=deny`, selected no ticket, preserved H-MICRO-01, and kept
+  `max_notional=0`.
+- `/trading/consumer-evidence?view=summary` returned a current consumer evidence receipt and a current route-proven
+  profit receipt, but `has_route_warrant=false` and `has_repair_bid=false`.
+- Full `/trading/consumer-evidence` returned `has_route_warrant=true` with
+  `route_warrant_id=route-warrant-exchange:989878b5ceeabaa4e08f` and `has_repair_bid=true` with
+  `repair_bid_ledger_id=repair-bid-settlement-ledger:db2cfac92bf7ccfe808c`.
+- `/trading/revenue-repair` carried `repair_bid_settlement_ledger` but not `route_warrant_exchange`. It is useful as a
+  business queue and repair-bid fallback, not as the complete source-serving contract authority.
+
+### Database And Data Evidence
+
+- Torghut `/db-check` returned `ok=true`, `schema_current=true`, and `schema_graph_lineage_ready=true`.
+- Jangar full status reported its database connected and migration-consistent.
+- Direct CNPG cluster reads were blocked by RBAC:
+  `clusters.postgresql.cnpg.io is forbidden` for `system:serviceaccount:agents:agents-sa`.
+- Direct Postgres exec into `torghut-db-1` was blocked by RBAC:
+  `pods/exec` forbidden for the same service account.
+- This is the correct access boundary for this lane. Jangar should consume typed service evidence and contract canaries,
+  not direct database reads.
+
+### Source And Test Surface
+
+- `services/jangar/src/server/control-plane-torghut-consumer-evidence.ts` rewrites
+  `/trading/consumer-evidence` to `/trading/consumer-evidence?view=summary` through `compactConsumerEvidenceEndpoint`.
+- `services/jangar/src/server/control-plane-source-serving-contract-verdict.ts` requires
+  `route_warrant_exchange` and `repair_bid_settlement_ledger` in `observed_contracts`, and holds dispatch repair when
+  either is missing.
+- `services/torghut/app/main.py` already builds both contracts in the full consumer-evidence path, but the summary path
+  returns only the receipt, route-proven receipt, proof floor, and coarse status.
+- Existing tests cover source-serving missing-contract behavior and Torghut full/summary consumer evidence shape. The
+  missing regression family is the transport split: summary current with full contracts present must not be classified
+  as source-serving contract missing, and summary current with full contracts unavailable must become a transport hold
+  rather than a false contract absence.
+
+## Problem
+
+Jangar is conflating three different facts:
+
+1. The cheap Torghut summary route is current.
+2. The full Torghut contract payload has source-serving contracts.
+3. Jangar is allowed to use those contracts for material action decisions.
+
+When those facts are collapsed, a transport optimization becomes a source-serving blocker. That has three production
+risks:
+
+- false holds: Jangar blocks repair dispatch even though Torghut already produced the required contracts;
+- false confidence: a future summary may claim freshness while the full contract payload is stale or schema-mismatched;
+- noisy handoffs: deployers see controller-ingestion lag when the actual blocker is contract transport authority.
+
+The architecture must keep summary evidence cheap, make full contract evidence authoritative, and keep capital locked
+unless both agree.
+
+## Alternatives Considered
+
+### Option A: Configure Jangar To Read Full Consumer Evidence Everywhere
+
+Jangar would stop rewriting the Torghut status URL and would always fetch full `/trading/consumer-evidence`.
+
+Advantages:
+
+- Small code change.
+- Uses the canonical Torghut payload directly.
+- Immediately exposes route warrant and repair-bid contracts.
+
+Disadvantages:
+
+- Makes the hot control-plane path depend on the largest Torghut payload.
+- Increases latency and failure blast radius for `/ready` and status refresh.
+- Does not distinguish transport failure from true contract absence.
+- Makes it harder to keep service health separate from material trading proof.
+
+Decision: reject as the primary architecture.
+
+### Option B: Put Every Required Contract Into The Summary Payload
+
+Torghut would expand `?view=summary` until it contains every source-serving contract Jangar may need.
+
+Advantages:
+
+- Keeps Jangar to one Torghut fetch.
+- Moves contract ownership close to the producer.
+- Reduces status resolver complexity.
+
+Disadvantages:
+
+- The summary route stops being a summary.
+- Every new material contract risks growing the hot payload.
+- Jangar still lacks a clear record of whether it used summary, full, or fallback authority.
+
+Decision: reject as the primary architecture. Keep compact refs in summary, not whole contracts.
+
+### Option C: Split Summary, Contract Canary, And Full Evidence Authority
+
+Jangar reads summary evidence for hot readiness, reads compact contract refs when available, and performs a bounded full
+contract-canary fetch when source-serving, controller-ingestion settlement, or material evidence settlement needs
+route-warrant and repair-bid authority. Torghut emits compact contract refs in summary so Jangar can avoid full reads
+for steady-state verification.
+
+Advantages:
+
+- Preserves hot-path performance.
+- Eliminates the current false missing-contract hold.
+- Gives operators explicit transport reasons.
+- Supports fallback from compact refs to full payload and then to revenue-repair repair-bid evidence.
+- Keeps paper and live support held unless route warrant, repair bids, source-serving proof, and capital gates all pass.
+
+Disadvantages:
+
+- Adds a transport reducer and tests on both sides.
+- Requires careful cache and timeout behavior.
+- Temporarily creates two contract paths until compact summary refs are deployed.
+
+Decision: select Option C.
+
+## Architecture
+
+Jangar adds `jangar.torghut-contract-canary-transport.v1`.
+
+```yaml
+schema_version: jangar.torghut-contract-canary-transport.v1
+transport_id: torghut-contract-canary-transport:<digest>
+generated_at: <iso8601>
+fresh_until: <iso8601>
+namespace: agents
+summary:
+  endpoint: /trading/consumer-evidence?view=summary
+  status: current|stale|unavailable|schema_mismatch
+  receipt_ref: <torghut-route-proven-profit:*|null>
+  observed_contract_refs:
+    route_warrant_exchange: <id|null>
+    repair_bid_settlement_ledger: <id|null>
+full:
+  endpoint: /trading/consumer-evidence
+  status: current|stale|unavailable|schema_mismatch|not_required
+  route_warrant_ref: <id|null>
+  repair_bid_settlement_ref: <id|null>
+fallbacks:
+  revenue_repair_repair_bid_ref: <id|null>
+decision: allow|repair_only|hold|block
+reason_codes: []
+selected_authority: summary_contract_refs|full_payload|revenue_repair_fallback|none
+max_notional: '0'
+validation_commands: []
+rollback_target: ignore contract-canary transport and keep source-serving verdicts in observe mode
+```
+
+Rules:
+
+- Summary current plus compact contract refs current can satisfy source-serving contract presence for `dispatch_repair`.
+- Summary current without compact refs triggers a bounded full fetch before Jangar declares contracts missing.
+- Full payload current with route warrant and repair-bid contracts converts missing-contract reasons into an allow or
+  repair-only source-serving verdict, subject to source CI, digest, Argo, and capital gates.
+- Full payload unavailable while summary is current yields `torghut_contract_transport_unavailable`, not
+  `source_serving_contract_missing`.
+- Revenue-repair may supply a repair-bid fallback, but it cannot satisfy route-warrant authority because the live
+  revenue-repair payload does not carry `route_warrant_exchange`.
+- Any schema mismatch, stale fresh-until, nonzero notional, or contradictory source-serving digest keeps dispatch held.
+- Live support remains blocked until full source-serving convergence and independent Torghut capital release.
+
+## Implementation Scope
+
+Engineer stage should make one production PR with these changes:
+
+- Jangar:
+  - add the transport reducer near `control-plane-torghut-consumer-evidence.ts`;
+  - stop treating summary-only evidence as proof that required full contracts are absent;
+  - feed transport output into `buildSourceServingContractVerdictExchange`;
+  - keep `/ready` summary-first and bounded by the existing timeout budget;
+  - add tests for summary-current/full-contracts-present, summary-current/full-unavailable, compact-ref success,
+    stale full payload, schema mismatch, and revenue-repair repair-bid fallback.
+- Torghut:
+  - add compact `contract_canary_refs` to summary consumer evidence with route warrant and repair-bid ids,
+    schema versions, fresh-until values, statuses, and max notional;
+  - preserve full payload authority for the complete contract bodies;
+  - add tests that summary stays under the canary payload budget and includes the compact refs.
+
+No implementation in this contract may widen Torghut paper or live notional. The expected first metric movement is a
+lower false `zero_notional_or_stale_evidence_rate` caused by stale or hidden proof transport. `routeable_candidate_count`
+may remain zero until no-delta reentry receives a changed or repairable release condition.
+
+## Validation Gates
+
+Local validation for the engineer PR:
+
+- `bun run --filter jangar test -- services/jangar/src/server/__tests__/control-plane-torghut-consumer-evidence.test.ts`
+- `bun run --filter jangar test -- services/jangar/src/server/__tests__/control-plane-source-serving-contract-verdict.test.ts`
+- `uv run --frozen pytest services/torghut/tests/test_trading_api.py -k consumer_evidence`
+- `uv run --frozen pytest services/torghut/tests/test_consumer_evidence.py`
+- `uv run --frozen pyright --project pyrightconfig.json`
+- `uv run --frozen pyright --project pyrightconfig.alpha.json`
+- `uv run --frozen pyright --project pyrightconfig.scripts.json`
+
+Post-deploy validation:
+
+- Argo `agents`, `jangar`, and `torghut` are `Synced/Healthy`.
+- Jangar full control-plane status shows `torghut_contract_canary_transport.decision` is not `block`.
+- Source-serving verdict no longer reports `source_serving_contract_missing:route_warrant_exchange` when full Torghut
+  consumer evidence has a current route warrant.
+- Torghut `/trading/consumer-evidence?view=summary` includes compact contract refs.
+- Torghut `/trading/revenue-repair` remains `business_state=repair_only`, `max_notional=0`, and no-delta reentry remains
+  denied unless a zero-notional repair ticket is selected.
+
+## Rollout
+
+1. Ship Jangar transport reducer in observe mode and log both summary and full authority without changing decisions.
+2. Ship Torghut compact summary contract refs.
+3. Enable Jangar source-serving to use compact refs or full contract canary for `dispatch_repair` only.
+4. Keep `dispatch_normal`, `paper_support`, `live_support`, and all capital-bearing actions on the stricter existing
+   source-serving and Torghut capital gates.
+5. Promote images through normal GitOps and verify Jangar/Torghut status surfaces after Argo convergence.
+
+## Rollback
+
+Rollback is safe because the contract is additive and observe-first:
+
+- disable Jangar contract-canary consumption and return source-serving verdicts to summary-only behavior;
+- keep Torghut compact summary refs present because they are additive and non-authoritative without Jangar consumption;
+- revert the PR if compact refs or full-fetch caching increase latency beyond the control-plane budget;
+- keep Torghut `max_notional=0` and no-delta duplicate reentry denial active throughout rollback.
+
+## Risks
+
+- A full payload fetch could exceed the existing Jangar timeout. Mitigation: summary remains authoritative for service
+  health; full payload failure produces a transport hold, not readiness failure.
+- Compact refs could drift from full payload contracts. Mitigation: include schema version, fresh-until, and ids in the
+  summary ref and compare them with full payload when both are available.
+- This fix may reveal the next blocker rather than immediately raising `routeable_candidate_count`. That is acceptable;
+  the current blocker is false contract transport, and routeability should only move after that is retired.
+
+## Handoff
+
+Engineer acceptance gate: a Jangar/Torghut implementation PR makes current summary evidence plus full contract payload
+produce a source-serving transport hold or repair-only verdict for the right reason, never a false missing-contract
+verdict.
+
+Deployer acceptance gate: after image promotion, live Jangar status can name the selected Torghut contract authority,
+Torghut summary exposes compact contract refs, revenue repair remains zero-notional, and no-delta reentry either stays
+denied with a transport reason retired or selects exactly one zero-notional repair ticket.

--- a/docs/torghut/README.md
+++ b/docs/torghut/README.md
@@ -4,6 +4,10 @@
 
 Start here:
 
+- `docs/agents/designs/207-jangar-consumer-evidence-transport-split-and-source-serving-contract-canary-2026-05-15.md`
+  (current Jangar consumer-evidence transport split and source-serving contract canary contract)
+- `docs/torghut/design-system/v6/213-torghut-consumer-evidence-contract-canary-and-alpha-reentry-transport-2026-05-15.md`
+  (current Torghut consumer-evidence contract canary and alpha reentry transport contract)
 - `docs/agents/designs/206-jangar-route-adjacent-proof-custody-and-torghut-reentry-admission-2026-05-14.md`
   (current Jangar route-adjacent proof custody and Torghut reentry admission contract)
 - `docs/torghut/design-system/v6/212-torghut-route-adjacent-proof-and-execution-freshness-reentry-2026-05-14.md`

--- a/docs/torghut/design-system/v6/213-torghut-consumer-evidence-contract-canary-and-alpha-reentry-transport-2026-05-15.md
+++ b/docs/torghut/design-system/v6/213-torghut-consumer-evidence-contract-canary-and-alpha-reentry-transport-2026-05-15.md
@@ -1,0 +1,338 @@
+# 213. Torghut Consumer-Evidence Contract Canary And Alpha Reentry Transport (2026-05-15)
+
+Status: Accepted for engineer and deployer handoff
+Date: 2026-05-15
+Owner: Gideon Park, Torghut Traders Architecture
+Scope: Torghut consumer-evidence summary/full transport, contract-canary refs, revenue-repair source authority,
+no-delta alpha reentry, validation gates, rollout, rollback, and cross-swarm handoff.
+
+Companion Jangar contract:
+
+- `docs/agents/designs/207-jangar-consumer-evidence-transport-split-and-source-serving-contract-canary-2026-05-15.md`
+
+Extends:
+
+- `212-torghut-route-adjacent-proof-and-execution-freshness-reentry-2026-05-14.md`
+- `212-torghut-consumer-evidence-parity-and-alpha-release-freshness-2026-05-14.md`
+- `211-torghut-controller-ingestion-carry-and-alpha-no-delta-release-2026-05-14.md`
+- `210-torghut-source-bound-verification-carry-import-and-no-delta-release-2026-05-14.md`
+- `191-torghut-source-serving-proof-and-repair-receipt-promotion-2026-05-13.md`
+
+## Decision
+
+I am selecting **consumer-evidence contract canaries with alpha-reentry transport separation** as Torghut's next
+architecture slice.
+
+The live business surface is still `repair_only`, not revenue-ready. The top queue item is
+`repair_alpha_readiness`, with value gate `routeable_candidate_count`, required output
+`torghut.executable-alpha-receipts.v1`, and `max_notional=0`. The no-delta auction correctly denies another H-MICRO-01
+reentry because the active release key has not changed and Jangar controller-ingestion carry is still lagging.
+
+The new evidence says part of that lag is self-inflicted by transport shape. Full `/trading/consumer-evidence` carries
+the route warrant and repair-bid settlement ledger that Jangar requires, but `?view=summary` omits them. Jangar reads the
+summary route for status, then marks `route_warrant_exchange` and `repair_bid_settlement_ledger` missing. Torghut should
+not force Jangar to choose between a cheap summary and correct source-serving contracts. Torghut should publish compact
+contract-canary refs in summary and keep the full contract bodies in the full payload.
+
+The tradeoff is that Torghut will duplicate small refs across payloads. I accept that. It is lower risk than widening
+the summary into another full payload, and it gives Jangar enough proof to avoid false missing-contract holds while
+capital remains locked.
+
+## Governing Runtime Requirements
+
+This design is the governing Torghut requirement for the next implementation stage:
+
+- code-changing runs must cite this doc or the companion Jangar doc;
+- implementation PRs must improve readiness, profit evidence, data freshness, execution quality, or capital safety;
+- verification must prove image promotion, Argo sync, live service health, and revenue-repair status after rollout;
+- final handoff must name the revenue metric improved or the smallest blocker preventing revenue impact.
+
+Value-gate mapping:
+
+- `routeable_candidate_count`: the top repair queue remains H-MICRO-01 alpha readiness; contract canaries remove a false
+  source-serving blocker before another reentry attempt.
+- `zero_notional_or_stale_evidence_rate`: compact refs make stale or hidden contracts measurable instead of invisible.
+- `fill_tca_or_slippage_quality`: execution TCA stays a separate receipt; this transport fix must not claim TCA quality
+  movement by itself.
+- `post_cost_daily_net_pnl`: no direct movement until routeable candidates and capital gates pass.
+- `capital_gate_safety`: all summary refs, full contracts, and reentry tickets in this slice carry `max_notional=0`.
+
+## Current Assessment
+
+Evidence was collected read-only on 2026-05-15 between 00:26Z and 00:30Z.
+
+### Cluster Assessment
+
+- Torghut Argo app was `Synced/Healthy` at `ff98e82146135c9a592eee4c3676da47c2e83477`.
+- Torghut live revision `torghut-00433` and sim revision `torghut-sim-00518` were running and ready.
+- Options catalog, options enricher, TA, websocket, ClickHouse, and guardrail exporters were running.
+- Execution TCA refresh had one active-deadline failure in recent events and later successful completions. That means
+  completed cron runs should remain evidence inputs, not capital-release proof.
+- Agents Argo was `Healthy/OutOfSync`; Jangar was `Synced/Healthy`. The control-plane source-serving contract should
+  carry this distinction explicitly instead of burying it in Torghut no-delta reasons.
+
+### Source Assessment
+
+- Torghut full consumer evidence builds:
+  - `route_warrant_exchange`;
+  - `repair_bid_settlement_ledger`;
+  - `source_serving_repair_receipt_ledger`;
+  - `freshness_carry_ledger`;
+  - `no_delta_repair_reentry_auction`;
+  - alpha readiness, repair, and dividend receipts.
+- The summary path in `services/torghut/app/main.py` returns only the lightweight receipt, route-proven receipt, proof
+  floor, live gate, market context, quant evidence, and coarse dependency status. It does not expose route warrant or
+  repair-bid compact refs.
+- Jangar's consumer-evidence resolver intentionally appends `view=summary` to `/trading/consumer-evidence`, then asks
+  source-serving verdict code for contracts that summary does not contain.
+- Existing tests cover full payload contract presence and summary payload exclusion, but they do not assert a compact
+  contract-canary surface for summary.
+
+### Database And Data Assessment
+
+- `/db-check` returned `ok=true`, `schema_current=true`, and `schema_graph_lineage_ready=true`.
+- Direct CNPG and Postgres exec checks are blocked for the agents service account. That is acceptable for this lane;
+  the deployer should verify typed service evidence, not direct database mutation or privileged reads.
+- Full consumer evidence at 00:29Z had `route_warrant_id=route-warrant-exchange:989878b5ceeabaa4e08f` and
+  `repair_bid_ledger_id=repair-bid-settlement-ledger:db2cfac92bf7ccfe808c`.
+- Summary consumer evidence at 00:29Z had current `torghut.consumer-evidence-receipt.v1` and
+  `torghut.route-proven-profit-receipt.v1`, but no route warrant and no repair-bid ledger.
+- Revenue repair at 00:27Z had `repair_bid_settlement_ledger` but not route warrant. It remains the business queue
+  authority, not the complete contract transport authority.
+
+### Business Evidence
+
+- `/trading/revenue-repair` returned `business_state=repair_only` and `revenue_ready=false`.
+- Top queue:
+  - `code=repair_alpha_readiness`;
+  - `reason=alpha_readiness_not_promotion_eligible`;
+  - `value_gate=routeable_candidate_count`;
+  - `required_output_receipt=torghut.executable-alpha-receipts.v1`;
+  - `max_notional=0`.
+- `jangar_controller_ingestion_carry.carry_state=lagging`.
+- `no_delta_repair_reentry_auction.reentry_decision=deny`, selected ticket `null`, selected hypothesis `H-MICRO-01`,
+  routeable candidates before and after `0`, and active no-delta release key present.
+
+## Problem
+
+Torghut is producing the contracts Jangar needs, but it does not expose compact evidence of those contracts on the
+summary path that Jangar uses for its control-plane status. That creates four bad interpretations:
+
+1. A current summary route can look like a missing route warrant.
+2. A current full route warrant can be ignored because the summary route hides it.
+3. No-delta reentry can stay denied for `jangar_controller_ingestion_lagging` without naming the transport artifact.
+4. Deployer handoff can mistake a source-serving transport miss for a trading-model defect.
+
+The next Torghut slice must make contract transport explicit while keeping the hot summary bounded.
+
+## Alternatives Considered
+
+### Option A: Make Summary Equal Full Consumer Evidence
+
+Torghut would remove the summary/full distinction.
+
+Advantages:
+
+- No duplicated refs.
+- Jangar sees all contracts with one request.
+- Simpler to reason about in tests.
+
+Disadvantages:
+
+- Summary loses its latency and payload-budget purpose.
+- Any future contract growth increases hot-path risk.
+- A full-payload failure becomes harder to distinguish from service-health failure.
+
+Decision: reject.
+
+### Option B: Keep Summary Minimal And Require Jangar To Fetch Full Evidence
+
+Torghut would leave summary unchanged and make Jangar always perform a second full fetch for contract checks.
+
+Advantages:
+
+- No Torghut payload change.
+- Keeps full payload as sole contract body authority.
+- Fastest Torghut implementation.
+
+Disadvantages:
+
+- Jangar still has no cheap steady-state proof that full contracts exist.
+- Full fetch failures would remain common during status refreshes.
+- Summary can be current while contract authority is unknown.
+
+Decision: reject as the sole architecture.
+
+### Option C: Add Compact Contract-Canary Refs To Summary And Keep Full Bodies Authoritative
+
+Torghut adds small contract refs to summary. Jangar uses those refs for cheap presence and freshness checks, and uses
+full payload only when it needs body-level proof or compact refs are absent.
+
+Advantages:
+
+- Preserves summary latency.
+- Makes source-serving contract presence visible.
+- Lets Jangar distinguish missing, stale, schema-mismatched, and transport-unavailable contracts.
+- Keeps full payload as the source of truth for body-level validation.
+- Keeps capital locked.
+
+Disadvantages:
+
+- Adds a compact schema and dual-path tests.
+- Requires ref/full consistency checks.
+- Does not by itself create routeable candidates.
+
+Decision: select Option C.
+
+## Architecture
+
+Torghut adds `torghut.consumer-evidence-contract-canary.v1` to `/trading/consumer-evidence?view=summary`.
+
+```yaml
+schema_version: torghut.consumer-evidence-contract-canary.v1
+canary_id: consumer-evidence-contract-canary:<digest>
+generated_at: <iso8601>
+fresh_until: <iso8601>
+source_commit: <sha>
+serving_revision: <revision>
+image_digest: <digest>
+summary_route_ref: /trading/consumer-evidence?view=summary
+full_route_ref: /trading/consumer-evidence
+observed_contracts:
+  - route_warrant_exchange
+  - repair_bid_settlement_ledger
+contract_refs:
+  route_warrant_exchange:
+    schema_version: torghut.route-warrant-exchange.v1
+    ref: <route-warrant-exchange:*|null>
+    fresh_until: <iso8601|null>
+    state: current|stale|missing|schema_mismatch
+    max_notional: '0'
+  repair_bid_settlement_ledger:
+    schema_version: torghut.repair-bid-settlement-ledger.v1
+    ref: <repair-bid-settlement-ledger:*|null>
+    fresh_until: <iso8601|null>
+    state: current|stale|missing|schema_mismatch
+    max_notional: '0'
+decision: current|hold|block
+reason_codes: []
+rollback_target: omit contract_canary_refs from summary and keep full consumer evidence as authority
+```
+
+Summary payload additions:
+
+- `contract_canary_refs`: the canary object above.
+- `observed_contracts`: compact normalized names.
+- `contract_schema_mismatches`: compact normalized mismatches.
+- `route_warrant_id`, `route_warrant_fresh_until`, `route_warrant_state`, and route-warrant value-gate fields.
+- `repair_bid_settlement_ledger_id`, `repair_bid_settlement_fresh_until`,
+  `repair_bid_settlement_routeable_candidate_count`, selected lot ids, held lot ids, dispatchable lot ids, and
+  `max_notional`.
+
+Full payload remains authoritative for:
+
+- complete route warrant body;
+- complete repair-bid settlement body;
+- source-serving repair receipt ledger;
+- route evidence clearinghouse;
+- no-delta reentry auction;
+- alpha readiness, executable-alpha, and dividend receipts.
+
+Revenue repair remains authoritative for:
+
+- current business state;
+- top repair queue;
+- required output receipt;
+- no-delta reentry decision;
+- Jangar controller-ingestion carry imported into Torghut;
+- the smallest blocker preventing revenue impact.
+
+## No-Delta Reentry Rules
+
+The contract canary does not release capital and does not automatically select a no-delta reentry ticket.
+
+No-delta reentry may select a `jangar_verify_carry` or successor ticket only when all of these are true:
+
+- revenue repair top queue is still `repair_alpha_readiness`;
+- selected value gate is `routeable_candidate_count`;
+- contract canary says route warrant and repair-bid settlement are current or repairable;
+- Jangar controller-ingestion carry is `repairable` or `current`;
+- active no-delta release key has a changed release condition or the selected ticket is explicitly a bounded
+  controller-ingestion repair;
+- required output receipt and validation commands are present;
+- `max_notional=0`.
+
+If any condition fails, Torghut keeps `reentry_decision=deny` or `hold` and preserves the reason codes.
+
+## Implementation Scope
+
+Engineer stage should make one bounded implementation PR:
+
+- add `build_consumer_evidence_contract_canary` in `services/torghut/app/trading/consumer_evidence.py`;
+- populate summary `contract_canary_refs`, `observed_contracts`, and compact contract fields from the already-built
+  full payload contracts in `services/torghut/app/main.py`;
+- add tests in `services/torghut/tests/test_consumer_evidence.py` and
+  `services/torghut/tests/test_trading_api.py -k consumer_evidence`;
+- update Jangar consumer-evidence normalization to read compact refs and fall back to full payload;
+- update Jangar source-serving tests so summary-current/full-contracts-present clears false contract-missing reasons.
+
+Do not touch order submission, notional limits, live submit flags, or capital gates in this milestone.
+
+## Validation Gates
+
+Local validation for the engineer PR:
+
+- `uv run --frozen pytest services/torghut/tests/test_consumer_evidence.py`
+- `uv run --frozen pytest services/torghut/tests/test_trading_api.py -k consumer_evidence`
+- `uv run --frozen pytest services/torghut/tests/test_no_delta_repair_reentry_auction.py`
+- `uv run --frozen pyright --project pyrightconfig.json`
+- `uv run --frozen pyright --project pyrightconfig.alpha.json`
+- `uv run --frozen pyright --project pyrightconfig.scripts.json`
+- `bun run --filter jangar test -- services/jangar/src/server/__tests__/control-plane-torghut-consumer-evidence.test.ts`
+- `bun run --filter jangar test -- services/jangar/src/server/__tests__/control-plane-source-serving-contract-verdict.test.ts`
+
+Post-deploy validation:
+
+- `/trading/consumer-evidence?view=summary` includes `contract_canary_refs` and stays within the existing summary
+  latency and payload budget.
+- Full `/trading/consumer-evidence` still includes the complete route warrant and repair-bid settlement bodies.
+- `/trading/revenue-repair` remains `repair_only`, `revenue_ready=false`, and `max_notional=0` until a later repair
+  actually creates routeable candidates.
+- Jangar source-serving no longer reports route warrant or repair-bid contract missing when the compact refs or full
+  payload prove them current.
+
+## Rollout
+
+1. Ship compact refs in Torghut summary with no Jangar decision change.
+2. Promote Torghut and verify summary/full consistency.
+3. Ship Jangar transport split and consume compact refs in observe mode.
+4. Allow source-serving `dispatch_repair` to use the contract canary only after both summary and full consistency tests
+   are green.
+5. Keep normal dispatch, paper canary, live micro canary, and live scale held by existing gates.
+
+## Rollback
+
+Rollback is additive:
+
+- remove or ignore `contract_canary_refs` from summary;
+- keep full `/trading/consumer-evidence` unchanged;
+- keep `/trading/revenue-repair` as business queue authority;
+- keep no-delta duplicate reentry denial and `max_notional=0`;
+- revert the implementation PR if summary latency or payload size breaches the canary budget.
+
+## Risks
+
+- Compact refs can drift from full contracts. Mitigation: compare ids, schema versions, fresh-until values, and
+  `max_notional` during Jangar full-fetch validation.
+- Summary may grow too large. Mitigation: refs only, no contract bodies, and keep existing canary payload budget.
+- The next blocker may become empirical jobs or alpha evidence rather than routeable candidates. Mitigation: keep value
+  gates explicit; the first expected improvement is retiring false stale-evidence transport, not positive PnL.
+
+## Handoff
+
+Engineer acceptance gate: summary consumer evidence proves route warrant and repair-bid contract refs without carrying
+their full bodies, and Jangar can consume those refs without declaring false missing-contract blockers.
+
+Deployer acceptance gate: after promotion, Torghut summary/full contract refs match, Jangar source-serving cites the
+selected transport authority, revenue repair stays zero-notional, and H-MICRO-01 no-delta reentry remains denied unless
+one bounded zero-notional repair ticket is selected with validation commands.

--- a/docs/torghut/design-system/v6/index.md
+++ b/docs/torghut/design-system/v6/index.md
@@ -12,7 +12,9 @@
 - Implementation status (strict, core 01-13 docs, source-state refresh `2026-03-09`): `Implemented=7`, `Partial=5`,
   `Completed=1`
 - Evidence (historical closure): `13-production-gap-closure-master-plan-2026-03-03.md` (Wave 0-6 closure + DoD)
-- Evidence (current next-work priority, refreshed `2026-05-14T20:45Z`):
+- Evidence (current next-work priority, refreshed `2026-05-15T00:30Z`):
+  - `docs/agents/designs/207-jangar-consumer-evidence-transport-split-and-source-serving-contract-canary-2026-05-15.md`
+  - `213-torghut-consumer-evidence-contract-canary-and-alpha-reentry-transport-2026-05-15.md`
   - `docs/agents/designs/206-jangar-route-adjacent-proof-custody-and-torghut-reentry-admission-2026-05-14.md`
   - `212-torghut-route-adjacent-proof-and-execution-freshness-reentry-2026-05-14.md`
   - `docs/agents/designs/206-jangar-material-evidence-settlement-spine-and-repair-dispatch-budget-2026-05-14.md`


### PR DESCRIPTION
## Summary

- Adds an accepted Jangar architecture contract for split Torghut consumer-evidence transport and source-serving contract canaries.
- Adds the companion Torghut architecture contract for compact summary contract refs, full-payload authority, no-delta alpha reentry rules, rollout, rollback, and validation gates.
- Updates Jangar and Torghut documentation entrypoints so engineer and deployer stages can find the current governing contracts.
- Captures the read-only cluster, source, and data evidence behind the decision, including the live `repair_alpha_readiness` blocker, `routeable_candidate_count` value gate, and `max_notional=0` safety boundary.

## Related Issues

None. Swarm mission: `torghut-quant` plan lane.

## Testing

- PASS: `bunx oxfmt --check docs/agents/README.md docs/agents/designs/207-jangar-consumer-evidence-transport-split-and-source-serving-contract-canary-2026-05-15.md docs/torghut/README.md docs/torghut/design-system/v6/index.md docs/torghut/design-system/v6/213-torghut-consumer-evidence-contract-canary-and-alpha-reentry-transport-2026-05-15.md`
- PASS: `git diff --cached --check`
- PASS: `git show --check --stat --oneline HEAD`
- PASS: marker scan across touched docs and handoff files for stale template, tracker, and review-request strings.

## Screenshots (if applicable)

N/A. Documentation-only architecture change; no UI surface changed.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
