### PR TITLE
fix(jangar): hydrate source-serving contract evidence

### DIFF
--- a/docs/agents/release-handoffs/jangar-source-serving-contract-hydration-2026-05-15.md
+++ b/docs/agents/release-handoffs/jangar-source-serving-contract-hydration-2026-05-15.md
@@ -1,0 +1,88 @@
+# Jangar Source-Serving Contract Hydration Handoff (2026-05-15)
+
+Governing design:
+
+- `docs/agents/designs/205-jangar-controller-ingestion-settlement-and-verification-carry-cutover-2026-05-14.md`
+- `docs/torghut/design-system/v6/211-torghut-controller-ingestion-carry-and-alpha-no-delta-release-2026-05-14.md`
+
+Runtime requirement:
+
+- Cross-swarm Jangar control-plane run for `codex/swarm-jangar-control-plane`, targeting reduced failed AgentRuns and
+  shorter green PR-to-healthy GitOps rollout time.
+
+## Business Evidence
+
+Before implementation, read-only evidence from `http://agents.agents.svc.cluster.local/ready` and
+`http://torghut.torghut.svc.cluster.local/trading/revenue-repair` showed:
+
+- `business_state=repair_only`
+- `revenue_ready=false`
+- top repair queue item `repair_alpha_readiness`
+- top repair reason `alpha_readiness_not_promotion_eligible`
+- affected value gate `routeable_candidate_count`
+- `execution_trust.status=degraded` because the Jangar verify stage was stale
+- Jangar `controller_ingestion_settlement.decision=hold`
+- source-serving evidence was still held by missing or unavailable contract evidence on the hot path
+- Torghut no-delta reentry stayed denied and `max_notional=0`
+
+After local implementation and validation, the live endpoints were intentionally unchanged because this is a PR-stage
+change and has not been deployed. The same read-only checks on 2026-05-15T00:44Z still reported
+`business_state=repair_only`, `revenue_ready=false`, top repair `repair_alpha_readiness`, and value gate
+`routeable_candidate_count`. The smallest remaining live blocker before rollout is serving the updated Jangar adapter
+so the controller-ingestion settlement can hydrate Torghut source-serving contract canaries from the full evidence
+payload instead of reporting false missing-contract debt.
+
+## What Changed
+
+- Jangar now falls back from Torghut's compact `/trading/consumer-evidence?view=summary` response to the full
+  `/trading/consumer-evidence` payload only when route-warrant source-serving evidence is absent from compact and
+  revenue-repair payloads.
+- Jangar hydrates `route_warrant_exchange`, `repair_bid_settlement_ledger`, and
+  `source_serving_repair_receipt_ledger` from that full payload or the revenue-repair fallback before computing
+  observed source-serving contracts.
+- Controller-ingestion settlement now evaluates source-serving carry from material action classes
+  (`dispatch_repair`, `dispatch_normal`, `deploy_widen`, and `merge_ready`) instead of treating a zero-notional
+  `live_support` block as controller-ingestion source carry failure.
+- Tests cover compact-summary contract fallback and the zero-notional live-support case.
+
+## Validation
+
+- `bun install --frozen-lockfile`: passed
+- `bunx vitest run --config vitest.config.ts src/server/__tests__/control-plane-torghut-consumer-evidence.test.ts src/server/__tests__/control-plane-controller-ingestion-settlement.test.ts src/server/__tests__/control-plane-source-serving-contract-verdict.test.ts`: passed, 28 tests
+- `bun run --filter @proompteng/jangar tsc`: passed
+- `bun run --filter @proompteng/jangar lint`: passed
+- `bun run --filter @proompteng/jangar lint:oxlint`: passed with existing warnings, 0 errors
+- `bun run --filter @proompteng/jangar lint:oxlint:type`: passed with existing warnings, 0 errors
+- `bun run --filter @proompteng/jangar check:module-sizes`: passed
+- `bun run --filter @proompteng/jangar docs:inventory:check`: passed
+- `bun run --filter @proompteng/jangar build`: passed
+- `git diff --check`: passed
+
+Note: `bun run --filter @proompteng/jangar test -- <files>` runs the package `pretest` with forwarded file arguments
+in this workspace and trips `@proompteng/temporal-bun-sdk build` with `TS5042`. The targeted Vitest command above was
+used for the actual focused test run.
+
+## Risk And Rollback
+
+Risk:
+
+- The fallback adds one full Torghut consumer-evidence request when compact and revenue-repair payloads do not expose
+  route-warrant evidence. It is bounded by the existing Torghut status timeout and keeps the compact path when the
+  compact or revenue payload already has the needed contract.
+- The controller-ingestion settlement still holds broad work when material source-serving action classes are held or
+  blocked; only zero-notional live-support block no longer poisons controller carry.
+
+Rollback:
+
+- Revert the Jangar adapter fallback and material-action source-serving decision change.
+- Keep Torghut `max_notional=0`, live submit disabled, and existing source-serving verdict, repair-slot, and
+  controller-ingestion settlement gates active.
+
+## Owner Status
+
+This change improves `ready_status_truth`, `manual_intervention_count`, and `handoff_evidence_quality` by removing a
+false missing-contract interpretation from Jangar's Torghut evidence adapter. It does not authorize paper or live
+capital. The release handoff should verify that the deployed `/ready` and full control-plane status no longer cite
+`source_serving_contract_missing:route_warrant_exchange` or
+`source_serving_contract_missing:repair_bid_settlement_ledger` when Torghut's full consumer evidence contains those
+contracts.

