### PR TITLE
feat(agents): add native hf swarm proof lane

### DIFF
--- a/argocd/applications/agents/hf-team-agentprovider.yaml
+++ b/argocd/applications/agents/hf-team-agentprovider.yaml
@@ -109,23 +109,142 @@ spec:
           except Exception as error:
             print(f"NATS handoff publish skipped: {error}", file=sys.stderr)
 
-        def role_guidance(role: str) -> str:
+        def k8s_request(path: str) -> dict | str | None:
+          host = os.environ.get("KUBERNETES_SERVICE_HOST", "").strip()
+          port = os.environ.get("KUBERNETES_SERVICE_PORT", "443").strip()
+          token_path = Path("/var/run/secrets/kubernetes.io/serviceaccount/token")
+          ca_path = Path("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt")
+          if not host or not token_path.exists():
+            return None
+          token = token_path.read_text(encoding="utf-8").strip()
+          url = f"https://{host}:{port}{path}"
+          request = urllib.request.Request(url, headers={"Authorization": f"Bearer {token}"})
+          context = None
+          if ca_path.exists():
+            import ssl
+
+            context = ssl.create_default_context(cafile=str(ca_path))
+          with urllib.request.urlopen(request, timeout=20, context=context) as response:
+            body = response.read().decode("utf-8", errors="replace")
+            content_type = response.headers.get("content-type", "")
+            if "application/json" in content_type:
+              return json.loads(body)
+            return body
+
+        def extract_hf_result(log_text: str) -> str:
+          start = log_text.find("SWARM_HF_RESULT_BEGIN")
+          end = log_text.find("SWARM_HF_RESULT_END")
+          if start >= 0 and end > start:
+            return log_text[start + len("SWARM_HF_RESULT_BEGIN") : end].strip()
+          return log_text.strip()[-4000:]
+
+        def read_pod_log(namespace: str, job_name: str) -> str:
+          from urllib.parse import quote
+
+          selector = quote(f"job-name={job_name}", safe="")
+          pods = k8s_request(f"/api/v1/namespaces/{namespace}/pods?labelSelector={selector}")
+          if not isinstance(pods, dict):
+            return ""
+          items = pods.get("items")
+          if not isinstance(items, list) or not items:
+            return ""
+          pod = items[0] if isinstance(items[0], dict) else {}
+          pod_name = as_text(pod.get("metadata", {}).get("name")) if isinstance(pod.get("metadata"), dict) else ""
+          if not pod_name:
+            return ""
+          log = k8s_request(f"/api/v1/namespaces/{namespace}/pods/{pod_name}/log?container=agent-runner")
+          return log if isinstance(log, str) else ""
+
+        def stage_predecessors(stage: str, role: str) -> list[str]:
+          normalized_stage = stage.lower().strip()
+          normalized_role = role.lower().strip()
+          if normalized_stage == "verify":
+            return ["implement", "plan", "discover"]
+          if normalized_stage == "implement":
+            return ["plan", "discover"]
+          if normalized_stage == "plan":
+            return ["discover"]
+          if normalized_role == "reviewer":
+            return ["builder", "scout"]
+          if normalized_role == "builder":
+            return ["scout"]
+          return []
+
+        def resolve_auto_upstream(payload: dict, swarm_name: str, stage: str, role: str, run_name: str) -> str:
+          predecessors = stage_predecessors(stage, role)
+          if not predecessors:
+            return "None"
+          from urllib.parse import quote
+
+          namespace = as_text(payload.get("metadata", {}).get("namespace"), "agents") if isinstance(payload.get("metadata"), dict) else "agents"
+          selector = quote(f"swarm.proompteng.ai/name={swarm_name}", safe="")
+          runs = k8s_request(f"/apis/agents.proompteng.ai/v1alpha1/namespaces/{namespace}/agentruns?labelSelector={selector}")
+          if not isinstance(runs, dict):
+            return "None"
+          candidates = []
+          for item in runs.get("items", []):
+            if not isinstance(item, dict):
+              continue
+            metadata = item.get("metadata") if isinstance(item.get("metadata"), dict) else {}
+            name = as_text(metadata.get("name"))
+            if not name or name == run_name:
+              continue
+            labels = metadata.get("labels") if isinstance(metadata.get("labels"), dict) else {}
+            item_stage = as_text(labels.get("swarm.proompteng.ai/stage"))
+            item_role = read_field(item, "swarmAgentRole")
+            if item_stage not in predecessors and item_role not in predecessors:
+              continue
+            status = item.get("status") if isinstance(item.get("status"), dict) else {}
+            if as_text(status.get("phase")).lower() != "succeeded":
+              continue
+            workflow = status.get("workflow") if isinstance(status.get("workflow"), dict) else {}
+            steps = workflow.get("steps") if isinstance(workflow.get("steps"), list) else []
+            if not steps:
+              continue
+            last_step = steps[-1] if isinstance(steps[-1], dict) else {}
+            job_ref = last_step.get("jobRef") if isinstance(last_step.get("jobRef"), dict) else {}
+            job_name = as_text(job_ref.get("name"))
+            if not job_name:
+              continue
+            finished = as_text(status.get("finishedAt")) or as_text(status.get("updatedAt")) or as_text(metadata.get("creationTimestamp"))
+            candidates.append({"name": name, "stage": item_stage or item_role, "finished": finished, "job": job_name})
+          candidates.sort(key=lambda item: item["finished"], reverse=True)
+          for candidate in candidates:
+            log_text = read_pod_log(namespace, candidate["job"])
+            result = extract_hf_result(log_text)
+            if result:
+              return "\n".join([
+                f"Auto-discovered upstream run: {candidate['name']}",
+                f"Auto-discovered upstream stage: {candidate['stage']}",
+                "",
+                result,
+              ])
+          return "None"
+
+        def role_guidance(role: str, stage: str) -> str:
           normalized = role.lower().strip()
