### PR TITLE
chore(jangar): promote image 1495ba8b

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 7609c870
-  digest: sha256:900acce20154495e5c5bc5e45f082f2beed8f62960c6db509ceaa1f59affcad3
+  tag: 1495ba8b
+  digest: sha256:3e6a5a24fc6a6063617575fe928176ac8075986978972c84458838019f1dbdc6
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,25 +11,25 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 7609c870
-    digest: sha256:f1dddd955020fde6b9c9a3ea4ce3c8dfb816922764bb62ecfbb1b269cf41014d
+    tag: 1495ba8b
+    digest: sha256:4e76f6fb7544f4b1f35d6941380fd6140a47d6df962d1d0bde4aabc323e474bc
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
       JANGAR_TORGHUT_STATUS_URL: http://torghut.torghut.svc.cluster.local/trading/consumer-evidence
       JANGAR_TORGHUT_STATUS_TIMEOUT_MS: "12000"
-      JANGAR_SOURCE_HEAD_SHA: 7609c870d379561f96214ed643c333e1c022d328
-      JANGAR_GITOPS_REVISION: 7609c870d379561f96214ed643c333e1c022d328
-      JANGAR_SOURCE_CI_RUN_ID: "25950481802"
+      JANGAR_SOURCE_HEAD_SHA: 1495ba8b1f8178edc8d6d0a0c24cb0a6a3252e30
+      JANGAR_GITOPS_REVISION: 1495ba8b1f8178edc8d6d0a0c24cb0a6a3252e30
+      JANGAR_SOURCE_CI_RUN_ID: "25950849806"
       JANGAR_SOURCE_CI_CONCLUSION: success
-      JANGAR_MANIFEST_IMAGE_DIGEST: sha256:f1dddd955020fde6b9c9a3ea4ce3c8dfb816922764bb62ecfbb1b269cf41014d
-      JANGAR_SERVING_BUILD_COMMIT: 7609c870d379561f96214ed643c333e1c022d328
-      JANGAR_SERVING_IMAGE_DIGEST: sha256:f1dddd955020fde6b9c9a3ea4ce3c8dfb816922764bb62ecfbb1b269cf41014d
+      JANGAR_MANIFEST_IMAGE_DIGEST: sha256:4e76f6fb7544f4b1f35d6941380fd6140a47d6df962d1d0bde4aabc323e474bc
+      JANGAR_SERVING_BUILD_COMMIT: 1495ba8b1f8178edc8d6d0a0c24cb0a6a3252e30
+      JANGAR_SERVING_IMAGE_DIGEST: sha256:4e76f6fb7544f4b1f35d6941380fd6140a47d6df962d1d0bde4aabc323e474bc
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 7609c870
-    digest: sha256:900acce20154495e5c5bc5e45f082f2beed8f62960c6db509ceaa1f59affcad3
+    tag: 1495ba8b
+    digest: sha256:3e6a5a24fc6a6063617575fe928176ac8075986978972c84458838019f1dbdc6
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-16T02:30:33Z
+    deploy.knative.dev/rollout: 2026-05-16T02:49:34Z
 spec:
   replicas: 1
   strategy:
@@ -57,11 +57,11 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_RUNTIME_IMAGE
-              value: registry.ide-newton.ts.net/lab/jangar:7609c870@sha256:900acce20154495e5c5bc5e45f082f2beed8f62960c6db509ceaa1f59affcad3
+              value: registry.ide-newton.ts.net/lab/jangar:1495ba8b@sha256:3e6a5a24fc6a6063617575fe928176ac8075986978972c84458838019f1dbdc6
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: 7609c870d379561f96214ed643c333e1c022d328
+              value: 1495ba8b1f8178edc8d6d0a0c24cb0a6a3252e30
             - name: JANGAR_GITOPS_REVISION
-              value: 7609c870d379561f96214ed643c333e1c022d328
+              value: 1495ba8b1f8178edc8d6d0a0c24cb0a6a3252e30
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_CONTROL_PLANE_STATUS_CACHE_TTL_MS
@@ -405,15 +405,15 @@ spec:
             - name: OPENAI_EMBEDDING_TIMEOUT_MS
               value: "60000"
             - name: JANGAR_SOURCE_CI_RUN_ID
-              value: "25950481802"
+              value: "25950849806"
             - name: JANGAR_SOURCE_CI_CONCLUSION
               value: success
             - name: JANGAR_MANIFEST_IMAGE_DIGEST
-              value: sha256:f1dddd955020fde6b9c9a3ea4ce3c8dfb816922764bb62ecfbb1b269cf41014d
+              value: sha256:4e76f6fb7544f4b1f35d6941380fd6140a47d6df962d1d0bde4aabc323e474bc
             - name: JANGAR_SERVING_BUILD_COMMIT
-              value: 7609c870d379561f96214ed643c333e1c022d328
+              value: 1495ba8b1f8178edc8d6d0a0c24cb0a6a3252e30
             - name: JANGAR_SERVING_IMAGE_DIGEST
-              value: sha256:f1dddd955020fde6b9c9a3ea4ce3c8dfb816922764bb62ecfbb1b269cf41014d
+              value: sha256:4e76f6fb7544f4b1f35d6941380fd6140a47d6df962d1d0bde4aabc323e474bc
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -59,5 +59,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: 7609c870
-    digest: sha256:900acce20154495e5c5bc5e45f082f2beed8f62960c6db509ceaa1f59affcad3
+    newTag: 1495ba8b
+    digest: sha256:3e6a5a24fc6a6063617575fe928176ac8075986978972c84458838019f1dbdc6


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `1495ba8b1f8178edc8d6d0a0c24cb0a6a3252e30`
- Image tag: `1495ba8b`
- Image digest: `sha256:3e6a5a24fc6a6063617575fe928176ac8075986978972c84458838019f1dbdc6`
- Source CI run: `25950849806`
- Control-plane serving digest: `sha256:4e76f6fb7544f4b1f35d6941380fd6140a47d6df962d1d0bde4aabc323e474bc`
- Updated API rollout annotation
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`
- Published source-serving proof env for revenue repair custody gates