### PR TITLE
feat(torghut): add consumer evidence contract canaries

### DIFF
--- a/docs/torghut/rollouts/2026-05-15-consumer-evidence-contract-canary.md
+++ b/docs/torghut/rollouts/2026-05-15-consumer-evidence-contract-canary.md
@@ -1,0 +1,65 @@
+# Consumer-Evidence Contract Canary Rollout (2026-05-15)
+
+## Design provenance
+
+- Torghut: `docs/torghut/design-system/v6/213-torghut-consumer-evidence-contract-canary-and-alpha-reentry-transport-2026-05-15.md`
+- Jangar: `docs/agents/designs/207-jangar-consumer-evidence-transport-split-and-source-serving-contract-canary-2026-05-15.md`
+
+## Runtime requirement
+
+Live `/trading/revenue-repair` selected `repair_alpha_readiness` as the top queue item with
+`value_gate=routeable_candidate_count`, `required_output_receipt=torghut.executable-alpha-receipts.v1`,
+`business_state=repair_only`, `revenue_ready=false`, and `max_notional=0`.
+
+Before and after this local implementation run, the live business evidence remained:
+
+| field                                | before                      | after                       |
+| ------------------------------------ | --------------------------- | --------------------------- |
+| `business_state`                     | `repair_only`               | `repair_only`               |
+| `revenue_ready`                      | `false`                     | `false`                     |
+| top queue item                       | `repair_alpha_readiness`    | `repair_alpha_readiness`    |
+| affected value gate                  | `routeable_candidate_count` | `routeable_candidate_count` |
+| `accepted_routeable_candidate_count` | `0`                         | `0`                         |
+| `max_notional`                       | `0`                         | `0`                         |
+
+The expected first movement is retiring false source-serving transport debt, not creating positive notional or live
+submission.
+
+## Change
+
+- Torghut summary consumer evidence now carries `torghut.consumer-evidence-contract-canary.v1` refs for
+  `route_warrant_exchange` and `repair_bid_settlement_ledger`.
+- Full Torghut consumer evidence remains the authority for the complete route-warrant and repair-bid bodies.
+- Jangar consumes compact refs first, falls back to one bounded full fetch when refs are missing, and records
+  `torghut_contract_transport_unavailable` when that fallback fails instead of reporting false missing contracts.
+- Source-serving verdicts can infer required contracts from compact route-warrant and repair-bid refs while keeping
+  zero-notional repair-only behavior.
+
+## Validation
+
+- `uv sync --frozen --extra dev`
+- `uv run --frozen ruff check app/main.py app/trading/consumer_evidence.py tests/test_consumer_evidence.py tests/test_trading_api.py`
+- `uv run --frozen ruff format --check app/main.py app/trading/consumer_evidence.py tests/test_consumer_evidence.py tests/test_trading_api.py`
+- `uv run --frozen pytest tests/test_consumer_evidence.py`
+- `uv run --frozen pytest tests/test_trading_api.py -k consumer_evidence`
+- `uv run --frozen pytest tests/test_no_delta_repair_reentry_auction.py`
+- `uv run --frozen pyright --project pyrightconfig.json`
+- `uv run --frozen pyright --project pyrightconfig.alpha.json`
+- `uv run --frozen pyright --project pyrightconfig.scripts.json`
+- `bunx oxfmt --check services/jangar/src/routes/ready.test.ts services/jangar/src/server/control-plane-torghut-consumer-evidence.ts services/jangar/src/server/control-plane-source-serving-contract-verdict.ts services/jangar/src/server/__tests__/control-plane-torghut-consumer-evidence.test.ts services/jangar/src/server/__tests__/control-plane-source-serving-contract-verdict.test.ts`
+- `bunx oxlint --config .oxlintrc.json services/jangar/src/routes/ready.test.ts services/jangar/src/server/control-plane-torghut-consumer-evidence.ts services/jangar/src/server/control-plane-source-serving-contract-verdict.ts services/jangar/src/server/__tests__/control-plane-torghut-consumer-evidence.test.ts services/jangar/src/server/__tests__/control-plane-source-serving-contract-verdict.test.ts`
+- `bun run --filter @proompteng/jangar tsc`
+- `bunx vitest run --config vitest.config.ts src/server/__tests__/control-plane-torghut-consumer-evidence.test.ts src/server/__tests__/control-plane-source-serving-contract-verdict.test.ts`
+- `bun run --filter @proompteng/jangar test`
+
+## Rollback
+
+Revert the implementation PR or have Jangar ignore `contract_canary_refs` and return to full payload authority. The
+Torghut summary canary is additive, the full consumer-evidence payload remains unchanged as the contract-body source,
+and all affected repair evidence keeps `max_notional=0`.
+
+## Risk
+
+The main risk is ref/body drift between summary and full payloads. The mitigation is to compare schema versions, ids,
+fresh-until values, and max-notional in Jangar full-fetch validation and post-deploy checks before using the refs for
+anything beyond repair-only source-serving evidence.

--- a/services/jangar/README.md
+++ b/services/jangar/README.md
@@ -721,6 +721,12 @@ requires Jangar to expose typed Torghut custody evidence from the non-recursive 
 Jangar requests `/trading/consumer-evidence?view=summary` when the configured Torghut status URL points at the
 consumer-evidence route, so readiness gets the compact status, receipt, route-profit, and canary fields without
 pulling the full operator ledger payload through the control-plane hot path.
+For the May 15 transport split in
+`docs/agents/designs/207-jangar-consumer-evidence-transport-split-and-source-serving-contract-canary-2026-05-15.md`,
+Jangar reads Torghut's compact `contract_canary_refs` for `route_warrant_exchange` and
+`repair_bid_settlement_ledger`. If compact refs are missing, it performs one bounded full consumer-evidence fetch
+before source-serving verdicts decide contract presence. If that fallback is unavailable while summary is current,
+Jangar records `torghut_contract_transport_unavailable` instead of declaring the source-serving contracts absent.
 When Torghut imports Jangar carry for that route, it calls `/api/agents/control-plane/status` with
 `x-torghut-consumer-evidence-mode: omit`; Jangar then computes the local control-plane status without fetching Torghut
 consumer evidence, which prevents a Torghut -> Jangar -> Torghut status loop.

--- a/services/jangar/src/routes/ready.test.ts
+++ b/services/jangar/src/routes/ready.test.ts
@@ -393,6 +393,28 @@ describe('getReadyHandler', () => {
             max_notional: '0',
             reason_codes: [],
           },
+          contract_canary_refs: {
+            schema_version: 'torghut.consumer-evidence-contract-canary.v1',
+            canary_id: 'consumer-evidence-contract-canary:ready-test',
+            observed_contracts: ['route_warrant_exchange', 'repair_bid_settlement_ledger'],
+            contract_schema_mismatches: [],
+            contract_refs: {
+              route_warrant_exchange: {
+                schema_version: 'torghut.route-warrant-exchange.v1',
+                ref: 'route-warrant-exchange:ready-test',
+                fresh_until: '2026-05-14T00:38:00.000Z',
+                state: 'current',
+                max_notional: '0',
+              },
+              repair_bid_settlement_ledger: {
+                schema_version: 'torghut.repair-bid-settlement-ledger.v1',
+                ref: 'repair-bid-settlement-ledger:ready-test',
+                fresh_until: '2026-05-14T00:38:00.000Z',
+                state: 'current',
+                max_notional: '0',
+              },
+            },
+          },
           alpha_readiness_settlement_conveyor: {
             schema_version: 'torghut.alpha-readiness-settlement-conveyor-ref.v1',
             conveyor_schema_version: 'torghut.alpha-readiness-settlement-conveyor.v1',

--- a/services/jangar/src/server/__tests__/control-plane-source-serving-contract-verdict.test.ts
+++ b/services/jangar/src/server/__tests__/control-plane-source-serving-contract-verdict.test.ts
@@ -118,6 +118,45 @@ describe('control-plane source-serving contract verdict', () => {
     })
   })
 
