### PR TITLE
test(temporal-bun-sdk): clean up integration workflow leaks

### DIFF
--- a/.github/workflows/temporal-bun-sdk.yml
+++ b/.github/workflows/temporal-bun-sdk.yml
@@ -107,6 +107,11 @@ jobs:
             exit 1
           fi
 
+      - name: Clean stale Temporal Bun SDK integration workflows
+        run: |
+          bun packages/temporal-bun-sdk/scripts/cleanup-integration-workflows.ts --terminate \
+            --reason "pre-test cleanup for GitHub Actions run ${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+
       - name: Run Oxfmt check (temporal-bun-sdk)
         run: bunx oxfmt --check packages/temporal-bun-sdk/src packages/temporal-bun-sdk/tests packages/temporal-bun-sdk/scripts packages/temporal-bun-sdk/docs
 
@@ -126,6 +131,9 @@ jobs:
         run: |
           cd packages/temporal-bun-sdk
           TEMPORAL_TEST_SERVER=1 bun test --timeout=30000 --max-concurrency=1
+
+      - name: Verify Temporal Bun SDK integration cleanup
+        run: bun packages/temporal-bun-sdk/scripts/cleanup-integration-workflows.ts --verify
 
       - name: Verify replay corpus
         run: bun run --filter @proompteng/temporal-bun-sdk verify:replay-corpus
@@ -155,6 +163,9 @@ jobs:
             --workflow-concurrency 50 \
             --activity-concurrency 80 \
             --failure-modes "${TEMPORAL_SOAK_FAILURE_MODES}"
+
+      - name: Verify Temporal Bun SDK load cleanup
+        run: bun packages/temporal-bun-sdk/scripts/cleanup-integration-workflows.ts --verify
 
       - name: Verify production package boundary
         run: bun run --filter @proompteng/temporal-bun-sdk verify:production

