### PR TITLE
fix(jangar): preserve revenue repair topline fallback

### DIFF
--- a/services/jangar/src/routes/ready.test.ts
+++ b/services/jangar/src/routes/ready.test.ts
@@ -716,6 +716,120 @@ describe('getReadyHandler', () => {
     })
   })
 
+  it('keeps ready revenue topline when consumer evidence transport drops but revenue-repair is current', async () => {
+    process.env.JANGAR_TORGHUT_STATUS_URL = 'http://torghut.torghut.svc.cluster.local/trading/consumer-evidence'
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(buildJsonResponse({ detail: 'consumer evidence temporarily unavailable' }, 503))
+      .mockResolvedValueOnce(
+        buildJsonResponse({
+          schema_version: 'torghut.revenue-repair-digest.v1',
+          business_state: 'repair_only',
+          revenue_ready: false,
+          repair_queue: [
+            {
+              code: 'repair_alpha_readiness',
+              reason: 'alpha_readiness_not_promotion_eligible',
+              dimension: 'alpha_readiness',
+              action: 'clear_hypothesis_blockers_before_capital',
+              priority: 70,
+              expected_unblock_value: 2,
+              source: 'proof_floor.repair_ladder',
+              value_gate: 'routeable_candidate_count',
+              required_output_receipt: 'torghut.executable-alpha-receipts.v1',
+              required_receipts: ['alpha_readiness_receipt', 'hypothesis_promotion_receipt', 'capital_replay_board'],
+              max_notional: '0',
+              capital_rule: 'zero_notional_repair_only',
+              observed_count: 1,
+            },
+          ],
+          alpha_readiness_settlement_conveyor: {
+            schema_version: 'torghut.alpha-readiness-settlement-conveyor.v1',
+            conveyor_id: 'alpha-readiness-settlement-conveyor:ready-fallback',
+            generated_at: '2026-05-15T01:30:00.000Z',
+            fresh_until: '2026-05-15T01:45:00.000Z',
+            status: 'no_delta',
+            settlement_state: 'no_delta',
+            reason_codes: ['active_no_delta_lease'],
+            selected_lane: {
+              hypothesis_id: 'H-MICRO-01',
+              no_delta_release_key: 'alpha-readiness-no-delta:H-MICRO-01:window-a',
+              repeat_launch_decision: 'deny',
+            },
+            selected_value_gate: 'routeable_candidate_count',
+            routeable_candidate_count_before: 0,
+            routeable_candidate_count_after: 0,
+            measured_routeable_candidate_delta: 0,
+            active_no_delta_leases: [{ lease_id: 'alpha-readiness-no-delta-lease:ready-fallback' }],
+            required_output_receipt: 'torghut.alpha-readiness-settlement-receipt.v1',
+            validation_commands: [
+              'uv run --frozen pytest services/torghut/tests/test_alpha_readiness_settlement_conveyor.py',
+            ],
+            max_notional: '0',
+            capital_rule: 'zero_notional_repair_only',
+            rollback_target: 'stop emitting alpha_readiness_settlement_conveyor and keep Torghut max_notional=0',
+          },
+        }),
+      )
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch
+
+    const { getReadyHandler } = await import('./ready')
+
+    const response = await getReadyHandler()
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(body).toMatchObject({
+      status: 'ok',
+      business_state: 'repair_only',
+      revenue_ready: false,
+      affected_value_gate: 'routeable_candidate_count',
+      top_repair_queue_item: expect.objectContaining({
+        code: 'repair_alpha_readiness',
+        value_gate: 'routeable_candidate_count',
+        max_notional: '0',
+      }),
+      torghut_consumer_evidence: {
+        status: 'unavailable',
+        revenue_repair_business_state: 'repair_only',
+        revenue_repair_ready: false,
+        revenue_repair_queue: [expect.objectContaining({ code: 'repair_alpha_readiness' })],
+        alpha_readiness_settlement_conveyor: expect.objectContaining({
+          conveyor_id: 'alpha-readiness-settlement-conveyor:ready-fallback',
+        }),
+      },
+      revenue_repair_settlement_custody: {
+        torghut_conveyor_ref: 'alpha-readiness-settlement-conveyor:ready-fallback',
+        selected_hypothesis_id: 'H-MICRO-01',
+        selected_value_gate: 'routeable_candidate_count',
+      },
+      material_evidence_settlement_spine: {
+        transport_truth: {
+          consumer_evidence_status: 'unavailable',
+          revenue_repair_topline_status: 'queue_head_inferred',
+          revenue_repair_topline_source: 'revenue_repair_queue_head',
+        },
+        business_truth: {
+          business_state: 'repair_only',
+          revenue_ready: false,
+          top_repair_queue_item: expect.objectContaining({ code: 'repair_alpha_readiness' }),
+          selected_value_gate: 'routeable_candidate_count',
+          max_notional: '0',
+        },
+      },
+    })
+    expect(body.material_evidence_settlement_spine.reason_codes).toEqual(
+      expect.arrayContaining(['torghut_consumer_evidence_unavailable', 'topline_inferred_from_queue_head']),
+    )
+    expect(body.material_evidence_settlement_spine.reason_codes).not.toEqual(
+      expect.arrayContaining(['business_state_missing', 'revenue_repair_top_item_missing']),
+    )
+    expect(body.revenue_repair_settlement_custody.reason_codes).not.toEqual(
+      expect.arrayContaining(['business_state_missing', 'revenue_repair_top_item_missing']),
+    )
+  })
+
   it('returns 200 and exposes a serving passport when only collaboration runtime debt is blocked', async () => {
     runtimeAdmissionMocks.buildRuntimeAdmissionSnapshot.mockReturnValue(
       buildRuntimeAdmissionSnapshot({

--- a/services/jangar/src/server/__tests__/control-plane-torghut-consumer-evidence.test.ts
+++ b/services/jangar/src/server/__tests__/control-plane-torghut-consumer-evidence.test.ts
@@ -855,6 +855,105 @@ describe('control-plane Torghut consumer evidence', () => {
     })
   })
 
+  it('carries revenue-repair source-of-truth topline when consumer evidence is unavailable', async () => {
+    process.env = {
+      ...originalEnv,
+      JANGAR_TORGHUT_STATUS_URL: 'http://torghut.torghut.svc.cluster.local/trading/consumer-evidence',
+    }
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(buildJsonResponse({ detail: 'consumer evidence timeout' }, 503))
+      .mockResolvedValueOnce(
+        buildJsonResponse({
+          schema_version: 'torghut.revenue-repair-digest.v1',
+          business_state: 'repair_only',
+          revenue_ready: false,
+          repair_queue: [
+            {
+              code: 'repair_alpha_readiness',
+              reason: 'alpha_readiness_not_promotion_eligible',
+              dimension: 'alpha_readiness',
+              action: 'clear_hypothesis_blockers_before_capital',
+              priority: 70,
+              expected_unblock_value: 2,
+              source: 'proof_floor.repair_ladder',
+              value_gate: 'routeable_candidate_count',
+              required_output_receipt: 'torghut.executable-alpha-receipts.v1',
+              required_receipts: ['alpha_readiness_receipt', 'hypothesis_promotion_receipt'],
+              max_notional: '0',
+              capital_rule: 'zero_notional_repair_only',
+              observed_count: 1,
+            },
+          ],
+          alpha_readiness_settlement_conveyor: {
+            schema_version: 'torghut.alpha-readiness-settlement-conveyor.v1',
+            conveyor_id: 'alpha-readiness-settlement-conveyor:fallback',
+            generated_at: '2026-05-15T01:30:00.000Z',
+            fresh_until: '2026-05-15T01:45:00.000Z',
+            status: 'no_delta',
+            settlement_state: 'no_delta',
+            reason_codes: ['active_no_delta_lease'],
+            selected_lane: {
+              hypothesis_id: 'H-MICRO-01',
+              no_delta_release_key: 'alpha-readiness-no-delta:H-MICRO-01:window-a',
+              repeat_launch_decision: 'deny',
+            },
+            selected_value_gate: 'routeable_candidate_count',
+            routeable_candidate_count_before: 0,
+            routeable_candidate_count_after: 0,
+            measured_routeable_candidate_delta: 0,
+            active_no_delta_leases: [{ lease_id: 'alpha-readiness-no-delta-lease:fallback' }],
+            required_output_receipt: 'torghut.alpha-readiness-settlement-receipt.v1',
+            validation_commands: [
+              'uv run --frozen pytest services/torghut/tests/test_alpha_readiness_settlement_conveyor.py',
+            ],
+            max_notional: '0',
+            capital_rule: 'zero_notional_repair_only',
+            rollback_target: 'stop emitting alpha_readiness_settlement_conveyor and keep Torghut max_notional=0',
+          },
+        }),
+      )
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch
+
+    const result = await resolveTorghutConsumerEvidence(new Date('2026-05-15T01:32:00.000Z'))
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(String(fetchMock.mock.calls[0]?.[0])).toBe(
+      'http://torghut.torghut.svc.cluster.local/trading/consumer-evidence?view=summary',
+    )
+    expect(String(fetchMock.mock.calls[1]?.[0])).toBe('http://torghut.torghut.svc.cluster.local/trading/revenue-repair')
+    expect(result.status).toMatchObject({
+      status: 'unavailable',
+      receipt_id: null,
+      revenue_repair_business_state: 'repair_only',
+      revenue_repair_ready: false,
+      max_notional: '0',
+      revenue_repair_queue: [
+        expect.objectContaining({
+          code: 'repair_alpha_readiness',
+          value_gate: 'routeable_candidate_count',
+          required_output_receipt: 'torghut.executable-alpha-receipts.v1',
+        }),
+      ],
+      observed_contracts: expect.arrayContaining(['alpha_readiness_settlement_conveyor']),
+      alpha_readiness_settlement_conveyor: expect.objectContaining({
+        conveyor_id: 'alpha-readiness-settlement-conveyor:fallback',
+        selected_hypothesis_id: 'H-MICRO-01',
+        selected_value_gate: 'routeable_candidate_count',
+        active_no_delta_lease_count: 1,
+        repeat_launch_decision: 'deny',
+        max_notional: '0',
+      }),
+      reason_codes: ['torghut_consumer_evidence_unavailable'],
+    })
+    expect(result.status.message).toContain('revenue-repair source-of-truth fallback carried business topline')
+    expect(result.negativeEvidence).toMatchObject({
+      consumer_evidence_status: 'unavailable',
+      consumer_evidence_reason_codes: ['torghut_consumer_evidence_unavailable'],
+      paper_settlement_clean: false,
+    })
+  })
+
   it('attaches a local Torghut stage-clearance packet as typed custody evidence', () => {
     const packet: StageClearancePacket = {
       schema_version: 'jangar.stage-clearance-packet.v1',

--- a/services/jangar/src/server/control-plane-material-evidence-settlement.ts
+++ b/services/jangar/src/server/control-plane-material-evidence-settlement.ts
@@ -144,13 +144,13 @@ const revenueRepairToplineStatus = (
   if (input.torghutConsumerEvidence.status === 'stale') return 'stale'
   if (input.torghutConsumerEvidence.status === 'schema_mismatch') return 'schema_mismatch'
   if (input.torghutConsumerEvidence.status === 'missing') return 'missing'
+  if (input.torghutConsumerEvidence.revenue_repair_queue?.[0]) return 'queue_head_inferred'
   if (
     input.torghutConsumerEvidence.status === 'unavailable' ||
     input.torghutConsumerEvidence.status === 'route_missing'
   ) {
     return 'unavailable'
   }
-  if (input.torghutConsumerEvidence.revenue_repair_queue?.[0]) return 'queue_head_inferred'
   if (
     input.torghutConsumerEvidence.revenue_repair_business_state ||
     input.torghutConsumerEvidence.revenue_repair_ready !== undefined

--- a/services/jangar/src/server/control-plane-torghut-consumer-evidence.ts
+++ b/services/jangar/src/server/control-plane-torghut-consumer-evidence.ts
@@ -38,6 +38,7 @@ import {
   normalizeRevenueRepairBoolean,
   readRevenueRepairQueue,
 } from '~/server/control-plane-torghut-revenue-repair'
+import { buildUnavailableStatusFromRevenueRepair } from '~/server/control-plane-torghut-revenue-repair-fallback'
 import type { TorghutNegativeEvidenceInput } from '~/server/control-plane-negative-evidence-router-torghut'
 import {
   normalizeNonEmpty,
@@ -171,21 +172,24 @@ export const resolveTorghutConsumerEvidence = async (now = new Date()): Promise<
     const routeMissing = routeResult.statusCode === 404
     const status = routeMissing ? 'route_missing' : 'unavailable'
     const reason = routeMissing ? 'torghut_consumer_evidence_route_missing' : 'torghut_consumer_evidence_unavailable'
+    const revenueRepairEndpoint = deriveRevenueRepairEndpoint(endpoint)
+    const revenueRepairResult =
+      revenueRepairEndpoint && revenueRepairEndpoint !== endpoint
+        ? await requestJson(revenueRepairEndpoint, config.torghutStatusTimeoutMs)
+        : null
+    const revenueRepairPayload = hasRevenueRepairSummary(revenueRepairResult?.payload ?? {})
+      ? (revenueRepairResult?.payload ?? null)
+      : null
     return {
-      status: {
-        status,
+      status: buildUnavailableStatusFromRevenueRepair({
         endpoint,
-        receipt_id: null,
-        generated_at: null,
-        fresh_until: null,
-        candidate_id: null,
-        dataset_snapshot_ref: null,
-        max_notional: null,
-        reason_codes: [reason],
+        status,
+        reason,
+        payload: revenueRepairPayload,
         message: routeMissing
           ? 'torghut consumer evidence route returned 404'
           : 'torghut consumer evidence endpoint unavailable',
-      },
+      }),
       negativeEvidence: {
         readiness_status: 'degraded',
         readyz_status_code: routeResult.statusCode,

--- a/services/jangar/src/server/control-plane-torghut-revenue-repair-fallback.ts
+++ b/services/jangar/src/server/control-plane-torghut-revenue-repair-fallback.ts
@@ -1,0 +1,96 @@
+import type { TorghutConsumerEvidenceStatus } from '~/data/agents-control-plane'
+import {
+  readAlphaEvidenceFoundry,
+  readAlphaRepairClosureBoard,
+} from '~/server/control-plane-torghut-alpha-closure-evidence'
+import {
+  alphaClosureDividendSloSchemaMismatch,
+  readAlphaClosureDividendSlo,
+} from '~/server/control-plane-torghut-alpha-closure-dividend-slo'
+import { readAlphaReadinessStrikeLedger } from '~/server/control-plane-torghut-alpha-readiness-strike'
+import {
+  alphaReadinessSettlementConveyorRefSchemaMismatch,
+  readAlphaReadinessSettlementConveyorRef,
+} from '~/server/control-plane-torghut-alpha-readiness-settlement-conveyor'
+import {
+  alphaRepairDividendLedgerRefSchemaMismatch,
+  readAlphaRepairDividendLedgerRef,
+} from '~/server/control-plane-torghut-alpha-repair-dividend-ledger'
+import {
+  noDeltaRepairReentryAuctionRefSchemaMismatch,
+  readNoDeltaRepairReentryAuctionRef,
+} from '~/server/control-plane-torghut-no-delta-repair-reentry-auction'
+import { readExecutableAlphaRepairReceipts } from '~/server/control-plane-torghut-executable-alpha-repair'
+import {
+  hasRevenueRepairSummary,
+  normalizeRevenueRepairBoolean,
+  readRevenueRepairQueue,
+} from '~/server/control-plane-torghut-revenue-repair'
+import { normalizeNonEmpty, normalizeReason, uniqueStrings } from '~/server/control-plane-torghut-evidence-normalizers'
+
+export const buildUnavailableStatusFromRevenueRepair = (input: {
+  endpoint: string
+  status: TorghutConsumerEvidenceStatus['status']
+  reason: string
+  message: string
+  payload: Record<string, unknown> | null
+}): TorghutConsumerEvidenceStatus => {
+  const revenueRepairBusinessState = normalizeReason(input.payload?.business_state)
+  const revenueRepairReady = normalizeRevenueRepairBoolean(input.payload?.revenue_ready)
+  const revenueRepairQueue = readRevenueRepairQueue(input.payload)
+  const alphaReadinessStrikeLedger = readAlphaReadinessStrikeLedger(input.payload)
+  const executableAlphaRepairReceipts = readExecutableAlphaRepairReceipts(input.payload)
+  const alphaRepairClosureBoard = readAlphaRepairClosureBoard(input.payload)
+  const alphaEvidenceFoundry = readAlphaEvidenceFoundry(input.payload)
+  const alphaReadinessSettlementConveyor = readAlphaReadinessSettlementConveyorRef(input.payload)
+  const alphaRepairDividendLedger = readAlphaRepairDividendLedgerRef(input.payload)
+  const alphaClosureDividendSlo = readAlphaClosureDividendSlo(input.payload)
+  const noDeltaRepairReentryAuction = readNoDeltaRepairReentryAuctionRef(input.payload)
+  const topRepairItem = revenueRepairQueue[0] ?? null
+  const maxNotional = normalizeNonEmpty(input.payload?.max_notional) ?? topRepairItem?.max_notional ?? null
+  const observedContracts = uniqueStrings([
+    alphaReadinessStrikeLedger ? 'alpha_readiness_strike_ledger' : null,
+    executableAlphaRepairReceipts ? 'executable_alpha_repair_receipts' : null,
+    alphaRepairClosureBoard ? 'alpha_repair_closure_board' : null,
+    alphaEvidenceFoundry ? 'alpha_evidence_foundry' : null,
+    alphaReadinessSettlementConveyor ? 'alpha_readiness_settlement_conveyor' : null,
+    alphaRepairDividendLedger ? 'alpha_repair_dividend_ledger' : null,
+    alphaClosureDividendSlo ? 'alpha_closure_dividend_slo' : null,
+    noDeltaRepairReentryAuction ? 'no_delta_repair_reentry_auction' : null,
+  ])
+  const contractSchemaMismatches = uniqueStrings([
+    alphaReadinessSettlementConveyorRefSchemaMismatch(input.payload),
+    alphaRepairDividendLedgerRefSchemaMismatch(input.payload),
+    alphaClosureDividendSloSchemaMismatch(input.payload),
+    noDeltaRepairReentryAuctionRefSchemaMismatch(input.payload),
+  ])
+
+  return {
+    status: input.status,
+    endpoint: input.endpoint,
+    receipt_id: null,
+    generated_at: null,
+    fresh_until: null,
+    candidate_id: null,
+    dataset_snapshot_ref: null,
+    max_notional: maxNotional,
+    revenue_repair_business_state: revenueRepairBusinessState,
+    revenue_repair_ready: revenueRepairReady,
+    revenue_repair_queue: revenueRepairQueue,
+    observed_contracts: observedContracts,
+    contract_schema_mismatches: contractSchemaMismatches,
+    alpha_readiness_strike_ledger: alphaReadinessStrikeLedger,
+    executable_alpha_repair_receipts: executableAlphaRepairReceipts,
+    alpha_repair_closure_board: alphaRepairClosureBoard,
+    alpha_evidence_foundry: alphaEvidenceFoundry,
+    alpha_readiness_settlement_conveyor: alphaReadinessSettlementConveyor,
+    alpha_repair_dividend_ledger: alphaRepairDividendLedger,
+    alpha_closure_dividend_slo: alphaClosureDividendSlo,
+    no_delta_repair_reentry_auction: noDeltaRepairReentryAuction,
+    reason_codes: [input.reason],
+    message:
+      input.payload && hasRevenueRepairSummary(input.payload)
+        ? `${input.message}; revenue-repair source-of-truth fallback carried business topline`
+        : input.message,
+  }
+}


### PR DESCRIPTION
## Summary

- Added a Torghut `/trading/revenue-repair` source-of-truth fallback when Jangar consumer evidence summary is unavailable or route-missing.
- Kept consumer evidence transport marked degraded while preserving `business_state`, `revenue_ready`, repair queue head, max notional, and settlement conveyor evidence for `/ready`.
- Updated material evidence settlement to classify fallback queue-head topline as `queue_head_inferred` instead of a missing topline.
- Added resolver and `/ready` regressions for the consumer-evidence transport drop case.

## Related Issues

None.

Requirement provenance: NATS `general` runtime objective for `jangar-control-plane` on 2026-05-15.

Design provenance:
- `docs/agents/designs/206-jangar-material-evidence-settlement-spine-and-repair-dispatch-budget-2026-05-14.md`
- `docs/agents/designs/200-jangar-revenue-repair-settlement-conveyor-and-stage-health-custody-2026-05-14.md`

## Testing

- `bun install --frozen-lockfile --ignore-scripts`: pass
- `bunx oxfmt --check services/jangar/src/server/control-plane-torghut-consumer-evidence.ts services/jangar/src/server/control-plane-torghut-revenue-repair-fallback.ts services/jangar/src/server/control-plane-material-evidence-settlement.ts services/jangar/src/server/__tests__/control-plane-torghut-consumer-evidence.test.ts services/jangar/src/routes/ready.test.ts`: pass
- `cd services/jangar && bunx vitest run --config vitest.config.ts src/server/__tests__/control-plane-torghut-consumer-evidence.test.ts -t "source-of-truth topline"`: pass
- `cd services/jangar && bunx vitest run --config vitest.config.ts src/routes/ready.test.ts -t "revenue topline"`: pass
- `cd services/jangar && bunx vitest run --config vitest.config.ts src/server/__tests__/control-plane-torghut-consumer-evidence.test.ts src/routes/ready.test.ts`: pass
- `cd services/jangar && bunx vitest run --config vitest.config.ts`: pass, 1259 tests
- `bun run --filter @proompteng/otel build`: pass
- `bun run --filter @proompteng/temporal-bun-sdk build`: pass
- `bun run --filter @proompteng/jangar tsc`: pass
- `bun run --filter @proompteng/jangar build`: pass
- `bun run --filter @proompteng/jangar docs:inventory:check`: pass
- `bun run --filter @proompteng/jangar check:module-sizes`: pass
- `bun run --filter @proompteng/jangar lint:oxlint`: pass with existing warnings and zero errors
- `bun run --filter @proompteng/jangar lint:oxlint:type`: pass with existing warnings and zero errors
- `git diff --check`: pass
- `git diff -- bun.lock --exit-code`: pass
- Hosted `agents-ci / validate`: pass, 50s
- Hosted `agents-ci / integration`: pass, 11m57s
- Hosted `jangar-ci / lint-and-typecheck / run`: pass, 2m23s
- Hosted `CI / check_changed_files`: pass, 6s
- Hosted `Semantic Commits / Lint commit messages`: pass, 21s
- Hosted `Semantic Pull Request / Validate PR title`: pass, 3s

## Screenshots (if applicable)

N/A. Runtime API behavior only.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.

## Runtime Evidence

Before live Jangar `/ready` sample on 2026-05-15:
- `business_state`: `null`
- `revenue_ready`: `null`
- `repair_queue_len`: `0`
- `top_repair_queue_item`: `null`
- `revenue_custody`: `null`
- `material_evidence_settlement`: `null`

Torghut source-of-truth `/trading/revenue-repair` sample from the same run:
- `business_state`: `repair_only`
- `revenue_ready`: `false`
- `repair_queue_len`: `5`
- top item: `repair_alpha_readiness`
- top item value gate: `routeable_candidate_count`
- `max_notional`: `0`
- `alpha_readiness_settlement_conveyor.status`: `no_delta`

After source-level validation:
- `/ready` preserves `business_state=repair_only`, `revenue_ready=false`, top item `repair_alpha_readiness`, affected value gate `routeable_candidate_count`, and `max_notional=0` when the consumer evidence summary transport is unavailable.
- Material evidence settlement emits `consumer_evidence_status=unavailable`, `revenue_repair_topline_status=queue_head_inferred`, and `topline_inferred_from_queue_head` while avoiding false `business_state_missing` and `revenue_repair_top_item_missing` gaps.

## Risk And Rollback

Risk: fallback topline could hide consumer evidence transport failure. Mitigation: the consumer evidence status and negative evidence remain `unavailable` or `route_missing`; this only carries the revenue-repair source-of-truth topline for readiness truth.

Risk: malformed fallback payload. Mitigation: existing revenue-repair readers normalize fields and contract mismatch helpers still report typed schema debt.

Rollback: revert this PR. That restores the previous behavior where unavailable consumer evidence removes the Jangar `/ready` revenue-repair topline.

Capital safety: unchanged. The fallback keeps `repair_only`, `revenue_ready=false`, and `max_notional=0` visible and does not enable live submission.

## Release Note

Jangar `/ready` now preserves Torghut revenue-repair topline evidence from the source-of-truth endpoint during consumer evidence transport drops. This improves `ready_status_truth` and reduces false failed AgentRun classification while keeping the real transport debt visible for rollout follow-up.
