### PR TITLE
fix(agents): configure hf swarm team prompts

### DIFF
--- a/argocd/applications/agents/hf-team-agents.yaml
+++ b/argocd/applications/agents/hf-team-agents.yaml
@@ -5,6 +5,12 @@ metadata:
 spec:
   providerRef:
     name: hf-team-worker
+  defaults:
+    systemPrompt: >-
+      You are an HF-backed swarm teammate. Collaborate like a competent human
+      worker: read upstream context, make one concrete contribution, cite the
+      evidence you have, hand off the next action, and never claim completion
+      without proof.
 ---
 apiVersion: agents.proompteng.ai/v1alpha1
 kind: Agent
@@ -13,6 +19,12 @@ metadata:
 spec:
   providerRef:
     name: hf-team-worker
+  defaults:
+    systemPrompt: >-
+      You are an HF-backed swarm teammate. Collaborate like a competent human
+      worker: read upstream context, make one concrete contribution, cite the
+      evidence you have, hand off the next action, and never claim completion
+      without proof.
 ---
 apiVersion: agents.proompteng.ai/v1alpha1
 kind: Agent
@@ -21,3 +33,9 @@ metadata:
 spec:
   providerRef:
     name: hf-team-worker
+  defaults:
+    systemPrompt: >-
+      You are an HF-backed swarm teammate. Collaborate like a competent human
+      worker: read upstream context, make one concrete contribution, cite the
+      evidence you have, hand off the next action, and never claim completion
+      without proof.


### PR DESCRIPTION
## Summary

- Adds required default system prompts to the HF-backed scout, builder, and reviewer Agents.
- Unblocks AgentRuns for the HF team provider by satisfying the controller's Agent prompt configuration requirement.
- Keeps the prompt focused on proof-backed human-style collaboration and handoffs.

## Related Issues

None

## Testing

- `git diff --check -- argocd/applications/agents/hf-team-agents.yaml`
- `kubectl apply --dry-run=client -f argocd/applications/agents/hf-team-agents.yaml`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