-          if normalized == "scout":
+          normalized_stage = stage.lower().strip()
+          if normalized == "scout" or normalized_stage == "discover":
             return (
               "Scout duty: identify the smallest grounded blocker or opportunity from the "
               "objective and supplied context. Do not design the full solution; hand off a "
-              "specific target for the builder."
+              "specific target for the next teammate."
             )
-          if normalized == "builder":
+          if normalized_stage == "plan":
             return (
-              "Builder duty: consume the scout handoff and turn it into a concrete, "
-              "implementable plan or artifact. Do not merely repeat the scout; add structure, "
-              "acceptance criteria, and the next build step."
+              "Planner duty: consume the discover handoff and convert it into a concise "
+              "plan with acceptance criteria, evidence requirements, and an exact next "
+              "implementation action. Do not merely repeat the scout."
             )
-          if normalized == "reviewer":
+          if normalized == "builder" or normalized == "engineer" or normalized_stage == "implement":
             return (
-              "Reviewer duty: consume the builder handoff, evaluate whether it satisfies the "
+              "Builder duty: consume the upstream handoff and turn it into a concrete, "
+              "implementable artifact or repair path. Do not merely repeat the prior worker; "
+              "add structure, acceptance criteria, and the next build step."
+            )
+          if normalized == "reviewer" or normalized == "deployer" or normalized_stage == "verify":
+            return (
+              "Reviewer duty: consume the implementation handoff, evaluate whether it satisfies the "
               "objective, list gaps or risks, and give a go/no-go next action. Do not speak as "
               "the builder or repeat the builder contribution as your own."
             )
@@ -147,10 +266,13 @@ spec:
           head = read_field(payload, "head", "unknown")
           swarm_name = read_field(payload, "swarmName", "hf-team")
           team_name = read_field(payload, "swarmTeamName", "HF Team")
+          stage = read_field(payload, "swarmStage", role)
           role = read_field(payload, "swarmAgentRole", "worker")
           identity = read_field(payload, "swarmAgentIdentity", role)
           objective = read_field(payload, "objective", "create measurable value with the team")
           upstream = read_field(payload, "upstreamArtifact", "None")
+          if upstream.lower() in {"", "none", "auto"}:
+            upstream = resolve_auto_upstream(payload, swarm_name, stage, role, run_name)
           expected_output = read_field(payload, "expectedOutput", "a concise production-quality handoff")
           model = os.environ.get("HF_MODEL", "meta-llama/Llama-3.1-8B-Instruct:novita").strip()
           base_url = os.environ.get("HF_BASE_URL", "https://router.huggingface.co/v1").strip()
@@ -177,8 +299,9 @@ spec:
                 f"Swarm: {swarm_name}",
                 f"Team: {team_name}",
                 f"Worker identity: {identity}",
+                f"Stage: {stage}",
                 f"Role: {role}",
-                role_guidance(role),
+                role_guidance(role, stage),
                 f"Objective: {objective}",
                 f"Expected output: {expected_output}",
                 "",

