### PR TITLE
chore(jangar): promote image 8bdb7043

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 6e4f7781
-  digest: sha256:1dd2a70030b16b84d6f91b41cf85db7690189cad8e4d630361e98b7252ba6445
+  tag: 8bdb7043
+  digest: sha256:980fc07b0ecb972383464e5c0f8102dd38c9ef5b058d47d5bdcc74ee91778204
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,25 +11,25 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 6e4f7781
-    digest: sha256:823dc66de05be65719d728fa77b967046a27c402e2e9b14162ba35bc762ba5e8
+    tag: 8bdb7043
+    digest: sha256:d8c0766059bd1b4ef2cbc79dd278e3c34d43ec3da7033e76427bdc36dbaafa2d
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
       JANGAR_TORGHUT_STATUS_URL: http://torghut.torghut.svc.cluster.local/trading/consumer-evidence
       JANGAR_TORGHUT_STATUS_TIMEOUT_MS: "12000"
-      JANGAR_SOURCE_HEAD_SHA: 6e4f778103c86751ac10af9d1812c5f48a10e20a
-      JANGAR_GITOPS_REVISION: 6e4f778103c86751ac10af9d1812c5f48a10e20a
-      JANGAR_SOURCE_CI_RUN_ID: "25897885296"
+      JANGAR_SOURCE_HEAD_SHA: 8bdb704321fa3448ee93b5b4e377cdb6c21e9025
+      JANGAR_GITOPS_REVISION: 8bdb704321fa3448ee93b5b4e377cdb6c21e9025
+      JANGAR_SOURCE_CI_RUN_ID: "25899327929"
       JANGAR_SOURCE_CI_CONCLUSION: success
-      JANGAR_MANIFEST_IMAGE_DIGEST: sha256:823dc66de05be65719d728fa77b967046a27c402e2e9b14162ba35bc762ba5e8
-      JANGAR_SERVING_BUILD_COMMIT: 6e4f778103c86751ac10af9d1812c5f48a10e20a
-      JANGAR_SERVING_IMAGE_DIGEST: sha256:823dc66de05be65719d728fa77b967046a27c402e2e9b14162ba35bc762ba5e8
+      JANGAR_MANIFEST_IMAGE_DIGEST: sha256:d8c0766059bd1b4ef2cbc79dd278e3c34d43ec3da7033e76427bdc36dbaafa2d
+      JANGAR_SERVING_BUILD_COMMIT: 8bdb704321fa3448ee93b5b4e377cdb6c21e9025
+      JANGAR_SERVING_IMAGE_DIGEST: sha256:d8c0766059bd1b4ef2cbc79dd278e3c34d43ec3da7033e76427bdc36dbaafa2d
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 6e4f7781
-    digest: sha256:1dd2a70030b16b84d6f91b41cf85db7690189cad8e4d630361e98b7252ba6445
+    tag: 8bdb7043
+    digest: sha256:980fc07b0ecb972383464e5c0f8102dd38c9ef5b058d47d5bdcc74ee91778204
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-15T03:04:07Z
+    deploy.knative.dev/rollout: 2026-05-15T03:55:35Z
 spec:
   replicas: 1
   strategy:
@@ -57,11 +57,11 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_RUNTIME_IMAGE
-              value: registry.ide-newton.ts.net/lab/jangar:6e4f7781@sha256:1dd2a70030b16b84d6f91b41cf85db7690189cad8e4d630361e98b7252ba6445
+              value: registry.ide-newton.ts.net/lab/jangar:8bdb7043@sha256:980fc07b0ecb972383464e5c0f8102dd38c9ef5b058d47d5bdcc74ee91778204
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: 6e4f778103c86751ac10af9d1812c5f48a10e20a
+              value: 8bdb704321fa3448ee93b5b4e377cdb6c21e9025
             - name: JANGAR_GITOPS_REVISION
-              value: 6e4f778103c86751ac10af9d1812c5f48a10e20a
+              value: 8bdb704321fa3448ee93b5b4e377cdb6c21e9025
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_CONTROL_PLANE_STATUS_CACHE_TTL_MS
@@ -405,15 +405,15 @@ spec:
             - name: OPENAI_EMBEDDING_TIMEOUT_MS
               value: "60000"
             - name: JANGAR_SOURCE_CI_RUN_ID
-              value: "25897885296"
+              value: "25899327929"
             - name: JANGAR_SOURCE_CI_CONCLUSION
               value: success
             - name: JANGAR_MANIFEST_IMAGE_DIGEST
-              value: sha256:823dc66de05be65719d728fa77b967046a27c402e2e9b14162ba35bc762ba5e8
+              value: sha256:d8c0766059bd1b4ef2cbc79dd278e3c34d43ec3da7033e76427bdc36dbaafa2d
             - name: JANGAR_SERVING_BUILD_COMMIT
-              value: 6e4f778103c86751ac10af9d1812c5f48a10e20a
+              value: 8bdb704321fa3448ee93b5b4e377cdb6c21e9025
             - name: JANGAR_SERVING_IMAGE_DIGEST
-              value: sha256:823dc66de05be65719d728fa77b967046a27c402e2e9b14162ba35bc762ba5e8
+              value: sha256:d8c0766059bd1b4ef2cbc79dd278e3c34d43ec3da7033e76427bdc36dbaafa2d
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -59,5 +59,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: 6e4f7781
-    digest: sha256:1dd2a70030b16b84d6f91b41cf85db7690189cad8e4d630361e98b7252ba6445
+    newTag: 8bdb7043
+    digest: sha256:980fc07b0ecb972383464e5c0f8102dd38c9ef5b058d47d5bdcc74ee91778204


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `8bdb704321fa3448ee93b5b4e377cdb6c21e9025`
- Image tag: `8bdb7043`
- Image digest: `sha256:980fc07b0ecb972383464e5c0f8102dd38c9ef5b058d47d5bdcc74ee91778204`
- Source CI run: `25899327929`
- Control-plane serving digest: `sha256:d8c0766059bd1b4ef2cbc79dd278e3c34d43ec3da7033e76427bdc36dbaafa2d`
- Updated API rollout annotation
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`
- Published source-serving proof env for revenue repair custody gates