### PR TITLE
fix(jangar): accept torghut repair queue topline

### DIFF
--- a/services/jangar/src/server/__tests__/control-plane-torghut-consumer-evidence.test.ts
+++ b/services/jangar/src/server/__tests__/control-plane-torghut-consumer-evidence.test.ts
@@ -1226,13 +1226,11 @@ describe('control-plane Torghut consumer evidence', () => {
           schema_version: 'torghut.consumer-evidence-status.v1',
           business_state: 'repair_only',
           revenue_ready: false,
-          repair_queue: [
-            {
-              code: 'repair_alpha_readiness',
-              reason: 'alpha_readiness_not_promotion_eligible',
-              value_gate: 'routeable_candidate_count',
-            },
-          ],
+          top_repair_queue_item: {
+            code: 'repair_alpha_readiness',
+            reason: 'alpha_readiness_not_promotion_eligible',
+            value_gate: 'routeable_candidate_count',
+          },
           alpha_readiness_settlement_conveyor: {
             schema_version: 'torghut.alpha-readiness-settlement-conveyor.v1',
             conveyor_id: 'alpha-readiness-settlement-conveyor:full',
@@ -1281,6 +1279,11 @@ describe('control-plane Torghut consumer evidence', () => {
       'http://torghut.torghut.svc.cluster.local/trading/consumer-evidence',
     )
     expect(result.status.observed_contracts).toEqual(expect.arrayContaining(['alpha_readiness_settlement_conveyor']))
+    expect(result.status.revenue_repair_queue?.[0]).toMatchObject({
+      code: 'repair_alpha_readiness',
+      reason: 'alpha_readiness_not_promotion_eligible',
+      value_gate: 'routeable_candidate_count',
+    })
     expect(result.status.contract_schema_mismatches).not.toEqual(
       expect.arrayContaining(['alpha_readiness_settlement_conveyor:torghut.alpha-readiness-settlement-conveyor.v1']),
     )

--- a/services/jangar/src/server/control-plane-torghut-revenue-repair.ts
+++ b/services/jangar/src/server/control-plane-torghut-revenue-repair.ts
@@ -19,7 +19,8 @@ export const normalizeRevenueRepairBoolean = (value: unknown): boolean | null =>
 export const hasRevenueRepairSummary = (payload: Record<string, unknown>) =>
   normalizeNonEmpty(payload.business_state) !== null ||
   normalizeRevenueRepairBoolean(payload.revenue_ready) !== null ||
-  Array.isArray(payload.repair_queue)
+  Array.isArray(payload.repair_queue) ||
+  asRecord(payload.top_repair_queue_item) !== null
 
 const readRevenueRepairQueueItem = (rawItem: unknown): TorghutRevenueRepairQueueItem | null => {
   const item = asRecord(rawItem)
@@ -46,8 +47,13 @@ const readRevenueRepairQueueItem = (rawItem: unknown): TorghutRevenueRepairQueue
 }
 
 export const readRevenueRepairQueue = (payload: Record<string, unknown> | null): TorghutRevenueRepairQueueItem[] => {
-  if (!payload || !Array.isArray(payload.repair_queue)) return []
-  return payload.repair_queue
-    .map(readRevenueRepairQueueItem)
-    .filter((item): item is TorghutRevenueRepairQueueItem => Boolean(item))
+  if (!payload) return []
+  const repairQueue = Array.isArray(payload.repair_queue)
+    ? payload.repair_queue
+        .map(readRevenueRepairQueueItem)
+        .filter((item): item is TorghutRevenueRepairQueueItem => Boolean(item))
+    : []
+  if (repairQueue.length > 0) return repairQueue
+  const topItem = readRevenueRepairQueueItem(payload.top_repair_queue_item)
+  return topItem ? [topItem] : []
 }


### PR DESCRIPTION
## Summary

- Accept Torghut `top_repair_queue_item` as the Jangar revenue-repair queue head when `repair_queue` is not emitted.
- Treat `top_repair_queue_item` as revenue-repair summary evidence so compact/full consumer-evidence payloads do not lose the repair lane.
- Add regression coverage for full consumer-evidence fallback payloads that publish the topline item without the queue array.

## Related Issues

None

## Testing

- `bun test services/jangar/src/server/__tests__/control-plane-torghut-consumer-evidence.test.ts`
- `bunx vitest run --config vitest.config.ts src/routes/ready.test.ts -t "projects Torghut revenue-repair business evidence"` from `services/jangar`
- `bun run --filter @proompteng/jangar tsc`
- `bun run --filter @proompteng/jangar lint`
- `bunx oxfmt --check services/jangar/src/server/control-plane-torghut-revenue-repair.ts services/jangar/src/server/__tests__/control-plane-torghut-consumer-evidence.test.ts`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
