### PR TITLE
test(temporal-bun-sdk): align load test timeout budget

### DIFF
--- a/packages/temporal-bun-sdk/tests/integration/load/runner.test.ts
+++ b/packages/temporal-bun-sdk/tests/integration/load/runner.test.ts
@@ -47,6 +47,22 @@ test('worker load completion budget covers activity timeout envelope and describ
   ).toBe(160_000)
 })
 
+test('worker load Bun test timeout budget covers completion budget plus harness margin', () => {
+  const config = {
+    workflowDurationBudgetMs: 105_000,
+    activityScheduleToStartTimeoutMs: 90_000,
+    activityStartToCloseTimeoutMs: 60_000,
+    activityScheduleToCloseTimeoutMs: 150_000,
+    workflowCount: 64,
+    workflowDescribeConcurrency: 32,
+    metricsFlushTimeoutMs: 5_000,
+  }
+  const completionBudgetMs = __workerLoadTestHooks.calculateLoadCompletionBudgetMs(config)
+
+  expect(completionBudgetMs).toBe(170_000)
+  expect(__workerLoadTestHooks.calculateWorkerLoadTestTimeoutBudgetMs(config)).toBe(completionBudgetMs + 15_000)
+})
+
 test('worker load update termination treats already-completed races as terminal success', () => {
   expect(
     __workerLoadTestHooks.isWorkflowAlreadyCompletedForTermination(

--- a/packages/temporal-bun-sdk/tests/integration/load/runner.ts
+++ b/packages/temporal-bun-sdk/tests/integration/load/runner.ts
@@ -720,7 +720,7 @@ const waitForWorkflowCompletionsRpc = async ({
   return completions
 }
 
-type LoadCompletionBudgetConfig = Pick<WorkerLoadConfig, 'workflowDurationBudgetMs' | 'metricsFlushTimeoutMs'> &
+export type LoadCompletionBudgetConfig = Pick<WorkerLoadConfig, 'workflowDurationBudgetMs' | 'metricsFlushTimeoutMs'> &
   Partial<
     Pick<
       WorkerLoadConfig,
@@ -732,7 +732,7 @@ type LoadCompletionBudgetConfig = Pick<WorkerLoadConfig, 'workflowDurationBudget
     >
   >
 
-const calculateLoadCompletionBudgetMs = (config: LoadCompletionBudgetConfig): number => {
+export const calculateLoadCompletionBudgetMs = (config: LoadCompletionBudgetConfig): number => {
   const activityTimeoutBudgetMs = Math.max(
     config.activityScheduleToCloseTimeoutMs ?? 0,
     (config.activityScheduleToStartTimeoutMs ?? 0) + (config.activityStartToCloseTimeoutMs ?? 0),
@@ -748,6 +748,11 @@ const calculateLoadCompletionBudgetMs = (config: LoadCompletionBudgetConfig): nu
   const flushAndDescribeBudgetMs = Math.max(config.metricsFlushTimeoutMs, 5_000, describeDrainBudgetMs)
   return workflowCompletionBudgetMs + flushAndDescribeBudgetMs
 }
+
+export const calculateWorkerLoadTestTimeoutBudgetMs = (
+  config: LoadCompletionBudgetConfig,
+  harnessMarginMs = 15_000,
+): number => calculateLoadCompletionBudgetMs(config) + harnessMarginMs
 
 const isAcceptedTerminalWorkflowStatus = (status: string): boolean =>
   status === 'COMPLETED' || status === 'TERMINATED' || status === 'CANCELED'
@@ -904,6 +909,7 @@ const workflowExecutionStatusNames: Record<number, string> = {
 
 export const __workerLoadTestHooks = {
   calculateLoadCompletionBudgetMs,
+  calculateWorkerLoadTestTimeoutBudgetMs,
   isWorkflowAlreadyCompletedForTermination,
   normalizeWorkflowStatus,
 }

--- a/packages/temporal-bun-sdk/tests/integration/worker-load.test.ts
+++ b/packages/temporal-bun-sdk/tests/integration/worker-load.test.ts
@@ -3,7 +3,7 @@ import { Effect, Exit } from 'effect'
 
 import { createIntegrationHarness, findTemporalCliUnavailableError, type IntegrationHarness, type TemporalDevServerConfig } from './harness'
 import { readWorkerLoadConfig } from './load/config'
-import { runWorkerLoad } from './load/runner'
+import { calculateWorkerLoadTestTimeoutBudgetMs, runWorkerLoad } from './load/runner'
 
 const shouldRunIntegration = process.env.TEMPORAL_INTEGRATION_TESTS === '1'
 const describeIntegration = shouldRunIntegration ? describe : describe.skip
@@ -14,10 +14,7 @@ const devServerDefaults: TemporalDevServerConfig = {
 }
 
 const loadSuiteDefaults = readWorkerLoadConfig()
-const testTimeoutBudgetMs =
-  loadSuiteDefaults.workflowDurationBudgetMs +
-  Math.max(loadSuiteDefaults.metricsFlushTimeoutMs, 5_000) +
-  15_000
+const testTimeoutBudgetMs = calculateWorkerLoadTestTimeoutBudgetMs(loadSuiteDefaults)
 const hookTimeoutMs = 60_000
 
 describeIntegration('worker runtime load/perf suite', () => {


### PR DESCRIPTION
## Summary

- Align the worker-load Bun test timeout with the runner's release-safe completion budget.
- Export the shared completion-budget helper and add a harness-margin helper for the test wrapper.
- Add a regression case for the failed release-prepare shape: 64 workflows, 32 describe concurrency, and a 150s activity timeout envelope.

## Related Issues

None

## Testing

- `bun test packages/temporal-bun-sdk/tests/integration/load/runner.test.ts`
- `bun run --filter @proompteng/temporal-bun-sdk build`
- `bun test packages/temporal-bun-sdk/tests/integration/worker-load.test.ts`
- `bunx oxfmt --check packages/temporal-bun-sdk/src packages/temporal-bun-sdk/tests packages/temporal-bun-sdk/scripts packages/temporal-bun-sdk/docs`
- `bun run --cwd packages/temporal-bun-sdk lint:oxlint`
- `bun run --cwd packages/temporal-bun-sdk lint:oxlint:type`
- `cd packages/temporal-bun-sdk && bun test --timeout=30000 --max-concurrency=1 $(find tests -path 'tests/integration' -prune -o -name '*.test.ts' -print)`
- `bun run --filter @proompteng/temporal-bun-sdk verify:production`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