--- a/argocd/applications/agents/hf-team-swarm-agentrun-templates.yaml
+++ b/argocd/applications/agents/hf-team-swarm-agentrun-templates.yaml
@@ -1,0 +1,147 @@
+apiVersion: agents.proompteng.ai/v1alpha1
+kind: AgentRun
+metadata:
+  name: hf-team-swarm-discover-template
+  namespace: agents
+  annotations:
+    agents.proompteng.ai/template: "true"
+spec:
+  agentRef:
+    name: hf-team-scout-agent
+  implementationSpecRef:
+    name: hf-team-collaboration-v1
+  runtime:
+    type: workflow
+    config:
+      serviceAccountName: agents-sa
+  ttlSecondsAfterFinished: 3600
+  workflow:
+    steps:
+      - name: discover
+        timeoutSeconds: 300
+  parameters:
+    repository: proompteng/lab
+    base: main
+    head: codex/swarm-hf-team-e2e
+    swarmName: hf-team-e2e
+    swarmStage: discover
+    swarmAgentRole: scout
+    swarmAgentIdentity: mira-scout
+    swarmTeamName: HF Team E2E
+    objective: identify the smallest grounded blocker or opportunity for proving native Swarm-managed teammate collaboration
+    upstreamArtifact: AUTO
+    expectedOutput: grounded discover handoff with evidence and exact next action
+  secrets:
+    - hf-router-token
+    - nats-agents-credentials
+---
+apiVersion: agents.proompteng.ai/v1alpha1
+kind: AgentRun
+metadata:
+  name: hf-team-swarm-plan-template
+  namespace: agents
+  annotations:
+    agents.proompteng.ai/template: "true"
+spec:
+  agentRef:
+    name: hf-team-scout-agent
+  implementationSpecRef:
+    name: hf-team-collaboration-v1
+  runtime:
+    type: workflow
+    config:
+      serviceAccountName: agents-sa
+  ttlSecondsAfterFinished: 3600
+  workflow:
+    steps:
+      - name: plan
+        timeoutSeconds: 300
+  parameters:
+    repository: proompteng/lab
+    base: main
+    head: codex/swarm-hf-team-e2e
+    swarmName: hf-team-e2e
+    swarmStage: plan
+    swarmAgentRole: planner
+    swarmAgentIdentity: paige-planner
+    swarmTeamName: HF Team E2E
+    objective: turn the discovered blocker or opportunity into an implementable Swarm proof plan with acceptance criteria
+    upstreamArtifact: AUTO
+    expectedOutput: grounded plan handoff that consumes discover output and names implementation proof criteria
+  secrets:
+    - hf-router-token
+    - nats-agents-credentials
+---
+apiVersion: agents.proompteng.ai/v1alpha1
+kind: AgentRun
+metadata:
+  name: hf-team-swarm-implement-template
+  namespace: agents
+  annotations:
+    agents.proompteng.ai/template: "true"
+spec:
+  agentRef:
+    name: hf-team-builder-agent
+  implementationSpecRef:
+    name: hf-team-collaboration-v1
+  runtime:
+    type: workflow
+    config:
+      serviceAccountName: agents-sa
+  ttlSecondsAfterFinished: 3600
+  workflow:
+    steps:
+      - name: implement
+        timeoutSeconds: 300
+  parameters:
+    repository: proompteng/lab
+    base: main
+    head: codex/swarm-hf-team-e2e
+    swarmName: hf-team-e2e
+    swarmStage: implement
+    swarmAgentRole: builder
+    swarmAgentIdentity: devon-builder
+    swarmTeamName: HF Team E2E
+    objective: create the concrete proof artifact or next implementation action from the Swarm plan handoff
+    upstreamArtifact: AUTO
+    expectedOutput: grounded implementation handoff that consumes plan output and creates measurable next-step value
+  secrets:
+    - hf-router-token
+    - nats-agents-credentials
+---
+apiVersion: agents.proompteng.ai/v1alpha1
+kind: AgentRun
+metadata:
+  name: hf-team-swarm-verify-template
+  namespace: agents
+  annotations:
+    agents.proompteng.ai/template: "true"
+spec:
+  agentRef:
+    name: hf-team-reviewer-agent
+  implementationSpecRef:
+    name: hf-team-collaboration-v1
+  runtime:
+    type: workflow
+    config:
+      serviceAccountName: agents-sa
+  ttlSecondsAfterFinished: 3600
+  workflow:
+    steps:
+      - name: verify
+        timeoutSeconds: 300
+  parameters:
+    repository: proompteng/lab
+    base: main
+    head: codex/swarm-hf-team-e2e
+    swarmName: hf-team-e2e
+    swarmStage: verify
+    swarmAgentRole: reviewer
+    swarmAgentIdentity: rhea-reviewer
+    swarmTeamName: HF Team E2E
+    objective: verify whether the implementation handoff proves native Swarm-managed teammate collaboration and name remaining gaps
+    upstreamArtifact: AUTO
+    expectedOutput: grounded verification handoff with go/no-go decision, risks, and exact next action
+  secrets:
+    - hf-router-token
+    - nats-agents-credentials

