### PR TITLE
fix(jangar): stabilize torghut evidence ready path

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -17,7 +17,7 @@ controlPlane:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
       JANGAR_TORGHUT_STATUS_URL: http://torghut.torghut.svc.cluster.local/trading/consumer-evidence
-      JANGAR_TORGHUT_STATUS_TIMEOUT_MS: "3000"
+      JANGAR_TORGHUT_STATUS_TIMEOUT_MS: "12000"
       JANGAR_SOURCE_HEAD_SHA: c5e3acea7c9d411a6af4d89ad5f37707a041e181
       JANGAR_GITOPS_REVISION: c5e3acea7c9d411a6af4d89ad5f37707a041e181
       JANGAR_SOURCE_CI_RUN_ID: "25895083407"

--- a/services/jangar/src/server/__tests__/control-plane-torghut-consumer-evidence.test.ts
+++ b/services/jangar/src/server/__tests__/control-plane-torghut-consumer-evidence.test.ts
@@ -422,7 +422,7 @@ describe('control-plane Torghut consumer evidence', () => {
     })
   })
 
-  it('hydrates executable alpha repair receipts from revenue-repair for material reentry', async () => {
+  it('hydrates executable alpha repair receipts from the full consumer-evidence fallback for material reentry', async () => {
     process.env = {
       ...originalEnv,
       JANGAR_TORGHUT_STATUS_URL: 'http://torghut.torghut.svc.cluster.local/trading/consumer-evidence',
@@ -446,7 +446,7 @@ describe('control-plane Torghut consumer evidence', () => {
       )
       .mockResolvedValueOnce(
         buildJsonResponse({
-          schema_version: 'torghut.revenue-repair-digest.v1',
+          schema_version: 'torghut.consumer-evidence-status.v1',
           business_state: 'repair_only',
           revenue_ready: false,
           repair_queue: [
@@ -518,11 +518,6 @@ describe('control-plane Torghut consumer evidence', () => {
             },
             receipts: [],
           },
-        }),
-      )
-      .mockResolvedValueOnce(
-        buildJsonResponse({
-          schema_version: 'torghut.consumer-evidence-status.v1',
           route_warrant_exchange: {
             schema_version: 'torghut.route-warrant-exchange.v1',
             warrant_id: 'route-warrant-exchange:repair',
@@ -536,7 +531,7 @@ describe('control-plane Torghut consumer evidence', () => {
 
     const result = await resolveTorghutConsumerEvidence(new Date('2026-05-14T00:23:10.000Z'))
 
-    expect(globalThis.fetch).toHaveBeenCalledTimes(3)
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2)
     expect(result.status).toMatchObject({
       revenue_repair_business_state: 'repair_only',
       revenue_repair_ready: false,
@@ -591,7 +586,7 @@ describe('control-plane Torghut consumer evidence', () => {
       )
       .mockResolvedValueOnce(
         buildJsonResponse({
-          schema_version: 'torghut.revenue-repair-digest.v1',
+          schema_version: 'torghut.consumer-evidence-status.v1',
           business_state: 'repair_only',
           revenue_ready: false,
           repair_queue: [
@@ -603,11 +598,6 @@ describe('control-plane Torghut consumer evidence', () => {
               max_notional: '0',
             },
           ],
-        }),
-      )
-      .mockResolvedValueOnce(
-        buildJsonResponse({
-          schema_version: 'torghut.consumer-evidence-status.v1',
           route_warrant_exchange: {
             schema_version: 'torghut.route-warrant-exchange.v1',
             warrant_id: 'route-warrant-exchange:full',
@@ -641,11 +631,6 @@ describe('control-plane Torghut consumer evidence', () => {
     )
     expect(globalThis.fetch).toHaveBeenNthCalledWith(
       2,
-      'http://torghut.torghut.svc.cluster.local/trading/revenue-repair',
-      expect.objectContaining({ method: 'GET' }),
-    )
-    expect(globalThis.fetch).toHaveBeenNthCalledWith(
-      3,
       'http://torghut.torghut.svc.cluster.local/trading/consumer-evidence',
       expect.objectContaining({ method: 'GET' }),
     )
@@ -1214,7 +1199,7 @@ describe('control-plane Torghut consumer evidence', () => {
     })
   })
 
-  it('normalizes full alpha-readiness settlement conveyors from the revenue-repair fallback', async () => {
+  it('normalizes full alpha-readiness settlement conveyors from the full consumer-evidence fallback', async () => {
     process.env = {
       ...originalEnv,
       JANGAR_TORGHUT_STATUS_URL: 'http://torghut.torghut.svc.cluster.local/trading/consumer-evidence',
@@ -1238,6 +1223,7 @@ describe('control-plane Torghut consumer evidence', () => {
       )
       .mockResolvedValueOnce(
         buildJsonResponse({
+          schema_version: 'torghut.consumer-evidence-status.v1',
           business_state: 'repair_only',
           revenue_ready: false,
           repair_queue: [
@@ -1273,11 +1259,6 @@ describe('control-plane Torghut consumer evidence', () => {
             capital_rule: 'zero_notional_repair_only',
             rollback_target: 'stop emitting alpha_readiness_settlement_conveyor and keep Torghut max_notional=0',
           },
-        }),
-      )
-      .mockResolvedValueOnce(
-        buildJsonResponse({
-          schema_version: 'torghut.consumer-evidence-status.v1',
           route_warrant_exchange: {
             schema_version: 'torghut.route-warrant-exchange.v1',
             warrant_id: 'route-warrant-exchange:settlement-conveyor',
@@ -1292,12 +1273,11 @@ describe('control-plane Torghut consumer evidence', () => {
 
     const result = await resolveTorghutConsumerEvidence(new Date('2026-05-14T09:15:10.000Z'))
 
-    expect(fetchMock).toHaveBeenCalledTimes(3)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
     expect(String(fetchMock.mock.calls[0]?.[0])).toBe(
       'http://torghut.torghut.svc.cluster.local/trading/consumer-evidence?view=summary',
     )
-    expect(String(fetchMock.mock.calls[1]?.[0])).toBe('http://torghut.torghut.svc.cluster.local/trading/revenue-repair')
-    expect(String(fetchMock.mock.calls[2]?.[0])).toBe(
+    expect(String(fetchMock.mock.calls[1]?.[0])).toBe(
       'http://torghut.torghut.svc.cluster.local/trading/consumer-evidence',
     )
     expect(result.status.observed_contracts).toEqual(expect.arrayContaining(['alpha_readiness_settlement_conveyor']))

--- a/services/jangar/src/server/control-plane-torghut-consumer-evidence.ts
+++ b/services/jangar/src/server/control-plane-torghut-consumer-evidence.ts
@@ -199,10 +199,23 @@ export const resolveTorghutConsumerEvidence = async (now = new Date()): Promise<
   }
 
   const payload = routeResult.payload ?? {}
-  const inlineAlphaReadinessStrikeLedger = readAlphaReadinessStrikeLedger(payload)
-  const inlineExecutableAlphaRepairReceipts = readExecutableAlphaRepairReceipts(payload)
+  const fullConsumerEvidenceResult =
+    compactEndpoint !== endpoint &&
+    (!hasRouteWarrantPayload(payload) ||
+      !hasRevenueRepairSummary(payload) ||
+      !readAlphaReadinessSettlementConveyorRef(payload))
+      ? await requestJson(endpoint, config.torghutStatusTimeoutMs)
+      : null
+  const fullConsumerEvidencePayload =
+    fullConsumerEvidenceResult?.ok && fullConsumerEvidenceResult.payload ? fullConsumerEvidenceResult.payload : null
+  const primaryEvidencePayload = fullConsumerEvidencePayload ?? payload
+  const inlineAlphaReadinessStrikeLedger =
+    readAlphaReadinessStrikeLedger(primaryEvidencePayload) ?? readAlphaReadinessStrikeLedger(payload)
+  const inlineExecutableAlphaRepairReceipts =
+    readExecutableAlphaRepairReceipts(primaryEvidencePayload) ?? readExecutableAlphaRepairReceipts(payload)
   const revenueRepairEndpoint = deriveRevenueRepairEndpoint(endpoint)
   const revenueRepairResult =
+    !fullConsumerEvidencePayload &&
     revenueRepairEndpoint &&
     revenueRepairEndpoint !== endpoint &&
     (!hasRevenueRepairSummary(payload) || !inlineAlphaReadinessStrikeLedger || !inlineExecutableAlphaRepairReceipts)
@@ -212,27 +225,37 @@ export const resolveTorghutConsumerEvidence = async (now = new Date()): Promise<
     inlineAlphaReadinessStrikeLedger ?? readAlphaReadinessStrikeLedger(revenueRepairResult?.payload ?? null)
   const executableAlphaRepairReceipts =
     inlineExecutableAlphaRepairReceipts ?? readExecutableAlphaRepairReceipts(revenueRepairResult?.payload ?? null)
-  const revenueRepairPayload = hasRevenueRepairSummary(payload) ? payload : (revenueRepairResult?.payload ?? null)
+  const revenueRepairPayload = hasRevenueRepairSummary(primaryEvidencePayload)
+    ? primaryEvidencePayload
+    : (revenueRepairResult?.payload ?? null)
   const revenueRepairBusinessState = normalizeReason(revenueRepairPayload?.business_state)
   const revenueRepairReady = normalizeRevenueRepairBoolean(revenueRepairPayload?.revenue_ready)
   const revenueRepairQueue = readRevenueRepairQueue(revenueRepairPayload)
-  const fullConsumerEvidenceResult =
-    compactEndpoint !== endpoint && !hasRouteWarrantPayload(payload) && !hasRouteWarrantPayload(revenueRepairPayload)
-      ? await requestJson(endpoint, config.torghutStatusTimeoutMs)
-      : null
-  const sourceServingContractPayload =
-    fullConsumerEvidenceResult?.ok && fullConsumerEvidenceResult.payload ? fullConsumerEvidenceResult.payload : payload
+  const sourceServingContractPayload = fullConsumerEvidencePayload ?? payload
   const alphaRepairClosureBoard =
-    readAlphaRepairClosureBoard(payload) ?? readAlphaRepairClosureBoard(revenueRepairPayload)
-  const alphaEvidenceFoundry = readAlphaEvidenceFoundry(payload) ?? readAlphaEvidenceFoundry(revenueRepairPayload)
+    readAlphaRepairClosureBoard(primaryEvidencePayload) ??
+    readAlphaRepairClosureBoard(payload) ??
+    readAlphaRepairClosureBoard(revenueRepairPayload)
+  const alphaEvidenceFoundry =
+    readAlphaEvidenceFoundry(primaryEvidencePayload) ??
+    readAlphaEvidenceFoundry(payload) ??
+    readAlphaEvidenceFoundry(revenueRepairPayload)
   const alphaReadinessSettlementConveyor =
-    readAlphaReadinessSettlementConveyorRef(payload) ?? readAlphaReadinessSettlementConveyorRef(revenueRepairPayload)
+    readAlphaReadinessSettlementConveyorRef(primaryEvidencePayload) ??
+    readAlphaReadinessSettlementConveyorRef(payload) ??
+    readAlphaReadinessSettlementConveyorRef(revenueRepairPayload)
   const alphaRepairDividendLedger =
-    readAlphaRepairDividendLedgerRef(payload) ?? readAlphaRepairDividendLedgerRef(revenueRepairPayload)
+    readAlphaRepairDividendLedgerRef(primaryEvidencePayload) ??
+    readAlphaRepairDividendLedgerRef(payload) ??
+    readAlphaRepairDividendLedgerRef(revenueRepairPayload)
   const alphaClosureDividendSlo =
-    readAlphaClosureDividendSlo(payload) ?? readAlphaClosureDividendSlo(revenueRepairPayload)
+    readAlphaClosureDividendSlo(primaryEvidencePayload) ??
+    readAlphaClosureDividendSlo(payload) ??
+    readAlphaClosureDividendSlo(revenueRepairPayload)
   const noDeltaRepairReentryAuction =
-    readNoDeltaRepairReentryAuctionRef(payload) ?? readNoDeltaRepairReentryAuctionRef(revenueRepairPayload)
+    readNoDeltaRepairReentryAuctionRef(primaryEvidencePayload) ??
+    readNoDeltaRepairReentryAuctionRef(payload) ??
+    readNoDeltaRepairReentryAuctionRef(revenueRepairPayload)
   const payloadSchema = normalizeNonEmpty(payload.schema_version)
   if (payloadSchema && payloadSchema !== CONSUMER_EVIDENCE_STATUS_SCHEMA_VERSION) {
     return {
@@ -344,7 +367,7 @@ export const resolveTorghutConsumerEvidence = async (now = new Date()): Promise<
   const liveReadinessState = normalizeNonEmpty(receipt.live_readiness_state)
   const readyzStatusCode = normalizeNonEmpty(asRecord(payload.readiness)?.status_code)
   const marketContext = readMarketContext(payload)
-  const cohortLedger = asRecord(payload.capital_reentry_cohort_ledger)
+  const cohortLedger = asRecord(primaryEvidencePayload.capital_reentry_cohort_ledger)
   const cohortRows = Array.isArray(cohortLedger?.cohorts)
     ? cohortLedger.cohorts
         .map((cohort) => asRecord(cohort))
@@ -357,7 +380,7 @@ export const resolveTorghutConsumerEvidence = async (now = new Date()): Promise<
   ])
   const capitalReentryAggregateState = normalizeNonEmpty(cohortLedger?.aggregate_state)
   const capitalReentryLedgerId = normalizeNonEmpty(cohortLedger?.ledger_id)
-  const profitRepairLedger = asRecord(payload.profit_repair_settlement_ledger)
+  const profitRepairLedger = asRecord(primaryEvidencePayload.profit_repair_settlement_ledger)
   const profitRepairLots = Array.isArray(profitRepairLedger?.repair_lots)
     ? profitRepairLedger.repair_lots
         .map((lot) => asRecord(lot))
@@ -370,7 +393,7 @@ export const resolveTorghutConsumerEvidence = async (now = new Date()): Promise<
   ])
   const profitRepairAggregateState = normalizeNonEmpty(profitRepairLedger?.aggregate_state)
   const profitRepairLedgerId = normalizeNonEmpty(profitRepairLedger?.ledger_id)
-  const routeabilityLedger = asRecord(payload.routeability_repair_acceptance_ledger)
+  const routeabilityLedger = asRecord(primaryEvidencePayload.routeability_repair_acceptance_ledger)
   const routeabilityLots = Array.isArray(routeabilityLedger?.lots)
     ? routeabilityLedger.lots.map((lot) => asRecord(lot)).filter((lot): lot is Record<string, unknown> => Boolean(lot))
     : []
@@ -384,7 +407,7 @@ export const resolveTorghutConsumerEvidence = async (now = new Date()): Promise<
   const acceptedRouteableCandidateCount = parseNumber(
     normalizeNonEmpty(routeabilityLedger?.accepted_routeable_candidate_count),
   )
-  const profitFreshnessFrontier = asRecord(payload.profit_freshness_frontier)
+  const profitFreshnessFrontier = asRecord(primaryEvidencePayload.profit_freshness_frontier)
   const profitFreshnessLots = Array.isArray(profitFreshnessFrontier?.repair_lots)
     ? profitFreshnessFrontier.repair_lots
         .map((lot) => asRecord(lot))
@@ -407,7 +430,7 @@ export const resolveTorghutConsumerEvidence = async (now = new Date()): Promise<
     profitFreshnessFrontier?.frontier_state ?? profitFreshnessFrontier?.aggregate_state,
   )
   const profitFreshnessFrontierId = normalizeNonEmpty(profitFreshnessFrontier?.frontier_id)
-  const evidenceClockArbiter = asRecord(payload.evidence_clock_arbiter)
+  const evidenceClockArbiter = asRecord(primaryEvidencePayload.evidence_clock_arbiter)
   const evidenceClockSplits = Array.isArray(evidenceClockArbiter?.clock_splits)
     ? evidenceClockArbiter.clock_splits
         .map((split) => asRecord(split))
@@ -444,7 +467,7 @@ export const resolveTorghutConsumerEvidence = async (now = new Date()): Promise<
       : []),
     ...(evidenceClockCustodyStatus === 'blocked' ? [`evidence_clock_custody_${custodyDecision ?? 'blocked'}`] : []),
   ])
-  const routeableExchange = asRecord(payload.routeable_profit_candidate_exchange)
+  const routeableExchange = asRecord(primaryEvidencePayload.routeable_profit_candidate_exchange)
   const routeableExchangeSummary = asRecord(routeableExchange?.summary)
   const zeroNotionalRepairLots = Array.isArray(routeableExchange?.zero_notional_repair_lots)
     ? routeableExchange.zero_notional_repair_lots
@@ -473,20 +496,20 @@ export const resolveTorghutConsumerEvidence = async (now = new Date()): Promise<
     sourceServingContractPayload.route_warrant_exchange ??
       sourceServingContractPayload.route_warrant_exchange_v1 ??
       sourceServingContractPayload.route_warrant ??
-      payload.route_warrant_exchange ??
-      payload.route_warrant_exchange_v1 ??
-      payload.route_warrant,
+      primaryEvidencePayload.route_warrant_exchange ??
+      primaryEvidencePayload.route_warrant_exchange_v1 ??
+      primaryEvidencePayload.route_warrant,
   )
   const repairBidSettlement =
     asRecord(sourceServingContractPayload.repair_bid_settlement_ledger) ??
-    asRecord(payload.repair_bid_settlement_ledger) ??
+    asRecord(primaryEvidencePayload.repair_bid_settlement_ledger) ??
     asRecord(revenueRepairPayload?.repair_bid_settlement_ledger)
-  const repairOutcome = readTorghutRepairOutcomeEvidence(payload)
+  const repairOutcome = readTorghutRepairOutcomeEvidence(primaryEvidencePayload)
   const sourceServingRepairReceiptLedger =
     asRecord(sourceServingContractPayload.source_serving_repair_receipt_ledger) ??
-    asRecord(payload.source_serving_repair_receipt_ledger) ??
+    asRecord(primaryEvidencePayload.source_serving_repair_receipt_ledger) ??
     asRecord(revenueRepairPayload?.source_serving_repair_receipt_ledger)
-  const freshnessCarry = readTorghutFreshnessCarryEvidence(payload)
+  const freshnessCarry = readTorghutFreshnessCarryEvidence(primaryEvidencePayload)
   const reasonCodes = uniqueStrings([...receiptReasonCodes, ...freshnessCarry.reasonCodes])
   const observedContracts = uniqueStrings([
     routeWarrant ? 'route_warrant_exchange' : null,
@@ -519,10 +542,10 @@ export const resolveTorghutConsumerEvidence = async (now = new Date()): Promise<
       : null,
     repairOutcome.contractSchemaMismatch,
     freshnessCarry.contractSchemaMismatch,
-    alphaReadinessSettlementConveyorRefSchemaMismatch(payload),
-    alphaRepairDividendLedgerRefSchemaMismatch(payload),
-    alphaClosureDividendSloSchemaMismatch(payload),
-    noDeltaRepairReentryAuctionRefSchemaMismatch(payload),
+    alphaReadinessSettlementConveyorRefSchemaMismatch(primaryEvidencePayload),
+    alphaRepairDividendLedgerRefSchemaMismatch(primaryEvidencePayload),
+    alphaClosureDividendSloSchemaMismatch(primaryEvidencePayload),
+    noDeltaRepairReentryAuctionRefSchemaMismatch(primaryEvidencePayload),
   ])
   const routeWarrantId = normalizeNonEmpty(routeWarrant?.warrant_id ?? routeWarrant?.exchange_id)
   const routeWarrantRepairPackets = Array.isArray(routeWarrant?.repair_packets)


### PR DESCRIPTION
## Summary

- Stabilizes Jangar Torghut evidence hydration by fetching the full non-recursive consumer-evidence payload directly when the compact summary omits business, conveyor, or source-serving contracts.
- Preserves compact summary evidence while merging fallback payloads, so a partial fallback cannot erase an already-present settlement conveyor ref.
- Raises the deployed Torghut evidence timeout from 3s to 12s, aligning the live override with the documented Jangar default envelope for the current Torghut route latency.

## Related Issues

None

## Testing

- `bun test services/jangar/src/server/__tests__/control-plane-torghut-consumer-evidence.test.ts`
- `bunx vitest run --config vitest.config.ts src/routes/ready.test.ts -t "projects Torghut revenue-repair business evidence"` from `services/jangar`
- `bun run --filter @proompteng/jangar tsc`
- `bun run --filter @proompteng/jangar lint`
- `bunx oxfmt --check services/jangar/src/server/control-plane-torghut-consumer-evidence.ts services/jangar/src/server/__tests__/control-plane-torghut-consumer-evidence.test.ts argocd/applications/agents/values.yaml`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
