### PR TITLE
fix(jangar): surface provider auth failures

### DIFF
--- a/services/jangar/src/server/__tests__/agents-controller-resource-reconcilers.test.ts
+++ b/services/jangar/src/server/__tests__/agents-controller-resource-reconcilers.test.ts
@@ -3,13 +3,13 @@ import { describe, expect, it, vi } from 'vitest'
 import { createResourceReconcilers } from '~/server/agents-controller/resource-reconcilers'
 import { validateAutonomousCodexAuthSecret } from '~/server/agents-controller/policy'
 
-const makeDeps = () => {
+const makeDeps = (now = '2026-01-01T00:00:00.000Z') => {
   const setStatus = vi.fn<
     (kube: unknown, resource: Record<string, unknown>, status: Record<string, unknown>) => Promise<void>
   >(async () => undefined)
   const deps = {
     setStatus,
-    nowIso: () => '2026-01-01T00:00:00.000Z',
+    nowIso: () => now,
     implementationTextLimit: 128 * 1024,
     resolveVcsAuthMethod: () => 'none',
     validateVcsAuthConfig: () => ({ ok: true as const, warnings: [] as Array<{ reason: string; message: string }> }),
@@ -159,6 +159,118 @@ describe('agents controller resource reconcilers module', () => {
           },
         },
       },
+    )
+
+    const [, , status] = setStatus.mock.calls[0]
+    expect(status.conditions).toEqual(
+      expect.arrayContaining([expect.objectContaining({ type: 'Ready', status: 'True', reason: 'ValidSpec' })]),
+    )
+  })
+
+  it('marks autonomous codex providers not ready when recent agent runs prove auth is unavailable', async () => {
+    const { deps, setStatus } = makeDeps('2026-01-01T00:10:00.000Z')
+    const { reconcileAgentProvider } = createResourceReconcilers(deps)
+
+    await reconcileAgentProvider(
+      {
+        get: vi.fn(async () => ({
+          data: {
+            'auth.json': Buffer.from(JSON.stringify({ auth_mode: 'chatgpt' })).toString('base64'),
+          },
+        })),
+      },
+      {
+        metadata: { name: 'codex-spark', generation: 1, namespace: 'agents' },
+        spec: {
+          binary: '/usr/local/bin/agent-runner',
+          envTemplate: {
+            AGENT_PROVIDER_PATH: '/root/.codex/provider-codex-spark.json',
+          },
+        },
+      },
+      [
+        {
+          metadata: { name: 'codex-spark-agent' },
+          spec: { providerRef: { name: 'codex-spark' } },
+        },
+      ],
+      [
+        {
+          metadata: { name: 'swarm-verify-failed', creationTimestamp: '2026-01-01T00:04:00.000Z' },
+          spec: { agentRef: { name: 'codex-spark-agent' } },
+          status: {
+            phase: 'Failed',
+            reason: 'ProviderAuthUnavailable',
+            message:
+              'workflow step verify: provider auth unavailable: access token could not be refreshed because refresh token was already used',
+            workflow: {
+              lastTransitionTime: '2026-01-01T00:05:00.000Z',
+            },
+          },
+        },
+      ],
+    )
+
+    const [, , status] = setStatus.mock.calls[0]
+    expect(status.conditions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'InvalidSpec', status: 'False', reason: 'ValidSpec' }),
+        expect.objectContaining({ type: 'Unreachable', status: 'True', reason: 'ProviderAuthUnavailable' }),
+        expect.objectContaining({ type: 'Ready', status: 'False', reason: 'ProviderAuthUnavailable' }),
+      ]),
+    )
+  })
+
+  it('marks autonomous codex providers ready after a newer agent run succeeds', async () => {
+    const { deps, setStatus } = makeDeps('2026-01-01T00:10:00.000Z')
+    const { reconcileAgentProvider } = createResourceReconcilers(deps)
+
+    await reconcileAgentProvider(
+      {
+        get: vi.fn(async () => ({
+          data: {
+            'auth.json': Buffer.from(JSON.stringify({ auth_mode: 'chatgpt' })).toString('base64'),
+          },
+        })),
+      },
+      {
+        metadata: { name: 'codex-spark', generation: 1, namespace: 'agents' },
+        spec: {
+          binary: '/usr/local/bin/agent-runner',
+          envTemplate: {
+            AGENT_PROVIDER_PATH: '/root/.codex/provider-codex-spark.json',
+          },
+        },
+      },
+      [
+        {
+          metadata: { name: 'codex-spark-agent' },
+          spec: { providerRef: { name: 'codex-spark' } },
+        },
+      ],
+      [
+        {
+          metadata: { name: 'swarm-verify-failed', creationTimestamp: '2026-01-01T00:04:00.000Z' },
+          spec: { agentRef: { name: 'codex-spark-agent' } },
+          status: {
+            phase: 'Failed',
+            reason: 'ProviderAuthUnavailable',
+            message:
+              'workflow step verify: provider auth unavailable: access token could not be refreshed because refresh token was already used',
+            workflow: {
+              lastTransitionTime: '2026-01-01T00:05:00.000Z',
+            },
+          },
+        },
+        {
+          metadata: { name: 'swarm-smoke-succeeded', creationTimestamp: '2026-01-01T00:06:00.000Z' },
+          spec: { agentRef: { name: 'codex-spark-agent' } },
+          status: {
+            phase: 'Succeeded',
+            completedAt: '2026-01-01T00:07:00.000Z',
+          },
+        },
+      ],
     )
 
     const [, , status] = setStatus.mock.calls[0]

--- a/services/jangar/src/server/__tests__/agents-controller.test.ts
+++ b/services/jangar/src/server/__tests__/agents-controller.test.ts
@@ -4556,6 +4556,116 @@ describe('agents controller reconcileAgentRun', () => {
     expect(failedStep.message).toContain('provider capacity exhausted')
   })
 
+  it('classifies workflow job pod auth logs as non-retryable provider auth failure', async () => {
+    const jobStatuses = new Map<string, Record<string, unknown>>()
+    const apply = vi.fn(async (resource: Record<string, unknown>) => {
+      const metadata = (resource.metadata ?? {}) as Record<string, unknown>
+      const uid = metadata.uid ?? `uid-${String(resource.kind ?? 'resource').toLowerCase()}`
+      const applied = { ...resource, metadata: { ...metadata, uid } }
+      if (resource.kind === 'Job') {
+        const name = (resource.metadata as Record<string, unknown> | undefined)?.name as string | undefined
+        if (name) {
+          jobStatuses.set(name, applied)
+        }
+      }
+      return applied
+    })
+    const kube = buildKube({
+      apply,
+      get: vi.fn(async (resource: string, name: string) => {
+        if (resource === RESOURCE_MAP.Agent) {
+          return {
+            metadata: { name: 'agent-1' },
+            spec: { providerRef: { name: 'provider-1' }, defaults: { systemPrompt: 'default-agent-prompt' } },
+          }
+        }
+        if (resource === RESOURCE_MAP.AgentProvider) {
+          return { metadata: { name: 'provider-1' }, spec: { binary: '/usr/local/bin/agent-runner' } }
+        }
+        if (resource === RESOURCE_MAP.ImplementationSpec) {
+          return { metadata: { name: 'impl-1' }, spec: { text: 'demo' } }
+        }
+        if (resource === 'job') {
+          return jobStatuses.get(name) ?? null
+        }
+        return null
+      }),
+      list: vi.fn(async (resource: string, _namespace: string, labelSelector?: string) => {
+        if (resource === 'pods' && labelSelector?.startsWith('job-name=')) {
+          return {
+            items: [
+              {
+                metadata: { name: 'run-1-step-1-attempt-1-pod' },
+                spec: { containers: [{ name: 'main' }] },
+              },
+            ],
+          }
+        }
+        return { items: [] }
+      }),
+      logs: vi.fn(async () =>
+        [
+          'Turn started',
+          'Stream error -> Your access token could not be refreshed because your refresh token was already used. Please log out and sign in again.',
+        ].join('\n'),
+      ),
+    })
+
+    const agentRun = buildAgentRun({
+      spec: {
+        agentRef: { name: 'agent-1' },
+        implementationSpecRef: { name: 'impl-1' },
+        runtime: { type: 'workflow', config: {} },
+        workload: { image: 'registry.ide-newton.ts.net/lab/codex-universal:20260219-234214-2a44dd59-dl' },
+        workflow: {
+          steps: [{ name: 'deploy-step', retries: 2 }],
+        },
+      },
+    })
+
+    await __test.reconcileAgentRun(kube as never, agentRun, 'agents', [], [], defaultConcurrency, buildInFlight(), 0)
+
+    const firstStatus = getLastStatus(kube)
+    const firstWorkflow = firstStatus.workflow as Record<string, unknown>
+    const firstStep = ((firstWorkflow.steps as Record<string, unknown>[]) ?? [])[0] ?? {}
+    const firstJobName = (firstStep.jobRef as Record<string, unknown> | undefined)?.name as string | undefined
+    jobStatuses.set(firstJobName ?? '', {
+      ...jobStatuses.get(firstJobName ?? ''),
+      status: {
+        failed: 1,
+        conditions: [
+          {
+            type: 'Failed',
+            status: 'True',
+            reason: 'BackoffLimitExceeded',
+            message: 'Job has reached the specified backoff limit',
+          },
+        ],
+      },
+    })
+
+    await __test.reconcileAgentRun(
+      kube as never,
+      { ...agentRun, status: firstStatus },
+      'agents',
+      [],
+      [],
+      defaultConcurrency,
+      buildInFlight(),
+      0,
+    )
+
+    const failedStatus = getLastStatus(kube)
+    expect(failedStatus.phase).toBe('Failed')
+    expect(failedStatus.reason).toBe('ProviderAuthUnavailable')
+    expect(failedStatus.message).toContain('workflow step deploy-step: provider auth unavailable')
+    const failedWorkflow = failedStatus.workflow as Record<string, unknown>
+    const failedStep = ((failedWorkflow.steps as Record<string, unknown>[]) ?? [])[0] ?? {}
+    expect(failedStep.phase).toBe('Failed')
+    expect(failedStep.message).toContain('provider auth unavailable')
+    expect(failedStep.nextRetryAt).toBeUndefined()
+  })
+
   it('propagates failed job reason and message onto AgentRun status', async () => {
     const kube = buildKube({
       get: vi.fn(async (resource: string, name: string) => {

--- a/services/jangar/src/server/__tests__/control-plane-stage-clearance.test.ts
+++ b/services/jangar/src/server/__tests__/control-plane-stage-clearance.test.ts
@@ -476,6 +476,27 @@ describe('control-plane stage clearance', () => {
     })
   })
 
+  it('holds normal launch packets with a provider-auth repair action when workers cannot authenticate', () => {
+    const packets = build({
+      workflows: workflows({
+        recent_failed_jobs: 3,
+        backoff_limit_exceeded_jobs: 3,
+        top_failure_reasons: [{ reason: 'ProviderAuthUnavailable', count: 3 }],
+      }),
+    })
+
+    expect(packet(packets, 'implement', 'dispatch_normal')).toMatchObject({
+      decision: 'hold',
+      max_launches: 0,
+      reason_codes: expect.arrayContaining([
+        'workflow_recent_failed_jobs',
+        'workflow_failure_providerauthunavailable',
+        'provider_auth_debt_active',
+      ]),
+      required_repair_action: 'restore provider auth before launch',
+    })
+  })
+
   it('holds normal stage launch when failure-domain holdbacks report missing lease authority', () => {
     const packets = build({
       failureDomainLeases: failureDomainHoldbackLeases(),

--- a/services/jangar/src/server/agents-controller/index.ts
+++ b/services/jangar/src/server/agents-controller/index.ts
@@ -1314,12 +1314,12 @@ const reconcileNamespaceSnapshot = async (
     await reconcileMemory(kube, memory, namespace)
   }
 
-  for (const agent of agents) {
-    await reconcileAgent(kube, agent, namespace, providers, memories)
+  for (const provider of providers) {
+    await reconcileAgentProvider(kube, provider, agents, runs)
   }
 
-  for (const provider of providers) {
-    await reconcileAgentProvider(kube, provider)
+  for (const agent of agents) {
+    await reconcileAgent(kube, agent, namespace, providers, memories)
   }
 
   for (const spec of specs) {

--- a/services/jangar/src/server/agents-controller/provider-capacity.ts
+++ b/services/jangar/src/server/agents-controller/provider-capacity.ts
@@ -4,6 +4,7 @@ import type { KubernetesClient } from '~/server/primitives-kube'
 import { extractJobFailureDetail } from './job-status'
 
 export const PROVIDER_CAPACITY_EXHAUSTED_REASON = 'ProviderCapacityExhausted'
+export const PROVIDER_AUTH_UNAVAILABLE_REASON = 'ProviderAuthUnavailable'
 
 type FailureFallback = {
   reason: string
@@ -18,6 +19,17 @@ const PROVIDER_CAPACITY_PATTERNS = [
   /\bquota (?:has been )?exceeded\b/i,
   /\brate limit(?:ed)?\b/i,
   /\bresource has been exhausted\b/i,
+]
+
+const PROVIDER_AUTH_PATTERNS = [
+  /\btoken_expired\b/i,
+  /\binvalid_grant\b/i,
+  /\bgrant not found\b/i,
+  /\brefresh token (?:was already used|could not be refreshed|unavailable)\b/i,
+  /\baccess token could not be refreshed\b/i,
+  /\bprovided authentication token is expired\b/i,
+  /\bmissing bearer or basic authentication\b/i,
+  /\bchatgpt authentication required\b/i,
 ]
 
 const MAX_PROVIDER_CAPACITY_MESSAGE_LENGTH = 320
@@ -37,6 +49,19 @@ export const resolveProviderCapacityFailureFromText = (text: string) => {
   return {
     reason: PROVIDER_CAPACITY_EXHAUSTED_REASON,
     message: `provider capacity exhausted: ${truncate(matchedLine, MAX_PROVIDER_CAPACITY_MESSAGE_LENGTH)}`,
+  }
+}
+
+export const resolveProviderAuthFailureFromText = (text: string) => {
+  const lines = text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+  const matchedLine = lines.find((line) => PROVIDER_AUTH_PATTERNS.some((pattern) => pattern.test(line)))
+  if (!matchedLine) return null
+  return {
+    reason: PROVIDER_AUTH_UNAVAILABLE_REASON,
+    message: `provider auth unavailable: ${truncate(matchedLine, MAX_PROVIDER_CAPACITY_MESSAGE_LENGTH)}`,
   }
 }
 
@@ -82,6 +107,8 @@ export const extractProviderCapacityFailureFromJobLogs = async (
           container,
           tailLines: PROVIDER_CAPACITY_LOG_TAIL_LINES,
         })
+        const providerAuthFailure = resolveProviderAuthFailureFromText(logs)
+        if (providerAuthFailure) return providerAuthFailure
         const providerCapacityFailure = resolveProviderCapacityFailureFromText(logs)
         if (providerCapacityFailure) return providerCapacityFailure
       } catch {
@@ -101,3 +128,6 @@ export const extractProviderAwareJobFailure = async (
 ) =>
   (jobName ? await extractProviderCapacityFailureFromJobLogs(kube, namespace, jobName) : null) ??
   extractJobFailureDetail(job, fallback)
+
+export const isNonRetryableProviderFailure = (reason: string) =>
+  reason === PROVIDER_CAPACITY_EXHAUSTED_REASON || reason === PROVIDER_AUTH_UNAVAILABLE_REASON

--- a/services/jangar/src/server/agents-controller/resource-reconcilers.ts
+++ b/services/jangar/src/server/agents-controller/resource-reconcilers.ts
@@ -1,6 +1,7 @@
 import { asRecord, asString, readNested } from '~/server/primitives-http'
 
 import { normalizeConditions, upsertCondition } from './conditions'
+import { PROVIDER_AUTH_UNAVAILABLE_REASON, resolveProviderAuthFailureFromText } from './provider-capacity'
 
 type KubeClient = {
   get: (kind: string, name: string, namespace: string) => Promise<Record<string, unknown> | null>
@@ -16,6 +17,111 @@ type VcsAuthValidation = {
   reason?: string
   message?: string
   warnings?: ConditionWarning[]
+}
+
+const PROVIDER_AUTH_FAILURE_LOOKBACK_MS = 2 * 60 * 60 * 1000
+
+const parseTimestamp = (value: unknown) => {
+  const text = asString(value)
+  if (!text) return null
+  const parsed = Date.parse(text)
+  return Number.isNaN(parsed) ? null : parsed
+}
+
+const latestConditionTransition = (run: Record<string, unknown>) => {
+  const conditions = readNested(run, ['status', 'conditions'])
+  if (!Array.isArray(conditions)) return null
+  const timestamps = conditions
+    .map((condition) => parseTimestamp(asRecord(condition)?.lastTransitionTime))
+    .filter((timestamp): timestamp is number => timestamp !== null)
+  if (timestamps.length === 0) return null
+  return Math.max(...timestamps)
+}
+
+const runObservedAt = (run: Record<string, unknown>) =>
+  parseTimestamp(readNested(run, ['status', 'completedAt'])) ??
+  parseTimestamp(readNested(run, ['status', 'workflow', 'lastTransitionTime'])) ??
+  latestConditionTransition(run) ??
+  parseTimestamp(readNested(run, ['metadata', 'creationTimestamp']))
+
+const runTextForProviderAuthDetection = (run: Record<string, unknown>) => {
+  const conditions = readNested(run, ['status', 'conditions'])
+  const workflowSteps = readNested(run, ['status', 'workflow', 'steps'])
+  return [
+    readNested(run, ['status', 'reason']),
+    readNested(run, ['status', 'message']),
+    ...(Array.isArray(conditions)
+      ? conditions
+          .map((condition: unknown) => {
+            const record = asRecord(condition)
+            return [record?.reason, record?.message].filter(Boolean).join(' ')
+          })
+          .filter(Boolean)
+      : []),
+    ...(Array.isArray(workflowSteps)
+      ? workflowSteps
+          .map((step: unknown) => {
+            const record = asRecord(step)
+            return [record?.reason, record?.message].filter(Boolean).join(' ')
+          })
+          .filter(Boolean)
+      : []),
+  ]
+    .map((value) => asString(value))
+    .filter((value): value is string => Boolean(value))
+    .join('\n')
+}
+
+const hasProviderAuthFailure = (run: Record<string, unknown>) => {
+  const reason = asString(readNested(run, ['status', 'reason']))
+  if (reason === PROVIDER_AUTH_UNAVAILABLE_REASON) return true
+  return resolveProviderAuthFailureFromText(runTextForProviderAuthDetection(run)) !== null
+}
+
+const phaseOf = (run: Record<string, unknown>) => asString(readNested(run, ['status', 'phase']))?.toLowerCase()
+
+const resolveRecentProviderAuthFailure = (
+  provider: Record<string, unknown>,
+  agents: Record<string, unknown>[],
+  runs: Record<string, unknown>[],
+  nowMs: number,
+) => {
+  const providerName = asString(readNested(provider, ['metadata', 'name']))
+  if (!providerName) return null
+  const agentNames = new Set(
+    agents
+      .filter((agent) => asString(readNested(agent, ['spec', 'providerRef', 'name'])) === providerName)
+      .map((agent) => asString(readNested(agent, ['metadata', 'name'])))
+      .filter((name): name is string => Boolean(name)),
+  )
+  if (agentNames.size === 0) return null
+
+  let latestFailure: { at: number; name: string; message: string } | null = null
+  let latestSuccessAt: number | null = null
+  for (const run of runs) {
+    const agentName = asString(readNested(run, ['spec', 'agentRef', 'name']))
+    if (!agentName || !agentNames.has(agentName)) continue
+    const observedAt = runObservedAt(run)
+    if (observedAt === null) continue
+    const phase = phaseOf(run)
+    if (phase === 'succeeded') {
+      latestSuccessAt = Math.max(latestSuccessAt ?? 0, observedAt)
+      continue
+    }
+    if (phase !== 'failed' || !hasProviderAuthFailure(run)) continue
+    const name = asString(readNested(run, ['metadata', 'name'])) ?? 'unknown'
+    const message =
+      resolveProviderAuthFailureFromText(runTextForProviderAuthDetection(run))?.message ??
+      `provider auth unavailable: ${name}`
+    if (!latestFailure || observedAt > latestFailure.at) {
+      latestFailure = { at: observedAt, name, message }
+    }
+  }
+
+  if (!latestFailure) return null
+  if (latestSuccessAt !== null && latestSuccessAt > latestFailure.at) return null
+  if (nowMs - latestFailure.at > PROVIDER_AUTH_FAILURE_LOOKBACK_MS) return null
+  return latestFailure
 }
 
 export const createResourceReconcilers = (deps: {
@@ -99,11 +205,17 @@ export const createResourceReconcilers = (deps: {
     })
   }
 
-  const reconcileAgentProvider = async (kube: unknown, provider: Record<string, unknown>) => {
+  const reconcileAgentProvider = async (
+    kube: unknown,
+    provider: Record<string, unknown>,
+    agents: Record<string, unknown>[] = [],
+    runs: Record<string, unknown>[] = [],
+  ) => {
     const spec = asRecord(provider.spec) ?? {}
     const conditions = buildConditions(provider)
     const binary = asString(spec.binary)
     const namespace = asString(readNested(provider, ['metadata', 'namespace'])) ?? 'default'
+    const nowMs = Date.parse(deps.nowIso())
     let updated = conditions
     if (!binary) {
       updated = upsertCondition(updated, {
@@ -137,9 +249,26 @@ export const createResourceReconcilers = (deps: {
           message: authValidation.message ?? 'autonomous Codex auth validation failed',
         })
       } else {
+        const recentAuthFailure = resolveRecentProviderAuthFailure(provider, agents, runs, nowMs)
         updated = upsertCondition(updated, { type: 'InvalidSpec', status: 'False', reason: 'ValidSpec', message: '' })
-        updated = upsertCondition(updated, { type: 'Unreachable', status: 'False', reason: 'Reachable', message: '' })
-        updated = upsertCondition(updated, { type: 'Ready', status: 'True', reason: 'ValidSpec' })
+        if (recentAuthFailure) {
+          const message = `${recentAuthFailure.message}; latest failed AgentRun ${recentAuthFailure.name}`
+          updated = upsertCondition(updated, {
+            type: 'Unreachable',
+            status: 'True',
+            reason: PROVIDER_AUTH_UNAVAILABLE_REASON,
+            message,
+          })
+          updated = upsertCondition(updated, {
+            type: 'Ready',
+            status: 'False',
+            reason: PROVIDER_AUTH_UNAVAILABLE_REASON,
+            message,
+          })
+        } else {
+          updated = upsertCondition(updated, { type: 'Unreachable', status: 'False', reason: 'Reachable', message: '' })
+          updated = upsertCondition(updated, { type: 'Ready', status: 'True', reason: 'ValidSpec' })
+        }
       }
     }
     await deps.setStatus(kube, provider, {

--- a/services/jangar/src/server/agents-controller/workflow-reconciler.ts
+++ b/services/jangar/src/server/agents-controller/workflow-reconciler.ts
@@ -8,7 +8,7 @@ import { parseStringList } from './env-config'
 import { hashAgentRunImmutableSpec } from './immutable-spec'
 import { resolveMemory } from './namespace-state'
 import { type ImagePolicyCandidate, validateAuthSecretPolicy, validateImagePolicy } from './policy'
-import { extractProviderAwareJobFailure } from './provider-capacity'
+import { extractProviderAwareJobFailure, isNonRetryableProviderFailure } from './provider-capacity'
 import { resolveImplementation, resolveParameters } from './run-utils'
 import { buildRuntimeRef, parseRuntimeRef, type RuntimeRef } from './runtime-resources'
 import { resolveSystemPrompt } from './system-prompt'
@@ -1020,7 +1020,7 @@ export const createWorkflowReconciler = (deps: WorkflowReconcilerDependencies) =
             reason: 'WorkflowStepFailed',
             message: `workflow step ${stepSpec.name} failed`,
           })
-          if (failureDetail.reason !== 'ProviderCapacityExhausted' && stepStatus.attempt < maxAttempts) {
+          if (!isNonRetryableProviderFailure(failureDetail.reason) && stepStatus.attempt < maxAttempts) {
             const retryMessage =
               failureDetail.message === `workflow step ${stepSpec.name} failed`
                 ? 'Step failed; retrying'

--- a/services/jangar/src/server/control-plane-stage-clearance.ts
+++ b/services/jangar/src/server/control-plane-stage-clearance.ts
@@ -145,6 +145,7 @@ const requiredRepairForReason = (reason: string) => {
   if (reason.includes('controller') || reason.includes('agentrun_ingestion')) {
     return 'publish fresh AgentRun ingestion and controller witness'
   }
+  if (reason.includes('provider_auth') || reason.includes('providerauth')) return 'restore provider auth before launch'
   if (reason.includes('provider_capacity')) return 'reduce provider capacity debt before launch'
   if (reason.includes('workflow') || reason.includes('backoff')) return 'retire workflow failure debt'
   if (reason.includes('market_context')) return 'refresh Torghut market-context evidence'
@@ -221,7 +222,11 @@ const workflowDebtForPacket = (
   const providerCapacityActive = workflows.top_failure_reasons.some((entry) =>
     normalizeReason(entry.reason).includes('providercapacityexhausted'),
   )
+  const providerAuthActive = workflows.top_failure_reasons.some((entry) =>
+    normalizeReason(entry.reason).includes('providerauthunavailable'),
+  )
   const reasonCodes = uniqueStrings([
+    ...(providerAuthActive ? ['provider_auth_debt_active'] : []),
     ...(workflows.data_confidence !== 'high' ? [`workflow_data_${workflows.data_confidence}`] : []),
     ...(workflows.recent_failed_jobs > 0 ? ['workflow_recent_failed_jobs'] : []),
     ...(workflows.backoff_limit_exceeded_jobs > 0 ? ['workflow_backoff_limit_exceeded_jobs'] : []),


### PR DESCRIPTION
## Summary

- Classify Codex worker authentication failures as `ProviderAuthUnavailable` from AgentRun pod logs.
- Stop retrying non-recoverable provider auth failures and propagate recent auth failures into AgentProvider readiness.
- Add provider-auth launch-clearance debt so swarm schedules report the repair action as restoring provider auth before launch.

## Related Issues

None

## Testing

- `bunx vitest run --config vitest.config.ts` from `services/jangar`
- `bunx tsc --noEmit -p tsconfig.app.json` from `services/jangar`
- `bunx oxfmt --check services/jangar/src/server/agents-controller/provider-capacity.ts services/jangar/src/server/agents-controller/workflow-reconciler.ts services/jangar/src/server/agents-controller/resource-reconcilers.ts services/jangar/src/server/agents-controller/index.ts services/jangar/src/server/control-plane-stage-clearance.ts services/jangar/src/server/__tests__/agents-controller.test.ts services/jangar/src/server/__tests__/agents-controller-resource-reconcilers.test.ts services/jangar/src/server/__tests__/control-plane-stage-clearance.test.ts`
- `bunx oxlint --config ../../.oxlintrc.json .` from `services/jangar` exited with 0 errors and existing warnings.
- `kubectl -n agents get agentruns --sort-by=.metadata.creationTimestamp | tail -n 10` confirmed live swarm runs remain blocked by current worker credentials until this fix and valid auth are deployed.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
