### PR TITLE
fix(torghut): preserve sim knative creator annotation

### DIFF
--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -9,6 +9,7 @@ metadata:
     app.kubernetes.io/part-of: lab
     networking.knative.dev/visibility: cluster-local
   annotations:
+    serving.knative.dev/creator: system:serviceaccount:argocd:argocd-application-controller
     serving.knative.dev/rollout-duration: 10s
     argocd.argoproj.io/tracking-id: torghut:serving.knative.dev/Service:torghut/torghut-sim
 spec:


### PR DESCRIPTION
## Summary

- Preserves the live immutable `serving.knative.dev/creator` annotation on the `torghut-sim` Knative Service.
- Unblocks Argo server-side apply for the Torghut promotion that carries image `e8f789a8`.
- Keeps the fix scoped to the GitOps manifest that failed during post-deploy verification.

## Related Issues

None

## Testing

- `bun run lint:argocd`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