--- a/services/jangar/src/server/__tests__/control-plane-controller-ingestion-settlement.test.ts
+++ b/services/jangar/src/server/__tests__/control-plane-controller-ingestion-settlement.test.ts
@@ -230,6 +230,32 @@ describe('control-plane controller ingestion settlement', () => {
     )
   })
 
+  it('does not treat zero-notional live support as a controller-ingestion source carry blocker', () => {
+    const settlement = buildSettlement({
+      sourceServingContractVerdictExchange: sourceServing({
+        status: 'block',
+        allowed_action_classes: [
+          'serve_readonly',
+          'dispatch_repair',
+          'dispatch_normal',
+          'deploy_widen',
+          'merge_ready',
+          'paper_support',
+        ],
+        repair_only_action_classes: [],
+        held_action_classes: [],
+        blocked_action_classes: ['live_support'],
+        reason_codes: [],
+      }),
+    })
+
+    expect(settlement).toMatchObject({
+      decision: 'allow',
+      source_serving_status: 'block',
+      reason_codes: [],
+    })
+  })
+
   it('selects one controller-ingestion repair ticket when ingestion is the only missing witness', () => {
     const settlement = buildSettlement({
       controllerWitness: controllerWitness({

--- a/services/jangar/src/server/__tests__/control-plane-torghut-consumer-evidence.test.ts
+++ b/services/jangar/src/server/__tests__/control-plane-torghut-consumer-evidence.test.ts
@@ -519,11 +519,24 @@ describe('control-plane Torghut consumer evidence', () => {
             receipts: [],
           },
         }),
+      )
+      .mockResolvedValueOnce(
+        buildJsonResponse({
+          schema_version: 'torghut.consumer-evidence-status.v1',
+          route_warrant_exchange: {
+            schema_version: 'torghut.route-warrant-exchange.v1',
+            warrant_id: 'route-warrant-exchange:repair',
+            generated_at: '2026-05-14T00:23:00.000Z',
+            fresh_until: '2026-05-14T00:38:00.000Z',
+            warrant_state: 'repair_only',
+            max_notional: '0',
+          },
+        }),
       ) as unknown as typeof globalThis.fetch
 
     const result = await resolveTorghutConsumerEvidence(new Date('2026-05-14T00:23:10.000Z'))
 
-    expect(globalThis.fetch).toHaveBeenCalledTimes(2)
+    expect(globalThis.fetch).toHaveBeenCalledTimes(3)
     expect(result.status).toMatchObject({
       revenue_repair_business_state: 'repair_only',
       revenue_repair_ready: false,
@@ -551,6 +564,101 @@ describe('control-plane Torghut consumer evidence', () => {
           action_class: 'dispatch_repair',
         }),
       }),
+    })
+  })
+
+  it('hydrates source-serving contract canaries from the full consumer-evidence payload when summary omits them', async () => {
+    process.env = {
+      ...originalEnv,
+      JANGAR_TORGHUT_STATUS_URL: 'http://torghut.torghut.svc.cluster.local/trading/consumer-evidence',
+    }
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        buildJsonResponse({
+          schema_version: 'torghut.consumer-evidence-status.v1',
+          route_proven_profit_receipt: {
+            schema_version: 'torghut.route-proven-profit-receipt.v1',
+            receipt_id: 'torghut-route-proven-profit:summary',
+            generated_at: '2026-05-15T00:30:00.000Z',
+            fresh_until: '2026-05-15T00:31:00.000Z',
+            candidate_id: 'candidate-a',
+            dataset_snapshot_ref: 'dataset-a',
+            max_notional: '0',
+            reason_codes: [],
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        buildJsonResponse({
+          schema_version: 'torghut.revenue-repair-digest.v1',
+          business_state: 'repair_only',
+          revenue_ready: false,
+          repair_queue: [
+            {
+              code: 'repair_alpha_readiness',
+              reason: 'alpha_readiness_not_promotion_eligible',
+              value_gate: 'routeable_candidate_count',
+              required_output_receipt: 'torghut.executable-alpha-receipts.v1',
+              max_notional: '0',
+            },
+          ],
+        }),
+      )
+      .mockResolvedValueOnce(
+        buildJsonResponse({
+          schema_version: 'torghut.consumer-evidence-status.v1',
+          route_warrant_exchange: {
+            schema_version: 'torghut.route-warrant-exchange.v1',
+            warrant_id: 'route-warrant-exchange:full',
+            generated_at: '2026-05-15T00:30:00.000Z',
+            fresh_until: '2026-05-15T00:31:00.000Z',
+            warrant_state: 'repair_only',
+            accepted_routeable_candidate_count: 0,
+            max_notional: '0',
+            blocking_reason_codes: ['alpha_readiness_not_promotion_eligible'],
+          },
+          repair_bid_settlement_ledger: {
+            schema_version: 'torghut.repair-bid-settlement-ledger.v1',
+            ledger_id: 'repair-bid-settlement-ledger:full',
+            generated_at: '2026-05-15T00:30:00.000Z',
+            fresh_until: '2026-05-15T00:31:00.000Z',
+            capital_decision: 'repair_only',
+            max_notional: '0',
+            selected_lot_ids: ['compacted-repair-lot:promotion'],
+            dispatchable_lot_ids: ['compacted-repair-lot:promotion'],
+            compacted_lots: [],
+          },
+        }),
+      ) as unknown as typeof globalThis.fetch
+
+    const result = await resolveTorghutConsumerEvidence(new Date('2026-05-15T00:30:10.000Z'))
+
+    expect(globalThis.fetch).toHaveBeenNthCalledWith(
+      1,
+      'http://torghut.torghut.svc.cluster.local/trading/consumer-evidence?view=summary',
+      expect.objectContaining({ method: 'GET' }),
+    )
+    expect(globalThis.fetch).toHaveBeenNthCalledWith(
+      2,
+      'http://torghut.torghut.svc.cluster.local/trading/revenue-repair',
+      expect.objectContaining({ method: 'GET' }),
+    )
+    expect(globalThis.fetch).toHaveBeenNthCalledWith(
+      3,
+      'http://torghut.torghut.svc.cluster.local/trading/consumer-evidence',
+      expect.objectContaining({ method: 'GET' }),
+    )
+    expect(result.status).toMatchObject({
+      receipt_id: 'torghut-route-proven-profit:summary',
+      observed_contracts: expect.arrayContaining(['route_warrant_exchange', 'repair_bid_settlement_ledger']),
+      route_warrant_id: 'route-warrant-exchange:full',
+      route_warrant_state: 'repair_only',
+      route_warrant_blocking_reason_codes: ['alpha_readiness_not_promotion_eligible'],
+      repair_bid_settlement_ledger_id: 'repair-bid-settlement-ledger:full',
+      repair_bid_settlement_status: 'current',
+      repair_bid_settlement_selected_lot_ids: ['compacted-repair-lot:promotion'],
+      repair_bid_settlement_dispatchable_lot_ids: ['compacted-repair-lot:promotion'],
     })
   })
 
@@ -1167,15 +1275,31 @@ describe('control-plane Torghut consumer evidence', () => {
           },
         }),
       )
