### PR TITLE
fix(agents): publish swarm handoffs on workflow subjects

### DIFF
--- a/argocd/applications/agents/codex-spark-agentprovider.yaml
+++ b/argocd/applications/agents/codex-spark-agentprovider.yaml
@@ -8,6 +8,8 @@ spec:
   envTemplate:
     CODEX_LOG_LEVEL: info
     NATS_URL: nats://nats.nats.svc.cluster.local:4222
+    AGENT_RUN_NAME: "{{agentRun.name}}"
+    AGENT_RUN_NAMESPACE: "{{agentRun.namespace}}"
     AGENT_PROVIDER_PATH: /root/.codex/provider-codex-spark.json
     CODEX_MODEL: gpt-5.5
     HF_BASE_URL: https://router.huggingface.co/v1
@@ -398,6 +400,27 @@ spec:
           command.extend(["pub", subject, json.dumps(handoff, sort_keys=True)])
           subprocess.run(command, check=False, timeout=20)
 
+        def subject_part(value: str, default: str) -> str:
+          text = as_text(value, default)
+          normalized = "".join(char if char.isalnum() or char in {"-", "_"} else "-" for char in text)
+          normalized = "-".join(part for part in normalized.split("-") if part)
+          return normalized or default
+
+        def handoff_subject(payload: dict, swarm_name: str, role: str, run_name: str, suffix: str = "") -> str:
+          prefix = read_field(payload, "natsSubjectPrefix", "workflow")
+          channel = read_field(payload, "natsChannel", "general")
+          parts = [
+            subject_part(prefix, "workflow"),
+            subject_part(channel, "general"),
+            "swarm",
+            subject_part(swarm_name, "unknown-swarm"),
+            subject_part(role, "worker"),
+            subject_part(run_name, "unknown-run"),
+          ]
+          if suffix:
+            parts.append(subject_part(suffix, "handoff"))
+          return ".".join(parts)
+
         def role_guidance(role: str, stage: str) -> str:
           normalized_stage = stage.lower().strip()
           normalized_role = role.lower().strip()
@@ -506,7 +529,8 @@ spec:
           if not token:
             raise RuntimeError("HF_TOKEN is required for Codex provider fallback")
 
-          run_name = read_field(payload, "name", as_text(payload.get("metadata", {}).get("name"), "unknown-run"))
+          env_run_name = os.environ.get("AGENT_RUN_NAME", "").strip()
+          run_name = read_field(payload, "name", env_run_name or as_text(payload.get("metadata", {}).get("name"), "unknown-run"))
           repository = read_field(payload, "repository", "unknown")
           base = read_field(payload, "base", "main")
           head = read_field(payload, "head", "unknown")
