### PR TITLE
fix(forgejo-runners): preserve dind entrypoint

### DIFF
--- a/argocd/applications/forgejo-runners/statefulset-forgejo-runners-amd64.yaml
+++ b/argocd/applications/forgejo-runners/statefulset-forgejo-runners-amd64.yaml
@@ -123,7 +123,7 @@ spec:
           env:
             - name: DOCKER_TLS_CERTDIR
               value: ''
-          command:
+          args:
             - dockerd
             - --host=unix:///var/run/docker.sock
             - --storage-driver=overlay2

--- a/argocd/applications/forgejo-runners/statefulset-forgejo-runners-arm64.yaml
+++ b/argocd/applications/forgejo-runners/statefulset-forgejo-runners-arm64.yaml
@@ -123,7 +123,7 @@ spec:
           env:
             - name: DOCKER_TLS_CERTDIR
               value: ''
-          command:
+          args:
             - dockerd
             - --host=unix:///var/run/docker.sock
             - --storage-driver=overlay2


### PR DESCRIPTION
## Summary

- Preserve the `docker:27.5.1-dind` image entrypoint for both Forgejo runner shards.
- Pass the existing `dockerd` startup flags as container args instead of overriding the entrypoint.
- Ensure DinD startup runs the image cleanup path that removes stale Docker PID files before launching the daemon.

## Related Issues

None

## Testing

- `git diff --check -- argocd/applications/forgejo-runners/statefulset-forgejo-runners-amd64.yaml argocd/applications/forgejo-runners/statefulset-forgejo-runners-arm64.yaml`
- `kubectl kustomize argocd/applications/forgejo-runners`
- `bun run lint:argocd`
- Live rollout: patched both `forgejo-runners` StatefulSets, force-removed already-terminated old pods, and verified both new pods are `2/2 Running`.
- Live logs: verified both DinD containers reached `API listen on /var/run/docker.sock` and both Forgejo runners declared their expected labels.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