+      .mockResolvedValueOnce(
+        buildJsonResponse({
+          schema_version: 'torghut.consumer-evidence-status.v1',
+          route_warrant_exchange: {
+            schema_version: 'torghut.route-warrant-exchange.v1',
+            warrant_id: 'route-warrant-exchange:settlement-conveyor',
+            generated_at: '2026-05-14T09:15:00.000Z',
+            fresh_until: '2026-05-14T09:16:00.000Z',
+            warrant_state: 'repair_only',
+            max_notional: '0',
+          },
+        }),
+      )
     globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch
 
     const result = await resolveTorghutConsumerEvidence(new Date('2026-05-14T09:15:10.000Z'))
 
-    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(fetchMock).toHaveBeenCalledTimes(3)
     expect(String(fetchMock.mock.calls[0]?.[0])).toBe(
       'http://torghut.torghut.svc.cluster.local/trading/consumer-evidence?view=summary',
     )
     expect(String(fetchMock.mock.calls[1]?.[0])).toBe('http://torghut.torghut.svc.cluster.local/trading/revenue-repair')
+    expect(String(fetchMock.mock.calls[2]?.[0])).toBe(
+      'http://torghut.torghut.svc.cluster.local/trading/consumer-evidence',
+    )
     expect(result.status.observed_contracts).toEqual(expect.arrayContaining(['alpha_readiness_settlement_conveyor']))
     expect(result.status.contract_schema_mismatches).not.toEqual(
       expect.arrayContaining(['alpha_readiness_settlement_conveyor:torghut.alpha-readiness-settlement-conveyor.v1']),

--- a/services/jangar/src/server/control-plane-controller-ingestion-settlement.ts
+++ b/services/jangar/src/server/control-plane-controller-ingestion-settlement.ts
@@ -29,6 +29,12 @@ export const CONTROLLER_INGESTION_SETTLEMENT_TORGHUT_DESIGN_ARTIFACT =
 const SCHEMA_VERSION = 'jangar.controller-ingestion-settlement.v1' as const
 const DEFAULT_TTL_SECONDS = 60
 const ZERO_NOTIONAL_VALUES = new Set(['0', '0.0', '0.00', '0.0000'])
+const MATERIAL_SOURCE_SERVING_ACTION_CLASSES = [
+  'dispatch_repair',
+  'dispatch_normal',
+  'deploy_widen',
+  'merge_ready',
+] as const
 const ROLLBACK_TARGET =
   'ignore controller_ingestion_settlement consumers and keep ready truth, stage credit, source-serving verdicts, and Torghut max_notional=0 as authorities'
 
@@ -142,15 +148,37 @@ const controllerWitnessReasons = (input: BuildControllerIngestionSettlementInput
     ...input.controllerWitness.reason_codes,
   ]).map((reason) => normalizeReason(reason) ?? reason)
 