--- a/packages/temporal-bun-sdk/scripts/cleanup-integration-workflows.ts
+++ b/packages/temporal-bun-sdk/scripts/cleanup-integration-workflows.ts
@@ -1,0 +1,161 @@
+const workflowTypes = [
+  'integrationTimerWorkflow',
+  'integrationActivityWorkflow',
+  'integrationChildWorkflow',
+  'integrationParentWorkflow',
+  'integrationContinueAsNewWorkflow',
+  'integrationHeartbeatWorkflow',
+  'integrationHeartbeatTimeoutWorkflow',
+  'integrationRetryProbeWorkflow',
+  'integrationMetadataWorkflow',
+  'integrationTimerCancellationWorkflow',
+  'integrationWorkflowTaskFailureWorkflow',
+  'integrationSignalQueryWorkflow',
+  'integrationQueryOnlyWorkflow',
+  'integrationUpdateWorkflow',
+  'concurrencyWorkflow',
+  'stickyMetadataWorkflow',
+  'stickyArgsWorkflow',
+  'codecPayloadWorkflow',
+  'workerLoadCpuWorkflow',
+  'workerLoadActivityWorkflow',
+  'workerLoadUpdateWorkflow',
+] as const
+
+type Mode = 'verify' | 'terminate'
+
+const args = new Set(process.argv.slice(2))
+const mode: Mode = args.has('--terminate') ? 'terminate' : 'verify'
+const address = process.env.TEMPORAL_ADDRESS ?? '127.0.0.1:7233'
+const namespace = process.env.TEMPORAL_NAMESPACE ?? 'default'
+const temporal = process.env.TEMPORAL_CLI_PATH ?? 'temporal'
+const reason = readArg('--reason') ?? 'temporal-bun-sdk integration cleanup'
+const terminateRps = process.env.TEMPORAL_CLEANUP_RPS ?? '5'
+const maxAttempts = normalizePositiveInteger(process.env.TEMPORAL_CLEANUP_MAX_ATTEMPTS, 8)
+const retryDelayMs = normalizePositiveInteger(process.env.TEMPORAL_CLEANUP_RETRY_MS, 1_000)
+
+let leaked = false
+
+for (const workflowType of workflowTypes) {
+  const query = `WorkflowType="${workflowType}" and ExecutionStatus="Running"`
+  const before = await count(query)
+  if (before === 0) {
+    continue
+  }
+
+  leaked = true
+  console.warn(`[temporal-bun-sdk] ${workflowType} has ${before} running workflow(s)`)
+  await list(query)
+
+  if (mode === 'terminate') {
+    await terminate(query)
+    const after = await count(query)
+    if (after > 0) {
+      throw new Error(`${workflowType} still has ${after} running workflow(s) after cleanup`)
+    }
+  }
+}
+
+if (leaked && mode === 'verify') {
+  throw new Error('Temporal Bun SDK integration workflows leaked after test cleanup')
+}
+
+if (!leaked) {
+  console.info('[temporal-bun-sdk] no running integration workflow leaks found')
+}
+
+function readArg(name: string): string | undefined {
+  const rawArgs = process.argv.slice(2)
+  const index = rawArgs.indexOf(name)
+  if (index >= 0) {
+    return rawArgs[index + 1]
+  }
+  return undefined
+}
+
+async function count(query: string): Promise<number> {
+  const output = await temporalCli(['workflow', 'count', '--namespace', namespace, '--query', query])
+  const match = /Total:\s*(\d+)/i.exec(output.stdout)
+  if (!match) {
+    throw new Error(`Unable to parse Temporal count output for query ${query}: ${output.stdout}`)
+  }
+  return Number.parseInt(match[1] ?? '0', 10)
+}
+
+async function list(query: string): Promise<void> {
+  const output = await temporalCli(['workflow', 'list', '--namespace', namespace, '--query', query, '--limit', '20'])
+  console.warn(output.stdout.trim())
+}
+
+async function terminate(query: string): Promise<void> {
+  const output = await temporalCli([
+    'workflow',
+    'terminate',
+    '--namespace',
+    namespace,
+    '--query',
+    query,
+    '--reason',
+    reason,
+    '--rps',
+    terminateRps,
+    '--yes',
+  ])
+  const jobId = /Started batch for job ID:\s*([0-9a-f-]+)/i.exec(output.stdout)?.[1]
+  if (jobId) {
+    await waitForBatch(jobId)
+  }
+}
+
+async function waitForBatch(jobId: string): Promise<void> {
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const output = await temporalCli(['batch', 'describe', '--job-id', jobId, '--namespace', namespace])
+    const state = /^ *State +(.+)$/im.exec(output.stdout)?.[1]?.trim()
+    if (state === 'Completed') {
+      return
+    }
+    if (state === 'Failed') {
+      throw new Error(`Temporal batch ${jobId} failed:\n${output.stdout}`)
+    }
+    await Bun.sleep(retryDelayMs * attempt)
+  }
+  throw new Error(`Timed out waiting for Temporal batch ${jobId} to complete`)
+}
+
+async function temporalCli(args: readonly string[]): Promise<{ stdout: string; stderr: string }> {
+  let lastOutput = ''
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const child = Bun.spawn([temporal, '--address', address, ...args], {
+      stdout: 'pipe',
+      stderr: 'pipe',
+      env: {
+        ...process.env,
+        TEMPORAL_ADDRESS: address,
+        TEMPORAL_NAMESPACE: namespace,
+      },
+    })
+    const exitCode = await child.exited
+    const stdout = child.stdout ? await new Response(child.stdout).text() : ''
+    const stderr = child.stderr ? await new Response(child.stderr).text() : ''
+    if (exitCode === 0) {
+      return { stdout, stderr }
+    }
+    lastOutput = stderr || stdout
+    if (!isRetryableTemporalCliError(lastOutput) || attempt === maxAttempts) {
+      throw new Error(`temporal ${args.join(' ')} failed with exit ${exitCode}: ${lastOutput}`)
+    }
+    await Bun.sleep(retryDelayMs * attempt)
+  }
+  throw new Error(`temporal ${args.join(' ')} failed: ${lastOutput}`)
+}
+
+function isRetryableTemporalCliError(output: string): boolean {
+  return /namespace rate limit exceeded|context deadline exceeded|transport: error while dialing|unavailable/i.test(
+    output,
+  )
+}
+
+function normalizePositiveInteger(value: string | undefined, fallback: number): number {
+  const parsed = Number.parseInt(value ?? '', 10)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
+}

