### PR TITLE
chore(jangar): promote image 1f5a08e8

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: c5e3acea
-  digest: sha256:d93a0c069db0e20ebaddec4752c43e52d5475e8e6f1911cc0b9d4ec8f5247dff
+  tag: 1f5a08e8
+  digest: sha256:618adc50ce0541e4b2c103da29805be0ea6cd16c352a828afff5585c6f74af63
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,25 +11,25 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: c5e3acea
-    digest: sha256:b184f0d405f0f900c403e2ebe2070b08f9959dcff1854e7f55c0daca5039c794
+    tag: 1f5a08e8
+    digest: sha256:1c4b8db3edff8dc131e651d35443221de63e02cfc1afcdf89d5ff28bdd53fe3d
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
       JANGAR_TORGHUT_STATUS_URL: http://torghut.torghut.svc.cluster.local/trading/consumer-evidence
       JANGAR_TORGHUT_STATUS_TIMEOUT_MS: "12000"
-      JANGAR_SOURCE_HEAD_SHA: c5e3acea7c9d411a6af4d89ad5f37707a041e181
-      JANGAR_GITOPS_REVISION: c5e3acea7c9d411a6af4d89ad5f37707a041e181
-      JANGAR_SOURCE_CI_RUN_ID: "25895083407"
+      JANGAR_SOURCE_HEAD_SHA: 1f5a08e85a6cc2d1192674234ff8fa88ef32a5f3
+      JANGAR_GITOPS_REVISION: 1f5a08e85a6cc2d1192674234ff8fa88ef32a5f3
+      JANGAR_SOURCE_CI_RUN_ID: "25896889670"
       JANGAR_SOURCE_CI_CONCLUSION: success
-      JANGAR_MANIFEST_IMAGE_DIGEST: sha256:b184f0d405f0f900c403e2ebe2070b08f9959dcff1854e7f55c0daca5039c794
-      JANGAR_SERVING_BUILD_COMMIT: c5e3acea7c9d411a6af4d89ad5f37707a041e181
-      JANGAR_SERVING_IMAGE_DIGEST: sha256:b184f0d405f0f900c403e2ebe2070b08f9959dcff1854e7f55c0daca5039c794
+      JANGAR_MANIFEST_IMAGE_DIGEST: sha256:1c4b8db3edff8dc131e651d35443221de63e02cfc1afcdf89d5ff28bdd53fe3d
+      JANGAR_SERVING_BUILD_COMMIT: 1f5a08e85a6cc2d1192674234ff8fa88ef32a5f3
+      JANGAR_SERVING_IMAGE_DIGEST: sha256:1c4b8db3edff8dc131e651d35443221de63e02cfc1afcdf89d5ff28bdd53fe3d
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: c5e3acea
-    digest: sha256:d93a0c069db0e20ebaddec4752c43e52d5475e8e6f1911cc0b9d4ec8f5247dff
+    tag: 1f5a08e8
+    digest: sha256:618adc50ce0541e4b2c103da29805be0ea6cd16c352a828afff5585c6f74af63
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-15T01:24:14Z
+    deploy.knative.dev/rollout: 2026-05-15T02:26:37Z
 spec:
   replicas: 1
   strategy:
@@ -57,11 +57,11 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_RUNTIME_IMAGE
-              value: registry.ide-newton.ts.net/lab/jangar:c5e3acea@sha256:d93a0c069db0e20ebaddec4752c43e52d5475e8e6f1911cc0b9d4ec8f5247dff
+              value: registry.ide-newton.ts.net/lab/jangar:1f5a08e8@sha256:618adc50ce0541e4b2c103da29805be0ea6cd16c352a828afff5585c6f74af63
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: c5e3acea7c9d411a6af4d89ad5f37707a041e181
+              value: 1f5a08e85a6cc2d1192674234ff8fa88ef32a5f3
             - name: JANGAR_GITOPS_REVISION
-              value: c5e3acea7c9d411a6af4d89ad5f37707a041e181
+              value: 1f5a08e85a6cc2d1192674234ff8fa88ef32a5f3
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_CONTROL_PLANE_STATUS_CACHE_TTL_MS
@@ -405,15 +405,15 @@ spec:
             - name: OPENAI_EMBEDDING_TIMEOUT_MS
               value: "60000"
             - name: JANGAR_SOURCE_CI_RUN_ID
-              value: "25895083407"
+              value: "25896889670"
             - name: JANGAR_SOURCE_CI_CONCLUSION
               value: success
             - name: JANGAR_MANIFEST_IMAGE_DIGEST
-              value: sha256:b184f0d405f0f900c403e2ebe2070b08f9959dcff1854e7f55c0daca5039c794
+              value: sha256:1c4b8db3edff8dc131e651d35443221de63e02cfc1afcdf89d5ff28bdd53fe3d
             - name: JANGAR_SERVING_BUILD_COMMIT
-              value: c5e3acea7c9d411a6af4d89ad5f37707a041e181
+              value: 1f5a08e85a6cc2d1192674234ff8fa88ef32a5f3
             - name: JANGAR_SERVING_IMAGE_DIGEST
-              value: sha256:b184f0d405f0f900c403e2ebe2070b08f9959dcff1854e7f55c0daca5039c794
+              value: sha256:1c4b8db3edff8dc131e651d35443221de63e02cfc1afcdf89d5ff28bdd53fe3d
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -59,5 +59,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: c5e3acea
-    digest: sha256:d93a0c069db0e20ebaddec4752c43e52d5475e8e6f1911cc0b9d4ec8f5247dff
+    newTag: 1f5a08e8
+    digest: sha256:618adc50ce0541e4b2c103da29805be0ea6cd16c352a828afff5585c6f74af63


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `1f5a08e85a6cc2d1192674234ff8fa88ef32a5f3`
- Image tag: `1f5a08e8`
- Image digest: `sha256:618adc50ce0541e4b2c103da29805be0ea6cd16c352a828afff5585c6f74af63`
- Source CI run: `25896889670`
- Control-plane serving digest: `sha256:1c4b8db3edff8dc131e651d35443221de63e02cfc1afcdf89d5ff28bdd53fe3d`
- Updated API rollout annotation
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`
- Published source-serving proof env for revenue repair custody gates