+const sourceServingMaterialDecision = (
+  exchange: SourceServingContractVerdictExchange,
+): SourceServingContractVerdictExchange['status'] => {
+  if (
+    MATERIAL_SOURCE_SERVING_ACTION_CLASSES.some((actionClass) => exchange.blocked_action_classes.includes(actionClass))
+  ) {
+    return 'block'
+  }
+  if (
+    MATERIAL_SOURCE_SERVING_ACTION_CLASSES.some((actionClass) => exchange.held_action_classes.includes(actionClass))
+  ) {
+    return 'hold'
+  }
+  if (
+    MATERIAL_SOURCE_SERVING_ACTION_CLASSES.some((actionClass) =>
+      exchange.repair_only_action_classes.includes(actionClass),
+    )
+  ) {
+    return 'repair_only'
+  }
+  return 'allow'
+}
+
 const sourceCarryReasons = (
   input: BuildControllerIngestionSettlementInput,
   carryStatus: ControllerIngestionSettlementTorghutCarryStatus,
-) =>
-  uniqueStrings([
+) => {
+  const materialDecision = sourceServingMaterialDecision(input.sourceServingContractVerdictExchange)
+  return uniqueStrings([
     isFresh(input.sourceServingContractVerdictExchange.fresh_until, input.now) ? null : 'source_serving_verdict_stale',
-    input.sourceServingContractVerdictExchange.status === 'allow'
-      ? null
-      : `source_serving_${input.sourceServingContractVerdictExchange.status}`,
+    materialDecision === 'allow' ? null : `source_serving_${materialDecision}`,
     ...input.sourceServingContractVerdictExchange.reason_codes,
     input.verifyTrustForeclosureBoard
       ? isFresh(input.verifyTrustForeclosureBoard.fresh_until, input.now)
@@ -162,6 +190,7 @@ const sourceCarryReasons = (
       : null,
     carryStatus === 'current' || carryStatus === 'unknown' ? null : `torghut_verification_carry_${carryStatus}`,
   ]).map((reason) => normalizeReason(reason) ?? reason)
+}
 
 const platformReasons = (input: BuildControllerIngestionSettlementInput) =>
   uniqueStrings([

--- a/services/jangar/src/server/control-plane-torghut-consumer-evidence.ts
+++ b/services/jangar/src/server/control-plane-torghut-consumer-evidence.ts
@@ -97,6 +97,11 @@ const requestJson = async (url: string, timeoutMs: number): Promise<JsonRouteRes
   }
 }
 
+const hasRouteWarrantPayload = (payload: Record<string, unknown> | null | undefined) =>
+  Boolean(
+    payload && asRecord(payload.route_warrant_exchange ?? payload.route_warrant_exchange_v1 ?? payload.route_warrant),
+  )
+
 const compactConsumerEvidenceEndpoint = (endpoint: string): string => {
   try {
     const url = new URL(endpoint)
@@ -160,7 +165,8 @@ export const resolveTorghutConsumerEvidence = async (now = new Date()): Promise<
     }
   }
 
-  const routeResult = await requestJson(compactConsumerEvidenceEndpoint(endpoint), config.torghutStatusTimeoutMs)
+  const compactEndpoint = compactConsumerEvidenceEndpoint(endpoint)
+  const routeResult = await requestJson(compactEndpoint, config.torghutStatusTimeoutMs)
   if (!routeResult.ok) {
     const routeMissing = routeResult.statusCode === 404
     const status = routeMissing ? 'route_missing' : 'unavailable'
@@ -210,6 +216,12 @@ export const resolveTorghutConsumerEvidence = async (now = new Date()): Promise<
   const revenueRepairBusinessState = normalizeReason(revenueRepairPayload?.business_state)
   const revenueRepairReady = normalizeRevenueRepairBoolean(revenueRepairPayload?.revenue_ready)
   const revenueRepairQueue = readRevenueRepairQueue(revenueRepairPayload)
+  const fullConsumerEvidenceResult =
+    compactEndpoint !== endpoint && !hasRouteWarrantPayload(payload) && !hasRouteWarrantPayload(revenueRepairPayload)
+      ? await requestJson(endpoint, config.torghutStatusTimeoutMs)
+      : null
+  const sourceServingContractPayload =
+    fullConsumerEvidenceResult?.ok && fullConsumerEvidenceResult.payload ? fullConsumerEvidenceResult.payload : payload
   const alphaRepairClosureBoard =
     readAlphaRepairClosureBoard(payload) ?? readAlphaRepairClosureBoard(revenueRepairPayload)
   const alphaEvidenceFoundry = readAlphaEvidenceFoundry(payload) ?? readAlphaEvidenceFoundry(revenueRepairPayload)
@@ -458,11 +470,22 @@ export const resolveTorghutConsumerEvidence = async (now = new Date()): Promise<
   const topClockSplit = evidenceClockSplits[0]
   const selectedEvidenceClockRepair = zeroNotionalRepairLots[0]
   const routeWarrant = asRecord(
-    payload.route_warrant_exchange ?? payload.route_warrant_exchange_v1 ?? payload.route_warrant,
+    sourceServingContractPayload.route_warrant_exchange ??
+      sourceServingContractPayload.route_warrant_exchange_v1 ??
+      sourceServingContractPayload.route_warrant ??
+      payload.route_warrant_exchange ??
+      payload.route_warrant_exchange_v1 ??
+      payload.route_warrant,
   )
-  const repairBidSettlement = asRecord(payload.repair_bid_settlement_ledger)
+  const repairBidSettlement =
+    asRecord(sourceServingContractPayload.repair_bid_settlement_ledger) ??
+    asRecord(payload.repair_bid_settlement_ledger) ??
+    asRecord(revenueRepairPayload?.repair_bid_settlement_ledger)
   const repairOutcome = readTorghutRepairOutcomeEvidence(payload)
-  const sourceServingRepairReceiptLedger = asRecord(payload.source_serving_repair_receipt_ledger)
+  const sourceServingRepairReceiptLedger =
+    asRecord(sourceServingContractPayload.source_serving_repair_receipt_ledger) ??
+    asRecord(payload.source_serving_repair_receipt_ledger) ??
+    asRecord(revenueRepairPayload?.source_serving_repair_receipt_ledger)
   const freshnessCarry = readTorghutFreshnessCarryEvidence(payload)
   const reasonCodes = uniqueStrings([...receiptReasonCodes, ...freshnessCarry.reasonCodes])
   const observedContracts = uniqueStrings([


### PR DESCRIPTION
## Summary

- Hydrates Jangar source-serving contract evidence from Torghut's full consumer-evidence payload when the compact summary omits `route_warrant_exchange` and `repair_bid_settlement_ledger`.
- Makes controller-ingestion settlement evaluate source-serving carry from material action classes only, so zero-notional `live_support` blocks do not falsely block controller carry.
- Adds regression coverage for compact-summary fallback and zero-notional live-support behavior.
- Adds release handoff evidence in `docs/agents/release-handoffs/jangar-source-serving-contract-hydration-2026-05-15.md`.

Design and runtime provenance:

- Governing Jangar design: `docs/agents/designs/205-jangar-controller-ingestion-settlement-and-verification-carry-cutover-2026-05-14.md`.
- Companion Torghut design: `docs/torghut/design-system/v6/211-torghut-controller-ingestion-carry-and-alpha-no-delta-release-2026-05-14.md`.
- Requirement: reduce failed AgentRuns and shorten green PR-to-healthy GitOps rollout time for the Jangar control plane.
- Value gates: `ready_status_truth`, `manual_intervention_count`, `handoff_evidence_quality`.

Business evidence:

- Before coding, `/ready` and `/trading/revenue-repair` were reachable with `business_state=repair_only`, `revenue_ready=false`, top repair `repair_alpha_readiness`, reason `alpha_readiness_not_promotion_eligible`, affected value gate `routeable_candidate_count`, and `max_notional=0`.
- After local validation, before rollout, live evidence remained intentionally unchanged: `business_state=repair_only`, `revenue_ready=false`, top repair `repair_alpha_readiness`, affected value gate `routeable_candidate_count`, `execution_trust.status=degraded`, and Torghut no-delta reentry denied.
- Final pre-merge read after hosted CI at 2026-05-15T01:03Z: `/ready` still reports `business_state=repair_only`, `revenue_ready=false`, top repair `repair_alpha_readiness`, affected value gate `routeable_candidate_count`, and `execution_trust.status=healthy`; `/trading/revenue-repair` still reports `repair_only`, `revenue_ready=false`, top repair `repair_alpha_readiness`, and `operating_rule=keep_live_submit_disabled_until_repair_queue_clears`.

Risk and rollback:

- Risk: one extra full Torghut consumer-evidence request is made only when compact and revenue-repair payloads do not expose route-warrant evidence; the call is bounded by the existing Torghut status timeout.
- Rollback: revert this PR and keep existing source-serving verdicts, controller-ingestion settlement, repair-slot gates, Torghut `max_notional=0`, and live submit disabled.

## Related Issues

None

## Testing

- `bun install --frozen-lockfile`
- `bunx vitest run --config vitest.config.ts src/server/__tests__/control-plane-torghut-consumer-evidence.test.ts src/server/__tests__/control-plane-controller-ingestion-settlement.test.ts src/server/__tests__/control-plane-source-serving-contract-verdict.test.ts`
- `bun run --filter @proompteng/jangar tsc`
- `bun run --filter @proompteng/jangar lint`
- `bun run --filter @proompteng/jangar lint:oxlint`
- `bun run --filter @proompteng/jangar lint:oxlint:type`
- `bun run --filter @proompteng/jangar check:module-sizes`
- `bun run --filter @proompteng/jangar docs:inventory:check`
- `bun run --filter @proompteng/jangar build`
- `git diff --check`
- `curl -fsS http://agents.agents.svc.cluster.local/ready | jq '{status,business_state,revenue_ready,top_repair_queue_item,affected_value_gate,execution_trust:{status:.execution_trust.status,reason:.execution_trust.reason}}'`
- `curl -fsS http://torghut.torghut.svc.cluster.local/trading/revenue-repair | jq '{business_state,revenue_ready,top_repair_queue_item:.repair_queue[0],operating_rule}'`
- Hosted `jangar-ci / lint-and-typecheck`: passed
- Hosted `agents-ci / validate`: passed
- Hosted `agents-ci / integration`: passed in 15m8s
- Hosted semantic title, semantic commits, and changed-files checks: passed

Note: `bun run --filter @proompteng/jangar test -- file arguments` forwards file arguments into package `pretest` in this workspace and trips `@proompteng/temporal-bun-sdk build` with `TS5042`, so focused Vitest was run directly from `services/jangar`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