+  it('uses compact Torghut contract refs when observed contract names are omitted', () => {
+    const exchange = build({
+      torghutConsumerEvidence: torghutEvidence({
+        observed_contracts: [],
+        route_warrant_id: 'route-warrant-exchange:summary',
+        repair_bid_settlement_ledger_id: 'repair-bid-settlement-ledger:summary',
+      }),
+    })
+
+    expect(exchange.observed_contracts).toEqual(['route_warrant_exchange', 'repair_bid_settlement_ledger'])
+    expect(exchange.missing_contracts).toEqual([])
+    expect(verdict(exchange, 'dispatch_repair')).toMatchObject({
+      decision: 'repair_only',
+      torghut_route_warrant_ref: 'route-warrant-exchange:summary',
+      torghut_repair_bid_settlement_ref: 'repair-bid-settlement-ledger:summary',
+    })
+  })
+
+  it('holds on transport unavailable without declaring source contracts absent', () => {
+    const exchange = build({
+      torghutConsumerEvidence: torghutEvidence({
+        observed_contracts: [],
+        route_warrant_id: null,
+        repair_bid_settlement_ledger_id: null,
+        reason_codes: ['torghut_contract_transport_unavailable'],
+      }),
+    })
+
+    expect(exchange.missing_contracts).toEqual([])
+    expect(exchange.reason_codes).toContain('torghut_contract_transport_unavailable')
+    expect(exchange.reason_codes).not.toContain('source_serving_contract_missing:route_warrant_exchange')
+    expect(exchange.reason_codes).not.toContain('source_serving_contract_missing:repair_bid_settlement_ledger')
+    expect(verdict(exchange, 'dispatch_repair')).toMatchObject({
+      decision: 'hold',
+      source_serving_state: 'unknown',
+      blocking_reason_codes: expect.arrayContaining(['torghut_contract_transport_unavailable']),
+    })
+  })
+
   it('allows deploy, merge, paper, and live only when source CI, build, digest, and contracts converge', () => {
     const digest = 'sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
     const exchange = build({

--- a/services/jangar/src/server/__tests__/control-plane-torghut-consumer-evidence.test.ts
+++ b/services/jangar/src/server/__tests__/control-plane-torghut-consumer-evidence.test.ts
@@ -422,6 +422,150 @@ describe('control-plane Torghut consumer evidence', () => {
     })
   })
 
+  it('reads compact source-serving contract refs from summary consumer evidence', async () => {
+    process.env = {
+      ...originalEnv,
+      JANGAR_TORGHUT_STATUS_URL: 'http://torghut.torghut.svc.cluster.local/trading/consumer-evidence',
+    }
+    globalThis.fetch = vi.fn(() =>
+      Promise.resolve(
+        buildJsonResponse({
+          schema_version: 'torghut.consumer-evidence-status.v1',
+          view: 'summary',
+          route_proven_profit_receipt: {
+            schema_version: 'torghut.route-proven-profit-receipt.v1',
+            receipt_id: 'torghut-route-proven-profit:summary',
+            generated_at: '2026-05-15T00:30:00.000Z',
+            fresh_until: '2026-05-15T00:31:00.000Z',
+            paper_readiness_state: 'blocked',
+            live_readiness_state: 'blocked',
+            max_notional: '0',
+            reason_codes: [],
+          },
+          build: {
+            commit: '4dfa7c70771f3f8d6f3884c52a77c41e5e851638',
+            active_revision: 'torghut-00434',
+            image_digest: 'sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          },
+          contract_canary_refs: {
+            schema_version: 'torghut.consumer-evidence-contract-canary.v1',
+            canary_id: 'consumer-evidence-contract-canary:summary',
+            generated_at: '2026-05-15T00:30:00.000Z',
+            fresh_until: '2026-05-15T00:31:00.000Z',
+            observed_contracts: ['route_warrant_exchange', 'repair_bid_settlement_ledger'],
+            contract_schema_mismatches: [],
+            decision: 'current',
+            contract_refs: {
+              route_warrant_exchange: {
+                schema_version: 'torghut.route-warrant-exchange.v1',
+                ref: 'route-warrant-exchange:summary',
+                fresh_until: '2026-05-15T00:31:00.000Z',
+                state: 'current',
+                max_notional: '0',
+              },
+              repair_bid_settlement_ledger: {
+                schema_version: 'torghut.repair-bid-settlement-ledger.v1',
+                ref: 'repair-bid-settlement-ledger:summary',
+                fresh_until: '2026-05-15T00:31:00.000Z',
+                state: 'current',
+                max_notional: '0',
+              },
+            },
+          },
+          business_state: 'repair_only',
+          revenue_ready: false,
+          alpha_readiness_strike_ledger: {
+            schema_version: 'torghut.alpha-readiness-strike-ledger.v1',
+            ledger_id: 'alpha-readiness-strike-ledger:summary',
+          },
+          executable_alpha_repair_receipts: {
+            schema_version: 'torghut.executable-alpha-repair-receipts.v1',
+            status: 'selected',
+            receipt_count: 0,
+            receipts: [],
+          },
+          route_warrant_id: 'route-warrant-exchange:summary',
+          route_warrant_state: 'repair_only',
+          route_warrant_fresh_until: '2026-05-15T00:31:00.000Z',
+          repair_bid_settlement_ledger_id: 'repair-bid-settlement-ledger:summary',
+          repair_bid_settlement_status: 'current',
+          repair_bid_settlement_fresh_until: '2026-05-15T00:31:00.000Z',
+          repair_bid_settlement_max_notional: '0',
+          repair_bid_settlement_routeable_candidate_count: 0,
+          repair_bid_settlement_selected_lot_ids: ['compacted-repair-lot:summary'],
+        }),
+      ),
+    ) as unknown as typeof globalThis.fetch
+
+    const result = await resolveTorghutConsumerEvidence(new Date('2026-05-15T00:30:10.000Z'))
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1)
+    expect(result.status).toMatchObject({
+      status: 'current',
+      observed_contracts: expect.arrayContaining(['route_warrant_exchange', 'repair_bid_settlement_ledger']),
+      contract_schema_mismatches: [],
+      route_warrant_id: 'route-warrant-exchange:summary',
+      route_warrant_state: 'repair_only',
+      repair_bid_settlement_ledger_id: 'repair-bid-settlement-ledger:summary',
+      repair_bid_settlement_status: 'current',
+      repair_bid_settlement_selected_lot_ids: ['compacted-repair-lot:summary'],
+      max_notional: '0',
+    })
+  })
+
+  it('marks contract transport unavailable when summary is current but bounded full fetch fails', async () => {
+    process.env = {
+      ...originalEnv,
+      JANGAR_TORGHUT_STATUS_URL: 'http://torghut.torghut.svc.cluster.local/trading/consumer-evidence',
+    }
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        buildJsonResponse({
+          schema_version: 'torghut.consumer-evidence-status.v1',
+          view: 'summary',
+          business_state: 'repair_only',
+          revenue_ready: false,
+          route_proven_profit_receipt: {
+            schema_version: 'torghut.route-proven-profit-receipt.v1',
+            receipt_id: 'torghut-route-proven-profit:summary-only',
+            generated_at: '2026-05-15T00:30:00.000Z',
+            fresh_until: '2026-05-15T00:31:00.000Z',
+            paper_readiness_state: 'blocked',
+            live_readiness_state: 'blocked',
+            max_notional: '0',
+            reason_codes: [],
+          },
+          alpha_readiness_strike_ledger: {
+            schema_version: 'torghut.alpha-readiness-strike-ledger.v1',
+            ledger_id: 'alpha-readiness-strike-ledger:summary-only',
+          },
+          executable_alpha_repair_receipts: {
+            schema_version: 'torghut.executable-alpha-repair-receipts.v1',
+            status: 'selected',
+            receipt_count: 0,
+            receipts: [],
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        buildJsonResponse({ error: 'full payload unavailable' }, 503),
+      ) as unknown as typeof globalThis.fetch
+
+    const result = await resolveTorghutConsumerEvidence(new Date('2026-05-15T00:30:10.000Z'))
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2)
+    expect(result.status).toMatchObject({
+      status: 'current',
+      receipt_id: 'torghut-route-proven-profit:summary-only',
+      route_warrant_id: null,
+      repair_bid_settlement_ledger_id: null,
+      reason_codes: ['torghut_contract_transport_unavailable'],
+    })
+    expect(result.status.observed_contracts).not.toContain('route_warrant_exchange')
+    expect(result.status.observed_contracts).not.toContain('repair_bid_settlement_ledger')
+  })
+
   it('hydrates executable alpha repair receipts from revenue-repair for material reentry', async () => {
     process.env = {
       ...originalEnv,
@@ -441,6 +585,28 @@ describe('control-plane Torghut consumer evidence', () => {
             live_readiness_state: 'blocked',
             max_notional: '0',
             reason_codes: [],
+          },
+          contract_canary_refs: {
+            schema_version: 'torghut.consumer-evidence-contract-canary.v1',
+            canary_id: 'consumer-evidence-contract-canary:repair',
+            observed_contracts: ['route_warrant_exchange', 'repair_bid_settlement_ledger'],
+            contract_schema_mismatches: [],
+            contract_refs: {
+              route_warrant_exchange: {
+                schema_version: 'torghut.route-warrant-exchange.v1',
+                ref: 'route-warrant-exchange:repair',
+                fresh_until: '2026-05-14T00:38:00.000Z',
+                state: 'current',
+                max_notional: '0',
+              },
+              repair_bid_settlement_ledger: {
+                schema_version: 'torghut.repair-bid-settlement-ledger.v1',
+                ref: 'repair-bid-settlement-ledger:repair',
+                fresh_until: '2026-05-14T00:38:00.000Z',
+                state: 'current',
+                max_notional: '0',
+              },
+            },
           },
         }),
       )
@@ -536,7 +702,7 @@ describe('control-plane Torghut consumer evidence', () => {
 
     const result = await resolveTorghutConsumerEvidence(new Date('2026-05-14T00:23:10.000Z'))
 
-    expect(globalThis.fetch).toHaveBeenCalledTimes(3)
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2)
     expect(result.status).toMatchObject({
       revenue_repair_business_state: 'repair_only',
       revenue_repair_ready: false,
@@ -1234,6 +1400,28 @@ describe('control-plane Torghut consumer evidence', () => {
             max_notional: '0',
             reason_codes: [],
           },
+          contract_canary_refs: {
+            schema_version: 'torghut.consumer-evidence-contract-canary.v1',
+            canary_id: 'consumer-evidence-contract-canary:settlement-conveyor-fallback',
+            observed_contracts: ['route_warrant_exchange', 'repair_bid_settlement_ledger'],
+            contract_schema_mismatches: [],
+            contract_refs: {
+              route_warrant_exchange: {
+                schema_version: 'torghut.route-warrant-exchange.v1',
+                ref: 'route-warrant-exchange:settlement-conveyor-fallback',
+                fresh_until: '2026-05-14T09:16:00.000Z',
+                state: 'current',
+                max_notional: '0',
+              },
+              repair_bid_settlement_ledger: {
+                schema_version: 'torghut.repair-bid-settlement-ledger.v1',
+                ref: 'repair-bid-settlement-ledger:settlement-conveyor-fallback',
+                fresh_until: '2026-05-14T09:16:00.000Z',
+                state: 'current',
+                max_notional: '0',
+              },
+            },
+          },
         }),
       )
       .mockResolvedValueOnce(
@@ -1292,14 +1480,11 @@ describe('control-plane Torghut consumer evidence', () => {
 
     const result = await resolveTorghutConsumerEvidence(new Date('2026-05-14T09:15:10.000Z'))
 
-    expect(fetchMock).toHaveBeenCalledTimes(3)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
     expect(String(fetchMock.mock.calls[0]?.[0])).toBe(
       'http://torghut.torghut.svc.cluster.local/trading/consumer-evidence?view=summary',
     )
     expect(String(fetchMock.mock.calls[1]?.[0])).toBe('http://torghut.torghut.svc.cluster.local/trading/revenue-repair')
-    expect(String(fetchMock.mock.calls[2]?.[0])).toBe(
-      'http://torghut.torghut.svc.cluster.local/trading/consumer-evidence',
-    )
     expect(result.status.observed_contracts).toEqual(expect.arrayContaining(['alpha_readiness_settlement_conveyor']))
     expect(result.status.contract_schema_mismatches).not.toEqual(
       expect.arrayContaining(['alpha_readiness_settlement_conveyor:torghut.alpha-readiness-settlement-conveyor.v1']),

--- a/services/jangar/src/server/control-plane-source-serving-contract-verdict.ts
+++ b/services/jangar/src/server/control-plane-source-serving-contract-verdict.ts
@@ -19,6 +19,7 @@ const PRODUCER_REVISION = '2026-05-13-source-serving-contract-verdict-observe-v1
 const VERDICT_SCHEMA_VERSION = 'jangar.source-serving-contract-verdict.v1' as const
 const DEFAULT_REPOSITORY = 'proompteng/lab'
 const DEFAULT_REQUIRED_CONTRACTS = ['route_warrant_exchange', 'repair_bid_settlement_ledger']
+const TORGHUT_CONTRACT_TRANSPORT_UNAVAILABLE_REASON = 'torghut_contract_transport_unavailable'
 
 const ACTION_CLASSES: SourceServingContractActionClass[] = [
   'serve_readonly',
@@ -171,8 +172,17 @@ const resolveSourceServingSummary = (input: SourceServingContractVerdictInput): 
     evidence.requiredContracts && evidence.requiredContracts.length > 0
       ? evidence.requiredContracts
       : DEFAULT_REQUIRED_CONTRACTS
-  const observedContracts = compactStrings(torghut.observed_contracts ?? [])
-  const missingContracts = requiredContracts.filter((contract) => !observedContracts.includes(contract))
+  const observedContracts = compactStrings([
+    ...(torghut.observed_contracts ?? []),
+    torghut.route_warrant_id ? 'route_warrant_exchange' : null,
+    torghut.repair_bid_settlement_ledger_id ? 'repair_bid_settlement_ledger' : null,
+  ])
+  const contractTransportUnavailable = Boolean(
+    torghut.reason_codes?.includes(TORGHUT_CONTRACT_TRANSPORT_UNAVAILABLE_REASON),
+  )
+  const missingContracts = contractTransportUnavailable
+    ? []
+    : requiredContracts.filter((contract) => !observedContracts.includes(contract))
   const contractSchemaMismatches = compactStrings(torghut.contract_schema_mismatches ?? [])
   const manifestImageDigest = normalizeNonEmpty(evidence.manifestImageDigest)
   const servingImageDigest =
@@ -193,8 +203,9 @@ const resolveSourceServingSummary = (input: SourceServingContractVerdictInput): 
   const routeRef = routeWarrantRef(torghut)
   const repairBidRef = normalizeNonEmpty(torghut.repair_bid_settlement_ledger_id)
   const ciPassed = sourceCiPassed(sourceCiConclusion)
-  const state: SourceServingContractState =
-    missingContracts.length > 0 || contractSchemaMismatches.length > 0
+  const state: SourceServingContractState = contractTransportUnavailable
+    ? 'unknown'
+    : missingContracts.length > 0 || contractSchemaMismatches.length > 0
       ? 'contract_missing'
       : sourceRevisionMissing || servingBuildMissing
         ? 'unknown'
@@ -215,10 +226,11 @@ const resolveSourceServingSummary = (input: SourceServingContractVerdictInput): 
     ...(servingDigestMissing ? ['serving_image_digest_missing'] : []),
     ...(manifestServingDigestMismatch ? ['manifest_serving_image_digest_mismatch'] : []),
     ...(argoHealthy ? [] : [`argo_health_${input.rolloutHealth.status}`]),
+    ...(contractTransportUnavailable ? [TORGHUT_CONTRACT_TRANSPORT_UNAVAILABLE_REASON] : []),
     ...missingContracts.map((contract) => `source_serving_contract_missing:${contract}`),
     ...contractSchemaMismatches.map((contract) => `source_serving_contract_schema_mismatch:${contract}`),
-    ...(routeRef ? [] : ['torghut_route_warrant_missing']),
-    ...(repairBidRef ? [] : ['repair_bid_settlement_ledger_missing']),
+    ...(routeRef || contractTransportUnavailable ? [] : ['torghut_route_warrant_missing']),
+    ...(repairBidRef || contractTransportUnavailable ? [] : ['repair_bid_settlement_ledger_missing']),
   ])
 
   return {
@@ -315,6 +327,9 @@ const requiredRepairReceipts = (summary: SourceServingSummary) =>
       : []),
     ...(summary.manifestDigestMissing || summary.servingDigestMissing || summary.manifestServingDigestMismatch
       ? ['source-serving-image-digest-reconcile-receipt']
+      : []),
+    ...(summary.reasonCodes.includes(TORGHUT_CONTRACT_TRANSPORT_UNAVAILABLE_REASON)
+      ? ['torghut-contract-transport-canary']
       : []),
     ...summary.missingContracts.map((contract) => `source-serving-contract-canary:${contract}`),
     ...summary.contractSchemaMismatches.map((contract) => `source-serving-contract-schema-repair:${contract}`),

--- a/services/jangar/src/server/control-plane-torghut-consumer-evidence-contracts.ts
+++ b/services/jangar/src/server/control-plane-torghut-consumer-evidence-contracts.ts
@@ -1,0 +1,85 @@
+import type { TorghutNegativeEvidenceInput } from '~/server/control-plane-negative-evidence-router-torghut'
+import { normalizeNonEmpty, stringValues, uniqueStrings } from '~/server/control-plane-torghut-evidence-normalizers'
+import { asRecord } from '~/server/primitives-http'
+
+export const CONSUMER_EVIDENCE_CONTRACT_CANARY_SCHEMA_VERSION = 'torghut.consumer-evidence-contract-canary.v1'
+export const ROUTE_WARRANT_EXCHANGE_SCHEMA_VERSION = 'torghut.route-warrant-exchange.v1'
+export const REPAIR_BID_SETTLEMENT_LEDGER_SCHEMA_VERSION = 'torghut.repair-bid-settlement-ledger.v1'
+export const CONTRACT_TRANSPORT_UNAVAILABLE_REASON = 'torghut_contract_transport_unavailable'
+
+const SOURCE_SERVING_CONTRACTS = ['route_warrant_exchange', 'repair_bid_settlement_ledger']
+
+export const hasRouteWarrantPayload = (payload: Record<string, unknown> | null | undefined) =>
+  Boolean(
+    payload && asRecord(payload.route_warrant_exchange ?? payload.route_warrant_exchange_v1 ?? payload.route_warrant),
+  )
+
+export const readContractCanary = (payload: Record<string, unknown> | null) => {
+  const canary = asRecord(payload?.contract_canary_refs ?? payload?.consumer_evidence_contract_canary)
+  const schema = normalizeNonEmpty(canary?.schema_version)
+  if (schema && schema !== CONSUMER_EVIDENCE_CONTRACT_CANARY_SCHEMA_VERSION) {
+    return canary
+  }
+  return canary
+}
+
+export const contractRef = (payload: Record<string, unknown> | null, contractName: string) => {
+  const canary = readContractCanary(payload)
+  return asRecord(asRecord(canary?.contract_refs)?.[contractName])
+}
+
+export const payloadHasSourceServingContractRefs = (payload: Record<string, unknown> | null) => {
+  const canary = readContractCanary(payload)
+  const observedContracts = uniqueStrings([
+    ...stringValues(payload?.observed_contracts),
+    ...stringValues(canary?.observed_contracts),
+  ])
+  const routeWarrant = asRecord(
+    payload?.route_warrant_exchange ?? payload?.route_warrant_exchange_v1 ?? payload?.route_warrant,
+  )
+  const repairBidSettlement = asRecord(payload?.repair_bid_settlement_ledger)
+  const routeWarrantRef = normalizeNonEmpty(
+    payload?.route_warrant_id ??
+      routeWarrant?.warrant_id ??
+      routeWarrant?.exchange_id ??
+      contractRef(payload, 'route_warrant_exchange')?.ref,
+  )
+  const repairBidRef = normalizeNonEmpty(
+    payload?.repair_bid_settlement_ledger_id ??
+      repairBidSettlement?.ledger_id ??
+      contractRef(payload, 'repair_bid_settlement_ledger')?.ref,
+  )
+  return (
+    SOURCE_SERVING_CONTRACTS.every((contract) => observedContracts.includes(contract)) ||
+    Boolean(routeWarrantRef && repairBidRef)
+  )
+}
+
+export const readMarketContext = (
+  payload: Record<string, unknown>,
+): Pick<TorghutNegativeEvidenceInput, 'market_context_status' | 'market_context_stale_domains'> => {
+  const marketContext = asRecord(payload.market_context)
+  const health = asRecord(marketContext?.health)
+  const status = normalizeNonEmpty(health?.status ?? marketContext?.status ?? marketContext?.last_reason)
+  const domains = asRecord(marketContext?.last_domain_states)
+  const staleDomains =
+    domains && typeof domains === 'object'
+      ? Object.entries(domains)
+          .filter(([, value]) => {
+            const domain = asRecord(value)
+            return normalizeNonEmpty(domain?.status) === 'stale' || domain?.stale === true
+          })
+          .map(([key]) => key)
+      : []
+
+  if (status === 'ok' || status === 'healthy') {
+    return { market_context_status: 'healthy', market_context_stale_domains: staleDomains }
+  }
+  if (status === 'stale') {
+    return { market_context_status: 'stale', market_context_stale_domains: staleDomains }
+  }
+  if (status === 'degraded') {
+    return { market_context_status: 'degraded', market_context_stale_domains: staleDomains }
+  }
+  return { market_context_status: undefined, market_context_stale_domains: staleDomains }
+}

--- a/services/jangar/src/server/control-plane-torghut-consumer-evidence-transport.ts
+++ b/services/jangar/src/server/control-plane-torghut-consumer-evidence-transport.ts
@@ -1,0 +1,40 @@
+type JsonRouteResult = {
+  ok: boolean
+  statusCode: number | null
+  payload: Record<string, unknown> | null
+}
+
+export const requestJson = async (url: string, timeoutMs: number): Promise<JsonRouteResult> => {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: { accept: 'application/json' },
+      signal: controller.signal,
+    })
+    const payload = (await response.json().catch(() => null)) as unknown
+    if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+      return { ok: response.ok, statusCode: response.status, payload: null }
+    }
+    return { ok: response.ok, statusCode: response.status, payload: payload as Record<string, unknown> }
+  } catch {
+    return { ok: false, statusCode: null, payload: null }
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+export const compactConsumerEvidenceEndpoint = (endpoint: string): string => {
+  try {
+    const url = new URL(endpoint)
+    const path = url.pathname.replace(/\/+$/, '')
+    if (path.endsWith('/trading/consumer-evidence') && !url.searchParams.has('view')) {
+      url.searchParams.set('view', 'summary')
+      return url.toString()
+    }
+  } catch {
+    return endpoint
+  }
+  return endpoint
+}

--- a/services/jangar/src/server/control-plane-torghut-consumer-evidence.ts
+++ b/services/jangar/src/server/control-plane-torghut-consumer-evidence.ts
@@ -40,6 +40,20 @@ import {
 } from '~/server/control-plane-torghut-revenue-repair'
 import type { TorghutNegativeEvidenceInput } from '~/server/control-plane-negative-evidence-router-torghut'
 import {
+  CONTRACT_TRANSPORT_UNAVAILABLE_REASON,
+  REPAIR_BID_SETTLEMENT_LEDGER_SCHEMA_VERSION,
+  ROUTE_WARRANT_EXCHANGE_SCHEMA_VERSION,
+  contractRef,
+  hasRouteWarrantPayload,
+  payloadHasSourceServingContractRefs,
+  readContractCanary,
+  readMarketContext,
+} from '~/server/control-plane-torghut-consumer-evidence-contracts'
+import {
+  compactConsumerEvidenceEndpoint,
+  requestJson,
+} from '~/server/control-plane-torghut-consumer-evidence-transport'
+import {
   normalizeNonEmpty,
   normalizeNumber,
   normalizeReason,
@@ -67,83 +81,6 @@ const paperActionStates = new Set(['allow', 'allowed', 'current', 'paper_canary'
 const CONSUMER_EVIDENCE_STATUS_SCHEMA_VERSION = 'torghut.consumer-evidence-status.v1'
 const CONSUMER_EVIDENCE_RECEIPT_SCHEMA_VERSION = 'torghut.consumer-evidence-receipt.v1'
 const ROUTE_PROVEN_PROFIT_RECEIPT_SCHEMA_VERSION = 'torghut.route-proven-profit-receipt.v1'
-const ROUTE_WARRANT_EXCHANGE_SCHEMA_VERSION = 'torghut.route-warrant-exchange.v1'
-const REPAIR_BID_SETTLEMENT_LEDGER_SCHEMA_VERSION = 'torghut.repair-bid-settlement-ledger.v1'
-
-type JsonRouteResult = {
-  ok: boolean
-  statusCode: number | null
-  payload: Record<string, unknown> | null
-}
-
-const requestJson = async (url: string, timeoutMs: number): Promise<JsonRouteResult> => {
-  const controller = new AbortController()
-  const timeout = setTimeout(() => controller.abort(), timeoutMs)
-  try {
-    const response = await fetch(url, {
-      method: 'GET',
-      headers: { accept: 'application/json' },
-      signal: controller.signal,
-    })
-    const payload = (await response.json().catch(() => null)) as unknown
-    if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
-      return { ok: response.ok, statusCode: response.status, payload: null }
-    }
-    return { ok: response.ok, statusCode: response.status, payload: payload as Record<string, unknown> }
-  } catch {
-    return { ok: false, statusCode: null, payload: null }
-  } finally {
-    clearTimeout(timeout)
-  }
-}
-
-const hasRouteWarrantPayload = (payload: Record<string, unknown> | null | undefined) =>
-  Boolean(
-    payload && asRecord(payload.route_warrant_exchange ?? payload.route_warrant_exchange_v1 ?? payload.route_warrant),
-  )
-
-const compactConsumerEvidenceEndpoint = (endpoint: string): string => {
-  try {
-    const url = new URL(endpoint)
-    const path = url.pathname.replace(/\/+$/, '')
-    if (path.endsWith('/trading/consumer-evidence') && !url.searchParams.has('view')) {
-      url.searchParams.set('view', 'summary')
-      return url.toString()
-    }
-  } catch {
-    return endpoint
-  }
-  return endpoint
-}
-
-const readMarketContext = (
-  payload: Record<string, unknown>,
-): Pick<TorghutNegativeEvidenceInput, 'market_context_status' | 'market_context_stale_domains'> => {
-  const marketContext = asRecord(payload.market_context)
-  const health = asRecord(marketContext?.health)
-  const status = normalizeNonEmpty(health?.status ?? marketContext?.status ?? marketContext?.last_reason)
-  const domains = asRecord(marketContext?.last_domain_states)
-  const staleDomains =
-    domains && typeof domains === 'object'
-      ? Object.entries(domains)
-          .filter(([, value]) => {
-            const domain = asRecord(value)
-            return normalizeNonEmpty(domain?.status) === 'stale' || domain?.stale === true
-          })
-          .map(([key]) => key)
-      : []
-
-  if (status === 'ok' || status === 'healthy') {
-    return { market_context_status: 'healthy', market_context_stale_domains: staleDomains }
-  }
-  if (status === 'stale') {
-    return { market_context_status: 'stale', market_context_stale_domains: staleDomains }
-  }
-  if (status === 'degraded') {
-    return { market_context_status: 'degraded', market_context_stale_domains: staleDomains }
-  }
-  return { market_context_status: undefined, market_context_stale_domains: staleDomains }
-}
 
 export const resolveTorghutConsumerEvidence = async (now = new Date()): Promise<TorghutConsumerEvidenceResolution> => {
   const config = resolveControlPlaneStatusConfig(process.env)
@@ -165,8 +102,8 @@ export const resolveTorghutConsumerEvidence = async (now = new Date()): Promise<
     }
   }
 
-  const compactEndpoint = compactConsumerEvidenceEndpoint(endpoint)
-  const routeResult = await requestJson(compactEndpoint, config.torghutStatusTimeoutMs)
+  const summaryEndpoint = compactConsumerEvidenceEndpoint(endpoint)
+  const routeResult = await requestJson(summaryEndpoint, config.torghutStatusTimeoutMs)
   if (!routeResult.ok) {
     const routeMissing = routeResult.statusCode === 404
     const status = routeMissing ? 'route_missing' : 'unavailable'
@@ -216,11 +153,19 @@ export const resolveTorghutConsumerEvidence = async (now = new Date()): Promise<
   const revenueRepairBusinessState = normalizeReason(revenueRepairPayload?.business_state)
   const revenueRepairReady = normalizeRevenueRepairBoolean(revenueRepairPayload?.revenue_ready)
   const revenueRepairQueue = readRevenueRepairQueue(revenueRepairPayload)
-  const fullConsumerEvidenceResult =
-    compactEndpoint !== endpoint && !hasRouteWarrantPayload(payload) && !hasRouteWarrantPayload(revenueRepairPayload)
-      ? await requestJson(endpoint, config.torghutStatusTimeoutMs)
-      : null
-  const sourceServingContractPayload =
+  const shouldFetchFullConsumerEvidence =
+    summaryEndpoint !== endpoint &&
+    !payloadHasSourceServingContractRefs(payload) &&
+    !hasRouteWarrantPayload(payload) &&
+    !hasRouteWarrantPayload(revenueRepairPayload)
+  const fullConsumerEvidenceResult = shouldFetchFullConsumerEvidence
+    ? await requestJson(endpoint, config.torghutStatusTimeoutMs)
+    : null
+  const contractTransportReasonCodes =
+    shouldFetchFullConsumerEvidence && (!fullConsumerEvidenceResult?.ok || !fullConsumerEvidenceResult.payload)
+      ? [CONTRACT_TRANSPORT_UNAVAILABLE_REASON]
+      : []
+  const contractPayload =
     fullConsumerEvidenceResult?.ok && fullConsumerEvidenceResult.payload ? fullConsumerEvidenceResult.payload : payload
   const alphaRepairClosureBoard =
     readAlphaRepairClosureBoard(payload) ?? readAlphaRepairClosureBoard(revenueRepairPayload)
@@ -469,26 +414,40 @@ export const resolveTorghutConsumerEvidence = async (now = new Date()): Promise<
     parseNumber(normalizeNonEmpty(routeableExchangeSummary?.rejected_candidate_count)) ?? rejectedCandidates.length
   const topClockSplit = evidenceClockSplits[0]
   const selectedEvidenceClockRepair = zeroNotionalRepairLots[0]
+  const contractCanary = readContractCanary(payload) ?? readContractCanary(contractPayload)
+  const routeWarrantCanaryRef =
+    contractRef(payload, 'route_warrant_exchange') ?? contractRef(contractPayload, 'route_warrant_exchange')
+  const repairBidCanaryRef =
+    contractRef(payload, 'repair_bid_settlement_ledger') ?? contractRef(contractPayload, 'repair_bid_settlement_ledger')
   const routeWarrant = asRecord(
-    sourceServingContractPayload.route_warrant_exchange ??
-      sourceServingContractPayload.route_warrant_exchange_v1 ??
-      sourceServingContractPayload.route_warrant ??
+    contractPayload.route_warrant_exchange ??
+      contractPayload.route_warrant_exchange_v1 ??
+      contractPayload.route_warrant ??
       payload.route_warrant_exchange ??
       payload.route_warrant_exchange_v1 ??
       payload.route_warrant,
   )
   const repairBidSettlement =
-    asRecord(sourceServingContractPayload.repair_bid_settlement_ledger) ??
+    asRecord(contractPayload.repair_bid_settlement_ledger) ??
     asRecord(payload.repair_bid_settlement_ledger) ??
     asRecord(revenueRepairPayload?.repair_bid_settlement_ledger)
-  const repairOutcome = readTorghutRepairOutcomeEvidence(payload)
+  const repairOutcome = readTorghutRepairOutcomeEvidence(contractPayload)
   const sourceServingRepairReceiptLedger =
-    asRecord(sourceServingContractPayload.source_serving_repair_receipt_ledger) ??
+    asRecord(contractPayload.source_serving_repair_receipt_ledger) ??
     asRecord(payload.source_serving_repair_receipt_ledger) ??
     asRecord(revenueRepairPayload?.source_serving_repair_receipt_ledger)
-  const freshnessCarry = readTorghutFreshnessCarryEvidence(payload)
-  const reasonCodes = uniqueStrings([...receiptReasonCodes, ...freshnessCarry.reasonCodes])
+  const freshnessCarry = readTorghutFreshnessCarryEvidence(contractPayload)
+  const reasonCodes = uniqueStrings([
+    ...receiptReasonCodes,
+    ...contractTransportReasonCodes,
+    ...freshnessCarry.reasonCodes,
+  ])
   const observedContracts = uniqueStrings([
+    ...stringValues(payload.observed_contracts),
+    ...stringValues(contractPayload.observed_contracts),
+    ...stringValues(contractCanary?.observed_contracts),
+    routeWarrantCanaryRef ? 'route_warrant_exchange' : null,
+    repairBidCanaryRef ? 'repair_bid_settlement_ledger' : null,
     routeWarrant ? 'route_warrant_exchange' : null,
     repairBidSettlement ? 'repair_bid_settlement_ledger' : null,
     repairOutcome.present ? 'repair_outcome_dividend_ledger' : null,
@@ -507,6 +466,9 @@ export const resolveTorghutConsumerEvidence = async (now = new Date()): Promise<
     noDeltaRepairReentryAuction ? 'no_delta_repair_reentry_auction' : null,
   ])
   const contractSchemaMismatches = uniqueStrings([
+    ...stringValues(payload.contract_schema_mismatches),
+    ...stringValues(contractPayload.contract_schema_mismatches),
+    ...stringValues(contractCanary?.contract_schema_mismatches),
     routeWarrant &&
     normalizeNonEmpty(routeWarrant.schema_version) &&
     normalizeNonEmpty(routeWarrant.schema_version) !== ROUTE_WARRANT_EXCHANGE_SCHEMA_VERSION
@@ -524,7 +486,9 @@ export const resolveTorghutConsumerEvidence = async (now = new Date()): Promise<
     alphaClosureDividendSloSchemaMismatch(payload),
     noDeltaRepairReentryAuctionRefSchemaMismatch(payload),
   ])
-  const routeWarrantId = normalizeNonEmpty(routeWarrant?.warrant_id ?? routeWarrant?.exchange_id)
+  const routeWarrantId = normalizeNonEmpty(
+    routeWarrant?.warrant_id ?? routeWarrant?.exchange_id ?? payload.route_warrant_id ?? routeWarrantCanaryRef?.ref,
+  )
   const routeWarrantRepairPackets = Array.isArray(routeWarrant?.repair_packets)
     ? routeWarrant.repair_packets
         .map((packet) => asRecord(packet))
@@ -551,14 +515,17 @@ export const resolveTorghutConsumerEvidence = async (now = new Date()): Promise<
     )
     return Boolean(state && !['accepted', 'current', 'fresh', 'healthy', 'ok', 'pass', 'ready'].includes(state))
   })
-  const routeWarrantRepairPacketIds = uniqueStrings(
-    routeWarrantRepairPackets.map((packet) => normalizeNonEmpty(packet.packet_id ?? packet.repair_packet_id)),
-  )
-  const routeWarrantRepairTargetValueGates = uniqueStrings(
-    routeWarrantRepairPackets.map((packet) => normalizeReason(packet.target_value_gate)),
-  )
+  const routeWarrantRepairPacketIds = uniqueStrings([
+    ...routeWarrantRepairPackets.map((packet) => normalizeNonEmpty(packet.packet_id ?? packet.repair_packet_id)),
+    ...stringValues(payload.route_warrant_repair_packet_ids),
+  ])
+  const routeWarrantRepairTargetValueGates = uniqueStrings([
+    ...routeWarrantRepairPackets.map((packet) => normalizeReason(packet.target_value_gate)),
+    ...stringValues(payload.route_warrant_repair_target_value_gates),
+  ])
   const routeWarrantBlockingDependencies = uniqueStrings([
     ...stringList(routeWarrant?.blocking_dependency_names),
+    ...stringValues(payload.route_warrant_blocking_dependency_names),
     ...routeWarrantRepairPackets.map((packet) => normalizeReason(packet.target_dependency)),
     ...staleWitnesses.map((witness) =>
       normalizeReason(
@@ -568,6 +535,7 @@ export const resolveTorghutConsumerEvidence = async (now = new Date()): Promise<
   ])
   const routeWarrantBlockingReasonCodes = uniqueStrings([
     ...stringList(routeWarrant?.blocking_reason_codes),
+    ...stringValues(payload.route_warrant_blocking_reason_codes),
     ...routeWarrantRepairPackets.flatMap((packet) => stringList(packet.blocking_reason_codes)),
     ...staleWitnesses.flatMap((witness) => [
       ...stringList(witness.reason_codes),
@@ -575,16 +543,29 @@ export const resolveTorghutConsumerEvidence = async (now = new Date()): Promise<
     ]),
   ])
   const repairBidSettlementSchema = normalizeNonEmpty(repairBidSettlement?.schema_version)
-  const repairBidSettlementLedgerId = normalizeNonEmpty(repairBidSettlement?.ledger_id)
-  const repairBidSettlementFreshUntil = normalizeNonEmpty(repairBidSettlement?.fresh_until)
+  const repairBidSettlementLedgerId = normalizeNonEmpty(
+    repairBidSettlement?.ledger_id ?? payload.repair_bid_settlement_ledger_id ?? repairBidCanaryRef?.ref,
+  )
+  const repairBidSettlementFreshUntil = normalizeNonEmpty(
+    repairBidSettlement?.fresh_until ?? payload.repair_bid_settlement_fresh_until ?? repairBidCanaryRef?.fresh_until,
+  )
   const repairBidSettlementFreshUntilMs = parseTimestampMs(repairBidSettlementFreshUntil)
   const repairBidSettlementLots = Array.isArray(repairBidSettlement?.compacted_lots)
     ? repairBidSettlement.compacted_lots
         .map((lot) => normalizeRepairBidSettlementLot(lot))
         .filter((lot): lot is TorghutRepairBidSettlementLot => Boolean(lot))
     : []
+  const flatRepairBidSettlementStatus = normalizeReason(
+    payload.repair_bid_settlement_status ?? repairBidCanaryRef?.state,
+  )
   const repairBidSettlementStatus: TorghutRepairBidSettlementStatus = !repairBidSettlement
-    ? 'missing'
+    ? flatRepairBidSettlementStatus === 'current' ||
+      flatRepairBidSettlementStatus === 'stale' ||
+      flatRepairBidSettlementStatus === 'missing' ||
+      flatRepairBidSettlementStatus === 'schema_mismatch' ||
+      flatRepairBidSettlementStatus === 'malformed'
+      ? flatRepairBidSettlementStatus
+      : 'missing'
     : repairBidSettlementSchema !== REPAIR_BID_SETTLEMENT_LEDGER_SCHEMA_VERSION
       ? 'schema_mismatch'
       : !repairBidSettlementLedgerId || !repairBidSettlementFreshUntil
@@ -656,30 +637,61 @@ export const resolveTorghutConsumerEvidence = async (now = new Date()): Promise<
       routeable_exchange_rejected_candidate_count: routeableExchangeRejectedCandidateCount,
       route_warrant_id: routeWarrantId,
       route_warrant_state: normalizeReason(
-        routeWarrant?.warrant_state ?? routeWarrant?.state ?? routeWarrant?.decision,
+        routeWarrant?.warrant_state ??
+          routeWarrant?.state ??
+          routeWarrant?.decision ??
+          payload.route_warrant_state ??
+          routeWarrantCanaryRef?.state,
       ),
-      route_warrant_fresh_until: normalizeNonEmpty(routeWarrant?.fresh_until),
+      route_warrant_fresh_until: normalizeNonEmpty(
+        routeWarrant?.fresh_until ?? payload.route_warrant_fresh_until ?? routeWarrantCanaryRef?.fresh_until,
+      ),
       route_warrant_repair_packet_ids: routeWarrantRepairPacketIds,
       route_warrant_repair_target_value_gates: routeWarrantRepairTargetValueGates,
       route_warrant_blocking_dependency_names: routeWarrantBlockingDependencies,
       route_warrant_blocking_reason_codes: routeWarrantBlockingReasonCodes,
       route_warrant_zero_notional_or_stale_evidence_rate: normalizeNumber(
-        routeWarrant?.zero_notional_or_stale_evidence_rate,
+        routeWarrant?.zero_notional_or_stale_evidence_rate ??
+          payload.route_warrant_zero_notional_or_stale_evidence_rate,
       ),
-      route_warrant_fill_tca_or_slippage_quality: normalizeReason(routeWarrant?.fill_tca_or_slippage_quality),
-      route_warrant_capital_gate_safety: normalizeReason(routeWarrant?.capital_gate_safety),
-      route_warrant_post_cost_daily_net_pnl_state: normalizeReason(routeWarrant?.post_cost_daily_net_pnl_state),
+      route_warrant_fill_tca_or_slippage_quality: normalizeReason(
+        routeWarrant?.fill_tca_or_slippage_quality ?? payload.route_warrant_fill_tca_or_slippage_quality,
+      ),
+      route_warrant_capital_gate_safety: normalizeReason(
+        routeWarrant?.capital_gate_safety ?? payload.route_warrant_capital_gate_safety,
+      ),
+      route_warrant_post_cost_daily_net_pnl_state: normalizeReason(
+        routeWarrant?.post_cost_daily_net_pnl_state ?? payload.route_warrant_post_cost_daily_net_pnl_state,
+      ),
       repair_bid_settlement_ledger_id: repairBidSettlementLedgerId,
       repair_bid_settlement_status: repairBidSettlementStatus,
-      repair_bid_settlement_generated_at: normalizeNonEmpty(repairBidSettlement?.generated_at),
+      repair_bid_settlement_generated_at: normalizeNonEmpty(
+        repairBidSettlement?.generated_at ?? payload.repair_bid_settlement_generated_at,
+      ),
       repair_bid_settlement_fresh_until: repairBidSettlementFreshUntil,
-      repair_bid_settlement_capital_decision: normalizeReason(repairBidSettlement?.capital_decision),
-      repair_bid_settlement_max_notional: normalizeNonEmpty(repairBidSettlement?.max_notional),
-      repair_bid_settlement_routeable_candidate_count: normalizeNumber(repairBidSettlement?.routeable_candidate_count),
-      repair_bid_settlement_selected_lot_ids: stringValues(repairBidSettlement?.selected_lot_ids),
-      repair_bid_settlement_dispatchable_lot_ids: stringValues(repairBidSettlement?.dispatchable_lot_ids),
-      repair_bid_settlement_held_lot_ids: stringValues(repairBidSettlement?.held_lot_ids),
-      repair_bid_settlement_active_dedupe_keys: stringValues(repairBidSettlement?.active_dedupe_keys),
+      repair_bid_settlement_capital_decision: normalizeReason(
+        repairBidSettlement?.capital_decision ?? payload.repair_bid_settlement_capital_decision,
+      ),
+      repair_bid_settlement_max_notional: normalizeNonEmpty(
+        repairBidSettlement?.max_notional ??
+          payload.repair_bid_settlement_max_notional ??
+          repairBidCanaryRef?.max_notional,
+      ),
+      repair_bid_settlement_routeable_candidate_count: normalizeNumber(
+        repairBidSettlement?.routeable_candidate_count ?? payload.repair_bid_settlement_routeable_candidate_count,
+      ),
+      repair_bid_settlement_selected_lot_ids: stringValues(
+        repairBidSettlement?.selected_lot_ids ?? payload.repair_bid_settlement_selected_lot_ids,
+      ),
+      repair_bid_settlement_dispatchable_lot_ids: stringValues(
+        repairBidSettlement?.dispatchable_lot_ids ?? payload.repair_bid_settlement_dispatchable_lot_ids,
+      ),
+      repair_bid_settlement_held_lot_ids: stringValues(
+        repairBidSettlement?.held_lot_ids ?? payload.repair_bid_settlement_held_lot_ids,
+      ),
+      repair_bid_settlement_active_dedupe_keys: stringValues(
+        repairBidSettlement?.active_dedupe_keys ?? payload.repair_bid_settlement_active_dedupe_keys,
+      ),
       repair_bid_settlement_compacted_lots: repairBidSettlementLots,
       repair_bid_settlement_reason_codes: repairBidSettlementReasonCodes,
       alpha_readiness_strike_ledger: alphaReadinessStrikeLedger,
@@ -754,16 +766,26 @@ export const resolveTorghutConsumerEvidence = async (now = new Date()): Promise<
       routeable_exchange_rejected_candidate_count: routeableExchangeRejectedCandidateCount,
       route_warrant_id: routeWarrantId,
       route_warrant_state: normalizeReason(
-        routeWarrant?.warrant_state ?? routeWarrant?.state ?? routeWarrant?.decision,
+        routeWarrant?.warrant_state ??
+          routeWarrant?.state ??
+          routeWarrant?.decision ??
+          payload.route_warrant_state ??
+          routeWarrantCanaryRef?.state,
       ),
       route_warrant_repair_packet_ids: routeWarrantRepairPacketIds,
       route_warrant_blocking_dependency_names: routeWarrantBlockingDependencies,
       route_warrant_blocking_reason_codes: routeWarrantBlockingReasonCodes,
       repair_bid_settlement_ledger_id: repairBidSettlementLedgerId,
       repair_bid_settlement_status: repairBidSettlementStatus,
-      repair_bid_settlement_selected_lot_ids: stringValues(repairBidSettlement?.selected_lot_ids),
-      repair_bid_settlement_dispatchable_lot_ids: stringValues(repairBidSettlement?.dispatchable_lot_ids),
-      repair_bid_settlement_held_lot_ids: stringValues(repairBidSettlement?.held_lot_ids),
+      repair_bid_settlement_selected_lot_ids: stringValues(
+        repairBidSettlement?.selected_lot_ids ?? payload.repair_bid_settlement_selected_lot_ids,
+      ),
+      repair_bid_settlement_dispatchable_lot_ids: stringValues(
+        repairBidSettlement?.dispatchable_lot_ids ?? payload.repair_bid_settlement_dispatchable_lot_ids,
+      ),
+      repair_bid_settlement_held_lot_ids: stringValues(
+        repairBidSettlement?.held_lot_ids ?? payload.repair_bid_settlement_held_lot_ids,
+      ),
       repair_bid_settlement_blocking_reason_codes: repairBidSettlementReasonCodes,
     },
   }

--- a/services/torghut/README.md
+++ b/services/torghut/README.md
@@ -263,6 +263,12 @@ Testing rules for the trading core:
   consumer-evidence expansion explicitly omitted, so the route can mirror current Jangar carry without recursively
   calling itself through Jangar.
   A `jangar_verify_carry` ticket is selectable only for `repairable` carry and always keeps `max_notional=0`.
+- `GET /trading/consumer-evidence?view=summary` also emits the May 15 doc 213
+  `torghut.consumer-evidence-contract-canary.v1` compact canary. It names the summary and full route refs, observed
+  `route_warrant_exchange` and `repair_bid_settlement_ledger` contracts, schema mismatches, ids, fresh-until values,
+  current/stale/missing/schema states, and `max_notional=0`. The full `/trading/consumer-evidence` route remains the
+  authority for complete contract bodies; summary carries refs only so Jangar can avoid false source-serving
+  missing-contract holds without widening the hot readiness payload.
 - `GET /trading/status` and `GET /readyz` now include the May 8 doc 181
   `quality_adjusted_profit_frontier` shadow projection. The reducer ranks zero-notional repair packets from quant
   quality, market-context risk flags, route/TCA state, simulation-cache freshness, and Jangar evidence-quality refs

--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -66,6 +66,7 @@ from .trading.autoresearch_routes import router as autoresearch_router
 from .trading.capital_reentry_cohorts import build_capital_reentry_cohort_ledger
 from .trading.completion import build_doc29_completion_status
 from .trading.consumer_evidence import (
+    build_consumer_evidence_contract_canary,
     build_route_proven_profit_receipt,
     build_torghut_consumer_evidence_receipt,
 )
@@ -3100,6 +3101,129 @@ def _consumer_evidence_summary_view(view: str | None) -> bool:
     return (view or "").strip().lower() in {"compact", "summary", "jangar"}
 
 
+def _summary_mapping(value: object) -> Mapping[str, Any]:
+    return cast(Mapping[str, Any], value) if isinstance(value, Mapping) else {}
+
+
+def _summary_sequence(value: object) -> Sequence[object]:
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return cast(Sequence[object], value)
+    return ()
+
+
+def _summary_text(value: object, default: str | None = None) -> str | None:
+    if value is None:
+        return default
+    normalized = str(value).strip()
+    return normalized or default
+
+
+def _summary_strings(value: object) -> list[str]:
+    result: list[str] = []
+    seen: set[str] = set()
+    for item in _summary_sequence(value):
+        normalized = _summary_text(item)
+        if normalized and normalized not in seen:
+            result.append(normalized)
+            seen.add(normalized)
+    return result
+
+
+def _consumer_evidence_contract_summary_fields(
+    *,
+    contract_canary_refs: Mapping[str, Any],
+    route_warrant_exchange: Mapping[str, Any],
+    repair_bid_settlement_ledger: Mapping[str, Any],
+) -> dict[str, object]:
+    contract_refs = _summary_mapping(contract_canary_refs.get("contract_refs"))
+    route_warrant_ref = _summary_mapping(contract_refs.get("route_warrant_exchange"))
+    repair_bid_ref = _summary_mapping(contract_refs.get("repair_bid_settlement_ledger"))
+    repair_packets = [
+        _summary_mapping(packet)
+        for packet in _summary_sequence(route_warrant_exchange.get("repair_packets"))
+    ]
+
+    return {
+        "contract_canary_refs": contract_canary_refs,
+        "observed_contracts": _summary_strings(
+            contract_canary_refs.get("observed_contracts")
+        ),
+        "contract_schema_mismatches": _summary_strings(
+            contract_canary_refs.get("contract_schema_mismatches")
+        ),
+        "route_warrant_id": _summary_text(route_warrant_ref.get("ref")),
+        "route_warrant_fresh_until": _summary_text(
+            route_warrant_ref.get("fresh_until")
+        ),
+        "route_warrant_state": _summary_text(
+            route_warrant_exchange.get("warrant_state")
+            or route_warrant_exchange.get("state")
+            or route_warrant_ref.get("state")
+        ),
+        "route_warrant_repair_packet_ids": _summary_strings(
+            [packet.get("packet_id") for packet in repair_packets]
+        ),
+        "route_warrant_repair_target_value_gates": _summary_strings(
+            [packet.get("target_value_gate") for packet in repair_packets]
+        ),
+        "route_warrant_blocking_dependency_names": _summary_strings(
+            [
+                *[
+                    dependency
+                    for dependency in _summary_sequence(
+                        route_warrant_exchange.get("blocking_dependency_names")
+                    )
+                ],
+                *[packet.get("target_dependency") for packet in repair_packets],
+            ]
+        ),
+        "route_warrant_blocking_reason_codes": _summary_strings(
+            route_warrant_exchange.get("blocking_reason_codes")
+        ),
+        "route_warrant_zero_notional_or_stale_evidence_rate": route_warrant_exchange.get(
+            "zero_notional_or_stale_evidence_rate"
+        ),
+        "route_warrant_fill_tca_or_slippage_quality": route_warrant_exchange.get(
+            "fill_tca_or_slippage_quality"
+        ),
+        "route_warrant_capital_gate_safety": route_warrant_exchange.get(
+            "capital_gate_safety"
+        ),
+        "route_warrant_post_cost_daily_net_pnl_state": route_warrant_exchange.get(
+            "post_cost_daily_net_pnl_state"
+        ),
+        "repair_bid_settlement_ledger_id": _summary_text(repair_bid_ref.get("ref")),
+        "repair_bid_settlement_status": _summary_text(repair_bid_ref.get("state")),
+        "repair_bid_settlement_generated_at": _summary_text(
+            repair_bid_settlement_ledger.get("generated_at")
+        ),
+        "repair_bid_settlement_fresh_until": _summary_text(
+            repair_bid_ref.get("fresh_until")
+        ),
+        "repair_bid_settlement_capital_decision": _summary_text(
+            repair_bid_settlement_ledger.get("capital_decision")
+        ),
+        "repair_bid_settlement_max_notional": _summary_text(
+            repair_bid_settlement_ledger.get("max_notional"), "0"
+        ),
+        "repair_bid_settlement_routeable_candidate_count": repair_bid_settlement_ledger.get(
+            "routeable_candidate_count"
+        ),
+        "repair_bid_settlement_selected_lot_ids": _summary_strings(
+            repair_bid_settlement_ledger.get("selected_lot_ids")
+        ),
+        "repair_bid_settlement_dispatchable_lot_ids": _summary_strings(
+            repair_bid_settlement_ledger.get("dispatchable_lot_ids")
+        ),
+        "repair_bid_settlement_held_lot_ids": _summary_strings(
+            repair_bid_settlement_ledger.get("held_lot_ids")
+        ),
+        "repair_bid_settlement_active_dedupe_keys": _summary_strings(
+            repair_bid_settlement_ledger.get("active_dedupe_keys")
+        ),
+    }
+
+
 def _revenue_repair_topline_fields(
     revenue_repair_digest: Mapping[str, Any],
 ) -> dict[str, object]:
@@ -3213,29 +3337,6 @@ def _build_trading_consumer_evidence_payload(
         == CONSUMER_EVIDENCE_CONTROL_PLANE_DEPENDENCY_MESSAGE
         else "jangar_status_non_recursive"
     )
-    if summary:
-        return {
-            "schema_version": "torghut.consumer-evidence-status.v1",
-            "view": "summary",
-            "generated_at": datetime.now(timezone.utc).isoformat(),
-            "enabled": settings.trading_enabled,
-            "mode": settings.trading_mode,
-            "running": state.running,
-            "build": build_payload,
-            "control_plane_dependency_mode": control_plane_dependency_mode,
-            "dependency_quorum": dependency_quorum.as_payload(),
-            "forecast_service": forecast_service_status,
-            "lean_authority": lean_authority_status,
-            "empirical_jobs": empirical_jobs,
-            "market_context": market_context_status,
-            "quant_evidence": quant_evidence,
-            "live_submission_gate": live_submission_gate,
-            "proof_floor": proof_floor,
-            "simple_lane_status": simple_lane_status,
-            "torghut_consumer_evidence_receipt": consumer_evidence_receipt,
-            "route_proven_profit_receipt": route_proven_profit_receipt,
-            "consumer_evidence_canary": route_proven_profit_receipt.get("route_canary"),
-        }
     route_reacquisition_board = build_route_reacquisition_board(
         proof_floor_receipt=proof_floor,
         route_reacquisition_book=cast(
@@ -3446,6 +3547,41 @@ def _build_trading_consumer_evidence_payload(
         empirical_jobs_status=empirical_jobs,
         market_context_status=market_context_status,
     )
+    contract_canary_refs = build_consumer_evidence_contract_canary(
+        source_commit=BUILD_COMMIT,
+        serving_revision=cast(str | None, shadow_first_runtime["active_revision"]),
+        image_digest=BUILD_IMAGE_DIGEST,
+        route_warrant_exchange=route_warrant_exchange,
+        repair_bid_settlement_ledger=repair_bid_settlement_ledger,
+    )
+    if summary:
+        return {
+            "schema_version": "torghut.consumer-evidence-status.v1",
+            "view": "summary",
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "enabled": settings.trading_enabled,
+            "mode": settings.trading_mode,
+            "running": state.running,
+            "build": build_payload,
+            "control_plane_dependency_mode": control_plane_dependency_mode,
+            "dependency_quorum": dependency_quorum.as_payload(),
+            "forecast_service": forecast_service_status,
+            "lean_authority": lean_authority_status,
+            "empirical_jobs": empirical_jobs,
+            "market_context": market_context_status,
+            "quant_evidence": quant_evidence,
+            "live_submission_gate": live_submission_gate,
+            "proof_floor": proof_floor,
+            "simple_lane_status": simple_lane_status,
+            "torghut_consumer_evidence_receipt": consumer_evidence_receipt,
+            "route_proven_profit_receipt": route_proven_profit_receipt,
+            "consumer_evidence_canary": route_proven_profit_receipt.get("route_canary"),
+            **_consumer_evidence_contract_summary_fields(
+                contract_canary_refs=contract_canary_refs,
+                route_warrant_exchange=route_warrant_exchange,
+                repair_bid_settlement_ledger=repair_bid_settlement_ledger,
+            ),
+        }
     source_serving_repair_receipt_ledger = _build_source_serving_repair_receipt_payload(
         source_commit=BUILD_COMMIT,
         build=build_payload,

--- a/services/torghut/app/trading/consumer_evidence.py
+++ b/services/torghut/app/trading/consumer_evidence.py
@@ -10,10 +10,16 @@ from typing import Any, Mapping, Sequence, cast
 CONSUMER_EVIDENCE_SCHEMA_VERSION = "torghut.consumer-evidence-receipt.v1"
 CONSUMER_EVIDENCE_STATUS_SCHEMA_VERSION = "torghut.consumer-evidence-status.v1"
 CONSUMER_EVIDENCE_CANARY_SCHEMA_VERSION = "torghut.consumer-evidence-canary.v1"
+CONSUMER_EVIDENCE_CONTRACT_CANARY_SCHEMA_VERSION = (
+    "torghut.consumer-evidence-contract-canary.v1"
+)
 ROUTE_PROVEN_PROFIT_RECEIPT_SCHEMA_VERSION = "torghut.route-proven-profit-receipt.v1"
 CONSUMER_EVIDENCE_ROUTE_REF = "/trading/consumer-evidence"
+CONSUMER_EVIDENCE_SUMMARY_ROUTE_REF = "/trading/consumer-evidence?view=summary"
 CONSUMER_EVIDENCE_CANARY_MAX_PAYLOAD_BYTES = 65_536
 CONSUMER_EVIDENCE_CANARY_MAX_LATENCY_MS = 3_000
+ROUTE_WARRANT_EXCHANGE_SCHEMA_VERSION = "torghut.route-warrant-exchange.v1"
+REPAIR_BID_SETTLEMENT_LEDGER_SCHEMA_VERSION = "torghut.repair-bid-settlement-ledger.v1"
 
 
 def _mapping(value: object) -> Mapping[str, Any]:
@@ -71,6 +77,20 @@ def _int(value: object, default: int = 0) -> int:
         return int(Decimal(str(value)))
     except (InvalidOperation, ValueError):
         return default
+
+
+def _timestamp(value: object) -> datetime | None:
+    raw = _text(value)
+    if not raw:
+        return None
+    normalized = raw[:-1] + "+00:00" if raw.endswith("Z") else raw
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return None
+    return parsed.astimezone(timezone.utc)
 
 
 def _dimension(proof_floor: Mapping[str, Any], name: str) -> Mapping[str, Any]:
@@ -273,6 +293,156 @@ def build_consumer_evidence_canary(
     }
 
 
+def _contract_state(
+    *,
+    payload: Mapping[str, Any],
+    expected_schema: str,
+    ref_keys: Sequence[str],
+    now: datetime,
+) -> str:
+    schema = _text(payload.get("schema_version"))
+    ref = next(
+        (_text(payload.get(key)) for key in ref_keys if _text(payload.get(key))), ""
+    )
+    if not payload or not ref:
+        return "missing"
+    if schema != expected_schema:
+        return "schema_mismatch"
+    fresh_until = _timestamp(payload.get("fresh_until"))
+    if fresh_until is not None and fresh_until <= now:
+        return "stale"
+    return "current"
+
+
+def _contract_ref(
+    *,
+    payload: Mapping[str, Any],
+    expected_schema: str,
+    ref_keys: Sequence[str],
+    now: datetime,
+) -> dict[str, object]:
+    ref = next(
+        (_text(payload.get(key)) for key in ref_keys if _text(payload.get(key))),
+        None,
+    )
+    return {
+        "schema_version": expected_schema,
+        "ref": ref,
+        "fresh_until": payload.get("fresh_until"),
+        "state": _contract_state(
+            payload=payload,
+            expected_schema=expected_schema,
+            ref_keys=ref_keys,
+            now=now,
+        ),
+        "max_notional": _text(payload.get("max_notional"), "0"),
+    }
+
+
+def build_consumer_evidence_contract_canary(
+    *,
+    source_commit: str,
+    serving_revision: str | None,
+    image_digest: str | None,
+    route_warrant_exchange: Mapping[str, Any] | None,
+    repair_bid_settlement_ledger: Mapping[str, Any] | None,
+    now: datetime | None = None,
+    freshness_seconds: int = 60,
+) -> dict[str, object]:
+    """Build compact source-serving contract refs for the summary route."""
+
+    generated_at = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    fresh_until = generated_at + timedelta(seconds=max(1, freshness_seconds))
+    route_warrant = _mapping(route_warrant_exchange)
+    repair_bid = _mapping(repair_bid_settlement_ledger)
+    route_warrant_ref = _contract_ref(
+        payload=route_warrant,
+        expected_schema=ROUTE_WARRANT_EXCHANGE_SCHEMA_VERSION,
+        ref_keys=("warrant_id", "exchange_id"),
+        now=generated_at,
+    )
+    repair_bid_ref = _contract_ref(
+        payload=repair_bid,
+        expected_schema=REPAIR_BID_SETTLEMENT_LEDGER_SCHEMA_VERSION,
+        ref_keys=("ledger_id",),
+        now=generated_at,
+    )
+    contract_refs = {
+        "route_warrant_exchange": route_warrant_ref,
+        "repair_bid_settlement_ledger": repair_bid_ref,
+    }
+    observed_contracts = [
+        name
+        for name, ref in contract_refs.items()
+        if _text(_mapping(ref).get("state")) in {"current", "stale"}
+    ]
+    schema_mismatches = [
+        name
+        for name, ref in contract_refs.items()
+        if _text(_mapping(ref).get("state")) == "schema_mismatch"
+    ]
+    missing_contracts = [
+        name
+        for name, ref in contract_refs.items()
+        if _text(_mapping(ref).get("state")) == "missing"
+    ]
+    stale_contracts = [
+        name
+        for name, ref in contract_refs.items()
+        if _text(_mapping(ref).get("state")) == "stale"
+    ]
+
+    decision = "current"
+    if schema_mismatches:
+        decision = "block"
+    elif missing_contracts or stale_contracts:
+        decision = "hold"
+
+    reason_codes = _unique(
+        [
+            *[
+                f"consumer_evidence_contract_missing:{contract}"
+                for contract in missing_contracts
+            ],
+            *[
+                f"consumer_evidence_contract_stale:{contract}"
+                for contract in stale_contracts
+            ],
+            *[
+                f"consumer_evidence_contract_schema_mismatch:{contract}"
+                for contract in schema_mismatches
+            ],
+        ]
+    )
+    canary_payload = {
+        "schema_version": CONSUMER_EVIDENCE_CONTRACT_CANARY_SCHEMA_VERSION,
+        "generated_at": generated_at.isoformat(),
+        "fresh_until": fresh_until.isoformat(),
+        "source_commit": source_commit,
+        "serving_revision": serving_revision,
+        "image_digest": image_digest,
+        "summary_route_ref": CONSUMER_EVIDENCE_SUMMARY_ROUTE_REF,
+        "full_route_ref": CONSUMER_EVIDENCE_ROUTE_REF,
+        "observed_contracts": observed_contracts,
+        "contract_schema_mismatches": schema_mismatches,
+        "contract_refs": contract_refs,
+        "decision": decision,
+        "reason_codes": reason_codes,
+    }
+
+    return {
+        **canary_payload,
+        "canary_id": _stable_ref(
+            "consumer-evidence-contract-canary",
+            canary_payload,
+        ),
+        "rollback_target": (
+            "omit contract_canary_refs from summary and keep full consumer "
+            "evidence as authority"
+        ),
+    }
+
+
 def build_route_proven_profit_receipt(
     *,
     consumer_evidence_receipt: Mapping[str, Any],
@@ -397,10 +567,12 @@ def build_torghut_consumer_evidence_receipt(
 
 
 __all__ = [
+    "CONSUMER_EVIDENCE_CONTRACT_CANARY_SCHEMA_VERSION",
     "CONSUMER_EVIDENCE_SCHEMA_VERSION",
     "CONSUMER_EVIDENCE_STATUS_SCHEMA_VERSION",
     "ROUTE_PROVEN_PROFIT_RECEIPT_SCHEMA_VERSION",
     "build_consumer_evidence_canary",
+    "build_consumer_evidence_contract_canary",
     "build_route_proven_profit_receipt",
     "build_torghut_consumer_evidence_receipt",
 ]

--- a/services/torghut/tests/test_consumer_evidence.py
+++ b/services/torghut/tests/test_consumer_evidence.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 
 from app.trading.consumer_evidence import (
     build_consumer_evidence_canary,
+    build_consumer_evidence_contract_canary,
     build_route_proven_profit_receipt,
     build_torghut_consumer_evidence_receipt,
 )
@@ -141,3 +142,76 @@ def test_consumer_evidence_receipt_marks_ready_without_notional_blockers() -> No
     assert receipt["forecast_registry_state"] == "ready"
     assert receipt["paper_readiness_state"] == "ready"
     assert receipt["reason_codes"] == []
+
+
+def test_consumer_evidence_contract_canary_exports_summary_refs() -> None:
+    canary = build_consumer_evidence_contract_canary(
+        now=datetime(2026, 5, 15, 0, 30, tzinfo=timezone.utc),
+        source_commit="abc123",
+        serving_revision="torghut-00434",
+        image_digest="sha256:test",
+        route_warrant_exchange={
+            "schema_version": "torghut.route-warrant-exchange.v1",
+            "warrant_id": "route-warrant-exchange:test",
+            "fresh_until": "2026-05-15T00:31:00+00:00",
+            "warrant_state": "repair_only",
+            "max_notional": "0",
+        },
+        repair_bid_settlement_ledger={
+            "schema_version": "torghut.repair-bid-settlement-ledger.v1",
+            "ledger_id": "repair-bid-settlement-ledger:test",
+            "fresh_until": "2026-05-15T00:31:00+00:00",
+            "capital_decision": "repair_only",
+            "max_notional": "0",
+        },
+    )
+
+    assert canary["schema_version"] == "torghut.consumer-evidence-contract-canary.v1"
+    assert str(canary["canary_id"]).startswith("consumer-evidence-contract-canary:")
+    assert canary["summary_route_ref"] == "/trading/consumer-evidence?view=summary"
+    assert canary["full_route_ref"] == "/trading/consumer-evidence"
+    assert canary["decision"] == "current"
+    assert canary["observed_contracts"] == [
+        "route_warrant_exchange",
+        "repair_bid_settlement_ledger",
+    ]
+    assert canary["contract_schema_mismatches"] == []
+    assert canary["reason_codes"] == []
+    refs = canary["contract_refs"]
+    assert refs["route_warrant_exchange"] == {
+        "schema_version": "torghut.route-warrant-exchange.v1",
+        "ref": "route-warrant-exchange:test",
+        "fresh_until": "2026-05-15T00:31:00+00:00",
+        "state": "current",
+        "max_notional": "0",
+    }
+    assert refs["repair_bid_settlement_ledger"] == {
+        "schema_version": "torghut.repair-bid-settlement-ledger.v1",
+        "ref": "repair-bid-settlement-ledger:test",
+        "fresh_until": "2026-05-15T00:31:00+00:00",
+        "state": "current",
+        "max_notional": "0",
+    }
+
+
+def test_consumer_evidence_contract_canary_holds_missing_contracts() -> None:
+    canary = build_consumer_evidence_contract_canary(
+        now=datetime(2026, 5, 15, 0, 30, tzinfo=timezone.utc),
+        source_commit="abc123",
+        serving_revision="torghut-00434",
+        image_digest="sha256:test",
+        route_warrant_exchange=None,
+        repair_bid_settlement_ledger={
+            "schema_version": "torghut.repair-bid-settlement-ledger.v1",
+            "ledger_id": "repair-bid-settlement-ledger:test",
+            "fresh_until": "2026-05-15T00:29:59+00:00",
+            "max_notional": "0",
+        },
+    )
+
+    assert canary["decision"] == "hold"
+    assert canary["observed_contracts"] == ["repair_bid_settlement_ledger"]
+    assert canary["reason_codes"] == [
+        "consumer_evidence_contract_missing:route_warrant_exchange",
+        "consumer_evidence_contract_stale:repair_bid_settlement_ledger",
+    ]

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -1273,6 +1273,39 @@ class TestTradingApi(TestCase):
         self.assertEqual(summary_payload["proof_floor"], proof_floor)
         self.assertIn("torghut_consumer_evidence_receipt", summary_payload)
         self.assertIn("route_proven_profit_receipt", summary_payload)
+        self.assertIn("contract_canary_refs", summary_payload)
+        self.assertEqual(
+            summary_payload["contract_canary_refs"]["schema_version"],
+            "torghut.consumer-evidence-contract-canary.v1",
+        )
+        self.assertEqual(
+            summary_payload["contract_canary_refs"]["decision"],
+            "current",
+        )
+        self.assertEqual(
+            summary_payload["observed_contracts"],
+            ["route_warrant_exchange", "repair_bid_settlement_ledger"],
+        )
+        self.assertEqual(summary_payload["contract_schema_mismatches"], [])
+        self.assertTrue(
+            str(summary_payload["route_warrant_id"]).startswith(
+                "route-warrant-exchange:"
+            )
+        )
+        self.assertTrue(
+            str(summary_payload["repair_bid_settlement_ledger_id"]).startswith(
+                "repair-bid-settlement-ledger:"
+            )
+        )
+        self.assertEqual(summary_payload["repair_bid_settlement_status"], "current")
+        self.assertEqual(
+            summary_payload["repair_bid_settlement_routeable_candidate_count"], 0
+        )
+        self.assertEqual(summary_payload["repair_bid_settlement_max_notional"], "0")
+        self.assertLess(len(summary_response.content), 65_536)
+        self.assertNotIn("route_warrant_exchange", summary_payload)
+        self.assertNotIn("repair_bid_settlement_ledger", summary_payload)
+        self.assertNotIn("source_serving_repair_receipt_ledger", summary_payload)
         self.assertNotIn("route_reacquisition_board", summary_payload)
         self.assertNotIn("capital_reentry_cohort_ledger", summary_payload)
         self.assertNotIn("profit_carry_passport_ledger", summary_payload)


### PR DESCRIPTION
## Summary

- Added `torghut.consumer-evidence-contract-canary.v1` compact refs to `/trading/consumer-evidence?view=summary` for `route_warrant_exchange` and `repair_bid_settlement_ledger`, while keeping full contract bodies on the full route.
- Updated Jangar Torghut evidence normalization to consume compact refs first, fall back to one bounded full consumer-evidence fetch when refs are absent, and report `torghut_contract_transport_unavailable` instead of false missing-contract blockers when that fallback fails.
- Split the Jangar resolver contract and transport helpers into focused modules so the production path stays under the module-size guardrail.
- Updated source-serving verdict behavior and tests so compact route-warrant and repair-bid refs satisfy required source-serving contract presence for zero-notional repair-only evidence.
- Documented design provenance, validation, rollout risk, rollback, and live revenue-repair before/after evidence in `docs/torghut/rollouts/2026-05-15-consumer-evidence-contract-canary.md`.

Design provenance:

- `docs/torghut/design-system/v6/213-torghut-consumer-evidence-contract-canary-and-alpha-reentry-transport-2026-05-15.md`
- `docs/agents/designs/207-jangar-consumer-evidence-transport-split-and-source-serving-contract-canary-2026-05-15.md`

Runtime evidence:

- Before local implementation: `/trading/revenue-repair` reported `business_state=repair_only`, `revenue_ready=false`, top queue item `repair_alpha_readiness`, affected value gate `routeable_candidate_count`, `accepted_routeable_candidate_count=0`, and `max_notional=0`.
- After local implementation and before deployment: `/trading/revenue-repair` still reports `business_state=repair_only`, `revenue_ready=false`, top queue item `repair_alpha_readiness`, affected value gate `routeable_candidate_count`, `accepted_routeable_candidate_count=0`, and `max_notional=0`.
- Expected first revenue impact is retiring false source-serving transport debt; this PR does not enable live submission or widen notional.

## Related Issues

None

## Testing

- PASS `uv sync --frozen --extra dev`
- PASS `uv run --frozen ruff check app/main.py app/trading/consumer_evidence.py tests/test_consumer_evidence.py tests/test_trading_api.py`
- PASS `uv run --frozen ruff format --check app/main.py app/trading/consumer_evidence.py tests/test_consumer_evidence.py tests/test_trading_api.py`
- PASS `uv run --frozen pytest tests/test_consumer_evidence.py`
- PASS `uv run --frozen pytest tests/test_trading_api.py -k consumer_evidence`
- PASS `uv run --frozen pytest tests/test_consumer_evidence.py tests/test_trading_api.py -k consumer_evidence`
- PASS `uv run --frozen pytest tests/test_no_delta_repair_reentry_auction.py`
- PASS `uv run --frozen pyright --project pyrightconfig.json`
- PASS `uv run --frozen pyright --project pyrightconfig.alpha.json`
- PASS `uv run --frozen pyright --project pyrightconfig.scripts.json`
- PASS `bunx oxfmt --check services/jangar/README.md services/torghut/README.md docs/torghut/rollouts/2026-05-15-consumer-evidence-contract-canary.md services/jangar/src/routes/ready.test.ts services/jangar/src/server/control-plane-torghut-consumer-evidence.ts services/jangar/src/server/control-plane-source-serving-contract-verdict.ts services/jangar/src/server/__tests__/control-plane-torghut-consumer-evidence.test.ts services/jangar/src/server/__tests__/control-plane-source-serving-contract-verdict.test.ts`
- PASS `bunx oxfmt --check services/jangar packages/scripts/src/jangar argocd/applications/jangar`
- PASS `bunx oxlint --config .oxlintrc.json services/jangar/src/routes/ready.test.ts services/jangar/src/server/control-plane-torghut-consumer-evidence.ts services/jangar/src/server/control-plane-source-serving-contract-verdict.ts services/jangar/src/server/__tests__/control-plane-torghut-consumer-evidence.test.ts services/jangar/src/server/__tests__/control-plane-source-serving-contract-verdict.test.ts`
- PASS `bun run --cwd services/jangar lint:oxlint`
- PASS `bun run --cwd services/jangar lint:oxlint:type`
- PASS `bun run --cwd services/jangar docs:inventory:check`
- PASS `bun run --cwd services/jangar check:module-sizes`
- PASS `bun run --filter @proompteng/otel build`
- PASS `bun run --filter @proompteng/temporal-bun-sdk build`
- PASS `bun run --filter @proompteng/jangar tsc`
- PASS `bunx tsc --noEmit --project tsconfig.paths.json`
- PASS `bunx vitest run --config vitest.config.ts src/server/__tests__/control-plane-torghut-consumer-evidence.test.ts src/server/__tests__/control-plane-source-serving-contract-verdict.test.ts`
- PASS `bun run --filter @proompteng/jangar test`
- PASS `bun run --cwd services/jangar build`
- PASS `git diff --check`
- PASS `curl -fsS http://torghut.torghut.svc.cluster.local/trading/revenue-repair | jq '{business_state, revenue_ready, max_notional, top_repair_queue_item: .repair_queue[0], selected_value_gate, accepted_routeable_candidate_count, zero_notional_or_stale_evidence_rate}'`
- PASS `gh pr checks 6727 --repo proompteng/lab`

## Screenshots (if applicable)

N/A

## Breaking Changes

None. The summary canary is additive, full consumer evidence remains authoritative for complete contract bodies, and Jangar falls back to full evidence when compact refs are missing.

Rollback path: revert this PR or have Jangar ignore `contract_canary_refs` and return source-serving verdicts to full-payload authority. Torghut `max_notional=0`, repair-only state, and live-submit gates remain unchanged.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