--- a/argocd/applications/agents/hf-team-swarm.yaml
+++ b/argocd/applications/agents/hf-team-swarm.yaml
@@ -1,0 +1,103 @@
+apiVersion: swarm.proompteng.ai/v1alpha1
+kind: Swarm
+metadata:
+  name: hf-team-e2e
+  namespace: agents
+spec:
+  owner:
+    id: hf-team-owner
+    channel: swarm://owner/hf-team-e2e
+  domains:
+    - swarm-reliability
+    - collaboration-proof
+  objectives:
+    - operate as a Swarm-managed HF fallback team when Codex/OpenAI capacity is unavailable
+    - prove teammate handoffs through discover, plan, implement, and verify stages
+    - create grounded next-step value without inventing evidence
+  mission:
+    ledgerRef: /workspace/.agentrun/swarm/hf-team-e2e-mission-ledger.md
+    sourceDesign: docs/agents/designs/swarm-agentic-mission-architecture-2026-05-08.md
+    businessMetric: successful Swarm-managed teammate handoff chain across all stages
+    validationContract:
+      - every stage must consume the prior stage handoff when one exists
+      - every stage must cite only supplied runtime or upstream evidence
+      - implement stages must create a concrete next-step artifact or repair path
+      - verify stages must name remaining gaps and an exact next action
+    valueGates:
+      - native_swarm_schedule_created
+      - prior_handoff_consumed
+      - stage_success_rate
+      - grounded_evidence_quality
+      - exact_next_action_quality
+    handoffRequiredFields:
+      - objective
+      - upstream_read
+      - contribution
+      - evidence
+      - unresolved_issues
+      - exact_next_action
+  mode: lights-out
+  timezone: UTC
+  cadence:
+    discoverEvery: 1h
+    planEvery: 1h
+    implementEvery: 1h
+    verifyEvery: 1h
+  integrations:
+    nats:
+      url: nats://nats.nats.svc.cluster.local:4222
+      subjectPrefix: workflow
+      channel: general
+      personas:
+        architect:
+          humanName: Mira Scout
+          workerIdentity: mira-scout
+        engineer:
+          humanName: Devon Builder
+          workerIdentity: devon-builder
+        deployer:
+          humanName: Rhea Reviewer
+          workerIdentity: rhea-reviewer
+  discovery:
+    minCitations: 1
+    minConfidence: 0.7
+    sources:
+      - name: runtime-handoff-artifacts
+      - name: swarm-status
+  delivery:
+    repoAllowlist:
+      - proompteng/lab
+    requiredChecks:
+      - lint
+      - validate
+    mergePolicy: merge-queue
+    deploymentTargets:
+      - agents
+    rollout:
+      strategy: canary
+      steps:
+        - setWeight: 100
+          pause: 0m
+      analysisTemplateRef: hf-team-e2e-proof
+  risk:
+    budgetRef: default-budget
+    approvalPolicyRef: default-approval
+    freezeAfterFailures: 3
+    freezeDuration: 60m
+  execution:
+    discover:
+      targetRef:
+        kind: AgentRun
+        name: hf-team-swarm-discover-template
+    plan:
+      targetRef:
+        kind: AgentRun
+        name: hf-team-swarm-plan-template
+    implement:
+      targetRef:
+        kind: AgentRun
+        name: hf-team-swarm-implement-template
+    verify:
+      targetRef:
+        kind: AgentRun
+        name: hf-team-swarm-verify-template

--- a/argocd/applications/agents/kustomization.yaml
+++ b/argocd/applications/agents/kustomization.yaml
@@ -10,6 +10,8 @@ resources:
   - hf-team-agentprovider.yaml
   - hf-team-agents.yaml
   - hf-team-implspec.yaml
+  - hf-team-swarm-agentrun-templates.yaml
+  - hf-team-swarm.yaml
   - hf-team-secretbinding.yaml
   - codex-secretbinding.yaml
   - codex-agent.yaml


### PR DESCRIPTION
## Summary

- Adds a native `hf-team-e2e` Swarm that owns discover, plan, implement, and verify schedules backed by the HF teammate Agents.
- Adds Swarm AgentRun templates for the HF team so the Swarm controller can launch the fallback team through normal Schedule/CronJob machinery.
- Teaches the HF worker to auto-discover the latest successful prior-stage handoff for the same Swarm from AgentRun pod logs when `upstreamArtifact` is `AUTO`.

## Related Issues

None

## Testing

- `git diff --check -- argocd/applications/agents`
- `kubectl apply --dry-run=client -f argocd/applications/agents/hf-team-agentprovider.yaml -f argocd/applications/agents/hf-team-swarm-agentrun-templates.yaml -f argocd/applications/agents/hf-team-swarm.yaml`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents`
- `bun run lint:argocd`
- `python3 -m py_compile /tmp/hf-team-worker.py`
- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
