### PR TITLE
fix(torghut): enforce honest portfolio proof scoring

### DIFF
--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -37,11 +37,11 @@ spec:
       - name: targetNetPnlPerDay
         value: '500'
       - name: maxCandidates
-        value: '96'
+        value: '136'
       - name: topK
-        value: '24'
+        value: '72'
       - name: explorationSlots
-        value: '16'
+        value: '64'
       - name: portfolioSizeMin
         value: '3'
       - name: portfolioSizeMax
@@ -49,13 +49,13 @@ spec:
       - name: maxFrontierCandidatesPerSpec
         value: '2'
       - name: maxTotalFrontierCandidates
-        value: '48'
+        value: '128'
       - name: realReplayTimeoutSeconds
-        value: '7200'
+        value: '10000'
       - name: realReplayShardSize
         value: '1'
       - name: realReplayShardTimeoutSeconds
-        value: '900'
+        value: '1800'
       - name: realReplayShardWorkers
         value: '6'
       - name: prefetchFullWindowRows
@@ -68,7 +68,7 @@ spec:
     - name: run
       nodeSelector:
         kubernetes.io/arch: arm64
-      activeDeadlineSeconds: 10800
+      activeDeadlineSeconds: 21600
       inputs:
         parameters:
           - name: runId

--- a/services/torghut/app/trading/discovery/portfolio_optimizer.py
+++ b/services/torghut/app/trading/discovery/portfolio_optimizer.py
@@ -242,20 +242,22 @@ def _correlation(left: Mapping[str, Decimal], right: Mapping[str, Decimal]) -> D
 def _portfolio_daily_net(
     selected: Sequence[CandidateEvidenceBundle],
 ) -> dict[str, Decimal]:
+    weights = _equal_weights(selected)
     daily_totals: dict[str, Decimal] = {}
-    for bundle in selected:
+    for bundle, weight in zip(selected, weights, strict=True):
         for day, value in _daily_net(bundle).items():
-            daily_totals[day] = daily_totals.get(day, Decimal("0")) + value
+            daily_totals[day] = daily_totals.get(day, Decimal("0")) + (value * weight)
     return daily_totals
 
 
 def _portfolio_daily_filled_notional(
     selected: Sequence[CandidateEvidenceBundle],
 ) -> dict[str, Decimal]:
+    weights = _equal_weights(selected)
     daily_totals: dict[str, Decimal] = {}
-    for bundle in selected:
+    for bundle, weight in zip(selected, weights, strict=True):
         for day, value in _daily_filled_notional(bundle).items():
-            daily_totals[day] = daily_totals.get(day, Decimal("0")) + value
+            daily_totals[day] = daily_totals.get(day, Decimal("0")) + (value * weight)
     return daily_totals
 
 
@@ -322,12 +324,13 @@ def _contribution_shares(values: Mapping[str, Decimal]) -> dict[str, Decimal]:
 def _cluster_contribution_shares(
     selected: Sequence[CandidateEvidenceBundle],
 ) -> dict[str, Decimal]:
+    weights = _equal_weights(selected)
     contributions: dict[str, Decimal] = {}
-    for bundle in selected:
+    for bundle, weight in zip(selected, weights, strict=True):
         cluster = _cluster_id(bundle)
-        contributions[cluster] = contributions.get(
-            cluster, Decimal("0")
-        ) + _positive_net_contribution(bundle)
+        contributions[cluster] = contributions.get(cluster, Decimal("0")) + (
+            _positive_net_contribution(bundle) * weight
+        )
     return _contribution_shares(contributions)
 
 
@@ -351,9 +354,10 @@ def _bundle_symbol_shares(bundle: CandidateEvidenceBundle) -> dict[str, Decimal]
 def _symbol_contribution_shares(
     selected: Sequence[CandidateEvidenceBundle],
 ) -> dict[str, Decimal]:
+    weights = _equal_weights(selected)
     contributions: dict[str, Decimal] = {}
