### PR TITLE
chore(jangar): promote image b35eb9cd

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: cf54fe72
-  digest: sha256:af031ed19a160c391ebc8577dd93e31031df763c5cb23b241cdcb38680f56a7a
+  tag: b35eb9cd
+  digest: sha256:14f358992cf5604add328b2b308a228dc3f3b54ac0b5dffdba3626d1bae2ac61
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,25 +11,25 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: cf54fe72
-    digest: sha256:16bfb26a9bda80cc6240cedde60bd372cfe0b529194a4d62f76d8569d00ce62e
+    tag: b35eb9cd
+    digest: sha256:08075a4c9f20cd5e590786937dcda4f8013df7b03f9ed1382d5bec71ac3ede1b
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
       JANGAR_TORGHUT_STATUS_URL: http://torghut.torghut.svc.cluster.local/trading/consumer-evidence
       JANGAR_TORGHUT_STATUS_TIMEOUT_MS: "12000"
-      JANGAR_SOURCE_HEAD_SHA: cf54fe7204eaedca790a39f78a91a6af76a7e72e
-      JANGAR_GITOPS_REVISION: cf54fe7204eaedca790a39f78a91a6af76a7e72e
-      JANGAR_SOURCE_CI_RUN_ID: "25953753602"
+      JANGAR_SOURCE_HEAD_SHA: b35eb9cda753343351c7b02bb4c98704cb7fd3ef
+      JANGAR_GITOPS_REVISION: b35eb9cda753343351c7b02bb4c98704cb7fd3ef
+      JANGAR_SOURCE_CI_RUN_ID: "25954277300"
       JANGAR_SOURCE_CI_CONCLUSION: success
-      JANGAR_MANIFEST_IMAGE_DIGEST: sha256:16bfb26a9bda80cc6240cedde60bd372cfe0b529194a4d62f76d8569d00ce62e
-      JANGAR_SERVING_BUILD_COMMIT: cf54fe7204eaedca790a39f78a91a6af76a7e72e
-      JANGAR_SERVING_IMAGE_DIGEST: sha256:16bfb26a9bda80cc6240cedde60bd372cfe0b529194a4d62f76d8569d00ce62e
+      JANGAR_MANIFEST_IMAGE_DIGEST: sha256:08075a4c9f20cd5e590786937dcda4f8013df7b03f9ed1382d5bec71ac3ede1b
+      JANGAR_SERVING_BUILD_COMMIT: b35eb9cda753343351c7b02bb4c98704cb7fd3ef
+      JANGAR_SERVING_IMAGE_DIGEST: sha256:08075a4c9f20cd5e590786937dcda4f8013df7b03f9ed1382d5bec71ac3ede1b
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: cf54fe72
-    digest: sha256:af031ed19a160c391ebc8577dd93e31031df763c5cb23b241cdcb38680f56a7a
+    tag: b35eb9cd
+    digest: sha256:14f358992cf5604add328b2b308a228dc3f3b54ac0b5dffdba3626d1bae2ac61
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-16T05:22:57Z
+    deploy.knative.dev/rollout: 2026-05-16T05:50:55Z
 spec:
   replicas: 1
   strategy:
@@ -57,11 +57,11 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_RUNTIME_IMAGE
-              value: registry.ide-newton.ts.net/lab/jangar:cf54fe72@sha256:af031ed19a160c391ebc8577dd93e31031df763c5cb23b241cdcb38680f56a7a
+              value: registry.ide-newton.ts.net/lab/jangar:b35eb9cd@sha256:14f358992cf5604add328b2b308a228dc3f3b54ac0b5dffdba3626d1bae2ac61
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: cf54fe7204eaedca790a39f78a91a6af76a7e72e
+              value: b35eb9cda753343351c7b02bb4c98704cb7fd3ef
             - name: JANGAR_GITOPS_REVISION
-              value: cf54fe7204eaedca790a39f78a91a6af76a7e72e
+              value: b35eb9cda753343351c7b02bb4c98704cb7fd3ef
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_CONTROL_PLANE_STATUS_CACHE_TTL_MS
@@ -405,15 +405,15 @@ spec:
             - name: OPENAI_EMBEDDING_TIMEOUT_MS
               value: "60000"
             - name: JANGAR_SOURCE_CI_RUN_ID
-              value: "25953753602"
+              value: "25954277300"
             - name: JANGAR_SOURCE_CI_CONCLUSION
               value: success
             - name: JANGAR_MANIFEST_IMAGE_DIGEST
-              value: sha256:16bfb26a9bda80cc6240cedde60bd372cfe0b529194a4d62f76d8569d00ce62e
+              value: sha256:08075a4c9f20cd5e590786937dcda4f8013df7b03f9ed1382d5bec71ac3ede1b
             - name: JANGAR_SERVING_BUILD_COMMIT
-              value: cf54fe7204eaedca790a39f78a91a6af76a7e72e
+              value: b35eb9cda753343351c7b02bb4c98704cb7fd3ef
             - name: JANGAR_SERVING_IMAGE_DIGEST
-              value: sha256:16bfb26a9bda80cc6240cedde60bd372cfe0b529194a4d62f76d8569d00ce62e
+              value: sha256:08075a4c9f20cd5e590786937dcda4f8013df7b03f9ed1382d5bec71ac3ede1b
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -59,5 +59,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: cf54fe72
-    digest: sha256:af031ed19a160c391ebc8577dd93e31031df763c5cb23b241cdcb38680f56a7a
+    newTag: b35eb9cd
+    digest: sha256:14f358992cf5604add328b2b308a228dc3f3b54ac0b5dffdba3626d1bae2ac61


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `b35eb9cda753343351c7b02bb4c98704cb7fd3ef`
- Image tag: `b35eb9cd`
- Image digest: `sha256:14f358992cf5604add328b2b308a228dc3f3b54ac0b5dffdba3626d1bae2ac61`
- Source CI run: `25954277300`
- Control-plane serving digest: `sha256:08075a4c9f20cd5e590786937dcda4f8013df7b03f9ed1382d5bec71ac3ede1b`
- Updated API rollout annotation
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`
- Published source-serving proof env for revenue repair custody gates