### PR TITLE
fix(agents): use reachable hf swarm model

### DIFF
--- a/argocd/applications/agents/hf-team-agentprovider.yaml
+++ b/argocd/applications/agents/hf-team-agentprovider.yaml
@@ -9,7 +9,7 @@ spec:
     - exec python3 /root/.codex/hf-team-worker.py /workspace/run.json
   envTemplate:
     HF_BASE_URL: https://router.huggingface.co/v1
-    HF_MODEL: Qwen/Qwen2.5-7B-Instruct
+    HF_MODEL: meta-llama/Llama-3.1-8B-Instruct:novita
     NATS_URL: nats://nats.nats.svc.cluster.local:4222
   inputFiles:
     - path: /root/.codex/hf-team-worker.py
@@ -127,7 +127,7 @@ spec:
           objective = read_field(payload, "objective", "create measurable value with the team")
           upstream = read_field(payload, "upstreamArtifact", "None")
           expected_output = read_field(payload, "expectedOutput", "a concise production-quality handoff")
-          model = os.environ.get("HF_MODEL", "Qwen/Qwen2.5-7B-Instruct").strip()
+          model = os.environ.get("HF_MODEL", "meta-llama/Llama-3.1-8B-Instruct:novita").strip()
           base_url = os.environ.get("HF_BASE_URL", "https://router.huggingface.co/v1").strip()
 
           messages = [


### PR DESCRIPTION
## Summary

- Switches the HF-backed swarm team provider to `meta-llama/Llama-3.1-8B-Instruct:novita`.
- Avoids the default Qwen route that resolved to a Together backend blocked by Cloudflare from the agents namespace.
- Keeps the worker on Hugging Face Router while pinning a provider route proven by an in-cluster probe.

## Related Issues

None

## Testing

- In-cluster probe job: `meta-llama/Llama-3.1-8B-Instruct:novita` returned `OK`; prior Qwen route failed with HTTP 403 Cloudflare 1010 from `api.together.xyz`.
- `git diff --check -- argocd/applications/agents/hf-team-agentprovider.yaml`
- `kubectl apply --dry-run=client -f argocd/applications/agents/hf-team-agentprovider.yaml`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
