### PR TITLE
fix(temporal-bun-sdk): suppress transient heartbeat failures

### DIFF
--- a/packages/temporal-bun-sdk/src/activities/lifecycle.ts
+++ b/packages/temporal-bun-sdk/src/activities/lifecycle.ts
@@ -270,11 +270,21 @@ class ActivityHeartbeatDriver {
       details: payloads.length > 0 ? create(PayloadsSchema, { payloads }) : undefined,
     })
 
-    const response = await this.#executeWithRetry(async () => {
-      return await this.#options.workflowService.recordActivityTaskHeartbeat(request, {
-        timeoutMs: this.#config.heartbeatRpcTimeoutMs,
+    let response: { cancelRequested?: boolean }
+    try {
+      response = await this.#executeWithRetry(async () => {
+        return await this.#options.workflowService.recordActivityTaskHeartbeat(request, {
+          timeoutMs: this.#config.heartbeatRpcTimeoutMs,
+        })
       })
-    })
+    } catch (error) {
+      if (!isRetriableHeartbeatError(error)) {
+        throw error
+      }
+      this.#recordHeartbeatFailure(error)
+      this.#options.context.info.lastHeartbeatDetails = details
+      return
+    }
 
     this.#options.context.info.lastHeartbeatDetails = details
     this.#options.context.info.lastHeartbeatTime = new Date()

--- a/packages/temporal-bun-sdk/tests/activities/lifecycle.test.ts
+++ b/packages/temporal-bun-sdk/tests/activities/lifecycle.test.ts
@@ -110,7 +110,7 @@ describe('activity lifecycle helpers', () => {
     expect(stub.calls[0]?.details).toBeUndefined()
   })
 
