### PR TITLE
chore(symphony): promote image 1495ba8b

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-05-14T08:19:06Z"
+        kubectl.kubernetes.io/restartedAt: "2026-05-16T02:40:38Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -23,5 +23,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "e3d66461"
-    digest: sha256:a7eb60e70fbe8389623f44f3a5dc907a7ae06617833292fb25bf4fb003d270ea
+    newTag: "1495ba8b"
+    digest: sha256:8d91887c5740c173b33eade1d8e01e5f210dde82df2d895394ba295da94982eb

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-05-14T08:19:06Z"
+        kubectl.kubernetes.io/restartedAt: "2026-05-16T02:40:38Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -25,5 +25,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "e3d66461"
-    digest: sha256:a7eb60e70fbe8389623f44f3a5dc907a7ae06617833292fb25bf4fb003d270ea
+    newTag: "1495ba8b"
+    digest: sha256:8d91887c5740c173b33eade1d8e01e5f210dde82df2d895394ba295da94982eb

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-05-14T08:19:06Z"
+        kubectl.kubernetes.io/restartedAt: "2026-05-16T02:40:38Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -18,5 +18,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "e3d66461"
-    digest: sha256:a7eb60e70fbe8389623f44f3a5dc907a7ae06617833292fb25bf4fb003d270ea
+    newTag: "1495ba8b"
+    digest: sha256:8d91887c5740c173b33eade1d8e01e5f210dde82df2d895394ba295da94982eb


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `1495ba8b1f8178edc8d6d0a0c24cb0a6a3252e30`
- Image tag: `1495ba8b`
- Image digest: `sha256:8d91887c5740c173b33eade1d8e01e5f210dde82df2d895394ba295da94982eb`