@@ -593,7 +617,7 @@ spec:
             "content": content,
           }
           (output_dir / "status.json").write_text(json.dumps({"status": "hf_fallback_succeeded", **handoff}, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-          publish_handoff(f"swarm.{swarm_name}.{role}.{run_name}.fallback".replace("/", "."), handoff)
+          publish_handoff(handoff_subject(payload, swarm_name, role, run_name, "fallback"), handoff)
           print("SWARM_CODEX_HF_FALLBACK_RESULT_BEGIN")
           print(content)
           print("SWARM_CODEX_HF_FALLBACK_RESULT_END")

--- a/argocd/applications/agents/hf-team-agentprovider.yaml
+++ b/argocd/applications/agents/hf-team-agentprovider.yaml
@@ -11,6 +11,8 @@ spec:
     HF_BASE_URL: https://router.huggingface.co/v1
     HF_MODEL: meta-llama/Llama-3.1-8B-Instruct:novita
     NATS_URL: nats://nats.nats.svc.cluster.local:4222
+    AGENT_RUN_NAME: "{{agentRun.name}}"
+    AGENT_RUN_NAMESPACE: "{{agentRun.namespace}}"
   inputFiles:
     - path: /root/.codex/hf-team-worker.py
       content: |-
@@ -108,6 +110,24 @@ spec:
             subprocess.run(command, check=False, timeout=20)
           except Exception as error:
             print(f"NATS handoff publish skipped: {error}", file=sys.stderr)
+
+        def subject_part(value: str, default: str) -> str:
+          text = as_text(value, default)
+          normalized = "".join(char if char.isalnum() or char in {"-", "_"} else "-" for char in text)
+          normalized = "-".join(part for part in normalized.split("-") if part)
+          return normalized or default
+
+        def handoff_subject(payload: dict, swarm_name: str, role: str, run_name: str) -> str:
+          prefix = read_field(payload, "natsSubjectPrefix", "workflow")
+          channel = read_field(payload, "natsChannel", "general")
+          return ".".join([
+            subject_part(prefix, "workflow"),
+            subject_part(channel, "general"),
+            "swarm",
+            subject_part(swarm_name, "unknown-swarm"),
+            subject_part(role, "worker"),
+            subject_part(run_name, "unknown-run"),
+          ])
 
         def k8s_request(path: str) -> dict | str | None:
           host = os.environ.get("KUBERNETES_SERVICE_HOST", "").strip()
@@ -402,7 +422,8 @@ spec:
           if not token:
             raise RuntimeError("HF_TOKEN is required")
 
-          run_name = read_field(payload, "name", as_text(payload.get("metadata", {}).get("name"), "unknown-run"))
+          env_run_name = os.environ.get("AGENT_RUN_NAME", "").strip()
+          run_name = read_field(payload, "name", env_run_name or as_text(payload.get("metadata", {}).get("name"), "unknown-run"))
           repository = read_field(payload, "repository", "unknown")
           base = read_field(payload, "base", "main")
           head = read_field(payload, "head", "unknown")
@@ -504,8 +525,7 @@ spec:
             "content": content,
           }
           status_path.write_text(json.dumps(handoff, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-          subject = f"swarm.{swarm_name}.{role}.{run_name}".replace("/", ".")
-          publish_handoff(subject, handoff)
+          publish_handoff(handoff_subject(payload, swarm_name, role, run_name), handoff)
 
           print("SWARM_HF_RESULT_BEGIN")
           print(content)

--- a/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
+++ b/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
@@ -360,6 +360,7 @@ describe('scheduled AgentRun templates', () => {
   it('renders Codex HF fallback handoff facts outside the model draft', () => {
     const manifests = readYamlObjects('argocd/applications/agents/codex-spark-agentprovider.yaml')
     const provider = manifests.find((manifest) => objectAt(objectAt(manifest, 'metadata'), 'name') === 'codex-spark')
+    const envTemplate = objectAt(objectAt(provider, 'spec'), 'envTemplate')
     const inputFiles = objectAt(objectAt(provider, 'spec'), 'inputFiles') as Record<string, unknown>[] | undefined
     const providerConfig = inputFiles?.find(
       (inputFile) => objectAt(inputFile, 'path') === '/root/.codex/provider-codex-spark.json',
@@ -373,11 +374,20 @@ describe('scheduled AgentRun templates', () => {
     expect(providerCommand).toContain('2>&1 | tee "$LOG_PATH"')
     expect(providerCommand).toContain('status=${PIPESTATUS[0]}')
     expect(providerCommand).not.toContain('> >(tee')
+    expect(objectAt(envTemplate, 'AGENT_RUN_NAME')).toBe('{{agentRun.name}}')
+    expect(objectAt(envTemplate, 'AGENT_RUN_NAMESPACE')).toBe('{{agentRun.namespace}}')
     expect(content).toContain('def summarize_upstream(upstream: str) -> str:')
+    expect(content).toContain(
+      'def handoff_subject(payload: dict, swarm_name: str, role: str, run_name: str, suffix: str = "") -> str:',
+    )
     expect(content).toContain('def render_fallback_result(')
     expect(content).toContain('Auto-discovered upstream run:')
     expect(content).toContain('The wrapper will render authoritative upstream run and stage facts.')
     expect(content).toContain('\"upstream_read\": summarize_upstream(upstream)')
+    expect(content).toContain(
+      'publish_handoff(handoff_subject(payload, swarm_name, role, run_name, "fallback"), handoff)',
+    )
+    expect(content).not.toContain('publish_handoff(f"swarm.')
   })
 
   it('classifies current Codex quota logs as HF fallback eligible', () => {
@@ -410,13 +420,17 @@ describe('scheduled AgentRun templates', () => {
   it('renders HF team handoff quality evidence outside the model draft', () => {
     const manifests = readYamlObjects('argocd/applications/agents/hf-team-agentprovider.yaml')
     const provider = manifests.find((manifest) => objectAt(objectAt(manifest, 'metadata'), 'name') === 'hf-team-worker')
+    const envTemplate = objectAt(objectAt(provider, 'spec'), 'envTemplate')
     const inputFiles = objectAt(objectAt(provider, 'spec'), 'inputFiles') as Record<string, unknown>[] | undefined
     const workerScript = inputFiles?.find(
       (inputFile) => objectAt(inputFile, 'path') === '/root/.codex/hf-team-worker.py',
     )
     const content = objectAt(workerScript, 'content')
 
+    expect(objectAt(envTemplate, 'AGENT_RUN_NAME')).toBe('{{agentRun.name}}')
+    expect(objectAt(envTemplate, 'AGENT_RUN_NAMESPACE')).toBe('{{agentRun.namespace}}')
     expect(content).toContain('def summarize_upstream(upstream: str) -> dict:')
+    expect(content).toContain('def handoff_subject(payload: dict, swarm_name: str, role: str, run_name: str) -> str:')
     expect(content).toContain(
       'def quality_report(stage: str, upstream_info: dict, exact_next_action: str, issues: list[str]) -> dict:',
     )
@@ -426,6 +440,8 @@ describe('scheduled AgentRun templates', () => {
     )
     expect(content).toContain('\"handoff_quality\": quality')
     expect(content).toContain('\"exact_next_action\": exact_next_action')
+    expect(content).toContain('publish_handoff(handoff_subject(payload, swarm_name, role, run_name), handoff)')
+    expect(content).not.toContain('publish_handoff(f"swarm.')
   })
 
   it('keeps the deployer implementation spec focused on a bounded release slice', () => {


### PR DESCRIPTION
## Summary

- Publishes HF team and Codex HF fallback swarm handoffs on `workflow.<channel>.swarm...` subjects that match live NATS publish permissions.
- Injects `AGENT_RUN_NAME` and `AGENT_RUN_NAMESPACE` into both providers so handoff subjects identify the real AgentRun instead of `unknown-run`.
- Adds focused smoke tests covering AgentRun env templating, handoff subject rendering, and prevention of direct `swarm.*` publish regressions.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `kubectl apply --dry-run=client -f argocd/applications/agents/codex-spark-agentprovider.yaml`
- `kubectl apply --dry-run=client -f argocd/applications/agents/hf-team-agentprovider.yaml`
- `git diff --check -- argocd/applications/agents/codex-spark-agentprovider.yaml argocd/applications/agents/hf-team-agentprovider.yaml packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
