### PR TITLE
fix(agents): harden hf swarm evidence prompts

### DIFF
--- a/argocd/applications/agents/hf-team-agentprovider.yaml
+++ b/argocd/applications/agents/hf-team-agentprovider.yaml
@@ -136,7 +136,11 @@ spec:
               "content": (
                 "You are an intelligent swarm teammate. Work like a competent human colleague: "
                 "read the upstream handoff, make one concrete contribution, state evidence, "
-                "handoff the next action, and avoid pretending work is complete without proof."
+                "handoff the next action, and avoid pretending work is complete without proof. "
+                "You only have the AgentRun payload and upstream artifact unless the prompt gives "
+                "you other evidence. Do not invent file paths, functions, command results, or repo "
+                "inspection. If evidence is limited, say that plainly and still provide a useful "
+                "next action."
               ),
             },
             {
@@ -163,6 +167,8 @@ spec:
                 "## Handoff",
                 "## Value Created",
                 "",
+                "Evidence rules: cite only the supplied objective, upstream artifact, runtime fields, "
+                "or explicit observations from this process. Do not fabricate source-code references.",
                 "Keep it specific and useful for the next worker.",
               ]),
             },

--- a/argocd/applications/agents/hf-team-agents.yaml
+++ b/argocd/applications/agents/hf-team-agents.yaml
@@ -10,7 +10,8 @@ spec:
       You are an HF-backed swarm teammate. Collaborate like a competent human
       worker: read upstream context, make one concrete contribution, cite the
       evidence you have, hand off the next action, and never claim completion
-      without proof.
+      without proof. Do not invent file paths, functions, command results, or
+      repo inspection when they were not supplied.
 ---
 apiVersion: agents.proompteng.ai/v1alpha1
 kind: Agent
@@ -24,7 +25,8 @@ spec:
       You are an HF-backed swarm teammate. Collaborate like a competent human
       worker: read upstream context, make one concrete contribution, cite the
       evidence you have, hand off the next action, and never claim completion
-      without proof.
+      without proof. Do not invent file paths, functions, command results, or
+      repo inspection when they were not supplied.
 ---
 apiVersion: agents.proompteng.ai/v1alpha1
 kind: Agent
@@ -38,4 +40,5 @@ spec:
       You are an HF-backed swarm teammate. Collaborate like a competent human
       worker: read upstream context, make one concrete contribution, cite the
       evidence you have, hand off the next action, and never claim completion
-      without proof.
+      without proof. Do not invent file paths, functions, command results, or
+      repo inspection when they were not supplied.


### PR DESCRIPTION
## Summary

- Hardens the HF swarm worker prompt so teammates only cite evidence they actually receive or observe.
- Adds the same no-fabricated-repo-inspection rule to the three HF team Agent defaults.
- Addresses the first successful scout smoke, which executed correctly but produced an ungrounded source-code reference.

## Related Issues

None

## Testing

- `git diff --check -- argocd/applications/agents/hf-team-agentprovider.yaml argocd/applications/agents/hf-team-agents.yaml`
- `kubectl apply --dry-run=client -f argocd/applications/agents/hf-team-agentprovider.yaml -f argocd/applications/agents/hf-team-agents.yaml`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
