### PR TITLE
chore(jangar): promote image c5e3acea

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: ff98e821
-  digest: sha256:64459686b1f0c5e7a956f239dfa6e00adcee3f215c48a93896dda670d0e36416
+  tag: c5e3acea
+  digest: sha256:d93a0c069db0e20ebaddec4752c43e52d5475e8e6f1911cc0b9d4ec8f5247dff
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,25 +11,25 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: ff98e821
-    digest: sha256:bf0169290cf1c31a5fe2d35c04b43e8c00f8320caf3e0884b2f19cfd546da2b5
+    tag: c5e3acea
+    digest: sha256:b184f0d405f0f900c403e2ebe2070b08f9959dcff1854e7f55c0daca5039c794
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
       JANGAR_TORGHUT_STATUS_URL: http://torghut.torghut.svc.cluster.local/trading/consumer-evidence
       JANGAR_TORGHUT_STATUS_TIMEOUT_MS: "3000"
-      JANGAR_SOURCE_HEAD_SHA: ff98e82146135c9a592eee4c3676da47c2e83477
-      JANGAR_GITOPS_REVISION: ff98e82146135c9a592eee4c3676da47c2e83477
-      JANGAR_SOURCE_CI_RUN_ID: "25893609619"
+      JANGAR_SOURCE_HEAD_SHA: c5e3acea7c9d411a6af4d89ad5f37707a041e181
+      JANGAR_GITOPS_REVISION: c5e3acea7c9d411a6af4d89ad5f37707a041e181
+      JANGAR_SOURCE_CI_RUN_ID: "25895083407"
       JANGAR_SOURCE_CI_CONCLUSION: success
-      JANGAR_MANIFEST_IMAGE_DIGEST: sha256:bf0169290cf1c31a5fe2d35c04b43e8c00f8320caf3e0884b2f19cfd546da2b5
-      JANGAR_SERVING_BUILD_COMMIT: ff98e82146135c9a592eee4c3676da47c2e83477
-      JANGAR_SERVING_IMAGE_DIGEST: sha256:bf0169290cf1c31a5fe2d35c04b43e8c00f8320caf3e0884b2f19cfd546da2b5
+      JANGAR_MANIFEST_IMAGE_DIGEST: sha256:b184f0d405f0f900c403e2ebe2070b08f9959dcff1854e7f55c0daca5039c794
+      JANGAR_SERVING_BUILD_COMMIT: c5e3acea7c9d411a6af4d89ad5f37707a041e181
+      JANGAR_SERVING_IMAGE_DIGEST: sha256:b184f0d405f0f900c403e2ebe2070b08f9959dcff1854e7f55c0daca5039c794
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: ff98e821
-    digest: sha256:64459686b1f0c5e7a956f239dfa6e00adcee3f215c48a93896dda670d0e36416
+    tag: c5e3acea
+    digest: sha256:d93a0c069db0e20ebaddec4752c43e52d5475e8e6f1911cc0b9d4ec8f5247dff
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-15T00:35:05Z
+    deploy.knative.dev/rollout: 2026-05-15T01:24:14Z
 spec:
   replicas: 1
   strategy:
@@ -57,11 +57,11 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_RUNTIME_IMAGE
-              value: registry.ide-newton.ts.net/lab/jangar:ff98e821@sha256:64459686b1f0c5e7a956f239dfa6e00adcee3f215c48a93896dda670d0e36416
+              value: registry.ide-newton.ts.net/lab/jangar:c5e3acea@sha256:d93a0c069db0e20ebaddec4752c43e52d5475e8e6f1911cc0b9d4ec8f5247dff
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: ff98e82146135c9a592eee4c3676da47c2e83477
+              value: c5e3acea7c9d411a6af4d89ad5f37707a041e181
             - name: JANGAR_GITOPS_REVISION
-              value: ff98e82146135c9a592eee4c3676da47c2e83477
+              value: c5e3acea7c9d411a6af4d89ad5f37707a041e181
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_CONTROL_PLANE_STATUS_CACHE_TTL_MS
@@ -405,15 +405,15 @@ spec:
             - name: OPENAI_EMBEDDING_TIMEOUT_MS
               value: "60000"
             - name: JANGAR_SOURCE_CI_RUN_ID
-              value: "25893609619"
+              value: "25895083407"
             - name: JANGAR_SOURCE_CI_CONCLUSION
               value: success
             - name: JANGAR_MANIFEST_IMAGE_DIGEST
-              value: sha256:bf0169290cf1c31a5fe2d35c04b43e8c00f8320caf3e0884b2f19cfd546da2b5
+              value: sha256:b184f0d405f0f900c403e2ebe2070b08f9959dcff1854e7f55c0daca5039c794
             - name: JANGAR_SERVING_BUILD_COMMIT
-              value: ff98e82146135c9a592eee4c3676da47c2e83477
+              value: c5e3acea7c9d411a6af4d89ad5f37707a041e181
             - name: JANGAR_SERVING_IMAGE_DIGEST
-              value: sha256:bf0169290cf1c31a5fe2d35c04b43e8c00f8320caf3e0884b2f19cfd546da2b5
+              value: sha256:b184f0d405f0f900c403e2ebe2070b08f9959dcff1854e7f55c0daca5039c794
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -59,5 +59,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: ff98e821
-    digest: sha256:64459686b1f0c5e7a956f239dfa6e00adcee3f215c48a93896dda670d0e36416
+    newTag: c5e3acea
+    digest: sha256:d93a0c069db0e20ebaddec4752c43e52d5475e8e6f1911cc0b9d4ec8f5247dff


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `c5e3acea7c9d411a6af4d89ad5f37707a041e181`
- Image tag: `c5e3acea`
- Image digest: `sha256:d93a0c069db0e20ebaddec4752c43e52d5475e8e6f1911cc0b9d4ec8f5247dff`
- Source CI run: `25895083407`
- Control-plane serving digest: `sha256:b184f0d405f0f900c403e2ebe2070b08f9959dcff1854e7f55c0daca5039c794`
- Updated API rollout annotation
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`
- Published source-serving proof env for revenue repair custody gates