-  test('records heartbeat failures once when retries are exhausted', async () => {
+  test('records and suppresses retryable heartbeat failures when retries are exhausted', async () => {
     const failureCounter = createTestCounter()
 
     const lifecycle = await Effect.runPromise(
@@ -147,27 +147,11 @@ describe('activity lifecycle helpers', () => {
       }),
     )
 
-    let caught = false
-    await Effect.runPromise(
-      registration
-        .heartbeat(['boom'])
-        .pipe(
-          Effect.catchAll((error) =>
-            Effect.sync(() => {
-              caught = true
-              const root =
-                typeof error === 'object' && error && 'cause' in error
-                  ? ((error as { cause?: unknown }).cause ?? error)
-                  : error
-              expect(root).toBeInstanceOf(ConnectError)
-            }),
-          ),
-        ),
-    )
-    expect(caught).toBe(true)
+    await Effect.runPromise(registration.heartbeat(['boom']))
     await Effect.runPromise(registration.shutdown)
 
     expect(failureCounter.getCount()).toBe(1)
+    expect(context.info.lastHeartbeatDetails).toEqual(['boom'])
   })
 
   test('heartbeat not-found aborts the activity instead of surfacing an RPC failure', async () => {

--- a/packages/temporal-bun-sdk/tests/observability/integration.test.ts
+++ b/packages/temporal-bun-sdk/tests/observability/integration.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from 'bun:test'
 import { Code, ConnectError } from '@connectrpc/connect'
-import { Cause, Effect, Exit, Option } from 'effect'
+import { Effect } from 'effect'
 import { readFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -102,23 +102,11 @@ test('activity lifecycle wiring emits logger + metric telemetry', async () => {
     }),
   )
 
-  const heartbeatExit = await Effect.runPromiseExit(registration.heartbeat(['telemetry']))
-  expect(Exit.isFailure(heartbeatExit)).toBeTrue()
-  if (Exit.isFailure(heartbeatExit)) {
-    const failure = Cause.failureOption(heartbeatExit.cause)
-    expect(Option.isSome(failure)).toBeTrue()
-    if (Option.isSome(failure)) {
-      const rootCause =
-        failure.value instanceof ConnectError
-          ? failure.value
-          : typeof failure.value === 'object' && failure.value !== null && 'cause' in failure.value
-            ? (failure.value as { cause?: unknown }).cause ?? failure.value
-            : failure.value
-      expect(rootCause).toBeInstanceOf(ConnectError)
-    }
-  }
+  await Effect.runPromise(registration.heartbeat(['telemetry']))
   await Effect.runPromise(registration.shutdown)
 
+  expect(context.info.lastHeartbeatDetails).toEqual(['telemetry'])
+  expect(context.isCancellationRequested).toBe(false)
   expect(exporter.getCounterValue('integration_heartbeat_retries_total')).toBeGreaterThanOrEqual(1)
   expect(exporter.getCounterValue('integration_heartbeat_failures_total')).toBe(1)
   expect(

--- a/packages/temporal-bun-sdk/tests/worker.activity-response-retry.test.ts
+++ b/packages/temporal-bun-sdk/tests/worker.activity-response-retry.test.ts
@@ -286,3 +286,99 @@ test('worker treats heartbeat not-found as activity cancellation', async () => {
   expect(completions).toBe(0)
   expect(failures).toBe(0)
 })
+
+test('worker suppresses retryable heartbeat RPC failures so activity retry policy remains server-owned', async () => {
+  const config: TemporalConfig = createTestTemporalConfig({
+    taskQueue: 'activity-heartbeat-transient',
+    stickySchedulingEnabled: false,
+    rpcRetryPolicy: {
+      maxAttempts: 2,
+      initialDelayMs: 1,
+      maxDelayMs: 1,
+      backoffCoefficient: 1,
+      jitterFactor: 0,
+      retryableStatusCodes: [Code.DeadlineExceeded],
+    },
+  })
+  const observability = createObservabilityStub()
+  let activityPolls = 0
+  let heartbeats = 0
+  let cancellations = 0
+  let completions = 0
+  let failures = 0
+
+  const workflowService: WorkflowServiceClient = {
+    pollWorkflowTaskQueue: async (_request, { signal }: { signal?: AbortSignal }) => await waitForAbort(signal),
+    pollActivityTaskQueue: async (_request, { signal }: { signal?: AbortSignal }) => {
+      activityPolls += 1
+      if (activityPolls === 1) {
+        return {
+          taskToken: new Uint8Array([10, 11, 12]),
+          workflowExecution: { workflowId: 'wf-heartbeat-transient', runId: 'run-heartbeat-transient' },
+          workflowNamespace: config.namespace,
+          workflowType: { name: 'activityHeartbeatTransientWorkflow' },
+          activityId: 'activity-1',
+          activityType: { name: 'heartbeatTransientActivity' },
+          attempt: 1,
+        }
+      }
+      return await waitForAbort(signal)
+    },
+    getWorkflowExecutionHistory: async () => ({ history: { events: [] }, nextPageToken: new Uint8Array() }),
+    recordActivityTaskHeartbeat: async () => {
+      heartbeats += 1
+      throw new ConnectError('[unavailable] shard status unknown', Code.Unavailable)
+    },
+    respondQueryTaskCompleted: async () => ({}),
+    respondWorkflowTaskCompleted: async () => ({}),
+    respondWorkflowTaskFailed: async () => ({}),
+    respondActivityTaskCompleted: async () => {
+      completions += 1
+      return {}
+    },
+    respondActivityTaskFailed: async () => {
+      failures += 1
+      return {}
+    },
+    respondActivityTaskCanceled: async () => {
+      cancellations += 1
+      return {}
+    },
+    requestCancelWorkflowExecution: async () => ({}),
+    pollWorkflowExecutionUpdate: async () => ({ messages: [] }),
+  } as unknown as WorkflowServiceClient
+
+  const runtime = await WorkerRuntime.create({
+    config,
+    taskQueue: config.taskQueue,
+    namespace: config.namespace,
+    workflows: [defineWorkflow('activityHeartbeatTransientWorkflow', () => Effect.succeed('ok'))],
+    activities: {
+      heartbeatTransientActivity: async () => {
+        const context = currentActivityContext()
+        if (!context) {
+          throw new Error('missing activity context')
+        }
+        await context.heartbeat({ step: 'heartbeat-transient' })
+        return 'completed-after-transient-heartbeat'
+      },
+    },
+    workflowService,
+    logger: observability.services.logger,
+    metrics: observability.services.metricsRegistry,
+    metricsExporter: observability.services.metricsExporter,
+    stickyScheduling: false,
+    pollers: { workflow: 0 },
+    concurrency: { workflow: 1, activity: 1 },
+  })
+
+  const runPromise = runtime.run()
+  await waitFor(() => completions >= 1 || failures >= 1 || cancellations >= 1, 7_000)
+  await runtime.shutdown()
+  await runPromise
+
+  expect(heartbeats).toBeGreaterThanOrEqual(1)
+  expect(completions).toBe(1)
+  expect(cancellations).toBe(0)
+  expect(failures).toBe(0)
+})


### PR DESCRIPTION
## Summary

- Suppresses exhausted retryable activity-heartbeat RPC failures after logging telemetry instead of surfacing them as activity failures.
- Preserves definitive heartbeat not-found/cancellation behavior while keeping transient Temporal outages out of user activity retry semantics.
- Adds worker-level and lifecycle/observability regression coverage for `[unavailable] shard status unknown` heartbeat failures.

## Related Issues

None

## Testing

- `bun test packages/temporal-bun-sdk/tests/activities/lifecycle.test.ts packages/temporal-bun-sdk/tests/worker.activity-response-retry.test.ts`
- `bun test packages/temporal-bun-sdk/tests/observability/integration.test.ts packages/temporal-bun-sdk/tests/activities/lifecycle.test.ts packages/temporal-bun-sdk/tests/worker.activity-response-retry.test.ts`
- `bunx oxfmt --check packages/temporal-bun-sdk/src/activities/lifecycle.ts packages/temporal-bun-sdk/tests/activities/lifecycle.test.ts packages/temporal-bun-sdk/tests/worker.activity-response-retry.test.ts packages/temporal-bun-sdk/tests/observability/integration.test.ts`
- `bun run --cwd packages/temporal-bun-sdk lint:oxlint`
- `bun run --cwd packages/temporal-bun-sdk lint:oxlint:type`
- `bun run --cwd packages/temporal-bun-sdk test`
- `bun run --filter @proompteng/temporal-bun-sdk build`
- `bun run --cwd packages/temporal-bun-sdk verify:production`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