-    for bundle in selected:
-        bundle_positive_net = _positive_net_contribution(bundle)
+    for bundle, weight in zip(selected, weights, strict=True):
+        bundle_positive_net = _positive_net_contribution(bundle) * weight
         for symbol, share in _bundle_symbol_shares(bundle).items():
             contributions[symbol] = contributions.get(symbol, Decimal("0")) + (
                 bundle_positive_net * share
@@ -389,23 +393,57 @@ def _max_drawdown_from_daily(daily_net: Mapping[str, Decimal]) -> Decimal:
     return drawdown
 
 
+def _equal_weights(selected: Sequence[CandidateEvidenceBundle]) -> tuple[Decimal, ...]:
+    if not selected:
+        return ()
+    weight = Decimal("1") / Decimal(len(selected))
+    return tuple(weight for _ in selected)
+
+
 def _portfolio_max_gross_exposure_pct_equity(
     selected: Sequence[CandidateEvidenceBundle],
 ) -> Decimal:
+    weights = _equal_weights(selected)
     return sum(
-        (_max_gross_exposure_pct_equity(bundle) for bundle in selected),
+        (
+            _max_gross_exposure_pct_equity(bundle) * weight
+            for bundle, weight in zip(selected, weights, strict=True)
+        ),
         Decimal("0"),
     )
 
 
 def _portfolio_min_cash(selected: Sequence[CandidateEvidenceBundle]) -> Decimal:
-    return min((_min_cash(bundle) for bundle in selected), default=Decimal("0"))
+    weights = _equal_weights(selected)
+    return sum(
+        (
+            _min_cash(bundle) * weight
+            for bundle, weight in zip(selected, weights, strict=True)
+        ),
+        Decimal("0"),
+    )
 
 
 def _portfolio_negative_cash_observation_count(
     selected: Sequence[CandidateEvidenceBundle],
 ) -> int:
     return sum(_negative_cash_observation_count(bundle) for bundle in selected)
+
+
+def _missing_sleeve_daily_net_count(
+    selected: Sequence[CandidateEvidenceBundle],
+    daily_net: Mapping[str, Decimal],
+) -> int:
+    if not selected:
+        return 0
+    portfolio_days = set(daily_net)
+    missing = 0
+    for bundle in selected:
+        bundle_daily = _daily_net(bundle)
+        expected_count = max(_trading_day_count(bundle), len(portfolio_days))
+        missing += len(portfolio_days.difference(bundle_daily))
+        missing += max(0, expected_count - len(portfolio_days))
+    return missing
 
 
 def _portfolio_trading_day_count(
@@ -425,6 +463,9 @@ def _portfolio_scorecard(
     daily_net = _portfolio_daily_net(selected)
     trading_day_count = _portfolio_trading_day_count(selected, daily_net)
     missing_day_count = max(0, trading_day_count - len(daily_net))
+    missing_sleeve_daily_net_count = _missing_sleeve_daily_net_count(
+        selected, daily_net
+    )
     values = [daily_net[day] for day in sorted(daily_net)] + (
         [Decimal("0")] * missing_day_count
     )
@@ -508,6 +549,7 @@ def _portfolio_scorecard(
         "trading_day_count": trading_day_count,
         "daily_net_observed_day_count": len(daily_net),
         "missing_daily_net_count": missing_day_count,
+        "missing_sleeve_daily_net_count": missing_sleeve_daily_net_count,
         "regime_slice_pass_rate": str(_mean(regime_pass_rates)),
         "posterior_edge_lower": str(min(posterior_lowers, default=Decimal("0"))),
         "shadow_parity_status": "within_budget"
@@ -852,8 +894,10 @@ def optimize_portfolio_candidate(
                 "runtime_family": _string(_scorecard(bundle).get("runtime_family")),
                 "runtime_strategy_name": f"{base_runtime_strategy_name}-sleeve-{sleeve_index}",
                 "weight": str(equal_weight),
-                "expected_net_pnl_per_day": str(_net_per_day(bundle)),
-                "risk_contribution": str(_max_drawdown(bundle)),
+                "expected_net_pnl_per_day": str(_net_per_day(bundle) * equal_weight),
+                "source_expected_net_pnl_per_day": str(_net_per_day(bundle)),
+                "risk_contribution": str(_max_drawdown(bundle) * equal_weight),
+                "source_risk_contribution": str(_max_drawdown(bundle)),
                 "correlation_cluster": _string(
                     _scorecard(bundle).get("correlation_cluster")
                 )

--- a/services/torghut/app/trading/discovery/profit_target_oracle.py
+++ b/services/torghut/app/trading/discovery/profit_target_oracle.py
@@ -30,6 +30,7 @@ class ProfitTargetOraclePolicy:
     require_executable_replay: bool = True
     min_executable_order_count: int = 1
     require_executable_replay_notional_within_buying_power: bool = True
+    max_missing_sleeve_daily_net_count: int = 0
 
     def to_payload(self) -> dict[str, Any]:
         return {
@@ -55,6 +56,7 @@ class ProfitTargetOraclePolicy:
             "require_executable_replay": self.require_executable_replay,
             "min_executable_order_count": self.min_executable_order_count,
             "require_executable_replay_notional_within_buying_power": self.require_executable_replay_notional_within_buying_power,
+            "max_missing_sleeve_daily_net_count": self.max_missing_sleeve_daily_net_count,
         }
 
 
@@ -170,6 +172,14 @@ def evaluate_profit_target_oracle(
             observed=Decimal(daily_net_observed_day_count),
             operator="gte",
             threshold=Decimal(trading_day_count),
+        ),
+        _numeric_check(
+            metric="missing_sleeve_daily_net_count",
+            observed=Decimal(
+                _nonnegative_int(scorecard.get("missing_sleeve_daily_net_count"))
+            ),
+            operator="lte",
+            threshold=Decimal(max(0, policy.max_missing_sleeve_daily_net_count)),
         ),
         _numeric_check(
             metric="best_day_share",

--- a/services/torghut/tests/test_portfolio_optimizer.py
+++ b/services/torghut/tests/test_portfolio_optimizer.py
@@ -95,9 +95,9 @@ class TestPortfolioOptimizer(TestCase):
 
     def test_portfolio_candidate_round_trips_from_optimizer_payload(self) -> None:
         daily_profiles = [
-            ("210", "220", "230", "240", "250"),
-            ("240", "230", "220", "210", "200"),
-            ("230", "210", "250", "220", "240"),
+            ("610", "620", "630", "640", "650"),
+            ("640", "630", "620", "610", "600"),
+            ("630", "610", "650", "620", "640"),
         ]
         bundles = [
             evidence_bundle_from_frontier_candidate(
@@ -108,7 +108,7 @@ class TestPortfolioOptimizer(TestCase):
                     "runtime_strategy_name": "microbar-cross-sectional-pairs-v1",
                     "family_template_id": "microbar_cross_sectional_pairs_v1",
                     "objective_scorecard": {
-                        "net_pnl_per_day": "275",
+                        "net_pnl_per_day": "625",
                         "active_day_ratio": "1.0",
                         "positive_day_ratio": "0.8",
                         "worst_day_loss": "0",
@@ -165,6 +165,10 @@ class TestPortfolioOptimizer(TestCase):
         )
         self.assertTrue(reloaded.objective_scorecard["target_met"])
         self.assertTrue(reloaded.objective_scorecard["oracle_passed"])
+        self.assertEqual(
+            reloaded.objective_scorecard["net_pnl_per_day"],
+            "626.6666666666666666666666664",
+        )
         self.assertLessEqual(
             Decimal(reloaded.objective_scorecard["max_cluster_contribution_share"]),
             Decimal("0.40"),
@@ -433,6 +437,96 @@ class TestPortfolioOptimizer(TestCase):
             scorecard["profit_target_oracle"]["blockers"],
         )
 
+    def test_portfolio_optimizer_blocks_missing_sleeve_daily_net_coverage(
+        self,
+    ) -> None:
+        def bundle(
+            *,
+            candidate_id: str,
+            daily_net: dict[str, str],
+            cluster: str,
+            symbol: str,
+        ) -> CandidateEvidenceBundle:
+            return evidence_bundle_from_frontier_candidate(
+                candidate_spec_id=f"spec-{candidate_id}",
+                candidate={
+                    "candidate_id": candidate_id,
+                    "runtime_family": "microbar_cross_sectional_pairs",
+                    "runtime_strategy_name": "microbar-cross-sectional-pairs-v1",
+                    "family_template_id": "microbar_cross_sectional_pairs_v1",
+                    "objective_scorecard": {
+                        "net_pnl_per_day": "900",
+                        "active_day_ratio": "1.0",
+                        "positive_day_ratio": "1.0",
+                        "worst_day_loss": "0",
+                        "max_drawdown": "0",
+                        "best_day_share": "0.25",
+                        "avg_filled_notional_per_day": "350000",
+                        "regime_slice_pass_rate": "0.55",
+                        "posterior_edge_lower": "0.01",
+                        "shadow_parity_status": "within_budget",
+                        "correlation_cluster": cluster,
+                        "symbol_contribution_shares": {symbol: "1.0"},
+                        **_executable_scorecard_fields(candidate_id),
+                    },
+                    "full_window": {
+                        "trading_day_count": 3,
+                        "daily_net": daily_net,
+                        "daily_filled_notional": {
+                            "2026-02-23": "350000",
+                            "2026-02-24": "350000",
+                            "2026-02-25": "350000",
+                        },
+                    },
+                },
+                dataset_snapshot_id="snapshot-missing-sleeve-day",
+                result_path=f"/tmp/{candidate_id}.json",
+            )
+
+        portfolio = optimize_portfolio_candidate(
+            evidence_bundles=[
+                bundle(
+                    candidate_id="cand-full",
+                    daily_net={
+                        "2026-02-23": "1000",
+                        "2026-02-24": "1000",
+                        "2026-02-25": "1000",
+                    },
+                    cluster="missing-sleeve-a",
+                    symbol="AAPL",
+                ),
+                bundle(
+                    candidate_id="cand-partial",
+                    daily_net={
+                        "2026-02-23": "1000",
+                        "2026-02-25": "1000",
+                    },
+                    cluster="missing-sleeve-b",
+                    symbol="AMZN",
+                ),
+            ],
+            target_net_pnl_per_day=Decimal("500"),
+            oracle_policy=ProfitTargetOraclePolicy(
+                max_best_day_share=Decimal("0.50"),
+                max_cluster_contribution_share=Decimal("0.60"),
+                max_single_symbol_contribution_share=Decimal("0.60"),
+            ),
+            portfolio_size_min=2,
+            portfolio_size_max=2,
+        )
+
+        self.assertIsNotNone(portfolio)
+        assert portfolio is not None
+        scorecard = portfolio.objective_scorecard
+        self.assertEqual(scorecard["daily_net_observed_day_count"], 3)
+        self.assertEqual(scorecard["missing_daily_net_count"], 0)
+        self.assertEqual(scorecard["missing_sleeve_daily_net_count"], 1)
+        self.assertFalse(scorecard["oracle_passed"])
+        self.assertIn(
+            "missing_sleeve_daily_net_count_failed",
+            scorecard["profit_target_oracle"]["blockers"],
+        )
+
     def test_invalid_evidence_bundles_are_not_admitted_to_portfolios(self) -> None:
         invalid = evidence_bundle_from_frontier_candidate(
             candidate_spec_id="spec-invalid",
@@ -595,19 +689,19 @@ class TestPortfolioOptimizer(TestCase):
                 vetoed,
                 bundle(
                     candidate_id="cand-clean-a",
-                    net_pnl_per_day="200",
+                    net_pnl_per_day="600",
                     symbol="AAPL",
                     cluster="clean-a",
                 ),
                 bundle(
                     candidate_id="cand-clean-b",
-                    net_pnl_per_day="200",
+                    net_pnl_per_day="600",
                     symbol="AMZN",
                     cluster="clean-b",
                 ),
                 bundle(
                     candidate_id="cand-clean-c",
-                    net_pnl_per_day="200",
+                    net_pnl_per_day="600",
                     symbol="GOOGL",
                     cluster="clean-c",
                 ),
@@ -660,7 +754,7 @@ class TestPortfolioOptimizer(TestCase):
                         "positive_day_ratio_below_oracle",
                     ],
                     "objective_scorecard": {
-                        "net_pnl_per_day": "190",
+                        "net_pnl_per_day": "570",
                         "active_day_ratio": "1.0",
                         "positive_day_ratio": "0.67",
                         "worst_day_loss": "40",
@@ -669,7 +763,7 @@ class TestPortfolioOptimizer(TestCase):
                         "min_cash": "12000",
                         "negative_cash_observation_count": 0,
                         "best_day_share": "0.80",
-                        "avg_filled_notional_per_day": "120000",
+                        "avg_filled_notional_per_day": "300000",
                         "regime_slice_pass_rate": "0.55",
                         "posterior_edge_lower": "0.01",
                         "shadow_parity_status": "within_budget",
@@ -684,9 +778,9 @@ class TestPortfolioOptimizer(TestCase):
                             "2026-02-25": daily_net[2],
                         },
                         "daily_filled_notional": {
-                            "2026-02-23": "120000",
-                            "2026-02-24": "120000",
-                            "2026-02-25": "120000",
+                            "2026-02-23": "300000",
+                            "2026-02-24": "300000",
+                            "2026-02-25": "300000",
                         },
                     },
                 },
@@ -700,19 +794,19 @@ class TestPortfolioOptimizer(TestCase):
                     candidate_id="cand-offset-a",
                     symbol="AAPL",
                     cluster="offset-a",
-                    daily_net=("300", "-40", "310"),
+                    daily_net=("900", "-120", "930"),
                 ),
                 bundle(
                     candidate_id="cand-offset-b",
                     symbol="AMZN",
                     cluster="offset-b",
-                    daily_net=("-40", "310", "300"),
+                    daily_net=("-120", "930", "900"),
                 ),
                 bundle(
                     candidate_id="cand-offset-c",
                     symbol="GOOGL",
                     cluster="offset-c",
-                    daily_net=("310", "300", "-40"),
+                    daily_net=("930", "900", "-120"),
                 ),
             ],
             target_net_pnl_per_day=Decimal("500"),
@@ -729,7 +823,7 @@ class TestPortfolioOptimizer(TestCase):
         )
         self.assertEqual(
             portfolio.objective_scorecard["max_gross_exposure_pct_equity"],
-            "0.75",
+            "0.2499999999999999999999999999",
         )
         self.assertTrue(portfolio.objective_scorecard["oracle_passed"])
 
@@ -859,19 +953,19 @@ class TestPortfolioOptimizer(TestCase):
                 ),
                 bundle(
                     candidate_id="cand-diverse-a",
-                    net_pnl_per_day="200",
+                    net_pnl_per_day="600",
                     symbol="AAPL",
                     cluster="diverse-a",
                 ),
                 bundle(
                     candidate_id="cand-diverse-b",
-                    net_pnl_per_day="200",
+                    net_pnl_per_day="600",
                     symbol="AMZN",
                     cluster="diverse-b",
                 ),
                 bundle(
                     candidate_id="cand-diverse-c",
-                    net_pnl_per_day="200",
+                    net_pnl_per_day="600",
                     symbol="GOOGL",
                     cluster="diverse-c",
                 ),

--- a/services/torghut/tests/test_profit_target_oracle.py
+++ b/services/torghut/tests/test_profit_target_oracle.py
@@ -119,6 +119,31 @@ class TestProfitTargetOracle(TestCase):
         self.assertIn("min_daily_net_pnl_failed", result["blockers"])
         self.assertIn("daily_net_observed_day_count_failed", result["blockers"])
 
+    def test_profit_target_oracle_fails_missing_sleeve_daily_coverage(self) -> None:
+        result = evaluate_profit_target_oracle(
+            {
+                "net_pnl_per_day": "700",
+                "active_day_ratio": "1",
+                "positive_day_ratio": "1",
+                "best_day_share": "0.25",
+                "max_single_day_contribution_share": "0.25",
+                "max_cluster_contribution_share": "0.34",
+                "max_single_symbol_contribution_share": "0.25",
+                "worst_day_loss": "0",
+                "max_drawdown": "0",
+                "avg_filled_notional_per_day": "700000",
+                "regime_slice_pass_rate": "0.55",
+                "posterior_edge_lower": "0.01",
+                "shadow_parity_status": "within_budget",
+                "missing_sleeve_daily_net_count": 1,
+                **_executable_scorecard_fields(),
+            },
+            target_net_pnl_per_day=Decimal("500"),
+        )
+
+        self.assertFalse(result["passed"])
+        self.assertIn("missing_sleeve_daily_net_count_failed", result["blockers"])
+
     def test_profit_target_oracle_reports_failed_criteria(self) -> None:
         result = evaluate_profit_target_oracle(
             {

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -254,6 +254,19 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             'if [ -n "{{inputs.parameters.expectedLastTradingDay}}" ]; then',
             template,
         )
+        self.assertIn("name: maxCandidates\n        value: '136'", template)
+        self.assertIn("name: topK\n        value: '72'", template)
+        self.assertIn("name: explorationSlots\n        value: '64'", template)
+        self.assertIn(
+            "name: maxTotalFrontierCandidates\n        value: '128'", template
+        )
+        self.assertIn(
+            "name: realReplayTimeoutSeconds\n        value: '10000'", template
+        )
+        self.assertIn(
+            "name: realReplayShardTimeoutSeconds\n        value: '1800'", template
+        )
+        self.assertIn("activeDeadlineSeconds: 21600", template)
         self.assertIn("name: allowStaleTape\n        value: 'false'", template)
         self.assertNotIn("value: '2026-04-24'", template)
         self.assertNotIn("value: '2026-05-01'", template)
@@ -1759,14 +1772,22 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             )
 
             portfolio = payload["best_portfolio_candidate"]
-            self.assertTrue(portfolio["objective_scorecard"]["target_met"])
+            self.assertFalse(portfolio["objective_scorecard"]["target_met"])
             self.assertFalse(portfolio["objective_scorecard"]["oracle_passed"])
             self.assertFalse(payload["oracle_candidate_found"])
+            self.assertIn(
+                "portfolio_post_cost_net_pnl_per_day_failed",
+                payload["profit_target_oracle"]["blockers"],
+            )
+            self.assertIn(
+                "min_daily_net_pnl_failed",
+                payload["profit_target_oracle"]["blockers"],
+            )
             self.assertIn(
                 "executable_replay_passed_failed",
                 payload["profit_target_oracle"]["blockers"],
             )
-            self.assertGreaterEqual(
+            self.assertLess(
                 float(portfolio["objective_scorecard"]["net_pnl_per_day"]), 500.0
             )
             self.assertTrue(payload["false_positive_table"])

--- a/services/torghut/tests/test_whitepaper_autoresearch_artifacts.py
+++ b/services/torghut/tests/test_whitepaper_autoresearch_artifacts.py
@@ -122,7 +122,7 @@ class TestWhitepaperAutoresearchArtifacts(TestCase):
                 candidate={
                     "candidate_id": f"cand-{index}",
                     "objective_scorecard": {
-                        "net_pnl_per_day": str(300 - (index * 25)),
+                        "net_pnl_per_day": str(625 - (index * 25)),
                         "active_day_ratio": "0.92",
                         "positive_day_ratio": "0.64",
                         "worst_day_loss": "150",
@@ -403,7 +403,7 @@ class TestWhitepaperAutoresearchArtifacts(TestCase):
                 candidate={
                     "candidate_id": "cand-a",
                     "objective_scorecard": {
-                        "net_pnl_per_day": "300",
+                        "net_pnl_per_day": "900",
                         "active_day_ratio": "1.0",
                         "positive_day_ratio": "1.0",
                         "worst_day_loss": "0",
@@ -412,9 +412,9 @@ class TestWhitepaperAutoresearchArtifacts(TestCase):
                     },
                     "full_window": {
                         "daily_net": {
-                            "2026-02-23": "200",
-                            "2026-02-24": "400",
-                            "2026-02-25": "300",
+                            "2026-02-23": "600",
+                            "2026-02-24": "1200",
+                            "2026-02-25": "900",
                         }
                     },
                 },
@@ -426,7 +426,7 @@ class TestWhitepaperAutoresearchArtifacts(TestCase):
                 candidate={
                     "candidate_id": "cand-b",
                     "objective_scorecard": {
-                        "net_pnl_per_day": "270",
+                        "net_pnl_per_day": "810",
                         "active_day_ratio": "1.0",
                         "positive_day_ratio": "1.0",
                         "worst_day_loss": "0",
@@ -435,9 +435,9 @@ class TestWhitepaperAutoresearchArtifacts(TestCase):
                     },
                     "full_window": {
                         "daily_net": {
-                            "2026-02-23": "100",
-                            "2026-02-24": "350",
-                            "2026-02-25": "360",
+                            "2026-02-23": "300",
+                            "2026-02-24": "1050",
+                            "2026-02-25": "1080",
                         }
                     },
                 },
@@ -449,7 +449,7 @@ class TestWhitepaperAutoresearchArtifacts(TestCase):
                 candidate={
                     "candidate_id": "cand-c",
                     "objective_scorecard": {
-                        "net_pnl_per_day": "260",
+                        "net_pnl_per_day": "780",
                         "active_day_ratio": "1.0",
                         "positive_day_ratio": "1.0",
                         "worst_day_loss": "0",
@@ -458,9 +458,9 @@ class TestWhitepaperAutoresearchArtifacts(TestCase):
                     },
                     "full_window": {
                         "daily_net": {
-                            "2026-02-23": "180",
-                            "2026-02-24": "360",
-                            "2026-02-25": "270",
+                            "2026-02-23": "540",
+                            "2026-02-24": "1080",
+                            "2026-02-25": "720",
                         }
                     },
                 },
@@ -479,14 +479,14 @@ class TestWhitepaperAutoresearchArtifacts(TestCase):
         self.assertIsNotNone(portfolio)
         assert portfolio is not None
         self.assertEqual(portfolio.source_candidate_ids, ("cand-a", "cand-b"))
-        self.assertEqual(portfolio.objective_scorecard["net_pnl_per_day"], "570")
+        self.assertEqual(portfolio.objective_scorecard["net_pnl_per_day"], "855.0")
         self.assertEqual(portfolio.objective_scorecard["worst_day_loss"], "0")
         self.assertEqual(
             portfolio.objective_scorecard["daily_net"],
             {
-                "2026-02-23": "300",
-                "2026-02-24": "750",
-                "2026-02-25": "660",
+                "2026-02-23": "450.0",
+                "2026-02-24": "1125.0",
+                "2026-02-25": "990.0",
             },
         )
         rejection_reasons = [


### PR DESCRIPTION
## Summary

- Enforces equal-weight capital semantics in Torghut portfolio optimizer scorecards so portfolio PnL, notional, exposure, cash, symbol, and cluster contributions match the advertised sleeve weights.
- Adds oracle gating for missing sleeve-level daily-net replay coverage, preventing a complete portfolio date union from hiding an incomplete sleeve replay.
- Widens the strict whitepaper autoresearch workflow defaults so no-stale $500 replay runs have enough candidate breadth and replay budget for real evidence gathering.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_portfolio_optimizer.py tests/test_profit_target_oracle.py`
- `uv run --frozen pytest tests/test_whitepaper_autoresearch_artifacts.py -k 'evidence_training_rows_and_portfolio_optimizer or portfolio_optimizer_uses_daily_vectors_and_correlation_cap'`
- `COVERAGE_FILE=.coverage.local-shard2 SHARD_INDEX=2 SHARD_TOTAL=4 uv run --frozen pytest -n auto --dist=worksteal --cov --cov-branch --cov-fail-under=0 --cov-report= $(find tests -name 'test_*.py' ! -path 'tests/test_run_whitepaper_autoresearch_profit_target.py' -print | sort | awk -v shard=2 -v total=4 '((NR - 1) % total) == shard')`
- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py -k workflow_template_surfaces_feedback_and_fails_closed_on_stale_tape`
- `uv run --frozen ruff format --check app/trading/discovery/portfolio_optimizer.py app/trading/discovery/profit_target_oracle.py tests/test_portfolio_optimizer.py tests/test_profit_target_oracle.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv run --frozen ruff check app/trading/discovery/portfolio_optimizer.py app/trading/discovery/profit_target_oracle.py tests/test_portfolio_optimizer.py tests/test_profit_target_oracle.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