--- a/packages/temporal-bun-sdk/tests/integration/client-resilience.integration.test.ts
+++ b/packages/temporal-bun-sdk/tests/integration/client-resilience.integration.test.ts
@@ -142,7 +142,7 @@ describeIntegration('Temporal client resilience', () => {
 
   const startWorkflow = async (callOptions?: Parameters<TemporalClient['startWorkflow']>[1]) => {
     if (!client) throw new Error('client not initialised')
-    return client.startWorkflow(
+    const result = await client.startWorkflow(
       {
         workflowType: 'integrationActivityWorkflow',
         workflowId: `resilience-${crypto.randomUUID()}`,
@@ -151,6 +151,8 @@ describeIntegration('Temporal client resilience', () => {
       },
       callOptions,
     )
+    harness?.trackWorkflow(result)
+    return result
   }
 
   test('retries transient WorkflowService failures', async () => {

--- a/packages/temporal-bun-sdk/tests/integration/harness.ts
+++ b/packages/temporal-bun-sdk/tests/integration/harness.ts
@@ -33,6 +33,14 @@ export interface WorkflowExecutionHandle {
 export interface IntegrationHarness {
   readonly setup: Effect.Effect<void, TemporalCliError, never>
   readonly teardown: Effect.Effect<void, TemporalCliError, never>
+  readonly trackWorkflow: (handle: WorkflowExecutionHandle) => WorkflowExecutionHandle
+  readonly terminateWorkflow: (
+    handle: WorkflowExecutionHandle,
+    options?: { readonly reason?: string },
+  ) => Effect.Effect<void, TemporalCliError, never>
+  readonly cleanupTrackedWorkflows: (
+    options?: { readonly reason?: string },
+  ) => Effect.Effect<void, TemporalCliError, never>
   readonly runScenario: <A>(
     name: string,
     scenario: () => Effect.Effect<A, TemporalCliError, never>,
@@ -180,6 +188,12 @@ export const createIntegrationHarness = (
     const cliExecutable = yield* resolveTemporalCliExecutable(config.cliBinaryPath)
 
     let started = false
+    const trackedWorkflows = new Map<string, WorkflowExecutionHandle>()
+    const workflowKey = (handle: WorkflowExecutionHandle) => `${handle.workflowId}:${handle.runId}`
+    const trackWorkflow = (handle: WorkflowExecutionHandle): WorkflowExecutionHandle => {
+      trackedWorkflows.set(workflowKey(handle), handle)
+      return handle
+    }
 
     const scenarioEnv: Record<string, string | undefined> = {
       TEMPORAL_ADDRESS: config.address,
@@ -263,6 +277,45 @@ export const createIntegrationHarness = (
         },
       })
     }
+
+    const terminateWorkflow = (
+      handle: WorkflowExecutionHandle,
+      options?: { readonly reason?: string },
+    ): Effect.Effect<void, TemporalCliError, never> => {
+      const command = [
+        'workflow',
+        'terminate',
+        '--workflow-id',
+        handle.workflowId,
+        '--run-id',
+        handle.runId,
+        '--namespace',
+        config.namespace,
+        '--reason',
+        options?.reason ?? 'integration-test-cleanup',
+      ] as const
+
+      return runTemporalCli(command).pipe(
+        Effect.asVoid,
+        Effect.tap(() => Effect.sync(() => trackedWorkflows.delete(workflowKey(handle)))),
+        Effect.catchAll((error) => {
+          if (isWorkflowAlreadyClosedCliError(error)) {
+            trackedWorkflows.delete(workflowKey(handle))
+            return Effect.void
+          }
+          return Effect.fail(error)
+        }),
+      )
+    }
+
+    const cleanupTrackedWorkflows = (
+      options?: { readonly reason?: string },
+    ): Effect.Effect<void, TemporalCliError, never> =>
+      Effect.forEach(
+        Array.from(trackedWorkflows.values()).reverse(),
+        (handle) => terminateWorkflow(handle, { reason: options?.reason ?? 'integration-test-cleanup' }),
+        { concurrency: 4, discard: true },
+      )
 
     const waitForNamespaceReady = async () => {
       // Keep readiness retries below the default 60s bun hook timeout so suites can catch and skip cleanly.
@@ -356,6 +409,7 @@ export const createIntegrationHarness = (
         if (!started) {
           return
         }
+        await Effect.runPromise(cleanupTrackedWorkflows({ reason: 'integration-harness-teardown' }))
         await withTestLock(lockDir, testLockFile, async () => {
           const currentRef = readRefcount(testRefcountFile)
           const nextRef = Math.max(0, currentRef - 1)
@@ -430,12 +484,14 @@ export const createIntegrationHarness = (
       const describeCommand = [cliExecutable, ...describeArgs] as const
       return runTemporalCli(command).pipe(
         Effect.flatMap((stdout) => parseWorkflowExecutionHandle(stdout, workflowId, cliCommand)),
+        Effect.map(trackWorkflow),
         Effect.catchAll((error) => {
           if (error instanceof TemporalCliCommandError) {
             console.warn('[temporal-bun-sdk:test] CLI command failed, stdout:', error.stdout)
             console.warn('[temporal-bun-sdk:test] CLI command failed, stderr:', error.stderr)
             return runTemporalCli(describeArgs).pipe(
               Effect.flatMap((stdout) => parseWorkflowDescribeHandle(stdout, workflowId, describeCommand)),
+              Effect.map(trackWorkflow),
             )
           }
           return Effect.fail(error)
@@ -475,6 +531,9 @@ export const createIntegrationHarness = (
     return {
       setup,
       teardown,
+      trackWorkflow,
+      terminateWorkflow,
+      cleanupTrackedWorkflows,
       runScenario,
       executeWorkflow,
       fetchWorkflowHistory,
@@ -530,6 +589,20 @@ export const isTemporalEndpointUnavailable = (error: unknown): boolean => {
     normalized.includes('getaddrinfo') ||
     normalized.includes('transport: error while dialing') ||
     normalized.includes('unavailable')
+  )
+}
+
+const isWorkflowAlreadyClosedCliError = (error: unknown): boolean => {
+  if (!(error instanceof TemporalCliCommandError)) {
+    return false
+  }
+  const detail = `${error.stderr}\n${error.stdout}\n${error.message}`.toLowerCase()
+  return (
+    detail.includes('workflow execution already completed') ||
+    detail.includes('workflow execution already terminated') ||
+    detail.includes('workflow execution already closed') ||
+    detail.includes('workflow not found') ||
+    detail.includes('not found')
   )
 }
 

--- a/packages/temporal-bun-sdk/tests/integration/interceptor-framework.integration.test.ts
+++ b/packages/temporal-bun-sdk/tests/integration/interceptor-framework.integration.test.ts
@@ -129,18 +129,20 @@ describeIntegration('interceptor framework wiring', () => {
       clientEvents.length = 0
       workerEvents.length = 0
 
-      await client!.startWorkflow({
+      const activityWorkflowHandle = await client!.startWorkflow({
         workflowType: 'integrationActivityWorkflow',
         workflowId: `int-activity-${crypto.randomUUID()}`,
         taskQueue: interceptorTaskQueue,
         args: [{ value: 'ok' }],
       })
+      integrationEnv?.harness?.trackWorkflow(activityWorkflowHandle)
 
       const signalWorkflowHandle = await client!.startWorkflow({
         workflowType: 'integrationSignalQueryWorkflow',
         workflowId: `int-signal-${crypto.randomUUID()}`,
         taskQueue: interceptorTaskQueue,
       })
+      integrationEnv?.harness?.trackWorkflow(signalWorkflowHandle)
 
       await client!.signalWorkflow(signalWorkflowHandle.handle, 'unblock', 'go')
       await client!.queryWorkflow(signalWorkflowHandle.handle, 'state', {})
@@ -151,6 +153,7 @@ describeIntegration('interceptor framework wiring', () => {
         taskQueue: interceptorTaskQueue,
         args: [{ initialMessage: 'boot' }],
       })
+      integrationEnv?.harness?.trackWorkflow(updateWorkflowHandle)
 
       await client!.updateWorkflow(updateWorkflowHandle.handle, {
         updateName: 'integrationUpdate.setMessage',

--- a/packages/temporal-bun-sdk/tests/integration/payload-codec.integration.test.ts
+++ b/packages/temporal-bun-sdk/tests/integration/payload-codec.integration.test.ts
@@ -186,6 +186,7 @@ describeIntegration('payload codec E2E', () => {
       ],
       memo: { env: 'codec-e2e' },
     })
+    harness?.trackWorkflow(start)
 
     const handle = start.handle
     const updateResult = await temporalClient.updateWorkflow(handle, {

--- a/packages/temporal-bun-sdk/tests/integration/test-environment.integration.test.ts
+++ b/packages/temporal-bun-sdk/tests/integration/test-environment.integration.test.ts
@@ -46,6 +46,7 @@ test('TestWorkflowEnvironment runs a worker end-to-end', { timeout: 30_000 }, as
         taskQueue,
         args: [{ value: 'ok' }],
       })
+      env.harness?.trackWorkflow(handle)
       const result = await testEnv.client.workflow.result(handle)
       expect(result).toBe('ok')
     } finally {

--- a/packages/temporal-bun-sdk/tests/integration/worker.runtime.integration.test.ts
+++ b/packages/temporal-bun-sdk/tests/integration/worker.runtime.integration.test.ts
@@ -5,7 +5,7 @@ import { Effect, Exit } from 'effect'
 import * as Schema from 'effect/Schema'
 
 import { buildTransportOptions, createTemporalClient, normalizeTemporalAddress } from '../../src/client'
-import { loadTemporalConfig, type TemporalConfig } from '../../src/config'
+import { loadTemporalConfig } from '../../src/config'
 import { TaskQueueKind } from '../../src/proto/temporal/api/enums/v1/task_queue_pb'
 import { WorkerVersioningMode } from '../../src/proto/temporal/api/enums/v1/deployment_pb'
 import { VersioningBehavior } from '../../src/proto/temporal/api/enums/v1/workflow_pb'
@@ -169,6 +169,7 @@ describeIntegration('Temporal worker runtime integration', () => {
                 args: [iterations],
                 workflowTaskTimeoutMs: 120_000,
               })
+              harness.trackWorkflow(result)
               executions.push({ workflowId: result.workflowId, runId: result.runId })
             }
 
@@ -334,6 +335,7 @@ describeIntegration('Temporal worker runtime integration', () => {
               workflowType: 'stickyMetadataWorkflow',
               taskQueue,
             })
+            harness.trackWorkflow(execution)
 
             const waitStart = Date.now()
             while (completions.length === 0) {
@@ -466,6 +468,7 @@ describeIntegration('Temporal worker runtime integration', () => {
               taskQueue,
               args: [{ initial: 'boot' }],
             })
+            harness.trackWorkflow(started)
 
             const result = await temporalClient.workflow.result(started.handle)
             expect(result).toBe('boot:done')


### PR DESCRIPTION
## Summary

- Tracks every integration workflow started through the shared Temporal test harness and terminates tracked executions during harness teardown.
- Registers direct-client integration workflows with the harness so signal/query, update, payload-codec, resilience, worker-runtime, and TestWorkflowEnvironment suites do not leave live executions behind.
- Adds a CI cleanup guard that clears stale SDK integration workflows before the suite and fails after tests/load/soak if known SDK workflow types are still running.

## Related Issues

None

## Testing

- `bunx oxfmt --check packages/temporal-bun-sdk/src packages/temporal-bun-sdk/tests packages/temporal-bun-sdk/scripts packages/temporal-bun-sdk/docs .github/workflows/temporal-bun-sdk.yml`
- `bun run --filter @proompteng/temporal-bun-sdk build`
- `bun run --cwd packages/temporal-bun-sdk lint:oxlint`
- `bun run --cwd packages/temporal-bun-sdk lint:oxlint:type`
- `bun test packages/temporal-bun-sdk/tests/integration/load/runner.test.ts`
- `bun run --filter @proompteng/temporal-bun-sdk verify:production`
- `TEMPORAL_TEST_SERVER=1 TEMPORAL_INTEGRATION_TESTS=1 TEMPORAL_BUN_RELEASE_GATE=1 TEMPORAL_ADDRESS=127.0.0.1:7233 TEMPORAL_NAMESPACE=default bun test packages/temporal-bun-sdk/tests/integration/query-only.integration.test.ts --timeout=60000 --max-concurrency=1`
- `TEMPORAL_TEST_SERVER=1 TEMPORAL_INTEGRATION_TESTS=1 TEMPORAL_BUN_RELEASE_GATE=1 TEMPORAL_ADDRESS=127.0.0.1:7233 TEMPORAL_NAMESPACE=default bun test packages/temporal-bun-sdk/tests/integration/interceptor-framework.integration.test.ts --timeout=60000 --max-concurrency=1 && TEMPORAL_ADDRESS=127.0.0.1:7233 TEMPORAL_NAMESPACE=default bun packages/temporal-bun-sdk/scripts/cleanup-integration-workflows.ts --verify`
- Live Temporal cleanup: terminated stale SDK integration workflow batches for known SDK workflow types, then verified `integrationSignalQueryWorkflow`, `integrationQueryOnlyWorkflow`, `integrationUpdateWorkflow`, `codecPayloadWorkflow`, and `stickyArgsWorkflow` running counts were `0`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
