### PR TITLE
fix(agents): make codex quota fallback deterministic

### DIFF
--- a/argocd/applications/agents/codex-spark-agentprovider.yaml
+++ b/argocd/applications/agents/codex-spark-agentprovider.yaml
@@ -51,7 +51,7 @@ spec:
           "binary": "/bin/bash",
           "argsTemplate": [
             "-lc",
-            "set -o pipefail; EVENT_FILE=$(mktemp /tmp/codex-event.XXXXXX.json) && cp \"$1\" \"$EVENT_FILE\" && python3 /root/.codex/ensure-market-context-issue-number.py \"$EVENT_FILE\" && mkdir -p /workspace/.agent && LOG_PATH=/workspace/.agent/runner.log && if /usr/local/bin/codex-implement \"$EVENT_FILE\" > >(tee \"$LOG_PATH\") 2> >(tee -a \"$LOG_PATH\" >&2); then exit 0; fi; status=$?; if python3 /root/.codex/should-hf-swarm-fallback.py \"$LOG_PATH\"; then exec python3 /root/.codex/swarm-hf-codex-fallback.py \"$EVENT_FILE\" \"$LOG_PATH\"; fi; exit \"$status\"",
+            "set -o pipefail; EVENT_FILE=$(mktemp /tmp/codex-event.XXXXXX.json) && cp \"$1\" \"$EVENT_FILE\" && python3 /root/.codex/ensure-market-context-issue-number.py \"$EVENT_FILE\" && mkdir -p /workspace/.agent && LOG_PATH=/workspace/.agent/runner.log && /usr/local/bin/codex-implement \"$EVENT_FILE\" 2>&1 | tee \"$LOG_PATH\"; status=${PIPESTATUS[0]}; if [ \"$status\" -eq 0 ]; then exit 0; fi; if python3 /root/.codex/should-hf-swarm-fallback.py \"$LOG_PATH\"; then exec python3 /root/.codex/swarm-hf-codex-fallback.py \"$EVENT_FILE\" \"$LOG_PATH\"; fi; exit \"$status\"",
             "--",
             "{{payloads.eventFilePath}}"
           ],

--- a/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
+++ b/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'bun:test'
-import { readFileSync } from 'node:fs'
-import { resolve } from 'node:path'
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
 import { parseAllDocuments } from 'yaml'
 
 import {
@@ -359,16 +361,50 @@ describe('scheduled AgentRun templates', () => {
     const manifests = readYamlObjects('argocd/applications/agents/codex-spark-agentprovider.yaml')
     const provider = manifests.find((manifest) => objectAt(objectAt(manifest, 'metadata'), 'name') === 'codex-spark')
     const inputFiles = objectAt(objectAt(provider, 'spec'), 'inputFiles') as Record<string, unknown>[] | undefined
+    const providerConfig = inputFiles?.find(
+      (inputFile) => objectAt(inputFile, 'path') === '/root/.codex/provider-codex-spark.json',
+    )
+    const providerCommand = JSON.parse(String(objectAt(providerConfig, 'content'))).argsTemplate[1]
     const fallbackScript = inputFiles?.find(
       (inputFile) => objectAt(inputFile, 'path') === '/root/.codex/swarm-hf-codex-fallback.py',
     )
     const content = objectAt(fallbackScript, 'content')
 
+    expect(providerCommand).toContain('2>&1 | tee "$LOG_PATH"')
+    expect(providerCommand).toContain('status=${PIPESTATUS[0]}')
+    expect(providerCommand).not.toContain('> >(tee')
     expect(content).toContain('def summarize_upstream(upstream: str) -> str:')
     expect(content).toContain('def render_fallback_result(')
     expect(content).toContain('Auto-discovered upstream run:')
     expect(content).toContain('The wrapper will render authoritative upstream run and stage facts.')
     expect(content).toContain('\"upstream_read\": summarize_upstream(upstream)')
+  })
+
+  it('classifies current Codex quota logs as HF fallback eligible', () => {
+    const manifests = readYamlObjects('argocd/applications/agents/codex-spark-agentprovider.yaml')
+    const provider = manifests.find((manifest) => objectAt(objectAt(manifest, 'metadata'), 'name') === 'codex-spark')
+    const inputFiles = objectAt(objectAt(provider, 'spec'), 'inputFiles') as Record<string, unknown>[] | undefined
+    const fallbackPredicate = inputFiles?.find(
+      (inputFile) => objectAt(inputFile, 'path') === '/root/.codex/should-hf-swarm-fallback.py',
+    )
+    const tempDir = mkdtempSync(join(tmpdir(), 'codex-fallback-'))
+    const scriptPath = join(tempDir, 'should-hf-swarm-fallback.py')
+    const logPath = join(tempDir, 'runner.log')
+
+    writeFileSync(scriptPath, String(objectAt(fallbackPredicate, 'content')))
+    writeFileSync(
+      logPath,
+      [
+        'Running Codex implementation for proompteng/lab#swarm-jangar-control-plane',
+        'Turn started',
+        'Stream error -> Quota exceeded. Check your plan and billing details.',
+        'Turn failed -> Quota exceeded. Check your plan and billing details.',
+      ].join('\n'),
+    )
+
+    const result = spawnSync('python3', [scriptPath, logPath], { encoding: 'utf8' })
+
+    expect(result.status).toBe(0)
   })
 
   it('renders HF team handoff quality evidence outside the model draft', () => {


### PR DESCRIPTION
## Summary

- Makes the Codex Spark provider capture primary runner output through a synchronous `tee` pipeline before evaluating HF fallback eligibility.
- Preserves the primary Codex exit code while avoiding the previous process-substitution log flush race.
- Adds regression coverage for the current live quota failure text from Jangar/Torghut swarm runs.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `kubectl apply --dry-run=client -f argocd/applications/agents/codex-spark-agentprovider.yaml`
- `git diff --check -- argocd/applications/agents/codex-spark-agentprovider.yaml packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents`
- `bun run lint:argocd`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
