### PR TITLE
revert(torghut): rollback failed promotion 09b61156da4484d1d9b33f5a466e695737d627d3

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:19f2bbe8c615f66a75f3d9252dd00ccc31c1a06f076ba1acb9acaf9d30828aa2
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:9fd3d1cf8cd52ede20e12bb676f565e0e7a94f57d47be319002c4352b89eaf1a
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.570.0-8-ge8f789a86
+              value: v0.569.1-522-g1495ba8b1
             - name: TORGHUT_OPTIONS_COMMIT
-              value: e8f789a868f399c9482859aff5d2bad01f6c0b66
+              value: 1495ba8b1f8178edc8d6d0a0c24cb0a6a3252e30
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:19f2bbe8c615f66a75f3d9252dd00ccc31c1a06f076ba1acb9acaf9d30828aa2
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:9fd3d1cf8cd52ede20e12bb676f565e0e7a94f57d47be319002c4352b89eaf1a
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.570.0-8-ge8f789a86
+              value: v0.569.1-522-g1495ba8b1
             - name: TORGHUT_OPTIONS_COMMIT
-              value: e8f789a868f399c9482859aff5d2bad01f6c0b66
+              value: 1495ba8b1f8178edc8d6d0a0c24cb0a6a3252e30
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:19f2bbe8c615f66a75f3d9252dd00ccc31c1a06f076ba1acb9acaf9d30828aa2
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:9fd3d1cf8cd52ede20e12bb676f565e0e7a94f57d47be319002c4352b89eaf1a
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:19f2bbe8c615f66a75f3d9252dd00ccc31c1a06f076ba1acb9acaf9d30828aa2
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:9fd3d1cf8cd52ede20e12bb676f565e0e7a94f57d47be319002c4352b89eaf1a
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:19f2bbe8c615f66a75f3d9252dd00ccc31c1a06f076ba1acb9acaf9d30828aa2
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:9fd3d1cf8cd52ede20e12bb676f565e0e7a94f57d47be319002c4352b89eaf1a
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:19f2bbe8c615f66a75f3d9252dd00ccc31c1a06f076ba1acb9acaf9d30828aa2
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:9fd3d1cf8cd52ede20e12bb676f565e0e7a94f57d47be319002c4352b89eaf1a
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:19f2bbe8c615f66a75f3d9252dd00ccc31c1a06f076ba1acb9acaf9d30828aa2
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:9fd3d1cf8cd52ede20e12bb676f565e0e7a94f57d47be319002c4352b89eaf1a
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -15,7 +15,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:19f2bbe8c615f66a75f3d9252dd00ccc31c1a06f076ba1acb9acaf9d30828aa2
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:9fd3d1cf8cd52ede20e12bb676f565e0e7a94f57d47be319002c4352b89eaf1a
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -23,7 +23,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:19f2bbe8c615f66a75f3d9252dd00ccc31c1a06f076ba1acb9acaf9d30828aa2
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:9fd3d1cf8cd52ede20e12bb676f565e0e7a94f57d47be319002c4352b89eaf1a
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+++ b/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
@@ -23,7 +23,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: refresh-execution-tca
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:19f2bbe8c615f66a75f3d9252dd00ccc31c1a06f076ba1acb9acaf9d30828aa2
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:9fd3d1cf8cd52ede20e12bb676f565e0e7a94f57d47be319002c4352b89eaf1a
               imagePullPolicy: IfNotPresent
               env:
                 - name: DB_DSN

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:19f2bbe8c615f66a75f3d9252dd00ccc31c1a06f076ba1acb9acaf9d30828aa2
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:9fd3d1cf8cd52ede20e12bb676f565e0e7a94f57d47be319002c4352b89eaf1a
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-16T02:59:23Z"
+        client.knative.dev/updateTimestamp: "2026-05-16T02:40:40Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -27,7 +27,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:19f2bbe8c615f66a75f3d9252dd00ccc31c1a06f076ba1acb9acaf9d30828aa2
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:9fd3d1cf8cd52ede20e12bb676f565e0e7a94f57d47be319002c4352b89eaf1a
           ports:
             - name: http1
               containerPort: 8181
@@ -494,11 +494,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.570.0-8-ge8f789a86
+              value: v0.569.1-522-g1495ba8b1
             - name: TORGHUT_COMMIT
-              value: e8f789a868f399c9482859aff5d2bad01f6c0b66
+              value: 1495ba8b1f8178edc8d6d0a0c24cb0a6a3252e30
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:19f2bbe8c615f66a75f3d9252dd00ccc31c1a06f076ba1acb9acaf9d30828aa2
+              value: sha256:9fd3d1cf8cd52ede20e12bb676f565e0e7a94f57d47be319002c4352b89eaf1a
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-16T02:59:23Z"
+        client.knative.dev/updateTimestamp: "2026-05-16T02:40:40Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:19f2bbe8c615f66a75f3d9252dd00ccc31c1a06f076ba1acb9acaf9d30828aa2
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:9fd3d1cf8cd52ede20e12bb676f565e0e7a94f57d47be319002c4352b89eaf1a
           ports:
             - name: http1
               containerPort: 8181
@@ -316,11 +316,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.570.0-8-ge8f789a86
+              value: v0.569.1-522-g1495ba8b1
             - name: TORGHUT_COMMIT
-              value: e8f789a868f399c9482859aff5d2bad01f6c0b66
+              value: 1495ba8b1f8178edc8d6d0a0c24cb0a6a3252e30
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:19f2bbe8c615f66a75f3d9252dd00ccc31c1a06f076ba1acb9acaf9d30828aa2
+              value: sha256:9fd3d1cf8cd52ede20e12bb676f565e0e7a94f57d47be319002c4352b89eaf1a
           livenessProbe:
             httpGet:
               path: /healthz

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -98,7 +98,7 @@ spec:
           - name: allowStaleTape
           - name: persistResults
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:19f2bbe8c615f66a75f3d9252dd00ccc31c1a06f076ba1acb9acaf9d30828aa2
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:9fd3d1cf8cd52ede20e12bb676f565e0e7a94f57d47be319002c4352b89eaf1a
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
+++ b/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:19f2bbe8c615f66a75f3d9252dd00ccc31c1a06f076ba1acb9acaf9d30828aa2
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:9fd3d1cf8cd52ede20e12bb676f565e0e7a94f57d47be319002c4352b89eaf1a
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
Automatic rollback created because `torghut-post-deploy-verify` failed on `main`.

- Failed commit: `09b61156da4484d1d9b33f5a466e695737d627d3`
- Workflow run: `https://github.com/proompteng/lab/actions/runs/25951204556`
- Rollback source: `HEAD^` manifests from the failed run checkout